### PR TITLE
fix(team): re-apply team provider after manual sidecar refresh

### DIFF
--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -168,6 +168,11 @@ export const LLMSection = React.memo(function LLMSection() {
       setOpenCodeBootstrapped(true, status.url)
       setOpenCodeReady(true, status.url)
       await initAll()
+      // Sidecar restart drops team provider state; ChatPanel's apply-effect doesn't re-fire (no openCodeReady transition).
+      const { teamMode, applyTeamModelToOpenCode } = useTeamModeStore.getState()
+      if (teamMode) {
+        await applyTeamModelToOpenCode(workspacePath, true)
+      }
     } catch (err) {
       console.error('Failed to restart OpenCode after provider connect:', err)
       setOpenCodeBootstrapped(false)

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -58,6 +58,7 @@ interface TeamConfig {
   gitToken?: string | null
   gitBranch?: string | null
   teamId?: string | null
+  fcEndpoint?: string | null
 }
 
 interface GitCheckResult {
@@ -100,6 +101,7 @@ interface InviteCodeData {
   r: string  // repoUrl
   p: string  // pat
   u: string  // bot username
+  e?: string // fcEndpoint (LiteLLM/FC base URL); legacy codes default to MANAGED_GIT_FC_ENDPOINT
 }
 
 function encodeInviteCode(data: InviteCodeData): string {
@@ -112,7 +114,11 @@ function decodeInviteCode(code: string): InviteCodeData | null {
     const raw = code.replace(/^tclaw:\/\/join\?code=/, '').trim()
     const json = atob(raw)
     const data = JSON.parse(json)
-    if (data.t && data.s && data.r && data.p) return data
+    if (data.t && data.s && data.r && data.p) {
+      // Backfill fcEndpoint for legacy codes (pre-fcEndpoint).
+      if (!data.e || typeof data.e !== 'string') data.e = MANAGED_GIT_FC_ENDPOINT
+      return data
+    }
     return null
   } catch {
     return null
@@ -251,6 +257,33 @@ export function TeamGitConfig() {
   React.useEffect(() => {
     initialize()
   }, [initialize])
+
+  // Listen for background-clone results (fired by team_git_join_background).
+  React.useEffect(() => {
+    if (!isTauri()) return
+    let unlistenCompleted: (() => void) | null = null
+    let unlistenFailed: (() => void) | null = null
+    void (async () => {
+      const { listen } = await import('@tauri-apps/api/event')
+      unlistenCompleted = await listen<{ teamId: string; message: string }>(
+        'team:git-join-clone-completed',
+        () => {
+          teamMembersStore.loadMembers()
+          teamMembersStore.loadMyRole()
+        },
+      )
+      unlistenFailed = await listen<{ teamId: string; error: string }>(
+        'team:git-join-clone-failed',
+        (evt) => {
+          setErrorMessage(evt.payload?.error || 'Background sync failed')
+        },
+      )
+    })()
+    return () => {
+      unlistenCompleted?.()
+      unlistenFailed?.()
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load current LLM config when connected
   React.useEffect(() => {
@@ -413,6 +446,7 @@ export function TeamGitConfig() {
         enabled: true,
         lastSyncAt: now,
         teamId: result.teamId,
+        ...(managedGit ? { fcEndpoint: MANAGED_GIT_FC_ENDPOINT } : {}),
         ...(effectiveGitToken ? { gitToken: effectiveGitToken } : {}),
         ...(gitBranch.trim() ? { gitBranch: gitBranch.trim() } : {}),
       }
@@ -432,6 +466,7 @@ export function TeamGitConfig() {
           r: effectiveGitUrl,
           p: managedPat,
           u: managedBotUsername,
+          e: MANAGED_GIT_FC_ENDPOINT,
         })
         setCreatedInviteCode(code)
       }
@@ -470,34 +505,114 @@ export function TeamGitConfig() {
     setState('connecting')
     setErrorMessage(null)
     try {
-      setConnectStep('Joining team...')
       const effectiveGitToken = gitToken.trim() || null
-      // Joining via invite code implies the team was created via managed-Git,
-      // so its LiteLLM team is registered on the managed FC endpoint.
-      const joinedViaInvite = !!decodeInviteCode(inviteCodeInput)
+      const inviteData = decodeInviteCode(inviteCodeInput)
+      const fcEndpoint = inviteData?.e ?? null
+      const teamIdTrim = teamIdInput.trim()
+      const teamSecretTrim = teamSecretInput.trim()
+      const memberNameTrim = memberName.trim()
+      const gitBranchTrim = gitBranch.trim()
+      const gitUrlTrim = gitUrl.trim()
+
+      // Fast path: invite code → register LiteLLM key via FC first, surface
+      // success to the user immediately, then run the slow clone in background.
+      if (fcEndpoint) {
+        setConnectStep('Registering with team service...')
+        const nodeId = await tauriInvoke<string>('get_device_node_id')
+        const fcUrl = `${fcEndpoint.replace(/\/+$/, '')}/ai/add-member`
+        const fcResp = await fetch(fcUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            teamId: teamIdTrim,
+            teamSecret: teamSecretTrim,
+            nodeId,
+            memberName: memberNameTrim,
+          }),
+        })
+        if (!fcResp.ok) {
+          // 502 with "alias already exists" means this nodeId already has a key
+          // for some team — likely a previous join attempt or rejoin. The clone
+          // step still proceeds below; the existing key will keep working.
+          let detail = ''
+          try {
+            const data = await fcResp.json()
+            detail = data?.detail?.error?.message || data?.error || ''
+          } catch {
+            detail = await fcResp.text()
+          }
+          const aliasConflict = /already exists/i.test(detail)
+          if (!aliasConflict) {
+            throw new Error(`Failed to register team key: ${detail || fcResp.statusText}`)
+          }
+          console.warn('[Team Join] /ai/add-member alias conflict (proceeding):', detail)
+        }
+
+        // Persist config + kick off background clone (returns immediately).
+        setConnectStep('Saving configuration...')
+        const now = new Date().toISOString()
+        const newConfig: TeamConfig = {
+          gitUrl: gitUrlTrim,
+          enabled: true,
+          lastSyncAt: now,
+          teamId: teamIdTrim,
+          fcEndpoint,
+          ...(effectiveGitToken ? { gitToken: effectiveGitToken } : {}),
+          ...(gitBranchTrim ? { gitBranch: gitBranchTrim } : {}),
+        }
+        await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
+        if (workspacePath) {
+          await saveTeamProviderFile(workspacePath, buildTeamProviderConfig(hostLlm, llmUrl, llmModels), hostLlm ? llmModels[0]?.id : undefined)
+        }
+        setTeamConfig(newConfig)
+
+        // Fire-and-forget: Tauri command spawns its own task and returns Ok(()).
+        await tauriInvoke('team_git_join_background', {
+          gitUrl: gitUrlTrim,
+          gitToken: effectiveGitToken,
+          gitBranch: gitBranchTrim || null,
+          teamId: teamIdTrim,
+          teamSecret: teamSecretTrim,
+          memberName: memberNameTrim,
+          llmBaseUrl: hostLlm ? (llmUrl || null) : null,
+          llmModel: hostLlm ? (llmModels[0]?.id || null) : null,
+          llmModelName: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
+          llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
+          // Frontend already called /ai/add-member; backend should not duplicate.
+          fcEndpoint: null,
+          ...workspaceArgs,
+        })
+
+        setState('connected')
+        return
+      }
+
+      // Slow path: manual entry without invite code → run the full sync clone
+      // in the foreground so verification errors surface inline.
+      setConnectStep('Joining team...')
       await tauriInvoke<{ success: boolean; message: string }>('team_git_join', {
-        gitUrl: gitUrl.trim(),
+        gitUrl: gitUrlTrim,
         gitToken: effectiveGitToken,
-        gitBranch: gitBranch.trim() || null,
-        teamId: teamIdInput.trim(),
-        teamSecret: teamSecretInput.trim(),
-        memberName: memberName.trim(),
+        gitBranch: gitBranchTrim || null,
+        teamId: teamIdTrim,
+        teamSecret: teamSecretTrim,
+        memberName: memberNameTrim,
         llmBaseUrl: hostLlm ? (llmUrl || null) : null,
         llmModel: hostLlm ? (llmModels[0]?.id || null) : null,
         llmModelName: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
         llmModels: hostLlm && llmModels.length > 0 ? JSON.stringify(llmModels) : null,
-        fcEndpoint: joinedViaInvite ? MANAGED_GIT_FC_ENDPOINT : null,
+        fcEndpoint: null,
         ...workspaceArgs,
       })
       setConnectStep('Saving configuration...')
       const now = new Date().toISOString()
       const newConfig: TeamConfig = {
-        gitUrl: gitUrl.trim(),
+        gitUrl: gitUrlTrim,
         enabled: true,
         lastSyncAt: now,
-        teamId: teamIdInput.trim(),
+        teamId: teamIdTrim,
         ...(effectiveGitToken ? { gitToken: effectiveGitToken } : {}),
-        ...(gitBranch.trim() ? { gitBranch: gitBranch.trim() } : {}),
+        ...(gitBranchTrim ? { gitBranch: gitBranchTrim } : {}),
       }
       await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
       if (workspacePath) {

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
-use tauri::State;
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::commands::mcp::{self, MCPServerConfig};
 use crate::commands::opencode::OpenCodeState;
@@ -26,6 +26,11 @@ pub struct TeamConfig {
     /// Team ID for shared secrets (generated on create, provided on join)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub team_id: Option<String>,
+    /// LiteLLM/FC endpoint for this team (cached from invite code or _meta/team.json).
+    /// When set, this client knows the team is registered with cloud LiteLLM and can
+    /// re-trigger background clone or sync member operations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fc_endpoint: Option<String>,
 }
 
 /// A single model entry in the team LLM configuration.
@@ -105,6 +110,11 @@ pub struct TeamMeta {
     pub secret_verify: String,
     pub created_at: String,
     pub owner_node_id: String,
+    /// LiteLLM/FC endpoint URL. When set, joining members register their key
+    /// via this endpoint. Older team repos without this field default to no
+    /// LiteLLM (joiners can still join, but won't get a cloud key issued).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fc_endpoint: Option<String>,
 }
 
 /// Result of team git create
@@ -1047,12 +1057,18 @@ pub async fn team_git_create(
     let node_id = crate::commands::oss_commands::get_device_id()?;
 
     // Write _meta/team.json
+    let normalized_fc_endpoint = fc_endpoint
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.trim_end_matches('/').to_string());
     let team_meta = TeamMeta {
         team_id: team_id.clone(),
         team_name: team_name.clone(),
         secret_verify,
         created_at: chrono::Utc::now().to_rfc3339(),
         owner_node_id: node_id.clone(),
+        fc_endpoint: normalized_fc_endpoint,
     };
     let team_meta_path = team_path.join("_meta").join("team.json");
     let team_meta_json = serde_json::to_string_pretty(&team_meta)
@@ -1209,9 +1225,8 @@ pub async fn team_git_create(
     })
 }
 
-/// Join an existing team repo: clone, verify HMAC secret, add self as member.
-#[tauri::command]
-pub async fn team_git_join(
+/// Inputs to the team-join clone & member-registration work.
+struct TeamGitJoinArgs {
     git_url: String,
     git_token: Option<String>,
     git_branch: Option<String>,
@@ -1223,11 +1238,30 @@ pub async fn team_git_join(
     llm_model_name: Option<String>,
     llm_models: Option<String>,
     fc_endpoint: Option<String>,
-    workspace_path: Option<String>,
-    opencode_state: State<'_, OpenCodeState>,
-    secrets_state: State<'_, crate::commands::shared_secrets::SharedSecretsState>,
+    workspace_path: String,
+}
+
+/// Shared body for both the synchronous (`team_git_join`) and background
+/// (`team_git_join_background`) commands. Looks up `SharedSecretsState` from
+/// the AppHandle so it can run inside a `tokio::spawn` future.
+async fn team_git_join_impl(
+    app: AppHandle,
+    args: TeamGitJoinArgs,
 ) -> Result<TeamGitResult, String> {
-    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
+    let TeamGitJoinArgs {
+        git_url,
+        git_token,
+        git_branch,
+        team_id,
+        team_secret,
+        member_name,
+        llm_base_url,
+        llm_model,
+        llm_model_name,
+        llm_models,
+        fc_endpoint,
+        workspace_path,
+    } = args;
     let team_dir = get_team_repo_path(&workspace_path);
 
     // 1. Validate team_dir doesn't exist
@@ -1418,7 +1452,14 @@ pub async fn team_git_join(
     println!("[Team Join] Saved team_secret to keychain");
 
     // 12. Init shared secrets
-    crate::commands::shared_secrets::init_shared_secrets(&secrets_state, &team_secret, team_path)?;
+    {
+        let secrets_state = app.state::<crate::commands::shared_secrets::SharedSecretsState>();
+        crate::commands::shared_secrets::init_shared_secrets(
+            secrets_state.inner(),
+            &team_secret,
+            team_path,
+        )?;
+    }
     println!("[Team Join] Initialized shared secrets");
 
     // 13. Sync MCP configs
@@ -1471,6 +1512,123 @@ pub async fn team_git_join(
         message: format!("Joined team '{}' successfully", team_meta.team_name),
         ..Default::default()
     })
+}
+
+/// Join an existing team repo synchronously: clone, verify HMAC secret,
+/// add self as member. Used by the slow path (manual entry without invite code).
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn team_git_join(
+    app: AppHandle,
+    git_url: String,
+    git_token: Option<String>,
+    git_branch: Option<String>,
+    team_id: String,
+    team_secret: String,
+    member_name: String,
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
+    llm_models: Option<String>,
+    fc_endpoint: Option<String>,
+    workspace_path: Option<String>,
+    opencode_state: State<'_, OpenCodeState>,
+) -> Result<TeamGitResult, String> {
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
+    team_git_join_impl(
+        app,
+        TeamGitJoinArgs {
+            git_url,
+            git_token,
+            git_branch,
+            team_id,
+            team_secret,
+            member_name,
+            llm_base_url,
+            llm_model,
+            llm_model_name,
+            llm_models,
+            fc_endpoint,
+            workspace_path,
+        },
+    )
+    .await
+}
+
+/// Join an existing team repo in the background. Returns immediately after
+/// scheduling the work; the caller (frontend) is expected to have already
+/// verified the team secret + registered its LiteLLM key out-of-band (via FC
+/// `/ai/add-member`) so the user can be told "joined" before clone finishes.
+///
+/// Emits `team:git-join-clone-completed` (with TeamGitResult) on success and
+/// `team:git-join-clone-failed` (with `{ error: String }`) on failure. On
+/// failure also pushes a tray notification with the error message.
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn team_git_join_background(
+    app: AppHandle,
+    git_url: String,
+    git_token: Option<String>,
+    git_branch: Option<String>,
+    team_id: String,
+    team_secret: String,
+    member_name: String,
+    llm_base_url: Option<String>,
+    llm_model: Option<String>,
+    llm_model_name: Option<String>,
+    llm_models: Option<String>,
+    fc_endpoint: Option<String>,
+    workspace_path: Option<String>,
+    opencode_state: State<'_, OpenCodeState>,
+) -> Result<(), String> {
+    let workspace_path = resolve_workspace_path(workspace_path, &opencode_state)?;
+    let app_for_spawn = app.clone();
+    let args = TeamGitJoinArgs {
+        git_url,
+        git_token,
+        git_branch,
+        team_id: team_id.clone(),
+        team_secret,
+        member_name,
+        llm_base_url,
+        llm_model,
+        llm_model_name,
+        llm_models,
+        fc_endpoint,
+        workspace_path,
+    };
+    tokio::spawn(async move {
+        match team_git_join_impl(app_for_spawn.clone(), args).await {
+            Ok(result) => {
+                println!("[Team Join Background] completed: {}", result.message);
+                let _ = app_for_spawn.emit(
+                    "team:git-join-clone-completed",
+                    serde_json::json!({
+                        "teamId": team_id,
+                        "message": result.message,
+                    }),
+                );
+            }
+            Err(err) => {
+                eprintln!("[Team Join Background] failed: {err}");
+                let _ = app_for_spawn.emit(
+                    "team:git-join-clone-failed",
+                    serde_json::json!({
+                        "teamId": team_id,
+                        "error": err,
+                    }),
+                );
+                use tauri_plugin_notification::NotificationExt;
+                let _ = app_for_spawn
+                    .notification()
+                    .builder()
+                    .title("Team sync failed")
+                    .body(format!("Could not finish syncing team repo: {err}"))
+                    .show();
+            }
+        }
+    });
+    Ok(())
 }
 
 /// 1.4 - Ensure .gitignore in team repo dir has all required rules.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -427,6 +427,7 @@ pub fn run() {
             commands::team::team_init_repo,
             commands::team::team_git_create,
             commands::team::team_git_join,
+            commands::team::team_git_join_background,
             commands::team::init_git_team_secrets,
             commands::team::get_git_team_secret,
             commands::team::team_generate_gitignore,


### PR DESCRIPTION
## Summary
- "Refresh Sidecar" in Advanced Settings restarts OpenCode but doesn't re-run `applyTeamModelToOpenCode`, so the team Provider entry disappears from the list
- `ChatPanel`'s apply-effect can't catch it — its dep is `[openCodeReady, workspacePath]`, neither of which actually transitions during the manual refresh
- After `initAll()`, re-apply team config when `teamMode` is on (`force=true` to bypass the `_appliedConfigKey` short-circuit)

## Test plan
- [ ] Enable team mode in a workspace, confirm team provider appears in LLM Settings
- [ ] Hit "Refresh" in Advanced → verify team provider stays visible and selectable
- [ ] Verify model still works (send a chat message) after the refresh
- [ ] Non-team workspace: verify refresh still works as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)