### PR TITLE
fix(webview): preserve injected device name

### DIFF
--- a/packages/app/src/components/main-content/WebViewContent.tsx
+++ b/packages/app/src/components/main-content/WebViewContent.tsx
@@ -5,6 +5,7 @@ import { normalizeUrl, urlToLabel } from "@/lib/webview-utils"
 import { useTabsStore } from "@/stores/tabs"
 import { useTeamModeStore } from "@/stores/team-mode"
 import { useTeamMembersStore } from "@/stores/team-members"
+import type { DeviceInfo } from "@/lib/git/types"
 
 interface WebViewContentProps {
   url: string
@@ -143,7 +144,7 @@ export function WebViewContent({ url: rawUrl }: WebViewContentProps) {
               if (useTeamModeStore.getState().teamMode) {
                 try {
                   const info = await Promise.race([
-                    invoke<{ nodeId: string }>("get_device_info"),
+                    invoke<DeviceInfo>("get_device_info"),
                     new Promise<never>((_, reject) =>
                       setTimeout(() => reject(new Error("timeout")), 500),
                     ),
@@ -151,14 +152,20 @@ export function WebViewContent({ url: rawUrl }: WebViewContentProps) {
                   deviceNo = info.nodeId
                   const members = useTeamMembersStore.getState().members
                   const me = members.find((m) => m.nodeId === deviceNo)
-                  deviceName = me?.name ?? ""
+                  deviceName = me?.name || info.hostname || ""
                 } catch {
                   // P2P not running — fall through to persistent ID below
                 }
               }
               if (!deviceNo) {
                 deviceNo = await invoke<string>("get_persistent_device_id")
-                deviceName = deviceName ?? ""
+              }
+              if (!deviceName) {
+                try {
+                  deviceName = await invoke<string>("get_device_hostname")
+                } catch {
+                  deviceName = ""
+                }
               }
             } catch {
               // Non-critical: webview works without identity

--- a/packages/app/src/components/main-content/__tests__/WebViewContent.test.tsx
+++ b/packages/app/src/components/main-content/__tests__/WebViewContent.test.tsx
@@ -1,0 +1,97 @@
+import { render, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { WebViewContent } from "../WebViewContent"
+import { useTeamMembersStore } from "@/stores/team-members"
+import { useTeamModeStore } from "@/stores/team-mode"
+
+const invokeMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}))
+
+vi.mock("@/lib/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/utils")>()),
+  isTauri: () => true,
+}))
+
+describe("WebViewContent", () => {
+  beforeEach(() => {
+    invokeMock.mockReset()
+    vi.stubGlobal("ResizeObserver", vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    })))
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 800,
+      bottom: 600,
+      width: 800,
+      height: 600,
+      toJSON: () => {},
+    })
+    useTeamModeStore.setState({ teamMode: true })
+    useTeamMembersStore.setState({ members: [] })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("falls back to device hostname when team member name is unavailable", async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "webview_set_bounds") return Promise.resolve()
+      if (command === "get_device_info") {
+        return Promise.resolve({
+          nodeId: "node-123",
+          platform: "macos",
+          arch: "aarch64",
+          hostname: "matts-mac",
+        })
+      }
+      if (command === "webview_create") return Promise.resolve()
+      if (command === "webview_hide") return Promise.resolve()
+      throw new Error(`unexpected command: ${command}`)
+    })
+
+    render(<WebViewContent url="https://example.test/device-name" />)
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        "webview_create",
+        expect.objectContaining({
+          deviceNo: "node-123",
+          deviceName: "matts-mac",
+        }),
+      )
+    })
+  })
+
+  it("uses device hostname with the persistent device id outside team mode", async () => {
+    useTeamModeStore.setState({ teamMode: false })
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "webview_set_bounds") return Promise.resolve()
+      if (command === "get_persistent_device_id") return Promise.resolve("persisted-node")
+      if (command === "get_device_hostname") return Promise.resolve("standalone-mac")
+      if (command === "webview_create") return Promise.resolve()
+      if (command === "webview_hide") return Promise.resolve()
+      throw new Error(`unexpected command: ${command}`)
+    })
+
+    render(<WebViewContent url="https://example.test/persistent-device-name" />)
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        "webview_create",
+        expect.objectContaining({
+          deviceNo: "persisted-node",
+          deviceName: "standalone-mac",
+        }),
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- fall back to the local hostname when a team member name is unavailable for injected WebView identity
- use hostname with the persistent device id outside team mode
- add WebViewContent coverage for both deviceName injection paths

## Test Plan
- pnpm --filter @teamclaw/app exec vitest run src/components/main-content/__tests__/WebViewContent.test.tsx
- pnpm --filter @teamclaw/app typecheck
- cargo test --manifest-path src-tauri/Cargo.toml teamclaw_identity_script --lib
- git diff --check