### PR TITLE
fix(ios): use default toolbar style for independent capsule buttons

### DIFF
--- a/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListView.swift
@@ -101,11 +101,7 @@ struct SessionListView: View {
                         }
                     } label: {
                         Text(isEditing ? "完成" : "选择")
-                            .font(.subheadline)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
                     }
-                    .liquidGlass(in: Capsule())
                 }
 
                 if !isEditing {
@@ -114,11 +110,7 @@ struct SessionListView: View {
                             showMemberPanel = true
                         } label: {
                             Image(systemName: "person.2.fill")
-                                .font(.subheadline)
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 6)
                         }
-                        .liquidGlass(in: Capsule())
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Remove manual `.liquidGlass(in: Capsule())` and extra padding from session list toolbar buttons
- Let the system default toolbar styling render each `ToolbarItem` as its own independent glass capsule

## Test plan
- [ ] Session list: verify "选择" and "成员" buttons are two completely separate capsules, not grouped

🤖 Generated with [Claude Code](https://claude.ai/code)