### PR TITLE
fix(chat): remove undefined setSessionSwitching causing crash

### DIFF
--- a/packages/app/src/components/chat/MessageList.tsx
+++ b/packages/app/src/components/chat/MessageList.tsx
@@ -412,9 +412,6 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
             }
           });
         });
-      } else if (!isLoading && messages.length === 0) {
-        // Also clear sessionSwitching when showing empty state (no messages)
-        setSessionSwitching(false);
       }
     }, [isLoading, messages.length]);
 


### PR DESCRIPTION
## Summary
- Removes a reference to `setSessionSwitching` in `MessageList.tsx` that was never defined or passed as a prop
- This caused a runtime crash: "Can't find variable: setSessionSwitching" when switching to an empty chat session

## Test plan
- [x] TypeScript type check passing
- [ ] Manual: switch between chat sessions, including empty ones — verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)