### PR TITLE
feat(analytics): integrate Aptabase for DAU and usage tracking

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-notification = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-aptabase = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 indexmap = { version = "2", features = ["serde"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -81,6 +81,7 @@
     "core:window:allow-is-visible",
     "global-shortcut:allow-register",
     "global-shortcut:allow-is-registered",
-    "process:allow-restart"
+    "process:allow-restart",
+    "aptabase:allow-track-event"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 
 use tauri::Manager;
 use tauri_plugin_global_shortcut::{Code, Modifiers, ShortcutState};
+use tauri_plugin_aptabase::EventTracker;
 
 mod commands;
 mod stt;
@@ -170,6 +171,7 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_aptabase::Builder::new("A-US-9094113207").build())
         .plugin({
             // Configure global shortcuts for Spotlight.
             // Errors in shortcut registration should not abort app startup, so we
@@ -812,18 +814,30 @@ pub fn run() {
                 });
             }
 
+            // Track app_started (always, regardless of consent)
+            app.handle().track_event("app_started", Some(serde_json::json!({
+                "version": env!("CARGO_PKG_VERSION"),
+                "platform": std::env::consts::OS,
+            })));
+
             Ok(())
         })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|_app, _event| {
-            // macOS: clicking the Dock icon when all windows are hidden should show the main window
-            #[cfg(target_os = "macos")]
-            if let tauri::RunEvent::Reopen { has_visible_windows, .. } = _event {
-                if !has_visible_windows {
-                    let state = _app.state::<commands::spotlight::SpotlightState>();
-                    commands::spotlight::show_main_window(_app.clone(), state);
+        .run(|app, event| {
+            match event {
+                #[cfg(target_os = "macos")]
+                tauri::RunEvent::Reopen { has_visible_windows, .. } => {
+                    if !has_visible_windows {
+                        let state = app.state::<commands::spotlight::SpotlightState>();
+                        commands::spotlight::show_main_window(app.clone(), state);
+                    }
                 }
+                tauri::RunEvent::Exit => {
+                    app.track_event("app_exited", None);
+                    app.flush_events_blocking();
+                }
+                _ => {}
             }
         });
 }

--- a/src-tauri/src/telemetry/commands.rs
+++ b/src-tauri/src/telemetry/commands.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tauri_plugin_aptabase::EventTracker;
+use serde_json::json;
 
 /// Managed state wrapper for TelemetryDb.
 pub struct TelemetryState {
@@ -78,12 +80,23 @@ pub async fn telemetry_set_consent(
 #[tauri::command]
 pub async fn telemetry_set_feedback(
     state: tauri::State<'_, TelemetryState>,
+    app_handle: tauri::AppHandle,
     session_id: String,
     message_id: String,
     rating: String,
 ) -> Result<(), String> {
     let db = get_db(&state).await?;
-    db.set_feedback(&session_id, &message_id, &rating).await
+    db.set_feedback(&session_id, &message_id, &rating).await?;
+
+    // Track analytics event (consent-gated)
+    let consent = db.get_consent().await.unwrap_or_default();
+    if consent == "granted" {
+        app_handle.track_event("feedback_given", Some(json!({
+            "rating": rating,
+        })));
+    }
+
+    Ok(())
 }
 
 #[tauri::command]
@@ -132,10 +145,27 @@ pub async fn telemetry_remove_star_rating(
 #[tauri::command]
 pub async fn telemetry_save_report(
     state: tauri::State<'_, TelemetryState>,
+    app_handle: tauri::AppHandle,
     report: SessionReport,
 ) -> Result<(), String> {
     let db = get_db(&state).await?;
-    db.save_report(&report).await
+    db.save_report(&report).await?;
+
+    // Track analytics events (consent-gated)
+    let consent = db.get_consent().await.unwrap_or_default();
+    if consent == "granted" {
+        app_handle.track_event("session_created", Some(json!({
+            "model_id": report.model_id.as_deref().unwrap_or("unknown"),
+            "provider_id": report.provider_id.as_deref().unwrap_or("unknown"),
+            "agent": report.agent.as_deref().unwrap_or("none"),
+            "tokens_input": report.total_tokens_input,
+            "tokens_output": report.total_tokens_output,
+            "tokens_reasoning": report.total_tokens_reasoning,
+            "cost": report.total_cost,
+        })));
+    }
+
+    Ok(())
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary

- Integrate `tauri-plugin-aptabase` v1.0 for anonymous usage analytics (Aptabase Cloud)
- Track `app_started`/`app_exited` lifecycle events (always, regardless of consent)
- Track `session_created` and `feedback_given` business events (consent-gated)
- All tracking happens on Rust side only — no frontend JS SDK needed

## Events

| Event | Properties | Consent |
|-------|-----------|---------|
| `app_started` | version, platform | Always |
| `app_exited` | — | Always |
| `session_created` | model_id, provider_id, agent, tokens, cost | Required |
| `feedback_given` | rating | Required |

## Changes (4 files, +56/-10)

- `Cargo.toml` — added `tauri-plugin-aptabase = "1.0"`
- `lib.rs` — registered plugin, `app_started` in setup(), `app_exited` in RunEvent::Exit
- `capabilities/default.json` — added `aptabase:allow-track-event` permission
- `telemetry/commands.rs` — consent-gated tracking in `telemetry_save_report` and `telemetry_set_feedback`

## Test plan

- [ ] Build and run app, verify `app_started` appears in Aptabase dashboard
- [ ] Grant consent, trigger session + feedback, verify `session_created` and `feedback_given` events
- [ ] Deny consent, verify only lifecycle events appear
- [ ] Quit app, verify `app_exited` appears

## Spec

`docs/superpowers/specs/2026-03-23-aptabase-analytics-design.md`

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)