### PR TITLE
feat(ui): optimize team management UI and fix toolbar overflow

### DIFF
--- a/packages/app/src/components/editors/TiptapMarkdownEditor.tsx
+++ b/packages/app/src/components/editors/TiptapMarkdownEditor.tsx
@@ -293,17 +293,21 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
     // Toggle between WYSIWYG and raw source mode
     const handleToggleRaw = useCallback(async () => {
       if (!editor) return;
-      if (!rawMode) {
-        // WYSIWYG → raw: extract current markdown
-        const md = unresolveMarkdownImages(editor.getMarkdown(), filePath);
-        setRawContent(md);
-        setRawMode(true);
-      } else {
-        // raw → WYSIWYG: push raw content back into editor
-        const resolved = await resolveMarkdownImages(rawContent, filePath);
-        editor.commands.setContent(resolved, { contentType: "markdown" });
-        previousContentRef.current = rawContent;
-        setRawMode(false);
+      try {
+        if (!rawMode) {
+          // WYSIWYG → raw: extract current markdown
+          const md = unresolveMarkdownImages(editor.getMarkdown(), filePath);
+          setRawContent(md);
+          setRawMode(true);
+        } else {
+          // raw → WYSIWYG: push raw content back into editor
+          const resolved = await resolveMarkdownImages(rawContent, filePath);
+          editor.commands.setContent(resolved, { contentType: "markdown" });
+          previousContentRef.current = rawContent;
+          setRawMode(false);
+        }
+      } catch (err) {
+        console.error("[TiptapMarkdownEditor] toggleRaw failed:", err);
       }
     }, [editor, rawMode, rawContent, filePath]);
 

--- a/packages/app/src/components/editors/TiptapToolbar.tsx
+++ b/packages/app/src/components/editors/TiptapToolbar.tsx
@@ -64,23 +64,19 @@ export function TiptapToolbar({
   rawMode = false,
   onToggleRaw,
 }: TiptapToolbarProps) {
-  const sourceToggle = onToggleRaw && (
-    <>
-      <div className="flex-1" />
-      <Separator orientation="vertical" className="h-6 mx-1" />
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={onToggleRaw}
-        className={cn('h-8 w-8', rawMode && 'bg-accent')}
-        title={rawMode ? 'Visual mode' : 'Source mode'}
-      >
-        <FileCode className="h-4 w-4" />
-      </Button>
-    </>
+  const sourceToggleButton = onToggleRaw && (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      onClick={onToggleRaw}
+      className={cn('h-8 w-8 shrink-0', rawMode && 'bg-accent')}
+      title={rawMode ? 'Visual mode' : 'Source mode'}
+    >
+      <FileCode className="h-4 w-4" />
+    </Button>
   );
 
-  const containerClass = cn(
+  const outerClass = cn(
     'flex items-center gap-1 p-2 border-b',
     isDark ? 'bg-[#1e1e1e] border-border' : 'bg-white border-border',
   );
@@ -88,8 +84,14 @@ export function TiptapToolbar({
   // In raw mode, show minimal toolbar with just the source toggle
   if (rawMode) {
     return (
-      <div className={containerClass}>
-        {sourceToggle}
+      <div className={outerClass}>
+        <div className="flex-1" />
+        {sourceToggleButton && (
+          <>
+            <Separator orientation="vertical" className="h-6 mx-1 shrink-0" />
+            {sourceToggleButton}
+          </>
+        )}
       </div>
     );
   }
@@ -99,14 +101,16 @@ export function TiptapToolbar({
   }
 
   return (
-    <div className={containerClass}>
+    <div className={outerClass}>
+      {/* Scrollable toolbar buttons */}
+      <div className="flex items-center gap-1 overflow-x-auto min-w-0 flex-1">
       {/* Undo/Redo */}
       <Button
         variant="ghost"
         size="icon-sm"
         onClick={() => editor.chain().focus().undo().run()}
         disabled={!editor.can().undo()}
-        className="h-8 w-8"
+        className="h-8 w-8 shrink-0"
       >
         <Undo2 className="h-4 w-4" />
       </Button>
@@ -115,12 +119,12 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().redo().run()}
         disabled={!editor.can().redo()}
-        className="h-8 w-8"
+        className="h-8 w-8 shrink-0"
       >
         <Redo2 className="h-4 w-4" />
       </Button>
 
-      <Separator orientation="vertical" className="h-6 mx-1" />
+      <Separator orientation="vertical" className="h-6 mx-1 shrink-0" />
 
       {/* Heading Dropdown */}
       <DropdownMenu>
@@ -185,7 +189,7 @@ export function TiptapToolbar({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <Separator orientation="vertical" className="h-6 mx-1" />
+      <Separator orientation="vertical" className="h-6 mx-1 shrink-0" />
 
       {/* Lists */}
       <Button
@@ -193,7 +197,7 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().toggleBulletList().run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('bulletList') && 'bg-accent',
         )}
       >
@@ -204,7 +208,7 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('orderedList') && 'bg-accent',
         )}
       >
@@ -215,14 +219,14 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().toggleTaskList().run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('taskList') && 'bg-accent',
         )}
       >
         <CheckSquare className="h-4 w-4" />
       </Button>
 
-      <Separator orientation="vertical" className="h-6 mx-1" />
+      <Separator orientation="vertical" className="h-6 mx-1 shrink-0" />
 
       {/* Formatting */}
       <Button
@@ -230,7 +234,7 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().toggleBold().run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('bold') && 'bg-accent',
         )}
       >
@@ -241,7 +245,7 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().toggleItalic().run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('italic') && 'bg-accent',
         )}
       >
@@ -252,7 +256,7 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().toggleStrike().run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('strike') && 'bg-accent',
         )}
       >
@@ -263,14 +267,14 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().toggleUnderline().run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('underline') && 'bg-accent',
         )}
       >
         <Underline className="h-4 w-4" />
       </Button>
 
-      <Separator orientation="vertical" className="h-6 mx-1" />
+      <Separator orientation="vertical" className="h-6 mx-1 shrink-0" />
 
       {/* Code */}
       <Button
@@ -278,7 +282,7 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().toggleCode().run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('code') && 'bg-accent',
         )}
       >
@@ -289,14 +293,14 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().toggleCodeBlock().run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('codeBlock') && 'bg-accent',
         )}
       >
         <Code2 className="h-4 w-4" />
       </Button>
 
-      <Separator orientation="vertical" className="h-6 mx-1" />
+      <Separator orientation="vertical" className="h-6 mx-1 shrink-0" />
 
       {/* Link */}
       <Button
@@ -309,14 +313,14 @@ export function TiptapToolbar({
           }
         }}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('link') && 'bg-accent',
         )}
       >
         <Link className="h-4 w-4" />
       </Button>
 
-      <Separator orientation="vertical" className="h-6 mx-1" />
+      <Separator orientation="vertical" className="h-6 mx-1 shrink-0" />
 
       {/* Text Alignment */}
       <Button
@@ -324,7 +328,7 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().setTextAlign('left').run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive({ textAlign: 'left' }) && 'bg-accent',
         )}
       >
@@ -335,7 +339,7 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().setTextAlign('center').run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive({ textAlign: 'center' }) && 'bg-accent',
         )}
       >
@@ -346,7 +350,7 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().setTextAlign('right').run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive({ textAlign: 'right' }) && 'bg-accent',
         )}
       >
@@ -357,14 +361,14 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().setTextAlign('justify').run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive({ textAlign: 'justify' }) && 'bg-accent',
         )}
       >
         <AlignJustify className="h-4 w-4" />
       </Button>
 
-      <Separator orientation="vertical" className="h-6 mx-1" />
+      <Separator orientation="vertical" className="h-6 mx-1 shrink-0" />
 
       {/* Blockquote */}
       <Button
@@ -372,7 +376,7 @@ export function TiptapToolbar({
         size="icon-sm"
         onClick={() => editor.chain().focus().toggleBlockquote().run()}
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('blockquote') && 'bg-accent',
         )}
       >
@@ -391,7 +395,7 @@ export function TiptapToolbar({
             .run()
         }
         className={cn(
-          'h-8 w-8',
+          'h-8 w-8 shrink-0',
           editor.isActive('table') && 'bg-accent',
         )}
       >
@@ -401,20 +405,26 @@ export function TiptapToolbar({
       {/* Image Upload */}
       {onImageUpload && (
         <>
-          <Separator orientation="vertical" className="h-6 mx-1" />
+          <Separator orientation="vertical" className="h-6 mx-1 shrink-0" />
           <Button
             variant="ghost"
             size="icon-sm"
             onClick={onImageUpload}
-            className="h-8 w-8"
+            className="h-8 w-8 shrink-0"
           >
             <Image className="h-4 w-4" />
           </Button>
         </>
       )}
 
-      {/* Source mode toggle - pushed to right */}
-      {sourceToggle}
+      </div>
+      {/* Source mode toggle - always visible at right edge */}
+      {sourceToggleButton && (
+        <>
+          <Separator orientation="vertical" className="h-6 mx-1 shrink-0" />
+          {sourceToggleButton}
+        </>
+      )}
     </div>
   );
 }

--- a/packages/app/src/components/settings/AddMemberInput.tsx
+++ b/packages/app/src/components/settings/AddMemberInput.tsx
@@ -33,49 +33,48 @@ export function AddMemberInput({
   }
 
   return (
-    <div className="space-y-2">
-      <div className="flex gap-2">
-        <div className="flex-1 flex flex-col gap-1.5">
-          <Input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Member name (e.g. Alice)"
-            className="h-9 text-sm"
-          />
-          <Input
-            value={nodeId}
-            onChange={(e) => setNodeId(e.target.value)}
-            placeholder="Paste member's Device ID"
-            className="h-9 font-mono text-xs"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && nodeId.trim()) handleSubmit()
-            }}
-          />
-          <Input
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-            placeholder="Label / Remark (optional)"
-            className="h-9 text-sm"
-          />
-          <Select value={role} onValueChange={(v) => setRole(v as 'editor' | 'viewer')}>
-            <SelectTrigger className="h-9">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="editor">Editor</SelectItem>
-              <SelectItem value="viewer">Viewer</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <Button
-          onClick={handleSubmit}
-          disabled={!nodeId.trim()}
-          size="sm"
-          className="shrink-0 gap-1 self-end"
-        >
-          <UserPlus className="h-4 w-4" />
-          Add
-        </Button>
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <label className="text-xs font-medium text-muted-foreground">Name</label>
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Alice"
+          className="h-9 text-sm"
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="text-xs font-medium text-muted-foreground">Device ID</label>
+        <Input
+          value={nodeId}
+          onChange={(e) => setNodeId(e.target.value)}
+          placeholder="Paste member's Device ID"
+          className="h-9 font-mono text-xs"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && nodeId.trim()) handleSubmit()
+          }}
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="text-xs font-medium text-muted-foreground">Label / Remark (optional)</label>
+        <Input
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="e.g. Backend team"
+          className="h-9 text-sm"
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="text-xs font-medium text-muted-foreground">Role</label>
+        <Select value={role} onValueChange={(v) => setRole(v as 'editor' | 'viewer')}>
+          <SelectTrigger className="h-9">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="editor">Editor</SelectItem>
+            <SelectItem value="viewer">Viewer</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
       {error && (
         <p className="text-xs text-destructive flex items-center gap-1">
@@ -83,6 +82,14 @@ export function AddMemberInput({
           {error}
         </p>
       )}
+      <Button
+        onClick={handleSubmit}
+        disabled={!nodeId.trim()}
+        className="w-full gap-2"
+      >
+        <UserPlus className="h-4 w-4" />
+        Add Member
+      </Button>
     </div>
   )
 }

--- a/packages/app/src/components/settings/TeamMemberList.tsx
+++ b/packages/app/src/components/settings/TeamMemberList.tsx
@@ -1,6 +1,12 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { UserMinus, Shield, Pencil, Eye, UserPlus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { useTeamMembersStore } from '../../stores/team-members'
 import { AddMemberInput } from './AddMemberInput'
 
@@ -48,6 +54,8 @@ export function TeamMemberList() {
     canManageMembers,
   } = useTeamMembersStore()
 
+  const [showAddDialog, setShowAddDialog] = useState(false)
+
   useEffect(() => {
     loadMembers()
     loadMyRole()
@@ -66,6 +74,7 @@ export function TeamMemberList() {
       hostname: '',
       addedAt: new Date().toISOString(),
     })
+    setShowAddDialog(false)
   }
 
   return (
@@ -143,14 +152,31 @@ export function TeamMemberList() {
           )
         })}
       </div>
+
+      {/* Add Member Modal */}
       {isManager && (
-        <div className="pt-2 border-t border-border">
-          <div className="flex items-center gap-1.5 mb-2">
-            <UserPlus className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium">Add Member</span>
-          </div>
-          <AddMemberInput onAdd={handleAdd} error={error} />
-        </div>
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={() => setShowAddDialog(true)}
+          >
+            <UserPlus className="h-4 w-4" />
+            Add Member
+          </Button>
+          <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
+            <DialogContent className="sm:max-w-[460px]">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <UserPlus className="h-5 w-5" />
+                  Add Member
+                </DialogTitle>
+              </DialogHeader>
+              <AddMemberInput onAdd={handleAdd} error={error} />
+            </DialogContent>
+          </Dialog>
+        </>
       )}
     </div>
   )

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -625,17 +625,14 @@ export function TeamP2PConfig() {
                     </p>
                   </div>
                 </div>
-                {isOwner ? (
-                  <Button variant="outline" size="sm" className="gap-1 text-destructive hover:text-destructive" onClick={handleP2pDisconnect} disabled={leaveLoading}>
-                    <Unlink className="h-3 w-3" />
-                    {t('settings.team.disconnect', 'Disconnect')}
-                  </Button>
-                ) : (
-                  <Button variant="outline" size="sm" className="gap-1 text-destructive hover:text-destructive" onClick={() => setConfirmLeave(true)} disabled={leaveLoading}>
-                    {leaveLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : <Unlink className="h-3 w-3" />}
-                    {t('settings.team.leaveTeam', 'Leave Team')}
-                  </Button>
-                )}
+                <Button variant="outline" size="sm" className="gap-1" onClick={() => {
+                  if (workspacePath) {
+                    loadSyncStatus()
+                  }
+                }}>
+                  <RefreshCw className="h-3 w-3" />
+                  {t('common.refresh', 'Refresh')}
+                </Button>
               </div>
             </div>
           </SettingCard>
@@ -853,25 +850,69 @@ export function TeamP2PConfig() {
             </div>
           </SettingCard>
 
-          {/* Dissolve Team (Owner only) */}
-          {isOwner && (
-            <SettingCard className="border-red-200 dark:border-red-800">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium text-red-700 dark:text-red-300">{t('settings.team.dissolveTeam', 'Dissolve Team')}</p>
-                  <p className="text-xs text-muted-foreground">{t('settings.team.dissolveTeamDesc', 'Permanently dissolve this team. All members will be disconnected.')}</p>
+          {/* Danger Zone */}
+          <SettingCard className="border-red-200 dark:border-red-800">
+            <div className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-wider text-red-600 dark:text-red-400">
+                {t('settings.team.dangerZone', 'Danger Zone')}
+              </p>
+              {isOwner ? (
+                <>
+                  {/* Disconnect */}
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-medium">{t('settings.team.disconnect', 'Disconnect')}</p>
+                      <p className="text-xs text-muted-foreground">{t('settings.team.disconnectDesc', 'This will delete local team data (.teamclaw and teamclaw-team directories). This action cannot be undone.')}</p>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="shrink-0 gap-1 text-destructive hover:text-destructive border-destructive/30"
+                      onClick={handleP2pDisconnect}
+                    >
+                      <Unlink className="h-3.5 w-3.5" />
+                      {t('settings.team.disconnect', 'Disconnect')}
+                    </Button>
+                  </div>
+                  <div className="border-t border-red-200 dark:border-red-800" />
+                  {/* Dissolve Team */}
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-red-700 dark:text-red-300">{t('settings.team.dissolveTeam', 'Dissolve Team')}</p>
+                      <p className="text-xs text-muted-foreground">{t('settings.team.dissolveTeamDesc', 'Permanently dissolve this team. All members will be disconnected.')}</p>
+                    </div>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      className="shrink-0"
+                      disabled={dissolveLoading}
+                      onClick={() => setConfirmDissolve(true)}
+                    >
+                      {dissolveLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : t('settings.team.dissolveTeam', 'Dissolve Team')}
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                /* Leave Team (non-owner) */
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium">{t('settings.team.leaveTeam', 'Leave Team')}</p>
+                    <p className="text-xs text-muted-foreground">{t('settings.team.leaveDesc', 'Leave this team and remove local team data.')}</p>
+                  </div>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    className="shrink-0 gap-1"
+                    disabled={leaveLoading}
+                    onClick={() => setConfirmLeave(true)}
+                  >
+                    {leaveLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Unlink className="h-3.5 w-3.5" />}
+                    {t('settings.team.leaveTeam', 'Leave Team')}
+                  </Button>
                 </div>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  disabled={dissolveLoading}
-                  onClick={() => setConfirmDissolve(true)}
-                >
-                  {dissolveLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : t('settings.team.dissolveTeam', 'Dissolve Team')}
-                </Button>
-              </div>
-            </SettingCard>
-          )}
+              )}
+            </div>
+          </SettingCard>
 
           {/* API Key Override */}
           <TeamApiKeyCard />


### PR DESCRIPTION
## Summary
- **Add Member**: inline form → modal dialog with labeled fields and full-width submit button
- **Danger Zone**: disconnect/dissolve/leave actions consolidated into a single card (owner sees disconnect + dissolve, non-owner sees leave), all with confirmation dialogs
- **Status card**: replaced disconnect button with refresh button
- **Markdown toolbar**: source toggle (FileCode) button fixed at right edge, other buttons scrollable via `overflow-x: auto` to prevent overflow hiding the toggle
- **Error handling**: `handleToggleRaw` wrapped in try-catch to surface silent async failures

## Test plan
- [ ] Open team settings, verify Add Member opens a modal dialog
- [ ] Verify Danger Zone card shows Disconnect + Dissolve for owner, Leave for non-owner
- [ ] Confirm all destructive actions still have confirmation dialogs
- [ ] Open a .md file, verify the source toggle button (FileCode icon) is visible at the toolbar right edge
- [ ] Click source toggle, verify it switches to raw markdown textarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)