### PR TITLE
feat: expose WeCom chatId in gateway settings UI

### DIFF
--- a/packages/app/src/components/settings/channels/Wecom.tsx
+++ b/packages/app/src/components/settings/channels/Wecom.tsx
@@ -12,6 +12,9 @@ import {
   ArrowLeft,
   Zap,
   ScanQrCode,
+  Copy,
+  MessageSquare,
+  Users,
 } from 'lucide-react'
 import { QRCodeSVG } from 'qrcode.react'
 import { cn } from '@/lib/utils'
@@ -609,9 +612,16 @@ export function WeComChannel() {
         status={wecomGatewayStatus.status}
         statusDetail={
           wecomGatewayStatus.botId ? (
-            <p className="text-sm text-muted-foreground">
-              Bot: {wecomGatewayStatus.botId}
-            </p>
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">
+                Bot: {wecomGatewayStatus.botId}
+              </p>
+              {wecomGatewayStatus.activeSessions && wecomGatewayStatus.activeSessions.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  {wecomGatewayStatus.activeSessions.length} active session{wecomGatewayStatus.activeSessions.length !== 1 ? 's' : ''}
+                </p>
+              )}
+            </div>
           ) : undefined
         }
         errorMessage={wecomGatewayStatus.errorMessage}
@@ -710,6 +720,44 @@ export function WeComChannel() {
             placeholder={t('settings.channels.wecom.encodingAesKeyPlaceholder', '43-character key for attachment decryption')}
           />
         </div>
+
+        {/* Active Sessions */}
+        {wecomGatewayStatus.activeSessions && wecomGatewayStatus.activeSessions.length > 0 && (
+          <div className="space-y-2">
+            <label className="text-sm font-medium flex items-center gap-2">
+              <MessageSquare className="h-4 w-4 text-muted-foreground" />
+              {t('settings.channels.wecom.activeSessions', 'Active Sessions')}
+              <span className="text-xs text-muted-foreground font-normal">({wecomGatewayStatus.activeSessions.length})</span>
+            </label>
+            <div className="space-y-1">
+              {wecomGatewayStatus.activeSessions.map((sessionKey) => {
+                const isDm = sessionKey.startsWith('wecom:dm:')
+                const chatId = isDm ? sessionKey.replace('wecom:dm:', '') : sessionKey.replace('wecom:', '')
+                return (
+                  <div
+                    key={sessionKey}
+                    className="flex items-center gap-2 p-2 rounded-md bg-muted/50 text-sm group"
+                  >
+                    {isDm ? (
+                      <MessageSquare className="h-3.5 w-3.5 text-blue-500 flex-shrink-0" />
+                    ) : (
+                      <Users className="h-3.5 w-3.5 text-emerald-500 flex-shrink-0" />
+                    )}
+                    <span className="text-xs text-muted-foreground">{isDm ? 'DM' : 'Group'}</span>
+                    <code className="text-xs font-mono flex-1 truncate">{chatId}</code>
+                    <button
+                      className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-muted"
+                      onClick={() => navigator.clipboard.writeText(chatId)}
+                      title={t('settings.channels.wecom.copyChatId', 'Copy Chat ID')}
+                    >
+                      <Copy className="h-3 w-3 text-muted-foreground" />
+                    </button>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
 
         {/* Error message */}
         {wecomGatewayStatus.errorMessage && (

--- a/packages/app/src/stores/channels-types.ts
+++ b/packages/app/src/stores/channels-types.ts
@@ -160,6 +160,8 @@ export interface WeComGatewayStatusResponse {
   status: WeComGatewayStatus
   errorMessage?: string
   botId?: string
+  /** Active session keys (e.g. "wecom:dm:userid", "wecom:chatid") */
+  activeSessions?: string[]
 }
 
 export interface WeComQrAuthStart {

--- a/src-tauri/crates/teamclaw-gateway/src/wecom.rs
+++ b/src-tauri/crates/teamclaw-gateway/src/wecom.rs
@@ -414,7 +414,17 @@ impl WeComGateway {
     }
 
     pub async fn get_status(&self) -> WeComGatewayStatusResponse {
-        self.status.read().await.clone()
+        let mut resp = self.status.read().await.clone();
+        // Populate active sessions from session mapping
+        let data = self.session_mapping.get_all_sessions().await;
+        resp.active_sessions = data
+            .sessions
+            .keys()
+            .filter(|k| k.starts_with("wecom:"))
+            .cloned()
+            .collect();
+        resp.active_sessions.sort();
+        resp
     }
 
     async fn set_status(&self, status: WeComGatewayStatus, error: Option<String>) {

--- a/src-tauri/crates/teamclaw-gateway/src/wecom_config.rs
+++ b/src-tauri/crates/teamclaw-gateway/src/wecom_config.rs
@@ -44,6 +44,9 @@ pub struct WeComGatewayStatusResponse {
     pub status: WeComGatewayStatus,
     pub error_message: Option<String>,
     pub bot_id: Option<String>,
+    /// Active session keys (e.g. "wecom:dm:userid", "wecom:chatid")
+    #[serde(default)]
+    pub active_sessions: Vec<String>,
 }
 
 impl Default for WeComGatewayStatusResponse {
@@ -52,6 +55,7 @@ impl Default for WeComGatewayStatusResponse {
             status: WeComGatewayStatus::Disconnected,
             error_message: None,
             bot_id: None,
+            active_sessions: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `activeSessions` field to `WeComGatewayStatusResponse` (Rust + TypeScript)
- Populate active session keys from `SessionMapping` when querying gateway status
- Display active sessions in WeCom settings card with DM/Group labels and copy-to-clipboard

## Test plan
- [ ] Start WeCom gateway, send a DM → verify session appears in settings
- [ ] Send a group message → verify group session appears with green icon
- [ ] Click copy button → verify chatId is copied to clipboard
- [ ] Verify collapsed card shows session count
- [ ] Verify no sessions shown when gateway is disconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)