### PR TITLE
Hide advanced workspace files by default

### DIFF
--- a/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
+++ b/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { FilePlus, FolderPlus, RefreshCw } from 'lucide-react'
+import { RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FileBrowser } from '@/components/workspace/FileBrowser'
 import { useWorkspaceStore } from '@/stores/workspace'
-import { useKnowledgeStore } from '@/stores/knowledge'
 import { useTeamModeStore } from '@/stores/team-mode'
-import { useUIStore } from '@/stores/ui'
 import { isTauri } from '@/lib/utils'
-import { TEAM_REPO_DIR } from '@/lib/build-config'
 
 interface KnowledgeBrowserProps {
   hidePanelToolbar?: boolean
@@ -32,14 +29,9 @@ export function KnowledgeBrowser({
 }: KnowledgeBrowserProps = {}) {
   const { t } = useTranslation()
   const workspacePath = useWorkspaceStore(s => s.workspacePath)
-  const teamMode = useTeamModeStore(s => s.teamMode)
-  const advancedMode = useUIStore(s => s.advancedMode)
   const refreshFileTree = useWorkspaceStore(s => s.refreshFileTree)
-  const selectFile = useWorkspaceStore(s => s.selectFile)
-  const createNoteFromLink = useKnowledgeStore(s => s.createNoteFromLink)
 
   const teamModeType = useTeamModeStore(s => s.teamModeType)
-  const [rootCreating, setRootCreating] = React.useState<'file' | 'folder' | null>(null)
   const [syncing, setSyncing] = React.useState(false)
 
   const handleGitSync = React.useCallback(async () => {
@@ -81,43 +73,6 @@ export function KnowledgeBrowser({
 
   if (!workspacePath) return null
 
-  const personalKnowledgePath = `${workspacePath}/knowledge`
-  const teamKnowledgePath = `${workspacePath}/${TEAM_REPO_DIR}/knowledge`
-
-  // advancedMode: show full workspace tree (no rootPath)
-  // teamMode (not dev): two virtual root folders for team + personal knowledge
-  // otherwise: personal knowledge only
-  const showFullTree = advancedMode
-  const rootPaths = !showFullTree && teamMode
-    ? [teamKnowledgePath, personalKnowledgePath]
-    : undefined
-  const rootLabels = !showFullTree && teamMode
-    ? [t('knowledge.teamDocs', '团队文档'), t('knowledge.personalDocs', '个人文档')]
-    : undefined
-  const rootPath = showFullTree ? undefined
-    : teamMode ? undefined
-    : personalKnowledgePath
-
-  const handleCreateConfirm = async (name: string) => {
-    const type = rootCreating
-    setRootCreating(null)
-    const targetPath = personalKnowledgePath
-    try {
-      if (type === 'file') {
-        const filePath = await createNoteFromLink(name, targetPath)
-        selectFile(filePath)
-      } else {
-        const { mkdir } = await import('@tauri-apps/plugin-fs')
-        await mkdir(`${targetPath}/${name}`, { recursive: true })
-        await refreshFileTree()
-      }
-    } catch (err) {
-      const key = type === 'file' ? 'knowledge.newNoteError' : 'knowledge.newFolderError'
-      const fallback = type === 'file' ? 'Failed to create note: {{err}}' : 'Failed to create folder: {{err}}'
-      toast.error(t(key, fallback, { err: String(err) }))
-    }
-  }
-
   const iconButtonClass = 'flex items-center justify-center h-7 w-7 rounded-md transition-colors shrink-0 text-muted-foreground hover:bg-muted hover:text-foreground'
 
   const gitSyncIcon = teamModeType === 'git' ? (
@@ -131,36 +86,13 @@ export function KnowledgeBrowser({
     </Tooltip>
   ) : null
 
-  const actionIcons = !showFullTree ? (
-    <>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button onClick={() => setRootCreating('file')} className={iconButtonClass}>
-            <FilePlus className="h-3.5 w-3.5" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">{t('knowledge.newNote', 'New Note')}</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button onClick={() => setRootCreating('folder')} className={iconButtonClass}>
-            <FolderPlus className="h-3.5 w-3.5" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">{t('knowledge.newFolder', 'New Folder')}</TooltipContent>
-      </Tooltip>
-      {gitSyncIcon}
-    </>
-  ) : gitSyncIcon ? (<>{gitSyncIcon}</>) : undefined
+  const actionIcons = gitSyncIcon ? (<>{gitSyncIcon}</>) : undefined
 
   return (
     <div className="flex flex-col min-h-0 flex-1">
       <FileBrowser
         variant="panel"
-        rootPath={rootPath}
-        rootPaths={rootPaths}
-        rootLabels={rootLabels}
-        hideGitStatus={!showFullTree}
+        hideGitStatus={false}
         hideToolbar={hidePanelToolbar}
         filterText={filterText}
         onFilterTextChange={onFilterTextChange}
@@ -169,9 +101,6 @@ export function KnowledgeBrowser({
         searchExpanded={searchExpanded}
         onSearchExpandedChange={onSearchExpandedChange}
         actionIcons={actionIcons}
-        rootCreating={showFullTree ? undefined : rootCreating}
-        onRootCreateConfirm={handleCreateConfirm}
-        onRootCreateCancel={() => setRootCreating(null)}
       />
     </div>
   )

--- a/packages/app/src/components/knowledge/__tests__/KnowledgeBrowser.test.tsx
+++ b/packages/app/src/components/knowledge/__tests__/KnowledgeBrowser.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+const fileBrowserMock = vi.hoisted(() => vi.fn(() => <div data-testid="file-browser" />))
+
+const workspaceState = vi.hoisted(() => ({
+  workspacePath: '/workspace',
+  refreshFileTree: vi.fn(),
+  selectFile: vi.fn(),
+}))
+
+const teamModeState = vi.hoisted(() => ({
+  teamMode: true,
+  teamModeType: null as string | null,
+}))
+
+const uiState = vi.hoisted(() => ({
+  advancedMode: false,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}))
+
+vi.mock('@/components/workspace/FileBrowser', () => ({
+  FileBrowser: fileBrowserMock,
+}))
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: (selector: (state: typeof workspaceState) => unknown) => selector(workspaceState),
+}))
+
+vi.mock('@/stores/knowledge', () => ({
+  useKnowledgeStore: (selector: (state: { createNoteFromLink: ReturnType<typeof vi.fn> }) => unknown) =>
+    selector({ createNoteFromLink: vi.fn() }),
+}))
+
+vi.mock('@/stores/team-mode', () => ({
+  useTeamModeStore: Object.assign(
+    (selector: (state: typeof teamModeState) => unknown) => selector(teamModeState),
+    {
+      setState: vi.fn(),
+      getState: () => ({
+        loadTeamGitFileSyncStatus: vi.fn(),
+      }),
+    },
+  ),
+}))
+
+vi.mock('@/stores/ui', () => ({
+  useUIStore: (selector: (state: typeof uiState) => unknown) => selector(uiState),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  isTauri: () => false,
+}))
+
+vi.mock('@/lib/build-config', () => ({
+  TEAM_REPO_DIR: 'teamclaw-team',
+}))
+
+import { KnowledgeBrowser } from '../KnowledgeBrowser'
+
+describe('KnowledgeBrowser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    workspaceState.workspacePath = '/workspace'
+    teamModeState.teamMode = true
+    teamModeState.teamModeType = null
+    uiState.advancedMode = false
+  })
+
+  it('does not render team/personal virtual document roots in basic mode', () => {
+    render(<KnowledgeBrowser />)
+
+    const props = fileBrowserMock.mock.calls[0][0] as Record<string, unknown>
+    expect(props).not.toHaveProperty('rootPath')
+    expect(props).not.toHaveProperty('rootPaths')
+    expect(props).not.toHaveProperty('rootLabels')
+    expect(props.hideGitStatus).toBe(false)
+  })
+})

--- a/packages/app/src/components/settings/GeneralSection.tsx
+++ b/packages/app/src/components/settings/GeneralSection.tsx
@@ -15,6 +15,7 @@ import {
   MessageSquareText,
   Plus,
   X,
+  SlidersHorizontal,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
@@ -30,6 +31,8 @@ import { SettingCard, SectionHeader, ToggleSwitch } from './shared'
 import { getPermissionPolicy, setPermissionPolicy, type PermissionPolicy } from '@/lib/permission-policy'
 import { PermissionBatchSection } from './PermissionBatchSection'
 import { useSuggestionsStore } from '@/stores/suggestions'
+import { useUIStore } from '@/stores/ui'
+import { useWorkspaceStore } from '@/stores/workspace'
 import { appShortName, buildConfig } from '@/lib/build-config'
 import { getPreferredLanguage, persistLanguage } from '@/lib/locale'
 
@@ -266,9 +269,55 @@ export const GeneralSection = React.memo(function GeneralSection() {
       )}
 
       <ChatSuggestionsCard />
+
+      <AdvancedModeCard />
     </div>
   )
 })
+
+function AdvancedModeCard() {
+  const { t } = useTranslation()
+  const advancedMode = useUIStore(s => s.advancedMode)
+  const setAdvancedMode = useUIStore(s => s.setAdvancedMode)
+  const workspacePath = useWorkspaceStore(s => s.workspacePath)
+  const refreshFileTree = useWorkspaceStore(s => s.refreshFileTree)
+  const [saving, setSaving] = React.useState(false)
+
+  const handleAdvancedModeChange = React.useCallback((enabled: boolean) => {
+    if (!workspacePath || saving) return
+
+    setSaving(true)
+    void (async () => {
+      try {
+        await setAdvancedMode(enabled, workspacePath)
+        await refreshFileTree()
+      } finally {
+        setSaving(false)
+      }
+    })()
+  }, [refreshFileTree, saving, setAdvancedMode, workspacePath])
+
+  return (
+    <SettingCard>
+      <div className="flex items-center justify-between gap-4">
+        <div className="space-y-1">
+          <label className="text-sm font-medium flex items-center gap-2">
+            <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
+            {t('settings.general.advancedMode', 'Advanced Mode')}
+          </label>
+          <p className="text-xs text-muted-foreground">
+            {t('settings.general.advancedModeDesc', 'Show system and team internal files in the file tree and enable Code mode')}
+          </p>
+        </div>
+        <ToggleSwitch
+          enabled={advancedMode}
+          onChange={handleAdvancedModeChange}
+          disabled={!workspacePath || saving}
+        />
+      </div>
+    </SettingCard>
+  )
+}
 
 function ChatSuggestionsCard() {
   const { t } = useTranslation()

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -542,7 +542,7 @@
       "noCustomSuggestions": "No custom suggestions yet",
       "builtInSuggestions": "Built-in Suggestions",
       "advancedMode": "Advanced Mode",
-      "advancedModeDesc": "Enable Code mode, Changes and Files panels for power users",
+      "advancedModeDesc": "Show system and team internal files in the file tree and enable Code mode",
       "notifAll": "All",
       "notifImportant": "Important only",
       "notifMute": "Mute"

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -558,7 +558,7 @@
       "noCustomSuggestions": "暂无自定义建议",
       "builtInSuggestions": "内置建议",
       "advancedMode": "高级模式",
-      "advancedModeDesc": "启用 Code 模式、Changes 和 Files 面板",
+      "advancedModeDesc": "在文件树显示系统和团队内部文件，并启用 Code 模式",
       "notifAll": "全部",
       "notifImportant": "仅重要通知",
       "notifMute": "静音"

--- a/packages/app/src/stores/__tests__/ui-advanced-mode.test.ts
+++ b/packages/app/src/stores/__tests__/ui-advanced-mode.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { CONFIG_FILE_NAME } from '@/lib/build-config'
+import { CONFIG_FILE_NAME, TEAMCLAW_DIR } from '@/lib/build-config'
 import { useUIStore } from '../ui'
+
+vi.mock('@/lib/utils', () => ({
+  isTauri: () => true,
+}))
 
 // Mock Tauri modules
 vi.mock('@tauri-apps/plugin-fs', () => ({
@@ -12,6 +16,10 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 
 vi.mock('@tauri-apps/api/path', () => ({
   join: vi.fn((...parts: string[]) => Promise.resolve(parts.join('/'))),
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(() => Promise.resolve(vi.fn())),
 }))
 
 // Mock workspace store — must be at top level for ESM compatibility
@@ -27,59 +35,71 @@ describe('UI Store - advancedMode', () => {
     vi.clearAllMocks()
   })
 
-  it('defaults to true', () => {
-    expect(useUIStore.getState().advancedMode).toBe(true)
+  it('setAdvancedMode(false) disables advanced mode', async () => {
+    await useUIStore.getState().setAdvancedMode(false, null)
+
+    expect(useUIStore.getState().advancedMode).toBe(false)
   })
 
-  it('setAdvancedMode keeps the store enabled', () => {
-    useUIStore.getState().setAdvancedMode(false, null)
-    expect(useUIStore.getState().advancedMode).toBe(true)
+  it(`setAdvancedMode writes ${CONFIG_FILE_NAME} while preserving other fields`, async () => {
+    const { exists, readTextFile, writeTextFile } = await import('@tauri-apps/plugin-fs')
+    vi.mocked(exists).mockResolvedValue(true)
+    vi.mocked(readTextFile).mockResolvedValue(JSON.stringify({ team: { enabled: true }, advancedMode: false }))
+
+    await useUIStore.getState().setAdvancedMode(true, '/workspace')
+
+    expect(writeTextFile).toHaveBeenCalledWith(
+      `/workspace/${TEAMCLAW_DIR}/${CONFIG_FILE_NAME}`,
+      `${JSON.stringify({ team: { enabled: true }, advancedMode: true }, null, 2)}\n`,
+    )
   })
 
-  it('setAdvancedMode(false) does not reset layoutMode from file to task', () => {
+  it('setAdvancedMode(false) keeps layoutMode unchanged', async () => {
     useUIStore.setState({ advancedMode: true, layoutMode: 'file' })
-    useUIStore.getState().setAdvancedMode(false, null)
+    await useUIStore.getState().setAdvancedMode(false, null)
+
     expect(useUIStore.getState().layoutMode).toBe('file')
   })
 
-  it('setAdvancedMode(false) does not reset fileModeRightTab', () => {
+  it('setAdvancedMode(false) keeps fileModeRightTab unchanged', async () => {
     useUIStore.setState({ advancedMode: true, fileModeRightTab: 'changes' })
-    useUIStore.getState().setAdvancedMode(false, null)
+    await useUIStore.getState().setAdvancedMode(false, null)
+
     expect(useUIStore.getState().fileModeRightTab).toBe('changes')
   })
 
-  it('loadAdvancedMode stays true when file does not exist', async () => {
+  it('loadAdvancedMode defaults to false when config file does not exist', async () => {
     const { exists } = await import('@tauri-apps/plugin-fs')
     vi.mocked(exists).mockResolvedValue(false)
 
     await useUIStore.getState().loadAdvancedMode('/workspace')
-    expect(useUIStore.getState().advancedMode).toBe(true)
+    expect(useUIStore.getState().advancedMode).toBe(false)
   })
 
-  it(`loadAdvancedMode ignores ${CONFIG_FILE_NAME} and stays true`, async () => {
+  it(`loadAdvancedMode reads advancedMode from ${CONFIG_FILE_NAME}`, async () => {
     const { exists, readTextFile } = await import('@tauri-apps/plugin-fs')
     vi.mocked(exists).mockResolvedValue(true)
-    vi.mocked(readTextFile).mockResolvedValue(JSON.stringify({ advancedMode: false }))
+    vi.mocked(readTextFile).mockResolvedValue(JSON.stringify({ advancedMode: true }))
 
     await useUIStore.getState().loadAdvancedMode('/workspace')
     expect(useUIStore.getState().advancedMode).toBe(true)
   })
 
-  it('loadAdvancedMode stays true on malformed JSON', async () => {
+  it('loadAdvancedMode resets to false on malformed JSON', async () => {
     const { exists, readTextFile } = await import('@tauri-apps/plugin-fs')
     vi.mocked(exists).mockResolvedValue(true)
     vi.mocked(readTextFile).mockResolvedValue('not json{{{')
 
     await useUIStore.getState().loadAdvancedMode('/workspace')
-    expect(useUIStore.getState().advancedMode).toBe(true)
+    expect(useUIStore.getState().advancedMode).toBe(false)
   })
 
-  it('loadAdvancedMode stays true when advancedMode field is missing', async () => {
+  it('loadAdvancedMode defaults to false when advancedMode field is missing', async () => {
     const { exists, readTextFile } = await import('@tauri-apps/plugin-fs')
     vi.mocked(exists).mockResolvedValue(true)
     vi.mocked(readTextFile).mockResolvedValue(JSON.stringify({ team: {} }))
 
     await useUIStore.getState().loadAdvancedMode('/workspace')
-    expect(useUIStore.getState().advancedMode).toBe(true)
+    expect(useUIStore.getState().advancedMode).toBe(false)
   })
 })

--- a/packages/app/src/stores/__tests__/workspace-behavior.test.ts
+++ b/packages/app/src/stores/__tests__/workspace-behavior.test.ts
@@ -12,8 +12,9 @@ vi.mock('@/components/viewers/UnsupportedFileViewer', () => ({
 }));
 
 // Import after mocks
-import { useWorkspaceStore } from '../workspace';
+import { shouldHideFileTreeEntry, useWorkspaceStore } from '../workspace';
 import type { FileNode } from '../workspace';
+import { TEAMCLAW_DIR, TEAM_REPO_DIR } from '@/lib/build-config';
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
@@ -162,6 +163,60 @@ describe('workspace store: behavioral tests', () => {
       ];
       const flat = useWorkspaceStore.getState().flattenVisibleFileTree(tree);
       expect(flat).toContain('/a/b/c/deep.ts');
+    });
+  });
+
+  describe('advanced mode file tree hiding', () => {
+    const workspacePath = '/workspace';
+
+    it('hides workspace system directories and files when advanced mode is off', () => {
+      const hiddenEntries: FileNode[] = [
+        { name: TEAMCLAW_DIR, path: `${workspacePath}/${TEAMCLAW_DIR}`, type: 'directory' },
+        { name: '.opencode', path: `${workspacePath}/.opencode`, type: 'directory' },
+        { name: 'opencode.json', path: `${workspacePath}/opencode.json`, type: 'file' },
+        { name: 'config.json', path: `${workspacePath}/config.json`, type: 'file' },
+      ];
+
+      for (const entry of hiddenEntries) {
+        expect(shouldHideFileTreeEntry(entry, workspacePath, false)).toBe(true);
+      }
+    });
+
+    it('hides team internal directories when advanced mode is off', () => {
+      const hiddenEntries: FileNode[] = [
+        { name: '_feedback', path: `${workspacePath}/${TEAM_REPO_DIR}/_feedback`, type: 'directory' },
+        { name: '_meta', path: `${workspacePath}/${TEAM_REPO_DIR}/_meta`, type: 'directory' },
+        { name: '_secrets', path: `${workspacePath}/${TEAM_REPO_DIR}/_secrets`, type: 'directory' },
+        { name: '.git', path: `${workspacePath}/${TEAM_REPO_DIR}/.git`, type: 'directory' },
+        { name: '.leaderboard', path: `${workspacePath}/${TEAM_REPO_DIR}/.leaderboard`, type: 'directory' },
+      ];
+
+      for (const entry of hiddenEntries) {
+        expect(shouldHideFileTreeEntry(entry, workspacePath, false)).toBe(true);
+      }
+    });
+
+    it('does not hide normal files or similarly named nested files in basic mode', () => {
+      const visibleEntries: FileNode[] = [
+        { name: TEAM_REPO_DIR, path: `${workspacePath}/${TEAM_REPO_DIR}`, type: 'directory' },
+        { name: 'README.md', path: `${workspacePath}/${TEAM_REPO_DIR}/README.md`, type: 'file' },
+        { name: 'config.json', path: `${workspacePath}/${TEAM_REPO_DIR}/config.json`, type: 'file' },
+        { name: '_meta', path: `${workspacePath}/src/_meta`, type: 'directory' },
+      ];
+
+      for (const entry of visibleEntries) {
+        expect(shouldHideFileTreeEntry(entry, workspacePath, false)).toBe(false);
+      }
+    });
+
+    it('shows advanced entries when advanced mode is on', () => {
+      const entry: FileNode = {
+        name: '_secrets',
+        path: `${workspacePath}/${TEAM_REPO_DIR}/_secrets`,
+        type: 'directory',
+      };
+
+      expect(shouldHideFileTreeEntry(entry, workspacePath, true)).toBe(false);
     });
   });
 

--- a/packages/app/src/stores/ui.ts
+++ b/packages/app/src/stores/ui.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { isTauri } from '@/lib/utils'
 import { useWorkspaceStore } from '@/stores/workspace'
+import { CONFIG_FILE_NAME, TEAMCLAW_DIR } from '@/lib/build-config'
 
 type View = 'chat' | 'settings'
 
@@ -43,10 +44,34 @@ interface UIState {
   setFileModeRightTab: (tab: FileModeRightTab) => void
   setSpotlightMode: (mode: boolean) => void
   advancedMode: boolean
-  setAdvancedMode: (value: boolean, workspacePath: string | null) => void
-  loadAdvancedMode: (workspacePath: string) => void
+  setAdvancedMode: (value: boolean, workspacePath: string | null) => Promise<void>
+  loadAdvancedMode: (workspacePath: string) => Promise<void>
   startNewChat: () => void
   switchToSession: (sessionId: string) => Promise<void>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+async function getWorkspaceConfigPath(workspacePath: string): Promise<{
+  dirPath: string
+  configPath: string
+}> {
+  const { join } = await import('@tauri-apps/api/path')
+  const dirPath = await join(workspacePath, TEAMCLAW_DIR)
+  const configPath = await join(dirPath, CONFIG_FILE_NAME)
+  return { dirPath, configPath }
+}
+
+async function readWorkspaceConfig(configPath: string): Promise<Record<string, unknown>> {
+  const { readTextFile } = await import('@tauri-apps/plugin-fs')
+  try {
+    const parsed = JSON.parse(await readTextFile(configPath))
+    return isRecord(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
 }
 
 export const useUIStore = create<UIState>((set, get) => ({
@@ -191,14 +216,52 @@ export const useUIStore = create<UIState>((set, get) => ({
 
   setSpotlightMode: (mode) => set({ spotlightMode: mode }),
 
-  advancedMode: true,
+  advancedMode: false,
 
-  setAdvancedMode: (_value, _workspacePath) => {
-    set({ advancedMode: true })
+  setAdvancedMode: async (value, workspacePath) => {
+    set({ advancedMode: value })
+    if (!workspacePath || !isTauri()) return
+
+    try {
+      const { exists, mkdir, writeTextFile } = await import('@tauri-apps/plugin-fs')
+      const { dirPath, configPath } = await getWorkspaceConfigPath(workspacePath)
+
+      if (!(await exists(dirPath))) {
+        await mkdir(dirPath, { recursive: true })
+      }
+
+      const config = (await exists(configPath))
+        ? await readWorkspaceConfig(configPath)
+        : {}
+      await writeTextFile(
+        configPath,
+        `${JSON.stringify({ ...config, advancedMode: value }, null, 2)}\n`,
+      )
+    } catch (error) {
+      console.warn('[UI] Failed to persist advanced mode:', error)
+    }
   },
 
-  loadAdvancedMode: async (_workspacePath) => {
-    set({ advancedMode: true })
+  loadAdvancedMode: async (workspacePath) => {
+    if (!workspacePath || !isTauri()) {
+      set({ advancedMode: false })
+      return
+    }
+
+    try {
+      const { exists } = await import('@tauri-apps/plugin-fs')
+      const { configPath } = await getWorkspaceConfigPath(workspacePath)
+      if (!(await exists(configPath))) {
+        set({ advancedMode: false })
+        return
+      }
+
+      const config = await readWorkspaceConfig(configPath)
+      set({ advancedMode: config.advancedMode === true })
+    } catch (error) {
+      console.warn('[UI] Failed to load advanced mode:', error)
+      set({ advancedMode: false })
+    }
   },
 }))
 

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -5,8 +5,56 @@ import { ensureGitignoreEntries } from '@/lib/gitignore-manager'
 import { appShortName, TEAMCLAW_DIR, TEAM_REPO_DIR } from '@/lib/build-config'
 import { useTeamModeStore } from './team-mode'
 
-// Directories to hide from file tree (system directories)
-const HIDDEN_DIRECTORIES = new Set([TEAMCLAW_DIR, '.opencode'])
+const ROOT_ADVANCED_MODE_DIRECTORIES = new Set([TEAMCLAW_DIR, '.opencode'])
+const ROOT_ADVANCED_MODE_FILES = new Set(['opencode.json', 'config.json'])
+const TEAM_REPO_ADVANCED_MODE_DIRECTORIES = new Set([
+  '_feedback',
+  '_meta',
+  '_secrets',
+  '.git',
+  '.leaderboard',
+])
+
+function normalizeFileTreePath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+function relativeWorkspacePath(path: string, workspacePath: string): string {
+  const normalizedPath = normalizeFileTreePath(path)
+  const normalizedWorkspace = normalizeFileTreePath(workspacePath)
+  if (normalizedPath === normalizedWorkspace) return ''
+  if (!normalizedPath.startsWith(`${normalizedWorkspace}/`)) return normalizedPath
+  return normalizedPath.slice(normalizedWorkspace.length + 1)
+}
+
+export function shouldHideFileTreeEntry(
+  node: Pick<FileNode, 'name' | 'path' | 'type'>,
+  workspacePath: string,
+  advancedMode: boolean,
+): boolean {
+  if (advancedMode) return false
+
+  const relPath = relativeWorkspacePath(node.path, workspacePath)
+  const isRootEntry = !relPath.includes('/')
+  if (isRootEntry && node.type === 'directory' && ROOT_ADVANCED_MODE_DIRECTORIES.has(node.name)) {
+    return true
+  }
+  if (isRootEntry && node.type === 'file' && ROOT_ADVANCED_MODE_FILES.has(node.name)) {
+    return true
+  }
+
+  const teamInternalDirPrefix = `${TEAM_REPO_DIR}/`
+  if (
+    node.type === 'directory' &&
+    relPath.startsWith(teamInternalDirPrefix) &&
+    !relPath.slice(teamInternalDirPrefix.length).includes('/') &&
+    TEAM_REPO_ADVANCED_MODE_DIRECTORIES.has(node.name)
+  ) {
+    return true
+  }
+
+  return false
+}
 
 // Start watching a directory for file changes
 async function startWatching(path: string): Promise<boolean> {
@@ -573,13 +621,14 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       const entries = await readDir(fullPath);
       console.log("[Workspace] Found", entries.length, "entries");
 
-      const visibleEntries = entries.filter(
-        (entry) =>
-          useTeamModeStore.getState().devUnlocked || !HIDDEN_DIRECTORIES.has(entry.name),
-      );
+      let advancedMode = false;
+      try {
+        const { useUIStore } = await import('./ui');
+        advancedMode = useUIStore.getState().advancedMode;
+      } catch { /* keep basic mode */ }
 
       const nodes: FileNode[] = await Promise.all(
-        visibleEntries.map(async (entry) => {
+        entries.map(async (entry) => {
           const entryPath = `${fullPath}/${entry.name}`;
           let isDirectory = entry.isDirectory;
           const needsStatResolution = !entry.isDirectory && !entry.isFile;
@@ -600,8 +649,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
           } as FileNode;
         }),
       );
+      const visibleNodes = nodes.filter(
+        (node) => !shouldHideFileTreeEntry(node, workspacePath, advancedMode),
+      );
 
-      nodes.sort((a, b) => {
+      visibleNodes.sort((a, b) => {
         // Always put teamclaw-team first
         if (a.name === TEAM_REPO_DIR && b.name !== TEAM_REPO_DIR) return -1;
         if (b.name === TEAM_REPO_DIR && a.name !== TEAM_REPO_DIR) return 1;
@@ -615,7 +667,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         return a.name.localeCompare(b.name);
       });
 
-      return nodes;
+      return visibleNodes;
     } catch (error) {
       console.error("[Workspace] Failed to load directory:", error);
       return [];


### PR DESCRIPTION
## Summary
- Add a workspace-level Advanced Mode toggle persisted in .teamclaw/teamclaw.json.
- Hide TeamClaw/OpenCode system files and team internal directories from the file tree unless Advanced Mode is enabled.
- Remove the basic-mode team/personal document virtual roots from the knowledge browser.

## Test Plan
- pnpm --filter @teamclaw/app exec vitest run src/components/knowledge/__tests__/KnowledgeBrowser.test.tsx src/stores/__tests__/ui-advanced-mode.test.ts src/stores/__tests__/workspace-behavior.test.ts
- pnpm --filter @teamclaw/app typecheck