### PR TITLE
fix(webview): inject nativeStorage whenever device id resolves

### DIFF
--- a/packages/app/src/components/main-content/WebViewContent.tsx
+++ b/packages/app/src/components/main-content/WebViewContent.tsx
@@ -5,7 +5,6 @@ import { normalizeUrl, urlToLabel } from "@/lib/webview-utils"
 import { useTabsStore } from "@/stores/tabs"
 import { useTeamModeStore } from "@/stores/team-mode"
 import { useTeamMembersStore } from "@/stores/team-members"
-import type { DeviceInfo } from "@/lib/git/types"
 
 interface WebViewContentProps {
   url: string
@@ -133,42 +132,32 @@ export function WebViewContent({ url: rawUrl }: WebViewContentProps) {
             // Create new native webview
             setIsLoading(true)
 
-            // Resolve device identity for window.teamclaw injection.
-            // Always inject: use the persistent fallback device ID so the
-            // JWT device_token is available regardless of teamMode / P2P state.
+            // Device ID is the persistent iroh node_id (derived from a local key
+            // file) — it does not depend on the P2P node being up, so racing P2P
+            // here is wasted latency. Always read it directly.
             let deviceNo: string | undefined
-            let deviceName: string | undefined
             try {
-              // Prefer the P2P node ID when teamMode is active and P2P is running;
-              // always fall back to the stable persisted UUID.
-              if (useTeamModeStore.getState().teamMode) {
-                try {
-                  const info = await Promise.race([
-                    invoke<DeviceInfo>("get_device_info"),
-                    new Promise<never>((_, reject) =>
-                      setTimeout(() => reject(new Error("timeout")), 500),
-                    ),
-                  ])
-                  deviceNo = info.nodeId
-                  const members = useTeamMembersStore.getState().members
-                  const me = members.find((m) => m.nodeId === deviceNo)
-                  deviceName = me?.name || info.hostname || ""
-                } catch {
-                  // P2P not running — fall through to persistent ID below
-                }
-              }
-              if (!deviceNo) {
-                deviceNo = await invoke<string>("get_persistent_device_id")
+              deviceNo = await invoke<string>("get_persistent_device_id")
+            } catch (err) {
+              console.error("[WebView] get_persistent_device_id failed:", err)
+            }
+
+            // Device name is purely a display value and must NOT gate injection:
+            // prefer the team member display name when available, fall back to
+            // hostname, accept empty if both fail.
+            let deviceName = ""
+            try {
+              if (deviceNo && useTeamModeStore.getState().teamMode) {
+                const me = useTeamMembersStore
+                  .getState()
+                  .members.find((m) => m.nodeId === deviceNo)
+                if (me?.name) deviceName = me.name
               }
               if (!deviceName) {
-                try {
-                  deviceName = await invoke<string>("get_device_hostname")
-                } catch {
-                  deviceName = ""
-                }
+                deviceName = await invoke<string>("get_device_hostname")
               }
             } catch {
-              // Non-critical: webview works without identity
+              // Empty deviceName is acceptable; injection still happens.
             }
 
             await invoke("webview_create", {

--- a/packages/app/src/components/main-content/__tests__/WebViewContent.test.tsx
+++ b/packages/app/src/components/main-content/__tests__/WebViewContent.test.tsx
@@ -42,17 +42,37 @@ describe("WebViewContent", () => {
     vi.unstubAllGlobals()
   })
 
+  it("uses team member display name when teamMode is on and member matches", async () => {
+    useTeamMembersStore.setState({
+      members: [{ nodeId: "node-123", name: "Matt", role: "owner" } as never],
+    })
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "webview_set_bounds") return Promise.resolve()
+      if (command === "get_persistent_device_id") return Promise.resolve("node-123")
+      if (command === "get_device_hostname") return Promise.resolve("matts-mac")
+      if (command === "webview_create") return Promise.resolve()
+      if (command === "webview_hide") return Promise.resolve()
+      throw new Error(`unexpected command: ${command}`)
+    })
+
+    render(<WebViewContent url="https://example.test/team-member-name" />)
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        "webview_create",
+        expect.objectContaining({
+          deviceNo: "node-123",
+          deviceName: "Matt",
+        }),
+      )
+    })
+  })
+
   it("falls back to device hostname when team member name is unavailable", async () => {
     invokeMock.mockImplementation((command: string) => {
       if (command === "webview_set_bounds") return Promise.resolve()
-      if (command === "get_device_info") {
-        return Promise.resolve({
-          nodeId: "node-123",
-          platform: "macos",
-          arch: "aarch64",
-          hostname: "matts-mac",
-        })
-      }
+      if (command === "get_persistent_device_id") return Promise.resolve("node-123")
+      if (command === "get_device_hostname") return Promise.resolve("matts-mac")
       if (command === "webview_create") return Promise.resolve()
       if (command === "webview_hide") return Promise.resolve()
       throw new Error(`unexpected command: ${command}`)
@@ -90,6 +110,30 @@ describe("WebViewContent", () => {
         expect.objectContaining({
           deviceNo: "persisted-node",
           deviceName: "standalone-mac",
+        }),
+      )
+    })
+  })
+
+  it("still passes deviceNo when get_device_hostname fails (does not gate injection on name)", async () => {
+    useTeamModeStore.setState({ teamMode: false })
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "webview_set_bounds") return Promise.resolve()
+      if (command === "get_persistent_device_id") return Promise.resolve("persisted-node")
+      if (command === "get_device_hostname") return Promise.reject(new Error("hostname failed"))
+      if (command === "webview_create") return Promise.resolve()
+      if (command === "webview_hide") return Promise.resolve()
+      throw new Error(`unexpected command: ${command}`)
+    })
+
+    render(<WebViewContent url="https://example.test/no-hostname" />)
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        "webview_create",
+        expect.objectContaining({
+          deviceNo: "persisted-node",
+          deviceName: "",
         }),
       )
     })

--- a/src-tauri/src/commands/webview.rs
+++ b/src-tauri/src/commands/webview.rs
@@ -432,11 +432,12 @@ pub async fn webview_create(
         });
     }
 
-    let identity = if let (Some(dno), Some(dname)) = (&device_no, &device_name) {
-        Some((dno.clone(), dname.clone()))
-    } else {
-        None
-    };
+    // Inject as long as we have a device ID. Device name is a display-only
+    // string — empty is fine and must not block the JWT/storage shim.
+    let identity = device_no
+        .as_deref()
+        .filter(|dno| !dno.is_empty())
+        .map(|dno| (dno.to_string(), device_name.clone().unwrap_or_default()));
     let initial_identity_script = identity
         .as_ref()
         .map(|(dno, dname)| build_teamclaw_identity_script_with_fresh_token(dno, dname));


### PR DESCRIPTION
## Summary

Customer reported `window.teamclaw.nativeStorage` was working on some webview pages but not others. Root cause: injection required **both** `device_no` AND `device_name` to be `Some`, and the frontend silently swallowed any identity-resolution failure (P2P 500ms race timeout, `get_device_hostname` error, etc.) into `undefined`, which killed the entire `window.teamclaw` injection for that webview's lifetime — including the `on_page_load` refresh path, since the closure captures the broken state.

- **Rust** (`src-tauri/src/commands/webview.rs`): gate injection on non-empty `device_no` only; empty `device_name` is acceptable since it's a display-only string and was never load-bearing.
- **Frontend** (`packages/app/src/components/main-content/WebViewContent.tsx`): drop the P2P race for device id. `get_device_info().nodeId` and `get_persistent_device_id` both call `oss_commands::get_device_id()` (read the same iroh key file) — racing P2P only added 500ms of latency without changing the value (see comment at `oss_commands.rs:18`). Device name now resolves in its own try block so a hostname failure can no longer un-inject the storage shim.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` passes
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` clean on `webview.rs`
- [x] `WebViewContent.test.tsx` — 4/4 tests pass, including new regression test for the "hostname fails but deviceNo still flows" path
- [ ] Manual: open a webview at app cold-start (worst case for P2P timing) and verify `window.teamclaw.nativeStorage` is defined
- [ ] Manual: open a webview while `get_device_hostname` would fail (or simulate by killing P2P) and verify `nativeStorage` is still defined, with `deviceName === ""`

🤖 Generated with [Claude Code](https://claude.com/claude-code)