### PR TITLE
fix(chat): preserve pinned sessions per workspace

### DIFF
--- a/packages/app/src/stores/__tests__/session-loader.test.ts
+++ b/packages/app/src/stores/__tests__/session-loader.test.ts
@@ -130,6 +130,7 @@ describe('session-loader: createLoaderActions', () => {
 
   it('loadSessions removes pinned ids that no longer exist', async () => {
     const now = Date.now()
+    state.currentWorkspacePath = '/workspace'
     state.pinnedSessionIds = ['missing', 'active']
     mockListSessions.mockResolvedValue([
       { id: 'active', title: 'Active', time: { created: now, updated: now } },
@@ -147,6 +148,31 @@ describe('session-loader: createLoaderActions', () => {
     expect(sessionsCall).toBeDefined()
     expect(sessionsCall![0].pinnedSessionIds).toEqual(['active'])
     expect(localStorage.setItem).toHaveBeenCalled()
+  })
+
+  it('loadSessions preserves pinned ids from other workspaces when switching', async () => {
+    const now = Date.now()
+    vi.mocked(localStorage.getItem).mockReturnValue(
+      JSON.stringify({
+        '/workspace-a': ['a-pinned'],
+        '/workspace-b': ['b-pinned'],
+      }),
+    )
+
+    mockListSessions.mockResolvedValue([
+      { id: 'b-pinned', title: 'Pinned in B', time: { created: now, updated: now } },
+      { id: 'b-other', title: 'Other in B', time: { created: now - 1000, updated: now - 1000 } },
+    ])
+
+    await actions.loadSessions('/workspace-b')
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'teamclaw-pinned-sessions',
+      JSON.stringify({
+        '/workspace-a': ['a-pinned'],
+        '/workspace-b': ['b-pinned'],
+      }),
+    )
   })
 
   it('loadSessions filters out archived and child sessions', async () => {

--- a/packages/app/src/stores/session-loader.ts
+++ b/packages/app/src/stores/session-loader.ts
@@ -27,6 +27,7 @@ import {
 import { trackEvent } from "@/stores/telemetry";
 import { sessionDataCache } from "./session-data-cache";
 import {
+  loadPinnedSessionIds,
   savePinnedSessionIds,
   sanitizePinnedSessionIds,
 } from "./session-pins";
@@ -44,6 +45,8 @@ export function createLoaderActions(set: SessionSet, get: SessionGet) {
       useStreamingStore.getState().clearStreaming();
       set({
         sessions: [],
+        pinnedSessionIds: [],
+        currentWorkspacePath: null,
         activeSessionId: null,
         messageQueue: [],
         pendingPermissions: [],
@@ -122,11 +125,16 @@ export function createLoaderActions(set: SessionSet, get: SessionGet) {
         // Sort by updatedAt descending (most recently active first)
         newSessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 
+        const rawPinnedSessionIds =
+          get().currentWorkspacePath === (workspacePath ?? null)
+            ? get().pinnedSessionIds
+            : loadPinnedSessionIds(workspacePath ?? null);
+
         const pinnedSessionIds = sanitizePinnedSessionIds(
-          get().pinnedSessionIds,
+          rawPinnedSessionIds,
           newSessions.map((session) => session.id),
         );
-        savePinnedSessionIds(pinnedSessionIds);
+        savePinnedSessionIds(workspacePath ?? null, pinnedSessionIds);
 
         // UI-level pagination: initially show first PAGE_SIZE sessions
         const hasMore = newSessions.length > UI_PAGE_SIZE;
@@ -164,6 +172,7 @@ export function createLoaderActions(set: SessionSet, get: SessionGet) {
         set({
           sessions: merged,
           pinnedSessionIds,
+          currentWorkspacePath: workspacePath ?? null,
           isLoading: false,
           hasMoreSessions: hasMore,
           visibleSessionCount: Math.min(newSessions.length, UI_PAGE_SIZE),
@@ -557,7 +566,7 @@ export function createLoaderActions(set: SessionSet, get: SessionGet) {
         set((state) => {
           const newSessions = state.sessions.filter((s) => s.id !== id);
           const pinnedSessionIds = state.pinnedSessionIds.filter((sessionId) => sessionId !== id);
-          savePinnedSessionIds(pinnedSessionIds);
+          savePinnedSessionIds(state.currentWorkspacePath ?? directory ?? null, pinnedSessionIds);
           updateSessionCache(newSessions);
 
           return {

--- a/packages/app/src/stores/session-pins.ts
+++ b/packages/app/src/stores/session-pins.ts
@@ -2,23 +2,66 @@ import { appShortName } from "@/lib/build-config";
 
 const STORAGE_KEY = `${appShortName}-pinned-sessions`;
 
-export function loadPinnedSessionIds(): string[] {
+type PinnedSessionStorage = Record<string, string[]>;
+
+function parsePinnedSessionStorage(raw: string | null): PinnedSessionStorage | null {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
+    if (!raw) return {};
 
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
+    if (Array.isArray(parsed)) {
+      // Backward compatibility with the legacy flat-array format.
+      return { __legacy__: parsed.filter((item): item is string => typeof item === "string") };
+    }
+    if (!parsed || typeof parsed !== "object") return {};
 
-    return parsed.filter((item): item is string => typeof item === "string");
+    const entries = Object.entries(parsed as Record<string, unknown>);
+    return Object.fromEntries(
+      entries.map(([workspaceKey, ids]) => [
+        workspaceKey,
+        Array.isArray(ids) ? ids.filter((item): item is string => typeof item === "string") : [],
+      ]),
+    );
   } catch {
-    return [];
+    return {};
   }
 }
 
-export function savePinnedSessionIds(ids: string[]): void {
+function normalizeWorkspaceKey(workspacePath: string | null | undefined): string | null {
+  const trimmed = workspacePath?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function loadPinnedSessionIds(workspacePath?: string | null): string[] {
+  const storage = parsePinnedSessionStorage(localStorage.getItem(STORAGE_KEY));
+  const workspaceKey = normalizeWorkspaceKey(workspacePath);
+
+  if (!storage) return [];
+  if (workspaceKey) {
+    return storage[workspaceKey] ?? storage.__legacy__ ?? [];
+  }
+  return storage.__legacy__ ?? [];
+}
+
+export function savePinnedSessionIds(
+  workspacePath: string | null | undefined,
+  ids: string[],
+): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+    const workspaceKey = normalizeWorkspaceKey(workspacePath);
+    const storage = parsePinnedSessionStorage(localStorage.getItem(STORAGE_KEY)) ?? {};
+
+    if (!workspaceKey) {
+      storage.__legacy__ = ids;
+    } else if (ids.length > 0) {
+      storage[workspaceKey] = ids;
+      delete storage.__legacy__;
+    } else {
+      delete storage[workspaceKey];
+      delete storage.__legacy__;
+    }
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(storage));
   } catch {
     // Ignore storage failures so session list still works in constrained envs.
   }
@@ -39,4 +82,3 @@ export function sanitizePinnedSessionIds(
 
   return uniquePinned;
 }
-

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -12,7 +12,6 @@ import { createSSEHandlers } from "./session-sse-handlers";
 import { createPermissionActions } from "./session-permissions";
 import { createQuestionActions } from "./session-questions";
 import {
-  loadPinnedSessionIds,
   savePinnedSessionIds,
 } from "./session-pins";
 import { getOpenCodeClient } from "@/lib/opencode/sdk-client";
@@ -21,7 +20,8 @@ import { convertMessage } from "./session-converters";
 export const useSessionStore = create<SessionState>((set, get) => ({
   // Initial state
   sessions: [],
-  pinnedSessionIds: loadPinnedSessionIds(),
+  pinnedSessionIds: [],
+  currentWorkspacePath: null,
   activeSessionId: null,
   isLoading: false,
   isLoadingMore: false,
@@ -64,7 +64,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         ? state.pinnedSessionIds.filter((sessionId) => sessionId !== id)
         : [id, ...state.pinnedSessionIds];
 
-      savePinnedSessionIds(pinnedSessionIds);
+      savePinnedSessionIds(state.currentWorkspacePath, pinnedSessionIds);
       return { pinnedSessionIds };
     });
   },

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -161,6 +161,7 @@ export interface SessionState {
   // State
   sessions: Session[];
   pinnedSessionIds: string[];
+  currentWorkspacePath: string | null;
   activeSessionId: string | null;
   isLoading: boolean;
   isLoadingMore: boolean; // Loading more sessions (UI pagination)


### PR DESCRIPTION
## Summary
- store pinned session ids per workspace instead of in one global array
- load and sanitize pins against the active workspace only during workspace switches
- add a regression test covering switching between workspaces without losing pinned chats

## Test Plan
- pnpm --filter @teamclaw/app exec vitest run src/stores/__tests__/session-loader.test.ts src/stores/__tests__/session.store.test.ts src/stores/__tests__/session-messages-behavior.test.ts src/hooks/__tests__/useSpotlight.test.ts
- pnpm --filter @teamclaw/app typecheck