### PR TITLE
fix: OSS team state on workspace switch and sidebar icon

### DIFF
--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { useTranslation } from "react-i18next"
-import { Search, SquarePen, MessageSquare, Loader2, Archive, PanelLeftIcon, FolderOpen, Users, Pencil, Ellipsis, Clock } from "lucide-react"
+import { Search, SquarePen, MessageSquare, Loader2, Archive, PanelLeftIcon, FolderOpen, Users, Cloud, Pencil, Ellipsis, Clock } from "lucide-react"
 
 import { useSessionStore } from "@/stores/session"
 import { useStreamingStore } from "@/stores/streaming"
@@ -9,6 +9,7 @@ import { useWorkspaceStore } from "@/stores/workspace"
 import { useTabsStore } from "@/stores/tabs"
 import { useCronStore } from "@/stores/cron"
 import { useTeamModeStore } from "@/stores/team-mode"
+import { useTeamOssStore } from "@/stores/team-oss"
 import {
   Sidebar,
   SidebarContent,
@@ -231,6 +232,8 @@ function WorkspaceSelectorButton() {
   const setWorkspace = useWorkspaceStore(s => s.setWorkspace)
   const teamMode = useTeamModeStore(s => s.teamMode)
   const p2pConnected = useTeamModeStore(s => s.p2pConnected)
+  const ossConfigured = useTeamOssStore(s => s.configured)
+  const ossConnected = useTeamOssStore(s => s.connected)
   const [isSelecting, setIsSelecting] = React.useState(false)
 
   // Poll P2P connection status when in team mode
@@ -288,6 +291,8 @@ function WorkspaceSelectorButton() {
         >
           {isLoading ? (
             <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+          ) : teamMode && workspaceName && ossConfigured ? (
+            <Cloud className={cn("h-4 w-4 shrink-0", ossConnected ? "text-blue-500" : "text-muted-foreground")} />
           ) : teamMode && workspaceName ? (
             <Users className={cn("h-4 w-4 shrink-0", p2pConnected ? "text-blue-500" : "text-muted-foreground")} />
           ) : (

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -325,12 +325,12 @@ export function useOssSyncInit() {
   const workspacePath = useWorkspaceStore((s) => s.workspacePath);
   const initialize = useTeamOssStore((s) => s.initialize);
   const cleanup = useTeamOssStore((s) => s.cleanup);
-  const hasInitialized = useRef(false);
 
   useEffect(() => {
-    if (!workspacePath || !isTauri() || hasInitialized.current) return;
-    hasInitialized.current = true;
+    if (!workspacePath || !isTauri()) return;
 
+    // Clean up previous workspace listener, reset state, then re-initialize
+    cleanup();
     initialize(workspacePath).catch((err: unknown) => {
       console.warn("[App] OSS sync init failed (non-critical):", err);
     });

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -75,8 +75,15 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   loadTeamConfig: async (_workspacePath: string) => {
     // teamMode = p2p.enabled || ossConfigured
     const status = await fetchTeamStatus()
-    const { useTeamOssStore } = await import('./team-oss')
-    const ossConfigured = useTeamOssStore.getState().configured
+    // Check OSS config directly from backend to avoid stale store state on workspace switch
+    let ossConfigured = false
+    if (isTauri()) {
+      try {
+        const { invoke } = await import('@tauri-apps/api/core')
+        const ossConfig = await invoke<{ enabled?: boolean } | null>('oss_get_team_config', { workspacePath: _workspacePath })
+        ossConfigured = !!ossConfig?.enabled
+      } catch { /* ignore */ }
+    }
     const p2pActive = !!status?.active
     const isTeamMode = p2pActive || ossConfigured
 

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -277,12 +277,16 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     // Reset team mode state — each workspace has its own team config
     try {
       const { useTeamModeStore } = await import("./team-mode");
+      const { useTeamOssStore } = await import("./team-oss");
+      // Reset OSS store first so loadTeamConfig reads clean state
+      useTeamOssStore.getState().cleanup();
       useTeamModeStore.setState({
         teamMode: false,
         teamModelConfig: null,
         teamApiKey: null,
         _appliedConfigKey: null,
         myRole: null,
+        p2pConnected: false,
       });
       // Load team config immediately so sidebar shows team tag on startup
       useTeamModeStore.getState().loadTeamConfig(expandedPath).catch(() => {});


### PR DESCRIPTION
## Summary
- Fix stale OSS state when switching workspaces — read config directly from backend instead of store
- Fix `useOssSyncInit`: cleanup and reinitialize on workspace change (was running only once)
- Reset OSS store and `p2pConnected` on workspace switch
- Add Cloud icon in sidebar for OSS-connected workspaces (blue when connected)

## Test plan
- [ ] Switch between OSS-connected and non-connected workspaces — verify correct team mode detection
- [ ] Verify sidebar shows Cloud icon for OSS workspaces, Users icon for P2P
- [ ] Verify OSS sync reinitializes after workspace switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)