### PR TITLE
fix: suppress noisy iroh::socket poll_send logs

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -195,6 +195,7 @@ pub fn run() {
                 // Suppress noisy third-party crate logs
                 let target = metadata.target();
                 !(target.starts_with("tracing::span")
+                    || target.starts_with("iroh::")
                     || target.starts_with("iroh_relay")
                     || target.starts_with("iroh_base")
                     || target.starts_with("iroh_net_report")


### PR DESCRIPTION
## Summary
- Add `iroh::` prefix to the log filter in `tauri_plugin_log` setup
- Fixes `iroh::socket::transports` `poll_send` INFO logs flooding stdout (dozens per second during sync_status checks)
- Existing `iroh_*` filters only covered sub-crates (iroh_relay, iroh_base, etc.), not the main `iroh::` module namespace

## Test plan
- [ ] Run app with P2P enabled, verify `poll_send` logs no longer appear in stdout
- [ ] Verify `[P2P]` diagnostic logs (via `eprintln!`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)