### PR TITLE
perf: cut release build time from ~20min to ~10min

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           - target: x86_64-apple-darwin
             opencode_asset: opencode-darwin-x64.zip
             opencode_binary: opencode-x86_64-apple-darwin
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge
     steps:
       - uses: actions/checkout@v4
 
@@ -171,6 +171,7 @@ jobs:
           UPDATER_GITHUB_TOKEN: ${{ secrets.UPDATER_GITHUB_TOKEN }}
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: sccache
+          CARGO_INCREMENTAL: "0"
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "TeamClaw ${{ github.ref_name }}"
@@ -297,6 +298,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: sccache
+          CARGO_INCREMENTAL: "0"
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "TeamClaw ${{ github.ref_name }}"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -134,6 +134,6 @@ wiremock = "0.5"
 [profile.release]
 # Use unwind so catch_unwind in email.rs and deps (e.g. html2md) work; abort would conflict.
 codegen-units = 16
-lto = "thin"
+lto = false
 opt-level = "s"
 strip = true


### PR DESCRIPTION
## Summary
- Switch macOS runners to `macos-latest-xlarge` (6-core M1 Max, free for public repos)
- Add `CARGO_INCREMENTAL=0` to sccache steps — incremental compilation and sccache conflict, this improves cache hit rate
- Disable LTO (`thin` → `false`) to reduce linker time; negligible binary impact for a desktop app

## Expected impact
| | Before | After |
|---|---|---|
| macOS tauri-action | ~17 min | ~8-9 min |
| Total wall time | ~20 min | ~10 min |

## Test Plan
- [ ] Trigger a release tag and verify build time reduction