### PR TITLE
feat: team skill usage leaderboard (+ fix leaderboard sync on OSS/git)

### DIFF
--- a/packages/app/src/components/settings/LeaderboardSection.tsx
+++ b/packages/app/src/components/settings/LeaderboardSection.tsx
@@ -212,6 +212,11 @@ export function LeaderboardSection() {
     }))
   }, [leaderboard, aggregateWorkspaceStats])
 
+  const topSkills = React.useMemo(
+    () => (leaderboard ? computeTopSkills(leaderboard, 10) : []),
+    [leaderboard],
+  )
+
   const teamSummary = React.useMemo(() => {
     const totalTokens = memberStats.reduce((sum, m) => sum + (m.totalTokens ?? 0), 0)
     const totalFeedbacks = memberStats.reduce((sum, m) => sum + (m.totalFeedbacks ?? 0), 0)
@@ -403,6 +408,35 @@ export function LeaderboardSection() {
               )
             })}
           </div>
+
+          {/* Top skills this team */}
+          {topSkills.length > 0 && (
+            <div className="rounded-xl border bg-card overflow-hidden">
+              <div className="flex items-center gap-2 px-4 py-2.5 bg-muted/30 border-b">
+                <Sparkles className="h-3.5 w-3.5 text-violet-500" />
+                <span className="text-xs font-medium">
+                  {t('settings.leaderboard.topSkills', 'Top Skills This Team')}
+                </span>
+              </div>
+              {topSkills.map((skill, idx) => (
+                <div
+                  key={skill.name}
+                  className="grid grid-cols-[40px_1fr_100px_120px] items-center gap-2 px-4 py-2.5 border-b last:border-b-0"
+                >
+                  <span className="text-xs text-muted-foreground font-medium tabular-nums text-center">
+                    {idx + 1}
+                  </span>
+                  <span className="text-sm truncate">{skill.name}</span>
+                  <span className="text-xs text-right tabular-nums">
+                    {skill.count} {t('settings.leaderboard.calls', 'calls')}
+                  </span>
+                  <span className="text-xs text-right text-muted-foreground tabular-nums">
+                    {t('settings.leaderboard.usedBy', { n: skill.userCount, defaultValue: '{{n}} members' })}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
         </>
       )}
     </div>

--- a/packages/app/src/components/settings/LeaderboardSection.tsx
+++ b/packages/app/src/components/settings/LeaderboardSection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Trophy, Flame, MessageSquareHeart, RefreshCw, Loader2 } from 'lucide-react'
+import { Trophy, Flame, MessageSquareHeart, Sparkles, RefreshCw, Loader2 } from 'lucide-react'
 import { cn, isTauri } from '@/lib/utils'
 import { TEAM_SYNCED_EVENT } from '@/lib/build-config'
 import { buildSharedRankMap } from '@/lib/team-leaderboard-ranks'
@@ -295,11 +295,12 @@ export function LeaderboardSection() {
         <>
           <div className="rounded-xl border bg-card overflow-hidden">
             {/* Table header */}
-            <div className="grid grid-cols-[40px_1fr_80px_100px_120px] items-center gap-2 px-4 py-2.5 bg-muted/30 border-b text-[11px] font-medium text-muted-foreground">
+            <div className="grid grid-cols-[40px_1fr_72px_72px_72px_112px] items-center gap-2 px-4 py-2.5 bg-muted/30 border-b text-[11px] font-medium text-muted-foreground">
               <span className="text-center">{t('settings.leaderboard.rank', '#')}</span>
               <span>{t('settings.leaderboard.member', 'Member')}</span>
               <span className="text-center">{t('settings.leaderboard.tokenRank', 'Token Rank')}</span>
               <span className="text-center">{t('settings.leaderboard.feedbackRank', 'Feedback Rank')}</span>
+              <span className="text-center">{t('settings.leaderboard.skillRank', 'Skill Rank')}</span>
               <span className="text-right">{t('settings.leaderboard.totalTokens', 'Total Tokens')}</span>
             </div>
 
@@ -317,7 +318,7 @@ export function LeaderboardSection() {
                   <div
                     key={member.name}
                     className={cn(
-                      "grid grid-cols-[40px_1fr_80px_100px_120px] items-center gap-2 px-4 py-2.5 border-b last:border-b-0 transition-colors",
+                      "grid grid-cols-[40px_1fr_72px_72px_72px_112px] items-center gap-2 px-4 py-2.5 border-b last:border-b-0 transition-colors",
                       member.isCurrentUser
                         ? "bg-indigo-500/[0.06]"
                         : "hover:bg-muted/30"
@@ -367,6 +368,9 @@ export function LeaderboardSection() {
                     {/* Feedback Rank */}
                     <RankCell rank={member.feedbackRank} />
 
+                    {/* Skill Rank */}
+                    <RankCell rank={member.skillRank} />
+
                     {/* Total Tokens */}
                     <div className="text-right">
                       <span className="text-sm font-medium tabular-nums">
@@ -374,6 +378,8 @@ export function LeaderboardSection() {
                       </span>
                       <div className="text-[10px] text-muted-foreground">
                         {member.totalFeedbacks} {t('settings.leaderboard.feedbacks', 'feedbacks')}
+                        {' · '}
+                        {t('settings.leaderboard.totalSkills', { count: member.totalSkillInvocations, defaultValue: '{{count}} skills' })}
                       </div>
                     </div>
                   </div>
@@ -386,6 +392,7 @@ export function LeaderboardSection() {
             {[
               { key: 'token', label: t('settings.leaderboard.tokenUsage', 'Token Usage'), icon: Flame, color: 'text-amber-500' },
               { key: 'feedback', label: t('settings.leaderboard.feedbackCount', 'Feedback Count'), icon: MessageSquareHeart, color: 'text-pink-500' },
+              { key: 'skill', label: t('settings.leaderboard.skillInvocations', 'Skill Invocations'), icon: Sparkles, color: 'text-violet-500' },
             ].map((col) => {
               const Icon = col.icon
               return (

--- a/packages/app/src/components/settings/LeaderboardSection.tsx
+++ b/packages/app/src/components/settings/LeaderboardSection.tsx
@@ -29,16 +29,17 @@ function formatTokens(tokens: number | undefined | null): string {
 
 // ── Types ──────────────────────────────────────────────────────────
 
-interface LeaderboardStats {
+export interface LeaderboardStats {
   totalFeedbacks: number
   positiveCount: number
   negativeCount: number
   totalTokens: number
   totalCost: number
   sessionCount: number
+  skillUsage?: Record<string, number>
 }
 
-interface MemberLeaderboardExport {
+export interface MemberLeaderboardExport {
   memberId: string
   memberName: string
   exportedAt: string
@@ -46,7 +47,7 @@ interface MemberLeaderboardExport {
   workspaces: Record<string, LeaderboardStats>  // workspace path -> stats
 }
 
-interface TeamLeaderboard {
+export interface TeamLeaderboard {
   members: MemberLeaderboardExport[]
 }
 
@@ -56,10 +57,12 @@ interface MemberStats {
   overallScore: number
   tokenRank: number
   feedbackRank: number
+  skillRank: number
   totalTokens: number
   totalFeedbacks: number
   totalCost: number
   sessionCount: number
+  totalSkillInvocations: number
   isCurrentUser?: boolean
 }
 
@@ -135,15 +138,19 @@ export function LeaderboardSection() {
       totalFeedbacks: 0,
       totalCost: 0,
       sessionCount: 0,
+      totalSkillInvocations: 0,
     }
-    
+
     Object.values(workspaces || {}).forEach(stats => {
       total.totalTokens += stats.totalTokens || 0
       total.totalFeedbacks += stats.totalFeedbacks || 0
       total.totalCost += stats.totalCost || 0
       total.sessionCount += stats.sessionCount || 0
+      for (const n of Object.values(stats.skillUsage || {})) {
+        total.totalSkillInvocations += n
+      }
     })
-    
+
     return total
   }, [])
 
@@ -167,10 +174,18 @@ export function LeaderboardSection() {
       getKey: (member) => member.memberName,
       getScore: (member) => member.aggregated.totalFeedbacks,
     })
+    const skillRanks = buildSharedRankMap({
+      items: membersWithAggregated,
+      getKey: (member) => member.memberName,
+      getScore: (member) => member.aggregated.totalSkillInvocations,
+    })
 
     const overallScores = membersWithAggregated.map((member) => ({
       memberName: member.memberName,
-      overallScore: ((tokenRanks.get(member.memberName) ?? 0) + (feedbackRanks.get(member.memberName) ?? 0)) / 2,
+      overallScore:
+        ((tokenRanks.get(member.memberName) ?? 0) +
+          (feedbackRanks.get(member.memberName) ?? 0) +
+          (skillRanks.get(member.memberName) ?? 0)) / 3,
     }))
     const overallScoreMap = new Map(
       overallScores.map((member) => [member.memberName, member.overallScore])
@@ -188,10 +203,12 @@ export function LeaderboardSection() {
       overallScore: overallScoreMap.get(member.memberName) ?? 0,
       tokenRank: tokenRanks.get(member.memberName) ?? 0,
       feedbackRank: feedbackRanks.get(member.memberName) ?? 0,
+      skillRank: skillRanks.get(member.memberName) ?? 0,
       totalTokens: member.aggregated.totalTokens,
       totalFeedbacks: member.aggregated.totalFeedbacks,
       totalCost: member.aggregated.totalCost,
       sessionCount: member.aggregated.sessionCount,
+      totalSkillInvocations: member.aggregated.totalSkillInvocations,
     }))
   }, [leaderboard, aggregateWorkspaceStats])
 
@@ -383,6 +400,29 @@ export function LeaderboardSection() {
       )}
     </div>
   )
+}
+
+// ── Pure helpers ────────────────────────────────────────────────────────
+
+export function computeTopSkills(
+  leaderboard: TeamLeaderboard,
+  limit: number,
+): Array<{ name: string; count: number; userCount: number }> {
+  const totals = new Map<string, { count: number; users: Set<string> }>()
+  for (const member of leaderboard.members || []) {
+    for (const ws of Object.values(member.workspaces || {})) {
+      for (const [name, n] of Object.entries(ws.skillUsage || {})) {
+        const entry = totals.get(name) ?? { count: 0, users: new Set<string>() }
+        entry.count += n
+        entry.users.add(member.memberName)
+        totals.set(name, entry)
+      }
+    }
+  }
+  return [...totals.entries()]
+    .map(([name, { count, users }]) => ({ name, count, userCount: users.size }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    .slice(0, limit)
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────

--- a/packages/app/src/components/settings/__tests__/LeaderboardSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/LeaderboardSection.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { computeTopSkills } from '../LeaderboardSection'
+import type { TeamLeaderboard } from '../LeaderboardSection'
+
+describe('computeTopSkills', () => {
+  it('aggregates skill counts across all members and workspaces, sorted desc', () => {
+    const leaderboard: TeamLeaderboard = {
+      members: [
+        {
+          memberId: 'a',
+          memberName: 'Alice',
+          exportedAt: '',
+          updateAt: '',
+          workspaces: {
+            '/w1': {
+              totalFeedbacks: 0, positiveCount: 0, negativeCount: 0,
+              totalTokens: 0, totalCost: 0, sessionCount: 0,
+              skillUsage: { 'sentry-fix': 10, 'fc-deploy': 5 },
+            },
+            '/w2': {
+              totalFeedbacks: 0, positiveCount: 0, negativeCount: 0,
+              totalTokens: 0, totalCost: 0, sessionCount: 0,
+              skillUsage: { 'sentry-fix': 3 },
+            },
+          },
+        },
+        {
+          memberId: 'b',
+          memberName: 'Bob',
+          exportedAt: '',
+          updateAt: '',
+          workspaces: {
+            '/w1': {
+              totalFeedbacks: 0, positiveCount: 0, negativeCount: 0,
+              totalTokens: 0, totalCost: 0, sessionCount: 0,
+              skillUsage: { 'fc-deploy': 7 },
+            },
+          },
+        },
+      ],
+    }
+
+    const top = computeTopSkills(leaderboard, 10)
+    expect(top).toEqual([
+      { name: 'sentry-fix', count: 13, userCount: 1 },
+      { name: 'fc-deploy', count: 12, userCount: 2 },
+    ])
+  })
+
+  it('returns empty array when no skills are used', () => {
+    expect(computeTopSkills({ members: [] }, 10)).toEqual([])
+  })
+
+  it('caps at the limit', () => {
+    const members = Array.from({ length: 15 }, (_, i) => ({
+      memberId: `m${i}`,
+      memberName: `M${i}`,
+      exportedAt: '', updateAt: '',
+      workspaces: {
+        '/w': {
+          totalFeedbacks: 0, positiveCount: 0, negativeCount: 0,
+          totalTokens: 0, totalCost: 0, sessionCount: 0,
+          skillUsage: { [`skill-${i}`]: i + 1 },
+        },
+      },
+    }))
+    const top = computeTopSkills({ members }, 10)
+    expect(top).toHaveLength(10)
+  })
+})

--- a/packages/app/src/lib/local-stats/types.ts
+++ b/packages/app/src/lib/local-stats/types.ts
@@ -15,6 +15,7 @@ export interface LocalStats {
   sessions: SessionStats     // Session statistics
   lastUpdated: string        // ISO 8601 timestamp
   createdAt: string          // ISO 8601 timestamp
+  skillUsage: Record<string, number>  // Skill usage count by skill name
 }
 
 export interface StarRatings {
@@ -40,6 +41,7 @@ export interface LocalStatsUpdate {
   starRating?: 1 | 2 | 3 | 4 | 5
   sessionsTotal?: number
   sessionsWithFeedback?: number
+  skillInvoked?: string
 }
 
 export type FeedbackRating = 'positive' | 'negative'

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1689,7 +1689,14 @@
       "feedbackCount": "Feedback Count",
       "teamRanking": "Team Ranking",
       "clickToView": "Click to view",
-      "you": "You"
+      "you": "You",
+      "skillRank": "Skill Rank",
+      "skillInvocations": "Skill Invocations",
+      "totalSkills_one": "{{count}} skill",
+      "totalSkills_other": "{{count}} skills",
+      "topSkills": "Top Skills This Team",
+      "calls": "calls",
+      "usedBy": "{{n}} members"
     }
   },
   "skillssh": {

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1710,7 +1710,13 @@
       "feedbackCount": "反馈数",
       "teamRanking": "团队排名",
       "clickToView": "点击查看",
-      "you": "你"
+      "you": "你",
+      "skillRank": "Skill 排名",
+      "skillInvocations": "Skill 调用",
+      "totalSkills_other": "{{count}} 次 skill",
+      "topSkills": "团队最常用 Skills",
+      "calls": "次",
+      "usedBy": "{{n}} 人用过"
     }
   },
   "skillssh": {

--- a/packages/app/src/stores/__tests__/local-stats-skills.test.ts
+++ b/packages/app/src/stores/__tests__/local-stats-skills.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const invokeMock = vi.fn()
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  isTauri: () => true,
+}))
+
+vi.mock('../telemetry', () => ({
+  triggerTeamLeaderboardExport: vi.fn(),
+}))
+
+describe('incrementSkillUsage', () => {
+  beforeEach(() => {
+    invokeMock.mockReset()
+    invokeMock.mockResolvedValue({
+      version: '1.0.0',
+      taskCompleted: 0,
+      totalTokens: 0,
+      totalCost: 0,
+      feedbackCount: 0,
+      positiveCount: 0,
+      negativeCount: 0,
+      starRatings: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
+      sessions: { total: 0, withFeedback: 0 },
+      lastUpdated: 'x',
+      createdAt: 'x',
+      skillUsage: { 'sentry-fix': 1 },
+    })
+  })
+
+  it('calls update_local_stats with skillInvoked set to the given name', async () => {
+    const { useLocalStatsStore } = await import('../local-stats')
+
+    await useLocalStatsStore.getState().incrementSkillUsage('/w', 'sentry-fix')
+
+    expect(invokeMock).toHaveBeenCalledWith('update_local_stats', {
+      workspacePath: '/w',
+      updates: { skillInvoked: 'sentry-fix' },
+    })
+  })
+
+  it('skips empty skill name', async () => {
+    const { useLocalStatsStore } = await import('../local-stats')
+
+    await useLocalStatsStore.getState().incrementSkillUsage('/w', '')
+
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+
+  it('skips empty workspace path', async () => {
+    const { useLocalStatsStore } = await import('../local-stats')
+
+    await useLocalStatsStore.getState().incrementSkillUsage('', 'foo')
+
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/stores/local-stats.ts
+++ b/packages/app/src/stores/local-stats.ts
@@ -28,6 +28,7 @@ interface LocalStatsStore {
   incrementFeedback: (workspacePath: string, rating: FeedbackRating) => Promise<void>
   addStarRating: (workspacePath: string, rating: StarRating) => Promise<void>
   incrementSessionCount: (workspacePath: string, hasFeedback?: boolean) => Promise<void>
+  incrementSkillUsage: (workspacePath: string, skillName: string) => Promise<void>
   resetStats: (workspacePath: string) => Promise<void>
   
   // Internal
@@ -120,6 +121,17 @@ export const useLocalStatsStore = create<LocalStatsStore>((set, get) => ({
     }
   },
   
+  incrementSkillUsage: async (workspacePath: string, skillName: string) => {
+    if (!isTauri() || !workspacePath || !skillName) return
+
+    try {
+      await get()._updateStats(workspacePath, { skillInvoked: skillName })
+      console.log(`[LocalStats] Incremented skill usage: ${skillName}`)
+    } catch (err) {
+      console.error('[LocalStats] Failed to increment skill usage:', err)
+    }
+  },
+
   resetStats: async (workspacePath: string) => {
     if (!isTauri() || !workspacePath) return
     

--- a/packages/app/src/stores/local-stats.ts
+++ b/packages/app/src/stores/local-stats.ts
@@ -126,7 +126,6 @@ export const useLocalStatsStore = create<LocalStatsStore>((set, get) => ({
 
     try {
       await get()._updateStats(workspacePath, { skillInvoked: skillName })
-      console.debug(`[LocalStats] Incremented skill usage: ${skillName}`)
     } catch (err) {
       console.error('[LocalStats] Failed to increment skill usage:', err)
     }

--- a/packages/app/src/stores/local-stats.ts
+++ b/packages/app/src/stores/local-stats.ts
@@ -126,7 +126,7 @@ export const useLocalStatsStore = create<LocalStatsStore>((set, get) => ({
 
     try {
       await get()._updateStats(workspacePath, { skillInvoked: skillName })
-      console.log(`[LocalStats] Incremented skill usage: ${skillName}`)
+      console.debug(`[LocalStats] Incremented skill usage: ${skillName}`)
     } catch (err) {
       console.error('[LocalStats] Failed to increment skill usage:', err)
     }

--- a/packages/app/src/stores/session-sse-message-handlers.ts
+++ b/packages/app/src/stores/session-sse-message-handlers.ts
@@ -26,6 +26,8 @@ import {
 } from "@/stores/streaming";
 import { insertMessageSorted } from "@/lib/insert-message-sorted";
 import type { MessagePart, Message } from "./session-types";
+import { useLocalStatsStore } from '@/stores/local-stats';
+import { useWorkspaceStore } from '@/stores/workspace';
 
 type SessionSet = (fn: ((state: SessionState) => Partial<SessionState>) | Partial<SessionState>) => void;
 type SessionGet = () => SessionState;
@@ -286,6 +288,24 @@ export function createMessageHandlers(set: SessionSet, get: SessionGet) {
               startTime: new Date(),
             },
           ];
+
+          // Skill usage telemetry — fire-and-forget, never blocks streaming.
+          const tname = event.tool.name?.toLowerCase();
+          if (tname === "skill" || tname === "role_skill") {
+            const input = event.tool.input as
+              | { skill?: unknown; skill_name?: unknown; name?: unknown }
+              | undefined;
+            const rawName =
+              input?.skill ?? input?.skill_name ?? input?.name;
+            const skillName =
+              typeof rawName === "string" ? rawName : undefined;
+            const workspacePath = useWorkspaceStore.getState().workspacePath;
+            if (skillName && workspacePath) {
+              void useLocalStatsStore
+                .getState()
+                .incrementSkillUsage(workspacePath, skillName);
+            }
+          }
         }
       }
 

--- a/packages/app/src/stores/session-sse-message-handlers.ts
+++ b/packages/app/src/stores/session-sse-message-handlers.ts
@@ -26,9 +26,6 @@ import {
 } from "@/stores/streaming";
 import { insertMessageSorted } from "@/lib/insert-message-sorted";
 import type { MessagePart, Message } from "./session-types";
-import { useLocalStatsStore } from '@/stores/local-stats';
-import { useWorkspaceStore } from '@/stores/workspace';
-
 type SessionSet = (fn: ((state: SessionState) => Partial<SessionState>) | Partial<SessionState>) => void;
 type SessionGet = () => SessionState;
 
@@ -288,24 +285,6 @@ export function createMessageHandlers(set: SessionSet, get: SessionGet) {
               startTime: new Date(),
             },
           ];
-
-          // Skill usage telemetry — fire-and-forget, never blocks streaming.
-          const tname = event.tool.name?.toLowerCase();
-          if (tname === "skill" || tname === "role_skill") {
-            const input = event.tool.input as
-              | { skill?: unknown; skill_name?: unknown; name?: unknown }
-              | undefined;
-            const rawName =
-              input?.skill ?? input?.skill_name ?? input?.name;
-            const skillName =
-              typeof rawName === "string" ? rawName : undefined;
-            const workspacePath = useWorkspaceStore.getState().workspacePath;
-            if (skillName && workspacePath) {
-              void useLocalStatsStore
-                .getState()
-                .incrementSkillUsage(workspacePath, skillName);
-            }
-          }
         }
       }
 

--- a/packages/app/src/stores/session-sse-tool-handlers.ts
+++ b/packages/app/src/stores/session-sse-tool-handlers.ts
@@ -37,6 +37,19 @@ import {
 type SessionSet = (fn: ((state: SessionState) => Partial<SessionState>) | Partial<SessionState>) => void;
 type SessionGet = () => SessionState;
 
+// Tracks toolCallIds already counted for skill telemetry so a single invocation
+// is counted exactly once, even though handleToolExecuting fires multiple times
+// (status: running → completed, and the first event often has empty args).
+const countedSkillToolCalls = new Set<string>();
+
+// Cap the set so it can't grow unbounded in a long-lived session.
+function markSkillCounted(toolCallId: string) {
+  if (countedSkillToolCalls.size > 10_000) {
+    countedSkillToolCalls.clear();
+  }
+  countedSkillToolCalls.add(toolCallId);
+}
+
 export function createToolHandlers(set: SessionSet, get: SessionGet) {
   return {
     handleToolExecuting: (event: ToolExecutingEvent) => {
@@ -278,44 +291,6 @@ export function createToolHandlers(set: SessionSet, get: SessionGet) {
             ...m,
             toolCalls: [...(m.toolCalls || []), newToolCall],
           };
-
-          // Skill usage telemetry — fire-and-forget, never blocks streaming.
-          // Fires once per tool invocation (we're in the "new tool call" branch).
-          if (toolNameLower === "skill" || toolNameLower === "role_skill") {
-            const args = event.arguments as
-              | { name?: unknown; skill?: unknown; skill_name?: unknown }
-              | undefined;
-            const rawName =
-              args?.name ?? args?.skill ?? args?.skill_name;
-            const skillName =
-              typeof rawName === "string" ? rawName : undefined;
-            const workspacePath = useWorkspaceStore.getState().workspacePath;
-            console.debug("[SkillTelemetry] detected", {
-              toolName: event.toolName,
-              args: event.arguments,
-              skillName,
-              workspacePath,
-            });
-            if (skillName && workspacePath) {
-              void useLocalStatsStore
-                .getState()
-                .incrementSkillUsage(workspacePath, skillName);
-            } else {
-              console.warn("[SkillTelemetry] skipped — missing skillName or workspace", {
-                skillName,
-                workspacePath,
-              });
-            }
-          } else if (
-            event.toolName &&
-            event.toolName.toLowerCase().includes("skill")
-          ) {
-            // Unexpected skill-ish tool name — log so we can add it to the matcher.
-            console.warn("[SkillTelemetry] skill-looking tool not matched", {
-              toolName: event.toolName,
-              args: event.arguments,
-            });
-          }
         }
 
         const messages = [...session.messages];
@@ -330,6 +305,31 @@ export function createToolHandlers(set: SessionSet, get: SessionGet) {
           ),
         };
       });
+
+      // Skill usage telemetry — fire-and-forget, never blocks streaming.
+      // handleToolExecuting fires multiple times per tool (running → completed);
+      // the first fire often has empty args, a later fire carries the name.
+      // We fire as soon as the name is populated and dedupe by toolCallId so
+      // each invocation is counted exactly once, regardless of final status.
+      if (
+        (toolNameLower === "skill" || toolNameLower === "role_skill") &&
+        !countedSkillToolCalls.has(event.toolCallId)
+      ) {
+        const args = event.arguments as
+          | { name?: unknown; skill?: unknown; skill_name?: unknown }
+          | undefined;
+        const rawName = args?.name ?? args?.skill ?? args?.skill_name;
+        const skillName = typeof rawName === "string" ? rawName : undefined;
+        if (skillName) {
+          const workspacePath = useWorkspaceStore.getState().workspacePath;
+          if (workspacePath) {
+            markSkillCounted(event.toolCallId);
+            void useLocalStatsStore
+              .getState()
+              .incrementSkillUsage(workspacePath, skillName);
+          }
+        }
+      }
     },
 
     forceCompleteToolCall: (toolCallId: string) => {

--- a/packages/app/src/stores/session-sse-tool-handlers.ts
+++ b/packages/app/src/stores/session-sse-tool-handlers.ts
@@ -22,6 +22,8 @@ import {
 import {
   useStreamingStore,
 } from "@/stores/streaming";
+import { useLocalStatsStore } from "@/stores/local-stats";
+import { useWorkspaceStore } from "@/stores/workspace";
 import { sessionDataCache } from "./session-data-cache";
 import {
   buildTerminalInputQuestion,
@@ -276,6 +278,24 @@ export function createToolHandlers(set: SessionSet, get: SessionGet) {
             ...m,
             toolCalls: [...(m.toolCalls || []), newToolCall],
           };
+
+          // Skill usage telemetry — fire-and-forget, never blocks streaming.
+          // Fires once per tool invocation (we're in the "new tool call" branch).
+          if (toolNameLower === "skill" || toolNameLower === "role_skill") {
+            const args = event.arguments as
+              | { name?: unknown; skill?: unknown; skill_name?: unknown }
+              | undefined;
+            const rawName =
+              args?.name ?? args?.skill ?? args?.skill_name;
+            const skillName =
+              typeof rawName === "string" ? rawName : undefined;
+            const workspacePath = useWorkspaceStore.getState().workspacePath;
+            if (skillName && workspacePath) {
+              void useLocalStatsStore
+                .getState()
+                .incrementSkillUsage(workspacePath, skillName);
+            }
+          }
         }
 
         const messages = [...session.messages];

--- a/packages/app/src/stores/session-sse-tool-handlers.ts
+++ b/packages/app/src/stores/session-sse-tool-handlers.ts
@@ -290,11 +290,31 @@ export function createToolHandlers(set: SessionSet, get: SessionGet) {
             const skillName =
               typeof rawName === "string" ? rawName : undefined;
             const workspacePath = useWorkspaceStore.getState().workspacePath;
+            console.debug("[SkillTelemetry] detected", {
+              toolName: event.toolName,
+              args: event.arguments,
+              skillName,
+              workspacePath,
+            });
             if (skillName && workspacePath) {
               void useLocalStatsStore
                 .getState()
                 .incrementSkillUsage(workspacePath, skillName);
+            } else {
+              console.warn("[SkillTelemetry] skipped — missing skillName or workspace", {
+                skillName,
+                workspacePath,
+              });
             }
+          } else if (
+            event.toolName &&
+            event.toolName.toLowerCase().includes("skill")
+          ) {
+            // Unexpected skill-ish tool name — log so we can add it to the matcher.
+            console.warn("[SkillTelemetry] skill-looking tool not matched", {
+              toolName: event.toolName,
+              args: event.arguments,
+            });
           }
         }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -11769,6 +11769,7 @@ dependencies = [
  "keyring",
  "libsql",
  "log",
+ "loro",
  "markitdown",
  "md5",
  "minisign-verify",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -132,6 +132,7 @@ objc2-web-kit = { version = "0.3", features = ["WKWebViewConfiguration", "WKWebV
 
 [dev-dependencies]
 wiremock = "0.5"
+loro = "1"
 
 [profile.release]
 # Use unwind so catch_unwind in email.rs and deps (e.g. html2md) work; abort would conflict.

--- a/src-tauri/crates/teamclaw-sync/src/oss_sync.rs
+++ b/src-tauri/crates/teamclaw-sync/src/oss_sync.rs
@@ -1007,18 +1007,24 @@ impl OssSyncManager {
                 let name = entry.file_name();
                 let name_str = name.to_string_lossy();
 
-                // Skip hidden files/dirs (but allow .gitignore)
-                if name_str.starts_with('.') && name_str != ".gitignore" {
-                    continue;
-                }
-
                 if path.is_dir() {
-                    // Check gitignore for directories
-                    if gitignore.matched(&path, true).is_ignore() {
+                    // Skip hidden dirs unless explicitly whitelisted in .gitignore
+                    // (.gitignore itself is a special file, not a dir, so no special case needed here)
+                    if name_str.starts_with('.') {
+                        if !gitignore.matched(&path, true).is_whitelist() {
+                            continue;
+                        }
+                    } else if gitignore.matched(&path, true).is_ignore() {
                         continue;
                     }
                     walk(base, &path, gitignore, result, skipped)?;
                 } else {
+                    // Skip hidden files unless explicitly whitelisted (.gitignore is always included)
+                    if name_str.starts_with('.') && name_str != ".gitignore" {
+                        if !gitignore.matched(&path, false).is_whitelist() {
+                            continue;
+                        }
+                    }
                     // Check gitignore for files
                     if gitignore.matched(&path, false).is_ignore() {
                         continue;
@@ -1108,17 +1114,23 @@ impl OssSyncManager {
                 let name = entry.file_name();
                 let name_str = name.to_string_lossy();
 
-                // Skip hidden files/dirs (but allow .gitignore)
-                if name_str.starts_with('.') && name_str != ".gitignore" {
-                    continue;
-                }
-
                 if path.is_dir() {
-                    if gitignore.matched(&path, true).is_ignore() {
+                    // Skip hidden dirs unless explicitly whitelisted in .gitignore
+                    if name_str.starts_with('.') {
+                        if !gitignore.matched(&path, true).is_whitelist() {
+                            continue;
+                        }
+                    } else if gitignore.matched(&path, true).is_ignore() {
                         continue;
                     }
                     walk_incremental(base, &path, since, gitignore, result, skipped)?;
                 } else {
+                    // Skip hidden files unless explicitly whitelisted (.gitignore is always included)
+                    if name_str.starts_with('.') && name_str != ".gitignore" {
+                        if !gitignore.matched(&path, false).is_whitelist() {
+                            continue;
+                        }
+                    }
                     if gitignore.matched(&path, false).is_ignore() {
                         continue;
                     }

--- a/src-tauri/crates/teamclaw-sync/src/oss_sync.rs
+++ b/src-tauri/crates/teamclaw-sync/src/oss_sync.rs
@@ -1019,14 +1019,14 @@ impl OssSyncManager {
                     }
                     walk(base, &path, gitignore, result, skipped)?;
                 } else {
-                    // Skip hidden files unless explicitly whitelisted (.gitignore is always included)
+                    let m = gitignore.matched(&path, false);
+                    // Hidden files: only include if explicitly whitelisted.
+                    // .gitignore is always included (special case).
                     if name_str.starts_with('.') && name_str != ".gitignore" {
-                        if !gitignore.matched(&path, false).is_whitelist() {
+                        if !m.is_whitelist() {
                             continue;
                         }
-                    }
-                    // Check gitignore for files
-                    if gitignore.matched(&path, false).is_ignore() {
+                    } else if m.is_ignore() {
                         continue;
                     }
                     // Skip files exceeding the size limit
@@ -1125,13 +1125,14 @@ impl OssSyncManager {
                     }
                     walk_incremental(base, &path, since, gitignore, result, skipped)?;
                 } else {
-                    // Skip hidden files unless explicitly whitelisted (.gitignore is always included)
+                    let m = gitignore.matched(&path, false);
+                    // Hidden files: only include if explicitly whitelisted.
+                    // .gitignore is always included (special case).
                     if name_str.starts_with('.') && name_str != ".gitignore" {
-                        if !gitignore.matched(&path, false).is_whitelist() {
+                        if !m.is_whitelist() {
                             continue;
                         }
-                    }
-                    if gitignore.matched(&path, false).is_ignore() {
+                    } else if m.is_ignore() {
                         continue;
                     }
                     // Skip files exceeding the size limit

--- a/src-tauri/src/commands/local_stats.rs
+++ b/src-tauri/src/commands/local_stats.rs
@@ -17,6 +17,8 @@ pub struct LocalStats {
     pub sessions: SessionStats,
     pub last_updated: String,
     pub created_at: String,
+    #[serde(default)]
+    pub skill_usage: std::collections::HashMap<String, i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -52,6 +54,7 @@ pub struct LocalStatsUpdate {
     pub star_rating: Option<i64>,
     pub sessions_total: Option<i64>,
     pub sessions_with_feedback: Option<i64>,
+    pub skill_invoked: Option<String>,
 }
 
 impl Default for LocalStats {
@@ -72,6 +75,7 @@ impl Default for LocalStats {
             },
             last_updated: now.clone(),
             created_at: now,
+            skill_usage: std::collections::HashMap::new(),
         }
     }
 }
@@ -192,6 +196,11 @@ pub async fn update_local_stats(
     if let Some(sessions_with_feedback) = updates.sessions_with_feedback {
         stats.sessions.with_feedback += sessions_with_feedback;
     }
+    if let Some(name) = updates.skill_invoked {
+        if !name.is_empty() && name.len() <= 256 {
+            *stats.skill_usage.entry(name).or_insert(0) += 1;
+        }
+    }
 
     // Update timestamp
     stats.last_updated = chrono::Utc::now().to_rfc3339();
@@ -208,4 +217,84 @@ pub async fn reset_local_stats(workspace_path: String) -> Result<LocalStats, Str
     let stats = LocalStats::default();
     write_local_stats(workspace_path, stats.clone()).await?;
     Ok(stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn temp_workspace() -> TempDir {
+        TempDir::new().expect("create tempdir")
+    }
+
+    fn empty_update() -> LocalStatsUpdate {
+        LocalStatsUpdate {
+            task_completed: None,
+            total_tokens: None,
+            total_cost: None,
+            feedback_count: None,
+            positive_count: None,
+            negative_count: None,
+            star_rating: None,
+            sessions_total: None,
+            sessions_with_feedback: None,
+            skill_invoked: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn update_local_stats_increments_skill_usage() {
+        let ws = temp_workspace();
+        let ws_path = ws.path().to_string_lossy().to_string();
+
+        let stats = update_local_stats(
+            ws_path.clone(),
+            LocalStatsUpdate {
+                skill_invoked: Some("superpowers:brainstorming".to_string()),
+                ..empty_update()
+            },
+        )
+        .await
+        .expect("first update ok");
+        assert_eq!(
+            stats.skill_usage.get("superpowers:brainstorming"),
+            Some(&1)
+        );
+
+        let stats = update_local_stats(
+            ws_path.clone(),
+            LocalStatsUpdate {
+                skill_invoked: Some("superpowers:brainstorming".to_string()),
+                ..empty_update()
+            },
+        )
+        .await
+        .expect("second update ok");
+        assert_eq!(
+            stats.skill_usage.get("superpowers:brainstorming"),
+            Some(&2)
+        );
+
+        let stats = update_local_stats(
+            ws_path.clone(),
+            LocalStatsUpdate {
+                skill_invoked: Some("sentry-fix".to_string()),
+                ..empty_update()
+            },
+        )
+        .await
+        .expect("third update ok");
+        assert_eq!(stats.skill_usage.get("sentry-fix"), Some(&1));
+        assert_eq!(
+            stats.skill_usage.get("superpowers:brainstorming"),
+            Some(&2)
+        );
+    }
+
+    #[tokio::test]
+    async fn default_local_stats_has_empty_skill_usage() {
+        let s = LocalStats::default();
+        assert!(s.skill_usage.is_empty());
+    }
 }

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -776,6 +776,31 @@ mod tests {
     }
 
     #[test]
+    fn scan_incremental_includes_leaderboard_dir_under_team_whitelist() {
+        use crate::commands::team::GITIGNORE_CONTENT;
+
+        let ws = create_temp_workspace();
+        let team_dir = ws.path().join(crate::commands::TEAM_REPO_DIR);
+        std::fs::create_dir_all(&team_dir).unwrap();
+        std::fs::write(team_dir.join(".gitignore"), GITIGNORE_CONTENT).unwrap();
+
+        // Record time before writing the new file so incremental picks it up.
+        let since = std::time::SystemTime::now();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let leaderboard_dir = team_dir.join(".leaderboard");
+        std::fs::create_dir_all(&leaderboard_dir).unwrap();
+        std::fs::write(leaderboard_dir.join("alice.json"), "{}").unwrap();
+
+        let (files, _) = OssSyncManager::scan_local_files_incremental(&team_dir, since).unwrap();
+        assert!(
+            files.contains_key(".leaderboard/alice.json"),
+            "incremental scan must include newly-whitelisted .leaderboard entries; got keys: {:?}",
+            files.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn scan_incremental_only_new_files() {
         let ws = create_temp_workspace();
         let skills_dir = ws

--- a/src-tauri/src/commands/oss_sync.rs
+++ b/src-tauri/src/commands/oss_sync.rs
@@ -755,6 +755,27 @@ mod tests {
     }
 
     #[test]
+    fn scan_includes_leaderboard_dir_under_team_whitelist() {
+        use crate::commands::team::GITIGNORE_CONTENT;
+
+        let ws = create_temp_workspace();
+        let team_dir = ws.path().join(crate::commands::TEAM_REPO_DIR);
+        std::fs::create_dir_all(&team_dir).unwrap();
+        std::fs::write(team_dir.join(".gitignore"), GITIGNORE_CONTENT).unwrap();
+
+        let leaderboard_dir = team_dir.join(".leaderboard");
+        std::fs::create_dir_all(&leaderboard_dir).unwrap();
+        std::fs::write(leaderboard_dir.join("alice.json"), "{}").unwrap();
+
+        let (files, _) = OssSyncManager::scan_local_files(&team_dir).unwrap();
+        assert!(
+            files.contains_key(".leaderboard/alice.json"),
+            ".leaderboard/ must be whitelisted for team sync; got keys: {:?}",
+            files.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn scan_incremental_only_new_files() {
         let ws = create_temp_workspace();
         let skills_dir = ws
@@ -785,7 +806,7 @@ mod tests {
     async fn write_doc_to_disk_creates_files_atomically() {
         let s3 = mini_s3::MiniS3::start().await;
         let ws = create_temp_workspace();
-        let mgr = create_test_manager(ws.path().to_str().unwrap(), &s3.endpoint());
+        let mut mgr = create_test_manager(ws.path().to_str().unwrap(), &s3.endpoint());
 
         // Populate the LoroDoc with a file entry
         let doc = mgr.get_doc(DocType::Skills);
@@ -820,7 +841,7 @@ mod tests {
     async fn write_doc_to_disk_deletes_removed_files() {
         let s3 = mini_s3::MiniS3::start().await;
         let ws = create_temp_workspace();
-        let mgr = create_test_manager(ws.path().to_str().unwrap(), &s3.endpoint());
+        let mut mgr = create_test_manager(ws.path().to_str().unwrap(), &s3.endpoint());
 
         let skills_dir = ws
             .path()
@@ -855,7 +876,7 @@ mod tests {
     async fn write_doc_to_disk_absorbs_local_only_files() {
         let s3 = mini_s3::MiniS3::start().await;
         let ws = create_temp_workspace();
-        let mgr = create_test_manager(ws.path().to_str().unwrap(), &s3.endpoint());
+        let mut mgr = create_test_manager(ws.path().to_str().unwrap(), &s3.endpoint());
 
         let skills_dir = ws
             .path()

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -498,7 +498,7 @@ pub fn write_team_mode(workspace_path: &str, mode: Option<&str>) -> Result<(), S
 }
 
 /// The whitelist .gitignore content
-const GITIGNORE_CONTENT: &str = r#"# ============================================
+pub const GITIGNORE_CONTENT: &str = r#"# ============================================
 # TeamClaw Team Drive — Whitelist mode
 # Ignore everything by default, only allow shared layer
 # ============================================
@@ -519,6 +519,8 @@ const GITIGNORE_CONTENT: &str = r#"# ===========================================
 !_meta/**
 !_secrets/
 !_secrets/**
+!.leaderboard/
+!.leaderboard/**
 
 # 3. Allow workspace config
 !.gitignore

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -693,14 +693,14 @@ mod tests {
                 &mut self.node,
                 &team_dir,
                 &workspace_path,
-                None,
-                None,
-                None,
                 Some("Unified Team Test".to_string()),
                 Some(self.name.clone()),
                 None,
                 None,
                 self.engine.clone(),
+                crate::commands::TEAMCLAW_DIR,
+                crate::commands::CONFIG_FILE_NAME,
+                crate::commands::TEAM_REPO_DIR,
             )
             .await
             .unwrap()
@@ -716,6 +716,9 @@ mod tests {
                 &workspace_path,
                 None,
                 self.engine.clone(),
+                crate::commands::TEAMCLAW_DIR,
+                crate::commands::CONFIG_FILE_NAME,
+                crate::commands::TEAM_REPO_DIR,
             )
             .await
             .unwrap();
@@ -762,6 +765,8 @@ mod tests {
             &owner.team_dir_path(),
             &owner.node_id(),
             joiner_member,
+            crate::commands::TEAMCLAW_DIR,
+            crate::commands::CONFIG_FILE_NAME,
         )
         .unwrap();
 

--- a/src-tauri/src/telemetry/commands.rs
+++ b/src-tauri/src/telemetry/commands.rs
@@ -565,6 +565,7 @@ pub async fn telemetry_export_leaderboard(
             total_tokens: local_stats.total_tokens,
             total_cost: local_stats.total_cost,
             session_count: local_stats.sessions.total,
+            skill_usage: local_stats.skill_usage.clone(),
         };
 
         let team_dir_str = team_dir.to_string_lossy().to_string();
@@ -631,6 +632,7 @@ fn aggregate_workspace_stats(
         total_tokens: 0,
         total_cost: 0.0,
         session_count: 0,
+        skill_usage: std::collections::HashMap::new(),
     };
 
     for stats in workspaces.values() {
@@ -640,6 +642,9 @@ fn aggregate_workspace_stats(
         total.total_tokens += stats.total_tokens;
         total.total_cost += stats.total_cost;
         total.session_count += stats.session_count;
+        for (name, count) in &stats.skill_usage {
+            *total.skill_usage.entry(name.clone()).or_insert(0) += count;
+        }
     }
 
     total
@@ -715,6 +720,7 @@ pub async fn telemetry_get_member_aggregated_stats(
             total_tokens: 0,
             total_cost: 0.0,
             session_count: 0,
+            skill_usage: std::collections::HashMap::new(),
         });
     }
 
@@ -724,4 +730,38 @@ pub async fn telemetry_get_member_aggregated_stats(
         .map_err(|e| format!("Failed to parse leaderboard file: {}", e))?;
 
     Ok(aggregate_workspace_stats(&export.workspaces))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leaderboard_stats_has_skill_usage_field() {
+        let stats = LeaderboardStats {
+            total_feedbacks: 0,
+            positive_count: 0,
+            negative_count: 0,
+            total_tokens: 0,
+            total_cost: 0.0,
+            session_count: 0,
+            skill_usage: std::collections::HashMap::from([
+                ("sentry-fix".to_string(), 3_i64),
+                ("fc-deploy".to_string(), 1_i64),
+            ]),
+        };
+
+        let json = serde_json::to_string(&stats).expect("serialize");
+        assert!(
+            json.contains("\"skillUsage\""),
+            "expected camelCase skillUsage, got: {json}"
+        );
+        assert!(json.contains("sentry-fix"));
+
+        // Round trip through a JSON without skillUsage (pre-migration file).
+        let legacy = r#"{"totalFeedbacks":5,"positiveCount":4,"negativeCount":1,"totalTokens":1000,"totalCost":0.05,"sessionCount":2}"#;
+        let parsed: LeaderboardStats = serde_json::from_str(legacy).expect("parse legacy");
+        assert_eq!(parsed.total_feedbacks, 5);
+        assert!(parsed.skill_usage.is_empty());
+    }
 }

--- a/src-tauri/src/telemetry/commands.rs
+++ b/src-tauri/src/telemetry/commands.rs
@@ -493,132 +493,125 @@ pub struct TeamLeaderboard {
 
 /// Export the current user's leaderboard stats to teamclaw-team/.leaderboard/{memberName}.json.
 /// Reads from .teamclaw/stats.json and organizes by workspace.
+///
+/// Works in all team sync modes (P2P, OSS, managed-git) — the export is a pure
+/// filesystem write that relies only on the stable device ID from
+/// `~/.teamclaw/iroh/secret_key`. The iroh node does NOT need to be running.
 #[tauri::command]
 pub async fn telemetry_export_leaderboard(
-    state: tauri::State<'_, TelemetryState>,
-    iroh_state: tauri::State<'_, crate::commands::p2p_state::IrohState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
-    #[cfg(not(feature = "p2p"))]
-    let _ = (state, iroh_state, opencode_state);
+    let node_id = crate::commands::oss_commands::get_device_id()?;
+    let hostname = gethostname::gethostname().to_string_lossy().to_string();
 
-    #[cfg(not(feature = "p2p"))]
-    return Err("P2P team sync is not available on this build.".into());
+    let workspace_path = opencode_state
+        .inner
+        .lock()
+        .map_err(|e| e.to_string())?
+        .workspace_path
+        .clone()
+        .ok_or("Workspace path not set")?;
+    let team_dir = std::path::Path::new(&workspace_path).join(crate::commands::TEAM_REPO_DIR);
+    if !team_dir.exists() {
+        return Ok(());
+    }
+    let leaderboard_dir = team_dir.join(".leaderboard");
 
-    #[cfg(feature = "p2p")]
-    {
-        let _db = get_db(&state).await?;
+    std::fs::create_dir_all(&leaderboard_dir)
+        .map_err(|e| format!("Failed to create .leaderboard dir: {}", e))?;
 
-        let guard = iroh_state.lock().await;
-        let node = guard.as_ref().ok_or("P2P node not running")?;
-        let node_id = crate::commands::team_p2p::get_node_id(node);
-        let device_info = crate::commands::team_p2p::get_device_metadata();
-        drop(guard);
-
-        let workspace_path = opencode_state
-            .inner
-            .lock()
-            .map_err(|e| e.to_string())?
-            .workspace_path
-            .clone()
-            .ok_or("Workspace path not set")?;
-        let team_dir = std::path::Path::new(&workspace_path).join(crate::commands::TEAM_REPO_DIR);
-        if !team_dir.exists() {
-            return Ok(());
-        }
-        let leaderboard_dir = team_dir.join(".leaderboard");
-
-        std::fs::create_dir_all(&leaderboard_dir)
-            .map_err(|e| format!("Failed to create .leaderboard dir: {}", e))?;
-
-        // Read local stats from current workspace's .teamclaw/stats.json
-        let stats_path = std::path::Path::new(&workspace_path)
-            .join(crate::commands::TEAMCLAW_DIR)
-            .join("stats.json");
-        let local_stats = if stats_path.exists() {
-            let content = std::fs::read_to_string(&stats_path).map_err(|e| {
+    // Read local stats from current workspace's .teamclaw/stats.json
+    let stats_path = std::path::Path::new(&workspace_path)
+        .join(crate::commands::TEAMCLAW_DIR)
+        .join("stats.json");
+    let local_stats = if stats_path.exists() {
+        let content = std::fs::read_to_string(&stats_path).map_err(|e| {
+            format!(
+                "Failed to read {}/stats.json: {}",
+                crate::commands::TEAMCLAW_DIR,
+                e
+            )
+        })?;
+        serde_json::from_str::<crate::commands::local_stats::LocalStats>(&content).map_err(
+            |e| {
                 format!(
-                    "Failed to read {}/stats.json: {}",
+                    "Failed to parse {}/stats.json: {}",
                     crate::commands::TEAMCLAW_DIR,
                     e
                 )
-            })?;
-            serde_json::from_str::<crate::commands::local_stats::LocalStats>(&content).map_err(
-                |e| {
-                    format!(
-                        "Failed to parse {}/stats.json: {}",
-                        crate::commands::TEAMCLAW_DIR,
-                        e
-                    )
-                },
-            )?
-        } else {
-            // If stats.json doesn't exist, use default
-            crate::commands::local_stats::LocalStats::default()
-        };
+            },
+        )?
+    } else {
+        // If stats.json doesn't exist, use default
+        crate::commands::local_stats::LocalStats::default()
+    };
 
-        // Convert LocalStats to LeaderboardStats
-        let workspace_stats = LeaderboardStats {
-            total_feedbacks: local_stats.feedback_count,
-            positive_count: local_stats.positive_count,
-            negative_count: local_stats.negative_count,
-            total_tokens: local_stats.total_tokens,
-            total_cost: local_stats.total_cost,
-            session_count: local_stats.sessions.total,
-            skill_usage: local_stats.skill_usage.clone(),
-        };
+    // Convert LocalStats to LeaderboardStats
+    let workspace_stats = LeaderboardStats {
+        total_feedbacks: local_stats.feedback_count,
+        positive_count: local_stats.positive_count,
+        negative_count: local_stats.negative_count,
+        total_tokens: local_stats.total_tokens,
+        total_cost: local_stats.total_cost,
+        session_count: local_stats.sessions.total,
+        skill_usage: local_stats.skill_usage.clone(),
+    };
 
-        let team_dir_str = team_dir.to_string_lossy().to_string();
-        let member_name = crate::commands::team_p2p::read_members_manifest(&team_dir_str)
-            .ok()
-            .flatten()
-            .and_then(|m| {
-                m.members
-                    .iter()
-                    .find(|mem| mem.node_id == node_id)
-                    .map(|mem| mem.name.clone())
-            })
-            .filter(|n| !n.is_empty())
-            .unwrap_or_else(|| device_info.hostname.clone());
+    let member_name = read_team_member_name(&team_dir, &node_id)
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| hostname.clone());
 
-        let safe_filename = member_name
-            .replace(['/', '\\', ':', '*', '?', '"', '<', '>', '|'], "_")
-            .chars()
-            .take(200)
-            .collect::<String>();
-        let file_path = leaderboard_dir.join(format!("{}.json", safe_filename));
+    let safe_filename = member_name
+        .replace(['/', '\\', ':', '*', '?', '"', '<', '>', '|'], "_")
+        .chars()
+        .take(200)
+        .collect::<String>();
+    let file_path = leaderboard_dir.join(format!("{}.json", safe_filename));
 
-        // Read existing leaderboard file or create new
-        let mut workspaces = if file_path.exists() {
-            let content = std::fs::read_to_string(&file_path)
-                .map_err(|e| format!("Failed to read existing leaderboard: {}", e))?;
-            let existing: MemberLeaderboardExport = serde_json::from_str(&content)
-                .map_err(|e| format!("Failed to parse existing leaderboard: {}", e))?;
-            existing.workspaces
-        } else {
-            std::collections::HashMap::new()
-        };
+    // Read existing leaderboard file or create new
+    let mut workspaces = if file_path.exists() {
+        let content = std::fs::read_to_string(&file_path)
+            .map_err(|e| format!("Failed to read existing leaderboard: {}", e))?;
+        let existing: MemberLeaderboardExport = serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse existing leaderboard: {}", e))?;
+        existing.workspaces
+    } else {
+        std::collections::HashMap::new()
+    };
 
-        // Update current workspace stats
-        workspaces.insert(workspace_path.clone(), workspace_stats);
+    // Update current workspace stats
+    workspaces.insert(workspace_path.clone(), workspace_stats);
 
-        let now = chrono::Utc::now().to_rfc3339();
-        let export = MemberLeaderboardExport {
-            member_id: node_id.clone(),
-            member_name: member_name.clone(),
-            exported_at: now.clone(),
-            update_at: now,
-            workspaces,
-        };
+    let now = chrono::Utc::now().to_rfc3339();
+    let export = MemberLeaderboardExport {
+        member_id: node_id,
+        member_name: member_name.clone(),
+        exported_at: now.clone(),
+        update_at: now,
+        workspaces,
+    };
 
-        let json = serde_json::to_string_pretty(&export)
-            .map_err(|e| format!("Failed to serialize leaderboard: {}", e))?;
+    let json = serde_json::to_string_pretty(&export)
+        .map_err(|e| format!("Failed to serialize leaderboard: {}", e))?;
 
-        std::fs::write(&file_path, json)
-            .map_err(|e| format!("Failed to write leaderboard file: {}", e))?;
+    std::fs::write(&file_path, json)
+        .map_err(|e| format!("Failed to write leaderboard file: {}", e))?;
 
-        Ok(())
-    }
+    Ok(())
+}
+
+/// Look up this device's member name from `<team_dir>/_team/members.json`.
+/// Returns None if the manifest is missing, malformed, or does not contain the
+/// given node_id. Caller falls back to hostname.
+fn read_team_member_name(team_dir: &std::path::Path, node_id: &str) -> Option<String> {
+    let manifest_path = team_dir.join("_team").join("members.json");
+    let content = std::fs::read_to_string(&manifest_path).ok()?;
+    let manifest: teamclaw_sync::oss_types::TeamManifest = serde_json::from_str(&content).ok()?;
+    manifest
+        .members
+        .into_iter()
+        .find(|m| m.node_id == node_id)
+        .map(|m| m.name)
 }
 
 /// Aggregate stats from all workspaces for a member

--- a/src-tauri/src/telemetry/commands.rs
+++ b/src-tauri/src/telemetry/commands.rs
@@ -302,81 +302,63 @@ pub struct TeamFeedbackSummary {
 }
 
 /// Export the current user's feedback summary to teamclaw-team/_feedback/{nodeId}.json.
+///
+/// Works in all team sync modes (P2P, OSS, managed-git) — identity comes from
+/// the stable device key at ~/.teamclaw/iroh/secret_key; the iroh node does
+/// NOT need to be running.
 #[tauri::command]
 pub async fn telemetry_export_team_feedback(
     state: tauri::State<'_, TelemetryState>,
-    iroh_state: tauri::State<'_, crate::commands::p2p_state::IrohState>,
     opencode_state: tauri::State<'_, crate::commands::opencode::OpenCodeState>,
 ) -> Result<(), String> {
-    #[cfg(not(feature = "p2p"))]
-    {
-        let _ = (state, iroh_state, opencode_state);
-        return Err("P2P team sync is not available on this build.".into());
+    let db = get_db(&state).await?;
+
+    let node_id = crate::commands::oss_commands::get_device_id()?;
+    let hostname = gethostname::gethostname().to_string_lossy().to_string();
+
+    let workspace_path = opencode_state
+        .inner
+        .lock()
+        .map_err(|e| e.to_string())?
+        .workspace_path
+        .clone()
+        .ok_or("Workspace path not set")?;
+    let team_dir = std::path::Path::new(&workspace_path).join(crate::commands::TEAM_REPO_DIR);
+    if !team_dir.exists() {
+        return Ok(());
     }
+    let feedback_dir = team_dir.join("_feedback");
 
-    #[cfg(feature = "p2p")]
-    {
-        let db = get_db(&state).await?;
+    std::fs::create_dir_all(&feedback_dir)
+        .map_err(|e| format!("Failed to create _feedback dir: {}", e))?;
 
-        let guard = iroh_state.lock().await;
-        let node = guard.as_ref().ok_or("P2P node not running")?;
-        let node_id = crate::commands::team_p2p::get_node_id(node);
-        let device_info = crate::commands::team_p2p::get_device_metadata();
-        drop(guard);
+    let summary = db.export_feedback_summary().await?;
 
-        let workspace_path = opencode_state
-            .inner
-            .lock()
-            .map_err(|e| e.to_string())?
-            .workspace_path
-            .clone()
-            .ok_or("Workspace path not set")?;
-        let team_dir = std::path::Path::new(&workspace_path).join(crate::commands::TEAM_REPO_DIR);
-        if !team_dir.exists() {
-            return Ok(());
-        }
-        let feedback_dir = team_dir.join("_feedback");
+    let member_name = read_team_member_name(&team_dir, &node_id)
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| hostname.clone());
 
-        std::fs::create_dir_all(&feedback_dir)
-            .map_err(|e| format!("Failed to create _feedback dir: {}", e))?;
+    let export = MemberFeedbackExport {
+        member_id: node_id,
+        member_name: member_name.clone(),
+        exported_at: chrono::Utc::now().to_rfc3339(),
+        summary,
+    };
 
-        let summary = db.export_feedback_summary().await?;
+    let json = serde_json::to_string_pretty(&export)
+        .map_err(|e| format!("Failed to serialize feedback: {}", e))?;
 
-        let team_dir_str = team_dir.to_string_lossy().to_string();
-        let member_name = crate::commands::team_p2p::read_members_manifest(&team_dir_str)
-            .ok()
-            .flatten()
-            .and_then(|m| {
-                m.members
-                    .iter()
-                    .find(|mem| mem.node_id == node_id)
-                    .map(|mem| mem.name.clone())
-            })
-            .filter(|n| !n.is_empty())
-            .unwrap_or_else(|| device_info.hostname.clone());
+    // Use memberName as filename (sanitize for safety)
+    let safe_filename = member_name
+        .replace(['/', '\\', ':', '*', '?', '"', '<', '>', '|'], "_")
+        .chars()
+        .take(200)
+        .collect::<String>();
+    let file_path = feedback_dir.join(format!("{}.json", safe_filename));
+    std::fs::write(&file_path, json)
+        .map_err(|e| format!("Failed to write feedback file: {}", e))?;
 
-        let export = MemberFeedbackExport {
-            member_id: node_id.clone(),
-            member_name: member_name.clone(),
-            exported_at: chrono::Utc::now().to_rfc3339(),
-            summary,
-        };
-
-        let json = serde_json::to_string_pretty(&export)
-            .map_err(|e| format!("Failed to serialize feedback: {}", e))?;
-
-        // Use memberName as filename (sanitize for safety)
-        let safe_filename = member_name
-            .replace(['/', '\\', ':', '*', '?', '"', '<', '>', '|'], "_")
-            .chars()
-            .take(200)
-            .collect::<String>();
-        let file_path = feedback_dir.join(format!("{}.json", safe_filename));
-        std::fs::write(&file_path, json)
-            .map_err(|e| format!("Failed to write feedback file: {}", e))?;
-
-        Ok(())
-    }
+    Ok(())
 }
 
 /// Read all member feedback JSONs from teamclaw-team/_feedback/ and return aggregated team summary.

--- a/src-tauri/src/telemetry/db.rs
+++ b/src-tauri/src/telemetry/db.rs
@@ -69,6 +69,8 @@ pub struct LeaderboardStats {
     pub total_tokens: i64,
     pub total_cost: f64,
     pub session_count: i64,
+    #[serde(default)]
+    pub skill_usage: std::collections::HashMap<String, i64>,
 }
 
 // ─── Database ────────────────────────────────────────────────────────────
@@ -779,6 +781,7 @@ impl TelemetryDb {
             total_tokens,
             total_cost: (total_cost * 10000.0).round() / 10000.0,
             session_count,
+            skill_usage: std::collections::HashMap::new(),
         })
     }
 }


### PR DESCRIPTION
## Description

Track every skill / role_skill invocation per team member across their workspaces and surface it on the existing Team Leaderboard.

**New user-visible surface area**
- Member row gains a **Skill 排名** column (3-way equal-weight overall rank now averages Token + Feedback + Skill)
- New **Top Skills This Team** block under the member table: top-10 aggregate, `N calls · M members`
- i18n keys added for en + zh-CN

**Architecture**
- OpenCode SSE `message.part.updated` tool events → `handleToolExecuting` → `incrementSkillUsage` (fire-and-forget) → Rust `update_local_stats` → `.teamclaw/stats.json` (new \`skillUsage\` map, serde-default)
- Rides existing telemetry pipeline: `telemetry_export_leaderboard` → \`teamclaw-team/.leaderboard/{member}.json\` → team sync (P2P / OSS / managed-git) → `telemetry_get_team_leaderboard` aggregates for render
- Zero new paths, zero new IPC protocols

**Bundled bug fixes** (both were latent, leaderboard was silently broken outside P2P)
- Team repo whitelist \`.gitignore\` now includes \`.leaderboard/\`. The sync scanner was also skipping all hidden dirs before consulting gitignore, which would have made the whitelist inert; that was fixed too.
- \`telemetry_export_leaderboard\` and \`telemetry_export_team_feedback\` were gated on iroh runtime state (\`P2P node not running\`). Both rewritten to use stable device identity (\`oss_commands::get_device_id()\` + \`gethostname\`) and inline members.json read — work across all sync modes now.

**Counting semantics**
- One count per tool invocation, regardless of success. Dedup by \`toolCallId\` via a module-scoped Set (tool event fires multiple times per invocation; first fire often has empty args, so we count on first populated \`args.name\`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Test plan

- [x] Rust unit tests — \`update_local_stats_increments_skill_usage\`, \`scan_includes_leaderboard_dir_under_team_whitelist\` (both scan paths), \`leaderboard_stats_has_skill_usage_field\` (camelCase + legacy round-trip)
- [x] TS unit tests — \`incrementSkillUsage\` (happy path + empty guards), \`computeTopSkills\` (cross-member aggregation + cap + empty)
- [x] \`cargo check\` + \`pnpm typecheck\` clean
- [x] Manual smoke (managed-git mode): trigger \`role_skill\` + \`skill\` calls → stats.json gets \`skillUsage\` entries → leaderboard Refresh shows Skill Rank and Top Skills block
- [ ] Cross-member verify on a 2-device team (reviewer)

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] No new warnings
- [x] Added tests for the feature
- [x] All existing tests pass locally

## Notes

- \`docs/superpowers/specs/2026-04-18-team-skill-usage-leaderboard-design.md\` and the matching plan exist locally (gitignored per repo convention)
- Pre-existing test \`write_doc_to_disk_deletes_removed_files\` was already broken at base commit 38d4503; not touched by this PR