### PR TITLE
Inject browser-first tool routing for login-related chat tasks

### DIFF
--- a/packages/app/src/stores/__tests__/session-messages-behavior.test.ts
+++ b/packages/app/src/stores/__tests__/session-messages-behavior.test.ts
@@ -169,6 +169,17 @@ describe('session store: message behavior', () => {
       );
     });
 
+    it('adds browser-routing system prompt for login-related web tasks', async () => {
+      await useSessionStore.getState().sendMessage('帮我登录这个网站然后抓取里面的数据');
+
+      expect(mockSendMessageAsync).toHaveBeenCalledTimes(1);
+      const callArgs = mockSendMessageAsync.mock.calls[0];
+      expect(callArgs[0]).toBe('sess-1');
+      expect(callArgs[1]).toBe('帮我登录这个网站然后抓取里面的数据');
+      expect(callArgs[4]).toContain('do not start with webfetch');
+      expect(callArgs[4]).toContain('chrome-control MCP');
+    });
+
     it('queues message when already streaming', async () => {
       // First send a message to start streaming
       await useSessionStore.getState().sendMessage('first message');

--- a/packages/app/src/stores/session-messages.ts
+++ b/packages/app/src/stores/session-messages.ts
@@ -28,6 +28,28 @@ import { appShortName } from "@/lib/build-config";
 type SessionSet = (fn: ((state: SessionState) => Partial<SessionState>) | Partial<SessionState>) => void;
 type SessionGet = () => SessionState;
 
+const LOGIN_RELATED_PROMPT = [
+  "Tool routing rule for web tasks:",
+  "If the user request may require website login, existing browser session, cookies, OAuth, SSO, MFA, CAPTCHA, or interactive page operations, do not start with webfetch.",
+  "First use the chrome-control MCP when available, or Playwright MCP as fallback, to open the site in a real browser, verify whether login is required, and continue only after the authenticated state is available.",
+  "Use webfetch only for public pages that do not require authentication or interactive browser state.",
+].join(" ");
+
+const LOGIN_RELATED_PATTERNS = [
+  /\b(login|log in|sign in|signin|authenticate|authentication|reauth|oauth|sso|mfa|2fa|captcha|cookie|cookies|session)\b/i,
+  /(登录|登陆|认证|鉴权|授权|会话|cookie|验证码|二次验证|双因子|单点登录)/i,
+];
+
+function shouldPreferInteractiveBrowserForMessage(message: string): boolean {
+  const normalized = message.trim();
+  if (!normalized) return false;
+  return LOGIN_RELATED_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function appendSystemPrompt(basePrompt: string | undefined, extraPrompt: string): string {
+  return basePrompt ? `${basePrompt}\n\n---\n\n${extraPrompt}` : extraPrompt;
+}
+
 export function createMessageActions(set: SessionSet, get: SessionGet) {
   return {
     // RAG V2: Auto-inject knowledge from pre-inference search
@@ -273,6 +295,10 @@ export function createMessageActions(set: SessionSet, get: SessionGet) {
           systemPrompt = systemPrompt
             ? `${ragResult.context}\n\n---\n\n${systemPrompt}`
             : ragResult.context;
+        }
+
+        if (shouldPreferInteractiveBrowserForMessage(content)) {
+          systemPrompt = appendSystemPrompt(systemPrompt, LOGIN_RELATED_PROMPT);
         }
 
         if (ragResult.chunks && ragResult.chunks.length > 0) {


### PR DESCRIPTION
## Summary
- detect login/auth-related user phrasing (English and Chinese) when sending a message
- append a short system prompt that prefers interactive browser MCP (chrome-control, then Playwright) over `webfetch` when authentication or session state may be required
- add a regression test covering a Chinese login + scrape style request

## Test plan
- [x] `pnpm vitest run src/stores/__tests__/session-messages-behavior.test.ts` (from `packages/app`)
- [ ] Manually send a login-related prompt and confirm downstream tool choice improves in practice

Made with [Cursor](https://cursor.com)