### PR TITLE
fix: update signing key with shell-safe password

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
       "requireLiteralLeadingDot": false
     },
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEQzMTQyOEM1RUM1RTQwMjUKUldRbFFGN3N4U2dVMDQzdC9MS1EybE1GMW5CdHdSWFp4ZFJXaDRaWVFyZ2lLMEtiS083ODUzczIK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5MkRBQzQwNjJGMTc2REQKUldUZGR2RmlRS3d0S1FrQ1B4SnpnWThzM1VJNjRTdjUyN3AvRXFFSkR1bFRkUmFVMkhOU2dXSi8K",
       "endpoints": [
         "https://github.com/diffrent-ai-studio/teamclaw/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Summary
- Update updater pubkey to match new signing key pair
- Previous password `X7#mQ!vL2$pN9&kR` had shell special chars (`$`, `!`, `&`) that got expanded/mangled in GitHub Actions bash
- New password `X7mQvL2pN9kRtW4z` is alphanumeric only, verified locally

## Test plan
- [ ] Signing key verification step passes (~30s)
- [ ] Full release build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)