### PR TITLE
feat(ui): show team tag with P2P connection status in sidebar

### DIFF
--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -230,7 +230,24 @@ function WorkspaceSelectorButton() {
   const isLoadingWorkspace = useWorkspaceStore(s => s.isLoadingWorkspace)
   const setWorkspace = useWorkspaceStore(s => s.setWorkspace)
   const teamMode = useTeamModeStore(s => s.teamMode)
+  const p2pConnected = useTeamModeStore(s => s.p2pConnected)
   const [isSelecting, setIsSelecting] = React.useState(false)
+
+  // Poll P2P connection status when in team mode
+  React.useEffect(() => {
+    if (!teamMode || !isTauri()) return
+    let cancelled = false
+    const poll = async () => {
+      try {
+        const { invoke } = await import('@tauri-apps/api/core')
+        const status = await invoke<{ connected?: boolean }>('p2p_sync_status')
+        if (!cancelled) useTeamModeStore.setState({ p2pConnected: status?.connected ?? false })
+      } catch { /* ignore */ }
+    }
+    poll()
+    const id = setInterval(poll, 5000)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [teamMode])
 
   const handleOpenFolder = async () => {
     if (!isTauri()) {
@@ -279,6 +296,17 @@ function WorkspaceSelectorButton() {
           <span className="truncate text-xs" data-testid="workspace-name">
             {workspaceName || t('workspace.selectWorkspace', 'Select Workspace')}
           </span>
+          {teamMode && workspaceName && (
+            <span className={cn(
+              "shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded flex items-center gap-1",
+              p2pConnected
+                ? "text-green-600 dark:text-green-400 bg-green-500/10"
+                : "text-amber-600 dark:text-amber-400 bg-amber-500/10"
+            )}>
+              <span className={cn("h-1.5 w-1.5 rounded-full", p2pConnected ? "bg-green-500" : "bg-amber-500")} />
+              {t('sidebar.teamTag', 'Team')}
+            </span>
+          )}
         </Button>
       </TooltipTrigger>
       <TooltipContent side="top">

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -206,7 +206,10 @@ export function TeamP2PConfig() {
     try {
       const status = await tauriInvoke<typeof syncStatus>('p2p_sync_status')
       setSyncStatus(status)
-      useTeamModeStore.setState({ myRole: (status?.role as 'owner' | 'editor' | 'viewer') ?? null })
+      useTeamModeStore.setState({
+        myRole: (status?.role as 'owner' | 'editor' | 'viewer') ?? null,
+        p2pConnected: status?.connected ?? false,
+      })
     } catch {
       // may not be available
     }

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -24,6 +24,7 @@ interface TeamModeState {
   _appliedConfigKey: string | null // fingerprint of last applied config to avoid redundant apply
   devUnlocked: boolean // hidden dev mode: unlocks model selector & hidden dirs in team mode
   myRole: 'owner' | 'editor' | 'viewer' | null
+  p2pConnected: boolean
 
   loadTeamConfig: (workspacePath: string) => Promise<void>
   applyTeamModelToOpenCode: (workspacePath: string) => Promise<void>
@@ -62,6 +63,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   _appliedConfigKey: null,
   devUnlocked: false,
   myRole: null,
+  p2pConnected: false,
   teamApiKey: (() => {
     try {
       return localStorage.getItem(TEAM_API_KEY_STORAGE) || null
@@ -72,23 +74,28 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
 
   loadTeamConfig: async (_workspacePath: string) => {
     const status = await fetchTeamStatus()
-    if (status?.active && status.llm) {
-      const config: TeamModelConfig = {
-        baseUrl: status.llm.baseUrl,
-        model: status.llm.model,
-        modelName: status.llm.modelName || status.llm.model,
+    if (status?.active) {
+      set({ teamMode: true })
+      if (status.llm) {
+        const config: TeamModelConfig = {
+          baseUrl: status.llm.baseUrl,
+          model: status.llm.model,
+          modelName: status.llm.modelName || status.llm.model,
+        }
+        set({ teamModelConfig: config })
       }
-      set({ teamModelConfig: config })
     } else {
-      set({ teamModelConfig: null })
+      set({ teamMode: false, teamModelConfig: null })
     }
 
     // Team mode is determined by P2P sync status
-    // Load user's role (non-critical)
+    // Load user's role and P2P connection status (non-critical)
     try {
       const { invoke } = await import('@tauri-apps/api/core')
       const role = await invoke<string | null>('unified_team_get_my_role')
       set({ myRole: role as any })
+      const syncStatus = await invoke<{ connected?: boolean }>('p2p_sync_status').catch(() => null)
+      set({ p2pConnected: syncStatus?.connected ?? false })
     } catch {
       // Non-critical, role can be loaded later
     }


### PR DESCRIPTION
## Summary
- Restore "Team" tag next to workspace name in sidebar footer (was removed in earlier refactor)
- Show connection status: green dot when P2P connected, amber dot when disconnected
- Add `p2pConnected` state to `team-mode` store
- Sync status updated from both `loadSyncStatus` (Team page) and `loadTeamConfig` (app startup)

## Test plan
- [ ] Team mode active + P2P connected → green "Team" tag in sidebar
- [ ] Team mode active + P2P disconnected → amber "Team" tag
- [ ] No team mode → no tag shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)