### PR TITLE
fix(filetree): prevent other folders from collapsing when clicking a file

### DIFF
--- a/packages/app/src/components/workspace/FileTree.tsx
+++ b/packages/app/src/components/workspace/FileTree.tsx
@@ -994,8 +994,13 @@ export function FileTree({
         }
         const tab = state.tabs.find(t => t.id === state.activeTabId);
         if (tab?.type === 'file' && tab.target) {
+          // Only reveal if the file was opened from outside the tree (e.g. tab click, chat link).
+          // If selectedFile already matches, the user clicked in the tree — no need to reveal.
+          const alreadySelected = useWorkspaceStore.getState().selectedFile === tab.target;
           useWorkspaceStore.setState({ selectedFile: tab.target, selectedFiles: [tab.target] });
-          revealFile(tab.target).catch(() => {});
+          if (!alreadySelected) {
+            revealFile(tab.target).catch(() => {});
+          }
         }
       });
     });

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -528,10 +528,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
   // Expand a directory node
   expandDirectory: async (path: string) => {
-    const { loadDirectory, expandedPaths } = get();
-
-    // If already expanded (e.g. re-expand after creating a file), just reload children
-    const alreadyExpanded = expandedPaths.has(path);
+    const { loadDirectory } = get();
 
     // Mark as loading via loadingPaths Set (O(1), no tree copy)
     const nextLoading = new Set(get().loadingPaths);
@@ -544,10 +541,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     // Update only the target node's children in the tree (minimal copy)
     const updatedTree = updateNodeChildren(get().fileTree, path, children);
 
-    // Update expanded/loading sets
-    const nextExpanded = alreadyExpanded
-      ? expandedPaths
-      : new Set(get().expandedPaths);
+    // Always clone CURRENT expandedPaths to avoid race conditions —
+    // the Set reference may have been replaced by refreshFileTree during the await
+    const nextExpanded = new Set(get().expandedPaths);
     nextExpanded.add(path);
     const doneLoading = new Set(get().loadingPaths);
     doneLoading.delete(path);


### PR DESCRIPTION
## Summary
- Fix race condition in `expandDirectory` where a stale `expandedPaths` reference captured before `await loadDirectory()` could overwrite the current state when `refreshFileTree` (file watcher) ran concurrently
- Skip unnecessary `revealFile` call when user clicks a file directly in the tree (file is already visible), preventing the race from being triggered

## Test plan
- [x] Unit tests pass (83/83)
- [ ] Open workspace, expand folder A and folder B, click a file in B → A should stay expanded
- [ ] Switch tabs → file tree still auto-reveals correctly for tab switches
- [ ] Open file from chat link → tree correctly reveals and scrolls to the file

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)