### PR TITLE
refactor: dynamic app name via buildConfig.app.name

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { Toaster } from "sonner";
 import { cn, isTauri } from "@/lib/utils";
+import { buildConfig } from "@/lib/build-config";
 import {
   AlertTriangle,
   Terminal,
@@ -524,7 +525,7 @@ function AppContent() {
                 />
               </>
             )}
-            <span className="font-medium">TeamClaw</span>
+            <span className="font-medium">{buildConfig.app.name}</span>
           </header>
           <div className="flex-1 overflow-hidden">
             <WorkspacePrompt />
@@ -554,7 +555,7 @@ function AppContent() {
                 />
               </>
             )}
-            <span className="font-medium">TeamClaw</span>
+            <span className="font-medium">{buildConfig.app.name}</span>
           </header>
           <div className="flex-1 overflow-hidden flex flex-col items-center justify-center gap-6 p-8">
             <div className="flex flex-col items-center gap-4 text-center max-w-lg">
@@ -629,7 +630,7 @@ function AppContent() {
           {/* Layout toggle - before TeamClaw */}
           {advancedMode && <LayoutToggleButton />}
 
-          <span className="text-sm font-medium">TeamClaw</span>
+          <span className="text-sm font-medium">{buildConfig.app.name}</span>
           <Separator
             orientation="vertical"
             className="data-[orientation=vertical]:h-4 mx-2"

--- a/packages/app/src/components/SetupGuide.tsx
+++ b/packages/app/src/components/SetupGuide.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useDepsStore, type DependencyInfo } from '@/stores/deps'
+import { buildConfig } from '@/lib/build-config'
 
 export type { DependencyInfo }
 
@@ -592,7 +593,7 @@ export function SetupGuide({ onContinue }: SetupGuideProps) {
   }
 
   const phaseDescription = {
-    overview: t('setup.intro', 'TeamClaw needs a few tools to work properly. Install the missing dependencies to get started.'),
+    overview: t('setup.intro', { defaultValue: '{{appName}} needs a few tools to work properly. Install the missing dependencies to get started.', appName: buildConfig.app.name }),
     customize: t('setup.customizeIntro', 'Choose which dependencies to install. Required tools are pre-selected.'),
     installing: t('setup.installingIntro', 'Please wait while dependencies are being installed...'),
     results: t('setup.resultsIntro', 'Installation has finished. See the results below.'),

--- a/packages/app/src/components/settings/AboutSection.tsx
+++ b/packages/app/src/components/settings/AboutSection.tsx
@@ -13,6 +13,7 @@ import {
   RefreshCw,
   AlertCircle,
 } from "lucide-react";
+import { buildConfig } from "@/lib/build-config";
 import { useUpdaterStore } from "@/stores/updater";
 import { useAppVersion } from "@/lib/version";
 import { Button } from "@/components/ui/button";
@@ -49,11 +50,11 @@ export const AboutSection = React.memo(function AboutSection() {
           <div className="flex items-center gap-4">
             <img
               src="/logo-64.png"
-              alt="TeamClaw Logo"
+              alt={`${buildConfig.app.name} Logo`}
               className="h-14 w-14 object-contain"
             />
             <div>
-              <h4 className="font-semibold text-lg">TeamClaw</h4>
+              <h4 className="font-semibold text-lg">{buildConfig.app.name}</h4>
               <p className="text-sm text-muted-foreground">
                 Version {appVersion}
               </p>
@@ -214,10 +215,10 @@ export const AboutSection = React.memo(function AboutSection() {
         <p className="text-sm text-muted-foreground flex items-center justify-center gap-1">
           {t("settings.about.madeWith", "Made with")}{" "}
           <Heart className="h-4 w-4 text-red-500 fill-red-500" />{" "}
-          {t("settings.about.byTeam", "by TeamClaw Team")}
+          {t("settings.about.byTeam", { defaultValue: "by {{appName}} Team", appName: buildConfig.app.name })}
         </p>
         <p className="text-xs text-muted-foreground mt-2">
-          &copy; 2024 TeamClaw. All rights reserved.
+          &copy; 2024 {buildConfig.app.name}. All rights reserved.
         </p>
       </div>
     </div>

--- a/packages/app/src/components/settings/DependenciesSection.tsx
+++ b/packages/app/src/components/settings/DependenciesSection.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn, isTauri, copyToClipboard } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { useDepsStore } from '@/stores/deps'
 import type { DependencyInfo } from '@/stores/deps'
 
@@ -164,7 +165,7 @@ export function DependenciesSection() {
         <SectionHeader
           icon={Package}
           title={t('settings.deps.title', 'Dependencies')}
-          description={t('settings.deps.description', 'External tools required by TeamClaw')}
+          description={t('settings.deps.description', { defaultValue: 'External tools required by {{appName}}', appName: buildConfig.app.name })}
           iconColor="text-teal-500"
         />
         <SettingCard>
@@ -181,7 +182,7 @@ export function DependenciesSection() {
       <SectionHeader
         icon={Package}
         title={t('settings.deps.title', 'Dependencies')}
-        description={t('settings.deps.description', 'External tools required by TeamClaw')}
+        description={t('settings.deps.description', { defaultValue: 'External tools required by {{appName}}', appName: buildConfig.app.name })}
         iconColor="text-teal-500"
       />
 

--- a/packages/app/src/components/settings/MCPSection.tsx
+++ b/packages/app/src/components/settings/MCPSection.tsx
@@ -18,6 +18,7 @@ import { useMCPStore, type MCPServerConfig } from '@/stores/mcp'
 import { useDepsStore } from '@/stores/deps'
 import type { MCPServerStatus } from '@/lib/opencode/types'
 import { cn } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -379,7 +380,7 @@ export const MCPSection = React.memo(function MCPSection() {
               {t('settings.mcp.inherentMCP')}
             </span>
             <div className="flex-1 h-px bg-blue-200/60 dark:bg-blue-800/40" />
-            <span className="text-xs text-muted-foreground">{t('settings.mcp.managedByTeamClaw')}</span>
+            <span className="text-xs text-muted-foreground">{t('settings.mcp.managedByTeamClaw', { defaultValue: 'Managed by {{appName}}', appName: buildConfig.app.name })}</span>
           </div>
           {inherentEntries.map(([name, config]) => {
             const runtime = runtimeStatus[name]

--- a/packages/app/src/components/settings/PrivacySection.tsx
+++ b/packages/app/src/components/settings/PrivacySection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Shield } from 'lucide-react'
 import { useTelemetryStore } from '@/stores/telemetry'
 import { cn } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 
 export function PrivacySection() {
   const { t } = useTranslation()
@@ -24,7 +25,7 @@ export function PrivacySection() {
           {t('settings.privacy.title', 'Privacy & Telemetry')}
         </h3>
         <p className="text-sm text-muted-foreground mt-1">
-          {t('settings.privacy.description', 'Control anonymous usage data collection to help improve TeamClaw.')}
+          {t('settings.privacy.description', { defaultValue: 'Control anonymous usage data collection to help improve {{appName}}.', appName: buildConfig.app.name })}
         </p>
       </div>
 

--- a/packages/app/src/components/settings/SkillsSection.tsx
+++ b/packages/app/src/components/settings/SkillsSection.tsx
@@ -27,6 +27,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { initOpenCodeClient } from '@/lib/opencode/client'
 import { cn } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -729,7 +730,7 @@ ${skillContent.trim()}`
                         {t('settings.skills.inherentSkills', 'Inherent Skills')}
                       </span>
                       <div className="flex-1 h-px bg-blue-200/60 dark:bg-blue-800/40" />
-                      <span className="text-xs text-muted-foreground">{t('settings.skills.managedByTeamClaw', 'Managed by TeamClaw')}</span>
+                      <span className="text-xs text-muted-foreground">{t('settings.skills.managedByTeamClaw', { defaultValue: 'Managed by {{appName}}', appName: buildConfig.app.name })}</span>
                     </div>
                     {builtinSkills.map(renderSkillCard)}
                   </div>

--- a/packages/app/src/components/settings/channels/DiscordDialogs.tsx
+++ b/packages/app/src/components/settings/channels/DiscordDialogs.tsx
@@ -18,6 +18,7 @@ import {
   Zap,
 } from 'lucide-react'
 import { cn, openExternalUrl, copyToClipboard as copyToClipboardUtil } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -36,7 +37,7 @@ import { ToggleSwitch } from './shared'
 
 // Setup Wizard Component - steps built with t() inside component
 const getDiscordWizardSteps = (t: (key: string, options?: Record<string, unknown>) => string) => [
-  { id: 'intro', title: t('settings.channels.discord.welcome', { defaultValue: 'Welcome to Discord Setup' }), description: t('settings.channels.discord.welcomeDesc', { defaultValue: "Let's connect your Discord bot to TeamClaw in a few simple steps." }) },
+  { id: 'intro', title: t('settings.channels.discord.welcome', { defaultValue: 'Welcome to Discord Setup' }), description: t('settings.channels.discord.welcomeDesc', { defaultValue: "Let's connect your Discord bot to {{appName}} in a few simple steps.", appName: buildConfig.app.name }) },
   { id: 'create-app', title: t('settings.channels.discord.createApp', { defaultValue: 'Create Discord Application' }), description: t('settings.channels.discord.createAppDesc', { defaultValue: 'First, we need to create a Discord application and bot.' }) },
   { id: 'get-token', title: t('settings.channels.discord.getToken', { defaultValue: 'Get Your Bot Token' }), description: t('settings.channels.discord.getTokenDesc', { defaultValue: "Copy your bot's secret token to authenticate." }) },
   { id: 'permissions', title: t('settings.channels.discord.permissions', { defaultValue: 'Configure Permissions' }), description: t('settings.channels.discord.permissionsDesc', { defaultValue: 'Set up the required permissions for your bot.' }) },
@@ -119,9 +120,9 @@ export function SetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.discord.connectTitle', 'Connect Discord to TeamClaw')}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.discord.connectTitle', { defaultValue: 'Connect Discord to {{appName}}', appName: buildConfig.app.name })}</h3>
               <p className="text-sm text-muted-foreground">
-                This wizard will guide you through creating a Discord bot and connecting it to TeamClaw.
+                {`This wizard will guide you through creating a Discord bot and connecting it to ${buildConfig.app.name}.`}
                 You'll be able to interact with AI directly from Discord channels and DMs.
               </p>
             </div>
@@ -161,7 +162,7 @@ export function SetupWizard({
                     <ol className="list-decimal list-inside space-y-2 text-blue-800 dark:text-blue-200">
                       <li>{t('settings.channels.discord.createBotStep1', 'Go to the Discord Developer Portal')}</li>
                       <li>{t('settings.channels.discord.createBotStep2', 'Click "New Application"')}</li>
-                      <li>{t('settings.channels.discord.createBotStep3', 'Enter a name (e.g., "TeamClaw Bot") and create')}</li>
+                      <li>{t('settings.channels.discord.createBotStep3', { defaultValue: 'Enter a name (e.g., "{{appName}} Bot") and create', appName: buildConfig.app.name })}</li>
                       <li>{t('settings.channels.discord.createBotStep4', 'Navigate to "Bot" in the left sidebar')}</li>
                       <li>{t('settings.channels.discord.createBotStep5', 'Click "Add Bot" to create a bot user')}</li>
                     </ol>

--- a/packages/app/src/components/settings/channels/Email.tsx
+++ b/packages/app/src/components/settings/channels/Email.tsx
@@ -21,6 +21,7 @@ import {
   Globe,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -493,14 +494,14 @@ export function EmailChannel() {
                 {t('settings.channels.email.displayName', 'Bot Display Name')}
               </label>
               <Input
-                placeholder={t('settings.channels.email.displayNamePlaceholder', 'TeamClaw Agent')}
+                placeholder={t('settings.channels.email.displayNamePlaceholder', { defaultValue: '{{appName}} Agent', appName: buildConfig.app.name })}
                 value={emailLocalConfig.displayName}
                 onChange={(e) => updateEmailLocalConfig({ displayName: e.target.value })}
               />
               <p className="text-xs text-muted-foreground">
                 {t('settings.channels.email.displayNameHint', 'Name shown in the From header of reply emails, e.g.')}{' '}
                 <span className="font-mono">
-                  {emailLocalConfig.displayName.trim() || 'TeamClaw Agent'}
+                  {emailLocalConfig.displayName.trim() || `${buildConfig.app.name} Agent`}
                   {' <'}
                   {(() => {
                     const baseEmail = emailLocalConfig.provider === 'gmail'

--- a/packages/app/src/components/settings/channels/EmailSetupWizard.tsx
+++ b/packages/app/src/components/settings/channels/EmailSetupWizard.tsx
@@ -13,6 +13,7 @@ import {
   ExternalLink,
 } from 'lucide-react'
 import { cn, openExternalUrl } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -35,7 +36,7 @@ const EMAIL_WIZARD_STEPS = [
     titleKey: 'settings.channels.email.wizardIntroTitle',
     title: 'Welcome to Email Setup',
     descKey: 'settings.channels.email.wizardIntroDesc',
-    description: "Let's connect your email to TeamClaw as a communication channel.",
+    description: `Let's connect your email to ${buildConfig.app.name} as a communication channel.`,
   },
   {
     id: 'provider',
@@ -160,7 +161,7 @@ export function EmailSetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.email.connectTitle', 'Connect Email to TeamClaw')}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.email.connectTitle', { defaultValue: 'Connect Email to {{appName}}', appName: buildConfig.app.name })}</h3>
               <p className="text-sm text-muted-foreground">
                 {t('settings.channels.email.connectDesc', 'This wizard will guide you through setting up email as a communication channel. The bot will monitor your inbox, process incoming emails through AI, and send threaded replies.')}
               </p>

--- a/packages/app/src/components/settings/channels/Feishu.tsx
+++ b/packages/app/src/components/settings/channels/Feishu.tsx
@@ -20,6 +20,7 @@ import {
   Zap,
 } from 'lucide-react'
 import { cn, openExternalUrl } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -48,7 +49,7 @@ const FEISHU_WIZARD_STEPS = [
     titleKey: 'settings.channels.feishu.wizardIntroTitle',
     title: 'Welcome to Feishu Setup',
     descKey: 'settings.channels.feishu.wizardIntroDesc',
-    description: "Let's connect your Feishu bot to TeamClaw in a few simple steps.",
+    description: `Let's connect your Feishu bot to ${buildConfig.app.name} in a few simple steps.`,
   },
   {
     id: 'create-app',
@@ -144,9 +145,9 @@ function FeishuSetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.feishu.connectTitle', 'Connect Feishu to TeamClaw')}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.feishu.connectTitle', { defaultValue: 'Connect Feishu to {{appName}}', appName: buildConfig.app.name })}</h3>
               <p className="text-sm text-muted-foreground">
-                {t('settings.channels.feishu.connectDesc', "This wizard will guide you through creating a Feishu app and connecting it to TeamClaw. You'll be able to interact with AI directly from Feishu chats.")}
+                {t('settings.channels.feishu.connectDesc', { defaultValue: "This wizard will guide you through creating a Feishu app and connecting it to {{appName}}. You'll be able to interact with AI directly from Feishu chats.", appName: buildConfig.app.name })}
               </p>
             </div>
 
@@ -184,7 +185,7 @@ function FeishuSetupWizard({
                   <ol className="list-decimal list-inside space-y-2 text-blue-800 dark:text-blue-200">
                     <li>{t('settings.channels.feishu.createAppStep1', 'Go to the Feishu Developer Portal')}</li>
                     <li>{t('settings.channels.feishu.createAppStep2', 'Click "Create Custom App"')}</li>
-                    <li>{t('settings.channels.feishu.createAppStep3', 'Enter a name (e.g., "TeamClaw Bot") and description')}</li>
+                    <li>{t('settings.channels.feishu.createAppStep3', { defaultValue: 'Enter a name (e.g., "{{appName}} Bot") and description', appName: buildConfig.app.name })}</li>
                     <li>{t('settings.channels.feishu.createAppStep4', 'Select your organization')}</li>
                     <li>{t('settings.channels.feishu.createAppStep5', 'Click "Create"')}</li>
                   </ol>

--- a/packages/app/src/components/settings/channels/KookDialogs.tsx
+++ b/packages/app/src/components/settings/channels/KookDialogs.tsx
@@ -15,6 +15,7 @@ import {
   ExternalLink,
 } from 'lucide-react'
 import { cn, openExternalUrl } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -38,7 +39,7 @@ const KOOK_WIZARD_STEPS = [
     titleKey: 'settings.channels.kook.wizardIntroTitle',
     title: 'Welcome to KOOK Setup',
     descKey: 'settings.channels.kook.wizardIntroDesc',
-    description: "Let's connect your KOOK bot to TeamClaw in a few simple steps.",
+    description: `Let's connect your KOOK bot to ${buildConfig.app.name} in a few simple steps.`,
   },
   {
     id: 'create-bot',
@@ -137,9 +138,9 @@ export function KookSetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.kook.connectTitle', 'Connect KOOK to TeamClaw')}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.kook.connectTitle', { defaultValue: 'Connect KOOK to {{appName}}', appName: buildConfig.app.name })}</h3>
               <p className="text-sm text-muted-foreground">
-                {t('settings.channels.kook.connectDesc', "This wizard will guide you through creating a KOOK bot and connecting it to TeamClaw. You'll be able to interact with AI directly from KOOK servers and DMs.")}
+                {t('settings.channels.kook.connectDesc', { defaultValue: "This wizard will guide you through creating a KOOK bot and connecting it to {{appName}}. You'll be able to interact with AI directly from KOOK servers and DMs.", appName: buildConfig.app.name })}
               </p>
             </div>
 
@@ -177,7 +178,7 @@ export function KookSetupWizard({
                   <ol className="list-decimal list-inside space-y-2 text-orange-800 dark:text-orange-200">
                     <li>{t('settings.channels.kook.createBotStep1', 'Go to the KOOK Developer Portal')}</li>
                     <li>{t('settings.channels.kook.createBotStep2', 'Click "Create Application"')}</li>
-                    <li>{t('settings.channels.kook.createBotStep3', 'Enter a name (e.g., "TeamClaw Bot") and icon')}</li>
+                    <li>{t('settings.channels.kook.createBotStep3', { defaultValue: 'Enter a name (e.g., "{{appName}} Bot") and icon', appName: buildConfig.app.name })}</li>
                     <li>{t('settings.channels.kook.createBotStep4', 'Select "Bot" type')}</li>
                     <li>{t('settings.channels.kook.createBotStep5', 'Click "Create"')}</li>
                   </ol>

--- a/packages/app/src/components/settings/channels/Wechat.tsx
+++ b/packages/app/src/components/settings/channels/Wechat.tsx
@@ -14,6 +14,7 @@ import {
   RefreshCw,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -41,7 +42,7 @@ const WECHAT_WIZARD_STEPS = [
     titleKey: 'settings.channels.wechat.wizardIntroTitle',
     title: 'Welcome to WeChat Setup',
     descKey: 'settings.channels.wechat.wizardIntroDesc',
-    description: "Let's connect your WeChat account to TeamClaw via ClawBot.",
+    description: `Let's connect your WeChat account to ${buildConfig.app.name} via ClawBot.`,
   },
   {
     id: 'scan',
@@ -177,7 +178,7 @@ function WeChatSetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.wechat.connectTitle', 'Connect WeChat to TeamClaw')}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.wechat.connectTitle', { defaultValue: 'Connect WeChat to {{appName}}', appName: buildConfig.app.name })}</h3>
               <p className="text-sm text-muted-foreground">
                 {t('settings.channels.wechat.connectDesc', "This wizard will connect your WeChat account via ClawBot. You'll scan a QR code with WeChat on your iPhone to log in.")}
               </p>

--- a/packages/app/src/components/settings/channels/Wecom.tsx
+++ b/packages/app/src/components/settings/channels/Wecom.tsx
@@ -15,6 +15,7 @@ import {
   Zap,
 } from 'lucide-react'
 import { cn, openExternalUrl } from '@/lib/utils'
+import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -42,7 +43,7 @@ const WECOM_WIZARD_STEPS = [
     titleKey: 'settings.channels.wecom.wizardIntroTitle',
     title: 'Welcome to WeCom Setup',
     descKey: 'settings.channels.wecom.wizardIntroDesc',
-    description: "Let's connect your WeCom AI bot to TeamClaw in a few simple steps.",
+    description: `Let's connect your WeCom AI bot to ${buildConfig.app.name} in a few simple steps.`,
   },
   {
     id: 'create-bot',
@@ -131,9 +132,9 @@ function WeComSetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.wecom.connectTitle', 'Connect WeCom to TeamClaw')}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.wecom.connectTitle', { defaultValue: 'Connect WeCom to {{appName}}', appName: buildConfig.app.name })}</h3>
               <p className="text-sm text-muted-foreground">
-                {t('settings.channels.wecom.connectDesc', "This wizard will guide you through creating a WeCom AI bot and connecting it to TeamClaw. You'll be able to interact with AI directly from WeCom chats.")}
+                {t('settings.channels.wecom.connectDesc', { defaultValue: "This wizard will guide you through creating a WeCom AI bot and connecting it to {{appName}}. You'll be able to interact with AI directly from WeCom chats.", appName: buildConfig.app.name })}
               </p>
             </div>
 

--- a/packages/app/src/components/settings/channels/__tests__/EmailSetupWizard.test.tsx
+++ b/packages/app/src/components/settings/channels/__tests__/EmailSetupWizard.test.tsx
@@ -41,7 +41,7 @@ describe('EmailSetupWizard', () => {
       <EmailSetupWizard open={true} onOpenChange={vi.fn()} onConfigSave={vi.fn()} />
     )
     expect(screen.getByText('Welcome to Email Setup')).toBeTruthy()
-    expect(screen.getByText('Connect Email to TeamClaw')).toBeTruthy()
+    expect(screen.getByText(/Connect Email to/)).toBeTruthy()
   })
 
   it('navigates to provider step on Next click', () => {

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -68,7 +68,7 @@ type ConnectionState =
 
 async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   if (!isTauri()) {
-    throw new Error('Team feature requires TeamClaw desktop app (Tauri not available)')
+    throw new Error(`Team feature requires ${buildConfig.app.name} desktop app (Tauri not available)`)
   }
   const { invoke } = await import('@tauri-apps/api/core')
   return invoke<T>(cmd, args)
@@ -644,7 +644,7 @@ export function TeamGitConfig() {
           <CollapsibleContent>
             <div className="mt-4 pt-4 border-t space-y-4 text-sm text-muted-foreground">
               <p>
-                {t('settings.team.repoGuide.intro', 'A shared repository for your team to centrally manage Agent Skills, MCP configurations, and knowledge documents. Use the structure below so TeamClaw can sync correctly.')}
+                {t('settings.team.repoGuide.intro', { defaultValue: 'A shared repository for your team to centrally manage Agent Skills, MCP configurations, and knowledge documents. Use the structure below so {{appName}} can sync correctly.', appName: buildConfig.app.name })}
               </p>
               <div>
                 <h5 className="font-medium text-foreground mb-1.5">
@@ -678,7 +678,7 @@ export function TeamGitConfig() {
                   {t('settings.team.repoGuide.usageTitle', 'Usage')}
                 </h5>
                 <ol className="list-decimal list-inside space-y-1">
-                  <li>{t('settings.team.repoGuide.usage1', 'Clone the repo; TeamClaw will create a teamclaw-team folder in your workspace.')}</li>
+                  <li>{t('settings.team.repoGuide.usage1', { defaultValue: 'Clone the repo; {{appName}} will create a teamclaw-team folder in your workspace.', appName: buildConfig.app.name })}</li>
                   <li>{t('settings.team.repoGuide.usage2', 'Whitelist .gitignore: only the three directories are tracked.')}</li>
                   <li>{t('settings.team.repoGuide.usage3', 'In Cursor, use @ to reference Skills and Knowledge.')}</li>
                 </ol>

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -47,7 +47,7 @@ import {
 
 async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   if (!isTauri()) {
-    throw new Error('Team feature requires TeamClaw desktop app (Tauri not available)')
+    throw new Error(`Team feature requires ${buildConfig.app.name} desktop app (Tauri not available)`)
   }
   const { invoke } = await import('@tauri-apps/api/core')
   return invoke<T>(cmd, args)

--- a/packages/app/src/components/telemetry/TelemetryConsentDialog.tsx
+++ b/packages/app/src/components/telemetry/TelemetryConsentDialog.tsx
@@ -11,6 +11,7 @@ import {
   AlertDialogCancel,
 } from '@/components/ui/alert-dialog'
 import { useTelemetryStore } from '@/stores/telemetry'
+import { buildConfig } from '@/lib/build-config'
 
 interface TelemetryConsentDialogProps {
   open: boolean
@@ -41,10 +42,10 @@ export function TelemetryConsentDialog({
             <BarChart3 className="h-6 w-6 text-primary" />
           </div>
           <AlertDialogTitle className="text-center">
-            帮助改善 TeamClaw
+            {`帮助改善 ${buildConfig.app.name}`}
           </AlertDialogTitle>
           <AlertDialogDescription className="text-center">
-            允许 TeamClaw 收集匿名使用数据，帮助我们改善 Agent 质量。
+            {`允许 ${buildConfig.app.name} 收集匿名使用数据，帮助我们改善 Agent 质量。`}
           </AlertDialogDescription>
         </AlertDialogHeader>
 

--- a/packages/app/src/lib/__tests__/gitignore-manager.test.ts
+++ b/packages/app/src/lib/__tests__/gitignore-manager.test.ts
@@ -77,7 +77,7 @@ describe('gitignore-manager', () => {
 
       expect(writeTextFile).toHaveBeenCalledWith(
         '/workspace/.gitignore',
-        expect.stringContaining('# TeamClaw system directories')
+        expect.stringContaining('system directories')
       )
     })
 

--- a/packages/app/src/lib/git/skill-loader.ts
+++ b/packages/app/src/lib/git/skill-loader.ts
@@ -3,6 +3,7 @@ import { homeDir } from '@tauri-apps/api/path'
 import type { SkillWithSource, SkillSource } from './types'
 import { INHERENT_SKILL_NAMES } from './types'
 import type { ClawHubLockfile } from '@/lib/clawhub/types'
+import { buildConfig } from '@/lib/build-config'
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -297,7 +298,7 @@ export function getSourceDirHint(source: SkillSource): string {
     case 'team':
       return 'opencode.json → skills.paths'
     case 'builtin':
-      return '.opencode/skills/ (TeamClaw 内置)'
+      return `.opencode/skills/ (${buildConfig.app.name} 内置)`
     case 'personal':
       return ''
     case 'global-opencode':

--- a/packages/app/src/lib/gitignore-manager.ts
+++ b/packages/app/src/lib/gitignore-manager.ts
@@ -1,11 +1,12 @@
 import { readTextFile, writeTextFile, exists } from '@tauri-apps/plugin-fs'
 import { join } from '@tauri-apps/api/path'
+import { buildConfig } from '@/lib/build-config'
 
 /**
  * Default entries that should be in workspace .gitignore
  */
 export const TEAMCLAW_GITIGNORE_ENTRIES = [
-  '# TeamClaw system directories',
+  `# ${buildConfig.app.name} system directories`,
   '.teamclaw/',
   '.opencode/',
 ]
@@ -68,7 +69,7 @@ export async function ensureGitignoreEntries(workspacePath: string): Promise<voi
     if (!existingContent.endsWith('\n')) {
       newContent += '\n'
     }
-    newContent += '\n# TeamClaw system directories\n'
+    newContent += `\n# ${buildConfig.app.name} system directories\n`
     newContent += missingEntries.join('\n') + '\n'
 
     await writeTextFile(gitignorePath, newContent)

--- a/packages/app/src/stores/channels-types.ts
+++ b/packages/app/src/stores/channels-types.ts
@@ -1,4 +1,5 @@
 // Channel type definitions and default configs — extracted from channels.ts
+import { buildConfig } from '@/lib/build-config'
 
 // Gateway status types
 export type GatewayStatus = 'disconnected' | 'connecting' | 'connected' | 'error'
@@ -262,7 +263,7 @@ export const defaultEmailConfig: EmailConfig = {
   allowedSenders: [],
   labels: [],
   replyAllNew: false,
-  displayName: 'TeamClaw Agent',
+  displayName: `${buildConfig.app.name} Agent`,
 }
 
 // Channels store state interface

--- a/packages/app/src/stores/session-permissions.ts
+++ b/packages/app/src/stores/session-permissions.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { getOpenCodeClient } from "@/lib/opencode/client";
 import { isTauri } from "@/lib/utils";
+import { buildConfig } from "@/lib/build-config";
 import { notificationService } from "@/lib/notification-service";
 import { shouldAutoAuthorize } from "@/lib/permission-policy";
 import type { PermissionAskedEvent } from "@/lib/opencode/types";
@@ -229,7 +230,7 @@ export function createPermissionActions(set: SessionSet, get: SessionGet) {
 
         notificationService.send(
           "action_required",
-          "TeamClaw - Authorization required",
+          `${buildConfig.app.name} - Authorization required`,
           `${sessionTitle} \u2014 requesting ${permissionType} permission`,
           event.sessionID,
           async () => {

--- a/packages/app/src/stores/session-questions.ts
+++ b/packages/app/src/stores/session-questions.ts
@@ -1,6 +1,7 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { getOpenCodeClient } from "@/lib/opencode/client";
 import { notificationService } from "@/lib/notification-service";
+import { buildConfig } from "@/lib/build-config";
 import type {
   QuestionAskedEvent,
 } from "@/lib/opencode/types";
@@ -115,7 +116,7 @@ export function createQuestionActions(set: SessionSet, get: SessionGet) {
 
         notificationService.send(
           "action_required",
-          "TeamClaw - \u9700\u8981\u56de\u7b54",
+          `${buildConfig.app.name} - \u9700\u8981\u56de\u7b54`,
           `${sessionTitle} \u2014 AI \u6709\u95ee\u9898\u9700\u8981\u4f60\u56de\u7b54`,
           event.sessionId,
           async () => {

--- a/packages/app/src/stores/session-sse-lifecycle-handlers.ts
+++ b/packages/app/src/stores/session-sse-lifecycle-handlers.ts
@@ -1,5 +1,6 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { notificationService } from "@/lib/notification-service";
+import { buildConfig } from "@/lib/build-config";
 import { getOpenCodeClient } from "@/lib/opencode/client";
 import type {
   SessionErrorEvent,
@@ -496,7 +497,7 @@ export function createLifecycleHandlers(set: SessionSet, get: SessionGet) {
           console.log("[SessionIdle] Sending notification for main session:", sessionTitle);
           notificationService.send(
             "task_completed",
-            `TeamClaw - ${sessionTitle}`,
+            `${buildConfig.app.name} - ${sessionTitle}`,
             contentPreview,
             event.sessionId,
             async () => {
@@ -584,7 +585,7 @@ export function createLifecycleHandlers(set: SessionSet, get: SessionGet) {
       const errorSessionId = event.sessionId || activeSessionId || "";
       notificationService.send(
         "action_required",
-        `TeamClaw - ${sessionTitle}`,
+        `${buildConfig.app.name} - ${sessionTitle}`,
         errorPreview,
         errorSessionId,
         async () => {


### PR DESCRIPTION
## Summary
- Replace all hardcoded "TeamClaw" UI strings with `buildConfig.app.name` across 25 files
- Enables white-labeling by changing `app.name` in `build.config.json`
- Covers: title bar, sidebar, about page, notifications, channel setup dialogs, settings pages, telemetry consent, gitignore comments, skill loader

## Scope
- **Changed**: Direct JSX text, notification titles, i18n fallback strings (using `{{appName}}` interpolation), default values
- **Preserved**: Code comments, ErrorBoundary scope identifiers, variable/type names, directory names (`teamclaw-team`), i18n locale file values (overridden by code interpolation)

## Test plan
- [ ] Verify app title shows `buildConfig.app.name` when no workspace is selected
- [ ] Verify About page shows dynamic name and copyright
- [ ] Verify notification titles use dynamic name
- [ ] Verify channel setup dialogs show dynamic name
- [ ] Change `app.name` in `build.config.json` and verify all UI updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)