### PR TITLE
docs: rebrand tagline to AI Ally / AI 搭档

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # TeamClaw
 
-OpenCode を基盤としたローカル AI エージェント。デジタル従業員のための土台
+OpenCode を基盤としたローカル AI エージェント。あなたの AI パートナー
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | 日本語 | [한국어](README.ko.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 # TeamClaw
 
-OpenCode 기반의 로컬 AI 에이전트, 디지털 직원을 위한 기반
+OpenCode 기반의 로컬 AI 에이전트, 당신의 AI 파트너
 
 [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | 한국어
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/diffrent-ai-studio/teamclaw/actions/workflows/ci.yml/badge.svg)](https://github.com/diffrent-ai-studio/teamclaw/actions)
 [![Contributors](https://img.shields.io/github/contributors/diffrent-ai-studio/teamclaw.svg)](https://github.com/diffrent-ai-studio/teamclaw/graphs/contributors)
 
-Local AI agents built on OpenCode — the foundation for digital employees
+Local AI agents built on OpenCode — your AI Ally for every role
 
 English | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # TeamClaw
 
-基于OpenCode打造的本地智能体，数字员工的基座
+基于 OpenCode 打造的本地智能体，你的 AI 搭档
 
 [English](README.md) | 简体中文 | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # TeamClaw
 
-基於 OpenCode 打造的本地智慧體，數位員工的基座
+基於 OpenCode 打造的本地智慧體，你的 AI 搭檔
 
 [English](README.md) | [简体中文](README.zh-CN.md) | 繁體中文 | [日本語](README.ja.md) | [한국어](README.ko.md)
 


### PR DESCRIPTION
## Summary
- Replace "digital employees" / "数字员工" positioning with **AI Ally / AI 搭档** across all 5 README language versions
- EN: "your AI Ally for every role"
- zh-CN: "你的 AI 搭档"
- zh-TW: "你的 AI 搭檔"
- ja: "あなたの AI パートナー"
- ko: "당신의 AI 파트너"

## Why
"数字员工" implies replacing human workers. "搭档/Ally" better communicates that TeamClaw is here to collaborate with you, not replace you — and naturally represents a category of roles, not an individual.

## Test plan
- [x] Verify all 5 README files render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)