### PR TITLE
fix: OSS team config loading and P2P auto-reconnect

### DIFF
--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -64,6 +64,7 @@ export function TeamOSSConfig() {
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
 
   const {
+    _initDone: ossInitDone,
     configured,
     connected,
     restoring,
@@ -340,15 +341,12 @@ export function TeamOSSConfig() {
     navigator.clipboard.writeText(text)
   }, [])
 
-  const teamModeType = useTeamModeStore((s) => s.teamModeType)
-  const configuredAsOss = configured || teamModeType === 'oss'
-
   const isOwner = myRole === 'owner'
 
   return (
     <div className="space-y-4">
-      {/* State 0: Restoring connection or configured via teamclaw.json but not connected yet */}
-      {!connected && (restoring || (configuredAsOss && !configured)) && (
+      {/* State 0: Restoring connection or OSS store still initializing */}
+      {!connected && (restoring || !ossInitDone) && (
         <SettingCard title="连接中" icon={Cloud}>
           <div className="flex flex-col gap-3 py-4 items-center">
             <div className="flex items-center gap-3 justify-center">
@@ -379,7 +377,7 @@ export function TeamOSSConfig() {
       )}
 
       {/* State 1a: Configured but disconnected — reconnect prompt */}
-      {!connected && !restoring && configured && (
+      {!connected && !restoring && ossInitDone && configured && (
         <SettingCard title="团队未连接" icon={Cloud}>
           <div className="flex flex-col items-center gap-3 py-4">
             <p className="text-sm text-muted-foreground">
@@ -404,7 +402,7 @@ export function TeamOSSConfig() {
       )}
 
       {/* State 1b: Not configured — Create/Join forms */}
-      {!connected && !restoring && !configuredAsOss && (
+      {!connected && !restoring && ossInitDone && !configured && (
         <>
           <SettingCard title="创建团队" icon={Users}>
             <div className="space-y-3">

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -471,9 +471,12 @@ export function useP2pAutoReconnect() {
   const workspacePath = useWorkspaceStore((s) => s.workspacePath);
   const openCodeReady = useWorkspaceStore((s) => s.openCodeReady);
   const teamMode = useTeamModeStore((s) => s.teamMode);
+  const teamModeType = useTeamModeStore((s) => s.teamModeType);
 
   useEffect(() => {
+    // Only auto-reconnect for P2P teams, not S3/OSS/Git
     if (!workspacePath || !openCodeReady || !teamMode || !isTauri()) return;
+    if (teamModeType && teamModeType !== 'p2p') return;
 
     let cancelled = false;
     const MAX_RETRIES = 5;
@@ -519,7 +522,7 @@ export function useP2pAutoReconnect() {
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [workspacePath, openCodeReady, teamMode]);
+  }, [workspacePath, openCodeReady, teamMode, teamModeType]);
 }
 
 export function useCronInit() {

--- a/packages/app/src/stores/team-oss.ts
+++ b/packages/app/src/stores/team-oss.ts
@@ -77,6 +77,7 @@ interface FileSyncStatus {
 
 interface TeamOssState {
   // State
+  _initDone: boolean  // true after initialize() completes (success or failure)
   configured: boolean // local config exists (oss.enabled), true even when offline
   connected: boolean
   restoring: boolean // true while oss_restore_sync is in progress on startup
@@ -147,6 +148,7 @@ interface TeamOssState {
 
 export const useTeamOssStore = create<TeamOssState>((set, get) => ({
   // initial state
+  _initDone: false,
   configured: false,
   connected: false,
   restoring: false,
@@ -200,6 +202,7 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
       })
 
       const config = await invoke<OssTeamConfig | null>('oss_get_team_config', { workspacePath })
+      console.log('[OSS] oss_get_team_config result:', workspacePath, config)
       if (config?.enabled) {
         set({ configured: true, restoring: true })
         try {
@@ -229,8 +232,11 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
         }
       }
     } catch (e) {
-      console.error('OSS sync init failed:', e)
+      console.error('[OSS] sync init failed:', e)
       set({ error: String(e) })
+    } finally {
+      console.log('[OSS] init done, configured:', get().configured, 'connected:', get().connected)
+      set({ _initDone: true })
     }
   },
 
@@ -450,6 +456,7 @@ export const useTeamOssStore = create<TeamOssState>((set, get) => ({
     }
     set({
       _unlisten: null,
+      _initDone: false,
       configured: false,
       connected: false,
       restoring: false,

--- a/src-tauri/crates/teamclaw-sync/src/oss_sync.rs
+++ b/src-tauri/crates/teamclaw-sync/src/oss_sync.rs
@@ -1845,6 +1845,99 @@ impl OssSyncManager {
         Ok(false)
     }
 
+    /// Immediately mark a file as `deleted=true` in the CRDT, export, and
+    /// upload the update.  Called by Tauri commands that delete team files so
+    /// the deletion is persisted in the CRDT before the next sync loop — this
+    /// prevents the race where `write_doc_to_disk` recreates the file from a
+    /// stale `deleted=false` entry.
+    pub async fn mark_file_deleted(
+        &mut self,
+        doc_type: DocType,
+        path: &str,
+    ) -> Result<bool, String> {
+        let now = Utc::now().to_rfc3339();
+        let node_id = self.node_id.clone();
+
+        {
+            let doc = self.get_doc_mut(doc_type);
+            let files_map = doc.get_map("files");
+
+            // Only mark if the entry exists and is not already deleted
+            let already_deleted = match files_map.get(path) {
+                Some(loro::ValueOrContainer::Container(loro::Container::Map(m))) => {
+                    let deep = m.get_deep_value();
+                    if let loro::LoroValue::Map(entry) = deep {
+                        matches!(entry.get("deleted"), Some(loro::LoroValue::Bool(true)))
+                    } else {
+                        false
+                    }
+                }
+                _ => return Ok(false), // entry doesn't exist — nothing to mark
+            };
+            if already_deleted {
+                return Ok(false);
+            }
+
+            Self::archive_current_version(&files_map, path)?;
+
+            let entry_map = files_map
+                .get_or_create_container(path, loro::LoroMap::new())
+                .map_err(|e| format!("mark_file_deleted: get map for {path}: {e}"))?;
+            entry_map
+                .insert("deleted", true)
+                .map_err(|e| format!("mark_file_deleted: set deleted for {path}: {e}"))?;
+            entry_map
+                .insert("updatedBy", node_id.as_str())
+                .map_err(|e| format!("mark_file_deleted: set updatedBy for {path}: {e}"))?;
+            entry_map
+                .insert("updatedAt", now.as_str())
+                .map_err(|e| format!("mark_file_deleted: set updatedAt for {path}: {e}"))?;
+        }
+
+        // Export and upload
+        let updates = {
+            let doc = self.get_doc(doc_type);
+            match self.last_exported_version.get(&doc_type) {
+                Some(vv_bytes) => match loro::VersionVector::decode(vv_bytes) {
+                    Ok(vv) => doc
+                        .export(loro::ExportMode::updates(&vv))
+                        .unwrap_or_else(|_| {
+                            doc.export(loro::ExportMode::all_updates())
+                                .unwrap_or_default()
+                        }),
+                    Err(_) => doc
+                        .export(loro::ExportMode::all_updates())
+                        .map_err(|e| format!("mark_file_deleted: export for {:?}: {e}", doc_type))?,
+                },
+                None => doc
+                    .export(loro::ExportMode::all_updates())
+                    .map_err(|e| format!("mark_file_deleted: export for {:?}: {e}", doc_type))?,
+            }
+        };
+
+        let timestamp_ms = Utc::now().timestamp_millis();
+        let key = format!(
+            "teams/{}/{}/updates/{}/{}.bin",
+            self.team_id,
+            doc_type.path(),
+            self.node_id,
+            timestamp_ms
+        );
+
+        let uploaded = self.upload_with_fallback(doc_type, &updates, &key).await?;
+        if uploaded {
+            info!("mark_file_deleted: uploaded deletion for {:?}/{}", doc_type, path);
+            let current_vv = self.get_doc(doc_type).oplog_vv().encode();
+            self.last_exported_version.insert(doc_type, current_vv);
+            // Signal other nodes
+            if let Err(e) = self.write_signal_flag().await {
+                warn!("mark_file_deleted: failed to write signal flag: {e}");
+            }
+        }
+
+        Ok(uploaded)
+    }
+
     pub async fn upload_local_changes(&mut self, doc_type: DocType) -> Result<bool, String> {
         self.skipped_files.clear();
         let dir = self.team_dir.join(doc_type.dir_name());
@@ -3444,8 +3537,21 @@ pub fn read_oss_config_with(workspace_path: &str, teamclaw_dir: &str, config_fil
 
     let content = std::fs::read_to_string(&config_path).ok()?;
     let json: Value = serde_json::from_str(&content).ok()?;
-    let oss_value = json.get("oss")?;
-    serde_json::from_value(oss_value.clone()).ok()
+    let mut oss_value = json.get("oss")?.clone();
+    // Remove legacy `fcEndpoint` if `teamEndpoint` also exists to avoid
+    // serde "duplicate field" error (alias + real field both present).
+    if let Some(obj) = oss_value.as_object_mut() {
+        if obj.contains_key("teamEndpoint") {
+            obj.remove("fcEndpoint");
+        }
+    }
+    match serde_json::from_value::<OssTeamConfig>(oss_value) {
+        Ok(config) => Some(config),
+        Err(e) => {
+            eprintln!("[OSS] Failed to deserialize OssTeamConfig: {e}");
+            None
+        }
+    }
 }
 
 pub fn write_oss_config_with(workspace_path: &str, config: &OssTeamConfig, teamclaw_dir: &str, config_file_name: &str) -> Result<(), String> {


### PR DESCRIPTION
## Summary
- Fix OSS config deserialization failure when JSON has both legacy `fcEndpoint` and `teamEndpoint` (serde "duplicate field" error causes `oss_get_team_config` to return null)
- Prevent P2P auto-reconnect from firing for S3/OSS/Git teams (was starting iroh node unnecessarily)
- Fix S3 settings page showing create/join form instead of team info due to race condition between `teamModeType` and OSS store initialization

## Test plan
- [x] TypeScript typecheck passes
- [x] Verified root cause via Rust `eprintln` diagnostic: `duplicate field teamEndpoint`
- [ ] Manual: open workspace with OSS team config containing both `fcEndpoint` and `teamEndpoint` — should show connected team, not create form
- [ ] Manual: S3/OSS team should not trigger P2P iroh node startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)