### PR TITLE
feat(sync): trash files before delete/overwrite in sync operations

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod stt;
 pub mod team;
 #[cfg(feature = "p2p")]
 pub mod team_p2p;
+pub mod trash;
 pub mod team_unified;
 pub mod team_webdav;
 pub mod updater;

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -1407,6 +1407,10 @@ impl OssSyncManager {
                                 _ => true,
                             };
                             if should_delete {
+                                let rel = format!("{}/{}", doc_type.dir_name(), path);
+                                if let Err(e) = super::trash::trash_file(&self.team_dir, &rel) {
+                                    log::warn!("[OssSync] Failed to trash before delete {path}: {e}");
+                                }
                                 let _ = std::fs::remove_file(&file_path);
                             }
                         }
@@ -1469,6 +1473,14 @@ impl OssSyncManager {
                     let _ = std::fs::remove_dir_all(&tmp_dir);
                     format!("Failed to create dir {}: {e}", parent.display())
                 })?;
+            }
+            // Trash before overwrite
+            if final_path.exists() {
+                if let Ok(rel) = final_path.strip_prefix(&self.team_dir) {
+                    if let Err(e) = super::trash::trash_file(&self.team_dir, &rel.to_string_lossy()) {
+                        log::warn!("[OssSync] Failed to trash before overwrite {}: {e}", final_path.display());
+                    }
+                }
             }
             std::fs::rename(tmp_path, final_path).map_err(|e| {
                 let _ = std::fs::remove_dir_all(&tmp_dir);

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -944,6 +944,9 @@ async fn write_doc_entries_to_disk(
         // Skip tombstones (deleted files)
         if is_tombstone(&content) {
             if file_path.exists() {
+                if let Err(e) = super::trash::trash_file(Path::new(team_dir), &key) {
+                    eprintln!("[P2P] Failed to trash before delete {}: {}", key, e);
+                }
                 let _ = std::fs::remove_file(&file_path);
             }
             continue;
@@ -951,6 +954,11 @@ async fn write_doc_entries_to_disk(
 
         if let Some(parent) = file_path.parent() {
             std::fs::create_dir_all(parent).ok();
+        }
+        if file_path.exists() {
+            if let Err(e) = super::trash::trash_file(Path::new(team_dir), &key) {
+                eprintln!("[P2P] Failed to trash before overwrite {}: {}", key, e);
+            }
         }
         std::fs::write(&file_path, &content)
             .map_err(|e| format!("Failed to write '{}': {}", key, e))?;
@@ -1033,6 +1041,9 @@ async fn reconcile_disk_and_doc(
                         "[P2P][reconcile] Remote tombstone -> deleting local: {}",
                         key
                     );
+                    if let Err(e) = super::trash::trash_file(Path::new(team_dir), &key) {
+                        eprintln!("[P2P][reconcile] Failed to trash before delete {}: {}", key, e);
+                    }
                     let _ = std::fs::remove_file(&file_path);
                     continue;
                 }
@@ -1083,6 +1094,9 @@ async fn reconcile_disk_and_doc(
                     // Local is stale (not edited since last sync) → remote wins
                     if let Ok(content) = blobs_store.blobs().get_bytes(entry.content_hash()).await {
                         if !is_tombstone(&content) {
+                            if let Err(e) = super::trash::trash_file(Path::new(team_dir), &key) {
+                                eprintln!("[P2P][reconcile] Failed to trash before overwrite {}: {}", key, e);
+                            }
                             if let Some(parent) = file_path.parent() {
                                 let _ = std::fs::create_dir_all(parent);
                             }
@@ -2916,9 +2930,31 @@ fn clear_p2p_and_team_dir(workspace_path: &str) -> Result<(), String> {
     }
 
     let team_dir = format!("{}/{}", workspace_path, super::TEAM_REPO_DIR);
-    if Path::new(&team_dir).exists() {
+    let team_path = Path::new(&team_dir);
+    if team_path.exists() {
+        // Trash all team files before bulk removal
+        if let Err(e) = super::trash::trash_all_files(team_path) {
+            eprintln!("[P2P] Failed to trash team files before removal: {}", e);
+        }
+
+        // Move .trash to temp location so it survives remove_dir_all
+        let trash_src = team_path.join(".trash");
+        let trash_tmp = Path::new(workspace_path)
+            .join(crate::commands::TEAMCLAW_DIR)
+            .join(".trash-backup");
+        let has_trash = trash_src.exists();
+        if has_trash {
+            let _ = std::fs::rename(&trash_src, &trash_tmp);
+        }
+
         std::fs::remove_dir_all(&team_dir)
             .map_err(|e| format!("Failed to remove team directory: {}", e))?;
+
+        // Restore .trash so user can still recover
+        if has_trash {
+            std::fs::create_dir_all(&team_dir).ok();
+            let _ = std::fs::rename(&trash_tmp, &trash_src);
+        }
     }
 
     Ok(())

--- a/src-tauri/src/commands/trash.rs
+++ b/src-tauri/src/commands/trash.rs
@@ -1,0 +1,98 @@
+use std::path::Path;
+
+const TRASH_DIR: &str = ".trash";
+const MAX_TRASH_VERSIONS: usize = 5;
+
+/// Move a file to `.trash/<rel_path>.<timestamp>` inside `team_dir` before deleting/overwriting.
+pub fn trash_file(team_dir: &Path, rel_path: &str) -> Result<(), String> {
+    let src = team_dir.join(rel_path);
+    if !src.exists() || !src.is_file() {
+        return Ok(());
+    }
+
+    let trash_dest = team_dir.join(TRASH_DIR).join(rel_path);
+    if let Some(parent) = trash_dest.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create trash dir {}: {e}", parent.display()))?;
+    }
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let versioned = format!("{}.{}", trash_dest.display(), timestamp);
+
+    std::fs::copy(&src, &versioned)
+        .map_err(|e| format!("Failed to copy {} to trash: {e}", src.display()))?;
+
+    // Prune old versions of this file
+    prune_old_versions(&trash_dest, MAX_TRASH_VERSIONS);
+
+    Ok(())
+}
+
+/// Trash all user-content files under `team_dir` (skips `.trash` itself and hidden dirs).
+pub fn trash_all_files(team_dir: &Path) -> Result<(), String> {
+    if !team_dir.exists() {
+        return Ok(());
+    }
+
+    let walker = walkdir::WalkDir::new(team_dir)
+        .min_depth(1)
+        .into_iter()
+        .filter_entry(|e| {
+            let name = e.file_name().to_string_lossy();
+            // Skip .trash dir and other dotfiles/dirs at top level
+            !(e.depth() == 1 && name.starts_with('.'))
+        });
+
+    for entry in walker.flatten() {
+        if entry.file_type().is_file() {
+            if let Ok(rel) = entry.path().strip_prefix(team_dir) {
+                if let Err(e) = trash_file(team_dir, &rel.to_string_lossy()) {
+                    log::warn!("[trash] Failed to trash {}: {e}", rel.display());
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Keep only the newest `max` versions of a trashed file.
+fn prune_old_versions(base_path: &Path, max: usize) {
+    let Some(parent) = base_path.parent() else {
+        return;
+    };
+    let Some(file_name) = base_path.file_name().and_then(|n| n.to_str()) else {
+        return;
+    };
+
+    let prefix = format!("{}.", file_name);
+    let mut versions: Vec<_> = std::fs::read_dir(parent)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .map(|n| n.starts_with(&prefix))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    if versions.len() <= max {
+        return;
+    }
+
+    // Sort by modified time, newest first
+    versions.sort_by(|a, b| {
+        let ta = a.metadata().and_then(|m| m.modified()).unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        let tb = b.metadata().and_then(|m| m.modified()).unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        tb.cmp(&ta)
+    });
+
+    for old in &versions[max..] {
+        let _ = std::fs::remove_file(old.path());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `trash.rs` utility module that moves files to `.trash/` before deletion or overwrite, with timestamped versions and auto-pruning (max 5 per file)
- Integrate trash calls in OSS sync (delete cleanup + restore overwrite)
- Integrate trash calls in P2P sync (tombstone delete, write overwrite, reconcile delete/overwrite, team reset)

## Test plan
- [ ] Verify compilation with `cargo check`
- [ ] Trigger OSS sync with file changes — confirm `.trash/` contains previous versions
- [ ] Trigger P2P sync with remote overwrites — confirm trashed files are recoverable
- [ ] Test team reset (`clear_p2p_and_team_dir`) — confirm `.trash/` is preserved after reset
- [ ] Verify pruning: overwrite same file 6+ times, confirm only 5 versions kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)