### PR TITLE
fix(ci): use available macOS runners for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,18 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: aarch64-apple-darwin
             opencode_asset: opencode-darwin-arm64.zip
             opencode_binary: opencode-aarch64-apple-darwin
+            runner: macos-latest
           - target: x86_64-apple-darwin
             opencode_asset: opencode-darwin-x64.zip
             opencode_binary: opencode-x86_64-apple-darwin
-    runs-on: macos-latest-xlarge
+            runner: macos-13
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- `macos-latest-xlarge` runner fails to provision (runner_id: 0, fails in 2s), blocking v0.1.22 macOS builds
- Switch to per-target runners: `macos-latest` (ARM64) and `macos-13` (x86_64)
- Add `fail-fast: false` to prevent cascade cancellation when one target fails

## Test plan
- [ ] Merge and re-tag v0.1.22 to trigger new release build
- [ ] Verify both macOS builds succeed with new runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)