### PR TITLE
feat: macOS install script and release instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,27 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "TeamClaw ${{ github.ref_name }}"
-          releaseBody: "See the assets to download and install TeamClaw."
+          releaseBody: |
+            ## Installation
+
+            ### macOS (one-line install)
+            ```bash
+            curl -fsSL https://raw.githubusercontent.com/diffrent-ai-studio/teamclaw/main/scripts/install-mac.sh | bash
+            ```
+
+            ### macOS (manual)
+            1. Download the `.dmg` file below
+            2. Open the DMG and drag TeamClaw to Applications
+            3. Before opening, run in Terminal:
+               ```
+               sudo xattr -dr com.apple.quarantine /Applications/Teamclaw.app
+               ```
+            4. Open TeamClaw from Applications
+
+            > **Why is this needed?** TeamClaw is not yet notarized with Apple. macOS blocks unsigned apps downloaded from the internet. The command above removes this restriction.
+
+            ### Windows
+            Download and run the `.exe` installer below.
           releaseDraft: false
           prerelease: false
           args: "--target aarch64-apple-darwin"
@@ -260,7 +280,27 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "TeamClaw ${{ github.ref_name }}"
-          releaseBody: "See the assets to download and install TeamClaw."
+          releaseBody: |
+            ## Installation
+
+            ### macOS (one-line install)
+            ```bash
+            curl -fsSL https://raw.githubusercontent.com/diffrent-ai-studio/teamclaw/main/scripts/install-mac.sh | bash
+            ```
+
+            ### macOS (manual)
+            1. Download the `.dmg` file below
+            2. Open the DMG and drag TeamClaw to Applications
+            3. Before opening, run in Terminal:
+               ```
+               sudo xattr -dr com.apple.quarantine /Applications/Teamclaw.app
+               ```
+            4. Open TeamClaw from Applications
+
+            > **Why is this needed?** TeamClaw is not yet notarized with Apple. macOS blocks unsigned apps downloaded from the internet. The command above removes this restriction.
+
+            ### Windows
+            Download and run the `.exe` installer below.
           releaseDraft: false
           prerelease: false
           # Windows: NSIS installer, no p2p feature (avoids wmi/windows-core conflicts)

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="diffrent-ai-studio/teamclaw"
+APP_NAME="TeamClaw"
+MOUNT_POINT="/Volumes/${APP_NAME}"
+
+echo "Installing ${APP_NAME}..."
+
+# Get latest release DMG URL
+DMG_URL=$(curl -sL "https://api.github.com/repos/${REPO}/releases/latest" \
+  | grep -o '"browser_download_url":\s*"[^"]*\.dmg"' \
+  | head -1 \
+  | cut -d'"' -f4)
+
+if [ -z "$DMG_URL" ]; then
+  echo "Error: Could not find DMG in latest release"
+  exit 1
+fi
+
+echo "Downloading from: ${DMG_URL}"
+DMG_FILE=$(mktemp /tmp/teamclaw-XXXXXX.dmg)
+curl -L --progress-bar -o "$DMG_FILE" "$DMG_URL"
+
+# Unmount if already mounted
+if [ -d "$MOUNT_POINT" ]; then
+  hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+fi
+
+echo "Mounting DMG..."
+hdiutil attach "$DMG_FILE" -quiet -nobrowse
+
+# Find .app in mounted volume
+APP_PATH=$(find "$MOUNT_POINT" -maxdepth 1 -name "*.app" -type d | head -1)
+if [ -z "$APP_PATH" ]; then
+  echo "Error: No .app found in DMG"
+  hdiutil detach "$MOUNT_POINT" -quiet
+  rm -f "$DMG_FILE"
+  exit 1
+fi
+
+# Close app if running
+if pgrep -x "$APP_NAME" >/dev/null 2>&1; then
+  echo "Closing running ${APP_NAME}..."
+  osascript -e "tell application \"${APP_NAME}\" to quit" 2>/dev/null || true
+  sleep 2
+fi
+
+echo "Installing to /Applications..."
+rm -rf "/Applications/${APP_NAME}.app"
+cp -R "$APP_PATH" /Applications/
+
+# Remove quarantine attribute
+xattr -dr com.apple.quarantine "/Applications/${APP_NAME}.app" 2>/dev/null || true
+
+# Cleanup
+hdiutil detach "$MOUNT_POINT" -quiet
+rm -f "$DMG_FILE"
+
+echo ""
+echo "${APP_NAME} installed successfully!"
+echo "Opening ${APP_NAME}..."
+open "/Applications/${APP_NAME}.app"


### PR DESCRIPTION
## Summary
- Added `scripts/install-mac.sh` — one-line install script that downloads latest DMG, installs to /Applications, removes quarantine, and launches the app
- Updated GitHub Release notes (both macOS and Windows jobs) with installation instructions including the `xattr` workaround

## Context
macOS quarantines apps downloaded from the internet that aren't notarized with Apple. Since we don't have an Apple Developer ID, users must manually remove the quarantine attribute. This PR makes that process easier.

## Test plan
- [ ] Verify release workflow YAML is valid
- [ ] Tag a release and confirm Release notes render correctly
- [ ] Test `curl ... | bash` install script on a clean Mac

🤖 Generated with [Claude Code](https://claude.ai/code)