### PR TITLE
feat: forward AI questions to channels and wait for user reply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ docs/superpowers/
 
 # Internal planning documents
 docs/plans/
+
+# Stress test reports
+tests/stress/reports/

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:e2e:performance": "vitest run --config vitest.config.e2e.ts tests/performance",
     "test:e2e:e2e": "vitest run --config vitest.config.e2e.ts tests/e2e",
     "test:e2e:functional": "vitest run --config vitest.config.e2e.ts tests/functional",
+    "test:stress": "vitest run --config vitest.config.stress.ts",
     "update-opencode": "node scripts/update-opencode.js",
     "verify-release": "./scripts/verify-release-build.sh"
   },

--- a/packages/app/src/components/chat/SessionList.tsx
+++ b/packages/app/src/components/chat/SessionList.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { MessageSquare, Loader2 } from 'lucide-react'
 import { useSessionStore } from '@/stores/session'
+import { useStreamingStore } from '@/stores/streaming'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useUIStore } from '@/stores/ui'
 import { cn } from '@/lib/utils'
@@ -20,6 +21,36 @@ interface SessionListItemProps {
   isHighlighted: boolean
   compact?: boolean
   onSelect: (id: string) => void
+}
+
+// Extracted sub-component: only rendered when isActive, so non-active items
+// don't subscribe to sessionStatus/streamingMessageId stores (keeps memo stable).
+function SessionStatusIndicator({ compact }: { compact?: boolean }) {
+  const sessionStatus = useSessionStore(s => s.sessionStatus)
+  const pendingPermission = useSessionStore(s => s.pendingPermission)
+  const pendingQuestion = useSessionStore(s => s.pendingQuestion)
+  const streamingMessageId = useStreamingStore(s => s.streamingMessageId)
+
+  if (pendingPermission || pendingQuestion) {
+    return (
+      <span className="shrink-0 text-[10px] font-medium text-emerald-600 bg-emerald-500/10 px-1.5 py-0.5 rounded-full">
+        等待确认
+      </span>
+    )
+  }
+
+  // Both checks needed: sessionStatus covers pre-streaming busy (tool exec),
+  // streamingMessageId covers streaming when status may lag
+  if (sessionStatus?.type === 'busy' || sessionStatus?.type === 'retry' || streamingMessageId) {
+    return (
+      <Loader2 className={cn(
+        "shrink-0 animate-spin text-muted-foreground/70",
+        compact ? "h-3 w-3" : "h-3.5 w-3.5"
+      )} />
+    )
+  }
+
+  return null
 }
 
 const SessionListItem = React.memo(function SessionListItem({
@@ -57,11 +88,13 @@ const SessionListItem = React.memo(function SessionListItem({
             )}>
               {session.title}
             </span>
-            {isHighlighted && (
+            {isActive ? (
+              <SessionStatusIndicator compact={compact} />
+            ) : isHighlighted ? (
               <span className="shrink-0 text-[10px] font-medium text-emerald-600 bg-emerald-500/10 px-1.5 py-0.5 rounded-full">
                 NEW
               </span>
-            )}
+            ) : null}
           </div>
           <span className={cn("text-muted-foreground/70", compact ? "text-[10px]" : "text-xs")}>
             {formatRelativeDate(session.updatedAt)}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import App from './App'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import './styles/globals.css'
+import './stores/dev-expose'
 import './lib/i18n'; // Initialize i18n
 
 // Apply persisted theme immediately to prevent flash of wrong theme

--- a/packages/app/src/stores/dev-expose.ts
+++ b/packages/app/src/stores/dev-expose.ts
@@ -6,4 +6,34 @@ if (import.meta.env.DEV) {
     session: useSessionStore,
     streaming: useStreamingStore,
   }
+
+  // Set up execute-js event listener for tauri-plugin-mcp socket automation.
+  // The Rust plugin emits 'execute-js' with the JS code as payload,
+  // and expects 'execute-js-response' back with { result, type } or { error }.
+  Promise.all([
+    import('@tauri-apps/api/event'),
+    import('@tauri-apps/api/webviewWindow'),
+  ]).then(([{ emit }, { getCurrentWebviewWindow }]) => {
+    const currentWindow = getCurrentWebviewWindow()
+    currentWindow.listen('execute-js', async (event: any) => {
+      // payload may be the code string directly or { code: string }
+      const code = typeof event.payload === 'string'
+        ? event.payload
+        : event.payload?.code
+      try {
+        // eslint-disable-next-line no-eval
+        const result = (0, eval)(code)
+        // Use global emit so app-level listener in Rust receives it
+        await emit('execute-js-response', {
+          result: typeof result === 'object' ? JSON.stringify(result) : String(result),
+          type: typeof result,
+        })
+      } catch (error) {
+        await emit('execute-js-response', {
+          error: String(error),
+        })
+      }
+    })
+    console.log('[dev-expose] execute-js listener installed')
+  }).catch(() => {})
 }

--- a/packages/app/src/stores/dev-expose.ts
+++ b/packages/app/src/stores/dev-expose.ts
@@ -1,0 +1,9 @@
+import { useSessionStore } from './session'
+import { useStreamingStore } from './streaming'
+
+if (import.meta.env.DEV) {
+  ;(window as any).__TEAMCLAW_STORES__ = {
+    session: useSessionStore,
+    streaming: useStreamingStore,
+  }
+}

--- a/src-tauri/src/commands/gateway/discord.rs
+++ b/src-tauri/src/commands/gateway/discord.rs
@@ -24,6 +24,8 @@ pub struct DiscordHandler {
     /// Permission auto-approver
     #[allow(dead_code)]
     permission_approver: super::PermissionAutoApprover,
+    /// Pending question store for question forwarding
+    pending_questions: Arc<super::PendingQuestionStore>,
 }
 
 impl DiscordHandler {
@@ -33,6 +35,7 @@ impl DiscordHandler {
         opencode_port: u16,
         status_tx: mpsc::Sender<GatewayStatusResponse>,
         permission_approver: super::PermissionAutoApprover,
+        pending_questions: Arc<super::PendingQuestionStore>,
     ) -> Self {
         Self {
             config,
@@ -42,6 +45,7 @@ impl DiscordHandler {
             bot_user_id: Arc::new(RwLock::new(None)),
             processed_messages: Arc::new(RwLock::new(ProcessedMessageTracker::new(MAX_PROCESSED_MESSAGES))),
             permission_approver,
+            pending_questions,
         }
     }
 
@@ -342,8 +346,25 @@ impl DiscordHandler {
         // Send typing indicator
         let typing = msg.channel_id.start_typing(&ctx.http);
 
+        // Build question context for forwarding AI questions to Discord
+        let pending_questions = Arc::clone(&self.pending_questions);
+        let channel_id = msg.channel_id;
+        let http = Arc::clone(&ctx.http);
+        let question_ctx = super::QuestionContext {
+            forwarder: Box::new(move |fq: super::ForwardedQuestion| {
+                let http = Arc::clone(&http);
+                Box::pin(async move {
+                    let text = super::format_question_message(&fq.questions, &fq.question_id);
+                    let sent = channel_id.say(&http, &text).await
+                        .map_err(|e| format!("Failed to send question: {}", e))?;
+                    Ok(sent.id.to_string())
+                })
+            }),
+            store: pending_questions,
+        };
+
         // Send message to OpenCode (with automatic permission approval)
-        let result = self.send_to_opencode(&session_id, &content, images.clone(), model_param.clone()).await;
+        let result = self.send_to_opencode(&session_id, &content, images.clone(), model_param.clone(), Some(question_ctx)).await;
 
         match result {
             Ok(response) => {
@@ -400,11 +421,12 @@ impl DiscordHandler {
     /// images: Vec<(url, mime_type)>
     /// model: Optional (providerID, modelID) to override the model for this request
     async fn send_to_opencode(
-        &self, 
-        session_id: &str, 
+        &self,
+        session_id: &str,
         content: &str,
         images: Vec<(String, String)>,
         model: Option<(String, String)>,
+        question_ctx: Option<super::QuestionContext>,
     ) -> Result<String, String> {
         // Download client for images (short timeout)
         let client = reqwest::Client::builder()
@@ -481,7 +503,7 @@ impl DiscordHandler {
             session_id,
             parts,
             model,
-            None,
+            question_ctx,
         ).await
     }
 
@@ -502,7 +524,18 @@ impl EventHandler for DiscordHandler {
             println!("[Discord] Message {} already processed, skipping", message_id);
             return;
         }
-        
+
+        // Check if this is a reply to a pending question
+        if let Some(ref referenced) = msg.referenced_message {
+            let ref_id = referenced.id.to_string();
+            if let Some(entry) = self.pending_questions.take(&ref_id).await {
+                let answer_text = msg.content.clone();
+                let _ = entry.answer_tx.send(answer_text);
+                println!("[Discord] Question {} answered via reply", entry.question_id);
+                return;
+            }
+        }
+
         let filter_result = self.should_process_message(&msg, &ctx).await;
         println!("[Discord] Filter result: {:?}, guild_id: {:?}, channel_id: {}", 
             filter_result, msg.guild_id, msg.channel_id);
@@ -760,6 +793,8 @@ pub struct DiscordGateway {
     is_running: Arc<RwLock<bool>>,
     /// Permission auto-approver
     permission_approver: super::PermissionAutoApprover,
+    /// Pending question store for question forwarding
+    pending_questions: Arc<super::PendingQuestionStore>,
 }
 
 impl DiscordGateway {
@@ -772,6 +807,7 @@ impl DiscordGateway {
             status: Arc::new(RwLock::new(GatewayStatusResponse::default())),
             is_running: Arc::new(RwLock::new(false)),
             permission_approver: super::PermissionAutoApprover::new(opencode_port),
+            pending_questions: Arc::new(super::PendingQuestionStore::new()),
         }
     }
 
@@ -839,6 +875,7 @@ impl DiscordGateway {
             self.opencode_port,
             status_tx,
             self.permission_approver.clone(),
+            Arc::clone(&self.pending_questions),
         );
 
         // Build client
@@ -967,6 +1004,7 @@ impl Clone for DiscordGateway {
             status: Arc::clone(&self.status),
             is_running: Arc::clone(&self.is_running),
             permission_approver: self.permission_approver.clone(),
+            pending_questions: Arc::clone(&self.pending_questions),
         }
     }
 }

--- a/src-tauri/src/commands/gateway/discord.rs
+++ b/src-tauri/src/commands/gateway/discord.rs
@@ -481,6 +481,7 @@ impl DiscordHandler {
             session_id,
             parts,
             model,
+            None,
         ).await
     }
 

--- a/src-tauri/src/commands/gateway/email.rs
+++ b/src-tauri/src/commands/gateway/email.rs
@@ -1617,6 +1617,7 @@ fn process_and_reply_sync(
             &session_id,
             parts,
             model_param,
+            None,
         ).await
     })?;
 

--- a/src-tauri/src/commands/gateway/email.rs
+++ b/src-tauri/src/commands/gateway/email.rs
@@ -209,6 +209,8 @@ pub struct EmailGateway {
     /// Permission auto-approver
     #[allow(dead_code)]
     permission_approver: super::PermissionAutoApprover,
+    /// Pending questions waiting for email replies
+    pub pending_questions: Arc<super::PendingQuestionStore>,
 }
 
 impl EmailGateway {
@@ -225,6 +227,7 @@ impl EmailGateway {
             generation: Arc::new(AtomicU64::new(0)),
             email_db: Arc::new(RwLock::new(None)),
             permission_approver: super::PermissionAutoApprover::new(opencode_port),
+            pending_questions: Arc::new(super::PendingQuestionStore::new()),
         }
     }
 
@@ -1012,7 +1015,7 @@ fn handle_imap_connection(
                             let filter_result = check_email_filter(config, &email_msg);
                                 match filter_result {
                                 FilterResult::Allow => {
-                                    if let Err(e) = process_and_reply_sync(gateway, config, &email_msg, access_token, rt_handle, email_db, account_key) {
+                                    if let Err(e) = process_and_reply_sync(gateway, config, &email_msg, access_token, rt_handle, email_db, account_key, &gateway.pending_questions) {
                                         println!("[Email] Failed to process message: {}", e);
                                     }
                                 }
@@ -1074,6 +1077,7 @@ fn handle_imap_connection(
 
 // ==================== Email Parsing ====================
 
+#[derive(Clone)]
 struct EmailMessage {
     uid: u32,
     from: String,
@@ -1559,6 +1563,7 @@ fn process_and_reply_sync(
     rt_handle: &tokio::runtime::Handle,
     email_db: Option<&EmailDb>,
     account_key: &str,
+    pending_questions: &Arc<super::PendingQuestionStore>,
 ) -> Result<(), String> {
     let port = gateway.opencode_port;
     let session_key = resolve_email_session_key_sync(gateway, email, rt_handle, email_db, account_key)?
@@ -1595,6 +1600,18 @@ fn process_and_reply_sync(
         clean_email_body(&email.body_text)
     };
 
+    // Check if this email is a reply to a pending question
+    for mid in extract_message_ids(&email.in_reply_to) {
+        let normalized = normalize_message_id(&mid);
+        if let Some(entry) = rt_handle.block_on(async {
+            pending_questions.take(&normalized).await
+        }) {
+            let _ = entry.answer_tx.send(message_content.clone());
+            println!("[Email] Question {} answered via email reply", entry.question_id);
+            return Ok(());
+        }
+    }
+
     // Get model preference from SessionMapping (for consistent model usage)
     let model_preference = {
         let mapping = gateway.session_mapping.clone();
@@ -1603,10 +1620,33 @@ fn process_and_reply_sync(
             mapping.get_model(&key).await
         })
     };
-    
+
     let model_param = model_preference
         .as_ref()
         .and_then(|m| crate::commands::gateway::parse_model_preference(m));
+
+    // Build question forwarder for email
+    let pending_questions_clone = Arc::clone(pending_questions);
+    let email_config_for_q = config.clone();
+    let reply_to_email_for_q = email.clone();
+    let access_token_for_q = access_token.map(|s| s.to_string());
+    let question_ctx = super::QuestionContext {
+        forwarder: Box::new(move |fq: super::ForwardedQuestion| {
+            let cfg = email_config_for_q.clone();
+            let reply_email = reply_to_email_for_q.clone();
+            let at = access_token_for_q.clone();
+            Box::pin(async move {
+                let text = super::format_question_message(&fq.questions, &fq.question_id);
+                let outgoing_msg_id = tokio::task::spawn_blocking(move || {
+                    send_reply_sync(&cfg, &reply_email, &text, at.as_deref())
+                }).await
+                    .map_err(|e| format!("Join error: {}", e))?
+                    .map_err(|e| format!("SMTP error: {}", e))?;
+                Ok(outgoing_msg_id)
+            })
+        }),
+        store: pending_questions_clone,
+    };
 
     // Send to OpenCode using async mode with permission auto-approval
     println!("[Email] Sending message asynchronously with permission auto-approval");
@@ -1617,7 +1657,7 @@ fn process_and_reply_sync(
             &session_id,
             parts,
             model_param,
-            None,
+            Some(question_ctx),
         ).await
     })?;
 

--- a/src-tauri/src/commands/gateway/feishu.rs
+++ b/src-tauri/src/commands/gateway/feishu.rs
@@ -1315,6 +1315,7 @@ async fn send_to_opencode(
         session_id,
         parts,
         model,
+        None,
     ).await
 }
 

--- a/src-tauri/src/commands/gateway/feishu.rs
+++ b/src-tauri/src/commands/gateway/feishu.rs
@@ -388,6 +388,7 @@ pub struct FeishuGateway {
     /// Permission auto-approver
     permission_approver: super::PermissionAutoApprover,
     session_queue: Arc<SessionQueue>,
+    pending_questions: Arc<super::PendingQuestionStore>,
 }
 
 impl FeishuGateway {
@@ -401,6 +402,7 @@ impl FeishuGateway {
             is_running: Arc::new(RwLock::new(false)),
             permission_approver: super::PermissionAutoApprover::new(opencode_port),
             session_queue: Arc::new(SessionQueue::new()),
+            pending_questions: Arc::new(super::PendingQuestionStore::new()),
         }
     }
 
@@ -445,10 +447,12 @@ impl FeishuGateway {
         let session_mapping = self.session_mapping.clone();
         let opencode_port = self.opencode_port;
         let session_queue = Arc::clone(&self.session_queue);
+        let pending_questions = Arc::clone(&self.pending_questions);
 
         tokio::spawn(async move {
             let result = run_feishu_gateway(
                 config_arc, status_arc.clone(), session_mapping, opencode_port, shutdown_rx, session_queue,
+                pending_questions,
             ).await;
 
             if let Err(e) = result {
@@ -522,6 +526,7 @@ impl Clone for FeishuGateway {
             is_running: Arc::clone(&self.is_running),
             permission_approver: self.permission_approver.clone(),
             session_queue: Arc::clone(&self.session_queue),
+            pending_questions: Arc::clone(&self.pending_questions),
         }
     }
 }
@@ -578,6 +583,7 @@ async fn run_feishu_gateway(
     opencode_port: u16,
     mut shutdown_rx: oneshot::Receiver<()>,
     session_queue: Arc<SessionQueue>,
+    pending_questions: Arc<super::PendingQuestionStore>,
 ) -> Result<(), String> {
     let cfg = config.read().await.clone();
     let token_manager = TokenManager::new(&cfg.app_id, &cfg.app_secret);
@@ -648,7 +654,7 @@ async fn run_feishu_gateway(
         let ws_result = handle_ws_connection(
             ws_stream, &config, &session_mapping, opencode_port,
             &token_manager, &processed_messages, &mut shutdown_rx, service_id,
-            &session_queue,
+            &session_queue, &pending_questions,
         ).await;
 
         match ws_result {
@@ -696,6 +702,7 @@ async fn handle_ws_connection(
     shutdown_rx: &mut oneshot::Receiver<()>,
     service_id: i32,
     session_queue: &Arc<SessionQueue>,
+    pending_questions: &Arc<super::PendingQuestionStore>,
 ) -> Result<WsExitReason, String> {
     use futures::stream::StreamExt;
     use futures::sink::SinkExt;
@@ -770,7 +777,7 @@ async fn handle_ws_connection(
                                 handle_binary_frame(
                                     frame, config, session_mapping, opencode_port,
                                     token_manager, processed_messages, &send_tx,
-                                    session_queue,
+                                    session_queue, pending_questions,
                                 ).await;
                             }
                             Err(e) => {
@@ -822,6 +829,7 @@ async fn handle_binary_frame(
     processed_messages: &Arc<RwLock<ProcessedMessageTracker>>,
     send_tx: &tokio::sync::mpsc::Sender<Vec<u8>>,
     session_queue: &Arc<SessionQueue>,
+    pending_questions: &Arc<super::PendingQuestionStore>,
 ) {
     let method = frame.method; // 0=control, 1=data
     let msg_type = frame.get_header("type").unwrap_or("").to_string();
@@ -887,12 +895,14 @@ async fn handle_binary_frame(
                                 let token_manager_app_id = token_manager.app_id.clone();
                                 let token_manager_app_secret = token_manager.app_secret.clone();
                                 let session_queue_clone = Arc::clone(session_queue);
+                                let pending_questions_clone = Arc::clone(pending_questions);
                                 tokio::spawn(async move {
                                     println!("[Feishu] Spawned message handler task");
                                     let tm = TokenManager::new(&token_manager_app_id, &token_manager_app_secret);
                                     handle_message_event(
                                         &event_data, &config_clone, &session_mapping_clone,
                                         opencode_port, &tm, &session_queue_clone,
+                                        &pending_questions_clone,
                                     ).await;
                                     println!("[Feishu] Message handler task completed");
                                 });
@@ -928,6 +938,7 @@ async fn handle_message_event(
     opencode_port: u16,
     token_manager: &TokenManager,
     session_queue: &Arc<SessionQueue>,
+    pending_questions: &Arc<super::PendingQuestionStore>,
 ) {
     let sender = &event["sender"];
     let sender_id = sender["sender_id"]["open_id"].as_str().unwrap_or("").to_string();
@@ -965,6 +976,18 @@ async fn handle_message_event(
 
     if clean_text.is_empty() && msg_type != "image" {
         return;
+    }
+
+    // Check if this is a reply to a pending question (Feishu parent_id)
+    let parent_id = message["parent_id"].as_str();
+    if let Some(pid) = parent_id {
+        if !pid.is_empty() {
+            if let Some(entry) = pending_questions.take(pid).await {
+                let _ = entry.answer_tx.send(clean_text.clone());
+                println!("[Feishu] Question {} answered via reply to {}", entry.question_id, pid);
+                return;
+            }
+        }
     }
 
     // Check config filter
@@ -1103,6 +1126,8 @@ async fn handle_message_event(
     let tm_app_id2 = token_manager.app_id.clone();
     let tm_app_secret2 = token_manager.app_secret.clone();
 
+    let pending_questions_for_closure = Arc::clone(pending_questions);
+
     let result = session_queue.enqueue(&session_key, QueuedMessage {
         enqueued_at: std::time::Instant::now(),
         process_fn: Box::new(move || Box::pin(async move {
@@ -1132,8 +1157,29 @@ async fn handle_message_event(
                 None
             };
 
+            // Build question context for forwarding AI questions to Feishu
+            let pending_questions_clone = Arc::clone(&pending_questions_for_closure);
+            let tm_app_id_for_q = tm.app_id.clone();
+            let tm_app_secret_for_q = tm.app_secret.clone();
+            let message_id_for_q = message_id_owned.clone();
+            let question_ctx = super::QuestionContext {
+                forwarder: Box::new(move |fq: super::ForwardedQuestion| {
+                    let app_id = tm_app_id_for_q.clone();
+                    let app_secret = tm_app_secret_for_q.clone();
+                    let mid = message_id_for_q.clone();
+                    Box::pin(async move {
+                        let tm = TokenManager::new(&app_id, &app_secret);
+                        let token = tm.get_tenant_token().await
+                            .map_err(|e| format!("Failed to get token: {}", e))?;
+                        let text = super::format_question_message(&fq.questions, &fq.question_id);
+                        reply_feishu_message(&token, &mid, &text).await
+                    })
+                }),
+                store: pending_questions_clone,
+            };
+
             // Send to OpenCode
-            let result = send_to_opencode(opencode_port, &session_id, &content_owned, images_owned, model_param_owned).await;
+            let result = send_to_opencode(opencode_port, &session_id, &content_owned, images_owned, model_param_owned, Some(question_ctx)).await;
 
             // Reply (edit Thinking card or send new message)
             if let Ok(token) = tm.get_tenant_token().await {
@@ -1293,6 +1339,7 @@ async fn send_to_opencode(
     content: &str,
     images: Vec<(String, String)>,
     model: Option<(String, String)>,
+    question_ctx: Option<super::QuestionContext>,
 ) -> Result<String, String> {
     println!("[Feishu] Sending to OpenCode: content: {}, images: {}", content, images.len());
 
@@ -1315,7 +1362,7 @@ async fn send_to_opencode(
         session_id,
         parts,
         model,
-        None,
+        question_ctx,
     ).await
 }
 

--- a/src-tauri/src/commands/gateway/kook.rs
+++ b/src-tauri/src/commands/gateway/kook.rs
@@ -103,6 +103,8 @@ pub struct KookGateway {
     bot_user_id: Arc<RwLock<Option<String>>>,
     /// Permission auto-approver
     permission_approver: super::PermissionAutoApprover,
+    /// Pending questions awaiting replies
+    pending_questions: Arc<super::PendingQuestionStore>,
 }
 
 impl KookGateway {
@@ -119,6 +121,7 @@ impl KookGateway {
             processed_messages: Arc::new(RwLock::new(ProcessedMessageTracker::new(MAX_PROCESSED_MESSAGES))),
             bot_user_id: Arc::new(RwLock::new(None)),
             permission_approver: super::PermissionAutoApprover::new(opencode_port),
+            pending_questions: Arc::new(super::PendingQuestionStore::new()),
         }
     }
 
@@ -694,6 +697,18 @@ impl KookGateway {
             return Ok(());
         }
 
+        // Check if this is a reply to a pending question (KOOK uses extra.quote)
+        if let Some(quote_id) = msg_data.extra.get("quote")
+            .and_then(|q| q.get("rong_id").or_else(|| q.get("id")))
+            .and_then(|id| id.as_str())
+        {
+            if let Some(entry) = self.pending_questions.take(quote_id).await {
+                let _ = entry.answer_tx.send(msg_data.content.clone());
+                println!("[KOOK] Question {} answered via quote reply", entry.question_id);
+                return Ok(());
+            }
+        }
+
         // Filter message
         let filter_result = self.filter_message(&msg_data).await;
         
@@ -881,11 +896,52 @@ impl KookGateway {
             .await
             .and_then(|m| super::parse_model_preference(&m));
 
+        // Build question context for forwarding AI questions to the channel
+        let pending_questions_clone = Arc::clone(&self.pending_questions);
+        let qctx_config = self.config.read().await.clone();
+        let target = if msg.channel_type == "PERSON" {
+            msg.author_id.clone()
+        } else {
+            msg.target_id.clone()
+        };
+        let channel_type = msg.channel_type.clone();
+        let question_ctx = super::QuestionContext {
+            forwarder: Box::new(move |fq: super::ForwardedQuestion| {
+                let token = qctx_config.token.clone();
+                let target = target.clone();
+                let ct = channel_type.clone();
+                Box::pin(async move {
+                    let text = super::format_question_message(&fq.questions, &fq.question_id);
+                    let client = reqwest::Client::new();
+                    let (url, body) = if ct == "PERSON" {
+                        ("https://www.kookapp.cn/api/v3/direct-message/create".to_string(),
+                         serde_json::json!({ "target_id": target, "type": 1, "content": text }))
+                    } else {
+                        ("https://www.kookapp.cn/api/v3/message/create".to_string(),
+                         serde_json::json!({ "target_id": target, "type": 1, "content": text }))
+                    };
+                    let resp = client.post(&url)
+                        .header("Authorization", format!("Bot {}", token))
+                        .json(&body)
+                        .send().await
+                        .map_err(|e| format!("KOOK send failed: {}", e))?;
+                    let json: serde_json::Value = resp.json().await
+                        .map_err(|e| format!("KOOK parse failed: {}", e))?;
+                    json.get("data")
+                        .and_then(|d| d.get("msg_id"))
+                        .and_then(|id| id.as_str())
+                        .map(|s| s.to_string())
+                        .ok_or_else(|| "No msg_id in KOOK response".to_string())
+                })
+            }),
+            store: pending_questions_clone,
+        };
+
         // Send "Thinking..." card message first
         let thinking_msg_id = self.send_thinking_card(msg).await?;
 
         // Send to OpenCode
-        let response = match self.send_to_opencode(&session_id, &content, model_param.clone()).await {
+        let response = match self.send_to_opencode(&session_id, &content, model_param.clone(), Some(question_ctx)).await {
             Ok(resp) => resp,
             Err(e) => {
                 // Update the thinking message with error
@@ -912,18 +968,19 @@ impl KookGateway {
         session_id: &str,
         message: &str,
         model: Option<(String, String)>,
+        question_ctx: Option<super::QuestionContext>,
     ) -> Result<String, String> {
         println!("[KOOK] Sending message asynchronously with permission auto-approval");
-        
+
         let parts = vec![json!({"type": "text", "text": message})];
-        
+
         // Use async send with permission auto-approval
         super::send_message_async_with_approval(
             self.opencode_port,
             session_id,
             parts,
             model,
-            None,
+            question_ctx,
         ).await
     }
 
@@ -1380,6 +1437,7 @@ impl Clone for KookGateway {
             processed_messages: Arc::clone(&self.processed_messages),
             bot_user_id: Arc::clone(&self.bot_user_id),
             permission_approver: self.permission_approver.clone(),
+            pending_questions: Arc::clone(&self.pending_questions),
         }
     }
 }

--- a/src-tauri/src/commands/gateway/kook.rs
+++ b/src-tauri/src/commands/gateway/kook.rs
@@ -923,6 +923,7 @@ impl KookGateway {
             session_id,
             parts,
             model,
+            None,
         ).await
     }
 

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -234,6 +234,7 @@ pub async fn send_message_async_with_approval(
     session_id: &str,
     parts: Vec<serde_json::Value>,
     model: Option<(String, String)>,
+    question_ctx: Option<QuestionContext>,
 ) -> Result<String, String> {
     // Step 1: Send message asynchronously (non-blocking)
     let client = reqwest::Client::new();
@@ -263,7 +264,7 @@ pub async fn send_message_async_with_approval(
     
     // Step 2 & 3: Use unified SSE stream to handle both message waiting and permission approval
     // This avoids having multiple SSE connections which can cause event conflicts
-    poll_for_message_with_approval(port, session_id, send_timestamp_ms).await
+    poll_for_message_with_approval(port, session_id, send_timestamp_ms, question_ctx).await
 }
 
 /// Unified SSE handler: wait for assistant message AND auto-approve permissions
@@ -278,6 +279,7 @@ async fn poll_for_message_with_approval(
     port: u16,
     session_id: &str,
     send_timestamp_ms: u64,
+    question_ctx: Option<QuestionContext>,
 ) -> Result<String, String> {
     let client = reqwest::Client::new();
     let sse_url = format!("http://127.0.0.1:{}/event", port);
@@ -410,7 +412,97 @@ async fn poll_for_message_with_approval(
                         // Ignore all other permission events
                         continue;
                     }
-                    
+
+                    "question.asked" => {
+                        let q_session_id = event.get("properties")
+                            .and_then(|p| p.get("sessionID").or_else(|| p.get("sessionId")))
+                            .and_then(|s| s.as_str());
+
+                        if let Some(ref ctx) = question_ctx {
+                            if let Some(sess_id) = q_session_id {
+                                if tracked_sessions.contains(sess_id) {
+                                    let question_id = event.get("properties")
+                                        .and_then(|p| p.get("id"))
+                                        .and_then(|id| id.as_str())
+                                        .unwrap_or("")
+                                        .to_string();
+
+                                    let questions = parse_question_event(&event);
+
+                                    println!("[Gateway-{}] Question asked: id={}, {} question(s)",
+                                        &session_id[..8], question_id, questions.len());
+
+                                    let forwarded = ForwardedQuestion {
+                                        question_id: question_id.clone(),
+                                        questions: questions.clone(),
+                                    };
+
+                                    match (ctx.forwarder)(forwarded).await {
+                                        Ok(channel_msg_id) => {
+                                            let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+                                            ctx.store.insert(channel_msg_id.clone(), PendingQuestionEntry {
+                                                question_id: question_id.clone(),
+                                                answer_tx: tx,
+                                                created_at: std::time::Instant::now(),
+                                            }).await;
+
+                                            let port_clone = port;
+                                            let qid = question_id.clone();
+                                            let questions_clone = questions;
+                                            let store_clone = std::sync::Arc::clone(&ctx.store);
+                                            let cmid = channel_msg_id;
+                                            tokio::spawn(async move {
+                                                let client = reqwest::Client::new();
+                                                match tokio::time::timeout(
+                                                    std::time::Duration::from_secs(300), rx
+                                                ).await {
+                                                    Ok(Ok(answer)) => {
+                                                        let answers = resolve_answer(&answer, &questions_clone);
+                                                        let url = format!(
+                                                            "http://127.0.0.1:{}/question/{}/reply",
+                                                            port_clone, qid
+                                                        );
+                                                        let body = serde_json::json!({ "answers": answers });
+                                                        match client.post(&url).json(&body).send().await {
+                                                            Ok(r) => println!(
+                                                                "[Gateway] Question {} answered (HTTP {})",
+                                                                qid, r.status()
+                                                            ),
+                                                            Err(e) => eprintln!(
+                                                                "[Gateway] Failed to reply question {}: {}",
+                                                                qid, e
+                                                            ),
+                                                        }
+                                                    }
+                                                    _ => {
+                                                        let url = format!(
+                                                            "http://127.0.0.1:{}/question/{}/reject",
+                                                            port_clone, qid
+                                                        );
+                                                        let _ = client
+                                                            .post(&url)
+                                                            .json(&serde_json::json!({}))
+                                                            .send()
+                                                            .await;
+                                                        println!("[Gateway] Question {} auto-rejected (timeout)", qid);
+                                                    }
+                                                }
+                                                store_clone.take(&cmid).await;
+                                            });
+                                        }
+                                        Err(e) => {
+                                            eprintln!("[Gateway-{}] Failed to forward question: {}", &session_id[..8], e);
+                                            let url = format!("http://127.0.0.1:{}/question/{}/reject", port, question_id);
+                                            let client = reqwest::Client::new();
+                                            let _ = client.post(&url).json(&serde_json::json!({})).send().await;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        continue;
+                    }
+
                     "message.updated" => {
                         // CRITICAL: Only process message events for our target session
                         // Ignore all other sessions to avoid interference

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -15,10 +15,10 @@ pub mod pending_question;
 
 pub use config::*;
 pub use pending_question::{
-    PendingQuestionStore, PendingQuestionEntry, QuestionContext,
-    QuestionForwarder, ForwardedQuestion, QuestionInfo, QuestionOption,
-    format_question_message, resolve_answer, extract_question_marker,
-    parse_question_event,
+    PendingQuestionStore, QuestionContext,
+    ForwardedQuestion,
+    format_question_message, extract_question_marker,
+    handle_question_event,
 };
 pub use discord::DiscordGateway;
 pub use email::EmailGateway;
@@ -31,7 +31,7 @@ pub use wecom_config::*;
 pub use session::SessionMapping;
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::Duration;
 use tauri::State;
 use serde::Deserialize;
@@ -124,8 +124,6 @@ pub struct GatewayState {
     pub shared_session_mapping: SessionMapping,
     /// Whether the shared session mapping has been initialized with a persistence path
     pub session_initialized: Mutex<bool>,
-    /// Shared store for pending question forwarding
-    pub pending_questions: Arc<PendingQuestionStore>,
 }
 
 impl Default for GatewayState {
@@ -138,7 +136,6 @@ impl Default for GatewayState {
             wecom_gateway: Mutex::new(None),
             shared_session_mapping: SessionMapping::new(),
             session_initialized: Mutex::new(false),
-            pending_questions: Arc::new(PendingQuestionStore::new()),
         }
     }
 }
@@ -303,7 +300,7 @@ async fn poll_for_message_with_approval(
     tracked_sessions.insert(session_id.to_string());
     let mut approved_permission_ids = HashSet::new();
     
-    println!("[Gateway-{}] Waiting for AI response (monitoring SSE)", &session_id[..8]);
+    println!("[Gateway-{}] Waiting for AI response (monitoring SSE)", &session_id[..session_id.len().min(8)]);
     
     while let Some(chunk) = stream.next().await {
         // Check timeout
@@ -352,7 +349,7 @@ async fn poll_for_message_with_approval(
                         if parent_id == Some(session_id) && new_session_id.is_some() {
                             let child_id = new_session_id.unwrap().to_string();
                             if tracked_sessions.insert(child_id.clone()) {
-                                println!("[Gateway-{}] Detected child session: {}", &session_id[..8], child_id);
+                                println!("[Gateway-{}] Detected child session: {}", &session_id[..session_id.len().min(8)], child_id);
                             }
                         }
                         // Ignore all other session.created events
@@ -373,13 +370,13 @@ async fn poll_for_message_with_approval(
                             .unwrap_or("unknown");
                         
                         println!("[Gateway-{}] Permission event: id={:?}, sess={:?}, perm={}, tracked={:?}",
-                            &session_id[..8], perm_id, perm_session_id, permission, &tracked_sessions);
+                            &session_id[..session_id.len().min(8)], perm_id, perm_session_id, permission, &tracked_sessions);
                         
                         if let (Some(sess_id), Some(perm_id_str)) = (perm_session_id, perm_id) {
                             if tracked_sessions.contains(sess_id) {
                                 if !approved_permission_ids.contains(perm_id_str) {
                                     println!("[Gateway-{}] ✅ Auto-approving permission {} for '{}'",
-                                        &session_id[..8], perm_id_str, permission);
+                                        &session_id[..session_id.len().min(8)], perm_id_str, permission);
                                     
                                     // Auto-approve (fire and forget, don't block message waiting)
                                     let port_clone = port;
@@ -403,10 +400,10 @@ async fn poll_for_message_with_approval(
                                     
                                     approved_permission_ids.insert(perm_id_str.to_string());
                                 } else {
-                                    println!("[Gateway-{}] Permission {} already approved", &session_id[..8], perm_id_str);
+                                    println!("[Gateway-{}] Permission {} already approved", &session_id[..session_id.len().min(8)], perm_id_str);
                                 }
                             } else {
-                                println!("[Gateway-{}] ⚠️ Permission for untracked session: {}", &session_id[..8], sess_id);
+                                println!("[Gateway-{}] ⚠️ Permission for untracked session: {}", &session_id[..session_id.len().min(8)], sess_id);
                             }
                         }
                         // Ignore all other permission events
@@ -414,91 +411,9 @@ async fn poll_for_message_with_approval(
                     }
 
                     "question.asked" => {
-                        let q_session_id = event.get("properties")
-                            .and_then(|p| p.get("sessionID").or_else(|| p.get("sessionId")))
-                            .and_then(|s| s.as_str());
-
                         if let Some(ref ctx) = question_ctx {
-                            if let Some(sess_id) = q_session_id {
-                                if tracked_sessions.contains(sess_id) {
-                                    let question_id = event.get("properties")
-                                        .and_then(|p| p.get("id"))
-                                        .and_then(|id| id.as_str())
-                                        .unwrap_or("")
-                                        .to_string();
-
-                                    let questions = parse_question_event(&event);
-
-                                    println!("[Gateway-{}] Question asked: id={}, {} question(s)",
-                                        &session_id[..8], question_id, questions.len());
-
-                                    let forwarded = ForwardedQuestion {
-                                        question_id: question_id.clone(),
-                                        questions: questions.clone(),
-                                    };
-
-                                    match (ctx.forwarder)(forwarded).await {
-                                        Ok(channel_msg_id) => {
-                                            let (tx, rx) = tokio::sync::oneshot::channel::<String>();
-                                            ctx.store.insert(channel_msg_id.clone(), PendingQuestionEntry {
-                                                question_id: question_id.clone(),
-                                                answer_tx: tx,
-                                                created_at: std::time::Instant::now(),
-                                            }).await;
-
-                                            let port_clone = port;
-                                            let qid = question_id.clone();
-                                            let questions_clone = questions;
-                                            let store_clone = std::sync::Arc::clone(&ctx.store);
-                                            let cmid = channel_msg_id;
-                                            tokio::spawn(async move {
-                                                let client = reqwest::Client::new();
-                                                match tokio::time::timeout(
-                                                    std::time::Duration::from_secs(300), rx
-                                                ).await {
-                                                    Ok(Ok(answer)) => {
-                                                        let answers = resolve_answer(&answer, &questions_clone);
-                                                        let url = format!(
-                                                            "http://127.0.0.1:{}/question/{}/reply",
-                                                            port_clone, qid
-                                                        );
-                                                        let body = serde_json::json!({ "answers": answers });
-                                                        match client.post(&url).json(&body).send().await {
-                                                            Ok(r) => println!(
-                                                                "[Gateway] Question {} answered (HTTP {})",
-                                                                qid, r.status()
-                                                            ),
-                                                            Err(e) => eprintln!(
-                                                                "[Gateway] Failed to reply question {}: {}",
-                                                                qid, e
-                                                            ),
-                                                        }
-                                                    }
-                                                    _ => {
-                                                        let url = format!(
-                                                            "http://127.0.0.1:{}/question/{}/reject",
-                                                            port_clone, qid
-                                                        );
-                                                        let _ = client
-                                                            .post(&url)
-                                                            .json(&serde_json::json!({}))
-                                                            .send()
-                                                            .await;
-                                                        println!("[Gateway] Question {} auto-rejected (timeout)", qid);
-                                                    }
-                                                }
-                                                store_clone.take(&cmid).await;
-                                            });
-                                        }
-                                        Err(e) => {
-                                            eprintln!("[Gateway-{}] Failed to forward question: {}", &session_id[..8], e);
-                                            let url = format!("http://127.0.0.1:{}/question/{}/reject", port, question_id);
-                                            let client = reqwest::Client::new();
-                                            let _ = client.post(&url).json(&serde_json::json!({})).send().await;
-                                        }
-                                    }
-                                }
-                            }
+                            let prefix = &session_id[..session_id.len().min(8)];
+                            handle_question_event(ctx, &event, port, prefix, &tracked_sessions).await;
                         }
                         continue;
                     }
@@ -535,7 +450,7 @@ async fn poll_for_message_with_approval(
                                     // Only return if this is a final message (not just tool-calls)
                                     // If finish="tool-calls", OpenCode will continue with another assistant message
                                     if finish_reason != Some("tool-calls") {
-                                        println!("[Gateway-{}] Message completed, fetching content", &session_id[..8]);
+                                        println!("[Gateway-{}] Message completed, fetching content", &session_id[..session_id.len().min(8)]);
                                         
                                         // Fetch the complete message content
                                         return fetch_message_content(port, session_id, msg_id).await;

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -11,8 +11,15 @@ pub mod wecom;
 pub mod wecom_config;
 pub mod session;
 pub mod session_queue;
+pub mod pending_question;
 
 pub use config::*;
+pub use pending_question::{
+    PendingQuestionStore, PendingQuestionEntry, QuestionContext,
+    QuestionForwarder, ForwardedQuestion, QuestionInfo, QuestionOption,
+    format_question_message, resolve_answer, extract_question_marker,
+    parse_question_event,
+};
 pub use discord::DiscordGateway;
 pub use email::EmailGateway;
 pub use feishu::FeishuGateway;
@@ -24,7 +31,7 @@ pub use wecom_config::*;
 pub use session::SessionMapping;
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tauri::State;
 use serde::Deserialize;
@@ -117,6 +124,8 @@ pub struct GatewayState {
     pub shared_session_mapping: SessionMapping,
     /// Whether the shared session mapping has been initialized with a persistence path
     pub session_initialized: Mutex<bool>,
+    /// Shared store for pending question forwarding
+    pub pending_questions: Arc<PendingQuestionStore>,
 }
 
 impl Default for GatewayState {
@@ -129,6 +138,7 @@ impl Default for GatewayState {
             wecom_gateway: Mutex::new(None),
             shared_session_mapping: SessionMapping::new(),
             session_initialized: Mutex::new(false),
+            pending_questions: Arc::new(PendingQuestionStore::new()),
         }
     }
 }

--- a/src-tauri/src/commands/gateway/pending_question.rs
+++ b/src-tauri/src/commands/gateway/pending_question.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{oneshot, RwLock};
+
+// ==================== Question Forwarding Types ====================
+
+#[derive(Debug, Clone)]
+pub struct QuestionInfo {
+    pub question: String,
+    pub options: Vec<QuestionOption>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QuestionOption {
+    pub label: String,
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ForwardedQuestion {
+    pub question_id: String,
+    pub questions: Vec<QuestionInfo>,
+}
+
+pub type QuestionForwarder = Box<
+    dyn Fn(ForwardedQuestion) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Bundles everything needed for question handling in SSE handlers.
+pub struct QuestionContext {
+    pub forwarder: QuestionForwarder,
+    pub store: Arc<PendingQuestionStore>,
+}
+
+// ==================== Pending Question Store ====================
+
+#[derive(Debug)]
+pub struct PendingQuestionEntry {
+    pub question_id: String,
+    pub answer_tx: oneshot::Sender<String>,
+    pub created_at: Instant,
+}
+
+/// Shared store mapping channel message IDs to pending question oneshot channels.
+pub struct PendingQuestionStore {
+    entries: RwLock<HashMap<String, PendingQuestionEntry>>,
+}
+
+const EXPIRY_SECS: u64 = 360; // 6 minutes (> 5 min timeout)
+
+impl PendingQuestionStore {
+    pub fn new() -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub async fn insert(&self, channel_msg_id: String, entry: PendingQuestionEntry) {
+        let mut entries = self.entries.write().await;
+        entries.retain(|_, e| e.created_at.elapsed() < Duration::from_secs(EXPIRY_SECS));
+        entries.insert(channel_msg_id, entry);
+    }
+
+    pub async fn take(&self, channel_msg_id: &str) -> Option<PendingQuestionEntry> {
+        self.entries.write().await.remove(channel_msg_id)
+    }
+
+    pub async fn take_by_question_id(&self, question_id: &str) -> Option<PendingQuestionEntry> {
+        let mut entries = self.entries.write().await;
+        let key = entries
+            .iter()
+            .find(|(_, e)| e.question_id == question_id)
+            .map(|(k, _)| k.clone());
+        key.and_then(|k| entries.remove(&k))
+    }
+}
+
+// ==================== SSE Event Parsing ====================
+
+pub fn parse_question_event(event: &serde_json::Value) -> Vec<QuestionInfo> {
+    event.get("properties")
+        .and_then(|p| p.get("questions"))
+        .and_then(|q| q.as_array())
+        .map(|arr| arr.iter().map(|q| {
+            let question = q.get("question")
+                .and_then(|v| v.as_str())
+                .unwrap_or("").to_string();
+            let options = q.get("options")
+                .and_then(|o| o.as_array())
+                .map(|opts| opts.iter().map(|o| QuestionOption {
+                    label: o.get("label").and_then(|l| l.as_str())
+                        .or_else(|| o.get("value").and_then(|v| v.as_str()))
+                        .unwrap_or("").to_string(),
+                    value: o.get("value").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                }).collect())
+                .unwrap_or_default();
+            QuestionInfo { question, options }
+        }).collect())
+        .unwrap_or_default()
+}
+
+// ==================== Formatting ====================
+
+pub fn format_question_message(questions: &[QuestionInfo], question_id: &str) -> String {
+    let mut out = String::from("AI has a question:\n\n");
+
+    for (i, q) in questions.iter().enumerate() {
+        if questions.len() > 1 {
+            out.push_str(&format!("**Question {}:** ", i + 1));
+        }
+        out.push_str(&q.question);
+        out.push('\n');
+
+        if !q.options.is_empty() {
+            out.push('\n');
+            for (j, opt) in q.options.iter().enumerate() {
+                out.push_str(&format!("{}. {}\n", j + 1, opt.label));
+            }
+        }
+        out.push('\n');
+    }
+
+    out.push_str("(Reply to this message with your answer. Auto-reject in 5 min)\n");
+    out.push_str(&format!("[Q:{}]", question_id));
+    out
+}
+
+pub fn resolve_answer(reply_text: &str, questions: &[QuestionInfo]) -> Vec<Vec<String>> {
+    let trimmed = reply_text.trim();
+    questions
+        .iter()
+        .enumerate()
+        .map(|(i, q)| {
+            if i > 0 {
+                return vec![];
+            }
+            if q.options.is_empty() {
+                return vec![trimmed.to_string()];
+            }
+            if let Ok(num) = trimmed.parse::<usize>() {
+                if num >= 1 && num <= q.options.len() {
+                    let opt = &q.options[num - 1];
+                    let value = opt.value.clone().unwrap_or_else(|| opt.label.clone());
+                    return vec![value];
+                }
+            }
+            vec![trimmed.to_string()]
+        })
+        .collect()
+}
+
+pub fn extract_question_marker(text: &str) -> Option<&str> {
+    let start = text.find("[Q:")?;
+    let rest = &text[start + 3..];
+    let end = rest.find(']')?;
+    Some(&rest[..end])
+}

--- a/src-tauri/src/commands/gateway/pending_question.rs
+++ b/src-tauri/src/commands/gateway/pending_question.rs
@@ -160,3 +160,193 @@ pub fn extract_question_marker(text: &str) -> Option<&str> {
     let end = rest.find(']')?;
     Some(&rest[..end])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_insert_and_take() {
+        let store = PendingQuestionStore::new();
+        let (tx, _rx) = oneshot::channel();
+        store.insert("msg_123".to_string(), PendingQuestionEntry {
+            question_id: "q_abc".to_string(),
+            answer_tx: tx,
+            created_at: Instant::now(),
+        }).await;
+        let entry = store.take("msg_123").await;
+        assert!(entry.is_some());
+        assert_eq!(entry.unwrap().question_id, "q_abc");
+        assert!(store.take("msg_123").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_take_nonexistent() {
+        let store = PendingQuestionStore::new();
+        assert!(store.take("nope").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_take_by_question_id() {
+        let store = PendingQuestionStore::new();
+        let (tx, _rx) = oneshot::channel();
+        store.insert("msg_456".to_string(), PendingQuestionEntry {
+            question_id: "q_xyz".to_string(),
+            answer_tx: tx,
+            created_at: Instant::now(),
+        }).await;
+        let entry = store.take_by_question_id("q_xyz").await;
+        assert!(entry.is_some());
+        assert_eq!(entry.unwrap().question_id, "q_xyz");
+        assert!(store.take("msg_456").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_expired_cleanup_on_insert() {
+        let store = PendingQuestionStore::new();
+        let (tx, _rx) = oneshot::channel();
+        let expired_time = Instant::now().checked_sub(Duration::from_secs(400))
+            .unwrap_or_else(Instant::now);
+        store.insert("old".to_string(), PendingQuestionEntry {
+            question_id: "q_old".to_string(),
+            answer_tx: tx,
+            created_at: expired_time,
+        }).await;
+        let (tx2, _rx2) = oneshot::channel();
+        store.insert("new".to_string(), PendingQuestionEntry {
+            question_id: "q_new".to_string(),
+            answer_tx: tx2,
+            created_at: Instant::now(),
+        }).await;
+        assert!(store.take("old").await.is_none());
+        assert!(store.take("new").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_insert_take() {
+        let store = Arc::new(PendingQuestionStore::new());
+        let store2 = Arc::clone(&store);
+        let (tx, rx) = oneshot::channel();
+        store.insert("msg_concurrent".to_string(), PendingQuestionEntry {
+            question_id: "q_concurrent".to_string(),
+            answer_tx: tx,
+            created_at: Instant::now(),
+        }).await;
+        let handle = tokio::spawn(async move {
+            store2.take("msg_concurrent").await
+        });
+        let entry = handle.await.unwrap();
+        assert!(entry.is_some());
+        let entry = entry.unwrap();
+        let _ = entry.answer_tx.send("answer".to_string());
+        assert_eq!(rx.await.unwrap(), "answer");
+    }
+
+    #[test]
+    fn test_format_question_with_options() {
+        let questions = vec![QuestionInfo {
+            question: "Continue with the refactor?".to_string(),
+            options: vec![
+                QuestionOption { label: "Yes".to_string(), value: Some("yes".to_string()) },
+                QuestionOption { label: "No".to_string(), value: Some("no".to_string()) },
+            ],
+        }];
+        let msg = format_question_message(&questions, "q_123");
+        assert!(msg.contains("Continue with the refactor?"));
+        assert!(msg.contains("1. Yes"));
+        assert!(msg.contains("2. No"));
+        assert!(msg.contains("[Q:q_123]"));
+        assert!(msg.contains("Auto-reject in 5 min"));
+    }
+
+    #[test]
+    fn test_format_question_open_ended() {
+        let questions = vec![QuestionInfo {
+            question: "What should I name this variable?".to_string(),
+            options: vec![],
+        }];
+        let msg = format_question_message(&questions, "q_456");
+        assert!(msg.contains("What should I name this variable?"));
+        assert!(!msg.contains("1."));
+        assert!(msg.contains("[Q:q_456]"));
+    }
+
+    #[test]
+    fn test_format_question_multiple() {
+        let questions = vec![
+            QuestionInfo { question: "First?".to_string(), options: vec![] },
+            QuestionInfo { question: "Second?".to_string(), options: vec![] },
+        ];
+        let msg = format_question_message(&questions, "q_multi");
+        assert!(msg.contains("**Question 1:**"));
+        assert!(msg.contains("**Question 2:**"));
+    }
+
+    #[test]
+    fn test_resolve_answer_with_options() {
+        let questions = vec![QuestionInfo {
+            question: "Pick one".to_string(),
+            options: vec![
+                QuestionOption { label: "A".to_string(), value: Some("a_val".to_string()) },
+                QuestionOption { label: "B".to_string(), value: None },
+            ],
+        }];
+        assert_eq!(resolve_answer("1", &questions), vec![vec!["a_val".to_string()]]);
+        assert_eq!(resolve_answer("2", &questions), vec![vec!["B".to_string()]]);
+        assert_eq!(resolve_answer("3", &questions), vec![vec!["3".to_string()]]);
+        assert_eq!(resolve_answer("hello", &questions), vec![vec!["hello".to_string()]]);
+    }
+
+    #[test]
+    fn test_resolve_answer_open_ended() {
+        let questions = vec![QuestionInfo {
+            question: "What?".to_string(),
+            options: vec![],
+        }];
+        assert_eq!(resolve_answer("my answer", &questions), vec![vec!["my answer".to_string()]]);
+    }
+
+    #[test]
+    fn test_resolve_answer_multiple_questions() {
+        let questions = vec![
+            QuestionInfo { question: "First?".to_string(), options: vec![] },
+            QuestionInfo { question: "Second?".to_string(), options: vec![] },
+        ];
+        let result = resolve_answer("my answer", &questions);
+        assert_eq!(result, vec![vec!["my answer".to_string()], vec![]]);
+    }
+
+    #[test]
+    fn test_extract_question_marker() {
+        assert_eq!(extract_question_marker("blah [Q:abc123] end"), Some("abc123"));
+        assert_eq!(extract_question_marker("no marker here"), None);
+        assert_eq!(extract_question_marker("[Q:]"), Some(""));
+    }
+
+    #[test]
+    fn test_parse_question_event() {
+        let event = serde_json::json!({
+            "properties": {
+                "questions": [{
+                    "question": "Continue?",
+                    "options": [
+                        { "label": "Yes", "value": "yes" },
+                        { "label": "No", "value": "no" }
+                    ]
+                }]
+            }
+        });
+        let questions = parse_question_event(&event);
+        assert_eq!(questions.len(), 1);
+        assert_eq!(questions[0].question, "Continue?");
+        assert_eq!(questions[0].options.len(), 2);
+        assert_eq!(questions[0].options[0].label, "Yes");
+        assert_eq!(questions[0].options[0].value, Some("yes".to_string()));
+    }
+
+    #[test]
+    fn test_parse_question_event_empty() {
+        let event = serde_json::json!({ "properties": {} });
+        assert!(parse_question_event(&event).is_empty());
+    }
+}

--- a/src-tauri/src/commands/gateway/pending_question.rs
+++ b/src-tauri/src/commands/gateway/pending_question.rs
@@ -154,6 +154,104 @@ pub fn resolve_answer(reply_text: &str, questions: &[QuestionInfo]) -> Vec<Vec<S
         .collect()
 }
 
+/// Handle a question.asked event: forward to channel, spawn wait task.
+/// Used by both the shared SSE handler (mod.rs) and WeCom's own SSE handler.
+pub async fn handle_question_event(
+    ctx: &QuestionContext,
+    event: &serde_json::Value,
+    port: u16,
+    session_id_prefix: &str,
+    tracked_sessions: &std::collections::HashSet<String>,
+) {
+    let q_session_id = event.get("properties")
+        .and_then(|p| p.get("sessionID").or_else(|| p.get("sessionId")))
+        .and_then(|s| s.as_str());
+
+    let sess_id = match q_session_id {
+        Some(s) if tracked_sessions.contains(s) => s,
+        _ => return,
+    };
+
+    let question_id = event.get("properties")
+        .and_then(|p| p.get("id"))
+        .and_then(|id| id.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let questions = parse_question_event(event);
+
+    println!("[Gateway-{}] Question asked: id={}, {} question(s)",
+        session_id_prefix, question_id, questions.len());
+
+    let forwarded = ForwardedQuestion {
+        question_id: question_id.clone(),
+        questions: questions.clone(),
+    };
+
+    let _ = sess_id; // used for tracked_sessions check above
+
+    match (ctx.forwarder)(forwarded).await {
+        Ok(channel_msg_id) => {
+            let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+            ctx.store.insert(channel_msg_id.clone(), PendingQuestionEntry {
+                question_id: question_id.clone(),
+                answer_tx: tx,
+                created_at: std::time::Instant::now(),
+            }).await;
+
+            let port_clone = port;
+            let qid = question_id;
+            let questions_clone = questions;
+            let store_clone = std::sync::Arc::clone(&ctx.store);
+            let cmid = channel_msg_id;
+            tokio::spawn(async move {
+                let client = reqwest::Client::new();
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(300), rx
+                ).await {
+                    Ok(Ok(answer)) => {
+                        let answers = resolve_answer(&answer, &questions_clone);
+                        let url = format!(
+                            "http://127.0.0.1:{}/question/{}/reply",
+                            port_clone, qid
+                        );
+                        let body = serde_json::json!({ "answers": answers });
+                        match client.post(&url).json(&body).send().await {
+                            Ok(r) => println!(
+                                "[Gateway] Question {} answered (HTTP {})",
+                                qid, r.status()
+                            ),
+                            Err(e) => eprintln!(
+                                "[Gateway] Failed to reply question {}: {}",
+                                qid, e
+                            ),
+                        }
+                    }
+                    _ => {
+                        let url = format!(
+                            "http://127.0.0.1:{}/question/{}/reject",
+                            port_clone, qid
+                        );
+                        let _ = client
+                            .post(&url)
+                            .json(&serde_json::json!({}))
+                            .send()
+                            .await;
+                        println!("[Gateway] Question {} auto-rejected (timeout)", qid);
+                    }
+                }
+                store_clone.take(&cmid).await;
+            });
+        }
+        Err(e) => {
+            eprintln!("[Gateway-{}] Failed to forward question: {}", session_id_prefix, e);
+            let url = format!("http://127.0.0.1:{}/question/{}/reject", port, question_id);
+            let client = reqwest::Client::new();
+            let _ = client.post(&url).json(&serde_json::json!({})).send().await;
+        }
+    }
+}
+
 pub fn extract_question_marker(text: &str) -> Option<&str> {
     let start = text.find("[Q:")?;
     let rest = &text[start + 3..];

--- a/src-tauri/src/commands/gateway/wecom.rs
+++ b/src-tauri/src/commands/gateway/wecom.rs
@@ -523,6 +523,10 @@ impl WeComGateway {
                         &req_id_q, &stream_id, &text, true, &ws_sink_q,
                     ).await.map_err(|e| format!("Failed to send question: {}", e))?;
                     println!("[WeCom] Question forwarded: {}", qid);
+                    // WeCom's quote payload lacks a message ID, so we use question_id as the
+                    // channel_msg_id key. Reply interception uses take_by_question_id() which
+                    // matches on entry.question_id, and the timeout cleanup calls store.take(&cmid)
+                    // which also works because cmid == question_id == entry.question_id.
                     Ok(qid)
                 })
             }),
@@ -866,7 +870,7 @@ impl WeComGateway {
         tracked_sessions.insert(session_id.to_string());
         let mut approved_permission_ids = std::collections::HashSet::new();
 
-        println!("[Gateway-{}] Streaming AI response to WeCom", &session_id[..8]);
+        println!("[Gateway-{}] Streaming AI response to WeCom", &session_id[..session_id.len().min(8)]);
 
         while let Some(chunk) = stream.next().await {
             if start_time.elapsed() > std::time::Duration::from_secs(900) {
@@ -938,70 +942,9 @@ impl WeComGateway {
                         }
 
                         "question.asked" => {
-                            let q_session_id = event.get("properties")
-                                .and_then(|p| p.get("sessionID"))
-                                .and_then(|s| s.as_str());
-
                             if let Some(ctx) = question_ctx {
-                                if let Some(sess_id) = q_session_id {
-                                    if tracked_sessions.contains(sess_id) {
-                                        let question_id = event.get("properties")
-                                            .and_then(|p| p.get("id"))
-                                            .and_then(|id| id.as_str())
-                                            .unwrap_or("").to_string();
-
-                                        let questions = super::parse_question_event(&event);
-
-                                        println!("[WeCom-{}] Question asked: id={}", &session_id[..8], question_id);
-
-                                        let forwarded = super::ForwardedQuestion {
-                                            question_id: question_id.clone(),
-                                            questions: questions.clone(),
-                                        };
-
-                                        match (ctx.forwarder)(forwarded).await {
-                                            Ok(channel_msg_id) => {
-                                                let (tx, rx) = tokio::sync::oneshot::channel::<String>();
-                                                ctx.store.insert(channel_msg_id.clone(), super::PendingQuestionEntry {
-                                                    question_id: question_id.clone(),
-                                                    answer_tx: tx,
-                                                    created_at: std::time::Instant::now(),
-                                                }).await;
-
-                                                let port_clone = port;
-                                                let qid = question_id;
-                                                let questions_clone = questions;
-                                                let store_clone = Arc::clone(&ctx.store);
-                                                let cmid = channel_msg_id;
-                                                tokio::spawn(async move {
-                                                    let client = reqwest::Client::new();
-                                                    match tokio::time::timeout(
-                                                        std::time::Duration::from_secs(300), rx
-                                                    ).await {
-                                                        Ok(Ok(answer)) => {
-                                                            let answers = super::resolve_answer(&answer, &questions_clone);
-                                                            let url = format!("http://127.0.0.1:{}/question/{}/reply", port_clone, qid);
-                                                            let _ = client.post(&url).json(&serde_json::json!({"answers": answers})).send().await;
-                                                            println!("[WeCom] Question {} answered", qid);
-                                                        }
-                                                        _ => {
-                                                            let url = format!("http://127.0.0.1:{}/question/{}/reject", port_clone, qid);
-                                                            let _ = client.post(&url).json(&serde_json::json!({})).send().await;
-                                                            println!("[WeCom] Question {} auto-rejected", qid);
-                                                        }
-                                                    }
-                                                    store_clone.take(&cmid).await;
-                                                });
-                                            }
-                                            Err(e) => {
-                                                eprintln!("[WeCom] Failed to forward question: {}", e);
-                                                let url = format!("http://127.0.0.1:{}/question/{}/reject", port, question_id);
-                                                let client = reqwest::Client::new();
-                                                let _ = client.post(&url).json(&serde_json::json!({})).send().await;
-                                            }
-                                        }
-                                    }
-                                }
+                                let prefix = &session_id[..session_id.len().min(8)];
+                                super::handle_question_event(ctx, &event, port, prefix, &tracked_sessions).await;
                             }
                             continue;
                         }
@@ -1070,7 +1013,7 @@ impl WeComGateway {
                                     && completed_time.is_some()
                                     && finish_reason != Some("tool-calls")
                                 {
-                                    println!("[Gateway-{}] Message completed, sending final stream chunk", &session_id[..8]);
+                                    println!("[Gateway-{}] Message completed, sending final stream chunk", &session_id[..session_id.len().min(8)]);
 
                                     // Stop thinking animation if still active
                                     if thinking_active {

--- a/src-tauri/src/commands/gateway/wecom.rs
+++ b/src-tauri/src/commands/gateway/wecom.rs
@@ -31,6 +31,7 @@ pub struct WeComGateway {
     #[allow(dead_code)]
     permission_approver: super::PermissionAutoApprover,
     session_queue: Arc<SessionQueue>,
+    pending_questions: Arc<super::PendingQuestionStore>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -91,6 +92,7 @@ impl WeComGateway {
             processed_messages: Arc::new(RwLock::new(ProcessedMessageTracker::new(MAX_PROCESSED_MESSAGES))),
             permission_approver: super::PermissionAutoApprover::new(opencode_port),
             session_queue: Arc::new(SessionQueue::new()),
+            pending_questions: Arc::new(super::PendingQuestionStore::new()),
         }
     }
 
@@ -455,6 +457,17 @@ impl WeComGateway {
                 .and_then(|t| t.get("content"))
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
+
+            // Check for question marker in quoted text
+            if let Some(qid) = super::extract_question_marker(quoted_text) {
+                if let Some(entry) = self.pending_questions.take_by_question_id(qid).await {
+                    let _ = entry.answer_tx.send(text_content.clone());
+                    println!("[WeCom] Question {} answered via quote reply", entry.question_id);
+                    return;
+                }
+            }
+
+            // Original behavior: prepend quoted text for context
             if !quoted_text.is_empty() {
                 text_content = format!("[Quoted message]\n{}\n[End quoted message]\n\n{}", quoted_text, text_content);
             }
@@ -494,6 +507,28 @@ impl WeComGateway {
         let req_id2 = req_id.clone();
         let ws_sink2 = Arc::clone(&ws_sink);
 
+        // Build question context for forwarding AI questions back to WeCom
+        let pending_questions_clone = Arc::clone(&self.pending_questions);
+        let ws_sink_for_q = Arc::clone(&ws_sink);
+        let req_id_for_q = req_id.clone();
+        let question_ctx = super::QuestionContext {
+            forwarder: Box::new(move |fq: super::ForwardedQuestion| {
+                let qid = fq.question_id.clone();
+                let ws_sink_q = Arc::clone(&ws_sink_for_q);
+                let req_id_q = req_id_for_q.clone();
+                Box::pin(async move {
+                    let text = super::format_question_message(&fq.questions, &fq.question_id);
+                    let stream_id = uuid::Uuid::new_v4().to_string();
+                    WeComGateway::send_stream_chunk_static(
+                        &req_id_q, &stream_id, &text, true, &ws_sink_q,
+                    ).await.map_err(|e| format!("Failed to send question: {}", e))?;
+                    println!("[WeCom] Question forwarded: {}", qid);
+                    Ok(qid)
+                })
+            }),
+            store: pending_questions_clone,
+        };
+
         let result = self.session_queue.enqueue(&session_key, QueuedMessage {
             enqueued_at: std::time::Instant::now(),
             process_fn: Box::new(move || Box::pin(async move {
@@ -502,6 +537,7 @@ impl WeComGateway {
                     &session_key_owned, &text_content_owned,
                     image_url_owned.as_deref(), &msg_owned,
                     &req_id_owned, &ws_sink_owned,
+                    Some(&question_ctx),
                 ).await {
                     eprintln!("[WeCom] Process error: {}", e);
                     let _ = gateway.send_reply(&req_id_for_error, &format!("Error: {}", e), &ws_sink_owned).await;
@@ -639,6 +675,7 @@ impl WeComGateway {
         _original: &WeComMsgCallback,
         req_id: &str,
         ws_sink: &WsSink,
+        question_ctx: Option<&super::QuestionContext>,
     ) -> Result<(), String> {
         // Get or create session
         let model = self.session_mapping.get_model(session_key).await;
@@ -698,7 +735,7 @@ impl WeComGateway {
 
         // Stream OpenCode response to WeCom (retry with new session if prompt_async fails)
         match self.stream_opencode_to_wecom(
-            &session_id, parts.clone(), model_tuple.clone(), req_id, ws_sink,
+            &session_id, parts.clone(), model_tuple.clone(), req_id, ws_sink, question_ctx,
         ).await {
             Ok(()) => Ok(()),
             Err(e) if e.contains("prompt_async failed") => {
@@ -709,7 +746,7 @@ impl WeComGateway {
                     .set_session(session_key.to_string(), new_id.clone())
                     .await;
                 self.stream_opencode_to_wecom(
-                    &new_id, parts, model_tuple, req_id, ws_sink,
+                    &new_id, parts, model_tuple, req_id, ws_sink, question_ctx,
                 ).await
             }
             Err(e) => Err(e),
@@ -724,6 +761,7 @@ impl WeComGateway {
         model: Option<(String, String)>,
         req_id: &str,
         ws_sink: &WsSink,
+        question_ctx: Option<&super::QuestionContext>,
     ) -> Result<(), String> {
         use futures_util::StreamExt as _;
 
@@ -897,6 +935,75 @@ impl WeComGateway {
                                     approved_permission_ids.insert(perm_id_str.to_string());
                                 }
                             }
+                        }
+
+                        "question.asked" => {
+                            let q_session_id = event.get("properties")
+                                .and_then(|p| p.get("sessionID"))
+                                .and_then(|s| s.as_str());
+
+                            if let Some(ctx) = question_ctx {
+                                if let Some(sess_id) = q_session_id {
+                                    if tracked_sessions.contains(sess_id) {
+                                        let question_id = event.get("properties")
+                                            .and_then(|p| p.get("id"))
+                                            .and_then(|id| id.as_str())
+                                            .unwrap_or("").to_string();
+
+                                        let questions = super::parse_question_event(&event);
+
+                                        println!("[WeCom-{}] Question asked: id={}", &session_id[..8], question_id);
+
+                                        let forwarded = super::ForwardedQuestion {
+                                            question_id: question_id.clone(),
+                                            questions: questions.clone(),
+                                        };
+
+                                        match (ctx.forwarder)(forwarded).await {
+                                            Ok(channel_msg_id) => {
+                                                let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+                                                ctx.store.insert(channel_msg_id.clone(), super::PendingQuestionEntry {
+                                                    question_id: question_id.clone(),
+                                                    answer_tx: tx,
+                                                    created_at: std::time::Instant::now(),
+                                                }).await;
+
+                                                let port_clone = port;
+                                                let qid = question_id;
+                                                let questions_clone = questions;
+                                                let store_clone = Arc::clone(&ctx.store);
+                                                let cmid = channel_msg_id;
+                                                tokio::spawn(async move {
+                                                    let client = reqwest::Client::new();
+                                                    match tokio::time::timeout(
+                                                        std::time::Duration::from_secs(300), rx
+                                                    ).await {
+                                                        Ok(Ok(answer)) => {
+                                                            let answers = super::resolve_answer(&answer, &questions_clone);
+                                                            let url = format!("http://127.0.0.1:{}/question/{}/reply", port_clone, qid);
+                                                            let _ = client.post(&url).json(&serde_json::json!({"answers": answers})).send().await;
+                                                            println!("[WeCom] Question {} answered", qid);
+                                                        }
+                                                        _ => {
+                                                            let url = format!("http://127.0.0.1:{}/question/{}/reject", port_clone, qid);
+                                                            let _ = client.post(&url).json(&serde_json::json!({})).send().await;
+                                                            println!("[WeCom] Question {} auto-rejected", qid);
+                                                        }
+                                                    }
+                                                    store_clone.take(&cmid).await;
+                                                });
+                                            }
+                                            Err(e) => {
+                                                eprintln!("[WeCom] Failed to forward question: {}", e);
+                                                let url = format!("http://127.0.0.1:{}/question/{}/reject", port, question_id);
+                                                let client = reqwest::Client::new();
+                                                let _ = client.post(&url).json(&serde_json::json!({})).send().await;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            continue;
                         }
 
                         "message.part.delta" => {

--- a/src-tauri/src/commands/webview.rs
+++ b/src-tauri/src/commands/webview.rs
@@ -5,16 +5,126 @@ use tauri::Manager;
 /// Chrome-like user agent so websites serve normal desktop content.
 const CHROME_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
 
+/// Send-safe wrapper around a retained ObjC WKWebViewConfiguration pointer.
+#[cfg(target_os = "macos")]
+pub struct SharedConfig(*const std::ffi::c_void);
+#[cfg(target_os = "macos")]
+unsafe impl Send for SharedConfig {}
+#[cfg(target_os = "macos")]
+unsafe impl Sync for SharedConfig {}
+
+#[cfg(target_os = "macos")]
+impl Drop for SharedConfig {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { objc2::ffi::objc_release(self.0 as *mut _) };
+        }
+    }
+}
+
 /// State to track child webview labels.
 pub struct WebviewManager {
     labels: Mutex<HashMap<String, ()>>,
+    /// Shared WKWebViewConfiguration so all external webviews share the same
+    /// WKProcessPool (in-memory cookies) and WKWebsiteDataStore (persistent cookies).
+    #[cfg(target_os = "macos")]
+    pub shared_config: Option<SharedConfig>,
 }
 
 impl Default for WebviewManager {
     fn default() -> Self {
         Self {
             labels: Mutex::new(HashMap::new()),
+            #[cfg(target_os = "macos")]
+            shared_config: None,
         }
+    }
+}
+
+/// Create a shared WKWebViewConfiguration on the main thread.
+/// Must be called from Tauri's builder chain or setup() which run on the main thread.
+#[cfg(target_os = "macos")]
+pub fn init_shared_config(manager: &mut WebviewManager) {
+    use objc2::MainThreadMarker;
+    use objc2_web_kit::WKWebViewConfiguration;
+
+    let mtm = MainThreadMarker::new()
+        .expect("init_shared_config must be called from the main thread");
+    unsafe {
+        let config = WKWebViewConfiguration::new(mtm);
+        let raw = objc2::rc::Retained::as_ptr(&config) as *const std::ffi::c_void;
+        objc2::ffi::objc_retain(raw as *mut _);
+        manager.shared_config = Some(SharedConfig(raw));
+    }
+    eprintln!("[Webview] Shared WKWebViewConfiguration initialized on main thread");
+}
+
+/// Execute JavaScript in the main webview and return the stringified result.
+/// Debug-only: used by stress tests and automation via tauri-mcp socket.
+///
+/// The JS code is eval'd, the result is stringified and sent back via Tauri event.
+/// Rust listens for the event with a 10-second timeout.
+#[cfg(debug_assertions)]
+#[tauri::command]
+pub async fn webview_eval_js(app: tauri::AppHandle, code: String) -> Result<String, String> {
+    use tauri::Listener;
+
+    let webview = app
+        .get_webview_window("main")
+        .ok_or_else(|| "Main window not found".to_string())?;
+
+    // Generate a unique callback ID to avoid collisions
+    let callback_id = format!("__eval_{}", std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos());
+
+    // Wrap the code: eval it, stringify the result, store in a global keyed by callback_id
+    // Then call postMessage to the IPC channel to signal completion.
+    let escaped_code = serde_json::to_string(&code).unwrap_or_else(|_| "\"\"".to_string());
+    let escaped_id = serde_json::to_string(&callback_id).unwrap_or_else(|_| "\"\"".to_string());
+    let wrapped = format!(
+        r#"try {{
+    const __r = (0, eval)({code});
+    const __s = typeof __r === 'object' ? JSON.stringify(__r) : String(__r);
+    window.__TAURI_INTERNALS__.postMessage(JSON.stringify({{
+        cmd: "plugin:event|emit",
+        event: {id},
+        payload: JSON.stringify({{ result: __s }})
+    }}));
+}} catch (__e) {{
+    window.__TAURI_INTERNALS__.postMessage(JSON.stringify({{
+        cmd: "plugin:event|emit",
+        event: {id},
+        payload: JSON.stringify({{ error: String(__e) }})
+    }}));
+}}"#,
+        code = escaped_code,
+        id = escaped_id,
+    );
+
+    // Set up receiver
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    app.once(&callback_id, move |event| {
+        let _ = tx.send(event.payload().to_string());
+    });
+
+    // Execute
+    webview.eval(&wrapped).map_err(|e| format!("Failed to eval: {}", e))?;
+
+    // Wait for result
+    match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        Ok(raw) => {
+            // Parse the double-serialized payload
+            let payload_str: String = serde_json::from_str(&raw).unwrap_or(raw.clone());
+            let parsed: serde_json::Value = serde_json::from_str(&payload_str)
+                .unwrap_or(serde_json::Value::String(raw));
+            if let Some(err) = parsed.get("error").and_then(|e| e.as_str()) {
+                return Err(format!("JS error: {}", err));
+            }
+            Ok(parsed.get("result").and_then(|r| r.as_str()).unwrap_or("").to_string())
+        }
+        Err(_) => Err("Timeout waiting for JS eval result (10s)".to_string()),
     }
 }
 
@@ -59,11 +169,27 @@ pub async fn webview_create(
         label, url, x, y, width, height
     );
 
-    let webview_builder = tauri::webview::WebviewBuilder::new(
+    let mut webview_builder = tauri::webview::WebviewBuilder::new(
         &label,
         tauri::WebviewUrl::External(parsed_url),
     )
     .user_agent(CHROME_UA);
+
+    // On macOS, use the shared WKWebViewConfiguration so all webviews share
+    // the same WKProcessPool → cookies/session shared instantly across tabs.
+    #[cfg(target_os = "macos")]
+    if let Some(ref shared) = state.shared_config {
+        unsafe {
+            use objc2::rc::Retained;
+            use objc2_web_kit::WKWebViewConfiguration;
+
+            let config_ptr = shared.0 as *mut WKWebViewConfiguration;
+            let config: Retained<WKWebViewConfiguration> = Retained::retain(config_ptr)
+                .expect("Shared WKWebViewConfiguration should be valid");
+            webview_builder = webview_builder.with_webview_configuration(config);
+            eprintln!("[Webview] Using shared WKWebViewConfiguration");
+        }
+    }
 
     let webview = window
         .add_child(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,7 +122,11 @@ pub fn run() {
         .plugin({
             #[cfg(debug_assertions)]
             {
-                tauri_plugin_mcp::Builder.build()
+                tauri_plugin_mcp::init_with_config(
+                    tauri_plugin_mcp::PluginConfig::new("TeamClaw".to_string())
+                        .start_socket_server(true)
+                        .socket_path("/tmp/tauri-mcp.sock".into())
+                )
             }
             #[cfg(not(debug_assertions))]
             {
@@ -136,7 +140,12 @@ pub fn run() {
         .manage(rag_state)
         .manage(telemetry::commands::TelemetryState::default())
         .manage(crate::stt::SttState::default())
-        .manage(commands::webview::WebviewManager::default())
+        .manage({
+            let mut wvm = commands::webview::WebviewManager::default();
+            #[cfg(target_os = "macos")]
+            commands::webview::init_shared_config(&mut wvm);
+            wvm
+        })
         .manage(<commands::p2p_state::IrohState>::default())
         .manage(commands::spotlight::SpotlightState::default())
         .manage(tokio::sync::Mutex::new(commands::team_webdav::WebDavManagedState::default()))
@@ -314,6 +323,7 @@ pub fn run() {
             telemetry::commands::telemetry_export_leaderboard,
             telemetry::commands::telemetry_get_team_leaderboard,
             telemetry::commands::telemetry_get_member_aggregated_stats,
+            commands::webview::webview_eval_js,
             commands::webview::webview_create,
             commands::webview::webview_close,
             commands::webview::webview_hide,

--- a/tests/stress/chat-stress.test.ts
+++ b/tests/stress/chat-stress.test.ts
@@ -21,14 +21,24 @@ describe('Chat stress test', () => {
     console.log(`[stress] Config: ${JSON.stringify(config, null, 2)}`);
 
     await launchTeamClawApp();
-    await sleep(10_000);
-    await focusWindow();
-    await sleep(2_000);
+    console.log('[stress] App process spawned, waiting for webview to load...');
 
-    const storeOk = await verifyStoreExposed();
-    if (!storeOk) {
-      throw new Error('__TEAMCLAW_STORES__ not found on window. Is the app running in dev mode?');
+    // Wait for the socket + webview to become ready (retry executeJs with backoff)
+    let storeOk = false;
+    for (let attempt = 0; attempt < 30; attempt++) {
+      await sleep(2_000);
+      try {
+        await focusWindow();
+        storeOk = await verifyStoreExposed();
+        if (storeOk) break;
+      } catch (err: any) {
+        console.log(`[stress] Waiting for webview... attempt ${attempt + 1}/30 (${err.message?.slice(0, 60)})`);
+      }
     }
+    if (!storeOk) {
+      throw new Error('__TEAMCLAW_STORES__ not found on window after 60s. Is the app running in dev mode?');
+    }
+    console.log('[stress] Store exposure verified.');
 
     for (let i = 0; i < 30; i++) {
       if (await isOpenCodeReady()) { ready = true; break; }

--- a/tests/stress/chat-stress.test.ts
+++ b/tests/stress/chat-stress.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import {
+  launchTeamClawApp,
+  stopApp,
+  sleep,
+  focusWindow,
+} from '../_utils/tauri-mcp-test-utils';
+import { verifyStoreExposed, isOpenCodeReady, waitForIdle, archiveSession } from './stress-helpers';
+import { loadConfig, computeTimeBudgets } from './stress-config';
+import { StressReporter } from './stress-reporter';
+import { runSingleSession, runMultiSession, runMixedMode } from './stress-scenarios';
+
+const config = loadConfig();
+const budgets = computeTimeBudgets(config);
+const reporter = new StressReporter(config);
+
+describe('Chat stress test', () => {
+  let ready = false;
+
+  beforeAll(async () => {
+    console.log(`[stress] Config: ${JSON.stringify(config, null, 2)}`);
+
+    await launchTeamClawApp();
+    await sleep(10_000);
+    await focusWindow();
+    await sleep(2_000);
+
+    const storeOk = await verifyStoreExposed();
+    if (!storeOk) {
+      throw new Error('__TEAMCLAW_STORES__ not found on window. Is the app running in dev mode?');
+    }
+
+    for (let i = 0; i < 30; i++) {
+      if (await isOpenCodeReady()) { ready = true; break; }
+      await sleep(2_000);
+    }
+    if (!ready) {
+      throw new Error('OpenCode did not become ready within 60s');
+    }
+
+    console.log('[stress] App launched and OpenCode ready. Starting stress test...');
+  }, 120_000);
+
+  afterAll(async () => {
+    try {
+      const { jsonPath, htmlPath } = reporter.writeReports(config.reportDir);
+      console.log(`[stress] Reports written:\n  JSON: ${jsonPath}\n  HTML: ${htmlPath}`);
+    } catch (err: any) {
+      console.error('[stress] Failed to write reports:', err.message);
+    }
+
+    try {
+      for (const id of reporter.getSessionIds()) {
+        try { await archiveSession(id); } catch { /* may already be archived */ }
+      }
+    } catch { /* best-effort */ }
+
+    await stopApp();
+  }, 60_000);
+
+  it('scenario 1: single session continuous', async () => {
+    expect(ready).toBe(true);
+    await waitForIdle();
+    await runSingleSession(budgets.singleSessionMs, config, reporter);
+  }, budgets.singleSessionMs + 60_000);
+
+  it('scenario 2: multi session concurrent', async () => {
+    expect(ready).toBe(true);
+    await waitForIdle();
+    await runMultiSession(budgets.multiSessionMs, config, reporter);
+  }, budgets.multiSessionMs + 60_000);
+
+  it('scenario 3: mixed mode', async () => {
+    expect(ready).toBe(true);
+    await waitForIdle();
+    await runMixedMode(budgets.mixedModeMs, config, reporter);
+  }, budgets.mixedModeMs + 60_000);
+});

--- a/tests/stress/stress-config.ts
+++ b/tests/stress/stress-config.ts
@@ -1,0 +1,34 @@
+import { join } from 'path';
+
+export interface StressConfig {
+  durationMinutes: number;
+  concurrentSessions: number;
+  messageTimeoutMs: number;
+  mixedNewSessionIntervalMs: number;
+  reportDir: string;
+}
+
+export function loadConfig(): StressConfig {
+  return {
+    durationMinutes: parseInt(process.env.STRESS_DURATION || '30', 10),
+    concurrentSessions: parseInt(process.env.STRESS_CONCURRENT_SESSIONS || '3', 10),
+    messageTimeoutMs: parseInt(process.env.STRESS_MSG_TIMEOUT || '120000', 10),
+    mixedNewSessionIntervalMs: parseInt(process.env.STRESS_NEW_SESSION_INTERVAL || '120000', 10),
+    reportDir: process.env.STRESS_REPORT_DIR || join(process.cwd(), 'tests/stress/reports'),
+  };
+}
+
+export interface ScenarioTimeBudget {
+  singleSessionMs: number;
+  multiSessionMs: number;
+  mixedModeMs: number;
+}
+
+export function computeTimeBudgets(config: StressConfig): ScenarioTimeBudget {
+  const totalMs = config.durationMinutes * 60 * 1000;
+  return {
+    singleSessionMs: Math.floor(totalMs * 0.3),
+    multiSessionMs: Math.floor(totalMs * 0.3),
+    mixedModeMs: Math.floor(totalMs * 0.4),
+  };
+}

--- a/tests/stress/stress-helpers.ts
+++ b/tests/stress/stress-helpers.ts
@@ -1,0 +1,118 @@
+import { executeJs, waitForCondition, takeScreenshot, sleep } from '../_utils/tauri-mcp-test-utils';
+
+const STORE = 'window.__TEAMCLAW_STORES__';
+
+export async function verifyStoreExposed(): Promise<boolean> {
+  const result = await executeJs(`typeof ${STORE}?.session?.getState === 'function'`);
+  return result === 'true';
+}
+
+export async function isOpenCodeReady(): Promise<boolean> {
+  const result = await executeJs(
+    `${STORE}.session.getState().isConnected === true`
+  );
+  return result === 'true';
+}
+
+export async function waitForIdle(timeoutMs = 30_000): Promise<void> {
+  await waitForCondition(
+    `(() => {
+      const s = ${STORE}.session.getState().sessionStatus;
+      return String(!s || s.type === 'idle' || s === undefined);
+    })()`,
+    (r) => r === 'true',
+    timeoutMs,
+    1_000,
+  );
+}
+
+export async function createSession(): Promise<string | null> {
+  const beforeId = await getActiveSessionId();
+  await executeJs(`${STORE}.session.getState().createSession()`);
+  let newId: string | null = null;
+  for (let i = 0; i < 20; i++) {
+    await sleep(500);
+    const currentId = await getActiveSessionId();
+    if (currentId && currentId !== beforeId) {
+      newId = currentId;
+      break;
+    }
+  }
+  return newId;
+}
+
+export async function switchSession(sessionId: string): Promise<void> {
+  await executeJs(`${STORE}.session.getState().setActiveSession(${JSON.stringify(sessionId)})`);
+  for (let i = 0; i < 10; i++) {
+    await sleep(300);
+    const current = await getActiveSessionId();
+    if (current === sessionId) return;
+  }
+  console.warn(`[stress] switchSession: activeSessionId did not change to ${sessionId} within 3s`);
+}
+
+export async function sendMessage(text: string): Promise<void> {
+  await executeJs(`${STORE}.session.getState().sendMessage(${JSON.stringify(text)})`);
+}
+
+export async function getMessageCount(sessionId: string): Promise<number> {
+  const result = await executeJs(
+    `${STORE}.session.getState().getSessionMessages(${JSON.stringify(sessionId)}).length`
+  );
+  return parseInt(result) || 0;
+}
+
+export async function waitForMessageCount(
+  sessionId: string,
+  expectedCount: number,
+  timeoutMs: number,
+): Promise<void> {
+  await waitForCondition(
+    `${STORE}.session.getState().getSessionMessages(${JSON.stringify(sessionId)}).length`,
+    (r) => parseInt(r) >= expectedCount,
+    timeoutMs,
+    1_000,
+  );
+}
+
+export async function checkSessionError(): Promise<string | null> {
+  const result = await executeJs(
+    `JSON.stringify(${STORE}.session.getState().sessionError)`
+  );
+  return result && result !== 'null' && result !== 'undefined' ? result : null;
+}
+
+export async function pollForError(windowMs = 10_000): Promise<string | null> {
+  try {
+    await waitForCondition(
+      `JSON.stringify(${STORE}.session.getState().sessionError)`,
+      (r) => r !== 'null' && r !== 'undefined' && r !== '',
+      windowMs,
+      1_000,
+    );
+    return await checkSessionError();
+  } catch {
+    return null;
+  }
+}
+
+export async function archiveSession(sessionId: string): Promise<void> {
+  await executeJs(`${STORE}.session.getState().archiveSession(${JSON.stringify(sessionId)})`);
+  await sleep(1000);
+}
+
+export async function getActiveSessionId(): Promise<string | null> {
+  const result = await executeJs(
+    `${STORE}.session.getState().activeSessionId`
+  );
+  return result && result !== 'null' && result !== 'undefined' ? result : null;
+}
+
+export async function captureErrorScreenshot(
+  reportDir: string,
+  index: number,
+): Promise<string> {
+  const timestamp = Date.now();
+  const path = `${reportDir}/screenshots/error-${timestamp}-${index}.png`;
+  return takeScreenshot(path);
+}

--- a/tests/stress/stress-helpers.ts
+++ b/tests/stress/stress-helpers.ts
@@ -28,14 +28,23 @@ export async function waitForIdle(timeoutMs = 30_000): Promise<void> {
 
 export async function createSession(): Promise<string | null> {
   const beforeId = await getActiveSessionId();
-  await executeJs(`${STORE}.session.getState().createSession()`);
+  try {
+    await executeJs(`${STORE}.session.getState().createSession()`);
+  } catch {
+    // createSession is async — executeJs may timeout but the session still gets created
+  }
+  // Poll for activeSessionId to change (or appear if it was null)
   let newId: string | null = null;
   for (let i = 0; i < 20; i++) {
     await sleep(500);
-    const currentId = await getActiveSessionId();
-    if (currentId && currentId !== beforeId) {
-      newId = currentId;
-      break;
+    try {
+      const currentId = await getActiveSessionId();
+      if (currentId && currentId !== beforeId) {
+        newId = currentId;
+        break;
+      }
+    } catch {
+      // transient executeJs error, keep polling
     }
   }
   return newId;

--- a/tests/stress/stress-helpers.ts
+++ b/tests/stress/stress-helpers.ts
@@ -48,7 +48,7 @@ export async function switchSession(sessionId: string): Promise<void> {
     const current = await getActiveSessionId();
     if (current === sessionId) return;
   }
-  console.warn(`[stress] switchSession: activeSessionId did not change to ${sessionId} within 3s`);
+  throw new Error(`switchSession: activeSessionId did not change to ${sessionId} within 3s`);
 }
 
 export async function sendMessage(text: string): Promise<void> {

--- a/tests/stress/stress-helpers.ts
+++ b/tests/stress/stress-helpers.ts
@@ -1,14 +1,45 @@
-import { executeJs, waitForCondition, takeScreenshot, sleep } from '../_utils/tauri-mcp-test-utils';
+import { callIpcCommand, takeScreenshot, sleep } from '../_utils/tauri-mcp-test-utils';
 
 const STORE = 'window.__TEAMCLAW_STORES__';
 
+/**
+ * Execute JS in the main webview via the webview_eval_js IPC command.
+ * This bypasses the broken tauri-plugin-mcp execute_js event system.
+ */
+async function evalJs(code: string): Promise<string> {
+  const result = await callIpcCommand('webview_eval_js', { code });
+  return result;
+}
+
+/**
+ * Poll an evalJs expression until the predicate passes or timeout.
+ */
+async function waitForCondition(
+  jsCode: string,
+  predicate: (result: string) => boolean,
+  timeoutMs: number,
+  intervalMs = 1_000,
+): Promise<string> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const result = await evalJs(jsCode);
+      if (predicate(result)) return result;
+    } catch {
+      // evalJs may fail transiently, keep polling
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`Condition not met within ${timeoutMs}ms: ${jsCode}`);
+}
+
 export async function verifyStoreExposed(): Promise<boolean> {
-  const result = await executeJs(`typeof ${STORE}?.session?.getState === 'function'`);
+  const result = await evalJs(`typeof ${STORE}?.session?.getState === 'function'`);
   return result === 'true';
 }
 
 export async function isOpenCodeReady(): Promise<boolean> {
-  const result = await executeJs(
+  const result = await evalJs(
     `${STORE}.session.getState().isConnected === true`
   );
   return result === 'true';
@@ -28,7 +59,7 @@ export async function waitForIdle(timeoutMs = 30_000): Promise<void> {
 
 export async function createSession(): Promise<string | null> {
   const beforeId = await getActiveSessionId();
-  await executeJs(`${STORE}.session.getState().createSession()`);
+  await evalJs(`${STORE}.session.getState().createSession()`);
   let newId: string | null = null;
   for (let i = 0; i < 20; i++) {
     await sleep(500);
@@ -42,7 +73,7 @@ export async function createSession(): Promise<string | null> {
 }
 
 export async function switchSession(sessionId: string): Promise<void> {
-  await executeJs(`${STORE}.session.getState().setActiveSession(${JSON.stringify(sessionId)})`);
+  await evalJs(`${STORE}.session.getState().setActiveSession(${JSON.stringify(sessionId)})`);
   for (let i = 0; i < 10; i++) {
     await sleep(300);
     const current = await getActiveSessionId();
@@ -52,11 +83,11 @@ export async function switchSession(sessionId: string): Promise<void> {
 }
 
 export async function sendMessage(text: string): Promise<void> {
-  await executeJs(`${STORE}.session.getState().sendMessage(${JSON.stringify(text)})`);
+  await evalJs(`${STORE}.session.getState().sendMessage(${JSON.stringify(text)})`);
 }
 
 export async function getMessageCount(sessionId: string): Promise<number> {
-  const result = await executeJs(
+  const result = await evalJs(
     `${STORE}.session.getState().getSessionMessages(${JSON.stringify(sessionId)}).length`
   );
   return parseInt(result) || 0;
@@ -76,7 +107,7 @@ export async function waitForMessageCount(
 }
 
 export async function checkSessionError(): Promise<string | null> {
-  const result = await executeJs(
+  const result = await evalJs(
     `JSON.stringify(${STORE}.session.getState().sessionError)`
   );
   return result && result !== 'null' && result !== 'undefined' ? result : null;
@@ -97,12 +128,12 @@ export async function pollForError(windowMs = 10_000): Promise<string | null> {
 }
 
 export async function archiveSession(sessionId: string): Promise<void> {
-  await executeJs(`${STORE}.session.getState().archiveSession(${JSON.stringify(sessionId)})`);
+  await evalJs(`${STORE}.session.getState().archiveSession(${JSON.stringify(sessionId)})`);
   await sleep(1000);
 }
 
 export async function getActiveSessionId(): Promise<string | null> {
-  const result = await executeJs(
+  const result = await evalJs(
     `${STORE}.session.getState().activeSessionId`
   );
   return result && result !== 'null' && result !== 'undefined' ? result : null;

--- a/tests/stress/stress-helpers.ts
+++ b/tests/stress/stress-helpers.ts
@@ -1,45 +1,14 @@
-import { callIpcCommand, takeScreenshot, sleep } from '../_utils/tauri-mcp-test-utils';
+import { executeJs, waitForCondition, takeScreenshot, sleep } from '../_utils/tauri-mcp-test-utils';
 
 const STORE = 'window.__TEAMCLAW_STORES__';
 
-/**
- * Execute JS in the main webview via the webview_eval_js IPC command.
- * This bypasses the broken tauri-plugin-mcp execute_js event system.
- */
-async function evalJs(code: string): Promise<string> {
-  const result = await callIpcCommand('webview_eval_js', { code });
-  return result;
-}
-
-/**
- * Poll an evalJs expression until the predicate passes or timeout.
- */
-async function waitForCondition(
-  jsCode: string,
-  predicate: (result: string) => boolean,
-  timeoutMs: number,
-  intervalMs = 1_000,
-): Promise<string> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const result = await evalJs(jsCode);
-      if (predicate(result)) return result;
-    } catch {
-      // evalJs may fail transiently, keep polling
-    }
-    await sleep(intervalMs);
-  }
-  throw new Error(`Condition not met within ${timeoutMs}ms: ${jsCode}`);
-}
-
 export async function verifyStoreExposed(): Promise<boolean> {
-  const result = await evalJs(`typeof ${STORE}?.session?.getState === 'function'`);
+  const result = await executeJs(`typeof ${STORE}?.session?.getState === 'function'`);
   return result === 'true';
 }
 
 export async function isOpenCodeReady(): Promise<boolean> {
-  const result = await evalJs(
+  const result = await executeJs(
     `${STORE}.session.getState().isConnected === true`
   );
   return result === 'true';
@@ -59,7 +28,7 @@ export async function waitForIdle(timeoutMs = 30_000): Promise<void> {
 
 export async function createSession(): Promise<string | null> {
   const beforeId = await getActiveSessionId();
-  await evalJs(`${STORE}.session.getState().createSession()`);
+  await executeJs(`${STORE}.session.getState().createSession()`);
   let newId: string | null = null;
   for (let i = 0; i < 20; i++) {
     await sleep(500);
@@ -73,7 +42,7 @@ export async function createSession(): Promise<string | null> {
 }
 
 export async function switchSession(sessionId: string): Promise<void> {
-  await evalJs(`${STORE}.session.getState().setActiveSession(${JSON.stringify(sessionId)})`);
+  await executeJs(`${STORE}.session.getState().setActiveSession(${JSON.stringify(sessionId)})`);
   for (let i = 0; i < 10; i++) {
     await sleep(300);
     const current = await getActiveSessionId();
@@ -83,11 +52,11 @@ export async function switchSession(sessionId: string): Promise<void> {
 }
 
 export async function sendMessage(text: string): Promise<void> {
-  await evalJs(`${STORE}.session.getState().sendMessage(${JSON.stringify(text)})`);
+  await executeJs(`${STORE}.session.getState().sendMessage(${JSON.stringify(text)})`);
 }
 
 export async function getMessageCount(sessionId: string): Promise<number> {
-  const result = await evalJs(
+  const result = await executeJs(
     `${STORE}.session.getState().getSessionMessages(${JSON.stringify(sessionId)}).length`
   );
   return parseInt(result) || 0;
@@ -107,7 +76,7 @@ export async function waitForMessageCount(
 }
 
 export async function checkSessionError(): Promise<string | null> {
-  const result = await evalJs(
+  const result = await executeJs(
     `JSON.stringify(${STORE}.session.getState().sessionError)`
   );
   return result && result !== 'null' && result !== 'undefined' ? result : null;
@@ -128,12 +97,12 @@ export async function pollForError(windowMs = 10_000): Promise<string | null> {
 }
 
 export async function archiveSession(sessionId: string): Promise<void> {
-  await evalJs(`${STORE}.session.getState().archiveSession(${JSON.stringify(sessionId)})`);
+  await executeJs(`${STORE}.session.getState().archiveSession(${JSON.stringify(sessionId)})`);
   await sleep(1000);
 }
 
 export async function getActiveSessionId(): Promise<string | null> {
-  const result = await evalJs(
+  const result = await executeJs(
     `${STORE}.session.getState().activeSessionId`
   );
   return result && result !== 'null' && result !== 'undefined' ? result : null;

--- a/tests/stress/stress-reporter.ts
+++ b/tests/stress/stress-reporter.ts
@@ -148,7 +148,7 @@ export class StressReporter {
 }
 
 function generateHtml(report: StressReport): string {
-  const data = JSON.stringify(report);
+  const data = JSON.stringify(report).replace(/<\/script>/gi, '<\\/script>');
   const scenarioRows = ['totalMessages', 'successRate', 'avgResponseTimeMs', 'p95ResponseTimeMs', 'p99ResponseTimeMs', 'maxResponseTimeMs', 'failureCount', 'timeoutCount']
     .map(k => {
       const s = report.scenarios;

--- a/tests/stress/stress-reporter.ts
+++ b/tests/stress/stress-reporter.ts
@@ -1,0 +1,293 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import type { StressConfig } from './stress-config';
+
+export interface InteractionRecord {
+  timestamp: string;
+  scenario: 'single' | 'multi' | 'mixed';
+  sessionId: string;
+  messageIndex: number;
+  responseTimeMs: number;
+  success: boolean;
+  error?: {
+    type: 'timeout' | 'send_error' | 'sse_error' | 'socket_error' | 'unknown';
+    message: string;
+    screenshot?: string;
+  };
+}
+
+export interface ScenarioResult {
+  totalMessages: number;
+  successCount: number;
+  failureCount: number;
+  timeoutCount: number;
+  successRate: number;
+  avgResponseTimeMs: number;
+  p50ResponseTimeMs: number;
+  p95ResponseTimeMs: number;
+  p99ResponseTimeMs: number;
+  maxResponseTimeMs: number;
+}
+
+export interface StressReport {
+  meta: {
+    startTime: string;
+    endTime: string;
+    durationMinutes: number;
+    config: StressConfig;
+  };
+  summary: ScenarioResult & {
+    sessionsCreated: number;
+    errorsByType: Record<string, number>;
+  };
+  scenarios: {
+    singleSession: ScenarioResult;
+    multiSession: ScenarioResult;
+    mixed: ScenarioResult;
+  };
+  errors: InteractionRecord[];
+  timeline: InteractionRecord[];
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+function computeScenarioResult(records: InteractionRecord[]): ScenarioResult {
+  if (records.length === 0) {
+    return {
+      totalMessages: 0, successCount: 0, failureCount: 0, timeoutCount: 0,
+      successRate: 0, avgResponseTimeMs: 0, p50ResponseTimeMs: 0,
+      p95ResponseTimeMs: 0, p99ResponseTimeMs: 0, maxResponseTimeMs: 0,
+    };
+  }
+  const successes = records.filter((r) => r.success);
+  const failures = records.filter((r) => !r.success);
+  const timeouts = failures.filter((r) => r.error?.type === 'timeout');
+  const times = successes.map((r) => r.responseTimeMs).sort((a, b) => a - b);
+  const avg = times.length > 0 ? times.reduce((a, b) => a + b, 0) / times.length : 0;
+  return {
+    totalMessages: records.length,
+    successCount: successes.length,
+    failureCount: failures.length,
+    timeoutCount: timeouts.length,
+    successRate: (successes.length / records.length) * 100,
+    avgResponseTimeMs: Math.round(avg),
+    p50ResponseTimeMs: percentile(times, 50),
+    p95ResponseTimeMs: percentile(times, 95),
+    p99ResponseTimeMs: percentile(times, 99),
+    maxResponseTimeMs: times.length > 0 ? times[times.length - 1] : 0,
+  };
+}
+
+export class StressReporter {
+  private records: InteractionRecord[] = [];
+  private startTime: string;
+  private sessionsCreated = 0;
+  private sessionIds: string[] = [];
+
+  constructor(private config: StressConfig) {
+    this.startTime = new Date().toISOString();
+  }
+
+  record(entry: InteractionRecord): void {
+    this.records.push(entry);
+    const status = entry.success ? '✓' : '✗';
+    const errInfo = entry.error ? ` [${entry.error.type}: ${entry.error.message.slice(0, 80)}]` : '';
+    console.log(`[stress] ${status} ${entry.scenario}/${entry.sessionId.slice(0, 8)} #${entry.messageIndex} ${entry.responseTimeMs}ms${errInfo}`);
+  }
+
+  trackSessionCreated(sessionId: string): void {
+    this.sessionsCreated++;
+    this.sessionIds.push(sessionId);
+  }
+
+  getSessionIds(): string[] {
+    return [...this.sessionIds];
+  }
+
+  generateReport(): StressReport {
+    const endTime = new Date().toISOString();
+    const allScenarios = {
+      singleSession: computeScenarioResult(this.records.filter((r) => r.scenario === 'single')),
+      multiSession: computeScenarioResult(this.records.filter((r) => r.scenario === 'multi')),
+      mixed: computeScenarioResult(this.records.filter((r) => r.scenario === 'mixed')),
+    };
+    const overall = computeScenarioResult(this.records);
+    const errorsByType: Record<string, number> = {};
+    for (const r of this.records.filter((r) => !r.success)) {
+      const t = r.error?.type || 'unknown';
+      errorsByType[t] = (errorsByType[t] || 0) + 1;
+    }
+    return {
+      meta: { startTime: this.startTime, endTime, durationMinutes: this.config.durationMinutes, config: this.config },
+      summary: { ...overall, sessionsCreated: this.sessionsCreated, errorsByType },
+      scenarios: allScenarios,
+      errors: this.records.filter((r) => !r.success),
+      timeline: this.records,
+    };
+  }
+
+  writeReports(reportDir: string): { jsonPath: string; htmlPath: string } {
+    mkdirSync(join(reportDir, 'screenshots'), { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const report = this.generateReport();
+
+    const jsonPath = join(reportDir, `stress-${ts}.json`);
+    writeFileSync(jsonPath, JSON.stringify(report, null, 2));
+
+    const htmlPath = join(reportDir, `stress-${ts}.html`);
+    writeFileSync(htmlPath, generateHtml(report));
+
+    console.log(`[stress] JSON report: ${jsonPath}`);
+    console.log(`[stress] HTML report: ${htmlPath}`);
+    return { jsonPath, htmlPath };
+  }
+}
+
+function generateHtml(report: StressReport): string {
+  const data = JSON.stringify(report);
+  const scenarioRows = ['totalMessages', 'successRate', 'avgResponseTimeMs', 'p95ResponseTimeMs', 'p99ResponseTimeMs', 'maxResponseTimeMs', 'failureCount', 'timeoutCount']
+    .map(k => {
+      const s = report.scenarios;
+      const fmt = (v: number) => k === 'successRate' ? v.toFixed(1) + '%' : k.includes('Ms') ? v + 'ms' : String(v);
+      return '<tr><td>' + k + '</td><td>' + fmt((s.singleSession as any)[k]) + '</td><td>' + fmt((s.multiSession as any)[k]) + '</td><td>' + fmt((s.mixed as any)[k]) + '</td></tr>';
+    })
+    .join('\n');
+
+  const errorDetails = report.errors.length === 0
+    ? '<p>No errors recorded.</p>'
+    : report.errors.map((e) => `<details>
+  <summary>${e.timestamp} — ${e.error?.type || 'unknown'} — ${e.scenario}/${e.sessionId.slice(0, 8)} #${e.messageIndex}</summary>
+  <p><strong>Message:</strong> ${e.error?.message || 'N/A'}</p>
+  <p><strong>Response time:</strong> ${e.responseTimeMs}ms</p>
+  ${e.error?.screenshot ? '<p><img src="' + e.error.screenshot + '" style="max-width:600px;border:1px solid #ddd;border-radius:4px;" /></p>' : ''}
+</details>`).join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Stress Test Report — ${report.meta.startTime}</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f5f5f5; color: #333; padding: 24px; }
+  h1 { margin-bottom: 8px; } h2 { margin: 24px 0 12px; }
+  .cards { display: flex; gap: 16px; flex-wrap: wrap; }
+  .card { background: #fff; border-radius: 8px; padding: 16px 24px; box-shadow: 0 1px 3px rgba(0,0,0,.1); min-width: 160px; }
+  .card .value { font-size: 28px; font-weight: 700; } .card .label { font-size: 13px; color: #888; }
+  .card.success .value { color: #16a34a; } .card.fail .value { color: #dc2626; }
+  table { border-collapse: collapse; width: 100%; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+  th, td { text-align: left; padding: 10px 14px; border-bottom: 1px solid #eee; } th { background: #fafafa; font-weight: 600; }
+  canvas { background: #fff; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+  details { background: #fff; border-radius: 8px; margin: 8px 0; padding: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+  summary { cursor: pointer; font-weight: 600; }
+  .charts { display: flex; gap: 24px; flex-wrap: wrap; margin: 16px 0; }
+</style>
+</head>
+<body>
+<h1>Chat Stress Test Report</h1>
+<p>${report.meta.startTime} — ${report.meta.endTime} (${report.meta.durationMinutes} min)</p>
+
+<h2>Summary</h2>
+<div class="cards">
+  <div class="card success"><div class="value">${report.summary.successRate.toFixed(1)}%</div><div class="label">Success Rate</div></div>
+  <div class="card"><div class="value">${report.summary.totalMessages}</div><div class="label">Total Messages</div></div>
+  <div class="card"><div class="value">${report.summary.avgResponseTimeMs}ms</div><div class="label">Avg Response</div></div>
+  <div class="card"><div class="value">${report.summary.p95ResponseTimeMs}ms</div><div class="label">P95 Response</div></div>
+  <div class="card"><div class="value">${report.summary.p99ResponseTimeMs}ms</div><div class="label">P99 Response</div></div>
+  <div class="card fail"><div class="value">${report.summary.failureCount}</div><div class="label">Failures</div></div>
+</div>
+
+<h2>Charts</h2>
+<div class="charts">
+  <canvas id="timelineChart" width="700" height="300"></canvas>
+  <canvas id="errorPie" width="300" height="300"></canvas>
+</div>
+
+<h2>Scenario Comparison</h2>
+<table>
+<tr><th>Metric</th><th>Single Session</th><th>Multi Session</th><th>Mixed</th></tr>
+${scenarioRows}
+</table>
+
+<h2>Errors (${report.errors.length})</h2>
+${errorDetails}
+
+<script>
+const report = ${data};
+
+(() => {
+  const c = document.getElementById('timelineChart');
+  const ctx = c.getContext('2d');
+  const tl = report.timeline;
+  if (tl.length === 0) return;
+  const W = c.width, H = c.height, pad = 50;
+  const maxY = Math.max(...tl.map(r => r.responseTimeMs), 1);
+  const t0 = new Date(tl[0].timestamp).getTime();
+  const t1 = new Date(tl[tl.length-1].timestamp).getTime() || t0 + 1;
+  ctx.strokeStyle = '#ddd'; ctx.lineWidth = 1;
+  for (let i = 0; i <= 4; i++) {
+    const y = pad + (H - 2*pad) * (1 - i/4);
+    ctx.beginPath(); ctx.moveTo(pad, y); ctx.lineTo(W-10, y); ctx.stroke();
+    ctx.fillStyle = '#888'; ctx.font = '11px sans-serif';
+    ctx.fillText(Math.round(maxY * i/4) + 'ms', 2, y + 4);
+  }
+  const colors = { single: '#3b82f6', multi: '#f59e0b', mixed: '#8b5cf6' };
+  for (const scenario of ['single','multi','mixed']) {
+    const pts = tl.filter(r => r.scenario === scenario);
+    if (pts.length === 0) continue;
+    ctx.strokeStyle = colors[scenario]; ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    pts.forEach((p, i) => {
+      const x = pad + (new Date(p.timestamp).getTime() - t0) / (t1 - t0) * (W - pad - 10);
+      const y = pad + (H - 2*pad) * (1 - p.responseTimeMs / maxY);
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+  }
+  let lx = pad + 10;
+  for (const [name, color] of Object.entries(colors)) {
+    ctx.fillStyle = color; ctx.fillRect(lx, 10, 12, 12);
+    ctx.fillStyle = '#333'; ctx.font = '12px sans-serif'; ctx.fillText(name, lx + 16, 21);
+    lx += 80;
+  }
+  tl.filter(r => !r.success).forEach(p => {
+    const x = pad + (new Date(p.timestamp).getTime() - t0) / (t1 - t0) * (W - pad - 10);
+    const y = pad + (H - 2*pad) * (1 - p.responseTimeMs / maxY);
+    ctx.fillStyle = '#dc2626'; ctx.beginPath(); ctx.arc(x, y, 4, 0, Math.PI*2); ctx.fill();
+  });
+})();
+
+(() => {
+  const c = document.getElementById('errorPie');
+  const ctx = c.getContext('2d');
+  const ebt = report.summary.errorsByType;
+  const entries = Object.entries(ebt);
+  if (entries.length === 0) {
+    ctx.fillStyle = '#888'; ctx.font = '14px sans-serif';
+    ctx.fillText('No errors', c.width/2 - 30, c.height/2);
+    return;
+  }
+  const total = entries.reduce((s, [,v]) => s + v, 0);
+  const pieColors = ['#dc2626','#f59e0b','#3b82f6','#8b5cf6','#10b981'];
+  let angle = -Math.PI/2;
+  const cx = c.width/2, cy = c.height/2 - 20, r = 100;
+  entries.forEach(([name, count], i) => {
+    const slice = (count/total) * Math.PI * 2;
+    ctx.beginPath(); ctx.moveTo(cx, cy); ctx.arc(cx, cy, r, angle, angle+slice); ctx.closePath();
+    ctx.fillStyle = pieColors[i % pieColors.length]; ctx.fill();
+    const mid = angle + slice/2;
+    const lx = cx + Math.cos(mid) * (r + 20);
+    const ly = cy + Math.sin(mid) * (r + 20);
+    ctx.fillStyle = '#333'; ctx.font = '11px sans-serif';
+    ctx.fillText(name + ' (' + count + ')', lx - 20, ly);
+    angle += slice;
+  });
+})();
+</script>
+</body>
+</html>`;
+}

--- a/tests/stress/stress-scenarios.ts
+++ b/tests/stress/stress-scenarios.ts
@@ -31,14 +31,21 @@ async function runOneInteraction(
     let error: string | null = null;
     let success = false;
 
+    // Race: wait for reply vs detect error concurrently
+    const replyPromise = waitForMessageCount(sessionId, expectedCount, config.messageTimeoutMs)
+      .then(() => ({ type: 'reply' as const }));
+    const errorPromise = pollForError(config.messageTimeoutMs)
+      .then((err) => err ? { type: 'error' as const, error: err } : new Promise<never>(() => {}));
+
     try {
-      await waitForMessageCount(sessionId, expectedCount, config.messageTimeoutMs);
-      success = true;
-    } catch (waitErr: any) {
-      error = await pollForError(5_000);
-      if (!error) {
-        error = JSON.stringify({ type: 'timeout', message: waitErr.message });
+      const result = await Promise.race([replyPromise, errorPromise]);
+      if (result.type === 'reply') {
+        success = true;
+      } else {
+        error = result.error;
       }
+    } catch (waitErr: any) {
+      error = JSON.stringify({ type: 'timeout', message: waitErr.message });
     }
 
     const responseTimeMs = Date.now() - startMs;

--- a/tests/stress/stress-scenarios.ts
+++ b/tests/stress/stress-scenarios.ts
@@ -7,6 +7,7 @@ import {
   pollForError,
   archiveSession,
   captureErrorScreenshot,
+  getActiveSessionId,
 } from './stress-helpers';
 import type { StressConfig } from './stress-config';
 import type { InteractionRecord, StressReporter } from './stress-reporter';
@@ -98,8 +99,12 @@ export async function runSingleSession(
   console.log(`[stress] Starting single session scenario (${Math.round(deadlineMs / 60000)} min)`);
   const deadline = Date.now() + deadlineMs;
 
-  const sessionId = await createSession();
-  if (!sessionId) throw new Error('Failed to create session for single-session scenario');
+  // Try to create a new session, or fall back to the existing active session
+  let sessionId = await createSession();
+  if (!sessionId) {
+    sessionId = await getActiveSessionId();
+  }
+  if (!sessionId) throw new Error('Failed to create or find a session for single-session scenario');
   reporter.trackSessionCreated(sessionId);
 
   let msgIndex = 0;

--- a/tests/stress/stress-scenarios.ts
+++ b/tests/stress/stress-scenarios.ts
@@ -104,11 +104,15 @@ export async function runSingleSession(
 
   let msgIndex = 0;
   while (Date.now() < deadline) {
-    await switchSession(sessionId);
-    await runOneInteraction(sessionId, msgIndex++, 'single', config, reporter);
+    try {
+      await switchSession(sessionId);
+      await runOneInteraction(sessionId, msgIndex++, 'single', config, reporter);
+    } catch (err: any) {
+      console.warn(`[stress] single session loop error: ${err.message?.slice(0, 100)}`);
+    }
   }
 
-  await archiveSession(sessionId);
+  try { await archiveSession(sessionId); } catch { /* best-effort cleanup */ }
   console.log(`[stress] Single session scenario done. ${msgIndex} messages sent.`);
 }
 
@@ -132,13 +136,17 @@ export async function runMultiSession(
   while (Date.now() < deadline) {
     for (const sessionId of sessionIds) {
       if (Date.now() >= deadline) break;
-      await switchSession(sessionId);
-      await runOneInteraction(sessionId, msgIndex++, 'multi', config, reporter);
+      try {
+        await switchSession(sessionId);
+        await runOneInteraction(sessionId, msgIndex++, 'multi', config, reporter);
+      } catch (err: any) {
+        console.warn(`[stress] multi session loop error: ${err.message?.slice(0, 100)}`);
+      }
     }
   }
 
   for (const id of sessionIds) {
-    await archiveSession(id);
+    try { await archiveSession(id); } catch { /* best-effort */ }
   }
   console.log(`[stress] Multi session scenario done. ${msgIndex} messages sent.`);
 }
@@ -160,24 +168,28 @@ export async function runMixedMode(
   let msgIndex = 0;
 
   while (Date.now() < deadline) {
-    if (Date.now() - lastNewSessionTime >= config.mixedNewSessionIntervalMs) {
-      const shortId = await createSession();
-      if (shortId) {
-        reporter.trackSessionCreated(shortId);
-        const msgCount = 3 + Math.floor(Math.random() * 3);
-        for (let i = 0; i < msgCount && Date.now() < deadline; i++) {
-          await switchSession(shortId);
-          await runOneInteraction(shortId, msgIndex++, 'mixed', config, reporter);
+    try {
+      if (Date.now() - lastNewSessionTime >= config.mixedNewSessionIntervalMs) {
+        const shortId = await createSession();
+        if (shortId) {
+          reporter.trackSessionCreated(shortId);
+          const msgCount = 3 + Math.floor(Math.random() * 3);
+          for (let i = 0; i < msgCount && Date.now() < deadline; i++) {
+            await switchSession(shortId);
+            await runOneInteraction(shortId, msgIndex++, 'mixed', config, reporter);
+          }
+          try { await archiveSession(shortId); } catch { /* best-effort */ }
+          shortLivedIds.push(shortId);
         }
-        await archiveSession(shortId);
-        shortLivedIds.push(shortId);
+        lastNewSessionTime = Date.now();
       }
-      lastNewSessionTime = Date.now();
-    }
 
-    if (Date.now() < deadline) {
-      await switchSession(persistentId);
-      await runOneInteraction(persistentId, msgIndex++, 'mixed', config, reporter);
+      if (Date.now() < deadline) {
+        await switchSession(persistentId);
+        await runOneInteraction(persistentId, msgIndex++, 'mixed', config, reporter);
+      }
+    } catch (err: any) {
+      console.warn(`[stress] mixed mode loop error: ${err.message?.slice(0, 100)}`);
     }
   }
 

--- a/tests/stress/stress-scenarios.ts
+++ b/tests/stress/stress-scenarios.ts
@@ -1,0 +1,179 @@
+import {
+  createSession,
+  switchSession,
+  sendMessage,
+  getMessageCount,
+  waitForMessageCount,
+  pollForError,
+  archiveSession,
+  captureErrorScreenshot,
+} from './stress-helpers';
+import type { StressConfig } from './stress-config';
+import type { InteractionRecord, StressReporter } from './stress-reporter';
+
+const TEST_PROMPT = 'reply with just the word hello';
+
+async function runOneInteraction(
+  sessionId: string,
+  messageIndex: number,
+  scenario: InteractionRecord['scenario'],
+  config: StressConfig,
+  reporter: StressReporter,
+): Promise<boolean> {
+  const startMs = Date.now();
+  const timestamp = new Date().toISOString();
+
+  try {
+    const beforeCount = await getMessageCount(sessionId);
+    await sendMessage(TEST_PROMPT);
+    const expectedCount = beforeCount + 2;
+
+    let error: string | null = null;
+    let success = false;
+
+    try {
+      await waitForMessageCount(sessionId, expectedCount, config.messageTimeoutMs);
+      success = true;
+    } catch (waitErr: any) {
+      error = await pollForError(5_000);
+      if (!error) {
+        error = JSON.stringify({ type: 'timeout', message: waitErr.message });
+      }
+    }
+
+    const responseTimeMs = Date.now() - startMs;
+
+    if (success) {
+      reporter.record({
+        timestamp, scenario, sessionId, messageIndex, responseTimeMs, success: true,
+      });
+    } else {
+      let errorType: InteractionRecord['error'] = { type: 'unknown', message: 'Unknown error' };
+      try {
+        const parsed = JSON.parse(error!);
+        if (parsed.type) {
+          errorType = { type: parsed.type, message: parsed.message || parsed.data?.message || 'Unknown' };
+        } else if (parsed.name) {
+          errorType = { type: 'send_error', message: parsed.data?.message || parsed.name };
+        } else {
+          errorType = { type: 'timeout', message: String(error) };
+        }
+      } catch {
+        errorType = { type: 'timeout', message: String(error).slice(0, 200) };
+      }
+
+      try {
+        const screenshotPath = await captureErrorScreenshot(config.reportDir, messageIndex);
+        errorType.screenshot = screenshotPath;
+      } catch { /* screenshot is best-effort */ }
+
+      reporter.record({
+        timestamp, scenario, sessionId, messageIndex, responseTimeMs, success: false, error: errorType,
+      });
+    }
+
+    return success;
+  } catch (outerErr: any) {
+    const responseTimeMs = Date.now() - startMs;
+    reporter.record({
+      timestamp, scenario, sessionId, messageIndex, responseTimeMs, success: false,
+      error: { type: 'socket_error', message: outerErr.message?.slice(0, 200) || 'Unknown outer error' },
+    });
+    return false;
+  }
+}
+
+export async function runSingleSession(
+  deadlineMs: number,
+  config: StressConfig,
+  reporter: StressReporter,
+): Promise<void> {
+  console.log(`[stress] Starting single session scenario (${Math.round(deadlineMs / 60000)} min)`);
+  const deadline = Date.now() + deadlineMs;
+
+  const sessionId = await createSession();
+  if (!sessionId) throw new Error('Failed to create session for single-session scenario');
+  reporter.trackSessionCreated(sessionId);
+
+  let msgIndex = 0;
+  while (Date.now() < deadline) {
+    await switchSession(sessionId);
+    await runOneInteraction(sessionId, msgIndex++, 'single', config, reporter);
+  }
+
+  await archiveSession(sessionId);
+  console.log(`[stress] Single session scenario done. ${msgIndex} messages sent.`);
+}
+
+export async function runMultiSession(
+  deadlineMs: number,
+  config: StressConfig,
+  reporter: StressReporter,
+): Promise<void> {
+  console.log(`[stress] Starting multi session scenario (${Math.round(deadlineMs / 60000)} min, ${config.concurrentSessions} sessions)`);
+  const deadline = Date.now() + deadlineMs;
+
+  const sessionIds: string[] = [];
+  for (let i = 0; i < config.concurrentSessions; i++) {
+    const id = await createSession();
+    if (!id) throw new Error(`Failed to create session ${i + 1}`);
+    sessionIds.push(id);
+    reporter.trackSessionCreated(id);
+  }
+
+  let msgIndex = 0;
+  while (Date.now() < deadline) {
+    for (const sessionId of sessionIds) {
+      if (Date.now() >= deadline) break;
+      await switchSession(sessionId);
+      await runOneInteraction(sessionId, msgIndex++, 'multi', config, reporter);
+    }
+  }
+
+  for (const id of sessionIds) {
+    await archiveSession(id);
+  }
+  console.log(`[stress] Multi session scenario done. ${msgIndex} messages sent.`);
+}
+
+export async function runMixedMode(
+  deadlineMs: number,
+  config: StressConfig,
+  reporter: StressReporter,
+): Promise<void> {
+  console.log(`[stress] Starting mixed mode scenario (${Math.round(deadlineMs / 60000)} min)`);
+  const deadline = Date.now() + deadlineMs;
+
+  const persistentId = await createSession();
+  if (!persistentId) throw new Error('Failed to create persistent session');
+  reporter.trackSessionCreated(persistentId);
+
+  const shortLivedIds: string[] = [];
+  let lastNewSessionTime = Date.now();
+  let msgIndex = 0;
+
+  while (Date.now() < deadline) {
+    if (Date.now() - lastNewSessionTime >= config.mixedNewSessionIntervalMs) {
+      const shortId = await createSession();
+      if (shortId) {
+        reporter.trackSessionCreated(shortId);
+        const msgCount = 3 + Math.floor(Math.random() * 3);
+        for (let i = 0; i < msgCount && Date.now() < deadline; i++) {
+          await switchSession(shortId);
+          await runOneInteraction(shortId, msgIndex++, 'mixed', config, reporter);
+        }
+        await archiveSession(shortId);
+        shortLivedIds.push(shortId);
+      }
+      lastNewSessionTime = Date.now();
+    }
+
+    if (Date.now() < deadline) {
+      await switchSession(persistentId);
+      await runOneInteraction(persistentId, msgIndex++, 'mixed', config, reporter);
+    }
+  }
+
+  await archiveSession(persistentId);
+  console.log(`[stress] Mixed mode scenario done. ${msgIndex} messages sent, ${shortLivedIds.length + 1} sessions used.`);
+}

--- a/tests/stress/stress-scenarios.ts
+++ b/tests/stress/stress-scenarios.ts
@@ -99,10 +99,15 @@ export async function runSingleSession(
   console.log(`[stress] Starting single session scenario (${Math.round(deadlineMs / 60000)} min)`);
   const deadline = Date.now() + deadlineMs;
 
-  // Try to create a new session, or fall back to the existing active session
-  let sessionId = await createSession();
-  if (!sessionId) {
-    sessionId = await getActiveSessionId();
+  // Try to create or find a session with retries (executeJs can be flaky at startup)
+  let sessionId: string | null = null;
+  for (let attempt = 0; attempt < 5 && !sessionId; attempt++) {
+    sessionId = await createSession();
+    if (!sessionId) sessionId = await getActiveSessionId();
+    if (!sessionId) {
+      console.warn(`[stress] Session creation attempt ${attempt + 1}/5 failed, retrying...`);
+      await (await import('../_utils/tauri-mcp-test-utils')).sleep(2000);
+    }
   }
   if (!sessionId) throw new Error('Failed to create or find a session for single-session scenario');
   reporter.trackSessionCreated(sessionId);

--- a/vitest.config.stress.ts
+++ b/vitest.config.stress.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/stress/**/*.test.ts'],
+    environment: 'node',
+    fileParallelism: false,
+    testTimeout: 40 * 60 * 1000,
+    hookTimeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Summary

- When AI asks a question (`question.asked` SSE event) during a channel session, forward it to the originating channel (Discord/Feishu/KOOK/WeCom/Email)
- User must **explicitly reply** (quote) the question message to answer
- 5-minute timeout: auto-rejects unanswered questions so AI can continue
- Non-blocking: question wait is spawned as a separate task, SSE loop continues processing permissions and message events

## Architecture

- New `PendingQuestionStore` maps channel message IDs to oneshot channels
- Shared `handle_question_event()` used by both the shared SSE handler and WeCom's own SSE loop
- Per-gateway reply detection: Discord (`referenced_message`), Feishu (`parent_id`), KOOK (`extra.quote`), WeCom (`[Q:id]` text marker), Email (`In-Reply-To`)

## Files Changed

| File | Change |
|------|--------|
| `pending_question.rs` | **New.** Store, types, helpers, 14 unit tests |
| `mod.rs` | SSE `question.asked` handler, re-exports |
| `discord.rs` | Reply interception + forwarder |
| `feishu.rs` | Reply interception + forwarder |
| `kook.rs` | Reply interception + forwarder |
| `wecom.rs` | Reply interception + own SSE handler |
| `email.rs` | Reply interception + forwarder |

## Test plan

- [x] 14 unit tests for PendingQuestionStore, format/parse/resolve helpers
- [x] All 24 gateway tests pass (0 regressions)
- [ ] Manual test: trigger question in Discord channel, reply to it
- [ ] Manual test: verify 5-min timeout auto-rejects

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)