### PR TITLE
fix(p2p): prevent non-owner members.json writes that cause stale allowList

### DIFF
--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -941,6 +941,7 @@ fn start_sync_tasks(
 
     // Task A: remote doc changes → disk
     let my_node_id_a = my_node_id.clone();
+    let owner_node_id_a = owner_node_id.clone();
     tokio::spawn(async move {
         doc_to_disk_watcher(
             doc_a,
@@ -948,7 +949,7 @@ fn start_sync_tasks(
             team_dir_a,
             suppressed_a,
             my_node_id_a,
-            owner_node_id,
+            owner_node_id_a,
             app_handle,
         )
         .await;
@@ -968,6 +969,7 @@ fn start_sync_tasks(
             suppressed_b,
             my_role,
             my_node_id,
+            owner_node_id,
         )
         .await;
     });
@@ -1492,7 +1494,42 @@ async fn doc_to_disk_watcher(
                     entry
                 };
 
-                // Apply same role checks as InsertRemote
+                // Apply same role + owner checks as InsertRemote
+                // Validate _team/members.json: only accept from owner
+                if key == "_team/members.json" {
+                    let writer_node = author_to_node.get(&author_id_str);
+                    let is_owner_write = match (writer_node, &owner_node_id) {
+                        (Some(writer), Some(owner)) => writer == owner,
+                        (None, _) => author_to_node.is_empty(), // bootstrap
+                        _ => false,
+                    };
+                    if !is_owner_write {
+                        eprintln!(
+                            "[P2P] Rejected ContentReady members.json from non-owner: {:?}",
+                            writer_node
+                        );
+                        continue;
+                    }
+                    // Owner write — write to disk and update role cache
+                    if let Ok(content) = blobs_store.blobs().get_bytes(hash).await {
+                        let file_path = Path::new(&team_dir).join(&key);
+                        write_and_suppress(&file_path, &content, &suppressed_paths).await;
+                        if let Ok(Some(manifest)) = read_members_manifest(&team_dir) {
+                            node_to_role.clear();
+                            for member in &manifest.members {
+                                node_to_role
+                                    .insert(member.node_id.clone(), member.role.clone());
+                            }
+                            if let Some(ref app) = app_handle {
+                                use tauri::Emitter;
+                                let _ =
+                                    app.emit("team:members-changed", serde_json::json!({}));
+                            }
+                        }
+                    }
+                    continue;
+                }
+
                 if let Some(writer) = author_to_node.get(&author_id_str) {
                     let writer_role = node_to_role
                         .get(writer)
@@ -1540,8 +1577,9 @@ async fn disk_to_doc_watcher(
     author: iroh_docs::AuthorId,
     team_dir: String,
     suppressed_paths: Arc<Mutex<HashSet<std::path::PathBuf>>>,
-    my_role: Arc<Mutex<MemberRole>>, // NEW
-    my_node_id: String,              // NEW
+    my_role: Arc<Mutex<MemberRole>>,
+    my_node_id: String,
+    owner_node_id: Option<String>,
 ) {
     use notify::{RecursiveMode, Watcher};
 
@@ -1618,6 +1656,21 @@ async fn disk_to_doc_watcher(
                                 let role = my_role.lock().await;
                                 if *role == MemberRole::Viewer {
                                     eprintln!("[P2P] Skipping upload (viewer mode): {}", rel_path);
+                                    continue;
+                                }
+                            }
+
+                            // Only the owner may upload _team/members.json
+                            // — non-owner writes pollute the doc with stale
+                            // entries that can cause "not in allowList" rejections.
+                            if rel_path == "_team/members.json" {
+                                let is_owner = owner_node_id
+                                    .as_deref()
+                                    .map_or(false, |owner| owner == my_node_id);
+                                if !is_owner {
+                                    eprintln!(
+                                        "[P2P] Skipping upload (non-owner): _team/members.json"
+                                    );
                                     continue;
                                 }
                             }


### PR DESCRIPTION
## Summary

- 修复非 owner 成员的 `disk_to_doc_watcher` 在抑制期过后将 `_team/members.json` 重新上传到 iroh doc 的问题
- 这些竞争条目的时间戳可能比 owner 的更新，导致 `single_latest_per_key()` 返回旧版 manifest，新成员加入时报 "not in allowList"
- 同时修复 `ContentReady` 处理器缺少 owner 校验的漏洞（`InsertRemote` 已有此检查）

## Root Cause

`disk_to_doc_watcher` 没有阻止非 owner 上传 `_team/members.json`。当成员收到 manifest 写入磁盘后，3 秒抑制期过后文件监听器会把同样的文件重新上传到 doc（以该成员为 author）。由于 `single_latest_per_key()` 只看时间戳不看 author，后续加入的成员可能读到旧版 manifest。

## Changes

- `disk_to_doc_watcher`: 非 owner 跳过 `_team/members.json` 上传
- `ContentReady` handler: 补齐 owner 校验 + role cache 更新
- `start_sync_tasks`: 传递 `owner_node_id` 给 `disk_to_doc_watcher`

## Test plan

- [ ] Owner 添加 A、B 两个成员，确认 A 和 B 都能成功加入
- [ ] C 之前加入过，Owner 删除后重新添加，确认 C 能重新加入
- [ ] 验证 owner 自己的 members.json 仍然正常同步到 doc
- [ ] `cargo test -- p2p` 通过（除 pre-existing `test_join_no_manifest_succeeds`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)