### PR TITLE
fix(i18n): follow system default language

### DIFF
--- a/packages/app/src/__tests__/i18n.test.ts
+++ b/packages/app/src/__tests__/i18n.test.ts
@@ -1,4 +1,5 @@
 import { appShortName } from '@/lib/build-config'
+import { vi } from 'vitest'
 
 // Mock localStorage BEFORE importing i18n (i18n.init calls getUserLanguage which uses localStorage)
 const mockLocalStorage = (() => {
@@ -22,6 +23,7 @@ Object.defineProperty(window, 'localStorage', {
   value: mockLocalStorage,
   writable: true,
 });
+vi.stubGlobal('localStorage', mockLocalStorage)
 
 // Use dynamic import so i18n loads after localStorage mock is set up
 let i18n: Awaited<typeof import('../lib/i18n')['default']>;

--- a/packages/app/src/components/settings/GeneralSection.tsx
+++ b/packages/app/src/components/settings/GeneralSection.tsx
@@ -32,6 +32,7 @@ import { getPermissionPolicy, setPermissionPolicy, type PermissionPolicy } from 
 import { PermissionBatchSection } from './PermissionBatchSection'
 import { useSuggestionsStore } from '@/stores/suggestions'
 import { appShortName, buildConfig } from '@/lib/build-config'
+import { getPreferredLanguage, persistLanguage } from '@/lib/locale'
 import { useUIStore } from '@/stores/ui'
 import { useWorkspaceStore } from '@/stores/workspace'
 
@@ -71,9 +72,7 @@ export const GeneralSection = React.memo(function GeneralSection() {
   const { t } = useTranslation()
   const [theme, setThemeState] = React.useState(getStoredTheme)
   const [language, setLanguage] = React.useState(() => {
-    const storedLang = localStorage.getItem(`${appShortName}-language`);
-    if (storedLang === 'zh') return 'zh-CN';
-    return storedLang || (navigator.language.startsWith('zh') ? 'zh-CN' : 'en');
+    return getPreferredLanguage()
   })
 
   // Sync language state with i18n instance
@@ -181,7 +180,7 @@ export const GeneralSection = React.memo(function GeneralSection() {
     onValueChange={(value) => {
       setLanguage(value);
       i18next.changeLanguage(value);
-      localStorage.setItem(`${appShortName}-language`, value);
+      persistLanguage(value);
       // Sync locale to config file for gateway i18n
       invoke('set_config_locale', { locale: value }).catch(console.error);
     }}

--- a/packages/app/src/lib/__tests__/locale.test.ts
+++ b/packages/app/src/lib/__tests__/locale.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { appShortName } from '@/lib/build-config'
+
+const store: Record<string, string> = {}
+
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, val: string) => { store[key] = val },
+  removeItem: (key: string) => { delete store[key] },
+  clear: () => { Object.keys(store).forEach((key) => delete store[key]) },
+})
+
+function setNavigatorLanguage(language: string, languages: string[] = [language]) {
+  Object.defineProperty(window.navigator, 'language', {
+    configurable: true,
+    value: language,
+  })
+  Object.defineProperty(window.navigator, 'languages', {
+    configurable: true,
+    value: languages,
+  })
+}
+
+describe('locale helpers', () => {
+  beforeEach(() => {
+    Object.keys(store).forEach((key) => delete store[key])
+    vi.resetModules()
+  })
+
+  it('uses the system language when there is no saved language', async () => {
+    setNavigatorLanguage('zh-CN')
+
+    const { getPreferredLanguage } = await import('../locale')
+
+    expect(getPreferredLanguage()).toBe('zh-CN')
+  })
+
+  it('prefers a saved language over the system language', async () => {
+    setNavigatorLanguage('zh-CN')
+    store[`${appShortName}-language`] = 'en'
+
+    const { getPreferredLanguage } = await import('../locale')
+
+    expect(getPreferredLanguage()).toBe('en')
+  })
+
+  it('falls back to English for unsupported system languages', async () => {
+    setNavigatorLanguage('fr-FR')
+
+    const { getPreferredLanguage } = await import('../locale')
+
+    expect(getPreferredLanguage()).toBe('en')
+  })
+})

--- a/packages/app/src/lib/__tests__/number-format-system-locale.test.ts
+++ b/packages/app/src/lib/__tests__/number-format-system-locale.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const store: Record<string, string> = {}
+
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, val: string) => { store[key] = val },
+  removeItem: (key: string) => { delete store[key] },
+  clear: () => { Object.keys(store).forEach((key) => delete store[key]) },
+})
+
+function setNavigatorLanguage(language: string) {
+  Object.defineProperty(window.navigator, 'language', {
+    configurable: true,
+    value: language,
+  })
+  Object.defineProperty(window.navigator, 'languages', {
+    configurable: true,
+    value: [language],
+  })
+}
+
+describe('number-format system locale fallback', () => {
+  beforeEach(() => {
+    Object.keys(store).forEach((key) => delete store[key])
+    vi.resetModules()
+  })
+
+  it('uses the system language when no saved language exists', async () => {
+    setNavigatorLanguage('zh-CN')
+
+    const numberFormatSpy = vi.spyOn(Intl, 'NumberFormat')
+
+    const { formatNumber } = await import('../number-format')
+    formatNumber(1234)
+
+    expect(numberFormatSpy).toHaveBeenCalledWith('zh-CN', {})
+
+    numberFormatSpy.mockRestore()
+  })
+})

--- a/packages/app/src/lib/date-format.ts
+++ b/packages/app/src/lib/date-format.ts
@@ -1,10 +1,10 @@
-import { appShortName } from '@/lib/build-config'
+import { getPreferredLanguage } from './locale'
 
 /**
  * Format a date according to the current locale
  */
 export const formatDate = (date: Date | string | number, options: Intl.DateTimeFormatOptions = {}): string => {
-  const lang = localStorage.getItem(`${appShortName}-language`) || 'en';
+  const lang = getPreferredLanguage();
   const dateObj = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
   
   // Default options if none provided
@@ -23,7 +23,7 @@ export const formatDate = (date: Date | string | number, options: Intl.DateTimeF
  * Format time according to the current locale
  */
 export const formatTime = (date: Date | string | number, options: Intl.DateTimeFormatOptions = {}): string => {
-  const lang = localStorage.getItem(`${appShortName}-language`) || 'en';
+  const lang = getPreferredLanguage();
   const dateObj = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
   
   // Default time options
@@ -41,7 +41,7 @@ export const formatTime = (date: Date | string | number, options: Intl.DateTimeF
  * Format datetime according to the current locale
  */
 export const formatDateTime = (date: Date | string | number, options: Intl.DateTimeFormatOptions = {}): string => {
-  const lang = localStorage.getItem(`${appShortName}-language`) || 'en';
+  const lang = getPreferredLanguage();
   const dateObj = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
   
   // Default datetime options
@@ -95,7 +95,7 @@ export function formatSessionDate(dateInput: string | Date): string {
  * Format relative time (e.g., "2 hours ago")
  */
 export const formatRelativeTime = (date: Date | string | number): string => {
-  const lang = localStorage.getItem(`${appShortName}-language`) || 'en';
+  const lang = getPreferredLanguage();
   const dateObj = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date;
   const now = new Date();
   const diffInSeconds = Math.floor((now.getTime() - dateObj.getTime()) / 1000);

--- a/packages/app/src/lib/i18n.ts
+++ b/packages/app/src/lib/i18n.ts
@@ -1,6 +1,6 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import { appShortName } from '@/lib/build-config';
+import { getPreferredLanguage, normalizeSupportedLanguage, persistLanguage } from './locale';
 
 // Import translation files
 import enTranslation from '../locales/en.json';
@@ -21,27 +21,12 @@ const resources = FORCED_LOCALE && FORCED_LOCALE !== 'all'
   ? { [FORCED_LOCALE]: allResources[FORCED_LOCALE as keyof typeof allResources] }
   : allResources;
 
-// Detect user's language preference
 const getUserLanguage = (): string => {
-  // Single-locale build — always use the forced locale
   if (FORCED_LOCALE && FORCED_LOCALE !== 'all') {
     return FORCED_LOCALE;
   }
 
-  // Check for persisted language in localStorage
-  const persistedLang = localStorage.getItem(`${appShortName}-language`);
-  if (persistedLang && Object.keys(resources).includes(persistedLang)) {
-    return persistedLang;
-  }
-
-  // Fallback to browser language detection
-  const browserLang = navigator.language;
-  if (browserLang.startsWith('zh')) {
-    return 'zh-CN';
-  }
-
-  // Default to English
-  return 'en';
+  return normalizeSupportedLanguage(getPreferredLanguage());
 };
 
 const defaultLng = FORCED_LOCALE && FORCED_LOCALE !== 'all' ? FORCED_LOCALE : 'en';
@@ -71,9 +56,11 @@ export default i18n;
 
 // Export utility functions for language switching and persistence
 export const changeLanguage = (lang: string) => {
-  if (Object.keys(resources).includes(lang)) {
-    i18n.changeLanguage(lang);
-    localStorage.setItem(`${appShortName}-language`, lang); // Persist the language preference
+  const normalizedLang = normalizeSupportedLanguage(lang);
+  persistLanguage(normalizedLang);
+
+  if (Object.keys(resources).includes(normalizedLang)) {
+    i18n.changeLanguage(normalizedLang);
   }
 };
 

--- a/packages/app/src/lib/locale.ts
+++ b/packages/app/src/lib/locale.ts
@@ -1,0 +1,83 @@
+import { appShortName } from '@/lib/build-config'
+
+export const LANGUAGE_STORAGE_KEY = `${appShortName}-language`
+
+function getStorage(): Storage | undefined {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage
+  }
+
+  if (typeof globalThis !== 'undefined' && 'localStorage' in globalThis) {
+    return globalThis.localStorage
+  }
+
+  return undefined
+}
+
+function getNavigator(): Navigator | undefined {
+  if (typeof window !== 'undefined' && window.navigator) {
+    return window.navigator
+  }
+
+  if (typeof globalThis !== 'undefined' && 'navigator' in globalThis) {
+    return globalThis.navigator
+  }
+
+  return undefined
+}
+
+export function normalizeSupportedLanguage(language: string | null | undefined): string {
+  if (!language) return 'en'
+
+  const normalized = language.toLowerCase()
+  if (normalized === 'en' || normalized.startsWith('en-')) {
+    return 'en'
+  }
+  if (normalized === 'zh' || normalized.startsWith('zh-')) {
+    return 'zh-CN'
+  }
+
+  return 'en'
+}
+
+export function getStoredLanguage(): string | null {
+  const storage = getStorage()
+  if (!storage) return null
+
+  try {
+    const language = storage.getItem(LANGUAGE_STORAGE_KEY)
+    return language ? normalizeSupportedLanguage(language) : null
+  } catch {
+    return null
+  }
+}
+
+export function getSystemLanguage(): string {
+  const nav = getNavigator()
+  if (!nav) return 'en'
+
+  const candidates = nav.languages?.length ? nav.languages : [nav.language]
+  for (const candidate of candidates) {
+    const language = normalizeSupportedLanguage(candidate)
+    if (language !== 'en' || candidate?.toLowerCase().startsWith('en')) {
+      return language
+    }
+  }
+
+  return 'en'
+}
+
+export function getPreferredLanguage(): string {
+  return getStoredLanguage() ?? getSystemLanguage()
+}
+
+export function persistLanguage(language: string): void {
+  const storage = getStorage()
+  if (!storage) return
+
+  try {
+    storage.setItem(LANGUAGE_STORAGE_KEY, normalizeSupportedLanguage(language))
+  } catch {
+    // Ignore storage failures and continue with in-memory language state.
+  }
+}

--- a/packages/app/src/lib/number-format.ts
+++ b/packages/app/src/lib/number-format.ts
@@ -1,10 +1,10 @@
-import { appShortName } from '@/lib/build-config'
+import { getPreferredLanguage } from './locale'
 
 /**
  * Format a number according to the current locale
  */
 export const formatNumber = (num: number, options: Intl.NumberFormatOptions = {}): string => {
-  const lang = localStorage.getItem(`${appShortName}-language`) || 'en';
+  const lang = getPreferredLanguage();
   
   // Default options if none provided
   const defaultOptions: Intl.NumberFormatOptions = {};
@@ -18,7 +18,7 @@ export const formatNumber = (num: number, options: Intl.NumberFormatOptions = {}
  * Format a number as currency according to the current locale
  */
 export const formatCurrency = (num: number, currency: string = 'USD', options: Intl.NumberFormatOptions = {}): string => {
-  const lang = localStorage.getItem(`${appShortName}-language`) || 'en';
+  const lang = getPreferredLanguage();
 
   // Default currency options
   const defaultOptions: Intl.NumberFormatOptions = {
@@ -35,7 +35,7 @@ export const formatCurrency = (num: number, currency: string = 'USD', options: I
  * Format a percentage according to the current locale
  */
 export const formatPercentage = (num: number, options: Intl.NumberFormatOptions = {}): string => {
-  const lang = localStorage.getItem(`${appShortName}-language`) || 'en';
+  const lang = getPreferredLanguage();
 
   // Default percentage options
   const defaultOptions: Intl.NumberFormatOptions = {

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { invoke } from '@tauri-apps/api/core'
 import { withAsync } from '@/lib/store-utils'
 import { appShortName } from '@/lib/build-config'
+import { getPreferredLanguage } from '@/lib/locale'
 
 // ==================== Types ====================
 
@@ -292,7 +293,7 @@ export function formatSchedule(schedule: CronSchedule): string {
 /** Format a relative time string with i18n support (e.g., "2 minutes ago" / "2分钟前") */
 export function formatRelativeTime(dateStr: string): string {
   try {
-    const lang = localStorage.getItem(`${appShortName}-language`) || 'en'
+    const lang = getPreferredLanguage()
     const date = new Date(dateStr)
     const now = new Date()
     const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000)


### PR DESCRIPTION
## Summary
- make app locale default to the system language when no explicit language preference has been saved
- centralize locale normalization and persistence so i18n, formatting helpers, and settings read the same source of truth
- add regression tests for system-language fallback and i18n persistence

## Test Plan
- pnpm exec vitest run src/lib/__tests__/locale.test.ts src/lib/__tests__/number-format-system-locale.test.ts src/__tests__/i18n.test.ts src/lib/__tests__/number-format.test.ts src/lib/__tests__/date-format.test.ts
