### PR TITLE
fix: channels feature flag & Windows build error

### DIFF
--- a/build.config.example.json
+++ b/build.config.example.json
@@ -13,7 +13,8 @@
   "features": {
     "advancedMode": true,
     "teamMode": true,
-    "updater": true
+    "updater": true,
+    "channels": true
   },
   "defaults": {
     "locale": "zh-CN",

--- a/build.config.json
+++ b/build.config.json
@@ -13,7 +13,8 @@
   "features": {
     "advancedMode": true,
     "teamMode": true,
-    "updater": true
+    "updater": true,
+    "channels": true
   },
   "defaults": {
     "locale": "zh-CN",

--- a/packages/app/src/components/settings/Settings.tsx
+++ b/packages/app/src/components/settings/Settings.tsx
@@ -24,6 +24,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Button } from '@/components/ui/button'
 import { useAppVersion } from '@/lib/version'
 import { useUpdaterStore } from '@/stores/updater'
+import { buildConfig } from '@/lib/build-config'
 
 // Section components
 import { LLMSection } from './LLMSection'
@@ -148,6 +149,12 @@ export function Settings(_props?: SettingsProps) {
   const [advancedExpanded, setAdvancedExpanded] = React.useState(false)
   const appVersion = useAppVersion()
 
+  // Filter sections based on build config feature flags
+  const filteredPrimarySections = React.useMemo(() =>
+    primarySections.filter(s => s.id !== 'channels' || buildConfig.features.channels),
+    []
+  )
+
   // Check if current view is an advanced section
   const isAdvancedSection = advancedSections.some(s => s.id === activeView)
 
@@ -168,7 +175,7 @@ export function Settings(_props?: SettingsProps) {
         </div>
         <ScrollArea className="flex-1 overflow-hidden py-2">
           <div className="px-2 space-y-0.5">
-            {primarySections.map((section) => {
+            {filteredPrimarySections.map((section) => {
               const Icon = section.icon
               const isActive = activeView === section.id
               return (

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -17,6 +17,7 @@ export interface BuildConfig {
     advancedMode: boolean
     teamMode: boolean
     updater: boolean
+    channels: boolean
   }
   defaults: {
     locale: string
@@ -30,7 +31,7 @@ const fallback: BuildConfig = {
     lockLlmConfig: false,
   },
   app: { name: 'TeamClaw' },
-  features: { advancedMode: true, teamMode: true, updater: true },
+  features: { advancedMode: true, teamMode: true, updater: true, channels: true },
   defaults: { locale: 'zh-CN', theme: 'system' },
 }
 

--- a/src-tauri/tauri-plugin-mcp-local/src/platform/windows.rs
+++ b/src-tauri/tauri-plugin-mcp-local/src/platform/windows.rs
@@ -33,7 +33,7 @@ pub async fn take_screenshot<R: Runtime>(
     // Get all windows
     let windows = match window_list() {
       Ok(list) => list,
-      Err(e) => return Err(Error::WindowOperationFailed(format!("Failed to get window list: {:?}", e))),
+      Err(e) => return Err(Error::window_operation_failed("screenshot", format!("Failed to get window list: {:?}", e))),
     };
     
     info!("[SCREENSHOT] Found {} windows through win-screenshot", windows.len());
@@ -66,7 +66,7 @@ pub async fn take_screenshot<R: Runtime>(
       // Use PrintWindow for more reliable capture
       let buffer = match capture_window_ex(hwnd, Using::PrintWindow, Area::Full, None, None) {
         Ok(buf) => buf,
-        Err(e) => return Err(Error::WindowOperationFailed(format!("Failed to capture window: {:?}", e))),
+        Err(e) => return Err(Error::window_operation_failed("screenshot", format!("Failed to capture window: {:?}", e))),
       };
       
       info!("[SCREENSHOT] Successfully captured window image: {}x{}", 
@@ -75,7 +75,7 @@ pub async fn take_screenshot<R: Runtime>(
       // Convert to dynamic image for processing
       let dynamic_image = DynamicImage::ImageRgba8(
         RgbaImage::from_raw(buffer.width, buffer.height, buffer.pixels)
-          .ok_or_else(|| Error::WindowOperationFailed("Failed to create image from buffer".to_string()))?
+          .ok_or_else(|| Error::window_operation_failed("screenshot", "Failed to create image from buffer"))?
       );
       
       // Process the image
@@ -85,7 +85,7 @@ pub async fn take_screenshot<R: Runtime>(
       }
     } else {
       // No window found at all
-      Err(Error::WindowOperationFailed("Window not found using any detection method. Please ensure the window is visible and not minimized.".to_string()))
+      Err(Error::window_operation_failed("screenshot", "Window not found using any detection method. Please ensure the window is visible and not minimized."))
     }
   }).await
 }

--- a/src-tauri/tauri-plugin-mcp-local/src/socket_server.rs
+++ b/src-tauri/tauri-plugin-mcp-local/src/socket_server.rs
@@ -158,6 +158,7 @@ impl<R: Runtime> SocketServer<R> {
         let listener = match &self.socket_type {
             SocketType::Ipc { path } => {
                 // Get the socket path for cleanup
+                #[allow(unused_variables)]
                 let socket_path = if let Some(p) = path {
                     p.clone()
                 } else {


### PR DESCRIPTION
## Summary
- Add `features.channels` flag to build config for controlling Channels section visibility in settings
- Fix Windows build failure in `tauri-plugin-mcp-local`: `Error::WindowOperationFailed` is a struct variant, not tuple — use helper methods instead
- Suppress unused `socket_path` variable warning on Windows

## Test plan
- [ ] Verify Windows CI build passes
- [ ] Set `features.channels: false` in build config, confirm Channels menu hidden
- [ ] Default config (`channels: true`) shows Channels normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)