### PR TITLE
ci(updater): add OSS mirror as primary update endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,17 +169,32 @@ jobs:
           ls -lh src-tauri/binaries/
           ls -lh packages/app/dist/ | head -5
 
-      # Skip beforeBuildCommand since frontend is already built above
-      - name: Skip frontend rebuild in tauri build
+      # Skip beforeBuildCommand since frontend is already built above,
+      # and substitute __OSS_BASE_URL__ in updater endpoints (drop if OSS not configured).
+      - name: Finalize tauri.conf.json for build
+        env:
+          OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT }}
+          OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
         run: |
-          python3 -c "
-          import json
+          python3 - <<'EOF'
+          import json, os
           with open('src-tauri/tauri.conf.json', 'r') as f:
               conf = json.load(f)
           conf['build']['beforeBuildCommand'] = 'echo frontend already built'
+          endpoints = conf.get('plugins', {}).get('updater', {}).get('endpoints', [])
+          bucket = os.environ.get('OSS_BUCKET', '')
+          endpoint_host = os.environ.get('OSS_ENDPOINT', '').replace('https://', '').replace('http://', '').rstrip('/')
+          oss_base = f'https://{bucket}.{endpoint_host}' if bucket and endpoint_host else ''
+          if oss_base:
+              endpoints = [e.replace('__OSS_BASE_URL__', oss_base) for e in endpoints]
+          endpoints = [e for e in endpoints if '__OSS_BASE_URL__' not in e]
+          conf.setdefault('plugins', {}).setdefault('updater', {})['endpoints'] = endpoints
           with open('src-tauri/tauri.conf.json', 'w') as f:
               json.dump(conf, f, indent=2)
-          "
+          print('Final updater endpoints:')
+          for e in endpoints:
+              print(f'  - {e}')
+          EOF
 
       - uses: tauri-apps/tauri-action@v0
         env:
@@ -362,15 +377,29 @@ jobs:
           echo "teamclaw-introspect ready"
 
       # Skip beforeBuildCommand since frontend is already built above
-      - name: Skip frontend rebuild in tauri build
+      - name: Finalize tauri.conf.json for build
         shell: python
+        env:
+          OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT }}
+          OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
         run: |
-          import json
+          import json, os
           with open('src-tauri/tauri.conf.json', 'r') as f:
               conf = json.load(f)
           conf['build']['beforeBuildCommand'] = 'echo frontend already built'
+          endpoints = conf.get('plugins', {}).get('updater', {}).get('endpoints', [])
+          bucket = os.environ.get('OSS_BUCKET', '')
+          endpoint_host = os.environ.get('OSS_ENDPOINT', '').replace('https://', '').replace('http://', '').rstrip('/')
+          oss_base = f'https://{bucket}.{endpoint_host}' if bucket and endpoint_host else ''
+          if oss_base:
+              endpoints = [e.replace('__OSS_BASE_URL__', oss_base) for e in endpoints]
+          endpoints = [e for e in endpoints if '__OSS_BASE_URL__' not in e]
+          conf.setdefault('plugins', {}).setdefault('updater', {})['endpoints'] = endpoints
           with open('src-tauri/tauri.conf.json', 'w') as f:
               json.dump(conf, f, indent=2)
+          print('Final updater endpoints:')
+          for e in endpoints:
+              print(f'  - {e}')
 
       - uses: tauri-apps/tauri-action@v0
         env:
@@ -452,6 +481,40 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Mirror latest.json to OSS
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OSS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+          OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT }}
+          OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          if [ -z "$OSS_ACCESS_KEY_ID" ]; then
+            echo "OSS not configured, skipping latest.json mirror"
+            exit 0
+          fi
+          gh release download "$VERSION" \
+            --repo ${{ github.repository }} \
+            --pattern 'latest.json' \
+            --dir /tmp/oss-latest
+          python3 -m pip install oss2 --quiet
+          python3 - <<'EOF'
+          import oss2, os
+          auth = oss2.Auth(os.environ['OSS_ACCESS_KEY_ID'], os.environ['OSS_ACCESS_KEY_SECRET'])
+          endpoint = os.environ['OSS_ENDPOINT']
+          if not endpoint.startswith('http'):
+              endpoint = 'https://' + endpoint
+          bucket = oss2.Bucket(auth, endpoint, os.environ['OSS_BUCKET'])
+          version = os.environ['VERSION']
+          bucket.put_object_from_file('releases/latest.json', '/tmp/oss-latest/latest.json')
+          bucket.put_object_from_file(f'releases/{version}/latest.json', '/tmp/oss-latest/latest.json')
+          host = os.environ['OSS_ENDPOINT'].replace('https://', '').replace('http://', '')
+          print(f'Mirrored latest.json -> https://{os.environ["OSS_BUCKET"]}.{host}/releases/latest.json')
+          print(f'Also archived -> https://{os.environ["OSS_BUCKET"]}.{host}/releases/{version}/latest.json')
+          EOF
+
       - name: Append CN mirror section to release notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/update-tauri-config.js
+++ b/scripts/update-tauri-config.js
@@ -52,19 +52,36 @@ const tauriConf = JSON.parse(fs.readFileSync(tauriConfPath, 'utf8'));
 
 let updated = false;
 
-if (buildConfig.app?.updater?.endpoint) {
+function ensureUpdater() {
   if (!tauriConf.plugins) tauriConf.plugins = {};
   if (!tauriConf.plugins.updater) tauriConf.plugins.updater = {};
-  
-  tauriConf.plugins.updater.endpoints = [buildConfig.app.updater.endpoint];
-  console.log(`✓ Updated updater endpoint: ${buildConfig.app.updater.endpoint}`);
+}
+
+// Start from buildConfig override (array or singular), else keep existing endpoints.
+let endpoints;
+if (Array.isArray(buildConfig.app?.updater?.endpoints)) {
+  endpoints = buildConfig.app.updater.endpoints.slice();
+} else if (buildConfig.app?.updater?.endpoint) {
+  endpoints = [buildConfig.app.updater.endpoint];
+} else if (Array.isArray(tauriConf.plugins?.updater?.endpoints)) {
+  endpoints = tauriConf.plugins.updater.endpoints.slice();
+}
+
+if (endpoints) {
+  const ossBase = (process.env.OSS_BASE_URL || '').replace(/\/+$/, '');
+  endpoints = endpoints
+    .map((url) => (ossBase ? url.replace('__OSS_BASE_URL__', ossBase) : url))
+    .filter((url) => !url.includes('__OSS_BASE_URL__'));
+
+  ensureUpdater();
+  tauriConf.plugins.updater.endpoints = endpoints;
+  console.log(`✓ Updated updater endpoints (${endpoints.length}):`);
+  for (const url of endpoints) console.log(`    - ${url}`);
   updated = true;
 }
 
 if (buildConfig.app?.updater?.pubkey) {
-  if (!tauriConf.plugins) tauriConf.plugins = {};
-  if (!tauriConf.plugins.updater) tauriConf.plugins.updater = {};
-  
+  ensureUpdater();
   tauriConf.plugins.updater.pubkey = buildConfig.app.updater.pubkey;
   console.log(`✓ Updated updater pubkey: ${buildConfig.app.updater.pubkey.substring(0, 50)}...`);
   updated = true;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,6 +52,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQzODk5QzIxMUI4RkY3OTkKUldTWjk0OGJJWnlKUTlnZVdEaUsyUGJ4WFpaYmlQZW03NGdlNVdyUlRMNGtKVVBKeTk3NEYwZXAK",
       "endpoints": [
+        "__OSS_BASE_URL__/releases/latest.json",
         "https://github.com/different-ai-studio/teamclaw/releases/latest/download/latest.json"
       ]
     }


### PR DESCRIPTION
## Summary

- Bakes an OSS CN mirror URL as the **primary** Tauri updater endpoint, keeping the GitHub URL as fallback, so CN users auto-update from OSS instead of GitHub.
- Uses a `__OSS_BASE_URL__` placeholder in `tauri.conf.json` that CI substitutes at build time from `OSS_ENDPOINT` + `OSS_BUCKET` secrets (no new secret required). Builds without OSS configured silently drop the placeholder and fall back to GitHub-only — current behavior preserved.
- Adds a post-release job step that mirrors the release's `latest.json` to `oss://<bucket>/releases/latest.json` so the new endpoint actually resolves.

Existing v0.1.60 installs keep updating via GitHub once, then start using OSS on the next version bump.

## Why

v0.1.60 release failed to upload to OSS (Windows `UnicodeEncodeError`, already fixed on main). But even after OSS upload works for binaries, the updater still hits GitHub for CN users — slow or unreachable. This PR fixes that for v0.1.61+.

## Changes

- `src-tauri/tauri.conf.json` — add `__OSS_BASE_URL__/releases/latest.json` before the GitHub URL in `plugins.updater.endpoints`.
- `scripts/update-tauri-config.js` — handle `endpoints` (array) in addition to legacy `endpoint` (singular); substitute `__OSS_BASE_URL__` from `OSS_BASE_URL` env; drop entries that still contain the placeholder.
- `.github/workflows/release.yml`:
  - Both build jobs: former "Skip frontend rebuild" step now also substitutes the OSS placeholder into `tauri.conf.json` using the OSS secrets.
  - `update-release-notes` job: new first step downloads `latest.json` from the GitHub Release and uploads it to `oss://<bucket>/releases/latest.json` (and a versioned copy).

## Test plan

- [x] `tauri.conf.json` parses as JSON
- [x] `update-tauri-config.js` syntax check (`node -c`)
- [x] `update-tauri-config.js` with `OSS_BASE_URL` set → produces `[OSS, GitHub]`
- [x] `update-tauri-config.js` with no `OSS_BASE_URL` → drops placeholder, produces `[GitHub]`
- [ ] Tag a new version (e.g. v0.1.61) and verify:
  - [ ] macOS/Windows build jobs log `Final updater endpoints:` with the OSS URL first
  - [ ] `oss://<bucket>/releases/latest.json` is uploaded by the `update-release-notes` job
  - [ ] Installed v0.1.61 app successfully detects a subsequent update via OSS
  - [ ] CN user on v0.1.60 can still auto-update to v0.1.61 via GitHub fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)