### PR TITLE
fix: prevent re-initialization on Spotlight/Main mode switch

### DIFF
--- a/docs/superpowers/plans/2026-04-13-introspect-mcp-server.md
+++ b/docs/superpowers/plans/2026-04-13-introspect-mcp-server.md
@@ -1,0 +1,1973 @@
+# Introspect MCP Server Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a built-in MCP server that gives TeamClaw's AI agent self-awareness of user-configured capabilities and the ability to act on them (send messages, manage cron jobs, manage shortcuts).
+
+**Architecture:** Standalone Rust binary (`teamclaw-introspect`) in `src-tauri/crates/teamclaw-introspect/`, packaged as a Tauri sidecar. Provides 4 MCP tools over stdio JSON-RPC. Reads config files directly from workspace. For operations requiring runtime state (WeCom WebSocket, cron manual run), communicates with Tauri via a lightweight internal HTTP API on port 13144. Auto-registered in `opencode.json` via `ensure_inherent_config()`.
+
+**Tech Stack:** Rust, `rmcp` crate (MCP SDK), `reqwest` (HTTP), `serde_json`, `tokio`
+
+**Spec:** `docs/superpowers/specs/2026-04-13-introspect-mcp-server-design.md`
+
+---
+
+## File Structure
+
+### New files (MCP server crate)
+- `src-tauri/crates/teamclaw-introspect/Cargo.toml` — Crate manifest with binary target
+- `src-tauri/crates/teamclaw-introspect/src/main.rs` — Entry point: parse args, start stdio MCP server
+- `src-tauri/crates/teamclaw-introspect/src/capabilities.rs` — `get_my_capabilities` tool handler
+- `src-tauri/crates/teamclaw-introspect/src/send.rs` — `send_channel_message` tool handler
+- `src-tauri/crates/teamclaw-introspect/src/cron.rs` — `manage_cron_job` tool handler
+- `src-tauri/crates/teamclaw-introspect/src/shortcuts.rs` — `manage_shortcuts` tool handler
+- `src-tauri/crates/teamclaw-introspect/src/config.rs` — Shared config reading (teamclaw.json, cron-jobs.json, members.json)
+
+### New files (Internal HTTP API)
+- `src-tauri/src/commands/introspect_api.rs` — HTTP server for runtime operations (send WeCom, cron run)
+
+### Modified files
+- `src-tauri/Cargo.toml` — Add `teamclaw-introspect` to workspace members
+- `src-tauri/src/commands/opencode.rs` — Register introspect MCP in `ensure_inherent_config()`
+- `src-tauri/src/commands/mod.rs` — Add `pub mod introspect_api;`
+- `src-tauri/src/lib.rs` — Start introspect HTTP API, add Tauri commands
+- `src-tauri/tauri.conf.json` — Add `binaries/teamclaw-introspect` to `externalBin`
+- `packages/app/src/stores/shortcuts.ts` — Migrate persistence from localStorage to Tauri commands
+- `src-tauri/src/commands/gateway/mod.rs` — Add `save_shortcuts` / `load_shortcuts` Tauri commands
+
+---
+
+## Task 1: Scaffold the `teamclaw-introspect` crate
+
+**Files:**
+- Create: `src-tauri/crates/teamclaw-introspect/Cargo.toml`
+- Create: `src-tauri/crates/teamclaw-introspect/src/main.rs`
+- Modify: `src-tauri/Cargo.toml` — Add workspace member
+
+- [ ] **Step 1: Create the crate directory**
+
+```bash
+mkdir -p src-tauri/crates/teamclaw-introspect/src
+```
+
+- [ ] **Step 2: Write Cargo.toml**
+
+Create `src-tauri/crates/teamclaw-introspect/Cargo.toml`:
+
+```toml
+[package]
+name = "teamclaw-introspect"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "teamclaw-introspect"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", features = ["json"] }
+clap = { version = "4", features = ["derive"] }
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1", features = ["v4"] }
+```
+
+- [ ] **Step 3: Write minimal main.rs with arg parsing**
+
+Create `src-tauri/crates/teamclaw-introspect/src/main.rs`:
+
+```rust
+use clap::Parser;
+
+mod capabilities;
+mod config;
+mod cron;
+mod send;
+mod shortcuts;
+
+#[derive(Parser, Debug)]
+#[command(name = "teamclaw-introspect")]
+struct Args {
+    /// Workspace root path
+    #[arg(long)]
+    workspace: String,
+
+    /// Internal API port for runtime operations (WeCom send, cron run)
+    #[arg(long, default_value = "13144")]
+    api_port: u16,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    eprintln!(
+        "[Introspect] Starting MCP server for workspace: {}",
+        args.workspace
+    );
+
+    if let Err(e) = run_mcp_server(args).await {
+        eprintln!("[Introspect] Fatal error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+async fn run_mcp_server(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    // Will be implemented in Task 2
+    todo!("MCP server loop")
+}
+```
+
+- [ ] **Step 4: Add to Cargo workspace**
+
+In `src-tauri/Cargo.toml`, add to the workspace members. Find the existing `members` array in `[workspace]` and add `"crates/teamclaw-introspect"`.
+
+- [ ] **Step 5: Create stub module files**
+
+Create these empty stub files so the crate compiles:
+
+`src-tauri/crates/teamclaw-introspect/src/config.rs`:
+```rust
+// Shared config reading utilities
+```
+
+`src-tauri/crates/teamclaw-introspect/src/capabilities.rs`:
+```rust
+// get_my_capabilities tool handler
+```
+
+`src-tauri/crates/teamclaw-introspect/src/send.rs`:
+```rust
+// send_channel_message tool handler
+```
+
+`src-tauri/crates/teamclaw-introspect/src/cron.rs`:
+```rust
+// manage_cron_job tool handler
+```
+
+`src-tauri/crates/teamclaw-introspect/src/shortcuts.rs`:
+```rust
+// manage_shortcuts tool handler
+```
+
+- [ ] **Step 6: Verify it compiles**
+
+```bash
+cd src-tauri && cargo check -p teamclaw-introspect
+```
+
+Expected: compiles with a warning about `todo!()` in main.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/crates/teamclaw-introspect/ src-tauri/Cargo.toml
+git commit -m "feat(introspect): scaffold teamclaw-introspect MCP server crate"
+```
+
+---
+
+## Task 2: Implement MCP stdio protocol handler
+
+The MCP protocol is JSON-RPC 2.0 over stdin/stdout. We implement it manually since we only need `initialize`, `tools/list`, and `tools/call`.
+
+**Files:**
+- Modify: `src-tauri/crates/teamclaw-introspect/src/main.rs`
+
+- [ ] **Step 1: Implement JSON-RPC types and stdio loop**
+
+Replace `run_mcp_server` in `main.rs` with the full MCP server implementation:
+
+```rust
+use serde_json::{json, Value};
+use std::io::{self, BufRead, Write};
+
+/// Read JSON-RPC messages from stdin, dispatch, write responses to stdout.
+async fn run_mcp_server(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+
+    for line in stdin.lock().lines() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let request: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(e) => {
+                let err_resp = json!({
+                    "jsonrpc": "2.0",
+                    "id": null,
+                    "error": { "code": -32700, "message": format!("Parse error: {}", e) }
+                });
+                writeln!(stdout, "{}", err_resp)?;
+                stdout.flush()?;
+                continue;
+            }
+        };
+
+        let id = request.get("id").cloned();
+        let method = request.get("method").and_then(|m| m.as_str()).unwrap_or("");
+        let params = request.get("params").cloned().unwrap_or(json!({}));
+
+        let result = match method {
+            "initialize" => handle_initialize(),
+            "tools/list" => handle_tools_list(),
+            "tools/call" => handle_tools_call(&args, &params).await,
+            "notifications/initialized" | "notifications/cancelled" => {
+                // Notification, no response needed
+                continue;
+            }
+            _ => Err(json!({ "code": -32601, "message": format!("Method not found: {}", method) })),
+        };
+
+        let response = match result {
+            Ok(res) => json!({ "jsonrpc": "2.0", "id": id, "result": res }),
+            Err(err) => json!({ "jsonrpc": "2.0", "id": id, "error": err }),
+        };
+
+        writeln!(stdout, "{}", response)?;
+        stdout.flush()?;
+    }
+
+    Ok(())
+}
+
+fn handle_initialize() -> Result<Value, Value> {
+    Ok(json!({
+        "protocolVersion": "2024-11-05",
+        "capabilities": { "tools": {} },
+        "serverInfo": {
+            "name": "teamclaw-introspect",
+            "version": "0.1.0"
+        }
+    }))
+}
+
+fn handle_tools_list() -> Result<Value, Value> {
+    Ok(json!({
+        "tools": [
+            {
+                "name": "get_my_capabilities",
+                "description": "查询当前用户在 TeamClaw 中配置的能力和设置。当用户提到发消息、查团队、用快捷键、看定时任务等操作时，先调用此工具了解可用能力。不传 category 返回所有类别的概览摘要。",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "category": {
+                            "type": "string",
+                            "enum": ["channels", "role", "shortcuts", "team_members", "env_vars", "team_info", "cron_jobs"],
+                            "description": "可选，按类别过滤。不传则返回全部概览。"
+                        }
+                    }
+                }
+            },
+            {
+                "name": "send_channel_message",
+                "description": "通过已绑定的消息频道发送消息。支持指定单个 channel 或广播到所有已绑定 channel。",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string",
+                            "enum": ["wecom", "discord", "email", "feishu", "kook", "wechat", "all"],
+                            "description": "目标频道。传 'all' 广播到所有已绑定的频道。"
+                        },
+                        "message": { "type": "string", "description": "要发送的消息内容（纯文本）。" },
+                        "target": {
+                            "type": "string",
+                            "description": "接收者标识。格式因 channel 而异：WeCom 'single:{userid}' 或 'group:{chatid}'；Discord 'dm:{user_id}' 或 'channel:{channel_id}'；Email 邮箱地址；Feishu chat_id；KOOK 'dm:{user_id}' 或 'channel:{channel_id}'；WeChat user_id。"
+                        }
+                    },
+                    "required": ["channel", "message"]
+                }
+            },
+            {
+                "name": "manage_cron_job",
+                "description": "管理定时任务：创建、暂停、恢复、删除、手动执行、查看运行历史。",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["create", "pause", "resume", "delete", "run", "get_runs"],
+                            "description": "操作类型"
+                        },
+                        "job_id": { "type": "string", "description": "目标任务 ID。create 时不需要。" },
+                        "name": { "type": "string", "description": "任务名称。create 时必须提供。" },
+                        "description": { "type": "string", "description": "任务描述。" },
+                        "schedule": {
+                            "type": "object",
+                            "description": "调度配置。create 时必须提供。",
+                            "properties": {
+                                "kind": { "type": "string", "enum": ["at", "every", "cron"] },
+                                "at": { "type": "string" },
+                                "every_ms": { "type": "number" },
+                                "expr": { "type": "string" },
+                                "tz": { "type": "string" }
+                            }
+                        },
+                        "message": { "type": "string", "description": "任务执行时发送给 AI 的 prompt。" },
+                        "delivery": {
+                            "type": "object",
+                            "properties": {
+                                "channel": { "type": "string", "enum": ["discord", "feishu", "email", "kook", "wechat", "wecom"] },
+                                "to": { "type": "string" }
+                            }
+                        }
+                    },
+                    "required": ["action"]
+                }
+            },
+            {
+                "name": "manage_shortcuts",
+                "description": "管理用户的快捷操作：创建、修改、删除。",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "action": { "type": "string", "enum": ["create", "update", "delete"] },
+                        "id": { "type": "string", "description": "快捷操作 ID。update/delete 时必须提供。" },
+                        "label": { "type": "string", "description": "显示名称。create 时必须提供。" },
+                        "type": { "type": "string", "enum": ["native", "link", "folder"] },
+                        "target": { "type": "string", "description": "目标内容。" },
+                        "icon": { "type": "string" },
+                        "parent_id": { "type": "string" }
+                    },
+                    "required": ["action"]
+                }
+            }
+        ]
+    }))
+}
+
+async fn handle_tools_call(args: &Args, params: &Value) -> Result<Value, Value> {
+    let tool_name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
+    let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
+
+    let result = match tool_name {
+        "get_my_capabilities" => capabilities::handle(&args.workspace, &arguments).await,
+        "send_channel_message" => send::handle(&args.workspace, args.api_port, &arguments).await,
+        "manage_cron_job" => cron::handle(&args.workspace, args.api_port, &arguments).await,
+        "manage_shortcuts" => shortcuts::handle(&args.workspace, &arguments).await,
+        _ => Err(format!("Unknown tool: {}", tool_name)),
+    };
+
+    match result {
+        Ok(content) => Ok(json!({
+            "content": [{ "type": "text", "text": serde_json::to_string_pretty(&content).unwrap_or_default() }]
+        })),
+        Err(e) => Ok(json!({
+            "content": [{ "type": "text", "text": format!("Error: {}", e) }],
+            "isError": true
+        })),
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd src-tauri && cargo check -p teamclaw-introspect
+```
+
+Expected: compiles (stub modules are empty, handler functions not yet defined).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src-tauri/crates/teamclaw-introspect/
+git commit -m "feat(introspect): implement MCP stdio protocol handler"
+```
+
+---
+
+## Task 3: Implement shared config reader
+
+**Files:**
+- Modify: `src-tauri/crates/teamclaw-introspect/src/config.rs`
+
+- [ ] **Step 1: Implement config reading utilities**
+
+Write `config.rs`:
+
+```rust
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+const TEAMCLAW_DIR: &str = ".teamclaw";
+const CONFIG_FILE_NAME: &str = "teamclaw.json";
+const TEAM_REPO_DIR: &str = "teamclaw-team";
+
+/// Read and parse teamclaw.json from workspace
+pub fn read_teamclaw_config(workspace: &str) -> Result<Value, String> {
+    let path = teamclaw_config_path(workspace);
+    if !path.exists() {
+        return Ok(serde_json::json!({}));
+    }
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read {}: {}", CONFIG_FILE_NAME, e))?;
+    serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse {}: {}", CONFIG_FILE_NAME, e))
+}
+
+/// Write teamclaw.json back to workspace
+pub fn write_teamclaw_config(workspace: &str, config: &Value) -> Result<(), String> {
+    let path = teamclaw_config_path(workspace);
+    // Ensure directory exists
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create config dir: {}", e))?;
+    }
+    let mut content = serde_json::to_string_pretty(config)
+        .map_err(|e| format!("Failed to serialize config: {}", e))?;
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+    std::fs::write(&path, &content)
+        .map_err(|e| format!("Failed to write {}: {}", CONFIG_FILE_NAME, e))
+}
+
+/// Read cron-jobs.json
+pub fn read_cron_jobs(workspace: &str) -> Result<Value, String> {
+    let path = cron_jobs_path(workspace);
+    if !path.exists() {
+        return Ok(serde_json::json!({ "jobs": [] }));
+    }
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read cron-jobs.json: {}", e))?;
+    serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse cron-jobs.json: {}", e))
+}
+
+/// Write cron-jobs.json
+pub fn write_cron_jobs(workspace: &str, data: &Value) -> Result<(), String> {
+    let path = cron_jobs_path(workspace);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create cron dir: {}", e))?;
+    }
+    let mut content = serde_json::to_string_pretty(data)
+        .map_err(|e| format!("Failed to serialize cron jobs: {}", e))?;
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+    std::fs::write(&path, &content)
+        .map_err(|e| format!("Failed to write cron-jobs.json: {}", e))
+}
+
+/// Read cron run history for a job (last N lines from JSONL)
+pub fn read_cron_runs(workspace: &str, job_id: &str, limit: usize) -> Result<Vec<Value>, String> {
+    let path = cron_run_file(workspace, job_id);
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read run history: {}", e))?;
+    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+    let start = if lines.len() > limit { lines.len() - limit } else { 0 };
+    let mut records = Vec::new();
+    for line in &lines[start..] {
+        if let Ok(v) = serde_json::from_str::<Value>(line) {
+            records.push(v);
+        }
+    }
+    Ok(records)
+}
+
+/// Read team members manifest
+pub fn read_team_members(workspace: &str) -> Result<Value, String> {
+    let path = Path::new(workspace)
+        .join(TEAM_REPO_DIR)
+        .join("_team")
+        .join("members.json");
+    if !path.exists() {
+        return Ok(serde_json::json!({ "members": [] }));
+    }
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read members.json: {}", e))?;
+    serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse members.json: {}", e))
+}
+
+/// Read all role definitions from .teamclaw/roles/*/ROLE.md
+pub fn read_roles(workspace: &str) -> Result<Vec<Value>, String> {
+    let roles_dir = Path::new(workspace).join(TEAMCLAW_DIR).join("roles");
+    if !roles_dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut roles = Vec::new();
+    let entries = std::fs::read_dir(&roles_dir)
+        .map_err(|e| format!("Failed to read roles dir: {}", e))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read dir entry: {}", e))?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let slug = path.file_name().and_then(|n| n.to_str()).unwrap_or("").to_string();
+        if slug == "skill" || slug == "config.json" {
+            continue;
+        }
+        let role_file = path.join("ROLE.md");
+        if !role_file.exists() {
+            continue;
+        }
+        if let Ok(content) = std::fs::read_to_string(&role_file) {
+            let role = parse_role_md(&slug, &content);
+            roles.push(role);
+        }
+    }
+    Ok(roles)
+}
+
+/// Parse ROLE.md frontmatter + sections
+fn parse_role_md(slug: &str, content: &str) -> Value {
+    let mut name = slug.to_string();
+    let mut description = String::new();
+    let mut working_style = String::new();
+
+    // Parse YAML frontmatter
+    if content.starts_with("---") {
+        if let Some(end) = content[3..].find("---") {
+            let frontmatter = &content[3..3 + end];
+            for line in frontmatter.lines() {
+                let line = line.trim();
+                if let Some(val) = line.strip_prefix("name:") {
+                    name = val.trim().trim_matches('"').to_string();
+                }
+                if let Some(val) = line.strip_prefix("description:") {
+                    description = val.trim().trim_matches('"').to_string();
+                }
+            }
+        }
+    }
+
+    // Parse ## sections
+    for section in content.split("\n## ") {
+        if section.starts_with("Working style") || section.starts_with("working style") {
+            working_style = section.lines().skip(1).collect::<Vec<_>>().join("\n").trim().to_string();
+        }
+    }
+
+    serde_json::json!({
+        "slug": slug,
+        "name": name,
+        "description": description,
+        "working_style": working_style,
+    })
+}
+
+fn teamclaw_config_path(workspace: &str) -> PathBuf {
+    Path::new(workspace).join(TEAMCLAW_DIR).join(CONFIG_FILE_NAME)
+}
+
+fn cron_jobs_path(workspace: &str) -> PathBuf {
+    Path::new(workspace).join(TEAMCLAW_DIR).join("cron-jobs.json")
+}
+
+fn cron_run_file(workspace: &str, job_id: &str) -> PathBuf {
+    Path::new(workspace)
+        .join(TEAMCLAW_DIR)
+        .join("cron-runs")
+        .join(format!("{}.jsonl", job_id))
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd src-tauri && cargo check -p teamclaw-introspect
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src-tauri/crates/teamclaw-introspect/src/config.rs
+git commit -m "feat(introspect): implement shared config reader"
+```
+
+---
+
+## Task 4: Implement `get_my_capabilities`
+
+**Files:**
+- Modify: `src-tauri/crates/teamclaw-introspect/src/capabilities.rs`
+
+- [ ] **Step 1: Implement the full handler**
+
+Write `capabilities.rs`:
+
+```rust
+use crate::config;
+use serde_json::{json, Value};
+
+pub async fn handle(workspace: &str, arguments: &Value) -> Result<Value, String> {
+    let category = arguments.get("category").and_then(|c| c.as_str());
+
+    match category {
+        Some("channels") => get_channels(workspace),
+        Some("role") => get_roles(workspace),
+        Some("shortcuts") => get_shortcuts(workspace),
+        Some("team_members") => get_team_members(workspace),
+        Some("env_vars") => get_env_vars(workspace),
+        Some("team_info") => get_team_info(workspace),
+        Some("cron_jobs") => get_cron_jobs(workspace),
+        Some(other) => Err(format!(
+            "Invalid category '{}'. Valid: channels, role, shortcuts, team_members, env_vars, team_info, cron_jobs",
+            other
+        )),
+        None => get_overview(workspace),
+    }
+}
+
+fn get_channels(workspace: &str) -> Result<Value, String> {
+    let config = config::read_teamclaw_config(workspace)?;
+    let channels = config.get("channels").cloned().unwrap_or(json!({}));
+    let channel_names = ["wecom", "discord", "email", "feishu", "kook", "wechat"];
+
+    let mut result = json!({});
+    for name in &channel_names {
+        let ch = channels.get(*name);
+        let bound = is_channel_bound(name, ch);
+        let mut info = json!({ "bound": bound });
+        if bound {
+            if let Some(ch) = ch {
+                add_channel_summary(name, ch, &mut info);
+            }
+        }
+        result[name] = info;
+    }
+    Ok(json!({ "channels": result }))
+}
+
+fn is_channel_bound(name: &str, config: Option<&Value>) -> bool {
+    let config = match config {
+        Some(c) if !c.is_null() => c,
+        _ => return false,
+    };
+    match name {
+        "wecom" => has_non_empty(config, "corpId") && has_non_empty(config, "agentId"),
+        "discord" => has_non_empty(config, "token"),
+        "email" => has_non_empty(config, "address") || has_non_empty(config, "gmailAddress"),
+        "feishu" => has_non_empty(config, "appId") && has_non_empty(config, "appSecret"),
+        "kook" => has_non_empty(config, "token"),
+        "wechat" => has_non_empty(config, "botToken"),
+        _ => false,
+    }
+}
+
+fn has_non_empty(config: &Value, key: &str) -> bool {
+    config
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+}
+
+fn add_channel_summary(name: &str, config: &Value, info: &mut Value) {
+    match name {
+        "wecom" => {
+            if let Some(v) = config.get("corpName").and_then(|v| v.as_str()) {
+                info["corp_name"] = json!(v);
+            }
+            if let Some(v) = config.get("agentName").and_then(|v| v.as_str()) {
+                info["agent_name"] = json!(v);
+            }
+        }
+        "email" => {
+            let addr = config.get("address").or(config.get("gmailAddress"));
+            if let Some(v) = addr.and_then(|v| v.as_str()) {
+                info["address"] = json!(v);
+            }
+        }
+        "discord" => {
+            if let Some(v) = config.get("botName").and_then(|v| v.as_str()) {
+                info["bot_name"] = json!(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn get_roles(workspace: &str) -> Result<Value, String> {
+    let roles = config::read_roles(workspace)?;
+    Ok(json!({ "available_roles": roles }))
+}
+
+fn get_shortcuts(workspace: &str) -> Result<Value, String> {
+    let config = config::read_teamclaw_config(workspace)?;
+    let shortcuts = config.get("shortcuts").cloned().unwrap_or(json!([]));
+    Ok(json!({ "shortcuts": shortcuts }))
+}
+
+fn get_team_members(workspace: &str) -> Result<Value, String> {
+    let data = config::read_team_members(workspace)?;
+    let members = data.get("members").cloned().unwrap_or(json!([]));
+    // Filter to only safe fields
+    let safe_members: Vec<Value> = members
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .map(|m| {
+            json!({
+                "name": m.get("name").unwrap_or(&json!("")),
+                "role": m.get("role").unwrap_or(&json!("")),
+                "label": m.get("label").unwrap_or(&json!("")),
+            })
+        })
+        .collect();
+    Ok(json!({ "members": safe_members }))
+}
+
+fn get_env_vars(workspace: &str) -> Result<Value, String> {
+    let config = config::read_teamclaw_config(workspace)?;
+    let env_vars = config.get("envVars").cloned().unwrap_or(json!([]));
+    // Only return key, description, category — never values
+    let safe_vars: Vec<Value> = env_vars
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .map(|v| {
+            json!({
+                "key": v.get("key").unwrap_or(&json!("")),
+                "description": v.get("description").unwrap_or(&json!("")),
+                "category": v.get("category"),
+            })
+        })
+        .collect();
+    Ok(json!({ "env_vars": safe_vars }))
+}
+
+fn get_team_info(workspace: &str) -> Result<Value, String> {
+    let config = config::read_teamclaw_config(workspace)?;
+    let team = config.get("team").cloned().unwrap_or(json!({}));
+    // Strip sensitive fields
+    let mut safe = team.clone();
+    if let Some(obj) = safe.as_object_mut() {
+        obj.remove("git_token");
+        obj.remove("gitToken");
+    }
+    Ok(json!({ "team": safe }))
+}
+
+fn get_cron_jobs(workspace: &str) -> Result<Value, String> {
+    let data = config::read_cron_jobs(workspace)?;
+    let jobs = data.get("jobs").cloned().unwrap_or(json!([]));
+    // Return summary without payload/delivery details
+    let safe_jobs: Vec<Value> = jobs
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .map(|j| {
+            json!({
+                "id": j.get("id"),
+                "name": j.get("name"),
+                "description": j.get("description"),
+                "enabled": j.get("enabled"),
+                "schedule": j.get("schedule"),
+                "last_run_at": j.get("last_run_at"),
+                "next_run_at": j.get("next_run_at"),
+            })
+        })
+        .collect();
+    Ok(json!({ "cron_jobs": safe_jobs }))
+}
+
+fn get_overview(workspace: &str) -> Result<Value, String> {
+    let config = config::read_teamclaw_config(workspace).unwrap_or(json!({}));
+    let channels_config = config.get("channels").cloned().unwrap_or(json!({}));
+
+    let channel_names = ["wecom", "discord", "email", "feishu", "kook", "wechat"];
+    let mut bound = vec![];
+    let mut unbound = vec![];
+    for name in &channel_names {
+        if is_channel_bound(name, channels_config.get(*name)) {
+            bound.push(*name);
+        } else {
+            unbound.push(*name);
+        }
+    }
+
+    let roles = config::read_roles(workspace).unwrap_or_default();
+    let shortcuts = config.get("shortcuts").and_then(|s| s.as_array()).map(|a| a.len()).unwrap_or(0);
+    let members = config::read_team_members(workspace)
+        .ok()
+        .and_then(|d| d.get("members").and_then(|m| m.as_array()).map(|a| a.len()))
+        .unwrap_or(0);
+    let env_vars = config.get("envVars").and_then(|e| e.as_array()).map(|a| a.len()).unwrap_or(0);
+    let team = config.get("team").cloned().unwrap_or(json!({}));
+    let cron_data = config::read_cron_jobs(workspace).unwrap_or(json!({"jobs": []}));
+    let cron_jobs = cron_data.get("jobs").and_then(|j| j.as_array()).unwrap_or(&vec![]);
+    let enabled_count = cron_jobs.iter().filter(|j| j.get("enabled") == Some(&json!(true))).count();
+
+    Ok(json!({
+        "overview": {
+            "channels": { "bound": bound, "unbound": unbound },
+            "role": { "available_count": roles.len() },
+            "shortcuts": { "count": shortcuts },
+            "team_members": { "count": members },
+            "env_vars": { "count": env_vars },
+            "team_info": {
+                "enabled": team.get("enabled").unwrap_or(&json!(false)),
+                "sync_mode": if team.get("git_url").is_some() || team.get("gitUrl").is_some() { "git" } else { "unknown" }
+            },
+            "cron_jobs": { "count": cron_jobs.len(), "enabled_count": enabled_count }
+        }
+    }))
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd src-tauri && cargo check -p teamclaw-introspect
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src-tauri/crates/teamclaw-introspect/src/capabilities.rs
+git commit -m "feat(introspect): implement get_my_capabilities tool"
+```
+
+---
+
+## Task 5: Implement `send_channel_message`
+
+For HTTP-based channels (Discord, Feishu, Email, KOOK, WeChat), the MCP binary makes API calls directly. For WeCom (requires WebSocket), it calls the Tauri internal HTTP API.
+
+**Files:**
+- Modify: `src-tauri/crates/teamclaw-introspect/src/send.rs`
+
+- [ ] **Step 1: Implement the send handler**
+
+Write `send.rs`:
+
+```rust
+use crate::config;
+use serde_json::{json, Value};
+
+pub async fn handle(workspace: &str, api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let channel = arguments.get("channel").and_then(|c| c.as_str())
+        .ok_or("Missing required parameter: channel")?;
+    let message = arguments.get("message").and_then(|m| m.as_str())
+        .ok_or("Missing required parameter: message")?;
+    let target = arguments.get("target").and_then(|t| t.as_str());
+
+    if channel == "all" {
+        return send_all(workspace, api_port, message, target).await;
+    }
+
+    let result = send_single(workspace, api_port, channel, message, target).await;
+    match result {
+        Ok(info) => Ok(json!({ "success": true, "channel": channel, "info": info })),
+        Err(e) => Ok(json!({ "success": false, "channel": channel, "error": e })),
+    }
+}
+
+async fn send_all(workspace: &str, api_port: u16, message: &str, target: Option<&str>) -> Result<Value, String> {
+    let tc_config = config::read_teamclaw_config(workspace)?;
+    let channels = tc_config.get("channels").cloned().unwrap_or(json!({}));
+
+    let channel_names = ["wecom", "discord", "email", "feishu", "kook", "wechat"];
+    let mut results = json!({});
+    let mut success_count = 0;
+    let mut total_bound = 0;
+
+    for name in &channel_names {
+        if !crate::capabilities::is_channel_bound_pub(name, channels.get(*name)) {
+            continue;
+        }
+        total_bound += 1;
+        match send_single(workspace, api_port, name, message, target).await {
+            Ok(info) => {
+                results[name] = json!({ "success": true, "info": info });
+                success_count += 1;
+            }
+            Err(e) => {
+                results[name] = json!({ "success": false, "error": e });
+            }
+        }
+    }
+
+    Ok(json!({
+        "results": results,
+        "summary": format!("{}/{} channels sent successfully", success_count, total_bound)
+    }))
+}
+
+async fn send_single(
+    workspace: &str,
+    api_port: u16,
+    channel: &str,
+    message: &str,
+    target: Option<&str>,
+) -> Result<Value, String> {
+    let tc_config = config::read_teamclaw_config(workspace)?;
+    let channels = tc_config.get("channels").cloned().unwrap_or(json!({}));
+    let ch_config = channels.get(channel).ok_or(format!("{} channel not configured", channel))?;
+
+    if !crate::capabilities::is_channel_bound_pub(channel, Some(ch_config)) {
+        return Err(format!("{} channel is not bound. Please configure it in Settings → Channels.", channel));
+    }
+
+    let target = target.ok_or(format!("Target is required for {}.", channel))?;
+
+    match channel {
+        "discord" => send_discord(ch_config, target, message).await,
+        "feishu" => send_feishu(ch_config, target, message).await,
+        "email" => send_email(ch_config, workspace, target, message).await,
+        "kook" => send_kook(ch_config, target, message).await,
+        "wechat" => send_wechat(ch_config, target, message).await,
+        "wecom" => send_wecom_via_api(api_port, target, message).await,
+        _ => Err(format!("Unknown channel: {}", channel)),
+    }
+}
+
+async fn send_discord(config: &Value, target: &str, message: &str) -> Result<Value, String> {
+    let token = config.get("token").and_then(|t| t.as_str())
+        .ok_or("Discord bot token not configured")?;
+
+    let client = reqwest::Client::new();
+
+    // Resolve channel ID from target format
+    let channel_id = if target.starts_with("channel:") {
+        target.strip_prefix("channel:").unwrap_or(target).to_string()
+    } else {
+        // DM: create DM channel first
+        let user_id = target.strip_prefix("dm:").unwrap_or(target);
+        let resp = client
+            .post("https://discord.com/api/v10/users/@me/channels")
+            .header("Authorization", format!("Bot {}", token))
+            .json(&json!({ "recipient_id": user_id }))
+            .send()
+            .await
+            .map_err(|e| format!("Discord DM create failed: {}", e))?;
+        let body: Value = resp.json().await.map_err(|e| format!("Discord DM parse failed: {}", e))?;
+        body.get("id").and_then(|id| id.as_str()).ok_or("No channel ID in DM response")?.to_string()
+    };
+
+    // Send message (split if > 2000 chars)
+    for chunk in split_message(message, 2000) {
+        client
+            .post(format!("https://discord.com/api/v10/channels/{}/messages", channel_id))
+            .header("Authorization", format!("Bot {}", token))
+            .json(&json!({ "content": chunk }))
+            .send()
+            .await
+            .map_err(|e| format!("Discord send failed: {}", e))?;
+    }
+
+    Ok(json!({ "sent_to": target }))
+}
+
+async fn send_feishu(config: &Value, target: &str, message: &str) -> Result<Value, String> {
+    let app_id = config.get("appId").and_then(|v| v.as_str())
+        .ok_or("Feishu app ID not configured")?;
+    let app_secret = config.get("appSecret").and_then(|v| v.as_str())
+        .ok_or("Feishu app secret not configured")?;
+
+    let client = reqwest::Client::new();
+
+    // Get tenant access token
+    let token_resp = client
+        .post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal")
+        .json(&json!({ "app_id": app_id, "app_secret": app_secret }))
+        .send()
+        .await
+        .map_err(|e| format!("Feishu auth failed: {}", e))?;
+    let token_body: Value = token_resp.json().await.map_err(|e| format!("Feishu auth parse failed: {}", e))?;
+    let access_token = token_body.get("tenant_access_token").and_then(|t| t.as_str())
+        .ok_or("Failed to get Feishu access token")?;
+
+    // Send message
+    for chunk in split_message(message, 4000) {
+        client
+            .post("https://open.feishu.cn/open-apis/im/v1/messages")
+            .header("Authorization", format!("Bearer {}", access_token))
+            .query(&[("receive_id_type", "chat_id")])
+            .json(&json!({
+                "receive_id": target,
+                "msg_type": "text",
+                "content": serde_json::to_string(&json!({ "text": chunk })).unwrap()
+            }))
+            .send()
+            .await
+            .map_err(|e| format!("Feishu send failed: {}", e))?;
+    }
+
+    Ok(json!({ "sent_to": target }))
+}
+
+async fn send_email(config: &Value, _workspace: &str, target: &str, message: &str) -> Result<Value, String> {
+    // Email sending requires SMTP or OAuth2 — complex to reimplement.
+    // Delegate to internal API.
+    // For now, return a clear error directing to use the Tauri app.
+    let _ = (config, target, message);
+    Err("Email sending from MCP is not yet supported. Use the Tauri app's cron delivery for email.".to_string())
+}
+
+async fn send_kook(config: &Value, target: &str, message: &str) -> Result<Value, String> {
+    let token = config.get("token").and_then(|t| t.as_str())
+        .ok_or("KOOK bot token not configured")?;
+
+    let client = reqwest::Client::new();
+
+    let (target_id, is_dm) = if target.starts_with("dm:") {
+        (target.strip_prefix("dm:").unwrap_or(target), true)
+    } else if target.starts_with("channel:") {
+        (target.strip_prefix("channel:").unwrap_or(target), false)
+    } else {
+        (target, true)
+    };
+
+    let url = if is_dm {
+        "https://www.kookapp.cn/api/v3/direct-message/create"
+    } else {
+        "https://www.kookapp.cn/api/v3/message/create"
+    };
+
+    for chunk in split_message(message, 8000) {
+        let mut body = json!({ "content": chunk, "type": 1 });
+        if is_dm {
+            body["target_id"] = json!(target_id);
+        } else {
+            body["target_id"] = json!(target_id);
+        }
+
+        client
+            .post(url)
+            .header("Authorization", format!("Bot {}", token))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("KOOK send failed: {}", e))?;
+    }
+
+    Ok(json!({ "sent_to": target }))
+}
+
+async fn send_wechat(config: &Value, target: &str, message: &str) -> Result<Value, String> {
+    let bot_token = config.get("botToken").and_then(|t| t.as_str())
+        .ok_or("WeChat bot token not configured")?;
+    let base_url = config.get("baseUrl").and_then(|u| u.as_str())
+        .unwrap_or("https://ilinkai.weixin.qq.com");
+    let context_token = config.get("contextTokens")
+        .and_then(|ct| ct.get(target))
+        .and_then(|t| t.as_str())
+        .ok_or(format!("No context_token for WeChat user '{}'. The user must send a message to the gateway first.", target))?;
+
+    let client = reqwest::Client::new();
+
+    client
+        .post(format!("{}/ilink/bot/sendmessage", base_url))
+        .header("Authorization", format!("Bearer {}", bot_token))
+        .json(&json!({
+            "to_user_id": target,
+            "content": { "type": "text", "text": message },
+            "context_token": context_token
+        }))
+        .send()
+        .await
+        .map_err(|e| format!("WeChat send failed: {}", e))?;
+
+    Ok(json!({ "sent_to": target }))
+}
+
+/// Send WeCom message via internal Tauri HTTP API (WebSocket-dependent)
+async fn send_wecom_via_api(api_port: u16, target: &str, message: &str) -> Result<Value, String> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://127.0.0.1:{}/send-wecom", api_port))
+        .json(&json!({ "target": target, "message": message }))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to reach internal API: {}. Is TeamClaw running?", e))?;
+
+    if resp.status().is_success() {
+        Ok(json!({ "sent_to": target }))
+    } else {
+        let body = resp.text().await.unwrap_or_default();
+        Err(format!("WeCom send failed: {}", body))
+    }
+}
+
+fn split_message(text: &str, max_len: usize) -> Vec<String> {
+    if text.len() <= max_len {
+        return vec![text.to_string()];
+    }
+    let mut chunks = Vec::new();
+    let mut remaining = text;
+    while !remaining.is_empty() {
+        if remaining.len() <= max_len {
+            chunks.push(remaining.to_string());
+            break;
+        }
+        let mut split_at = max_len;
+        while split_at > 0 && !remaining.is_char_boundary(split_at) {
+            split_at -= 1;
+        }
+        let actual_split = remaining[..split_at]
+            .rfind('\n')
+            .unwrap_or_else(|| remaining[..split_at].rfind(' ').unwrap_or(split_at));
+        if actual_split == 0 {
+            chunks.push(remaining[..split_at].to_string());
+            remaining = &remaining[split_at..];
+        } else {
+            chunks.push(remaining[..actual_split].to_string());
+            remaining = remaining[actual_split..].trim_start();
+        }
+    }
+    chunks
+}
+```
+
+- [ ] **Step 2: Expose `is_channel_bound` as pub in capabilities.rs**
+
+Add this public wrapper function to `capabilities.rs`:
+
+```rust
+/// Public wrapper for use by send.rs
+pub fn is_channel_bound_pub(name: &str, config: Option<&Value>) -> bool {
+    is_channel_bound(name, config)
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+cd src-tauri && cargo check -p teamclaw-introspect
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/crates/teamclaw-introspect/src/send.rs src-tauri/crates/teamclaw-introspect/src/capabilities.rs
+git commit -m "feat(introspect): implement send_channel_message tool"
+```
+
+---
+
+## Task 6: Implement `manage_cron_job`
+
+**Files:**
+- Modify: `src-tauri/crates/teamclaw-introspect/src/cron.rs`
+
+- [ ] **Step 1: Implement the cron handler**
+
+Write `cron.rs`:
+
+```rust
+use crate::config;
+use chrono::Utc;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+pub async fn handle(workspace: &str, api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let action = arguments.get("action").and_then(|a| a.as_str())
+        .ok_or("Missing required parameter: action")?;
+
+    match action {
+        "create" => create_job(workspace, arguments),
+        "pause" => toggle_job(workspace, arguments, false),
+        "resume" => toggle_job(workspace, arguments, true),
+        "delete" => delete_job(workspace, arguments),
+        "run" => run_job(api_port, arguments).await,
+        "get_runs" => get_runs(workspace, arguments),
+        _ => Err(format!("Invalid action '{}'. Valid: create, pause, resume, delete, run, get_runs", action)),
+    }
+}
+
+fn create_job(workspace: &str, arguments: &Value) -> Result<Value, String> {
+    let name = arguments.get("name").and_then(|n| n.as_str())
+        .ok_or("Missing required parameter: name")?;
+    let schedule = arguments.get("schedule")
+        .ok_or("Missing required parameter: schedule")?;
+    let message = arguments.get("message").and_then(|m| m.as_str())
+        .ok_or("Missing required parameter: message")?;
+    let description = arguments.get("description").and_then(|d| d.as_str());
+
+    // Validate schedule
+    let kind = schedule.get("kind").and_then(|k| k.as_str())
+        .ok_or("Missing schedule.kind")?;
+    match kind {
+        "at" => {
+            schedule.get("at").and_then(|a| a.as_str())
+                .ok_or("schedule.at is required when kind='at'")?;
+        }
+        "every" => {
+            schedule.get("every_ms").and_then(|e| e.as_u64())
+                .ok_or("schedule.every_ms is required when kind='every'")?;
+        }
+        "cron" => {
+            schedule.get("expr").and_then(|e| e.as_str())
+                .ok_or("schedule.expr is required when kind='cron'")?;
+        }
+        _ => return Err(format!("Invalid schedule.kind '{}'. Valid: at, every, cron", kind)),
+    }
+
+    let mut data = config::read_cron_jobs(workspace)?;
+    let jobs = data.get_mut("jobs")
+        .and_then(|j| j.as_array_mut())
+        .ok_or("Invalid cron-jobs.json structure")?;
+
+    let now = Utc::now().to_rfc3339();
+    let id = Uuid::new_v4().to_string();
+
+    // Build delivery if provided
+    let delivery = arguments.get("delivery").cloned();
+
+    let job = json!({
+        "id": id,
+        "name": name,
+        "description": description,
+        "enabled": true,
+        "schedule": {
+            "kind": kind,
+            "at": schedule.get("at"),
+            "every_ms": schedule.get("every_ms"),
+            "expr": schedule.get("expr"),
+            "tz": schedule.get("tz"),
+        },
+        "payload": {
+            "message": message,
+        },
+        "delivery": delivery.map(|d| json!({
+            "mode": "announce",
+            "channel": d.get("channel"),
+            "to": d.get("to").and_then(|t| t.as_str()).unwrap_or(""),
+            "best_effort": true,
+        })),
+        "delete_after_run": kind == "at",
+        "created_at": now,
+        "updated_at": now,
+        "last_run_at": null,
+        "next_run_at": null,
+    });
+
+    jobs.push(job.clone());
+    config::write_cron_jobs(workspace, &data)?;
+
+    Ok(json!({
+        "success": true,
+        "job": {
+            "id": id,
+            "name": name,
+            "enabled": true,
+            "schedule": schedule,
+        }
+    }))
+}
+
+fn toggle_job(workspace: &str, arguments: &Value, enabled: bool) -> Result<Value, String> {
+    let job_id = arguments.get("job_id").and_then(|j| j.as_str())
+        .ok_or("Missing required parameter: job_id")?;
+
+    let mut data = config::read_cron_jobs(workspace)?;
+    let jobs = data.get_mut("jobs")
+        .and_then(|j| j.as_array_mut())
+        .ok_or("Invalid cron-jobs.json structure")?;
+
+    let job = jobs.iter_mut()
+        .find(|j| j.get("id").and_then(|id| id.as_str()) == Some(job_id))
+        .ok_or(format!("Job not found: {}", job_id))?;
+
+    job["enabled"] = json!(enabled);
+    job["updated_at"] = json!(Utc::now().to_rfc3339());
+
+    config::write_cron_jobs(workspace, &data)?;
+
+    let action = if enabled { "resumed" } else { "paused" };
+    let name = job.get("name").and_then(|n| n.as_str()).unwrap_or(job_id);
+    Ok(json!({
+        "success": true,
+        "message": format!("Job '{}' {}", name, action)
+    }))
+}
+
+fn delete_job(workspace: &str, arguments: &Value) -> Result<Value, String> {
+    let job_id = arguments.get("job_id").and_then(|j| j.as_str())
+        .ok_or("Missing required parameter: job_id")?;
+
+    let mut data = config::read_cron_jobs(workspace)?;
+    let jobs = data.get_mut("jobs")
+        .and_then(|j| j.as_array_mut())
+        .ok_or("Invalid cron-jobs.json structure")?;
+
+    let original_len = jobs.len();
+    jobs.retain(|j| j.get("id").and_then(|id| id.as_str()) != Some(job_id));
+
+    if jobs.len() == original_len {
+        return Err(format!("Job not found: {}", job_id));
+    }
+
+    config::write_cron_jobs(workspace, &data)?;
+
+    // Also remove run history file
+    let run_file = std::path::Path::new(workspace)
+        .join(".teamclaw")
+        .join("cron-runs")
+        .join(format!("{}.jsonl", job_id));
+    let _ = std::fs::remove_file(run_file); // Best effort
+
+    Ok(json!({
+        "success": true,
+        "message": format!("Job '{}' deleted", job_id)
+    }))
+}
+
+async fn run_job(api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let job_id = arguments.get("job_id").and_then(|j| j.as_str())
+        .ok_or("Missing required parameter: job_id")?;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://127.0.0.1:{}/cron-run", api_port))
+        .json(&json!({ "job_id": job_id }))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to reach internal API: {}. Is TeamClaw running?", e))?;
+
+    if resp.status().is_success() {
+        Ok(json!({
+            "success": true,
+            "message": format!("Job '{}' triggered for immediate execution", job_id)
+        }))
+    } else {
+        let body = resp.text().await.unwrap_or_default();
+        Err(format!("Failed to trigger job: {}", body))
+    }
+}
+
+fn get_runs(workspace: &str, arguments: &Value) -> Result<Value, String> {
+    let job_id = arguments.get("job_id").and_then(|j| j.as_str())
+        .ok_or("Missing required parameter: job_id")?;
+
+    let runs = config::read_cron_runs(workspace, job_id, 10)?;
+
+    // Filter to safe fields
+    let safe_runs: Vec<Value> = runs.iter().map(|r| {
+        json!({
+            "run_id": r.get("run_id"),
+            "status": r.get("status"),
+            "started_at": r.get("started_at"),
+            "finished_at": r.get("finished_at"),
+            "response_summary": r.get("response_summary"),
+            "error": r.get("error"),
+        })
+    }).collect();
+
+    Ok(json!({ "runs": safe_runs }))
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd src-tauri && cargo check -p teamclaw-introspect
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src-tauri/crates/teamclaw-introspect/src/cron.rs
+git commit -m "feat(introspect): implement manage_cron_job tool"
+```
+
+---
+
+## Task 7: Implement `manage_shortcuts`
+
+**Files:**
+- Modify: `src-tauri/crates/teamclaw-introspect/src/shortcuts.rs`
+
+- [ ] **Step 1: Implement the shortcuts handler**
+
+Write `shortcuts.rs`:
+
+```rust
+use crate::config;
+use serde_json::{json, Value};
+
+pub async fn handle(workspace: &str, arguments: &Value) -> Result<Value, String> {
+    let action = arguments.get("action").and_then(|a| a.as_str())
+        .ok_or("Missing required parameter: action")?;
+
+    match action {
+        "create" => create_shortcut(workspace, arguments),
+        "update" => update_shortcut(workspace, arguments),
+        "delete" => delete_shortcut(workspace, arguments),
+        _ => Err(format!("Invalid action '{}'. Valid: create, update, delete", action)),
+    }
+}
+
+fn create_shortcut(workspace: &str, arguments: &Value) -> Result<Value, String> {
+    let label = arguments.get("label").and_then(|l| l.as_str())
+        .ok_or("Missing required parameter: label")?;
+    let sc_type = arguments.get("type").and_then(|t| t.as_str())
+        .ok_or("Missing required parameter: type")?;
+    let target = arguments.get("target").and_then(|t| t.as_str()).unwrap_or("");
+
+    if !["native", "link", "folder"].contains(&sc_type) {
+        return Err(format!("Invalid type '{}'. Valid: native, link, folder", sc_type));
+    }
+
+    let mut tc_config = config::read_teamclaw_config(workspace)?;
+
+    let shortcuts = tc_config
+        .as_object_mut()
+        .ok_or("Invalid teamclaw.json")?
+        .entry("shortcuts")
+        .or_insert_with(|| json!([]))
+        .as_array_mut()
+        .ok_or("shortcuts is not an array")?;
+
+    // Generate ID and compute order
+    let id = format!(
+        "shortcut-{}-{}",
+        chrono::Utc::now().timestamp_millis(),
+        &uuid::Uuid::new_v4().to_string()[..7]
+    );
+    let parent_id = arguments.get("parent_id").and_then(|p| p.as_str());
+    let order = shortcuts
+        .iter()
+        .filter(|s| s.get("parentId").and_then(|p| p.as_str()) == parent_id)
+        .count();
+
+    let shortcut = json!({
+        "id": id,
+        "label": label,
+        "type": sc_type,
+        "target": target,
+        "icon": arguments.get("icon").and_then(|i| i.as_str()).unwrap_or(""),
+        "order": order,
+        "parentId": parent_id,
+    });
+
+    shortcuts.push(shortcut.clone());
+    config::write_teamclaw_config(workspace, &tc_config)?;
+
+    Ok(json!({ "success": true, "shortcut": shortcut }))
+}
+
+fn update_shortcut(workspace: &str, arguments: &Value) -> Result<Value, String> {
+    let id = arguments.get("id").and_then(|i| i.as_str())
+        .ok_or("Missing required parameter: id")?;
+
+    let mut tc_config = config::read_teamclaw_config(workspace)?;
+    let shortcuts = tc_config.get_mut("shortcuts")
+        .and_then(|s| s.as_array_mut())
+        .ok_or("No shortcuts configured")?;
+
+    let shortcut = shortcuts.iter_mut()
+        .find(|s| s.get("id").and_then(|sid| sid.as_str()) == Some(id))
+        .ok_or(format!("Shortcut not found: {}", id))?;
+
+    // Update provided fields
+    if let Some(label) = arguments.get("label").and_then(|l| l.as_str()) {
+        shortcut["label"] = json!(label);
+    }
+    if let Some(sc_type) = arguments.get("type").and_then(|t| t.as_str()) {
+        shortcut["type"] = json!(sc_type);
+    }
+    if let Some(target) = arguments.get("target").and_then(|t| t.as_str()) {
+        shortcut["target"] = json!(target);
+    }
+    if let Some(icon) = arguments.get("icon").and_then(|i| i.as_str()) {
+        shortcut["icon"] = json!(icon);
+    }
+    if let Some(parent_id) = arguments.get("parent_id") {
+        shortcut["parentId"] = parent_id.clone();
+    }
+
+    let updated = shortcut.clone();
+    config::write_teamclaw_config(workspace, &tc_config)?;
+
+    Ok(json!({ "success": true, "shortcut": updated }))
+}
+
+fn delete_shortcut(workspace: &str, arguments: &Value) -> Result<Value, String> {
+    let id = arguments.get("id").and_then(|i| i.as_str())
+        .ok_or("Missing required parameter: id")?;
+
+    let mut tc_config = config::read_teamclaw_config(workspace)?;
+    let shortcuts = tc_config.get_mut("shortcuts")
+        .and_then(|s| s.as_array_mut())
+        .ok_or("No shortcuts configured")?;
+
+    // Collect IDs to delete (target + all children if folder)
+    let mut ids_to_delete = vec![id.to_string()];
+    collect_children(shortcuts, id, &mut ids_to_delete);
+
+    let original_len = shortcuts.len();
+    shortcuts.retain(|s| {
+        let sid = s.get("id").and_then(|sid| sid.as_str()).unwrap_or("");
+        !ids_to_delete.contains(&sid.to_string())
+    });
+
+    let deleted_count = original_len - shortcuts.len();
+    if deleted_count == 0 {
+        return Err(format!("Shortcut not found: {}", id));
+    }
+
+    config::write_teamclaw_config(workspace, &tc_config)?;
+
+    Ok(json!({
+        "success": true,
+        "deleted_count": deleted_count,
+    }))
+}
+
+fn collect_children(shortcuts: &[Value], parent_id: &str, ids: &mut Vec<String>) {
+    for s in shortcuts {
+        if s.get("parentId").and_then(|p| p.as_str()) == Some(parent_id) {
+            if let Some(child_id) = s.get("id").and_then(|id| id.as_str()) {
+                ids.push(child_id.to_string());
+                collect_children(shortcuts, child_id, ids);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd src-tauri && cargo check -p teamclaw-introspect
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src-tauri/crates/teamclaw-introspect/src/shortcuts.rs
+git commit -m "feat(introspect): implement manage_shortcuts tool"
+```
+
+---
+
+## Task 8: Shortcuts persistence migration (localStorage → file system)
+
+**Files:**
+- Modify: `src-tauri/src/commands/gateway/mod.rs` — Add Tauri commands
+- Modify: `packages/app/src/stores/shortcuts.ts` — Switch persistence
+
+- [ ] **Step 1: Add Tauri commands for shortcuts persistence**
+
+In `src-tauri/src/commands/gateway/mod.rs`, add near the other config commands:
+
+```rust
+#[tauri::command]
+pub fn load_shortcuts(
+    opencode_state: State<'_, super::opencode::OpenCodeState>,
+) -> Result<Vec<serde_json::Value>, String> {
+    let workspace_path = {
+        let inner = opencode_state.inner.lock().map_err(|e| e.to_string())?;
+        inner.workspace_path.clone()?
+    };
+    let config = read_config(&workspace_path)?;
+    let shortcuts = config.get("shortcuts").cloned().unwrap_or(serde_json::json!([]));
+    Ok(shortcuts.as_array().cloned().unwrap_or_default())
+}
+
+#[tauri::command]
+pub fn save_shortcuts(
+    opencode_state: State<'_, super::opencode::OpenCodeState>,
+    nodes: Vec<serde_json::Value>,
+) -> Result<(), String> {
+    let workspace_path = {
+        let inner = opencode_state.inner.lock().map_err(|e| e.to_string())?;
+        inner.workspace_path.clone()?
+    };
+    let mut config = read_config(&workspace_path)?;
+    config["shortcuts"] = serde_json::json!(nodes);
+    write_config(&workspace_path, &config)
+}
+```
+
+- [ ] **Step 2: Register the Tauri commands**
+
+In `src-tauri/src/lib.rs`, add to the `invoke_handler` list:
+
+```rust
+commands::gateway::load_shortcuts,
+commands::gateway::save_shortcuts,
+```
+
+- [ ] **Step 3: Update frontend shortcuts store**
+
+Replace the persistence functions in `packages/app/src/stores/shortcuts.ts`:
+
+```typescript
+import { invoke } from '@tauri-apps/api/core'
+
+// Replace loadPersistedNodes
+async function loadPersistedNodesFromFile(): Promise<ShortcutNode[]> {
+  try {
+    const nodes = await invoke<ShortcutNode[]>('load_shortcuts')
+    return nodes || []
+  } catch {
+    // Fallback to localStorage for migration
+    const stored = loadFromStorage<{ nodes: ShortcutNode[]; version: number }>(STORAGE_KEY, { nodes: [], version: 1 })
+    return stored.nodes || []
+  }
+}
+
+// Replace persistNodes
+async function persistNodesToFile(nodes: ShortcutNode[]): Promise<void> {
+  try {
+    await invoke('save_shortcuts', { nodes })
+  } catch (e) {
+    console.error('[Shortcuts] Failed to persist to file, falling back to localStorage', e)
+    saveToStorage(STORAGE_KEY, { nodes, version: 1 })
+  }
+}
+```
+
+Update the store to use async init pattern: change `nodes: loadPersistedNodes()` to lazy initialization with the async function, and update `persistNodes()` calls to use the new async version.
+
+- [ ] **Step 4: Add one-time migration logic**
+
+In the store's initialization, add migration: if file has no shortcuts but localStorage does, write localStorage data to file and clear localStorage.
+
+- [ ] **Step 5: Verify it compiles**
+
+```bash
+cd src-tauri && cargo check
+pnpm typecheck
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/commands/gateway/mod.rs src-tauri/src/lib.rs packages/app/src/stores/shortcuts.ts
+git commit -m "feat(shortcuts): migrate persistence from localStorage to teamclaw.json"
+```
+
+---
+
+## Task 9: Internal HTTP API for runtime operations
+
+The MCP binary needs to call the Tauri process for operations requiring runtime state: WeCom sending (WebSocket) and cron manual run (scheduler).
+
+**Files:**
+- Create: `src-tauri/src/commands/introspect_api.rs`
+- Modify: `src-tauri/src/commands/mod.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Create the HTTP API server**
+
+Create `src-tauri/src/commands/introspect_api.rs`:
+
+```rust
+use std::sync::Arc;
+use tauri::AppHandle;
+use tokio::sync::RwLock;
+
+/// Port for the introspect internal API
+pub const INTROSPECT_API_PORT: u16 = 13144;
+
+/// Start a minimal HTTP server for the introspect MCP binary to call.
+/// Handles: POST /send-wecom, POST /cron-run
+pub async fn start_introspect_api(app_handle: AppHandle) -> Result<(), String> {
+    use std::io::{Read, Write};
+
+    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", INTROSPECT_API_PORT))
+        .await
+        .map_err(|e| format!("Failed to bind introspect API: {}", e))?;
+
+    eprintln!("[IntrospectAPI] Listening on 127.0.0.1:{}", INTROSPECT_API_PORT);
+
+    loop {
+        let (stream, _) = listener.accept().await.map_err(|e| format!("Accept error: {}", e))?;
+        let app = app_handle.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_connection(stream, app).await {
+                eprintln!("[IntrospectAPI] Error: {}", e);
+            }
+        });
+    }
+}
+
+async fn handle_connection(
+    mut stream: tokio::net::TcpStream,
+    app: AppHandle,
+) -> Result<(), String> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut buf = vec![0u8; 8192];
+    let n = stream.read(&mut buf).await.map_err(|e| e.to_string())?;
+    let request = String::from_utf8_lossy(&buf[..n]);
+
+    // Simple HTTP parsing
+    let (method, path, body) = parse_http_request(&request);
+
+    let (status, response_body) = match (method.as_str(), path.as_str()) {
+        ("POST", "/send-wecom") => handle_send_wecom(&app, &body).await,
+        ("POST", "/cron-run") => handle_cron_run(&app, &body).await,
+        _ => ("404 Not Found".to_string(), r#"{"error":"Not found"}"#.to_string()),
+    };
+
+    let response = format!(
+        "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        status,
+        response_body.len(),
+        response_body
+    );
+    stream.write_all(response.as_bytes()).await.map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn parse_http_request(raw: &str) -> (String, String, String) {
+    let mut lines = raw.split("\r\n");
+    let first_line = lines.next().unwrap_or("");
+    let parts: Vec<&str> = first_line.split_whitespace().collect();
+    let method = parts.first().unwrap_or(&"GET").to_string();
+    let path = parts.get(1).unwrap_or(&"/").to_string();
+
+    // Find body after empty line
+    let body = if let Some(pos) = raw.find("\r\n\r\n") {
+        raw[pos + 4..].to_string()
+    } else {
+        String::new()
+    };
+
+    (method, path, body)
+}
+
+async fn handle_send_wecom(app: &AppHandle, body: &str) -> (String, String) {
+    let params: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => return ("400 Bad Request".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    };
+
+    let target = match params.get("target").and_then(|t| t.as_str()) {
+        Some(t) => t,
+        None => return ("400 Bad Request".into(), r#"{"error":"missing target"}"#.into()),
+    };
+    let message = match params.get("message").and_then(|m| m.as_str()) {
+        Some(m) => m,
+        None => return ("400 Bad Request".into(), r#"{"error":"missing message"}"#.into()),
+    };
+
+    // Parse target format
+    let (chatid, chat_type) = if target.starts_with("single:") {
+        (target.strip_prefix("single:").unwrap_or(target), 1u32)
+    } else if target.starts_with("group:") {
+        (target.strip_prefix("group:").unwrap_or(target), 2u32)
+    } else {
+        (target, 1u32)
+    };
+
+    match super::gateway::wecom::send_proactive_message(chatid, chat_type, message).await {
+        Ok(()) => ("200 OK".into(), r#"{"success":true}"#.into()),
+        Err(e) => ("500 Internal Server Error".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    }
+}
+
+async fn handle_cron_run(app: &AppHandle, body: &str) -> (String, String) {
+    let params: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => return ("400 Bad Request".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    };
+
+    let job_id = match params.get("job_id").and_then(|j| j.as_str()) {
+        Some(id) => id.to_string(),
+        None => return ("400 Bad Request".into(), r#"{"error":"missing job_id"}"#.into()),
+    };
+
+    let cron_state = app.state::<super::cron::CronState>();
+    match cron_state.scheduler.run_job_now(&job_id).await {
+        Ok(()) => ("200 OK".into(), r#"{"success":true}"#.into()),
+        Err(e) => ("500 Internal Server Error".into(), format!(r#"{{"error":"{}"}}"#, e)),
+    }
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+In `src-tauri/src/commands/mod.rs`, add:
+
+```rust
+pub mod introspect_api;
+```
+
+- [ ] **Step 3: Start the API server in lib.rs setup**
+
+In the `setup` closure of `src-tauri/src/lib.rs`, add alongside the existing RAG HTTP server spawn:
+
+```rust
+// Start introspect internal API server
+{
+    let app_handle = app.handle().clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = commands::introspect_api::start_introspect_api(app_handle).await {
+            eprintln!("[IntrospectAPI] Failed to start: {}", e);
+        }
+    });
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+```bash
+cd src-tauri && cargo check
+```
+
+Note: The `cron_state.scheduler.run_job_now()` method may not exist yet. Check `scheduler.rs` for the exact method name — it may be exposed via the existing `cron_run_job` Tauri command pattern. Adjust the call accordingly. If needed, add a `pub async fn run_job_now(&self, job_id: &str)` wrapper to the scheduler.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/commands/introspect_api.rs src-tauri/src/commands/mod.rs src-tauri/src/lib.rs
+git commit -m "feat(introspect): add internal HTTP API for WeCom send and cron run"
+```
+
+---
+
+## Task 10: Auto-registration in opencode.json
+
+**Files:**
+- Modify: `src-tauri/src/commands/opencode.rs` — Add to `ensure_inherent_config()`
+- Modify: `src-tauri/tauri.conf.json` — Add to `externalBin`
+
+- [ ] **Step 1: Register introspect MCP in ensure_inherent_config**
+
+In `src-tauri/src/commands/opencode.rs`, inside the `ensure_inherent_config()` function, after the existing `autoui` block (around line 905), add:
+
+```rust
+if !mcp_obj.contains_key("teamclaw-introspect") {
+    // Resolve the sidecar binary path
+    let introspect_bin = app_resource_path("teamclaw-introspect");
+    mcp_obj.insert(
+        "teamclaw-introspect".to_string(),
+        serde_json::json!({
+            "type": "local",
+            "enabled": true,
+            "command": [
+                introspect_bin,
+                "--workspace",
+                workspace_path,
+                "--api-port",
+                format!("{}", super::introspect_api::INTROSPECT_API_PORT)
+            ]
+        }),
+    );
+    changed = true;
+    println!("[Config] Added inherent 'teamclaw-introspect' MCP config");
+}
+```
+
+Note: The function currently takes only `workspace_path`. The binary path resolution needs to use the same mechanism as the OpenCode sidecar. Check `start_opencode_inner()` for how `app.shell().sidecar("opencode")` resolves the binary path. For `ensure_inherent_config`, since we don't have the `AppHandle`, we need to resolve the binary path differently — likely by computing it relative to the executable's directory using `std::env::current_exe()`.
+
+Alternative: Instead of embedding the full path, use a relative path or pass the workspace path to OpenCode's config so OpenCode can spawn it:
+
+```rust
+mcp_obj.insert(
+    "teamclaw-introspect".to_string(),
+    serde_json::json!({
+        "type": "local",
+        "enabled": true,
+        "command": [
+            "./binaries/teamclaw-introspect",
+            "--workspace", workspace_path,
+            "--api-port", "13144"
+        ]
+    }),
+);
+```
+
+The exact binary path format depends on how OpenCode resolves MCP server commands. Test this step manually.
+
+- [ ] **Step 2: Add to externalBin in tauri.conf.json**
+
+In `src-tauri/tauri.conf.json`, update the `externalBin` array:
+
+```json
+"externalBin": [
+    "binaries/opencode",
+    "binaries/teamclaw-introspect"
+]
+```
+
+- [ ] **Step 3: Build the binary and place in binaries/**
+
+```bash
+cd src-tauri && cargo build --release -p teamclaw-introspect
+cp target/release/teamclaw-introspect binaries/teamclaw-introspect-$(rustc -vV | sed -n 's|host: ||p')
+```
+
+This creates `binaries/teamclaw-introspect-aarch64-apple-darwin` (or equivalent for the platform).
+
+- [ ] **Step 4: Verify registration works**
+
+Start the app with `pnpm tauri:dev`, then check `opencode.json` in the workspace directory:
+
+```bash
+cat <workspace>/opencode.json | jq '.mcp["teamclaw-introspect"]'
+```
+
+Expected: should show the MCP server configuration with the correct binary path and workspace argument.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/commands/opencode.rs src-tauri/tauri.conf.json
+git commit -m "feat(introspect): auto-register MCP server in opencode.json"
+```
+
+---
+
+## Task 11: Integration testing
+
+- [ ] **Step 1: Manual smoke test — get_my_capabilities**
+
+Start the app with `pnpm tauri:dev`. In a chat session, type:
+
+> "我有哪些已绑定的 channel？"
+
+The AI should call `get_my_capabilities` and return the configured channels.
+
+- [ ] **Step 2: Manual smoke test — send_channel_message**
+
+If you have a channel configured (e.g., Discord), test:
+
+> "帮我通过 Discord 发一条消息给 channel:123456，内容是'测试消息'"
+
+- [ ] **Step 3: Manual smoke test — manage_cron_job**
+
+> "帮我看看有多少定时任务"
+
+Then:
+
+> "帮我新建一个每天早上9点的日报任务"
+
+- [ ] **Step 4: Manual smoke test — manage_shortcuts**
+
+> "帮我创建一个叫'日报'的快捷操作，内容是'请帮我生成今日工作日报'"
+
+- [ ] **Step 5: Verify end-to-end broadcast scenario**
+
+> "给我所有 channel 发一条消息：系统维护通知"
+
+Verify it sends to all bound channels and returns per-channel results.
+
+- [ ] **Step 6: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(introspect): fixes from integration testing"
+```
+
+---
+
+## Known Limitations (v1)
+
+1. **Email sending** not supported from MCP binary (requires SMTP/OAuth2 complexity). Workaround: use cron delivery for email.
+2. **WeCom sending** requires the Tauri internal HTTP API — if TeamClaw app is not running, WeCom messages will fail.
+3. **Cron manual run** requires the internal HTTP API for the same reason.
+4. **Current role** cannot be determined (selection state is in frontend memory). Only `available_roles` is returned.
+5. **Cron next_run_at** is not recomputed by the MCP binary after create — the running scheduler will pick up the new job but `next_run_at` will be null until the scheduler recomputes it.

--- a/docs/superpowers/specs/2026-04-13-introspect-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-04-13-introspect-mcp-server-design.md
@@ -1,0 +1,637 @@
+# Introspect MCP Server — AI 能力自省与执行
+
+**Date:** 2026-04-13
+**Status:** Draft
+
+## Problem
+
+TeamClaw 有大量用户可配置的能力（消息频道、角色、快捷键、定时任务等），但 AI agent 在对话时完全不知道这些配置的存在。当用户说"帮我通过企微发条消息"，AI 无法知道 WeCom channel 是否已绑定、团队有哪些成员、环境里配置了什么。
+
+更关键的是，即使 AI 知道了有哪些能力，也无法执行关键操作——比如通过已绑定的 channel 发送消息。底层发送函数（`DeliveryManager`）已经完整实现了所有 channel 的发送逻辑，但只被 cron 系统内部使用，没有暴露给 AI agent。
+
+## Solution
+
+实现一个内置 MCP server（`teamclaw-introspect`），提供四个工具：
+1. **`get_my_capabilities`** — 发现：查询用户已配置的能力和设置信息
+2. **`send_channel_message`** — 执行：通过已绑定的 channel 发送消息
+3. **`manage_cron_job`** — 管理：创建、暂停、恢复、删除定时任务
+4. **`manage_shortcuts`** — 管理：创建、修改、删除快捷操作
+
+**核心选型决策：**
+
+| 决策 | 选择 | 原因 |
+|------|------|------|
+| 注入方式 | 按需查询（非自动注入 system prompt） | 不浪费 token，只在需要时查询 |
+| 实现机制 | MCP tool（非前端拦截） | 架构干净，符合 MCP 规范，AI 天然发现 |
+| 工具粒度 | 单工具 + 可选 category 参数 | 兼顾全局概览和精准查询 |
+| 实现语言 | Rust（嵌入 Tauri） | 数据在文件系统，Rust 直接读取，无需跨进程 |
+| 注册方式 | 启动时自动注册 | 对用户透明，无需手动配置 |
+
+## Design
+
+### 1. MCP Tool Definition
+
+```json
+{
+  "name": "get_my_capabilities",
+  "description": "查询当前用户在 TeamClaw 中配置的能力和设置。当用户提到发消息、查团队、用快捷键、看定时任务等操作时，先调用此工具了解可用能力。不传 category 返回所有类别的概览摘要。",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "category": {
+        "type": "string",
+        "enum": ["channels", "role", "shortcuts", "team_members", "env_vars", "team_info", "cron_jobs"],
+        "description": "可选，按类别过滤。不传则返回全部概览。"
+      }
+    }
+  }
+}
+```
+
+### 2. MCP Tool Definition — `send_channel_message`
+
+```json
+{
+  "name": "send_channel_message",
+  "description": "通过已绑定的消息频道发送消息。支持指定单个 channel 或广播到所有已绑定 channel。发送前请先调用 get_my_capabilities 确认 channel 绑定状态。",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "channel": {
+        "type": "string",
+        "enum": ["wecom", "discord", "email", "feishu", "kook", "wechat", "all"],
+        "description": "目标频道。传 'all' 广播到所有已绑定的频道。"
+      },
+      "message": {
+        "type": "string",
+        "description": "要发送的消息内容（纯文本）。"
+      },
+      "target": {
+        "type": "string",
+        "description": "接收者标识。格式因 channel 而异：WeCom 'single:{userid}' 或 'group:{chatid}'；Discord 'dm:{user_id}' 或 'channel:{channel_id}'；Email 邮箱地址；Feishu chat_id；KOOK 'dm:{user_id}' 或 'channel:{channel_id}'；WeChat user_id。channel='all' 时为可选，不传则使用各 channel 的默认目标。"
+      }
+    },
+    "required": ["channel", "message"]
+  }
+}
+```
+
+#### 执行逻辑
+
+**单 channel 发送 (`channel` != `"all"`):**
+1. 从 `teamclaw.json` 读取该 channel 配置
+2. 校验 channel 已绑定（必填字段存在）
+3. 调用 `DeliveryManager::send_notification()` 发送
+4. 返回发送结果（成功/失败及错误信息）
+
+**广播发送 (`channel` = `"all"`):**
+1. 从 `teamclaw.json` 读取所有 channel 配置
+2. 过滤出已绑定的 channel
+3. 逐个调用 `DeliveryManager::send_notification()`
+4. 返回每个 channel 的发送结果
+
+```json
+// 广播返回示例
+{
+  "results": {
+    "wecom": { "success": true },
+    "email": { "success": true, "message_id": "abc123@gmail.com" },
+    "discord": { "success": false, "error": "Bot token expired" }
+  },
+  "summary": "2/3 channels sent successfully"
+}
+```
+
+#### Target 解析规则
+
+| Channel | Target 格式 | 默认值（不传时） |
+|---------|------------|----------------|
+| wecom | `single:{userid}` / `group:{chatid}` / `{userid}` | 无默认，必须指定 |
+| discord | `dm:{user_id}` / `channel:{channel_id}` | 无默认，必须指定 |
+| email | 邮箱地址 | 无默认，必须指定 |
+| feishu | chat_id | 无默认，必须指定 |
+| kook | `dm:{user_id}` / `channel:{channel_id}` | 无默认，必须指定 |
+| wechat | user_id | 无默认，必须指定 |
+
+**注意:** `channel="all"` 时 `target` 为可选。如果不传 target，各 channel 使用 `teamclaw.json` 中配置的默认接收者（如有）。如果某个 channel 无默认接收者且未传 target，则跳过该 channel 并在结果中标注。
+
+#### 复用 DeliveryManager
+
+`send_channel_message` 底层直接复用已有的 `DeliveryManager`（`src-tauri/src/commands/cron/delivery.rs`）：
+
+- `DeliveryManager` 已封装所有 6 个 channel 的发送逻辑
+- 每次发送时重新读取 `teamclaw.json` 配置（自动感知配置变更）
+- 内置消息分片（Discord 2000 字符、WeCom/Feishu 4000 字符、KOOK 8000 字符）
+- 内置 UTF-8 安全的分割逻辑
+
+MCP server 只需创建 `DeliveryManager` 实例并调用 `send_notification()`，不需要重新实现任何发送逻辑。
+
+#### 用户场景示例
+
+**场景 1:** "帮我给企微发条消息，告诉张三明天开会"
+```
+AI → get_my_capabilities(category="channels")  → 发现 wecom 已绑定
+AI → get_my_capabilities(category="team_members") → 找到张三的 userid
+AI → send_channel_message(channel="wecom", target="single:zhangsan", message="明天开会，请准时参加")
+```
+
+**场景 2:** "给我所有 channel 发一条消息：系统维护通知"
+```
+AI → get_my_capabilities(category="channels") → 发现 wecom + email 已绑定
+AI → send_channel_message(channel="all", message="系统维护通知：今晚 22:00-23:00 进行系统升级")
+→ 返回: wecom ✅, email ✅ (其他未绑定跳过)
+```
+
+### 3. MCP Tool Definition — `manage_cron_job`
+
+```json
+{
+  "name": "manage_cron_job",
+  "description": "管理定时任务：创建、暂停、恢复、删除、手动执行、查看运行历史。先用 get_my_capabilities(category='cron_jobs') 了解已有任务。",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "action": {
+        "type": "string",
+        "enum": ["create", "pause", "resume", "delete", "run", "get_runs"],
+        "description": "操作类型"
+      },
+      "job_id": {
+        "type": "string",
+        "description": "目标任务 ID。create 时不需要，其他操作必须提供。"
+      },
+      "name": {
+        "type": "string",
+        "description": "任务名称。create 时必须提供。"
+      },
+      "description": {
+        "type": "string",
+        "description": "任务描述。create 时可选。"
+      },
+      "schedule": {
+        "type": "object",
+        "description": "调度配置。create 时必须提供。",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["at", "every", "cron"],
+            "description": "调度类型：at=一次性定时、every=固定间隔、cron=cron 表达式"
+          },
+          "at": {
+            "type": "string",
+            "description": "kind=at 时，ISO 8601 时间戳"
+          },
+          "every_ms": {
+            "type": "number",
+            "description": "kind=every 时，间隔毫秒数"
+          },
+          "expr": {
+            "type": "string",
+            "description": "kind=cron 时，5 段 cron 表达式（如 '0 9 * * *'）"
+          },
+          "tz": {
+            "type": "string",
+            "description": "可选 IANA 时区（如 'Asia/Shanghai'），默认系统本地时区"
+          }
+        }
+      },
+      "message": {
+        "type": "string",
+        "description": "任务执行时发送给 AI 的 prompt。create 时必须提供。"
+      },
+      "delivery": {
+        "type": "object",
+        "description": "可选，任务结果推送配置。",
+        "properties": {
+          "channel": {
+            "type": "string",
+            "enum": ["discord", "feishu", "email", "kook", "wechat", "wecom"]
+          },
+          "to": {
+            "type": "string",
+            "description": "推送目标（同 send_channel_message 的 target 格式）"
+          }
+        }
+      }
+    },
+    "required": ["action"]
+  }
+}
+```
+
+#### 各 Action 行为
+
+| Action | 必须参数 | 底层调用 | 说明 |
+|--------|---------|---------|------|
+| `create` | name, schedule, message | `CronStorage::add_job()` | 创建任务，自动生成 ID，计算 next_run_at |
+| `pause` | job_id | `CronStorage::toggle_enabled(id, false)` | 暂停任务 |
+| `resume` | job_id | `CronStorage::toggle_enabled(id, true)` | 恢复任务，重新计算 next_run_at |
+| `delete` | job_id | `CronStorage::remove_job(id)` | 删除任务及运行历史 |
+| `run` | job_id | `CronScheduler::execute_job()` | 立即手动触发一次执行 |
+| `get_runs` | job_id | `CronStorage::get_runs(id, 10)` | 查看最近 10 条运行记录 |
+
+#### 返回示例
+
+**create 返回:**
+```json
+{
+  "success": true,
+  "job": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "每日站会提醒",
+    "enabled": true,
+    "schedule": "0 9 * * * (Asia/Shanghai)",
+    "next_run_at": "2026-04-14T01:00:00Z"
+  }
+}
+```
+
+**get_runs 返回:**
+```json
+{
+  "runs": [
+    {
+      "run_id": "run-1",
+      "status": "success",
+      "started_at": "2026-04-13T01:00:00Z",
+      "finished_at": "2026-04-13T01:02:30Z",
+      "summary": "已发送站会提醒到企业微信群"
+    }
+  ]
+}
+```
+
+#### 用户场景示例
+
+**场景:** "帮我看看有多少定时任务，把那个日报任务暂停掉，然后新建一个每周一早上9点的周报任务"
+```
+AI → get_my_capabilities(category="cron_jobs")
+     → 返回: 3个任务 (日报id=abc, 周会提醒id=def, 数据备份id=ghi)
+
+AI → manage_cron_job(action="pause", job_id="abc")
+     → 返回: 日报任务已暂停
+
+AI → manage_cron_job(action="create", name="周报", description="每周一生成周报",
+       schedule={kind:"cron", expr:"0 9 * * 1", tz:"Asia/Shanghai"},
+       message="请生成本周工作周报，总结本周完成的任务和下周计划",
+       delivery={channel:"wecom", to:"group:weekly-report"})
+     → 返回: 任务创建成功，下次执行 2026-04-14T01:00:00Z
+```
+
+### 4. MCP Tool Definition — `manage_shortcuts`
+
+```json
+{
+  "name": "manage_shortcuts",
+  "description": "管理用户的快捷操作：创建、修改、删除。快捷操作可以是原生命令、链接或文件夹。先用 get_my_capabilities(category='shortcuts') 了解已有快捷操作。",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "action": {
+        "type": "string",
+        "enum": ["create", "update", "delete"],
+        "description": "操作类型"
+      },
+      "id": {
+        "type": "string",
+        "description": "快捷操作 ID。update/delete 时必须提供。"
+      },
+      "label": {
+        "type": "string",
+        "description": "显示名称。create 时必须提供。"
+      },
+      "type": {
+        "type": "string",
+        "enum": ["native", "link", "folder"],
+        "description": "类型：native=内置命令、link=外部链接、folder=文件夹。create 时必须提供。"
+      },
+      "target": {
+        "type": "string",
+        "description": "目标：native 时为命令内容，link 时为 URL。create 时必须提供（folder 可为空）。"
+      },
+      "icon": {
+        "type": "string",
+        "description": "可选，图标标识。"
+      },
+      "parent_id": {
+        "type": "string",
+        "description": "可选，父文件夹 ID。不传则放在根级别。"
+      }
+    },
+    "required": ["action"]
+  }
+}
+```
+
+#### 各 Action 行为
+
+| Action | 必须参数 | 说明 |
+|--------|---------|------|
+| `create` | label, type, target | 创建快捷操作，自动生成 ID 和 order |
+| `update` | id + 要修改的字段 | 修改已有快捷操作的任意字段 |
+| `delete` | id | 删除快捷操作（如为 folder 则同时删除子项） |
+
+#### 返回示例
+
+```json
+{
+  "success": true,
+  "shortcut": {
+    "id": "shortcut-1713000000-abc1234",
+    "label": "日报",
+    "type": "native",
+    "target": "请帮我生成今日工作日报"
+  }
+}
+```
+
+### 5. Category 定义与数据源
+
+#### `channels` — 已绑定的消息频道
+
+**数据源:** `{workspace}/.opencode/teamclaw.json` → `channels` 字段
+
+**返回内容:**
+```json
+{
+  "channels": {
+    "wecom": { "bound": true, "corp_name": "XX公司", "agent_name": "TeamClaw" },
+    "discord": { "bound": false },
+    "email": { "bound": true, "address": "user@example.com", "provider": "gmail" },
+    "feishu": { "bound": false },
+    "kook": { "bound": false },
+    "wechat": { "bound": false }
+  }
+}
+```
+
+**规则:**
+- `bound` 通过检查关键必填字段是否存在来判断（如 WeCom 需要 `corp_id` + `agent_id` + `secret`）
+- 返回帮助 AI 理解频道用途的摘要字段（如 corp_name），不返回 token/secret
+
+#### `role` — 当前角色
+
+**数据源:** `{workspace}/.opencode/roles/*/ROLE.md` + 前端选中状态
+
+**返回内容:**
+```json
+{
+  "current_role": {
+    "slug": "product-assistant",
+    "name": "产品助理",
+    "description": "协助产品需求分析和文档撰写",
+    "working_style": "结构化输出，先分析再建议",
+    "skills": ["需求分析", "PRD撰写"]
+  },
+  "available_roles": [
+    { "slug": "dev-assistant", "name": "开发助手" },
+    { "slug": "product-assistant", "name": "产品助理" }
+  ]
+}
+```
+
+**注意:** 当前选中的 role 信息需要从 OpenCode sidecar 或配置文件中获取。如果选中状态仅在前端内存中，则只返回 `available_roles` 列表，不返回 `current_role`。
+
+#### `shortcuts` — 用户自定义快捷操作
+
+**数据源:** `{workspace}/.opencode/teamclaw.json` → `shortcuts` 字段
+
+**返回内容:**
+```json
+{
+  "shortcuts": [
+    { "id": "shortcut-1713000000-abc", "label": "日报", "type": "native", "target": "请帮我生成今日工作日报" },
+    { "id": "shortcut-1713000001-def", "label": "周报", "type": "native", "target": "汇总本周工作" }
+  ]
+}
+```
+
+#### `team_members` — 团队成员
+
+**数据源:** `{workspace}/opencode-team/_team/members.json`
+
+**返回内容:**
+```json
+{
+  "members": [
+    { "name": "张三", "role": "editor", "label": "后端开发" },
+    { "name": "李四", "role": "viewer", "label": "产品经理" }
+  ]
+}
+```
+
+**规则:** 只返回 name、role、label。不返回 node_id、platform、arch 等技术字段。
+
+#### `env_vars` — 环境变量
+
+**数据源:** `{workspace}/.opencode/teamclaw.json` → `envVars` 字段（元数据索引）
+
+**返回内容:**
+```json
+{
+  "env_vars": [
+    { "key": "OPENAI_API_KEY", "description": "OpenAI API密钥", "category": "system" },
+    { "key": "CUSTOM_TOKEN", "description": "自定义服务Token", "category": null }
+  ]
+}
+```
+
+**安全规则:** 只返回 key 名和 description，**绝不返回 value**。从 `teamclaw.json` 的元数据索引读取，不访问 keychain。
+
+#### `team_info` — 团队信息
+
+**数据源:** `{workspace}/.opencode/teamclaw.json` → `team` 字段
+
+**返回内容:**
+```json
+{
+  "team": {
+    "enabled": true,
+    "sync_mode": "oss",
+    "git_url": "https://github.com/org/team-repo",
+    "last_sync_at": "2026-04-13T10:30:00Z"
+  }
+}
+```
+
+**规则:** 不返回 `git_token`。
+
+#### `cron_jobs` — 定时任务
+
+**数据源:** `{workspace}/.opencode/cron-jobs.json`
+
+**返回内容:**
+```json
+{
+  "cron_jobs": [
+    {
+      "id": "uuid-1",
+      "name": "每日站会提醒",
+      "description": "每天早上9点发送站会提醒",
+      "enabled": true,
+      "schedule": "0 9 * * *",
+      "last_run_at": "2026-04-13T01:00:00Z",
+      "next_run_at": "2026-04-14T01:00:00Z"
+    }
+  ]
+}
+```
+
+**规则:** 返回任务摘要信息，不返回完整的 payload 和 delivery 配置。
+
+### 5. 无 category 时的概览响应
+
+不传 `category` 参数时，返回精简的全局概览：
+
+```json
+{
+  "overview": {
+    "channels": { "bound": ["wecom", "email"], "unbound": ["discord", "feishu", "kook", "wechat"] },
+    "role": { "current": "产品助理", "available_count": 3 },
+    "shortcuts": { "count": 5, "names": ["日报", "周报", "代码审查", "..."] },
+    "team_members": { "count": 4, "names": ["张三", "李四", "..."] },
+    "env_vars": { "count": 3, "keys": ["OPENAI_API_KEY", "CUSTOM_TOKEN", "..."] },
+    "team_info": { "enabled": true, "sync_mode": "oss" },
+    "cron_jobs": { "count": 2, "enabled_count": 1 }
+  }
+}
+```
+
+概览用于 AI 快速了解全局情况，再通过 category 参数查询详细信息。
+
+### 6. MCP Server 架构
+
+#### 进程模型
+
+内置 MCP server 作为一个 stdio MCP server 实现，由 Tauri 应用启动时 spawn 为子进程。
+
+```
+TeamClaw App 启动
+  ↓
+Tauri setup hook → spawn teamclaw-introspect 子进程 (stdio MCP)
+  ↓
+自动写入 opencode.json 的 mcpServers 配置
+  ↓
+OpenCode sidecar 读取配置 → 连接 MCP server
+  ↓
+AI 对话时在工具列表中看到 get_my_capabilities + send_channel_message
+```
+
+#### 实现方式
+
+在 `src-tauri/` 中新建一个 Rust binary target `teamclaw-introspect`：
+
+```
+src-tauri/
+  src/
+    bin/
+      teamclaw-introspect.rs   ← MCP server binary entry
+  src/
+    introspect/
+      mod.rs                   ← MCP server 逻辑 + tools/list + tools/call 路由
+      capabilities.rs          ← get_my_capabilities 实现（7 个 category 读取）
+      send.rs                  ← send_channel_message 实现（复用 DeliveryManager）
+      cron.rs                  ← manage_cron_job 实现（复用 CronStorage + CronScheduler）
+      shortcuts.rs             ← manage_shortcuts 实现（读写 teamclaw.json）
+```
+
+#### MCP 协议实现
+
+使用 `rmcp` crate（Rust MCP SDK）实现 stdio 传输的 MCP server：
+
+- 监听 stdin，响应写入 stdout
+- 实现 `tools/list` → 返回 4 个工具定义
+- 实现 `tools/call` → 按工具名路由到对应处理逻辑
+- workspace 路径通过命令行参数传入
+
+#### 自动注册
+
+Tauri 启动时：
+
+1. 将 `teamclaw-introspect` binary 打包为 sidecar（与 OpenCode sidecar 类似）
+2. 在 `opencode.json` 的 `mcpServers` 中注入配置：
+   ```json
+   {
+     "mcpServers": {
+       "teamclaw-introspect": {
+         "command": "{path_to_binary}",
+         "args": ["--workspace", "{workspace_path}"],
+         "type": "local"
+       }
+     }
+   }
+   ```
+3. OpenCode sidecar 启动后自动发现并连接
+
+### 7. Shortcuts 持久化迁移
+
+个人 shortcuts 当前存在 localStorage，需要迁移到文件系统，使其与团队 shortcuts 一致，MCP server 也能直接读写。
+
+**迁移方案:**
+
+1. **新增 Tauri commands:**
+   - `save_shortcuts(nodes: ShortcutNode[])` — 写入 `teamclaw.json` → `shortcuts` 字段
+   - `load_shortcuts() → ShortcutNode[]` — 从 `teamclaw.json` 读取
+
+2. **前端 store 改造:**
+   - `shortcuts.ts` 的 `loadPersistedNodes()` 改为调用 `invoke('load_shortcuts')`
+   - `persistNodes()` 改为调用 `invoke('save_shortcuts', { nodes })`
+   - 移除 localStorage 的读写逻辑
+
+3. **一次性迁移:** 首次启动时，如果 `teamclaw.json` 中无 `shortcuts` 字段但 localStorage 有数据，则读取 localStorage 写入 `teamclaw.json`，完成迁移后清除 localStorage 中的旧数据。
+
+4. **Source of truth:** 迁移后 `teamclaw.json` → `shortcuts` 为唯一数据源，前端和 MCP server 都从这里读写，不存在同步问题。
+
+### 8. 安全规则汇总
+
+| 数据 | 返回 | 不返回 |
+|------|------|--------|
+| channels | bound 状态、名称、基本描述 | token、secret、webhook URL |
+| role | 名称、描述、工作风格、技能列表 | 完整 markdown body |
+| shortcuts | 名称、描述、触发词 | — |
+| team_members | 名称、角色、标签 | node_id、platform、arch、hostname |
+| env_vars | key 名、description、category | **value（绝不返回）** |
+| team_info | enabled、sync_mode、git_url | git_token |
+| cron_jobs | 名称、描述、schedule、enabled、时间 | payload、delivery 详细配置 |
+
+### 9. 错误处理
+
+**get_my_capabilities:**
+- 配置文件不存在 → 返回该 category 为空/默认值，不报错
+- JSON 解析失败 → 返回错误信息，标记该 category 为 `"error"`
+- 无效 category 参数 → 返回错误提示，列出可用的 category 值
+
+**send_channel_message:**
+- channel 未绑定 → 返回错误：`"WeCom channel is not bound. Please configure it in Settings → Channels."`
+- target 未提供且无默认值 → 返回错误：`"Target is required for {channel}. Format: {expected_format}"`
+- 发送失败（网络/认证） → 返回底层错误信息，AI 可告知用户具体原因
+- `channel="all"` 部分失败 → 不中断，返回每个 channel 的独立结果
+
+**manage_cron_job:**
+- job_id 不存在 → 返回错误：`"Job not found: {job_id}"`
+- create 缺少必填字段 → 返回错误，列出缺失字段
+- 无效 cron 表达式 → 返回解析错误信息
+- run 触发失败 → 返回执行错误，不影响任务本身状态
+
+**manage_shortcuts:**
+- id 不存在 → 返回错误：`"Shortcut not found: {id}"`
+- create 缺少必填字段 → 返回错误，列出缺失字段
+- delete folder → 同时删除所有子项，返回删除数量
+
+## Scope
+
+### In Scope
+- `teamclaw-introspect` Rust binary（MCP server）
+- `get_my_capabilities` 工具实现（7 个 category）
+- `send_channel_message` 工具实现（复用 DeliveryManager，支持单发和广播）
+- `manage_cron_job` 工具实现（复用 CronStorage + CronScheduler，6 种操作）
+- `manage_shortcuts` 工具实现（CRUD 快捷操作）
+- 个人 shortcuts 从 localStorage 迁移到 `teamclaw.json`（含一次性数据迁移）
+- 自动注册到 `opencode.json` 的 mcpServers
+- Tauri 启动时 spawn MCP server 子进程
+
+### Out of Scope
+- 修改 AI 的 system prompt（保持现状）
+- 其他写入操作的 MCP 工具（如修改配置、管理 cron）
+- 前端 UI 变更（MCP server 对用户透明）
+- 发送富文本/附件（仅支持纯文本消息）

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1223,18 +1223,13 @@ function App() {
   const { showConsentDialog, setShowConsentDialog } = useTelemetryConsent(showSetupGuide);
   const devUnlocked = useTeamModeStore(s => s.devUnlocked)
 
-  if (spotlightMode) {
-    return (
-      <>
-        <SSEProvider />
-        <Suspense fallback={<div className="h-screen w-screen rounded-2xl overflow-hidden" />}>
-          <div className="h-screen w-screen rounded-2xl overflow-hidden">
-            <SpotlightWindow />
-          </div>
-        </Suspense>
-      </>
-    )
-  }
+  const spotlightContent = (
+    <Suspense fallback={<div className="h-screen w-screen rounded-2xl overflow-hidden" />}>
+      <div className="h-screen w-screen rounded-2xl overflow-hidden">
+        <SpotlightWindow />
+      </div>
+    </Suspense>
+  )
 
   const mainContent = (
     <>
@@ -1277,7 +1272,12 @@ function App() {
   return isTauri() ? (
     <div className="h-screen w-screen rounded-2xl overflow-hidden bg-background">
       <SSEProvider />
-      {mainContent}
+      <div style={{ display: spotlightMode ? 'contents' : 'none' }}>
+        {spotlightContent}
+      </div>
+      <div style={{ display: spotlightMode ? 'none' : 'contents' }}>
+        {mainContent}
+      </div>
       {devUnlocked && (
         <div className="fixed bottom-2 right-2 z-50 text-[10px] font-mono font-bold text-orange-500 bg-orange-500/10 border border-orange-500/30 px-1.5 py-0.5 rounded pointer-events-none">
           DEV
@@ -1287,7 +1287,12 @@ function App() {
   ) : (
     <>
       <SSEProvider />
-      {mainContent}
+      <div style={{ display: spotlightMode ? 'contents' : 'none' }}>
+        {spotlightContent}
+      </div>
+      <div style={{ display: spotlightMode ? 'none' : 'contents' }}>
+        {mainContent}
+      </div>
     </>
   )
 }

--- a/packages/app/src/packages/ai/editable-with-file-chips.tsx
+++ b/packages/app/src/packages/ai/editable-with-file-chips.tsx
@@ -138,7 +138,8 @@ export const EditableWithFileChips = React.forwardRef<HTMLDivElement, EditableWi
         editableRef.current.innerHTML = html || ""
         
         // Restore cursor to end and focus when content was updated externally
-        {
+        // Guard: skip focus if element is hidden (e.g. inside display:none parent)
+        if (editableRef.current.offsetParent !== null) {
           editableRef.current.focus()
           const range = document.createRange()
           const sel = window.getSelection()


### PR DESCRIPTION
## Summary
- **Root cause**: `App.tsx` used conditional rendering (`if (spotlightMode) return ...`) which unmounted the entire main component tree when switching to Spotlight mode, causing Cron, OssRestore (×2), FileWatcher, P2P, and Gateway to fully re-initialize on every mode switch
- Changed to CSS `display:none/contents` toggling so both Spotlight and Main trees stay mounted — no more re-initialization
- Fixed focus-stealing bug where the hidden `ChatPanel`'s `EditableWithFileChips` called `.focus()` on external value changes (shared `draftInput` store), causing the visible input to lose focus on every keystroke

## Test plan
- [ ] Open app → minimize to tray → click tray to open Spotlight → verify no FileWatcher/Cron/OssRestore re-initialization logs
- [ ] Switch from Spotlight → Main → verify no re-initialization logs
- [ ] Type continuously in Spotlight prompt input → verify no focus loss
- [ ] Type continuously in Main prompt input → verify no focus loss
- [ ] Verify clipboard auto-paste still works in Spotlight mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)