### PR TITLE
fix: share .cargo-target across git worktrees

### DIFF
--- a/scripts/rust-build-env.js
+++ b/scripts/rust-build-env.js
@@ -7,7 +7,28 @@ function findRepoRoot(startDir) {
   let current = startDir;
 
   while (true) {
-    if (fs.existsSync(path.join(current, ".git")) && fs.existsSync(path.join(current, "package.json"))) {
+    const gitPath = path.join(current, ".git");
+    if (fs.existsSync(gitPath) && fs.existsSync(path.join(current, "package.json"))) {
+      // In a git worktree, .git is a file containing "gitdir: <path>".
+      // Resolve to the main repo root so all worktrees share .cargo-target/.
+      try {
+        const stat = fs.statSync(gitPath);
+        if (stat.isFile()) {
+          const content = fs.readFileSync(gitPath, "utf8").trim();
+          const match = content.match(/^gitdir:\s*(.+)$/);
+          if (match) {
+            // gitdir points to <main-repo>/.git/worktrees/<name>
+            const gitdir = path.resolve(current, match[1]);
+            const mainGitDir = path.resolve(gitdir, "..", "..");
+            const mainRoot = path.dirname(mainGitDir);
+            if (fs.existsSync(path.join(mainRoot, "package.json"))) {
+              return mainRoot;
+            }
+          }
+        }
+      } catch (_) {
+        // Fall through to return current worktree root
+      }
       return current;
     }
 


### PR DESCRIPTION
## Summary
- Worktree builds were compiling from scratch because `findRepoRoot()` resolved to the worktree directory instead of the main repo root
- In a git worktree, `.git` is a file containing `gitdir: <path>` — now parses this to resolve back to the main repo root
- All worktrees (nested `.worktrees/` and external) share the same `CARGO_TARGET_DIR`

## Test plan
- [x] Verified main repo still resolves to `/Volumes/openbeta/workspace/teamclaw/.cargo-target`
- [x] Verified nested worktree (`improve-opencode-startup`) resolves to main repo's `.cargo-target`
- [x] Verified external worktree (`teamclaw-super-agent`) resolves to main repo's `.cargo-target`

🤖 Generated with [Claude Code](https://claude.com/claude-code)