### PR TITLE
fix(team): sync shared providers via _meta/provider.json

### DIFF
--- a/packages/app/src/__tests__/TeamMemberList.test.ts
+++ b/packages/app/src/__tests__/TeamMemberList.test.ts
@@ -9,8 +9,13 @@ vi.mock('@tauri-apps/api/event', () => ({
 }))
 
 vi.mock('@/stores/workspace', () => ({
-  useWorkspaceStore: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector({ workspacePath: '/tmp/test-workspace' }),
+  useWorkspaceStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) =>
+      selector({ workspacePath: '/tmp/test-workspace' }),
+    {
+      getState: () => ({ workspacePath: '/tmp/test-workspace' }),
+    },
+  ),
 }))
 
 vi.mock('@/stores/p2p-engine', () => ({
@@ -96,6 +101,21 @@ describe('TeamMemberList', () => {
     })
 
     expect(screen.getByText('Owner')).toBeDefined()
+  })
+
+  it('passes workspacePath to workspace-aware team commands', async () => {
+    const { TeamMemberList } = await import('../components/settings/TeamMemberList')
+
+    await act(async () => {
+      render(React.createElement(TeamMemberList))
+    })
+
+    expect(mockInvoke).toHaveBeenCalledWith('unified_team_get_members', {
+      workspacePath: '/tmp/test-workspace',
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('unified_team_get_my_role', {
+      workspacePath: '/tmp/test-workspace',
+    })
   })
 
   it('shows Remove buttons when myRole=owner', async () => {

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -340,10 +340,12 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     (async () => {
       const { listen } = await import('@tauri-apps/api/event');
       unlisten = await listen<{ path: string; kind: string }>('file-change', (event) => {
-        if (!event.payload.path.includes(`${TEAMCLAW_DIR}/${CONFIG_FILE_NAME}`)) return;
+        const isTeamConfigChange = event.payload.path.includes(`${TEAMCLAW_DIR}/${CONFIG_FILE_NAME}`);
+        const isProviderMetaChange = event.payload.path.includes(`${TEAM_REPO_DIR}/_meta/provider.json`);
+        if (!isTeamConfigChange && !isProviderMetaChange) return;
         if (debounceTimer) clearTimeout(debounceTimer);
         debounceTimer = setTimeout(async () => {
-          console.log('[TeamMode] teamclaw.json changed, reloading team config');
+          console.log('[TeamMode] Team config changed, reloading team config');
           const store = useTeamModeStore.getState();
           const wasTeamMode = store.teamMode;
           await store.loadTeamConfig(workspacePath);

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -31,6 +31,7 @@ import { HostLlmConfig } from './HostLlmConfig'
 import { useTeamMembersStore } from '@/stores/team-members'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { buildConfig, TEAM_SYNCED_EVENT, TEAM_REPO_DIR } from '@/lib/build-config'
+import { buildTeamProviderConfig, loadTeamProviderFormState, saveTeamProviderFile } from '@/lib/team-provider'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -252,17 +253,26 @@ export function TeamGitConfig() {
   // Load current LLM config when connected
   React.useEffect(() => {
     if ((state === 'connected' || state === 'syncing') && !llmLoaded && isTauri()) {
-      tauriInvoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status', workspaceArgs)
-        .then((status) => {
-          if (status.llm?.baseUrl) {
-            setHostLlm(true)
-            setLlmUrl(status.llm.baseUrl)
-            if (status.llm.models?.length) {
-              setLlmModels(status.llm.models)
-            } else if (status.llm.model) {
-              setLlmModels([{ id: status.llm.model, name: status.llm.modelName || status.llm.model }])
-            }
+      loadTeamProviderFormState(workspacePath!)
+        .then((providerState) => {
+          if (providerState) {
+            setHostLlm(providerState.enabled)
+            setLlmUrl(providerState.baseUrl)
+            setLlmModels(providerState.models)
+            return
           }
+          return tauriInvoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status', workspaceArgs)
+            .then((status) => {
+              if (status.llm?.baseUrl) {
+                setHostLlm(true)
+                setLlmUrl(status.llm.baseUrl)
+                if (status.llm.models?.length) {
+                  setLlmModels(status.llm.models)
+                } else if (status.llm.model) {
+                  setLlmModels([{ id: status.llm.model, name: status.llm.modelName || status.llm.model }])
+                }
+              }
+            })
         })
         .catch(() => {})
       setLlmLoaded(true)
@@ -289,6 +299,9 @@ export function TeamGitConfig() {
         llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
         ...workspaceArgs,
       })
+      if (workspacePath) {
+        await saveTeamProviderFile(workspacePath, buildTeamProviderConfig(hostLlm, llmUrl, llmModels), hostLlm ? llmModels[0]?.id : undefined)
+      }
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : String(err))
     } finally {
@@ -331,6 +344,9 @@ export function TeamGitConfig() {
         ...(gitBranch.trim() ? { gitBranch: gitBranch.trim() } : {}),
       }
       await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
+      if (workspacePath) {
+        await saveTeamProviderFile(workspacePath, buildTeamProviderConfig(hostLlm, llmUrl, llmModels), hostLlm ? llmModels[0]?.id : undefined)
+      }
 
       setTeamConfig(newConfig)
       setState('connected')
@@ -399,6 +415,9 @@ export function TeamGitConfig() {
         ...(gitBranch.trim() ? { gitBranch: gitBranch.trim() } : {}),
       }
       await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
+      if (workspacePath) {
+        await saveTeamProviderFile(workspacePath, buildTeamProviderConfig(hostLlm, llmUrl, llmModels), hostLlm ? llmModels[0]?.id : undefined)
+      }
       setTeamConfig(newConfig)
       setCreatedTeamId(result.teamId)
       setCreatedTeamSecret(result.teamSecret)
@@ -479,6 +498,9 @@ export function TeamGitConfig() {
         ...(gitBranch.trim() ? { gitBranch: gitBranch.trim() } : {}),
       }
       await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
+      if (workspacePath) {
+        await saveTeamProviderFile(workspacePath, buildTeamProviderConfig(hostLlm, llmUrl, llmModels), hostLlm ? llmModels[0]?.id : undefined)
+      }
       setTeamConfig(newConfig)
       setState('connected')
 

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -11,6 +11,7 @@ import { TeamMemberList } from '@/components/settings/TeamMemberList'
 import { VersionHistorySection } from './VersionHistorySection'
 import { invoke } from '@tauri-apps/api/core'
 import { buildConfig } from '@/lib/build-config'
+import { buildTeamProviderConfig, loadTeamProviderFormState, saveTeamProviderFile } from '@/lib/team-provider'
 import type { DeviceInfo } from '@/lib/git/types'
 import { useTeamModeStore } from '@/stores/team-mode'
 import { useProviderStore } from '@/stores/provider'
@@ -149,17 +150,26 @@ export function TeamOSSConfig() {
             if (config) setCfgFcEndpoint(config.teamEndpoint || '')
           })
           .catch(() => {})
-        invoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status', { workspacePath })
-          .then((status) => {
-            if (status.llm?.baseUrl) {
-              setCfgHostLlm(true)
-              setCfgLlmUrl(status.llm.baseUrl)
-              if (status.llm.models?.length) {
-                setCfgLlmModels(status.llm.models)
-              } else if (status.llm.model) {
-                setCfgLlmModels([{ id: status.llm.model, name: status.llm.modelName || status.llm.model }])
-              }
+        loadTeamProviderFormState(workspacePath)
+          .then((providerState) => {
+            if (providerState) {
+              setCfgHostLlm(providerState.enabled)
+              setCfgLlmUrl(providerState.baseUrl)
+              setCfgLlmModels(providerState.models)
+              return
             }
+            return invoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status', { workspacePath })
+              .then((status) => {
+                if (status.llm?.baseUrl) {
+                  setCfgHostLlm(true)
+                  setCfgLlmUrl(status.llm.baseUrl)
+                  if (status.llm.models?.length) {
+                    setCfgLlmModels(status.llm.models)
+                  } else if (status.llm.model) {
+                    setCfgLlmModels([{ id: status.llm.model, name: status.llm.modelName || status.llm.model }])
+                  }
+                }
+              })
           })
           .catch(() => {})
         setCfgLoaded(true)
@@ -188,6 +198,11 @@ export function TeamOSSConfig() {
         llmModelName: createHostLlm ? (createLlmModels[0]?.name || undefined) : undefined,
         llmModels: createHostLlm && createLlmModels.length > 0 ? JSON.stringify(createLlmModels) : undefined,
       })
+      await saveTeamProviderFile(
+        workspacePath,
+        buildTeamProviderConfig(createHostLlm, createLlmUrl, createLlmModels),
+        createHostLlm ? createLlmModels[0]?.id : undefined,
+      )
       setTeamName('')
       setOwnerName('')
       setOwnerEmail('')
@@ -297,6 +312,11 @@ export function TeamOSSConfig() {
         llmModelName: cfgHostLlm ? (cfgLlmModels[0]?.name || undefined) : undefined,
         llmModels: cfgHostLlm && cfgLlmModels.length > 0 ? JSON.stringify(cfgLlmModels) : undefined,
       })
+      await saveTeamProviderFile(
+        workspacePath,
+        buildTeamProviderConfig(cfgHostLlm, cfgLlmUrl, cfgLlmModels),
+        cfgHostLlm ? cfgLlmModels[0]?.id : undefined,
+      )
     } catch {
       // error is set in the store
     } finally {

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -24,6 +24,7 @@ import { HostLlmConfig } from './HostLlmConfig'
 import { cn, isTauri, copyToClipboard } from '@/lib/utils'
 import { toast } from 'sonner'
 import { buildConfig, TEAMCLAW_DIR, TEAM_REPO_DIR } from '@/lib/build-config'
+import { buildTeamProviderConfig, loadTeamProviderFormState, saveTeamProviderFile } from '@/lib/team-provider'
 import { useTeamModeStore } from '@/stores/team-mode'
 import { useP2pEngineStore } from '@/stores/p2p-engine'
 import { useTeamMembersStore } from '@/stores/team-members'
@@ -195,14 +196,21 @@ export function TeamP2PConfig() {
         // Load current LLM config for editing
         if (!cfgLoaded) {
           try {
-            const status = await tauriInvoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status', { workspacePath })
-            if (status.llm?.baseUrl) {
-              setCfgHostLlm(true)
-              setCfgLlmUrl(status.llm.baseUrl)
-              if (status.llm.models?.length) {
-                setCfgLlmModels(status.llm.models)
-              } else if (status.llm.model) {
-                setCfgLlmModels([{ id: status.llm.model, name: status.llm.modelName || status.llm.model }])
+            const providerState = await loadTeamProviderFormState(workspacePath)
+            if (providerState) {
+              setCfgHostLlm(providerState.enabled)
+              setCfgLlmUrl(providerState.baseUrl)
+              setCfgLlmModels(providerState.models)
+            } else {
+              const status = await tauriInvoke<{ active: boolean; llm?: { baseUrl: string; model?: string; modelName?: string; models?: Array<{ id: string; name: string }> } }>('get_team_status', { workspacePath })
+              if (status.llm?.baseUrl) {
+                setCfgHostLlm(true)
+                setCfgLlmUrl(status.llm.baseUrl)
+                if (status.llm.models?.length) {
+                  setCfgLlmModels(status.llm.models)
+                } else if (status.llm.model) {
+                  setCfgLlmModels([{ id: status.llm.model, name: status.llm.modelName || status.llm.model }])
+                }
               }
             }
           } catch { /* ignore */ }
@@ -351,6 +359,13 @@ export function TeamP2PConfig() {
         llmModelName: createHostLlm ? (createLlmModels[0]?.name || null) : null,
         llmModels: createHostLlm && createLlmModels.length > 0 ? JSON.stringify(createLlmModels) : null,
       })
+      if (workspacePath) {
+        await saveTeamProviderFile(
+          workspacePath,
+          buildTeamProviderConfig(createHostLlm, createLlmUrl, createLlmModels),
+          createHostLlm ? createLlmModels[0]?.id : undefined,
+        )
+      }
       await loadSyncStatus()
       useWorkspaceStore.getState().refreshFileTree()
       if (workspacePath) {
@@ -414,6 +429,13 @@ export function TeamP2PConfig() {
         llmModels: cfgHostLlm && cfgLlmModels.length > 0 ? JSON.stringify(cfgLlmModels) : null,
         workspacePath,
       })
+      if (workspacePath) {
+        await saveTeamProviderFile(
+          workspacePath,
+          buildTeamProviderConfig(cfgHostLlm, cfgLlmUrl, cfgLlmModels),
+          cfgHostLlm ? cfgLlmModels[0]?.id : undefined,
+        )
+      }
     } catch (err) {
       setP2pError(err instanceof Error ? err.message : String(err))
     } finally {

--- a/packages/app/src/lib/__tests__/team-provider.test.ts
+++ b/packages/app/src/lib/__tests__/team-provider.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockExists = vi.fn()
+const mockMkdir = vi.fn()
+const mockReadTextFile = vi.fn()
+const mockWriteTextFile = vi.fn()
+const mockRemove = vi.fn()
+const mockAddCustomProviderToConfig = vi.fn()
+const mockRemoveCustomProviderFromConfig = vi.fn()
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  exists: mockExists,
+  mkdir: mockMkdir,
+  readTextFile: mockReadTextFile,
+  writeTextFile: mockWriteTextFile,
+  remove: mockRemove,
+}))
+
+vi.mock('@/lib/opencode/config', () => ({
+  addCustomProviderToConfig: mockAddCustomProviderToConfig,
+  removeCustomProviderFromConfig: mockRemoveCustomProviderFromConfig,
+}))
+
+vi.mock('@/lib/build-config', () => ({
+  TEAM_REPO_DIR: 'teamclaw-team',
+}))
+
+describe('team provider file helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExists.mockResolvedValue(false)
+    mockMkdir.mockResolvedValue(undefined)
+    mockReadTextFile.mockResolvedValue('')
+    mockWriteTextFile.mockResolvedValue(undefined)
+    mockRemove.mockResolvedValue(undefined)
+    mockAddCustomProviderToConfig.mockResolvedValue('team')
+    mockRemoveCustomProviderFromConfig.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('creates _meta/provider.json for the shared team provider', async () => {
+    const { saveTeamProviderFile } = await import('@/lib/team-provider')
+
+    await saveTeamProviderFile(
+      '/workspace',
+      {
+        name: 'Team',
+        baseURL: 'https://ai.ucar.cc',
+        apiKey: '${tc_api_key}',
+        models: [
+          { modelId: 'default', modelName: 'Default' },
+          { modelId: 'pro', modelName: 'Pro' },
+        ],
+      },
+      'default',
+    )
+
+    expect(mockExists).toHaveBeenCalledWith('/workspace/teamclaw-team/_meta')
+    expect(mockMkdir).toHaveBeenCalledWith('/workspace/teamclaw-team/_meta', { recursive: true })
+    expect(mockWriteTextFile).toHaveBeenCalledWith(
+      '/workspace/teamclaw-team/_meta/provider.json',
+      JSON.stringify({
+        version: 1,
+        provider: {
+          id: 'team',
+          name: 'Team',
+          baseURL: 'https://ai.ucar.cc',
+          apiKey: '${tc_api_key}',
+          defaultModel: 'default',
+          models: [
+            { id: 'default', name: 'Default' },
+            { id: 'pro', name: 'Pro' },
+          ],
+        },
+      }, null, 2),
+    )
+  })
+
+  it('syncs provider.json into workspace opencode.json', async () => {
+    mockExists.mockImplementation(async (path: string) => path === '/workspace/teamclaw-team/_meta/provider.json')
+    mockReadTextFile.mockResolvedValue(JSON.stringify({
+      version: 1,
+      provider: {
+        id: 'team',
+        name: 'Team',
+        baseURL: 'https://ai.ucar.cc',
+        apiKey: '${tc_api_key}',
+        defaultModel: 'pro',
+        models: [
+          { id: 'default', name: 'Default' },
+          { id: 'pro', name: 'Pro' },
+        ],
+      },
+    }))
+
+    const { syncTeamProviderToOpenCode } = await import('@/lib/team-provider')
+    const result = await syncTeamProviderToOpenCode('/workspace')
+
+    expect(result?.provider.baseURL).toBe('https://ai.ucar.cc')
+    expect(mockAddCustomProviderToConfig).toHaveBeenCalledWith('/workspace', {
+      name: 'Team',
+      baseURL: 'https://ai.ucar.cc',
+      apiKey: '${tc_api_key}',
+      models: [
+        { modelId: 'default', modelName: 'Default', limit: { context: 256000, output: 16000 } },
+        { modelId: 'pro', modelName: 'Pro', limit: { context: 256000, output: 16000 } },
+      ],
+    })
+  })
+
+  it('removes the shared provider from opencode.json when provider.json is absent', async () => {
+    const { syncTeamProviderToOpenCode } = await import('@/lib/team-provider')
+    const result = await syncTeamProviderToOpenCode('/workspace')
+
+    expect(result).toBeNull()
+    expect(mockRemoveCustomProviderFromConfig).toHaveBeenCalledWith('/workspace', 'team')
+  })
+})

--- a/packages/app/src/lib/team-provider.ts
+++ b/packages/app/src/lib/team-provider.ts
@@ -1,0 +1,163 @@
+import { exists, mkdir, readTextFile, remove, writeTextFile } from '@tauri-apps/plugin-fs'
+import { TEAM_REPO_DIR } from '@/lib/build-config'
+import {
+  addCustomProviderToConfig,
+  removeCustomProviderFromConfig,
+  type CustomProviderConfig,
+} from '@/lib/opencode/config'
+
+export const TEAM_SHARED_PROVIDER_ID = 'team'
+
+export interface TeamProviderModelEntry {
+  id: string
+  name: string
+}
+
+export interface TeamProviderFile {
+  version: 1
+  provider: {
+    id: string
+    name: string
+    baseURL: string
+    apiKey: string
+    defaultModel?: string
+    models: TeamProviderModelEntry[]
+  }
+}
+
+export interface TeamProviderFormState {
+  enabled: boolean
+  baseUrl: string
+  models: TeamProviderModelEntry[]
+  defaultModel?: string
+}
+
+function teamProviderFilePath(workspacePath: string): string {
+  return `${workspacePath}/${TEAM_REPO_DIR}/_meta/provider.json`
+}
+
+function teamProviderMetaDir(workspacePath: string): string {
+  return `${workspacePath}/${TEAM_REPO_DIR}/_meta`
+}
+
+function isValidTeamProviderFile(value: unknown): value is TeamProviderFile {
+  if (!value || typeof value !== 'object') return false
+  const provider = (value as any).provider
+  return (
+    (value as any).version === 1 &&
+    provider &&
+    typeof provider.id === 'string' &&
+    typeof provider.name === 'string' &&
+    typeof provider.baseURL === 'string' &&
+    typeof provider.apiKey === 'string' &&
+    Array.isArray(provider.models)
+  )
+}
+
+export async function loadTeamProviderFile(workspacePath: string): Promise<TeamProviderFile | null> {
+  const path = teamProviderFilePath(workspacePath)
+  if (!(await exists(path))) return null
+
+  try {
+    const content = await readTextFile(path)
+    const parsed = JSON.parse(content) as unknown
+    if (!isValidTeamProviderFile(parsed)) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export async function saveTeamProviderFile(
+  workspacePath: string,
+  provider: CustomProviderConfig | null,
+  defaultModel?: string,
+): Promise<void> {
+  const path = teamProviderFilePath(workspacePath)
+  if (!provider) {
+    if (await exists(path)) {
+      await remove(path)
+    }
+    return
+  }
+
+  const metaDir = teamProviderMetaDir(workspacePath)
+  if (!(await exists(metaDir))) {
+    await mkdir(metaDir, { recursive: true })
+  }
+
+  const file: TeamProviderFile = {
+    version: 1,
+    provider: {
+      id: TEAM_SHARED_PROVIDER_ID,
+      name: provider.name,
+      baseURL: provider.baseURL,
+      apiKey: provider.apiKey || '${tc_api_key}',
+      defaultModel,
+      models: provider.models.map((model) => ({
+        id: model.modelId,
+        name: model.modelName || model.modelId,
+      })),
+    },
+  }
+
+  await writeTextFile(path, JSON.stringify(file, null, 2))
+}
+
+export async function syncTeamProviderToOpenCode(workspacePath: string): Promise<TeamProviderFile | null> {
+  const providerFile = await loadTeamProviderFile(workspacePath)
+  if (!providerFile) {
+    await removeCustomProviderFromConfig(workspacePath, TEAM_SHARED_PROVIDER_ID)
+    return null
+  }
+
+  await addCustomProviderToConfig(workspacePath, {
+    name: providerFile.provider.name,
+    baseURL: providerFile.provider.baseURL,
+    apiKey: providerFile.provider.apiKey,
+    models: providerFile.provider.models.map((model) => ({
+      modelId: model.id,
+      modelName: model.name,
+      limit: { context: 256000, output: 16000 },
+    })),
+  })
+
+  return providerFile
+}
+
+export async function loadTeamProviderFormState(workspacePath: string): Promise<TeamProviderFormState | null> {
+  const providerFile = await loadTeamProviderFile(workspacePath)
+  if (!providerFile) return null
+
+  return {
+    enabled: true,
+    baseUrl: providerFile.provider.baseURL,
+    models: providerFile.provider.models,
+    defaultModel: providerFile.provider.defaultModel,
+  }
+}
+
+export function buildTeamProviderConfig(
+  enabled: boolean,
+  baseUrl: string,
+  models: TeamProviderModelEntry[],
+): CustomProviderConfig | null {
+  if (!enabled) return null
+  if (!baseUrl.trim()) return null
+
+  const normalizedModels = models
+    .map((model) => ({
+      modelId: model.id.trim(),
+      modelName: model.name.trim() || model.id.trim(),
+    }))
+    .filter((model) => model.modelId)
+
+  if (normalizedModels.length === 0) return null
+
+  return {
+    name: 'Team',
+    baseURL: baseUrl.trim(),
+    apiKey: '${tc_api_key}',
+    models: normalizedModels,
+  }
+}

--- a/packages/app/src/stores/__tests__/cron.test.ts
+++ b/packages/app/src/stores/__tests__/cron.test.ts
@@ -6,6 +6,12 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
 }))
 
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: {
+    getState: () => ({ workspacePath: '/test/workspace' }),
+  },
+}))
+
 vi.mock('@/lib/store-utils', () => ({
   withAsync: async (set: any, fn: any, opts?: any) => {
     set({ isLoading: true, error: null })
@@ -46,8 +52,9 @@ describe('cron store', () => {
   it('init calls cron_init and loads jobs', async () => {
     mockInvoke.mockResolvedValueOnce(undefined) // cron_init
     mockInvoke.mockResolvedValueOnce([]) // cron_list_jobs via loadJobs
+    mockInvoke.mockResolvedValueOnce([]) // cron_get_all_session_ids via loadCronSessionIds
     await useCronStore.getState().init()
-    expect(mockInvoke).toHaveBeenCalledWith('cron_init')
+    expect(mockInvoke).toHaveBeenCalledWith('cron_init', { workspacePath: '/test/workspace' })
     expect(useCronStore.getState().isInitialized).toBe(true)
   })
 
@@ -251,6 +258,7 @@ describe('cron store actions', () => {
     const job = await useCronStore.getState().addJob(baseRequest)
     expect(job).toEqual(mockJob)
     expect(useCronStore.getState().jobs).toContainEqual(mockJob)
+    expect(mockInvoke).toHaveBeenCalledWith('cron_add_job', { request: baseRequest, workspacePath: '/test/workspace' })
   })
 
   it('addJob propagates errors', async () => {
@@ -266,6 +274,10 @@ describe('cron store actions', () => {
     const result = await useCronStore.getState().updateJob({ id: 'job-1', name: 'Updated Job' })
     expect(result.name).toBe('Updated Job')
     expect(useCronStore.getState().jobs[0].name).toBe('Updated Job')
+    expect(mockInvoke).toHaveBeenCalledWith('cron_update_job', {
+      request: { id: 'job-1', name: 'Updated Job' },
+      workspacePath: '/test/workspace',
+    })
   })
 
   it('removeJob removes the job from state', async () => {
@@ -273,6 +285,7 @@ describe('cron store actions', () => {
     mockInvoke.mockResolvedValueOnce(undefined)
     await useCronStore.getState().removeJob('job-1')
     expect(useCronStore.getState().jobs).toHaveLength(0)
+    expect(mockInvoke).toHaveBeenCalledWith('cron_remove_job', { jobId: 'job-1', workspacePath: '/test/workspace' })
   })
 
   it('removeJob clears selectedJobId when the removed job was selected', async () => {
@@ -287,6 +300,11 @@ describe('cron store actions', () => {
     mockInvoke.mockResolvedValueOnce(undefined)
     await useCronStore.getState().toggleEnabled('job-1', false)
     expect(useCronStore.getState().jobs[0].enabled).toBe(false)
+    expect(mockInvoke).toHaveBeenCalledWith('cron_toggle_enabled', {
+      jobId: 'job-1',
+      enabled: false,
+      workspacePath: '/test/workspace',
+    })
   })
 
   it('loadRuns populates runs and sets selectedJobId', async () => {
@@ -296,12 +314,18 @@ describe('cron store actions', () => {
     expect(useCronStore.getState().runs).toEqual(runs)
     expect(useCronStore.getState().selectedJobId).toBe('job-1')
     expect(useCronStore.getState().runsLoading).toBe(false)
+    expect(mockInvoke).toHaveBeenCalledWith('cron_get_runs', {
+      jobId: 'job-1',
+      limit: 50,
+      workspacePath: '/test/workspace',
+    })
   })
 
   it('loadJobs sets jobs from backend', async () => {
     mockInvoke.mockResolvedValueOnce([mockJob])
     await useCronStore.getState().loadJobs()
     expect(useCronStore.getState().jobs).toEqual([mockJob])
+    expect(mockInvoke).toHaveBeenCalledWith('cron_list_jobs', { workspacePath: '/test/workspace' })
   })
 
   it('reinit resets initialized flag and reloads jobs', async () => {
@@ -311,6 +335,26 @@ describe('cron store actions', () => {
     mockInvoke.mockResolvedValueOnce([]) // cron_get_all_session_ids
     await useCronStore.getState().reinit()
     expect(useCronStore.getState().isInitialized).toBe(true)
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, 'cron_init', { workspacePath: '/test/workspace' })
+  })
+
+  it('runJob passes workspacePath', async () => {
+    mockInvoke.mockResolvedValueOnce(undefined)
+    await useCronStore.getState().runJob('job-1')
+    expect(mockInvoke).toHaveBeenCalledWith('cron_run_job', { jobId: 'job-1', workspacePath: '/test/workspace' })
+  })
+
+  it('loadCronSessionIds passes workspacePath', async () => {
+    mockInvoke.mockResolvedValueOnce(['sess-1'])
+    await useCronStore.getState().loadCronSessionIds()
+    expect(mockInvoke).toHaveBeenCalledWith('cron_get_all_session_ids', { workspacePath: '/test/workspace' })
+    expect(useCronStore.getState().cronSessionIds).toEqual(new Set(['sess-1']))
+  })
+
+  it('refreshDelivery passes workspacePath', async () => {
+    mockInvoke.mockResolvedValueOnce(undefined)
+    await useCronStore.getState().refreshDelivery()
+    expect(mockInvoke).toHaveBeenCalledWith('cron_refresh_delivery', { workspacePath: '/test/workspace' })
   })
 
   it('toggleShowCronSessions flips the flag', () => {

--- a/packages/app/src/stores/__tests__/team-mode-git-file-status.test.ts
+++ b/packages/app/src/stores/__tests__/team-mode-git-file-status.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockInvoke = vi.fn()
+const mockSyncTeamProviderToOpenCode = vi.fn()
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
@@ -16,8 +17,23 @@ vi.mock('@/lib/opencode/config', () => ({
   removeCustomProviderFromConfig: vi.fn(),
 }))
 
+vi.mock('@/lib/team-provider', () => ({
+  TEAM_SHARED_PROVIDER_ID: 'team',
+  syncTeamProviderToOpenCode: mockSyncTeamProviderToOpenCode,
+}))
+
 vi.mock('@/stores/provider', () => ({
-  useProviderStore: { getState: () => ({}) },
+  useProviderStore: {
+    getState: () => ({
+      currentModelKey: null,
+      selectModel: vi.fn().mockResolvedValue(undefined),
+      refreshConfiguredProviders: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}))
+
+vi.mock('@/lib/opencode/sdk-client', () => ({
+  initOpenCodeClient: vi.fn(),
 }))
 
 vi.mock('@/lib/build-config', () => ({
@@ -28,6 +44,8 @@ vi.mock('@/lib/build-config', () => ({
 
 beforeEach(() => {
   mockInvoke.mockReset()
+  mockSyncTeamProviderToOpenCode.mockReset()
+  mockSyncTeamProviderToOpenCode.mockResolvedValue(null)
 })
 
 describe('loadTeamGitFileSyncStatus', () => {
@@ -80,5 +98,45 @@ describe('loadTeamGitFileSyncStatus', () => {
     useTeamModeStore.setState({ teamGitFileSyncStatusMap: { 'x.md': 'modified' } })
     await useTeamModeStore.getState().clearTeamMode()
     expect(useTeamModeStore.getState().teamGitFileSyncStatusMap).toEqual({})
+  })
+
+  it('applies provider.json when present before falling back to legacy llm config', async () => {
+    mockSyncTeamProviderToOpenCode.mockResolvedValueOnce({
+      version: 1,
+      provider: {
+        id: 'team',
+        name: 'Team',
+        baseURL: 'https://ai.ucar.cc',
+        apiKey: '${tc_api_key}',
+        defaultModel: 'pro',
+        models: [
+          { id: 'default', name: 'Default' },
+          { id: 'pro', name: 'Pro' },
+        ],
+      },
+    })
+
+    const { useTeamModeStore } = await import('@/stores/team-mode')
+    useTeamModeStore.setState({
+      teamModelConfig: {
+        baseUrl: 'https://legacy.example.com',
+        model: 'legacy',
+        modelName: 'Legacy',
+      },
+      teamModelOptions: [],
+    })
+
+    await useTeamModeStore.getState().applyTeamModelToOpenCode('/ws')
+
+    expect(mockSyncTeamProviderToOpenCode).toHaveBeenCalledWith('/ws')
+    expect(useTeamModeStore.getState().teamModelConfig).toEqual({
+      baseUrl: 'https://ai.ucar.cc',
+      model: 'pro',
+      modelName: 'Pro',
+    })
+    expect(useTeamModeStore.getState().teamModelOptions).toEqual([
+      { id: 'default', name: 'Default' },
+      { id: 'pro', name: 'Pro' },
+    ])
   })
 })

--- a/packages/app/src/stores/channels-store.ts
+++ b/packages/app/src/stores/channels-store.ts
@@ -29,6 +29,12 @@ import { createEmailActions } from './channels/email'
 import { createKookActions } from './channels/kook'
 import { createWecomActions } from './channels/wecom'
 import { createWechatActions } from './channels/wechat'
+import { useWorkspaceStore } from './workspace'
+
+function getWorkspaceArgs() {
+  const workspacePath = useWorkspaceStore.getState().workspacePath
+  return workspacePath ? { workspacePath } : {}
+}
 
 export const useChannelsStore = create<ChannelsState>((set) => ({
   // Discord initial state
@@ -138,8 +144,8 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
       let wecomConfig: WeComConfig | null = null
       let wecomStatus: WeComGatewayStatusResponse = { status: 'disconnected' }
       try {
-        wecomConfig = await invoke<WeComConfig | null>('get_wecom_config')
-        wecomStatus = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        wecomConfig = await invoke<WeComConfig | null>('get_wecom_config', getWorkspaceArgs())
+        wecomStatus = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
       } catch {
         // WeCom config may not exist yet
       }
@@ -220,7 +226,7 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
 
     if (state.wecomGatewayStatus.status !== 'disconnected') {
       try {
-        await invoke('stop_wecom_gateway')
+        await invoke('stop_wecom_gateway', getWorkspaceArgs())
       } catch (e) {
         console.warn('[Channels] Failed to stop WeCom gateway:', e)
       }
@@ -322,9 +328,9 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
     if (state.wecom?.enabled && state.wecomGatewayStatus.status === 'disconnected') {
       console.log('[AutoStart] Starting WeCom gateway...')
       try {
-        await invoke('start_wecom_gateway')
+        await invoke('start_wecom_gateway', getWorkspaceArgs())
         await new Promise((resolve) => setTimeout(resolve, 1000))
-        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
         set({ wecomGatewayStatus: status })
       } catch (error) {
         console.error('[AutoStart] WeCom start failed:', error)
@@ -367,7 +373,7 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
         invoke<FeishuGatewayStatusResponse>('get_feishu_gateway_status').catch(() => null),
         invoke<EmailGatewayStatusResponse>('get_email_gateway_status').catch(() => null),
         invoke<KookGatewayStatusResponse>('get_kook_gateway_status').catch(() => null),
-        invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status').catch(() => null),
+        invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs()).catch(() => null),
         invoke<WeChatGatewayStatusResponse>('get_wechat_gateway_status').catch(() => null),
       ])
       if (discordStatus) set({ gatewayStatus: discordStatus })
@@ -465,11 +471,11 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
     ) {
       console.log('[KeepAlive] WeCom is enabled but status=', updated.wecomGatewayStatus.status, '- restarting...')
       try {
-        await invoke('stop_wecom_gateway').catch(() => {})
+        await invoke('stop_wecom_gateway', getWorkspaceArgs()).catch(() => {})
         await new Promise((resolve) => setTimeout(resolve, 500))
-        await invoke('start_wecom_gateway')
+        await invoke('start_wecom_gateway', getWorkspaceArgs())
         await new Promise((resolve) => setTimeout(resolve, 1000))
-        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
         set({ wecomGatewayStatus: status })
         console.log('[KeepAlive] WeCom restarted, status=', status.status)
       } catch (error) {

--- a/packages/app/src/stores/channels/__tests__/wecom.test.ts
+++ b/packages/app/src/stores/channels/__tests__/wecom.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockInvoke = vi.hoisted(() => vi.fn())
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: {
+    getState: () => ({ workspacePath: '/tmp/test-workspace' }),
+  },
+}))
+
+describe('createWecomActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes workspacePath when loading config and status', async () => {
+    mockInvoke
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ status: 'disconnected' })
+
+    const { createWecomActions } = await import('../wecom')
+    const set = vi.fn()
+    const actions = createWecomActions(set)
+
+    await actions.loadWecomConfig()
+
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, 'get_wecom_config', {
+      workspacePath: '/tmp/test-workspace',
+    })
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, 'get_wecom_gateway_status', {
+      workspacePath: '/tmp/test-workspace',
+    })
+  })
+
+  it('passes workspacePath when starting and stopping the gateway', async () => {
+    mockInvoke
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ status: 'connected' })
+      .mockResolvedValueOnce(undefined)
+
+    const { createWecomActions } = await import('../wecom')
+    const set = vi.fn()
+    const actions = createWecomActions(set)
+
+    await actions.startWecomGateway()
+    await actions.stopWecomGateway()
+
+    expect(mockInvoke).toHaveBeenCalledWith('start_wecom_gateway', {
+      workspacePath: '/tmp/test-workspace',
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('get_wecom_gateway_status', {
+      workspacePath: '/tmp/test-workspace',
+    })
+    expect(mockInvoke).toHaveBeenCalledWith('stop_wecom_gateway', {
+      workspacePath: '/tmp/test-workspace',
+    })
+  })
+})

--- a/packages/app/src/stores/channels/wecom.ts
+++ b/packages/app/src/stores/channels/wecom.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core'
+import { useWorkspaceStore } from '@/stores/workspace'
 import type {
   WeComConfig,
   WeComGatewayStatusResponse,
@@ -10,13 +11,18 @@ import { defaultWeComConfig } from '../channels-types'
 
 type ChannelsSet = (fn: ((state: ChannelsState) => Partial<ChannelsState>) | Partial<ChannelsState>) => void
 
+function getWorkspaceArgs() {
+  const workspacePath = useWorkspaceStore.getState().workspacePath
+  return workspacePath ? { workspacePath } : {}
+}
+
 export function createWecomActions(set: ChannelsSet) {
   return {
     loadWecomConfig: async () => {
       set({ wecomIsLoading: true })
       try {
-        const config = await invoke<WeComConfig | null>('get_wecom_config')
-        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        const config = await invoke<WeComConfig | null>('get_wecom_config', getWorkspaceArgs())
+        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
         set({
           wecom: config || defaultWeComConfig,
           wecomGatewayStatus: status,
@@ -30,7 +36,7 @@ export function createWecomActions(set: ChannelsSet) {
 
     saveWecomConfig: async (config: WeComConfig) => {
       try {
-        await invoke('save_wecom_config', { wecom: config })
+        await invoke('save_wecom_config', { wecom: config, ...getWorkspaceArgs() })
         set({ wecom: config, wecomHasChanges: false })
       } catch (e) {
         console.error('[WeCom] Failed to save config:', e)
@@ -39,8 +45,8 @@ export function createWecomActions(set: ChannelsSet) {
 
     startWecomGateway: async () => {
       try {
-        await invoke('start_wecom_gateway')
-        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        await invoke('start_wecom_gateway', getWorkspaceArgs())
+        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
         set({ wecomGatewayStatus: status })
       } catch (e) {
         console.error('[WeCom] Failed to start gateway:', e)
@@ -50,7 +56,7 @@ export function createWecomActions(set: ChannelsSet) {
 
     stopWecomGateway: async () => {
       try {
-        await invoke('stop_wecom_gateway')
+        await invoke('stop_wecom_gateway', getWorkspaceArgs())
         set({ wecomGatewayStatus: { status: 'disconnected' } })
       } catch (e) {
         console.error('[WeCom] Failed to stop gateway:', e)
@@ -59,7 +65,7 @@ export function createWecomActions(set: ChannelsSet) {
 
     refreshWecomStatus: async () => {
       try {
-        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+        const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
         set({ wecomGatewayStatus: status })
       } catch (e) {
         console.error('[WeCom] Failed to refresh status:', e)
@@ -91,16 +97,16 @@ export function createWecomActions(set: ChannelsSet) {
     setWecomHasChanges: (hasChanges: boolean) => set({ wecomHasChanges: hasChanges }),
 
     toggleWecomEnabled: async (enabled: boolean, config: WeComConfig) => {
-      const updatedConfig = { ...config, enabled }
+        const updatedConfig = { ...config, enabled }
       try {
-        await invoke('save_wecom_config', { wecom: updatedConfig })
+        await invoke('save_wecom_config', { wecom: updatedConfig, ...getWorkspaceArgs() })
         set({ wecom: updatedConfig })
         if (enabled) {
           set({ wecomIsLoading: true })
           try {
-            await invoke('start_wecom_gateway')
+            await invoke('start_wecom_gateway', getWorkspaceArgs())
             await new Promise((resolve) => setTimeout(resolve, 1000))
-            const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status')
+            const status = await invoke<WeComGatewayStatusResponse>('get_wecom_gateway_status', getWorkspaceArgs())
             set({ wecomGatewayStatus: status, wecomIsLoading: false, wecomHasChanges: false })
           } catch (error) {
             console.error('[WeCom] Auto-start failed:', error)
@@ -108,7 +114,7 @@ export function createWecomActions(set: ChannelsSet) {
           }
         } else {
           try {
-            await invoke('stop_wecom_gateway')
+            await invoke('stop_wecom_gateway', getWorkspaceArgs())
             set({ wecomGatewayStatus: { status: 'disconnected' }, wecomHasChanges: false })
           } catch {
             // Ignore stop errors

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { invoke } from '@tauri-apps/api/core'
 import { withAsync } from '@/lib/store-utils'
 import { getPreferredLanguage } from '@/lib/locale'
+import { useWorkspaceStore } from '@/stores/workspace'
 
 // ==================== Types ====================
 
@@ -139,7 +140,8 @@ export const useCronStore = create<CronState>((set, get) => ({
       return
     }
     try {
-      await invoke('cron_init')
+      const workspacePath = useWorkspaceStore.getState().workspacePath
+      await invoke('cron_init', { workspacePath })
       set({ isInitialized: true })
       await Promise.all([get().loadJobs(), get().loadCronSessionIds()])
     } catch (error) {
@@ -151,8 +153,9 @@ export const useCronStore = create<CronState>((set, get) => ({
   // Force re-initialization (used when workspace changes)
   reinit: async () => {
     try {
+      const workspacePath = useWorkspaceStore.getState().workspacePath
       set({ isInitialized: false })
-      await invoke('cron_init')
+      await invoke('cron_init', { workspacePath })
       set({ isInitialized: true })
       await Promise.all([get().loadJobs(), get().loadCronSessionIds()])
     } catch (error) {
@@ -163,14 +166,16 @@ export const useCronStore = create<CronState>((set, get) => ({
 
   loadJobs: async () => {
     await withAsync(set, async () => {
-      const jobs = await invoke<CronJob[]>('cron_list_jobs')
+      const workspacePath = useWorkspaceStore.getState().workspacePath
+      const jobs = await invoke<CronJob[]>('cron_list_jobs', { workspacePath })
       set({ jobs })
     })
   },
 
   addJob: async (request: CreateCronJobRequest) => {
     const job = await withAsync(set, async () => {
-      const job = await invoke<CronJob>('cron_add_job', { request })
+      const workspacePath = useWorkspaceStore.getState().workspacePath
+      const job = await invoke<CronJob>('cron_add_job', { request, workspacePath })
       set((state) => ({
         jobs: [...state.jobs, job],
       }))
@@ -181,7 +186,8 @@ export const useCronStore = create<CronState>((set, get) => ({
 
   updateJob: async (request: UpdateCronJobRequest) => {
     const updated = await withAsync(set, async () => {
-      const updated = await invoke<CronJob>('cron_update_job', { request })
+      const workspacePath = useWorkspaceStore.getState().workspacePath
+      const updated = await invoke<CronJob>('cron_update_job', { request, workspacePath })
       set((state) => ({
         jobs: state.jobs.map((j) => (j.id === updated.id ? updated : j)),
       }))
@@ -192,7 +198,8 @@ export const useCronStore = create<CronState>((set, get) => ({
 
   removeJob: async (jobId: string) => {
     await withAsync(set, async () => {
-      await invoke('cron_remove_job', { jobId })
+      const workspacePath = useWorkspaceStore.getState().workspacePath
+      await invoke('cron_remove_job', { jobId, workspacePath })
       set((state) => ({
         jobs: state.jobs.filter((j) => j.id !== jobId),
         selectedJobId: state.selectedJobId === jobId ? null : state.selectedJobId,
@@ -202,7 +209,8 @@ export const useCronStore = create<CronState>((set, get) => ({
 
   toggleEnabled: async (jobId: string, enabled: boolean) => {
     try {
-      await invoke('cron_toggle_enabled', { jobId, enabled })
+      const workspacePath = useWorkspaceStore.getState().workspacePath
+      await invoke('cron_toggle_enabled', { jobId, enabled, workspacePath })
       set((state) => ({
         jobs: state.jobs.map((j) =>
           j.id === jobId ? { ...j, enabled } : j
@@ -215,7 +223,8 @@ export const useCronStore = create<CronState>((set, get) => ({
 
   runJob: async (jobId: string) => {
     try {
-      await invoke('cron_run_job', { jobId })
+      const workspacePath = useWorkspaceStore.getState().workspacePath
+      await invoke('cron_run_job', { jobId, workspacePath })
     } catch (error) {
       set({ error: error instanceof Error ? error.message : String(error) })
     }
@@ -223,7 +232,8 @@ export const useCronStore = create<CronState>((set, get) => ({
 
   loadCronSessionIds: async () => {
     try {
-      const ids = await invoke<string[]>('cron_get_all_session_ids')
+      const workspacePath = useWorkspaceStore.getState().workspacePath
+      const ids = await invoke<string[]>('cron_get_all_session_ids', { workspacePath })
       set({ cronSessionIds: new Set(ids) })
     } catch (error) {
       console.error('[Cron] Failed to load cron session IDs:', error)
@@ -233,9 +243,11 @@ export const useCronStore = create<CronState>((set, get) => ({
   loadRuns: async (jobId: string, limit?: number) => {
     set({ runsLoading: true, selectedJobId: jobId })
     try {
+      const workspacePath = useWorkspaceStore.getState().workspacePath
       const runs = await invoke<CronRunRecord[]>('cron_get_runs', {
         jobId,
         limit: limit ?? 50,
+        workspacePath,
       })
       set({ runs, runsLoading: false })
     } catch (error) {
@@ -246,7 +258,8 @@ export const useCronStore = create<CronState>((set, get) => ({
 
   refreshDelivery: async () => {
     try {
-      await invoke('cron_refresh_delivery')
+      const workspacePath = useWorkspaceStore.getState().workspacePath
+      await invoke('cron_refresh_delivery', { workspacePath })
     } catch (error) {
       console.error('[Cron] Failed to refresh delivery:', error)
     }

--- a/packages/app/src/stores/team-members.ts
+++ b/packages/app/src/stores/team-members.ts
@@ -2,6 +2,7 @@
 import { create } from 'zustand'
 import { invoke } from '@tauri-apps/api/core'
 import type { TeamMember } from '../lib/git/types'
+import { useWorkspaceStore } from './workspace'
 
 type MemberRole = 'owner' | 'manager' | 'editor' | 'viewer'
 
@@ -39,6 +40,11 @@ interface TeamMembersState {
   reset: () => void
 }
 
+function getWorkspaceArgs() {
+  const workspacePath = useWorkspaceStore.getState().workspacePath
+  return workspacePath ? { workspacePath } : {}
+}
+
 export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
   members: [],
   myRole: null,
@@ -61,7 +67,7 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
   loadMembers: async () => {
     set({ loading: true, error: null })
     try {
-      const members = await invoke<TeamMember[]>('unified_team_get_members')
+      const members = await invoke<TeamMember[]>('unified_team_get_members', getWorkspaceArgs())
       set({ members, loading: false })
     } catch (e) {
       set({ error: String(e), loading: false })
@@ -70,7 +76,7 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
 
   loadMyRole: async () => {
     try {
-      const role = await invoke<MemberRole | null>('unified_team_get_my_role')
+      const role = await invoke<MemberRole | null>('unified_team_get_my_role', getWorkspaceArgs())
       set({ myRole: role })
     } catch {
       set({ myRole: null })
@@ -80,7 +86,7 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
   addMember: async (member: TeamMember) => {
     set({ error: null })
     try {
-      await invoke('unified_team_add_member', { member })
+      await invoke('unified_team_add_member', { member, ...getWorkspaceArgs() })
       await get().loadMembers()
     } catch (e) {
       set({ error: String(e) })
@@ -91,7 +97,7 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
   removeMember: async (nodeId: string) => {
     set({ error: null })
     try {
-      await invoke('unified_team_remove_member', { nodeId })
+      await invoke('unified_team_remove_member', { nodeId, ...getWorkspaceArgs() })
       await get().loadMembers()
     } catch (e) {
       set({ error: String(e) })
@@ -102,7 +108,7 @@ export const useTeamMembersStore = create<TeamMembersState>((set, get) => ({
   updateMemberRole: async (nodeId: string, role: MemberRole) => {
     set({ error: null })
     try {
-      await invoke('unified_team_update_member_role', { nodeId, role })
+      await invoke('unified_team_update_member_role', { nodeId, role, ...getWorkspaceArgs() })
       await get().loadMembers()
     } catch (e) {
       set({ error: String(e) })

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -4,12 +4,13 @@ import {
   getCustomProviderConfig,
   removeCustomProviderFromConfig,
 } from '@/lib/opencode/config'
+import { syncTeamProviderToOpenCode, TEAM_SHARED_PROVIDER_ID } from '@/lib/team-provider'
 import { useProviderStore } from './provider'
 import { isTauri } from '@/lib/utils'
 import { appShortName, buildConfig, TEAM_REPO_DIR, type TeamModelOption } from '@/lib/build-config'
 
 
-const TEAM_PROVIDER_ID = 'team'
+const TEAM_PROVIDER_ID = TEAM_SHARED_PROVIDER_ID
 
 /**
  * Upgrade `http://` → `https://` for remote LLM hosts.
@@ -146,7 +147,18 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
         // Fire-and-forget; errors swallowed inside action
         get().loadTeamGitFileSyncStatus(_workspacePath)
       }
-      if (status?.llm) {
+      const providerFile = _workspacePath ? await syncTeamProviderToOpenCode(_workspacePath).catch(() => null) : null
+      if (providerFile?.provider) {
+        const teamModels = providerFile.provider.models
+        const defaultModelId = providerFile.provider.defaultModel || teamModels[0]?.id || ''
+        const defaultModel = teamModels.find((model) => model.id === defaultModelId) || teamModels[0]
+        const config: TeamModelConfig = {
+          baseUrl: normalizeLlmBaseUrl(providerFile.provider.baseURL),
+          model: defaultModel?.id || '',
+          modelName: defaultModel?.name || defaultModel?.id || '',
+        }
+        set({ teamModelConfig: config, teamModelOptions: teamModels })
+      } else if (status?.llm) {
         // Use models from team config (stored in teamclaw.json), fallback to build config
         const teamModels = status.llm.models && status.llm.models.length > 0
           ? status.llm.models
@@ -192,6 +204,21 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   },
 
   applyTeamModelToOpenCode: async (workspacePath: string, force?: boolean) => {
+    const syncedProviderFile = await syncTeamProviderToOpenCode(workspacePath).catch(() => null)
+    if (syncedProviderFile?.provider) {
+      const syncedModels = syncedProviderFile.provider.models
+      const defaultModelId = syncedProviderFile.provider.defaultModel || syncedModels[0]?.id || ''
+      const defaultModel = syncedModels.find((model) => model.id === defaultModelId) || syncedModels[0]
+      set({
+        teamModelConfig: {
+          baseUrl: normalizeLlmBaseUrl(syncedProviderFile.provider.baseURL),
+          model: defaultModel?.id || '',
+          modelName: defaultModel?.name || defaultModel?.id || '',
+        },
+        teamModelOptions: syncedModels,
+      })
+    }
+
     const { teamModelConfig, _appliedConfigKey } = get()
     if (!teamModelConfig) return
 

--- a/src-tauri/crates/teamclaw-gateway/src/wecom.rs
+++ b/src-tauri/crates/teamclaw-gateway/src/wecom.rs
@@ -413,6 +413,14 @@ impl WeComGateway {
         *self.config.write().await = config;
     }
 
+    pub fn workspace_path(&self) -> &str {
+        &self.workspace_path
+    }
+
+    pub fn opencode_port(&self) -> u16 {
+        self.opencode_port
+    }
+
     pub async fn get_status(&self) -> WeComGatewayStatusResponse {
         let mut resp = self.status.read().await.clone();
         // Populate active sessions from session mapping

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -1798,21 +1798,28 @@ pub async fn test_kook_token(token: String) -> Result<String, String> {
 /// Get WeCom configuration
 #[tauri::command]
 pub async fn get_wecom_config(
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<wecom_config::WeComConfig, String> {
-    let channels = get_channel_config(opencode_state).await?;
-    Ok(channels.wecom.unwrap_or_default())
+    let workspace_path =
+        crate::commands::team::resolve_workspace_path(workspace_path, &opencode_state)?;
+    let config = read_config(&workspace_path)?;
+    Ok(config
+        .channels
+        .and_then(|channels| channels.wecom)
+        .unwrap_or_default())
 }
 
 /// Save WeCom configuration
 #[tauri::command]
 pub async fn save_wecom_config(
     wecom: wecom_config::WeComConfig,
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
     let workspace_path =
-        crate::commands::opencode::current_workspace_path(&opencode_state)?;
+        crate::commands::team::resolve_workspace_path(workspace_path, &opencode_state)?;
 
     let mut config = read_config(&workspace_path)?;
     let channels = config.channels.get_or_insert_with(ChannelsConfig::default);
@@ -1827,7 +1834,7 @@ pub async fn save_wecom_config(
         gateway.as_ref().map(|gw| gw.clone())
     };
 
-    if let Some(gw) = gateway_clone {
+    if let Some(gw) = gateway_clone.filter(|gw| gw.workspace_path() == workspace_path) {
         gw.set_config(wecom).await;
     }
 
@@ -1837,11 +1844,14 @@ pub async fn save_wecom_config(
 /// Start WeCom gateway
 #[tauri::command]
 pub async fn start_wecom_gateway(
+    workspace_path: Option<String>,
     opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<(), String> {
-    let (workspace_path, port) =
-        crate::commands::opencode::resolve_workspace(&opencode_state, None)?;
+    let (workspace_path, port) = crate::commands::opencode::resolve_workspace(
+        &opencode_state,
+        workspace_path.as_deref(),
+    )?;
 
     println!(
         "[Gateway] start_wecom_gateway called, workspace={}",
@@ -1883,6 +1893,25 @@ pub async fn start_wecom_gateway(
     ensure_session_initialized(&gateway_state, &workspace_path).await;
 
     let gateway_clone = {
+        let guard = gateway_state
+            .wecom_gateway
+            .lock()
+            .map_err(|e| e.to_string())?;
+        guard.as_ref().map(|gw| gw.clone())
+    };
+
+    if let Some(gw) = gateway_clone.as_ref() {
+        if gw.workspace_path() != workspace_path || gw.opencode_port() != port {
+            gw.stop().await?;
+            let mut guard = gateway_state
+                .wecom_gateway
+                .lock()
+                .map_err(|e| e.to_string())?;
+            *guard = None;
+        }
+    }
+
+    let gateway_clone = {
         let mut guard = gateway_state
             .wecom_gateway
             .lock()
@@ -1910,7 +1939,14 @@ pub async fn start_wecom_gateway(
 
 /// Stop WeCom gateway
 #[tauri::command]
-pub async fn stop_wecom_gateway(gateway_state: State<'_, GatewayState>) -> Result<(), String> {
+pub async fn stop_wecom_gateway(
+    workspace_path: Option<String>,
+    opencode_state: State<'_, OpenCodeState>,
+    gateway_state: State<'_, GatewayState>,
+) -> Result<(), String> {
+    let resolved_workspace_path =
+        crate::commands::team::resolve_workspace_path(workspace_path, &opencode_state).ok();
+
     let gateway_clone = {
         let guard = gateway_state
             .wecom_gateway
@@ -1919,7 +1955,12 @@ pub async fn stop_wecom_gateway(gateway_state: State<'_, GatewayState>) -> Resul
         guard.as_ref().map(|gw| gw.clone())
     };
 
-    if let Some(gw) = gateway_clone {
+    if let Some(gw) = gateway_clone.filter(|gw| {
+        resolved_workspace_path
+            .as_ref()
+            .map(|path| gw.workspace_path() == path)
+            .unwrap_or(true)
+    }) {
         gw.stop().await?;
     }
 
@@ -1929,8 +1970,12 @@ pub async fn stop_wecom_gateway(gateway_state: State<'_, GatewayState>) -> Resul
 /// Get WeCom gateway status
 #[tauri::command]
 pub async fn get_wecom_gateway_status(
+    workspace_path: Option<String>,
+    opencode_state: State<'_, OpenCodeState>,
     gateway_state: State<'_, GatewayState>,
 ) -> Result<WeComGatewayStatusResponse, String> {
+    let workspace_path =
+        crate::commands::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let gateway_clone = {
         let guard = gateway_state
             .wecom_gateway
@@ -1939,7 +1984,7 @@ pub async fn get_wecom_gateway_status(
         guard.as_ref().map(|gw| gw.clone())
     };
 
-    if let Some(gw) = gateway_clone {
+    if let Some(gw) = gateway_clone.filter(|gw| gw.workspace_path() == workspace_path) {
         Ok(gw.get_status().await)
     } else {
         Ok(WeComGatewayStatusResponse::default())

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -231,11 +231,12 @@ fn write_git_manifest(workspace_path: &str, manifest: &TeamManifest) -> Result<(
 /// - Git: reads from teamclaw-team/_meta/members.json
 #[tauri::command]
 pub async fn unified_team_get_members(
+    workspace_path: Option<String>,
     opencode_state: State<'_, super::opencode::OpenCodeState>,
     oss_state: State<'_, super::oss_sync::OssSyncState>,
     iroh_state: State<'_, super::p2p_state::IrohState>,
 ) -> Result<Vec<TeamMember>, String> {
-    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let workspace_path = super::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let status = super::team::check_team_status(&workspace_path);
 
     match status.mode.as_deref() {
@@ -295,13 +296,14 @@ pub async fn unified_team_get_members(
 #[tauri::command]
 pub async fn unified_team_add_member(
     member: TeamMember,
+    workspace_path: Option<String>,
     opencode_state: State<'_, super::opencode::OpenCodeState>,
     oss_state: State<'_, super::oss_sync::OssSyncState>,
     iroh_state: State<'_, super::p2p_state::IrohState>,
 ) -> Result<(), String> {
     validate_node_id(&member.node_id)?;
 
-    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let workspace_path = super::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let status = super::team::check_team_status(&workspace_path);
 
     match status.mode.as_deref() {
@@ -402,11 +404,12 @@ pub async fn unified_team_add_member(
 #[tauri::command]
 pub async fn unified_team_remove_member(
     node_id: String,
+    workspace_path: Option<String>,
     opencode_state: State<'_, super::opencode::OpenCodeState>,
     oss_state: State<'_, super::oss_sync::OssSyncState>,
     iroh_state: State<'_, super::p2p_state::IrohState>,
 ) -> Result<(), String> {
-    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let workspace_path = super::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let status = super::team::check_team_status(&workspace_path);
 
     match status.mode.as_deref() {
@@ -527,11 +530,12 @@ pub async fn unified_team_remove_member(
 pub async fn unified_team_update_member_role(
     node_id: String,
     role: MemberRole,
+    workspace_path: Option<String>,
     opencode_state: State<'_, super::opencode::OpenCodeState>,
     oss_state: State<'_, super::oss_sync::OssSyncState>,
     iroh_state: State<'_, super::p2p_state::IrohState>,
 ) -> Result<(), String> {
-    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let workspace_path = super::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let status = super::team::check_team_status(&workspace_path);
 
     match status.mode.as_deref() {
@@ -575,11 +579,12 @@ pub async fn unified_team_update_member_role(
 /// Get the current device's role in the active team.
 #[tauri::command]
 pub async fn unified_team_get_my_role(
+    workspace_path: Option<String>,
     opencode_state: State<'_, super::opencode::OpenCodeState>,
     oss_state: State<'_, super::oss_sync::OssSyncState>,
     iroh_state: State<'_, super::p2p_state::IrohState>,
 ) -> Result<MemberRole, String> {
-    let workspace_path = super::team::get_workspace_path(&opencode_state)?;
+    let workspace_path = super::team::resolve_workspace_path(workspace_path, &opencode_state)?;
     let status = super::team::check_team_status(&workspace_path);
 
     match status.mode.as_deref() {


### PR DESCRIPTION
## Summary
- use `teamclaw-team/_meta/provider.json` as the shared source of truth for team-hosted LLM providers across Git, OSS, and P2P modes
- sync that shared provider metadata into each workspace's `opencode.json` during startup and on file changes
- pass `workspacePath` to cron commands so the Automation page works correctly when multiple OpenCode instances are active

## Testing
- pnpm vitest run src/lib/__tests__/team-provider.test.ts src/stores/__tests__/team-mode-git-file-status.test.ts src/components/settings/team/__tests__/TeamGitConfig.test.tsx src/components/chat/__tests__/ChatPanel.test.tsx
- pnpm vitest run src/stores/__tests__/cron.test.ts
- pnpm typecheck