### PR TITLE
fix(team): OSS sync bugs and P2P alignment

### DIFF
--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -142,6 +142,8 @@ export function TeamOSSConfig() {
     }
   }, [workspacePath, joinTeamId, joinTeamSecret, joinTeam, teamMembersStore])
 
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false)
+
   const handleLeaveTeam = useCallback(async () => {
     if (!workspacePath) return
     setLeaving(true)
@@ -151,6 +153,7 @@ export function TeamOSSConfig() {
       // error is set in the store
     } finally {
       setLeaving(false)
+      setShowLeaveConfirm(false)
     }
   }, [workspacePath, leaveTeam])
 
@@ -308,15 +311,15 @@ export function TeamOSSConfig() {
               </div>
               {teamInfo.teamSecret && (
                 <div className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2">
-                  <span className="text-muted-foreground">团队密钥</span>
-                  <div className="flex items-center gap-1.5">
-                    <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+                  <span className="shrink-0 text-muted-foreground">团队密钥</span>
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <code className="truncate rounded bg-muted px-1.5 py-0.5 font-mono text-xs max-w-[180px]">
                       {showSecret ? teamInfo.teamSecret : '••••••••••••'}
                     </code>
                     <Button
                       size="icon"
                       variant="ghost"
-                      className="h-6 w-6"
+                      className="h-6 w-6 shrink-0"
                       onClick={() => setShowSecret(!showSecret)}
                     >
                       {showSecret ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
@@ -324,7 +327,7 @@ export function TeamOSSConfig() {
                     <Button
                       size="icon"
                       variant="ghost"
-                      className="h-6 w-6"
+                      className="h-6 w-6 shrink-0"
                       onClick={() => copyToClipboard(teamInfo.teamSecret!)}
                     >
                       <Copy className="h-3 w-3" />
@@ -421,16 +424,39 @@ export function TeamOSSConfig() {
           )}
 
           <div className="pt-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleLeaveTeam}
-              disabled={leaving}
-              className="text-destructive hover:text-destructive hover:bg-destructive/10"
-            >
-              <LogOut className="mr-1.5 h-3.5 w-3.5" />
-              {leaving ? '离开中...' : '离开团队'}
-            </Button>
+            {!showLeaveConfirm ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowLeaveConfirm(true)}
+                className="text-destructive hover:text-destructive hover:bg-destructive/10"
+              >
+                <LogOut className="mr-1.5 h-3.5 w-3.5" />
+                离开团队
+              </Button>
+            ) : (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 space-y-2">
+                <p className="text-sm text-destructive">确定要离开团队吗？本地团队配置将被清除。</p>
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={handleLeaveTeam}
+                    disabled={leaving}
+                  >
+                    {leaving ? '离开中...' : '确认离开'}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setShowLeaveConfirm(false)}
+                    disabled={leaving}
+                  >
+                    取消
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         </>
       )}

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -250,6 +250,8 @@ export function TeamP2PConfig() {
       await tauriInvoke('p2p_join_drive', { ticket: joinTicketInput.trim(), label: '' })
       setJoinTicketInput('')
       await loadSyncStatus()
+      // Refresh file tree so the new teamclaw-team directory appears
+      useWorkspaceStore.getState().refreshFileTree()
       // Load unified members after successful join
       await teamMembersStore.loadMembers()
       await teamMembersStore.loadMyRole()
@@ -286,6 +288,8 @@ export function TeamP2PConfig() {
         llmModelName: buildConfig.team.llm.modelName || null,
       })
       await loadSyncStatus()
+      // Refresh file tree so the new teamclaw-team directory appears
+      useWorkspaceStore.getState().refreshFileTree()
       if (workspacePath) {
         const store = useTeamModeStore.getState()
         await store.loadTeamConfig(workspacePath)

--- a/packages/app/src/stores/team-oss.ts
+++ b/packages/app/src/stores/team-oss.ts
@@ -122,6 +122,9 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
         fcEndpoint: buildConfig.oss?.fcEndpoint ?? '',
       })
       set({ connected: true, teamInfo: info, error: null })
+      // Refresh file tree so the new teamclaw-team directory appears
+      const { useWorkspaceStore } = await import('@/stores/workspace')
+      await useWorkspaceStore.getState().refreshFileTree()
       return info
     } catch (e) {
       set({ error: String(e) })
@@ -136,6 +139,9 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
         fcEndpoint: buildConfig.oss?.fcEndpoint ?? '',
       })
       set({ connected: true, teamInfo: info, error: null })
+      // Refresh file tree so the new teamclaw-team directory appears
+      const { useWorkspaceStore } = await import('@/stores/workspace')
+      await useWorkspaceStore.getState().refreshFileTree()
       return info
     } catch (e) {
       set({ error: String(e) })
@@ -144,14 +150,19 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
   },
 
   leaveTeam: async (workspacePath) => {
-    await invoke('oss_leave_team', { workspacePath })
-    set({
-      connected: false,
-      teamInfo: null,
-      syncStatus: null,
-      members: [],
-      error: null,
-    })
+    try {
+      await invoke('oss_leave_team', { workspacePath })
+      set({
+        connected: false,
+        teamInfo: null,
+        syncStatus: null,
+        members: [],
+        error: null,
+      })
+    } catch (e) {
+      set({ error: String(e) })
+      throw e
+    }
   },
 
   syncNow: async (workspacePath) => {

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -113,6 +113,10 @@ pub async fn oss_create_team(
     let node_id = get_or_create_node_id(&workspace_path)?;
     let team_secret = generate_team_secret()?;
 
+    // Scaffold teamclaw-team directory with default structure
+    let team_dir = format!("{}/teamclaw-team", workspace_path);
+    super::team::scaffold_team_dir(&team_dir)?;
+
     // Create a temporary manager with empty team_id to call FC /register
     let mut manager = OssSyncManager::new(
         String::new(), // team_id not yet known
@@ -389,7 +393,7 @@ pub async fn oss_restore_sync(
 
     Ok(OssTeamInfo {
         team_id,
-        team_secret: None,
+        team_secret: Some(team_secret),
         team_name,
         owner_name,
         role,
@@ -401,12 +405,16 @@ pub async fn oss_leave_team(
     state: State<'_, OssSyncState>,
     workspace_path: String,
 ) -> Result<(), String> {
-    // Prevent owner from leaving — must transfer ownership first
+    // Prevent owner from leaving if there are other members
     {
         let guard = state.manager.lock().await;
         if let Some(ref mgr) = *guard {
             if mgr.role() == MemberRole::Owner {
-                return Err("团队创建者不能离开团队，请先转让管理员角色".to_string());
+                if let Ok(Some(manifest)) = mgr.download_members_manifest().await {
+                    if manifest.members.len() > 1 {
+                        return Err("团队还有其他成员，请先移除所有成员或转让管理员角色后再离开".to_string());
+                    }
+                }
             }
         }
     }

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -950,19 +950,23 @@ impl OssSyncManager {
 // Members Manifest S3 Operations
 // ---------------------------------------------------------------------------
 
-const MEMBERS_MANIFEST_KEY: &str = "_team/members.json";
-
 impl OssSyncManager {
+    fn members_manifest_key(&self) -> String {
+        format!("teams/{}/_meta/members.json", self.team_id)
+    }
+
     /// Upload members manifest to S3
     pub async fn upload_members_manifest(&self, manifest: &TeamManifest) -> Result<(), String> {
         let json = serde_json::to_string_pretty(manifest)
             .map_err(|e| format!("Failed to serialize manifest: {}", e))?;
-        self.s3_put(MEMBERS_MANIFEST_KEY, json.as_bytes()).await
+        let key = self.members_manifest_key();
+        self.s3_put(&key, json.as_bytes()).await
     }
 
     /// Download members manifest from S3
     pub async fn download_members_manifest(&self) -> Result<Option<TeamManifest>, String> {
-        match self.s3_get(MEMBERS_MANIFEST_KEY).await {
+        let key = self.members_manifest_key();
+        match self.s3_get(&key).await {
             Ok(data) => {
                 let manifest: TeamManifest = serde_json::from_slice(&data)
                     .map_err(|e| format!("Failed to parse manifest: {}", e))?;
@@ -1064,9 +1068,18 @@ pub fn write_oss_config(workspace_path: &str, config: &OssTeamConfig) -> Result<
     let oss_value =
         serde_json::to_value(config).map_err(|e| format!("Failed to serialize oss config: {e}"))?;
 
-    json.as_object_mut()
-        .ok_or_else(|| "teamclaw.json root is not an object".to_string())?
-        .insert("oss".to_string(), oss_value);
+    // Merge new config into existing oss object to preserve fields like nodeId
+    let root = json.as_object_mut()
+        .ok_or_else(|| "teamclaw.json root is not an object".to_string())?;
+    if let Some(existing_oss) = root.get_mut("oss").and_then(|v| v.as_object_mut()) {
+        if let Some(new_obj) = oss_value.as_object() {
+            for (k, v) in new_obj {
+                existing_oss.insert(k.clone(), v.clone());
+            }
+        }
+    } else {
+        root.insert("oss".to_string(), oss_value);
+    }
 
     // Ensure parent dir exists
     if let Some(parent) = config_path.parent() {

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -211,6 +211,36 @@ fn write_team_config_to_file(
 /// Subfolder inside workspace where the team repo is cloned (not workspace root)
 pub const TEAM_REPO_DIR: &str = "teamclaw-team";
 
+/// Scaffold the teamclaw-team directory with default structure if it doesn't exist or is empty.
+pub fn scaffold_team_dir(team_dir: &str) -> Result<(), String> {
+    let team_path = Path::new(team_dir);
+
+    let is_empty = !team_path.exists()
+        || team_path
+            .read_dir()
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(true);
+
+    if !is_empty {
+        return Ok(());
+    }
+
+    let dirs = ["skills", ".mcp", "knowledge", "_feedback"];
+    for d in &dirs {
+        std::fs::create_dir_all(team_path.join(d))
+            .map_err(|e| format!("Failed to create {}: {}", d, e))?;
+    }
+
+    let readme_path = team_path.join("README.md");
+    if !readme_path.exists() {
+        let readme = "# TeamClaw Team Drive\n\nShared team resources.\n\n## Structure\n\n- `skills/` - Shared agent skills\n- `.mcp/` - MCP server configurations\n- `knowledge/` - Shared knowledge base\n- `_feedback/` - Member feedback summaries (auto-synced)\n";
+        std::fs::write(&readme_path, readme)
+            .map_err(|e| format!("Failed to write README.md: {}", e))?;
+    }
+
+    Ok(())
+}
+
 fn get_team_repo_path(workspace_path: &str) -> String {
     let p = Path::new(workspace_path).join(TEAM_REPO_DIR);
     p.to_string_lossy().to_string()

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -182,31 +182,8 @@ fn collect_files(base: &Path, dir: &Path) -> Vec<(String, Vec<u8>)> {
     files
 }
 
-/// Scaffold the teamclaw-team directory with default structure if it doesn't exist or is empty.
-fn scaffold_team_dir(team_dir: &str) -> Result<(), String> {
-    let team_path = Path::new(team_dir);
-
-    let need_scaffold = !team_path.exists() || collect_files(team_path, team_path).is_empty();
-
-    if !need_scaffold {
-        return Ok(());
-    }
-
-    let dirs = ["skills", ".mcp", "knowledge", "_feedback"];
-    for d in &dirs {
-        std::fs::create_dir_all(team_path.join(d))
-            .map_err(|e| format!("Failed to create {}: {}", d, e))?;
-    }
-
-    let readme_path = team_path.join("README.md");
-    if !readme_path.exists() {
-        let readme = "# TeamClaw Team Drive\n\nShared team resources synced via P2P.\n\n## Structure\n\n- `skills/` - Shared agent skills\n- `.mcp/` - MCP server configurations\n- `knowledge/` - Shared knowledge base\n- `_feedback/` - Member feedback summaries (auto-synced)\n";
-        std::fs::write(&readme_path, readme)
-            .map_err(|e| format!("Failed to write README.md: {}", e))?;
-    }
-
-    Ok(())
-}
+// Re-use shared scaffold from team.rs
+use super::team::scaffold_team_dir;
 
 // ─── Create / Join (iroh-docs) ──────────────────────────────────────────
 
@@ -988,6 +965,20 @@ pub async fn p2p_disconnect_source(
         .map_err(|e| e.to_string())?
         .clone()
         .ok_or("No workspace path set")?;
+
+    // Prevent owner from disconnecting if there are other members
+    if let Ok(Some(config)) = read_p2p_config(&workspace_path) {
+        let guard = iroh_state.lock().await;
+        if let Some(node) = guard.as_ref() {
+            let my_node_id = get_node_id(node);
+            if config.owner_node_id.as_deref() == Some(&my_node_id)
+                && config.allowed_members.len() > 1
+            {
+                return Err("团队还有其他成员，请先移除所有成员或转让管理员角色后再断开".to_string());
+            }
+        }
+        drop(guard);
+    }
 
     // Close active doc
     let mut guard = iroh_state.lock().await;

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -168,15 +168,14 @@ pub async fn unified_team_add_member(
         Some("oss") => {
             let guard = oss_state.manager.lock().await;
             let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
-            // Check caller role via manifest
-            let caller_node_id = manager.node_id().to_string();
-            let manifest = manager.download_members_manifest().await?
-                .ok_or("No members manifest found")?;
-            require_manager_role(&manifest, &caller_node_id).await?;
-            drop(guard);
-            // Re-acquire to call add_member
-            let guard = oss_state.manager.lock().await;
-            let manager = guard.as_ref().ok_or("OSS sync not initialized")?;
+            // Check caller role: use manifest if available, fall back to manager role
+            let manifest = manager.download_members_manifest().await?;
+            if let Some(ref m) = manifest {
+                let caller_node_id = manager.node_id().to_string();
+                require_manager_role(m, &caller_node_id).await?;
+            } else if !can_manage_members(&manager.role()) {
+                return Err("Insufficient permissions: Owner or Editor role required".to_string());
+            }
             manager.add_member(member).await
         }
         #[cfg(feature = "p2p")]


### PR DESCRIPTION
## Summary

- **Fix 403 on OSS team creation**: members manifest S3 key was `_team/members.json` (outside STS policy scope), changed to `teams/{team_id}/_meta/members.json`
- **Fix owner role lost after app restart**: `write_oss_config` was replacing the entire `oss` object in `teamclaw.json`, wiping `nodeId`. Now merges fields instead
- **Fix team secret not shown after restart**: `oss_restore_sync` now returns secret from keyring
- **Fix leave team silent failure for owner**: error now surfaces to UI; owner can leave if sole member, blocked with message if others exist
- **Fix file tree not refreshing** after create/join team (both OSS and P2P)
- **Add scaffold_team_dir** to OSS create flow, shared with P2P
- **Add leave team confirmation** dialog for OSS
- **Add owner disconnect protection** for P2P (aligned with OSS)
- **Fix team secret display overflow** with truncate
- **Fix add member when manifest missing**: fall back to manager role check

## Test plan

- [ ] OSS: Create team → verify no 403, members manifest uploaded
- [ ] OSS: Restart app → verify role stays "管理员" and secret is visible
- [ ] OSS: Add member → join from another device → verify success
- [ ] OSS: Click leave team → verify confirmation dialog appears
- [ ] OSS: Owner with members → leave blocked with error message
- [ ] OSS: Owner sole member → leave succeeds
- [ ] P2P: Create team → verify teamclaw-team appears in file browser
- [ ] P2P: Owner with members → disconnect blocked with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)