### PR TITLE
fix(preview): render svg attachments reliably

### DIFF
--- a/packages/app/src/components/FileEditor.tsx
+++ b/packages/app/src/components/FileEditor.tsx
@@ -95,6 +95,7 @@ export function ImageViewer({
   const { t } = useTranslation();
   const [zoom, setZoom] = useState(100);
   const [rotation, setRotation] = useState(0);
+  const isSvg = filename.toLowerCase().endsWith(".svg");
 
   const handleZoomIn = () => setZoom((prev) => Math.min(prev + 25, 300));
   const handleZoomOut = () => setZoom((prev) => Math.max(prev - 25, 25));
@@ -148,14 +149,37 @@ export function ImageViewer({
 
       {/* Image container */}
       <div className="flex-1 overflow-auto bg-muted/20 flex items-center justify-center p-4">
-        <img
-          src={content}
-          alt={filename}
-          className="max-w-full max-h-full object-contain transition-transform duration-200"
+        <div
+          className="rounded-lg p-2"
           style={{
-            transform: `scale(${zoom / 100}) rotate(${rotation}deg)`,
+            backgroundColor: "#ffffff",
+            backgroundImage:
+              "linear-gradient(45deg, #f1f5f9 25%, transparent 25%), linear-gradient(-45deg, #f1f5f9 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f1f5f9 75%), linear-gradient(-45deg, transparent 75%, #f1f5f9 75%)",
+            backgroundSize: "16px 16px",
+            backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
           }}
-        />
+        >
+          {isSvg ? (
+            <iframe
+              src={content}
+              title={filename}
+              sandbox=""
+              className="max-w-full max-h-full min-h-[60vh] min-w-[60vw] border-0 bg-transparent transition-transform duration-200"
+              style={{
+                transform: `scale(${zoom / 100}) rotate(${rotation}deg)`,
+              }}
+            />
+          ) : (
+            <img
+              src={content}
+              alt={filename}
+              className="max-w-full max-h-full object-contain transition-transform duration-200"
+              style={{
+                transform: `scale(${zoom / 100}) rotate(${rotation}deg)`,
+              }}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/app/src/components/__tests__/FileEditor.test.tsx
+++ b/packages/app/src/components/__tests__/FileEditor.test.tsx
@@ -110,4 +110,21 @@ describe('FileEditor', () => {
 
     expect(screen.getByText('Unable to load file content')).toBeDefined()
   })
+
+  it('FileContentViewer renders svg files in an iframe preview', () => {
+    const svgDataUrl = 'data:image/svg+xml;base64,PHN2Zy8+'
+
+    const { container } = render(
+      <FileContentViewer
+        selectedFile="/workspace/assets/logo.svg"
+        fileContent={svgDataUrl}
+        isLoadingFile={false}
+        onClose={vi.fn()}
+      />,
+    )
+
+    const iframe = container.querySelector('iframe[title="logo.svg"]')
+    expect(iframe).toBeTruthy()
+    expect(iframe?.getAttribute('src')).toBe(svgDataUrl)
+  })
 })

--- a/packages/app/src/packages/ai/__tests__/message.test.tsx
+++ b/packages/app/src/packages/ai/__tests__/message.test.tsx
@@ -96,3 +96,37 @@ describe('MessageBranch components', () => {
     expect(screen.getByText('1 / 2')).toBeDefined()
   })
 })
+
+describe('image preview rendering', () => {
+  it('renders SVG previews with an iframe canvas', async () => {
+    const { ClickableImage } = await import('@/packages/ai/message')
+    const svgDataUrl = 'data:image/svg+xml;base64,PHN2Zy8+'
+
+    const { container } = render(
+      React.createElement(ClickableImage, {
+        src: svgDataUrl,
+        alt: 'diagram.svg',
+      })
+    )
+
+    const iframe = container.querySelector('iframe[title="diagram.svg"]')
+    expect(iframe).toBeTruthy()
+    expect(iframe?.getAttribute('src')).toBe(svgDataUrl)
+  })
+
+  it('renders bitmap previews with img tags', async () => {
+    const { ClickableImage } = await import('@/packages/ai/message')
+    const pngDataUrl = 'data:image/png;base64,abc'
+
+    render(
+      React.createElement(ClickableImage, {
+        src: pngDataUrl,
+        alt: 'photo.png',
+      })
+    )
+
+    const images = screen.getAllByAltText('photo.png')
+    expect(images.length).toBeGreaterThan(0)
+    expect(images[0].getAttribute('src')).toBe(pngDataUrl)
+  })
+})

--- a/packages/app/src/packages/ai/message.tsx
+++ b/packages/app/src/packages/ai/message.tsx
@@ -144,6 +144,58 @@ function getMimeType(filename: string): string {
   return mimeTypes[ext] || 'image/png'
 }
 
+function isSvgImageSource(src: string): boolean {
+  return src.startsWith('data:image/svg+xml') || /\.svg(?:$|[?#])/i.test(src)
+}
+
+function PreviewImage({
+  src,
+  alt,
+  className,
+}: {
+  src: string
+  alt?: string
+  className?: string
+}) {
+  if (isSvgImageSource(src)) {
+    return (
+      <iframe
+        src={src}
+        title={alt || 'SVG preview'}
+        sandbox=""
+        className={cn("border-0 bg-transparent", className)}
+      />
+    )
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt || 'Image'}
+      className={className}
+    />
+  )
+}
+
+function PreviewCanvas({
+  children,
+}: React.PropsWithChildren) {
+  return (
+    <div
+      className="rounded-lg p-2"
+      style={{
+        backgroundColor: '#ffffff',
+        backgroundImage:
+          'linear-gradient(45deg, #f1f5f9 25%, transparent 25%), linear-gradient(-45deg, #f1f5f9 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f1f5f9 75%), linear-gradient(-45deg, transparent 75%, #f1f5f9 75%)',
+        backgroundSize: '16px 16px',
+        backgroundPosition: '0 0, 0 8px, 8px -8px, -8px 0px',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
 // Component to load and display local image files with click-to-enlarge
 export function LocalImage({ src, alt, className, onError: onErrorCallback, onLoad: onLoadCallback }: { src: string; alt?: string; className?: string; onError?: () => void; onLoad?: () => void }) {
   const [dataUrl, setDataUrl] = React.useState<string | null>(null)
@@ -233,11 +285,13 @@ export function LocalImage({ src, alt, className, onError: onErrorCallback, onLo
               <X className="h-4 w-4" />
             </button>
           </div>
-          <img 
-            src={dataUrl} 
-            alt={alt || 'Image'} 
-            className="max-w-[95vw] max-h-[95vh] object-contain rounded-lg"
-          />
+          <PreviewCanvas>
+            <PreviewImage
+              src={dataUrl}
+              alt={alt || 'Image'}
+              className="max-w-[95vw] max-h-[95vh] w-[95vw] h-[95vh] object-contain rounded-lg"
+            />
+          </PreviewCanvas>
           {alt && (
             <div className="absolute bottom-0 left-0 right-0 bg-black/60 px-3 py-1.5 text-center text-xs text-white/90 rounded-b-lg">
               {alt}
@@ -391,11 +445,13 @@ export function ClickableImage({ src, alt, className }: { src: string; alt?: str
               <X className="h-4 w-4" />
             </button>
           </div>
-          <img 
-            src={src} 
-            alt={alt || 'Image'} 
-            className="max-w-[95vw] max-h-[95vh] object-contain rounded-lg"
-          />
+          <PreviewCanvas>
+            <PreviewImage
+              src={src}
+              alt={alt || 'Image'}
+              className="max-w-[95vw] max-h-[95vh] w-[95vw] h-[95vh] object-contain rounded-lg"
+            />
+          </PreviewCanvas>
           {alt && (
             <div className="absolute bottom-0 left-0 right-0 bg-black/60 px-3 py-1.5 text-center text-xs text-white/90 rounded-b-lg">
               {alt}


### PR DESCRIPTION
## Summary
- render SVG file previews in a sandboxed iframe so inline SVG assets display reliably in dialogs and message previews
- add a checkerboard preview canvas so transparent SVG and bitmap images are easier to inspect consistently
- cover both file viewer and chat image preview paths with focused SVG rendering tests

## Test plan
- [ ] Open an SVG attachment in the file viewer and verify it renders correctly
- [ ] Open an SVG image from a chat message and verify the enlarged preview renders correctly
- [ ] Confirm bitmap image previews still render as expected

Made with [Cursor](https://cursor.com)