### PR TITLE
fix: write LLM config on OSS create/join team

### DIFF
--- a/packages/app/src/stores/team-oss.ts
+++ b/packages/app/src/stores/team-oss.ts
@@ -164,6 +164,9 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
       const info = await invoke<OssTeamInfo>('oss_create_team', {
         ...params,
         fcEndpoint: buildConfig.oss?.fcEndpoint ?? '',
+        llmBaseUrl: buildConfig.team.llm.baseUrl || null,
+        llmModel: buildConfig.team.llm.model || null,
+        llmModelName: buildConfig.team.llm.modelName || null,
       })
       set({ configured: true, connected: true, teamInfo: info, error: null })
       // Refresh file tree so the new teamclaw-team directory appears
@@ -181,6 +184,9 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
       const result = await invoke<OssJoinResult>('oss_join_team', {
         ...params,
         fcEndpoint: buildConfig.oss?.fcEndpoint ?? '',
+        llmBaseUrl: buildConfig.team.llm.baseUrl || null,
+        llmModel: buildConfig.team.llm.model || null,
+        llmModelName: buildConfig.team.llm.modelName || null,
       })
 
       if (result.status === 'not_member') {

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -73,9 +73,18 @@ pub async fn oss_create_team(
     owner_name: String,
     owner_email: String,
     fc_endpoint: String,
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
 ) -> Result<OssTeamInfo, String> {
     let node_id = get_p2p_node_id(&iroh_state).await?;
     let team_secret = generate_team_secret()?;
+
+    // Write LLM config to .teamclaw/teamclaw.json
+    let llm_config =
+        super::team::build_llm_config(llm_base_url, llm_model, llm_model_name);
+    super::team::write_llm_config(&workspace_path, Some(&llm_config))?;
+    info!("oss_create_team: wrote LLM config to .teamclaw/teamclaw.json");
 
     // Scaffold teamclaw-team directory with default structure
     let team_dir = format!("{}/teamclaw-team", workspace_path);
@@ -205,6 +214,9 @@ pub async fn oss_join_team(
     team_id: String,
     team_secret: String,
     fc_endpoint: String,
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
 ) -> Result<OssJoinResult, String> {
     let node_id = get_p2p_node_id(&iroh_state).await?;
 
@@ -268,6 +280,11 @@ pub async fn oss_join_team(
     if !std::path::Path::new(&team_dir).exists() {
         super::team::scaffold_team_dir(&team_dir)?;
     }
+
+    // Write LLM config to .teamclaw/teamclaw.json
+    let llm_config =
+        super::team::build_llm_config(llm_base_url, llm_model, llm_model_name);
+    super::team::write_llm_config(&workspace_path, Some(&llm_config))?;
 
     // Run initial sync
     manager.initial_sync().await?;


### PR DESCRIPTION
## Summary

- `oss_create_team` and `oss_join_team` now accept `llmBaseUrl`, `llmModel`, `llmModelName` parameters
- Rust writes LLM config to `.teamclaw/teamclaw.json` on create/join, matching P2P and Git behavior
- Frontend passes `buildConfig.team.llm` values to both commands

Previously OSS mode never wrote the `llm` field to `teamclaw.json`, so `loadTeamConfig` couldn't find the LLM config and the default team provider never loaded.

## Test plan

- [ ] OSS create team → check `.teamclaw/teamclaw.json` has `llm` field
- [ ] OSS join team → check `.teamclaw/teamclaw.json` has `llm` field
- [ ] After create/join, `opencode.json` should have team provider with correct baseURL
- [ ] Restart app → team provider auto-loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)