### PR TITLE
feat(autoui): manage vision env vars as system-shared, drop inline MCP env

### DIFF
--- a/packages/app/src/components/settings/AddMCPDialog.tsx
+++ b/packages/app/src/components/settings/AddMCPDialog.tsx
@@ -9,6 +9,7 @@ import {
   Trash2,
   Eye,
   EyeOff,
+  KeyRound,
 } from 'lucide-react'
 import { type MCPServerConfig } from '@/stores/mcp'
 import { cn } from '@/lib/utils'
@@ -28,6 +29,19 @@ interface AddMCPDialogProps {
   onOpenChange: (open: boolean) => void
   editingServer?: { name: string; config: MCPServerConfig } | null
   onSave: (name: string, config: MCPServerConfig) => Promise<void>
+}
+
+/** MCP servers TeamClaw auto-injects — env vars are managed in the env-var settings page. */
+const INHERENT_MCP_NAMES = new Set([
+  'playwright',
+  'chrome-control',
+  'autoui',
+  'teamclaw-introspect',
+])
+
+/** For each inherent server, the env-var keys the user should configure on the env-var page. */
+const INHERENT_REQUIRED_ENV_KEYS: Record<string, string[]> = {
+  autoui: ['AUTOUI_VISION_BASE_URL', 'AUTOUI_VISION_API_KEY', 'AUTOUI_VISION_MODEL'],
 }
 
 interface EnvVar {
@@ -54,6 +68,8 @@ export function AddMCPDialog({
   const [error, setError] = React.useState<string | null>(null)
 
   const isEditing = !!editingServer
+  const isInherent = isEditing && INHERENT_MCP_NAMES.has(editingServer!.name)
+  const requiredEnvKeys = isInherent ? INHERENT_REQUIRED_ENV_KEYS[editingServer!.name] ?? [] : []
 
   // Convert array to object
   const arrayToObject = (vars: EnvVar[]): Record<string, string> => {
@@ -125,7 +141,9 @@ export function AddMCPDialog({
 
       if (serverType === 'local') {
         config.command = command.trim().split(/\s+/)
-        const env = arrayToObject(envVars)
+        // Inherent servers source secrets from the env-var settings page; never
+        // persist an `environment` block here (legacy entries get cleaned up).
+        const env = isInherent ? {} : arrayToObject(envVars)
         if (Object.keys(env).length > 0) {
           config.environment = env
         }
@@ -242,7 +260,43 @@ export function AddMCPDialog({
                   {t('settings.mcp.commandHint', 'The command to start the MCP server')}
                 </p>
               </div>
-              {/* Environment Variables */}
+              {/* Environment Variables — for inherent servers, point users to
+                  the env-var settings page instead of accepting inline values. */}
+              {isInherent ? (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">
+                    {t('settings.mcp.envVars', '环境变量')}
+                  </label>
+                  <div className="rounded-lg border border-blue-200 dark:border-blue-900 bg-blue-50/60 dark:bg-blue-950/30 p-3 flex gap-3">
+                    <KeyRound className="h-4 w-4 text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />
+                    <div className="space-y-2 text-sm">
+                      <p className="text-foreground">
+                        {t(
+                          'settings.mcp.inherentEnvNotice',
+                          '此服务器的环境变量由"环境变量"设置统一管理，请前往配置以下变量：',
+                        )}
+                      </p>
+                      {requiredEnvKeys.length > 0 && (
+                        <ul className="space-y-1">
+                          {requiredEnvKeys.map((k) => (
+                            <li key={k}>
+                              <code className="text-xs font-mono bg-background/80 px-1.5 py-0.5 rounded">
+                                {k}
+                              </code>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      <p className="text-xs text-muted-foreground">
+                        {t(
+                          'settings.mcp.inherentEnvHint',
+                          '在"设置 → 环境变量"中填写后，重启 OpenCode 即可生效。',
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ) : (
               <div className="space-y-2">
                 <div className="flex items-center justify-between mb-2">
                   <label className="text-sm font-medium">
@@ -339,6 +393,7 @@ export function AddMCPDialog({
                   </div>
                 )}
               </div>
+              )}
             </>
           )}
 

--- a/packages/app/src/components/settings/EnvVarsSection.tsx
+++ b/packages/app/src/components/settings/EnvVarsSection.tsx
@@ -24,8 +24,11 @@ import { listen } from '@tauri-apps/api/event'
 // ─── Unified type for the combined list ─────────────────────────────────
 
 type UnifiedEntry =
-  | { scope: 'personal'; key: string; description?: string; category?: 'system' | null; dirty?: boolean }
+  | { scope: 'personal'; key: string; description?: string; category?: 'system' | 'system-shared' | null; dirty?: boolean }
   | { scope: 'team'; key: string; description: string; category: string; createdBy: string; updatedBy: string; updatedAt: string; dirty?: boolean }
+  // Placeholder shown when a `system-shared` system def exists but the team secret
+  // has not yet been set. Edit-saves default to "Share with team".
+  | { scope: 'team-placeholder'; key: string; description?: string; category: 'system-shared'; dirty?: boolean }
 
 // ─── Add / Edit Dialog ──────────────────────────────────────────────────
 
@@ -46,13 +49,25 @@ function EnvVarDialog({ open, onOpenChange, editingEntry, onSave }: EnvVarDialog
   const [error, setError] = React.useState<string | null>(null)
 
   const isEditing = !!editingEntry
+  // `system-shared` placeholders haven't been saved yet; treat the dialog as a
+  // first-time create so a value is required and the key+description are seeded
+  // from the system definition.
+  const isPlaceholder = editingEntry?.scope === 'team-placeholder'
+  const isFirstSave = !isEditing || isPlaceholder
+  // Lock the key for system / system-shared / placeholder rows so the user can't
+  // rename a system-managed entry into something else.
+  const lockedKey =
+    isPlaceholder ||
+    (editingEntry?.scope === 'personal' && editingEntry.category === 'system') ||
+    editingEntry?.scope === 'team'
 
   React.useEffect(() => {
     if (open) {
       if (editingEntry) {
         setKey(editingEntry.key)
         setDescription(editingEntry.description || '')
-        setShared(editingEntry.scope === 'team')
+        // Default-share when editing a team secret OR a system-shared placeholder.
+        setShared(editingEntry.scope === 'team' || editingEntry.scope === 'team-placeholder')
         setValue('')
       } else {
         setKey('')
@@ -70,16 +85,21 @@ function EnvVarDialog({ open, onOpenChange, editingEntry, onSave }: EnvVarDialog
       setError(t('settings.envVars.error.keyRequired', 'Key is required'))
       return
     }
-    if (!value && !isEditing) {
+    if (!value && isFirstSave) {
       setError(t('settings.envVars.error.valueRequired', 'Value is required'))
       return
     }
-    if (!value && isEditing) {
+    if (!value && isEditing && !isPlaceholder) {
       setError(t('settings.envVars.error.valueRequired', 'Please enter the new value'))
       return
     }
+    // shared_secrets requires lowercase keys server-side. For system-shared
+    // placeholder rows the displayed key is uppercase (matches the env-var name
+    // autoui-mcp reads), but the dialog stores the lowercase form transparently
+    // — so we accept either case here and let `onSave` normalize.
     if (shared) {
-      if (!/^[a-z0-9_]+$/.test(trimmedKey) || trimmedKey.length > 64) {
+      const probe = isPlaceholder ? trimmedKey.toLowerCase() : trimmedKey
+      if (!/^[a-z0-9_]+$/.test(probe) || probe.length > 64) {
         setError(t('settings.envVars.error.invalidKeyShared', 'Shared key must be lowercase letters, digits, underscores (max 64 chars)'))
         return
       }
@@ -93,7 +113,11 @@ function EnvVarDialog({ open, onOpenChange, editingEntry, onSave }: EnvVarDialog
     setSaving(true)
     setError(null)
     try {
-      await onSave(trimmedKey, value, description.trim() || '', shared)
+      // Lowercase the key when saving a system-shared placeholder as a team
+      // secret — the displayed name is uppercase (env-var convention) but
+      // shared_secrets stores lowercase. opencode injects both cases at startup.
+      const outboundKey = isPlaceholder && shared ? trimmedKey.toLowerCase() : trimmedKey
+      await onSave(outboundKey, value, description.trim() || '', shared)
       onOpenChange(false)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
@@ -127,8 +151,8 @@ function EnvVarDialog({ open, onOpenChange, editingEntry, onSave }: EnvVarDialog
               value={key}
               onChange={(e) => setKey(e.target.value)}
               placeholder={shared ? 'openai_api_key' : 'MY_API_KEY'}
-              disabled={isEditing}
-              autoFocus={!isEditing}
+              disabled={lockedKey}
+              autoFocus={!lockedKey}
             />
           </div>
 
@@ -159,20 +183,21 @@ function EnvVarDialog({ open, onOpenChange, editingEntry, onSave }: EnvVarDialog
             />
           </div>
 
-          {/* Share with team checkbox */}
+          {/* Share with team checkbox — locked for system-shared placeholders
+              (always team-shared) and existing team secrets (scope is fixed). */}
           <div className="flex items-center gap-2">
             <Checkbox
               id="shared"
               checked={shared}
               onCheckedChange={(checked) => setShared(checked === true)}
-              disabled={isEditing}
+              disabled={isEditing || isPlaceholder}
             />
             <label htmlFor="shared" className="text-sm font-medium cursor-pointer select-none flex items-center gap-1.5">
               <Users className="h-3.5 w-3.5 text-blue-500" />
               {t('settings.envVars.shareWithTeam', 'Share with team')}
             </label>
           </div>
-          {shared && !isEditing && (
+          {shared && isFirstSave && (
             <p className="text-xs text-muted-foreground ml-6">
               {t('settings.envVars.shareHint', 'This variable will be encrypted and synced to all team members.')}
             </p>
@@ -261,10 +286,12 @@ function EnvVarRow({ entry, canDelete, onEdit, onDelete }: EnvVarRowProps) {
   const { getEnvVarValue } = useEnvVarsStore()
 
   const isSystem = entry.scope === 'personal' && entry.category === 'system'
+  const isSystemShared = entry.category === 'system-shared'
   const isPersonal = entry.scope === 'personal'
+  const isPlaceholder = entry.scope === 'team-placeholder'
 
   const handleReveal = async () => {
-    if (!isPersonal) return // Team secrets cannot be revealed
+    if (!isPersonal) return // Team secrets / placeholders cannot be revealed
     if (revealed) {
       setRevealed(false)
       setRevealedValue(null)
@@ -293,7 +320,20 @@ function EnvVarRow({ entry, canDelete, onEdit, onDelete }: EnvVarRowProps) {
           <code className="text-sm font-mono font-medium bg-muted px-2 py-0.5 rounded">
             {entry.key}
           </code>
-          {isSystem ? (
+          {isSystemShared ? (
+            // System-managed key whose value is team-shared: show both badges so
+            // the user knows it's auto-registered AND syncs across the team.
+            <>
+              <span className="inline-flex items-center gap-1 text-xs text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-950/40 px-1.5 py-0.5 rounded">
+                <Lock className="h-3 w-3" />
+                {t('settings.envVars.scopeSystem', 'System')}
+              </span>
+              <span className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/40 px-1.5 py-0.5 rounded">
+                <Users className="h-3 w-3" />
+                {t('settings.envVars.scopeTeam', 'Team')}
+              </span>
+            </>
+          ) : isSystem ? (
             <span className="inline-flex items-center gap-1 text-xs text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-950/40 px-1.5 py-0.5 rounded">
               <Lock className="h-3 w-3" />
               {t('settings.envVars.scopeSystem', 'System')}
@@ -307,6 +347,12 @@ function EnvVarRow({ entry, canDelete, onEdit, onDelete }: EnvVarRowProps) {
             <span className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/40 px-1.5 py-0.5 rounded">
               <Users className="h-3 w-3" />
               {t('settings.envVars.scopeTeam', 'Team')}
+            </span>
+          )}
+          {isPlaceholder && (
+            <span className="inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/40 px-1.5 py-0.5 rounded">
+              <AlertCircle className="h-3 w-3" />
+              {t('settings.envVars.notConfigured', 'Not configured')}
             </span>
           )}
           {entry.dirty && (
@@ -426,28 +472,63 @@ export const EnvVarsSection = React.memo(function EnvVarsSection() {
     }
   }, [loadEnvVars, loadSecrets, listenForChanges])
 
-  // Build unified list: personal env vars + team secrets
+  // Build unified list: personal env vars + team secrets, with `system-shared`
+  // system defs surfaced as either the matching team secret (uppercase key) or
+  // a placeholder row when no value has been set yet.
   const hasSyncDirty = dirtyKeys.has('__team_sync__')
   const unifiedEntries: UnifiedEntry[] = React.useMemo(() => {
-    const personal: UnifiedEntry[] = envVars.map((e) => ({
-      scope: 'personal' as const,
-      key: e.key,
-      description: e.description,
-      category: e.category,
-      dirty: dirtyKeys.has(e.key),
-    }))
-    const team: UnifiedEntry[] = secrets.map((s) => ({
-      scope: 'team' as const,
-      key: s.keyId,
-      description: s.description,
-      category: s.category,
-      createdBy: s.createdBy,
-      updatedBy: s.updatedBy,
-      updatedAt: s.updatedAt,
-      dirty: dirtyKeys.has(s.keyId) || hasSyncDirty,
-    }))
-    const all = [...team, ...personal]
-    // System entries first; all other entries sorted alphabetically by key
+    const sharedSystemDefs = envVars.filter((e) => e.category === 'system-shared')
+    // lowercase(secretKey) -> matching system-shared def (so we can promote the
+    // team secret's display key to the canonical uppercase name)
+    const sharedSystemByLower = new Map(
+      sharedSystemDefs.map((d) => [d.key.toLowerCase(), d] as const),
+    )
+    // Track which lowercase secret keys have been satisfied so we can suppress
+    // the placeholder when a value already exists.
+    const satisfiedLowerKeys = new Set<string>()
+
+    const team: UnifiedEntry[] = secrets.map((s) => {
+      const lower = s.keyId.toLowerCase()
+      const matched = sharedSystemByLower.get(lower)
+      if (matched) {
+        satisfiedLowerKeys.add(lower)
+      }
+      return {
+        scope: 'team' as const,
+        key: matched ? matched.key : s.keyId,
+        description: matched?.description || s.description,
+        category: matched ? 'system-shared' : s.category,
+        createdBy: s.createdBy,
+        updatedBy: s.updatedBy,
+        updatedAt: s.updatedAt,
+        dirty: dirtyKeys.has(s.keyId) || hasSyncDirty,
+      }
+    })
+
+    const personal: UnifiedEntry[] = envVars
+      // Drop `system-shared` defs from the personal bucket — they're either
+      // promoted into `team` above or rendered as a `team-placeholder` below.
+      .filter((e) => e.category !== 'system-shared')
+      .map((e) => ({
+        scope: 'personal' as const,
+        key: e.key,
+        description: e.description,
+        category: e.category,
+        dirty: dirtyKeys.has(e.key),
+      }))
+
+    const placeholders: UnifiedEntry[] = sharedSystemDefs
+      .filter((d) => !satisfiedLowerKeys.has(d.key.toLowerCase()))
+      .map((d) => ({
+        scope: 'team-placeholder' as const,
+        key: d.key,
+        description: d.description,
+        category: 'system-shared' as const,
+        dirty: dirtyKeys.has(d.key),
+      }))
+
+    const all = [...team, ...placeholders, ...personal]
+    // System entries (locally seeded) first, then everything else alphabetical.
     all.sort((a, b) => {
       const aIsSystem = a.scope === 'personal' && a.category === 'system'
       const bIsSystem = b.scope === 'personal' && b.category === 'system'
@@ -471,16 +552,19 @@ export const EnvVarsSection = React.memo(function EnvVarsSection() {
     if (!deleteTarget) return
     if (deleteTarget.scope === 'team') {
       await deleteSecret(deleteTarget.key, currentNodeId ?? '', myRole ?? '')
-    } else {
+    } else if (deleteTarget.scope === 'personal') {
       await deleteEnvVar(deleteTarget.key)
     }
+    // Placeholders have no backing storage to delete.
     setDeleteTarget(null)
   }
 
   // Note: the Rust env_var_delete command also enforces the system-var guard server-side.
   const canDeleteEntry = (entry: UnifiedEntry): boolean => {
-    if (entry.scope === 'personal' && entry.category === 'system') return false
+    if (entry.scope === 'team-placeholder') return false
+    if (entry.scope === 'personal' && (entry.category === 'system' || entry.category === 'system-shared')) return false
     if (entry.scope === 'personal') return true
+    if (entry.scope === 'team' && entry.category === 'system-shared') return false
     if (myRole === 'owner') return true
     if (entry.scope === 'team' && entry.createdBy === currentNodeId) return true
     return false

--- a/packages/app/src/stores/env-vars.ts
+++ b/packages/app/src/stores/env-vars.ts
@@ -6,7 +6,13 @@ import { withAsync } from '@/lib/store-utils'
 export interface EnvVarEntry {
   key: string
   description?: string
-  category?: 'system' | null
+  /**
+   * `system`        — locally seeded by Rust on every launch (e.g. `tc_api_key`).
+   * `system-shared` — registered by Rust on every launch but the value lives in
+   *                   `shared_secrets` (team KMS). Surfaced in the UI even when no
+   *                   value has been set so the user is reminded to fill it in.
+   */
+  category?: 'system' | 'system-shared' | null
 }
 
 interface EnvVarsState {

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -213,27 +213,69 @@ struct SystemEnvVarContext {
     device_id: String,
 }
 
+/// How a system env var's default value should be applied on startup.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DefaultPolicy {
+    /// Re-derive on every startup; overwrite the stored value if it differs.
+    /// Use when the default depends on system state that may change
+    /// (e.g. `tc_api_key` is derived from `device_id`).
+    RegenerateAlways,
+    /// Write the default only when the key is missing from the blob.
+    /// Empty user-set values are preserved (treated as "user has decided to leave blank").
+    SetIfAbsent,
+}
+
 /// Definition of a system-managed env var.
 pub(crate) struct SystemEnvVarDef {
     key: &'static str,
     description: &'static str,
     default_fn: fn(&SystemEnvVarContext) -> Option<String>,
+    policy: DefaultPolicy,
+    /// When true, the entry is registered with category `system-shared`. The UI uses
+    /// this to surface the key as a team-shared candidate (encrypted, synced via
+    /// `shared_secrets`) and never seeds a value into the local keychain blob.
+    shared_default: bool,
 }
 
 /// Registry of all system env vars.
 /// To add a new one: append an entry here — nothing else changes.
-pub(crate) const SYSTEM_ENV_VARS: &[SystemEnvVarDef] = &[SystemEnvVarDef {
-    key: "tc_api_key",
-    description: "Team LLM API Key",
-    default_fn: |ctx| {
-        if ctx.device_id.is_empty() {
-            return None;
-        }
-        let id = &ctx.device_id;
-        // 40 chars: matches the LiteLLM virtual key suffix length limit
-        Some(format!("sk-tc-{}", &id[..id.len().min(40)]))
+pub(crate) const SYSTEM_ENV_VARS: &[SystemEnvVarDef] = &[
+    SystemEnvVarDef {
+        key: "tc_api_key",
+        description: "Team LLM API Key",
+        default_fn: |ctx| {
+            if ctx.device_id.is_empty() {
+                return None;
+            }
+            let id = &ctx.device_id;
+            // 40 chars: matches the LiteLLM virtual key suffix length limit
+            Some(format!("sk-tc-{}", &id[..id.len().min(40)]))
+        },
+        policy: DefaultPolicy::RegenerateAlways,
+        shared_default: false,
     },
-}];
+    SystemEnvVarDef {
+        key: "AUTOUI_VISION_BASE_URL",
+        description: "AutoUI vision endpoint (OpenAI-compatible)",
+        default_fn: |_| None,
+        policy: DefaultPolicy::SetIfAbsent,
+        shared_default: true,
+    },
+    SystemEnvVarDef {
+        key: "AUTOUI_VISION_API_KEY",
+        description: "AutoUI vision API key",
+        default_fn: |_| None,
+        policy: DefaultPolicy::SetIfAbsent,
+        shared_default: true,
+    },
+    SystemEnvVarDef {
+        key: "AUTOUI_VISION_MODEL",
+        description: "AutoUI vision model name",
+        default_fn: |_| None,
+        policy: DefaultPolicy::SetIfAbsent,
+        shared_default: true,
+    },
+];
 
 /// A single environment variable entry (key + description, no value).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -385,10 +427,14 @@ pub async fn env_var_delete(state: State<'_, OpenCodeState>, key: String) -> Res
     let mut json = read_teamclaw_json(&workspace_path)?;
     let mut entries = get_env_vars_from_json(&json);
 
-    // Check category — system vars cannot be deleted
+    // Check category — system / system-shared vars cannot be deleted from the index
+    // (they're auto-registered each launch by `ensure_system_env_vars`).
     if let Some(entry) = entries.iter().find(|e| e.key == key) {
-        if entry.category.as_deref() == Some("system") {
-            return Err(format!("System variable '{}' cannot be deleted", key));
+        match entry.category.as_deref() {
+            Some("system") | Some("system-shared") => {
+                return Err(format!("System variable '{}' cannot be deleted", key));
+            }
+            _ => {}
         }
     }
 
@@ -509,47 +555,87 @@ pub(crate) fn ensure_system_env_vars(workspace_path: &str, device_id: &str) -> R
     let mut index_changed = false;
 
     for def in SYSTEM_ENV_VARS {
-        // Check if there's already a non-empty value in the blob
-        let existing_value = blob.get(def.key).and_then(|v| v.as_str()).unwrap_or("");
+        // `system-shared` defs never touch the local keychain blob — their values
+        // live in `shared_secrets` (team KMS) and are injected into opencode at startup.
+        // We only register them in the teamclaw.json index so the key shows up in
+        // the env-var UI on every member's machine.
+        if !def.shared_default {
+            let key_present_in_blob = blob.contains_key(def.key);
+            let existing_value = blob.get(def.key).and_then(|v| v.as_str()).unwrap_or("");
 
-        // Always regenerate: the device_id source may have changed (e.g. UUID → iroh node_id),
-        // so we overwrite whenever the generated value differs from the stored one.
-        if let Some(new_value) = (def.default_fn)(&ctx) {
-            if existing_value != new_value {
-                if !existing_value.is_empty() {
-                    println!("[EnvVars] Updating system var {} (value changed)", def.key);
-                } else {
-                    println!(
-                        "[EnvVars] Generated default value for system var: {}",
-                        def.key
-                    );
+            match def.policy {
+                DefaultPolicy::RegenerateAlways => {
+                    // Re-derive on every startup; overwrite if the result differs.
+                    // Used when the default depends on mutable system state (e.g. device_id).
+                    if let Some(new_value) = (def.default_fn)(&ctx) {
+                        if existing_value != new_value {
+                            if !existing_value.is_empty() {
+                                println!(
+                                    "[EnvVars] Updating system var {} (value changed)",
+                                    def.key
+                                );
+                            } else {
+                                println!(
+                                    "[EnvVars] Generated default value for system var: {}",
+                                    def.key
+                                );
+                            }
+                            blob.insert(
+                                def.key.to_string(),
+                                serde_json::Value::String(new_value),
+                            );
+                            blob_changed = true;
+                        }
+                    }
                 }
-                blob.insert(def.key.to_string(), serde_json::Value::String(new_value));
-                blob_changed = true;
+                DefaultPolicy::SetIfAbsent => {
+                    // Only seed the default when the key has never been written.
+                    // An existing empty string is treated as "user left it blank intentionally".
+                    if !key_present_in_blob {
+                        if let Some(default) = (def.default_fn)(&ctx) {
+                            println!("[EnvVars] Seeding system var {} with default", def.key);
+                            blob.insert(
+                                def.key.to_string(),
+                                serde_json::Value::String(default),
+                            );
+                            blob_changed = true;
+                        }
+                    }
+                }
             }
         }
 
-        // Only register in index if the blob has a value (either pre-existing or just generated)
-        let blob_has_value_now = blob
-            .get(def.key)
-            .and_then(|v| v.as_str())
-            .map_or(false, |v| !v.is_empty());
-        if !blob_has_value_now {
-            // Skip index entry — no value available (e.g., device_id not ready)
+        // Decide whether to register in the index (synced via teamclaw.json):
+        //   - shared_default:                always register (key shows in UI; value lives in shared_secrets).
+        //   - SetIfAbsent (local):           always register so the key shows even before a value is set.
+        //   - RegenerateAlways (local):      only when the blob holds a non-empty value
+        //                                    (skip when the generator yielded nothing, e.g. device_id not ready).
+        let should_index = if def.shared_default {
+            true
+        } else {
+            match def.policy {
+                DefaultPolicy::RegenerateAlways => blob
+                    .get(def.key)
+                    .and_then(|v| v.as_str())
+                    .map_or(false, |v| !v.is_empty()),
+                DefaultPolicy::SetIfAbsent => true,
+            }
+        };
+        if !should_index {
             continue;
         }
 
-        // Ensure index entry exists with category: "system"
+        let target_category = if def.shared_default { "system-shared" } else { "system" };
         if let Some(existing) = entries.iter_mut().find(|e| e.key == def.key) {
-            if existing.category.as_deref() != Some("system") {
-                existing.category = Some("system".to_string());
+            if existing.category.as_deref() != Some(target_category) {
+                existing.category = Some(target_category.to_string());
                 index_changed = true;
             }
         } else {
             entries.push(EnvVarEntry {
                 key: def.key.to_string(),
                 description: Some(def.description.to_string()),
-                category: Some("system".to_string()),
+                category: Some(target_category.to_string()),
             });
             index_changed = true;
         }

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -967,21 +967,43 @@ fn ensure_inherent_config(workspace_path: &str) -> Result<(), String> {
         }
 
         if !mcp_obj.contains_key("autoui") {
+            // No `environment` block: AUTOUI_VISION_* are managed via the env-var
+            // settings page (system-shared scope) and injected into the opencode
+            // sidecar process at startup, so autoui-mcp picks them up via std::env::var.
             mcp_obj.insert(
                 "autoui".to_string(),
                 serde_json::json!({
                     "type": "local",
                     "enabled": true,
-                    "command": ["npx", "-y", "autoui-mcp@latest"],
-                    "environment": {
-                        "AUTOUI_VISION_API_KEY": "${tc_api_key}",
-                        "AUTOUI_VISION_BASE_URL": "https://ai.ucar.cc",
-                        "AUTOUI_VISION_MODEL": "qwen3-vl-flash"
-                    }
+                    "command": ["npx", "-y", "autoui-mcp@latest"]
                 }),
             );
             changed = true;
             println!("[Config] Added inherent 'autoui' MCP config");
+        } else if let Some(autoui) = mcp_obj.get_mut("autoui").and_then(|v| v.as_object_mut()) {
+            // Migration: drop the auto-injected `environment` block so vision config
+            // is sourced from the env-var settings page (system-shared scope) and
+            // injected via the opencode sidecar's process env. Only strip when every
+            // key matches the known auto-injected set, so user-added overrides are
+            // preserved.
+            let known_keys: &[&str] = &[
+                "AUTOUI_VISION_API_KEY",
+                "AUTOUI_VISION_BASE_URL",
+                "AUTOUI_VISION_MODEL",
+                "QWEN_API_KEY",
+                "QWEN_BASE_URL",
+                "QWEN_MODEL",
+            ];
+            let strip = autoui
+                .get("environment")
+                .and_then(|v| v.as_object())
+                .map(|env| !env.is_empty() && env.keys().all(|k| known_keys.contains(&k.as_str())))
+                .unwrap_or(false);
+            if strip {
+                autoui.remove("environment");
+                changed = true;
+                println!("[Config] Stripped legacy 'environment' block from autoui MCP config");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Move the autoui MCP server's vision config (`AUTOUI_VISION_BASE_URL` / `_API_KEY` / `_MODEL`) out of `opencode.json`'s inline `environment` block and into the env-var settings page as `system-shared` keys — auto-registered on every machine, encrypted in `shared_secrets`, synced via team.

- **`env_vars.rs`**: add `DefaultPolicy` + `shared_default` to `SystemEnvVarDef`; register the three `AUTOUI_VISION_*` keys with `category: system-shared`; never seed them into the local keychain blob; extend the delete guard.
- **`opencode.rs`**: stop emitting the `environment` block when seeding inherent autoui config; migrate existing entries by stripping the auto-injected block (only when every key is a known auto-injected name, so user overrides survive).
- **`EnvVarsSection.tsx`**: fold `system-shared` defs into the matching team secret (display key promoted to canonical UPPER_CASE) or render an amber "Not configured" placeholder when no value is set; dialog defaults *Share with team* to checked for placeholders and lowercases the key on save (shared_secrets enforces lowercase server-side; opencode injects both cases at startup so `AUTOUI_VISION_*` still resolves inside autoui-mcp).
- **`AddMCPDialog.tsx`**: for inherent MCPs (`autoui` / `playwright` / `chrome-control` / `teamclaw-introspect`) replace the env-var editor with a notice card pointing to the env-var settings page; force-empty the env block on save to defend against legacy in-flight configs.

LiteLLM proxy at `ai.ucar.cc` already has `qwen3-vl-flash` registered against dashscope (`https://dashscope.aliyuncs.com/compatible-mode/v1`), verified end-to-end (text + 64×64 vision smoke test).

## Test plan
- [ ] App starts: `ensure_inherent_mcp_configs` strips the legacy `environment` block from existing autoui entries — only when every key matches the known auto-injected names (`AUTOUI_VISION_*` / `QWEN_*`).
- [ ] App starts: `ensure_system_env_vars` registers `AUTOUI_VISION_*` in `teamclaw.json` with `category: system-shared` and does NOT seed values into the local keychain blob.
- [ ] Settings → Environment Variables: `AUTOUI_VISION_*` rows show **System** + **Team** badges; unset rows display amber "Not configured".
- [ ] Edit a placeholder: *Share with team* is pre-checked & disabled; saving stores under lowercased key in `shared_secrets`; restart-prompt appears.
- [ ] After restart: opencode injects both lowercase and uppercase forms into the sidecar env; `npx autoui-mcp` resolves `AUTOUI_VISION_API_KEY` via `std::env::var`; vision tool calls succeed.
- [ ] Settings → MCP → edit `autoui`: env-var editor is replaced by a notice card listing the three required keys; saving doesn't re-introduce an `environment` block.
- [ ] Cross-device: secret syncs via team, autoui-mcp on the second machine resolves the same value after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)