### PR TITLE
fix(ios): polish NewSessionSheet layout and toolbar buttons

### DIFF
--- a/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/Chat/ChatDetailView.swift
@@ -154,22 +154,18 @@ struct ChatDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                HStack(spacing: 16) {
-                    Button {
-                        viewModel.requestMessageHistory()
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 15, weight: .medium))
-                            .foregroundStyle(.primary)
-                    }
+                Button {
+                    viewModel.requestMessageHistory()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
 
-                    Button {
-                        showEditSheet = true
-                    } label: {
-                        Image(systemName: "person.badge.plus")
-                            .font(.system(size: 15, weight: .medium))
-                            .foregroundStyle(.primary)
-                    }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    showEditSheet = true
+                } label: {
+                    Image(systemName: "person.badge.plus")
                 }
             }
         }

--- a/TeamClawMobile/TeamClawMobile/Features/SessionList/NewSessionSheet.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/SessionList/NewSessionSheet.swift
@@ -48,13 +48,11 @@ struct NewSessionSheet: View {
                 }
             }
             .navigationTitle("New Session")
-            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarTitleDisplayMode(.large)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .navigationBarLeading) {
                     Button { dismiss() } label: {
                         Image(systemName: "xmark")
-                            .font(.body.weight(.semibold))
-                            .foregroundStyle(.secondary)
                     }
                 }
             }
@@ -115,7 +113,6 @@ struct NewSessionSheet: View {
             } label: {
                 Image(systemName: "plus.circle.fill")
                     .font(.title3)
-                    .foregroundStyle(.blue)
             }
         }
         .padding(.horizontal, 16)

--- a/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListView.swift
+++ b/TeamClawMobile/TeamClawMobile/Features/SessionList/SessionListView.swift
@@ -18,6 +18,7 @@ struct SessionListView: View {
     @State private var navigationPath: [String] = []
     @State private var searchText = ""
     @FocusState private var isSearchFocused: Bool
+    @Namespace private var sheetTransition
 
     // Edit mode
     @State private var isEditing = false
@@ -145,6 +146,7 @@ struct SessionListView: View {
                     viewModel.applySearch()
                     navigationPath.append(newSession.id)
                 }
+                .navigationTransition(.zoom(sourceID: "newSession", in: sheetTransition))
             }
             .sheet(item: $addMemberSession) { session in
                 UnifiedMemberSheet(
@@ -243,6 +245,7 @@ struct SessionListView: View {
                             .frame(width: 48, height: 48)
                     }
                     .liquidGlass(in: Circle())
+                    .matchedTransitionSource(id: "newSession", in: sheetTransition)
                     .transition(.scale.combined(with: .opacity))
                 }
             }


### PR DESCRIPTION
## Summary
- **NewSessionSheet**: close button moved to top-left, large title style (like email compose), collaborator "+" icon uses system default color
- **ChatDetailView**: split toolbar buttons (refresh + add member) into separate ToolbarItems for independent capsule rendering

## Test plan
- [ ] NewSessionSheet: verify close button is on top-left
- [ ] NewSessionSheet: verify large title "New Session" displays correctly
- [ ] NewSessionSheet: verify collaborator "+" icon uses system tint color
- [ ] ChatDetailView: verify refresh and add-member buttons are two independent capsules

🤖 Generated with [Claude Code](https://claude.ai/code)