### PR TITLE
fix: make device_token injection non-fatal for webview creation

### DIFF
--- a/packages/app/src/components/main-content/WebViewContent.tsx
+++ b/packages/app/src/components/main-content/WebViewContent.tsx
@@ -189,7 +189,7 @@ export function WebViewContent({ url: rawUrl }: WebViewContentProps) {
           console.error("[WebView] Failed:", err)
           if (!cancelled) {
             setError(
-              err instanceof Error ? err.message : "Failed to create webview",
+              err instanceof Error ? err.message : String(err || "Failed to create webview"),
             )
             setIsLoading(false)
           }

--- a/src-tauri/src/commands/webview.rs
+++ b/src-tauri/src/commands/webview.rs
@@ -254,25 +254,29 @@ pub async fn webview_create(
     );
 
     // Inject window.teamclaw identity global before any page scripts run.
+    // Non-fatal: if device_token generation fails (e.g. DEVICE_JWT_SECRET not configured),
+    // the webview still loads — just without the identity global.
     if let (Some(ref dno), Some(ref dname)) = (&device_no, &device_name) {
-        let device_token = match super::device_token::generate(dno, "") {
-            Ok(tok) => tok,
-            Err(e) => {
-                eprintln!("[Webview] Failed to generate device_token: {}", e);
-                return Err(format!("Failed to generate device_token: {}", e));
+        match super::device_token::generate(dno, "") {
+            Ok(device_token) => {
+                let escaped_no =
+                    serde_json::to_string(dno).unwrap_or_else(|_| "\"\"".to_string());
+                let escaped_name =
+                    serde_json::to_string(dname).unwrap_or_else(|_| "\"\"".to_string());
+                let escaped_token =
+                    serde_json::to_string(&device_token).unwrap_or_else(|_| "\"\"".to_string());
+                let script = format!(
+                    "Object.defineProperty(window, 'teamclaw', {{ value: Object.freeze({{ deviceNo: {no}, deviceName: {name}, deviceToken: {token} }}), writable: false, configurable: false }});",
+                    no = escaped_no,
+                    name = escaped_name,
+                    token = escaped_token,
+                );
+                webview_builder = webview_builder.initialization_script(&script);
             }
-        };
-        let escaped_no = serde_json::to_string(dno).unwrap_or_else(|_| "\"\"".to_string());
-        let escaped_name = serde_json::to_string(dname).unwrap_or_else(|_| "\"\"".to_string());
-        let escaped_token =
-            serde_json::to_string(&device_token).unwrap_or_else(|_| "\"\"".to_string());
-        let script = format!(
-            "Object.defineProperty(window, 'teamclaw', {{ value: Object.freeze({{ deviceNo: {no}, deviceName: {name}, deviceToken: {token} }}), writable: false, configurable: false }});",
-            no = escaped_no,
-            name = escaped_name,
-            token = escaped_token,
-        );
-        webview_builder = webview_builder.initialization_script(&script);
+            Err(e) => {
+                eprintln!("[Webview] Skipping device_token injection: {}", e);
+            }
+        }
     }
 
     let webview = window


### PR DESCRIPTION
## Summary
- Webview creation was failing when `DEVICE_JWT_SECRET` is not configured, blocking all shortcut webviews
- Made device_token injection non-fatal: webview loads without `window.teamclaw` identity instead of erroring out
- Improved error display in WebViewContent to show actual error messages instead of generic "Failed to create webview"

## Test plan
- [ ] Open a shortcut webview without `DEVICE_JWT_SECRET` configured — should load normally
- [ ] Open a shortcut webview with `DEVICE_JWT_SECRET` configured — should inject `window.teamclaw` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)