### PR TITLE
feat(telemetry): fire app_active heartbeat to fix DAU undercount

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -164,6 +164,40 @@ fn fix_path_env() {
     }
 }
 
+// Foreground-activation heartbeat for Aptabase DAU.
+// `app_started` only fires on cold start; on macOS users who keep the app
+// running for days would otherwise show as DAU only on day 1. Firing
+// `app_active` on focus / Reopen (rate-limited) closes that gap.
+static LAST_ACTIVE_AT: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(0);
+const APP_ACTIVE_THRESHOLD_SECS: i64 = 4 * 3600;
+
+fn now_unix_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn record_activity() {
+    LAST_ACTIVE_AT.store(now_unix_secs(), std::sync::atomic::Ordering::Relaxed);
+}
+
+fn maybe_emit_app_active(app: &tauri::AppHandle) {
+    let now = now_unix_secs();
+    let last = LAST_ACTIVE_AT.load(std::sync::atomic::Ordering::Relaxed);
+    if last != 0 && now - last < APP_ACTIVE_THRESHOLD_SECS {
+        return;
+    }
+    LAST_ACTIVE_AT.store(now, std::sync::atomic::Ordering::Relaxed);
+    let _ = app.track_event(
+        "app_active",
+        Some(serde_json::json!({
+            "version": env!("CARGO_PKG_VERSION"),
+            "platform": std::env::consts::OS,
+        })),
+    );
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let startup_t0 = std::time::Instant::now();
@@ -853,6 +887,11 @@ pub fn run() {
                                 commands::spotlight::reposition_traffic_lights(&main_win_clone);
                             }
                         }
+                        // DAU heartbeat: fires `app_active` once the app
+                        // returns to focus after >=4h idle.
+                        tauri::WindowEvent::Focused(true) => {
+                            maybe_emit_app_active(&close_app_handle);
+                        }
                         _ => {}
                     }
                 });
@@ -972,6 +1011,7 @@ pub fn run() {
                 "version": env!("CARGO_PKG_VERSION"),
                 "platform": std::env::consts::OS,
             })));
+            record_activity();
 
             Ok(())
         })
@@ -987,6 +1027,7 @@ pub fn run() {
                     // unconditionally bring the window back.
                     let state = app.state::<commands::spotlight::SpotlightState>();
                     commands::spotlight::show_main_window(app.clone(), state);
+                    maybe_emit_app_active(app);
                 }
                 tauri::RunEvent::Exit => {
                     // Kill the OpenCode sidecar synchronously.


### PR DESCRIPTION
## Why

`app_started` is only emitted in Tauri's `setup()` — i.e. on cold start. On macOS, where closing the window only hides it and users routinely keep the app running for days, a single user therefore shows up in Aptabase DAU only on the day they last launched it. Real DAU is being undercounted.

## What

Add an `app_active` heartbeat event that fires when the app returns to the foreground:

- `WindowEvent::Focused(true)` — cross-platform window-focus signal
- `RunEvent::Reopen` — macOS dock-click on a running app

Rate-limited to at most once per **4h** via a process-wide `AtomicI64` last-active timestamp. The timestamp is primed immediately after `app_started`, so the `Focused(true)` that fires moments after launch can't double-emit. Like `app_started`, the heartbeat bypasses the consent gate so DAU isn't truncated by users who haven't accepted analytics.

```
Δ src-tauri/src/lib.rs:
  + LAST_ACTIVE_AT (static AtomicI64) + APP_ACTIVE_THRESHOLD_SECS = 4*3600
  + record_activity() / maybe_emit_app_active(app)
  + record_activity() right after the existing app_started track call
  + tauri::WindowEvent::Focused(true) → maybe_emit_app_active
  + RunEvent::Reopen → maybe_emit_app_active (after show_main_window)
```

Event shape (matches `app_started`):
```json
{ "version": "<CARGO_PKG_VERSION>", "platform": "macos|windows|linux" }
```

## How to verify (a few days post-release)

- Aptabase DAU rises — magnitude reflects the share of long-running macOS users.
- `app_active` event count exceeds `app_started` by a wide margin.
- `app_active.platform` skews macOS; Windows/Linux users restart more often so `app_started` already covers them.
- Cross-check against OpenCode sidecar starts / OSS update-check requests / Sentry sessions — gap should narrow.

## Test plan
- [ ] `pnpm rust:check` clean
- [ ] Cold start fires `app_started` once and primes the timestamp; the `Focused(true)` that follows is suppressed
- [ ] Switching focus away and back within 4h does not fire `app_active`
- [ ] After ≥4h idle (or wall-clock advance), next focus / dock-reopen fires `app_active`
- [ ] Consent denied → `app_active` still fires (parity with `app_started`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)