### PR TITLE
fix(chat): reliable session abort (stop button)

### DIFF
--- a/packages/app/src/lib/opencode/client.ts
+++ b/packages/app/src/lib/opencode/client.ts
@@ -181,7 +181,39 @@ export class OpenCodeClient {
   }
 
   async abortSession(id: string): Promise<boolean> {
-    return this.request<boolean>('POST', `/session/${id}/abort`)
+    // Abort endpoint may return 200/202/204 with empty body in some OpenCode versions.
+    // Use a tolerant parser here instead of generic JSON-only request().
+    const url = this.buildUrl(`/session/${id}/abort`)
+    let response: Response
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: this.getHeaders(),
+      })
+    } catch {
+      throw new Error(`Cannot connect to OpenCode server (${this.baseUrl}). Please make sure OpenCode server is running.`)
+    }
+
+    if (!response.ok) {
+      const contentType = response.headers.get('content-type') || ''
+      if (contentType.includes('application/json')) {
+        try {
+          const data = await response.json()
+          if (data?.success === false && data?.error) {
+            const errorMessage = Array.isArray(data.error)
+              ? data.error.map((e: { message?: string }) => e.message).join(', ')
+              : String(data.error)
+            throw new Error(`OpenCode API Error: ${errorMessage}`)
+          }
+        } catch {
+          // Fall through to generic status error below.
+        }
+      }
+      throw new Error(`OpenCode API Error: ${response.status}`)
+    }
+
+    // 204/empty body is considered success for abort.
+    return true
   }
 
   // Message APIs

--- a/packages/app/src/stores/session-messages.ts
+++ b/packages/app/src/stores/session-messages.ts
@@ -18,6 +18,7 @@ import {
 } from "./session-internals";
 import {
   useStreamingStore,
+  cleanupAllChildSessions,
 } from "@/stores/streaming";
 import { insertMessageSorted } from "@/lib/insert-message-sorted";
 
@@ -319,16 +320,32 @@ export function createMessageActions(set: SessionSet, get: SessionGet) {
     // Abort the current session's operation
     abortSession: async () => {
       const { activeSessionId } = get();
-      const { streamingMessageId } = useStreamingStore.getState();
-      if (!activeSessionId || !streamingMessageId) return;
+      if (!activeSessionId) return;
+      const { streamingMessageId, childSessionStreaming } = useStreamingStore.getState();
+      const childSessionIds = Object.entries(childSessionStreaming || {})
+        .filter(([, state]) => state.isStreaming)
+        .map(([sessionId]) => sessionId);
+
+      if (!streamingMessageId && childSessionIds.length === 0) return;
 
       try {
         clearMessageTimeout();
         const client = getOpenCodeClient();
-        await client.abortSession(activeSessionId);
+        const sessionIdsToAbort = Array.from(new Set([activeSessionId, ...childSessionIds]));
+        const abortResults = await Promise.allSettled(
+          sessionIdsToAbort.map((sessionId) => client.abortSession(sessionId)),
+        );
+        const failedAborts = abortResults.filter((r) => r.status === "rejected");
+        if (failedAborts.length > 0) {
+          console.warn("[Session] Some abort requests failed:", failedAborts.length);
+        }
 
         useStreamingStore.getState().clearStreaming();
+        cleanupAllChildSessions();
         set((state) => ({
+          pendingQuestion: null,
+          pendingPermission: null,
+          pendingPermissionChildSessionId: null,
           sessions: state.sessions.map((s) => ({
             ...s,
             messages: s.messages.map((m) =>
@@ -349,6 +366,8 @@ export function createMessageActions(set: SessionSet, get: SessionGet) {
           }
         }, 500);
       } catch (error) {
+        useStreamingStore.getState().clearStreaming();
+        cleanupAllChildSessions();
         set({
           error:
             error instanceof Error ? error.message : "Failed to abort session",


### PR DESCRIPTION
## Summary
Fixes cases where clicking **Stop** during chat appeared to do nothing.

## Changes
- **OpenCodeClient.abortSession**: Handle abort endpoint with dedicated etch so **204 No Content** or empty bodies no longer fail JSON parsing.
- **bortSession (session store)**: Abort parent + streaming child sessions; clear pending question/permission; cleanup child SSE state on success or failure.

## Testing
- pnpm --filter @teamclaw/app test:unit -- src/stores/__tests__/session-messages-behavior.test.ts

Branch rebased onto current upstream/main.

Made with [Cursor](https://cursor.com)