### PR TITLE
fix(team): fall back to team_meta.fc_endpoint on manual join

### DIFF
--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -1334,6 +1334,18 @@ async fn team_git_join_impl(
         ));
     }
 
+    // If the caller didn't pass an fc_endpoint (e.g. manual entry without an
+    // invite code), fall back to the team's persisted value from
+    // _meta/team.json so the FC `/ai/add-member` block below still fires.
+    // Invite-code joins already had FC called by the frontend and intentionally
+    // pass None to avoid duplicate registration — that path is unaffected.
+    let fc_endpoint = fc_endpoint
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .or_else(|| team_meta.fc_endpoint.clone());
+
     // 5. Verify team_secret via HMAC comparison
     let computed_verify = match compute_secret_verify(&team_secret) {
         Ok(v) => v,


### PR DESCRIPTION
## Summary

Manual team joins (paste team_id + secret + git URL, no invite code) didn't auto-register with LiteLLM, even when \`_meta/team.json\` declared the team's \`fcEndpoint\`. The fast path covers invite-code joins, but the slow path's FC fire-and-forget block (\`if let Some(endpoint) = fc_endpoint\`) only fires when the frontend explicitly hands over an endpoint — and the frontend has none for manual entries.

This PR closes that gap: after \`team_git_join_impl\` reads \`team_meta\` from the cloned repo, fall back to \`team_meta.fc_endpoint\` when the caller didn't supply one.

## Why this is its own PR

Independent of the merged #404 (fast-path) and #408 (.gitkeep). #404 made the persisted-fcEndpoint mechanism possible by writing \`fc_endpoint\` into \`TeamMeta\` on create; this PR is the missing read on the join side that makes it actually take effect for manual joins.

## Behavior matrix

| Join path | Before this PR | After this PR |
|---|---|---|
| Invite code (fast path) | ✅ frontend POSTs \`/ai/add-member\` directly | ✅ unchanged |
| Manual entry, team.json has \`fcEndpoint\` | ❌ no FC call | ✅ FC fires from \`team_meta.fc_endpoint\` |
| Manual entry, team.json has no \`fcEndpoint\` | ❌ no FC call (no-op) | ❌ no FC call (no-op) |

The fast path explicitly passes \`fcEndpoint: null\` to \`team_git_join_background\` to avoid duplicate \`/ai/add-member\` calls — that contract is preserved (the fallback only kicks in when the param is None).

## Files

- \`src-tauri/src/commands/team.rs\` — 12-line addition after step 3 of \`team_git_join_impl\` to shadow \`fc_endpoint\` with \`team_meta.fc_endpoint\` when the caller's value is empty/missing.

## Test plan

- [x] \`pnpm rust:check\` clean
- [ ] Manual: managed-Git team owner creates team (with \`fcEndpoint\` written into \`_meta/team.json\` by #404). New member uses **manual entry** (no invite code) to join → confirm a LiteLLM key gets issued for them.
- [ ] Manual: invite-code join still works and doesn't double-register (frontend's POST + backend's fallback = two calls otherwise; verified by code that frontend passes \`null\`, so backend's fallback is the only call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)