### PR TITLE
feat(webview): inject window.teamclaw identity into all webviews

### DIFF
--- a/packages/app/src/components/main-content/WebViewContent.tsx
+++ b/packages/app/src/components/main-content/WebViewContent.tsx
@@ -3,6 +3,8 @@ import { Loader2, ExternalLink } from "lucide-react"
 import { isTauri } from "@/lib/utils"
 import { normalizeUrl, urlToLabel } from "@/lib/webview-utils"
 import { useTabsStore } from "@/stores/tabs"
+import { useTeamModeStore } from "@/stores/team-mode"
+import { useTeamMembersStore } from "@/stores/team-members"
 
 interface WebViewContentProps {
   url: string
@@ -129,6 +131,22 @@ export function WebViewContent({ url: rawUrl }: WebViewContentProps) {
           } else {
             // Create new native webview
             setIsLoading(true)
+
+            // Resolve team identity for window.teamclaw injection
+            let deviceNo: string | undefined
+            let deviceName: string | undefined
+            if (useTeamModeStore.getState().teamMode) {
+              try {
+                const info = await invoke<{ nodeId: string }>("get_device_info")
+                deviceNo = info.nodeId
+                const members = useTeamMembersStore.getState().members
+                const me = members.find((m) => m.nodeId === deviceNo)
+                deviceName = me?.name ?? ""
+              } catch {
+                // Non-critical: webview works without identity
+              }
+            }
+
             await invoke("webview_create", {
               label,
               url,
@@ -136,6 +154,8 @@ export function WebViewContent({ url: rawUrl }: WebViewContentProps) {
               y: bounds.y,
               width: Math.max(1, bounds.width),
               height: Math.max(1, bounds.height),
+              deviceNo,
+              deviceName,
             })
 
             if (!cancelled) {

--- a/packages/app/src/components/workspace/FileTree.tsx
+++ b/packages/app/src/components/workspace/FileTree.tsx
@@ -970,12 +970,23 @@ export function FileTree({
     import('@tauri-apps/api/event').then(async ({ listen }) => {
       if (cancelled) return;
 
-      // Handle external file drop (skip if internal drag is in progress)
+      // Handle external file drop (or internal drag that landed outside the file tree)
       unlisteners.push(await listen<{ paths: string[]; position: { x: number; y: number } }>(
         'tauri://drag-drop',
         async (event) => {
-          // Skip external handler when an internal drag-move is active
-          if (dragSourcePathRef.current) return;
+          // Internal drag-move: Tauri intercepts the HTML5 drop event, so the
+          // PromptInput's onDrop never fires. Re-dispatch as a custom DOM event
+          // so the prompt input (or any other drop target) can pick it up.
+          if (dragSourcePathRef.current) {
+            const sourcePath = dragSourcePathRef.current;
+            dragSourcePathRef.current = null;
+            setDragSourcePath(null);
+            setDragOverPath(null);
+            window.dispatchEvent(new CustomEvent('teamclaw:filedrop', {
+              detail: { path: sourcePath, position: event.payload.position },
+            }));
+            return;
+          }
           const paths = event.payload.paths;
           if (!paths || paths.length === 0) return;
 

--- a/packages/app/src/packages/ai/prompt-input.tsx
+++ b/packages/app/src/packages/ai/prompt-input.tsx
@@ -131,6 +131,24 @@ export function PromptInput({
     event.stopPropagation()
   }
 
+  const formRef = React.useRef<HTMLFormElement>(null)
+
+  // Listen for teamclaw:filedrop custom events dispatched when Tauri intercepts
+  // an internal file-tree drag that lands outside the tree (e.g. on this input).
+  React.useEffect(() => {
+    if (!onFilePathsDrop) return
+    const handler = (e: Event) => {
+      const { path, position } = (e as CustomEvent).detail as { path: string; position: { x: number; y: number } }
+      const rect = formRef.current?.getBoundingClientRect()
+      if (!rect) return
+      if (position.x >= rect.left && position.x <= rect.right && position.y >= rect.top && position.y <= rect.bottom) {
+        onFilePathsDrop([path])
+      }
+    }
+    window.addEventListener('teamclaw:filedrop', handler)
+    return () => window.removeEventListener('teamclaw:filedrop', handler)
+  }, [onFilePathsDrop])
+
   const handleDrop = (event: React.DragEvent) => {
     event.preventDefault()
     event.stopPropagation()
@@ -168,6 +186,7 @@ export function PromptInput({
       commandStartRef: commandStartRefState
     }}>
       <form
+        ref={formRef}
         className={cn(
           "relative rounded-2xl border border-border bg-white shadow-sm transition-colors",
           isDragging && "border-primary border-2 bg-primary/5",

--- a/src-tauri/src/commands/webview.rs
+++ b/src-tauri/src/commands/webview.rs
@@ -147,6 +147,10 @@ pub async fn webview_eval_js(app: tauri::AppHandle, code: String) -> Result<Stri
 }
 
 /// Create a native webview as a child of the main window at the given position.
+///
+/// When `device_no` and `device_name` are provided, a `window.teamclaw` global
+/// is injected into the webview before any page scripts run, exposing identity
+/// information for the current team member.
 #[tauri::command]
 pub async fn webview_create(
     app: tauri::AppHandle,
@@ -157,6 +161,8 @@ pub async fn webview_create(
     y: f64,
     width: f64,
     height: f64,
+    device_no: Option<String>,
+    device_name: Option<String>,
 ) -> Result<(), String> {
     // If webview with this label already exists, just show and reposition it
     let exists = state.labels.lock().unwrap().contains_key(&label);
@@ -209,6 +215,17 @@ pub async fn webview_create(
             webview_builder = webview_builder.with_webview_configuration(config);
             eprintln!("[Webview] Using shared WKWebViewConfiguration");
         }
+    }
+
+    // Inject window.teamclaw identity global before any page scripts run.
+    if let (Some(ref dno), Some(ref dname)) = (&device_no, &device_name) {
+        let escaped_no = serde_json::to_string(dno).unwrap_or_else(|_| "\"\"".to_string());
+        let escaped_name = serde_json::to_string(dname).unwrap_or_else(|_| "\"\"".to_string());
+        let script = format!(
+            "Object.defineProperty(window, 'teamclaw', {{ value: Object.freeze({{ deviceNo: {}, deviceName: {} }}), writable: false, configurable: false }});",
+            escaped_no, escaped_name,
+        );
+        webview_builder = webview_builder.initialization_script(&script);
     }
 
     let webview = window


### PR DESCRIPTION
## Summary
- Inject a frozen `window.teamclaw = { deviceNo, deviceName }` global into every native webview via Tauri's `initialization_script` API
- `deviceNo` = team NodeId (from `get_device_info`), `deviceName` = current member name (from team members store)
- Only injected when `teamMode` is active; non-team webviews are unaffected
- Property is non-writable and frozen to prevent page scripts from tampering

## Test plan
- [ ] In team mode, open a shortcut link webview — verify `window.teamclaw.deviceNo` and `window.teamclaw.deviceName` are set correctly in the webview's devtools console
- [ ] Verify the property is frozen (`window.teamclaw.deviceNo = 'x'` should fail silently)
- [ ] In non-team mode, open a webview — verify `window.teamclaw` is undefined
- [ ] Verify existing webview functionality (show/hide/reposition) is unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)