### PR TITLE
feat(updater): add periodic update check every 4 hours

### DIFF
--- a/packages/app/src/components/updater/UpdateDialog.tsx
+++ b/packages/app/src/components/updater/UpdateDialog.tsx
@@ -18,7 +18,7 @@ export function UpdateDialogContainer() {
   const { update, checkForUpdates, installUpdate, restart } = useUpdaterStore()
   const [dismissed, setDismissed] = useState(false)
 
-  // Check for updates on app startup (3s delay)
+  // Check for updates on app startup (3s delay) and every 4 hours
   useEffect(() => {
     if (typeof window === "undefined" || !(window as unknown as { __TAURI__: unknown }).__TAURI__) {
       return
@@ -28,7 +28,14 @@ export function UpdateDialogContainer() {
       checkForUpdates(true)
     }, 3000)
 
-    return () => clearTimeout(timer)
+    const interval = setInterval(() => {
+      checkForUpdates(true)
+    }, 4 * 60 * 60 * 1000)
+
+    return () => {
+      clearTimeout(timer)
+      clearInterval(interval)
+    }
   }, [checkForUpdates])
 
   // Reset dismissed state when a new check starts


### PR DESCRIPTION
## Summary
- 在启动检查之外，增加每 4 小时自动静默检查更新，长时间运行的会话无需重启即可发现新版本
- 使用 `setInterval` 实现，组件卸载时正确清理

## Test plan
- [ ] 启动 app，确认 3 秒后仍正常触发首次检查
- [ ] 将 interval 临时改为短时间（如 10 秒），验证定时检查触发
- [ ] 确认检查为静默模式，无更新时不弹窗

🤖 Generated with [Claude Code](https://claude.com/claude-code)