### PR TITLE
refactor: Update leaderboard labels and improve team disconnect flow

### DIFF
--- a/packages/app/src/components/settings/LeaderboardSection.tsx
+++ b/packages/app/src/components/settings/LeaderboardSection.tsx
@@ -60,8 +60,8 @@ interface MemberStats {
 }
 
 const COLUMNS = [
-  { key: 'token', label: 'Token 用量', icon: Flame, color: 'text-amber-500' },
-  { key: 'feedback', label: '反馈次数', icon: MessageSquareHeart, color: 'text-pink-500' },
+  { key: 'token', label: 'Token Usage', icon: Flame, color: 'text-amber-500' },
+  { key: 'feedback', label: 'Feedback Count', icon: MessageSquareHeart, color: 'text-pink-500' },
 ] as const
 
 // ── Component ──────────────────────────────────────────────────────────

--- a/packages/app/src/components/settings/TeamRankingCard.tsx
+++ b/packages/app/src/components/settings/TeamRankingCard.tsx
@@ -130,8 +130,8 @@ export function TeamRankingCard({ onClick }: TeamRankingCardProps) {
   const { overallRank, totalMembers, tokenRank, feedbackRank } = ranks
 
   const stats = [
-    { label: 'Token 用量', rank: tokenRank, icon: Flame, color: 'text-amber-300' },
-    { label: '反馈次数', rank: feedbackRank, icon: MessageSquareHeart, color: 'text-pink-300' },
+    { label: 'Token Usage', rank: tokenRank, icon: Flame, color: 'text-amber-300' },
+    { label: 'Feedback Count', rank: feedbackRank, icon: MessageSquareHeart, color: 'text-pink-300' },
   ]
 
   if (totalMembers === 0) {

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -603,7 +603,7 @@ export function TeamGitConfig() {
           <DialogHeader>
             <DialogTitle>{t('settings.team.disconnectTitle', 'Disconnect Team Repository')}</DialogTitle>
             <DialogDescription>
-              {t('settings.team.disconnectConfirm', 'Are you sure you want to disconnect the team repository? The shared content (skills, MCP configs, knowledge) will be kept locally but will no longer sync automatically.')}
+              {t('settings.team.disconnectConfirm', 'Are you sure you want to disconnect the team repository? The teamclaw-team directory and all its content will be permanently deleted.')}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1106,7 +1106,7 @@
       "sharedKnowledge": "Shared knowledge base",
       "somethingWrong": "Something went wrong",
       "disconnectTitle": "Disconnect Team Repository",
-      "disconnectConfirm": "Are you sure you want to disconnect the team repository? The shared content (skills, MCP configs, knowledge) will be kept locally but will no longer sync automatically.",
+      "disconnectConfirm": "Are you sure you want to disconnect the team repository? The teamclaw-team directory and all its content will be permanently deleted.",
       "gitInstallHint": "Git CLI is not installed or not in PATH. Install git to enable team repository sharing:",
       "tabP2p": "P2P",
       "tabGit": "Git",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1138,7 +1138,7 @@
       "sharedKnowledge": "共享知识库",
       "somethingWrong": "出了点问题",
       "disconnectTitle": "断开团队仓库",
-      "disconnectConfirm": "确定要断开团队仓库吗？共享内容（技能、MCP 配置、知识库）将保留在本地，但不再自动同步。",
+      "disconnectConfirm": "确定要断开团队仓库吗？teamclaw-team 目录及其所有内容将被永久删除。",
       "gitInstallHint": "Git CLI 未安装或不在 PATH 中。请安装 git 以启用团队仓库共享：",
       "tabP2p": "P2P",
       "tabGit": "Git",

--- a/src-tauri/binaries/download-opencode.sh
+++ b/src-tauri/binaries/download-opencode.sh
@@ -24,11 +24,11 @@ case "$OS-$ARCH" in
     TARGET_NAME="opencode-aarch64-apple-darwin"
     ;;
   Darwin-x86_64)
-    ASSET_PATTERN="opencode-darwin-amd64.zip"
+    ASSET_PATTERN="opencode-darwin-x64.zip"
     TARGET_NAME="opencode-x86_64-apple-darwin"
     ;;
   Linux-x86_64)
-    ASSET_PATTERN="opencode-linux-amd64.tar.gz"
+    ASSET_PATTERN="opencode-linux-x64.tar.gz"
     TARGET_NAME="opencode-x86_64-unknown-linux-gnu"
     ;;
   *)

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -877,7 +877,16 @@ pub async fn p2p_disconnect_source(
     config.namespace_id = None;
     config.doc_ticket = None;
     config.role = None;
-    write_p2p_config(&workspace_path, Some(&config))
+    write_p2p_config(&workspace_path, Some(&config))?;
+
+    // Remove teamclaw-team directory
+    let team_dir = format!("{}/teamclaw-team", workspace_path);
+    if Path::new(&team_dir).exists() {
+        std::fs::remove_dir_all(&team_dir)
+            .map_err(|e| format!("Failed to remove team directory: {}", e))?;
+    }
+
+    Ok(())
 }
 
 // ─── Team Member Management ─────────────────────────────────────────────

--- a/src-tauri/src/commands/team_webdav.rs
+++ b/src-tauri/src/commands/team_webdav.rs
@@ -847,6 +847,13 @@ pub async fn webdav_disconnect(
     // Clear team_mode
     write_team_mode(&workspace_path, None)?;
 
+    // Remove teamclaw-team directory
+    let team_dir = Path::new(&workspace_path).join(TEAM_REPO_DIR);
+    if team_dir.exists() {
+        std::fs::remove_dir_all(&team_dir)
+            .map_err(|e| format!("Failed to remove team directory: {}", e))?;
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -125,11 +125,7 @@ pub fn run() {
         .plugin({
             #[cfg(debug_assertions)]
             {
-                tauri_plugin_mcp::init_with_config(
-                    tauri_plugin_mcp::PluginConfig::new("TeamClaw".to_string())
-                        .start_socket_server(true)
-                        .socket_path("/tmp/tauri-mcp.sock".into())
-                )
+                tauri_plugin_mcp::Builder.build()
             }
             #[cfg(not(debug_assertions))]
             {


### PR DESCRIPTION
## Summary

This PR includes two improvements:
- Update leaderboard labels from Chinese to English for better internationalization
- Improve team disconnect flow by properly removing team directory and updating confirmation messages

## Changes

1. **Leaderboard Internationalization**
   - Changed "Token 用量" to "Token Usage"
   - Changed "反馈次数" to "Feedback Count"
   - Updated in both LeaderboardSection and TeamRankingCard components

2. **Team Disconnect Improvements**
   - Updated disconnect confirmation message to clearly indicate that teamclaw-team directory will be permanently deleted
   - Added logic to remove teamclaw-team directory on disconnect for both P2P and WebDAV modes
   - Updated localization files (en.json and zh-CN.json) with new message

3. **Build Configuration Updates**
   - Updated opencode download script asset patterns for better compatibility
   - Simplified MCP plugin initialization in debug mode

## Test Plan

- [ ] Verify leaderboard displays English labels correctly
- [ ] Test team disconnect flow (P2P mode) - confirm directory is removed
- [ ] Test team disconnect flow (WebDAV mode) - confirm directory is removed
- [ ] Verify confirmation dialog shows correct warning message
- [ ] Test that builds work correctly on macOS with updated Cargo.toml configuration


Made with [Cursor](https://cursor.com)