### PR TITLE
feat(oss-sync): performance optimizations and robustness fixes

### DIFF
--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -351,11 +351,27 @@ pub async fn oss_join_team(
         }
     }
 
-    // Scaffold teamclaw-team directory
+    // Clean and scaffold teamclaw-team directory.
+    // If the directory already exists (e.g. user left and is re-joining),
+    // remove old files first so initial_sync won't absorb stale local
+    // files back into the CRDT. The remote state is authoritative on join.
     let team_dir = format!("{}/{}", workspace_path, super::TEAM_REPO_DIR);
-    if !std::path::Path::new(&team_dir).exists() {
-        super::team::scaffold_team_dir(&team_dir)?;
+    let team_dir_path = std::path::Path::new(&team_dir);
+    if team_dir_path.exists() {
+        info!("oss_join_team: cleaning existing team dir before initial sync");
+        // Remove contents but keep the directory itself
+        if let Ok(entries) = std::fs::read_dir(team_dir_path) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    let _ = std::fs::remove_dir_all(&p);
+                } else {
+                    let _ = std::fs::remove_file(&p);
+                }
+            }
+        }
     }
+    super::team::scaffold_team_dir(&team_dir)?;
 
     // Write LLM config to .teamclaw/teamclaw.json
     let llm_config = super::team::build_llm_config(llm_base_url, llm_model, llm_model_name);

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -43,15 +43,27 @@ fn parse_doc_type(s: &str) -> Result<DocType, String> {
 }
 
 async fn start_poll_loop(state: &OssSyncState) {
-    let manager_arc = state.manager.clone();
-    let handle = tokio::spawn(async move {
-        OssSyncManager::poll_loop(manager_arc).await;
+    // Spawn fast loop (30s signal-based)
+    let fast_arc = state.manager.clone();
+    let fast_handle = tokio::spawn(async move {
+        OssSyncManager::fast_loop(fast_arc).await;
     });
-    let mut poll_guard = state.poll_handle.lock().await;
-    if let Some(old_handle) = poll_guard.take() {
+    let mut fast_guard = state.fast_poll_handle.lock().await;
+    if let Some(old_handle) = fast_guard.take() {
         old_handle.abort();
     }
-    *poll_guard = Some(handle);
+    *fast_guard = Some(fast_handle);
+
+    // Spawn slow loop (5min full sync + compaction)
+    let slow_arc = state.manager.clone();
+    let slow_handle = tokio::spawn(async move {
+        OssSyncManager::slow_loop(slow_arc).await;
+    });
+    let mut slow_guard = state.slow_poll_handle.lock().await;
+    if let Some(old_handle) = slow_guard.take() {
+        old_handle.abort();
+    }
+    *slow_guard = Some(slow_handle);
 }
 
 /// Generate a 32-byte random hex string for use as a team secret.
@@ -527,10 +539,16 @@ pub async fn oss_leave_team(
         }
     }
 
-    // Stop poll loop
+    // Stop both poll loops
     {
-        let mut poll_guard = state.poll_handle.lock().await;
-        if let Some(handle) = poll_guard.take() {
+        let mut fast_guard = state.fast_poll_handle.lock().await;
+        if let Some(handle) = fast_guard.take() {
+            handle.abort();
+        }
+    }
+    {
+        let mut slow_guard = state.slow_poll_handle.lock().await;
+        if let Some(handle) = slow_guard.take() {
             handle.abort();
         }
     }

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -66,6 +66,52 @@ async fn start_poll_loop(state: &OssSyncState) {
     *slow_guard = Some(slow_handle);
 }
 
+/// Archive a team directory into a zip file. Returns the number of files archived.
+fn archive_team_dir(dir: &std::path::Path, dest: &std::path::Path) -> Result<usize, String> {
+    let file = std::fs::File::create(dest)
+        .map_err(|e| format!("Failed to create archive {}: {e}", dest.display()))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    let mut count = 0usize;
+    fn walk_zip(
+        base: &std::path::Path,
+        current: &std::path::Path,
+        zip: &mut zip::ZipWriter<std::fs::File>,
+        options: zip::write::SimpleFileOptions,
+        count: &mut usize,
+    ) -> Result<(), String> {
+        let entries = std::fs::read_dir(current)
+            .map_err(|e| format!("Failed to read dir {}: {e}", current.display()))?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let rel = path
+                .strip_prefix(base)
+                .map_err(|e| format!("Path strip error: {e}"))?;
+            let name = rel.to_string_lossy().to_string();
+
+            if path.is_dir() {
+                walk_zip(base, &path, zip, options, count)?;
+            } else {
+                let data = std::fs::read(&path)
+                    .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+                zip.start_file(&name, options)
+                    .map_err(|e| format!("Failed to start zip entry {name}: {e}"))?;
+                std::io::Write::write_all(zip, &data)
+                    .map_err(|e| format!("Failed to write zip entry {name}: {e}"))?;
+                *count += 1;
+            }
+        }
+        Ok(())
+    }
+
+    walk_zip(dir, dir, &mut zip, options, &mut count)?;
+    zip.finish()
+        .map_err(|e| format!("Failed to finalize archive: {e}"))?;
+    Ok(count)
+}
+
 /// Generate a 32-byte random hex string for use as a team secret.
 fn generate_team_secret() -> Result<String, String> {
     let mut buf = [0u8; 32];
@@ -351,14 +397,25 @@ pub async fn oss_join_team(
         }
     }
 
-    // Clean and scaffold teamclaw-team directory.
+    // Archive and scaffold teamclaw-team directory.
     // If the directory already exists (e.g. user left and is re-joining),
-    // remove old files first so initial_sync won't absorb stale local
-    // files back into the CRDT. The remote state is authoritative on join.
+    // archive it as a zip so initial_sync won't absorb stale local files
+    // back into the CRDT. The remote state is authoritative on join.
     let team_dir = format!("{}/{}", workspace_path, super::TEAM_REPO_DIR);
     let team_dir_path = std::path::Path::new(&team_dir);
     if team_dir_path.exists() {
-        info!("oss_join_team: cleaning existing team dir before initial sync");
+        let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
+        let archive_name = format!("{}.backup_{}.zip", super::TEAM_REPO_DIR, timestamp);
+        let archive_path = std::path::Path::new(&workspace_path).join(&archive_name);
+        info!(
+            "oss_join_team: archiving existing team dir to {}",
+            archive_path.display()
+        );
+        // Best-effort archive — if it fails, log and proceed anyway
+        match archive_team_dir(team_dir_path, &archive_path) {
+            Ok(count) => info!("Archived {count} files to {}", archive_path.display()),
+            Err(e) => warn!("Failed to archive team dir (proceeding anyway): {e}"),
+        }
         // Remove contents but keep the directory itself
         if let Ok(entries) = std::fs::read_dir(team_dir_path) {
             for entry in entries.flatten() {

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -671,10 +671,22 @@ pub async fn oss_sync_now(state: State<'_, OssSyncState>) -> Result<SyncStatus, 
 
     manager.refresh_token_if_needed().await?;
 
+    let mut any_uploaded = false;
     for doc_type in DocType::all() {
-        manager.upload_local_changes(doc_type).await?;
+        match manager.upload_local_changes(doc_type).await {
+            Ok(true) => any_uploaded = true,
+            Ok(false) => {}
+            Err(e) => return Err(e),
+        }
         manager.pull_remote_changes(doc_type).await?;
         let _ = manager.persist_local_snapshot(doc_type);
+    }
+
+    // Write signal flag so other nodes detect the manual sync quickly
+    if any_uploaded {
+        if let Err(e) = manager.write_signal_flag().await {
+            warn!("Failed to write signal flag after manual sync: {}", e);
+        }
     }
 
     let now = chrono::Utc::now().to_rfc3339();

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -1279,6 +1279,101 @@ impl OssSyncManager {
     }
 
     // -----------------------------------------------------------------------
+    // Compaction Operations
+    // -----------------------------------------------------------------------
+
+    /// Check if compaction is needed for a given DocType.
+    async fn should_compact(&self, doc_type: DocType) -> bool {
+        // Only Owner/Editor can compact
+        if self.role != MemberRole::Owner && self.role != MemberRole::Editor {
+            return false;
+        }
+
+        // Check time since last compaction
+        if let Some(last) = self.last_compaction_at.get(&doc_type) {
+            let elapsed = Utc::now().signed_duration_since(*last).num_seconds();
+            if elapsed < 3600 {
+                // Less than 1 hour — check file count threshold instead
+                let prefix = format!("teams/{}/{}/updates/", self.team_id, doc_type.path());
+                match self.s3_list(&prefix).await {
+                    Ok(keys) => keys.len() > 100,
+                    Err(_) => false,
+                }
+            } else {
+                true
+            }
+        } else {
+            true
+        }
+    }
+
+    /// Compact update files into a snapshot, then delete old updates.
+    async fn compact(&mut self, doc_type: DocType) -> Result<(), String> {
+        info!("Starting compaction for {:?}...", doc_type);
+
+        // 1. Pull all latest updates to ensure doc is current
+        self.pull_remote_changes(doc_type).await?;
+
+        // 2. Export full snapshot
+        let doc = self.get_doc(doc_type);
+        let snapshot = doc
+            .export(loro::ExportMode::Snapshot)
+            .map_err(|e| format!("Failed to export snapshot for {:?}: {e}", doc_type))?;
+
+        // 3. Upload new snapshot
+        let timestamp_ms = Utc::now().timestamp_millis();
+        let snap_key = format!(
+            "teams/{}/{}/snapshot/{}.bin",
+            self.team_id,
+            doc_type.path(),
+            timestamp_ms
+        );
+        self.s3_put(&snap_key, &snapshot).await?;
+        info!(
+            "Compaction: uploaded snapshot for {:?} ({} bytes)",
+            doc_type,
+            snapshot.len()
+        );
+
+        // 4. Delete all update files
+        let update_prefix = format!("teams/{}/{}/updates/", self.team_id, doc_type.path());
+        let update_keys = self.s3_list(&update_prefix).await?;
+        for key in &update_keys {
+            self.s3_delete(key).await?;
+        }
+        info!(
+            "Compaction: deleted {} update files for {:?}",
+            update_keys.len(),
+            doc_type
+        );
+
+        // 5. Trim old snapshots (keep only 2 most recent)
+        let snap_prefix = format!("teams/{}/{}/snapshot/", self.team_id, doc_type.path());
+        let snap_keys = self.s3_list(&snap_prefix).await?;
+        if snap_keys.len() > 2 {
+            for key in &snap_keys[..snap_keys.len() - 2] {
+                self.s3_delete(key).await?;
+            }
+            info!(
+                "Compaction: trimmed {} old snapshots for {:?}",
+                snap_keys.len() - 2,
+                doc_type
+            );
+        }
+
+        // 6. Reset local state
+        self.known_files.insert(doc_type, HashSet::new());
+        self.last_known_key.remove(&doc_type);
+        self.last_exported_version.remove(&doc_type);
+
+        // 7. Record compaction time
+        self.last_compaction_at.insert(doc_type, Utc::now());
+
+        info!("Compaction complete for {:?}", doc_type);
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
     // Version History Operations
     // -----------------------------------------------------------------------
 

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -485,7 +485,7 @@ impl OssSyncManager {
     // -----------------------------------------------------------------------
 
     /// Write a 0-byte signal flag to S3 to notify other nodes of changes.
-    async fn write_signal_flag(&self) -> Result<(), String> {
+    pub async fn write_signal_flag(&self) -> Result<(), String> {
         let timestamp_ms = Utc::now().timestamp_millis();
         let key = format!(
             "teams/{}/signal/{}/{}.flag",
@@ -1014,7 +1014,9 @@ impl OssSyncManager {
         Ok(result)
     }
 
-    pub fn write_doc_to_disk(&self, doc_type: DocType) -> Result<(), String> {
+    /// Write LoroDoc state to disk and absorb any local-only files into the CRDT.
+    /// Returns `Ok(true)` if files were absorbed (caller should upload the changes).
+    pub fn write_doc_to_disk(&self, doc_type: DocType) -> Result<bool, String> {
         let doc = self.get_doc(doc_type);
         let dir = self.team_dir.join(doc_type.dir_name());
 
@@ -1083,6 +1085,7 @@ impl OssSyncManager {
         // via Finder while the app was closed or between sync cycles).
         // This also catches files that the CRDT marks as deleted but
         // which exist locally — they are re-absorbed with deleted=false.
+        let mut absorbed = false;
         if dir.exists() {
             let disk_files = Self::scan_local_files(&dir)?;
             let now = Utc::now().to_rfc3339();
@@ -1113,11 +1116,12 @@ impl OssSyncManager {
                         .map_err(|e| format!("Failed to set updatedAt for {path}: {e}"))?;
 
                     info!("Absorbed local-only file into LoroDoc: {path}");
+                    absorbed = true;
                 }
             }
         }
 
-        Ok(())
+        Ok(absorbed)
     }
 
     pub fn persist_local_snapshot(&self, doc_type: DocType) -> Result<(), String> {
@@ -1843,13 +1847,30 @@ impl OssSyncManager {
                 match manager.check_signal_flags().await {
                     Ok(true) => {
                         // New signals found — pull remote changes
+                        let mut needs_upload = false;
                         for doc_type in DocType::all() {
                             if let Err(e) = manager.pull_remote_changes(doc_type).await {
                                 warn!("OSS fast pull error for {:?}: {}", doc_type, e);
                                 had_network_error = true;
                             }
-                            if let Err(e) = manager.write_doc_to_disk(doc_type) {
-                                warn!("OSS fast write_doc_to_disk error for {:?}: {}", doc_type, e);
+                            match manager.write_doc_to_disk(doc_type) {
+                                Ok(true) => needs_upload = true, // absorbed local files
+                                Ok(false) => {}
+                                Err(e) => warn!("OSS fast write_doc_to_disk error for {:?}: {}", doc_type, e),
+                            }
+                        }
+
+                        // If write_doc_to_disk absorbed local-only files into the
+                        // CRDT, upload them so other nodes can see them.
+                        if needs_upload && !had_network_error {
+                            for doc_type in DocType::all() {
+                                if let Err(e) = manager.upload_local_changes(doc_type).await {
+                                    warn!("OSS fast absorb-upload error for {:?}: {}", doc_type, e);
+                                    had_network_error = true;
+                                }
+                            }
+                            if let Err(e) = manager.write_signal_flag().await {
+                                warn!("Failed to write signal flag after absorb: {}", e);
                             }
                         }
 
@@ -1903,6 +1924,7 @@ impl OssSyncManager {
                     let mut had_network_error = false;
 
                     // 1. Full upload + pull for all DocTypes
+                    let mut needs_absorb_upload = false;
                     for doc_type in DocType::all() {
                         if let Err(e) = manager.upload_local_changes(doc_type).await {
                             warn!("OSS slow upload error for {:?}: {}", doc_type, e);
@@ -1912,10 +1934,22 @@ impl OssSyncManager {
                             warn!("OSS slow pull error for {:?}: {}", doc_type, e);
                             had_network_error = true;
                         }
-                        if let Err(e) = manager.write_doc_to_disk(doc_type) {
-                            warn!("OSS slow write_doc_to_disk error for {:?}: {}", doc_type, e);
+                        match manager.write_doc_to_disk(doc_type) {
+                            Ok(true) => needs_absorb_upload = true,
+                            Ok(false) => {}
+                            Err(e) => warn!("OSS slow write_doc_to_disk error for {:?}: {}", doc_type, e),
                         }
                         let _ = manager.persist_local_snapshot(doc_type);
+                    }
+
+                    // Upload absorbed local-only files so other nodes see them
+                    if needs_absorb_upload && !had_network_error {
+                        for doc_type in DocType::all() {
+                            if let Err(e) = manager.upload_local_changes(doc_type).await {
+                                warn!("OSS slow absorb-upload error for {:?}: {}", doc_type, e);
+                                had_network_error = true;
+                            }
+                        }
                     }
 
                     // 2. List pending applications for owners/editors

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -476,6 +476,74 @@ impl OssSyncManager {
     }
 
     // -----------------------------------------------------------------------
+    // Signal Flag Operations
+    // -----------------------------------------------------------------------
+
+    /// Write a 0-byte signal flag to S3 to notify other nodes of changes.
+    async fn write_signal_flag(&self) -> Result<(), String> {
+        let timestamp_ms = Utc::now().timestamp_millis();
+        let key = format!(
+            "teams/{}/signal/{}/{}.flag",
+            self.team_id, self.node_id, timestamp_ms
+        );
+        self.s3_put(&key, &[]).await?;
+        info!("Wrote signal flag: {key}");
+        Ok(())
+    }
+
+    /// Check for new signal flags from other nodes.
+    /// Returns `true` if there are new flags (meaning remote changes exist).
+    async fn check_signal_flags(&mut self) -> Result<bool, String> {
+        let prefix = format!("teams/{}/signal/", self.team_id);
+        let all_flags = self.s3_list(&prefix).await?;
+
+        let mut has_new = false;
+        for flag in &all_flags {
+            let own_prefix = format!("teams/{}/signal/{}/", self.team_id, self.node_id);
+            if flag.starts_with(&own_prefix) {
+                continue;
+            }
+            if !self.known_signal_keys.contains(flag) {
+                has_new = true;
+                self.known_signal_keys.insert(flag.clone());
+            }
+        }
+
+        Ok(has_new)
+    }
+
+    /// Delete signal flags older than 1 hour.
+    async fn cleanup_expired_signal_flags(&self) -> Result<u32, String> {
+        let prefix = format!("teams/{}/signal/", self.team_id);
+        let flags = self.s3_list(&prefix).await?;
+        let one_hour_ago_ms = Utc::now().timestamp_millis() - 3_600_000;
+
+        let mut deleted = 0u32;
+        for key in &flags {
+            if let Some(ts) = Self::extract_timestamp_from_flag_key(key) {
+                if ts < one_hour_ago_ms {
+                    self.s3_delete(key).await?;
+                    deleted += 1;
+                }
+            }
+        }
+
+        if deleted > 0 {
+            info!("Cleaned up {deleted} expired signal flags");
+        }
+        Ok(deleted)
+    }
+
+    /// Extract timestamp_ms from a signal flag key.
+    /// Key format: `teams/{team_id}/signal/{node_id}/{timestamp_ms}.flag`
+    fn extract_timestamp_from_flag_key(key: &str) -> Option<i64> {
+        key.rsplit('/')
+            .next()
+            .and_then(|f| f.strip_suffix(".flag"))
+            .and_then(|s| s.parse().ok())
+    }
+
+    // -----------------------------------------------------------------------
     // Loro Document Operations
     // -----------------------------------------------------------------------
 

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -681,6 +681,93 @@ impl OssSyncManager {
         Ok(result)
     }
 
+    /// Like `scan_local_files`, but only reads files whose mtime is newer than `since`.
+    /// Used by the fast loop for quick change detection.
+    fn scan_local_files_incremental(
+        dir: &Path,
+        since: std::time::SystemTime,
+    ) -> Result<HashMap<String, Vec<u8>>, String> {
+        let mut result = HashMap::new();
+
+        if !dir.exists() {
+            return Ok(result);
+        }
+
+        fn walk_incremental(
+            base: &Path,
+            current: &Path,
+            since: std::time::SystemTime,
+            result: &mut HashMap<String, Vec<u8>>,
+        ) -> Result<(), String> {
+            let entries = std::fs::read_dir(current)
+                .map_err(|e| format!("Failed to read dir {}: {e}", current.display()))?;
+
+            for entry in entries {
+                let entry = entry.map_err(|e| format!("Dir entry error: {e}"))?;
+                let path = entry.path();
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+
+                if name_str.starts_with('.') {
+                    continue;
+                }
+
+                if path.is_dir() {
+                    walk_incremental(base, &path, since, result)?;
+                } else {
+                    let dominated = path
+                        .metadata()
+                        .ok()
+                        .and_then(|m| m.modified().ok())
+                        .map(|mtime| mtime > since)
+                        .unwrap_or(true);
+
+                    if dominated {
+                        let rel = path
+                            .strip_prefix(base)
+                            .map_err(|e| format!("Path strip error: {e}"))?;
+                        let rel_str = rel.to_string_lossy().to_string();
+                        let content = std::fs::read(&path)
+                            .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+                        result.insert(rel_str, content);
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        walk_incremental(dir, dir, since, &mut result)?;
+        Ok(result)
+    }
+
+    /// Fast-path upload: only check files modified since last scan (mtime-based).
+    /// Returns `Ok(true)` if changes were uploaded.
+    pub async fn upload_local_changes_incremental(
+        &mut self,
+        doc_type: DocType,
+    ) -> Result<bool, String> {
+        let dir = self.team_dir.join(doc_type.dir_name());
+        let since = self
+            .last_scan_time
+            .get(&doc_type)
+            .copied()
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+
+        let local_files = Self::scan_local_files_incremental(&dir, since)?;
+
+        if local_files.is_empty() {
+            return Ok(false);
+        }
+
+        // Update scan time before processing
+        self.last_scan_time
+            .insert(doc_type, std::time::SystemTime::now());
+
+        // Delegate to the full upload_local_changes which will detect
+        // changes via hash comparison against the Loro doc
+        self.upload_local_changes(doc_type).await
+    }
+
     fn compute_hash(content: &[u8]) -> String {
         let mut hasher = Sha256::new();
         hasher.update(content);

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -465,6 +465,13 @@ impl OssSyncManager {
         Ok(keys)
     }
 
+    /// Best-effort existence check for a specific S3 object key.
+    /// Uses LIST with exact-key prefix to avoid broad scans.
+    async fn s3_key_exists(&self, key: &str) -> Result<bool, String> {
+        let keys = self.s3_list(key).await?;
+        Ok(keys.iter().any(|k| k == key))
+    }
+
     pub async fn s3_delete(&self, key: &str) -> Result<(), String> {
         let client = self.client()?;
         let bucket = self.bucket()?;
@@ -818,9 +825,6 @@ impl OssSyncManager {
             return Ok(false);
         }
 
-        self.last_scan_time
-            .insert(doc_type, std::time::SystemTime::now());
-
         // Update CRDT with only the changed files, then export and upload
         let now = Utc::now().to_rfc3339();
         let node_id = self.node_id.clone();
@@ -891,6 +895,11 @@ impl OssSyncManager {
             doc_type,
             updates.len()
         );
+
+        // Advance scan cursor only after a successful upload, so failed uploads
+        // are retried on the next fast-loop cycle.
+        self.last_scan_time
+            .insert(doc_type, std::time::SystemTime::now());
 
         let current_vv = self.get_doc(doc_type).oplog_vv().encode();
         self.last_exported_version.insert(doc_type, current_vv);
@@ -1324,10 +1333,20 @@ impl OssSyncManager {
         let start_after = self.last_known_key.get(&doc_type).map(|s| s.as_str());
         let new_keys = self.s3_list_after(&prefix, start_after).await?;
 
-        // Race condition detection: if we had a cursor but got zero results,
-        // another node may have compacted (deleted all updates).
-        // Fall back to reloading from the latest snapshot.
-        if new_keys.is_empty() && self.last_known_key.contains_key(&doc_type) {
+        // Race condition detection: if we had a cursor and got zero results, treat
+        // it as compaction only when the cursor key itself no longer exists.
+        // Zero results alone can also mean "no new updates" and should be cheap.
+        let had_cursor = self.last_known_key.contains_key(&doc_type);
+        let cursor_missing = if had_cursor {
+            let last_key = self
+                .last_known_key
+                .get(&doc_type)
+                .ok_or_else(|| "Missing last_known_key despite cursor flag".to_string())?;
+            !self.s3_key_exists(last_key).await?
+        } else {
+            false
+        };
+        if Self::should_reload_snapshot_after_empty_listing(new_keys.is_empty(), cursor_missing) {
             let snap_prefix = format!("teams/{}/{}/snapshot/", self.team_id, doc_type.path());
             let snap_keys = self.s3_list(&snap_prefix).await?;
             if let Some(latest_snap) = snap_keys.last() {
@@ -1439,6 +1458,25 @@ impl OssSyncManager {
         Ok(())
     }
 
+    fn should_reload_snapshot_after_empty_listing(
+        new_keys_is_empty: bool,
+        cursor_missing: bool,
+    ) -> bool {
+        new_keys_is_empty && cursor_missing
+    }
+
+    fn select_compaction_deletion_keys(
+        pre_snapshot_updates: &[String],
+        current_updates: &[String],
+    ) -> Vec<String> {
+        let frozen: HashSet<&str> = pre_snapshot_updates.iter().map(String::as_str).collect();
+        current_updates
+            .iter()
+            .filter(|k| frozen.contains(k.as_str()))
+            .cloned()
+            .collect()
+    }
+
     pub async fn initial_sync(&mut self) -> Result<(), String> {
         for doc_type in DocType::all() {
             info!("Initial sync for {:?}...", doc_type);
@@ -1511,13 +1549,18 @@ impl OssSyncManager {
         // 1. Pull all latest updates to ensure doc is current
         self.pull_remote_changes(doc_type).await?;
 
-        // 2. Export full snapshot
+        // 2. Freeze the deletion set BEFORE snapshot upload. We only delete keys
+        // observed at this point, so concurrently written updates are preserved.
+        let update_prefix = format!("teams/{}/{}/updates/", self.team_id, doc_type.path());
+        let pre_snapshot_updates = self.s3_list(&update_prefix).await?;
+
+        // 3. Export full snapshot
         let doc = self.get_doc(doc_type);
         let snapshot = doc
             .export(loro::ExportMode::Snapshot)
             .map_err(|e| format!("Failed to export snapshot for {:?}: {e}", doc_type))?;
 
-        // 3. Upload new snapshot
+        // 4. Upload new snapshot
         let timestamp_ms = Utc::now().timestamp_millis();
         let snap_key = format!(
             "teams/{}/{}/snapshot/{}.bin",
@@ -1532,19 +1575,22 @@ impl OssSyncManager {
             snapshot.len()
         );
 
-        // 4. Delete all update files
-        let update_prefix = format!("teams/{}/{}/updates/", self.team_id, doc_type.path());
-        let update_keys = self.s3_list(&update_prefix).await?;
-        for key in &update_keys {
+        // 5. Re-list and delete only keys that already existed pre-snapshot.
+        let current_updates = self.s3_list(&update_prefix).await?;
+        let updates_to_delete = Self::select_compaction_deletion_keys(
+            &pre_snapshot_updates,
+            &current_updates,
+        );
+        for key in &updates_to_delete {
             self.s3_delete(key).await?;
         }
         info!(
-            "Compaction: deleted {} update files for {:?}",
-            update_keys.len(),
+            "Compaction: deleted {} pre-snapshot update files for {:?}",
+            updates_to_delete.len(),
             doc_type
         );
 
-        // 5. Trim old snapshots (keep only 2 most recent)
+        // 6. Trim old snapshots (keep only 2 most recent)
         let snap_prefix = format!("teams/{}/{}/snapshot/", self.team_id, doc_type.path());
         let snap_keys = self.s3_list(&snap_prefix).await?;
         if snap_keys.len() > 2 {
@@ -1558,12 +1604,12 @@ impl OssSyncManager {
             );
         }
 
-        // 6. Reset local state
+        // 7. Reset local state
         self.known_files.insert(doc_type, HashSet::new());
         self.last_known_key.remove(&doc_type);
         self.last_exported_version.remove(&doc_type);
 
-        // 7. Record compaction time
+        // 8. Record compaction time
         self.last_compaction_at.insert(doc_type, Utc::now());
 
         info!("Compaction complete for {:?}", doc_type);
@@ -2169,6 +2215,46 @@ impl OssSyncManager {
             next_sync_at,
             docs,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OssSyncManager;
+
+    #[test]
+    fn snapshot_reload_only_when_cursor_missing() {
+        assert!(OssSyncManager::should_reload_snapshot_after_empty_listing(
+            true, true
+        ));
+        assert!(!OssSyncManager::should_reload_snapshot_after_empty_listing(
+            true, false
+        ));
+        assert!(!OssSyncManager::should_reload_snapshot_after_empty_listing(
+            false, true
+        ));
+    }
+
+    #[test]
+    fn compaction_deletes_only_pre_snapshot_updates() {
+        let pre_snapshot = vec![
+            "teams/t/notes/updates/a/100.bin".to_string(),
+            "teams/t/notes/updates/a/101.bin".to_string(),
+        ];
+        let current = vec![
+            "teams/t/notes/updates/a/100.bin".to_string(),
+            "teams/t/notes/updates/a/101.bin".to_string(),
+            "teams/t/notes/updates/b/102.bin".to_string(), // concurrent new write
+        ];
+
+        let deletion = OssSyncManager::select_compaction_deletion_keys(&pre_snapshot, &current);
+        assert_eq!(
+            deletion,
+            vec![
+                "teams/t/notes/updates/a/100.bin".to_string(),
+                "teams/t/notes/updates/a/101.bin".to_string(),
+            ]
+        );
     }
 }
 

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -1660,7 +1660,15 @@ impl OssSyncManager {
         loop {
             tokio::time::sleep(fast_interval).await;
 
-            let mut guard = state.lock().await;
+            // Use try_lock: if slow_loop holds the lock, skip this cycle
+            // rather than blocking. The slow_loop does a full sync anyway.
+            let mut guard = match state.try_lock() {
+                Ok(g) => g,
+                Err(_) => {
+                    info!("Fast loop skipped: slow loop is running");
+                    continue;
+                }
+            };
             let manager = match guard.as_mut() {
                 Some(m) => m,
                 None => return,

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -1614,6 +1614,34 @@ pub fn write_oss_config(workspace_path: &str, config: &OssTeamConfig) -> Result<
     Ok(())
 }
 
+fn sync_cursor_path(workspace_path: &str) -> PathBuf {
+    Path::new(workspace_path)
+        .join(TEAMCLAW_DIR)
+        .join("loro")
+        .join("sync_cursor.json")
+}
+
+pub fn read_sync_cursor(workspace_path: &str) -> SyncCursor {
+    let path = sync_cursor_path(workspace_path);
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => SyncCursor::default(),
+    }
+}
+
+pub fn write_sync_cursor(workspace_path: &str, cursor: &SyncCursor) -> Result<(), String> {
+    let path = sync_cursor_path(workspace_path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create cursor dir: {e}"))?;
+    }
+    let json = serde_json::to_string_pretty(cursor)
+        .map_err(|e| format!("Failed to serialize sync cursor: {e}"))?;
+    std::fs::write(&path, json)
+        .map_err(|e| format!("Failed to write sync cursor: {e}"))?;
+    Ok(())
+}
+
 pub fn save_team_secret(team_id: &str, secret: &str) -> Result<(), String> {
     let entry = keyring::Entry::new(KEYRING_SERVICE, team_id)
         .map_err(|e| format!("Failed to create keyring entry: {e}"))?;

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -52,7 +52,6 @@ pub struct OssSyncManager {
     known_signal_keys: HashSet<String>,
 
     poll_interval: Duration,
-    #[allow(dead_code)]
     workspace_path: String,
     team_dir: PathBuf,
     loro_cache_dir: PathBuf,
@@ -64,14 +63,16 @@ pub struct OssSyncManager {
 
 pub struct OssSyncState {
     pub manager: Arc<Mutex<Option<OssSyncManager>>>,
-    pub poll_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    pub fast_poll_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    pub slow_poll_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 impl Default for OssSyncState {
     fn default() -> Self {
         Self {
             manager: Arc::new(Mutex::new(None)),
-            poll_handle: Arc::new(Mutex::new(None)),
+            fast_poll_handle: Arc::new(Mutex::new(None)),
+            slow_poll_handle: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -1584,10 +1585,76 @@ impl OssSyncManager {
     }
 
     // -----------------------------------------------------------------------
-    // Poll Loop
+    // Dual Poll Loops
     // -----------------------------------------------------------------------
 
-    pub async fn poll_loop(state: Arc<Mutex<Option<OssSyncManager>>>) {
+    /// Fast loop: runs every 30 seconds.
+    /// - Checks local file changes (mtime-based) → upload + signal flag
+    /// - Checks signal flags → pull remote changes
+    pub async fn fast_loop(state: Arc<Mutex<Option<OssSyncManager>>>) {
+        let fast_interval = Duration::from_secs(30);
+
+        loop {
+            tokio::time::sleep(fast_interval).await;
+
+            let mut guard = state.lock().await;
+            let manager = match guard.as_mut() {
+                Some(m) => m,
+                None => return,
+            };
+
+            let _ = manager.refresh_token_if_needed().await;
+
+            // 1. Check local changes and upload (incremental scan)
+            let mut any_uploaded = false;
+            for doc_type in DocType::all() {
+                match manager.upload_local_changes_incremental(doc_type).await {
+                    Ok(true) => any_uploaded = true,
+                    Ok(false) => {}
+                    Err(e) => warn!("OSS fast upload error for {:?}: {}", doc_type, e),
+                }
+            }
+
+            // Write signal flag if we uploaded anything
+            if any_uploaded {
+                if let Err(e) = manager.write_signal_flag().await {
+                    warn!("Failed to write signal flag: {}", e);
+                }
+            }
+
+            // 2. Check for remote changes via signal flags
+            match manager.check_signal_flags().await {
+                Ok(true) => {
+                    // New signals found — pull remote changes
+                    for doc_type in DocType::all() {
+                        if let Err(e) = manager.pull_remote_changes(doc_type).await {
+                            warn!("OSS fast pull error for {:?}: {}", doc_type, e);
+                        }
+                        if let Err(e) = manager.write_doc_to_disk(doc_type) {
+                            warn!("OSS fast write_doc_to_disk error for {:?}: {}", doc_type, e);
+                        }
+                    }
+
+                    // Emit status event (data changed)
+                    let now = Utc::now().to_rfc3339();
+                    manager.last_sync_at = Some(now);
+                    if let Some(handle) = &manager.app_handle {
+                        let status = manager.get_sync_status();
+                        let _ = handle.emit("oss-sync-status", &status);
+                    }
+                }
+                Ok(false) => {} // No new signals, skip
+                Err(e) => warn!("Failed to check signal flags: {}", e),
+            }
+        }
+    }
+
+    /// Slow loop: runs every 5 minutes.
+    /// - Unconditional full pull (fallback consistency)
+    /// - Full local file scan
+    /// - Persist snapshots and cursor
+    /// - Compaction and signal cleanup
+    pub async fn slow_loop(state: Arc<Mutex<Option<OssSyncManager>>>) {
         loop {
             let interval = {
                 let mut guard = state.lock().await;
@@ -1595,17 +1662,21 @@ impl OssSyncManager {
                     manager.syncing = true;
                     let _ = manager.refresh_token_if_needed().await;
 
+                    // 1. Full upload + pull for all DocTypes
                     for doc_type in DocType::all() {
                         if let Err(e) = manager.upload_local_changes(doc_type).await {
-                            warn!("OSS upload error for {:?}: {}", doc_type, e);
+                            warn!("OSS slow upload error for {:?}: {}", doc_type, e);
                         }
                         if let Err(e) = manager.pull_remote_changes(doc_type).await {
-                            warn!("OSS pull error for {:?}: {}", doc_type, e);
+                            warn!("OSS slow pull error for {:?}: {}", doc_type, e);
+                        }
+                        if let Err(e) = manager.write_doc_to_disk(doc_type) {
+                            warn!("OSS slow write_doc_to_disk error for {:?}: {}", doc_type, e);
                         }
                         let _ = manager.persist_local_snapshot(doc_type);
                     }
 
-                    // List pending applications for owners/editors
+                    // 2. List pending applications for owners/editors
                     if manager.role() == MemberRole::Owner || manager.role() == MemberRole::Editor {
                         match manager.list_applications().await {
                             Ok(apps) => {
@@ -1617,6 +1688,26 @@ impl OssSyncManager {
                                 warn!("Failed to list applications: {}", e);
                             }
                         }
+                    }
+
+                    // 3. Persist sync cursor
+                    let cursor = manager.export_sync_cursor();
+                    if let Err(e) = write_sync_cursor(&manager.workspace_path, &cursor) {
+                        warn!("Failed to persist sync cursor: {}", e);
+                    }
+
+                    // 4. Compaction check
+                    for doc_type in DocType::all() {
+                        if manager.should_compact(doc_type).await {
+                            if let Err(e) = manager.compact(doc_type).await {
+                                warn!("Compaction failed for {:?}: {}", doc_type, e);
+                            }
+                        }
+                    }
+
+                    // 5. Signal flag cleanup
+                    if let Err(e) = manager.cleanup_expired_signal_flags().await {
+                        warn!("Signal flag cleanup failed: {}", e);
                     }
 
                     manager.syncing = false;

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -18,6 +18,10 @@ use tracing::{info, warn};
 
 const KEYRING_SERVICE: &str = concat!(env!("APP_SHORT_NAME"), "-oss");
 const TOKEN_REFRESH_MARGIN_SECS: i64 = 300; // refresh 5 min before expiry
+/// Maximum file size (in bytes) that will be synced. Files larger than this
+/// are silently skipped during scan to prevent OOM and oversized S3 PUTs.
+/// 2 MB is generous for config/skill/knowledge text files.
+const MAX_SYNC_FILE_SIZE: u64 = 2 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // OssSyncManager
@@ -666,6 +670,17 @@ impl OssSyncManager {
                 if path.is_dir() {
                     walk(base, &path, result)?;
                 } else {
+                    // Skip files exceeding the size limit
+                    if let Ok(meta) = path.metadata() {
+                        if meta.len() > MAX_SYNC_FILE_SIZE {
+                            tracing::warn!(
+                                "Skipping oversized file ({} bytes): {}",
+                                meta.len(),
+                                path.display()
+                            );
+                            continue;
+                        }
+                    }
                     let rel = path
                         .strip_prefix(base)
                         .map_err(|e| format!("Path strip error: {e}"))?;
@@ -716,9 +731,20 @@ impl OssSyncManager {
                 if path.is_dir() {
                     walk_incremental(base, &path, since, result)?;
                 } else {
-                    let dominated = path
-                        .metadata()
-                        .ok()
+                    // Skip files exceeding the size limit
+                    let meta = path.metadata().ok();
+                    if let Some(ref m) = meta {
+                        if m.len() > MAX_SYNC_FILE_SIZE {
+                            tracing::warn!(
+                                "Skipping oversized file ({} bytes): {}",
+                                m.len(),
+                                path.display()
+                            );
+                            continue;
+                        }
+                    }
+
+                    let dominated = meta
                         .and_then(|m| m.modified().ok())
                         .map(|mtime| mtime > since)
                         .unwrap_or(true);

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -1135,13 +1135,32 @@ impl OssSyncManager {
             }
         }
 
-        // Export updates and upload
-        let doc = self.get_doc(doc_type);
-        // TODO: Verify ExportMode for incremental updates in loro v1.
-        // Using updates_till or all_updates — adjust API as needed.
-        let updates = doc
-            .export(loro::ExportMode::all_updates())
-            .map_err(|e| format!("Failed to export loro updates for {:?}: {e}", doc_type))?;
+        // Export updates and upload — use incremental export when a prior version vector exists
+        let updates = {
+            let doc = self.get_doc(doc_type);
+            match self.last_exported_version.get(&doc_type) {
+                Some(vv_bytes) => {
+                    match loro::VersionVector::decode(vv_bytes) {
+                        Ok(vv) => doc
+                            .export(loro::ExportMode::updates(&vv))
+                            .unwrap_or_else(|_| {
+                                doc.export(loro::ExportMode::all_updates())
+                                    .unwrap_or_default()
+                            }),
+                        Err(_) => doc
+                            .export(loro::ExportMode::all_updates())
+                            .map_err(|e| {
+                                format!("Failed to export loro updates for {:?}: {e}", doc_type)
+                            })?,
+                    }
+                }
+                None => doc
+                    .export(loro::ExportMode::all_updates())
+                    .map_err(|e| {
+                        format!("Failed to export loro updates for {:?}: {e}", doc_type)
+                    })?,
+            }
+        };
 
         let timestamp_ms = Utc::now().timestamp_millis();
         let key = format!(
@@ -1160,6 +1179,10 @@ impl OssSyncManager {
             updates.len()
         );
 
+        // Record version vector for future incremental exports
+        let current_vv = self.get_doc(doc_type).oplog_vv().encode();
+        self.last_exported_version.insert(doc_type, current_vv);
+
         Ok(true)
     }
 
@@ -1167,6 +1190,46 @@ impl OssSyncManager {
         let prefix = format!("teams/{}/{}/updates/", self.team_id, doc_type.path());
         let start_after = self.last_known_key.get(&doc_type).map(|s| s.as_str());
         let new_keys = self.s3_list_after(&prefix, start_after).await?;
+
+        // Race condition detection: if we had a cursor but got zero results,
+        // another node may have compacted (deleted all updates).
+        // Fall back to reloading from the latest snapshot.
+        if new_keys.is_empty() && self.last_known_key.contains_key(&doc_type) {
+            let snap_prefix = format!("teams/{}/{}/snapshot/", self.team_id, doc_type.path());
+            let snap_keys = self.s3_list(&snap_prefix).await?;
+            if let Some(latest_snap) = snap_keys.last() {
+                info!(
+                    "Compaction detected for {:?} — reloading from snapshot: {}",
+                    doc_type, latest_snap
+                );
+                let data = self.s3_get(latest_snap).await?;
+                let doc = self.get_doc_mut(doc_type);
+                doc.import(&data)
+                    .map_err(|e| format!("Failed to import snapshot after compaction: {e}"))?;
+
+                // Reset cursor and re-list updates (there may be new ones after the snapshot)
+                self.last_known_key.remove(&doc_type);
+                self.known_files.insert(doc_type, HashSet::new());
+
+                let fresh_keys = self.s3_list(&prefix).await?;
+                for key in &fresh_keys {
+                    let data = self.s3_get(key).await?;
+                    let doc = self.get_doc_mut(doc_type);
+                    doc.import(&data)
+                        .map_err(|e| format!("Failed to import update {key}: {e}"))?;
+                }
+
+                if let Some(last) = fresh_keys.last() {
+                    self.last_known_key.insert(doc_type, last.clone());
+                }
+                let known_set = self.known_files.entry(doc_type).or_default();
+                for key in &fresh_keys {
+                    known_set.insert(key.clone());
+                }
+
+                return Ok(());
+            }
+        }
 
         if new_keys.is_empty() {
             return Ok(());

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -413,6 +413,52 @@ impl OssSyncManager {
         Ok(keys)
     }
 
+    /// Like `s3_list`, but only returns keys lexicographically after `start_after`.
+    /// If `start_after` is None, behaves identically to `s3_list`.
+    async fn s3_list_after(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> Result<Vec<String>, String> {
+        let client = self.client()?;
+        let bucket = self.bucket()?;
+
+        let mut keys: Vec<String> = Vec::new();
+        let mut continuation_token: Option<String> = None;
+
+        loop {
+            let mut req = client.list_objects_v2().bucket(bucket).prefix(prefix);
+
+            if let Some(after) = start_after {
+                req = req.start_after(after);
+            }
+
+            if let Some(token) = &continuation_token {
+                req = req.continuation_token(token);
+            }
+
+            let resp = req
+                .send()
+                .await
+                .map_err(|e| format!("S3 LIST {prefix} failed: {e}"))?;
+
+            for obj in resp.contents() {
+                if let Some(key) = obj.key() {
+                    keys.push(key.to_string());
+                }
+            }
+
+            if resp.is_truncated() == Some(true) {
+                continuation_token = resp.next_continuation_token().map(|s| s.to_string());
+            } else {
+                break;
+            }
+        }
+
+        keys.sort();
+        Ok(keys)
+    }
+
     pub async fn s3_delete(&self, key: &str) -> Result<(), String> {
         let client = self.client()?;
         let bucket = self.bucket()?;
@@ -962,14 +1008,8 @@ impl OssSyncManager {
 
     pub async fn pull_remote_changes(&mut self, doc_type: DocType) -> Result<(), String> {
         let prefix = format!("teams/{}/{}/updates/", self.team_id, doc_type.path());
-        let all_keys = self.s3_list(&prefix).await?;
-
-        let known = self.known_files.get(&doc_type).cloned().unwrap_or_default();
-
-        let new_keys: Vec<String> = all_keys
-            .into_iter()
-            .filter(|k| !known.contains(k))
-            .collect();
+        let start_after = self.last_known_key.get(&doc_type).map(|s| s.as_str());
+        let new_keys = self.s3_list_after(&prefix, start_after).await?;
 
         if new_keys.is_empty() {
             return Ok(());
@@ -988,10 +1028,15 @@ impl OssSyncManager {
                 .map_err(|e| format!("Failed to import update {key}: {e}"))?;
         }
 
-        // Add to known files
+        // Update cursor to the last processed key
+        if let Some(last) = new_keys.last() {
+            self.last_known_key.insert(doc_type, last.clone());
+        }
+
+        // Also maintain known_files for backward compat (get_sync_status uses it)
         let known_set = self.known_files.entry(doc_type).or_default();
-        for key in new_keys {
-            known_set.insert(key);
+        for key in &new_keys {
+            known_set.insert(key.clone());
         }
 
         // Write changes to disk

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -831,7 +831,7 @@ impl OssSyncManager {
     // Sync Operations
     // -----------------------------------------------------------------------
 
-    pub async fn upload_local_changes(&mut self, doc_type: DocType) -> Result<(), String> {
+    pub async fn upload_local_changes(&mut self, doc_type: DocType) -> Result<bool, String> {
         let dir = self.team_dir.join(doc_type.dir_name());
         let local_files = Self::scan_local_files(&dir)?;
         let changed = self.detect_local_changes(doc_type, &local_files);
@@ -859,7 +859,7 @@ impl OssSyncManager {
             }
 
             if !has_deletions {
-                return Ok(());
+                return Ok(false);
             }
         }
 
@@ -957,7 +957,7 @@ impl OssSyncManager {
             updates.len()
         );
 
-        Ok(())
+        Ok(true)
     }
 
     pub async fn pull_remote_changes(&mut self, doc_type: DocType) -> Result<(), String> {

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -4,6 +4,7 @@ use crate::commands::version_types::MAX_VERSIONS;
 use crate::commands::TEAMCLAW_DIR;
 
 use aws_sdk_s3::primitives::ByteStream;
+use futures::stream::{self, StreamExt};
 use chrono::Utc;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -1021,11 +1022,52 @@ impl OssSyncManager {
             doc_type
         );
 
-        for key in &new_keys {
-            let data = self.s3_get(key).await?;
-            let doc = self.get_doc_mut(doc_type);
-            doc.import(&data)
-                .map_err(|e| format!("Failed to import update {key}: {e}"))?;
+        // Download concurrently (up to 5 at a time)
+        if !new_keys.is_empty() {
+            let download_results: Vec<(String, Result<Vec<u8>, String>)> = stream::iter(
+                new_keys.iter().cloned(),
+            )
+            .map(|key| {
+                let client = self.client().cloned();
+                let bucket = self.bucket().map(|b| b.to_string());
+                async move {
+                    let result = match (client, bucket) {
+                        (Ok(c), Ok(b)) => {
+                            match c
+                                .get_object()
+                                .bucket(&b)
+                                .key(&key)
+                                .send()
+                                .await
+                            {
+                                Ok(resp) => resp
+                                    .body
+                                    .collect()
+                                    .await
+                                    .map(|d| d.into_bytes().to_vec())
+                                    .map_err(|e| format!("S3 GET {key} body read failed: {e}")),
+                                Err(e) => Err(format!("S3 GET {key} failed: {e}")),
+                            }
+                        }
+                        (Err(e), _) | (_, Err(e)) => Err(e),
+                    };
+                    (key, result)
+                }
+            })
+            .buffer_unordered(5)
+            .collect()
+            .await;
+
+            // Import in key order (keys are sorted by timestamp)
+            let mut sorted_results = download_results;
+            sorted_results.sort_by(|a, b| a.0.cmp(&b.0));
+
+            for (key, result) in sorted_results {
+                let data = result?;
+                let doc = self.get_doc_mut(doc_type);
+                doc.import(&data)
+                    .map_err(|e| format!("Failed to import update {key}: {e}"))?;
+            }
         }
 
         // Update cursor to the last processed key

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -689,6 +689,16 @@ impl OssSyncManager {
                     let rel_str = rel.to_string_lossy().to_string();
                     let content = std::fs::read(&path)
                         .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+                    // Skip binary files — CRDT stores content as UTF-8 strings,
+                    // and from_utf8_lossy would corrupt binary data and cause
+                    // infinite re-upload (hash mismatch every cycle).
+                    if std::str::from_utf8(&content).is_err() {
+                        tracing::warn!(
+                            "Skipping non-UTF-8 file: {}",
+                            path.display()
+                        );
+                        continue;
+                    }
                     result.insert(rel_str, content);
                 }
             }
@@ -758,6 +768,13 @@ impl OssSyncManager {
                         let rel_str = rel.to_string_lossy().to_string();
                         let content = std::fs::read(&path)
                             .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+                        if std::str::from_utf8(&content).is_err() {
+                            tracing::warn!(
+                                "Skipping non-UTF-8 file: {}",
+                                path.display()
+                            );
+                            continue;
+                        }
                         result.insert(rel_str, content);
                     }
                 }
@@ -771,6 +788,10 @@ impl OssSyncManager {
 
     /// Fast-path upload: only check files modified since last scan (mtime-based).
     /// Returns `Ok(true)` if changes were uploaded.
+    ///
+    /// Only uploads changed/new files — does NOT detect deletions (that's the
+    /// slow_loop's job via full `upload_local_changes`). This avoids a redundant
+    /// full directory scan every 30 seconds.
     pub async fn upload_local_changes_incremental(
         &mut self,
         doc_type: DocType,
@@ -782,19 +803,99 @@ impl OssSyncManager {
             .copied()
             .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
 
-        let local_files = Self::scan_local_files_incremental(&dir, since)?;
+        let mtime_changed = Self::scan_local_files_incremental(&dir, since)?;
 
-        if local_files.is_empty() {
+        if mtime_changed.is_empty() {
             return Ok(false);
         }
 
-        // Update scan time before processing
+        // Filter to only truly changed files (hash differs from CRDT)
+        let changed = self.detect_local_changes(doc_type, &mtime_changed);
+        if changed.is_empty() {
+            // mtime changed but content didn't (e.g. touch, copy with same content)
+            self.last_scan_time
+                .insert(doc_type, std::time::SystemTime::now());
+            return Ok(false);
+        }
+
         self.last_scan_time
             .insert(doc_type, std::time::SystemTime::now());
 
-        // Delegate to the full upload_local_changes which will detect
-        // changes via hash comparison against the Loro doc
-        self.upload_local_changes(doc_type).await
+        // Update CRDT with only the changed files, then export and upload
+        let now = Utc::now().to_rfc3339();
+        let node_id = self.node_id.clone();
+        {
+            let doc = self.get_doc_mut(doc_type);
+            let files_map = doc.get_map("files");
+
+            for path in &changed {
+                if let Some(content) = mtime_changed.get(path) {
+                    Self::archive_current_version(&files_map, path)?;
+
+                    let hash = Self::compute_hash(content);
+                    let content_str = String::from_utf8_lossy(content).to_string();
+
+                    let entry_map = files_map
+                        .get_or_create_container(path, loro::LoroMap::new())
+                        .map_err(|e| format!("Failed to get/create map entry for {path}: {e}"))?;
+                    entry_map.insert("content", content_str.as_str())
+                        .map_err(|e| format!("Failed to set content for {path}: {e}"))?;
+                    entry_map.insert("hash", hash.as_str())
+                        .map_err(|e| format!("Failed to set hash for {path}: {e}"))?;
+                    entry_map.insert("deleted", false)
+                        .map_err(|e| format!("Failed to set deleted for {path}: {e}"))?;
+                    entry_map.insert("updatedBy", node_id.as_str())
+                        .map_err(|e| format!("Failed to set updatedBy for {path}: {e}"))?;
+                    entry_map.insert("updatedAt", now.as_str())
+                        .map_err(|e| format!("Failed to set updatedAt for {path}: {e}"))?;
+                }
+            }
+        }
+
+        // Export and upload
+        let updates = {
+            let doc = self.get_doc(doc_type);
+            match self.last_exported_version.get(&doc_type) {
+                Some(vv_bytes) => {
+                    match loro::VersionVector::decode(vv_bytes) {
+                        Ok(vv) => doc
+                            .export(loro::ExportMode::updates(&vv))
+                            .unwrap_or_else(|_| {
+                                doc.export(loro::ExportMode::all_updates())
+                                    .unwrap_or_default()
+                            }),
+                        Err(_) => doc
+                            .export(loro::ExportMode::all_updates())
+                            .map_err(|e| format!("Failed to export updates for {:?}: {e}", doc_type))?,
+                    }
+                }
+                None => doc
+                    .export(loro::ExportMode::all_updates())
+                    .map_err(|e| format!("Failed to export updates for {:?}: {e}", doc_type))?,
+            }
+        };
+
+        let timestamp_ms = Utc::now().timestamp_millis();
+        let key = format!(
+            "teams/{}/{}/updates/{}/{}.bin",
+            self.team_id,
+            doc_type.path(),
+            self.node_id,
+            timestamp_ms
+        );
+
+        self.s3_put(&key, &updates).await?;
+        info!(
+            "Incremental upload: {} changes for {:?} ({} bytes)",
+            changed.len(),
+            doc_type,
+            updates.len()
+        );
+
+        let current_vv = self.get_doc(doc_type).oplog_vv().encode();
+        self.last_exported_version.insert(doc_type, current_vv);
+
+        Ok(true)
     }
 
     fn compute_hash(content: &[u8]) -> String {

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -39,6 +39,17 @@ pub struct OssSyncManager {
     role: MemberRole,
     known_files: HashMap<DocType, HashSet<String>>,
 
+    /// Last processed S3 key per DocType, for start_after pruning
+    last_known_key: HashMap<DocType, String>,
+    /// Last exported Loro version vector bytes per DocType, for incremental export
+    last_exported_version: HashMap<DocType, Vec<u8>>,
+    /// Last local file scan time per DocType, for mtime-based incremental scanning
+    last_scan_time: HashMap<DocType, std::time::SystemTime>,
+    /// Last compaction time per DocType
+    last_compaction_at: HashMap<DocType, chrono::DateTime<Utc>>,
+    /// Signal flag keys already seen (to avoid re-triggering pulls)
+    known_signal_keys: HashSet<String>,
+
     poll_interval: Duration,
     #[allow(dead_code)]
     workspace_path: String,
@@ -87,6 +98,22 @@ impl OssSyncManager {
             known_files.insert(dt, HashSet::new());
         }
 
+        let cursor = read_sync_cursor(&workspace_path);
+
+        let mut last_known_key = HashMap::new();
+        let mut last_compaction_at_map = HashMap::new();
+        for dt in DocType::all() {
+            if let Some(key) = cursor.last_known_keys.get(dt.path()) {
+                last_known_key.insert(dt, key.clone());
+            }
+            if let Some(ts_str) = cursor.last_compaction_at.get(dt.path()) {
+                if let Ok(dt_parsed) = chrono::DateTime::parse_from_rfc3339(ts_str) {
+                    last_compaction_at_map.insert(dt, dt_parsed.with_timezone(&Utc));
+                }
+            }
+        }
+        let known_signal_keys: HashSet<String> = cursor.known_signal_keys.into_iter().collect();
+
         Self {
             s3_client: None,
             credentials: None,
@@ -101,6 +128,11 @@ impl OssSyncManager {
             team_secret,
             role: MemberRole::Editor,
             known_files,
+            last_known_key,
+            last_exported_version: HashMap::new(),
+            last_scan_time: HashMap::new(),
+            last_compaction_at: last_compaction_at_map,
+            known_signal_keys,
             poll_interval,
             workspace_path,
             team_dir,
@@ -146,6 +178,22 @@ impl OssSyncManager {
 
     pub fn set_last_sync_at(&mut self, ts: Option<String>) {
         self.last_sync_at = ts;
+    }
+
+    pub fn export_sync_cursor(&self) -> SyncCursor {
+        let mut last_known_keys = HashMap::new();
+        for (dt, key) in &self.last_known_key {
+            last_known_keys.insert(dt.path().to_string(), key.clone());
+        }
+        let mut last_compaction_at = HashMap::new();
+        for (dt, ts) in &self.last_compaction_at {
+            last_compaction_at.insert(dt.path().to_string(), ts.to_rfc3339());
+        }
+        SyncCursor {
+            last_known_keys,
+            known_signal_keys: self.known_signal_keys.iter().cloned().collect(),
+            last_compaction_at,
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -517,8 +517,9 @@ impl OssSyncManager {
         Ok(has_new)
     }
 
-    /// Delete signal flags older than 1 hour.
-    async fn cleanup_expired_signal_flags(&self) -> Result<u32, String> {
+    /// Delete signal flags older than 1 hour, and prune matching entries
+    /// from `known_signal_keys` to prevent unbounded memory growth.
+    async fn cleanup_expired_signal_flags(&mut self) -> Result<u32, String> {
         let prefix = format!("teams/{}/signal/", self.team_id);
         let flags = self.s3_list(&prefix).await?;
         let one_hour_ago_ms = Utc::now().timestamp_millis() - 3_600_000;
@@ -528,6 +529,7 @@ impl OssSyncManager {
             if let Some(ts) = Self::extract_timestamp_from_flag_key(key) {
                 if ts < one_hour_ago_ms {
                     self.s3_delete(key).await?;
+                    self.known_signal_keys.remove(key);
                     deleted += 1;
                 }
             }
@@ -1681,10 +1683,19 @@ impl OssSyncManager {
     /// - Checks local file changes (mtime-based) → upload + signal flag
     /// - Checks signal flags → pull remote changes
     pub async fn fast_loop(state: Arc<Mutex<Option<OssSyncManager>>>) {
-        let fast_interval = Duration::from_secs(30);
+        let base_interval = Duration::from_secs(30);
+        let max_interval = Duration::from_secs(300); // back off up to 5 min
+        let mut consecutive_failures: u32 = 0;
 
         loop {
-            tokio::time::sleep(fast_interval).await;
+            // Exponential backoff: 30s, 60s, 120s, 240s, 300s (capped)
+            let sleep_duration = if consecutive_failures == 0 {
+                base_interval
+            } else {
+                let backoff_secs = 30u64 * 2u64.pow(consecutive_failures.min(4));
+                Duration::from_secs(backoff_secs).min(max_interval)
+            };
+            tokio::time::sleep(sleep_duration).await;
 
             // Use try_lock: if slow_loop holds the lock, skip this cycle
             // rather than blocking. The slow_loop does a full sync anyway.
@@ -1702,13 +1713,19 @@ impl OssSyncManager {
 
             let _ = manager.refresh_token_if_needed().await;
 
+            // Track whether any S3 call fails this cycle
+            let mut had_network_error = false;
+
             // 1. Check local changes and upload (incremental scan)
             let mut any_uploaded = false;
             for doc_type in DocType::all() {
                 match manager.upload_local_changes_incremental(doc_type).await {
                     Ok(true) => any_uploaded = true,
                     Ok(false) => {}
-                    Err(e) => warn!("OSS fast upload error for {:?}: {}", doc_type, e),
+                    Err(e) => {
+                        warn!("OSS fast upload error for {:?}: {}", doc_type, e);
+                        had_network_error = true;
+                    }
                 }
             }
 
@@ -1716,32 +1733,52 @@ impl OssSyncManager {
             if any_uploaded {
                 if let Err(e) = manager.write_signal_flag().await {
                     warn!("Failed to write signal flag: {}", e);
+                    had_network_error = true;
                 }
             }
 
             // 2. Check for remote changes via signal flags
-            match manager.check_signal_flags().await {
-                Ok(true) => {
-                    // New signals found — pull remote changes
-                    for doc_type in DocType::all() {
-                        if let Err(e) = manager.pull_remote_changes(doc_type).await {
-                            warn!("OSS fast pull error for {:?}: {}", doc_type, e);
+            if !had_network_error {
+                match manager.check_signal_flags().await {
+                    Ok(true) => {
+                        // New signals found — pull remote changes
+                        for doc_type in DocType::all() {
+                            if let Err(e) = manager.pull_remote_changes(doc_type).await {
+                                warn!("OSS fast pull error for {:?}: {}", doc_type, e);
+                                had_network_error = true;
+                            }
+                            if let Err(e) = manager.write_doc_to_disk(doc_type) {
+                                warn!("OSS fast write_doc_to_disk error for {:?}: {}", doc_type, e);
+                            }
                         }
-                        if let Err(e) = manager.write_doc_to_disk(doc_type) {
-                            warn!("OSS fast write_doc_to_disk error for {:?}: {}", doc_type, e);
+
+                        // Emit status event (data changed)
+                        let now = Utc::now().to_rfc3339();
+                        manager.last_sync_at = Some(now);
+                        if let Some(handle) = &manager.app_handle {
+                            let status = manager.get_sync_status();
+                            let _ = handle.emit("oss-sync-status", &status);
                         }
                     }
-
-                    // Emit status event (data changed)
-                    let now = Utc::now().to_rfc3339();
-                    manager.last_sync_at = Some(now);
-                    if let Some(handle) = &manager.app_handle {
-                        let status = manager.get_sync_status();
-                        let _ = handle.emit("oss-sync-status", &status);
+                    Ok(false) => {} // No new signals, skip
+                    Err(e) => {
+                        warn!("Failed to check signal flags: {}", e);
+                        had_network_error = true;
                     }
                 }
-                Ok(false) => {} // No new signals, skip
-                Err(e) => warn!("Failed to check signal flags: {}", e),
+            }
+
+            // Update backoff state
+            if had_network_error {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                if consecutive_failures == 1 {
+                    warn!("Fast loop: network error, will back off");
+                }
+            } else {
+                if consecutive_failures > 0 {
+                    info!("Fast loop: network recovered after {} failures", consecutive_failures);
+                }
+                consecutive_failures = 0;
             }
         }
     }
@@ -1752,6 +1789,9 @@ impl OssSyncManager {
     /// - Persist snapshots and cursor
     /// - Compaction and signal cleanup
     pub async fn slow_loop(state: Arc<Mutex<Option<OssSyncManager>>>) {
+        let max_interval = Duration::from_secs(3600); // back off up to 1 hour
+        let mut consecutive_failures: u32 = 0;
+
         loop {
             let interval = {
                 let mut guard = state.lock().await;
@@ -1759,13 +1799,17 @@ impl OssSyncManager {
                     manager.syncing = true;
                     let _ = manager.refresh_token_if_needed().await;
 
+                    let mut had_network_error = false;
+
                     // 1. Full upload + pull for all DocTypes
                     for doc_type in DocType::all() {
                         if let Err(e) = manager.upload_local_changes(doc_type).await {
                             warn!("OSS slow upload error for {:?}: {}", doc_type, e);
+                            had_network_error = true;
                         }
                         if let Err(e) = manager.pull_remote_changes(doc_type).await {
                             warn!("OSS slow pull error for {:?}: {}", doc_type, e);
+                            had_network_error = true;
                         }
                         if let Err(e) = manager.write_doc_to_disk(doc_type) {
                             warn!("OSS slow write_doc_to_disk error for {:?}: {}", doc_type, e);
@@ -1793,18 +1837,20 @@ impl OssSyncManager {
                         warn!("Failed to persist sync cursor: {}", e);
                     }
 
-                    // 4. Compaction check
-                    for doc_type in DocType::all() {
-                        if manager.should_compact(doc_type).await {
-                            if let Err(e) = manager.compact(doc_type).await {
-                                warn!("Compaction failed for {:?}: {}", doc_type, e);
+                    // 4. Compaction check (skip if network is down)
+                    if !had_network_error {
+                        for doc_type in DocType::all() {
+                            if manager.should_compact(doc_type).await {
+                                if let Err(e) = manager.compact(doc_type).await {
+                                    warn!("Compaction failed for {:?}: {}", doc_type, e);
+                                }
                             }
                         }
-                    }
 
-                    // 5. Signal flag cleanup
-                    if let Err(e) = manager.cleanup_expired_signal_flags().await {
-                        warn!("Signal flag cleanup failed: {}", e);
+                        // 5. Signal flag cleanup
+                        if let Err(e) = manager.cleanup_expired_signal_flags().await {
+                            warn!("Signal flag cleanup failed: {}", e);
+                        }
                     }
 
                     manager.syncing = false;
@@ -1817,7 +1863,21 @@ impl OssSyncManager {
                         let _ = handle.emit("oss-sync-status", &status);
                     }
 
-                    manager.poll_interval
+                    // Backoff on network errors: 5m, 10m, 20m, 40m, 60m (capped)
+                    if had_network_error {
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                        if consecutive_failures == 1 {
+                            warn!("Slow loop: network error, will back off");
+                        }
+                        let backoff = manager.poll_interval * 2u32.pow(consecutive_failures.min(4));
+                        backoff.min(max_interval)
+                    } else {
+                        if consecutive_failures > 0 {
+                            info!("Slow loop: network recovered after {} failures", consecutive_failures);
+                        }
+                        consecutive_failures = 0;
+                        manager.poll_interval
+                    }
                 } else {
                     return;
                 }

--- a/src-tauri/src/commands/oss_types.rs
+++ b/src-tauri/src/commands/oss_types.rs
@@ -161,3 +161,17 @@ pub struct FileSyncStatus {
     pub doc_type: String,
     pub status: SyncFileStatus,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncCursor {
+    /// Last processed update key per DocType (for start_after pruning)
+    #[serde(default)]
+    pub last_known_keys: HashMap<String, String>,
+    /// Signal flag keys already processed
+    #[serde(default)]
+    pub known_signal_keys: Vec<String>,
+    /// Last compaction timestamp per DocType (RFC3339)
+    #[serde(default)]
+    pub last_compaction_at: HashMap<String, String>,
+}


### PR DESCRIPTION
## Summary

- **Dual fast/slow loop architecture**: Replace single poll_loop with fast loop (frequent local scans) and slow loop (periodic full sync)
- **Incremental scanning**: mtime-based local file scanning with SyncCursor persistence, skip no-op uploads
- **Concurrent S3 downloads**: Up to 5 parallel downloads in pull_remote_changes, pruned S3 LIST with start_after
- **CRDT compaction**: Snapshot consolidation with race condition handling for incremental exports
- **Signal flags**: Write/check/cleanup methods for coordinating sync signals between loops
- **Robustness**: Network backoff, memory leak fix for known_signal_keys, try_lock to avoid blocking
- **File filtering**: Skip binary files and files >2MB during sync scan
- **Team dir cleanup**: Archive as zip before re-join instead of deleting, clean before join to prevent stale re-upload

## Test plan

- [ ] `cargo check` passes
- [ ] OSS sync connects and syncs files correctly
- [ ] Large files (>2MB) are skipped
- [ ] Binary files are skipped
- [ ] Re-join archives old team dir as zip
- [ ] Signal flags coordinate fast/slow loops without conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)