### PR TITLE
docs(readme): remove broken screenshots from all locales

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,8 +4,6 @@ AI Agent デスクトッププラットフォーム
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | 日本語 | [한국어](README.ko.md)
 
-![TeamClaw スクリーンショット](_assets/screenshot.jpg)
-
 ## 主な機能
 
 - **3カラムレイアウト** — サイドバー、チャットエリア、詳細パネル

--- a/README.ko.md
+++ b/README.ko.md
@@ -4,8 +4,6 @@ AI Agent 데스크톱 플랫폼
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | 한국어
 
-![TeamClaw 스크린샷](_assets/screenshot.jpg)
-
 ## 주요 기능
 
 - **3단 레이아웃** — 사이드바, 채팅 영역, 상세 패널

--- a/README.md
+++ b/README.md
@@ -8,22 +8,6 @@ AI Agent Desktop Platform
 
 English | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 
-![TeamClaw Screenshot](_assets/screenshot.jpg)
-
-## UI Screenshots
-
-### Home
-
-![TeamClaw Home](images/home.png)
-
-### Channels
-
-![TeamClaw Channels](images/channel.png)
-
-### Team
-
-![TeamClaw Team](images/team.png)
-
 ## Features
 
 - Three-column layout (Sidebar, Chat, Detail Panel)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,22 +4,6 @@ AI Agent 桌面平台
 
 [English](README.md) | 简体中文 | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 
-![TeamClaw 截图](_assets/screenshot.jpg)
-
-## 界面预览
-
-### 首页
-
-![TeamClaw 首页](images/home.png)
-
-### 渠道配置
-
-![TeamClaw 渠道](images/channel.png)
-
-### 团队设置
-
-![TeamClaw 团队](images/team.png)
-
 ## 功能特性
 
 - **三栏布局** — 侧边栏、聊天区、详情面板

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -4,8 +4,6 @@ AI Agent 桌面平台
 
 [English](README.md) | [简体中文](README.zh-CN.md) | 繁體中文 | [日本語](README.ja.md) | [한국어](README.ko.md)
 
-![TeamClaw 截圖](_assets/screenshot.jpg)
-
 ## 功能特性
 
 - **三欄佈局** — 側邊欄、聊天區、詳情面板


### PR DESCRIPTION
## Summary
- remove broken top screenshot sections from `README.md`
- remove corresponding broken screenshot blocks from localized READMEs (`README.zh-CN.md`, `README.zh-TW.md`, `README.ja.md`, `README.ko.md`)
- keep feature and setup content unchanged

## Test plan
- [x] verify markdown diffs render without image references at the top of each README
- [ ] preview README pages on GitHub after merge

Made with [Cursor](https://cursor.com)