### PR TITLE
fix(wecom): fix error message layout and image MIME type detection

### DIFF
--- a/packages/app/src/components/settings/channels/TestCredentialsButton.tsx
+++ b/packages/app/src/components/settings/channels/TestCredentialsButton.tsx
@@ -49,16 +49,16 @@ export function TestCredentialsButton({
       </Button>
       {testResult && (
         <div className={cn(
-          "flex items-center gap-2 text-sm mt-2",
+          "flex items-start gap-2 text-sm mt-2 w-full basis-full",
           testResult.success ? "text-emerald-600" : "text-red-600"
         )}>
           {testResult.success ? (
-            <CheckCircle2 className="h-4 w-4" />
+            <CheckCircle2 className="h-4 w-4 flex-shrink-0 mt-0.5" />
           ) : (
-            <AlertCircle className="h-4 w-4" />
+            <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
           )}
-          {testResult.message}
-          <Button variant="ghost" size="sm" className="h-4 w-4 p-0" onClick={onClearResult}>
+          <span className="break-words min-w-0">{testResult.message}</span>
+          <Button variant="ghost" size="sm" className="h-4 w-4 p-0 flex-shrink-0" onClick={onClearResult}>
             <X className="h-3 w-3" />
           </Button>
         </div>

--- a/packages/app/src/components/settings/channels/Wecom.tsx
+++ b/packages/app/src/components/settings/channels/Wecom.tsx
@@ -469,7 +469,7 @@ export function WeComChannel() {
             </div>
             <div className="space-y-1">
               <label className="text-xs text-muted-foreground">{t('settings.channels.wecom.secret', 'Secret')}</label>
-              <div className="flex gap-2">
+              <div className="flex flex-wrap gap-2">
                 <div className="relative flex-1">
                   <Input
                     type="password"

--- a/src-tauri/src/commands/gateway/wecom.rs
+++ b/src-tauri/src/commands/gateway/wecom.rs
@@ -7,6 +7,26 @@ use futures_util::stream::SplitSink;
 use super::session::SessionMapping;
 use super::wecom_config::{WeComConfig, WeComGatewayStatus, WeComGatewayStatusResponse};
 
+/// Detect image MIME type from file magic bytes
+fn detect_image_mime(bytes: &[u8]) -> Option<String> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        Some("image/jpeg".into())
+    } else if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
+        Some("image/png".into())
+    } else if bytes.starts_with(b"GIF8") {
+        Some("image/gif".into())
+    } else if bytes.starts_with(b"RIFF") && bytes.len() >= 12 && &bytes[8..12] == b"WEBP" {
+        Some("image/webp".into())
+    } else if bytes.starts_with(b"BM") {
+        Some("image/bmp".into())
+    } else {
+        None
+    }
+}
+
 type WsSink = Arc<tokio::sync::Mutex<SplitSink<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
     tokio_tungstenite::tungstenite::Message,
@@ -646,7 +666,7 @@ impl WeComGateway {
         }
 
         // Detect MIME from Content-Type header or default to image/png
-        let content_type = resp
+        let header_type = resp
             .headers()
             .get("content-type")
             .and_then(|v| v.to_str().ok())
@@ -660,6 +680,13 @@ impl WeComGateway {
             .bytes()
             .await
             .map_err(|e| format!("Failed to read body: {}", e))?;
+
+        // If Content-Type is generic octet-stream, detect actual image type from magic bytes
+        let content_type = if header_type == "application/octet-stream" {
+            detect_image_mime(&bytes).unwrap_or_else(|| header_type)
+        } else {
+            header_type
+        };
 
         println!("[WeCom] Downloaded image: {} bytes, mime={}", bytes.len(), content_type);
 


### PR DESCRIPTION
## Summary
- **Error message layout**: Fix TestCredentialsButton error text breaking the Secret field layout — error message now wraps below the input+button row instead of appearing inline
- **Image MIME detection**: When WeCom returns `application/octet-stream` for images, detect actual type (JPEG/PNG/GIF/WebP/BMP) from file magic bytes, fixing `AI_UnsupportedFunctionalityError`

## Test plan
- [ ] Enter invalid WeCom secret and click 测试, verify error message displays below the input row without breaking layout
- [ ] Send an image through WeCom and verify it's processed correctly without `application/octet-stream` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)