### PR TITLE
fix: make team member and WeCom flows workspace-aware

### DIFF
--- a/packages/app/src/__tests__/TeamMemberList.test.ts
+++ b/packages/app/src/__tests__/TeamMemberList.test.ts
@@ -9,8 +9,13 @@ vi.mock('@tauri-apps/api/event', () => ({
 }))
 
 vi.mock('@/stores/workspace', () => ({
-  useWorkspaceStore: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector({ workspacePath: '/tmp/test-workspace' }),
+  useWorkspaceStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) =>
+      selector({ workspacePath: '/tmp/test-workspace' }),
+    {
+      getState: () => ({ workspacePath: '/tmp/test-workspace' }),
+    },
+  ),
 }))
 
 vi.mock('@/stores/p2p-engine', () => ({
@@ -96,6 +101,21 @@ describe('TeamMemberList', () => {
     })
 
     expect(screen.getByText('Owner')).toBeDefined()
+  })
+
+  it('passes workspacePath to workspace-aware team commands', async () => {
+    const { TeamMemberList } = await import('../components/settings/TeamMemberList')
+
+    await act(async () => {
+      render(React.createElement(TeamMemberList))
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('unified_team_get_members', {
+      workspacePath: '/tmp/test-workspace',
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('unified_team_get_my_role', {
+      workspacePath: '/tmp/test-workspace',
+    })
   })
 
   it('shows Remove buttons when myRole=owner', async () => {

--- a/packages/app/src/stores/channels-store.ts
+++ b/packages/app/src/stores/channels-store.ts
@@ -29,6 +29,12 @@ import { createEmailActions } from './channels/email'
 import { createKookActions } from './channels/kook'
 import { createWecomActions } from './channels/wecom'
 import { createWechatActions } from './channels/wechat'
+import { useWorkspaceStore } from './workspace'
+
+function getWorkspaceArgs() {
+  const workspacePath = useWorkspaceStore.getState().workspacePath
+  return workspacePath ? { workspacePath } : {}
+}
 
 export const useChannelsStore = create<ChannelsState>((set) => ({
   // Discord initial state
@@ -138,8 +144,8 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
       let wecomConfig: WeComConfig | null = null
       let wecomStatus: WeComGatewayStatusResponse = { status: 'disconnected' }
       try {
-        wecomConfig = await invoke<WeComConfig | null>('get_wecom_config')
-        wecomStatus = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        wecomConfig = await invoke<WeComConfig | null>('get_wecom_config', getWorkspaceArgs())
+        wecomStatus = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
       } catch {
         // WeCom config may not exist yet
       }
@@ -220,7 +226,7 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
 
     if (state.wecomGatewayStatus.status !== 'disconnected') {
       try {
-        await invoke('stop_wecom_gateway')
+        await invoke('stop_wecom_gateway', getWorkspaceArgs())
       } catch (e) {
         console.warn('[Channels] Failed to stop WeCom gateway:', e)
       }
@@ -322,9 +328,9 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
     if (state.wecom?.enabled && state.wecomGatewayStatus.status === 'disconnected') {
       console.log('[AutoStart] Starting WeCom gateway...')
       try {
-        await invoke('start_wecom_gateway')
+        await invoke('start_wecom_gateway', getWorkspaceArgs())
         await new Promise((resolve) => setTimeout(resolve, 1000))
-        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
         set({ wecomGatewayStatus: status })
       } catch (error) {
         console.error('[AutoStart] WeCom start failed:', error)
@@ -367,7 +373,7 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
         invoke<FeishuGatewayStatusResponse>('get_feishu_gateway_status').catch(() => null),
         invoke<EmailGatewayStatusResponse>('get_email_gateway_status').catch(() => null),
         invoke<KookGatewayStatusResponse>('get_kook_gateway_status').catch(() => null),
-        invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status').catch(() => null),
+        invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs()).catch(() => null),
         invoke<WeChatGatewayStatusResponse>('get_wechat_gateway_status').catch(() => null),
       ])
       if (discordStatus) set({ gatewayStatus: discordStatus })
@@ -465,11 +471,11 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
     ) {
       console.log('[KeepAlive] WeCom is enabled but status=', updated.wecomGatewayStatus.status, '- restarting...')
       try {
-        await invoke('stop_wecom_gateway').catch(() => {})
+        await invoke('stop_wecom_gateway', getWorkspaceArgs()).catch(() => {})
         await new Promise((resolve) => setTimeout(resolve, 500))
-        await invoke('start_wecom_gateway')
+        await invoke('start_wecom_gateway', getWorkspaceArgs())
         await new Promise((resolve) => setTimeout(resolve, 1000))
-        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
         set({ wecomGatewayStatus: status })
         console.log('[KeepAlive] WeCom restarted, status=', status.status)
       } catch (error) {

--- a/packages/app/src/stores/channels/__tests__/wecom.test.ts
+++ b/packages/app/src/stores/channels/__tests__/wecom.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockInvoke = vi.hoisted(() => vi.fn())
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: {
+    getState: () => ({ workspacePath: '/tmp/test-workspace' }),
+  },
+}))
+
+describe('createWecomActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes workspacePath when loading config and status', async () => {
+    mockInvoke
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ status: 'disconnected' })
+
+    const { createWecomActions } = await import('../wecom')
+    const set = vi.fn()
+    const actions = createWecomActions(set)
+
+    await actions.loadWecomConfig()
+
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, 'get_wecom_config', {
+      workspacePath: '/tmp/test-workspace',
+    })
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, 'get_wecom_gateway_status', {
+      workspacePath: '/tmp/test-workspace',
+    })
+  })
+
+  it('passes workspacePath when starting and stopping the gateway', async () => {
+    mockInvoke
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ status: 'connected' })
+      .mockResolvedValueOnce(undefined)
+
+    const { createWecomActions } = await import('../wecom')
+    const set = vi.fn()
+    const actions = createWecomActions(set)
+
+    await actions.startWecomGateway()
+    await actions.stopWecomGateway()
+
+    expect(mockInvoke).toHaveBeenCalledWith('start_wecom_gateway', {
+      workspacePath: '/tmp/test-workspace',
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('get_wecom_gateway_status', {
+      workspacePath: '/tmp/test-workspace',
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('stop_wecom_gateway', {
+      workspacePath: '/tmp/test-workspace',
+    })
+  })
+})

--- a/packages/app/src/stores/channels/wecom.ts
+++ b/packages/app/src/stores/channels/wecom.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core'
+import { useWorkspaceStore } from '@/stores/workspace'
 import type {
   WeComConfig,
   WeComGatewayStatusResponse,
@@ -10,13 +11,18 @@ import { defaultWeComConfig } from '../channels-types'
 
 type ChannelsSet = (fn: ((state: ChannelsState) => Partial<ChannelsState>) | Partial<ChannelsState>) => void
 
+function getWorkspaceArgs() {
+  const workspacePath = useWorkspaceStore.getState().workspacePath
+  return workspacePath ? { workspacePath } : {}
+}
+
 export function createWecomActions(set: ChannelsSet) {
   return {
     loadWecomConfig: async () => {
       set({ wecomIsLoading: true })
       try {
-        const config = await invoke<WeComConfig | null>('get_wecom_config')
-        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        const config = await invoke<WeComConfig | null>('get_wecom_config', getWorkspaceArgs())
+        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
         set({
           wecom: config || defaultWeComConfig,
           wecomGatewayStatus: status,
@@ -30,7 +36,7 @@ export function createWecomActions(set: ChannelsSet) {
 
     saveWecomConfig: async (config: WeComConfig) => {
       try {
-        await invoke('save_wecom_config', { wecom: config })
+        await invoke('save_wecom_config', { wecom: config, ...getWorkspaceArgs() })
         set({ wecom: config, wecomHasChanges: false })
       } catch (e) {
         console.error('[WeCom] Failed to save config:', e)
@@ -39,8 +45,8 @@ export function createWecomActions(set: ChannelsSet) {
 
     startWecomGateway: async () => {
       try {
-        await invoke('start_wecom_gateway')
-        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        await invoke('start_wecom_gateway', getWorkspaceArgs())
+        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
         set({ wecomGatewayStatus: status })
       } catch (e) {
         console.error('[WeCom] Failed to start gateway:', e)
@@ -50,7 +56,7 @@ export function createWecomActions(set: ChannelsSet) {
 
     stopWecomGateway: async () => {
       try {
-        await invoke('stop_wecom_gateway')
+        await invoke('stop_wecom_gateway', getWorkspaceArgs())
         set({ wecomGatewayStatus: { status: 'disconnected' } })
       } catch (e) {
         console.error('[WeCom] Failed to stop gateway:', e)
@@ -59,7 +65,7 @@ export function createWecomActions(set: ChannelsSet) {
 
     refreshWecomStatus: async () => {
       try {
-        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
         set({ wecomGatewayStatus: status })
       } catch (e) {
         console.error('[WeCom] Failed to refresh status:', e)
@@ -91,16 +97,16 @@ export function createWecomActions(set: ChannelsSet) {
     setWecomHasChanges: (hasChanges: boolean) => set({ wecomHasChanges: hasChanges }),
 
     toggleWecomEnabled: async (enabled: boolean, config: WeComConfig) => {
-      const updatedConfig = { ...config, enabled }
+        const updatedConfig = { ...config, enabled }
       try {
-        await invoke('save_wecom_config', { wecom: updatedConfig })
+        await invoke('save_wecom_config', { wecom: updatedConfig, ...getWorkspaceArgs() })
         set({ wecom: updatedConfig })
         if (enabled) {
           set({ wecomIsLoading: true })
           try {
-            await invoke('start_wecom_gateway')
+            await invoke('start_wecom_gateway', getWorkspaceArgs())
             await new Promise((resolve) => setTimeout(resolve, 1000))
-            const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+            const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
             set({ wecomGatewayStatus: status, wecomIsLoading: false, wecomHasChanges: false })
           } catch (error) {
             console.error('[WeCom] Auto-start failed:', error)
@@ -108,7 +114,7 @@ export function createWecomActions(set: ChannelsSet) {
           }
         } else {
           try {
-            await invoke('stop_wecom_gateway')
+            await invoke('stop_wecom_gateway', getWorkspaceArgs())
             set({ wecomGatewayStatus: { status: 'disconnected' }, wecomHasChanges: false })
           } catch {
             // Ignore stop errors

--- a/packages/app/src/stores/team-members.ts
+++ b/packages/app/src/stores/team-members.ts
@@ -2,6 +2,7 @@
 import { create } from 'zustand'
 import { invoke } from '@tauri-apps/api/core'
 import type { TeamMember } from '../lib/git/types'
+import { useWorkspaceStore } from './workspace'
 
 type MemberRole = 'owner' | 'manager' | 'editor' | 'viewer'
 
@@ -39,6 +40,11 @@ interface TeamMembersState {
   reset: () => void
 }
 
+function getWorkspaceArgs() {
+  const workspacePath = useWorkspaceStore.getState().workspacePath
+  return workspacePath ? { workspacePath } : {}
+}
+
 export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
   members: [],
   myRole: null,
@@ -61,7 +67,7 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
   loadMembers: async () => {
     set({ loading: true, error: null })
     try {
-      const members = await invoke<TeamMember[]>('unified_team_get_members')
+      const members = await invoke<TeamMember[]>('unified_team_get_members', getWorkspaceArgs())
       set({ members, loading: false })
     } catch (e) {
       set({ error: String(e), loading: false })
@@ -70,7 +76,7 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
 
   loadMyRole: async () => {
     try {
-      const role = await invoke<MemberRole | null>('unified_team_get_my_role')
+      const role = await invoke<MemberRole | null>('unified_team_get_my_role', getWorkspaceArgs())
       set({ myRole: role })
     } catch {
       set({ myRole: null })
@@ -80,7 +86,7 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
   addMember: async (member: TeamMember) => {
     set({ error: null })
     try {
-      await invoke('unified_team_add_member', { member })
+      await invoke('unified_team_add_member', { member, ...getWorkspaceArgs() })
       await get().loadMembers()
     } catch (e) {
       set({ error: String(e) })
@@ -91,7 +97,7 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
   removeMember: async (nodeId: string) => {
     set({ error: null })
     try {
-      await invoke('unified_team_remove_member', { nodeId })
+      await invoke('unified_team_remove_member', { nodeId, ...getWorkspaceArgs() })
       await get().loadMembers()
     } catch (e) {
       set({ error: String(e) })
@@ -102,7 +108,7 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
   updateMemberRole: async (nodeId: string, role: MemberRole) => {
     set({ error: null })
     try {
-      await invoke('unified_team_update_member_role', { nodeId, role })
+      await invoke('unified_team_update_member_role', { nodeId, role, ...getWorkspaceArgs() })
       await get().loadMembers()
     } catch (e) {
       set({ error: String(e) })

--- a/src-tauri/crates/teamclaw-gateway/src/wecom.rs
+++ b/src-tauri/crates/teamclaw-gateway/src/wecom.rs
@@ -413,6 +413,14 @@ impl WeComGateway {
         *self.config.write().await = config;
     }
 
+    pub fn workspace_path(&self) -> &str {
+        &self.workspace_path
+    }
+
+    pub fn opencode_port(&self) -> u16 {
+        self.opencode_port
+    }
+
     pub async fn get_status(&self) -> WeComGatewayStatusResponse {
         let mut resp = self.status.read().await.clone();
         // Populate active sessions from session mapping

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -1798,21 +1798,28 @@ pub async fn test_kook_token(token: String) -> Result<String, String> {
 /// Get WeCom configuration
 #[tauri::command]
 pub async fn get_wecom_config(
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<wecom_config::WeComConfig, String> {
-    let channels = get_channel_config(opencode_state).await?;
-    Ok(channels.wecom.unwrap_or_default())
+    let workspace_path =
+        crate::commands::team::resolve_workspace_path(workspace_path, &opencode_state)?;
+    let config = read_config(&workspace_path)?;
+    Ok(config
+        .channels
+        .and_then(|channels| channels.wecom)
+        .unwrap_or_default())
 }
 
 /// Save WeCom configuration
 #[tauri::command]
 pub async fn save_wecom_config(
     wecom: wecom_config::WeComConfig,
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
     let workspace_path =
-        crate::commands::opencode::current_workspace_path(&opencode_state)?;
+        crate::commands::team::resolve_workspace_path(workspace_path, &opencode_state)?;
 
     let mut config = read_config(&workspace_path)?;
     let channels = config.channels.get_or_insert_with(ChannelsConfig::default);
@@ -1827,7 +1834,7 @@ pub async fn save_wecom_config(
         gateway.as_ref().map(|gw| gw.clone())
     };
 
-    if let Some(gw) = gateway_clone {
+    if let Some(gw) = gateway_clone.filter(|gw| gw.workspace_path() == workspace_path) {
         gw.set_config(wecom).await;
     }
 
@@ -1837,11 +1844,14 @@ pub async fn save_wecom_config(
 /// Start WeCom gateway
 #[tauri::command]
 pub async fn start_wecom_gateway(
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
-    let (workspace_path, port) =
-        crate::commands::opencode::resolve_workspace(&opencode_state, None)?;
+    let (workspace_path, port) = crate::commands::opencode::resolve_workspace(
+        &opencode_state,
+        workspace_path.as_deref(),
+    )?;
 
     println!(
         "[Gateway] start_wecom_gateway called, workspace={}",
@@ -1883,6 +1893,25 @@ pub async fn start_wecom_gateway(
     ensure_session_initialized(&gateway_state, &workspace_path).await;
 
     let gateway_clone = {
+        let guard = gateway_state
+            .wecom_gateway
+            .lock()
+            .map_err(|e| e.to_string())?;
+        guard.as_ref().map(|gw| gw.clone())
+    };
+
+    if let Some(gw) = gateway_clone.as_ref() {
+        if gw.workspace_path() != workspace_path || gw.opencode_port() != port {
+            gw.stop().await?;
+            let mut guard = gateway_state
+                .wecom_gateway
+                .lock()
+                .map_err(|e| e.to_string())?;
+            *guard = None;
+        }
+    }
+
+    let gateway_clone = {
         let mut guard = gateway_state
             .wecom_gateway
             .lock()
@@ -1910,7 +1939,14 @@ pub async fn start_wecom_gateway(
 
 /// Stop WeCom gateway
 #[tauri::command]
-pub async fn stop_wecom_gateway(gateway_state: State<'_, GatewayState>) -> Result<(), String> {
+pub async fn stop_wecom_gateway(
+    workspace_path: Option<String>,
+    opencode_state: State<'_, OpenCodeState>,
+    gateway_state: State<'_, GatewayState>,
+) -> Result<(), String> {
+    let resolved_workspace_path =
+        crate::commands::team::resolve_workspace_path(workspace_path, &opencode_state).ok();
+
     let gateway_clone = {
         let guard = gateway_state
             .wecom_gateway
@@ -1919,7 +1955,12 @@ pub async fn stop_wecom_gateway(gateway_state: State<'_, GatewayState>) -> Resul
         guard.as_ref().map(|gw| gw.clone())
     };
 
-    if let Some(gw) = gateway_clone {
+    if let Some(gw) = gateway_clone.filter(|gw| {
+        resolved_workspace_path
+            .as_ref()
+            .map(|path| gw.workspace_path() == path)
+            .unwrap_or(true)
+    }) {
         gw.stop().await?;
     }
 
@@ -1929,8 +1970,12 @@ pub async fn stop_wecom_gateway(gateway_state: State<'_, GatewayState>) -> Resul
 /// Get WeCom gateway status
 #[tauri::command]
 pub async fn get_wecom_gateway_status(
+    workspace_path: Option<String>,
+    opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<WeComGatewayStatusResponse, String> {
+    let workspace_path =
+        crate::commands::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let gateway_clone = {
         let guard = gateway_state
             .wecom_gateway
@@ -1939,7 +1984,7 @@ pub async fn get_wecom_gateway_status(
         guard.as_ref().map(|gw| gw.clone())
     };
 
-    if let Some(gw) = gateway_clone {
+    if let Some(gw) = gateway_clone.filter(|gw| gw.workspace_path() == workspace_path) {
         Ok(gw.get_status().await)
     } else {
         Ok(WeComGatewayStatusResponse::default())

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -231,11 +231,12 @@ fn write_git_manifest(workspace_path: &str, manifest: &TeamManifest) -> Result<(
 /// - Git: reads from teamclaw-team/_meta/members.json
 #[tauri::command]
 pub async fn unified_team_get_members(
+    workspace_path: Option<String>,
     opencode_state: State<'_, super::opencode::OpenCodeState>,
     oss_state: State<'_, super::oss_sync::OssSyncState>,
     iroh_state: State<'_, super::p2p_state::IrohState>,
 ) -> Result<Vec<TeamMember>, String> {
-    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let workspace_path = super::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let status = super::team::check_team_status(&workspace_path);
 
     match status.mode.as_deref() {
@@ -295,13 +296,14 @@ pub async fn unified_team_get_members(
 #[tauri::command]
 pub async fn unified_team_add_member(
     member: TeamMember,
+    workspace_path: Option<String>,
     opencode_state: State<'_, super::opencode::OpenCodeState>,
     oss_state: State<'_, super::oss_sync::OssSyncState>,
     iroh_state: State<'_, super::p2p_state::IrohState>,
 ) -> Result<(), String> {
     validate_node_id(&member.node_id)?;
 
-    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let workspace_path = super::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let status = super::team::check_team_status(&workspace_path);
 
     match status.mode.as_deref() {
@@ -402,11 +404,12 @@ pub async fn unified_team_add_member(
 #[tauri::command]
 pub async fn unified_team_remove_member(
     node_id: String,
+    workspace_path: Option<String>,
     opencode_state: State<'_, super::opencode::OpenCodeState>,
     oss_state: State<'_, super::oss_sync::OssSyncState>,
     iroh_state: State<'_, super::p2p_state::IrohState>,
 ) -> Result<(), String> {
-    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let workspace_path = super::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let status = super::team::check_team_status(&workspace_path);
 
     match status.mode.as_deref() {
@@ -527,11 +530,12 @@ pub async fn unified_team_remove_member(
 pub async fn unified_team_update_member_role(
     node_id: String,
     role: MemberRole,
+    workspace_path: Option<String>,
     opencode_state: State<'_, super::opencode::OpenCodeState>,
     oss_state: State<'_, super::oss_sync::OssSyncState>,
     iroh_state: State<'_, super::p2p_state::IrohState>,
 ) -> Result<(), String> {
-    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let workspace_path = super::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let status = super::team::check_team_status(&workspace_path);
 
     match status.mode.as_deref() {
@@ -575,11 +579,12 @@ pub async fn unified_team_update_member_role(
 /// Get the current device's role in the active team.
 #[tauri::command]
 pub async fn unified_team_get_my_role(
+    workspace_path: Option<String>,
     opencode_state: State<'_, super::opencode::OpenCodeState>,
     oss_state: State<'_, super::oss_sync::OssSyncState>,
     iroh_state: State<'_, super::p2p_state::IrohState>,
 ) -> Result<MemberRole, String> {
-    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let workspace_path = super::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let status = super::team::check_team_status(&workspace_path);
 
     match status.mode.as_deref() {


### PR DESCRIPTION
## Summary
- pass the active workspace path from the frontend for team member and WeCom channel operations
- update Tauri team and WeCom commands to resolve the explicit workspace instead of relying on the legacy single-instance fallback
- recreate and scope the WeCom gateway by workspace/port so multi-workspace sessions do not leak status or reuse the wrong gateway
- add targeted tests for team member calls and WeCom store workspace routing

## Testing
- pnpm --filter @teamclaw/app exec vitest run src/__tests__/TeamMemberList.test.ts
- pnpm --filter @teamclaw/app exec vitest run src/stores/channels/__tests__/wecom.test.ts src/components/settings/channels/__tests__/Wecom.test.tsx
- pnpm rust:check