### PR TITLE
fix(chat): handle terminal input prompts safely

### DIFF
--- a/packages/app/src/components/chat/QuestionCard.tsx
+++ b/packages/app/src/components/chat/QuestionCard.tsx
@@ -22,6 +22,11 @@ export const QuestionCard = React.memo(function QuestionCard({ toolCallId, quest
   const [hasSubmitted, setHasSubmitted] = React.useState(false)
 
   const isPending = pendingQuestion?.toolCallId === toolCallId
+  const terminalPromptKind =
+    isPending && pendingQuestion?.source === 'terminal_input'
+      ? pendingQuestion.terminalInputContext?.kind
+      : undefined
+  const isSensitiveTerminalInput = terminalPromptKind === 'password'
   // questionId arrives via question.asked SSE event (may lag behind tool executing event)
   const hasQuestionId = !!pendingQuestion?.questionId
   // Show as waiting for completion if submitted but not yet completed
@@ -158,7 +163,15 @@ export const QuestionCard = React.memo(function QuestionCard({ toolCallId, quest
               {showInteractiveUI && (
                 <div className="pt-1">
                   <Input
-                    placeholder={question.options?.length ? "Or type a custom answer..." : "Type your answer..."}
+                    type={isSensitiveTerminalInput ? "password" : "text"}
+                    autoComplete={isSensitiveTerminalInput ? "off" : undefined}
+                    placeholder={
+                      isSensitiveTerminalInput
+                        ? "Type the password or passphrase..."
+                        : question.options?.length
+                          ? "Or type a custom answer..."
+                          : "Type your answer..."
+                    }
                     value={customInput}
                     onChange={(e) => handleCustomInput(qIndex, e.target.value)}
                     onKeyDown={(e) => {

--- a/packages/app/src/components/chat/ToolCallCard.tsx
+++ b/packages/app/src/components/chat/ToolCallCard.tsx
@@ -12,6 +12,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { QuestionCard } from "./QuestionCard";
+import { getCommandText } from "@/lib/terminal-interaction";
 
 // Import sub-cards and utilities from tool-calls/
 import { WriteToolCard } from "./tool-calls/WriteToolCard";
@@ -28,6 +29,8 @@ import {
   isReadTool,
   isTaskTool,
   isSkillTool,
+  isCommandTool,
+  isCommandToolLikelyWaitingForInput,
   formatToolName,
   useToolCallTimeout,
 } from "./tool-calls/tool-call-utils";
@@ -47,6 +50,9 @@ export const ToolCallCard = React.memo(function ToolCallCard({ toolCall, onOpenD
   const config = statusConfig[toolCall.status];
   const StatusIcon = config.icon;
   const ToolIcon = getToolIcon(toolCall.name);
+  const isCommand = isCommandTool(toolCall.name);
+  const isWaitingForInput = isCommandToolLikelyWaitingForInput(toolCall);
+  const commandText = getCommandText(toolCall.arguments);
 
   const handleForceComplete = useCallback(
     (e: React.MouseEvent) => {
@@ -148,156 +154,179 @@ export const ToolCallCard = React.memo(function ToolCallCard({ toolCall, onOpenD
   }
 
   return (
-    <Collapsible open={expanded} onOpenChange={setExpanded}>
-      <div className="rounded-lg border border-border bg-muted/30 overflow-hidden transition-all duration-200">
-        <CollapsibleTrigger asChild>
-          <button className="w-full flex items-center gap-2 px-3 py-2 text-left bg-muted/50 hover:bg-muted/70 transition-colors">
-            {/* Expand icon */}
-            <ChevronRight
-              size={14}
-              className={cn(
-                "text-muted-foreground transition-transform duration-200 shrink-0",
-                expanded && "rotate-90",
-              )}
-            />
-
-            {/* Tool icon */}
-            <ToolIcon size={14} className="text-muted-foreground shrink-0" />
-
-            {/* Tool name */}
-            <span className="text-xs font-medium text-foreground">
-              {formatToolName(toolCall.name)}
-            </span>
-
-            {/* Summary (if available and not expanded) */}
-            {summary && !expanded && (
-              <span className="text-xs text-muted-foreground truncate flex-1 max-w-[200px] font-mono">
-                {summary}
+    <div className="space-y-2">
+      <Collapsible open={expanded} onOpenChange={setExpanded}>
+        <div className="rounded-lg border border-border bg-muted/30 overflow-hidden transition-all duration-200">
+          <CollapsibleTrigger asChild>
+            <button className="w-full flex items-center gap-2 px-3 py-2 text-left bg-muted/50 hover:bg-muted/70 transition-colors">
+              <ChevronRight
+                size={14}
+                className={cn(
+                  "text-muted-foreground transition-transform duration-200 shrink-0",
+                  expanded && "rotate-90",
+                )}
+              />
+              <ToolIcon size={14} className="text-muted-foreground shrink-0" />
+              <span className="text-xs font-medium text-foreground">
+                {formatToolName(toolCall.name)}
               </span>
-            )}
-
-            {/* Status indicator */}
-            <div className="ml-auto flex items-center gap-2">
-              {/* Duration */}
-              {toolCall.duration && (
-                <span className="text-[10px] text-muted-foreground/70">
-                  {formatDuration(toolCall.duration)}
+              {summary && !expanded && (
+                <span className="text-xs text-muted-foreground truncate flex-1 max-w-[200px] font-mono">
+                  {summary}
                 </span>
               )}
-
-              {/* Status icon or timeout button */}
-              {isTimedOut ? (
-                <button
-                  onClick={handleForceComplete}
-                  className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] bg-muted hover:bg-muted/80 text-foreground border border-border transition-colors"
-                  title="Tool call timed out - click to mark as done"
-                >
-                  <AlertTriangle size={10} />
-                  <span>Timed out</span>
-                  <CheckCircle2 size={10} />
-                </button>
-              ) : (
-                <StatusIcon
-                  size={14}
-                  className={cn(
-                    config.textColor,
-                    config.animate && "animate-spin",
-                  )}
-                />
-              )}
-            </div>
-          </button>
-        </CollapsibleTrigger>
-
-        <CollapsibleContent>
-          <div className="px-3 pb-3 pt-1 text-xs space-y-2 border-t border-border/50">
-            {/* Arguments */}
-            {toolCall.arguments &&
-              Object.keys(toolCall.arguments).length > 0 && (
-                <div>
-                  <span className="text-muted-foreground font-medium">
-                    Arguments
+              <div className="ml-auto flex items-center gap-2">
+                {toolCall.duration && (
+                  <span className="text-[10px] text-muted-foreground/70">
+                    {formatDuration(toolCall.duration)}
                   </span>
-                  <pre className="mt-1 p-2 bg-background/60 rounded text-[10px] overflow-x-auto font-mono max-h-24">
-                    {JSON.stringify(toolCall.arguments, null, 2)}
-                  </pre>
+                )}
+                {isTimedOut ? (
+                  <button
+                    onClick={handleForceComplete}
+                    className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] bg-muted hover:bg-muted/80 text-foreground border border-border transition-colors"
+                    title={
+                      isCommand
+                        ? "Command may be blocked waiting for terminal input - click to mark as done"
+                        : "Tool call timed out - click to mark as done"
+                    }
+                  >
+                    <AlertTriangle size={10} />
+                    <span>{isCommand ? "Waiting input" : "Timed out"}</span>
+                    <CheckCircle2 size={10} />
+                  </button>
+                ) : isWaitingForInput ? (
+                  <div
+                    className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] bg-amber-100 text-amber-800 border border-amber-200"
+                    title="Command output looks like it is waiting for confirmation or stdin input"
+                  >
+                    <AlertTriangle size={10} />
+                    <span>Input needed</span>
+                  </div>
+                ) : (
+                  <StatusIcon
+                    size={14}
+                    className={cn(
+                      config.textColor,
+                      config.animate && "animate-spin",
+                    )}
+                  />
+                )}
+              </div>
+            </button>
+          </CollapsibleTrigger>
+
+          <CollapsibleContent>
+            <div className="px-3 pb-3 pt-1 text-xs space-y-2 border-t border-border/50">
+              {isCommand && (isWaitingForInput || isTimedOut) && (
+                <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-2 text-[11px] text-amber-900">
+                  <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                  <div className="space-y-1">
+                    <p className="font-medium">
+                      {isWaitingForInput
+                        ? "This command looks like it is waiting for terminal input."
+                        : "This command has been running for a while."}
+                    </p>
+                    <p className="text-amber-800/90">
+                      Prefer non-interactive flags like `--yes` or `-y`. If input is required, ask a question before running the command.
+                    </p>
+                    {commandText && (
+                      <p className="font-mono text-[10px] break-all text-amber-800/80">
+                        {commandText}
+                      </p>
+                    )}
+                  </div>
                 </div>
               )}
 
-            {/* Result - handle various result formats */}
-            {(() => {
-              // Extract result content - handle different formats
-              let resultContent = toolCall.result;
-
-              // If result is an object with content array (common MCP format)
-              if (resultContent && typeof resultContent === "object") {
-                const resultObj = resultContent as Record<string, unknown>;
-                // Check for common MCP result structures
-                if (Array.isArray(resultObj.content)) {
-                  // Extract text from content array
-                  const textParts = resultObj.content
-                    .filter(
-                      (c: unknown) =>
-                        c &&
-                        typeof c === "object" &&
-                        (c as Record<string, unknown>).type === "text",
-                    )
-                    .map((c: unknown) => (c as Record<string, unknown>).text)
-                    .join("\n");
-                  if (textParts) resultContent = textParts;
-                } else if (resultObj.text) {
-                  resultContent = resultObj.text;
-                } else if (resultObj.output) {
-                  resultContent = resultObj.output;
-                }
-              }
-
-              if (resultContent !== undefined && resultContent !== null) {
-                const displayText =
-                  typeof resultContent === "string"
-                    ? resultContent.slice(0, 500) +
-                      (resultContent.length > 500 ? "..." : "")
-                    : JSON.stringify(resultContent, null, 2);
-
-                return (
+              {toolCall.arguments &&
+                Object.keys(toolCall.arguments).length > 0 && (
                   <div>
                     <span className="text-muted-foreground font-medium">
-                      Result
+                      Arguments
                     </span>
-                    <pre className="mt-1 p-2 bg-background/60 rounded text-[10px] overflow-x-auto max-h-48 font-mono whitespace-pre-wrap">
-                      {displayText}
+                    <pre className="mt-1 p-2 bg-background/60 rounded text-[10px] overflow-x-auto font-mono max-h-24">
+                      {JSON.stringify(toolCall.arguments, null, 2)}
                     </pre>
                   </div>
-                );
-              }
-              return null;
-            })()}
+                )}
 
-            {/* Show placeholder if no content */}
-            {(!toolCall.arguments ||
-              Object.keys(toolCall.arguments).length === 0) &&
-              (toolCall.result === undefined || toolCall.result === null) && (
-                <div className="text-muted-foreground/60 italic py-2">
-                  No details available
-                </div>
-              )}
+              {(() => {
+                let resultContent = toolCall.result;
 
-            {/* View details link */}
-            {onOpenDetail && (
-              <button
-                onClick={() =>
-                  onOpenDetail(getDetailType(toolCall.name), toolCall)
+                if (resultContent && typeof resultContent === "object") {
+                  const resultObj = resultContent as Record<string, unknown>;
+                  if (Array.isArray(resultObj.content)) {
+                    const textParts = resultObj.content
+                      .filter(
+                        (c: unknown) =>
+                          c &&
+                          typeof c === "object" &&
+                          (c as Record<string, unknown>).type === "text",
+                      )
+                      .map((c: unknown) => (c as Record<string, unknown>).text)
+                      .join("\n");
+                    if (textParts) resultContent = textParts;
+                  } else if (resultObj.text) {
+                    resultContent = resultObj.text;
+                  } else if (resultObj.output) {
+                    resultContent = resultObj.output;
+                  }
                 }
-                className="text-[10px] text-muted-foreground hover:text-foreground hover:underline"
-              >
-                View full details →
-              </button>
-            )}
-          </div>
-        </CollapsibleContent>
 
-        <PermissionApprovalBar toolCall={toolCall} />
-      </div>
-    </Collapsible>
+                if (resultContent !== undefined && resultContent !== null) {
+                  const displayText =
+                    typeof resultContent === "string"
+                      ? resultContent.slice(0, 500) +
+                        (resultContent.length > 500 ? "..." : "")
+                      : JSON.stringify(resultContent, null, 2);
+
+                  return (
+                    <div>
+                      <span className="text-muted-foreground font-medium">
+                        Result
+                      </span>
+                      <pre className="mt-1 p-2 bg-background/60 rounded text-[10px] overflow-x-auto max-h-48 font-mono whitespace-pre-wrap">
+                        {displayText}
+                      </pre>
+                    </div>
+                  );
+                }
+                return null;
+              })()}
+
+              {(!toolCall.arguments ||
+                Object.keys(toolCall.arguments).length === 0) &&
+                (toolCall.result === undefined || toolCall.result === null) && (
+                  <div className="text-muted-foreground/60 italic py-2">
+                    No details available
+                  </div>
+                )}
+
+              {onOpenDetail && (
+                <button
+                  onClick={() =>
+                    onOpenDetail(getDetailType(toolCall.name), toolCall)
+                  }
+                  className="text-[10px] text-muted-foreground hover:text-foreground hover:underline"
+                >
+                  View full details →
+                </button>
+              )}
+            </div>
+          </CollapsibleContent>
+
+          <PermissionApprovalBar toolCall={toolCall} />
+        </div>
+      </Collapsible>
+
+      {!!toolCall.questions?.length && (
+        <QuestionCard
+          toolCallId={toolCall.id}
+          questions={toolCall.questions}
+          isCompleted={toolCall.status === "completed"}
+        />
+      )}
+    </div>
   );
 });

--- a/packages/app/src/components/chat/__tests__/tool-call-utils.test.ts
+++ b/packages/app/src/components/chat/__tests__/tool-call-utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { ToolCall } from "@/stores/session";
+import { isCommandToolLikelyWaitingForInput } from "../tool-calls/tool-call-utils";
+import {
+  buildTerminalInputQuestion,
+  getCommandText,
+  getTerminalPromptKind,
+  getToolCallOutputText,
+  isTerminalCancelAnswer,
+} from "@/lib/terminal-interaction";
+
+function makeToolCall(overrides: Partial<ToolCall> = {}): ToolCall {
+  return {
+    id: "tc-1",
+    name: "bash",
+    status: "calling",
+    arguments: {},
+    startTime: new Date(),
+    ...overrides,
+  };
+}
+
+describe("tool-call-utils", () => {
+  it("extracts command text from common argument keys", () => {
+    expect(getCommandText({ command: "pnpm install" })).toBe("pnpm install");
+    expect(getCommandText({ cmd: "npm test" })).toBe("npm test");
+    expect(getCommandText({ input: "git status" })).toBe("git status");
+  });
+
+  it("extracts output text from structured tool results", () => {
+    expect(getToolCallOutputText({ output: "hello" })).toBe("hello");
+    expect(getToolCallOutputText({ raw: "world" })).toBe("world");
+    expect(getToolCallOutputText("plain")).toBe("plain");
+  });
+
+  it("detects confirmation prompts in terminal output", () => {
+    const toolCall = makeToolCall({
+      result: "This will remove files. Continue? [y/N]",
+    });
+
+    expect(isCommandToolLikelyWaitingForInput(toolCall)).toBe(true);
+  });
+
+  it("detects password prompts in terminal output", () => {
+    const toolCall = makeToolCall({
+      result: "Password:",
+    });
+
+    expect(isCommandToolLikelyWaitingForInput(toolCall)).toBe(true);
+  });
+
+  it("does not flag completed or normal command output", () => {
+    const completedToolCall = makeToolCall({
+      status: "completed",
+      result: "Done",
+    });
+    const normalRunningToolCall = makeToolCall({
+      result: "Installing dependencies...\nFetched 14 packages",
+    });
+
+    expect(isCommandToolLikelyWaitingForInput(completedToolCall)).toBe(false);
+    expect(isCommandToolLikelyWaitingForInput(normalRunningToolCall)).toBe(false);
+  });
+
+  it("builds a yes/no terminal input question from the prompt", () => {
+    const question = buildTerminalInputQuestion(
+      "rm -rf build",
+      "This will remove files. Continue? [y/N]",
+    );
+
+    expect(question.header).toBe("Terminal Input");
+    expect(question.question).toContain("rm -rf build");
+    expect(question.options.map((option) => option.value)).toEqual(["yes", "no", "cancel"]);
+  });
+
+  it("classifies password prompts and cancel answers", () => {
+    expect(getTerminalPromptKind("Password:")).toBe("password");
+    expect(getTerminalPromptKind("Press Enter to continue")).toBe("continue");
+    expect(isTerminalCancelAnswer("cancel")).toBe(true);
+    expect(isTerminalCancelAnswer("yes")).toBe(false);
+  });
+});

--- a/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
+++ b/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
@@ -17,11 +17,21 @@ import { ToolCall, useSessionStore, convertMessage } from "@/stores/session";
 import { useStreamingStore } from "@/stores/streaming";
 import { useWorkspaceStore } from "@/stores/workspace";
 import {
+  getCommandText,
+  getToolCallOutputText,
+} from "@/lib/terminal-interaction";
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { statusConfig, formatToolName, useToolCallTimeout, isCommandTool } from "./tool-call-utils";
+import {
+  statusConfig,
+  formatToolName,
+  useToolCallTimeout,
+  isCommandTool,
+  isCommandToolLikelyWaitingForInput,
+} from "./tool-call-utils";
 
 // Skill Tool Card - Shows skill execution inline
 export function SkillToolCard({ toolCall }: { toolCall: ToolCall }) {
@@ -514,23 +524,9 @@ function SubagentToolCallItem({ toolCall }: { toolCall: ToolCall }) {
   }
 
   if (isCommandTool(toolCall.name)) {
-    const command =
-      (typeof args?.command === "string" ? args.command : null) ||
-      (typeof args?.cmd === "string" ? args.cmd : null) ||
-      (typeof args?.input === "string" ? args.input : null) ||
-      "";
-    const outputRaw = toolCall.result;
-    const output =
-      typeof outputRaw === "string"
-        ? outputRaw
-        : outputRaw != null && typeof outputRaw === "object"
-          ? String(
-              (outputRaw as Record<string, unknown>).raw ??
-                (outputRaw as Record<string, unknown>).output ??
-                (outputRaw as Record<string, unknown>).result ??
-                "",
-            )
-          : "";
+    const command = getCommandText(args);
+    const output = getToolCallOutputText(toolCall.result);
+    const isWaitingForInput = isCommandToolLikelyWaitingForInput(toolCall);
     const cmdSummary = command ? (command.length > 80 ? `${command.slice(0, 80)}…` : command) : null;
     return (
       <Collapsible open={expanded} onOpenChange={setExpanded}>
@@ -552,7 +548,12 @@ function SubagentToolCallItem({ toolCall }: { toolCall: ToolCall }) {
                   {cmdSummary}
                 </span>
               )}
-              {output !== "" && (
+              {isWaitingForInput ? (
+                <span className="flex items-center gap-1 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800 border border-amber-200">
+                  <AlertTriangle size={10} />
+                  Input needed
+                </span>
+              ) : output !== "" && (
                 <span className="text-[10px] text-muted-foreground">
                   {toolCall.status === "completed" ? "✓" : toolCall.status === "failed" ? "✗" : "..."}
                 </span>
@@ -561,6 +562,17 @@ function SubagentToolCallItem({ toolCall }: { toolCall: ToolCall }) {
           </CollapsibleTrigger>
           <CollapsibleContent>
             <div className="border-t border-border/50 p-2 space-y-2 bg-muted/10">
+              {isWaitingForInput && (
+                <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-2 text-[11px] text-amber-900">
+                  <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                  <div>
+                    <p className="font-medium">This command looks like it is waiting for terminal input.</p>
+                    <p className="text-amber-800/90">
+                      Prefer non-interactive flags like `--yes` or `-y`, or ask a question before continuing.
+                    </p>
+                  </div>
+                </div>
+              )}
               <div>
                 <label className="text-[10px] text-muted-foreground">Command</label>
                 <div className="mt-1 flex items-center gap-2 p-2 bg-bg-tertiary rounded-md text-xs font-mono">

--- a/packages/app/src/components/chat/tool-calls/tool-call-utils.ts
+++ b/packages/app/src/components/chat/tool-calls/tool-call-utils.ts
@@ -12,6 +12,10 @@ import {
   X,
 } from "lucide-react";
 import type { ToolCall } from "@/stores/session";
+import {
+  getToolCallOutputText,
+  isLikelyTerminalPromptText,
+} from "@/lib/terminal-interaction";
 
 export const statusConfig = {
   calling: {
@@ -121,6 +125,19 @@ export function isCommandTool(toolName: string): boolean {
     name.includes("terminal") ||
     name.includes("run_command")
   );
+}
+
+export function isCommandToolLikelyWaitingForInput(
+  toolCall: Pick<ToolCall, "name" | "status" | "arguments" | "result">,
+): boolean {
+  if (!isCommandTool(toolCall.name) || toolCall.status !== "calling") {
+    return false;
+  }
+
+  const output = getToolCallOutputText(toolCall.result).trim();
+  if (!output) return false;
+
+  return isLikelyTerminalPromptText(output);
 }
 
 // Check if this is a Task tool (subagent)

--- a/packages/app/src/lib/terminal-interaction.ts
+++ b/packages/app/src/lib/terminal-interaction.ts
@@ -1,0 +1,166 @@
+import type { Question } from "@/lib/opencode/types";
+
+export type TerminalPromptKind =
+  | "confirm"
+  | "password"
+  | "selection"
+  | "continue"
+  | "generic";
+
+const INTERACTIVE_TERMINAL_PATTERNS = [
+  /(?:^|\n)\s*(?:password|passphrase)(?: for .*?)?:\s*$/im,
+  /\[(?:Y\/n|y\/N|y\/n|Y\/N)\]/,
+  /\((?:y\/n|yes\/no)\)/i,
+  /(?:are you sure|continue\?|proceed\?|confirm)/i,
+  /do you want to continue/i,
+  /press (?:enter|return|any key)/i,
+  /\btype\s+['"`]?(?:yes|y|no|n)['"`]?\s+to continue/i,
+  /enter (?:your )?(?:choice|selection|password|passphrase)/i,
+  /select (?:an option|a number|one of)/i,
+] as const;
+
+const YES_NO_PATTERNS = [/\[(?:Y\/n|y\/N|y\/n|Y\/N)\]/, /\((?:y\/n|yes\/no)\)/i] as const;
+const PASSWORD_PATTERN = /(?:^|\n)\s*(?:password|passphrase)(?: for .*?)?:\s*$/im;
+const CONTINUE_PATTERN = /press (?:enter|return|any key)/i;
+const SELECTION_PATTERN = /select (?:an option|a number|one of)|enter (?:your )?(?:choice|selection)/i;
+
+export function getTerminalPromptKind(output: string): TerminalPromptKind {
+  const normalized = output.trim();
+  if (!normalized) return "generic";
+  if (PASSWORD_PATTERN.test(normalized)) return "password";
+  if (YES_NO_PATTERNS.some((pattern) => pattern.test(normalized))) return "confirm";
+  if (CONTINUE_PATTERN.test(normalized)) return "continue";
+  if (SELECTION_PATTERN.test(normalized)) return "selection";
+  return "generic";
+}
+
+export function getCommandText(
+  args: Record<string, unknown> | undefined,
+): string {
+  if (!args) return "";
+  return (
+    (typeof args.command === "string" ? args.command : null) ||
+    (typeof args.cmd === "string" ? args.cmd : null) ||
+    (typeof args.input === "string" ? args.input : null) ||
+    ""
+  );
+}
+
+export function getToolCallOutputText(result: unknown): string {
+  if (typeof result === "string") return result;
+  if (result && typeof result === "object") {
+    const resultObj = result as Record<string, unknown>;
+    return (
+      (typeof resultObj.raw === "string" ? resultObj.raw : null) ||
+      (typeof resultObj.output === "string" ? resultObj.output : null) ||
+      (typeof resultObj.result === "string" ? resultObj.result : null) ||
+      (typeof resultObj.text === "string" ? resultObj.text : null) ||
+      ""
+    );
+  }
+  return "";
+}
+
+export function isLikelyTerminalPromptText(output: string): boolean {
+  const normalized = output.trim();
+  if (!normalized) return false;
+  return INTERACTIVE_TERMINAL_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function extractTerminalPromptSnippet(output: string): string {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0);
+
+  if (lines.length === 0) return "";
+
+  const tail = lines.slice(-4).join("\n").trim();
+  return tail.length > 280 ? tail.slice(-280) : tail;
+}
+
+export function makeSyntheticTerminalQuestionId(toolCallId: string): string {
+  return `terminal-input:${toolCallId}`;
+}
+
+export function isSyntheticTerminalQuestionId(questionId: string): boolean {
+  return questionId.startsWith("terminal-input:");
+}
+
+export function buildTerminalInputQuestion(
+  command: string,
+  output: string,
+): Question {
+  const prompt = extractTerminalPromptSnippet(output);
+  const promptKind = getTerminalPromptKind(prompt);
+
+  const options =
+    promptKind === "confirm"
+      ? [
+          { label: "Yes", value: "yes" },
+          { label: "No", value: "no" },
+          { label: "Cancel command", value: "cancel" },
+        ]
+      : promptKind === "continue"
+        ? [
+            { label: "Continue", value: "continue" },
+            { label: "Cancel command", value: "cancel" },
+          ]
+        : promptKind === "selection"
+          ? [{ label: "Cancel command", value: "cancel" }]
+          : promptKind === "password"
+            ? [{ label: "Cancel command", value: "cancel" }]
+            : [{ label: "Cancel command", value: "cancel" }];
+
+  return {
+    id: "terminal-input",
+    header: "Terminal Input",
+    question: [
+      "The terminal command is waiting for input.",
+      command ? `Command: ${command}` : "",
+      prompt ? `Prompt:\n${prompt}` : "",
+      "What should the assistant send or do next?",
+    ]
+      .filter(Boolean)
+      .join("\n\n"),
+    options,
+  };
+}
+
+export function isTerminalCancelAnswer(answer: string): boolean {
+  return ["cancel", "cancel command", "stop", "abort"].includes(
+    answer.trim().toLowerCase(),
+  );
+}
+
+export function buildTerminalInputFollowUpMessage(params: {
+  command: string;
+  prompt: string;
+  answer: string;
+  kind: TerminalPromptKind;
+}): string {
+  const { command, prompt, answer, kind } = params;
+
+  const instruction =
+    kind === "confirm"
+      ? "Retry or continue the task in a non-interactive way that applies the user's confirmation choice safely."
+      : kind === "password"
+        ? "If a secret is required, use the user-provided value carefully and avoid printing it back unnecessarily. Prefer a safer non-interactive path if available."
+        : kind === "continue"
+          ? "Continue the task without relying on another blocking terminal prompt if possible."
+          : kind === "selection"
+            ? "Continue the task using the user's selected input, and prefer a non-interactive retry."
+            : "Continue the task using the user's requested terminal input, and avoid another blocking prompt if possible.";
+
+  return [
+    "The previous terminal command got stuck waiting for interactive input.",
+    command ? `Command: \`${command}\`` : "",
+    prompt ? `Observed prompt:\n\`\`\`\n${prompt}\n\`\`\`` : "",
+    `User wants this response: \`${answer}\``,
+    "Please continue the task in the same session.",
+    instruction,
+    "If true stdin input is still required, explicitly ask before running another blocking command.",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/packages/app/src/stores/__tests__/session-messages-behavior.test.ts
+++ b/packages/app/src/stores/__tests__/session-messages-behavior.test.ts
@@ -160,13 +160,14 @@ describe('session store: message behavior', () => {
 
     it('calls sendMessageAsync with correct session and content', async () => {
       await useSessionStore.getState().sendMessage('test content');
-      expect(mockSendMessageAsync).toHaveBeenCalledWith(
-        'sess-1',
-        'test content',
-        undefined, // no model
-        undefined, // no agent
-        undefined, // no system prompt (localStorage empty in test)
-      );
+      expect(mockSendMessageAsync).toHaveBeenCalledTimes(1);
+      const callArgs = mockSendMessageAsync.mock.calls[0];
+      expect(callArgs[0]).toBe('sess-1');
+      expect(callArgs[1]).toBe('test content');
+      expect(callArgs[2]).toBeUndefined();
+      expect(callArgs[3]).toBeUndefined();
+      expect(callArgs[4]).toContain('Prefer non-interactive commands');
+      expect(callArgs[4]).toContain('ask the user first');
     });
 
     it('adds browser-routing system prompt for login-related web tasks', async () => {

--- a/packages/app/src/stores/__tests__/session-questions.test.ts
+++ b/packages/app/src/stores/__tests__/session-questions.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createQuestionActions } from "@/stores/session-questions";
+import { sessionDataCache } from "@/stores/session-data-cache";
+
+const mockReplyQuestion = vi.fn();
+
+vi.mock("@/lib/opencode/client", () => ({
+  getOpenCodeClient: () => ({
+    replyQuestion: mockReplyQuestion,
+  }),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: vi.fn(() => ({
+    setFocus: vi.fn(),
+    unminimize: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/notification-service", () => ({
+  notificationService: { send: vi.fn() },
+}));
+
+vi.mock("@/lib/build-config", () => ({
+  buildConfig: { app: { name: "TeamClaw" } },
+}));
+
+const mockStreamingState = {
+  streamingMessageId: "msg-1" as string | null,
+  clearStreaming: vi.fn(),
+};
+
+vi.mock("@/stores/streaming", () => ({
+  useStreamingStore: Object.assign(
+    (selector: (s: typeof mockStreamingState) => unknown) => selector(mockStreamingState),
+    { getState: () => mockStreamingState },
+  ),
+}));
+
+describe("session-questions", () => {
+  let state: Record<string, unknown>;
+  let set: ReturnType<typeof vi.fn>;
+  let get: ReturnType<typeof vi.fn>;
+  let actions: ReturnType<typeof createQuestionActions>;
+  let abortSession: ReturnType<typeof vi.fn>;
+  let sendMessage: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionDataCache.clear();
+
+    abortSession = vi.fn().mockResolvedValue(undefined);
+    sendMessage = vi.fn().mockResolvedValue(undefined);
+
+    state = {
+      activeSessionId: "sess-1",
+      pendingQuestion: {
+        questionId: "terminal-input:tc-1",
+        toolCallId: "tc-1",
+        messageId: "msg-1",
+        source: "terminal_input",
+        terminalInputContext: {
+          command: "rm -rf build",
+          prompt: "Continue? [y/N]",
+          kind: "confirm",
+        },
+        questions: [
+          {
+            id: "terminal-input",
+            header: "Terminal Input",
+            question: "Continue?",
+            options: [{ label: "Yes", value: "yes" }, { label: "No", value: "no" }],
+          },
+        ],
+      },
+      sessions: [
+        {
+          id: "sess-1",
+          title: "Test",
+          messages: [
+            {
+              id: "msg-1",
+              toolCalls: [
+                {
+                  id: "tc-1",
+                  name: "bash",
+                  status: "waiting",
+                  arguments: { command: "rm -rf build" },
+                  questions: [
+                    {
+                      id: "terminal-input",
+                      header: "Terminal Input",
+                      question: "Continue?",
+                      options: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      abortSession,
+      sendMessage,
+    };
+
+    sessionDataCache.set("sess-1", { todos: [], diff: [], pendingQuestion: state.pendingQuestion as any });
+
+    set = vi.fn((updater) => {
+      if (typeof updater === "function") {
+        Object.assign(state, updater(state as any));
+      } else {
+        Object.assign(state, updater);
+      }
+    });
+    get = vi.fn(() => state);
+    actions = createQuestionActions(set, get);
+  });
+
+  it("aborts the stuck run and sends a follow-up message for synthetic terminal questions", async () => {
+    await actions.answerQuestion({ "terminal-input": "yes" });
+
+    expect(abortSession).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0][0]).toContain("User wants this response: `yes`");
+    expect(sendMessage.mock.calls[0][0]).toContain("rm -rf build");
+    expect((state as any).pendingQuestion).toBeNull();
+    expect(mockReplyQuestion).not.toHaveBeenCalled();
+  });
+
+  it("aborts and clears state without sending follow-up when user cancels", async () => {
+    await actions.answerQuestion({ "terminal-input": "cancel" });
+
+    expect(abortSession).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect((state as any).pendingQuestion).toBeNull();
+    expect(mockReplyQuestion).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/stores/__tests__/session-sse-tool-handlers.test.ts
+++ b/packages/app/src/stores/__tests__/session-sse-tool-handlers.test.ts
@@ -147,6 +147,29 @@ describe('session-sse-tool-handlers', () => {
     expect(stateMutations).toHaveLength(0)
   })
 
+  it('creates a synthetic question when a command waits for input', () => {
+    handlers.handleToolExecuting({
+      toolCallId: 'tc-bash-1',
+      toolName: 'bash',
+      status: 'running',
+      arguments: { command: 'rm -rf build' },
+      result: 'This will remove files. Continue? [y/N]',
+      sessionId: 'sess-1',
+      messageId: 'msg-assist-1',
+    } as any)
+
+    expect((state as any).pendingQuestion).toMatchObject({
+      questionId: 'terminal-input:tc-bash-1',
+      toolCallId: 'tc-bash-1',
+      source: 'terminal_input',
+    })
+
+    const session = sessionLookupCache.get('sess-1')
+    const toolCall = session?.messages[0]?.toolCalls?.find((t: any) => t.id === 'tc-bash-1')
+    expect(toolCall?.status).toBe('waiting')
+    expect(toolCall?.questions?.[0]?.header).toBe('Terminal Input')
+  })
+
   it('handleTodoUpdated sets todos in state and caches them', () => {
     const todos = [
       { id: 't1', content: 'Fix bug', status: 'pending', priority: 'high' },

--- a/packages/app/src/stores/session-data-cache.ts
+++ b/packages/app/src/stores/session-data-cache.ts
@@ -1,13 +1,8 @@
-import type { Todo, FileDiff, Question } from "@/lib/opencode/types";
-import type { QueuedMessage } from "./session-types";
+import type { Todo, FileDiff } from "@/lib/opencode/types";
+import type { PendingQuestionState, QueuedMessage } from "./session-types";
 
 // Pending question data cached per session
-export interface CachedPendingQuestion {
-  questionId: string;
-  toolCallId: string;
-  messageId: string;
-  questions: Question[];
-}
+export type CachedPendingQuestion = PendingQuestionState;
 
 // Cache for session-specific data (todos, diff, message queue, and pending questions)
 // Shared across session action modules

--- a/packages/app/src/stores/session-messages.ts
+++ b/packages/app/src/stores/session-messages.ts
@@ -35,6 +35,14 @@ const LOGIN_RELATED_PROMPT = [
   "Use webfetch only for public pages that do not require authentication or interactive browser state.",
 ].join(" ");
 
+const TERMINAL_NON_INTERACTIVE_PROMPT = [
+  "Terminal execution rule:",
+  "Prefer non-interactive commands.",
+  "If a command may wait for confirmation, passwords, editor input, or stdin, do not run it in interactive mode.",
+  "First look for safe non-interactive flags or env such as `--yes`, `-y`, `--force`, `CI=1`, `DEBIAN_FRONTEND=noninteractive`, `GIT_PAGER=cat`, or `PAGER=cat` when appropriate.",
+  "If the task truly requires user confirmation and there is no safe non-interactive form, ask the user first instead of starting a command that waits on terminal input.",
+].join(" ");
+
 const LOGIN_RELATED_PATTERNS = [
   /\b(login|log in|sign in|signin|authenticate|authentication|reauth|oauth|sso|mfa|2fa|captcha|cookie|cookies|session)\b/i,
   /(登录|登陆|认证|鉴权|授权|会话|cookie|验证码|二次验证|双因子|单点登录)/i,
@@ -300,6 +308,11 @@ export function createMessageActions(set: SessionSet, get: SessionGet) {
         if (shouldPreferInteractiveBrowserForMessage(content)) {
           systemPrompt = appendSystemPrompt(systemPrompt, LOGIN_RELATED_PROMPT);
         }
+
+        systemPrompt = appendSystemPrompt(
+          systemPrompt,
+          TERMINAL_NON_INTERACTIVE_PROMPT,
+        );
 
         if (ragResult.chunks && ragResult.chunks.length > 0) {
           set((state) => {

--- a/packages/app/src/stores/session-questions.ts
+++ b/packages/app/src/stores/session-questions.ts
@@ -17,6 +17,11 @@ import {
   useStreamingStore,
 } from "@/stores/streaming";
 import { sessionDataCache } from "./session-data-cache";
+import {
+  buildTerminalInputFollowUpMessage,
+  isTerminalCancelAnswer,
+  isSyntheticTerminalQuestionId,
+} from "@/lib/terminal-interaction";
 
 type SessionSet = (fn: ((state: SessionState) => Partial<SessionState>) | Partial<SessionState>) => void;
 type SessionGet = () => SessionState;
@@ -46,6 +51,63 @@ export function createQuestionActions(set: SessionSet, get: SessionGet) {
           pendingQuestion.questionId,
         );
         console.log("[Question] Answers:", formattedAnswers);
+
+        if (
+          pendingQuestion.source === "terminal_input" ||
+          isSyntheticTerminalQuestionId(pendingQuestion.questionId)
+        ) {
+          const answerText = formattedAnswers.flat().join("; ").trim();
+          const streamingMessageId = useStreamingStore.getState().streamingMessageId;
+
+          if (streamingMessageId) {
+            await get().abortSession();
+          }
+
+          set((state) => ({
+            sessions: state.sessions.map((s) =>
+              s.id === activeSessionId
+                ? {
+                    ...s,
+                    messages: s.messages.map((m) => ({
+                      ...m,
+                      toolCalls: m.toolCalls?.map((tc) =>
+                        tc.id === pendingQuestion.toolCallId
+                          ? {
+                              ...tc,
+                              status: "failed" as const,
+                              questions: undefined,
+                            }
+                          : tc,
+                      ),
+                    })),
+                    updatedAt: new Date(),
+                  }
+                : s,
+            ),
+            pendingQuestion: null,
+          }));
+
+          if (activeSessionId) {
+            const cached = sessionDataCache.get(activeSessionId);
+            if (cached) {
+              sessionDataCache.set(activeSessionId, { ...cached, pendingQuestion: null });
+            }
+          }
+
+          if (isTerminalCancelAnswer(answerText)) {
+            return;
+          }
+
+          const followUp = buildTerminalInputFollowUpMessage({
+            command: pendingQuestion.terminalInputContext?.command || "",
+            prompt: pendingQuestion.terminalInputContext?.prompt || "",
+            answer: answerText,
+            kind: pendingQuestion.terminalInputContext?.kind || "generic",
+          });
+
+          await get().sendMessage(followUp);
+          return;
+        }
 
         try {
           await client.replyQuestion(
@@ -145,6 +207,7 @@ export function createQuestionActions(set: SessionSet, get: SessionGet) {
           streamingMessageId ||
           "",
         questions: event.questions || existing?.questions || [],
+        source: "opencode" as const,
       };
 
       if (event.sessionId !== activeSessionId) {

--- a/packages/app/src/stores/session-sse-tool-handlers.ts
+++ b/packages/app/src/stores/session-sse-tool-handlers.ts
@@ -23,6 +23,14 @@ import {
   useStreamingStore,
 } from "@/stores/streaming";
 import { sessionDataCache } from "./session-data-cache";
+import {
+  buildTerminalInputQuestion,
+  extractTerminalPromptSnippet,
+  getCommandText,
+  getTerminalPromptKind,
+  getToolCallOutputText,
+  isLikelyTerminalPromptText,
+} from "@/lib/terminal-interaction";
 
 type SessionSet = (fn: ((state: SessionState) => Partial<SessionState>) | Partial<SessionState>) => void;
 type SessionGet = () => SessionState;
@@ -55,12 +63,67 @@ export function createToolHandlers(set: SessionSet, get: SessionGet) {
 
       const isQuestionTool = event.toolName.toLowerCase() === "question";
       const isRunning = event.status === "running";
+      const toolNameLower = event.toolName.toLowerCase();
+      const isCommandTool =
+        toolNameLower.includes("bash") ||
+        toolNameLower.includes("shell") ||
+        toolNameLower.includes("terminal") ||
+        toolNameLower.includes("run_command");
+      const commandText = getCommandText(event.arguments);
+      const outputText = getToolCallOutputText(event.result);
+      const needsTerminalInput =
+        isCommandTool &&
+        isRunning &&
+        isLikelyTerminalPromptText(outputText);
 
       let questions: Question[] | undefined;
       if (isQuestionTool && event.arguments) {
         const args = event.arguments as unknown as QuestionToolInput;
         if (args.questions && Array.isArray(args.questions)) {
           questions = args.questions;
+        }
+      }
+
+      if (needsTerminalInput) {
+        const promptSnippet = extractTerminalPromptSnippet(outputText);
+        questions = [buildTerminalInputQuestion(commandText, outputText)];
+
+        const questionData = {
+          questionId: `terminal-input:${event.toolCallId}`,
+          toolCallId: event.toolCallId,
+          messageId: streamingMessageId,
+          questions,
+          source: "terminal_input" as const,
+          terminalInputContext: {
+            command: commandText,
+            prompt: promptSnippet,
+            kind: getTerminalPromptKind(promptSnippet),
+          },
+        };
+
+        const existing = get().pendingQuestion;
+        if (
+          !existing ||
+          existing.source !== "opencode" ||
+          existing.toolCallId === event.toolCallId
+        ) {
+          set({ pendingQuestion: questionData });
+          if (activeSessionId) {
+            const cached = sessionDataCache.get(activeSessionId) || { todos: [], diff: [] };
+            sessionDataCache.set(activeSessionId, { ...cached, pendingQuestion: questionData });
+          }
+        }
+      } else if (
+        get().pendingQuestion?.source === "terminal_input" &&
+        get().pendingQuestion?.toolCallId === event.toolCallId &&
+        event.status !== "running"
+      ) {
+        set({ pendingQuestion: null });
+        if (activeSessionId) {
+          const cached = sessionDataCache.get(activeSessionId);
+          if (cached) {
+            sessionDataCache.set(activeSessionId, { ...cached, pendingQuestion: null });
+          }
         }
       }
 
@@ -113,7 +176,9 @@ export function createToolHandlers(set: SessionSet, get: SessionGet) {
         );
 
         if (existingTool) {
-          const newStatus = mapStatus(event.status);
+          const newStatus = needsTerminalInput
+            ? "waiting"
+            : mapStatus(event.status);
           updatedMessage = {
             ...m,
             toolCalls: m.toolCalls?.map((tc) =>
@@ -132,7 +197,11 @@ export function createToolHandlers(set: SessionSet, get: SessionGet) {
                       (newStatus === "completed" && tc.startTime
                         ? Date.now() - tc.startTime.getTime()
                         : tc.duration),
-                    questions: questions || tc.questions,
+                    questions:
+                      questions ||
+                      (event.status === "completed" || event.status === "failed"
+                        ? undefined
+                        : tc.questions),
                     metadata: event.metadata || tc.metadata,
                   }
                 : tc,
@@ -143,7 +212,7 @@ export function createToolHandlers(set: SessionSet, get: SessionGet) {
           const newToolCall: ToolCall = {
             id: event.toolCallId,
             name: event.toolName,
-            status: mapStatus(event.status),
+            status: needsTerminalInput ? "waiting" : mapStatus(event.status),
             arguments: event.arguments || {},
             result: event.result,
             duration: event.duration,

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -9,6 +9,7 @@ import type {
   SessionErrorEvent,
   SendMessageFilePart,
 } from '@/lib/opencode/types';
+import type { TerminalPromptKind } from "@/lib/terminal-interaction";
 import type {
   SessionCreatedEvent,
   SessionUpdatedEvent,
@@ -65,6 +66,19 @@ export interface ToolCall {
         title?: string;
       };
     }>;
+  };
+}
+
+export interface PendingQuestionState {
+  questionId: string; // The question.asked event ID, or a local synthetic question id
+  toolCallId: string;
+  messageId: string;
+  questions: Question[];
+  source?: "opencode" | "terminal_input";
+  terminalInputContext?: {
+    command?: string;
+    prompt?: string;
+    kind?: TerminalPromptKind;
   };
 }
 
@@ -169,12 +183,7 @@ export interface SessionState {
   pendingPermissionChildSessionId: string | null;
 
   // Pending question (from question tool)
-  pendingQuestion: {
-    questionId: string; // The question.asked event ID
-    toolCallId: string;
-    messageId: string;
-    questions: Question[];
-  } | null;
+  pendingQuestion: PendingQuestionState | null;
 
   // Todo list (from todowrite tool)
   todos: Todo[];
@@ -240,12 +249,7 @@ export interface SessionState {
   // Actions - Question
   answerQuestion: (answers: Record<string, string>) => Promise<void>;
   setPendingQuestion: (
-    question: {
-      questionId: string;
-      toolCallId: string;
-      messageId: string;
-      questions: Question[];
-    } | null,
+    question: PendingQuestionState | null,
   ) => void;
   handleQuestionAsked: (event: QuestionAskedEvent) => void;
 


### PR DESCRIPTION
## Summary
- detect when command-style tool calls are blocked on terminal input and surface a synthetic question instead of leaving the run looking stuck
- add UI affordances for input-needed states, including safer password entry handling and clearer guidance for non-interactive retries
- append a non-interactive terminal execution rule to outgoing prompts and cover the new flow with focused store and tool utility tests

## Test plan
- [x] `cd packages/app && pnpm vitest run src/components/chat/__tests__/tool-call-utils.test.ts src/stores/__tests__/session-questions.test.ts src/stores/__tests__/session-sse-tool-handlers.test.ts src/stores/__tests__/session-messages-behavior.test.ts`
- [ ] Trigger a command that prompts for confirmation and verify the chat shows an input-needed question flow
- [ ] Trigger a password-style prompt and verify the input field is masked

Made with [Cursor](https://cursor.com)