### PR TITLE
fix(prompt): load system prompt from teamclaw.json at message send

### DIFF
--- a/packages/app/src/stores/session-messages.ts
+++ b/packages/app/src/stores/session-messages.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { getOpenCodeClient } from "@/lib/opencode/sdk-client";
 import type { SendMessageFilePart, SessionErrorEvent } from "@/lib/opencode/sdk-types";
 import type {
@@ -23,7 +24,7 @@ import {
 import { trackEvent } from "@/stores/telemetry";
 import { syncSetSessionId } from "@/lib/opencode/sdk-sse";
 import { insertMessageSorted } from "@/lib/insert-message-sorted";
-import { appShortName } from "@/lib/build-config";
+import { useWorkspaceStore } from "@/stores/workspace";
 
 type SessionSet = (fn: ((state: SessionState) => Partial<SessionState>) | Partial<SessionState>) => void;
 type SessionGet = () => SessionState;
@@ -279,7 +280,8 @@ export function createMessageActions(set: SessionSet, get: SessionGet) {
           : undefined;
         let systemPrompt: string | undefined;
         try {
-          const stored = localStorage.getItem(`${appShortName}-system-prompt`);
+          const workspacePath = useWorkspaceStore.getState().workspacePath ?? undefined;
+          const stored = await invoke<string>('load_system_prompt', { workspacePath });
           if (stored && stored.trim()) {
             systemPrompt = stored.trim();
           }


### PR DESCRIPTION
## Summary
- The Settings → Prompt panel persists the system prompt to per-workspace `teamclaw.json` via `load_system_prompt` / `save_system_prompt`. On first open it migrates the legacy `localStorage["teamclaw-system-prompt"]` value into the workspace file and **deletes** the localStorage key (`PromptSection.tsx:34-43`).
- The actual message-send path in `session-messages.ts:282` still read from that legacy localStorage key — which is now empty after migration. So the user's saved prompt was never spread into the `system` field at `sdk-client.ts:365,384,403` and never reached the OpenCode sidecar.
- Switch the runtime read to `invoke('load_system_prompt', { workspacePath })` so both Settings and the send path share one source of truth.

## Test plan
- [ ] Open Settings → Prompt, save a distinctive sentence (e.g. "Always start replies with 🦀")
- [ ] Send a message in a session and confirm the model's behavior reflects the prompt
- [ ] Verify the request to `localhost:13141` includes the prompt in the `system` field
- [ ] Switch workspaces and confirm a different (or empty) prompt is loaded for the new workspace

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)