### PR TITLE
fix: reload custom file browser roots after tree init

### DIFF
--- a/packages/app/src/components/workspace/FileBrowser.tsx
+++ b/packages/app/src/components/workspace/FileBrowser.tsx
@@ -86,7 +86,9 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
     return findSubtree(fileTree, rootPath) ?? []
   }, [rootPaths, rootLabels, rootPath, fileTree])
 
-  // Ensure rootPath(s) and their ancestors are loaded into the global tree on mount
+  // Ensure custom rootPath(s) are present in the global tree before we try to
+  // render them as virtual roots. In practice the initial attempt can race the
+  // first root refresh, especially for deep team paths like teamclaw-team/knowledge.
   React.useEffect(() => {
     const expandWithAncestors = async (targetPath: string) => {
       const wp = useWorkspaceStore.getState().workspacePath
@@ -99,14 +101,19 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
         await useWorkspaceStore.getState().expandDirectory(current)
       }
     }
+
+    const needsLoad = (targetPath: string) => findSubtree(fileTree, targetPath) === undefined
+
     if (rootPaths && rootPaths.length > 0) {
       for (const p of rootPaths) {
-        expandWithAncestors(p)
+        if (needsLoad(p)) {
+          expandWithAncestors(p)
+        }
       }
-    } else if (rootPath) {
+    } else if (rootPath && needsLoad(rootPath)) {
       expandWithAncestors(rootPath)
     }
-  }, [rootPaths, rootPath])
+  }, [rootPaths, rootPath, fileTree])
 
   // Auto-refresh file tree when panel opens (default variant) or when mounted (panel variant)
   React.useEffect(() => {

--- a/packages/app/src/components/workspace/__tests__/FileBrowser.test.tsx
+++ b/packages/app/src/components/workspace/__tests__/FileBrowser.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type MockFileNode = {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+  children?: MockFileNode[];
+};
+
+let mockFileTree: MockFileNode[] = [];
+let latestNodesProp: MockFileNode[] | undefined;
+
+const mockExpandDirectory = vi.fn(async (path: string) => {
+  if (path === "/workspace/teamclaw-team") {
+    mockFileTree = mockFileTree.map((node) =>
+      node.path === path
+        ? {
+            ...node,
+            children: [
+              {
+                name: "knowledge",
+                path: "/workspace/teamclaw-team/knowledge",
+                type: "directory",
+              },
+            ],
+          }
+        : node,
+    );
+  }
+
+  if (path === "/workspace/teamclaw-team/knowledge") {
+    mockFileTree = mockFileTree.map((node) =>
+      node.path === "/workspace/teamclaw-team"
+        ? {
+            ...node,
+            children: node.children?.map((child) =>
+              child.path === path
+                ? {
+                    ...child,
+                    children: [
+                      {
+                        name: "guide.md",
+                        path: "/workspace/teamclaw-team/knowledge/guide.md",
+                        type: "file",
+                      },
+                    ],
+                  }
+                : child,
+            ),
+          }
+        : node,
+    );
+  }
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: Array<string | false | null | undefined>) =>
+    args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/hooks/useFileChangeListener", () => ({
+  useFileChangeListener: vi.fn(),
+}));
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollBar: () => null,
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("../FileTree", () => ({
+  FileTree: ({ nodes }: { nodes?: MockFileNode[] }) => {
+    latestNodesProp = nodes;
+    return <div data-testid="file-tree" />;
+  },
+}));
+
+vi.mock("@/stores/workspace", () => ({
+  useWorkspaceStore: Object.assign(
+    (selector: (state: Record<string, unknown>) => unknown) =>
+      selector({
+        workspacePath: "/workspace",
+        isPanelOpen: true,
+        fileTree: mockFileTree,
+        refreshFileTree: vi.fn().mockResolvedValue(undefined),
+        collapseAll: vi.fn(),
+        undo: vi.fn().mockResolvedValue(true),
+        undoStack: [],
+        expandDirectory: mockExpandDirectory,
+      }),
+    {
+      getState: () => ({
+        workspacePath: "/workspace",
+        expandDirectory: mockExpandDirectory,
+      }),
+      subscribe: vi.fn(() => vi.fn()),
+      setState: vi.fn(),
+    },
+  ),
+}));
+
+import { FileBrowser } from "../FileBrowser";
+
+describe("FileBrowser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFileTree = [];
+    latestNodesProp = undefined;
+  });
+
+  it("retries loading custom root ancestors after the global tree becomes available", async () => {
+    const rootPath = "/workspace/teamclaw-team/knowledge";
+    const rootPaths = [rootPath];
+    const { rerender } = render(
+      <FileBrowser variant="panel" rootPaths={rootPaths} />,
+    );
+
+    await waitFor(() => {
+      expect(mockExpandDirectory).toHaveBeenCalledWith("/workspace/teamclaw-team");
+      expect(mockExpandDirectory).toHaveBeenCalledWith(rootPath);
+    });
+
+    await act(async () => {
+      mockFileTree = [
+        {
+          name: "teamclaw-team",
+          path: "/workspace/teamclaw-team",
+          type: "directory",
+        },
+      ];
+      rerender(<FileBrowser variant="panel" rootPaths={rootPaths} />);
+    });
+
+    await waitFor(() => {
+      expect(mockExpandDirectory).toHaveBeenCalledTimes(4);
+    });
+
+    await act(async () => {
+      rerender(<FileBrowser variant="panel" rootPaths={rootPaths} />);
+    });
+
+    expect(latestNodesProp?.[0]?.children).toEqual([
+      {
+        name: "guide.md",
+        path: "/workspace/teamclaw-team/knowledge/guide.md",
+        type: "file",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Please link to the issue here if applicable -->
Fixes #(issue)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
