### PR TITLE
chore: remove hardcoded default URLs from config

### DIFF
--- a/packages/app/src/components/settings/KnowledgeConfigPanel.tsx
+++ b/packages/app/src/components/settings/KnowledgeConfigPanel.tsx
@@ -398,7 +398,7 @@ export const KnowledgeConfigPanel = React.memo(function KnowledgeConfigPanel() {
                       id="rerank-base-url"
                       value={localConfig.rerankBaseUrl}
                       onChange={(e) => updateConfig({ rerankBaseUrl: e.target.value })}
-                      placeholder={localConfig.rerankProvider === 'compass' ? 'https://compass.llm.shopee.io/compass-api/v1' : 'https://api.langsearch.com/v1'}
+                      placeholder={localConfig.rerankProvider === 'compass' ? '' : 'https://api.langsearch.com/v1'}
                     />
                   </FormField>
                 )}

--- a/scripts/llm-proxy.mjs
+++ b/scripts/llm-proxy.mjs
@@ -11,7 +11,7 @@
  * 
  * Default:
  *   Port: 13142
- *   Target: https://compass.llm.shopee.io/compass-api/v1
+ *   Target: (user-provided URL)
  */
 
 import http from 'node:http';
@@ -20,7 +20,7 @@ import { URL } from 'node:url';
 
 const args = process.argv.slice(2);
 const PORT = parseInt(args.find((_, i, a) => a[i - 1] === '--port') || '13142');
-const TARGET = args.find((_, i, a) => a[i - 1] === '--target') || 'https://compass.llm.shopee.io/compass-api/v1';
+const TARGET = args.find((_, i, a) => a[i - 1] === '--target') || '';
 
 const targetUrl = new URL(TARGET);
 

--- a/src-tauri/crates/teamclaw-rag/src/config.rs
+++ b/src-tauri/crates/teamclaw-rag/src/config.rs
@@ -44,7 +44,7 @@ fn default_knowledge_dirs() -> Vec<String> {
 }
 
 fn default_rerank_base_url() -> String {
-    "https://compass.llm.shopee.io/compass-api/v1".to_string()
+    String::new()
 }
 
 impl Default for RagConfig {
@@ -54,7 +54,7 @@ impl Default for RagConfig {
             embedding_model: "compass-embedding-v4".to_string(),
             embedding_dimensions: 2560,
             embedding_api_key: None,
-            embedding_base_url: "https://compass.llm.shopee.io/compass-api/v1".to_string(),
+            embedding_base_url: String::new(),
             chunk_size: 800,
             chunk_overlap: 100,
             auto_index: true,

--- a/src-tauri/crates/teamclaw-rag/src/reranker.rs
+++ b/src-tauri/crates/teamclaw-rag/src/reranker.rs
@@ -131,7 +131,7 @@ impl Reranker for JinaReranker {
 }
 
 // ---------------------------------------------------------------------------
-// Compass Reranker  (https://compass.llm.shopee.io/compass-api/v1/rerank)
+// Compass Reranker
 // Response `results` is a positional array of scores matching the input order.
 // ---------------------------------------------------------------------------
 
@@ -389,7 +389,7 @@ pub fn create_reranker(
         "jina" => Ok(Box::new(JinaReranker::new(api_key, model))),
         "compass" => {
             let url = base_url
-                .unwrap_or_else(|| "https://compass.llm.shopee.io/compass-api/v1".to_string());
+                .unwrap_or_default();
             Ok(Box::new(CompassReranker::new(api_key, url)))
         }
         "langsearch" => Ok(Box::new(LangSearchReranker::new(api_key, model, base_url))),
@@ -419,11 +419,11 @@ mod tests {
     fn test_compass_reranker_creation() {
         let reranker = CompassReranker::new(
             Some("test-key".to_string()),
-            "https://compass.llm.shopee.io/compass-api/v1".to_string(),
+            "https://example.com/api/v1".to_string(),
         );
         assert_eq!(
             reranker.base_url,
-            "https://compass.llm.shopee.io/compass-api/v1"
+            "https://example.com/api/v1"
         );
     }
 
@@ -459,7 +459,7 @@ mod tests {
     async fn test_compass_reranker_empty_documents() {
         let reranker = CompassReranker::new(
             Some("test-key".to_string()),
-            "https://compass.llm.shopee.io/compass-api/v1".to_string(),
+            "https://example.com/api/v1".to_string(),
         );
         let results = reranker.rerank("test query", Vec::new()).await.unwrap();
         assert!(results.is_empty());
@@ -478,7 +478,7 @@ mod tests {
             "compass",
             Some("key".to_string()),
             String::new(),
-            Some("https://compass.llm.shopee.io/compass-api/v1".to_string()),
+            Some("https://example.com/api/v1".to_string()),
         );
         assert!(reranker.is_ok());
     }


### PR DESCRIPTION
## Summary
- Remove all hardcoded default URLs from RAG/embedding/rerank config
- Replace with empty strings — users must provide their own endpoints

## Test plan
- [ ] Verify RAG config panel loads without errors
- [ ] Verify rerank/embedding settings accept user-provided URLs

🤖 Generated with [Claude Code](https://claude.ai/code)