### PR TITLE
feat: integrate LiteLLM team management via FC

### DIFF
--- a/fc/index.mjs
+++ b/fc/index.mjs
@@ -19,6 +19,10 @@ const REGION = () => process.env.REGION || "cn-hangzhou";
 const ENDPOINT = () =>
   process.env.ENDPOINT || "https://oss-cn-hangzhou.aliyuncs.com";
 
+// LiteLLM proxy
+const LITELLM_URL = () => process.env.LITELLM_URL || "https://ai.ucar.cc";
+const LITELLM_MASTER_KEY = () => process.env.LITELLM_MASTER_KEY || "";
+
 // ---------------------------------------------------------------------------
 // Rate limiting — in-memory, per IP, 10 req/min
 // ---------------------------------------------------------------------------
@@ -339,6 +343,233 @@ async function handleApply(body) {
 }
 
 // ---------------------------------------------------------------------------
+// LiteLLM helpers
+// ---------------------------------------------------------------------------
+async function litellmFetch(path, method, body) {
+  const url = `${LITELLM_URL()}${path}`;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${LITELLM_MASTER_KEY()}`,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  try {
+    return { ok: res.ok, status: res.status, data: JSON.parse(text) };
+  } catch {
+    return { ok: res.ok, status: res.status, data: text };
+  }
+}
+
+/**
+ * Verify teamSecret and optionally check owner identity.
+ * Returns { auth, isOwner } or a json error response.
+ */
+async function verifyTeam(teamId, teamSecret, requireOwnerNodeId) {
+  if (!teamId || !teamSecret) {
+    return { error: json(400, { error: "Missing teamId or teamSecret" }) };
+  }
+  const auth = await ossGet(`teams/${teamId}/_registry/auth.json`);
+  if (!auth) {
+    return { error: json(404, { error: "Team not found" }) };
+  }
+  if (sha256(teamSecret) !== auth.teamSecretHash) {
+    return { error: json(403, { error: "Invalid team secret" }) };
+  }
+  if (requireOwnerNodeId && requireOwnerNodeId !== auth.ownerNodeId) {
+    return { error: json(403, { error: "Only the owner can perform this action" }) };
+  }
+  return { auth, isOwner: (nodeId) => nodeId === auth.ownerNodeId };
+}
+
+// ---------------------------------------------------------------------------
+// LiteLLM route handlers
+// ---------------------------------------------------------------------------
+
+/** POST /ai/setup-team — create a LiteLLM team for this teamclaw team */
+async function handleAiSetupTeam(body) {
+  const { teamId, teamSecret, teamName } = body;
+  const v = await verifyTeam(teamId, teamSecret);
+  if (v.error) return v.error;
+
+  const litellmTeamId = `tc-${teamId}`;
+  const res = await litellmFetch("/team/new", "POST", {
+    team_id: litellmTeamId,
+    team_alias: teamName || teamId,
+  });
+
+  if (!res.ok && res.status !== 409) {
+    console.error(`[ai/setup-team] LiteLLM error:`, res.data);
+    return json(502, { error: "Failed to create LiteLLM team", detail: res.data });
+  }
+
+  console.log(`[ai/setup-team] Created LiteLLM team ${litellmTeamId}`);
+  return json(200, { success: true, litellmTeamId });
+}
+
+/** POST /ai/add-member — create a LiteLLM API key for a team member */
+async function handleAiAddMember(body) {
+  const { teamId, teamSecret, nodeId, memberName } = body;
+  if (!nodeId) return json(400, { error: "Missing nodeId" });
+  const v = await verifyTeam(teamId, teamSecret);
+  if (v.error) return v.error;
+
+  const litellmTeamId = `tc-${teamId}`;
+  const keyAlias = `${memberName || "member"}-${nodeId.slice(0, 8)}`;
+  const keyValue = `sk-tc-${nodeId.slice(0, 40)}`;
+
+  const res = await litellmFetch("/key/generate", "POST", {
+    key: keyValue,
+    team_id: litellmTeamId,
+    key_alias: keyAlias,
+  });
+
+  if (!res.ok) {
+    console.error(`[ai/add-member] LiteLLM error:`, res.data);
+    return json(502, { error: "Failed to create LiteLLM key", detail: res.data });
+  }
+
+  console.log(`[ai/add-member] Created key for ${nodeId.slice(0, 8)} in team ${litellmTeamId}`);
+  return json(200, { success: true, key: keyValue, keyAlias });
+}
+
+/** POST /ai/remove-member — delete a member's LiteLLM API key */
+async function handleAiRemoveMember(body) {
+  const { teamId, teamSecret, ownerNodeId, nodeId } = body;
+  if (!nodeId) return json(400, { error: "Missing nodeId" });
+  const v = await verifyTeam(teamId, teamSecret, ownerNodeId);
+  if (v.error) return v.error;
+
+  // Find the key by alias pattern
+  const keyValue = `sk-tc-${nodeId.slice(0, 40)}`;
+  const res = await litellmFetch("/key/delete", "POST", { keys: [keyValue] });
+
+  if (!res.ok) {
+    console.error(`[ai/remove-member] LiteLLM error:`, res.data);
+    return json(502, { error: "Failed to delete LiteLLM key", detail: res.data });
+  }
+
+  console.log(`[ai/remove-member] Deleted key for ${nodeId.slice(0, 8)}`);
+  return json(200, { success: true });
+}
+
+/** POST /ai/keys — list all LiteLLM keys for this team */
+async function handleAiKeys(body) {
+  const { teamId, teamSecret } = body;
+  const v = await verifyTeam(teamId, teamSecret);
+  if (v.error) return v.error;
+
+  const litellmTeamId = `tc-${teamId}`;
+  const res = await litellmFetch(`/team/info?team_id=${litellmTeamId}`, "GET");
+
+  if (!res.ok) {
+    console.error(`[ai/keys] LiteLLM error:`, res.data);
+    return json(502, { error: "Failed to fetch team info", detail: res.data });
+  }
+
+  const keys = (res.data.keys || []).map((k) => ({
+    key: k.token ? `${k.token.slice(0, 10)}...` : "",
+    alias: k.key_alias || "",
+    spend: k.spend || 0,
+    created_at: k.created_at || "",
+  }));
+
+  return json(200, { teamId: litellmTeamId, keys });
+}
+
+/** POST /ai/usage — get team or individual spend and usage.
+ *  - Any member can query their own usage by passing their nodeId.
+ *  - Owner can query any member's usage or omit nodeId for team-wide view.
+ */
+async function handleAiUsage(body) {
+  const { teamId, teamSecret, nodeId, startDate, endDate } = body;
+  const v = await verifyTeam(teamId, teamSecret);
+  if (v.error) return v.error;
+
+  const litellmTeamId = `tc-${teamId}`;
+  const start = startDate || new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
+  const end = endDate || new Date().toISOString().slice(0, 10);
+
+  // If nodeId is provided, query individual key spend
+  if (nodeId) {
+    const keyValue = `sk-tc-${nodeId.slice(0, 40)}`;
+    const keyRes = await litellmFetch(
+      `/key/info`,
+      "POST",
+      { key: keyValue }
+    );
+
+    if (!keyRes.ok) {
+      console.error(`[ai/usage] LiteLLM key/info error:`, keyRes.data);
+      return json(502, { error: "Failed to fetch key info", detail: keyRes.data });
+    }
+
+    const info = keyRes.data.info || keyRes.data;
+    return json(200, {
+      teamId: litellmTeamId,
+      nodeId,
+      startDate: start,
+      endDate: end,
+      spend: info.spend || 0,
+      maxBudget: info.max_budget || null,
+      keyAlias: info.key_alias || "",
+    });
+  }
+
+  // Team-wide usage (all members)
+  // First get all keys for the team to show per-member breakdown
+  const teamRes = await litellmFetch(`/team/info?team_id=${litellmTeamId}`, "GET");
+
+  const members = [];
+  let totalSpend = 0;
+  if (teamRes.ok) {
+    for (const k of teamRes.data.keys || []) {
+      const spend = k.spend || 0;
+      totalSpend += spend;
+      members.push({
+        alias: k.key_alias || "",
+        spend,
+      });
+    }
+  }
+
+  return json(200, {
+    teamId: litellmTeamId,
+    startDate: start,
+    endDate: end,
+    totalSpend,
+    members,
+  });
+}
+
+/** POST /ai/budget — set team budget (owner only) */
+async function handleAiBudget(body) {
+  const { teamId, teamSecret, ownerNodeId, maxBudget } = body;
+  const v = await verifyTeam(teamId, teamSecret, ownerNodeId);
+  if (v.error) return v.error;
+
+  if (maxBudget === undefined || maxBudget === null) {
+    return json(400, { error: "Missing maxBudget" });
+  }
+
+  const litellmTeamId = `tc-${teamId}`;
+  const res = await litellmFetch("/team/update", "POST", {
+    team_id: litellmTeamId,
+    max_budget: Number(maxBudget),
+  });
+
+  if (!res.ok) {
+    console.error(`[ai/budget] LiteLLM error:`, res.data);
+    return json(502, { error: "Failed to update budget", detail: res.data });
+  }
+
+  console.log(`[ai/budget] Set budget $${maxBudget} for team ${litellmTeamId}`);
+  return json(200, { success: true, maxBudget: Number(maxBudget) });
+}
+
+// ---------------------------------------------------------------------------
 // FC HTTP handler
 // ---------------------------------------------------------------------------
 export async function handler(event, context) {
@@ -385,6 +616,18 @@ export async function handler(event, context) {
         return await handleResetSecret(body);
       case "/apply":
         return await handleApply(body);
+      case "/ai/setup-team":
+        return await handleAiSetupTeam(body);
+      case "/ai/add-member":
+        return await handleAiAddMember(body);
+      case "/ai/remove-member":
+        return await handleAiRemoveMember(body);
+      case "/ai/keys":
+        return await handleAiKeys(body);
+      case "/ai/usage":
+        return await handleAiUsage(body);
+      case "/ai/budget":
+        return await handleAiBudget(body);
       default:
         return json(404, { error: "Not found" });
     }

--- a/packages/app/src/lib/skills/ai-keys/SKILL.md
+++ b/packages/app/src/lib/skills/ai-keys/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: ai-keys
+description: List all AI API keys for the current team. Shows key aliases, masked key values, and spend per key. Use when a team member asks about their API key or wants to see who has access.
+---
+
+# AI Keys
+
+List all AI API keys for the current team via the FC `/ai/keys` endpoint.
+
+## Prerequisites
+
+- Must be in an active OSS team (team_id and team_secret available in local config)
+- Team must have been set up with LiteLLM (`/ai/setup-team` called during team creation)
+
+## Usage
+
+Read the team config from `.teamclaw/teamclaw.json` to get `oss.team_id` and `oss.team_endpoint`, then load the team secret from the system keyring.
+
+```bash
+# Read team config
+TEAM_ID=$(cat .teamclaw/teamclaw.json | jq -r '.oss.team_id')
+TEAM_ENDPOINT=$(cat .teamclaw/teamclaw.json | jq -r '.oss.team_endpoint')
+
+# The team secret is stored in the system keyring under service "teamclaw-team" account "{team_id}"
+# It should be retrieved programmatically by the client
+
+curl -s -X POST "${TEAM_ENDPOINT}/ai/keys" \
+  -H "Content-Type: application/json" \
+  -d "{\"teamId\": \"${TEAM_ID}\", \"teamSecret\": \"${TEAM_SECRET}\"}"
+```
+
+## Response Format
+
+```json
+{
+  "teamId": "tc-abc123",
+  "keys": [
+    {
+      "key": "sk-tc-abcd...",
+      "alias": "alice-abcdef01",
+      "spend": 0.0387,
+      "created_at": "2026-03-25T12:00:00Z"
+    }
+  ]
+}
+```
+
+## Output
+
+Present the keys in a readable table format:
+
+| Member | Key (masked) | Spend |
+|--------|-------------|-------|
+| alias  | sk-tc-xxxx... | $0.04 |

--- a/packages/app/src/lib/skills/ai-manage/SKILL.md
+++ b/packages/app/src/lib/skills/ai-manage/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ai-manage
+description: Manage AI API keys and budget for the current team. Owner-only operations include adding/removing member keys and setting budget limits. Use when the team owner wants to manage AI access.
+---
+
+# AI Manage
+
+Manage AI API keys and team budget via FC endpoints. Most operations require team owner permissions.
+
+## Prerequisites
+
+- Must be in an active OSS team
+- Team must have been set up with LiteLLM
+- Owner operations require the owner's node_id
+
+## Operations
+
+### Add a member's API key
+
+Creates a LiteLLM API key for a team member using their node_id. This is normally done automatically when a member joins, but can be triggered manually.
+
+```bash
+TEAM_ID=$(cat .teamclaw/teamclaw.json | jq -r '.oss.team_id')
+TEAM_ENDPOINT=$(cat .teamclaw/teamclaw.json | jq -r '.oss.team_endpoint')
+
+curl -s -X POST "${TEAM_ENDPOINT}/ai/add-member" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"teamId\": \"${TEAM_ID}\",
+    \"teamSecret\": \"${TEAM_SECRET}\",
+    \"nodeId\": \"<member-node-id>\",
+    \"memberName\": \"Alice\"
+  }"
+```
+
+Returns: `{ "success": true, "key": "sk-tc-...", "keyAlias": "Alice-abcdef01" }`
+
+### Remove a member's API key (owner only)
+
+```bash
+curl -s -X POST "${TEAM_ENDPOINT}/ai/remove-member" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"teamId\": \"${TEAM_ID}\",
+    \"teamSecret\": \"${TEAM_SECRET}\",
+    \"ownerNodeId\": \"<owner-node-id>\",
+    \"nodeId\": \"<member-node-id>\"
+  }"
+```
+
+### Set team budget (owner only)
+
+Sets a maximum budget in USD for the team. Once reached, all API calls will be rejected.
+
+```bash
+curl -s -X POST "${TEAM_ENDPOINT}/ai/budget" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"teamId\": \"${TEAM_ID}\",
+    \"teamSecret\": \"${TEAM_SECRET}\",
+    \"ownerNodeId\": \"<owner-node-id>\",
+    \"maxBudget\": 50
+  }"
+```
+
+Returns: `{ "success": true, "maxBudget": 50 }`
+
+## Notes
+
+- The member's API key format is `sk-tc-{first 40 chars of node_id}`
+- The LiteLLM team ID format is `tc-{teamId}`
+- Keys are automatically created during team join if `/ai/add-member` is called from the client
+- Budget is per-team, not per-member

--- a/packages/app/src/lib/skills/ai-usage/SKILL.md
+++ b/packages/app/src/lib/skills/ai-usage/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ai-usage
+description: Check AI usage and spend for the current team or individual member. Shows total spend, per-member breakdown, or personal usage. Use when someone asks about costs, budget, or how much has been used.
+---
+
+# AI Usage
+
+Query AI usage and spend via the FC `/ai/usage` endpoint.
+
+## Prerequisites
+
+- Must be in an active OSS team
+- Team must have been set up with LiteLLM
+
+## How to get parameters
+
+All parameters can be read from local config. The user does NOT need to provide anything manually.
+
+```bash
+TEAM_ID=$(cat .teamclaw/teamclaw.json | jq -r '.oss.team_id')
+TEAM_ENDPOINT=$(cat .teamclaw/teamclaw.json | jq -r '.oss.team_endpoint')
+# node_id is the local device's P2P identity, available via the Tauri command get_node_id
+# team_secret is in the system keyring under service "teamclaw-team" account "{team_id}"
+```
+
+## View your own usage
+
+Automatically includes the local `nodeId` so the user sees their own spend:
+
+```bash
+curl -s -X POST "${TEAM_ENDPOINT}/ai/usage" \
+  -H "Content-Type: application/json" \
+  -d "{\"teamId\": \"${TEAM_ID}\", \"teamSecret\": \"${TEAM_SECRET}\", \"nodeId\": \"${NODE_ID}\"}"
+```
+
+Response:
+```json
+{
+  "teamId": "tc-abc123",
+  "nodeId": "abcdef...",
+  "spend": 0.0387,
+  "maxBudget": null,
+  "keyAlias": "alice-abcdef01"
+}
+```
+
+## View team-wide usage (all members)
+
+Omit `nodeId` to get the full team breakdown:
+
+```bash
+curl -s -X POST "${TEAM_ENDPOINT}/ai/usage" \
+  -H "Content-Type: application/json" \
+  -d "{\"teamId\": \"${TEAM_ID}\", \"teamSecret\": \"${TEAM_SECRET}\"}"
+```
+
+Response:
+```json
+{
+  "teamId": "tc-abc123",
+  "totalSpend": 1.23,
+  "members": [
+    { "alias": "alice-abcdef01", "spend": 0.80 },
+    { "alias": "bob-12345678", "spend": 0.43 }
+  ]
+}
+```
+
+## Notes
+
+- Default time range is last 30 days. Add `startDate` / `endDate` (YYYY-MM-DD) to filter.
+- When the user asks "how much have I used", always pass their nodeId for personal view.
+- When the user asks "team usage" or "everyone's usage", omit nodeId for the team-wide view.

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -783,6 +783,18 @@ fn inherent_skills() -> Vec<InherentSkill> {
                 "../../../packages/app/src/lib/skills/using-superpowers/SKILL.md"
             ),
         },
+        InherentSkill {
+            dirname: "ai-keys",
+            content: include_str!("../../../packages/app/src/lib/skills/ai-keys/SKILL.md"),
+        },
+        InherentSkill {
+            dirname: "ai-usage",
+            content: include_str!("../../../packages/app/src/lib/skills/ai-usage/SKILL.md"),
+        },
+        InherentSkill {
+            dirname: "ai-manage",
+            content: include_str!("../../../packages/app/src/lib/skills/ai-manage/SKILL.md"),
+        },
     ]
 }
 

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -201,6 +201,44 @@ pub async fn oss_create_team(
 
     info!("OSS team created: {team_id}");
 
+    // Fire-and-forget: register team + owner key in LiteLLM via FC
+    {
+        let fc_endpoint = team_endpoint.clone();
+        let fc_team_id = team_id.clone();
+        let fc_team_secret = team_secret.clone();
+        let fc_team_name = team_name.clone();
+        let fc_node_id = node_id.clone();
+        let fc_owner_name = owner_name.clone();
+        tokio::spawn(async move {
+            let client = reqwest::Client::new();
+            // Setup team in LiteLLM
+            let setup_body = serde_json::json!({
+                "teamId": fc_team_id,
+                "teamSecret": fc_team_secret,
+                "teamName": fc_team_name,
+            });
+            match client.post(format!("{}/ai/setup-team", fc_endpoint))
+                .json(&setup_body).send().await
+            {
+                Ok(r) => tracing::info!("LiteLLM setup-team: status={}", r.status()),
+                Err(e) => tracing::warn!("LiteLLM setup-team failed: {e}"),
+            }
+            // Add owner key
+            let member_body = serde_json::json!({
+                "teamId": fc_team_id,
+                "teamSecret": fc_team_secret,
+                "nodeId": fc_node_id,
+                "memberName": fc_owner_name,
+            });
+            match client.post(format!("{}/ai/add-member", fc_endpoint))
+                .json(&member_body).send().await
+            {
+                Ok(r) => tracing::info!("LiteLLM add-member (owner): status={}", r.status()),
+                Err(e) => tracing::warn!("LiteLLM add-member (owner) failed: {e}"),
+            }
+        });
+    }
+
     Ok(OssTeamInfo {
         team_id,
         team_secret: Some(team_secret),
@@ -315,6 +353,28 @@ pub async fn oss_join_team(
     start_poll_loop(&state).await;
 
     info!("Joined OSS team: {team_id}");
+
+    // Fire-and-forget: create LiteLLM key for joining member via FC
+    {
+        let fc_endpoint = team_endpoint.clone();
+        let fc_team_id = team_id.clone();
+        let fc_team_secret = team_secret.clone();
+        let fc_node_id = node_id.clone();
+        tokio::spawn(async move {
+            let client = reqwest::Client::new();
+            let body = serde_json::json!({
+                "teamId": fc_team_id,
+                "teamSecret": fc_team_secret,
+                "nodeId": fc_node_id,
+            });
+            match client.post(format!("{}/ai/add-member", fc_endpoint))
+                .json(&body).send().await
+            {
+                Ok(r) => tracing::info!("LiteLLM add-member (join): status={}", r.status()),
+                Err(e) => tracing::warn!("LiteLLM add-member (join) failed: {e}"),
+            }
+        });
+    }
 
     Ok(OssJoinResult::Joined {
         info: OssTeamInfo {


### PR DESCRIPTION
## Summary

- Add 6 new FC endpoints (`/ai/setup-team`, `/ai/add-member`, `/ai/remove-member`, `/ai/keys`, `/ai/usage`, `/ai/budget`) to proxy LiteLLM management with team-level isolation
- Auto-register LiteLLM team + owner key on OSS team creation, member key on join (fire-and-forget)
- Add 3 built-in skills (`ai-keys`, `ai-usage`, `ai-manage`) so team members can query/manage AI access via natural language

## Architecture

```
User (skill) → teamclaw client → FC (index.mjs) → LiteLLM API
                                     ↓
                              master key only on FC side
                              team isolation via teamSecret auth
```

## Test plan

- [ ] Deploy FC and verify `/ai/setup-team` creates a LiteLLM team
- [ ] Verify `/ai/add-member` creates a key with nodeId
- [ ] Verify `/ai/keys` returns only the requesting team's keys
- [ ] Verify `/ai/usage` returns individual and team-wide spend
- [ ] Verify `/ai/budget` rejects non-owner requests
- [ ] Verify `oss_create_team` fire-and-forget call doesn't block on FC failure
- [ ] Verify skills are auto-provisioned in workspace `.opencode/skills/`

🤖 Generated with [Claude Code](https://claude.ai/code)