### PR TITLE
feat(gateway): internationalize user-facing strings

### DIFF
--- a/packages/app/src/components/settings/GeneralSection.tsx
+++ b/packages/app/src/components/settings/GeneralSection.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import i18next from 'i18next'
+import { invoke } from '@tauri-apps/api/core'
 import {
   Settings2,
   Moon,
@@ -181,6 +182,8 @@ export const GeneralSection = React.memo(function GeneralSection() {
       setLanguage(value);
       i18next.changeLanguage(value);
       localStorage.setItem(`${appShortName}-language`, value);
+      // Sync locale to config file for gateway i18n
+      invoke('set_config_locale', { locale: value }).catch(console.error);
     }}
   >
     <SelectTrigger className="h-11">

--- a/packages/app/src/lib/i18n.ts
+++ b/packages/app/src/lib/i18n.ts
@@ -58,6 +58,15 @@ i18n
     keySeparator: '.' // Enable nested key lookup (e.g., 'common.save' → common → save)
   });
 
+// Sync initial language to config file for gateway i18n
+if (typeof window !== 'undefined' && ('__TAURI__' in window || '__TAURI_INTERNALS__' in window)) {
+  import('@tauri-apps/api/core').then(({ invoke }) => {
+    invoke('set_config_locale', { locale: i18n.language }).catch(() => {
+      // Silently ignore — workspace may not be set yet
+    });
+  });
+}
+
 export default i18n;
 
 // Export utility functions for language switching and persistence

--- a/src-tauri/src/commands/gateway/discord.rs
+++ b/src-tauri/src/commands/gateway/discord.rs
@@ -924,6 +924,8 @@ pub struct DiscordGateway {
     config: Arc<RwLock<DiscordConfig>>,
     session_mapping: SessionMapping,
     opencode_port: u16,
+    #[allow(dead_code)]
+    workspace_path: String,
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     status: Arc<RwLock<GatewayStatusResponse>>,
     /// Track if gateway is currently running
@@ -935,11 +937,12 @@ pub struct DiscordGateway {
 }
 
 impl DiscordGateway {
-    pub fn new(opencode_port: u16, session_mapping: SessionMapping) -> Self {
+    pub fn new(opencode_port: u16, session_mapping: SessionMapping, workspace_path: String) -> Self {
         Self {
             config: Arc::new(RwLock::new(DiscordConfig::default())),
             session_mapping,
             opencode_port,
+            workspace_path,
             shutdown_tx: Arc::new(RwLock::new(None)),
             status: Arc::new(RwLock::new(GatewayStatusResponse::default())),
             is_running: Arc::new(RwLock::new(false)),
@@ -1137,6 +1140,7 @@ impl Clone for DiscordGateway {
             config: Arc::clone(&self.config),
             session_mapping: self.session_mapping.clone(),
             opencode_port: self.opencode_port,
+            workspace_path: self.workspace_path.clone(),
             shutdown_tx: Arc::clone(&self.shutdown_tx),
             status: Arc::clone(&self.status),
             is_running: Arc::clone(&self.is_running),

--- a/src-tauri/src/commands/gateway/discord.rs
+++ b/src-tauri/src/commands/gateway/discord.rs
@@ -10,13 +10,14 @@ use tokio::sync::{mpsc, oneshot, RwLock};
 use super::config::{DiscordConfig, GatewayStatus, GatewayStatusResponse};
 use super::session::SessionMapping;
 
-use super::{FilterResult, ProcessedMessageTracker, MAX_PROCESSED_MESSAGES};
+use super::{i18n, FilterResult, ProcessedMessageTracker, MAX_PROCESSED_MESSAGES};
 
 /// Discord bot handler
 pub struct DiscordHandler {
     config: Arc<RwLock<DiscordConfig>>,
     session_mapping: SessionMapping,
     opencode_port: u16,
+    workspace_path: String,
     status_tx: mpsc::Sender<GatewayStatusResponse>,
     bot_user_id: Arc<RwLock<Option<u64>>>,
     /// Tracker for processed message IDs to prevent duplicate processing
@@ -33,6 +34,7 @@ impl DiscordHandler {
         config: Arc<RwLock<DiscordConfig>>,
         session_mapping: SessionMapping,
         opencode_port: u16,
+        workspace_path: String,
         status_tx: mpsc::Sender<GatewayStatusResponse>,
         permission_approver: super::PermissionAutoApprover,
         pending_questions: Arc<super::PendingQuestionStore>,
@@ -41,6 +43,7 @@ impl DiscordHandler {
             config,
             session_mapping,
             opencode_port,
+            workspace_path,
             status_tx,
             bot_user_id: Arc::new(RwLock::new(None)),
             processed_messages: Arc::new(RwLock::new(ProcessedMessageTracker::new(
@@ -263,11 +266,13 @@ impl DiscordHandler {
                 ""
             };
             println!("[Discord] Model command received, arg: '{}'", arg);
+            let locale = i18n::get_locale(&self.workspace_path);
             let response = super::handle_model_command(
                 self.opencode_port,
                 &self.session_mapping,
                 &session_key,
                 arg,
+                locale,
             )
             .await;
 
@@ -292,12 +297,9 @@ impl DiscordHandler {
         if content.eq_ignore_ascii_case("/reset") {
             println!("[Discord] Reset command received");
             self.session_mapping.remove_session(&session_key).await;
-            let reply_text = if is_dm {
-                "Session reset. A new session will be created for your next message."
-            } else {
-                "Channel session reset. A new session will be created for the next message."
-            };
-            let _ = msg.reply(&ctx.http, reply_text).await;
+            let locale = i18n::get_locale(&self.workspace_path);
+            let reply_text = i18n::t(i18n::MsgKey::SessionReset, locale);
+            let _ = msg.reply(&ctx.http, &reply_text).await;
             println!("[Discord] Session reset completed");
             return;
         }
@@ -305,9 +307,14 @@ impl DiscordHandler {
         // Handle /stop command
         if content.eq_ignore_ascii_case("/stop") {
             println!("[Discord] Stop command received");
-            let response =
-                super::handle_stop_command(self.opencode_port, &self.session_mapping, &session_key)
-                    .await;
+            let locale = i18n::get_locale(&self.workspace_path);
+            let response = super::handle_stop_command(
+                self.opencode_port,
+                &self.session_mapping,
+                &session_key,
+                locale,
+            )
+            .await;
             let _ = msg.reply(&ctx.http, &response).await;
             return;
         }
@@ -324,12 +331,16 @@ impl DiscordHandler {
             println!("[Discord] Sessions command received, arg: '{}'", arg);
 
             // Send a placeholder message first
-            let placeholder = msg.reply(&ctx.http, "Loading sessions...").await;
+            let locale = i18n::get_locale(&self.workspace_path);
+            let placeholder = msg
+                .reply(&ctx.http, &i18n::t(i18n::MsgKey::LoadingSessions, locale))
+                .await;
             let response = super::handle_sessions_command(
                 self.opencode_port,
                 &self.session_mapping,
                 &session_key,
                 arg,
+                locale,
             )
             .await;
 
@@ -405,11 +416,12 @@ impl DiscordHandler {
         let pending_questions = Arc::clone(&self.pending_questions);
         let channel_id = msg.channel_id;
         let http = Arc::clone(&ctx.http);
+        let locale_for_q = i18n::get_locale(&self.workspace_path);
         let question_ctx = super::QuestionContext {
             forwarder: Box::new(move |fq: super::ForwardedQuestion| {
                 let http = Arc::clone(&http);
                 Box::pin(async move {
-                    let text = super::format_question_message(&fq.questions, &fq.question_id);
+                    let text = super::format_question_message(&fq.questions, &fq.question_id, locale_for_q);
                     let sent = channel_id
                         .say(&http, &text)
                         .await
@@ -633,17 +645,24 @@ impl EventHandler for DiscordHandler {
 
         // Check for /answer command — routes reply to the most recent pending question
         if let Some(answer_text) = super::PendingQuestionStore::parse_answer_command(&msg.content) {
+            let locale = i18n::get_locale(&self.workspace_path);
             if let Some(qid) = self.pending_questions.try_answer(answer_text).await {
                 println!(
                     "[Discord] Question {} answered via /answer: {}",
                     qid, answer_text
                 );
                 let _ = msg
-                    .reply(&ctx.http, &format!("✓ Answered: {}", answer_text))
+                    .reply(
+                        &ctx.http,
+                        &i18n::t(i18n::MsgKey::AnswerSubmitted(answer_text), locale),
+                    )
                     .await;
             } else {
                 let _ = msg
-                    .reply(&ctx.http, "No pending questions to answer.")
+                    .reply(
+                        &ctx.http,
+                        &i18n::t(i18n::MsgKey::NoPendingQuestions, locale),
+                    )
                     .await;
             }
             return;
@@ -759,6 +778,7 @@ impl EventHandler for DiscordHandler {
                 return;
             }
 
+            let locale = i18n::get_locale(&self.workspace_path);
             let content = match command.data.name.as_str() {
                 "reset" => {
                     let is_dm = command.guild_id.is_none();
@@ -772,12 +792,7 @@ impl EventHandler for DiscordHandler {
                         )
                     };
                     self.session_mapping.remove_session(&session_key).await;
-                    if is_dm {
-                        "Session reset! A new conversation will start with your next message."
-                            .to_string()
-                    } else {
-                        "Channel session reset! A new conversation will start with the next message.".to_string()
-                    }
+                    i18n::t(i18n::MsgKey::SessionReset, locale)
                 }
                 "model" => {
                     let model_arg = command
@@ -804,6 +819,7 @@ impl EventHandler for DiscordHandler {
                         &self.session_mapping,
                         &session_key,
                         model_arg,
+                        locale,
                     )
                     .await
                 }
@@ -823,6 +839,7 @@ impl EventHandler for DiscordHandler {
                         self.opencode_port,
                         &self.session_mapping,
                         &session_key,
+                        locale,
                     )
                     .await
                 }
@@ -852,21 +869,12 @@ impl EventHandler for DiscordHandler {
                         &self.session_mapping,
                         &session_key,
                         &session_arg,
+                        locale,
                     )
                     .await
                 }
-                "help" => "**TeamClaw Bot Commands**\n\n\
-                    `/reset` - Reset the current chat session\n\
-                    `/model` - View current model or switch models\n\
-                    `/sessions` - List or switch sessions\n\
-                    `/stop` - Stop the current processing\n\
-                    `/help` - Show this help message\n\n\
-                    **How to use:**\n\
-                    • In DMs: Just send a message to start chatting\n\
-                    • In channels: Mention the bot or reply to its messages\n\n\
-                    You can also send images along with your messages!"
-                    .to_string(),
-                _ => "Unknown command".to_string(),
+                "help" => i18n::t(i18n::MsgKey::HelpDiscord, locale),
+                name => i18n::t(i18n::MsgKey::UnknownCommand(name), locale),
             };
 
             // Edit the deferred response with the actual content
@@ -924,7 +932,6 @@ pub struct DiscordGateway {
     config: Arc<RwLock<DiscordConfig>>,
     session_mapping: SessionMapping,
     opencode_port: u16,
-    #[allow(dead_code)]
     workspace_path: String,
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     status: Arc<RwLock<GatewayStatusResponse>>,
@@ -1013,6 +1020,7 @@ impl DiscordGateway {
             Arc::clone(&self.config),
             self.session_mapping.clone(),
             self.opencode_port,
+            self.workspace_path.clone(),
             status_tx,
             self.permission_approver.clone(),
             Arc::clone(&self.pending_questions),

--- a/src-tauri/src/commands/gateway/feishu.rs
+++ b/src-tauri/src/commands/gateway/feishu.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use tokio::sync::{oneshot, RwLock};
 
 use super::feishu_config::{FeishuConfig, FeishuGatewayStatus, FeishuGatewayStatusResponse};
+use super::i18n;
 use super::session::SessionMapping;
 
 use super::session_queue::{EnqueueResult, QueuedMessage, RejectReason, SessionQueue};
@@ -397,7 +398,6 @@ pub struct FeishuGateway {
     config: Arc<RwLock<FeishuConfig>>,
     session_mapping: SessionMapping,
     opencode_port: u16,
-    #[allow(dead_code)]
     workspace_path: String,
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     status: Arc<RwLock<FeishuGatewayStatusResponse>>,
@@ -466,6 +466,7 @@ impl FeishuGateway {
         let opencode_port = self.opencode_port;
         let session_queue = Arc::clone(&self.session_queue);
         let pending_questions = Arc::clone(&self.pending_questions);
+        let workspace_path = self.workspace_path.clone();
 
         tokio::spawn(async move {
             let result = run_feishu_gateway(
@@ -476,6 +477,7 @@ impl FeishuGateway {
                 shutdown_rx,
                 session_queue,
                 pending_questions,
+                workspace_path,
             )
             .await;
 
@@ -613,6 +615,7 @@ async fn run_feishu_gateway(
     mut shutdown_rx: oneshot::Receiver<()>,
     session_queue: Arc<SessionQueue>,
     pending_questions: Arc<super::PendingQuestionStore>,
+    workspace_path: String,
 ) -> Result<(), String> {
     let cfg = config.read().await.clone();
     let token_manager = TokenManager::new(&cfg.app_id, &cfg.app_secret);
@@ -692,6 +695,7 @@ async fn run_feishu_gateway(
             service_id,
             &session_queue,
             &pending_questions,
+            &workspace_path,
         )
         .await;
 
@@ -741,6 +745,7 @@ async fn handle_ws_connection(
     service_id: i32,
     session_queue: &Arc<SessionQueue>,
     pending_questions: &Arc<super::PendingQuestionStore>,
+    workspace_path: &str,
 ) -> Result<WsExitReason, String> {
     use futures::sink::SinkExt;
     use futures::stream::StreamExt;
@@ -815,7 +820,7 @@ async fn handle_ws_connection(
                                 handle_binary_frame(
                                     frame, config, session_mapping, opencode_port,
                                     token_manager, processed_messages, &send_tx,
-                                    session_queue, pending_questions,
+                                    session_queue, pending_questions, &workspace_path,
                                 ).await;
                             }
                             Err(e) => {
@@ -868,6 +873,7 @@ async fn handle_binary_frame(
     send_tx: &tokio::sync::mpsc::Sender<Vec<u8>>,
     session_queue: &Arc<SessionQueue>,
     pending_questions: &Arc<super::PendingQuestionStore>,
+    workspace_path: &str,
 ) {
     let method = frame.method; // 0=control, 1=data
     let msg_type = frame.get_header("type").unwrap_or("").to_string();
@@ -942,6 +948,7 @@ async fn handle_binary_frame(
                                 let token_manager_app_secret = token_manager.app_secret.clone();
                                 let session_queue_clone = Arc::clone(session_queue);
                                 let pending_questions_clone = Arc::clone(pending_questions);
+                                let workspace_path_clone = workspace_path.to_string();
                                 tokio::spawn(async move {
                                     println!("[Feishu] Spawned message handler task");
                                     let tm = TokenManager::new(
@@ -956,6 +963,7 @@ async fn handle_binary_frame(
                                         &tm,
                                         &session_queue_clone,
                                         &pending_questions_clone,
+                                        &workspace_path_clone,
                                     )
                                     .await;
                                     println!("[Feishu] Message handler task completed");
@@ -993,6 +1001,7 @@ async fn handle_message_event(
     token_manager: &TokenManager,
     session_queue: &Arc<SessionQueue>,
     pending_questions: &Arc<super::PendingQuestionStore>,
+    workspace_path: &str,
 ) {
     let sender = &event["sender"];
     let sender_id = sender["sender_id"]["open_id"]
@@ -1078,6 +1087,7 @@ async fn handle_message_event(
 
     // Build session key for this chat context (used for session ID, model preference, and commands)
     let session_key = format!("feishu:{}", chat_id);
+    let locale = i18n::get_locale(workspace_path);
 
     // Check for /answer command — routes reply to the most recent pending question
     if let Some(answer_text) = super::PendingQuestionStore::parse_answer_command(&clean_text) {
@@ -1090,12 +1100,12 @@ async fn handle_message_event(
                 let _ = reply_feishu_message(
                     &token,
                     &message_id,
-                    &format!("✓ 已回复: {}", answer_text),
+                    &i18n::t(i18n::MsgKey::AnswerSubmitted(answer_text), locale),
                 )
                 .await;
             }
         } else if let Ok(token) = token_manager.get_tenant_token().await {
-            let _ = reply_feishu_message(&token, &message_id, "当前没有待回复的问题").await;
+            let _ = reply_feishu_message(&token, &message_id, &i18n::t(i18n::MsgKey::NoPendingQuestions, locale)).await;
         }
         return;
     }
@@ -1110,7 +1120,7 @@ async fn handle_message_event(
         };
         println!("[Feishu] Model command received, arg: '{}'", arg);
         let response =
-            super::handle_model_command(opencode_port, session_mapping, &session_key, arg).await;
+            super::handle_model_command(opencode_port, session_mapping, &session_key, arg, locale).await;
 
         if let Ok(token) = token_manager.get_tenant_token().await {
             let chunks = split_message(&response, 4000);
@@ -1134,7 +1144,7 @@ async fn handle_message_event(
             let _ = reply_feishu_message(
                 &token,
                 &message_id,
-                "Session reset. A new session will be created for your next message.",
+                &i18n::t(i18n::MsgKey::SessionReset, locale),
             )
             .await;
         }
@@ -1145,7 +1155,7 @@ async fn handle_message_event(
     if clean_text.eq_ignore_ascii_case("/stop") {
         println!("[Feishu] Stop command received");
         let response =
-            super::handle_stop_command(opencode_port, session_mapping, &session_key).await;
+            super::handle_stop_command(opencode_port, session_mapping, &session_key, locale).await;
         if let Ok(token) = token_manager.get_tenant_token().await {
             let _ = reply_feishu_message(&token, &message_id, &response).await;
         }
@@ -1163,7 +1173,7 @@ async fn handle_message_event(
         };
         println!("[Feishu] Sessions command received, arg: '{}'", arg);
         let response =
-            super::handle_sessions_command(opencode_port, session_mapping, &session_key, arg).await;
+            super::handle_sessions_command(opencode_port, session_mapping, &session_key, arg, locale).await;
 
         if let Ok(token) = token_manager.get_tenant_token().await {
             let chunks = split_message(&response, 4000);
@@ -1278,6 +1288,7 @@ async fn handle_message_event(
                         let tm_app_id_for_q = tm.app_id.clone();
                         let tm_app_secret_for_q = tm.app_secret.clone();
                         let message_id_for_q = message_id_owned.clone();
+                        let locale_for_q = locale;
                         let question_ctx = super::QuestionContext {
                             forwarder: Box::new(move |fq: super::ForwardedQuestion| {
                                 let app_id = tm_app_id_for_q.clone();
@@ -1292,6 +1303,7 @@ async fn handle_message_event(
                                     let text = super::format_question_message(
                                         &fq.questions,
                                         &fq.question_id,
+                                        locale_for_q,
                                     );
                                     reply_feishu_message(&token, &mid, &text).await
                                 })

--- a/src-tauri/src/commands/gateway/feishu.rs
+++ b/src-tauri/src/commands/gateway/feishu.rs
@@ -397,6 +397,8 @@ pub struct FeishuGateway {
     config: Arc<RwLock<FeishuConfig>>,
     session_mapping: SessionMapping,
     opencode_port: u16,
+    #[allow(dead_code)]
+    workspace_path: String,
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     status: Arc<RwLock<FeishuGatewayStatusResponse>>,
     is_running: Arc<RwLock<bool>>,
@@ -407,11 +409,12 @@ pub struct FeishuGateway {
 }
 
 impl FeishuGateway {
-    pub fn new(opencode_port: u16, session_mapping: SessionMapping) -> Self {
+    pub fn new(opencode_port: u16, session_mapping: SessionMapping, workspace_path: String) -> Self {
         Self {
             config: Arc::new(RwLock::new(FeishuConfig::default())),
             session_mapping,
             opencode_port,
+            workspace_path,
             shutdown_tx: Arc::new(RwLock::new(None)),
             status: Arc::new(RwLock::new(FeishuGatewayStatusResponse::default())),
             is_running: Arc::new(RwLock::new(false)),
@@ -542,6 +545,7 @@ impl Clone for FeishuGateway {
             config: Arc::clone(&self.config),
             session_mapping: self.session_mapping.clone(),
             opencode_port: self.opencode_port,
+            workspace_path: self.workspace_path.clone(),
             shutdown_tx: Arc::clone(&self.shutdown_tx),
             status: Arc::clone(&self.status),
             is_running: Arc::clone(&self.is_running),

--- a/src-tauri/src/commands/gateway/i18n.rs
+++ b/src-tauri/src/commands/gateway/i18n.rs
@@ -1,0 +1,340 @@
+use super::read_config;
+
+/// Supported locales
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Locale {
+    En,
+    ZhCN,
+}
+
+impl Locale {
+    pub fn from_str(s: &str) -> Locale {
+        match s {
+            "zh-CN" | "zh" | "zh-cn" => Locale::ZhCN,
+            _ => Locale::En,
+        }
+    }
+}
+
+/// Read locale from teamclaw.json config, defaulting to En
+pub fn get_locale(workspace_path: &str) -> Locale {
+    read_config(workspace_path)
+        .ok()
+        .and_then(|c| c.locale)
+        .map(|s| Locale::from_str(&s))
+        .unwrap_or(Locale::En)
+}
+
+/// All translatable message keys
+pub enum MsgKey<'a> {
+    // === Shared: /model command ===
+    CurrentModelCustom(&'a str),
+    CurrentModelDefault(&'a str),
+    AvailableModels,
+    ModelSwitchUsage,
+    ModelSwitched(&'a str),
+    ModelResetToDefault,
+    ModelNotFound(&'a str),
+    FailedToGetModels(&'a str),
+    ModelListTruncated,
+    ModelCurrentMarker,
+
+    // === Shared: /sessions command ===
+    NoSessionsFound,
+    RecentSessions,
+    Untitled,
+    CurrentSessionMarker,
+    SessionsSwitchUsage,
+    InvalidSessionNumber(&'a str),
+    SessionNotFound(usize, usize),
+    SwitchedToSession(&'a str),
+    SwitchedToSessionWithLatest(&'a str, &'a str),
+    SwitchedToSessionNoLatest(&'a str),
+    FailedToListSessions(&'a str),
+    NoAssistantMessages,
+
+    // === Shared: /stop command ===
+    NoActiveSession,
+    SessionStopped,
+    FailedToStopSession(&'a str),
+    FailedToStopSessionWithStatus(u16, &'a str),
+
+    // === Shared: time formatting ===
+    JustNow,
+    MinAgo(i64),
+    HrAgo(i64),
+    DayAgo(i64),
+
+    // === Shared: session reset ===
+    SessionReset,
+
+    // === Shared: /answer responses ===
+    AnswerSubmitted(&'a str),
+    NoPendingQuestions,
+
+    // === Shared: pending question prompt ===
+    PendingQuestionUsage,
+    PendingQuestionExample(&'a str),
+
+    // === Queue messages (WeChat, WeCom) ===
+    QueueTimeout,
+    QueueFull,
+    GatewayShuttingDown,
+    MessageCouldNotBeProcessed,
+
+    // === Error fallback ===
+    ModelEmptyResponse,
+
+    // === Unknown command ===
+    UnknownCommand(&'a str),
+
+    // === /help per-gateway ===
+    HelpWechat,
+    HelpWecom,
+    HelpDiscord,
+    HelpKook,
+
+    // === WeCom welcome ===
+    WecomWelcome,
+
+    // === Discord specific ===
+    LoadingSessions,
+
+    // === KOOK card-specific ===
+    KookCardHeaderModels,
+    KookCardCurrentModel(&'a str, bool),
+    KookCardHeaderHelp,
+    KookCardHelpUsage,
+}
+
+/// Return the translated string for a given key and locale
+pub fn t(key: MsgKey, locale: Locale) -> String {
+    use Locale::*;
+    use MsgKey::*;
+    match (key, locale) {
+        // === /model command ===
+        (CurrentModelCustom(m), En) => format!("**Current Model:** `{}` (custom)\n\n", m),
+        (CurrentModelCustom(m), ZhCN) => format!("**当前模型:** `{}` (自定义)\n\n", m),
+
+        (CurrentModelDefault(m), En) => format!("**Current Model:** `{}` (default)\n\n", m),
+        (CurrentModelDefault(m), ZhCN) => format!("**当前模型:** `{}` (默认)\n\n", m),
+
+        (AvailableModels, En) => "**Available Models:**\n".into(),
+        (AvailableModels, ZhCN) => "**可用模型:**\n".into(),
+
+        (ModelSwitchUsage, En) => "\n\nUse `/model <provider/model>` to switch.\nUse `/model default` to reset to default.".into(),
+        (ModelSwitchUsage, ZhCN) => "\n\n使用 `/model <provider/model>` 切换模型。\n使用 `/model default` 恢复默认。".into(),
+
+        (ModelSwitched(m), En) => format!("Model switched to: `{}`\nAll subsequent messages in this context will use this model.", m),
+        (ModelSwitched(m), ZhCN) => format!("模型已切换为: `{}`\n后续消息将使用此模型。", m),
+
+        (ModelResetToDefault, En) => "Model reset to default. Subsequent messages will use the global default model.".into(),
+        (ModelResetToDefault, ZhCN) => "已恢复默认模型，后续消息将使用全局默认模型。".into(),
+
+        (ModelNotFound(m), En) => format!("Model `{}` not found. Use `/model` to see available models.", m),
+        (ModelNotFound(m), ZhCN) => format!("模型 `{}` 未找到。使用 `/model` 查看可用模型。", m),
+
+        (FailedToGetModels(e), En) => format!("Failed to get models: {}", e),
+        (FailedToGetModels(e), ZhCN) => format!("获取模型列表失败: {}", e),
+
+        (ModelListTruncated, En) => "\n_(List truncated due to length. Visit OpenCode UI for full model list.)_".into(),
+        (ModelListTruncated, ZhCN) => "\n_(列表过长已截断，请在 OpenCode 界面查看完整列表。)_".into(),
+
+        (ModelCurrentMarker, En) => " ← current".into(),
+        (ModelCurrentMarker, ZhCN) => " ← 当前".into(),
+
+        // === /sessions command ===
+        (NoSessionsFound, En) => "No sessions found.".into(),
+        (NoSessionsFound, ZhCN) => "暂无会话。".into(),
+
+        (RecentSessions, En) => "**Recent Sessions:**\n".into(),
+        (RecentSessions, ZhCN) => "**最近会话:**\n".into(),
+
+        (Untitled, En) => "(untitled)".into(),
+        (Untitled, ZhCN) => "(无标题)".into(),
+
+        (CurrentSessionMarker, En) => "  <-- current".into(),
+        (CurrentSessionMarker, ZhCN) => "  <-- 当前".into(),
+
+        (SessionsSwitchUsage, En) => "\nUse `/sessions <number>` to switch.".into(),
+        (SessionsSwitchUsage, ZhCN) => "\n使用 `/sessions <编号>` 切换会话。".into(),
+
+        (InvalidSessionNumber(s), En) => format!("`{}` is not a valid session number. Use `/sessions` to see the list.", s),
+        (InvalidSessionNumber(s), ZhCN) => format!("`{}` 不是有效的会话编号。使用 `/sessions` 查看列表。", s),
+
+        (SessionNotFound(num, total), En) => format!("Session #{} not found. There are only {} sessions.", num, total),
+        (SessionNotFound(num, total), ZhCN) => format!("会话 #{} 不存在，当前共有 {} 个会话。", num, total),
+
+        (SwitchedToSession(title), En) => format!("Switched to session: \"{}\"", title),
+        (SwitchedToSession(title), ZhCN) => format!("已切换到会话: \"{}\"", title),
+
+        (SwitchedToSessionWithLatest(title, latest), En) => {
+            format!("Switched to session: \"{}\"\n\n**Latest response:**\n{}", title, latest)
+        }
+        (SwitchedToSessionWithLatest(title, latest), ZhCN) => {
+            format!("已切换到会话: \"{}\"\n\n**最近回复:**\n{}", title, latest)
+        }
+
+        (SwitchedToSessionNoLatest(title), En) => {
+            format!("Switched to session: \"{}\"\n\nSubsequent messages will be sent to this session.", title)
+        }
+        (SwitchedToSessionNoLatest(title), ZhCN) => {
+            format!("已切换到会话: \"{}\"\n\n后续消息将发送到此会话。", title)
+        }
+
+        (FailedToListSessions(e), En) => format!("Failed to list sessions: {}", e),
+        (FailedToListSessions(e), ZhCN) => format!("获取会话列表失败: {}", e),
+
+        (NoAssistantMessages, En) => "(no assistant messages yet)".into(),
+        (NoAssistantMessages, ZhCN) => "(暂无助手消息)".into(),
+
+        // === /stop command ===
+        (NoActiveSession, En) => "No active session. Nothing to stop.".into(),
+        (NoActiveSession, ZhCN) => "没有活跃会话，无需停止。".into(),
+
+        (SessionStopped, En) => "Session processing stopped.".into(),
+        (SessionStopped, ZhCN) => "会话处理已停止。".into(),
+
+        (FailedToStopSession(e), En) => format!("Failed to stop session: {}", e),
+        (FailedToStopSession(e), ZhCN) => format!("停止会话失败: {}", e),
+
+        (FailedToStopSessionWithStatus(status, body), En) => format!("Failed to stop session ({}): {}", status, body),
+        (FailedToStopSessionWithStatus(status, body), ZhCN) => format!("停止会话失败 ({}): {}", status, body),
+
+        // === Time formatting ===
+        (JustNow, En) => "just now".into(),
+        (JustNow, ZhCN) => "刚刚".into(),
+
+        (MinAgo(n), En) => format!("{} min ago", n),
+        (MinAgo(n), ZhCN) => format!("{} 分钟前", n),
+
+        (HrAgo(n), En) => format!("{} hr ago", n),
+        (HrAgo(n), ZhCN) => format!("{} 小时前", n),
+
+        (DayAgo(n), En) => format!("{} day ago", n),
+        (DayAgo(n), ZhCN) => format!("{} 天前", n),
+
+        // === Session reset ===
+        (SessionReset, En) => "Session reset. Next message will start a new conversation.".into(),
+        (SessionReset, ZhCN) => "会话已重置，下一条消息将开始新对话。".into(),
+
+        // === /answer responses ===
+        (AnswerSubmitted(text), En) => format!("✓ Answered: {}", text),
+        (AnswerSubmitted(text), ZhCN) => format!("✓ 已回复: {}", text),
+
+        (NoPendingQuestions, En) => "No pending questions to answer.".into(),
+        (NoPendingQuestions, ZhCN) => "当前没有待回复的问题。".into(),
+
+        // === Pending question prompt ===
+        (PendingQuestionUsage, En) => "Reply with /answer <number or text>, valid for 5 minutes\n".into(),
+        (PendingQuestionUsage, ZhCN) => "请用 /answer <序号或内容> 回复，5分钟内有效\n".into(),
+
+        (PendingQuestionExample(qid), En) => format!("e.g.: /answer 1\n[Q:{}]", qid),
+        (PendingQuestionExample(qid), ZhCN) => format!("例如: /answer 1\n[Q:{}]", qid),
+
+        // === Queue messages ===
+        (QueueTimeout, En) => "Message queue timeout, please try again.".into(),
+        (QueueTimeout, ZhCN) => "消息排队超时，请重试。".into(),
+
+        (QueueFull, En) => "Too many messages, please wait.".into(),
+        (QueueFull, ZhCN) => "消息过多，请稍候。".into(),
+
+        (GatewayShuttingDown, En) => "Gateway is shutting down.".into(),
+        (GatewayShuttingDown, ZhCN) => "网关正在关闭。".into(),
+
+        (MessageCouldNotBeProcessed, En) => "Your message could not be processed. Please resend.".into(),
+        (MessageCouldNotBeProcessed, ZhCN) => "消息处理失败，请重新发送。".into(),
+
+        // === Error fallback ===
+        (ModelEmptyResponse, En) => "The model returned no text content. Please try again or rephrase.".into(),
+        (ModelEmptyResponse, ZhCN) => "模型未返回文字内容，请稍后重试或换种说法。".into(),
+
+        // === Unknown command ===
+        (UnknownCommand(cmd), En) => format!("Unknown command: {}\nType /help for available commands.", cmd),
+        (UnknownCommand(cmd), ZhCN) => format!("未知命令: {}\n输入 /help 查看可用命令。", cmd),
+
+        // === /help per-gateway ===
+        (HelpWechat, En) => "Available commands:\n\
+            /help - Show this help\n\
+            /model [name] - List or switch models\n\
+            /sessions [id] - List or bind sessions\n\
+            /reset - Start new session\n\
+            /stop - Stop current processing\n\
+            /answer - Reply to an AI clarification (see bot message)".into(),
+        (HelpWechat, ZhCN) => "可用命令:\n\
+            /help - 显示帮助\n\
+            /model [名称] - 查看或切换模型\n\
+            /sessions [编号] - 查看或绑定会话\n\
+            /reset - 开始新会话\n\
+            /stop - 停止当前处理\n\
+            /answer - 回复 AI 的澄清问题（见机器人消息）".into(),
+
+        (HelpWecom, En) => "Available commands:\n\
+            /help - Show this help\n\
+            /model [name] - List or switch models\n\
+            /sessions [id] - List or bind sessions\n\
+            /reset - Start new session\n\
+            /stop - Stop current processing".into(),
+        (HelpWecom, ZhCN) => "可用命令:\n\
+            /help - 显示帮助\n\
+            /model [名称] - 查看或切换模型\n\
+            /sessions [编号] - 查看或绑定会话\n\
+            /reset - 开始新会话\n\
+            /stop - 停止当前处理".into(),
+
+        (HelpDiscord, En) => "**TeamClaw Bot Commands**\n\n\
+            /reset - Reset the current chat session\n\
+            /model - View current model or switch models\n\
+            /sessions - List or switch sessions\n\
+            /stop - Stop the current processing\n\
+            /help - Show this help message\n\n\
+            **How to use:**\n\
+            • In DMs: Just send a message to start chatting\n\
+            • In channels: Mention the bot or reply to its messages\n\n\
+            You can also send images along with your messages!".into(),
+        (HelpDiscord, ZhCN) => "**TeamClaw 机器人命令**\n\n\
+            /reset - 重置当前聊天会话\n\
+            /model - 查看或切换模型\n\
+            /sessions - 查看或切换会话\n\
+            /stop - 停止当前处理\n\
+            /help - 显示帮助\n\n\
+            **使用方法:**\n\
+            • 私聊: 直接发消息开始对话\n\
+            • 频道: @机器人 或回复机器人消息\n\n\
+            你也可以在消息中附带图片！".into(),
+
+        (HelpKook, En) => "/reset - Reset the current chat session\n\
+            /model - View current model or switch models\n\
+            /sessions - List or switch sessions\n\
+            /stop - Stop the current processing\n\
+            /help - Show this help message".into(),
+        (HelpKook, ZhCN) => "/reset - 重置当前聊天会话\n\
+            /model - 查看或切换模型\n\
+            /sessions - 查看或切换会话\n\
+            /stop - 停止当前处理\n\
+            /help - 显示帮助".into(),
+
+        // === WeCom welcome ===
+        (WecomWelcome, En) => "Hello! I'm an AI assistant. Send me a message to start a conversation, or type /help for available commands.".into(),
+        (WecomWelcome, ZhCN) => "你好！我是 AI 助手。直接发消息给我开始对话，发送 /help 查看可用命令。".into(),
+
+        // === Discord specific ===
+        (LoadingSessions, En) => "Loading sessions...".into(),
+        (LoadingSessions, ZhCN) => "正在加载会话...".into(),
+
+        // === KOOK card-specific ===
+        (KookCardHeaderModels, En) => "Available Models".into(),
+        (KookCardHeaderModels, ZhCN) => "可用模型".into(),
+
+        (KookCardCurrentModel(model, true), En) => format!("**Current Model:** {} (custom)", model),
+        (KookCardCurrentModel(model, true), ZhCN) => format!("**当前模型:** {} (自定义)", model),
+        (KookCardCurrentModel(model, false), En) => format!("**Current Model:** {} (default)", model),
+        (KookCardCurrentModel(model, false), ZhCN) => format!("**当前模型:** {} (默认)", model),
+
+        (KookCardHeaderHelp, En) => "TeamClaw Bot Commands".into(),
+        (KookCardHeaderHelp, ZhCN) => "TeamClaw 机器人命令".into(),
+
+        (KookCardHelpUsage, En) => "In DMs: Just send a message to start chatting. In channels: Send messages directly.".into(),
+        (KookCardHelpUsage, ZhCN) => "私聊: 直接发消息开始对话。频道: 直接发送消息即可。".into(),
+    }
+}

--- a/src-tauri/src/commands/gateway/kook.rs
+++ b/src-tauri/src/commands/gateway/kook.rs
@@ -89,6 +89,8 @@ pub struct KookGateway {
     config: Arc<RwLock<KookConfig>>,
     session_mapping: SessionMapping,
     opencode_port: u16,
+    #[allow(dead_code)]
+    workspace_path: String,
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     status: Arc<RwLock<KookGatewayStatusResponse>>,
     is_running: Arc<RwLock<bool>>,
@@ -107,11 +109,12 @@ pub struct KookGateway {
 }
 
 impl KookGateway {
-    pub fn new(opencode_port: u16, session_mapping: SessionMapping) -> Self {
+    pub fn new(opencode_port: u16, session_mapping: SessionMapping, workspace_path: String) -> Self {
         Self {
             config: Arc::new(RwLock::new(KookConfig::default())),
             session_mapping,
             opencode_port,
+            workspace_path,
             shutdown_tx: Arc::new(RwLock::new(None)),
             status: Arc::new(RwLock::new(KookGatewayStatusResponse::default())),
             is_running: Arc::new(RwLock::new(false)),
@@ -1553,6 +1556,7 @@ impl Clone for KookGateway {
             config: Arc::clone(&self.config),
             session_mapping: self.session_mapping.clone(),
             opencode_port: self.opencode_port,
+            workspace_path: self.workspace_path.clone(),
             shutdown_tx: Arc::clone(&self.shutdown_tx),
             status: Arc::clone(&self.status),
             is_running: Arc::clone(&self.is_running),

--- a/src-tauri/src/commands/gateway/kook.rs
+++ b/src-tauri/src/commands/gateway/kook.rs
@@ -11,6 +11,7 @@ use super::kook_config::{KookConfig, KookGatewayStatus, KookGatewayStatusRespons
 use super::session::SessionMapping;
 
 use super::{FilterResult, ProcessedMessageTracker, MAX_PROCESSED_MESSAGES};
+use super::i18n;
 
 /// Maximum number of buffered out-of-order messages
 const MAX_BUFFER_SIZE: usize = 100;
@@ -926,6 +927,7 @@ impl KookGateway {
         drop(bot_id);
 
         // Check for /answer command — routes reply to the most recent pending question
+        let locale = i18n::get_locale(&self.workspace_path);
         if let Some(answer_text) = super::PendingQuestionStore::parse_answer_command(&content) {
             if let Some(qid) = self.pending_questions.try_answer(answer_text).await {
                 println!(
@@ -933,10 +935,10 @@ impl KookGateway {
                     qid, answer_text
                 );
                 let _ = self
-                    .send_reply(msg, &format!("✓ 已回复: {}", answer_text))
+                    .send_reply(msg, &i18n::t(i18n::MsgKey::AnswerSubmitted(answer_text), locale))
                     .await;
             } else {
-                let _ = self.send_reply(msg, "当前没有待回复的问题").await;
+                let _ = self.send_reply(msg, &i18n::t(i18n::MsgKey::NoPendingQuestions, locale)).await;
             }
             return Ok(());
         }
@@ -962,13 +964,14 @@ impl KookGateway {
             msg.target_id.clone()
         };
         let channel_type = msg.channel_type.clone();
+        let locale_for_q = i18n::get_locale(&self.workspace_path);
         let question_ctx = super::QuestionContext {
             forwarder: Box::new(move |fq: super::ForwardedQuestion| {
                 let token = qctx_config.token.clone();
                 let target = target.clone();
                 let ct = channel_type.clone();
                 Box::pin(async move {
-                    let text = super::format_question_message(&fq.questions, &fq.question_id);
+                    let text = super::format_question_message(&fq.questions, &fq.question_id, locale_for_q);
                     let client = reqwest::Client::new();
                     let (url, body) = if ct == "PERSON" {
                         (
@@ -1289,6 +1292,7 @@ impl KookGateway {
         content: &str,
         msg: &KookMessageData,
     ) -> Result<(), String> {
+        let locale = i18n::get_locale(&self.workspace_path);
         let parts: Vec<&str> = content.trim().split_whitespace().collect();
         let command = parts.first().map(|s| s.to_lowercase()).unwrap_or_default();
         let arg = parts.get(1..).map(|s| s.join(" ")).unwrap_or_default();
@@ -1298,7 +1302,7 @@ impl KookGateway {
                 self.session_mapping.remove_session(session_key).await;
                 self.send_reply(
                     msg,
-                    "Session reset! A new conversation will start with your next message.",
+                    &i18n::t(i18n::MsgKey::SessionReset, locale),
                 )
                 .await?;
             }
@@ -1312,6 +1316,7 @@ impl KookGateway {
                     &self.session_mapping,
                     session_key,
                     &arg,
+                    locale,
                 )
                 .await;
                 self.send_reply(msg, &response).await?;
@@ -1322,6 +1327,7 @@ impl KookGateway {
                     &self.session_mapping,
                     session_key,
                     &arg,
+                    locale,
                 )
                 .await;
                 self.send_reply(msg, &response).await?;
@@ -1331,6 +1337,7 @@ impl KookGateway {
                     self.opencode_port,
                     &self.session_mapping,
                     session_key,
+                    locale,
                 )
                 .await;
                 self.send_reply(msg, &response).await?;
@@ -1356,13 +1363,12 @@ impl KookGateway {
             .await
             .map_err(|e| format!("Failed to get models: {}", e))?;
 
+        let locale = i18n::get_locale(&self.workspace_path);
         let stored = self.session_mapping.get_model(session_key).await;
         let (active, is_custom) = match &stored {
             Some(m) => (m.as_str(), true),
             None => (default_model.as_str(), false),
         };
-
-        let current_label = if is_custom { "custom" } else { "default" };
 
         // Group models by provider
         let mut provider_groups: std::collections::BTreeMap<String, Vec<&super::ModelInfo>> =
@@ -1378,13 +1384,13 @@ impl KookGateway {
         let mut modules: Vec<serde_json::Value> = vec![
             json!({
                 "type": "header",
-                "text": { "type": "plain-text", "content": "Available Models" }
+                "text": { "type": "plain-text", "content": i18n::t(i18n::MsgKey::KookCardHeaderModels, locale) }
             }),
             json!({
                 "type": "section",
                 "text": {
                     "type": "kmarkdown",
-                    "content": format!("**Current Model:** {} ({})", active, current_label)
+                    "content": i18n::t(i18n::MsgKey::KookCardCurrentModel(active, is_custom), locale)
                 }
             }),
             json!({ "type": "divider" }),
@@ -1397,9 +1403,9 @@ impl KookGateway {
                 .map(|m| {
                     let full_id = format!("{}/{}", m.provider, m.id);
                     let marker = if full_id == active {
-                        " ← current"
+                        i18n::t(i18n::MsgKey::ModelCurrentMarker, locale)
                     } else {
-                        ""
+                        String::new()
                     };
                     format!("{} ({}){}", full_id, m.name, marker)
                 })
@@ -1421,7 +1427,7 @@ impl KookGateway {
                     "type": "section",
                     "text": {
                         "type": "kmarkdown",
-                        "content": "_(List truncated. Visit OpenCode UI for full model list.)_"
+                        "content": i18n::t(i18n::MsgKey::ModelListTruncated, locale)
                     }
                 }));
                 break;
@@ -1433,7 +1439,7 @@ impl KookGateway {
             "type": "context",
             "elements": [{
                 "type": "kmarkdown",
-                "content": "Use `/model provider/model` to switch. Use `/model default` to reset."
+                "content": i18n::t(i18n::MsgKey::ModelSwitchUsage, locale)
             }]
         }));
 
@@ -1449,6 +1455,7 @@ impl KookGateway {
 
     /// Send help as a well-structured card
     async fn send_help_card(&self, msg: &KookMessageData) -> Result<(), String> {
+        let locale = i18n::get_locale(&self.workspace_path);
         let card = json!([{
             "type": "card",
             "theme": "info",
@@ -1456,13 +1463,13 @@ impl KookGateway {
             "modules": [
                 {
                     "type": "header",
-                    "text": { "type": "plain-text", "content": "TeamClaw Bot Commands" }
+                    "text": { "type": "plain-text", "content": i18n::t(i18n::MsgKey::KookCardHeaderHelp, locale) }
                 },
                 {
                     "type": "section",
                     "text": {
                         "type": "kmarkdown",
-                        "content": "/reset - Reset the current chat session\n/model - View current model or switch models\n/sessions - List or switch sessions\n/stop - Stop the current processing\n/help - Show this help message"
+                        "content": i18n::t(i18n::MsgKey::HelpKook, locale)
                     }
                 },
                 { "type": "divider" },
@@ -1470,7 +1477,7 @@ impl KookGateway {
                     "type": "context",
                     "elements": [{
                         "type": "kmarkdown",
-                        "content": "In DMs: Just send a message to start chatting. In channels: Send messages directly."
+                        "content": i18n::t(i18n::MsgKey::KookCardHelpUsage, locale)
                     }]
                 }
             ]

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -1325,7 +1325,7 @@ pub async fn start_gateway(
 
         let session_mapping = gateway_state.shared_session_mapping.clone();
         let gateway =
-            gateway_guard.get_or_insert_with(|| DiscordGateway::new(port, session_mapping));
+            gateway_guard.get_or_insert_with(|| DiscordGateway::new(port, session_mapping, workspace_path.clone()));
         gateway.clone()
     };
 
@@ -1465,7 +1465,7 @@ pub async fn start_feishu_gateway(
 
         let session_mapping = gateway_state.shared_session_mapping.clone();
         let gateway =
-            gateway_guard.get_or_insert_with(|| FeishuGateway::new(port, session_mapping));
+            gateway_guard.get_or_insert_with(|| FeishuGateway::new(port, session_mapping, workspace_path.clone()));
         gateway.clone()
     };
 
@@ -1801,7 +1801,7 @@ pub async fn start_kook_gateway(
             .map_err(|e| e.to_string())?;
 
         if guard.is_none() {
-            let gateway = KookGateway::new(port, gateway_state.shared_session_mapping.clone());
+            let gateway = KookGateway::new(port, gateway_state.shared_session_mapping.clone(), workspace_path.clone());
             *guard = Some(gateway);
         }
 
@@ -2005,7 +2005,7 @@ pub async fn start_wecom_gateway(
             .map_err(|e| e.to_string())?;
 
         if guard.is_none() {
-            let gateway = WeComGateway::new(port, gateway_state.shared_session_mapping.clone());
+            let gateway = WeComGateway::new(port, gateway_state.shared_session_mapping.clone(), workspace_path.clone());
             *guard = Some(gateway);
         }
 
@@ -2224,7 +2224,7 @@ pub async fn start_wechat_gateway(
             .map_err(|e| e.to_string())?;
 
         if guard.is_none() {
-            let gateway = WeChatGateway::new(port, gateway_state.shared_session_mapping.clone());
+            let gateway = WeChatGateway::new(port, gateway_state.shared_session_mapping.clone(), workspace_path.clone());
             *guard = Some(gateway);
         }
 
@@ -2233,7 +2233,6 @@ pub async fn start_wechat_gateway(
 
     if let Some(gw) = gateway_clone {
         gw.set_config(wechat_cfg).await;
-        gw.set_workspace_path(workspace_path).await;
         gw.start().await?;
     }
 

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -708,25 +708,18 @@ pub async fn opencode_get_available_models(port: u16) -> Result<(Vec<ModelInfo>,
 }
 
 /// Format the model list response for chat commands
-fn format_model_list(models: &[ModelInfo], active_model: &str, is_custom: bool) -> String {
+fn format_model_list(models: &[ModelInfo], active_model: &str, is_custom: bool, locale: i18n::Locale) -> String {
     const MAX_LENGTH: usize = 1900; // Leave buffer for Discord's 2000 char limit
 
     let mut text = String::new();
     if is_custom {
-        text.push_str(&format!(
-            "**Current Model:** `{}` (custom)\n\n",
-            active_model
-        ));
+        text.push_str(&i18n::t(i18n::MsgKey::CurrentModelCustom(active_model), locale));
     } else {
-        text.push_str(&format!(
-            "**Current Model:** `{}` (default)\n\n",
-            active_model
-        ));
+        text.push_str(&i18n::t(i18n::MsgKey::CurrentModelDefault(active_model), locale));
     }
-    text.push_str("**Available Models:**\n");
+    text.push_str(&i18n::t(i18n::MsgKey::AvailableModels, locale));
 
-    let footer =
-        "\n\nUse `/model <provider/model>` to switch.\nUse `/model default` to reset to default.";
+    let footer = i18n::t(i18n::MsgKey::ModelSwitchUsage, locale);
     let footer_len = footer.len();
 
     // Group models by provider for better readability
@@ -758,9 +751,9 @@ fn format_model_list(models: &[ModelInfo], active_model: &str, is_custom: bool) 
             for m in models_in_provider {
                 let full_id = format!("{}/{}", m.provider, m.id);
                 let marker = if full_id == active_model {
-                    " ← current"
+                    i18n::t(i18n::MsgKey::ModelCurrentMarker, locale)
                 } else {
-                    ""
+                    String::new()
                 };
                 let line = format!("• `{}` ({}){}\n", full_id, m.name, marker);
 
@@ -780,19 +773,16 @@ fn format_model_list(models: &[ModelInfo], active_model: &str, is_custom: bool) 
     }
 
     if truncated {
-        text.push_str("\n_(List truncated due to length. Visit OpenCode UI for full model list.)_");
+        text.push_str(&i18n::t(i18n::MsgKey::ModelListTruncated, locale));
     }
 
-    text.push_str(footer);
+    text.push_str(&footer);
     text
 }
 
 /// Format the model switch success response
-fn format_model_switched(new_model: &str) -> String {
-    format!(
-        "Model switched to: `{}`\nAll subsequent messages in this context will use this model.",
-        new_model
-    )
+fn format_model_switched(new_model: &str, locale: i18n::Locale) -> String {
+    i18n::t(i18n::MsgKey::ModelSwitched(new_model), locale)
 }
 
 /// Handle the /model command logic (shared between gateways).
@@ -807,6 +797,7 @@ pub async fn handle_model_command(
     session_mapping: &SessionMapping,
     session_key: &str,
     arg: &str,
+    locale: i18n::Locale,
 ) -> String {
     let arg = arg.trim();
 
@@ -819,14 +810,14 @@ pub async fn handle_model_command(
                     Some(m) => (m.as_str(), true),
                     None => (default_model.as_str(), false),
                 };
-                format_model_list(&models, active, is_custom)
+                format_model_list(&models, active, is_custom, locale)
             }
-            Err(e) => format!("Failed to get models: {}", e),
+            Err(e) => i18n::t(i18n::MsgKey::FailedToGetModels(&e.to_string()), locale),
         }
     } else if arg.eq_ignore_ascii_case("default") {
         // Reset to default model
         session_mapping.remove_model(session_key).await;
-        "Model reset to default. Subsequent messages will use the global default model.".to_string()
+        i18n::t(i18n::MsgKey::ModelResetToDefault, locale)
     } else {
         // Validate model exists then store preference
         match opencode_get_available_models(port).await {
@@ -838,15 +829,12 @@ pub async fn handle_model_command(
                     session_mapping
                         .set_model(session_key.to_string(), arg.to_string())
                         .await;
-                    format_model_switched(arg)
+                    format_model_switched(arg, locale)
                 } else {
-                    format!(
-                        "Model `{}` not found. Use `/model` to see available models.",
-                        arg
-                    )
+                    i18n::t(i18n::MsgKey::ModelNotFound(arg), locale)
                 }
             }
-            Err(e) => format!("Failed to get models: {}", e),
+            Err(e) => i18n::t(i18n::MsgKey::FailedToGetModels(&e.to_string()), locale),
         }
     }
 }
@@ -920,7 +908,7 @@ pub async fn opencode_list_sessions(port: u16) -> Result<Vec<SessionInfo>, Strin
 }
 
 /// Fetch the latest assistant message text from a session
-async fn fetch_latest_assistant_message(port: u16, session_id: &str) -> Result<String, String> {
+async fn fetch_latest_assistant_message(port: u16, session_id: &str, locale: i18n::Locale) -> Result<String, String> {
     let client = reqwest::Client::new();
     let url = format!("http://127.0.0.1:{}/session/{}/message", port, session_id);
 
@@ -964,11 +952,11 @@ async fn fetch_latest_assistant_message(port: u16, session_id: &str) -> Result<S
         }
     }
 
-    Ok("(no assistant messages yet)".to_string())
+    Ok(i18n::t(i18n::MsgKey::NoAssistantMessages, locale))
 }
 
 /// Format a relative time string from a unix timestamp (seconds)
-fn format_relative_time(timestamp_secs: i64) -> String {
+fn format_relative_time(timestamp_secs: i64, locale: i18n::Locale) -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
@@ -983,16 +971,16 @@ fn format_relative_time(timestamp_secs: i64) -> String {
 
     let diff = now - ts;
     if diff < 60 {
-        "just now".to_string()
+        i18n::t(i18n::MsgKey::JustNow, locale)
     } else if diff < 3600 {
         let mins = diff / 60;
-        format!("{} min ago", mins)
+        i18n::t(i18n::MsgKey::MinAgo(mins), locale)
     } else if diff < 86400 {
         let hours = diff / 3600;
-        format!("{} hr ago", hours)
+        i18n::t(i18n::MsgKey::HrAgo(hours), locale)
     } else {
         let days = diff / 86400;
-        format!("{} day ago", days)
+        i18n::t(i18n::MsgKey::DayAgo(days), locale)
     }
 }
 
@@ -1007,6 +995,7 @@ pub async fn handle_sessions_command(
     session_mapping: &SessionMapping,
     session_key: &str,
     arg: &str,
+    locale: i18n::Locale,
 ) -> String {
     let arg = arg.trim();
 
@@ -1015,50 +1004,45 @@ pub async fn handle_sessions_command(
         match opencode_list_sessions(port).await {
             Ok(sessions) => {
                 if sessions.is_empty() {
-                    return "No sessions found.".to_string();
+                    return i18n::t(i18n::MsgKey::NoSessionsFound, locale);
                 }
 
                 let current_session = session_mapping.get_session(session_key).await;
+                let untitled = i18n::t(i18n::MsgKey::Untitled, locale);
+                let current_marker = i18n::t(i18n::MsgKey::CurrentSessionMarker, locale);
 
-                let mut text = String::from("**Recent Sessions:**\n");
+                let mut text = i18n::t(i18n::MsgKey::RecentSessions, locale);
                 for (i, s) in sessions.iter().enumerate() {
-                    let time_str = format_relative_time(s.updated);
+                    let time_str = format_relative_time(s.updated, locale);
                     let title = if s.title.is_empty() {
-                        "(untitled)"
+                        &untitled
                     } else {
                         &s.title
                     };
                     let marker = match &current_session {
-                        Some(id) if *id == s.id => "  <-- current",
+                        Some(id) if *id == s.id => &current_marker,
                         _ => "",
                     };
-                    text.push_str(&format!("{}. {} ({}){}\n", i + 1, title, time_str, marker,));
+                    text.push_str(&format!("{}. {} ({}){}\n", i + 1, title, time_str, marker));
                 }
-                text.push_str("\nUse `/sessions <number>` to switch.");
+                text.push_str(&i18n::t(i18n::MsgKey::SessionsSwitchUsage, locale));
                 text
             }
-            Err(e) => format!("Failed to list sessions: {}", e),
+            Err(e) => i18n::t(i18n::MsgKey::FailedToListSessions(&e), locale),
         }
     } else {
         // Switch to session by number
         let num: usize = match arg.parse() {
             Ok(n) if n >= 1 => n,
             _ => {
-                return format!(
-                    "`{}` is not a valid session number. Use `/sessions` to see the list.",
-                    arg
-                )
+                return i18n::t(i18n::MsgKey::InvalidSessionNumber(arg), locale);
             }
         };
 
         match opencode_list_sessions(port).await {
             Ok(sessions) => {
                 if num > sessions.len() {
-                    return format!(
-                        "Session #{} not found. There are only {} sessions.",
-                        num,
-                        sessions.len()
-                    );
+                    return i18n::t(i18n::MsgKey::SessionNotFound(num, sessions.len()), locale);
                 }
 
                 let target = &sessions[num - 1];
@@ -1066,29 +1050,24 @@ pub async fn handle_sessions_command(
                     .set_session(session_key.to_string(), target.id.clone())
                     .await;
 
+                let untitled = i18n::t(i18n::MsgKey::Untitled, locale);
                 let title = if target.title.is_empty() {
-                    "(untitled)"
+                    &untitled
                 } else {
                     &target.title
                 };
 
                 // Fetch latest assistant message
-                match fetch_latest_assistant_message(port, &target.id).await {
+                match fetch_latest_assistant_message(port, &target.id, locale).await {
                     Ok(latest) => {
-                        format!(
-                            "Switched to session: \"{}\"\n\n**Latest response:**\n{}",
-                            title, latest
-                        )
+                        i18n::t(i18n::MsgKey::SwitchedToSessionWithLatest(title, &latest), locale)
                     }
                     Err(_) => {
-                        format!(
-                            "Switched to session: \"{}\"\n\nSubsequent messages will be sent to this session.",
-                            title
-                        )
+                        i18n::t(i18n::MsgKey::SwitchedToSessionNoLatest(title), locale)
                     }
                 }
             }
-            Err(e) => format!("Failed to list sessions: {}", e),
+            Err(e) => i18n::t(i18n::MsgKey::FailedToListSessions(&e), locale),
         }
     }
 }
@@ -1105,10 +1084,11 @@ pub async fn handle_stop_command(
     port: u16,
     session_mapping: &SessionMapping,
     session_key: &str,
+    locale: i18n::Locale,
 ) -> String {
     let session_id = match session_mapping.get_session(session_key).await {
         Some(id) => id,
-        None => return "No active session. Nothing to stop.".to_string(),
+        None => return i18n::t(i18n::MsgKey::NoActiveSession, locale),
     };
 
     let client = reqwest::Client::new();
@@ -1117,14 +1097,14 @@ pub async fn handle_stop_command(
     match client.post(&url).send().await {
         Ok(resp) => {
             if resp.status().is_success() {
-                "Session processing stopped.".to_string()
+                i18n::t(i18n::MsgKey::SessionStopped, locale)
             } else {
                 let status = resp.status();
                 let body = resp.text().await.unwrap_or_default();
-                format!("Failed to stop session ({}): {}", status, body)
+                i18n::t(i18n::MsgKey::FailedToStopSessionWithStatus(status.as_u16(), &body), locale)
             }
         }
-        Err(e) => format!("Failed to stop session: {}", e),
+        Err(e) => i18n::t(i18n::MsgKey::FailedToStopSession(&e.to_string()), locale),
     }
 }
 

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod discord;
 pub mod email;
 pub mod email_config;
+pub mod i18n;
 pub mod email_db;
 pub mod feishu;
 pub mod feishu_config;
@@ -1133,6 +1134,8 @@ pub struct OpenCodeJsonConfigWithChannels {
     #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
     pub schema: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mcp: Option<HashMap<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channels: Option<ChannelsConfig>,
@@ -1153,7 +1156,7 @@ fn get_config_path(workspace_path: &str) -> String {
 }
 
 /// Read configuration from file
-fn read_config(workspace_path: &str) -> Result<OpenCodeJsonConfigWithChannels, String> {
+pub(crate) fn read_config(workspace_path: &str) -> Result<OpenCodeJsonConfigWithChannels, String> {
     ensure_teamclaw_dir(workspace_path)?;
     let path = get_config_path(workspace_path);
 

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -1265,6 +1265,23 @@ pub async fn save_discord_config(
     Ok(())
 }
 
+/// Set the locale in teamclaw.json for gateway i18n
+#[tauri::command]
+pub async fn set_config_locale(
+    opencode_state: State<'_, OpenCodeState>,
+    locale: String,
+) -> Result<(), String> {
+    let workspace_path = opencode_state
+        .workspace_path
+        .lock()
+        .map_err(|e| e.to_string())?
+        .clone()
+        .ok_or("No workspace path set. Please select a workspace first.")?;
+    let mut config = read_config(&workspace_path)?;
+    config.locale = Some(locale);
+    write_config(&workspace_path, &config)
+}
+
 /// Start the Discord gateway
 #[tauri::command]
 pub async fn start_gateway(

--- a/src-tauri/src/commands/gateway/pending_question.rs
+++ b/src-tauri/src/commands/gateway/pending_question.rs
@@ -438,7 +438,7 @@ mod tests {
                 },
             ],
         }];
-        let msg = format_question_message(&questions, "q_123", super::i18n::Locale::En);
+        let msg = format_question_message(&questions, "q_123", crate::commands::gateway::i18n::Locale::En);
         assert!(msg.contains("Continue with the refactor?"));
         assert!(msg.contains("1. Yes"));
         assert!(msg.contains("2. No"));
@@ -452,7 +452,7 @@ mod tests {
             question: "What should I name this variable?".to_string(),
             options: vec![],
         }];
-        let msg = format_question_message(&questions, "q_456", super::i18n::Locale::En);
+        let msg = format_question_message(&questions, "q_456", crate::commands::gateway::i18n::Locale::En);
         assert!(msg.contains("What should I name this variable?"));
         assert!(!msg.contains("1."));
         assert!(msg.contains("[Q:q_456]"));
@@ -470,7 +470,7 @@ mod tests {
                 options: vec![],
             },
         ];
-        let msg = format_question_message(&questions, "q_multi", super::i18n::Locale::En);
+        let msg = format_question_message(&questions, "q_multi", crate::commands::gateway::i18n::Locale::En);
         assert!(msg.contains("**Question 1:**"));
         assert!(msg.contains("**Question 2:**"));
     }

--- a/src-tauri/src/commands/gateway/pending_question.rs
+++ b/src-tauri/src/commands/gateway/pending_question.rs
@@ -152,7 +152,11 @@ pub fn parse_question_event(event: &serde_json::Value) -> Vec<QuestionInfo> {
 
 // ==================== Formatting ====================
 
-pub fn format_question_message(questions: &[QuestionInfo], question_id: &str) -> String {
+pub fn format_question_message(
+    questions: &[QuestionInfo],
+    question_id: &str,
+    locale: super::i18n::Locale,
+) -> String {
     let mut out = String::from("AI has a question:\n\n");
 
     for (i, q) in questions.iter().enumerate() {
@@ -171,8 +175,14 @@ pub fn format_question_message(questions: &[QuestionInfo], question_id: &str) ->
         out.push('\n');
     }
 
-    out.push_str("请用 /answer <序号或内容> 回复，5分钟内有效\n");
-    out.push_str(&format!("例如: /answer 1\n[Q:{}]", question_id));
+    out.push_str(&super::i18n::t(
+        super::i18n::MsgKey::PendingQuestionUsage,
+        locale,
+    ));
+    out.push_str(&super::i18n::t(
+        super::i18n::MsgKey::PendingQuestionExample(question_id),
+        locale,
+    ));
     out
 }
 
@@ -428,12 +438,12 @@ mod tests {
                 },
             ],
         }];
-        let msg = format_question_message(&questions, "q_123");
+        let msg = format_question_message(&questions, "q_123", super::i18n::Locale::En);
         assert!(msg.contains("Continue with the refactor?"));
         assert!(msg.contains("1. Yes"));
         assert!(msg.contains("2. No"));
         assert!(msg.contains("[Q:q_123]"));
-        assert!(msg.contains("Auto-reject in 5 min"));
+        assert!(msg.contains("/answer"));
     }
 
     #[test]
@@ -442,7 +452,7 @@ mod tests {
             question: "What should I name this variable?".to_string(),
             options: vec![],
         }];
-        let msg = format_question_message(&questions, "q_456");
+        let msg = format_question_message(&questions, "q_456", super::i18n::Locale::En);
         assert!(msg.contains("What should I name this variable?"));
         assert!(!msg.contains("1."));
         assert!(msg.contains("[Q:q_456]"));
@@ -460,7 +470,7 @@ mod tests {
                 options: vec![],
             },
         ];
-        let msg = format_question_message(&questions, "q_multi");
+        let msg = format_question_message(&questions, "q_multi", super::i18n::Locale::En);
         assert!(msg.contains("**Question 1:**"));
         assert!(msg.contains("**Question 2:**"));
     }

--- a/src-tauri/src/commands/gateway/wechat.rs
+++ b/src-tauri/src/commands/gateway/wechat.rs
@@ -353,6 +353,8 @@ pub struct WeChatGateway {
     config: Arc<RwLock<WeChatConfig>>,
     session_mapping: SessionMapping,
     opencode_port: u16,
+    #[allow(dead_code)]
+    workspace_path: String,
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     status: Arc<RwLock<WeChatGatewayStatusResponse>>,
     is_running: Arc<RwLock<bool>>,
@@ -364,16 +366,15 @@ pub struct WeChatGateway {
     pending_questions: Arc<super::PendingQuestionStore>,
     /// Cache of from_user_id -> context_token for replies
     context_tokens: Arc<RwLock<HashMap<String, String>>>,
-    /// Workspace path for persisting config to disk
-    workspace_path: Arc<RwLock<Option<String>>>,
 }
 
 impl WeChatGateway {
-    pub fn new(opencode_port: u16, session_mapping: SessionMapping) -> Self {
+    pub fn new(opencode_port: u16, session_mapping: SessionMapping, workspace_path: String) -> Self {
         Self {
             config: Arc::new(RwLock::new(WeChatConfig::default())),
             session_mapping,
             opencode_port,
+            workspace_path,
             shutdown_tx: Arc::new(RwLock::new(None)),
             status: Arc::new(RwLock::new(WeChatGatewayStatusResponse::default())),
             is_running: Arc::new(RwLock::new(false)),
@@ -384,12 +385,7 @@ impl WeChatGateway {
             session_queue: Arc::new(SessionQueue::new()),
             pending_questions: Arc::new(super::PendingQuestionStore::new()),
             context_tokens: Arc::new(RwLock::new(HashMap::new())),
-            workspace_path: Arc::new(RwLock::new(None)),
         }
-    }
-
-    pub async fn set_workspace_path(&self, path: String) {
-        *self.workspace_path.write().await = Some(path);
     }
 
     pub async fn set_config(&self, config: WeChatConfig) {
@@ -441,14 +437,10 @@ impl WeChatGateway {
 
     /// Persist context_tokens from in-memory config to teamclaw.json on disk
     async fn persist_context_tokens(&self) {
-        let workspace_path = match self.workspace_path.read().await.clone() {
-            Some(p) => p,
-            None => return,
-        };
         let config = self.config.read().await.clone();
         let path = format!(
             "{}/{}/{}",
-            workspace_path,
+            self.workspace_path,
             crate::commands::TEAMCLAW_DIR,
             crate::commands::CONFIG_FILE_NAME
         );

--- a/src-tauri/src/commands/gateway/wechat.rs
+++ b/src-tauri/src/commands/gateway/wechat.rs
@@ -1,3 +1,4 @@
+use super::i18n;
 use super::session::SessionMapping;
 use super::session_queue::{EnqueueResult, QueuedMessage, RejectReason, SessionQueue};
 use super::wechat_config::{
@@ -660,6 +661,7 @@ impl WeChatGateway {
 
     async fn handle_incoming_message(&self, sender_id: &str, text: &str) -> Result<(), String> {
         let session_key = format!("wechat:dm:{}", sender_id);
+        let locale = i18n::get_locale(&self.workspace_path);
 
         let trimmed = text.trim();
 
@@ -671,10 +673,10 @@ impl WeChatGateway {
                     qid, answer_text
                 );
                 let _ = self
-                    .send_to_user(sender_id, &format!("✓ 已提交：{}", answer_text))
+                    .send_to_user(sender_id, &i18n::t(i18n::MsgKey::AnswerSubmitted(answer_text), locale))
                     .await;
             } else {
-                let _ = self.send_to_user(sender_id, "当前没有待回答的问题。").await;
+                let _ = self.send_to_user(sender_id, &i18n::t(i18n::MsgKey::NoPendingQuestions, locale)).await;
             }
             return Ok(());
         }
@@ -711,16 +713,17 @@ impl WeChatGateway {
         let notify_fn = {
             let gateway = gateway.clone();
             let sender_id = sender_id.clone();
+            let locale_for_notify = locale;
             Some(Box::new(move |reason: RejectReason| {
                 let gateway = gateway.clone();
                 let sender_id = sender_id.clone();
                 Box::pin(async move {
                     let msg = match reason {
-                        RejectReason::Timeout => "Message queue timeout, please try again.",
-                        RejectReason::QueueFull => "Too many messages, please wait.",
-                        RejectReason::SessionClosed => "Gateway is shutting down.",
+                        RejectReason::Timeout => i18n::t(i18n::MsgKey::QueueTimeout, locale_for_notify),
+                        RejectReason::QueueFull => i18n::t(i18n::MsgKey::QueueFull, locale_for_notify),
+                        RejectReason::SessionClosed => i18n::t(i18n::MsgKey::GatewayShuttingDown, locale_for_notify),
                     };
-                    let _ = gateway.send_to_user(&sender_id, msg).await;
+                    let _ = gateway.send_to_user(&sender_id, &msg).await;
                 })
                     as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
             })
@@ -756,17 +759,18 @@ impl WeChatGateway {
     }
 
     async fn handle_slash_command(&self, session_key: &str, content: &str) -> String {
+        let locale = i18n::get_locale(&self.workspace_path);
         let parts: Vec<&str> = content.splitn(2, ' ').collect();
         let cmd = parts[0].to_lowercase();
         let arg = parts.get(1).copied().unwrap_or("").trim();
 
         match cmd.as_str() {
             "/help" => {
-                "Available commands:\n/help - Show this help\n/model [name] - List or switch models\n/sessions [id] - List or bind sessions\n/reset - Start new session\n/stop - Stop current processing\n/answer - Reply to an AI clarification (see bot message)".to_string()
+                i18n::t(i18n::MsgKey::HelpWechat, locale)
             }
             "/reset" => {
                 self.session_mapping.remove_session(session_key).await;
-                "Session reset. Next message will start a new conversation.".to_string()
+                i18n::t(i18n::MsgKey::SessionReset, locale)
             }
             "/model" => {
                 super::handle_model_command(
@@ -774,6 +778,7 @@ impl WeChatGateway {
                     &self.session_mapping,
                     session_key,
                     arg,
+                    locale,
                 )
                 .await
             }
@@ -783,6 +788,7 @@ impl WeChatGateway {
                     &self.session_mapping,
                     session_key,
                     arg,
+                    locale,
                 )
                 .await
             }
@@ -791,14 +797,16 @@ impl WeChatGateway {
                     self.opencode_port,
                     &self.session_mapping,
                     session_key,
+                    locale,
                 )
                 .await
             }
-            _ => format!("Unknown command: {}\nType /help for available commands.", cmd),
+            _ => i18n::t(i18n::MsgKey::UnknownCommand(&cmd), locale),
         }
     }
 
     async fn process_and_reply(&self, sender_id: &str, text: &str) {
+        let locale = i18n::get_locale(&self.workspace_path);
         // Get or create session
         let session_key = format!("wechat:dm:{}", sender_id);
         let session_id = match self.session_mapping.get_session(&session_key).await {
@@ -834,12 +842,13 @@ impl WeChatGateway {
         let pending_questions = Arc::clone(&self.pending_questions);
         let sender_for_q = sender_id.to_string();
         let gateway_for_q = self.clone();
+        let locale_for_q = i18n::get_locale(&self.workspace_path);
         let question_ctx = super::QuestionContext {
             forwarder: Box::new(move |fq: super::ForwardedQuestion| {
                 let gateway = gateway_for_q.clone();
                 let sid = sender_for_q.clone();
                 Box::pin(async move {
-                    let text = super::format_question_message(&fq.questions, &fq.question_id);
+                    let text = super::format_question_message(&fq.questions, &fq.question_id, locale_for_q);
                     gateway.send_to_user(&sid, &text).await?;
                     Ok(uuid::Uuid::new_v4().to_string())
                 })
@@ -866,7 +875,7 @@ impl WeChatGateway {
         {
             Ok(response) => {
                 let reply = if response.trim().is_empty() {
-                    "模型未返回文字内容，请稍后重试或换种说法。".to_string()
+                    i18n::t(i18n::MsgKey::ModelEmptyResponse, locale)
                 } else {
                     response
                 };

--- a/src-tauri/src/commands/gateway/wecom.rs
+++ b/src-tauri/src/commands/gateway/wecom.rs
@@ -58,6 +58,8 @@ pub struct WeComGateway {
     config: Arc<RwLock<WeComConfig>>,
     session_mapping: SessionMapping,
     opencode_port: u16,
+    #[allow(dead_code)]
+    workspace_path: String,
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     status: Arc<RwLock<WeComGatewayStatusResponse>>,
     is_running: Arc<RwLock<bool>>,
@@ -128,11 +130,12 @@ enum WsExitReason {
 }
 
 impl WeComGateway {
-    pub fn new(opencode_port: u16, session_mapping: SessionMapping) -> Self {
+    pub fn new(opencode_port: u16, session_mapping: SessionMapping, workspace_path: String) -> Self {
         Self {
             config: Arc::new(RwLock::new(WeComConfig::default())),
             session_mapping,
             opencode_port,
+            workspace_path,
             shutdown_tx: Arc::new(RwLock::new(None)),
             status: Arc::new(RwLock::new(WeComGatewayStatusResponse::default())),
             is_running: Arc::new(RwLock::new(false)),

--- a/src-tauri/src/commands/gateway/wecom.rs
+++ b/src-tauri/src/commands/gateway/wecom.rs
@@ -1,3 +1,4 @@
+use super::i18n;
 use super::session::SessionMapping;
 use super::wecom_config::{WeComConfig, WeComGatewayStatus, WeComGatewayStatusResponse};
 use futures_util::stream::SplitSink;
@@ -58,7 +59,6 @@ pub struct WeComGateway {
     config: Arc<RwLock<WeComConfig>>,
     session_mapping: SessionMapping,
     opencode_port: u16,
-    #[allow(dead_code)]
     workspace_path: String,
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     status: Arc<RwLock<WeComGatewayStatusResponse>>,
@@ -625,17 +625,18 @@ impl WeComGateway {
         // Check for /answer command — routes reply to the most recent pending question
         if let Some(answer_text) = super::PendingQuestionStore::parse_answer_command(&text_content)
         {
+            let locale = i18n::get_locale(&self.workspace_path);
             if let Some(qid) = self.pending_questions.try_answer(answer_text).await {
                 println!(
                     "[WeCom] Question {} answered via /answer: {}",
                     qid, answer_text
                 );
                 let _ = self
-                    .send_reply(&req_id, &format!("✓ 已回复: {}", answer_text), &ws_sink)
+                    .send_reply(&req_id, &i18n::t(i18n::MsgKey::AnswerSubmitted(answer_text), locale), &ws_sink)
                     .await;
             } else {
                 let _ = self
-                    .send_reply(&req_id, "当前没有待回复的问题", &ws_sink)
+                    .send_reply(&req_id, &i18n::t(i18n::MsgKey::NoPendingQuestions, locale), &ws_sink)
                     .await;
             }
             return;
@@ -718,16 +719,13 @@ impl WeComGateway {
                     }),
                     notify_fn: Some(Box::new(move |reason| {
                         Box::pin(async move {
+                            let locale = i18n::get_locale(&gateway2.workspace_path);
                             let msg = match reason {
-                                RejectReason::Timeout => "Your message timed out waiting in queue.",
-                                RejectReason::QueueFull => {
-                                    "Too many messages queued. Please try again later."
-                                }
-                                RejectReason::SessionClosed => {
-                                    "Your message could not be processed. Please resend."
-                                }
+                                RejectReason::Timeout => i18n::t(i18n::MsgKey::QueueTimeout, locale),
+                                RejectReason::QueueFull => i18n::t(i18n::MsgKey::QueueFull, locale),
+                                RejectReason::SessionClosed => i18n::t(i18n::MsgKey::MessageCouldNotBeProcessed, locale),
                             };
-                            let _ = gateway2.send_reply(&req_id2, msg, &ws_sink2).await;
+                            let _ = gateway2.send_reply(&req_id2, &msg, &ws_sink2).await;
                         })
                     })),
                 },
@@ -765,14 +763,13 @@ impl WeComGateway {
         let parts: Vec<&str> = content.splitn(2, ' ').collect();
         let cmd = parts[0].to_lowercase();
         let arg = parts.get(1).copied().unwrap_or("").trim();
+        let locale = i18n::get_locale(&self.workspace_path);
 
         let reply = match cmd.as_str() {
-            "/help" => {
-                "Available commands:\n/help - Show this help\n/model [name] - List or switch models\n/sessions [id] - List or bind sessions\n/reset - Start new session\n/stop - Stop current processing".to_string()
-            }
+            "/help" => i18n::t(i18n::MsgKey::HelpWecom, locale),
             "/reset" => {
                 self.session_mapping.remove_session(session_key).await;
-                "Session reset. Next message will start a new conversation.".to_string()
+                i18n::t(i18n::MsgKey::SessionReset, locale)
             }
             "/model" => {
                 super::handle_model_command(
@@ -780,6 +777,7 @@ impl WeComGateway {
                     &self.session_mapping,
                     session_key,
                     arg,
+                    locale,
                 )
                 .await
             }
@@ -789,6 +787,7 @@ impl WeComGateway {
                     &self.session_mapping,
                     session_key,
                     arg,
+                    locale,
                 )
                 .await
             }
@@ -797,10 +796,11 @@ impl WeComGateway {
                     self.opencode_port,
                     &self.session_mapping,
                     session_key,
+                    locale,
                 )
                 .await
             }
-            _ => format!("Unknown command: {}", cmd),
+            _ => i18n::t(i18n::MsgKey::UnknownCommand(&cmd), locale),
         };
 
         self.send_reply(req_id, &reply, ws_sink).await
@@ -1278,6 +1278,7 @@ impl WeComGateway {
                                         let text = super::format_question_message(
                                             &[q.clone()],
                                             &question_id,
+                                            i18n::get_locale(&self.workspace_path),
                                         );
                                         let _ = self
                                             .send_stream_chunk(
@@ -1537,13 +1538,14 @@ impl WeComGateway {
     async fn handle_enter_chat(&self, req_id: &str, ws_sink: &WsSink) {
         use futures_util::SinkExt;
 
+        let locale = i18n::get_locale(&self.workspace_path);
         let welcome = serde_json::json!({
             "cmd": "aibot_respond_welcome_msg",
             "headers": { "req_id": req_id },
             "body": {
                 "msgtype": "text",
                 "text": {
-                    "content": "你好！我是 AI 助手。直接发消息给我开始对话，发送 /help 查看可用命令。"
+                    "content": i18n::t(i18n::MsgKey::WecomWelcome, locale)
                 }
             }
         });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -329,6 +329,7 @@ pub fn run() {
             commands::filewatcher::get_watched_directories,
             commands::gateway::get_channel_config,
             commands::gateway::save_channel_config,
+            commands::gateway::set_config_locale,
             commands::gateway::get_discord_config,
             commands::gateway::save_discord_config,
             commands::gateway::start_gateway,


### PR DESCRIPTION
## Summary

- Add `i18n.rs` module with `Locale` enum (En/ZhCN), `MsgKey` enum (48 keys), and `t()` translation function
- Gateway responses now follow the app's language setting stored in `teamclaw.json`
- Replace ~60 hardcoded strings (mixed English/Chinese) across all 6 gateway files + shared handlers
- Frontend syncs language changes to config file via new `set_config_locale` Tauri command

## Files changed

| Area | Files |
|------|-------|
| i18n module | `gateway/i18n.rs` (new) |
| Config | `gateway/mod.rs` — locale field, shared handlers, Tauri command |
| Gateways | `wechat.rs`, `wecom.rs`, `discord.rs`, `feishu.rs`, `kook.rs` |
| Questions | `pending_question.rs` |
| Frontend | `GeneralSection.tsx`, `i18n.ts` |

## Test plan

- [ ] `cargo check` passes
- [ ] `cargo test` — 97 passed (2 pre-existing failures in audio/P2P)
- [ ] TypeScript compiles clean
- [ ] Switch language in Settings → gateway responses match selected language
- [ ] Test `/help`, `/reset`, `/model`, `/sessions`, `/stop` on each platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)