### PR TITLE
feat(ui): miscellaneous UI/UX improvements

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1173,7 +1173,14 @@ function App() {
           >
             <AppContent />
           </SidebarProvider>
-          <Toaster position="bottom-right" richColors />
+          <Toaster
+            position="top-center"
+            offset={40}
+            toastOptions={{
+              className: '!bg-popover !text-popover-foreground !border-border !shadow-md !rounded-md !text-xs !py-2 !px-3 !min-h-0 !gap-1.5',
+              descriptionClassName: '!text-muted-foreground !text-[11px]',
+            }}
+          />
           <UpdateDialogContainer />
           <TelemetryConsentDialog
             open={showConsentDialog}

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -637,7 +637,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 />
               ) : (
                 <>
-                  <span className="truncate text-left text-xs">
+                  <span className="truncate text-left text-l">
                     {session.title}
                   </span>
                   {isPinned && (

--- a/packages/app/src/components/chat/ChatMessage.tsx
+++ b/packages/app/src/components/chat/ChatMessage.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Check, Copy, Loader2 } from "lucide-react";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { copyToClipboard } from "@/lib/utils";
+import { cn, copyToClipboard } from "@/lib/utils";
 import { type Message as StoreMessage, useSessionStore, getSessionById } from "@/stores/session";
 import { useStreamingStore } from "@/stores/streaming";
 import {
@@ -142,7 +142,7 @@ export const ChatMessage = React.memo(function ChatMessage({
   }, [textContent, t]);
 
   return (
-    <div className={isToolCallOnly ? "mb-0.5" : "mb-1.5"} data-testid="chat-message" data-message-role={message.role}>
+    <div className={cn("group/msg", isToolCallOnly ? "mb-0.5" : "mb-1.5")} data-testid="chat-message" data-message-role={message.role}>
       {/* Thinking indicator - MUST be first for assistant messages during streaming */}
       {showThinkingOnly && !hasReasoning && (
         <div className="flex items-start gap-2 pl-1 mb-2">
@@ -190,7 +190,7 @@ export const ChatMessage = React.memo(function ChatMessage({
 
       {/* User message actions */}
       {isUser && !latestMessage.isStreaming && (
-        <div className="flex justify-end mt-1 pr-1">
+        <div className={cn("flex justify-end mt-1 pr-1 transition-opacity", copied ? "opacity-100" : "opacity-0 group-hover/msg:opacity-100")}>
           <button
             type="button"
             onClick={handleCopy}
@@ -244,7 +244,7 @@ export const ChatMessage = React.memo(function ChatMessage({
 
       {/* Copy action for assistant text responses */}
       {!isUser && !latestMessage.isStreaming && textContent && (
-        <div className="pl-1 mt-1 group">
+        <div className={cn("pl-1 mt-1 transition-opacity", copied ? "opacity-100" : "opacity-0 group-hover/msg:opacity-100")}>
           <button
             type="button"
             onClick={handleCopy}

--- a/packages/app/src/components/chat/MessageCard.tsx
+++ b/packages/app/src/components/chat/MessageCard.tsx
@@ -88,7 +88,7 @@ export function MessageCard({ message }: MessageCardProps) {
                   const isInline = !className
                   return isInline ? (
                     <code
-                      className="bg-bg-tertiary px-1.5 py-0.5 rounded text-accent-green-dark text-sm font-mono"
+                      className="bg-bg-tertiary px-1.5 py-0.5 rounded text-foreground text-sm font-mono break-words [overflow-wrap:anywhere]"
                       {...props}
                     >
                       {children}

--- a/packages/app/src/components/chat/SessionList.tsx
+++ b/packages/app/src/components/chat/SessionList.tsx
@@ -84,7 +84,7 @@ const SessionListItem = React.memo(function SessionListItem({
           <div className="flex items-center gap-1.5">
             <span className={cn(
               "truncate leading-snug",
-              compact ? "text-xs" : "text-sm",
+              compact ? "text-sm" : "text-[15px]",
               isActive && "font-medium",
             )}>
               {session.title}
@@ -97,7 +97,7 @@ const SessionListItem = React.memo(function SessionListItem({
               </span>
             ) : null}
           </div>
-          <span className={cn("text-muted-foreground/70", compact ? "text-[10px]" : "text-xs")}>
+          <span className={cn("text-muted-foreground/70", compact ? "text-xs" : "text-xs")}>
             {formatRelativeDate(session.updatedAt)}
             {session.messageCount !== undefined && (
               <> · {session.messageCount} msgs</>

--- a/packages/app/src/components/chat/tool-calls/EditToolCard.tsx
+++ b/packages/app/src/components/chat/tool-calls/EditToolCard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useMemo } from "react";
 import {
   ChevronRight,
   FileEdit,
+  Trash2,
   Copy,
   CheckCheck,
 } from "lucide-react";
@@ -13,6 +14,7 @@ import {
   statusConfig,
   extractFilePath,
   extractPatchTextFromToolArgs,
+  parseDeleteOnlyPatch,
   getFileExtension,
   getLanguageName,
   getFileName,
@@ -133,6 +135,12 @@ export function EditToolCard({ toolCall }: { toolCall: ToolCall }) {
   const config = statusConfig[toolCall.status];
   const StatusIcon = config.icon;
 
+  // Detect delete-only patches (*** Delete File: xxx)
+  const deletedFiles = useMemo(
+    () => (patchText ? parseDeleteOnlyPatch(patchText) : null),
+    [patchText],
+  );
+
   // Generate unified diff and parse into structured format (str-replace edit or raw patch)
   const diffData = useMemo(() => {
     try {
@@ -213,6 +221,53 @@ export function EditToolCard({ toolCall }: { toolCall: ToolCall }) {
     setIsExpanded((prev) => !prev);
   }, []);
 
+  // Delete-only patch: render as file deletion list
+  if (deletedFiles) {
+    return (
+      <div className="rounded-lg border border-border bg-muted/30 overflow-hidden transition-all duration-200">
+        <div
+          className="flex items-center gap-2 px-3 py-2 bg-muted/50 cursor-pointer select-none hover:bg-muted/70"
+          onClick={handleToggleExpand}
+        >
+          <ChevronRight
+            size={14}
+            className={cn(
+              "text-muted-foreground transition-transform duration-200 shrink-0",
+              isExpanded && "rotate-90",
+            )}
+          />
+          <Trash2 size={14} className="text-muted-foreground shrink-0" />
+          <span className="text-xs font-medium text-foreground">
+            Deleted {deletedFiles.length} file{deletedFiles.length !== 1 ? "s" : ""}
+          </span>
+          <span className="flex-1" />
+          {toolCall.duration && (
+            <span className="text-[10px] text-muted-foreground/70">
+              {toolCall.duration < 1000
+                ? `${toolCall.duration}ms`
+                : `${(toolCall.duration / 1000).toFixed(1)}s`}
+            </span>
+          )}
+          <StatusIcon
+            size={14}
+            className={cn(config.textColor, config.animate && "animate-spin")}
+          />
+        </div>
+        {isExpanded && (
+          <div className="px-3 pb-2 pt-1 space-y-0.5">
+            {deletedFiles.map((f, i) => (
+              <div key={i} className="flex items-center gap-2 py-0.5 text-xs text-muted-foreground">
+                <span className="text-red-500 dark:text-red-400 text-[10px]">D</span>
+                <span className="font-mono truncate line-through">{getFileName(f)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+        <PermissionApprovalBar toolCall={toolCall} />
+      </div>
+    );
+  }
+
   return (
     <div className="rounded-lg border border-border bg-muted/30 overflow-hidden transition-all duration-200">
       {/* Header: click chevron to toggle, click rest to open file */}
@@ -282,7 +337,7 @@ export function EditToolCard({ toolCall }: { toolCall: ToolCall }) {
       )}
 
       {/* Fallback: show error if diff generation failed but we have content */}
-      {isExpanded && (oldStr || newStr || patchText) && !diffData && (
+      {isExpanded && (oldStr || newStr || patchText) && !diffData && !deletedFiles && (
         <div className="p-3 text-xs text-muted-foreground italic">
           Unable to generate diff view
         </div>

--- a/packages/app/src/components/chat/tool-calls/tool-call-utils.ts
+++ b/packages/app/src/components/chat/tool-calls/tool-call-utils.ts
@@ -242,11 +242,34 @@ export function extractFilePath(args: Record<string, unknown> | undefined): stri
 
 const PATCH_ARG_KEYS = [
   "patch",
+  "patchText",
   "diff",
   "unifiedDiff",
   "unified_diff",
   "udiff",
 ] as const;
+
+/**
+ * Parse a patch that only contains file deletions (*** Delete File: xxx).
+ * Returns the list of deleted file paths, or null if the patch contains non-delete operations.
+ */
+export function parseDeleteOnlyPatch(patchText: string): string[] | null {
+  const lines = patchText.trim().split('\n').filter(l => l.trim());
+  const deleteFiles: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '*** Begin Patch' || trimmed === '*** End Patch') continue;
+    const match = trimmed.match(/^\*\*\* Delete File:\s*(.+)$/);
+    if (match) {
+      deleteFiles.push(match[1].trim());
+    } else {
+      return null;
+    }
+  }
+
+  return deleteFiles.length > 0 ? deleteFiles : null;
+}
 
 /**
  * Extract raw patch / unified-diff text from apply_patch (and similar) tool arguments.

--- a/packages/app/src/components/diff/shiki-renderer.ts
+++ b/packages/app/src/components/diff/shiki-renderer.ts
@@ -12,7 +12,7 @@ let highlighterPromise: Promise<HighlighterGeneric<BundledLanguage, BundledTheme
  * Get or create a shared Shiki highlighter instance.
  * Lazy loads on first use.
  */
-async function getHighlighter() {
+export async function getHighlighter() {
   if (!highlighterPromise) {
     highlighterPromise = import('shiki').then(({ createHighlighter }) =>
       createHighlighter({
@@ -31,7 +31,7 @@ async function getHighlighter() {
 /**
  * Map common language identifiers to Shiki language identifiers.
  */
-function mapLanguage(lang: string): BundledLanguage {
+export function mapLanguage(lang: string): BundledLanguage {
   const map: Record<string, BundledLanguage> = {
     ts: 'typescript',
     tsx: 'typescript',

--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -12,6 +12,7 @@ import {
   Link,
   Trash2,
   ChevronRight,
+  ChevronDown,
   Zap,
   Settings,
   ExternalLink,
@@ -35,6 +36,17 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { SettingCard, SectionHeader } from './shared'
+
+const MAINSTREAM_PROVIDER_IDS = new Set([
+  'anthropic',
+  'openai',
+  'google',
+  'deepseek',
+  'ollama',
+  'alibaba',
+  'alibaba-cn',
+  'zhipuai',
+])
 
 export const LLMSection = React.memo(function LLMSection() {
   const { t } = useTranslation()
@@ -100,6 +112,35 @@ export const LLMSection = React.memo(function LLMSection() {
 
   // Detail view for connected provider
   const [selectedProviderId, setSelectedProviderId] = React.useState<string | null>(null)
+
+  // Collapsible other providers
+  const [showAllProviders, setShowAllProviders] = React.useState(false)
+
+  const { visibleProviders, hiddenCount } = React.useMemo(() => {
+    const connected: typeof providers = []
+    const mainstream: typeof providers = []
+    const others: typeof providers = []
+
+    for (const p of providers) {
+      if (p.configured) {
+        connected.push(p)
+      } else if (
+        customProviderIds.includes(p.id) ||
+        MAINSTREAM_PROVIDER_IDS.has(p.id.toLowerCase())
+      ) {
+        mainstream.push(p)
+      } else {
+        others.push(p)
+      }
+    }
+
+    return {
+      visibleProviders: showAllProviders
+        ? [...connected, ...mainstream, ...others]
+        : [...connected, ...mainstream],
+      hiddenCount: others.length,
+    }
+  }, [providers, showAllProviders, customProviderIds])
 
   // Load providers on mount and when OpenCode becomes ready
   React.useEffect(() => {
@@ -438,7 +479,7 @@ export const LLMSection = React.memo(function LLMSection() {
       {/* Provider List */}
       {!providersLoading || providers.length > 0 ? (
         <div className="space-y-3">
-          {providers.map((p) => {
+          {visibleProviders.map((p) => {
             const isConnected = p.configured
             const isExpanded = selectedProviderId === p.id
             const models = isConnected ? getProviderModels(p.id) : []
@@ -577,6 +618,18 @@ export const LLMSection = React.memo(function LLMSection() {
               </SettingCard>
             )
           })}
+
+          {hiddenCount > 0 && (
+            <button
+              className="w-full flex items-center justify-center gap-1.5 py-2.5 text-xs text-muted-foreground hover:text-foreground transition-colors rounded-lg hover:bg-muted/50"
+              onClick={() => setShowAllProviders(!showAllProviders)}
+            >
+              <ChevronDown className={cn("h-3.5 w-3.5 transition-transform", showAllProviders && "rotate-180")} />
+              {showAllProviders
+                ? t('settings.llm.showLess', 'Show Less')
+                : t('settings.llm.showMore', { count: hiddenCount, defaultValue: `Show ${hiddenCount} more providers` })}
+            </button>
+          )}
 
           {providers.length === 0 && !providersLoading && (
             <SettingCard>

--- a/packages/app/src/packages/ai/message.tsx
+++ b/packages/app/src/packages/ai/message.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { readFile } from "@tauri-apps/plugin-fs"
-import { Download, X } from "lucide-react"
+import { Download, X, Copy, Check } from "lucide-react"
 
 import { cn, isTauri } from "@/lib/utils"
 import {
@@ -98,8 +98,10 @@ export function MessageContent({
   return (
     <div
       className={cn(
-        "max-w-[85%] rounded-2xl px-4 py-3 text-sm overflow-hidden break-words [overflow-wrap:anywhere] min-w-0",
-        from === "user" ? "bg-[#6f8c8a] text-white" : "bg-transparent",
+        "text-sm overflow-hidden break-words [overflow-wrap:anywhere] min-w-0",
+        from === "user"
+          ? "max-w-[85%] rounded-2xl px-4 py-3 bg-[#6f8c8a] text-white"
+          : "w-full",
         className
       )}
       {...props}
@@ -463,6 +465,61 @@ export function ClickableImage({ src, alt, className }: { src: string; alt?: str
   )
 }
 
+// --- Code block with syntax highlighting, language header, and copy button ---
+function CodeBlock({ language, children }: { language: string; children: string }) {
+  const [highlightedHtml, setHighlightedHtml] = React.useState<string | null>(null)
+  const [copied, setCopied] = React.useState(false)
+  const code = String(children).replace(/\n$/, '')
+
+  React.useEffect(() => {
+    let cancelled = false
+    import('@/components/diff/shiki-renderer').then(async ({ getHighlighter, mapLanguage }) => {
+      if (cancelled) return
+      try {
+        const highlighter = await getHighlighter()
+        const isDark = document.documentElement.classList.contains('dark')
+        const theme = isDark ? 'github-dark' : 'github-light'
+        const lang = mapLanguage(language)
+        const html = highlighter.codeToHtml(code, { lang, theme })
+        if (!cancelled) setHighlightedHtml(html)
+      } catch {
+        // Fallback: no highlighting
+      }
+    })
+    return () => { cancelled = true }
+  }, [code, language])
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="w-full rounded-lg bg-foreground/[0.02] overflow-hidden my-2">
+      <div className="flex items-center justify-between px-3 py-1.5">
+        <span className="text-xs text-muted-foreground font-mono">{language}</span>
+        <button
+          onClick={handleCopy}
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+        </button>
+      </div>
+      {highlightedHtml ? (
+        <div
+          className="px-3 pb-3 overflow-x-auto text-sm [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0 [&_code]:!bg-transparent [&_code]:!p-0"
+          dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+        />
+      ) : (
+        <pre className="px-3 pb-3 overflow-x-auto">
+          <code className="font-mono text-sm text-foreground">{code}</code>
+        </pre>
+      )}
+    </div>
+  )
+}
+
 // --- Stable ReactMarkdown components (no closure over basePath) ---
 // Hoisted to module level so the object reference never changes between renders.
 // The `img` component needs basePath, so it's added per-render via useMemo.
@@ -495,31 +552,21 @@ const markdownComponentsBase = {
   blockquote: ({ children }: { children?: React.ReactNode }) => (
     <blockquote className="border-l-4 border-[#5a7a64] pl-4 my-3 italic text-muted-foreground">{children}</blockquote>
   ),
-  pre: ({ children }: { children?: React.ReactNode }) => (
-    <pre className="my-2 max-w-full overflow-x-auto rounded-lg [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-      {children}
-    </pre>
-  ),
+  pre: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   code: ({ className, children, ...codeProps }: { className?: string; children?: React.ReactNode }) => {
     const isInline = !className
-    return isInline ? (
-      <code
-        className="inline-block max-w-full align-middle overflow-x-auto whitespace-nowrap rounded bg-muted px-1.5 py-px font-mono text-[0.9em] leading-snug text-[#4a6a54] [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-        {...codeProps}
-      >
-        {children}
-      </code>
-    ) : (
-      <code
-        className={cn(
-          "block max-w-full overflow-x-auto rounded-lg bg-muted p-3 font-mono text-xs text-foreground [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
-          className,
-        )}
-        {...codeProps}
-      >
-        {children}
-      </code>
-    )
+    if (isInline) {
+      return (
+        <code
+          className="rounded bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-[0.9em] leading-snug text-foreground break-words [overflow-wrap:anywhere]"
+          {...codeProps}
+        >
+          {children}
+        </code>
+      )
+    }
+    const language = className?.replace('language-', '') || ''
+    return <CodeBlock language={language}>{String(children)}</CodeBlock>
   },
   a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
     <a href={href} target="_blank" rel="noopener noreferrer" className="text-[#5a7a64] hover:underline">{children}</a>


### PR DESCRIPTION
## Summary

- **LLM Settings**: Prioritize mainstream AI providers (Anthropic, OpenAI, Google, DeepSeek, Ollama, Alibaba, Zhipu) at the top; collapse others behind a "Show More" button. Connected providers still stay at the top.
- **Markdown Rendering**: Add syntax-highlighted code blocks (via Shiki) with language header and copy button; restyle inline code to gray background with black text and word wrapping.
- **Chat UX**: Hide copy buttons on user/assistant messages by default, show on hover.
- **Tool Calls**: Detect and render delete-only patches (`*** Delete File`) with a dedicated deletion UI instead of showing "Unable to generate diff view".
- **Toast Notifications**: Move to top-center with compact styling.
- **Session List & Sidebar**: Adjust font sizes for better readability.

## Test plan

- [ ] Verify LLM settings page shows mainstream providers first, "Show More" reveals the rest
- [ ] Verify connected providers remain at the top regardless of mainstream status
- [ ] Verify markdown code blocks render with syntax highlighting, language label, and copy button
- [ ] Verify inline code renders with gray background and wraps on long lines
- [ ] Verify copy buttons on messages are hidden by default and appear on hover
- [ ] Verify delete file tool calls render with dedicated UI (trash icon + file list)
- [ ] Verify toast notifications appear at top-center


Made with [Cursor](https://cursor.com)