### PR TITLE
feat: support .gitignore in P2P and OSS/S3 sync

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -99,6 +99,7 @@ futures-lite = "2"
 axum = "0.7"
 tower-http = { version = "0.6", features = ["cors"] }
 gethostname = "1.1.0"
+ignore = "0.4"
 
 # ClawHub skill registry
 zip = "8"

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -667,6 +667,27 @@ impl OssSyncManager {
         Ok(())
     }
 
+    /// Build a gitignore matcher that layers rules from the team root
+    /// `.gitignore` (parent of `dir`) and the doc-type subdir `.gitignore`.
+    fn build_gitignore(dir: &Path) -> ignore::gitignore::Gitignore {
+        let mut builder = ignore::gitignore::GitignoreBuilder::new(dir);
+        // Team root .gitignore (one level up, e.g. teamclaw-team/.gitignore)
+        if let Some(parent) = dir.parent() {
+            let root_gi = parent.join(".gitignore");
+            if root_gi.exists() {
+                let _ = builder.add(root_gi);
+            }
+        }
+        // Subdir .gitignore (e.g. teamclaw-team/skills/.gitignore)
+        let sub_gi = dir.join(".gitignore");
+        if sub_gi.exists() {
+            let _ = builder.add(sub_gi);
+        }
+        builder.build().unwrap_or_else(|_| {
+            ignore::gitignore::GitignoreBuilder::new(dir).build().unwrap()
+        })
+    }
+
     fn scan_local_files(dir: &Path) -> Result<HashMap<String, Vec<u8>>, String> {
         let mut result = HashMap::new();
 
@@ -674,9 +695,12 @@ impl OssSyncManager {
             return Ok(result);
         }
 
+        let gitignore = Self::build_gitignore(dir);
+
         fn walk(
             base: &Path,
             current: &Path,
+            gitignore: &ignore::gitignore::Gitignore,
             result: &mut HashMap<String, Vec<u8>>,
         ) -> Result<(), String> {
             let entries = std::fs::read_dir(current)
@@ -688,14 +712,22 @@ impl OssSyncManager {
                 let name = entry.file_name();
                 let name_str = name.to_string_lossy();
 
-                // Skip hidden files/dirs
-                if name_str.starts_with('.') {
+                // Skip hidden files/dirs (but allow .gitignore)
+                if name_str.starts_with('.') && name_str != ".gitignore" {
                     continue;
                 }
 
                 if path.is_dir() {
-                    walk(base, &path, result)?;
+                    // Check gitignore for directories
+                    if gitignore.matched(&path, true).is_ignore() {
+                        continue;
+                    }
+                    walk(base, &path, gitignore, result)?;
                 } else {
+                    // Check gitignore for files
+                    if gitignore.matched(&path, false).is_ignore() {
+                        continue;
+                    }
                     // Skip files exceeding the size limit
                     if let Ok(meta) = path.metadata() {
                         if meta.len() > MAX_SYNC_FILE_SIZE {
@@ -729,7 +761,7 @@ impl OssSyncManager {
             Ok(())
         }
 
-        walk(dir, dir, &mut result)?;
+        walk(dir, dir, &gitignore, &mut result)?;
         Ok(result)
     }
 
@@ -745,10 +777,13 @@ impl OssSyncManager {
             return Ok(result);
         }
 
+        let gitignore = Self::build_gitignore(dir);
+
         fn walk_incremental(
             base: &Path,
             current: &Path,
             since: std::time::SystemTime,
+            gitignore: &ignore::gitignore::Gitignore,
             result: &mut HashMap<String, Vec<u8>>,
         ) -> Result<(), String> {
             let entries = std::fs::read_dir(current)
@@ -760,13 +795,20 @@ impl OssSyncManager {
                 let name = entry.file_name();
                 let name_str = name.to_string_lossy();
 
-                if name_str.starts_with('.') {
+                // Skip hidden files/dirs (but allow .gitignore)
+                if name_str.starts_with('.') && name_str != ".gitignore" {
                     continue;
                 }
 
                 if path.is_dir() {
-                    walk_incremental(base, &path, since, result)?;
+                    if gitignore.matched(&path, true).is_ignore() {
+                        continue;
+                    }
+                    walk_incremental(base, &path, since, gitignore, result)?;
                 } else {
+                    if gitignore.matched(&path, false).is_ignore() {
+                        continue;
+                    }
                     // Skip files exceeding the size limit
                     let meta = path.metadata().ok();
                     if let Some(ref m) = meta {
@@ -806,7 +848,7 @@ impl OssSyncManager {
             Ok(())
         }
 
-        walk_incremental(dir, dir, since, &mut result)?;
+        walk_incremental(dir, dir, since, &gitignore, &mut result)?;
         Ok(result)
     }
 

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -504,10 +504,37 @@ fn collect_files(base: &Path, dir: &Path) -> Vec<(String, Vec<u8>)> {
     if !dir.exists() {
         return files;
     }
+
+    // Build gitignore matcher from .gitignore files in the team directory tree
+    let gitignore = {
+        let mut builder = ignore::gitignore::GitignoreBuilder::new(dir);
+        let root_gi = dir.join(".gitignore");
+        if root_gi.exists() {
+            let _ = builder.add(root_gi);
+        }
+        // Also check subdirectories for .gitignore files
+        for subdir in &["skills", "knowledge"] {
+            let sub_gi = dir.join(subdir).join(".gitignore");
+            if sub_gi.exists() {
+                let _ = builder.add(&sub_gi);
+            }
+        }
+        builder.build().unwrap_or_else(|_| {
+            ignore::gitignore::GitignoreBuilder::new(dir).build().unwrap()
+        })
+    };
+
     'outer: for entry in walkdir::WalkDir::new(dir)
         .into_iter()
         .filter_map(|e| e.ok())
     {
+        let path = entry.path();
+
+        // Apply gitignore rules
+        if gitignore.matched(path, entry.file_type().is_dir()).is_ignore() {
+            continue;
+        }
+
         if entry.file_type().is_file() {
             // Skip files larger than MAX_SYNC_FILE_SIZE to avoid memory spikes
             if let Ok(meta) = entry.metadata() {
@@ -515,7 +542,7 @@ fn collect_files(base: &Path, dir: &Path) -> Vec<(String, Vec<u8>)> {
                     eprintln!(
                         "[P2P] Skipping large file ({} MB): {}",
                         meta.len() / (1024 * 1024),
-                        entry.path().display()
+                        path.display()
                     );
                     continue;
                 }
@@ -527,8 +554,8 @@ fn collect_files(base: &Path, dir: &Path) -> Vec<(String, Vec<u8>)> {
                     break 'outer;
                 }
             }
-            if let Ok(content) = std::fs::read(entry.path()) {
-                if let Ok(rel) = entry.path().strip_prefix(base) {
+            if let Ok(content) = std::fs::read(path) {
+                if let Ok(rel) = path.strip_prefix(base) {
                     total_size += content.len() as u64;
                     files.push((rel.to_string_lossy().to_string(), content));
                 }


### PR DESCRIPTION
## Summary
- Add `.gitignore` support to all sync file scanners (OSS `scan_local_files`, `scan_local_files_incremental`, P2P `collect_files`)
- Hierarchical rules: team root `.gitignore` + subdir `.gitignore` (e.g. `skills/.gitignore`)
- `.gitignore` files themselves are synced across nodes (dotfile exception)
- Uses `ignore` crate (ripgrep's gitignore implementation)
- Existing synced files are not retroactively removed

## Test plan
- [ ] Create `teamclaw-team/.gitignore` with a pattern (e.g. `*.log`), verify matching files are not synced
- [ ] Create `teamclaw-team/skills/.gitignore` with additional patterns, verify subdir rules layer on top
- [ ] Verify `.gitignore` file itself gets synced to other nodes
- [ ] Verify already-synced files remain untouched when new ignore rules are added

🤖 Generated with [Claude Code](https://claude.com/claude-code)