### PR TITLE
feat(secrets): migrate personal secrets off os keychain

### DIFF
--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -7,6 +7,7 @@ use super::opencode::OpenCodeState;
 
 /// Single keychain entry that stores all env vars as a JSON blob.
 pub(crate) const KEYRING_SERVICE: &str = concat!(env!("APP_SHORT_NAME"), ".env");
+const LEGACY_MIGRATION_MARKER_KEY: &str = "_localPersonalSecretsMigrationComplete";
 
 /// Disk-based fallback path for the env blob.
 /// Used when keychain is inaccessible (e.g. after an unsigned app update
@@ -109,9 +110,104 @@ fn read_personal_secret_blob(
     workspace_path: &str,
 ) -> Result<serde_json::Map<String, serde_json::Value>, String> {
     let paths = personal_secret_store_paths()?;
-    local_secret_store::read_or_migrate_secret_blob(&paths, || {
-        read_legacy_keychain_blob(workspace_path)
-    })
+    read_personal_secret_blob_from_paths(workspace_path, &paths)
+}
+
+pub(crate) fn read_personal_secret_blob_from_paths(
+    workspace_path: &str,
+    paths: &local_secret_store::SecretStorePaths,
+) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    read_personal_secret_blob_with_reader(workspace_path, paths, read_legacy_keychain_blob)
+}
+
+pub(crate) fn read_personal_secret_blob_for_startup_from_paths(
+    workspace_path: &str,
+    paths: &local_secret_store::SecretStorePaths,
+) -> Result<(serde_json::Map<String, serde_json::Value>, bool), String> {
+    read_personal_secret_blob_with_reader_for_startup(
+        workspace_path,
+        paths,
+        read_legacy_keychain_blob,
+    )
+}
+
+fn read_personal_secret_blob_with_reader<F>(
+    workspace_path: &str,
+    paths: &local_secret_store::SecretStorePaths,
+    legacy_reader: F,
+) -> Result<serde_json::Map<String, serde_json::Value>, String>
+where
+    F: Fn(&str) -> Result<Option<serde_json::Map<String, serde_json::Value>>, String>,
+{
+    read_personal_secret_blob_with_reader_for_startup(workspace_path, paths, legacy_reader)
+        .map(|(blob, _retry_needed)| blob)
+}
+
+fn read_personal_secret_blob_with_reader_for_startup<F>(
+    workspace_path: &str,
+    paths: &local_secret_store::SecretStorePaths,
+    legacy_reader: F,
+) -> Result<(serde_json::Map<String, serde_json::Value>, bool), String>
+where
+    F: Fn(&str) -> Result<Option<serde_json::Map<String, serde_json::Value>>, String>,
+{
+    if !paths.blob_path.exists() {
+        let blob = local_secret_store::read_or_migrate_secret_blob(paths, || {
+            legacy_reader(workspace_path)
+        })?;
+        if workspace_can_persist_legacy_migration_marker(workspace_path) {
+            mark_workspace_legacy_migration_complete_best_effort(workspace_path);
+        }
+        return Ok((blob, false));
+    }
+
+    let mut blob = local_secret_store::read_secret_blob(paths)?;
+    let mut top_up_succeeded = false;
+    let mut retry_needed = false;
+    let migration_pending = match workspace_legacy_migration_pending(workspace_path) {
+        Ok(pending) => pending,
+        Err(err) => {
+            eprintln!(
+                "[EnvVars] Legacy workspace top-up marker check failed for '{}': {}",
+                workspace_path, err
+            );
+            retry_needed = true;
+            false
+        }
+    };
+
+    if migration_pending {
+        match legacy_reader(workspace_path) {
+            Ok(Some(legacy_map)) => {
+                let mut changed = false;
+                for (key, value) in legacy_map {
+                    if let serde_json::map::Entry::Vacant(entry) = blob.entry(key) {
+                        entry.insert(value);
+                        changed = true;
+                    }
+                }
+                if changed {
+                    local_secret_store::write_secret_blob(paths, &blob)?;
+                }
+                top_up_succeeded = true;
+            }
+            Ok(None) => {
+                top_up_succeeded = true;
+            }
+            Err(err) => {
+                eprintln!(
+                    "[EnvVars] Legacy workspace top-up skipped for '{}': {}",
+                    workspace_path, err
+                );
+                retry_needed = true;
+            }
+        }
+        if top_up_succeeded {
+            mark_workspace_legacy_migration_complete_best_effort(workspace_path);
+        }
+    }
+
+    Ok((blob, retry_needed))
 }
 
 fn write_personal_secret_blob(
@@ -166,7 +262,8 @@ pub(crate) fn snapshot_env_blob_to_disk() {
 }
 
 /// Read old per-key keychain entries and consolidate into a map.
-/// Deletes old entries after reading.
+/// Legacy entries are intentionally retained so migration can be retried safely
+/// and additional workspaces can still top up the local encrypted store.
 fn migrate_legacy_keyring(workspace_path: &str) -> serde_json::Map<String, serde_json::Value> {
     let path = format!("{}/{}/teamclaw.json", workspace_path, super::TEAMCLAW_DIR);
     let json: serde_json::Value = match std::fs::read_to_string(&path)
@@ -194,8 +291,6 @@ fn migrate_legacy_keyring(workspace_path: &str) -> serde_json::Map<String, serde
             match e.get_password() {
                 Ok(value) => {
                     map.insert(key.to_string(), serde_json::Value::String(value));
-                    // Delete old entry
-                    let _ = e.delete_credential();
                 }
                 Err(e) => {
                     eprintln!(
@@ -207,6 +302,40 @@ fn migrate_legacy_keyring(workspace_path: &str) -> serde_json::Map<String, serde
         }
     }
     map
+}
+
+fn workspace_legacy_migration_pending(workspace_path: &str) -> Result<bool, String> {
+    let json = read_teamclaw_json(workspace_path)?;
+    Ok(!json
+        .get(LEGACY_MIGRATION_MARKER_KEY)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false))
+}
+
+fn mark_workspace_legacy_migration_complete(workspace_path: &str) -> Result<(), String> {
+    let mut json = read_teamclaw_json(workspace_path)?;
+    if let Some(obj) = json.as_object_mut() {
+        obj.insert(
+            LEGACY_MIGRATION_MARKER_KEY.to_string(),
+            serde_json::Value::Bool(true),
+        );
+        write_teamclaw_json(workspace_path, &json)?;
+    }
+    Ok(())
+}
+
+fn workspace_can_persist_legacy_migration_marker(workspace_path: &str) -> bool {
+    let path = get_teamclaw_json_path(workspace_path);
+    Path::new(&path).exists() && read_teamclaw_json(workspace_path).is_ok()
+}
+
+fn mark_workspace_legacy_migration_complete_best_effort(workspace_path: &str) {
+    if let Err(err) = mark_workspace_legacy_migration_complete(workspace_path) {
+        eprintln!(
+            "[EnvVars] Failed to persist legacy workspace migration marker for '{}': {}",
+            workspace_path, err
+        );
+    }
 }
 
 /// Context available to system env var default generators.
@@ -706,5 +835,183 @@ mod tests {
             reloaded.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
             Some("local-secret")
         );
+    }
+
+    #[test]
+    fn read_personal_secret_blob_merges_legacy_once_per_workspace() {
+        let _home_guard = home_lock().lock().unwrap();
+        let home_dir = tempdir().unwrap();
+        let workspace_a = tempdir().unwrap();
+        let workspace_b = tempdir().unwrap();
+        let _home = HomeGuard::set(home_dir.path());
+
+        let paths = SecretStorePaths::for_home_dir().unwrap();
+        let workspace_a_path = workspace_a.path().to_string_lossy().to_string();
+        let workspace_b_path = workspace_b.path().to_string_lossy().to_string();
+
+        let first = read_personal_secret_blob_with_reader(&workspace_a_path, &paths, |wp| {
+            let mut map = serde_json::Map::new();
+            if wp == workspace_a_path {
+                map.insert(
+                    "WORKSPACE_A_KEY".into(),
+                    serde_json::Value::String("a-secret".into()),
+                );
+            }
+            Ok(Some(map))
+        })
+        .unwrap();
+        assert_eq!(
+            first.get("WORKSPACE_A_KEY").and_then(|v| v.as_str()),
+            Some("a-secret")
+        );
+
+        let second = read_personal_secret_blob_with_reader(&workspace_b_path, &paths, |wp| {
+            let mut map = serde_json::Map::new();
+            if wp == workspace_b_path {
+                map.insert(
+                    "WORKSPACE_B_KEY".into(),
+                    serde_json::Value::String("b-secret".into()),
+                );
+            }
+            Ok(Some(map))
+        })
+        .unwrap();
+        assert_eq!(
+            second.get("WORKSPACE_A_KEY").and_then(|v| v.as_str()),
+            Some("a-secret")
+        );
+        assert_eq!(
+            second.get("WORKSPACE_B_KEY").and_then(|v| v.as_str()),
+            Some("b-secret")
+        );
+
+        let third = read_personal_secret_blob_with_reader(&workspace_b_path, &paths, |_wp| {
+            Err("legacy reader should not run after workspace migration".to_string())
+        })
+        .unwrap();
+        assert_eq!(third, second);
+    }
+
+    #[test]
+    fn existing_blob_survives_legacy_reader_error_without_marking_complete() {
+        let _home_guard = home_lock().lock().unwrap();
+        let home_dir = tempdir().unwrap();
+        let workspace_dir = tempdir().unwrap();
+        let _home = HomeGuard::set(home_dir.path());
+
+        let paths = SecretStorePaths::for_home_dir().unwrap();
+        let workspace_path = workspace_dir.path().to_string_lossy().to_string();
+
+        let mut blob = serde_json::Map::new();
+        blob.insert(
+            "OPENAI_API_KEY".into(),
+            serde_json::Value::String("local-secret".into()),
+        );
+        local_secret_store::write_secret_blob(&paths, &blob).unwrap();
+
+        let (first, retry_needed) =
+            read_personal_secret_blob_with_reader_for_startup(&workspace_path, &paths, |_wp| {
+                Err("simulated legacy reader failure".to_string())
+            })
+            .unwrap();
+        assert_eq!(
+            first.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
+            Some("local-secret")
+        );
+        assert!(retry_needed);
+
+        let second = read_personal_secret_blob_with_reader(&workspace_path, &paths, |_wp| {
+            Err("legacy reader failure remains non-fatal on later reads".to_string())
+        })
+        .unwrap();
+        assert_eq!(second, first);
+    }
+
+    #[test]
+    fn existing_blob_reads_even_if_teamclaw_json_is_invalid() {
+        let _home_guard = home_lock().lock().unwrap();
+        let home_dir = tempdir().unwrap();
+        let workspace_dir = tempdir().unwrap();
+        let _home = HomeGuard::set(home_dir.path());
+
+        let teamclaw_dir = workspace_dir.path().join(super::super::TEAMCLAW_DIR);
+        std::fs::create_dir_all(&teamclaw_dir).unwrap();
+        std::fs::write(teamclaw_dir.join(super::super::CONFIG_FILE_NAME), "{").unwrap();
+
+        let paths = SecretStorePaths::for_home_dir().unwrap();
+        let workspace_path = workspace_dir.path().to_string_lossy().to_string();
+
+        let mut blob = serde_json::Map::new();
+        blob.insert(
+            "OPENAI_API_KEY".into(),
+            serde_json::Value::String("local-secret".into()),
+        );
+        local_secret_store::write_secret_blob(&paths, &blob).unwrap();
+
+        let loaded = read_personal_secret_blob_with_reader(&workspace_path, &paths, |_wp| {
+            Err("legacy reader should not be required when local blob already exists".into())
+        })
+        .unwrap();
+
+        assert_eq!(
+            loaded.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
+            Some("local-secret")
+        );
+    }
+
+    #[test]
+    fn first_migration_succeeds_even_if_teamclaw_json_is_invalid() {
+        let _home_guard = home_lock().lock().unwrap();
+        let home_dir = tempdir().unwrap();
+        let workspace_dir = tempdir().unwrap();
+        let _home = HomeGuard::set(home_dir.path());
+
+        let teamclaw_dir = workspace_dir.path().join(super::super::TEAMCLAW_DIR);
+        std::fs::create_dir_all(&teamclaw_dir).unwrap();
+        std::fs::write(teamclaw_dir.join(super::super::CONFIG_FILE_NAME), "{").unwrap();
+
+        let workspace_path = workspace_dir.path().to_string_lossy().to_string();
+        let loaded = read_env_blob(&workspace_path).unwrap();
+        assert!(loaded.is_empty());
+
+        let paths = SecretStorePaths::for_home_dir().unwrap();
+        assert!(
+            paths.blob_path.exists(),
+            "expected encrypted blob to be created"
+        );
+    }
+
+    #[test]
+    fn startup_retry_is_requested_when_teamclaw_json_is_invalid() {
+        let _home_guard = home_lock().lock().unwrap();
+        let home_dir = tempdir().unwrap();
+        let workspace_dir = tempdir().unwrap();
+        let _home = HomeGuard::set(home_dir.path());
+
+        let teamclaw_dir = workspace_dir.path().join(super::super::TEAMCLAW_DIR);
+        std::fs::create_dir_all(&teamclaw_dir).unwrap();
+        std::fs::write(teamclaw_dir.join(super::super::CONFIG_FILE_NAME), "{").unwrap();
+
+        let paths = SecretStorePaths::for_home_dir().unwrap();
+        let workspace_path = workspace_dir.path().to_string_lossy().to_string();
+
+        let mut blob = serde_json::Map::new();
+        blob.insert(
+            "OPENAI_API_KEY".into(),
+            serde_json::Value::String("local-secret".into()),
+        );
+        local_secret_store::write_secret_blob(&paths, &blob).unwrap();
+
+        let (loaded, retry_needed) =
+            read_personal_secret_blob_with_reader_for_startup(&workspace_path, &paths, |_wp| {
+                Ok(None)
+            })
+            .unwrap();
+
+        assert_eq!(
+            loaded.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
+            Some("local-secret")
+        );
+        assert!(retry_needed);
     }
 }

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tauri::State;
 
+use super::local_secret_store;
 use super::opencode::OpenCodeState;
 
 /// Single keychain entry that stores all env vars as a JSON blob.
@@ -41,14 +42,13 @@ fn write_env_blob_to_disk(map: &serde_json::Map<String, serde_json::Value>) {
     }
 }
 
-/// Read the entire env var blob from keychain.
-/// Returns an empty map if the entry doesn't exist yet.
-/// On first call after migration: detects old per-key entries and consolidates them.
-/// May write to keychain on first call if legacy migration is needed.
-/// Falls back to a disk file when keychain is inaccessible (e.g. after app update).
-pub(crate) fn read_env_blob(
+fn personal_secret_store_paths() -> Result<local_secret_store::SecretStorePaths, String> {
+    local_secret_store::SecretStorePaths::for_home_dir()
+}
+
+fn read_legacy_keychain_blob(
     workspace_path: &str,
-) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+) -> Result<Option<serde_json::Map<String, serde_json::Value>>, String> {
     let entry = keyring::Entry::new(KEYRING_SERVICE, "teamclaw")
         .map_err(|e| format!("Failed to open keychain entry: {}", e))?;
 
@@ -62,56 +62,74 @@ pub(crate) fn read_env_blob(
                 serde_json::Value::Object(serde_json::Map::new())
             });
             match val {
-                serde_json::Value::Object(map) => Ok(map),
-                _ => Ok(serde_json::Map::new()),
+                serde_json::Value::Object(map) => Ok(Some(map)),
+                _ => Ok(Some(serde_json::Map::new())),
             }
         }
         Err(keyring::Error::NoEntry) => {
-            // First launch (or blob deleted): attempt migration from legacy per-key format.
             let migrated = migrate_legacy_keyring(workspace_path);
             if !migrated.is_empty() {
                 println!(
-                    "[EnvVars] Migrated {} legacy keychain entries to blob",
+                    "[EnvVars] Migrated {} legacy keychain entries to local encrypted store",
                     migrated.len()
                 );
-                write_env_blob(&migrated)?;
-                return Ok(migrated);
+                return Ok(Some(migrated));
             }
-            // Try disk fallback (handles post-update keychain loss)
             if let Some(disk_blob) = read_env_blob_from_disk() {
                 if !disk_blob.is_empty() {
                     println!(
-                        "[EnvVars] Restored {} entries from disk fallback",
+                        "[EnvVars] Restored {} entries from legacy disk fallback",
                         disk_blob.len()
                     );
-                    // Re-populate keychain so subsequent reads are fast
-                    let _ = write_env_blob_to_keychain(&disk_blob);
-                    return Ok(disk_blob);
+                    return Ok(Some(disk_blob));
                 }
             }
-            Ok(serde_json::Map::new())
+            Ok(None)
         }
         Err(e) => {
-            // Keychain error (e.g. access denied after app update) — try disk fallback
             eprintln!(
-                "[EnvVars] Keychain read failed: {}. Trying disk fallback...",
+                "[EnvVars] Legacy keychain read failed: {}. Trying disk fallback...",
                 e
             );
             if let Some(disk_blob) = read_env_blob_from_disk() {
                 if !disk_blob.is_empty() {
                     println!(
-                        "[EnvVars] Restored {} entries from disk fallback",
+                        "[EnvVars] Restored {} entries from legacy disk fallback",
                         disk_blob.len()
                     );
-                    return Ok(disk_blob);
+                    return Ok(Some(disk_blob));
                 }
             }
-            Err(format!("Failed to read keychain blob: {}", e))
+            Err(format!("Failed to read legacy keychain blob: {}", e))
         }
     }
 }
 
-/// Write the env blob to keychain only (no disk fallback).
+fn read_personal_secret_blob(
+    workspace_path: &str,
+) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    let paths = personal_secret_store_paths()?;
+    local_secret_store::read_or_migrate_secret_blob(&paths, || read_legacy_keychain_blob(workspace_path))
+}
+
+fn write_personal_secret_blob(
+    map: &serde_json::Map<String, serde_json::Value>,
+) -> Result<(), String> {
+    let paths = personal_secret_store_paths()?;
+    local_secret_store::write_secret_blob(&paths, map)
+}
+
+/// Read the entire env var blob from the local encrypted personal secret store.
+/// On first read, migrate legacy keychain or disk-snapshot data if present.
+pub(crate) fn read_env_blob(
+    workspace_path: &str,
+) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    read_personal_secret_blob(workspace_path)
+}
+
+/// Write the env blob to the legacy keychain blob path.
+/// Retained only for compatibility helpers such as updater snapshots.
+#[allow(dead_code)]
 fn write_env_blob_to_keychain(
     map: &serde_json::Map<String, serde_json::Value>,
 ) -> Result<(), String> {
@@ -124,23 +142,11 @@ fn write_env_blob_to_keychain(
         .map_err(|e| format!("Failed to write keychain blob: {}", e))
 }
 
-/// Write the entire env var blob to keychain and disk fallback.
+/// Write the entire env var blob to the local encrypted personal secret store.
 pub(crate) fn write_env_blob(
     map: &serde_json::Map<String, serde_json::Value>,
 ) -> Result<(), String> {
-    // Always write disk fallback (survives app updates)
-    write_env_blob_to_disk(map);
-    // Write to keychain (may fail after update, but that's OK — disk has it)
-    match write_env_blob_to_keychain(map) {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            eprintln!(
-                "[EnvVars] Keychain write failed (disk fallback saved): {}",
-                e
-            );
-            Ok(())
-        }
-    }
+    write_personal_secret_blob(map)
 }
 
 /// Snapshot the current keychain env blob to the disk fallback file.
@@ -330,7 +336,7 @@ fn get_workspace_path(state: &State<'_, OpenCodeState>) -> Result<String, String
 
 // ─── Tauri Commands ─────────────────────────────────────────────────────
 
-/// Store (or update) an environment variable in the keychain blob and update the index in teamclaw.json.
+/// Store (or update) an environment variable in the local encrypted store and update the index in teamclaw.json.
 #[tauri::command]
 pub async fn env_var_set(
     state: State<'_, OpenCodeState>,
@@ -370,7 +376,7 @@ pub async fn env_var_set(
     write_teamclaw_json(&workspace_path, &json)
 }
 
-/// Retrieve an environment variable value from the keychain blob.
+/// Retrieve an environment variable value from the local encrypted store.
 #[tauri::command]
 pub async fn env_var_get(state: State<'_, OpenCodeState>, key: String) -> Result<String, String> {
     let workspace_path = get_workspace_path(&state)?;
@@ -387,7 +393,7 @@ pub async fn env_var_get(state: State<'_, OpenCodeState>, key: String) -> Result
         .ok_or_else(|| format!("Key '{}' not found", key))
 }
 
-/// Delete an environment variable from both the keychain blob and teamclaw.json index.
+/// Delete an environment variable from both the local encrypted store and teamclaw.json index.
 #[tauri::command]
 pub async fn env_var_delete(state: State<'_, OpenCodeState>, key: String) -> Result<(), String> {
     let workspace_path = get_workspace_path(&state)?;
@@ -439,7 +445,7 @@ pub async fn env_var_list(state: State<'_, OpenCodeState>) -> Result<Vec<EnvVarE
 ///
 /// Resolution order for each `${KEY}`:
 ///   1. Shared secrets (team KMS, in-memory HashMap)
-///   2. Local keyring blob (per-user OS keyring, single blob entry)
+///   2. Local encrypted personal secret blob
 ///   3. System environment variables (`std::env::var`)
 #[tauri::command]
 pub async fn env_var_resolve(
@@ -462,14 +468,14 @@ pub async fn env_var_resolve(
         })
         .collect();
 
-    // Read blob once upfront (one keychain access for all keys)
+    // Read blob once upfront.
     let blob = {
         let wp = workspace_path.clone();
         tokio::task::spawn_blocking(move || read_env_blob(&wp))
             .await
             .map_err(|e| e.to_string())?
             .unwrap_or_else(|e| {
-                eprintln!("[EnvVars] env_var_resolve: failed to read keychain blob, proceeding without local secrets: {}", e);
+                eprintln!("[EnvVars] env_var_resolve: failed to read personal secret blob, proceeding without local secrets: {}", e);
                 serde_json::Map::new()
             })
     };
@@ -485,7 +491,7 @@ pub async fn env_var_resolve(
             continue;
         }
 
-        // 2. Check local keyring blob
+        // 2. Check local encrypted personal secret blob
         if let Some(value) = blob.get(&key).and_then(|v| v.as_str()) {
             result = result.replace(&full_match, value);
             continue;
@@ -512,10 +518,10 @@ pub async fn env_var_resolve(
     Ok(result)
 }
 
-/// Ensure all system env vars exist in keychain blob and in the teamclaw.json index.
+/// Ensure all system env vars exist in the local encrypted store and in the teamclaw.json index.
 /// If a key is missing from the blob, its default value is generated and written.
 /// If a key already has a value (user customized), it is left unchanged.
-/// This must be called on a blocking thread (keychain I/O).
+/// This must be called on a blocking thread (disk I/O).
 pub(crate) fn ensure_system_env_vars(workspace_path: &str, device_id: &str) -> Result<(), String> {
     let ctx = SystemEnvVarContext {
         device_id: device_id.to_string(),
@@ -622,4 +628,84 @@ pub(crate) fn ensure_system_env_vars(workspace_path: &str, device_id: &str) -> R
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::local_secret_store::SecretStorePaths;
+    use std::sync::{Mutex, OnceLock};
+    use tempfile::tempdir;
+
+    fn home_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct HomeGuard {
+        original_home: Option<std::ffi::OsString>,
+    }
+
+    impl HomeGuard {
+        fn set(path: &Path) -> Self {
+            let original_home = std::env::var_os("HOME");
+            std::env::set_var("HOME", path);
+            Self { original_home }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.original_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn read_env_blob_migrates_legacy_disk_snapshot_into_local_encrypted_store() {
+        let _home_guard = home_lock().lock().unwrap();
+        let home_dir = tempdir().unwrap();
+        let workspace_dir = tempdir().unwrap();
+        let _home = HomeGuard::set(home_dir.path());
+
+        let legacy_blob_dir = home_dir.path().join(concat!(".", env!("APP_SHORT_NAME")));
+        std::fs::create_dir_all(&legacy_blob_dir).unwrap();
+
+        let mut legacy_blob = serde_json::Map::new();
+        legacy_blob.insert(
+            "OPENAI_API_KEY".into(),
+            serde_json::Value::String("legacy-secret".into()),
+        );
+        std::fs::write(
+            legacy_blob_dir.join("env-blob.json"),
+            serde_json::to_vec(&legacy_blob).unwrap(),
+        )
+        .unwrap();
+
+        let workspace_path = workspace_dir.path().to_string_lossy().to_string();
+        let loaded = read_env_blob(&workspace_path).unwrap();
+        assert_eq!(loaded, legacy_blob);
+
+        let paths = SecretStorePaths::for_home_dir().unwrap();
+        assert!(paths.blob_path.exists(), "expected encrypted blob to be created");
+        let meta = crate::commands::local_secret_store::read_meta(&paths).unwrap();
+        assert!(meta.migrated_from_keychain);
+
+        std::fs::remove_file(legacy_blob_dir.join("env-blob.json")).unwrap();
+
+        let mut updated_blob = loaded.clone();
+        updated_blob.insert(
+            "OPENAI_API_KEY".into(),
+            serde_json::Value::String("local-secret".into()),
+        );
+        write_env_blob(&updated_blob).unwrap();
+
+        let reloaded = read_env_blob(&workspace_path).unwrap();
+        assert_eq!(
+            reloaded.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
+            Some("local-secret")
+        );
+    }
 }

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -46,7 +46,7 @@ fn personal_secret_store_paths() -> Result<local_secret_store::SecretStorePaths,
     local_secret_store::SecretStorePaths::for_home_dir()
 }
 
-fn read_legacy_keychain_blob(
+pub(crate) fn read_legacy_keychain_blob(
     workspace_path: &str,
 ) -> Result<Option<serde_json::Map<String, serde_json::Value>>, String> {
     let entry = keyring::Entry::new(KEYRING_SERVICE, "teamclaw")

--- a/src-tauri/src/commands/env_vars.rs
+++ b/src-tauri/src/commands/env_vars.rs
@@ -109,7 +109,9 @@ fn read_personal_secret_blob(
     workspace_path: &str,
 ) -> Result<serde_json::Map<String, serde_json::Value>, String> {
     let paths = personal_secret_store_paths()?;
-    local_secret_store::read_or_migrate_secret_blob(&paths, || read_legacy_keychain_blob(workspace_path))
+    local_secret_store::read_or_migrate_secret_blob(&paths, || {
+        read_legacy_keychain_blob(workspace_path)
+    })
 }
 
 fn write_personal_secret_blob(
@@ -127,21 +129,6 @@ pub(crate) fn read_env_blob(
     read_personal_secret_blob(workspace_path)
 }
 
-/// Write the env blob to the legacy keychain blob path.
-/// Retained only for compatibility helpers such as updater snapshots.
-#[allow(dead_code)]
-fn write_env_blob_to_keychain(
-    map: &serde_json::Map<String, serde_json::Value>,
-) -> Result<(), String> {
-    let json_str =
-        serde_json::to_string(map).map_err(|e| format!("Failed to serialize env blob: {}", e))?;
-    let entry = keyring::Entry::new(KEYRING_SERVICE, "teamclaw")
-        .map_err(|e| format!("Failed to open keychain entry: {}", e))?;
-    entry
-        .set_password(&json_str)
-        .map_err(|e| format!("Failed to write keychain blob: {}", e))
-}
-
 /// Write the entire env var blob to the local encrypted personal secret store.
 pub(crate) fn write_env_blob(
     map: &serde_json::Map<String, serde_json::Value>,
@@ -149,10 +136,18 @@ pub(crate) fn write_env_blob(
     write_personal_secret_blob(map)
 }
 
-/// Snapshot the current keychain env blob to the disk fallback file.
-/// Called by the updater before replacing the app bundle so the new binary
-/// (which may have a different code signature) can recover secrets.
+/// Snapshot legacy keychain data to the disk fallback file only when migration
+/// has not yet produced a local encrypted blob. Called by the updater before
+/// replacing the app bundle so pre-migration installs can still recover their
+/// personal secrets after a signature-changing update.
 pub(crate) fn snapshot_env_blob_to_disk() {
+    let Ok(paths) = personal_secret_store_paths() else {
+        return;
+    };
+    if paths.blob_path.exists() {
+        return;
+    }
+
     let entry = match keyring::Entry::new(KEYRING_SERVICE, "teamclaw") {
         Ok(e) => e,
         Err(_) => return,
@@ -298,7 +293,10 @@ pub(crate) fn read_teamclaw_json(workspace_path: &str) -> Result<serde_json::Val
 }
 
 /// Write the full teamclaw.json back (preserving all other fields).
-pub(crate) fn write_teamclaw_json(workspace_path: &str, json: &serde_json::Value) -> Result<(), String> {
+pub(crate) fn write_teamclaw_json(
+    workspace_path: &str,
+    json: &serde_json::Value,
+) -> Result<(), String> {
     let teamclaw_dir = format!("{}/{}", workspace_path, super::TEAMCLAW_DIR);
     let _ = std::fs::create_dir_all(&teamclaw_dir);
     let path = get_teamclaw_json_path(workspace_path);
@@ -558,10 +556,7 @@ pub(crate) fn ensure_system_env_vars(workspace_path: &str, device_id: &str) -> R
                                     def.key
                                 );
                             }
-                            blob.insert(
-                                def.key.to_string(),
-                                serde_json::Value::String(new_value),
-                            );
+                            blob.insert(def.key.to_string(), serde_json::Value::String(new_value));
                             blob_changed = true;
                         }
                     }
@@ -572,10 +567,7 @@ pub(crate) fn ensure_system_env_vars(workspace_path: &str, device_id: &str) -> R
                     if !key_present_in_blob {
                         if let Some(default) = (def.default_fn)(&ctx) {
                             println!("[EnvVars] Seeding system var {} with default", def.key);
-                            blob.insert(
-                                def.key.to_string(),
-                                serde_json::Value::String(default),
-                            );
+                            blob.insert(def.key.to_string(), serde_json::Value::String(default));
                             blob_changed = true;
                         }
                     }
@@ -603,7 +595,11 @@ pub(crate) fn ensure_system_env_vars(workspace_path: &str, device_id: &str) -> R
             continue;
         }
 
-        let target_category = if def.shared_default { "system-shared" } else { "system" };
+        let target_category = if def.shared_default {
+            "system-shared"
+        } else {
+            "system"
+        };
         if let Some(existing) = entries.iter_mut().find(|e| e.key == def.key) {
             if existing.category.as_deref() != Some(target_category) {
                 existing.category = Some(target_category.to_string());
@@ -689,7 +685,10 @@ mod tests {
         assert_eq!(loaded, legacy_blob);
 
         let paths = SecretStorePaths::for_home_dir().unwrap();
-        assert!(paths.blob_path.exists(), "expected encrypted blob to be created");
+        assert!(
+            paths.blob_path.exists(),
+            "expected encrypted blob to be created"
+        );
         let meta = crate::commands::local_secret_store::read_meta(&paths).unwrap();
         assert!(meta.migrated_from_keychain);
 

--- a/src-tauri/src/commands/local_secret_store.rs
+++ b/src-tauri/src/commands/local_secret_store.rs
@@ -11,17 +11,17 @@ pub(crate) const LOCAL_SECRETS_VERSION: u32 = 1;
 
 #[derive(Debug, Clone)]
 pub(crate) struct SecretStorePaths {
-    pub base_dir: PathBuf,
-    pub master_key_path: PathBuf,
-    pub blob_path: PathBuf,
-    pub meta_path: PathBuf,
+    base_dir: PathBuf,
+    master_key_path: PathBuf,
+    blob_path: PathBuf,
+    meta_path: PathBuf,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct SecretStoreMeta {
-    pub version: u32,
-    pub algorithm: String,
-    pub migrated_from_keychain: bool,
+    version: u32,
+    algorithm: String,
+    migrated_from_keychain: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,7 +31,7 @@ struct EncryptedBlobFile {
 }
 
 impl SecretStorePaths {
-    pub fn for_home_dir() -> Result<Self, String> {
+    pub(crate) fn for_home_dir() -> Result<Self, String> {
         let home = dirs::home_dir().ok_or_else(|| "Home directory not found".to_string())?;
         Ok(Self::for_base_dir(
             home.join(concat!(".", env!("APP_SHORT_NAME")))
@@ -39,7 +39,7 @@ impl SecretStorePaths {
         ))
     }
 
-    pub fn for_base_dir(base_dir: PathBuf) -> Self {
+    pub(crate) fn for_base_dir(base_dir: PathBuf) -> Self {
         Self {
             master_key_path: base_dir.join("master.key"),
             blob_path: base_dir.join("personal-secrets.json.enc"),

--- a/src-tauri/src/commands/local_secret_store.rs
+++ b/src-tauri/src/commands/local_secret_store.rs
@@ -5,7 +5,12 @@ use aes_gcm::{
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 pub(crate) const LOCAL_SECRETS_VERSION: u32 = 1;
 
@@ -54,21 +59,64 @@ fn ensure_base_dir(paths: &SecretStorePaths) -> Result<(), String> {
         .map_err(|e| format!("Failed to create secrets dir: {}", e))
 }
 
-fn load_or_create_master_key(paths: &SecretStorePaths) -> Result<[u8; 32], String> {
-    ensure_base_dir(paths)?;
-    if paths.master_key_path.exists() {
-        let raw = std::fs::read(&paths.master_key_path)
-            .map_err(|e| format!("Failed to read master key: {}", e))?;
-        return raw
-            .try_into()
-            .map_err(|_| "Invalid master key length".to_string());
+fn set_owner_only_permissions(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        let mut perms = std::fs::metadata(path)
+            .map_err(|e| format!("Failed to inspect permissions for {}: {}", path.display(), e))?
+            .permissions();
+        perms.set_mode(0o600);
+        std::fs::set_permissions(path, perms)
+            .map_err(|e| format!("Failed to set permissions for {}: {}", path.display(), e))?;
     }
 
-    let mut key = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut key);
-    std::fs::write(&paths.master_key_path, key)
-        .map_err(|e| format!("Failed to write master key: {}", e))?;
-    Ok(key)
+    Ok(())
+}
+
+fn load_or_create_master_key(paths: &SecretStorePaths) -> Result<[u8; 32], String> {
+    ensure_base_dir(paths)?;
+    for _ in 0..50 {
+        let mut open_options = std::fs::OpenOptions::new();
+        open_options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            open_options.mode(0o600);
+        }
+
+        match open_options.open(&paths.master_key_path) {
+            Ok(mut file) => {
+                let mut key = [0u8; 32];
+                rand::thread_rng().fill_bytes(&mut key);
+                file.write_all(&key)
+                    .map_err(|e| format!("Failed to write master key: {}", e))?;
+                file.sync_all()
+                    .map_err(|e| format!("Failed to flush master key: {}", e))?;
+                set_owner_only_permissions(&paths.master_key_path)?;
+                return Ok(key);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                let raw = match std::fs::read(&paths.master_key_path) {
+                    Ok(raw) => raw,
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                        std::thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+                    Err(err) => return Err(format!("Failed to read master key: {}", err)),
+                };
+
+                match raw.try_into() {
+                    Ok(key) => return Ok(key),
+                    Err(_) => {
+                        std::thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+                }
+            }
+            Err(e) => return Err(format!("Failed to create master key: {}", e)),
+        }
+    }
+
+    Err("Failed to initialize master key after retries".to_string())
 }
 
 fn load_existing_master_key(paths: &SecretStorePaths) -> Result<[u8; 32], String> {
@@ -83,6 +131,10 @@ pub(crate) fn write_secret_blob(
     map: &serde_json::Map<String, serde_json::Value>,
 ) -> Result<(), String> {
     ensure_base_dir(paths)?;
+    let migrated_from_keychain = read_meta(paths)
+        .ok()
+        .map(|m| m.migrated_from_keychain)
+        .unwrap_or(false);
     let key = load_or_create_master_key(paths)?;
     let cipher =
         Aes256Gcm::new_from_slice(&key).map_err(|e| format!("Cipher init failed: {}", e))?;
@@ -101,25 +153,16 @@ pub(crate) fn write_secret_blob(
         ciphertext_b64: B64.encode(ciphertext),
     };
 
-    let tmp_path = paths.blob_path.with_extension("tmp");
-    std::fs::write(
-        &tmp_path,
-        serde_json::to_vec_pretty(&file)
-            .map_err(|e| format!("Failed to encode blob file: {}", e))?,
-    )
-    .map_err(|e| format!("Failed to write temp blob file: {}", e))?;
-    std::fs::rename(&tmp_path, &paths.blob_path)
-        .map_err(|e| format!("Failed to atomically replace blob file: {}", e))?;
+    let blob_bytes =
+        serde_json::to_vec_pretty(&file).map_err(|e| format!("Failed to encode blob file: {}", e))?;
+    write_blob_atomically(&paths.blob_path, &blob_bytes)?;
 
     write_meta(
         paths,
         SecretStoreMeta {
             version: LOCAL_SECRETS_VERSION,
             algorithm: "aes-256-gcm".to_string(),
-            migrated_from_keychain: read_meta(paths)
-                .ok()
-                .map(|m| m.migrated_from_keychain)
-                .unwrap_or(false),
+            migrated_from_keychain,
         },
     )?;
 
@@ -163,6 +206,57 @@ pub(crate) fn read_secret_blob(
         serde_json::Value::Object(map) => Ok(map),
         _ => Err("Secret blob JSON must be an object".to_string()),
     }
+}
+
+fn write_blob_atomically(target: &Path, bytes: &[u8]) -> Result<(), String> {
+    let parent = target
+        .parent()
+        .ok_or_else(|| format!("Blob path has no parent directory: {}", target.display()))?;
+    let stem = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("Invalid blob file name: {}", target.display()))?;
+
+    for _ in 0..50 {
+        let tmp_path = parent.join(format!(
+            ".{}.{}.{}.tmp",
+            stem,
+            std::process::id(),
+            rand::thread_rng().next_u64()
+        ));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+        {
+            Ok(mut file) => {
+                let write_result = (|| -> Result<(), String> {
+                    file.write_all(bytes)
+                        .map_err(|e| format!("Failed to write temp blob file: {}", e))?;
+                    file.sync_all()
+                        .map_err(|e| format!("Failed to flush temp blob file: {}", e))?;
+                    Ok(())
+                })();
+
+                if let Err(err) = write_result {
+                    let _ = std::fs::remove_file(&tmp_path);
+                    return Err(err);
+                }
+
+                match std::fs::rename(&tmp_path, target) {
+                    Ok(()) => return Ok(()),
+                    Err(e) => {
+                        let _ = std::fs::remove_file(&tmp_path);
+                        return Err(format!("Failed to atomically replace blob file: {}", e));
+                    }
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(format!("Failed to create temp blob file: {}", e)),
+        }
+    }
+
+    Err("Failed to create unique temp blob file after retries".to_string())
 }
 
 pub(crate) fn write_meta(paths: &SecretStorePaths, meta: SecretStoreMeta) -> Result<(), String> {
@@ -233,5 +327,23 @@ mod tests {
 
         let err = read_secret_blob(&paths).unwrap_err();
         assert!(err.contains("master key"));
+    }
+
+    #[test]
+    fn meta_round_trip_writes_and_reads() {
+        let dir = tempdir().unwrap();
+        let paths = SecretStorePaths::for_base_dir(dir.path().to_path_buf());
+        let meta = SecretStoreMeta {
+            version: LOCAL_SECRETS_VERSION,
+            algorithm: "aes-256-gcm".to_string(),
+            migrated_from_keychain: true,
+        };
+
+        write_meta(&paths, meta).unwrap();
+        let loaded = read_meta(&paths).unwrap();
+
+        assert_eq!(loaded.version, LOCAL_SECRETS_VERSION);
+        assert_eq!(loaded.algorithm, "aes-256-gcm");
+        assert!(loaded.migrated_from_keychain);
     }
 }

--- a/src-tauri/src/commands/local_secret_store.rs
+++ b/src-tauri/src/commands/local_secret_store.rs
@@ -63,7 +63,13 @@ fn set_owner_only_permissions(path: &Path) -> Result<(), String> {
     #[cfg(unix)]
     {
         let mut perms = std::fs::metadata(path)
-            .map_err(|e| format!("Failed to inspect permissions for {}: {}", path.display(), e))?
+            .map_err(|e| {
+                format!(
+                    "Failed to inspect permissions for {}: {}",
+                    path.display(),
+                    e
+                )
+            })?
             .permissions();
         perms.set_mode(0o600);
         std::fs::set_permissions(path, perms)
@@ -169,8 +175,8 @@ pub(crate) fn write_secret_blob(
         ciphertext_b64: B64.encode(ciphertext),
     };
 
-    let blob_bytes =
-        serde_json::to_vec_pretty(&file).map_err(|e| format!("Failed to encode blob file: {}", e))?;
+    let blob_bytes = serde_json::to_vec_pretty(&file)
+        .map_err(|e| format!("Failed to encode blob file: {}", e))?;
     write_blob_atomically(&paths.blob_path, &blob_bytes)?;
 
     write_meta(
@@ -343,7 +349,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let paths = SecretStorePaths::for_base_dir(dir.path().to_path_buf());
         let mut map = serde_json::Map::new();
-        map.insert("OPENAI_API_KEY".into(), serde_json::Value::String("sk-test".into()));
+        map.insert(
+            "OPENAI_API_KEY".into(),
+            serde_json::Value::String("sk-test".into()),
+        );
 
         write_secret_blob(&paths, &map).unwrap();
         let loaded = read_secret_blob(&paths).unwrap();
@@ -430,7 +439,10 @@ mod tests {
         write_secret_blob(&paths, &existing_map).unwrap();
 
         let mut legacy_map = serde_json::Map::new();
-        legacy_map.insert("LEGACY".into(), serde_json::Value::String("SHOULD_NOT_WIN".into()));
+        legacy_map.insert(
+            "LEGACY".into(),
+            serde_json::Value::String("SHOULD_NOT_WIN".into()),
+        );
 
         migrate_from_legacy_map_if_needed(&paths, Some(legacy_map)).unwrap();
 
@@ -451,6 +463,40 @@ mod tests {
 
         assert!(loaded.is_empty());
         assert!(!meta.migrated_from_keychain);
+    }
+
+    #[test]
+    fn read_or_migrate_uses_legacy_reader_once_then_prefers_local_blob() {
+        let dir = tempdir().unwrap();
+        let paths = SecretStorePaths::for_base_dir(dir.path().to_path_buf());
+        let legacy_reads = std::sync::atomic::AtomicUsize::new(0);
+
+        let first = read_or_migrate_secret_blob(&paths, || {
+            legacy_reads.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+            let mut legacy_map = serde_json::Map::new();
+            legacy_map.insert(
+                "OPENAI_API_KEY".into(),
+                serde_json::Value::String("migrated-secret".into()),
+            );
+            Ok(Some(legacy_map))
+        })
+        .unwrap();
+
+        assert_eq!(
+            first.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
+            Some("migrated-secret")
+        );
+        assert_eq!(legacy_reads.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        let second = read_or_migrate_secret_blob(&paths, || {
+            legacy_reads.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err("legacy reader should not run after local blob exists".to_string())
+        })
+        .unwrap();
+
+        assert_eq!(second, first);
+        assert_eq!(legacy_reads.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 
     #[cfg(unix)]
@@ -478,7 +524,11 @@ mod tests {
         let loaded = load_or_create_master_key(&paths).unwrap();
         assert_eq!(loaded, key);
 
-        let mode = std::fs::metadata(&paths.master_key_path).unwrap().permissions().mode() & 0o777;
+        let mode = std::fs::metadata(&paths.master_key_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
         assert_eq!(mode, 0o600);
     }
 
@@ -493,14 +543,20 @@ mod tests {
         map.insert("A".into(), serde_json::Value::String("B".into()));
 
         write_secret_blob(&paths, &map).unwrap();
-        let mut perms = std::fs::metadata(&paths.master_key_path).unwrap().permissions();
+        let mut perms = std::fs::metadata(&paths.master_key_path)
+            .unwrap()
+            .permissions();
         perms.set_mode(0o644);
         std::fs::set_permissions(&paths.master_key_path, perms).unwrap();
 
         let loaded = read_secret_blob(&paths).unwrap();
         assert_eq!(loaded.get("A").and_then(|v| v.as_str()), Some("B"));
 
-        let mode = std::fs::metadata(&paths.master_key_path).unwrap().permissions().mode() & 0o777;
+        let mode = std::fs::metadata(&paths.master_key_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
         assert_eq!(mode, 0o600);
     }
 }

--- a/src-tauri/src/commands/local_secret_store.rs
+++ b/src-tauri/src/commands/local_secret_store.rs
@@ -135,8 +135,11 @@ fn load_or_create_master_key(paths: &SecretStorePaths) -> Result<[u8; 32], Strin
 fn load_existing_master_key(paths: &SecretStorePaths) -> Result<[u8; 32], String> {
     let raw = std::fs::read(&paths.master_key_path)
         .map_err(|_| "Missing master key for existing encrypted secret store".to_string())?;
-    raw.try_into()
-        .map_err(|_| "Invalid master key length".to_string())
+    let key: [u8; 32] = raw
+        .try_into()
+        .map_err(|_| "Invalid master key length".to_string())?;
+    set_owner_only_permissions(&paths.master_key_path)?;
+    Ok(key)
 }
 
 pub(crate) fn write_secret_blob(
@@ -384,6 +387,28 @@ mod tests {
 
         let loaded = load_or_create_master_key(&paths).unwrap();
         assert_eq!(loaded, key);
+
+        let mode = std::fs::metadata(&paths.master_key_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_path_repairs_existing_master_key_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let paths = SecretStorePaths::for_base_dir(dir.path().to_path_buf());
+        let mut map = serde_json::Map::new();
+        map.insert("A".into(), serde_json::Value::String("B".into()));
+
+        write_secret_blob(&paths, &map).unwrap();
+        let mut perms = std::fs::metadata(&paths.master_key_path).unwrap().permissions();
+        perms.set_mode(0o644);
+        std::fs::set_permissions(&paths.master_key_path, perms).unwrap();
+
+        let loaded = read_secret_blob(&paths).unwrap();
+        assert_eq!(loaded.get("A").and_then(|v| v.as_str()), Some("B"));
 
         let mode = std::fs::metadata(&paths.master_key_path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);

--- a/src-tauri/src/commands/local_secret_store.rs
+++ b/src-tauri/src/commands/local_secret_store.rs
@@ -224,6 +224,48 @@ pub(crate) fn read_secret_blob(
     }
 }
 
+pub(crate) fn migrate_from_legacy_map_if_needed(
+    paths: &SecretStorePaths,
+    legacy_map: Option<serde_json::Map<String, serde_json::Value>>,
+) -> Result<(), String> {
+    if paths.blob_path.exists() {
+        return Ok(());
+    }
+
+    let had_legacy_data = legacy_map.is_some();
+    let map = legacy_map.unwrap_or_default();
+    write_secret_blob(paths, &map)?;
+
+    if had_legacy_data {
+        write_meta(
+            paths,
+            SecretStoreMeta {
+                version: LOCAL_SECRETS_VERSION,
+                algorithm: "aes-256-gcm".to_string(),
+                migrated_from_keychain: true,
+            },
+        )?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn read_or_migrate_secret_blob<F>(
+    paths: &SecretStorePaths,
+    legacy_reader: F,
+) -> Result<serde_json::Map<String, serde_json::Value>, String>
+where
+    F: FnOnce() -> Result<Option<serde_json::Map<String, serde_json::Value>>, String>,
+{
+    if paths.blob_path.exists() {
+        return read_secret_blob(paths);
+    }
+
+    let legacy_map = legacy_reader()?;
+    migrate_from_legacy_map_if_needed(paths, legacy_map)?;
+    read_secret_blob(paths)
+}
+
 fn write_blob_atomically(target: &Path, bytes: &[u8]) -> Result<(), String> {
     let parent = target
         .parent()
@@ -361,6 +403,54 @@ mod tests {
         assert_eq!(loaded.version, LOCAL_SECRETS_VERSION);
         assert_eq!(loaded.algorithm, "aes-256-gcm");
         assert!(loaded.migrated_from_keychain);
+    }
+
+    #[test]
+    fn migration_writes_local_blob_from_legacy_map() {
+        let dir = tempdir().unwrap();
+        let paths = SecretStorePaths::for_base_dir(dir.path().to_path_buf());
+        let mut legacy_map = serde_json::Map::new();
+        legacy_map.insert("A".into(), serde_json::Value::String("B".into()));
+
+        migrate_from_legacy_map_if_needed(&paths, Some(legacy_map.clone())).unwrap();
+
+        let loaded = read_secret_blob(&paths).unwrap();
+        let meta = read_meta(&paths).unwrap();
+
+        assert_eq!(loaded, legacy_map);
+        assert!(meta.migrated_from_keychain);
+    }
+
+    #[test]
+    fn migration_is_noop_when_encrypted_blob_already_exists() {
+        let dir = tempdir().unwrap();
+        let paths = SecretStorePaths::for_base_dir(dir.path().to_path_buf());
+        let mut existing_map = serde_json::Map::new();
+        existing_map.insert("EXISTING".into(), serde_json::Value::String("VALUE".into()));
+        write_secret_blob(&paths, &existing_map).unwrap();
+
+        let mut legacy_map = serde_json::Map::new();
+        legacy_map.insert("LEGACY".into(), serde_json::Value::String("SHOULD_NOT_WIN".into()));
+
+        migrate_from_legacy_map_if_needed(&paths, Some(legacy_map)).unwrap();
+
+        let loaded = read_secret_blob(&paths).unwrap();
+        let meta = read_meta(&paths).unwrap();
+
+        assert_eq!(loaded, existing_map);
+        assert!(!meta.migrated_from_keychain);
+    }
+
+    #[test]
+    fn read_or_migrate_initializes_empty_store_when_both_missing() {
+        let dir = tempdir().unwrap();
+        let paths = SecretStorePaths::for_base_dir(dir.path().to_path_buf());
+
+        let loaded = read_or_migrate_secret_blob(&paths, || Ok(None)).unwrap();
+        let meta = read_meta(&paths).unwrap();
+
+        assert!(loaded.is_empty());
+        assert!(!meta.migrated_from_keychain);
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/local_secret_store.rs
+++ b/src-tauri/src/commands/local_secret_store.rs
@@ -87,12 +87,22 @@ fn load_or_create_master_key(paths: &SecretStorePaths) -> Result<[u8; 32], Strin
             Ok(mut file) => {
                 let mut key = [0u8; 32];
                 rand::thread_rng().fill_bytes(&mut key);
-                file.write_all(&key)
-                    .map_err(|e| format!("Failed to write master key: {}", e))?;
-                file.sync_all()
-                    .map_err(|e| format!("Failed to flush master key: {}", e))?;
-                set_owner_only_permissions(&paths.master_key_path)?;
-                return Ok(key);
+                let write_result = (|| -> Result<[u8; 32], String> {
+                    file.write_all(&key)
+                        .map_err(|e| format!("Failed to write master key: {}", e))?;
+                    file.sync_all()
+                        .map_err(|e| format!("Failed to flush master key: {}", e))?;
+                    set_owner_only_permissions(&paths.master_key_path)?;
+                    Ok(key)
+                })();
+
+                match write_result {
+                    Ok(key) => return Ok(key),
+                    Err(err) => {
+                        let _ = std::fs::remove_file(&paths.master_key_path);
+                        return Err(err);
+                    }
+                }
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 let raw = match std::fs::read(&paths.master_key_path) {
@@ -105,7 +115,10 @@ fn load_or_create_master_key(paths: &SecretStorePaths) -> Result<[u8; 32], Strin
                 };
 
                 match raw.try_into() {
-                    Ok(key) => return Ok(key),
+                    Ok(key) => {
+                        set_owner_only_permissions(&paths.master_key_path)?;
+                        return Ok(key);
+                    }
                     Err(_) => {
                         std::thread::sleep(Duration::from_millis(10));
                         continue;
@@ -345,5 +358,34 @@ mod tests {
         assert_eq!(loaded.version, LOCAL_SECRETS_VERSION);
         assert_eq!(loaded.algorithm, "aes-256-gcm");
         assert!(loaded.migrated_from_keychain);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_master_key_permissions_are_corrected() {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let dir = tempdir().unwrap();
+        let paths = SecretStorePaths::for_base_dir(dir.path().to_path_buf());
+        std::fs::create_dir_all(&paths.base_dir).unwrap();
+
+        let mut key = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut key);
+
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o644)
+            .open(&paths.master_key_path)
+            .unwrap();
+        file.write_all(&key).unwrap();
+        file.sync_all().unwrap();
+
+        let loaded = load_or_create_master_key(&paths).unwrap();
+        assert_eq!(loaded, key);
+
+        let mode = std::fs::metadata(&paths.master_key_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
     }
 }

--- a/src-tauri/src/commands/local_secret_store.rs
+++ b/src-tauri/src/commands/local_secret_store.rs
@@ -1,0 +1,237 @@
+use aes_gcm::{
+    aead::{Aead, KeyInit},
+    Aes256Gcm, Nonce,
+};
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+pub(crate) const LOCAL_SECRETS_VERSION: u32 = 1;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SecretStorePaths {
+    pub base_dir: PathBuf,
+    pub master_key_path: PathBuf,
+    pub blob_path: PathBuf,
+    pub meta_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SecretStoreMeta {
+    pub version: u32,
+    pub algorithm: String,
+    pub migrated_from_keychain: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EncryptedBlobFile {
+    nonce_b64: String,
+    ciphertext_b64: String,
+}
+
+impl SecretStorePaths {
+    pub fn for_home_dir() -> Result<Self, String> {
+        let home = dirs::home_dir().ok_or_else(|| "Home directory not found".to_string())?;
+        Ok(Self::for_base_dir(
+            home.join(concat!(".", env!("APP_SHORT_NAME")))
+                .join("secrets"),
+        ))
+    }
+
+    pub fn for_base_dir(base_dir: PathBuf) -> Self {
+        Self {
+            master_key_path: base_dir.join("master.key"),
+            blob_path: base_dir.join("personal-secrets.json.enc"),
+            meta_path: base_dir.join("meta.json"),
+            base_dir,
+        }
+    }
+}
+
+fn ensure_base_dir(paths: &SecretStorePaths) -> Result<(), String> {
+    std::fs::create_dir_all(&paths.base_dir)
+        .map_err(|e| format!("Failed to create secrets dir: {}", e))
+}
+
+fn load_or_create_master_key(paths: &SecretStorePaths) -> Result<[u8; 32], String> {
+    ensure_base_dir(paths)?;
+    if paths.master_key_path.exists() {
+        let raw = std::fs::read(&paths.master_key_path)
+            .map_err(|e| format!("Failed to read master key: {}", e))?;
+        return raw
+            .try_into()
+            .map_err(|_| "Invalid master key length".to_string());
+    }
+
+    let mut key = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut key);
+    std::fs::write(&paths.master_key_path, key)
+        .map_err(|e| format!("Failed to write master key: {}", e))?;
+    Ok(key)
+}
+
+fn load_existing_master_key(paths: &SecretStorePaths) -> Result<[u8; 32], String> {
+    let raw = std::fs::read(&paths.master_key_path)
+        .map_err(|_| "Missing master key for existing encrypted secret store".to_string())?;
+    raw.try_into()
+        .map_err(|_| "Invalid master key length".to_string())
+}
+
+pub(crate) fn write_secret_blob(
+    paths: &SecretStorePaths,
+    map: &serde_json::Map<String, serde_json::Value>,
+) -> Result<(), String> {
+    ensure_base_dir(paths)?;
+    let key = load_or_create_master_key(paths)?;
+    let cipher =
+        Aes256Gcm::new_from_slice(&key).map_err(|e| format!("Cipher init failed: {}", e))?;
+    let plaintext =
+        serde_json::to_vec(map).map_err(|e| format!("Failed to serialize secret blob: {}", e))?;
+
+    let mut nonce_bytes = [0u8; 12];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext.as_ref())
+        .map_err(|e| format!("Failed to encrypt secret blob: {}", e))?;
+
+    let file = EncryptedBlobFile {
+        nonce_b64: B64.encode(nonce_bytes),
+        ciphertext_b64: B64.encode(ciphertext),
+    };
+
+    let tmp_path = paths.blob_path.with_extension("tmp");
+    std::fs::write(
+        &tmp_path,
+        serde_json::to_vec_pretty(&file)
+            .map_err(|e| format!("Failed to encode blob file: {}", e))?,
+    )
+    .map_err(|e| format!("Failed to write temp blob file: {}", e))?;
+    std::fs::rename(&tmp_path, &paths.blob_path)
+        .map_err(|e| format!("Failed to atomically replace blob file: {}", e))?;
+
+    write_meta(
+        paths,
+        SecretStoreMeta {
+            version: LOCAL_SECRETS_VERSION,
+            algorithm: "aes-256-gcm".to_string(),
+            migrated_from_keychain: read_meta(paths)
+                .ok()
+                .map(|m| m.migrated_from_keychain)
+                .unwrap_or(false),
+        },
+    )?;
+
+    Ok(())
+}
+
+pub(crate) fn read_secret_blob(
+    paths: &SecretStorePaths,
+) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    if !paths.blob_path.exists() {
+        return Ok(serde_json::Map::new());
+    }
+
+    let key = load_existing_master_key(paths)?;
+    let cipher =
+        Aes256Gcm::new_from_slice(&key).map_err(|e| format!("Cipher init failed: {}", e))?;
+    let file: EncryptedBlobFile = serde_json::from_slice(
+        &std::fs::read(&paths.blob_path).map_err(|e| format!("Failed to read blob file: {}", e))?,
+    )
+    .map_err(|e| format!("Failed to parse blob file: {}", e))?;
+
+    let nonce_bytes = B64
+        .decode(file.nonce_b64)
+        .map_err(|e| format!("Failed to decode blob nonce: {}", e))?;
+    if nonce_bytes.len() != 12 {
+        return Err(format!(
+            "Failed to decrypt secret blob: invalid nonce length {}",
+            nonce_bytes.len()
+        ));
+    }
+    let ciphertext = B64
+        .decode(file.ciphertext_b64)
+        .map_err(|e| format!("Failed to decode blob ciphertext: {}", e))?;
+    let plaintext = cipher
+        .decrypt(Nonce::from_slice(&nonce_bytes), ciphertext.as_ref())
+        .map_err(|_| "Failed to decrypt secret blob (authentication failed)".to_string())?;
+
+    let value: serde_json::Value = serde_json::from_slice(&plaintext)
+        .map_err(|e| format!("Failed to parse secret blob JSON: {}", e))?;
+    match value {
+        serde_json::Value::Object(map) => Ok(map),
+        _ => Err("Secret blob JSON must be an object".to_string()),
+    }
+}
+
+pub(crate) fn write_meta(paths: &SecretStorePaths, meta: SecretStoreMeta) -> Result<(), String> {
+    ensure_base_dir(paths)?;
+    std::fs::write(
+        &paths.meta_path,
+        serde_json::to_vec_pretty(&meta).map_err(|e| format!("Failed to encode meta: {}", e))?,
+    )
+    .map_err(|e| format!("Failed to write meta file: {}", e))
+}
+
+pub(crate) fn read_meta(paths: &SecretStorePaths) -> Result<SecretStoreMeta, String> {
+    serde_json::from_slice(
+        &std::fs::read(&paths.meta_path).map_err(|e| format!("Failed to read meta file: {}", e))?,
+    )
+    .map_err(|e| format!("Failed to parse meta file: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn round_trip_encrypts_and_decrypts_blob() {
+        let dir = tempdir().unwrap();
+        let paths = SecretStorePaths::for_base_dir(dir.path().to_path_buf());
+        let mut map = serde_json::Map::new();
+        map.insert("OPENAI_API_KEY".into(), serde_json::Value::String("sk-test".into()));
+
+        write_secret_blob(&paths, &map).unwrap();
+        let loaded = read_secret_blob(&paths).unwrap();
+
+        assert_eq!(
+            loaded.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
+            Some("sk-test")
+        );
+    }
+
+    #[test]
+    fn tampered_blob_fails_to_decrypt() {
+        let dir = tempdir().unwrap();
+        let paths = SecretStorePaths::for_base_dir(dir.path().to_path_buf());
+        let mut map = serde_json::Map::new();
+        map.insert("A".into(), serde_json::Value::String("B".into()));
+
+        write_secret_blob(&paths, &map).unwrap();
+        let raw = std::fs::read(&paths.blob_path).unwrap();
+        let mut file: EncryptedBlobFile = serde_json::from_slice(&raw).unwrap();
+        let mut ciphertext = B64.decode(file.ciphertext_b64).unwrap();
+        ciphertext[0] ^= 0x01;
+        file.ciphertext_b64 = B64.encode(ciphertext);
+        std::fs::write(&paths.blob_path, serde_json::to_vec(&file).unwrap()).unwrap();
+
+        let err = read_secret_blob(&paths).unwrap_err();
+        assert!(err.contains("decrypt") || err.contains("authentication"));
+    }
+
+    #[test]
+    fn missing_master_key_with_present_blob_fails() {
+        let dir = tempdir().unwrap();
+        let paths = SecretStorePaths::for_base_dir(dir.path().to_path_buf());
+        let mut map = serde_json::Map::new();
+        map.insert("A".into(), serde_json::Value::String("B".into()));
+
+        write_secret_blob(&paths, &map).unwrap();
+        std::fs::remove_file(&paths.master_key_path).unwrap();
+
+        let err = read_secret_blob(&paths).unwrap_err();
+        assert!(err.contains("master key"));
+    }
+}

--- a/src-tauri/src/commands/local_secret_store.rs
+++ b/src-tauri/src/commands/local_secret_store.rs
@@ -11,17 +11,17 @@ pub(crate) const LOCAL_SECRETS_VERSION: u32 = 1;
 
 #[derive(Debug, Clone)]
 pub(crate) struct SecretStorePaths {
-    base_dir: PathBuf,
-    master_key_path: PathBuf,
-    blob_path: PathBuf,
-    meta_path: PathBuf,
+    pub(crate) base_dir: PathBuf,
+    pub(crate) master_key_path: PathBuf,
+    pub(crate) blob_path: PathBuf,
+    pub(crate) meta_path: PathBuf,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct SecretStoreMeta {
-    version: u32,
-    algorithm: String,
-    migrated_from_keychain: bool,
+    pub(crate) version: u32,
+    pub(crate) algorithm: String,
+    pub(crate) migrated_from_keychain: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod gateway;
 pub mod git;
 pub mod introspect_api;
 pub mod knowledge;
+pub mod local_secret_store;
 pub mod local_stats;
 pub mod mcp;
 pub mod opencode;

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -1705,6 +1705,7 @@ fn resolve_sidecar_binary_paths(workspace_path: &str) -> Result<(), String> {
 //   2. Write resolved values into opencode.json before OpenCode starts
 //   3. Restore the ${KEY} references after all MCP servers have connected
 
+#[cfg(test)]
 fn load_local_personal_secrets_from_blob<F>(
     paths: &super::local_secret_store::SecretStorePaths,
     legacy_reader: F,
@@ -1722,10 +1723,15 @@ where
 fn load_local_personal_secrets_from_paths(
     workspace_path: &str,
     paths: &super::local_secret_store::SecretStorePaths,
-) -> Result<Vec<(String, String)>, String> {
-    load_local_personal_secrets_from_blob(paths, || {
-        super::env_vars::read_legacy_keychain_blob(workspace_path)
-    })
+) -> Result<(Vec<(String, String)>, bool), String> {
+    let (blob, retry_needed) =
+        super::env_vars::read_personal_secret_blob_for_startup_from_paths(workspace_path, paths)?;
+    Ok((
+        blob.into_iter()
+            .filter_map(|(k, v)| v.as_str().map(|s| (k, s.to_string())))
+            .collect(),
+        retry_needed,
+    ))
 }
 
 /// Read all personal env vars from the local encrypted secret blob.
@@ -1744,12 +1750,19 @@ fn load_local_personal_secrets(workspace_path: &str) -> (Vec<(String, String)>, 
     };
 
     match load_local_personal_secrets_from_paths(workspace_path, &paths) {
-        Ok(blob) => {
+        Ok((blob, retry_needed)) => {
             println!(
                 "[OpenCode] Loaded {} personal secrets from local encrypted store",
                 blob.len()
             );
-            (blob, Vec::new())
+            (
+                blob,
+                if retry_needed {
+                    vec!["__blob__".to_string()]
+                } else {
+                    Vec::new()
+                },
+            )
         }
         Err(e) => {
             eprintln!(
@@ -2192,7 +2205,7 @@ mod tests {
         let custom_store_dir = tempdir().unwrap();
         let custom_paths = SecretStorePaths::for_base_dir(custom_store_dir.path().join("secrets"));
 
-        let secrets =
+        let (secrets, retry_needed) =
             load_local_personal_secrets_from_paths(&workspace_path, &custom_paths).unwrap();
 
         assert_eq!(
@@ -2202,6 +2215,7 @@ mod tests {
                 "from-legacy-reader".to_string()
             )]
         );
+        assert!(!retry_needed);
 
         let migrated = local_secret_store::read_secret_blob(&custom_paths).unwrap();
         assert_eq!(

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -1706,7 +1706,7 @@ fn resolve_sidecar_binary_paths(workspace_path: &str) -> Result<(), String> {
 //   2. Write resolved values into opencode.json before OpenCode starts
 //   3. Restore the ${KEY} references after all MCP servers have connected
 
-fn load_local_personal_secrets_from_paths<F>(
+fn load_local_personal_secrets_from_blob<F>(
     paths: &super::local_secret_store::SecretStorePaths,
     legacy_reader: F,
 ) -> Result<Vec<(String, String)>, String>
@@ -1718,6 +1718,15 @@ where
         .into_iter()
         .filter_map(|(k, v)| v.as_str().map(|s| (k, s.to_string())))
         .collect())
+}
+
+fn load_local_personal_secrets_from_paths(
+    workspace_path: &str,
+    paths: &super::local_secret_store::SecretStorePaths,
+) -> Result<Vec<(String, String)>, String> {
+    load_local_personal_secrets_from_blob(paths, || {
+        super::env_vars::read_legacy_keychain_blob(workspace_path)
+    })
 }
 
 /// Read all personal env vars from the local encrypted secret blob.
@@ -1735,9 +1744,7 @@ fn load_local_personal_secrets(workspace_path: &str) -> (Vec<(String, String)>, 
         }
     };
 
-    match load_local_personal_secrets_from_paths(&paths, || {
-        super::env_vars::read_env_blob(workspace_path).map(Some)
-    }) {
+    match load_local_personal_secrets_from_paths(workspace_path, &paths) {
         Ok(blob) => {
             println!(
                 "[OpenCode] Loaded {} personal secrets from local encrypted store",
@@ -2141,7 +2148,7 @@ mod tests {
         local_secret_store::write_secret_blob(&paths, &map).unwrap();
 
         let legacy_reader_called = AtomicBool::new(false);
-        let secrets = load_local_personal_secrets_from_paths(&paths, || {
+        let secrets = load_local_personal_secrets_from_blob(&paths, || {
             legacy_reader_called.store(true, Ordering::SeqCst);
             Ok(Some(serde_json::Map::new()))
         })
@@ -2152,6 +2159,55 @@ mod tests {
             vec![("OPENAI_API_KEY".to_string(), "local-secret".to_string())]
         );
         assert!(!legacy_reader_called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn load_local_personal_secrets_migrates_from_legacy_reader_not_read_env_blob() {
+        let _home_guard = home_lock().lock().unwrap();
+        let home_dir = tempdir().unwrap();
+        let _home = HomeGuard::set(home_dir.path());
+        let workspace_dir = tempdir().unwrap();
+        let workspace_path = workspace_dir.path().to_string_lossy().to_string();
+
+        let home_paths = SecretStorePaths::for_home_dir().unwrap();
+        let mut home_map = serde_json::Map::new();
+        home_map.insert(
+            "OPENAI_API_KEY".into(),
+            serde_json::Value::String("from-read-env-blob".into()),
+        );
+        local_secret_store::write_secret_blob(&home_paths, &home_map).unwrap();
+
+        let legacy_blob_dir = home_dir.path().join(concat!(".", env!("APP_SHORT_NAME")));
+        std::fs::create_dir_all(&legacy_blob_dir).unwrap();
+        let mut legacy_map = serde_json::Map::new();
+        legacy_map.insert(
+            "OPENAI_API_KEY".into(),
+            serde_json::Value::String("from-legacy-reader".into()),
+        );
+        std::fs::write(
+            legacy_blob_dir.join("env-blob.json"),
+            serde_json::to_vec(&legacy_map).unwrap(),
+        )
+        .unwrap();
+
+        let custom_store_dir = tempdir().unwrap();
+        let custom_paths = SecretStorePaths::for_base_dir(custom_store_dir.path().join("secrets"));
+
+        let secrets = load_local_personal_secrets_from_paths(&workspace_path, &custom_paths).unwrap();
+
+        assert_eq!(
+            secrets,
+            vec![(
+                "OPENAI_API_KEY".to_string(),
+                "from-legacy-reader".to_string()
+            )]
+        );
+
+        let migrated = local_secret_store::read_secret_blob(&custom_paths).unwrap();
+        assert_eq!(
+            migrated.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
+            Some("from-legacy-reader")
+        );
     }
 }
 

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -541,50 +541,20 @@ pub async fn start_opencode_inner(
         (Vec::new(), Vec::new())
     });
 
-    // Local encrypted secret blob retry logic (unchanged from original)
     if !failed_keys.is_empty() {
         if failed_keys == ["__blob__"] {
-            println!("[OpenCode] Local encrypted secret blob unavailable, retrying once...");
+            eprintln!("[OpenCode] Warning: local encrypted secret blob unavailable");
         } else {
-            println!(
-                "[OpenCode] {} personal secret(s) failed to read ({:?}), retrying local encrypted blob load...",
+            eprintln!(
+                "[OpenCode] Warning: {} personal secret(s) failed to read: {:?}",
                 failed_keys.len(),
                 failed_keys
             );
         }
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-        let ws_retry = workspace_path.clone();
-        let (retry_secrets, still_failed) =
-            tokio::task::spawn_blocking(move || load_local_personal_secrets(&ws_retry))
-                .await
-                .unwrap_or_else(|e| {
-                    eprintln!(
-                        "[OpenCode] spawn_blocking for local personal secrets retry failed: {}",
-                        e
-                    );
-                    (Vec::new(), Vec::new())
-                });
-
-        if !still_failed.is_empty() {
-            if still_failed == ["__blob__"] {
-                eprintln!(
-                    "[OpenCode] Warning: local encrypted secret blob still unavailable after retry"
-                );
-            } else {
-                eprintln!(
-                    "[OpenCode] Warning: {} personal secret(s) still unavailable after retry: {:?}",
-                    still_failed.len(),
-                    still_failed
-                );
-            }
-        }
-
-        secrets = retry_secrets;
     }
 
     // Merge shared secrets (team KMS) into secrets vec.
-    // Shared secrets take priority over local keyring entries with the same key.
+    // Shared secrets take priority over local personal secrets with the same key.
     //
     // On every (re)start: (1) lazy-init if needed — supports both OSS and Git
     // teams via `try_lazy_init_from_workspace`, and (2) re-read the `_secrets/`
@@ -1698,7 +1668,7 @@ fn resolve_sidecar_binary_paths(workspace_path: &str) -> Result<(), String> {
 // ─── Secret / env-var helpers for MCP config ────────────────────────────
 //
 // teamclaw stores personal API keys in a local encrypted secret blob.
-// Legacy keychain data is migrated into that local store on first read.
+// Legacy keychain data is consulted only as first-read migration input.
 // opencode.json
 // references them via ${KEY_NAME}.  OpenCode passes environment values
 // literally to MCP server processes, so we must:
@@ -2193,7 +2163,8 @@ mod tests {
         let custom_store_dir = tempdir().unwrap();
         let custom_paths = SecretStorePaths::for_base_dir(custom_store_dir.path().join("secrets"));
 
-        let secrets = load_local_personal_secrets_from_paths(&workspace_path, &custom_paths).unwrap();
+        let secrets =
+            load_local_personal_secrets_from_paths(&workspace_path, &custom_paths).unwrap();
 
         assert_eq!(
             secrets,

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -543,14 +543,43 @@ pub async fn start_opencode_inner(
 
     if !failed_keys.is_empty() {
         if failed_keys == ["__blob__"] {
-            eprintln!("[OpenCode] Warning: local encrypted secret blob unavailable");
+            println!("[OpenCode] Local encrypted secret blob unavailable, retrying once...");
         } else {
-            eprintln!(
-                "[OpenCode] Warning: {} personal secret(s) failed to read: {:?}",
+            println!(
+                "[OpenCode] {} personal secret(s) failed to read ({:?}), retrying local encrypted blob load...",
                 failed_keys.len(),
                 failed_keys
             );
         }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        let ws_retry = workspace_path.clone();
+        let (retry_secrets, still_failed) =
+            tokio::task::spawn_blocking(move || load_local_personal_secrets(&ws_retry))
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!(
+                        "[OpenCode] spawn_blocking for local personal secrets retry failed: {}",
+                        e
+                    );
+                    (Vec::new(), Vec::new())
+                });
+
+        if !still_failed.is_empty() {
+            if still_failed == ["__blob__"] {
+                eprintln!(
+                    "[OpenCode] Warning: local encrypted secret blob still unavailable after retry"
+                );
+            } else {
+                eprintln!(
+                    "[OpenCode] Warning: {} personal secret(s) still unavailable after retry: {:?}",
+                    still_failed.len(),
+                    still_failed
+                );
+            }
+        }
+
+        secrets = retry_secrets;
     }
 
     // Merge shared secrets (team KMS) into secrets vec.

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -462,13 +462,13 @@ pub async fn start_opencode_inner(
     // Three branches run concurrently via tokio::join!:
     //   1. opencode.json writers (sequential: permissions → config → binary paths)
     //   2. ensure_inherent_skills (writes to .opencode/skills/, independent)
-    //   3. read_keyring_secrets (reads OS keyring, independent)
+    //   3. load_local_personal_secrets (reads local encrypted secret blob, independent)
     //
     // resolve_config_secret_refs runs AFTER all three complete (depends on
-    // both the config writers finishing and keyring secrets being available).
+    // both the config writers finishing and local personal secrets being available).
 
-    // Ensure system env vars exist (e.g. tc_api_key) before reading keyring secrets.
-    // Runs synchronously — one keychain read + optional write.
+    // Ensure system env vars exist (e.g. tc_api_key) before reading personal secrets.
+    // Runs synchronously before the local encrypted secret blob load.
     {
         let device_id = super::oss_commands::get_device_id().unwrap_or_default();
         let ws = workspace_path.clone();
@@ -488,9 +488,9 @@ pub async fn start_opencode_inner(
 
     let ws_for_config = workspace_path.clone();
     let ws_for_skills = workspace_path.clone();
-    let ws_for_keyring = workspace_path.clone();
+    let ws_for_personal_secrets = workspace_path.clone();
 
-    let (config_result, skills_result, keyring_result) = tokio::join!(
+    let (config_result, skills_result, personal_secrets_result) = tokio::join!(
         // Branch 1: opencode.json writers (must be sequential with each other)
         tokio::task::spawn_blocking(move || {
             if let Err(e) = ensure_default_permissions(&ws_for_config) {
@@ -521,8 +521,8 @@ pub async fn start_opencode_inner(
                 );
             }
         }),
-        // Branch 3: keyring secrets
-        tokio::task::spawn_blocking(move || read_keyring_secrets(&ws_for_keyring))
+        // Branch 3: local personal secrets
+        tokio::task::spawn_blocking(move || load_local_personal_secrets(&ws_for_personal_secrets))
     );
 
     // Unwrap spawn results (panics inside spawn_blocking become JoinErrors)
@@ -533,18 +533,21 @@ pub async fn start_opencode_inner(
         eprintln!("[OpenCode] Skills setup task panicked: {}", e);
     }
 
-    let (mut secrets, failed_keys) = keyring_result.unwrap_or_else(|e| {
-        eprintln!("[OpenCode] spawn_blocking for keyring failed: {}", e);
+    let (mut secrets, failed_keys) = personal_secrets_result.unwrap_or_else(|e| {
+        eprintln!(
+            "[OpenCode] spawn_blocking for local personal secrets failed: {}",
+            e
+        );
         (Vec::new(), Vec::new())
     });
 
-    // Keyring retry logic (unchanged from original)
+    // Local encrypted secret blob retry logic (unchanged from original)
     if !failed_keys.is_empty() {
         if failed_keys == ["__blob__"] {
-            println!("[OpenCode] Keychain blob unavailable, retrying after keychain unlock...");
+            println!("[OpenCode] Local encrypted secret blob unavailable, retrying once...");
         } else {
             println!(
-                "[OpenCode] {} secret(s) failed to read ({:?}), retrying after keychain unlock...",
+                "[OpenCode] {} personal secret(s) failed to read ({:?}), retrying local encrypted blob load...",
                 failed_keys.len(),
                 failed_keys
             );
@@ -553,19 +556,24 @@ pub async fn start_opencode_inner(
 
         let ws_retry = workspace_path.clone();
         let (retry_secrets, still_failed) =
-            tokio::task::spawn_blocking(move || read_keyring_secrets(&ws_retry))
+            tokio::task::spawn_blocking(move || load_local_personal_secrets(&ws_retry))
                 .await
                 .unwrap_or_else(|e| {
-                    eprintln!("[OpenCode] spawn_blocking for keyring retry failed: {}", e);
+                    eprintln!(
+                        "[OpenCode] spawn_blocking for local personal secrets retry failed: {}",
+                        e
+                    );
                     (Vec::new(), Vec::new())
                 });
 
         if !still_failed.is_empty() {
             if still_failed == ["__blob__"] {
-                eprintln!("[OpenCode] Warning: keychain blob still unavailable after retry");
+                eprintln!(
+                    "[OpenCode] Warning: local encrypted secret blob still unavailable after retry"
+                );
             } else {
                 eprintln!(
-                    "[OpenCode] Warning: {} secret(s) still unavailable after retry: {:?}",
+                    "[OpenCode] Warning: {} personal secret(s) still unavailable after retry: {:?}",
                     still_failed.len(),
                     still_failed
                 );
@@ -583,10 +591,9 @@ pub async fn start_opencode_inner(
     // directory unconditionally so we pick up envelopes that arrived via sync
     // while the app was running (or while opencode was stopped).
     if let Some(shared_state) = app.try_state::<super::shared_secrets::SharedSecretsState>() {
-        if let Err(e) = super::shared_secrets::try_lazy_init_from_workspace(
-            &shared_state,
-            &workspace_path,
-        ) {
+        if let Err(e) =
+            super::shared_secrets::try_lazy_init_from_workspace(&shared_state, &workspace_path)
+        {
             // Not an error when the workspace has no team — expected for solo workspaces.
             println!("[OpenCode] shared_secrets init skipped: {}", e);
         }
@@ -1690,32 +1697,59 @@ fn resolve_sidecar_binary_paths(workspace_path: &str) -> Result<(), String> {
 
 // ─── Secret / env-var helpers for MCP config ────────────────────────────
 //
-// teamclaw stores API keys in the OS credential store (macOS Keychain /
-// Windows Credential Manager / Linux Secret Service).  opencode.json
+// teamclaw stores personal API keys in a local encrypted secret blob.
+// Legacy keychain data is migrated into that local store on first read.
+// opencode.json
 // references them via ${KEY_NAME}.  OpenCode passes environment values
 // literally to MCP server processes, so we must:
-//   1. Read secrets from the keyring
+//   1. Read personal secrets from the local encrypted store
 //   2. Write resolved values into opencode.json before OpenCode starts
 //   3. Restore the ${KEY} references after all MCP servers have connected
 
-/// Read all personal env vars from the single keychain blob.
+fn load_local_personal_secrets_from_paths<F>(
+    paths: &super::local_secret_store::SecretStorePaths,
+    legacy_reader: F,
+) -> Result<Vec<(String, String)>, String>
+where
+    F: FnOnce() -> Result<Option<serde_json::Map<String, serde_json::Value>>, String>,
+{
+    let blob = super::local_secret_store::read_or_migrate_secret_blob(paths, legacy_reader)?;
+    Ok(blob
+        .into_iter()
+        .filter_map(|(k, v)| v.as_str().map(|s| (k, s.to_string())))
+        .collect())
+}
+
+/// Read all personal env vars from the local encrypted secret blob.
 /// Returns `(secrets, failed)` — failed is always empty on success, or contains
 /// a diagnostic sentinel if the blob itself cannot be read.
-fn read_keyring_secrets(workspace_path: &str) -> (Vec<(String, String)>, Vec<String>) {
-    match super::env_vars::read_env_blob(workspace_path) {
-        Ok(blob) => {
-            let secrets: Vec<(String, String)> = blob
-                .into_iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k, s.to_string())))
-                .collect();
-            println!(
-                "[OpenCode] Loaded {} secrets from keychain blob",
-                secrets.len()
+fn load_local_personal_secrets(workspace_path: &str) -> (Vec<(String, String)>, Vec<String>) {
+    let paths = match super::local_secret_store::SecretStorePaths::for_home_dir() {
+        Ok(paths) => paths,
+        Err(e) => {
+            eprintln!(
+                "[OpenCode] Failed to resolve local encrypted secret store path: {}",
+                e
             );
-            (secrets, Vec::new())
+            return (Vec::new(), vec!["__blob__".to_string()]);
+        }
+    };
+
+    match load_local_personal_secrets_from_paths(&paths, || {
+        super::env_vars::read_env_blob(workspace_path).map(Some)
+    }) {
+        Ok(blob) => {
+            println!(
+                "[OpenCode] Loaded {} personal secrets from local encrypted store",
+                blob.len()
+            );
+            (blob, Vec::new())
         }
         Err(e) => {
-            eprintln!("[OpenCode] Failed to read keychain blob: {}", e);
+            eprintln!(
+                "[OpenCode] Failed to read local encrypted secret blob: {}",
+                e
+            );
             (Vec::new(), vec!["__blob__".to_string()])
         }
     }
@@ -2054,6 +2088,71 @@ async fn get_server_paths(port: u16) -> (Option<String>, Option<String>) {
     }
 
     (None, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::local_secret_store::{self, SecretStorePaths};
+    use std::path::Path;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Mutex, OnceLock};
+    use tempfile::tempdir;
+
+    fn home_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct HomeGuard {
+        original_home: Option<std::ffi::OsString>,
+    }
+
+    impl HomeGuard {
+        fn set(path: &Path) -> Self {
+            let original_home = std::env::var_os("HOME");
+            std::env::set_var("HOME", path);
+            Self { original_home }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.original_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn load_local_personal_secrets_prefers_existing_encrypted_blob_without_legacy_read() {
+        let _home_guard = home_lock().lock().unwrap();
+        let home_dir = tempdir().unwrap();
+        let _home = HomeGuard::set(home_dir.path());
+        let paths = SecretStorePaths::for_home_dir().unwrap();
+
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "OPENAI_API_KEY".into(),
+            serde_json::Value::String("local-secret".into()),
+        );
+        map.insert("IGNORED".into(), serde_json::json!(123));
+        local_secret_store::write_secret_blob(&paths, &map).unwrap();
+
+        let legacy_reader_called = AtomicBool::new(false);
+        let secrets = load_local_personal_secrets_from_paths(&paths, || {
+            legacy_reader_called.store(true, Ordering::SeqCst);
+            Ok(Some(serde_json::Map::new()))
+        })
+        .unwrap();
+
+        assert_eq!(
+            secrets,
+            vec![("OPENAI_API_KEY".to_string(), "local-secret".to_string())]
+        );
+        assert!(!legacy_reader_called.load(Ordering::SeqCst));
+    }
 }
 
 /// Stop OpenCode sidecar(s) (production) or clear running state (dev).

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -634,11 +634,8 @@ pub async fn download_and_install_update<R: Runtime>(
     let pubkey = get_updater_pubkey();
     verify_signature(&bytes, &signature, pubkey)?;
 
-    // 3. Snapshot keychain env blob to disk before replacing the app bundle.
-    //    The current process still has keychain access (matching code signature).
-    //    After the bundle is replaced, the new binary's signature won't match the
-    //    keychain ACL, so this disk snapshot is the only way the new version can
-    //    recover secrets on first launch.
+    // 3. Snapshot legacy keychain env data only for installs that have not yet
+    //    migrated to the local encrypted blob. After migration this hook is a no-op.
     super::env_vars::snapshot_env_blob_to_disk();
 
     // 4. Install (extract tar.gz and replace .app bundle)


### PR DESCRIPTION
## Summary
- move personal env vars and provider API keys from OS keychain to a local encrypted secret store
- migrate legacy keychain and disk snapshot data into the encrypted blob while preserving team shared secrets behavior
- harden workspace-by-workspace legacy top-up and startup retry behavior during migration

## Test Plan
- cargo test --manifest-path src-tauri/Cargo.toml existing_blob_survives_legacy_reader_error_without_marking_complete -- --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml startup_retry_is_requested_when_teamclaw_json_is_invalid -- --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml commands::opencode::tests -- --nocapture