### PR TITLE
Add real P2P test coverage and sync fixes

### DIFF
--- a/packages/app/src/components/__tests__/NodeStatusPopover.test.tsx
+++ b/packages/app/src/components/__tests__/NodeStatusPopover.test.tsx
@@ -21,6 +21,8 @@ const p2pEngineStoreMock = vi.hoisted(() => ({
 
 const teamMembersStoreMock = vi.hoisted(() => ({
   members: [],
+  currentNodeId: null,
+  loadCurrentNodeId: vi.fn(),
 }))
 
 vi.mock('@/stores/p2p-engine', () => ({
@@ -57,6 +59,8 @@ import { NodeStatusPopover } from '../NodeStatusPopover'
 describe('NodeStatusPopover', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    teamMembersStoreMock.currentNodeId = 'local-node'
+    teamMembersStoreMock.loadCurrentNodeId = vi.fn(async () => {})
     teamMembersStoreMock.members = [
       {
         nodeId: 'local-node',

--- a/packages/app/src/components/chat/__tests__/SessionList.test.tsx
+++ b/packages/app/src/components/chat/__tests__/SessionList.test.tsx
@@ -80,7 +80,10 @@ vi.mock('@/stores/ui', () => ({
     (selector: (s: unknown) => unknown) =>
       selector({ layoutMode: mockLayoutMode, setFileModeRightTab: mockSetFileModeRightTab }),
     {
-      getState: () => ({ layoutMode: mockLayoutMode }),
+      getState: () => ({
+        layoutMode: mockLayoutMode,
+        switchToSession: mockSetActiveSession,
+      }),
     },
   ),
 }))

--- a/packages/app/src/components/settings/__tests__/TeamMemberList.test.tsx
+++ b/packages/app/src/components/settings/__tests__/TeamMemberList.test.tsx
@@ -19,6 +19,8 @@ const teamMembersStoreMock = vi.hoisted(() => ({
   approveApplication: vi.fn(),
   listenForApplications: vi.fn(),
   cleanupApplicationsListener: vi.fn(),
+  currentNodeId: null,
+  loadCurrentNodeId: vi.fn(),
 }))
 
 const p2pEngineStoreMock = vi.hoisted(() => ({
@@ -53,6 +55,8 @@ import { TeamMemberList } from '../TeamMemberList'
 describe('TeamMemberList', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    teamMembersStoreMock.currentNodeId = 'node-1'
+    teamMembersStoreMock.loadCurrentNodeId = vi.fn(async () => {})
     teamMembersStoreMock.members = [
       {
         nodeId: 'node-1',

--- a/packages/app/src/components/settings/channels/Wecom.tsx
+++ b/packages/app/src/components/settings/channels/Wecom.tsx
@@ -94,7 +94,7 @@ function WeComSetupWizard({
   const [secret, setSecret] = React.useState(existingSecret || '')
   const [method, setMethod] = React.useState<'qr' | 'manual' | null>(null)
   const [qrAuthUrl, setQrAuthUrl] = React.useState<string | null>(null)
-  const [_qrScode, setQrScode] = React.useState<string | null>(null)
+  const [, setQrScode] = React.useState<string | null>(null)
   const [qrLoading, setQrLoading] = React.useState(false)
   const [qrError, setQrError] = React.useState<string>('')
   const [scanStatus, setScanStatus] = React.useState<string>('')

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -198,7 +198,7 @@ export function TeamP2PConfig() {
 
   const allowedMembers = syncStatus?.members ?? []
   const isOwner = syncStatus?.role === 'owner'
-  const isConnected = engineSnapshot.status === 'connected' || (syncStatus?.connected ?? false)
+  const isConnected = engineSnapshot?.status === 'connected' || (syncStatus?.connected ?? false)
   const docTicket = syncStatus?.docTicket ?? null
 
   // Load device info, sync status, and reconnect on mount

--- a/packages/app/src/components/settings/team/__tests__/TeamP2PConfig.test.tsx
+++ b/packages/app/src/components/settings/team/__tests__/TeamP2PConfig.test.tsx
@@ -72,8 +72,18 @@ vi.mock('@/stores/team-mode', () => ({
 }))
 
 vi.mock('@/stores/p2p-engine', () => ({
-  useP2pEngineStore: (sel: (s: Record<string, unknown>) => unknown) =>
-    sel(p2pEngineStoreMocks as unknown as Record<string, unknown>),
+  useP2pEngineStore: Object.assign(
+    (sel: (s: Record<string, unknown>) => unknown) =>
+      sel(p2pEngineStoreMocks as unknown as Record<string, unknown>),
+    {
+      getState: () => ({
+        snapshot: p2pEngineStoreMocks.snapshot,
+        initialized: p2pEngineStoreMocks.initialized,
+        init: p2pEngineStoreMocks.init,
+        fetch: vi.fn(async () => {}),
+      }),
+    },
+  ),
 }))
 
 vi.mock('@/stores/team-members', () => ({

--- a/packages/app/src/stores/p2p-engine.ts
+++ b/packages/app/src/stores/p2p-engine.ts
@@ -46,6 +46,20 @@ interface P2pEngineState {
   fetch: () => Promise<void>
 }
 
+function isEngineSnapshot(value: unknown): value is EngineSnapshot {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<EngineSnapshot>
+  return (
+    typeof candidate.status === 'string' &&
+    typeof candidate.streamHealth === 'string' &&
+    typeof candidate.uptimeSecs === 'number' &&
+    typeof candidate.restartCount === 'number' &&
+    Array.isArray(candidate.peers) &&
+    typeof candidate.syncedFiles === 'number' &&
+    typeof candidate.pendingFiles === 'number'
+  )
+}
+
 export const useP2pEngineStore = create<P2pEngineState>((set, get) => ({
   snapshot: DEFAULT_SNAPSHOT,
   initialized: false,
@@ -81,8 +95,10 @@ export const useP2pEngineStore = create<P2pEngineState>((set, get) => ({
     if (!isTauri()) return
     try {
       const { invoke } = await import('@tauri-apps/api/core')
-      const snapshot = await invoke<EngineSnapshot>('p2p_node_status')
-      set({ snapshot })
+      const snapshot = await invoke<EngineSnapshot | null>('p2p_node_status')
+      if (isEngineSnapshot(snapshot)) {
+        set({ snapshot })
+      }
     } catch (err) {
       console.warn('[P2pEngine] Failed to fetch engine snapshot:', err)
     }
@@ -91,7 +107,7 @@ export const useP2pEngineStore = create<P2pEngineState>((set, get) => ({
 
 // Sync p2pConnected to team-mode store so existing consumers keep working
 useP2pEngineStore.subscribe((state) => {
-  const connected = state.snapshot.status === 'connected'
+  const connected = state.snapshot?.status === 'connected'
   if (useTeamModeStore.getState().p2pConnected !== connected) {
     useTeamModeStore.setState({ p2pConnected: connected })
   }

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -166,10 +166,7 @@ impl SyncEngine {
                 name: p.name.clone(),
                 role: p.role.clone(),
                 connection: p.connection(),
-                last_seen_secs_ago: p
-                    .last_activity
-                    .map(|t| t.elapsed().as_secs())
-                    .unwrap_or(0),
+                last_seen_secs_ago: p.last_activity.map(|t| t.elapsed().as_secs()).unwrap_or(0),
                 entries_sent: p.entries_sent,
                 entries_received: p.entries_received,
             })
@@ -225,8 +222,12 @@ impl SyncEngine {
 
     /// Record that a file has been synced with the given local mtime.
     pub fn record_file_synced(&mut self, key: String, mtime: SystemTime) {
-        self.file_sync_records
-            .insert(key, FileSyncRecord { local_mtime_at_sync: mtime });
+        self.file_sync_records.insert(
+            key,
+            FileSyncRecord {
+                local_mtime_at_sync: mtime,
+            },
+        );
     }
 }
 
@@ -353,8 +354,22 @@ impl IrohNode {
 
     /// Gracefully shut down the iroh node.
     #[allow(dead_code)]
-    pub async fn shutdown(self) {
-        self.router.shutdown().await.ok();
+    pub async fn shutdown(mut self) {
+        self.bump_sync_generation();
+        if let Some(doc) = self.active_doc.take() {
+            if tokio::time::timeout(std::time::Duration::from_secs(5), doc.leave())
+                .await
+                .is_err()
+            {
+                eprintln!("[P2P] Timed out leaving active doc during shutdown");
+            }
+        }
+        if tokio::time::timeout(std::time::Duration::from_secs(5), self.router.shutdown())
+            .await
+            .is_err()
+        {
+            eprintln!("[P2P] Timed out shutting down iroh router");
+        }
     }
 
     /// Bump the sync generation, causing all running sync tasks to exit.
@@ -671,7 +686,10 @@ pub async fn join_team_drive(
 
         // If we've synced some files, no need to wait the full 10s
         if file_count > 0 && attempt >= 3 {
-            eprintln!("[P2P] Got {} files after {}s, proceeding", file_count, attempt);
+            eprintln!(
+                "[P2P] Got {} files after {}s, proceeding",
+                file_count, attempt
+            );
             break;
         }
     }
@@ -884,7 +902,10 @@ async fn reconcile_disk_and_doc(
             if let Ok(remote_content) = blobs_store.blobs().get_bytes(entry.content_hash()).await {
                 if is_tombstone(&remote_content) {
                     let file_path = team_path.join(&key);
-                    eprintln!("[P2P][reconcile] Remote tombstone -> deleting local: {}", key);
+                    eprintln!(
+                        "[P2P][reconcile] Remote tombstone -> deleting local: {}",
+                        key
+                    );
                     let _ = std::fs::remove_file(&file_path);
                     continue;
                 }
@@ -926,7 +947,10 @@ async fn reconcile_disk_and_doc(
                     if let Err(e) = doc.set_bytes(author, key.clone(), content).await {
                         eprintln!("[P2P][reconcile] Failed to upload {}: {}", key, e);
                     } else {
-                        eprintln!("[P2P][reconcile] Conflict -> local wins (edited offline): {}", key);
+                        eprintln!(
+                            "[P2P][reconcile] Conflict -> local wins (edited offline): {}",
+                            key
+                        );
                         uploaded += 1;
                     }
                 } else {
@@ -939,7 +963,10 @@ async fn reconcile_disk_and_doc(
                             if let Err(e) = std::fs::write(&file_path, &content) {
                                 eprintln!("[P2P][reconcile] Failed to write {}: {}", key, e);
                             } else {
-                                eprintln!("[P2P][reconcile] Conflict -> remote wins (local stale): {}", key);
+                                eprintln!(
+                                    "[P2P][reconcile] Conflict -> remote wins (local stale): {}",
+                                    key
+                                );
                                 downloaded += 1;
                             }
                         }
@@ -1033,13 +1060,21 @@ pub async fn rotate_namespace(
     workspace_path: &str,
     engine: SyncEngineState,
 ) -> Result<String, String> {
+    let previous_config = read_p2p_config(workspace_path)?.unwrap_or_default();
+    let previous_manifest = read_members_manifest(team_dir)?;
+    let previous_team_info =
+        std::fs::read(Path::new(team_dir).join("_team").join("team.json")).ok();
+
+    // Stop the old namespace's watchers before we reuse the same team dir.
+    node.bump_sync_generation();
+
     // Close existing doc
     if let Some(old_doc) = node.active_doc.take() {
         let _ = old_doc.leave().await;
     }
 
-    // Re-create as owner
-    create_team(
+    // Re-create as owner in a new namespace.
+    let ticket = create_team(
         node,
         team_dir,
         workspace_path,
@@ -1052,7 +1087,66 @@ pub async fn rotate_namespace(
         None,
         engine,
     )
-    .await
+    .await?;
+
+    let owner_node_id = previous_manifest
+        .as_ref()
+        .map(|manifest| manifest.owner_node_id.clone())
+        .or_else(|| previous_config.owner_node_id.clone())
+        .unwrap_or_else(|| get_node_id(node));
+    let restored_members = previous_manifest
+        .as_ref()
+        .map(|manifest| manifest.members.clone())
+        .unwrap_or_else(|| previous_config.allowed_members.clone());
+
+    if !restored_members.is_empty() {
+        write_members_manifest(team_dir, &owner_node_id, &restored_members)?;
+    }
+
+    if let Some(team_info_bytes) = previous_team_info {
+        let team_info_path = Path::new(team_dir).join("_team").join("team.json");
+        if let Some(parent) = team_info_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        std::fs::write(&team_info_path, &team_info_bytes)
+            .map_err(|e| format!("Failed to restore team.json after rotation: {}", e))?;
+    }
+
+    let mut new_config = read_p2p_config(workspace_path)?.unwrap_or_default();
+    new_config.tickets = previous_config.tickets;
+    new_config.publish_enabled = previous_config.publish_enabled;
+    new_config.last_sync_at = previous_config.last_sync_at;
+    new_config.owner_node_id = Some(owner_node_id.clone());
+    new_config.allowed_members = restored_members.clone();
+    new_config.role = previous_config.role.or(Some(MemberRole::Owner));
+    new_config.seed_url = previous_config.seed_url;
+    new_config.team_secret = previous_config.team_secret;
+    new_config.seed_iroh_node_id = previous_config.seed_iroh_node_id;
+    new_config.seed_iroh_relay_url = previous_config.seed_iroh_relay_url;
+    new_config.seed_iroh_addrs = previous_config.seed_iroh_addrs;
+    new_config.cached_peer_addrs = previous_config.cached_peer_addrs;
+    write_p2p_config(workspace_path, Some(&new_config))?;
+
+    if let Some(doc) = node.active_doc.as_ref() {
+        if !restored_members.is_empty() {
+            let manifest_bytes =
+                std::fs::read(Path::new(team_dir).join("_team").join("members.json"))
+                    .map_err(|e| format!("Failed to read restored members.json: {}", e))?;
+            doc.set_bytes(node.author, "_team/members.json", manifest_bytes)
+                .await
+                .map_err(|e| format!("Failed to sync restored members.json: {}", e))?;
+        }
+
+        if let Some(team_info_bytes) =
+            std::fs::read(Path::new(team_dir).join("_team").join("team.json")).ok()
+        {
+            doc.set_bytes(node.author, "_team/team.json", team_info_bytes)
+                .await
+                .map_err(|e| format!("Failed to sync restored team.json: {}", e))?;
+        }
+    }
+
+    Ok(ticket)
 }
 
 // ─── Background Sync Tasks ──────────────────────────────────────────────
@@ -1465,7 +1559,11 @@ fn start_sync_tasks(
             // Mark stream health
             {
                 let mut eng = engine.lock().await;
-                eng.stream_health = if restart_count == 0 { StreamHealth::Healthy } else { StreamHealth::Restarting };
+                eng.stream_health = if restart_count == 0 {
+                    StreamHealth::Healthy
+                } else {
+                    StreamHealth::Restarting
+                };
                 eng.restart_count = restart_count;
             }
             emit_engine_state(&app_handle, &engine).await;
@@ -1484,10 +1582,17 @@ fn start_sync_tasks(
             let manifest_lock_a = manifest_lock.clone();
             let task_a = tokio::spawn(async move {
                 doc_to_disk_watcher(
-                    doc_a, blobs_a, team_dir_a, suppressed_a,
-                    my_node_id_a, owner_node_id_a, app_handle_a, engine_a,
+                    doc_a,
+                    blobs_a,
+                    team_dir_a,
+                    suppressed_a,
+                    my_node_id_a,
+                    owner_node_id_a,
+                    app_handle_a,
+                    engine_a,
                     manifest_lock_a,
-                ).await;
+                )
+                .await;
                 "doc_to_disk"
             });
 
@@ -1503,10 +1608,18 @@ fn start_sync_tasks(
             let manifest_lock_b = manifest_lock.clone();
             let task_b = tokio::spawn(async move {
                 disk_to_doc_watcher(
-                    doc_b, blobs_b, author, team_dir_b, suppressed_b,
-                    my_role_b, my_node_id_b, owner_node_id_b, engine_b,
+                    doc_b,
+                    blobs_b,
+                    author,
+                    team_dir_b,
+                    suppressed_b,
+                    my_role_b,
+                    my_node_id_b,
+                    owner_node_id_b,
+                    engine_b,
                     manifest_lock_b,
-                ).await;
+                )
+                .await;
                 "disk_to_doc"
             });
 
@@ -1522,10 +1635,17 @@ fn start_sync_tasks(
             let app_handle_c = app_handle.clone();
             let task_c = tokio::spawn(async move {
                 run_sync_coordinator(
-                    doc_c, ep_c, team_dir_c, doc_ticket_c,
-                    seed_ep_c, cached_addrs_c, ws_path_c,
-                    engine_c, app_handle_c,
-                ).await;
+                    doc_c,
+                    ep_c,
+                    team_dir_c,
+                    doc_ticket_c,
+                    seed_ep_c,
+                    cached_addrs_c,
+                    ws_path_c,
+                    engine_c,
+                    app_handle_c,
+                )
+                .await;
                 "sync_coordinator"
             });
 
@@ -1535,10 +1655,18 @@ fn start_sync_tasks(
             let abort_c = task_c.abort_handle();
 
             // Wait for ANY task to exit
-            let which = tokio::select! {
-                result = task_a => result.unwrap_or("doc_to_disk (panic)"),
-                result = task_b => result.unwrap_or("disk_to_doc (panic)"),
-                result = task_c => result.unwrap_or("sync_coordinator (panic)"),
+            let (which, generation_changed) = tokio::select! {
+                result = task_a => (result.unwrap_or("doc_to_disk (panic)"), false),
+                result = task_b => (result.unwrap_or("disk_to_doc (panic)"), false),
+                result = task_c => (result.unwrap_or("sync_coordinator (panic)"), false),
+                changed = generation_rx.changed() => {
+                    let label = if changed.is_ok() {
+                        "generation_changed"
+                    } else {
+                        "generation_closed"
+                    };
+                    (label, true)
+                }
             };
 
             // One task died — abort the others
@@ -1546,8 +1674,21 @@ fn start_sync_tasks(
             abort_b.abort();
             abort_c.abort();
 
+            if generation_changed || *generation_rx.borrow() != my_generation {
+                eprintln!(
+                    "[P2P][engine] Generation {} changed while '{}' was running, exiting supervisor",
+                    my_generation, which
+                );
+                let mut eng = engine.lock().await;
+                eng.stream_health = StreamHealth::Dead;
+                break;
+            }
+
             restart_count += 1;
-            eprintln!("[P2P][engine] Task '{}' exited — restarting all in 3s (restart #{})", which, restart_count);
+            eprintln!(
+                "[P2P][engine] Task '{}' exited — restarting all in 3s (restart #{})",
+                which, restart_count
+            );
 
             {
                 let mut eng = engine.lock().await;
@@ -1587,10 +1728,7 @@ fn start_sync_tasks(
 }
 
 /// Emit the current engine snapshot to the frontend via Tauri event.
-async fn emit_engine_state(
-    app_handle: &Option<tauri::AppHandle>,
-    engine: &Arc<Mutex<SyncEngine>>,
-) {
+async fn emit_engine_state(app_handle: &Option<tauri::AppHandle>, engine: &Arc<Mutex<SyncEngine>>) {
     if let Some(ref app) = app_handle {
         use tauri::Emitter;
         let snapshot = engine.lock().await.snapshot();
@@ -1698,7 +1836,10 @@ async fn doc_to_disk_watcher(
                 consecutive_errors += 1;
                 let err_str = e.to_string();
                 // Treat repeated errors or "closed" errors as fatal — let supervisor restart
-                if consecutive_errors >= 3 || err_str.contains("closed") || err_str.contains("shutdown") {
+                if consecutive_errors >= 3
+                    || err_str.contains("closed")
+                    || err_str.contains("shutdown")
+                {
                     eprintln!(
                         "[P2P][doc→disk] Fatal event stream error (count={}): {}",
                         consecutive_errors, e
@@ -1728,10 +1869,8 @@ async fn doc_to_disk_watcher(
 
                 if content_status != iroh_docs::ContentStatus::Complete {
                     // Content not yet downloaded — remember it for ContentReady
-                    pending_content.insert(
-                        entry.content_hash(),
-                        (key.clone(), author_id_str.clone()),
-                    );
+                    pending_content
+                        .insert(entry.content_hash(), (key.clone(), author_id_str.clone()));
                     eprintln!(
                         "[P2P][doc→disk] Queued for ContentReady: {} (pending={})",
                         key,
@@ -1809,8 +1948,10 @@ async fn doc_to_disk_watcher(
                                     if let Ok(Some(manifest)) = read_members_manifest(&team_dir) {
                                         node_to_role.clear();
                                         for member in &manifest.members {
-                                            node_to_role
-                                                .insert(member.node_id.clone(), member.role.clone());
+                                            node_to_role.insert(
+                                                member.node_id.clone(),
+                                                member.role.clone(),
+                                            );
                                         }
                                     }
                                 }
@@ -1866,7 +2007,10 @@ async fn doc_to_disk_watcher(
                     let is_privileged_write = match (&writer_node_id, &owner_node_id) {
                         (Some(writer), Some(owner)) if writer == owner => true,
                         (None, _) if author_to_node.is_empty() => true, // bootstrap: no authors known yet
-                        _ => matches!(writer_role, Some(MemberRole::Owner) | Some(MemberRole::Editor)),
+                        _ => matches!(
+                            writer_role,
+                            Some(MemberRole::Owner) | Some(MemberRole::Editor)
+                        ),
                     };
                     if !is_privileged_write {
                         eprintln!(
@@ -1974,7 +2118,8 @@ async fn doc_to_disk_watcher(
                         eprintln!("[P2P][doc→disk] Writing: {} ({} bytes)", key, content.len());
                         write_and_suppress(&file_path, &content, &suppressed_paths).await;
                         // Record file sync timestamp
-                        if let Ok(mtime) = std::fs::metadata(&file_path).and_then(|m| m.modified()) {
+                        if let Ok(mtime) = std::fs::metadata(&file_path).and_then(|m| m.modified())
+                        {
                             engine.lock().await.record_file_synced(key.clone(), mtime);
                         }
                     }
@@ -2021,12 +2166,15 @@ async fn doc_to_disk_watcher(
                 // Validate _team/members.json: only accept from owner or editor
                 if key == "_team/members.json" {
                     let writer_node = author_to_node.get(&author_id_str);
-                    let writer_role = writer_node
-                        .and_then(|w| node_to_role.get(w.as_str()).cloned());
+                    let writer_role =
+                        writer_node.and_then(|w| node_to_role.get(w.as_str()).cloned());
                     let is_privileged_write = match (writer_node, &owner_node_id) {
                         (Some(writer), Some(owner)) if writer == owner => true,
                         (None, _) if author_to_node.is_empty() => true, // bootstrap
-                        _ => matches!(writer_role, Some(MemberRole::Owner) | Some(MemberRole::Editor)),
+                        _ => matches!(
+                            writer_role,
+                            Some(MemberRole::Owner) | Some(MemberRole::Editor)
+                        ),
                     };
                     if !is_privileged_write {
                         eprintln!(
@@ -2049,8 +2197,7 @@ async fn doc_to_disk_watcher(
                                 }
                                 if let Some(ref app) = app_handle {
                                     use tauri::Emitter;
-                                    let _ =
-                                        app.emit("team:members-changed", serde_json::json!({}));
+                                    let _ = app.emit("team:members-changed", serde_json::json!({}));
                                 }
                             }
                         }
@@ -2071,10 +2218,7 @@ async fn doc_to_disk_watcher(
                         continue;
                     }
                 } else if !author_to_node.is_empty() {
-                    eprintln!(
-                        "[P2P] Rejected ContentReady from unknown author: {}",
-                        key
-                    );
+                    eprintln!("[P2P] Rejected ContentReady from unknown author: {}", key);
                     continue;
                 }
 
@@ -2084,10 +2228,15 @@ async fn doc_to_disk_watcher(
                         eprintln!("[P2P][ContentReady] Deleting (tombstone): {}", key);
                         let _ = std::fs::remove_file(&file_path);
                     } else {
-                        eprintln!("[P2P][ContentReady] Writing: {} ({} bytes)", key, content.len());
+                        eprintln!(
+                            "[P2P][ContentReady] Writing: {} ({} bytes)",
+                            key,
+                            content.len()
+                        );
                         write_and_suppress(&file_path, &content, &suppressed_paths).await;
                         // Record file sync timestamp
-                        if let Ok(mtime) = std::fs::metadata(&file_path).and_then(|m| m.modified()) {
+                        if let Ok(mtime) = std::fs::metadata(&file_path).and_then(|m| m.modified())
+                        {
                             engine.lock().await.record_file_synced(key.clone(), mtime);
                         }
                     }
@@ -2235,7 +2384,9 @@ async fn disk_to_doc_watcher(
                                     eprintln!("[P2P] Failed to sync local change '{}': {}", key, e);
                                 } else {
                                     // Record file sync timestamp
-                                    if let Ok(mtime) = std::fs::metadata(path).and_then(|m| m.modified()) {
+                                    if let Ok(mtime) =
+                                        std::fs::metadata(path).and_then(|m| m.modified())
+                                    {
                                         engine.lock().await.record_file_synced(key.clone(), mtime);
                                     }
                                 }
@@ -2267,7 +2418,10 @@ async fn disk_to_doc_watcher(
                             let key = rel_path;
                             // Write tombstone marker (iroh rejects empty blobs)
                             eprintln!("[P2P][disk→doc] Deleting (tombstone): {}", key);
-                            if let Err(e) = doc.set_bytes(author, key.clone(), TOMBSTONE_MARKER.to_vec()).await {
+                            if let Err(e) = doc
+                                .set_bytes(author, key.clone(), TOMBSTONE_MARKER.to_vec())
+                                .await
+                            {
                                 eprintln!("[P2P] Failed to write tombstone for '{}': {}", key, e);
                             }
                         }
@@ -2489,24 +2643,12 @@ pub fn read_members_manifest(team_dir: &str) -> Result<Option<TeamManifest>, Str
 
 // ─── Leave Team (member) ─────────────────────────────────────────────────
 
-/// Leave the team as a non-owner member.
-/// Writes a leave tombstone to the P2P doc so the owner is notified,
-/// then disconnects and removes all local team data.
-#[tauri::command]
-pub async fn p2p_leave_team(
-    iroh_state: tauri::State<'_, IrohState>,
-    opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
+async fn leave_team_for_workspace(
+    iroh_state: &IrohState,
+    workspace_path: &str,
 ) -> Result<(), String> {
-    let workspace_path = opencode_state
-        .inner
-        .lock()
-        .map_err(|e| e.to_string())?
-        .workspace_path
-        .clone()
-        .ok_or("No workspace path set")?;
-
     // Owner must use p2p_dissolve_team instead
-    let config = read_p2p_config(&workspace_path)?.unwrap_or_default();
+    let config = read_p2p_config(workspace_path)?.unwrap_or_default();
     if config.role == Some(MemberRole::Owner) {
         return Err("Team owners cannot leave — use Dissolve Team to end the team".to_string());
     }
@@ -2533,15 +2675,16 @@ pub async fn p2p_leave_team(
     }
     drop(guard);
 
-    clear_p2p_and_team_dir(&workspace_path)?;
+    clear_p2p_and_team_dir(workspace_path)?;
 
     Ok(())
 }
 
-// ─── Disconnect ─────────────────────────────────────────────────────────
-
+/// Leave the team as a non-owner member.
+/// Writes a leave tombstone to the P2P doc so the owner is notified,
+/// then disconnects and removes all local team data.
 #[tauri::command]
-pub async fn p2p_disconnect_source(
+pub async fn p2p_leave_team(
     iroh_state: tauri::State<'_, IrohState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
@@ -2552,9 +2695,17 @@ pub async fn p2p_disconnect_source(
         .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
+    leave_team_for_workspace(iroh_state.inner(), &workspace_path).await
+}
 
+// ─── Disconnect ─────────────────────────────────────────────────────────
+
+async fn disconnect_source_for_workspace(
+    iroh_state: &IrohState,
+    workspace_path: &str,
+) -> Result<(), String> {
     // Prevent owner from disconnecting if there are other members
-    if let Ok(Some(config)) = read_p2p_config(&workspace_path) {
+    if let Ok(Some(config)) = read_p2p_config(workspace_path) {
         let guard = iroh_state.lock().await;
         if let Some(node) = guard.as_ref() {
             let my_node_id = get_node_id(node);
@@ -2579,15 +2730,13 @@ pub async fn p2p_disconnect_source(
     }
     drop(guard);
 
-    clear_p2p_and_team_dir(&workspace_path)?;
+    clear_p2p_and_team_dir(workspace_path)?;
 
     Ok(())
 }
 
-/// Dissolve the team. Only the owner can call this.
-/// Writes a tombstone to notify other members, then cleans up local data.
 #[tauri::command]
-pub async fn p2p_dissolve_team(
+pub async fn p2p_disconnect_source(
     iroh_state: tauri::State<'_, IrohState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
@@ -2598,9 +2747,17 @@ pub async fn p2p_dissolve_team(
         .workspace_path
         .clone()
         .ok_or("No workspace path set")?;
+    disconnect_source_for_workspace(iroh_state.inner(), &workspace_path).await
+}
 
+/// Dissolve the team. Only the owner can call this.
+/// Writes a tombstone to notify other members, then cleans up local data.
+async fn dissolve_team_for_workspace(
+    iroh_state: &IrohState,
+    workspace_path: &str,
+) -> Result<(), String> {
     // Only owner can dissolve
-    let config = read_p2p_config(&workspace_path)?.unwrap_or_default();
+    let config = read_p2p_config(workspace_path)?.unwrap_or_default();
     if config.role != Some(MemberRole::Owner) {
         return Err("Only the team owner can dissolve the team".to_string());
     }
@@ -2625,9 +2782,24 @@ pub async fn p2p_dissolve_team(
     }
     drop(guard);
 
-    clear_p2p_and_team_dir(&workspace_path)?;
+    clear_p2p_and_team_dir(workspace_path)?;
 
     Ok(())
+}
+
+#[tauri::command]
+pub async fn p2p_dissolve_team(
+    iroh_state: tauri::State<'_, IrohState>,
+    opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
+) -> Result<(), String> {
+    let workspace_path = opencode_state
+        .inner
+        .lock()
+        .map_err(|e| e.to_string())?
+        .workspace_path
+        .clone()
+        .ok_or("No workspace path set")?;
+    dissolve_team_for_workspace(iroh_state.inner(), &workspace_path).await
 }
 
 // ─── Team Member Management ─────────────────────────────────────────────
@@ -2657,9 +2829,9 @@ pub fn add_member_to_team(
 
     // Any existing member (owner or editor) can add new members.
     let is_owner = owner_id == caller_node_id;
-    let is_member = members
-        .iter()
-        .any(|m| m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor));
+    let is_member = members.iter().any(|m| {
+        m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor)
+    });
     if !is_owner && !is_member {
         return Err("Only team members can add new members".to_string());
     }
@@ -2728,9 +2900,9 @@ pub fn remove_member_from_team(
     };
 
     let is_owner = owner_id == caller_node_id;
-    let is_editor = members
-        .iter()
-        .any(|m| m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor));
+    let is_editor = members.iter().any(|m| {
+        m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor)
+    });
     if !is_owner && !is_editor {
         return Err("Only team members (owner or editor) can manage members".to_string());
     }
@@ -2775,9 +2947,9 @@ pub fn update_member_role(
     };
 
     let is_owner = owner_id == caller_node_id;
-    let is_editor = members
-        .iter()
-        .any(|m| m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor));
+    let is_editor = members.iter().any(|m| {
+        m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor)
+    });
     if !is_owner && !is_editor {
         return Err("Only team members (owner or editor) can manage members".to_string());
     }
@@ -3139,31 +3311,19 @@ pub async fn p2p_join_drive(
 }
 
 /// Reconnect to an existing team document on app restart.
-#[tauri::command]
-pub async fn p2p_reconnect(
-    app: tauri::AppHandle,
-    iroh_state: tauri::State<'_, IrohState>,
-    engine_state: tauri::State<'_, SyncEngineState>,
-    opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
+async fn reconnect_team_for_workspace(
+    node: &mut IrohNode,
+    workspace_path: &str,
+    app_handle: Option<tauri::AppHandle>,
+    engine: SyncEngineState,
 ) -> Result<(), String> {
-    let workspace_path = opencode_state
-        .inner
-        .lock()
-        .map_err(|e| e.to_string())?
-        .workspace_path
-        .clone()
-        .ok_or("No workspace path set")?;
-
-    let config = read_p2p_config(&workspace_path)?;
+    let config = read_p2p_config(workspace_path)?;
     let config = match config {
         Some(c) if c.enabled && c.namespace_id.is_some() => c,
         _ => return Ok(()), // No team to reconnect to
     };
 
     let _namespace_id_str = config.namespace_id.as_ref().unwrap();
-
-    let mut guard = iroh_state.lock().await;
-    let node = guard.as_mut().ok_or("P2P node not running")?;
 
     // Skip if already connected
     if node.active_doc.is_some() {
@@ -3205,7 +3365,7 @@ pub async fn p2p_reconnect(
     if !is_owner {
         if let Err(auth_err) = check_join_authorization(&team_dir, &my_node_id) {
             let _ = doc.close().await;
-            clear_p2p_and_team_dir(&workspace_path)?;
+            clear_p2p_and_team_dir(workspace_path)?;
             return Err(format!("Reconnect rejected: {}", auth_err));
         }
     }
@@ -3245,13 +3405,13 @@ pub async fn p2p_reconnect(
         Arc::new(Mutex::new(my_role)),
         my_node_id,
         config.owner_node_id.clone(),
-        Some(app),
+        app_handle,
         node.router.endpoint().clone(),
         config.doc_ticket.clone(),
         seed_ep,
         config.cached_peer_addrs.clone(),
-        Some(workspace_path.clone()),
-        engine_state.inner().clone(),
+        Some(workspace_path.to_string()),
+        engine,
         node.sync_generation_rx.clone(),
         *node.sync_generation_rx.borrow(),
         node.manifest_lock.clone(),
@@ -3260,6 +3420,32 @@ pub async fn p2p_reconnect(
     node.active_doc = Some(doc);
 
     Ok(())
+}
+
+#[tauri::command]
+pub async fn p2p_reconnect(
+    app: tauri::AppHandle,
+    iroh_state: tauri::State<'_, IrohState>,
+    engine_state: tauri::State<'_, SyncEngineState>,
+    opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
+) -> Result<(), String> {
+    let workspace_path = opencode_state
+        .inner
+        .lock()
+        .map_err(|e| e.to_string())?
+        .workspace_path
+        .clone()
+        .ok_or("No workspace path set")?;
+
+    let mut guard = iroh_state.lock().await;
+    let node = guard.as_mut().ok_or("P2P node not running")?;
+    reconnect_team_for_workspace(
+        node,
+        &workspace_path,
+        Some(app),
+        engine_state.inner().clone(),
+    )
+    .await
 }
 
 /// Regenerate the team ticket (namespace rotation). Owner only.
@@ -3281,7 +3467,13 @@ pub async fn p2p_rotate_ticket(
     let node = guard.as_mut().ok_or("P2P node not running")?;
 
     let team_dir = format!("{}/{}", workspace_path, super::TEAM_REPO_DIR);
-    rotate_namespace(node, &team_dir, &workspace_path, engine_state.inner().clone()).await
+    rotate_namespace(
+        node,
+        &team_dir,
+        &workspace_path,
+        engine_state.inner().clone(),
+    )
+    .await
 }
 
 #[tauri::command]
@@ -3350,10 +3542,13 @@ pub async fn p2p_sync_status(
     // includes own address + up to 4 random other known peers.
     let member_ticket = if let Some(node) = guard.as_ref() {
         if let Some(doc) = &node.active_doc {
-            match doc.share(
-                iroh_docs::api::protocol::ShareMode::Write,
-                iroh_docs::api::protocol::AddrInfoOptions::RelayAndAddresses,
-            ).await {
+            match doc
+                .share(
+                    iroh_docs::api::protocol::ShareMode::Write,
+                    iroh_docs::api::protocol::AddrInfoOptions::RelayAndAddresses,
+                )
+                .await
+            {
                 Ok(mut ticket) => {
                     // Collect other known peers from manifest + cache
                     let team_dir = format!("{}/{}", workspace_path, super::TEAM_REPO_DIR);
@@ -3374,9 +3569,13 @@ pub async fn p2p_sync_status(
                                     }
                                 }
                                 if addrs.is_empty() {
-                                    if let Some(cached) = config.cached_peer_addrs.get(&member.node_id) {
+                                    if let Some(cached) =
+                                        config.cached_peer_addrs.get(&member.node_id)
+                                    {
                                         for addr_str in cached {
-                                            if let Ok(sock) = addr_str.parse::<std::net::SocketAddr>() {
+                                            if let Ok(sock) =
+                                                addr_str.parse::<std::net::SocketAddr>()
+                                            {
                                                 addrs.insert(iroh::TransportAddr::Ip(sock));
                                             }
                                         }
@@ -3677,6 +3876,1064 @@ pub async fn p2p_skills_leaderboard(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_lite::StreamExt;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    struct TestPeer {
+        name: String,
+        workspace_dir: tempfile::TempDir,
+        _iroh_storage_dir: tempfile::TempDir,
+        team_dir: PathBuf,
+        node: IrohNode,
+        engine: SyncEngineState,
+    }
+
+    impl TestPeer {
+        async fn new(name: &str) -> Self {
+            let workspace_dir = tempfile::tempdir().unwrap();
+            let iroh_storage_dir = tempfile::tempdir().unwrap();
+            let team_dir = workspace_dir.path().join(crate::commands::TEAM_REPO_DIR);
+            std::fs::create_dir_all(&team_dir).unwrap();
+            let node = IrohNode::new(iroh_storage_dir.path()).await.unwrap();
+
+            Self {
+                name: name.to_string(),
+                workspace_dir,
+                _iroh_storage_dir: iroh_storage_dir,
+                team_dir,
+                node,
+                engine: Arc::new(Mutex::new(SyncEngine::new())),
+            }
+        }
+
+        fn workspace_path(&self) -> String {
+            self.workspace_dir.path().to_string_lossy().to_string()
+        }
+
+        fn team_dir_path(&self) -> String {
+            self.team_dir.to_string_lossy().to_string()
+        }
+
+        fn node_id(&self) -> String {
+            get_node_id(&self.node)
+        }
+
+        fn member(&self, role: MemberRole) -> TeamMember {
+            TeamMember {
+                node_id: self.node_id(),
+                name: self.name.clone(),
+                role,
+                label: self.name.clone(),
+                platform: std::env::consts::OS.to_string(),
+                arch: std::env::consts::ARCH.to_string(),
+                hostname: format!("{}-host", self.name.to_lowercase()),
+                added_at: chrono::Utc::now().to_rfc3339(),
+            }
+        }
+
+        async fn create_team(&mut self) -> String {
+            let workspace_path = self.workspace_path();
+            let team_dir = self.team_dir_path();
+            create_team(
+                &mut self.node,
+                &team_dir,
+                &workspace_path,
+                None,
+                None,
+                None,
+                Some("P2P Test Team".to_string()),
+                Some(self.name.clone()),
+                None,
+                None,
+                self.engine.clone(),
+            )
+            .await
+            .unwrap()
+        }
+
+        async fn join_team(&mut self, ticket: &str) -> String {
+            let workspace_path = self.workspace_path();
+            let team_dir = self.team_dir_path();
+            join_team_drive(
+                &mut self.node,
+                ticket,
+                &team_dir,
+                &workspace_path,
+                None,
+                self.engine.clone(),
+            )
+            .await
+            .unwrap()
+        }
+
+        async fn publish(&self) -> String {
+            let workspace_path = self.workspace_path();
+            let team_dir = self.team_dir_path();
+            publish_team_drive(&self.node, &team_dir, &workspace_path)
+                .await
+                .unwrap()
+        }
+
+        async fn inject_doc_entry(&self, key: &str, content: &[u8]) {
+            let doc = self
+                .node
+                .active_doc
+                .as_ref()
+                .expect("active doc should exist for raw doc writes");
+            doc.set_bytes(self.node.author, key.to_string(), content.to_vec())
+                .await
+                .unwrap();
+        }
+
+        fn write_file(&self, rel_path: &str, content: &str) {
+            let path = self.team_dir.join(rel_path);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(path, content).unwrap();
+        }
+
+        fn read_file(&self, rel_path: &str) -> Option<String> {
+            std::fs::read_to_string(self.team_dir.join(rel_path)).ok()
+        }
+
+        fn manifest(&self) -> TeamManifest {
+            read_members_manifest(&self.team_dir_path())
+                .unwrap()
+                .expect("members manifest should exist")
+        }
+
+        fn p2p_config(&self) -> Option<P2pConfig> {
+            read_p2p_config(&self.workspace_path()).unwrap()
+        }
+
+        async fn add_member_and_sync(&mut self, member: TeamMember) {
+            let workspace_path = self.workspace_path();
+            let team_dir = self.team_dir_path();
+            let caller_node_id = self.node_id();
+            add_member_to_team(&workspace_path, &team_dir, &caller_node_id, member).unwrap();
+            self.sync_members_manifest_to_doc().await;
+        }
+
+        async fn update_member_role_and_sync(
+            &mut self,
+            target_node_id: &str,
+            new_role: MemberRole,
+        ) {
+            let workspace_path = self.workspace_path();
+            let team_dir = self.team_dir_path();
+            let caller_node_id = self.node_id();
+            update_member_role(
+                &workspace_path,
+                &team_dir,
+                &caller_node_id,
+                target_node_id,
+                new_role,
+            )
+            .unwrap();
+            self.sync_members_manifest_to_doc().await;
+        }
+
+        async fn sync_members_manifest_to_doc(&self) {
+            let doc = self
+                .node
+                .active_doc
+                .as_ref()
+                .expect("active doc should exist for manifest sync");
+            let content = std::fs::read(self.team_dir.join("_team/members.json")).unwrap();
+            doc.set_bytes(self.node.author, "_team/members.json", content)
+                .await
+                .unwrap();
+        }
+
+        async fn reconnect(&mut self) -> Result<(), String> {
+            let workspace_path = self.workspace_path();
+            reconnect_team_for_workspace(&mut self.node, &workspace_path, None, self.engine.clone())
+                .await
+        }
+
+        async fn active_doc_has_key(&self, key: &str) -> bool {
+            let Some(doc) = self.node.active_doc.as_ref() else {
+                return false;
+            };
+            let query = iroh_docs::store::Query::single_latest_per_key().build();
+            let Ok(entries) = doc.get_many(query).await else {
+                return false;
+            };
+            let mut entries = std::pin::pin!(entries);
+            while let Some(Ok(entry)) = entries.next().await {
+                if String::from_utf8_lossy(entry.key()) == key {
+                    return true;
+                }
+            }
+            false
+        }
+
+        async fn shutdown(mut self) {
+            self.node.bump_sync_generation();
+            let _ = self.node.active_doc.take();
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+
+        async fn restart_node(&mut self) {
+            self.node.bump_sync_generation();
+            if let Some(doc) = self.node.active_doc.take() {
+                let _ = tokio::time::timeout(std::time::Duration::from_secs(3), doc.leave()).await;
+            }
+            let storage_path = self._iroh_storage_dir.path().to_path_buf();
+            let replacement = IrohNode::new(&storage_path).await.unwrap();
+            let old_node = std::mem::replace(&mut self.node, replacement);
+            self.engine = Arc::new(Mutex::new(SyncEngine::new()));
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_secs(3),
+                old_node.router.shutdown(),
+            )
+            .await;
+        }
+    }
+
+    async fn wait_until(
+        timeout: std::time::Duration,
+        mut check: impl FnMut() -> bool,
+        description: &str,
+    ) {
+        let start = Instant::now();
+        loop {
+            if check() {
+                return;
+            }
+            assert!(
+                start.elapsed() < timeout,
+                "timed out waiting for {} after {:?}",
+                description,
+                timeout
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+    }
+
+    async fn assert_stays_false_for(
+        duration: std::time::Duration,
+        mut check: impl FnMut() -> bool,
+        description: &str,
+    ) {
+        let start = Instant::now();
+        loop {
+            assert!(
+                !check(),
+                "condition unexpectedly became true while waiting for {}",
+                description
+            );
+            if start.elapsed() >= duration {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+    }
+
+    async fn wait_until_async<F, Fut>(timeout: std::time::Duration, mut check: F, description: &str)
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = bool>,
+    {
+        let start = Instant::now();
+        loop {
+            if check().await {
+                return;
+            }
+            assert!(
+                start.elapsed() < timeout,
+                "timed out waiting for {} after {:?}",
+                description,
+                timeout
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_create_join_and_initial_sync() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        owner.write_file("docs/hello.txt", "hello from owner");
+        let ticket = owner.create_team().await;
+        owner
+            .add_member_and_sync(joiner.member(MemberRole::Editor))
+            .await;
+
+        let result = joiner.join_team(&ticket).await;
+        assert!(result.contains("Synced"));
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.read_file("docs/hello.txt").as_deref() == Some("hello from owner"),
+            "joiner initial file sync",
+        )
+        .await;
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_owner_publish_syncs_to_joiner() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        owner.write_file("docs/initial.txt", "v1");
+        let ticket = owner.create_team().await;
+        owner
+            .add_member_and_sync(joiner.member(MemberRole::Editor))
+            .await;
+        joiner.join_team(&ticket).await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.read_file("docs/initial.txt").as_deref() == Some("v1"),
+            "joiner receives initial file",
+        )
+        .await;
+
+        owner.write_file("docs/initial.txt", "v2 from owner");
+        owner.publish().await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.read_file("docs/initial.txt").as_deref() == Some("v2 from owner"),
+            "joiner receives owner update",
+        )
+        .await;
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_members_manifest_role_change_syncs() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        let ticket = owner.create_team().await;
+        let joiner_node_id = joiner.node_id();
+        owner
+            .add_member_and_sync(joiner.member(MemberRole::Editor))
+            .await;
+        joiner.join_team(&ticket).await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || {
+                joiner
+                    .manifest()
+                    .members
+                    .iter()
+                    .find(|m| m.node_id == joiner_node_id)
+                    .map(|m| m.role.clone())
+                    == Some(MemberRole::Editor)
+            },
+            "joiner manifest editor role",
+        )
+        .await;
+
+        owner
+            .update_member_role_and_sync(&joiner_node_id, MemberRole::Viewer)
+            .await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || {
+                joiner
+                    .manifest()
+                    .members
+                    .iter()
+                    .find(|m| m.node_id == joiner_node_id)
+                    .map(|m| m.role.clone())
+                    == Some(MemberRole::Viewer)
+            },
+            "joiner manifest viewer role",
+        )
+        .await;
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_viewer_cannot_sync_new_writes() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        owner.write_file("docs/shared.txt", "seed");
+        let ticket = owner.create_team().await;
+        let joiner_node_id = joiner.node_id();
+        owner
+            .add_member_and_sync(joiner.member(MemberRole::Editor))
+            .await;
+        joiner.join_team(&ticket).await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.read_file("docs/shared.txt").as_deref() == Some("seed"),
+            "joiner receives seed file",
+        )
+        .await;
+
+        owner
+            .update_member_role_and_sync(&joiner_node_id, MemberRole::Viewer)
+            .await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || {
+                joiner
+                    .manifest()
+                    .members
+                    .iter()
+                    .find(|m| m.node_id == joiner_node_id)
+                    .map(|m| m.role.clone())
+                    == Some(MemberRole::Viewer)
+            },
+            "joiner manifest viewer role before write attempt",
+        )
+        .await;
+
+        joiner.write_file("docs/viewer-write.txt", "should not replicate");
+        let publish_result = joiner.publish().await;
+        assert!(
+            publish_result.contains("Synced") || publish_result.contains("0"),
+            "unexpected publish result: {}",
+            publish_result
+        );
+
+        assert_stays_false_for(
+            std::time::Duration::from_secs(5),
+            || owner.read_file("docs/viewer-write.txt").is_some(),
+            "viewer write staying absent on owner",
+        )
+        .await;
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_removed_member_receives_removal_manifest() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        let ticket = owner.create_team().await;
+        let joiner_member = joiner.member(MemberRole::Editor);
+        let joiner_node_id = joiner_member.node_id.clone();
+        owner.add_member_and_sync(joiner_member).await;
+        joiner.join_team(&ticket).await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || {
+                joiner
+                    .manifest()
+                    .members
+                    .iter()
+                    .any(|m| m.node_id == joiner_node_id)
+            },
+            "joiner initially appears in local manifest",
+        )
+        .await;
+
+        let workspace_path = owner.workspace_path();
+        let team_dir = owner.team_dir_path();
+        let owner_node_id = owner.node_id();
+        remove_member_from_team(&workspace_path, &team_dir, &owner_node_id, &joiner_node_id)
+            .unwrap();
+        owner.sync_members_manifest_to_doc().await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || {
+                !joiner
+                    .manifest()
+                    .members
+                    .iter()
+                    .any(|m| m.node_id == joiner_node_id)
+            },
+            "joiner receives removal in members manifest",
+        )
+        .await;
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_removed_member_cannot_rejoin_with_preserved_identity() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        owner.write_file("docs/owner.txt", "owned by owner");
+        let ticket = owner.create_team().await;
+        let joiner_member = joiner.member(MemberRole::Editor);
+        let joiner_node_id = joiner_member.node_id.clone();
+        owner.add_member_and_sync(joiner_member).await;
+        joiner.join_team(&ticket).await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.read_file("docs/owner.txt").as_deref() == Some("owned by owner"),
+            "joiner receives initial owner file before removal",
+        )
+        .await;
+
+        // Simulate app restart / offline period on the removed member side.
+        // The local members.json still contains the old allowlist at this point.
+        joiner.restart_node().await;
+
+        let workspace_path = owner.workspace_path();
+        let team_dir = owner.team_dir_path();
+        let owner_node_id = owner.node_id();
+        remove_member_from_team(&workspace_path, &team_dir, &owner_node_id, &joiner_node_id)
+            .unwrap();
+        owner.sync_members_manifest_to_doc().await;
+
+        let joiner_team_dir = joiner.team_dir_path();
+        let joiner_workspace_path = joiner.workspace_path();
+        let joiner_engine = joiner.engine.clone();
+        let rejoin_result = join_team_drive(
+            &mut joiner.node,
+            &ticket,
+            &joiner_team_dir,
+            &joiner_workspace_path,
+            None,
+            joiner_engine,
+        )
+        .await;
+
+        assert!(
+            rejoin_result.is_err(),
+            "removed member should not be able to rejoin with preserved identity"
+        );
+        let err = rejoin_result.unwrap_err();
+        assert!(
+            err.contains("Not authorized") || err.contains("not authorized"),
+            "unexpected rejoin error: {}",
+            err
+        );
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_reconnect_happy_path_resumes_sync() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        owner.write_file("docs/seed.txt", "before reconnect");
+        let ticket = owner.create_team().await;
+        owner
+            .add_member_and_sync(joiner.member(MemberRole::Editor))
+            .await;
+        joiner.join_team(&ticket).await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.read_file("docs/seed.txt").as_deref() == Some("before reconnect"),
+            "joiner receives seed file before reconnect",
+        )
+        .await;
+
+        joiner.restart_node().await;
+        assert!(
+            joiner.node.active_doc.is_none(),
+            "restart should leave joiner without an active doc"
+        );
+
+        joiner.reconnect().await.unwrap();
+        assert!(
+            joiner.node.active_doc.is_some(),
+            "reconnect should restore the active doc"
+        );
+
+        owner.write_file("docs/post-reconnect.txt", "after reconnect");
+        owner.publish().await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.read_file("docs/post-reconnect.txt").as_deref() == Some("after reconnect"),
+            "joiner receives owner update after reconnect",
+        )
+        .await;
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_leave_team_removes_member_and_cleans_local_state() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        let ticket = owner.create_team().await;
+        let joiner_member = joiner.member(MemberRole::Editor);
+        let joiner_node_id = joiner_member.node_id.clone();
+        owner.add_member_and_sync(joiner_member).await;
+        joiner.join_team(&ticket).await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || {
+                joiner
+                    .manifest()
+                    .members
+                    .iter()
+                    .any(|m| m.node_id == joiner_node_id)
+            },
+            "joiner appears in manifest before leave",
+        )
+        .await;
+
+        let joiner_workspace_path = joiner.workspace_path();
+        let joiner_state: IrohState = Arc::new(Mutex::new(Some(joiner.node)));
+        leave_team_for_workspace(&joiner_state, &joiner_workspace_path)
+            .await
+            .unwrap();
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || {
+                !owner
+                    .manifest()
+                    .members
+                    .iter()
+                    .any(|m| m.node_id == joiner_node_id)
+            },
+            "owner receives member leave removal",
+        )
+        .await;
+
+        let joiner_node = joiner_state
+            .lock()
+            .await
+            .take()
+            .expect("joiner node should still be present");
+        joiner.node = joiner_node;
+
+        assert!(
+            !joiner.team_dir.exists(),
+            "leave should remove the local team directory"
+        );
+        assert!(
+            joiner.p2p_config().is_none(),
+            "leave should clear local P2P config"
+        );
+        assert!(
+            joiner.node.active_doc.is_none(),
+            "leave should close the local active doc"
+        );
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_dissolve_team_writes_marker_and_cleans_owner_state() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        let ticket = owner.create_team().await;
+        owner
+            .add_member_and_sync(joiner.member(MemberRole::Editor))
+            .await;
+        joiner.join_team(&ticket).await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.manifest().members.len() == 2,
+            "joiner sees shared manifest before dissolve",
+        )
+        .await;
+
+        let owner_workspace_path = owner.workspace_path();
+        let owner_state: IrohState = Arc::new(Mutex::new(Some(owner.node)));
+        dissolve_team_for_workspace(&owner_state, &owner_workspace_path)
+            .await
+            .unwrap();
+
+        wait_until_async(
+            std::time::Duration::from_secs(15),
+            || joiner.active_doc_has_key("_team/dissolved"),
+            "joiner receives dissolved marker",
+        )
+        .await;
+
+        let owner_node = owner_state
+            .lock()
+            .await
+            .take()
+            .expect("owner node should still be present");
+        owner.node = owner_node;
+
+        assert!(
+            !owner.team_dir.exists(),
+            "dissolve should remove the owner's local team directory"
+        );
+        assert!(
+            owner.p2p_config().is_none(),
+            "dissolve should clear the owner's local P2P config"
+        );
+        assert!(
+            owner.node.active_doc.is_none(),
+            "dissolve should close the owner's active doc"
+        );
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_disconnect_source_cleans_local_state_for_single_owner() {
+        let mut owner = TestPeer::new("Owner").await;
+        owner.create_team().await;
+
+        let owner_workspace_path = owner.workspace_path();
+        let owner_state: IrohState = Arc::new(Mutex::new(Some(owner.node)));
+        disconnect_source_for_workspace(&owner_state, &owner_workspace_path)
+            .await
+            .unwrap();
+
+        let owner_node = owner_state
+            .lock()
+            .await
+            .take()
+            .expect("owner node should still be present");
+        owner.node = owner_node;
+
+        assert!(
+            !owner.team_dir.exists(),
+            "disconnect should remove the local team directory"
+        );
+        assert!(
+            owner.p2p_config().is_none(),
+            "disconnect should clear local P2P config"
+        );
+        assert!(
+            owner.node.active_doc.is_none(),
+            "disconnect should close the active doc"
+        );
+
+        owner.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_disconnect_source_rejects_owner_with_existing_members() {
+        let mut owner = TestPeer::new("Owner").await;
+        let joiner = TestPeer::new("Joiner").await;
+
+        owner.create_team().await;
+        owner
+            .add_member_and_sync(joiner.member(MemberRole::Editor))
+            .await;
+
+        let owner_workspace_path = owner.workspace_path();
+        let owner_state: IrohState = Arc::new(Mutex::new(Some(owner.node)));
+        let result = disconnect_source_for_workspace(&owner_state, &owner_workspace_path).await;
+
+        assert!(
+            result.is_err(),
+            "owner disconnect should be rejected while members remain"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("还有其他成员"),
+            "unexpected disconnect rejection message: {}",
+            err
+        );
+
+        let owner_node = owner_state
+            .lock()
+            .await
+            .take()
+            .expect("owner node should still be present");
+        owner.node = owner_node;
+
+        assert!(
+            owner.team_dir.exists(),
+            "rejected disconnect must not remove the local team directory"
+        );
+        assert!(
+            owner.p2p_config().is_some(),
+            "rejected disconnect must not clear local P2P config"
+        );
+        assert!(
+            owner.node.active_doc.is_some(),
+            "rejected disconnect must keep the active doc open"
+        );
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_reconnect_reconciles_owner_offline_edits() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        owner.write_file("docs/shared.txt", "seed");
+        let ticket = owner.create_team().await;
+        owner
+            .add_member_and_sync(joiner.member(MemberRole::Editor))
+            .await;
+        joiner.join_team(&ticket).await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.read_file("docs/shared.txt").as_deref() == Some("seed"),
+            "joiner receives seed file before owner reconnect reconcile",
+        )
+        .await;
+
+        owner.restart_node().await;
+        owner.write_file("docs/shared.txt", "offline owner edit");
+        assert!(
+            owner.node.active_doc.is_none(),
+            "owner restart should leave no active doc before reconnect"
+        );
+
+        owner.reconnect().await.unwrap();
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.read_file("docs/shared.txt").as_deref() == Some("offline owner edit"),
+            "joiner receives owner offline edit after reconnect reconcile",
+        )
+        .await;
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_no_team_is_noop() {
+        let mut peer = TestPeer::new("Peer").await;
+
+        let result = peer.reconnect().await;
+        assert!(
+            result.is_ok(),
+            "reconnect without saved team should be a no-op"
+        );
+        assert!(
+            peer.node.active_doc.is_none(),
+            "no-op reconnect should not attach an active doc"
+        );
+
+        peer.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_missing_saved_ticket_returns_error() {
+        let mut peer = TestPeer::new("Peer").await;
+        let workspace_path = peer.workspace_path();
+        let config = P2pConfig {
+            enabled: true,
+            namespace_id: Some("ns-missing-ticket".to_string()),
+            owner_node_id: Some(peer.node_id()),
+            role: Some(MemberRole::Owner),
+            ..Default::default()
+        };
+        write_p2p_config(&workspace_path, Some(&config)).unwrap();
+
+        let result = peer.reconnect().await;
+        assert!(
+            result.is_err(),
+            "reconnect should fail without a saved ticket"
+        );
+        assert!(
+            result.unwrap_err().contains("No saved ticket"),
+            "reconnect should explain that the saved ticket is missing"
+        );
+        assert!(
+            peer.node.active_doc.is_none(),
+            "failed reconnect should not attach an active doc"
+        );
+
+        peer.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_invalid_saved_ticket_returns_error() {
+        let mut peer = TestPeer::new("Peer").await;
+        let workspace_path = peer.workspace_path();
+        let config = P2pConfig {
+            enabled: true,
+            namespace_id: Some("ns-invalid-ticket".to_string()),
+            doc_ticket: Some("definitely-not-a-doc-ticket".to_string()),
+            owner_node_id: Some(peer.node_id()),
+            role: Some(MemberRole::Owner),
+            ..Default::default()
+        };
+        write_p2p_config(&workspace_path, Some(&config)).unwrap();
+
+        let result = peer.reconnect().await;
+        assert!(
+            result.is_err(),
+            "reconnect should fail with an invalid saved ticket"
+        );
+        assert!(
+            result.unwrap_err().contains("Invalid saved ticket"),
+            "reconnect should explain that the saved ticket is invalid"
+        );
+        assert!(
+            peer.node.active_doc.is_none(),
+            "failed reconnect should not attach an active doc"
+        );
+
+        peer.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_rotate_ticket_preserves_existing_member_access() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        owner.write_file("docs/shared.txt", "before rotate");
+        let original_ticket = owner.create_team().await;
+        let joiner_member = joiner.member(MemberRole::Editor);
+        let joiner_node_id = joiner_member.node_id.clone();
+        owner.add_member_and_sync(joiner_member).await;
+        joiner.join_team(&original_ticket).await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.read_file("docs/shared.txt").as_deref() == Some("before rotate"),
+            "joiner receives initial shared file before rotation",
+        )
+        .await;
+
+        let owner_team_dir = owner.team_dir_path();
+        let owner_workspace_path = owner.workspace_path();
+        let owner_engine = owner.engine.clone();
+        let rotated_ticket = rotate_namespace(
+            &mut owner.node,
+            &owner_team_dir,
+            &owner_workspace_path,
+            owner_engine,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            owner
+                .manifest()
+                .members
+                .iter()
+                .any(|m| m.node_id == joiner_node_id),
+            "ticket rotation should preserve existing members in the manifest"
+        );
+
+        joiner.restart_node().await;
+        joiner.join_team(&rotated_ticket).await;
+
+        wait_until(
+            std::time::Duration::from_secs(15),
+            || joiner.read_file("docs/shared.txt").as_deref() == Some("before rotate"),
+            "existing member rejoins rotated namespace and keeps access",
+        )
+        .await;
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_real_p2p_unauthorized_join_does_not_leave_synced_files() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut intruder = TestPeer::new("Intruder").await;
+
+        owner.write_file("docs/private.txt", "owner-only secret");
+        let ticket = owner.create_team().await;
+
+        let intruder_team_dir = intruder.team_dir_path();
+        let intruder_workspace_path = intruder.workspace_path();
+        let intruder_engine = intruder.engine.clone();
+        let intruder_private_file = intruder.team_dir.join("docs/private.txt");
+        let join_result = join_team_drive(
+            &mut intruder.node,
+            &ticket,
+            &intruder_team_dir,
+            &intruder_workspace_path,
+            None,
+            intruder_engine,
+        )
+        .await;
+
+        assert!(
+            join_result.is_err(),
+            "unauthorized join should be rejected once members manifest syncs"
+        );
+        let err = join_result.unwrap_err();
+        assert!(
+            err.contains("Not authorized") || err.contains("not authorized"),
+            "unexpected unauthorized join error: {}",
+            err
+        );
+        assert!(
+            !intruder_private_file.exists(),
+            "unauthorized join must not leave synced business files on disk"
+        );
+        assert!(
+            intruder.read_file("docs/private.txt").is_none(),
+            "unauthorized join should not keep readable private content locally"
+        );
+
+        owner.shutdown().await;
+        intruder.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "Security regression test using real iroh sync; expected to fail until path validation is enforced"]
+    async fn test_real_p2p_malicious_doc_key_cannot_escape_team_dir() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        let ticket = owner.create_team().await;
+        owner
+            .add_member_and_sync(joiner.member(MemberRole::Editor))
+            .await;
+        joiner.join_team(&ticket).await;
+
+        let escaped_path = Path::new(&joiner.workspace_path()).join("escaped.txt");
+        assert!(
+            !escaped_path.exists(),
+            "precondition failed: escaped path already exists"
+        );
+
+        owner
+            .inject_doc_entry("../escaped.txt", b"malicious traversal payload")
+            .await;
+
+        assert_stays_false_for(
+            std::time::Duration::from_secs(5),
+            || escaped_path.exists(),
+            "path traversal creating workspace-level file",
+        )
+        .await;
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
+    }
 
     #[tokio::test]
     async fn test_iroh_node_creates_and_shuts_down() {
@@ -4180,8 +5437,7 @@ mod tests {
             hostname: "new-box".to_string(),
             added_at: "2026-01-03T00:00:00Z".to_string(),
         };
-        add_member_to_team(workspace, team_dir.to_str().unwrap(), editor_id, new_member)
-            .unwrap();
+        add_member_to_team(workspace, team_dir.to_str().unwrap(), editor_id, new_member).unwrap();
 
         let config = read_p2p_config(workspace).unwrap().unwrap();
         assert_eq!(config.allowed_members.len(), 3);
@@ -4244,12 +5500,8 @@ mod tests {
             hostname: "new".to_string(),
             added_at: "2026-01-03T00:00:00Z".to_string(),
         };
-        let result = add_member_to_team(
-            workspace,
-            team_dir.to_str().unwrap(),
-            viewer_id,
-            new_member,
-        );
+        let result =
+            add_member_to_team(workspace, team_dir.to_str().unwrap(), viewer_id, new_member);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Only team members"));
     }

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -120,6 +120,88 @@ async fn require_manager_role(manifest: &TeamManifest, caller_node_id: &str) -> 
     Ok(())
 }
 
+#[cfg(feature = "p2p")]
+async fn p2p_update_member_role_and_sync(
+    workspace_path: &str,
+    iroh_state: &super::p2p_state::IrohState,
+    node_id: &str,
+    role: MemberRole,
+) -> Result<(), String> {
+    let mut guard = iroh_state.lock().await;
+    let node = guard.as_mut().ok_or("P2P node not running")?;
+    let caller_node_id = super::team_p2p::get_node_id(node);
+    let team_dir = format!("{}/{}", workspace_path, super::TEAM_REPO_DIR);
+    if node.active_doc.is_none() {
+        return Err(
+            "No active team document — cannot sync role changes to peers. Reconnect to the team, then try again."
+                .to_string(),
+        );
+    }
+
+    let previous_role = super::team_p2p::read_members_manifest(&team_dir)?
+        .map(|manifest| {
+            manifest
+                .members
+                .into_iter()
+                .find(|member| member.node_id == node_id)
+                .map(|member| member.role)
+        })
+        .flatten()
+        .or_else(|| {
+            super::team_p2p::read_p2p_config(workspace_path)
+                .ok()
+                .flatten()
+                .and_then(|config| {
+                    config
+                        .allowed_members
+                        .into_iter()
+                        .find(|member| member.node_id == node_id)
+                        .map(|member| member.role)
+                })
+        })
+        .ok_or_else(|| "Member not found".to_string())?;
+
+    super::team_p2p::update_member_role(workspace_path, &team_dir, &caller_node_id, node_id, role)?;
+
+    let manifest_path = format!("{}/{}", team_dir, "_team/members.json");
+    let content = match std::fs::read(&manifest_path) {
+        Ok(content) => content,
+        Err(e) => {
+            let _ = super::team_p2p::update_member_role(
+                workspace_path,
+                &team_dir,
+                &caller_node_id,
+                node_id,
+                previous_role,
+            );
+            return Err(format!(
+                "Could not read members.json after role update (local role restored): {}",
+                e
+            ));
+        }
+    };
+
+    let doc = node.active_doc.as_ref().expect("checked active_doc above");
+    if let Err(e) = doc
+        .set_bytes(node.author, "_team/members.json", content)
+        .await
+    {
+        let _ = super::team_p2p::update_member_role(
+            workspace_path,
+            &team_dir,
+            &caller_node_id,
+            node_id,
+            previous_role,
+        );
+        return Err(format!(
+            "Failed to sync role change to the team document (local role restored): {}. Reconnect and try again.",
+            e
+        ));
+    }
+
+    Ok(())
+}
+
 /// Get the list of team members from the active sync mode.
 /// - OSS: downloads members manifest from S3
 /// - P2P: reads from p2p config's allowed_members
@@ -228,10 +310,7 @@ pub async fn unified_team_add_member(
                     ));
                 }
             };
-            let doc = node
-                .active_doc
-                .as_ref()
-                .expect("checked active_doc above");
+            let doc = node.active_doc.as_ref().expect("checked active_doc above");
             if let Err(e) = doc
                 .set_bytes(node.author, "_team/members.json", content)
                 .await
@@ -334,10 +413,7 @@ pub async fn unified_team_remove_member(
                 }
             };
 
-            let doc = node
-                .active_doc
-                .as_ref()
-                .expect("checked active_doc above");
+            let doc = node.active_doc.as_ref().expect("checked active_doc above");
             if let Err(e) = doc
                 .set_bytes(node.author, "_team/members.json", content)
                 .await
@@ -399,18 +475,8 @@ pub async fn unified_team_update_member_role(
         }
         #[cfg(feature = "p2p")]
         Some("p2p") => {
-            let guard = iroh_state.lock().await;
-            let node = guard.as_ref().ok_or("P2P node not running")?;
-            let caller_node_id = super::team_p2p::get_node_id(node);
-            drop(guard);
-            let team_dir = format!("{}/{}", workspace_path, super::TEAM_REPO_DIR);
-            super::team_p2p::update_member_role(
-                &workspace_path,
-                &team_dir,
-                &caller_node_id,
-                &node_id,
-                role,
-            )
+            p2p_update_member_role_and_sync(&workspace_path, iroh_state.inner(), &node_id, role)
+                .await
         }
         Some(mode) => Err(format!(
             "Member management not supported for mode: {}",
@@ -456,5 +522,215 @@ pub async fn unified_team_get_my_role(
             mode
         )),
         None => Err("No active team mode".to_string()),
+    }
+}
+
+#[cfg(all(test, feature = "p2p"))]
+mod tests {
+    use super::*;
+    use crate::commands::team_p2p::{
+        add_member_to_team, create_team, get_node_id, join_team_drive, read_members_manifest,
+        IrohNode, SyncEngine,
+    };
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+    use tokio::sync::Mutex;
+
+    struct TestPeer {
+        name: String,
+        workspace_dir: tempfile::TempDir,
+        _iroh_storage_dir: tempfile::TempDir,
+        team_dir: PathBuf,
+        node: IrohNode,
+        engine: super::super::p2p_state::SyncEngineState,
+    }
+
+    impl TestPeer {
+        async fn new(name: &str) -> Self {
+            let workspace_dir = tempfile::tempdir().unwrap();
+            let iroh_storage_dir = tempfile::tempdir().unwrap();
+            let team_dir = workspace_dir.path().join(crate::commands::TEAM_REPO_DIR);
+            std::fs::create_dir_all(&team_dir).unwrap();
+            let node = IrohNode::new(iroh_storage_dir.path()).await.unwrap();
+
+            Self {
+                name: name.to_string(),
+                workspace_dir,
+                _iroh_storage_dir: iroh_storage_dir,
+                team_dir,
+                node,
+                engine: Arc::new(Mutex::new(SyncEngine::new())),
+            }
+        }
+
+        fn workspace_path(&self) -> String {
+            self.workspace_dir.path().to_string_lossy().to_string()
+        }
+
+        fn team_dir_path(&self) -> String {
+            self.team_dir.to_string_lossy().to_string()
+        }
+
+        fn node_id(&self) -> String {
+            get_node_id(&self.node)
+        }
+
+        fn member(&self, role: MemberRole) -> TeamMember {
+            TeamMember {
+                node_id: self.node_id(),
+                name: self.name.clone(),
+                role,
+                label: self.name.clone(),
+                platform: std::env::consts::OS.to_string(),
+                arch: std::env::consts::ARCH.to_string(),
+                hostname: format!("{}-host", self.name.to_lowercase()),
+                added_at: chrono::Utc::now().to_rfc3339(),
+            }
+        }
+
+        async fn create_team(&mut self) -> String {
+            let workspace_path = self.workspace_path();
+            let team_dir = self.team_dir_path();
+            create_team(
+                &mut self.node,
+                &team_dir,
+                &workspace_path,
+                None,
+                None,
+                None,
+                Some("Unified Team Test".to_string()),
+                Some(self.name.clone()),
+                None,
+                None,
+                self.engine.clone(),
+            )
+            .await
+            .unwrap()
+        }
+
+        async fn join_team(&mut self, ticket: &str) {
+            let workspace_path = self.workspace_path();
+            let team_dir = self.team_dir_path();
+            join_team_drive(
+                &mut self.node,
+                ticket,
+                &team_dir,
+                &workspace_path,
+                None,
+                self.engine.clone(),
+            )
+            .await
+            .unwrap();
+        }
+
+        fn manifest(&self) -> TeamManifest {
+            read_members_manifest(&self.team_dir_path())
+                .unwrap()
+                .expect("members manifest should exist")
+        }
+
+        async fn shutdown(self) {
+            self.node.shutdown().await;
+        }
+    }
+
+    async fn wait_until(timeout: Duration, mut check: impl FnMut() -> bool, description: &str) {
+        let start = Instant::now();
+        loop {
+            if check() {
+                return;
+            }
+            assert!(
+                start.elapsed() < timeout,
+                "timed out waiting for {} after {:?}",
+                description,
+                timeout
+            );
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "Uses real iroh nodes and file watchers; run explicitly with --ignored --test-threads=1"]
+    async fn test_p2p_update_member_role_and_sync_updates_remote_manifest() {
+        let mut owner = TestPeer::new("Owner").await;
+        let mut joiner = TestPeer::new("Joiner").await;
+
+        let ticket = owner.create_team().await;
+        let joiner_member = joiner.member(MemberRole::Editor);
+        let joiner_node_id = joiner_member.node_id.clone();
+        add_member_to_team(
+            &owner.workspace_path(),
+            &owner.team_dir_path(),
+            &owner.node_id(),
+            joiner_member,
+        )
+        .unwrap();
+
+        let members_manifest = std::fs::read(owner.team_dir.join("_team/members.json")).unwrap();
+        owner
+            .node
+            .active_doc
+            .as_ref()
+            .expect("owner should have active doc")
+            .set_bytes(owner.node.author, "_team/members.json", members_manifest)
+            .await
+            .unwrap();
+
+        joiner.join_team(&ticket).await;
+
+        wait_until(
+            Duration::from_secs(15),
+            || {
+                joiner
+                    .manifest()
+                    .members
+                    .iter()
+                    .find(|member| member.node_id == joiner_node_id)
+                    .map(|member| member.role.clone())
+                    == Some(MemberRole::Editor)
+            },
+            "joiner sees initial editor role",
+        )
+        .await;
+
+        let owner_workspace_path = owner.workspace_path();
+        let owner_state: super::super::p2p_state::IrohState =
+            Arc::new(Mutex::new(Some(owner.node)));
+
+        p2p_update_member_role_and_sync(
+            &owner_workspace_path,
+            &owner_state,
+            &joiner_node_id,
+            MemberRole::Viewer,
+        )
+        .await
+        .unwrap();
+
+        wait_until(
+            Duration::from_secs(15),
+            || {
+                joiner
+                    .manifest()
+                    .members
+                    .iter()
+                    .find(|member| member.node_id == joiner_node_id)
+                    .map(|member| member.role.clone())
+                    == Some(MemberRole::Viewer)
+            },
+            "joiner receives viewer role from unified helper",
+        )
+        .await;
+
+        let owner_node = owner_state
+            .lock()
+            .await
+            .take()
+            .expect("owner node should still be present");
+        owner.node = owner_node;
+
+        owner.shutdown().await;
+        joiner.shutdown().await;
     }
 }


### PR DESCRIPTION
## Summary
- add real iroh-backed P2P integration coverage for create/join, publish, reconnect, leave/disconnect/dissolve, role updates, removal, and ticket rotation flows
- fix the unified P2P role update path so `members.json` is pushed back to the active doc instead of only mutating local state
- harden namespace rotation and sync generation handling so old watchers are stopped before reusing the same team directory

## What changed
- introduced a richer real-node test harness in `src-tauri/src/commands/team_p2p.rs` and expanded ignored network tests for the main P2P lifecycle
- extracted reusable workspace helpers for leave, disconnect, dissolve, and reconnect paths to make command behavior and tests share the same logic
- updated `rotate_namespace` to preserve existing members and team metadata when creating a new namespace
- updated the sync supervisor to exit promptly when the sync generation changes, which fixes hangs during reconnect/rotation/shutdown flows
- added a shared helper in `src-tauri/src/commands/team_unified.rs` so P2P role changes are synced back to peers and rolled back on failure

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo check --tests --manifest-path src-tauri/Cargo.toml`
- started running ignored real-network tests locally; to avoid contention with an existing `cargo run --features p2p` process, follow-up runs are using an isolated `CARGO_TARGET_DIR=/tmp/teamclaw-p2p-tests-target`

## Notes
- I intentionally staged only the P2P-related command files because the worktree already had many unrelated local modifications.
- The real-network suite is substantially closer to production behavior, but the first isolated run is still paying the full cold-compile cost in the separate target directory.
