### PR TITLE
feat(team-git): color file tree by git status in managed-git mode

### DIFF
--- a/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
+++ b/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
@@ -35,6 +35,7 @@ export function KnowledgeBrowser() {
         toast.success(result.message)
         useTeamModeStore.setState({ teamGitLastSyncAt: new Date().toISOString() })
         await refreshFileTree()
+        await useTeamModeStore.getState().loadTeamGitFileSyncStatus(workspacePath!)
       } else {
         toast.error(result.message)
       }
@@ -44,7 +45,7 @@ export function KnowledgeBrowser() {
       setSyncing(false)
       useTeamModeStore.setState({ teamGitSyncing: false })
     }
-  }, [syncing, refreshFileTree])
+  }, [syncing, refreshFileTree, workspacePath])
 
   if (!workspacePath) return null
 

--- a/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
+++ b/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
@@ -35,7 +35,9 @@ export function KnowledgeBrowser() {
         toast.success(result.message)
         useTeamModeStore.setState({ teamGitLastSyncAt: new Date().toISOString() })
         await refreshFileTree()
-        await useTeamModeStore.getState().loadTeamGitFileSyncStatus(workspacePath!)
+        if (workspacePath) {
+          await useTeamModeStore.getState().loadTeamGitFileSyncStatus(workspacePath)
+        }
       } else {
         toast.error(result.message)
       }

--- a/packages/app/src/components/workspace/FileTree.tsx
+++ b/packages/app/src/components/workspace/FileTree.tsx
@@ -349,13 +349,18 @@ export function FileTree({
     return { fileGitStatusMap: fileMap, dirtyDirectories: dirtyDirs };
   }, [effectiveShowGitStatus, gitStatuses, workspacePath]);
 
-  // Pre-compute sync status data for team files (merge OSS and P2P sources)
+  // Pre-compute sync status data for team files (merge OSS, P2P, and Git sources)
   const ossFileSyncStatusMap = useTeamOssStore(s => s.fileSyncStatusMap);
   const p2pFileSyncStatusMap = useTeamModeStore(s => s.p2pFileSyncStatusMap);
+  const teamGitFileSyncStatusMap = useTeamModeStore(s => s.teamGitFileSyncStatusMap);
   const p2pConnected = useTeamModeStore(s => s.p2pConnected);
+  const teamModeType = useTeamModeStore(s => s.teamModeType);
   const teamGitSyncing = useTeamModeStore(s => s.teamGitSyncing);
   const teamGitLastSyncAt = useTeamModeStore(s => s.teamGitLastSyncAt);
-  const fileSyncStatusMap = p2pConnected ? p2pFileSyncStatusMap : ossFileSyncStatusMap;
+  const fileSyncStatusMap =
+    teamModeType === 'git' ? teamGitFileSyncStatusMap :
+    p2pConnected           ? p2pFileSyncStatusMap     :
+                             ossFileSyncStatusMap;
   const syncDirtyDirectories = useMemo(() => {
     const dirtyDirs = new Map<string, 'synced' | 'modified' | 'new'>();
     if (!workspacePath) return dirtyDirs;

--- a/packages/app/src/components/workspace/FileTreeNode.tsx
+++ b/packages/app/src/components/workspace/FileTreeNode.tsx
@@ -41,9 +41,9 @@ import {
 
 function getSyncStatusTextColor(status: 'synced' | 'modified' | 'new'): string {
   switch (status) {
-    case 'synced': return 'text-green-600'
-    case 'modified': return 'text-orange-500'
-    case 'new': return 'text-gray-400'
+    case 'synced': return ''
+    case 'modified': return 'text-yellow-500'
+    case 'new': return 'text-green-500'
   }
 }
 

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -31,7 +31,7 @@ import {
   waitForOpenCodeBootstrapped,
 } from "@/lib/opencode/preloader";
 import { getSkillDirectories, loadAllSkills } from "@/lib/git/skill-loader";
-import { appShortName } from "@/lib/build-config";
+import { appShortName, TEAM_REPO_DIR } from "@/lib/build-config";
 
 export const SKILLS_CHANGED_EVENT = "skills-files-changed";
 
@@ -416,6 +416,7 @@ export function useGitReposInit() {
                     if (r.success) {
                       const { useTeamModeStore } = await import("@/stores/team-mode");
                       useTeamModeStore.setState({ teamGitLastSyncAt: new Date().toISOString() });
+                      useTeamModeStore.getState().loadTeamGitFileSyncStatus(workspacePath);
                       console.log("[App] Team repo sync completed (MCP configs updated)");
                     } else {
                       console.warn("[App] Team repo sync skipped:", r.message);
@@ -464,6 +465,40 @@ export function useGitReposInit() {
       }
     };
   }, [workspacePath, openCodeReady]);
+
+  // Real-time: refresh team-git file status when files inside teamclaw-team/ change
+  useEffect(() => {
+    if (!workspacePath || !isTauri()) return;
+    let unlisten: (() => void) | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+
+    const teamDirPrefix = `${workspacePath}/${TEAM_REPO_DIR}/`;
+
+    import("@tauri-apps/api/event").then(({ listen }) => {
+      if (cancelled) return;
+      listen<{ path: string; kind: string }>("file-change", (event) => {
+        const path = event.payload.path.replace(/\\/g, "/");
+        if (!path.startsWith(teamDirPrefix)) return;
+        // Skip churn inside .git/
+        if (path.includes(`/${TEAM_REPO_DIR}/.git/`)) return;
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(async () => {
+          const { useTeamModeStore } = await import("@/stores/team-mode");
+          if (useTeamModeStore.getState().teamModeType !== "git") return;
+          useTeamModeStore.getState().loadTeamGitFileSyncStatus(workspacePath);
+        }, 500);
+      }).then((fn) => {
+        unlisten = fn;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      unlisten?.();
+    };
+  }, [workspacePath]);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -416,7 +416,9 @@ export function useGitReposInit() {
                     if (r.success) {
                       const { useTeamModeStore } = await import("@/stores/team-mode");
                       useTeamModeStore.setState({ teamGitLastSyncAt: new Date().toISOString() });
-                      useTeamModeStore.getState().loadTeamGitFileSyncStatus(workspacePath);
+                      if (useTeamModeStore.getState().teamModeType === "git") {
+                        useTeamModeStore.getState().loadTeamGitFileSyncStatus(workspacePath);
+                      }
                       console.log("[App] Team repo sync completed (MCP configs updated)");
                     } else {
                       console.warn("[App] Team repo sync skipped:", r.message);

--- a/packages/app/src/stores/__tests__/team-mode-git-file-status.test.ts
+++ b/packages/app/src/stores/__tests__/team-mode-git-file-status.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockInvoke = vi.fn()
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  isTauri: () => true,
+}))
+
+vi.mock('@/lib/opencode/config', () => ({
+  addCustomProviderToConfig: vi.fn(),
+  getCustomProviderConfig: vi.fn(),
+  removeCustomProviderFromConfig: vi.fn(),
+}))
+
+vi.mock('@/stores/provider', () => ({
+  useProviderStore: { getState: () => ({}) },
+}))
+
+vi.mock('@/lib/build-config', () => ({
+  appShortName: 'teamclaw',
+  TEAM_REPO_DIR: 'teamclaw-team',
+  buildConfig: { team: { llm: { models: [] }, lockLlmConfig: false } },
+}))
+
+beforeEach(() => {
+  mockInvoke.mockReset()
+})
+
+describe('loadTeamGitFileSyncStatus', () => {
+  it('maps untracked → new, modified/added/deleted/renamed/copied → modified, drops ignored', async () => {
+    mockInvoke.mockResolvedValueOnce({
+      branch: 'main',
+      clean: false,
+      files: [
+        { path: 'a.md', status: 'untracked', staged: false },
+        { path: 'b.md', status: 'modified', staged: false },
+        { path: 'c.md', status: 'added', staged: true },
+        { path: 'd.md', status: 'deleted', staged: false },
+        { path: 'e.md', status: 'renamed', staged: true },
+        { path: 'f.md', status: 'copied', staged: true },
+        { path: 'g.md', status: 'ignored', staged: false },
+        { path: 'h.md', status: 'unknown', staged: false },
+      ],
+    })
+
+    const { useTeamModeStore } = await import('@/stores/team-mode')
+    await useTeamModeStore.getState().loadTeamGitFileSyncStatus('/ws')
+
+    expect(mockInvoke).toHaveBeenCalledWith('git_status', { path: '/ws/teamclaw-team' })
+    const map = useTeamModeStore.getState().teamGitFileSyncStatusMap
+    expect(map).toEqual({
+      'a.md': 'new',
+      'b.md': 'modified',
+      'c.md': 'modified',
+      'd.md': 'modified',
+      'e.md': 'modified',
+      'f.md': 'modified',
+    })
+  })
+
+  it('swallows errors and leaves map unchanged', async () => {
+    const { useTeamModeStore } = await import('@/stores/team-mode')
+    useTeamModeStore.setState({ teamGitFileSyncStatusMap: { 'x.md': 'modified' } })
+
+    mockInvoke.mockRejectedValueOnce(new Error('no .git'))
+
+    await expect(
+      useTeamModeStore.getState().loadTeamGitFileSyncStatus('/ws')
+    ).resolves.toBeUndefined()
+
+    expect(useTeamModeStore.getState().teamGitFileSyncStatusMap).toEqual({ 'x.md': 'modified' })
+  })
+
+  it('clearTeamMode resets teamGitFileSyncStatusMap', async () => {
+    const { useTeamModeStore } = await import('@/stores/team-mode')
+    useTeamModeStore.setState({ teamGitFileSyncStatusMap: { 'x.md': 'modified' } })
+    await useTeamModeStore.getState().clearTeamMode()
+    expect(useTeamModeStore.getState().teamGitFileSyncStatusMap).toEqual({})
+  })
+})

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -6,7 +6,7 @@ import {
 } from '@/lib/opencode/config'
 import { useProviderStore } from './provider'
 import { isTauri } from '@/lib/utils'
-import { appShortName, buildConfig, type TeamModelOption } from '@/lib/build-config'
+import { appShortName, buildConfig, TEAM_REPO_DIR, type TeamModelOption } from '@/lib/build-config'
 
 
 const TEAM_PROVIDER_ID = 'team'
@@ -28,6 +28,7 @@ interface TeamModeState {
   p2pConnected: boolean
   p2pConfigured: boolean
   p2pFileSyncStatusMap: Record<string, 'synced' | 'modified' | 'new'>
+  teamGitFileSyncStatusMap: Record<string, 'modified' | 'new'>
   /** True while a Git team sync is in progress (for file tree loading indicator) */
   teamGitSyncing: boolean
   /** ISO timestamp of last successful team repo sync (read from teamclaw.json) */
@@ -39,6 +40,7 @@ interface TeamModeState {
   clearTeamMode: (workspacePath?: string) => Promise<void>
   setDevUnlocked: (unlocked: boolean) => void
   loadP2pFileSyncStatus: () => Promise<void>
+  loadTeamGitFileSyncStatus: (workspacePath: string) => Promise<void>
 }
 
 interface TeamStatusLlm extends TeamModelConfig {
@@ -78,6 +80,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   teamGitSyncing: false,
   teamGitLastSyncAt: null,
   p2pFileSyncStatusMap: {},
+  teamGitFileSyncStatusMap: {},
 
   loadTeamConfig: async (_workspacePath: string) => {
     // teamMode = p2p.enabled || ossConfigured
@@ -104,6 +107,10 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
 
     if (isTeamMode) {
       set({ teamMode: true, teamModeType: status?.mode ?? (ossConfigured ? 'oss' : null) })
+      if ((status?.mode ?? (ossConfigured ? 'oss' : null)) === 'git' && _workspacePath) {
+        // Fire-and-forget; errors swallowed inside action
+        get().loadTeamGitFileSyncStatus(_workspacePath)
+      }
       if (status?.llm) {
         // Use models from team config (stored in teamclaw.json), fallback to build config
         const teamModels = status.llm.models && status.llm.models.length > 0
@@ -284,12 +291,42 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
     }
   },
 
+  loadTeamGitFileSyncStatus: async (workspacePath: string) => {
+    if (!isTauri() || !workspacePath) return
+    try {
+      const { invoke } = await import('@tauri-apps/api/core')
+      const result = await invoke<{
+        branch: string | null
+        clean: boolean
+        files: Array<{ path: string; status: string; staged: boolean }>
+      }>('git_status', { path: `${workspacePath}/${TEAM_REPO_DIR}` })
+      const map: Record<string, 'modified' | 'new'> = {}
+      for (const f of result.files) {
+        if (f.status === 'untracked') {
+          map[f.path] = 'new'
+        } else if (
+          f.status === 'modified' ||
+          f.status === 'added' ||
+          f.status === 'deleted' ||
+          f.status === 'renamed' ||
+          f.status === 'copied'
+        ) {
+          map[f.path] = 'modified'
+        }
+        // 'ignored' and 'unknown' are omitted
+      }
+      set({ teamGitFileSyncStatusMap: map })
+    } catch (e) {
+      console.debug('[team-mode] loadTeamGitFileSyncStatus skipped:', e)
+    }
+  },
+
   clearTeamMode: async (workspacePath?: string) => {
     // When LLM config is locked via build config, prevent exiting team mode
     if (buildConfig.team.lockLlmConfig) return
 
     // Set state immediately to trigger UI updates
-    set({ teamMode: false, teamModeType: null, teamModelConfig: null, _appliedConfigKey: null, p2pFileSyncStatusMap: {} })
+    set({ teamMode: false, teamModeType: null, teamModelConfig: null, _appliedConfigKey: null, p2pFileSyncStatusMap: {}, teamGitFileSyncStatusMap: {} })
 
     // Remove team provider from opencode.json
     if (workspacePath) {


### PR DESCRIPTION
## Summary
- In managed-git team mode, color files in `teamclaw-team/` by working-tree git status: **modified → yellow**, **untracked → green**, **synced → neutral** (unified across OSS / P2P / git modes).
- Reuses the existing `git_status` Tauri command — zero backend changes.
- Refresh triggers: on git-mode detection (`loadTeamConfig`), after every `team_sync_repo` (manual + periodic), and a 500 ms-debounced file-change listener in `useAppInit` scoped to the team dir (skipping `.git/` churn). Auto-sync path guards on `teamModeType === 'git'` to avoid useless IPC on OSS/P2P workspaces.
- Store: new `teamGitFileSyncStatusMap` + `loadTeamGitFileSyncStatus` action on `useTeamModeStore`, mirroring the existing `p2pFileSyncStatusMap` pattern. Reset in `clearTeamMode`.

Spec: `docs/superpowers/specs/2026-04-17-team-git-file-status-coloring-design.md`
Plan: `docs/superpowers/plans/2026-04-17-team-git-file-status-coloring.md`

## Test plan
- [ ] In a git-mode team workspace: edit a file in `teamclaw-team/knowledge/` → within ~500 ms the row turns yellow and parent folders show the modified indicator.
- [ ] Create a new file under `teamclaw-team/` → turns green.
- [ ] Trigger `team_sync_repo` (sync button or 5-min auto) → after pull/commit, affected rows revert to neutral.
- [ ] OSS mode regression: `synced` rows render neutral (no green), `modified` → yellow, `new` → green.
- [ ] Non-team workspace: tree renders uncolored, no console errors, `loadTeamGitFileSyncStatus` never called.
- [ ] Workspace switch: listener teardown + state reset verified (no leak of previous workspace's map).

## Known follow-ups (not blocking)
- Rust `git_status` parses `R` (renamed) porcelain lines as `"new -> old"`, so renamed files won't match their tree row. Rare in team repos; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)