### PR TITLE
fix(oss-sync): detect file deletions in fast loop

### DIFF
--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -830,6 +830,30 @@ impl OssSyncManager {
         let mtime_changed = Self::scan_local_files_incremental(&dir, since)?;
 
         if mtime_changed.is_empty() {
+            // No mtime changes, but files may have been deleted since the
+            // last scan.  Check the CRDT for entries that are not marked
+            // deleted yet whose files no longer exist on disk.  If any are
+            // found, delegate to the full `upload_local_changes` which
+            // handles deletion marking + upload in one shot.
+            let local_files = Self::scan_local_files(&dir)?;
+            let doc = self.get_doc(doc_type);
+            let files_map = doc.get_map("files");
+            let map_value = files_map.get_deep_value();
+            if let loro::LoroValue::Map(entries) = &map_value {
+                for (path, value) in entries.iter() {
+                    if let loro::LoroValue::Map(entry) = value {
+                        let deleted = match entry.get("deleted") {
+                            Some(loro::LoroValue::Bool(b)) => *b,
+                            _ => false,
+                        };
+                        if !deleted && !local_files.contains_key(path.as_str()) {
+                            // At least one file was deleted locally — hand off
+                            // to the full upload path which marks deletions.
+                            return self.upload_local_changes(doc_type).await;
+                        }
+                    }
+                }
+            }
             return Ok(false);
         }
 


### PR DESCRIPTION
## Summary
- Fast loop 的 `upload_local_changes_incremental` 只检测 mtime 变化的文件，完全漏掉了本地删除
- CRDT 里 `deleted` 保持 `false` 直到 5 分钟后 slow loop 才标记，期间任何 signal flag 触发的 `write_doc_to_disk` 都会把文件从 CRDT 内容重新写回磁盘（"复活"）
- 现在 incremental upload 也检测 CRDT 条目对应的文件是否还在磁盘上，发现删除后委托给完整的 upload 路径，30 秒内即可标记删除

## Test plan
- [ ] 开启 S3 同步，两个节点同步 skills 文件夹
- [ ] 在节点 A 删除一个 skill 子目录
- [ ] 验证 30s 内（而非 5min）删除被同步到 S3
- [ ] 在节点 B 修改任意文件触发 signal flag，确认节点 A 的已删除文件不会被重新创建

🤖 Generated with [Claude Code](https://claude.com/claude-code)