### PR TITLE
feat: team LLM multi-model support & shared config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # TeamClaw
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![CI](https://github.com/diffrent-ai-studio/teamclaw/actions/workflows/ci.yml/badge.svg)](https://github.com/diffrent-ai-studio/teamclaw/actions)
-[![Contributors](https://img.shields.io/github/contributors/diffrent-ai-studio/teamclaw.svg)](https://github.com/diffrent-ai-studio/teamclaw/graphs/contributors)
+[![CI](https://github.com/different-ai-studio/teamclaw/actions/workflows/ci.yml/badge.svg)](https://github.com/different-ai-studio/teamclaw/actions)
+[![Contributors](https://img.shields.io/github/contributors/different-ai-studio/teamclaw.svg)](https://github.com/different-ai-studio/teamclaw/graphs/contributors)
 
 Local AI agents built on OpenCode — your AI Ally for every role
 
@@ -58,7 +58,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## Install
 
-Download the installer for your platform from [GitHub Releases](https://github.com/diffrent-ai-studio/teamclaw/releases) (`.dmg` for macOS, `.exe` for Windows).
+Download the installer for your platform from [GitHub Releases](https://github.com/different-ai-studio/teamclaw/releases) (`.dmg` for macOS, `.exe` for Windows).
 
 - **Windows**: See [Windows Install Guide](docs/windows-install-guide.md).
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,73 @@ TeamClaw supports multiple team collaboration modes:
    - Pull remote repository contents
    - Generate a whitelist `.gitignore` (only syncs shared directories)
 
+### Configuring the Team FC Endpoint
+
+TeamClaw uses a serverless backend (FC — Function Compute) to handle team registration, authentication, and AI budget management. The FC endpoint is configured at **build time** via `build.config.*.json`.
+
+**Configuration files:**
+
+| File | Purpose |
+|------|---------|
+| `build.config.example.json` | Template — copy this to get started |
+| `build.config.local.json` | Local development (git-ignored) |
+| `build.config.production.json` | Production builds |
+
+**Steps to configure:**
+
+1. Copy the example config:
+
+   ```bash
+   cp build.config.example.json build.config.local.json
+   ```
+
+2. Set the `s3.teamEndpoint` to your FC endpoint URL:
+
+   ```json
+   {
+     "s3": {
+       "teamEndpoint": "https://your-fc-endpoint.example.com",
+       "forcePathStyle": false
+     }
+   }
+   ```
+
+3. If your team provides a shared LLM proxy, also configure `team.llm`:
+
+   ```json
+   {
+     "team": {
+       "llm": {
+         "baseUrl": "https://your-llm-proxy.example.com/v1",
+         "model": "default",
+         "modelName": "default"
+       },
+       "lockLlmConfig": true
+     }
+   }
+   ```
+
+4. Enable team mode in `features`:
+
+   ```json
+   {
+     "features": {
+       "teamMode": true
+     }
+   }
+   ```
+
+5. Rebuild the app (`pnpm tauri:dev` or `pnpm tauri:build`) for changes to take effect.
+
+**Self-hosting the FC backend:**
+
+The FC source is in the `fc/` directory. It requires:
+- Node.js 20 runtime
+- Alibaba Cloud OSS (or S3-compatible storage) for team data
+- (Optional) LiteLLM proxy for shared AI budget management
+
+Environment variables needed: `ACCESS_KEY_ID`, `ACCESS_KEY_SECRET`, `ROLE_ARN`, `BUCKET`, `REGION`, `ENDPOINT`. See `fc/s.yaml` for the full list.
+
 ### Shared Content
 
 The team repository automatically syncs the following:

--- a/build.config.example.json
+++ b/build.config.example.json
@@ -3,7 +3,8 @@
     "llm": {
       "baseUrl": "",
       "model": "",
-      "modelName": ""
+      "modelName": "",
+      "models": []
     },
     "lockLlmConfig": false,
     "seedUrl": "http://localhost:9090"

--- a/build.config.local.json
+++ b/build.config.local.json
@@ -1,0 +1,38 @@
+{
+  "team": {
+    "llm": {
+      "baseUrl": "",
+      "model": "",
+      "modelName": "",
+      "models": []
+    },
+    "lockLlmConfig": false,
+    "seedUrl": "http://localhost:9090"
+  },
+  "app": {
+    "name": "TeamClaw",
+    "shortName": "teamclaw",
+    "uiVariant": "default"
+  },
+  "features": {
+    "advancedMode": true,
+    "teamMode": false,
+    "updater": true,
+    "channels": {
+      "discord": true,
+      "feishu": true,
+      "email": true,
+      "kook": true,
+      "wecom": true,
+      "wechat": true
+    }
+  },
+  "s3": {
+    "teamEndpoint": "",
+    "forcePathStyle": false
+  },
+  "defaults": {
+    "locale": "zh-CN",
+    "theme": "system"
+  }
+}

--- a/build.config.production.json
+++ b/build.config.production.json
@@ -1,0 +1,38 @@
+{
+  "team": {
+    "llm": {
+      "baseUrl": "",
+      "model": "",
+      "modelName": "",
+      "models": []
+    },
+    "lockLlmConfig": false,
+    "seedUrl": ""
+  },
+  "app": {
+    "name": "TeamClaw",
+    "shortName": "teamclaw",
+    "uiVariant": "default"
+  },
+  "features": {
+    "advancedMode": true,
+    "teamMode": true,
+    "updater": true,
+    "channels": {
+      "discord": true,
+      "feishu": true,
+      "email": true,
+      "kook": true,
+      "wecom": true,
+      "wechat": true
+    }
+  },
+  "s3": {
+    "teamEndpoint": "",
+    "forcePathStyle": false
+  },
+  "defaults": {
+    "locale": "zh-CN",
+    "theme": "system"
+  }
+}

--- a/packages/app/src/components/chat/ChatInputArea.tsx
+++ b/packages/app/src/components/chat/ChatInputArea.tsx
@@ -156,6 +156,8 @@ export function ChatInputArea({
   // Team mode
   const teamMode = useTeamModeStore(s => s.teamMode);
   const teamModelConfig = useTeamModeStore(s => s.teamModelConfig);
+  const teamModelOptions = useTeamModeStore(s => s.teamModelOptions);
+  const switchTeamModel = useTeamModeStore(s => s.switchTeamModel);
   const devUnlocked = useTeamModeStore(s => s.devUnlocked);
   const advancedMode = useUIStore((s) => s.advancedMode);
   const canShowPlanToggle = advancedMode && devUnlocked;
@@ -430,7 +432,43 @@ export function ChatInputArea({
                 </Button>
               )}
 
-              {(!teamMode || !teamModelConfig || devUnlocked) && (
+              {teamMode && teamModelConfig && !devUnlocked && teamModelOptions.length > 1 ? (
+                <ModelSelector
+                  open={modelSelectorOpen}
+                  onOpenChange={setModelSelectorOpen}
+                >
+                  <ModelSelectorTrigger asChild>
+                    <PromptInputButton>
+                      <ModelSelectorLogo provider="team" />
+                      {teamModelConfig.modelName}
+                    </PromptInputButton>
+                  </ModelSelectorTrigger>
+                  <ModelSelectorContent align="start">
+                    <ModelSelectorList>
+                      <ModelSelectorGroup heading="Team">
+                        {teamModelOptions.map((option) => (
+                          <ModelSelectorItem
+                            key={option.id}
+                            onSelect={() => {
+                              setModelSelectorOpen(false);
+                              const wsPath = useWorkspaceStore.getState().workspacePath;
+                              if (wsPath) switchTeamModel(option.id, wsPath);
+                            }}
+                          >
+                            <ModelSelectorLogo provider="team" />
+                            <ModelSelectorName>{option.name}</ModelSelectorName>
+                          </ModelSelectorItem>
+                        ))}
+                      </ModelSelectorGroup>
+                    </ModelSelectorList>
+                  </ModelSelectorContent>
+                </ModelSelector>
+              ) : teamMode && teamModelConfig && !devUnlocked ? (
+                <PromptInputButton>
+                  <ModelSelectorLogo provider="team" />
+                  {teamModelConfig.modelName}
+                </PromptInputButton>
+              ) : (
                 <ModelSelector
                   open={modelSelectorOpen}
                   onOpenChange={setModelSelectorOpen}

--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -403,7 +403,11 @@ export const LLMSection = React.memo(function LLMSection() {
     }
   }
 
+  const teamModelOptions = useTeamModeStore((s) => s.teamModelOptions)
+  const switchTeamModel = useTeamModeStore((s) => s.switchTeamModel)
+
   if (teamMode && teamModelConfig && !devUnlocked) {
+    const hasMultipleModels = teamModelOptions.length > 1
     return (
       <div className="space-y-6">
         <SectionHeader
@@ -417,13 +421,35 @@ export const LLMSection = React.memo(function LLMSection() {
             <div className="h-9 w-9 rounded-lg flex items-center justify-center bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400">
               <Shield className="h-4.5 w-4.5" />
             </div>
-            <div>
+            <div className="flex-1">
               <p className="text-sm font-medium">{t('settings.llm.managedByTeam', 'Managed by team')}</p>
-              <p className="text-xs text-muted-foreground">
-                {t('settings.llm.managedByTeamDesc', 'Model configuration is managed by team admin, no personal configuration needed.')}
-              </p>
+              {hasMultipleModels ? (
+                <div className="flex items-center gap-1.5 mt-2">
+                  {teamModelOptions.map((option) => {
+                    const isActive = teamModelConfig?.model === option.id
+                    return (
+                      <button
+                        key={option.id}
+                        onClick={() => workspacePath && switchTeamModel(option.id, workspacePath)}
+                        className={cn(
+                          'px-3 py-1.5 rounded-md text-xs font-medium transition-colors',
+                          isActive
+                            ? 'bg-violet-600 text-white'
+                            : 'bg-muted text-muted-foreground hover:bg-muted/80',
+                        )}
+                      >
+                        {option.name}
+                      </button>
+                    )
+                  })}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  {t('settings.llm.managedByTeamDesc', 'Model configuration is managed by team admin, no personal configuration needed.')}
+                </p>
+              )}
               {teamModelConfig && (
-                <p className="text-xs text-muted-foreground mt-1">
+                <p className="text-xs text-muted-foreground mt-1.5">
                   {teamModelConfig.modelName} · {teamModelConfig.baseUrl}
                 </p>
               )}

--- a/packages/app/src/components/settings/team/HostLlmConfig.tsx
+++ b/packages/app/src/components/settings/team/HostLlmConfig.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Plus, X } from 'lucide-react'
+
+export interface LlmModelEntry {
+  id: string
+  name: string
+}
+
+export interface HostLlmConfigProps {
+  enabled: boolean
+  onEnabledChange: (enabled: boolean) => void
+  baseUrl: string
+  onBaseUrlChange: (url: string) => void
+  models: LlmModelEntry[]
+  onModelsChange: (models: LlmModelEntry[]) => void
+  disabled?: boolean
+}
+
+export const HostLlmConfig = React.memo(function HostLlmConfig({
+  enabled,
+  onEnabledChange,
+  baseUrl,
+  onBaseUrlChange,
+  models,
+  onModelsChange,
+  disabled,
+}: HostLlmConfigProps) {
+  const { t } = useTranslation()
+
+  const addModel = () => {
+    onModelsChange([...models, { id: '', name: '' }])
+  }
+
+  const removeModel = (index: number) => {
+    onModelsChange(models.filter((_, i) => i !== index))
+  }
+
+  const updateModel = (index: number, field: 'id' | 'name', value: string) => {
+    const updated = models.map((m, i) => (i === index ? { ...m, [field]: value } : m))
+    onModelsChange(updated)
+  }
+
+  return (
+    <div className="rounded-lg border border-border/40 bg-muted/20 p-3 space-y-2">
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => onEnabledChange(e.target.checked)}
+          className="rounded border-border"
+          disabled={disabled}
+        />
+        <span className="text-xs font-medium text-muted-foreground">
+          {t('settings.team.hostLlm', 'Host LLM (team shared AI model)')}
+        </span>
+      </label>
+      {enabled && (
+        <div className="space-y-2 pt-1">
+          <div>
+            <label className="mb-1 block text-xs text-muted-foreground">LLM API {t('settings.team.llmBaseUrlLabel', 'Base URL')}</label>
+            <Input
+              value={baseUrl}
+              onChange={(e) => onBaseUrlChange(e.target.value)}
+              placeholder="https://your-llm-proxy.com/v1"
+              className="bg-background/50 font-mono text-xs"
+              disabled={disabled}
+            />
+          </div>
+
+          {/* Models list */}
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <label className="text-xs text-muted-foreground">{t('settings.team.llmModels', 'Models')}</label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 px-1.5 text-xs text-muted-foreground"
+                onClick={addModel}
+                disabled={disabled}
+              >
+                <Plus className="h-3 w-3 mr-0.5" />
+                {t('settings.team.addModel', 'Add')}
+              </Button>
+            </div>
+            {models.map((model, index) => (
+              <div key={index} className="flex items-center gap-1.5">
+                <Input
+                  value={model.id}
+                  onChange={(e) => updateModel(index, 'id', e.target.value)}
+                  placeholder="model-id"
+                  className="bg-background/50 font-mono text-xs flex-1"
+                  disabled={disabled}
+                />
+                <Input
+                  value={model.name}
+                  onChange={(e) => updateModel(index, 'name', e.target.value)}
+                  placeholder={t('settings.team.modelNamePlaceholder', 'Display name')}
+                  className="bg-background/50 text-xs flex-1"
+                  disabled={disabled}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
+                  onClick={() => removeModel(index)}
+                  disabled={disabled}
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              </div>
+            ))}
+          </div>
+
+          <p className="text-xs text-muted-foreground/60">
+            {t('settings.team.llmApiKeyHint', 'API key is read from env var')} <code className="rounded bg-muted px-1 py-0.5 font-mono">tc_api_key</code>{t('settings.team.llmApiKeyDefault', ', defaults to device ID')}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+})

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -26,6 +26,7 @@ import { cn, isTauri } from '@/lib/utils'
 import { ToggleSwitch } from '@/components/settings/shared'
 import { TeamMemberList } from '@/components/settings/TeamMemberList'
 import { DeviceIdDisplay } from '@/components/settings/DeviceIdDisplay'
+import { HostLlmConfig } from './HostLlmConfig'
 import { useTeamMembersStore } from '@/stores/team-members'
 import { buildConfig, TEAM_SYNCED_EVENT, TEAM_REPO_DIR } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
@@ -115,6 +116,8 @@ export function TeamGitConfig() {
   const defaultLlmUrl = buildConfig.team.llm.baseUrl || ''
   const [hostLlm, setHostLlm] = React.useState(!!defaultLlmUrl)
   const [llmUrl, setLlmUrl] = React.useState(defaultLlmUrl)
+  const defaultLlmModels = (buildConfig.team.llm.models ?? []).map((m) => ({ id: m.id, name: m.name }))
+  const [llmModels, setLlmModels] = React.useState(defaultLlmModels)
   const [llmSaving, setLlmSaving] = React.useState(false)
   const [llmLoaded, setLlmLoaded] = React.useState(false)
 
@@ -166,11 +169,16 @@ export function TeamGitConfig() {
   // Load current LLM config when connected
   React.useEffect(() => {
     if ((state === 'connected' || state === 'syncing') && !llmLoaded && isTauri()) {
-      tauriInvoke<{ active: boolean; llm?: { baseUrl: string } }>('get_team_status')
+      tauriInvoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status')
         .then((status) => {
           if (status.llm?.baseUrl) {
             setHostLlm(true)
             setLlmUrl(status.llm.baseUrl)
+            if (status.llm.models?.length) {
+              setLlmModels(status.llm.models)
+            } else if (status.llm.model) {
+              setLlmModels([{ id: status.llm.model, name: status.llm.modelName || status.llm.model }])
+            }
           }
         })
         .catch(() => {})
@@ -193,8 +201,9 @@ export function TeamGitConfig() {
     try {
       await tauriInvoke('update_team_llm_config', {
         llmBaseUrl: hostLlm ? (llmUrl || null) : null,
-        llmModel: null,
-        llmModelName: null,
+        llmModel: hostLlm ? (llmModels[0]?.id || null) : null,
+        llmModelName: hostLlm ? (llmModels[0]?.name || null) : null,
+        llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
       })
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : String(err))
@@ -218,8 +227,9 @@ export function TeamGitConfig() {
         gitToken: isHttpsUrl && gitToken.trim() ? gitToken.trim() : null,
         gitBranch: gitBranch.trim() || null,
         llmBaseUrl: hostLlm ? (llmUrl || null) : null,
-        llmModel: null,
-        llmModelName: null,
+        llmModel: hostLlm ? (llmModels[0]?.id || null) : null,
+        llmModelName: hostLlm ? (llmModels[0]?.name || null) : null,
+        llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
       })
 
       setConnectStep(t('settings.team.generatingGitignore', 'Generating .gitignore...'))
@@ -509,34 +519,15 @@ export function TeamGitConfig() {
             )}
 
             {/* LLM hosting */}
-            <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={hostLlm}
-                  onChange={(e) => setHostLlm(e.target.checked)}
-                  className="rounded border-border"
-                  disabled={state === 'connecting'}
-                />
-                <span className="text-xs font-medium text-muted-foreground">
-                  {t('settings.team.hostLlm', 'Host LLM (team shared AI model)')}
-                </span>
-              </label>
-              {hostLlm && (
-                <div className="space-y-2 pt-1">
-                  <Input
-                    value={llmUrl}
-                    onChange={(e) => setLlmUrl(e.target.value)}
-                    placeholder="https://your-llm-proxy.com/v1"
-                    className="h-9 text-sm font-mono"
-                    disabled={state === 'connecting'}
-                  />
-                  <p className="text-xs text-muted-foreground/60">
-                    {t('settings.team.llmApiKeyHint', 'API key is read from env var')} <code className="rounded bg-muted px-1 py-0.5 font-mono">tc_api_key</code>{t('settings.team.llmApiKeyDefault', ', defaults to device ID')}
-                  </p>
-                </div>
-              )}
-            </div>
+            <HostLlmConfig
+              enabled={hostLlm}
+              onEnabledChange={setHostLlm}
+              baseUrl={llmUrl}
+              onBaseUrlChange={setLlmUrl}
+              models={llmModels}
+              onModelsChange={setLlmModels}
+              disabled={state === 'connecting'}
+            />
 
             {/* Connection progress */}
             {state === 'connecting' && connectStep && (
@@ -650,32 +641,14 @@ export function TeamGitConfig() {
                   <p className="text-xs text-muted-foreground">{t('settings.team.serviceConfigDesc', 'LLM hosting settings for this team')}</p>
                 </div>
               </div>
-              <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={hostLlm}
-                    onChange={(e) => setHostLlm(e.target.checked)}
-                    className="rounded border-border"
-                  />
-                  <span className="text-xs font-medium text-muted-foreground">
-                    {t('settings.team.hostLlm', 'Host LLM (team shared AI model)')}
-                  </span>
-                </label>
-                {hostLlm && (
-                  <div className="space-y-2 pt-1">
-                    <Input
-                      value={llmUrl}
-                      onChange={(e) => setLlmUrl(e.target.value)}
-                      placeholder="https://your-llm-proxy.com/v1"
-                      className="h-9 text-sm font-mono"
-                    />
-                    <p className="text-xs text-muted-foreground/60">
-                      {t('settings.team.llmApiKeyHint', 'API key is read from env var')} <code className="rounded bg-muted px-1 py-0.5 font-mono">tc_api_key</code>{t('settings.team.llmApiKeyDefault', ', defaults to device ID')}
-                    </p>
-                  </div>
-                )}
-              </div>
+              <HostLlmConfig
+                enabled={hostLlm}
+                onEnabledChange={setHostLlm}
+                baseUrl={llmUrl}
+                onBaseUrlChange={setLlmUrl}
+                models={llmModels}
+                onModelsChange={setLlmModels}
+              />
               <Button
                 size="sm"
                 className="gap-1.5"

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -6,6 +6,7 @@ import { useWorkspaceStore } from '@/stores/workspace'
 import { useTeamMembersStore } from '@/stores/team-members'
 import { DeviceIdDisplay } from '@/components/settings/DeviceIdDisplay'
 import { ApplicationDialog } from './ApplicationDialog'
+import { HostLlmConfig } from './HostLlmConfig'
 import { TeamMemberList } from '@/components/settings/TeamMemberList'
 import { VersionHistorySection } from './VersionHistorySection'
 import { invoke } from '@tauri-apps/api/core'
@@ -99,6 +100,8 @@ export function TeamOSSConfig() {
   const [createFcEndpoint, setCreateFcEndpoint] = useState(defaultFcEndpoint)
   const [createHostLlm, setCreateHostLlm] = useState(!!defaultLlmUrl)
   const [createLlmUrl, setCreateLlmUrl] = useState(defaultLlmUrl)
+  const defaultLlmModels = (buildConfig.team.llm.models ?? []).map((m) => ({ id: m.id, name: m.name }))
+  const [createLlmModels, setCreateLlmModels] = useState(defaultLlmModels)
 
   // Join team form
   const [joinTeamId, setJoinTeamId] = useState('')
@@ -109,6 +112,8 @@ export function TeamOSSConfig() {
   const [cfgFcEndpoint, setCfgFcEndpoint] = useState('')
   const [cfgHostLlm, setCfgHostLlm] = useState(false)
   const [cfgLlmUrl, setCfgLlmUrl] = useState('')
+  const [cfgLlmModels, setCfgLlmModels] = useState<Array<{ id: string; name: string }>>([])
+
   const [cfgSaving, setCfgSaving] = useState(false)
   const [cfgLoaded, setCfgLoaded] = useState(false)
 
@@ -142,11 +147,16 @@ export function TeamOSSConfig() {
             if (config) setCfgFcEndpoint(config.teamEndpoint || '')
           })
           .catch(() => {})
-        invoke<{ active: boolean; llm?: { baseUrl: string } }>('get_team_status')
+        invoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status')
           .then((status) => {
             if (status.llm?.baseUrl) {
               setCfgHostLlm(true)
               setCfgLlmUrl(status.llm.baseUrl)
+              if (status.llm.models?.length) {
+                setCfgLlmModels(status.llm.models)
+              } else if (status.llm.model) {
+                setCfgLlmModels([{ id: status.llm.model, name: status.llm.modelName || status.llm.model }])
+              }
             }
           })
           .catch(() => {})
@@ -172,6 +182,9 @@ export function TeamOSSConfig() {
         ownerEmail,
         fcEndpoint: createFcEndpoint,
         llmBaseUrl: createHostLlm ? createLlmUrl : undefined,
+        llmModel: createHostLlm ? (createLlmModels[0]?.id || undefined) : undefined,
+        llmModelName: createHostLlm ? (createLlmModels[0]?.name || undefined) : undefined,
+        llmModels: createHostLlm && createLlmModels.length > 0 ? JSON.stringify(createLlmModels) : undefined,
       })
       setTeamName('')
       setOwnerName('')
@@ -179,6 +192,7 @@ export function TeamOSSConfig() {
       setCreateFcEndpoint('')
       setCreateHostLlm(false)
       setCreateLlmUrl('')
+      setCreateLlmModels([])
       // Load team config and apply LLM provider
       const store = useTeamModeStore.getState()
       await store.loadTeamConfig(workspacePath)
@@ -191,7 +205,7 @@ export function TeamOSSConfig() {
     } finally {
       setCreating(false)
     }
-  }, [workspacePath, teamName, ownerName, ownerEmail, createFcEndpoint, createHostLlm, createLlmUrl, createTeam])
+  }, [workspacePath, teamName, ownerName, ownerEmail, createFcEndpoint, createHostLlm, createLlmUrl, createLlmModels, createTeam])
 
   const handleJoinTeam = useCallback(async () => {
     if (!workspacePath) return
@@ -277,13 +291,16 @@ export function TeamOSSConfig() {
         workspacePath,
         teamEndpoint: cfgFcEndpoint || undefined,
         llmBaseUrl: cfgHostLlm ? cfgLlmUrl : undefined,
+        llmModel: cfgHostLlm ? (cfgLlmModels[0]?.id || undefined) : undefined,
+        llmModelName: cfgHostLlm ? (cfgLlmModels[0]?.name || undefined) : undefined,
+        llmModels: cfgHostLlm && cfgLlmModels.length > 0 ? JSON.stringify(cfgLlmModels) : undefined,
       })
     } catch {
       // error is set in the store
     } finally {
       setCfgSaving(false)
     }
-  }, [workspacePath, cfgFcEndpoint, cfgHostLlm, cfgLlmUrl, updateServiceConfig])
+  }, [workspacePath, cfgFcEndpoint, cfgHostLlm, cfgLlmUrl, cfgLlmModels, updateServiceConfig])
 
   const handleSyncNow = useCallback(async () => {
     if (!workspacePath) return
@@ -326,7 +343,7 @@ export function TeamOSSConfig() {
   const teamModeType = useTeamModeStore((s) => s.teamModeType)
   const configuredAsOss = configured || teamModeType === 'oss'
 
-  const isOwner = myRole === 'owner' || myRole === 'manager'
+  const isOwner = myRole === 'owner'
 
   return (
     <div className="space-y-4">
@@ -432,33 +449,14 @@ export function TeamOSSConfig() {
                   />
                 </div>
               </div>
-              <div className="rounded-lg border border-border/40 bg-muted/20 p-3 space-y-2">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={createHostLlm}
-                    onChange={(e) => setCreateHostLlm(e.target.checked)}
-                    className="rounded border-border"
-                  />
-                  <span className="text-xs font-medium text-muted-foreground">托管 LLM（团队共享 AI 模型）</span>
-                </label>
-                {createHostLlm && (
-                  <div className="space-y-2 pt-1">
-                    <div>
-                      <label className="mb-1 block text-xs text-muted-foreground">LLM API 地址</label>
-                      <Input
-                        value={createLlmUrl}
-                        onChange={(e) => setCreateLlmUrl(e.target.value)}
-                        placeholder="https://your-llm-proxy.com/v1"
-                        className="bg-background/50 font-mono text-xs"
-                      />
-                    </div>
-                    <p className="text-xs text-muted-foreground/60">
-                      访问 LLM 时将从环境变量 <code className="rounded bg-muted px-1 py-0.5 font-mono">tc_api_key</code> 获取密钥，默认值为设备 ID
-                    </p>
-                  </div>
-                )}
-              </div>
+              <HostLlmConfig
+                enabled={createHostLlm}
+                onEnabledChange={setCreateHostLlm}
+                baseUrl={createLlmUrl}
+                onBaseUrlChange={setCreateLlmUrl}
+                models={createLlmModels}
+                onModelsChange={setCreateLlmModels}
+              />
               <Button
                 onClick={handleCreateTeam}
                 disabled={creating || !teamName || !ownerName || !ownerEmail || !createFcEndpoint}
@@ -629,33 +627,14 @@ export function TeamOSSConfig() {
                     OSS 凭证和团队注册服务的地址
                   </p>
                 </div>
-                <div className="rounded-lg border border-border/40 bg-muted/20 p-3 space-y-2">
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={cfgHostLlm}
-                      onChange={(e) => setCfgHostLlm(e.target.checked)}
-                      className="rounded border-border"
-                    />
-                    <span className="text-xs font-medium text-muted-foreground">托管 LLM（团队共享 AI 模型）</span>
-                  </label>
-                  {cfgHostLlm && (
-                    <div className="space-y-2 pt-1">
-                      <div>
-                        <label className="mb-1 block text-xs text-muted-foreground">LLM API 地址</label>
-                        <Input
-                          value={cfgLlmUrl}
-                          onChange={(e) => setCfgLlmUrl(e.target.value)}
-                          placeholder="https://your-llm-proxy.com/v1"
-                          className="bg-background/50 font-mono text-xs"
-                        />
-                      </div>
-                      <p className="text-xs text-muted-foreground/60">
-                        访问 LLM 时将从环境变量 <code className="rounded bg-muted px-1 py-0.5 font-mono">tc_api_key</code> 获取密钥，默认值为设备 ID
-                      </p>
-                    </div>
-                  )}
-                </div>
+                <HostLlmConfig
+                  enabled={cfgHostLlm}
+                  onEnabledChange={setCfgHostLlm}
+                  baseUrl={cfgLlmUrl}
+                  onBaseUrlChange={setCfgLlmUrl}
+                  models={cfgLlmModels}
+                  onModelsChange={setCfgLlmModels}
+                />
                 <Button
                   onClick={handleSaveServiceConfig}
                   disabled={cfgSaving || !cfgFcEndpoint}

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -599,7 +599,7 @@ export function TeamOSSConfig() {
                 <div className="flex items-center gap-1.5">
                   <Shield className="h-3.5 w-3.5 text-muted-foreground" />
                   <span className="font-medium">
-                    {myRole === 'owner' ? '管理员' : myRole === 'manager' ? '经理' : myRole === 'editor' ? '编辑' : myRole === 'viewer' ? '只读' : '成员'}
+                    {myRole === 'owner' ? '所有者' : myRole === 'manager' ? '管理员' : myRole === 'editor' ? '编辑' : myRole === 'viewer' ? '只读' : '成员'}
                   </span>
                 </div>
               </div>

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -20,6 +20,7 @@ import {
   Save,
 } from 'lucide-react'
 import { VersionHistorySection } from './VersionHistorySection'
+import { HostLlmConfig } from './HostLlmConfig'
 import { cn, isTauri, copyToClipboard } from '@/lib/utils'
 import { toast } from 'sonner'
 import { buildConfig, TEAMCLAW_DIR, TEAM_REPO_DIR } from '@/lib/build-config'
@@ -88,9 +89,12 @@ export function TeamP2PConfig() {
   const defaultLlmUrl = buildConfig.team.llm.baseUrl || ''
   const [createHostLlm, setCreateHostLlm] = React.useState(!!defaultLlmUrl)
   const [createLlmUrl, setCreateLlmUrl] = React.useState(defaultLlmUrl)
+  const defaultLlmModels = (buildConfig.team.llm.models ?? []).map((m) => ({ id: m.id, name: m.name }))
+  const [createLlmModels, setCreateLlmModels] = React.useState(defaultLlmModels)
   // Service config form (for connected state editing)
   const [cfgHostLlm, setCfgHostLlm] = React.useState(false)
   const [cfgLlmUrl, setCfgLlmUrl] = React.useState('')
+  const [cfgLlmModels, setCfgLlmModels] = React.useState<Array<{ id: string; name: string }>>([])
   const [cfgSaving, setCfgSaving] = React.useState(false)
   const [cfgLoaded, setCfgLoaded] = React.useState(false)
   const [dissolveLoading, setDissolveLoading] = React.useState(false)
@@ -191,10 +195,15 @@ export function TeamP2PConfig() {
         // Load current LLM config for editing
         if (!cfgLoaded) {
           try {
-            const status = await tauriInvoke<{ active: boolean; llm?: { baseUrl: string } }>('get_team_status')
+            const status = await tauriInvoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status')
             if (status.llm?.baseUrl) {
               setCfgHostLlm(true)
               setCfgLlmUrl(status.llm.baseUrl)
+              if (status.llm.models?.length) {
+                setCfgLlmModels(status.llm.models)
+              } else if (status.llm.model) {
+                setCfgLlmModels([{ id: status.llm.model, name: status.llm.modelName || status.llm.model }])
+              }
             }
           } catch { /* ignore */ }
           setCfgLoaded(true)
@@ -338,8 +347,9 @@ export function TeamP2PConfig() {
         ownerName: createOwnerName.trim() || null,
         ownerEmail: createOwnerEmail.trim() || null,
         llmBaseUrl: createHostLlm ? (createLlmUrl || null) : null,
-        llmModel: null,
-        llmModelName: null,
+        llmModel: createHostLlm ? (createLlmModels[0]?.id || null) : null,
+        llmModelName: createHostLlm ? (createLlmModels[0]?.name || null) : null,
+        llmModels: createHostLlm && createLlmModels.length > 0 ? JSON.stringify(createLlmModels) : null,
       })
       await loadSyncStatus()
       useWorkspaceStore.getState().refreshFileTree()
@@ -399,8 +409,9 @@ export function TeamP2PConfig() {
     try {
       await tauriInvoke('update_team_llm_config', {
         llmBaseUrl: cfgHostLlm ? (cfgLlmUrl || null) : null,
-        llmModel: null,
-        llmModelName: null,
+        llmModel: cfgHostLlm ? (cfgLlmModels[0]?.id || null) : null,
+        llmModelName: cfgHostLlm ? (cfgLlmModels[0]?.name || null) : null,
+        llmModels: cfgHostLlm && cfgLlmModels.length > 0 ? JSON.stringify(cfgLlmModels) : null,
       })
     } catch (err) {
       setP2pError(err instanceof Error ? err.message : String(err))
@@ -636,32 +647,14 @@ export function TeamP2PConfig() {
                     <p className="text-xs text-muted-foreground">{t('settings.team.serviceConfigDesc', 'LLM hosting settings for this team')}</p>
                   </div>
                 </div>
-                <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={cfgHostLlm}
-                      onChange={(e) => setCfgHostLlm(e.target.checked)}
-                      className="rounded border-border"
-                    />
-                    <span className="text-xs font-medium text-muted-foreground">
-                      {t('settings.team.hostLlm', 'Host LLM (team shared AI model)')}
-                    </span>
-                  </label>
-                  {cfgHostLlm && (
-                    <div className="space-y-2 pt-1">
-                      <Input
-                        value={cfgLlmUrl}
-                        onChange={(e) => setCfgLlmUrl(e.target.value)}
-                        placeholder="https://your-llm-proxy.com/v1"
-                        className="h-9 text-sm font-mono"
-                      />
-                      <p className="text-xs text-muted-foreground/60">
-                        {t('settings.team.llmApiKeyHint', 'API key is read from env var')} <code className="rounded bg-muted px-1 py-0.5 font-mono">tc_api_key</code>{t('settings.team.llmApiKeyDefault', ', defaults to device ID')}
-                      </p>
-                    </div>
-                  )}
-                </div>
+                <HostLlmConfig
+                  enabled={cfgHostLlm}
+                  onEnabledChange={setCfgHostLlm}
+                  baseUrl={cfgLlmUrl}
+                  onBaseUrlChange={setCfgLlmUrl}
+                  models={cfgLlmModels}
+                  onModelsChange={setCfgLlmModels}
+                />
                 <Button
                   size="sm"
                   className="gap-1.5"
@@ -960,8 +953,8 @@ export function TeamP2PConfig() {
         </>
       )}
 
-      {/* ─── Reconnecting State (initial load) ─────────────────────────── */}
-      {!isConnected && reconnecting && (
+      {/* ─── Reconnecting State (initial load, only when P2P was configured) ── */}
+      {!isConnected && reconnecting && configuredAsP2p && (
         <SettingCard>
           <div className="flex items-center gap-3 py-4 justify-center">
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
@@ -1014,7 +1007,7 @@ export function TeamP2PConfig() {
       )}
 
       {/* ─── Not Connected State ─────────────────────────────────────── */}
-      {!isConnected && !reconnecting && !configuredAsP2p && (
+      {!isConnected && !configuredAsP2p && (
         <>
           {/* Create Team */}
           <SettingCard>
@@ -1054,34 +1047,15 @@ export function TeamP2PConfig() {
                     disabled={createLoading}
                   />
                 </div>
-                <div className="rounded-lg border border-border/40 bg-muted/20 p-3 space-y-2">
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={createHostLlm}
-                      onChange={(e) => setCreateHostLlm(e.target.checked)}
-                      className="rounded border-border"
-                      disabled={createLoading}
-                    />
-                    <span className="text-xs font-medium text-muted-foreground">
-                      {t('settings.team.hostLlm', 'Host LLM (team shared AI model)')}
-                    </span>
-                  </label>
-                  {createHostLlm && (
-                    <div className="space-y-2 pt-1">
-                      <Input
-                        value={createLlmUrl}
-                        onChange={(e) => setCreateLlmUrl(e.target.value)}
-                        placeholder="https://your-llm-proxy.com/v1"
-                        className="h-9 text-sm font-mono bg-background/50"
-                        disabled={createLoading}
-                      />
-                      <p className="text-xs text-muted-foreground/60">
-                        {t('settings.team.llmApiKeyHint', 'API key is read from env var')} <code className="rounded bg-muted px-1 py-0.5 font-mono">tc_api_key</code>{t('settings.team.llmApiKeyDefault', ', defaults to device ID')}
-                      </p>
-                    </div>
-                  )}
-                </div>
+                <HostLlmConfig
+                  enabled={createHostLlm}
+                  onEnabledChange={setCreateHostLlm}
+                  baseUrl={createLlmUrl}
+                  onBaseUrlChange={setCreateLlmUrl}
+                  models={createLlmModels}
+                  onModelsChange={setCreateLlmModels}
+                  disabled={createLoading}
+                />
                 <Button
                   onClick={handleCreateTeam}
                   disabled={createLoading || !createTeamName.trim() || !createInviteCode.trim()}

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -10,12 +10,19 @@ export interface ChannelsFeatureConfig {
   wechat: boolean
 }
 
+export interface TeamModelOption {
+  id: string
+  name: string
+}
+
 export interface BuildConfig {
   team: {
     llm: {
       baseUrl: string
       model: string
       modelName: string
+      /** Multiple selectable models. When set, users can switch between these in team mode. */
+      models?: TeamModelOption[]
       supportsVision?: boolean
     }
     lockLlmConfig: boolean

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -39,10 +39,14 @@ interface TeamModeState {
   loadP2pFileSyncStatus: () => Promise<void>
 }
 
+interface TeamStatusLlm extends TeamModelConfig {
+  models?: Array<{ id: string; name: string }>
+}
+
 interface TeamStatusResponse {
   active: boolean
   mode: string | null
-  llm: TeamModelConfig | null
+  llm: TeamStatusLlm | null
 }
 
 async function fetchTeamStatus(): Promise<TeamStatusResponse | null> {
@@ -88,11 +92,14 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
     if (isTeamMode) {
       set({ teamMode: true, teamModeType: status?.mode ?? (ossConfigured ? 'oss' : null) })
       if (status?.llm) {
+        // Use models from team config (stored in teamclaw.json), fallback to build config
+        const teamModels = status.llm.models && status.llm.models.length > 0
+          ? status.llm.models
+          : (buildConfig.team.llm.models ?? [])
         // Restore previously selected team model if available
-        const teamModels = buildConfig.team.llm.models
         let selectedModel = status.llm.model
         let selectedModelName = status.llm.modelName || status.llm.model
-        if (teamModels && teamModels.length > 0) {
+        if (teamModels.length > 0) {
           try {
             const savedModelId = localStorage.getItem(`${appShortName}-team-model`)
             const match = savedModelId ? teamModels.find((m) => m.id === savedModelId) : null
@@ -107,7 +114,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
           model: selectedModel,
           modelName: selectedModelName,
         }
-        set({ teamModelConfig: config })
+        set({ teamModelConfig: config, teamModelOptions: teamModels })
       } else {
         set({ teamModelConfig: null })
       }
@@ -146,8 +153,8 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
         } catch { /* ignore */ }
       }
 
-      // Build model configs — use models array from build config if available, otherwise single model
-      const teamModels = buildConfig.team.llm.models
+      // Build model configs — use models from team config (state), fallback to build config
+      const teamModels = get().teamModelOptions.length > 0 ? get().teamModelOptions : buildConfig.team.llm.models
       const modelConfigs: any[] = teamModels && teamModels.length > 0
         ? teamModels.map((m) => {
             const mc: any = {

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -6,7 +6,7 @@ import {
 } from '@/lib/opencode/config'
 import { useProviderStore } from './provider'
 import { isTauri } from '@/lib/utils'
-import { appShortName, buildConfig } from '@/lib/build-config'
+import { appShortName, buildConfig, type TeamModelOption } from '@/lib/build-config'
 
 
 const TEAM_PROVIDER_ID = 'team'
@@ -21,6 +21,7 @@ interface TeamModeState {
   teamMode: boolean
   teamModeType: string | null // "p2p" | "oss" | "webdav" | "git" — from teamclaw.json
   teamModelConfig: TeamModelConfig | null
+  teamModelOptions: TeamModelOption[] // available model choices from build config
   _appliedConfigKey: string | null // fingerprint of last applied config to avoid redundant apply
   devUnlocked: boolean // hidden dev mode: unlocks model selector & hidden dirs in team mode
   myRole: 'owner' | 'editor' | 'viewer' | null
@@ -32,6 +33,7 @@ interface TeamModeState {
 
   loadTeamConfig: (workspacePath: string) => Promise<void>
   applyTeamModelToOpenCode: (workspacePath: string, force?: boolean) => Promise<void>
+  switchTeamModel: (modelId: string, workspacePath: string) => Promise<void>
   clearTeamMode: (workspacePath?: string) => Promise<void>
   setDevUnlocked: (unlocked: boolean) => void
   loadP2pFileSyncStatus: () => Promise<void>
@@ -59,6 +61,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   teamMode: false,
   teamModeType: null,
   teamModelConfig: null,
+  teamModelOptions: buildConfig.team.llm.models ?? [],
   _appliedConfigKey: null,
   devUnlocked: false,
   myRole: null,
@@ -85,10 +88,24 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
     if (isTeamMode) {
       set({ teamMode: true, teamModeType: status?.mode ?? (ossConfigured ? 'oss' : null) })
       if (status?.llm) {
+        // Restore previously selected team model if available
+        const teamModels = buildConfig.team.llm.models
+        let selectedModel = status.llm.model
+        let selectedModelName = status.llm.modelName || status.llm.model
+        if (teamModels && teamModels.length > 0) {
+          try {
+            const savedModelId = localStorage.getItem(`${appShortName}-team-model`)
+            const match = savedModelId ? teamModels.find((m) => m.id === savedModelId) : null
+            if (match) {
+              selectedModel = match.id
+              selectedModelName = match.name
+            }
+          } catch { /* ignore */ }
+        }
         const config: TeamModelConfig = {
           baseUrl: status.llm.baseUrl,
-          model: status.llm.model,
-          modelName: status.llm.modelName || status.llm.model,
+          model: selectedModel,
+          modelName: selectedModelName,
         }
         set({ teamModelConfig: config })
       } else {
@@ -129,36 +146,44 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
         } catch { /* ignore */ }
       }
 
-      const modelConfig: any = {
-        modelId: teamModelConfig.model,
-        modelName: teamModelConfig.modelName,
-        limit: {
-          context: 256000,
-          output: 16000
-        }
-      }
-
-      if (buildConfig.team.llm.supportsVision) {
-        modelConfig.modalities = {
-          input: ['text', 'image'],
-          output: ['text']
-        }
-      }
+      // Build model configs — use models array from build config if available, otherwise single model
+      const teamModels = buildConfig.team.llm.models
+      const modelConfigs: any[] = teamModels && teamModels.length > 0
+        ? teamModels.map((m) => {
+            const mc: any = {
+              modelId: m.id,
+              modelName: m.name,
+              limit: { context: 256000, output: 16000 },
+            }
+            if (buildConfig.team.llm.supportsVision) {
+              mc.modalities = { input: ['text', 'image'], output: ['text'] }
+            }
+            return mc
+          })
+        : [{
+            modelId: teamModelConfig.model,
+            modelName: teamModelConfig.modelName,
+            limit: { context: 256000, output: 16000 },
+            ...(buildConfig.team.llm.supportsVision
+              ? { modalities: { input: ['text', 'image'], output: ['text'] } }
+              : {}),
+          }]
 
       // Check if the provider config already exists in opencode.json with matching values.
       // If so, skip the disruptive restart — the sidecar already loaded the correct config.
       const existingConfig = await getCustomProviderConfig(workspacePath, TEAM_PROVIDER_ID)
+      const expectedModelIds = modelConfigs.map((m) => m.modelId).sort()
+      const existingModelIds = existingConfig?.models.map((m) => m.modelId).sort() ?? []
       const configAlreadyMatches = existingConfig
         && existingConfig.baseURL === teamModelConfig.baseUrl
-        && existingConfig.models.length > 0
-        && existingConfig.models[0].modelId === teamModelConfig.model
+        && JSON.stringify(expectedModelIds) === JSON.stringify(existingModelIds)
 
       if (!configAlreadyMatches) {
         await addCustomProviderToConfig(workspacePath, {
           name: 'Team',
           baseURL: teamModelConfig.baseUrl,
           apiKey: '${tc_api_key}',
-          models: [modelConfig],
+          models: modelConfigs,
         })
 
         // Restart OpenCode to pick up new provider config
@@ -189,6 +214,31 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
     } catch (err) {
       console.error('[TeamMode] Failed to apply team model to OpenCode:', err)
     }
+  },
+
+  switchTeamModel: async (modelId: string, _workspacePath: string) => {
+    const { teamModelConfig, teamModelOptions } = get()
+    if (!teamModelConfig) return
+    const option = teamModelOptions.find((m) => m.id === modelId)
+    if (!option) return
+
+    const newConfig: TeamModelConfig = {
+      baseUrl: teamModelConfig.baseUrl,
+      model: modelId,
+      modelName: option.name,
+    }
+    set({ teamModelConfig: newConfig })
+
+    // Select the model in OpenCode (all models are already registered in the provider)
+    const providerStore = useProviderStore.getState()
+    await providerStore.selectModel(TEAM_PROVIDER_ID, modelId, option.name)
+
+    // Persist selection
+    try {
+      localStorage.setItem(`${appShortName}-team-model`, modelId)
+    } catch { /* ignore */ }
+
+    console.log('[TeamMode] Switched team model to:', modelId)
   },
 
   setDevUnlocked: (unlocked: boolean) => {

--- a/packages/app/src/stores/team-oss.ts
+++ b/packages/app/src/stores/team-oss.ts
@@ -101,6 +101,7 @@ interface TeamOssState {
     llmBaseUrl?: string
     llmModel?: string
     llmModelName?: string
+    llmModels?: string
   }) => Promise<OssTeamInfo>
   joinTeam: (params: {
     workspacePath: string
@@ -110,6 +111,7 @@ interface TeamOssState {
     llmBaseUrl?: string
     llmModel?: string
     llmModelName?: string
+    llmModels?: string
   }) => Promise<OssJoinResult>
   leaveTeam: (workspacePath: string) => Promise<void>
   syncNow: (workspacePath: string) => Promise<void>
@@ -133,6 +135,7 @@ interface TeamOssState {
     llmBaseUrl?: string
     llmModel?: string
     llmModelName?: string
+    llmModels?: string
   }) => Promise<void>
   reconnect: (workspacePath: string) => Promise<void>
   resetSync: (workspacePath: string) => Promise<void>
@@ -268,6 +271,7 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
         llmBaseUrl: params.llmBaseUrl || null,
         llmModel: params.llmModel || null,
         llmModelName: params.llmModelName || null,
+        llmModels: params.llmModels || null,
       })
       set({ configured: true, connected: true, teamInfo: info, error: null })
       // Refresh file tree so the new teamclaw-team directory appears
@@ -291,6 +295,7 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
         llmBaseUrl: params.llmBaseUrl || null,
         llmModel: params.llmModel || null,
         llmModelName: params.llmModelName || null,
+        llmModels: params.llmModels || null,
       })
 
       if (result.status === 'not_member') {
@@ -387,6 +392,7 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
         llmBaseUrl: params.llmBaseUrl || null,
         llmModel: params.llmModel || null,
         llmModelName: params.llmModelName || null,
+        llmModels: params.llmModels || null,
       })
       set({ error: null })
     } catch (e) {

--- a/src-tauri/src/commands/oss_commands.rs
+++ b/src-tauri/src/commands/oss_commands.rs
@@ -175,12 +175,13 @@ pub async fn oss_create_team(
     llm_base_url: Option<String>,
     llm_model: Option<String>,
     llm_model_name: Option<String>,
+    llm_models: Option<String>,
 ) -> Result<OssTeamInfo, String> {
     let node_id = get_p2p_node_id_sync()?;
     let team_secret = generate_team_secret()?;
 
     // Write LLM config to .teamclaw/teamclaw.json (only if user chose to host LLM)
-    let llm_config = super::team::build_llm_config(llm_base_url, llm_model, llm_model_name);
+    let llm_config = super::team::build_llm_config(llm_base_url, llm_model, llm_model_name, llm_models);
     super::team::write_llm_config(&workspace_path, llm_config.as_ref())?;
     info!(
         "oss_create_team: wrote LLM config to {}/{}",
@@ -401,6 +402,7 @@ pub async fn oss_join_team(
     llm_base_url: Option<String>,
     llm_model: Option<String>,
     llm_model_name: Option<String>,
+    llm_models: Option<String>,
 ) -> Result<OssJoinResult, String> {
     let node_id = get_p2p_node_id_sync()?;
 
@@ -494,7 +496,7 @@ pub async fn oss_join_team(
     super::team::scaffold_team_dir(&team_dir)?;
 
     // Write LLM config to .teamclaw/teamclaw.json (only if user chose to host LLM)
-    let llm_config = super::team::build_llm_config(llm_base_url, llm_model, llm_model_name);
+    let llm_config = super::team::build_llm_config(llm_base_url, llm_model, llm_model_name, llm_models);
     super::team::write_llm_config(&workspace_path, llm_config.as_ref())?;
 
     // Cache team meta locally for fast restore
@@ -1080,6 +1082,7 @@ pub async fn oss_update_service_config(
     llm_base_url: Option<String>,
     llm_model: Option<String>,
     llm_model_name: Option<String>,
+    llm_models: Option<String>,
 ) -> Result<(), String> {
     // Update FC endpoint in oss.json if provided
     if let Some(ref new_endpoint) = team_endpoint {
@@ -1091,7 +1094,7 @@ pub async fn oss_update_service_config(
     }
 
     // Update LLM config in teamclaw.json
-    let llm_config = super::team::build_llm_config(llm_base_url, llm_model, llm_model_name);
+    let llm_config = super::team::build_llm_config(llm_base_url, llm_model, llm_model_name, llm_models);
     super::team::write_llm_config(&workspace_path, llm_config.as_ref())?;
     info!("oss_update_service_config: updated LLM config");
 

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -25,6 +25,14 @@ pub struct TeamConfig {
     pub git_branch: Option<String>,
 }
 
+/// A single model entry in the team LLM configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LlmModelEntry {
+    pub id: String,
+    pub name: String,
+}
+
 /// LLM configuration stored in teamclaw.json under "llm" key.
 /// Replaces the old teamclaw-team/teamclaw.yaml file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -33,6 +41,9 @@ pub struct LlmConfig {
     pub base_url: String,
     pub model: String,
     pub model_name: String,
+    /// Multiple selectable models. When present, users can switch between these.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<LlmModelEntry>,
 }
 
 /// Unified team status returned by check_team_status().
@@ -294,16 +305,25 @@ pub fn build_llm_config(
     base_url: Option<String>,
     model: Option<String>,
     model_name: Option<String>,
+    models_json: Option<String>,
 ) -> Option<LlmConfig> {
     let url = base_url.filter(|s| !s.is_empty())?;
+    let models: Vec<LlmModelEntry> = models_json
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default();
+    // Use first model from array as default if model/model_name not explicitly set
+    let default_model = models.first();
     Some(LlmConfig {
         base_url: url,
         model: model
             .filter(|s| !s.is_empty())
+            .or_else(|| default_model.map(|m| m.id.clone()))
             .unwrap_or_else(|| "default".to_string()),
         model_name: model_name
             .filter(|s| !s.is_empty())
+            .or_else(|| default_model.map(|m| m.name.clone()))
             .unwrap_or_else(|| "default".to_string()),
+        models,
     })
 }
 
@@ -661,10 +681,11 @@ pub fn update_team_llm_config(
     llm_base_url: Option<String>,
     llm_model: Option<String>,
     llm_model_name: Option<String>,
+    llm_models: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<(), String> {
     let workspace_path = get_workspace_path(&opencode_state)?;
-    let llm_config = build_llm_config(llm_base_url, llm_model, llm_model_name);
+    let llm_config = build_llm_config(llm_base_url, llm_model, llm_model_name, llm_models);
     write_llm_config(&workspace_path, llm_config.as_ref())?;
     Ok(())
 }
@@ -715,6 +736,7 @@ pub async fn team_init_repo(
     llm_base_url: Option<String>,
     llm_model: Option<String>,
     llm_model_name: Option<String>,
+    llm_models: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<TeamGitResult, String> {
     let workspace_path = get_workspace_path(&opencode_state)?;
@@ -755,7 +777,7 @@ pub async fn team_init_repo(
     }
 
     // Write LLM config to .teamclaw/teamclaw.json (only if user chose to host LLM)
-    let llm_config = build_llm_config(llm_base_url, llm_model, llm_model_name);
+    let llm_config = build_llm_config(llm_base_url, llm_model, llm_model_name, llm_models);
     write_llm_config(&workspace_path, llm_config.as_ref())?;
     println!(
         "[Team Init] Wrote LLM config to {}/{}",

--- a/src-tauri/src/commands/team_p2p.rs
+++ b/src-tauri/src/commands/team_p2p.rs
@@ -459,6 +459,7 @@ pub async fn p2p_create_team(
     llm_base_url: Option<String>,
     llm_model: Option<String>,
     llm_model_name: Option<String>,
+    llm_models: Option<String>,
     team_name: Option<String>,
     owner_name: Option<String>,
     owner_email: Option<String>,
@@ -481,7 +482,7 @@ pub async fn p2p_create_team(
 
     // Write LLM config (only if user chose to host LLM)
     let llm_config =
-        crate::commands::team::build_llm_config(llm_base_url, llm_model, llm_model_name);
+        crate::commands::team::build_llm_config(llm_base_url, llm_model, llm_model_name, llm_models);
     crate::commands::team::write_llm_config(&workspace_path, llm_config.as_ref())?;
 
     create_team(
@@ -565,6 +566,7 @@ pub async fn p2p_join_drive(
     llm_base_url: Option<String>,
     llm_model: Option<String>,
     llm_model_name: Option<String>,
+    llm_models: Option<String>,
     iroh_state: tauri::State<'_, IrohState>,
     engine_state: tauri::State<'_, SyncEngineState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
@@ -597,7 +599,7 @@ pub async fn p2p_join_drive(
 
     // Write LLM config (only if user chose to host LLM)
     let llm_config =
-        crate::commands::team::build_llm_config(llm_base_url, llm_model, llm_model_name);
+        crate::commands::team::build_llm_config(llm_base_url, llm_model, llm_model_name, llm_models);
     crate::commands::team::write_llm_config(&workspace_path, llm_config.as_ref())?;
 
     Ok(result)


### PR DESCRIPTION
## Summary
- **Shared `HostLlmConfig` component** — P2P/S3/Git team configs all use the same LLM configuration UI with multi-model add/remove support
- **Multi-model storage** — Rust backend `LlmConfig` now stores a `models[]` array in `teamclaw.json`, passed through all create/join/update commands
- **Team model selector** — Chat input area shows a team-specific model picker (e.g. Default/Pro/Max) instead of hiding the selector entirely
- **Service Config owner-only** — LLM hosting config restricted to `owner` role (not `manager`)
- **P2P loading fix** — Non-team users no longer see "Connecting to team..." spinner when switching to P2P tab
- **Role label fix** — Owner now displays as "所有者" instead of "管理员"
- **Remove hardcoded defaults** — Cleared `cloud.ucar.cc`/`ai.ucar.cc` from build configs; all values now come from team setup or private configs

## Test plan
- [ ] Create a team with Host LLM enabled and 3 models → verify all 3 persist after creation
- [ ] Switch between team models in chat input area → verify model switches correctly
- [ ] Verify Service Config section only visible to owner, not manager/editor
- [ ] Switch to P2P tab without a team → should show create/join form immediately (no spinner)
- [ ] Verify owner role displays as "所有者"

🤖 Generated with [Claude Code](https://claude.com/claude-code)