### PR TITLE
feat(team-git): register LiteLLM for managed-Git invite users

### DIFF
--- a/fc/index.mjs
+++ b/fc/index.mjs
@@ -690,6 +690,85 @@ async function codeupFetch(path, method, body) {
   }
 }
 
+/**
+ * POST /managed-git/setup-litellm — bootstrap LiteLLM for a managed-Git team.
+ *
+ * Managed-Git teams skip the OSS /register flow, so they have no entry in
+ * teams/{teamId}/_registry/auth.json. This endpoint:
+ *   1. Writes auth.json + _meta/team.json (idempotent — same secret hash → no-op).
+ *   2. Creates the LiteLLM team (idempotent — 409 treated as success).
+ *   3. Issues the owner's LiteLLM key.
+ *
+ * After this runs, subsequent /ai/add-member calls (for joining members) work,
+ * because verifyTeam can now find auth.json.
+ */
+async function handleManagedGitSetupLitellm(body) {
+  const { teamId, teamSecret, teamName, ownerNodeId, ownerName } = body;
+  if (!teamId || !teamSecret || !ownerNodeId) {
+    return json(400, { error: "Missing teamId, teamSecret, or ownerNodeId" });
+  }
+
+  const teamSecretHash = sha256(teamSecret);
+  const existing = await ossGet(`teams/${teamId}/_registry/auth.json`);
+  if (existing) {
+    if (existing.teamSecretHash !== teamSecretHash) {
+      return json(403, { error: "Team already registered with different secret" });
+    }
+  } else {
+    const createdAt = new Date().toISOString();
+    await ossPut(`teams/${teamId}/_registry/auth.json`, {
+      schemaVersion: 1,
+      teamSecretHash,
+      ownerNodeId,
+      createdAt,
+    });
+    await ossPut(`teams/${teamId}/_meta/team.json`, {
+      schemaVersion: 1,
+      teamId,
+      teamName: teamName || teamId,
+      ownerName: ownerName || "",
+      ownerNodeId,
+      createdAt,
+    });
+    console.log(`[managed-git/setup-litellm] Registered teamId=${teamId} owner=${ownerNodeId.slice(0, 8)}`);
+  }
+
+  const litellmTeamId = `tc-${teamId}`;
+  const maxBudget = LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD();
+  const teamRes = await litellmFetch("/team/new", "POST", {
+    team_id: litellmTeamId,
+    team_alias: teamName || teamId,
+    max_budget: maxBudget,
+  });
+  if (!teamRes.ok && teamRes.status !== 409) {
+    console.error(`[managed-git/setup-litellm] team/new error:`, teamRes.data);
+    return json(502, { error: "Failed to create LiteLLM team", detail: teamRes.data });
+  }
+
+  const keyAlias = `${ownerName || "owner"}-${ownerNodeId.slice(0, 8)}`;
+  const keyValue = `sk-tc-${ownerNodeId.slice(0, 40)}`;
+  const keyRes = await litellmFetch("/key/generate", "POST", {
+    key: keyValue,
+    team_id: litellmTeamId,
+    key_alias: keyAlias,
+  });
+  if (!keyRes.ok) {
+    console.error(`[managed-git/setup-litellm] key/generate error:`, keyRes.data);
+    return json(502, { error: "Failed to create owner key", detail: keyRes.data });
+  }
+
+  console.log(
+    `[managed-git/setup-litellm] team=${litellmTeamId} owner=${ownerNodeId.slice(0, 8)} max_budget_usd=${maxBudget}`
+  );
+  return json(200, {
+    success: true,
+    litellmTeamId,
+    key: keyValue,
+    keyAlias,
+    maxBudgetUsd: maxBudget,
+  });
+}
+
 /** POST /managed-git/create-repo — create a private CodeUp repo for a team */
 async function handleManagedGitCreateRepo(body) {
   const { teamName } = body;
@@ -804,6 +883,8 @@ export async function handler(event, context) {
         return await handleAiBudget(body);
       case "/managed-git/create-repo":
         return await handleManagedGitCreateRepo(body);
+      case "/managed-git/setup-litellm":
+        return await handleManagedGitSetupLitellm(body);
       default:
         return json(404, { error: "Not found" });
     }

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -23,12 +23,13 @@ import {
   Save,
   Copy,
 } from 'lucide-react'
-import { cn, isTauri } from '@/lib/utils'
+import { cn, isTauri, copyToClipboard } from '@/lib/utils'
 import { ToggleSwitch } from '@/components/settings/shared'
 import { TeamMemberList } from '@/components/settings/TeamMemberList'
 import { DeviceIdDisplay } from '@/components/settings/DeviceIdDisplay'
 import { HostLlmConfig } from './HostLlmConfig'
 import { useTeamMembersStore } from '@/stores/team-members'
+import { useWorkspaceStore } from '@/stores/workspace'
 import { buildConfig, TEAM_SYNCED_EVENT, TEAM_REPO_DIR } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -135,6 +136,8 @@ function SettingCard({ children, className }: { children: React.ReactNode; class
 export function TeamGitConfig() {
   const { t } = useTranslation()
   const teamMembersStore = useTeamMembersStore()
+  const workspacePath = useWorkspaceStore((s) => s.workspacePath)
+  const openCodeReady = useWorkspaceStore((s) => s.openCodeReady)
   const [deviceInfo, setDeviceInfo] = React.useState<{ nodeId: string } | null>(null)
   const [state, setState] = React.useState<ConnectionState>('loading')
   const [teamConfig, setTeamConfig] = React.useState<TeamConfig | null>(null)
@@ -193,6 +196,12 @@ export function TeamGitConfig() {
         return
       }
 
+      // Wait for OpenCode to register the workspace in backend state.
+      // Otherwise get_team_config races startup and throws "No workspace path set".
+      if (!workspacePath || !openCodeReady) {
+        return
+      }
+
       const gitCheck = await tauriInvoke<GitCheckResult>('team_check_git_installed')
       if (!gitCheck.installed) {
         setState('no-git')
@@ -227,7 +236,7 @@ export function TeamGitConfig() {
       setErrorMessage(err instanceof Error ? err.message : String(err))
       setState('error')
     }
-  }, [])
+  }, [workspacePath, openCodeReady])
 
   React.useEffect(() => {
     initialize()
@@ -367,6 +376,7 @@ export function TeamGitConfig() {
         llmModel: hostLlm ? (llmModels[0]?.id || null) : null,
         llmModelName: hostLlm ? (llmModels[0]?.name || null) : null,
         llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
+        fcEndpoint: managedGit ? MANAGED_GIT_FC_ENDPOINT : null,
       })
       setConnectStep('Saving configuration...')
       const now = new Date().toISOString()
@@ -431,6 +441,9 @@ export function TeamGitConfig() {
     try {
       setConnectStep('Joining team...')
       const effectiveGitToken = gitToken.trim() || null
+      // Joining via invite code implies the team was created via managed-Git,
+      // so its LiteLLM team is registered on the managed FC endpoint.
+      const joinedViaInvite = !!decodeInviteCode(inviteCodeInput)
       await tauriInvoke<{ success: boolean; message: string }>('team_git_join', {
         gitUrl: gitUrl.trim(),
         gitToken: effectiveGitToken,
@@ -442,6 +455,7 @@ export function TeamGitConfig() {
         llmModel: hostLlm ? (llmModels[0]?.id || null) : null,
         llmModelName: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
         llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
+        fcEndpoint: joinedViaInvite ? MANAGED_GIT_FC_ENDPOINT : null,
       })
       setConnectStep('Saving configuration...')
       const now = new Date().toISOString()
@@ -1001,7 +1015,7 @@ export function TeamGitConfig() {
                           p: teamConfig.gitToken!,
                           u: 'teamclaw',
                         })
-                        navigator.clipboard.writeText(code)
+                        await copyToClipboard(code, t('common.copied', 'Copied!'))
                       }}
                     >
                       <Copy className="h-3 w-3" />
@@ -1018,7 +1032,7 @@ export function TeamGitConfig() {
                         variant="ghost"
                         size="sm"
                         className="shrink-0 h-7 w-7 p-0"
-                        onClick={() => navigator.clipboard.writeText(teamConfig.teamId!)}
+                        onClick={() => copyToClipboard(teamConfig.teamId!, t('common.copied', 'Copied!'))}
                       >
                         <Copy className="h-3.5 w-3.5 text-muted-foreground" />
                       </Button>
@@ -1051,15 +1065,14 @@ export function TeamGitConfig() {
                         size="sm"
                         className="shrink-0 h-7 w-7 p-0"
                         onClick={async () => {
-                          if (!loadedTeamSecret) {
+                          let secret = loadedTeamSecret
+                          if (!secret) {
                             try {
-                              const secret = await tauriInvoke<string>('get_git_team_secret', { teamId: teamConfig.teamId })
+                              secret = await tauriInvoke<string>('get_git_team_secret', { teamId: teamConfig.teamId })
                               setLoadedTeamSecret(secret)
-                              navigator.clipboard.writeText(secret)
-                            } catch { /* ignore */ }
-                          } else {
-                            navigator.clipboard.writeText(loadedTeamSecret)
+                            } catch { return }
                           }
+                          await copyToClipboard(secret, t('common.copied', 'Copied!'))
                         }}
                       >
                         <Copy className="h-3.5 w-3.5 text-muted-foreground" />

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -952,6 +952,7 @@ pub async fn team_git_create(
     llm_model: Option<String>,
     llm_model_name: Option<String>,
     llm_models: Option<String>,
+    fc_endpoint: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
     secrets_state: State<'_, crate::commands::shared_secrets::SharedSecretsState>,
 ) -> Result<TeamGitCreateResult, String> {
@@ -1137,6 +1138,35 @@ pub async fn team_git_create(
         }
     }
 
+    // Fire-and-forget: bootstrap LiteLLM team + owner key via FC.
+    // Only runs for managed-Git (frontend passes fc_endpoint when managedGit=true).
+    if let Some(endpoint) = fc_endpoint.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        let url = format!("{}/managed-git/setup-litellm", endpoint.trim_end_matches('/'));
+        let body = serde_json::json!({
+            "teamId": team_id,
+            "teamSecret": team_secret,
+            "teamName": team_name,
+            "ownerNodeId": node_id,
+            "ownerName": git_user_name,
+        });
+        println!("[Team Create] Scheduling LiteLLM bootstrap via FC: {}", url);
+        tokio::spawn(async move {
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new());
+            match client.post(&url).json(&body).send().await {
+                Ok(r) => println!(
+                    "[Team Create] LiteLLM via FC: setup-litellm HTTP status={}",
+                    r.status()
+                ),
+                Err(e) => eprintln!(
+                    "[Team Create] LiteLLM via FC: setup-litellm request failed: {e}"
+                ),
+            }
+        });
+    }
+
     Ok(TeamGitCreateResult {
         team_id,
         team_secret,
@@ -1156,6 +1186,7 @@ pub async fn team_git_join(
     llm_model: Option<String>,
     llm_model_name: Option<String>,
     llm_models: Option<String>,
+    fc_endpoint: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
     secrets_state: State<'_, crate::commands::shared_secrets::SharedSecretsState>,
 ) -> Result<TeamGitResult, String> {
@@ -1362,6 +1393,34 @@ pub async fn team_git_join(
         Err(e) => {
             println!("[Team Join] Warning: Failed to sync MCP configs: {}", e);
         }
+    }
+
+    // Fire-and-forget: register joining member's LiteLLM key via FC.
+    // Only runs for managed-Git (frontend passes fc_endpoint when managedGit=true).
+    if let Some(endpoint) = fc_endpoint.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        let url = format!("{}/ai/add-member", endpoint.trim_end_matches('/'));
+        let body = serde_json::json!({
+            "teamId": team_id,
+            "teamSecret": team_secret,
+            "nodeId": node_id,
+            "memberName": member_name,
+        });
+        println!("[Team Join] Scheduling LiteLLM add-member via FC: {}", url);
+        tokio::spawn(async move {
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new());
+            match client.post(&url).json(&body).send().await {
+                Ok(r) => println!(
+                    "[Team Join] LiteLLM via FC: add-member HTTP status={}",
+                    r.status()
+                ),
+                Err(e) => eprintln!(
+                    "[Team Join] LiteLLM via FC: add-member request failed: {e}"
+                ),
+            }
+        });
     }
 
     // 14. Return success


### PR DESCRIPTION
## Summary
- Managed-Git create/join previously skipped FC, so invited members never got a LiteLLM key and couldn't use team AI features. This PR mirrors the OSS flow with fire-and-forget FC calls.
- New FC endpoint `POST /managed-git/setup-litellm` (idempotent): writes `auth.json` + `_meta/team.json` so subsequent `verifyTeam` works, creates the LiteLLM team, and issues the owner's key.
- Rust `team_git_create` / `team_git_join` take an optional `fc_endpoint` and spawn a background POST. Frontend passes the managed FC endpoint only for managed-Git create or invite-code join — BYO-Git stays unchanged.

## Notes
- FC is **already deployed** to `https://cloud.ucar.cc` so the new desktop client just needs to ship.
- Drive-by fixes in `TeamGitConfig.tsx`: use `copyToClipboard` helper (Tauri-safe), and gate `initialize()` on workspace readiness to avoid the `No workspace path set` startup race.

## Test plan
- [ ] Create a new managed-Git team → check FC logs show `[managed-git/setup-litellm]` line and an owner LiteLLM key is issued
- [ ] Generate invite code, join from a second device → FC logs show `[ai/add-member]` line and the joining device gets a key
- [ ] BYO-Git create/join still works and does **not** call FC
- [ ] Re-running create with the same teamId/secret is a no-op (idempotent), with mismatched secret returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)