### PR TITLE
fix: perf improvements and concurrency fixes

### DIFF
--- a/packages/app/src/components/editors/TiptapMarkdownEditor.tsx
+++ b/packages/app/src/components/editors/TiptapMarkdownEditor.tsx
@@ -9,7 +9,7 @@
  * - Image paste and auto-upload to _assets directory
  */
 
-import { useCallback, useEffect, useRef, useState, useImperativeHandle, forwardRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useImperativeHandle, forwardRef } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import { Markdown } from "@tiptap/markdown";
 import { Table, TableRow, TableCell, TableHeader } from "@tiptap/extension-table";
@@ -77,16 +77,23 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
     // → overwrites the file with serialized content even though the user never edited.
     const isProgrammaticUpdateRef = useRef(false);
 
+    // Stores the post-roundtrip markdown after programmatic content loads.
+    // Used to detect and suppress "roundtrip noise" in onUpdate: if the
+    // serialized markdown matches this baseline, it's not a real user edit.
+    const normalizedBaselineRef = useRef("");
+
+    const extraExtensions = useMemo(() => [
+      Markdown,
+      Table.configure({ resizable: false, HTMLAttributes: { class: "tiptap-table" } }),
+      TableRow,
+      TableCell,
+      TableHeader,
+      AgentHighlight,
+    ], []);
+
     const baseExtensions = useTiptapExtensions({
       imageConfig: { inline: false, allowBase64: true },
-      extraExtensions: [
-        Markdown,
-        Table.configure({ resizable: false, HTMLAttributes: { class: "tiptap-table" } }),
-        TableRow,
-        TableCell,
-        TableHeader,
-        AgentHighlight,
-      ],
+      extraExtensions,
     })
 
     const editor = useEditor({
@@ -103,6 +110,14 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
         // Decorations (AgentHighlight) don't affect getMarkdown output
         const md = editor.getMarkdown();
         const cleaned = unresolveMarkdownImages(md, filePath);
+
+        // Skip if the serialized markdown matches the post-roundtrip baseline.
+        // This catches "roundtrip noise" from deferred ProseMirror updates
+        // (e.g. extension normalization) that fire after the programmatic guard
+        // is released.
+        if (cleaned === normalizedBaselineRef.current) return;
+        normalizedBaselineRef.current = cleaned;
+
         onChangeRef.current?.(cleaned);
       },
       editorProps: {
@@ -134,8 +149,15 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
         const resolved = await resolveMarkdownImages(content, filePath);
         if (cancelled) return;
         isProgrammaticUpdateRef.current = true;
-        editor.commands.setContent(resolved, { contentType: "markdown" });
+        editor.commands.setContent(resolved, { contentType: "markdown", emitUpdate: false });
         isProgrammaticUpdateRef.current = false;
+        // Store the post-roundtrip markdown as the baseline so that
+        // deferred onUpdate calls (from extension normalization etc.)
+        // won't be mistaken for user edits.
+        normalizedBaselineRef.current = unresolveMarkdownImages(
+          editor.getMarkdown(),
+          filePath,
+        );
         previousContentRef.current = content;
         setIsReady(true);
       };
@@ -166,10 +188,14 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
         // Resolve images and set content
         const resolved = await resolveMarkdownImages(newMarkdown, filePath);
         isProgrammaticUpdateRef.current = true;
-        editor.commands.setContent(resolved, { contentType: "markdown" });
+        editor.commands.setContent(resolved, { contentType: "markdown", emitUpdate: false });
         isProgrammaticUpdateRef.current = false;
 
-        // Update the tracked content reference
+        // Update baselines
+        normalizedBaselineRef.current = unresolveMarkdownImages(
+          editor.getMarkdown(),
+          filePath,
+        );
         previousContentRef.current = newMarkdown;
 
         // Get the new doc after setContent
@@ -281,8 +307,13 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
             isProgrammaticUpdateRef.current = true;
             editor.commands.setContent(resolved, {
               contentType: "markdown",
+              emitUpdate: false,
             });
             isProgrammaticUpdateRef.current = false;
+            normalizedBaselineRef.current = unresolveMarkdownImages(
+              editor.getMarkdown(),
+              filePath,
+            );
 
             // Restore cursor position
             const maxPos = editor.state.doc.content.size;
@@ -319,7 +350,13 @@ export const TiptapMarkdownEditor = forwardRef<TiptapEditorHandle, EditorProps>(
         } else {
           // raw → WYSIWYG: push raw content back into editor
           const resolved = await resolveMarkdownImages(rawContent, filePath);
-          editor.commands.setContent(resolved, { contentType: "markdown" });
+          isProgrammaticUpdateRef.current = true;
+          editor.commands.setContent(resolved, { contentType: "markdown", emitUpdate: false });
+          isProgrammaticUpdateRef.current = false;
+          normalizedBaselineRef.current = unresolveMarkdownImages(
+            editor.getMarkdown(),
+            filePath,
+          );
           previousContentRef.current = rawContent;
           setRawMode(false);
         }

--- a/packages/app/src/components/workspace/FileBrowser.tsx
+++ b/packages/app/src/components/workspace/FileBrowser.tsx
@@ -34,6 +34,7 @@ export function FileBrowser({ className, variant = 'default' }: FileBrowserProps
   const undo = useWorkspaceStore(s => s.undo)
   const undoStack = useWorkspaceStore(s => s.undoStack)
   const [filterText, setFilterText] = React.useState('')
+  const deferredFilterText = React.useDeferredValue(filterText)
   const [gitChangedOnly, setGitChangedOnly] = React.useState(false)
 
   // Auto-refresh file tree when panel opens (default variant) or when mounted (panel variant)
@@ -174,7 +175,7 @@ export function FileBrowser({ className, variant = 'default' }: FileBrowserProps
       <ScrollAreaPrimitive.Root className="flex-1 relative overflow-hidden">
         <ScrollAreaPrimitive.Viewport className="h-full w-full">
           <div className="py-1 min-w-max">
-            <FileTree filterText={filterText} gitChangedOnly={gitChangedOnly} />
+            <FileTree filterText={deferredFilterText} gitChangedOnly={gitChangedOnly} />
           </div>
         </ScrollAreaPrimitive.Viewport>
         <ScrollBar orientation="vertical" />

--- a/src-tauri/src/commands/cron/delivery.rs
+++ b/src-tauri/src/commands/cron/delivery.rs
@@ -280,7 +280,10 @@ impl DeliveryManager {
             ))?;
 
         use crate::commands::gateway::wechat;
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         wechat::send_text_message(&client, base_url, bot_token, target, message, context_token)
             .await
     }

--- a/src-tauri/src/commands/cron/mod.rs
+++ b/src-tauri/src/commands/cron/mod.rs
@@ -41,14 +41,11 @@ pub async fn cron_init(
     cron_state: State<'_, CronState>,
     gateway_state: State<'_, crate::commands::gateway::GatewayState>,
 ) -> Result<(), String> {
-    let workspace_path = opencode_state
-        .workspace_path
-        .lock()
-        .map_err(|e| e.to_string())?
-        .clone()
-        .ok_or("No workspace path set.")?;
-
-    let port = *opencode_state.port.lock().map_err(|e| e.to_string())?;
+    let (workspace_path, port) = {
+        let inner = opencode_state.inner.lock().map_err(|e| e.to_string())?;
+        let ws = inner.workspace_path.clone().ok_or("No workspace path set.")?;
+        (ws, inner.port)
+    };
 
     // Step 1: Stop old scheduler first (if reinitializing).
     // CRITICAL: Must stop BEFORE init() to prevent old tick loop from reading

--- a/src-tauri/src/commands/cron/scheduler.rs
+++ b/src-tauri/src/commands/cron/scheduler.rs
@@ -880,7 +880,10 @@ impl CronScheduler {
     /// Check if an OpenCode session is archived.
     /// Returns true if archived, false if active, false on error (fail-open).
     async fn is_session_archived(&self, port: u16, session_id: &str) -> bool {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         let url = format!("http://127.0.0.1:{}/session/{}", port, session_id);
 
         match client.get(&url).send().await {
@@ -902,7 +905,10 @@ impl CronScheduler {
         port: u16,
         directory: Option<&str>,
     ) -> Result<String, String> {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         let mut url = format!("http://127.0.0.1:{}/session", port);
         if let Some(dir) = directory {
             url = format!("{}?directory={}", url, urlencoding::encode(dir));

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -81,9 +81,10 @@ fn set_env_vars_in_json(json: &mut serde_json::Value, entries: &[EnvVarEntry]) {
 /// Extract workspace_path from OpenCodeState.
 fn get_workspace_path(state: &State<'_, OpenCodeState>) -> Result<String, String> {
     state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or_else(|| "No workspace path set. Please select a workspace first.".to_string())
 }

--- a/src-tauri/src/commands/gateway/discord.rs
+++ b/src-tauri/src/commands/gateway/discord.rs
@@ -1168,7 +1168,10 @@ pub async fn send_channel_message(
     channel_id: &str,
     content: &str,
 ) -> Result<(), String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!(
         "https://discord.com/api/v10/channels/{}/messages",
         channel_id
@@ -1193,7 +1196,10 @@ pub async fn send_channel_message(
 
 /// Create a DM channel with a Discord user. Returns the DM channel ID.
 pub async fn create_dm_channel(token: &str, user_id: &str) -> Result<String, String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = "https://discord.com/api/v10/users/@me/channels";
     let body = serde_json::json!({ "recipient_id": user_id });
 

--- a/src-tauri/src/commands/gateway/feishu.rs
+++ b/src-tauri/src/commands/gateway/feishu.rs
@@ -304,7 +304,10 @@ impl TokenManager {
 
     /// Refresh the app access token (used for WebSocket auth)
     async fn refresh_token(&self) -> Result<String, String> {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         let url = format!(
             "{}/open-apis/auth/v3/app_access_token/internal",
             FEISHU_API_BASE
@@ -353,7 +356,10 @@ impl TokenManager {
 
     /// Also get a tenant_access_token for API calls (sending messages, etc.)
     async fn get_tenant_token(&self) -> Result<String, String> {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         let url = format!(
             "{}/open-apis/auth/v3/tenant_access_token/internal",
             FEISHU_API_BASE
@@ -563,7 +569,10 @@ impl Clone for FeishuGateway {
 /// Get the WebSocket endpoint URL from Feishu API
 /// Uses AppID + AppSecret in body (no bearer token), matching Go SDK behavior.
 async fn get_ws_endpoint(app_id: &str, app_secret: &str) -> Result<(String, i32), String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!("{}/callback/ws/endpoint", FEISHU_API_BASE);
 
     println!("[Feishu] Getting WS endpoint from: {}", url);
@@ -1586,7 +1595,10 @@ async fn send_to_opencode(
 
 /// Reply to a Feishu message. Returns the reply message_id on success.
 async fn reply_feishu_message(token: &str, message_id: &str, text: &str) -> Result<String, String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!(
         "{}/open-apis/im/v1/messages/{}/reply",
         FEISHU_API_BASE, message_id
@@ -1628,7 +1640,10 @@ async fn reply_feishu_message(token: &str, message_id: &str, text: &str) -> Resu
 /// Update (edit) an existing Feishu card message content.
 /// The message MUST have been sent as an interactive card; plain text messages cannot be updated.
 async fn update_feishu_message(token: &str, message_id: &str, text: &str) -> Result<(), String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!(
         "{}/open-apis/im/v1/messages/{}",
         FEISHU_API_BASE, message_id
@@ -1694,7 +1709,10 @@ async fn reply_feishu_card_message(
     text: &str,
     title: Option<&str>,
 ) -> Result<String, String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!(
         "{}/open-apis/im/v1/messages/{}/reply",
         FEISHU_API_BASE, message_id
@@ -1750,7 +1768,10 @@ pub async fn send_chat_message(
 }
 
 async fn send_feishu_message(token: &str, chat_id: &str, text: &str) -> Result<(), String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!(
         "{}/open-apis/im/v1/messages?receive_id_type=chat_id",
         FEISHU_API_BASE
@@ -1787,7 +1808,10 @@ async fn download_feishu_image(
     message_id: &str,
     image_key: &str,
 ) -> Result<(String, String), String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!(
         "{}/open-apis/im/v1/messages/{}/resources/{}?type=image",
         FEISHU_API_BASE, message_id, image_key

--- a/src-tauri/src/commands/gateway/kook.rs
+++ b/src-tauri/src/commands/gateway/kook.rs
@@ -308,7 +308,10 @@ impl KookGateway {
 
     /// Fetch the bot's own user ID via /api/v3/user/me
     async fn fetch_bot_user_id(&self, token: &str) -> Result<String, String> {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         let url = format!("{}/user/me", KOOK_API_BASE);
 
         let resp = client
@@ -534,7 +537,10 @@ impl KookGateway {
 
     /// Get gateway WebSocket URL from KOOK API
     async fn get_gateway_url(&self, token: &str) -> Result<String, String> {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         let url = format!("{}/gateway/index?compress=0", KOOK_API_BASE);
 
         let resp = client
@@ -972,7 +978,10 @@ impl KookGateway {
                 let ct = channel_type.clone();
                 Box::pin(async move {
                     let text = super::format_question_message(&fq.questions, &fq.question_id, locale_for_q);
-                    let client = reqwest::Client::new();
+                    let client = reqwest::Client::builder()
+                        .timeout(std::time::Duration::from_secs(30))
+                        .build()
+                        .unwrap_or_else(|_| reqwest::Client::new());
                     let (url, body) = if ct == "PERSON" {
                         (
                             "https://www.kookapp.cn/api/v3/direct-message/create".to_string(),
@@ -1081,7 +1090,10 @@ impl KookGateway {
     /// Send "Thinking..." card message and return msg_id
     async fn send_thinking_card(&self, original: &KookMessageData) -> Result<String, String> {
         let config = self.config.read().await;
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
 
         // Create a simple card with "Thinking..." text
         let card = json!([
@@ -1160,7 +1172,10 @@ impl KookGateway {
         is_dm: bool,
     ) -> Result<(), String> {
         let config = self.config.read().await;
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
 
         // Create card with the actual content
         let card = json!([
@@ -1220,7 +1235,10 @@ impl KookGateway {
     /// Send reply via KOOK HTTP API using card message for rich formatting
     async fn send_reply(&self, original: &KookMessageData, reply_text: &str) -> Result<(), String> {
         let config = self.config.read().await;
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
 
         let card = json!([
             {
@@ -1493,7 +1511,10 @@ impl KookGateway {
         card: &serde_json::Value,
     ) -> Result<(), String> {
         let config = self.config.read().await;
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
 
         let (endpoint, payload) = if original.channel_type == "PERSON" {
             let url = format!("{}/direct-message/create", KOOK_API_BASE);
@@ -1586,7 +1607,10 @@ pub async fn send_kook_message_http(
     content: &str,
     is_dm: bool,
 ) -> Result<(), String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
 
     let (endpoint, payload) = if is_dm {
         let url = format!("{}/direct-message/create", KOOK_API_BASE);

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -1182,9 +1182,10 @@ pub async fn get_channel_config(
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<ChannelsConfig, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -1199,9 +1200,10 @@ pub async fn save_channel_config(
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -1227,9 +1229,10 @@ pub async fn save_discord_config(
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -1261,9 +1264,10 @@ pub async fn set_config_locale(
     locale: String,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
     let mut config = read_config(&workspace_path)?;
@@ -1277,16 +1281,13 @@ pub async fn start_gateway(
     opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
-    // Get OpenCode port
-    let port = *opencode_state.port.lock().map_err(|e| e.to_string())?;
-
-    // Get workspace path for config
-    let workspace_path = opencode_state
-        .workspace_path
-        .lock()
-        .map_err(|e| e.to_string())?
-        .clone()
-        .ok_or("No workspace path set. Please select a workspace first.")?;
+    // Get OpenCode port and workspace path
+    let (port, workspace_path) = {
+        let inner = opencode_state.inner.lock().map_err(|e| e.to_string())?;
+        let ws = inner.workspace_path.clone()
+            .ok_or("No workspace path set. Please select a workspace first.")?;
+        (inner.port, ws)
+    };
 
     // Read config
     println!("[Gateway] Reading config from: {}", workspace_path);
@@ -1390,9 +1391,10 @@ pub async fn save_feishu_config(
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -1423,14 +1425,12 @@ pub async fn start_feishu_gateway(
     opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
-    let port = *opencode_state.port.lock().map_err(|e| e.to_string())?;
-
-    let workspace_path = opencode_state
-        .workspace_path
-        .lock()
-        .map_err(|e| e.to_string())?
-        .clone()
-        .ok_or("No workspace path set. Please select a workspace first.")?;
+    let (port, workspace_path) = {
+        let inner = opencode_state.inner.lock().map_err(|e| e.to_string())?;
+        let ws = inner.workspace_path.clone()
+            .ok_or("No workspace path set. Please select a workspace first.")?;
+        (inner.port, ws)
+    };
 
     let config = read_config(&workspace_path)?;
     let feishu_config = config
@@ -1552,9 +1552,10 @@ pub async fn save_email_config(
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -1585,14 +1586,12 @@ pub async fn start_email_gateway(
     opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
-    let port = *opencode_state.port.lock().map_err(|e| e.to_string())?;
-
-    let workspace_path = opencode_state
-        .workspace_path
-        .lock()
-        .map_err(|e| e.to_string())?
-        .clone()
-        .ok_or("No workspace path set. Please select a workspace first.")?;
+    let (port, workspace_path) = {
+        let inner = opencode_state.inner.lock().map_err(|e| e.to_string())?;
+        let ws = inner.workspace_path.clone()
+            .ok_or("No workspace path set. Please select a workspace first.")?;
+        (inner.port, ws)
+    };
 
     let config = read_config(&workspace_path)?;
     let email_config = config
@@ -1677,9 +1676,10 @@ pub async fn gmail_authorize(
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<String, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -1690,9 +1690,10 @@ pub async fn gmail_authorize(
 #[tauri::command]
 pub async fn check_gmail_auth(opencode_state: State<'_, OpenCodeState>) -> Result<bool, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -1718,9 +1719,10 @@ pub async fn save_kook_config(
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -1751,14 +1753,12 @@ pub async fn start_kook_gateway(
     opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
-    let port = *opencode_state.port.lock().map_err(|e| e.to_string())?;
-
-    let workspace_path = opencode_state
-        .workspace_path
-        .lock()
-        .map_err(|e| e.to_string())?
-        .clone()
-        .ok_or("No workspace path set. Please select a workspace first.")?;
+    let (port, workspace_path) = {
+        let inner = opencode_state.inner.lock().map_err(|e| e.to_string())?;
+        let ws = inner.workspace_path.clone()
+            .ok_or("No workspace path set. Please select a workspace first.")?;
+        (inner.port, ws)
+    };
 
     let config = read_config(&workspace_path)?;
     let kook_config = config
@@ -1904,9 +1904,10 @@ pub async fn save_wecom_config(
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -1937,14 +1938,12 @@ pub async fn start_wecom_gateway(
     opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
-    let port = *opencode_state.port.lock().map_err(|e| e.to_string())?;
-
-    let workspace_path = opencode_state
-        .workspace_path
-        .lock()
-        .map_err(|e| e.to_string())?
-        .clone()
-        .ok_or("No workspace path set. Please select a workspace first.")?;
+    let (port, workspace_path) = {
+        let inner = opencode_state.inner.lock().map_err(|e| e.to_string())?;
+        let ws = inner.workspace_path.clone()
+            .ok_or("No workspace path set. Please select a workspace first.")?;
+        (inner.port, ws)
+    };
 
     println!(
         "[Gateway] start_wecom_gateway called, workspace={}",
@@ -2135,9 +2134,10 @@ pub async fn save_wechat_config(
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -2168,14 +2168,12 @@ pub async fn start_wechat_gateway(
     opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
-    let port = *opencode_state.port.lock().map_err(|e| e.to_string())?;
-
-    let workspace_path = opencode_state
-        .workspace_path
-        .lock()
-        .map_err(|e| e.to_string())?
-        .clone()
-        .ok_or("No workspace path set. Please select a workspace first.")?;
+    let (port, workspace_path) = {
+        let inner = opencode_state.inner.lock().map_err(|e| e.to_string())?;
+        let ws = inner.workspace_path.clone()
+            .ok_or("No workspace path set. Please select a workspace first.")?;
+        (inner.port, ws)
+    };
 
     println!(
         "[Gateway] start_wechat_gateway called, workspace={}",
@@ -2307,8 +2305,8 @@ pub async fn poll_wechat_qr_status(
                 context_tokens: std::collections::HashMap::new(),
             };
             // Save to config if workspace is set
-            if let Ok(guard) = opencode_state.workspace_path.lock() {
-                if let Some(ref workspace_path) = *guard {
+            if let Ok(inner) = opencode_state.inner.lock() {
+                if let Some(ref workspace_path) = inner.workspace_path {
                     if let Ok(mut config) = read_config(workspace_path) {
                         let channels = config.channels.get_or_insert_with(ChannelsConfig::default);
                         channels.wechat = Some(wechat_cfg.clone());

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -91,7 +91,10 @@ impl ProcessedMessageTracker {
 
 /// Create a new OpenCode session
 pub async fn create_opencode_session(port: u16) -> Result<String, String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!("http://127.0.0.1:{}/session", port);
 
     // Set an explicit title to avoid OpenCode auto-generating titles that might conflict
@@ -269,7 +272,10 @@ pub async fn send_message_async_with_approval(
         }
     }
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
 
     // Step 1: Connect to SSE FIRST to avoid missing events
     let sse_url = format!("http://127.0.0.1:{}/event", port);
@@ -448,7 +454,10 @@ async fn poll_for_message_with_approval_from_stream(
                                     let port_clone = port;
                                     let perm_id_clone = perm_id_str.to_string();
                                     tokio::spawn(async move {
-                                        let client = reqwest::Client::new();
+                                        let client = reqwest::Client::builder()
+                                            .timeout(std::time::Duration::from_secs(30))
+                                            .build()
+                                            .unwrap_or_else(|_| reqwest::Client::new());
                                         let approve_url = format!(
                                             "http://127.0.0.1:{}/permission/{}/reply",
                                             port_clone, perm_id_clone
@@ -592,7 +601,10 @@ async fn fetch_message_content(
     session_id: &str,
     message_id: &str,
 ) -> Result<String, String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!("http://127.0.0.1:{}/session/{}/message", port, session_id);
 
     let response = client
@@ -676,7 +688,10 @@ pub struct ModelInfo {
 
 /// Get available models from OpenCode config providers, along with the global default
 pub async fn opencode_get_available_models(port: u16) -> Result<(Vec<ModelInfo>, String), String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
 
     // Get both current config and providers in parallel
     let config_url = format!("http://127.0.0.1:{}/config", port);
@@ -881,7 +896,10 @@ const MAX_SESSIONS_LIST: usize = 10;
 
 /// Fetch recent sessions from OpenCode, sorted by updated time descending
 pub async fn opencode_list_sessions(port: u16) -> Result<Vec<SessionInfo>, String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!("http://127.0.0.1:{}/session", port);
 
     let resp = client
@@ -924,7 +942,10 @@ pub async fn opencode_list_sessions(port: u16) -> Result<Vec<SessionInfo>, Strin
 
 /// Fetch the latest assistant message text from a session
 async fn fetch_latest_assistant_message(port: u16, session_id: &str, locale: i18n::Locale) -> Result<String, String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!("http://127.0.0.1:{}/session/{}/message", port, session_id);
 
     let resp = client
@@ -1106,7 +1127,10 @@ pub async fn handle_stop_command(
         None => return i18n::t(i18n::MsgKey::NoActiveSession, locale),
     };
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!("http://127.0.0.1:{}/session/{}/abort", port, session_id);
 
     match client.post(&url).send().await {
@@ -1856,7 +1880,10 @@ pub async fn test_kook_token(token: String) -> Result<String, String> {
         return Err("Token is empty".to_string());
     }
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let url = format!("{}/gateway/index?compress=0", kook::KOOK_API_BASE);
 
     match client

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -157,7 +157,13 @@ impl Default for GatewayState {
 /// Ensure the shared session mapping is initialized with persistence
 async fn ensure_session_initialized(gateway_state: &GatewayState, workspace_path: &str) {
     let needs_init = {
-        let mut initialized = gateway_state.session_initialized.lock().unwrap();
+        let mut initialized = match gateway_state.session_initialized.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                eprintln!("[Gateway] session_initialized mutex was poisoned, recovering");
+                poisoned.into_inner()
+            }
+        };
         if *initialized {
             false
         } else {

--- a/src-tauri/src/commands/gateway/pending_question.rs
+++ b/src-tauri/src/commands/gateway/pending_question.rs
@@ -292,7 +292,10 @@ pub async fn handle_question_event(
             let store_clone = std::sync::Arc::clone(&ctx.store);
             let cmid = channel_msg_id;
             tokio::spawn(async move {
-                let client = reqwest::Client::new();
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()
+                    .unwrap_or_else(|_| reqwest::Client::new());
                 match tokio::time::timeout(std::time::Duration::from_secs(300), rx).await {
                     Ok(Ok(answer)) => {
                         let answers = resolve_answer(&answer, &questions_clone);
@@ -325,7 +328,10 @@ pub async fn handle_question_event(
                 session_id_prefix, e
             );
             let url = format!("http://127.0.0.1:{}/question/{}/reject", port, question_id);
-            let client = reqwest::Client::new();
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new());
             let _ = client.post(&url).json(&serde_json::json!({})).send().await;
         }
     }

--- a/src-tauri/src/commands/gateway/wechat.rs
+++ b/src-tauri/src/commands/gateway/wechat.rs
@@ -133,7 +133,10 @@ pub async fn fetch_qr_code(base_url: &str) -> Result<WeChatQrLoginResponse, Stri
         "{}/ilink/bot/get_bot_qrcode?bot_type=3",
         base_url.trim_end_matches('/')
     );
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let resp = client
         .get(&url)
         .send()
@@ -424,7 +427,10 @@ impl WeChatGateway {
                     to_user_id
                 )
             })?;
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         send_text_message(
             &client,
             &config.base_url,

--- a/src-tauri/src/commands/gateway/wecom.rs
+++ b/src-tauri/src/commands/gateway/wecom.rs
@@ -182,7 +182,10 @@ pub async fn fetch_wecom_qr_code() -> Result<super::wecom_config::WeComQrAuthSta
     use super::wecom_config::{WeComQrGenerateResponse, WeComQrAuthStart};
 
     let url = format!("{}?source=teamclaw&plat={}", WECOM_QR_GENERATE_URL, get_plat_code());
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let resp = client
         .get(&url)
         .send()
@@ -1068,7 +1071,10 @@ impl WeComGateway {
         aeskey: Option<&str>,
         filename_hint: Option<&str>,
     ) -> Result<(String, String, Vec<u8>), String> {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         let resp = client
             .get(url)
             .timeout(std::time::Duration::from_secs(30))
@@ -1314,7 +1320,10 @@ impl WeComGateway {
         use futures_util::StreamExt as _;
 
         let port = self.opencode_port;
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         let mut stream_id = uuid::Uuid::new_v4().to_string();
 
         // Start thinking animation IMMEDIATELY (before prompt_async / SSE setup)
@@ -1535,7 +1544,10 @@ impl WeComGateway {
                                     let port_clone = port;
                                     let perm_id_clone = perm_id_str.to_string();
                                     tokio::spawn(async move {
-                                        let client = reqwest::Client::new();
+                                        let client = reqwest::Client::builder()
+                                            .timeout(std::time::Duration::from_secs(30))
+                                            .build()
+                                            .unwrap_or_else(|_| reqwest::Client::new());
                                         let url = format!(
                                             "http://127.0.0.1:{}/permission/{}/reply",
                                             port_clone, perm_id_clone

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -87,9 +87,10 @@ pub async fn get_mcp_config(
     state: State<'_, OpenCodeState>,
 ) -> Result<IndexMap<String, MCPServerConfig>, String> {
     let workspace_path = state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -104,9 +105,10 @@ pub async fn save_mcp_config(
     mcp_config: IndexMap<String, MCPServerConfig>,
 ) -> Result<(), String> {
     let workspace_path = state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -127,9 +129,10 @@ pub async fn add_mcp_server(
     server_config: MCPServerConfig,
 ) -> Result<(), String> {
     let workspace_path = state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -153,9 +156,10 @@ pub async fn update_mcp_server(
     server_config: MCPServerConfig,
 ) -> Result<(), String> {
     let workspace_path = state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -178,9 +182,10 @@ pub async fn remove_mcp_server(
     name: String,
 ) -> Result<(), String> {
     let workspace_path = state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -204,9 +209,10 @@ pub async fn toggle_mcp_server(
     enabled: bool,
 ) -> Result<(), String> {
     let workspace_path = state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -237,9 +243,10 @@ pub async fn test_mcp_server(
     name: String,
 ) -> Result<MCPTestResult, String> {
     let workspace_path = state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.")?;
 
@@ -720,9 +727,10 @@ pub async fn list_mcp_tools(
     state: State<'_, OpenCodeState>,
 ) -> Result<HashMap<String, Vec<String>>, String> {
     let workspace_path = state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -10,13 +10,21 @@ use tokio::sync::mpsc;
 /// This is the single source of truth for the port number.
 const DEFAULT_PORT: u16 = 13141;
 
+/// Mutable runtime state for the OpenCode sidecar, protected by a single Mutex.
+pub struct OpenCodeInner {
+    pub is_running: bool,
+    pub port: u16,
+    pub child_process: Option<CommandChild>,
+    pub is_dev_mode: bool,
+    pub workspace_path: Option<String>,
+    /// Handle to the async task monitoring sidecar stdout/stderr.
+    /// Aborted on shutdown to prevent resource leaks.
+    pub reader_task: Option<tauri::async_runtime::JoinHandle<()>>,
+}
+
 /// OpenCode server state
 pub struct OpenCodeState {
-    pub is_running: Mutex<bool>,
-    pub port: Mutex<u16>,
-    pub child_process: Mutex<Option<CommandChild>>,
-    pub is_dev_mode: Mutex<bool>,
-    pub workspace_path: Mutex<Option<String>>,
+    pub inner: Mutex<OpenCodeInner>,
     /// Async lock that serializes `start_opencode` calls to prevent concurrent spawns.
     pub start_lock: tokio::sync::Mutex<()>,
     /// Early launch state — set by setup hook, consumed by start_opencode.
@@ -31,11 +39,14 @@ impl Default for OpenCodeState {
             .unwrap_or(false);
 
         Self {
-            is_running: Mutex::new(false),
-            port: Mutex::new(DEFAULT_PORT),
-            child_process: Mutex::new(None),
-            is_dev_mode: Mutex::new(is_dev),
-            workspace_path: Mutex::new(None),
+            inner: Mutex::new(OpenCodeInner {
+                is_running: false,
+                port: DEFAULT_PORT,
+                child_process: None,
+                is_dev_mode: is_dev,
+                workspace_path: None,
+                reader_task: None,
+            }),
             start_lock: tokio::sync::Mutex::new(()),
             early_launch: tokio::sync::Mutex::new(None),
         }
@@ -127,36 +138,31 @@ pub async fn start_opencode_inner(
         inner_t0.elapsed().as_secs_f64() * 1000.0
     );
 
-    let is_dev_mode = *state.is_dev_mode.lock().map_err(|e| e.to_string())?;
     let port = config.port.unwrap_or(DEFAULT_PORT);
 
-    // Check if already running (extract values and drop guards before any await)
+    // Check if already running (extract values and drop guard before any await)
     let mut needs_restart = false;
+    let is_dev_mode;
     {
-        let is_running = *state.is_running.lock().map_err(|e| e.to_string())?;
-        let current_workspace = state
-            .workspace_path
-            .lock()
-            .map_err(|e| e.to_string())?
-            .clone();
+        let inner = state.inner.lock().map_err(|e| e.to_string())?;
+        is_dev_mode = inner.is_dev_mode;
 
-        if is_running {
-            let workspace_changed = current_workspace.as_ref() != Some(&config.workspace_path);
+        if inner.is_running {
+            let workspace_changed = inner.workspace_path.as_ref() != Some(&config.workspace_path);
 
             if !workspace_changed {
-                let port = *state.port.lock().map_err(|e| e.to_string())?;
                 return Ok(OpenCodeStatus {
                     is_running: true,
-                    port,
-                    url: format!("http://127.0.0.1:{}", port),
+                    port: inner.port,
+                    url: format!("http://127.0.0.1:{}", inner.port),
                     is_dev_mode,
-                    workspace_path: current_workspace,
+                    workspace_path: inner.workspace_path.clone(),
                 });
             }
 
             println!(
                 "[OpenCode] Workspace changed from {:?} to {}, restarting...",
-                current_workspace.as_ref(),
+                inner.workspace_path.as_ref(),
                 config.workspace_path
             );
 
@@ -167,17 +173,19 @@ pub async fn start_opencode_inner(
     if needs_restart {
         // Stop the existing server
         if !is_dev_mode {
-            let mut child_guard = state.child_process.lock().map_err(|e| e.to_string())?;
-            if let Some(child) = child_guard.take() {
+            let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+            if let Some(child) = inner.child_process.take() {
                 println!("[OpenCode] Killing previous process...");
                 let _ = child.kill();
             }
-        }
-
-        // Update state to not running
-        {
-            let mut is_running = state.is_running.lock().map_err(|e| e.to_string())?;
-            *is_running = false;
+            // Abort old reader task
+            if let Some(handle) = inner.reader_task.take() {
+                handle.abort();
+            }
+            inner.is_running = false;
+        } else {
+            let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+            inner.is_running = false;
         }
 
         // Wait for port to be released with exponential backoff
@@ -294,12 +302,10 @@ pub async fn start_opencode_inner(
 
         // Update state
         {
-            let mut is_running = state.is_running.lock().map_err(|e| e.to_string())?;
-            *is_running = true;
-            let mut port_guard = state.port.lock().map_err(|e| e.to_string())?;
-            *port_guard = port;
-            let mut workspace_guard = state.workspace_path.lock().map_err(|e| e.to_string())?;
-            *workspace_guard = Some(requested_path.clone());
+            let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+            inner.is_running = true;
+            inner.port = port;
+            inner.workspace_path = Some(requested_path.clone());
         }
 
         return Ok(OpenCodeStatus {
@@ -460,15 +466,15 @@ pub async fn start_opencode_inner(
 
     // Store the child process
     {
-        let mut child_guard = state.child_process.lock().map_err(|e| e.to_string())?;
-        *child_guard = Some(child);
+        let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+        inner.child_process = Some(child);
     }
 
     // Wait for server to be ready — channel carries Ok(()) on success or Err(message) on crash
     let (ready_tx, mut ready_rx) = mpsc::channel::<Result<(), String>>(1);
 
     let ready_tx_clone = ready_tx.clone();
-    tauri::async_runtime::spawn(async move {
+    let reader_handle = tauri::async_runtime::spawn(async move {
         let mut stderr_lines: Vec<String> = Vec::new();
         while let Some(event) = rx.recv().await {
             match event {
@@ -526,6 +532,12 @@ pub async fn start_opencode_inner(
         }
     });
 
+    // Store the reader task handle for cleanup
+    {
+        let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+        inner.reader_task = Some(reader_handle);
+    }
+
     // Wait for ready signal with timeout
     let ready = tokio::time::timeout(std::time::Duration::from_secs(15), ready_rx.recv()).await;
 
@@ -570,12 +582,10 @@ pub async fn start_opencode_inner(
 
     // Update state
     {
-        let mut is_running = state.is_running.lock().map_err(|e| e.to_string())?;
-        *is_running = true;
-        let mut port_guard = state.port.lock().map_err(|e| e.to_string())?;
-        *port_guard = port;
-        let mut workspace_guard = state.workspace_path.lock().map_err(|e| e.to_string())?;
-        *workspace_guard = Some(workspace_path.clone());
+        let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+        inner.is_running = true;
+        inner.port = port;
+        inner.workspace_path = Some(workspace_path.clone());
     }
 
     #[cfg(debug_assertions)]
@@ -1327,23 +1337,28 @@ async fn get_server_paths(port: u16) -> (Option<String>, Option<String>) {
 /// Stop OpenCode sidecar (production) or clear running state (dev). Shared by the
 /// `stop_opencode` command and application exit (`RunEvent::Exit`).
 pub async fn shutdown_opencode(state: &OpenCodeState) -> Result<(), String> {
-    let is_dev_mode = *state.is_dev_mode.lock().map_err(|e| e.to_string())?;
-    let port = *state.port.lock().map_err(|e| e.to_string())?;
+    let (is_dev_mode, port) = {
+        let inner = state.inner.lock().map_err(|e| e.to_string())?;
+        (inner.is_dev_mode, inner.port)
+    };
 
     // In dev mode, just update state (don't try to kill external process)
     if is_dev_mode {
-        let mut is_running = state.is_running.lock().map_err(|e| e.to_string())?;
-        *is_running = false;
+        let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+        inner.is_running = false;
         return Ok(());
     }
 
-    // Production mode: kill sidecar
+    // Production mode: kill sidecar and abort reader task
     {
-        let mut child_guard = state.child_process.lock().map_err(|e| e.to_string())?;
-        if let Some(child) = child_guard.take() {
+        let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+        if let Some(child) = inner.child_process.take() {
             child
                 .kill()
                 .map_err(|e| format!("Failed to stop OpenCode: {}", e))?;
+        }
+        if let Some(handle) = inner.reader_task.take() {
+            handle.abort();
         }
     }
 
@@ -1373,8 +1388,8 @@ pub async fn shutdown_opencode(state: &OpenCodeState) -> Result<(), String> {
 
     // Update state
     {
-        let mut is_running = state.is_running.lock().map_err(|e| e.to_string())?;
-        *is_running = false;
+        let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+        inner.is_running = false;
     }
 
     Ok(())
@@ -1631,20 +1646,12 @@ fn write_last_workspace(workspace_path: &str) {
 pub async fn get_opencode_status(
     state: State<'_, OpenCodeState>,
 ) -> Result<OpenCodeStatus, String> {
-    let is_running = *state.is_running.lock().map_err(|e| e.to_string())?;
-    let port = *state.port.lock().map_err(|e| e.to_string())?;
-    let is_dev_mode = *state.is_dev_mode.lock().map_err(|e| e.to_string())?;
-    let workspace_path = state
-        .workspace_path
-        .lock()
-        .map_err(|e| e.to_string())?
-        .clone();
-
+    let inner = state.inner.lock().map_err(|e| e.to_string())?;
     Ok(OpenCodeStatus {
-        is_running,
-        port,
-        url: format!("http://127.0.0.1:{}", port),
-        is_dev_mode,
-        workspace_path,
+        is_running: inner.is_running,
+        port: inner.port,
+        url: format!("http://127.0.0.1:{}", inner.port),
+        is_dev_mode: inner.is_dev_mode,
+        workspace_path: inner.workspace_path.clone(),
     })
 }

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -219,7 +219,10 @@ pub async fn oss_create_team(
         let fc_node_id = node_id.clone();
         let fc_owner_name = owner_name.clone();
         tokio::spawn(async move {
-            let client = reqwest::Client::new();
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new());
             let setup_url = format!("{}/ai/setup-team", fc_endpoint.trim_end_matches('/'));
             let add_url = format!("{}/ai/add-member", fc_endpoint.trim_end_matches('/'));
             tracing::info!("LiteLLM via FC: requesting {}", setup_url);
@@ -384,7 +387,10 @@ pub async fn oss_join_team(
         let fc_team_secret = team_secret.clone();
         let fc_node_id = node_id.clone();
         tokio::spawn(async move {
-            let client = reqwest::Client::new();
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new());
             let add_url = format!("{}/ai/add-member", fc_endpoint.trim_end_matches('/'));
             tracing::info!("LiteLLM via FC: requesting {}", add_url);
             let body = serde_json::json!({
@@ -718,7 +724,10 @@ pub async fn oss_apply_team(
     let arch = std::env::consts::ARCH.to_string();
 
     // Call FC /apply
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
     let body = serde_json::json!({
         "teamId": team_id,
         "teamSecret": team_secret,

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -219,7 +219,10 @@ impl OssSyncManager {
 
     pub async fn call_fc(&self, path: &str, body: &Value) -> Result<FcResponse, String> {
         let url = format!("{}{}", self.team_endpoint, path);
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
 
         let max_retries = 3u32;
         let mut attempt = 0u32;

--- a/src-tauri/src/commands/spotlight.rs
+++ b/src-tauri/src/commands/spotlight.rs
@@ -155,7 +155,7 @@ fn save_spotlight_position(win: &tauri::WebviewWindow, state: &SpotlightState) {
             .flatten()
             .map(|m| m.scale_factor())
             .unwrap_or(1.0);
-        let mut last_pos = state.spotlight_position.lock().unwrap();
+        let mut last_pos = state.spotlight_position.lock().unwrap_or_else(|e| e.into_inner());
         *last_pos = Some((pos.x as f64 / scale, pos.y as f64 / scale));
     }
 }
@@ -176,7 +176,7 @@ fn default_spotlight_position(win: &tauri::WebviewWindow) -> (f64, f64) {
 
 /// Restore the saved spotlight position, or default to top-right of the current monitor.
 fn restore_spotlight_position(win: &tauri::WebviewWindow, state: &SpotlightState) {
-    let last_pos = state.spotlight_position.lock().unwrap();
+    let last_pos = state.spotlight_position.lock().unwrap_or_else(|e| e.into_inner());
     if let Some((x, y)) = *last_pos {
         let _ = win.set_position(LogicalPosition::new(x, y));
     } else {
@@ -194,7 +194,7 @@ fn configure_as_spotlight(win: &tauri::WebviewWindow, state: &SpotlightState) {
     let _ = win.set_min_size(Some(LogicalSize::new(320.0, 300.0)));
     let _ = win.set_size(LogicalSize::new(SPOTLIGHT_WIDTH, SPOTLIGHT_HEIGHT));
     let _ = win.set_skip_taskbar(true);
-    let pinned = *state.pinned.lock().unwrap();
+    let pinned = *state.pinned.lock().unwrap_or_else(|e| e.into_inner());
     let _ = win.set_always_on_top(pinned);
     restore_spotlight_position(win, state);
 }
@@ -206,7 +206,7 @@ fn configure_as_main(win: &tauri::WebviewWindow, state: &SpotlightState) {
     let _ = win.set_min_size(Some(LogicalSize::new(800.0, 600.0)));
 
     // Restore saved main geometry or center at default size
-    let geom = state.main_geometry.lock().unwrap();
+    let geom = state.main_geometry.lock().unwrap_or_else(|e| e.into_inner());
     if let Some((x, y, w, h)) = *geom {
         let _ = win.set_size(LogicalSize::new(w, h));
         let _ = win.set_position(LogicalPosition::new(x, y));
@@ -229,7 +229,7 @@ pub fn save_main_geometry(win: &tauri::WebviewWindow, state: &SpotlightState) {
         .unwrap_or(1.0);
 
     if let (Ok(pos), Ok(size)) = (win.outer_position(), win.outer_size()) {
-        let mut geom = state.main_geometry.lock().unwrap();
+        let mut geom = state.main_geometry.lock().unwrap_or_else(|e| e.into_inner());
         *geom = Some((
             pos.x as f64 / scale,
             pos.y as f64 / scale,
@@ -290,14 +290,14 @@ pub fn toggle_spotlight(app: AppHandle, state: State<'_, SpotlightState>) {
     };
 
     let visible = win.is_visible().unwrap_or(false);
-    let mode = *state.mode.lock().unwrap();
+    let mode = *state.mode.lock().unwrap_or_else(|e| e.into_inner());
 
     if visible {
         match mode {
             WindowMode::Main => {
                 // Switch from main mode to spotlight mode
                 save_main_geometry(&win, &state);
-                *state.mode.lock().unwrap() = WindowMode::Spotlight;
+                *state.mode.lock().unwrap_or_else(|e| e.into_inner()) = WindowMode::Spotlight;
                 configure_as_spotlight(&win, &state);
                 emit_spotlight_opened(&app);
                 show_and_activate(&win);
@@ -309,7 +309,7 @@ pub fn toggle_spotlight(app: AppHandle, state: State<'_, SpotlightState>) {
         }
     } else {
         // Show as spotlight (was hidden) — set alpha=0 first to prevent flash
-        *state.mode.lock().unwrap() = WindowMode::Spotlight;
+        *state.mode.lock().unwrap_or_else(|e| e.into_inner()) = WindowMode::Spotlight;
         configure_as_spotlight(&win, &state);
         emit_spotlight_opened(&app);
         #[cfg(target_os = "macos")]
@@ -336,7 +336,7 @@ pub fn toggle_spotlight_from_tray(app: AppHandle, state: State<'_, SpotlightStat
     };
 
     let visible = win.is_visible().unwrap_or(false);
-    let mode = *state.mode.lock().unwrap();
+    let mode = *state.mode.lock().unwrap_or_else(|e| e.into_inner());
 
     if visible && mode == WindowMode::Spotlight {
         // Toggle off
@@ -350,7 +350,7 @@ pub fn toggle_spotlight_from_tray(app: AppHandle, state: State<'_, SpotlightStat
         }
 
         // Switch to spotlight mode — set alpha=0 first to prevent flash
-        *state.mode.lock().unwrap() = WindowMode::Spotlight;
+        *state.mode.lock().unwrap_or_else(|e| e.into_inner()) = WindowMode::Spotlight;
         configure_as_spotlight(&win, &state);
         emit_spotlight_opened(&app);
         #[cfg(target_os = "macos")]
@@ -370,9 +370,9 @@ pub fn toggle_spotlight_from_tray(app: AppHandle, state: State<'_, SpotlightStat
 /// Set spotlight window always-on-top state and persist it.
 #[tauri::command]
 pub fn set_spotlight_pin(app: AppHandle, state: State<'_, SpotlightState>, pinned: bool) {
-    *state.pinned.lock().unwrap() = pinned;
+    *state.pinned.lock().unwrap_or_else(|e| e.into_inner()) = pinned;
 
-    let mode = *state.mode.lock().unwrap();
+    let mode = *state.mode.lock().unwrap_or_else(|e| e.into_inner());
     if mode == WindowMode::Spotlight {
         if let Some(win) = app.get_webview_window("main") {
             let _ = win.set_always_on_top(pinned);
@@ -391,7 +391,7 @@ pub fn set_spotlight_pin(app: AppHandle, state: State<'_, SpotlightState>, pinne
 pub fn expand_to_main(app: AppHandle, state: State<'_, SpotlightState>) -> Result<(), String> {
     let win = app.get_webview_window("main").ok_or("Window not found")?;
 
-    let current_mode = *state.mode.lock().unwrap();
+    let current_mode = *state.mode.lock().map_err(|e| e.to_string())?;
     if current_mode != WindowMode::Spotlight {
         return Ok(());
     }
@@ -414,7 +414,7 @@ pub fn expand_to_main(app: AppHandle, state: State<'_, SpotlightState>) -> Resul
 
     // Determine target geometry
     let (target_x, target_y, target_w, target_h) = {
-        let geom = state.main_geometry.lock().unwrap();
+        let geom = state.main_geometry.lock().map_err(|e| e.to_string())?;
         if let Some((x, y, w, h)) = *geom {
             (x, y, w, h)
         } else {
@@ -434,7 +434,7 @@ pub fn expand_to_main(app: AppHandle, state: State<'_, SpotlightState>) -> Resul
     save_spotlight_position(&win, &state);
 
     // Update mode BEFORE animation
-    *state.mode.lock().unwrap() = WindowMode::Main;
+    *state.mode.lock().map_err(|e| e.to_string())? = WindowMode::Main;
 
     // Remove always-on-top and skip-taskbar during animation
     let _ = win.set_always_on_top(false);
@@ -486,14 +486,14 @@ pub fn show_main_window(app: AppHandle, state: State<'_, SpotlightState>) {
         None => return,
     };
 
-    let current_mode = *state.mode.lock().unwrap();
+    let current_mode = *state.mode.lock().unwrap_or_else(|e| e.into_inner());
 
     // If currently visible in spotlight mode, save position
     if win.is_visible().unwrap_or(false) && current_mode == WindowMode::Spotlight {
         save_spotlight_position(&win, &state);
     }
 
-    *state.mode.lock().unwrap() = WindowMode::Main;
+    *state.mode.lock().unwrap_or_else(|e| e.into_inner()) = WindowMode::Main;
     configure_as_main(&win, &state);
     let _ = app.emit("spotlight-mode-changed", false);
     show_and_activate(&win);
@@ -508,8 +508,8 @@ pub fn force_toggle_spotlight(app: AppHandle, state: State<'_, SpotlightState>) 
 /// Get spotlight window state for testing/debugging.
 #[tauri::command]
 pub fn get_spotlight_state(app: AppHandle, state: State<'_, SpotlightState>) -> serde_json::Value {
-    let pinned = *state.pinned.lock().unwrap();
-    let mode = *state.mode.lock().unwrap();
+    let pinned = *state.pinned.lock().unwrap_or_else(|e| e.into_inner());
+    let mode = *state.mode.lock().unwrap_or_else(|e| e.into_inner());
     let visible = app
         .get_webview_window("main")
         .map(|w| w.is_visible().unwrap_or(false))

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -132,9 +132,10 @@ fn is_https_url(url: &str) -> bool {
 /// Get the workspace path from OpenCodeState
 pub fn get_workspace_path(opencode_state: &OpenCodeState) -> Result<String, String> {
     opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set. Please select a workspace first.".to_string())
 }

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -200,13 +200,15 @@ pub async fn get_device_node_id(iroh_state: tauri::State<'_, IrohState>) -> Resu
 
 /// Collect all files recursively from a directory, returning (relative_path, content) pairs.
 const MAX_SYNC_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB
+const MAX_TOTAL_SYNC_SIZE: u64 = 500 * 1024 * 1024; // 500 MB total
 
 fn collect_files(base: &Path, dir: &Path) -> Vec<(String, Vec<u8>)> {
     let mut files = Vec::new();
+    let mut total_size: u64 = 0;
     if !dir.exists() {
         return files;
     }
-    for entry in walkdir::WalkDir::new(dir)
+    'outer: for entry in walkdir::WalkDir::new(dir)
         .into_iter()
         .filter_map(|e| e.ok())
     {
@@ -221,9 +223,17 @@ fn collect_files(base: &Path, dir: &Path) -> Vec<(String, Vec<u8>)> {
                     );
                     continue;
                 }
+                if total_size + meta.len() > MAX_TOTAL_SYNC_SIZE {
+                    eprintln!(
+                        "[P2P] Reached cumulative size limit ({} MB), stopping collection",
+                        MAX_TOTAL_SYNC_SIZE / (1024 * 1024)
+                    );
+                    break 'outer;
+                }
             }
             if let Ok(content) = std::fs::read(entry.path()) {
                 if let Ok(rel) = entry.path().strip_prefix(base) {
+                    total_size += content.len() as u64;
                     files.push((rel.to_string_lossy().to_string(), content));
                 }
             }

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -1950,9 +1950,10 @@ pub async fn p2p_leave_team(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -1997,9 +1998,10 @@ pub async fn p2p_disconnect_source(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2041,9 +2043,10 @@ pub async fn p2p_dissolve_team(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2217,9 +2220,10 @@ pub async fn team_add_member(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2289,9 +2293,10 @@ pub async fn team_remove_member(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2339,9 +2344,10 @@ pub async fn team_update_member_role(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2395,9 +2401,10 @@ pub async fn p2p_check_team_dir(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<serde_json::Value, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2427,9 +2434,10 @@ pub async fn p2p_create_team(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<String, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2458,9 +2466,10 @@ pub async fn p2p_publish_drive(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<String, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2507,9 +2516,10 @@ pub async fn p2p_join_drive(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<String, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2535,9 +2545,10 @@ pub async fn p2p_reconnect(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2647,9 +2658,10 @@ pub async fn p2p_rotate_ticket(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<String, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2665,9 +2677,10 @@ pub async fn get_p2p_config(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<Option<P2pConfig>, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
     read_p2p_config(&workspace_path)
@@ -2679,9 +2692,10 @@ pub async fn save_p2p_config(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
     write_p2p_config(&workspace_path, Some(&config))
@@ -2694,9 +2708,10 @@ pub async fn p2p_sync_status(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<P2pSyncStatus, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2746,9 +2761,10 @@ pub async fn p2p_get_files_sync_status(
     use futures_lite::StreamExt;
 
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 
@@ -2822,9 +2838,10 @@ pub async fn p2p_save_seed_config(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
 

--- a/src-tauri/src/commands/webview.rs
+++ b/src-tauri/src/commands/webview.rs
@@ -165,7 +165,7 @@ pub async fn webview_create(
     device_name: Option<String>,
 ) -> Result<(), String> {
     // If webview with this label already exists, just show and reposition it
-    let exists = state.labels.lock().unwrap().contains_key(&label);
+    let exists = state.labels.lock().map_err(|e| e.to_string())?.contains_key(&label);
     if exists {
         if let Some(webview) = app.get_webview(&label) {
             eprintln!(
@@ -179,7 +179,7 @@ pub async fn webview_create(
             return Ok(());
         } else {
             // Label tracked but webview gone — clean up
-            state.labels.lock().unwrap().remove(&label);
+            state.labels.lock().map_err(|e| e.to_string())?.remove(&label);
         }
     }
 
@@ -240,7 +240,7 @@ pub async fn webview_create(
     let _ = webview.set_focus();
 
     // Track the label
-    state.labels.lock().unwrap().insert(label.clone(), ());
+    state.labels.lock().map_err(|e| e.to_string())?.insert(label.clone(), ());
 
     eprintln!("[Webview] Created successfully: {}", label);
     Ok(())
@@ -251,7 +251,7 @@ fn webview_close_inner(
     state: &tauri::State<'_, WebviewManager>,
     label: &str,
 ) {
-    state.labels.lock().unwrap().remove(label);
+    state.labels.lock().unwrap_or_else(|e| e.into_inner()).remove(label);
     if let Some(webview) = app.get_webview(label) {
         let _ = webview.close();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -911,11 +911,13 @@ pub fn run() {
         .run(|app, event| {
             match event {
                 #[cfg(target_os = "macos")]
-                tauri::RunEvent::Reopen { has_visible_windows, .. } => {
-                    if !has_visible_windows {
-                        let state = app.state::<commands::spotlight::SpotlightState>();
-                        commands::spotlight::show_main_window(app.clone(), state);
-                    }
+                tauri::RunEvent::Reopen { .. } => {
+                    // Always show the main window when the dock icon is clicked.
+                    // Tauri's `has_visible_windows` can report `true` even when
+                    // the window was hidden via `win.hide()`, so we ignore it and
+                    // unconditionally bring the window back.
+                    let state = app.state::<commands::spotlight::SpotlightState>();
+                    commands::spotlight::show_main_window(app.clone(), state);
                 }
                 tauri::RunEvent::Exit => {
                     // Kill the OpenCode sidecar synchronously.
@@ -935,8 +937,11 @@ pub fn run() {
                             }
                         }
                     }
+                    // Fire-and-forget: enqueue the event but don't block on flush.
+                    // The aptabase plugin's own Exit handler will attempt to flush,
+                    // but we don't want to block exit for up to 10s on a network
+                    // request (the aptabase HTTP timeout) if the server is slow.
                     let _ = app.track_event("app_exited", None);
-                    app.flush_events_blocking();
                 }
                 _ => {}
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -924,8 +924,11 @@ pub fn run() {
                     // which causes block_on to deadlock or panic, preventing
                     // std::process::exit from ever being called.
                     let oc_state = app.state::<commands::opencode::OpenCodeState>();
-                    if let Ok(mut child_guard) = oc_state.child_process.lock() {
-                        if let Some(child) = child_guard.take() {
+                    if let Ok(mut inner) = oc_state.inner.lock() {
+                        if let Some(handle) = inner.reader_task.take() {
+                            handle.abort();
+                        }
+                        if let Some(child) = inner.child_process.take() {
                             if let Err(e) = child.kill() {
                                 sentry_utils::capture_err("[OpenCode] Failed to stop sidecar on exit", &e);
                                 eprintln!("[OpenCode] Failed to stop sidecar on app exit: {}", e);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -694,7 +694,7 @@ pub fn run() {
                                 | rdev::EventType::KeyRelease(rdev::Key::ControlLeft | rdev::Key::ControlRight)
                         );
 
-                        let mut s = state.lock().unwrap();
+                        let mut s = state.lock().unwrap_or_else(|e| e.into_inner());
 
                         match event.event_type {
                             rdev::EventType::KeyPress(rdev::Key::ControlLeft | rdev::Key::ControlRight) => {
@@ -746,7 +746,7 @@ pub fn run() {
                             // Save main geometry if in Main mode before hiding
                             let state = close_app_handle.state::<commands::spotlight::SpotlightState>();
                             {
-                                let mode = state.mode.lock().unwrap();
+                                let mode = state.mode.lock().unwrap_or_else(|e| e.into_inner());
                                 if *mode == commands::spotlight::WindowMode::Main {
                                     commands::spotlight::save_main_geometry(&main_win_clone, &state);
                                 }
@@ -789,7 +789,7 @@ pub fn run() {
                         #[cfg(target_os = "macos")]
                         tauri::WindowEvent::Resized { .. } => {
                             let state = close_app_handle.state::<commands::spotlight::SpotlightState>();
-                            let mode = *state.mode.lock().unwrap();
+                            let mode = *state.mode.lock().unwrap_or_else(|e| e.into_inner());
                             if mode == commands::spotlight::WindowMode::Main {
                                 commands::spotlight::reposition_traffic_lights(&main_win_clone);
                             }

--- a/src-tauri/src/rag/db.rs
+++ b/src-tauri/src/rag/db.rs
@@ -277,31 +277,43 @@ impl Database {
             Option<i64>,
         )],
     ) -> Result<()> {
-        let conn = self.conn.lock().await;
+        for batch in chunks.chunks(100) {
+            let conn = self.conn.lock().await;
+            conn.execute("BEGIN", ()).await.context("Failed to begin transaction")?;
 
-        for (content, chunk_index, heading, embedding, chunk_type, name, start_line, end_line) in
-            chunks
-        {
-            // Convert Vec<f32> to binary blob for F32_BLOB
-            let embedding_bytes: Vec<u8> = embedding.iter().flat_map(|f| f.to_le_bytes()).collect();
+            for (content, chunk_index, heading, embedding, chunk_type, name, start_line, end_line) in
+                batch
+            {
+                // Convert Vec<f32> to binary blob for F32_BLOB
+                let embedding_bytes: Vec<u8> = embedding.iter().flat_map(|f| f.to_le_bytes()).collect();
 
-            conn.execute(
-                "INSERT INTO chunks (doc_id, content, chunk_index, heading, embedding, chunk_type, name, start_line, end_line)
-                 VALUES (?1, ?2, ?3, ?4, vector32(?5), ?6, ?7, ?8, ?9)",
-                params![
-                    doc_id,
-                    content.as_str(),
-                    *chunk_index,
-                    heading.as_deref(),
-                    libsql::Value::Blob(embedding_bytes),
-                    chunk_type.as_deref(),
-                    name.as_deref(),
-                    *start_line,
-                    *end_line,
-                ],
-            )
-            .await
-            .context("Failed to insert chunk")?;
+                match conn.execute(
+                    "INSERT INTO chunks (doc_id, content, chunk_index, heading, embedding, chunk_type, name, start_line, end_line)
+                     VALUES (?1, ?2, ?3, ?4, vector32(?5), ?6, ?7, ?8, ?9)",
+                    params![
+                        doc_id,
+                        content.as_str(),
+                        *chunk_index,
+                        heading.as_deref(),
+                        libsql::Value::Blob(embedding_bytes),
+                        chunk_type.as_deref(),
+                        name.as_deref(),
+                        *start_line,
+                        *end_line,
+                    ],
+                )
+                .await
+                {
+                    Ok(_) => {}
+                    Err(e) => {
+                        conn.execute("ROLLBACK", ()).await.ok();
+                        return Err(e).context("Failed to insert chunk");
+                    }
+                }
+            }
+
+            conn.execute("COMMIT", ()).await.context("Failed to commit transaction")?;
+            // Lock dropped here — other operations can proceed between batches
         }
 
         Ok(())

--- a/src-tauri/src/rag/embedding.rs
+++ b/src-tauri/src/rag/embedding.rs
@@ -28,7 +28,10 @@ pub fn create_provider(config: &RagConfig) -> Result<SharedEmbeddingProvider> {
             base_url: config.embedding_base_url.clone(),
             model: config.embedding_model.clone(),
             dimensions: config.embedding_dimensions,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
         })),
         other => {
             bail!(

--- a/src-tauri/src/rag/reranker.rs
+++ b/src-tauri/src/rag/reranker.rs
@@ -45,7 +45,10 @@ struct JinaRerankResult {
 impl JinaReranker {
     pub fn new(api_key: Option<String>, model: String) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
             api_key,
             model,
             base_url: "https://api.jina.ai/v1".to_string(),
@@ -155,7 +158,10 @@ struct CompassRerankResponse {
 impl CompassReranker {
     pub fn new(api_key: Option<String>, base_url: String) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
             api_key,
             base_url,
         }
@@ -279,7 +285,10 @@ struct LangSearchRerankResult {
 impl LangSearchReranker {
     pub fn new(api_key: Option<String>, model: String, base_url: Option<String>) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
             api_key,
             model: if model.is_empty() {
                 "langsearch-reranker-v1".to_string()

--- a/src-tauri/src/stt/audio.rs
+++ b/src-tauri/src/stt/audio.rs
@@ -37,7 +37,7 @@ pub fn record_until_stopped(stop: Arc<AtomicBool>) -> Result<RecordedAudio, Stri
             device.build_input_stream(
                 &config_clone.into(),
                 move |data: &[f32], _: &cpal::InputCallbackInfo| {
-                    buffer_in.lock().unwrap().extend_from_slice(data);
+                    buffer_in.lock().unwrap_or_else(|e| e.into_inner()).extend_from_slice(data);
                 },
                 |err| {
                     eprintln!("[STT audio] stream error: {}", err);
@@ -52,7 +52,7 @@ pub fn record_until_stopped(stop: Arc<AtomicBool>) -> Result<RecordedAudio, Stri
                 move |data: &[i16], _: &cpal::InputCallbackInfo| {
                     let f32_samples: Vec<f32> =
                         data.iter().map(|&s| s as f32 / i16::MAX as f32).collect();
-                    buffer_in.lock().unwrap().extend(f32_samples);
+                    buffer_in.lock().unwrap_or_else(|e| e.into_inner()).extend(f32_samples);
                 },
                 |err| {
                     eprintln!("[STT audio] stream error: {}", err);
@@ -69,7 +69,7 @@ pub fn record_until_stopped(stop: Arc<AtomicBool>) -> Result<RecordedAudio, Stri
                         .iter()
                         .map(|&s| (s as f32 / u16::MAX as f32) * 2.0 - 1.0)
                         .collect();
-                    buffer_in.lock().unwrap().extend(f32_samples);
+                    buffer_in.lock().unwrap_or_else(|e| e.into_inner()).extend(f32_samples);
                 },
                 |err| {
                     eprintln!("[STT audio] stream error: {}", err);
@@ -89,7 +89,7 @@ pub fn record_until_stopped(stop: Arc<AtomicBool>) -> Result<RecordedAudio, Stri
 
     drop(stream);
 
-    let samples = buffer.lock().unwrap().clone();
+    let samples = buffer.lock().unwrap_or_else(|e| e.into_inner()).clone();
     let sample_rate = config.sample_rate();
     Ok(RecordedAudio {
         samples,
@@ -152,7 +152,7 @@ pub fn stream_chunks_until_stopped(
                 device.build_input_stream(
                     &config_clone.into(),
                     move |data: &[f32], _: &cpal::InputCallbackInfo| {
-                        buffer_in.lock().unwrap().extend_from_slice(data);
+                        buffer_in.lock().unwrap_or_else(|e| e.into_inner()).extend_from_slice(data);
                     },
                     |err| {
                         eprintln!("[STT audio] stream error: {}", err);
@@ -167,7 +167,7 @@ pub fn stream_chunks_until_stopped(
                     move |data: &[i16], _: &cpal::InputCallbackInfo| {
                         let f32_samples: Vec<f32> =
                             data.iter().map(|&s| s as f32 / i16::MAX as f32).collect();
-                        buffer_in.lock().unwrap().extend(f32_samples);
+                        buffer_in.lock().unwrap_or_else(|e| e.into_inner()).extend(f32_samples);
                     },
                     |err| {
                         eprintln!("[STT audio] stream error: {}", err);
@@ -184,7 +184,7 @@ pub fn stream_chunks_until_stopped(
                             .iter()
                             .map(|&s| (s as f32 / u16::MAX as f32) * 2.0 - 1.0)
                             .collect();
-                        buffer_in.lock().unwrap().extend(f32_samples);
+                        buffer_in.lock().unwrap_or_else(|e| e.into_inner()).extend(f32_samples);
                     },
                     |err| {
                         eprintln!("[STT audio] stream error: {}", err);
@@ -210,7 +210,7 @@ pub fn stream_chunks_until_stopped(
         }
         while !stop.load(Ordering::SeqCst) {
             let chunk = {
-                let mut buf = buffer.lock().unwrap();
+                let mut buf = buffer.lock().unwrap_or_else(|e| e.into_inner());
                 if buf.len() >= samples_per_step {
                     let take: Vec<f32> = buf.drain(..samples_per_step).collect();
                     take

--- a/src-tauri/src/telemetry/commands.rs
+++ b/src-tauri/src/telemetry/commands.rs
@@ -325,9 +325,10 @@ pub async fn telemetry_export_team_feedback(
         drop(guard);
 
         let workspace_path = opencode_state
-            .workspace_path
+            .inner
             .lock()
             .map_err(|e| e.to_string())?
+            .workspace_path
             .clone()
             .ok_or("Workspace path not set")?;
         let team_dir = std::path::Path::new(&workspace_path).join(crate::commands::TEAM_REPO_DIR);
@@ -373,9 +374,10 @@ pub async fn telemetry_get_team_feedback_summary(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<TeamFeedbackSummary, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("Workspace path not set")?;
     let feedback_dir = std::path::Path::new(&workspace_path)
@@ -503,9 +505,10 @@ pub async fn telemetry_export_leaderboard(
         drop(guard);
 
         let workspace_path = opencode_state
-            .workspace_path
+            .inner
             .lock()
             .map_err(|e| e.to_string())?
+            .workspace_path
             .clone()
             .ok_or("Workspace path not set")?;
         let team_dir = std::path::Path::new(&workspace_path).join(crate::commands::TEAM_REPO_DIR);
@@ -626,9 +629,10 @@ pub async fn telemetry_get_team_leaderboard(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<TeamLeaderboard, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("Workspace path not set")?;
     let leaderboard_dir = std::path::Path::new(&workspace_path)
@@ -663,9 +667,10 @@ pub async fn telemetry_get_member_aggregated_stats(
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<LeaderboardStats, String> {
     let workspace_path = opencode_state
-        .workspace_path
+        .inner
         .lock()
         .map_err(|e| e.to_string())?
+        .workspace_path
         .clone()
         .ok_or("Workspace path not set")?;
     let leaderboard_dir = std::path::Path::new(&workspace_path)

--- a/tests/regression/macos-dock-tray.test.ts
+++ b/tests/regression/macos-dock-tray.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression: macOS close-to-tray and dock reopen (REG-16)
+ * Uses test control server to close window and verify dock reopen.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  launchTeamClawApp,
+  stopApp,
+  sleep,
+  focusWindow,
+  getWindowInfo,
+  takeScreenshot,
+} from '../_utils/tauri-mcp-test-utils';
+
+const CONTROL_SERVER = 'http://127.0.0.1:13199';
+
+async function tauriCommand(command: string): Promise<Record<string, unknown>> {
+  const res = await fetch(`${CONTROL_SERVER}/test/command`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ command }),
+  });
+  return res.json() as Promise<Record<string, unknown>>;
+}
+
+describe('Regression: macOS close-to-tray and dock reopen', () => {
+  let appReady = false;
+
+  beforeAll(async () => {
+    try {
+      await launchTeamClawApp();
+      await sleep(8000);
+      await focusWindow();
+      await sleep(500);
+
+      // Wait for test control server
+      for (let i = 0; i < 10; i++) {
+        try {
+          const res = await fetch(`${CONTROL_SERVER}/test/command`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ command: 'get_spotlight_state' }),
+          });
+          if (res.ok) {
+            appReady = true;
+            break;
+          }
+        } catch {
+          // not ready yet
+        }
+        await sleep(2000);
+      }
+
+      if (!appReady) {
+        console.error('App launched but test control server not reachable');
+      } else {
+        // Ensure window is in a clean main-mode visible state
+        await tauriCommand('show_main_window');
+        await sleep(1000);
+      }
+    } catch (err: unknown) {
+      console.error('Failed to launch app:', (err as Error).message);
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    await stopApp();
+  }, 30_000);
+
+  it('REG-16: close window hides to tray, dock click reopens', async () => {
+    if (!appReady) return;
+
+    // 1. Ensure main window is visible
+    await tauriCommand('show_main_window');
+    await sleep(1000);
+
+    const before = await tauriCommand('get_spotlight_state');
+    expect(before['visible']).toBe(true);
+    expect(before['mode']).toBe('main');
+    await takeScreenshot('/tmp/reg-dock-before-close.png');
+
+    // 2. Close window via test control server (triggers CloseRequested → hide)
+    await tauriCommand('close_window');
+    await sleep(2000);
+
+    // 3. Verify window is hidden via Tauri state (more reliable than AppleScript)
+    const afterClose = await tauriCommand('get_spotlight_state');
+    expect(afterClose['visible']).toBe(false);
+
+    // 4. Simulate dock click by showing main window (same as reopen_from_dock)
+    await tauriCommand('show_main_window');
+    await sleep(2000);
+
+    // 5. Verify window is visible again
+    const afterReopen = await tauriCommand('get_spotlight_state');
+    expect(afterReopen['visible']).toBe(true);
+    expect(afterReopen['mode']).toBe('main');
+
+    const win = await getWindowInfo();
+    expect(win.isVisible).toBe(true);
+    const path = await takeScreenshot('/tmp/reg-dock-reopen.png');
+    expect(path).toBeTruthy();
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary
- **perf(filetree):** debounce search filter with `useDeferredValue`
- **fix(macos):** dock icon click not showing window + slow app exit
- **perf(p2p):** add 500MB cumulative size limit to `collect_files`
- **perf(rag):** batch chunk insertion to reduce lock contention
- **perf:** add timeouts to all reqwest HTTP clients
- **fix(editor):** prevent markdown roundtrip from overwriting original files
- **test(macos):** add regression test for dock icon reopen (REG-16)

## Test plan
- [ ] Verify filetree search is responsive with large file trees
- [ ] macOS: close window → click dock icon → window reopens
- [ ] P2P sync with large repos stays within 500MB limit
- [ ] RAG indexing performance improved under concurrent access
- [ ] HTTP client requests don't hang indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)