### PR TITLE
feat: support OAuth browser login for LLM providers

### DIFF
--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -14,6 +14,9 @@ import {
   ChevronRight,
   Zap,
   Settings,
+  ExternalLink,
+  Copy,
+  Check,
 } from 'lucide-react'
 import { invoke } from '@tauri-apps/api/core'
 import { useProviderStore } from '@/stores/provider'
@@ -43,7 +46,11 @@ export const LLMSection = React.memo(function LLMSection() {
   const configuredProviders = useProviderStore((s) => s.configuredProviders)
   const refreshProviders = useProviderStore((s) => s.refreshProviders)
   const refreshConfiguredProviders = useProviderStore((s) => s.refreshConfiguredProviders)
+  const authMethods = useProviderStore((s) => s.authMethods)
+  const refreshAuthMethods = useProviderStore((s) => s.refreshAuthMethods)
   const connectProvider = useProviderStore((s) => s.connectProvider)
+  const connectProviderOAuth = useProviderStore((s) => s.connectProviderOAuth)
+  const completeOAuthCallback = useProviderStore((s) => s.completeOAuthCallback)
   const initAll = useProviderStore((s) => s.initAll)
   const customProviderIds = useProviderStore((s) => s.customProviderIds)
   const refreshCustomProviderIds = useProviderStore((s) => s.refreshCustomProviderIds)
@@ -79,6 +86,12 @@ export const LLMSection = React.memo(function LLMSection() {
   const [deletingProviderId, setDeletingProviderId] = React.useState<string | null>(null)
   const [isDeleting, setIsDeleting] = React.useState(false)
 
+  // OAuth flow state
+  const [oauthPending, setOAuthPending] = React.useState(false)
+  const [oauthInstructions, setOAuthInstructions] = React.useState('')
+  const [oauthUrl, setOAuthUrl] = React.useState('')
+  const [oauthCodeCopied, setOAuthCodeCopied] = React.useState(false)
+
   // Disconnect confirmation state
   const [disconnectingProviderId, setDisconnectingProviderId] = React.useState<string | null>(null)
   const [disconnectingProviderName, setDisconnectingProviderName] = React.useState<string>('')
@@ -91,6 +104,7 @@ export const LLMSection = React.memo(function LLMSection() {
   React.useEffect(() => {
     refreshProviders()
     refreshConfiguredProviders()
+    refreshAuthMethods()
     if (workspacePath) {
       refreshCustomProviderIds(workspacePath)
     }
@@ -118,10 +132,18 @@ export const LLMSection = React.memo(function LLMSection() {
     }
   }
 
+  const getProviderOAuthMethodIndex = (providerId: string): number => {
+    const methods = authMethods[providerId] || []
+    return methods.findIndex((m) => m.type === 'oauth')
+  }
+
   const handleConnectClick = (providerId: string, providerName: string) => {
     setConnectingProviderId(providerId)
     setConnectingProviderName(providerName)
     setApiKeyInput('')
+    setOAuthPending(false)
+    setOAuthInstructions('')
+    setOAuthUrl('')
     setConnectDialogOpen(true)
   }
 
@@ -135,6 +157,42 @@ export const LLMSection = React.memo(function LLMSection() {
       await restartOpenCodeAndRefresh()
     }
     setIsConnecting(false)
+  }
+
+  const handleOAuthLogin = async () => {
+    const methodIndex = getProviderOAuthMethodIndex(connectingProviderId)
+    if (methodIndex === -1) return
+    setIsConnecting(true)
+    const result = await connectProviderOAuth(connectingProviderId, methodIndex)
+    if (result.status !== 'pending') {
+      setIsConnecting(false)
+      return
+    }
+    // Open browser and show instructions
+    const { open } = await import('@tauri-apps/plugin-shell')
+    await open(result.url)
+    setOAuthUrl(result.url)
+    setOAuthInstructions(result.instructions)
+    setOAuthPending(true)
+    setIsConnecting(false)
+    // For Device Flow ("auto"), sidecar polls internally — kick off callback in background
+    completeOAuthCallback(connectingProviderId, methodIndex).then((success) => {
+      if (success) {
+        setConnectDialogOpen(false)
+        setOAuthPending(false)
+        restartOpenCodeAndRefresh()
+      }
+    })
+  }
+
+  const handleCopyOAuthCode = async () => {
+    // Extract code from instructions (e.g. "Enter code: XXXX-YYYY")
+    const match = oauthInstructions.match(/[A-Z0-9]{4}-[A-Z0-9]{4}/)
+    if (match) {
+      await navigator.clipboard.writeText(match[0])
+      setOAuthCodeCopied(true)
+      setTimeout(() => setOAuthCodeCopied(false), 2000)
+    }
   }
 
   const handleProviderClick = (providerId: string, configured: boolean, providerName: string) => {
@@ -531,66 +589,130 @@ export const LLMSection = React.memo(function LLMSection() {
       ) : null}
 
       {/* Connect Provider Dialog */}
-      <Dialog open={connectDialogOpen} onOpenChange={setConnectDialogOpen}>
+      <Dialog open={connectDialogOpen} onOpenChange={(open) => {
+        if (!open) { setOAuthPending(false); setOAuthInstructions(''); setOAuthUrl('') }
+        setConnectDialogOpen(open)
+      }}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>{t('settings.llm.connectTitle', { provider: connectingProviderName, defaultValue: `Connect ${connectingProviderName}` })}</DialogTitle>
             <DialogDescription>
-              {t('settings.llm.connectDescription', 'Enter your API key to connect this provider. Your key is stored locally.')}
+              {oauthPending
+                ? t('settings.llm.oauthWaiting', 'Browser opened. Complete authorization and return here.')
+                : getProviderOAuthMethodIndex(connectingProviderId) !== -1
+                  ? t('settings.llm.connectDescriptionOAuth', 'Connect via your browser subscription or enter an API key.')
+                  : t('settings.llm.connectDescription', 'Enter your API key to connect this provider. Your key is stored locally.')}
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-4 py-2">
-            <div className="space-y-2">
-              <label className="text-sm font-medium flex items-center gap-2">
-                <Key className="h-4 w-4 text-muted-foreground" />
-                {t('settings.llm.apiKey', 'API Key')}
-              </label>
-              <div className="relative">
-                <Input
-                  type="password"
-                  value={apiKeyInput}
-                  onChange={(e) => setApiKeyInput(e.target.value)}
-                  placeholder={t('settings.llm.apiKeyPlaceholder', 'sk-...')}
-                  className="h-11 pr-10"
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && apiKeyInput.trim()) {
-                      handleConnectSubmit()
-                    }
-                  }}
-                />
-                <Shield className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+
+          {oauthPending ? (
+            /* OAuth Device Flow — waiting for user to complete in browser */
+            <div className="space-y-4 py-2">
+              <div className="rounded-lg border bg-muted/40 p-4 space-y-3">
+                <p className="text-sm font-medium">{oauthInstructions}</p>
+                {/[A-Z0-9]{4}-[A-Z0-9]{4}/.test(oauthInstructions) && (
+                  <Button variant="outline" size="sm" className="gap-2" onClick={handleCopyOAuthCode}>
+                    {oauthCodeCopied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+                    {oauthCodeCopied ? t('settings.llm.copied', 'Copied!') : t('settings.llm.copyCode', 'Copy code')}
+                  </Button>
+                )}
               </div>
-              <p className="text-xs text-muted-foreground flex items-center gap-1">
-                <Shield className="h-3 w-3" />
-                {t('settings.llm.apiKeyPrivacy', 'Your API key is stored locally and never sent to our servers.')}
-              </p>
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin shrink-0" />
+                {t('settings.llm.oauthPolling', 'Waiting for authorization...')}
+              </div>
+              <Button variant="outline" size="sm" className="gap-2 w-full" onClick={async () => {
+                const { open } = await import('@tauri-apps/plugin-shell')
+                open(oauthUrl)
+              }}>
+                <ExternalLink className="h-3.5 w-3.5" />
+                {t('settings.llm.reopenBrowser', 'Re-open browser')}
+              </Button>
             </div>
-          </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              {/* OAuth login button — shown when provider supports OAuth */}
+              {getProviderOAuthMethodIndex(connectingProviderId) !== -1 && (
+                <div className="space-y-2">
+                  <Button
+                    variant="outline"
+                    className="w-full h-11 gap-2 justify-center"
+                    onClick={handleOAuthLogin}
+                    disabled={isConnecting}
+                  >
+                    {isConnecting ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <ExternalLink className="h-4 w-4" />
+                    )}
+                    {t('settings.llm.loginWithBrowser', 'Login with browser')}
+                  </Button>
+                  <div className="relative">
+                    <div className="absolute inset-0 flex items-center">
+                      <span className="w-full border-t" />
+                    </div>
+                    <div className="relative flex justify-center text-xs uppercase">
+                      <span className="bg-background px-2 text-muted-foreground">{t('settings.llm.or', 'or')}</span>
+                    </div>
+                  </div>
+                </div>
+              )}
+              {/* API Key input */}
+              <div className="space-y-2">
+                <label className="text-sm font-medium flex items-center gap-2">
+                  <Key className="h-4 w-4 text-muted-foreground" />
+                  {t('settings.llm.apiKey', 'API Key')}
+                </label>
+                <div className="relative">
+                  <Input
+                    type="password"
+                    value={apiKeyInput}
+                    onChange={(e) => setApiKeyInput(e.target.value)}
+                    placeholder={t('settings.llm.apiKeyPlaceholder', 'sk-...')}
+                    className="h-11 pr-10"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && apiKeyInput.trim()) {
+                        handleConnectSubmit()
+                      }
+                    }}
+                  />
+                  <Shield className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                </div>
+                <p className="text-xs text-muted-foreground flex items-center gap-1">
+                  <Shield className="h-3 w-3" />
+                  {t('settings.llm.apiKeyPrivacy', 'Your API key is stored locally and never sent to our servers.')}
+                </p>
+              </div>
+            </div>
+          )}
+
           <DialogFooter>
             <Button
               variant="outline"
-              onClick={() => setConnectDialogOpen(false)}
+              onClick={() => { setOAuthPending(false); setConnectDialogOpen(false) }}
               disabled={isConnecting}
             >
               {t('common.cancel', 'Cancel')}
             </Button>
-            <Button
-              onClick={handleConnectSubmit}
-              disabled={isConnecting || !apiKeyInput.trim()}
-              className="gap-2"
-            >
-              {isConnecting ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  {t('settings.llm.connecting', 'Connecting...')}
-                </>
-              ) : (
-                <>
-                  <Link className="h-4 w-4" />
-                  {t('settings.llm.connect', 'Connect')}
-                </>
-              )}
-            </Button>
+            {!oauthPending && (
+              <Button
+                onClick={handleConnectSubmit}
+                disabled={isConnecting || !apiKeyInput.trim()}
+                className="gap-2"
+              >
+                {isConnecting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {t('settings.llm.connecting', 'Connecting...')}
+                  </>
+                ) : (
+                  <>
+                    <Link className="h-4 w-4" />
+                    {t('settings.llm.connect', 'Connect')}
+                  </>
+                )}
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/packages/app/src/lib/opencode/client.ts
+++ b/packages/app/src/lib/opencode/client.ts
@@ -452,6 +452,27 @@ export class OpenCodeClient {
     return this.request<boolean>('DELETE', `/auth/${providerId}`)
   }
 
+  // Get available auth methods for all providers (GET /provider/auth)
+  // Returns Record<providerId, ProviderAuthMethod[]>
+  async getAuthMethods(): Promise<Record<string, Array<{ type: 'oauth' | 'api'; label: string; prompts?: unknown[] }>>> {
+    return this.request('GET', '/provider/auth')
+  }
+
+  // Initiate OAuth authorization for a provider (POST /provider/:id/oauth/authorize)
+  async oauthAuthorize(
+    providerId: string,
+    method: number,
+    inputs?: Record<string, string>,
+  ): Promise<{ url: string; method: 'auto' | 'code'; instructions: string } | undefined> {
+    return this.request('POST', `/provider/${encodeURIComponent(providerId)}/oauth/authorize`, { method, inputs })
+  }
+
+  // Complete OAuth callback (POST /provider/:id/oauth/callback)
+  // For Device Flow (method:"auto"), sidecar polls internally — just call and wait.
+  async oauthCallback(providerId: string, method: number, code?: string): Promise<boolean> {
+    return this.request<boolean>('POST', `/provider/${encodeURIComponent(providerId)}/oauth/callback`, { method, ...(code ? { code } : {}) })
+  }
+
   // Project APIs
   async getProject(): Promise<Project> {
     return this.request<Project>('GET', '/project')

--- a/packages/app/src/stores/provider.ts
+++ b/packages/app/src/stores/provider.ts
@@ -19,6 +19,12 @@ function tryGetClient() {
   }
 }
 
+export interface ProviderAuthMethod {
+  type: 'oauth' | 'api'
+  label: string
+  prompts?: unknown[]
+}
+
 // A model option available for selection in the ChatPanel
 export interface ModelOption {
   id: string
@@ -55,6 +61,9 @@ export interface ProviderState {
   // Currently selected model (from GET /config)
   currentModelKey: string | null // format: "providerId/modelId"
 
+  // Auth methods per provider (from GET /provider/auth)
+  authMethods: Record<string, ProviderAuthMethod[]>
+
   // Custom provider IDs (defined in opencode.json)
   customProviderIds: string[]
 
@@ -64,6 +73,13 @@ export interface ProviderState {
   _disconnectedIds: Set<string>
 
   // Actions
+  refreshAuthMethods: () => Promise<void>
+  connectProviderOAuth: (providerId: string, methodIndex: number) => Promise<
+    { status: 'pending'; url: string; instructions: string; methodType: 'auto' | 'code' } |
+    { status: 'success' } |
+    { status: 'error'; message: string }
+  >
+  completeOAuthCallback: (providerId: string, methodIndex: number, code?: string) => Promise<boolean>
   refreshProviders: () => Promise<void>
   refreshConfiguredProviders: () => Promise<void>
   refreshCurrentModel: () => Promise<void>
@@ -80,6 +96,7 @@ export interface ProviderState {
 
 export const useProviderStore = create<ProviderState>((set, get) => ({
   // Initial state
+  authMethods: {},
   providers: [],
   providersLoading: false,
   configuredProviders: [],
@@ -88,6 +105,51 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
   currentModelKey: null,
   customProviderIds: [],
   _disconnectedIds: new Set<string>(),
+
+  refreshAuthMethods: async () => {
+    const client = tryGetClient()
+    if (!client) return
+    try {
+      const methods = await client.getAuthMethods()
+      set({ authMethods: methods })
+    } catch (err) {
+      console.error('Failed to load auth methods:', err)
+    }
+  },
+
+  // Initiate OAuth for a provider. Returns pending state with url+instructions for the UI to show.
+  connectProviderOAuth: async (providerId, methodIndex) => {
+    const client = tryGetClient()
+    if (!client) return { status: 'error', message: 'OpenCode not connected' }
+    try {
+      const result = await client.oauthAuthorize(providerId, methodIndex)
+      if (!result) return { status: 'error', message: 'Provider does not support OAuth' }
+      return { status: 'pending', url: result.url, instructions: result.instructions, methodType: result.method }
+    } catch (err) {
+      return { status: 'error', message: err instanceof Error ? err.message : 'Unknown error' }
+    }
+  },
+
+  // Poll/wait for OAuth callback to complete (call after opening browser).
+  // For Device Flow (methodType:"auto") the sidecar polls GitHub internally; this call blocks until done.
+  completeOAuthCallback: async (providerId, methodIndex, code) => {
+    const client = tryGetClient()
+    if (!client) return false
+    try {
+      await client.oauthCallback(providerId, methodIndex, code)
+      set((state) => {
+        const newDisconnected = new Set(state._disconnectedIds)
+        newDisconnected.delete(providerId)
+        return { _disconnectedIds: newDisconnected }
+      })
+      toast.success('Provider connected', { description: `Successfully connected ${providerId}` })
+      await Promise.all([get().refreshProviders(), get().refreshConfiguredProviders()])
+      return true
+    } catch (err) {
+      toast.error('OAuth login failed', { description: err instanceof Error ? err.message : 'Unknown error' })
+      return false
+    }
+  },
 
   // Refresh all available providers (GET /provider)
   // Response: { all: ProviderObj[], connected: string[], default: Record<string,string> }


### PR DESCRIPTION
## Summary

- Add `getAuthMethods` / `oauthAuthorize` / `oauthCallback` to `OpenCodeClient`, wrapping the existing opencode sidecar endpoints (`GET /provider/auth`, `POST /provider/:id/oauth/authorize`, `POST /provider/:id/oauth/callback`)
- Add `authMethods` state and `connectProviderOAuth` / `completeOAuthCallback` actions to the provider store
- Update the connect dialog in `LLMSection` to show a **"Login with browser"** button when the provider supports OAuth (GitHub Copilot, GitLab, Poe), with Device Flow code display + one-click copy while waiting for authorization

## How it works

Uses the opencode sidecar's built-in Device Flow support — no redirect URL needed. After opening the browser, the sidecar polls the provider API internally; the frontend just waits for `oauthCallback` to resolve.

## Test plan

- [ ] Open Settings → LLM，找到 GitHub Copilot — 确认 "Login with browser" 按钮出现在 API key 输入框上方
- [ ] 点击"Login with browser" — 确认浏览器打开，dialog 切换到等待状态并显示激活码
- [ ] 在浏览器完成授权 — 确认 dialog 关闭，Copilot 显示为已连接
- [ ] 其他 provider（如 Anthropic、OpenAI）的 API key 流程不受影响
- [ ] OAuth 等待中取消 — 确认 dialog 正常关闭

🤖 Generated with [Claude Code](https://claude.com/claude-code)