### PR TITLE
feat(onboarding): main workspace tour and workspace prompt polish

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -80,6 +80,7 @@ import { SetupGuide } from "@/components/SetupGuide";
 import { TelemetryConsentDialog } from "@/components/telemetry/TelemetryConsentDialog";
 import { WorkspacePrompt } from "@/components/workspace";
 import { WorkspaceTypeDialog } from "@/components/workspace/WorkspaceTypeDialog";
+import { OnboardingTour, type OnboardingStep } from "@/components/onboarding";
 import { useSessionStore } from "@/stores/session";
 import { useUIStore } from "@/stores/ui";
 import { useWorkspaceStore } from "@/stores/workspace";
@@ -477,6 +478,56 @@ function AppContent() {
   ) : null;
   const needsTrafficLightSpacer = useNeedsTrafficLightSpacer();
   const [isRefreshingMessages, setIsRefreshingMessages] = useState(false);
+  const mainWorkspaceOnboardingSteps: OnboardingStep[] = [
+    {
+      target: '[data-onboarding-id="main-sidebar"]',
+      title: t("onboarding.main.sidebarTitle", "Session sidebar"),
+      description: t(
+        "onboarding.main.sidebarBody",
+        "Use the left sidebar to create a new chat, switch tasks, and find earlier conversations.",
+      ),
+    },
+    {
+      target: '[data-onboarding-id="main-chat-area"]',
+      title: t("onboarding.main.chatTitle", "Work from the chat center"),
+      description: t(
+        "onboarding.main.chatBody",
+        "Describe what you want in plain language here. Most tasks can start with a sentence instead of a command.",
+      ),
+    },
+    {
+      target: '[data-onboarding-id="workspace-panel-tabs"]',
+      title: t("onboarding.main.panelTitle", "Open the helper panels"),
+      description: t(
+        "onboarding.main.panelBody",
+        "This area opens tasks and helper panels. If advanced mode is enabled, file and change views will also appear here.",
+      ),
+    },
+    {
+      target: '[data-onboarding-id="chat-input-root"]',
+      title: t("onboarding.chatInput.inputTitle", "Describe the task here"),
+      description: t(
+        "onboarding.chatInput.inputBody",
+        "You can start with a plain sentence like asking for analysis, code changes, or a summary of the current project.",
+      ),
+    },
+    {
+      target: '[data-onboarding-id="chat-input-files"]',
+      title: t("onboarding.chatInput.filesTitle", "Attach files when useful"),
+      description: t(
+        "onboarding.chatInput.filesBody",
+        "Use this button to add files or screenshots so the assistant can work with concrete context.",
+      ),
+    },
+    {
+      target: '[data-onboarding-id="chat-input-submit"]',
+      title: t("onboarding.chatInput.submitTitle", "Send or stop here"),
+      description: t(
+        "onboarding.chatInput.submitBody",
+        "Send your request from here. If the assistant is already working, the same area lets you stop and retry.",
+      ),
+    },
+  ];
 
   // Extracted hooks — initialization, panel state, keyboard shortcuts
   const { openCodeError, setOpenCodeError, initialWorkspaceResolved } = useOpenCodeInit();
@@ -953,7 +1004,7 @@ function AppContent() {
             )}
 
             {/* Panel tabs - right side of header (Shortcuts lives in sidebar when workspace UI variant) */}
-            <div className="ml-auto flex shrink-0 items-center gap-0.5">
+            <div className="ml-auto flex shrink-0 items-center gap-0.5" data-onboarding-id="workspace-panel-tabs">
               {!isWorkspaceUIVariant() && (
                 <HeaderPanelTab
                   icon={Bookmark}
@@ -1004,7 +1055,10 @@ function AppContent() {
           </header>
 
           {/* Main content - Chat, file preview, or embedded settings section */}
-          <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div
+            className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
+            data-onboarding-id="main-chat-area"
+          >
             {embeddedSettingsSection ? (
               <SettingsSectionBody section={embeddedSettingsSection} />
             ) : (
@@ -1030,6 +1084,14 @@ function AppContent() {
         </div>
       </SidebarInset>
       <VoiceInputFloatingButton />
+      <OnboardingTour
+        id="main-workspace"
+        enabled={
+          !!workspacePath &&
+          !embeddedSettingsSection
+        }
+        steps={mainWorkspaceOnboardingSteps}
+      />
       <WorkspaceTypeDialog
         open={isNewWorkspace}
         onSelectPersonal={() => setIsNewWorkspace(false)}

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -591,22 +591,23 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
   return (
     <Sidebar variant="floating" {...props}>
-      {/* Header: custom traffic lights (Tauri) or spacer + icon group */}
-      <SidebarHeader 
-        className="flex-row items-center px-2 pt-1 pb-2"
-        data-tauri-drag-region
-      >
-        <TrafficLights />
-        {/* Flexible drag region */}
-        <div className="flex-1" data-tauri-drag-region />
-        {/* Icon group: workspace shell keeps only collapse in the header */}
-        {isWorkspaceUIVariant() ? <SidebarCollapseToggle /> : <SidebarIconGroup />}
-      </SidebarHeader>
+      <div className="flex h-full flex-col rounded-lg" data-onboarding-id="main-sidebar">
+        {/* Header: custom traffic lights (Tauri) or spacer + icon group */}
+        <SidebarHeader 
+          className="flex-row items-center px-2 pt-1 pb-2"
+          data-tauri-drag-region
+        >
+          <TrafficLights />
+          {/* Flexible drag region */}
+          <div className="flex-1" data-tauri-drag-region />
+          {/* Icon group: workspace shell keeps only collapse in the header */}
+          {isWorkspaceUIVariant() ? <SidebarCollapseToggle /> : <SidebarIconGroup />}
+        </SidebarHeader>
 
-      <SidebarContent>
-        {isWorkspaceUIVariant() && (
-          <div className="px-1.5 pb-0 pt-0">
-            <div className="flex flex-col gap-0.5">
+        <SidebarContent>
+          {isWorkspaceUIVariant() && (
+            <div className="px-1.5 pb-0 pt-0">
+              <div className="flex flex-col gap-0.5">
               <Button
                 variant="ghost"
                 size="sm"
@@ -651,10 +652,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               aria-hidden
             />
           </div>
-        )}
-        <SidebarGroup
-          className={cn(isWorkspaceUIVariant() && "!px-1 !pb-2 !pt-1")}
-        >
+          )}
+          <SidebarGroup
+            className={cn(isWorkspaceUIVariant() && "!px-1 !pb-2 !pt-1")}
+          >
           {isWorkspaceUIVariant() && (
             <div className="flex w-full shrink-0 flex-col pb-3 pt-0.5">
               <SidebarSecondarySessionActions
@@ -796,22 +797,23 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               </Button>
             </div>
           )}
-        </SidebarGroup>
-      </SidebarContent>
+          </SidebarGroup>
+        </SidebarContent>
 
-      <SidebarFooter className="px-3 py-3">
-        <div className="flex items-center justify-between">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
-            onClick={() => openSettings()}
-          >
-            {t('sidebar.settings', '设置')}
-          </Button>
-          <WorkspaceSelectorButton />
-        </div>
-      </SidebarFooter>
+        <SidebarFooter className="px-3 py-3">
+          <div className="flex items-center justify-between">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => openSettings()}
+            >
+              {t('sidebar.settings', '设置')}
+            </Button>
+            <WorkspaceSelectorButton />
+          </div>
+        </SidebarFooter>
+      </div>
     </Sidebar>
   )
 }

--- a/packages/app/src/components/chat/ChatInputArea.tsx
+++ b/packages/app/src/components/chat/ChatInputArea.tsx
@@ -266,6 +266,7 @@ export function ChatInputArea({
         )}
 
         <PromptInput
+          data-onboarding-id="chat-input-root"
           value={inputValue}
           onValueChange={onInputChange}
           onSubmit={handleSubmit}
@@ -381,7 +382,9 @@ export function ChatInputArea({
 
           <PromptInputFooter>
             <PromptInputTools>
-              <FileInputButton onFilesSelected={onFilesChange} />
+              <div data-onboarding-id="chat-input-files">
+                <FileInputButton onFilesSelected={onFilesChange} />
+              </div>
 
               {/* Voice input mic button */}
               {stt.isSupported && (
@@ -481,7 +484,7 @@ export function ChatInputArea({
               )}
             </PromptInputTools>
 
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2" data-onboarding-id="chat-input-submit">
               <ContextUsageBadge />
               <PromptInputSubmit
                 disabled={!inputValue.trim() && attachedFiles.length === 0 && imageFiles.length === 0}

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -532,6 +532,6 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
           </>
         }
       />
-                        </div>
+    </div>
   );
 }

--- a/packages/app/src/components/onboarding/OnboardingTour.tsx
+++ b/packages/app/src/components/onboarding/OnboardingTour.tsx
@@ -1,0 +1,195 @@
+import * as React from "react"
+import { createPortal } from "react-dom"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@/components/ui/button"
+import { markOnboardingCompleted, hasCompletedOnboarding } from "@/lib/onboarding"
+
+export interface OnboardingStep {
+  target: string
+  title: string
+  description: string
+}
+
+interface OnboardingTourProps {
+  id: string
+  steps: OnboardingStep[]
+  enabled: boolean
+  onFinish?: () => void
+}
+
+type SpotlightRect = {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+const PADDING = 4
+
+function getSpotlightRect(selector: string): SpotlightRect | null {
+  const element = document.querySelector<HTMLElement>(selector)
+  if (!element) return null
+
+  const rect = element.getBoundingClientRect()
+  if (rect.width <= 0 || rect.height <= 0) return null
+
+  return {
+    top: Math.max(8, rect.top - PADDING),
+    left: Math.max(8, rect.left - PADDING),
+    width: rect.width + PADDING * 2,
+    height: rect.height + PADDING * 2,
+  }
+}
+
+export function OnboardingTour({ id, steps, enabled, onFinish }: OnboardingTourProps) {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = React.useState(false)
+  const [stepIndex, setStepIndex] = React.useState(0)
+  const [rect, setRect] = React.useState<SpotlightRect | null>(null)
+  const [mounted, setMounted] = React.useState(false)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  React.useEffect(() => {
+    if (!enabled || steps.length === 0 || hasCompletedOnboarding(id)) return
+    setIsOpen(true)
+    setStepIndex(0)
+  }, [enabled, id, steps.length])
+
+  const finish = React.useCallback(() => {
+    markOnboardingCompleted(id)
+    setIsOpen(false)
+    onFinish?.()
+  }, [id, onFinish])
+
+  React.useEffect(() => {
+    if (!isOpen) return
+
+    const step = steps[stepIndex]
+    if (!step) return
+
+    const updateRect = () => {
+      const nextRect = getSpotlightRect(step.target)
+      setRect(nextRect)
+    }
+
+    const target = document.querySelector<HTMLElement>(step.target)
+    if (typeof target?.scrollIntoView === "function") {
+      target.scrollIntoView({ block: "nearest", inline: "nearest" })
+    }
+    updateRect()
+
+    window.addEventListener("resize", updateRect)
+    window.addEventListener("scroll", updateRect, true)
+
+    return () => {
+      window.removeEventListener("resize", updateRect)
+      window.removeEventListener("scroll", updateRect, true)
+    }
+  }, [isOpen, stepIndex, steps])
+
+  React.useEffect(() => {
+    if (!isOpen || rect) return
+    const timer = window.setTimeout(() => {
+      const step = steps[stepIndex]
+      if (!step) return
+      const fallbackRect = getSpotlightRect(step.target)
+      if (fallbackRect) {
+        setRect(fallbackRect)
+        return
+      }
+      if (stepIndex >= steps.length - 1) {
+        finish()
+      } else {
+        setStepIndex((current) => current + 1)
+      }
+    }, 150)
+
+    return () => window.clearTimeout(timer)
+  }, [finish, isOpen, rect, stepIndex, steps])
+
+  if (!mounted || !isOpen || !rect) return null
+
+  const step = steps[stepIndex]
+  if (!step) return null
+
+  const viewportWidth = window.innerWidth
+  const viewportHeight = window.innerHeight
+  const cardWidth = Math.min(360, viewportWidth - 32)
+  const roomOnRight = viewportWidth - (rect.left + rect.width)
+  const roomBelow = viewportHeight - (rect.top + rect.height)
+
+  let cardLeft = rect.left
+  let cardTop = rect.top + rect.height + 16
+
+  if (roomOnRight > cardWidth + 24) {
+    cardLeft = rect.left + rect.width + 16
+    cardTop = rect.top
+  } else if (roomBelow < 180) {
+    cardTop = Math.max(16, rect.top - 180)
+  }
+
+  cardLeft = Math.min(Math.max(16, cardLeft), viewportWidth - cardWidth - 16)
+  cardTop = Math.min(Math.max(16, cardTop), viewportHeight - 180)
+
+  return createPortal(
+    <div className="fixed inset-0 z-[300]">
+      <div className="absolute inset-0 bg-black/55" />
+      <div
+        className="absolute rounded-[20px] border border-white/70 bg-transparent shadow-[0_0_0_9999px_rgba(0,0,0,0.55)] transition-all duration-200 pointer-events-none"
+        style={{
+          top: rect.top,
+          left: rect.left,
+          width: rect.width,
+          height: rect.height,
+        }}
+      />
+
+      <div
+        className="absolute w-[min(360px,calc(100vw-2rem))] rounded-2xl border border-border bg-background p-4 shadow-2xl"
+        style={{ top: cardTop, left: cardLeft }}
+      >
+        <div className="mb-2 text-xs font-medium text-muted-foreground">
+          {stepIndex + 1} / {steps.length}
+        </div>
+        <h3 className="text-base font-semibold">{step.title}</h3>
+        <p className="mt-2 text-sm text-muted-foreground">{step.description}</p>
+
+        <div className="mt-4 flex items-center justify-between gap-2">
+          <Button variant="ghost" size="sm" onClick={finish}>
+            {t("onboarding.common.skip", "Skip")}
+          </Button>
+          <div className="flex items-center gap-2">
+            {stepIndex > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setStepIndex((current) => Math.max(0, current - 1))}
+              >
+                {t("onboarding.common.back", "Back")}
+              </Button>
+            )}
+            <Button
+              size="sm"
+              onClick={() => {
+                if (stepIndex >= steps.length - 1) {
+                  finish()
+                } else {
+                  setStepIndex((current) => current + 1)
+                }
+              }}
+            >
+              {stepIndex >= steps.length - 1
+                ? t("onboarding.common.done", "Done")
+                : t("onboarding.common.next", "Next")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/packages/app/src/components/onboarding/__tests__/OnboardingTour.test.tsx
+++ b/packages/app/src/components/onboarding/__tests__/OnboardingTour.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}))
+
+beforeEach(() => {
+  localStorage.clear()
+  document.body.innerHTML = ""
+})
+
+import { OnboardingTour } from "../OnboardingTour"
+
+describe("OnboardingTour", () => {
+  it("renders the first step when enabled", async () => {
+    const target = document.createElement("div")
+    target.setAttribute("data-onboarding-id", "target")
+    target.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        left: 100,
+        width: 200,
+        height: 80,
+        bottom: 180,
+        right: 300,
+        x: 100,
+        y: 100,
+        toJSON: () => ({}),
+      }) as DOMRect
+    document.body.appendChild(target)
+
+    render(
+      <OnboardingTour
+        id="main-workspace"
+        enabled
+        steps={[
+          {
+            target: '[data-onboarding-id="target"]',
+            title: "First step",
+            description: "Explain the page",
+          },
+        ]}
+      />,
+    )
+
+    expect(await screen.findByText("First step")).toBeTruthy()
+    expect(screen.getByText("Explain the page")).toBeTruthy()
+  })
+
+  it("marks the tour as completed when done", async () => {
+    const target = document.createElement("div")
+    target.setAttribute("data-onboarding-id", "target")
+    target.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        left: 100,
+        width: 200,
+        height: 80,
+        bottom: 180,
+        right: 300,
+        x: 100,
+        y: 100,
+        toJSON: () => ({}),
+      }) as DOMRect
+    document.body.appendChild(target)
+
+    render(
+      <OnboardingTour
+        id="main-workspace"
+        enabled
+        steps={[
+          {
+            target: '[data-onboarding-id="target"]',
+            title: "First step",
+            description: "Explain the page",
+          },
+        ]}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText("Done"))
+
+    expect(localStorage.getItem("teamclaw-onboarding-main-workspace")).toBe("done")
+  })
+
+  it("does not reopen after completion", () => {
+    localStorage.setItem("teamclaw-onboarding-main-workspace", "done")
+
+    const target = document.createElement("div")
+    target.setAttribute("data-onboarding-id", "target")
+    target.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        left: 100,
+        width: 200,
+        height: 80,
+        bottom: 180,
+        right: 300,
+        x: 100,
+        y: 100,
+        toJSON: () => ({}),
+      }) as DOMRect
+    document.body.appendChild(target)
+
+    render(
+      <OnboardingTour
+        id="main-workspace"
+        enabled
+        steps={[
+          {
+            target: '[data-onboarding-id="target"]',
+            title: "First step",
+            description: "Explain the page",
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.queryByText("First step")).toBeNull()
+  })
+})

--- a/packages/app/src/components/onboarding/index.ts
+++ b/packages/app/src/components/onboarding/index.ts
@@ -1,0 +1,2 @@
+export { OnboardingTour } from "./OnboardingTour"
+export type { OnboardingStep } from "./OnboardingTour"

--- a/packages/app/src/components/workspace/WorkspacePrompt.tsx
+++ b/packages/app/src/components/workspace/WorkspacePrompt.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { FolderOpen, FolderPlus, Globe } from "lucide-react"
+import { CheckCircle2, FolderOpen, FolderPlus, Globe, Sparkles } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -92,122 +92,201 @@ export function WorkspacePrompt() {
   // In web mode, show a simpler UI with path input
   if (isWebMode) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-6 p-8">
-        <div className="flex flex-col items-center gap-4 text-center">
-          <div className="rounded-full bg-muted p-4">
-            <Globe className="h-12 w-12 text-muted-foreground" />
+      <div className="flex h-full items-center justify-center bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),_transparent_35%),linear-gradient(180deg,rgba(255,255,255,0.96),rgba(248,250,252,0.98))] p-6">
+        <div className="w-full max-w-2xl overflow-hidden rounded-[28px] border border-border/60 bg-background/95 shadow-[0_24px_90px_rgba(15,23,42,0.16)] backdrop-blur">
+          <div className="border-b border-border/50 bg-[linear-gradient(135deg,rgba(59,130,246,0.14),rgba(16,185,129,0.06))] px-8 py-8">
+            <div className="flex flex-col items-center gap-4 text-center">
+              <div className="rounded-2xl border border-white/60 bg-background/90 p-4 shadow-sm">
+                <Globe className="h-10 w-10 text-foreground" />
+              </div>
+              <div className="space-y-2">
+                <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
+                  TeamClaw
+                </p>
+                <h2 className="text-2xl font-semibold">{t('workspace.webMode', 'Web Mode')}</h2>
+                <p className="mx-auto max-w-xl text-sm leading-6 text-muted-foreground">
+                  {t('workspace.webModeBody', 'Running in web mode. Enter a workspace path so TeamClaw knows where to read and write project files.')}
+                </p>
+              </div>
+            </div>
           </div>
-          <div className="space-y-2">
-            <h2 className="text-xl font-semibold">{t('workspace.webMode', 'Web Mode')}</h2>
-            <p className="max-w-md text-sm text-muted-foreground">
-              Running in web mode. Enter workspace path or use the default.
-            </p>
+
+          <div className="space-y-6 px-8 py-8">
+            <div className="space-y-3">
+              <label className="text-sm font-medium" htmlFor="workspace-path">
+                {t('workspace.enterPath', 'Enter workspace path')}
+              </label>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Input
+                  id="workspace-path"
+                  value={customPath}
+                  onChange={(e) => setCustomPath(e.target.value)}
+                  placeholder={t('workspace.enterPath', 'Enter workspace path')}
+                  className="h-12 flex-1 rounded-xl border-border/70 bg-background/80"
+                />
+                <Button
+                  onClick={handleSelectFolder}
+                  disabled={isLoadingWorkspace || !customPath.trim()}
+                  className="h-12 rounded-xl px-6"
+                >
+                  {isLoadingWorkspace ? t('common.loading', 'Loading...') : t('common.confirm', 'Confirm')}
+                </Button>
+              </div>
+            </div>
+
+            <div className="grid gap-3 rounded-2xl border border-border/60 bg-muted/30 p-4 text-sm text-muted-foreground sm:grid-cols-2">
+              <div className="flex items-start gap-3 rounded-xl bg-background/80 p-4">
+                <CheckCircle2 className="mt-0.5 h-4 w-4 text-emerald-600" />
+                <div>
+                  <p className="font-medium text-foreground">{t('workspace.webModeTipTitle', 'Recommended')}</p>
+                  <p className="mt-1 leading-5">
+                    {t('workspace.webModeTipBody', 'Use an absolute path for the smoothest setup, especially when the server runs in a different environment.')}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3 rounded-xl bg-background/80 p-4">
+                <Sparkles className="mt-0.5 h-4 w-4 text-sky-600" />
+                <div>
+                  <p className="font-medium text-foreground">{t('workspace.webModeAccessTitle', 'Access check')}</p>
+                  <p className="mt-1 leading-5">
+                    {t('workspace.webModeAccessBody', 'Make sure the OpenCode server has permission to access this directory before continuing.')}
+                  </p>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-        
-        <div className="flex w-full max-w-md gap-2">
-          <Input
-            value={customPath}
-            onChange={(e) => setCustomPath(e.target.value)}
-            placeholder={t('workspace.enterPath', 'Enter workspace path')}
-            className="flex-1"
-          />
-          <Button
-            onClick={handleSelectFolder}
-            disabled={isLoadingWorkspace || !customPath.trim()}
-          >
-            {isLoadingWorkspace ? t('common.loading', 'Loading...') : t('common.confirm', 'Confirm')}
-          </Button>
-        </div>
-        
-        <p className="text-xs text-muted-foreground">
-          Tip: Ensure OpenCode server has permission to access this directory
-        </p>
       </div>
     )
   }
 
   return (
-    <>
-      <div className="flex h-full flex-col items-center justify-center gap-6 p-8">
-        <div className="flex flex-col items-center gap-4 text-center">
-          <div className="rounded-full bg-muted p-4">
-            <FolderOpen className="h-12 w-12 text-muted-foreground" />
-          </div>
-          <div className="space-y-2">
-            <h2 className="text-xl font-semibold">{t('workspace.selectWorkspace', 'Select Workspace')}</h2>
-            <p className="max-w-md text-sm text-muted-foreground">
-              {t(
-                'workspace.startupPromptBody',
-                'Please choose an existing workspace or create a new one before continuing.',
-              )}
-            </p>
-          </div>
-        </div>
-      </div>
+    <Dialog open>
+      <DialogContent
+        showCloseButton={false}
+        className="overflow-hidden border-border/60 p-0 shadow-[0_28px_100px_rgba(15,23,42,0.28)] sm:max-w-3xl"
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <div className="bg-[radial-gradient(circle_at_top_left,_rgba(59,130,246,0.16),_transparent_34%),radial-gradient(circle_at_top_right,_rgba(16,185,129,0.10),_transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.98),rgba(248,250,252,0.98))]">
+          <div className="border-b border-border/50 px-8 py-8 sm:px-10">
+            <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+              <div className="max-w-xl space-y-3">
+                <div className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/85 px-3 py-1 text-xs font-medium text-muted-foreground shadow-sm">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  TeamClaw
+                </div>
+                <DialogHeader className="text-left">
+                  <DialogTitle className="text-2xl font-semibold tracking-tight">
+                    {t('workspace.startupPromptTitle', 'Choose a workspace to get started')}
+                  </DialogTitle>
+                  <DialogDescription className="max-w-xl text-sm leading-6 text-muted-foreground">
+                    {t(
+                      'workspace.startupPromptBody',
+                      'Please choose an existing workspace or create a new one before continuing.',
+                    )}
+                  </DialogDescription>
+                </DialogHeader>
+              </div>
 
-      <Dialog open>
-        <DialogContent
-          showCloseButton={false}
-          className="sm:max-w-md"
-          onPointerDownOutside={(e) => e.preventDefault()}
-          onEscapeKeyDown={(e) => e.preventDefault()}
-        >
-          <DialogHeader>
-            <DialogTitle>
-              {t('workspace.startupPromptTitle', 'Choose a workspace to get started')}
-            </DialogTitle>
-            <DialogDescription>
-              {t(
-                'workspace.startupPromptBody',
-                'Please choose an existing workspace or create a new one before continuing.',
-              )}
-            </DialogDescription>
-          </DialogHeader>
+              <div className="grid gap-3 rounded-2xl border border-border/60 bg-background/80 p-4 text-sm text-muted-foreground shadow-sm sm:w-[260px]">
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-emerald-600" />
+                  <div>
+                    <p className="font-medium text-foreground">{t('workspace.startupFeatureFast', 'Fast resume')}</p>
+                    <p className="mt-1 leading-5">
+                      {t('workspace.startupFeatureFastDesc', 'If your last workspace is still available, the app will reopen it automatically next time.')}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-sky-600" />
+                  <div>
+                    <p className="font-medium text-foreground">{t('workspace.startupFeatureSafe', 'Clear first step')}</p>
+                    <p className="mt-1 leading-5">
+                      {t('workspace.startupFeatureSafeDesc', 'Choose an existing folder if you already have a project, or create a clean workspace for a new one.')}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 
-          <div className="grid gap-3 sm:grid-cols-2">
-            <Button
-              size="lg"
+          <div className="grid gap-4 px-8 py-8 sm:grid-cols-2 sm:px-10">
+            <button
+              type="button"
               onClick={handleSelectFolder}
               disabled={isLoadingWorkspace}
-              className="h-auto min-h-24 flex-col items-start gap-2 px-4 py-4 text-left"
+              className="group rounded-[24px] border border-border/60 bg-background/90 p-6 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-lg disabled:pointer-events-none disabled:opacity-60"
             >
-              <span className="flex items-center gap-2">
-                <FolderOpen className="h-4 w-4" />
-                {t('workspace.selectFolder', 'Select Folder')}
-              </span>
-              <span className="text-xs font-normal opacity-80">
-                {t('workspace.selectExistingDesc', 'Open an existing project or directory.')}
-              </span>
-            </Button>
+              <div className="flex h-full flex-col gap-5">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="rounded-2xl bg-sky-50 p-3 text-sky-700 ring-1 ring-sky-100">
+                    <FolderOpen className="h-6 w-6" />
+                  </div>
+                  <span className="rounded-full border border-border/60 px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                    {t('workspace.recommended', 'Recommended')}
+                  </span>
+                </div>
 
-            <Button
-              size="lg"
-              variant="outline"
+                <div className="space-y-2">
+                  <h3 className="text-lg font-semibold text-foreground">
+                    {t('workspace.selectFolder', 'Select Folder')}
+                  </h3>
+                  <p className="text-sm leading-6 text-muted-foreground">
+                    {t('workspace.selectExistingDesc', 'Open an existing project or directory.')}
+                  </p>
+                </div>
+
+                <div className="mt-auto inline-flex items-center text-sm font-medium text-foreground">
+                  {isLoadingWorkspace ? t('common.loading', 'Loading...') : t('workspace.openExistingAction', 'Open existing workspace')}
+                </div>
+              </div>
+            </button>
+
+            <button
+              type="button"
               onClick={handleCreateWorkspace}
               disabled={isLoadingWorkspace}
-              className="h-auto min-h-24 flex-col items-start gap-2 px-4 py-4 text-left"
+              className="group rounded-[24px] border border-border/60 bg-[linear-gradient(180deg,rgba(248,250,252,0.98),rgba(255,255,255,0.98))] p-6 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-lg disabled:pointer-events-none disabled:opacity-60"
             >
-              <span className="flex items-center gap-2">
-                <FolderPlus className="h-4 w-4" />
-                {t('workspace.createWorkspace', 'Create Workspace')}
-              </span>
-              <span className="text-xs font-normal text-muted-foreground">
-                {t('workspace.createWorkspaceDesc', 'Pick a path and create a new empty workspace.')}
-              </span>
-            </Button>
+              <div className="flex h-full flex-col gap-5">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="rounded-2xl bg-emerald-50 p-3 text-emerald-700 ring-1 ring-emerald-100">
+                    <FolderPlus className="h-6 w-6" />
+                  </div>
+                  <span className="rounded-full border border-border/60 px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                    {t('workspace.newProjectBadge', 'New')}
+                  </span>
+                </div>
+
+                <div className="space-y-2">
+                  <h3 className="text-lg font-semibold text-foreground">
+                    {t('workspace.createWorkspace', 'Create Workspace')}
+                  </h3>
+                  <p className="text-sm leading-6 text-muted-foreground">
+                    {t('workspace.createWorkspaceDesc', 'Pick a path and create a new empty workspace.')}
+                  </p>
+                </div>
+
+                <div className="mt-auto inline-flex items-center text-sm font-medium text-foreground">
+                  {t('workspace.createWorkspaceAction', 'Choose location and create')}
+                </div>
+              </div>
+            </button>
           </div>
 
-          <DialogFooter className="justify-start sm:justify-start">
-            <p className="text-xs text-muted-foreground">
+          <DialogFooter className="justify-start border-t border-border/50 bg-muted/20 px-8 py-4 sm:justify-start sm:px-10">
+            <p className="text-xs leading-5 text-muted-foreground">
               {t(
                 'workspace.startupPromptTip',
                 'If you already used TeamClaw before, the last available workspace will be opened automatically next time.',
               )}
             </p>
           </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+        </div>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/packages/app/src/lib/onboarding.ts
+++ b/packages/app/src/lib/onboarding.ts
@@ -1,0 +1,21 @@
+import { appShortName } from "@/lib/build-config"
+
+export function getOnboardingStorageKey(id: string): string {
+  return `${appShortName}-onboarding-${id}`
+}
+
+export function hasCompletedOnboarding(id: string): boolean {
+  try {
+    return localStorage.getItem(getOnboardingStorageKey(id)) === "done"
+  } catch {
+    return false
+  }
+}
+
+export function markOnboardingCompleted(id: string): void {
+  try {
+    localStorage.setItem(getOnboardingStorageKey(id), "done")
+  } catch {
+    // ignore storage errors
+  }
+}

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -86,6 +86,30 @@
     "voiceInputNoSession": "Please select or create a session first",
     "voiceInputInsertToChat": "Insert to chat"
   },
+  "onboarding": {
+    "common": {
+      "skip": "Skip",
+      "back": "Back",
+      "next": "Next",
+      "done": "Done"
+    },
+    "main": {
+      "sidebarTitle": "Session sidebar",
+      "sidebarBody": "Use the left sidebar to create a new chat, switch tasks, and find earlier conversations.",
+      "chatTitle": "Work from the chat center",
+      "chatBody": "Most tasks can start here with plain language, not a detailed command.",
+      "panelTitle": "Open the helper panels",
+      "panelBody": "This area opens tasks and helper panels. If advanced mode is enabled, file and change views will also appear here."
+    },
+    "chatInput": {
+      "inputTitle": "Describe the task here",
+      "inputBody": "You can start with a plain sentence like asking for analysis, code changes, or a summary of the current project.",
+      "filesTitle": "Attach files when useful",
+      "filesBody": "Use this button to add files or screenshots so the assistant can work with concrete context.",
+      "submitTitle": "Send or stop here",
+      "submitBody": "Send your request from here. If the assistant is already working, the same area lets you stop and retry."
+    }
+  },
   "workspace": {
     "title": "Workspace",
     "openFolder": "Open Folder",
@@ -101,8 +125,21 @@
     "startupPromptTitle": "Choose a workspace to get started",
     "startupPromptBody": "Please choose an existing workspace or create a new one before continuing.",
     "startupPromptTip": "If your last workspace still exists, TeamClaw will open it automatically next time.",
+    "startupFeatureFast": "Fast resume",
+    "startupFeatureFastDesc": "If your last workspace is still available, the app will reopen it automatically next time.",
+    "startupFeatureSafe": "Clear first step",
+    "startupFeatureSafeDesc": "Choose an existing folder if you already have a project, or create a clean workspace for a new one.",
     "selectExistingDesc": "Open an existing project or directory.",
+    "recommended": "Recommended",
+    "openExistingAction": "Open existing workspace",
+    "newProjectBadge": "New",
+    "createWorkspaceAction": "Choose location and create",
     "webMode": "Web Mode",
+    "webModeBody": "Running in web mode. Enter a workspace path so TeamClaw knows where to read and write project files.",
+    "webModeTipTitle": "Recommended",
+    "webModeTipBody": "Use an absolute path for the smoothest setup, especially when the server runs in a different environment.",
+    "webModeAccessTitle": "Access check",
+    "webModeAccessBody": "Make sure the OpenCode server has permission to access this directory before continuing.",
     "enterPath": "Enter workspace path",
     "clickToSelect": "Click to select a folder",
     "selectFolder": "Select Folder",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -86,6 +86,30 @@
     "voiceInputNoSession": "请先选择或创建会话",
     "voiceInputInsertToChat": "插入到聊天"
   },
+  "onboarding": {
+    "common": {
+      "skip": "跳过",
+      "back": "上一步",
+      "next": "下一步",
+      "done": "完成"
+    },
+    "main": {
+      "sidebarTitle": "会话侧栏",
+      "sidebarBody": "左侧可以新建会话、切换任务，并快速找到之前的对话。",
+      "chatTitle": "从中间聊天区开始",
+      "chatBody": "大多数任务直接用自然语言描述就可以开始，不需要先写复杂命令。",
+      "panelTitle": "打开辅助面板",
+      "panelBody": "这里可以展开任务和辅助面板；开启高级模式后，还会看到文件和变更视图。"
+    },
+    "chatInput": {
+      "inputTitle": "先在这里描述任务",
+      "inputBody": "直接写自然语言即可，比如让它分析项目、修改代码，或总结当前问题。",
+      "filesTitle": "需要时附带文件",
+      "filesBody": "可以从这里附加文件或截图，让助手基于更具体的上下文工作。",
+      "submitTitle": "从这里发送或中断",
+      "submitBody": "这里负责发送请求；当助手正在处理中时，也可以在同一区域停止并重试。"
+    }
+  },
   "workspace": {
     "title": "工作区",
     "openFolder": "打开文件夹",
@@ -102,8 +126,21 @@
     "startupPromptTitle": "选择一个工作区开始使用",
     "startupPromptBody": "启动前需要先选择一个已有工作区，或创建一个新的工作区。",
     "startupPromptTip": "如果上一次使用的工作区仍然存在，下次启动会自动直接进入。",
+    "startupFeatureFast": "快速恢复",
+    "startupFeatureFastDesc": "如果上一次使用的工作区仍然可用，下次启动时会自动直接进入。",
+    "startupFeatureSafe": "更清晰的开始方式",
+    "startupFeatureSafeDesc": "已有项目就选择现有文件夹；准备新项目就创建一个全新的工作区。",
     "selectExistingDesc": "打开一个已有项目或目录。",
+    "recommended": "推荐",
+    "openExistingAction": "打开已有工作区",
+    "newProjectBadge": "新建",
+    "createWorkspaceAction": "选择位置并创建",
     "webMode": "Web 模式",
+    "webModeBody": "当前运行在 Web 模式下，请输入一个工作区路径，TeamClaw 才能知道要在哪里读取和写入项目文件。",
+    "webModeTipTitle": "推荐方式",
+    "webModeTipBody": "尽量使用绝对路径，尤其是在服务端和当前环境不完全一致时会更稳定。",
+    "webModeAccessTitle": "访问检查",
+    "webModeAccessBody": "继续之前，请确认 OpenCode server 对这个目录有访问权限。",
     "enterPath": "输入工作区路径",
     "clickToSelect": "点击选择文件夹",
     "typeDialog": {


### PR DESCRIPTION
## Summary

Follow-up to the merged workspace-first flow: adds a guided tour for the main workspace layout and polishes the workspace selection screens.

## Changes

- **OnboardingTour**: Spotlight-style steps for session sidebar, main chat area, header panel tabs, and chat input (attach files + submit). Completion is persisted via `localStorage` (`packages/app/src/lib/onboarding.ts`).
- **Anchors**: `data-onboarding-id` on sidebar wrapper, chat region, panel tabs, and `ChatInputArea` (root, files, submit).
- **WorkspacePrompt**: Visual refresh for Tauri (modal) and web (card layout); additional EN/zh-CN strings for tips and actions.
- **Tests**: `OnboardingTour.test.tsx`; minor `ChatPanel` markup indentation fix.

## How to test

1. Clear onboarding key in devtools: `localStorage` keys prefixed per `onboarding.ts`, then open app with a workspace selected — tour should appear.
2. Complete or skip tour; reload — should not show again until storage cleared.
3. Empty workspace: prompt UI should match new layout; create/select flows unchanged in behavior.


Made with [Cursor](https://cursor.com)