### PR TITLE
feat: workspace type dialog for new workspaces

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -67,6 +67,7 @@ import { Settings } from "@/components/settings";
 import { SetupGuide } from "@/components/SetupGuide";
 import { TelemetryConsentDialog } from "@/components/telemetry/TelemetryConsentDialog";
 import { WorkspacePrompt } from "@/components/workspace";
+import { WorkspaceTypeDialog } from "@/components/workspace/WorkspaceTypeDialog";
 import { useSessionStore } from "@/stores/session";
 import { useUIStore } from "@/stores/ui";
 import { useWorkspaceStore } from "@/stores/workspace";
@@ -429,6 +430,9 @@ function AppContent() {
   const fileModeRightTab = useUIStore((s) => s.fileModeRightTab);
   const setFileModeRightTab = useUIStore((s) => s.setFileModeRightTab);
   const advancedMode = useUIStore((s) => s.advancedMode);
+  const openSettings = useUIStore((s) => s.openSettings);
+  const isNewWorkspace = useWorkspaceStore((s) => s.isNewWorkspace);
+  const setIsNewWorkspace = useWorkspaceStore((s) => s.setIsNewWorkspace);
   const { state } = useSidebar();
   const isCollapsed = state === "collapsed";
   const needsTrafficLightSpacer = useNeedsTrafficLightSpacer();
@@ -770,6 +774,14 @@ function AppContent() {
           </div>
         </div>
         <VoiceInputFloatingButton />
+        <WorkspaceTypeDialog
+          open={isNewWorkspace}
+          onSelectPersonal={() => setIsNewWorkspace(false)}
+          onSelectTeam={() => {
+            setIsNewWorkspace(false);
+            openSettings('team');
+          }}
+        />
       </div>
     );
   }
@@ -897,6 +909,14 @@ function AppContent() {
         </div>
       </SidebarInset>
       <VoiceInputFloatingButton />
+      <WorkspaceTypeDialog
+        open={isNewWorkspace}
+        onSelectPersonal={() => setIsNewWorkspace(false)}
+        onSelectTeam={() => {
+          setIsNewWorkspace(false);
+          openSettings('team');
+        }}
+      />
     </>
   );
 }

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -547,7 +547,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             variant="ghost"
             size="icon"
             className="h-7 w-7 text-muted-foreground hover:text-foreground"
-            onClick={openSettings}
+            onClick={() => openSettings()}
           >
             <Settings className="h-4 w-4" />
           </Button>

--- a/packages/app/src/components/panel/ShortcutsPanel.tsx
+++ b/packages/app/src/components/panel/ShortcutsPanel.tsx
@@ -181,7 +181,7 @@ export function ShortcutsPanel() {
                 variant="ghost"
                 size="sm"
                 className="mt-1.5 h-6 text-[11px] gap-1 text-muted-foreground"
-                onClick={openSettings}
+                onClick={() => openSettings()}
               >
                 <Plus className="h-3 w-3" />
                 {t("settings.shortcuts.addShortcut", "Add Shortcut")}

--- a/packages/app/src/components/settings/Settings.tsx
+++ b/packages/app/src/components/settings/Settings.tsx
@@ -26,6 +26,7 @@ import { useAppVersion } from '@/lib/version'
 import { useUpdaterStore } from '@/stores/updater'
 import { buildConfig, hasAnyChannel } from '@/lib/build-config'
 import { useTeamModeStore } from '@/stores/team-mode'
+import { useUIStore } from '@/stores/ui'
 
 // Section components
 import { LLMSection } from './LLMSection'
@@ -146,7 +147,8 @@ function UpdateButton() {
 
 export function Settings(_props?: SettingsProps) {
   const { t } = useTranslation()
-  const [activeView, setActiveView] = React.useState<SettingsSection>('general')
+  const settingsInitialSection = useUIStore(s => s.settingsInitialSection)
+  const [activeView, setActiveView] = React.useState<SettingsSection>(settingsInitialSection ?? 'general')
   const [advancedExpanded, setAdvancedExpanded] = React.useState(false)
   const appVersion = useAppVersion()
   const teamMode = useTeamModeStore(s => s.teamMode)

--- a/packages/app/src/components/workspace/WorkspaceTypeDialog.tsx
+++ b/packages/app/src/components/workspace/WorkspaceTypeDialog.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from 'react-i18next'
+import { User, Users } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+} from '@/components/ui/dialog'
+
+interface WorkspaceTypeDialogProps {
+  open: boolean
+  onSelectPersonal: () => void
+  onSelectTeam: () => void
+}
+
+export function WorkspaceTypeDialog({ open, onSelectPersonal, onSelectTeam }: WorkspaceTypeDialogProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Dialog open={open}>
+      <DialogContent
+        showCloseButton={false}
+        className="sm:max-w-md p-0 gap-0 overflow-hidden"
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <div className="p-6 pb-2 text-center">
+          <h2 className="text-lg font-medium">
+            {t('workspace.typeDialog.title', '你打算怎么使用这个工作区？')}
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            {t('workspace.typeDialog.subtitle', '你随时可以在设置中更改')}
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 p-6">
+          <button
+            onClick={onSelectPersonal}
+            className="flex flex-col items-center gap-3 rounded-xl border border-border/50 bg-muted/30 p-5 transition-colors hover:bg-muted/60 hover:border-border cursor-pointer"
+          >
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-background">
+              <User className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <div className="text-center">
+              <div className="text-sm font-medium">
+                {t('workspace.typeDialog.personal', '个人使用')}
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">
+                {t('workspace.typeDialog.personalDesc', '独立工作，无需同步')}
+              </div>
+            </div>
+          </button>
+
+          <button
+            onClick={onSelectTeam}
+            className="flex flex-col items-center gap-3 rounded-xl border border-border/50 bg-muted/30 p-5 transition-colors hover:bg-muted/60 hover:border-border cursor-pointer"
+          >
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-background">
+              <Users className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <div className="text-center">
+              <div className="text-sm font-medium">
+                {t('workspace.typeDialog.team', '团队协作')}
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">
+                {t('workspace.typeDialog.teamDesc', '加入团队，同步共享资源')}
+              </div>
+            </div>
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -97,7 +97,15 @@
     "webMode": "Web Mode",
     "enterPath": "Enter workspace path",
     "clickToSelect": "Click to select a folder",
-    "selectFolder": "Select Folder"
+    "selectFolder": "Select Folder",
+    "typeDialog": {
+      "title": "How will you use this workspace?",
+      "subtitle": "You can change this anytime in settings",
+      "personal": "Personal",
+      "personalDesc": "Work independently, no sync needed",
+      "team": "Team",
+      "teamDesc": "Join a team, sync shared resources"
+    }
   },
   "fileExplorer": {
     "newFile": "New File",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -97,7 +97,15 @@
     "selectWorkspace": "选择工作区",
     "webMode": "Web 模式",
     "enterPath": "输入工作区路径",
-    "clickToSelect": "点击选择文件夹"
+    "clickToSelect": "点击选择文件夹",
+    "typeDialog": {
+      "title": "你打算怎么使用这个工作区？",
+      "subtitle": "你随时可以在设置中更改",
+      "personal": "个人使用",
+      "personalDesc": "独立工作，无需同步",
+      "team": "团队协作",
+      "teamDesc": "加入团队，同步共享资源"
+    }
   },
   "fileExplorer": {
     "newFile": "新建文件",

--- a/packages/app/src/stores/ui.ts
+++ b/packages/app/src/stores/ui.ts
@@ -10,13 +10,16 @@ export type LayoutMode = 'task' | 'file'
 // Right panel tab in file mode
 export type FileModeRightTab = 'shortcuts' | 'tasks' | 'changes' | 'files' | 'agent'
 
+export type SettingsSection = 'llm' | 'general' | 'voice' | 'prompt' | 'mcp' | 'channels' | 'automation' | 'team' | 'envVars' | 'skills' | 'knowledge' | 'deps' | 'tokenUsage' | 'privacy' | 'permissions' | 'leaderboard' | 'shortcuts'
+
 interface UIState {
   currentView: View
   layoutMode: LayoutMode
   fileModeRightTab: FileModeRightTab
   spotlightMode: boolean
+  settingsInitialSection: SettingsSection | null
   setView: (view: View) => void
-  openSettings: () => void
+  openSettings: (section?: SettingsSection) => void
   closeSettings: () => void
   setLayoutMode: (mode: LayoutMode) => void
   toggleLayoutMode: () => void
@@ -32,12 +35,13 @@ export const useUIStore = create<UIState>((set, get) => ({
   layoutMode: 'task',
   fileModeRightTab: 'agent',
   spotlightMode: false,
+  settingsInitialSection: null,
 
   setView: (view) => set({ currentView: view }),
 
-  openSettings: () => set({ currentView: 'settings' }),
+  openSettings: (section) => set({ currentView: 'settings', settingsInitialSection: section ?? null }),
 
-  closeSettings: () => set({ currentView: 'chat' }),
+  closeSettings: () => set({ currentView: 'chat', settingsInitialSection: null }),
 
   setLayoutMode: (mode) => set({ layoutMode: mode }),
 

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -107,6 +107,10 @@ interface WorkspaceState {
   // Undo stack
   undoStack: UndoOperation[];
 
+  // New workspace detection
+  isNewWorkspace: boolean;
+  setIsNewWorkspace: (value: boolean) => void;
+
   // Actions
   setWorkspace: (path: string) => Promise<void>;
   clearWorkspace: () => Promise<void>;
@@ -195,6 +199,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   targetHeading: null,
   focusedPath: null,
   undoStack: [],
+  isNewWorkspace: false,
+  setIsNewWorkspace: (value: boolean) => set({ isNewWorkspace: value }),
 
   // Set workspace and load file tree
   setWorkspace: async (path: string) => {
@@ -215,8 +221,24 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       await stopWatching(currentPath);
     }
 
+    // Check if this is a new workspace (no .teamclaw directory yet)
+    // Must run BEFORE set({workspacePath}) because that triggers OpenCode
+    // server start (via useOpenCodeInit hook) which creates .teamclaw
+    let detectedNewWorkspace = false;
+    if (isTauri()) {
+      try {
+        const { join } = await import("@tauri-apps/api/path");
+        const { exists } = await import("@tauri-apps/plugin-fs");
+        const teamclawDir = await join(expandedPath, ".teamclaw");
+        detectedNewWorkspace = !(await exists(teamclawDir));
+      } catch {
+        // Ignore errors — don't block workspace setup
+      }
+    }
+
     set({
       isLoadingWorkspace: true,
+      isNewWorkspace: detectedNewWorkspace,
       openCodeReady: false,
       openCodeUrl: null,
       workspacePath: expandedPath,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -89,6 +89,7 @@ futures-lite = "2"
 
 # axum: E2E test control server (debug builds only, lib.rs)
 axum = "0.7"
+tower-http = { version = "0.6", features = ["cors"] }
 gethostname = "1.1.0"
 
 # ClawHub skill registry


### PR DESCRIPTION
## Summary
- When opening a new workspace (no `.teamclaw` directory), shows a modal dialog asking: **Personal** or **Team**
- Personal → dismisses dialog, normal usage
- Team → dismisses dialog, navigates directly to Settings → Team section
- Detection runs before `set({workspacePath})` to avoid race condition with OpenCode server creating `.teamclaw`

## Changes
- **New**: `WorkspaceTypeDialog.tsx` — modal with personal/team options
- **`stores/workspace.ts`**: `isNewWorkspace` state, detected in `setWorkspace()` before init
- **`stores/ui.ts`**: `openSettings(section?)` now accepts optional section, `settingsInitialSection` state
- **`Settings.tsx`**: reads `settingsInitialSection` for initial tab
- **`App.tsx`**: renders dialog in both file mode and task mode
- **i18n**: zh-CN and en translations added

## Test plan
- [ ] Open a fresh directory → dialog appears
- [ ] Click "Personal" → dialog closes, stays on chat
- [ ] Open another fresh directory → click "Team" → navigates to Settings > Team
- [ ] Open an existing workspace (has `.teamclaw`) → no dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)