### PR TITLE
Add pinned sessions to sidebar with persistence

### DIFF
--- a/packages/app/src/components/__tests__/app-sidebar.test.tsx
+++ b/packages/app/src/components/__tests__/app-sidebar.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@/lib/utils', () => ({
 
 vi.mock('@/lib/date-format', () => ({
   formatSessionDate: (d: Date) => d.toISOString(),
+  formatRelativeTime: (d: Date) => d.toISOString(),
 }))
 
 // Mock stores
@@ -28,6 +29,7 @@ vi.mock('@/stores/session', () => ({
         { id: 's1', title: 'Session One', updatedAt: new Date('2025-01-01'), messages: [] },
         { id: 's2', title: 'Session Two', updatedAt: new Date('2025-01-02'), messages: [] },
       ],
+      pinnedSessionIds: ['s1'],
       activeSessionId: 's1',
       isLoading: false,
       isLoadingMore: false,
@@ -37,6 +39,7 @@ vi.mock('@/stores/session', () => ({
       setActiveSession: vi.fn(),
       archiveSession: vi.fn(),
       updateSessionTitle: vi.fn(),
+      toggleSessionPinned: vi.fn(),
       loadMoreSessions: vi.fn(),
       createSession: vi.fn(),
     }),
@@ -138,6 +141,23 @@ describe('AppSidebar', () => {
     render(<AppSidebar />)
     expect(screen.getByText('Session One')).toBeDefined()
     expect(screen.getByText('Session Two')).toBeDefined()
+  })
+
+  it('shows pinned sessions before newer unpinned sessions', () => {
+    render(<AppSidebar />)
+    expect(screen.getByText('Pinned')).toBeDefined()
+    expect(screen.getByText('All sessions')).toBeDefined()
+    const sessionOne = screen.getByText('Session One')
+    const sessionTwo = screen.getByText('Session Two')
+    const sessionOneButton = sessionOne.closest('button')
+    const sessionTwoButton = sessionTwo.closest('button')
+
+    expect(sessionOneButton).not.toBeNull()
+    expect(sessionTwoButton).not.toBeNull()
+    expect(
+      sessionOneButton!.compareDocumentPosition(sessionTwoButton!) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
   })
 
   it('renders sidebar container', () => {

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { useTranslation } from "react-i18next"
-import { Search, SquarePen, MessageSquare, Loader2, Archive, PanelLeftIcon, FolderOpen, Users, Cloud, Pencil, Ellipsis, Clock, Sparkles, Bookmark, Settings } from "lucide-react"
+import { Search, SquarePen, MessageSquare, Loader2, Archive, PanelLeftIcon, FolderOpen, Users, Cloud, Pencil, Ellipsis, Clock, Sparkles, Bookmark, Settings, Pin } from "lucide-react"
 import { isWorkspaceUIVariant } from "@/lib/ui-variant"
 
 import { useSessionStore } from "@/stores/session"
@@ -475,6 +475,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { t } = useTranslation()
   const { state: sidebarDisplayState } = useSidebar()
   const allSessions = useSessionStore(s => s.sessions)
+  const pinnedSessionIds = useSessionStore(s => s.pinnedSessionIds)
   const activeSessionId = useSessionStore(s => s.activeSessionId)
   const isLoading = useSessionStore(s => s.isLoading)
   const isLoadingMore = useSessionStore(s => s.isLoadingMore)
@@ -484,6 +485,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const setActiveSession = useSessionStore(s => s.setActiveSession)
   const archiveSession = useSessionStore(s => s.archiveSession)
   const updateSessionTitle = useSessionStore(s => s.updateSessionTitle)
+  const toggleSessionPinned = useSessionStore(s => s.toggleSessionPinned)
   const loadMoreSessions = useSessionStore(s => s.loadMoreSessions)
   const cronSessionIds = useCronStore(s => s.cronSessionIds)
   const showCronSessions = useCronStore(s => s.showCronSessions)
@@ -498,8 +500,22 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         ? cronSessionIds.has(s.id)
         : !cronSessionIds.has(s.id)
       )
+      .sort((a, b) => {
+        const aPinned = pinnedSessionIds.includes(a.id)
+        const bPinned = pinnedSessionIds.includes(b.id)
+        if (aPinned !== bPinned) return aPinned ? -1 : 1
+        return b.updatedAt.getTime() - a.updatedAt.getTime()
+      })
       .slice(0, visibleSessionCount),
-    [allSessions, cronSessionIds, showCronSessions, visibleSessionCount],
+    [allSessions, cronSessionIds, pinnedSessionIds, showCronSessions, visibleSessionCount],
+  )
+  const pinnedSessions = React.useMemo(
+    () => sessions.filter((session) => pinnedSessionIds.includes(session.id)),
+    [sessions, pinnedSessionIds],
+  )
+  const unpinnedSessions = React.useMemo(
+    () => sessions.filter((session) => !pinnedSessionIds.includes(session.id)),
+    [sessions, pinnedSessionIds],
   )
   
   const openSettings = useUIStore(s => s.openSettings)
@@ -578,8 +594,120 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     setRenamingSessionId(null)
   }
 
+  const handleTogglePinned = (e: React.MouseEvent, id: string) => {
+    e.stopPropagation()
+    toggleSessionPinned(id)
+  }
+
   // Format date for display with relative time
   const formatDate = (date: Date) => formatRelativeTime(date)
+
+  const renderSessionItem = (session: typeof sessions[number]) => {
+    const isHighlighted = highlightedSessionIds.includes(session.id)
+    const isRenaming = renamingSessionId === session.id
+    const isPinned = pinnedSessionIds.includes(session.id)
+
+    return (
+      <SidebarMenuItem key={session.id}>
+        <SidebarMenuButton
+          isActive={session.id === activeSessionId}
+          className={cn(
+            "h-auto py-2 transition-all duration-300",
+            isWorkspaceUIVariant() &&
+              session.id === activeSessionId &&
+              "relative z-0 data-[active=true]:!bg-muted/40 data-[active=true]:font-medium before:pointer-events-none before:absolute before:left-0 before:top-1/2 before:z-10 before:h-[72%] before:w-0.5 before:-translate-y-1/2 before:rounded-full before:bg-primary before:content-['']",
+            isHighlighted &&
+              session.id !== activeSessionId &&
+              "bg-emerald-500/15 ring-1 ring-emerald-500/30"
+          )}
+          onClick={() => {
+            if (!isRenaming) {
+              handleSelectSession(session.id)
+            }
+          }}
+          onDoubleClick={(e) => {
+            e.stopPropagation()
+            handleStartRename(e, session.id)
+          }}
+        >
+          <div className="flex flex-col items-start gap-0.5 flex-1 min-w-0">
+            <div className="flex items-center gap-1.5 w-full">
+              {isRenaming ? (
+                <SessionRenameInput
+                  defaultValue={session.title}
+                  onConfirm={(newTitle) => handleRenameConfirm(session.id, newTitle)}
+                  onCancel={handleRenameCancel}
+                />
+              ) : (
+                <>
+                  <span className="truncate text-left">
+                    {session.title}
+                  </span>
+                  {isPinned && (
+                    <Pin className="h-3 w-3 shrink-0 text-amber-500 fill-amber-500/20" />
+                  )}
+                  {session.id !== activeSessionId && isHighlighted && (
+                    <span className="shrink-0 text-[10px] font-medium text-emerald-500 bg-emerald-500/10 px-1.5 py-0.5 rounded-full">
+                      NEW
+                    </span>
+                  )}
+                </>
+              )}
+            </div>
+            {!isRenaming && (
+              <div className="flex items-center gap-1.5 w-full">
+                <span className="text-[10px] text-muted-foreground">
+                  {formatDate(session.updatedAt)}
+                  {session.messageCount !== undefined && (
+                    <> · {session.messageCount} messages</>
+                  )}
+                </span>
+                {session.id === activeSessionId && (
+                  <span className="ml-auto">
+                    <SidebarSessionStatusIndicator />
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+        </SidebarMenuButton>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute right-1 bottom-1 h-5 w-5 opacity-0 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 transition-opacity hover:bg-black/10 dark:hover:bg-white/10 rounded-md"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Ellipsis className="h-3 w-3" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={(e) => handleTogglePinned(e as unknown as React.MouseEvent, session.id)}
+            >
+              <Pin className="h-4 w-4 mr-2" />
+              {isPinned
+                ? t('sidebar.unpin', 'Unpin')
+                : t('sidebar.pinToTop', 'Pin to top')}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => handleStartRename(e, session.id)}
+            >
+              <Pencil className="h-4 w-4 mr-2" />
+              {t('sidebar.rename', 'Rename')}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => handleArchiveSession(e as unknown as React.MouseEvent, session.id)}
+            >
+              <Archive className="h-4 w-4 mr-2" />
+              {t('sidebar.archive', 'Archive')}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    )
+  }
 
   return (
     <Sidebar variant="sidebar" {...props}>
@@ -672,99 +800,26 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 </p>
               </div>
             ) : (
-              sessions.map((session) => {
-                const isHighlighted = highlightedSessionIds.includes(session.id)
-                const isRenaming = renamingSessionId === session.id
-                return (
-                <SidebarMenuItem key={session.id}>
-                  <SidebarMenuButton
-                    isActive={session.id === activeSessionId}
-                    className={cn(
-                      "h-auto py-2 transition-all duration-300",
-                      isWorkspaceUIVariant() &&
-                        session.id === activeSessionId &&
-                        "relative z-0 data-[active=true]:!bg-muted/40 data-[active=true]:font-medium before:pointer-events-none before:absolute before:left-0 before:top-1/2 before:z-10 before:h-[72%] before:w-0.5 before:-translate-y-1/2 before:rounded-full before:bg-primary before:content-['']",
-                      isHighlighted &&
-                        session.id !== activeSessionId &&
-                        "bg-emerald-500/15 ring-1 ring-emerald-500/30"
-                    )}
-                    onClick={() => {
-                      if (!isRenaming) {
-                        handleSelectSession(session.id)
-                      }
-                    }}
-                    onDoubleClick={(e) => {
-                      e.stopPropagation()
-                      handleStartRename(e, session.id)
-                    }}
-                  >
-                    <div className="flex flex-col items-start gap-0.5 flex-1 min-w-0">
-                      <div className="flex items-center gap-1.5 w-full">
-                        {isRenaming ? (
-                          <SessionRenameInput
-                            defaultValue={session.title}
-                            onConfirm={(newTitle) => handleRenameConfirm(session.id, newTitle)}
-                            onCancel={handleRenameCancel}
-                          />
-                        ) : (
-                          <>
-                            <span className="truncate text-left">
-                              {session.title}
-                            </span>
-                            {session.id !== activeSessionId && isHighlighted && (
-                              <span className="shrink-0 text-[10px] font-medium text-emerald-500 bg-emerald-500/10 px-1.5 py-0.5 rounded-full">
-                                NEW
-                              </span>
-                            )}
-                          </>
-                        )}
-                      </div>
-                      {!isRenaming && (
-                        <div className="flex items-center gap-1.5 w-full">
-                          <span className="text-[10px] text-muted-foreground">
-                            {formatDate(session.updatedAt)}
-                            {session.messageCount !== undefined && (
-                              <> · {session.messageCount} messages</>
-                            )}
-                          </span>
-                          {session.id === activeSessionId && (
-                            <span className="ml-auto">
-                              <SidebarSessionStatusIndicator />
-                            </span>
-                          )}
-                        </div>
-                      )}
+              <>
+                {pinnedSessions.length > 0 && (
+                  <>
+                    <div className="px-2 pb-1 pt-0.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">
+                      {t('sidebar.pinnedSessions', 'Pinned')}
                     </div>
-                  </SidebarMenuButton>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="absolute right-1 bottom-1 h-5 w-5 opacity-0 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 transition-opacity hover:bg-black/10 dark:hover:bg-white/10 rounded-md"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <Ellipsis className="h-3 w-3" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem
-                        onClick={(e) => handleStartRename(e, session.id)}
-                      >
-                        <Pencil className="h-4 w-4 mr-2" />
-                        {t('sidebar.rename', 'Rename')}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={(e) => handleArchiveSession(e as unknown as React.MouseEvent, session.id)}
-                      >
-                        <Archive className="h-4 w-4 mr-2" />
-                        {t('sidebar.archive', 'Archive')}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </SidebarMenuItem>
-                )
-              })
+                    {pinnedSessions.map(renderSessionItem)}
+                  </>
+                )}
+                {unpinnedSessions.length > 0 && (
+                  <>
+                    {pinnedSessions.length > 0 && (
+                      <div className="px-2 pb-1 pt-3 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">
+                        {t('sidebar.allSessions', 'All sessions')}
+                      </div>
+                    )}
+                    {unpinnedSessions.map(renderSessionItem)}
+                  </>
+                )}
+              </>
             )}
           </SidebarMenu>
           

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -205,6 +205,10 @@
     "clickToStartChat": "Click the edit icon to start a new chat",
     "noSessionsFound": "No sessions found",
     "currentWorkspace": "Current: {{path}}",
+    "pinnedSessions": "Pinned",
+    "allSessions": "All sessions",
+    "pinToTop": "Pin to top",
+    "unpin": "Unpin",
     "loadMore": "Load More",
     "loadingMore": "Loading...",
     "settings": "Settings"

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -205,6 +205,10 @@
     "clickToStartChat": "点击编辑图标开始新聊天",
     "noSessionsFound": "未找到会话",
     "currentWorkspace": "当前：{{path}}",
+    "pinnedSessions": "固定会话",
+    "allSessions": "全部会话",
+    "pinToTop": "固定到顶部",
+    "unpin": "取消固定",
     "loadMore": "加载更多",
     "loadingMore": "加载中...",
     "settings": "设置"

--- a/packages/app/src/stores/__tests__/session-loader.test.ts
+++ b/packages/app/src/stores/__tests__/session-loader.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // --- Hoisted mocks ---
 const mockListSessions = vi.fn()
 const mockCreateSession = vi.fn()
+const mockArchiveSession = vi.fn()
 const mockGetMessages = vi.fn()
 const mockGetSession = vi.fn()
 const mockGetTodos = vi.fn()
@@ -12,6 +13,7 @@ vi.mock('@/lib/opencode/client', () => ({
   getOpenCodeClient: () => ({
     listSessions: mockListSessions,
     createSession: mockCreateSession,
+    archiveSession: mockArchiveSession,
     getMessages: mockGetMessages,
     getSession: mockGetSession,
     getTodos: mockGetTodos,
@@ -78,6 +80,7 @@ describe('session-loader: createLoaderActions', () => {
 
     state = {
       sessions: [],
+      pinnedSessionIds: [],
       activeSessionId: null,
       isLoading: false,
       messageQueue: [],
@@ -123,6 +126,27 @@ describe('session-loader: createLoaderActions', () => {
     expect(sessions).toHaveLength(2)
     expect(sessions[0].id).toBe('newer')
     expect(sessions[1].id).toBe('older')
+  })
+
+  it('loadSessions removes pinned ids that no longer exist', async () => {
+    const now = Date.now()
+    state.pinnedSessionIds = ['missing', 'active']
+    mockListSessions.mockResolvedValue([
+      { id: 'active', title: 'Active', time: { created: now, updated: now } },
+    ])
+
+    await actions.loadSessions('/workspace')
+
+    const sessionsCall = set.mock.calls.find(
+      (c) => {
+        const arg = c[0]
+        return typeof arg === 'object' && arg !== null && 'pinnedSessionIds' in arg
+      }
+    )
+
+    expect(sessionsCall).toBeDefined()
+    expect(sessionsCall![0].pinnedSessionIds).toEqual(['active'])
+    expect(localStorage.setItem).toHaveBeenCalled()
   })
 
   it('loadSessions filters out archived and child sessions', async () => {
@@ -204,5 +228,27 @@ describe('session-loader: createLoaderActions', () => {
       isLoading: true,
     }))
     expect(mockGetMessages).toHaveBeenCalledWith('sess-1')
+  })
+
+  it('archiveSession removes the session from pinned ids', async () => {
+    const now = Date.now()
+    state.sessions = [{
+      id: 'sess-1',
+      title: 'Test',
+      messages: [],
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
+      directory: '/workspace',
+    }]
+    state.pinnedSessionIds = ['sess-1']
+    state.activeSessionId = 'sess-1'
+    mockArchiveSession.mockResolvedValue(undefined)
+
+    await actions.archiveSession('sess-1')
+
+    expect(mockArchiveSession).toHaveBeenCalledWith('sess-1', '/workspace')
+    expect(state.pinnedSessionIds).toEqual([])
+    expect(localStorage.setItem).toHaveBeenCalled()
+    expect(state.activeSessionId).toBeNull()
   })
 })

--- a/packages/app/src/stores/session-loader.ts
+++ b/packages/app/src/stores/session-loader.ts
@@ -26,6 +26,10 @@ import {
 } from "@/stores/streaming";
 import { trackEvent } from "@/stores/telemetry";
 import { sessionDataCache } from "./session-data-cache";
+import {
+  savePinnedSessionIds,
+  sanitizePinnedSessionIds,
+} from "./session-pins";
 
 type SessionSet = (fn: ((state: SessionState) => Partial<SessionState>) | Partial<SessionState>) => void;
 type SessionGet = () => SessionState;
@@ -119,11 +123,18 @@ export function createLoaderActions(set: SessionSet, get: SessionGet) {
         // Sort by updatedAt descending (most recently active first)
         newSessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 
+        const pinnedSessionIds = sanitizePinnedSessionIds(
+          get().pinnedSessionIds,
+          newSessions.map((session) => session.id),
+        );
+        savePinnedSessionIds(pinnedSessionIds);
+
         // UI-level pagination: initially show first PAGE_SIZE sessions
         const hasMore = newSessions.length > UI_PAGE_SIZE;
 
         set({
           sessions: newSessions,
+          pinnedSessionIds,
           isLoading: false,
           hasMoreSessions: hasMore,
           visibleSessionCount: Math.min(newSessions.length, UI_PAGE_SIZE),
@@ -497,10 +508,13 @@ export function createLoaderActions(set: SessionSet, get: SessionGet) {
 
         set((state) => {
           const newSessions = state.sessions.filter((s) => s.id !== id);
+          const pinnedSessionIds = state.pinnedSessionIds.filter((sessionId) => sessionId !== id);
+          savePinnedSessionIds(pinnedSessionIds);
           updateSessionCache(newSessions);
 
           return {
             sessions: newSessions,
+            pinnedSessionIds,
             activeSessionId:
               state.activeSessionId === id
                 ? (newSessions[0]?.id ?? null)

--- a/packages/app/src/stores/session-pins.ts
+++ b/packages/app/src/stores/session-pins.ts
@@ -1,0 +1,42 @@
+import { appShortName } from "@/lib/build-config";
+
+const STORAGE_KEY = `${appShortName}-pinned-sessions`;
+
+export function loadPinnedSessionIds(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter((item): item is string => typeof item === "string");
+  } catch {
+    return [];
+  }
+}
+
+export function savePinnedSessionIds(ids: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    // Ignore storage failures so session list still works in constrained envs.
+  }
+}
+
+export function sanitizePinnedSessionIds(
+  pinnedIds: string[],
+  validSessionIds: Iterable<string>,
+): string[] {
+  const validSet = new Set(validSessionIds);
+  const uniquePinned: string[] = [];
+
+  for (const id of pinnedIds) {
+    if (validSet.has(id) && !uniquePinned.includes(id)) {
+      uniquePinned.push(id);
+    }
+  }
+
+  return uniquePinned;
+}
+

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -11,10 +11,15 @@ import { createMessageActions } from "./session-messages";
 import { createSSEHandlers } from "./session-sse-handlers";
 import { createPermissionActions } from "./session-permissions";
 import { createQuestionActions } from "./session-questions";
+import {
+  loadPinnedSessionIds,
+  savePinnedSessionIds,
+} from "./session-pins";
 
 export const useSessionStore = create<SessionState>((set, get) => ({
   // Initial state
   sessions: [],
+  pinnedSessionIds: loadPinnedSessionIds(),
   activeSessionId: null,
   isLoading: false,
   isLoadingMore: false,
@@ -46,6 +51,19 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   ...createQuestionActions(set, get),
 
   // Simple state setters
+  toggleSessionPinned: (id: string) => {
+    set((state) => {
+      const exists = state.sessions.some((session) => session.id === id);
+      if (!exists) return {};
+
+      const pinnedSessionIds = state.pinnedSessionIds.includes(id)
+        ? state.pinnedSessionIds.filter((sessionId) => sessionId !== id)
+        : [id, ...state.pinnedSessionIds];
+
+      savePinnedSessionIds(pinnedSessionIds);
+      return { pinnedSessionIds };
+    });
+  },
   setConnected: (connected: boolean) => {
     set({ isConnected: connected });
   },

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -144,6 +144,7 @@ export interface SelectedModel {
 export interface SessionState {
   // State
   sessions: Session[];
+  pinnedSessionIds: string[];
   activeSessionId: string | null;
   isLoading: boolean;
   isLoadingMore: boolean; // Loading more sessions (UI pagination)
@@ -205,6 +206,7 @@ export interface SessionState {
   setActiveSession: (id: string) => Promise<void>;
   archiveSession: (id: string) => Promise<void>;
   updateSessionTitle: (id: string, title: string) => Promise<void>;
+  toggleSessionPinned: (id: string) => void;
   resetSessions: () => void;
 
   // Actions - Model selection


### PR DESCRIPTION
## Summary
- add session pin/unpin actions in the sidebar item menu and show pinned sessions first
- persist pinned session IDs in local storage and sanitize stale IDs on reload/archive
- split sidebar list into `Pinned` and `All sessions` groups, with new i18n strings in English and Chinese
- add tests for pin ordering in sidebar and pin cleanup behavior in session loader actions

## Test plan
- [x] `pnpm vitest run src/components/__tests__/app-sidebar.test.tsx src/stores/__tests__/session-loader.test.ts` (run in `packages/app`)
- [ ] Manually pin/unpin sessions in sidebar and verify ordering + labels
- [ ] Archive a pinned session and verify it is removed from pinned state

Made with [Cursor](https://cursor.com)