### PR TITLE
Improve workspace chat UX and skill reload flow

### DIFF
--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { useTranslation } from "react-i18next"
-import { Search, SquarePen, MessageSquare, Loader2, Archive, PanelLeftIcon, FolderOpen, Users, Cloud, Pencil, Ellipsis, Clock, Sparkles, Bookmark } from "lucide-react"
+import { Search, SquarePen, MessageSquare, Loader2, Archive, PanelLeftIcon, FolderOpen, Users, Cloud, Pencil, Ellipsis, Clock, Sparkles, Bookmark, Settings } from "lucide-react"
 import { isWorkspaceUIVariant } from "@/lib/ui-variant"
 
 import { useSessionStore } from "@/stores/session"
@@ -590,8 +590,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   }
 
   return (
-    <Sidebar variant="floating" {...props}>
-      <div className="flex h-full flex-col rounded-lg" data-onboarding-id="main-sidebar">
+    <Sidebar variant="sidebar" {...props}>
+      <div className="flex h-full flex-col" data-onboarding-id="main-sidebar">
         {/* Header: custom traffic lights (Tauri) or spacer + icon group */}
         <SidebarHeader 
           className="flex-row items-center px-2 pt-1 pb-2"
@@ -805,9 +805,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+              className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground gap-1.5"
               onClick={() => openSettings()}
             >
+              <Settings className="h-3.5 w-3.5 shrink-0" />
               {t('sidebar.settings', '设置')}
             </Button>
             <WorkspaceSelectorButton />

--- a/packages/app/src/components/chat/MessageList.tsx
+++ b/packages/app/src/components/chat/MessageList.tsx
@@ -17,6 +17,7 @@ import { SAFE_BOTTOM_SPACING, NEAR_BOTTOM_THRESHOLD } from "./layout-constants";
 // The current virtualized path occasionally keeps stale row heights and causes
 // overlap, so we keep the stable non-virtualized path for normal conversations.
 const VIRTUAL_MSG_THRESHOLD = Number.MAX_SAFE_INTEGER;
+const SESSION_SWITCH_MIN_HOLD_MS = 90;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -367,11 +368,18 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
     // Reset scroll state when switching sessions
     const prevSessionIdRef = React.useRef(activeSessionId);
     const needsScrollAfterLoadRef = React.useRef(false);
+    const sessionSwitchStartedAtRef = React.useRef<number>(0);
+    const sessionSwitchRevealTimeoutRef = React.useRef<number | null>(null);
     React.useEffect(() => {
       if (activeSessionId !== prevSessionIdRef.current) {
         prevSessionIdRef.current = activeSessionId;
         userScrolledUpRef.current = false;
         setShowScrollButton(false);
+        if (sessionSwitchRevealTimeoutRef.current !== null) {
+          window.clearTimeout(sessionSwitchRevealTimeoutRef.current);
+          sessionSwitchRevealTimeoutRef.current = null;
+        }
+        sessionSwitchStartedAtRef.current = Date.now();
         setSessionSwitching(true);
         needsScrollAfterLoadRef.current = true;
       }
@@ -396,27 +404,48 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
       const wasLoading = prevLoadingRef.current;
       prevLoadingRef.current = isLoading;
 
-      const shouldScroll =
+      const shouldReveal =
         (wasLoading && !isLoading && needsScrollAfterLoadRef.current) ||
-        (!isLoading &&
-          messages.length > 0 &&
-          needsScrollAfterLoadRef.current);
+        (!isLoading && needsScrollAfterLoadRef.current);
 
-      if (shouldScroll && scrollRef.current) {
+      if (shouldReveal) {
         needsScrollAfterLoadRef.current = false;
         requestAnimationFrame(() => {
           requestAnimationFrame(() => {
-            if (scrollRef.current) {
-              scrollRef.current.scrollTo({
-                top: scrollRef.current.scrollHeight,
-                behavior: "instant",
-              });
+            const reveal = () => {
+              if (scrollRef.current) {
+                scrollRef.current.scrollTo({
+                  top: scrollRef.current.scrollHeight,
+                  behavior: "instant",
+                });
+              }
+              setSessionSwitching(false);
+            };
+
+            const elapsed = Date.now() - sessionSwitchStartedAtRef.current;
+            const remaining = Math.max(0, SESSION_SWITCH_MIN_HOLD_MS - elapsed);
+
+            if (remaining > 0) {
+              sessionSwitchRevealTimeoutRef.current = window.setTimeout(() => {
+                sessionSwitchRevealTimeoutRef.current = null;
+                reveal();
+              }, remaining);
+              return;
             }
-            setSessionSwitching(false);
+
+            reveal();
           });
         });
       }
     }, [isLoading, messages.length]);
+
+    React.useEffect(() => {
+      return () => {
+        if (sessionSwitchRevealTimeoutRef.current !== null) {
+          window.clearTimeout(sessionSwitchRevealTimeoutRef.current);
+        }
+      };
+    }, []);
 
     // Initial mount scroll
     const hasInitialScrolled = React.useRef(false);
@@ -494,8 +523,10 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
           ref={scrollRef}
           data-chat-messages
           className={cn(
-            "flex-1 overflow-y-auto overflow-x-hidden transition-opacity duration-0",
-            sessionSwitching ? "opacity-0" : "opacity-100",
+            "flex-1 overflow-y-auto overflow-x-hidden transition-all duration-200 ease-out motion-reduce:transition-none",
+            sessionSwitching
+              ? "translate-y-1 opacity-0"
+              : "translate-y-0 opacity-100",
           )}
         >
           <div


### PR DESCRIPTION
## Summary
- improve chat composer/message UX by rendering image attachments as previews, normalizing pasted attachment tokens, adding copy actions, and keeping quick suggestions in slash-skill chip format
- add skill file change detection + runtime restart prompts in chat/settings so new or updated skills are surfaced without silent stale runtime state
- polish workspace UI interactions with smoother session-switch reveal behavior and a flush left sidebar layout (including settings icon affordance)

## Test plan
- [ ] Open workspace UI and verify left sidebar is flush with container with no floating gap
- [ ] Switch sessions repeatedly and confirm message list reveal is smooth without flicker/overlap
- [ ] Paste attachment tokens containing image paths and verify preview chips render and text is cleaned
- [ ] Use copy action on both user and assistant messages and confirm clipboard + copied feedback
- [ ] Modify or install a skill, confirm restart prompt appears, and verify restart reloads runtime successfully

Made with [Cursor](https://cursor.com)