### PR TITLE
fix(analytics): move aptabase init into setup() + simplify oss-sync

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -178,7 +178,8 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
-        .plugin(tauri_plugin_aptabase::Builder::new("A-US-9094113207").build())
+        // NOTE: aptabase is registered in the setup() closure below so that
+        // the Tokio runtime is available when its internal `tokio::spawn` runs.
         .plugin({
             // Configure global shortcuts for Spotlight.
             // Errors in shortcut registration should not abort app startup, so we
@@ -477,6 +478,10 @@ pub fn run() {
         .setup(|app| {
             #[cfg(debug_assertions)]
             let setup_t0 = std::time::Instant::now();
+
+            // Register aptabase here (inside setup) so the Tokio runtime is available
+            // for its internal `tokio::spawn` polling loop.
+            app.handle().plugin(tauri_plugin_aptabase::Builder::new("A-US-9094113207").build())?;
 
             // Start RAG HTTP API server for MCP bridge
             let rag_state_handle = app.handle().state::<commands::knowledge::RagState>();


### PR DESCRIPTION
## Summary
- **fix**: Move `tauri-plugin-aptabase` registration from Builder `.plugin()` chain into the `.setup()` closure, where the Tokio runtime is available. Fixes startup panic: `there is no reactor running, must be called from the context of a Tokio 1.x runtime`
- **refactor**: Simplify `oss_sync.rs` — remove unnecessary nested `if let` / `Ok()` patterns, use direct comparisons and iterator chaining

## Test plan
- [ ] App launches without the aptabase `tokio::spawn` panic
- [ ] Analytics events still fire correctly (check with `RUST_LOG=debug`)
- [ ] OSS sync functionality unaffected by the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)