### PR TITLE
fix(team): add .gitkeep so empty scaffold dirs survive initial commit

### DIFF
--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -1019,7 +1019,11 @@ pub async fn team_git_create(
         .map_err(|e| format!("Failed to generate random secret: {e}"))?;
     let team_secret = hex::encode(secret_bytes);
 
-    // Scaffold standard team directories
+    // Scaffold standard team directories. Git doesn't track empty
+    // directories, so we drop a .gitkeep placeholder in each one — otherwise
+    // members cloning the repo only see whichever folders happened to receive
+    // a tracked file (e.g. _meta got team.json/members.json) and miss the
+    // rest of the layout.
     let team_path = Path::new(&team_dir);
     for d in &[
         "skills",
@@ -1029,8 +1033,14 @@ pub async fn team_git_create(
         "_meta",
         "_secrets",
     ] {
-        std::fs::create_dir_all(team_path.join(d))
+        let dir_path = team_path.join(d);
+        std::fs::create_dir_all(&dir_path)
             .map_err(|e| format!("Failed to create {}: {}", d, e))?;
+        let gitkeep_path = dir_path.join(".gitkeep");
+        if !gitkeep_path.exists() {
+            std::fs::write(&gitkeep_path, "")
+                .map_err(|e| format!("Failed to write {}/.gitkeep: {}", d, e))?;
+        }
     }
 
     // Write README.md if missing


### PR DESCRIPTION
## Summary

\`team_git_create\` scaffolds \`skills/\`, \`.mcp/\`, \`knowledge/\`, \`_feedback/\`, \`_meta/\`, \`_secrets/\` but git won't track empty directories. The initial commit only carried folders that happened to receive a tracked file (\`_meta/\` got \`team.json\` + \`members.json\`), so joiners cloned a half-built layout — \`skills/\`, \`.mcp/\`, \`knowledge/\`, \`_feedback/\` were all missing.

This drops a \`.gitkeep\` placeholder in each scaffold dir before \`git add -A\`. The team's whitelist \`.gitignore\` (\`!skills/**\` etc.) already permits it, so no gitignore changes are needed.

## Why this is its own PR

Independent bug from #404. Has been broken since \`team_git_create\` shipped — anyone who created a managed-Git team got the truncated layout. Doesn't depend on the fast-path join changes.

## Files

- \`src-tauri/src/commands/team.rs\` — scaffold loop in \`team_git_create\` now writes \`.gitkeep\` to each created directory.

## Test plan

- [x] \`pnpm rust:check\` clean
- [ ] Manual: create a managed-Git team via the UI, then in Codeup confirm all 6 dirs (\`skills/\`, \`.mcp/\`, \`knowledge/\`, \`_feedback/\`, \`_meta/\`, \`_secrets/\`) are present with their \`.gitkeep\` files.
- [ ] Manual: a second member joins via invite code, verify their local \`teamclaw-team/\` has all 6 dirs.

## Migrating existing teams

Pre-existing teams missing dirs can be patched manually:
\`\`\`bash
cd <workspace>/teamclaw-team
mkdir -p skills .mcp knowledge _feedback
touch skills/.gitkeep .mcp/.gitkeep knowledge/.gitkeep _feedback/.gitkeep
git add . && git commit -m "chore: backfill scaffold dirs" && git push
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)