### PR TITLE
fix: suppress Rust warnings — remove unused variant, allow dead_code

### DIFF
--- a/src-tauri/src/commands/gateway/i18n.rs
+++ b/src-tauri/src/commands/gateway/i18n.rs
@@ -47,7 +47,6 @@ pub enum MsgKey<'a> {
     SessionsSwitchUsage,
     InvalidSessionNumber(&'a str),
     SessionNotFound(usize, usize),
-    SwitchedToSession(&'a str),
     SwitchedToSessionWithLatest(&'a str, &'a str),
     SwitchedToSessionNoLatest(&'a str),
     FailedToListSessions(&'a str),
@@ -164,9 +163,6 @@ pub fn t(key: MsgKey, locale: Locale) -> String {
 
         (SessionNotFound(num, total), En) => format!("Session #{} not found. There are only {} sessions.", num, total),
         (SessionNotFound(num, total), ZhCN) => format!("会话 #{} 不存在，当前共有 {} 个会话。", num, total),
-
-        (SwitchedToSession(title), En) => format!("Switched to session: \"{}\"", title),
-        (SwitchedToSession(title), ZhCN) => format!("已切换到会话: \"{}\"", title),
 
         (SwitchedToSessionWithLatest(title, latest), En) => {
             format!("Switched to session: \"{}\"\n\n**Latest response:**\n{}", title, latest)

--- a/src-tauri/src/commands/gateway/wecom.rs
+++ b/src-tauri/src/commands/gateway/wecom.rs
@@ -244,6 +244,7 @@ struct WeComFrom {
 /// Metadata stored when a template card is sent for a question,
 /// needed to update the card when the user clicks a button.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct CardMetadata {
     question_text: String,
     options: Vec<super::pending_question::QuestionOption>,

--- a/src-tauri/src/commands/version_store.rs
+++ b/src-tauri/src/commands/version_store.rs
@@ -62,6 +62,7 @@ impl VersionStore {
     }
 
     /// Record a new version (or update-in-place for recent local edits).
+    #[allow(dead_code)]
     pub async fn record_version(
         &self,
         file_path: &str,
@@ -269,6 +270,7 @@ impl VersionStore {
 
 /// Returns true if the datetime string (SQLite datetime format: "YYYY-MM-DD HH:MM:SS")
 /// is within 5 minutes of now (UTC).
+#[allow(dead_code)]
 fn parse_and_check_within_5min(dt_str: &str) -> bool {
     // Parse "YYYY-MM-DD HH:MM:SS" from SQLite datetime('now') output
     let parts: Vec<&str> = dt_str.split_whitespace().collect();
@@ -302,6 +304,7 @@ fn parse_and_check_within_5min(dt_str: &str) -> bool {
 
 /// Very rough conversion from calendar date to unix seconds.
 /// Accurate enough for 5-minute comparison.
+#[allow(dead_code)]
 fn approx_unix_secs(year: i64, month: i64, day: i64, hour: i64, minute: i64, second: i64) -> i64 {
     // Days since epoch (1970-01-01)
     let mut days: i64 = 0;
@@ -320,6 +323,7 @@ fn approx_unix_secs(year: i64, month: i64, day: i64, hour: i64, minute: i64, sec
     days * 86400 + hour * 3600 + minute * 60 + second
 }
 
+#[allow(dead_code)]
 fn is_leap(year: i64) -> bool {
     (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
 }


### PR DESCRIPTION
## Summary

- Remove unused `SwitchedToSession` MsgKey variant in i18n.rs (replaced by `WithLatest`/`NoLatest`)
- Allow dead_code on `CardMetadata` struct in wecom.rs
- Allow dead_code on `record_version` and helper functions in version_store.rs

Brings `cargo check` to zero warnings.

## Test plan

- [x] `cargo check` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)