### PR TITLE
fix(p2p): robustness fixes for sync engine and member status

### DIFF
--- a/packages/app/src/components/NodeStatusPopover.tsx
+++ b/packages/app/src/components/NodeStatusPopover.tsx
@@ -1,0 +1,206 @@
+import * as React from "react"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Separator } from "@/components/ui/separator"
+import { useP2pEngineStore, PeerInfo, PeerConnection } from "@/stores/p2p-engine"
+import { cn } from "@/lib/utils"
+
+// ─── Helper functions ────────────────────────────────────────────────────────
+
+function connectionDot(connection: PeerConnection): string {
+  switch (connection) {
+    case "active":
+      return "bg-emerald-500"
+    case "stale":
+      return "bg-amber-500"
+    case "lost":
+      return "bg-red-500"
+    case "unknown":
+    default:
+      return "bg-muted-foreground/40"
+  }
+}
+
+function connectionLabel(connection: PeerConnection, lastSeenSecsAgo: number): string {
+  switch (connection) {
+    case "active":
+      return "Active"
+    case "stale": {
+      if (lastSeenSecsAgo < 60) return `Stale ${lastSeenSecsAgo}s`
+      const mins = Math.floor(lastSeenSecsAgo / 60)
+      return `Stale ${mins}m`
+    }
+    case "lost": {
+      if (lastSeenSecsAgo < 60) return `Lost ${lastSeenSecsAgo}s`
+      const mins = Math.floor(lastSeenSecsAgo / 60)
+      if (mins < 60) return `Lost ${mins}m`
+      const hrs = Math.floor(mins / 60)
+      return `Lost ${hrs}h`
+    }
+    case "unknown":
+    default:
+      return "Unknown"
+  }
+}
+
+function formatLastSync(iso: string | null): string {
+  if (!iso) return "Never"
+  const date = new Date(iso)
+  const secsAgo = Math.floor((Date.now() - date.getTime()) / 1000)
+  if (secsAgo < 5) return "Just now"
+  if (secsAgo < 60) return `${secsAgo}s ago`
+  const mins = Math.floor(secsAgo / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  const days = Math.floor(hrs / 24)
+  return `${days}d ago`
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function StatusDot({ className }: { className: string }) {
+  return (
+    <span className={cn("inline-block h-2 w-2 shrink-0 rounded-full", className)} />
+  )
+}
+
+function PeerRow({ peer }: { peer: PeerInfo }) {
+  const displayName = peer.name || peer.nodeId.slice(0, 8) + "…"
+  const dotColor = connectionDot(peer.connection)
+  const label = connectionLabel(peer.connection, peer.lastSeenSecsAgo)
+
+  return (
+    <div className="flex items-center gap-2 py-0.5">
+      <StatusDot className={dotColor} />
+      <span className="flex-1 min-w-0 truncate text-xs text-foreground">
+        {displayName}
+      </span>
+      <span className="shrink-0 text-[10px] text-muted-foreground capitalize">
+        {peer.role}
+      </span>
+      <span
+        className={cn(
+          "shrink-0 text-[10px]",
+          peer.connection === "active"
+            ? "text-emerald-500"
+            : peer.connection === "stale"
+            ? "text-amber-500"
+            : peer.connection === "lost"
+            ? "text-red-500"
+            : "text-muted-foreground"
+        )}
+      >
+        {label}
+      </span>
+    </div>
+  )
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function NodeStatusPopover({ children }: { children: React.ReactNode }) {
+  const snapshot = useP2pEngineStore((s) => s.snapshot)
+  const fetchSnapshot = useP2pEngineStore((s) => s.fetch)
+
+  const handleMouseEnter = () => {
+    void fetchSnapshot()
+  }
+
+  // Derive display status
+  const { status, streamHealth, restartCount, lastSyncAt, peers, syncedFiles, pendingFiles } =
+    snapshot
+
+  const isHealthy = status === "connected" && streamHealth === "healthy"
+  const isDegraded = status === "connected" && streamHealth !== "healthy"
+  const isReconnecting = status === "reconnecting"
+  const isDisconnected = status === "disconnected"
+
+  const statusDotColor = isHealthy
+    ? "bg-emerald-500"
+    : isDegraded || isReconnecting
+    ? "bg-amber-500"
+    : "bg-red-500"
+
+  const statusLabel = isHealthy
+    ? "Connected"
+    : isDegraded
+    ? "Degraded"
+    : isReconnecting
+    ? "Reconnecting..."
+    : "Disconnected"
+
+  const showEngineInfo = !isHealthy && streamHealth !== "healthy"
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild onMouseEnter={handleMouseEnter}>
+        {/* Wrap children so we get onMouseEnter on the trigger */}
+        <span className="contents">{children}</span>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        className="w-72 p-3 bg-card text-card-foreground"
+        onMouseEnter={handleMouseEnter}
+      >
+        {/* ── Header ── */}
+        <div className="flex items-center gap-2 mb-2">
+          <StatusDot className={statusDotColor} />
+          <span className="text-xs font-medium">{statusLabel}</span>
+        </div>
+
+        {showEngineInfo && (
+          <div className="mb-2 space-y-0.5">
+            <p className="text-[10px] text-muted-foreground">
+              Engine: {streamHealth}
+            </p>
+            {restartCount > 0 && (
+              <p className="text-[10px] text-muted-foreground">
+                Restarts: {restartCount}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* ── Stats ── */}
+        <div className="space-y-1 mb-1">
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] text-muted-foreground">Last sync</span>
+            <span className="text-[10px] text-foreground">{formatLastSync(lastSyncAt)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] text-muted-foreground">Synced files</span>
+            <span className="text-[10px] text-foreground">{syncedFiles}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] text-muted-foreground">Pending files</span>
+            <span
+              className={cn(
+                "text-[10px]",
+                pendingFiles > 0 ? "text-amber-500" : "text-foreground"
+              )}
+            >
+              {pendingFiles}
+            </span>
+          </div>
+        </div>
+
+        {/* ── Peers ── */}
+        {peers.length > 0 && (
+          <>
+            <Separator className="my-2" />
+            <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1.5">
+              Team Members ({peers.length})
+            </p>
+            <div className="space-y-0.5">
+              {peers.map((peer) => (
+                <PeerRow key={peer.nodeId} peer={peer} />
+              ))}
+            </div>
+          </>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/packages/app/src/components/NodeStatusPopover.tsx
+++ b/packages/app/src/components/NodeStatusPopover.tsx
@@ -108,19 +108,14 @@ export function NodeStatusPopover({ children }: { children: React.ReactNode }) {
   const snapshot = useP2pEngineStore((s) => s.snapshot)
   const fetchSnapshot = useP2pEngineStore((s) => s.fetch)
   const members = useTeamMembersStore((s) => s.members)
+  const currentNodeId = useTeamMembersStore((s) => s.currentNodeId)
+  const loadCurrentNodeId = useTeamMembersStore((s) => s.loadCurrentNodeId)
   const [open, setOpen] = React.useState(false)
-  const [currentNodeId, setCurrentNodeId] = React.useState<string | null>(null)
   const closeTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
   React.useEffect(() => {
     if (!isTauri()) return
-    let cancelled = false
-    import("@tauri-apps/api/core").then(({ invoke }) =>
-      invoke<{ nodeId: string }>("get_device_info")
-        .then((info) => { if (!cancelled) setCurrentNodeId(info.nodeId) })
-        .catch(() => {})
-    )
-    return () => { cancelled = true }
+    loadCurrentNodeId()
   }, [])
 
   const cancelClose = () => {

--- a/packages/app/src/components/NodeStatusPopover.tsx
+++ b/packages/app/src/components/NodeStatusPopover.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Separator } from "@/components/ui/separator"
-import { useP2pEngineStore, PeerInfo, PeerConnection } from "@/stores/p2p-engine"
-import { cn } from "@/lib/utils"
+import { useP2pEngineStore, type PeerConnection } from "@/stores/p2p-engine"
+import { useTeamMembersStore } from "@/stores/team-members"
+import { cn, isTauri } from "@/lib/utils"
 
 // ─── Helper functions ────────────────────────────────────────────────────────
 
@@ -23,18 +24,18 @@ function connectionDot(connection: PeerConnection): string {
 function connectionLabel(connection: PeerConnection, lastSeenSecsAgo: number): string {
   switch (connection) {
     case "active":
-      return "Active"
+      return "Online"
     case "stale": {
       if (lastSeenSecsAgo < 60) return `Stale ${lastSeenSecsAgo}s`
       const mins = Math.floor(lastSeenSecsAgo / 60)
       return `Stale ${mins}m`
     }
     case "lost": {
-      if (lastSeenSecsAgo < 60) return `Lost ${lastSeenSecsAgo}s`
+      if (lastSeenSecsAgo < 60) return `Offline ${lastSeenSecsAgo}s`
       const mins = Math.floor(lastSeenSecsAgo / 60)
-      if (mins < 60) return `Lost ${mins}m`
+      if (mins < 60) return `Offline ${mins}m`
       const hrs = Math.floor(mins / 60)
-      return `Lost ${hrs}h`
+      return `Offline ${hrs}h`
     }
     case "unknown":
     default:
@@ -64,32 +65,37 @@ function StatusDot({ className }: { className: string }) {
   )
 }
 
-function PeerRow({ peer }: { peer: PeerInfo }) {
-  const displayName = peer.name || peer.nodeId.slice(0, 8) + "…"
-  const dotColor = connectionDot(peer.connection)
-  const label = connectionLabel(peer.connection, peer.lastSeenSecsAgo)
+interface MemberRowProps {
+  name: string
+  role: string
+  isLocal: boolean
+  connection: PeerConnection
+  lastSeenSecsAgo: number
+}
+
+function MemberRow({ name, role, isLocal, connection, lastSeenSecsAgo }: MemberRowProps) {
+  const dotColor = isLocal ? "bg-blue-500" : connectionDot(connection)
+  const label = isLocal ? "This device" : connectionLabel(connection, lastSeenSecsAgo)
+  const labelColor = isLocal
+    ? "text-blue-500"
+    : connection === "active"
+    ? "text-emerald-500"
+    : connection === "stale"
+    ? "text-amber-500"
+    : connection === "lost"
+    ? "text-red-500"
+    : "text-muted-foreground"
 
   return (
     <div className="flex items-center gap-2 py-0.5">
       <StatusDot className={dotColor} />
       <span className="flex-1 min-w-0 truncate text-xs text-foreground">
-        {displayName}
+        {name}
       </span>
       <span className="shrink-0 text-[10px] text-muted-foreground capitalize">
-        {peer.role}
+        {role}
       </span>
-      <span
-        className={cn(
-          "shrink-0 text-[10px]",
-          peer.connection === "active"
-            ? "text-emerald-500"
-            : peer.connection === "stale"
-            ? "text-amber-500"
-            : peer.connection === "lost"
-            ? "text-red-500"
-            : "text-muted-foreground"
-        )}
-      >
+      <span className={cn("shrink-0 text-[10px]", labelColor)}>
         {label}
       </span>
     </div>
@@ -101,9 +107,38 @@ function PeerRow({ peer }: { peer: PeerInfo }) {
 export function NodeStatusPopover({ children }: { children: React.ReactNode }) {
   const snapshot = useP2pEngineStore((s) => s.snapshot)
   const fetchSnapshot = useP2pEngineStore((s) => s.fetch)
+  const members = useTeamMembersStore((s) => s.members)
+  const [open, setOpen] = React.useState(false)
+  const [currentNodeId, setCurrentNodeId] = React.useState<string | null>(null)
+  const closeTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const handleMouseEnter = () => {
+  React.useEffect(() => {
+    if (!isTauri()) return
+    let cancelled = false
+    import("@tauri-apps/api/core").then(({ invoke }) =>
+      invoke<{ nodeId: string }>("get_device_info")
+        .then((info) => { if (!cancelled) setCurrentNodeId(info.nodeId) })
+        .catch(() => {})
+    )
+    return () => { cancelled = true }
+  }, [])
+
+  const cancelClose = () => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current)
+      closeTimer.current = null
+    }
+  }
+
+  const scheduleClose = () => {
+    cancelClose()
+    closeTimer.current = setTimeout(() => setOpen(false), 200)
+  }
+
+  const handleTriggerEnter = () => {
+    cancelClose()
     void fetchSnapshot()
+    setOpen(true)
   }
 
   // Derive display status
@@ -129,18 +164,63 @@ export function NodeStatusPopover({ children }: { children: React.ReactNode }) {
 
   const showEngineInfo = !isHealthy && streamHealth !== "healthy"
 
+  const memberRows = React.useMemo(() => {
+    if (members.length > 0) {
+      return members.map((m) => {
+        const isLocal = m.nodeId === currentNodeId
+        const peer = peers.find((p) => p.nodeId === m.nodeId)
+        return {
+          key: m.nodeId,
+          name: m.name || m.hostname || m.nodeId.slice(0, 8) + "…",
+          role: m.role || "editor",
+          isLocal,
+          connection: (peer?.connection ?? "unknown") as PeerConnection,
+          lastSeenSecsAgo: peer?.lastSeenSecsAgo ?? 0,
+        }
+      })
+    }
+
+    return peers.map((peer) => ({
+      key: peer.nodeId,
+      name: peer.name || peer.nodeId.slice(0, 8) + "…",
+      role: peer.role,
+      isLocal: peer.nodeId === currentNodeId,
+      connection: peer.connection,
+      lastSeenSecsAgo: peer.lastSeenSecsAgo,
+    }))
+  }, [members, peers, currentNodeId])
+
+  const sortedRows = React.useMemo(() => {
+    const roleOrder: Record<string, number> = { owner: 0, editor: 1, viewer: 2 }
+    return [...memberRows].sort((a, b) => {
+      if (a.isLocal !== b.isLocal) return a.isLocal ? -1 : 1
+      const ra = roleOrder[a.role] ?? 3
+      const rb = roleOrder[b.role] ?? 3
+      if (ra !== rb) return ra - rb
+      return a.name.localeCompare(b.name)
+    })
+  }, [memberRows])
+
   return (
-    <Popover>
-      <PopoverTrigger asChild onMouseEnter={handleMouseEnter}>
-        {/* Wrap children so we get onMouseEnter on the trigger */}
-        <span className="contents">{children}</span>
+    <Popover open={open} onOpenChange={() => {}}>
+      <PopoverTrigger asChild>
+        <span
+          className="inline-flex"
+          onMouseEnter={handleTriggerEnter}
+          onMouseLeave={scheduleClose}
+        >
+          {children}
+        </span>
       </PopoverTrigger>
       <PopoverContent
-        side="top"
-        align="start"
+        side="right"
+        align="end"
         sideOffset={8}
         className="w-72 p-3 bg-card text-card-foreground"
-        onMouseEnter={handleMouseEnter}
+        onMouseEnter={cancelClose}
+        onMouseLeave={scheduleClose}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
       >
         {/* ── Header ── */}
         <div className="flex items-center gap-2 mb-2">
@@ -184,16 +264,23 @@ export function NodeStatusPopover({ children }: { children: React.ReactNode }) {
           </div>
         </div>
 
-        {/* ── Peers ── */}
-        {peers.length > 0 && (
+        {/* ── Members ── */}
+        {sortedRows.length > 0 && (
           <>
             <Separator className="my-2" />
             <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1.5">
-              Team Members ({peers.length})
+              Team Members ({sortedRows.length})
             </p>
             <div className="space-y-0.5">
-              {peers.map((peer) => (
-                <PeerRow key={peer.nodeId} peer={peer} />
+              {sortedRows.map((row) => (
+                <MemberRow
+                  key={row.key}
+                  name={row.name}
+                  role={row.role}
+                  isLocal={row.isLocal}
+                  connection={row.connection}
+                  lastSeenSecsAgo={row.lastSeenSecsAgo}
+                />
               ))}
             </div>
           </>

--- a/packages/app/src/components/NodeStatusPopover.tsx
+++ b/packages/app/src/components/NodeStatusPopover.tsx
@@ -113,8 +113,6 @@ export function NodeStatusPopover({ children }: { children: React.ReactNode }) {
   const isHealthy = status === "connected" && streamHealth === "healthy"
   const isDegraded = status === "connected" && streamHealth !== "healthy"
   const isReconnecting = status === "reconnecting"
-  const isDisconnected = status === "disconnected"
-
   const statusDotColor = isHealthy
     ? "bg-emerald-500"
     : isDegraded || isReconnecting

--- a/packages/app/src/components/__tests__/NodeStatusPopover.test.tsx
+++ b/packages/app/src/components/__tests__/NodeStatusPopover.test.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+const mockInvoke = vi.hoisted(() => vi.fn())
+const fetchMock = vi.hoisted(() => vi.fn())
+
+const p2pEngineStoreMock = vi.hoisted(() => ({
+  snapshot: {
+    status: 'connected',
+    streamHealth: 'healthy',
+    uptimeSecs: 120,
+    restartCount: 0,
+    lastSyncAt: '2024-01-01T00:00:00Z',
+    peers: [],
+    syncedFiles: 3,
+    pendingFiles: 0,
+  },
+  fetch: fetchMock,
+}))
+
+const teamMembersStoreMock = vi.hoisted(() => ({
+  members: [],
+}))
+
+vi.mock('@/stores/p2p-engine', () => ({
+  useP2pEngineStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel(p2pEngineStoreMock as unknown as Record<string, unknown>),
+}))
+
+vi.mock('@/stores/team-members', () => ({
+  useTeamMembersStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel(teamMembersStoreMock as unknown as Record<string, unknown>),
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+  isTauri: () => true,
+}))
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <>{children}</>,
+  PopoverContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+}))
+
+vi.mock('@/components/ui/separator', () => ({
+  Separator: () => <div />, 
+}))
+
+import { NodeStatusPopover } from '../NodeStatusPopover'
+
+describe('NodeStatusPopover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    teamMembersStoreMock.members = [
+      {
+        nodeId: 'local-node',
+        name: 'Matt',
+        role: 'owner',
+        hostname: 'matt-mac',
+      },
+      {
+        nodeId: 'owner-remote',
+        name: 'Alice',
+        role: 'owner',
+        hostname: 'alice-mac',
+      },
+      {
+        nodeId: 'editor-remote',
+        name: 'Bob',
+        role: 'editor',
+        hostname: 'bob-linux',
+      },
+    ]
+    p2pEngineStoreMock.snapshot = {
+      status: 'connected',
+      streamHealth: 'healthy',
+      uptimeSecs: 120,
+      restartCount: 0,
+      lastSyncAt: '2024-01-01T00:00:00Z',
+      peers: [
+        {
+          nodeId: 'owner-remote',
+          name: 'Alice',
+          role: 'owner',
+          connection: 'active',
+          lastSeenSecsAgo: 5,
+          entriesSent: 0,
+          entriesReceived: 0,
+        },
+      ],
+      syncedFiles: 3,
+      pendingFiles: 0,
+    }
+    mockInvoke.mockResolvedValue({ nodeId: 'local-node' })
+  })
+
+  it('opens on hover and shows self, remote owner, and unknown member states', async () => {
+    render(
+      <NodeStatusPopover>
+        <button>Workspace</button>
+      </NodeStatusPopover>,
+    )
+
+    fireEvent.mouseEnter(screen.getByText('Workspace'))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled()
+      expect(screen.getByText('Team Members (3)')).toBeTruthy()
+    })
+
+    expect(screen.getByText('This device')).toBeTruthy()
+    expect(screen.getByText('Online')).toBeTruthy()
+    expect(screen.getByText('Unknown')).toBeTruthy()
+  })
+})

--- a/packages/app/src/components/__tests__/app-sidebar.test.tsx
+++ b/packages/app/src/components/__tests__/app-sidebar.test.tsx
@@ -25,6 +25,25 @@ const workspaceStoreMocks = vi.hoisted(() => ({
   activeTab: 'tasks',
 }))
 
+const teamModeStoreMocks = vi.hoisted(() => ({
+  teamMode: false,
+  p2pConnected: false,
+}))
+
+const teamOssStoreMocks = vi.hoisted(() => ({
+  configured: false,
+  connected: false,
+}))
+
+const p2pEngineStoreMocks = vi.hoisted(() => ({
+  initialized: true,
+  snapshot: {
+    status: 'disconnected',
+    streamHealth: 'dead',
+  },
+  init: vi.fn(async () => () => {}),
+}))
+
 // Mock i18n
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -83,6 +102,21 @@ vi.mock('@/stores/tabs', () => ({
   ),
 }))
 
+vi.mock('@/stores/team-mode', () => ({
+  useTeamModeStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel(teamModeStoreMocks as unknown as Record<string, unknown>),
+}))
+
+vi.mock('@/stores/team-oss', () => ({
+  useTeamOssStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel(teamOssStoreMocks as unknown as Record<string, unknown>),
+}))
+
+vi.mock('@/stores/p2p-engine', () => ({
+  useP2pEngineStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel(p2pEngineStoreMocks as unknown as Record<string, unknown>),
+}))
+
 // Mock sidebar UI components
 vi.mock('@/lib/ui-variant', () => ({
   isWorkspaceUIVariant: () => uiVariantMocks.workspaceShell,
@@ -95,7 +129,7 @@ vi.mock('@/components/ui/sidebar', () => ({
   SidebarGroup: ({ children }: any) => <div>{children}</div>,
   SidebarHeader: ({ children }: any) => <div>{children}</div>,
   SidebarMenu: ({ children }: any) => <div>{children}</div>,
-  SidebarMenuButton: ({ children, onClick, ...props }: any) => (
+  SidebarMenuButton: ({ children, onClick, isActive: _isActive, ...props }: any) => (
     <button onClick={onClick} {...props}>{children}</button>
   ),
   SidebarMenuItem: ({ children }: any) => <div>{children}</div>,
@@ -134,6 +168,10 @@ vi.mock('@/components/ui/command', () => ({
   CommandItem: () => null,
 }))
 
+vi.mock('@/components/NodeStatusPopover', () => ({
+  NodeStatusPopover: ({ children }: any) => <div>{children}</div>,
+}))
+
 import { AppSidebar } from '@/components/app-sidebar'
 
 describe('AppSidebar', () => {
@@ -149,6 +187,16 @@ describe('AppSidebar', () => {
     workspaceStoreMocks.activeTab = 'tasks'
     workspaceStoreMocks.openPanel = vi.fn()
     workspaceStoreMocks.closePanel = vi.fn()
+    teamModeStoreMocks.teamMode = false
+    teamModeStoreMocks.p2pConnected = false
+    teamOssStoreMocks.configured = false
+    teamOssStoreMocks.connected = false
+    p2pEngineStoreMocks.initialized = true
+    p2pEngineStoreMocks.snapshot = {
+      status: 'disconnected',
+      streamHealth: 'dead',
+    }
+    p2pEngineStoreMocks.init = vi.fn(async () => () => {})
   })
 
   it('renders session titles in sidebar', () => {
@@ -244,5 +292,47 @@ describe('AppSidebar', () => {
     render(<AppSidebar />)
     screen.getByText('Files').closest('button')!.click()
     expect(closePanelFn).toHaveBeenCalled()
+  })
+
+  it('shows connected P2P icon state from engine snapshot', () => {
+    teamModeStoreMocks.teamMode = true
+    p2pEngineStoreMocks.snapshot = {
+      status: 'connected',
+      streamHealth: 'healthy',
+    }
+
+    render(<AppSidebar />)
+
+    const icon = screen.getByTestId('workspace-p2p-icon')
+    expect(icon.getAttribute('data-p2p-status')).toBe('connected')
+    expect(icon.getAttribute('class')).toContain('text-blue-500')
+  })
+
+  it('shows degraded P2P icon state from engine snapshot', () => {
+    teamModeStoreMocks.teamMode = true
+    p2pEngineStoreMocks.snapshot = {
+      status: 'connected',
+      streamHealth: 'restarting',
+    }
+
+    render(<AppSidebar />)
+
+    const icon = screen.getByTestId('workspace-p2p-icon')
+    expect(icon.getAttribute('data-p2p-status')).toBe('degraded')
+    expect(icon.getAttribute('class')).toContain('text-amber-500')
+  })
+
+  it('shows disconnected P2P icon state when engine is disconnected', () => {
+    teamModeStoreMocks.teamMode = true
+    p2pEngineStoreMocks.snapshot = {
+      status: 'disconnected',
+      streamHealth: 'dead',
+    }
+
+    render(<AppSidebar />)
+
+    const icon = screen.getByTestId('workspace-p2p-icon')
+    expect(icon.getAttribute('data-p2p-status')).toBe('disconnected')
+    expect(icon.getAttribute('class')).toContain('text-muted-foreground')
   })
 })

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -11,6 +11,8 @@ import { useTabsStore } from "@/stores/tabs"
 import { useCronStore } from "@/stores/cron"
 import { useTeamModeStore } from "@/stores/team-mode"
 import { useTeamOssStore } from "@/stores/team-oss"
+import { useP2pEngineStore } from "@/stores/p2p-engine"
+import { NodeStatusPopover } from "@/components/NodeStatusPopover"
 import {
   Sidebar,
   SidebarContent,
@@ -324,26 +326,22 @@ function WorkspaceSelectorButton() {
   const isLoadingWorkspace = useWorkspaceStore(s => s.isLoadingWorkspace)
   const setWorkspace = useWorkspaceStore(s => s.setWorkspace)
   const teamMode = useTeamModeStore(s => s.teamMode)
-  const p2pConnected = useTeamModeStore(s => s.p2pConnected)
   const ossConfigured = useTeamOssStore(s => s.configured)
   const ossConnected = useTeamOssStore(s => s.connected)
+  const engineStatus = useP2pEngineStore(s => s.snapshot.status)
+  const engineStreamHealth = useP2pEngineStore(s => s.snapshot.streamHealth)
+  const engineInit = useP2pEngineStore(s => s.init)
   const [isSelecting, setIsSelecting] = React.useState(false)
 
-  // Poll P2P connection status when in team mode
+  // Initialize P2P engine store when in team mode
   React.useEffect(() => {
     if (!teamMode || !isTauri()) return
-    let cancelled = false
-    const poll = async () => {
-      try {
-        const { invoke } = await import('@tauri-apps/api/core')
-        const status = await invoke<{ connected?: boolean }>('p2p_sync_status')
-        if (!cancelled) useTeamModeStore.setState({ p2pConnected: status?.connected ?? false })
-      } catch { /* ignore */ }
-    }
-    poll()
-    const id = setInterval(poll, 5000)
-    return () => { cancelled = true; clearInterval(id) }
-  }, [teamMode])
+    let cleanup: (() => void) | undefined
+    engineInit().then((c) => { cleanup = c })
+    return () => { cleanup?.() }
+  }, [teamMode, engineInit])
+
+  const p2pConnected = engineStatus === 'connected'
 
   const handleOpenFolder = async () => {
     if (!isTauri()) {
@@ -372,29 +370,49 @@ function WorkspaceSelectorButton() {
 
   const isLoading = isLoadingWorkspace || isSelecting
 
+  const buttonContent = (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="h-7 gap-1.5 px-2 text-muted-foreground hover:text-foreground max-w-[180px]"
+      disabled={isLoading}
+      onClick={handleOpenFolder}
+    >
+      {isLoading ? (
+        <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+      ) : teamMode && workspaceName && ossConfigured ? (
+        <Cloud className={cn("h-4 w-4 shrink-0", ossConnected ? "text-blue-500" : "text-muted-foreground")} />
+      ) : teamMode && workspaceName ? (
+        <Users className={cn(
+          "h-4 w-4 shrink-0",
+          p2pConnected && engineStreamHealth === 'healthy'
+            ? "text-blue-500"
+            : p2pConnected
+              ? "text-amber-500"
+              : "text-muted-foreground"
+        )} />
+      ) : (
+        <FolderOpen className="h-4 w-4 shrink-0" />
+      )}
+      <span className="truncate text-xs" data-testid="workspace-name">
+        {workspaceName || t('workspace.selectWorkspace', 'Select Workspace')}
+      </span>
+    </Button>
+  )
+
+  // P2P mode: wrap in NodeStatusPopover for hover details
+  if (teamMode && workspaceName && !ossConfigured) {
+    return (
+      <NodeStatusPopover>
+        {buttonContent}
+      </NodeStatusPopover>
+    )
+  }
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1.5 px-2 text-muted-foreground hover:text-foreground max-w-[180px]"
-          disabled={isLoading}
-          onClick={handleOpenFolder}
-        >
-          {isLoading ? (
-            <Loader2 className="h-4 w-4 animate-spin shrink-0" />
-          ) : teamMode && workspaceName && ossConfigured ? (
-            <Cloud className={cn("h-4 w-4 shrink-0", ossConnected ? "text-blue-500" : "text-muted-foreground")} />
-          ) : teamMode && workspaceName ? (
-            <Users className={cn("h-4 w-4 shrink-0", p2pConnected ? "text-blue-500" : "text-muted-foreground")} />
-          ) : (
-            <FolderOpen className="h-4 w-4 shrink-0" />
-          )}
-          <span className="truncate text-xs" data-testid="workspace-name">
-            {workspaceName || t('workspace.selectWorkspace', 'Select Workspace')}
-          </span>
-        </Button>
+        {buttonContent}
       </TooltipTrigger>
       <TooltipContent side="top">
         <p>{workspaceName ? t('sidebar.currentWorkspace', 'Current: {{path}}', { path: workspaceName }) : t('workspace.selectWorkspace', 'Select Workspace')}</p>

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -326,6 +326,7 @@ function WorkspaceSelectorButton() {
   const isLoadingWorkspace = useWorkspaceStore(s => s.isLoadingWorkspace)
   const setWorkspace = useWorkspaceStore(s => s.setWorkspace)
   const teamMode = useTeamModeStore(s => s.teamMode)
+  const teamModeP2pConnected = useTeamModeStore(s => s.p2pConnected)
   const ossConfigured = useTeamOssStore(s => s.configured)
   const ossConnected = useTeamOssStore(s => s.connected)
   const engineStatus = useP2pEngineStore(s => s.snapshot.status)
@@ -341,7 +342,9 @@ function WorkspaceSelectorButton() {
     return () => { cleanup?.() }
   }, [teamMode, engineInit])
 
-  const p2pConnected = engineStatus === 'connected'
+  // Use engine store status with fallback to team-mode store
+  // (useP2pAutoReconnect updates team-mode store immediately, engine store may init later)
+  const p2pConnected = engineStatus === 'connected' || teamModeP2pConnected
 
   const handleOpenFolder = async () => {
     if (!isTauri()) {

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -329,6 +329,7 @@ function WorkspaceSelectorButton() {
   const teamModeP2pConnected = useTeamModeStore(s => s.p2pConnected)
   const ossConfigured = useTeamOssStore(s => s.configured)
   const ossConnected = useTeamOssStore(s => s.connected)
+  const engineInitialized = useP2pEngineStore(s => s.initialized)
   const engineStatus = useP2pEngineStore(s => s.snapshot.status)
   const engineStreamHealth = useP2pEngineStore(s => s.snapshot.streamHealth)
   const engineInit = useP2pEngineStore(s => s.init)
@@ -342,9 +343,14 @@ function WorkspaceSelectorButton() {
     return () => { cleanup?.() }
   }, [teamMode, engineInit])
 
-  // Use engine store status with fallback to team-mode store
-  // (useP2pAutoReconnect updates team-mode store immediately, engine store may init later)
-  const p2pConnected = engineStatus === 'connected' || teamModeP2pConnected
+  // Prefer the engine snapshot for connection truth. Keep a narrow fallback to the
+  // mirrored team-mode flag only before the engine store finishes initialization.
+  const p2pConnected = engineStatus === 'connected' || (!engineInitialized && teamModeP2pConnected)
+  const p2pStatusTone = p2pConnected
+    ? engineStatus === 'connected' && engineStreamHealth !== 'healthy'
+      ? 'degraded'
+      : 'connected'
+    : 'disconnected'
 
   const handleOpenFolder = async () => {
     if (!isTauri()) {
@@ -388,12 +394,12 @@ function WorkspaceSelectorButton() {
       ) : teamMode && workspaceName ? (
         <Users className={cn(
           "h-4 w-4 shrink-0",
-          p2pConnected && engineStreamHealth === 'healthy'
+          p2pStatusTone === 'connected'
             ? "text-blue-500"
-            : p2pConnected
+            : p2pStatusTone === 'degraded'
               ? "text-amber-500"
               : "text-muted-foreground"
-        )} />
+        )} data-testid="workspace-p2p-icon" data-p2p-status={p2pStatusTone} />
       ) : (
         <FolderOpen className="h-4 w-4 shrink-0" />
       )}

--- a/packages/app/src/components/settings/TeamMemberList.tsx
+++ b/packages/app/src/components/settings/TeamMemberList.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { UserMinus, Shield, Pencil, Eye, UserPlus, Clock, UserCheck } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useTeamMembersStore } from '../../stores/team-members'
 import { AddMemberInput } from './AddMemberInput'
 import { useP2pEngineStore, type PeerConnection } from '@/stores/p2p-engine'
 import { cn } from '@/lib/utils'
-import { invoke } from '@tauri-apps/api/core'
 
 function truncateId(id: string): string {
   if (id.length <= 16) return id
@@ -85,26 +84,18 @@ export function TeamMemberList() {
     approveApplication,
     listenForApplications,
     cleanupApplicationsListener,
+    currentNodeId,
+    loadCurrentNodeId,
   } = useTeamMembersStore()
 
   const enginePeers = useP2pEngineStore((s) => s.snapshot.peers)
-  const [currentNodeId, setCurrentNodeId] = useState<string | null>(null)
 
   useEffect(() => {
     loadMembers()
     loadMyRole()
+    loadCurrentNodeId()
     listenForApplications()
     return () => cleanupApplicationsListener()
-  }, [])
-
-  useEffect(() => {
-    let cancelled = false
-    invoke<{ nodeId: string }>('get_device_info')
-      .then((info) => {
-        if (!cancelled) setCurrentNodeId(info.nodeId)
-      })
-      .catch(() => {})
-    return () => { cancelled = true }
   }, [])
 
   const isManager = canManageMembers()

--- a/packages/app/src/components/settings/TeamMemberList.tsx
+++ b/packages/app/src/components/settings/TeamMemberList.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { UserMinus, Shield, Pencil, Eye, UserPlus, Clock, UserCheck } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useTeamMembersStore } from '../../stores/team-members'
 import { AddMemberInput } from './AddMemberInput'
 import { useP2pEngineStore, type PeerConnection } from '@/stores/p2p-engine'
 import { cn } from '@/lib/utils'
+import { invoke } from '@tauri-apps/api/core'
 
 function truncateId(id: string): string {
   if (id.length <= 16) return id
@@ -47,7 +48,7 @@ function ConnectionDot({ connection }: { connection: PeerConnection }) {
     active: 'Online',
     stale: 'Unstable',
     lost: 'Offline',
-    unknown: '',
+    unknown: 'Unknown',
   }
   return (
     <span className="inline-flex items-center gap-1">
@@ -55,6 +56,15 @@ function ConnectionDot({ connection }: { connection: PeerConnection }) {
       {labels[connection] && (
         <span className="text-[10px] text-muted-foreground">{labels[connection]}</span>
       )}
+    </span>
+  )
+}
+
+function LocalDeviceBadge() {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="h-2 w-2 rounded-full inline-block bg-blue-500" />
+      <span className="text-[10px] text-muted-foreground">This device</span>
     </span>
   )
 }
@@ -78,12 +88,23 @@ export function TeamMemberList() {
   } = useTeamMembersStore()
 
   const enginePeers = useP2pEngineStore((s) => s.snapshot.peers)
+  const [currentNodeId, setCurrentNodeId] = useState<string | null>(null)
 
   useEffect(() => {
     loadMembers()
     loadMyRole()
     listenForApplications()
     return () => cleanupApplicationsListener()
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    invoke<{ nodeId: string }>('get_device_info')
+      .then((info) => {
+        if (!cancelled) setCurrentNodeId(info.nodeId)
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
   }, [])
 
   const isManager = canManageMembers()
@@ -160,8 +181,9 @@ export function TeamMemberList() {
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
                   {(() => {
+                    if (member.nodeId === currentNodeId) return <LocalDeviceBadge />
                     const peer = enginePeers.find((p) => p.nodeId === member.nodeId)
-                    return peer ? <ConnectionDot connection={peer.connection} /> : null
+                    return <ConnectionDot connection={peer?.connection ?? 'unknown'} />
                   })()}
                   <p className="text-sm font-medium truncate">
                     {member.name || member.hostname}

--- a/packages/app/src/components/settings/TeamMemberList.tsx
+++ b/packages/app/src/components/settings/TeamMemberList.tsx
@@ -3,6 +3,8 @@ import { UserMinus, Shield, Pencil, Eye, UserPlus, Clock, UserCheck } from 'luci
 import { Button } from '@/components/ui/button'
 import { useTeamMembersStore } from '../../stores/team-members'
 import { AddMemberInput } from './AddMemberInput'
+import { useP2pEngineStore, type PeerConnection } from '@/stores/p2p-engine'
+import { cn } from '@/lib/utils'
 
 function truncateId(id: string): string {
   if (id.length <= 16) return id
@@ -34,6 +36,29 @@ function RoleBadge({ role }: { role?: string }) {
   )
 }
 
+function ConnectionDot({ connection }: { connection: PeerConnection }) {
+  const colors: Record<PeerConnection, string> = {
+    active: 'bg-green-500',
+    stale: 'bg-amber-500',
+    lost: 'bg-red-500',
+    unknown: 'bg-gray-400',
+  }
+  const labels: Record<PeerConnection, string> = {
+    active: 'Online',
+    stale: 'Unstable',
+    lost: 'Offline',
+    unknown: '',
+  }
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className={cn('h-2 w-2 rounded-full inline-block', colors[connection])} />
+      {labels[connection] && (
+        <span className="text-[10px] text-muted-foreground">{labels[connection]}</span>
+      )}
+    </span>
+  )
+}
+
 export function TeamMemberList() {
   const {
     members,
@@ -51,6 +76,8 @@ export function TeamMemberList() {
     listenForApplications,
     cleanupApplicationsListener,
   } = useTeamMembersStore()
+
+  const enginePeers = useP2pEngineStore((s) => s.snapshot.peers)
 
   useEffect(() => {
     loadMembers()
@@ -132,6 +159,10 @@ export function TeamMemberList() {
             >
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
+                  {(() => {
+                    const peer = enginePeers.find((p) => p.nodeId === member.nodeId)
+                    return peer ? <ConnectionDot connection={peer.connection} /> : null
+                  })()}
                   <p className="text-sm font-medium truncate">
                     {member.name || member.hostname}
                   </p>

--- a/packages/app/src/components/settings/__tests__/TeamMemberList.test.tsx
+++ b/packages/app/src/components/settings/__tests__/TeamMemberList.test.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+const mockInvoke = vi.hoisted(() => vi.fn())
+
+const teamMembersStoreMock = vi.hoisted(() => ({
+  members: [],
+  myRole: 'owner',
+  loading: false,
+  error: null,
+  loadMembers: vi.fn(),
+  loadMyRole: vi.fn(),
+  addMember: vi.fn(),
+  removeMember: vi.fn(),
+  updateMemberRole: vi.fn(),
+  canManageMembers: vi.fn(() => true),
+  applications: [],
+  approveApplication: vi.fn(),
+  listenForApplications: vi.fn(),
+  cleanupApplicationsListener: vi.fn(),
+}))
+
+const p2pEngineStoreMock = vi.hoisted(() => ({
+  snapshot: {
+    peers: [],
+  },
+}))
+
+vi.mock('@/stores/team-members', () => ({
+  useTeamMembersStore: () => teamMembersStoreMock,
+}))
+
+vi.mock('@/stores/p2p-engine', () => ({
+  useP2pEngineStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel(p2pEngineStoreMock as unknown as Record<string, unknown>),
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/settings/AddMemberInput', () => ({
+  AddMemberInput: () => <div>Add member input</div>,
+}))
+
+import { TeamMemberList } from '../TeamMemberList'
+
+describe('TeamMemberList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    teamMembersStoreMock.members = [
+      {
+        nodeId: 'node-1',
+        name: 'Alice',
+        label: 'Alice MacBook',
+        role: 'owner',
+        platform: 'macOS',
+        arch: 'arm64',
+        hostname: 'alice-macbook',
+        addedAt: new Date().toISOString(),
+      },
+      {
+        nodeId: 'node-2',
+        name: 'Bob',
+        label: 'Bob Linux',
+        role: 'viewer',
+        platform: 'linux',
+        arch: 'x64',
+        hostname: 'bob-linux',
+        addedAt: new Date().toISOString(),
+      },
+      {
+        nodeId: 'node-3',
+        name: 'Carol',
+        label: 'Carol Studio',
+        role: 'owner',
+        platform: 'macOS',
+        arch: 'arm64',
+        hostname: 'carol-studio',
+        addedAt: new Date().toISOString(),
+      },
+    ]
+    p2pEngineStoreMock.snapshot = {
+      peers: [
+        {
+          nodeId: 'node-3',
+          name: 'Carol',
+          role: 'owner',
+          connection: 'active',
+          lastSeenSecsAgo: 3,
+          entriesSent: 0,
+          entriesReceived: 0,
+        },
+      ],
+    }
+    mockInvoke.mockResolvedValue({ nodeId: 'node-1' })
+  })
+
+  it('shows This device for the local member, real state for remote owner, and Unknown for unmatched remote members', async () => {
+    render(<TeamMemberList />)
+
+    expect(screen.getByText('Alice')).toBeTruthy()
+    await waitFor(() => {
+      expect(screen.getByText('This device')).toBeTruthy()
+    })
+    expect(screen.getByText('Carol')).toBeTruthy()
+    expect(screen.getByText('Online')).toBeTruthy()
+    expect(screen.getByText('Unknown')).toBeTruthy()
+  })
+})

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -222,44 +222,18 @@ export function TeamP2PConfig() {
     }
     let cancelled = false
     ;(async () => {
-      // Check if already connected before showing loading
+      // Load device info
       try {
         const info = await tauriInvoke<DeviceInfo>('get_device_info')
         if (!cancelled) setDeviceInfo(info)
-        const status = await tauriInvoke<{ connected?: boolean }>('p2p_sync_status').catch(() => null)
-        if (status?.connected) {
-          // Already connected — just load status, no loading spinner
-          if (!cancelled) {
-            await loadSyncStatus()
-            await engineInit()
-            setReconnecting(false)
-          }
-          return
-        }
       } catch {
-        // Couldn't check — fall through to reconnect
+        // ignore
       }
 
-      // Not connected — show loading and reconnect
-      if (!cancelled) setReconnecting(true)
-      for (let attempt = 0; attempt < 10 && !cancelled; attempt++) {
-        try {
-          if (!deviceInfo) {
-            const info = await tauriInvoke<DeviceInfo>('get_device_info')
-            if (!cancelled) setDeviceInfo(info)
-          }
-          await tauriInvoke('p2p_reconnect')
-          break // success
-        } catch {
-          // P2P node not ready yet, wait and retry
-          await new Promise((r) => setTimeout(r, 1500))
-        }
-      }
-      if (!cancelled) {
-        await loadSyncStatus()
-        await engineInit()
-        setReconnecting(false)
-      }
+      // Load sync status — reconnect is handled by useP2pAutoReconnect in App.tsx
+      await loadSyncStatus()
+      await engineInit()
+      if (!cancelled) setReconnecting(false)
     })()
     return () => { cancelled = true }
   }, [loadSyncStatus])

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -23,6 +23,7 @@ import { cn, isTauri, copyToClipboard } from '@/lib/utils'
 import { toast } from 'sonner'
 import { buildConfig, TEAMCLAW_DIR, TEAM_REPO_DIR } from '@/lib/build-config'
 import { useTeamModeStore } from '@/stores/team-mode'
+import { useP2pEngineStore } from '@/stores/p2p-engine'
 import { useTeamMembersStore } from '@/stores/team-members'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { DeviceIdDisplay } from '@/components/settings/DeviceIdDisplay'
@@ -142,6 +143,7 @@ function TeamApiKeyCard() {
 export function TeamP2PConfig() {
   const { t } = useTranslation()
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
+  const engineSnapshot = useP2pEngineStore((s) => s.snapshot)
 
   const teamMembersStore = useTeamMembersStore()
 
@@ -195,7 +197,7 @@ export function TeamP2PConfig() {
 
   const allowedMembers = syncStatus?.members ?? []
   const isOwner = syncStatus?.role === 'owner'
-  const isConnected = syncStatus?.connected ?? false
+  const isConnected = engineSnapshot.status === 'connected'
   const docTicket = syncStatus?.docTicket ?? null
 
   // Load device info, sync status, and reconnect on mount
@@ -206,7 +208,6 @@ export function TeamP2PConfig() {
       setSyncStatus(status)
       useTeamModeStore.setState({
         myRole: (status?.role as 'owner' | 'editor' | 'viewer') ?? null,
-        p2pConnected: status?.connected ?? false,
       })
     } catch {
       // may not be available

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -233,6 +233,8 @@ export function TeamP2PConfig() {
       // Load sync status — reconnect is handled by useP2pAutoReconnect in App.tsx
       await loadSyncStatus()
       await engineInit()
+      // Always fetch latest peer snapshot (init() is a no-op when already initialized)
+      await useP2pEngineStore.getState().fetch()
       if (!cancelled) setReconnecting(false)
     })()
     return () => { cancelled = true }

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -144,6 +144,7 @@ export function TeamP2PConfig() {
   const { t } = useTranslation()
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
   const engineSnapshot = useP2pEngineStore((s) => s.snapshot)
+  const engineInit = useP2pEngineStore((s) => s.init)
 
   const teamMembersStore = useTeamMembersStore()
 
@@ -197,7 +198,7 @@ export function TeamP2PConfig() {
 
   const allowedMembers = syncStatus?.members ?? []
   const isOwner = syncStatus?.role === 'owner'
-  const isConnected = engineSnapshot.status === 'connected'
+  const isConnected = engineSnapshot.status === 'connected' || (syncStatus?.connected ?? false)
   const docTicket = syncStatus?.docTicket ?? null
 
   // Load device info, sync status, and reconnect on mount
@@ -236,6 +237,7 @@ export function TeamP2PConfig() {
       }
       if (!cancelled) {
         await loadSyncStatus()
+        await engineInit()
         setReconnecting(false)
       }
     })()

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -221,13 +221,33 @@ export function TeamP2PConfig() {
       return
     }
     let cancelled = false
-    setReconnecting(true)
     ;(async () => {
-      // Retry loop: P2P node may still be initializing
+      // Check if already connected before showing loading
+      try {
+        const info = await tauriInvoke<DeviceInfo>('get_device_info')
+        if (!cancelled) setDeviceInfo(info)
+        const status = await tauriInvoke<{ connected?: boolean }>('p2p_sync_status').catch(() => null)
+        if (status?.connected) {
+          // Already connected — just load status, no loading spinner
+          if (!cancelled) {
+            await loadSyncStatus()
+            await engineInit()
+            setReconnecting(false)
+          }
+          return
+        }
+      } catch {
+        // Couldn't check — fall through to reconnect
+      }
+
+      // Not connected — show loading and reconnect
+      if (!cancelled) setReconnecting(true)
       for (let attempt = 0; attempt < 10 && !cancelled; attempt++) {
         try {
-          const info = await tauriInvoke<DeviceInfo>('get_device_info')
-          setDeviceInfo(info)
+          if (!deviceInfo) {
+            const info = await tauriInvoke<DeviceInfo>('get_device_info')
+            if (!cancelled) setDeviceInfo(info)
+          }
           await tauriInvoke('p2p_reconnect')
           break // success
         } catch {

--- a/packages/app/src/components/settings/team/__tests__/TeamP2PConfig.test.tsx
+++ b/packages/app/src/components/settings/team/__tests__/TeamP2PConfig.test.tsx
@@ -1,0 +1,187 @@
+import * as React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+const mockInvoke = vi.hoisted(() => vi.fn())
+
+const teamModeStoreMocks = vi.hoisted(() => ({
+  setState: vi.fn(),
+  clearTeamMode: vi.fn(),
+  teamApiKey: null,
+  setTeamApiKey: vi.fn(),
+}))
+
+const p2pEngineStoreMocks = vi.hoisted(() => ({
+  initialized: true,
+  snapshot: {
+    status: 'connected',
+    streamHealth: 'healthy',
+    uptimeSecs: 120,
+    restartCount: 0,
+    lastSyncAt: '2024-01-01T00:00:00Z',
+    peers: [],
+    syncedFiles: 0,
+    pendingFiles: 0,
+  },
+  init: vi.fn(async () => () => {}),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallbackOrOptions?: string | Record<string, unknown>) => {
+      if (typeof fallbackOrOptions === 'string') return fallbackOrOptions
+      if (fallbackOrOptions && typeof fallbackOrOptions.defaultValue === 'string') {
+        return fallbackOrOptions.defaultValue
+      }
+      return key
+    },
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/utils', () => ({
+  isTauri: () => true,
+  copyToClipboard: vi.fn(),
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/lib/build-config', () => ({
+  buildConfig: {
+    app: { name: 'TeamClaw' },
+    team: { seedUrl: '' },
+  },
+  TEAMCLAW_DIR: '.teamclaw',
+  TEAM_REPO_DIR: 'teamclaw-team',
+}))
+
+vi.mock('@/stores/team-mode', () => ({
+  useTeamModeStore: Object.assign(
+    (sel: (s: Record<string, unknown>) => unknown) => sel(teamModeStoreMocks as unknown as Record<string, unknown>),
+    {
+      setState: teamModeStoreMocks.setState,
+      getState: () => teamModeStoreMocks,
+    },
+  ),
+}))
+
+vi.mock('@/stores/p2p-engine', () => ({
+  useP2pEngineStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel(p2pEngineStoreMocks as unknown as Record<string, unknown>),
+}))
+
+vi.mock('@/stores/team-members', () => ({
+  useTeamMembersStore: () => ({})
+}))
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({ workspacePath: '/workspace', refreshFileTree: vi.fn() }),
+}))
+
+vi.mock('@/components/settings/DeviceIdDisplay', () => ({
+  DeviceIdDisplay: ({ nodeId }: { nodeId: string }) => <div>{nodeId}</div>,
+}))
+
+vi.mock('@/components/settings/TeamMemberList', () => ({
+  TeamMemberList: () => <div>Team members</div>,
+}))
+
+vi.mock('@/components/settings/team/VersionHistorySection', () => ({
+  VersionHistorySection: () => <div>Version history</div>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />, 
+}))
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: () => <div />,
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <div>{children}</div>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => () => {}),
+}))
+
+import { TeamP2PConfig } from '../TeamP2PConfig'
+
+describe('TeamP2PConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    teamModeStoreMocks.teamApiKey = null
+    teamModeStoreMocks.setTeamApiKey = vi.fn()
+    teamModeStoreMocks.clearTeamMode = vi.fn()
+    p2pEngineStoreMocks.initialized = true
+    p2pEngineStoreMocks.snapshot = {
+      status: 'connected',
+      streamHealth: 'healthy',
+      uptimeSecs: 120,
+      restartCount: 0,
+      lastSyncAt: '2024-01-01T00:00:00Z',
+      peers: [],
+      syncedFiles: 0,
+      pendingFiles: 0,
+    }
+    p2pEngineStoreMocks.init = vi.fn(async () => () => {})
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_device_info') {
+        return { nodeId: 'node-123' }
+      }
+      if (cmd === 'p2p_sync_status') {
+        return {
+          connected: true,
+          role: 'owner',
+          docTicket: 'ticket-1',
+          namespaceId: 'team-1',
+          lastSyncAt: '2024-01-01T00:00:00Z',
+          members: [],
+          ownerNodeId: 'node-123',
+          seedUrl: null,
+          teamSecret: 'secret',
+        }
+      }
+      return null
+    })
+  })
+
+  it('shows connected state without triggering reconnect on mount', async () => {
+    render(<TeamP2PConfig />)
+
+    expect(screen.getByText('Team Drive Active')).toBeDefined()
+    expect(screen.queryByText('Connecting to team...')).toBeNull()
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('get_device_info', undefined)
+      expect(mockInvoke).toHaveBeenCalledWith('p2p_sync_status', undefined)
+    })
+
+    expect(mockInvoke).not.toHaveBeenCalledWith('p2p_reconnect', undefined)
+  })
+})

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -462,6 +462,11 @@ export function useP2pAutoReconnect() {
             myRole: (status.role as 'owner' | 'editor' | 'viewer') ?? null,
           });
         }
+
+        // Initialize engine store so sidebar icon and popover reflect connection state
+        const { useP2pEngineStore } = await import("@/stores/p2p-engine");
+        await useP2pEngineStore.getState().init();
+
         console.log("[P2P] Auto-reconnect completed");
       } catch (err) {
         console.warn("[P2P] Auto-reconnect failed (non-critical):", err);

--- a/packages/app/src/stores/__tests__/p2p-engine.test.ts
+++ b/packages/app/src/stores/__tests__/p2p-engine.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockSetState, mockUnlisten, mockListen, mockInvoke } = vi.hoisted(() => ({
+  mockSetState: vi.fn(),
+  mockUnlisten: vi.fn(),
+  mockListen: vi.fn(),
+  mockInvoke: vi.fn(),
+}))
+
+// Mock isTauri to return true
+vi.mock('@/lib/utils', () => ({
+  isTauri: () => true,
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}))
+
+// Mock team-mode store
+vi.mock('@/stores/team-mode', () => ({
+  useTeamModeStore: Object.assign(
+    () => ({}),
+    {
+      getState: () => ({ p2pConnected: false }),
+      setState: mockSetState,
+      subscribe: vi.fn(() => vi.fn()),
+    },
+  ),
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => mockListen(...args),
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+const DEFAULT_SNAPSHOT = {
+  status: 'disconnected',
+  streamHealth: 'dead',
+  uptimeSecs: 0,
+  restartCount: 0,
+  lastSyncAt: null,
+  peers: [],
+  syncedFiles: 0,
+  pendingFiles: 0,
+}
+
+const CONNECTED_SNAPSHOT = {
+  status: 'connected',
+  streamHealth: 'healthy',
+  uptimeSecs: 120,
+  restartCount: 0,
+  lastSyncAt: '2024-01-01T00:00:00Z',
+  peers: [
+    {
+      nodeId: 'peer-1',
+      name: 'Alice',
+      role: 'editor',
+      connection: 'active',
+      lastSeenSecsAgo: 5,
+      entriesSent: 10,
+      entriesReceived: 20,
+    },
+  ],
+  syncedFiles: 5,
+  pendingFiles: 2,
+}
+
+import { useP2pEngineStore } from '../p2p-engine'
+
+let eventCallback: ((event: { payload: unknown }) => void) | null = null
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  eventCallback = null
+  mockListen.mockImplementation(
+    async (_eventName: string, callback: (event: { payload: unknown }) => void) => {
+      eventCallback = callback
+      return mockUnlisten
+    },
+  )
+  mockInvoke.mockResolvedValue(CONNECTED_SNAPSHOT)
+  // Reset store state
+  useP2pEngineStore.setState({ snapshot: { ...DEFAULT_SNAPSHOT, peers: [] }, initialized: false })
+})
+
+describe('useP2pEngineStore', () => {
+  it('has correct default snapshot', () => {
+    const { snapshot } = useP2pEngineStore.getState()
+    expect(snapshot.status).toBe('disconnected')
+    expect(snapshot.streamHealth).toBe('dead')
+    expect(snapshot.peers).toEqual([])
+    expect(snapshot.uptimeSecs).toBe(0)
+    expect(snapshot.syncedFiles).toBe(0)
+    expect(snapshot.pendingFiles).toBe(0)
+  })
+
+  it('fetch updates snapshot', async () => {
+    await useP2pEngineStore.getState().fetch()
+    expect(mockInvoke).toHaveBeenCalledWith('p2p_node_status')
+    const { snapshot } = useP2pEngineStore.getState()
+    expect(snapshot.status).toBe('connected')
+    expect(snapshot.peers).toHaveLength(1)
+    expect(snapshot.syncedFiles).toBe(5)
+  })
+
+  it('init subscribes to p2p:engine-state event', async () => {
+    await useP2pEngineStore.getState().init()
+    expect(mockListen).toHaveBeenCalledWith('p2p:engine-state', expect.any(Function))
+  })
+
+  it('init fetches initial state', async () => {
+    await useP2pEngineStore.getState().init()
+    expect(mockInvoke).toHaveBeenCalledWith('p2p_node_status')
+  })
+
+  it('init is idempotent', async () => {
+    await useP2pEngineStore.getState().init()
+    await useP2pEngineStore.getState().init()
+    expect(mockListen).toHaveBeenCalledTimes(1)
+  })
+
+  it('event updates snapshot', async () => {
+    await useP2pEngineStore.getState().init()
+
+    const newSnapshot = { ...CONNECTED_SNAPSHOT, uptimeSecs: 999 }
+    eventCallback!({ payload: newSnapshot })
+
+    const { snapshot } = useP2pEngineStore.getState()
+    expect(snapshot.uptimeSecs).toBe(999)
+  })
+
+  it('cleanup unsubscribes', async () => {
+    const cleanup = await useP2pEngineStore.getState().init()
+    cleanup()
+    expect(mockUnlisten).toHaveBeenCalled()
+  })
+
+  it('syncs p2pConnected to team-mode store on connected event', async () => {
+    await useP2pEngineStore.getState().init()
+    mockSetState.mockClear()
+
+    eventCallback!({ payload: { ...CONNECTED_SNAPSHOT, status: 'connected' } })
+
+    expect(mockSetState).toHaveBeenCalledWith({ p2pConnected: true })
+  })
+})

--- a/packages/app/src/stores/p2p-engine.ts
+++ b/packages/app/src/stores/p2p-engine.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { isTauri } from '@/lib/utils'
+import { useTeamModeStore } from './team-mode'
 
 // Types must match Rust backend's EngineSnapshot exactly
 export type PeerConnection = 'active' | 'stale' | 'lost' | 'unknown'
@@ -87,3 +88,11 @@ export const useP2pEngineStore = create<P2pEngineState>((set, get) => ({
     }
   },
 }))
+
+// Sync p2pConnected to team-mode store so existing consumers keep working
+useP2pEngineStore.subscribe((state) => {
+  const connected = state.snapshot.status === 'connected'
+  if (useTeamModeStore.getState().p2pConnected !== connected) {
+    useTeamModeStore.setState({ p2pConnected: connected })
+  }
+})

--- a/packages/app/src/stores/p2p-engine.ts
+++ b/packages/app/src/stores/p2p-engine.ts
@@ -1,0 +1,89 @@
+import { create } from 'zustand'
+import { isTauri } from '@/lib/utils'
+
+// Types must match Rust backend's EngineSnapshot exactly
+export type PeerConnection = 'active' | 'stale' | 'lost' | 'unknown'
+export type EngineStatus = 'connected' | 'disconnected' | 'reconnecting'
+export type StreamHealth = 'healthy' | 'dead' | 'restarting'
+
+export interface PeerInfo {
+  nodeId: string
+  name: string
+  role: 'owner' | 'editor' | 'viewer'
+  connection: PeerConnection
+  lastSeenSecsAgo: number
+  entriesSent: number
+  entriesReceived: number
+}
+
+export interface EngineSnapshot {
+  status: EngineStatus
+  streamHealth: StreamHealth
+  uptimeSecs: number
+  restartCount: number
+  lastSyncAt: string | null
+  peers: PeerInfo[]
+  syncedFiles: number
+  pendingFiles: number
+}
+
+const DEFAULT_SNAPSHOT: EngineSnapshot = {
+  status: 'disconnected',
+  streamHealth: 'dead',
+  uptimeSecs: 0,
+  restartCount: 0,
+  lastSyncAt: null,
+  peers: [],
+  syncedFiles: 0,
+  pendingFiles: 0,
+}
+
+interface P2pEngineState {
+  snapshot: EngineSnapshot
+  initialized: boolean
+  init: () => Promise<() => void>
+  fetch: () => Promise<void>
+}
+
+export const useP2pEngineStore = create<P2pEngineState>((set, get) => ({
+  snapshot: DEFAULT_SNAPSHOT,
+  initialized: false,
+
+  init: async () => {
+    if (get().initialized) {
+      return () => {}
+    }
+
+    if (!isTauri()) {
+      set({ initialized: true })
+      return () => {}
+    }
+
+    const { listen } = await import('@tauri-apps/api/event')
+
+    const unlisten = await listen<EngineSnapshot>('p2p:engine-state', (event) => {
+      set({ snapshot: event.payload })
+    })
+
+    set({ initialized: true })
+
+    // Fetch initial state after subscribing to avoid missing early events
+    await get().fetch()
+
+    return () => {
+      unlisten()
+      set({ initialized: false })
+    }
+  },
+
+  fetch: async () => {
+    if (!isTauri()) return
+    try {
+      const { invoke } = await import('@tauri-apps/api/core')
+      const snapshot = await invoke<EngineSnapshot>('p2p_node_status')
+      set({ snapshot })
+    } catch (err) {
+      console.warn('[P2pEngine] Failed to fetch engine snapshot:', err)
+    }
+  },
+}))

--- a/packages/app/src/stores/provider.ts
+++ b/packages/app/src/stores/provider.ts
@@ -284,14 +284,17 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
           if (import.meta.env.DEV) {
             console.log('[LLM connect] providerId=', providerId, 'found=', true, 'modelCount=', modelCount)
           }
-          if (modelCount > 0) {
-            toast.success('Provider connected', {
-              description: `Successfully connected ${providerId}`,
-            })
-          } else {
-            toast.success('Provider connected', {
-              description: 'If no models appear below, the provider may list them later or use a custom model ID.',
-            })
+          // Skip toast for team provider — sidebar icon already indicates connection
+          if (providerId !== 'team') {
+            if (modelCount > 0) {
+              toast.success('Provider connected', {
+                description: `Successfully connected ${providerId}`,
+              })
+            } else {
+              toast.success('Provider connected', {
+                description: 'If no models appear below, the provider may list them later or use a custom model ID.',
+              })
+            }
           }
           set((state) => {
             const newDisconnected = new Set(state._disconnectedIds)
@@ -310,9 +313,11 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
       }
       const providers = data.providers || []
       console.warn('[LLM connect] Provider not in config list after setAuth (may be valid for some providers).', { providerId, providerIds: providers.map((p: { id?: string; name?: string }) => p.id || p.name) })
-      toast.success('Provider connected', {
-        description: 'If no models appear, select the model in chat or check the provider’s custom model ID.',
-      })
+      if (providerId !== ‘team’) {
+        toast.success(‘Provider connected’, {
+          description: ‘If no models appear, select the model in chat or check the provider\’s custom model ID.’,
+        })
+      }
       set((state) => {
         const newDisconnected = new Set(state._disconnectedIds)
         newDisconnected.delete(providerId)

--- a/packages/app/src/stores/provider.ts
+++ b/packages/app/src/stores/provider.ts
@@ -313,9 +313,9 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
       }
       const providers = data.providers || []
       console.warn('[LLM connect] Provider not in config list after setAuth (may be valid for some providers).', { providerId, providerIds: providers.map((p: { id?: string; name?: string }) => p.id || p.name) })
-      if (providerId !== ‘team’) {
-        toast.success(‘Provider connected’, {
-          description: ‘If no models appear, select the model in chat or check the provider\’s custom model ID.’,
+      if (providerId !== 'team') {
+        toast.success('Provider connected', {
+          description: "If no models appear, select the model in chat or check the provider's custom model ID.",
         })
       }
       set((state) => {

--- a/packages/app/src/stores/team-members.ts
+++ b/packages/app/src/stores/team-members.ts
@@ -23,9 +23,12 @@ interface TeamMembersState {
   error: string | null
   applications: TeamApplication[]
   _unlistenApplications: (() => void) | null
+  /** This device's P2P node ID, loaded once and shared across components. */
+  currentNodeId: string | null
 
   loadMembers: () => Promise<void>
   loadMyRole: () => Promise<void>
+  loadCurrentNodeId: () => Promise<void>
   addMember: (member: TeamMember) => Promise<void>
   removeMember: (nodeId: string) => Promise<void>
   updateMemberRole: (nodeId: string, role: MemberRole) => Promise<void>
@@ -42,6 +45,17 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
   error: null,
   applications: [],
   _unlistenApplications: null,
+  currentNodeId: null,
+
+  loadCurrentNodeId: async () => {
+    if (get().currentNodeId) return
+    try {
+      const info = await invoke<{ nodeId: string }>('get_device_info')
+      set({ currentNodeId: info.nodeId })
+    } catch {
+      // P2P node not running yet — will retry next call
+    }
+  },
 
   loadMembers: async () => {
     set({ loading: true, error: null })

--- a/src-tauri/src/commands/p2p_state.rs
+++ b/src-tauri/src/commands/p2p_state.rs
@@ -4,9 +4,15 @@
 #[cfg(feature = "p2p")]
 pub use super::team_p2p::IrohState;
 
+#[cfg(feature = "p2p")]
+pub use super::team_p2p::SyncEngineState;
+
 #[cfg(not(feature = "p2p"))]
 use std::sync::Arc;
 #[cfg(not(feature = "p2p"))]
 use tokio::sync::Mutex;
 #[cfg(not(feature = "p2p"))]
 pub type IrohState = Arc<Mutex<Option<()>>>;
+
+#[cfg(not(feature = "p2p"))]
+pub type SyncEngineState = Arc<Mutex<Option<()>>>;

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -77,7 +77,7 @@ impl PeerState {
 }
 
 /// High-level status of the sync engine.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum EngineStatus {
     Connected,
@@ -86,7 +86,7 @@ pub enum EngineStatus {
 }
 
 /// Health of the event stream between this node and the iroh document.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum StreamHealth {
     Healthy,
@@ -4356,5 +4356,206 @@ mod tests {
         assert!(json.get("p2p").is_some(), "p2p config should exist");
         assert_eq!(json["team"]["gitUrl"], "https://example.com/repo.git");
         assert_eq!(json["p2p"]["enabled"], false);
+    }
+
+    // ─── SyncEngine unit tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_sync_engine_new_defaults() {
+        let engine = SyncEngine::new();
+        assert_eq!(engine.status, EngineStatus::Disconnected);
+        assert_eq!(engine.stream_health, StreamHealth::Dead);
+        assert_eq!(engine.restart_count, 0);
+        assert!(engine.last_sync_at.is_none());
+        assert!(engine.peers.is_empty());
+        assert!(engine.file_sync_records.is_empty());
+        assert_eq!(engine.synced_files, 0);
+        assert_eq!(engine.pending_files, 0);
+    }
+
+    #[test]
+    fn test_sync_engine_snapshot() {
+        let mut engine = SyncEngine::new();
+        engine.status = EngineStatus::Connected;
+        engine.stream_health = StreamHealth::Healthy;
+        engine.synced_files = 42;
+
+        let snap = engine.snapshot();
+        assert_eq!(snap.status, EngineStatus::Connected);
+        assert_eq!(snap.stream_health, StreamHealth::Healthy);
+        assert_eq!(snap.synced_files, 42);
+        assert!(snap.peers.is_empty());
+    }
+
+    #[test]
+    fn test_peer_state_connection_unknown() {
+        let peer = PeerState {
+            node_id: "test".to_string(),
+            name: "Test".to_string(),
+            role: MemberRole::Editor,
+            last_activity: None,
+            entries_sent: 0,
+            entries_received: 0,
+        };
+        assert_eq!(peer.connection(), PeerConnection::Unknown);
+    }
+
+    #[test]
+    fn test_peer_state_connection_active() {
+        let peer = PeerState {
+            node_id: "test".to_string(),
+            name: "Test".to_string(),
+            role: MemberRole::Editor,
+            last_activity: Some(Instant::now()),
+            entries_sent: 0,
+            entries_received: 0,
+        };
+        assert_eq!(peer.connection(), PeerConnection::Active);
+    }
+
+    #[test]
+    fn test_peer_state_connection_stale() {
+        let peer = PeerState {
+            node_id: "test".to_string(),
+            name: "Test".to_string(),
+            role: MemberRole::Editor,
+            last_activity: Some(Instant::now() - std::time::Duration::from_secs(60)),
+            entries_sent: 0,
+            entries_received: 0,
+        };
+        assert_eq!(peer.connection(), PeerConnection::Stale);
+    }
+
+    #[test]
+    fn test_peer_state_connection_lost() {
+        let peer = PeerState {
+            node_id: "test".to_string(),
+            name: "Test".to_string(),
+            role: MemberRole::Editor,
+            last_activity: Some(Instant::now() - std::time::Duration::from_secs(300)),
+            entries_sent: 0,
+            entries_received: 0,
+        };
+        assert_eq!(peer.connection(), PeerConnection::Lost);
+    }
+
+    #[test]
+    fn test_record_sync_finished() {
+        let mut engine = SyncEngine::new();
+        engine.peers.insert(
+            "peer1".to_string(),
+            PeerState {
+                node_id: "peer1".to_string(),
+                name: "Peer1".to_string(),
+                role: MemberRole::Editor,
+                last_activity: None,
+                entries_sent: 0,
+                entries_received: 0,
+            },
+        );
+
+        engine.record_sync_finished("peer1", 5, 10);
+
+        let peer = engine.peers.get("peer1").unwrap();
+        assert_eq!(peer.entries_sent, 5);
+        assert_eq!(peer.entries_received, 10);
+        assert!(peer.last_activity.is_some());
+        assert!(engine.last_sync_at.is_some());
+    }
+
+    #[test]
+    fn test_record_neighbor_up() {
+        let mut engine = SyncEngine::new();
+        engine.peers.insert(
+            "peer1".to_string(),
+            PeerState {
+                node_id: "peer1".to_string(),
+                name: "Peer1".to_string(),
+                role: MemberRole::Editor,
+                last_activity: None,
+                entries_sent: 0,
+                entries_received: 0,
+            },
+        );
+
+        engine.record_neighbor_up("peer1");
+
+        let peer = engine.peers.get("peer1").unwrap();
+        assert!(peer.last_activity.is_some());
+        assert_eq!(peer.connection(), PeerConnection::Active);
+    }
+
+    #[test]
+    fn test_record_file_synced() {
+        let mut engine = SyncEngine::new();
+        let now = SystemTime::now();
+        engine.record_file_synced("test.txt".to_string(), now);
+
+        assert!(engine.file_sync_records.contains_key("test.txt"));
+        assert_eq!(
+            engine
+                .file_sync_records
+                .get("test.txt")
+                .unwrap()
+                .local_mtime_at_sync,
+            now
+        );
+    }
+
+    #[test]
+    fn test_snapshot_includes_peer_info() {
+        let mut engine = SyncEngine::new();
+        engine.peers.insert(
+            "peer1".to_string(),
+            PeerState {
+                node_id: "peer1".to_string(),
+                name: "Alice".to_string(),
+                role: MemberRole::Owner,
+                last_activity: Some(Instant::now()),
+                entries_sent: 10,
+                entries_received: 20,
+            },
+        );
+
+        let snap = engine.snapshot();
+        assert_eq!(snap.peers.len(), 1);
+        assert_eq!(snap.peers[0].node_id, "peer1");
+        assert_eq!(snap.peers[0].name, "Alice");
+        assert_eq!(snap.peers[0].connection, PeerConnection::Active);
+        assert_eq!(snap.peers[0].entries_sent, 10);
+        assert_eq!(snap.peers[0].entries_received, 20);
+    }
+
+    #[test]
+    fn test_load_peers_from_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let team_dir = tmp.path().join("teamclaw-team");
+        let team_meta = team_dir.join("_team");
+        std::fs::create_dir_all(&team_meta).unwrap();
+
+        // Write a members.json (camelCase keys to match serde rename)
+        let manifest = serde_json::json!({
+            "ownerNodeId": "node_owner",
+            "members": [
+                { "nodeId": "node_owner", "name": "Owner", "role": "owner", "platform": "", "arch": "", "hostname": "", "addedAt": "" },
+                { "nodeId": "node_editor", "name": "Editor", "role": "editor", "platform": "", "arch": "", "hostname": "", "addedAt": "" },
+            ]
+        });
+        std::fs::write(
+            team_meta.join("members.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let mut engine = SyncEngine::new();
+        let _ = engine.load_peers_from_manifest(team_dir.to_str().unwrap());
+
+        assert_eq!(engine.peers.len(), 2);
+        assert!(engine.peers.contains_key("node_owner"));
+        assert!(engine.peers.contains_key("node_editor"));
+        assert_eq!(
+            engine.peers.get("node_owner").unwrap().role,
+            MemberRole::Owner
+        );
     }
 }

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 use iroh::{Endpoint, SecretKey};
 use iroh_blobs::store::fs::FsStore;
@@ -271,6 +271,11 @@ pub struct IrohNode {
     pub(crate) active_doc: Option<iroh_docs::api::Doc>,
     /// Paths being written by remote sync — suppresses fs watcher feedback loop
     suppressed_paths: Arc<Mutex<HashSet<std::path::PathBuf>>>,
+    /// Incremented on reconnect/disconnect to signal stale sync tasks to exit.
+    sync_generation_tx: tokio::sync::watch::Sender<u64>,
+    sync_generation_rx: tokio::sync::watch::Receiver<u64>,
+    /// Protects concurrent reads/writes of _team/members.json across sync tasks.
+    manifest_lock: Arc<RwLock<()>>,
 }
 
 impl IrohNode {
@@ -316,6 +321,8 @@ impl IrohNode {
             .accept(iroh_docs::ALPN, docs.clone())
             .spawn();
 
+        let (gen_tx, gen_rx) = tokio::sync::watch::channel(0u64);
+
         Ok(IrohNode {
             endpoint,
             store,
@@ -325,6 +332,9 @@ impl IrohNode {
             author,
             active_doc: None,
             suppressed_paths: Arc::new(Mutex::new(HashSet::new())),
+            sync_generation_tx: gen_tx,
+            sync_generation_rx: gen_rx,
+            manifest_lock: Arc::new(RwLock::new(())),
         })
     }
 
@@ -345,6 +355,15 @@ impl IrohNode {
     #[allow(dead_code)]
     pub async fn shutdown(self) {
         self.router.shutdown().await.ok();
+    }
+
+    /// Bump the sync generation, causing all running sync tasks to exit.
+    /// Returns the new generation value.
+    pub fn bump_sync_generation(&self) -> u64 {
+        let new_gen = *self.sync_generation_rx.borrow() + 1;
+        let _ = self.sync_generation_tx.send(new_gen);
+        eprintln!("[P2P] Bumped sync generation to {}", new_gen);
+        new_gen
     }
 }
 
@@ -568,6 +587,9 @@ pub async fn create_team(
         HashMap::new(), // no cached peers yet for new team
         Some(workspace_path.to_string()),
         engine,
+        node.sync_generation_rx.clone(),
+        *node.sync_generation_rx.borrow(),
+        node.manifest_lock.clone(),
     );
 
     node.active_doc = Some(doc);
@@ -737,6 +759,9 @@ pub async fn join_team_drive(
         HashMap::new(), // no cached peers yet for new joiner
         Some(workspace_path.to_string()),
         engine,
+        node.sync_generation_rx.clone(),
+        *node.sync_generation_rx.borrow(),
+        node.manifest_lock.clone(),
     );
 
     node.active_doc = Some(doc);
@@ -1388,6 +1413,9 @@ fn start_sync_tasks(
     cached_peer_addrs: HashMap<String, Vec<String>>,
     workspace_path: Option<String>,
     engine: Arc<Mutex<SyncEngine>>,
+    mut generation_rx: tokio::sync::watch::Receiver<u64>,
+    my_generation: u64,
+    manifest_lock: Arc<RwLock<()>>,
 ) {
     let doc = doc.clone();
     let store = store.clone();
@@ -1408,6 +1436,18 @@ fn start_sync_tasks(
         let mut restart_count: u32 = 0;
 
         loop {
+            // Check if this sync generation is still current
+            if *generation_rx.borrow() != my_generation {
+                eprintln!(
+                    "[P2P][engine] Generation {} is stale (current={}), exiting supervisor",
+                    my_generation,
+                    *generation_rx.borrow()
+                );
+                let mut eng = engine.lock().await;
+                eng.stream_health = StreamHealth::Dead;
+                break;
+            }
+
             // Mark stream health
             {
                 let mut eng = engine.lock().await;
@@ -1498,7 +1538,18 @@ fn start_sync_tasks(
             }
             emit_engine_state(&app_handle, &engine).await;
 
-            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+            // Wait 3s before restart, but exit immediately if generation changes
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_secs(3)) => {}
+                _ = generation_rx.changed() => {
+                    eprintln!(
+                        "[P2P][engine] Generation changed during restart sleep, exiting supervisor"
+                    );
+                    let mut eng = engine.lock().await;
+                    eng.stream_health = StreamHealth::Dead;
+                    break;
+                }
+            }
 
             // Mark as restarting before re-entering loop
             {
@@ -1506,6 +1557,13 @@ fn start_sync_tasks(
                 eng.stream_health = StreamHealth::Restarting;
             }
             emit_engine_state(&app_handle, &engine).await;
+        }
+
+        // Clean up suppressed paths on exit
+        {
+            let mut suppressed = suppressed_paths.lock().await;
+            suppressed.clear();
+            eprintln!("[P2P][engine] Cleared suppressed paths on supervisor exit");
         }
     });
 }
@@ -2454,9 +2512,10 @@ pub async fn p2p_disconnect_source(
         drop(guard);
     }
 
-    // Close active doc
+    // Close active doc — bump generation first to kill running sync tasks
     let mut guard = iroh_state.lock().await;
     if let Some(node) = guard.as_mut() {
+        node.bump_sync_generation();
         if let Some(doc) = node.active_doc.take() {
             let _ = doc.leave().await;
         }
@@ -3054,6 +3113,9 @@ pub async fn p2p_reconnect(
         return Ok(());
     }
 
+    // Kill any leftover sync tasks from a previous session
+    node.bump_sync_generation();
+
     let my_node_id = get_node_id(node);
     let is_owner = config
         .owner_node_id
@@ -3133,6 +3195,9 @@ pub async fn p2p_reconnect(
         config.cached_peer_addrs.clone(),
         Some(workspace_path.clone()),
         engine_state.inner().clone(),
+        node.sync_generation_rx.clone(),
+        *node.sync_generation_rx.borrow(),
+        node.manifest_lock.clone(),
     );
 
     node.active_doc = Some(doc);

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
+use std::time::{Instant, SystemTime};
 use tokio::sync::Mutex;
 
 use iroh::{Endpoint, SecretKey};
@@ -26,6 +27,205 @@ fn is_tombstone(content: &[u8]) -> bool {
 const IROH_STORAGE_DIR: &str = concat!(".", env!("APP_SHORT_NAME"), "/iroh");
 /// Filename for the persisted Ed25519 secret key
 const SECRET_KEY_FILE: &str = "secret_key";
+
+// ─── SyncEngine types ──────────────────────────────────────────────────────
+
+/// Connection status for an individual peer, derived from elapsed time since last activity.
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum PeerConnection {
+    Active,
+    Stale,
+    Lost,
+    Unknown,
+}
+
+/// Tracks the local mtime at the moment a file was last synced, enabling safe reconciliation.
+#[derive(Debug, Clone)]
+pub struct FileSyncRecord {
+    pub local_mtime_at_sync: SystemTime,
+}
+
+/// Runtime state for a single peer. Not serializable because it contains `Instant`.
+#[derive(Debug, Clone)]
+pub struct PeerState {
+    pub node_id: String,
+    pub name: String,
+    pub role: MemberRole,
+    pub last_activity: Option<Instant>,
+    pub entries_sent: u64,
+    pub entries_received: u64,
+}
+
+impl PeerState {
+    /// Derive connection quality from elapsed time since last activity.
+    pub fn connection(&self) -> PeerConnection {
+        match self.last_activity {
+            Some(t) => {
+                let elapsed = t.elapsed().as_secs();
+                if elapsed < 30 {
+                    PeerConnection::Active
+                } else if elapsed <= 120 {
+                    PeerConnection::Stale
+                } else {
+                    PeerConnection::Lost
+                }
+            }
+            None => PeerConnection::Unknown,
+        }
+    }
+}
+
+/// High-level status of the sync engine.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum EngineStatus {
+    Connected,
+    Disconnected,
+    Reconnecting,
+}
+
+/// Health of the event stream between this node and the iroh document.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum StreamHealth {
+    Healthy,
+    Dead,
+    Restarting,
+}
+
+/// Serializable projection of `PeerState` for the frontend.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PeerInfo {
+    pub node_id: String,
+    pub name: String,
+    pub role: MemberRole,
+    pub connection: PeerConnection,
+    pub last_seen_secs_ago: u64,
+    pub entries_sent: u64,
+    pub entries_received: u64,
+}
+
+/// Serializable snapshot of the entire sync engine state, sent to the frontend.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct EngineSnapshot {
+    pub status: EngineStatus,
+    pub stream_health: StreamHealth,
+    pub uptime_secs: u64,
+    pub restart_count: u32,
+    pub last_sync_at: Option<String>,
+    pub peers: Vec<PeerInfo>,
+    pub synced_files: u32,
+    pub pending_files: u32,
+}
+
+/// Central state for the P2P sync engine. Not serializable (contains `Instant`).
+pub struct SyncEngine {
+    pub status: EngineStatus,
+    pub stream_health: StreamHealth,
+    pub started_at: Instant,
+    pub restart_count: u32,
+    pub last_sync_at: Option<String>,
+    pub peers: HashMap<String, PeerState>,
+    pub file_sync_records: HashMap<String, FileSyncRecord>,
+    pub synced_files: u32,
+    pub pending_files: u32,
+}
+
+impl SyncEngine {
+    /// Create a new engine in disconnected state.
+    pub fn new() -> Self {
+        Self {
+            status: EngineStatus::Disconnected,
+            stream_health: StreamHealth::Dead,
+            started_at: Instant::now(),
+            restart_count: 0,
+            last_sync_at: None,
+            peers: HashMap::new(),
+            file_sync_records: HashMap::new(),
+            synced_files: 0,
+            pending_files: 0,
+        }
+    }
+
+    /// Build a serializable snapshot of the current engine state.
+    pub fn snapshot(&self) -> EngineSnapshot {
+        let peers: Vec<PeerInfo> = self
+            .peers
+            .values()
+            .map(|p| PeerInfo {
+                node_id: p.node_id.clone(),
+                name: p.name.clone(),
+                role: p.role.clone(),
+                connection: p.connection(),
+                last_seen_secs_ago: p
+                    .last_activity
+                    .map(|t| t.elapsed().as_secs())
+                    .unwrap_or(0),
+                entries_sent: p.entries_sent,
+                entries_received: p.entries_received,
+            })
+            .collect();
+
+        EngineSnapshot {
+            status: self.status.clone(),
+            stream_health: self.stream_health.clone(),
+            uptime_secs: self.started_at.elapsed().as_secs(),
+            restart_count: self.restart_count,
+            last_sync_at: self.last_sync_at.clone(),
+            peers,
+            synced_files: self.synced_files,
+            pending_files: self.pending_files,
+        }
+    }
+
+    /// Record that a sync round with `node_id` has finished.
+    pub fn record_sync_finished(&mut self, node_id: &str, sent: u64, received: u64) {
+        if let Some(peer) = self.peers.get_mut(node_id) {
+            peer.entries_sent += sent;
+            peer.entries_received += received;
+            peer.last_activity = Some(Instant::now());
+        }
+        self.last_sync_at = Some(chrono::Utc::now().to_rfc3339());
+    }
+
+    /// Record that a neighbor (peer) has come online.
+    pub fn record_neighbor_up(&mut self, node_id: &str) {
+        if let Some(peer) = self.peers.get_mut(node_id) {
+            peer.last_activity = Some(Instant::now());
+        }
+    }
+
+    /// Populate the peers map from the on-disk members manifest.
+    pub fn load_peers_from_manifest(&mut self, team_dir: &str) -> Result<(), String> {
+        if let Some(manifest) = read_members_manifest(team_dir)? {
+            for member in &manifest.members {
+                self.peers
+                    .entry(member.node_id.clone())
+                    .or_insert_with(|| PeerState {
+                        node_id: member.node_id.clone(),
+                        name: member.name.clone(),
+                        role: member.role.clone(),
+                        last_activity: None,
+                        entries_sent: 0,
+                        entries_received: 0,
+                    });
+            }
+        }
+        Ok(())
+    }
+
+    /// Record that a file has been synced with the given local mtime.
+    pub fn record_file_synced(&mut self, key: String, mtime: SystemTime) {
+        self.file_sync_records
+            .insert(key, FileSyncRecord { local_mtime_at_sync: mtime });
+    }
+}
+
+/// Shared, async-safe handle to the sync engine.
+pub type SyncEngineState = Arc<Mutex<SyncEngine>>;
 
 /// Load or generate a persistent Ed25519 secret key at `storage_path/secret_key`.
 fn load_or_create_secret_key(storage_path: &Path) -> Result<SecretKey, String> {

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -566,6 +566,7 @@ pub async fn create_team(
         None,           // seed_endpoint resolved later on reconnect
         HashMap::new(), // no cached peers yet for new team
         Some(workspace_path.to_string()),
+        Arc::new(Mutex::new(SyncEngine::new())),
     );
 
     node.active_doc = Some(doc);
@@ -733,6 +734,7 @@ pub async fn join_team_drive(
         seed_ep,
         HashMap::new(), // no cached peers yet for new joiner
         Some(workspace_path.to_string()),
+        Arc::new(Mutex::new(SyncEngine::new())),
     );
 
     node.active_doc = Some(doc);
@@ -1185,7 +1187,187 @@ async fn collect_sync_peers(
     peers
 }
 
+/// Sync coordinator: handles NeighborUp/SyncFinished events and periodic fallback sync.
+/// Extracted from the inline Task C in start_sync_tasks for clarity and reuse.
+async fn run_sync_coordinator(
+    doc: iroh_docs::api::Doc,
+    endpoint: Endpoint,
+    team_dir: String,
+    doc_ticket: Option<String>,
+    seed_endpoint: Option<iroh::EndpointAddr>,
+    mut cached_addrs: HashMap<String, Vec<String>>,
+    workspace_path: Option<String>,
+    engine: Arc<Mutex<SyncEngine>>,
+    app_handle: Option<tauri::AppHandle>,
+) {
+    use futures_lite::StreamExt;
+    use iroh_docs::engine::LiveEvent;
+    let seed_ref = seed_endpoint.as_ref();
+
+    // Parse ticket peers (the owner's address for joiners).
+    let mut ticket_peers: Vec<iroh::EndpointAddr> = Vec::new();
+    if let Some(ref ticket_str) = doc_ticket {
+        if let Ok(ticket) = ticket_str.trim().parse::<iroh_docs::DocTicket>() {
+            ticket_peers = ticket.nodes;
+        }
+    }
+
+    let ep = endpoint;
+
+    // Do an initial sync shortly after startup
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    {
+        let peers =
+            collect_sync_peers(&ep, &ticket_peers, &team_dir, seed_ref, &cached_addrs).await;
+        if !peers.is_empty() {
+            if let Err(e) = doc.start_sync(peers.clone()).await {
+                eprintln!("[P2P][sync] Initial sync failed: {}", e);
+            } else {
+                eprintln!(
+                    "[P2P][sync] Initial sync triggered with {} peers",
+                    peers.len()
+                );
+            }
+        }
+    }
+
+    // Subscribe to doc events for NeighborUp
+    let mut events = match doc.subscribe().await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[P2P][sync] Failed to subscribe for sync events: {}", e);
+            return;
+        }
+    };
+
+    // Fallback timer: sync every 5 minutes
+    let mut fallback = tokio::time::interval(std::time::Duration::from_secs(300));
+    fallback.tick().await; // skip first immediate tick
+
+    loop {
+        tokio::select! {
+            event = events.next() => {
+                match event {
+                    Some(Ok(LiveEvent::NeighborUp(peer_key))) => {
+                        // New peer appeared in gossip — trigger sync with them
+                        let peer_id: iroh::EndpointId = peer_key;
+                        let peer_id_str = peer_id.to_string();
+                        eprintln!("[P2P][sync] NeighborUp: {}", &peer_id_str[..10]);
+                        engine.lock().await.record_neighbor_up(&peer_id_str);
+                        emit_engine_state(&app_handle, &engine).await;
+                        if let Some(info) = ep.remote_info(peer_id).await {
+                            let mut addrs = std::collections::BTreeSet::new();
+                            for addr_info in info.addrs() {
+                                addrs.insert(addr_info.addr().clone());
+                            }
+                            if !addrs.is_empty() {
+                                let peer_addr = iroh::EndpointAddr { id: peer_id, addrs };
+                                let _ = doc.start_sync(vec![peer_addr]).await;
+                            }
+                        }
+                    }
+                    Some(Ok(LiveEvent::SyncFinished(ev))) => {
+                        let peer_id_str = ev.peer.to_string();
+                        if let Ok(details) = &ev.result {
+                            if details.entries_received > 0 || details.entries_sent > 0 {
+                                eprintln!(
+                                    "[P2P][sync] SyncFinished peer={} sent={} recv={}",
+                                    &peer_id_str[..10],
+                                    details.entries_sent,
+                                    details.entries_received
+                                );
+                            }
+                            engine.lock().await.record_sync_finished(
+                                &peer_id_str,
+                                details.entries_sent as u64,
+                                details.entries_received as u64,
+                            );
+                            emit_engine_state(&app_handle, &engine).await;
+                        }
+                        // Cache the peer's address for future LAN reconnection
+                        let peer_id: iroh::EndpointId = ev.peer;
+                        if let Some(info) = ep.remote_info(peer_id).await {
+                            let addrs: Vec<String> = info.addrs()
+                                .filter_map(|a| match a.addr() {
+                                    iroh::TransportAddr::Ip(sock) => Some(sock.to_string()),
+                                    _ => None, // skip relay addrs
+                                })
+                                .collect();
+                            if !addrs.is_empty() {
+                                cached_addrs.insert(peer_id.to_string(), addrs);
+                            }
+                        }
+                    }
+                    Some(Err(_)) | None => {
+                        // Stream ended or error — break out
+                        eprintln!("[P2P][sync] Event stream ended");
+                        break;
+                    }
+                    _ => {} // Ignore other events
+                }
+            }
+            _ = fallback.tick() => {
+                // Fallback: sync with all known peers every 5 minutes
+                let peers = collect_sync_peers(&ep, &ticket_peers, &team_dir, seed_ref, &cached_addrs).await;
+                if !peers.is_empty() {
+                    // Update cache from collected peers (IP addrs only)
+                    for peer in &peers {
+                        let addrs: Vec<String> = peer.addrs.iter()
+                            .filter_map(|a| match a {
+                                iroh::TransportAddr::Ip(sock) => Some(sock.to_string()),
+                                _ => None,
+                            })
+                            .collect();
+                        if !addrs.is_empty() {
+                            cached_addrs.insert(peer.id.to_string(), addrs);
+                        }
+                    }
+                    // Refresh ticket with a few known peers so new joiners
+                    // can connect to ANY online member, not just the owner.
+                    // Cap at 5 peers to keep the ticket string small.
+                    if let Some(ref ws) = workspace_path {
+                        if let Ok(fresh_ticket) = doc.share(
+                            iroh_docs::api::protocol::ShareMode::Write,
+                            iroh_docs::api::protocol::AddrInfoOptions::RelayAndAddresses,
+                        ).await {
+                            let mut enriched = fresh_ticket;
+                            for peer in &peers {
+                                if enriched.nodes.len() >= 5 {
+                                    break;
+                                }
+                                if !enriched.nodes.iter().any(|n| n.id == peer.id) {
+                                    enriched.nodes.push(peer.clone());
+                                }
+                            }
+                            if let Ok(Some(mut cfg)) = read_p2p_config(ws) {
+                                cfg.doc_ticket = Some(enriched.to_string());
+                                cfg.cached_peer_addrs = cached_addrs.clone();
+                                let _ = write_p2p_config(ws, Some(&cfg));
+                            }
+                        } else {
+                            // Ticket refresh failed — still persist cached addrs
+                            if let Ok(Some(mut cfg)) = read_p2p_config(ws) {
+                                cfg.cached_peer_addrs = cached_addrs.clone();
+                                let _ = write_p2p_config(ws, Some(&cfg));
+                            }
+                        }
+                    }
+                    match doc.start_sync(peers.clone()).await {
+                        Ok(()) => eprintln!(
+                            "[P2P][sync] Fallback sync with {} peers",
+                            peers.len()
+                        ),
+                        Err(e) => eprintln!("[P2P][sync] Fallback sync failed: {}", e),
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Start background tasks for bidirectional sync between doc and filesystem.
+/// Wraps all 3 sync tasks (doc→disk, disk→doc, sync coordinator) in a supervisor
+/// loop that restarts them all if any one exits.
 fn start_sync_tasks(
     doc: &iroh_docs::api::Doc,
     author: iroh_docs::AuthorId,
@@ -1201,211 +1383,139 @@ fn start_sync_tasks(
     seed_endpoint: Option<iroh::EndpointAddr>,
     cached_peer_addrs: HashMap<String, Vec<String>>,
     workspace_path: Option<String>,
+    engine: Arc<Mutex<SyncEngine>>,
 ) {
-    let blobs_store: iroh_blobs::api::Store = store.clone().into();
-    let team_dir_a = team_dir.to_string();
-    let doc_a = doc.clone();
-    let suppressed_a = suppressed_paths.clone();
+    let doc = doc.clone();
+    let store = store.clone();
+    let team_dir = team_dir.to_string();
 
-    // Task A: remote doc changes → disk
-    let my_node_id_a = my_node_id.clone();
-    let owner_node_id_a = owner_node_id.clone();
     tokio::spawn(async move {
-        doc_to_disk_watcher(
-            doc_a,
-            blobs_store,
-            team_dir_a,
-            suppressed_a,
-            my_node_id_a,
-            owner_node_id_a,
-            app_handle,
-        )
-        .await;
-    });
-
-    // Task B: local disk changes → doc (with blob store for skills counting)
-    let doc_b = doc.clone();
-    let blobs_store_b: iroh_blobs::api::Store = store.clone().into();
-    let team_dir_b = team_dir.to_string();
-    let suppressed_b = suppressed_paths;
-    tokio::spawn(async move {
-        disk_to_doc_watcher(
-            doc_b,
-            blobs_store_b,
-            author,
-            team_dir_b,
-            suppressed_b,
-            my_role,
-            my_node_id,
-            owner_node_id,
-        )
-        .await;
-    });
-
-    // Task C: event-driven + fallback periodic sync.
-    // Listens for NeighborUp/SyncFinished events to register new peers with gossip,
-    // and falls back to a periodic sync every 5 minutes for resilience.
-    let doc_c = doc.clone();
-    let _doc_c2 = doc.clone();
-    let team_dir_c = team_dir.to_string();
-    let seed_ep = seed_endpoint;
-    let mut cached_addrs = cached_peer_addrs;
-    let ws_path = workspace_path;
-    tokio::spawn(async move {
-        use futures_lite::StreamExt;
-        use iroh_docs::engine::LiveEvent;
-        let seed_ref = seed_ep.as_ref();
-
-        // Parse ticket peers (the owner's address for joiners).
-        let mut ticket_peers: Vec<iroh::EndpointAddr> = Vec::new();
-        if let Some(ref ticket_str) = doc_ticket {
-            if let Ok(ticket) = ticket_str.trim().parse::<iroh_docs::DocTicket>() {
-                ticket_peers = ticket.nodes;
-            }
-        }
-
-        let ep = endpoint;
-
-        // Do an initial sync shortly after startup
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        // Initialize engine
         {
-            let peers =
-                collect_sync_peers(&ep, &ticket_peers, &team_dir_c, seed_ref, &cached_addrs).await;
-            if !peers.is_empty() {
-                if let Err(e) = doc_c.start_sync(peers.clone()).await {
-                    eprintln!("[P2P][sync] Initial sync failed: {}", e);
-                } else {
-                    eprintln!(
-                        "[P2P][sync] Initial sync triggered with {} peers",
-                        peers.len()
-                    );
-                }
+            let mut eng = engine.lock().await;
+            eng.status = EngineStatus::Connected;
+            eng.started_at = Instant::now();
+            if let Err(e) = eng.load_peers_from_manifest(&team_dir) {
+                eprintln!("[P2P][engine] Failed to load peers from manifest: {}", e);
             }
         }
+        emit_engine_state(&app_handle, &engine).await;
 
-        // Subscribe to doc events for NeighborUp
-        let mut events = match doc_c.subscribe().await {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("[P2P][sync] Failed to subscribe for sync events: {}", e);
-                return;
-            }
-        };
-
-        // Fallback timer: sync every 5 minutes
-        let mut fallback = tokio::time::interval(std::time::Duration::from_secs(300));
-        fallback.tick().await; // skip first immediate tick
+        let mut restart_count: u32 = 0;
 
         loop {
-            tokio::select! {
-                event = events.next() => {
-                    match event {
-                        Some(Ok(LiveEvent::NeighborUp(peer_key))) => {
-                            // New peer appeared in gossip — trigger sync with them
-                            let peer_id: iroh::EndpointId = peer_key;
-                            eprintln!("[P2P][sync] NeighborUp: {}", &peer_id.to_string()[..10]);
-                            if let Some(info) = ep.remote_info(peer_id).await {
-                                let mut addrs = std::collections::BTreeSet::new();
-                                for addr_info in info.addrs() {
-                                    addrs.insert(addr_info.addr().clone());
-                                }
-                                if !addrs.is_empty() {
-                                    let peer_addr = iroh::EndpointAddr { id: peer_id, addrs };
-                                    let _ = doc_c.start_sync(vec![peer_addr]).await;
-                                }
-                            }
-                        }
-                        Some(Ok(LiveEvent::SyncFinished(ev))) => {
-                            if let Ok(details) = &ev.result {
-                                if details.entries_received > 0 || details.entries_sent > 0 {
-                                    eprintln!(
-                                        "[P2P][sync] SyncFinished peer={} sent={} recv={}",
-                                        &ev.peer.to_string()[..10],
-                                        details.entries_sent,
-                                        details.entries_received
-                                    );
-                                }
-                            }
-                            // Cache the peer's address for future LAN reconnection
-                            let peer_id: iroh::EndpointId = ev.peer;
-                            if let Some(info) = ep.remote_info(peer_id).await {
-                                let addrs: Vec<String> = info.addrs()
-                                    .filter_map(|a| match a.addr() {
-                                        iroh::TransportAddr::Ip(sock) => Some(sock.to_string()),
-                                        _ => None, // skip relay addrs
-                                    })
-                                    .collect();
-                                if !addrs.is_empty() {
-                                    cached_addrs.insert(peer_id.to_string(), addrs);
-                                }
-                            }
-                        }
-                        Some(Err(_)) | None => {
-                            // Stream ended or error — break out
-                            eprintln!("[P2P][sync] Event stream ended");
-                            break;
-                        }
-                        _ => {} // Ignore other events
-                    }
-                }
-                _ = fallback.tick() => {
-                    // Fallback: sync with all known peers every 5 minutes
-                    let peers = collect_sync_peers(&ep, &ticket_peers, &team_dir_c, seed_ref, &cached_addrs).await;
-                    if !peers.is_empty() {
-                        // Update cache from collected peers (IP addrs only)
-                        for peer in &peers {
-                            let addrs: Vec<String> = peer.addrs.iter()
-                                .filter_map(|a| match a {
-                                    iroh::TransportAddr::Ip(sock) => Some(sock.to_string()),
-                                    _ => None,
-                                })
-                                .collect();
-                            if !addrs.is_empty() {
-                                cached_addrs.insert(peer.id.to_string(), addrs);
-                            }
-                        }
-                        // Refresh ticket with a few known peers so new joiners
-                        // can connect to ANY online member, not just the owner.
-                        // Cap at 5 peers to keep the ticket string small.
-                        if let Some(ref ws) = ws_path {
-                            if let Ok(fresh_ticket) = doc_c.share(
-                                iroh_docs::api::protocol::ShareMode::Write,
-                                iroh_docs::api::protocol::AddrInfoOptions::RelayAndAddresses,
-                            ).await {
-                                let mut enriched = fresh_ticket;
-                                for peer in &peers {
-                                    if enriched.nodes.len() >= 5 {
-                                        break;
-                                    }
-                                    if !enriched.nodes.iter().any(|n| n.id == peer.id) {
-                                        enriched.nodes.push(peer.clone());
-                                    }
-                                }
-                                if let Ok(Some(mut cfg)) = read_p2p_config(ws) {
-                                    cfg.doc_ticket = Some(enriched.to_string());
-                                    cfg.cached_peer_addrs = cached_addrs.clone();
-                                    let _ = write_p2p_config(ws, Some(&cfg));
-                                }
-                            } else {
-                                // Ticket refresh failed — still persist cached addrs
-                                if let Ok(Some(mut cfg)) = read_p2p_config(ws) {
-                                    cfg.cached_peer_addrs = cached_addrs.clone();
-                                    let _ = write_p2p_config(ws, Some(&cfg));
-                                }
-                            }
-                        }
-                        match doc_c.start_sync(peers.clone()).await {
-                            Ok(()) => eprintln!(
-                                "[P2P][sync] Fallback sync with {} peers",
-                                peers.len()
-                            ),
-                            Err(e) => eprintln!("[P2P][sync] Fallback sync failed: {}", e),
-                        }
-                    }
-                }
+            // Mark stream health
+            {
+                let mut eng = engine.lock().await;
+                eng.stream_health = if restart_count == 0 { StreamHealth::Healthy } else { StreamHealth::Restarting };
+                eng.restart_count = restart_count;
             }
+            emit_engine_state(&app_handle, &engine).await;
+
+            let blobs_store: iroh_blobs::api::Store = store.clone().into();
+
+            // Spawn Task A: doc → disk
+            let doc_a = doc.clone();
+            let blobs_a = blobs_store.clone();
+            let team_dir_a = team_dir.clone();
+            let suppressed_a = suppressed_paths.clone();
+            let my_node_id_a = my_node_id.clone();
+            let owner_node_id_a = owner_node_id.clone();
+            let app_handle_a = app_handle.clone();
+            let engine_a = engine.clone();
+            let task_a = tokio::spawn(async move {
+                doc_to_disk_watcher(
+                    doc_a, blobs_a, team_dir_a, suppressed_a,
+                    my_node_id_a, owner_node_id_a, app_handle_a, engine_a,
+                ).await;
+                "doc_to_disk"
+            });
+
+            // Spawn Task B: disk → doc
+            let doc_b = doc.clone();
+            let blobs_b: iroh_blobs::api::Store = store.clone().into();
+            let team_dir_b = team_dir.clone();
+            let suppressed_b = suppressed_paths.clone();
+            let my_role_b = my_role.clone();
+            let my_node_id_b = my_node_id.clone();
+            let owner_node_id_b = owner_node_id.clone();
+            let engine_b = engine.clone();
+            let task_b = tokio::spawn(async move {
+                disk_to_doc_watcher(
+                    doc_b, blobs_b, author, team_dir_b, suppressed_b,
+                    my_role_b, my_node_id_b, owner_node_id_b, engine_b,
+                ).await;
+                "disk_to_doc"
+            });
+
+            // Spawn Task C: sync coordinator (NeighborUp + fallback)
+            let doc_c = doc.clone();
+            let team_dir_c = team_dir.clone();
+            let ep_c = endpoint.clone();
+            let doc_ticket_c = doc_ticket.clone();
+            let seed_ep_c = seed_endpoint.clone();
+            let cached_addrs_c = cached_peer_addrs.clone();
+            let ws_path_c = workspace_path.clone();
+            let engine_c = engine.clone();
+            let app_handle_c = app_handle.clone();
+            let task_c = tokio::spawn(async move {
+                run_sync_coordinator(
+                    doc_c, ep_c, team_dir_c, doc_ticket_c,
+                    seed_ep_c, cached_addrs_c, ws_path_c,
+                    engine_c, app_handle_c,
+                ).await;
+                "sync_coordinator"
+            });
+
+            // Grab abort handles before select! moves the JoinHandles
+            let abort_a = task_a.abort_handle();
+            let abort_b = task_b.abort_handle();
+            let abort_c = task_c.abort_handle();
+
+            // Wait for ANY task to exit
+            let which = tokio::select! {
+                result = task_a => result.unwrap_or("doc_to_disk (panic)"),
+                result = task_b => result.unwrap_or("disk_to_doc (panic)"),
+                result = task_c => result.unwrap_or("sync_coordinator (panic)"),
+            };
+
+            // One task died — abort the others
+            abort_a.abort();
+            abort_b.abort();
+            abort_c.abort();
+
+            restart_count += 1;
+            eprintln!("[P2P][engine] Task '{}' exited — restarting all in 3s (restart #{})", which, restart_count);
+
+            {
+                let mut eng = engine.lock().await;
+                eng.stream_health = StreamHealth::Dead;
+                eng.restart_count = restart_count;
+            }
+            emit_engine_state(&app_handle, &engine).await;
+
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+            // Mark as restarting before re-entering loop
+            {
+                let mut eng = engine.lock().await;
+                eng.stream_health = StreamHealth::Restarting;
+            }
+            emit_engine_state(&app_handle, &engine).await;
         }
     });
+}
+
+/// Emit the current engine snapshot to the frontend via Tauri event.
+async fn emit_engine_state(
+    app_handle: &Option<tauri::AppHandle>,
+    engine: &Arc<Mutex<SyncEngine>>,
+) {
+    if let Some(ref app) = app_handle {
+        use tauri::Emitter;
+        let snapshot = engine.lock().await.snapshot();
+        let _ = app.emit("p2p:engine-state", &snapshot);
+    }
 }
 
 /// Write content to a file path while suppressing fs watcher feedback.
@@ -1445,6 +1555,7 @@ async fn doc_to_disk_watcher(
     my_node_id: String,
     owner_node_id: Option<String>,
     app_handle: Option<tauri::AppHandle>,
+    engine: Arc<Mutex<SyncEngine>>,
 ) {
     use futures_lite::StreamExt;
     use iroh_docs::engine::LiveEvent;
@@ -1756,6 +1867,10 @@ async fn doc_to_disk_watcher(
                     } else {
                         eprintln!("[P2P][doc→disk] Writing: {} ({} bytes)", key, content.len());
                         write_and_suppress(&file_path, &content, &suppressed_paths).await;
+                        // Record file sync timestamp
+                        if let Ok(mtime) = std::fs::metadata(&file_path).and_then(|m| m.modified()) {
+                            engine.lock().await.record_file_synced(key.clone(), mtime);
+                        }
                     }
                 } else {
                     eprintln!("[P2P][doc→disk] Failed to get blob for: {}", key);
@@ -1862,6 +1977,10 @@ async fn doc_to_disk_watcher(
                     } else {
                         eprintln!("[P2P][ContentReady] Writing: {} ({} bytes)", key, content.len());
                         write_and_suppress(&file_path, &content, &suppressed_paths).await;
+                        // Record file sync timestamp
+                        if let Ok(mtime) = std::fs::metadata(&file_path).and_then(|m| m.modified()) {
+                            engine.lock().await.record_file_synced(key.clone(), mtime);
+                        }
                     }
                 }
             }
@@ -1884,6 +2003,7 @@ async fn disk_to_doc_watcher(
     my_role: Arc<Mutex<MemberRole>>,
     my_node_id: String,
     owner_node_id: Option<String>,
+    engine: Arc<Mutex<SyncEngine>>,
 ) {
     use notify::{RecursiveMode, Watcher};
 
@@ -1994,6 +2114,11 @@ async fn disk_to_doc_watcher(
                                 );
                                 if let Err(e) = doc.set_bytes(author, key.clone(), content).await {
                                     eprintln!("[P2P] Failed to sync local change '{}': {}", key, e);
+                                } else {
+                                    // Record file sync timestamp
+                                    if let Ok(mtime) = std::fs::metadata(path).and_then(|m| m.modified()) {
+                                        engine.lock().await.record_file_synced(key.clone(), mtime);
+                                    }
                                 }
                                 // Track skill file contributions for leaderboard
                                 if path
@@ -2989,6 +3114,7 @@ pub async fn p2p_reconnect(
         seed_ep,
         config.cached_peer_addrs.clone(),
         Some(workspace_path.clone()),
+        Arc::new(Mutex::new(SyncEngine::new())),
     );
 
     node.active_doc = Some(doc);

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -692,6 +692,7 @@ pub async fn join_team_drive(
 
     // Reconcile offline edits (primarily for re-join scenarios)
     let is_owner = manifest_owner.as_deref() == Some(&joiner_node_id);
+    let temp_engine: Arc<Mutex<SyncEngine>> = Arc::new(Mutex::new(SyncEngine::new()));
     if let Err(e) = reconcile_disk_and_doc(
         &doc,
         &node.store,
@@ -699,6 +700,7 @@ pub async fn join_team_drive(
         team_dir,
         is_owner,
         &joiner_role,
+        &temp_engine,
     )
     .await
     {
@@ -812,6 +814,7 @@ async fn reconcile_disk_and_doc(
     team_dir: &str,
     is_owner: bool,
     role: &MemberRole,
+    engine: &Arc<Mutex<SyncEngine>>,
 ) -> Result<(usize, usize), String> {
     use futures_lite::StreamExt;
 
@@ -855,11 +858,32 @@ async fn reconcile_disk_and_doc(
             // Both exist — check if they differ
             let local_hash = iroh_blobs::Hash::new(&local_content);
             if local_hash != entry.content_hash() {
-                // Local wins: upload local version
-                if *role != MemberRole::Viewer {
-                    if key == "_team/members.json" && !is_owner && *role == MemberRole::Viewer {
-                        continue;
+                if *role == MemberRole::Viewer {
+                    continue;
+                }
+                if key == "_team/members.json" && !is_owner {
+                    continue;
+                }
+
+                // Check if local file was modified since last sync
+                let file_path = team_path.join(&key);
+                let local_was_edited = {
+                    let eng = engine.lock().await;
+                    if let Some(record) = eng.file_sync_records.get(&key) {
+                        // Compare file's current mtime against mtime at last sync
+                        match std::fs::metadata(&file_path).and_then(|m| m.modified()) {
+                            Ok(current_mtime) => current_mtime > record.local_mtime_at_sync,
+                            Err(_) => false,
+                        }
+                    } else {
+                        // No sync record → first reconcile after upgrade.
+                        // Conservative: owner wins for backwards compat, others defer to remote.
+                        is_owner
                     }
+                };
+
+                if local_was_edited {
+                    // Local was genuinely edited offline → local wins
                     let content = if local_content.is_empty() {
                         vec![b'\n']
                     } else {
@@ -868,8 +892,23 @@ async fn reconcile_disk_and_doc(
                     if let Err(e) = doc.set_bytes(author, key.clone(), content).await {
                         eprintln!("[P2P][reconcile] Failed to upload {}: {}", key, e);
                     } else {
-                        eprintln!("[P2P][reconcile] Conflict -> local wins: {}", key);
+                        eprintln!("[P2P][reconcile] Conflict -> local wins (edited offline): {}", key);
                         uploaded += 1;
+                    }
+                } else {
+                    // Local is stale (not edited since last sync) → remote wins
+                    if let Ok(content) = blobs_store.blobs().get_bytes(entry.content_hash()).await {
+                        if !is_tombstone(&content) {
+                            if let Some(parent) = file_path.parent() {
+                                let _ = std::fs::create_dir_all(parent);
+                            }
+                            if let Err(e) = std::fs::write(&file_path, &content) {
+                                eprintln!("[P2P][reconcile] Failed to write {}: {}", key, e);
+                            } else {
+                                eprintln!("[P2P][reconcile] Conflict -> remote wins (local stale): {}", key);
+                                downloaded += 1;
+                            }
+                        }
                     }
                 }
             }
@@ -2912,6 +2951,7 @@ pub async fn p2p_reconnect(
     let my_role = config.role.clone().unwrap_or(MemberRole::Editor);
 
     // Reconcile offline edits before starting watchers
+    let temp_engine: Arc<Mutex<SyncEngine>> = Arc::new(Mutex::new(SyncEngine::new()));
     if let Err(e) = reconcile_disk_and_doc(
         &doc,
         &node.store,
@@ -2919,6 +2959,7 @@ pub async fn p2p_reconnect(
         &team_dir,
         is_owner,
         &my_role,
+        &temp_engine,
     )
     .await
     {

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -2,7 +2,7 @@
 
 use super::team_unified::{MemberRole, TeamManifest, TeamMember};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
@@ -270,7 +270,7 @@ pub struct IrohNode {
     /// Currently active team document (set after create/join)
     pub(crate) active_doc: Option<iroh_docs::api::Doc>,
     /// Paths being written by remote sync — suppresses fs watcher feedback loop
-    suppressed_paths: Arc<Mutex<HashSet<std::path::PathBuf>>>,
+    suppressed_paths: Arc<Mutex<HashMap<std::path::PathBuf, Instant>>>,
     /// Incremented on reconnect/disconnect to signal stale sync tasks to exit.
     sync_generation_tx: tokio::sync::watch::Sender<u64>,
     sync_generation_rx: tokio::sync::watch::Receiver<u64>,
@@ -331,7 +331,7 @@ impl IrohNode {
             router,
             author,
             active_doc: None,
-            suppressed_paths: Arc::new(Mutex::new(HashSet::new())),
+            suppressed_paths: Arc::new(Mutex::new(HashMap::new())),
             sync_generation_tx: gen_tx,
             sync_generation_rx: gen_rx,
             manifest_lock: Arc::new(RwLock::new(())),
@@ -1402,7 +1402,7 @@ fn start_sync_tasks(
     author: iroh_docs::AuthorId,
     store: &FsStore,
     team_dir: &str,
-    suppressed_paths: Arc<Mutex<HashSet<std::path::PathBuf>>>,
+    suppressed_paths: Arc<Mutex<HashMap<std::path::PathBuf, Instant>>>,
     my_role: Arc<Mutex<MemberRole>>,
     my_node_id: String,
     owner_node_id: Option<String>,
@@ -1588,11 +1588,11 @@ async fn emit_engine_state(
 async fn write_and_suppress(
     file_path: &std::path::Path,
     content: &[u8],
-    suppressed_paths: &Arc<Mutex<HashSet<std::path::PathBuf>>>,
+    suppressed_paths: &Arc<Mutex<HashMap<std::path::PathBuf, Instant>>>,
 ) {
     {
         let mut suppressed = suppressed_paths.lock().await;
-        suppressed.insert(file_path.to_path_buf());
+        suppressed.insert(file_path.to_path_buf(), Instant::now());
     }
 
     if let Some(parent) = file_path.parent() {
@@ -1617,7 +1617,7 @@ async fn doc_to_disk_watcher(
     doc: iroh_docs::api::Doc,
     blobs_store: iroh_blobs::api::Store,
     team_dir: String,
-    suppressed_paths: Arc<Mutex<HashSet<std::path::PathBuf>>>,
+    suppressed_paths: Arc<Mutex<HashMap<std::path::PathBuf, Instant>>>,
     my_node_id: String,
     owner_node_id: Option<String>,
     app_handle: Option<tauri::AppHandle>,
@@ -2079,7 +2079,7 @@ async fn disk_to_doc_watcher(
     blobs_store: iroh_blobs::api::Store,
     author: iroh_docs::AuthorId,
     team_dir: String,
-    suppressed_paths: Arc<Mutex<HashSet<std::path::PathBuf>>>,
+    suppressed_paths: Arc<Mutex<HashMap<std::path::PathBuf, Instant>>>,
     my_role: Arc<Mutex<MemberRole>>,
     my_node_id: String,
     owner_node_id: Option<String>,
@@ -2130,9 +2130,17 @@ async fn disk_to_doc_watcher(
                     for path in &event.paths {
                         // Skip suppressed paths (written by remote sync)
                         {
-                            let suppressed = suppressed_paths.lock().await;
-                            if suppressed.contains(path) {
-                                continue;
+                            let mut suppressed = suppressed_paths.lock().await;
+                            if let Some(inserted_at) = suppressed.get(path) {
+                                if inserted_at.elapsed().as_secs() < 10 {
+                                    continue;
+                                }
+                                // Stale entry (>10s) — cleanup task likely failed, remove it
+                                suppressed.remove(path);
+                                eprintln!(
+                                    "[P2P] Removed stale suppressed path: {}",
+                                    path.display()
+                                );
                             }
                         }
 

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -465,6 +465,7 @@ pub async fn create_team(
     owner_name: Option<String>,
     owner_email: Option<String>,
     app_handle: Option<tauri::AppHandle>,
+    engine: SyncEngineState,
 ) -> Result<String, String> {
     scaffold_team_dir(team_dir)?;
 
@@ -566,7 +567,7 @@ pub async fn create_team(
         None,           // seed_endpoint resolved later on reconnect
         HashMap::new(), // no cached peers yet for new team
         Some(workspace_path.to_string()),
-        Arc::new(Mutex::new(SyncEngine::new())),
+        engine,
     );
 
     node.active_doc = Some(doc);
@@ -595,6 +596,7 @@ pub async fn join_team_drive(
     team_dir: &str,
     workspace_path: &str,
     app_handle: Option<tauri::AppHandle>,
+    engine: SyncEngineState,
 ) -> Result<String, String> {
     use std::str::FromStr;
 
@@ -734,7 +736,7 @@ pub async fn join_team_drive(
         seed_ep,
         HashMap::new(), // no cached peers yet for new joiner
         Some(workspace_path.to_string()),
-        Arc::new(Mutex::new(SyncEngine::new())),
+        engine,
     );
 
     node.active_doc = Some(doc);
@@ -999,6 +1001,7 @@ pub async fn rotate_namespace(
     node: &mut IrohNode,
     team_dir: &str,
     workspace_path: &str,
+    engine: SyncEngineState,
 ) -> Result<String, String> {
     // Close existing doc
     if let Some(old_doc) = node.active_doc.take() {
@@ -1017,6 +1020,7 @@ pub async fn rotate_namespace(
         None,
         None,
         None,
+        engine,
     )
     .await
 }
@@ -2899,6 +2903,7 @@ pub async fn p2p_create_team(
     owner_name: Option<String>,
     owner_email: Option<String>,
     iroh_state: tauri::State<'_, IrohState>,
+    engine_state: tauri::State<'_, SyncEngineState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<String, String> {
     let workspace_path = opencode_state
@@ -2924,6 +2929,7 @@ pub async fn p2p_create_team(
         owner_name,
         owner_email,
         Some(app),
+        engine_state.inner().clone(),
     )
     .await
 }
@@ -2931,6 +2937,7 @@ pub async fn p2p_create_team(
 #[tauri::command]
 pub async fn p2p_publish_drive(
     iroh_state: tauri::State<'_, IrohState>,
+    engine_state: tauri::State<'_, SyncEngineState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<String, String> {
     let workspace_path = opencode_state
@@ -2959,6 +2966,7 @@ pub async fn p2p_publish_drive(
             None,
             None,
             None,
+            engine_state.inner().clone(),
         )
         .await;
     }
@@ -2981,6 +2989,7 @@ pub async fn p2p_join_drive(
     llm_model: Option<String>,
     llm_model_name: Option<String>,
     iroh_state: tauri::State<'_, IrohState>,
+    engine_state: tauri::State<'_, SyncEngineState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<String, String> {
     let workspace_path = opencode_state
@@ -2995,7 +3004,15 @@ pub async fn p2p_join_drive(
     let node = guard.as_mut().ok_or("P2P node not running")?;
 
     let team_dir = format!("{}/{}", workspace_path, super::TEAM_REPO_DIR);
-    let result = join_team_drive(node, &ticket, &team_dir, &workspace_path, Some(app)).await?;
+    let result = join_team_drive(
+        node,
+        &ticket,
+        &team_dir,
+        &workspace_path,
+        Some(app),
+        engine_state.inner().clone(),
+    )
+    .await?;
 
     // Write LLM config to .teamclaw/teamclaw.json (same as oss_join_team and create_team)
     let llm_config =
@@ -3010,6 +3027,7 @@ pub async fn p2p_join_drive(
 pub async fn p2p_reconnect(
     app: tauri::AppHandle,
     iroh_state: tauri::State<'_, IrohState>,
+    engine_state: tauri::State<'_, SyncEngineState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = opencode_state
@@ -3114,7 +3132,7 @@ pub async fn p2p_reconnect(
         seed_ep,
         config.cached_peer_addrs.clone(),
         Some(workspace_path.clone()),
-        Arc::new(Mutex::new(SyncEngine::new())),
+        engine_state.inner().clone(),
     );
 
     node.active_doc = Some(doc);
@@ -3126,6 +3144,7 @@ pub async fn p2p_reconnect(
 #[tauri::command]
 pub async fn p2p_rotate_ticket(
     iroh_state: tauri::State<'_, IrohState>,
+    engine_state: tauri::State<'_, SyncEngineState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<String, String> {
     let workspace_path = opencode_state
@@ -3140,7 +3159,7 @@ pub async fn p2p_rotate_ticket(
     let node = guard.as_mut().ok_or("P2P node not running")?;
 
     let team_dir = format!("{}/{}", workspace_path, super::TEAM_REPO_DIR);
-    rotate_namespace(node, &team_dir, &workspace_path).await
+    rotate_namespace(node, &team_dir, &workspace_path, engine_state.inner().clone()).await
 }
 
 #[tauri::command]
@@ -3564,6 +3583,7 @@ mod tests {
             team_dir.to_str().unwrap(),
             tmp.path().to_str().unwrap(),
             None,
+            Arc::new(Mutex::new(SyncEngine::new())),
         )
         .await;
         assert!(result.is_err(), "should fail with invalid ticket");
@@ -3599,6 +3619,7 @@ mod tests {
             None,
             None,
             None,
+            Arc::new(Mutex::new(SyncEngine::new())),
         )
         .await
         .unwrap();
@@ -4179,6 +4200,7 @@ mod tests {
             None,
             None,
             None,
+            Arc::new(Mutex::new(SyncEngine::new())),
         )
         .await
         .unwrap();

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -134,6 +134,12 @@ pub struct SyncEngine {
     pub pending_files: u32,
 }
 
+impl Default for SyncEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SyncEngine {
     /// Create a new engine in disconnected state.
     pub fn new() -> Self {

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -1467,10 +1467,12 @@ fn start_sync_tasks(
             let owner_node_id_a = owner_node_id.clone();
             let app_handle_a = app_handle.clone();
             let engine_a = engine.clone();
+            let manifest_lock_a = manifest_lock.clone();
             let task_a = tokio::spawn(async move {
                 doc_to_disk_watcher(
                     doc_a, blobs_a, team_dir_a, suppressed_a,
                     my_node_id_a, owner_node_id_a, app_handle_a, engine_a,
+                    manifest_lock_a,
                 ).await;
                 "doc_to_disk"
             });
@@ -1484,10 +1486,12 @@ fn start_sync_tasks(
             let my_node_id_b = my_node_id.clone();
             let owner_node_id_b = owner_node_id.clone();
             let engine_b = engine.clone();
+            let manifest_lock_b = manifest_lock.clone();
             let task_b = tokio::spawn(async move {
                 disk_to_doc_watcher(
                     doc_b, blobs_b, author, team_dir_b, suppressed_b,
                     my_role_b, my_node_id_b, owner_node_id_b, engine_b,
+                    manifest_lock_b,
                 ).await;
                 "disk_to_doc"
             });
@@ -1618,6 +1622,7 @@ async fn doc_to_disk_watcher(
     owner_node_id: Option<String>,
     app_handle: Option<tauri::AppHandle>,
     engine: Arc<Mutex<SyncEngine>>,
+    manifest_lock: Arc<RwLock<()>>,
 ) {
     use futures_lite::StreamExt;
     use iroh_docs::engine::LiveEvent;
@@ -1654,9 +1659,12 @@ async fn doc_to_disk_watcher(
     }
 
     // Pre-load role map from _team/members.json
-    if let Ok(Some(manifest)) = read_members_manifest(&team_dir) {
-        for member in &manifest.members {
-            node_to_role.insert(member.node_id.clone(), member.role.clone());
+    {
+        let _guard = manifest_lock.read().await;
+        if let Ok(Some(manifest)) = read_members_manifest(&team_dir) {
+            for member in &manifest.members {
+                node_to_role.insert(member.node_id.clone(), member.role.clone());
+            }
         }
     }
 
@@ -1767,11 +1775,14 @@ async fn doc_to_disk_watcher(
                                     leaving_node_id
                                 );
                                 // Refresh role cache
-                                if let Ok(Some(manifest)) = read_members_manifest(&team_dir) {
-                                    node_to_role.clear();
-                                    for member in &manifest.members {
-                                        node_to_role
-                                            .insert(member.node_id.clone(), member.role.clone());
+                                {
+                                    let _guard = manifest_lock.read().await;
+                                    if let Ok(Some(manifest)) = read_members_manifest(&team_dir) {
+                                        node_to_role.clear();
+                                        for member in &manifest.members {
+                                            node_to_role
+                                                .insert(member.node_id.clone(), member.role.clone());
+                                        }
                                     }
                                 }
                                 // Emit Tauri event so the owner's UI can show a notification
@@ -1840,7 +1851,11 @@ async fn doc_to_disk_watcher(
                         let file_path = Path::new(&team_dir).join(&key);
                         write_and_suppress(&file_path, &content, &suppressed_paths).await;
                         // Refresh role cache
-                        if let Ok(Some(manifest)) = read_members_manifest(&team_dir) {
+                        let manifest_opt = {
+                            let _guard = manifest_lock.read().await;
+                            read_members_manifest(&team_dir).ok().flatten()
+                        };
+                        if let Some(manifest) = manifest_opt {
                             node_to_role.clear();
                             for member in &manifest.members {
                                 node_to_role.insert(member.node_id.clone(), member.role.clone());
@@ -1995,16 +2010,19 @@ async fn doc_to_disk_watcher(
                     if let Ok(content) = blobs_store.blobs().get_bytes(hash).await {
                         let file_path = Path::new(&team_dir).join(&key);
                         write_and_suppress(&file_path, &content, &suppressed_paths).await;
-                        if let Ok(Some(manifest)) = read_members_manifest(&team_dir) {
-                            node_to_role.clear();
-                            for member in &manifest.members {
-                                node_to_role
-                                    .insert(member.node_id.clone(), member.role.clone());
-                            }
-                            if let Some(ref app) = app_handle {
-                                use tauri::Emitter;
-                                let _ =
-                                    app.emit("team:members-changed", serde_json::json!({}));
+                        {
+                            let _guard = manifest_lock.read().await;
+                            if let Ok(Some(manifest)) = read_members_manifest(&team_dir) {
+                                node_to_role.clear();
+                                for member in &manifest.members {
+                                    node_to_role
+                                        .insert(member.node_id.clone(), member.role.clone());
+                                }
+                                if let Some(ref app) = app_handle {
+                                    use tauri::Emitter;
+                                    let _ =
+                                        app.emit("team:members-changed", serde_json::json!({}));
+                                }
                             }
                         }
                     }
@@ -2066,6 +2084,7 @@ async fn disk_to_doc_watcher(
     my_node_id: String,
     owner_node_id: Option<String>,
     engine: Arc<Mutex<SyncEngine>>,
+    manifest_lock: Arc<RwLock<()>>,
 ) {
     use notify::{RecursiveMode, Watcher};
 
@@ -2126,6 +2145,7 @@ async fn disk_to_doc_watcher(
 
                             // Refresh my_role if the members manifest changed
                             if rel_path == "_team/members.json" {
+                                let _guard = manifest_lock.read().await;
                                 if let Ok(Some(manifest)) = read_members_manifest(&team_dir) {
                                     if let Some(me) =
                                         manifest.members.iter().find(|m| m.node_id == my_node_id)

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -1327,8 +1327,17 @@ async fn run_sync_coordinator(
                             }
                         }
                     }
-                    Some(Err(_)) | None => {
-                        // Stream ended or error — break out
+                    Some(Err(e)) => {
+                        let err_str = e.to_string();
+                        if err_str.contains("closed") || err_str.contains("shutdown") {
+                            eprintln!("[P2P][sync] Event stream closed (fatal): {}", e);
+                            break;
+                        }
+                        // Transient error — keep listening
+                        eprintln!("[P2P][sync] Event stream error (transient): {}", e);
+                    }
+                    None => {
+                        // Stream ended — fatal
                         eprintln!("[P2P][sync] Event stream ended");
                         break;
                     }
@@ -1672,11 +1681,26 @@ async fn doc_to_disk_watcher(
     // When ContentReady fires we do an O(1) lookup instead of scanning all entries.
     let mut pending_content: HashMap<iroh_blobs::Hash, (String, String)> = HashMap::new();
 
+    let mut consecutive_errors: u32 = 0;
+
     while let Some(event_result) = events.next().await {
         let event = match event_result {
-            Ok(e) => e,
+            Ok(e) => {
+                consecutive_errors = 0;
+                e
+            }
             Err(e) => {
-                eprintln!("[P2P][doc→disk] Event stream error: {}", e);
+                consecutive_errors += 1;
+                let err_str = e.to_string();
+                // Treat repeated errors or "closed" errors as fatal — let supervisor restart
+                if consecutive_errors >= 3 || err_str.contains("closed") || err_str.contains("shutdown") {
+                    eprintln!(
+                        "[P2P][doc→disk] Fatal event stream error (count={}): {}",
+                        consecutive_errors, e
+                    );
+                    break;
+                }
+                eprintln!("[P2P][doc→disk] Transient event stream error: {}", e);
                 continue;
             }
         };

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -3172,6 +3172,15 @@ pub async fn save_p2p_config(
     write_p2p_config(&workspace_path, Some(&config))
 }
 
+/// Get detailed node/engine status for the frontend popover.
+#[tauri::command]
+pub async fn p2p_node_status(
+    engine_state: tauri::State<'_, SyncEngineState>,
+) -> Result<EngineSnapshot, String> {
+    let eng = engine_state.lock().await;
+    Ok(eng.snapshot())
+}
+
 /// Get the current team sync status.
 #[tauri::command]
 pub async fn p2p_sync_status(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -283,6 +283,7 @@ pub fn run() {
             wvm
         })
         .manage(<commands::p2p_state::IrohState>::default())
+        .manage(<commands::p2p_state::SyncEngineState>::default())
         .manage(commands::spotlight::SpotlightState::default())
         .manage(tokio::sync::Mutex::new(commands::team_webdav::WebDavManagedState::default()))
         .manage(commands::oss_sync::OssSyncState::default())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -449,6 +449,8 @@ pub fn run() {
             #[cfg(feature = "p2p")]
             commands::team_p2p::p2p_rotate_ticket,
             #[cfg(feature = "p2p")]
+            commands::team_p2p::p2p_node_status,
+            #[cfg(feature = "p2p")]
             commands::team_p2p::p2p_sync_status,
             #[cfg(feature = "p2p")]
             commands::team_p2p::p2p_get_files_sync_status,


### PR DESCRIPTION
## Summary

- **Sync generation channel**: Orphaned sync tasks now auto-exit when reconnect/disconnect bumps the generation counter, preventing task proliferation
- **Manifest RwLock**: Concurrent reads/writes of `_team/members.json` across doc→disk and disk→doc watchers are now serialized
- **Suppressed paths TTL**: Stale suppression entries auto-expire after 10s (defense against crashed cleanup tasks), cleared on generation change
- **Event stream error classification**: Fatal errors (closed/shutdown) break the loop for supervisor restart; transient errors continue listening
- **Unified currentNodeId**: Sidebar and team page now share `currentNodeId` from `useTeamMembersStore`, fixing inconsistent "This device" vs "Unknown" status
- **Peer snapshot refresh**: Explicit `fetch()` on team settings page revisit so member status dots update immediately
- **Centralized reconnect**: Removed duplicate reconnect logic, suppressed spurious "Provider connected" toast

## Test plan

- [ ] `cargo check` and `cargo test -- team_p2p` pass (34/34 tests)
- [ ] TypeScript type check passes (`tsc --noEmit`)
- [ ] Switch away from team settings and back — member status dots refresh immediately
- [ ] Sidebar and team page show consistent status for "this device" (blue dot + "This device")
- [ ] Reconnect/disconnect properly cancels old sync tasks (check logs for "Generation X is stale")
- [ ] Multiple rapid reconnects don't create orphaned supervisor loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)