### PR TITLE
fix(team): wait for OpenCode workspace before loading Git tab

### DIFF
--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -29,6 +29,7 @@ import { TeamMemberList } from '@/components/settings/TeamMemberList'
 import { DeviceIdDisplay } from '@/components/settings/DeviceIdDisplay'
 import { HostLlmConfig } from './HostLlmConfig'
 import { useTeamMembersStore } from '@/stores/team-members'
+import { useWorkspaceStore } from '@/stores/workspace'
 import { buildConfig, TEAM_SYNCED_EVENT, TEAM_REPO_DIR } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -135,6 +136,8 @@ function SettingCard({ children, className }: { children: React.ReactNode; class
 export function TeamGitConfig() {
   const { t } = useTranslation()
   const teamMembersStore = useTeamMembersStore()
+  const workspacePath = useWorkspaceStore((s) => s.workspacePath)
+  const openCodeReady = useWorkspaceStore((s) => s.openCodeReady)
   const [deviceInfo, setDeviceInfo] = React.useState<{ nodeId: string } | null>(null)
   const [state, setState] = React.useState<ConnectionState>('loading')
   const [teamConfig, setTeamConfig] = React.useState<TeamConfig | null>(null)
@@ -193,6 +196,12 @@ export function TeamGitConfig() {
         return
       }
 
+      // Wait for OpenCode to register the workspace in backend state.
+      // Otherwise get_team_config races startup and throws "No workspace path set".
+      if (!workspacePath || !openCodeReady) {
+        return
+      }
+
       const gitCheck = await tauriInvoke<GitCheckResult>('team_check_git_installed')
       if (!gitCheck.installed) {
         setState('no-git')
@@ -227,7 +236,7 @@ export function TeamGitConfig() {
       setErrorMessage(err instanceof Error ? err.message : String(err))
       setState('error')
     }
-  }, [])
+  }, [workspacePath, openCodeReady])
 
   React.useEffect(() => {
     initialize()


### PR DESCRIPTION
## Summary
- Settings → Team → Git showed a red "No workspace path set" error on new/empty workspaces due to a startup race: `get_team_config` requires `OpenCodeState.workspace_path`, which is only set after `start_opencode` finishes, but `initialize()` fired before that.
- Gate `initialize()` on `useWorkspaceStore`'s `workspacePath` + `openCodeReady` so the Git tab waits for OpenCode the same way the S3/OSS tab already does. During the race the tab just shows the existing loading spinner and auto-proceeds when the workspace is registered.

## Test plan
- [ ] Open a brand-new empty workspace, immediately navigate to Settings → Team → Git — no red banner, spinner resolves into the normal Create/Join form.
- [ ] Existing workspace with saved team config still loads straight into the Connected view.
- [ ] `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)