### PR TITLE
fix(sidecar): use selective XDG isolation to preserve tool credentials

### DIFF
--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -503,9 +503,15 @@ pub async fn start_opencode_inner(
 
     // Build sidecar command, also injecting secrets as process env vars (backup)
     //
-    // XDG isolation: redirect all OpenCode data/config/state/cache directories
-    // into <workspace>/.opencode/ so each workspace is fully self-contained
-    // and independent of any system-installed OpenCode.
+    // Selective XDG isolation: only redirect DATA and STATE directories into
+    // <workspace>/.opencode/ to isolate OpenCode's database and session state.
+    // CONFIG and CACHE are left at system defaults so that child processes
+    // spawned by OpenCode's bash tool (gh, git, ssh, etc.) can still find
+    // their credentials and configuration.
+    //
+    // OPENCODE_CONFIG_DIR is set so that "global" skills installed under the
+    // workspace-local config path are still discoverable by OpenCode without
+    // overriding XDG_CONFIG_HOME (which would break gh, git, etc.).
     let xdg_base = std::path::PathBuf::from(&workspace_path).join(".opencode");
     let mut sidecar_command = app
         .shell()
@@ -514,9 +520,8 @@ pub async fn start_opencode_inner(
         .args(["serve", "--port", &port_str])
         .current_dir(&workspace_path)
         .env("XDG_DATA_HOME", xdg_base.join("data").to_string_lossy().as_ref())
-        .env("XDG_CONFIG_HOME", xdg_base.join("config").to_string_lossy().as_ref())
         .env("XDG_STATE_HOME", xdg_base.join("state").to_string_lossy().as_ref())
-        .env("XDG_CACHE_HOME", xdg_base.join("cache").to_string_lossy().as_ref());
+        .env("OPENCODE_CONFIG_DIR", xdg_base.join("config").join("opencode").to_string_lossy().as_ref());
     // Inject device identity as environment variables
     if let Ok(device_id) = super::oss_commands::get_or_create_fallback_device_id() {
         sidecar_command = sidecar_command.env("device_id", &device_id);


### PR DESCRIPTION
## Summary

- Replace full XDG directory overrides with selective isolation when spawning the OpenCode sidecar
- Only `XDG_DATA_HOME` and `XDG_STATE_HOME` are overridden (to isolate OpenCode's database and session state per workspace)
- `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` are no longer overridden, so child processes spawned by OpenCode's bash tool (`gh`, `git`, `ssh`, etc.) can find their credentials and configuration at the default system paths
- `OPENCODE_CONFIG_DIR` is set to the workspace-local config path so that "global" skills remain discoverable

## Context

Previously all four XDG directories were redirected into `<workspace>/.opencode/`, which isolated OpenCode data but also broke authentication for tools like `gh` (which stores auth in `$XDG_CONFIG_HOME/gh/hosts.yml`). This change narrows the isolation to only what OpenCode needs (data + state), leaving config and cache at system defaults.

## Test plan

- [ ] Start the app and verify OpenCode sidecar starts successfully
- [ ] Run `gh auth status` inside OpenCode's bash tool and confirm it shows logged-in status
- [ ] Run `git push` to a remote requiring auth and confirm credentials work
- [ ] Verify OpenCode's session data is still isolated under `<workspace>/.opencode/data/`
- [ ] Install a "global" skill and verify it's discoverable by OpenCode


Made with [Cursor](https://cursor.com)