### PR TITLE
feat(opencode): isolate bundled OpenCode per workspace via XDG env vars

### DIFF
--- a/packages/app/src/components/settings/PermissionManagementSection.tsx
+++ b/packages/app/src/components/settings/PermissionManagementSection.tsx
@@ -139,11 +139,11 @@ export const PermissionManagementSection = React.memo(function PermissionManagem
 
   // Load allowlist from opencode.db via Tauri command
   const loadAllowlist = React.useCallback(async () => {
-    if (!isTauri()) return
+    if (!isTauri() || !workspacePath) return
 
     setLoadingAllowlist(true)
     try {
-      const rows = await invoke<AllowlistRow[]>('read_opencode_allowlist')
+      const rows = await invoke<AllowlistRow[]>('read_opencode_allowlist', { workspacePath })
       setAllowlistRows(rows)
     } catch (error) {
       console.error('[PermissionManagement] Failed to load allowlist from DB:', error)
@@ -151,7 +151,7 @@ export const PermissionManagementSection = React.memo(function PermissionManagem
     } finally {
       setLoadingAllowlist(false)
     }
-  }, [])
+  }, [workspacePath])
 
   // Remove a single rule
   const removeRule = React.useCallback(async (projectId: string, ruleIndex: number) => {
@@ -161,6 +161,7 @@ export const PermissionManagementSection = React.memo(function PermissionManagem
     try {
       const updatedRules = row.rules.filter((_, i) => i !== ruleIndex)
       await invoke('write_opencode_allowlist', {
+        workspacePath,
         projectId,
         rules: updatedRules,
       })
@@ -168,7 +169,7 @@ export const PermissionManagementSection = React.memo(function PermissionManagem
     } catch (error) {
       console.error('[PermissionManagement] Failed to remove rule:', error)
     }
-  }, [allowlistRows, loadAllowlist])
+  }, [allowlistRows, loadAllowlist, workspacePath])
 
   // Load permission config from opencode.json
   const loadPermissionConfig = React.useCallback(async () => {

--- a/packages/app/src/stores/session-permissions.ts
+++ b/packages/app/src/stores/session-permissions.ts
@@ -142,7 +142,9 @@ async function persistAllowlistRule(perm: PermissionAskedEvent): Promise<void> {
   type Row = { project_id: string; rules: Rule[] };
   let existingRows: Row[] = [];
   try {
-    existingRows = await invoke<Row[]>("read_opencode_allowlist");
+    existingRows = await invoke<Row[]>("read_opencode_allowlist", {
+      workspacePath: workspacePath || "/",
+    });
   } catch {
     // DB may not exist yet
   }
@@ -160,6 +162,7 @@ async function persistAllowlistRule(perm: PermissionAskedEvent): Promise<void> {
   }
 
   await invoke("write_opencode_allowlist", {
+    workspacePath: workspacePath || "/",
     projectId,
     rules: currentRules,
   });

--- a/src-tauri/src/commands/clawhub.rs
+++ b/src-tauri/src/commands/clawhub.rs
@@ -251,9 +251,14 @@ fn skills_dir(workspace_path: &str) -> PathBuf {
         .join("skills")
 }
 
-fn global_skills_dir() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or_else(|| "Failed to determine home directory".to_string())?;
-    Ok(home.join(".config").join("opencode").join("skills"))
+fn global_skills_dir(workspace_path: &str) -> PathBuf {
+    // Under XDG isolation, "global" skills live inside the workspace:
+    // <workspace>/.opencode/config/opencode/skills/
+    PathBuf::from(workspace_path)
+        .join(".opencode")
+        .join("config")
+        .join("opencode")
+        .join("skills")
 }
 
 fn validate_slug(slug: &str) -> Result<(), String> {
@@ -504,12 +509,12 @@ pub fn clawhub_install(
     let client = build_client()?;
 
     let is_global = is_global.unwrap_or(false);
+    let ws_path = workspace_path
+        .as_ref()
+        .ok_or_else(|| "Workspace path required for skill installation".to_string())?;
     let skills = if is_global {
-        global_skills_dir()?
+        global_skills_dir(ws_path)
     } else {
-        let ws_path = workspace_path
-            .as_ref()
-            .ok_or_else(|| "Workspace path required for workspace installation".to_string())?;
         skills_dir(ws_path)
     };
 

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -435,12 +435,21 @@ pub async fn start_opencode_inner(
     );
 
     // Build sidecar command, also injecting secrets as process env vars (backup)
+    //
+    // XDG isolation: redirect all OpenCode data/config/state/cache directories
+    // into <workspace>/.opencode/ so each workspace is fully self-contained
+    // and independent of any system-installed OpenCode.
+    let xdg_base = std::path::PathBuf::from(&workspace_path).join(".opencode");
     let mut sidecar_command = app
         .shell()
         .sidecar("opencode")
         .map_err(|e| format!("Failed to create sidecar command: {}", e))?
         .args(["serve", "--port", &port_str])
-        .current_dir(&workspace_path);
+        .current_dir(&workspace_path)
+        .env("XDG_DATA_HOME", xdg_base.join("data").to_string_lossy().as_ref())
+        .env("XDG_CONFIG_HOME", xdg_base.join("config").to_string_lossy().as_ref())
+        .env("XDG_STATE_HOME", xdg_base.join("state").to_string_lossy().as_ref())
+        .env("XDG_CACHE_HOME", xdg_base.join("cache").to_string_lossy().as_ref());
     for (key, value) in &secrets {
         sidecar_command = sidecar_command.env(key, value);
     }
@@ -1379,14 +1388,27 @@ pub async fn stop_opencode(state: State<'_, OpenCodeState>) -> Result<(), String
 
 // ─── OpenCode DB allowlist commands ──────────────────────────────────
 
-fn get_opencode_db_path() -> Result<String, String> {
+fn get_opencode_db_path(workspace_path: &str) -> Result<String, String> {
+    // With XDG isolation, the DB lives at <workspace>/.opencode/data/opencode/opencode.db
+    let isolated_path = std::path::PathBuf::from(workspace_path)
+        .join(".opencode/data/opencode/opencode.db");
+    if isolated_path.exists() {
+        return Ok(isolated_path.to_string_lossy().to_string());
+    }
+
+    // Fallback to legacy global path for workspaces that haven't been re-launched yet
     let home =
         std::env::var("HOME").map_err(|_| "HOME environment variable not set".to_string())?;
-    let path = format!("{}/.local/share/opencode/opencode.db", home);
-    if !std::path::Path::new(&path).exists() {
-        return Err(format!("OpenCode database not found at: {}", path));
+    let legacy_path = format!("{}/.local/share/opencode/opencode.db", home);
+    if std::path::Path::new(&legacy_path).exists() {
+        return Ok(legacy_path);
     }
-    Ok(path)
+
+    Err(format!(
+        "OpenCode database not found at: {} or {}",
+        isolated_path.display(),
+        legacy_path
+    ))
 }
 
 /// Look up the project_id for a given workspace path from the project table.
@@ -1395,7 +1417,7 @@ fn get_opencode_db_path() -> Result<String, String> {
 ///   - non-git directories use "global"
 #[tauri::command]
 pub async fn get_opencode_project_id(workspace_path: String) -> Result<String, String> {
-    let db_path = get_opencode_db_path()?;
+    let db_path = get_opencode_db_path(&workspace_path)?;
     let normalized = workspace_path.trim_end_matches('/');
 
     let output = std::process::Command::new("sqlite3")
@@ -1453,8 +1475,8 @@ pub struct AllowlistRow {
 
 /// Read all permission allowlist rows from the opencode.db permission table.
 #[tauri::command]
-pub async fn read_opencode_allowlist() -> Result<Vec<AllowlistRow>, String> {
-    let db_path = get_opencode_db_path()?;
+pub async fn read_opencode_allowlist(workspace_path: String) -> Result<Vec<AllowlistRow>, String> {
+    let db_path = get_opencode_db_path(&workspace_path)?;
 
     let output = std::process::Command::new("sqlite3")
         .args([
@@ -1507,10 +1529,11 @@ pub async fn read_opencode_allowlist() -> Result<Vec<AllowlistRow>, String> {
 /// Pass an empty `rules` array to delete the entry.
 #[tauri::command]
 pub async fn write_opencode_allowlist(
+    workspace_path: String,
     project_id: String,
     rules: Vec<PermissionRule>,
 ) -> Result<(), String> {
-    let db_path = get_opencode_db_path()?;
+    let db_path = get_opencode_db_path(&workspace_path)?;
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| e.to_string())?

--- a/src-tauri/src/commands/skillssh.rs
+++ b/src-tauri/src/commands/skillssh.rs
@@ -1053,10 +1053,13 @@ pub async fn install_skill_from_git_url(
 
     // Determine target directory based on install location
     let target_dir = if is_global {
-        // Global install: ~/.config/opencode/skills/<slug>
-        let home =
-            dirs::home_dir().ok_or_else(|| "Failed to determine home directory".to_string())?;
-        home.join(".config")
+        // "Global" install is workspace-scoped under XDG isolation:
+        // <workspace>/.opencode/config/opencode/skills/<slug>
+        let ws_path = workspace_path
+            .ok_or_else(|| "Workspace path required for global skill installation under XDG isolation".to_string())?;
+        Path::new(&ws_path)
+            .join(".opencode")
+            .join("config")
             .join("opencode")
             .join("skills")
             .join(slug)
@@ -1293,9 +1296,14 @@ pub fn import_skill_from_zip(
         validate_skill_import_slug(&slug)?;
 
         let target_dir = if is_global {
-            let home =
-                dirs::home_dir().ok_or_else(|| "Failed to determine home directory".to_string())?;
-            home.join(".config")
+            // "Global" install is workspace-scoped under XDG isolation:
+            // <workspace>/.opencode/config/opencode/skills/<slug>
+            let ws_path = workspace_path.ok_or_else(|| {
+                "Workspace path required for global skill installation under XDG isolation".to_string()
+            })?;
+            Path::new(&ws_path)
+                .join(".opencode")
+                .join("config")
                 .join("opencode")
                 .join("skills")
                 .join(&slug)


### PR DESCRIPTION
## Summary
- Inject `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME` env vars when spawning the OpenCode sidecar, redirecting all paths to `<workspace>/.opencode/`
- Prevents conflicts with system-installed OpenCode's global config/data dirs (`~/.config/opencode`, `~/.local/share/opencode`)
- `get_opencode_db_path`: workspace-aware lookup with legacy fallback
- `read/write_opencode_allowlist`: accept `workspace_path` parameter
- Global skills install redirected to workspace-scoped path
- Frontend callers pass `workspacePath` to DB commands

## Test plan
- [ ] Open two different workspaces — verify each has its own `.opencode/` directory with isolated config/data
- [ ] Verify OpenCode sidecar starts correctly with the XDG env vars
- [ ] Verify session permissions UI still loads and saves correctly
- [ ] If a system-installed OpenCode exists, verify no cross-contamination of config
- [ ] Verify legacy fallback works for workspaces without `.opencode/` directory

🤖 Generated with [Claude Code](https://claude.ai/code)