### PR TITLE
feat: QR code pairing for iOS mobile

### DIFF
--- a/TeamClawMobile/TeamClawMobile/Core/PairingManager.swift
+++ b/TeamClawMobile/TeamClawMobile/Core/PairingManager.swift
@@ -41,11 +41,7 @@ final class PairingManager: ObservableObject {
         static let desktopDeviceID   = "teamclaw_desktop_device_id"
     }
 
-    // Shared broker credentials used during pairing handshake
-    static let sharedHost     = "a81fb6d3.ala.cn-hangzhou.emqxsl.cn"
-    static let sharedPort: UInt16 = 8883
-    static let sharedUsername = "teamclaw_ios"
-    static let sharedPassword = "teamclaw_ios"
+    // Shared broker credentials used during pairing handshake (user-provided per session)
 
     // MARK: - Init
 
@@ -109,9 +105,19 @@ final class PairingManager: ObservableObject {
 
     /// Real pairing: connect with shared creds, discover desktop via retained status,
     /// then publish pair request and wait for credentials response.
-    func pair(with code: String) {
+    func pair(
+        with code: String,
+        brokerHost: String,
+        brokerPort: UInt16 = 8883,
+        brokerUsername: String? = nil,
+        brokerPassword: String? = nil
+    ) {
         guard code.count == 6, code.allSatisfy(\.isNumber) else {
             pairingError = "配对码必须是 6 位数字"
+            return
+        }
+        guard !brokerHost.isEmpty else {
+            pairingError = "请输入 MQTT 服务器地址"
             return
         }
 
@@ -125,7 +131,11 @@ final class PairingManager: ObservableObject {
                 let result = try await PairingService.perform(
                     code: code,
                     mobileDeviceID: mobileDeviceID,
-                    mobileDeviceName: UIDevice.current.name
+                    mobileDeviceName: UIDevice.current.name,
+                    brokerHost: brokerHost,
+                    brokerPort: brokerPort,
+                    brokerUsername: brokerUsername,
+                    brokerPassword: brokerPassword
                 )
 
                 await MainActor.run {
@@ -195,6 +205,10 @@ final class PairingService {
     private let code: String
     private let mobileDeviceID: String
     private let mobileDeviceName: String
+    private let brokerHost: String
+    private let brokerPort: UInt16
+    private let brokerUsername: String?
+    private let brokerPassword: String?
 
     private var discoveredTeamID: String?
     private var discoveredDesktopDeviceID: String?
@@ -204,20 +218,40 @@ final class PairingService {
     static func perform(
         code: String,
         mobileDeviceID: String,
-        mobileDeviceName: String
+        mobileDeviceName: String,
+        brokerHost: String,
+        brokerPort: UInt16,
+        brokerUsername: String?,
+        brokerPassword: String?
     ) async throws -> PairingResult {
         let service = PairingService(
             code: code,
             mobileDeviceID: mobileDeviceID,
-            mobileDeviceName: mobileDeviceName
+            mobileDeviceName: mobileDeviceName,
+            brokerHost: brokerHost,
+            brokerPort: brokerPort,
+            brokerUsername: brokerUsername,
+            brokerPassword: brokerPassword
         )
         return try await service.run()
     }
 
-    private init(code: String, mobileDeviceID: String, mobileDeviceName: String) {
+    private init(
+        code: String,
+        mobileDeviceID: String,
+        mobileDeviceName: String,
+        brokerHost: String,
+        brokerPort: UInt16,
+        brokerUsername: String?,
+        brokerPassword: String?
+    ) {
         self.code = code
         self.mobileDeviceID = mobileDeviceID
         self.mobileDeviceName = mobileDeviceName
+        self.brokerHost = brokerHost
+        self.brokerPort = brokerPort
+        self.brokerUsername = brokerUsername
+        self.brokerPassword = brokerPassword
     }
 
     private func run() async throws -> PairingResult {
@@ -230,22 +264,28 @@ final class PairingService {
         self.continuation = continuation
 
         let clientID = "teamclaw-ios-pair-\(UUID().uuidString.prefix(8))"
-        NSLog("[Pairing] Connecting to \(PairingManager.sharedHost):\(PairingManager.sharedPort) as \(clientID)")
+        NSLog("[Pairing] Connecting to \(brokerHost):\(brokerPort) as \(clientID)")
 
         let client = CocoaMQTT5(
             clientID: clientID,
-            host: PairingManager.sharedHost,
-            port: PairingManager.sharedPort
+            host: brokerHost,
+            port: brokerPort
         )
-        client.username = PairingManager.sharedUsername
-        client.password = PairingManager.sharedPassword
-        client.enableSSL = true
+        if let username = brokerUsername {
+            client.username = username
+        }
+        if let password = brokerPassword {
+            client.password = password
+        }
+        client.enableSSL = (brokerPort == 8883)
         client.allowUntrustCACertificate = true
         client.cleanSession = true
         client.keepAlive = 30
-        client.sslSettings = [
-            kCFStreamSSLPeerName as String: PairingManager.sharedHost as NSString
-        ]
+        if client.enableSSL {
+            client.sslSettings = [
+                kCFStreamSSLPeerName as String: brokerHost as NSString
+            ]
+        }
         client.didReceiveTrust = { _, _, completionHandler in
             completionHandler(true)
         }

--- a/TeamClawMobile/TeamClawMobile/Features/Settings/PairingView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Settings/PairingView.swift
@@ -6,83 +6,159 @@ struct PairingView: View {
     @ObservedObject var pairingManager: PairingManager
 
     @State private var code = ""
-    @FocusState private var isCodeFocused: Bool
+    @State private var mqttHost: String = UserDefaults.standard.string(forKey: "teamclaw_pairing_broker_host") ?? ""
+    @State private var mqttPort: String = {
+        let saved = UserDefaults.standard.integer(forKey: "teamclaw_pairing_broker_port")
+        return saved > 0 ? String(saved) : "8883"
+    }()
+    @State private var mqttUsername: String = UserDefaults.standard.string(forKey: "teamclaw_pairing_broker_username") ?? ""
+    @State private var mqttPassword: String = UserDefaults.standard.string(forKey: "teamclaw_pairing_broker_password") ?? ""
+    @FocusState private var focusedField: Field?
+
+    private enum Field {
+        case host, port, username, password, code
+    }
 
     var body: some View {
-        VStack(spacing: 32) {
-            Spacer()
+        ScrollView {
+            VStack(spacing: 28) {
+                Spacer().frame(height: 20)
 
-            // Icon
-            Image(systemName: "link.badge.plus")
-                .font(.system(size: 64))
-                .foregroundStyle(.blue)
+                // Icon
+                Image(systemName: "link.badge.plus")
+                    .font(.system(size: 56))
+                    .foregroundStyle(.blue)
 
-            // Title and subtitle
-            VStack(spacing: 8) {
-                Text("连接桌面端")
-                    .font(.title.bold())
+                // Title and subtitle
+                VStack(spacing: 8) {
+                    Text("连接桌面端")
+                        .font(.title.bold())
 
-                Text("在桌面端设置中生成配对码，然后在下方输入")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 32)
-            }
+                    Text("输入 MQTT 服务器信息和配对码")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 32)
+                }
 
-            // Code input
-            VStack(spacing: 12) {
-                TextField("000000", text: $code)
-                    .font(.system(.title, design: .monospaced).bold())
-                    .multilineTextAlignment(.center)
-                    .keyboardType(.numberPad)
-                    .textContentType(.oneTimeCode)
-                    .focused($isCodeFocused)
-                    .onChange(of: code) { _, newValue in
-                        // Limit to 6 digits
-                        let filtered = newValue.filter(\.isNumber)
-                        if filtered.count > 6 {
-                            code = String(filtered.prefix(6))
-                        } else if filtered != newValue {
-                            code = filtered
+                // MQTT Server section
+                VStack(spacing: 12) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "server.rack")
+                            .foregroundStyle(.secondary)
+                            .frame(width: 20)
+                        Text("MQTT 服务器")
+                            .font(.subheadline.bold())
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 40)
+
+                    VStack(spacing: 10) {
+                        HStack(spacing: 8) {
+                            TextField("服务器地址", text: $mqttHost)
+                                .textContentType(.URL)
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                                .focused($focusedField, equals: .host)
+                            TextField("端口", text: $mqttPort)
+                                .keyboardType(.numberPad)
+                                .focused($focusedField, equals: .port)
+                                .frame(width: 70)
+                        }
+                        .textFieldStyle(.roundedBorder)
+
+                        HStack(spacing: 8) {
+                            TextField("用户名（可选）", text: $mqttUsername)
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                                .focused($focusedField, equals: .username)
+                            SecureField("密码（可选）", text: $mqttPassword)
+                                .focused($focusedField, equals: .password)
+                        }
+                        .textFieldStyle(.roundedBorder)
+                    }
+                    .padding(.horizontal, 40)
+                }
+
+                // Code input section
+                VStack(spacing: 12) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "number")
+                            .foregroundStyle(.secondary)
+                            .frame(width: 20)
+                        Text("配对码")
+                            .font(.subheadline.bold())
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 40)
+
+                    TextField("000000", text: $code)
+                        .font(.system(.title, design: .monospaced).bold())
+                        .multilineTextAlignment(.center)
+                        .keyboardType(.numberPad)
+                        .textContentType(.oneTimeCode)
+                        .focused($focusedField, equals: .code)
+                        .onChange(of: code) { _, newValue in
+                            let filtered = newValue.filter(\.isNumber)
+                            if filtered.count > 6 {
+                                code = String(filtered.prefix(6))
+                            } else if filtered != newValue {
+                                code = filtered
+                            }
+                        }
+                        .padding(.horizontal, 40)
+
+                    Divider()
+                        .padding(.horizontal, 40)
+
+                    // Error text
+                    if let error = pairingManager.pairingError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                // Pair button
+                Button {
+                    // Save broker info for next time
+                    let ud = UserDefaults.standard
+                    ud.set(mqttHost, forKey: "teamclaw_pairing_broker_host")
+                    ud.set(Int(mqttPort) ?? 8883, forKey: "teamclaw_pairing_broker_port")
+                    ud.set(mqttUsername, forKey: "teamclaw_pairing_broker_username")
+                    ud.set(mqttPassword, forKey: "teamclaw_pairing_broker_password")
+
+                    pairingManager.pair(
+                        with: code,
+                        brokerHost: mqttHost,
+                        brokerPort: UInt16(mqttPort) ?? 8883,
+                        brokerUsername: mqttUsername.isEmpty ? nil : mqttUsername,
+                        brokerPassword: mqttPassword.isEmpty ? nil : mqttPassword
+                    )
+                } label: {
+                    Group {
+                        if pairingManager.isPairing {
+                            ProgressView()
+                                .tint(.white)
+                        } else {
+                            Text("配对")
+                                .font(.headline)
                         }
                     }
-                    .padding(.horizontal, 40)
-
-                Divider()
-                    .padding(.horizontal, 40)
-
-                // Error text
-                if let error = pairingManager.pairingError {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
                 }
-            }
+                .buttonStyle(.borderedProminent)
+                .disabled(mqttHost.isEmpty || code.count != 6 || pairingManager.isPairing)
+                .padding(.horizontal, 40)
 
-            // Pair button
-            Button {
-                pairingManager.pair(with: code)
-            } label: {
-                Group {
-                    if pairingManager.isPairing {
-                        ProgressView()
-                            .tint(.white)
-                    } else {
-                        Text("配对")
-                            .font(.headline)
-                    }
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
+                Spacer().frame(height: 20)
             }
-            .buttonStyle(.borderedProminent)
-            .disabled(code.count != 6 || pairingManager.isPairing)
-            .padding(.horizontal, 40)
-
-            Spacer()
         }
         .onAppear {
-            isCodeFocused = true
+            focusedField = mqttHost.isEmpty ? .host : .code
         }
     }
 }

--- a/TeamClawMobile/TeamClawMobile/Features/Settings/PairingView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Settings/PairingView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AVFoundation
 
 // MARK: - PairingView
 
@@ -13,6 +14,8 @@ struct PairingView: View {
     }()
     @State private var mqttUsername: String = UserDefaults.standard.string(forKey: "teamclaw_pairing_broker_username") ?? ""
     @State private var mqttPassword: String = UserDefaults.standard.string(forKey: "teamclaw_pairing_broker_password") ?? ""
+    @State private var showScanner = false
+    @State private var showManualEntry = false
     @FocusState private var focusedField: Field?
 
     private enum Field {
@@ -22,7 +25,7 @@ struct PairingView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 28) {
-                Spacer().frame(height: 20)
+                Spacer().frame(height: 40)
 
                 // Icon
                 Image(systemName: "link.badge.plus")
@@ -34,132 +37,373 @@ struct PairingView: View {
                     Text("连接桌面端")
                         .font(.title.bold())
 
-                    Text("输入 MQTT 服务器信息和配对码")
+                    Text("扫描桌面端显示的二维码即可配对")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 32)
                 }
 
-                // MQTT Server section
-                VStack(spacing: 12) {
-                    HStack(spacing: 8) {
-                        Image(systemName: "server.rack")
-                            .foregroundStyle(.secondary)
-                            .frame(width: 20)
-                        Text("MQTT 服务器")
-                            .font(.subheadline.bold())
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                    }
-                    .padding(.horizontal, 40)
-
-                    VStack(spacing: 10) {
-                        HStack(spacing: 8) {
-                            TextField("服务器地址", text: $mqttHost)
-                                .textContentType(.URL)
-                                .autocapitalization(.none)
-                                .disableAutocorrection(true)
-                                .focused($focusedField, equals: .host)
-                            TextField("端口", text: $mqttPort)
-                                .keyboardType(.numberPad)
-                                .focused($focusedField, equals: .port)
-                                .frame(width: 70)
-                        }
-                        .textFieldStyle(.roundedBorder)
-
-                        HStack(spacing: 8) {
-                            TextField("用户名（可选）", text: $mqttUsername)
-                                .autocapitalization(.none)
-                                .disableAutocorrection(true)
-                                .focused($focusedField, equals: .username)
-                            SecureField("密码（可选）", text: $mqttPassword)
-                                .focused($focusedField, equals: .password)
-                        }
-                        .textFieldStyle(.roundedBorder)
-                    }
-                    .padding(.horizontal, 40)
-                }
-
-                // Code input section
-                VStack(spacing: 12) {
-                    HStack(spacing: 8) {
-                        Image(systemName: "number")
-                            .foregroundStyle(.secondary)
-                            .frame(width: 20)
-                        Text("配对码")
-                            .font(.subheadline.bold())
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                    }
-                    .padding(.horizontal, 40)
-
-                    TextField("000000", text: $code)
-                        .font(.system(.title, design: .monospaced).bold())
-                        .multilineTextAlignment(.center)
-                        .keyboardType(.numberPad)
-                        .textContentType(.oneTimeCode)
-                        .focused($focusedField, equals: .code)
-                        .onChange(of: code) { _, newValue in
-                            let filtered = newValue.filter(\.isNumber)
-                            if filtered.count > 6 {
-                                code = String(filtered.prefix(6))
-                            } else if filtered != newValue {
-                                code = filtered
-                            }
-                        }
-                        .padding(.horizontal, 40)
-
-                    Divider()
-                        .padding(.horizontal, 40)
-
-                    // Error text
-                    if let error = pairingManager.pairingError {
-                        Text(error)
-                            .font(.caption)
-                            .foregroundStyle(.red)
-                    }
-                }
-
-                // Pair button
+                // Scan QR button
                 Button {
-                    // Save broker info for next time
-                    let ud = UserDefaults.standard
-                    ud.set(mqttHost, forKey: "teamclaw_pairing_broker_host")
-                    ud.set(Int(mqttPort) ?? 8883, forKey: "teamclaw_pairing_broker_port")
-                    ud.set(mqttUsername, forKey: "teamclaw_pairing_broker_username")
-                    ud.set(mqttPassword, forKey: "teamclaw_pairing_broker_password")
-
-                    pairingManager.pair(
-                        with: code,
-                        brokerHost: mqttHost,
-                        brokerPort: UInt16(mqttPort) ?? 8883,
-                        brokerUsername: mqttUsername.isEmpty ? nil : mqttUsername,
-                        brokerPassword: mqttPassword.isEmpty ? nil : mqttPassword
-                    )
+                    showScanner = true
                 } label: {
-                    Group {
-                        if pairingManager.isPairing {
-                            ProgressView()
-                                .tint(.white)
-                        } else {
-                            Text("配对")
-                                .font(.headline)
-                        }
+                    HStack(spacing: 12) {
+                        Image(systemName: "qrcode.viewfinder")
+                            .font(.title2)
+                        Text("扫码配对")
+                            .font(.headline)
                     }
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 14)
+                    .padding(.vertical, 16)
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(mqttHost.isEmpty || code.count != 6 || pairingManager.isPairing)
                 .padding(.horizontal, 40)
+
+                // Error text
+                if let error = pairingManager.pairingError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .padding(.horizontal, 40)
+                }
+
+                // Pairing progress
+                if pairingManager.isPairing {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                        Text("正在配对...")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                // Manual entry toggle
+                Button {
+                    withAnimation {
+                        showManualEntry.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text("手动输入")
+                            .font(.subheadline)
+                        Image(systemName: showManualEntry ? "chevron.up" : "chevron.down")
+                            .font(.caption)
+                    }
+                    .foregroundStyle(.secondary)
+                }
+
+                if showManualEntry {
+                    manualEntrySection
+                }
 
                 Spacer().frame(height: 20)
             }
         }
-        .onAppear {
-            focusedField = mqttHost.isEmpty ? .host : .code
+        .sheet(isPresented: $showScanner) {
+            QRScannerView { result in
+                showScanner = false
+                handleQRResult(result)
+            }
         }
+    }
+
+    // MARK: - Manual Entry
+
+    private var manualEntrySection: some View {
+        VStack(spacing: 20) {
+            // MQTT Server section
+            VStack(spacing: 12) {
+                HStack(spacing: 8) {
+                    Image(systemName: "server.rack")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20)
+                    Text("MQTT 服务器")
+                        .font(.subheadline.bold())
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .padding(.horizontal, 40)
+
+                VStack(spacing: 10) {
+                    HStack(spacing: 8) {
+                        TextField("服务器地址", text: $mqttHost)
+                            .textContentType(.URL)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .focused($focusedField, equals: .host)
+                        TextField("端口", text: $mqttPort)
+                            .keyboardType(.numberPad)
+                            .focused($focusedField, equals: .port)
+                            .frame(width: 70)
+                    }
+                    .textFieldStyle(.roundedBorder)
+
+                    HStack(spacing: 8) {
+                        TextField("用户名（可选）", text: $mqttUsername)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .focused($focusedField, equals: .username)
+                        SecureField("密码（可选）", text: $mqttPassword)
+                            .focused($focusedField, equals: .password)
+                    }
+                    .textFieldStyle(.roundedBorder)
+                }
+                .padding(.horizontal, 40)
+            }
+
+            // Code input
+            VStack(spacing: 12) {
+                HStack(spacing: 8) {
+                    Image(systemName: "number")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20)
+                    Text("配对码")
+                        .font(.subheadline.bold())
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .padding(.horizontal, 40)
+
+                TextField("000000", text: $code)
+                    .font(.system(.title, design: .monospaced).bold())
+                    .multilineTextAlignment(.center)
+                    .keyboardType(.numberPad)
+                    .textContentType(.oneTimeCode)
+                    .focused($focusedField, equals: .code)
+                    .onChange(of: code) { _, newValue in
+                        let filtered = newValue.filter(\.isNumber)
+                        if filtered.count > 6 {
+                            code = String(filtered.prefix(6))
+                        } else if filtered != newValue {
+                            code = filtered
+                        }
+                    }
+                    .padding(.horizontal, 40)
+
+                Divider()
+                    .padding(.horizontal, 40)
+            }
+
+            // Pair button
+            Button {
+                saveBrokerInfo()
+                pairingManager.pair(
+                    with: code,
+                    brokerHost: mqttHost,
+                    brokerPort: UInt16(mqttPort) ?? 8883,
+                    brokerUsername: mqttUsername.isEmpty ? nil : mqttUsername,
+                    brokerPassword: mqttPassword.isEmpty ? nil : mqttPassword
+                )
+            } label: {
+                Group {
+                    if pairingManager.isPairing {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Text("配对")
+                            .font(.headline)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(mqttHost.isEmpty || code.count != 6 || pairingManager.isPairing)
+            .padding(.horizontal, 40)
+        }
+        .transition(.opacity.combined(with: .move(edge: .top)))
+    }
+
+    // MARK: - QR Handling
+
+    private func handleQRResult(_ content: String) {
+        guard let data = content.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let host = json["host"] as? String,
+              let codeValue = json["code"] as? String
+        else {
+            pairingManager.pairingError = "无效的二维码"
+            return
+        }
+
+        let port = json["port"] as? Int ?? 8883
+        let username = json["user"] as? String
+        let password = json["pass"] as? String
+
+        // Update fields
+        mqttHost = host
+        mqttPort = String(port)
+        mqttUsername = username ?? ""
+        mqttPassword = password ?? ""
+        code = codeValue
+
+        saveBrokerInfo()
+
+        // Auto-pair
+        pairingManager.pair(
+            with: codeValue,
+            brokerHost: host,
+            brokerPort: UInt16(port),
+            brokerUsername: username,
+            brokerPassword: password
+        )
+    }
+
+    private func saveBrokerInfo() {
+        let ud = UserDefaults.standard
+        ud.set(mqttHost, forKey: "teamclaw_pairing_broker_host")
+        ud.set(Int(mqttPort) ?? 8883, forKey: "teamclaw_pairing_broker_port")
+        ud.set(mqttUsername, forKey: "teamclaw_pairing_broker_username")
+        ud.set(mqttPassword, forKey: "teamclaw_pairing_broker_password")
+    }
+}
+
+// MARK: - QRScannerView
+
+struct QRScannerView: UIViewControllerRepresentable {
+    let onResult: (String) -> Void
+
+    func makeUIViewController(context: Context) -> QRScannerViewController {
+        let vc = QRScannerViewController()
+        vc.onResult = onResult
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: QRScannerViewController, context: Context) {}
+}
+
+final class QRScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+    var onResult: ((String) -> Void)?
+
+    private let captureSession = AVCaptureSession()
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var hasReported = false
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+
+        guard let device = AVCaptureDevice.default(for: .video),
+              let input = try? AVCaptureDeviceInput(device: device),
+              captureSession.canAddInput(input)
+        else {
+            showError("无法访问相机")
+            return
+        }
+
+        captureSession.addInput(input)
+
+        let output = AVCaptureMetadataOutput()
+        guard captureSession.canAddOutput(output) else {
+            showError("无法初始化扫描器")
+            return
+        }
+        captureSession.addOutput(output)
+        output.setMetadataObjectsDelegate(self, queue: .main)
+        output.metadataObjectTypes = [.qr]
+
+        let preview = AVCaptureVideoPreviewLayer(session: captureSession)
+        preview.videoGravity = .resizeAspectFill
+        preview.frame = view.bounds
+        view.layer.addSublayer(preview)
+        previewLayer = preview
+
+        // Overlay UI
+        addOverlay()
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.captureSession.startRunning()
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.bounds
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        captureSession.stopRunning()
+    }
+
+    private func addOverlay() {
+        // Close button
+        let closeButton = UIButton(type: .system)
+        closeButton.setImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
+        closeButton.tintColor = .white
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        closeButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
+        view.addSubview(closeButton)
+
+        // Hint label
+        let hintLabel = UILabel()
+        hintLabel.text = "扫描桌面端的配对二维码"
+        hintLabel.textColor = .white
+        hintLabel.font = .systemFont(ofSize: 16, weight: .medium)
+        hintLabel.textAlignment = .center
+        hintLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hintLabel)
+
+        // Scan frame
+        let frameSize: CGFloat = 250
+        let scanFrame = UIView()
+        scanFrame.layer.borderColor = UIColor.white.cgColor
+        scanFrame.layer.borderWidth = 2
+        scanFrame.layer.cornerRadius = 12
+        scanFrame.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scanFrame)
+
+        NSLayoutConstraint.activate([
+            closeButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            closeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            closeButton.widthAnchor.constraint(equalToConstant: 32),
+            closeButton.heightAnchor.constraint(equalToConstant: 32),
+
+            scanFrame.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            scanFrame.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -40),
+            scanFrame.widthAnchor.constraint(equalToConstant: frameSize),
+            scanFrame.heightAnchor.constraint(equalToConstant: frameSize),
+
+            hintLabel.topAnchor.constraint(equalTo: scanFrame.bottomAnchor, constant: 24),
+            hintLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+        ])
+    }
+
+    @objc private func closeTapped() {
+        dismiss(animated: true)
+    }
+
+    func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
+        guard !hasReported,
+              let object = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+              object.type == .qr,
+              let value = object.stringValue
+        else { return }
+
+        hasReported = true
+        captureSession.stopRunning()
+
+        // Haptic feedback
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
+
+        dismiss(animated: true) { [weak self] in
+            self?.onResult?(value)
+        }
+    }
+
+    private func showError(_ message: String) {
+        let label = UILabel()
+        label.text = message
+        label.textColor = .white
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
     }
 }
 

--- a/TeamClawMobile/TeamClawMobile/Info.plist
+++ b/TeamClawMobile/TeamClawMobile/Info.plist
@@ -32,6 +32,8 @@
 		<key>UIImageName</key>
 		<string></string>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>需要使用相机扫描配对二维码</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/packages/app/src/components/settings/MobileRelaySettings.tsx
+++ b/packages/app/src/components/settings/MobileRelaySettings.tsx
@@ -10,7 +10,9 @@ import {
   Play,
   Square,
   Hash,
+  QrCode,
 } from 'lucide-react'
+import { QRCodeSVG } from 'qrcode.react'
 import { invoke } from '@tauri-apps/api/core'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -410,11 +412,32 @@ export function MobileRelaySettings() {
           )}
 
           {pairingCode ? (
-            <div className="flex flex-col items-center gap-3 py-4">
+            <div className="flex flex-col items-center gap-4 py-4">
               <p className="text-sm text-muted-foreground">
-                {t('settings.mobileRelay.pairingCodeHint', 'Enter this code on your mobile device to pair it:')}
+                {t('settings.mobileRelay.pairingQrHint', 'Scan this QR code with the mobile app to pair:')}
               </p>
-              <div className="flex items-center gap-2 px-6 py-4 rounded-xl bg-muted border-2 border-dashed border-primary/30">
+              <div className="p-4 rounded-xl bg-white">
+                <QRCodeSVG
+                  value={JSON.stringify({
+                    host: config.brokerHost,
+                    port: config.brokerPort,
+                    user: config.username || undefined,
+                    pass: config.password || undefined,
+                    code: pairingCode,
+                  })}
+                  size={180}
+                  level="H"
+                  imageSettings={{
+                    src: '/logo-64.png',
+                    x: undefined,
+                    y: undefined,
+                    height: 36,
+                    width: 36,
+                    excavate: true,
+                  }}
+                />
+              </div>
+              <div className="flex items-center gap-2 px-6 py-3 rounded-xl bg-muted border-2 border-dashed border-primary/30">
                 <Hash className="h-5 w-5 text-muted-foreground" />
                 <span className="text-4xl font-mono font-bold tracking-widest text-primary select-all">
                   {pairingCode}


### PR DESCRIPTION
## Summary
- Desktop generates QR code (with TeamClaw logo) containing MQTT broker info + pairing code when pairing is initiated
- iOS scans QR code and auto-pairs in one step — no manual typing needed
- Manual entry still available as fallback (collapsed by default)
- Removed hardcoded shared MQTT broker — users provide their own broker info
- Added camera permission (`NSCameraUsageDescription`) for QR scanning

## Test plan
- [ ] Desktop: generate pairing code, verify QR code displays with logo
- [ ] iOS: tap "扫码配对", scan QR from desktop, verify auto-pairing completes
- [ ] iOS: expand manual entry, fill fields manually, verify pairing works
- [ ] iOS: verify broker info persists across app restarts
- [ ] Verify QR code scannable with different screen brightness levels

🤖 Generated with [Claude Code](https://claude.ai/code)