### PR TITLE
feat: add hidden dev mode for team mode

### DIFF
--- a/packages/app/src/components/chat/ChatInputArea.tsx
+++ b/packages/app/src/components/chat/ChatInputArea.tsx
@@ -151,6 +151,7 @@ export function ChatInputArea({
 
   // Team mode
   const teamMode = useTeamModeStore(s => s.teamMode);
+  const devUnlocked = useTeamModeStore(s => s.devUnlocked);
 
   // Model selector
   const [modelSelectorOpen, setModelSelectorOpen] = React.useState(false);
@@ -408,7 +409,7 @@ export function ChatInputArea({
                 Plan
               </Button>
 
-              {!teamMode && selectedModelOption?.provider !== 'team' && (
+              {(!teamMode || devUnlocked) && selectedModelOption?.provider !== 'team' && (
                 <ModelSelector
                   open={modelSelectorOpen}
                   onOpenChange={setModelSelectorOpen}

--- a/packages/app/src/components/chat/FileMentionPopover.tsx
+++ b/packages/app/src/components/chat/FileMentionPopover.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { File, Folder, Loader2 } from "lucide-react"
 import { useWorkspaceStore } from "@/stores/workspace"
+import { useTeamModeStore } from "@/stores/team-mode"
 import { isTauri } from "@/lib/utils"
 import { cn } from "@/lib/utils"
 
@@ -12,11 +13,19 @@ interface FileMentionPopoverProps {
   onSelect: (relativePath: string) => void
 }
 
-const IGNORED_NAMES = new Set([
+const ALWAYS_IGNORED_NAMES = new Set([
   "node_modules", ".git", ".DS_Store", "dist", "build", ".next",
   "__pycache__", ".cache", ".turbo", "target", ".idea", ".vscode",
-  ".teamclaw", ".opencode", ".ruff_cache",
+  ".ruff_cache",
 ])
+
+const DEV_ONLY_NAMES = new Set([".teamclaw", ".opencode"])
+
+function isIgnoredName(name: string): boolean {
+  if (ALWAYS_IGNORED_NAMES.has(name)) return true
+  if (DEV_ONLY_NAMES.has(name) && !useTeamModeStore.getState().devUnlocked) return true
+  return false
+}
 
 interface FlatEntry {
   name: string
@@ -54,7 +63,7 @@ async function scanRecursive(
   }
 
   const sorted = [...raw]
-    .filter(e => e.name && !IGNORED_NAMES.has(e.name))
+    .filter(e => e.name && !isIgnoredName(e.name))
     .sort((a, b) => {
       if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1
       return (a.name || "").localeCompare(b.name || "")

--- a/packages/app/src/components/settings/AboutSection.tsx
+++ b/packages/app/src/components/settings/AboutSection.tsx
@@ -18,6 +18,8 @@ import { useAppVersion } from "@/lib/version";
 import { Button } from "@/components/ui/button";
 import { SettingCard, SectionHeader } from "./shared";
 import { openExternalUrl } from "@/lib/utils";
+import { useTeamModeStore } from "@/stores/team-mode";
+import { toast } from "sonner";
 
 export const AboutSection = React.memo(function AboutSection() {
   const { t } = useTranslation();
@@ -25,6 +27,10 @@ export const AboutSection = React.memo(function AboutSection() {
   const update = useUpdaterStore((s) => s.update);
   const checkForUpdates = useUpdaterStore((s) => s.checkForUpdates);
   const installUpdate = useUpdaterStore((s) => s.installUpdate);
+  const devUnlocked = useTeamModeStore((s) => s.devUnlocked);
+  const setDevUnlocked = useTeamModeStore((s) => s.setDevUnlocked);
+  const devClickCount = React.useRef(0);
+  const devClickTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const isChecking = update.state === "checking";
   const isAvailable = update.state === "available";
@@ -55,7 +61,22 @@ export const AboutSection = React.memo(function AboutSection() {
             />
             <div>
               <h4 className="font-semibold text-lg">TeamClaw</h4>
-              <p className="text-sm text-muted-foreground">
+              <p
+                className="text-sm text-muted-foreground select-none cursor-default"
+                onClick={() => {
+                  if (devUnlocked) return;
+                  devClickCount.current += 1;
+                  if (devClickTimer.current) clearTimeout(devClickTimer.current);
+                  devClickTimer.current = setTimeout(() => {
+                    devClickCount.current = 0;
+                  }, 2000);
+                  if (devClickCount.current >= 3) {
+                    devClickCount.current = 0;
+                    setDevUnlocked(true);
+                    toast.success('Dev mode unlocked');
+                  }
+                }}
+              >
                 Version {appVersion}
               </p>
             </div>

--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -37,6 +37,7 @@ export const LLMSection = React.memo(function LLMSection() {
   const { t } = useTranslation()
   const teamMode = useTeamModeStore((s) => s.teamMode)
   const teamModelConfig = useTeamModeStore((s) => s.teamModelConfig)
+  const devUnlocked = useTeamModeStore((s) => s.devUnlocked)
   const providers = useProviderStore((s) => s.providers)
   const providersLoading = useProviderStore((s) => s.providersLoading)
   const configuredProviders = useProviderStore((s) => s.configuredProviders)
@@ -298,7 +299,7 @@ export const LLMSection = React.memo(function LLMSection() {
     }
   }
 
-  if (teamMode) {
+  if (teamMode && !devUnlocked) {
     return (
       <div className="space-y-6">
         <SectionHeader

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -22,11 +22,13 @@ interface TeamModeState {
   teamModelConfig: TeamModelConfig | null
   teamApiKey: string | null // user-overridden key, null = use NodeId
   _appliedConfigKey: string | null // fingerprint of last applied config to avoid redundant apply
+  devUnlocked: boolean // hidden dev mode: unlocks model selector & hidden dirs in team mode
 
   loadTeamConfig: (workspacePath: string) => Promise<void>
   applyTeamModelToOpenCode: (workspacePath: string) => Promise<void>
   setTeamApiKey: (key: string | null, workspacePath?: string) => Promise<void>
   clearTeamMode: (workspacePath?: string) => Promise<void>
+  setDevUnlocked: (unlocked: boolean) => void
 }
 
 interface TeamStatusResponse {
@@ -57,6 +59,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   teamMode: false,
   teamModelConfig: null,
   _appliedConfigKey: null,
+  devUnlocked: false,
   teamApiKey: (() => {
     try {
       return localStorage.getItem(TEAM_API_KEY_STORAGE) || null
@@ -179,6 +182,10 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
         await providerStore.connectProvider(TEAM_PROVIDER_ID, apiKey)
       }
     }
+  },
+
+  setDevUnlocked: (unlocked: boolean) => {
+    set({ devUnlocked: unlocked })
   },
 
   clearTeamMode: async (workspacePath?: string) => {

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { UNSUPPORTED_BINARY_EXTENSIONS } from "@/components/viewers/UnsupportedFileViewer";
 import { isTauri } from '@/lib/utils'
 import { ensureGitignoreEntries } from '@/lib/gitignore-manager'
+import { useTeamModeStore } from './team-mode'
 
 // Directories to hide from file tree (system directories)
 const HIDDEN_DIRECTORIES = new Set(['.teamclaw', '.opencode'])
@@ -370,7 +371,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       console.log("[Workspace] Found", entries.length, "entries");
 
       const nodes: FileNode[] = entries
-        .filter(entry => !HIDDEN_DIRECTORIES.has(entry.name))
+        .filter(entry => useTeamModeStore.getState().devUnlocked || !HIDDEN_DIRECTORIES.has(entry.name))
         .map(
           (entry) =>
             ({


### PR DESCRIPTION
## Summary
- 在设置页 About 区域的版本号上连续点击 3 次，可解锁隐藏的 dev 模式
- 解锁后：模型选择器显示在输入框旁、LLM 设置恢复完整 provider 管理界面、文件树显示 `.teamclaw` 和 `.opencode` 目录
- 纯内存状态，应用重启后自动恢复锁定

## Changes
- `stores/team-mode.ts` — 新增 `devUnlocked` 状态和 `setDevUnlocked` action
- `components/settings/AboutSection.tsx` — 版本号点击计数触发 + toast 提示
- `components/chat/ChatInputArea.tsx` — 模型选择器条件加 `|| devUnlocked`
- `components/settings/LLMSection.tsx` — LLM 设置条件加 `&& !devUnlocked`
- `stores/workspace.ts` — 文件树过滤跳过隐藏目录
- `components/chat/FileMentionPopover.tsx` — 文件提及过滤跳过隐藏目录

## Test plan
- [ ] 团队模式下，确认模型选择器和 LLM 设置默认不可见
- [ ] 进入设置 > About，连续点击版本号 3 次，确认出现 "Dev mode unlocked" toast
- [ ] 解锁后，确认模型选择器出现、LLM 设置可配置、文件树显示 .teamclaw 和 .opencode
- [ ] 重启应用后，确认 dev 模式已恢复锁定

🤖 Generated with [Claude Code](https://claude.ai/code)