### PR TITLE
feat: cron session filter toggle in sidebar

### DIFF
--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { useTranslation } from "react-i18next"
-import { Search, SquarePen, Settings, MessageSquare, Loader2, Archive, PanelLeftIcon, FolderOpen, Pencil, Ellipsis } from "lucide-react"
+import { Search, SquarePen, Settings, MessageSquare, Loader2, Archive, PanelLeftIcon, FolderOpen, Pencil, Ellipsis, Clock } from "lucide-react"
 
 import { useSessionStore } from "@/stores/session"
 import { useStreamingStore } from "@/stores/streaming"
@@ -134,6 +134,8 @@ export function SidebarIconGroup({ className }: { className?: string }) {
   const { toggleSidebar } = useSidebar()
   const createSession = useSessionStore(s => s.createSession)
   const workspacePath = useWorkspaceStore(s => s.workspacePath)
+  const showCronSessions = useCronStore(s => s.showCronSessions)
+  const toggleShowCronSessions = useCronStore(s => s.toggleShowCronSessions)
   const [isCreating, setIsCreating] = React.useState(false)
   const [searchOpen, setSearchOpen] = React.useState(false)
   
@@ -185,6 +187,21 @@ export function SidebarIconGroup({ className }: { className?: string }) {
           title={hasWorkspace ? "Search (⌘K)" : t('sidebar.selectWorkspaceFirst', 'Please select a workspace first')}
         >
           <Search className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn(
+            "h-7 w-7 transition-colors disabled:opacity-40",
+            showCronSessions
+              ? "text-foreground bg-muted"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+          disabled={!hasWorkspace}
+          onClick={toggleShowCronSessions}
+          title={showCronSessions ? t('sidebar.showAllSessions', 'Show all sessions') : t('sidebar.showCronSessions', 'Show scheduled sessions')}
+        >
+          <Clock className="h-4 w-4" />
         </Button>
         <Button
           variant="ghost"
@@ -327,16 +344,20 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const updateSessionTitle = useSessionStore(s => s.updateSessionTitle)
   const loadMoreSessions = useSessionStore(s => s.loadMoreSessions)
   const cronSessionIds = useCronStore(s => s.cronSessionIds)
+  const showCronSessions = useCronStore(s => s.showCronSessions)
 
   // Rename state
   const [renamingSessionId, setRenamingSessionId] = React.useState<string | null>(null)
 
-  // UI-level pagination: filter out cron sessions, then slice to visible count
+  // UI-level pagination: filter by cron toggle, then slice to visible count
   const sessions = React.useMemo(
     () => allSessions
-      .filter(s => !cronSessionIds.has(s.id) || s.id === activeSessionId)
+      .filter(s => showCronSessions
+        ? cronSessionIds.has(s.id)
+        : !cronSessionIds.has(s.id) || s.id === activeSessionId
+      )
       .slice(0, visibleSessionCount),
-    [allSessions, cronSessionIds, activeSessionId, visibleSessionCount],
+    [allSessions, cronSessionIds, showCronSessions, activeSessionId, visibleSessionCount],
   )
   
   const openSettings = useUIStore(s => s.openSettings)

--- a/packages/app/src/components/chat/SessionList.tsx
+++ b/packages/app/src/components/chat/SessionList.tsx
@@ -118,11 +118,15 @@ export function SessionList({ compact, onSessionSelected }: SessionListProps) {
   const allSessions = useSessionStore(s => s.sessions)
   const activeSessionId = useSessionStore(s => s.activeSessionId)
   const cronSessionIds = useCronStore(s => s.cronSessionIds)
+  const showCronSessions = useCronStore(s => s.showCronSessions)
 
-  // Filter out cron-created sessions (unless it's the currently active one)
+  // Filter sessions by cron toggle
   const sessions = useMemo(
-    () => allSessions.filter(s => !cronSessionIds.has(s.id) || s.id === activeSessionId),
-    [allSessions, cronSessionIds, activeSessionId],
+    () => allSessions.filter(s => showCronSessions
+      ? cronSessionIds.has(s.id)
+      : !cronSessionIds.has(s.id) || s.id === activeSessionId
+    ),
+    [allSessions, cronSessionIds, showCronSessions, activeSessionId],
   )
   const isLoading = useSessionStore(s => s.isLoading)
   const highlightedSessionIds = useSessionStore(s => s.highlightedSessionIds)

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -93,6 +93,8 @@ interface CronState {
 
   // All session IDs created by cron (for filtering in session list)
   cronSessionIds: Set<string>
+  // Toggle to show only cron sessions in the session list
+  showCronSessions: boolean
 
   // Run history for the currently viewed job
   selectedJobId: string | null
@@ -113,6 +115,7 @@ interface CronState {
   refreshDelivery: () => Promise<void>
   clearError: () => void
   setSelectedJobId: (jobId: string | null) => void
+  toggleShowCronSessions: () => void
 }
 
 export const useCronStore = create<CronState>((set, get) => ({
@@ -122,6 +125,7 @@ export const useCronStore = create<CronState>((set, get) => ({
   isInitialized: false,
 
   cronSessionIds: new Set<string>(),
+  showCronSessions: false,
 
   selectedJobId: null,
   runs: [],
@@ -249,6 +253,7 @@ export const useCronStore = create<CronState>((set, get) => ({
 
   clearError: () => set({ error: null }),
   setSelectedJobId: (jobId: string | null) => set({ selectedJobId: jobId }),
+  toggleShowCronSessions: () => set(s => ({ showCronSessions: !s.showCronSessions })),
 }))
 
 // ==================== Helpers ====================


### PR DESCRIPTION
## Summary
- Add a Clock icon toggle button next to the search icon in the sidebar header
- **Selected (highlighted)**: session list shows only scheduled/cron sessions  
- **Unselected (default)**: session list hides cron sessions (existing behavior)

## Test plan
- [ ] Click Clock icon → only cron sessions shown, icon highlighted
- [ ] Click again → back to default
- [ ] Default behavior unchanged on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)