### PR TITLE
feat(sidebar): quick access, left dock, and file tab toggle

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -423,18 +423,18 @@ function AppContent() {
   const isNewWorkspace = useWorkspaceStore((s) => s.isNewWorkspace);
   const setIsNewWorkspace = useWorkspaceStore((s) => s.setIsNewWorkspace);
   const { state, open: sidebarOpen, setOpen: setSidebarOpen } = useSidebar();
-  /** Workspace UI: Shortcuts docks left of chat; other panel tabs use the right column. */
-  const shortcutsLeftDock =
-    isWorkspaceUIVariant() && isPanelOpen && activeTab === "shortcuts";
-  const showRightWorkspacePanel = isPanelOpen && !shortcutsLeftDock;
+  /** Shortcuts and Files dock left of chat (both variants); other panel tabs use the right column. */
+  const leftDockActive =
+    isPanelOpen && (activeTab === "shortcuts" || activeTab === "files");
+  const showRightWorkspacePanel = isPanelOpen && !leftDockActive;
   const isCollapsed = state === "collapsed";
-  /** Native traffic lights sit over the left column; spare inset header when Shortcuts owns that strip. */
-  const hideInsetChromeForShortcutsDock =
-    shortcutsLeftDock && isWorkspaceUIVariant() && currentView !== "settings";
+  /** Native traffic lights sit over the left column; spare inset header when left dock owns that strip. */
+  const hideInsetChromeForLeftDock =
+    leftDockActive && currentView !== "settings";
   const collapsedInsetLeading = isCollapsed ? (
-    hideInsetChromeForShortcutsDock ? null : (
+    hideInsetChromeForLeftDock ? null : (
       <>
-        {(!shortcutsLeftDock || currentView === "settings") && <TrafficLights />}
+        {(!leftDockActive || currentView === "settings") && <TrafficLights />}
         {isWorkspaceUIVariant() ? (
           <>
             <SidebarCollapseToggle className="mr-0.5" />
@@ -518,32 +518,27 @@ function AppContent() {
   useFileTabSync();
   const { rightPanelWidth, handleRightPanelResize } = useResizablePanels();
 
-  /** When Shortcuts opens in workspace UI, hide the main sidebar first; restore prior expansion when it closes. */
-  const restoreSidebarAfterShortcutsRef = useRef<boolean | null>(null);
+  /** When left dock opens, hide the main sidebar; restore prior expansion when it closes. */
+  const restoreSidebarAfterLeftDockRef = useRef<boolean | null>(null);
   useEffect(() => {
-    if (!isWorkspaceUIVariant()) {
-      restoreSidebarAfterShortcutsRef.current = null;
-      return;
-    }
-    if (shortcutsLeftDock) {
-      if (restoreSidebarAfterShortcutsRef.current === null) {
-        // Remember whether to re-expand when Shortcuts closes; collapse only if needed.
-        restoreSidebarAfterShortcutsRef.current = sidebarOpen;
+    if (leftDockActive) {
+      if (restoreSidebarAfterLeftDockRef.current === null) {
+        restoreSidebarAfterLeftDockRef.current = sidebarOpen;
         if (sidebarOpen) {
           setSidebarOpen(false);
         }
       } else if (sidebarOpen) {
-        // User expanded the session sidebar while Shortcuts is open — exit Shortcuts.
+        // User re-opened sidebar while left dock is active — close the dock.
         closePanel();
       }
     } else {
-      const shouldExpand = restoreSidebarAfterShortcutsRef.current === true;
-      restoreSidebarAfterShortcutsRef.current = null;
+      const shouldExpand = restoreSidebarAfterLeftDockRef.current === true;
+      restoreSidebarAfterLeftDockRef.current = null;
       if (shouldExpand) {
         setSidebarOpen(true);
       }
     }
-  }, [shortcutsLeftDock, sidebarOpen, setSidebarOpen, closePanel]);
+  }, [leftDockActive, sidebarOpen, setSidebarOpen, closePanel]);
 
   // Full-screen loading overlay when OpenCode server is starting/restarting
   const showConnectingOverlay =
@@ -901,49 +896,49 @@ function AppContent() {
       {showConnectingOverlay && <ConnectingOverlay />}
       <AppSidebar />
       <SidebarInset className="flex flex-row h-svh overflow-hidden relative">
-        {isWorkspaceUIVariant() && (
-          <div
-            className={cn(
-              "shrink-0 overflow-hidden border-border bg-background transition-[width,opacity,transform] duration-500 ease-out",
-              shortcutsLeftDock
-                ? "w-(--sidebar-width) translate-x-0 border-r opacity-100"
-                : "pointer-events-none w-0 -translate-x-4 border-r-0 opacity-0",
-            )}
-          >
-            <div className="flex h-full w-(--sidebar-width) flex-col overflow-hidden bg-background">
-              {shortcutsLeftDock && (
-                <>
-                  <div
-                    className="flex h-12 shrink-0 items-center gap-1 border-b border-border bg-background px-2"
-                    data-tauri-drag-region
+        <div
+          className={cn(
+            "shrink-0 overflow-hidden border-border bg-background transition-[width,opacity,transform] duration-500 ease-out",
+            leftDockActive
+              ? "w-(--sidebar-width) translate-x-0 border-r opacity-100"
+              : "pointer-events-none w-0 -translate-x-4 border-r-0 opacity-0",
+          )}
+        >
+          <div className="flex h-full w-(--sidebar-width) flex-col overflow-hidden bg-background">
+            {leftDockActive && (
+              <>
+                <div
+                  className="flex h-12 shrink-0 items-center gap-1 border-b border-border bg-background px-2"
+                  data-tauri-drag-region
+                >
+                  <TrafficLights />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 shrink-0 rounded-lg"
+                    onClick={() => closePanel()}
+                    title={t("shortcuts.backToSidebar", "Back to sidebar")}
+                    aria-label={t(
+                      "shortcuts.backToSidebar",
+                      "Back to sidebar",
+                    )}
                   >
-                    <TrafficLights />
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 shrink-0 rounded-lg"
-                      onClick={() => closePanel()}
-                      title={t("shortcuts.backToSidebar", "Back to sidebar")}
-                      aria-label={t(
-                        "shortcuts.backToSidebar",
-                        "Back to sidebar",
-                      )}
-                    >
-                      <ChevronLeft className="h-4 w-4" />
-                    </Button>
-                    <span className="min-w-0 truncate text-sm font-medium">
-                      {t("navigation.shortcuts", "Shortcuts")}
-                    </span>
-                    <div className="min-w-0 flex-1" data-tauri-drag-region />
-                  </div>
-                  <div className="min-h-0 flex-1 overflow-hidden">
-                    <RightPanel todos={todos} diff={sessionDiff} />
-                  </div>
-                </>
-              )}
-            </div>
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <span className="min-w-0 truncate text-sm font-medium">
+                    {activeTab === "files"
+                      ? t("navigation.files", "Files")
+                      : t("navigation.shortcuts", "Shortcuts")}
+                  </span>
+                  <div className="min-w-0 flex-1" data-tauri-drag-region />
+                </div>
+                <div className="min-h-0 flex-1 overflow-hidden">
+                  <RightPanel todos={todos} diff={sessionDiff} />
+                </div>
+              </>
+            )}
           </div>
-        )}
+        </div>
         {/* Main column: header + main content */}
         <div className="flex flex-1 flex-col min-w-0 overflow-hidden">
           {/* Header with breadcrumb - sticky */}
@@ -996,17 +991,8 @@ function AppContent() {
               </>
             )}
 
-            {/* Panel tabs - right side of header (Shortcuts lives in sidebar when workspace UI variant) */}
+            {/* Panel tabs - right side of header */}
             <div className="ml-auto flex shrink-0 items-center gap-0.5" data-onboarding-id="workspace-panel-tabs">
-              {!isWorkspaceUIVariant() && (
-                <HeaderPanelTab
-                  icon={Bookmark}
-                  label={t("navigation.shortcuts", "Shortcuts")}
-                  count={0}
-                  isActive={isPanelOpen && activeTab === "shortcuts"}
-                  onClick={() => isPanelOpen && activeTab === "shortcuts" ? closePanel() : openPanel("shortcuts")}
-                />
-              )}
               <HeaderPanelTab
                 icon={ListTodo}
                 label={t("navigation.tasks", "Tasks")}
@@ -1025,15 +1011,6 @@ function AppContent() {
                   count={sessionDiff.length}
                   isActive={isPanelOpen && activeTab === "diff"}
                   onClick={() => isPanelOpen && activeTab === "diff" ? closePanel() : openPanel("diff")}
-                />
-              )}
-              {advancedMode && (
-                <HeaderPanelTab
-                  icon={FolderTree}
-                  label={t("navigation.files", "Files")}
-                  count={0}
-                  isActive={isPanelOpen && activeTab === "files"}
-                  onClick={() => isPanelOpen && activeTab === "files" ? closePanel() : openPanel("files")}
                 />
               )}
               {isPanelOpen && (
@@ -1060,7 +1037,7 @@ function AppContent() {
           </div>
         </div>
 
-        {/* Right Panel - full height (Shortcuts use left dock in workspace UI) */}
+        {/* Right Panel - full height */}
         <div
           className={cn(
             "shrink-0 overflow-hidden border-l border-border bg-background transition-[width,opacity,transform] duration-500 ease-out",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -210,7 +210,7 @@ function HeaderPanelTab({
 }: {
   icon: typeof ListTodo;
   label: string;
-  count: number;
+  count?: number;
   isActive: boolean;
   onClick: () => void;
 }) {
@@ -225,7 +225,7 @@ function HeaderPanelTab({
     >
       <Icon className="h-4 w-4" />
       {isActive && <span>{label}</span>}
-      {count > 0 && (
+      {!!count && count > 0 && (
         <span
           className={`min-w-[1.25rem] h-5 px-1 rounded-full text-[10px] font-medium flex items-center justify-center ${
             isActive ? "bg-primary/20 text-primary" : "bg-muted-foreground/20"
@@ -426,9 +426,9 @@ function AppContent() {
   const { state, open: sidebarOpen, setOpen: setSidebarOpen } = useSidebar();
   const hasActiveFileTab = !!useTabsStore(selectActiveTab);
   const hasHiddenTabs = useTabsStore(selectHasHiddenTabs);
-  /** Shortcuts and Files dock left of chat (both variants); other panel tabs use the right column. */
+  /** Shortcuts always dock left; Files dock left only in default variant (workspace uses the right panel for Files). */
   const leftDockActive =
-    isPanelOpen && (activeTab === "shortcuts" || activeTab === "files");
+    isPanelOpen && (activeTab === "shortcuts" || (!isWorkspaceUIVariant() && activeTab === "files"));
   const showRightWorkspacePanel = isPanelOpen && !leftDockActive;
   const isCollapsed = state === "collapsed";
   /** Native traffic lights sit over the left column; spare inset header when left dock owns that strip. */
@@ -1046,6 +1046,14 @@ function AppContent() {
                   count={sessionDiff.length}
                   isActive={isPanelOpen && activeTab === "diff"}
                   onClick={() => isPanelOpen && activeTab === "diff" ? closePanel() : openPanel("diff")}
+                />
+              )}
+              {isWorkspaceUIVariant() && (
+                <HeaderPanelTab
+                  icon={FolderTree}
+                  label={t("navigation.files", "Files")}
+                  isActive={isPanelOpen && activeTab === "files"}
+                  onClick={() => isPanelOpen && activeTab === "files" ? closePanel() : openPanel("files")}
                 />
               )}
               {showRightWorkspacePanel && (

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -19,7 +19,6 @@ import {
   ChevronLeft,
   X,
   Loader2,
-  Code,
   Bot,
   ChevronDown,
   Plus,
@@ -359,33 +358,6 @@ function ResizeHandle({
         `}
       />
     </div>
-  );
-}
-
-// Layout toggle button component
-function LayoutToggleButton() {
-  const { t } = useTranslation();
-  const { layoutMode, toggleLayoutMode } = useUIStore();
-  const isFileMode = layoutMode === "file";
-
-  // Detect OS for keyboard shortcut display
-  const isMac =
-    typeof navigator !== "undefined" &&
-    navigator.platform.toUpperCase().indexOf("MAC") >= 0;
-  const shortcutKey = isMac ? "⌘\\" : "Ctrl+\\";
-
-  return (
-    <button
-      className={`p-1.5 transition-colors rounded ${
-        isFileMode
-          ? "bg-primary/15 text-primary"
-          : "text-muted-foreground hover:text-foreground hover:bg-muted"
-      }`}
-      onClick={toggleLayoutMode}
-      title={`${isFileMode ? t("app.switchTaskMode", "Switch to Task Mode") : t("app.switchCodeSpace", "Switch to Code Space")} (${shortcutKey})`}
-    >
-      <Code className="h-4 w-4" />
-    </button>
   );
 }
 
@@ -760,9 +732,6 @@ function AppContent() {
         >
           {needsTrafficLightSpacer && <TrafficLights />}
 
-          {/* Layout toggle - before TeamClaw */}
-          {advancedMode && <LayoutToggleButton />}
-
           <span className="text-sm font-medium">{buildConfig.app.name}</span>
           <Separator
             orientation="vertical"
@@ -986,7 +955,6 @@ function AppContent() {
 
             {embeddedSettingsSection ? (
               <>
-                {advancedMode && <LayoutToggleButton />}
                 <Button
                   variant="ghost"
                   size="icon"
@@ -1004,7 +972,6 @@ function AppContent() {
               </>
             ) : (
               <>
-                {advancedMode && <LayoutToggleButton />}
                 <span className="min-w-0 truncate text-sm">
                   {activeSession?.title || t("chat.newChat", "New Chat")}
                 </span>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -25,6 +25,7 @@ import {
   Bookmark,
   RotateCw,
   MessageSquarePlus,
+  AppWindow,
 } from "lucide-react";
 // Spotlight window - lazy loaded for spotlight window label
 const SpotlightWindow = lazy(() =>
@@ -84,7 +85,7 @@ import { OnboardingTour, type OnboardingStep } from "@/components/onboarding";
 import { useSessionStore } from "@/stores/session";
 import { useUIStore } from "@/stores/ui";
 import { useWorkspaceStore } from "@/stores/workspace";
-import { useTabsStore, selectActiveTab } from "@/stores/tabs";
+import { useTabsStore, selectActiveTab, selectHasHiddenTabs } from "@/stores/tabs";
 import { TabBar } from "@/components/tab-bar/TabBar";
 import { TabContentRenderer } from "@/components/tab-bar/TabContentRenderer";
 import { WebViewToolbar } from "@/components/tab-bar/WebViewToolbar";
@@ -423,6 +424,8 @@ function AppContent() {
   const isNewWorkspace = useWorkspaceStore((s) => s.isNewWorkspace);
   const setIsNewWorkspace = useWorkspaceStore((s) => s.setIsNewWorkspace);
   const { state, open: sidebarOpen, setOpen: setSidebarOpen } = useSidebar();
+  const hasActiveFileTab = !!useTabsStore(selectActiveTab);
+  const hasHiddenTabs = useTabsStore(selectHasHiddenTabs);
   /** Shortcuts and Files dock left of chat (both variants); other panel tabs use the right column. */
   const leftDockActive =
     isPanelOpen && (activeTab === "shortcuts" || activeTab === "files");
@@ -967,9 +970,20 @@ function AppContent() {
               </>
             ) : (
               <>
-                <span className="min-w-0 truncate text-sm">
+                <button
+                  className={cn(
+                    "min-w-0 truncate text-sm text-left",
+                    hasActiveFileTab && "cursor-pointer hover:text-foreground/70 transition-colors"
+                  )}
+                  onClick={() => {
+                    if (hasActiveFileTab) {
+                      useTabsStore.getState().hideAll();
+                    }
+                  }}
+                  disabled={!hasActiveFileTab}
+                >
                   {activeSession?.title || t("chat.newChat", "New Chat")}
-                </span>
+                </button>
                 {activeSession && (
                   <button
                     onClick={async () => {
@@ -993,6 +1007,27 @@ function AppContent() {
 
             {/* Panel tabs - right side of header */}
             <div className="ml-auto flex shrink-0 items-center gap-0.5" data-onboarding-id="workspace-panel-tabs">
+              {(hasActiveFileTab || hasHiddenTabs) && (
+                <button
+                  className={cn(
+                    "rounded p-1 transition-colors hover:bg-muted hover:text-foreground",
+                    hasActiveFileTab ? "text-foreground" : "text-muted-foreground",
+                  )}
+                  onClick={() => {
+                    if (hasActiveFileTab) {
+                      useTabsStore.getState().hideAll();
+                    } else {
+                      useTabsStore.getState().restoreLastTab();
+                    }
+                  }}
+                  title={hasActiveFileTab
+                    ? t("navigation.hideTabs", "Hide files")
+                    : t("navigation.restoreTabs", "Show files")
+                  }
+                >
+                  <AppWindow className="h-4 w-4" />
+                </button>
+              )}
               <HeaderPanelTab
                 icon={ListTodo}
                 label={t("navigation.tasks", "Tasks")}
@@ -1013,7 +1048,7 @@ function AppContent() {
                   onClick={() => isPanelOpen && activeTab === "diff" ? closePanel() : openPanel("diff")}
                 />
               )}
-              {isPanelOpen && (
+              {showRightWorkspacePanel && (
                 <button
                   className="ml-1 rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                   onClick={closePanel}

--- a/packages/app/src/components/__tests__/app-sidebar.test.tsx
+++ b/packages/app/src/components/__tests__/app-sidebar.test.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 const uiVariantMocks = vi.hoisted(() => ({ workspaceShell: false }))
 
 const uiStoreMocks = vi.hoisted(() => ({
+  advancedMode: true,
   openSettings: vi.fn(),
   closeSettings: vi.fn(),
   embeddedSettingsSection: null as string | null,

--- a/packages/app/src/components/__tests__/app-sidebar.test.tsx
+++ b/packages/app/src/components/__tests__/app-sidebar.test.tsx
@@ -4,6 +4,26 @@ import React from 'react'
 
 const uiVariantMocks = vi.hoisted(() => ({ workspaceShell: false }))
 
+const uiStoreMocks = vi.hoisted(() => ({
+  openSettings: vi.fn(),
+  closeSettings: vi.fn(),
+  embeddedSettingsSection: null as string | null,
+  openEmbeddedSettingsSection: vi.fn(),
+  closeEmbeddedSettingsSection: vi.fn(),
+}))
+
+const workspaceStoreMocks = vi.hoisted(() => ({
+  openPanel: vi.fn(),
+  closePanel: vi.fn(),
+  clearSelection: vi.fn(),
+  setWorkspace: vi.fn(),
+  workspacePath: '/workspace',
+  workspaceName: 'workspace',
+  isLoadingWorkspace: false,
+  isPanelOpen: false,
+  activeTab: 'tasks',
+}))
+
 // Mock i18n
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -47,28 +67,12 @@ vi.mock('@/stores/session', () => ({
 
 vi.mock('@/stores/ui', () => ({
   useUIStore: (sel: (s: Record<string, unknown>) => unknown) =>
-    sel({
-      openSettings: vi.fn(),
-      closeSettings: vi.fn(),
-      embeddedSettingsSection: null,
-      openEmbeddedSettingsSection: vi.fn(),
-      closeEmbeddedSettingsSection: vi.fn(),
-    }),
+    sel(uiStoreMocks as unknown as Record<string, unknown>),
 }))
 
 vi.mock('@/stores/workspace', () => ({
   useWorkspaceStore: (sel: (s: Record<string, unknown>) => unknown) =>
-    sel({
-      workspacePath: '/workspace',
-      workspaceName: 'workspace',
-      isLoadingWorkspace: false,
-      clearSelection: vi.fn(),
-      setWorkspace: vi.fn(),
-      isPanelOpen: false,
-      activeTab: 'tasks',
-      openPanel: vi.fn(),
-      closePanel: vi.fn(),
-    }),
+    sel(workspaceStoreMocks),
 }))
 
 vi.mock('@/stores/tabs', () => ({
@@ -135,6 +139,15 @@ describe('AppSidebar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     uiVariantMocks.workspaceShell = false
+    uiStoreMocks.embeddedSettingsSection = null
+    uiStoreMocks.openSettings = vi.fn()
+    uiStoreMocks.closeSettings = vi.fn()
+    uiStoreMocks.openEmbeddedSettingsSection = vi.fn()
+    uiStoreMocks.closeEmbeddedSettingsSection = vi.fn()
+    workspaceStoreMocks.isPanelOpen = false
+    workspaceStoreMocks.activeTab = 'tasks'
+    workspaceStoreMocks.openPanel = vi.fn()
+    workspaceStoreMocks.closePanel = vi.fn()
   })
 
   it('renders session titles in sidebar', () => {
@@ -181,5 +194,54 @@ describe('AppSidebar', () => {
     expect(screen.getByText('Shortcuts')).toBeDefined()
     expect(screen.getByText('Automation')).toBeDefined()
     expect(screen.getByText('Skills')).toBeDefined()
+  })
+
+  it('default mode renders Quick Access section with all four entries', () => {
+    uiVariantMocks.workspaceShell = false
+    render(<AppSidebar />)
+    expect(screen.getByText('Shortcuts')).toBeDefined()
+    expect(screen.getByText('Automation')).toBeDefined()
+    expect(screen.getByText('Skills')).toBeDefined()
+    expect(screen.getByText('Files')).toBeDefined()
+  })
+
+  it('workspace mode does not render bottom Files entry', () => {
+    uiVariantMocks.workspaceShell = true
+    render(<AppSidebar />)
+    // workspace mode has its own quick links but NOT "Files"
+    expect(screen.queryByText('Files')).toBeNull()
+  })
+
+  it('clicking Shortcuts in Quick Access calls openPanel with "shortcuts"', () => {
+    uiVariantMocks.workspaceShell = false
+    render(<AppSidebar />)
+    screen.getByText('Shortcuts').closest('button')!.click()
+    expect(workspaceStoreMocks.openPanel).toHaveBeenCalledWith('shortcuts')
+  })
+
+  it('clicking Files in Quick Access calls openPanel with "files"', () => {
+    uiVariantMocks.workspaceShell = false
+    render(<AppSidebar />)
+    screen.getByText('Files').closest('button')!.click()
+    expect(workspaceStoreMocks.openPanel).toHaveBeenCalledWith('files')
+  })
+
+  it('clicking active Automation in Quick Access closes it', () => {
+    uiVariantMocks.workspaceShell = false
+    uiStoreMocks.embeddedSettingsSection = 'automation'  // already active
+    render(<AppSidebar />)
+    screen.getByText('Automation').closest('button')!.click()
+    expect(uiStoreMocks.closeEmbeddedSettingsSection).toHaveBeenCalled()
+  })
+
+  it('clicking active Files in Quick Access closes the panel', () => {
+    uiVariantMocks.workspaceShell = false
+    const closePanelFn = vi.fn()
+    workspaceStoreMocks.isPanelOpen = true
+    workspaceStoreMocks.activeTab = 'files'
+    workspaceStoreMocks.closePanel = closePanelFn
+    render(<AppSidebar />)
+    screen.getByText('Files').closest('button')!.click()
+    expect(closePanelFn).toHaveBeenCalled()
   })
 })

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -495,6 +495,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     [sessions, pinnedSessionIds],
   )
   
+  const advancedMode = useUIStore(s => s.advancedMode)
   const openSettings = useUIStore(s => s.openSettings)
   const closeSettings = useUIStore(s => s.closeSettings)
   const embeddedSettingsSection = useUIStore(s => s.embeddedSettingsSection)
@@ -842,96 +843,95 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           )}
           </SidebarGroup>
 
+        </SidebarContent>
+
+        <SidebarFooter className="gap-1 px-3 pb-3 pt-1.5">
           {/* Quick Access — default mode only */}
           {!isWorkspaceUIVariant() && (
-            <div className="px-1.5 pb-2">
-              <div className="mx-3 mb-2 h-px shrink-0 bg-border/60" aria-hidden />
-              <div className="flex flex-col gap-0.5">
-                <Button
-                  variant="ghost"
-                  size="sm"
+            <div className="flex flex-col gap-0.5">
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  'h-7 justify-start gap-1.5 px-2 font-normal',
+                  shortcutsStripActive && 'bg-primary/10 text-primary font-medium',
+                )}
+                onClick={handleWorkspaceShortcutsPanel}
+              >
+                <Bookmark
                   className={cn(
-                    'h-9 justify-start gap-2 px-1.5 font-normal',
-                    shortcutsStripActive && 'bg-primary/10 text-primary font-medium',
+                    'h-3.5 w-3.5 shrink-0',
+                    shortcutsStripActive ? 'text-amber-500' : 'text-muted-foreground',
                   )}
-                  onClick={handleWorkspaceShortcutsPanel}
-                >
-                  <Bookmark
-                    className={cn(
-                      'h-4 w-4 shrink-0',
-                      shortcutsStripActive ? 'text-amber-500' : 'text-muted-foreground',
-                    )}
-                  />
-                  <span className="truncate text-sm">
-                    {t('navigation.shortcuts', 'Shortcuts')}
-                  </span>
-                </Button>
+                />
+                <span className="truncate text-xs">
+                  {t('navigation.shortcuts', 'Shortcuts')}
+                </span>
+              </Button>
 
-                <Button
-                  variant="ghost"
-                  size="sm"
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  'h-7 justify-start gap-1.5 px-2 font-normal',
+                  embeddedSettingsSection === 'automation' && 'bg-primary/10 text-primary font-medium',
+                )}
+                onClick={() => handleQuickAccessEmbeddedSection('automation')}
+              >
+                <Clock
                   className={cn(
-                    'h-9 justify-start gap-2 px-1.5 font-normal',
-                    embeddedSettingsSection === 'automation' && 'bg-primary/10 text-primary font-medium',
+                    'h-3.5 w-3.5 shrink-0',
+                    embeddedSettingsSection === 'automation' ? 'text-amber-500' : 'text-muted-foreground',
                   )}
-                  onClick={() => handleQuickAccessEmbeddedSection('automation')}
-                >
-                  <Clock
-                    className={cn(
-                      'h-4 w-4 shrink-0',
-                      embeddedSettingsSection === 'automation' ? 'text-amber-500' : 'text-muted-foreground',
-                    )}
-                  />
-                  <span className="truncate text-sm">
-                    {t('settings.nav.automation', 'Automation')}
-                  </span>
-                </Button>
+                />
+                <span className="truncate text-xs">
+                  {t('settings.nav.automation', 'Automation')}
+                </span>
+              </Button>
 
-                <Button
-                  variant="ghost"
-                  size="sm"
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  'h-7 justify-start gap-1.5 px-2 font-normal',
+                  embeddedSettingsSection === 'skills' && 'bg-primary/10 text-primary font-medium',
+                )}
+                onClick={() => handleQuickAccessEmbeddedSection('skills')}
+              >
+                <Sparkles
                   className={cn(
-                    'h-9 justify-start gap-2 px-1.5 font-normal',
-                    embeddedSettingsSection === 'skills' && 'bg-primary/10 text-primary font-medium',
+                    'h-3.5 w-3.5 shrink-0',
+                    embeddedSettingsSection === 'skills' ? 'text-yellow-500' : 'text-muted-foreground',
                   )}
-                  onClick={() => handleQuickAccessEmbeddedSection('skills')}
-                >
-                  <Sparkles
-                    className={cn(
-                      'h-4 w-4 shrink-0',
-                      embeddedSettingsSection === 'skills' ? 'text-yellow-500' : 'text-muted-foreground',
-                    )}
-                  />
-                  <span className="truncate text-sm">
-                    {t('settings.nav.skills', 'Skills')}
-                  </span>
-                </Button>
+                />
+                <span className="truncate text-xs">
+                  {t('settings.nav.skills', 'Skills')}
+                </span>
+              </Button>
 
+              {advancedMode && (
                 <Button
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    'h-9 justify-start gap-2 px-1.5 font-normal',
+                    'h-7 justify-start gap-1.5 px-2 font-normal',
                     fileStripActive && 'bg-primary/10 text-primary font-medium',
                   )}
                   onClick={handleOpenFilePanel}
                 >
                   <FolderOpen
                     className={cn(
-                      'h-4 w-4 shrink-0',
+                      'h-3.5 w-3.5 shrink-0',
                       fileStripActive ? 'text-blue-500' : 'text-muted-foreground',
                     )}
                   />
-                  <span className="truncate text-sm">
+                  <span className="truncate text-xs">
                     {t('navigation.files', 'Files')}
                   </span>
                 </Button>
-              </div>
+              )}
             </div>
           )}
-        </SidebarContent>
-
-        <SidebarFooter className="px-3 py-3">
           <div className="flex items-center justify-between">
             <Button
               variant="ghost"

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -609,7 +609,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarMenuButton
           isActive={session.id === activeSessionId}
           className={cn(
-            "h-auto py-2 transition-all duration-300",
+            "h-auto py-1.5 transition-all duration-300",
             isWorkspaceUIVariant() &&
               session.id === activeSessionId &&
               "relative z-0 data-[active=true]:!bg-muted/40 data-[active=true]:font-medium before:pointer-events-none before:absolute before:left-0 before:top-1/2 before:z-10 before:h-[72%] before:w-0.5 before:-translate-y-1/2 before:rounded-full before:bg-primary before:content-['']",
@@ -637,7 +637,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 />
               ) : (
                 <>
-                  <span className="truncate text-left">
+                  <span className="truncate text-left text-xs">
                     {session.title}
                   </span>
                   {isPinned && (

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -514,6 +514,18 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     openEmbeddedSettingsSection(section)
   }
 
+  const handleQuickAccessEmbeddedSection = (section: EmbeddedSidebarSettingsSection) => {
+    clearSelection()
+    closeSettings()
+    useTabsStore.getState().hideAll()
+    if (embeddedSettingsSection === section) {
+      closeEmbeddedSettingsSection()
+      return
+    }
+    closePanel()
+    openEmbeddedSettingsSection(section)
+  }
+
   const handleWorkspaceShortcutsPanel = () => {
     clearSelection()
     closeSettings()
@@ -526,9 +538,26 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     }
   }
 
+  const handleOpenFilePanel = () => {
+    clearSelection()
+    closeSettings()
+    closeEmbeddedSettingsSection()
+    useTabsStore.getState().hideAll()
+    if (isPanelOpen && activeWorkspacePanelTab === 'files') {
+      closePanel()
+    } else {
+      openPanel('files')
+    }
+  }
+
   const shortcutsStripActive =
     isPanelOpen &&
     activeWorkspacePanelTab === "shortcuts" &&
+    !embeddedSettingsSection
+
+  const fileStripActive =
+    isPanelOpen &&
+    activeWorkspacePanelTab === 'files' &&
     !embeddedSettingsSection
 
   const handleSelectSession = (id: string) => {
@@ -812,6 +841,94 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             </div>
           )}
           </SidebarGroup>
+
+          {/* Quick Access — default mode only */}
+          {!isWorkspaceUIVariant() && (
+            <div className="px-1.5 pb-2">
+              <div className="mx-3 mb-2 h-px shrink-0 bg-border/60" aria-hidden />
+              <div className="flex flex-col gap-0.5">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    'h-9 justify-start gap-2 px-1.5 font-normal',
+                    shortcutsStripActive && 'bg-primary/10 text-primary font-medium',
+                  )}
+                  onClick={handleWorkspaceShortcutsPanel}
+                >
+                  <Bookmark
+                    className={cn(
+                      'h-4 w-4 shrink-0',
+                      shortcutsStripActive ? 'text-amber-500' : 'text-muted-foreground',
+                    )}
+                  />
+                  <span className="truncate text-sm">
+                    {t('navigation.shortcuts', 'Shortcuts')}
+                  </span>
+                </Button>
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    'h-9 justify-start gap-2 px-1.5 font-normal',
+                    embeddedSettingsSection === 'automation' && 'bg-primary/10 text-primary font-medium',
+                  )}
+                  onClick={() => handleQuickAccessEmbeddedSection('automation')}
+                >
+                  <Clock
+                    className={cn(
+                      'h-4 w-4 shrink-0',
+                      embeddedSettingsSection === 'automation' ? 'text-amber-500' : 'text-muted-foreground',
+                    )}
+                  />
+                  <span className="truncate text-sm">
+                    {t('settings.nav.automation', 'Automation')}
+                  </span>
+                </Button>
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    'h-9 justify-start gap-2 px-1.5 font-normal',
+                    embeddedSettingsSection === 'skills' && 'bg-primary/10 text-primary font-medium',
+                  )}
+                  onClick={() => handleQuickAccessEmbeddedSection('skills')}
+                >
+                  <Sparkles
+                    className={cn(
+                      'h-4 w-4 shrink-0',
+                      embeddedSettingsSection === 'skills' ? 'text-yellow-500' : 'text-muted-foreground',
+                    )}
+                  />
+                  <span className="truncate text-sm">
+                    {t('settings.nav.skills', 'Skills')}
+                  </span>
+                </Button>
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    'h-9 justify-start gap-2 px-1.5 font-normal',
+                    fileStripActive && 'bg-primary/10 text-primary font-medium',
+                  )}
+                  onClick={handleOpenFilePanel}
+                >
+                  <FolderOpen
+                    className={cn(
+                      'h-4 w-4 shrink-0',
+                      fileStripActive ? 'text-blue-500' : 'text-muted-foreground',
+                    )}
+                  />
+                  <span className="truncate text-sm">
+                    {t('navigation.files', 'Files')}
+                  </span>
+                </Button>
+              </div>
+            </div>
+          )}
         </SidebarContent>
 
         <SidebarFooter className="px-3 py-3">

--- a/packages/app/src/components/tab-bar/TabBar.tsx
+++ b/packages/app/src/components/tab-bar/TabBar.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useTabsStore, Tab } from "@/stores/tabs";
 import { cn } from "@/lib/utils";
-import { X, Code, Globe, LayoutDashboard, FileText, Image, EyeOff } from "lucide-react";
+import { X, Code, Globe, LayoutDashboard, FileText, Image } from "lucide-react";
 
 function getTabIcon(tab: Tab) {
   if (tab.type === "webview") return Globe;
@@ -32,7 +32,6 @@ export function TabBar() {
   const closeTab = useTabsStore((s) => s.closeTab);
   const closeOthers = useTabsStore((s) => s.closeOthers);
   const closeAll = useTabsStore((s) => s.closeAll);
-  const hideAll = useTabsStore((s) => s.hideAll);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
 
   const handleContextMenu = useCallback((e: React.MouseEvent, tabId: string) => {
@@ -113,15 +112,6 @@ export function TabBar() {
           </div>
         );
       })}
-
-      {/* Hide all tabs button — returns to agent view without closing tabs */}
-      <button
-        className="ml-auto shrink-0 p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors rounded-md mx-1"
-        onClick={hideAll}
-        title="Back to Agent"
-      >
-        <EyeOff className="h-3.5 w-3.5" />
-      </button>
 
       {contextMenu && createPortal(
         <div

--- a/packages/app/src/stores/tabs.ts
+++ b/packages/app/src/stores/tabs.ts
@@ -19,6 +19,8 @@ let nextId = 1;
 interface TabsState {
   tabs: Tab[];
   activeTabId: string | null;
+  /** Remembers the last active tab when hideAll is called */
+  _lastActiveTabId: string | null;
   openTab: (item: OpenTabInput) => void;
   closeTab: (id: string) => void;
   setActiveTab: (id: string) => void;
@@ -27,7 +29,14 @@ interface TabsState {
   closeAll: () => void;
   /** Deactivate all tabs without closing them — returns to agent view */
   hideAll: () => void;
+  /** Re-activate the last tab after hideAll */
+  restoreLastTab: () => void;
   getActiveTab: () => Tab | null;
+}
+
+/** True when tabs exist but none is active (hidden via hideAll). */
+export function selectHasHiddenTabs(s: TabsState): boolean {
+  return s.tabs.length > 0 && s.activeTabId === null;
 }
 
 /** Zustand selector for the active tab. Use with `useTabsStore(selectActiveTab)`. */
@@ -39,6 +48,7 @@ export function selectActiveTab(s: TabsState): Tab | null {
 export const useTabsStore = create<TabsState>((set, get) => ({
   tabs: [],
   activeTabId: null,
+  _lastActiveTabId: null,
 
   openTab: (item) => {
     const { tabs, activeTabId } = get();
@@ -98,7 +108,19 @@ export const useTabsStore = create<TabsState>((set, get) => ({
   },
 
   hideAll: () => {
-    set({ activeTabId: null });
+    const { activeTabId } = get();
+    if (activeTabId) set({ _lastActiveTabId: activeTabId, activeTabId: null });
+    else set({ activeTabId: null });
+  },
+
+  restoreLastTab: () => {
+    const { tabs, activeTabId, _lastActiveTabId } = get();
+    if (activeTabId) return; // already showing a tab
+    if (_lastActiveTabId && tabs.some((t) => t.id === _lastActiveTabId)) {
+      set({ activeTabId: _lastActiveTabId });
+    } else if (tabs.length > 0) {
+      set({ activeTabId: tabs[tabs.length - 1].id });
+    }
   },
 
   getActiveTab: () => {


### PR DESCRIPTION
## Summary
- Add Quick Access section to default mode sidebar with pinned shortcuts (Files, Shortcuts)
- Enable left dock for Shortcuts and Files panels in default mode (not just advanced mode)
- Remove Code Mode toggle button from sidebar
- Add file tab toggle button in header — click to hide/restore file tabs without closing them
- Clicking session title hides open file tabs to return to chat
- Reduce session list font size for higher information density
- Fix close (X) button incorrectly showing in header when left dock is active

## Test plan
- [ ] Open sidebar in default mode, verify Quick Access section appears at bottom
- [ ] Click Files/Shortcuts in Quick Access, verify they open in left dock
- [ ] Open a file, verify AppWindow toggle button appears in header
- [ ] Click toggle button to hide files, verify chat is shown and button stays visible (dimmed)
- [ ] Click toggle button again to restore file view
- [ ] Click session title while file is open, verify it hides files
- [ ] Open Files/Shortcuts in left dock, verify no X button in top-right header

🤖 Generated with [Claude Code](https://claude.com/claude-code)