### PR TITLE
fix: add missing cfg(feature = "p2p") gate for p2p_dissolve_team

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -435,6 +435,7 @@ pub fn run() {
             commands::team_p2p::p2p_disconnect_source,
             #[cfg(feature = "p2p")]
             commands::team_p2p::p2p_leave_team,
+            #[cfg(feature = "p2p")]
             commands::team_p2p::p2p_dissolve_team,
             #[cfg(feature = "p2p")]
             commands::team_p2p::p2p_reconnect,


### PR DESCRIPTION
## Summary
- Add missing `#[cfg(feature = "p2p")]` gate for `p2p_dissolve_team` in `lib.rs`
- Fixes Windows release build failure in v0.1.16 (`could not find team_p2p in commands`)

## Root cause
Windows builds use `--no-default-features` which disables the `p2p` feature. The `team_p2p` module is gated behind `#[cfg(feature = "p2p")]`, but `p2p_dissolve_team` was missing its gate.

## Test plan
- [ ] Windows release build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)