### PR TITLE
fix(ios): member confirm capsule + chat refresh button

### DIFF
--- a/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailView.swift
@@ -154,12 +154,22 @@ struct ChatDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
-                    showEditSheet = true
-                } label: {
-                    Image(systemName: "person.badge.plus")
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundStyle(.primary)
+                HStack(spacing: 16) {
+                    Button {
+                        viewModel.requestMessageHistory()
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(.primary)
+                    }
+
+                    Button {
+                        showEditSheet = true
+                    } label: {
+                        Image(systemName: "person.badge.plus")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(.primary)
+                    }
                 }
             }
         }

--- a/TeamClawMobile/TeamClawMobile/Features/TeamMembers/UnifiedMemberSheet.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/TeamMembers/UnifiedMemberSheet.swift
@@ -57,25 +57,33 @@ struct UnifiedMemberSheet: View {
             .navigationTitle(isSelectMode ? "选择成员" : "团队成员")
             .navigationBarTitleDisplayMode(isSelectMode ? .inline : .large)
             .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    if !isSelectMode {
-                        Button("完成") { dismiss() }
-                    }
-                }
                 ToolbarItem(placement: .cancellationAction) {
                     if isSelectMode {
                         Button("取消") { dismiss() }
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSelectMode {
+                        Button {
+                            if case .select(_, let onConfirm) = mode {
+                                onConfirm(selectedIDs)
+                            }
+                            dismiss()
+                        } label: {
+                            Text(selectedIDs.isEmpty ? "确定" : "确定 (\(selectedIDs.count))")
+                                .font(.subheadline.weight(.semibold))
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                        }
+                        .liquidGlass(in: Capsule())
+                    } else {
+                        Button("完成") { dismiss() }
                     }
                 }
             }
             .searchable(text: $searchText, prompt: "搜索")
             .refreshable {
                 viewModel.requestMembers()
-            }
-            .safeAreaInset(edge: .bottom) {
-                if isSelectMode {
-                    confirmBar
-                }
             }
             .onAppear {
                 viewModel.setModelContext(modelContext)
@@ -117,28 +125,6 @@ struct UnifiedMemberSheet: View {
         }
     }
 
-    // MARK: - Confirm Bar
-
-    private var confirmBar: some View {
-        VStack(spacing: 0) {
-            Divider()
-            Button {
-                if case .select(_, let onConfirm) = mode {
-                    onConfirm(selectedIDs)
-                }
-                dismiss()
-            } label: {
-                Text(selectedIDs.isEmpty ? "确定" : "确定 (\(selectedIDs.count))")
-                    .font(.headline)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 14)
-            }
-            .buttonStyle(.borderedProminent)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-        }
-        .background(.bar)
-    }
 }
 
 // MARK: - MemberRow


### PR DESCRIPTION
## Summary
- **成员选择确定按钮**: 从底部全宽大按钮改为右上角 liquidGlass 胶囊，显示选中数量 "确定 (N)"
- **Chat detail 刷新按钮**: 右上角新增 arrow.clockwise 刷新按钮，和添加成员按钮并排

## Test plan
- [ ] 成员选择模式：右上角确定按钮为液态玻璃胶囊样式，显示选中数量
- [ ] 底部不再有全宽确定按钮
- [ ] Chat detail 右上角有刷新和添加成员两个按钮
- [ ] 点击刷新按钮能重新拉取消息历史

🤖 Generated with [Claude Code](https://claude.ai/code)