### PR TITLE
feat(wecom): add proactive message push via aibot_send_msg

### DIFF
--- a/packages/app/src/lib/cron-utils.ts
+++ b/packages/app/src/lib/cron-utils.ts
@@ -216,6 +216,23 @@ export const DELIVERY_CHANNEL_REGISTRY: DeliveryChannelRegistryEntry[] = [
     buildTarget: (_mode, values) => values.userId,
     parseTarget: (to) => ({ mode: '', values: { userId: to } }),
   },
+  {
+    id: 'wecom',
+    name: 'WeCom',
+    getEnabled: (s) => !!s.wecom?.enabled,
+    getConnected: (s) => s.wecomGatewayStatus?.status === 'connected',
+    fields: [
+      {
+        key: 'chatId',
+        label: 'Chat ID',
+        placeholder: 'e.g., wrkSFfCgAAxxxxxx',
+        hint: 'The WeCom conversation ID (chatid). Visible in gateway logs when a user sends a message. The user must have messaged the bot at least once before proactive push works.',
+        required: true,
+      },
+    ],
+    buildTarget: (_mode, values) => values.chatId,
+    parseTarget: (to) => ({ mode: '', values: { chatId: to } }),
+  },
 ]
 
 export function getRegistryEntry(channelId: DeliveryChannel): DeliveryChannelRegistryEntry | undefined {

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -23,7 +23,7 @@ export interface CronPayload {
 }
 
 export type DeliveryMode = 'announce' | 'none'
-export type DeliveryChannel = 'discord' | 'feishu' | 'email' | 'kook' | 'wechat'
+export type DeliveryChannel = 'discord' | 'feishu' | 'email' | 'kook' | 'wechat' | 'wecom'
 
 export interface CronDelivery {
   mode: DeliveryMode

--- a/src-tauri/src/commands/cron/delivery.rs
+++ b/src-tauri/src/commands/cron/delivery.rs
@@ -50,6 +50,10 @@ impl DeliveryManager {
                 self.send_wechat(&config, target, message).await?;
                 Ok(None)
             }
+            DeliveryChannel::Wecom => {
+                self.send_wecom(target, message).await?;
+                Ok(None)
+            }
         }
     }
 
@@ -279,6 +283,23 @@ impl DeliveryManager {
         let client = reqwest::Client::new();
         wechat::send_text_message(&client, base_url, bot_token, target, message, context_token)
             .await
+    }
+    // ==================== WeCom ====================
+
+    /// Send via WeCom — delegates to the running WeComGateway's send_chat_message.
+    /// The gateway must be connected (WebSocket active).
+    async fn send_wecom(
+        &self,
+        target: &str,
+        message: &str,
+    ) -> Result<(), String> {
+        let chunks = split_message(message, 4000);
+        for chunk in chunks {
+            gateway::wecom::send_proactive_message(target, &chunk).await?;
+        }
+
+        println!("[Cron Delivery] WeCom message sent to {}", target);
+        Ok(())
     }
 }
 

--- a/src-tauri/src/commands/cron/scheduler.rs
+++ b/src-tauri/src/commands/cron/scheduler.rs
@@ -164,6 +164,7 @@ impl CronScheduler {
                 }
             }
             DeliveryChannel::Wechat => Some(format!("wechat:dm:{}", target)),
+            DeliveryChannel::Wecom => Some(format!("wecom:{}", target)),
         }
     }
 

--- a/src-tauri/src/commands/cron/types.rs
+++ b/src-tauri/src/commands/cron/types.rs
@@ -78,6 +78,7 @@ pub enum DeliveryChannel {
     Email,
     Kook,
     Wechat,
+    Wecom,
 }
 
 /// Delivery configuration for cron job results

--- a/src-tauri/src/commands/gateway/wecom.rs
+++ b/src-tauri/src/commands/gateway/wecom.rs
@@ -6,6 +6,14 @@ use futures_util::StreamExt;
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, RwLock};
+use std::sync::OnceLock;
+
+/// Global reference to the active WeComGateway for proactive message sending.
+static ACTIVE_GATEWAY: OnceLock<Arc<RwLock<Option<WeComGateway>>>> = OnceLock::new();
+
+fn get_active_gateway_holder() -> &'static Arc<RwLock<Option<WeComGateway>>> {
+    ACTIVE_GATEWAY.get_or_init(|| Arc::new(RwLock::new(None)))
+}
 
 /// Detect image MIME type from file magic bytes
 fn detect_image_mime(bytes: &[u8]) -> Option<String> {
@@ -152,6 +160,7 @@ impl WeComGateway {
         }
 
         *self.is_running.write().await = true;
+        *get_active_gateway_holder().write().await = Some(self.clone());
         self.set_status(WeComGatewayStatus::Connecting, None).await;
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -174,6 +183,7 @@ impl WeComGateway {
             let _ = tx.send(());
         }
         self.session_queue.shutdown().await;
+        *get_active_gateway_holder().write().await = None;
         *self.shared_ws_sink.write().await = None;
         *self.is_running.write().await = false;
         self.set_status(WeComGatewayStatus::Disconnected, None)
@@ -226,6 +236,7 @@ impl WeComGateway {
         }
 
         *self.is_running.write().await = false;
+        *get_active_gateway_holder().write().await = None;
         self.set_status(WeComGatewayStatus::Disconnected, None)
             .await;
     }
@@ -1532,4 +1543,19 @@ impl WeComGateway {
         self.send_stream_chunk(req_id, &stream_id, text, true, ws_sink)
             .await
     }
+}
+
+/// Send a proactive message to a WeCom conversation.
+/// Called by cron delivery and other modules that don't have direct gateway access.
+/// Requires the WeCom gateway to be running and connected.
+pub async fn send_proactive_message(chatid: &str, text: &str) -> Result<(), String> {
+    let gateway = get_active_gateway_holder()
+        .read()
+        .await
+        .clone()
+        .ok_or_else(|| {
+            "WeCom gateway is not running. Start the WeCom gateway before sending proactive messages.".to_string()
+        })?;
+
+    gateway.send_chat_message(chatid, text).await
 }

--- a/src-tauri/src/commands/gateway/wecom.rs
+++ b/src-tauri/src/commands/gateway/wecom.rs
@@ -58,6 +58,7 @@ pub struct WeComGateway {
     permission_approver: super::PermissionAutoApprover,
     session_queue: Arc<SessionQueue>,
     pending_questions: Arc<super::PendingQuestionStore>,
+    shared_ws_sink: Arc<RwLock<Option<WsSink>>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -121,6 +122,7 @@ impl WeComGateway {
             permission_approver: super::PermissionAutoApprover::new(opencode_port),
             session_queue: Arc::new(SessionQueue::new()),
             pending_questions: Arc::new(super::PendingQuestionStore::new()),
+            shared_ws_sink: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -172,6 +174,7 @@ impl WeComGateway {
             let _ = tx.send(());
         }
         self.session_queue.shutdown().await;
+        *self.shared_ws_sink.write().await = None;
         *self.is_running.write().await = false;
         self.set_status(WeComGatewayStatus::Disconnected, None)
             .await;
@@ -288,6 +291,7 @@ impl WeComGateway {
 
         // Heartbeat task
         let ws_sink = Arc::new(tokio::sync::Mutex::new(ws_sink));
+        *self.shared_ws_sink.write().await = Some(Arc::clone(&ws_sink));
         let ws_sink_hb = Arc::clone(&ws_sink);
         let (hb_shutdown_tx, mut hb_shutdown_rx) = mpsc::channel::<()>(1);
 
@@ -347,6 +351,7 @@ impl WeComGateway {
             }
         };
 
+        *self.shared_ws_sink.write().await = None;
         let _ = hb_shutdown_tx.send(()).await;
         heartbeat_handle.abort();
         Ok(exit_reason)
@@ -1481,6 +1486,44 @@ impl WeComGateway {
             ))
             .await
             .map_err(|e| format!("Failed to send reply: {}", e))
+    }
+
+    /// Send a proactive message to a WeCom conversation via aibot_send_msg.
+    /// Requires the gateway to be connected and the target user to have
+    /// previously messaged the bot in that conversation.
+    pub async fn send_chat_message(&self, chatid: &str, text: &str) -> Result<(), String> {
+        use futures_util::SinkExt;
+
+        let ws_sink = self
+            .shared_ws_sink
+            .read()
+            .await
+            .clone()
+            .ok_or_else(|| {
+                "WeCom gateway is not connected. Cannot send proactive message.".to_string()
+            })?;
+
+        let msg = serde_json::json!({
+            "cmd": "aibot_send_msg",
+            "headers": { "req_id": uuid::Uuid::new_v4().to_string() },
+            "body": {
+                "chatid": chatid,
+                "msgtype": "text",
+                "text": { "content": text }
+            }
+        });
+
+        ws_sink
+            .lock()
+            .await
+            .send(tokio_tungstenite::tungstenite::Message::Text(
+                msg.to_string().into(),
+            ))
+            .await
+            .map_err(|e| format!("Failed to send proactive message: {}", e))?;
+
+        println!("[WeCom] Proactive message sent to chatid={}", chatid);
+        Ok(())
     }
 
     /// Simple non-streaming reply (for slash commands and errors)


### PR DESCRIPTION
## Summary

- Add `aibot_send_msg` proactive message sending to WeCom gateway via existing WebSocket connection
- Integrate WeCom as a delivery channel in the cron system, enabling scheduled task result push
- Add WeCom to frontend cron delivery channel options

## Changes

- **wecom.rs**: Store shared `WsSink` on connect, expose `send_chat_message()` and global `send_proactive_message()` accessor
- **cron/types.rs**: Add `Wecom` variant to `DeliveryChannel` enum
- **cron/delivery.rs**: Add `send_wecom()` delivery method
- **cron/scheduler.rs**: Add WeCom session key mapping
- **Frontend**: Add `'wecom'` to `DeliveryChannel` type and channel registry

## Constraints

Per WeCom docs: user must have sent at least one message to the bot in a conversation before proactive push works. Rate limit: 30 msg/min, 1000 msg/hour per conversation.

## Test plan

- [ ] Start WeCom gateway, send a message from WeCom to bot
- [ ] Create a cron job with WeCom delivery configured (chatid from logs)
- [ ] Verify cron job result is proactively pushed to the WeCom conversation
- [ ] Verify gateway-offline error is handled gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)