### PR TITLE
fix chat pending assistant binding on early part events

### DIFF
--- a/packages/app/src/stores/__tests__/session-sse-message-handlers.test.ts
+++ b/packages/app/src/stores/__tests__/session-sse-message-handlers.test.ts
@@ -143,6 +143,44 @@ describe('session-sse-message-handlers', () => {
     expect(scheduleTypewriter).toHaveBeenCalled()
   })
 
+  it('binds pending assistant to the real message id when part events arrive first', () => {
+    const session = sessionLookupCache.get('sess-1')!
+    session.messages.push({
+      id: 'pending-assistant-1',
+      sessionId: 'sess-1',
+      role: 'assistant',
+      content: '',
+      parts: [],
+      timestamp: new Date(),
+      isStreaming: true,
+    } as any)
+    sessionLookupCache.set('sess-1', session)
+    state.sessions = [session]
+
+    const streamState = useStreamingStore.getState()
+    streamState.streamingMessageId = 'pending-assistant-1'
+    streamState.streamingContent = ''
+
+    handlers.handleMessagePartCreated({
+      messageId: 'assist-msg-1',
+      partId: 'step-1',
+      type: 'step-start',
+    } as any)
+
+    const updated = sessionLookupCache.get('sess-1')!
+    expect(updated.messages.find((m: any) => m.id === 'pending-assistant-1')).toBeUndefined()
+    const rebound = updated.messages.find((m: any) => m.id === 'assist-msg-1')
+    expect(rebound).toBeDefined()
+    expect(rebound.isStreaming).toBe(true)
+    expect(rebound.parts).toEqual([
+      expect.objectContaining({
+        id: 'step-1',
+        type: 'step-start',
+      }),
+    ])
+    expect(streamState.setStreaming).toHaveBeenCalledWith('assist-msg-1', '')
+  })
+
   it('handleMessageCompleted sets isStreaming to false and clears streaming', () => {
     // Setup: add an assistant message
     const session = sessionLookupCache.get('sess-1')!

--- a/packages/app/src/stores/session-sse-message-handlers.ts
+++ b/packages/app/src/stores/session-sse-message-handlers.ts
@@ -38,6 +38,37 @@ const DEBUG = () => {
 };
 
 export function createMessageHandlers(set: SessionSet, get: SessionGet) {
+  const bindPendingAssistantToRealMessage = (
+    sessionId: string,
+    pendingMessageId: string,
+    realMessageId: string,
+  ) => {
+    const currentStreamingContent = useStreamingStore.getState().streamingContent;
+    useStreamingStore.getState().setStreaming(realMessageId, currentStreamingContent);
+
+    set((state) => {
+      const session = getSessionById(sessionId);
+      if (!session) return state;
+
+      const newSession = {
+        ...session,
+        messages: session.messages.map((message) =>
+          message.id === pendingMessageId
+            ? { ...message, id: realMessageId }
+            : message,
+        ),
+        updatedAt: new Date(),
+      };
+      sessionLookupCache.set(sessionId, newSession);
+
+      return {
+        sessions: state.sessions.map((sessionItem) =>
+          sessionItem.id === sessionId ? newSession : sessionItem,
+        ),
+      };
+    });
+  };
+
   return {
     handleMessageCreated: (event: MessageCreatedEvent) => {
       const { activeSessionId } = get();
@@ -216,8 +247,18 @@ export function createMessageHandlers(set: SessionSet, get: SessionGet) {
       if (event.messageId !== streamingMessageId && activeSessionId) {
         const session = getSessionById(activeSessionId);
         const targetMessage = session?.messages.find(m => m.id === event.messageId);
-        
-        if (targetMessage?.isStreaming) {
+
+        if (
+          !targetMessage &&
+          streamingMessageId?.startsWith("pending-assistant-") &&
+          session?.messages.some((message) => message.id === streamingMessageId)
+        ) {
+          bindPendingAssistantToRealMessage(
+            activeSessionId,
+            streamingMessageId,
+            event.messageId,
+          );
+        } else if (targetMessage?.isStreaming) {
           console.warn("[PartCreated] Auto-recovering lost streamingMessageId:", {
             eventMessageId: event.messageId,
             oldStreamingId: streamingMessageId,
@@ -326,8 +367,18 @@ export function createMessageHandlers(set: SessionSet, get: SessionGet) {
       if (event.messageId !== streamingMessageId && activeSessionId) {
         const session = getSessionById(activeSessionId);
         const targetMessage = session?.messages.find(m => m.id === event.messageId);
-        
-        if (targetMessage?.isStreaming) {
+
+        if (
+          !targetMessage &&
+          streamingMessageId?.startsWith("pending-assistant-") &&
+          session?.messages.some((message) => message.id === streamingMessageId)
+        ) {
+          bindPendingAssistantToRealMessage(
+            activeSessionId,
+            streamingMessageId,
+            event.messageId,
+          );
+        } else if (targetMessage?.isStreaming) {
           console.warn("[PartUpdated] Auto-recovering lost streamingMessageId:", {
             eventMessageId: event.messageId,
             oldStreamingId: streamingMessageId,


### PR DESCRIPTION
## Summary
- bind the optimistic pending assistant to the real assistant message id when  arrives before 
- keep the fix scoped to the original model-switch regression path
- add a regression test for the early-part-event ordering case

## Testing
- pnpm vitest src/stores/__tests__/session-sse-message-handlers.test.ts --run
- pnpm typecheck