### PR TITLE
fix(p2p): start iroh node on-demand when creating team for first time

### DIFF
--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -420,6 +420,20 @@ pub async fn p2p_create_team(
         .ok_or("No workspace path set")?;
 
     let mut guard = iroh_state.lock().await;
+
+    // Start the node on-demand if it hasn't been started yet (first-time team creation).
+    if guard.is_none() {
+        match IrohNode::new_default().await {
+            Ok(node) => {
+                *guard = Some(node);
+                eprintln!("[P2P] iroh node started on-demand for team creation");
+            }
+            Err(e) => {
+                return Err(format!("Failed to start P2P node: {}", e));
+            }
+        }
+    }
+
     let node = guard.as_mut().ok_or("P2P node not running")?;
 
     let team_dir = format!("{}/{}", workspace_path, team_repo_dir());


### PR DESCRIPTION
## Summary

- New users have no `p2p.enabled` config, so the iroh node was never started at app boot
- Clicking "Create Team" called `p2p_create_team` which immediately failed with "P2P node not running"
- Fixed by starting `IrohNode::new_default()` on-demand inside `p2p_create_team` if the node is not yet running

## Test plan

- [ ] Fresh install (no existing P2P config) — click Create Team, should succeed without "节点未启动" error
- [ ] Existing P2P user — node already running at boot, create flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)