### PR TITLE
fix(fc): add managerPolicy with _meta write permission

### DIFF
--- a/.claude/skills/fc-deploy/deploy.sh
+++ b/.claude/skills/fc-deploy/deploy.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+cd "$REPO_ROOT/fc"
+
+# Load .env if present
+if [ -f .env ]; then
+  source .env
+fi
+if [ -f "$REPO_ROOT/.env.local" ]; then
+  set -a
+  source "$REPO_ROOT/.env.local"
+  set +a
+fi
+
+# Normalize names expected by s.yaml / FC runtime
+export ACCESS_KEY_ID="${ACCESS_KEY_ID:-${SLS_ACCESS_KEY_ID:-}}"
+export ACCESS_KEY_SECRET="${ACCESS_KEY_SECRET:-${SLS_ACCESS_KEY_SECRET:-}}"
+export LITELLM_URL="${LITELLM_URL:-${liteLLM_URL:-}}"
+export LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-${liteLLM_MASTER_KEY:-}}"
+export LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD="${LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD:-${liteLLM_DEFAULT_TEAM_MAX_BUDGET_USD:-}}"
+
+# Check required env vars
+for var in ACCESS_KEY_ID ACCESS_KEY_SECRET ROLE_ARN; do
+  if [ -z "${!var:-}" ]; then
+    echo "Error: $var is not set" >&2
+    exit 1
+  fi
+done
+
+# Check s CLI
+if ! command -v s &>/dev/null; then
+  echo "Installing Serverless Devs..."
+  npm install -g @serverless-devs/s
+fi
+
+# Install dependencies (avoid broken third-party npm mirrors)
+export NPM_CONFIG_REGISTRY="${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org/}"
+npm install --omit=dev
+
+# Deploy
+s deploy -y

--- a/fc/index.mjs
+++ b/fc/index.mjs
@@ -164,6 +164,11 @@ function memberPolicy(teamId, nodeId) {
         Action: ["oss:PutObject"],
         Resource: `acs:oss:*:*:${BUCKET()}/teams/${teamId}/*/updates/${nodeId}/*`,
       },
+      {
+        Effect: "Allow",
+        Action: ["oss:PutObject"],
+        Resource: `acs:oss:*:*:${BUCKET()}/teams/${teamId}/signal/${nodeId}/*`,
+      },
     ],
   });
 }

--- a/fc/index.mjs
+++ b/fc/index.mjs
@@ -207,6 +207,17 @@ function editorPolicy(teamId, nodeId) {
   return JSON.stringify(base);
 }
 
+function managerPolicy(teamId, nodeId) {
+  const base = JSON.parse(editorPolicy(teamId, nodeId));
+  // Managers can update team metadata (members.json, etc.)
+  base.Statement.push({
+    Effect: "Allow",
+    Action: ["oss:PutObject"],
+    Resource: `acs:oss:*:*:${BUCKET()}/teams/${teamId}/_meta/*`,
+  });
+  return JSON.stringify(base);
+}
+
 function ownerPolicy(teamId, nodeId) {
   const base = JSON.parse(memberPolicy(teamId, nodeId));
   base.Statement.push(
@@ -334,7 +345,10 @@ async function handleToken(body) {
     const manifest = await ossGet(`teams/${teamId}/_meta/members.json`);
     if (manifest) {
       const member = manifest.members?.find((m) => (m.nodeId ?? m.node_id) === nodeId);
-      if (member?.role === "editor" || member?.role === "manager") {
+      if (member?.role === "manager") {
+        role = member.role;
+        policy = managerPolicy(teamId, nodeId);
+      } else if (member?.role === "editor") {
         role = member.role;
         policy = editorPolicy(teamId, nodeId);
       }


### PR DESCRIPTION
## Summary
- Add `managerPolicy` that extends `editorPolicy` with `_meta/*` write access, allowing managers to update `members.json` (set viewer, remove member)
- Add `signal/` path write permission to `memberPolicy` for all roles
- Token handler now issues `managerPolicy` for manager role instead of `editorPolicy`

## Test plan
- [x] Deployed to FC and verified endpoint responds
- [ ] Manager can set member role to viewer without AccessDenied
- [ ] Editor cannot write to `_meta/*` (no regression)
- [ ] Signal flag writes work for all roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)