### PR TITLE
fix(oss): preserve locally added files on app restart

### DIFF
--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -439,11 +439,17 @@ pub async fn oss_restore_sync(
         serde_json::from_str(&format!("\"{}\"", resp.role)).unwrap_or(MemberRole::Editor);
     manager.set_role(role.clone());
 
-    // Restore from local snapshots, then pull remote
+    // Restore from local snapshots, then pull remote, then reconcile disk.
+    // write_doc_to_disk must always run so that files the user added while
+    // the app was closed are absorbed into the LoroDoc (even when there are
+    // no new remote keys and pull_remote_changes returns early).
     for doc_type in DocType::all() {
         let _ = manager.restore_from_local_snapshot(doc_type);
         if let Err(e) = manager.pull_remote_changes(doc_type).await {
             warn!("Restore pull for {:?} failed: {}", doc_type, e);
+        }
+        if let Err(e) = manager.write_doc_to_disk(doc_type) {
+            warn!("Restore write_doc_to_disk for {:?} failed: {}", doc_type, e);
         }
     }
 

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -535,14 +535,25 @@ impl OssSyncManager {
         for (path, content) in local_files {
             let local_hash = Self::compute_hash(content);
 
-            // Check if the file exists in the doc with the same hash
+            // Check if the file exists in the doc with the same hash.
+            // Also flag files that are marked deleted in the doc but exist
+            // locally — the user re-added them and we must flip deleted→false.
             let needs_update = match files_map.get(path) {
                 Some(loro::ValueOrContainer::Container(loro::Container::Map(entry_map))) => {
                     let deep = entry_map.get_deep_value();
                     if let loro::LoroValue::Map(entry) = deep {
-                        match entry.get("hash") {
-                            Some(loro::LoroValue::String(h)) => h.as_ref() != local_hash,
-                            _ => true,
+                        let is_deleted = matches!(
+                            entry.get("deleted"),
+                            Some(loro::LoroValue::Bool(true))
+                        );
+                        if is_deleted {
+                            // File on disk but doc says deleted → needs update
+                            true
+                        } else {
+                            match entry.get("hash") {
+                                Some(loro::LoroValue::String(h)) => h.as_ref() != local_hash,
+                                _ => true,
+                            }
                         }
                     } else {
                         true
@@ -617,7 +628,7 @@ impl OssSyncManager {
         Ok(result)
     }
 
-    fn write_doc_to_disk(&self, doc_type: DocType) -> Result<(), String> {
+    pub fn write_doc_to_disk(&self, doc_type: DocType) -> Result<(), String> {
         let doc = self.get_doc(doc_type);
         let dir = self.team_dir.join(doc_type.dir_name());
 
@@ -630,8 +641,6 @@ impl OssSyncManager {
         // Collect files that should exist on disk from the LoroDoc
         let mut doc_files: HashSet<String> = HashSet::new();
 
-        // TODO: The exact iteration API for LoroMap may differ. This uses a
-        // reasonable approach — adjust after verifying the loro v1 API.
         let map_value = files_map.get_deep_value();
         if let loro::LoroValue::Map(entries) = map_value {
             for (path, value) in entries.iter() {
@@ -642,10 +651,29 @@ impl OssSyncManager {
                     };
 
                     if deleted {
-                        // Remove file from disk if it exists
                         let file_path = dir.join(path.as_str());
                         if file_path.exists() {
-                            let _ = std::fs::remove_file(&file_path);
+                            // Only delete if the file on disk is unchanged
+                            // since the CRDT wrote it (hash matches).  If the
+                            // hash differs the user re-added or modified the
+                            // file locally — preserve it so the absorb phase
+                            // below can rescue it into the CRDT.
+                            let should_delete = match entry.get("hash") {
+                                Some(loro::LoroValue::String(doc_hash)) => {
+                                    match std::fs::read(&file_path) {
+                                        Ok(disk_content) => {
+                                            let disk_hash =
+                                                Self::compute_hash(&disk_content);
+                                            disk_hash == doc_hash.as_ref()
+                                        }
+                                        Err(_) => true,
+                                    }
+                                }
+                                _ => true,
+                            };
+                            if should_delete {
+                                let _ = std::fs::remove_file(&file_path);
+                            }
                         }
                     } else {
                         doc_files.insert(path.to_string());
@@ -668,6 +696,8 @@ impl OssSyncManager {
 
         // Absorb files on disk that are not yet in the LoroDoc (e.g. copied
         // via Finder while the app was closed or between sync cycles).
+        // This also catches files that the CRDT marks as deleted but
+        // which exist locally — they are re-absorbed with deleted=false.
         if dir.exists() {
             let disk_files = Self::scan_local_files(&dir)?;
             let now = Utc::now().to_rfc3339();


### PR DESCRIPTION
## Summary

- **write_doc_to_disk**: before deleting a file marked `deleted:true` in the CRDT, compare the disk file's hash against the CRDT hash — only delete if they match (old unchanged version). If the hash differs, the user re-added or modified the file, so preserve it for the absorb phase.
- **detect_local_changes**: also flag files that exist on disk but are `deleted:true` in the CRDT, ensuring `upload_local_changes` flips `deleted` back to `false` and uploads the re-added content.
- **oss_restore_sync**: explicitly call `write_doc_to_disk` after restore+pull, so local-only files are absorbed even when `pull_remote_changes` returns early (no new remote keys).

Fixes the issue where files added to the team folder in S3/OSS mode were deleted upon reopening the app if they hadn't been uploaded yet.

## Test plan

- [ ] Add a new file to `teamclaw-team/skills/` while the app is running (S3/OSS mode)
- [ ] Close the app before the poll interval (5 min) elapses
- [ ] Reopen the app — verify the file is still present and gets synced
- [ ] Verify remote teammate deletions still propagate correctly (unchanged files are deleted)
- [ ] Re-add a previously deleted file with different content — verify it is preserved
- [ ] Re-add a previously deleted file with identical content — verify `detect_local_changes` now flags it

🤖 Generated with [Claude Code](https://claude.ai/code)