### PR TITLE
fix: editor auto-save overwrite, OSS disconnect on settings, 429 retry storm

### DIFF
--- a/packages/app/src/components/editors/TiptapHtmlEditor.tsx
+++ b/packages/app/src/components/editors/TiptapHtmlEditor.tsx
@@ -37,6 +37,7 @@ export function TiptapHtmlEditor({
   const [currentContent, setCurrentContent] = useState(content);
   const [isProcessingImage, setIsProcessingImage] = useState(false);
   const previousContentRef = useRef(content);
+  const isProgrammaticUpdateRef = useRef(false);
 
   const extensions = useTiptapExtensions({ imageConfig: { inline: true, allowBase64: false } })
 
@@ -45,6 +46,7 @@ export function TiptapHtmlEditor({
     content,
     editable: !readOnly,
     onUpdate: ({ editor }) => {
+      if (isProgrammaticUpdateRef.current) return;
       const html = editor.getHTML();
       setCurrentContent(html);
       onChange?.(html);
@@ -62,7 +64,9 @@ export function TiptapHtmlEditor({
       previousContentRef.current = content;
       const editorHtml = editor.getHTML();
       if (editorHtml !== content) {
+        isProgrammaticUpdateRef.current = true;
         editor.commands.setContent(content);
+        isProgrammaticUpdateRef.current = false;
         setCurrentContent(content);
       }
     }

--- a/packages/app/src/components/editors/TiptapMarkdownEditor.tsx
+++ b/packages/app/src/components/editors/TiptapMarkdownEditor.tsx
@@ -70,6 +70,13 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
     const onChangeRef = useRef(onChange);
     onChangeRef.current = onChange;
 
+    // Guard flag: when true, suppress onUpdate → onChange to prevent
+    // programmatic setContent calls from being treated as user edits.
+    // Without this, the markdown round-trip (markdown → Tiptap DOM → markdown)
+    // produces slightly different output, which triggers isModified → auto-save
+    // → overwrites the file with serialized content even though the user never edited.
+    const isProgrammaticUpdateRef = useRef(false);
+
     const baseExtensions = useTiptapExtensions({
       imageConfig: { inline: false, allowBase64: true },
       extraExtensions: [
@@ -88,6 +95,10 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
       contentType: "markdown",
       editable: !readOnly,
       onUpdate: ({ editor }) => {
+        // Skip onChange for programmatic setContent calls (initial load, agent
+        // changes, external sync).  Only user-initiated edits should propagate.
+        if (isProgrammaticUpdateRef.current) return;
+
         // Get markdown content and convert asset URLs back to relative paths
         // Decorations (AgentHighlight) don't affect getMarkdown output
         const md = editor.getMarkdown();
@@ -122,7 +133,9 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
         // Resolve relative image paths to Tauri asset URLs
         const resolved = await resolveMarkdownImages(content, filePath);
         if (cancelled) return;
+        isProgrammaticUpdateRef.current = true;
         editor.commands.setContent(resolved, { contentType: "markdown" });
+        isProgrammaticUpdateRef.current = false;
         previousContentRef.current = content;
         setIsReady(true);
       };
@@ -152,7 +165,9 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
 
         // Resolve images and set content
         const resolved = await resolveMarkdownImages(newMarkdown, filePath);
+        isProgrammaticUpdateRef.current = true;
         editor.commands.setContent(resolved, { contentType: "markdown" });
+        isProgrammaticUpdateRef.current = false;
 
         // Update the tracked content reference
         previousContentRef.current = newMarkdown;
@@ -263,9 +278,11 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
             const scrollEl = editor.view.dom.closest(".overflow-auto");
             const savedScrollTop = scrollEl?.scrollTop ?? 0;
 
+            isProgrammaticUpdateRef.current = true;
             editor.commands.setContent(resolved, {
               contentType: "markdown",
             });
+            isProgrammaticUpdateRef.current = false;
 
             // Restore cursor position
             const maxPos = editor.state.doc.content.size;

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -125,7 +125,6 @@ export function TeamOSSConfig() {
     syncStatus,
     teamInfo,
     error,
-    initialize,
     createTeam,
     joinTeam,
     leaveTeam,
@@ -133,7 +132,6 @@ export function TeamOSSConfig() {
     loadSyncStatus,
     createSnapshot,
     cleanupUpdates,
-    cleanup,
     applyToTeam,
     pendingApplication,
     loadPendingApplication,
@@ -162,12 +160,10 @@ export function TeamOSSConfig() {
   const [showApplicationDialog, setShowApplicationDialog] = useState(false)
   const [applicationTeamName, setApplicationTeamName] = useState('')
 
-  useEffect(() => {
-    if (workspacePath) {
-      initialize(workspacePath)
-    }
-    return () => cleanup()
-  }, [workspacePath, initialize, cleanup])
+  // NOTE: Do NOT call initialize/cleanup here. The OSS sync lifecycle is
+  // managed at the app level by useOssSyncInit (in useAppInit.ts).
+  // Previously this component called cleanup() on unmount, which killed
+  // the OSS connection whenever the user switched away from the S3 tab.
 
   useEffect(() => {
     invoke<DeviceInfo>('get_device_info').then(setDeviceInfo).catch(() => {})

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -238,11 +238,19 @@ impl OssSyncManager {
                         "FC request to {path} rate-limited after {max_retries} retries"
                     ));
                 }
-                let delay_secs = 2u64.pow(attempt); // 2s, 4s, 8s
-                warn!(
-                    "FC request to {path} returned 429, retrying in {delay_secs}s (attempt {attempt}/{max_retries})"
-                );
-                tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                // Exponential backoff with jitter to avoid thundering herd
+                let base_delay_ms = 2000u64 * 2u64.pow(attempt - 1); // 2s, 4s, 8s
+                let jitter_ms = (std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .subsec_nanos() as u64) % 1000; // 0-999ms jitter
+                let delay_ms = base_delay_ms + jitter_ms;
+                if attempt == 1 {
+                    warn!(
+                        "FC request to {path} returned 429, will retry up to {max_retries} times with backoff"
+                    );
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                 continue;
             }
 


### PR DESCRIPTION
## Summary

- **Editor auto-save overwrite**: Tiptap editors fired `onUpdate` during programmatic `setContent`, causing markdown round-trip differences to trigger `isModified → auto-save`, overwriting agent changes or the original file. Added `isProgrammaticUpdateRef` guard to suppress `onChange` during programmatic updates (same pattern CodeMirror already uses).
- **OSS disconnect on settings open**: `TeamOSSConfig` called `cleanup()` on unmount, resetting all OSS state (`connected=false`, `configured=false`) when switching away from the S3 tab. Removed component-level lifecycle — OSS sync is managed at app level by `useOssSyncInit`.
- **429 retry storm**: Concurrent FC requests hitting rate limits retried at the exact same time (no jitter), causing thundering herd. Added random jitter (0-999ms) to exponential backoff and reduced log noise to a single warn on first 429.

## Test plan

- [ ] Open a markdown file in editor, verify no auto-save triggers without user edits
- [ ] Have agent modify an open file, verify changes are not overwritten
- [ ] Open Settings → Team while OSS is connected, verify connection stays green
- [ ] Switch between P2P and S3 tabs, verify OSS doesn't disconnect
- [ ] Trigger 429 rate limit scenario, verify logs show single warn + jittered retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)