### PR TITLE
feat(mcp): add manage_knowledge, manage_roles, manage_env_vars, manage_channels to introspect MCP

### DIFF
--- a/src-tauri/crates/teamclaw-introspect/src/channels.rs
+++ b/src-tauri/crates/teamclaw-introspect/src/channels.rs
@@ -1,0 +1,185 @@
+use crate::config;
+use serde_json::{json, Value};
+
+/// Fields that must never be returned to the AI (replace with "[configured]").
+const SENSITIVE: &[(&str, &[&str])] = &[
+    ("wecom", &["secret", "encodingAesKey"]),
+    ("discord", &["token"]),
+    ("feishu", &["appSecret"]),
+    ("email", &["gmailClientSecret", "password"]),
+    ("kook", &["token"]),
+    ("wechat", &["botToken"]),
+];
+
+pub async fn handle(workspace: &str, api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let action = arguments
+        .get("action")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: action")?;
+
+    match action {
+        "get" => {
+            let channel = arguments.get("channel").and_then(|v| v.as_str());
+            get_channels(workspace, channel)
+        }
+
+        "set" => {
+            let channel = arguments
+                .get("channel")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing field: channel")?;
+            let config = arguments
+                .get("config")
+                .ok_or("Missing field: config")?;
+
+            post_api(
+                api_port,
+                "/channel-set",
+                &json!({ "channel": channel, "config": config }),
+            )
+            .await
+        }
+
+        unknown => Err(format!(
+            "Unknown action: '{}'. Valid actions: get, set",
+            unknown
+        )),
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn get_channels(workspace: &str, channel: Option<&str>) -> Result<Value, String> {
+    let cfg = config::read_teamclaw_config(workspace)?;
+    let empty = json!({});
+    let channels = cfg.get("channels").unwrap_or(&empty);
+
+    if let Some(name) = channel {
+        let ch_cfg = channels.get(name).unwrap_or(&empty);
+        Ok(json!({
+            "channel": name,
+            "bound": is_bound(name, channels),
+            "config": redact(name, ch_cfg),
+        }))
+    } else {
+        let all_channels = ["wecom", "discord", "feishu", "email", "kook", "wechat"];
+        let result: serde_json::Map<String, Value> = all_channels
+            .iter()
+            .map(|name| {
+                let ch_cfg = channels.get(*name).unwrap_or(&empty);
+                let v = json!({
+                    "bound": is_bound(name, channels),
+                    "config": redact(name, ch_cfg),
+                });
+                (name.to_string(), v)
+            })
+            .collect();
+        Ok(Value::Object(result))
+    }
+}
+
+/// Replace sensitive field values with "[configured]" if non-empty, remove if empty.
+fn redact(channel: &str, config: &Value) -> Value {
+    let Some(obj) = config.as_object() else {
+        return config.clone();
+    };
+
+    let sensitive_keys: &[&str] = SENSITIVE
+        .iter()
+        .find(|(ch, _)| *ch == channel)
+        .map(|(_, keys)| *keys)
+        .unwrap_or(&[]);
+
+    let mut out = serde_json::Map::new();
+    for (k, v) in obj {
+        if sensitive_keys.contains(&k.as_str()) {
+            // Only include if non-empty string — indicate it's configured without revealing value
+            let is_set = v.as_str().map(|s| !s.is_empty()).unwrap_or(false);
+            if is_set {
+                out.insert(k.clone(), json!("[configured]"));
+            }
+        } else {
+            out.insert(k.clone(), v.clone());
+        }
+    }
+    Value::Object(out)
+}
+
+fn is_bound(name: &str, channels: &Value) -> bool {
+    use crate::capabilities::is_channel_bound_pub;
+    is_channel_bound_pub(name, channels)
+}
+
+async fn post_api(api_port: u16, path: &str, body: &Value) -> Result<Value, String> {
+    let url = format!("http://127.0.0.1:{api_port}{path}");
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}. Is the TeamClaw app running?"))?;
+
+    if !resp.status().is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("API error: {text}"));
+    }
+
+    resp.json::<Value>()
+        .await
+        .map_err(|e| format!("Failed to parse response: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_redact_wecom() {
+        let cfg = json!({ "botId": "bot123", "secret": "mysecret", "ownerId": "user1" });
+        let result = redact("wecom", &cfg);
+        assert_eq!(result["botId"], "bot123");
+        assert_eq!(result["ownerId"], "user1");
+        assert_eq!(result["secret"], "[configured]");
+    }
+
+    #[test]
+    fn test_redact_empty_secret_omitted() {
+        let cfg = json!({ "botId": "bot123", "secret": "" });
+        let result = redact("wecom", &cfg);
+        assert_eq!(result["botId"], "bot123");
+        assert!(result.get("secret").is_none());
+    }
+
+    #[test]
+    fn test_redact_discord() {
+        let cfg = json!({ "token": "abc123", "dm": { "enabled": true } });
+        let result = redact("discord", &cfg);
+        assert_eq!(result["token"], "[configured]");
+        assert_eq!(result["dm"]["enabled"], true);
+    }
+
+    #[tokio::test]
+    async fn test_unknown_action() {
+        let args = json!({ "action": "nope" });
+        let result = handle(".", 13144, &args).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown action"));
+    }
+
+    #[tokio::test]
+    async fn test_set_missing_channel() {
+        let args = json!({ "action": "set", "config": {} });
+        let result = handle(".", 13144, &args).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing field: channel"));
+    }
+
+    #[tokio::test]
+    async fn test_set_missing_config() {
+        let args = json!({ "action": "set", "channel": "wecom" });
+        let result = handle(".", 13144, &args).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing field: config"));
+    }
+}

--- a/src-tauri/crates/teamclaw-introspect/src/env_vars.rs
+++ b/src-tauri/crates/teamclaw-introspect/src/env_vars.rs
@@ -1,0 +1,103 @@
+use crate::config;
+use serde_json::{json, Value};
+
+pub async fn handle(workspace: &str, api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let action = arguments
+        .get("action")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: action")?;
+
+    match action {
+        "list" => {
+            let cfg = config::read_teamclaw_config(workspace)?;
+            let entries = cfg
+                .get("envVars")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            Ok(json!({ "env_vars": entries }))
+        }
+
+        "set" => {
+            let key = arguments
+                .get("key")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing field: key")?;
+            let value = arguments
+                .get("value")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing field: value")?;
+            let description = arguments.get("description").and_then(|v| v.as_str());
+
+            let mut body = json!({ "key": key, "value": value });
+            if let Some(d) = description {
+                body["description"] = json!(d);
+            }
+
+            post_api(api_port, "/env-var-set", &body).await
+        }
+
+        "delete" => {
+            let key = arguments
+                .get("key")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing field: key")?;
+
+            post_api(api_port, "/env-var-delete", &json!({ "key": key })).await
+        }
+
+        unknown => Err(format!(
+            "Unknown action: '{}'. Valid actions: list, set, delete",
+            unknown
+        )),
+    }
+}
+
+async fn post_api(api_port: u16, path: &str, body: &Value) -> Result<Value, String> {
+    let url = format!("http://127.0.0.1:{api_port}{path}");
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}. Is the TeamClaw app running?"))?;
+
+    if !resp.status().is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("API error: {text}"));
+    }
+
+    resp.json::<Value>()
+        .await
+        .map_err(|e| format!("Failed to parse response: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_unknown_action() {
+        let args = json!({ "action": "nope" });
+        let result = handle(".", 13144, &args).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown action"));
+    }
+
+    #[tokio::test]
+    async fn test_set_missing_key() {
+        let args = json!({ "action": "set", "value": "abc" });
+        let result = handle(".", 13144, &args).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing field: key"));
+    }
+
+    #[tokio::test]
+    async fn test_set_missing_value() {
+        let args = json!({ "action": "set", "key": "MY_KEY" });
+        let result = handle(".", 13144, &args).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing field: value"));
+    }
+}

--- a/src-tauri/crates/teamclaw-introspect/src/knowledge.rs
+++ b/src-tauri/crates/teamclaw-introspect/src/knowledge.rs
@@ -1,0 +1,100 @@
+use serde_json::{json, Value};
+
+pub async fn handle(workspace: &str, api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let action = arguments
+        .get("action")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: action")?;
+
+    match action {
+        "search" => {
+            let query = arguments
+                .get("query")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing field: query")?;
+            let top_k = arguments.get("top_k").and_then(|v| v.as_u64());
+
+            let mut body = json!({ "query": query });
+            if let Some(k) = top_k {
+                body["top_k"] = json!(k);
+            }
+
+            post_api(api_port, "/knowledge-search", &body).await
+        }
+
+        "add" => {
+            let content = arguments
+                .get("content")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing field: content")?;
+            let title = arguments.get("title").and_then(|v| v.as_str());
+            let filename = arguments.get("filename").and_then(|v| v.as_str());
+
+            let mut body = json!({ "content": content });
+            if let Some(t) = title {
+                body["title"] = json!(t);
+            }
+            if let Some(f) = filename {
+                body["filename"] = json!(f);
+            }
+
+            post_api(api_port, "/knowledge-add", &body).await
+        }
+
+        "list" => post_api(api_port, "/knowledge-list", &json!({})).await,
+
+        "delete" => {
+            let filename = arguments
+                .get("filename")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing field: filename")?;
+
+            post_api(api_port, "/knowledge-delete", &json!({ "filename": filename })).await
+        }
+
+        unknown => Err(format!(
+            "Unknown action: '{}'. Valid actions: search, add, list, delete",
+            unknown
+        )),
+    }
+}
+
+async fn post_api(api_port: u16, path: &str, body: &Value) -> Result<Value, String> {
+    let url = format!("http://127.0.0.1:{api_port}{path}");
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}. Is the TeamClaw app running?"))?;
+
+    if !resp.status().is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("API error: {text}"));
+    }
+
+    resp.json::<Value>()
+        .await
+        .map_err(|e| format!("Failed to parse response: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_unknown_action() {
+        let args = json!({ "action": "nope" });
+        let result = handle(".", 13144, &args).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown action"));
+    }
+
+    #[test]
+    fn test_add_builds_body() {
+        let args = json!({ "action": "add", "content": "hello", "title": "My Note" });
+        assert_eq!(args["action"], "add");
+        assert_eq!(args["content"], "hello");
+    }
+}

--- a/src-tauri/crates/teamclaw-introspect/src/main.rs
+++ b/src-tauri/crates/teamclaw-introspect/src/main.rs
@@ -1,6 +1,10 @@
 mod capabilities;
+mod channels;
 mod config;
 mod cron;
+mod env_vars;
+mod knowledge;
+mod roles;
 mod send;
 mod shortcuts;
 mod sync;
@@ -157,6 +161,123 @@ fn tool_definitions() -> Value {
                 "type": "object",
                 "properties": {}
             }
+        },
+        {
+            "name": "manage_knowledge",
+            "description": "Manage the knowledge base: search entries, add a memory note, list all memory entries, or delete one. Use 'search' to find relevant information. Use 'add' to persist content for future reference.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["search", "add", "list", "delete"],
+                        "description": "The action to perform."
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Search query (required for action=search)."
+                    },
+                    "top_k": {
+                        "type": "integer",
+                        "description": "Max results to return for search (default 5)."
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Content to save (required for action=add)."
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Title of the memory note (optional for action=add)."
+                    },
+                    "filename": {
+                        "type": "string",
+                        "description": "Filename for the note (optional for add/delete). Auto-generated if omitted for add. Required for delete."
+                    }
+                },
+                "required": ["action"]
+            }
+        },
+        {
+            "name": "manage_roles",
+            "description": "Manage AI agent roles: list available roles, create a new role, update an existing role, or delete one. Roles are defined by a name, description, and working style.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["list", "create", "update", "delete"],
+                        "description": "The action to perform."
+                    },
+                    "slug": {
+                        "type": "string",
+                        "description": "Role identifier (directory name). Required for update/delete. Auto-generated from name if omitted for create."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Display name for the role (required for create)."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Short description of what this role does."
+                    },
+                    "working_style": {
+                        "type": "string",
+                        "description": "Working style instructions for the role."
+                    }
+                },
+                "required": ["action"]
+            }
+        },
+        {
+            "name": "manage_env_vars",
+            "description": "Manage environment variables: list registered keys (no values returned), set a key-value pair, or delete a key. Values are stored securely in the system keychain.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["list", "set", "delete"],
+                        "description": "The action to perform."
+                    },
+                    "key": {
+                        "type": "string",
+                        "description": "The environment variable name (required for set/delete)."
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "The value to store (required for set). Never returned by list."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Optional description for the env var (used for set)."
+                    }
+                },
+                "required": ["action"]
+            }
+        },
+        {
+            "name": "manage_channels",
+            "description": "View or update message channel configuration (WeCom, Discord, Feishu, Email, KOOK, WeChat). Use 'get' to check what's configured (sensitive values are redacted). Use 'set' to configure a channel with the provided fields.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["get", "set"],
+                        "description": "The action to perform."
+                    },
+                    "channel": {
+                        "type": "string",
+                        "enum": ["wecom", "discord", "feishu", "email", "kook", "wechat"],
+                        "description": "Target channel. Required for set; optional for get (omit to get all channels)."
+                    },
+                    "config": {
+                        "type": "object",
+                        "description": "Channel config fields to set. Required for set. Fields vary by channel:\n- wecom: botId, secret, encodingAesKey, ownerId\n- discord: token, dm, guilds\n- feishu: appId, appSecret, chats\n- email: provider, gmailEmail, gmailClientId, gmailClientSecret (or imapServer, smtpServer, username, password for custom)\n- kook: token, dm, guilds\n- wechat: botToken, accountId, baseUrl"
+                    }
+                },
+                "required": ["action"]
+            }
         }
     ])
 }
@@ -290,6 +411,42 @@ async fn handle_request(req: &Value, workspace: &str, api_port: u16) -> Option<V
                 }
                 "sync_team_dir" => {
                     match sync::handle(workspace, api_port, &arguments).await {
+                        Ok(v) => {
+                            let text = serde_json::to_string_pretty(&v).unwrap_or_default();
+                            tool_ok(&text)
+                        }
+                        Err(e) => tool_err(&e),
+                    }
+                }
+                "manage_knowledge" => {
+                    match knowledge::handle(workspace, api_port, &arguments).await {
+                        Ok(v) => {
+                            let text = serde_json::to_string_pretty(&v).unwrap_or_default();
+                            tool_ok(&text)
+                        }
+                        Err(e) => tool_err(&e),
+                    }
+                }
+                "manage_roles" => {
+                    match roles::handle(workspace, &arguments).await {
+                        Ok(v) => {
+                            let text = serde_json::to_string_pretty(&v).unwrap_or_default();
+                            tool_ok(&text)
+                        }
+                        Err(e) => tool_err(&e),
+                    }
+                }
+                "manage_env_vars" => {
+                    match env_vars::handle(workspace, api_port, &arguments).await {
+                        Ok(v) => {
+                            let text = serde_json::to_string_pretty(&v).unwrap_or_default();
+                            tool_ok(&text)
+                        }
+                        Err(e) => tool_err(&e),
+                    }
+                }
+                "manage_channels" => {
+                    match channels::handle(workspace, api_port, &arguments).await {
                         Ok(v) => {
                             let text = serde_json::to_string_pretty(&v).unwrap_or_default();
                             tool_ok(&text)

--- a/src-tauri/crates/teamclaw-introspect/src/roles.rs
+++ b/src-tauri/crates/teamclaw-introspect/src/roles.rs
@@ -1,0 +1,259 @@
+use crate::config;
+use serde_json::{json, Value};
+use std::path::Path;
+
+pub async fn handle(workspace: &str, arguments: &Value) -> Result<Value, String> {
+    let action = arguments
+        .get("action")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: action")?;
+
+    match action {
+        "list" => {
+            let roles = config::read_roles(workspace)?;
+            let with_slugs = roles_with_slugs(workspace);
+            Ok(json!({ "roles": with_slugs }))
+        }
+
+        "create" => {
+            let name = arguments
+                .get("name")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing field: name")?;
+            let slug = arguments
+                .get("slug")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| slugify(name));
+            let description = arguments
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let working_style = arguments
+                .get("working_style")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+
+            let role_dir = role_dir(workspace, &slug);
+            if role_dir.exists() {
+                return Err(format!("Role '{}' already exists", slug));
+            }
+            std::fs::create_dir_all(&role_dir)
+                .map_err(|e| format!("Failed to create role dir: {e}"))?;
+
+            let content = build_role_md(name, description, working_style);
+            let role_md = role_dir.join("ROLE.md");
+            std::fs::write(&role_md, content)
+                .map_err(|e| format!("Failed to write ROLE.md: {e}"))?;
+
+            Ok(json!({ "ok": true, "slug": slug, "name": name }))
+        }
+
+        "update" => {
+            let slug = arguments
+                .get("slug")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing field: slug")?;
+
+            let role_md_path = role_dir(workspace, slug).join("ROLE.md");
+            if !role_md_path.exists() {
+                return Err(format!("Role '{}' not found", slug));
+            }
+
+            let raw = std::fs::read_to_string(&role_md_path)
+                .map_err(|e| format!("Failed to read ROLE.md: {e}"))?;
+            let (mut cur_name, mut cur_desc, mut cur_ws) = parse_role_fields(&raw);
+
+            if let Some(v) = arguments.get("name").and_then(|v| v.as_str()) {
+                cur_name = v.to_string();
+            }
+            if let Some(v) = arguments.get("description").and_then(|v| v.as_str()) {
+                cur_desc = v.to_string();
+            }
+            if let Some(v) = arguments.get("working_style").and_then(|v| v.as_str()) {
+                cur_ws = v.to_string();
+            }
+
+            let content = build_role_md(&cur_name, &cur_desc, &cur_ws);
+            std::fs::write(&role_md_path, content)
+                .map_err(|e| format!("Failed to write ROLE.md: {e}"))?;
+
+            Ok(json!({ "ok": true, "slug": slug }))
+        }
+
+        "delete" => {
+            let slug = arguments
+                .get("slug")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing field: slug")?;
+
+            let dir = role_dir(workspace, slug);
+            if !dir.exists() {
+                return Err(format!("Role '{}' not found", slug));
+            }
+
+            std::fs::remove_dir_all(&dir)
+                .map_err(|e| format!("Failed to delete role '{}': {e}", slug))?;
+
+            Ok(json!({ "ok": true, "slug": slug }))
+        }
+
+        unknown => Err(format!(
+            "Unknown action: '{}'. Valid actions: list, create, update, delete",
+            unknown
+        )),
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn role_dir(workspace: &str, slug: &str) -> std::path::PathBuf {
+    Path::new(workspace)
+        .join(config::TEAMCLAW_DIR)
+        .join("roles")
+        .join(slug)
+}
+
+/// Like `read_roles` but includes the slug (directory name) in each entry.
+fn roles_with_slugs(workspace: &str) -> Vec<Value> {
+    let roles_dir = Path::new(workspace)
+        .join(config::TEAMCLAW_DIR)
+        .join("roles");
+
+    if !roles_dir.exists() {
+        return vec![];
+    }
+
+    let Ok(entries) = std::fs::read_dir(&roles_dir) else {
+        return vec![];
+    };
+
+    let mut roles: Vec<Value> = entries
+        .flatten()
+        .filter(|e| {
+            let name = e.file_name();
+            let name_str = name.to_string_lossy();
+            name_str != "skill"
+                && name_str != "config.json"
+                && e.file_type().map(|t| t.is_dir()).unwrap_or(false)
+        })
+        .filter_map(|e| {
+            let slug = e.file_name().to_string_lossy().to_string();
+            let role_md = e.path().join("ROLE.md");
+            if !role_md.exists() {
+                return None;
+            }
+            let raw = std::fs::read_to_string(&role_md).ok()?;
+            let (name, desc, ws) = parse_role_fields(&raw);
+            let mut obj = serde_json::Map::new();
+            obj.insert("slug".to_string(), json!(slug));
+            obj.insert("name".to_string(), json!(name));
+            obj.insert("description".to_string(), json!(desc));
+            if !ws.is_empty() {
+                obj.insert("working_style".to_string(), json!(ws));
+            }
+            Some(Value::Object(obj))
+        })
+        .collect();
+
+    roles.sort_by(|a, b| {
+        let na = a.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let nb = b.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        na.cmp(nb)
+    });
+
+    roles
+}
+
+fn build_role_md(name: &str, description: &str, working_style: &str) -> String {
+    let mut out = format!("---\nname: \"{name}\"\ndescription: \"{description}\"\n---\n");
+    if !working_style.is_empty() {
+        out.push_str(&format!("\n## Working style\n\n{working_style}\n"));
+    }
+    out
+}
+
+fn slugify(name: &str) -> String {
+    name.chars()
+        .map(|c| if c.is_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+/// Parse name, description, working_style from a ROLE.md string.
+fn parse_role_fields(raw: &str) -> (String, String, String) {
+    let mut name = String::new();
+    let mut description = String::new();
+    let mut working_style = String::new();
+
+    let rest = if raw.starts_with("---") {
+        let after = &raw[3..];
+        if let Some(close) = after.find("\n---") {
+            let fm = &after[..close];
+            for line in fm.lines() {
+                let line = line.trim();
+                if let Some(v) = line.strip_prefix("name:") {
+                    name = v.trim().trim_matches('"').trim_matches('\'').to_string();
+                } else if let Some(v) = line.strip_prefix("description:") {
+                    description = v.trim().trim_matches('"').trim_matches('\'').to_string();
+                }
+            }
+            &after[close + 4..]
+        } else {
+            after
+        }
+    } else {
+        raw
+    };
+
+    let lower = rest.to_lowercase();
+    let marker = "## working style";
+    if let Some(start) = lower.find(marker) {
+        let after = &rest[start + marker.len()..];
+        let end = after.find("\n##").unwrap_or(after.len());
+        working_style = after[..end].trim().to_string();
+    }
+
+    (name, description, working_style)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slugify() {
+        assert_eq!(slugify("My Role Name"), "my-role-name");
+        assert_eq!(slugify("dev assistant"), "dev-assistant");
+        assert_eq!(slugify("  --hello--  "), "hello");
+    }
+
+    #[test]
+    fn test_parse_role_fields() {
+        let raw = "---\nname: \"Dev\"\ndescription: \"coding\"\n---\n\n## Working style\n\nfast\n";
+        let (name, desc, ws) = parse_role_fields(raw);
+        assert_eq!(name, "Dev");
+        assert_eq!(desc, "coding");
+        assert_eq!(ws, "fast");
+    }
+
+    #[test]
+    fn test_build_role_md_roundtrip() {
+        let md = build_role_md("Dev", "coding", "fast");
+        let (name, desc, ws) = parse_role_fields(&md);
+        assert_eq!(name, "Dev");
+        assert_eq!(desc, "coding");
+        assert_eq!(ws, "fast");
+    }
+
+    #[tokio::test]
+    async fn test_unknown_action() {
+        let args = serde_json::json!({ "action": "nope" });
+        let result = handle(".", &args).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown action"));
+    }
+}

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -278,7 +278,7 @@ fn get_teamclaw_json_path(workspace_path: &str) -> String {
 }
 
 /// Read the envVars index from teamclaw.json (preserving all other fields).
-fn read_teamclaw_json(workspace_path: &str) -> Result<serde_json::Value, String> {
+pub(crate) fn read_teamclaw_json(workspace_path: &str) -> Result<serde_json::Value, String> {
     let path = get_teamclaw_json_path(workspace_path);
     if !Path::new(&path).exists() {
         return Ok(serde_json::json!({
@@ -292,7 +292,7 @@ fn read_teamclaw_json(workspace_path: &str) -> Result<serde_json::Value, String>
 }
 
 /// Write the full teamclaw.json back (preserving all other fields).
-fn write_teamclaw_json(workspace_path: &str, json: &serde_json::Value) -> Result<(), String> {
+pub(crate) fn write_teamclaw_json(workspace_path: &str, json: &serde_json::Value) -> Result<(), String> {
     let teamclaw_dir = format!("{}/{}", workspace_path, super::TEAMCLAW_DIR);
     let _ = std::fs::create_dir_all(&teamclaw_dir);
     let path = get_teamclaw_json_path(workspace_path);

--- a/src-tauri/src/commands/introspect_api.rs
+++ b/src-tauri/src/commands/introspect_api.rs
@@ -1,8 +1,15 @@
 /// Internal HTTP API server for the teamclaw-introspect MCP binary.
 ///
 /// Listens on 127.0.0.1:13144 and handles:
-///   POST /send-wecom   — send a proactive WeCom message
-///   POST /cron-run     — manually trigger a cron job
+///   POST /send-wecom        — send a proactive WeCom message
+///   POST /cron-run          — manually trigger a cron job
+///   POST /team-sync-all     — trigger team sync
+///   POST /knowledge-search  — semantic search in knowledge base
+///   POST /knowledge-add     — save a memory entry
+///   POST /knowledge-list    — list memory entries
+///   POST /knowledge-delete  — delete a memory entry
+///   POST /env-var-set       — create or update an env var
+///   POST /env-var-delete    — delete an env var
 ///
 /// Uses raw TCP + manual HTTP parsing to stay minimal (no axum state needed).
 
@@ -81,6 +88,13 @@ pub async fn start_introspect_api(app: AppHandle) -> anyhow::Result<()> {
                 ("POST", "/send-wecom") => handle_send_wecom(&app_clone, body_bytes).await,
                 ("POST", "/cron-run") => handle_cron_run(&app_clone, body_bytes).await,
                 ("POST", "/team-sync-all") => handle_team_sync_all(&app_clone, body_bytes).await,
+                ("POST", "/knowledge-search") => handle_knowledge_search(&app_clone, body_bytes).await,
+                ("POST", "/knowledge-add") => handle_knowledge_add(&app_clone, body_bytes).await,
+                ("POST", "/knowledge-list") => handle_knowledge_list(&app_clone, body_bytes).await,
+                ("POST", "/knowledge-delete") => handle_knowledge_delete(&app_clone, body_bytes).await,
+                ("POST", "/env-var-set") => handle_env_var_set(&app_clone, body_bytes).await,
+                ("POST", "/env-var-delete") => handle_env_var_delete(&app_clone, body_bytes).await,
+                ("POST", "/channel-set") => handle_channel_set(&app_clone, body_bytes).await,
                 _ => Err(format!("Not found: {} {}", method, path)),
             };
 
@@ -231,6 +245,200 @@ fn detect_media_type(filename: &str) -> &'static str {
         "mp4" | "mov" | "avi" | "mkv" | "wmv" => "video",
         _ => "file",
     }
+}
+
+// ─── Knowledge Handlers ──────────────────────────────────────────────────────
+
+async fn handle_knowledge_search(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?;
+
+    let query = v
+        .get("query")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: query")?
+        .to_string();
+    let top_k = v.get("top_k").and_then(|v| v.as_u64()).map(|n| n as usize);
+
+    let oc_state = app.state::<super::opencode::OpenCodeState>();
+    let workspace_path = super::opencode::current_workspace_path(&oc_state)?;
+
+    let rag_state = app.state::<super::knowledge::RagState>();
+    let result =
+        super::knowledge::rag_search(workspace_path, query, top_k, None, None, rag_state).await?;
+
+    serde_json::to_string(&result).map_err(|e| format!("Serialization error: {e}"))
+}
+
+async fn handle_knowledge_add(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?;
+
+    let content = v
+        .get("content")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: content")?;
+    let title = v
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Untitled");
+    let filename = v.get("filename").and_then(|v| v.as_str());
+
+    let oc_state = app.state::<super::opencode::OpenCodeState>();
+    let workspace_path = super::opencode::current_workspace_path(&oc_state)?;
+
+    let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let safe_filename = filename
+        .map(|f| {
+            if f.ends_with(".md") {
+                f.to_string()
+            } else {
+                format!("{}.md", f)
+            }
+        })
+        .unwrap_or_else(|| {
+            let slug = title
+                .chars()
+                .map(|c| if c.is_alphanumeric() { c } else { '-' })
+                .collect::<String>()
+                .to_lowercase();
+            let slug = slug.trim_matches('-').to_string();
+            let ts = chrono::Utc::now().timestamp();
+            format!("{slug}-{ts}.md")
+        });
+
+    let file_content = format!(
+        "---\ntitle: \"{title}\"\ncreated: \"{now}\"\nupdated: \"{now}\"\n---\n\n{content}\n"
+    );
+
+    let rag_state = app.state::<super::knowledge::RagState>();
+    super::knowledge::rag_save_memory(workspace_path, safe_filename.clone(), file_content, rag_state)
+        .await?;
+
+    Ok(format!(r#"{{"ok":true,"filename":"{}"}}"#, safe_filename))
+}
+
+async fn handle_knowledge_list(app: &AppHandle, _body: &[u8]) -> Result<String, String> {
+    let oc_state = app.state::<super::opencode::OpenCodeState>();
+    let workspace_path = super::opencode::current_workspace_path(&oc_state)?;
+
+    let memories = super::knowledge::rag_list_memories(workspace_path).await?;
+    serde_json::to_string(&memories).map_err(|e| format!("Serialization error: {e}"))
+}
+
+async fn handle_knowledge_delete(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?;
+
+    let filename = v
+        .get("filename")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: filename")?
+        .to_string();
+
+    let oc_state = app.state::<super::opencode::OpenCodeState>();
+    let workspace_path = super::opencode::current_workspace_path(&oc_state)?;
+
+    let rag_state = app.state::<super::knowledge::RagState>();
+    super::knowledge::rag_delete_memory(workspace_path, filename.clone(), rag_state).await?;
+
+    Ok(format!(r#"{{"ok":true,"filename":"{}"}}"#, filename))
+}
+
+// ─── Env Var Handlers ────────────────────────────────────────────────────────
+
+async fn handle_env_var_set(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?;
+
+    let key = v
+        .get("key")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: key")?
+        .to_string();
+    let value = v
+        .get("value")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: value")?
+        .to_string();
+    let description = v
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let oc_state = app.state::<super::opencode::OpenCodeState>();
+    super::env_vars::env_var_set(oc_state, key.clone(), value, description).await?;
+
+    Ok(format!(r#"{{"ok":true,"key":"{}"}}"#, key))
+}
+
+async fn handle_env_var_delete(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?;
+
+    let key = v
+        .get("key")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: key")?
+        .to_string();
+
+    let oc_state = app.state::<super::opencode::OpenCodeState>();
+    super::env_vars::env_var_delete(oc_state, key.clone()).await?;
+
+    Ok(format!(r#"{{"ok":true,"key":"{}"}}"#, key))
+}
+
+// ─── Channel Handler ─────────────────────────────────────────────────────────
+
+async fn handle_channel_set(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?;
+
+    let channel = v
+        .get("channel")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: channel")?;
+    let patch = v.get("config").ok_or("Missing field: config")?;
+
+    let valid_channels = ["wecom", "discord", "feishu", "email", "kook", "wechat"];
+    if !valid_channels.contains(&channel) {
+        return Err(format!(
+            "Unknown channel: '{}'. Valid: {}",
+            channel,
+            valid_channels.join(", ")
+        ));
+    }
+
+    let oc_state = app.state::<super::opencode::OpenCodeState>();
+    let workspace = super::opencode::current_workspace_path(&oc_state)?;
+
+    let mut json = super::env_vars::read_teamclaw_json(&workspace)?;
+
+    // Ensure channels object exists
+    if json.get("channels").is_none() {
+        json["channels"] = serde_json::json!({});
+    }
+
+    let channels = json["channels"]
+        .as_object_mut()
+        .ok_or("channels is not an object")?;
+
+    // Merge patch fields into channel config (shallow merge)
+    let ch_entry = channels
+        .entry(channel.to_string())
+        .or_insert_with(|| serde_json::json!({}));
+
+    if let (Some(obj), Some(patch_obj)) = (ch_entry.as_object_mut(), patch.as_object()) {
+        for (k, val) in patch_obj {
+            obj.insert(k.clone(), val.clone());
+        }
+    } else {
+        return Err("config must be a JSON object".to_string());
+    }
+
+    super::env_vars::write_teamclaw_json(&workspace, &json)?;
+
+    Ok(format!(r#"{{"ok":true,"channel":"{}"}}"#, channel))
 }
 
 /// Find the position of `\r\n\r\n` in `data`, returning the index of the first `\r`.


### PR DESCRIPTION
## Summary

- **`manage_knowledge`** — search/add/list/delete knowledge base memory entries via RAG
- **`manage_roles`** — list/create/update/delete AI agent roles (pure file I/O on `.teamclaw/roles/*/ROLE.md`)
- **`manage_env_vars`** — list/set/delete environment variables (set/delete via keychain through introspect API)
- **`manage_channels`** — get/set channel configuration for all 6 channels (wecom, discord, feishu, email, kook, wechat); sensitive fields redacted on read

Introspect MCP now has 9 tools total (was 5 before this PR).

### New introspect API endpoints
- `POST /knowledge-search`, `/knowledge-add`, `/knowledge-list`, `/knowledge-delete`
- `POST /env-var-set`, `/env-var-delete`
- `POST /channel-set`

## Test Plan
- [x] `cargo test` — 17 tests pass in teamclaw-introspect crate
- [x] `pnpm rust:check` — compiles clean (no new errors)
- [ ] Manual: open app, confirm new tools appear in MCP tool list
- [ ] Manual: `manage_channels(action="get")` returns all 6 channels with bound status
- [ ] Manual: `manage_knowledge(action="add", content="hello", title="test")` saves to `knowledge/memory/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)