### PR TITLE
fix: align team mode detection and fix P2P reconnect reliability

### DIFF
--- a/packages/app/src/components/settings/EnvVarsSection.tsx
+++ b/packages/app/src/components/settings/EnvVarsSection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { KeyRound, Plus, Eye, EyeOff, Pencil, Trash2, ShieldCheck, AlertCircle, RefreshCw, Loader2, Users, User, Lock } from 'lucide-react'
+import { KeyRound, Plus, Eye, EyeOff, Pencil, Trash2, ShieldCheck, AlertCircle, RefreshCw, Loader2, Users, User, Lock, Copy, Check } from 'lucide-react'
 import { invoke } from '@tauri-apps/api/core'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -257,6 +257,7 @@ function EnvVarRow({ entry, canDelete, onEdit, onDelete }: EnvVarRowProps) {
   const [revealed, setRevealed] = React.useState(false)
   const [revealedValue, setRevealedValue] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(false)
+  const [copied, setCopied] = React.useState(false)
   const { getEnvVarValue } = useEnvVarsStore()
 
   const isSystem = entry.scope === 'personal' && entry.category === 'system'
@@ -321,9 +322,24 @@ function EnvVarRow({ entry, canDelete, onEdit, onDelete }: EnvVarRowProps) {
           </p>
         )}
         {isPersonal && revealed && revealedValue !== null && (
-          <p className="text-xs font-mono text-muted-foreground mt-1 bg-muted/50 px-2 py-1 rounded break-all">
-            {revealedValue}
-          </p>
+          <div className="flex items-center gap-1 mt-1">
+            <p className="text-xs font-mono text-muted-foreground bg-muted/50 px-2 py-1 rounded break-all flex-1 min-w-0">
+              {revealedValue}
+            </p>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 shrink-0"
+              onClick={async () => {
+                await navigator.clipboard.writeText(revealedValue)
+                setCopied(true)
+                setTimeout(() => setCopied(false), 1500)
+              }}
+              title={t('common.copy', 'Copy')}
+            >
+              {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
+            </Button>
+          </div>
         )}
       </div>
 

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -247,12 +247,15 @@ export function TeamOSSConfig() {
     navigator.clipboard.writeText(text)
   }, [])
 
+  const teamModeType = useTeamModeStore((s) => s.teamModeType)
+  const configuredAsOss = configured || teamModeType === 'oss'
+
   const isOwner = teamInfo?.role === 'owner' || teamInfo?.role === 'admin'
 
   return (
     <div className="space-y-4">
-      {/* State 0: Restoring connection */}
-      {!connected && restoring && (
+      {/* State 0: Restoring connection or configured via teamclaw.json but not connected yet */}
+      {!connected && (restoring || (configuredAsOss && !configured)) && (
         <SettingCard title="连接中" icon={Cloud}>
           <div className="flex items-center gap-3 py-4 justify-center">
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
@@ -287,7 +290,7 @@ export function TeamOSSConfig() {
       )}
 
       {/* State 1b: Not configured — Create/Join forms */}
-      {!connected && !restoring && !configured && (
+      {!connected && !restoring && !configuredAsOss && (
         <>
           <SettingCard title="创建团队" icon={Users}>
             <div className="space-y-3">

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -123,6 +123,9 @@ export function TeamP2PConfig() {
   const [confirmDisconnect, setConfirmDisconnect] = React.useState(false)
   const [reconnecting, setReconnecting] = React.useState(true)
 
+  const teamModeType = useTeamModeStore((s) => s.teamModeType)
+  const configuredAsP2p = teamModeType === 'p2p'
+
   const allowedMembers = syncStatus?.members ?? []
   const isOwner = syncStatus?.role === 'owner'
   const isConnected = engineSnapshot?.status === 'connected' || (syncStatus?.connected ?? false)
@@ -867,7 +870,7 @@ export function TeamP2PConfig() {
         </>
       )}
 
-      {/* ─── Reconnecting State ──────────────────────────────────────── */}
+      {/* ─── Reconnecting State (initial load) ─────────────────────────── */}
       {!isConnected && reconnecting && (
         <SettingCard>
           <div className="flex items-center gap-3 py-4 justify-center">
@@ -877,8 +880,51 @@ export function TeamP2PConfig() {
         </SettingCard>
       )}
 
+      {/* ─── Configured but not connected (reconnect prompt) ─────────── */}
+      {!isConnected && !reconnecting && configuredAsP2p && (
+        <SettingCard>
+          <div className="flex flex-col items-center gap-3 py-4">
+            <p className="text-sm text-muted-foreground">
+              {t('settings.team.p2pConfiguredNotConnected', 'Team is configured but not connected. Peers may be offline or unreachable.')}
+            </p>
+            {p2pError && (
+              <p className="text-xs text-destructive text-center">{p2pError}</p>
+            )}
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1"
+                onClick={async () => {
+                  setReconnecting(true)
+                  setP2pError(null)
+                  try {
+                    await loadSyncStatus()
+                    await engineInit()
+                    await useP2pEngineStore.getState().fetch()
+                  } catch { /* ignore */ }
+                  setReconnecting(false)
+                }}
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+                {t('settings.team.retryConnect', 'Retry')}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1 text-destructive hover:text-destructive border-destructive/30"
+                onClick={handleP2pDisconnect}
+              >
+                <Unlink className="h-3.5 w-3.5" />
+                {t('settings.team.disconnect', 'Disconnect')}
+              </Button>
+            </div>
+          </div>
+        </SettingCard>
+      )}
+
       {/* ─── Not Connected State ─────────────────────────────────────── */}
-      {!isConnected && !reconnecting && (
+      {!isConnected && !reconnecting && !configuredAsP2p && (
         <>
           {/* Create Team */}
           <SettingCard>

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -447,8 +447,12 @@ export function useP2pAutoReconnect() {
   useEffect(() => {
     if (!workspacePath || !openCodeReady || !teamMode || !isTauri()) return;
 
-    // Delay P2P reconnect so it doesn't compete with app startup
-    const timer = setTimeout(async () => {
+    let cancelled = false;
+    const MAX_RETRIES = 5;
+    const INITIAL_DELAY = 3000;
+
+    const attemptReconnect = async (attempt: number) => {
+      if (cancelled) return;
       try {
         const { invoke } = await import("@tauri-apps/api/core");
         await invoke("p2p_reconnect");
@@ -469,11 +473,24 @@ export function useP2pAutoReconnect() {
 
         console.log("[P2P] Auto-reconnect completed");
       } catch (err) {
-        console.warn("[P2P] Auto-reconnect failed (non-critical):", err);
+        const msg = err instanceof Error ? err.message : String(err);
+        if (attempt < MAX_RETRIES && msg.includes("not running")) {
+          const delay = INITIAL_DELAY * Math.pow(2, attempt);
+          console.warn(`[P2P] Auto-reconnect attempt ${attempt + 1}/${MAX_RETRIES} failed (iroh not ready), retrying in ${delay}ms`);
+          timer = setTimeout(() => attemptReconnect(attempt + 1), delay);
+        } else {
+          console.warn("[P2P] Auto-reconnect failed:", msg);
+        }
       }
-    }, 3000);
+    };
 
-    return () => clearTimeout(timer);
+    // Delay first attempt so it doesn't compete with app startup
+    let timer: ReturnType<typeof setTimeout> = setTimeout(() => attemptReconnect(0), INITIAL_DELAY);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
   }, [workspacePath, openCodeReady, teamMode]);
 }
 

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -293,6 +293,7 @@ pub struct IrohNode {
 impl IrohNode {
     /// Create and start a new iroh node with persistent storage at the given path.
     pub async fn new(storage_path: &Path) -> Result<Self, String> {
+        let t0 = std::time::Instant::now();
         let blob_path = storage_path.join("blobs");
         let docs_path = storage_path.join("docs");
         std::fs::create_dir_all(&blob_path)
@@ -300,27 +301,32 @@ impl IrohNode {
         std::fs::create_dir_all(&docs_path)
             .map_err(|e| format!("Failed to create iroh docs dir: {}", e))?;
 
+        eprintln!("[P2P] Loading blob store...");
         let store = FsStore::load(&blob_path)
             .await
             .map_err(|e| format!("Failed to create iroh blob store: {}", e))?;
+        eprintln!("[P2P] Blob store loaded ({:.0}ms)", t0.elapsed().as_millis());
 
         let secret_key = load_or_create_secret_key(storage_path)?;
+        eprintln!("[P2P] Binding endpoint...");
         let endpoint = Endpoint::builder(iroh::endpoint::presets::N0)
             .secret_key(secret_key)
             .bind()
             .await
             .map_err(|e| format!("Failed to bind iroh endpoint: {}", e))?;
+        eprintln!("[P2P] Endpoint bound ({:.0}ms)", t0.elapsed().as_millis());
 
         let gossip = Gossip::builder().spawn(endpoint.clone());
 
         let blobs_store: iroh_blobs::api::Store = store.clone().into();
 
+        eprintln!("[P2P] Starting docs engine...");
         let docs = iroh_docs::protocol::Docs::persistent(docs_path)
             .spawn(endpoint.clone(), blobs_store.clone(), gossip.clone())
             .await
             .map_err(|e| format!("Failed to start docs engine: {}", e))?;
+        eprintln!("[P2P] Docs engine started ({:.0}ms)", t0.elapsed().as_millis());
 
-        // Get or create a persistent default author
         let author = docs
             .author_default()
             .await
@@ -334,6 +340,8 @@ impl IrohNode {
             .spawn();
 
         let (gen_tx, gen_rx) = tokio::sync::watch::channel(0u64);
+
+        eprintln!("[P2P] Node ready ({:.0}ms total)", t0.elapsed().as_millis());
 
         Ok(IrohNode {
             endpoint,
@@ -3766,12 +3774,23 @@ async fn reconnect_team_for_workspace(
 
     let team_dir = format!("{}/{}", workspace_path, super::TEAM_REPO_DIR);
 
-    // Re-check authorization on reconnect (except for owner)
+    // Check authorization on reconnect (except for owner).
+    // If the members manifest is missing locally (e.g. team dir was not synced yet),
+    // skip the check and let sync proceed — the manifest will arrive from peers.
     if !is_owner {
-        if let Err(auth_err) = check_join_authorization(&team_dir, &my_node_id) {
-            let _ = doc.close().await;
-            clear_p2p_and_team_dir(workspace_path)?;
-            return Err(format!("Reconnect rejected: {}", auth_err));
+        match check_join_authorization(&team_dir, &my_node_id) {
+            Ok(()) => {}
+            Err(ref e) if e.contains("no members manifest found") => {
+                eprintln!(
+                    "[P2P] Members manifest not found locally, skipping auth check (will sync from peers)"
+                );
+            }
+            Err(auth_err) => {
+                eprintln!("[P2P] Reconnect authorization failed: {}", auth_err);
+                let _ = doc.close().await;
+                // Don't clear config — allow user to retry or rejoin manually
+                return Err(format!("Reconnect rejected: {}", auth_err));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **统一团队判断逻辑**：团队设置 UI 和 LLM 部分现在都以 `teamclaw.json` 持久化配置为准判断是否属于团队，解决两边判断不一致的问题（LLM 显示"由团队统一管理"但团队页显示"创建/加入"）
- **P2P 已配置但未连接时的 UI**：不再显示创建/加入表单，改为显示"已配置但未连接"提示，带重试和断开连接按钮
- **P2P auto-reconnect 加重试**：指数退避重试 5 次（3s→6s→12s→24s→48s），修复 iroh 节点启动慢时 reconnect 只尝试一次就放弃的问题
- **iroh 节点启动分步日志**：在 `IrohNode::new()` 的每个关键步骤加 timing 日志，便于排查启动卡住问题
- **reconnect 不再误删 P2P 配置**：members manifest 本地不存在时跳过 auth check（等待从 peer 同步），auth 失败时也不再调用 `clear_p2p_and_team_dir` 清空配置

## Changed Files

| File | Change |
|------|--------|
| `TeamP2PConfig.tsx` | 读取 `teamModeType`，新增"已配置未连接"状态（重试/断开） |
| `TeamOSSConfig.tsx` | 读取 `teamModeType`，OSS 配置存在时不显示创建/加入 |
| `useAppInit.ts` | `useP2pAutoReconnect` 改为带取消和指数退避的重试 |
| `team_p2p.rs` | `IrohNode::new` 加分步日志；`reconnect_team_for_workspace` 放宽 auth check、不清配置 |
| `EnvVarsSection.tsx` | 环境变量值增加复制按钮 |

## Test plan

- [ ] 有 P2P 配置但 peer 不在线时，团队设置显示"已配置但未连接"而非创建/加入
- [ ] LLM 设置和团队设置对"是否属于团队"的判断一致
- [ ] iroh 节点启动时终端有分步 timing 日志
- [ ] iroh 启动慢时 auto-reconnect 能自动重试成功连接
- [ ] reconnect 时本地无 members manifest 不会清空 P2P 配置


Made with [Cursor](https://cursor.com)