### PR TITLE
feat(chat): tool-call diff UI for apply_patch and preview improvements

### DIFF
--- a/packages/app/src/components/chat/tool-calls/EditToolCard.tsx
+++ b/packages/app/src/components/chat/tool-calls/EditToolCard.tsx
@@ -12,11 +12,14 @@ import { PermissionApprovalBar } from "./PermissionApprovalBar";
 import {
   statusConfig,
   extractFilePath,
+  extractPatchTextFromToolArgs,
   getFileExtension,
   getLanguageName,
   getFileName,
 } from "./tool-call-utils";
 import { parseSingleFileDiff, type DiffLine } from "@/components/diff/diff-ast";
+import { tryParseToolPatchForUI } from "@/components/diff/parse-tool-patch";
+import { ToolCallDiffBody } from "./ToolCallDiffBody";
 
 // Generate unified diff from before/after strings
 function generateUnifiedDiff(before: string, after: string, filePath: string): string {
@@ -120,50 +123,71 @@ export function EditToolCard({ toolCall }: { toolCall: ToolCall }) {
 
   const args = toolCall.arguments as Record<string, unknown>;
   const filePath = extractFilePath(args);
+  const patchText = extractPatchTextFromToolArgs(args);
   const oldStr = String(args?.old_string || args?.oldString || "");
   const newStr = String(args?.new_string || args?.newString || "");
-  const ext = getFileExtension(filePath);
-  const langName = getLanguageName(ext);
   const config = statusConfig[toolCall.status];
   const StatusIcon = config.icon;
 
-  // Generate unified diff and parse into structured format
+  // Generate unified diff and parse into structured format (str-replace edit or raw patch)
   const diffData = useMemo(() => {
-    if (!oldStr && !newStr) return null;
     try {
-      const diffText = generateUnifiedDiff(oldStr, newStr, filePath || "file");
-      const parsed = parseSingleFileDiff(diffText, filePath || "file");
-      if (!parsed) return null;
+      if (oldStr || newStr) {
+        const diffText = generateUnifiedDiff(oldStr, newStr, filePath || "file");
+        const parsed = parseSingleFileDiff(diffText, filePath || "file");
+        if (!parsed) return null;
 
-      // Merge all hunks into a single list of lines
-      const allLines: DiffLine[] = [];
-      for (const hunk of parsed.hunks) {
-        allLines.push(...hunk.lines);
+        const allLines: DiffLine[] = [];
+        for (const hunk of parsed.hunks) {
+          allLines.push(...hunk.lines);
+        }
+
+        return {
+          lines: allLines,
+          additions: parsed.addedCount,
+          deletions: parsed.removedCount,
+          headerPath: filePath || "file",
+          copyText: newStr,
+        };
       }
 
-      return {
-        lines: allLines,
-        additions: parsed.addedCount,
-        deletions: parsed.removedCount,
-      };
+      if (patchText) {
+        const parsed = tryParseToolPatchForUI(patchText, filePath);
+        if (!parsed || parsed.lines.length === 0) return null;
+
+        return {
+          lines: parsed.lines,
+          additions: parsed.additions,
+          deletions: parsed.deletions,
+          headerPath: filePath || parsed.filePath || "file",
+          copyText: patchText,
+        };
+      }
     } catch (error) {
       console.error("[EditToolCard] Failed to generate diff:", error);
       return null;
     }
-  }, [oldStr, newStr, filePath]);
+    return null;
+  }, [oldStr, newStr, filePath, patchText]);
+
+  const headerPath = diffData?.headerPath ?? filePath;
+  const ext = getFileExtension(headerPath);
+  const langName = getLanguageName(ext);
 
   const handleCopy = async () => {
-    await copyToClipboard(newStr);
+    const text = diffData?.copyText ?? newStr;
+    if (!text) return;
+    await copyToClipboard(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
 
   const handleOpenFile = useCallback(() => {
-    if (!filePath) return;
+    if (!headerPath) return;
     const fullPath =
-      filePath.startsWith("/") ? filePath : `${workspacePath}/${filePath}`;
+      headerPath.startsWith("/") ? headerPath : `${workspacePath}/${headerPath}`;
     selectFile(fullPath);
-  }, [filePath, workspacePath, selectFile]);
+  }, [headerPath, workspacePath, selectFile]);
 
   const handleToggleExpand = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -176,9 +200,9 @@ export function EditToolCard({ toolCall }: { toolCall: ToolCall }) {
       <div
         className={cn(
           "flex items-center gap-2 px-3 py-2 bg-muted/50 transition-colors select-none hover:bg-muted/70",
-          filePath ? "cursor-pointer" : "",
+          headerPath ? "cursor-pointer" : "",
         )}
-        onClick={filePath ? handleOpenFile : handleToggleExpand}
+        onClick={headerPath ? handleOpenFile : handleToggleExpand}
       >
         <ChevronRight
           size={14}
@@ -189,15 +213,15 @@ export function EditToolCard({ toolCall }: { toolCall: ToolCall }) {
           onClick={handleToggleExpand}
         />
         <FileEdit size={14} className="text-muted-foreground shrink-0" />
-        {filePath && (
+        {headerPath && (
           <span
             className="text-xs text-foreground truncate flex-1 cursor-pointer font-mono"
-            title={filePath}
+            title={headerPath}
           >
-            {getFileName(filePath)}
+            {getFileName(headerPath)}
           </span>
         )}
-        {!filePath && <span className="flex-1" />}
+        {!headerPath && <span className="flex-1" />}
         <span className="text-[10px] text-muted-foreground">{langName}</span>
         {diffData && diffData.additions > 0 && (
           <span className="text-[10px] text-green-600 dark:text-green-500">+{diffData.additions}</span>
@@ -215,7 +239,7 @@ export function EditToolCard({ toolCall }: { toolCall: ToolCall }) {
         <button
           onClick={handleCopy}
           className="p-1 rounded hover:bg-background transition-colors"
-          title="Copy new content"
+          title="Copy patch or new content"
         >
           {copied ? (
             <CheckCheck size={12} className="text-foreground" />
@@ -229,49 +253,12 @@ export function EditToolCard({ toolCall }: { toolCall: ToolCall }) {
         />
       </div>
 
-      {/* Unified diff view - all lines merged without hunk grouping */}
       {isExpanded && diffData && diffData.lines.length > 0 && (
-        <div className="border-t border-border bg-background max-h-[400px] overflow-y-auto">
-          {diffData.lines.map((line, index) => (
-            <div
-              key={index}
-              className={cn(
-                "flex font-mono text-[11px] leading-5",
-                line.type === "added" && "bg-green-500/5 dark:bg-green-500/10",
-                line.type === "removed" && "bg-red-500/5 dark:bg-red-500/10",
-                line.type === "context" && "bg-transparent",
-              )}
-            >
-              {/* Old line number */}
-              <span className="w-10 text-right pr-2 select-none text-muted-foreground/40 shrink-0 text-[10px]">
-                {line.oldLineNumber ?? ""}
-              </span>
-              {/* New line number */}
-              <span className="w-10 text-right pr-2 select-none text-muted-foreground/40 shrink-0 text-[10px]">
-                {line.newLineNumber ?? ""}
-              </span>
-              {/* Change indicator */}
-              <span
-                className={cn(
-                  "w-4 text-center select-none shrink-0 text-[10px]",
-                  line.type === "added" && "text-green-600 dark:text-green-500",
-                  line.type === "removed" && "text-red-600 dark:text-red-500",
-                  line.type === "context" && "text-muted-foreground/30",
-                )}
-              >
-                {line.type === "added" ? "+" : line.type === "removed" ? "−" : " "}
-              </span>
-              {/* Content */}
-              <span className="flex-1 whitespace-pre-wrap break-all pl-1 text-foreground/90">
-                {line.content}
-              </span>
-            </div>
-          ))}
-        </div>
+        <ToolCallDiffBody lines={diffData.lines} />
       )}
 
       {/* Fallback: show error if diff generation failed but we have content */}
-      {isExpanded && (oldStr || newStr) && !diffData && (
+      {isExpanded && (oldStr || newStr || patchText) && !diffData && (
         <div className="p-3 text-xs text-muted-foreground italic">
           Unable to generate diff view
         </div>

--- a/packages/app/src/components/chat/tool-calls/ToolCallDiffBody.tsx
+++ b/packages/app/src/components/chat/tool-calls/ToolCallDiffBody.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { DiffLine } from "@/components/diff/diff-ast";
+
+/** Default visible rows before tail fold (collapsed preview height). */
+const DEFAULT_PREVIEW_LINES = 6;
+
+function DiffLineRow({ line }: { line: DiffLine }) {
+  return (
+    <div
+      className={cn(
+        "flex min-w-full w-max font-mono text-[11px] leading-5",
+        line.type === "added" && "bg-green-500/5 dark:bg-green-500/10",
+        line.type === "removed" && "bg-red-500/5 dark:bg-red-500/10",
+        line.type === "context" && "bg-transparent",
+      )}
+    >
+      <span className="w-10 text-right pr-2 select-none text-muted-foreground/40 shrink-0 text-[10px]">
+        {line.oldLineNumber ?? ""}
+      </span>
+      <span className="w-10 text-right pr-2 select-none text-muted-foreground/40 shrink-0 text-[10px]">
+        {line.newLineNumber ?? ""}
+      </span>
+      <span
+        className={cn(
+          "w-4 text-center select-none shrink-0 text-[10px]",
+          line.type === "added" && "text-green-600 dark:text-green-500",
+          line.type === "removed" && "text-red-600 dark:text-red-500",
+          line.type === "context" && "text-muted-foreground/30",
+        )}
+      >
+        {line.type === "added" ? "+" : line.type === "removed" ? "−" : " "}
+      </span>
+      <span className="whitespace-pre pl-1 pr-3 text-foreground/90">
+        {line.content}
+      </span>
+    </div>
+  );
+}
+
+export interface ToolCallDiffBodyProps {
+  lines: DiffLine[];
+  /** How many diff rows to show before the tail fold (default 6). */
+  previewLineCount?: number;
+}
+
+/**
+ * Diff block for edit/write tool cards: default shows a few lines, bottom chevron expands the rest.
+ * Header-level expand/collapse is handled by the parent card.
+ */
+export function ToolCallDiffBody({
+  lines,
+  previewLineCount = DEFAULT_PREVIEW_LINES,
+}: ToolCallDiffBodyProps) {
+  const [tailExpanded, setTailExpanded] = useState(false);
+  const needsTailToggle = lines.length > previewLineCount;
+  const displayed =
+    !needsTailToggle || tailExpanded ? lines : lines.slice(0, previewLineCount);
+  const collapsedPreview = needsTailToggle && !tailExpanded;
+
+  return (
+    <div className="group relative border-t border-border bg-background">
+      <div
+        className={cn(
+          "max-w-full",
+          needsTailToggle && tailExpanded
+            ? "max-h-[min(400px,70vh)] overflow-auto"
+            : "overflow-x-auto",
+        )}
+      >
+        {displayed.map((line, index) => (
+          <DiffLineRow key={index} line={line} />
+        ))}
+      </div>
+
+      {/* Fade hint: more content below (only when tail is collapsed) */}
+      {collapsedPreview && (
+        <div
+          className="pointer-events-none absolute bottom-0 left-0 right-0 z-[1] h-16 bg-gradient-to-t from-background from-25% via-background/55 to-transparent dark:from-background dark:via-background/50"
+          aria-hidden
+        />
+      )}
+
+      {needsTailToggle && (
+        <div
+          className={cn(
+            "relative z-[2] flex justify-center",
+            collapsedPreview ? "absolute bottom-0 left-0 right-0" : "border-t border-border/50",
+          )}
+        >
+          <button
+            type="button"
+            className={cn(
+              "flex w-full justify-center outline-none transition-colors",
+              "hover:bg-muted/25 focus-visible:bg-muted/30 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm",
+              collapsedPreview
+                ? "min-h-10 items-end pb-1.5 pt-6"
+                : "min-h-0 items-center py-1",
+            )}
+            onClick={(e) => {
+              e.stopPropagation();
+              setTailExpanded((v) => !v);
+            }}
+            aria-expanded={tailExpanded}
+            aria-label={tailExpanded ? "Collapse diff preview" : "Expand full diff"}
+          >
+            <ChevronDown
+              size={16}
+              className={cn(
+                "shrink-0 text-muted-foreground/90 transition-all duration-200",
+                tailExpanded && "opacity-100 rotate-180",
+                collapsedPreview &&
+                  "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
+              )}
+            />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/chat/tool-calls/WriteToolCard.tsx
+++ b/packages/app/src/components/chat/tool-calls/WriteToolCard.tsx
@@ -21,6 +21,7 @@ import {
   useToolCallTimeout,
 } from "./tool-call-utils";
 import { parseSingleFileDiff, type DiffLine } from "@/components/diff/diff-ast";
+import { ToolCallDiffBody } from "./ToolCallDiffBody";
 
 // Generate unified diff for new file (empty before)
 function generateNewFileDiff(content: string, filePath: string): string {
@@ -191,45 +192,8 @@ export function WriteToolCard({ toolCall }: { toolCall: ToolCall }) {
         )}
       </div>
 
-      {/* Unified diff view for new file - all lines merged without hunk grouping */}
       {isExpanded && diffData && diffData.lines.length > 0 && (
-        <div className="border-t border-border bg-background max-h-[400px] overflow-y-auto">
-          {diffData.lines.map((line, index) => (
-            <div
-              key={index}
-              className={cn(
-                "flex font-mono text-[11px] leading-5",
-                line.type === "added" && "bg-green-500/5 dark:bg-green-500/10",
-                line.type === "removed" && "bg-red-500/5 dark:bg-red-500/10",
-                line.type === "context" && "bg-transparent",
-              )}
-            >
-              {/* Old line number */}
-              <span className="w-10 text-right pr-2 select-none text-muted-foreground/40 shrink-0 text-[10px]">
-                {line.oldLineNumber ?? ""}
-              </span>
-              {/* New line number */}
-              <span className="w-10 text-right pr-2 select-none text-muted-foreground/40 shrink-0 text-[10px]">
-                {line.newLineNumber ?? ""}
-              </span>
-              {/* Change indicator */}
-              <span
-                className={cn(
-                  "w-4 text-center select-none shrink-0 text-[10px]",
-                  line.type === "added" && "text-green-600 dark:text-green-500",
-                  line.type === "removed" && "text-red-600 dark:text-red-500",
-                  line.type === "context" && "text-muted-foreground/30",
-                )}
-              >
-                {line.type === "added" ? "+" : line.type === "removed" ? "−" : " "}
-              </span>
-              {/* Content */}
-              <span className="flex-1 whitespace-pre-wrap break-all pl-1 text-foreground/90">
-                {line.content}
-              </span>
-            </div>
-          ))}
-        </div>
+        <ToolCallDiffBody lines={diffData.lines} />
       )}
 
       {/* Loading placeholder when no content yet */}

--- a/packages/app/src/components/chat/tool-calls/tool-call-utils.ts
+++ b/packages/app/src/components/chat/tool-calls/tool-call-utils.ts
@@ -100,7 +100,9 @@ export function isEditTool(toolName: string): boolean {
     name === "edit_file" ||
     name === "editfile" ||
     name === "str_replace" ||
-    name === "strreplace"
+    name === "strreplace" ||
+    name === "apply_patch" ||
+    name === "applypatch"
   );
 }
 
@@ -217,6 +219,51 @@ export function extractFilePath(args: Record<string, unknown> | undefined): stri
   if (!args) return "";
   const path =
     args.path || args.file || args.filePath || args.filepath ||
-    args.file_path || args.filename || "";
+    args.file_path || args.filename || args.target_file || args.targetFile || "";
   return String(path);
+}
+
+const PATCH_ARG_KEYS = [
+  "patch",
+  "diff",
+  "unifiedDiff",
+  "unified_diff",
+  "udiff",
+] as const;
+
+/**
+ * Extract raw patch / unified-diff text from apply_patch (and similar) tool arguments.
+ */
+export function extractPatchTextFromToolArgs(
+  args: Record<string, unknown> | undefined,
+): string | null {
+  if (!args) return null;
+
+  for (const k of PATCH_ARG_KEYS) {
+    const v = args[k];
+    if (typeof v === "string" && v.trim().length > 0) return v;
+  }
+
+  const content = args.content;
+  if (typeof content === "string" && content.trim().length > 0) {
+    const t = content.trim();
+    if (
+      t.startsWith("diff --git") ||
+      t.includes("*** Begin Patch") ||
+      t.startsWith("--- ") ||
+      t.includes("\n@@")
+    ) {
+      return content;
+    }
+  }
+
+  for (const v of Object.values(args)) {
+    if (typeof v !== "string" || v.trim().length === 0) continue;
+    const t = v.trim();
+    if (t.startsWith("diff --git") || t.includes("*** Begin Patch")) {
+      return v;
+    }
+  }
+
+  return null;
 }

--- a/packages/app/src/components/diff/__tests__/parse-tool-patch.test.ts
+++ b/packages/app/src/components/diff/__tests__/parse-tool-patch.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { tryParseToolPatchForUI } from "../parse-tool-patch";
+import { extractPatchTextFromToolArgs } from "@/components/chat/tool-calls/tool-call-utils";
+
+const UNIFIED = `diff --git a/foo/bar.ts b/foo/bar.ts
+--- a/foo/bar.ts
++++ b/foo/bar.ts
+@@ -1,2 +1,3 @@
+ line1
+-old
++new
+ line2`;
+
+const V4A = `*** Begin Patch
+*** Update File: foo/bar.ts
+@@
+ context
+-old line
++new line
+*** End Patch`;
+
+describe("tryParseToolPatchForUI", () => {
+  it("parses unified diff --git", () => {
+    const r = tryParseToolPatchForUI(UNIFIED, "");
+    expect(r).not.toBeNull();
+    expect(r!.filePath).toContain("bar.ts");
+    expect(r!.additions).toBeGreaterThan(0);
+    expect(r!.deletions).toBeGreaterThan(0);
+    expect(r!.lines.some((l) => l.type === "added")).toBe(true);
+  });
+
+  it("parses V4A Begin Patch block", () => {
+    const r = tryParseToolPatchForUI(V4A, "");
+    expect(r).not.toBeNull();
+    expect(r!.filePath).toBe("foo/bar.ts");
+    expect(r!.lines.length).toBeGreaterThan(0);
+  });
+});
+
+describe("extractPatchTextFromToolArgs", () => {
+  it("reads patch key", () => {
+    expect(extractPatchTextFromToolArgs({ patch: UNIFIED })).toBe(UNIFIED);
+  });
+
+  it("finds diff-looking content field", () => {
+    expect(
+      extractPatchTextFromToolArgs({ content: "*** Begin Patch\n" }),
+    ).toContain("Begin Patch");
+  });
+});

--- a/packages/app/src/components/diff/parse-tool-patch.ts
+++ b/packages/app/src/components/diff/parse-tool-patch.ts
@@ -1,0 +1,173 @@
+/**
+ * Parse patch / unified-diff strings from agent "apply_patch" (and similar) tools
+ * into the DiffLine[] shape used by chat tool cards.
+ */
+
+import {
+  parseDiff,
+  parseSingleFileDiff,
+  type DiffLine,
+} from "@/components/diff/diff-ast";
+
+export interface ParsedToolPatch {
+  lines: DiffLine[];
+  additions: number;
+  deletions: number;
+  filePath: string;
+}
+
+function extractPathFromDiffGit(text: string): string {
+  const m = text.match(/^diff --git a\/(.+?) b\//m);
+  return m ? m[1].trim() : "";
+}
+
+function extractPathFromUnifiedPlus(text: string): string {
+  const m = text.match(/^\+\+\+\s+[ab]\/(.+?)\s*$/m);
+  return m ? m[1].trim() : "";
+}
+
+/**
+ * Parse V4A-style "*** Begin Patch" blocks that contain +/- lines, with or without @@ hunks.
+ */
+function parseV4ALoosePatch(
+  text: string,
+  defaultPath: string,
+): ParsedToolPatch | null {
+  if (!text.includes("*** Begin Patch")) return null;
+
+  let filePath = defaultPath;
+  const updateMatch = text.match(/\*\*\* Update File:\s*(.+?)\s*$/m);
+  const addMatch = text.match(/\*\*\* Add File:\s*(.+?)\s*$/m);
+  if (updateMatch) filePath = updateMatch[1].trim();
+  else if (addMatch) filePath = addMatch[1].trim();
+
+  const endIdx = text.indexOf("*** End Patch");
+  const startIdx = text.indexOf("*** Begin Patch");
+  const slice =
+    endIdx >= 0
+      ? text.slice(startIdx, endIdx)
+      : startIdx >= 0
+        ? text.slice(startIdx)
+        : text;
+
+  const rawLines = slice.split("\n");
+  const bodyLines = rawLines.filter((l) => !l.trimStart().startsWith("***"));
+
+  const body = bodyLines.join("\n").trim();
+  if (body.includes("@@")) {
+    const parsed = parseSingleFileDiff(body, filePath || "file");
+    if (parsed && parsed.hunks.length > 0) {
+      const allLines: DiffLine[] = [];
+      for (const h of parsed.hunks) {
+        allLines.push(...h.lines);
+      }
+      return {
+        lines: allLines,
+        additions: parsed.addedCount,
+        deletions: parsed.removedCount,
+        filePath: parsed.filePath || filePath || "file",
+      };
+    }
+  }
+
+  let oldN = 1;
+  let newN = 1;
+  const diffLines: DiffLine[] = [];
+  let additions = 0;
+  let deletions = 0;
+
+  for (const line of bodyLines) {
+    const t = line.trimEnd();
+    if (t === "") continue;
+    if (t.startsWith("\\")) continue;
+
+    const c = t[0];
+    const rest = t.slice(1);
+
+    if (c === "+") {
+      diffLines.push({
+        type: "added",
+        content: rest,
+        oldLineNumber: null,
+        newLineNumber: newN,
+      });
+      newN++;
+      additions++;
+    } else if (c === "-") {
+      diffLines.push({
+        type: "removed",
+        content: rest,
+        oldLineNumber: oldN,
+        newLineNumber: null,
+      });
+      oldN++;
+      deletions++;
+    } else if (c === " ") {
+      diffLines.push({
+        type: "context",
+        content: rest,
+        oldLineNumber: oldN,
+        newLineNumber: newN,
+      });
+      oldN++;
+      newN++;
+    }
+  }
+
+  if (diffLines.length === 0) return null;
+
+  return {
+    lines: diffLines,
+    additions,
+    deletions,
+    filePath: filePath || "file",
+  };
+}
+
+/**
+ * Best-effort parse of patch text from apply_patch / edit tools for the diff UI.
+ */
+export function tryParseToolPatchForUI(
+  patchText: string,
+  hintPath: string,
+): ParsedToolPatch | null {
+  const trimmed = patchText.trim();
+  if (!trimmed) return null;
+
+  const pathHint =
+    hintPath ||
+    extractPathFromDiffGit(trimmed) ||
+    extractPathFromUnifiedPlus(trimmed);
+
+  if (trimmed.startsWith("diff --git")) {
+    const files = parseDiff(trimmed);
+    if (files.length === 0) return null;
+    const target = files[0];
+    const allLines: DiffLine[] = [];
+    for (const h of target.hunks) {
+      allLines.push(...h.lines);
+    }
+    return {
+      lines: allLines,
+      additions: target.addedCount,
+      deletions: target.removedCount,
+      filePath: target.filePath || pathHint || "file",
+    };
+  }
+
+  const single = parseSingleFileDiff(trimmed, pathHint || "file");
+  if (single && single.hunks.length > 0) {
+    const allLines: DiffLine[] = [];
+    for (const h of single.hunks) {
+      allLines.push(...h.lines);
+    }
+    return {
+      lines: allLines,
+      additions: single.addedCount,
+      deletions: single.removedCount,
+      filePath: single.filePath || pathHint || "file",
+    };
+  }
+
+  return parseV4ALoosePatch(trimmed, pathHint || "file");
+}


### PR DESCRIPTION
## Summary
Improves the chat tool-call cards for file edits so **apply_patch** uses the same line-level diff UI as **edit** / **write**, and refines the diff preview behavior.

## Changes
- **apply_patch**: Recognized in `isEditTool`; patch text parsed from common argument shapes (unified diff, `diff --git`, V4A `*** Begin Patch` blocks).
- **ToolCallDiffBody** (shared by Edit + Write cards):
  - Collapsed preview shows **6** diff rows by default; chevron expands the rest.
  - Bottom **gradient** when collapsed; expand chevron on **hover** / focus-within.
  - **Horizontal scroll**, **no line wrap** (`whitespace-pre`).
  - **Compact** bottom bar when expanded (collapse back to preview).
- **Tests**: `parse-tool-patch.test.ts` for parser helpers.

## How to test
- `pnpm exec vitest run packages/app/src/components/diff/__tests__/parse-tool-patch.test.ts`
- Manual: trigger OpenCode tool calls for edit / write / apply_patch and confirm diff preview + expand/collapse.

## Notes
Does not include unrelated local changes (lockfile, release scripts).

Made with [Cursor](https://cursor.com)