### PR TITLE
fix(team): reconcile provider.team in Rust, additive-only at runtime

### DIFF
--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -199,7 +199,6 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
   const openCodeBootstrapped = useWorkspaceStore(s => s.openCodeBootstrapped);
   const openCodeReady = useWorkspaceStore(s => s.openCodeReady);
   const setOpenCodeBootstrapped = useWorkspaceStore(s => s.setOpenCodeBootstrapped);
-  const setOpenCodeReady = useWorkspaceStore(s => s.setOpenCodeReady);
 
   // ── Local state ───────────────────────────────────────────────────────
   const inputValue = draftInput;
@@ -712,17 +711,9 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
   const handleRestartSkillsRuntime = React.useCallback(async () => {
     if (!workspacePath) return;
     setIsRestartingSkillsRuntime(true);
-    setOpenCodeBootstrapped(false);
     try {
-      await invoke("stop_opencode");
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      const status = await invoke<{ url: string }>("start_opencode", {
-        config: { workspace_path: workspacePath },
-      });
-      const { initOpenCodeClient } = await import("@/lib/opencode/sdk-client");
-      initOpenCodeClient({ baseUrl: status.url, workspacePath });
-      setOpenCodeBootstrapped(true, status.url);
-      setOpenCodeReady(true, status.url);
+      const { restartOpencode } = await import("@/lib/opencode/restart");
+      await restartOpencode(workspacePath);
       setHasSkillRestartPrompt(false);
     } catch (error) {
       console.error("[ChatPanel] Failed to restart OpenCode for skills:", error);
@@ -731,7 +722,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     } finally {
       setIsRestartingSkillsRuntime(false);
     }
-  }, [workspacePath, setOpenCodeBootstrapped, setOpenCodeReady, setError]);
+  }, [workspacePath, setOpenCodeBootstrapped, setError]);
 
   // ── Empty state with suggestions ──────────────────────────────────────
   const emptyState = React.useMemo(() => (

--- a/packages/app/src/components/settings/EnvVarsSection.tsx
+++ b/packages/app/src/components/settings/EnvVarsSection.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { KeyRound, Plus, Eye, EyeOff, Pencil, Trash2, ShieldCheck, AlertCircle, RefreshCw, Loader2, Users, User, Lock, Copy, Check } from 'lucide-react'
-import { invoke } from '@tauri-apps/api/core'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -20,7 +19,7 @@ import { useTeamMembersStore } from '@/stores/team-members'
 // `myRole` is null until the user joins a team; gate team-shared UI on it so
 // users without a team don't hit the backend's `secrets not initialized` error.
 import { useWorkspaceStore } from '@/stores/workspace'
-import { initOpenCodeClient } from '@/lib/opencode/sdk-client'
+import { restartOpencode } from '@/lib/opencode/restart'
 import { listen } from '@tauri-apps/api/event'
 
 // ─── Unified type for the combined list ─────────────────────────────────
@@ -616,12 +615,7 @@ export const EnvVarsSection = React.memo(function EnvVarsSection() {
     setIsRestarting(true)
     setRestartError(null)
     try {
-      await invoke('stop_opencode')
-      await new Promise((resolve) => setTimeout(resolve, 500))
-      const status = await invoke<{ url: string }>('start_opencode', {
-        config: { workspace_path: workspacePath },
-      })
-      initOpenCodeClient({ baseUrl: status.url })
+      await restartOpencode(workspacePath)
       setHasChanges(false)
       setDirtyKeys(new Set())
     } catch (err) {

--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -19,11 +19,10 @@ import {
   Copy,
   Check,
 } from 'lucide-react'
-import { invoke } from '@tauri-apps/api/core'
 import { useProviderStore } from '@/stores/provider'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useTeamModeStore } from '@/stores/team-mode'
-import { initOpenCodeClient } from '@/lib/opencode/sdk-client'
+import { restartOpencode } from '@/lib/opencode/restart'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -153,30 +152,14 @@ export const LLMSection = React.memo(function LLMSection() {
     }
   }, [openCodeReady])
 
-  // Restart OpenCode sidecar so newly connected providers take effect
   const restartOpenCodeAndRefresh = async () => {
     if (!workspacePath) return
-    const { setOpenCodeBootstrapped, setOpenCodeReady } = useWorkspaceStore.getState()
     try {
-      setOpenCodeBootstrapped(false)
-      await invoke('stop_opencode')
-      const status = await invoke<{ url: string }>('start_opencode', {
-        config: { workspace_path: workspacePath },
-      })
-      // Pass workspacePath so API requests include the directory param
-      initOpenCodeClient({ baseUrl: status.url, workspacePath })
-      setOpenCodeBootstrapped(true, status.url)
-      setOpenCodeReady(true, status.url)
+      await restartOpencode(workspacePath)
       await initAll()
-      // Sidecar restart drops team provider state; ChatPanel's apply-effect doesn't re-fire (no openCodeReady transition).
-      const { teamMode: inTeamMode, applyTeamModelToOpenCode } = useTeamModeStore.getState()
-      if (inTeamMode) {
-        await applyTeamModelToOpenCode(workspacePath, true)
-      }
     } catch (err) {
       console.error('Failed to restart OpenCode after provider connect:', err)
-      setOpenCodeBootstrapped(false)
-      // Fallback: just refresh without restart
+      useWorkspaceStore.getState().setOpenCodeBootstrapped(false)
       await Promise.all([refreshProviders(), refreshConfiguredProviders()])
     }
   }

--- a/packages/app/src/components/settings/PermissionManagementSection.tsx
+++ b/packages/app/src/components/settings/PermissionManagementSection.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react'
 import { invoke } from '@tauri-apps/api/core'
 import { useWorkspaceStore } from '@/stores/workspace'
+import { restartOpencode } from '@/lib/opencode/restart'
 import { cn, isTauri } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -218,14 +219,8 @@ export const PermissionManagementSection = React.memo(function PermissionManagem
       setConfigModified(false)
       invalidatePermissionConfigCache()
 
-      // Restart OpenCode so the new permission config takes effect immediately
       try {
-        await invoke('stop_opencode')
-        await new Promise((resolve) => setTimeout(resolve, 500))
-        await invoke('start_opencode', {
-          config: { workspace_path: workspacePath },
-        })
-        console.log('[PermissionManagement] OpenCode restarted with new permissions')
+        await restartOpencode(workspacePath)
       } catch (restartErr) {
         console.error('[PermissionManagement] Failed to restart OpenCode:', restartErr)
       }

--- a/packages/app/src/components/settings/SkillsSection.tsx
+++ b/packages/app/src/components/settings/SkillsSection.tsx
@@ -30,7 +30,7 @@ import {
 import { invoke } from '@tauri-apps/api/core'
 import { SKILLS_CHANGED_EVENT } from '@/hooks/useAppInit'
 import { useWorkspaceStore } from '@/stores/workspace'
-import { initOpenCodeClient } from '@/lib/opencode/sdk-client'
+import { restartOpencode } from '@/lib/opencode/restart'
 import { cn } from '@/lib/utils'
 import { buildConfig } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
@@ -301,14 +301,7 @@ export const SkillsSection = React.memo(function SkillsSection({
   const restartOpenCodeInstance = React.useCallback(
     async (options?: RestartOptions) => {
       if (!workspacePath) return
-
-      await invoke('stop_opencode')
-      await new Promise((resolve) => setTimeout(resolve, 500))
-      const status = await invoke<{ url: string }>('start_opencode', {
-        config: { workspace_path: workspacePath },
-      })
-      initOpenCodeClient({ baseUrl: status.url, workspacePath })
-
+      await restartOpencode(workspacePath)
       if (!options?.preserveChangeFlag) {
         setHasChanges(false)
       }

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -289,6 +289,14 @@ export function TeamGitConfig() {
                 buildTeamProviderConfig(pending.hostLlm, pending.llmUrl, pending.llmModels),
                 pending.hostLlm ? pending.llmModels[0]?.id : undefined,
               )
+              // Push the new team provider into the running sidecar without
+              // waiting for the 1s file-watcher debounce.
+              const { useTeamModeStore } = await import('@/stores/team-mode')
+              const store = useTeamModeStore.getState()
+              await store.loadTeamConfig(pending.workspacePath)
+              if (useTeamModeStore.getState().teamMode) {
+                await store.applyTeamModelToOpenCode(pending.workspacePath, true)
+              }
             } catch (err) {
               console.warn('[Team Join] Deferred provider save failed:', err)
             }
@@ -651,6 +659,14 @@ export function TeamGitConfig() {
       await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
       if (workspacePath) {
         await saveTeamProviderFile(workspacePath, buildTeamProviderConfig(hostLlm, llmUrl, llmModels), hostLlm ? llmModels[0]?.id : undefined)
+        // Push the new team provider into the running sidecar without
+        // waiting for the 1s file-watcher debounce.
+        const { useTeamModeStore } = await import('@/stores/team-mode')
+        const store = useTeamModeStore.getState()
+        await store.loadTeamConfig(workspacePath)
+        if (useTeamModeStore.getState().teamMode) {
+          await store.applyTeamModelToOpenCode(workspacePath, true)
+        }
       }
       setTeamConfig(newConfig)
       setState('connected')

--- a/packages/app/src/lib/__tests__/team-provider.test.ts
+++ b/packages/app/src/lib/__tests__/team-provider.test.ts
@@ -79,7 +79,7 @@ describe('team provider file helpers', () => {
     )
   })
 
-  it('syncs provider.json into workspace opencode.json', async () => {
+  it('loads provider.json into a TeamProviderFile', async () => {
     mockExists.mockImplementation(async (path: string) => path === '/workspace/teamclaw-team/_meta/provider.json')
     mockReadTextFile.mockResolvedValue(JSON.stringify({
       version: 1,
@@ -96,26 +96,20 @@ describe('team provider file helpers', () => {
       },
     }))
 
-    const { syncTeamProviderToOpenCode } = await import('@/lib/team-provider')
-    const result = await syncTeamProviderToOpenCode('/workspace')
+    const { loadTeamProviderFile } = await import('@/lib/team-provider')
+    const result = await loadTeamProviderFile('/workspace')
 
     expect(result?.provider.baseURL).toBe('https://ai.ucar.cc')
-    expect(mockAddCustomProviderToConfig).toHaveBeenCalledWith('/workspace', {
-      name: 'Team',
-      baseURL: 'https://ai.ucar.cc',
-      apiKey: '${tc_api_key}',
-      models: [
-        { modelId: 'default', modelName: 'Default', limit: { context: 256000, output: 16000 } },
-        { modelId: 'pro', modelName: 'Pro', limit: { context: 256000, output: 16000 } },
-      ],
-    })
+    expect(result?.provider.models).toHaveLength(2)
+    expect(mockAddCustomProviderToConfig).not.toHaveBeenCalled()
   })
 
-  it('removes the shared provider from opencode.json when provider.json is absent', async () => {
-    const { syncTeamProviderToOpenCode } = await import('@/lib/team-provider')
-    const result = await syncTeamProviderToOpenCode('/workspace')
+  it('returns null when provider.json is absent and never writes opencode.json', async () => {
+    const { loadTeamProviderFile } = await import('@/lib/team-provider')
+    const result = await loadTeamProviderFile('/workspace')
 
     expect(result).toBeNull()
-    expect(mockRemoveCustomProviderFromConfig).toHaveBeenCalledWith('/workspace', 'team')
+    expect(mockAddCustomProviderToConfig).not.toHaveBeenCalled()
+    expect(mockRemoveCustomProviderFromConfig).not.toHaveBeenCalled()
   })
 })

--- a/packages/app/src/lib/opencode/restart.ts
+++ b/packages/app/src/lib/opencode/restart.ts
@@ -1,17 +1,15 @@
 import { invoke } from '@tauri-apps/api/core'
 import { initOpenCodeClient } from './sdk-client'
 import { useWorkspaceStore } from '@/stores/workspace'
-import { useTeamModeStore } from '@/stores/team-mode'
 
 export interface RestartResult {
   url: string
 }
 
-// Stop+start the OpenCode sidecar and restore everything callers tend to forget:
-// the SDK client URL, bootstrapped/ready flags, and the team LLM provider config
-// (which the sidecar drops on stop, and which ChatPanel's apply-effect can't
-// recover without an openCodeReady transition). Throws on failure; caller decides
-// how to surface it. Set bootstrapped=false in the catch path if you need it.
+// Stop+start the OpenCode sidecar and restore the SDK client URL and ready flags.
+// Provider state (including the team provider) is reconciled by the Rust
+// `ensure_team_provider` step inside `start_opencode` itself, so callers don't
+// need to re-apply team config here.
 export async function restartOpencode(workspacePath: string): Promise<RestartResult> {
   const { setOpenCodeBootstrapped, setOpenCodeReady } = useWorkspaceStore.getState()
   setOpenCodeBootstrapped(false)
@@ -23,11 +21,5 @@ export async function restartOpencode(workspacePath: string): Promise<RestartRes
   initOpenCodeClient({ baseUrl: status.url, workspacePath })
   setOpenCodeBootstrapped(true, status.url)
   setOpenCodeReady(true, status.url)
-
-  const { teamMode, applyTeamModelToOpenCode } = useTeamModeStore.getState()
-  if (teamMode) {
-    await applyTeamModelToOpenCode(workspacePath, true)
-  }
-
   return { url: status.url }
 }

--- a/packages/app/src/lib/opencode/restart.ts
+++ b/packages/app/src/lib/opencode/restart.ts
@@ -1,0 +1,33 @@
+import { invoke } from '@tauri-apps/api/core'
+import { initOpenCodeClient } from './sdk-client'
+import { useWorkspaceStore } from '@/stores/workspace'
+import { useTeamModeStore } from '@/stores/team-mode'
+
+export interface RestartResult {
+  url: string
+}
+
+// Stop+start the OpenCode sidecar and restore everything callers tend to forget:
+// the SDK client URL, bootstrapped/ready flags, and the team LLM provider config
+// (which the sidecar drops on stop, and which ChatPanel's apply-effect can't
+// recover without an openCodeReady transition). Throws on failure; caller decides
+// how to surface it. Set bootstrapped=false in the catch path if you need it.
+export async function restartOpencode(workspacePath: string): Promise<RestartResult> {
+  const { setOpenCodeBootstrapped, setOpenCodeReady } = useWorkspaceStore.getState()
+  setOpenCodeBootstrapped(false)
+  await invoke('stop_opencode')
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  const status = await invoke<{ url: string }>('start_opencode', {
+    config: { workspace_path: workspacePath },
+  })
+  initOpenCodeClient({ baseUrl: status.url, workspacePath })
+  setOpenCodeBootstrapped(true, status.url)
+  setOpenCodeReady(true, status.url)
+
+  const { teamMode, applyTeamModelToOpenCode } = useTeamModeStore.getState()
+  if (teamMode) {
+    await applyTeamModelToOpenCode(workspacePath, true)
+  }
+
+  return { url: status.url }
+}

--- a/packages/app/src/lib/team-provider.ts
+++ b/packages/app/src/lib/team-provider.ts
@@ -1,9 +1,6 @@
 import { exists, mkdir, readTextFile, remove, writeTextFile } from '@tauri-apps/plugin-fs'
 import { TEAM_REPO_DIR } from '@/lib/build-config'
-import {
-  addCustomProviderToConfig,
-  type CustomProviderConfig,
-} from '@/lib/opencode/config'
+import type { CustomProviderConfig } from '@/lib/opencode/config'
 
 export const TEAM_SHARED_PROVIDER_ID = 'team'
 
@@ -101,28 +98,6 @@ export async function saveTeamProviderFile(
   }
 
   await writeTextFile(path, JSON.stringify(file, null, 2))
-}
-
-// Additive only: never removes provider.team. Removal is owned by the Rust
-// `ensure_team_provider` reconcile that runs at sidecar startup, where disk
-// state is trusted. A transient miss here (file-watcher firing mid-git-sync,
-// parse race) used to silently yank the team provider out of opencode.json.
-export async function syncTeamProviderToOpenCode(workspacePath: string): Promise<TeamProviderFile | null> {
-  const providerFile = await loadTeamProviderFile(workspacePath)
-  if (!providerFile) return null
-
-  await addCustomProviderToConfig(workspacePath, {
-    name: providerFile.provider.name,
-    baseURL: providerFile.provider.baseURL,
-    apiKey: providerFile.provider.apiKey,
-    models: providerFile.provider.models.map((model) => ({
-      modelId: model.id,
-      modelName: model.name,
-      limit: { context: 256000, output: 16000 },
-    })),
-  })
-
-  return providerFile
 }
 
 export async function loadTeamProviderFormState(workspacePath: string): Promise<TeamProviderFormState | null> {

--- a/packages/app/src/lib/team-provider.ts
+++ b/packages/app/src/lib/team-provider.ts
@@ -2,7 +2,6 @@ import { exists, mkdir, readTextFile, remove, writeTextFile } from '@tauri-apps/
 import { TEAM_REPO_DIR } from '@/lib/build-config'
 import {
   addCustomProviderToConfig,
-  removeCustomProviderFromConfig,
   type CustomProviderConfig,
 } from '@/lib/opencode/config'
 
@@ -104,12 +103,13 @@ export async function saveTeamProviderFile(
   await writeTextFile(path, JSON.stringify(file, null, 2))
 }
 
+// Additive only: never removes provider.team. Removal is owned by the Rust
+// `ensure_team_provider` reconcile that runs at sidecar startup, where disk
+// state is trusted. A transient miss here (file-watcher firing mid-git-sync,
+// parse race) used to silently yank the team provider out of opencode.json.
 export async function syncTeamProviderToOpenCode(workspacePath: string): Promise<TeamProviderFile | null> {
   const providerFile = await loadTeamProviderFile(workspacePath)
-  if (!providerFile) {
-    await removeCustomProviderFromConfig(workspacePath, TEAM_SHARED_PROVIDER_ID)
-    return null
-  }
+  if (!providerFile) return null
 
   await addCustomProviderToConfig(workspacePath, {
     name: providerFile.provider.name,

--- a/packages/app/src/stores/__tests__/team-mode-git-file-status.test.ts
+++ b/packages/app/src/stores/__tests__/team-mode-git-file-status.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockInvoke = vi.fn()
-const mockSyncTeamProviderToOpenCode = vi.fn()
+const mockLoadTeamProviderFile = vi.fn()
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
@@ -12,14 +12,13 @@ vi.mock('@/lib/utils', () => ({
 }))
 
 vi.mock('@/lib/opencode/config', () => ({
-  addCustomProviderToConfig: vi.fn(),
-  getCustomProviderConfig: vi.fn(),
-  removeCustomProviderFromConfig: vi.fn(),
+  getCustomProviderConfig: vi.fn().mockResolvedValue(null),
+  removeCustomProviderFromConfig: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@/lib/team-provider', () => ({
   TEAM_SHARED_PROVIDER_ID: 'team',
-  syncTeamProviderToOpenCode: mockSyncTeamProviderToOpenCode,
+  loadTeamProviderFile: mockLoadTeamProviderFile,
 }))
 
 vi.mock('@/stores/provider', () => ({
@@ -36,6 +35,19 @@ vi.mock('@/lib/opencode/sdk-client', () => ({
   initOpenCodeClient: vi.fn(),
 }))
 
+vi.mock('@/lib/opencode/restart', () => ({
+  restartOpencode: vi.fn().mockResolvedValue({ url: 'http://test' }),
+}))
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: {
+    getState: () => ({
+      setOpenCodeBootstrapped: vi.fn(),
+      setOpenCodeReady: vi.fn(),
+    }),
+  },
+}))
+
 vi.mock('@/lib/build-config', () => ({
   appShortName: 'teamclaw',
   TEAM_REPO_DIR: 'teamclaw-team',
@@ -44,8 +56,8 @@ vi.mock('@/lib/build-config', () => ({
 
 beforeEach(() => {
   mockInvoke.mockReset()
-  mockSyncTeamProviderToOpenCode.mockReset()
-  mockSyncTeamProviderToOpenCode.mockResolvedValue(null)
+  mockLoadTeamProviderFile.mockReset()
+  mockLoadTeamProviderFile.mockResolvedValue(null)
 })
 
 describe('loadTeamGitFileSyncStatus', () => {
@@ -101,7 +113,7 @@ describe('loadTeamGitFileSyncStatus', () => {
   })
 
   it('applies provider.json when present before falling back to legacy llm config', async () => {
-    mockSyncTeamProviderToOpenCode.mockResolvedValueOnce({
+    mockLoadTeamProviderFile.mockResolvedValueOnce({
       version: 1,
       provider: {
         id: 'team',
@@ -128,7 +140,7 @@ describe('loadTeamGitFileSyncStatus', () => {
 
     await useTeamModeStore.getState().applyTeamModelToOpenCode('/ws')
 
-    expect(mockSyncTeamProviderToOpenCode).toHaveBeenCalledWith('/ws')
+    expect(mockLoadTeamProviderFile).toHaveBeenCalledWith('/ws')
     expect(useTeamModeStore.getState().teamModelConfig).toEqual({
       baseUrl: 'https://ai.ucar.cc',
       model: 'pro',

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -1,10 +1,9 @@
 import { create } from 'zustand'
 import {
-  addCustomProviderToConfig,
   getCustomProviderConfig,
   removeCustomProviderFromConfig,
 } from '@/lib/opencode/config'
-import { syncTeamProviderToOpenCode, TEAM_SHARED_PROVIDER_ID } from '@/lib/team-provider'
+import { loadTeamProviderFile, TEAM_SHARED_PROVIDER_ID } from '@/lib/team-provider'
 import { useProviderStore } from './provider'
 import { isTauri } from '@/lib/utils'
 import { appShortName, buildConfig, TEAM_REPO_DIR, type TeamModelOption } from '@/lib/build-config'
@@ -147,7 +146,7 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
         // Fire-and-forget; errors swallowed inside action
         get().loadTeamGitFileSyncStatus(_workspacePath)
       }
-      const providerFile = _workspacePath ? await syncTeamProviderToOpenCode(_workspacePath).catch(() => null) : null
+      const providerFile = _workspacePath ? await loadTeamProviderFile(_workspacePath).catch(() => null) : null
       if (providerFile?.provider) {
         const teamModels = providerFile.provider.models
         const defaultModelId = providerFile.provider.defaultModel || teamModels[0]?.id || ''
@@ -204,14 +203,17 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
   },
 
   applyTeamModelToOpenCode: async (workspacePath: string, force?: boolean) => {
-    const syncedProviderFile = await syncTeamProviderToOpenCode(workspacePath).catch(() => null)
-    if (syncedProviderFile?.provider) {
-      const syncedModels = syncedProviderFile.provider.models
-      const defaultModelId = syncedProviderFile.provider.defaultModel || syncedModels[0]?.id || ''
+    // Refresh in-memory state from `_meta/provider.json`. Disk → opencode.json
+    // sync is owned by Rust `ensure_team_provider`, which runs inside every
+    // start_opencode — we never write opencode.json from here.
+    const providerFile = await loadTeamProviderFile(workspacePath).catch(() => null)
+    if (providerFile?.provider) {
+      const syncedModels = providerFile.provider.models
+      const defaultModelId = providerFile.provider.defaultModel || syncedModels[0]?.id || ''
       const defaultModel = syncedModels.find((model) => model.id === defaultModelId) || syncedModels[0]
       set({
         teamModelConfig: {
-          baseUrl: normalizeLlmBaseUrl(syncedProviderFile.provider.baseURL),
+          baseUrl: normalizeLlmBaseUrl(providerFile.provider.baseURL),
           model: defaultModel?.id || '',
           modelName: defaultModel?.name || defaultModel?.id || '',
         },
@@ -235,71 +237,24 @@ export const useTeamModeStore = create<TeamModeState>((set, get) => ({
         } catch { /* ignore */ }
       }
 
-      // Build model configs — use models from team config (state), fallback to build config
-      const teamModels = get().teamModelOptions.length > 0 ? get().teamModelOptions : buildConfig.team.llm.models
-      const modelConfigs: any[] = teamModels && teamModels.length > 0
-        ? teamModels.map((m) => {
-            const mc: any = {
-              modelId: m.id,
-              modelName: m.name,
-              limit: { context: 256000, output: 16000 },
-            }
-            if (buildConfig.team.llm.supportsVision) {
-              mc.modalities = { input: ['text', 'image'], output: ['text'] }
-            }
-            return mc
-          })
-        : [{
-            modelId: teamModelConfig.model,
-            modelName: teamModelConfig.modelName,
-            limit: { context: 256000, output: 16000 },
-            ...(buildConfig.team.llm.supportsVision
-              ? { modalities: { input: ['text', 'image'], output: ['text'] } }
-              : {}),
-          }]
-
-      // Check if the provider config already exists in opencode.json with matching values.
-      // If so, skip the disruptive restart — the sidecar already loaded the correct config.
-      const existingConfig = await getCustomProviderConfig(workspacePath, TEAM_PROVIDER_ID)
-      const expectedModelIds = modelConfigs.map((m) => m.modelId).sort()
+      // Skip the restart if the running sidecar's opencode.json already matches what
+      // we want — Rust `ensure_team_provider` writes it on cold start, so post-boot
+      // applyTeamModelToOpenCode calls are usually no-ops.
+      const teamModels = get().teamModelOptions.length > 0 ? get().teamModelOptions : (buildConfig.team.llm.models ?? [])
+      const expectedModelIds = teamModels.map((m) => m.id).sort()
+      const existingConfig = await getCustomProviderConfig(workspacePath, TEAM_PROVIDER_ID).catch(() => null)
       const existingModelIds = existingConfig?.models.map((m) => m.modelId).sort() ?? []
-      const configAlreadyMatches = existingConfig
+      const configAlreadyMatches = !!existingConfig
         && existingConfig.baseURL === teamModelConfig.baseUrl
         && JSON.stringify(expectedModelIds) === JSON.stringify(existingModelIds)
 
-      if (!configAlreadyMatches) {
-        await addCustomProviderToConfig(workspacePath, {
-          name: 'Team',
-          baseURL: teamModelConfig.baseUrl,
-          apiKey: '${tc_api_key}',
-          models: modelConfigs,
-        })
-
-        // Restart OpenCode to pick up new provider config
-        if (isTauri()) {
-          const { invoke } = await import('@tauri-apps/api/core')
-          const { initOpenCodeClient } = await import('@/lib/opencode/sdk-client')
-
-          await invoke('stop_opencode')
-          await new Promise((r) => setTimeout(r, 500))
-          const status = await invoke<{ url: string }>('start_opencode', {
-            config: { workspace_path: workspacePath },
-          })
-          initOpenCodeClient({ baseUrl: status.url, workspacePath })
-
-          const { useWorkspaceStore } = await import('./workspace')
-          useWorkspaceStore.getState().setOpenCodeReady(true, status.url)
-
-          await new Promise((r) => setTimeout(r, 500))
-        }
-      } else {
-        console.log('[TeamMode] Provider config already in opencode.json, skipping restart')
+      if (!configAlreadyMatches && isTauri()) {
+        const { restartOpencode } = await import('@/lib/opencode/restart')
+        await restartOpencode(workspacePath)
       }
 
       await providerStore.selectModel(TEAM_PROVIDER_ID, teamModelConfig.model, teamModelConfig.modelName)
       await providerStore.refreshConfiguredProviders()
-
-      console.log('[TeamMode] Applied team model config:', teamModelConfig)
     } catch (err) {
       console.error('[TeamMode] Failed to apply team model to OpenCode:', err)
     }

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -505,6 +505,12 @@ pub async fn start_opencode_inner(
                     e
                 );
             }
+            if let Err(e) = ensure_team_provider(&ws_for_config) {
+                eprintln!(
+                    "[OpenCode] Warning: failed to ensure team provider: {}",
+                    e
+                );
+            }
             if let Err(e) = resolve_sidecar_binary_paths(&ws_for_config) {
                 eprintln!("[OpenCode] Warning: failed to resolve binary paths: {}", e);
             }
@@ -1103,9 +1109,11 @@ fn ensure_inherent_config(workspace_path: &str) -> Result<(), String> {
         }
     }
 
-    // Provider section is NOT auto-populated.
-    // Team provider is added only when creating/joining a team (via team-mode store).
     // Personal providers are added manually by the user in Settings > LLM.
+    // The `team` provider is reconciled separately by `ensure_team_provider`
+    // against teamclaw-team/_meta/provider.json — that's the only path that
+    // adds OR removes it, so transient frontend reads can't accidentally
+    // delete it on a bad cycle.
 
     if changed {
         let mut new_content = serde_json::to_string_pretty(&config)
@@ -1119,6 +1127,139 @@ fn ensure_inherent_config(workspace_path: &str) -> Result<(), String> {
             "[Config] Updated opencode.json with inherent configs in {}",
             config_path.display()
         );
+    }
+
+    Ok(())
+}
+
+/// Reconcile `provider.team` in opencode.json against teamclaw-team/_meta/provider.json.
+///
+/// Sidecar startup is the only point where disk state is trusted enough to remove:
+/// no in-flight git sync, no concurrent file readers, no UI race. So this is the only
+/// path that DELETES `provider.team`. Runtime sync (frontend file-watcher etc.) only
+/// adds; that protects against a transient `_meta/provider.json` miss yanking the
+/// provider mid-session.
+///
+/// Behavior:
+/// - `_meta/provider.json` exists, `opencode.json` lacks `provider.team` → ADD
+/// - `_meta/provider.json` missing/invalid, `opencode.json` has `provider.team` → REMOVE
+/// - Both present → leave existing entry alone (frontend owns field-level updates,
+///   so we don't strip richer metadata like modalities/limit if the user added it)
+/// - Neither → no-op
+fn ensure_team_provider(workspace_path: &str) -> Result<(), String> {
+    let config_path = super::mcp::get_config_path(workspace_path);
+    let provider_meta_path = std::path::Path::new(workspace_path)
+        .join(super::TEAM_REPO_DIR)
+        .join("_meta")
+        .join("provider.json");
+
+    let mut config: serde_json::Value = if config_path.exists() {
+        let content = std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("Failed to read opencode.json: {}", e))?;
+        serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse opencode.json: {}", e))?
+    } else {
+        serde_json::json!({ "$schema": "https://opencode.ai/config.json" })
+    };
+    let obj = config
+        .as_object_mut()
+        .ok_or("opencode.json root is not an object")?;
+
+    let provider_meta: Option<serde_json::Value> = if provider_meta_path.exists() {
+        std::fs::read_to_string(&provider_meta_path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .filter(|v| v.get("provider").and_then(|p| p.get("baseURL")).is_some())
+    } else {
+        None
+    };
+
+    let has_team_in_opencode = obj
+        .get("provider")
+        .and_then(|p| p.as_object())
+        .map(|p| p.contains_key("team"))
+        .unwrap_or(false);
+
+    let mut changed = false;
+
+    match (provider_meta, has_team_in_opencode) {
+        // ADD: meta exists, opencode.json lacks the entry
+        (Some(meta), false) => {
+            let p = meta.get("provider").ok_or("provider field missing")?;
+            let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("Team");
+            let base_url = p
+                .get("baseURL")
+                .and_then(|v| v.as_str())
+                .ok_or("provider.baseURL missing")?;
+            let api_key = p
+                .get("apiKey")
+                .and_then(|v| v.as_str())
+                .unwrap_or("${tc_api_key}");
+            let models_in = p
+                .get("models")
+                .and_then(|v| v.as_array())
+                .ok_or("provider.models missing or not an array")?;
+
+            let mut models_out = serde_json::Map::new();
+            for m in models_in {
+                let id = match m.get("id").and_then(|v| v.as_str()) {
+                    Some(s) => s,
+                    None => continue,
+                };
+                let mname = m.get("name").and_then(|v| v.as_str()).unwrap_or(id);
+                models_out.insert(
+                    id.to_string(),
+                    serde_json::json!({
+                        "name": mname,
+                        "limit": { "context": 256000, "output": 16000 }
+                    }),
+                );
+            }
+
+            let providers = obj
+                .entry("provider")
+                .or_insert_with(|| serde_json::json!({}))
+                .as_object_mut()
+                .ok_or("provider is not an object")?;
+            providers.insert(
+                "team".to_string(),
+                serde_json::json!({
+                    "npm": "@ai-sdk/openai-compatible",
+                    "name": name,
+                    "options": { "baseURL": base_url, "apiKey": api_key },
+                    "models": models_out,
+                }),
+            );
+            changed = true;
+            println!(
+                "[Config] Added provider.team to opencode.json (synced from {})",
+                provider_meta_path.display()
+            );
+        }
+        // REMOVE: meta missing, opencode.json still has stale entry
+        (None, true) => {
+            if let Some(providers) = obj.get_mut("provider").and_then(|p| p.as_object_mut()) {
+                providers.remove("team");
+                if providers.is_empty() {
+                    obj.remove("provider");
+                }
+                changed = true;
+                println!("[Config] Removed stale provider.team from opencode.json");
+            }
+        }
+        // Both present: leave alone. Frontend owns field-level updates.
+        // Neither: no-op.
+        _ => {}
+    }
+
+    if changed {
+        let mut new_content = serde_json::to_string_pretty(&config)
+            .map_err(|e| format!("Failed to serialize opencode.json: {}", e))?;
+        if !new_content.ends_with('\n') {
+            new_content.push('\n');
+        }
+        std::fs::write(&config_path, &new_content)
+            .map_err(|e| format!("Failed to write opencode.json: {}", e))?;
     }
 
     Ok(())

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -1334,6 +1334,18 @@ async fn team_git_join_impl(
         ));
     }
 
+    // If the caller didn't pass an fc_endpoint (e.g. manual entry without an
+    // invite code), fall back to the team's persisted value from
+    // _meta/team.json so the FC `/ai/add-member` block below still fires.
+    // Invite-code joins already had FC called by the frontend and intentionally
+    // pass None to avoid duplicate registration — that path is unaffected.
+    let fc_endpoint = fc_endpoint
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .or_else(|| team_meta.fc_endpoint.clone());
+
     // 5. Verify team_secret via HMAC comparison
     let computed_verify = match compute_secret_verify(&team_secret) {
         Ok(v) => v,


### PR DESCRIPTION
## Summary
End-to-end fix for "team provider disappears" bugs by collapsing the disk → `opencode.json` sync down to a single Rust step at sidecar startup.

### The invariant
**`start_opencode` finishes ⇒ `opencode.json` is consistent with `teamclaw-team/_meta/provider.json`.**

That's it. Everything else falls out of this:
- Cold start, refresh sidecar, permission save, env var save, skills change, team join, team config change in git — they all go through `start_opencode`, so they all converge on the same state.
- File-watcher / runtime sync paths only need to *trigger a restart*; they no longer need to write `opencode.json` themselves.

### Changes

**Rust (`opencode.rs`):** New `ensure_team_provider` runs in `start_opencode` pre-setup.
- `_meta/provider.json` exists, `opencode.json` lacks `provider.team` → ADD
- `_meta/provider.json` missing/invalid, `opencode.json` has `provider.team` → REMOVE  *(the only delete path; sidecar startup is the only point where disk state is reliably settled)*
- Both present → leave alone (frontend owns field-level updates like vision modalities)

**Frontend — runtime sync is now additive-only and read-only:**
- `syncTeamProviderToOpenCode` **deleted** (Rust owns disk → opencode.json sync)
- `applyTeamModelToOpenCode` simplified: read `_meta/provider.json` for in-memory state, skip-restart check against the live `opencode.json`, otherwise call `restartOpencode` and let Rust write
- `restartOpencode` extracted as a 5-callsite shared helper (LLMSection / SkillsSection / PermissionManagementSection / EnvVarsSection / ChatPanel), no longer needs to know about teams
- `TeamGitConfig` join paths (slow + fast/background) explicitly call `applyTeamModelToOpenCode` after `saveTeamProviderFile`, so first-time joins don't wait for the 1s file-watcher debounce

### Bugs this fixes
- Team provider deleted by transient `_meta/provider.json` read failure (file-watcher firing mid-git-sync, parse race) — runtime sync no longer deletes
- Team provider missing after Refresh Sidecar / skills restart / env-var restart / permission save — every restart now goes through `start_opencode` → Rust reconciles
- `PermissionManagementSection` not re-initializing the SDK client after restart (latent bug surfaced while consolidating the 5 callsites)
- Double-restart on cold start in team mode — existing-config check skips the redundant bounce when Rust already wrote `opencode.json`
- 1s lag visible on first-time team join — explicit `applyTeamModelToOpenCode` after save skips the file-watcher debounce

### Test plan
- [ ] **Cold start in team mode**: `provider.team` appears in `opencode.json` before sidecar boots; no double-restart in logs
- [ ] **Refresh sidecar in team mode** in each of 5 callsites — provider stays in the list:
  - [ ] Settings → LLM → Refresh
  - [ ] Settings → Skills → restart prompt
  - [ ] Settings → Permissions → save
  - [ ] Settings → Env Vars → restart
  - [ ] Chat → skills runtime restart prompt
- [ ] **First-time team join**: provider appears in UI within ~1 second (no 1s+ debounce visible)
- [ ] **Team admin disables LLM**: after next restart, `provider.team` is removed from `opencode.json`
- [ ] **Transient miss**: rename `_meta/provider.json` mid-session and back; provider stays in `opencode.json` the whole time
- [ ] **Original buggy workspace** (`/Volumes/openbeta/workspace/TestWorkspace/git-team-test`): on next restart, `provider.team` auto-added back from `_meta/provider.json`
- [ ] **Non-team workspace**: no `provider` section appears unintentionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)