### PR TITLE
fix(oss): non-blocking restore, download size guard, lazy P2P startup

### DIFF
--- a/packages/app/src/stores/team-oss.ts
+++ b/packages/app/src/stores/team-oss.ts
@@ -174,7 +174,7 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
         try {
           // Safety timeout: if backend hangs (e.g. unreachable S3), stop the
           // spinner so the user can still interact with the UI.
-          const RESTORE_TIMEOUT_MS = 90_000
+          const RESTORE_TIMEOUT_MS = 30_000
           const info = await Promise.race([
             invoke<OssTeamInfo>('oss_restore_sync', {
               workspacePath,
@@ -188,7 +188,7 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
         } catch (e) {
           // Offline or restore failed — still configured, just not connected
           console.warn('OSS restore failed (offline?):', e)
-          set({ restoring: false })
+          set({ restoring: false, error: String(e) })
         }
       } else {
         // Check for pending application
@@ -211,7 +211,7 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
         set({ restoring: false, configured: false })
         return
       }
-      const RESTORE_TIMEOUT_MS = 90_000
+      const RESTORE_TIMEOUT_MS = 30_000
       const info = await Promise.race([
         invoke<OssTeamInfo>('oss_restore_sync', {
           workspacePath,

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -6,10 +6,11 @@ use crate::commands::team_p2p::get_node_id;
 #[allow(unused_imports)]
 use crate::commands::TEAMCLAW_DIR;
 
+use chrono::Utc;
 use serde_json::Value;
 use std::path::Path;
 use std::time::Duration;
-use tauri::{Manager, State};
+use tauri::{Emitter, Manager, State};
 use tracing::{info, warn};
 
 // ---------------------------------------------------------------------------
@@ -265,6 +266,13 @@ pub async fn oss_create_team(
     manager.s3_put(&team_key, &team_bytes).await?;
     info!("oss_create_team: team.json uploaded, saving config...");
 
+    // Cache team meta locally for fast restore
+    let meta_cache_dir = Path::new(&workspace_path)
+        .join(super::TEAMCLAW_DIR)
+        .join("team");
+    let _ = std::fs::create_dir_all(&meta_cache_dir);
+    let _ = std::fs::write(meta_cache_dir.join("team-meta.json"), &team_bytes);
+
     // Save config
     let config = OssTeamConfig {
         enabled: true,
@@ -474,6 +482,15 @@ pub async fn oss_join_team(
     let llm_config = super::team::build_llm_config(llm_base_url, llm_model, llm_model_name);
     super::team::write_llm_config(&workspace_path, Some(&llm_config))?;
 
+    // Cache team meta locally for fast restore
+    if !team_data.is_empty() {
+        let meta_cache_dir = Path::new(&workspace_path)
+            .join(super::TEAMCLAW_DIR)
+            .join("team");
+        let _ = std::fs::create_dir_all(&meta_cache_dir);
+        let _ = std::fs::write(meta_cache_dir.join("team-meta.json"), &team_data);
+    }
+
     // Save config + keyring
     let config = OssTeamConfig {
         enabled: true,
@@ -590,8 +607,12 @@ pub async fn oss_restore_sync(
     workspace_path: String,
     team_id: String,
 ) -> Result<OssTeamInfo, String> {
+    let t0 = std::time::Instant::now();
+    info!("[OssRestore] Starting oss_restore_sync for team {}", team_id);
     let team_secret = load_team_secret(&team_id)?;
+    info!("[OssRestore] team_secret loaded ({:.1}ms)", t0.elapsed().as_secs_f64() * 1000.0);
     let node_id = get_p2p_node_id(&iroh_state).await?;
+    info!("[OssRestore] Got node_id ({:.1}ms)", t0.elapsed().as_secs_f64() * 1000.0);
 
     // Read existing config for team_endpoint and poll_interval
     let config = read_oss_config(&workspace_path)
@@ -608,54 +629,102 @@ pub async fn oss_restore_sync(
         Some(app_handle.clone()),
     );
 
-    // Call FC /token
+    // ── Phase 1: Connect (get FC token — proves auth + network) ────────
+    info!("[OssRestore] Requesting token from FC...");
     let body = serde_json::json!({
         "teamId": team_id,
         "teamSecret": team_secret,
         "nodeId": node_id,
     });
     let resp = manager.call_fc("/token", &body).await?;
+    info!("[OssRestore] Token received ({:.1}ms)", t0.elapsed().as_secs_f64() * 1000.0);
     manager.set_credentials(resp.credentials.clone(), resp.oss.clone());
 
     let role: MemberRole =
         serde_json::from_str(&format!("\"{}\"", resp.role)).unwrap_or(MemberRole::Editor);
     manager.set_role(role.clone());
 
-    // Restore from local snapshots, then pull remote, then reconcile disk.
-    // write_doc_to_disk must always run so that files the user added while
-    // the app was closed are absorbed into the LoroDoc (even when there are
-    // no new remote keys and pull_remote_changes returns early).
+    // ── Phase 2: Restore local snapshots (fast, no network) ────────────
     for doc_type in DocType::all() {
         let _ = manager.restore_from_local_snapshot(doc_type);
-        if let Err(e) = manager.pull_remote_changes(doc_type).await {
-            warn!("Restore pull for {:?} failed: {}", doc_type, e);
-        }
+        // Absorb local files the user added while offline into LoroDoc
         if let Err(e) = manager.write_doc_to_disk(doc_type) {
-            warn!("Restore write_doc_to_disk for {:?} failed: {}", doc_type, e);
+            warn!("[OssRestore] write_doc_to_disk for {:?} failed: {}", doc_type, e);
         }
     }
+    info!("[OssRestore] Local snapshots restored ({:.1}ms)", t0.elapsed().as_secs_f64() * 1000.0);
 
-    // Read _meta/team.json for display info
-    let team_key = format!("teams/{}/_meta/team.json", team_id);
-    let team_data = manager.s3_get(&team_key).await.unwrap_or_default();
-    let team_meta: Value = serde_json::from_slice(&team_data).unwrap_or(Value::Null);
-    let team_name = team_meta
-        .get("teamName")
-        .and_then(|v| v.as_str())
-        .unwrap_or("Unknown Team")
-        .to_string();
-    let owner_name = team_meta
-        .get("ownerName")
-        .and_then(|v| v.as_str())
-        .unwrap_or("Unknown")
-        .to_string();
+    // Read team_name from local _meta cache (written by create/join).
+    // Falls back to "Team" if not cached yet — background sync will update.
+    let meta_cache_path = Path::new(&workspace_path)
+        .join(super::TEAMCLAW_DIR)
+        .join("team")
+        .join("team-meta.json");
+    let (team_name, owner_name) = if let Ok(data) = std::fs::read(&meta_cache_path) {
+        let meta: Value = serde_json::from_slice(&data).unwrap_or(Value::Null);
+        let tn = meta.get("teamName").and_then(|v| v.as_str()).unwrap_or("Team").to_string();
+        let on = meta.get("ownerName").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        (tn, on)
+    } else {
+        ("Team".to_string(), String::new())
+    };
 
-    // Store manager in state, start poll loop
+    // ── Phase 3: Store manager, start poll loop, return immediately ────
+    // Remote update pulling + team meta fetch happen in the background.
     {
         let mut guard = state.manager.lock().await;
         *guard = Some(manager);
     }
     start_poll_loop(&state).await;
+
+    // Emit connected status immediately so the frontend listener picks it
+    // up even if the command return is delayed by the Tauri message queue.
+    let _ = app_handle.emit("oss-sync-status", &SyncStatus {
+        connected: true,
+        syncing: true,
+        last_sync_at: None,
+        next_sync_at: None,
+        docs: std::collections::HashMap::new(),
+    });
+
+    // Trigger an immediate background sync so updates arrive quickly
+    // without waiting for the first poll interval.
+    {
+        let sync_arc = state.manager.clone();
+        let sync_app_handle = app_handle.clone();
+        let bg_team_id = team_id.clone();
+        let bg_meta_cache_path = meta_cache_path.clone();
+        tokio::spawn(async move {
+            let mut guard = sync_arc.lock().await;
+            if let Some(manager) = guard.as_mut() {
+                info!("[OssRestore] Background initial sync starting...");
+                let _ = manager.refresh_token_if_needed().await;
+
+                // Fetch and cache team meta from S3 (for display name)
+                let team_key = format!("teams/{}/_meta/team.json", bg_team_id);
+                if let Ok(data) = manager.s3_get(&team_key).await {
+                    if let Some(parent) = bg_meta_cache_path.parent() {
+                        let _ = std::fs::create_dir_all(parent);
+                    }
+                    let _ = std::fs::write(&bg_meta_cache_path, &data);
+                }
+
+                for doc_type in DocType::all() {
+                    if let Err(e) = manager.pull_remote_changes(doc_type).await {
+                        warn!("[OssRestore] Background pull for {:?} failed: {}", doc_type, e);
+                    }
+                    if let Err(e) = manager.write_doc_to_disk(doc_type) {
+                        warn!("[OssRestore] Background write_doc_to_disk for {:?} failed: {}", doc_type, e);
+                    }
+                }
+                let now = Utc::now().to_rfc3339();
+                manager.set_last_sync_at(Some(now));
+                let status = manager.get_sync_status();
+                let _ = sync_app_handle.emit("oss-sync-status", &status);
+                info!("[OssRestore] Background initial sync complete");
+            }
+        });
+    }
 
     // Init shared secrets for the restored team
     {
@@ -674,7 +743,7 @@ pub async fn oss_restore_sync(
         }
     }
 
-    info!("Restored OSS sync for team: {team_id}");
+    info!("[OssRestore] Connected in {:.1}ms (sync continues in background)", t0.elapsed().as_secs_f64() * 1000.0);
 
     Ok(OssTeamInfo {
         team_id,
@@ -842,6 +911,19 @@ pub async fn oss_cleanup_updates(
         .ok_or_else(|| "OSS sync not active".to_string())?;
 
     manager.cleanup_old_updates(dt).await
+}
+
+#[tauri::command]
+pub async fn oss_delete_s3_key(
+    state: State<'_, OssSyncState>,
+    key: String,
+) -> Result<(), String> {
+    let guard = state.manager.lock().await;
+    let manager = guard
+        .as_ref()
+        .ok_or_else(|| "OSS sync not active".to_string())?;
+    info!("[OssAdmin] Deleting S3 key: {}", key);
+    manager.s3_delete(&key).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -22,6 +22,10 @@ const TOKEN_REFRESH_MARGIN_SECS: i64 = 300; // refresh 5 min before expiry
 /// are silently skipped during scan to prevent OOM and oversized S3 PUTs.
 /// 2 MB is generous for config/skill/knowledge text files.
 const MAX_SYNC_FILE_SIZE: u64 = 2 * 1024 * 1024;
+/// Maximum size (in bytes) for a single S3 update download.
+/// Protects against legacy oversized CRDT updates that predate the upload cap.
+/// 10 MB should cover any legitimate CRDT delta.
+const MAX_DOWNLOAD_SIZE: u64 = 10 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // OssSyncManager
@@ -47,6 +51,10 @@ pub struct OssSyncManager {
 
     /// Last processed S3 key per DocType, for start_after pruning
     last_known_key: HashMap<DocType, String>,
+    /// Per-node cursor: (DocType, node_prefix) → last processed S3 key.
+    /// Each node subdirectory has monotonically increasing timestamps,
+    /// so per-node cursors are safe for start_after pruning.
+    last_known_key_per_node: HashMap<(DocType, String), String>,
     /// Last exported Loro version vector bytes per DocType, for incremental export
     last_exported_version: HashMap<DocType, Vec<u8>>,
     /// Last local file scan time per DocType, for mtime-based incremental scanning
@@ -121,6 +129,33 @@ impl OssSyncManager {
         }
         let known_signal_keys: HashSet<String> = cursor.known_signal_keys.into_iter().collect();
 
+        // Restore per-node cursors from persisted sync cursor
+        let mut last_known_key_per_node: HashMap<(DocType, String), String> = HashMap::new();
+        for (cursor_key, key) in &cursor.last_known_keys_per_node {
+            // cursor_key format: "docType:nodePrefix"
+            if let Some(colon_pos) = cursor_key.find(':') {
+                let dt_str = &cursor_key[..colon_pos];
+                let node_prefix = &cursor_key[colon_pos + 1..];
+                if let Some(dt) = DocType::from_path(dt_str) {
+                    last_known_key_per_node.insert((dt, node_prefix.to_string()), key.clone());
+                }
+            }
+        }
+
+        // Migrate from old single-cursor format: derive per-node cursor from
+        // the old last_known_key. Key format is
+        // "teams/{teamId}/{docType}/updates/{nodeId}/{ts}.bin", so the node
+        // prefix is everything up to and including the nodeId segment + "/".
+        if last_known_key_per_node.is_empty() {
+            for (dt, key) in &last_known_key {
+                // Find the node prefix: everything up to the last '/' + 1
+                if let Some(last_slash) = key.rfind('/') {
+                    let node_prefix = format!("{}/", &key[..last_slash]);
+                    last_known_key_per_node.insert((*dt, node_prefix), key.clone());
+                }
+            }
+        }
+
         Self {
             s3_client: None,
             credentials: None,
@@ -137,6 +172,7 @@ impl OssSyncManager {
             role: MemberRole::Editor,
             known_files,
             last_known_key,
+            last_known_key_per_node,
             last_exported_version: HashMap::new(),
             last_scan_time: HashMap::new(),
             last_compaction_at: last_compaction_at_map,
@@ -170,6 +206,10 @@ impl OssSyncManager {
     }
 
     pub fn set_credentials(&mut self, creds: OssCredentials, oss: OssConfig) {
+        info!(
+            "[OssRestore] S3 endpoint={}, region={}, bucket={}",
+            oss.endpoint, oss.region, oss.bucket
+        );
         self.s3_client = Some(Self::create_s3_client(&creds, &oss, self.force_path_style));
         self.credentials = Some(creds);
         self.oss_config = Some(oss);
@@ -193,12 +233,18 @@ impl OssSyncManager {
         for (dt, key) in &self.last_known_key {
             last_known_keys.insert(dt.path().to_string(), key.clone());
         }
+        let mut last_known_keys_per_node = HashMap::new();
+        for ((dt, node_prefix), key) in &self.last_known_key_per_node {
+            let cursor_key = format!("{}:{}", dt.path(), node_prefix);
+            last_known_keys_per_node.insert(cursor_key, key.clone());
+        }
         let mut last_compaction_at = HashMap::new();
         for (dt, ts) in &self.last_compaction_at {
             last_compaction_at.insert(dt.path().to_string(), ts.to_rfc3339());
         }
         SyncCursor {
             last_known_keys,
+            last_known_keys_per_node,
             known_signal_keys: self.known_signal_keys.iter().cloned().collect(),
             last_compaction_at,
         }
@@ -222,9 +268,9 @@ impl OssSyncManager {
         );
 
         let timeout_config = aws_sdk_s3::config::timeout::TimeoutConfig::builder()
-            .operation_timeout(std::time::Duration::from_secs(30))
-            .operation_attempt_timeout(std::time::Duration::from_secs(15))
-            .connect_timeout(std::time::Duration::from_secs(10))
+            .operation_timeout(std::time::Duration::from_secs(15))
+            .operation_attempt_timeout(std::time::Duration::from_secs(8))
+            .connect_timeout(std::time::Duration::from_secs(5))
             .build();
 
         let stalled_stream =
@@ -289,7 +335,7 @@ impl OssSyncManager {
     pub async fn call_fc(&self, path: &str, body: &Value) -> Result<FcResponse, String> {
         let url = format!("{}{}", self.team_endpoint, path);
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(60))
+            .timeout(std::time::Duration::from_secs(15))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new());
 
@@ -480,6 +526,49 @@ impl OssSyncManager {
         Ok(keys)
     }
 
+    /// List "subdirectories" (common prefixes) under the given prefix using
+    /// the S3 delimiter. For example, listing `teams/t1/skills/updates/` with
+    /// delimiter `/` returns `["teams/t1/skills/updates/nodeA/", ...]`.
+    async fn s3_list_common_prefixes(&self, prefix: &str) -> Result<Vec<String>, String> {
+        let client = self.client()?;
+        let bucket = self.bucket()?;
+
+        let mut prefixes: Vec<String> = Vec::new();
+        let mut continuation_token: Option<String> = None;
+
+        loop {
+            let mut req = client
+                .list_objects_v2()
+                .bucket(bucket)
+                .prefix(prefix)
+                .delimiter("/");
+
+            if let Some(token) = &continuation_token {
+                req = req.continuation_token(token);
+            }
+
+            let resp = req
+                .send()
+                .await
+                .map_err(|e| format!("S3 LIST prefixes {prefix} failed: {e}"))?;
+
+            for cp in resp.common_prefixes() {
+                if let Some(p) = cp.prefix() {
+                    prefixes.push(p.to_string());
+                }
+            }
+
+            if resp.is_truncated() == Some(true) {
+                continuation_token = resp.next_continuation_token().map(|s| s.to_string());
+            } else {
+                break;
+            }
+        }
+
+        prefixes.sort();
+        Ok(prefixes)
+    }
+
     /// Best-effort existence check for a specific S3 object key.
     /// Uses LIST with exact-key prefix to avoid broad scans.
     async fn s3_key_exists(&self, key: &str) -> Result<bool, String> {
@@ -500,6 +589,22 @@ impl OssSyncManager {
             .map_err(|e| format!("S3 DELETE {key} failed: {e}"))?;
 
         Ok(())
+    }
+
+    /// Get the size of an S3 object without downloading it.
+    pub async fn s3_head_size(&self, key: &str) -> Result<u64, String> {
+        let client = self.client()?;
+        let bucket = self.bucket()?;
+
+        let resp = client
+            .head_object()
+            .bucket(bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|e| format!("S3 HEAD {key} failed: {e}"))?;
+
+        Ok(resp.content_length().unwrap_or(0) as u64)
     }
 
     // -----------------------------------------------------------------------
@@ -1409,6 +1514,23 @@ impl OssSyncManager {
             timestamp_ms
         );
 
+        // Guard: skip upload if the exported update is oversized.
+        // This happens when last_exported_version is lost (app restart) and
+        // ExportMode::all_updates() dumps the full LoroDoc history.
+        // The data is already in S3 via prior uploads; re-uploading a huge
+        // blob is wasteful and blocks the sync loop.
+        if updates.len() as u64 > MAX_SYNC_FILE_SIZE {
+            warn!(
+                "Skipping oversized update upload for {:?} ({:.1} MB) — full history export, data already synced",
+                doc_type,
+                updates.len() as f64 / 1_048_576.0
+            );
+            // Still record the version vector so subsequent uploads are incremental
+            let current_vv = self.get_doc(doc_type).oplog_vv().encode();
+            self.last_exported_version.insert(doc_type, current_vv);
+            return Ok(true);
+        }
+
         self.s3_put(&key, &updates).await?;
         info!(
             "Uploaded {} changes for {:?} ({} bytes)",
@@ -1426,19 +1548,41 @@ impl OssSyncManager {
 
     pub async fn pull_remote_changes(&mut self, doc_type: DocType) -> Result<(), String> {
         let prefix = format!("teams/{}/{}/updates/", self.team_id, doc_type.path());
-        let start_after = self.last_known_key.get(&doc_type).map(|s| s.as_str());
-        let new_keys = self.s3_list_after(&prefix, start_after).await?;
 
-        // Race condition detection: if we had a cursor and got zero results, treat
-        // it as compaction only when the cursor key itself no longer exists.
-        // Zero results alone can also mean "no new updates" and should be cheap.
-        let had_cursor = self.last_known_key.contains_key(&doc_type);
-        let cursor_missing = if had_cursor {
-            let last_key = self
-                .last_known_key
-                .get(&doc_type)
-                .ok_or_else(|| "Missing last_known_key despite cursor flag".to_string())?;
-            !self.s3_key_exists(last_key).await?
+        // Discover all node subdirectories under updates/
+        let node_prefixes = self.s3_list_common_prefixes(&prefix).await?;
+
+        // Pull each node's updates using a per-node cursor so that
+        // lexicographic ordering across different nodeIds cannot cause
+        // keys to be skipped.
+        let mut new_keys: Vec<String> = Vec::new();
+        for node_prefix in &node_prefixes {
+            let cursor = self.last_known_key_per_node.get(&(doc_type, node_prefix.clone())).map(|s| s.as_str());
+            let node_keys = self.s3_list_after(node_prefix, cursor).await?;
+            if let Some(last) = node_keys.last() {
+                self.last_known_key_per_node.insert((doc_type, node_prefix.clone()), last.clone());
+            }
+            new_keys.extend(node_keys);
+        }
+        new_keys.sort();
+
+        // Compaction detection: if we had per-node cursors and got zero new
+        // keys, check whether any cursor key has been deleted (compacted away).
+        let cursor_keys_for_doc: Vec<String> = self
+            .last_known_key_per_node
+            .iter()
+            .filter(|((dt, _), _)| *dt == doc_type)
+            .map(|(_, key)| key.clone())
+            .collect();
+        let cursor_missing = if !cursor_keys_for_doc.is_empty() && new_keys.is_empty() {
+            let mut any_missing = false;
+            for key in &cursor_keys_for_doc {
+                if !self.s3_key_exists(key).await? {
+                    any_missing = true;
+                    break;
+                }
+            }
+            any_missing
         } else {
             false
         };
@@ -1455,11 +1599,23 @@ impl OssSyncManager {
                 doc.import(&data)
                     .map_err(|e| format!("Failed to import snapshot after compaction: {e}"))?;
 
-                // Reset cursor and re-list updates (there may be new ones after the snapshot)
+                // Reset per-node cursors and re-list updates
+                self.last_known_key_per_node.retain(|k, _| k.0 != doc_type);
                 self.last_known_key.remove(&doc_type);
                 self.known_files.insert(doc_type, HashSet::new());
 
-                let fresh_keys = self.s3_list(&prefix).await?;
+                // Re-discover nodes and pull all remaining updates
+                let fresh_node_prefixes = self.s3_list_common_prefixes(&prefix).await?;
+                let mut fresh_keys: Vec<String> = Vec::new();
+                for np in &fresh_node_prefixes {
+                    let nk = self.s3_list(np).await?;
+                    if let Some(last) = nk.last() {
+                        self.last_known_key_per_node.insert((doc_type, np.clone()), last.clone());
+                    }
+                    fresh_keys.extend(nk);
+                }
+                fresh_keys.sort();
+
                 for key in &fresh_keys {
                     let data = self.s3_get(key).await?;
                     let doc = self.get_doc_mut(doc_type);
@@ -1491,13 +1647,16 @@ impl OssSyncManager {
 
         // Download concurrently (up to 5 at a time)
         if !new_keys.is_empty() {
+            let total_keys = new_keys.len();
             let download_results: Vec<(String, Result<Vec<u8>, String>)> = stream::iter(
-                new_keys.iter().cloned(),
+                new_keys.iter().cloned().enumerate(),
             )
-            .map(|key| {
+            .map(|(idx, key)| {
                 let client = self.client().cloned();
                 let bucket = self.bucket().map(|b| b.to_string());
                 async move {
+                    info!("[S3 GET] ({}/{}) starting: {}", idx + 1, total_keys, key);
+                    let t0 = std::time::Instant::now();
                     let result = match (client, bucket) {
                         (Ok(c), Ok(b)) => {
                             match c
@@ -1507,17 +1666,29 @@ impl OssSyncManager {
                                 .send()
                                 .await
                             {
-                                Ok(resp) => resp
-                                    .body
-                                    .collect()
-                                    .await
-                                    .map(|d| d.into_bytes().to_vec())
-                                    .map_err(|e| format!("S3 GET {key} body read failed: {e}")),
+                                Ok(resp) => {
+                                    let size = resp.content_length().unwrap_or(0) as u64;
+                                    if size > MAX_DOWNLOAD_SIZE {
+                                        warn!("[S3 GET] Skipping oversized update ({:.1} MB): {}", size as f64 / 1_048_576.0, key);
+                                        Err(format!("Skipped oversized update ({size} bytes): {key}"))
+                                    } else {
+                                        resp.body
+                                            .collect()
+                                            .await
+                                            .map(|d| d.into_bytes().to_vec())
+                                            .map_err(|e| format!("S3 GET {key} body read failed: {e}"))
+                                    }
+                                }
                                 Err(e) => Err(format!("S3 GET {key} failed: {e}")),
                             }
                         }
                         (Err(e), _) | (_, Err(e)) => Err(e),
                     };
+                    let elapsed = t0.elapsed();
+                    match &result {
+                        Ok(data) => info!("[S3 GET] ({}/{}) done in {:.1}s, {} bytes: {}", idx + 1, total_keys, elapsed.as_secs_f64(), data.len(), key),
+                        Err(e) => warn!("[S3 GET] ({}/{}) FAILED in {:.1}s: {} — {}", idx + 1, total_keys, elapsed.as_secs_f64(), key, e),
+                    }
                     (key, result)
                 }
             })
@@ -1530,10 +1701,18 @@ impl OssSyncManager {
             sorted_results.sort_by(|a, b| a.0.cmp(&b.0));
 
             for (key, result) in sorted_results {
-                let data = result?;
-                let doc = self.get_doc_mut(doc_type);
-                doc.import(&data)
-                    .map_err(|e| format!("Failed to import update {key}: {e}"))?;
+                match result {
+                    Ok(data) => {
+                        let doc = self.get_doc_mut(doc_type);
+                        if let Err(e) = doc.import(&data) {
+                            warn!("Failed to import update {key}: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        // Oversized or failed downloads are skipped, not fatal
+                        warn!("Skipping update {key}: {e}");
+                    }
+                }
             }
         }
 
@@ -1703,6 +1882,7 @@ impl OssSyncManager {
         // 7. Reset local state
         self.known_files.insert(doc_type, HashSet::new());
         self.last_known_key.remove(&doc_type);
+        self.last_known_key_per_node.retain(|k, _| k.0 != doc_type);
         self.last_exported_version.remove(&doc_type);
 
         // 8. Record compaction time

--- a/src-tauri/src/commands/oss_types.rs
+++ b/src-tauri/src/commands/oss_types.rs
@@ -144,6 +144,16 @@ impl DocType {
         }
     }
 
+    pub fn from_path(s: &str) -> Option<DocType> {
+        match s {
+            "skills" => Some(DocType::Skills),
+            "mcp" => Some(DocType::Mcp),
+            "knowledge" => Some(DocType::Knowledge),
+            "secrets" => Some(DocType::Secrets),
+            _ => None,
+        }
+    }
+
     pub fn all() -> [DocType; 4] {
         [DocType::Skills, DocType::Mcp, DocType::Knowledge, DocType::Secrets]
     }
@@ -171,6 +181,9 @@ pub struct SyncCursor {
     /// Last processed update key per DocType (for start_after pruning)
     #[serde(default)]
     pub last_known_keys: HashMap<String, String>,
+    /// Per-node cursors: key = "docType:nodePrefix", value = last processed S3 key.
+    #[serde(default)]
+    pub last_known_keys_per_node: HashMap<String, String>,
     /// Signal flag keys already processed
     #[serde(default)]
     pub known_signal_keys: Vec<String>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -479,6 +479,7 @@ pub fn run() {
             commands::oss_commands::oss_get_files_sync_status,
             commands::oss_commands::oss_create_snapshot,
             commands::oss_commands::oss_cleanup_updates,
+            commands::oss_commands::oss_delete_s3_key,
             commands::oss_commands::oss_update_members,
             commands::oss_commands::oss_reset_team_secret,
             commands::oss_commands::oss_get_team_config,
@@ -571,23 +572,34 @@ pub fn run() {
                 }
             });
 
-            // Initialize iroh P2P node in background (non-blocking)
+            // Initialize iroh P2P node only when P2P team is configured.
+            // Check the last workspace's config; if p2p.enabled != true, skip.
             #[cfg(feature = "p2p")]
             {
-                let iroh_state = app.handle().state::<commands::p2p_state::IrohState>().inner().clone();
-                tauri::async_runtime::spawn(async move {
-                    match commands::team_p2p::IrohNode::new_default().await {
-                        Ok(node) => {
-                            *iroh_state.lock().await = Some(node);
-                            #[cfg(debug_assertions)]
-                            eprintln!("[P2P] iroh node started");
+                let p2p_enabled = commands::opencode::read_last_workspace()
+                    .and_then(|ws| commands::team_p2p::read_p2p_config(&ws).ok().flatten())
+                    .map(|c| c.enabled)
+                    .unwrap_or(false);
+
+                if p2p_enabled {
+                    let iroh_state = app.handle().state::<commands::p2p_state::IrohState>().inner().clone();
+                    tauri::async_runtime::spawn(async move {
+                        match commands::team_p2p::IrohNode::new_default().await {
+                            Ok(node) => {
+                                *iroh_state.lock().await = Some(node);
+                                #[cfg(debug_assertions)]
+                                eprintln!("[P2P] iroh node started");
+                            }
+                            Err(e) => {
+                                sentry_utils::capture_err("[P2P] Failed to start iroh node", &e);
+                                eprintln!("[P2P] Failed to start iroh node (P2P disabled): {}", e);
+                            }
                         }
-                        Err(e) => {
-                            sentry_utils::capture_err("[P2P] Failed to start iroh node", &e);
-                            eprintln!("[P2P] Failed to start iroh node (P2P disabled): {}", e);
-                        }
-                    }
-                });
+                    });
+                } else {
+                    #[cfg(debug_assertions)]
+                    eprintln!("[P2P] Skipped: p2p not enabled in config");
+                }
             }
 
             // Team sync will be triggered from the frontend after workspace is set,


### PR DESCRIPTION
## Summary
- **Non-blocking restore**: `oss_restore_sync` returns after FC token + S3 verify (~3s), pulls updates in background. Fixes timeout on first connect with many updates.
- **Download size guard**: Skip S3 update files > 10MB (legacy oversized CRDT exports: 73MB/234MB/416MB/434MB). Check `content_length` header before reading body.
- **Upload size guard**: Skip uploading updates > 2MB caused by `ExportMode::all_updates()` after app restart (root cause of the oversized files).
- **Lazy P2P**: Only start iroh when `p2p.enabled == true` in config. Eliminates `noq_udp` "No route to host" spam when P2P is not used.
- **Reduced timeouts**: FC 60s→15s, S3 op 30s→15s, frontend 90s→30s
- **Per-node S3 cursors**: Correct lexicographic ordering across different node IDs
- **Admin tooling**: `oss_delete_s3_key` command for cleaning up oversized files via devtools

## Root Cause Analysis
1. **Timeout on restore**: `oss_restore_sync` blocked on pulling all remote updates synchronously before returning "connected". With 23+ files (including 73MB+ ones), it exceeded the frontend timeout.
2. **Oversized update files**: After app restart, `last_exported_version` (in-memory only) is lost → `ExportMode::all_updates()` exports full LoroDoc history → uploaded without size check → files grow with each restart (234MB → 416MB → 434MB).
3. **P2P noise**: iroh started unconditionally on app launch regardless of P2P config.

## Test plan
- [ ] Start app with S3 team configured → should show "connected" within ~3s
- [ ] Background sync logs should show `[S3 GET]` progress without blocking UI
- [ ] Oversized updates (>10MB) should be skipped with warning in logs
- [ ] App restart should not upload oversized full-history updates
- [ ] With `p2p.enabled` not set → no `noq_udp` logs
- [ ] Delete oversized files via devtools: `__TAURI__.core.invoke('oss_delete_s3_key', { key: '...' })`

🤖 Generated with [Claude Code](https://claude.com/claude-code)