### PR TITLE
Fix Tauri dev startup on Windows

### DIFF
--- a/src-tauri/src/commands/p2p_state.rs
+++ b/src-tauri/src/commands/p2p_state.rs
@@ -25,11 +25,29 @@ impl Default for IrohState {
 }
 
 #[cfg(not(feature = "p2p"))]
+impl std::ops::Deref for IrohState {
+    type Target = Arc<Mutex<Option<()>>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(not(feature = "p2p"))]
 pub struct SyncEngineState(pub Arc<Mutex<Option<()>>>);
 
 #[cfg(not(feature = "p2p"))]
 impl Default for SyncEngineState {
     fn default() -> Self {
         Self(Arc::new(Mutex::new(None)))
+    }
+}
+
+#[cfg(not(feature = "p2p"))]
+impl std::ops::Deref for SyncEngineState {
+    type Target = Arc<Mutex<Option<()>>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }


### PR DESCRIPTION
## Summary

Fixes Windows Tauri dev startup when P2P is disabled by making the non-P2P dummy state wrappers usable with the existing `.lock().await` call sites.

## Root Cause

The latest upstream branch already uses distinct newtype wrappers for `IrohState` and `SyncEngineState` in non-P2P builds to avoid duplicate Tauri managed-state TypeIds, but the wrappers no longer dereference to their inner `Arc<Mutex<Option<()>>>`. Existing non-P2P call sites still call `.lock().await`, so Windows `--no-default-features` builds need the wrappers to expose the inner mutex behavior.

## Validation

- `cargo check --no-default-features` from `src-tauri` passes on Windows after preparing required local sidecars and setting `LIBCLANG_PATH`.

## Notes

This change is gated behind `#[cfg(not(feature = "p2p"))]`, so normal P2P-enabled builds keep using the real `teamclaw_p2p` state types.