### PR TITLE
feat(chat): add context usage percentage badge

### DIFF
--- a/packages/app/src/components/chat/ChatInputArea.tsx
+++ b/packages/app/src/components/chat/ChatInputArea.tsx
@@ -34,6 +34,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { FileInputButton } from "./FileInputButton";
 import { MessageQueueDisplay } from "./MessageQueueDisplay";
+import { ContextUsageBadge } from "./ContextUsageBadge";
 import { type QueuedMessage, useSessionStore } from "@/stores/session";
 import { useVoiceInputStore } from "@/stores/voice-input";
 import { useSpeechRecognition } from "@/hooks/useSpeechRecognition";
@@ -480,11 +481,14 @@ export function ChatInputArea({
               )}
             </PromptInputTools>
 
-            <PromptInputSubmit
-              disabled={!inputValue.trim() && attachedFiles.length === 0 && imageFiles.length === 0}
-              status={isStreaming ? "streaming" : "ready"}
-              onStop={onAbort}
-            />
+            <div className="flex items-center gap-2">
+              <ContextUsageBadge />
+              <PromptInputSubmit
+                disabled={!inputValue.trim() && attachedFiles.length === 0 && imageFiles.length === 0}
+                status={isStreaming ? "streaming" : "ready"}
+                onStop={onAbort}
+              />
+            </div>
           </PromptInputFooter>
         </PromptInput>
       </div>

--- a/packages/app/src/components/chat/ContextUsageBadge.tsx
+++ b/packages/app/src/components/chat/ContextUsageBadge.tsx
@@ -1,0 +1,140 @@
+import * as React from "react";
+import { useSessionStore } from "@/stores/session";
+import { useProviderStore } from "@/stores/provider";
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+// Known context window sizes (in tokens) for popular models
+const MODEL_CONTEXT_SIZES: Record<string, number> = {
+  // Anthropic
+  "claude-sonnet-4-20250514": 200_000,
+  "claude-sonnet-4-0": 200_000,
+  "claude-opus-4-0": 200_000,
+  "claude-opus-4-20250514": 200_000,
+  "claude-3-5-sonnet-20241022": 200_000,
+  "claude-3-5-sonnet": 200_000,
+  "claude-3-5-haiku-20241022": 200_000,
+  "claude-3-5-haiku": 200_000,
+  "claude-3-opus": 200_000,
+  "claude-3-sonnet": 200_000,
+  "claude-3-haiku": 200_000,
+  // OpenAI
+  "gpt-4o": 128_000,
+  "gpt-4o-mini": 128_000,
+  "gpt-4-turbo": 128_000,
+  "gpt-4": 8_192,
+  "o1": 200_000,
+  "o1-mini": 128_000,
+  "o1-preview": 128_000,
+  "o3": 200_000,
+  "o3-mini": 200_000,
+  "o4-mini": 200_000,
+  // Google
+  "gemini-2.5-pro": 1_000_000,
+  "gemini-2.5-flash": 1_000_000,
+  "gemini-2.0-flash": 1_000_000,
+  "gemini-1.5-pro": 2_000_000,
+  "gemini-1.5-flash": 1_000_000,
+  // Deepseek
+  "deepseek-chat": 128_000,
+  "deepseek-reasoner": 128_000,
+};
+
+const DEFAULT_CONTEXT_SIZE = 200_000;
+
+function getContextWindowSize(modelId: string): number {
+  // Direct match
+  if (MODEL_CONTEXT_SIZES[modelId]) return MODEL_CONTEXT_SIZES[modelId];
+
+  // Fuzzy match: check if the model ID contains a known key
+  const lowerModelId = modelId.toLowerCase();
+  for (const [key, size] of Object.entries(MODEL_CONTEXT_SIZES)) {
+    if (lowerModelId.includes(key.toLowerCase())) return size;
+  }
+
+  // Check by prefix patterns
+  if (lowerModelId.includes("claude")) return 200_000;
+  if (lowerModelId.includes("gpt-4o")) return 128_000;
+  if (lowerModelId.includes("gemini")) return 1_000_000;
+  if (lowerModelId.includes("deepseek")) return 128_000;
+
+  return DEFAULT_CONTEXT_SIZE;
+}
+
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(0)}k`;
+  return `${tokens}`;
+}
+
+export function ContextUsageBadge() {
+  const activeSessionId = useSessionStore((s) => s.activeSessionId);
+  const sessions = useSessionStore((s) => s.sessions);
+  const currentModelKey = useProviderStore((s) => s.currentModelKey);
+
+  const { percentage, totalTokens, contextSize } = React.useMemo(() => {
+    if (!activeSessionId) return { percentage: 0, totalTokens: 0, contextSize: DEFAULT_CONTEXT_SIZE };
+
+    const session = sessions.find((s) => s.id === activeSessionId);
+    if (!session) return { percentage: 0, totalTokens: 0, contextSize: DEFAULT_CONTEXT_SIZE };
+
+    // Sum input tokens from all messages (input tokens represent context consumed)
+    let total = 0;
+    for (const msg of session.messages) {
+      if (msg.tokens) {
+        total += msg.tokens.input + (msg.tokens.cache?.read || 0);
+      }
+    }
+
+    // Get context window size for current model
+    const modelId = currentModelKey?.split("/").slice(1).join("/") || "";
+    const ctxSize = getContextWindowSize(modelId);
+
+    // Use the last message's input tokens as the best estimate of current context usage
+    // (each message's input tokens includes all prior context)
+    const lastAssistantMsg = [...session.messages].reverse().find(
+      (m) => m.role === "assistant" && m.tokens
+    );
+    const currentUsage = lastAssistantMsg?.tokens?.input || 0;
+
+    return {
+      percentage: ctxSize > 0 ? Math.min(100, Math.round((currentUsage / ctxSize) * 100)) : 0,
+      totalTokens: currentUsage,
+      contextSize: ctxSize,
+    };
+  }, [activeSessionId, sessions, currentModelKey]);
+
+  if (percentage === 0) return null;
+
+  const color =
+    percentage >= 90
+      ? "text-red-500"
+      : percentage >= 70
+        ? "text-orange-500"
+        : "text-muted-foreground";
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={cn(
+              "text-[11px] font-mono tabular-nums select-none cursor-default",
+              color,
+            )}
+          >
+            {percentage}%
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          <p>Context: {formatTokenCount(totalTokens)} / {formatTokenCount(contextSize)} tokens</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a context window usage percentage indicator (e.g. `42%`) to the left of the send button in the chat input area
- Tooltip shows exact token counts (e.g. "Context: 84k / 200k tokens")
- Color-coded: gray (<70%), orange (70-90%), red (>90%)
- Supports common model context window sizes (Claude, GPT-4o, Gemini, DeepSeek) with fuzzy matching

## Test plan
- [ ] Start a new session — badge should be hidden (0%)
- [ ] Send a few messages — badge should appear with increasing percentage
- [ ] Hover over badge — tooltip shows token details
- [ ] Switch models — percentage recalculates based on new model's context window
- [ ] Verify color transitions at 70% and 90% thresholds

🤖 Generated with [Claude Code](https://claude.ai/code)