### PR TITLE
feat(cron): hide cron sessions from sidebar session list

### DIFF
--- a/packages/app/src/components/chat/SessionList.tsx
+++ b/packages/app/src/components/chat/SessionList.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useMemo, useRef } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { MessageSquare, Loader2 } from 'lucide-react'
 import { useSessionStore } from '@/stores/session'
 import { useStreamingStore } from '@/stores/streaming'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useUIStore } from '@/stores/ui'
+import { useCronStore } from '@/stores/cron'
 import { cn } from '@/lib/utils'
 import { formatRelativeDate } from '@/lib/date-format'
 
@@ -114,8 +115,15 @@ const ROW_HEIGHT = 52
 const ROW_HEIGHT_COMPACT = 40
 
 export function SessionList({ compact, onSessionSelected }: SessionListProps) {
-  const sessions = useSessionStore(s => s.sessions)
+  const allSessions = useSessionStore(s => s.sessions)
   const activeSessionId = useSessionStore(s => s.activeSessionId)
+  const cronSessionIds = useCronStore(s => s.cronSessionIds)
+
+  // Filter out cron-created sessions (unless it's the currently active one)
+  const sessions = useMemo(
+    () => allSessions.filter(s => !cronSessionIds.has(s.id) || s.id === activeSessionId),
+    [allSessions, cronSessionIds, activeSessionId],
+  )
   const isLoading = useSessionStore(s => s.isLoading)
   const highlightedSessionIds = useSessionStore(s => s.highlightedSessionIds)
   const setActiveSession = useSessionStore(s => s.setActiveSession)

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -91,6 +91,9 @@ interface CronState {
   error: string | null
   isInitialized: boolean
 
+  // All session IDs created by cron (for filtering in session list)
+  cronSessionIds: Set<string>
+
   // Run history for the currently viewed job
   selectedJobId: string | null
   runs: CronRunRecord[]
@@ -100,6 +103,7 @@ interface CronState {
   init: () => Promise<void>
   reinit: () => Promise<void>
   loadJobs: () => Promise<void>
+  loadCronSessionIds: () => Promise<void>
   addJob: (request: CreateCronJobRequest) => Promise<CronJob>
   updateJob: (request: UpdateCronJobRequest) => Promise<CronJob>
   removeJob: (jobId: string) => Promise<void>
@@ -117,6 +121,8 @@ export const useCronStore = create<CronState>((set, get) => ({
   error: null,
   isInitialized: false,
 
+  cronSessionIds: new Set<string>(),
+
   selectedJobId: null,
   runs: [],
   runsLoading: false,
@@ -130,7 +136,7 @@ export const useCronStore = create<CronState>((set, get) => ({
     try {
       await invoke('cron_init')
       set({ isInitialized: true })
-      await get().loadJobs()
+      await Promise.all([get().loadJobs(), get().loadCronSessionIds()])
     } catch (error) {
       console.error('[Cron] Init failed:', error)
       set({ error: error instanceof Error ? error.message : String(error) })
@@ -143,7 +149,7 @@ export const useCronStore = create<CronState>((set, get) => ({
       set({ isInitialized: false })
       await invoke('cron_init')
       set({ isInitialized: true })
-      await get().loadJobs()
+      await Promise.all([get().loadJobs(), get().loadCronSessionIds()])
     } catch (error) {
       console.error('[Cron] Re-init failed:', error)
       set({ error: error instanceof Error ? error.message : String(error) })
@@ -207,6 +213,15 @@ export const useCronStore = create<CronState>((set, get) => ({
       await invoke('cron_run_job', { jobId })
     } catch (error) {
       set({ error: error instanceof Error ? error.message : String(error) })
+    }
+  },
+
+  loadCronSessionIds: async () => {
+    try {
+      const ids = await invoke<string[]>('cron_get_all_session_ids')
+      set({ cronSessionIds: new Set(ids) })
+    } catch (error) {
+      console.error('[Cron] Failed to load cron session IDs:', error)
     }
   },
 

--- a/packages/app/src/stores/session-sse-lifecycle-handlers.ts
+++ b/packages/app/src/stores/session-sse-lifecycle-handlers.ts
@@ -89,6 +89,11 @@ export function createLifecycleHandlers(set: SessionSet, get: SessionGet) {
         }
       }
 
+      // Refresh cron session IDs so newly created cron sessions get filtered
+      import("@/stores/cron").then(({ useCronStore }) => {
+        useCronStore.getState().loadCronSessionIds();
+      });
+
       set((state) => ({
         highlightedSessionIds: [...state.highlightedSessionIds, event.sessionId],
       }));

--- a/src-tauri/src/commands/cron/mod.rs
+++ b/src-tauri/src/commands/cron/mod.rs
@@ -239,6 +239,14 @@ pub async fn cron_get_runs(
     Ok(cron_state.storage.get_runs(&job_id, Some(limit)).await)
 }
 
+/// Get all session IDs created by cron jobs (used to filter cron sessions in UI)
+#[tauri::command]
+pub async fn cron_get_all_session_ids(
+    cron_state: State<'_, CronState>,
+) -> Result<Vec<String>, String> {
+    Ok(cron_state.storage.get_all_session_ids().await)
+}
+
 /// Refresh delivery configs (no-op now — DeliveryManager reads config on demand)
 #[tauri::command]
 pub async fn cron_refresh_delivery(

--- a/src-tauri/src/commands/cron/storage.rs
+++ b/src-tauri/src/commands/cron/storage.rs
@@ -318,6 +318,45 @@ impl CronStorage {
         }
     }
 
+    /// Collect all session IDs created by cron jobs (across all jobs).
+    /// Used by the frontend to filter cron sessions from the session list.
+    pub async fn get_all_session_ids(&self) -> Vec<String> {
+        let workspace = self.workspace_path.read().await;
+        let Some(ws) = workspace.as_ref() else {
+            return Vec::new();
+        };
+
+        let runs_dir = Self::runs_dir(ws);
+        if !runs_dir.exists() {
+            return Vec::new();
+        }
+
+        let mut session_ids = std::collections::HashSet::new();
+
+        if let Ok(entries) = std::fs::read_dir(&runs_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                    continue;
+                }
+                if let Ok(content) = std::fs::read_to_string(&path) {
+                    for line in content.lines() {
+                        if line.trim().is_empty() {
+                            continue;
+                        }
+                        if let Ok(record) = serde_json::from_str::<CronRunRecord>(line) {
+                            if let Some(sid) = record.session_id {
+                                session_ids.insert(sid);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        session_ids.into_iter().collect()
+    }
+
     /// Get run history for a job (most recent first, with optional limit)
     /// Get run history for a job.
     ///

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -330,6 +330,7 @@ pub fn run() {
             commands::cron::cron_toggle_enabled,
             commands::cron::cron_run_job,
             commands::cron::cron_get_runs,
+            commands::cron::cron_get_all_session_ids,
             commands::cron::cron_refresh_delivery,
             commands::clawhub::clawhub_search,
             commands::clawhub::clawhub_explore,


### PR DESCRIPTION
## Summary

- Cron 任务每次执行都会生成新 session，量大时会把正常 session 挤到看不到
- 新增 `cron_get_all_session_ids` Tauri command，从所有 job 的 run history 中收集 session ID
- SessionList 使用该集合过滤 cron session（当前 active 的保留可见）
- 外部 session 创建时通过 SSE 事件自动刷新过滤集合

## Test plan

- [ ] 创建 cron 任务并执行，确认生成的 session 不出现在侧边栏
- [ ] 手动切换到 cron session 后，确认它仍然可见（active 例外逻辑）
- [ ] 切换 workspace 后确认 cronSessionIds 正确刷新
- [ ] 无 cron 任务时确认 session list 行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)