### PR TITLE
refactor: rename oss config to s3, add forcePathStyle

### DIFF
--- a/build.config.example.json
+++ b/build.config.example.json
@@ -24,8 +24,9 @@
       "wechat": true
     }
   },
-  "oss": {
-    "fcEndpoint": "https://cloud.ucar.cc"
+  "s3": {
+    "teamEndpoint": "https://cloud.ucar.cc",
+    "forcePathStyle": false
   },
   "defaults": {
     "locale": "zh-CN",

--- a/build.config.json
+++ b/build.config.json
@@ -24,8 +24,9 @@
       "wechat": true
     }
   },
-  "oss": {
-    "fcEndpoint": "https://cloud.ucar.cc"
+  "s3": {
+    "teamEndpoint": "https://cloud.ucar.cc",
+    "forcePathStyle": false
   },
   "defaults": {
     "locale": "zh-CN",

--- a/packages/app/src/components/settings/TeamSection.tsx
+++ b/packages/app/src/components/settings/TeamSection.tsx
@@ -85,18 +85,30 @@ function SectionHeader({
 // ─── Hook: detect which sync method is active ───────────────────────────────
 
 function useActiveSyncMethod(): TeamTab | null {
+  const ossConfigured = useTeamOssStore((s) => s.configured)
   const ossConnected = useTeamOssStore((s) => s.connected)
   const [p2pConnected, setP2pConnected] = React.useState(false)
+  const [p2pConfigured, setP2pConfigured] = React.useState(false)
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
 
   React.useEffect(() => {
-    invoke<{ connected: boolean }>('p2p_sync_status')
-      .then((s) => setP2pConnected(s?.connected ?? false))
-      .catch(() => setP2pConnected(false))
+    invoke<{ connected: boolean; namespaceId?: string | null }>('p2p_sync_status')
+      .then((s) => {
+        setP2pConnected(s?.connected ?? false)
+        // P2P is configured if it has a namespace (team was created/joined)
+        setP2pConfigured(!!s?.namespaceId)
+      })
+      .catch(() => {
+        setP2pConnected(false)
+        setP2pConfigured(false)
+      })
   }, [workspacePath])
 
+  // Prefer connected state, fall back to configured state
   if (p2pConnected) return 'p2p'
   if (ossConnected) return 's3'
+  if (p2pConfigured) return 'p2p'
+  if (ossConfigured) return 's3'
   return null
 }
 
@@ -108,9 +120,7 @@ export function TeamSection() {
   const activeSyncMethod = useActiveSyncMethod()
 
   React.useEffect(() => {
-    if (activeSyncMethod) {
-      setActiveTab(activeSyncMethod)
-    }
+    setActiveTab(activeSyncMethod ?? 'p2p')
   }, [activeSyncMethod])
 
   const disabledTabs = React.useMemo(() => {

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -31,8 +31,9 @@ export interface BuildConfig {
     updater: boolean
     channels: boolean | ChannelsFeatureConfig
   }
-  oss?: {
-    fcEndpoint: string
+  s3?: {
+    teamEndpoint: string
+    forcePathStyle?: boolean
   }
   defaults: {
     locale: string

--- a/packages/app/src/stores/team-oss.ts
+++ b/packages/app/src/stores/team-oss.ts
@@ -41,7 +41,8 @@ interface TeamMember {
 interface OssTeamConfig {
   enabled: boolean
   teamId: string
-  fcEndpoint: string
+  teamEndpoint: string
+  forcePathStyle: boolean
   lastSyncAt: string | null
   pollIntervalSecs: number
 }
@@ -60,7 +61,7 @@ interface OssJoinResult {
 
 interface PendingApplication {
   teamId: string
-  fcEndpoint: string
+  teamEndpoint: string
   appliedAt: string
 }
 
@@ -163,7 +164,8 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
     try {
       const info = await invoke<OssTeamInfo>('oss_create_team', {
         ...params,
-        fcEndpoint: buildConfig.oss?.fcEndpoint ?? '',
+        teamEndpoint: buildConfig.s3?.teamEndpoint ?? '',
+        forcePathStyle: buildConfig.s3?.forcePathStyle ?? false,
         llmBaseUrl: buildConfig.team.llm.baseUrl || null,
         llmModel: buildConfig.team.llm.model || null,
         llmModelName: buildConfig.team.llm.modelName || null,
@@ -183,7 +185,8 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
     try {
       const result = await invoke<OssJoinResult>('oss_join_team', {
         ...params,
-        fcEndpoint: buildConfig.oss?.fcEndpoint ?? '',
+        teamEndpoint: buildConfig.s3?.teamEndpoint ?? '',
+        forcePathStyle: buildConfig.s3?.forcePathStyle ?? false,
         llmBaseUrl: buildConfig.team.llm.baseUrl || null,
         llmModel: buildConfig.team.llm.model || null,
         llmModelName: buildConfig.team.llm.modelName || null,
@@ -269,11 +272,12 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
     try {
       await invoke('oss_apply_team', {
         ...params,
-        fcEndpoint: buildConfig.oss?.fcEndpoint ?? '',
+        teamEndpoint: buildConfig.s3?.teamEndpoint ?? '',
+        forcePathStyle: buildConfig.s3?.forcePathStyle ?? false,
       })
       const pending: PendingApplication = {
         teamId: params.teamId,
-        fcEndpoint: buildConfig.oss?.fcEndpoint ?? '',
+        teamEndpoint: buildConfig.s3?.teamEndpoint ?? '',
         appliedAt: new Date().toISOString(),
       }
       set({ pendingApplication: pending, error: null })
@@ -305,7 +309,17 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
     const { _unlisten } = get()
     if (_unlisten) {
       _unlisten()
-      set({ _unlisten: null })
     }
+    set({
+      _unlisten: null,
+      configured: false,
+      connected: false,
+      syncing: false,
+      syncStatus: null,
+      teamInfo: null,
+      members: [],
+      error: null,
+      pendingApplication: null,
+    })
   },
 }))

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -74,7 +74,8 @@ pub async fn oss_create_team(
     team_name: String,
     owner_name: String,
     owner_email: String,
-    fc_endpoint: String,
+    team_endpoint: String,
+    force_path_style: bool,
     llm_base_url: Option<String>,
     llm_model: Option<String>,
     llm_model_name: Option<String>,
@@ -96,7 +97,8 @@ pub async fn oss_create_team(
         String::new(), // team_id not yet known
         node_id.clone(),
         team_secret.clone(),
-        fc_endpoint.clone(),
+        team_endpoint.clone(),
+        force_path_style,
         workspace_path.clone(),
         Duration::from_secs(300),
         Some(app_handle.clone()),
@@ -124,7 +126,8 @@ pub async fn oss_create_team(
         team_id.clone(),
         node_id.clone(),
         team_secret.clone(),
-        fc_endpoint.clone(),
+        team_endpoint.clone(),
+        force_path_style,
         workspace_path.clone(),
         Duration::from_secs(300),
         Some(app_handle.clone()),
@@ -181,7 +184,8 @@ pub async fn oss_create_team(
     let config = OssTeamConfig {
         enabled: true,
         team_id: team_id.clone(),
-        fc_endpoint: fc_endpoint.clone(),
+        team_endpoint: team_endpoint.clone(),
+        force_path_style,
         last_sync_at: None,
         poll_interval_secs: 300,
     };
@@ -214,7 +218,8 @@ pub async fn oss_join_team(
     workspace_path: String,
     team_id: String,
     team_secret: String,
-    fc_endpoint: String,
+    team_endpoint: String,
+    force_path_style: bool,
     llm_base_url: Option<String>,
     llm_model: Option<String>,
     llm_model_name: Option<String>,
@@ -226,7 +231,8 @@ pub async fn oss_join_team(
         team_id.clone(),
         node_id.clone(),
         team_secret.clone(),
-        fc_endpoint.clone(),
+        team_endpoint.clone(),
+        force_path_style,
         workspace_path.clone(),
         Duration::from_secs(300),
         Some(app_handle.clone()),
@@ -290,7 +296,8 @@ pub async fn oss_join_team(
     let config = OssTeamConfig {
         enabled: true,
         team_id: team_id.clone(),
-        fc_endpoint: fc_endpoint.clone(),
+        team_endpoint: team_endpoint.clone(),
+        force_path_style,
         last_sync_at: None,
         poll_interval_secs: 300,
     };
@@ -331,7 +338,7 @@ pub async fn oss_restore_sync(
     let team_secret = load_team_secret(&team_id)?;
     let node_id = get_p2p_node_id(&iroh_state).await?;
 
-    // Read existing config for fc_endpoint and poll_interval
+    // Read existing config for team_endpoint and poll_interval
     let config = read_oss_config(&workspace_path)
         .ok_or_else(|| "No OSS config found in teamclaw.json".to_string())?;
 
@@ -339,7 +346,8 @@ pub async fn oss_restore_sync(
         team_id.clone(),
         node_id.clone(),
         team_secret.clone(),
-        config.fc_endpoint.clone(),
+        config.team_endpoint.clone(),
+        config.force_path_style,
         workspace_path.clone(),
         Duration::from_secs(config.poll_interval_secs),
         Some(app_handle.clone()),
@@ -584,7 +592,8 @@ pub async fn oss_apply_team(
     workspace_path: String,
     team_id: String,
     team_secret: String,
-    fc_endpoint: String,
+    team_endpoint: String,
+    #[allow(unused)] force_path_style: bool,
     name: String,
     email: String,
     note: String,
@@ -610,7 +619,7 @@ pub async fn oss_apply_team(
         "hostname": hostname,
     });
 
-    let url = format!("{}/apply", fc_endpoint);
+    let url = format!("{}/apply", team_endpoint);
     let response = client
         .post(&url)
         .json(&body)
@@ -629,7 +638,7 @@ pub async fn oss_apply_team(
     // Save pending application state locally
     let pending = PendingApplication {
         team_id: team_id.clone(),
-        fc_endpoint,
+        team_endpoint,
         applied_at: chrono::Utc::now().to_rfc3339(),
     };
     write_pending_application(&workspace_path, &pending)?;

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -25,7 +25,8 @@ pub struct OssSyncManager {
     s3_client: Option<aws_sdk_s3::Client>,
     credentials: Option<OssCredentials>,
     oss_config: Option<OssConfig>,
-    fc_endpoint: String,
+    team_endpoint: String,
+    force_path_style: bool,
 
     skills_doc: loro::LoroDoc,
     mcp_doc: loro::LoroDoc,
@@ -71,7 +72,8 @@ impl OssSyncManager {
         team_id: String,
         node_id: String,
         team_secret: String,
-        fc_endpoint: String,
+        team_endpoint: String,
+        force_path_style: bool,
         workspace_path: String,
         poll_interval: Duration,
         app_handle: Option<tauri::AppHandle>,
@@ -88,7 +90,8 @@ impl OssSyncManager {
             s3_client: None,
             credentials: None,
             oss_config: None,
-            fc_endpoint,
+            team_endpoint,
+            force_path_style,
             skills_doc: loro::LoroDoc::new(),
             mcp_doc: loro::LoroDoc::new(),
             knowledge_doc: loro::LoroDoc::new(),
@@ -126,7 +129,7 @@ impl OssSyncManager {
     }
 
     pub fn set_credentials(&mut self, creds: OssCredentials, oss: OssConfig) {
-        self.s3_client = Some(Self::create_s3_client(&creds, &oss));
+        self.s3_client = Some(Self::create_s3_client(&creds, &oss, self.force_path_style));
         self.credentials = Some(creds);
         self.oss_config = Some(oss);
         self.connected = true;
@@ -148,7 +151,7 @@ impl OssSyncManager {
     // S3 Client
     // -----------------------------------------------------------------------
 
-    fn create_s3_client(creds: &OssCredentials, config: &OssConfig) -> aws_sdk_s3::Client {
+    fn create_s3_client(creds: &OssCredentials, config: &OssConfig, force_path_style: bool) -> aws_sdk_s3::Client {
         let credentials = aws_sdk_s3::config::Credentials::new(
             &creds.access_key_id,
             &creds.access_key_secret,
@@ -162,7 +165,7 @@ impl OssSyncManager {
             .endpoint_url(&config.endpoint)
             .region(aws_sdk_s3::config::Region::new(config.region.clone()))
             .credentials_provider(credentials)
-            .force_path_style(false)
+            .force_path_style(force_path_style)
             .build();
 
         aws_sdk_s3::Client::from_conf(s3_config)
@@ -196,7 +199,7 @@ impl OssSyncManager {
 
         self.credentials = Some(resp.credentials.clone());
         self.oss_config = Some(resp.oss.clone());
-        self.s3_client = Some(Self::create_s3_client(&resp.credentials, &resp.oss));
+        self.s3_client = Some(Self::create_s3_client(&resp.credentials, &resp.oss, self.force_path_style));
 
         self.role =
             serde_json::from_str(&format!("\"{}\"", resp.role)).unwrap_or(MemberRole::Editor);
@@ -206,7 +209,7 @@ impl OssSyncManager {
     }
 
     pub async fn call_fc(&self, path: &str, body: &Value) -> Result<FcResponse, String> {
-        let url = format!("{}{}", self.fc_endpoint, path);
+        let url = format!("{}{}", self.team_endpoint, path);
         let client = reqwest::Client::new();
 
         let max_retries = 3u32;

--- a/src-tauri/src/commands/oss_types.rs
+++ b/src-tauri/src/commands/oss_types.rs
@@ -101,7 +101,9 @@ pub struct CleanupResult {
 pub struct OssTeamConfig {
     pub enabled: bool,
     pub team_id: String,
-    pub fc_endpoint: String,
+    pub team_endpoint: String,
+    #[serde(default)]
+    pub force_path_style: bool,
     pub last_sync_at: Option<String>,
     pub poll_interval_secs: u64,
 }
@@ -110,7 +112,7 @@ pub struct OssTeamConfig {
 #[serde(rename_all = "camelCase")]
 pub struct PendingApplication {
     pub team_id: String,
-    pub fc_endpoint: String,
+    pub team_endpoint: String,
     pub applied_at: String,
 }
 


### PR DESCRIPTION
## Summary
- Rename build config key `oss.fcEndpoint` → `s3.teamEndpoint` for clarity
- Add `s3.forcePathStyle` boolean to support both S3-compatible (OSS, R2) and standard S3 (MinIO) storage
- Rename Rust `fc_endpoint` → `team_endpoint` across all OSS command/sync/type files
- Update frontend Tauri invoke calls to match new parameter names
- GitHub Actions `BUILD_CONFIG_PRODUCTION` secret updated

## Test plan
- [ ] Verify S3 team create/join/restore works with `forcePathStyle: false` (OSS/R2)
- [ ] Verify config is correctly persisted in `teamclaw.json` with new field names
- [ ] Verify old configs without `forcePathStyle` still work (serde default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)