### PR TITLE
Refine chat dock and command toolcall UX

### DIFF
--- a/packages/app/src/components/chat/ChatInputArea.tsx
+++ b/packages/app/src/components/chat/ChatInputArea.tsx
@@ -33,7 +33,6 @@ import {
 } from "@/packages/ai/model-selector";
 import { Button } from "@/components/ui/button";
 import { FileInputButton } from "./FileInputButton";
-import { MessageQueueDisplay } from "./MessageQueueDisplay";
 import { ContextUsageBadge } from "./ContextUsageBadge";
 import { type QueuedMessage, useSessionStore } from "@/stores/session";
 import { useVoiceInputStore } from "@/stores/voice-input";
@@ -135,8 +134,8 @@ export function ChatInputArea({
   onSubmit,
   isStreaming,
   onAbort,
-  messageQueue,
-  onRemoveFromQueue,
+  messageQueue: _messageQueue,
+  onRemoveFromQueue: _onRemoveFromQueue,
   onHeightChange,
   headerContent,
 }: ChatInputAreaProps) {
@@ -255,14 +254,6 @@ export function ChatInputArea({
       <div className={cn("relative w-full", compact ? "" : "mx-auto max-w-3xl")}>
         {/* Permission & Error UI (rendered above input so it's visible) */}
         {headerContent}
-
-        {/* Message Queue Display */}
-        {!compact && (
-          <MessageQueueDisplay
-            queue={messageQueue}
-            onRemove={onRemoveFromQueue}
-          />
-        )}
 
         <PromptInput
           data-onboarding-id="chat-input-root"

--- a/packages/app/src/components/chat/ChatInputArea.tsx
+++ b/packages/app/src/components/chat/ChatInputArea.tsx
@@ -248,39 +248,47 @@ export function ChatInputArea({
         "z-10",
         compact
           ? "absolute bottom-0 left-0 right-0 px-2 pb-2 pt-2 bg-background"
-          : "absolute bottom-0 left-0 right-0 px-4 pb-6 pt-8 bg-gradient-to-t from-background from-70% to-transparent",
+          : "absolute bottom-0 left-0 right-0 px-4 pb-6 pt-8",
       )}
     >
       <div className={cn("relative w-full", compact ? "" : "mx-auto max-w-3xl")}>
         {/* Permission & Error UI (rendered above input so it's visible) */}
         {headerContent}
 
-        <PromptInput
-          data-onboarding-id="chat-input-root"
-          value={inputValue}
-          onValueChange={onInputChange}
-          onSubmit={handleSubmit}
-          onFilesChange={handlePastedFiles}
-          onFilePathsDrop={handleFilePathsDrop}
-          onMentionTrigger={(query) => {
-            setMentionSearchQuery(query);
-            setMentionPopoverOpen(true);
-          }}
-          onMentionClose={() => {
-            setMentionPopoverOpen(false);
-            setMentionSearchQuery("");
-          }}
-          onCommandTrigger={(query) => {
-            setCommandSearchQuery(query);
-            setCommandPopoverOpen(true);
-          }}
-          onCommandClose={() => {
-            setCommandPopoverOpen(false);
-            setCommandSearchQuery("");
-          }}
-          multiple
-          className="relative z-10 bg-card shadow-lg"
-        >
+        <div className="relative">
+          {!compact ? (
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute left-[-1px] right-[-1px] top-0 bottom-[-1.75rem] bg-background"
+            />
+          ) : null}
+
+          <PromptInput
+            data-onboarding-id="chat-input-root"
+            value={inputValue}
+            onValueChange={onInputChange}
+            onSubmit={handleSubmit}
+            onFilesChange={handlePastedFiles}
+            onFilePathsDrop={handleFilePathsDrop}
+            onMentionTrigger={(query) => {
+              setMentionSearchQuery(query);
+              setMentionPopoverOpen(true);
+            }}
+            onMentionClose={() => {
+              setMentionPopoverOpen(false);
+              setMentionSearchQuery("");
+            }}
+            onCommandTrigger={(query) => {
+              setCommandSearchQuery(query);
+              setCommandPopoverOpen(true);
+            }}
+            onCommandClose={() => {
+              setCommandPopoverOpen(false);
+              setCommandSearchQuery("");
+            }}
+            multiple
+            className="relative z-10 bg-card shadow-lg"
+          >
           {/* Image previews */}
           {imageFiles.length > 0 && (
             <div className="flex flex-wrap gap-2 px-4 pt-3 pb-2">
@@ -539,7 +547,8 @@ export function ChatInputArea({
               />
             </div>
           </PromptInputFooter>
-        </PromptInput>
+          </PromptInput>
+        </div>
       </div>
     </div>
   );

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -116,9 +116,10 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
   );
   const isViewingChild = !!viewingChildSessionId;
   const showInlineTodo = React.useMemo(() => {
-    if (isViewingChild || todos.length === 0) return false;
+    if (isViewingChild) return false;
+    if (todos.length === 0 && messageQueue.length === 0) return false;
     return !hasVisiblePendingPermissions(activeSessionId, sessions, pendingPermissions);
-  }, [activeSessionId, isViewingChild, pendingPermissions, sessions, todos]);
+  }, [activeSessionId, isViewingChild, messageQueue.length, pendingPermissions, sessions, todos]);
   const displayedChildSessionMessages = React.useMemo(() => {
     if (!viewingChildSessionId) return EMPTY_MESSAGES;
 
@@ -915,7 +916,14 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
           onHeightChange={handleInputHeightChange}
           headerContent={
             <>
-              {showInlineTodo ? <TodoList todos={todos} variant="inline" /> : null}
+              {showInlineTodo ? (
+                <TodoList
+                  todos={todos}
+                  queue={messageQueue}
+                  onRemoveFromQueue={removeFromQueue}
+                  variant="inline"
+                />
+              ) : null}
               <PendingPermissionInline />
               {sessionError && (
                 <SessionErrorAlert

--- a/packages/app/src/components/chat/TodoList.tsx
+++ b/packages/app/src/components/chat/TodoList.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { CheckCircle2, ChevronDown, ChevronUp, Circle, Clock3, ListTodo, XCircle } from "lucide-react";
+import { CheckCircle2, ChevronDown, ChevronUp, Circle, Clock3, ListTodo, Trash2, XCircle } from "lucide-react";
 import type { Todo } from "@/lib/opencode/sdk-types";
+import type { QueuedMessage } from "@/stores/session";
 import { cn } from "@/lib/utils";
 
 interface TodoListProps {
-  todos: Todo[];
+  todos?: Todo[];
+  queue?: QueuedMessage[];
+  onRemoveFromQueue?: (id: string) => void;
   compact?: boolean;
   variant?: "sidebar" | "inline";
 }
@@ -63,117 +66,242 @@ function SidebarTodoList({ todos }: { todos: Todo[] }) {
   );
 }
 
-function InlineTodoList({ todos }: { todos: Todo[] }) {
+function SectionHeader({
+  icon,
+  label,
+  isTop,
+  collapsed,
+  collapseAria,
+  expandAria,
+  onToggleCollapsed,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  isTop: boolean;
+  collapsed: boolean;
+  collapseAria: string;
+  expandAria: string;
+  onToggleCollapsed: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2.5 px-4 text-[12px] font-medium text-muted-foreground",
+        isTop ? "rounded-t-[24px] bg-white/25 py-3 dark:bg-white/5" : "bg-white/10 py-2.5 dark:bg-white/[0.03]",
+      )}
+    >
+      {icon}
+      <div className="min-w-0 flex-1">{label}</div>
+      <button
+        type="button"
+        aria-expanded={!collapsed}
+        aria-label={collapsed ? expandAria : collapseAria}
+        onClick={onToggleCollapsed}
+        className="inline-flex h-5 w-5 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+      >
+        {collapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
+      </button>
+    </div>
+  );
+}
+
+function InlineTodoList({
+  todos,
+  queue,
+  onRemoveFromQueue,
+}: {
+  todos: Todo[];
+  queue: QueuedMessage[];
+  onRemoveFromQueue?: (id: string) => void;
+}) {
   const { t } = useTranslation();
   const completedCount = todos.filter((todo) => todo.status === "completed").length;
-  const allCompleted = completedCount === todos.length;
-  const [collapsed, setCollapsed] = React.useState(allCompleted);
+  const allCompleted = todos.length > 0 && completedCount === todos.length;
+  const [todoCollapsed, setTodoCollapsed] = React.useState(allCompleted);
+  const [queueCollapsed, setQueueCollapsed] = React.useState(false);
   const activeTodo = getActiveTodo(todos);
+  const hasTodos = todos.length > 0;
+  const hasQueue = queue.length > 0;
+  const hasAnyContent = hasTodos || hasQueue;
   const todoSignature = React.useMemo(
-    () => todos.map((todo) => `${todo.id}:${todo.status}:${todo.content}`).join("|"),
+    () => todos.map((todo) => `todo:${todo.id}:${todo.status}:${todo.content}`).join("|"),
     [todos],
   );
-  const previousSignatureRef = React.useRef(todoSignature);
+  const queueSignature = React.useMemo(
+    () => queue.map((msg) => `queue:${msg.id}:${msg.content}`).join("|"),
+    [queue],
+  );
+  const previousTodoSignatureRef = React.useRef(todoSignature);
+  const previousQueueSignatureRef = React.useRef(queueSignature);
 
   React.useEffect(() => {
-    if (allCompleted) {
-      setCollapsed(true);
+    if (hasTodos && allCompleted) {
+      setTodoCollapsed(true);
     }
-  }, [allCompleted]);
+  }, [allCompleted, hasTodos]);
 
   React.useEffect(() => {
-    if (previousSignatureRef.current !== todoSignature) {
-      previousSignatureRef.current = todoSignature;
+    if (previousTodoSignatureRef.current !== todoSignature) {
+      previousTodoSignatureRef.current = todoSignature;
       if (!allCompleted) {
-        setCollapsed(false);
+        setTodoCollapsed(false);
       }
     }
   }, [allCompleted, todoSignature]);
+
+  React.useEffect(() => {
+    if (previousQueueSignatureRef.current !== queueSignature) {
+      previousQueueSignatureRef.current = queueSignature;
+      if (queue.length > 0) {
+        setQueueCollapsed(false);
+      }
+    }
+  }, [queue.length, queueSignature]);
+
+  if (!hasAnyContent) return null;
+
+  const topSection = hasTodos ? "todo" : "queue";
+  const dockCollapsed = (!hasTodos || todoCollapsed) && (!hasQueue || queueCollapsed);
+  const showCollapsedTodoSummary = todoCollapsed && !allCompleted && (!hasQueue || !queueCollapsed);
+  const headerOnlyCollapsed = dockCollapsed && !showCollapsedTodoSummary && (!hasQueue || queueCollapsed);
 
   return (
     <div
       data-testid="todo-list-inline"
       className={cn(
         "relative z-0 mx-auto w-[calc(100%-3.5rem)] max-w-[42rem] px-2",
-        collapsed ? "-mb-6" : "-mb-10",
+        dockCollapsed ? (headerOnlyCollapsed ? "-mb-1" : "-mb-6") : "-mb-10",
       )}
     >
       <div
         className={cn(
-          "overflow-hidden rounded-[24px] border border-[rgba(214,219,228,0.92)] bg-[rgba(250,251,252,0.10)] shadow-[0_1px_3px_rgba(15,23,42,0.03)] backdrop-blur-md supports-[backdrop-filter]:bg-[rgba(250,251,252,0.05)] transition-all dark:border-white/12 dark:bg-[rgba(15,23,42,0.28)] dark:supports-[backdrop-filter]:bg-[rgba(15,23,42,0.22)]",
-          collapsed ? "pb-1" : "pb-10",
+          "overflow-hidden rounded-[24px] border border-[rgba(214,219,228,0.92)] bg-[rgba(250,251,252,0.07)] shadow-[0_1px_3px_rgba(15,23,42,0.03)] backdrop-blur-md supports-[backdrop-filter]:bg-[rgba(250,251,252,0.035)] dark:border-white/12 dark:bg-[rgba(15,23,42,0.22)] dark:supports-[backdrop-filter]:bg-[rgba(15,23,42,0.16)]",
+          dockCollapsed ? "pb-1" : "pb-10",
+          headerOnlyCollapsed && "rounded-b-none pb-0",
         )}
       >
-        <div className={cn("flex items-center gap-2.5 px-4", collapsed ? "py-2" : "py-3")}>
-          <ListTodo className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          <div className="min-w-0 flex-1 text-[12px] font-medium text-muted-foreground">
-            {t("chat.todo.summary", "{{count}} tasks, {{completed}} completed", {
-              count: todos.length,
-              completed: completedCount,
-            })}
-          </div>
-          <button
-            type="button"
-            aria-expanded={!collapsed}
-            aria-label={
-              collapsed
-                ? t("chat.todo.expandAria", "Expand todo panel")
-                : t("chat.todo.collapseAria", "Collapse todo panel")
-            }
-            onClick={() => setCollapsed((value) => !value)}
-            className="inline-flex h-5 w-5 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
-          >
-            {collapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
-          </button>
-        </div>
-
-        {collapsed ? (
-          <div className="px-4 pb-0 text-[12px] leading-4 text-foreground/90">
-            {!allCompleted && activeTodo
-              ? t("chat.todo.activeSummary", "In progress: {{task}}", { task: activeTodo.content })
-              : t("chat.todo.allCompleted", "All tasks completed")}
-          </div>
-        ) : (
-          <div
-            data-testid="todo-list-inline-scroll"
-            className="space-y-2 overflow-y-auto px-4 pb-1 max-h-[8.75rem]"
-          >
-            {todos.map((todo, index) => (
+        <>
+          {hasTodos ? (
+            <section className={cn(hasQueue && "border-b border-white/40 dark:border-white/10")}>
+              <SectionHeader
+                icon={<ListTodo className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+                label={t("chat.todo.summary", "{{count}} tasks, {{completed}} completed", {
+                  count: todos.length,
+                  completed: completedCount,
+                })}
+                isTop={topSection === "todo"}
+                collapsed={todoCollapsed}
+                collapseAria={t("chat.todo.collapseAria", "Collapse todo panel")}
+                expandAria={t("chat.todo.expandAria", "Expand todo panel")}
+                onToggleCollapsed={() => setTodoCollapsed((value) => !value)}
+              />
               <div
-                key={todo.id}
+                data-testid="todo-list-inline-scroll-shell"
+                aria-hidden={todoCollapsed}
                 className={cn(
-                  "grid grid-cols-[18px_minmax(0,1fr)] items-center gap-2.5",
-                  todo.status === "completed" && "opacity-65",
+                  "overflow-hidden transition-[max-height,opacity,padding] duration-200 ease-in-out",
+                  !todoCollapsed ? "max-h-[11rem] opacity-100 px-4 py-3" : "max-h-0 opacity-0 px-4 py-0",
                 )}
               >
-                <div>{getTodoStatusIcon(todo.status, "h-3.5 w-3.5")}</div>
                 <div
-                  className={cn(
-                    "text-[14px] leading-6 text-foreground",
-                    todo.status === "completed" && "text-muted-foreground line-through",
-                  )}
+                  data-testid="todo-list-inline-scroll"
+                  className="space-y-2 overflow-y-auto max-h-[8.75rem]"
                 >
-                  <span className="mr-1.5 text-muted-foreground">{index + 1}.</span>
-                  {todo.content}
+                  {todos.map((todo, index) => (
+                    <div
+                      key={todo.id}
+                      className={cn(
+                        "grid grid-cols-[18px_minmax(0,1fr)] items-center gap-2.5",
+                        todo.status === "completed" && "opacity-65",
+                      )}
+                    >
+                      <div>{getTodoStatusIcon(todo.status, "h-3.5 w-3.5")}</div>
+                      <div
+                        className={cn(
+                          "text-[14px] leading-6 text-foreground",
+                          todo.status === "completed" && "text-muted-foreground line-through",
+                        )}
+                      >
+                        <span className="mr-1.5 text-muted-foreground">{index + 1}.</span>
+                        {todo.content}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               </div>
-            ))}
-          </div>
-        )}
+              {showCollapsedTodoSummary ? (
+                <div className="px-4 pb-0 text-[12px] leading-4 text-foreground/90">
+                  {activeTodo
+                    ? t("chat.todo.activeSummary", "In progress: {{task}}", { task: activeTodo.content })
+                    : null}
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+
+          {hasQueue ? (
+            <section data-testid="todo-list-inline-queue">
+              <SectionHeader
+                icon={<Clock3 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+                label={t("chat.messagesQueued", "{{count}} messages queued", { count: queue.length })}
+                isTop={topSection === "queue"}
+                collapsed={queueCollapsed}
+                collapseAria={t("chat.todo.queueCollapseAria", "Collapse queued messages")}
+                expandAria={t("chat.todo.queueExpandAria", "Expand queued messages")}
+                onToggleCollapsed={() => setQueueCollapsed((value) => !value)}
+              />
+              <div
+                data-testid="todo-list-inline-queue-shell"
+                aria-hidden={queueCollapsed}
+                className={cn(
+                  "overflow-hidden transition-[max-height,opacity,padding] duration-200 ease-in-out",
+                  !queueCollapsed ? "max-h-[10rem] opacity-100 px-4 py-3" : "max-h-0 opacity-0 px-4 py-0",
+                )}
+              >
+                <div
+                  className="space-y-1.5 overflow-y-auto max-h-[8.5rem]"
+                  data-testid="todo-list-inline-queue-body"
+                >
+                  {queue.map((msg, index) => (
+                    <div
+                      key={msg.id}
+                      className="group flex items-center gap-3 text-[13px] leading-5 text-foreground"
+                    >
+                      <span className="w-5 shrink-0 text-xs text-muted-foreground">{index + 1}.</span>
+                      <span className="min-w-0 flex-1 truncate">{msg.content}</span>
+                      {onRemoveFromQueue ? (
+                        <button
+                          type="button"
+                          onClick={() => onRemoveFromQueue(msg.id)}
+                          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-all hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+                          title={t("common.remove", "Remove")}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+          ) : null}
+        </>
       </div>
     </div>
   );
 }
 
 export const TodoList = React.memo(function TodoList({
-  todos,
+  todos = [],
+  queue = [],
+  onRemoveFromQueue,
   compact: _compact,
   variant = "sidebar",
 }: TodoListProps) {
-  if (todos.length === 0) return null;
+  if (todos.length === 0 && queue.length === 0) return null;
 
   if (variant === "inline") {
-    return <InlineTodoList todos={todos} />;
+    return <InlineTodoList todos={todos} queue={queue} onRemoveFromQueue={onRemoveFromQueue} />;
   }
 
   return <SidebarTodoList todos={todos} />;

--- a/packages/app/src/components/chat/TodoList.tsx
+++ b/packages/app/src/components/chat/TodoList.tsx
@@ -87,7 +87,7 @@ function SectionHeader({
     <div
       className={cn(
         "flex items-center gap-2.5 px-4 text-[12px] font-medium text-muted-foreground",
-        isTop ? "rounded-t-[24px] bg-white/25 py-3 dark:bg-white/5" : "bg-white/10 py-2.5 dark:bg-white/[0.03]",
+        isTop ? "rounded-t-[24px] py-3" : "py-2.5",
       )}
     >
       {icon}
@@ -175,14 +175,14 @@ function InlineTodoList({
     >
       <div
         className={cn(
-          "overflow-hidden rounded-[24px] border border-[rgba(214,219,228,0.92)] bg-[rgba(250,251,252,0.07)] shadow-[0_1px_3px_rgba(15,23,42,0.03)] backdrop-blur-md supports-[backdrop-filter]:bg-[rgba(250,251,252,0.035)] dark:border-white/12 dark:bg-[rgba(15,23,42,0.22)] dark:supports-[backdrop-filter]:bg-[rgba(15,23,42,0.16)]",
+          "overflow-hidden rounded-[24px] border border-[rgba(214,219,228,0.42)] bg-[rgba(255,255,255,0.02)] shadow-[0_1px_2px_rgba(15,23,42,0.018)] backdrop-blur-[9px] supports-[backdrop-filter]:bg-[rgba(255,255,255,0.5)] dark:border-white/10 dark:bg-[rgba(15,23,42,0.08)] dark:supports-[backdrop-filter]:bg-[rgba(15,23,42,0.055)]",
           dockCollapsed ? "pb-1" : "pb-10",
           headerOnlyCollapsed && "rounded-b-none pb-0",
         )}
       >
         <>
           {hasTodos ? (
-            <section className={cn(hasQueue && "border-b border-white/40 dark:border-white/10")}>
+            <section>
               <SectionHeader
                 icon={<ListTodo className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
                 label={t("chat.todo.summary", "{{count}} tasks, {{completed}} completed", {
@@ -200,13 +200,10 @@ function InlineTodoList({
                 aria-hidden={todoCollapsed}
                 className={cn(
                   "overflow-hidden transition-[max-height,opacity,padding] duration-200 ease-in-out",
-                  !todoCollapsed ? "max-h-[11rem] opacity-100 px-4 py-3" : "max-h-0 opacity-0 px-4 py-0",
+                  !todoCollapsed ? "max-h-[11rem] opacity-100 px-4 pt-3 pb-0" : "max-h-0 opacity-0 px-4 py-0",
                 )}
               >
-                <div
-                  data-testid="todo-list-inline-scroll"
-                  className="space-y-2 overflow-y-auto max-h-[8.75rem]"
-                >
+                <div data-testid="todo-list-inline-scroll" className="space-y-2 overflow-y-auto max-h-[8.75rem]">
                   {todos.map((todo, index) => (
                     <div
                       key={todo.id}
@@ -255,13 +252,10 @@ function InlineTodoList({
                 aria-hidden={queueCollapsed}
                 className={cn(
                   "overflow-hidden transition-[max-height,opacity,padding] duration-200 ease-in-out",
-                  !queueCollapsed ? "max-h-[10rem] opacity-100 px-4 py-3" : "max-h-0 opacity-0 px-4 py-0",
+                  !queueCollapsed ? "max-h-[10rem] opacity-100 px-4 pt-3 pb-0" : "max-h-0 opacity-0 px-4 py-0",
                 )}
               >
-                <div
-                  className="space-y-1.5 overflow-y-auto max-h-[8.5rem]"
-                  data-testid="todo-list-inline-queue-body"
-                >
+                <div className="space-y-1.5 overflow-y-auto max-h-[8.5rem]" data-testid="todo-list-inline-queue-body">
                   {queue.map((msg, index) => (
                     <div
                       key={msg.id}

--- a/packages/app/src/components/chat/ToolCallCard.tsx
+++ b/packages/app/src/components/chat/ToolCallCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ChevronRight,
+  Terminal,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ToolCall } from "@/stores/session";
@@ -121,6 +122,26 @@ export const ToolCallCard = React.memo(function ToolCallCard({ toolCall, onOpenD
     if (toolCall.status === "failed") return "✕";
     return "●";
   })();
+
+  const renderExpandableHeaderSlot = (icon: React.ReactNode, testId?: string) => (
+    <span className="relative h-[22px] w-[22px] shrink-0" aria-hidden="true">
+      <span
+        data-testid={testId}
+        className="absolute inset-0 flex items-center justify-center group-hover:opacity-0"
+      >
+        {icon}
+      </span>
+      <span className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100">
+        <ChevronRight
+          size={13}
+          className={cn(
+            "text-[#64748b] transition-transform duration-200 dark:text-muted-foreground",
+            expanded && "rotate-90",
+          )}
+        />
+      </span>
+    </span>
+  );
 
   const getCompactTitle = () => {
     if (compactToolName.includes("grep")) return t("chat.toolCall.search.grep", "Grep");
@@ -269,17 +290,13 @@ export const ToolCallCard = React.memo(function ToolCallCard({ toolCall, onOpenD
         <button
           type="button"
           onClick={() => setExpanded((value) => !value)}
-          className="flex w-full items-center gap-[10px] px-[14px] py-[10px] text-left transition-colors hover:bg-[#f4f7fa] dark:hover:bg-muted/30"
+          className="group flex w-full items-center gap-[10px] px-[14px] py-[10px] text-left transition-colors hover:bg-[#f4f7fa] dark:hover:bg-muted/30"
           aria-expanded={expanded}
           aria-label={`${commandDescription} ${summary || commandText}`.trim()}
         >
-          <ChevronRight
-            size={13}
-            className={cn(
-              "shrink-0 text-[#64748b] transition-transform duration-200 dark:text-muted-foreground",
-              expanded && "rotate-90",
-            )}
-          />
+          {renderExpandableHeaderSlot(
+            <Terminal size={13} className="text-[#64748b] dark:text-muted-foreground" />,
+          )}
           <span className="text-[13px] font-semibold text-[#1f2933] shrink-0 dark:text-foreground">{commandDescription}</span>
           {commandStatusText ? (
             <span className="text-[11px] text-[#64748b] dark:text-muted-foreground">
@@ -295,11 +312,21 @@ export const ToolCallCard = React.memo(function ToolCallCard({ toolCall, onOpenD
         {expanded ? (
           <div
             data-testid="tool-card-bash-output"
-            className="max-h-[220px] overflow-auto border-t border-[#eef2f5] bg-white/80 px-[14px] py-3 dark:border-border/60 dark:bg-background/40"
+            className="max-h-[280px] overflow-auto border-t border-[#eef2f5] bg-white px-[16px] py-[14px] dark:border-border/60 dark:bg-[#101318]"
           >
-            <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-5 text-foreground/85">
-              {commandOutput || t("chat.toolCall.command.noOutput", "No output")}
-            </pre>
+            <div className="space-y-4 font-mono">
+              <div>
+                <div className="flex items-start gap-2 text-[12px] leading-6 text-[#1f2937] dark:text-[#f3f4f6]">
+                  <span className="shrink-0 text-[#64748b] dark:text-[#94a3b8]">$</span>
+                  <pre className="min-w-0 whitespace-pre-wrap break-words">{commandText}</pre>
+                </div>
+              </div>
+              <div>
+                <pre className="whitespace-pre-wrap break-words text-[12px] leading-6 text-[#475569] dark:text-[#cbd5e1]">
+                  {commandOutput || t("chat.toolCall.command.noOutput", "No output")}
+                </pre>
+              </div>
+            </div>
           </div>
         ) : null}
       </div>
@@ -340,23 +367,18 @@ export const ToolCallCard = React.memo(function ToolCallCard({ toolCall, onOpenD
       <Collapsible open={expanded} onOpenChange={setExpanded}>
         <div className="overflow-hidden rounded-[16px] border border-[#e7edf4] bg-[#fbfcfe] transition-all duration-200 dark:border-border dark:bg-card">
           <CollapsibleTrigger asChild>
-            <button className="w-full flex items-center gap-[10px] px-[12px] py-[10px] text-left transition-colors hover:bg-[#f4f7fa] dark:hover:bg-muted/30">
-              <ChevronRight
-                size={13}
-                className={cn(
-                  "shrink-0 text-[#64748b] transition-transform duration-200 dark:text-muted-foreground",
-                  expanded && "rotate-90",
-                )}
-              />
-              <span
-                data-testid="tool-fallback-icon"
-                className="relative h-[22px] w-[22px] shrink-0 rounded-[8px] border border-[#e2e8f0] bg-[#f8fafc] dark:border-border dark:bg-muted/20"
-                aria-hidden="true"
-              >
-                <span className="absolute left-[4px] top-[5px] h-[5px] w-[5px] rounded-full bg-[#475569] dark:bg-slate-300" />
-                <span className="absolute left-[12px] top-[5px] h-[4px] w-[4px] rounded-full bg-[#94a3b8] dark:bg-slate-500" />
-                <span className="absolute left-[8px] top-[12px] h-[6px] w-[6px] rounded-full bg-[#cbd5e1] dark:bg-slate-600" />
-              </span>
+            <button className="group w-full flex items-center gap-[10px] px-[12px] py-[10px] text-left transition-colors hover:bg-[#f4f7fa] dark:hover:bg-muted/30">
+              {renderExpandableHeaderSlot(
+                <span
+                  className="relative h-[22px] w-[22px] shrink-0 rounded-[8px] border border-[#e2e8f0] bg-[#f8fafc] dark:border-border dark:bg-muted/20"
+                  aria-hidden="true"
+                >
+                  <span className="absolute left-[4px] top-[5px] h-[5px] w-[5px] rounded-full bg-[#475569] dark:bg-slate-300" />
+                  <span className="absolute left-[12px] top-[5px] h-[4px] w-[4px] rounded-full bg-[#94a3b8] dark:bg-slate-500" />
+                  <span className="absolute left-[8px] top-[12px] h-[6px] w-[6px] rounded-full bg-[#cbd5e1] dark:bg-slate-600" />
+                </span>,
+                "tool-fallback-icon",
+              )}
               <span className="min-w-0 flex-1 text-[13px] font-medium text-[#1f2933] dark:text-foreground">
                 {formatToolName((key, fallback, options) => t(key, { defaultValue: fallback, ...options }), toolCall.name)}
               </span>

--- a/packages/app/src/components/chat/__tests__/ChatPanel-submission.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ChatPanel-submission.test.tsx
@@ -106,7 +106,12 @@ vi.mock('@/stores/suggestions', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback ?? _key,
+    t: (key: string, fallback?: string, options?: Record<string, unknown>) => {
+      const template = fallback ?? key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_, token: string) =>
+        String(options?.[token] ?? `{{${token}}}`),
+      );
+    },
   }),
 }));
 
@@ -225,6 +230,7 @@ describe('ChatPanel submission flow', () => {
     mockSessionState.activeSessionId = 'sess-1';
     mockSessionState.error = null;
     mockSessionState.isConnected = true;
+    mockSessionState.messageQueue = [];
     mockSessionState.sessionError = null;
     mockSessionState.draftInput = '';
     mockSessionState.pendingPermissions = [];
@@ -388,6 +394,52 @@ describe('ChatPanel submission flow', () => {
 
       expect(screen.queryByTestId('todo-list-inline')).toBeNull();
       expect(screen.getByTestId('pending-permission-inline')).toBeTruthy();
+    });
+
+    it('renders a unified dock when todos and message queue are both present', async () => {
+      mockSessionState.todos = [
+        { id: 'todo-1', content: 'Inspect parser config', status: 'in_progress', priority: 'high' },
+      ];
+      mockSessionState.messageQueue = [
+        { id: 'queued-1', content: 'run follow-up check', timestamp: new Date() },
+      ];
+
+      const { ChatPanel } = await import('../ChatPanel');
+      render(React.createElement(ChatPanel));
+
+      expect(screen.getByTestId('todo-list-inline')).toBeTruthy();
+      expect(screen.getByTestId('todo-list-inline-queue').textContent).toContain('1 messages queued');
+      expect(screen.getByText('Inspect parser config')).toBeTruthy();
+    });
+
+    it('renders the unified dock in queue-only mode when there are no todos', async () => {
+      mockSessionState.messageQueue = [
+        { id: 'queued-1', content: 'run follow-up check', timestamp: new Date() },
+      ];
+
+      const { ChatPanel } = await import('../ChatPanel');
+      render(React.createElement(ChatPanel));
+
+      expect(screen.getByTestId('todo-list-inline')).toBeTruthy();
+      expect(screen.getByTestId('todo-list-inline-queue').textContent).toContain('1 messages queued');
+      expect(screen.getByText('run follow-up check')).toBeTruthy();
+    });
+
+    it('hides the unified dock when approval is occupying the dock, even if queue exists', async () => {
+      mockSessionState.todos = [
+        { id: 'todo-1', content: 'Inspect parser config', status: 'in_progress', priority: 'high' },
+      ];
+      mockSessionState.messageQueue = [
+        { id: 'queued-1', content: 'run follow-up check', timestamp: new Date() },
+      ];
+      mockSessionState.pendingPermissions = [{ permission: { id: 'perm-1' } }];
+
+      const { ChatPanel } = await import('../ChatPanel');
+      render(React.createElement(ChatPanel));
+
+      expect(screen.queryByTestId('todo-list-inline')).toBeNull();
+      expect(screen.getByTestId('pending-permission-inline')).toBeTruthy();
+      expect(screen.queryByText('1 messages queued')).toBeNull();
     });
   });
 

--- a/packages/app/src/components/chat/__tests__/TodoList.test.tsx
+++ b/packages/app/src/components/chat/__tests__/TodoList.test.tsx
@@ -34,6 +34,9 @@ describe("TodoList", () => {
     render(
       <TodoList
         variant="inline"
+        queue={[
+          { id: "q-1", content: "Run follow-up checks", timestamp: new Date() },
+        ]}
         todos={[
           { id: "1", content: "Inspect parser config", status: "completed", priority: "high" } as never,
           { id: "2", content: "Update role load UI", status: "in_progress", priority: "medium" } as never,
@@ -44,6 +47,8 @@ describe("TodoList", () => {
 
     expect(screen.getByTestId("todo-list-inline")).toBeTruthy();
     expect(screen.getByText("3 tasks, 1 completed")).toBeTruthy();
+    expect(screen.getByTestId("todo-list-inline-queue").textContent).toContain("1 messages queued");
+    expect(screen.getByText("Run follow-up checks")).toBeTruthy();
     expect(screen.getByText("Update role load UI")).toBeTruthy();
     expect(screen.getByTestId("todo-list-inline-scroll").className).toContain("max-h-[8.75rem]");
     expect(screen.getByTestId("todo-list-inline-scroll").className).toContain("overflow-y-auto");
@@ -54,6 +59,9 @@ describe("TodoList", () => {
     render(
       <TodoList
         variant="inline"
+        queue={[
+          { id: "q-1", content: "Run follow-up checks", timestamp: new Date() },
+        ]}
         todos={[
           { id: "1", content: "Inspect parser config", status: "completed", priority: "high" } as never,
           { id: "2", content: "Update role load UI", status: "in_progress", priority: "medium" } as never,
@@ -64,9 +72,11 @@ describe("TodoList", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Collapse todo panel" }));
 
-    expect(screen.queryByText("Inspect parser config")).toBeNull();
+    expect(screen.getByTestId("todo-list-inline-scroll-shell").getAttribute("aria-hidden")).toBe("true");
     expect(screen.getByText("In progress: Update role load UI")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Expand todo panel" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Collapse queued messages" })).toBeTruthy();
+    expect(screen.getByText("Run follow-up checks")).toBeTruthy();
   });
 
   it("starts collapsed when all todos are completed", () => {
@@ -80,9 +90,11 @@ describe("TodoList", () => {
       />,
     );
 
-    expect(screen.getByText("All tasks completed")).toBeTruthy();
+    expect(screen.getByTestId("todo-list-inline").className).toContain("-mb-1");
+    expect(screen.getByTestId("todo-list-inline").firstElementChild?.className).toContain("rounded-b-none");
+    expect(screen.queryByText("All tasks completed")).toBeNull();
     expect(screen.getByRole("button", { name: "Expand todo panel" })).toBeTruthy();
-    expect(screen.queryByText("Inspect parser config")).toBeNull();
+    expect(screen.getByTestId("todo-list-inline-scroll-shell").getAttribute("aria-hidden")).toBe("true");
   });
 
   it("auto-expands when todos update while collapsed", () => {
@@ -108,5 +120,71 @@ describe("TodoList", () => {
 
     expect(screen.getByRole("button", { name: "Collapse todo panel" })).toBeTruthy();
     expect(screen.getByText("Verify markdown rendering")).toBeTruthy();
+  });
+
+  it("lets queue collapse independently while keeping both headers visible", () => {
+    render(
+      <TodoList
+        variant="inline"
+        queue={[
+          { id: "q-1", content: "Run follow-up checks", timestamp: new Date() },
+        ]}
+        todos={[
+          { id: "1", content: "Update role load UI", status: "in_progress", priority: "medium" } as never,
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse queued messages" }));
+
+    expect(screen.getByRole("button", { name: "Collapse todo panel" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Expand queued messages" })).toBeTruthy();
+    expect(screen.getByTestId("todo-list-inline-queue-shell").getAttribute("aria-hidden")).toBe("true");
+    expect(screen.getByText("Update role load UI")).toBeTruthy();
+  });
+
+  it("keeps both headers visible when both sections are collapsed", () => {
+    render(
+      <TodoList
+        variant="inline"
+        queue={[
+          { id: "q-1", content: "Run follow-up checks", timestamp: new Date() },
+        ]}
+        todos={[
+          { id: "1", content: "Update role load UI", status: "in_progress", priority: "medium" } as never,
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse todo panel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Collapse queued messages" }));
+
+    expect(screen.getByTestId("todo-list-inline").className).toContain("-mb-1");
+    expect(screen.getByTestId("todo-list-inline").firstElementChild?.className).toContain("rounded-b-none");
+    expect(screen.getByRole("button", { name: "Expand todo panel" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Expand queued messages" })).toBeTruthy();
+    expect(screen.getByText("1 tasks, 0 completed")).toBeTruthy();
+    expect(screen.getByTestId("todo-list-inline-queue").textContent).toContain("1 messages queued");
+    expect(screen.queryByText("In progress: Update role load UI")).toBeNull();
+    expect(screen.getByTestId("todo-list-inline-scroll-shell").getAttribute("aria-hidden")).toBe("true");
+    expect(screen.getByTestId("todo-list-inline-queue-shell").getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("renders queue-only mode when no todos exist", () => {
+    render(
+      <TodoList
+        variant="inline"
+        queue={[
+          { id: "q-1", content: "Run follow-up checks", timestamp: new Date() },
+          { id: "q-2", content: "Summarize findings", timestamp: new Date() },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("todo-list-inline")).toBeTruthy();
+    expect(screen.queryByText("All tasks completed")).toBeNull();
+    expect(screen.getByTestId("todo-list-inline-queue").textContent).toContain("2 messages queued");
+    expect(screen.getByText("Run follow-up checks")).toBeTruthy();
+    expect(screen.getByText("Summarize findings")).toBeTruthy();
   });
 });

--- a/packages/app/src/components/chat/__tests__/ToolCallVisuals.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ToolCallVisuals.test.tsx
@@ -151,7 +151,9 @@ describe("Tool call visual redesign", () => {
 
     const output = screen.getByTestId("tool-card-bash-output");
     expect(output.textContent).toContain("line 7");
-    expect(output.className).toContain("max-h-[220px]");
+    expect(output.textContent).toContain("$");
+    expect(output.textContent).toContain("cat long.log");
+    expect(output.className).toContain("max-h-[280px]");
     expect(output.className).toContain("overflow-auto");
   });
 
@@ -169,6 +171,26 @@ describe("Tool call visual redesign", () => {
 
     const output = screen.getByTestId("tool-card-bash-output");
     expect(output.textContent).toContain("No output");
+  });
+
+  it("shows the full bash command in the expanded terminal-style body", () => {
+    render(<ToolCallCard toolCall={makeToolCall({
+      id: "tool-long-bash",
+      name: "bash",
+      status: "completed",
+      arguments: {
+        command:
+          '/Users/haigang.ye/project/accounting-live/scripts/query_logs.sh --application billing-core --trace-id 7d9e7db1-62f8-4b6b-9c38-0d64f542c104 --query-string "service:billing level:error" --hours 24 --limit 20 --output-path /Users/haigang.ye/project/accounting-live/tmp/query_logs_usage.txt',
+      },
+      result: "Usage:\nquery_logs.sh --application <app|suffix>",
+    })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Execute command/ }));
+
+    const output = screen.getByTestId("tool-card-bash-output");
+    expect(output.textContent).toContain("/Users/haigang.ye/project/accounting-live/scripts/query_logs.sh");
+    expect(output.textContent).toContain("--query-string");
+    expect(output.textContent).toContain("Usage:");
   });
 
   it("prefers an explicit command description before the command text", () => {

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -107,7 +107,9 @@
       "activeSummary": "In progress: {{task}}",
       "allCompleted": "All tasks completed",
       "collapseAria": "Collapse todo panel",
-      "expandAria": "Expand todo panel"
+      "expandAria": "Expand todo panel",
+      "queueCollapseAria": "Collapse queued messages",
+      "queueExpandAria": "Expand queued messages"
     },
     "toolCall": {
       "status": {
@@ -134,7 +136,9 @@
       },
       "command": {
         "defaultDescription": "Execute command",
-        "noOutput": "No output"
+        "noOutput": "No output",
+        "commandLabel": "Command",
+        "outputLabel": "Output"
       },
       "permission": {
         "bash": "Bash",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -108,7 +108,9 @@
       "activeSummary": "进行中：{{task}}",
       "allCompleted": "任务已全部完成",
       "collapseAria": "收起待办面板",
-      "expandAria": "展开待办面板"
+      "expandAria": "展开待办面板",
+      "queueCollapseAria": "收起排队消息",
+      "queueExpandAria": "展开排队消息"
     },
     "toolCall": {
       "status": {
@@ -135,7 +137,9 @@
       },
       "command": {
         "defaultDescription": "执行命令",
-        "noOutput": "无输出"
+        "noOutput": "无输出",
+        "commandLabel": "命令",
+        "outputLabel": "输出"
       },
       "permission": {
         "bash": "Bash",


### PR DESCRIPTION
## Summary
- refine the unified todo and message queue dock presentation and translucency
- improve the chat input area background layering so content is not prematurely faded or visible under the composer
- show full command context in expanded command tool calls and polish fallback/toolcall visuals

## Testing
- pnpm --filter @teamclaw/app exec vitest run src/components/chat/__tests__/TodoList.test.tsx src/components/chat/__tests__/ChatPanel-submission.test.tsx src/components/chat/__tests__/ChatInputArea-interactions.test.tsx src/components/chat/__tests__/ToolCallVisuals.test.tsx
- pnpm --filter @teamclaw/app typecheck