### PR TITLE
feat(cron): add worktree isolation for scheduled jobs

### DIFF
--- a/packages/app/src/components/settings/cron/CronHistoryDialog.tsx
+++ b/packages/app/src/components/settings/cron/CronHistoryDialog.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   History,
   Send,
+  GitBranch,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -78,6 +79,13 @@ function RunRecordCard({ run }: { run: CronRunRecord }) {
         <p className="text-xs text-muted-foreground">
           <Send className="h-3 w-3 inline mr-1" />
           {run.deliveryStatus}
+        </p>
+      )}
+
+      {run.worktreePath && (
+        <p className="text-xs text-muted-foreground">
+          <GitBranch className="h-3 w-3 inline mr-1" />
+          {run.worktreePath}
         </p>
       )}
 

--- a/packages/app/src/components/settings/cron/CronJobDialog.tsx
+++ b/packages/app/src/components/settings/cron/CronJobDialog.tsx
@@ -10,6 +10,7 @@ import {
   Timer,
   Zap,
   Send,
+  GitBranch,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -460,6 +461,35 @@ export function CronJobDialog({
                   {t('settings.cron.timeoutHint', 'Max time for AI to respond. Auto-aborts if exceeded (30-900s, default 180s).')}
                 </p>
               </div>
+
+              {/* Worktree isolation */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <label className="text-sm font-medium">{t('settings.cron.useWorktree', 'Run in isolated worktree')}</label>
+                  <p className="text-xs text-muted-foreground">
+                    {t('settings.cron.useWorktreeDesc', 'Execute in a temporary git worktree copy')}
+                  </p>
+                </div>
+                <ToggleSwitch
+                  enabled={form.useWorktree}
+                  onChange={(v) => update({ useWorktree: v })}
+                />
+              </div>
+
+              {form.useWorktree && (
+                <div className="space-y-2 pl-4 border-l-2 border-muted">
+                  <label className="text-sm font-medium flex items-center gap-1.5">
+                    <GitBranch className="h-3.5 w-3.5" />
+                    {t('settings.cron.worktreeBranch', 'Branch')}
+                  </label>
+                  <Input
+                    value={form.worktreeBranch}
+                    onChange={(e) => update({ worktreeBranch: e.target.value })}
+                    placeholder={t('settings.cron.worktreeBranchPlaceholder', 'main')}
+                    className="font-mono text-xs"
+                  />
+                </div>
+              )}
             </div>
 
             {/* Section 4: Delivery */}

--- a/packages/app/src/lib/cron-utils.ts
+++ b/packages/app/src/lib/cron-utils.ts
@@ -244,6 +244,8 @@ export interface JobFormState {
   deliveryBestEffort: boolean
   deleteAfterRun: boolean
   runImmediately: boolean
+  useWorktree: boolean
+  worktreeBranch: string
 }
 
 export const defaultFormState: JobFormState = {
@@ -266,6 +268,8 @@ export const defaultFormState: JobFormState = {
   deliveryBestEffort: true,
   deleteAfterRun: false,
   runImmediately: true,
+  useWorktree: false,
+  worktreeBranch: '',
 }
 
 export function jobToFormState(job: CronJob): JobFormState {
@@ -312,6 +316,8 @@ export function jobToFormState(job: CronJob): JobFormState {
     deliveryBestEffort: job.delivery?.bestEffort ?? true,
     deleteAfterRun: job.deleteAfterRun,
     runImmediately: false,
+    useWorktree: job.payload.useWorktree ?? false,
+    worktreeBranch: job.payload.worktreeBranch ?? '',
   }
 }
 
@@ -353,6 +359,8 @@ export function formStateToPayload(form: JobFormState): CronPayload {
     message: form.message,
     model: form.model || undefined,
     timeoutSeconds: form.timeoutSeconds !== 180 ? form.timeoutSeconds : undefined,
+    useWorktree: form.useWorktree || undefined,
+    worktreeBranch: form.useWorktree && form.worktreeBranch ? form.worktreeBranch : undefined,
   }
 }
 

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1111,7 +1111,11 @@
       "newJob": "New Job",
       "noJobs": "No scheduled jobs yet",
       "noJobsDesc": "Create your first automated task to have your AI agent perform actions on a schedule. For example, check your approval platform every 30 minutes.",
-      "createFirstJob": "Create Your First Job"
+      "createFirstJob": "Create Your First Job",
+      "useWorktree": "Run in isolated worktree",
+      "useWorktreeDesc": "Execute in a temporary git worktree copy",
+      "worktreeBranch": "Branch",
+      "worktreeBranchPlaceholder": "main"
     },
     "team": {
       "checkingWorkspace": "Checking workspace...",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1135,7 +1135,11 @@
       "newJob": "新建作业",
       "noJobs": "暂无定时作业",
       "noJobsDesc": "创建您的第一个自动化任务，让 AI 助手按计划执行操作。例如，每 30 分钟检查一次审批平台。",
-      "createFirstJob": "创建您的第一个作业"
+      "createFirstJob": "创建您的第一个作业",
+      "useWorktree": "在隔离工作树中运行",
+      "useWorktreeDesc": "在临时 git worktree 副本中执行",
+      "worktreeBranch": "分支",
+      "worktreeBranchPlaceholder": "main"
     },
     "team": {
       "checkingWorkspace": "检查工作区...",

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -18,6 +18,8 @@ export interface CronPayload {
   message: string
   model?: string // "provider/model"
   timeoutSeconds?: number // Max seconds for AI to respond (default: 180)
+  useWorktree?: boolean
+  worktreeBranch?: string
 }
 
 export type DeliveryMode = 'announce' | 'none'
@@ -57,6 +59,7 @@ export interface CronRunRecord {
   responseSummary?: string
   deliveryStatus?: string
   error?: string
+  worktreePath?: string
 }
 
 export interface CreateCronJobRequest {

--- a/src-tauri/src/commands/cron/scheduler.rs
+++ b/src-tauri/src/commands/cron/scheduler.rs
@@ -34,6 +34,34 @@ impl Clone for CronScheduler {
     }
 }
 
+/// RAII guard that automatically removes a git worktree when dropped.
+/// Ensures cleanup on ALL exit paths, including `check_generation!()` early returns.
+struct WorktreeGuard {
+    workspace: String,
+    path: Option<String>,
+}
+
+impl WorktreeGuard {
+    fn new(workspace: &str) -> Self {
+        Self {
+            workspace: workspace.to_string(),
+            path: None,
+        }
+    }
+
+    fn activate(&mut self, path: String) {
+        self.path = Some(path);
+    }
+}
+
+impl Drop for WorktreeGuard {
+    fn drop(&mut self) {
+        if let Some(ref wt) = self.path {
+            CronScheduler::remove_worktree(&self.workspace, wt);
+        }
+    }
+}
+
 impl CronScheduler {
     pub fn new(storage: CronStorage) -> Self {
         Self {
@@ -170,6 +198,11 @@ impl CronScheduler {
         let current_gen = *gen;
         drop(gen);
 
+        // Clean up any orphan worktrees from previous runs
+        if let Some(workspace) = self.storage.get_workspace_path().await {
+            Self::cleanup_orphan_worktrees(&workspace);
+        }
+
         println!("[Cron] Scheduler started (gen: {}, tick every 15 seconds)", current_gen);
 
         let scheduler = self.clone();
@@ -246,6 +279,66 @@ impl CronScheduler {
         }
     }
 
+    /// Create a git worktree for isolated job execution.
+    fn create_worktree(workspace: &str, worktree_path: &str, branch: &str) -> Result<(), String> {
+        let output = std::process::Command::new("git")
+            .current_dir(workspace)
+            .args(["worktree", "add", "--detach", worktree_path, branch])
+            .output()
+            .map_err(|e| format!("Failed to run git worktree add: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("git worktree add failed: {}", stderr.trim()));
+        }
+
+        println!("[Cron] Created worktree at: {} (branch: {})", worktree_path, branch);
+        Ok(())
+    }
+
+    /// Remove a git worktree. Falls back to rm -rf + prune if git remove fails.
+    fn remove_worktree(workspace: &str, worktree_path: &str) {
+        let result = std::process::Command::new("git")
+            .current_dir(workspace)
+            .args(["worktree", "remove", "--force", worktree_path])
+            .output();
+
+        match result {
+            Ok(output) if output.status.success() => {
+                println!("[Cron] Removed worktree: {}", worktree_path);
+            }
+            _ => {
+                println!("[Cron] git worktree remove failed, falling back to rm -rf for: {}", worktree_path);
+                let _ = std::fs::remove_dir_all(worktree_path);
+                let _ = std::process::Command::new("git")
+                    .current_dir(workspace)
+                    .args(["worktree", "prune"])
+                    .output();
+            }
+        }
+    }
+
+    /// Clean up orphaned cron worktrees from previous runs.
+    fn cleanup_orphan_worktrees(workspace: &str) {
+        let worktrees_dir = std::path::Path::new(workspace).join(".worktrees");
+        if !worktrees_dir.exists() {
+            return;
+        }
+
+        let entries = match std::fs::read_dir(&worktrees_dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with("cron-") && entry.path().is_dir() {
+                println!("[Cron] Cleaning up orphan worktree: {}", entry.path().display());
+                Self::remove_worktree(workspace, &entry.path().to_string_lossy());
+            }
+        }
+    }
+
     /// Execute a single cron job
     pub async fn execute_job(&self, job: CronJob) {
         let run_id = uuid::Uuid::new_v4().to_string();
@@ -255,6 +348,10 @@ impl CronScheduler {
         // restarted during execution (e.g., workspace switched). If so, abort.
         let my_generation = *self.generation.read().await;
         let my_workspace = self.storage.get_workspace_path().await.unwrap_or_default();
+
+        // Worktree setup (if enabled)
+        let use_worktree = job.payload.use_worktree.unwrap_or(false);
+        let mut wt_guard = WorktreeGuard::new(&my_workspace);
 
         // Create initial run record
         let mut record = CronRunRecord {
@@ -270,6 +367,41 @@ impl CronScheduler {
             worktree_path: None,
         };
         self.storage.append_run(&record).await;
+
+        if use_worktree {
+            let wt_dir = std::path::Path::new(&my_workspace)
+                .join(".worktrees")
+                .join(format!("cron-{}-{}", job.id, run_id));
+            let wt_path = wt_dir.to_string_lossy().to_string();
+            let branch = job.payload.worktree_branch.as_deref().unwrap_or("main");
+
+            if let Err(e) = std::fs::create_dir_all(wt_dir.parent().unwrap()) {
+                record.status = RunStatus::Failed;
+                record.finished_at = Some(Utc::now());
+                record.error = Some(format!("Failed to create .worktrees dir: {}", e));
+                self.storage.update_last_run(&record).await;
+                self.update_job_after_run(&job, started_at, &my_workspace).await;
+                return;
+            }
+
+            match Self::create_worktree(&my_workspace, &wt_path, branch) {
+                Ok(()) => {
+                    record.worktree_path = Some(wt_path.clone());
+                    self.storage.append_run(&record).await;
+                    wt_guard.activate(wt_path);
+                }
+                Err(e) => {
+                    record.status = RunStatus::Failed;
+                    record.finished_at = Some(Utc::now());
+                    record.error = Some(format!("Worktree creation failed: {}", e));
+                    self.storage.update_last_run(&record).await;
+                    self.update_job_after_run(&job, started_at, &my_workspace).await;
+                    return;
+                }
+            }
+        }
+
+        let opencode_directory = wt_guard.path.as_deref();
 
         let port = *self.opencode_port.read().await;
 
@@ -314,9 +446,28 @@ impl CronScheduler {
             None
         };
 
-        let (session_id, _is_new_session) = if is_email_delivery {
+        let (session_id, _is_new_session) = if use_worktree {
+            // Worktree mode: always create a new session bound to the worktree directory
+            match self.create_opencode_session(port, opencode_directory).await {
+                Ok(id) => {
+                    println!(
+                        "[Cron] Created worktree session '{}' for job '{}' (dir: {:?})",
+                        id, job.name, opencode_directory
+                    );
+                    (id, true)
+                }
+                Err(e) => {
+                    record.status = RunStatus::Failed;
+                    record.finished_at = Some(Utc::now());
+                    record.error = Some(format!("Failed to create session: {}", e));
+                    self.storage.update_last_run(&record).await;
+                    self.update_job_after_run(&job, started_at, &my_workspace).await;
+                    return;
+                }
+            }
+        } else if is_email_delivery {
             // Email: always create a new OpenCode session per execution
-            match self.create_opencode_session(port).await {
+            match self.create_opencode_session(port, None).await {
                 Ok(id) => {
                     let session_key = email_session_key.as_ref().unwrap();
                     println!(
@@ -351,7 +502,7 @@ impl CronScheduler {
                 (existing_id, false)
             } else {
                 // No existing session — create a new one and store it
-                match self.create_opencode_session(port).await {
+                match self.create_opencode_session(port, None).await {
                     Ok(id) => {
                         println!(
                             "[Cron] Created new session '{}' for job '{}' (no existing session found)",
@@ -372,7 +523,7 @@ impl CronScheduler {
             }
         } else {
             // No delivery configured — always create a fresh session
-            match self.create_opencode_session(port).await {
+            match self.create_opencode_session(port, None).await {
                 Ok(id) => (id, true),
                 Err(e) => {
                     record.status = RunStatus::Failed;
@@ -568,6 +719,11 @@ impl CronScheduler {
             );
         }
 
+        // Wait briefly for OpenCode to flush any pending file writes before worktree cleanup
+        if wt_guard.path.is_some() {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
+
         println!("[Cron] Job '{}' completed successfully", job.name);
     }
 
@@ -673,9 +829,12 @@ impl CronScheduler {
     }
 
     /// Create a new OpenCode session
-    async fn create_opencode_session(&self, port: u16) -> Result<String, String> {
+    async fn create_opencode_session(&self, port: u16, directory: Option<&str>) -> Result<String, String> {
         let client = reqwest::Client::new();
-        let url = format!("http://127.0.0.1:{}/session", port);
+        let mut url = format!("http://127.0.0.1:{}/session", port);
+        if let Some(dir) = directory {
+            url = format!("{}?directory={}", url, urlencoding::encode(dir));
+        }
         println!("[Cron] Creating OpenCode session at: {}", url);
 
         let response = client

--- a/src-tauri/src/commands/cron/scheduler.rs
+++ b/src-tauri/src/commands/cron/scheduler.rs
@@ -267,6 +267,7 @@ impl CronScheduler {
             response_summary: None,
             delivery_status: None,
             error: None,
+            worktree_path: None,
         };
         self.storage.append_run(&record).await;
 

--- a/src-tauri/src/commands/cron/types.rs
+++ b/src-tauri/src/commands/cron/types.rs
@@ -51,6 +51,12 @@ pub struct CronPayload {
     /// Default: 180 (3 minutes). Range: 30–900.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_seconds: Option<u64>,
+    /// Whether to run in an isolated git worktree
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_worktree: Option<bool>,
+    /// Branch to checkout in worktree (default: "main")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_branch: Option<String>,
 }
 
 /// Delivery mode for cron job results
@@ -162,6 +168,9 @@ pub struct CronRunRecord {
     /// Error message if failed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Worktree path used for this run (if worktree mode was enabled)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
 }
 
 /// Persistent storage structure for all cron jobs


### PR DESCRIPTION
## Summary

- Add optional per-job git worktree isolation to the cron scheduler
- When enabled, each job execution creates a temporary detached worktree, runs the AI agent in it via `?directory=` on OpenCode session creation, then cleans up after completion
- RAII `WorktreeGuard` ensures worktree cleanup on all exit paths (including timeouts and generation changes)
- Orphan worktrees from crashed runs are cleaned up on scheduler startup

## Changes

**Rust backend** (`scheduler.rs`, `types.rs`):
- `CronPayload`: new `use_worktree` and `worktree_branch` fields
- `CronRunRecord`: new `worktree_path` field for debugging
- `WorktreeGuard` RAII struct for automatic cleanup
- `create/remove_worktree`, `cleanup_orphan_worktrees` helpers
- `create_opencode_session` accepts optional `directory` parameter
- Worktree lifecycle integrated into `execute_job`

**TypeScript frontend** (`cron.ts`, `cron-utils.ts`, `CronJobDialog.tsx`, `CronHistoryDialog.tsx`):
- Type definitions updated with worktree fields
- Form state, serialization, and defaults added
- Toggle switch + branch input in job creation/edit dialog
- Worktree path shown in run history

**i18n** (`en.json`, `zh-CN.json`):
- 4 new translation keys for worktree UI

## Test plan

- [ ] Create a cron job with "Run in isolated worktree" enabled, branch = main
- [ ] Trigger manual run, verify the AI executes in `.worktrees/cron-{id}-{runId}`
- [ ] Verify worktree is cleaned up after execution
- [ ] Verify run history shows the worktree path
- [ ] Create a cron job without worktree enabled, verify existing behavior unchanged
- [ ] Kill the app during a worktree job run, restart, verify orphan worktree is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)