### PR TITLE
fix(ui): remove Team tag badge from sidebar

### DIFF
--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -296,17 +296,6 @@ function WorkspaceSelectorButton() {
           <span className="truncate text-xs" data-testid="workspace-name">
             {workspaceName || t('workspace.selectWorkspace', 'Select Workspace')}
           </span>
-          {teamMode && workspaceName && (
-            <span className={cn(
-              "shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded flex items-center gap-1",
-              p2pConnected
-                ? "text-green-600 dark:text-green-400 bg-green-500/10"
-                : "text-amber-600 dark:text-amber-400 bg-amber-500/10"
-            )}>
-              <span className={cn("h-1.5 w-1.5 rounded-full", p2pConnected ? "bg-green-500" : "bg-amber-500")} />
-              {t('sidebar.teamTag', 'Team')}
-            </span>
-          )}
         </Button>
       </TooltipTrigger>
       <TooltipContent side="top">


### PR DESCRIPTION
## Summary
- Remove the green/amber "Team" badge from the sidebar workspace selector
- Team status is now indicated solely by the Users icon color: blue (P2P connected) / gray (disconnected)
- Simplifies the sidebar UI per updated design requirements

## Test plan
- [ ] Verify non-team workspace shows folder icon + name only
- [ ] Verify team workspace (P2P disconnected) shows gray Users icon + name, no badge
- [ ] Verify team workspace (P2P connected) shows blue Users icon + name, no badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)