### PR TITLE
fix(ci): use macos-latest for x86_64 cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           - target: x86_64-apple-darwin
             opencode_asset: opencode-darwin-x64.zip
             opencode_binary: opencode-x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- `macos-13` runner also fails to provision (runner_id: 0)
- Use `macos-latest` for both macOS targets — Rust handles x86_64 cross-compilation via `--target`

## Context
v0.1.22 release now has Windows + macOS ARM64 artifacts. This fix enables the x86_64 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)