### PR TITLE
perf(ci): sccache + codegen-units + merge CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [main, master]
 
 jobs:
-  lint:
-    name: Lint
+  frontend:
+    name: Lint, Typecheck & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,9 +19,14 @@ jobs:
           node-version: '20'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          version: '10'
+          path: ~/.local/share/pnpm/store/v3
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install
@@ -29,46 +34,8 @@ jobs:
       - name: Run ESLint
         run: pnpm lint
 
-  typecheck:
-    name: Type Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: '10'
-
-      - name: Install dependencies
-        run: pnpm install
-
       - name: Run TypeScript check
         run: pnpm typecheck
-
-  test:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: '10'
-
-      - name: Install dependencies
-        run: pnpm install
 
       - name: Run unit tests
         run: pnpm test:unit
@@ -79,8 +46,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libglib2.0-dev patchelf
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            ./src-tauri -> target
 
       - name: Check Rust formatting
         run: cargo fmt --check --manifest-path src-tauri/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           targets: aarch64-apple-darwin
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
@@ -156,6 +159,8 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           UPDATER_GITHUB_TOKEN: ${{ secrets.UPDATER_GITHUB_TOKEN }}
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: sccache
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "TeamClaw ${{ github.ref_name }}"
@@ -234,6 +239,9 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
@@ -277,6 +285,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: sccache
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "TeamClaw ${{ github.ref_name }}"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -134,7 +134,7 @@ wiremock = "0.5"
 
 [profile.release]
 # Use unwind so catch_unwind in email.rs and deps (e.g. html2md) work; abort would conflict.
-codegen-units = 1
+codegen-units = 16
 lto = "thin"
 opt-level = "s"
 strip = true


### PR DESCRIPTION
## Summary

- **sccache**: 为 macOS 和 Windows release 构建添加 `mozilla-actions/sccache-action`，缓存编译结果，二次构建预计节省 5-10 分钟
- **codegen-units 16**: 从 `codegen-units = 1`（单线程）改为 `16`（并行编译），预计节省 3-5 分钟
- **合并 CI jobs**: 将 lint/typecheck/test 三个 job 合并为一个，避免 3 次重复 `pnpm install`，预计节省 1-2 分钟
- **CI 缓存**: 为合并后的 frontend job 添加 pnpm cache，为 rust-check 添加 rust-cache
- **修复 Clippy CI**: 添加 `libglib2.0-dev` 等系统依赖，修复 `glib-2.0 not found` 错误

## 预期效果

Release 构建从 ~30 分钟 → ~15 分钟（首次有缓存后更快）

## Test plan

- [ ] Release workflow 正常完成 macOS + Windows 构建
- [ ] CI workflow lint/typecheck/test 全部通过
- [ ] Clippy 不再因缺少系统库失败
- [ ] 二次 release 构建时间明显缩短（sccache 命中）

🤖 Generated with [Claude Code](https://claude.com/claude-code)