### PR TITLE
fix(ui): sidebar session status reset and cron UX improvements

### DIFF
--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -7,6 +7,7 @@ import { useStreamingStore } from "@/stores/streaming"
 import { useUIStore } from "@/stores/ui"
 import { useWorkspaceStore } from "@/stores/workspace"
 import { useTabsStore } from "@/stores/tabs"
+import { useCronStore } from "@/stores/cron"
 import {
   Sidebar,
   SidebarContent,
@@ -325,14 +326,17 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const archiveSession = useSessionStore(s => s.archiveSession)
   const updateSessionTitle = useSessionStore(s => s.updateSessionTitle)
   const loadMoreSessions = useSessionStore(s => s.loadMoreSessions)
+  const cronSessionIds = useCronStore(s => s.cronSessionIds)
 
   // Rename state
   const [renamingSessionId, setRenamingSessionId] = React.useState<string | null>(null)
 
-  // UI-level pagination: only render the first visibleSessionCount sessions
+  // UI-level pagination: filter out cron sessions, then slice to visible count
   const sessions = React.useMemo(
-    () => allSessions.slice(0, visibleSessionCount),
-    [allSessions, visibleSessionCount],
+    () => allSessions
+      .filter(s => !cronSessionIds.has(s.id) || s.id === activeSessionId)
+      .slice(0, visibleSessionCount),
+    [allSessions, cronSessionIds, activeSessionId, visibleSessionCount],
   )
   
   const openSettings = useUIStore(s => s.openSettings)

--- a/packages/app/src/components/settings/CronSection.tsx
+++ b/packages/app/src/components/settings/CronSection.tsx
@@ -115,7 +115,6 @@ function JobCard({
           variant="outline"
           size="sm"
           onClick={onEdit}
-          disabled={!job.enabled}
           className="h-7 text-xs"
         >
           <Edit2 className="h-3 w-3 mr-1" />
@@ -125,7 +124,6 @@ function JobCard({
           variant="outline"
           size="sm"
           onClick={onViewHistory}
-          disabled={!job.enabled}
           className="h-7 text-xs"
         >
           <History className="h-3 w-3 mr-1" />

--- a/packages/app/src/components/settings/cron/CronHistoryDialog.tsx
+++ b/packages/app/src/components/settings/cron/CronHistoryDialog.tsx
@@ -12,9 +12,14 @@ import {
   History,
   Send,
   GitBranch,
+  MessageSquare,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { useSessionStore } from '@/stores/session'
+import { useUIStore } from '@/stores/ui'
+import { useWorkspaceStore } from '@/stores/workspace'
+import { useTabsStore } from '@/stores/tabs'
 import {
   Dialog,
   DialogContent,
@@ -32,7 +37,7 @@ import {
   type CronRunRecord,
 } from '@/stores/cron'
 
-function RunRecordCard({ run }: { run: CronRunRecord }) {
+function RunRecordCard({ run, onViewSession }: { run: CronRunRecord; onViewSession?: (sessionId: string) => void }) {
   const statusColor = getRunStatusColor(run.status)
   const duration =
     run.startedAt && run.finishedAt
@@ -95,6 +100,18 @@ function RunRecordCard({ run }: { run: CronRunRecord }) {
           {run.error}
         </p>
       )}
+
+      {run.sessionId && onViewSession && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+          onClick={() => onViewSession(run.sessionId!)}
+        >
+          <MessageSquare className="h-3 w-3 mr-1" />
+          查看对话
+        </Button>
+      )}
     </div>
   )
 }
@@ -110,6 +127,17 @@ export function CronHistoryDialog({
 }) {
   const { t } = useTranslation()
   const { runs, runsLoading, loadRuns } = useCronStore()
+  const setActiveSession = useSessionStore(s => s.setActiveSession)
+  const closeSettings = useUIStore(s => s.closeSettings)
+  const clearSelection = useWorkspaceStore(s => s.clearSelection)
+
+  const handleViewSession = React.useCallback(async (sessionId: string) => {
+    clearSelection()
+    useTabsStore.getState().hideAll()
+    await setActiveSession(sessionId)
+    closeSettings()
+    onOpenChange(false)
+  }, [clearSelection, setActiveSession, closeSettings, onOpenChange])
 
   React.useEffect(() => {
     if (open && job) {
@@ -145,7 +173,7 @@ export function CronHistoryDialog({
           ) : (
             <div className="space-y-3">
               {runs.map((run) => (
-                <RunRecordCard key={run.runId} run={run} />
+                <RunRecordCard key={run.runId} run={run} onViewSession={handleViewSession} />
               ))}
             </div>
           )}

--- a/packages/app/src/stores/session-loader.ts
+++ b/packages/app/src/stores/session-loader.ts
@@ -255,6 +255,7 @@ export function createLoaderActions(set: SessionSet, get: SessionGet) {
         todos: cachedData?.todos || [],
         sessionDiff: cachedData?.diff || [],
         sessionError: null,
+        sessionStatus: null,
         pendingPermission: null,
         pendingPermissionChildSessionId: null,
         pendingQuestion: cachedData?.pendingQuestion || null,


### PR DESCRIPTION
## Summary
- **Fix stale loading spinner**: Reset `sessionStatus` when switching sessions, preventing the spinner from carrying over from a busy session to an idle one
- **Fix cron session filtering in sidebar**: `AppSidebar` was missing the cron session filter that `SessionList` already had — cron sessions now hidden from both views
- **Add "查看对话" in cron history**: Run history records with a `sessionId` now show a button to navigate directly to that session's conversation
- **Enable Edit/History for disabled jobs**: Only "Run Now" is disabled when a cron job is paused; Edit and History remain accessible

## Test plan
- [ ] Switch between sessions — verify no stale loading spinner on idle sessions
- [ ] Create a cron job, run it — verify the session does not appear in sidebar
- [ ] Open cron job history — verify "查看对话" button appears and navigates to the session
- [ ] Disable a cron job — verify Edit and History buttons are still clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)