### PR TITLE
feat(ios): incremental session sync + structured message parts

### DIFF
--- a/TeamClawMobile/TeamClawMobile.xcodeproj/project.pbxproj
+++ b/TeamClawMobile/TeamClawMobile.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		EFD3FEF6ECB8BB3196FB7E17 /* ConnectionMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4BF600C2F057B605FC1015 /* ConnectionMonitorTests.swift */; };
 		F72276690532533498ED380B /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36621DE5BE808E48FCAB3565 /* ChatMessage.swift */; };
 		F92B8FF29F538FE5EF2E82AD /* StreamingTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 304DBC8795E823C5963EE650 /* StreamingTextView.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* ToolCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E5F4A3B2C1D0E9F8071625 /* ToolCallView.swift */; };
 		FB47D1A057337D95C268D8D1 /* MessageAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877250779DF25DFB6EA564C9 /* MessageAggregator.swift */; };
 		FC43E4D56FEA629C3A0072FB /* SessionListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65299398879A9250C02F60B9 /* SessionListViewModelTests.swift */; };
 		FC84563FEF5BE97D9D28FB07 /* RoleDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A2D13653D33ACFF78BD96C /* RoleDetailView.swift */; };
@@ -102,6 +103,7 @@
 		2AC0C0BCFF2BE9EC099FB476 /* SkillHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillHomeView.swift; sourceTree = "<group>"; };
 		2FCB7D9D27F63BE7540362BC /* Skill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Skill.swift; sourceTree = "<group>"; };
 		304DBC8795E823C5963EE650 /* StreamingTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingTextView.swift; sourceTree = "<group>"; };
+		D6E5F4A3B2C1D0E9F8071625 /* ToolCallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallView.swift; sourceTree = "<group>"; };
 		36621DE5BE808E48FCAB3565 /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		3753BE0DCBBDDF6981D3B684 /* MemberAutomationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberAutomationView.swift; sourceTree = "<group>"; };
 		3AF9EEA26C502C1D43B7E4D2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 				9DC4A3372C9F29BEC02488EB /* ChatInputBar.swift */,
 				FC5358997970581A339AEFF3 /* MessageBubbleView.swift */,
 				304DBC8795E823C5963EE650 /* StreamingTextView.swift */,
+				D6E5F4A3B2C1D0E9F8071625 /* ToolCallView.swift */,
 			);
 			path = Chat;
 			sourceTree = "<group>";
@@ -591,6 +594,7 @@
 				54432692497E580B6783943C /* SkillMarketView.swift in Sources */,
 				858DB153EFDF26079F8F3655 /* SkillViewModel.swift in Sources */,
 				F92B8FF29F538FE5EF2E82AD /* StreamingTextView.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* ToolCallView.swift in Sources */,
 				2BA0BFB80E068EBFF2E3B86D /* Talent.swift in Sources */,
 				D7601B4CBD1B8F3C837F4B0B /* TalentViewModel.swift in Sources */,
 				161E2FC7CA32B7CB0625F006 /* TaskEditView.swift in Sources */,

--- a/TeamClawMobile/TeamClawMobile/Core/MQTT/ProtoMQTTCoder.swift
+++ b/TeamClawMobile/TeamClawMobile/Core/MQTT/ProtoMQTTCoder.swift
@@ -25,7 +25,18 @@ enum ProtoMQTTCoder {
         case .sessionSyncRequest(let r):  type = "SessionSyncReq(page=\(r.pagination.page),after=\(r.afterUpdated))"
         case .sessionSyncResponse(let r): type = "SessionSyncRes(sessions=\(r.sessions.count), page=\(r.pagination.page)/total=\(r.pagination.total))"
         case .chatRequest(let r):         type = "ChatReq(session=\(r.sessionID.prefix(8)))"
-        case .chatResponse(let r):        type = "ChatRes(session=\(r.sessionID.prefix(8)), seq=\(r.seq))"
+        case .chatResponse(let r):
+            let eventDesc: String
+            switch r.event {
+            case .delta: eventDesc = "delta"
+            case .done: eventDesc = "done"
+            case .error: eventDesc = "error"
+            case .toolEvent(let t): eventDesc = "tool(\(t.toolName),\(t.status))"
+            case .hasThinking: eventDesc = "thinking"
+            case .none: eventDesc = "none"
+            @unknown default: eventDesc = "unknown"
+            }
+            type = "ChatRes(session=\(r.sessionID.prefix(8)),seq=\(r.seq),\(eventDesc))"
         case .chatCancel(let r):          type = "ChatCancel(session=\(r.sessionID.prefix(8)))"
         case .memberSyncRequest(let r):   type = "MemberSyncReq(page=\(r.pagination.page))"
         case .memberSyncResponse(let r):  type = "MemberSyncRes(members=\(r.members.count))"

--- a/TeamClawMobile/TeamClawMobile/Core/MQTT/ProtoMQTTCoder.swift
+++ b/TeamClawMobile/TeamClawMobile/Core/MQTT/ProtoMQTTCoder.swift
@@ -22,7 +22,7 @@ enum ProtoMQTTCoder {
     static func summary(_ msg: Teamclaw_MqttMessage) -> String {
         let type: String
         switch msg.payload {
-        case .sessionSyncRequest(let r):  type = "SessionSyncReq(page=\(r.pagination.page))"
+        case .sessionSyncRequest(let r):  type = "SessionSyncReq(page=\(r.pagination.page),after=\(r.afterUpdated))"
         case .sessionSyncResponse(let r): type = "SessionSyncRes(sessions=\(r.sessions.count), page=\(r.pagination.page)/total=\(r.pagination.total))"
         case .chatRequest(let r):         type = "ChatReq(session=\(r.sessionID.prefix(8)))"
         case .chatResponse(let r):        type = "ChatRes(session=\(r.sessionID.prefix(8)), seq=\(r.seq))"

--- a/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailView.swift
@@ -92,7 +92,7 @@ struct ChatDetailView: View {
                         }
 
                         if viewModel.isStreaming {
-                            StreamingTextView(content: viewModel.streamingContent)
+                            StreamingTextView(content: viewModel.streamingContent, streamingToolCalls: viewModel.streamingToolCalls)
                                 .id("streaming")
                         }
 

--- a/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailViewModel.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailViewModel.swift
@@ -12,6 +12,8 @@ final class ChatDetailViewModel: ObservableObject {
     @Published var isDesktopOnline = true
     @Published var selectedModel: String = "default"
     @Published var availableModels: [String] = ["default"]
+    @Published var streamingToolCalls: [ToolCallInfo] = []
+    private var hasStreamingThinking = false
 
     let sessionID: String
     private var modelContext: ModelContext?
@@ -171,16 +173,38 @@ final class ChatDetailViewModel: ObservableObject {
 
         for data in response.messages {
             guard !existingIDs.contains(data.id) else { continue }
-            // Skip empty messages (e.g. tool_use only)
-            guard !data.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+
+            let messageParts: [MessagePart] = data.parts.map { partData in
+                if partData.type == "tool" && partData.hasTool {
+                    let t = partData.tool
+                    return MessagePart(type: "tool", text: nil, tool: ToolCallInfo(
+                        toolCallId: t.toolCallID,
+                        toolName: t.toolName,
+                        status: t.status,
+                        argumentsJson: t.argumentsJson,
+                        resultSummary: t.resultSummary,
+                        durationMs: Int(t.durationMs)
+                    ))
+                } else {
+                    return MessagePart(type: "text", text: partData.hasText ? partData.text : nil, tool: nil)
+                }
+            }
+            let partsData = (try? JSONEncoder().encode(messageParts)) ?? Data()
+            let partsJSON = String(data: partsData, encoding: .utf8) ?? "[]"
+
+            let displayContent = data.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !displayContent.isEmpty || !messageParts.isEmpty else { continue }
+
             let role: MessageRole = data.role == "assistant" ? .assistant : .user
             let message = ChatMessage(
                 id: data.id,
                 sessionID: sessionID,
                 role: role,
-                content: data.content,
+                content: displayContent,
                 timestamp: Date(timeIntervalSince1970: data.timestamp),
-                imageURL: data.hasImageURL ? data.imageURL : nil
+                imageURL: data.hasImageURL ? data.imageURL : nil,
+                partsJSON: partsJSON,
+                hasThinking: data.hasThinking
             )
             modelContext.insert(message)
             newMessages.append(message)
@@ -223,6 +247,25 @@ final class ChatDetailViewModel: ObservableObject {
         case .error(let err):
             let finalContent = aggregator.currentContent(for: messageID)
             finishStreaming(messageID: messageID, content: finalContent + "\n[Error: \(err.message)]")
+
+        case .toolEvent(let toolEvent):
+            let info = ToolCallInfo(
+                toolCallId: toolEvent.toolCallID,
+                toolName: toolEvent.toolName,
+                status: toolEvent.status,
+                argumentsJson: toolEvent.argumentsJson,
+                resultSummary: toolEvent.resultSummary,
+                durationMs: Int(toolEvent.durationMs)
+            )
+            if let idx = streamingToolCalls.firstIndex(where: { $0.toolCallId == info.toolCallId }) {
+                streamingToolCalls[idx] = info
+            } else {
+                streamingToolCalls.append(info)
+            }
+
+        case .hasThinking(let flag):
+            if flag { hasStreamingThinking = true }
+
         default:
             break
         }
@@ -231,23 +274,36 @@ final class ChatDetailViewModel: ObservableObject {
     private func finishStreaming(messageID: String, content: String) {
         isStreaming = false
 
+        var messageParts: [MessagePart] = []
+        if !content.isEmpty {
+            messageParts.append(MessagePart(type: "text", text: content, tool: nil))
+        }
+        for tool in streamingToolCalls {
+            messageParts.append(MessagePart(type: "tool", text: nil, tool: tool))
+        }
+        let partsData = (try? JSONEncoder().encode(messageParts)) ?? Data()
+        let partsJSON = String(data: partsData, encoding: .utf8) ?? "[]"
+
         let assistantMessage = ChatMessage(
             id: UUID().uuidString,
             sessionID: sessionID,
             role: .assistant,
             content: content,
-            timestamp: Date()
+            timestamp: Date(),
+            partsJSON: partsJSON,
+            hasThinking: hasStreamingThinking
         )
         modelContext?.insert(assistantMessage)
         try? modelContext?.save()
         messages.append(assistantMessage)
 
         streamingContent = ""
+        streamingToolCalls = []
+        hasStreamingThinking = false
         aggregator.reset(messageID: messageID)
         currentStreamingMessageID = nil
         aggregatorCancellable = nil
 
-        // Refresh session list — OpenCode may have updated the title after first reply
         requestSessionRefresh()
     }
 

--- a/TeamClawMobile/TeamClawMobile/Features/Chat/MessageBubbleView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Chat/MessageBubbleView.swift
@@ -66,11 +66,47 @@ struct MessageBubbleView: View {
 
     private var assistantBubble: some View {
         HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 0) {
-                MarkdownRenderer(content: message.content)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            VStack(alignment: .leading, spacing: 4) {
+                let messageParts = message.parts
+                if messageParts.isEmpty {
+                    MarkdownRenderer(content: message.content)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                } else {
+                    ForEach(Array(messageParts.enumerated()), id: \.offset) { _, part in
+                        switch part.type {
+                        case "text":
+                            if let text = part.text, !text.isEmpty {
+                                MarkdownRenderer(content: text)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 4)
+                            }
+                        case "tool":
+                            if let tool = part.tool {
+                                ToolCallView(tool: tool)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 2)
+                            }
+                        default:
+                            EmptyView()
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                if message.hasThinking {
+                    HStack(spacing: 4) {
+                        Image(systemName: "brain")
+                            .font(.system(size: 9))
+                        Text("有思考过程")
+                            .font(.system(size: 9))
+                    }
+                    .foregroundStyle(.secondary)
                     .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
+                    .padding(.bottom, 6)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color(red: 0.94, green: 0.945, blue: 0.961))

--- a/TeamClawMobile/TeamClawMobile/Features/Chat/StreamingTextView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Chat/StreamingTextView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct StreamingTextView: View {
     let content: String
+    var streamingToolCalls: [ToolCallInfo] = []
 
     @State private var cursorVisible = true
 
@@ -17,6 +18,12 @@ struct StreamingTextView: View {
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
+
+                ForEach(streamingToolCalls) { tool in
+                    ToolCallView(tool: tool)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color(red: 0.94, green: 0.945, blue: 0.961))

--- a/TeamClawMobile/TeamClawMobile/Features/Chat/ToolCallView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Chat/ToolCallView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+struct ToolCallView: View {
+    let tool: ToolCallInfo
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .foregroundStyle(.secondary)
+
+                    Image(systemName: toolIcon)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Text(displayName)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.primary)
+
+                    if let summary = tool.summary, !isExpanded {
+                        Text(summary)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+
+                    Spacer()
+
+                    if tool.durationMs > 0 && tool.status != "running" {
+                        Text(formatDuration(tool.durationMs))
+                            .font(.system(size: 9))
+                            .foregroundStyle(.tertiary)
+                    }
+
+                    statusIndicator
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 8) {
+                    if !tool.argumentsJson.isEmpty && tool.argumentsJson != "{}" {
+                        detailSection(title: "Arguments", content: formatJSON(tool.argumentsJson))
+                    }
+                    if !tool.resultSummary.isEmpty {
+                        detailSection(title: "Result", content: tool.resultSummary)
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.bottom, 8)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .background(Color(.systemGray6))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var toolIcon: String {
+        let name = tool.toolName.lowercased()
+        if name.contains("write") || name.contains("edit") { return "doc.text" }
+        if name.contains("read") { return "doc" }
+        if name.contains("bash") || name.contains("shell") || name.contains("terminal") { return "terminal" }
+        if name.contains("search") || name.contains("grep") || name.contains("glob") { return "magnifyingglass" }
+        if name.contains("task") { return "person.2" }
+        if name.contains("web") { return "globe" }
+        return "wrench"
+    }
+
+    private var displayName: String {
+        let name = tool.toolName
+        if let range = name.range(of: "__", options: .backwards) {
+            return String(name[range.upperBound...])
+        }
+        return name
+    }
+
+    @ViewBuilder
+    private var statusIndicator: some View {
+        switch tool.status {
+        case "running":
+            ProgressView()
+                .scaleEffect(0.6)
+                .frame(width: 14, height: 14)
+        case "completed":
+            Image(systemName: "checkmark.circle.fill")
+                .font(.caption2)
+                .foregroundStyle(.green)
+        case "failed":
+            Image(systemName: "xmark.circle.fill")
+                .font(.caption2)
+                .foregroundStyle(.red)
+        default:
+            EmptyView()
+        }
+    }
+
+    private func detailSection(title: String, content: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+            Text(content)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.primary)
+                .lineLimit(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(6)
+                .background(Color(.systemBackground).opacity(0.6))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+    }
+
+    private func formatDuration(_ ms: Int) -> String {
+        if ms < 1000 { return "\(ms)ms" }
+        return String(format: "%.1fs", Double(ms) / 1000.0)
+    }
+
+    private func formatJSON(_ json: String) -> String {
+        guard let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data),
+              let pretty = try? JSONSerialization.data(withJSONObject: obj, options: .prettyPrinted),
+              let str = String(data: pretty, encoding: .utf8) else {
+            return json
+        }
+        return str
+    }
+}

--- a/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListView.swift
@@ -9,6 +9,7 @@ struct SessionListView: View {
     @ObservedObject var pairingManager: PairingManager
 
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.scenePhase) private var scenePhase
     @StateObject private var viewModel: SessionListViewModel
 
     @State private var showFunctionPanel = false
@@ -167,6 +168,11 @@ struct SessionListView: View {
             .onAppear {
                 viewModel.setModelContext(modelContext)
                 viewModel.loadSessions()
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                if newPhase == .active {
+                    viewModel.refreshIfStale()
+                }
             }
         }
     }

--- a/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListViewModel.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListViewModel.swift
@@ -16,6 +16,15 @@ final class SessionListViewModel: ObservableObject {
     // Buffer for MQTT responses that arrived before modelContext was set
     private var pendingSessionResponse: Teamclaw_SessionSyncResponse?
 
+    /// 上次成功同步的时间戳（秒），持久化到 UserDefaults
+    private var lastSyncTimestamp: Int64 {
+        get { UserDefaults.standard.value(forKey: "sessionLastSyncTimestamp") as? Int64 ?? 0 }
+        set { UserDefaults.standard.set(newValue, forKey: "sessionLastSyncTimestamp") }
+    }
+
+    /// 自动刷新阈值：60 分钟
+    private let staleThreshold: TimeInterval = 60 * 60
+
     func setModelContext(_ context: ModelContext) {
         guard modelContext == nil else { return }
         modelContext = context
@@ -48,7 +57,7 @@ final class SessionListViewModel: ObservableObject {
             .sink { [weak self] _ in
                 // Only re-fetch if the view is active (modelContext set) and we have no sessions yet
                 guard let self, self.modelContext != nil, self.sessions.isEmpty else { return }
-                self.requestSessions()
+                self.requestSessions(page: 1, incremental: false)
             }
             .store(in: &cancellables)
     }
@@ -71,10 +80,15 @@ final class SessionListViewModel: ObservableObject {
             filteredSessions = []
         }
 
-        requestSessions(page: 1)
+        // 如果本地已有 session 且有上次同步记录，用增量模式
+        if !sessions.isEmpty && lastSyncTimestamp > 0 {
+            requestSessions(page: 1, incremental: true)
+        } else {
+            requestSessions(page: 1, incremental: false)
+        }
     }
 
-    func requestSessions(page: Int = 1) {
+    func requestSessions(page: Int = 1, incremental: Bool = false) {
         guard let creds = PairingManager.currentCredentials else { return }
         if page == 1 { isLoading = true; startLoadingTimeout() }
         let topic = "teamclaw/\(creds.teamID)/\(creds.deviceID)/chat/req"
@@ -83,6 +97,10 @@ final class SessionListViewModel: ObservableObject {
         pg.page = Int32(page)
         pg.pageSize = 50
         req.pagination = pg
+        if incremental && lastSyncTimestamp > 0 {
+            // 减 5 分钟容差，防止 iOS/桌面时钟偏差导致漏掉 session
+            req.afterUpdated = max(0, lastSyncTimestamp - 300)
+        }
         let msg = ProtoMQTTCoder.makeEnvelope(.sessionSyncRequest(req))
         mqttService.publish(topic: topic, message: msg, qos: 1)
     }
@@ -96,7 +114,6 @@ final class SessionListViewModel: ObservableObject {
 
     private func handleSessionSync(_ response: Teamclaw_SessionSyncResponse) {
         guard let modelContext else {
-            // modelContext not yet set (onAppear hasn't fired); buffer and retry
             NSLog("[SessionList] handleSessionSync: modelContext nil — buffering %d sessions", response.sessions.count)
             pendingSessionResponse = response
             return
@@ -104,6 +121,15 @@ final class SessionListViewModel: ObservableObject {
         NSLog("[SessionList] handleSessionSync: processing %d sessions, in-memory sessions=%d", response.sessions.count, sessions.count)
         for sessionData in response.sessions {
             let updated = Date(timeIntervalSince1970: TimeInterval(sessionData.updated))
+
+            if sessionData.isArchived {
+                // 桌面端归档了这个 session → 本地也标记归档
+                if let existing = sessions.first(where: { $0.id == sessionData.id }) {
+                    existing.isArchived = true
+                }
+                continue
+            }
+
             if let existing = sessions.first(where: { $0.id == sessionData.id }) {
                 existing.title = sessionData.title
                 existing.lastMessageTime = updated
@@ -131,6 +157,7 @@ final class SessionListViewModel: ObservableObject {
         } else {
             isLoading = false
             loadingTimer?.cancel()
+            lastSyncTimestamp = Int64(Date().timeIntervalSince1970)
             loadSessionsFromDB()
         }
     }
@@ -163,6 +190,16 @@ final class SessionListViewModel: ObservableObject {
                 session.title.localizedCaseInsensitiveContains(query) ||
                 session.lastMessageContent.localizedCaseInsensitiveContains(query)
             }
+        }
+    }
+
+    /// 距上次同步超过阈值则自动增量刷新
+    func refreshIfStale() {
+        let now = Int64(Date().timeIntervalSince1970)
+        let elapsed = now - lastSyncTimestamp
+        if elapsed >= Int64(staleThreshold) {
+            NSLog("[SessionList] refreshIfStale: %d seconds since last sync, triggering incremental refresh", elapsed)
+            requestSessions(page: 1, incremental: true)
         }
     }
 

--- a/TeamClawMobile/TeamClawMobile/Generated/teamclaw.pb.swift
+++ b/TeamClawMobile/TeamClawMobile/Generated/teamclaw.pb.swift
@@ -338,12 +338,30 @@ struct Teamclaw_ChatResponse: Sendable {
     set {event = .error(newValue)}
   }
 
+  var toolEvent: Teamclaw_ToolEvent {
+    get {
+      if case .toolEvent(let v)? = event {return v}
+      return Teamclaw_ToolEvent()
+    }
+    set {event = .toolEvent(newValue)}
+  }
+
+  var hasThinking: Bool {
+    get {
+      if case .hasThinking(let v)? = event {return v}
+      return false
+    }
+    set {event = .hasThinking(newValue)}
+  }
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   enum OneOf_Event: Equatable, Sendable {
     case delta(String)
     case done(Teamclaw_StreamDone)
     case error(Teamclaw_StreamError)
+    case toolEvent(Teamclaw_ToolEvent)
+    case hasThinking(Bool)
 
   }
 
@@ -370,6 +388,61 @@ struct Teamclaw_StreamError: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
+}
+
+struct Teamclaw_ToolEvent: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var toolCallID: String = String()
+
+  var toolName: String = String()
+
+  var status: String = String()
+
+  var argumentsJson: String = String()
+
+  var resultSummary: String = String()
+
+  var durationMs: Int32 = 0
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+struct Teamclaw_MessagePartData: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var type: String = String()
+
+  var text: String {
+    get {_text ?? String()}
+    set {_text = newValue}
+  }
+  /// Returns true if `text` has been explicitly set.
+  var hasText: Bool {self._text != nil}
+  /// Clears the value of `text`. Subsequent reads from it will return its default value.
+  mutating func clearText() {self._text = nil}
+
+  var tool: Teamclaw_ToolEvent {
+    get {_tool ?? Teamclaw_ToolEvent()}
+    set {_tool = newValue}
+  }
+  /// Returns true if `tool` has been explicitly set.
+  var hasTool: Bool {self._tool != nil}
+  /// Clears the value of `tool`. Subsequent reads from it will return its default value.
+  mutating func clearTool() {self._tool = nil}
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+
+  fileprivate var _text: String? = nil
+  fileprivate var _tool: Teamclaw_ToolEvent? = nil
 }
 
 struct Teamclaw_ChatCancel: Sendable {
@@ -867,6 +940,10 @@ struct Teamclaw_ChatMessageData: Sendable {
   var hasImageURL: Bool {self._imageURL != nil}
   /// Clears the value of `imageURL`. Subsequent reads from it will return its default value.
   mutating func clearImageURL() {self._imageURL = nil}
+
+  var parts: [Teamclaw_MessagePartData] = []
+
+  var hasThinking: Bool = false
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1501,7 +1578,7 @@ extension Teamclaw_ChatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
 extension Teamclaw_ChatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ChatResponse"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{1}seq\0\u{2}\u{8}delta\0\u{1}done\0\u{1}error\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{1}seq\0\u{2}\u{8}delta\0\u{1}done\0\u{1}error\0\u{3}tool_event\0\u{3}has_thinking\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1545,6 +1622,27 @@ extension Teamclaw_ChatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
           self.event = .error(v)
         }
       }()
+      case 13: try {
+        var v: Teamclaw_ToolEvent?
+        var hadOneofValue = false
+        if let current = self.event {
+          hadOneofValue = true
+          if case .toolEvent(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.event = .toolEvent(v)
+        }
+      }()
+      case 14: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.event != nil {try decoder.handleConflictingOneOf()}
+          self.event = .hasThinking(v)
+        }
+      }()
       default: break
       }
     }
@@ -1573,6 +1671,14 @@ extension Teamclaw_ChatResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     case .error?: try {
       guard case .error(let v)? = self.event else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+    }()
+    case .toolEvent?: try {
+      guard case .toolEvent(let v)? = self.event else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+    }()
+    case .hasThinking?: try {
+      guard case .hasThinking(let v)? = self.event else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 14)
     }()
     case nil: break
     }
@@ -1632,6 +1738,116 @@ extension Teamclaw_StreamError: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
 
   static func ==(lhs: Teamclaw_StreamError, rhs: Teamclaw_StreamError) -> Bool {
     if lhs.message != rhs.message {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Teamclaw_ToolEvent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".ToolEvent"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "tool_call_id"),
+    2: .standard(proto: "tool_name"),
+    3: .same(proto: "status"),
+    4: .standard(proto: "arguments_json"),
+    5: .standard(proto: "result_summary"),
+    6: .standard(proto: "duration_ms"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.toolCallID) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.toolName) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.status) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.argumentsJson) }()
+      case 5: try { try decoder.decodeSingularStringField(value: &self.resultSummary) }()
+      case 6: try { try decoder.decodeSingularInt32Field(value: &self.durationMs) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.toolCallID.isEmpty {
+      try visitor.visitSingularStringField(value: self.toolCallID, fieldNumber: 1)
+    }
+    if !self.toolName.isEmpty {
+      try visitor.visitSingularStringField(value: self.toolName, fieldNumber: 2)
+    }
+    if !self.status.isEmpty {
+      try visitor.visitSingularStringField(value: self.status, fieldNumber: 3)
+    }
+    if !self.argumentsJson.isEmpty {
+      try visitor.visitSingularStringField(value: self.argumentsJson, fieldNumber: 4)
+    }
+    if !self.resultSummary.isEmpty {
+      try visitor.visitSingularStringField(value: self.resultSummary, fieldNumber: 5)
+    }
+    if self.durationMs != 0 {
+      try visitor.visitSingularInt32Field(value: self.durationMs, fieldNumber: 6)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Teamclaw_ToolEvent, rhs: Teamclaw_ToolEvent) -> Bool {
+    if lhs.toolCallID != rhs.toolCallID {return false}
+    if lhs.toolName != rhs.toolName {return false}
+    if lhs.status != rhs.status {return false}
+    if lhs.argumentsJson != rhs.argumentsJson {return false}
+    if lhs.resultSummary != rhs.resultSummary {return false}
+    if lhs.durationMs != rhs.durationMs {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Teamclaw_MessagePartData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".MessagePartData"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "type"),
+    2: .same(proto: "text"),
+    3: .same(proto: "tool"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.type) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self._text) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._tool) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if !self.type.isEmpty {
+      try visitor.visitSingularStringField(value: self.type, fieldNumber: 1)
+    }
+    try { if let v = self._text {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    } }()
+    try { if let v = self._tool {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Teamclaw_MessagePartData, rhs: Teamclaw_MessagePartData) -> Bool {
+    if lhs.type != rhs.type {return false}
+    if lhs._text != rhs._text {return false}
+    if lhs._tool != rhs._tool {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2543,7 +2759,7 @@ extension Teamclaw_MessageSyncResponse: SwiftProtobuf.Message, SwiftProtobuf._Me
 
 extension Teamclaw_ChatMessageData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ChatMessageData"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}role\0\u{1}content\0\u{1}timestamp\0\u{3}image_url\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}role\0\u{1}content\0\u{1}timestamp\0\u{3}image_url\0\u{2}\u{2}\u{1}parts\0\u{3}has_thinking\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2556,6 +2772,8 @@ extension Teamclaw_ChatMessageData: SwiftProtobuf.Message, SwiftProtobuf._Messag
       case 3: try { try decoder.decodeSingularStringField(value: &self.content) }()
       case 4: try { try decoder.decodeSingularDoubleField(value: &self.timestamp) }()
       case 5: try { try decoder.decodeSingularStringField(value: &self._imageURL) }()
+      case 7: try { try decoder.decodeRepeatedMessageField(value: &self.parts) }()
+      case 8: try { try decoder.decodeSingularBoolField(value: &self.hasThinking) }()
       default: break
       }
     }
@@ -2581,6 +2799,12 @@ extension Teamclaw_ChatMessageData: SwiftProtobuf.Message, SwiftProtobuf._Messag
     try { if let v = self._imageURL {
       try visitor.visitSingularStringField(value: v, fieldNumber: 5)
     } }()
+    if !self.parts.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.parts, fieldNumber: 7)
+    }
+    if self.hasThinking != false {
+      try visitor.visitSingularBoolField(value: self.hasThinking, fieldNumber: 8)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -2590,6 +2814,8 @@ extension Teamclaw_ChatMessageData: SwiftProtobuf.Message, SwiftProtobuf._Messag
     if lhs.content != rhs.content {return false}
     if lhs.timestamp != rhs.timestamp {return false}
     if lhs._imageURL != rhs._imageURL {return false}
+    if lhs.parts != rhs.parts {return false}
+    if lhs.hasThinking != rhs.hasThinking {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/TeamClawMobile/TeamClawMobile/Generated/teamclaw.pb.swift
+++ b/TeamClawMobile/TeamClawMobile/Generated/teamclaw.pb.swift
@@ -421,6 +421,8 @@ struct Teamclaw_SessionSyncRequest: Sendable {
   /// Clears the value of `pagination`. Subsequent reads from it will return its default value.
   mutating func clearPagination() {self._pagination = nil}
 
+  var afterUpdated: Int64 = 0
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -461,6 +463,8 @@ struct Teamclaw_SessionData: Sendable {
   var title: String = String()
 
   var updated: Int64 = 0
+
+  var isArchived: Bool = false
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1704,7 +1708,10 @@ extension Teamclaw_StatusReport: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
 
 extension Teamclaw_SessionSyncRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SessionSyncRequest"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}pagination\0")
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "pagination"),
+    2: .standard(proto: "after_updated"),
+  ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1713,6 +1720,7 @@ extension Teamclaw_SessionSyncRequest: SwiftProtobuf.Message, SwiftProtobuf._Mes
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._pagination) }()
+      case 2: try { try decoder.decodeSingularInt64Field(value: &self.afterUpdated) }()
       default: break
       }
     }
@@ -1726,11 +1734,15 @@ extension Teamclaw_SessionSyncRequest: SwiftProtobuf.Message, SwiftProtobuf._Mes
     try { if let v = self._pagination {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     } }()
+    if self.afterUpdated != 0 {
+      try visitor.visitSingularInt64Field(value: self.afterUpdated, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Teamclaw_SessionSyncRequest, rhs: Teamclaw_SessionSyncRequest) -> Bool {
     if lhs._pagination != rhs._pagination {return false}
+    if lhs.afterUpdated != rhs.afterUpdated {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -1777,7 +1789,12 @@ extension Teamclaw_SessionSyncResponse: SwiftProtobuf.Message, SwiftProtobuf._Me
 
 extension Teamclaw_SessionData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SessionData"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}title\0\u{1}updated\0")
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "id"),
+    2: .same(proto: "title"),
+    3: .same(proto: "updated"),
+    4: .standard(proto: "is_archived"),
+  ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1788,6 +1805,7 @@ extension Teamclaw_SessionData: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
       case 1: try { try decoder.decodeSingularStringField(value: &self.id) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.title) }()
       case 3: try { try decoder.decodeSingularInt64Field(value: &self.updated) }()
+      case 4: try { try decoder.decodeSingularBoolField(value: &self.isArchived) }()
       default: break
       }
     }
@@ -1803,6 +1821,9 @@ extension Teamclaw_SessionData: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
     if self.updated != 0 {
       try visitor.visitSingularInt64Field(value: self.updated, fieldNumber: 3)
     }
+    if self.isArchived != false {
+      try visitor.visitSingularBoolField(value: self.isArchived, fieldNumber: 4)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1810,6 +1831,7 @@ extension Teamclaw_SessionData: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
     if lhs.id != rhs.id {return false}
     if lhs.title != rhs.title {return false}
     if lhs.updated != rhs.updated {return false}
+    if lhs.isArchived != rhs.isArchived {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/TeamClawMobile/TeamClawMobile/Models/ChatMessage.swift
+++ b/TeamClawMobile/TeamClawMobile/Models/ChatMessage.swift
@@ -7,6 +7,35 @@ enum MessageRole: String, Codable {
     case collaborator
 }
 
+struct ToolCallInfo: Codable, Identifiable {
+    var id: String { toolCallId }
+    let toolCallId: String
+    let toolName: String
+    var status: String
+    let argumentsJson: String
+    let resultSummary: String
+    let durationMs: Int
+
+    var summary: String? {
+        guard let data = argumentsJson.data(using: .utf8),
+              let args = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        if let path = args["path"] as? String { return path }
+        if let command = args["command"] as? String {
+            return command.count > 60 ? String(command.prefix(60)) + "..." : command
+        }
+        if let query = args["query"] as? String { return query }
+        if let url = args["url"] as? String { return url }
+        if let pattern = args["pattern"] as? String { return pattern }
+        return nil
+    }
+}
+
+struct MessagePart: Codable {
+    let type: String
+    let text: String?
+    let tool: ToolCallInfo?
+}
+
 @Model
 final class ChatMessage {
     @Attribute(.unique) var id: String
@@ -17,10 +46,17 @@ final class ChatMessage {
     var senderName: String?
     var isStreaming: Bool
     var imageURL: String?
+    var partsJSON: String
+    var hasThinking: Bool
 
     var role: MessageRole {
         get { MessageRole(rawValue: roleRaw) ?? .user }
         set { roleRaw = newValue.rawValue }
+    }
+
+    var parts: [MessagePart] {
+        guard let data = partsJSON.data(using: .utf8) else { return [] }
+        return (try? JSONDecoder().decode([MessagePart].self, from: data)) ?? []
     }
 
     init(
@@ -31,7 +67,9 @@ final class ChatMessage {
         timestamp: Date,
         senderName: String? = nil,
         isStreaming: Bool = false,
-        imageURL: String? = nil
+        imageURL: String? = nil,
+        partsJSON: String = "[]",
+        hasThinking: Bool = false
     ) {
         self.id = id
         self.sessionID = sessionID
@@ -41,5 +79,7 @@ final class ChatMessage {
         self.senderName = senderName
         self.isStreaming = isStreaming
         self.imageURL = imageURL
+        self.partsJSON = partsJSON
+        self.hasThinking = hasThinking
     }
 }

--- a/proto/teamclaw.proto
+++ b/proto/teamclaw.proto
@@ -85,6 +85,7 @@ message StatusReport {
 
 message SessionSyncRequest {
   PageRequest pagination = 1;
+  int64 after_updated = 2;    // 只返回 updated > after_updated 的 session，0 = 全量
 }
 
 message SessionSyncResponse {
@@ -96,6 +97,7 @@ message SessionData {
   string id = 1;
   string title = 2;
   int64 updated = 3;
+  bool is_archived = 4;       // 该 session 是否已归档
 }
 
 message SessionArchiveRequest {

--- a/proto/teamclaw.proto
+++ b/proto/teamclaw.proto
@@ -61,6 +61,8 @@ message ChatResponse {
     string delta = 10;
     StreamDone done = 11;
     StreamError error = 12;
+    ToolEvent tool_event = 13;
+    bool has_thinking = 14;
   }
 }
 
@@ -68,6 +70,21 @@ message StreamDone {}
 
 message StreamError {
   string message = 1;
+}
+
+message ToolEvent {
+  string tool_call_id = 1;
+  string tool_name = 2;          // "Write", "Edit", "Bash", "Read", etc.
+  string status = 3;             // "running" | "completed" | "failed"
+  string arguments_json = 4;     // JSON string, truncated to 500 chars
+  string result_summary = 5;     // Result text, truncated to 1000 chars
+  int32 duration_ms = 6;
+}
+
+message MessagePartData {
+  string type = 1;               // "text" | "tool"
+  optional string text = 2;     // Content when type="text"
+  optional ToolEvent tool = 3;  // Tool info when type="tool"
 }
 
 message ChatCancel {
@@ -214,6 +231,8 @@ message ChatMessageData {
   string content = 3;
   double timestamp = 4;
   optional string image_url = 5;
+  repeated MessagePartData parts = 7;
+  bool has_thinking = 8;
 }
 
 // ─── Task Update (server push) ───

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -792,6 +792,7 @@ pub struct SessionInfo {
     pub id: String,
     pub title: String,
     pub updated: i64,
+    pub archived: bool,
 }
 
 /// Maximum number of sessions to show in the list
@@ -830,7 +831,8 @@ pub async fn opencode_list_sessions(port: u16) -> Result<Vec<SessionInfo>, Strin
                 if title.is_empty() || title == "(untitled)" {
                     // Still include them but with a placeholder
                 }
-                Some(SessionInfo { id, title, updated })
+                let archived = s["time"]["archived"].as_i64().is_some();
+                Some(SessionInfo { id, title, updated, archived })
             })
             .collect(),
         None => return Err("Unexpected session list format".to_string()),

--- a/src-tauri/src/commands/gateway/mqtt_relay.rs
+++ b/src-tauri/src/commands/gateway/mqtt_relay.rs
@@ -413,6 +413,7 @@ impl MqttRelay {
         let mut last_flush = tokio::time::Instant::now();
         let flush_interval = Duration::from_millis(200);
         let mut pending_delta = String::new();
+        let mut sent_thinking = false;
         let deadline = tokio::time::Instant::now() + Duration::from_secs(900);
 
         loop {
@@ -471,17 +472,102 @@ impl MqttRelay {
 
                                 match event_type {
                                     "message.part.delta" => {
-                                        // {"type":"message.part.delta","properties":{"sessionID":"...","messageID":"...","partID":"...","field":"text","delta":"hello"}}
-                                        if let Some(text) = props.and_then(|p| p.get("delta").and_then(|d| d.as_str())) {
-                                            pending_delta.push_str(text);
-                                            if last_flush.elapsed() >= flush_interval && !pending_delta.is_empty() {
-                                                let msg = build_chat_delta(session_id, seq, &pending_delta);
-                                                self.publish_chat_response_proto(device_id, &msg).await?;
-                                                full_content.push_str(&pending_delta);
-                                                pending_delta.clear();
-                                                seq += 1;
-                                                last_flush = tokio::time::Instant::now();
+                                        let field = props
+                                            .and_then(|p| p.get("field").and_then(|f| f.as_str()))
+                                            .unwrap_or("text");
+                                        if field == "text" {
+                                            if let Some(text) = props.and_then(|p| p.get("delta").and_then(|d| d.as_str())) {
+                                                pending_delta.push_str(text);
+                                                if last_flush.elapsed() >= flush_interval && !pending_delta.is_empty() {
+                                                    let msg = build_chat_delta(session_id, seq, &pending_delta);
+                                                    self.publish_chat_response_proto(device_id, &msg).await?;
+                                                    full_content.push_str(&pending_delta);
+                                                    pending_delta.clear();
+                                                    seq += 1;
+                                                    last_flush = tokio::time::Instant::now();
+                                                }
                                             }
+                                        }
+                                        // field == "reasoning" → ignore (don't send thinking content)
+                                    }
+                                    "message.part.updated" => {
+                                        let part_type = props
+                                            .and_then(|p| p.get("type").and_then(|t| t.as_str()))
+                                            .unwrap_or("");
+
+                                        match part_type {
+                                            "tool" | "tool-call" => {
+                                                // Flush any pending text delta first
+                                                if !pending_delta.is_empty() {
+                                                    let msg = build_chat_delta(session_id, seq, &pending_delta);
+                                                    self.publish_chat_response_proto(device_id, &msg).await?;
+                                                    full_content.push_str(&pending_delta);
+                                                    pending_delta.clear();
+                                                    seq += 1;
+                                                    last_flush = tokio::time::Instant::now();
+                                                }
+
+                                                let tool_name = props
+                                                    .and_then(|p| p.get("tool").and_then(|t| t.as_str()))
+                                                    .unwrap_or("unknown");
+                                                let tool_call_id = props
+                                                    .and_then(|p| p.get("callID").and_then(|t| t.as_str()))
+                                                    .or_else(|| props.and_then(|p| p.get("id").and_then(|t| t.as_str())))
+                                                    .unwrap_or("");
+                                                let state = props.and_then(|p| p.get("state"));
+                                                let status_raw = state
+                                                    .and_then(|s| s.get("status"))
+                                                    .and_then(|s| s.as_str())
+                                                    .unwrap_or("");
+                                                let has_ended = props
+                                                    .and_then(|p| p.get("time"))
+                                                    .and_then(|t| t.get("end"))
+                                                    .is_some();
+
+                                                let status = match status_raw {
+                                                    "completed" | "done" | "success" => "completed",
+                                                    "error" | "failed" => "failed",
+                                                    _ if has_ended => "completed",
+                                                    _ => "running",
+                                                };
+
+                                                let arguments_json = state
+                                                    .and_then(|s| s.get("input"))
+                                                    .map(|input| serde_json::to_string(input).unwrap_or_default())
+                                                    .unwrap_or_default();
+                                                let result_summary = state
+                                                    .and_then(|s| s.get("output").or_else(|| s.get("raw")).or_else(|| s.get("result")))
+                                                    .map(|r| {
+                                                        if let Some(s) = r.as_str() { s.to_string() }
+                                                        else { serde_json::to_string(r).unwrap_or_default() }
+                                                    })
+                                                    .unwrap_or_default();
+                                                let duration_ms = props
+                                                    .and_then(|p| p.get("time"))
+                                                    .and_then(|t| {
+                                                        let start = t.get("start")?.as_f64()?;
+                                                        let end = t.get("end")?.as_f64()?;
+                                                        Some(((end - start) * 1000.0) as i32)
+                                                    })
+                                                    .unwrap_or(0);
+
+                                                let msg = build_chat_tool_event(
+                                                    session_id, seq,
+                                                    tool_call_id, tool_name, status,
+                                                    &arguments_json, &result_summary, duration_ms,
+                                                );
+                                                self.publish_chat_response_proto(device_id, &msg).await?;
+                                                seq += 1;
+                                            }
+                                            "thinking" | "reasoning" => {
+                                                if !sent_thinking {
+                                                    sent_thinking = true;
+                                                    let msg = build_chat_has_thinking(session_id, seq);
+                                                    self.publish_chat_response_proto(device_id, &msg).await?;
+                                                    seq += 1;
+                                                }
+                                            }
+                                            _ => {}
                                         }
                                     }
                                     "message.completed" => {
@@ -910,41 +996,101 @@ impl MqttRelay {
                 let role = info.get("role")?.as_str()?;
                 if role != "user" && role != "assistant" { return None; }
 
-                let parts = msg.get("parts")?.as_array()?;
+                let parts_array = msg.get("parts")?.as_array()?;
+                let mut message_parts: Vec<proto::MessagePartData> = Vec::new();
                 let mut content_parts: Vec<String> = Vec::new();
-                for part in parts {
+                let mut has_thinking = false;
+
+                for part in parts_array {
                     match part.get("type").and_then(|t| t.as_str()) {
                         Some("text") => {
                             if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
                                 content_parts.push(text.to_string());
+                                message_parts.push(proto::MessagePartData {
+                                    r#type: "text".to_string(),
+                                    text: Some(text.to_string()),
+                                    tool: None,
+                                });
                             }
                         }
-                        Some("tool") => {
+                        Some("tool") | Some("tool-call") => {
                             let tool_name = part.get("tool").and_then(|t| t.as_str()).unwrap_or("tool");
-                            let input_summary = part.get("state")
+                            let tool_call_id = part.get("callID")
+                                .or_else(|| part.get("id"))
+                                .and_then(|t| t.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            let state = part.get("state");
+                            let status_raw = state
+                                .and_then(|s| s.get("status"))
+                                .and_then(|s| s.as_str())
+                                .unwrap_or("completed");
+                            let has_ended = part.get("time")
+                                .and_then(|t| t.get("end"))
+                                .is_some();
+                            let status = match status_raw {
+                                "completed" | "done" | "success" => "completed",
+                                "error" | "failed" => "failed",
+                                _ if has_ended => "completed",
+                                _ => "running",
+                            };
+                            let arguments_json = state
+                                .and_then(|s| s.get("input"))
+                                .map(|input| serde_json::to_string(input).unwrap_or_default())
+                                .unwrap_or_default();
+                            let result_summary = state
+                                .and_then(|s| s.get("output").or_else(|| s.get("raw")).or_else(|| s.get("result")))
+                                .map(|r| {
+                                    if let Some(s) = r.as_str() { s.to_string() }
+                                    else { serde_json::to_string(r).unwrap_or_default() }
+                                })
+                                .unwrap_or_default();
+                            let duration_ms = part.get("time")
+                                .and_then(|t| {
+                                    let start = t.get("start")?.as_f64()?;
+                                    let end = t.get("end")?.as_f64()?;
+                                    Some(((end - start) * 1000.0) as i32)
+                                })
+                                .unwrap_or(0);
+
+                            // Backward-compat content summary
+                            let input_summary = state
                                 .and_then(|s| s.get("input"))
                                 .map(|input| {
-                                    // For websearch/webfetch, show the query/url
-                                    if let Some(q) = input.get("query").and_then(|v| v.as_str()) {
-                                        q.to_string()
-                                    } else if let Some(u) = input.get("url").and_then(|v| v.as_str()) {
-                                        u.to_string()
-                                    } else {
+                                    if let Some(q) = input.get("query").and_then(|v| v.as_str()) { q.to_string() }
+                                    else if let Some(u) = input.get("url").and_then(|v| v.as_str()) { u.to_string() }
+                                    else if let Some(p) = input.get("path").and_then(|v| v.as_str()) { p.to_string() }
+                                    else if let Some(c) = input.get("command").and_then(|v| v.as_str()) { c.to_string() }
+                                    else {
                                         serde_json::to_string(input).unwrap_or_default()
                                             .chars().take(80).collect()
                                     }
                                 })
                                 .unwrap_or_default();
                             content_parts.push(format!("🔧 {} {}", tool_name, input_summary));
+
+                            message_parts.push(proto::MessagePartData {
+                                r#type: "tool".to_string(),
+                                text: None,
+                                tool: Some(proto::ToolEvent {
+                                    tool_call_id,
+                                    tool_name: tool_name.to_string(),
+                                    status: status.to_string(),
+                                    arguments_json: truncate_string(&arguments_json, 500),
+                                    result_summary: truncate_string(&result_summary, 1000),
+                                    duration_ms,
+                                }),
+                            });
+                        }
+                        Some("thinking") | Some("reasoning") => {
+                            has_thinking = true;
                         }
                         _ => {}
                     }
                 }
                 let content = content_parts.join("\n");
-                // Skip messages with no displayable content
-                if content.trim().is_empty() { return None; }
+                if content.trim().is_empty() && message_parts.is_empty() { return None; }
 
-                // Timestamp: info.time.created (milliseconds) or fallback to 0
                 let timestamp_ms = info.get("time")
                     .and_then(|t| t.get("created"))
                     .and_then(|t| t.as_f64())
@@ -957,6 +1103,8 @@ impl MqttRelay {
                     content,
                     timestamp,
                     image_url: None,
+                    parts: message_parts,
+                    has_thinking,
                 })
             })
             .collect();
@@ -1243,6 +1391,51 @@ fn build_chat_error(session_id: &str, seq: i32, message: &str) -> proto::MqttMes
             event: Some(proto::chat_response::Event::Error(proto::StreamError {
                 message: message.to_string(),
             })),
+        },
+    ))
+}
+
+fn truncate_string(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_chars).collect();
+        format!("{}...(truncated)", truncated)
+    }
+}
+
+fn build_chat_tool_event(
+    session_id: &str,
+    seq: i32,
+    tool_call_id: &str,
+    tool_name: &str,
+    status: &str,
+    arguments_json: &str,
+    result_summary: &str,
+    duration_ms: i32,
+) -> proto::MqttMessage {
+    build_envelope(proto::mqtt_message::Payload::ChatResponse(
+        proto::ChatResponse {
+            session_id: session_id.to_string(),
+            seq,
+            event: Some(proto::chat_response::Event::ToolEvent(proto::ToolEvent {
+                tool_call_id: tool_call_id.to_string(),
+                tool_name: tool_name.to_string(),
+                status: status.to_string(),
+                arguments_json: truncate_string(arguments_json, 500),
+                result_summary: truncate_string(result_summary, 1000),
+                duration_ms,
+            })),
+        },
+    ))
+}
+
+fn build_chat_has_thinking(session_id: &str, seq: i32) -> proto::MqttMessage {
+    build_envelope(proto::mqtt_message::Payload::ChatResponse(
+        proto::ChatResponse {
+            session_id: session_id.to_string(),
+            seq,
+            event: Some(proto::chat_response::Event::HasThinking(true)),
         },
     ))
 }

--- a/src-tauri/src/commands/gateway/mqtt_relay.rs
+++ b/src-tauri/src/commands/gateway/mqtt_relay.rs
@@ -270,9 +270,9 @@ impl MqttRelay {
             Some(proto::mqtt_message::Payload::ChatCancel(ref cancel)) => {
                 self.handle_chat_cancel(&cancel.session_id).await;
             }
-            Some(proto::mqtt_message::Payload::SessionSyncRequest(ref _req)) => {
+            Some(proto::mqtt_message::Payload::SessionSyncRequest(ref req)) => {
                 if let Some(did) = device_id {
-                    self.handle_session_list_request(&did).await?;
+                    self.handle_session_list_request(&did, req).await?;
                 }
             }
             Some(proto::mqtt_message::Payload::MemberSyncRequest(ref req)) => {
@@ -546,26 +546,46 @@ impl MqttRelay {
 
     // ─── Session List ──────────────────────────────────────────
 
-    async fn handle_session_list_request(&self, device_id: &str) -> Result<(), String> {
+    async fn handle_session_list_request(
+        &self,
+        device_id: &str,
+        req: &proto::SessionSyncRequest,
+    ) -> Result<(), String> {
         let port = self.opencode_port;
         match super::opencode_list_sessions(port).await {
-            Ok(sessions) => {
-                eprintln!("[MQTT Relay] Sending {} session(s) to device {}", sessions.len(), &device_id[..device_id.len().min(8)]);
+            Ok(mut sessions) => {
+                let after = req.after_updated;
+                if after > 0 {
+                    // Incremental mode: return sessions updated after the given timestamp (including archived ones)
+                    let after_ms = after * 1000;
+                    sessions.retain(|s| s.updated > after_ms);
+                } else {
+                    // Full mode: filter out archived, truncate
+                    sessions.retain(|s| !s.archived);
+                    sessions.truncate(super::MAX_SESSIONS_LIST);
+                }
+                eprintln!(
+                    "[MQTT Relay] Sending {} session(s) to device {} (after_updated={})",
+                    sessions.len(),
+                    &device_id[..device_id.len().min(8)],
+                    after
+                );
                 let session_data: Vec<proto::SessionData> = sessions
                     .iter()
                     .map(|s| proto::SessionData {
                         id: s.id.clone(),
                         title: s.title.clone(),
-                        updated: s.updated / 1000, // Convert ms to seconds
+                        updated: s.updated / 1000,
+                        is_archived: s.archived,
                     })
                     .collect();
                 let msg = build_envelope(proto::mqtt_message::Payload::SessionSyncResponse(
                     proto::SessionSyncResponse {
-                        sessions: session_data,
+                        sessions: session_data.clone(),
                         pagination: Some(proto::PageInfo {
                             page: 1,
                             page_size: 50,
-                            total: sessions.len() as i32,
+                            total: session_data.len() as i32,
                         }),
                     },
                 ));


### PR DESCRIPTION
## Summary

- **Session List 增量同步**: `SessionSyncRequest` 新增 `after_updated` 字段实现增量拉取，`SessionData` 新增 `is_archived` 字段实现归档同步，iOS 回到前台超过 60 分钟自动刷新
- **结构化消息 Parts**: `ChatResponse` 扩展 `ToolEvent` 和 `has_thinking` 事件，流式阶段实时显示 tool 调用状态（running/completed/failed），历史同步传输结构化 parts，iOS 按工具类型分渲染（Write/Edit/Bash/Read 等专属卡片）
- **截断策略**: tool arguments 截断到 500 字符，result 截断到 1000 字符，Rust 端发送前处理

## Changes

### Proto
- `SessionSyncRequest` + `after_updated`, `SessionData` + `is_archived`
- New `ToolEvent`, `MessagePartData` messages
- `ChatResponse` event oneof + `tool_event`, `has_thinking`
- `ChatMessageData` + `parts`, `has_thinking`

### Rust
- Incremental session filtering with `after_updated` and archived support
- SSE `message.part.updated` handler for tool events and thinking markers
- Structured `MessagePartData` in message history sync
- `truncate_string` helper for arguments/result truncation

### iOS
- Swift protobuf: ToolEvent, MessagePartData, ChatResponse/ChatMessageData extensions
- `ChatMessage` model: `partsJSON`, `hasThinking`, `MessagePart`/`ToolCallInfo` value types
- `ChatDetailViewModel`: streaming ToolEvent handling, structured parts on finish
- New `ToolCallView` component: per-tool-type rendering with expandable details
- `MessageBubbleView`: renders parts array (text + tool cards + thinking badge)
- `StreamingTextView`: shows tool cards during streaming
- `SessionListViewModel`: incremental sync + archived cleanup + 60min auto-refresh

## Test plan

- [ ] Rust compilation: `pnpm rust:check`
- [ ] iOS Xcode build
- [ ] 首次启动全量同步 session list
- [ ] 增量同步（回到前台 / 下拉刷新）
- [ ] 桌面归档 session → iOS 增量同步后消失
- [ ] 流式响应中 tool 调用卡片实时显示 running → completed
- [ ] 历史同步显示结构化 tool 卡片（可展开 arguments/result）
- [ ] 旧格式消息 fallback 到纯文本显示
- [ ] thinking badge 显示

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)