### PR TITLE
perf: optimize startup speed (~1-2s faster)

### DIFF
--- a/docs/superpowers/plans/2026-03-19-startup-speed-optimization.md
+++ b/docs/superpowers/plans/2026-03-19-startup-speed-optimization.md
@@ -1,0 +1,744 @@
+# Startup Speed Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce TeamClaw startup time by ~1-2 seconds through PATH caching, parallel file I/O, early sidecar launch, and frontend delay removal.
+
+**Architecture:** Keep `fix_path_env()` synchronous but add file-based PATH caching. Parallelize independent pre-sidecar operations with `tokio::join!`. Launch the OpenCode sidecar from the Rust setup hook (before frontend renders) using a persisted workspace path. Remove unnecessary frontend delays.
+
+**Tech Stack:** Rust (Tauri 2.0, tokio), TypeScript (React 19, Zustand)
+
+**Spec:** `docs/superpowers/specs/2026-03-19-startup-speed-optimization-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src-tauri/src/lib.rs` | Modify | PATH caching in `fix_path_env()`, early sidecar launch in `setup` hook |
+| `src-tauri/src/commands/opencode.rs` | Modify | Parallel file I/O, `EarlyLaunchState`, workspace path persistence |
+| `packages/app/src/hooks/useAppInit.ts` | Modify | Remove 300ms delay, defer dependency check |
+| `packages/app/src/App.tsx` | Modify | Pass `openCodeReady` to `useSetupGuide` |
+
+---
+
+### Task 1: PATH Caching in `fix_path_env()`
+
+**Files:**
+- Modify: `src-tauri/src/lib.rs:21-73`
+
+- [ ] **Step 1: Add PATH cache read logic**
+
+At the top of `fix_path_env()`, before the shell spawn, try to read the cached PATH. The cache file is `~/.teamclaw/cached-path.txt` with format `<shell_profile_mtime>\n<path_value>`. If the cache exists and the mtime matches the current shell profile's mtime, use the cached PATH and return early.
+
+```rust
+fn fix_path_env() {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| {
+        if cfg!(target_os = "windows") {
+            "cmd".to_string()
+        } else {
+            "/bin/zsh".to_string()
+        }
+    });
+
+    if cfg!(target_os = "windows") {
+        return;
+    }
+
+    // Try cache first
+    let home = std::env::var("HOME").unwrap_or_default();
+    let cache_path = std::path::PathBuf::from(&home).join(".teamclaw").join("cached-path.txt");
+    let profile_mtime = get_shell_profile_mtime(&shell, &home);
+
+    if let Some(cached) = read_path_cache(&cache_path, profile_mtime) {
+        std::env::set_var("PATH", &cached);
+        #[cfg(debug_assertions)]
+        eprintln!("[fix_path_env] PATH set from cache");
+        return;
+    }
+
+    // Spawn login shell (existing logic)
+    let output = std::process::Command::new(&shell)
+        .args(["-l", "-c", "echo $PATH"])
+        .output();
+
+    match output {
+        Ok(o) if o.status.success() => {
+            let full_path = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if !full_path.is_empty() {
+                std::env::set_var("PATH", &full_path);
+                // Write cache (fire-and-forget)
+                write_path_cache(&cache_path, profile_mtime, &full_path);
+                #[cfg(debug_assertions)]
+                eprintln!("[fix_path_env] PATH set to: {}", &full_path);
+            }
+        }
+        _ => {
+            // Existing fallback logic (unchanged)
+            let current = std::env::var("PATH").unwrap_or_default();
+            let extra = [
+                "/opt/homebrew/bin",
+                "/opt/homebrew/sbin",
+                "/usr/local/bin",
+                "/usr/local/sbin",
+                "/home/linuxbrew/.linuxbrew/bin",
+            ];
+            let mut path = current.clone();
+            for p in extra {
+                if !path.split(':').any(|seg| seg == p) {
+                    path = format!("{}:{}", p, path);
+                }
+            }
+            if path != current {
+                std::env::set_var("PATH", &path);
+                #[cfg(debug_assertions)]
+                eprintln!("[fix_path_env] PATH fallback set to: {}", &path);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add helper functions for cache read/write**
+
+Add these helper functions above `fix_path_env()` in `lib.rs`:
+
+```rust
+/// Get the mtime of the user's shell profile file as a u64 (seconds since epoch).
+/// Returns 0 if the file doesn't exist or can't be read.
+fn get_shell_profile_mtime(shell: &str, home: &str) -> u64 {
+    let profile = if shell.ends_with("zsh") {
+        format!("{}/.zshrc", home)
+    } else if shell.ends_with("bash") {
+        format!("{}/.bashrc", home)
+    } else {
+        return 0;
+    };
+    std::fs::metadata(&profile)
+        .and_then(|m| m.modified())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)))
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Read cached PATH if cache exists and profile mtime matches.
+fn read_path_cache(cache_path: &std::path::Path, current_mtime: u64) -> Option<String> {
+    let content = std::fs::read_to_string(cache_path).ok()?;
+    let mut lines = content.lines();
+    let cached_mtime: u64 = lines.next()?.parse().ok()?;
+    if cached_mtime != current_mtime || current_mtime == 0 {
+        return None;
+    }
+    let path = lines.next()?;
+    if path.is_empty() {
+        return None;
+    }
+    Some(path.to_string())
+}
+
+/// Write PATH cache file. Creates ~/.teamclaw/ if needed.
+fn write_path_cache(cache_path: &std::path::Path, mtime: u64, path: &str) {
+    if let Some(parent) = cache_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let content = format!("{}\n{}", mtime, path);
+    let _ = std::fs::write(cache_path, content);
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw && cargo build -p teamclaw 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 4: Manual test — cache miss then cache hit**
+
+1. Delete cache: `rm -f ~/.teamclaw/cached-path.txt`
+2. Run the app. Observe `[fix_path_env] PATH set to:` in debug log (shell was spawned).
+3. Check cache was created: `cat ~/.teamclaw/cached-path.txt`
+4. Restart the app. Observe `[fix_path_env] PATH set from cache` (no shell spawn).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/lib.rs
+git commit -m "perf: cache fix_path_env() PATH result to avoid shell spawn on restart"
+```
+
+---
+
+### Task 2: Parallel File I/O Before Sidecar Spawn
+
+**Files:**
+- Modify: `src-tauri/src/commands/opencode.rs:273-349`
+
+- [ ] **Step 1: Refactor pre-sidecar operations into parallel groups**
+
+Replace the sequential block at lines 273-349 with parallel execution. The three `opencode.json` writers stay sequential in one branch, while `ensure_inherent_skills` and `read_keyring_secrets` run in parallel branches.
+
+Replace lines 273-349 of `opencode.rs` (from `// Ensure opencode.json has a permission section` to `let original_config = resolve_config_secret_refs(...)`) with:
+
+```rust
+    // ── Pre-sidecar setup (parallelized) ──────────────────────────────
+    //
+    // Three branches run concurrently via tokio::join!:
+    //   1. opencode.json writers (sequential: permissions → config → binary paths)
+    //   2. ensure_inherent_skills (writes to .opencode/skills/, independent)
+    //   3. read_keyring_secrets (reads OS keyring, independent)
+    //
+    // resolve_config_secret_refs runs AFTER all three complete (depends on
+    // both the config writers finishing and keyring secrets being available).
+
+    let ws_for_config = workspace_path.clone();
+    let ws_for_skills = workspace_path.clone();
+    let ws_for_keyring = workspace_path.clone();
+
+    let (config_result, skills_result, keyring_result) = tokio::join!(
+        // Branch 1: opencode.json writers (must be sequential with each other)
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = ensure_default_permissions(&ws_for_config) {
+                eprintln!("[OpenCode] Warning: failed to ensure default permissions: {}", e);
+            }
+            if let Err(e) = ensure_inherent_config(&ws_for_config) {
+                eprintln!("[OpenCode] Warning: failed to ensure inherent configs: {}", e);
+            }
+            if let Err(e) = resolve_sidecar_binary_paths(&ws_for_config) {
+                eprintln!("[OpenCode] Warning: failed to resolve binary paths: {}", e);
+            }
+        }),
+        // Branch 2: inherent skills (writes to .opencode/skills/, no opencode.json conflict)
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = ensure_inherent_skills(&ws_for_skills) {
+                eprintln!("[OpenCode] Warning: failed to ensure inherent skills: {}", e);
+            }
+        }),
+        // Branch 3: keyring secrets
+        tokio::task::spawn_blocking(move || read_keyring_secrets(&ws_for_keyring))
+    );
+
+    // Unwrap spawn results (panics inside spawn_blocking become JoinErrors)
+    if let Err(e) = config_result {
+        eprintln!("[OpenCode] Config setup task panicked: {}", e);
+    }
+    if let Err(e) = skills_result {
+        eprintln!("[OpenCode] Skills setup task panicked: {}", e);
+    }
+
+    let (mut secrets, failed_keys) = keyring_result.unwrap_or_else(|e| {
+        eprintln!("[OpenCode] spawn_blocking for keyring failed: {}", e);
+        (Vec::new(), Vec::new())
+    });
+
+    // Keyring retry logic (unchanged)
+    if !failed_keys.is_empty() {
+        println!(
+            "[OpenCode] {} secret(s) failed to read ({:?}), retrying after keychain unlock...",
+            failed_keys.len(),
+            failed_keys
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        let ws_retry = workspace_path.clone();
+        let (retry_secrets, still_failed) =
+            tokio::task::spawn_blocking(move || read_keyring_secrets(&ws_retry))
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("[OpenCode] spawn_blocking for keyring retry failed: {}", e);
+                    (Vec::new(), Vec::new())
+                });
+
+        if !still_failed.is_empty() {
+            eprintln!(
+                "[OpenCode] Warning: {} secret(s) still unavailable after retry: {:?}",
+                still_failed.len(),
+                still_failed
+            );
+        }
+
+        secrets = retry_secrets;
+    }
+
+    let original_config = resolve_config_secret_refs(&workspace_path, &secrets);
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw && cargo build -p teamclaw 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 3: Manual test — start app, verify sidecar starts normally**
+
+Start the app, select a workspace. Verify:
+- OpenCode sidecar starts and becomes ready
+- No errors in the terminal log
+- Chat is functional
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/commands/opencode.rs
+git commit -m "perf: parallelize pre-sidecar file I/O with tokio::join!"
+```
+
+---
+
+### Task 3: Early Sidecar Launch — State and Persistence
+
+**Files:**
+- Modify: `src-tauri/src/commands/opencode.rs:14-55` (OpenCodeState struct)
+
+- [ ] **Step 1: Add EarlyLaunchState and extend OpenCodeState**
+
+Add an `EarlyLaunchState` struct and a field to `OpenCodeState` to hold the early launch result. Add this right after the existing `OpenCodeState` struct definition:
+
+```rust
+/// State for the early sidecar launch (initiated from setup hook before frontend).
+pub struct EarlyLaunchState {
+    /// The workspace path this early launch was started for.
+    pub workspace_path: String,
+    /// Receiver to await the result. Clone to subscribe.
+    pub result_rx: tokio::sync::watch::Receiver<Option<Result<OpenCodeStatus, String>>>,
+}
+```
+
+Add this field to `OpenCodeState`:
+
+```rust
+    /// Early launch state — set by setup hook, consumed by start_opencode.
+    pub early_launch: tokio::sync::Mutex<Option<EarlyLaunchState>>,
+```
+
+And initialize it in the `Default` impl:
+
+```rust
+    early_launch: tokio::sync::Mutex::new(None),
+```
+
+- [ ] **Step 2: Add workspace path persistence helpers**
+
+Add these functions at the bottom of `opencode.rs` (before the tests, if any):
+
+```rust
+/// Path to the file that persists the last workspace for early launch.
+fn last_workspace_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    std::path::PathBuf::from(home).join(".teamclaw").join("last-workspace.json")
+}
+
+/// Read the last workspace path from ~/.teamclaw/last-workspace.json.
+pub fn read_last_workspace() -> Option<String> {
+    let path = last_workspace_path();
+    let content = std::fs::read_to_string(&path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let ws = json.get("workspace_path")?.as_str()?;
+    // Verify the directory still exists
+    if std::path::Path::new(ws).is_dir() {
+        Some(ws.to_string())
+    } else {
+        #[cfg(debug_assertions)]
+        eprintln!("[EarlyLaunch] Last workspace '{}' no longer exists, skipping", ws);
+        None
+    }
+}
+
+/// Persist the workspace path for next launch.
+fn write_last_workspace(workspace_path: &str) {
+    let path = last_workspace_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let json = serde_json::json!({ "workspace_path": workspace_path });
+    let _ = std::fs::write(&path, serde_json::to_string_pretty(&json).unwrap_or_default());
+}
+```
+
+- [ ] **Step 3: Write workspace path after successful start**
+
+In the `start_opencode` function, after the final state update block (around line 455-463, the block that sets `is_running`, `port`, and `workspace_path`), add:
+
+```rust
+    // Persist workspace for early launch on next startup
+    write_last_workspace(&workspace_path);
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw && cargo build -p teamclaw 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/commands/opencode.rs
+git commit -m "feat: add EarlyLaunchState and workspace path persistence"
+```
+
+---
+
+### Task 4: Early Sidecar Launch — Setup Hook Integration
+
+**Files:**
+- Modify: `src-tauri/src/lib.rs:354-667` (setup hook)
+- Modify: `src-tauri/src/commands/opencode.rs:59-472` (start_opencode)
+
+- [ ] **Step 1: Add early launch trigger in setup hook**
+
+In `lib.rs`, inside the `setup` closure (after the P2P initialization block, around line 381, before the `// --- System Tray ---` comment), add:
+
+```rust
+            // --- Early sidecar launch ---
+            // Read last workspace and start OpenCode before frontend renders.
+            // The frontend's start_opencode call will reuse this result if the path matches.
+            if std::env::var("TEAMCLAW_DISABLE_EARLY_LAUNCH").unwrap_or_default() != "1" {
+                if let Some(workspace_path) = commands::opencode::read_last_workspace() {
+                    println!("[EarlyLaunch] Starting sidecar for: {}", workspace_path);
+                    let app_handle = app.handle().clone();
+                    let (tx, rx) = tokio::sync::watch::channel(None);
+
+                    // Store the early launch state so start_opencode can find it
+                    let early_state = app_handle.state::<commands::opencode::OpenCodeState>();
+                    {
+                        let mut early = early_state.early_launch.blocking_lock();
+                        *early = Some(commands::opencode::EarlyLaunchState {
+                            workspace_path: workspace_path.clone(),
+                            result_rx: rx,
+                        });
+                    }
+
+                    tauri::async_runtime::spawn(async move {
+                        let state = app_handle.state::<commands::opencode::OpenCodeState>();
+                        let config = commands::opencode::OpenCodeConfig {
+                            workspace_path,
+                            port: None,
+                        };
+                        let result = commands::opencode::start_opencode_inner(
+                            app_handle.clone(),
+                            &state,
+                            config,
+                        ).await;
+                        let _ = tx.send(Some(result));
+                    });
+                }
+            }
+```
+
+- [ ] **Step 2: Extract `start_opencode_inner` from `start_opencode`**
+
+In `opencode.rs`, create a new `pub async fn start_opencode_inner` by moving the **entire body** of the current `start_opencode` function (lines 64-471, from `let _start_guard = state.start_lock.lock().await;` through the final `Ok(OpenCodeStatus { ... })`) into it.
+
+Key signature change: `state` parameter changes from `State<'_, OpenCodeState>` (Tauri managed state wrapper) to `&OpenCodeState` (plain reference), since `start_opencode_inner` is not a Tauri command. `State` auto-derefs to the inner type, so all existing `state.xxx` usage works unchanged.
+
+Note on `start_lock`: `start_opencode_inner` retains the `start_lock` acquisition at the top. This means if the early launch is still running when a frontend mismatch/fallback triggers `start_opencode_inner`, the fallback will block on the lock until the early launch completes — this is correct behavior.
+
+```rust
+/// Core sidecar startup logic, shared between the Tauri command and early launch.
+///
+/// Acquires `start_lock` internally to serialize concurrent calls.
+pub async fn start_opencode_inner(
+    app: AppHandle,
+    state: &OpenCodeState,
+    config: OpenCodeConfig,
+) -> Result<OpenCodeStatus, String> {
+    // Serialize concurrent calls — only one start_opencode runs at a time.
+    let _start_guard = state.start_lock.lock().await;
+
+    // ... rest is the ENTIRE existing body of start_opencode from line 66
+    // (let is_dev_mode = ...) through line 471 (the final Ok(OpenCodeStatus { ... })),
+    // copied verbatim. No changes needed to the body — all `state.xxx` calls
+    // work because State<'_, T> derefs to &T.
+}
+```
+
+- [ ] **Step 3: Write the new `start_opencode` wrapper with early launch check**
+
+Replace the existing `start_opencode` function with a thin wrapper:
+
+```rust
+/// Start OpenCode server as a sidecar process (or connect to external in dev mode)
+#[tauri::command]
+pub async fn start_opencode(
+    app: AppHandle,
+    state: State<'_, OpenCodeState>,
+    config: OpenCodeConfig,
+) -> Result<OpenCodeStatus, String> {
+    // Check if early launch is in progress for this workspace
+    {
+        let mut early_guard = state.early_launch.lock().await;
+        if let Some(early) = early_guard.as_ref() {
+            if early.workspace_path == config.workspace_path {
+                println!("[OpenCode] Reusing early launch for: {}", config.workspace_path);
+                let mut rx = early.result_rx.clone();
+                // Drop the lock before awaiting
+                drop(early_guard);
+                // Wait for the early launch to complete
+                while rx.borrow().is_none() {
+                    if rx.changed().await.is_err() {
+                        break;
+                    }
+                }
+                let result = rx.borrow().clone();
+                // Clear early launch state
+                let mut early_guard = state.early_launch.lock().await;
+                *early_guard = None;
+                match result {
+                    Some(Ok(status)) => return Ok(status),
+                    Some(Err(e)) => {
+                        // Early launch failed — fall through to fresh attempt
+                        println!("[OpenCode] Early launch failed ({}), retrying fresh", e);
+                    }
+                    None => {
+                        // Sender dropped without result — fall through
+                        println!("[OpenCode] Early launch sender dropped, retrying fresh");
+                    }
+                }
+            } else {
+                // Different workspace — clear early launch, proceed normally
+                println!("[OpenCode] Workspace mismatch, clearing early launch");
+                *early_guard = None;
+            }
+        }
+    }
+
+    start_opencode_inner(app, &state, config).await
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw && cargo build -p teamclaw 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 5: Manual test — early launch flow**
+
+1. Start the app with a workspace. Wait for it to be ready. Quit.
+2. Check `~/.teamclaw/last-workspace.json` exists with correct path.
+3. Restart the app. Observe in logs:
+   - `[EarlyLaunch] Starting sidecar for: /path/to/workspace`
+   - `[OpenCode] Reusing early launch for: /path/to/workspace`
+4. Verify app starts faster (sidecar was already starting during React render).
+
+- [ ] **Step 6: Manual test — early launch disabled**
+
+Run: `TEAMCLAW_DISABLE_EARLY_LAUNCH=1 cargo tauri dev`
+Verify the app starts normally without the early launch log messages.
+
+- [ ] **Step 7: Manual test — workspace mismatch**
+
+1. Start app with workspace A. Quit.
+2. Edit `~/.teamclaw/last-workspace.json` to point to workspace B.
+3. Start app, select workspace A from prompt.
+4. Verify `[OpenCode] Workspace mismatch, clearing early launch` in logs.
+5. Verify workspace A loads correctly.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src-tauri/src/lib.rs src-tauri/src/commands/opencode.rs
+git commit -m "perf: early sidecar launch from Rust setup hook"
+```
+
+---
+
+### Task 5: Remove Frontend 300ms Delay
+
+**Files:**
+- Modify: `packages/app/src/hooks/useAppInit.ts:58-109`
+
+- [ ] **Step 1: Simplify useOpenCodeInit**
+
+Replace the setTimeout-based launch with a direct call. Replace lines 74-108 (from `const alreadyPreloading` to the end of the useEffect return) with:
+
+```typescript
+    const alreadyPreloading = hasPreloadFor(workspacePath);
+    if (!alreadyPreloading) {
+      setOpenCodeReady(false);
+    }
+
+    let cancelled = false;
+
+    console.log(
+      alreadyPreloading
+        ? "[OpenCode] Awaiting preloaded server for:"
+        : "[OpenCode] Starting server for:",
+      workspacePath,
+    );
+    startOpenCode(workspacePath)
+      .then((status) => {
+        if (cancelled) return;
+        console.log("[OpenCode] Server started:", status);
+        initOpenCodeClient({ baseUrl: status.url, workspacePath });
+        setOpenCodeError(null);
+        setOpenCodeReady(true, status.url);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error("[OpenCode] Failed to start server:", error);
+        setOpenCodeError(String(error));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+```
+
+- [ ] **Step 2: Verify frontend builds**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw && pnpm --filter app build 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/app/src/hooks/useAppInit.ts
+git commit -m "perf: remove unnecessary 300ms delay in useOpenCodeInit"
+```
+
+---
+
+### Task 6: Defer Dependency Check
+
+**Files:**
+- Modify: `packages/app/src/hooks/useAppInit.ts:286-361` (useSetupGuide)
+- Modify: `packages/app/src/App.tsx:919`
+
+- [ ] **Step 1: Add `openCodeReady` parameter to `useSetupGuide`**
+
+Change the `useSetupGuide` function signature and defer the dependency check:
+
+```typescript
+export function useSetupGuide(openCodeReady: boolean) {
+```
+
+Then modify the mount useEffect (around line 300) to only run when `openCodeReady` is true. Change:
+
+```typescript
+  // Preload + dependency check on mount
+  useEffect(() => {
+    const debugForceSetup = (() => {
+      try {
+        return localStorage.getItem("teamclaw-debug-force-setup") === "1";
+      } catch {
+        return false;
+      }
+    })();
+
+    if (!isTauri() && !debugForceSetup) return;
+
+    const decision = setupDecisionRef.current;
+
+    if (decision === "skip") {
+      console.log("[Preload] Setup previously completed, skipping dep check");
+      depsResultRef.current = { checked: true, hasRequiredMissing: false };
+      return;
+    }
+
+    console.log("[Preload] Checking dependencies (decision:", decision, ")");
+    checkDependencies().then((result) => {
+      const hasRequiredMissing = result.some((d) => d.required && !d.installed);
+      depsResultRef.current = { checked: true, hasRequiredMissing };
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+```
+
+To:
+
+```typescript
+  // Dependency check — deferred until OpenCode is ready to avoid CPU contention
+  useEffect(() => {
+    const debugForceSetup = (() => {
+      try {
+        return localStorage.getItem("teamclaw-debug-force-setup") === "1";
+      } catch {
+        return false;
+      }
+    })();
+
+    if (!isTauri() && !debugForceSetup) return;
+
+    const decision = setupDecisionRef.current;
+
+    if (decision === "skip") {
+      depsResultRef.current = { checked: true, hasRequiredMissing: false };
+      return;
+    }
+
+    // Wait for OpenCode to be ready before checking deps (reduces startup CPU contention)
+    if (!openCodeReady && isTauri()) return;
+
+    console.log("[Setup] Checking dependencies (decision:", decision, ")");
+    checkDependencies().then((result) => {
+      const hasRequiredMissing = result.some((d) => d.required && !d.installed);
+      depsResultRef.current = { checked: true, hasRequiredMissing };
+    });
+  }, [openCodeReady, checkDependencies]);
+```
+
+- [ ] **Step 2: Update call site in App.tsx**
+
+In `App.tsx`, line 919, change:
+
+```typescript
+  const { showSetupGuide, dependencies, handleRecheck, handleSetupContinue } = useSetupGuide();
+```
+
+To:
+
+```typescript
+  const openCodeReady = useWorkspaceStore((s) => s.openCodeReady);
+  const { showSetupGuide, dependencies, handleRecheck, handleSetupContinue } = useSetupGuide(openCodeReady);
+```
+
+Note: `useWorkspaceStore` is already imported in `App.tsx` (line 70). The `openCodeReady` selector is already used in `AppContent` (line 414), but `App` function needs its own subscription since hooks can't be shared across components.
+
+- [ ] **Step 3: Verify frontend builds**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw && pnpm --filter app build 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 4: Manual test — dependency check timing**
+
+1. Clear setup flag: `localStorage.removeItem('teamclaw-setup-completed')` in devtools
+2. Start app with a workspace
+3. Observe that dependency check logs appear AFTER `[OpenCode] Server started` in console
+4. Setup guide should still appear if required deps are missing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/hooks/useAppInit.ts packages/app/src/App.tsx
+git commit -m "perf: defer dependency check until after OpenCode is ready"
+```
+
+---
+
+### Task 7: Final Verification and Cleanup
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Full build check (Rust + Frontend)**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw && cargo build -p teamclaw && pnpm --filter app build`
+Expected: Both succeed
+
+- [ ] **Step 2: Test all startup scenarios**
+
+Test each scenario manually:
+
+1. **Fresh install**: Delete `~/.teamclaw/last-workspace.json` and `~/.teamclaw/cached-path.txt`. Start app. Verify workspace prompt appears, then sidecar starts after selecting a workspace.
+
+2. **Normal restart**: Quit and restart. Verify early launch kicks in and app starts faster.
+
+3. **Workspace switch**: Start app, go to settings, switch workspace. Verify the new workspace loads correctly.
+
+4. **Deleted workspace**: Edit `last-workspace.json` to point to a non-existent path. Start app. Verify fallback to frontend-triggered flow (no crash).
+
+5. **Dev mode**: Set `OPENCODE_DEV_MODE=true`. Start app. Verify dev mode still works.
+
+6. **Early launch disabled**: Set `TEAMCLAW_DISABLE_EARLY_LAUNCH=1`. Verify normal startup flow.
+
+- [ ] **Step 3: Commit any fixups**
+
+If any issues found, fix and commit with descriptive messages.

--- a/docs/superpowers/specs/2026-03-19-startup-speed-optimization-design.md
+++ b/docs/superpowers/specs/2026-03-19-startup-speed-optimization-design.md
@@ -41,15 +41,20 @@ SSE connect → openCodeReady = true → UI usable
 **Problem**: `fix_path_env()` runs synchronously at the very start of `run()`, blocking Tauri Builder construction for ~50-200ms while spawning a login shell.
 
 **Solution**:
-- Move `fix_path_env()` into the `setup` hook, executed via `tauri::async_runtime::spawn_blocking`
-- Use a global `tokio::sync::OnceCell<()>` (or `std::sync::OnceLock`) as a completion signal
-- `start_opencode` awaits this signal before spawning the sidecar (sidecar inherits process PATH)
+- Spawn `fix_path_env()` on a dedicated thread **before** `tauri::Builder::default()`, but don't block on its result
+- Use a global `std::sync::OnceLock<()>` as a completion signal (set by the spawned thread when PATH is applied)
+- `start_opencode` checks this signal before spawning the sidecar (sidecar inherits process PATH)
+
+**Implementation detail**: `fix_path_env()` calls `std::env::set_var`, which is `unsafe` in multi-threaded contexts on Rust 1.83+. To mitigate: spawn the PATH-reading thread before `tauri::Builder::default()` (while still single-threaded for env reads), capture the result, and apply `set_var` before the Builder starts constructing. The OnceLock simply signals completion so downstream code knows PATH is ready. Alternatively, keep `fix_path_env()` synchronous but move the slow shell spawn to a pre-cached approach: try reading a cached PATH from `~/.teamclaw/cached-path.txt` first, fall back to shell spawn only if missing.
+
+**Chosen approach**: Keep `fix_path_env()` synchronous and before `Builder::default()` (avoiding `set_var` safety issues), but optimize it by caching the PATH result. This is simpler and avoids the multi-threaded `set_var` problem entirely. The ~50-200ms savings come from cache hits on subsequent launches.
 
 **Files**: `src-tauri/src/lib.rs`
 
 **Constraints**:
 - PATH must be set before any child process is spawned (sidecar, shell commands)
-- The `fix_path_env` completion signal must be awaitable from async context
+- `std::env::set_var` must be called while still effectively single-threaded (before Builder construction)
+- Cache file (`~/.teamclaw/cached-path.txt`) must be invalidated when shell profile changes (use file mtime of `~/.zshrc` / `~/.bashrc` as cache key)
 
 ### 2. Parallel File I/O Before Sidecar Spawn
 
@@ -60,39 +65,31 @@ ensure_default_permissions → ensure_inherent_config → ensure_inherent_skills
 → resolve_sidecar_binary_paths → read_keyring_secrets
 ```
 
-These are all independent of each other.
+Three of these (`ensure_default_permissions`, `ensure_inherent_config`, `resolve_sidecar_binary_paths`) all read/write `opencode.json` and must remain sequential with each other. The remaining two (`ensure_inherent_skills` writes to `.opencode/skills/`, `read_keyring_secrets` reads the OS keyring) are independent and can run in parallel.
 
 **Solution**:
-- Wrap the first 4 sync functions in `spawn_blocking`
-- Run all 5 operations in parallel via `tokio::join!`
-- `resolve_config_secret_refs` depends on keyring results, so it stays sequential after the join
+- Group the three `opencode.json` writers into a sequential chain, wrapped in a single `spawn_blocking`
+- Run `ensure_inherent_skills` and `read_keyring_secrets` in parallel with the config chain via `tokio::join!`
+- `resolve_config_secret_refs` depends on both the config chain AND keyring results completing, so it runs after the `tokio::join!`
 
 **Before** (serial, total = sum of all):
 ```
 ensure_permissions → ensure_config → ensure_skills → resolve_paths → read_keyring
 ```
 
-**After** (parallel, total ≈ max of all):
-```
-┌─ ensure_permissions ─┐
-├─ ensure_config ──────┤
-├─ ensure_skills ──────┼──→ resolve_config_secret_refs → spawn sidecar
-├─ resolve_paths ──────┤
-└─ read_keyring ───────┘
-```
-
-**Files**: `src-tauri/src/commands/opencode.rs`
-
-**Constraints**:
-- `ensure_default_permissions` and `ensure_inherent_config` both read/write `opencode.json` — they are logically independent (permissions section vs mcp/skills sections), but write to the same file. Must ensure no concurrent writes corrupt the file.
-- Solution: keep `ensure_default_permissions` and `ensure_inherent_config` sequential with each other (they share `opencode.json`), but parallel with `ensure_inherent_skills`, `resolve_sidecar_binary_paths`, and `read_keyring_secrets`.
-
-**Revised parallel layout**:
+**After** (partially parallel, total ≈ max of the two branches):
 ```
 ┌─ ensure_permissions → ensure_config → resolve_paths ─┐
 ├─ ensure_skills ──────────────────────────────────────┼──→ resolve_secret_refs → spawn
 └─ read_keyring ───────────────────────────────────────┘
 ```
+
+**Files**: `src-tauri/src/commands/opencode.rs`
+
+**Constraints**:
+- `ensure_default_permissions`, `ensure_inherent_config`, and `resolve_sidecar_binary_paths` all read/write `opencode.json` — they MUST remain sequential
+- `resolve_config_secret_refs` must not begin until ALL `opencode.json` mutations are complete (it reads the raw file content for string replacement)
+- `ensure_inherent_skills` and `read_keyring_secrets` have no file dependencies on `opencode.json` and are safe to parallelize
 
 ### 3. Early Sidecar Launch from Rust Setup Hook (Core Optimization)
 
@@ -106,14 +103,17 @@ ensure_permissions → ensure_config → ensure_skills → resolve_paths → rea
 - Write is fire-and-forget (non-blocking, errors logged)
 
 **3b. Early launch in setup hook**:
-- In `setup`, after spawning `fix_path_env`, read `last-workspace.json`
-- If a valid workspace path is found, spawn the full `start_opencode` logic (including file I/O, keyring, sidecar spawn) as an async task
-- Store the result in `Arc<tokio::sync::OnceCell<Result<OpenCodeStatus, String>>>` on `OpenCodeState`
+- In `setup`, read `last-workspace.json` (PATH is already set since `fix_path_env` runs synchronously before Builder)
+- If a valid workspace path is found, spawn the full sidecar startup logic (file I/O, keyring, sidecar spawn) as an async task
+- Store the in-flight future's result in a `Mutex<Option<EarlyLaunchState>>` on `OpenCodeState`, where `EarlyLaunchState` holds the workspace path and a `tokio::sync::watch::Sender/Receiver` for the result
 
 **3c. Frontend invoke hits cache**:
-- When frontend calls `start_opencode` with the same workspace path, check if the early-launch OnceCell is already set (or in progress)
-- If match: await the OnceCell and return its result
-- If mismatch (user changed workspace): proceed with normal restart logic, clear the OnceCell
+- When frontend calls `start_opencode` with the same workspace path, check if an early launch is in progress or completed for that path
+- If match and succeeded: return the cached result immediately
+- If match and failed: clear the early launch state, proceed with a fresh attempt (supports retry)
+- If mismatch (user changed workspace): clear the early launch state, proceed with normal restart logic
+
+**Why `watch` instead of `OnceCell`**: `OnceCell` can only be set once — if the early launch fails, subsequent retries cannot reset it. A `watch` channel (or `Mutex<Option<Result<...>>>`) allows the state to be cleared on failure, enabling the retry flow from the frontend's error screen.
 
 **Timing comparison**:
 
@@ -134,6 +134,7 @@ After:
 **Files**: `src-tauri/src/lib.rs`, `src-tauri/src/commands/opencode.rs`
 
 **Edge cases**:
+- `~/.teamclaw/` directory doesn't exist → `create_dir_all` before writing `last-workspace.json`
 - `last-workspace.json` missing or unreadable → skip early launch, fallback to frontend-triggered flow
 - Workspace directory deleted → sidecar fails, OnceCell stores Err, frontend receives error and shows error screen
 - User switches workspace → frontend invoke path differs from cached path, triggers normal restart logic
@@ -150,7 +151,7 @@ const timer = setTimeout(() => {
 }, delay);
 ```
 
-With early sidecar launch from Rust, this delay is unnecessary.
+With early sidecar launch from Rust, this delay is unnecessary. The original 300ms delay was a heuristic to give `useOpenCodePreload` time to fire first, but the preloader's deduplication (`hasPreloadFor` check + shared promise in `preloader.ts`) already handles double-invocation correctly. React strict mode's double-mount is also safe because the preloader returns the same in-flight promise.
 
 **Solution**: Remove the setTimeout, call `startOpenCode(workspacePath)` directly.
 
@@ -173,7 +174,7 @@ With early sidecar launch from Rust, this delay is unnecessary.
 
 | # | Optimization | Files | Expected Gain |
 |---|-------------|-------|---------------|
-| 1 | Async `fix_path_env()` | `lib.rs` | ~50-200ms |
+| 1 | Cache `fix_path_env()` PATH result | `lib.rs` | ~50-200ms (on cache hit) |
 | 2 | Parallel file I/O before sidecar | `opencode.rs` | ~100-300ms |
 | 3 | Early sidecar launch from setup hook | `lib.rs` + `opencode.rs` | ~500-1500ms |
 | 4 | Remove frontend 300ms delay | `useAppInit.ts` | 300ms |
@@ -193,9 +194,12 @@ With early sidecar launch from Rust, this delay is unnecessary.
   - Dev mode (`OPENCODE_DEV_MODE=true`)
 - **Cross-platform**: Test on macOS (primary), verify Windows/Linux builds compile and start correctly
 
+## Debugging
+
+Set `TEAMCLAW_DISABLE_EARLY_LAUNCH=1` to disable the early sidecar launch (optimization 3) for debugging. When set, the app falls back to the frontend-triggered launch flow.
+
 ## Non-Goals
 
 - No splash screen or UI flow changes
 - No Tauri plugin lazy loading (risk of side effects)
 - No frontend chunk splitting changes
-- No PATH caching to file (diminishing returns for added complexity)

--- a/docs/superpowers/specs/2026-03-19-startup-speed-optimization-design.md
+++ b/docs/superpowers/specs/2026-03-19-startup-speed-optimization-design.md
@@ -1,0 +1,201 @@
+# Startup Speed Optimization Design
+
+## Goal
+
+Reduce TeamClaw's startup time by ~1-2 seconds through parallelization and early sidecar launch, without changing the existing UI flow.
+
+## Current Startup Critical Path
+
+```
+fix_path_env() [~50-200ms, blocking, spawns login shell]
+    ↓
+Tauri Builder [plugin registration, synchronous]
+    ↓
+Setup Hook [RAG server, tray, event handlers]
+    ↓
+Window creation + Webview load
+    ↓
+React render [main.tsx → App.tsx]
+    ↓
+useOpenCodePreload() → invoke("start_opencode")
+    ↓
+Rust start_opencode:
+  ensure_default_permissions()     [sync file I/O]
+  ensure_inherent_config()         [sync file I/O]
+  ensure_inherent_skills()         [sync file I/O]
+  resolve_sidecar_binary_paths()   [sync file I/O]
+  read_keyring_secrets()           [spawn_blocking]
+  resolve_config_secret_refs()     [file I/O]
+    ↓
+Sidecar spawn + wait for "ready" [1-10s, biggest bottleneck]
+    ↓
+SSE connect → openCodeReady = true → UI usable
+```
+
+**Total: ~2-15 seconds** (dominated by sidecar startup).
+
+## Optimizations
+
+### 1. Async `fix_path_env()`
+
+**Problem**: `fix_path_env()` runs synchronously at the very start of `run()`, blocking Tauri Builder construction for ~50-200ms while spawning a login shell.
+
+**Solution**:
+- Move `fix_path_env()` into the `setup` hook, executed via `tauri::async_runtime::spawn_blocking`
+- Use a global `tokio::sync::OnceCell<()>` (or `std::sync::OnceLock`) as a completion signal
+- `start_opencode` awaits this signal before spawning the sidecar (sidecar inherits process PATH)
+
+**Files**: `src-tauri/src/lib.rs`
+
+**Constraints**:
+- PATH must be set before any child process is spawned (sidecar, shell commands)
+- The `fix_path_env` completion signal must be awaitable from async context
+
+### 2. Parallel File I/O Before Sidecar Spawn
+
+**Problem**: In `start_opencode`, 5 operations run sequentially before the sidecar is spawned:
+
+```
+ensure_default_permissions → ensure_inherent_config → ensure_inherent_skills
+→ resolve_sidecar_binary_paths → read_keyring_secrets
+```
+
+These are all independent of each other.
+
+**Solution**:
+- Wrap the first 4 sync functions in `spawn_blocking`
+- Run all 5 operations in parallel via `tokio::join!`
+- `resolve_config_secret_refs` depends on keyring results, so it stays sequential after the join
+
+**Before** (serial, total = sum of all):
+```
+ensure_permissions → ensure_config → ensure_skills → resolve_paths → read_keyring
+```
+
+**After** (parallel, total ≈ max of all):
+```
+┌─ ensure_permissions ─┐
+├─ ensure_config ──────┤
+├─ ensure_skills ──────┼──→ resolve_config_secret_refs → spawn sidecar
+├─ resolve_paths ──────┤
+└─ read_keyring ───────┘
+```
+
+**Files**: `src-tauri/src/commands/opencode.rs`
+
+**Constraints**:
+- `ensure_default_permissions` and `ensure_inherent_config` both read/write `opencode.json` — they are logically independent (permissions section vs mcp/skills sections), but write to the same file. Must ensure no concurrent writes corrupt the file.
+- Solution: keep `ensure_default_permissions` and `ensure_inherent_config` sequential with each other (they share `opencode.json`), but parallel with `ensure_inherent_skills`, `resolve_sidecar_binary_paths`, and `read_keyring_secrets`.
+
+**Revised parallel layout**:
+```
+┌─ ensure_permissions → ensure_config → resolve_paths ─┐
+├─ ensure_skills ──────────────────────────────────────┼──→ resolve_secret_refs → spawn
+└─ read_keyring ───────────────────────────────────────┘
+```
+
+### 3. Early Sidecar Launch from Rust Setup Hook (Core Optimization)
+
+**Problem**: The sidecar doesn't start until the frontend renders and sends an `invoke("start_opencode")` call. The window load + React render adds ~200-500ms of dead time before the sidecar even begins starting.
+
+**Solution**:
+
+**3a. Persist workspace path on Rust side**:
+- After successful `start_opencode`, write workspace path to `~/.teamclaw/last-workspace.json`
+- Format: `{"workspace_path": "/path/to/workspace"}`
+- Write is fire-and-forget (non-blocking, errors logged)
+
+**3b. Early launch in setup hook**:
+- In `setup`, after spawning `fix_path_env`, read `last-workspace.json`
+- If a valid workspace path is found, spawn the full `start_opencode` logic (including file I/O, keyring, sidecar spawn) as an async task
+- Store the result in `Arc<tokio::sync::OnceCell<Result<OpenCodeStatus, String>>>` on `OpenCodeState`
+
+**3c. Frontend invoke hits cache**:
+- When frontend calls `start_opencode` with the same workspace path, check if the early-launch OnceCell is already set (or in progress)
+- If match: await the OnceCell and return its result
+- If mismatch (user changed workspace): proceed with normal restart logic, clear the OnceCell
+
+**Timing comparison**:
+
+Before:
+```
+[Tauri init]──[Window]──[React render]──[invoke]──[file I/O]──[spawn]──[ready]
+                                         ↑                                ↑
+                                      sidecar starts                   UI usable
+```
+
+After:
+```
+[Tauri init]──[setup: early sidecar spawn]─────────────────────[ready]
+              [Window]──[React render]──[invoke: hits cache]──────↑
+                                                               UI usable
+```
+
+**Files**: `src-tauri/src/lib.rs`, `src-tauri/src/commands/opencode.rs`
+
+**Edge cases**:
+- `last-workspace.json` missing or unreadable → skip early launch, fallback to frontend-triggered flow
+- Workspace directory deleted → sidecar fails, OnceCell stores Err, frontend receives error and shows error screen
+- User switches workspace → frontend invoke path differs from cached path, triggers normal restart logic
+- Concurrent calls → existing `start_lock` mutex serializes them; OnceCell ensures single initialization
+
+### 4. Remove Frontend 300ms Delay
+
+**Problem**: `useOpenCodeInit` has a hardcoded 300ms setTimeout when no preload is in progress:
+
+```typescript
+const delay = alreadyPreloading ? 0 : 300;
+const timer = setTimeout(() => {
+  startOpenCode(workspacePath)...
+}, delay);
+```
+
+With early sidecar launch from Rust, this delay is unnecessary.
+
+**Solution**: Remove the setTimeout, call `startOpenCode(workspacePath)` directly.
+
+**Files**: `packages/app/src/hooks/useAppInit.ts` (`useOpenCodeInit`)
+
+### 5. Defer Dependency Check
+
+**Problem**: `useSetupGuide` runs `checkDependencies()` on mount, which spawns multiple shell processes (checking git, node, rust, etc.). These compete for CPU/IO with the sidecar startup.
+
+**Solution**: Defer `checkDependencies()` until after `openCodeReady` is true. If setup was previously completed (localStorage flag), still skip entirely.
+
+**Implementation**:
+- `useSetupGuide` accepts `openCodeReady: boolean` parameter
+- Only triggers `checkDependencies()` when `openCodeReady` is true (or when not in Tauri)
+- If `decision === "skip"`, behavior unchanged (no check at all)
+
+**Files**: `packages/app/src/hooks/useAppInit.ts` (`useSetupGuide`), `packages/app/src/App.tsx` (pass `openCodeReady` prop)
+
+## Summary
+
+| # | Optimization | Files | Expected Gain |
+|---|-------------|-------|---------------|
+| 1 | Async `fix_path_env()` | `lib.rs` | ~50-200ms |
+| 2 | Parallel file I/O before sidecar | `opencode.rs` | ~100-300ms |
+| 3 | Early sidecar launch from setup hook | `lib.rs` + `opencode.rs` | ~500-1500ms |
+| 4 | Remove frontend 300ms delay | `useAppInit.ts` | 300ms |
+| 5 | Defer dependency check | `useAppInit.ts` + `App.tsx` | indirect (less CPU contention) |
+
+**Total expected gain: ~1-2 seconds**
+
+## Testing Strategy
+
+- **Manual timing**: Add `console.time`/`timeEnd` markers around key startup phases, compare before/after
+- **Regression check**: Verify all startup scenarios still work:
+  - Fresh install (no `last-workspace.json`)
+  - Normal restart (workspace path cached)
+  - Workspace switch (path mismatch)
+  - Workspace directory deleted
+  - Keychain locked (first-time secret access)
+  - Dev mode (`OPENCODE_DEV_MODE=true`)
+- **Cross-platform**: Test on macOS (primary), verify Windows/Linux builds compile and start correctly
+
+## Non-Goals
+
+- No splash screen or UI flow changes
+- No Tauri plugin lazy loading (risk of side effects)
+- No frontend chunk splitting changes
+- No PATH caching to file (diminishing returns for added complexity)

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -916,7 +916,8 @@ function App() {
   // Extracted hooks — initialization, setup guide, telemetry consent, preload
   useTauriBodyClass();
   useOpenCodePreload();
-  const { showSetupGuide, dependencies, handleRecheck, handleSetupContinue } = useSetupGuide();
+  const openCodeReady = useWorkspaceStore((s) => s.openCodeReady);
+  const { showSetupGuide, dependencies, handleRecheck, handleSetupContinue } = useSetupGuide(openCodeReady);
   const { showConsentDialog, setShowConsentDialog } = useTelemetryConsent(showSetupGuide);
 
   if (spotlightMode) {

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -21,6 +21,7 @@ import {
   BookOpen,
 } from 'lucide-react'
 import { cn, isTauri } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -183,6 +184,9 @@ export function TeamGitConfig() {
       await tauriInvoke<TeamGitResult>('team_init_repo', {
         gitUrl: gitUrl.trim(),
         gitToken: isHttpsUrl && gitToken.trim() ? gitToken.trim() : null,
+        llmBaseUrl: buildConfig.team.llm.baseUrl || null,
+        llmModel: buildConfig.team.llm.model || null,
+        llmModelName: buildConfig.team.llm.modelName || null,
       })
 
       setConnectStep(t('settings.team.generatingGitignore', 'Generating .gitignore...'))

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -19,6 +19,7 @@ import {
   Share2,
 } from 'lucide-react'
 import { cn, isTauri, copyToClipboard } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { useTeamModeStore } from '@/stores/team-mode'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { DeviceIdDisplay } from '@/components/settings/DeviceIdDisplay'
@@ -272,7 +273,11 @@ export function TeamP2PConfig() {
     setCreateLoading(true)
     setP2pError(null)
     try {
-      await tauriInvoke<string>('p2p_create_team')
+      await tauriInvoke<string>('p2p_create_team', {
+        llmBaseUrl: buildConfig.team.llm.baseUrl || null,
+        llmModel: buildConfig.team.llm.model || null,
+        llmModelName: buildConfig.team.llm.modelName || null,
+      })
       await loadSyncStatus()
       if (workspacePath) {
         const store = useTeamModeStore.getState()

--- a/packages/app/src/hooks/__tests__/useAppInit.test.ts
+++ b/packages/app/src/hooks/__tests__/useAppInit.test.ts
@@ -114,7 +114,7 @@ describe('useLayoutModeShortcut', () => {
 describe('useSetupGuide', () => {
   it('returns showSetupGuide as false initially', async () => {
     const { useSetupGuide } = await import('@/hooks/useAppInit')
-    const { result } = renderHook(() => useSetupGuide())
+    const { result } = renderHook(() => useSetupGuide(false))
     expect(result.current.showSetupGuide).toBe(false)
     expect(result.current.dependencies).toEqual([])
   })

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -77,34 +77,29 @@ export function useOpenCodeInit() {
     }
 
     let cancelled = false;
-    const delay = alreadyPreloading ? 0 : 300;
 
-    const timer = setTimeout(() => {
-      if (cancelled) return;
-      console.log(
-        alreadyPreloading
-          ? "[OpenCode] Awaiting preloaded server for:"
-          : "[OpenCode] Starting server for:",
-        workspacePath,
-      );
-      startOpenCode(workspacePath)
-        .then((status) => {
-          if (cancelled) return;
-          console.log("[OpenCode] Server started:", status);
-          initOpenCodeClient({ baseUrl: status.url, workspacePath });
-          setOpenCodeError(null);
-          setOpenCodeReady(true, status.url);
-        })
-        .catch((error) => {
-          if (cancelled) return;
-          console.error("[OpenCode] Failed to start server:", error);
-          setOpenCodeError(String(error));
-        });
-    }, delay);
+    console.log(
+      alreadyPreloading
+        ? "[OpenCode] Awaiting preloaded server for:"
+        : "[OpenCode] Starting server for:",
+      workspacePath,
+    );
+    startOpenCode(workspacePath)
+      .then((status) => {
+        if (cancelled) return;
+        console.log("[OpenCode] Server started:", status);
+        initOpenCodeClient({ baseUrl: status.url, workspacePath });
+        setOpenCodeError(null);
+        setOpenCodeReady(true, status.url);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error("[OpenCode] Failed to start server:", error);
+        setOpenCodeError(String(error));
+      });
 
     return () => {
       cancelled = true;
-      clearTimeout(timer);
     };
   }, [workspacePath, setOpenCodeReady]);
 
@@ -283,7 +278,7 @@ export function useTauriBodyClass() {
 // Dependency check / setup guide
 // ─────────────────────────────────────────────────────────────────────────────
 
-export function useSetupGuide() {
+export function useSetupGuide(openCodeReady: boolean) {
   const [showSetupGuide, setShowSetupGuide] = useState(false);
   const {
     dependencies,
@@ -296,7 +291,7 @@ export function useSetupGuide() {
   });
   const setupDecisionRef = useRef(getSetupDecision());
 
-  // Preload + dependency check on mount
+  // Dependency check — deferred until OpenCode is ready to avoid CPU contention
   useEffect(() => {
     const debugForceSetup = (() => {
       try {
@@ -311,18 +306,19 @@ export function useSetupGuide() {
     const decision = setupDecisionRef.current;
 
     if (decision === "skip") {
-      console.log("[Preload] Setup previously completed, skipping dep check");
       depsResultRef.current = { checked: true, hasRequiredMissing: false };
       return;
     }
 
-    console.log("[Preload] Checking dependencies (decision:", decision, ")");
+    // Wait for OpenCode to be ready before checking deps (reduces startup CPU contention)
+    if (!openCodeReady && isTauri()) return;
+
+    console.log("[Setup] Checking dependencies (decision:", decision, ")");
     checkDependencies().then((result) => {
       const hasRequiredMissing = result.some((d) => d.required && !d.installed);
       depsResultRef.current = { checked: true, hasRequiredMissing };
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [openCodeReady, checkDependencies]);
 
   // Apply deps result once check completes
   useEffect(() => {

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -282,7 +282,6 @@ export function useSetupGuide(openCodeReady: boolean) {
   const [showSetupGuide, setShowSetupGuide] = useState(false);
   const {
     dependencies,
-    checked: depsChecked,
     checkDependencies,
   } = useDepsStore();
   const depsResultRef = useRef<{ checked: boolean; hasRequiredMissing: boolean }>({
@@ -317,32 +316,11 @@ export function useSetupGuide(openCodeReady: boolean) {
     checkDependencies().then((result) => {
       const hasRequiredMissing = result.some((d) => d.required && !d.installed);
       depsResultRef.current = { checked: true, hasRequiredMissing };
-    });
-  }, [openCodeReady, checkDependencies]);
-
-  // Apply deps result once check completes
-  useEffect(() => {
-    const decision = setupDecisionRef.current;
-
-    if (depsResultRef.current.checked) {
-      if (
-        depsResultRef.current.hasRequiredMissing &&
-        (decision === "show" || decision === "silent-check")
-      ) {
-        setShowSetupGuide(true);
-      }
-      return;
-    }
-
-    if (depsChecked) return;
-
-    checkDependencies().then((result) => {
-      const hasRequiredMissing = result.some((d) => d.required && !d.installed);
       if (hasRequiredMissing && (decision === "show" || decision === "silent-check")) {
         setShowSetupGuide(true);
       }
     });
-  }, [depsChecked, checkDependencies]);
+  }, [openCodeReady, checkDependencies]);
 
   const handleRecheck = useCallback(async () => {
     return checkDependencies();

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -72,6 +72,48 @@ pub async fn start_opencode(
     state: State<'_, OpenCodeState>,
     config: OpenCodeConfig,
 ) -> Result<OpenCodeStatus, String> {
+    // Check if early launch is in progress for this workspace
+    {
+        let mut early_guard = state.early_launch.lock().await;
+        if let Some(early) = early_guard.as_ref() {
+            if early.workspace_path == config.workspace_path {
+                println!("[OpenCode] Reusing early launch for: {}", config.workspace_path);
+                let mut rx = early.result_rx.clone();
+                drop(early_guard);
+                // Wait for the early launch to complete
+                while rx.borrow().is_none() {
+                    if rx.changed().await.is_err() {
+                        break;
+                    }
+                }
+                let result = rx.borrow().clone();
+                let mut early_guard = state.early_launch.lock().await;
+                *early_guard = None;
+                match result {
+                    Some(Ok(status)) => return Ok(status),
+                    Some(Err(e)) => {
+                        println!("[OpenCode] Early launch failed ({}), retrying fresh", e);
+                    }
+                    None => {
+                        println!("[OpenCode] Early launch sender dropped, retrying fresh");
+                    }
+                }
+            } else {
+                println!("[OpenCode] Workspace mismatch, clearing early launch");
+                *early_guard = None;
+            }
+        }
+    }
+
+    start_opencode_inner(app, &state, config).await
+}
+
+/// Core sidecar startup logic, shared between the Tauri command and early launch.
+pub async fn start_opencode_inner(
+    app: AppHandle,
+    state: &OpenCodeState,
+    config: OpenCodeConfig,
+) -> Result<OpenCodeStatus, String> {
     // Serialize concurrent calls — only one start_opencode runs at a time.
     let _start_guard = state.start_lock.lock().await;
 

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -19,6 +19,8 @@ pub struct OpenCodeState {
     pub workspace_path: Mutex<Option<String>>,
     /// Async lock that serializes `start_opencode` calls to prevent concurrent spawns.
     pub start_lock: tokio::sync::Mutex<()>,
+    /// Early launch state — set by setup hook, consumed by start_opencode.
+    pub early_launch: tokio::sync::Mutex<Option<EarlyLaunchState>>,
 }
 
 impl Default for OpenCodeState {
@@ -35,6 +37,7 @@ impl Default for OpenCodeState {
             is_dev_mode: Mutex::new(is_dev),
             workspace_path: Mutex::new(None),
             start_lock: tokio::sync::Mutex::new(()),
+            early_launch: tokio::sync::Mutex::new(None),
         }
     }
 }
@@ -52,6 +55,14 @@ pub struct OpenCodeStatus {
     pub url: String,
     pub is_dev_mode: bool,
     pub workspace_path: Option<String>,
+}
+
+/// State for the early sidecar launch (initiated from setup hook before frontend).
+pub struct EarlyLaunchState {
+    /// The workspace path this early launch was started for.
+    pub workspace_path: String,
+    /// Receiver to await the result. Clone to subscribe.
+    pub result_rx: tokio::sync::watch::Receiver<Option<Result<OpenCodeStatus, String>>>,
 }
 
 /// Start OpenCode server as a sidecar process (or connect to external in dev mode)
@@ -464,6 +475,9 @@ pub async fn start_opencode(
         let mut workspace_guard = state.workspace_path.lock().map_err(|e| e.to_string())?;
         *workspace_guard = Some(workspace_path.clone());
     }
+
+    // Persist workspace for early launch on next startup
+    write_last_workspace(&workspace_path);
 
     Ok(OpenCodeStatus {
         is_running: true,
@@ -1364,6 +1378,46 @@ pub async fn write_opencode_allowlist(
         rules.len()
     );
     Ok(())
+}
+
+/// Path to the file that persists the last workspace for early launch.
+fn last_workspace_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    std::path::PathBuf::from(home)
+        .join(".teamclaw")
+        .join("last-workspace.json")
+}
+
+/// Read the last workspace path from ~/.teamclaw/last-workspace.json.
+pub fn read_last_workspace() -> Option<String> {
+    let path = last_workspace_path();
+    let content = std::fs::read_to_string(&path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let ws = json.get("workspace_path")?.as_str()?;
+    // Verify the directory still exists
+    if std::path::Path::new(ws).is_dir() {
+        Some(ws.to_string())
+    } else {
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "[EarlyLaunch] Last workspace '{}' no longer exists, skipping",
+            ws
+        );
+        None
+    }
+}
+
+/// Persist the workspace path for next launch.
+fn write_last_workspace(workspace_path: &str) {
+    let path = last_workspace_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let json = serde_json::json!({ "workspace_path": workspace_path });
+    let _ = std::fs::write(
+        &path,
+        serde_json::to_string_pretty(&json).unwrap_or_default(),
+    );
 }
 
 /// Get OpenCode server status

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -270,59 +270,63 @@ pub async fn start_opencode(
     let port_str = port.to_string();
     let workspace_path = config.workspace_path.clone();
 
-    // Ensure opencode.json has a permission section with TeamClaw defaults
-    if let Err(e) = ensure_default_permissions(&workspace_path) {
-        eprintln!(
-            "[OpenCode] Warning: failed to ensure default permissions: {}",
-            e
-        );
-    }
+    // ── Pre-sidecar setup (parallelized) ──────────────────────────────
+    //
+    // Three branches run concurrently via tokio::join!:
+    //   1. opencode.json writers (sequential: permissions → config → binary paths)
+    //   2. ensure_inherent_skills (writes to .opencode/skills/, independent)
+    //   3. read_keyring_secrets (reads OS keyring, independent)
+    //
+    // resolve_config_secret_refs runs AFTER all three complete (depends on
+    // both the config writers finishing and keyring secrets being available).
 
-    // Ensure autoui/playwright MCPs and compass provider are present in opencode.json
-    if let Err(e) = ensure_inherent_config(&workspace_path) {
-        eprintln!(
-            "[OpenCode] Warning: failed to ensure inherent configs: {}",
-            e
-        );
-    }
-
-    // Ensure inherent skills are present in the workspace
-    if let Err(e) = ensure_inherent_skills(&workspace_path) {
-        eprintln!(
-            "[OpenCode] Warning: failed to ensure inherent skills: {}",
-            e
-        );
-    }
-
-    // Pre-process opencode.json before OpenCode reads it:
-    // 1. Fix architecture-specific binary paths for bundled MCP servers
-    // 2. Replace ${KEY} secret references with actual values from OS keyring
-    if let Err(e) = resolve_sidecar_binary_paths(&workspace_path) {
-        eprintln!("[OpenCode] Warning: failed to resolve binary paths: {}", e);
-    }
-
-    // Read secrets from OS keyring using spawn_blocking so that:
-    //  - The blocking keyring I/O runs on a dedicated thread (not a Tokio worker)
-    //  - macOS keychain password dialogs can properly display and block
+    let ws_for_config = workspace_path.clone();
+    let ws_for_skills = workspace_path.clone();
     let ws_for_keyring = workspace_path.clone();
-    let (mut secrets, failed_keys) =
-        tokio::task::spawn_blocking(move || read_keyring_secrets(&ws_for_keyring))
-            .await
-            .unwrap_or_else(|e| {
-                eprintln!("[OpenCode] spawn_blocking for keyring failed: {}", e);
-                (Vec::new(), Vec::new())
-            });
 
-    // If some secrets failed on the first attempt, retry.  The first read may
-    // have triggered the macOS keychain unlock dialog; once the user enters their
-    // password the keychain stays unlocked and the retry should succeed.
+    let (config_result, skills_result, keyring_result) = tokio::join!(
+        // Branch 1: opencode.json writers (must be sequential with each other)
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = ensure_default_permissions(&ws_for_config) {
+                eprintln!("[OpenCode] Warning: failed to ensure default permissions: {}", e);
+            }
+            if let Err(e) = ensure_inherent_config(&ws_for_config) {
+                eprintln!("[OpenCode] Warning: failed to ensure inherent configs: {}", e);
+            }
+            if let Err(e) = resolve_sidecar_binary_paths(&ws_for_config) {
+                eprintln!("[OpenCode] Warning: failed to resolve binary paths: {}", e);
+            }
+        }),
+        // Branch 2: inherent skills (writes to .opencode/skills/, no opencode.json conflict)
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = ensure_inherent_skills(&ws_for_skills) {
+                eprintln!("[OpenCode] Warning: failed to ensure inherent skills: {}", e);
+            }
+        }),
+        // Branch 3: keyring secrets
+        tokio::task::spawn_blocking(move || read_keyring_secrets(&ws_for_keyring))
+    );
+
+    // Unwrap spawn results (panics inside spawn_blocking become JoinErrors)
+    if let Err(e) = config_result {
+        eprintln!("[OpenCode] Config setup task panicked: {}", e);
+    }
+    if let Err(e) = skills_result {
+        eprintln!("[OpenCode] Skills setup task panicked: {}", e);
+    }
+
+    let (mut secrets, failed_keys) = keyring_result.unwrap_or_else(|e| {
+        eprintln!("[OpenCode] spawn_blocking for keyring failed: {}", e);
+        (Vec::new(), Vec::new())
+    });
+
+    // Keyring retry logic (unchanged from original)
     if !failed_keys.is_empty() {
         println!(
             "[OpenCode] {} secret(s) failed to read ({:?}), retrying after keychain unlock...",
             failed_keys.len(),
             failed_keys
         );
-        // Give the user a moment to finish the keychain dialog
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
         let ws_retry = workspace_path.clone();
@@ -342,7 +346,6 @@ pub async fn start_opencode(
             );
         }
 
-        // Use the retry result (it re-reads all secrets, not just the failed ones)
         secrets = retry_secrets;
     }
 

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -114,8 +114,12 @@ pub async fn start_opencode_inner(
     state: &OpenCodeState,
     config: OpenCodeConfig,
 ) -> Result<OpenCodeStatus, String> {
+    #[cfg(debug_assertions)]
+    let inner_t0 = std::time::Instant::now();
     // Serialize concurrent calls — only one start_opencode runs at a time.
     let _start_guard = state.start_lock.lock().await;
+    #[cfg(debug_assertions)]
+    eprintln!("[Startup] start_opencode_inner: lock acquired in {:.1}ms", inner_t0.elapsed().as_secs_f64() * 1000.0);
 
     let is_dev_mode = *state.is_dev_mode.lock().map_err(|e| e.to_string())?;
     let port = config.port.unwrap_or(DEFAULT_PORT);
@@ -402,6 +406,9 @@ pub async fn start_opencode_inner(
         secrets = retry_secrets;
     }
 
+    #[cfg(debug_assertions)]
+    eprintln!("[Startup] Pre-sidecar I/O (parallel): {:.1}ms", inner_t0.elapsed().as_secs_f64() * 1000.0);
+
     let original_config = resolve_config_secret_refs(&workspace_path, &secrets);
 
     println!(
@@ -517,6 +524,9 @@ pub async fn start_opencode_inner(
         let mut workspace_guard = state.workspace_path.lock().map_err(|e| e.to_string())?;
         *workspace_guard = Some(workspace_path.clone());
     }
+
+    #[cfg(debug_assertions)]
+    eprintln!("[Startup] start_opencode_inner TOTAL: {:.1}ms", inner_t0.elapsed().as_secs_f64() * 1000.0);
 
     // Persist workspace for early launch on next startup
     write_last_workspace(&workspace_path);

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -200,6 +200,14 @@ pub const DEFAULT_TEAMCLAW_YAML: &str = r#"llm:
   modelName: "default"
 "#;
 
+/// Build teamclaw.yaml content using provided LLM config, falling back to defaults.
+pub fn build_teamclaw_yaml(base_url: Option<String>, model: Option<String>, model_name: Option<String>) -> String {
+    let base_url = base_url.filter(|s| !s.is_empty()).unwrap_or_else(|| "https://api.openai.com/v1".to_string());
+    let model = model.filter(|s| !s.is_empty()).unwrap_or_else(|| "default".to_string());
+    let model_name = model_name.filter(|s| !s.is_empty()).unwrap_or_else(|| "default".to_string());
+    format!("llm:\n  baseUrl: \"{}\"\n  model: \"{}\"\n  modelName: \"{}\"\n", base_url, model, model_name)
+}
+
 /// The whitelist .gitignore content
 const GITIGNORE_CONTENT: &str = r#"# ============================================
 # TeamClaw Workspace — Whitelist mode
@@ -425,6 +433,9 @@ pub async fn team_check_workspace_has_git(
 pub async fn team_init_repo(
     git_url: String,
     git_token: Option<String>,
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<TeamGitResult, String> {
     let workspace_path = get_workspace_path(&opencode_state)?;
@@ -458,7 +469,8 @@ pub async fn team_init_repo(
     // Write default teamclaw.yaml if the cloned repo doesn't have one
     let teamclaw_yaml_path = Path::new(&team_dir).join("teamclaw.yaml");
     if !teamclaw_yaml_path.exists() {
-        std::fs::write(&teamclaw_yaml_path, DEFAULT_TEAMCLAW_YAML)
+        let yaml_content = build_teamclaw_yaml(llm_base_url, llm_model, llm_model_name);
+        std::fs::write(&teamclaw_yaml_path, &yaml_content)
             .map_err(|e| format!("Failed to write default teamclaw.yaml: {}", e))?;
         println!("[Team Init] Created default teamclaw.yaml with team LLM config");
 

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -182,8 +182,9 @@ fn collect_files(base: &Path, dir: &Path) -> Vec<(String, Vec<u8>)> {
 }
 
 /// Scaffold the teamclaw-team directory with default structure if it doesn't exist or is empty.
-fn scaffold_team_dir(team_dir: &str) -> Result<(), String> {
+fn scaffold_team_dir(team_dir: &str, llm_base_url: Option<String>, llm_model: Option<String>, llm_model_name: Option<String>) -> Result<(), String> {
     let team_path = Path::new(team_dir);
+    let yaml_content = crate::commands::team::build_teamclaw_yaml(llm_base_url, llm_model, llm_model_name);
 
     // Always ensure teamclaw.yaml exists, even if directory already has content
     let teamclaw_yaml_path = team_path.join("teamclaw.yaml");
@@ -192,7 +193,7 @@ fn scaffold_team_dir(team_dir: &str) -> Result<(), String> {
     if !need_scaffold {
         // Directory exists with files, but still ensure teamclaw.yaml is present
         if !teamclaw_yaml_path.exists() {
-            std::fs::write(&teamclaw_yaml_path, crate::commands::team::DEFAULT_TEAMCLAW_YAML)
+            std::fs::write(&teamclaw_yaml_path, &yaml_content)
                 .map_err(|e| format!("Failed to write default teamclaw.yaml: {}", e))?;
             println!("[Team P2P] Created default teamclaw.yaml with team LLM config");
         }
@@ -214,7 +215,7 @@ fn scaffold_team_dir(team_dir: &str) -> Result<(), String> {
 
     // Write default teamclaw.yaml with team LLM config if not present
     if !teamclaw_yaml_path.exists() {
-        std::fs::write(&teamclaw_yaml_path, crate::commands::team::DEFAULT_TEAMCLAW_YAML)
+        std::fs::write(&teamclaw_yaml_path, &yaml_content)
             .map_err(|e| format!("Failed to write default teamclaw.yaml: {}", e))?;
         println!("[Team P2P] Created default teamclaw.yaml with team LLM config");
     }
@@ -229,8 +230,11 @@ pub async fn create_team(
     node: &mut IrohNode,
     team_dir: &str,
     workspace_path: &str,
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
 ) -> Result<String, String> {
-    scaffold_team_dir(team_dir)?;
+    scaffold_team_dir(team_dir, llm_base_url, llm_model, llm_model_name)?;
 
     let node_id = get_node_id(node);
     let info = get_device_metadata();
@@ -419,7 +423,7 @@ pub async fn publish_team_drive(node: &IrohNode, team_dir: &str) -> Result<Strin
         .ok_or("No active team document. Create or join a team first.")?;
 
     let team_path = Path::new(team_dir);
-    scaffold_team_dir(team_dir)?;
+    scaffold_team_dir(team_dir, None, None, None)?;
 
     let files = collect_files(team_path, team_path);
     for (key, content) in &files {
@@ -444,7 +448,7 @@ pub async fn rotate_namespace(
     }
 
     // Re-create as owner
-    create_team(node, team_dir, workspace_path).await
+    create_team(node, team_dir, workspace_path, None, None, None).await
 }
 
 // ─── Background Sync Tasks ──────────────────────────────────────────────
@@ -1061,6 +1065,9 @@ pub async fn p2p_check_team_dir(
 
 #[tauri::command]
 pub async fn p2p_create_team(
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
     iroh_state: tauri::State<'_, IrohState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<String, String> {
@@ -1075,7 +1082,7 @@ pub async fn p2p_create_team(
     let node = guard.as_mut().ok_or("P2P node not running")?;
 
     let team_dir = format!("{}/teamclaw-team", workspace_path);
-    create_team(node, &team_dir, &workspace_path).await
+    create_team(node, &team_dir, &workspace_path, llm_base_url, llm_model, llm_model_name).await
 }
 
 #[tauri::command]
@@ -1097,7 +1104,7 @@ pub async fn p2p_publish_drive(
 
     // If no active doc, create a team (first-time publish)
     if node.active_doc.is_none() {
-        return create_team(node, &team_dir, &workspace_path).await;
+        return create_team(node, &team_dir, &workspace_path, None, None, None).await;
     }
 
     // Otherwise, sync current files into existing doc and return saved ticket
@@ -1443,6 +1450,7 @@ mod tests {
             &mut node,
             team_dir.to_str().unwrap(),
             tmp.path().to_str().unwrap(),
+            None, None, None,
         ).await.unwrap();
 
         assert!(!ticket.is_empty(), "ticket should not be empty");
@@ -1748,6 +1756,7 @@ mod tests {
             &mut node,
             team_dir.to_str().unwrap(),
             workspace,
+            None, None, None,
         ).await.unwrap();
 
         assert!(!ticket.is_empty(), "should return a ticket");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,50 @@ mod stt;
 mod rag;
 mod telemetry;
 
+/// Get the mtime of the user's shell profile file as a u64 (seconds since epoch).
+/// Returns 0 if the file doesn't exist or can't be read.
+fn get_shell_profile_mtime(shell: &str, home: &str) -> u64 {
+    let profile = if shell.ends_with("zsh") {
+        format!("{}/.zshrc", home)
+    } else if shell.ends_with("bash") {
+        format!("{}/.bashrc", home)
+    } else {
+        return 0;
+    };
+    std::fs::metadata(&profile)
+        .and_then(|m| m.modified())
+        .and_then(|t| {
+            t.duration_since(std::time::UNIX_EPOCH)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        })
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Read cached PATH if cache exists and profile mtime matches.
+fn read_path_cache(cache_path: &std::path::Path, current_mtime: u64) -> Option<String> {
+    let content = std::fs::read_to_string(cache_path).ok()?;
+    let mut lines = content.lines();
+    let cached_mtime: u64 = lines.next()?.parse().ok()?;
+    if cached_mtime != current_mtime || current_mtime == 0 {
+        return None;
+    }
+    let path = lines.next()?;
+    if path.is_empty() {
+        return None;
+    }
+    Some(path.to_string())
+}
+
+/// Write PATH cache file. Creates ~/.teamclaw/ if needed.
+fn write_path_cache(cache_path: &std::path::Path, mtime: u64, path: &str) {
+    if let Some(parent) = cache_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let content = format!("{}\n{}", mtime, path);
+    let _ = std::fs::write(cache_path, content);
+}
+
 /// Fix PATH environment variable for GUI apps on macOS/Linux.
 ///
 /// When launched from Dock/Spotlight (not a terminal), GUI apps inherit a minimal
@@ -33,6 +77,18 @@ fn fix_path_env() {
         return;
     }
 
+    // Try cache first
+    let home = std::env::var("HOME").unwrap_or_default();
+    let cache_path = std::path::PathBuf::from(&home).join(".teamclaw").join("cached-path.txt");
+    let profile_mtime = get_shell_profile_mtime(&shell, &home);
+
+    if let Some(cached) = read_path_cache(&cache_path, profile_mtime) {
+        std::env::set_var("PATH", &cached);
+        #[cfg(debug_assertions)]
+        eprintln!("[fix_path_env] PATH set from cache");
+        return;
+    }
+
     // Spawn a login shell to get the full PATH
     let output = std::process::Command::new(&shell)
         .args(["-l", "-c", "echo $PATH"])
@@ -45,6 +101,8 @@ fn fix_path_env() {
                 std::env::set_var("PATH", &full_path);
                 #[cfg(debug_assertions)]
                 eprintln!("[fix_path_env] PATH set to: {}", &full_path);
+                // Write cache (fire-and-forget)
+                write_path_cache(&cache_path, profile_mtime, &full_path);
             }
         }
         _ => {
@@ -125,7 +183,10 @@ pub fn run() {
         .plugin({
             #[cfg(debug_assertions)]
             {
-                tauri_plugin_mcp::init()
+                tauri_plugin_mcp::init_with_config(
+                    tauri_plugin_mcp::PluginConfig::new(String::from("teamclaw"))
+                        .socket_path(std::path::PathBuf::from("/tmp/tauri-mcp.sock"))
+                )
             }
             #[cfg(not(debug_assertions))]
             {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -442,6 +442,41 @@ pub fn run() {
             // since workspace_path is not available at setup time.
             // The frontend calls team_sync_repo on startup when team config is enabled.
 
+            // --- Early sidecar launch ---
+            // Read last workspace and start OpenCode before frontend renders.
+            // The frontend's start_opencode call will reuse this result if the path matches.
+            if std::env::var("TEAMCLAW_DISABLE_EARLY_LAUNCH").unwrap_or_default() != "1" {
+                if let Some(workspace_path) = commands::opencode::read_last_workspace() {
+                    println!("[EarlyLaunch] Starting sidecar for: {}", workspace_path);
+                    let app_handle = app.handle().clone();
+                    let (tx, rx) = tokio::sync::watch::channel(None);
+
+                    // Store the early launch state so start_opencode can find it
+                    let early_state = app_handle.state::<commands::opencode::OpenCodeState>();
+                    {
+                        let mut early = early_state.early_launch.blocking_lock();
+                        *early = Some(commands::opencode::EarlyLaunchState {
+                            workspace_path: workspace_path.clone(),
+                            result_rx: rx,
+                        });
+                    }
+
+                    tauri::async_runtime::spawn(async move {
+                        let state = app_handle.state::<commands::opencode::OpenCodeState>();
+                        let config = commands::opencode::OpenCodeConfig {
+                            workspace_path,
+                            port: None,
+                        };
+                        let result = commands::opencode::start_opencode_inner(
+                            app_handle.clone(),
+                            &state,
+                            config,
+                        ).await;
+                        let _ = tx.send(Some(result));
+                    });
+                }
+            }
+
             // --- System Tray ---
             use tauri::menu::{MenuBuilder, MenuItemBuilder};
             use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -132,8 +132,13 @@ fn fix_path_env() {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(debug_assertions)]
+    let startup_t0 = std::time::Instant::now();
+
     // Fix PATH before anything else so all child processes can find tools
     fix_path_env();
+    #[cfg(debug_assertions)]
+    eprintln!("[Startup] fix_path_env: {:.1}ms", startup_t0.elapsed().as_secs_f64() * 1000.0);
 
     // Create RagState (HTTP server will be started in setup hook)
     let rag_state = commands::knowledge::RagState::default();
@@ -410,6 +415,9 @@ pub fn run() {
             commands::team_webdav::get_team_mode,
         ])
         .setup(|app| {
+            #[cfg(debug_assertions)]
+            let setup_t0 = std::time::Instant::now();
+
             // Start RAG HTTP API server for MCP bridge
             let rag_state_handle = app.handle().state::<commands::knowledge::RagState>();
             let rag_state_for_http = std::sync::Arc::new(rag_state_handle.inner().clone());
@@ -441,6 +449,9 @@ pub fn run() {
             // Team sync will be triggered from the frontend after workspace is set,
             // since workspace_path is not available at setup time.
             // The frontend calls team_sync_repo on startup when team config is enabled.
+
+            #[cfg(debug_assertions)]
+            eprintln!("[Startup] Setup hook (before early launch): {:.1}ms", setup_t0.elapsed().as_secs_f64() * 1000.0);
 
             // --- Early sidecar launch ---
             // Read last workspace and start OpenCode before frontend renders.


### PR DESCRIPTION
## Summary

- **PATH caching**: Cache `fix_path_env()` result to `~/.teamclaw/cached-path.txt`, keyed by shell profile mtime. Eliminates ~50-200ms shell spawn on subsequent launches (1.5ms cache hit).
- **Parallel pre-sidecar I/O**: Run `ensure_inherent_skills` and `read_keyring_secrets` in parallel with the `opencode.json` config writers via `tokio::join!`.
- **Early sidecar launch**: Start OpenCode sidecar from Rust setup hook (before frontend renders) using persisted workspace path. Frontend `start_opencode` reuses the in-flight result via `watch` channel.
- **Remove 300ms frontend delay**: Eliminate unnecessary `setTimeout` in `useOpenCodeInit`.
- **Defer dependency check**: Postpone `checkDependencies()` until after OpenCode is ready, reducing CPU contention during startup.

### Measured results (dev build)

| Phase | Time |
|-------|------|
| `fix_path_env()` (cache hit) | 1.5ms |
| Setup hook → early launch | 0.5ms |
| Pre-sidecar I/O (parallel) | ~50ms (normal) |
| `start_opencode_inner` total | ~2.5s (sidecar inherent) |
| Frontend invoke | 0ms (reuses early launch) |

Debug-only timing logs added via `#[cfg(debug_assertions)]`.

## Test plan

- [ ] Fresh install: delete `~/.teamclaw/last-workspace.json` + `cached-path.txt`, verify workspace prompt appears
- [ ] Normal restart: verify early launch kicks in, app starts faster
- [ ] Workspace switch: verify new workspace loads correctly
- [ ] Deleted workspace in cache: verify graceful fallback
- [ ] Dev mode (`OPENCODE_DEV_MODE=true`): verify still works
- [ ] Early launch disabled (`TEAMCLAW_DISABLE_EARLY_LAUNCH=1`): verify normal flow
- [ ] Cross-platform: verify builds on macOS/Linux/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)