### PR TITLE
fix: support fcEndpoint alias in OssTeamConfig deserialization

### DIFF
--- a/src-tauri/src/commands/oss_types.rs
+++ b/src-tauri/src/commands/oss_types.rs
@@ -101,6 +101,7 @@ pub struct CleanupResult {
 pub struct OssTeamConfig {
     pub enabled: bool,
     pub team_id: String,
+    #[serde(alias = "fcEndpoint")]
     pub team_endpoint: String,
     #[serde(default)]
     pub force_path_style: bool,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -435,6 +435,7 @@ pub fn run() {
             commands::team_p2p::p2p_disconnect_source,
             #[cfg(feature = "p2p")]
             commands::team_p2p::p2p_leave_team,
+            #[cfg(feature = "p2p")]
             commands::team_p2p::p2p_dissolve_team,
             #[cfg(feature = "p2p")]
             commands::team_p2p::p2p_reconnect,


### PR DESCRIPTION
## Summary

- Adds `#[serde(alias = "fcEndpoint")]` to `team_endpoint` in `OssTeamConfig`
- Configs written with the older `"fcEndpoint"` key now deserialize correctly alongside the canonical `"teamEndpoint"`
- Without this fix, `read_oss_config` returned `None` for such configs, so the OSS store's `configured` flag was never set, and the settings UI showed the P2P create/join forms instead of the existing team info

## Test plan

- [ ] Open a workspace whose `.teamclaw/teamclaw.json` has `oss.fcEndpoint` — settings Team tab should now show the existing OSS team (S3 tab active) instead of the P2P create/join form
- [ ] Verify that configs with `oss.teamEndpoint` still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)