### PR TITLE
fix(drag): restore file-tree drag-to-prompt-input on Tauri

### DIFF
--- a/packages/app/src/components/workspace/FileTree.tsx
+++ b/packages/app/src/components/workspace/FileTree.tsx
@@ -970,12 +970,23 @@ export function FileTree({
     import('@tauri-apps/api/event').then(async ({ listen }) => {
       if (cancelled) return;
 
-      // Handle external file drop (skip if internal drag is in progress)
+      // Handle external file drop (or internal drag that landed outside the file tree)
       unlisteners.push(await listen<{ paths: string[]; position: { x: number; y: number } }>(
         'tauri://drag-drop',
         async (event) => {
-          // Skip external handler when an internal drag-move is active
-          if (dragSourcePathRef.current) return;
+          // Internal drag-move: Tauri intercepts the HTML5 drop event, so the
+          // PromptInput's onDrop never fires. Re-dispatch as a custom DOM event
+          // so the prompt input (or any other drop target) can pick it up.
+          if (dragSourcePathRef.current) {
+            const sourcePath = dragSourcePathRef.current;
+            dragSourcePathRef.current = null;
+            setDragSourcePath(null);
+            setDragOverPath(null);
+            window.dispatchEvent(new CustomEvent('teamclaw:filedrop', {
+              detail: { path: sourcePath, position: event.payload.position },
+            }));
+            return;
+          }
           const paths = event.payload.paths;
           if (!paths || paths.length === 0) return;
 

--- a/packages/app/src/packages/ai/prompt-input.tsx
+++ b/packages/app/src/packages/ai/prompt-input.tsx
@@ -131,6 +131,24 @@ export function PromptInput({
     event.stopPropagation()
   }
 
+  const formRef = React.useRef<HTMLFormElement>(null)
+
+  // Listen for teamclaw:filedrop custom events dispatched when Tauri intercepts
+  // an internal file-tree drag that lands outside the tree (e.g. on this input).
+  React.useEffect(() => {
+    if (!onFilePathsDrop) return
+    const handler = (e: Event) => {
+      const { path, position } = (e as CustomEvent).detail as { path: string; position: { x: number; y: number } }
+      const rect = formRef.current?.getBoundingClientRect()
+      if (!rect) return
+      if (position.x >= rect.left && position.x <= rect.right && position.y >= rect.top && position.y <= rect.bottom) {
+        onFilePathsDrop([path])
+      }
+    }
+    window.addEventListener('teamclaw:filedrop', handler)
+    return () => window.removeEventListener('teamclaw:filedrop', handler)
+  }, [onFilePathsDrop])
+
   const handleDrop = (event: React.DragEvent) => {
     event.preventDefault()
     event.stopPropagation()
@@ -168,6 +186,7 @@ export function PromptInput({
       commandStartRef: commandStartRefState
     }}>
       <form
+        ref={formRef}
         className={cn(
           "relative rounded-2xl border border-border bg-white shadow-sm transition-colors",
           isDragging && "border-primary border-2 bg-primary/5",


### PR DESCRIPTION
## Summary
- Fix drag-and-drop from file tree to prompt input broken by Tauri's `dragDropEnabled`
- Tauri intercepts the HTML5 `drop` event at the WKWebView level, so PromptInput's `onDrop` never fires for internal drags
- PR #183 fixed internal file-tree drag-move but left the drag-to-prompt path broken
- When `tauri://drag-drop` fires during an internal drag, dispatch a custom DOM event (`teamclaw:filedrop`) with source path and drop position
- PromptInput listens for this event and hit-tests against its form bounds to call `onFilePathsDrop`

## Test plan
- [ ] Drag a file from the file tree to the chat prompt input — should insert `@{filepath}` mention
- [ ] Drag a file within the file tree to move it — should still work as before
- [ ] Drop an external file (from Finder) onto the file tree — should still copy
- [ ] Drag a file from file tree and drop on empty area (not prompt) — should not insert mention

🤖 Generated with [Claude Code](https://claude.ai/code)