### PR TITLE
feat(team): display last sync timestamp on team repo root

### DIFF
--- a/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
+++ b/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
@@ -33,6 +33,7 @@ export function KnowledgeBrowser() {
       const result = await invoke<{ success: boolean; message: string }>('team_sync_repo')
       if (result.success) {
         toast.success(result.message)
+        useTeamModeStore.setState({ teamGitLastSyncAt: new Date().toISOString() })
         await refreshFileTree()
       } else {
         toast.error(result.message)

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -485,6 +485,8 @@ export function TeamGitConfig() {
       }
       await tauriInvoke('save_team_config', { team: updatedConfig })
       setTeamConfig(updatedConfig)
+      const { useTeamModeStore } = await import('@/stores/team-mode')
+      useTeamModeStore.setState({ teamGitLastSyncAt: now })
 
       if (updateUi) {
         setState('connected')

--- a/packages/app/src/components/workspace/FileTree.tsx
+++ b/packages/app/src/components/workspace/FileTree.tsx
@@ -354,6 +354,7 @@ export function FileTree({
   const p2pFileSyncStatusMap = useTeamModeStore(s => s.p2pFileSyncStatusMap);
   const p2pConnected = useTeamModeStore(s => s.p2pConnected);
   const teamGitSyncing = useTeamModeStore(s => s.teamGitSyncing);
+  const teamGitLastSyncAt = useTeamModeStore(s => s.teamGitLastSyncAt);
   const fileSyncStatusMap = p2pConnected ? p2pFileSyncStatusMap : ossFileSyncStatusMap;
   const syncDirtyDirectories = useMemo(() => {
     const dirtyDirs = new Map<string, 'synced' | 'modified' | 'new'>();
@@ -1221,6 +1222,7 @@ export function FileTree({
     isDragOver: dragOverPath === node.path,
     isTeamClawTeam: node.name === TEAM_REPO_DIR && node.type === "directory" && level === 0,
     teamSyncing: node.name === TEAM_REPO_DIR && node.type === "directory" && level === 0 ? teamGitSyncing : undefined,
+    teamLastSyncAt: node.name === TEAM_REPO_DIR && node.type === "directory" && level === 0 ? teamGitLastSyncAt : undefined,
     syncStatus: (() => {
       if (!node.path.includes(`/${TEAM_REPO_DIR}/`)) return null;
       if (node.type === 'directory') {

--- a/packages/app/src/components/workspace/FileTreeNode.tsx
+++ b/packages/app/src/components/workspace/FileTreeNode.tsx
@@ -27,6 +27,7 @@ import { useTeamModeStore } from '@/stores/team-mode';
 import { useTabsStore } from '@/stores/tabs';
 import { getFileIcon } from '@/lib/file-icons';
 import { getGitStatusIndicator, getGitStatusTextColor } from '@/lib/git-status-utils';
+import { formatDateTime, formatRelativeTime } from '@/lib/date-format';
 import { GitStatus } from "@/lib/git/service";
 import type { FileNode } from "@/stores/workspace";
 import {
@@ -163,6 +164,8 @@ export interface FileTreeItemProps {
   isTeamClawTeam?: boolean;
   /** Whether the team directory is currently syncing (Git mode) */
   teamSyncing?: boolean;
+  /** ISO timestamp of last successful team repo sync (for relative-time label) */
+  teamLastSyncAt?: string | null;
   /** OSS sync status for team files */
   syncStatus?: 'synced' | 'modified' | 'new' | null;
   compactName?: string;
@@ -214,6 +217,7 @@ export const FileTreeItem = React.memo(function FileTreeItem({
   isDragOver,
   isTeamClawTeam,
   teamSyncing,
+  teamLastSyncAt,
   syncStatus,
   onSelectFile,
   onSelectFileRange,
@@ -397,6 +401,19 @@ export const FileTreeItem = React.memo(function FileTreeItem({
         })()}
       {hasGitChanges && isDirectory && (
         <Circle className="h-1.5 w-1.5 fill-amber-500 text-amber-500 shrink-0" />
+      )}
+      {isTeamClawTeam && !teamSyncing && teamLastSyncAt && (
+        <span
+          className="ml-auto pl-2 text-[10px] text-muted-foreground/70 font-normal shrink-0"
+          title={t('fileExplorer.teamLastSyncTooltip', 'Last sync: {{time}}', { time: formatDateTime(teamLastSyncAt) })}
+        >
+          {formatRelativeTime(teamLastSyncAt)}
+        </span>
+      )}
+      {isTeamClawTeam && teamSyncing && (
+        <span className="ml-auto pl-2 text-[10px] text-muted-foreground/70 font-normal shrink-0">
+          {t('fileExplorer.teamSyncing', 'Syncing…')}
+        </span>
       )}
     </button>
   );

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -411,9 +411,11 @@ export function useGitReposInit() {
             if (teamConfig?.enabled) {
               const doSync = () => {
                 invoke("team_sync_repo")
-                  .then((result: unknown) => {
+                  .then(async (result: unknown) => {
                     const r = result as { success: boolean; message: string };
                     if (r.success) {
+                      const { useTeamModeStore } = await import("@/stores/team-mode");
+                      useTeamModeStore.setState({ teamGitLastSyncAt: new Date().toISOString() });
                       console.log("[App] Team repo sync completed (MCP configs updated)");
                     } else {
                       console.warn("[App] Team repo sync skipped:", r.message);

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -178,7 +178,9 @@
     "pasted": "Pasted",
     "pasteFailed": "Paste failed",
     "externalDropped": "Copied {{count}} file(s)",
-    "externalDropFailed": "Failed to copy files"
+    "externalDropFailed": "Failed to copy files",
+    "teamLastSyncTooltip": "Last sync: {{time}}",
+    "teamSyncing": "Syncing…"
   },
   "git": {
     "modified": "Modified",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -194,7 +194,9 @@
     "confirmBatchDeleteTitle": "删除 {{count}} 项？",
     "confirmDeleteFileDesc": "此操作将永久删除该文件。",
     "confirmDeleteDirDesc": "此操作将永久删除该文件夹及其所有内容。",
-    "confirmBatchDeleteDesc": "此操作将永久删除所有选中项。文件夹删除后无法撤销。"
+    "confirmBatchDeleteDesc": "此操作将永久删除所有选中项。文件夹删除后无法撤销。",
+    "teamLastSyncTooltip": "最后同步：{{time}}",
+    "teamSyncing": "同步中…"
   },
   "git": {
     "modified": "已修改",

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -30,6 +30,8 @@ interface TeamModeState {
   p2pFileSyncStatusMap: Record<string, 'synced' | 'modified' | 'new'>
   /** True while a Git team sync is in progress (for file tree loading indicator) */
   teamGitSyncing: boolean
+  /** ISO timestamp of last successful team repo sync (read from teamclaw.json) */
+  teamGitLastSyncAt: string | null
 
   loadTeamConfig: (workspacePath: string) => Promise<void>
   applyTeamModelToOpenCode: (workspacePath: string, force?: boolean) => Promise<void>
@@ -74,6 +76,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   p2pConnected: false,
   p2pConfigured: false,
   teamGitSyncing: false,
+  teamGitLastSyncAt: null,
   p2pFileSyncStatusMap: {},
 
   loadTeamConfig: async (_workspacePath: string) => {
@@ -86,6 +89,14 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
         const { invoke } = await import('@tauri-apps/api/core')
         const ossConfig = await invoke<{ enabled?: boolean } | null>('oss_get_team_config', { workspacePath: _workspacePath })
         ossConfigured = !!ossConfig?.enabled
+      } catch { /* ignore */ }
+    }
+    // Load last sync timestamp from teamclaw.json (git mode persists it via team_sync_repo)
+    if (isTauri()) {
+      try {
+        const { invoke } = await import('@tauri-apps/api/core')
+        const teamConfig = await invoke<{ lastSyncAt?: string | null } | null>('get_team_config')
+        set({ teamGitLastSyncAt: teamConfig?.lastSyncAt ?? null })
       } catch { /* ignore */ }
     }
     const p2pActive = !!status?.active

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -1510,6 +1510,12 @@ pub async fn team_sync_repo(
         println!("[Team Sync] Warning: Failed to reload shared secrets: {}", e);
     }
 
+    // Persist last sync timestamp to teamclaw.json so the UI can display it
+    if let Ok(Some(mut cfg)) = read_team_config_from_file(&workspace_path) {
+        cfg.last_sync_at = Some(chrono::Utc::now().to_rfc3339());
+        let _ = write_team_config_to_file(&workspace_path, Some(&cfg));
+    }
+
     let sync_detail = if conflict_resolved {
         format!("Synced with origin/{} (conflict resolved, local backup in .trash/){}", branch, mcp_msg)
     } else if had_local_changes {


### PR DESCRIPTION
## Summary
- Persist `last_sync_at` in `teamclaw.json` each time `team_sync_repo` succeeds (both manual and periodic auto-sync paths).
- Load the timestamp into `useTeamModeStore.teamGitLastSyncAt` on `loadTeamConfig` and after each sync.
- Render it as a relative-time label (e.g. "Just now", "2 minutes ago") next to the `teamclaw-team` folder in the file tree. During an in-flight sync the label flips to "Syncing…".

## Test plan
- [ ] In a git-mode team workspace, confirm the team root folder shows "Just now" right after a manual sync via the Knowledge panel refresh button.
- [ ] Wait a few minutes, confirm the label transitions ("2 minutes ago", …) and its tooltip shows the full timestamp.
- [ ] While a sync is running, confirm the label reads "Syncing…" and the refresh icon spins.
- [ ] Switch to a workspace without team mode, confirm no label appears and no console errors.
- [ ] Language toggle: labels render in both `en` and `zh-CN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)