### PR TITLE
fix: workspace switch UI reset & team tab race condition

### DIFF
--- a/fc/s.yaml
+++ b/fc/s.yaml
@@ -21,6 +21,8 @@ resources:
         BUCKET: teamclaw-team
         REGION: cn-shenzhen
         ENDPOINT: https://oss-cn-shenzhen.aliyuncs.com
+        LITELLM_URL: ${env('LITELLM_URL')}
+        LITELLM_MASTER_KEY: ${env('LITELLM_MASTER_KEY')}
       triggers:
         - triggerName: http-trigger
           triggerType: http

--- a/packages/app/src/components/editors/TiptapHtmlEditor.tsx
+++ b/packages/app/src/components/editors/TiptapHtmlEditor.tsx
@@ -37,6 +37,7 @@ export function TiptapHtmlEditor({
   const [currentContent, setCurrentContent] = useState(content);
   const [isProcessingImage, setIsProcessingImage] = useState(false);
   const previousContentRef = useRef(content);
+  const isProgrammaticUpdateRef = useRef(false);
 
   const extensions = useTiptapExtensions({ imageConfig: { inline: true, allowBase64: false } })
 
@@ -45,6 +46,7 @@ export function TiptapHtmlEditor({
     content,
     editable: !readOnly,
     onUpdate: ({ editor }) => {
+      if (isProgrammaticUpdateRef.current) return;
       const html = editor.getHTML();
       setCurrentContent(html);
       onChange?.(html);
@@ -62,7 +64,9 @@ export function TiptapHtmlEditor({
       previousContentRef.current = content;
       const editorHtml = editor.getHTML();
       if (editorHtml !== content) {
+        isProgrammaticUpdateRef.current = true;
         editor.commands.setContent(content);
+        isProgrammaticUpdateRef.current = false;
         setCurrentContent(content);
       }
     }

--- a/packages/app/src/components/editors/TiptapMarkdownEditor.tsx
+++ b/packages/app/src/components/editors/TiptapMarkdownEditor.tsx
@@ -70,6 +70,13 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
     const onChangeRef = useRef(onChange);
     onChangeRef.current = onChange;
 
+    // Guard flag: when true, suppress onUpdate → onChange to prevent
+    // programmatic setContent calls from being treated as user edits.
+    // Without this, the markdown round-trip (markdown → Tiptap DOM → markdown)
+    // produces slightly different output, which triggers isModified → auto-save
+    // → overwrites the file with serialized content even though the user never edited.
+    const isProgrammaticUpdateRef = useRef(false);
+
     const baseExtensions = useTiptapExtensions({
       imageConfig: { inline: false, allowBase64: true },
       extraExtensions: [
@@ -88,6 +95,10 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
       contentType: "markdown",
       editable: !readOnly,
       onUpdate: ({ editor }) => {
+        // Skip onChange for programmatic setContent calls (initial load, agent
+        // changes, external sync).  Only user-initiated edits should propagate.
+        if (isProgrammaticUpdateRef.current) return;
+
         // Get markdown content and convert asset URLs back to relative paths
         // Decorations (AgentHighlight) don't affect getMarkdown output
         const md = editor.getMarkdown();
@@ -122,7 +133,9 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
         // Resolve relative image paths to Tauri asset URLs
         const resolved = await resolveMarkdownImages(content, filePath);
         if (cancelled) return;
+        isProgrammaticUpdateRef.current = true;
         editor.commands.setContent(resolved, { contentType: "markdown" });
+        isProgrammaticUpdateRef.current = false;
         previousContentRef.current = content;
         setIsReady(true);
       };
@@ -152,7 +165,9 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
 
         // Resolve images and set content
         const resolved = await resolveMarkdownImages(newMarkdown, filePath);
+        isProgrammaticUpdateRef.current = true;
         editor.commands.setContent(resolved, { contentType: "markdown" });
+        isProgrammaticUpdateRef.current = false;
 
         // Update the tracked content reference
         previousContentRef.current = newMarkdown;
@@ -263,9 +278,11 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
             const scrollEl = editor.view.dom.closest(".overflow-auto");
             const savedScrollTop = scrollEl?.scrollTop ?? 0;
 
+            isProgrammaticUpdateRef.current = true;
             editor.commands.setContent(resolved, {
               contentType: "markdown",
             });
+            isProgrammaticUpdateRef.current = false;
 
             // Restore cursor position
             const maxPos = editor.state.doc.content.size;

--- a/packages/app/src/components/settings/TeamSection.tsx
+++ b/packages/app/src/components/settings/TeamSection.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { invoke } from '@tauri-apps/api/core'
 import {
   Users,
 } from 'lucide-react'
@@ -8,7 +7,7 @@ import { cn } from '@/lib/utils'
 import { TeamP2PConfig } from './team/TeamP2PConfig'
 import { TeamOSSConfig } from './team/TeamOSSConfig'
 import { useTeamOssStore } from '@/stores/team-oss'
-import { useWorkspaceStore } from '@/stores/workspace'
+import { useTeamModeStore } from '@/stores/team-mode'
 
 // ─── Tab Switcher ────────────────────────────────────────────────────────────
 
@@ -87,22 +86,8 @@ function SectionHeader({
 function useActiveSyncMethod(): TeamTab | null {
   const ossConfigured = useTeamOssStore((s) => s.configured)
   const ossConnected = useTeamOssStore((s) => s.connected)
-  const [p2pConnected, setP2pConnected] = React.useState(false)
-  const [p2pConfigured, setP2pConfigured] = React.useState(false)
-  const workspacePath = useWorkspaceStore((s) => s.workspacePath)
-
-  React.useEffect(() => {
-    invoke<{ connected: boolean; namespaceId?: string | null }>('p2p_sync_status')
-      .then((s) => {
-        setP2pConnected(s?.connected ?? false)
-        // P2P is configured if it has a namespace (team was created/joined)
-        setP2pConfigured(!!s?.namespaceId)
-      })
-      .catch(() => {
-        setP2pConnected(false)
-        setP2pConfigured(false)
-      })
-  }, [workspacePath])
+  const p2pConnected = useTeamModeStore((s) => s.p2pConnected)
+  const p2pConfigured = useTeamModeStore((s) => s.p2pConfigured)
 
   // Prefer connected state, fall back to configured state
   if (p2pConnected) return 'p2p'

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -125,7 +125,6 @@ export function TeamOSSConfig() {
     syncStatus,
     teamInfo,
     error,
-    initialize,
     createTeam,
     joinTeam,
     leaveTeam,
@@ -133,7 +132,6 @@ export function TeamOSSConfig() {
     loadSyncStatus,
     createSnapshot,
     cleanupUpdates,
-    cleanup,
     applyToTeam,
     pendingApplication,
     loadPendingApplication,
@@ -162,12 +160,10 @@ export function TeamOSSConfig() {
   const [showApplicationDialog, setShowApplicationDialog] = useState(false)
   const [applicationTeamName, setApplicationTeamName] = useState('')
 
-  useEffect(() => {
-    if (workspacePath) {
-      initialize(workspacePath)
-    }
-    return () => cleanup()
-  }, [workspacePath, initialize, cleanup])
+  // NOTE: Do NOT call initialize/cleanup here. The OSS sync lifecycle is
+  // managed at the app level by useOssSyncInit (in useAppInit.ts).
+  // Previously this component called cleanup() on unmount, which killed
+  // the OSS connection whenever the user switched away from the S3 tab.
 
   useEffect(() => {
     invoke<DeviceInfo>('get_device_info').then(setDeviceInfo).catch(() => {})

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -25,6 +25,7 @@ interface TeamModeState {
   devUnlocked: boolean // hidden dev mode: unlocks model selector & hidden dirs in team mode
   myRole: 'owner' | 'editor' | 'viewer' | null
   p2pConnected: boolean
+  p2pConfigured: boolean
 
   loadTeamConfig: (workspacePath: string) => Promise<void>
   applyTeamModelToOpenCode: (workspacePath: string) => Promise<void>
@@ -64,6 +65,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   devUnlocked: false,
   myRole: null,
   p2pConnected: false,
+  p2pConfigured: false,
   teamApiKey: (() => {
     try {
       return localStorage.getItem(TEAM_API_KEY_STORAGE) || null
@@ -107,8 +109,8 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
       const { invoke } = await import('@tauri-apps/api/core')
       const role = await invoke<string | null>('unified_team_get_my_role')
       set({ myRole: role as any })
-      const syncStatus = await invoke<{ connected?: boolean }>('p2p_sync_status').catch(() => null)
-      set({ p2pConnected: syncStatus?.connected ?? false })
+      const syncStatus = await invoke<{ connected?: boolean; namespaceId?: string | null }>('p2p_sync_status').catch(() => null)
+      set({ p2pConnected: syncStatus?.connected ?? false, p2pConfigured: !!syncStatus?.namespaceId })
     } catch {
       // Non-critical, role can be loaded later
     }

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -269,10 +269,20 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       } catch { /* ignore */ }
     }
 
-    // Reset advancedMode to default until new workspace config is loaded
+    // Reset UI to home state: close settings, switch to task/chat mode, clear tabs
     try {
       const { useUIStore } = await import("./ui");
-      useUIStore.setState({ advancedMode: false });
+      useUIStore.setState({
+        advancedMode: false,
+        currentView: 'chat',
+        layoutMode: 'task',
+        settingsInitialSection: null,
+        embeddedSettingsSection: null,
+      });
+    } catch { /* ignore */ }
+    try {
+      const { useTabsStore } = await import("./tabs");
+      useTabsStore.getState().closeAll();
     } catch { /* ignore */ }
 
     // Reset team mode state — each workspace has its own team config
@@ -288,6 +298,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         _appliedConfigKey: null,
         myRole: null,
         p2pConnected: false,
+        p2pConfigured: false,
       });
       // Load team config immediately so sidebar shows team tag on startup
       useTeamModeStore.getState().loadTeamConfig(expandedPath).catch(() => {});

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -238,11 +238,19 @@ impl OssSyncManager {
                         "FC request to {path} rate-limited after {max_retries} retries"
                     ));
                 }
-                let delay_secs = 2u64.pow(attempt); // 2s, 4s, 8s
-                warn!(
-                    "FC request to {path} returned 429, retrying in {delay_secs}s (attempt {attempt}/{max_retries})"
-                );
-                tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                // Exponential backoff with jitter to avoid thundering herd
+                let base_delay_ms = 2000u64 * 2u64.pow(attempt - 1); // 2s, 4s, 8s
+                let jitter_ms = (std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .subsec_nanos() as u64) % 1000; // 0-999ms jitter
+                let delay_ms = base_delay_ms + jitter_ms;
+                if attempt == 1 {
+                    warn!(
+                        "FC request to {path} returned 429, will retry up to {max_retries} times with backoff"
+                    );
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                 continue;
             }
 

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -2568,24 +2568,16 @@ pub async fn p2p_sync_status(
 
     let config = read_p2p_config(&workspace_path)?.unwrap_or_default();
     let guard = iroh_state.lock().await;
-    let has_active_doc = guard.as_ref().map_or(false, |n| n.active_doc.is_some());
-    // Diagnostic: log active doc namespace vs config namespace
-    if let Some(node) = guard.as_ref() {
-        if let Some(doc) = &node.active_doc {
-            let active_ns = doc.id().to_string();
-            let config_ns = config.namespace_id.as_deref().unwrap_or("none");
-            eprintln!(
-                "[Team] Active doc namespace={}, config namespace={}",
-                &active_ns[..10.min(active_ns.len())],
-                &config_ns[..10.min(config_ns.len())]
-            );
-        } else {
-            eprintln!("[Team] WARNING: No active doc in sync_status check");
+    // connected = active doc exists AND its namespace matches this workspace's config
+    let connected = guard.as_ref().map_or(false, |n| {
+        match (&n.active_doc, config.namespace_id.as_deref()) {
+            (Some(doc), Some(config_ns)) => doc.id().to_string() == config_ns,
+            _ => false,
         }
-    }
+    });
 
     Ok(P2pSyncStatus {
-        connected: has_active_doc,
+        connected,
         role: config.role,
         doc_ticket: config.doc_ticket,
         namespace_id: config.namespace_id,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -902,13 +902,18 @@ pub fn run() {
                     }
                 }
                 tauri::RunEvent::Exit => {
+                    // Kill the OpenCode sidecar synchronously.
+                    // NOTE: Do NOT use tauri::async_runtime::block_on here — the
+                    // main thread already has a tokio runtime entered (_guard),
+                    // which causes block_on to deadlock or panic, preventing
+                    // std::process::exit from ever being called.
                     let oc_state = app.state::<commands::opencode::OpenCodeState>();
-                    if let Err(e) =
-                        tauri::async_runtime::block_on(commands::opencode::shutdown_opencode(
-                            oc_state.inner(),
-                        ))
-                    {
-                        eprintln!("[OpenCode] Failed to stop sidecar on app exit: {}", e);
+                    if let Ok(mut child_guard) = oc_state.child_process.lock() {
+                        if let Some(child) = child_guard.take() {
+                            if let Err(e) = child.kill() {
+                                eprintln!("[OpenCode] Failed to stop sidecar on app exit: {}", e);
+                            }
+                        }
                     }
                     let _ = app.track_event("app_exited", None);
                     app.flush_events_blocking();


### PR DESCRIPTION
## Summary
- **Workspace switch → home**: Switching workspaces now resets `currentView` to chat, `layoutMode` to task, closes all tabs and settings panels — prevents stale UI from previous workspace
- **Team tab race condition**: `useActiveSyncMethod` no longer uses async `useEffect` + local state for P2P status. Moved `p2pConfigured` into `useTeamModeStore`, so both P2P and OSS state come from stores synchronously
- **Backend p2p_sync_status fix**: `connected` now verifies the iroh active doc's namespace matches the current workspace's P2P config. Prevents workspace A's P2P node from making workspace B appear P2P-connected
- **Sidecar shutdown fix**: Replaced `block_on` with synchronous `child.kill()` to avoid tokio deadlock on app exit

## Test plan
- [ ] Switch from P2P workspace to S3 workspace → open Settings > Team → should show S3 tab
- [ ] Switch from S3 workspace to P2P workspace → open Settings > Team → should show P2P tab
- [ ] Switch workspace while on Settings page → should return to chat home
- [ ] Switch workspace while in file mode → should return to task mode
- [ ] Verify app exits cleanly without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)