### PR TITLE
fix(sync): absorb local-only files into Loro instead of deleting

### DIFF
--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -666,13 +666,40 @@ impl OssSyncManager {
             }
         }
 
-        // Remove files on disk that are not in the LoroDoc
+        // Absorb files on disk that are not yet in the LoroDoc (e.g. copied
+        // via Finder while the app was closed or between sync cycles).
         if dir.exists() {
             let disk_files = Self::scan_local_files(&dir)?;
-            for path in disk_files.keys() {
+            let now = Utc::now().to_rfc3339();
+            let node_id = &self.node_id;
+
+            for (path, content) in &disk_files {
                 if !doc_files.contains(path) {
-                    let file_path = dir.join(path);
-                    let _ = std::fs::remove_file(&file_path);
+                    let hash = Self::compute_hash(content);
+                    let content_str = String::from_utf8_lossy(content).to_string();
+
+                    let entry_map = files_map
+                        .get_or_create_container(path, loro::LoroMap::new())
+                        .map_err(|e| {
+                            format!("Failed to create map entry for {path}: {e}")
+                        })?;
+                    entry_map
+                        .insert("content", content_str.as_str())
+                        .map_err(|e| format!("Failed to set content for {path}: {e}"))?;
+                    entry_map
+                        .insert("hash", hash.as_str())
+                        .map_err(|e| format!("Failed to set hash for {path}: {e}"))?;
+                    entry_map
+                        .insert("deleted", false)
+                        .map_err(|e| format!("Failed to set deleted for {path}: {e}"))?;
+                    entry_map
+                        .insert("updatedBy", node_id.as_str())
+                        .map_err(|e| format!("Failed to set updatedBy for {path}: {e}"))?;
+                    entry_map
+                        .insert("updatedAt", now.as_str())
+                        .map_err(|e| format!("Failed to set updatedAt for {path}: {e}"))?;
+
+                    info!("Absorbed local-only file into LoroDoc: {path}");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `write_doc_to_disk()` previously deleted any disk file not present in the Loro CRDT doc, causing data loss when files were added externally (e.g. via Finder) between sync cycles or while the app was closed
- Changed behavior: orphaned disk files are now absorbed into the Loro document, so they persist across restarts and sync to S3 on the next poll cycle

## Root cause
App exit has no final sync (`upload_local_changes` is never called on shutdown). Files copied to `teamclaw-team/skills/` via Finder exist only on disk. On restart, `oss_restore_sync` → `pull_remote_changes` → `write_doc_to_disk` would delete anything not in the Loro doc.

## Test plan
- [ ] Copy a folder into `teamclaw-team/skills/` via Finder while app is running
- [ ] Close and reopen the app
- [ ] Verify the copied folder persists after restart
- [ ] Verify the absorbed files sync to S3 on next poll cycle
- [ ] Verify normal team sync (remote changes from other members) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)