### PR TITLE
Fix multi-window webview routing

### DIFF
--- a/packages/app/src/lib/__tests__/webview-utils.test.ts
+++ b/packages/app/src/lib/__tests__/webview-utils.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ label: "ws-secondary" }),
+}));
+
+import { urlToLabel } from "@/lib/webview-utils";
+
+describe("urlToLabel", () => {
+  it("scopes native webview labels to the current window", () => {
+    expect(urlToLabel("https://example.com")).toContain("ws_secondary");
+  });
+});

--- a/packages/app/src/lib/webview-utils.ts
+++ b/packages/app/src/lib/webview-utils.ts
@@ -1,3 +1,5 @@
+import { getCurrentWindow } from "@tauri-apps/api/window"
+
 /** Ensure URL has a protocol prefix */
 export function normalizeUrl(url: string): string {
   if (!url) return url
@@ -7,10 +9,25 @@ export function normalizeUrl(url: string): string {
   return url
 }
 
+function sanitizeLabelPart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9]/g, "_")
+}
+
+function getCurrentWindowLabel(): string {
+  try {
+    return getCurrentWindow().label
+  } catch {
+    return "main"
+  }
+}
+
 /**
  * Generate a stable, deterministic label from the URL.
- * Same URL always produces the same label so we can reuse native webviews.
+ * Scope labels to the current Tauri window so the same URL opened in two
+ * windows does not alias the same native child webview.
  */
-export function urlToLabel(url: string): string {
-  return `wv-${normalizeUrl(url).replace(/[^a-zA-Z0-9]/g, "_").slice(0, 60)}`
+export function urlToLabel(url: string, windowLabel = getCurrentWindowLabel()): string {
+  const scopedWindowLabel = sanitizeLabelPart(windowLabel).slice(0, 24)
+  const scopedUrl = sanitizeLabelPart(normalizeUrl(url)).slice(0, 60)
+  return `wv-${scopedWindowLabel}-${scopedUrl}`
 }

--- a/src-tauri/src/commands/webview.rs
+++ b/src-tauri/src/commands/webview.rs
@@ -163,7 +163,7 @@ pub async fn webview_eval_js(app: tauri::AppHandle, code: String) -> Result<Stri
     }
 }
 
-/// Create a native webview as a child of the main window at the given position.
+/// Create a native webview as a child of the calling window at the given position.
 ///
 /// When `device_no` and `device_name` are provided, a `window.teamclaw` global
 /// is injected into the webview before any page scripts run, exposing identity
@@ -171,6 +171,7 @@ pub async fn webview_eval_js(app: tauri::AppHandle, code: String) -> Result<Stri
 #[tauri::command]
 pub async fn webview_create(
     app: tauri::AppHandle,
+    window: tauri::Window,
     state: tauri::State<'_, WebviewManager>,
     label: String,
     url: String,
@@ -208,17 +209,19 @@ pub async fn webview_create(
         }
     }
 
-    let window = app
-        .get_window("main")
-        .ok_or_else(|| "Main window not found".to_string())?;
-
     let parsed_url = url
         .parse::<tauri::Url>()
         .map_err(|e| format!("Invalid URL '{}': {}", url, e))?;
 
     eprintln!(
-        "[Webview] Creating '{}' url={} pos=({},{}) size={}x{}",
-        label, url, x, y, width, height
+        "[Webview] Creating '{}' in parent '{}' url={} pos=({},{}) size={}x{}",
+        label,
+        window.label(),
+        url,
+        x,
+        y,
+        width,
+        height
     );
 
     #[allow(unused_mut)]


### PR DESCRIPTION
## Summary
- scope native webview labels by Tauri window label so the same URL opened in multiple windows does not alias one child webview
- attach child webviews to the calling window instead of always parenting them to `main`
- add a regression test covering window-scoped webview labels

## Test Plan
- [x] `pnpm --filter @teamclaw/app test:unit src/lib/__tests__/webview-utils.test.ts`
- [x] `cargo check`
- [ ] manual multi-window repro

## Notes
- `pnpm --filter @teamclaw/app typecheck` currently fails due to a pre-existing unrelated error in `packages/app/src/stores/cron.ts` (`appShortName` is imported but unused).