### PR TITLE
feat: bundle the superpowers plugin

### DIFF
--- a/packages/app/src/lib/opencode/__tests__/superpowers-plugin-installer.test.ts
+++ b/packages/app/src/lib/opencode/__tests__/superpowers-plugin-installer.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockExists = vi.fn()
+const mockReadTextFile = vi.fn()
+const mockWriteTextFile = vi.fn()
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  exists: (path: string) => mockExists(path),
+  readTextFile: (path: string) => mockReadTextFile(path),
+  writeTextFile: (...args: unknown[]) => mockWriteTextFile(...args),
+}))
+
+describe("superpowers plugin installer", () => {
+  const workspacePath = "/tmp/ws"
+  const configPath = "/tmp/ws/opencode.json"
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExists.mockResolvedValue(false)
+    mockReadTextFile.mockResolvedValue("")
+    mockWriteTextFile.mockResolvedValue(undefined)
+  })
+
+  it("creates opencode.json with the superpowers plugin when missing", async () => {
+    const { ensureSuperpowersPlugin } = await import("../superpowers-plugin-installer")
+    const result = await ensureSuperpowersPlugin(workspacePath)
+
+    expect(result).toEqual({ status: "installed", path: configPath })
+    expect(mockWriteTextFile).toHaveBeenCalledTimes(1)
+    expect(mockWriteTextFile).toHaveBeenCalledWith(
+      configPath,
+      expect.stringContaining(
+        '"plugin": [\n    "superpowers@git+https://github.com/obra/superpowers.git"\n  ]',
+      ),
+    )
+  })
+
+  it("adds the superpowers plugin to an existing opencode.json", async () => {
+    mockExists.mockImplementation((path: string) => {
+      if (path === configPath) return Promise.resolve(true)
+      return Promise.resolve(false)
+    })
+    mockReadTextFile.mockResolvedValue(
+      JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        plugin: ["some-other-plugin"],
+      }),
+    )
+
+    const { ensureSuperpowersPlugin } = await import("../superpowers-plugin-installer")
+    const result = await ensureSuperpowersPlugin(workspacePath)
+
+    expect(result).toEqual({ status: "updated", path: configPath })
+    expect(mockWriteTextFile).toHaveBeenCalledWith(
+      configPath,
+      expect.stringContaining('"superpowers@git+https://github.com/obra/superpowers.git"'),
+    )
+  })
+
+  it("does not duplicate an equivalent alias-based superpowers install", async () => {
+    mockExists.mockImplementation((path: string) => {
+      if (path === configPath) return Promise.resolve(true)
+      return Promise.resolve(false)
+    })
+    mockReadTextFile.mockResolvedValue(
+      JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        plugin: ["superpowers@github:obra/superpowers"],
+      }),
+    )
+
+    const { ensureSuperpowersPlugin } = await import("../superpowers-plugin-installer")
+    const result = await ensureSuperpowersPlugin(workspacePath)
+
+    expect(result).toEqual({ status: "unchanged", path: configPath })
+    expect(mockWriteTextFile).not.toHaveBeenCalled()
+  })
+
+  it("does not duplicate a repo-equivalent superpowers install with a different alias", async () => {
+    mockExists.mockImplementation((path: string) => {
+      if (path === configPath) return Promise.resolve(true)
+      return Promise.resolve(false)
+    })
+    mockReadTextFile.mockResolvedValue(
+      JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        plugin: ["teamclaw-superpowers@git+https://github.com/obra/superpowers.git"],
+      }),
+    )
+
+    const { ensureSuperpowersPlugin } = await import("../superpowers-plugin-installer")
+    const result = await ensureSuperpowersPlugin(workspacePath)
+
+    expect(result).toEqual({ status: "unchanged", path: configPath })
+    expect(mockWriteTextFile).not.toHaveBeenCalled()
+  })
+
+  it("returns conflict when plugin is not a string array", async () => {
+    mockExists.mockImplementation((path: string) => {
+      if (path === configPath) return Promise.resolve(true)
+      return Promise.resolve(false)
+    })
+    mockReadTextFile.mockResolvedValue(
+      JSON.stringify({
+        plugin: { name: "superpowers" },
+      }),
+    )
+
+    const { ensureSuperpowersPlugin } = await import("../superpowers-plugin-installer")
+    const result = await ensureSuperpowersPlugin(workspacePath)
+
+    expect(result.status).toBe("conflict")
+    expect(result.path).toBe(configPath)
+    expect(mockWriteTextFile).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/lib/opencode/superpowers-plugin-installer.ts
+++ b/packages/app/src/lib/opencode/superpowers-plugin-installer.ts
@@ -1,0 +1,109 @@
+export interface EnsureSuperpowersPluginResult {
+  status: "installed" | "updated" | "unchanged" | "conflict" | "failed"
+  path: string
+  reason?: string
+}
+
+interface OpenCodePluginConfig {
+  $schema?: string
+  plugin?: unknown
+  [key: string]: unknown
+}
+
+const OPENCODE_CONFIG_RELATIVE_PATH = "opencode.json"
+const OPENCODE_CONFIG_SCHEMA = "https://opencode.ai/config.json"
+const SUPERPOWERS_PLUGIN_PACKAGE = "superpowers@git+https://github.com/obra/superpowers.git"
+
+function normalizePluginList(value: unknown): string[] | null {
+  if (value === undefined) return []
+  if (!Array.isArray(value)) return null
+  if (!value.every((entry) => typeof entry === "string")) return null
+  return [...value]
+}
+
+function isEquivalentSuperpowersPlugin(entry: string): boolean {
+  const normalized = entry
+    .trim()
+    .toLowerCase()
+    .replace(/^git\+/, "")
+    .replace(/\.git(?=([#?].*)?$)/, "")
+
+  if (normalized === "superpowers" || normalized.startsWith("superpowers@")) {
+    return true
+  }
+
+  return (
+    normalized.includes("github.com/obra/superpowers") ||
+    normalized.includes("github.com:obra/superpowers") ||
+    normalized === "github:obra/superpowers" ||
+    normalized.endsWith("@github:obra/superpowers") ||
+    normalized === "obra/superpowers" ||
+    normalized.endsWith("@obra/superpowers")
+  )
+}
+
+export async function ensureSuperpowersPlugin(
+  workspacePath: string,
+): Promise<EnsureSuperpowersPluginResult> {
+  const configPath = `${workspacePath}/${OPENCODE_CONFIG_RELATIVE_PATH}`
+
+  try {
+    const { exists, readTextFile, writeTextFile } = await import("@tauri-apps/plugin-fs")
+
+    if (!(await exists(configPath))) {
+      const config: OpenCodePluginConfig = {
+        $schema: OPENCODE_CONFIG_SCHEMA,
+        plugin: [SUPERPOWERS_PLUGIN_PACKAGE],
+      }
+      await writeTextFile(configPath, `${JSON.stringify(config, null, 2)}\n`)
+      const result = { status: "installed", path: configPath } as const
+      console.log("[SuperpowersPluginInstaller] Added superpowers plugin to new opencode.json:", result)
+      return result
+    }
+
+    const existingContent = await readTextFile(configPath)
+    const parsedConfig = JSON.parse(existingContent) as OpenCodePluginConfig
+    const pluginList = normalizePluginList(parsedConfig.plugin)
+
+    if (pluginList === null) {
+      const result = {
+        status: "conflict",
+        path: configPath,
+        reason: 'Existing opencode.json "plugin" field is not a string array',
+      } as const
+      console.warn("[SuperpowersPluginInstaller] Plugin config conflict:", result)
+      return result
+    }
+
+    let changed = false
+    if (parsedConfig.$schema !== OPENCODE_CONFIG_SCHEMA) {
+      parsedConfig.$schema = OPENCODE_CONFIG_SCHEMA
+      changed = true
+    }
+
+    if (!pluginList.some(isEquivalentSuperpowersPlugin)) {
+      pluginList.push(SUPERPOWERS_PLUGIN_PACKAGE)
+      parsedConfig.plugin = pluginList
+      changed = true
+    }
+
+    if (changed) {
+      await writeTextFile(configPath, `${JSON.stringify(parsedConfig, null, 2)}\n`)
+      const result = { status: "updated", path: configPath } as const
+      console.log("[SuperpowersPluginInstaller] Updated opencode.json plugin list:", result)
+      return result
+    }
+
+    const result = { status: "unchanged", path: configPath } as const
+    console.log("[SuperpowersPluginInstaller] Superpowers plugin already present in opencode.json:", result)
+    return result
+  } catch (error) {
+    const result = {
+      status: "failed",
+      path: configPath,
+      reason: error instanceof Error ? error.message : String(error),
+    } as const
+    console.error("[SuperpowersPluginInstaller] Failed to ensure superpowers plugin config:", result)
+    return result
+  }
+}


### PR DESCRIPTION
## Summary
- add a built-in superpowers plugin installer for workspaces
- avoid duplicating equivalent existing superpowers installs from alias or repo-based plugin specs
- cover installer behavior with focused unit tests

## Test Plan
- pnpm exec vitest run src/lib/opencode/__tests__/role-plugin-installer.test.ts src/lib/opencode/__tests__/superpowers-plugin-installer.test.ts
- pnpm exec eslint src/components/chat/ChatPanel.tsx src/lib/opencode/superpowers-plugin-installer.ts src/lib/opencode/__tests__/superpowers-plugin-installer.test.ts
  - existing ChatPanel hook warnings remain; no new lint errors introduced