### PR TITLE
feat(team): fast-path invite-code join + persist fcEndpoint

### DIFF
--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -58,6 +58,7 @@ interface TeamConfig {
   gitToken?: string | null
   gitBranch?: string | null
   teamId?: string | null
+  fcEndpoint?: string | null
 }
 
 interface GitCheckResult {
@@ -100,6 +101,7 @@ interface InviteCodeData {
   r: string  // repoUrl
   p: string  // pat
   u: string  // bot username
+  e?: string // fcEndpoint (LiteLLM/FC base URL); legacy codes default to MANAGED_GIT_FC_ENDPOINT
 }
 
 function encodeInviteCode(data: InviteCodeData): string {
@@ -112,7 +114,11 @@ function decodeInviteCode(code: string): InviteCodeData | null {
     const raw = code.replace(/^tclaw:\/\/join\?code=/, '').trim()
     const json = atob(raw)
     const data = JSON.parse(json)
-    if (data.t && data.s && data.r && data.p) return data
+    if (data.t && data.s && data.r && data.p) {
+      // Backfill fcEndpoint for legacy codes (pre-fcEndpoint).
+      if (!data.e || typeof data.e !== 'string') data.e = MANAGED_GIT_FC_ENDPOINT
+      return data
+    }
     return null
   } catch {
     return null
@@ -251,6 +257,33 @@ export function TeamGitConfig() {
   React.useEffect(() => {
     initialize()
   }, [initialize])
+
+  // Listen for background-clone results (fired by team_git_join_background).
+  React.useEffect(() => {
+    if (!isTauri()) return
+    let unlistenCompleted: (() => void) | null = null
+    let unlistenFailed: (() => void) | null = null
+    void (async () => {
+      const { listen } = await import('@tauri-apps/api/event')
+      unlistenCompleted = await listen<{ teamId: string; message: string }>(
+        'team:git-join-clone-completed',
+        () => {
+          teamMembersStore.loadMembers()
+          teamMembersStore.loadMyRole()
+        },
+      )
+      unlistenFailed = await listen<{ teamId: string; error: string }>(
+        'team:git-join-clone-failed',
+        (evt) => {
+          setErrorMessage(evt.payload?.error || 'Background sync failed')
+        },
+      )
+    })()
+    return () => {
+      unlistenCompleted?.()
+      unlistenFailed?.()
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load current LLM config when connected
   React.useEffect(() => {
@@ -413,6 +446,7 @@ export function TeamGitConfig() {
         enabled: true,
         lastSyncAt: now,
         teamId: result.teamId,
+        ...(managedGit ? { fcEndpoint: MANAGED_GIT_FC_ENDPOINT } : {}),
         ...(effectiveGitToken ? { gitToken: effectiveGitToken } : {}),
         ...(gitBranch.trim() ? { gitBranch: gitBranch.trim() } : {}),
       }
@@ -432,6 +466,7 @@ export function TeamGitConfig() {
           r: effectiveGitUrl,
           p: managedPat,
           u: managedBotUsername,
+          e: MANAGED_GIT_FC_ENDPOINT,
         })
         setCreatedInviteCode(code)
       }
@@ -470,34 +505,114 @@ export function TeamGitConfig() {
     setState('connecting')
     setErrorMessage(null)
     try {
-      setConnectStep('Joining team...')
       const effectiveGitToken = gitToken.trim() || null
-      // Joining via invite code implies the team was created via managed-Git,
-      // so its LiteLLM team is registered on the managed FC endpoint.
-      const joinedViaInvite = !!decodeInviteCode(inviteCodeInput)
+      const inviteData = decodeInviteCode(inviteCodeInput)
+      const fcEndpoint = inviteData?.e ?? null
+      const teamIdTrim = teamIdInput.trim()
+      const teamSecretTrim = teamSecretInput.trim()
+      const memberNameTrim = memberName.trim()
+      const gitBranchTrim = gitBranch.trim()
+      const gitUrlTrim = gitUrl.trim()
+
+      // Fast path: invite code → register LiteLLM key via FC first, surface
+      // success to the user immediately, then run the slow clone in background.
+      if (fcEndpoint) {
+        setConnectStep('Registering with team service...')
+        const nodeId = await tauriInvoke<string>('get_device_node_id')
+        const fcUrl = `${fcEndpoint.replace(/\/+$/, '')}/ai/add-member`
+        const fcResp = await fetch(fcUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            teamId: teamIdTrim,
+            teamSecret: teamSecretTrim,
+            nodeId,
+            memberName: memberNameTrim,
+          }),
+        })
+        if (!fcResp.ok) {
+          // 502 with "alias already exists" means this nodeId already has a key
+          // for some team — likely a previous join attempt or rejoin. The clone
+          // step still proceeds below; the existing key will keep working.
+          let detail = ''
+          try {
+            const data = await fcResp.json()
+            detail = data?.detail?.error?.message || data?.error || ''
+          } catch {
+            detail = await fcResp.text()
+          }
+          const aliasConflict = /already exists/i.test(detail)
+          if (!aliasConflict) {
+            throw new Error(`Failed to register team key: ${detail || fcResp.statusText}`)
+          }
+          console.warn('[Team Join] /ai/add-member alias conflict (proceeding):', detail)
+        }
+
+        // Persist config + kick off background clone (returns immediately).
+        setConnectStep('Saving configuration...')
+        const now = new Date().toISOString()
+        const newConfig: TeamConfig = {
+          gitUrl: gitUrlTrim,
+          enabled: true,
+          lastSyncAt: now,
+          teamId: teamIdTrim,
+          fcEndpoint,
+          ...(effectiveGitToken ? { gitToken: effectiveGitToken } : {}),
+          ...(gitBranchTrim ? { gitBranch: gitBranchTrim } : {}),
+        }
+        await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
+        if (workspacePath) {
+          await saveTeamProviderFile(workspacePath, buildTeamProviderConfig(hostLlm, llmUrl, llmModels), hostLlm ? llmModels[0]?.id : undefined)
+        }
+        setTeamConfig(newConfig)
+
+        // Fire-and-forget: Tauri command spawns its own task and returns Ok(()).
+        await tauriInvoke('team_git_join_background', {
+          gitUrl: gitUrlTrim,
+          gitToken: effectiveGitToken,
+          gitBranch: gitBranchTrim || null,
+          teamId: teamIdTrim,
+          teamSecret: teamSecretTrim,
+          memberName: memberNameTrim,
+          llmBaseUrl: hostLlm ? (llmUrl || null) : null,
+          llmModel: hostLlm ? (llmModels[0]?.id || null) : null,
+          llmModelName: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
+          llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
+          // Frontend already called /ai/add-member; backend should not duplicate.
+          fcEndpoint: null,
+          ...workspaceArgs,
+        })
+
+        setState('connected')
+        return
+      }
+
+      // Slow path: manual entry without invite code → run the full sync clone
+      // in the foreground so verification errors surface inline.
+      setConnectStep('Joining team...')
       await tauriInvoke<{ success: boolean; message: string }>('team_git_join', {
-        gitUrl: gitUrl.trim(),
+        gitUrl: gitUrlTrim,
         gitToken: effectiveGitToken,
-        gitBranch: gitBranch.trim() || null,
-        teamId: teamIdInput.trim(),
-        teamSecret: teamSecretInput.trim(),
-        memberName: memberName.trim(),
+        gitBranch: gitBranchTrim || null,
+        teamId: teamIdTrim,
+        teamSecret: teamSecretTrim,
+        memberName: memberNameTrim,
         llmBaseUrl: hostLlm ? (llmUrl || null) : null,
         llmModel: hostLlm ? (llmModels[0]?.id || null) : null,
         llmModelName: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
         llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
-        fcEndpoint: joinedViaInvite ? MANAGED_GIT_FC_ENDPOINT : null,
+        fcEndpoint: null,
         ...workspaceArgs,
       })
       setConnectStep('Saving configuration...')
       const now = new Date().toISOString()
       const newConfig: TeamConfig = {
-        gitUrl: gitUrl.trim(),
+        gitUrl: gitUrlTrim,
         enabled: true,
         lastSyncAt: now,
-        teamId: teamIdInput.trim(),
+        teamId: teamIdTrim,
         ...(effectiveGitToken ? { gitToken: effectiveGitToken } : {}),
-        ...(gitBranch.trim() ? { gitBranch: gitBranch.trim() } : {}),
+        ...(gitBranchTrim ? { gitBranch: gitBranchTrim } : {}),
       }
       await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
       if (workspacePath) {

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -197,6 +197,17 @@ export function TeamGitConfig() {
   // Detect if current URL is HTTPS (needs token auth)
   const isHttpsUrl = gitUrl.trim().startsWith('https://') || gitUrl.trim().startsWith('http://')
 
+  // Provider config queued during fast-path join — written only after the
+  // background clone completes, otherwise saveTeamProviderFile would
+  // mkdir teamclaw-team/_meta and break the subsequent git clone.
+  type PendingProviderSave = {
+    workspacePath: string
+    hostLlm: boolean
+    llmUrl: string
+    llmModels: { id: string; name: string }[]
+  }
+  const pendingProviderSaveRef = React.useRef<PendingProviderSave | null>(null)
+
   // ─── Initialize: check git + load config ─────────────────────────────────
 
   const initialize = React.useCallback(async () => {
@@ -267,7 +278,21 @@ export function TeamGitConfig() {
       const { listen } = await import('@tauri-apps/api/event')
       unlistenCompleted = await listen<{ teamId: string; message: string }>(
         'team:git-join-clone-completed',
-        () => {
+        async () => {
+          // Now that teamclaw-team/_meta/ exists, flush any queued provider save.
+          const pending = pendingProviderSaveRef.current
+          if (pending) {
+            pendingProviderSaveRef.current = null
+            try {
+              await saveTeamProviderFile(
+                pending.workspacePath,
+                buildTeamProviderConfig(pending.hostLlm, pending.llmUrl, pending.llmModels),
+                pending.hostLlm ? pending.llmModels[0]?.id : undefined,
+              )
+            } catch (err) {
+              console.warn('[Team Join] Deferred provider save failed:', err)
+            }
+          }
           teamMembersStore.loadMembers()
           teamMembersStore.loadMyRole()
         },
@@ -275,6 +300,7 @@ export function TeamGitConfig() {
       unlistenFailed = await listen<{ teamId: string; error: string }>(
         'team:git-join-clone-failed',
         (evt) => {
+          pendingProviderSaveRef.current = null
           setErrorMessage(evt.payload?.error || 'Background sync failed')
         },
       )
@@ -561,8 +587,16 @@ export function TeamGitConfig() {
           ...(gitBranchTrim ? { gitBranch: gitBranchTrim } : {}),
         }
         await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
+        // Defer saveTeamProviderFile until the background clone finishes — it
+        // would otherwise mkdir teamclaw-team/_meta and break git clone's
+        // empty-target requirement.
         if (workspacePath) {
-          await saveTeamProviderFile(workspacePath, buildTeamProviderConfig(hostLlm, llmUrl, llmModels), hostLlm ? llmModels[0]?.id : undefined)
+          pendingProviderSaveRef.current = {
+            workspacePath,
+            hostLlm,
+            llmUrl,
+            llmModels,
+          }
         }
         setTeamConfig(newConfig)
 
@@ -1180,7 +1214,7 @@ export function TeamGitConfig() {
                   <div>
                     <label className="mb-1.5 block text-xs font-medium text-muted-foreground">{t('settings.team.teamId', 'Team ID')}</label>
                     <div className="flex items-center gap-1.5">
-                      <code className="flex-1 rounded-md bg-muted px-2.5 py-1.5 text-xs font-mono truncate">{teamConfig.teamId}</code>
+                      <code className="flex-1 min-w-0 rounded-md bg-muted px-2.5 py-1.5 text-xs font-mono truncate">{teamConfig.teamId}</code>
                       <Button
                         variant="ghost"
                         size="sm"
@@ -1194,7 +1228,7 @@ export function TeamGitConfig() {
                   <div>
                     <label className="mb-1.5 block text-xs font-medium text-muted-foreground">{t('settings.team.teamSecret', 'Team Secret')}</label>
                     <div className="flex items-center gap-1.5">
-                      <code className="flex-1 rounded-md bg-muted px-2.5 py-1.5 text-xs font-mono truncate">
+                      <code className="flex-1 min-w-0 rounded-md bg-muted px-2.5 py-1.5 text-xs font-mono truncate">
                         {showTeamSecret && loadedTeamSecret ? loadedTeamSecret : '••••••••••••••••'}
                       </code>
                       <Button
@@ -1365,7 +1399,7 @@ export function TeamGitConfig() {
               <div className="space-y-1.5">
                 <label className="text-sm font-medium">{t('settings.team.inviteCode', 'Invite Code')}</label>
                 <div className="flex items-center gap-2">
-                  <code className="flex-1 rounded-md bg-violet-50 dark:bg-violet-950/30 border border-violet-200 dark:border-violet-800 px-3 py-2 text-xs font-mono break-all max-h-20 overflow-y-auto">
+                  <code className="flex-1 min-w-0 rounded-md bg-violet-50 dark:bg-violet-950/30 border border-violet-200 dark:border-violet-800 px-3 py-2 text-xs font-mono break-all max-h-20 overflow-y-auto">
                     {createdInviteCode}
                   </code>
                   <Button
@@ -1384,7 +1418,7 @@ export function TeamGitConfig() {
             <div className="space-y-1.5">
               <label className="text-sm font-medium">{t('settings.team.teamId', 'Team ID')}</label>
               <div className="flex items-center gap-2">
-                <code className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
+                <code className="flex-1 min-w-0 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
                   {createdTeamId}
                 </code>
                 <Button
@@ -1401,7 +1435,7 @@ export function TeamGitConfig() {
             <div className="space-y-1.5">
               <label className="text-sm font-medium">{t('settings.team.teamSecret', 'Team Secret')}</label>
               <div className="flex items-center gap-2">
-                <code className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
+                <code className="flex-1 min-w-0 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
                   {showCreatedSecret ? createdTeamSecret : createdTeamSecret.replace(/./g, '*')}
                 </code>
                 <Button

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
-use tauri::State;
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::commands::mcp::{self, MCPServerConfig};
 use crate::commands::opencode::OpenCodeState;
@@ -26,6 +26,11 @@ pub struct TeamConfig {
     /// Team ID for shared secrets (generated on create, provided on join)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub team_id: Option<String>,
+    /// LiteLLM/FC endpoint for this team (cached from invite code or _meta/team.json).
+    /// When set, this client knows the team is registered with cloud LiteLLM and can
+    /// re-trigger background clone or sync member operations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fc_endpoint: Option<String>,
 }
 
 /// A single model entry in the team LLM configuration.
@@ -105,6 +110,11 @@ pub struct TeamMeta {
     pub secret_verify: String,
     pub created_at: String,
     pub owner_node_id: String,
+    /// LiteLLM/FC endpoint URL. When set, joining members register their key
+    /// via this endpoint. Older team repos without this field default to no
+    /// LiteLLM (joiners can still join, but won't get a cloud key issued).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fc_endpoint: Option<String>,
 }
 
 /// Result of team git create
@@ -1047,12 +1057,18 @@ pub async fn team_git_create(
     let node_id = crate::commands::oss_commands::get_device_id()?;
 
     // Write _meta/team.json
+    let normalized_fc_endpoint = fc_endpoint
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.trim_end_matches('/').to_string());
     let team_meta = TeamMeta {
         team_id: team_id.clone(),
         team_name: team_name.clone(),
         secret_verify,
         created_at: chrono::Utc::now().to_rfc3339(),
         owner_node_id: node_id.clone(),
+        fc_endpoint: normalized_fc_endpoint,
     };
     let team_meta_path = team_path.join("_meta").join("team.json");
     let team_meta_json = serde_json::to_string_pretty(&team_meta)
@@ -1209,9 +1225,8 @@ pub async fn team_git_create(
     })
 }
 
-/// Join an existing team repo: clone, verify HMAC secret, add self as member.
-#[tauri::command]
-pub async fn team_git_join(
+/// Inputs to the team-join clone & member-registration work.
+struct TeamGitJoinArgs {
     git_url: String,
     git_token: Option<String>,
     git_branch: Option<String>,
@@ -1223,11 +1238,30 @@ pub async fn team_git_join(
     llm_model_name: Option<String>,
     llm_models: Option<String>,
     fc_endpoint: Option<String>,
-    workspace_path: Option<String>,
-    opencode_state: State<'_, OpenCodeState>,
-    secrets_state: State<'_, crate::commands::shared_secrets::SharedSecretsState>,
+    workspace_path: String,
+}
+
+/// Shared body for both the synchronous (`team_git_join`) and background
+/// (`team_git_join_background`) commands. Looks up `SharedSecretsState` from
+/// the AppHandle so it can run inside a `tokio::spawn` future.
+async fn team_git_join_impl(
+    app: AppHandle,
+    args: TeamGitJoinArgs,
 ) -> Result<TeamGitResult, String> {
-    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
+    let TeamGitJoinArgs {
+        git_url,
+        git_token,
+        git_branch,
+        team_id,
+        team_secret,
+        member_name,
+        llm_base_url,
+        llm_model,
+        llm_model_name,
+        llm_models,
+        fc_endpoint,
+        workspace_path,
+    } = args;
     let team_dir = get_team_repo_path(&workspace_path);
 
     // 1. Validate team_dir doesn't exist
@@ -1418,7 +1452,14 @@ pub async fn team_git_join(
     println!("[Team Join] Saved team_secret to keychain");
 
     // 12. Init shared secrets
-    crate::commands::shared_secrets::init_shared_secrets(&secrets_state, &team_secret, team_path)?;
+    {
+        let secrets_state = app.state::<crate::commands::shared_secrets::SharedSecretsState>();
+        crate::commands::shared_secrets::init_shared_secrets(
+            secrets_state.inner(),
+            &team_secret,
+            team_path,
+        )?;
+    }
     println!("[Team Join] Initialized shared secrets");
 
     // 13. Sync MCP configs
@@ -1471,6 +1512,123 @@ pub async fn team_git_join(
         message: format!("Joined team '{}' successfully", team_meta.team_name),
         ..Default::default()
     })
+}
+
+/// Join an existing team repo synchronously: clone, verify HMAC secret,
+/// add self as member. Used by the slow path (manual entry without invite code).
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn team_git_join(
+    app: AppHandle,
+    git_url: String,
+    git_token: Option<String>,
+    git_branch: Option<String>,
+    team_id: String,
+    team_secret: String,
+    member_name: String,
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
+    llm_models: Option<String>,
+    fc_endpoint: Option<String>,
+    workspace_path: Option<String>,
+    opencode_state: State<'_, OpenCodeState>,
+) -> Result<TeamGitResult, String> {
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
+    team_git_join_impl(
+        app,
+        TeamGitJoinArgs {
+            git_url,
+            git_token,
+            git_branch,
+            team_id,
+            team_secret,
+            member_name,
+            llm_base_url,
+            llm_model,
+            llm_model_name,
+            llm_models,
+            fc_endpoint,
+            workspace_path,
+        },
+    )
+    .await
+}
+
+/// Join an existing team repo in the background. Returns immediately after
+/// scheduling the work; the caller (frontend) is expected to have already
+/// verified the team secret + registered its LiteLLM key out-of-band (via FC
+/// `/ai/add-member`) so the user can be told "joined" before clone finishes.
+///
+/// Emits `team:git-join-clone-completed` (with TeamGitResult) on success and
+/// `team:git-join-clone-failed` (with `{ error: String }`) on failure. On
+/// failure also pushes a tray notification with the error message.
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn team_git_join_background(
+    app: AppHandle,
+    git_url: String,
+    git_token: Option<String>,
+    git_branch: Option<String>,
+    team_id: String,
+    team_secret: String,
+    member_name: String,
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
+    llm_models: Option<String>,
+    fc_endpoint: Option<String>,
+    workspace_path: Option<String>,
+    opencode_state: State<'_, OpenCodeState>,
+) -> Result<(), String> {
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
+    let app_for_spawn = app.clone();
+    let args = TeamGitJoinArgs {
+        git_url,
+        git_token,
+        git_branch,
+        team_id: team_id.clone(),
+        team_secret,
+        member_name,
+        llm_base_url,
+        llm_model,
+        llm_model_name,
+        llm_models,
+        fc_endpoint,
+        workspace_path,
+    };
+    tokio::spawn(async move {
+        match team_git_join_impl(app_for_spawn.clone(), args).await {
+            Ok(result) => {
+                println!("[Team Join Background] completed: {}", result.message);
+                let _ = app_for_spawn.emit(
+                    "team:git-join-clone-completed",
+                    serde_json::json!({
+                        "teamId": team_id,
+                        "message": result.message,
+                    }),
+                );
+            }
+            Err(err) => {
+                eprintln!("[Team Join Background] failed: {err}");
+                let _ = app_for_spawn.emit(
+                    "team:git-join-clone-failed",
+                    serde_json::json!({
+                        "teamId": team_id,
+                        "error": err,
+                    }),
+                );
+                use tauri_plugin_notification::NotificationExt;
+                let _ = app_for_spawn
+                    .notification()
+                    .builder()
+                    .title("Team sync failed")
+                    .body(format!("Could not finish syncing team repo: {err}"))
+                    .show();
+            }
+        }
+    });
+    Ok(())
 }
 
 /// 1.4 - Ensure .gitignore in team repo dir has all required rules.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -427,6 +427,7 @@ pub fn run() {
             commands::team::team_init_repo,
             commands::team::team_git_create,
             commands::team::team_git_join,
+            commands::team::team_git_join_background,
             commands::team::init_git_team_secrets,
             commands::team::get_git_team_secret,
             commands::team::team_generate_gitignore,


### PR DESCRIPTION
## Summary

- **Fast-path join**: invite-code joins now POST \`/ai/add-member\` to the FC endpoint from the frontend and show "joined" as soon as the LiteLLM key is issued. The git clone runs in \`tokio::spawn\` behind a new \`team_git_join_background\` command. Manual joins (no invite code) keep the existing synchronous slow path.
- **Tray notification on background-clone failure** via \`tauri-plugin-notification\`. The frontend also subscribes to \`team:git-join-clone-{completed,failed}\` events and updates the members list / error banner.
- **\`fcEndpoint\` persisted** in \`TeamMeta\` (\`_meta/team.json\`, written by the owner on create), \`TeamConfig\` (local \`teamclaw.json\`), and invite codes (new \`e\` field). Legacy invite codes default to \`MANAGED_GIT_FC_ENDPOINT\` for back-compat.
- **Defer provider save** during fast-path join. \`saveTeamProviderFile()\` does \`mkdir teamclaw-team/_meta\` recursively, which would create a non-empty \`teamclaw-team/\` before the background \`git clone\` could populate it — clone then refused the non-empty target. Provider-save args are now queued in a \`useRef\` and flushed from the \`team:git-join-clone-completed\` event handler.

## Commits

- \`ce20876\` — feat: fast-path invite join + persist fcEndpoint
- \`11c9be2\` — fix: defer provider save until background clone finishes (patches a bug introduced by ce20876)

## Why these are bundled

The provider-defer fix only applies to the fast path introduced in this PR. Splitting them would leave the feat commit broken on its own. Keeping them as two commits in one PR preserves the bug-and-fix story while making review straightforward.

## Split out

The unrelated \`.gitkeep\` scaffold fix (originally \`5c5185f\`) is now in its own PR — independent bug in \`team_git_create\` predating fast-path join.

## Files

- \`src-tauri/src/commands/team.rs\` — \`TeamMeta\` and \`TeamConfig\` gain \`fc_endpoint\`. Body of \`team_git_join\` extracted into \`team_git_join_impl(app, args)\`. New \`team_git_join_background\` command spawns the impl and emits Tauri events; failure also pushes a tray notification.
- \`src-tauri/src/lib.rs\` — registers \`team_git_join_background\` in the invoke handler.
- \`packages/app/src/components/settings/team/TeamGitConfig.tsx\` — \`InviteCodeData\`/\`TeamConfig\` interfaces gain \`e\`/\`fcEndpoint\`. \`handleJoin\` is split into fast (invite-code) and slow (manual) branches. Provider-save deferred via ref. Owner's \`teamclaw.json\` saves \`fcEndpoint\` on create when \`managedGit\` was on. New \`useEffect\` listens for the background-clone events.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm rust:check\` clean (no new warnings)
- [x] \`pnpm lint\` no new warnings on modified files
- [x] \`vitest TeamGitConfig.test.tsx\` 2/2 pass
- [ ] Manual: managed-Git owner generates invite code → joiner pastes it → "joined" toast appears in <2s, members list refreshes once clone finishes in background
- [ ] Manual: kill app mid-clone → tray notification fires; frontend error banner shows the failure reason
- [ ] Manual: legacy invite code (without \`e\` field) still works (defaults to \`https://cloud.ucar.cc\`)
- [ ] Manual: self-hosted Git team (no invite code) still joins via the slow path

## Known follow-ups

- Auto-retry of half-joined state on next app launch — would need persisting \`memberName\` in \`TeamConfig\`. Today the user manually disconnects/rejoins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)