### PR TITLE
feat: add macOS Intel (x86_64) build support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,15 @@ jobs:
   release-macos:
     permissions:
       contents: write
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            opencode_asset: opencode-darwin-arm64.zip
+            opencode_binary: opencode-aarch64-apple-darwin
+          - target: x86_64-apple-darwin
+            opencode_asset: opencode-darwin-x64.zip
+            opencode_binary: opencode-x86_64-apple-darwin
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +68,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: ${{ matrix.target }}
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.7
@@ -69,6 +78,7 @@ jobs:
         with:
           workspaces: |
             ./src-tauri -> target
+          key: ${{ matrix.target }}
 
       # Parallel: pnpm install + frontend build, opencode download, certificate import
       - name: Build all (parallel)
@@ -95,12 +105,12 @@ jobs:
             set -e
             OPENCODE_VERSION=$(gh release view --repo anomalyco/opencode --json tagName -q '.tagName')
             echo "Downloading opencode ${OPENCODE_VERSION}..."
-            gh release download "$OPENCODE_VERSION" --repo anomalyco/opencode --pattern "opencode-darwin-arm64.zip" --dir /tmp
-            unzip -o /tmp/opencode-darwin-arm64.zip -d /tmp/opencode-extract
-            mv /tmp/opencode-extract/opencode src-tauri/binaries/opencode-aarch64-apple-darwin
-            chmod +x src-tauri/binaries/opencode-aarch64-apple-darwin
-            xattr -cr src-tauri/binaries/opencode-aarch64-apple-darwin
-            codesign --force --sign - src-tauri/binaries/opencode-aarch64-apple-darwin
+            gh release download "$OPENCODE_VERSION" --repo anomalyco/opencode --pattern "${{ matrix.opencode_asset }}" --dir /tmp
+            unzip -o /tmp/${{ matrix.opencode_asset }} -d /tmp/opencode-extract
+            mv /tmp/opencode-extract/opencode src-tauri/binaries/${{ matrix.opencode_binary }}
+            chmod +x src-tauri/binaries/${{ matrix.opencode_binary }}
+            xattr -cr src-tauri/binaries/${{ matrix.opencode_binary }}
+            codesign --force --sign - src-tauri/binaries/${{ matrix.opencode_binary }}
             echo "opencode ${OPENCODE_VERSION} ready"
           ) > /tmp/opencode.log 2>&1 &
           PID_OPENCODE=$!
@@ -173,7 +183,7 @@ jobs:
             ```
 
             ### macOS (manual)
-            1. Download the `.dmg` file below
+            1. Download the `.dmg` file below (choose `aarch64` for Apple Silicon, `x64` for Intel)
             2. Open the DMG and drag TeamClaw to Applications
             3. Before opening, run in Terminal:
                ```
@@ -187,7 +197,7 @@ jobs:
             Download and run the `.exe` installer below.
           releaseDraft: false
           prerelease: false
-          args: "--target aarch64-apple-darwin"
+          args: "--target ${{ matrix.target }}"
 
   # Windows job uploads artifacts to the same GitHub Release created by macOS job
   release-windows:

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -7,14 +7,31 @@ MOUNT_POINT="/Volumes/${APP_NAME}"
 
 echo "Installing ${APP_NAME}..."
 
-# Get latest release DMG URL
+# Detect architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+  arm64)
+    DMG_PATTERN="aarch64.dmg"
+    echo "Detected Apple Silicon (arm64)"
+    ;;
+  x86_64)
+    DMG_PATTERN="x64.dmg"
+    echo "Detected Intel (x86_64)"
+    ;;
+  *)
+    echo "Error: Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+# Get matching DMG URL from latest release
 DMG_URL=$(curl -sL "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep -o '"browser_download_url":\s*"[^"]*\.dmg"' \
+  | grep -o '"browser_download_url":\s*"[^"]*'"${DMG_PATTERN}"'"' \
   | head -1 \
   | cut -d'"' -f4)
 
 if [ -z "$DMG_URL" ]; then
-  echo "Error: Could not find DMG in latest release"
+  echo "Error: Could not find ${DMG_PATTERN} in latest release"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Add matrix strategy to release workflow to build both `aarch64-apple-darwin` and `x86_64-apple-darwin` DMGs
- Update `install-mac.sh` to auto-detect architecture via `uname -m` and download the correct DMG
- Verified `opencode-darwin-x64.zip` asset exists in anomalyco/opencode releases

## Test plan
- [ ] Tag a test release and verify both macOS matrix jobs complete
- [ ] Verify both `aarch64` and `x64` DMGs appear in the GitHub Release
- [ ] Run `install-mac.sh` on Apple Silicon Mac
- [ ] Run `install-mac.sh` on Intel Mac (or Rosetta)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)