### PR TITLE
fix(p2p): use manifest as authoritative member list for all operations

### DIFF
--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -2156,44 +2156,39 @@ pub fn add_member_to_team(
         .as_deref()
         .ok_or("No team owner configured")?;
 
+    // Use the synced manifest as the authoritative member list when available,
+    // since joiners don't have allowed_members in their local config.
+    let manifest = read_members_manifest(team_dir).ok().flatten();
+    let mut members = if let Some(ref m) = manifest {
+        m.members.clone()
+    } else {
+        config.allowed_members.clone()
+    };
+
     // Any existing member (owner or editor) can add new members.
-    // Check both local config AND the synced manifest (joiners may not have
-    // allowed_members populated in their local config).
     let is_owner = owner_id == caller_node_id;
-    let is_member_in_config = config
-        .allowed_members
+    let is_member = members
         .iter()
         .any(|m| m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor));
-    let is_member_in_manifest = read_members_manifest(team_dir)
-        .ok()
-        .flatten()
-        .map(|manifest| {
-            manifest.members.iter().any(|m| {
-                m.node_id == caller_node_id
-                    && matches!(m.role, MemberRole::Owner | MemberRole::Editor)
-            })
-        })
-        .unwrap_or(false);
-    if !is_owner && !is_member_in_config && !is_member_in_manifest {
+    if !is_owner && !is_member {
         return Err("Only team members can add new members".to_string());
     }
 
-    if config
-        .allowed_members
-        .iter()
-        .any(|m| m.node_id == member.node_id)
-    {
+    if members.iter().any(|m| m.node_id == member.node_id) {
         return Err("Member already exists".to_string());
     }
 
     eprintln!(
         "[Team] Adding member node_id={} to team (total will be {}) by={}",
         &member.node_id,
-        config.allowed_members.len() + 1,
+        members.len() + 1,
         &caller_node_id[..10.min(caller_node_id.len())]
     );
 
-    config.allowed_members.push(member);
+    members.push(member);
+
+    // Update local config
+    config.allowed_members = members.clone();
     write_p2p_config(workspace_path, Some(&config))?;
     eprintln!(
         "[Team] P2P config written with {} members",
@@ -2201,7 +2196,7 @@ pub fn add_member_to_team(
     );
 
     // Always use owner_node_id for manifest (it's the canonical owner field)
-    write_members_manifest(team_dir, owner_id, &config.allowed_members)?;
+    write_members_manifest(team_dir, owner_id, &members)?;
     eprintln!(
         "[Team] members.json written to {}/{}/_team/members.json",
         workspace_path,
@@ -2234,21 +2229,18 @@ pub fn remove_member_from_team(
         .owner_node_id
         .as_deref()
         .ok_or("No team owner configured")?;
+    // Use manifest as authoritative member list when available
+    let manifest = read_members_manifest(team_dir).ok().flatten();
+    let mut members = if let Some(ref m) = manifest {
+        m.members.clone()
+    } else {
+        config.allowed_members.clone()
+    };
+
     let is_owner = owner_id == caller_node_id;
-    let is_editor = config
-        .allowed_members
+    let is_editor = members
         .iter()
-        .any(|m| m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor))
-        || read_members_manifest(team_dir)
-            .ok()
-            .flatten()
-            .map(|manifest| {
-                manifest.members.iter().any(|m| {
-                    m.node_id == caller_node_id
-                        && matches!(m.role, MemberRole::Owner | MemberRole::Editor)
-                })
-            })
-            .unwrap_or(false);
+        .any(|m| m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor));
     if !is_owner && !is_editor {
         return Err("Only team members (owner or editor) can manage members".to_string());
     }
@@ -2257,16 +2249,15 @@ pub fn remove_member_from_team(
         return Err("Cannot remove the team owner".to_string());
     }
 
-    let before_len = config.allowed_members.len();
-    config
-        .allowed_members
-        .retain(|m| m.node_id != target_node_id);
-    if config.allowed_members.len() == before_len {
+    let before_len = members.len();
+    members.retain(|m| m.node_id != target_node_id);
+    if members.len() == before_len {
         return Err("Member not found".to_string());
     }
 
+    config.allowed_members = members.clone();
     write_p2p_config(workspace_path, Some(&config))?;
-    write_members_manifest(team_dir, caller_node_id, &config.allowed_members)?;
+    write_members_manifest(team_dir, owner_id, &members)?;
 
     Ok(())
 }
@@ -2285,21 +2276,18 @@ pub fn update_member_role(
         .owner_node_id
         .as_deref()
         .ok_or("No team owner configured")?;
+    // Use manifest as authoritative member list when available
+    let manifest = read_members_manifest(team_dir).ok().flatten();
+    let mut members = if let Some(ref m) = manifest {
+        m.members.clone()
+    } else {
+        config.allowed_members.clone()
+    };
+
     let is_owner = owner_id == caller_node_id;
-    let is_editor = config
-        .allowed_members
+    let is_editor = members
         .iter()
-        .any(|m| m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor))
-        || read_members_manifest(team_dir)
-            .ok()
-            .flatten()
-            .map(|manifest| {
-                manifest.members.iter().any(|m| {
-                    m.node_id == caller_node_id
-                        && matches!(m.role, MemberRole::Owner | MemberRole::Editor)
-                })
-            })
-            .unwrap_or(false);
+        .any(|m| m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor));
     if !is_owner && !is_editor {
         return Err("Only team members (owner or editor) can manage members".to_string());
     }
@@ -2308,15 +2296,15 @@ pub fn update_member_role(
         return Err("Cannot change the owner's role".to_string());
     }
 
-    let member = config
-        .allowed_members
+    let member = members
         .iter_mut()
         .find(|m| m.node_id == target_node_id)
         .ok_or("Member not found")?;
     member.role = new_role;
 
+    config.allowed_members = members.clone();
     write_p2p_config(workspace_path, Some(&config))?;
-    write_members_manifest(team_dir, caller_node_id, &config.allowed_members)?;
+    write_members_manifest(team_dir, owner_id, &members)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- All member management functions (add/remove/update-role) now read the existing member list from `_team/members.json` manifest instead of local config's `allowed_members`
- Prevents editors from overwriting the full member list with their empty local config when adding members
- Syncs updated members back to local config after each operation

## Context
When an editor adds a member, their local `config.allowed_members` is empty (join flow doesn't populate it). The add function was pushing only the new member to an empty list, then writing that as the manifest — overwriting all existing members.

## Test plan
- [ ] As editor, add a member — existing members should remain in the list
- [ ] As owner, add/remove/update members — should work as before
- [ ] Verify member count in UI matches actual members after operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)