### PR TITLE
feat(chat): browser-first routing hint + session switch crossfade

### DIFF
--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -170,6 +170,41 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
   const activeSession = useSessionStore(s =>
     s.activeSessionId ? s.sessions.find((ss) => ss.id === s.activeSessionId) : undefined
   );
+  /** Shown messages lag store during fade so old session can fade out before swap */
+  const [displaySessionId, setDisplaySessionId] = React.useState<string | null>(activeSessionId);
+  const [sessionFadeOpacity, setSessionFadeOpacity] = React.useState(1);
+
+  const displaySession = useSessionStore((s) =>
+    displaySessionId ? s.sessions.find((ss) => ss.id === displaySessionId) : undefined,
+  );
+
+  const SESSION_FADE_MS = 150;
+
+  React.useEffect(() => {
+    if (activeSessionId === null) {
+      setDisplaySessionId(null);
+      setSessionFadeOpacity(1);
+    }
+  }, [activeSessionId]);
+
+  React.useEffect(() => {
+    if (activeSessionId === null) return;
+    if (displaySessionId === activeSessionId) return;
+    if (displaySessionId === null) {
+      setDisplaySessionId(activeSessionId);
+      setSessionFadeOpacity(1);
+      return;
+    }
+    setSessionFadeOpacity(0);
+    const t = window.setTimeout(() => {
+      setDisplaySessionId(activeSessionId);
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => setSessionFadeOpacity(1));
+      });
+    }, SESSION_FADE_MS);
+    return () => clearTimeout(t);
+  }, [activeSessionId, displaySessionId]);
+
   const isStreaming = !!streamingMessageId;
 
   // ── Provider & Team mode init ──────────────────────────────────────
@@ -656,16 +691,24 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
         </div>
       )}
 
-      {/* ─── Message List ─────────────────────────────────────────────── */}
-      <MessageList
-        ref={messageListRef}
-        messages={activeSession?.messages ?? []}
-        activeSessionId={activeSessionId}
-        isStreaming={isStreaming}
-        streamingMessageId={streamingMessageId}
-        compact={compact}
-        emptyState={emptyState}
-      />
+      {/* ─── Message List (fade on session switch; input stays stable) ─── */}
+      <div
+        className={cn(
+          "flex-1 min-h-0 flex flex-col overflow-hidden",
+          "transition-opacity duration-150 ease-in-out motion-reduce:transition-none",
+        )}
+        style={{ opacity: sessionFadeOpacity }}
+      >
+        <MessageList
+          ref={messageListRef}
+          messages={displaySession?.messages ?? []}
+          activeSessionId={displaySessionId}
+          isStreaming={isStreaming}
+          streamingMessageId={streamingMessageId}
+          compact={compact}
+          emptyState={emptyState}
+        />
+      </div>
 
       {/* ─── Input Area (with Permission & Error UI above it) ─────────── */}
       <ChatInputArea

--- a/packages/app/src/components/chat/MessageList.tsx
+++ b/packages/app/src/components/chat/MessageList.tsx
@@ -17,7 +17,6 @@ import { SAFE_BOTTOM_SPACING, NEAR_BOTTOM_THRESHOLD } from "./layout-constants";
 // The current virtualized path occasionally keeps stale row heights and causes
 // overlap, so we keep the stable non-virtualized path for normal conversations.
 const VIRTUAL_MSG_THRESHOLD = Number.MAX_SAFE_INTEGER;
-const SESSION_SWITCH_MIN_HOLD_MS = 90;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -72,10 +71,10 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
 
     // PERF: Return primitive string instead of session object.
     // Object references from .find() change on every sessions update → unnecessary re-renders.
-    // We only need activeSession.directory for basePath, so return that directly.
+    // Use `activeSessionId` prop (may lag store during ChatPanel fade) so paths match shown messages.
     const activeSessionDirectory = useSessionStore((s) =>
-      s.activeSessionId
-        ? s.sessions.find((ss) => ss.id === s.activeSessionId)?.directory
+      activeSessionId
+        ? s.sessions.find((ss) => ss.id === activeSessionId)?.directory
         : undefined,
     );
 
@@ -152,7 +151,6 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
 
     // ── Local state ──────────────────────────────────────────────────────
     const [showScrollButton, setShowScrollButton] = React.useState(false);
-    const [sessionSwitching, setSessionSwitching] = React.useState(false);
     const [inputAreaHeight, setInputAreaHeight] = React.useState(160);
     const [messageAreaWidth, setMessageAreaWidth] = React.useState(0);
 
@@ -365,40 +363,34 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
       }
     }, [childStreamingScrollTrigger]);
 
-    // Reset scroll state when switching sessions
+    // Reset scroll state when switching sessions (prop tracks displayed session, may lag store during fade)
     const prevSessionIdRef = React.useRef(activeSessionId);
     const needsScrollAfterLoadRef = React.useRef(false);
-    const sessionSwitchStartedAtRef = React.useRef<number>(0);
-    const sessionSwitchRevealTimeoutRef = React.useRef<number | null>(null);
     React.useEffect(() => {
       if (activeSessionId !== prevSessionIdRef.current) {
         prevSessionIdRef.current = activeSessionId;
         userScrolledUpRef.current = false;
         setShowScrollButton(false);
-        if (sessionSwitchRevealTimeoutRef.current !== null) {
-          window.clearTimeout(sessionSwitchRevealTimeoutRef.current);
-          sessionSwitchRevealTimeoutRef.current = null;
-        }
-        sessionSwitchStartedAtRef.current = Date.now();
-        setSessionSwitching(true);
         needsScrollAfterLoadRef.current = true;
       }
     }, [activeSessionId]);
 
-    // Load feedback state when session changes
+    const storeActiveSessionId = useSessionStore((s) => s.activeSessionId);
+
+    // Load feedback for the store-active session (not the lagging display id during fade)
     React.useEffect(() => {
-      if (activeSessionId) {
+      if (storeActiveSessionId) {
         import("@/stores/telemetry")
           .then(({ useTelemetryStore }) => {
-            useTelemetryStore.getState().loadFeedbacks(activeSessionId);
+            useTelemetryStore.getState().loadFeedbacks(storeActiveSessionId);
           })
           .catch(() => {
             /* telemetry not available */
           });
       }
-    }, [activeSessionId]);
+    }, [storeActiveSessionId]);
 
-    // Scroll to bottom after session messages are loaded, then reveal
+    // Scroll to bottom after session messages are loaded
     const prevLoadingRef = React.useRef(isLoading);
     React.useEffect(() => {
       const wasLoading = prevLoadingRef.current;
@@ -412,40 +404,16 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
         needsScrollAfterLoadRef.current = false;
         requestAnimationFrame(() => {
           requestAnimationFrame(() => {
-            const reveal = () => {
-              if (scrollRef.current) {
-                scrollRef.current.scrollTo({
-                  top: scrollRef.current.scrollHeight,
-                  behavior: "instant",
-                });
-              }
-              setSessionSwitching(false);
-            };
-
-            const elapsed = Date.now() - sessionSwitchStartedAtRef.current;
-            const remaining = Math.max(0, SESSION_SWITCH_MIN_HOLD_MS - elapsed);
-
-            if (remaining > 0) {
-              sessionSwitchRevealTimeoutRef.current = window.setTimeout(() => {
-                sessionSwitchRevealTimeoutRef.current = null;
-                reveal();
-              }, remaining);
-              return;
+            if (scrollRef.current) {
+              scrollRef.current.scrollTo({
+                top: scrollRef.current.scrollHeight,
+                behavior: "instant",
+              });
             }
-
-            reveal();
           });
         });
       }
     }, [isLoading, messages.length]);
-
-    React.useEffect(() => {
-      return () => {
-        if (sessionSwitchRevealTimeoutRef.current !== null) {
-          window.clearTimeout(sessionSwitchRevealTimeoutRef.current);
-        }
-      };
-    }, []);
 
     // Initial mount scroll
     const hasInitialScrolled = React.useRef(false);
@@ -522,12 +490,7 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
         <div
           ref={scrollRef}
           data-chat-messages
-          className={cn(
-            "flex-1 overflow-y-auto overflow-x-hidden transition-all duration-200 ease-out motion-reduce:transition-none",
-            sessionSwitching
-              ? "translate-y-1 opacity-0"
-              : "translate-y-0 opacity-100",
-          )}
+          className="flex-1 overflow-y-auto overflow-x-hidden"
         >
           <div
             ref={messageAreaRef}

--- a/packages/app/src/stores/__tests__/session-messages-behavior.test.ts
+++ b/packages/app/src/stores/__tests__/session-messages-behavior.test.ts
@@ -169,6 +169,17 @@ describe('session store: message behavior', () => {
       );
     });
 
+    it('adds browser-routing system prompt for login-related web tasks', async () => {
+      await useSessionStore.getState().sendMessage('帮我登录这个网站然后抓取里面的数据');
+
+      expect(mockSendMessageAsync).toHaveBeenCalledTimes(1);
+      const callArgs = mockSendMessageAsync.mock.calls[0];
+      expect(callArgs[0]).toBe('sess-1');
+      expect(callArgs[1]).toBe('帮我登录这个网站然后抓取里面的数据');
+      expect(callArgs[4]).toContain('do not start with webfetch');
+      expect(callArgs[4]).toContain('chrome-control MCP');
+    });
+
     it('queues message when already streaming', async () => {
       // First send a message to start streaming
       await useSessionStore.getState().sendMessage('first message');

--- a/packages/app/src/stores/session-messages.ts
+++ b/packages/app/src/stores/session-messages.ts
@@ -28,6 +28,28 @@ import { appShortName } from "@/lib/build-config";
 type SessionSet = (fn: ((state: SessionState) => Partial<SessionState>) | Partial<SessionState>) => void;
 type SessionGet = () => SessionState;
 
+const LOGIN_RELATED_PROMPT = [
+  "Tool routing rule for web tasks:",
+  "If the user request may require website login, existing browser session, cookies, OAuth, SSO, MFA, CAPTCHA, or interactive page operations, do not start with webfetch.",
+  "First use the chrome-control MCP when available, or Playwright MCP as fallback, to open the site in a real browser, verify whether login is required, and continue only after the authenticated state is available.",
+  "Use webfetch only for public pages that do not require authentication or interactive browser state.",
+].join(" ");
+
+const LOGIN_RELATED_PATTERNS = [
+  /\b(login|log in|sign in|signin|authenticate|authentication|reauth|oauth|sso|mfa|2fa|captcha|cookie|cookies|session)\b/i,
+  /(登录|登陆|认证|鉴权|授权|会话|cookie|验证码|二次验证|双因子|单点登录)/i,
+];
+
+function shouldPreferInteractiveBrowserForMessage(message: string): boolean {
+  const normalized = message.trim();
+  if (!normalized) return false;
+  return LOGIN_RELATED_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function appendSystemPrompt(basePrompt: string | undefined, extraPrompt: string): string {
+  return basePrompt ? `${basePrompt}\n\n---\n\n${extraPrompt}` : extraPrompt;
+}
+
 export function createMessageActions(set: SessionSet, get: SessionGet) {
   return {
     // RAG V2: Auto-inject knowledge from pre-inference search
@@ -273,6 +295,10 @@ export function createMessageActions(set: SessionSet, get: SessionGet) {
           systemPrompt = systemPrompt
             ? `${ragResult.context}\n\n---\n\n${systemPrompt}`
             : ragResult.context;
+        }
+
+        if (shouldPreferInteractiveBrowserForMessage(content)) {
+          systemPrompt = appendSystemPrompt(systemPrompt, LOGIN_RELATED_PROMPT);
         }
 
         if (ragResult.chunks && ragResult.chunks.length > 0) {


### PR DESCRIPTION
## Summary

- **Login / interactive web tasks**: When user messages match login-related patterns (EN/ZH), append a system prompt that steers tools toward real-browser MCP (chrome-control / Playwright) before webfetch, with unit test coverage.
- **Session switching**: Crossfade the message list on session change by deferring the displayed session id until fade-out completes; remove the previous translate-y + hold reveal. Attachment paths follow the displayed session; telemetry feedback loads for the store-active session during fade.

## Test plan

- [ ] `pnpm --filter @teamclaw/app run test:unit`
- [ ] Manual: switch sessions in sidebar; message area fades without jarring slide
- [ ] Send a login-related prompt (e.g. Chinese phrasing); verify routing hint is applied

Made with [Cursor](https://cursor.com)