### PR TITLE
fix: clean up team state properly on workspace switch

### DIFF
--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -374,24 +374,29 @@ export function useGitReposInit() {
   const workspacePath = useWorkspaceStore((s) => s.workspacePath);
   const openCodeReady = useWorkspaceStore((s) => s.openCodeReady);
   const { initialize: initGitRepos, syncAll: syncGitRepos } = useGitReposStore();
-  const hasGitSynced = useRef(false);
+  const prevWorkspaceRef = useRef<string | null>(null);
   const teamSyncIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Local git repos init — runs immediately when workspace is set
+  // Local git repos init — re-runs when workspace changes
   useEffect(() => {
-    if (workspacePath && !hasGitSynced.current) {
-      hasGitSynced.current = true;
+    if (!workspacePath) return;
 
-      initGitRepos()
-        .then(() => {
-          syncGitRepos().catch((err: unknown) => {
-            console.warn("[App] Git auto-sync failed (non-critical):", err);
-          });
-        })
-        .catch((err: unknown) => {
-          console.warn("[App] Git repos init failed (non-critical):", err);
-        });
+    const isWorkspaceChange = prevWorkspaceRef.current !== null && prevWorkspaceRef.current !== workspacePath;
+    prevWorkspaceRef.current = workspacePath;
+
+    if (isWorkspaceChange) {
+      useGitReposStore.getState().reset();
     }
+
+    initGitRepos()
+      .then(() => {
+        syncGitRepos().catch((err: unknown) => {
+          console.warn("[App] Git auto-sync failed (non-critical):", err);
+        });
+      })
+      .catch((err: unknown) => {
+        console.warn("[App] Git repos init failed (non-critical):", err);
+      });
   }, [workspacePath, initGitRepos, syncGitRepos]);
 
   // Team sync — deferred until sidecar is ready to avoid I/O contention

--- a/packages/app/src/stores/git-repos.ts
+++ b/packages/app/src/stores/git-repos.ts
@@ -32,6 +32,7 @@ interface GitReposState {
   setPersonalSkillsUrl: (url: string) => Promise<void>
   setPersonalDocumentsUrl: (url: string) => Promise<void>
   setTeamRepoUrl: (type: 'skills' | 'documents', url: string) => Promise<void>
+  reset: () => void
 }
 
 function loadPersistedState(): Partial<{ gitAvailable: boolean; gitVersion: string }> {
@@ -153,5 +154,9 @@ export const useGitReposStore = create<GitReposState>((set, get) => ({
       config.team.documentsUrl = url
     }
     await get().setConfig(config)
+  },
+
+  reset: () => {
+    set({ repos: [], config: {}, initialized: false, syncing: false })
   },
 }))

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -49,11 +49,13 @@ interface TeamStatusResponse {
   llm: TeamStatusLlm | null
 }
 
-async function fetchTeamStatus(): Promise<TeamStatusResponse | null> {
+async function fetchTeamStatus(workspacePath?: string): Promise<TeamStatusResponse | null> {
   if (!isTauri()) return null
   try {
     const { invoke } = await import('@tauri-apps/api/core')
-    return await invoke<TeamStatusResponse>('get_team_status')
+    return await invoke<TeamStatusResponse>('get_team_status', {
+      workspacePath: workspacePath ?? null,
+    })
   } catch (err) {
     console.warn('[TeamMode] Failed to read team status:', err)
     return null
@@ -76,7 +78,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
 
   loadTeamConfig: async (_workspacePath: string) => {
     // teamMode = p2p.enabled || ossConfigured
-    const status = await fetchTeamStatus()
+    const status = await fetchTeamStatus(_workspacePath)
     // Check OSS config directly from backend to avoid stale store state on workspace switch
     let ossConfigured = false
     if (isTauri()) {

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -372,6 +372,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       useTeamMembersStore.getState().reset();
       // Reset OSS store first so loadTeamConfig reads clean state
       useTeamOssStore.getState().cleanup();
+      // Reset git repos store so it re-initializes for the new workspace
+      try {
+        const { useGitReposStore } = await import("./git-repos");
+        useGitReposStore.getState().reset();
+      } catch { /* ignore */ }
       useTeamModeStore.setState({
         teamMode: false,
         teamModeType: null,
@@ -380,6 +385,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         myRole: null,
         p2pConnected: false,
         p2pConfigured: false,
+        teamGitSyncing: false,
+        p2pFileSyncStatusMap: {},
       });
       // Load team config immediately so sidebar shows team tag on startup
       useTeamModeStore.getState().loadTeamConfig(expandedPath).catch(() => {});
@@ -476,13 +483,20 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       const { useP2pEngineStore } = await import("./p2p-engine");
       const { useTeamMembersStore } = await import("./team-members");
       const { useTeamModeStore } = await import("./team-mode");
+      const { useTeamOssStore } = await import("./team-oss");
       useP2pEngineStore.getState().reset();
       useTeamMembersStore.getState().reset();
+      useTeamOssStore.getState().cleanup();
       useTeamModeStore.setState({
         teamMode: false,
+        teamModeType: null,
         teamModelConfig: null,
         _appliedConfigKey: null,
         myRole: null,
+        p2pConnected: false,
+        p2pConfigured: false,
+        teamGitSyncing: false,
+        p2pFileSyncStatusMap: {},
       });
     } catch { /* ignore */ }
 

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -706,10 +706,19 @@ fn convert_team_server_to_opencode(server: &TeamMCPServer) -> MCPServerConfig {
 // ─── Tauri Commands: Team Status ─────────────────────────────────────────────
 
 /// Unified team status check — single source of truth for frontend.
+/// Accepts an optional `workspace_path` override so the frontend can pass
+/// the correct path during workspace switches (before `start_opencode` updates
+/// `OpenCodeState`).
 #[tauri::command]
-pub fn get_team_status(opencode_state: State<'_, OpenCodeState>) -> Result<TeamStatus, String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
-    Ok(check_team_status(&workspace_path))
+pub fn get_team_status(
+    workspace_path: Option<String>,
+    opencode_state: State<'_, OpenCodeState>,
+) -> Result<TeamStatus, String> {
+    let ws = workspace_path
+        .filter(|p| !p.is_empty())
+        .or_else(|| get_workspace_path(&opencode_state).ok())
+        .ok_or("No workspace path set. Please select a workspace first.".to_string())?;
+    Ok(check_team_status(&ws))
 }
 
 /// Update LLM config for an existing team (any mode: P2P, OSS, Git, WebDAV).


### PR DESCRIPTION
## Summary

- Fix team settings tabs (e.g. Git) becoming unselectable after switching workspaces
- Root cause: `loadTeamConfig()` read team status from the old workspace via `OpenCodeState` before `start_opencode` updated it for the new workspace
- `clearWorkspace()` was also missing resets for several team-related fields

## Changes

- **Rust `get_team_status`**: accepts optional `workspace_path` parameter so the frontend can pass the correct path during workspace switches
- **`fetchTeamStatus()` / `loadTeamConfig()`**: passes workspace path directly to avoid stale reads from `OpenCodeState`
- **`setWorkspace()`**: resets all team fields including `teamGitSyncing`, `p2pFileSyncStatusMap`, and `useGitReposStore`
- **`clearWorkspace()`**: now resets `teamModeType`, `p2pConnected`, `p2pConfigured`, and calls `useTeamOssStore.cleanup()`
- **`useGitReposStore`**: new `reset()` method; `useGitReposInit` properly re-initializes on workspace change

## Test plan

- [x] `pnpm lint` — no new errors
- [x] `pnpm test` — 867/867 tests pass
- [x] `pnpm rust:check` — compiles successfully
- [ ] Manual: switch between a workspace with Git team configured and one without — Git tab should be selectable in the new workspace
- [ ] Manual: switch between a workspace with P2P/OSS configured and one without — all tabs should be selectable in the new workspace