### PR TITLE
Fix child session detail streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,5 @@ sre/
 
 # TeamClaw system directories
 .ac360/
+
+build.config.json

--- a/packages/app/src/components/chat/ChatMessage.tsx
+++ b/packages/app/src/components/chat/ChatMessage.tsx
@@ -27,12 +27,14 @@ import { RetrievedChunksCard } from "./RetrievedChunksCard";
 /** Renders a single message with all its parts. Memoized to avoid re-renders when siblings change. */
 export const ChatMessage = React.memo(function ChatMessage({
   message,
+  activeSessionId,
   basePath,
   shouldShowThinking = true,
   showStarRating = false,
   tokenGroupInfo,
 }: {
   message: StoreMessage;
+  activeSessionId?: string | null;
   basePath?: string;
   shouldShowThinking?: boolean;
   showStarRating?: boolean;
@@ -49,35 +51,56 @@ export const ChatMessage = React.memo(function ChatMessage({
   // PERF: Only the streaming message subscribes to high-frequency updates (trigger/content).
   // Non-streaming messages subscribe to streamingMessageId only (changes ~2x per conversation).
   const streamingMessageId = useStreamingStore(s => s.streamingMessageId);
-  const isThisMessageStreaming = message.isStreaming && message.id === streamingMessageId;
+  const isViewingThisSession = !!activeSessionId && message.sessionId === activeSessionId;
+  const childStreamingState = useStreamingStore(s =>
+    message.isStreaming && isViewingThisSession && activeSessionId
+      ? s.childSessionStreaming[activeSessionId]
+      : undefined,
+  );
+  const isChildSessionStreaming =
+    message.isStreaming &&
+    isViewingThisSession &&
+    !!childStreamingState?.isStreaming;
+  const isThisMessageStreaming =
+    message.isStreaming &&
+    (message.id === streamingMessageId || isChildSessionStreaming);
 
   // Only subscribe to per-frame updates when THIS message is streaming.
   // This prevents all other ChatMessage instances from re-rendering every frame.
   const streamingContent = useStreamingStore(s =>
-    isThisMessageStreaming ? s.streamingContent : "",
+    isThisMessageStreaming && !isChildSessionStreaming ? s.streamingContent : "",
   );
   const streamingUpdateTrigger = useStreamingStore(s =>
-    isThisMessageStreaming ? s.streamingUpdateTrigger : 0,
+    isThisMessageStreaming && !isChildSessionStreaming ? s.streamingUpdateTrigger : 0,
   );
-  const activeSessionId = useSessionStore(s => s.activeSessionId);
+  const storeActiveSessionId = useSessionStore(s => s.activeSessionId);
+  const resolvedSessionId = activeSessionId ?? storeActiveSessionId;
 
   // When streaming, get the latest message data from sessionLookupCache
   // which includes updated reasoning parts from typewriterTick
   const latestMessage = React.useMemo(() => {
-    if (!isThisMessageStreaming || !activeSessionId) return message;
-    const session = getSessionById(activeSessionId);
+    if (!isThisMessageStreaming || !resolvedSessionId) return message;
+    const session = getSessionById(resolvedSessionId);
     if (!session) return message;
     const latest = session.messages.find(m => m.id === message.id);
     return latest || message;
-  }, [isThisMessageStreaming, activeSessionId, message, streamingUpdateTrigger]);
+  }, [isThisMessageStreaming, resolvedSessionId, message, streamingUpdateTrigger]);
 
-  const textContent = isThisMessageStreaming ? streamingContent : (latestMessage.content || "");
+  const textContent = isThisMessageStreaming
+    ? (isChildSessionStreaming ? (childStreamingState?.text || "") : streamingContent)
+    : (latestMessage.content || "");
 
   // Extract reasoning/thinking content from parts — memoized to avoid
   // re-filtering on every render during streaming.
   const { reasoningContent, hasReasoning, hasThinking } = React.useMemo(() => {
     const rParts = latestMessage.parts.filter((p) => p.type === "reasoning");
-    const rContent = rParts.map((p) => p.text || "").filter(Boolean).join("\n");
+    const streamedReasoning = isChildSessionStreaming
+      ? (childStreamingState?.reasoning || "")
+      : "";
+    const rContent = [
+      rParts.map((p) => p.text || "").filter(Boolean).join("\n"),
+      streamedReasoning,
+    ].filter(Boolean).join("\n");
     return {
       reasoningContent: rContent,
       hasReasoning: rContent.length > 0,
@@ -85,7 +108,7 @@ export const ChatMessage = React.memo(function ChatMessage({
         (p) => p.type === "step-start" || p.type === "step-finish",
       ),
     };
-  }, [latestMessage.parts]);
+  }, [childStreamingState?.reasoning, isChildSessionStreaming, latestMessage.parts]);
 
   const hasToolCalls = latestMessage.toolCalls && latestMessage.toolCalls.length > 0;
 

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -104,6 +104,44 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     viewingChildSessionId ? s.childSessionStreaming[viewingChildSessionId] : undefined
   );
   const isViewingChild = !!viewingChildSessionId;
+  const displayedChildSessionMessages = React.useMemo(() => {
+    if (!viewingChildSessionId) return EMPTY_MESSAGES;
+
+    const hasLiveChildStreaming =
+      !!childStreamingContent &&
+      (childStreamingContent.isStreaming ||
+        !!childStreamingContent.text ||
+        !!childStreamingContent.reasoning);
+
+    if (!hasLiveChildStreaming) {
+      return childSessionMessages;
+    }
+
+    const hasStreamingPlaceholder = childSessionMessages.some((message) => message.isStreaming);
+    if (hasStreamingPlaceholder) {
+      return childSessionMessages;
+    }
+
+    const lastTimestamp = childSessionMessages[childSessionMessages.length - 1]?.timestamp;
+    const placeholderTimestamp =
+      lastTimestamp instanceof Date
+        ? new Date(lastTimestamp.getTime() + 1)
+        : new Date();
+
+    return [
+      ...childSessionMessages,
+      {
+        id: `child-streaming-${viewingChildSessionId}`,
+        sessionId: viewingChildSessionId,
+        role: "assistant" as const,
+        content: childStreamingContent?.text || "",
+        parts: [],
+        toolCalls: [],
+        isStreaming: true,
+        timestamp: placeholderTimestamp,
+      },
+    ];
+  }, [childSessionMessages, childStreamingContent, viewingChildSessionId]);
 
   // Actions — accessed via getState() to avoid creating subscriptions.
   // Zustand actions are stable references; subscribing to them wastes equality checks.
@@ -780,7 +818,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
           ) : (
             <MessageList
               ref={messageListRef}
-              messages={childSessionMessages}
+              messages={displayedChildSessionMessages}
               activeSessionId={viewingChildSessionId}
               isStreaming={!!childStreamingContent?.isStreaming}
               streamingMessageId={null}

--- a/packages/app/src/components/chat/MessageList.tsx
+++ b/packages/app/src/components/chat/MessageList.tsx
@@ -594,6 +594,7 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
                               <ErrorBoundary scope="Message" inline>
                                 <ChatMessage
                                   message={message}
+                                  activeSessionId={activeSessionId}
                                   basePath={activeSessionDirectory}
                                   shouldShowThinking={shouldShowThinking}
                                   showStarRating={
@@ -623,6 +624,7 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
                         >
                           <ChatMessage
                             message={message}
+                            activeSessionId={activeSessionId}
                             basePath={activeSessionDirectory}
                             shouldShowThinking={shouldShowThinking}
                             showStarRating={

--- a/packages/app/src/components/chat/__tests__/ChatMessage-streaming.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ChatMessage-streaming.test.tsx
@@ -189,4 +189,31 @@ describe('ChatMessage streaming typewriter', () => {
     const dots = container.querySelectorAll('[class*="animate-"]');
     expect(dots.length).toBeGreaterThanOrEqual(3);
   });
+
+  it('displays child session streaming content while viewing a child session', async () => {
+    const ChatMessage = await importChatMessage();
+
+    const message = makeMessage({
+      sessionId: 'child-1',
+      isStreaming: true,
+      content: '',
+    });
+
+    useStreamingStore.setState({
+      childSessionStreaming: {
+        'child-1': {
+          sessionId: 'child-1',
+          text: 'Child stream in progress',
+          reasoning: '',
+          isStreaming: true,
+        },
+      },
+    });
+
+    const { container } = render(
+      <ChatMessage message={message} activeSessionId="child-1" />
+    );
+
+    expect(container.textContent).toContain('Child stream in progress');
+  });
 });

--- a/packages/app/src/components/chat/__tests__/ChatPanel.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ChatPanel.test.tsx
@@ -10,6 +10,10 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
+if (!HTMLElement.prototype.scrollTo) {
+  HTMLElement.prototype.scrollTo = () => {};
+}
+
 // ── Mocks ──────────────────────────────────────────────────────────────
 
 vi.mock('react-i18next', () => ({
@@ -44,6 +48,9 @@ vi.mock('@tauri-apps/api/window', () => ({
 // Session store state — mutated per test
 const sessionState = {
   activeSessionId: null as string | null,
+  viewingChildSessionId: null as string | null,
+  childSessionMessages: {} as Record<string, unknown[]>,
+  isLoadingChildMessages: false,
   sessions: [] as unknown[],
   error: null as string | null,
   isConnected: true,
@@ -199,6 +206,9 @@ describe('ChatPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessionState.activeSessionId = null;
+    sessionState.viewingChildSessionId = null;
+    sessionState.childSessionMessages = {};
+    sessionState.isLoadingChildMessages = false;
     sessionState.isConnected = true;
     sessionState.error = null;
     sessionState.sessionError = null;
@@ -206,6 +216,7 @@ describe('ChatPanel', () => {
     sessionState.messageQueue = [];
     sessionState.sessions = [];
     streamingState.streamingMessageId = null;
+    streamingState.childSessionStreaming = {};
     workspaceState.openCodeReady = true;
     voiceInputState.registerInsertToChatHandler = vi.fn(() => () => {});
     sessionState.loadSessions = vi.fn(() => Promise.resolve());
@@ -238,5 +249,26 @@ describe('ChatPanel', () => {
     const { container } = render(<ChatPanel />);
     // When isConnected is false and there's an active session, the connecting indicator shows
     expect(container.textContent).toContain('Connecting');
+  });
+
+  it('renders streaming child session content before child messages finish loading', () => {
+    sessionState.activeSessionId = 'sess-parent';
+    sessionState.viewingChildSessionId = 'child-1';
+    sessionState.childSessionMessages = {
+      'child-1': [],
+    };
+    streamingState.childSessionStreaming = {
+      'child-1': {
+        sessionId: 'child-1',
+        text: 'Child stream in progress',
+        reasoning: '',
+        isStreaming: true,
+      },
+    };
+
+    const { container } = render(<ChatPanel />);
+
+    expect(container.textContent).toContain('Child stream in progress');
+    expect(container.textContent).toContain('返回主会话');
   });
 });

--- a/packages/app/src/components/chat/__tests__/TaskToolCard.test.tsx
+++ b/packages/app/src/components/chat/__tests__/TaskToolCard.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ToolCall } from "@/stores/session";
+
+vi.mock("@/stores/session", () => ({
+  useSessionStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({
+        forceCompleteToolCall: vi.fn(),
+      }),
+    {
+      getState: () => ({
+        setViewingChildSession: vi.fn(),
+      }),
+    },
+  ),
+  convertMessage: vi.fn(),
+}));
+
+vi.mock("@/stores/streaming", () => ({
+  useStreamingStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      childSessionStreaming: {
+        "child-session-1": {
+          sessionId: "child-session-1",
+          text: "streaming details should stay in the child session view",
+          reasoning: "",
+          isStreaming: true,
+        },
+      },
+    }),
+}));
+
+vi.mock("@/stores/workspace", () => ({
+  useWorkspaceStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({
+        workspacePath: "/workspace",
+        selectFile: vi.fn(),
+      }),
+    {
+      getState: () => ({
+        workspacePath: "/workspace",
+        selectFile: vi.fn(),
+      }),
+    },
+  ),
+}));
+
+vi.mock("@/lib/opencode/sdk-client", () => ({
+  getOpenCodeClient: vi.fn(),
+}));
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    openExternalUrl: vi.fn(),
+  };
+});
+
+import { TaskToolCard } from "@/components/chat/tool-calls/TaskToolCard";
+
+describe("TaskToolCard", () => {
+  it("keeps only the view-session entry in the parent session", () => {
+    const toolCall: ToolCall = {
+      id: "task-1",
+      name: "task",
+      status: "calling",
+      arguments: {
+        description: "Investigate the regression",
+        subagent_type: "worker",
+      },
+      result: "<task_result>final child output should not be shown inline</task_result>\nsession_id: child-session-1",
+      startTime: new Date("2026-04-10T10:00:00Z"),
+      duration: 1200,
+      metadata: {
+        sessionId: "child-session-1",
+        summary: [
+          {
+            id: "summary-1",
+            tool: "read",
+            state: {
+              status: "running",
+              title: "src/app.tsx",
+            },
+          },
+        ],
+      },
+    };
+
+    render(<TaskToolCard toolCall={toolCall} />);
+
+    expect(screen.getByText("查看会话")).toBeTruthy();
+    expect(screen.queryByText("查看子任务详情")).toBeNull();
+    expect(screen.queryByText("final child output should not be shown inline")).toBeNull();
+    expect(screen.queryByText("streaming details should stay in the child session view")).toBeNull();
+  });
+});

--- a/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
+++ b/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
@@ -1,25 +1,13 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useCallback } from "react";
 import {
   ChevronRight,
-  Loader2,
-  Eye,
   Zap,
   Bot,
   AlertTriangle,
   CheckCircle2,
-  Terminal,
 } from "lucide-react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import { cn, openExternalUrl } from "@/lib/utils";
-import { getOpenCodeClient } from "@/lib/opencode/sdk-client";
-import { ToolCall, useSessionStore, convertMessage } from "@/stores/session";
-import { useStreamingStore } from "@/stores/streaming";
-import { useWorkspaceStore } from "@/stores/workspace";
-import {
-  getCommandText,
-  getToolCallOutputText,
-} from "@/lib/terminal-interaction";
+import { cn } from "@/lib/utils";
+import { ToolCall, useSessionStore } from "@/stores/session";
 import {
   Collapsible,
   CollapsibleContent,
@@ -27,10 +15,7 @@ import {
 } from "@/components/ui/collapsible";
 import {
   statusConfig,
-  formatToolName,
   useToolCallTimeout,
-  isCommandTool,
-  isCommandToolLikelyWaitingForInput,
 } from "./tool-call-utils";
 
 // Skill Tool Card - Shows skill execution inline
@@ -236,58 +221,18 @@ export function RoleSkillToolCard({ toolCall }: { toolCall: ToolCall }) {
 export function TaskToolCard({ toolCall }: { toolCall: ToolCall }) {
   const args = toolCall.arguments as {
     description?: string;
-    prompt?: string;
     subagent_type?: string;
   };
 
-  // Parse result to get output and session ID
   const result = toolCall.result as string | undefined;
-  let output = "";
   let sessionId = toolCall.metadata?.sessionId || "";
 
-  // Result format includes various metadata tags:
-  // - <task_id>xxx</task_id>
-  // - <task_result>output</task_result>
-  // - <session>session_id: xxx</session>
-  // - session_id: xxx
   if (typeof result === "string") {
-    let cleanedResult = result;
-
-    // Extract session ID from various formats
     const sessionMatch = result.match(/session_id:\s*([^\n<\s]+)/);
     if (sessionMatch && !sessionId) {
       sessionId = sessionMatch[1].trim();
     }
-
-    // Clean up all backend metadata tags
-    cleanedResult = cleanedResult
-      .replace(/<task_id>[\s\S]*?<\/task_id>/g, "")
-      .replace(/<task_result>([\s\S]*?)<\/task_result>/g, "$1")
-      .replace(/<session>[\s\S]*?<\/session>/g, "")
-      .replace(/\b_?task_id:\s*\S+\s*/g, "")
-      .replace(/\bsession_id:\s*\S+\s*/g, "")
-      .replace(/\(for resuming to continue this task if needed\)/g, "")
-      .replace(/^\s*[\r\n]/gm, "")
-      .replace(/\n{3,}/g, "\n\n")
-      .trim();
-
-    output = cleanedResult;
   }
-
-  // Read streaming content from child session
-  const childStreaming = useStreamingStore(
-    (s) => sessionId ? s.childSessionStreaming[sessionId] : undefined,
-  );
-  const streamingText = childStreaming?.text || "";
-  const isChildStreaming = childStreaming?.isStreaming ?? false;
-
-  // Auto-scroll streaming content
-  const streamingRef = React.useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (streamingRef.current && isChildStreaming) {
-      streamingRef.current.scrollTop = streamingRef.current.scrollHeight;
-    }
-  }, [streamingText, isChildStreaming]);
 
   const config = statusConfig[toolCall.status];
   const StatusIcon = config.icon;
@@ -301,51 +246,12 @@ export function TaskToolCard({ toolCall }: { toolCall: ToolCall }) {
     }
   }, [sessionId]);
 
-  const markdownClasses =
-    "prose prose-sm max-w-none text-xs text-foreground/90 prose-headings:text-foreground prose-headings:text-sm prose-headings:font-semibold prose-headings:my-1 prose-p:text-foreground/80 prose-p:my-1 prose-strong:text-foreground prose-code:text-foreground prose-code:text-[11px] prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-muted prose-pre:text-foreground prose-pre:text-[11px] prose-ul:text-foreground/80 prose-ul:my-1 prose-ol:text-foreground/80 prose-ol:my-1 prose-li:text-foreground/80 prose-li:my-0";
-
-  const markdownComponents = {
-    a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-foreground/80 hover:text-foreground hover:underline"
-        onClick={(e) => {
-          if (href && /^https?:\/\//.test(href)) {
-            e.preventDefault();
-            openExternalUrl(href);
-          }
-        }}
-      >
-        {children}
-      </a>
-    ),
-    table: ({ children }: { children?: React.ReactNode }) => (
-      <div className="overflow-x-auto my-2 rounded border border-border">
-        <table className="min-w-full border-collapse text-[11px]">{children}</table>
-      </div>
-    ),
-    thead: ({ children }: { children?: React.ReactNode }) => (
-      <thead className="bg-muted/50">{children}</thead>
-    ),
-    th: ({ children }: { children?: React.ReactNode }) => (
-      <th className="border-b border-border px-2 py-1.5 text-left font-semibold text-foreground text-[11px]">{children}</th>
-    ),
-    tr: ({ children }: { children?: React.ReactNode }) => (
-      <tr className="border-b border-border last:border-b-0">{children}</tr>
-    ),
-    td: ({ children }: { children?: React.ReactNode }) => (
-      <td className="px-2 py-1.5 text-foreground/80 text-[11px]">{children}</td>
-    ),
-  };
-
   return (
-    <div className="border-l-2 border-border pl-3 py-1 space-y-2">
+    <div className="border-l-2 border-border pl-3 py-1">
       <div className="flex items-center gap-2 text-[11px]">
         <Bot size={12} className="text-muted-foreground" />
         <span className="text-foreground font-medium">@{subagentType}</span>
-        <span className="text-muted-foreground">{description}</span>
+        <span className="text-muted-foreground truncate">{description}</span>
         {toolCall.duration && (
           <span className="text-[10px] text-muted-foreground/70">
             {toolCall.duration < 1000
@@ -368,375 +274,6 @@ export function TaskToolCard({ toolCall }: { toolCall: ToolCall }) {
           className={cn(config.textColor, config.animate && "animate-spin")}
         />
       </div>
-
-      {toolCall.status === "calling" && (
-        <div className="space-y-1">
-          {toolCall.metadata?.summary &&
-          toolCall.metadata.summary.length > 0 ? (
-            <>
-              {toolCall.metadata.summary.map((item, index) => {
-                const itemStatus = item.state?.status || "running";
-                const statusCfg =
-                  itemStatus === "completed"
-                    ? statusConfig.completed
-                    : itemStatus === "error"
-                      ? statusConfig.failed
-                      : itemStatus === "running"
-                        ? statusConfig.calling
-                        : statusConfig.waiting;
-                const ToolStatusIcon = statusCfg.icon;
-                const toolName = item.tool || "unknown";
-                const title = item.state?.title;
-
-                if (toolName.toLowerCase() === "read") {
-                  const fileName = title?.split("/").pop() || title || "";
-                  const handleSubagentFileClick = () => {
-                    if (!title) return;
-                    const ws = useWorkspaceStore.getState().workspacePath;
-                    const full = title.startsWith("/") ? title : `${ws}/${title}`;
-                    useWorkspaceStore.getState().selectFile(full);
-                  };
-                  return (
-                    <div
-                      key={item.id || index}
-                      className="flex items-center gap-2 text-[11px] text-muted-foreground cursor-pointer hover:text-foreground/80 transition-colors"
-                      onClick={handleSubagentFileClick}
-                      title={title || "Open file"}
-                    >
-                      <Eye size={10} className="shrink-0" />
-                      <span className="font-mono truncate">{fileName}</span>
-                      <ToolStatusIcon
-                        size={10}
-                        className={cn(
-                          "shrink-0",
-                          statusCfg.textColor,
-                          statusCfg.animate && "animate-spin",
-                        )}
-                      />
-                    </div>
-                  );
-                }
-
-                return (
-                  <div
-                    key={item.id || index}
-                    className="flex items-center gap-2 px-2 py-1 bg-muted/30 rounded text-[11px]"
-                  >
-                    <span className="font-medium text-foreground/80">
-                      {formatToolName(toolName)}
-                    </span>
-                    {title && (
-                      <span className="text-muted-foreground truncate flex-1">
-                        {title}
-                      </span>
-                    )}
-                    <ToolStatusIcon
-                      size={10}
-                      className={cn(
-                        "shrink-0",
-                        statusCfg.textColor,
-                        statusCfg.animate && "animate-spin",
-                      )}
-                    />
-                  </div>
-                );
-              })}
-            </>
-          ) : null}
-
-          {streamingText ? (
-            <div
-              ref={streamingRef}
-              className="max-h-64 overflow-y-auto border-t border-border/30 pt-1 mt-1"
-            >
-              <div className={markdownClasses}>
-                <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{streamingText}</ReactMarkdown>
-                {isChildStreaming && (
-                  <span className="inline-block w-1.5 h-3 bg-foreground/60 animate-pulse ml-0.5 align-text-bottom" />
-                )}
-              </div>
-            </div>
-          ) : (
-            <div className="flex items-center gap-2 py-0.5 text-muted-foreground">
-              <Loader2 size={10} className="animate-spin text-muted-foreground" />
-              <span className="text-[10px]">Working...</span>
-            </div>
-          )}
-        </div>
-      )}
-
-      {output && (
-        <div className="max-h-64 overflow-y-auto border-t border-border/30 pt-1 mt-1">
-          <div className={markdownClasses}>
-            <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{output}</ReactMarkdown>
-          </div>
-        </div>
-      )}
-
-      {sessionId && (
-        <SubagentToolDetails sessionId={sessionId} />
-      )}
     </div>
-  );
-}
-
-const childSessionToolCache = new Map<
-  string,
-  { toolCalls: ToolCall[]; fetchedAt: number }
->();
-
-function SubagentToolDetails({ sessionId }: { sessionId: string }) {
-  const [detailsOpen, setDetailsOpen] = useState(false);
-  const [toolCalls, setToolCalls] = useState<ToolCall[] | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchChildMessages = useCallback(async () => {
-    const cached = childSessionToolCache.get(sessionId);
-    if (cached) {
-      setToolCalls(cached.toolCalls);
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    try {
-      const client = getOpenCodeClient();
-      const messages = await client.getMessages(sessionId);
-      const allToolCalls: ToolCall[] = [];
-      for (const msg of messages) {
-        const converted = convertMessage(msg);
-        if (converted.toolCalls) {
-          allToolCalls.push(...converted.toolCalls);
-        }
-      }
-      childSessionToolCache.set(sessionId, {
-        toolCalls: allToolCalls,
-        fetchedAt: Date.now(),
-      });
-      setToolCalls(allToolCalls);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      setError(msg);
-      setToolCalls([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [sessionId]);
-
-  useEffect(() => {
-    if (detailsOpen && !toolCalls && !loading && !error) {
-      fetchChildMessages();
-    }
-  }, [detailsOpen, toolCalls, loading, error, fetchChildMessages]);
-
-  return (
-    <Collapsible open={detailsOpen} onOpenChange={setDetailsOpen}>
-      <CollapsibleTrigger asChild>
-        <button
-          type="button"
-          className="flex items-center gap-1.5 py-1 text-[11px] text-muted-foreground hover:text-foreground hover:underline"
-        >
-          <ChevronRight
-            size={10}
-            className={cn(
-              "shrink-0 transition-transform",
-              detailsOpen && "rotate-90",
-            )}
-          />
-          查看子任务详情
-        </button>
-      </CollapsibleTrigger>
-      <CollapsibleContent>
-        <div className="border-t border-border/30 pt-2 space-y-1.5">
-          {loading && (
-            <div className="flex items-center gap-2 py-2 text-[11px] text-muted-foreground">
-              <Loader2 size={10} className="animate-spin text-muted-foreground" />
-              加载中…
-            </div>
-          )}
-          {error && (
-            <div className="py-2 text-[11px] text-red-600 dark:text-red-500 flex items-center gap-2">
-              <AlertTriangle size={10} />
-              {error}
-            </div>
-          )}
-          {!loading && !error && toolCalls && toolCalls.length === 0 && (
-            <div className="py-2 text-[11px] text-muted-foreground">
-              无工具调用记录
-            </div>
-          )}
-          {!loading && !error && toolCalls && toolCalls.length > 0 && (
-            <div className="space-y-1 max-h-96 overflow-y-auto">
-              {toolCalls.map((tc, idx) => (
-                <SubagentToolCallItem key={tc.id || idx} toolCall={tc} />
-              ))}
-            </div>
-          )}
-        </div>
-      </CollapsibleContent>
-    </Collapsible>
-  );
-}
-
-function SubagentToolCallItem({ toolCall }: { toolCall: ToolCall }) {
-  const [expanded, setExpanded] = useState(false);
-  const args = toolCall.arguments as Record<string, unknown>;
-  const argSummary =
-    typeof args?.path === "string"
-      ? args.path
-      : typeof args?.command === "string"
-        ? args.command
-        : typeof args?.query === "string"
-          ? args.query
-          : typeof args?.url === "string"
-            ? args.url
-            : typeof args?.pattern === "string"
-              ? args.pattern
-              : null;
-  const resultStr =
-    toolCall.result != null
-      ? typeof toolCall.result === "string"
-        ? toolCall.result
-        : JSON.stringify(toolCall.result, null, 2)
-      : null;
-
-  const isRead = toolCall.name.toLowerCase().includes("read");
-  const title = (argSummary || args?.path || args?.title) as string | undefined;
-
-  if (isRead && title) {
-    const handleFileClick = () => {
-      const ws = useWorkspaceStore.getState().workspacePath;
-      const full = title.startsWith("/") ? title : `${ws || ""}/${title}`;
-      useWorkspaceStore.getState().selectFile(full);
-    };
-    return (
-      <div
-        className="flex items-center gap-2 px-2 py-1 rounded bg-muted/30 text-[11px] cursor-pointer hover:bg-muted/50"
-        onClick={handleFileClick}
-        title={title}
-      >
-        <Eye size={10} className="shrink-0 text-muted-foreground" />
-        <span className="font-mono truncate flex-1">{title.split("/").pop() || title}</span>
-        <CheckCircle2 size={10} className="shrink-0 text-foreground/60" />
-      </div>
-    );
-  }
-
-  if (isCommandTool(toolCall.name)) {
-    const command = getCommandText(args);
-    const output = getToolCallOutputText(toolCall.result);
-    const isWaitingForInput = isCommandToolLikelyWaitingForInput(toolCall);
-    const cmdSummary = command ? (command.length > 80 ? `${command.slice(0, 80)}…` : command) : null;
-    return (
-      <Collapsible open={expanded} onOpenChange={setExpanded}>
-        <div className="rounded border border-border/50 overflow-hidden">
-          <CollapsibleTrigger asChild>
-            <button
-              type="button"
-              className="w-full flex items-center gap-2 px-2 py-1.5 text-left text-[11px] bg-muted/20 hover:bg-muted/30"
-            >
-              <ChevronRight
-                size={10}
-                className={cn("shrink-0 transition-transform", expanded && "rotate-90")}
-              />
-              <span className="font-medium text-foreground/90">
-                {formatToolName(toolCall.name)}
-              </span>
-              {cmdSummary && (
-                <span className="truncate text-muted-foreground flex-1 font-mono">
-                  {cmdSummary}
-                </span>
-              )}
-              {isWaitingForInput ? (
-                <span className="flex items-center gap-1 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800 border border-amber-200">
-                  <AlertTriangle size={10} />
-                  Input needed
-                </span>
-              ) : output !== "" && (
-                <span className="text-[10px] text-muted-foreground">
-                  {toolCall.status === "completed" ? "✓" : toolCall.status === "failed" ? "✗" : "..."}
-                </span>
-              )}
-            </button>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <div className="border-t border-border/50 p-2 space-y-2 bg-muted/10">
-              {isWaitingForInput && (
-                <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-2 text-[11px] text-amber-900">
-                  <AlertTriangle size={12} className="mt-0.5 shrink-0" />
-                  <div>
-                    <p className="font-medium">This command looks like it is waiting for terminal input.</p>
-                    <p className="text-amber-800/90">
-                      Prefer non-interactive flags like `--yes` or `-y`, or ask a question before continuing.
-                    </p>
-                  </div>
-                </div>
-              )}
-              <div>
-                <label className="text-[10px] text-muted-foreground">Command</label>
-                <div className="mt-1 flex items-center gap-2 p-2 bg-bg-tertiary rounded-md text-xs font-mono">
-                  <span className="text-accent-green">$</span>
-                  <span className="break-all">{command || "(no command)"}</span>
-                </div>
-              </div>
-              <div>
-                <label className="text-[10px] text-muted-foreground">Output</label>
-                <div className="mt-1 bg-[#1e1e1e] rounded-md overflow-hidden">
-                  <div className="flex items-center gap-2 px-2 py-1 bg-bg-tertiary border-b border-border">
-                    <Terminal size={10} className="text-text-muted" />
-                    <span className="text-[10px] text-text-muted">Terminal</span>
-                  </div>
-                  <pre className="p-2 text-[10px] overflow-auto max-h-[300px] font-mono text-green-400 whitespace-pre-wrap break-words">
-                    {output || "(no output)"}
-                  </pre>
-                </div>
-              </div>
-            </div>
-          </CollapsibleContent>
-        </div>
-      </Collapsible>
-    );
-  }
-
-  return (
-    <Collapsible open={expanded} onOpenChange={setExpanded}>
-      <div className="rounded border border-border/50 overflow-hidden">
-        <CollapsibleTrigger asChild>
-          <button
-            type="button"
-            className="w-full flex items-center gap-2 px-2 py-1.5 text-left text-[11px] bg-muted/20 hover:bg-muted/30"
-          >
-            <ChevronRight
-              size={10}
-              className={cn("shrink-0 transition-transform", expanded && "rotate-90")}
-            />
-            <span className="font-medium text-foreground/90">
-              {formatToolName(toolCall.name)}
-            </span>
-            {argSummary && (
-              <span className="truncate text-muted-foreground flex-1">
-                {argSummary.length > 50 ? `${argSummary.slice(0, 50)}…` : argSummary}
-              </span>
-            )}
-            {resultStr != null && (
-              <span className="text-[10px] text-muted-foreground">
-                {toolCall.status === "completed" ? "✓" : toolCall.status === "failed" ? "✗" : "..."}
-              </span>
-            )}
-          </button>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          {resultStr ? (
-            <div className="max-h-48 overflow-y-auto border-t border-border/50 p-2 bg-muted/10">
-              <pre className="text-[10px] font-mono whitespace-pre-wrap break-words text-foreground/90 m-0">
-                {resultStr}
-              </pre>
-            </div>
-          ) : (
-            <div className="p-2 text-[10px] text-muted-foreground">无返回值</div>
-          )}
-        </CollapsibleContent>
-      </div>
-    </Collapsible>
   );
 }


### PR DESCRIPTION
## Summary
- keep sub-agent task cards lightweight and rely on "查看会话" for detailed child session output
- restore streaming output in child session view by rendering live child-session text before message reload completes
- ignore local build.config.json in .gitignore

## Test Plan
- pnpm vitest run src/components/chat/__tests__/ChatPanel.test.tsx src/components/chat/__tests__/ChatPanel-submission.test.tsx src/components/chat/__tests__/ChatMessage-streaming.test.tsx src/components/chat/__tests__/MessageList.test.tsx src/components/chat/__tests__/TaskToolCard.test.tsx
- pnpm typecheck