### PR TITLE
fix(p2p): write LLM config on join + prevent stale allowList

### DIFF
--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -283,7 +283,13 @@ export function TeamP2PConfig() {
     setJoinApprovalPending(false)
 
     try {
-      await tauriInvoke('p2p_join_drive', { ticket: ticket.trim(), label: '' })
+      await tauriInvoke('p2p_join_drive', {
+        ticket: ticket.trim(),
+        label: '',
+        llmBaseUrl: buildConfig.team.llm.baseUrl || null,
+        llmModel: buildConfig.team.llm.model || null,
+        llmModelName: buildConfig.team.llm.modelName || null,
+      })
       setJoinTicketInput('')
       setSeedUrl('')
       setTeamId('')

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -2500,6 +2500,9 @@ pub async fn p2p_join_drive(
     app: tauri::AppHandle,
     ticket: String,
     #[allow(unused_variables)] label: String,
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
     iroh_state: tauri::State<'_, IrohState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<String, String> {
@@ -2514,7 +2517,14 @@ pub async fn p2p_join_drive(
     let node = guard.as_mut().ok_or("P2P node not running")?;
 
     let team_dir = format!("{}/{}", workspace_path, super::TEAM_REPO_DIR);
-    join_team_drive(node, &ticket, &team_dir, &workspace_path, Some(app)).await
+    let result = join_team_drive(node, &ticket, &team_dir, &workspace_path, Some(app)).await?;
+
+    // Write LLM config to .teamclaw/teamclaw.json (same as oss_join_team and create_team)
+    let llm_config =
+        crate::commands::team::build_llm_config(llm_base_url, llm_model, llm_model_name);
+    crate::commands::team::write_llm_config(&workspace_path, Some(&llm_config))?;
+
+    Ok(result)
 }
 
 /// Reconnect to an existing team document on app restart.

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -941,6 +941,7 @@ fn start_sync_tasks(
 
     // Task A: remote doc changes → disk
     let my_node_id_a = my_node_id.clone();
+    let owner_node_id_a = owner_node_id.clone();
     tokio::spawn(async move {
         doc_to_disk_watcher(
             doc_a,
@@ -948,7 +949,7 @@ fn start_sync_tasks(
             team_dir_a,
             suppressed_a,
             my_node_id_a,
-            owner_node_id,
+            owner_node_id_a,
             app_handle,
         )
         .await;
@@ -968,6 +969,7 @@ fn start_sync_tasks(
             suppressed_b,
             my_role,
             my_node_id,
+            owner_node_id,
         )
         .await;
     });
@@ -1492,7 +1494,42 @@ async fn doc_to_disk_watcher(
                     entry
                 };
 
-                // Apply same role checks as InsertRemote
+                // Apply same role + owner checks as InsertRemote
+                // Validate _team/members.json: only accept from owner
+                if key == "_team/members.json" {
+                    let writer_node = author_to_node.get(&author_id_str);
+                    let is_owner_write = match (writer_node, &owner_node_id) {
+                        (Some(writer), Some(owner)) => writer == owner,
+                        (None, _) => author_to_node.is_empty(), // bootstrap
+                        _ => false,
+                    };
+                    if !is_owner_write {
+                        eprintln!(
+                            "[P2P] Rejected ContentReady members.json from non-owner: {:?}",
+                            writer_node
+                        );
+                        continue;
+                    }
+                    // Owner write — write to disk and update role cache
+                    if let Ok(content) = blobs_store.blobs().get_bytes(hash).await {
+                        let file_path = Path::new(&team_dir).join(&key);
+                        write_and_suppress(&file_path, &content, &suppressed_paths).await;
+                        if let Ok(Some(manifest)) = read_members_manifest(&team_dir) {
+                            node_to_role.clear();
+                            for member in &manifest.members {
+                                node_to_role
+                                    .insert(member.node_id.clone(), member.role.clone());
+                            }
+                            if let Some(ref app) = app_handle {
+                                use tauri::Emitter;
+                                let _ =
+                                    app.emit("team:members-changed", serde_json::json!({}));
+                            }
+                        }
+                    }
+                    continue;
+                }
+
                 if let Some(writer) = author_to_node.get(&author_id_str) {
                     let writer_role = node_to_role
                         .get(writer)
@@ -1540,8 +1577,9 @@ async fn disk_to_doc_watcher(
     author: iroh_docs::AuthorId,
     team_dir: String,
     suppressed_paths: Arc<Mutex<HashSet<std::path::PathBuf>>>,
-    my_role: Arc<Mutex<MemberRole>>, // NEW
-    my_node_id: String,              // NEW
+    my_role: Arc<Mutex<MemberRole>>,
+    my_node_id: String,
+    owner_node_id: Option<String>,
 ) {
     use notify::{RecursiveMode, Watcher};
 
@@ -1618,6 +1656,21 @@ async fn disk_to_doc_watcher(
                                 let role = my_role.lock().await;
                                 if *role == MemberRole::Viewer {
                                     eprintln!("[P2P] Skipping upload (viewer mode): {}", rel_path);
+                                    continue;
+                                }
+                            }
+
+                            // Only the owner may upload _team/members.json
+                            // — non-owner writes pollute the doc with stale
+                            // entries that can cause "not in allowList" rejections.
+                            if rel_path == "_team/members.json" {
+                                let is_owner = owner_node_id
+                                    .as_deref()
+                                    .map_or(false, |owner| owner == my_node_id);
+                                if !is_owner {
+                                    eprintln!(
+                                        "[P2P] Skipping upload (non-owner): _team/members.json"
+                                    );
                                     continue;
                                 }
                             }


### PR DESCRIPTION
## Summary
- **Write LLM config on P2P join**: `p2p_join_drive` was missing the `write_llm_config` call after successful join, causing `opencode.json` to never get the team provider. Both `create_team` and `oss_join_team` already had this — now `p2p_join_drive` matches.
- **Pass LLM build config from frontend**: `joinWithTicket` now passes `llmBaseUrl`, `llmModel`, `llmModelName` to the Rust command (same pattern as `doCreateTeam`).
- **Prevent non-owner members.json writes**: Non-owner nodes could write stale `members.json` to the Iroh doc, causing "not in allowList" rejections for legitimate members.

## Test plan
- [ ] Join a P2P team as a new member → verify `.teamclaw/teamclaw.json` contains `llm` section
- [ ] Verify `opencode.json` gets the team provider after join
- [ ] Verify non-owner members cannot overwrite `members.json` in the Iroh doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)