### PR TITLE
fix(team): reload shared_secrets on sync+restart; revert autoui QWEN env

### DIFF
--- a/autoui-mcp/src/config.rs
+++ b/autoui-mcp/src/config.rs
@@ -3,28 +3,27 @@ use std::env;
 /// Application configuration loaded from environment variables.
 #[derive(Debug, Clone)]
 pub struct Config {
-    /// API key for the OpenAI-compatible vision endpoint (locate / verify / plan)
-    pub vision_api_key: String,
-    /// OpenAI-compatible API base URL
-    pub vision_base_url: String,
+    /// Qwen API key for vision locate / verify
+    pub qwen_api_key: String,
+    /// Qwen-compatible API base URL
+    pub qwen_base_url: String,
     /// Vision model name
-    pub vision_model: String,
+    pub qwen_model: String,
 }
 
 impl Config {
     /// Build config from environment variables.
     pub fn from_env() -> Self {
         Self {
-            vision_api_key: env::var("AUTOUI_VISION_API_KEY").unwrap_or_default(),
-            vision_base_url: env::var("AUTOUI_VISION_BASE_URL")
+            qwen_api_key: env::var("QWEN_API_KEY").unwrap_or_default(),
+            qwen_base_url: env::var("QWEN_BASE_URL")
                 .unwrap_or_else(|_| "https://dashscope.aliyuncs.com/compatible-mode/v1".into()),
-            vision_model: env::var("AUTOUI_VISION_MODEL")
-                .unwrap_or_else(|_| "qwen3-vl-flash".into()),
+            qwen_model: env::var("QWEN_MODEL").unwrap_or_else(|_| "qwen3-vl-flash".into()),
         }
     }
 
-    /// Returns true when a vision API key has been configured.
+    /// Returns true when a Qwen API key has been configured.
     pub fn has_vision(&self) -> bool {
-        !self.vision_api_key.is_empty()
+        !self.qwen_api_key.is_empty()
     }
 }

--- a/autoui-mcp/src/main.rs
+++ b/autoui-mcp/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     tracing::info!("Starting AutoUI MCP Server v{}", env!("CARGO_PKG_VERSION"));
     tracing::info!(
         vision_enabled = config.has_vision(),
-        model = config.vision_model.as_str(),
+        model = config.qwen_model.as_str(),
         "Configuration loaded"
     );
 

--- a/autoui-mcp/src/mcp.rs
+++ b/autoui-mcp/src/mcp.rs
@@ -131,7 +131,7 @@ impl AutoUiService {
     ) -> Result<CallToolResult, McpError> {
         if !self.config.has_vision() {
             return Ok(CallToolResult::error(vec![Content::text(
-                "Error: AUTOUI_VISION_API_KEY not configured. Set it in environment.",
+                "Error: QWEN_API_KEY not configured. Set it in environment.",
             )]));
         }
         let assertion = req.assertion.trim().to_string();
@@ -173,7 +173,7 @@ impl AutoUiService {
     ) -> Result<CallToolResult, McpError> {
         if !self.config.has_vision() {
             return Ok(CallToolResult::error(vec![Content::text(
-                "Error: AUTOUI_VISION_API_KEY not configured. Set it in environment.",
+                "Error: QWEN_API_KEY not configured. Set it in environment.",
             )]));
         }
         let intent = req.intent.trim().to_string();

--- a/autoui-mcp/src/vision.rs
+++ b/autoui-mcp/src/vision.rs
@@ -485,7 +485,7 @@ fn build_chat_body(
     max_tokens: u32,
 ) -> Value {
     serde_json::json!({
-        "model": config.vision_model,
+        "model": config.qwen_model,
         "messages": [
             { "role": "system", "content": system_prompt },
             {
@@ -515,8 +515,8 @@ async fn call_qwen(config: &Config, body: &Value) -> Result<String> {
         .context("HTTP client build failed")?;
 
     let resp = client
-        .post(format!("{}/chat/completions", config.vision_base_url))
-        .header("Authorization", format!("Bearer {}", config.vision_api_key))
+        .post(format!("{}/chat/completions", config.qwen_base_url))
+        .header("Authorization", format!("Bearer {}", config.qwen_api_key))
         .header("Content-Type", "application/json")
         .json(body)
         .send()

--- a/packages/app/src/components/settings/AddMCPDialog.tsx
+++ b/packages/app/src/components/settings/AddMCPDialog.tsx
@@ -35,14 +35,11 @@ interface AddMCPDialogProps {
 const INHERENT_MCP_NAMES = new Set([
   'playwright',
   'chrome-control',
-  'autoui',
   'teamclaw-introspect',
 ])
 
 /** For each inherent server, the env-var keys the user should configure on the env-var page. */
-const INHERENT_REQUIRED_ENV_KEYS: Record<string, string[]> = {
-  autoui: ['AUTOUI_VISION_BASE_URL', 'AUTOUI_VISION_API_KEY', 'AUTOUI_VISION_MODEL'],
-}
+const INHERENT_REQUIRED_ENV_KEYS: Record<string, string[]> = {}
 
 interface EnvVar {
   id: string

--- a/packages/app/src/components/settings/EnvVarsSection.tsx
+++ b/packages/app/src/components/settings/EnvVarsSection.tsx
@@ -17,6 +17,8 @@ import { SettingCard, SectionHeader } from './shared'
 import { useEnvVarsStore } from '@/stores/env-vars'
 import { useSharedSecretsStore } from '@/stores/shared-secrets'
 import { useTeamMembersStore } from '@/stores/team-members'
+// `myRole` is null until the user joins a team; gate team-shared UI on it so
+// users without a team don't hit the backend's `secrets not initialized` error.
 import { useWorkspaceStore } from '@/stores/workspace'
 import { initOpenCodeClient } from '@/lib/opencode/sdk-client'
 import { listen } from '@tauri-apps/api/event'
@@ -41,6 +43,8 @@ interface EnvVarDialogProps {
 
 function EnvVarDialog({ open, onOpenChange, editingEntry, onSave }: EnvVarDialogProps) {
   const { t } = useTranslation()
+  const myRole = useTeamMembersStore((s) => s.myRole)
+  const teamAvailable = myRole !== null
   const [key, setKey] = React.useState('')
   const [value, setValue] = React.useState('')
   const [description, setDescription] = React.useState('')
@@ -66,8 +70,12 @@ function EnvVarDialog({ open, onOpenChange, editingEntry, onSave }: EnvVarDialog
       if (editingEntry) {
         setKey(editingEntry.key)
         setDescription(editingEntry.description || '')
-        // Default-share when editing a team secret OR a system-shared placeholder.
-        setShared(editingEntry.scope === 'team' || editingEntry.scope === 'team-placeholder')
+        // Default-share when editing a team secret OR a system-shared placeholder,
+        // but only if a team is actually available.
+        setShared(
+          teamAvailable &&
+            (editingEntry.scope === 'team' || editingEntry.scope === 'team-placeholder'),
+        )
         setValue('')
       } else {
         setKey('')
@@ -77,7 +85,7 @@ function EnvVarDialog({ open, onOpenChange, editingEntry, onSave }: EnvVarDialog
       }
       setError(null)
     }
-  }, [open, editingEntry])
+  }, [open, editingEntry, teamAvailable])
 
   const handleSave = async () => {
     const trimmedKey = key.trim()
@@ -184,23 +192,28 @@ function EnvVarDialog({ open, onOpenChange, editingEntry, onSave }: EnvVarDialog
           </div>
 
           {/* Share with team checkbox — locked for system-shared placeholders
-              (always team-shared) and existing team secrets (scope is fixed). */}
-          <div className="flex items-center gap-2">
-            <Checkbox
-              id="shared"
-              checked={shared}
-              onCheckedChange={(checked) => setShared(checked === true)}
-              disabled={isEditing || isPlaceholder}
-            />
-            <label htmlFor="shared" className="text-sm font-medium cursor-pointer select-none flex items-center gap-1.5">
-              <Users className="h-3.5 w-3.5 text-blue-500" />
-              {t('settings.envVars.shareWithTeam', 'Share with team')}
-            </label>
-          </div>
-          {shared && isFirstSave && (
-            <p className="text-xs text-muted-foreground ml-6">
-              {t('settings.envVars.shareHint', 'This variable will be encrypted and synced to all team members.')}
-            </p>
+              (always team-shared) and existing team secrets (scope is fixed).
+              Hidden entirely when the user has not joined a team. */}
+          {teamAvailable && (
+            <>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="shared"
+                  checked={shared}
+                  onCheckedChange={(checked) => setShared(checked === true)}
+                  disabled={isEditing || isPlaceholder}
+                />
+                <label htmlFor="shared" className="text-sm font-medium cursor-pointer select-none flex items-center gap-1.5">
+                  <Users className="h-3.5 w-3.5 text-blue-500" />
+                  {t('settings.envVars.shareWithTeam', 'Share with team')}
+                </label>
+              </div>
+              {shared && isFirstSave && (
+                <p className="text-xs text-muted-foreground ml-6">
+                  {t('settings.envVars.shareHint', 'This variable will be encrypted and synced to all team members.')}
+                </p>
+              )}
+            </>
           )}
 
           {error && (
@@ -437,6 +450,12 @@ export const EnvVarsSection = React.memo(function EnvVarsSection() {
   const { secrets, isLoading: secretsLoading, loadSecrets, setSecret, deleteSecret, listenForChanges } = useSharedSecretsStore()
   const currentNodeId = useTeamMembersStore((s) => s.currentNodeId)
   const myRole = useTeamMembersStore((s) => s.myRole)
+  // `myRole` / `currentNodeId` are usually hydrated by TeamMemberList when the
+  // user opens the Team settings panel. Env-Vars can be reached without ever
+  // visiting that panel, so load them here too — otherwise the "Share with team"
+  // gate stays closed for users who are actually in a team.
+  const loadMyRole = useTeamMembersStore((s) => s.loadMyRole)
+  const loadCurrentNodeId = useTeamMembersStore((s) => s.loadCurrentNodeId)
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
 
   const [addDialogOpen, setAddDialogOpen] = React.useState(false)
@@ -453,6 +472,8 @@ export const EnvVarsSection = React.memo(function EnvVarsSection() {
   React.useEffect(() => {
     loadEnvVars()
     loadSecrets()
+    loadMyRole()
+    loadCurrentNodeId()
     let unlisten: (() => void) | undefined
     listenForChanges().then((fn) => { unlisten = fn })
     // Also listen for secrets-changed from sync to mark as dirty
@@ -470,7 +491,7 @@ export const EnvVarsSection = React.memo(function EnvVarsSection() {
       unlisten?.()
       unlistenSync?.()
     }
-  }, [loadEnvVars, loadSecrets, listenForChanges])
+  }, [loadEnvVars, loadSecrets, listenForChanges, loadMyRole, loadCurrentNodeId])
 
   // Build unified list: personal env vars + team secrets, with `system-shared`
   // system defs surfaced as either the matching team secret (uppercase key) or

--- a/packages/app/src/components/settings/__tests__/EnvVarsSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/EnvVarsSection.test.tsx
@@ -71,7 +71,12 @@ vi.mock('@/stores/shared-secrets', () => ({
 
 vi.mock('@/stores/team-members', () => ({
   useTeamMembersStore: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector({ currentNodeId: null, myRole: null }),
+    selector({
+      currentNodeId: null,
+      myRole: null,
+      loadMyRole: vi.fn(),
+      loadCurrentNodeId: vi.fn(),
+    }),
 }))
 
 vi.mock('@tauri-apps/api/event', () => ({

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -11,6 +11,39 @@ import { appShortName, buildConfig, TEAM_REPO_DIR, type TeamModelOption } from '
 
 const TEAM_PROVIDER_ID = 'team'
 
+/**
+ * Upgrade `http://` → `https://` for remote LLM hosts.
+ *
+ * LiteLLM deployments behind Caddy/Nginx typically 308-redirect `http` → `https`,
+ * and both fetch and the AI SDK drop the `Authorization` header across that
+ * redirect — surfacing as `Authentication Error, No api key passed in.` on
+ * chat-completions calls. Force https for any non-local host before we hand
+ * the URL to OpenCode's provider config.
+ *
+ * Local/private hosts keep `http://` (they don't redirect, and users may run
+ * a dev LiteLLM without TLS).
+ */
+function normalizeLlmBaseUrl(url: string): string {
+  if (!url.startsWith('http://')) return url
+  try {
+    const parsed = new URL(url)
+    const host = parsed.hostname
+    const isLocal =
+      host === 'localhost' ||
+      host === '127.0.0.1' ||
+      host === '0.0.0.0' ||
+      host.endsWith('.local') ||
+      /^10\./.test(host) ||
+      /^192\.168\./.test(host) ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+    if (isLocal) return url
+    parsed.protocol = 'https:'
+    return parsed.toString().replace(/\/$/, '')
+  } catch {
+    return url
+  }
+}
+
 export interface TeamModelConfig {
   baseUrl: string
   model: string
@@ -130,7 +163,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
           } catch { /* ignore */ }
         }
         const config: TeamModelConfig = {
-          baseUrl: status.llm.baseUrl,
+          baseUrl: normalizeLlmBaseUrl(status.llm.baseUrl),
           model: selectedModel,
           modelName: selectedModelName,
         }

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -222,6 +222,7 @@ pub(crate) enum DefaultPolicy {
     RegenerateAlways,
     /// Write the default only when the key is missing from the blob.
     /// Empty user-set values are preserved (treated as "user has decided to leave blank").
+    #[allow(dead_code)]
     SetIfAbsent,
 }
 
@@ -239,43 +240,20 @@ pub(crate) struct SystemEnvVarDef {
 
 /// Registry of all system env vars.
 /// To add a new one: append an entry here — nothing else changes.
-pub(crate) const SYSTEM_ENV_VARS: &[SystemEnvVarDef] = &[
-    SystemEnvVarDef {
-        key: "tc_api_key",
-        description: "Team LLM API Key",
-        default_fn: |ctx| {
-            if ctx.device_id.is_empty() {
-                return None;
-            }
-            let id = &ctx.device_id;
-            // 40 chars: matches the LiteLLM virtual key suffix length limit
-            Some(format!("sk-tc-{}", &id[..id.len().min(40)]))
-        },
-        policy: DefaultPolicy::RegenerateAlways,
-        shared_default: false,
+pub(crate) const SYSTEM_ENV_VARS: &[SystemEnvVarDef] = &[SystemEnvVarDef {
+    key: "tc_api_key",
+    description: "Team LLM API Key",
+    default_fn: |ctx| {
+        if ctx.device_id.is_empty() {
+            return None;
+        }
+        let id = &ctx.device_id;
+        // 40 chars: matches the LiteLLM virtual key suffix length limit
+        Some(format!("sk-tc-{}", &id[..id.len().min(40)]))
     },
-    SystemEnvVarDef {
-        key: "AUTOUI_VISION_BASE_URL",
-        description: "AutoUI vision endpoint (OpenAI-compatible)",
-        default_fn: |_| None,
-        policy: DefaultPolicy::SetIfAbsent,
-        shared_default: true,
-    },
-    SystemEnvVarDef {
-        key: "AUTOUI_VISION_API_KEY",
-        description: "AutoUI vision API key",
-        default_fn: |_| None,
-        policy: DefaultPolicy::SetIfAbsent,
-        shared_default: true,
-    },
-    SystemEnvVarDef {
-        key: "AUTOUI_VISION_MODEL",
-        description: "AutoUI vision model name",
-        default_fn: |_| None,
-        policy: DefaultPolicy::SetIfAbsent,
-        shared_default: true,
-    },
-];
+    policy: DefaultPolicy::RegenerateAlways,
+    shared_default: false,
+}];
 
 /// A single environment variable entry (key + description, no value).
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -487,54 +487,21 @@ pub async fn start_opencode_inner(
     // Merge shared secrets (team KMS) into secrets vec.
     // Shared secrets take priority over local keyring entries with the same key.
     //
-    // Lazy init: if shared secrets haven't been initialized yet (e.g. early launch
-    // before oss_restore_sync), try to read team config and init from disk.
+    // On every (re)start: (1) lazy-init if needed — supports both OSS and Git
+    // teams via `try_lazy_init_from_workspace`, and (2) re-read the `_secrets/`
+    // directory unconditionally so we pick up envelopes that arrived via sync
+    // while the app was running (or while opencode was stopped).
     if let Some(shared_state) = app.try_state::<super::shared_secrets::SharedSecretsState>() {
-        {
-            let dk = shared_state
-                .derived_key
-                .lock()
-                .unwrap_or_else(|p| p.into_inner());
-            if dk.is_none() {
-                drop(dk);
-                // Try to init from workspace team config
-                let config_path = format!(
-                    "{}/{}/{}",
-                    workspace_path,
-                    super::TEAMCLAW_DIR,
-                    super::CONFIG_FILE_NAME
-                );
-                if let Ok(content) = std::fs::read_to_string(&config_path) {
-                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if let Some(oss) = json.get("oss") {
-                            if let (Some(team_id), Some(true)) = (
-                                oss.get("teamId").and_then(|v| v.as_str()),
-                                oss.get("enabled").and_then(|v| v.as_bool()),
-                            ) {
-                                if let Ok(team_secret) =
-                                    super::oss_sync::load_team_secret(&workspace_path, team_id)
-                                {
-                                    let team_dir = std::path::Path::new(&workspace_path)
-                                        .join(super::TEAM_REPO_DIR);
-                                    match super::shared_secrets::init_shared_secrets(
-                                        &shared_state,
-                                        &team_secret,
-                                        &team_dir,
-                                    ) {
-                                        Ok(()) => println!(
-                                            "[OpenCode] Lazy-initialized shared secrets from disk"
-                                        ),
-                                        Err(e) => eprintln!(
-                                            "[OpenCode] Failed to lazy-init shared secrets: {}",
-                                            e
-                                        ),
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+        if let Err(e) = super::shared_secrets::try_lazy_init_from_workspace(
+            &shared_state,
+            &workspace_path,
+        ) {
+            // Not an error when the workspace has no team — expected for solo workspaces.
+            println!("[OpenCode] shared_secrets init skipped: {}", e);
+        }
+        if let Err(e) = super::shared_secrets::load_all_secrets(&shared_state) {
+            // Only surfaces when init also failed (no team_dir set). Safe to ignore.
+            println!("[OpenCode] shared_secrets reload skipped: {}", e);
         }
 
         let shared_map = shared_state
@@ -967,42 +934,41 @@ fn ensure_inherent_config(workspace_path: &str) -> Result<(), String> {
         }
 
         if !mcp_obj.contains_key("autoui") {
-            // No `environment` block: AUTOUI_VISION_* are managed via the env-var
-            // settings page (system-shared scope) and injected into the opencode
-            // sidecar process at startup, so autoui-mcp picks them up via std::env::var.
             mcp_obj.insert(
                 "autoui".to_string(),
                 serde_json::json!({
                     "type": "local",
                     "enabled": true,
-                    "command": ["npx", "-y", "autoui-mcp@latest"]
+                    "command": ["npx", "-y", "autoui-mcp@latest"],
+                    "environment": {
+                        "QWEN_API_KEY": "${QWEN_API_KEY}",
+                        "QWEN_BASE_URL": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                        "QWEN_MODEL": "qwen3-vl-flash"
+                    }
                 }),
             );
             changed = true;
             println!("[Config] Added inherent 'autoui' MCP config");
         } else if let Some(autoui) = mcp_obj.get_mut("autoui").and_then(|v| v.as_object_mut()) {
-            // Migration: drop the auto-injected `environment` block so vision config
-            // is sourced from the env-var settings page (system-shared scope) and
-            // injected via the opencode sidecar's process env. Only strip when every
-            // key matches the known auto-injected set, so user-added overrides are
-            // preserved.
-            let known_keys: &[&str] = &[
-                "AUTOUI_VISION_API_KEY",
-                "AUTOUI_VISION_BASE_URL",
-                "AUTOUI_VISION_MODEL",
-                "QWEN_API_KEY",
-                "QWEN_BASE_URL",
-                "QWEN_MODEL",
-            ];
-            let strip = autoui
+            // Migration for users whose autoui `environment` block was stripped by a
+            // previous build: restore the 3 QWEN_* defaults. Only runs when the block
+            // is absent or empty, so partial user customizations are left alone.
+            let needs_restore = autoui
                 .get("environment")
                 .and_then(|v| v.as_object())
-                .map(|env| !env.is_empty() && env.keys().all(|k| known_keys.contains(&k.as_str())))
-                .unwrap_or(false);
-            if strip {
-                autoui.remove("environment");
+                .map(|env| env.is_empty())
+                .unwrap_or(true);
+            if needs_restore {
+                autoui.insert(
+                    "environment".to_string(),
+                    serde_json::json!({
+                        "QWEN_API_KEY": "${QWEN_API_KEY}",
+                        "QWEN_BASE_URL": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                        "QWEN_MODEL": "qwen3-vl-flash"
+                    }),
+                );
                 changed = true;
-                println!("[Config] Stripped legacy 'environment' block from autoui MCP config");
+                println!("[Config] Restored default environment block on autoui MCP config");
             }
         }
     }

--- a/src-tauri/src/commands/shared_secrets.rs
+++ b/src-tauri/src/commands/shared_secrets.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use super::shared_secrets_crypto::{
     decrypt_secret, derive_key, encrypt_secret, EncryptedEnvelope, SecretEntry, SecretMeta,
@@ -228,6 +228,59 @@ pub fn get_secret_value(state: &SharedSecretsState, key_id: &str) -> Option<Stri
     secrets.get(key_id).map(|e| e.key.clone())
 }
 
+/// Try to initialize shared_secrets from the workspace's team config.
+/// Supports both `oss.teamId` (OSS teams) and `team.teamId` (managed-Git teams).
+/// Fast-path returns Ok() immediately when already initialized.
+///
+/// Called by `shared_secret_set` / `shared_secret_delete` so a user who joined
+/// a team but hasn't yet mounted the TeamGitConfig panel (which eagerly inits
+/// from the frontend) can still save/delete shared secrets.
+pub fn try_lazy_init_from_workspace(
+    state: &SharedSecretsState,
+    workspace_path: &str,
+) -> Result<(), String> {
+    // Fast path: already initialized.
+    {
+        let dk = state
+            .derived_key
+            .lock()
+            .map_err(|e| format!("try_lazy_init: lock derived_key: {e}"))?;
+        if dk.is_some() {
+            return Ok(());
+        }
+    }
+
+    let config_path = format!(
+        "{}/{}/{}",
+        workspace_path,
+        super::TEAMCLAW_DIR,
+        super::CONFIG_FILE_NAME
+    );
+    let content = std::fs::read_to_string(&config_path)
+        .map_err(|_| "No team configured for this workspace".to_string())?;
+    let json: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse teamclaw.json: {e}"))?;
+
+    // Pick the first enabled team section that carries a `teamId`.
+    // Both OSS and Git team configs use camelCase `teamId` in JSON.
+    let team_id = ["oss", "team"]
+        .iter()
+        .find_map(|section| {
+            let obj = json.get(*section)?.as_object()?;
+            if obj.get("enabled").and_then(|v| v.as_bool()) != Some(true) {
+                return None;
+            }
+            obj.get("teamId")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+        })
+        .ok_or_else(|| "No team configured for this workspace".to_string())?;
+
+    let team_secret = super::oss_sync::load_team_secret(workspace_path, &team_id)?;
+    let team_dir = std::path::Path::new(workspace_path).join(super::TEAM_REPO_DIR);
+    init_shared_secrets(state, &team_secret, &team_dir)
+}
+
 // ---------------------------------------------------------------------------
 // Tauri commands
 // ---------------------------------------------------------------------------
@@ -244,6 +297,23 @@ pub async fn shared_secret_set(
     node_id: String,
 ) -> Result<(), String> {
     validate_key_id(&key_id)?;
+
+    // Lazy-init from workspace config when not yet initialized (e.g. Git teams
+    // whose TeamGitConfig panel hasn't been mounted yet this session).
+    if let Some(opencode_state) =
+        app_handle.try_state::<super::opencode::OpenCodeState>()
+    {
+        let workspace_path = opencode_state
+            .inner
+            .lock()
+            .ok()
+            .and_then(|inner| inner.workspace_path.clone());
+        if let Some(wp) = workspace_path {
+            if let Err(e) = try_lazy_init_from_workspace(&state, &wp) {
+                log::debug!("shared_secret_set: lazy init skipped: {e}");
+            }
+        }
+    }
 
     let team_dir = {
         let td = state
@@ -310,6 +380,22 @@ pub async fn shared_secret_delete(
     role: String,
 ) -> Result<(), String> {
     validate_key_id(&key_id)?;
+
+    // Same lazy-init as `shared_secret_set` — needed before the team_dir check below.
+    if let Some(opencode_state) =
+        app_handle.try_state::<super::opencode::OpenCodeState>()
+    {
+        let workspace_path = opencode_state
+            .inner
+            .lock()
+            .ok()
+            .and_then(|inner| inner.workspace_path.clone());
+        if let Some(wp) = workspace_path {
+            if let Err(e) = try_lazy_init_from_workspace(&state, &wp) {
+                log::debug!("shared_secret_delete: lazy init skipped: {e}");
+            }
+        }
+    }
 
     // Check permission: Owner can delete any; others can only delete their own
     {


### PR DESCRIPTION
## Summary

- **Reload team shared_secrets on every OpenCode (re)start**, not just first-launch on OSS teams. Replaces the OSS-only lazy-init in `start_opencode` with `try_lazy_init_from_workspace` (covers both `oss.teamId` and `team.teamId`) plus an unconditional `load_all_secrets`, so envelopes fetched via git pull / OSS sync while opencode was stopped are picked up on restart.
- **Lazy-init from `shared_secret_set` / `shared_secret_delete`** so Git-team members who reach the env-var page without mounting `TeamGitConfig` can still save team-shared secrets. Fixes `shared_secret_set: secrets not initialized` errors.
- **Revert #367/#368 autoui vision rename**: restore `QWEN_API_KEY / QWEN_BASE_URL / QWEN_MODEL` in autoui-mcp source, re-inject the inline `environment` block in the inherent MCP config (with migration for users whose block was stripped by the previous build), drop the three `AUTOUI_VISION_*` entries from `SYSTEM_ENV_VARS`, and remove autoui from `INHERENT_MCP_NAMES` so the env editor shows inline again.
- **Gate "Share with team" on team membership**: hide the checkbox when `myRole === null`. `EnvVarsSection` now eagerly calls `loadMyRole` / `loadCurrentNodeId` on mount so the gate resolves correctly when users reach env-vars without opening the Team settings panel.
- **Force `https://` for remote team LLM baseURLs** in `team-mode`. LiteLLM behind Caddy/Nginx 308-redirects http→https, and both `fetch` and the AI SDK strip `Authorization` across that redirect — surfacing as `Authentication Error, No api key passed in.` on chat/completions. Local/private hosts keep `http://`.

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm -w run rust:check` clean
- [ ] `pnpm --filter @teamclaw/app test:unit` — 881 tests pass
- [ ] Solo workspace (no team) → "Share with team" hidden in env-var add dialog
- [ ] Git team workspace → "Share with team" visible, save succeeds without needing to open Team settings first
- [ ] Team owner updates a shared secret → after git pull on another member, opencode restart picks up new value (check via `${KEY}` expansion)
- [ ] autoui MCP dialog shows the 3 QWEN_* env vars inline; existing workspaces whose environment block was stripped by the prior build get the defaults restored on next launch
- [ ] Team LLM with `http://ai.ucar.cc` in `llm.baseUrl` — chat/completions works (opencode.json provider.baseURL should be `https://`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)