### PR TITLE
feat(team): add manager role and misc fixes

### DIFF
--- a/packages/app/src/components/settings/AddMemberInput.tsx
+++ b/packages/app/src/components/settings/AddMemberInput.tsx
@@ -13,14 +13,16 @@ import {
 export function AddMemberInput({
   onAdd,
   error,
+  myRole,
 }: {
   onAdd: (nodeId: string, name: string, role: string, label: string) => void
   error?: string | null
+  myRole?: string | null
 }) {
   const [nodeId, setNodeId] = React.useState('')
   const [name, setName] = React.useState('')
   const [label, setLabel] = React.useState('')
-  const [role, setRole] = React.useState<'editor' | 'viewer'>('editor')
+  const [role, setRole] = React.useState<'manager' | 'editor' | 'viewer'>('editor')
 
   const handleSubmit = () => {
     if (nodeId.trim()) {
@@ -66,11 +68,12 @@ export function AddMemberInput({
       </div>
       <div className="space-y-2">
         <label className="text-xs font-medium text-muted-foreground">Role</label>
-        <Select value={role} onValueChange={(v) => setRole(v as 'editor' | 'viewer')}>
+        <Select value={role} onValueChange={(v) => setRole(v as 'manager' | 'editor' | 'viewer')}>
           <SelectTrigger className="h-9">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
+            {myRole === 'owner' && <SelectItem value="manager">Manager</SelectItem>}
             <SelectItem value="editor">Editor</SelectItem>
             <SelectItem value="viewer">Viewer</SelectItem>
           </SelectContent>

--- a/packages/app/src/components/settings/TeamMemberList.tsx
+++ b/packages/app/src/components/settings/TeamMemberList.tsx
@@ -5,6 +5,13 @@ import { useTeamMembersStore } from '../../stores/team-members'
 import { AddMemberInput } from './AddMemberInput'
 import { useP2pEngineStore, type PeerConnection } from '@/stores/p2p-engine'
 import { cn } from '@/lib/utils'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 
 function truncateId(id: string): string {
   if (id.length <= 16) return id
@@ -17,6 +24,14 @@ function RoleBadge({ role }: { role?: string }) {
       <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 px-1.5 py-0.5 rounded">
         <Shield className="h-3 w-3" />
         Owner
+      </span>
+    )
+  }
+  if (role === 'manager') {
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 px-1.5 py-0.5 rounded">
+        <Shield className="h-3 w-3" />
+        Manager
       </span>
     )
   }
@@ -161,8 +176,14 @@ export function TeamMemberList() {
       <div className="space-y-2">
         {members.map((member) => {
           const isMemberOwner = member.role === 'owner'
-          // Editors cannot remove or demote the owner
-          const canActOnMember = isManager && !isMemberOwner && !(myRole === 'editor' && isMemberOwner)
+          const isMemberManager = member.role === 'manager'
+          // Owner can act on anyone except themselves; Manager can only act on editor/viewer
+          const canActOnMember =
+            isManager &&
+            member.nodeId !== currentNodeId &&
+            (myRole === 'owner'
+              ? !isMemberOwner
+              : !isMemberOwner && !isMemberManager)
 
           return (
             <div
@@ -192,7 +213,22 @@ export function TeamMemberList() {
                 </p>
               </div>
               <div className="flex items-center gap-1">
-                {canActOnMember && (
+                {canActOnMember && myRole === 'owner' && (
+                  <Select
+                    value={member.role}
+                    onValueChange={(v) => updateMemberRole(member.nodeId, v as any)}
+                  >
+                    <SelectTrigger className="h-8 w-[110px] text-xs">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="manager">Manager</SelectItem>
+                      <SelectItem value="editor">Editor</SelectItem>
+                      <SelectItem value="viewer">Viewer</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+                {canActOnMember && myRole === 'manager' && (
                   <Button
                     variant="ghost"
                     size="sm"
@@ -236,7 +272,7 @@ export function TeamMemberList() {
             <UserPlus className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Add Member</span>
           </div>
-          <AddMemberInput onAdd={handleAdd} error={error} />
+          <AddMemberInput onAdd={handleAdd} error={error} myRole={myRole} />
         </div>
       )}
     </div>

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -129,6 +129,7 @@ export function TeamOSSConfig() {
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
 
   const {
+    configured,
     connected,
     restoring,
     syncing,
@@ -146,6 +147,7 @@ export function TeamOSSConfig() {
     pendingApplication,
     loadPendingApplication,
     cancelApplication,
+    initialize,
   } = useTeamOssStore()
 
   const teamMembersStore = useTeamMembersStore()
@@ -164,6 +166,7 @@ export function TeamOSSConfig() {
   const [joining, setJoining] = useState(false)
   const [leaving, setLeaving] = useState(false)
   const [showSecret, setShowSecret] = useState(false)
+  const [reconnecting, setReconnecting] = useState(false)
   const [snapshotLoading, setSnapshotLoading] = useState<string | null>(null)
   const [cleanupLoading, setCleanupLoading] = useState<string | null>(null)
   const [deviceInfo, setDeviceInfo] = useState<DeviceInfo | null>(null)
@@ -330,8 +333,41 @@ export function TeamOSSConfig() {
         </SettingCard>
       )}
 
-      {/* State 1: Disconnected — Create/Join forms */}
-      {!connected && !restoring && (
+      {/* State 1a: Configured but disconnected — reconnect prompt */}
+      {!connected && !restoring && configured && (
+        <SettingCard title="团队未连接" icon={Cloud}>
+          <div className="flex flex-col items-center gap-3 py-4">
+            <p className="text-sm text-muted-foreground">
+              已检测到团队配置，但连接失败。可能是网络问题或 S3 服务不可用。
+            </p>
+            {error && (
+              <p className="text-xs text-destructive text-center">{error}</p>
+            )}
+            <Button
+              onClick={async () => {
+                if (!workspacePath) return
+                setReconnecting(true)
+                try {
+                  await initialize(workspacePath)
+                } finally {
+                  setReconnecting(false)
+                }
+              }}
+              disabled={reconnecting}
+              variant="outline"
+            >
+              {reconnecting ? (
+                <><Loader2 className="mr-2 h-4 w-4 animate-spin" />重新连接中...</>
+              ) : (
+                <><RefreshCw className="mr-2 h-4 w-4" />重新连接</>
+              )}
+            </Button>
+          </div>
+        </SettingCard>
+      )}
+
+      {/* State 1b: Not configured — Create/Join forms */}
+      {!connected && !restoring && !configured && (
         <>
           <SettingCard title="创建团队" icon={Users}>
             <div className="space-y-3">

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -147,7 +147,7 @@ export function TeamOSSConfig() {
     pendingApplication,
     loadPendingApplication,
     cancelApplication,
-    initialize,
+    reconnect,
   } = useTeamOssStore()
 
   const teamMembersStore = useTeamMembersStore()
@@ -166,7 +166,6 @@ export function TeamOSSConfig() {
   const [joining, setJoining] = useState(false)
   const [leaving, setLeaving] = useState(false)
   const [showSecret, setShowSecret] = useState(false)
-  const [reconnecting, setReconnecting] = useState(false)
   const [snapshotLoading, setSnapshotLoading] = useState<string | null>(null)
   const [cleanupLoading, setCleanupLoading] = useState<string | null>(null)
   const [deviceInfo, setDeviceInfo] = useState<DeviceInfo | null>(null)
@@ -344,19 +343,11 @@ export function TeamOSSConfig() {
               <p className="text-xs text-destructive text-center">{error}</p>
             )}
             <Button
-              onClick={async () => {
-                if (!workspacePath) return
-                setReconnecting(true)
-                try {
-                  await initialize(workspacePath)
-                } finally {
-                  setReconnecting(false)
-                }
-              }}
-              disabled={reconnecting}
+              onClick={() => workspacePath && reconnect(workspacePath)}
+              disabled={restoring}
               variant="outline"
             >
-              {reconnecting ? (
+              {restoring ? (
                 <><Loader2 className="mr-2 h-4 w-4 animate-spin" />重新连接中...</>
               ) : (
                 <><RefreshCw className="mr-2 h-4 w-4" />重新连接</>

--- a/packages/app/src/components/settings/team/VersionHistorySection.tsx
+++ b/packages/app/src/components/settings/team/VersionHistorySection.tsx
@@ -30,6 +30,8 @@ export function VersionHistorySection() {
 
   const [docTypeFilter, setDocTypeFilter] = useState<string | null>(null)
   const [dialogFile, setDialogFile] = useState<VersionedFileInfo | null>(null)
+  const [page, setPage] = useState(0)
+  const pageSize = 10
 
   useEffect(() => {
     if (workspacePath) {
@@ -39,6 +41,7 @@ export function VersionHistorySection() {
 
   const handleFilterChange = (filter: string | null) => {
     setDocTypeFilter(filter)
+    setPage(0)
     if (workspacePath) {
       loadVersionedFiles(workspacePath, filter ?? undefined)
     }
@@ -47,6 +50,9 @@ export function VersionHistorySection() {
   const filteredFiles = docTypeFilter
     ? versionedFiles.filter((f) => f.docType === docTypeFilter)
     : versionedFiles
+
+  const totalPages = Math.ceil(filteredFiles.length / pageSize)
+  const pagedFiles = filteredFiles.slice(page * pageSize, (page + 1) * pageSize)
 
   return (
     <div className="rounded-xl border border-border/40 bg-card/30 p-5 backdrop-blur-sm">
@@ -79,47 +85,75 @@ export function VersionHistorySection() {
       ) : filteredFiles.length === 0 ? (
         <p className="text-xs text-muted-foreground py-2">暂无文件版本记录</p>
       ) : (
-        <div className="space-y-1.5">
-          {filteredFiles.map((file) => {
-            const fileName = getFileName(file.path)
-            const docLabel = DOC_TYPE_LABELS[file.docType] ?? file.docType
+        <>
+          <div className="space-y-1.5">
+            {pagedFiles.map((file) => {
+              const fileName = getFileName(file.path)
+              const docLabel = DOC_TYPE_LABELS[file.docType] ?? file.docType
 
-            return (
-              <div
-                key={`${file.docType}:${file.path}`}
-                className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span
-                      className={cn(
-                        'truncate text-sm font-medium',
-                        file.currentDeleted && 'line-through text-destructive'
-                      )}
-                    >
-                      {fileName}
-                    </span>
-                    <span className="shrink-0 rounded px-1.5 py-0.5 text-[10px] bg-muted text-muted-foreground">
-                      {docLabel}
-                    </span>
-                  </div>
-                  <div className="text-xs text-muted-foreground mt-0.5">
-                    {file.versionCount} 个版本
-                    {file.latestUpdateBy && ` · ${file.latestUpdateBy}`}
-                  </div>
-                </div>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="ml-3 h-7 shrink-0 text-xs"
-                  onClick={() => setDialogFile(file)}
+              return (
+                <div
+                  key={`${file.docType}:${file.path}`}
+                  className="flex items-center justify-between rounded-lg bg-muted/30 px-3 py-2"
                 >
-                  查看历史
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={cn(
+                          'truncate text-sm font-medium',
+                          file.currentDeleted && 'line-through text-destructive'
+                        )}
+                      >
+                        {fileName}
+                      </span>
+                      <span className="shrink-0 rounded px-1.5 py-0.5 text-[10px] bg-muted text-muted-foreground">
+                        {docLabel}
+                      </span>
+                    </div>
+                    <div className="text-xs text-muted-foreground mt-0.5">
+                      {file.versionCount} 个版本
+                      {file.latestUpdateBy && ` · ${file.latestUpdateBy}`}
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="ml-3 h-7 shrink-0 text-xs"
+                    onClick={() => setDialogFile(file)}
+                  >
+                    查看历史
+                  </Button>
+                </div>
+              )
+            })}
+          </div>
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between pt-2 text-xs text-muted-foreground">
+              <span>{filteredFiles.length} 个文件</span>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs"
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  上一页
+                </Button>
+                <span>{page + 1} / {totalPages}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs"
+                  disabled={page >= totalPages - 1}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  下一页
                 </Button>
               </div>
-            )
-          })}
-        </div>
+            </div>
+          )}
+        </>
       )}
 
       {dialogFile && (

--- a/packages/app/src/lib/git/types.ts
+++ b/packages/app/src/lib/git/types.ts
@@ -98,8 +98,8 @@ export interface TeamMember {
   nodeId: string
   /** Human-readable display name (e.g. "Alice", "Bob") */
   name: string
-  /** Member role: owner, editor, or viewer */
-  role?: 'owner' | 'editor' | 'viewer'
+  /** Member role: owner, manager, editor, or viewer */
+  role?: 'owner' | 'manager' | 'editor' | 'viewer'
   /** Human-readable label */
   label: string
   /** OS name */
@@ -255,7 +255,7 @@ export interface TeamCreateResult {
 
 export interface TeamJoinResult {
   success: boolean
-  role: 'owner' | 'editor' | 'viewer'
+  role: 'owner' | 'manager' | 'editor' | 'viewer'
   members: TeamMember[]
 }
 

--- a/packages/app/src/stores/team-members.ts
+++ b/packages/app/src/stores/team-members.ts
@@ -3,7 +3,7 @@ import { create } from 'zustand'
 import { invoke } from '@tauri-apps/api/core'
 import type { TeamMember } from '../lib/git/types'
 
-type MemberRole = 'owner' | 'editor' | 'viewer'
+type MemberRole = 'owner' | 'manager' | 'editor' | 'viewer'
 
 interface TeamApplication {
   nodeId: string
@@ -111,7 +111,7 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
 
   canManageMembers: () => {
     const { myRole } = get()
-    return myRole === 'owner' || myRole === 'editor'
+    return myRole === 'owner' || myRole === 'manager'
   },
 
   listenForApplications: async () => {

--- a/packages/app/src/stores/team-oss.ts
+++ b/packages/app/src/stores/team-oss.ts
@@ -113,6 +113,7 @@ interface TeamOssState {
     email: string
     note: string
   }) => Promise<void>
+  reconnect: (workspacePath: string) => Promise<void>
   loadPendingApplication: (workspacePath: string) => Promise<void>
   cancelApplication: (workspacePath: string) => Promise<void>
   cleanup: () => void
@@ -199,6 +200,31 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
     } catch (e) {
       console.error('OSS sync init failed:', e)
       set({ error: String(e) })
+    }
+  },
+
+  reconnect: async (workspacePath) => {
+    set({ restoring: true, error: null })
+    try {
+      const config = await invoke<OssTeamConfig | null>('oss_get_team_config', { workspacePath })
+      if (!config?.enabled) {
+        set({ restoring: false, configured: false })
+        return
+      }
+      const RESTORE_TIMEOUT_MS = 90_000
+      const info = await Promise.race([
+        invoke<OssTeamInfo>('oss_restore_sync', {
+          workspacePath,
+          teamId: config.teamId,
+        }),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('OSS restore timed out')), RESTORE_TIMEOUT_MS),
+        ),
+      ])
+      set({ connected: true, teamInfo: info, restoring: false })
+    } catch (e) {
+      console.warn('OSS reconnect failed:', e)
+      set({ restoring: false, error: String(e) })
     }
   },
 

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -16,21 +16,44 @@ use tracing::{info, warn};
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Get the P2P node ID to use as the unified device identity.
+/// Get a stable device identity for OSS operations.
+/// Prefers the P2P node ID when available, falls back to a persisted UUID
+/// when P2P is disabled at compile time or the node hasn't started yet.
 async fn get_p2p_node_id(iroh_state: &State<'_, IrohState>) -> Result<String, String> {
     let guard = iroh_state.lock().await;
     #[cfg(feature = "p2p")]
     {
-        let node = guard
-            .as_ref()
-            .ok_or("P2P node not running. Please wait for the app to fully initialize.")?;
-        Ok(get_node_id(node))
+        if let Some(node) = guard.as_ref() {
+            return Ok(get_node_id(node));
+        }
+        // P2P node not started yet — use fallback
+        drop(guard);
+        get_or_create_fallback_device_id()
     }
     #[cfg(not(feature = "p2p"))]
     {
         let _ = guard;
-        Err("P2P feature is not enabled".to_string())
+        get_or_create_fallback_device_id()
     }
+}
+
+/// Generate or load a persistent fallback device ID.
+fn get_or_create_fallback_device_id() -> Result<String, String> {
+    let dir = dirs::home_dir()
+        .ok_or("Cannot determine home directory")?
+        .join(".teamclaw");
+    let path = dir.join("device-id");
+    if let Ok(id) = std::fs::read_to_string(&path) {
+        let id = id.trim().to_string();
+        if !id.is_empty() {
+            return Ok(id);
+        }
+    }
+    let id = uuid::Uuid::new_v4().to_string();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create config dir: {e}"))?;
+    std::fs::write(&path, &id).map_err(|e| format!("Failed to write device ID: {e}"))?;
+    info!("Generated fallback device ID: {id}");
+    Ok(id)
 }
 
 fn parse_doc_type(s: &str) -> Result<DocType, String> {

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -2348,6 +2348,15 @@ impl OssSyncManager {
             return Err("Cannot remove the team Owner".to_string());
         }
 
+        // If caller is manager (not owner), block removing other managers
+        let is_owner = manifest.owner_node_id == self.node_id;
+        if !is_owner {
+            let target_role = manifest.members.iter().find(|m| m.node_id == node_id).map(|m| &m.role);
+            if matches!(target_role, Some(MemberRole::Owner) | Some(MemberRole::Manager)) {
+                return Err("Managers can only remove editors and viewers".to_string());
+            }
+        }
+
         manifest.members.retain(|m| m.node_id != node_id);
         self.upload_members_manifest(&manifest).await
     }
@@ -2361,6 +2370,24 @@ impl OssSyncManager {
 
         if manifest.owner_node_id == node_id && role != MemberRole::Owner {
             return Err("Cannot change the Owner's role".to_string());
+        }
+
+        // Cannot assign Owner role
+        if matches!(role, MemberRole::Owner) {
+            return Err("Cannot assign the owner role".to_string());
+        }
+
+        let is_owner = manifest.owner_node_id == self.node_id;
+        let target_role = manifest.members.iter().find(|m| m.node_id == node_id).map(|m| m.role.clone());
+
+        // Manager restrictions
+        if !is_owner {
+            if matches!(role, MemberRole::Manager) {
+                return Err("Only the owner can promote to manager".to_string());
+            }
+            if matches!(target_role, Some(MemberRole::Manager)) {
+                return Err("Managers cannot change another manager's role".to_string());
+            }
         }
 
         if let Some(member) = manifest.members.iter_mut().find(|m| m.node_id == node_id) {

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -2884,13 +2884,13 @@ pub fn add_member_to_team(
         config.allowed_members.clone()
     };
 
-    // Any existing member (owner or editor) can add new members.
+    // Any existing member (owner or manager) can add new members.
     let is_owner = owner_id == caller_node_id;
-    let is_member = members.iter().any(|m| {
-        m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor)
+    let is_manager = members.iter().any(|m| {
+        m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Manager)
     });
-    if !is_owner && !is_member {
-        return Err("Only team members can add new members".to_string());
+    if !is_owner && !is_manager {
+        return Err("Only team owner or manager can add new members".to_string());
     }
 
     if members.iter().any(|m| m.node_id == member.node_id) {
@@ -2957,15 +2957,22 @@ pub fn remove_member_from_team(
     };
 
     let is_owner = owner_id == caller_node_id;
-    let is_editor = members.iter().any(|m| {
-        m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor)
-    });
-    if !is_owner && !is_editor {
-        return Err("Only team members (owner or editor) can manage members".to_string());
+    let caller_role = members.iter().find(|m| m.node_id == caller_node_id).map(|m| &m.role);
+    let is_manager = matches!(caller_role, Some(MemberRole::Owner) | Some(MemberRole::Manager));
+    if !is_owner && !is_manager {
+        return Err("Only team owner or manager can remove members".to_string());
     }
 
-    if target_node_id == caller_node_id {
+    if target_node_id == owner_id {
         return Err("Cannot remove the team owner".to_string());
+    }
+
+    // Managers cannot remove other managers or the owner
+    if !is_owner {
+        let target_role = members.iter().find(|m| m.node_id == target_node_id).map(|m| &m.role);
+        if matches!(target_role, Some(MemberRole::Owner) | Some(MemberRole::Manager)) {
+            return Err("Managers can only remove editors and viewers".to_string());
+        }
     }
 
     let before_len = members.len();
@@ -2981,7 +2988,7 @@ pub fn remove_member_from_team(
     Ok(())
 }
 
-/// Update a member's role. Owner or editor can call this.
+/// Update a member's role. Owner or manager can call this.
 pub fn update_member_role(
     workspace_path: &str,
     team_dir: &str,
@@ -2995,7 +3002,6 @@ pub fn update_member_role(
         .owner_node_id
         .as_deref()
         .ok_or("No team owner configured")?;
-    // Use manifest as authoritative member list when available
     let manifest = read_members_manifest(team_dir).ok().flatten();
     let mut members = if let Some(ref m) = manifest {
         m.members.clone()
@@ -3004,15 +3010,40 @@ pub fn update_member_role(
     };
 
     let is_owner = owner_id == caller_node_id;
-    let is_editor = members.iter().any(|m| {
-        m.node_id == caller_node_id && matches!(m.role, MemberRole::Owner | MemberRole::Editor)
-    });
-    if !is_owner && !is_editor {
-        return Err("Only team members (owner or editor) can manage members".to_string());
+    let caller_role = members.iter().find(|m| m.node_id == caller_node_id).map(|m| m.role.clone());
+    let is_manager = matches!(caller_role, Some(MemberRole::Owner) | Some(MemberRole::Manager));
+
+    if !is_owner && !is_manager {
+        return Err("Only team owner or manager can change roles".to_string());
     }
 
+    // Cannot change own role
     if target_node_id == caller_node_id {
+        return Err("Cannot change your own role".to_string());
+    }
+
+    // Cannot change the owner's role
+    if target_node_id == owner_id {
         return Err("Cannot change the owner's role".to_string());
+    }
+
+    let target_role = members.iter().find(|m| m.node_id == target_node_id).map(|m| m.role.clone());
+
+    // Manager restrictions
+    if !is_owner {
+        // Manager cannot promote to Manager or Owner
+        if matches!(new_role, MemberRole::Owner | MemberRole::Manager) {
+            return Err("Only the owner can promote to manager".to_string());
+        }
+        // Manager cannot change another manager's role
+        if matches!(target_role, Some(MemberRole::Manager)) {
+            return Err("Managers cannot change another manager's role".to_string());
+        }
+    }
+
+    // Owner cannot set someone to Owner (single owner constraint)
+    if matches!(new_role, MemberRole::Owner) {
+        return Err("Cannot assign the owner role".to_string());
     }
 
     let member = members

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -9,6 +9,7 @@ use tauri::State;
 #[serde(rename_all = "lowercase")]
 pub enum MemberRole {
     Owner,
+    Manager,
     #[default]
     #[serde(alias = "member")]
     Editor,
@@ -95,7 +96,7 @@ pub fn validate_node_id(node_id: &str) -> Result<(), String> {
 
 /// Check if a role can manage members (add/remove/edit)
 pub fn can_manage_members(role: &MemberRole) -> bool {
-    matches!(role, MemberRole::Owner | MemberRole::Editor)
+    matches!(role, MemberRole::Owner | MemberRole::Manager)
 }
 
 /// Find a member's role in a manifest by node_id
@@ -109,13 +110,13 @@ pub fn find_member_role(manifest: &TeamManifest, node_id: &str) -> Option<Member
 
 // --- Unified Tauri Commands ---
 
-/// Helper: check that caller has Owner or Editor role by looking up their NodeId in the manifest.
+/// Helper: check that caller has Owner or Manager role by looking up their NodeId in the manifest.
 /// Returns Err if they lack the required role.
 async fn require_manager_role(manifest: &TeamManifest, caller_node_id: &str) -> Result<(), String> {
     let role = find_member_role(manifest, caller_node_id)
         .ok_or_else(|| "Your device is not in the team manifest".to_string())?;
     if !can_manage_members(&role) {
-        return Err("Insufficient permissions: Owner or Editor role required".to_string());
+        return Err("Insufficient permissions: Owner or Manager role required".to_string());
     }
     Ok(())
 }

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -270,7 +270,7 @@ pub async fn unified_team_add_member(
                 let caller_node_id = manager.node_id().to_string();
                 require_manager_role(m, &caller_node_id).await?;
             } else if !can_manage_members(&manager.role()) {
-                return Err("Insufficient permissions: Owner or Editor role required".to_string());
+                return Err("Insufficient permissions: Owner or Manager role required".to_string());
             }
             manager.add_member(member).await
         }


### PR DESCRIPTION
## Summary
- Add Manager role variant to MemberRole enum with corresponding permission logic across P2P, OSS, and unified command layers
- Update frontend UI (TeamMemberList, AddMemberInput) with manager role support
- Add reconnect method and UI for configured-but-disconnected team state
- Fix fallback to UUID device ID when P2P node not yet started
- Add pagination to version history file list

## Test plan
- [ ] Verify manager role can be assigned to team members
- [ ] Verify manager permissions work correctly across P2P, OSS, and unified commands
- [ ] Test reconnect flow when team is configured but disconnected
- [ ] Test version history pagination with large file lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)