### PR TITLE
fix(team): re-apply provider after sidecar refresh + secret display overflow

### DIFF
--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -168,6 +168,11 @@ export const LLMSection = React.memo(function LLMSection() {
       setOpenCodeBootstrapped(true, status.url)
       setOpenCodeReady(true, status.url)
       await initAll()
+      // Sidecar restart drops team provider state; ChatPanel's apply-effect doesn't re-fire (no openCodeReady transition).
+      const { teamMode: inTeamMode, applyTeamModelToOpenCode } = useTeamModeStore.getState()
+      if (inTeamMode) {
+        await applyTeamModelToOpenCode(workspacePath, true)
+      }
     } catch (err) {
       console.error('Failed to restart OpenCode after provider connect:', err)
       setOpenCodeBootstrapped(false)

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -1065,7 +1065,7 @@ export function TeamGitConfig() {
                   <div>
                     <label className="mb-1.5 block text-xs font-medium text-muted-foreground">{t('settings.team.teamId', 'Team ID')}</label>
                     <div className="flex items-center gap-1.5">
-                      <code className="flex-1 rounded-md bg-muted px-2.5 py-1.5 text-xs font-mono truncate">{teamConfig.teamId}</code>
+                      <code className="flex-1 min-w-0 rounded-md bg-muted px-2.5 py-1.5 text-xs font-mono truncate">{teamConfig.teamId}</code>
                       <Button
                         variant="ghost"
                         size="sm"
@@ -1079,7 +1079,7 @@ export function TeamGitConfig() {
                   <div>
                     <label className="mb-1.5 block text-xs font-medium text-muted-foreground">{t('settings.team.teamSecret', 'Team Secret')}</label>
                     <div className="flex items-center gap-1.5">
-                      <code className="flex-1 rounded-md bg-muted px-2.5 py-1.5 text-xs font-mono truncate">
+                      <code className="flex-1 min-w-0 rounded-md bg-muted px-2.5 py-1.5 text-xs font-mono truncate">
                         {showTeamSecret && loadedTeamSecret ? loadedTeamSecret : '••••••••••••••••'}
                       </code>
                       <Button
@@ -1250,7 +1250,7 @@ export function TeamGitConfig() {
               <div className="space-y-1.5">
                 <label className="text-sm font-medium">{t('settings.team.inviteCode', 'Invite Code')}</label>
                 <div className="flex items-center gap-2">
-                  <code className="flex-1 rounded-md bg-violet-50 dark:bg-violet-950/30 border border-violet-200 dark:border-violet-800 px-3 py-2 text-xs font-mono break-all max-h-20 overflow-y-auto">
+                  <code className="flex-1 min-w-0 rounded-md bg-violet-50 dark:bg-violet-950/30 border border-violet-200 dark:border-violet-800 px-3 py-2 text-xs font-mono break-all max-h-20 overflow-y-auto">
                     {createdInviteCode}
                   </code>
                   <Button
@@ -1269,7 +1269,7 @@ export function TeamGitConfig() {
             <div className="space-y-1.5">
               <label className="text-sm font-medium">{t('settings.team.teamId', 'Team ID')}</label>
               <div className="flex items-center gap-2">
-                <code className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
+                <code className="flex-1 min-w-0 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
                   {createdTeamId}
                 </code>
                 <Button
@@ -1286,7 +1286,7 @@ export function TeamGitConfig() {
             <div className="space-y-1.5">
               <label className="text-sm font-medium">{t('settings.team.teamSecret', 'Team Secret')}</label>
               <div className="flex items-center gap-2">
-                <code className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
+                <code className="flex-1 min-w-0 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
                   {showCreatedSecret ? createdTeamSecret : createdTeamSecret.replace(/./g, '*')}
                 </code>
                 <Button


### PR DESCRIPTION
## Summary
Two related team-mode UI bugs:

**1. Team LLM provider disappears after Advanced → Refresh Sidecar.**
The handler in `LLMSection.tsx` restarts OpenCode and re-runs `initAll()`, but never re-applies the team provider config. `ChatPanel`'s apply-effect can't catch it either — its dep is `[openCodeReady, workspacePath]`, neither of which transitions during the manual refresh. After `initAll()`, re-run `applyTeamModelToOpenCode(workspacePath, true)` when in team mode (`force=true` to bypass the `_appliedConfigKey` short-circuit).

**2. Team Secret / Team ID / Invite Code overflow the container.**
Five `<code className="flex-1 ... truncate|break-all">` blocks in `TeamGitConfig.tsx` lacked `min-w-0`. Flex items default to `min-width: auto`, so a long unbroken string of asterisks (or base64 invite code) refused to shrink — pushing eye/copy buttons mid-string and bleeding past the dialog edge. Adding `min-w-0` lets `truncate` ellipsize and `break-all` wrap as intended.

## Test plan
- [ ] **Provider refresh**: Enable team mode, hit Advanced → Refresh Sidecar → confirm team provider stays in the providers list and is selectable
- [ ] **Provider refresh (non-team)**: Confirm refresh still works in a non-team workspace (no regression)
- [ ] **Secret overflow**: Open "Team Created Successfully" dialog → confirm Team ID / Team Secret / Invite Code all stay within the dialog with eye/copy buttons positioned at the right edge
- [ ] **Settings overflow**: In Team settings → confirm the masked Team Secret row no longer pushes eye/copy buttons outside the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)