### PR TITLE
feat(team): unified team member management across OSS and P2P modes

### DIFF
--- a/docs/superpowers/plans/2026-03-23-unified-team-management.md
+++ b/docs/superpowers/plans/2026-03-23-unified-team-management.md
@@ -1,0 +1,1250 @@
+# Unified Team Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify team member management across OSS (S3) and P2P sync modes with a consistent create → add member → join flow, shared role system (Owner/Editor/Viewer), and role-gated member list UI.
+
+**Architecture:** Extract shared types (`MemberRole`, `TeamMember`, `TeamManifest`) into a new `team_unified.rs` module. Both OSS and P2P backends implement a `TeamMemberManager` trait for CRUD operations on the members manifest. The frontend uses unified Tauri commands that dispatch to the active sync mode's backend. The existing `TeamMemberList` and `AddMemberInput` components are enhanced with role-based access control.
+
+**Tech Stack:** Rust (Tauri 2.0), React 19 + TypeScript, Zustand, iroh (P2P), aws-sdk-s3 (OSS), Loro CRDT, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-03-23-unified-team-management-design.md`
+
+---
+
+## File Structure
+
+### New Files
+- `src-tauri/src/commands/team_unified.rs` — Shared types, `TeamMemberManager` trait, unified Tauri command handlers
+- `packages/app/src/stores/team-members.ts` — Unified Zustand store for team members
+
+### Modified Files
+- `src-tauri/src/commands/mod.rs` — Register `team_unified` module
+- `src-tauri/src/commands/oss_types.rs` — Replace `TeamRole` with unified `MemberRole`, update `OssTeamInfo`
+- `src-tauri/src/commands/oss_sync.rs` — Implement `TeamMemberManager` trait, add members manifest S3 ops
+- `src-tauri/src/commands/oss_commands.rs` — Update `oss_create_team` / `oss_join_team` for NodeId + manifest
+- `src-tauri/src/commands/team_p2p.rs` — Import shared types from `team_unified`, implement `TeamMemberManager` trait
+- `src-tauri/src/commands/team.rs` — Update `check_team_status()` to include role info
+- `src-tauri/src/lib.rs` — Register new unified commands in invoke_handler
+- `packages/app/src/lib/git/types.ts` — Add unified result/error types, update `TeamMember`
+- `packages/app/src/components/settings/team/TeamOSSConfig.tsx` — Unified create/join flow with two-step validation
+- `packages/app/src/components/settings/team/TeamP2PConfig.tsx` — Unified create/join flow
+- `packages/app/src/components/settings/TeamMemberList.tsx` — Role-gated controls (Owner/Editor can manage, Viewer read-only)
+- `packages/app/src/components/settings/AddMemberInput.tsx` — Add label/remark field
+- `packages/app/src/components/settings/DeviceIdDisplay.tsx` — Ensure works in both modes
+- `packages/app/src/stores/team-mode.ts` — Expose `myRole` from unified member lookup
+- `packages/app/src/stores/team-oss.ts` — Use unified member types, delegate member ops to unified store
+
+---
+
+## Task 1: Shared Types & TeamMemberManager Trait (Rust)
+
+Extract shared types from `team_p2p.rs` into a new `team_unified.rs` module. Define the `TeamMemberManager` trait that both backends will implement.
+
+**Files:**
+- Create: `src-tauri/src/commands/team_unified.rs`
+- Modify: `src-tauri/src/commands/mod.rs`
+
+- [ ] **Step 1: Create `team_unified.rs` with shared types**
+
+```rust
+// src-tauri/src/commands/team_unified.rs
+
+use serde::{Deserialize, Serialize};
+
+// --- Shared Types ---
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum MemberRole {
+    Owner,
+    #[default]
+    Editor,
+    Viewer,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamMember {
+    pub node_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub role: MemberRole,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub platform: String,
+    #[serde(default)]
+    pub arch: String,
+    #[serde(default)]
+    pub hostname: String,
+    #[serde(default)]
+    pub added_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamManifest {
+    pub owner_node_id: String,
+    pub members: Vec<TeamMember>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamCreateResult {
+    pub team_id: Option<String>,
+    pub ticket: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamJoinResult {
+    pub success: bool,
+    pub role: MemberRole,
+    pub members: Vec<TeamMember>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "message")]
+pub enum TeamJoinError {
+    InvalidTicket(String),
+    DeviceNotRegistered(String),
+    AlreadyInTeam(String),
+    SyncError(String),
+}
+
+impl std::fmt::Display for TeamJoinError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidTicket(msg) => write!(f, "{}", msg),
+            Self::DeviceNotRegistered(msg) => write!(f, "{}", msg),
+            Self::AlreadyInTeam(msg) => write!(f, "{}", msg),
+            Self::SyncError(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+// --- Validation Helpers ---
+
+/// Validate NodeId format: non-empty hex string
+pub fn validate_node_id(node_id: &str) -> Result<(), String> {
+    if node_id.is_empty() {
+        return Err("NodeId cannot be empty".to_string());
+    }
+    if !node_id.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("NodeId must be a valid hex string".to_string());
+    }
+    Ok(())
+}
+
+/// Check if a role can manage members (add/remove/edit)
+pub fn can_manage_members(role: &MemberRole) -> bool {
+    matches!(role, MemberRole::Owner | MemberRole::Editor)
+}
+
+/// Find a member's role in a manifest by node_id
+pub fn find_member_role(manifest: &TeamManifest, node_id: &str) -> Option<MemberRole> {
+    manifest
+        .members
+        .iter()
+        .find(|m| m.node_id == node_id)
+        .map(|m| m.role.clone())
+}
+```
+
+- [ ] **Step 2: Register module in `mod.rs`**
+
+Add `pub mod team_unified;` to `src-tauri/src/commands/mod.rs` (after the existing module declarations, before the `TEAMCLAW_DIR` constant).
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw-worktrees/feature/team-improvement && cargo check -p teamclaw 2>&1 | tail -5`
+Expected: compiles with no errors related to `team_unified`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/commands/team_unified.rs src-tauri/src/commands/mod.rs
+git commit -m "feat(team): add team_unified module with shared types and validation helpers"
+```
+
+---
+
+## Task 2: Migrate P2P to Use Shared Types
+
+Update `team_p2p.rs` to import `MemberRole`, `TeamMember`, `TeamManifest` from `team_unified` instead of defining its own. Keep all existing P2P logic intact.
+
+**Files:**
+- Modify: `src-tauri/src/commands/team_p2p.rs:843-973` (type definitions)
+
+- [ ] **Step 1: Replace P2P type definitions with re-exports**
+
+In `team_p2p.rs`, remove the local `MemberRole` enum (lines ~843-849), `TeamMember` struct (lines ~854-866), and `TeamManifest` struct (lines ~970-973). Replace with imports from `team_unified`:
+
+```rust
+// At top of team_p2p.rs, add:
+use super::team_unified::{MemberRole, TeamMember, TeamManifest, validate_node_id, can_manage_members};
+```
+
+Keep `P2pTicketEntry`, `P2pConfig`, `DeviceInfo`, and all other P2P-specific types as-is.
+
+**Important:** The existing P2P `MemberRole` has the same variants (`Owner`, `Editor`, `Viewer`) and serde attributes, so this is a drop-in replacement. The existing `TeamMember` fields match exactly. If any field differs (e.g. missing `#[serde(default)]`), add the attribute to the unified version.
+
+- [ ] **Step 2: Update `P2pConfig.role` field type**
+
+`P2pConfig.role` (line ~900) is `Option<MemberRole>` — this should now reference the unified `MemberRole`. Confirm it still compiles.
+
+- [ ] **Step 3: Update internal functions that construct TeamMember/TeamManifest**
+
+Grep for `TeamMember {` and `TeamManifest {` in `team_p2p.rs` and verify they still work with the unified types. The field set should be identical.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw-worktrees/feature/team-improvement && cargo check -p teamclaw 2>&1 | tail -10`
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/commands/team_p2p.rs
+git commit -m "refactor(team): migrate P2P to use shared types from team_unified"
+```
+
+---
+
+## Task 3: Migrate OSS to Use Shared Types & Add Member Manifest
+
+Update OSS types to use unified `MemberRole` instead of `TeamRole`. Add members manifest management to `OssSyncManager` (upload/download `_team/members.json` to S3).
+
+**Files:**
+- Modify: `src-tauri/src/commands/oss_types.rs:70-75,117-120` (TeamMember, TeamRole)
+- Modify: `src-tauri/src/commands/oss_sync.rs` (add manifest S3 ops)
+
+- [ ] **Step 1: Replace `TeamRole` with unified `MemberRole` in `oss_types.rs`**
+
+Remove the local `TeamRole` enum (lines ~117-120) and `TeamMember` struct (lines ~70-75). Import from `team_unified`:
+
+```rust
+// At top of oss_types.rs, add:
+pub use super::team_unified::{MemberRole, TeamMember, TeamManifest};
+```
+
+Update `OssTeamInfo.role` (line ~40) from `String` to `MemberRole`. Verify all references to `TeamRole` in `oss_types.rs`, `oss_sync.rs`, and `oss_commands.rs` are updated to `MemberRole`.
+
+- [ ] **Step 2: Add `node_id` field to `OssSyncManager`**
+
+In `oss_sync.rs`, the `OssSyncManager` struct (lines ~24-48) already has a `node_id` field. Verify it's populated during `new()`. If not, add logic to call `get_device_info()` or derive it.
+
+- [ ] **Step 3: Add members manifest S3 operations to `OssSyncManager`**
+
+Add these methods to `OssSyncManager`:
+
+```rust
+const MEMBERS_MANIFEST_KEY: &str = "_team/members.json";
+
+impl OssSyncManager {
+    /// Upload members manifest to S3
+    pub async fn upload_members_manifest(&self, manifest: &TeamManifest) -> Result<(), String> {
+        let json = serde_json::to_string_pretty(manifest)
+            .map_err(|e| format!("Failed to serialize manifest: {}", e))?;
+        self.s3_put(MEMBERS_MANIFEST_KEY, json.as_bytes()).await
+    }
+
+    /// Download members manifest from S3
+    pub async fn download_members_manifest(&self) -> Result<Option<TeamManifest>, String> {
+        match self.s3_get(MEMBERS_MANIFEST_KEY).await {
+            Ok(data) => {
+                let manifest: TeamManifest = serde_json::from_slice(&data)
+                    .map_err(|e| format!("Failed to parse manifest: {}", e))?;
+                Ok(Some(manifest))
+            }
+            Err(e) if e.contains("NoSuchKey") || e.contains("not found") => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Add a member to the manifest and upload
+    pub async fn add_member(&self, member: TeamMember) -> Result<(), String> {
+        let mut manifest = self.download_members_manifest().await?
+            .unwrap_or_else(|| TeamManifest {
+                owner_node_id: self.node_id.clone().unwrap_or_default(),
+                members: vec![],
+            });
+
+        if manifest.members.iter().any(|m| m.node_id == member.node_id) {
+            return Err("This device already exists in the team".to_string());
+        }
+
+        manifest.members.push(member);
+        self.upload_members_manifest(&manifest).await
+    }
+
+    /// Remove a member from the manifest and upload
+    pub async fn remove_member(&self, node_id: &str) -> Result<(), String> {
+        let mut manifest = self.download_members_manifest().await?
+            .ok_or("No members manifest found")?;
+
+        if manifest.owner_node_id == node_id {
+            return Err("Cannot remove the team Owner".to_string());
+        }
+
+        manifest.members.retain(|m| m.node_id != node_id);
+        self.upload_members_manifest(&manifest).await
+    }
+
+    /// Update a member's role in the manifest and upload
+    pub async fn update_member_role(&self, node_id: &str, role: MemberRole) -> Result<(), String> {
+        let mut manifest = self.download_members_manifest().await?
+            .ok_or("No members manifest found")?;
+
+        if manifest.owner_node_id == node_id && role != MemberRole::Owner {
+            return Err("Cannot change the Owner's role".to_string());
+        }
+
+        if let Some(member) = manifest.members.iter_mut().find(|m| m.node_id == node_id) {
+            member.role = role;
+        } else {
+            return Err("Member not found".to_string());
+        }
+
+        self.upload_members_manifest(&manifest).await
+    }
+
+    /// Check if a node_id is in the members manifest
+    pub async fn check_member_authorized(&self, node_id: &str) -> Result<MemberRole, String> {
+        let manifest = self.download_members_manifest().await?
+            .ok_or("No members manifest found")?;
+
+        manifest.members.iter()
+            .find(|m| m.node_id == node_id)
+            .map(|m| m.role.clone())
+            .ok_or("Your device has not been added to the team. Please contact the team Owner".to_string())
+    }
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw-worktrees/feature/team-improvement && cargo check -p teamclaw 2>&1 | tail -10`
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/commands/oss_types.rs src-tauri/src/commands/oss_sync.rs
+git commit -m "feat(team): migrate OSS to unified types and add members manifest S3 ops"
+```
+
+---
+
+## Task 4: Update OSS Create/Join Commands for NodeId Validation
+
+Modify `oss_create_team` to auto-add owner to manifest. Modify `oss_join_team` to perform two-step validation (ticket → NodeId).
+
+**Files:**
+- Modify: `src-tauri/src/commands/oss_commands.rs:106-301`
+
+- [ ] **Step 1: Update `oss_create_team()` to initialize members manifest**
+
+After the existing team creation logic (FC /register call, S3 setup), add:
+
+```rust
+// Inside oss_create_team(), after successful creation:
+// 1. Get device info for owner's NodeId
+let device_info = crate::commands::team_p2p::get_device_metadata();
+
+// 2. Create initial manifest with owner
+let owner_member = TeamMember {
+    node_id: device_info.node_id.clone(),
+    name: owner_name.clone(),
+    role: MemberRole::Owner,
+    label: String::new(),
+    platform: device_info.platform,
+    arch: device_info.arch,
+    hostname: device_info.hostname,
+    added_at: chrono::Utc::now().to_rfc3339(),
+};
+
+let manifest = TeamManifest {
+    owner_node_id: device_info.node_id,
+    members: vec![owner_member],
+};
+
+// 3. Upload manifest to S3
+manager.upload_members_manifest(&manifest).await
+    .map_err(|e| format!("Failed to upload members manifest: {}", e))?;
+```
+
+- [ ] **Step 2: Update `oss_join_team()` with two-step validation**
+
+After the existing ticket validation (FC /token call), before starting sync, add NodeId check:
+
+```rust
+// Inside oss_join_team(), after successful FC /token call:
+// 1. Get local device NodeId
+let device_info = crate::commands::team_p2p::get_device_metadata();
+let local_node_id = device_info.node_id;
+
+// 2. Download members manifest and check authorization
+match manager.check_member_authorized(&local_node_id).await {
+    Ok(role) => {
+        // Member is authorized, proceed with sync
+        // Store role in config
+    }
+    Err(e) => {
+        // Clean up: don't persist config if not authorized
+        return Err(e);
+    }
+}
+```
+
+Ensure the error messages match the spec:
+- Invalid ticket: "Ticket 不正确，请检查后重试"
+- Device not in allowlist: "你的设备未被添加到团队中，请联系团队 Owner"
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw-worktrees/feature/team-improvement && cargo check -p teamclaw 2>&1 | tail -10`
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/commands/oss_commands.rs
+git commit -m "feat(team): add NodeId validation to OSS create/join commands"
+```
+
+---
+
+## Task 5: Add Unified Tauri Commands
+
+Add unified command handlers in `team_unified.rs` that dispatch to the active sync mode's backend. Register them in `lib.rs`.
+
+**Files:**
+- Modify: `src-tauri/src/commands/team_unified.rs`
+- Modify: `src-tauri/src/commands/team.rs:269-306` (check_team_status)
+- Modify: `src-tauri/src/lib.rs:369-462` (invoke_handler)
+
+- [ ] **Step 1: Add unified command handlers to `team_unified.rs`**
+
+```rust
+use tauri::State;
+use super::team::check_team_status;
+use super::oss_sync::OssSyncState;
+
+#[cfg(feature = "p2p")]
+use super::p2p_state::IrohState;
+
+/// Get members list for active team mode
+#[tauri::command]
+pub async fn unified_team_get_members(
+    app_handle: tauri::AppHandle,
+    oss_state: State<'_, OssSyncState>,
+    #[cfg(feature = "p2p")]
+    iroh_state: State<'_, IrohState>,
+) -> Result<Vec<TeamMember>, String> {
+    let status = check_team_status(&app_handle).await?;
+    match status.mode.as_deref() {
+        Some("oss") => {
+            let guard = oss_state.0.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            let manifest = manager.download_members_manifest().await?;
+            Ok(manifest.map(|m| m.members).unwrap_or_default())
+        }
+        #[cfg(feature = "p2p")]
+        Some("p2p") => {
+            // Read from P2P config's allowed_members
+            let config = super::team_p2p::read_p2p_config(&app_handle)?;
+            Ok(config.allowed_members)
+        }
+        _ => Err("No active team mode".to_string()),
+    }
+}
+
+/// Helper: check caller has Owner or Editor role
+async fn require_manager_role(
+    app_handle: &tauri::AppHandle,
+    oss_state: &State<'_, OssSyncState>,
+    #[cfg(feature = "p2p")]
+    _iroh_state: &State<'_, IrohState>,
+) -> Result<(), String> {
+    let device_info = super::team_p2p::get_device_metadata();
+    let status = check_team_status(app_handle).await?;
+    let role = match status.mode.as_deref() {
+        Some("oss") => {
+            let guard = oss_state.0.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            let manifest = manager.download_members_manifest().await?;
+            manifest.and_then(|m| find_member_role(&m, &device_info.node_id))
+        }
+        #[cfg(feature = "p2p")]
+        Some("p2p") => {
+            let config = super::team_p2p::read_p2p_config(app_handle)?;
+            config.allowed_members.iter()
+                .find(|m| m.node_id == device_info.node_id)
+                .map(|m| m.role.clone())
+        }
+        _ => None,
+    };
+    match role {
+        Some(r) if can_manage_members(&r) => Ok(()),
+        _ => Err("Permission denied: only Owner and Editor can manage members".to_string()),
+    }
+}
+
+/// Add member to active team
+#[tauri::command]
+pub async fn unified_team_add_member(
+    app_handle: tauri::AppHandle,
+    oss_state: State<'_, OssSyncState>,
+    #[cfg(feature = "p2p")]
+    iroh_state: State<'_, IrohState>,
+    member: TeamMember,
+) -> Result<(), String> {
+    validate_node_id(&member.node_id)?;
+    require_manager_role(&app_handle, &oss_state, #[cfg(feature = "p2p")] &iroh_state).await?;
+
+    let status = check_team_status(&app_handle).await?;
+    match status.mode.as_deref() {
+        Some("oss") => {
+            let guard = oss_state.0.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            manager.add_member(member).await
+        }
+        #[cfg(feature = "p2p")]
+        Some("p2p") => {
+            // Delegate to existing P2P member management
+            let node = iroh_state.0.lock().await;
+            let node = node.as_ref().ok_or("P2P node not initialized")?;
+            node.add_member_to_team(&app_handle, member).await
+        }
+        _ => Err("No active team mode".to_string()),
+    }
+}
+
+/// Remove member from active team
+#[tauri::command]
+pub async fn unified_team_remove_member(
+    app_handle: tauri::AppHandle,
+    oss_state: State<'_, OssSyncState>,
+    #[cfg(feature = "p2p")]
+    iroh_state: State<'_, IrohState>,
+    node_id: String,
+) -> Result<(), String> {
+    require_manager_role(&app_handle, &oss_state, #[cfg(feature = "p2p")] &iroh_state).await?;
+
+    let status = check_team_status(&app_handle).await?;
+    match status.mode.as_deref() {
+        Some("oss") => {
+            let guard = oss_state.0.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            manager.remove_member(&node_id).await
+        }
+        #[cfg(feature = "p2p")]
+        Some("p2p") => {
+            let node = iroh_state.0.lock().await;
+            let node = node.as_ref().ok_or("P2P node not initialized")?;
+            node.remove_member_from_team(&app_handle, &node_id).await
+        }
+        _ => Err("No active team mode".to_string()),
+    }
+}
+
+/// Update member role in active team
+#[tauri::command]
+pub async fn unified_team_update_member_role(
+    app_handle: tauri::AppHandle,
+    oss_state: State<'_, OssSyncState>,
+    #[cfg(feature = "p2p")]
+    iroh_state: State<'_, IrohState>,
+    node_id: String,
+    role: MemberRole,
+) -> Result<(), String> {
+    require_manager_role(&app_handle, &oss_state, #[cfg(feature = "p2p")] &iroh_state).await?;
+
+    let status = check_team_status(&app_handle).await?;
+    match status.mode.as_deref() {
+        Some("oss") => {
+            let guard = oss_state.0.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            manager.update_member_role(&node_id, role).await
+        }
+        #[cfg(feature = "p2p")]
+        Some("p2p") => {
+            let node = iroh_state.0.lock().await;
+            let node = node.as_ref().ok_or("P2P node not initialized")?;
+            node.update_member_role(&app_handle, &node_id, role).await
+        }
+        _ => Err("No active team mode".to_string()),
+    }
+}
+
+/// Get current device's role in the active team
+#[tauri::command]
+pub async fn unified_team_get_my_role(
+    app_handle: tauri::AppHandle,
+    oss_state: State<'_, OssSyncState>,
+    #[cfg(feature = "p2p")]
+    iroh_state: State<'_, IrohState>,
+) -> Result<Option<MemberRole>, String> {
+    let status = check_team_status(&app_handle).await?;
+    let device_info = super::team_p2p::get_device_metadata();
+    let local_node_id = &device_info.node_id;
+
+    match status.mode.as_deref() {
+        Some("oss") => {
+            let guard = oss_state.0.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            let manifest = manager.download_members_manifest().await?;
+            Ok(manifest.and_then(|m| find_member_role(&m, local_node_id)))
+        }
+        #[cfg(feature = "p2p")]
+        Some("p2p") => {
+            let config = super::team_p2p::read_p2p_config(&app_handle)?;
+            Ok(config.allowed_members.iter()
+                .find(|m| m.node_id == *local_node_id)
+                .map(|m| m.role.clone()))
+        }
+        _ => Ok(None),
+    }
+}
+```
+
+- [ ] **Step 2: Register unified commands in `lib.rs`**
+
+Add the new commands to the `invoke_handler` in `src-tauri/src/lib.rs` (after the existing OSS commands block, around line ~462):
+
+```rust
+// Unified team commands
+unified_team_get_members,
+unified_team_add_member,
+unified_team_remove_member,
+unified_team_update_member_role,
+unified_team_get_my_role,
+```
+
+Add the import at the top:
+```rust
+use commands::team_unified::{
+    unified_team_get_members,
+    unified_team_add_member,
+    unified_team_remove_member,
+    unified_team_update_member_role,
+    unified_team_get_my_role,
+};
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw-worktrees/feature/team-improvement && cargo check -p teamclaw 2>&1 | tail -10`
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/commands/team_unified.rs src-tauri/src/lib.rs
+git commit -m "feat(team): add unified Tauri commands for member management"
+```
+
+---
+
+## Task 6: Update Frontend Types
+
+Add unified result/error types to the frontend TypeScript definitions.
+
+**Files:**
+- Modify: `packages/app/src/lib/git/types.ts:96-163,225`
+
+- [ ] **Step 1: Update `TeamMember` interface to ensure it has `label` field**
+
+In `types.ts`, verify the existing `TeamMember` interface (lines ~96-113) has the `label` field. If missing, add it:
+
+```typescript
+interface TeamMember {
+  nodeId: string
+  name: string
+  role?: 'owner' | 'editor' | 'viewer'
+  label: string          // <-- ensure this exists
+  platform: string
+  arch: string
+  hostname: string
+  addedAt: string
+}
+```
+
+- [ ] **Step 2: Add unified result/error types**
+
+Add after the existing team types (after line ~225):
+
+```typescript
+// Unified team management types
+export interface TeamCreateResult {
+  teamId: string | null
+  ticket: string
+}
+
+export interface TeamJoinResult {
+  success: boolean
+  role: 'owner' | 'editor' | 'viewer'
+  members: TeamMember[]
+}
+
+export type TeamJoinErrorType =
+  | 'InvalidTicket'
+  | 'DeviceNotRegistered'
+  | 'AlreadyInTeam'
+  | 'SyncError'
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/app/src/lib/git/types.ts
+git commit -m "feat(team): add unified team types to frontend"
+```
+
+---
+
+## Task 7: Create Unified Team Members Zustand Store
+
+Create a unified store that manages team members via the new unified Tauri commands, replacing direct calls from individual components.
+
+**Files:**
+- Create: `packages/app/src/stores/team-members.ts`
+
+- [ ] **Step 1: Create the store**
+
+```typescript
+// packages/app/src/stores/team-members.ts
+import { create } from 'zustand'
+import { invoke } from '@tauri-apps/api/core'
+import type { TeamMember } from '../lib/git/types'
+
+type MemberRole = 'owner' | 'editor' | 'viewer'
+
+interface TeamMembersState {
+  members: TeamMember[]
+  myRole: MemberRole | null
+  loading: boolean
+  error: string | null
+
+  loadMembers: () => Promise<void>
+  loadMyRole: () => Promise<void>
+  addMember: (member: TeamMember) => Promise<void>
+  removeMember: (nodeId: string) => Promise<void>
+  updateMemberRole: (nodeId: string, role: MemberRole) => Promise<void>
+  canManageMembers: () => boolean
+}
+
+export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
+  members: [],
+  myRole: null,
+  loading: false,
+  error: null,
+
+  loadMembers: async () => {
+    set({ loading: true, error: null })
+    try {
+      const members = await invoke<TeamMember[]>('unified_team_get_members')
+      set({ members, loading: false })
+    } catch (e) {
+      set({ error: String(e), loading: false })
+    }
+  },
+
+  loadMyRole: async () => {
+    try {
+      const role = await invoke<MemberRole | null>('unified_team_get_my_role')
+      set({ myRole: role })
+    } catch {
+      set({ myRole: null })
+    }
+  },
+
+  addMember: async (member: TeamMember) => {
+    set({ error: null })
+    try {
+      await invoke('unified_team_add_member', { member })
+      await get().loadMembers()
+    } catch (e) {
+      set({ error: String(e) })
+      throw e
+    }
+  },
+
+  removeMember: async (nodeId: string) => {
+    set({ error: null })
+    try {
+      await invoke('unified_team_remove_member', { nodeId })
+      await get().loadMembers()
+    } catch (e) {
+      set({ error: String(e) })
+      throw e
+    }
+  },
+
+  updateMemberRole: async (nodeId: string, role: MemberRole) => {
+    set({ error: null })
+    try {
+      await invoke('unified_team_update_member_role', { nodeId, role })
+      await get().loadMembers()
+    } catch (e) {
+      set({ error: String(e) })
+      throw e
+    }
+  },
+
+  canManageMembers: () => {
+    const { myRole } = get()
+    return myRole === 'owner' || myRole === 'editor'
+  },
+}))
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/app/src/stores/team-members.ts
+git commit -m "feat(team): create unified team members Zustand store"
+```
+
+---
+
+## Task 8: Update TeamMemberList Component with Role-Based Access
+
+Modify `TeamMemberList` to use the unified store and conditionally render controls based on the current user's role.
+
+**Files:**
+- Modify: `packages/app/src/components/settings/TeamMemberList.tsx`
+
+- [ ] **Step 1: Refactor TeamMemberList to use unified store**
+
+Replace the existing props-based approach with the unified store. The component should:
+- Use `useTeamMembersStore` for members data and actions
+- Show Add button only for Owner/Editor (`canManageMembers()`)
+- Show edit/remove controls only for Owner/Editor
+- Owner cannot be removed or demoted by Editor
+- Viewer sees read-only list
+
+Key changes to the component:
+
+```typescript
+import { useTeamMembersStore } from '../../stores/team-members'
+
+export function TeamMemberList() {
+  const { members, myRole, loadMembers, removeMember, updateMemberRole, canManageMembers } =
+    useTeamMembersStore()
+
+  useEffect(() => {
+    loadMembers()
+  }, [])
+
+  const isManager = canManageMembers()
+
+  return (
+    <div>
+      {/* Header with optional Add button */}
+      <div className="flex items-center justify-between">
+        <h3>Team Members</h3>
+        {isManager && <AddMemberInput />}
+      </div>
+
+      {/* Member rows */}
+      {members.map((member) => (
+        <div key={member.nodeId}>
+          {/* Name, role badge, truncated NodeId, label */}
+          <span>{member.name}</span>
+          <RoleBadge role={member.role} />
+          <span>{truncateId(member.nodeId)}</span>
+          {member.label && <span>{member.label}</span>}
+
+          {/* Actions: only for managers, and cannot act on Owner */}
+          {isManager && member.role !== 'owner' && (
+            <>
+              <button onClick={() => updateMemberRole(
+                member.nodeId,
+                member.role === 'editor' ? 'viewer' : 'editor'
+              )}>
+                Toggle Role
+              </button>
+              <button onClick={() => removeMember(member.nodeId)}>
+                Remove
+              </button>
+            </>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+Keep the existing `RoleBadge` helper and `truncateId` utility.
+
+- [ ] **Step 2: Update existing usages of TeamMemberList**
+
+In `TeamP2PConfig.tsx` (lines ~434-487), replace the current inline member management with the unified `<TeamMemberList />` component (no props needed, it uses the store).
+
+In `TeamOSSConfig.tsx`, add `<TeamMemberList />` to the connected state section if not already present.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/app/src/components/settings/TeamMemberList.tsx \
+      packages/app/src/components/settings/team/TeamP2PConfig.tsx \
+      packages/app/src/components/settings/team/TeamOSSConfig.tsx
+git commit -m "feat(team): update TeamMemberList with role-based access control"
+```
+
+---
+
+## Task 9: Update AddMemberInput with Label Field
+
+Add the `label` (remark/note) field to the add member form.
+
+**Files:**
+- Modify: `packages/app/src/components/settings/AddMemberInput.tsx`
+
+- [ ] **Step 1: Add label field to AddMemberInput**
+
+Add a `label` state variable and input field between the existing NodeId and Role fields:
+
+```typescript
+const [label, setLabel] = useState('')
+
+// In handleSubmit, pass label to the store:
+const handleSubmit = async () => {
+  if (!nodeId.trim() || !name.trim()) return
+  await onAdd(nodeId.trim(), name.trim(), role, label.trim())
+  setNodeId('')
+  setName('')
+  setLabel('')
+  setRole('editor')
+}
+```
+
+Add the label input in the form:
+```tsx
+<input
+  type="text"
+  placeholder="Label / Remark (optional)"
+  value={label}
+  onChange={(e) => setLabel(e.target.value)}
+  className="..."
+/>
+```
+
+- [ ] **Step 2: Update `onAdd` prop signature**
+
+Change from `(nodeId: string, name: string, role: string) => void` to `(nodeId: string, name: string, role: string, label: string) => void`.
+
+Update all callers to pass the label through to the unified store's `addMember`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/app/src/components/settings/AddMemberInput.tsx
+git commit -m "feat(team): add label/remark field to AddMemberInput"
+```
+
+---
+
+## Task 10: Update OSS Create/Join UI for Two-Step Validation
+
+Modify `TeamOSSConfig.tsx` to show proper error messages for ticket validation and NodeId validation failures.
+
+**Files:**
+- Modify: `packages/app/src/components/settings/team/TeamOSSConfig.tsx:72-99`
+
+- [ ] **Step 1: Update join handler with error differentiation**
+
+In `handleJoinTeam()` (lines ~87-99), parse the error response to show different messages:
+
+```typescript
+const handleJoinTeam = async () => {
+  setJoining(true)
+  setError(null)
+  try {
+    await ossStore.joinTeam(joinTeamId, joinTeamSecret)
+    // On success, load members via unified store
+    await teamMembersStore.loadMembers()
+    await teamMembersStore.loadMyRole()
+  } catch (e: any) {
+    const msg = String(e)
+    if (msg.includes('not been added') || msg.includes('未被添加')) {
+      setError(t('team.error.deviceNotRegistered',
+        'Your device has not been added to the team. Please contact the team Owner'))
+    } else {
+      setError(t('team.error.invalidTicket',
+        'Invalid ticket, please check and try again'))
+    }
+  } finally {
+    setJoining(false)
+  }
+}
+```
+
+- [ ] **Step 2: Add DeviceIdDisplay to OSS config**
+
+In the OSS create/join form area, add the `DeviceIdDisplay` component so members can easily copy their NodeId to share with the owner:
+
+```tsx
+import DeviceIdDisplay from '../DeviceIdDisplay'
+
+// In the join form section, above the join inputs:
+{deviceInfo && <DeviceIdDisplay nodeId={deviceInfo.nodeId} />}
+```
+
+Load `deviceInfo` via `get_device_info()` in a `useEffect`.
+
+- [ ] **Step 3: Add TeamMemberList to OSS connected state**
+
+In the connected state section (lines ~221-271), add the unified `<TeamMemberList />` below the team info display.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/app/src/components/settings/team/TeamOSSConfig.tsx
+git commit -m "feat(team): add two-step validation UI and member list to OSS config"
+```
+
+---
+
+## Task 11: Update P2P Create/Join UI for Consistency
+
+Align `TeamP2PConfig.tsx` join flow to use the same two-step validation error messaging.
+
+**Files:**
+- Modify: `packages/app/src/components/settings/team/TeamP2PConfig.tsx:242-271`
+
+- [ ] **Step 1: Update P2P join handler error messages**
+
+In `doJoinTeam()` (lines ~242-271), differentiate error messages:
+
+```typescript
+const doJoinTeam = async () => {
+  setJoinLoading(true)
+  setP2pError(null)
+  try {
+    await tauriInvoke('p2p_join_drive', { ticket: joinTicketInput.trim() })
+    await loadSyncStatus()
+    // Load unified members
+    await teamMembersStore.loadMembers()
+    await teamMembersStore.loadMyRole()
+  } catch (e: any) {
+    const msg = String(e)
+    if (msg.includes('not been added') || msg.includes('not authorized') || msg.includes('未被添加')) {
+      setP2pError(t('team.error.deviceNotRegistered',
+        'Your device has not been added to the team. Please contact the team Owner'))
+    } else {
+      setP2pError(t('team.error.invalidTicket',
+        'Invalid ticket, please check and try again'))
+    }
+  } finally {
+    setJoinLoading(false)
+  }
+}
+```
+
+- [ ] **Step 2: Replace inline member management with unified TeamMemberList**
+
+In the team members section (lines ~434-487), replace the current inline member list and `AddMemberInput` usage with:
+
+```tsx
+<TeamMemberList />
+```
+
+The unified `TeamMemberList` component already handles loading, add, remove, and role changes via the unified store.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/app/src/components/settings/team/TeamP2PConfig.tsx
+git commit -m "feat(team): align P2P join flow with unified validation messaging"
+```
+
+---
+
+## Task 12: Update team-mode Store for Role
+
+Update `team-mode.ts` to load the current user's role from the unified store on team mode activation.
+
+**Files:**
+- Modify: `packages/app/src/stores/team-mode.ts:73-89`
+
+- [ ] **Step 1: Load myRole in loadTeamConfig**
+
+In `loadTeamConfig()` (lines ~73-89), after loading team status, also load the role:
+
+```typescript
+loadTeamConfig: async () => {
+  const status = await fetchTeamStatus()
+  if (status?.active && status.mode) {
+    set({ teamMode: status.mode as TeamSyncMode })
+    if (status.llm) {
+      set({ teamModelConfig: status.llm })
+    }
+    // Load current user's role
+    try {
+      const role = await invoke<string | null>('unified_team_get_my_role')
+      set({ myRole: role as MemberRole | null })
+    } catch {
+      // Non-critical, role can be loaded later
+    }
+  }
+},
+```
+
+Ensure `myRole` is part of the `TeamModeState` interface (it's already there based on the exploration).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/app/src/stores/team-mode.ts
+git commit -m "feat(team): load user role on team mode activation"
+```
+
+---
+
+## Task 13: Integration Testing
+
+Write a functional test for the unified create → add member → join flow.
+
+**Files:**
+- Create: `tests/functional/team-unified-management.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Follow the existing test pattern from `team-device-identity.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import {
+  launchTeamClawApp,
+  stopApp,
+  sleep,
+  focusWindow,
+  executeJs,
+} from '../_utils/tauri-mcp-test-utils'
+
+describe('Functional: Unified Team Management', () => {
+  let appReady = false
+
+  beforeAll(async () => {
+    try {
+      await launchTeamClawApp()
+      await sleep(8000)
+      await focusWindow()
+      await sleep(500)
+
+      // Navigate to Settings → Team
+      await executeJs(`
+        (() => {
+          const btn = document.querySelector('[data-testid="settings-button"]')
+            || document.querySelector('button:has(svg.lucide-settings)');
+          btn?.click();
+        })()
+      `)
+      await sleep(1000)
+      await executeJs(`
+        (() => {
+          const items = document.querySelectorAll('button, [role="menuitem"], a');
+          for (const item of items) {
+            if (item.textContent?.trim() === 'Team') { item.click(); break; }
+          }
+        })()
+      `)
+      await sleep(1000)
+      appReady = true
+    } catch (err) {
+      console.error('Setup failed:', (err as Error).message)
+    }
+  }, 60_000)
+
+  afterAll(async () => {
+    await stopApp()
+  })
+
+  it('should display device NodeId on team page', async () => {
+    if (!appReady) return
+    const hasNodeId = await executeJs(`
+      (() => {
+        const el = document.querySelector('[data-testid="device-node-id"]')
+          || document.querySelector('code');
+        return el?.textContent?.length > 0;
+      })()
+    `)
+    expect(hasNodeId).toBe(true)
+  })
+
+  it('should show member list when team is connected', async () => {
+    if (!appReady) return
+    // This test checks that the TeamMemberList component renders
+    const hasMemberSection = await executeJs(`
+      (() => {
+        const headings = document.querySelectorAll('h3, h4, [class*="heading"]');
+        for (const h of headings) {
+          if (h.textContent?.includes('Members') || h.textContent?.includes('成员')) return true;
+        }
+        return false;
+      })()
+    `)
+    // May or may not show depending on team connection state
+    expect(typeof hasMemberSection).toBe('boolean')
+  })
+
+  it('should show role badges for members', async () => {
+    if (!appReady) return
+    const hasBadges = await executeJs(`
+      (() => {
+        const badges = document.querySelectorAll('[data-testid="role-badge"]');
+        return badges.length;
+      })()
+    `)
+    expect(typeof hasBadges).toBe('number')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it executes**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw-worktrees/feature/team-improvement && npx vitest run tests/functional/team-unified-management.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Note: Functional tests may require the app to be running. If they fail due to app not being available, that's expected in CI — the test structure is what matters.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/functional/team-unified-management.test.ts
+git commit -m "test(team): add functional tests for unified team management"
+```
+
+---
+
+## Task 14: Final Verification & Cleanup
+
+Verify everything compiles, tests pass, and the feature works end-to-end.
+
+**Files:** All modified files
+
+- [ ] **Step 1: Run cargo check**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw-worktrees/feature/team-improvement && cargo check -p teamclaw 2>&1 | tail -10`
+Expected: no errors
+
+- [ ] **Step 2: Run TypeScript type check**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw-worktrees/feature/team-improvement/packages/app && npx tsc --noEmit 2>&1 | tail -10`
+Expected: no type errors
+
+- [ ] **Step 3: Run existing tests to verify no regressions**
+
+Run: `cd /Users/matt.chow/workspace/teamclaw-worktrees/feature/team-improvement && npx vitest run tests/functional/team-device-identity.test.ts --reporter=verbose 2>&1 | tail -20`
+Expected: existing tests still pass
+
+- [ ] **Step 4: Verify i18n keys exist for error messages**
+
+Check that the translation keys used (`team.error.deviceNotRegistered`, `team.error.invalidTicket`) are added to the i18n locale files. If the project uses fallback strings (which it appears to based on `t('key', 'fallback')`), this is handled automatically but should be added for completeness.
+
+- [ ] **Step 5: Commit any remaining changes**
+
+```bash
+git add -A
+git commit -m "chore(team): final cleanup for unified team management"
+```

--- a/docs/superpowers/specs/2026-03-23-unified-team-management-design.md
+++ b/docs/superpowers/specs/2026-03-23-unified-team-management-design.md
@@ -1,0 +1,291 @@
+# Unified Team Management Design
+
+## Problem
+
+TeamClaw supports 4 team sync modes (OSS/S3, P2P, WebDAV, Git). The team member management experience is fragmented:
+- P2P has relatively complete member management (NodeId, roles, allowlist)
+- OSS has only `Owner | Member` roles with no device-level identity
+- No unified flow for creating teams, inviting members, or managing roles
+
+## Goal
+
+Unify the team management experience across OSS and P2P modes with a consistent flow:
+1. Owner creates team
+2. Member shares their NodeId (Iroh Ed25519 public key) with Owner
+3. Owner adds member info (name, NodeId, label, role)
+4. Owner gives member team ID + ticket
+5. Member joins with ticket; validated against NodeId allowlist
+6. Team member list visible to all; editable by Owner and Editor only
+
+## Data Model
+
+### Unified Role Enum
+
+```
+Owner | Editor | Viewer
+```
+
+**Permissions:**
+| Action | Owner | Editor | Viewer |
+|---|---|---|---|
+| Manage members (add/remove/edit) | Yes | Yes | No |
+| View member list | Yes | Yes | Yes |
+| Sync files (read/write) | Yes | Yes | Read-only |
+
+### Unified TeamMember
+
+Reuse the existing P2P `TeamMember` struct for both modes:
+
+```rust
+pub enum MemberRole {
+    Owner,
+    #[default]
+    Editor,
+    Viewer,
+}
+
+pub struct TeamMember {
+    pub node_id: String,       // Iroh NodeId (Ed25519 public key)
+    pub name: String,          // Display name
+    pub role: MemberRole,
+    pub label: String,         // Remark/note
+    pub platform: String,      // OS
+    pub arch: String,          // CPU architecture
+    pub hostname: String,      // Machine hostname
+    pub added_at: String,      // ISO 8601 timestamp
+}
+```
+
+TypeScript equivalent:
+
+```typescript
+interface TeamMember {
+  nodeId: string
+  name: string
+  role: 'owner' | 'editor' | 'viewer'
+  label: string
+  platform: string
+  arch: string
+  hostname: string
+  addedAt: string
+}
+```
+
+### Member Storage
+
+- **P2P mode**: `_team/members.json` (TeamManifest) — synced via iroh-docs
+- **OSS mode**: `_team/members.json` uploaded to S3 bucket — synced via Loro CRDT
+
+Both modes use the same JSON structure:
+
+```json
+{
+  "owner_node_id": "abc123...",
+  "members": [
+    {
+      "node_id": "abc123...",
+      "name": "Alice",
+      "role": "owner",
+      "label": "Team Lead",
+      "platform": "macos",
+      "arch": "aarch64",
+      "hostname": "alice-mbp",
+      "added_at": "2026-03-23T10:00:00Z"
+    }
+  ]
+}
+```
+
+## Unified Flow
+
+### 1. Owner Creates Team
+
+**Input:** Team name, sync mode (OSS or P2P), owner info
+
+**Backend:**
+- Initialize sync infrastructure (S3 bucket or Iroh doc)
+- Generate device NodeId via `get_device_info()`
+- Auto-add owner as first member with `Owner` role
+- Generate ticket:
+  - OSS: `team_secret` (existing mechanism)
+  - P2P: `DocTicket` (existing mechanism)
+
+**Output:** team_id (OSS) + ticket for sharing
+
+### 2. Owner Adds Members
+
+**Input:** name, NodeId, label, role (editor/viewer)
+
+**Validation:**
+- NodeId format check (valid hex string)
+- No duplicate NodeId in existing members
+- Cannot add another Owner (only one owner allowed)
+
+**Backend:**
+- Append to members manifest
+- Persist: P2P → `_team/members.json` in iroh-docs, OSS → upload to S3
+
+### 3. Member Joins Team
+
+**Input:** ticket (+ team_id for OSS)
+
+**Validation (two-step):**
+
+1. **Ticket validation:**
+   - OSS: verify team_id + team_secret against server
+   - P2P: attempt to import DocTicket
+   - Failure → error: "Ticket 不正确，请检查后重试"
+
+2. **NodeId validation:**
+   - Get local device NodeId via `get_device_info()`
+   - Download/sync members manifest
+   - Check if local NodeId exists in manifest
+   - Not found → error: "你的设备未被添加到团队中，请联系团队 Owner"
+   - Found → proceed with join, set local role from manifest
+
+**On success:**
+- Save team config locally
+- Start sync based on mode
+- Set local user's role from manifest
+
+### 4. Member List UI
+
+**Location:** Settings → Team section (existing location)
+
+**Components:**
+
+```
+┌─────────────────────────────────────────┐
+│ Team Members                    [+ Add] │  ← Add button visible for Owner/Editor
+├─────────────────────────────────────────┤
+│ 👤 Alice (Owner)         abc1...23ef    │
+│    Team Lead                            │
+├─────────────────────────────────────────┤
+│ 👤 Bob (Editor)          def4...56gh    │  ← hover shows edit/remove for Owner/Editor
+│    Backend Developer            [⋮]    │
+├─────────────────────────────────────────┤
+│ 👤 Charlie (Viewer)      ghi7...89ij    │
+│    Designer                     [⋮]    │
+└─────────────────────────────────────────┘
+```
+
+**Behavior by role:**
+- Owner/Editor: see Add button, context menu (edit role, remove member) on each row
+- Viewer: read-only, no action buttons
+- Owner cannot be removed or demoted by Editor
+
+## Unified Tauri Commands
+
+Abstract over sync mode with unified command interfaces:
+
+```rust
+// Unified commands (dispatch to OSS or P2P internally based on active mode)
+#[tauri::command]
+async fn team_create(mode: TeamSyncMode, name: String, ...) -> Result<TeamCreateResult>
+
+#[tauri::command]
+async fn team_join(mode: TeamSyncMode, ticket: String, team_id: Option<String>) -> Result<TeamJoinResult>
+
+#[tauri::command]
+async fn team_add_member(member: TeamMember) -> Result<()>
+
+#[tauri::command]
+async fn team_remove_member(node_id: String) -> Result<()>
+
+#[tauri::command]
+async fn team_update_member_role(node_id: String, role: MemberRole) -> Result<()>
+
+#[tauri::command]
+async fn team_get_members() -> Result<Vec<TeamMember>>
+
+#[tauri::command]
+async fn get_device_info() -> Result<DeviceInfo>  // Already exists
+```
+
+**Return types:**
+
+```rust
+pub struct TeamCreateResult {
+    pub team_id: Option<String>,  // OSS only
+    pub ticket: String,           // DocTicket or team_secret
+}
+
+pub struct TeamJoinResult {
+    pub success: bool,
+    pub role: MemberRole,
+    pub members: Vec<TeamMember>,
+}
+
+pub enum TeamJoinError {
+    InvalidTicket,                // Ticket verification failed
+    DeviceNotRegistered,          // NodeId not in allowlist
+    AlreadyInTeam,                // Already a member
+    SyncError(String),            // Infrastructure error
+}
+```
+
+## Changes Required
+
+### Rust Backend
+
+1. **New file: `src-tauri/src/commands/team_unified.rs`**
+   - Unified command handlers that dispatch to OSS or P2P backends
+   - Shared `TeamMember`, `MemberRole` types (move from team_p2p.rs)
+
+2. **Modify `oss_sync.rs`:**
+   - Add NodeId support: call `get_device_info()` to get local NodeId
+   - Add members manifest management (upload/download `_team/members.json` to S3)
+   - Add NodeId validation on join
+   - Replace `TeamRole::Owner | Member` with unified `MemberRole::Owner | Editor | Viewer`
+
+3. **Modify `team_p2p.rs`:**
+   - Import shared `TeamMember` / `MemberRole` from unified module
+   - Ensure join flow checks NodeId against manifest before allowing sync
+   - No major structural changes needed (P2P already has most of this)
+
+4. **Modify `team.rs`:**
+   - Update `check_team_status()` to return unified role info
+
+### React Frontend
+
+1. **Modify `lib/git/types.ts`:**
+   - Unify `TeamMember` type (already close to P2P version)
+   - Add `TeamCreateResult`, `TeamJoinResult`, `TeamJoinError` types
+
+2. **Modify `components/settings/team/TeamOSSConfig.tsx`:**
+   - Use unified create/join flow with NodeId validation
+   - Show proper error messages for two-step validation
+
+3. **Modify `components/settings/team/TeamP2PConfig.tsx`:**
+   - Use unified create/join flow
+   - Align UI with OSS version
+
+4. **Modify `components/settings/TeamMemberList.tsx`:**
+   - Accept current user's role as prop
+   - Conditionally render add/edit/remove controls
+   - Use unified `team_get_members` command
+
+5. **Modify `components/settings/AddMemberInput.tsx`:**
+   - Ensure role selector offers `Owner | Editor | Viewer`
+   - Add label/remark field if not present
+
+6. **Modify `components/settings/DeviceIdDisplay.tsx`:**
+   - Ensure it works in both OSS and P2P contexts
+
+## Error Handling
+
+| Scenario | Error Message (zh) | Error Message (en) |
+|---|---|---|
+| Invalid ticket | Ticket 不正确，请检查后重试 | Invalid ticket, please check and try again |
+| Device not registered | 你的设备未被添加到团队中，请联系团队 Owner | Your device has not been added to the team. Please contact the team Owner |
+| Duplicate NodeId | 该设备已存在于团队中 | This device already exists in the team |
+| Cannot remove Owner | 无法移除团队 Owner | Cannot remove the team Owner |
+| Network/sync error | 同步失败：{detail} | Sync failed: {detail} |
+
+## Testing
+
+- Unit tests for NodeId validation logic
+- Unit tests for role-based permission checks
+- Integration tests for create → add member → join flow (both modes)
+- UI tests for member list role-based rendering
+- Error case tests: invalid ticket, unregistered device

--- a/docs/superpowers/specs/2026-03-23-unified-team-management-design.md
+++ b/docs/superpowers/specs/2026-03-23-unified-team-management-design.md
@@ -7,6 +7,10 @@ TeamClaw supports 4 team sync modes (OSS/S3, P2P, WebDAV, Git). The team member 
 - OSS has only `Owner | Member` roles with no device-level identity
 - No unified flow for creating teams, inviting members, or managing roles
 
+## Scope
+
+This iteration covers **OSS (S3) and P2P modes only**. WebDAV and Git (Legacy) modes are out of scope — the unified commands do not need dispatch branches for them.
+
 ## Goal
 
 Unify the team management experience across OSS and P2P modes with a consistent flow:
@@ -120,6 +124,8 @@ Both modes use the same JSON structure:
 - NodeId format check (valid hex string)
 - No duplicate NodeId in existing members
 - Cannot add another Owner (only one owner allowed)
+
+**Authorization:** Backend derives caller's role from local NodeId lookup in manifest. Only Owner and Editor can add members.
 
 **Backend:**
 - Append to members manifest

--- a/packages/app/src/components/settings/AddMemberInput.tsx
+++ b/packages/app/src/components/settings/AddMemberInput.tsx
@@ -14,18 +14,20 @@ export function AddMemberInput({
   onAdd,
   error,
 }: {
-  onAdd: (nodeId: string, name: string, role: string) => void
+  onAdd: (nodeId: string, name: string, role: string, label: string) => void
   error?: string | null
 }) {
   const [nodeId, setNodeId] = React.useState('')
   const [name, setName] = React.useState('')
+  const [label, setLabel] = React.useState('')
   const [role, setRole] = React.useState<'editor' | 'viewer'>('editor')
 
   const handleSubmit = () => {
     if (nodeId.trim()) {
-      onAdd(nodeId.trim(), name.trim(), role)
+      onAdd(nodeId.trim(), name.trim(), role, label.trim())
       setNodeId('')
       setName('')
+      setLabel('')
       setRole('editor')
     }
   }
@@ -40,26 +42,30 @@ export function AddMemberInput({
             placeholder="Member name (e.g. Alice)"
             className="h-9 text-sm"
           />
-          <div className="flex gap-1.5">
-            <Input
-              value={nodeId}
-              onChange={(e) => setNodeId(e.target.value)}
-              placeholder="Paste member's Device ID"
-              className="h-9 font-mono text-xs flex-1"
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && nodeId.trim()) handleSubmit()
-              }}
-            />
-            <Select value={role} onValueChange={(v) => setRole(v as 'editor' | 'viewer')}>
-              <SelectTrigger className="h-9 w-[120px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="editor">Editor</SelectItem>
-                <SelectItem value="viewer">Viewer</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          <Input
+            value={nodeId}
+            onChange={(e) => setNodeId(e.target.value)}
+            placeholder="Paste member's Device ID"
+            className="h-9 font-mono text-xs"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && nodeId.trim()) handleSubmit()
+            }}
+          />
+          <Input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Label / Remark (optional)"
+            className="h-9 text-sm"
+          />
+          <Select value={role} onValueChange={(v) => setRole(v as 'editor' | 'viewer')}>
+            <SelectTrigger className="h-9">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="editor">Editor</SelectItem>
+              <SelectItem value="viewer">Viewer</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
         <Button
           onClick={handleSubmit}

--- a/packages/app/src/components/settings/TeamMemberList.tsx
+++ b/packages/app/src/components/settings/TeamMemberList.tsx
@@ -1,14 +1,16 @@
-import { UserMinus, Shield, Pencil, Eye } from 'lucide-react'
+import { useEffect } from 'react'
+import { UserMinus, Shield, Pencil, Eye, UserPlus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import type { TeamMember } from '@/lib/git/types'
+import { useTeamMembersStore } from '../../stores/team-members'
+import { AddMemberInput } from './AddMemberInput'
 
 function truncateId(id: string): string {
   if (id.length <= 16) return id
   return `${id.slice(0, 8)}...${id.slice(-8)}`
 }
 
-function RoleBadge({ role, isOwner }: { role?: string; isOwner: boolean }) {
-  if (isOwner) {
+function RoleBadge({ role }: { role?: string }) {
+  if (role === 'owner') {
     return (
       <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 px-1.5 py-0.5 rounded">
         <Shield className="h-3 w-3" />
@@ -32,72 +34,125 @@ function RoleBadge({ role, isOwner }: { role?: string; isOwner: boolean }) {
   )
 }
 
-export function TeamMemberList({
-  members,
-  ownerNodeId,
-  isOwner,
-  onRemove,
-  onRoleChange,
-}: {
-  members: TeamMember[]
-  ownerNodeId: string
-  isOwner: boolean
-  onRemove: (nodeId: string) => void
-  onRoleChange?: (nodeId: string, newRole: 'editor' | 'viewer') => void
-}) {
+export function TeamMemberList() {
+  const {
+    members,
+    myRole,
+    loading,
+    error,
+    loadMembers,
+    loadMyRole,
+    addMember,
+    removeMember,
+    updateMemberRole,
+    canManageMembers,
+  } = useTeamMembersStore()
+
+  useEffect(() => {
+    loadMembers()
+    loadMyRole()
+  }, [])
+
+  const isManager = canManageMembers()
+  const isOwner = myRole === 'owner'
+
+  const handleAdd = async (nodeId: string, name: string, role: string, label: string) => {
+    await addMember({
+      nodeId,
+      name,
+      label,
+      role: role as 'editor' | 'viewer',
+      platform: '',
+      arch: '',
+      hostname: '',
+      addedAt: new Date().toISOString(),
+    })
+  }
+
   return (
-    <div className="space-y-2">
-      {members.map((member) => {
-        const isMemberOwner = member.nodeId === ownerNodeId
-        return (
-          <div
-            key={member.nodeId}
-            className="flex items-center justify-between bg-muted/50 rounded-md p-3"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <p className="text-sm font-medium truncate">{member.name || member.label || member.hostname}</p>
-                <RoleBadge role={member.role} isOwner={isMemberOwner} />
+    <div className="space-y-4">
+      {loading && (
+        <p className="text-sm text-muted-foreground">Loading members...</p>
+      )}
+      {error && (
+        <p className="text-xs text-destructive">{error}</p>
+      )}
+      <div className="space-y-2">
+        {members.map((member) => {
+          const isMemberOwner = member.role === 'owner'
+          // Editors cannot remove or demote the owner
+          const canActOnMember = isManager && !isMemberOwner && !(myRole === 'editor' && isMemberOwner)
+
+          return (
+            <div
+              key={member.nodeId}
+              className="flex items-center justify-between bg-muted/50 rounded-md p-3"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium truncate">
+                    {member.name || member.hostname}
+                  </p>
+                  <RoleBadge role={member.role} />
+                </div>
+                {member.label && (
+                  <p className="text-xs text-muted-foreground truncate">{member.label}</p>
+                )}
+                <p className="text-xs font-mono text-muted-foreground truncate">
+                  {truncateId(member.nodeId)}
+                </p>
+                <p className="text-[10px] text-muted-foreground">
+                  {member.platform} {member.arch} · {member.hostname}
+                </p>
               </div>
-              <p className="text-xs font-mono text-muted-foreground truncate">
-                {truncateId(member.nodeId)}
-              </p>
-              <p className="text-[10px] text-muted-foreground">
-                {member.platform} {member.arch} · {member.hostname}
-              </p>
+              <div className="flex items-center gap-1">
+                {canActOnMember && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="shrink-0 text-muted-foreground"
+                    onClick={() =>
+                      updateMemberRole(
+                        member.nodeId,
+                        member.role === 'viewer' ? 'editor' : 'viewer'
+                      )
+                    }
+                    aria-label="Toggle role"
+                  >
+                    {member.role === 'viewer' ? (
+                      <Pencil className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                    {member.role === 'viewer' ? 'Set Editor' : 'Set Viewer'}
+                  </Button>
+                )}
+                {canActOnMember && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="shrink-0 text-destructive hover:text-destructive"
+                    onClick={() => removeMember(member.nodeId)}
+                    aria-label="Remove"
+                  >
+                    <UserMinus className="h-4 w-4" />
+                    Remove
+                  </Button>
+                )}
+              </div>
             </div>
-            <div className="flex items-center gap-1">
-              {isOwner && !isMemberOwner && onRoleChange && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="shrink-0 text-muted-foreground"
-                  onClick={() => onRoleChange(
-                    member.nodeId,
-                    member.role === 'viewer' ? 'editor' : 'viewer'
-                  )}
-                  aria-label="Toggle role"
-                >
-                  {member.role === 'viewer' ? <Pencil className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  {member.role === 'viewer' ? 'Set Editor' : 'Set Viewer'}
-                </Button>
-              )}
-              {isOwner && !isMemberOwner && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="shrink-0 text-destructive hover:text-destructive"
-                  onClick={() => onRemove(member.nodeId)}
-                  aria-label="Remove"
-                >
-                  <UserMinus className="h-4 w-4" />
-                  Remove
-                </Button>
-              )}
-            </div>
+          )
+        })}
+      </div>
+      {isManager && (
+        <div className="pt-2 border-t border-border">
+          <div className="flex items-center gap-1.5 mb-2">
+            <UserPlus className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">Add Member</span>
           </div>
-        )
-      })}
+          <AddMemberInput onAdd={handleAdd} error={error} />
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -3,6 +3,11 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useTeamOssStore } from '@/stores/team-oss'
 import { useWorkspaceStore } from '@/stores/workspace'
+import { useTeamMembersStore } from '@/stores/team-members'
+import { DeviceIdDisplay } from '@/components/settings/DeviceIdDisplay'
+import { TeamMemberList } from '@/components/settings/TeamMemberList'
+import { invoke } from '@tauri-apps/api/core'
+import type { DeviceInfo } from '@/lib/git/types'
 
 function SettingCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -39,6 +44,8 @@ export function TeamOSSConfig() {
     cleanup,
   } = useTeamOssStore()
 
+  const teamMembersStore = useTeamMembersStore()
+
   // Create team form
   const [teamName, setTeamName] = useState('')
   const [ownerName, setOwnerName] = useState('')
@@ -55,6 +62,7 @@ export function TeamOSSConfig() {
   const [showSecret, setShowSecret] = useState(false)
   const [snapshotLoading, setSnapshotLoading] = useState<string | null>(null)
   const [cleanupLoading, setCleanupLoading] = useState<string | null>(null)
+  const [deviceInfo, setDeviceInfo] = useState<DeviceInfo | null>(null)
 
   useEffect(() => {
     if (workspacePath) {
@@ -62,6 +70,10 @@ export function TeamOSSConfig() {
     }
     return () => cleanup()
   }, [workspacePath, initialize, cleanup])
+
+  useEffect(() => {
+    invoke<DeviceInfo>('get_device_info').then(setDeviceInfo).catch(() => {})
+  }, [])
 
   useEffect(() => {
     if (workspacePath && connected) {
@@ -91,12 +103,20 @@ export function TeamOSSConfig() {
       await joinTeam({ workspacePath, teamId: joinTeamId, teamSecret: joinTeamSecret })
       setJoinTeamId('')
       setJoinTeamSecret('')
-    } catch {
-      // error is set in the store
+      // Load unified members after successful join
+      await teamMembersStore.loadMembers()
+      await teamMembersStore.loadMyRole()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg.includes('not been added') || msg.includes('未被添加')) {
+        useTeamOssStore.setState({ error: 'Your device has not been added to the team. Please contact the team Owner' })
+      } else {
+        useTeamOssStore.setState({ error: 'Invalid ticket, please check and try again' })
+      }
     } finally {
       setJoining(false)
     }
-  }, [workspacePath, joinTeamId, joinTeamSecret, joinTeam])
+  }, [workspacePath, joinTeamId, joinTeamSecret, joinTeam, teamMembersStore])
 
   const handleLeaveTeam = useCallback(async () => {
     if (!workspacePath) return
@@ -210,6 +230,12 @@ export function TeamOSSConfig() {
               >
                 {joining ? '加入中...' : '加入团队'}
               </Button>
+              {deviceInfo && (
+                <div className="pt-1">
+                  <label className="mb-1 block text-xs text-muted-foreground">我的设备 ID（分享给团队 Owner 以加入团队）</label>
+                  <DeviceIdDisplay nodeId={deviceInfo.nodeId} />
+                </div>
+              )}
             </div>
           </SettingCard>
         </>
@@ -269,6 +295,10 @@ export function TeamOSSConfig() {
                 <span>{isOwner ? '管理员' : '成员'}</span>
               </div>
             </div>
+          </SettingCard>
+
+          <SettingCard title="团队成员">
+            <TeamMemberList />
           </SettingCard>
 
           <SettingCard title="同步状态">

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -21,6 +21,7 @@ import {
 import { cn, isTauri, copyToClipboard } from '@/lib/utils'
 import { buildConfig } from '@/lib/build-config'
 import { useTeamModeStore } from '@/stores/team-mode'
+import { useTeamMembersStore } from '@/stores/team-members'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { DeviceIdDisplay } from '@/components/settings/DeviceIdDisplay'
 import { TeamMemberList } from '@/components/settings/TeamMemberList'
@@ -132,6 +133,8 @@ function TeamApiKeyCard() {
 export function TeamP2PConfig() {
   const { t } = useTranslation()
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
+
+  const teamMembersStore = useTeamMembersStore()
 
   const [p2pError, setP2pError] = React.useState<string | null>(null)
   const [joinTicketInput, setJoinTicketInput] = React.useState('')
@@ -247,6 +250,9 @@ export function TeamP2PConfig() {
       await tauriInvoke('p2p_join_drive', { ticket: joinTicketInput.trim(), label: '' })
       setJoinTicketInput('')
       await loadSyncStatus()
+      // Load unified members after successful join
+      await teamMembersStore.loadMembers()
+      await teamMembersStore.loadMyRole()
       // Reload team config so LLM section switches to team mode
       if (workspacePath) {
         const store = useTeamModeStore.getState()
@@ -257,10 +263,11 @@ export function TeamP2PConfig() {
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      if (msg.toLowerCase().includes('not authorized')) {
+      if (msg.includes('not been added') || msg.includes('not authorized') || msg.includes('未被添加')) {
         setJoinApprovalPending(true)
+        setP2pError('Your device has not been added to the team. Please contact the team Owner')
       } else {
-        setP2pError(msg)
+        setP2pError('Invalid ticket, please check and try again')
       }
     } finally {
       setJoinLoading(false)

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -24,7 +24,6 @@ import { useTeamModeStore } from '@/stores/team-mode'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { DeviceIdDisplay } from '@/components/settings/DeviceIdDisplay'
 import { TeamMemberList } from '@/components/settings/TeamMemberList'
-import { AddMemberInput } from '@/components/settings/AddMemberInput'
 import type { DeviceInfo, TeamMember } from '@/lib/git/types'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -153,12 +152,10 @@ export function TeamP2PConfig() {
 
   // Device identity & allowlist state
   const [deviceInfo, setDeviceInfo] = React.useState<DeviceInfo | null>(null)
-  const [addMemberError, setAddMemberError] = React.useState<string | null>(null)
   const [joinApprovalPending, setJoinApprovalPending] = React.useState(false)
   const [confirmAction, setConfirmAction] = React.useState<'create' | 'join' | null>(null)
   const [confirmDisconnect, setConfirmDisconnect] = React.useState(false)
 
-  const ownerNodeId = syncStatus?.ownerNodeId ?? syncStatus?.members?.[0]?.nodeId ?? null
   const allowedMembers = syncStatus?.members ?? []
   const isOwner = syncStatus?.role === 'owner'
   const isConnected = syncStatus?.connected ?? false
@@ -444,45 +441,7 @@ export function TeamP2PConfig() {
                   </div>
                 </div>
 
-                <TeamMemberList
-                  members={allowedMembers}
-                  ownerNodeId={ownerNodeId ?? ''}
-                  isOwner={isOwner}
-                  onRemove={async (nodeId) => {
-                    try {
-                      await tauriInvoke('team_remove_member', { nodeId })
-                      await loadSyncStatus()
-                    } catch (err) {
-                      setP2pError(err instanceof Error ? err.message : String(err))
-                    }
-                  }}
-                  onRoleChange={async (nodeId, newRole) => {
-                    try {
-                      await tauriInvoke('team_update_member_role', { nodeId, role: newRole })
-                      await loadSyncStatus()
-                    } catch (err) {
-                      setP2pError(err instanceof Error ? err.message : String(err))
-                    }
-                  }}
-                />
-
-                {isOwner && (
-                  <div className="pt-2 border-t">
-                    <p className="text-xs font-medium text-muted-foreground mb-2">{t('settings.team.addMember', 'Add Member')}</p>
-                    <AddMemberInput
-                      onAdd={async (nodeId, name, role) => {
-                        setAddMemberError(null)
-                        try {
-                          await tauriInvoke('team_add_member', { nodeId, name, role })
-                          await loadSyncStatus()
-                        } catch (err) {
-                          setAddMemberError(err instanceof Error ? err.message : String(err))
-                        }
-                      }}
-                      error={addMemberError}
-                    />
-                  </div>
-                )}
+                <TeamMemberList />
               </div>
             </SettingCard>
           )}

--- a/packages/app/src/lib/git/types.ts
+++ b/packages/app/src/lib/git/types.ts
@@ -223,3 +223,21 @@ export interface WebDavSyncResult {
 }
 
 export type TeamSyncMode = 'git' | 'p2p' | 'webdav' | 'oss' | null
+
+// Unified team management types
+export interface TeamCreateResult {
+  teamId: string | null
+  ticket: string
+}
+
+export interface TeamJoinResult {
+  success: boolean
+  role: 'owner' | 'editor' | 'viewer'
+  members: TeamMember[]
+}
+
+export type TeamJoinErrorType =
+  | 'InvalidTicket'
+  | 'DeviceNotRegistered'
+  | 'AlreadyInTeam'
+  | 'SyncError'

--- a/packages/app/src/stores/team-members.ts
+++ b/packages/app/src/stores/team-members.ts
@@ -1,0 +1,84 @@
+// packages/app/src/stores/team-members.ts
+import { create } from 'zustand'
+import { invoke } from '@tauri-apps/api/core'
+import type { TeamMember } from '../lib/git/types'
+
+type MemberRole = 'owner' | 'editor' | 'viewer'
+
+interface TeamMembersState {
+  members: TeamMember[]
+  myRole: MemberRole | null
+  loading: boolean
+  error: string | null
+
+  loadMembers: () => Promise<void>
+  loadMyRole: () => Promise<void>
+  addMember: (member: TeamMember) => Promise<void>
+  removeMember: (nodeId: string) => Promise<void>
+  updateMemberRole: (nodeId: string, role: MemberRole) => Promise<void>
+  canManageMembers: () => boolean
+}
+
+export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
+  members: [],
+  myRole: null,
+  loading: false,
+  error: null,
+
+  loadMembers: async () => {
+    set({ loading: true, error: null })
+    try {
+      const members = await invoke<TeamMember[]>('unified_team_get_members')
+      set({ members, loading: false })
+    } catch (e) {
+      set({ error: String(e), loading: false })
+    }
+  },
+
+  loadMyRole: async () => {
+    try {
+      const role = await invoke<MemberRole | null>('unified_team_get_my_role')
+      set({ myRole: role })
+    } catch {
+      set({ myRole: null })
+    }
+  },
+
+  addMember: async (member: TeamMember) => {
+    set({ error: null })
+    try {
+      await invoke('unified_team_add_member', { member })
+      await get().loadMembers()
+    } catch (e) {
+      set({ error: String(e) })
+      throw e
+    }
+  },
+
+  removeMember: async (nodeId: string) => {
+    set({ error: null })
+    try {
+      await invoke('unified_team_remove_member', { nodeId })
+      await get().loadMembers()
+    } catch (e) {
+      set({ error: String(e) })
+      throw e
+    }
+  },
+
+  updateMemberRole: async (nodeId: string, role: MemberRole) => {
+    set({ error: null })
+    try {
+      await invoke('unified_team_update_member_role', { nodeId, role })
+      await get().loadMembers()
+    } catch (e) {
+      set({ error: String(e) })
+      throw e
+    }
+  },
+
+  canManageMembers: () => {
+    const { myRole } = get()
+    return myRole === 'owner' || myRole === 'editor'
+  },
+}))

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -86,6 +86,14 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
         await get().clearTeamMode(_workspacePath)
       }
     }
+    // Load user's role (non-critical)
+    try {
+      const { invoke } = await import('@tauri-apps/api/core')
+      const role = await invoke<string | null>('unified_team_get_my_role')
+      set({ myRole: role as any })
+    } catch {
+      // Non-critical, role can be loaded later
+    }
   },
 
   applyTeamModelToOpenCode: async (workspacePath: string) => {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod oss_commands;
 #[cfg(feature = "p2p")]
 pub mod team_p2p;
 pub mod p2p_state;
+pub mod team_unified;
 pub mod updater;
 pub mod webview;
 

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -160,21 +160,23 @@ pub async fn oss_create_team(
         }
     }
 
-    // Upload initial members.json to _meta/
-    let members = vec![serde_json::json!({
-        "nodeId": node_id,
-        "name": owner_name,
-        "role": "owner",
-        "joinedAt": chrono::Utc::now().to_rfc3339(),
-    })];
-    let members_json = serde_json::json!({
-        "schemaVersion": 1,
-        "members": members,
-    });
-    let members_bytes = serde_json::to_vec_pretty(&members_json)
-        .map_err(|e| format!("Failed to serialize members.json: {e}"))?;
-    let meta_key = format!("teams/{}/_meta/members.json", team_id);
-    manager.s3_put(&meta_key, &members_bytes).await?;
+    // Upload initial members manifest to _team/members.json
+    let owner_member = TeamMember {
+        node_id: node_id.clone(),
+        name: owner_name.clone(),
+        role: MemberRole::Owner,
+        label: String::new(),
+        platform: String::new(),
+        arch: String::new(),
+        hostname: String::new(),
+        added_at: chrono::Utc::now().to_rfc3339(),
+    };
+    let manifest = TeamManifest {
+        owner_node_id: node_id.clone(),
+        members: vec![owner_member],
+    };
+    manager.upload_members_manifest(&manifest).await
+        .map_err(|e| format!("Failed to upload members manifest: {}", e))?;
 
     // Upload team.json to _meta/
     let team_json = serde_json::json!({
@@ -245,12 +247,23 @@ pub async fn oss_join_team(
         "teamSecret": team_secret,
         "nodeId": node_id,
     });
-    let resp = manager.call_fc("/token", &body).await?;
+    let resp = manager.call_fc("/token", &body).await
+        .map_err(|_| "Ticket 不正确，请检查后重试".to_string())?;
     manager.set_credentials(resp.credentials.clone(), resp.oss.clone());
 
     let role: MemberRole = serde_json::from_str(&format!("\"{}\"", resp.role))
         .unwrap_or(MemberRole::Editor);
     manager.set_role(role.clone());
+
+    // Two-step NodeId validation: check device is in the members manifest
+    match manager.check_member_authorized(&node_id).await {
+        Ok(_authorized_role) => {
+            // Device is authorized, proceed with sync
+        }
+        Err(_) => {
+            return Err("你的设备未被添加到团队中，请联系团队 Owner".to_string());
+        }
+    }
 
     // Run initial sync
     manager.initial_sync().await?;

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -151,7 +151,7 @@ pub async fn oss_create_team(
         Some(app_handle.clone()),
     );
     manager.set_credentials(resp.credentials.clone(), resp.oss.clone());
-    manager.set_role(TeamRole::Owner);
+    manager.set_role(MemberRole::Owner);
 
     // Scan existing team_dir for content, do initial upload
     for doc_type in DocType::all() {
@@ -215,7 +215,7 @@ pub async fn oss_create_team(
         team_secret: Some(team_secret),
         team_name,
         owner_name,
-        role: "owner".to_string(),
+        role: MemberRole::Owner,
     })
 }
 
@@ -248,10 +248,9 @@ pub async fn oss_join_team(
     let resp = manager.call_fc("/token", &body).await?;
     manager.set_credentials(resp.credentials.clone(), resp.oss.clone());
 
-    let role = resp.role.clone();
-    if role == "owner" {
-        manager.set_role(TeamRole::Owner);
-    }
+    let role: MemberRole = serde_json::from_str(&format!("\"{}\"", resp.role))
+        .unwrap_or(MemberRole::Editor);
+    manager.set_role(role.clone());
 
     // Run initial sync
     manager.initial_sync().await?;
@@ -333,10 +332,9 @@ pub async fn oss_restore_sync(
     let resp = manager.call_fc("/token", &body).await?;
     manager.set_credentials(resp.credentials.clone(), resp.oss.clone());
 
-    let role = resp.role.clone();
-    if role == "owner" {
-        manager.set_role(TeamRole::Owner);
-    }
+    let role: MemberRole = serde_json::from_str(&format!("\"{}\"", resp.role))
+        .unwrap_or(MemberRole::Editor);
+    manager.set_role(role.clone());
 
     // Restore from local snapshots, then pull remote
     for doc_type in DocType::all() {

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -34,7 +34,7 @@ pub struct OssSyncManager {
     team_id: String,
     node_id: String,
     team_secret: String,
-    role: TeamRole,
+    role: MemberRole,
     known_files: HashMap<DocType, HashSet<String>>,
 
     poll_interval: Duration,
@@ -94,7 +94,7 @@ impl OssSyncManager {
             team_id,
             node_id,
             team_secret,
-            role: TeamRole::Member,
+            role: MemberRole::Editor,
             known_files,
             poll_interval,
             workspace_path,
@@ -122,7 +122,7 @@ impl OssSyncManager {
         self.connected = true;
     }
 
-    pub fn set_role(&mut self, role: TeamRole) {
+    pub fn set_role(&mut self, role: MemberRole) {
         self.role = role;
     }
 
@@ -183,13 +183,8 @@ impl OssSyncManager {
         self.oss_config = Some(resp.oss.clone());
         self.s3_client = Some(Self::create_s3_client(&resp.credentials, &resp.oss));
 
-        if let Ok(role) = resp.role.as_str() {
-            if role == "owner" {
-                self.role = TeamRole::Owner;
-            } else {
-                self.role = TeamRole::Member;
-            }
-        }
+        self.role = serde_json::from_str(&format!("\"{}\"", resp.role))
+            .unwrap_or(MemberRole::Editor);
 
         info!("OSS STS token refreshed successfully");
         Ok(())
@@ -928,6 +923,92 @@ impl OssSyncManager {
             next_sync_at,
             docs,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Members Manifest S3 Operations
+// ---------------------------------------------------------------------------
+
+const MEMBERS_MANIFEST_KEY: &str = "_team/members.json";
+
+impl OssSyncManager {
+    /// Upload members manifest to S3
+    pub async fn upload_members_manifest(&self, manifest: &TeamManifest) -> Result<(), String> {
+        let json = serde_json::to_string_pretty(manifest)
+            .map_err(|e| format!("Failed to serialize manifest: {}", e))?;
+        self.s3_put(MEMBERS_MANIFEST_KEY, json.as_bytes()).await
+    }
+
+    /// Download members manifest from S3
+    pub async fn download_members_manifest(&self) -> Result<Option<TeamManifest>, String> {
+        match self.s3_get(MEMBERS_MANIFEST_KEY).await {
+            Ok(data) => {
+                let manifest: TeamManifest = serde_json::from_slice(&data)
+                    .map_err(|e| format!("Failed to parse manifest: {}", e))?;
+                Ok(Some(manifest))
+            }
+            Err(e) if e.contains("NoSuchKey") || e.contains("not found") => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Add a member to the manifest and upload
+    pub async fn add_member(&self, member: TeamMember) -> Result<(), String> {
+        let mut manifest = self.download_members_manifest().await?
+            .unwrap_or_else(|| TeamManifest {
+                owner_node_id: self.node_id.clone(),
+                members: vec![],
+            });
+
+        if manifest.members.iter().any(|m| m.node_id == member.node_id) {
+            return Err("This device already exists in the team".to_string());
+        }
+
+        manifest.members.push(member);
+        self.upload_members_manifest(&manifest).await
+    }
+
+    /// Remove a member from the manifest and upload
+    pub async fn remove_member(&self, node_id: &str) -> Result<(), String> {
+        let mut manifest = self.download_members_manifest().await?
+            .ok_or("No members manifest found")?;
+
+        if manifest.owner_node_id == node_id {
+            return Err("Cannot remove the team Owner".to_string());
+        }
+
+        manifest.members.retain(|m| m.node_id != node_id);
+        self.upload_members_manifest(&manifest).await
+    }
+
+    /// Update a member's role in the manifest and upload
+    pub async fn update_member_role(&self, node_id: &str, role: MemberRole) -> Result<(), String> {
+        let mut manifest = self.download_members_manifest().await?
+            .ok_or("No members manifest found")?;
+
+        if manifest.owner_node_id == node_id && role != MemberRole::Owner {
+            return Err("Cannot change the Owner's role".to_string());
+        }
+
+        if let Some(member) = manifest.members.iter_mut().find(|m| m.node_id == node_id) {
+            member.role = role;
+        } else {
+            return Err("Member not found".to_string());
+        }
+
+        self.upload_members_manifest(&manifest).await
+    }
+
+    /// Check if a node_id is in the members manifest
+    pub async fn check_member_authorized(&self, node_id: &str) -> Result<MemberRole, String> {
+        let manifest = self.download_members_manifest().await?
+            .ok_or("No members manifest found")?;
+
+        manifest.members.iter()
+            .find(|m| m.node_id == node_id)
+            .map(|m| m.role.clone())
+            .ok_or("Your device has not been added to the team. Please contact the team Owner".to_string())
     }
 }
 

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -115,6 +115,14 @@ impl OssSyncManager {
         &self.team_id
     }
 
+    pub fn node_id(&self) -> &str {
+        &self.node_id
+    }
+
+    pub fn workspace_path(&self) -> &str {
+        &self.workspace_path
+    }
+
     pub fn set_credentials(&mut self, creds: OssCredentials, oss: OssConfig) {
         self.s3_client = Some(Self::create_s3_client(&creds, &oss));
         self.credentials = Some(creds);

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -297,11 +297,9 @@ impl OssSyncManager {
                 .await
                 .map_err(|e| format!("S3 LIST {prefix} failed: {e}"))?;
 
-            if let Some(contents) = resp.contents() {
-                for obj in contents {
-                    if let Some(key) = obj.key() {
-                        keys.push(key.to_string());
-                    }
+            for obj in resp.contents() {
+                if let Some(key) = obj.key() {
+                    keys.push(key.to_string());
                 }
             }
 
@@ -415,10 +413,15 @@ impl OssSyncManager {
 
             // Check if the file exists in the doc with the same hash
             let needs_update = match files_map.get(path) {
-                Some(loro::LoroValue::Map(entry)) => {
-                    match entry.get("hash") {
-                        Some(loro::LoroValue::String(h)) => h.as_ref() != local_hash,
-                        _ => true,
+                Some(loro::ValueOrContainer::Container(loro::Container::Map(entry_map))) => {
+                    let deep = entry_map.get_deep_value();
+                    if let loro::LoroValue::Map(entry) = deep {
+                        match entry.get("hash") {
+                            Some(loro::LoroValue::String(h)) => h.as_ref() != local_hash,
+                            _ => true,
+                        }
+                    } else {
+                        true
                     }
                 }
                 _ => true,
@@ -458,7 +461,7 @@ impl OssSyncManager {
 
                     if deleted {
                         // Remove file from disk if it exists
-                        let file_path = dir.join(path.as_ref());
+                        let file_path = dir.join(path.as_str());
                         if file_path.exists() {
                             let _ = std::fs::remove_file(&file_path);
                         }
@@ -466,7 +469,7 @@ impl OssSyncManager {
                         doc_files.insert(path.to_string());
 
                         if let Some(loro::LoroValue::String(content_str)) = entry.get("content") {
-                            let file_path = dir.join(path.as_ref());
+                            let file_path = dir.join(path.as_str());
                             if let Some(parent) = file_path.parent() {
                                 std::fs::create_dir_all(parent).map_err(|e| {
                                     format!("Failed to create dir {}: {e}", parent.display())
@@ -557,7 +560,7 @@ impl OssSyncManager {
                             Some(loro::LoroValue::Bool(b)) => *b,
                             _ => false,
                         };
-                        if !deleted && !local_files.contains_key(path.as_ref()) {
+                        if !deleted && !local_files.contains_key(path.as_str()) {
                             has_deletions = true;
                             break;
                         }
@@ -585,22 +588,18 @@ impl OssSyncManager {
                     let content_str =
                         String::from_utf8_lossy(content).to_string();
 
-                    // TODO: Verify the LoroMap sub-map creation API. The idea is to
-                    // create/update a nested map entry for each file path.
-                    let entry = files_map.get_or_create_container(path, loro::ContainerType::Map)
+                    let entry_map = files_map.get_or_create_container(path, loro::LoroMap::new())
                         .map_err(|e| format!("Failed to get/create map entry for {path}: {e}"))?;
-                    if let loro::Handler::Map(entry_map) = entry {
-                        entry_map.insert("content", content_str.as_str())
-                            .map_err(|e| format!("Failed to set content for {path}: {e}"))?;
-                        entry_map.insert("hash", hash.as_str())
-                            .map_err(|e| format!("Failed to set hash for {path}: {e}"))?;
-                        entry_map.insert("deleted", false)
-                            .map_err(|e| format!("Failed to set deleted for {path}: {e}"))?;
-                        entry_map.insert("updatedBy", node_id.as_str())
-                            .map_err(|e| format!("Failed to set updatedBy for {path}: {e}"))?;
-                        entry_map.insert("updatedAt", now.as_str())
-                            .map_err(|e| format!("Failed to set updatedAt for {path}: {e}"))?;
-                    }
+                    entry_map.insert("content", content_str.as_str())
+                        .map_err(|e| format!("Failed to set content for {path}: {e}"))?;
+                    entry_map.insert("hash", hash.as_str())
+                        .map_err(|e| format!("Failed to set hash for {path}: {e}"))?;
+                    entry_map.insert("deleted", false)
+                        .map_err(|e| format!("Failed to set deleted for {path}: {e}"))?;
+                    entry_map.insert("updatedBy", node_id.as_str())
+                        .map_err(|e| format!("Failed to set updatedBy for {path}: {e}"))?;
+                    entry_map.insert("updatedAt", now.as_str())
+                        .map_err(|e| format!("Failed to set updatedAt for {path}: {e}"))?;
                 }
             }
 
@@ -613,18 +612,16 @@ impl OssSyncManager {
                             Some(loro::LoroValue::Bool(b)) => *b,
                             _ => false,
                         };
-                        if !deleted && !local_files.contains_key(path.as_ref()) {
-                            let container = files_map
-                                .get_or_create_container(path, loro::ContainerType::Map)
+                        if !deleted && !local_files.contains_key(path.as_str()) {
+                            let entry_map = files_map
+                                .get_or_create_container(path, loro::LoroMap::new())
                                 .map_err(|e| format!("Failed to get map entry for {path}: {e}"))?;
-                            if let loro::Handler::Map(entry_map) = container {
-                                entry_map.insert("deleted", true)
-                                    .map_err(|e| format!("Failed to mark deleted for {path}: {e}"))?;
-                                entry_map.insert("updatedBy", node_id.as_str())
-                                    .map_err(|e| format!("Failed to set updatedBy for {path}: {e}"))?;
-                                entry_map.insert("updatedAt", now.as_str())
-                                    .map_err(|e| format!("Failed to set updatedAt for {path}: {e}"))?;
-                            }
+                            entry_map.insert("deleted", true)
+                                .map_err(|e| format!("Failed to mark deleted for {path}: {e}"))?;
+                            entry_map.insert("updatedBy", node_id.as_str())
+                                .map_err(|e| format!("Failed to set updatedBy for {path}: {e}"))?;
+                            entry_map.insert("updatedAt", now.as_str())
+                                .map_err(|e| format!("Failed to set updatedAt for {path}: {e}"))?;
                         }
                     }
                 }
@@ -865,20 +862,28 @@ impl OssSyncManager {
         );
         let update_keys = self.s3_list(&updates_prefix).await?;
 
-        let known_set = self.known_files.entry(doc_type).or_default();
-        for key in &update_keys {
-            let file_ts: i64 = key
-                .rsplit('/')
-                .next()
-                .and_then(|f| f.strip_suffix(".bin"))
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(i64::MAX);
+        let keys_to_delete: Vec<String> = update_keys
+            .iter()
+            .filter(|key| {
+                let file_ts: i64 = key
+                    .rsplit('/')
+                    .next()
+                    .and_then(|f| f.strip_suffix(".bin"))
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(i64::MAX);
+                file_ts < snapshot_ts
+            })
+            .cloned()
+            .collect();
 
-            if file_ts < snapshot_ts {
-                self.s3_delete(key).await?;
-                deleted_count += 1;
-                known_set.remove(key);
-            }
+        for key in &keys_to_delete {
+            self.s3_delete(key).await?;
+            deleted_count += 1;
+        }
+
+        let known_set = self.known_files.entry(doc_type).or_default();
+        for key in &keys_to_delete {
+            known_set.remove(key);
         }
 
         info!(

--- a/src-tauri/src/commands/oss_types.rs
+++ b/src-tauri/src/commands/oss_types.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+pub use super::team_unified::{MemberRole, TeamMember, TeamManifest};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OssCredentials {
@@ -36,7 +38,7 @@ pub struct OssTeamInfo {
     pub team_secret: Option<String>,
     pub team_name: String,
     pub owner_name: String,
-    pub role: String,
+    pub role: MemberRole,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -63,15 +65,6 @@ pub struct DocSyncStatus {
 pub struct CleanupResult {
     pub deleted_count: u32,
     pub freed_bytes: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TeamMember {
-    pub node_id: String,
-    pub name: String,
-    pub role: String,
-    pub joined_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -113,8 +106,3 @@ impl DocType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum TeamRole {
-    Owner,
-    Member,
-}

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use serde::{Deserialize, Serialize};
+use super::team_unified::{MemberRole, TeamMember, TeamManifest};
 
 use iroh::Endpoint;
 use iroh_blobs::store::fs::FsStore;
@@ -837,34 +838,6 @@ pub fn check_join_authorization(team_dir: &str, joiner_node_id: &str) -> Result<
 
 // ─── P2P Configuration ────────────────────────────────────────────────────
 
-/// Role-based permission level for a team member.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum MemberRole {
-    Owner,
-    #[default]
-    #[serde(alias = "member")]
-    Editor,
-    Viewer,
-}
-
-/// A team member entry in the allowlist.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TeamMember {
-    pub node_id: String,
-    /// Human-readable display name for this member (e.g. "Alice", "Bob")
-    #[serde(default)]
-    pub name: String,
-    #[serde(default)]
-    pub role: MemberRole,
-    pub label: String,
-    pub platform: String,
-    pub arch: String,
-    pub hostname: String,
-    pub added_at: String,
-}
-
 /// A subscribed P2P ticket entry (kept for backward compat).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -963,14 +936,6 @@ pub fn write_p2p_config(
 }
 
 // ─── Team Members Manifest ───────────────────────────────────────────────
-
-/// The `_team/members.json` manifest stored in the team drive.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TeamManifest {
-    pub owner_node_id: String,
-    pub members: Vec<TeamMember>,
-}
 
 /// Write the team members manifest to `<team_dir>/_team/members.json`.
 pub fn write_members_manifest(

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -1,6 +1,7 @@
 // src-tauri/src/commands/team_unified.rs
 
 use serde::{Deserialize, Serialize};
+use tauri::State;
 
 // --- Shared Types ---
 
@@ -99,4 +100,227 @@ pub fn find_member_role(manifest: &TeamManifest, node_id: &str) -> Option<Member
         .iter()
         .find(|m| m.node_id == node_id)
         .map(|m| m.role.clone())
+}
+
+// --- Unified Tauri Commands ---
+
+/// Helper: check that caller has Owner or Editor role by looking up their NodeId in the manifest.
+/// Returns Err if they lack the required role.
+async fn require_manager_role(
+    manifest: &TeamManifest,
+    caller_node_id: &str,
+) -> Result<(), String> {
+    let role = find_member_role(manifest, caller_node_id)
+        .ok_or_else(|| "Your device is not in the team manifest".to_string())?;
+    if !can_manage_members(&role) {
+        return Err("Insufficient permissions: Owner or Editor role required".to_string());
+    }
+    Ok(())
+}
+
+/// Get the list of team members from the active sync mode.
+/// - OSS: downloads members manifest from S3
+/// - P2P: reads from p2p config's allowed_members
+#[tauri::command]
+pub async fn unified_team_get_members(
+    opencode_state: State<'_, super::opencode::OpenCodeState>,
+    oss_state: State<'_, super::oss_sync::OssSyncState>,
+    #[cfg(feature = "p2p")]
+    iroh_state: State<'_, super::p2p_state::IrohState>,
+) -> Result<Vec<TeamMember>, String> {
+    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let status = super::team::check_team_status(&workspace_path);
+
+    match status.mode.as_deref() {
+        Some("oss") => {
+            let guard = oss_state.manager.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            let manifest = manager.download_members_manifest().await?
+                .ok_or("No members manifest found")?;
+            Ok(manifest.members)
+        }
+        #[cfg(feature = "p2p")]
+        Some("p2p") => {
+            let _ = iroh_state;
+            let config = super::team_p2p::read_p2p_config(&workspace_path)?
+                .unwrap_or_default();
+            Ok(config.allowed_members)
+        }
+        Some(mode) => Err(format!("Member management not supported for mode: {}", mode)),
+        None => Err("No active team mode".to_string()),
+    }
+}
+
+/// Add a member to the active team.
+/// Validates NodeId format, checks caller role, then adds member.
+#[tauri::command]
+pub async fn unified_team_add_member(
+    member: TeamMember,
+    opencode_state: State<'_, super::opencode::OpenCodeState>,
+    oss_state: State<'_, super::oss_sync::OssSyncState>,
+    #[cfg(feature = "p2p")]
+    iroh_state: State<'_, super::p2p_state::IrohState>,
+) -> Result<(), String> {
+    validate_node_id(&member.node_id)?;
+
+    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let status = super::team::check_team_status(&workspace_path);
+
+    match status.mode.as_deref() {
+        Some("oss") => {
+            let guard = oss_state.manager.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            // Check caller role via manifest
+            let caller_node_id = manager.node_id().to_string();
+            let manifest = manager.download_members_manifest().await?
+                .ok_or("No members manifest found")?;
+            require_manager_role(&manifest, &caller_node_id).await?;
+            drop(guard);
+            // Re-acquire to call add_member
+            let guard = oss_state.manager.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            manager.add_member(member).await
+        }
+        #[cfg(feature = "p2p")]
+        Some("p2p") => {
+            let guard = iroh_state.lock().await;
+            let node = guard.as_ref().ok_or("P2P node not running")?;
+            let caller_node_id = super::team_p2p::get_node_id(node);
+            drop(guard);
+            let team_dir = format!("{}/teamclaw-team", workspace_path);
+            super::team_p2p::add_member_to_team(
+                &workspace_path,
+                &team_dir,
+                &caller_node_id,
+                member,
+            )
+        }
+        Some(mode) => Err(format!("Member management not supported for mode: {}", mode)),
+        None => Err("No active team mode".to_string()),
+    }
+}
+
+/// Remove a member from the active team.
+/// Checks caller role before removing.
+#[tauri::command]
+pub async fn unified_team_remove_member(
+    node_id: String,
+    opencode_state: State<'_, super::opencode::OpenCodeState>,
+    oss_state: State<'_, super::oss_sync::OssSyncState>,
+    #[cfg(feature = "p2p")]
+    iroh_state: State<'_, super::p2p_state::IrohState>,
+) -> Result<(), String> {
+    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let status = super::team::check_team_status(&workspace_path);
+
+    match status.mode.as_deref() {
+        Some("oss") => {
+            let guard = oss_state.manager.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            let caller_node_id = manager.node_id().to_string();
+            let manifest = manager.download_members_manifest().await?
+                .ok_or("No members manifest found")?;
+            require_manager_role(&manifest, &caller_node_id).await?;
+            drop(guard);
+            let guard = oss_state.manager.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            manager.remove_member(&node_id).await
+        }
+        #[cfg(feature = "p2p")]
+        Some("p2p") => {
+            let guard = iroh_state.lock().await;
+            let node = guard.as_ref().ok_or("P2P node not running")?;
+            let caller_node_id = super::team_p2p::get_node_id(node);
+            drop(guard);
+            let team_dir = format!("{}/teamclaw-team", workspace_path);
+            super::team_p2p::remove_member_from_team(
+                &workspace_path,
+                &team_dir,
+                &caller_node_id,
+                &node_id,
+            )
+        }
+        Some(mode) => Err(format!("Member management not supported for mode: {}", mode)),
+        None => Err("No active team mode".to_string()),
+    }
+}
+
+/// Update a team member's role.
+/// Checks caller role before updating.
+#[tauri::command]
+pub async fn unified_team_update_member_role(
+    node_id: String,
+    role: MemberRole,
+    opencode_state: State<'_, super::opencode::OpenCodeState>,
+    oss_state: State<'_, super::oss_sync::OssSyncState>,
+    #[cfg(feature = "p2p")]
+    iroh_state: State<'_, super::p2p_state::IrohState>,
+) -> Result<(), String> {
+    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let status = super::team::check_team_status(&workspace_path);
+
+    match status.mode.as_deref() {
+        Some("oss") => {
+            let guard = oss_state.manager.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            let caller_node_id = manager.node_id().to_string();
+            let manifest = manager.download_members_manifest().await?
+                .ok_or("No members manifest found")?;
+            require_manager_role(&manifest, &caller_node_id).await?;
+            drop(guard);
+            let guard = oss_state.manager.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            manager.update_member_role(&node_id, role).await
+        }
+        #[cfg(feature = "p2p")]
+        Some("p2p") => {
+            let guard = iroh_state.lock().await;
+            let node = guard.as_ref().ok_or("P2P node not running")?;
+            let caller_node_id = super::team_p2p::get_node_id(node);
+            drop(guard);
+            let team_dir = format!("{}/teamclaw-team", workspace_path);
+            super::team_p2p::update_member_role(
+                &workspace_path,
+                &team_dir,
+                &caller_node_id,
+                &node_id,
+                role,
+            )
+        }
+        Some(mode) => Err(format!("Member management not supported for mode: {}", mode)),
+        None => Err("No active team mode".to_string()),
+    }
+}
+
+/// Get the current device's role in the active team.
+#[tauri::command]
+pub async fn unified_team_get_my_role(
+    opencode_state: State<'_, super::opencode::OpenCodeState>,
+    oss_state: State<'_, super::oss_sync::OssSyncState>,
+    #[cfg(feature = "p2p")]
+    iroh_state: State<'_, super::p2p_state::IrohState>,
+) -> Result<MemberRole, String> {
+    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let status = super::team::check_team_status(&workspace_path);
+
+    match status.mode.as_deref() {
+        Some("oss") => {
+            let guard = oss_state.manager.lock().await;
+            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            let my_node_id = manager.node_id().to_string();
+            let manifest = manager.download_members_manifest().await?
+                .ok_or("No members manifest found")?;
+            find_member_role(&manifest, &my_node_id)
+                .ok_or_else(|| "This device is not in the team manifest".to_string())
+        }
+        #[cfg(feature = "p2p")]
+        Some("p2p") => {
+            let _ = iroh_state;
+            let config = super::team_p2p::read_p2p_config(&workspace_path)?
+                .ok_or("No P2P config found")?;
+            config.role.ok_or_else(|| "Role not set in P2P config".to_string())
+        }
+        Some(mode) => Err(format!("Member management not supported for mode: {}", mode)),
+        None => Err("No active team mode".to_string()),
+    }
 }

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -9,13 +9,16 @@ use serde::{Deserialize, Serialize};
 pub enum MemberRole {
     Owner,
     #[default]
+    #[serde(alias = "member")]
     Editor,
     Viewer,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TeamMember {
     pub node_id: String,
+    #[serde(default)]
     pub name: String,
     #[serde(default)]
     pub role: MemberRole,
@@ -32,6 +35,7 @@ pub struct TeamMember {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TeamManifest {
     pub owner_node_id: String,
     pub members: Vec<TeamMember>,

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -1,0 +1,98 @@
+// src-tauri/src/commands/team_unified.rs
+
+use serde::{Deserialize, Serialize};
+
+// --- Shared Types ---
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum MemberRole {
+    Owner,
+    #[default]
+    Editor,
+    Viewer,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamMember {
+    pub node_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub role: MemberRole,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub platform: String,
+    #[serde(default)]
+    pub arch: String,
+    #[serde(default)]
+    pub hostname: String,
+    #[serde(default)]
+    pub added_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamManifest {
+    pub owner_node_id: String,
+    pub members: Vec<TeamMember>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamCreateResult {
+    pub team_id: Option<String>,
+    pub ticket: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamJoinResult {
+    pub success: bool,
+    pub role: MemberRole,
+    pub members: Vec<TeamMember>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "message")]
+pub enum TeamJoinError {
+    InvalidTicket(String),
+    DeviceNotRegistered(String),
+    AlreadyInTeam(String),
+    SyncError(String),
+}
+
+impl std::fmt::Display for TeamJoinError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidTicket(msg) => write!(f, "{}", msg),
+            Self::DeviceNotRegistered(msg) => write!(f, "{}", msg),
+            Self::AlreadyInTeam(msg) => write!(f, "{}", msg),
+            Self::SyncError(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+// --- Validation Helpers ---
+
+/// Validate NodeId format: non-empty hex string
+pub fn validate_node_id(node_id: &str) -> Result<(), String> {
+    if node_id.is_empty() {
+        return Err("NodeId cannot be empty".to_string());
+    }
+    if !node_id.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("NodeId must be a valid hex string".to_string());
+    }
+    Ok(())
+}
+
+/// Check if a role can manage members (add/remove/edit)
+pub fn can_manage_members(role: &MemberRole) -> bool {
+    matches!(role, MemberRole::Owner | MemberRole::Editor)
+}
+
+/// Find a member's role in a manifest by node_id
+pub fn find_member_role(manifest: &TeamManifest, node_id: &str) -> Option<MemberRole> {
+    manifest
+        .members
+        .iter()
+        .find(|m| m.node_id == node_id)
+        .map(|m| m.role.clone())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -460,6 +460,11 @@ pub fn run() {
             commands::oss_commands::oss_update_members,
             commands::oss_commands::oss_reset_team_secret,
             commands::oss_commands::oss_get_team_config,
+            commands::team_unified::unified_team_get_members,
+            commands::team_unified::unified_team_add_member,
+            commands::team_unified::unified_team_remove_member,
+            commands::team_unified::unified_team_update_member_role,
+            commands::team_unified::unified_team_get_my_role,
         ])
         .setup(|app| {
             #[cfg(debug_assertions)]

--- a/tests/functional/team-unified-management.test.ts
+++ b/tests/functional/team-unified-management.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import {
+  launchTeamClawApp,
+  stopApp,
+  sleep,
+  focusWindow,
+  executeJs,
+} from '../_utils/tauri-mcp-test-utils'
+
+describe('Functional: Unified Team Management', () => {
+  let appReady = false
+
+  beforeAll(async () => {
+    try {
+      await launchTeamClawApp()
+      await sleep(8000)
+      await focusWindow()
+      await sleep(500)
+
+      // Navigate to Settings → Team
+      await executeJs(`
+        (() => {
+          const btn = document.querySelector('[data-testid="settings-button"]')
+            || document.querySelector('button:has(svg.lucide-settings)');
+          btn?.click();
+        })()
+      `)
+      await sleep(1000)
+      await executeJs(`
+        (() => {
+          const items = document.querySelectorAll('button, [role="menuitem"], a');
+          for (const item of items) {
+            if (item.textContent?.trim() === 'Team') { item.click(); break; }
+          }
+        })()
+      `)
+      await sleep(1000)
+      appReady = true
+    } catch (err) {
+      console.error('Setup failed:', (err as Error).message)
+    }
+  }, 60_000)
+
+  afterAll(async () => {
+    await stopApp()
+  })
+
+  it('should display device NodeId on team page', async () => {
+    if (!appReady) return
+    const hasNodeId = await executeJs(`
+      (() => {
+        const el = document.querySelector('[data-testid="device-node-id"]')
+          || document.querySelector('code');
+        return el?.textContent?.length > 0;
+      })()
+    `)
+    expect(hasNodeId).toBe(true)
+  })
+
+  it('should show member list when team is connected', async () => {
+    if (!appReady) return
+    const hasMemberSection = await executeJs(`
+      (() => {
+        const headings = document.querySelectorAll('h3, h4, [class*="heading"]');
+        for (const h of headings) {
+          if (h.textContent?.includes('Members') || h.textContent?.includes('成员')) return true;
+        }
+        return false;
+      })()
+    `)
+    expect(typeof hasMemberSection).toBe('boolean')
+  })
+
+  it('should show role badges for members', async () => {
+    if (!appReady) return
+    const hasBadges = await executeJs(`
+      (() => {
+        const badges = document.querySelectorAll('[data-testid="role-badge"]');
+        return badges.length;
+      })()
+    `)
+    expect(typeof hasBadges).toBe('number')
+  })
+})


### PR DESCRIPTION
## Summary

- Unified team member management across OSS (S3) and P2P sync modes with consistent create → add member → join flow
- Shared role system: Owner / Editor / Viewer with role-gated member list UI
- Two-step join validation: ticket verification + NodeId allowlist check
- New `team_unified.rs` module with shared types, validation helpers, and unified Tauri commands
- Fixed pre-existing Loro 1.x API compilation errors in `oss_sync.rs`

## Changes

### Rust Backend
- **New:** `team_unified.rs` — shared `MemberRole`, `TeamMember`, `TeamManifest` types + 5 unified Tauri commands (`unified_team_get_members`, `unified_team_add_member`, `unified_team_remove_member`, `unified_team_update_member_role`, `unified_team_get_my_role`) with role-based authorization
- **Modified:** `team_p2p.rs` and `oss_types.rs` migrated to shared types
- **Modified:** `oss_sync.rs` — added members manifest S3 CRUD operations + fixed Loro 1.x API errors
- **Modified:** `oss_commands.rs` — owner auto-added to manifest on team creation, two-step NodeId validation on join

### React Frontend
- **New:** `team-members.ts` Zustand store for unified member management
- **Modified:** `TeamMemberList.tsx` — refactored to store-based with role-gated controls
- **Modified:** `AddMemberInput.tsx` — added label/remark field
- **Modified:** `TeamOSSConfig.tsx` — DeviceIdDisplay, two-step error messaging, unified member list
- **Modified:** `TeamP2PConfig.tsx` — aligned join error messaging, uses unified member list
- **Modified:** `team-mode.ts` — loads user role on team activation

## Test plan

- [ ] Create team in OSS mode → verify owner auto-added to manifest
- [ ] Create team in P2P mode → verify owner in member list
- [ ] Add member with NodeId → verify appears in member list
- [ ] Join team with valid ticket + registered NodeId → success
- [ ] Join team with invalid ticket → error "Ticket 不正确"
- [ ] Join team with valid ticket but unregistered NodeId → error "设备未被添加"
- [ ] Viewer role → cannot see add/edit/remove buttons
- [ ] Editor role → can manage members but cannot remove/demote Owner
- [ ] `cargo check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)