### PR TITLE
fix(cron): remove unused appShortName import

### DIFF
--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand'
 import { invoke } from '@tauri-apps/api/core'
 import { withAsync } from '@/lib/store-utils'
-import { appShortName } from '@/lib/build-config'
 import { getPreferredLanguage } from '@/lib/locale'
 
 // ==================== Types ====================


### PR DESCRIPTION
## Summary

- Removes unused `appShortName` import from `packages/app/src/stores/cron.ts`
- This import triggered `error TS6133` during `tsc -b`, failing all release CI jobs (macOS aarch64, macOS x86_64, Windows) for tags v0.1.61–v0.1.63
- Only the Windows exe made it to OSS because... actually all three failed for the same reason

## Root cause

The `appShortName` symbol was imported but never referenced in the file. TypeScript strict mode (`noUnusedLocals`) treats this as an error.

## Test plan

- [x] `pnpm typecheck` passes locally with this change
- [ ] Merge and re-tag to trigger a clean release build