### PR TITLE
fix: pass workspace path to git team commands

### DIFF
--- a/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
+++ b/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
@@ -36,7 +36,7 @@ export function KnowledgeBrowser() {
         needsConfirmation?: boolean
         newFiles?: Array<{ path: string; sizeBytes: number }>
         totalBytes?: number
-      }>('team_sync_repo', { force: false })
+      }>('team_sync_repo', { force: false, workspacePath })
       if (result.needsConfirmation) {
         toast.warning(
           `检测到 ${result.newFiles?.length ?? 0} 个较大的新文件待同步，请在设置 → 团队中确认`,

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -138,6 +138,10 @@ export function TeamGitConfig() {
   const teamMembersStore = useTeamMembersStore()
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
   const openCodeReady = useWorkspaceStore((s) => s.openCodeReady)
+  const workspaceArgs = React.useMemo<{ workspacePath?: string }>(
+    () => (workspacePath ? { workspacePath } : {}),
+    [workspacePath],
+  )
   const [deviceInfo, setDeviceInfo] = React.useState<{ nodeId: string } | null>(null)
   const [state, setState] = React.useState<ConnectionState>('loading')
   const [teamConfig, setTeamConfig] = React.useState<TeamConfig | null>(null)
@@ -208,7 +212,7 @@ export function TeamGitConfig() {
         return
       }
 
-      const config = await tauriInvoke<TeamConfig | null>('get_team_config')
+      const config = await tauriInvoke<TeamConfig | null>('get_team_config', workspaceArgs)
       if (config) {
         setTeamConfig(config)
         setGitUrl(config.gitUrl)
@@ -217,7 +221,10 @@ export function TeamGitConfig() {
         // Init shared secrets if team_id exists
         if (config.teamId) {
           try {
-            await tauriInvoke('init_git_team_secrets', { teamId: config.teamId })
+            await tauriInvoke('init_git_team_secrets', {
+              teamId: config.teamId,
+              ...workspaceArgs,
+            })
           } catch (err) {
             console.warn('Failed to init shared secrets:', err)
           }
@@ -236,7 +243,7 @@ export function TeamGitConfig() {
       setErrorMessage(err instanceof Error ? err.message : String(err))
       setState('error')
     }
-  }, [workspacePath, openCodeReady])
+  }, [workspacePath, openCodeReady, workspaceArgs])
 
   React.useEffect(() => {
     initialize()
@@ -245,7 +252,7 @@ export function TeamGitConfig() {
   // Load current LLM config when connected
   React.useEffect(() => {
     if ((state === 'connected' || state === 'syncing') && !llmLoaded && isTauri()) {
-      tauriInvoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status')
+      tauriInvoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status', workspaceArgs)
         .then((status) => {
           if (status.llm?.baseUrl) {
             setHostLlm(true)
@@ -260,7 +267,7 @@ export function TeamGitConfig() {
         .catch(() => {})
       setLlmLoaded(true)
     }
-  }, [state, llmLoaded])
+  }, [state, llmLoaded, workspaceArgs])
 
   // Load members and device info when connected
   React.useEffect(() => {
@@ -280,6 +287,7 @@ export function TeamGitConfig() {
         llmModel: hostLlm ? (llmModels[0]?.id || null) : null,
         llmModelName: hostLlm ? (llmModels[0]?.name || null) : null,
         llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
+        ...workspaceArgs,
       })
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : String(err))
@@ -307,10 +315,11 @@ export function TeamGitConfig() {
         llmModel: hostLlm ? (llmModels[0]?.id || null) : null,
         llmModelName: hostLlm ? (llmModels[0]?.name || null) : null,
         llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
+        ...workspaceArgs,
       })
 
       setConnectStep(t('settings.team.generatingGitignore', 'Generating .gitignore...'))
-      await tauriInvoke<TeamGitResult>('team_generate_gitignore')
+      await tauriInvoke<TeamGitResult>('team_generate_gitignore', workspaceArgs)
 
       setConnectStep(t('settings.team.savingConfig', 'Saving configuration...'))
       const now = new Date().toISOString()
@@ -321,7 +330,7 @@ export function TeamGitConfig() {
         ...(isHttpsUrl && gitToken.trim() ? { gitToken: gitToken.trim() } : {}),
         ...(gitBranch.trim() ? { gitBranch: gitBranch.trim() } : {}),
       }
-      await tauriInvoke('save_team_config', { team: newConfig })
+      await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
 
       setTeamConfig(newConfig)
       setState('connected')
@@ -377,6 +386,7 @@ export function TeamGitConfig() {
         llmModelName: hostLlm ? (llmModels[0]?.name || null) : null,
         llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
         fcEndpoint: managedGit ? MANAGED_GIT_FC_ENDPOINT : null,
+        ...workspaceArgs,
       })
       setConnectStep('Saving configuration...')
       const now = new Date().toISOString()
@@ -388,7 +398,7 @@ export function TeamGitConfig() {
         ...(effectiveGitToken ? { gitToken: effectiveGitToken } : {}),
         ...(gitBranch.trim() ? { gitBranch: gitBranch.trim() } : {}),
       }
-      await tauriInvoke('save_team_config', { team: newConfig })
+      await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
       setTeamConfig(newConfig)
       setCreatedTeamId(result.teamId)
       setCreatedTeamSecret(result.teamSecret)
@@ -456,6 +466,7 @@ export function TeamGitConfig() {
         llmModelName: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
         llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
         fcEndpoint: joinedViaInvite ? MANAGED_GIT_FC_ENDPOINT : null,
+        ...workspaceArgs,
       })
       setConnectStep('Saving configuration...')
       const now = new Date().toISOString()
@@ -467,7 +478,7 @@ export function TeamGitConfig() {
         ...(effectiveGitToken ? { gitToken: effectiveGitToken } : {}),
         ...(gitBranch.trim() ? { gitBranch: gitBranch.trim() } : {}),
       }
-      await tauriInvoke('save_team_config', { team: newConfig })
+      await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
       setTeamConfig(newConfig)
       setState('connected')
 
@@ -488,7 +499,7 @@ export function TeamGitConfig() {
     setErrorMessage(null)
 
     try {
-      const result = await tauriInvoke<TeamGitResult>('team_sync_repo', { force })
+      const result = await tauriInvoke<TeamGitResult>('team_sync_repo', { force, ...workspaceArgs })
 
       if (result.needsConfirmation) {
         setPendingUpdateUi(updateUi)
@@ -518,7 +529,7 @@ export function TeamGitConfig() {
         ...teamConfig!,
         lastSyncAt: now,
       }
-      await tauriInvoke('save_team_config', { team: updatedConfig })
+      await tauriInvoke('save_team_config', { team: updatedConfig, ...workspaceArgs })
       setTeamConfig(updatedConfig)
       const { useTeamModeStore } = await import('@/stores/team-mode')
       useTeamModeStore.setState({ teamGitLastSyncAt: now })
@@ -542,8 +553,8 @@ export function TeamGitConfig() {
     setErrorMessage(null)
 
     try {
-      await tauriInvoke<TeamGitResult>('team_disconnect_repo')
-      await tauriInvoke('clear_team_config')
+      await tauriInvoke<TeamGitResult>('team_disconnect_repo', workspaceArgs)
+      await tauriInvoke('clear_team_config', workspaceArgs)
 
       setTeamConfig(null)
       setGitUrl('')
@@ -562,7 +573,7 @@ export function TeamGitConfig() {
 
     try {
       const updatedConfig: TeamConfig = { ...teamConfig, enabled }
-      await tauriInvoke('save_team_config', { team: updatedConfig })
+      await tauriInvoke('save_team_config', { team: updatedConfig, ...workspaceArgs })
       setTeamConfig(updatedConfig)
     } catch (err) {
       console.error('Toggle error:', err)
@@ -1004,7 +1015,10 @@ export function TeamGitConfig() {
                         let secret = loadedTeamSecret
                         if (!secret) {
                           try {
-                            secret = await tauriInvoke<string>('get_git_team_secret', { teamId: teamConfig.teamId })
+                            secret = await tauriInvoke<string>('get_git_team_secret', {
+                              teamId: teamConfig.teamId,
+                              ...workspaceArgs,
+                            })
                             setLoadedTeamSecret(secret)
                           } catch { return }
                         }
@@ -1051,7 +1065,10 @@ export function TeamGitConfig() {
                         onClick={async () => {
                           if (!showTeamSecret && !loadedTeamSecret) {
                             try {
-                              const secret = await tauriInvoke<string>('get_git_team_secret', { teamId: teamConfig.teamId })
+                              const secret = await tauriInvoke<string>('get_git_team_secret', {
+                                teamId: teamConfig.teamId,
+                                ...workspaceArgs,
+                              })
                               setLoadedTeamSecret(secret)
                             } catch { /* ignore */ }
                           }
@@ -1068,7 +1085,10 @@ export function TeamGitConfig() {
                           let secret = loadedTeamSecret
                           if (!secret) {
                             try {
-                              secret = await tauriInvoke<string>('get_git_team_secret', { teamId: teamConfig.teamId })
+                              secret = await tauriInvoke<string>('get_git_team_secret', {
+                                teamId: teamConfig.teamId,
+                                ...workspaceArgs,
+                              })
                               setLoadedTeamSecret(secret)
                             } catch { return }
                           }

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -149,7 +149,7 @@ export function TeamOSSConfig() {
             if (config) setCfgFcEndpoint(config.teamEndpoint || '')
           })
           .catch(() => {})
-        invoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status')
+        invoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status', { workspacePath })
           .then((status) => {
             if (status.llm?.baseUrl) {
               setCfgHostLlm(true)

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -195,7 +195,7 @@ export function TeamP2PConfig() {
         // Load current LLM config for editing
         if (!cfgLoaded) {
           try {
-            const status = await tauriInvoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status')
+            const status = await tauriInvoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status', { workspacePath })
             if (status.llm?.baseUrl) {
               setCfgHostLlm(true)
               setCfgLlmUrl(status.llm.baseUrl)
@@ -412,6 +412,7 @@ export function TeamP2PConfig() {
         llmModel: cfgHostLlm ? (cfgLlmModels[0]?.id || null) : null,
         llmModelName: cfgHostLlm ? (cfgLlmModels[0]?.name || null) : null,
         llmModels: cfgHostLlm && cfgLlmModels.length > 0 ? JSON.stringify(cfgLlmModels) : null,
+        workspacePath,
       })
     } catch (err) {
       setP2pError(err instanceof Error ? err.message : String(err))

--- a/packages/app/src/components/settings/team/__tests__/TeamGitConfig.test.tsx
+++ b/packages/app/src/components/settings/team/__tests__/TeamGitConfig.test.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+
+const mockInvoke = vi.hoisted(() => vi.fn())
+
+const workspaceStoreMocks = vi.hoisted(() => ({
+  workspacePath: '/workspace-a',
+  openCodeReady: true,
+}))
+
+const teamMembersStoreMocks = vi.hoisted(() => ({
+  loadMembers: vi.fn(),
+  loadMyRole: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallbackOrOptions?: string | Record<string, unknown>) => {
+      if (typeof fallbackOrOptions === 'string') return fallbackOrOptions
+      if (fallbackOrOptions && typeof fallbackOrOptions.defaultValue === 'string') {
+        return fallbackOrOptions.defaultValue
+      }
+      return key
+    },
+  }),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  isTauri: () => true,
+  copyToClipboard: vi.fn(),
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/lib/build-config', () => ({
+  buildConfig: {
+    app: { name: 'TeamClaw' },
+    team: {
+      llm: { baseUrl: '', models: [] },
+    },
+  },
+  TEAM_SYNCED_EVENT: 'team-synced',
+  TEAM_REPO_DIR: 'teamclaw-team',
+}))
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel(workspaceStoreMocks as unknown as Record<string, unknown>),
+}))
+
+vi.mock('@/stores/team-members', () => ({
+  useTeamMembersStore: () => teamMembersStoreMocks,
+}))
+
+vi.mock('./HostLlmConfig', () => ({
+  HostLlmConfig: () => <div>Host LLM</div>,
+}))
+
+vi.mock('@/components/settings/shared', () => ({
+  ToggleSwitch: ({ enabled: _enabled, ...props }: any) => <button {...props} />,
+}))
+
+vi.mock('@/components/settings/TeamMemberList', () => ({
+  TeamMemberList: () => <div>Team members</div>,
+}))
+
+vi.mock('@/components/settings/DeviceIdDisplay', () => ({
+  DeviceIdDisplay: () => <div>Device ID</div>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <div>{children}</div>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/collapsible', () => ({
+  Collapsible: ({ children }: any) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: any) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: any) => <button>{children}</button>,
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+import { TeamGitConfig } from '../TeamGitConfig'
+
+describe('TeamGitConfig workspace-aware calls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    workspaceStoreMocks.workspacePath = '/workspace-a'
+    workspaceStoreMocks.openCodeReady = true
+    teamMembersStoreMocks.loadMembers.mockReset()
+    teamMembersStoreMocks.loadMyRole.mockReset()
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      value: {
+        transformCallback: vi.fn(() => 0),
+        invoke: vi.fn(async () => null),
+      },
+      configurable: true,
+    })
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'team_check_git_installed') return { installed: true, version: 'git version 2.0.0' }
+      if (cmd === 'get_team_config') return null
+      if (cmd === 'get_device_info') return { nodeId: 'node-123' }
+      return null
+    })
+  })
+
+  it('passes workspacePath when loading the Git team config', async () => {
+    render(<TeamGitConfig />)
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('get_team_config', { workspacePath: '/workspace-a' })
+    })
+  })
+
+  it('passes workspacePath when initializing secrets for a configured Git team', async () => {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'team_check_git_installed') return { installed: true, version: 'git version 2.0.0' }
+      if (cmd === 'get_team_config') {
+        return {
+          gitUrl: 'https://example.com/repo.git',
+          enabled: false,
+          lastSyncAt: null,
+          teamId: 'team-123',
+        }
+      }
+      if (cmd === 'init_git_team_secrets') return null
+      if (cmd === 'get_team_status') return { active: true, llm: null }
+      if (cmd === 'get_device_info') return { nodeId: 'node-123' }
+      return null
+    })
+
+    render(<TeamGitConfig />)
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('init_git_team_secrets', {
+        teamId: 'team-123',
+        workspacePath: '/workspace-a',
+      })
+    })
+  })
+})

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -435,12 +435,12 @@ export function useGitReposInit() {
 
     import("@tauri-apps/api/core")
       .then(({ invoke }) => {
-        invoke("get_team_config")
+        invoke("get_team_config", { workspacePath })
           .then((config: unknown) => {
             const teamConfig = config as { enabled?: boolean } | null;
             if (teamConfig?.enabled) {
               const doSync = () => {
-                invoke("team_sync_repo", { force: false })
+                invoke("team_sync_repo", { force: false, workspacePath })
                   .then(async (result: unknown) => {
                     const r = result as {
                       success: boolean;

--- a/packages/app/src/stores/__tests__/workspace-load-directory.test.ts
+++ b/packages/app/src/stores/__tests__/workspace-load-directory.test.ts
@@ -78,4 +78,58 @@ describe("workspace loadDirectory", () => {
       },
     ]);
   });
+
+  it("treats alias-like ambiguous entries as directories via stat fallback", async () => {
+    mockReadDir.mockResolvedValue([
+      {
+        name: "skills",
+        isDirectory: false,
+        isFile: false,
+        isSymlink: false,
+      },
+    ]);
+    mockStat.mockResolvedValue({
+      isDirectory: true,
+      isFile: false,
+      isSymlink: false,
+    });
+
+    const result = await useWorkspaceStore.getState().loadDirectory(".");
+
+    expect(mockStat).toHaveBeenCalledWith("/workspace/skills");
+    expect(result).toEqual([
+      {
+        name: "skills",
+        path: "/workspace/skills",
+        type: "directory",
+      },
+    ]);
+  });
+
+  it("treats ambiguous linked files as files via stat fallback", async () => {
+    mockReadDir.mockResolvedValue([
+      {
+        name: "linked-file.md",
+        isDirectory: false,
+        isFile: false,
+        isSymlink: false,
+      },
+    ]);
+    mockStat.mockResolvedValue({
+      isDirectory: false,
+      isFile: true,
+      isSymlink: false,
+    });
+
+    const result = await useWorkspaceStore.getState().loadDirectory(".");
+
+    expect(mockStat).toHaveBeenCalledWith("/workspace/linked-file.md");
+    expect(result).toEqual([
+      {
+        name: "linked-file.md",
+        path: "/workspace/linked-file.md",
+        type: "file",
+      },
+    ]);
+  });
 });

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -131,7 +131,9 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
     if (isTauri()) {
       try {
         const { invoke } = await import('@tauri-apps/api/core')
-        const teamConfig = await invoke<{ lastSyncAt?: string | null } | null>('get_team_config')
+        const teamConfig = await invoke<{ lastSyncAt?: string | null } | null>('get_team_config', {
+          workspacePath: _workspacePath,
+        })
         set({ teamGitLastSyncAt: teamConfig?.lastSyncAt ?? null })
       } catch { /* ignore */ }
     }

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -582,12 +582,14 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         visibleEntries.map(async (entry) => {
           const entryPath = `${fullPath}/${entry.name}`;
           let isDirectory = entry.isDirectory;
+          const needsStatResolution = !entry.isDirectory && !entry.isFile;
 
-          if (!isDirectory && entry.isSymlink) {
+          if (!isDirectory && needsStatResolution) {
             try {
-              isDirectory = (await stat(entryPath)).isDirectory;
+              const resolved = await stat(entryPath);
+              isDirectory = resolved.isDirectory;
             } catch (error) {
-              console.warn("[Workspace] Failed to resolve symlink target:", entryPath, error);
+              console.warn("[Workspace] Failed to resolve ambiguous file tree entry:", entryPath, error);
             }
           }
 

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -228,6 +228,18 @@ pub fn get_workspace_path(opencode_state: &OpenCodeState) -> Result<String, Stri
     crate::commands::opencode::current_workspace_path(opencode_state)
 }
 
+/// Resolve a workspace path from an explicit frontend argument when provided,
+/// otherwise fall back to the legacy single-instance OpenCode selection.
+pub fn resolve_workspace_path(
+    workspace_path: Option<String>,
+    opencode_state: &OpenCodeState,
+) -> Result<String, String> {
+    workspace_path
+        .filter(|path| !path.is_empty())
+        .or_else(|| get_workspace_path(opencode_state).ok())
+        .ok_or("No workspace path set. Please select a workspace first.".to_string())
+}
+
 /// Read team config from teamclaw.json
 fn read_team_config_from_file(workspace_path: &str) -> Result<Option<TeamConfig>, String> {
     let config_path = format!(
@@ -754,10 +766,7 @@ pub fn get_team_status(
     workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<TeamStatus, String> {
-    let ws = workspace_path
-        .filter(|p| !p.is_empty())
-        .or_else(|| get_workspace_path(&opencode_state).ok())
-        .ok_or("No workspace path set. Please select a workspace first.".to_string())?;
+    let ws = resolve_workspace_path(workspace_path, &opencode_state)?;
     Ok(check_team_status(&ws))
 }
 
@@ -769,9 +778,10 @@ pub fn update_team_llm_config(
     llm_model: Option<String>,
     llm_model_name: Option<String>,
     llm_models: Option<String>,
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<(), String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     let llm_config = build_llm_config(llm_base_url, llm_model, llm_model_name, llm_models);
     write_llm_config(&workspace_path, llm_config.as_ref())?;
     Ok(())
@@ -805,9 +815,10 @@ pub fn team_check_git_installed() -> Result<GitCheckResult, String> {
 /// 1.2 - Check if workspace already has a .git directory
 #[tauri::command]
 pub async fn team_check_workspace_has_git(
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<WorkspaceGitCheckResult, String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     let git_dir = Path::new(&workspace_path).join(".git");
     Ok(WorkspaceGitCheckResult {
         has_git: git_dir.exists(),
@@ -824,9 +835,10 @@ pub async fn team_init_repo(
     llm_model: Option<String>,
     llm_model_name: Option<String>,
     llm_models: Option<String>,
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<TeamGitResult, String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     let team_dir = get_team_repo_path(&workspace_path);
 
     if Path::new(&team_dir).exists() {
@@ -950,10 +962,11 @@ pub async fn team_git_create(
     llm_model_name: Option<String>,
     llm_models: Option<String>,
     fc_endpoint: Option<String>,
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
     secrets_state: State<'_, crate::commands::shared_secrets::SharedSecretsState>,
 ) -> Result<TeamGitCreateResult, String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     let team_dir = get_team_repo_path(&workspace_path);
 
     if Path::new(&team_dir).exists() {
@@ -1184,10 +1197,11 @@ pub async fn team_git_join(
     llm_model_name: Option<String>,
     llm_models: Option<String>,
     fc_endpoint: Option<String>,
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
     secrets_state: State<'_, crate::commands::shared_secrets::SharedSecretsState>,
 ) -> Result<TeamGitResult, String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     let team_dir = get_team_repo_path(&workspace_path);
 
     // 1. Validate team_dir doesn't exist
@@ -1432,9 +1446,10 @@ pub async fn team_git_join(
 /// Creates the file if missing, or appends missing rules if it already exists.
 #[tauri::command]
 pub async fn team_generate_gitignore(
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<TeamGitResult, String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     let team_dir = get_team_repo_path(&workspace_path);
     ensure_gitignore_rules(&team_dir);
     Ok(TeamGitResult {
@@ -1491,11 +1506,12 @@ fn detect_precheck_breach(team_dir: &str) -> Option<(Vec<SyncPrecheckFile>, u64)
 /// without touching the repo — the caller must confirm and re-invoke with force.
 #[tauri::command]
 pub async fn team_sync_repo(
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
     secrets_state: State<'_, crate::commands::shared_secrets::SharedSecretsState>,
     force: Option<bool>,
 ) -> Result<TeamGitResult, String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     let team_dir = get_team_repo_path(&workspace_path);
 
     let git_dir = Path::new(&team_dir).join(".git");
@@ -1693,9 +1709,10 @@ pub async fn team_sync_repo(
 /// 1.6 - Disconnect team repo: remove workspace/teamclaw-team directory
 #[tauri::command]
 pub async fn team_disconnect_repo(
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<TeamGitResult, String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     let team_dir = get_team_repo_path(&workspace_path);
 
     if !Path::new(&team_dir).exists() {
@@ -1721,10 +1738,11 @@ pub async fn team_disconnect_repo(
 #[tauri::command]
 pub async fn init_git_team_secrets(
     team_id: String,
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
     secrets_state: State<'_, crate::commands::shared_secrets::SharedSecretsState>,
 ) -> Result<(), String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     let team_dir = get_team_repo_path(&workspace_path);
     let team_path = Path::new(&team_dir);
 
@@ -1749,9 +1767,10 @@ pub async fn init_git_team_secrets(
 #[tauri::command]
 pub async fn get_git_team_secret(
     team_id: String,
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<String, String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     crate::commands::oss_sync::load_team_secret(&workspace_path, &team_id)
 }
 
@@ -1760,9 +1779,10 @@ pub async fn get_git_team_secret(
 /// 2.2 - Get team config from teamclaw.json
 #[tauri::command]
 pub async fn get_team_config(
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<Option<TeamConfig>, String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     read_team_config_from_file(&workspace_path)
 }
 
@@ -1770,16 +1790,20 @@ pub async fn get_team_config(
 #[tauri::command]
 pub async fn save_team_config(
     team: TeamConfig,
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<(), String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     write_team_config_to_file(&workspace_path, Some(&team))
 }
 
 /// 2.4 - Clear team config from teamclaw.json
 #[tauri::command]
-pub async fn clear_team_config(opencode_state: State<'_, OpenCodeState>) -> Result<(), String> {
-    let workspace_path = get_workspace_path(&opencode_state)?;
+pub async fn clear_team_config(
+    workspace_path: Option<String>,
+    opencode_state: State<'_, OpenCodeState>,
+) -> Result<(), String> {
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
     write_team_config_to_file(&workspace_path, None)
 }
 
@@ -1790,6 +1814,7 @@ pub async fn clear_team_config(opencode_state: State<'_, OpenCodeState>) -> Resu
 #[cfg(test)]
 mod sync_precheck_tests {
     use super::*;
+    use crate::commands::opencode::OpenCodeInner;
 
     #[test]
     fn test_parse_untracked_paths_basic() {
@@ -1815,5 +1840,35 @@ mod sync_precheck_tests {
         let input = b"?? my new file.txt\x00";
         let paths = parse_untracked_paths(input);
         assert_eq!(paths, vec!["my new file.txt".to_string()]);
+    }
+
+    #[test]
+    fn resolve_workspace_path_prefers_explicit_workspace_in_multi_instance_mode() {
+        let state = OpenCodeState::default();
+        let mut instances = state.instances.lock().unwrap();
+        instances.insert(
+            "/workspace-a".to_string(),
+            OpenCodeInner {
+                is_running: true,
+                port: 13141,
+                child_process: None,
+                reader_task: None,
+            },
+        );
+        instances.insert(
+            "/workspace-b".to_string(),
+            OpenCodeInner {
+                is_running: true,
+                port: 13142,
+                child_process: None,
+                reader_task: None,
+            },
+        );
+        drop(instances);
+
+        let resolved =
+            resolve_workspace_path(Some("/workspace-b".to_string()), &state).unwrap();
+
+        assert_eq!(resolved, "/workspace-b");
     }
 }

--- a/src-tauri/src/commands/team_sync_all.rs
+++ b/src-tauri/src/commands/team_sync_all.rs
@@ -14,7 +14,7 @@ pub struct SyncAllResult {
 pub async fn sync_all(app: &AppHandle, workspace: &str) -> SyncAllResult {
     let status = check_team_status(workspace);
     match status.mode.as_deref() {
-        Some("git") => sync_git(app).await,
+        Some("git") => sync_git(app, workspace).await,
         Some("oss") | Some("webdav") => sync_oss(app).await,
         Some("p2p") => sync_p2p(app).await,
         _ => SyncAllResult {
@@ -26,7 +26,7 @@ pub async fn sync_all(app: &AppHandle, workspace: &str) -> SyncAllResult {
     }
 }
 
-async fn sync_git(app: &AppHandle) -> SyncAllResult {
+async fn sync_git(app: &AppHandle, workspace: &str) -> SyncAllResult {
     use crate::commands::opencode::OpenCodeState;
     use crate::commands::shared_secrets::SharedSecretsState;
     use crate::commands::team::team_sync_repo;
@@ -34,7 +34,7 @@ async fn sync_git(app: &AppHandle) -> SyncAllResult {
     let opencode = app.state::<OpenCodeState>();
     let secrets = app.state::<SharedSecretsState>();
 
-    match team_sync_repo(opencode, secrets, Some(false)).await {
+    match team_sync_repo(Some(workspace.to_string()), opencode, secrets, Some(false)).await {
         Ok(result) if result.needs_confirmation => SyncAllResult {
             mode: "git".to_string(),
             success: false,


### PR DESCRIPTION
## Summary
- pass `workspacePath` from the Team Git UI and related frontend sync/status entry points
- make Git/team Tauri commands accept an explicit `workspace_path` with legacy single-instance fallback
- add frontend and Rust regression coverage for the multi-OpenCode-instance path resolution case

## Test Plan
- `pnpm vitest run src/components/settings/team/__tests__/TeamGitConfig.test.tsx`
- `cargo test resolve_workspace_path_prefers_explicit_workspace_in_multi_instance_mode --lib`
- `pnpm typecheck` *(currently blocked by pre-existing `src/stores/cron.ts` TS6133 unused `appShortName` error, unrelated to this change)*