### PR TITLE
fix(ios): polish session list & chat UI sizing and layout

### DIFF
--- a/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailView.swift
@@ -175,7 +175,7 @@ struct ChatDetailView: View {
             }
         }
         .sheet(isPresented: $showEditSheet) {
-            ChatEditSheet(session: session)
+            MemberPickerSheet(session: session, mqttService: mqttService)
         }
         .sheet(isPresented: $showMenuSheet) {
             ChatMenuSheet(

--- a/TeamClawMobile/TeamClawMobile/Features/Chat/ChatInputBar.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Chat/ChatInputBar.swift
@@ -53,16 +53,16 @@ struct ChatInputBar: View {
             HStack(spacing: 0) {
                 Button(action: onTogglePin) {
                     Image(systemName: session.isPinned ? "pin.slash.fill" : "pin.fill")
-                        .font(.system(size: 17))
+                        .font(.system(size: 20))
                         .foregroundStyle(.primary)
-                        .frame(width: 44, height: 44)
+                        .frame(width: 48, height: 48)
                 }
 
                 Button { showArchiveConfirmation = true } label: {
                     Image(systemName: "archivebox.fill")
-                        .font(.system(size: 17))
+                        .font(.system(size: 20))
                         .foregroundStyle(.primary)
-                        .frame(width: 44, height: 44)
+                        .frame(width: 48, height: 48)
                 }
             }
             .liquidGlass(in: Capsule())
@@ -74,9 +74,9 @@ struct ChatInputBar: View {
                 // TODO: voice input
             } label: {
                 Image(systemName: "mic.fill")
-                    .font(.system(size: 20))
+                    .font(.system(size: 22))
                     .foregroundStyle(.primary)
-                    .frame(width: 52, height: 52)
+                    .frame(width: 56, height: 56)
             }
             .liquidGlass(in: Circle())
 
@@ -86,9 +86,9 @@ struct ChatInputBar: View {
             HStack(spacing: 0) {
                 Button(action: onShowMenu) {
                     Image(systemName: "ellipsis")
-                        .font(.system(size: 17))
+                        .font(.system(size: 20))
                         .foregroundStyle(.primary)
-                        .frame(width: 44, height: 44)
+                        .frame(width: 48, height: 48)
                 }
 
                 Button {
@@ -96,9 +96,9 @@ struct ChatInputBar: View {
                     isInputFocused = true
                 } label: {
                     Image(systemName: "square.and.pencil")
-                        .font(.system(size: 17))
+                        .font(.system(size: 20))
                         .foregroundStyle(.primary)
-                        .frame(width: 44, height: 44)
+                        .frame(width: 48, height: 48)
                 }
             }
             .liquidGlass(in: Capsule())
@@ -117,8 +117,8 @@ struct ChatInputBar: View {
                     matching: .images
                 ) {
                     Image(systemName: "plus")
-                        .font(.system(size: 17, weight: .medium))
-                        .frame(width: 34, height: 34)
+                        .font(.system(size: 20, weight: .medium))
+                        .frame(width: 40, height: 40)
                         .liquidGlass(in: Circle())
                 }
                 .disabled(isDisabled)
@@ -129,17 +129,18 @@ struct ChatInputBar: View {
                         text: $text,
                         axis: .vertical
                     )
+                    .font(.body)
                     .lineLimit(1...5)
-                    .padding(.leading, 12)
+                    .padding(.leading, 14)
                     .padding(.trailing, 4)
-                    .padding(.vertical, 8)
+                    .padding(.vertical, 10)
                     .disabled(isDisabled || isStreaming)
                     .focused($isInputFocused)
 
                     if showActionButton {
                         actionButton
-                            .padding(.trailing, 4)
-                            .padding(.bottom, 4)
+                            .padding(.trailing, 6)
+                            .padding(.bottom, 6)
                     }
                 }
                 .background(Color(.systemGray6), in: Capsule())
@@ -152,8 +153,8 @@ struct ChatInputBar: View {
                         isInputFocused = false
                     } label: {
                         Image(systemName: "xmark")
-                            .font(.system(size: 15, weight: .medium))
-                            .frame(width: 34, height: 34)
+                            .font(.system(size: 17, weight: .medium))
+                            .frame(width: 40, height: 40)
                             .liquidGlass(in: Circle())
                     }
                 }
@@ -174,9 +175,9 @@ struct ChatInputBar: View {
         if isStreaming {
             Button(action: onCancel) {
                 Image(systemName: "stop.fill")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(.white)
-                    .frame(width: 28, height: 28)
+                    .frame(width: 32, height: 32)
                     .background(.red, in: Circle())
             }
         } else {
@@ -186,9 +187,9 @@ struct ChatInputBar: View {
                 isInputFocused = false
             } label: {
                 Image(systemName: "arrow.up")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(.white)
-                    .frame(width: 28, height: 28)
+                    .frame(width: 32, height: 32)
                     .background(canSend ? Color.blue : Color.secondary, in: Circle())
             }
             .disabled(!canSend)

--- a/TeamClawMobile/TeamClawMobile/Features/SessionList/NewSessionSheet.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/SessionList/NewSessionSheet.swift
@@ -126,29 +126,30 @@ struct NewSessionSheet: View {
         HStack(alignment: .bottom, spacing: 8) {
             Button {} label: {
                 Image(systemName: "plus")
-                    .font(.system(size: 17, weight: .medium))
-                    .frame(width: 34, height: 34)
+                    .font(.system(size: 20, weight: .medium))
+                    .frame(width: 40, height: 40)
                     .liquidGlass(in: Circle())
             }
 
             HStack(alignment: .bottom, spacing: 4) {
                 TextField("消息", text: $messageText, axis: .vertical)
+                    .font(.body)
                     .lineLimit(1...5)
                     .focused($isInputFocused)
-                    .padding(.leading, 12)
+                    .padding(.leading, 14)
                     .padding(.trailing, 4)
-                    .padding(.vertical, 8)
+                    .padding(.vertical, 10)
 
                 if canSend {
                     Button(action: sendAndCreate) {
                         Image(systemName: "arrow.up")
                             .font(.system(size: 14, weight: .semibold))
                             .foregroundStyle(.white)
-                            .frame(width: 28, height: 28)
+                            .frame(width: 32, height: 32)
                             .background(Color.green, in: Circle())
                     }
-                    .padding(.trailing, 4)
-                    .padding(.bottom, 4)
+                    .padding(.trailing, 6)
+                    .padding(.bottom, 6)
                 }
             }
             .background(Color(.systemGray6), in: Capsule())

--- a/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListView.swift
@@ -93,6 +93,18 @@ struct SessionListView: View {
                     }
                 }
 
+                if !isEditing {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button {
+                            showMemberPanel = true
+                        } label: {
+                            Image(systemName: "person.2.fill")
+                                .font(.subheadline)
+                                .foregroundStyle(.primary)
+                        }
+                    }
+                }
+
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
                         withAnimation(.spring(duration: 0.25)) {
@@ -103,18 +115,6 @@ struct SessionListView: View {
                         Text(isEditing ? "完成" : "选择")
                             .font(.subheadline)
                             .foregroundStyle(.primary)
-                    }
-                }
-
-                if !isEditing {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Button {
-                            showMemberPanel = true
-                        } label: {
-                            Image(systemName: "person.2.fill")
-                                .font(.subheadline)
-                                .foregroundStyle(.primary)
-                        }
                     }
                 }
             }
@@ -188,7 +188,7 @@ struct SessionListView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "magnifyingglass")
                         .foregroundStyle(.secondary)
-                        .font(.subheadline)
+                        .font(.body)
                     TextField("搜索", text: $searchText)
                         .font(.body)
                         .focused($isSearchFocused)
@@ -202,11 +202,12 @@ struct SessionListView: View {
                         } label: {
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundStyle(.secondary)
+                                .font(.body)
                         }
                     }
                 }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
                 .liquidGlass(in: Capsule(), interactive: false)
 
                 if isSearchFocused {
@@ -216,7 +217,8 @@ struct SessionListView: View {
                     } label: {
                         Image(systemName: "xmark")
                             .font(.title2)
-                            .frame(width: 44, height: 44)
+                            .foregroundStyle(.primary)
+                            .frame(width: 48, height: 48)
                     }
                     .liquidGlass(in: Circle())
                     .transition(.scale.combined(with: .opacity))
@@ -226,7 +228,8 @@ struct SessionListView: View {
                     } label: {
                         Image(systemName: "square.and.pencil")
                             .font(.title2)
-                            .frame(width: 44, height: 44)
+                            .foregroundStyle(.primary)
+                            .frame(width: 48, height: 48)
                     }
                     .liquidGlass(in: Circle())
                     .transition(.scale.combined(with: .opacity))
@@ -484,7 +487,7 @@ struct SessionRowView: View {
 
 // MARK: - MemberPickerSheet
 
-private struct MemberPickerSheet: View {
+struct MemberPickerSheet: View {
     let session: Session
     let mqttService: MQTTServiceProtocol
     @Environment(\.dismiss) private var dismiss


### PR DESCRIPTION
## Summary
- **搜索栏尺寸**: 增大 session list 底部搜索栏的 padding 和字号，与 MemberListView 系统搜索风格一致；新建按钮去掉蓝色改为 `.primary`
- **Toolbar 按钮分离**: 调换"选择"和成员按钮顺序，视觉上不再紧贴
- **添加成员直通**: ChatDetail 右上角按钮直接弹出 `MemberPickerSheet`（复用 SessionListView 组件），跳过中间 ChatEditSheet
- **控件尺寸统一**: 浮动胶囊按钮 44→48、麦克风 52→56；输入栏 + 按钮 34→40、发送按钮 28→32；NewSessionSheet 同步调大

## Test plan
- [ ] Session list 底部搜索栏高度与 MemberListView 搜索栏视觉一致
- [ ] 新建会话按钮 icon 不再是蓝色
- [ ] 右上角"选择"和成员图标清晰分离
- [ ] ChatDetail 右上角点击直接弹出成员选择列表（非中间编辑页）
- [ ] 底部浮动胶囊按钮和输入栏控件尺寸明显增大，接近系统默认

🤖 Generated with [Claude Code](https://claude.ai/code)