### PR TITLE
fix: decouple device ID from P2P state, fix S3 role display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclaw",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "private": true,
   "description": "TeamClaw - AI Agent Desktop Platform",
   "scripts": {

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -83,6 +83,7 @@ export function TeamOSSConfig() {
   } = useTeamOssStore()
 
   const teamMembersStore = useTeamMembersStore()
+  const myRole = useTeamMembersStore((s) => s.myRole)
 
   // Create team form
   const [teamName, setTeamName] = useState('')
@@ -258,7 +259,7 @@ export function TeamOSSConfig() {
   const teamModeType = useTeamModeStore((s) => s.teamModeType)
   const configuredAsOss = configured || teamModeType === 'oss'
 
-  const isOwner = teamInfo?.role === 'owner' || teamInfo?.role === 'admin'
+  const isOwner = myRole === 'owner' || myRole === 'manager'
 
   return (
     <div className="space-y-4">
@@ -484,7 +485,9 @@ export function TeamOSSConfig() {
                 <span className="text-muted-foreground">角色</span>
                 <div className="flex items-center gap-1.5">
                   <Shield className="h-3.5 w-3.5 text-muted-foreground" />
-                  <span className="font-medium">{isOwner ? '管理员' : '成员'}</span>
+                  <span className="font-medium">
+                    {myRole === 'owner' ? '管理员' : myRole === 'manager' ? '经理' : myRole === 'editor' ? '编辑' : myRole === 'viewer' ? '只读' : '成员'}
+                  </span>
                 </div>
               </div>
               {deviceInfo && (

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "teamclaw"
-version = "0.1.42"
+version = "0.1.43"
 description = "TeamClaw - AI Agent Desktop Platform"
 authors = ["TeamClaw Team"]
 edition = "2021"

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -1,8 +1,5 @@
 use crate::commands::oss_sync::*;
 use crate::commands::oss_types::*;
-use crate::commands::p2p_state::IrohState;
-#[cfg(feature = "p2p")]
-use crate::commands::team_p2p::get_node_id;
 #[allow(unused_imports)]
 use crate::commands::TEAMCLAW_DIR;
 
@@ -17,19 +14,9 @@ use tracing::{info, warn};
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Get a stable device identity for OSS operations.
-/// Prefers the P2P node ID when the node is running, otherwise derives the
-/// Get the device ID (iroh node_id). If the P2P node is running, reads from
-/// the live node; otherwise derives from the persisted secret key on disk.
-async fn get_p2p_node_id(iroh_state: &State<'_, IrohState>) -> Result<String, String> {
-    let guard = iroh_state.lock().await;
-    #[cfg(feature = "p2p")]
-    {
-        if let Some(node) = guard.as_ref() {
-            return Ok(get_node_id(node));
-        }
-    }
-    drop(guard);
+/// Get the canonical device ID (iroh node_id derived from the persisted secret key).
+/// This is independent of whether the P2P node is running.
+fn get_p2p_node_id_sync() -> Result<String, String> {
     get_device_id()
 }
 
@@ -177,7 +164,7 @@ fn generate_team_secret() -> Result<String, String> {
 #[tauri::command]
 pub async fn oss_create_team(
     state: State<'_, OssSyncState>,
-    iroh_state: State<'_, IrohState>,
+
     app_handle: tauri::AppHandle,
     workspace_path: String,
     team_name: String,
@@ -189,7 +176,7 @@ pub async fn oss_create_team(
     llm_model: Option<String>,
     llm_model_name: Option<String>,
 ) -> Result<OssTeamInfo, String> {
-    let node_id = get_p2p_node_id(&iroh_state).await?;
+    let node_id = get_p2p_node_id_sync()?;
     let team_secret = generate_team_secret()?;
 
     // Write LLM config to .teamclaw/teamclaw.json
@@ -405,7 +392,7 @@ pub async fn oss_create_team(
 #[tauri::command]
 pub async fn oss_join_team(
     state: State<'_, OssSyncState>,
-    iroh_state: State<'_, IrohState>,
+
     app_handle: tauri::AppHandle,
     workspace_path: String,
     team_id: String,
@@ -416,7 +403,7 @@ pub async fn oss_join_team(
     llm_model: Option<String>,
     llm_model_name: Option<String>,
 ) -> Result<OssJoinResult, String> {
-    let node_id = get_p2p_node_id(&iroh_state).await?;
+    let node_id = get_p2p_node_id_sync()?;
 
     // Create manager and call FC /token
     let mut manager = OssSyncManager::new(
@@ -629,7 +616,7 @@ pub async fn oss_join_team(
 #[tauri::command]
 pub async fn oss_restore_sync(
     state: State<'_, OssSyncState>,
-    iroh_state: State<'_, IrohState>,
+
     app_handle: tauri::AppHandle,
     workspace_path: String,
     team_id: String,
@@ -638,7 +625,7 @@ pub async fn oss_restore_sync(
     info!("[OssRestore] Starting oss_restore_sync for team {}", team_id);
     let team_secret = load_team_secret(&workspace_path, &team_id)?;
     info!("[OssRestore] team_secret loaded ({:.1}ms)", t0.elapsed().as_secs_f64() * 1000.0);
-    let node_id = get_p2p_node_id(&iroh_state).await?;
+    let node_id = get_p2p_node_id_sync()?;
     info!("[OssRestore] Got node_id ({:.1}ms)", t0.elapsed().as_secs_f64() * 1000.0);
 
     // Read existing config for team_endpoint and poll_interval
@@ -1054,7 +1041,7 @@ pub async fn oss_get_team_config(workspace_path: String) -> Result<Option<OssTea
 
 #[tauri::command]
 pub async fn oss_apply_team(
-    iroh_state: State<'_, IrohState>,
+
     workspace_path: String,
     team_id: String,
     team_secret: String,
@@ -1064,7 +1051,7 @@ pub async fn oss_apply_team(
     email: String,
     note: String,
 ) -> Result<(), String> {
-    let node_id = get_p2p_node_id(&iroh_state).await?;
+    let node_id = get_p2p_node_id_sync()?;
 
     // Get device info for the application
     let hostname = gethostname::gethostname().to_string_lossy().to_string();

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -113,21 +113,15 @@ fn team_repo_dir() -> &'static str {
 // ─── Tauri Commands ─────────────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_device_info(
-    iroh_state: tauri::State<'_, IrohState>,
-) -> Result<DeviceInfo, String> {
-    let guard = iroh_state.lock().await;
-    let node = guard.as_ref().ok_or("P2P node not running")?;
+pub fn get_device_info() -> Result<DeviceInfo, String> {
     let mut info = get_device_metadata();
-    info.node_id = get_node_id(node);
+    info.node_id = super::oss_commands::get_device_id()?;
     Ok(info)
 }
 
 #[tauri::command]
-pub async fn get_device_node_id(iroh_state: tauri::State<'_, IrohState>) -> Result<String, String> {
-    let guard = iroh_state.lock().await;
-    let node = guard.as_ref().ok_or("P2P node not running")?;
-    Ok(get_node_id(node))
+pub fn get_device_node_id() -> Result<String, String> {
+    super::oss_commands::get_device_id()
 }
 
 #[tauri::command]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClaw",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "identifier": "com.teamclaw.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclaw/app dev",


### PR DESCRIPTION
## Summary
- **Device ID 完全解耦 P2P**: `get_device_info`/`get_device_node_id` 直接从磁盘密钥文件读取 iroh node ID，不再依赖 P2P node 是否运行。S3 模式加入团队前也能显示 Device ID。
- **移除 OSS 命令的 iroh_state 依赖**: `oss_create_team`、`oss_join_team`、`oss_restore_sync`、`oss_apply_team` 不再需要 `iroh_state` 参数。
- **修复 S3 角色显示**: 使用 `myRole`（manifest 查找）替代 `teamInfo.role`（FC 响应），确保角色显示与 Add Member 权限一致。显示细化为 管理员/经理/编辑/只读。

## Test plan
- [ ] S3 模式下，加入团队前确认 Device ID 正常显示
- [ ] S3 模式下，Owner 角色显示"管理员"，可 Add Member
- [ ] S3 模式下，Viewer 角色显示"只读"，不可 Add Member
- [ ] P2P 模式下，Device ID 正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)