### PR TITLE
fix: update signing key pubkey after regeneration

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
       "requireLiteralLeadingDot": false
     },
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5MkRBQzQwNjJGMTc2REQKUldUZGR2RmlRS3d0S1FrQ1B4SnpnWThzM1VJNjRTdjUyN3AvRXFFSkR1bFRkUmFVMkhOU2dXSi8K",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQzODk5QzIxMUI4RkY3OTkKUldTWjk0OGJJWnlKUTlnZVdEaUsyUGJ4WFpaYmlQZW03NGdlNVdyUlRMNGtKVVBKeTk3NEYwZXAK",
       "endpoints": [
         "https://github.com/diffrent-ai-studio/teamclaw/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Summary
- Regenerated Tauri signing key pair with a simple password (no shell special chars)
- Verified key+password match locally before uploading to GitHub Secrets
- Updated pubkey in `tauri.conf.json` to match the new key pair

## Root cause
Previous password `X7#mQ!vL2$pN9&kR` contained shell special characters (`!`, `$`) that were being escaped/interpreted differently during key generation vs. usage, causing persistent "Wrong password" errors.

## Test plan
- [x] Local verification: `tauri signer sign` succeeds with new key+password
- [x] GitHub Secrets updated via `gh secret set` (no copy-paste issues)
- [ ] CI release build should pass signing step

🤖 Generated with [Claude Code](https://claude.com/claude-code)