### PR TITLE
feat(webview): open URLs in built-in webview instead of system browser

### DIFF
--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -11,7 +11,9 @@
  *  - Telemetry consent dialog
  */
 import { useEffect, useRef, useState, useCallback } from "react";
-import { isTauri, openExternalUrl } from "@/lib/utils";
+import { isTauri } from "@/lib/utils";
+import { useTabsStore } from "@/stores/tabs";
+import { urlToLabel } from "@/lib/webview-utils";
 import { useWorkspaceStore } from "@/stores/workspace";
 import { useChannelsStore } from "@/stores/channels";
 import { useGitReposStore } from "@/stores/git-repos";
@@ -542,7 +544,11 @@ export function useExternalLinkHandler() {
       if (href && /^https?:\/\//.test(href)) {
         e.preventDefault();
         e.stopPropagation();
-        openExternalUrl(href);
+        useTabsStore.getState().openTab({
+          type: "webview",
+          target: href,
+          label: urlToLabel(href),
+        });
       }
     };
 

--- a/src-tauri/src/commands/webview.rs
+++ b/src-tauri/src/commands/webview.rs
@@ -217,6 +217,34 @@ pub async fn webview_create(
         }
     }
 
+    // Intercept target="_blank" links and window.open() so they navigate
+    // within the same webview instead of opening the system browser.
+    webview_builder = webview_builder.initialization_script(
+        r#"(function(){
+  document.addEventListener('click', function(e) {
+    var a = e.target.closest && e.target.closest('a');
+    if (!a) return;
+    var t = a.getAttribute('target');
+    if (t && t !== '_self') {
+      var href = a.href || a.getAttribute('href');
+      if (href && /^https?:\/\//.test(href)) {
+        e.preventDefault();
+        e.stopPropagation();
+        window.location.href = href;
+      }
+    }
+  }, true);
+  var _open = window.open;
+  window.open = function(url) {
+    if (url && /^https?:\/\//.test(String(url))) {
+      window.location.href = String(url);
+      return window;
+    }
+    return _open.apply(this, arguments);
+  };
+})();"#,
+    );
+
     // Inject window.teamclaw identity global before any page scripts run.
     if let (Some(ref dno), Some(ref dname)) = (&device_no, &device_name) {
         let escaped_no = serde_json::to_string(dno).unwrap_or_else(|_| "\"\"".to_string());


### PR DESCRIPTION
## Summary
- **Message list links**: Clicking URLs in chat messages now opens them in an internal WebView tab instead of launching the system browser
- **WebView internal links**: `target="_blank"` links and `window.open()` calls inside native webviews now navigate within the same webview instead of escaping to the system browser

## Changes
- `useAppInit.ts`: `useExternalLinkHandler` now calls `useTabsStore.openTab({ type: "webview" })` instead of `openExternalUrl()`
- `webview.rs`: Injects an initialization script into every child webview that intercepts `target="_blank"` clicks and `window.open()` calls

## Test plan
- [ ] Click a URL in a chat message → should open in a WebView tab
- [ ] Inside that WebView, click a `target="_blank"` link → should navigate within the same webview
- [ ] Verify `window.open()` calls from webview pages stay in-app

🤖 Generated with [Claude Code](https://claude.ai/code)