### PR TITLE
feat: system env vars with single keychain blob storage

### DIFF
--- a/docs/superpowers/plans/2026-04-03-system-env-vars.md
+++ b/docs/superpowers/plans/2026-04-03-system-env-vars.md
@@ -1,0 +1,898 @@
+# System Env Vars Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-key keychain storage with a single blob, add a system env var category with a Rust registry, and remove fragile team-mode auth logic that depends on webview/localStorage.
+
+**Architecture:** All personal env vars are merged into one JSON blob stored under a single keychain entry (`teamclaw.env`), eliminating per-key macOS authorization prompts. A static `SYSTEM_ENV_VARS` registry in Rust auto-generates default values (like `tc_api_key`) at startup if missing. The team provider reads its API key via `${tc_api_key}` resolved from the blob at opencode startup — no more HTTP `connectProvider` calls after startup.
+
+**Tech Stack:** Rust (keyring crate, serde_json), TypeScript/React (Zustand, Tauri invoke), Tauri v2
+
+---
+
+## File Map
+
+| File | What changes |
+|------|--------------|
+| `src-tauri/src/commands/env_vars.rs` | Blob storage helpers, migration, `category` field, system registry, `ensure_system_env_vars`, delete guard |
+| `src-tauri/src/commands/opencode.rs` | Call `ensure_system_env_vars` pre-startup; update `read_keyring_secrets` for blob format |
+| `packages/app/src/lib/opencode/config.ts` | Add `apiKey?: string` to `CustomProviderConfig`; write it into `options` |
+| `packages/app/src/stores/team-mode.ts` | Remove `connectProvider`, `reAuthTeamProvider`, `teamApiKey`, `setTeamApiKey`, `getPersistedTeamApiKey`; pass `apiKey: '${tc_api_key}'` to provider config |
+| `packages/app/src/components/chat/ChatPanel.tsx` | Remove `reAuthTeamProvider` and `teamApiKey` from init logic; simplify `configKey` |
+| `packages/app/src/stores/env-vars.ts` | Add `category?: 'system' \| null` to `EnvVarEntry` |
+| `packages/app/src/components/settings/EnvVarsSection.tsx` | System badge + lock icon; hide delete for system entries |
+
+---
+
+### Task 1: Blob storage helpers in env_vars.rs
+
+**Files:**
+- Modify: `src-tauri/src/commands/env_vars.rs`
+
+The keychain entry `teamclaw.env` (service) / `teamclaw` (username) stores a JSON object as its password. All reads and writes go through two helpers: `read_env_blob` and `write_env_blob`. Migration from old per-key entries runs inside `read_env_blob` on first call.
+
+- [ ] **Step 1: Add blob constants and helpers**
+
+In `src-tauri/src/commands/env_vars.rs`, replace the existing `KEYRING_SERVICE_PREFIX` constant and `keyring_service` function with:
+
+```rust
+/// Single keychain entry that stores all env vars as a JSON blob.
+pub(crate) const KEYRING_SERVICE: &str = concat!(env!("APP_SHORT_NAME"), ".env");
+
+/// Legacy per-key service prefix (used only for migration detection).
+const LEGACY_SERVICE_PREFIX: &str = concat!(env!("APP_SHORT_NAME"), ".env");
+
+/// Read the entire env var blob from keychain.
+/// Returns an empty map if the entry doesn't exist yet.
+/// On first call after migration: detects old per-key entries and consolidates them.
+pub(crate) fn read_env_blob(workspace_path: &str) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, "teamclaw")
+        .map_err(|e| format!("Failed to open keychain entry: {}", e))?;
+
+    match entry.get_password() {
+        Ok(json_str) => {
+            let val: serde_json::Value = serde_json::from_str(&json_str)
+                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+            match val {
+                serde_json::Value::Object(map) => Ok(map),
+                _ => Ok(serde_json::Map::new()),
+            }
+        }
+        Err(keyring::Error::NoEntry) => {
+            // First launch: attempt migration from legacy per-key format
+            let migrated = migrate_legacy_keyring(workspace_path);
+            if !migrated.is_empty() {
+                println!("[EnvVars] Migrated {} legacy keychain entries to blob", migrated.len());
+                write_env_blob(&migrated)?;
+            }
+            Ok(migrated)
+        }
+        Err(e) => Err(format!("Failed to read keychain blob: {}", e)),
+    }
+}
+
+/// Write the entire env var blob to keychain.
+pub(crate) fn write_env_blob(map: &serde_json::Map<String, serde_json::Value>) -> Result<(), String> {
+    let json_str = serde_json::to_string(map)
+        .map_err(|e| format!("Failed to serialize env blob: {}", e))?;
+    let entry = keyring::Entry::new(KEYRING_SERVICE, "teamclaw")
+        .map_err(|e| format!("Failed to open keychain entry: {}", e))?;
+    entry.set_password(&json_str)
+        .map_err(|e| format!("Failed to write keychain blob: {}", e))
+}
+
+/// Read old per-key keychain entries and consolidate into a map.
+/// Deletes old entries after reading.
+fn migrate_legacy_keyring(workspace_path: &str) -> serde_json::Map<String, serde_json::Value> {
+    let path = format!("{}/{}/teamclaw.json", workspace_path, super::TEAMCLAW_DIR);
+    let json: serde_json::Value = match std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+    {
+        Some(v) => v,
+        None => return serde_json::Map::new(),
+    };
+
+    let entries = match json.get("envVars").and_then(|v| v.as_array()) {
+        Some(arr) => arr.clone(),
+        None => return serde_json::Map::new(),
+    };
+
+    let mut map = serde_json::Map::new();
+    for entry_val in &entries {
+        let key = match entry_val.get("key").and_then(|k| k.as_str()) {
+            Some(k) => k,
+            None => continue,
+        };
+        // Legacy service name was "teamclaw.env.<KEY>"
+        let legacy_service = format!("{}.{}", LEGACY_SERVICE_PREFIX, key);
+        if let Ok(e) = keyring::Entry::new(&legacy_service, "teamclaw") {
+            if let Ok(value) = e.get_password() {
+                map.insert(key.to_string(), serde_json::Value::String(value));
+                // Delete old entry
+                let _ = e.delete_credential();
+            }
+        }
+    }
+    map
+}
+```
+
+- [ ] **Step 2: Verify the project builds**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw && cargo build -p teamclaw 2>&1 | tail -20
+```
+Expected: no errors (warnings ok).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw
+git add src-tauri/src/commands/env_vars.rs
+git commit -m "feat(env-vars): add single-blob keychain helpers with legacy migration"
+```
+
+---
+
+### Task 2: Update CRUD commands to use blob
+
+**Files:**
+- Modify: `src-tauri/src/commands/env_vars.rs`
+
+Replace the per-key keyring calls in `env_var_set`, `env_var_get`, and `env_var_delete` with blob read-modify-write.
+
+- [ ] **Step 1: Update `env_var_set`**
+
+Replace the existing `env_var_set` function body:
+
+```rust
+#[tauri::command]
+pub async fn env_var_set(
+    state: State<'_, OpenCodeState>,
+    key: String,
+    value: String,
+    description: Option<String>,
+) -> Result<(), String> {
+    let workspace_path = get_workspace_path(&state)?;
+
+    // Read-modify-write the blob
+    let mut blob = tokio::task::spawn_blocking({
+        let wp = workspace_path.clone();
+        move || read_env_blob(&wp)
+    }).await.map_err(|e| e.to_string())??;
+
+    blob.insert(key.clone(), serde_json::Value::String(value));
+    write_env_blob(&blob)?;
+
+    // Update index in teamclaw.json (metadata only, no value)
+    let mut json = read_teamclaw_json(&workspace_path)?;
+    let mut entries = get_env_vars_from_json(&json);
+
+    if let Some(existing) = entries.iter_mut().find(|e| e.key == key) {
+        existing.description = description;
+    } else {
+        entries.push(EnvVarEntry { key, description, category: None });
+    }
+
+    set_env_vars_in_json(&mut json, &entries);
+    write_teamclaw_json(&workspace_path, &json)
+}
+```
+
+- [ ] **Step 2: Update `env_var_get`**
+
+Replace the existing `env_var_get` function body:
+
+```rust
+#[tauri::command]
+pub async fn env_var_get(
+    state: State<'_, OpenCodeState>,
+    key: String,
+) -> Result<String, String> {
+    let workspace_path = get_workspace_path(&state)?;
+    let blob = tokio::task::spawn_blocking({
+        let wp = workspace_path.clone();
+        move || read_env_blob(&wp)
+    }).await.map_err(|e| e.to_string())??;
+
+    blob.get(&key)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("Key '{}' not found", key))
+}
+```
+
+Note: `env_var_get` previously took only `key: String`. It now also takes `state` — update the Tauri command registration in `src-tauri/src/lib.rs` if the signature is listed there (it's registered as `env_var_get` — check it takes the new parameter automatically via Tauri's state injection).
+
+- [ ] **Step 3: Update `env_var_delete`**
+
+Replace the existing `env_var_delete` function body:
+
+```rust
+#[tauri::command]
+pub async fn env_var_delete(state: State<'_, OpenCodeState>, key: String) -> Result<(), String> {
+    let workspace_path = get_workspace_path(&state)?;
+
+    // Check category in index — system vars cannot be deleted
+    let json = read_teamclaw_json(&workspace_path)?;
+    let entries = get_env_vars_from_json(&json);
+    if let Some(entry) = entries.iter().find(|e| e.key == key) {
+        if entry.category.as_deref() == Some("system") {
+            return Err(format!("System variable '{}' cannot be deleted", key));
+        }
+    }
+
+    // Read-modify-write the blob
+    let mut blob = tokio::task::spawn_blocking({
+        let wp = workspace_path.clone();
+        move || read_env_blob(&wp)
+    }).await.map_err(|e| e.to_string())??;
+
+    blob.remove(&key);
+    write_env_blob(&blob)?;
+
+    // Remove from teamclaw.json index
+    let mut json = read_teamclaw_json(&workspace_path)?;
+    let mut entries = get_env_vars_from_json(&json);
+    entries.retain(|e| e.key != key);
+    set_env_vars_in_json(&mut json, &entries);
+    write_teamclaw_json(&workspace_path, &json)
+}
+```
+
+- [ ] **Step 4: Build to verify**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw && cargo build -p teamclaw 2>&1 | tail -20
+```
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw
+git add src-tauri/src/commands/env_vars.rs
+git commit -m "feat(env-vars): migrate CRUD commands to single blob keychain storage"
+```
+
+---
+
+### Task 3: Add `category` field, system registry, `ensure_system_env_vars`
+
+**Files:**
+- Modify: `src-tauri/src/commands/env_vars.rs`
+
+- [ ] **Step 1: Add `category` field to `EnvVarEntry`**
+
+Replace the existing `EnvVarEntry` struct:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvVarEntry {
+    pub key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,  // "system" | None
+}
+```
+
+- [ ] **Step 2: Add system registry and `ensure_system_env_vars`**
+
+Add these after the `KEYRING_SERVICE` constant at the top of `env_vars.rs`:
+
+```rust
+/// Context available to system env var default generators.
+pub(crate) struct SystemEnvVarContext {
+    pub device_id: String,
+}
+
+/// Definition of a system-managed env var.
+pub(crate) struct SystemEnvVarDef {
+    pub key: &'static str,
+    pub description: &'static str,
+    pub default_fn: fn(&SystemEnvVarContext) -> Option<String>,
+}
+
+/// Registry of all system env vars.
+/// To add a new one: append an entry here — nothing else changes.
+pub(crate) const SYSTEM_ENV_VARS: &[SystemEnvVarDef] = &[
+    SystemEnvVarDef {
+        key: "tc_api_key",
+        description: "Team LLM API Key",
+        default_fn: |ctx| {
+            if ctx.device_id.is_empty() {
+                return None;
+            }
+            let id = &ctx.device_id;
+            Some(format!("sk-tc-{}", &id[..id.len().min(40)]))
+        },
+    },
+];
+
+/// Ensure all system env vars exist in keychain and in the teamclaw.json index.
+/// If a key is missing from the blob, its default value is generated and written.
+/// If a key already has a value (user customized), it is left unchanged.
+/// This must be called on a blocking thread (keychain I/O).
+pub(crate) fn ensure_system_env_vars(
+    workspace_path: &str,
+    device_id: &str,
+) -> Result<(), String> {
+    let ctx = SystemEnvVarContext { device_id: device_id.to_string() };
+    let mut blob = read_env_blob(workspace_path)?;
+    let mut json = read_teamclaw_json(workspace_path)?;
+    let mut entries = get_env_vars_from_json(&json);
+    let mut blob_changed = false;
+    let mut index_changed = false;
+
+    for def in SYSTEM_ENV_VARS {
+        // Generate default value if not already set
+        if !blob.contains_key(def.key) || blob[def.key].as_str().map_or(true, |v| v.is_empty()) {
+            if let Some(default_value) = (def.default_fn)(&ctx) {
+                blob.insert(def.key.to_string(), serde_json::Value::String(default_value));
+                blob_changed = true;
+                println!("[EnvVars] Generated default value for system var: {}", def.key);
+            }
+        }
+
+        // Ensure index entry exists with category: "system"
+        if let Some(existing) = entries.iter_mut().find(|e| e.key == def.key) {
+            if existing.category.as_deref() != Some("system") {
+                existing.category = Some("system".to_string());
+                index_changed = true;
+            }
+        } else {
+            entries.push(EnvVarEntry {
+                key: def.key.to_string(),
+                description: Some(def.description.to_string()),
+                category: Some("system".to_string()),
+            });
+            index_changed = true;
+        }
+    }
+
+    if blob_changed {
+        write_env_blob(&blob)?;
+    }
+    if index_changed {
+        set_env_vars_in_json(&mut json, &entries);
+        write_teamclaw_json(workspace_path, &json)?;
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw && cargo build -p teamclaw 2>&1 | tail -20
+```
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw
+git add src-tauri/src/commands/env_vars.rs
+git commit -m "feat(env-vars): add system env var registry and ensure_system_env_vars"
+```
+
+---
+
+### Task 4: Update opencode.rs startup
+
+**Files:**
+- Modify: `src-tauri/src/commands/opencode.rs`
+
+Two changes: (1) call `ensure_system_env_vars` before the parallel block, (2) update `read_keyring_secrets` to use the blob.
+
+- [ ] **Step 1: Update `read_keyring_secrets` to use blob**
+
+Replace the entire `read_keyring_secrets` function (lines ~1080–1121):
+
+```rust
+/// Read all personal env vars from the single keychain blob.
+/// Returns `(secrets, failed)` — failed is empty on success, or contains
+/// a diagnostic message if the blob itself cannot be read.
+fn read_keyring_secrets(workspace_path: &str) -> (Vec<(String, String)>, Vec<String>) {
+    match super::env_vars::read_env_blob(workspace_path) {
+        Ok(blob) => {
+            let secrets: Vec<(String, String)> = blob
+                .into_iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k, s.to_string())))
+                .collect();
+            println!("[OpenCode] Loaded {} secrets from keychain blob", secrets.len());
+            (secrets, Vec::new())
+        }
+        Err(e) => {
+            eprintln!("[OpenCode] Failed to read keychain blob: {}", e);
+            (Vec::new(), vec!["__blob__".to_string()])
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Call `ensure_system_env_vars` before the parallel startup block**
+
+In `start_opencode`, find the line:
+```rust
+let ws_for_config = workspace_path.clone();
+```
+
+Insert before it:
+
+```rust
+// Ensure system env vars exist (e.g. tc_api_key) before reading keyring secrets.
+// This runs synchronously — it's fast (one keychain read + optional write).
+{
+    let device_id = super::oss_commands::get_or_create_fallback_device_id()
+        .unwrap_or_default();
+    let ws = workspace_path.clone();
+    let did = device_id.clone();
+    if let Err(e) = tokio::task::spawn_blocking(move || {
+        super::env_vars::ensure_system_env_vars(&ws, &did)
+    }).await.map_err(|e| e.to_string()).and_then(|r| r.map_err(|e| e)) {
+        eprintln!("[OpenCode] Warning: failed to ensure system env vars: {}", e);
+    }
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw && cargo build -p teamclaw 2>&1 | tail -20
+```
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw
+git add src-tauri/src/commands/opencode.rs
+git commit -m "feat(opencode): inject system env vars and use blob for keychain secrets at startup"
+```
+
+---
+
+### Task 5: Add apiKey support to provider config
+
+**Files:**
+- Modify: `packages/app/src/lib/opencode/config.ts`
+
+The team provider config in opencode.json needs `options.apiKey: "${tc_api_key}"` so `resolve_config_secret_refs` substitutes the real value before opencode starts.
+
+- [ ] **Step 1: Add `apiKey` to `CustomProviderConfig`**
+
+In `config.ts`, replace:
+
+```typescript
+export interface CustomProviderConfig {
+  name: string
+  baseURL: string
+  models: CustomModelConfig[]
+}
+```
+
+With:
+
+```typescript
+export interface CustomProviderConfig {
+  name: string
+  baseURL: string
+  apiKey?: string
+  models: CustomModelConfig[]
+}
+```
+
+- [ ] **Step 2: Write `apiKey` into the provider options in `addCustomProviderToConfig`**
+
+In `addCustomProviderToConfig`, replace:
+
+```typescript
+  openCodeConfig.provider[providerId] = {
+    npm: '@ai-sdk/openai-compatible',
+    name: config.name,
+    options: {
+      baseURL: config.baseURL,
+    },
+    models: modelsObj,
+  }
+```
+
+With:
+
+```typescript
+  const providerOptions: { baseURL: string; apiKey?: string } = {
+    baseURL: config.baseURL,
+  }
+  if (config.apiKey) {
+    providerOptions.apiKey = config.apiKey
+  }
+
+  openCodeConfig.provider[providerId] = {
+    npm: '@ai-sdk/openai-compatible',
+    name: config.name,
+    options: providerOptions,
+    models: modelsObj,
+  }
+```
+
+Also apply the same pattern in `updateCustomProviderConfig` (same block, around line 238):
+
+```typescript
+  const providerOptions: { baseURL: string; apiKey?: string } = {
+    baseURL: config.baseURL,
+  }
+  if (config.apiKey) {
+    providerOptions.apiKey = config.apiKey
+  }
+
+  openCodeConfig.provider[providerId] = {
+    npm: '@ai-sdk/openai-compatible',
+    name: config.name,
+    options: providerOptions,
+    models: modelsObj,
+  }
+```
+
+- [ ] **Step 3: Build to verify TypeScript compiles**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw/packages/app && npx tsc --noEmit 2>&1 | head -30
+```
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw
+git add packages/app/src/lib/opencode/config.ts
+git commit -m "feat(config): add optional apiKey to CustomProviderConfig"
+```
+
+---
+
+### Task 6: Clean up team-mode.ts
+
+**Files:**
+- Modify: `packages/app/src/stores/team-mode.ts`
+
+Remove all localStorage-based auth logic. Pass `apiKey: '${tc_api_key}'` when writing the team provider config so opencode resolves it from the env var blob at startup.
+
+- [ ] **Step 1: Remove `TEAM_API_KEY_STORAGE` import and `getPersistedTeamApiKey`**
+
+Remove the import line:
+```typescript
+import { appShortName, buildConfig, TEAM_API_KEY_STORAGE_KEY } from '@/lib/build-config'
+```
+Replace with (drop `TEAM_API_KEY_STORAGE_KEY` and `appShortName` if no longer used):
+```typescript
+import { buildConfig } from '@/lib/build-config'
+```
+
+Remove the constants and function:
+```typescript
+const TEAM_API_KEY_STORAGE = TEAM_API_KEY_STORAGE_KEY
+
+export function getPersistedTeamApiKey(): string | null {
+  try {
+    return localStorage.getItem(TEAM_API_KEY_STORAGE) || null
+  } catch {
+    return null
+  }
+}
+```
+
+- [ ] **Step 2: Remove `teamApiKey` and `setTeamApiKey` from state interface and store**
+
+In `TeamModeState` interface, remove:
+```typescript
+  teamApiKey: string | null
+  setTeamApiKey: (key: string | null, workspacePath?: string) => Promise<void>
+  reAuthTeamProvider: () => Promise<void>
+```
+
+In the store initial state, remove:
+```typescript
+  teamApiKey: getPersistedTeamApiKey(),
+```
+
+Remove the `getDeviceNodeId` function and `defaultTeamLiteLlmApiKey` function entirely:
+```typescript
+async function getDeviceNodeId(): Promise<string> { ... }
+function defaultTeamLiteLlmApiKey(nodeId: string): string { ... }
+```
+
+Remove the `setTeamApiKey` action and `reAuthTeamProvider` action from the store.
+
+- [ ] **Step 3: Simplify `applyTeamModelToOpenCode`**
+
+Replace the section that determines the API key and calls `connectProvider`:
+
+```typescript
+      // Determine API key: user override or FC default virtual key (not raw nodeId)
+      const nodeId = await getDeviceNodeId()
+      const apiKey = teamApiKey || defaultTeamLiteLlmApiKey(nodeId)
+      if (!apiKey) {
+        console.error('[TeamMode] No API key and no device NodeId available')
+        return
+      }
+      ...
+      // Connect provider with key
+      await providerStore.connectProvider(TEAM_PROVIDER_ID, apiKey)
+```
+
+With nothing — `connectProvider` is no longer called. Also, in `addCustomProviderToConfig`, pass the `${tc_api_key}` placeholder:
+
+```typescript
+      await addCustomProviderToConfig(workspacePath, {
+        name: 'Team',
+        baseURL: teamModelConfig.baseUrl,
+        apiKey: '${tc_api_key}',
+        models: [modelConfig],
+      })
+```
+
+Remove the entire "wait for provider to register before selecting model" block that calls `client.getProviders()` in a loop checking for `TEAM_PROVIDER_ID` — this was needed because `connectProvider` was async and opencode needed time to register. Now the provider config is written before startup, so opencode already knows about it.
+
+- [ ] **Step 4: Remove `_appliedConfigKey` logic that included `teamApiKey`**
+
+The `configKey` fingerprint in `applyTeamModelToOpenCode` was:
+```typescript
+const configKey = `${teamModelConfig.baseUrl}|${teamModelConfig.model}|${teamApiKey || ''}`
+```
+Remove the `|${teamApiKey || ''}` part:
+```typescript
+const configKey = `${teamModelConfig.baseUrl}|${teamModelConfig.model}`
+```
+
+- [ ] **Step 5: Build TypeScript**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw/packages/app && npx tsc --noEmit 2>&1 | head -30
+```
+Expected: no errors. Fix any remaining references to `teamApiKey`, `setTeamApiKey`, `reAuthTeamProvider`, or `getPersistedTeamApiKey`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw
+git add packages/app/src/stores/team-mode.ts
+git commit -m "feat(team-mode): remove localStorage auth, use \${tc_api_key} env var for team provider"
+```
+
+---
+
+### Task 7: Simplify ChatPanel.tsx init logic
+
+**Files:**
+- Modify: `packages/app/src/components/chat/ChatPanel.tsx`
+
+- [ ] **Step 1: Remove `reAuthTeamProvider` and `teamApiKey` from init effect**
+
+Find the effect at line ~214. Currently:
+
+```typescript
+    const { loadTeamConfig, applyTeamModelToOpenCode, reAuthTeamProvider } = useTeamModeStore.getState();
+    loadTeamConfig(workspacePath).then(async () => {
+      if (useTeamModeStore.getState().teamMode) {
+        const { _appliedConfigKey, teamModelConfig, teamApiKey } = useTeamModeStore.getState();
+        const configKey = teamModelConfig
+          ? `${teamModelConfig.baseUrl}|${teamModelConfig.model}|${teamApiKey || ''}`
+          : null;
+        if (configKey && configKey === _appliedConfigKey) {
+          await reAuthTeamProvider();
+        } else {
+          await applyTeamModelToOpenCode(workspacePath);
+        }
+      }
+      initProviderStore();
+    });
+```
+
+Replace with:
+
+```typescript
+    const { loadTeamConfig, applyTeamModelToOpenCode } = useTeamModeStore.getState();
+    loadTeamConfig(workspacePath).then(async () => {
+      if (useTeamModeStore.getState().teamMode) {
+        const { _appliedConfigKey, teamModelConfig } = useTeamModeStore.getState();
+        const configKey = teamModelConfig
+          ? `${teamModelConfig.baseUrl}|${teamModelConfig.model}`
+          : null;
+        if (configKey !== _appliedConfigKey) {
+          await applyTeamModelToOpenCode(workspacePath);
+        }
+      }
+      initProviderStore();
+    });
+```
+
+When `configKey === _appliedConfigKey` (sidecar restarted externally), we no longer need to re-auth — the env var is already in the sidecar process environment.
+
+- [ ] **Step 2: Build TypeScript**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw/packages/app && npx tsc --noEmit 2>&1 | head -30
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw
+git add packages/app/src/components/chat/ChatPanel.tsx
+git commit -m "fix(chat): remove reAuthTeamProvider, simplify team mode init after sidebar refresh"
+```
+
+---
+
+### Task 8: TypeScript types + EnvVarsSection UI
+
+**Files:**
+- Modify: `packages/app/src/stores/env-vars.ts`
+- Modify: `packages/app/src/components/settings/EnvVarsSection.tsx`
+
+- [ ] **Step 1: Add `category` to `EnvVarEntry` in the store**
+
+In `packages/app/src/stores/env-vars.ts`, replace:
+
+```typescript
+export interface EnvVarEntry {
+  key: string
+  description?: string
+}
+```
+
+With:
+
+```typescript
+export interface EnvVarEntry {
+  key: string
+  description?: string
+  category?: 'system' | null
+}
+```
+
+- [ ] **Step 2: Update `UnifiedEntry` in EnvVarsSection to carry `category`**
+
+In `EnvVarsSection.tsx`, replace the `UnifiedEntry` type:
+
+```typescript
+type UnifiedEntry =
+  | { scope: 'personal'; key: string; description?: string; category?: 'system' | null; dirty?: boolean }
+  | { scope: 'team'; key: string; description: string; category: string; createdBy: string; updatedBy: string; updatedAt: string; dirty?: boolean }
+```
+
+Update the `personal` array in `unifiedEntries` useMemo to carry `category`:
+
+```typescript
+    const personal: UnifiedEntry[] = envVars.map((e) => ({
+      scope: 'personal' as const,
+      key: e.key,
+      description: e.description,
+      category: e.category,
+      dirty: dirtyKeys.has(e.key),
+    }))
+```
+
+- [ ] **Step 3: Add `Lock` to lucide-react imports and update `EnvVarRow`**
+
+Add `Lock` to the import from `lucide-react` at the top of `EnvVarsSection.tsx`:
+
+```typescript
+import { KeyRound, Plus, Eye, EyeOff, Pencil, Trash2, ShieldCheck, AlertCircle, RefreshCw, Loader2, Users, User, Lock } from 'lucide-react'
+```
+
+In `EnvVarRow`, update the badge rendering section. Currently `isPersonal ? <Personal badge> : <Team badge>`. Add a system check before:
+
+```typescript
+  const isSystem = entry.scope === 'personal' && (entry as any).category === 'system'
+  const isPersonal = entry.scope === 'personal'
+```
+
+Replace the badge JSX block:
+
+```typescript
+          {isSystem ? (
+            <span className="inline-flex items-center gap-1 text-xs text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-950/40 px-1.5 py-0.5 rounded">
+              <Lock className="h-3 w-3" />
+              {t('settings.envVars.scopeSystem', 'System')}
+            </span>
+          ) : isPersonal ? (
+            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+              <User className="h-3 w-3" />
+              {t('settings.envVars.scopePersonal', 'Personal')}
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/40 px-1.5 py-0.5 rounded">
+              <Users className="h-3 w-3" />
+              {t('settings.envVars.scopeTeam', 'Team')}
+            </span>
+          )}
+```
+
+- [ ] **Step 4: Hide delete for system entries**
+
+In `canDeleteEntry`:
+
+```typescript
+  const canDeleteEntry = (entry: UnifiedEntry): boolean => {
+    if (entry.scope === 'personal' && (entry as any).category === 'system') return false
+    if (entry.scope === 'personal') return true
+    if (myRole === 'owner') return true
+    if (entry.scope === 'team' && entry.createdBy === currentNodeId) return true
+    return false
+  }
+```
+
+- [ ] **Step 5: Sort system entries first**
+
+In the `unifiedEntries` useMemo, after building `personal` and `team` arrays, sort before returning:
+
+```typescript
+    const all = [...team, ...personal]
+    // System entries first, then alphabetical within each group
+    all.sort((a, b) => {
+      const aIsSystem = a.scope === 'personal' && (a as any).category === 'system'
+      const bIsSystem = b.scope === 'personal' && (b as any).category === 'system'
+      if (aIsSystem && !bIsSystem) return -1
+      if (!aIsSystem && bIsSystem) return 1
+      return a.key.localeCompare(b.key)
+    })
+    return all
+```
+
+- [ ] **Step 6: Build TypeScript**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw/packages/app && npx tsc --noEmit 2>&1 | head -30
+```
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw
+git add packages/app/src/stores/env-vars.ts packages/app/src/components/settings/EnvVarsSection.tsx
+git commit -m "feat(ui): show system env vars with lock badge, hide delete button"
+```
+
+---
+
+### Task 9: Full build verification
+
+- [ ] **Step 1: Rust build**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw && cargo build -p teamclaw 2>&1 | tail -20
+```
+Expected: compiles clean.
+
+- [ ] **Step 2: TypeScript build**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw/packages/app && npx tsc --noEmit 2>&1 | head -30
+```
+Expected: no errors.
+
+- [ ] **Step 3: Check no remaining references to removed symbols**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw && grep -r "reAuthTeamProvider\|teamApiKey\|TEAM_API_KEY_STORAGE\|getPersistedTeamApiKey\|setTeamApiKey" packages/app/src --include="*.ts" --include="*.tsx" -l
+```
+Expected: no files listed (all references removed).
+
+```bash
+grep -r "keyring_service\b" src-tauri/src --include="*.rs"
+```
+Expected: only appears inside `env_vars.rs` if at all — no callers outside that file using the old per-key service function (it was renamed/replaced).
+
+- [ ] **Step 4: Final commit**
+
+```bash
+cd /Volumes/openbeta/workspace/teamclaw
+git commit --allow-empty -m "chore: system env vars feature complete"
+```

--- a/docs/superpowers/specs/2026-04-03-system-env-vars-design.md
+++ b/docs/superpowers/specs/2026-04-03-system-env-vars-design.md
@@ -1,0 +1,187 @@
+# System Environment Variables
+
+**Date:** 2026-04-03
+**Status:** Draft
+
+## Problem
+
+Team mode API key (`tc_api_key`) is currently injected via `connectProvider` HTTP call **after** opencode starts, and stored in browser localStorage. This causes:
+
+1. **Sidebar refresh loses auth** — `reAuthTeamProvider` silently fails when localStorage clears or `getDeviceNodeId()` isn't ready
+2. **Race conditions** — auth depends on webview lifecycle, not sidecar lifecycle
+3. **No extensibility** — future default env vars (e.g. gateway tokens) would need similar fragile plumbing
+4. **macOS Keychain prompt spam** — each env var is a separate keychain entry with its own authorization prompt
+
+## Solution
+
+Two improvements combined:
+
+1. **Single keychain blob** — all personal env vars stored in one keychain entry as a JSON object, so macOS only prompts once per session
+2. **System env var category** — a built-in registry of env vars with default value generators, injected at startup, not deletable by users
+
+## Design
+
+### 1. Single Keychain Blob Storage
+
+**Before:** each key gets its own keychain entry
+```
+teamclaw.env.MY_KEY_1   → "val1"
+teamclaw.env.MY_KEY_2   → "val2"
+teamclaw.env.tc_api_key → "sk-tc-..."
+```
+Result: N keys = up to N macOS authorization prompts per session.
+
+**After:** all personal env vars stored in one keychain entry
+```
+teamclaw.env  →  {"MY_KEY_1": "val1", "MY_KEY_2": "val2", "tc_api_key": "sk-tc-..."}
+```
+Result: 1 prompt per session regardless of how many keys exist.
+
+**CRUD operations** become read-modify-write on the JSON blob:
+- `env_var_set(key, value)` → read blob → set `blob[key] = value` → write blob
+- `env_var_get(key)` → read blob → return `blob[key]`
+- `env_var_delete(key)` → read blob → remove `blob[key]` → write blob
+
+The keychain service name changes from `teamclaw.env.<KEY>` to just `teamclaw.env`.
+
+**Migration:** on first access, detect old-format entries (`teamclaw.env.<KEY>`) in teamclaw.json, read them all into the new blob, delete the old entries. One-time, transparent.
+
+### 2. Data Model Changes
+
+#### Rust: `EnvVarEntry` gains `category`
+
+```rust
+// env_vars.rs
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvVarEntry {
+    pub key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,  // "system" | null (user)
+}
+```
+
+Stored in `teamclaw.json` (index only, no values):
+```json
+{
+  "envVars": [
+    { "key": "tc_api_key", "description": "Team LLM API Key", "category": "system" },
+    { "key": "MY_CUSTOM_KEY", "description": "user added" }
+  ]
+}
+```
+
+Values live only in the single keychain blob — not in teamclaw.json.
+
+#### TypeScript: same addition
+
+```typescript
+export interface EnvVarEntry {
+  key: string
+  description?: string
+  category?: 'system' | null
+}
+```
+
+### 3. System Env Var Registry (Rust)
+
+A static list in `env_vars.rs` defining all system env vars and their default value generators:
+
+```rust
+struct SystemEnvVarDef {
+    key: &'static str,
+    description: &'static str,
+    default_fn: fn(&SystemEnvVarContext) -> Option<String>,
+}
+
+struct SystemEnvVarContext {
+    device_id: String,  // from get_or_create_fallback_device_id()
+}
+
+const SYSTEM_ENV_VARS: &[SystemEnvVarDef] = &[
+    SystemEnvVarDef {
+        key: "tc_api_key",
+        description: "Team LLM API Key",
+        default_fn: |ctx| {
+            if ctx.device_id.is_empty() { return None; }
+            Some(format!("sk-tc-{}", &ctx.device_id[..ctx.device_id.len().min(40)]))
+        },
+    },
+    // Future: add more system env vars here
+];
+```
+
+### 4. Startup Flow (`opencode.rs`)
+
+```
+opencode startup
+  ↓
+ensure_system_env_vars(workspace_path, device_id)
+  → read blob from keychain (single prompt if needed)
+  → for each SYSTEM_ENV_VARS entry:
+      → if blob[key] missing or empty → generate default → write blob + update teamclaw.json index
+      → if present → skip (user may have customized)
+  ↓
+read_keyring_secrets(workspace_path)   ← unchanged, reads same blob, expands to Vec<(String, String)>
+  ↓
+inject all as process env vars → spawn opencode sidecar
+```
+
+`read_keyring_secrets` changes: instead of reading N separate keychain entries, it reads the single `teamclaw.env` blob and expands it into `Vec<(String, String)>`.
+
+### 5. Team Mode Changes (`team-mode.ts`)
+
+**Remove:**
+- `connectProvider(TEAM_PROVIDER_ID, apiKey)` call in `applyTeamModelToOpenCode`
+- `reAuthTeamProvider()` function entirely
+- `teamApiKey` state field and localStorage persistence
+- `setTeamApiKey` action
+- `getPersistedTeamApiKey()` helper
+
+**Keep:**
+- `addCustomProviderToConfig` — still writes team provider with baseURL to opencode.json
+- Team provider config references `${tc_api_key}` which gets resolved at startup
+
+**Provider config in opencode.json** after this change:
+```json
+{
+  "providers": {
+    "team": {
+      "baseURL": "https://...",
+      "apiKey": "${tc_api_key}",
+      "models": [...]
+    }
+  }
+}
+```
+`resolve_config_secret_refs` resolves `${tc_api_key}` from the blob at startup — same mechanism as MCP env vars.
+
+### 6. `env_var_delete` Guard
+
+Refuse to delete keys with `category: "system"` in teamclaw.json index. Returns an error like `"System variable 'tc_api_key' cannot be deleted"`.
+
+### 7. UI Changes (`EnvVarsSection.tsx`)
+
+- System entries show a **lock icon** + "System" badge instead of Personal/Team badge
+- **Delete button hidden** for system entries
+- **Edit button enabled** — user can override the default value
+- System entries sorted first in the list
+- UI behavior is otherwise identical — still shows one row per key
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src-tauri/src/commands/env_vars.rs` | Single blob storage, migration, `category` field, system registry, `ensure_system_env_vars()`, delete guard |
+| `src-tauri/src/commands/opencode.rs` | Call `ensure_system_env_vars` before keyring read; update `read_keyring_secrets` for blob format |
+| `packages/app/src/stores/env-vars.ts` | Add `category` to `EnvVarEntry` |
+| `packages/app/src/stores/team-mode.ts` | Remove `connectProvider`, `reAuthTeamProvider`, `teamApiKey` |
+| `packages/app/src/components/settings/EnvVarsSection.tsx` | System badge, hide delete for system entries |
+| `packages/app/src/components/chat/ChatPanel.tsx` | Remove `reAuthTeamProvider` call |
+
+## Out of Scope
+
+- Changes to shared/team secrets — only personal env vars get the `system` category and blob storage
+- opencode provider config format changes beyond adding `${tc_api_key}` reference
+- Migration of existing users' localStorage `teamApiKey` — system env var auto-generates the same default value so no action needed

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -220,20 +220,12 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
       return;
     }
 
-    const { loadTeamConfig, applyTeamModelToOpenCode, reAuthTeamProvider } = useTeamModeStore.getState();
+    const { loadTeamConfig, applyTeamModelToOpenCode } = useTeamModeStore.getState();
     loadTeamConfig(workspacePath).then(async () => {
       if (useTeamModeStore.getState().teamMode) {
         // Team mode: apply team config (restarts OpenCode), then init providers.
-        // If config was already applied (sidecar restarted externally), just re-auth.
-        const { _appliedConfigKey, teamModelConfig, teamApiKey } = useTeamModeStore.getState();
-        const configKey = teamModelConfig
-          ? `${teamModelConfig.baseUrl}|${teamModelConfig.model}|${teamApiKey || ''}`
-          : null;
-        if (configKey && configKey === _appliedConfigKey) {
-          await reAuthTeamProvider();
-        } else {
-          await applyTeamModelToOpenCode(workspacePath);
-        }
+        // applyTeamModelToOpenCode is idempotent — skips if config key unchanged.
+        await applyTeamModelToOpenCode(workspacePath);
       }
       initProviderStore();
     });

--- a/packages/app/src/components/chat/__tests__/ChatPanel.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ChatPanel.test.tsx
@@ -151,7 +151,6 @@ vi.mock('@/stores/provider', () => {
 const teamModeState = {
   teamMode: false,
   teamModelConfig: null,
-  teamApiKey: null,
   loadTeamConfig: vi.fn(() => Promise.resolve()),
   applyTeamModelToOpenCode: vi.fn(() => Promise.resolve()),
 };

--- a/packages/app/src/components/settings/EnvVarsSection.tsx
+++ b/packages/app/src/components/settings/EnvVarsSection.tsx
@@ -431,7 +431,7 @@ export const EnvVarsSection = React.memo(function EnvVarsSection() {
       dirty: dirtyKeys.has(s.keyId) || hasSyncDirty,
     }))
     const all = [...team, ...personal]
-    // System entries first, then team, then personal alphabetical
+    // System entries first; all other entries sorted alphabetically by key
     all.sort((a, b) => {
       const aIsSystem = a.scope === 'personal' && a.category === 'system'
       const bIsSystem = b.scope === 'personal' && b.category === 'system'
@@ -461,7 +461,7 @@ export const EnvVarsSection = React.memo(function EnvVarsSection() {
     setDeleteTarget(null)
   }
 
-  // Check if current user can delete a given entry
+  // Note: the Rust env_var_delete command also enforces the system-var guard server-side.
   const canDeleteEntry = (entry: UnifiedEntry): boolean => {
     if (entry.scope === 'personal' && entry.category === 'system') return false
     if (entry.scope === 'personal') return true

--- a/packages/app/src/components/settings/EnvVarsSection.tsx
+++ b/packages/app/src/components/settings/EnvVarsSection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { KeyRound, Plus, Eye, EyeOff, Pencil, Trash2, ShieldCheck, AlertCircle, RefreshCw, Loader2, Users, User } from 'lucide-react'
+import { KeyRound, Plus, Eye, EyeOff, Pencil, Trash2, ShieldCheck, AlertCircle, RefreshCw, Loader2, Users, User, Lock } from 'lucide-react'
 import { invoke } from '@tauri-apps/api/core'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -24,7 +24,7 @@ import { listen } from '@tauri-apps/api/event'
 // ─── Unified type for the combined list ─────────────────────────────────
 
 type UnifiedEntry =
-  | { scope: 'personal'; key: string; description?: string; dirty?: boolean }
+  | { scope: 'personal'; key: string; description?: string; category?: 'system' | null; dirty?: boolean }
   | { scope: 'team'; key: string; description: string; category: string; createdBy: string; updatedBy: string; updatedAt: string; dirty?: boolean }
 
 // ─── Add / Edit Dialog ──────────────────────────────────────────────────
@@ -259,6 +259,7 @@ function EnvVarRow({ entry, canDelete, onEdit, onDelete }: EnvVarRowProps) {
   const [loading, setLoading] = React.useState(false)
   const { getEnvVarValue } = useEnvVarsStore()
 
+  const isSystem = entry.scope === 'personal' && entry.category === 'system'
   const isPersonal = entry.scope === 'personal'
 
   const handleReveal = async () => {
@@ -291,7 +292,12 @@ function EnvVarRow({ entry, canDelete, onEdit, onDelete }: EnvVarRowProps) {
           <code className="text-sm font-mono font-medium bg-muted px-2 py-0.5 rounded">
             {entry.key}
           </code>
-          {isPersonal ? (
+          {isSystem ? (
+            <span className="inline-flex items-center gap-1 text-xs text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-950/40 px-1.5 py-0.5 rounded">
+              <Lock className="h-3 w-3" />
+              {t('settings.envVars.scopeSystem', 'System')}
+            </span>
+          ) : isPersonal ? (
             <span className="inline-flex items-center gap-1 text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
               <User className="h-3 w-3" />
               {t('settings.envVars.scopePersonal', 'Personal')}
@@ -411,6 +417,7 @@ export const EnvVarsSection = React.memo(function EnvVarsSection() {
       scope: 'personal' as const,
       key: e.key,
       description: e.description,
+      category: e.category,
       dirty: dirtyKeys.has(e.key),
     }))
     const team: UnifiedEntry[] = secrets.map((s) => ({
@@ -423,7 +430,16 @@ export const EnvVarsSection = React.memo(function EnvVarsSection() {
       updatedAt: s.updatedAt,
       dirty: dirtyKeys.has(s.keyId) || hasSyncDirty,
     }))
-    return [...team, ...personal]
+    const all = [...team, ...personal]
+    // System entries first, then team, then personal alphabetical
+    all.sort((a, b) => {
+      const aIsSystem = a.scope === 'personal' && a.category === 'system'
+      const bIsSystem = b.scope === 'personal' && b.category === 'system'
+      if (aIsSystem && !bIsSystem) return -1
+      if (!aIsSystem && bIsSystem) return 1
+      return a.key.localeCompare(b.key)
+    })
+    return all
   }, [envVars, secrets, dirtyKeys, hasSyncDirty])
 
   const handleSave = async (key: string, value: string, description: string, shared: boolean) => {
@@ -447,6 +463,7 @@ export const EnvVarsSection = React.memo(function EnvVarsSection() {
 
   // Check if current user can delete a given entry
   const canDeleteEntry = (entry: UnifiedEntry): boolean => {
+    if (entry.scope === 'personal' && entry.category === 'system') return false
     if (entry.scope === 'personal') return true
     if (myRole === 'owner') return true
     if (entry.scope === 'team' && entry.createdBy === currentNodeId) return true

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -12,13 +12,11 @@ import { invoke } from '@tauri-apps/api/core'
 import type { DeviceInfo } from '@/lib/git/types'
 import { useTeamModeStore } from '@/stores/team-mode'
 import { useProviderStore } from '@/stores/provider'
-import { useTranslation } from 'react-i18next'
 import {
   Cloud,
   Copy,
   Eye,
   EyeOff,
-  KeyRound,
   Loader2,
   LogOut,
   RefreshCw,
@@ -49,75 +47,6 @@ function SettingCard({
   )
 }
 
-function TeamApiKeyCard() {
-  const { t } = useTranslation()
-  const teamApiKey = useTeamModeStore((s) => s.teamApiKey)
-  const setTeamApiKey = useTeamModeStore((s) => s.setTeamApiKey)
-  const workspacePath = useWorkspaceStore((s) => s.workspacePath)
-  const [keyInput, setKeyInput] = useState(teamApiKey || '')
-  const [saving, setSaving] = useState(false)
-
-  const handleSave = async () => {
-    setSaving(true)
-    try {
-      const key = keyInput.trim() || null
-      await setTeamApiKey(key, workspacePath || undefined)
-      if (!key) setKeyInput('')
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  return (
-    <SettingCard title={t('settings.team.apiKeyTitle', 'API Key')} icon={KeyRound}>
-      <div className="space-y-3">
-        <p className="text-xs text-muted-foreground">
-          {t(
-            'settings.team.apiKeyDesc',
-            'Optional. Leave empty to use the team LiteLLM key auto-provisioned for this device (sk-tc- + first 40 chars of device ID).',
-          )}
-        </p>
-        <div className="flex items-center gap-2">
-          <Input
-            type="password"
-            value={keyInput}
-            onChange={(e) => setKeyInput(e.target.value)}
-            placeholder={t(
-              'settings.team.apiKeyPlaceholder',
-              'Override key, or leave empty for auto sk-tc- key',
-            )}
-            className="h-9 text-sm bg-background/50"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') handleSave()
-            }}
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            className="shrink-0 h-9"
-            disabled={saving}
-            onClick={handleSave}
-          >
-            {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : t('common.save', 'Save')}
-          </Button>
-          {teamApiKey && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="shrink-0 h-9 text-xs text-muted-foreground"
-              onClick={async () => {
-                setKeyInput('')
-                await setTeamApiKey(null, workspacePath || undefined)
-              }}
-            >
-              {t('settings.team.useDeviceId', 'Use auto key')}
-            </Button>
-          )}
-        </div>
-      </div>
-    </SettingCard>
-  )
-}
 
 const DOC_TYPES = [
   { key: 'skills', label: 'Skills' },
@@ -534,8 +463,6 @@ export function TeamOSSConfig() {
               )}
             </div>
           </SettingCard>
-
-          <TeamApiKeyCard />
 
           <SettingCard title="团队成员">
             <TeamMemberList />

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -14,7 +14,6 @@ import {
   Unlink,
   CheckCircle2,
   Clock,
-  KeyRound,
   Copy,
   Share2,
 } from 'lucide-react'
@@ -63,78 +62,6 @@ function SettingCard({ children, className }: { children: React.ReactNode; class
     )}>
       {children}
     </div>
-  )
-}
-
-// ─── Team API Key Card ──────────────────────────────────────────────────────
-
-function TeamApiKeyCard() {
-  const { t } = useTranslation()
-  const teamApiKey = useTeamModeStore((s) => s.teamApiKey)
-  const setTeamApiKey = useTeamModeStore((s) => s.setTeamApiKey)
-  const workspacePath = useWorkspaceStore((s) => s.workspacePath)
-  const [keyInput, setKeyInput] = React.useState(teamApiKey || '')
-  const [saving, setSaving] = React.useState(false)
-
-  const handleSave = async () => {
-    setSaving(true)
-    try {
-      const key = keyInput.trim() || null
-      await setTeamApiKey(key, workspacePath || undefined)
-      if (!key) setKeyInput('')
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  return (
-    <SettingCard>
-      <div className="space-y-3">
-        <div className="flex items-center gap-3">
-          <div className="h-9 w-9 rounded-lg flex items-center justify-center bg-amber-100 dark:bg-amber-900/30">
-            <KeyRound className="h-5 w-5 text-amber-700 dark:text-amber-400" />
-          </div>
-          <div>
-            <p className="text-sm font-medium">{t('settings.team.apiKeyTitle', 'API Key')}</p>
-            <p className="text-xs text-muted-foreground">{t('settings.team.apiKeyDesc', 'Optional. Leave empty to use the team LiteLLM key auto-provisioned for this device (sk-tc- + first 40 chars of device ID).')}</p>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Input
-            type="password"
-            value={keyInput}
-            onChange={(e) => setKeyInput(e.target.value)}
-            placeholder={t('settings.team.apiKeyPlaceholder', 'Override key, or leave empty for auto sk-tc- key')}
-            className="h-9 text-sm"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') handleSave()
-            }}
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            className="shrink-0 h-9"
-            disabled={saving}
-            onClick={handleSave}
-          >
-            {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : t('common.save', 'Save')}
-          </Button>
-          {teamApiKey && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="shrink-0 h-9 text-xs text-muted-foreground"
-              onClick={async () => {
-                setKeyInput('')
-                await setTeamApiKey(null, workspacePath || undefined)
-              }}
-            >
-              {t('settings.team.useDeviceId', 'Use auto key')}
-            </Button>
-          )}
-        </div>
-      </div>
-    </SettingCard>
   )
 }
 
@@ -937,8 +864,6 @@ export function TeamP2PConfig() {
             </div>
           </SettingCard>
 
-          {/* API Key Override */}
-          <TeamApiKeyCard />
         </>
       )}
 

--- a/packages/app/src/components/settings/team/__tests__/TeamP2PConfig.test.tsx
+++ b/packages/app/src/components/settings/team/__tests__/TeamP2PConfig.test.tsx
@@ -7,8 +7,6 @@ const mockInvoke = vi.hoisted(() => vi.fn())
 const teamModeStoreMocks = vi.hoisted(() => ({
   setState: vi.fn(),
   clearTeamMode: vi.fn(),
-  teamApiKey: null,
-  setTeamApiKey: vi.fn(),
   myRole: null as 'owner' | 'editor' | 'viewer' | null,
 }))
 
@@ -154,8 +152,6 @@ import { TeamP2PConfig } from '../TeamP2PConfig'
 describe('TeamP2PConfig', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    teamModeStoreMocks.teamApiKey = null
-    teamModeStoreMocks.setTeamApiKey = vi.fn()
     teamModeStoreMocks.clearTeamMode = vi.fn()
     teamModeStoreMocks.myRole = null
     p2pEngineStoreMocks.initialized = true

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -111,4 +111,3 @@ export const TEAMCLAW_DIR = `.${appShortName}`
 export const TEAM_REPO_DIR = `${appShortName}-team`
 export const CONFIG_FILE_NAME = `${appShortName}.json`
 export const TEAM_SYNCED_EVENT = `${appShortName}-team-synced`
-export const TEAM_API_KEY_STORAGE_KEY = `${appShortName}-team-api-key`

--- a/packages/app/src/lib/opencode/config.ts
+++ b/packages/app/src/lib/opencode/config.ts
@@ -21,6 +21,7 @@ export interface CustomModelConfig {
 export interface CustomProviderConfig {
   name: string
   baseURL: string
+  apiKey?: string
   models: CustomModelConfig[]
 }
 
@@ -142,12 +143,17 @@ export async function addCustomProviderToConfig(
     modelsObj[model.modelId] = modelEntry
   }
 
+  const providerOptions: { baseURL: string; apiKey?: string } = {
+    baseURL: config.baseURL,
+  }
+  if (config.apiKey) {
+    providerOptions.apiKey = config.apiKey
+  }
+
   openCodeConfig.provider[providerId] = {
     npm: '@ai-sdk/openai-compatible',
     name: config.name,
-    options: {
-      baseURL: config.baseURL,
-    },
+    options: providerOptions,
     models: modelsObj,
   }
 
@@ -235,12 +241,17 @@ export async function updateCustomProviderConfig(
     modelsObj[model.modelId] = modelEntry
   }
 
+  const providerOptions: { baseURL: string; apiKey?: string } = {
+    baseURL: config.baseURL,
+  }
+  if (config.apiKey) {
+    providerOptions.apiKey = config.apiKey
+  }
+
   openCodeConfig.provider[providerId] = {
     npm: '@ai-sdk/openai-compatible',
     name: config.name,
-    options: {
-      baseURL: config.baseURL,
-    },
+    options: providerOptions,
     models: modelsObj,
   }
 

--- a/packages/app/src/stores/env-vars.ts
+++ b/packages/app/src/stores/env-vars.ts
@@ -6,6 +6,7 @@ import { withAsync } from '@/lib/store-utils'
 export interface EnvVarEntry {
   key: string
   description?: string
+  category?: 'system' | null
 }
 
 interface EnvVarsState {

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -5,20 +5,10 @@ import {
 } from '@/lib/opencode/config'
 import { useProviderStore } from './provider'
 import { isTauri } from '@/lib/utils'
-import { appShortName, buildConfig, TEAM_API_KEY_STORAGE_KEY } from '@/lib/build-config'
+import { appShortName, buildConfig } from '@/lib/build-config'
 
 
 const TEAM_PROVIDER_ID = 'team'
-const TEAM_API_KEY_STORAGE = TEAM_API_KEY_STORAGE_KEY
-
-/** Read team API key override from persistent storage (global, not per-workspace). */
-export function getPersistedTeamApiKey(): string | null {
-  try {
-    return localStorage.getItem(TEAM_API_KEY_STORAGE) || null
-  } catch {
-    return null
-  }
-}
 
 export interface TeamModelConfig {
   baseUrl: string
@@ -30,7 +20,6 @@ interface TeamModeState {
   teamMode: boolean
   teamModeType: string | null // "p2p" | "oss" | "webdav" | "git" — from teamclaw.json
   teamModelConfig: TeamModelConfig | null
-  teamApiKey: string | null // user-overridden key, null = sk-tc-{nodeId[:40]} (FC add-member)
   _appliedConfigKey: string | null // fingerprint of last applied config to avoid redundant apply
   devUnlocked: boolean // hidden dev mode: unlocks model selector & hidden dirs in team mode
   myRole: 'owner' | 'editor' | 'viewer' | null
@@ -40,8 +29,6 @@ interface TeamModeState {
 
   loadTeamConfig: (workspacePath: string) => Promise<void>
   applyTeamModelToOpenCode: (workspacePath: string, force?: boolean) => Promise<void>
-  setTeamApiKey: (key: string | null, workspacePath?: string) => Promise<void>
-  reAuthTeamProvider: () => Promise<void>
   clearTeamMode: (workspacePath?: string) => Promise<void>
   setDevUnlocked: (unlocked: boolean) => void
   loadP2pFileSyncStatus: () => Promise<void>
@@ -64,18 +51,6 @@ async function fetchTeamStatus(): Promise<TeamStatusResponse | null> {
   }
 }
 
-async function getDeviceNodeId(): Promise<string> {
-  if (!isTauri()) return ''
-  const { invoke } = await import('@tauri-apps/api/core')
-  const info = await invoke<{ nodeId: string }>('get_device_info')
-  return info.nodeId
-}
-
-/** Default LiteLLM virtual key for this device; must match fc/index.mjs `/ai/add-member`. */
-function defaultTeamLiteLlmApiKey(nodeId: string): string {
-  if (!nodeId) return ''
-  return `sk-tc-${nodeId.slice(0, 40)}`
-}
 
 export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   teamMode: false,
@@ -86,7 +61,6 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   myRole: null,
   p2pConnected: false,
   p2pConfigured: false,
-  teamApiKey: getPersistedTeamApiKey(),
   p2pFileSyncStatusMap: {},
 
   loadTeamConfig: async (_workspacePath: string) => {
@@ -135,11 +109,11 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   },
 
   applyTeamModelToOpenCode: async (workspacePath: string, force?: boolean) => {
-    const { teamModelConfig, teamApiKey, _appliedConfigKey } = get()
+    const { teamModelConfig, _appliedConfigKey } = get()
     if (!teamModelConfig) return
 
     // Build a fingerprint of the current config to avoid redundant restarts/toasts
-    const configKey = `${teamModelConfig.baseUrl}|${teamModelConfig.model}|${teamApiKey || ''}`
+    const configKey = `${teamModelConfig.baseUrl}|${teamModelConfig.model}`
     if (!force && configKey === _appliedConfigKey) return
     set({ _appliedConfigKey: configKey })
 
@@ -175,16 +149,9 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
       await addCustomProviderToConfig(workspacePath, {
         name: 'Team',
         baseURL: teamModelConfig.baseUrl,
+        apiKey: '${tc_api_key}',
         models: [modelConfig],
       })
-
-      // Determine API key: user override or FC default virtual key (not raw nodeId)
-      const nodeId = await getDeviceNodeId()
-      const apiKey = teamApiKey || defaultTeamLiteLlmApiKey(nodeId)
-      if (!apiKey) {
-        console.error('[TeamMode] No API key and no device NodeId available')
-        return
-      }
 
       // Restart OpenCode to pick up new provider config
       if (isTauri()) {
@@ -202,52 +169,12 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
         await new Promise((r) => setTimeout(r, 500))
       }
 
-      // Connect provider with key
-      await providerStore.connectProvider(TEAM_PROVIDER_ID, apiKey)
-
-      // Wait for OpenCode to register the team custom provider before selecting the model.
-      // PATCH /config returns 500 if the model isn't in OpenCode's provider registry yet.
-      const { getOpenCodeClient } = await import('@/lib/opencode/client')
-      let client: ReturnType<typeof getOpenCodeClient> | null = null
-      try { client = getOpenCodeClient() } catch { /* not initialized */ }
-      if (client) {
-        const deadline = Date.now() + 10_000
-        while (Date.now() < deadline) {
-          try {
-            const result = await client.getProviders()
-            if (result.connected.includes(TEAM_PROVIDER_ID)) break
-          } catch { /* server still initializing */ }
-          await new Promise((r) => setTimeout(r, 500))
-        }
-      }
-
       await providerStore.selectModel(TEAM_PROVIDER_ID, teamModelConfig.model, teamModelConfig.modelName)
       await providerStore.refreshConfiguredProviders()
 
       console.log('[TeamMode] Applied team model config:', teamModelConfig)
     } catch (err) {
       console.error('[TeamMode] Failed to apply team model to OpenCode:', err)
-    }
-  },
-
-  setTeamApiKey: async (key: string | null, workspacePath?: string) => {
-    set({ teamApiKey: key })
-    try {
-      if (key) {
-        localStorage.setItem(TEAM_API_KEY_STORAGE, key)
-      } else {
-        localStorage.removeItem(TEAM_API_KEY_STORAGE)
-      }
-    } catch { /* ignore */ }
-
-    // Re-apply if in team mode
-    if (get().teamMode && workspacePath) {
-      const nodeId = await getDeviceNodeId()
-      const apiKey = key || defaultTeamLiteLlmApiKey(nodeId)
-      if (apiKey) {
-        const providerStore = useProviderStore.getState()
-        await providerStore.connectProvider(TEAM_PROVIDER_ID, apiKey)
-      }
     }
   },
 
@@ -274,33 +201,12 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
     }
   },
 
-  // Re-authenticate team provider without restarting sidecar.
-  // Call this after any OpenCode restart to restore auth state.
-  reAuthTeamProvider: async () => {
-    const { teamMode, teamModelConfig, teamApiKey } = get()
-    if (!teamMode || !teamModelConfig) return
-    try {
-      const nodeId = await getDeviceNodeId()
-      const apiKey = teamApiKey || defaultTeamLiteLlmApiKey(nodeId)
-      if (!apiKey) return
-      const providerStore = useProviderStore.getState()
-      await providerStore.connectProvider(TEAM_PROVIDER_ID, apiKey)
-      console.log('[TeamMode] Re-authenticated team provider after sidecar restart')
-    } catch (err) {
-      console.error('[TeamMode] Failed to re-authenticate team provider:', err)
-    }
-  },
-
   clearTeamMode: async (workspacePath?: string) => {
     // When LLM config is locked via build config, prevent exiting team mode
     if (buildConfig.team.lockLlmConfig) return
 
     // Set state immediately to trigger UI updates
     set({ teamMode: false, teamModeType: null, teamModelConfig: null, _appliedConfigKey: null, p2pFileSyncStatusMap: {} })
-
-    try {
-      localStorage.removeItem(TEAM_API_KEY_STORAGE)
-    } catch { /* ignore */ }
 
     // Remove team provider from opencode.json
     if (workspacePath) {

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -3,7 +3,7 @@ import { UNSUPPORTED_BINARY_EXTENSIONS } from "@/components/viewers/UnsupportedF
 import { isTauri } from '@/lib/utils'
 import { ensureGitignoreEntries } from '@/lib/gitignore-manager'
 import { appShortName, TEAMCLAW_DIR, TEAM_REPO_DIR } from '@/lib/build-config'
-import { getPersistedTeamApiKey, useTeamModeStore } from './team-mode'
+import { useTeamModeStore } from './team-mode'
 
 // Directories to hide from file tree (system directories)
 const HIDDEN_DIRECTORIES = new Set([TEAMCLAW_DIR, '.opencode'])
@@ -345,8 +345,6 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         teamMode: false,
         teamModeType: null,
         teamModelConfig: null,
-        // API key is stored globally in localStorage; do not clear on workspace load
-        teamApiKey: getPersistedTeamApiKey(),
         _appliedConfigKey: null,
         myRole: null,
         p2pConnected: false,
@@ -446,7 +444,6 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       useTeamModeStore.setState({
         teamMode: false,
         teamModelConfig: null,
-        teamApiKey: null,
         _appliedConfigKey: null,
         myRole: null,
       });

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -99,15 +99,15 @@ fn migrate_legacy_keyring(workspace_path: &str) -> serde_json::Map<String, serde
 }
 
 /// Context available to system env var default generators.
-pub(crate) struct SystemEnvVarContext {
-    pub device_id: String,
+struct SystemEnvVarContext {
+    device_id: String,
 }
 
 /// Definition of a system-managed env var.
-pub(crate) struct SystemEnvVarDef {
-    pub key: &'static str,
-    pub description: &'static str,
-    pub default_fn: fn(&SystemEnvVarContext) -> Option<String>,
+struct SystemEnvVarDef {
+    key: &'static str,
+    description: &'static str,
+    default_fn: fn(&SystemEnvVarContext) -> Option<String>,
 }
 
 /// Registry of all system env vars.
@@ -121,6 +121,7 @@ pub(crate) const SYSTEM_ENV_VARS: &[SystemEnvVarDef] = &[
                 return None;
             }
             let id = &ctx.device_id;
+            // 40 chars: matches the LiteLLM virtual key suffix length limit
             Some(format!("sk-tc-{}", &id[..id.len().min(40)]))
         },
     },
@@ -269,16 +270,18 @@ pub async fn env_var_get(
 pub async fn env_var_delete(state: State<'_, OpenCodeState>, key: String) -> Result<(), String> {
     let workspace_path = get_workspace_path(&state)?;
 
-    // Check category in index — system vars cannot be deleted
-    let json = read_teamclaw_json(&workspace_path)?;
-    let entries = get_env_vars_from_json(&json);
+    // Read index once — used for both the guard check and the removal below
+    let mut json = read_teamclaw_json(&workspace_path)?;
+    let mut entries = get_env_vars_from_json(&json);
+
+    // Check category — system vars cannot be deleted
     if let Some(entry) = entries.iter().find(|e| e.key == key) {
         if entry.category.as_deref() == Some("system") {
             return Err(format!("System variable '{}' cannot be deleted", key));
         }
     }
 
-    // Read-modify-write atomically on a blocking thread
+    // Read-modify-write blob atomically on a blocking thread
     let key_clone = key.clone();
     let wp = workspace_path.clone();
     tokio::task::spawn_blocking(move || -> Result<(), String> {
@@ -287,9 +290,7 @@ pub async fn env_var_delete(state: State<'_, OpenCodeState>, key: String) -> Res
         write_env_blob(&blob)
     }).await.map_err(|e| e.to_string())??;
 
-    // Remove from teamclaw.json index
-    let mut json = read_teamclaw_json(&workspace_path)?;
-    let mut entries = get_env_vars_from_json(&json);
+    // Remove from teamclaw.json index (reuse the already-read json)
     entries.retain(|e| e.key != key);
     set_env_vars_in_json(&mut json, &entries);
     write_teamclaw_json(&workspace_path, &json)
@@ -395,13 +396,23 @@ pub(crate) fn ensure_system_env_vars(
     let mut index_changed = false;
 
     for def in SYSTEM_ENV_VARS {
+        // Check if there's already a non-empty value in the blob
+        let has_value = blob.get(def.key).and_then(|v| v.as_str()).map_or(false, |v| !v.is_empty());
+
         // Generate default value if not already set
-        if !blob.contains_key(def.key) || blob[def.key].as_str().map_or(true, |v| v.is_empty()) {
+        if !has_value {
             if let Some(default_value) = (def.default_fn)(&ctx) {
                 blob.insert(def.key.to_string(), serde_json::Value::String(default_value));
                 blob_changed = true;
                 println!("[EnvVars] Generated default value for system var: {}", def.key);
             }
+        }
+
+        // Only register in index if the blob has a value (either pre-existing or just generated)
+        let blob_has_value_now = blob.get(def.key).and_then(|v| v.as_str()).map_or(false, |v| !v.is_empty());
+        if !blob_has_value_now {
+            // Skip index entry — no value available (e.g., device_id not ready)
+            continue;
         }
 
         // Ensure index entry exists with category: "system"

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -98,12 +98,42 @@ fn migrate_legacy_keyring(workspace_path: &str) -> serde_json::Map<String, serde
     map
 }
 
+/// Context available to system env var default generators.
+pub(crate) struct SystemEnvVarContext {
+    pub device_id: String,
+}
+
+/// Definition of a system-managed env var.
+pub(crate) struct SystemEnvVarDef {
+    pub key: &'static str,
+    pub description: &'static str,
+    pub default_fn: fn(&SystemEnvVarContext) -> Option<String>,
+}
+
+/// Registry of all system env vars.
+/// To add a new one: append an entry here — nothing else changes.
+pub(crate) const SYSTEM_ENV_VARS: &[SystemEnvVarDef] = &[
+    SystemEnvVarDef {
+        key: "tc_api_key",
+        description: "Team LLM API Key",
+        default_fn: |ctx| {
+            if ctx.device_id.is_empty() {
+                return None;
+            }
+            let id = &ctx.device_id;
+            Some(format!("sk-tc-{}", &id[..id.len().min(40)]))
+        },
+    },
+];
+
 /// A single environment variable entry (key + description, no value).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnvVarEntry {
     pub key: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,  // "system" | None
 }
 
 // ─── Internal helpers ───────────────────────────────────────────────────
@@ -209,7 +239,7 @@ pub async fn env_var_set(
     if let Some(existing) = entries.iter_mut().find(|e| e.key == key) {
         existing.description = description;
     } else {
-        entries.push(EnvVarEntry { key, description });
+        entries.push(EnvVarEntry { key, description, category: None });
     }
 
     set_env_vars_in_json(&mut json, &entries);
@@ -238,6 +268,15 @@ pub async fn env_var_get(
 #[tauri::command]
 pub async fn env_var_delete(state: State<'_, OpenCodeState>, key: String) -> Result<(), String> {
     let workspace_path = get_workspace_path(&state)?;
+
+    // Check category in index — system vars cannot be deleted
+    let json = read_teamclaw_json(&workspace_path)?;
+    let entries = get_env_vars_from_json(&json);
+    if let Some(entry) = entries.iter().find(|e| e.key == key) {
+        if entry.category.as_deref() == Some("system") {
+            return Err(format!("System variable '{}' cannot be deleted", key));
+        }
+    }
 
     // Read-modify-write atomically on a blocking thread
     let key_clone = key.clone();
@@ -338,4 +377,56 @@ pub async fn env_var_resolve(
     }
 
     Ok(result)
+}
+
+/// Ensure all system env vars exist in keychain blob and in the teamclaw.json index.
+/// If a key is missing from the blob, its default value is generated and written.
+/// If a key already has a value (user customized), it is left unchanged.
+/// This must be called on a blocking thread (keychain I/O).
+pub(crate) fn ensure_system_env_vars(
+    workspace_path: &str,
+    device_id: &str,
+) -> Result<(), String> {
+    let ctx = SystemEnvVarContext { device_id: device_id.to_string() };
+    let mut blob = read_env_blob(workspace_path)?;
+    let mut json = read_teamclaw_json(workspace_path)?;
+    let mut entries = get_env_vars_from_json(&json);
+    let mut blob_changed = false;
+    let mut index_changed = false;
+
+    for def in SYSTEM_ENV_VARS {
+        // Generate default value if not already set
+        if !blob.contains_key(def.key) || blob[def.key].as_str().map_or(true, |v| v.is_empty()) {
+            if let Some(default_value) = (def.default_fn)(&ctx) {
+                blob.insert(def.key.to_string(), serde_json::Value::String(default_value));
+                blob_changed = true;
+                println!("[EnvVars] Generated default value for system var: {}", def.key);
+            }
+        }
+
+        // Ensure index entry exists with category: "system"
+        if let Some(existing) = entries.iter_mut().find(|e| e.key == def.key) {
+            if existing.category.as_deref() != Some("system") {
+                existing.category = Some("system".to_string());
+                index_changed = true;
+            }
+        } else {
+            entries.push(EnvVarEntry {
+                key: def.key.to_string(),
+                description: Some(def.description.to_string()),
+                category: Some("system".to_string()),
+            });
+            index_changed = true;
+        }
+    }
+
+    if blob_changed {
+        write_env_blob(&blob)?;
+    }
+    if index_changed {
+        set_env_vars_in_json(&mut json, &entries);
+        write_teamclaw_json(workspace_path, &json)?;
+    }
+
+    Ok(())
 }

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -192,14 +192,15 @@ pub async fn env_var_set(
 ) -> Result<(), String> {
     let workspace_path = get_workspace_path(&state)?;
 
-    // Read-modify-write the blob
-    let mut blob = tokio::task::spawn_blocking({
-        let wp = workspace_path.clone();
-        move || read_env_blob(&wp)
+    // Read-modify-write atomically on a blocking thread
+    let key_clone = key.clone();
+    let value_clone = value.clone();
+    let wp = workspace_path.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let mut blob = read_env_blob(&wp)?;
+        blob.insert(key_clone, serde_json::Value::String(value_clone));
+        write_env_blob(&blob)
     }).await.map_err(|e| e.to_string())??;
-
-    blob.insert(key.clone(), serde_json::Value::String(value));
-    write_env_blob(&blob)?;
 
     // Update index in teamclaw.json (metadata only, no value)
     let mut json = read_teamclaw_json(&workspace_path)?;
@@ -238,14 +239,14 @@ pub async fn env_var_get(
 pub async fn env_var_delete(state: State<'_, OpenCodeState>, key: String) -> Result<(), String> {
     let workspace_path = get_workspace_path(&state)?;
 
-    // Read-modify-write the blob
-    let mut blob = tokio::task::spawn_blocking({
-        let wp = workspace_path.clone();
-        move || read_env_blob(&wp)
+    // Read-modify-write atomically on a blocking thread
+    let key_clone = key.clone();
+    let wp = workspace_path.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let mut blob = read_env_blob(&wp)?;
+        blob.remove(&key_clone);
+        write_env_blob(&blob)
     }).await.map_err(|e| e.to_string())??;
-
-    blob.remove(&key);
-    write_env_blob(&blob)?;
 
     // Remove from teamclaw.json index
     let mut json = read_teamclaw_json(&workspace_path)?;
@@ -296,7 +297,10 @@ pub async fn env_var_resolve(
         tokio::task::spawn_blocking(move || read_env_blob(&wp))
             .await
             .map_err(|e| e.to_string())?
-            .unwrap_or_default()
+            .unwrap_or_else(|e| {
+                eprintln!("[EnvVars] env_var_resolve: failed to read keychain blob, proceeding without local secrets: {}", e);
+                serde_json::Map::new()
+            })
     };
 
     for (full_match, key) in matches {

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -4,9 +4,6 @@ use tauri::State;
 
 use super::opencode::OpenCodeState;
 
-/// Keyring service name prefix for all TeamClaw environment variables.
-pub(crate) const KEYRING_SERVICE_PREFIX: &str = concat!(env!("APP_SHORT_NAME"), ".env");
-
 /// Single keychain entry that stores all env vars as a JSON blob.
 pub(crate) const KEYRING_SERVICE: &str = concat!(env!("APP_SHORT_NAME"), ".env");
 
@@ -138,11 +135,6 @@ pub struct EnvVarEntry {
 }
 
 // ─── Internal helpers ───────────────────────────────────────────────────
-
-/// Build the keyring service name for a given key.
-pub(crate) fn keyring_service(key: &str) -> String {
-    format!("{}.{}", KEYRING_SERVICE_PREFIX, key)
-}
 
 /// Get the teamclaw.json path inside the workspace.
 fn get_teamclaw_json_path(workspace_path: &str) -> String {

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -28,7 +28,10 @@ pub(crate) fn read_env_blob(workspace_path: &str) -> Result<serde_json::Map<Stri
             }
         }
         Err(keyring::Error::NoEntry) => {
-            // First launch: attempt migration from legacy per-key format
+            // First launch (or blob deleted): attempt migration from legacy per-key format.
+            // Note: migration only fires when the blob entry is absent (NoEntry). If the blob
+            // exists but contains empty/corrupt JSON, we return the fallback empty map above and
+            // skip migration — legacy per-key entries would remain orphaned in that case.
             let migrated = migrate_legacy_keyring(workspace_path);
             if !migrated.is_empty() {
                 println!("[EnvVars] Migrated {} legacy keychain entries to blob", migrated.len());
@@ -258,7 +261,10 @@ pub async fn env_var_get(
 pub async fn env_var_delete(state: State<'_, OpenCodeState>, key: String) -> Result<(), String> {
     let workspace_path = get_workspace_path(&state)?;
 
-    // Read index once — used for both the guard check and the removal below
+    // Read index once — used for both the guard check and the removal below.
+    // Note: concurrent deletes from multiple Tauri windows could race here (each reads,
+    // modifies, and writes the same json independently). In practice the settings UI is
+    // single-user sequential, so this is acceptable.
     let mut json = read_teamclaw_json(&workspace_path)?;
     let mut entries = get_env_vars_from_json(&json);
 

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -7,10 +7,6 @@ use super::opencode::OpenCodeState;
 /// Single keychain entry that stores all env vars as a JSON blob.
 pub(crate) const KEYRING_SERVICE: &str = concat!(env!("APP_SHORT_NAME"), ".env");
 
-/// Legacy per-key service prefix (used only for migration detection).
-/// Produces service names like `teamclaw.env.<KEY>`, distinct from the blob service `teamclaw.env`.
-const LEGACY_PER_KEY_SERVICE_PREFIX: &str = concat!(env!("APP_SHORT_NAME"), ".env");
-
 /// Read the entire env var blob from keychain.
 /// Returns an empty map if the entry doesn't exist yet.
 /// On first call after migration: detects old per-key entries and consolidates them.
@@ -77,8 +73,8 @@ fn migrate_legacy_keyring(workspace_path: &str) -> serde_json::Map<String, serde
             Some(k) => k,
             None => continue,
         };
-        // Legacy service name was "teamclaw.env.<KEY>"
-        let legacy_service = format!("{}.{}", LEGACY_PER_KEY_SERVICE_PREFIX, key);
+        // Legacy service name was `{KEYRING_SERVICE}.<KEY>`
+        let legacy_service = format!("{}.{}", KEYRING_SERVICE, key);
         if let Ok(e) = keyring::Entry::new(&legacy_service, "teamclaw") {
             match e.get_password() {
                 Ok(value) => {

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -11,11 +11,13 @@ pub(crate) const KEYRING_SERVICE_PREFIX: &str = concat!(env!("APP_SHORT_NAME"), 
 pub(crate) const KEYRING_SERVICE: &str = concat!(env!("APP_SHORT_NAME"), ".env");
 
 /// Legacy per-key service prefix (used only for migration detection).
-const LEGACY_SERVICE_PREFIX: &str = concat!(env!("APP_SHORT_NAME"), ".env");
+/// Produces service names like `teamclaw.env.<KEY>`, distinct from the blob service `teamclaw.env`.
+const LEGACY_PER_KEY_SERVICE_PREFIX: &str = concat!(env!("APP_SHORT_NAME"), ".env");
 
 /// Read the entire env var blob from keychain.
 /// Returns an empty map if the entry doesn't exist yet.
 /// On first call after migration: detects old per-key entries and consolidates them.
+/// May write to keychain on first call if legacy migration is needed.
 pub(crate) fn read_env_blob(workspace_path: &str) -> Result<serde_json::Map<String, serde_json::Value>, String> {
     let entry = keyring::Entry::new(KEYRING_SERVICE, "teamclaw")
         .map_err(|e| format!("Failed to open keychain entry: {}", e))?;
@@ -23,7 +25,10 @@ pub(crate) fn read_env_blob(workspace_path: &str) -> Result<serde_json::Map<Stri
     match entry.get_password() {
         Ok(json_str) => {
             let val: serde_json::Value = serde_json::from_str(&json_str)
-                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+                .unwrap_or_else(|e| {
+                    eprintln!("[EnvVars] Failed to parse keychain blob as JSON (corrupt?): {}", e);
+                    serde_json::Value::Object(serde_json::Map::new())
+                });
             match val {
                 serde_json::Value::Object(map) => Ok(map),
                 _ => Ok(serde_json::Map::new()),
@@ -76,12 +81,17 @@ fn migrate_legacy_keyring(workspace_path: &str) -> serde_json::Map<String, serde
             None => continue,
         };
         // Legacy service name was "teamclaw.env.<KEY>"
-        let legacy_service = format!("{}.{}", LEGACY_SERVICE_PREFIX, key);
+        let legacy_service = format!("{}.{}", LEGACY_PER_KEY_SERVICE_PREFIX, key);
         if let Ok(e) = keyring::Entry::new(&legacy_service, "teamclaw") {
-            if let Ok(value) = e.get_password() {
-                map.insert(key.to_string(), serde_json::Value::String(value));
-                // Delete old entry
-                let _ = e.delete_credential();
+            match e.get_password() {
+                Ok(value) => {
+                    map.insert(key.to_string(), serde_json::Value::String(value));
+                    // Delete old entry
+                    let _ = e.delete_credential();
+                }
+                Err(e) => {
+                    eprintln!("[EnvVars] Migration: failed to read legacy keychain entry '{}': {}", key, e);
+                }
             }
         }
     }

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -97,7 +97,7 @@ struct SystemEnvVarContext {
 }
 
 /// Definition of a system-managed env var.
-struct SystemEnvVarDef {
+pub(crate) struct SystemEnvVarDef {
     key: &'static str,
     description: &'static str,
     default_fn: fn(&SystemEnvVarContext) -> Option<String>,

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -7,6 +7,87 @@ use super::opencode::OpenCodeState;
 /// Keyring service name prefix for all TeamClaw environment variables.
 pub(crate) const KEYRING_SERVICE_PREFIX: &str = concat!(env!("APP_SHORT_NAME"), ".env");
 
+/// Single keychain entry that stores all env vars as a JSON blob.
+pub(crate) const KEYRING_SERVICE: &str = concat!(env!("APP_SHORT_NAME"), ".env");
+
+/// Legacy per-key service prefix (used only for migration detection).
+const LEGACY_SERVICE_PREFIX: &str = concat!(env!("APP_SHORT_NAME"), ".env");
+
+/// Read the entire env var blob from keychain.
+/// Returns an empty map if the entry doesn't exist yet.
+/// On first call after migration: detects old per-key entries and consolidates them.
+pub(crate) fn read_env_blob(workspace_path: &str) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, "teamclaw")
+        .map_err(|e| format!("Failed to open keychain entry: {}", e))?;
+
+    match entry.get_password() {
+        Ok(json_str) => {
+            let val: serde_json::Value = serde_json::from_str(&json_str)
+                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+            match val {
+                serde_json::Value::Object(map) => Ok(map),
+                _ => Ok(serde_json::Map::new()),
+            }
+        }
+        Err(keyring::Error::NoEntry) => {
+            // First launch: attempt migration from legacy per-key format
+            let migrated = migrate_legacy_keyring(workspace_path);
+            if !migrated.is_empty() {
+                println!("[EnvVars] Migrated {} legacy keychain entries to blob", migrated.len());
+                write_env_blob(&migrated)?;
+            }
+            Ok(migrated)
+        }
+        Err(e) => Err(format!("Failed to read keychain blob: {}", e)),
+    }
+}
+
+/// Write the entire env var blob to keychain.
+pub(crate) fn write_env_blob(map: &serde_json::Map<String, serde_json::Value>) -> Result<(), String> {
+    let json_str = serde_json::to_string(map)
+        .map_err(|e| format!("Failed to serialize env blob: {}", e))?;
+    let entry = keyring::Entry::new(KEYRING_SERVICE, "teamclaw")
+        .map_err(|e| format!("Failed to open keychain entry: {}", e))?;
+    entry.set_password(&json_str)
+        .map_err(|e| format!("Failed to write keychain blob: {}", e))
+}
+
+/// Read old per-key keychain entries and consolidate into a map.
+/// Deletes old entries after reading.
+fn migrate_legacy_keyring(workspace_path: &str) -> serde_json::Map<String, serde_json::Value> {
+    let path = format!("{}/{}/teamclaw.json", workspace_path, super::TEAMCLAW_DIR);
+    let json: serde_json::Value = match std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+    {
+        Some(v) => v,
+        None => return serde_json::Map::new(),
+    };
+
+    let entries = match json.get("envVars").and_then(|v| v.as_array()) {
+        Some(arr) => arr.clone(),
+        None => return serde_json::Map::new(),
+    };
+
+    let mut map = serde_json::Map::new();
+    for entry_val in &entries {
+        let key = match entry_val.get("key").and_then(|k| k.as_str()) {
+            Some(k) => k,
+            None => continue,
+        };
+        // Legacy service name was "teamclaw.env.<KEY>"
+        let legacy_service = format!("{}.{}", LEGACY_SERVICE_PREFIX, key);
+        if let Ok(e) = keyring::Entry::new(&legacy_service, "teamclaw") {
+            if let Ok(value) = e.get_password() {
+                map.insert(key.to_string(), serde_json::Value::String(value));
+                // Delete old entry
+                let _ = e.delete_credential();
+            }
+        }
+    }
+    map
+}
+
 /// A single environment variable entry (key + description, no value).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnvVarEntry {

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -182,7 +182,7 @@ fn get_workspace_path(state: &State<'_, OpenCodeState>) -> Result<String, String
 
 // ─── Tauri Commands ─────────────────────────────────────────────────────
 
-/// Store (or update) an environment variable in the OS keyring and update the index in teamclaw.json.
+/// Store (or update) an environment variable in the keychain blob and update the index in teamclaw.json.
 #[tauri::command]
 pub async fn env_var_set(
     state: State<'_, OpenCodeState>,
@@ -192,22 +192,22 @@ pub async fn env_var_set(
 ) -> Result<(), String> {
     let workspace_path = get_workspace_path(&state)?;
 
-    // Store value in OS keyring
-    let entry = keyring::Entry::new(&keyring_service(&key), "teamclaw")
-        .map_err(|e| format!("Failed to create keyring entry: {}", e))?;
-    entry
-        .set_password(&value)
-        .map_err(|e| format!("Failed to store secret in keyring: {}", e))?;
+    // Read-modify-write the blob
+    let mut blob = tokio::task::spawn_blocking({
+        let wp = workspace_path.clone();
+        move || read_env_blob(&wp)
+    }).await.map_err(|e| e.to_string())??;
 
-    // Update index in teamclaw.json
+    blob.insert(key.clone(), serde_json::Value::String(value));
+    write_env_blob(&blob)?;
+
+    // Update index in teamclaw.json (metadata only, no value)
     let mut json = read_teamclaw_json(&workspace_path)?;
     let mut entries = get_env_vars_from_json(&json);
 
     if let Some(existing) = entries.iter_mut().find(|e| e.key == key) {
-        // Update description if changed
         existing.description = description;
     } else {
-        // Add new entry
         entries.push(EnvVarEntry { key, description });
     }
 
@@ -215,25 +215,37 @@ pub async fn env_var_set(
     write_teamclaw_json(&workspace_path, &json)
 }
 
-/// Retrieve an environment variable value from the OS keyring.
+/// Retrieve an environment variable value from the keychain blob.
 #[tauri::command]
-pub async fn env_var_get(key: String) -> Result<String, String> {
-    let entry = keyring::Entry::new(&keyring_service(&key), "teamclaw")
-        .map_err(|e| format!("Failed to create keyring entry: {}", e))?;
-    entry
-        .get_password()
-        .map_err(|e| format!("Key '{}' not found in keyring: {}", key, e))
+pub async fn env_var_get(
+    state: State<'_, OpenCodeState>,
+    key: String,
+) -> Result<String, String> {
+    let workspace_path = get_workspace_path(&state)?;
+    let blob = tokio::task::spawn_blocking({
+        let wp = workspace_path.clone();
+        move || read_env_blob(&wp)
+    }).await.map_err(|e| e.to_string())??;
+
+    blob.get(&key)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("Key '{}' not found", key))
 }
 
-/// Delete an environment variable from both the OS keyring and teamclaw.json index.
+/// Delete an environment variable from both the keychain blob and teamclaw.json index.
 #[tauri::command]
 pub async fn env_var_delete(state: State<'_, OpenCodeState>, key: String) -> Result<(), String> {
     let workspace_path = get_workspace_path(&state)?;
 
-    // Delete from OS keyring (ignore errors if not found)
-    let entry = keyring::Entry::new(&keyring_service(&key), "teamclaw")
-        .map_err(|e| format!("Failed to create keyring entry: {}", e))?;
-    let _ = entry.delete_credential();
+    // Read-modify-write the blob
+    let mut blob = tokio::task::spawn_blocking({
+        let wp = workspace_path.clone();
+        move || read_env_blob(&wp)
+    }).await.map_err(|e| e.to_string())??;
+
+    blob.remove(&key);
+    write_env_blob(&blob)?;
 
     // Remove from teamclaw.json index
     let mut json = read_teamclaw_json(&workspace_path)?;
@@ -255,19 +267,20 @@ pub async fn env_var_list(state: State<'_, OpenCodeState>) -> Result<Vec<EnvVarE
 ///
 /// Resolution order for each `${KEY}`:
 ///   1. Shared secrets (team KMS, in-memory HashMap)
-///   2. Local keyring (per-user OS keyring)
+///   2. Local keyring blob (per-user OS keyring, single blob entry)
 ///   3. System environment variables (`std::env::var`)
 #[tauri::command]
 pub async fn env_var_resolve(
+    state: State<'_, OpenCodeState>,
     shared_secrets: State<'_, super::shared_secrets::SharedSecretsState>,
     input: String,
 ) -> Result<String, String> {
+    let workspace_path = get_workspace_path(&state)?;
     let re = regex::Regex::new(r"\$\{([^}]+)\}").map_err(|e| format!("Invalid regex: {}", e))?;
 
     let mut result = input.clone();
     let mut errors: Vec<String> = Vec::new();
 
-    // Collect all matches first to avoid borrow issues
     let matches: Vec<(String, String)> = re
         .captures_iter(&input)
         .map(|cap| {
@@ -276,6 +289,15 @@ pub async fn env_var_resolve(
             (full_match, key)
         })
         .collect();
+
+    // Read blob once upfront (one keychain access for all keys)
+    let blob = {
+        let wp = workspace_path.clone();
+        tokio::task::spawn_blocking(move || read_env_blob(&wp))
+            .await
+            .map_err(|e| e.to_string())?
+            .unwrap_or_default()
+    };
 
     for (full_match, key) in matches {
         // 1. Check shared secrets (team KMS) — try original key, then lowercase
@@ -287,15 +309,10 @@ pub async fn env_var_resolve(
             continue;
         }
 
-        // 2. Check local keyring
-        let entry = keyring::Entry::new(&keyring_service(&key), "teamclaw")
-            .map_err(|e| format!("Failed to create keyring entry for '{}': {}", key, e))?;
-        match entry.get_password() {
-            Ok(value) => {
-                result = result.replace(&full_match, &value);
-                continue;
-            }
-            Err(_) => {}
+        // 2. Check local keyring blob
+        if let Some(value) = blob.get(&key).and_then(|v| v.as_str()) {
+            result = result.replace(&full_match, value);
+            continue;
         }
 
         // 3. Check system environment variables

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -358,7 +358,7 @@ pub async fn start_opencode_inner(
         let did = device_id.clone();
         if let Err(e) = tokio::task::spawn_blocking(move || {
             super::env_vars::ensure_system_env_vars(&ws, &did)
-        }).await.map_err(|e| e.to_string()).and_then(|r| r.map_err(|e| e)) {
+        }).await.map_err(|e| e.to_string()).and_then(|r| r) {
             eprintln!("[OpenCode] Warning: failed to ensure system env vars: {}", e);
         }
     }
@@ -414,11 +414,15 @@ pub async fn start_opencode_inner(
 
     // Keyring retry logic (unchanged from original)
     if !failed_keys.is_empty() {
-        println!(
-            "[OpenCode] {} secret(s) failed to read ({:?}), retrying after keychain unlock...",
-            failed_keys.len(),
-            failed_keys
-        );
+        if failed_keys == ["__blob__"] {
+            println!("[OpenCode] Keychain blob unavailable, retrying after keychain unlock...");
+        } else {
+            println!(
+                "[OpenCode] {} secret(s) failed to read ({:?}), retrying after keychain unlock...",
+                failed_keys.len(),
+                failed_keys
+            );
+        }
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
         let ws_retry = workspace_path.clone();
@@ -431,11 +435,15 @@ pub async fn start_opencode_inner(
                 });
 
         if !still_failed.is_empty() {
-            eprintln!(
-                "[OpenCode] Warning: {} secret(s) still unavailable after retry: {:?}",
-                still_failed.len(),
-                still_failed
-            );
+            if still_failed == ["__blob__"] {
+                eprintln!("[OpenCode] Warning: keychain blob still unavailable after retry");
+            } else {
+                eprintln!(
+                    "[OpenCode] Warning: {} secret(s) still unavailable after retry: {:?}",
+                    still_failed.len(),
+                    still_failed
+                );
+            }
         }
 
         secrets = retry_secrets;

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -349,6 +349,20 @@ pub async fn start_opencode_inner(
     // resolve_config_secret_refs runs AFTER all three complete (depends on
     // both the config writers finishing and keyring secrets being available).
 
+    // Ensure system env vars exist (e.g. tc_api_key) before reading keyring secrets.
+    // Runs synchronously — one keychain read + optional write.
+    {
+        let device_id = super::oss_commands::get_or_create_fallback_device_id()
+            .unwrap_or_default();
+        let ws = workspace_path.clone();
+        let did = device_id.clone();
+        if let Err(e) = tokio::task::spawn_blocking(move || {
+            super::env_vars::ensure_system_env_vars(&ws, &did)
+        }).await.map_err(|e| e.to_string()).and_then(|r| r.map_err(|e| e)) {
+            eprintln!("[OpenCode] Warning: failed to ensure system env vars: {}", e);
+        }
+    }
+
     let ws_for_config = workspace_path.clone();
     let ws_for_skills = workspace_path.clone();
     let ws_for_keyring = workspace_path.clone();
@@ -1068,56 +1082,24 @@ fn resolve_sidecar_binary_paths(workspace_path: &str) -> Result<(), String> {
 //   2. Write resolved values into opencode.json before OpenCode starts
 //   3. Restore the ${KEY} references after all MCP servers have connected
 
-/// Read all registered env-var secrets from the OS credential store.
-///
-/// Reads the key index from `.teamclaw/teamclaw.json`, looks up each value via
-/// the `keyring` crate (cross-platform), and returns a tuple of
-/// `(successful_secrets, failed_key_names)`.
-///
-/// On macOS the first access after login may trigger a system keychain
-/// password dialog.  The caller should use `spawn_blocking` so the dialog
-/// can block a dedicated thread without starving the async runtime.
+/// Read all personal env vars from the single keychain blob.
+/// Returns `(secrets, failed)` — failed is always empty on success, or contains
+/// a diagnostic sentinel if the blob itself cannot be read.
 fn read_keyring_secrets(workspace_path: &str) -> (Vec<(String, String)>, Vec<String>) {
-    let path = format!("{}/{}/teamclaw.json", workspace_path, super::TEAMCLAW_DIR);
-    let json: serde_json::Value = match std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|c| serde_json::from_str(&c).ok())
-    {
-        Some(v) => v,
-        None => return (Vec::new(), Vec::new()),
-    };
-
-    let entries = match json.get("envVars").and_then(|v| v.as_array()) {
-        Some(arr) => arr,
-        None => return (Vec::new(), Vec::new()),
-    };
-
-    let mut secrets = Vec::new();
-    let mut failed_keys = Vec::new();
-
-    for entry in entries {
-        let key = match entry.get("key").and_then(|k| k.as_str()) {
-            Some(k) => k,
-            None => continue,
-        };
-        let service = super::env_vars::keyring_service(key);
-        match keyring::Entry::new(&service, "teamclaw").and_then(|e| e.get_password()) {
-            Ok(value) => {
-                println!(
-                    "[OpenCode] Loaded secret from keyring: {} ({}...)",
-                    key,
-                    &value[..value.len().min(8)]
-                );
-                secrets.push((key.to_string(), value));
-            }
-            Err(e) => {
-                eprintln!("[OpenCode] Failed to read keyring secret '{}': {}", key, e);
-                failed_keys.push(key.to_string());
-            }
+    match super::env_vars::read_env_blob(workspace_path) {
+        Ok(blob) => {
+            let secrets: Vec<(String, String)> = blob
+                .into_iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k, s.to_string())))
+                .collect();
+            println!("[OpenCode] Loaded {} secrets from keychain blob", secrets.len());
+            (secrets, Vec::new())
+        }
+        Err(e) => {
+            eprintln!("[OpenCode] Failed to read keychain blob: {}", e);
+            (Vec::new(), vec!["__blob__".to_string()])
         }
     }
-
-    (secrets, failed_keys)
 }
 
 /// Replace `${KEY}` references in opencode.json MCP environment sections


### PR DESCRIPTION
## Summary

- **Single keychain blob**: All personal env vars stored in one macOS Keychain entry (`teamclaw.env`) as a JSON object instead of per-key entries. Reduces macOS authorization prompts from N to 1 per session.
- **System env var registry**: Built-in `SYSTEM_ENV_VARS` in Rust with default value generators. `tc_api_key` is auto-generated from device ID at startup if missing. System vars cannot be deleted but can be edited.
- **Team mode auth simplified**: Removed fragile localStorage/HTTP `connectProvider` auth flow. Team provider now uses `${tc_api_key}` reference resolved at sidecar startup — immune to sidebar refresh/webview lifecycle issues.
- **UI updates**: System env vars show lock badge, delete button hidden, sorted first in list.

## What Changed

| Area | Change |
|------|--------|
| `env_vars.rs` | Single blob storage, legacy migration, system registry, `ensure_system_env_vars()`, delete guard |
| `opencode.rs` | Call `ensure_system_env_vars` before keyring read; blob-based `read_keyring_secrets` |
| `team-mode.ts` | Remove `connectProvider`, `reAuthTeamProvider`, `teamApiKey` state; use `${tc_api_key}` |
| `ChatPanel.tsx` | Remove `reAuthTeamProvider` call |
| `EnvVarsSection.tsx` | System badge, hide delete for system entries, sort system first |
| `config.ts` | Add `apiKey` to `CustomProviderConfig` |

## Test Plan

- [ ] Launch app → verify `tc_api_key` auto-created in env vars (system badge visible)
- [ ] Enable team mode → verify model works without manual API key setup
- [ ] Refresh sidebar → verify team mode still works (no "API key doesn't exist")
- [ ] Add/edit/delete personal env vars → verify CRUD still works
- [ ] Try to delete system env var → verify it's blocked
- [ ] Edit system env var value → verify custom value persists across restarts
- [ ] Verify only 1 macOS Keychain prompt per session (not N)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)