### PR TITLE
fix(gateway): add missing locale param in email gateway

### DIFF
--- a/src-tauri/src/commands/gateway/email.rs
+++ b/src-tauri/src/commands/gateway/email.rs
@@ -1737,7 +1737,7 @@ fn process_and_reply_sync(
             let reply_email = reply_to_email_for_q.clone();
             let at = access_token_for_q.clone();
             Box::pin(async move {
-                let text = super::format_question_message(&fq.questions, &fq.question_id);
+                let text = super::format_question_message(&fq.questions, &fq.question_id, super::i18n::Locale::En);
                 let outgoing_msg_id = tokio::task::spawn_blocking(move || {
                     send_reply_sync(&cfg, &reply_email, &text, at.as_deref())
                 })


### PR DESCRIPTION
## Summary

- Fix compilation error from #180 merge — email gateway's `format_question_message` call was missing the new `locale` parameter
- Defaults to `Locale::En` for email (email gateway doesn't have easy workspace_path access in the closure context)

## Test plan

- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)