### PR TITLE
feat: sidebar team connection status with simplified icon states

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -42,6 +42,7 @@ import {
   useChannelGatewayInit,
   useGitReposInit,
   useCronInit,
+  useP2pAutoReconnect,
 
   useExternalLinkHandler,
   useTauriBodyClass,
@@ -445,6 +446,7 @@ function AppContent() {
   useChannelGatewayInit();
   useGitReposInit();
   useCronInit();
+  useP2pAutoReconnect();
   useMCPFileWatcher(workspacePath);
   useExternalLinkHandler();
   useLayoutModeShortcut();

--- a/packages/app/src/__tests__/App.test.tsx
+++ b/packages/app/src/__tests__/App.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/hooks/useAppInit', () => ({
   useChannelGatewayInit: vi.fn(),
   useGitReposInit: vi.fn(),
   useCronInit: vi.fn(),
+  useP2pAutoReconnect: vi.fn(),
   useOssSyncInit: vi.fn(),
   useExternalLinkHandler: vi.fn(),
   useTauriBodyClass: vi.fn(),

--- a/packages/app/src/__tests__/TeamP2pJoin.test.ts
+++ b/packages/app/src/__tests__/TeamP2pJoin.test.ts
@@ -69,21 +69,17 @@ beforeEach(() => {
   }
 })
 
-async function renderAndSwitchToTicketMode() {
-  // TeamSection now renders TeamP2PConfig directly (no tab switcher)
+async function renderTeamSection() {
+  // TeamSection renders TeamP2PConfig directly; default joinMode is 'ticket'
   const { TeamSection } = await import('../components/settings/TeamSection')
   await act(async () => {
     render(React.createElement(TeamSection))
-  })
-  // Default join mode is 'seed'; switch to 'ticket' mode to get the ticket input
-  await act(async () => {
-    fireEvent.click(screen.getByRole('button', { name: /LAN \(ticket\)/i }))
   })
 }
 
 describe('TeamP2P Join Flow', () => {
   it('shows ticket input and Join button in P2P tab', async () => {
-    await renderAndSwitchToTicketMode()
+    await renderTeamSection()
 
     expect(screen.getByPlaceholderText(/ticket/i)).toBeDefined()
     expect(screen.getByRole('button', { name: /join/i })).toBeDefined()
@@ -92,7 +88,7 @@ describe('TeamP2P Join Flow', () => {
   it('shows inline error for invalid ticket', async () => {
     joinResult = new Error('Invalid ticket format')
 
-    await renderAndSwitchToTicketMode()
+    await renderTeamSection()
 
     // Wait for init effects
     await act(async () => {

--- a/packages/app/src/__tests__/TeamSection-join-approval.test.ts
+++ b/packages/app/src/__tests__/TeamSection-join-approval.test.ts
@@ -106,10 +106,7 @@ describe('TeamSection Join Approval Status', () => {
       await new Promise(r => setTimeout(r, 50))
     })
 
-    // Default join mode is 'seed'; switch to 'ticket' mode to get the ticket input
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /LAN \(ticket\)/i }))
-    })
+    // Default join mode is 'ticket', ticket input is already visible
 
     // Enter a ticket and click Join
     await waitFor(() => {
@@ -163,10 +160,7 @@ describe('TeamSection Join Approval Status', () => {
       await new Promise(r => setTimeout(r, 50))
     })
 
-    // Default join mode is 'seed'; switch to 'ticket' mode to get the ticket input
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /LAN \(ticket\)/i }))
-    })
+    // Default join mode is 'ticket', ticket input is already visible
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText(/ticket/i)).toBeDefined()

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -230,7 +230,24 @@ function WorkspaceSelectorButton() {
   const isLoadingWorkspace = useWorkspaceStore(s => s.isLoadingWorkspace)
   const setWorkspace = useWorkspaceStore(s => s.setWorkspace)
   const teamMode = useTeamModeStore(s => s.teamMode)
+  const p2pConnected = useTeamModeStore(s => s.p2pConnected)
   const [isSelecting, setIsSelecting] = React.useState(false)
+
+  // Poll P2P connection status when in team mode
+  React.useEffect(() => {
+    if (!teamMode || !isTauri()) return
+    let cancelled = false
+    const poll = async () => {
+      try {
+        const { invoke } = await import('@tauri-apps/api/core')
+        const status = await invoke<{ connected?: boolean }>('p2p_sync_status')
+        if (!cancelled) useTeamModeStore.setState({ p2pConnected: status?.connected ?? false })
+      } catch { /* ignore */ }
+    }
+    poll()
+    const id = setInterval(poll, 5000)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [teamMode])
 
   const handleOpenFolder = async () => {
     if (!isTauri()) {
@@ -279,6 +296,17 @@ function WorkspaceSelectorButton() {
           <span className="truncate text-xs" data-testid="workspace-name">
             {workspaceName || t('workspace.selectWorkspace', 'Select Workspace')}
           </span>
+          {teamMode && workspaceName && (
+            <span className={cn(
+              "shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded flex items-center gap-1",
+              p2pConnected
+                ? "text-green-600 dark:text-green-400 bg-green-500/10"
+                : "text-amber-600 dark:text-amber-400 bg-amber-500/10"
+            )}>
+              <span className={cn("h-1.5 w-1.5 rounded-full", p2pConnected ? "bg-green-500" : "bg-amber-500")} />
+              {t('sidebar.teamTag', 'Team')}
+            </span>
+          )}
         </Button>
       </TooltipTrigger>
       <TooltipContent side="top">

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -230,6 +230,7 @@ function WorkspaceSelectorButton() {
   const isLoadingWorkspace = useWorkspaceStore(s => s.isLoadingWorkspace)
   const setWorkspace = useWorkspaceStore(s => s.setWorkspace)
   const teamMode = useTeamModeStore(s => s.teamMode)
+  const p2pConnected = useTeamModeStore(s => s.p2pConnected)
   const [isSelecting, setIsSelecting] = React.useState(false)
 
   const handleOpenFolder = async () => {
@@ -279,6 +280,17 @@ function WorkspaceSelectorButton() {
           <span className="truncate text-xs" data-testid="workspace-name">
             {workspaceName || t('workspace.selectWorkspace', 'Select Workspace')}
           </span>
+          {teamMode && workspaceName && (
+            <span className={cn(
+              "shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded flex items-center gap-1",
+              p2pConnected
+                ? "text-green-600 dark:text-green-400 bg-green-500/10"
+                : "text-amber-600 dark:text-amber-400 bg-amber-500/10"
+            )}>
+              <span className={cn("h-1.5 w-1.5 rounded-full", p2pConnected ? "bg-green-500" : "bg-amber-500")} />
+              {t('sidebar.teamTag', 'Team')}
+            </span>
+          )}
         </Button>
       </TooltipTrigger>
       <TooltipContent side="top">

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -289,24 +289,13 @@ function WorkspaceSelectorButton() {
           {isLoading ? (
             <Loader2 className="h-4 w-4 animate-spin shrink-0" />
           ) : teamMode && workspaceName ? (
-            <Users className="h-4 w-4 shrink-0 text-blue-500" />
+            <Users className={cn("h-4 w-4 shrink-0", p2pConnected ? "text-blue-500" : "text-muted-foreground")} />
           ) : (
             <FolderOpen className="h-4 w-4 shrink-0" />
           )}
           <span className="truncate text-xs" data-testid="workspace-name">
             {workspaceName || t('workspace.selectWorkspace', 'Select Workspace')}
           </span>
-          {teamMode && workspaceName && (
-            <span className={cn(
-              "shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded flex items-center gap-1",
-              p2pConnected
-                ? "text-green-600 dark:text-green-400 bg-green-500/10"
-                : "text-amber-600 dark:text-amber-400 bg-amber-500/10"
-            )}>
-              <span className={cn("h-1.5 w-1.5 rounded-full", p2pConnected ? "bg-green-500" : "bg-amber-500")} />
-              {t('sidebar.teamTag', 'Team')}
-            </span>
-          )}
         </Button>
       </TooltipTrigger>
       <TooltipContent side="top">

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -206,7 +206,10 @@ export function TeamP2PConfig() {
     try {
       const status = await tauriInvoke<typeof syncStatus>('p2p_sync_status')
       setSyncStatus(status)
-      useTeamModeStore.setState({ myRole: (status?.role as 'owner' | 'editor' | 'viewer') ?? null })
+      useTeamModeStore.setState({
+        myRole: (status?.role as 'owner' | 'editor' | 'viewer') ?? null,
+        p2pConnected: status?.connected ?? false,
+      })
     } catch {
       // may not be available
     }

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -267,6 +267,44 @@ export function useGitReposInit() {
 // Cron session IDs (for sidebar filtering)
 // ─────────────────────────────────────────────────────────────────────────────
 
+// ─────────────────────────────────────────────────────────────────────────────
+// P2P auto-reconnect (team mode)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function useP2pAutoReconnect() {
+  const workspacePath = useWorkspaceStore((s) => s.workspacePath);
+  const openCodeReady = useWorkspaceStore((s) => s.openCodeReady);
+
+  useEffect(() => {
+    if (!workspacePath || !openCodeReady || !isTauri()) return;
+
+    // Delay P2P reconnect so it doesn't compete with app startup
+    const timer = setTimeout(async () => {
+      try {
+        const { useTeamModeStore } = await import("@/stores/team-mode");
+        if (!useTeamModeStore.getState().teamMode) return;
+
+        const { invoke } = await import("@tauri-apps/api/core");
+        await invoke("p2p_reconnect");
+
+        // Update connection status
+        const status = await invoke<{ connected?: boolean; role?: string }>("p2p_sync_status").catch(() => null);
+        if (status) {
+          useTeamModeStore.setState({
+            p2pConnected: status.connected ?? false,
+            myRole: (status.role as 'owner' | 'editor' | 'viewer') ?? null,
+          });
+        }
+        console.log("[P2P] Auto-reconnect completed");
+      } catch (err) {
+        console.warn("[P2P] Auto-reconnect failed (non-critical):", err);
+      }
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [workspacePath, openCodeReady]);
+}
+
 export function useCronInit() {
   const workspacePath = useWorkspaceStore((s) => s.workspacePath);
   const openCodeReady = useWorkspaceStore((s) => s.openCodeReady);

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -24,6 +24,7 @@ interface TeamModeState {
   _appliedConfigKey: string | null // fingerprint of last applied config to avoid redundant apply
   devUnlocked: boolean // hidden dev mode: unlocks model selector & hidden dirs in team mode
   myRole: 'owner' | 'editor' | 'viewer' | null
+  p2pConnected: boolean
 
   loadTeamConfig: (workspacePath: string) => Promise<void>
   applyTeamModelToOpenCode: (workspacePath: string) => Promise<void>
@@ -62,6 +63,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   _appliedConfigKey: null,
   devUnlocked: false,
   myRole: null,
+  p2pConnected: false,
   teamApiKey: (() => {
     try {
       return localStorage.getItem(TEAM_API_KEY_STORAGE) || null
@@ -72,23 +74,28 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
 
   loadTeamConfig: async (_workspacePath: string) => {
     const status = await fetchTeamStatus()
-    if (status?.active && status.llm) {
-      const config: TeamModelConfig = {
-        baseUrl: status.llm.baseUrl,
-        model: status.llm.model,
-        modelName: status.llm.modelName || status.llm.model,
+    if (status?.active) {
+      set({ teamMode: true })
+      if (status.llm) {
+        const config: TeamModelConfig = {
+          baseUrl: status.llm.baseUrl,
+          model: status.llm.model,
+          modelName: status.llm.modelName || status.llm.model,
+        }
+        set({ teamModelConfig: config })
       }
-      set({ teamModelConfig: config })
     } else {
-      set({ teamModelConfig: null })
+      set({ teamMode: false, teamModelConfig: null })
     }
 
     // Team mode is determined by P2P sync status
-    // Load user's role (non-critical)
+    // Load user's role and P2P connection status (non-critical)
     try {
       const { invoke } = await import('@tauri-apps/api/core')
       const role = await invoke<string | null>('unified_team_get_my_role')
       set({ myRole: role as any })
+      const syncStatus = await invoke<{ connected?: boolean }>('p2p_sync_status').catch(() => null)
+      set({ p2pConnected: syncStatus?.connected ?? false })
     } catch {
       // Non-critical, role can be loaded later
     }

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -24,6 +24,7 @@ interface TeamModeState {
   _appliedConfigKey: string | null // fingerprint of last applied config to avoid redundant apply
   devUnlocked: boolean // hidden dev mode: unlocks model selector & hidden dirs in team mode
   myRole: 'owner' | 'editor' | 'viewer' | null
+  p2pConnected: boolean
 
   loadTeamConfig: (workspacePath: string) => Promise<void>
   applyTeamModelToOpenCode: (workspacePath: string) => Promise<void>
@@ -62,6 +63,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   _appliedConfigKey: null,
   devUnlocked: false,
   myRole: null,
+  p2pConnected: false,
   teamApiKey: (() => {
     try {
       return localStorage.getItem(TEAM_API_KEY_STORAGE) || null
@@ -84,11 +86,13 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
     }
 
     // Team mode is determined by P2P sync status
-    // Load user's role (non-critical)
+    // Load user's role and P2P connection status (non-critical)
     try {
       const { invoke } = await import('@tauri-apps/api/core')
       const role = await invoke<string | null>('unified_team_get_my_role')
       set({ myRole: role as any })
+      const syncStatus = await invoke<{ connected?: boolean }>('p2p_sync_status').catch(() => null)
+      set({ p2pConnected: syncStatus?.connected ?? false })
     } catch {
       // Non-critical, role can be loaded later
     }

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -284,6 +284,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         _appliedConfigKey: null,
         myRole: null,
       });
+      // Load team config immediately so sidebar shows team tag on startup
+      useTeamModeStore.getState().loadTeamConfig(expandedPath).catch(() => {});
     } catch { /* ignore */ }
 
     // Persist workspace path for auto-restore on next launch

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -535,6 +535,7 @@ fn sync_team_mcp_configs_from_dir(
 }
 
 /// Scan .mcp/*.json from the workspace and merge into opencode.json (legacy: when team repo was at workspace root).
+#[allow(dead_code)]
 pub fn sync_team_mcp_configs(workspace_path: &str) -> Result<usize, String> {
     sync_team_mcp_configs_from_dir(workspace_path, workspace_path)
 }

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -1774,20 +1774,41 @@ pub async fn p2p_reconnect(
         return Ok(());
     }
 
-    // Always re-import from saved ticket to register for network sync.
+    let my_node_id = get_node_id(node);
+    let is_owner = config
+        .owner_node_id
+        .as_deref()
+        .map_or(false, |owner| owner == my_node_id);
+
+    // Re-import from saved ticket to register for network sync.
     // docs.open() only loads locally and does NOT accept incoming sync requests.
-    let doc = if let Some(ref ticket_str) = config.doc_ticket {
-        eprintln!("[P2P] Reconnecting via ticket import");
-        let ticket = ticket_str
-            .trim()
-            .parse::<iroh_docs::DocTicket>()
-            .map_err(|_| "Invalid saved ticket".to_string())?;
-        node.docs
-            .import(ticket)
-            .await
-            .map_err(|e| format!("Failed to import doc: {}", e))?
+    // However, if we are the owner the ticket contains our own address — importing
+    // it would make iroh attempt to connect to ourselves. In that case fall back to
+    // docs.open() which is sufficient because joiners will connect to us via their
+    // copy of the ticket.
+    let doc = if !is_owner {
+        if let Some(ref ticket_str) = config.doc_ticket {
+            eprintln!("[P2P] Reconnecting via ticket import");
+            let ticket = ticket_str
+                .trim()
+                .parse::<iroh_docs::DocTicket>()
+                .map_err(|_| "Invalid saved ticket".to_string())?;
+            node.docs
+                .import(ticket)
+                .await
+                .map_err(|e| format!("Failed to import doc: {}", e))?
+        } else {
+            let namespace_id = namespace_id_str
+                .parse::<iroh_docs::NamespaceId>()
+                .map_err(|e| format!("Invalid namespace ID: {}", e))?;
+            node.docs
+                .open(namespace_id)
+                .await
+                .map_err(|e| format!("Failed to open doc: {}", e))?
+                .ok_or("Team document not found")?
+        }
     } else {
-        // Fallback: try opening from local storage (won't accept remote sync)
+        eprintln!("[P2P] Owner reconnect — opening doc locally (skip self-connect)");
         let namespace_id = namespace_id_str
             .parse::<iroh_docs::NamespaceId>()
             .map_err(|e| format!("Invalid namespace ID: {}", e))?;
@@ -1801,7 +1822,6 @@ pub async fn p2p_reconnect(
     // Start background sync
     let team_dir = format!("{}/teamclaw-team", workspace_path);
     let my_role = config.role.clone().unwrap_or(MemberRole::Editor);
-    let my_node_id = get_node_id(node);
     start_sync_tasks(
         &doc,
         node.author,

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -381,8 +381,7 @@ pub async fn join_team_drive(
     .await
     .map_err(|e| format!("Failed to write author meta: {}", e))?;
 
-    // Sync MCP configs
-    let _ = crate::commands::team::sync_team_mcp_configs(workspace_path);
+    // MCP configs are auto-discovered via hot reload from teamclaw-team/.mcp/
 
     let namespace_id = doc.id().to_string();
 
@@ -987,7 +986,11 @@ async fn disk_to_doc_watcher(
                             let key = rel_path;
                             if let Ok(content) = std::fs::read(path) {
                                 // Iroh rejects empty blobs; use a single newline as placeholder
-                                let content = if content.is_empty() { vec![b'\n'] } else { content };
+                                let content = if content.is_empty() {
+                                    vec![b'\n']
+                                } else {
+                                    content
+                                };
                                 if let Err(e) = doc.set_bytes(author, key.clone(), content).await {
                                     eprintln!("[P2P] Failed to sync local change '{}': {}", key, e);
                                 }
@@ -1090,6 +1093,33 @@ pub struct P2pConfig {
     pub seed_url: Option<String>,
     #[serde(default)]
     pub team_secret: Option<String>,
+}
+
+/// Clear the p2p field from .teamclaw/teamclaw.json and remove teamclaw-team/ directory.
+/// Preserves iroh keys, llm config, and other fields in teamclaw.json.
+fn clear_p2p_and_team_dir(workspace_path: &str) -> Result<(), String> {
+    let config_path = Path::new(workspace_path)
+        .join(crate::commands::TEAMCLAW_DIR)
+        .join("teamclaw.json");
+    if config_path.exists() {
+        let content = std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("Failed to read teamclaw.json: {}", e))?;
+        if let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Some(obj) = json.as_object_mut() {
+                obj.remove("p2p");
+            }
+            std::fs::write(&config_path, serde_json::to_string_pretty(&json).unwrap())
+                .map_err(|e| format!("Failed to write teamclaw.json: {}", e))?;
+        }
+    }
+
+    let team_dir = format!("{}/teamclaw-team", workspace_path);
+    if Path::new(&team_dir).exists() {
+        std::fs::remove_dir_all(&team_dir)
+            .map_err(|e| format!("Failed to remove team directory: {}", e))?;
+    }
+
+    Ok(())
 }
 
 /// Read P2P config from teamclaw.json in the workspace.
@@ -1241,17 +1271,7 @@ pub async fn p2p_leave_team(
     }
     drop(guard);
 
-    // Remove local team data
-    let teamclaw_dir = format!("{}/{}", workspace_path, crate::commands::TEAMCLAW_DIR);
-    if Path::new(&teamclaw_dir).exists() {
-        std::fs::remove_dir_all(&teamclaw_dir)
-            .map_err(|e| format!("Failed to remove .teamclaw directory: {}", e))?;
-    }
-    let team_dir = format!("{}/teamclaw-team", workspace_path);
-    if Path::new(&team_dir).exists() {
-        std::fs::remove_dir_all(&team_dir)
-            .map_err(|e| format!("Failed to remove team directory: {}", e))?;
-    }
+    clear_p2p_and_team_dir(&workspace_path)?;
 
     Ok(())
 }
@@ -1295,19 +1315,7 @@ pub async fn p2p_disconnect_source(
     }
     drop(guard);
 
-    // Remove .teamclaw directory (contains teamclaw.json, iroh data, etc.)
-    let teamclaw_dir = format!("{}/{}", workspace_path, crate::commands::TEAMCLAW_DIR);
-    if Path::new(&teamclaw_dir).exists() {
-        std::fs::remove_dir_all(&teamclaw_dir)
-            .map_err(|e| format!("Failed to remove .teamclaw directory: {}", e))?;
-    }
-
-    // Remove teamclaw-team directory
-    let team_dir = format!("{}/teamclaw-team", workspace_path);
-    if Path::new(&team_dir).exists() {
-        std::fs::remove_dir_all(&team_dir)
-            .map_err(|e| format!("Failed to remove team directory: {}", e))?;
-    }
+    clear_p2p_and_team_dir(&workspace_path)?;
 
     Ok(())
 }
@@ -1352,17 +1360,7 @@ pub async fn p2p_dissolve_team(
     }
     drop(guard);
 
-    // Clean up local data
-    let teamclaw_dir = format!("{}/{}", workspace_path, crate::commands::TEAMCLAW_DIR);
-    if Path::new(&teamclaw_dir).exists() {
-        std::fs::remove_dir_all(&teamclaw_dir)
-            .map_err(|e| format!("Failed to remove .teamclaw directory: {}", e))?;
-    }
-    let team_dir = format!("{}/teamclaw-team", workspace_path);
-    if Path::new(&team_dir).exists() {
-        std::fs::remove_dir_all(&team_dir)
-            .map_err(|e| format!("Failed to remove team directory: {}", e))?;
-    }
+    clear_p2p_and_team_dir(&workspace_path)?;
 
     Ok(())
 }

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -140,7 +140,12 @@ pub async fn unified_team_add_member(
             let node = guard.as_mut().ok_or("P2P node not running")?;
             let caller_node_id = super::team_p2p::get_node_id(node);
             let team_dir = format!("{}/teamclaw-team", workspace_path);
-            super::team_p2p::add_member_to_team(&workspace_path, &team_dir, &caller_node_id, member)?;
+            super::team_p2p::add_member_to_team(
+                &workspace_path,
+                &team_dir,
+                &caller_node_id,
+                member,
+            )?;
             // Push updated members.json to Iroh doc immediately (don't rely on fs watcher)
             if let Some(ref doc) = node.active_doc {
                 let manifest_path = format!("{}/{}", team_dir, "_team/members.json");


### PR DESCRIPTION
## Summary
- Show team P2P connection status in sidebar via icon color: folder (non-team), gray people (disconnected), blue people (connected)
- Auto-reconnect P2P 3 seconds after openCode ready when in team mode
- Load team config on workspace open so sidebar reflects team state immediately
- Fix owner self-connect error by using `docs.open()` instead of re-importing own ticket
- Fix leave/disconnect cleanup and remove MCP sync on join

## Test plan
- [ ] Open workspace with team config → sidebar shows gray people icon
- [ ] P2P connects → icon turns blue
- [ ] Non-team workspace → shows folder icon
- [ ] Owner reconnect → no "Connecting to ourself" error in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)