### PR TITLE
fix: add http://* to remote URLs for Tauri webview

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,7 +5,7 @@
   "windows": ["main", "spotlight"],
   "webviews": ["main", "wv-*"],
   "remote": {
-    "urls": ["https://*"]
+    "urls": ["https://*", "http://*"]
   },
   "permissions": [
     "core:default",


### PR DESCRIPTION
## Summary

修复 webview 加载 HTTP 网站时出现的权限错误。

### 问题
当 webview 加载 `http://admin.climban.com/` 时，报错：
```
notification.is_permission_granted not allowed on window "main", webview "wv-http___admin_climban_com_users"
```

### 原因
`capabilities/default.json` 中只配置了 `https://*`，导致加载 HTTP 网站时 Tauri 权限系统拒绝 API 调用。

### 修复
在 `remote.urls` 中添加 `http://*` 支持。