### PR TITLE
feat(ios): optimize member sync — local cache, AI ally merge, detail page

### DIFF
--- a/TeamClawMobile/TeamClawMobile/Features/TeamMembers/MemberDetailView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/TeamMembers/MemberDetailView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct MemberDetailView: View {
+    let member: TeamMember
+    @ObservedObject var viewModel: MemberViewModel
+
+    var body: some View {
+        List {
+            // Header section
+            Section {
+                HStack(spacing: 16) {
+                    ZStack {
+                        Circle()
+                            .fill(member.isAIAlly ? Color.blue.opacity(0.15) : Color.purple.opacity(0.15))
+                            .frame(width: 64, height: 64)
+
+                        if member.isAIAlly {
+                            Image(systemName: "cpu")
+                                .font(.title2)
+                                .foregroundStyle(.blue)
+                        } else {
+                            Text(String(member.name.prefix(1)))
+                                .font(.title2)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(.purple)
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack(spacing: 8) {
+                            Text(member.name)
+                                .font(.title3)
+                                .fontWeight(.semibold)
+
+                            Text(member.isAIAlly ? "AI 搭档" : "成员")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                                .foregroundStyle(member.isAIAlly ? .blue : .secondary)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 3)
+                                .background(
+                                    Capsule()
+                                        .fill(member.isAIAlly ? Color.blue.opacity(0.1) : Color.secondary.opacity(0.1))
+                                )
+                        }
+
+                        if let dept = member.department, !dept.isEmpty {
+                            Text(dept)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        if let note = member.note, !note.isEmpty {
+                            Text(note)
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+
+            // Collaborative sessions section
+            let sessions = viewModel.collaborativeSessions(for: member)
+            Section("协作 Session") {
+                if sessions.isEmpty {
+                    Text("暂无协作 Session")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(sessions, id: \.id) { session in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(session.title)
+                                .fontWeight(.medium)
+
+                            Text(session.lastMessageContent)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            }
+
+            Section {
+                Button {
+                    // Placeholder for new collaborative session
+                } label: {
+                    Label("新建协作 Session", systemImage: "plus.bubble")
+                }
+            }
+        }
+        .navigationTitle(member.name)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/TeamClawMobile/TeamClawMobile/Features/TeamMembers/MemberListView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/TeamMembers/MemberListView.swift
@@ -40,7 +40,7 @@ struct MemberListView: View {
                 } else {
                     List(displayedMembers, id: \.id) { member in
                         NavigationLink {
-                            MemberSessionsView(member: member, viewModel: viewModel)
+                            MemberDetailView(member: member, viewModel: viewModel)
                         } label: {
                             MemberRow(member: member)
                         }

--- a/TeamClawMobile/TeamClawMobile/Features/TeamMembers/MemberViewModel.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/TeamMembers/MemberViewModel.swift
@@ -112,7 +112,13 @@ final class MemberViewModel: ObservableObject {
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] status in
-                self?.isDesktopOnline = status.online
+                guard let self else { return }
+                let wasOffline = !self.isDesktopOnline
+                self.isDesktopOnline = status.online
+                // Auto-refresh members when desktop comes online
+                if wasOffline && status.online {
+                    self.requestMembers(page: 1)
+                }
             }
             .store(in: &cancellables)
     }

--- a/src-tauri/crates/teamclaw-sync/src/oss_sync.rs
+++ b/src-tauri/crates/teamclaw-sync/src/oss_sync.rs
@@ -2842,6 +2842,13 @@ impl OssSyncManager {
                         }
                     }
 
+                    // 1b. Cache members manifest locally for MQTT relay
+                    if !had_network_error {
+                        if let Err(e) = manager.download_and_cache_members_manifest().await {
+                            warn!("OSS slow loop: failed to cache members manifest: {}", e);
+                        }
+                    }
+
                     // 2. List pending applications for owners/editors
                     if manager.role() == MemberRole::Owner || manager.role() == MemberRole::Editor {
                         match manager.list_applications().await {
@@ -3117,6 +3124,27 @@ impl OssSyncManager {
             Err(e) if e.contains("NoSuchKey") || e.contains("not found") => Ok(None),
             Err(e) => Err(e),
         }
+    }
+
+    /// Download members manifest from S3 and cache it locally for MQTT relay.
+    pub async fn download_and_cache_members_manifest(&self) -> Result<Option<TeamManifest>, String> {
+        let manifest = self.download_members_manifest().await?;
+        if let Some(ref m) = manifest {
+            let team_dir = std::path::Path::new(&self.workspace_path)
+                .join(&self.teamclaw_dir_name)
+                .join("_team");
+            if let Err(e) = std::fs::create_dir_all(&team_dir) {
+                warn!("Failed to create _team dir: {}", e);
+            } else {
+                let json = serde_json::to_string_pretty(m)
+                    .map_err(|e| format!("Failed to serialize manifest: {}", e))?;
+                let path = team_dir.join("members.json");
+                if let Err(e) = std::fs::write(&path, json) {
+                    warn!("Failed to cache members.json locally: {}", e);
+                }
+            }
+        }
+        Ok(manifest)
     }
 
     /// Add a member to the manifest and upload

--- a/src-tauri/src/commands/gateway/mqtt_relay.rs
+++ b/src-tauri/src/commands/gateway/mqtt_relay.rs
@@ -580,19 +580,53 @@ impl MqttRelay {
         device_id: &str,
         _req: &proto::MemberSyncRequest,
     ) -> Result<(), String> {
-        let manifest = self.fetch_team_manifest().await?;
+        let manifest = self.fetch_team_manifest()?;
 
-        let members: Vec<proto::MemberData> = match manifest {
-            Some(m) => m.members.into_iter().map(|tm| proto::MemberData {
-                id: tm.node_id,
-                name: if tm.name.is_empty() { tm.hostname.clone() } else { tm.name },
-                avatar_url: String::new(),
-                department: if tm.label.is_empty() { None } else { Some(tm.label) },
-                is_ai_ally: tm.role == MemberRole::Seed,
-                note: format!("{}/{} ({:?})", tm.platform, tm.arch, tm.role),
-            }).collect(),
+        // Human members from manifest (filter out Seed nodes)
+        let mut members: Vec<proto::MemberData> = match manifest {
+            Some(m) => m.members.into_iter()
+                .filter(|tm| tm.role != MemberRole::Seed)
+                .map(|tm| proto::MemberData {
+                    id: tm.node_id,
+                    name: if tm.name.is_empty() { tm.hostname.clone() } else { tm.name },
+                    avatar_url: String::new(),
+                    department: if tm.label.is_empty() { None } else { Some(tm.label) },
+                    is_ai_ally: false,
+                    note: format!("{}/{} ({:?})", tm.platform, tm.arch, tm.role),
+                }).collect(),
             None => vec![],
         };
+
+        // AI allies from .opencode/roles/
+        let roles_dir = std::path::Path::new(&self.workspace_path)
+            .join(".opencode")
+            .join("roles");
+        if roles_dir.exists() {
+            if let Ok(entries) = std::fs::read_dir(&roles_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if !path.is_dir() { continue; }
+                    let slug = entry.file_name().to_string_lossy().to_string();
+                    if slug == "skill" || slug == "config.json" { continue; }
+
+                    let role_md = path.join("ROLE.md");
+                    if !role_md.exists() { continue; }
+
+                    if let Ok(content) = std::fs::read_to_string(&role_md) {
+                        let parsed = parse_role_md(&content);
+                        let name = if parsed.name.is_empty() { slug.clone() } else { parsed.name };
+                        members.push(proto::MemberData {
+                            id: slug,
+                            name,
+                            avatar_url: String::new(),
+                            department: Some("Role".to_string()),
+                            is_ai_ally: true,
+                            note: parsed.description,
+                        });
+                    }
+                }
+            }
+        }
 
         let total = members.len() as i32;
         let msg = build_envelope(proto::mqtt_message::Payload::MemberSyncResponse(
@@ -604,54 +638,21 @@ impl MqttRelay {
         self.publish_proto_to_device(device_id, "member", &msg).await
     }
 
-    /// Fetch TeamManifest: try P2P local file first, then OSS S3.
-    async fn fetch_team_manifest(&self) -> Result<Option<TeamManifest>, String> {
-        // Try P2P local file first (fast, no network)
-        let manifest_path = format!("{}/teamclaw-team/_team/members.json", self.workspace_path);
-        match std::fs::read_to_string(&manifest_path) {
-            Ok(content) => match serde_json::from_str::<TeamManifest>(&content) {
-                Ok(manifest) => {
-                    return Ok(Some(manifest));
-                }
-                Err(e) => {
-                    eprintln!("[MQTT Relay] P2P members.json parse error: {}", e);
-                }
-            },
-            Err(_) => {
-                // P2P file not available — fall through to S3
+    /// Fetch TeamManifest from local files only (P2P or OSS cache). No S3 calls.
+    fn fetch_team_manifest(&self) -> Result<Option<TeamManifest>, String> {
+        // Try P2P local file
+        let p2p_path = format!("{}/teamclaw-team/_team/members.json", self.workspace_path);
+        if let Ok(content) = std::fs::read_to_string(&p2p_path) {
+            if let Ok(manifest) = serde_json::from_str::<TeamManifest>(&content) {
+                return Ok(Some(manifest));
             }
         }
 
-        // Fallback to OSS S3 (if configured)
-        match self.oss_sync_state {
-            None => {
-                eprintln!("[MQTT Relay] No OSS sync state configured, cannot fetch members");
-            }
-            Some(ref oss_state) => {
-                let mut guard = oss_state.lock().await;
-                match *guard {
-                    None => {
-                        eprintln!("[MQTT Relay] OSS manager not initialized, cannot fetch members");
-                    }
-                    Some(ref mut manager) => {
-                        manager.refresh_token_if_needed().await?;
-                        let key = format!("teams/{}/_meta/members.json", manager.team_id());
-                        match manager.s3_get(&key).await {
-                            Ok(data) => {
-                                let manifest: TeamManifest = serde_json::from_slice(&data)
-                                    .map_err(|e| format!("Failed to parse OSS members.json: {}", e))?;
-                                return Ok(Some(manifest));
-                            }
-                            Err(e) if e.contains("NoSuchKey") || e.contains("not found") => {
-                                return Ok(None);
-                            }
-                            Err(e) => {
-                                eprintln!("[MQTT Relay] OSS members fetch failed: {}", e);
-                                return Err(format!("OSS members fetch failed: {}", e));
-                            }
-                        }
-                    }
-                }
+        // Try OSS local cache (written by slow loop)
+        let oss_cache_path = format!("{}/.teamclaw/_team/members.json", self.workspace_path);
+        if let Ok(content) = std::fs::read_to_string(&oss_cache_path) {
+            if let Ok(manifest) = serde_json::from_str::<TeamManifest>(&content) {
+                return Ok(Some(manifest));
             }
         }
 


### PR DESCRIPTION
## Summary
- OSS slow loop now caches `members.json` locally at `{workspace}/.teamclaw/_team/members.json` for zero-network MQTT relay reads
- MQTT relay `fetch_team_manifest()` is now a pure local sync function — reads P2P file then OSS cache, no S3 calls
- `handle_member_sync_request` filters out Seed nodes and merges AI allies from `.opencode/roles/` (with description in `note` field)
- iOS auto-refreshes members when desktop transitions to online
- New `MemberDetailView` with header (avatar, name, badge, department, note) + embedded collaborative sessions list

## Test plan
- [ ] Verify OSS mode creates local `_team/members.json` after first slow loop cycle
- [ ] Verify MQTT member sync returns both human members and AI allies
- [ ] Verify Seed nodes are filtered from member list
- [ ] Verify iOS displays cached members immediately, refreshes when desktop comes online
- [ ] Verify MemberDetailView shows correct info for human vs AI ally members

🤖 Generated with [Claude Code](https://claude.ai/code)