### PR TITLE
fix(skills): avoid restart prompt on first launch

### DIFF
--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -147,6 +147,7 @@ export function useOpenCodeInit() {
     let watchedDirs: string[] = [];
     let skillDirs: string[] = [];
     let lastSkillSignature = "";
+    let hasObservedSkillChange = false;
     let changeVersion = 0;
 
     const QUIET_WINDOW_MS = 3000;
@@ -186,7 +187,12 @@ export function useOpenCodeInit() {
       if (firstSignature !== secondSignature) return;
 
       if (secondSignature !== lastSkillSignature) {
+        const isFirstObservedChange = !hasObservedSkillChange;
+        hasObservedSkillChange = true;
         lastSkillSignature = secondSignature;
+        // Suppress restart prompts caused by startup-time churn while the
+        // initial watcher baseline is stabilizing.
+        if (isFirstObservedChange) return;
         window.dispatchEvent(new CustomEvent(SKILLS_CHANGED_EVENT));
       }
     };


### PR DESCRIPTION
## Summary
- suppress the first observed skills-signature change during watcher baseline stabilization
- keep emitting `skills-files-changed` for subsequent genuine skill file updates
- prevent false-positive restart prompts on initial startup while preserving normal runtime change prompts

## Test plan
- [x] Launch app with existing workspace and confirm no immediate skill restart prompt appears on first startup
- [x] Modify a skill file after startup and confirm restart prompt still appears
- [x] Verify no lint errors in `packages/app/src/hooks/useAppInit.ts`

Made with [Cursor](https://cursor.com)