### PR TITLE
fix(i18n): localize workspace sidebar settings label

### DIFF
--- a/packages/app/src/components/__tests__/app-sidebar.test.tsx
+++ b/packages/app/src/components/__tests__/app-sidebar.test.tsx
@@ -298,6 +298,13 @@ describe('AppSidebar', () => {
     expect(screen.queryByText('Knowledge')).toBeNull()
   })
 
+  it('workspace mode renders settings entry with english fallback text', () => {
+    uiVariantMocks.workspaceShell = true
+    render(<AppSidebar />)
+    expect(screen.getByText('Settings')).toBeDefined()
+    expect(screen.queryByText('设置')).toBeNull()
+  })
+
   it('clicking Shortcuts in Quick Access calls openPanel with "shortcuts"', () => {
     uiVariantMocks.workspaceShell = false
     render(<AppSidebar />)

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -1017,7 +1017,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               onClick={() => openSettings()}
             >
               <Settings className="h-3.5 w-3.5 shrink-0" />
-              {t('sidebar.settings', '设置')}
+              {t('common.settings', 'Settings')}
             </Button>
             <div className="flex items-center gap-0.5">
               <WorkspaceSelectorButton />


### PR DESCRIPTION
## Summary
- switch the workspace sidebar settings button to use the shared settings translation key with an English fallback
- add a regression test covering the workspace sidebar settings label so it does not fall back to Chinese in English mode

## Test Plan
- pnpm --filter @teamclaw/app test:unit src/components/__tests__/app-sidebar.test.tsx
- pnpm --filter @teamclaw/app typecheck