### PR TITLE
fix(updater): restore OSS update manifest fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -501,6 +501,7 @@ jobs:
             --dir /tmp/oss-latest
           python3 -m pip install oss2 --quiet
           python3 - <<'EOF'
+          import json
           import oss2, os
           auth = oss2.Auth(os.environ['OSS_ACCESS_KEY_ID'], os.environ['OSS_ACCESS_KEY_SECRET'])
           endpoint = os.environ['OSS_ENDPOINT']
@@ -508,11 +509,30 @@ jobs:
               endpoint = 'https://' + endpoint
           bucket = oss2.Bucket(auth, endpoint, os.environ['OSS_BUCKET'])
           version = os.environ['VERSION']
-          bucket.put_object_from_file('releases/latest.json', '/tmp/oss-latest/latest.json')
-          bucket.put_object_from_file(f'releases/{version}/latest.json', '/tmp/oss-latest/latest.json')
-          host = os.environ['OSS_ENDPOINT'].replace('https://', '').replace('http://', '')
-          print(f'Mirrored latest.json -> https://{os.environ["OSS_BUCKET"]}.{host}/releases/latest.json')
-          print(f'Also archived -> https://{os.environ["OSS_BUCKET"]}.{host}/releases/{version}/latest.json')
+          host = os.environ['OSS_ENDPOINT'].replace('https://', '').replace('http://', '').rstrip('/')
+          oss_base = f'https://{os.environ["OSS_BUCKET"]}.{host}'
+          manifest_path = '/tmp/oss-latest/latest.json'
+
+          with open(manifest_path, 'r', encoding='utf-8') as f:
+              manifest = json.load(f)
+
+          for entry in manifest.get('platforms', {}).values():
+              url = entry.get('url', '')
+              if not url:
+                  continue
+              filename = url.rstrip('/').split('/')[-1]
+              if filename:
+                  entry['url'] = f'{oss_base}/releases/{version}/{filename}'
+
+          mirrored_manifest_path = '/tmp/oss-latest/latest.oss.json'
+          with open(mirrored_manifest_path, 'w', encoding='utf-8') as f:
+              json.dump(manifest, f, indent=2)
+              f.write('\n')
+
+          bucket.put_object_from_file('releases/latest.json', mirrored_manifest_path)
+          bucket.put_object_from_file(f'releases/{version}/latest.json', mirrored_manifest_path)
+          print(f'Mirrored latest.json -> {oss_base}/releases/latest.json')
+          print(f'Also archived -> {oss_base}/releases/{version}/latest.json')
           EOF
 
       - name: Append CN mirror section to release notes

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,6 +52,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQzODk5QzIxMUI4RkY3OTkKUldTWjk0OGJJWnlKUTlnZVdEaUsyUGJ4WFpaYmlQZW03NGdlNVdyUlRMNGtKVVBKeTk3NEYwZXAK",
       "endpoints": [
+        "__OSS_BASE_URL__/releases/latest.json",
         "https://github.com/different-ai-studio/teamclaw/releases/latest/download/latest.json"
       ]
     }

--- a/tests/e2e/auto-update.test.ts
+++ b/tests/e2e/auto-update.test.ts
@@ -31,8 +31,8 @@ describe('Auto Update - Configuration', () => {
     expect(config.plugins.updater.pubkey).toBeTruthy();
     expect(config.plugins.updater.endpoints).toBeInstanceOf(Array);
     expect(config.plugins.updater.endpoints.length).toBeGreaterThan(0);
-    expect(config.plugins.updater.endpoints[0]).toContain('github.com');
-    expect(config.plugins.updater.endpoints[0]).toContain('latest.json');
+    expect(config.plugins.updater.endpoints).toContain('__OSS_BASE_URL__/releases/latest.json');
+    expect(config.plugins.updater.endpoints).toContain('https://github.com/different-ai-studio/teamclaw/releases/latest/download/latest.json');
     expect(config.bundle.createUpdaterArtifacts).toBe(true);
   });
 
@@ -61,12 +61,15 @@ describe('Auto Update - Configuration', () => {
     );
     const workflow = fs.readFileSync(workflowPath, 'utf-8');
 
-    expect(workflow).toContain("'v*'");
+    expect(workflow).toContain('"v*"');
     expect(workflow).toContain('tauri-apps/tauri-action');
     expect(workflow).toContain('TAURI_SIGNING_PRIVATE_KEY');
     expect(workflow).toContain('TAURI_SIGNING_PRIVATE_KEY_PASSWORD');
     expect(workflow).toContain('aarch64-apple-darwin');
     expect(workflow).toContain('pnpm');
+    expect(workflow).toContain("bucket.put_object_from_file('releases/latest.json'");
+    expect(workflow).toContain("platforms");
+    expect(workflow).toContain("entry['url'] =");
   });
 });
 


### PR DESCRIPTION
## Summary
- restore the OSS updater manifest endpoint in tauri updater config while keeping GitHub as fallback
- rewrite mirrored OSS latest.json platform download URLs so app updates fetch release assets from OSS instead of GitHub
- tighten the auto-update configuration test to cover both the OSS endpoint and manifest URL rewrite behavior

## Test Plan
- pnpm exec vitest run --config vitest.config.e2e.ts tests/e2e/auto-update.test.ts