### PR TITLE
fix: file tree context menu flashing and disappearing

### DIFF
--- a/packages/app/src/components/workspace/FileTreeNode.tsx
+++ b/packages/app/src/components/workspace/FileTreeNode.tsx
@@ -310,8 +310,7 @@ export const FileTreeItem = React.memo(function FileTreeItem({
       onDragOver={(e) => isDirectory ? onDragOver(e, node.path) : undefined}
       onDragLeave={(e) => isDirectory ? onDragLeave(e) : undefined}
       onDrop={(e) => isDirectory ? onDrop(e, node.path) : undefined}
-      onContextMenu={(e) => {
-        e.currentTarget.focus();
+      onContextMenu={() => {
         window.getSelection()?.removeAllRanges();
       }}
       data-path={node.path}


### PR DESCRIPTION
## Summary
- Remove explicit `focus()` call in `onContextMenu` handler that was racing with Radix ContextMenu's internal focus management, causing the menu to flash and immediately close

## Test plan
- [ ] Right-click a file in the file tree — context menu should appear and stay open
- [ ] Right-click a directory — context menu should appear and stay open
- [ ] Click a menu item — action should execute normally
- [ ] Verify text selection is still cleared on right-click

🤖 Generated with [Claude Code](https://claude.com/claude-code)