### PR TITLE
fix(oss-sync): add S3 client timeouts to prevent infinite loading spinner

### DIFF
--- a/packages/app/src/stores/team-oss.ts
+++ b/packages/app/src/stores/team-oss.ts
@@ -171,10 +171,18 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
       if (config?.enabled) {
         set({ configured: true, restoring: true })
         try {
-          const info = await invoke<OssTeamInfo>('oss_restore_sync', {
-            workspacePath,
-            teamId: config.teamId,
-          })
+          // Safety timeout: if backend hangs (e.g. unreachable S3), stop the
+          // spinner so the user can still interact with the UI.
+          const RESTORE_TIMEOUT_MS = 90_000
+          const info = await Promise.race([
+            invoke<OssTeamInfo>('oss_restore_sync', {
+              workspacePath,
+              teamId: config.teamId,
+            }),
+            new Promise<never>((_, reject) =>
+              setTimeout(() => reject(new Error('OSS restore timed out')), RESTORE_TIMEOUT_MS),
+            ),
+          ])
           set({ connected: true, teamInfo: info, restoring: false })
         } catch (e) {
           // Offline or restore failed — still configured, just not connected

--- a/scripts/tauri-cli.js
+++ b/scripts/tauri-cli.js
@@ -33,6 +33,12 @@ if (isWindows && (sub === "dev" || sub === "build")) {
 const env = { ...process.env };
 delete env.CI;
 
+// Workaround: Xcode 26 beta clang reports "arm64-apple-darwin" which causes
+// bindgen to fail with an assertion error (expects "aarch64-apple-darwin").
+if (platform === "darwin" && process.arch === "arm64" && !env.BINDGEN_EXTRA_CLANG_ARGS) {
+  env.BINDGEN_EXTRA_CLANG_ARGS = "--target=aarch64-apple-darwin";
+}
+
 // Build command string with proper quoting for shell
 const commandStr = args.map((arg) => {
   // Quote arguments that contain spaces or special characters (like JSON)

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -219,12 +219,25 @@ impl OssSyncManager {
             "oss-sts",
         );
 
+        let timeout_config = aws_sdk_s3::config::timeout::TimeoutConfig::builder()
+            .operation_timeout(std::time::Duration::from_secs(30))
+            .operation_attempt_timeout(std::time::Duration::from_secs(15))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .build();
+
+        let stalled_stream =
+            aws_sdk_s3::config::StalledStreamProtectionConfig::enabled()
+                .grace_period(std::time::Duration::from_secs(10))
+                .build();
+
         let s3_config = aws_sdk_s3::config::Builder::new()
             .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
             .endpoint_url(&config.endpoint)
             .region(aws_sdk_s3::config::Region::new(config.region.clone()))
             .credentials_provider(credentials)
             .force_path_style(force_path_style)
+            .timeout_config(timeout_config)
+            .stalled_stream_protection(stalled_stream)
             .build();
 
         aws_sdk_s3::Client::from_conf(s3_config)


### PR DESCRIPTION
## Summary
- S3 client had no timeout config — unreachable endpoints caused the "连接中" spinner to hang forever
- Added connect (10s), operation attempt (15s), operation (30s) timeouts and stalled stream protection to AWS S3 client
- Added 90s frontend `Promise.race` safety timeout as fallback
- Added Xcode 26 beta `bindgen` workaround in `tauri-cli.js` (arm64 vs aarch64 triple mismatch)

## Test plan
- [ ] Configure S3 team with unreachable endpoint → verify spinner stops after ~30s instead of hanging
- [ ] Configure S3 team with valid endpoint → verify normal connection still works
- [ ] `pnpm tauri dev` on macOS with Xcode 26 beta → verify build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)