### PR TITLE
fix: wait for OpenCode sidecar ready before loading providers

### DIFF
--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -60,6 +60,7 @@ export const LLMSection = React.memo(function LLMSection() {
   const removeCustomProvider = useProviderStore((s) => s.removeCustomProvider)
   const disconnectProvider = useProviderStore((s) => s.disconnectProvider)
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
+  const openCodeReady = useWorkspaceStore((s) => s.openCodeReady)
 
   // Dialog state for connecting a provider
   const [connectDialogOpen, setConnectDialogOpen] = React.useState(false)
@@ -100,15 +101,16 @@ export const LLMSection = React.memo(function LLMSection() {
   // Detail view for connected provider
   const [selectedProviderId, setSelectedProviderId] = React.useState<string | null>(null)
 
-  // Load providers on mount
+  // Load providers on mount and when OpenCode becomes ready
   React.useEffect(() => {
+    if (!openCodeReady) return
     refreshProviders()
     refreshConfiguredProviders()
     refreshAuthMethods()
     if (workspacePath) {
       refreshCustomProviderIds(workspacePath)
     }
-  }, [])
+  }, [openCodeReady])
 
   // Restart OpenCode sidecar so newly connected providers take effect
   const restartOpenCodeAndRefresh = async () => {

--- a/packages/app/src/stores/provider.ts
+++ b/packages/app/src/stores/provider.ts
@@ -474,6 +474,21 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
       get().refreshCurrentModel(),
     ])
 
+    // Retry: sidecar may be healthy but provider registry not yet loaded.
+    // `/provider` always returns non-empty when providers are registered,
+    // so an empty list means the registry hasn't initialized yet.
+    if (get().providers.length === 0) {
+      const deadline = Date.now() + 5_000
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 500))
+        await Promise.all([
+          get().refreshProviders(),
+          get().refreshConfiguredProviders(),
+        ])
+        if (get().providers.length > 0) break
+      }
+    }
+
     // After loading, resolve selected model:
     // Priority: opencode config > localStorage > first available model
     const { currentModelKey, models } = get()


### PR DESCRIPTION
## Summary
- Gate LLMSection provider loading on `openCodeReady` state so we don't fetch before the sidecar is initialized
- Add retry loop (up to 5s, polling every 500ms) in `refreshProviders` when the provider registry returns an empty list

## Test plan
- [ ] Start app fresh, verify provider list loads correctly without showing empty state
- [ ] Verify no regression when providers are already available immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)