### PR TITLE
fix(ios): polish mobile client — upsert sync, shared ModelContext, SSE parsing

### DIFF
--- a/TeamClawMobile/TeamClawMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TeamClawMobile/TeamClawMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4935055a2f7ebee01067e43f0bbcc660aec2d6f53236158b9b2c600b3f624086",
+  "originHash" : "8efdc3278a25409c14848734f85b745e0e586d4d6b79ed2d69daf16e28397581",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -53,6 +53,15 @@
       "state" : {
         "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
         "version" : "0.7.3"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "a008af1a102ff3dd6cc3764bb69bf63226d0f5f6",
+        "version" : "1.36.1"
       }
     }
   ],

--- a/TeamClawMobile/TeamClawMobile/App/ContentView.swift
+++ b/TeamClawMobile/TeamClawMobile/App/ContentView.swift
@@ -6,13 +6,11 @@ struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
 
     @StateObject private var connectionMonitor: ConnectionMonitor
-
-    private let mqttService: MQTTServiceProtocol
+    @State private var hasRequestedInitialData = false
 
     init(pairingManager: PairingManager) {
         self.pairingManager = pairingManager
         let mqtt = MQTTService()
-        self.mqttService = mqtt
         self._connectionMonitor = StateObject(wrappedValue: ConnectionMonitor(mqttService: mqtt))
 
         if pairingManager.isPaired {
@@ -29,22 +27,27 @@ struct ContentView: View {
         Group {
             if pairingManager.isPaired {
                 SessionListView(
-                    mqttService: mqttService,
+                    mqttService: connectionMonitor.mqttService,
                     connectionMonitor: connectionMonitor,
-                    pairingManager: pairingManager
+                    pairingManager: pairingManager,
+                    modelContext: modelContext
                 )
             } else {
                 PairingView(pairingManager: pairingManager)
             }
         }
-        .onReceive(mqttService.isConnected) { connected in
+        .onChange(of: connectionMonitor.isMQTTConnected) { _, connected in
             guard connected, let creds = pairingManager.credentials else { return }
             subscribeTopics(creds: creds)
-            requestInitialData(creds: creds)
+            if !hasRequestedInitialData {
+                hasRequestedInitialData = true
+                requestInitialData(creds: creds)
+            }
         }
         .onChange(of: pairingManager.isPaired) { _, paired in
             if paired {
-                guard let mqtt = mqttService as? MQTTService else { return }
+                hasRequestedInitialData = false
+                guard let mqtt = connectionMonitor.mqttService as? MQTTService else { return }
                 mqtt.connect(
                     host: PairingManager.sharedHost,
                     port: PairingManager.sharedPort,
@@ -52,55 +55,45 @@ struct ContentView: View {
                     password: PairingManager.sharedPassword
                 )
             } else {
-                // Unpaired — clear all cached data
                 clearAllData()
-                (mqttService as? MQTTService)?.disconnect()
+                (connectionMonitor.mqttService as? MQTTService)?.disconnect()
             }
         }
     }
 
     private func subscribeTopics(creds: PairingCredentials) {
-        mqttService.subscribe(
-            topic: "teamclaw/\(creds.teamID)/\(creds.desktopDeviceID)/status",
-            qos: 1
-        )
-        mqttService.subscribe(
-            topic: "teamclaw/\(creds.teamID)/\(creds.deviceID)/chat/res",
-            qos: 1
-        )
-        mqttService.subscribe(topic: "teamclaw/\(creds.teamID)/\(creds.deviceID)/task",   qos: 1)
-        mqttService.subscribe(topic: "teamclaw/\(creds.teamID)/\(creds.deviceID)/skill",  qos: 1)
-        mqttService.subscribe(topic: "teamclaw/\(creds.teamID)/\(creds.deviceID)/member", qos: 1)
-        mqttService.subscribe(topic: "teamclaw/\(creds.teamID)/\(creds.deviceID)/talent", qos: 1)
+        let mqtt = connectionMonitor.mqttService
+        mqtt.subscribe(topic: "teamclaw/\(creds.teamID)/\(creds.desktopDeviceID)/status", qos: 1)
+        mqtt.subscribe(topic: "teamclaw/\(creds.teamID)/\(creds.deviceID)/chat/res", qos: 1)
+        mqtt.subscribe(topic: "teamclaw/\(creds.teamID)/\(creds.deviceID)/task",     qos: 1)
+        mqtt.subscribe(topic: "teamclaw/\(creds.teamID)/\(creds.deviceID)/skill",    qos: 1)
+        mqtt.subscribe(topic: "teamclaw/\(creds.teamID)/\(creds.deviceID)/member",   qos: 1)
+        mqtt.subscribe(topic: "teamclaw/\(creds.teamID)/\(creds.deviceID)/talent",   qos: 1)
     }
 
-    /// Request initial data after MQTT connection is established.
     private func requestInitialData(creds: PairingCredentials) {
+        let mqtt = connectionMonitor.mqttService
         let topic = "teamclaw/\(creds.teamID)/\(creds.deviceID)/chat/req"
 
-        // Sessions
         var sessionReq = Teamclaw_SessionSyncRequest()
         var pg1 = Teamclaw_PageRequest()
         pg1.page = 1; pg1.pageSize = 50
         sessionReq.pagination = pg1
-        mqttService.publish(topic: topic, message: ProtoMQTTCoder.makeEnvelope(.sessionSyncRequest(sessionReq)), qos: 1)
+        mqtt.publish(topic: topic, message: ProtoMQTTCoder.makeEnvelope(.sessionSyncRequest(sessionReq)), qos: 1)
 
-        // Members
         var memberReq = Teamclaw_MemberSyncRequest()
         var pg2 = Teamclaw_PageRequest()
         pg2.page = 1; pg2.pageSize = 50
         memberReq.pagination = pg2
-        mqttService.publish(topic: topic, message: ProtoMQTTCoder.makeEnvelope(.memberSyncRequest(memberReq)), qos: 1)
+        mqtt.publish(topic: topic, message: ProtoMQTTCoder.makeEnvelope(.memberSyncRequest(memberReq)), qos: 1)
 
-        // Automations
         var autoReq = Teamclaw_AutomationSyncRequest()
         var pg3 = Teamclaw_PageRequest()
         pg3.page = 1; pg3.pageSize = 50
         autoReq.pagination = pg3
-        mqttService.publish(topic: topic, message: ProtoMQTTCoder.makeEnvelope(.automationSyncRequest(autoReq)), qos: 1)
+        mqtt.publish(topic: topic, message: ProtoMQTTCoder.makeEnvelope(.automationSyncRequest(autoReq)), qos: 1)
     }
 
-    /// Clear all SwiftData when unpairing.
     private func clearAllData() {
         do {
             try modelContext.delete(model: Session.self)

--- a/TeamClawMobile/TeamClawMobile/Core/ConnectionMonitor.swift
+++ b/TeamClawMobile/TeamClawMobile/Core/ConnectionMonitor.swift
@@ -4,11 +4,25 @@ import Foundation
 final class ConnectionMonitor: ObservableObject {
 
     @Published var isDesktopOnline: Bool = false
+    @Published var isMQTTConnected: Bool = false
     @Published var desktopDeviceName: String?
+
+    /// Stable MQTTService instance — lives as long as this @StateObject.
+    let mqttService: MQTTServiceProtocol
 
     private var cancellables = Set<AnyCancellable>()
 
     init(mqttService: MQTTServiceProtocol) {
+        self.mqttService = mqttService
+
+        mqttService.isConnected
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] connected in
+                self?.isMQTTConnected = connected
+            }
+            .store(in: &cancellables)
+
         mqttService.receivedMessage
             .compactMap { msg -> Teamclaw_StatusReport? in
                 if case .statusReport(let status) = msg.payload { return status }

--- a/TeamClawMobile/TeamClawMobile/Core/MQTT/MQTTService.swift
+++ b/TeamClawMobile/TeamClawMobile/Core/MQTT/MQTTService.swift
@@ -38,7 +38,11 @@ final class MQTTService: NSObject, MQTTServiceProtocol {
     }
 
     func publish(topic: String, message: Teamclaw_MqttMessage, qos: Int) {
-        guard let data = ProtoMQTTCoder.encode(message) else { return }
+        guard let data = ProtoMQTTCoder.encode(message) else {
+            NSLog("[MQTT ⬆️] ENCODE FAILED topic=%@", topic)
+            return
+        }
+        NSLog("[MQTT ⬆️] topic=%@ size=%d payload=%@", topic, data.count, ProtoMQTTCoder.summary(message))
         let q: CocoaMQTTQoS = qos == 0 ? .qos0 : qos == 2 ? .qos2 : .qos1
         let props = MqttPublishProperties()
         let message5 = CocoaMQTT5Message(topic: topic, payload: [UInt8](data))
@@ -49,22 +53,32 @@ final class MQTTService: NSObject, MQTTServiceProtocol {
 
 extension MQTTService: CocoaMQTT5Delegate {
     func mqtt5(_ mqtt5: CocoaMQTT5, didConnectAck ack: CocoaMQTTCONNACKReasonCode, connAckData: MqttDecodeConnAck?) {
+        NSLog("[MQTT] didConnectAck: %d (%@)", ack.rawValue, ack == .success ? "success" : "failed")
         connectedSubject.send(ack == .success)
     }
 
     func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveMessage message: CocoaMQTT5Message, id: UInt16, publishData: MqttDecodePublish?) {
         let data = Data(message.payload)
-        dataSubject.send((topic: message.topic, data: data))
         if let msg = ProtoMQTTCoder.decode(data) {
+            NSLog("[MQTT ⬇️] topic=%@ size=%d payload=%@", message.topic, data.count, ProtoMQTTCoder.summary(msg))
+            dataSubject.send((topic: message.topic, data: data))
             messageSubject.send(msg)
+        } else {
+            NSLog("[MQTT ⬇️] topic=%@ size=%d DECODE FAILED", message.topic, data.count)
+            dataSubject.send((topic: message.topic, data: data))
         }
     }
 
-    func mqtt5DidDisconnect(_ mqtt5: CocoaMQTT5, withError err: Error?) { connectedSubject.send(false) }
+    func mqtt5DidDisconnect(_ mqtt5: CocoaMQTT5, withError err: Error?) {
+        NSLog("[MQTT] disconnected error=%@", String(describing: err))
+        connectedSubject.send(false)
+    }
     func mqtt5(_ mqtt5: CocoaMQTT5, didPublishMessage message: CocoaMQTT5Message, id: UInt16) {}
     func mqtt5(_ mqtt5: CocoaMQTT5, didPublishAck id: UInt16, pubAckData: MqttDecodePubAck?) {}
     func mqtt5(_ mqtt5: CocoaMQTT5, didPublishRec id: UInt16, pubRecData: MqttDecodePubRec?) {}
-    func mqtt5(_ mqtt5: CocoaMQTT5, didSubscribeTopics success: NSDictionary, failed: [String], subAckData: MqttDecodeSubAck?) {}
+    func mqtt5(_ mqtt5: CocoaMQTT5, didSubscribeTopics success: NSDictionary, failed: [String], subAckData: MqttDecodeSubAck?) {
+        NSLog("[MQTT] subscribed success=%@ failed=%@", success, failed)
+    }
     func mqtt5(_ mqtt5: CocoaMQTT5, didUnsubscribeTopics topics: [String], unsubAckData: MqttDecodeUnsubAck?) {}
     func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveDisconnectReasonCode reasonCode: CocoaMQTTDISCONNECTReasonCode) {}
     func mqtt5(_ mqtt5: CocoaMQTT5, didReceiveAuthReasonCode reasonCode: CocoaMQTTAUTHReasonCode) {}

--- a/TeamClawMobile/TeamClawMobile/Core/MQTT/ProtoMQTTCoder.swift
+++ b/TeamClawMobile/TeamClawMobile/Core/MQTT/ProtoMQTTCoder.swift
@@ -18,4 +18,33 @@ enum ProtoMQTTCoder {
         msg.payload = payload
         return msg
     }
+
+    static func summary(_ msg: Teamclaw_MqttMessage) -> String {
+        let type: String
+        switch msg.payload {
+        case .sessionSyncRequest(let r):  type = "SessionSyncReq(page=\(r.pagination.page))"
+        case .sessionSyncResponse(let r): type = "SessionSyncRes(sessions=\(r.sessions.count), page=\(r.pagination.page)/total=\(r.pagination.total))"
+        case .chatRequest(let r):         type = "ChatReq(session=\(r.sessionID.prefix(8)))"
+        case .chatResponse(let r):        type = "ChatRes(session=\(r.sessionID.prefix(8)), seq=\(r.seq))"
+        case .chatCancel(let r):          type = "ChatCancel(session=\(r.sessionID.prefix(8)))"
+        case .memberSyncRequest(let r):   type = "MemberSyncReq(page=\(r.pagination.page))"
+        case .memberSyncResponse(let r):  type = "MemberSyncRes(members=\(r.members.count))"
+        case .automationSyncRequest(let r):  type = "AutoSyncReq(page=\(r.pagination.page))"
+        case .automationSyncResponse(let r): type = "AutoSyncRes(tasks=\(r.tasks.count))"
+        case .skillSyncRequest:              type = "SkillSyncReq"
+        case .skillSyncResponse(let r):      type = "SkillSyncRes(skills=\(r.skills.count))"
+        case .talentSyncRequest:             type = "TalentSyncReq"
+        case .talentSyncResponse(let r):     type = "TalentSyncRes(talents=\(r.talents.count))"
+        case .taskUpdate(let r):             type = "TaskUpdate(task=\(r.taskID.prefix(8)),status=\(r.status))"
+        case .messageSyncRequest(let r):     type = "MsgSyncReq(session=\(r.sessionID.prefix(8)))"
+        case .messageSyncResponse(let r):    type = "MsgSyncRes(msgs=\(r.messages.count))"
+        case .statusReport(let s):           type = "StatusReport(online=\(s.online))"
+        case .pairingRequest:               type = "PairingReq"
+        case .pairingResponse:              type = "PairingRes"
+        case .pairingDiscovery:             type = "PairingDiscovery"
+        case .none:                         type = "nil"
+        default:                            type = "unknown(\(String(describing: msg.payload).prefix(40)))"
+        }
+        return "id=\(msg.id.prefix(8)) \(type)"
+    }
 }

--- a/TeamClawMobile/TeamClawMobile/Features/Automation/TaskViewModel.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Automation/TaskViewModel.swift
@@ -6,19 +6,25 @@ import SwiftData
 final class TaskViewModel: ObservableObject {
 
     @Published var tasks: [AutomationTask] = []
+    @Published private(set) var isDesktopOnline: Bool = false
 
     private let modelContext: ModelContext
     private let mqttService: MQTTServiceProtocol
     private var cancellables = Set<AnyCancellable>()
 
+    /// IDs received across all pages of the current sync cycle.
+    private var receivedIDs: Set<String> = []
+
     init(modelContext: ModelContext, mqttService: MQTTServiceProtocol) {
         self.modelContext = modelContext
         self.mqttService = mqttService
         subscribeToMQTT()
+        subscribeToStatus()
+        loadTasksFromDB()
     }
 
     func loadTasks() {
-        loadTasksFromDB()
+        guard isDesktopOnline else { return }
         requestAutomations(page: 1)
     }
 
@@ -95,16 +101,16 @@ final class TaskViewModel: ObservableObject {
 
     private func handleAutomationSync(_ response: Teamclaw_AutomationSyncResponse) {
         let pg = response.pagination
+
+        // Don't wipe cache when server returns empty
+        guard !response.tasks.isEmpty || pg.total > 0 else { return }
+
         let isFirstPage = pg.page <= 1
+        if isFirstPage { receivedIDs.removeAll() }
 
-        if isFirstPage {
-            let descriptor = FetchDescriptor<AutomationTask>()
-            if let existing = try? modelContext.fetch(descriptor) {
-                for task in existing { modelContext.delete(task) }
-            }
-        }
-
+        // Upsert: @Attribute(.unique) on id makes insert act as upsert
         for data in response.tasks {
+            receivedIDs.insert(data.id)
             let task = AutomationTask(
                 id: data.id,
                 name: data.name,
@@ -116,14 +122,33 @@ final class TaskViewModel: ObservableObject {
             modelContext.insert(task)
         }
 
-        try? modelContext.save()
-
         let hasMore = pg.total > pg.page * pg.pageSize
         if hasMore {
             requestAutomations(page: Int(pg.page) + 1)
         } else {
+            // Remove stale tasks not present in this sync cycle
+            let descriptor = FetchDescriptor<AutomationTask>()
+            if let existing = try? modelContext.fetch(descriptor) {
+                for task in existing where !receivedIDs.contains(task.id) {
+                    modelContext.delete(task)
+                }
+            }
+            try? modelContext.save()
             loadTasksFromDB()
         }
+    }
+
+    private func subscribeToStatus() {
+        mqttService.receivedMessage
+            .compactMap { msg -> Teamclaw_StatusReport? in
+                if case .statusReport(let status) = msg.payload { return status }
+                return nil
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                self?.isDesktopOnline = status.online
+            }
+            .store(in: &cancellables)
     }
 
     private func loadTasksFromDB() {

--- a/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailView.swift
@@ -44,18 +44,17 @@ struct ChatDetailView: View {
     let session: Session
     let mqttService: MQTTServiceProtocol
 
-    @Environment(\.modelContext) private var modelContext
     @StateObject private var viewModel: ChatDetailViewModel
 
     @State private var showModelPicker = false
     @State private var scrollProxy: ScrollViewProxy?
 
-    init(session: Session, mqttService: MQTTServiceProtocol) {
+    init(session: Session, mqttService: MQTTServiceProtocol, modelContext: ModelContext) {
         self.session = session
         self.mqttService = mqttService
         _viewModel = StateObject(wrappedValue: ChatDetailViewModel(
             sessionID: session.id,
-            modelContext: ModelContext(try! ModelContainer(for: ChatMessage.self)),
+            modelContext: modelContext,
             mqttService: mqttService
         ))
     }
@@ -203,7 +202,7 @@ struct ChatDetailView: View {
     let mockMQTT = MockMQTTService()
 
     return NavigationStack {
-        ChatDetailView(session: session, mqttService: mockMQTT)
+        ChatDetailView(session: session, mqttService: mockMQTT, modelContext: context)
     }
     .modelContainer(container)
 }

--- a/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailViewModel.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailViewModel.swift
@@ -49,8 +49,8 @@ final class ChatDetailViewModel: ObservableObject {
             messages = []
         }
 
-        // If no local messages, request history from Desktop
-        if messages.isEmpty {
+        // If no local messages and desktop is online, request history
+        if messages.isEmpty && isDesktopOnline {
             requestMessageHistory()
         }
     }
@@ -166,6 +166,8 @@ final class ChatDetailViewModel: ObservableObject {
 
         for data in response.messages {
             guard !existingIDs.contains(data.id) else { continue }
+            // Skip empty messages (e.g. tool_use only)
+            guard !data.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
             let role: MessageRole = data.role == "assistant" ? .assistant : .user
             let message = ChatMessage(
                 id: data.id,

--- a/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListView.swift
@@ -18,14 +18,12 @@ struct SessionListView: View {
     @State private var isSearchActive = false
     @FocusState private var searchFocused: Bool
 
-    init(mqttService: MQTTServiceProtocol, connectionMonitor: ConnectionMonitor, pairingManager: PairingManager) {
+    init(mqttService: MQTTServiceProtocol, connectionMonitor: ConnectionMonitor, pairingManager: PairingManager, modelContext: ModelContext) {
         self.mqttService = mqttService
         self.connectionMonitor = connectionMonitor
         self.pairingManager = pairingManager
-        // Use shared app container so data persists correctly
-        let container = try! ModelContainer(for: Session.self, ChatMessage.self, TeamMember.self, AutomationTask.self, Skill.self)
         _viewModel = StateObject(wrappedValue: SessionListViewModel(
-            modelContext: ModelContext(container),
+            modelContext: modelContext,
             mqttService: mqttService
         ))
     }
@@ -84,7 +82,7 @@ struct SessionListView: View {
             }
             .navigationDestination(for: String.self) { sessionID in
                 if let session = viewModel.sessions.first(where: { $0.id == sessionID }) {
-                    ChatDetailView(session: session, mqttService: mqttService)
+                    ChatDetailView(session: session, mqttService: mqttService, modelContext: modelContext)
                 } else {
                     Text("Session not found")
                 }
@@ -326,6 +324,6 @@ struct SessionRowView: View {
     let mockMQTT = MockMQTTService()
     let monitor = ConnectionMonitor(mqttService: mockMQTT)
 
-    return SessionListView(mqttService: mockMQTT, connectionMonitor: monitor, pairingManager: PairingManager())
+    return SessionListView(mqttService: mockMQTT, connectionMonitor: monitor, pairingManager: PairingManager(), modelContext: context)
         .modelContainer(container)
 }

--- a/TeamClawMobile/TeamClawMobile/Features/Skills/SkillViewModel.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Skills/SkillViewModel.swift
@@ -7,19 +7,25 @@ final class SkillViewModel: ObservableObject {
 
     @Published var personalSkills: [Skill] = []
     @Published var teamSkills: [Skill] = []
+    @Published private(set) var isDesktopOnline: Bool = false
 
     private let modelContext: ModelContext
     private let mqttService: MQTTServiceProtocol
     private var cancellables = Set<AnyCancellable>()
 
+    /// IDs received across all pages of the current sync cycle.
+    private var receivedIDs: Set<String> = []
+
     init(modelContext: ModelContext, mqttService: MQTTServiceProtocol) {
         self.modelContext = modelContext
         self.mqttService = mqttService
         subscribeToMQTT()
+        subscribeToStatus()
+        loadSkillsFromDB()
     }
 
     func loadSkills() {
-        loadSkillsFromDB()
+        guard isDesktopOnline else { return }
         requestSkills(page: 1)
     }
 
@@ -50,16 +56,16 @@ final class SkillViewModel: ObservableObject {
 
     private func handleSkillSync(_ response: Teamclaw_SkillSyncResponse) {
         let pg = response.pagination
+
+        // Don't wipe cache when server returns empty
+        guard !response.skills.isEmpty || pg.total > 0 else { return }
+
         let isFirstPage = pg.page <= 1
+        if isFirstPage { receivedIDs.removeAll() }
 
-        if isFirstPage {
-            let descriptor = FetchDescriptor<Skill>()
-            if let existing = try? modelContext.fetch(descriptor) {
-                for skill in existing { modelContext.delete(skill) }
-            }
-        }
-
+        // Upsert: @Attribute(.unique) on id makes insert act as upsert
         for data in response.skills {
+            receivedIDs.insert(data.id)
             let skill = Skill(
                 id: data.id,
                 name: data.name,
@@ -70,14 +76,33 @@ final class SkillViewModel: ObservableObject {
             modelContext.insert(skill)
         }
 
-        try? modelContext.save()
-
         let hasMore = pg.total > pg.page * pg.pageSize
         if hasMore {
             requestSkills(page: Int(pg.page) + 1)
         } else {
+            // Remove stale skills not present in this sync cycle
+            let descriptor = FetchDescriptor<Skill>()
+            if let existing = try? modelContext.fetch(descriptor) {
+                for skill in existing where !receivedIDs.contains(skill.id) {
+                    modelContext.delete(skill)
+                }
+            }
+            try? modelContext.save()
             loadSkillsFromDB()
         }
+    }
+
+    private func subscribeToStatus() {
+        mqttService.receivedMessage
+            .compactMap { msg -> Teamclaw_StatusReport? in
+                if case .statusReport(let status) = msg.payload { return status }
+                return nil
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                self?.isDesktopOnline = status.online
+            }
+            .store(in: &cancellables)
     }
 
     private func loadSkillsFromDB() {

--- a/TeamClawMobile/TeamClawMobile/Features/TeamMembers/FeaturedAllyView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/TeamMembers/FeaturedAllyView.swift
@@ -7,7 +7,13 @@ struct FeaturedAllyView: View {
     var body: some View {
         NavigationStack {
             Group {
-                if viewModel.talents.isEmpty {
+                if !viewModel.isDesktopOnline && viewModel.talents.isEmpty {
+                    ContentUnavailableView(
+                        "桌面端离线",
+                        systemImage: "wifi.slash",
+                        description: Text("连接桌面端后查看精选搭档")
+                    )
+                } else if viewModel.talents.isEmpty {
                     ContentUnavailableView("暂无精选搭档", systemImage: "cpu")
                 } else {
                     List(viewModel.talents, id: \.id) { talent in
@@ -42,7 +48,13 @@ struct FeaturedAllyListView: View {
 
     var body: some View {
         Group {
-            if viewModel.talents.isEmpty {
+            if !viewModel.isDesktopOnline && viewModel.talents.isEmpty {
+                ContentUnavailableView(
+                    "桌面端离线",
+                    systemImage: "wifi.slash",
+                    description: Text("连接桌面端后查看精选搭档")
+                )
+            } else if viewModel.talents.isEmpty {
                 ContentUnavailableView("暂无精选搭档", systemImage: "cpu")
             } else {
                 List(viewModel.talents, id: \.id) { talent in

--- a/TeamClawMobile/TeamClawMobile/Features/TeamMembers/MemberViewModel.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/TeamMembers/MemberViewModel.swift
@@ -6,6 +6,7 @@ import SwiftData
 final class MemberViewModel: ObservableObject {
 
     @Published var members: [TeamMember] = []
+    @Published private(set) var isDesktopOnline: Bool = false
 
     private let modelContext: ModelContext
     private let mqttService: MQTTServiceProtocol
@@ -15,10 +16,12 @@ final class MemberViewModel: ObservableObject {
         self.modelContext = modelContext
         self.mqttService = mqttService
         subscribeToMQTT()
+        subscribeToStatus()
+        loadMembersFromDB()
     }
 
     func loadMembers() {
-        loadMembersFromDB()
+        guard isDesktopOnline else { return }
         requestMembers(page: 1)
     }
 
@@ -53,18 +56,21 @@ final class MemberViewModel: ObservableObject {
             .store(in: &cancellables)
     }
 
+    /// IDs received across all pages of the current sync cycle.
+    private var receivedIDs: Set<String> = []
+
     private func handleMemberSync(_ response: Teamclaw_MemberSyncResponse) {
         let pg = response.pagination
+
+        // Don't wipe cached members when server returns empty first page
+        guard !response.members.isEmpty || pg.total > 0 else { return }
+
         let isFirstPage = pg.page <= 1
+        if isFirstPage { receivedIDs.removeAll() }
 
-        if isFirstPage {
-            let descriptor = FetchDescriptor<TeamMember>()
-            if let existing = try? modelContext.fetch(descriptor) {
-                for member in existing { modelContext.delete(member) }
-            }
-        }
-
+        // Upsert: @Attribute(.unique) on id makes insert act as upsert
         for data in response.members {
+            receivedIDs.insert(data.id)
             let member = TeamMember(
                 id: data.id,
                 name: data.name,
@@ -76,14 +82,33 @@ final class MemberViewModel: ObservableObject {
             modelContext.insert(member)
         }
 
-        try? modelContext.save()
-
         let hasMore = pg.total > pg.page * pg.pageSize
         if hasMore {
             requestMembers(page: Int(pg.page) + 1)
         } else {
+            // Remove stale members not present in this sync cycle
+            let descriptor = FetchDescriptor<TeamMember>()
+            if let existing = try? modelContext.fetch(descriptor) {
+                for member in existing where !receivedIDs.contains(member.id) {
+                    modelContext.delete(member)
+                }
+            }
+            try? modelContext.save()
             loadMembersFromDB()
         }
+    }
+
+    private func subscribeToStatus() {
+        mqttService.receivedMessage
+            .compactMap { msg -> Teamclaw_StatusReport? in
+                if case .statusReport(let status) = msg.payload { return status }
+                return nil
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                self?.isDesktopOnline = status.online
+            }
+            .store(in: &cancellables)
     }
 
     private func loadMembersFromDB() {

--- a/TeamClawMobile/TeamClawMobile/Features/TeamMembers/SkillMarketView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/TeamMembers/SkillMarketView.swift
@@ -7,7 +7,13 @@ struct SkillMarketView: View {
     var body: some View {
         NavigationStack {
             Group {
-                if viewModel.personalSkills.isEmpty && viewModel.teamSkills.isEmpty {
+                if !viewModel.isDesktopOnline && viewModel.personalSkills.isEmpty && viewModel.teamSkills.isEmpty {
+                    ContentUnavailableView(
+                        "桌面端离线",
+                        systemImage: "wifi.slash",
+                        description: Text("连接桌面端后浏览技能市场")
+                    )
+                } else if viewModel.personalSkills.isEmpty && viewModel.teamSkills.isEmpty {
                     ContentUnavailableView("暂无技能", systemImage: "puzzlepiece")
                 } else {
                     skillList
@@ -43,7 +49,13 @@ struct SkillMarketListView: View {
 
     var body: some View {
         Group {
-            if viewModel.personalSkills.isEmpty && viewModel.teamSkills.isEmpty {
+            if !viewModel.isDesktopOnline && viewModel.personalSkills.isEmpty && viewModel.teamSkills.isEmpty {
+                ContentUnavailableView(
+                    "桌面端离线",
+                    systemImage: "wifi.slash",
+                    description: Text("连接桌面端后浏览技能市场")
+                )
+            } else if viewModel.personalSkills.isEmpty && viewModel.teamSkills.isEmpty {
                 ContentUnavailableView("暂无技能", systemImage: "puzzlepiece")
             } else {
                 let allSkills = viewModel.personalSkills + viewModel.teamSkills

--- a/TeamClawMobile/TeamClawMobile/Features/TeamMembers/TalentViewModel.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/TeamMembers/TalentViewModel.swift
@@ -6,19 +6,24 @@ import SwiftData
 final class TalentViewModel: ObservableObject {
 
     @Published var talents: [Talent] = []
+    @Published private(set) var isDesktopOnline: Bool = false
 
     private let modelContext: ModelContext
     private let mqttService: MQTTServiceProtocol
     private var cancellables = Set<AnyCancellable>()
 
+    /// IDs received across all pages of the current sync cycle.
+    private var receivedIDs: Set<String> = []
+
     init(modelContext: ModelContext, mqttService: MQTTServiceProtocol) {
         self.modelContext = modelContext
         self.mqttService = mqttService
         subscribeToMQTT()
+        subscribeToStatus()
     }
 
     func loadTalents() {
-        loadTalentsFromDB()
+        guard isDesktopOnline else { return }
         requestTalents(page: 1)
     }
 
@@ -49,16 +54,16 @@ final class TalentViewModel: ObservableObject {
 
     private func handleTalentSync(_ response: Teamclaw_TalentSyncResponse) {
         let pg = response.pagination
+
+        // Don't wipe cache when server returns empty
+        guard !response.talents.isEmpty || pg.total > 0 else { return }
+
         let isFirstPage = pg.page <= 1
+        if isFirstPage { receivedIDs.removeAll() }
 
-        if isFirstPage {
-            let descriptor = FetchDescriptor<Talent>()
-            if let existing = try? modelContext.fetch(descriptor) {
-                for talent in existing { modelContext.delete(talent) }
-            }
-        }
-
+        // Upsert: @Attribute(.unique) on id makes insert act as upsert
         for data in response.talents {
+            receivedIDs.insert(data.id)
             let talent = Talent(
                 id: data.id,
                 name: data.name,
@@ -73,14 +78,33 @@ final class TalentViewModel: ObservableObject {
             modelContext.insert(talent)
         }
 
-        try? modelContext.save()
-
         let hasMore = pg.total > pg.page * pg.pageSize
         if hasMore {
             requestTalents(page: Int(pg.page) + 1)
         } else {
+            // Remove stale talents not present in this sync cycle
+            let descriptor = FetchDescriptor<Talent>()
+            if let existing = try? modelContext.fetch(descriptor) {
+                for talent in existing where !receivedIDs.contains(talent.id) {
+                    modelContext.delete(talent)
+                }
+            }
+            try? modelContext.save()
             loadTalentsFromDB()
         }
+    }
+
+    private func subscribeToStatus() {
+        mqttService.receivedMessage
+            .compactMap { msg -> Teamclaw_StatusReport? in
+                if case .statusReport(let status) = msg.payload { return status }
+                return nil
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                self?.isDesktopOnline = status.online
+            }
+            .store(in: &cancellables)
     }
 
     private func loadTalentsFromDB() {

--- a/packages/app/src/stores/channels-store.ts
+++ b/packages/app/src/stores/channels-store.ts
@@ -355,6 +355,20 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
         console.error('[AutoStart] Email start failed:', error)
       }
     }
+
+    // MQTT Mobile Relay — auto-start if config exists with enabled flag
+    try {
+      const mqttConfig = await invoke<{ enabled: boolean; pairedDevices: unknown[] }>('get_mqtt_relay_config')
+      if (mqttConfig.enabled && mqttConfig.pairedDevices.length > 0) {
+        const mqttStatus = await invoke<{ connected: boolean }>('get_mqtt_relay_status')
+        if (!mqttStatus.connected) {
+          console.log('[AutoStart] Starting MQTT Mobile Relay...')
+          await invoke('start_mqtt_relay')
+        }
+      }
+    } catch (error) {
+      console.error('[AutoStart] MQTT relay start failed:', error)
+    }
   },
 
   // ========== Keep-Alive: Periodic Health Check ==========

--- a/src-tauri/src/commands/gateway/mqtt_relay.rs
+++ b/src-tauri/src/commands/gateway/mqtt_relay.rs
@@ -439,33 +439,45 @@ impl MqttRelay {
                                 let event_block = buffer[..pos].to_string();
                                 buffer = buffer[pos + 2..].to_string();
 
-                                let mut event_type = String::new();
+                                // OpenCode SSE: no `event:` line, all data in `data:` as JSON
+                                // Format: data: {"type": "message.part.delta", "properties": {...}}
                                 let mut data = String::new();
                                 for line in event_block.lines() {
-                                    if let Some(t) = line.strip_prefix("event: ") {
-                                        event_type = t.to_string();
-                                    } else if let Some(d) = line.strip_prefix("data: ") {
+                                    if let Some(d) = line.strip_prefix("data: ") {
                                         data = d.to_string();
                                     }
                                 }
 
-                                match event_type.as_str() {
-                                    "message.delta" => {
-                                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {
-                                            if let Some(text) = v.get("content").and_then(|c| c.as_str()) {
-                                                pending_delta.push_str(text);
-                                                if last_flush.elapsed() >= flush_interval && !pending_delta.is_empty() {
-                                                    let msg = build_chat_delta(session_id, seq, &pending_delta);
-                                                    self.publish_chat_response_proto(device_id, &msg).await?;
-                                                    full_content.push_str(&pending_delta);
-                                                    pending_delta.clear();
-                                                    seq += 1;
-                                                    last_flush = tokio::time::Instant::now();
-                                                }
+                                if data.is_empty() { continue; }
+
+                                let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) else { continue };
+                                let event_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                                let props = v.get("properties");
+
+                                // Filter: only process events for our session
+                                let event_sid = props
+                                    .and_then(|p| p.get("sessionID").and_then(|s| s.as_str()))
+                                    .or_else(|| props.and_then(|p| p.get("info").and_then(|i| i.get("sessionID").and_then(|s| s.as_str()))));
+                                if let Some(sid) = event_sid {
+                                    if sid != session_id { continue; }
+                                }
+
+                                match event_type {
+                                    "message.part.delta" => {
+                                        // {"type":"message.part.delta","properties":{"sessionID":"...","messageID":"...","partID":"...","field":"text","delta":"hello"}}
+                                        if let Some(text) = props.and_then(|p| p.get("delta").and_then(|d| d.as_str())) {
+                                            pending_delta.push_str(text);
+                                            if last_flush.elapsed() >= flush_interval && !pending_delta.is_empty() {
+                                                let msg = build_chat_delta(session_id, seq, &pending_delta);
+                                                self.publish_chat_response_proto(device_id, &msg).await?;
+                                                full_content.push_str(&pending_delta);
+                                                pending_delta.clear();
+                                                seq += 1;
+                                                last_flush = tokio::time::Instant::now();
                                             }
                                         }
                                     }
-                                    "message.done" => {
+                                    "message.completed" => {
                                         if !pending_delta.is_empty() {
                                             let msg = build_chat_delta(session_id, seq, &pending_delta);
                                             self.publish_chat_response_proto(device_id, &msg).await?;
@@ -475,6 +487,29 @@ impl MqttRelay {
                                         let msg = build_chat_done(session_id, seq);
                                         self.publish_chat_response_proto(device_id, &msg).await?;
                                         return Ok(());
+                                    }
+                                    "message.updated" => {
+                                        // message.updated with time.completed signals assistant message finished
+                                        let is_completed = props
+                                            .and_then(|p| p.get("info"))
+                                            .and_then(|i| i.get("time"))
+                                            .and_then(|t| t.get("completed"))
+                                            .is_some();
+                                        let is_assistant = props
+                                            .and_then(|p| p.get("info"))
+                                            .and_then(|i| i.get("role").and_then(|r| r.as_str()))
+                                            == Some("assistant");
+                                        if is_completed && is_assistant && seq > 0 {
+                                            if !pending_delta.is_empty() {
+                                                let msg = build_chat_delta(session_id, seq, &pending_delta);
+                                                self.publish_chat_response_proto(device_id, &msg).await?;
+                                                seq += 1;
+                                                pending_delta.clear();
+                                            }
+                                            let msg = build_chat_done(session_id, seq);
+                                            self.publish_chat_response_proto(device_id, &msg).await?;
+                                            return Ok(());
+                                        }
                                     }
                                     _ => {}
                                 }
@@ -513,7 +548,7 @@ impl MqttRelay {
                     .map(|s| proto::SessionData {
                         id: s.id.clone(),
                         title: s.title.clone(),
-                        updated: s.updated,
+                        updated: s.updated / 1000, // Convert ms to seconds
                     })
                     .collect();
                 let msg = build_envelope(proto::mqtt_message::Payload::SessionSyncResponse(
@@ -570,29 +605,48 @@ impl MqttRelay {
     async fn fetch_team_manifest(&self) -> Result<Option<TeamManifest>, String> {
         // Try P2P local file first (fast, no network)
         let manifest_path = format!("{}/teamclaw-team/_team/members.json", self.workspace_path);
-        if let Ok(content) = std::fs::read_to_string(&manifest_path) {
-            if let Ok(manifest) = serde_json::from_str::<TeamManifest>(&content) {
-                return Ok(Some(manifest));
+        match std::fs::read_to_string(&manifest_path) {
+            Ok(content) => match serde_json::from_str::<TeamManifest>(&content) {
+                Ok(manifest) => {
+                    return Ok(Some(manifest));
+                }
+                Err(e) => {
+                    eprintln!("[MQTT Relay] P2P members.json parse error: {}", e);
+                }
+            },
+            Err(_) => {
+                // P2P file not available — fall through to S3
             }
         }
 
         // Fallback to OSS S3 (if configured)
-        if let Some(ref oss_state) = self.oss_sync_state {
-            let mut guard = oss_state.lock().await;
-            if let Some(ref mut manager) = *guard {
-                manager.refresh_token_if_needed().await?;
-                let key = format!("teams/{}/_meta/members.json", manager.team_id());
-                match manager.s3_get(&key).await {
-                    Ok(data) => {
-                        let manifest: TeamManifest = serde_json::from_slice(&data)
-                            .map_err(|e| format!("Failed to parse OSS members.json: {}", e))?;
-                        return Ok(Some(manifest));
+        match self.oss_sync_state {
+            None => {
+                eprintln!("[MQTT Relay] No OSS sync state configured, cannot fetch members");
+            }
+            Some(ref oss_state) => {
+                let mut guard = oss_state.lock().await;
+                match *guard {
+                    None => {
+                        eprintln!("[MQTT Relay] OSS manager not initialized, cannot fetch members");
                     }
-                    Err(e) if e.contains("NoSuchKey") || e.contains("not found") => {
-                        return Ok(None);
-                    }
-                    Err(e) => {
-                        eprintln!("[MQTT Relay] OSS members fetch failed: {}", e);
+                    Some(ref mut manager) => {
+                        manager.refresh_token_if_needed().await?;
+                        let key = format!("teams/{}/_meta/members.json", manager.team_id());
+                        match manager.s3_get(&key).await {
+                            Ok(data) => {
+                                let manifest: TeamManifest = serde_json::from_slice(&data)
+                                    .map_err(|e| format!("Failed to parse OSS members.json: {}", e))?;
+                                return Ok(Some(manifest));
+                            }
+                            Err(e) if e.contains("NoSuchKey") || e.contains("not found") => {
+                                return Ok(None);
+                            }
+                            Err(e) => {
+                                eprintln!("[MQTT Relay] OSS members fetch failed: {}", e);
+                                return Err(format!("OSS members fetch failed: {}", e));
+                            }
+                        }
                     }
                 }
             }
@@ -799,18 +853,45 @@ impl MqttRelay {
                 if role != "user" && role != "assistant" { return None; }
 
                 let parts = msg.get("parts")?.as_array()?;
-                let mut text_parts: Vec<String> = Vec::new();
+                let mut content_parts: Vec<String> = Vec::new();
                 for part in parts {
-                    if part.get("type")?.as_str()? == "text" {
-                        if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                            text_parts.push(text.to_string());
+                    match part.get("type").and_then(|t| t.as_str()) {
+                        Some("text") => {
+                            if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                                content_parts.push(text.to_string());
+                            }
                         }
+                        Some("tool") => {
+                            let tool_name = part.get("tool").and_then(|t| t.as_str()).unwrap_or("tool");
+                            let input_summary = part.get("state")
+                                .and_then(|s| s.get("input"))
+                                .map(|input| {
+                                    // For websearch/webfetch, show the query/url
+                                    if let Some(q) = input.get("query").and_then(|v| v.as_str()) {
+                                        q.to_string()
+                                    } else if let Some(u) = input.get("url").and_then(|v| v.as_str()) {
+                                        u.to_string()
+                                    } else {
+                                        serde_json::to_string(input).unwrap_or_default()
+                                            .chars().take(80).collect()
+                                    }
+                                })
+                                .unwrap_or_default();
+                            content_parts.push(format!("🔧 {} {}", tool_name, input_summary));
+                        }
+                        _ => {}
                     }
                 }
-                let content = text_parts.join("\n");
-                let timestamp = info.get("createdAt")
+                let content = content_parts.join("\n");
+                // Skip messages with no displayable content
+                if content.trim().is_empty() { return None; }
+
+                // Timestamp: info.time.created (milliseconds) or fallback to 0
+                let timestamp_ms = info.get("time")
+                    .and_then(|t| t.get("created"))
                     .and_then(|t| t.as_f64())
                     .unwrap_or(0.0);
+                let timestamp = timestamp_ms / 1000.0;
 
                 Some(proto::ChatMessageData {
                     id: id.to_string(),
@@ -932,6 +1013,12 @@ impl MqttRelay {
                 .subscribe(&topic, QoS::AtLeastOnce)
                 .await
                 .map_err(|e| format!("Subscribe failed: {}", e))?;
+        }
+
+        // Re-publish online status so the new device receives it immediately
+        if let Some(client) = self.client.lock().await.as_ref() {
+            let config = self.config.read().await;
+            let _ = self.publish_status(client, &config, true).await;
         }
 
         if let Some(client) = self.client.lock().await.as_ref() {


### PR DESCRIPTION
## Summary

- **Fix shared ModelContext**: pass from app root instead of creating per-view `ModelContainer`, preventing data isolation bugs
- **Fix data sync strategy**: replace destructive delete-all-then-insert with upsert + stale record cleanup across all ViewModels (Task, Skill, Member, Talent), eliminating UI flash on refresh
- **Fix SSE stream parsing**: align Rust relay with OpenCode's actual SSE format (`message.part.delta`, `message.completed`, `message.updated`) — previously using wrong event names
- **Add desktop online awareness**: all ViewModels now track `isDesktopOnline`, skip network requests when offline, show offline placeholders in UI
- **Add MQTT debug logging**: detailed NSLog for publish/subscribe/connect/disconnect with payload type summaries via `ProtoMQTTCoder.summary()`
- **Add MQTT relay auto-start**: desktop auto-starts relay on app launch when config exists with paired devices
- **Fix message history**: parse tool calls as `🔧 tool_name` summaries, skip empty messages, fix timestamp ms→s conversion
- **Fix pairing flow**: re-publish online status after new device pairs for immediate StatusReport delivery
- **Improve error paths**: detailed logging in `fetch_team_manifest` for both P2P and OSS fallback

## Test plan

- [ ] Verify iOS app launches and shows cached data when desktop is offline
- [ ] Verify data sync (sessions, members, skills, talents, tasks) works without UI flash
- [ ] Verify chat streaming works end-to-end with correct SSE parsing
- [ ] Verify MQTT relay auto-starts on desktop app launch
- [ ] Verify new device pairing immediately receives online status
- [ ] Check Xcode console for MQTT debug logs during normal usage

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)