### PR TITLE
fix(keychain): add disk fallback for env blob to survive app updates

### DIFF
--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -7,10 +7,45 @@ use super::opencode::OpenCodeState;
 /// Single keychain entry that stores all env vars as a JSON blob.
 pub(crate) const KEYRING_SERVICE: &str = concat!(env!("APP_SHORT_NAME"), ".env");
 
+/// Disk-based fallback path for the env blob.
+/// Used when keychain is inaccessible (e.g. after an unsigned app update
+/// changes the binary signature and macOS revokes keychain access).
+fn env_blob_fallback_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(concat!(".", env!("APP_SHORT_NAME"), "/env-blob.json")))
+}
+
+/// Read the env blob from the disk fallback file.
+fn read_env_blob_from_disk() -> Option<serde_json::Map<String, serde_json::Value>> {
+    let path = env_blob_fallback_path()?;
+    let content = std::fs::read_to_string(&path).ok()?;
+    let val: serde_json::Value = serde_json::from_str(&content).ok()?;
+    match val {
+        serde_json::Value::Object(map) => Some(map),
+        _ => None,
+    }
+}
+
+/// Write the env blob to the disk fallback file.
+fn write_env_blob_to_disk(map: &serde_json::Map<String, serde_json::Value>) {
+    if let Some(path) = env_blob_fallback_path() {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let json_str = match serde_json::to_string(map) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        if let Err(e) = std::fs::write(&path, &json_str) {
+            eprintln!("[EnvVars] Failed to write disk fallback: {}", e);
+        }
+    }
+}
+
 /// Read the entire env var blob from keychain.
 /// Returns an empty map if the entry doesn't exist yet.
 /// On first call after migration: detects old per-key entries and consolidates them.
 /// May write to keychain on first call if legacy migration is needed.
+/// Falls back to a disk file when keychain is inaccessible (e.g. after app update).
 pub(crate) fn read_env_blob(workspace_path: &str) -> Result<serde_json::Map<String, serde_json::Value>, String> {
     let entry = keyring::Entry::new(KEYRING_SERVICE, "teamclaw")
         .map_err(|e| format!("Failed to open keychain entry: {}", e))?;
@@ -29,28 +64,77 @@ pub(crate) fn read_env_blob(workspace_path: &str) -> Result<serde_json::Map<Stri
         }
         Err(keyring::Error::NoEntry) => {
             // First launch (or blob deleted): attempt migration from legacy per-key format.
-            // Note: migration only fires when the blob entry is absent (NoEntry). If the blob
-            // exists but contains empty/corrupt JSON, we return the fallback empty map above and
-            // skip migration — legacy per-key entries would remain orphaned in that case.
             let migrated = migrate_legacy_keyring(workspace_path);
             if !migrated.is_empty() {
                 println!("[EnvVars] Migrated {} legacy keychain entries to blob", migrated.len());
                 write_env_blob(&migrated)?;
+                return Ok(migrated);
             }
-            Ok(migrated)
+            // Try disk fallback (handles post-update keychain loss)
+            if let Some(disk_blob) = read_env_blob_from_disk() {
+                if !disk_blob.is_empty() {
+                    println!("[EnvVars] Restored {} entries from disk fallback", disk_blob.len());
+                    // Re-populate keychain so subsequent reads are fast
+                    let _ = write_env_blob_to_keychain(&disk_blob);
+                    return Ok(disk_blob);
+                }
+            }
+            Ok(serde_json::Map::new())
         }
-        Err(e) => Err(format!("Failed to read keychain blob: {}", e)),
+        Err(e) => {
+            // Keychain error (e.g. access denied after app update) — try disk fallback
+            eprintln!("[EnvVars] Keychain read failed: {}. Trying disk fallback...", e);
+            if let Some(disk_blob) = read_env_blob_from_disk() {
+                if !disk_blob.is_empty() {
+                    println!("[EnvVars] Restored {} entries from disk fallback", disk_blob.len());
+                    return Ok(disk_blob);
+                }
+            }
+            Err(format!("Failed to read keychain blob: {}", e))
+        }
     }
 }
 
-/// Write the entire env var blob to keychain.
-pub(crate) fn write_env_blob(map: &serde_json::Map<String, serde_json::Value>) -> Result<(), String> {
+/// Write the env blob to keychain only (no disk fallback).
+fn write_env_blob_to_keychain(map: &serde_json::Map<String, serde_json::Value>) -> Result<(), String> {
     let json_str = serde_json::to_string(map)
         .map_err(|e| format!("Failed to serialize env blob: {}", e))?;
     let entry = keyring::Entry::new(KEYRING_SERVICE, "teamclaw")
         .map_err(|e| format!("Failed to open keychain entry: {}", e))?;
     entry.set_password(&json_str)
         .map_err(|e| format!("Failed to write keychain blob: {}", e))
+}
+
+/// Write the entire env var blob to keychain and disk fallback.
+pub(crate) fn write_env_blob(map: &serde_json::Map<String, serde_json::Value>) -> Result<(), String> {
+    // Always write disk fallback (survives app updates)
+    write_env_blob_to_disk(map);
+    // Write to keychain (may fail after update, but that's OK — disk has it)
+    match write_env_blob_to_keychain(map) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            eprintln!("[EnvVars] Keychain write failed (disk fallback saved): {}", e);
+            Ok(())
+        }
+    }
+}
+
+/// Snapshot the current keychain env blob to the disk fallback file.
+/// Called by the updater before replacing the app bundle so the new binary
+/// (which may have a different code signature) can recover secrets.
+pub(crate) fn snapshot_env_blob_to_disk() {
+    let entry = match keyring::Entry::new(KEYRING_SERVICE, "teamclaw") {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    if let Ok(json_str) = entry.get_password() {
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json_str) {
+            if let serde_json::Value::Object(map) = val {
+                write_env_blob_to_disk(&map);
+                println!("[EnvVars] Snapshot {} keychain entries to disk before update", map.len());
+            }
+        }
+    }
 }
 
 /// Read old per-key keychain entries and consolidate into a map.

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -473,7 +473,7 @@ pub async fn start_opencode_inner(
                                 oss.get("teamId").and_then(|v| v.as_str()),
                                 oss.get("enabled").and_then(|v| v.as_bool()),
                             ) {
-                                if let Ok(team_secret) = super::oss_sync::load_team_secret(team_id) {
+                                if let Ok(team_secret) = super::oss_sync::load_team_secret(&workspace_path, team_id) {
                                     let team_dir = std::path::Path::new(&workspace_path)
                                         .join(super::TEAM_REPO_DIR);
                                     match super::shared_secrets::init_shared_secrets(

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -314,7 +314,7 @@ pub async fn oss_create_team(
         poll_interval_secs: 300,
     };
     write_oss_config(&workspace_path, &config)?;
-    save_team_secret(&team_id, &team_secret)?;
+    save_team_secret(&workspace_path, &team_id, &team_secret)?;
 
     // Store manager in state, start poll loop
     {
@@ -532,7 +532,7 @@ pub async fn oss_join_team(
         poll_interval_secs: 300,
     };
     write_oss_config(&workspace_path, &config)?;
-    save_team_secret(&team_id, &team_secret)?;
+    save_team_secret(&workspace_path, &team_id, &team_secret)?;
 
     // Clear any pending application
     let _ = clear_pending_application(&workspace_path);
@@ -640,7 +640,7 @@ pub async fn oss_restore_sync(
 ) -> Result<OssTeamInfo, String> {
     let t0 = std::time::Instant::now();
     info!("[OssRestore] Starting oss_restore_sync for team {}", team_id);
-    let team_secret = load_team_secret(&team_id)?;
+    let team_secret = load_team_secret(&workspace_path, &team_id)?;
     info!("[OssRestore] team_secret loaded ({:.1}ms)", t0.elapsed().as_secs_f64() * 1000.0);
     let node_id = get_p2p_node_id(&iroh_state).await?;
     info!("[OssRestore] Got node_id ({:.1}ms)", t0.elapsed().as_secs_f64() * 1000.0);
@@ -832,7 +832,7 @@ pub async fn oss_leave_team(
 
     // Read config to get team_id, then clean up
     if let Some(config) = read_oss_config(&workspace_path) {
-        let _ = delete_team_secret(&config.team_id);
+        let _ = delete_team_secret(&workspace_path, &config.team_id);
     }
 
     // Disable OSS in teamclaw.json
@@ -988,7 +988,7 @@ pub async fn oss_update_members(
 #[tauri::command]
 pub async fn oss_reset_team_secret(
     state: State<'_, OssSyncState>,
-    _workspace_path: String,
+    workspace_path: String,
 ) -> Result<String, String> {
     let new_secret = generate_team_secret()?;
 
@@ -998,7 +998,7 @@ pub async fn oss_reset_team_secret(
         .ok_or_else(|| "OSS sync not active".to_string())?;
 
     let team_id = manager.team_id().to_string();
-    let old_secret = load_team_secret(&team_id)?;
+    let old_secret = load_team_secret(&workspace_path, &team_id)?;
 
     let body = serde_json::json!({
         "teamId": team_id,
@@ -1007,8 +1007,8 @@ pub async fn oss_reset_team_secret(
     });
     manager.call_fc("/reset-secret", &body).await?;
 
-    // Update keyring with new secret
-    save_team_secret(&team_id, &new_secret)?;
+    // Update secret in env blob
+    save_team_secret(&workspace_path, &team_id, &new_secret)?;
 
     info!("Team secret reset for team: {team_id}");
     Ok(new_secret)
@@ -1080,7 +1080,7 @@ pub async fn oss_apply_team(
     write_pending_application(&workspace_path, &pending)?;
 
     // Save team secret so we can re-check later
-    save_team_secret(&team_id, &team_secret)?;
+    save_team_secret(&workspace_path, &team_id, &team_secret)?;
 
     info!("Application submitted for team: {team_id}");
     Ok(())

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -4558,29 +4558,50 @@ pub fn write_sync_cursor(workspace_path: &str, cursor: &SyncCursor) -> Result<()
     Ok(())
 }
 
-pub fn save_team_secret(team_id: &str, secret: &str) -> Result<(), String> {
-    let entry = keyring::Entry::new(KEYRING_SERVICE, team_id)
-        .map_err(|e| format!("Failed to create keyring entry: {e}"))?;
-    entry
-        .set_password(secret)
-        .map_err(|e| format!("Failed to save team secret to keyring: {e}"))?;
-    Ok(())
+fn team_secret_blob_key(team_id: &str) -> String {
+    format!("_oss_team_secret.{}", team_id)
 }
 
-pub fn load_team_secret(team_id: &str) -> Result<String, String> {
-    let entry = keyring::Entry::new(KEYRING_SERVICE, team_id)
-        .map_err(|e| format!("Failed to create keyring entry: {e}"))?;
-    entry
-        .get_password()
-        .map_err(|e| format!("Failed to load team secret from keyring: {e}"))
+pub fn save_team_secret(workspace_path: &str, team_id: &str, secret: &str) -> Result<(), String> {
+    let mut blob = super::env_vars::read_env_blob(workspace_path)?;
+    blob.insert(
+        team_secret_blob_key(team_id),
+        serde_json::Value::String(secret.to_string()),
+    );
+    super::env_vars::write_env_blob(&blob)
 }
 
-pub fn delete_team_secret(team_id: &str) -> Result<(), String> {
-    let entry = keyring::Entry::new(KEYRING_SERVICE, team_id)
+pub fn load_team_secret(workspace_path: &str, team_id: &str) -> Result<String, String> {
+    let blob = super::env_vars::read_env_blob(workspace_path)?;
+    let key = team_secret_blob_key(team_id);
+    if let Some(value) = blob.get(&key).and_then(|v| v.as_str()) {
+        return Ok(value.to_string());
+    }
+    // Migration: try legacy per-team keyring entry
+    let legacy_entry = keyring::Entry::new(KEYRING_SERVICE, team_id)
         .map_err(|e| format!("Failed to create keyring entry: {e}"))?;
-    entry
-        .delete_credential()
-        .map_err(|e| format!("Failed to delete team secret from keyring: {e}"))?;
+    match legacy_entry.get_password() {
+        Ok(secret) => {
+            // Migrate into env blob and delete legacy entry
+            let mut blob = blob;
+            blob.insert(key, serde_json::Value::String(secret.clone()));
+            let _ = super::env_vars::write_env_blob(&blob);
+            let _ = legacy_entry.delete_credential();
+            info!("Migrated team secret for {} from legacy keyring to env blob", team_id);
+            Ok(secret)
+        }
+        Err(_) => Err(format!("Team secret not found for team {team_id}")),
+    }
+}
+
+pub fn delete_team_secret(workspace_path: &str, team_id: &str) -> Result<(), String> {
+    let mut blob = super::env_vars::read_env_blob(workspace_path)?;
+    blob.remove(&team_secret_blob_key(team_id));
+    super::env_vars::write_env_blob(&blob)?;
+    // Also clean up legacy entry if it exists
+    if let Ok(legacy_entry) = keyring::Entry::new(KEYRING_SERVICE, team_id) {
+        let _ = legacy_entry.delete_credential();
+    }
     Ok(())
 }
 

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -629,7 +629,14 @@ pub async fn download_and_install_update<R: Runtime>(
     let pubkey = get_updater_pubkey();
     verify_signature(&bytes, &signature, pubkey)?;
 
-    // 3. Install (extract tar.gz and replace .app bundle)
+    // 3. Snapshot keychain env blob to disk before replacing the app bundle.
+    //    The current process still has keychain access (matching code signature).
+    //    After the bundle is replaced, the new binary's signature won't match the
+    //    keychain ACL, so this disk snapshot is the only way the new version can
+    //    recover secrets on first launch.
+    super::env_vars::snapshot_env_blob_to_disk();
+
+    // 4. Install (extract tar.gz and replace .app bundle)
     install_update(&bytes)?;
 
     Ok(())


### PR DESCRIPTION
## Summary
- On macOS with ad-hoc signing, each app update changes the binary signature, causing macOS keychain to deny access to secrets — team connection fails after update
- `write_env_blob()` now writes to both keychain and `~/.teamclaw/env-blob.json`
- `read_env_blob()` falls back to disk file when keychain is inaccessible
- Updater snapshots keychain blob to disk **before** replacing the app bundle, so the new version can recover secrets on first launch
- Migrate team secret storage from per-team keyring entries to the unified env blob (benefits from disk fallback)

## Impact
- Users who already updated to v0.1.38 will need to rejoin their team once (secrets already lost)
- From this version onward, updates will preserve team connection seamlessly

## Test plan
- [ ] Fresh install: team create/join stores secrets in both keychain and disk
- [ ] App update: new version reads secrets from disk fallback when keychain is denied
- [ ] Legacy migration: old per-team keyring entries migrate to env blob on first read

🤖 Generated with [Claude Code](https://claude.com/claude-code)