### PR TITLE
fix: ChatPanel infinite re-render and Windows P2P state crash

### DIFF
--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -9,7 +9,7 @@ import { useSessionStore } from "@/stores/session";
 import { useStreamingStore } from "@/stores/streaming";
 import { useVoiceInputStore } from "@/stores/voice-input";
 import { useWorkspaceStore } from "@/stores/workspace";
-import { useProviderStore, getSelectedModelOption } from "@/stores/provider";
+import { useProviderStore, type ModelOption } from "@/stores/provider";
 import { useTeamModeStore } from "@/stores/team-mode";
 import { useSuggestionsStore } from "@/stores/suggestions";
 import { useShortcutsStore } from "@/stores/shortcuts";
@@ -218,7 +218,32 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
   // ── Provider store ────────────────────────────────────────────────────
   const currentModelKey = useProviderStore(s => s.currentModelKey);
   const initProviderStore = useProviderStore(s => s.initAll);
-  const selectedModelOption = useProviderStore((s) => getSelectedModelOption(s));
+  // Derive selected model from currentModelKey + models. Use useMemo with a
+  // ref to avoid returning a new object when the logical value hasn't changed.
+  // This prevents re-render cascades when initAll() rebuilds the models array
+  // with identical data (fixes TEAMCLAW-REACT-1R).
+  const providerModels = useProviderStore(s => s.models);
+  const selectedModelOptionRef = React.useRef<ModelOption | null>(null);
+  const selectedModelOption = React.useMemo(() => {
+    if (!currentModelKey) {
+      selectedModelOptionRef.current = null;
+      return null;
+    }
+    const idx = currentModelKey.indexOf('/');
+    if (idx < 0) {
+      selectedModelOptionRef.current = null;
+      return null;
+    }
+    const providerId = currentModelKey.substring(0, idx);
+    const modelId = currentModelKey.substring(idx + 1);
+    const found = providerModels.find((m) => m.provider === providerId && m.id === modelId) || null;
+    const prev = selectedModelOptionRef.current;
+    if (prev && found && prev.id === found.id && prev.provider === found.provider && prev.name === found.name) {
+      return prev; // stable reference
+    }
+    selectedModelOptionRef.current = found;
+    return found;
+  }, [currentModelKey, providerModels]);
 
   // ── Refs ───────────────────────────────────────────────────────────────
   const messageListRef = React.useRef<MessageListHandle>(null);

--- a/src-tauri/src/commands/p2p_state.rs
+++ b/src-tauri/src/commands/p2p_state.rs
@@ -1,5 +1,7 @@
 //! Shim so the app always has an IrohState type for Tauri state.
 //! When the p2p feature is off (e.g. Windows build), this is a dummy type.
+//! Each dummy uses a distinct newtype wrapper so Tauri's type-keyed state
+//! manager doesn't panic from registering the same concrete type twice.
 
 #[cfg(feature = "p2p")]
 pub use teamclaw_p2p::IrohState;
@@ -11,8 +13,23 @@ pub use teamclaw_p2p::SyncEngineState;
 use std::sync::Arc;
 #[cfg(not(feature = "p2p"))]
 use tokio::sync::Mutex;
-#[cfg(not(feature = "p2p"))]
-pub type IrohState = Arc<Mutex<Option<()>>>;
 
 #[cfg(not(feature = "p2p"))]
-pub type SyncEngineState = Arc<Mutex<Option<()>>>;
+pub struct IrohState(pub Arc<Mutex<Option<()>>>);
+
+#[cfg(not(feature = "p2p"))]
+impl Default for IrohState {
+    fn default() -> Self {
+        Self(Arc::new(Mutex::new(None)))
+    }
+}
+
+#[cfg(not(feature = "p2p"))]
+pub struct SyncEngineState(pub Arc<Mutex<Option<()>>>);
+
+#[cfg(not(feature = "p2p"))]
+impl Default for SyncEngineState {
+    fn default() -> Self {
+        Self(Arc::new(Mutex::new(None)))
+    }
+}


### PR DESCRIPTION
## Summary
- **TEAMCLAW-REACT-1R**: Replace `getSelectedModelOption` selector with `useMemo`+`useRef` that returns a stable object reference when the model hasn't logically changed, preventing infinite re-render cascades during provider `initAll()` retry loop under React 19
- **TEAMCLAW-3**: Change dummy `IrohState`/`SyncEngineState` from type aliases to newtype structs when `p2p` feature is disabled, so Tauri's type-keyed state manager sees them as distinct types on Windows

## Test plan
- [ ] Start app fresh — verify no "Maximum update depth exceeded" error in console
- [ ] Switch models in ChatPanel — verify model selection still syncs correctly
- [ ] Windows build: verify app starts without "state already being managed" panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)