### PR TITLE
chore: reset build.config.json to open-source defaults

### DIFF
--- a/build.config.json
+++ b/build.config.json
@@ -10,8 +10,8 @@
   },
   "app": {
     "name": "TeamClaw",
-    "shortName": "ac360",
-    "uiVariant": "workspace"
+    "shortName": "teamclaw",
+    "uiVariant": "default"
   },
   "features": {
     "advancedMode": true,


### PR DESCRIPTION
## Summary
- Reset `shortName` from `ac360` to `teamclaw`
- Reset `uiVariant` from `workspace` to `default`
- Production builds now fully replace this file via `BUILD_CONFIG_PRODUCTION` secret (see d8e81d4), so repo defaults are for open-source/dev use only

## Test plan
- [ ] `pnpm dev` starts with default config

🤖 Generated with [Claude Code](https://claude.com/claude-code)