### PR TITLE
fix: signing key verification and password-protected key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify Tauri signing key
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          npm install --no-save @tauri-apps/cli
+          echo "test" > /tmp/test_sign_file
+          npx @tauri-apps/cli signer sign --private-key "$TAURI_SIGNING_PRIVATE_KEY" --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" /tmp/test_sign_file
+          echo "✅ Signing key verified successfully"
+          rm -f /tmp/test_sign_file /tmp/test_sign_file.sig
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -132,7 +143,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           UPDATER_GITHUB_TOKEN: ${{ secrets.UPDATER_GITHUB_TOKEN }}
         with:
           tagName: ${{ github.ref_name }}
@@ -149,6 +160,18 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Verify Tauri signing key
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        shell: bash
+        run: |
+          npm install --no-save @tauri-apps/cli
+          echo "test" > "$RUNNER_TEMP/test_sign_file"
+          npx @tauri-apps/cli signer sign --private-key "$TAURI_SIGNING_PRIVATE_KEY" --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" "$RUNNER_TEMP/test_sign_file"
+          echo "✅ Signing key verified successfully"
+          rm -f "$RUNNER_TEMP/test_sign_file" "$RUNNER_TEMP/test_sign_file.sig"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -208,7 +231,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "TeamClaw ${{ github.ref_name }}"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
       "requireLiteralLeadingDot": false
     },
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQyMjFENTNDMDY5OEYzMjQKUldRazg1Z0dQTlVoUWlYbHhGaHZsSElCbXhkT1hMbHoxd0ViVCtJc3FiT3BzU3JvWWpBRkw3MHAK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEQzMTQyOEM1RUM1RTQwMjUKUldRbFFGN3N4U2dVMDQzdC9MS1EybE1GMW5CdHdSWFp4ZFJXaDRaWVFyZ2lLMEtiS083ODUzczIK",
       "endpoints": [
         "https://github.com/diffrent-ai-studio/teamclaw/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Summary
- Regenerate Tauri signing key with password (Tauri v2.10.0 has bug with `--ci` empty password keys)
- Update updater pubkey in `tauri.conf.json` to match new key pair
- Add signing key verification step at the **start** of both macOS and Windows release jobs — key issues now fail fast (~30s) instead of after a 20min build

## Test plan
- [ ] Verify signing key check passes in CI
- [ ] Verify full release build succeeds with new key

🤖 Generated with [Claude Code](https://claude.com/claude-code)