### PR TITLE
fix: pass build config LLM settings to team creation

### DIFF
--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -21,6 +21,7 @@ import {
   BookOpen,
 } from 'lucide-react'
 import { cn, isTauri } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -183,6 +184,9 @@ export function TeamGitConfig() {
       await tauriInvoke<TeamGitResult>('team_init_repo', {
         gitUrl: gitUrl.trim(),
         gitToken: isHttpsUrl && gitToken.trim() ? gitToken.trim() : null,
+        llmBaseUrl: buildConfig.team.llm.baseUrl || null,
+        llmModel: buildConfig.team.llm.model || null,
+        llmModelName: buildConfig.team.llm.modelName || null,
       })
 
       setConnectStep(t('settings.team.generatingGitignore', 'Generating .gitignore...'))

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -19,6 +19,7 @@ import {
   Share2,
 } from 'lucide-react'
 import { cn, isTauri, copyToClipboard } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { useTeamModeStore } from '@/stores/team-mode'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { DeviceIdDisplay } from '@/components/settings/DeviceIdDisplay'
@@ -272,7 +273,11 @@ export function TeamP2PConfig() {
     setCreateLoading(true)
     setP2pError(null)
     try {
-      await tauriInvoke<string>('p2p_create_team')
+      await tauriInvoke<string>('p2p_create_team', {
+        llmBaseUrl: buildConfig.team.llm.baseUrl || null,
+        llmModel: buildConfig.team.llm.model || null,
+        llmModelName: buildConfig.team.llm.modelName || null,
+      })
       await loadSyncStatus()
       if (workspacePath) {
         const store = useTeamModeStore.getState()

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -200,6 +200,14 @@ pub const DEFAULT_TEAMCLAW_YAML: &str = r#"llm:
   modelName: "default"
 "#;
 
+/// Build teamclaw.yaml content using provided LLM config, falling back to defaults.
+pub fn build_teamclaw_yaml(base_url: Option<String>, model: Option<String>, model_name: Option<String>) -> String {
+    let base_url = base_url.filter(|s| !s.is_empty()).unwrap_or_else(|| "https://api.openai.com/v1".to_string());
+    let model = model.filter(|s| !s.is_empty()).unwrap_or_else(|| "default".to_string());
+    let model_name = model_name.filter(|s| !s.is_empty()).unwrap_or_else(|| "default".to_string());
+    format!("llm:\n  baseUrl: \"{}\"\n  model: \"{}\"\n  modelName: \"{}\"\n", base_url, model, model_name)
+}
+
 /// The whitelist .gitignore content
 const GITIGNORE_CONTENT: &str = r#"# ============================================
 # TeamClaw Workspace — Whitelist mode
@@ -425,6 +433,9 @@ pub async fn team_check_workspace_has_git(
 pub async fn team_init_repo(
     git_url: String,
     git_token: Option<String>,
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<TeamGitResult, String> {
     let workspace_path = get_workspace_path(&opencode_state)?;
@@ -458,7 +469,8 @@ pub async fn team_init_repo(
     // Write default teamclaw.yaml if the cloned repo doesn't have one
     let teamclaw_yaml_path = Path::new(&team_dir).join("teamclaw.yaml");
     if !teamclaw_yaml_path.exists() {
-        std::fs::write(&teamclaw_yaml_path, DEFAULT_TEAMCLAW_YAML)
+        let yaml_content = build_teamclaw_yaml(llm_base_url, llm_model, llm_model_name);
+        std::fs::write(&teamclaw_yaml_path, &yaml_content)
             .map_err(|e| format!("Failed to write default teamclaw.yaml: {}", e))?;
         println!("[Team Init] Created default teamclaw.yaml with team LLM config");
 

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -182,8 +182,9 @@ fn collect_files(base: &Path, dir: &Path) -> Vec<(String, Vec<u8>)> {
 }
 
 /// Scaffold the teamclaw-team directory with default structure if it doesn't exist or is empty.
-fn scaffold_team_dir(team_dir: &str) -> Result<(), String> {
+fn scaffold_team_dir(team_dir: &str, llm_base_url: Option<String>, llm_model: Option<String>, llm_model_name: Option<String>) -> Result<(), String> {
     let team_path = Path::new(team_dir);
+    let yaml_content = crate::commands::team::build_teamclaw_yaml(llm_base_url, llm_model, llm_model_name);
 
     // Always ensure teamclaw.yaml exists, even if directory already has content
     let teamclaw_yaml_path = team_path.join("teamclaw.yaml");
@@ -192,7 +193,7 @@ fn scaffold_team_dir(team_dir: &str) -> Result<(), String> {
     if !need_scaffold {
         // Directory exists with files, but still ensure teamclaw.yaml is present
         if !teamclaw_yaml_path.exists() {
-            std::fs::write(&teamclaw_yaml_path, crate::commands::team::DEFAULT_TEAMCLAW_YAML)
+            std::fs::write(&teamclaw_yaml_path, &yaml_content)
                 .map_err(|e| format!("Failed to write default teamclaw.yaml: {}", e))?;
             println!("[Team P2P] Created default teamclaw.yaml with team LLM config");
         }
@@ -214,7 +215,7 @@ fn scaffold_team_dir(team_dir: &str) -> Result<(), String> {
 
     // Write default teamclaw.yaml with team LLM config if not present
     if !teamclaw_yaml_path.exists() {
-        std::fs::write(&teamclaw_yaml_path, crate::commands::team::DEFAULT_TEAMCLAW_YAML)
+        std::fs::write(&teamclaw_yaml_path, &yaml_content)
             .map_err(|e| format!("Failed to write default teamclaw.yaml: {}", e))?;
         println!("[Team P2P] Created default teamclaw.yaml with team LLM config");
     }
@@ -229,8 +230,11 @@ pub async fn create_team(
     node: &mut IrohNode,
     team_dir: &str,
     workspace_path: &str,
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
 ) -> Result<String, String> {
-    scaffold_team_dir(team_dir)?;
+    scaffold_team_dir(team_dir, llm_base_url, llm_model, llm_model_name)?;
 
     let node_id = get_node_id(node);
     let info = get_device_metadata();
@@ -419,7 +423,7 @@ pub async fn publish_team_drive(node: &IrohNode, team_dir: &str) -> Result<Strin
         .ok_or("No active team document. Create or join a team first.")?;
 
     let team_path = Path::new(team_dir);
-    scaffold_team_dir(team_dir)?;
+    scaffold_team_dir(team_dir, None, None, None)?;
 
     let files = collect_files(team_path, team_path);
     for (key, content) in &files {
@@ -444,7 +448,7 @@ pub async fn rotate_namespace(
     }
 
     // Re-create as owner
-    create_team(node, team_dir, workspace_path).await
+    create_team(node, team_dir, workspace_path, None, None, None).await
 }
 
 // ─── Background Sync Tasks ──────────────────────────────────────────────
@@ -1061,6 +1065,9 @@ pub async fn p2p_check_team_dir(
 
 #[tauri::command]
 pub async fn p2p_create_team(
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
     iroh_state: tauri::State<'_, IrohState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<String, String> {
@@ -1075,7 +1082,7 @@ pub async fn p2p_create_team(
     let node = guard.as_mut().ok_or("P2P node not running")?;
 
     let team_dir = format!("{}/teamclaw-team", workspace_path);
-    create_team(node, &team_dir, &workspace_path).await
+    create_team(node, &team_dir, &workspace_path, llm_base_url, llm_model, llm_model_name).await
 }
 
 #[tauri::command]
@@ -1097,7 +1104,7 @@ pub async fn p2p_publish_drive(
 
     // If no active doc, create a team (first-time publish)
     if node.active_doc.is_none() {
-        return create_team(node, &team_dir, &workspace_path).await;
+        return create_team(node, &team_dir, &workspace_path, None, None, None).await;
     }
 
     // Otherwise, sync current files into existing doc and return saved ticket
@@ -1443,6 +1450,7 @@ mod tests {
             &mut node,
             team_dir.to_str().unwrap(),
             tmp.path().to_str().unwrap(),
+            None, None, None,
         ).await.unwrap();
 
         assert!(!ticket.is_empty(), "ticket should not be empty");
@@ -1748,6 +1756,7 @@ mod tests {
             &mut node,
             team_dir.to_str().unwrap(),
             workspace,
+            None, None, None,
         ).await.unwrap();
 
         assert!(!ticket.is_empty(), "should return a ticket");


### PR DESCRIPTION
## Summary
- 创建团队时（P2P 和 Git 模式），Rust 端之前用硬编码的 `api.openai.com/v1` 写 `teamclaw.yaml`，导致 `build.config.json` 里配置的 `team.llm` 设置无法生效
- 前端现在会将 build config 中的 LLM 设置（baseUrl、model、modelName）传给 Rust 命令
- Rust 端新增 `build_teamclaw_yaml()` 函数，优先使用传入值，空值时 fallback 到默认值

## Changes
- `team.rs`: 新增 `build_teamclaw_yaml()` 函数；`team_init_repo` 增加可选 LLM 参数
- `team_p2p.rs`: `scaffold_team_dir`、`create_team`、`p2p_create_team` 增加可选 LLM 参数
- `TeamP2PConfig.tsx`: 调用 `p2p_create_team` 时传入 build config LLM 值
- `TeamGitConfig.tsx`: 调用 `team_init_repo` 时传入 build config LLM 值

## Test plan
- [ ] 在 `build.config.json` 配置自定义 LLM URL，打包后 P2P 创建团队，验证 `teamclaw.yaml` 使用配置的 URL
- [ ] 不配置 LLM URL（留空），创建团队后验证 fallback 到 `api.openai.com/v1`
- [ ] Git 模式创建团队同样验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)