### PR TITLE
fix(release): re-validate OSS pointer files to bypass CN CDN cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,12 +277,28 @@ jobs:
           if target != 'aarch64-apple-darwin':
               sys.exit(0)
 
-          bucket.put_object('releases/latest.txt', version.encode())
+          # These are mutable "pointer" objects that change every release.
+          # Without an explicit Cache-Control header, Alibaba CDN applies its
+          # default TTL (hours), so users keep installing the previous version
+          # until the cached entry expires. Tell the CDN to re-validate.
+          short_cache = {
+              'Cache-Control': 'max-age=60, must-revalidate',
+          }
+
+          bucket.put_object(
+              'releases/latest.txt',
+              version.encode(),
+              headers={**short_cache, 'Content-Type': 'text/plain; charset=utf-8'},
+          )
           print(f'✅ {oss_base}/releases/latest.txt -> {version}')
 
           with open('scripts/install-mac-cn.sh', 'r') as f:
               script = f.read()
-          bucket.put_object('install-mac-cn.sh', script.encode())
+          bucket.put_object(
+              'install-mac-cn.sh',
+              script.encode(),
+              headers={**short_cache, 'Content-Type': 'text/x-shellscript; charset=utf-8'},
+          )
           print(f'✅ {oss_base}/install-mac-cn.sh')
           EOF
 
@@ -530,7 +546,16 @@ jobs:
               json.dump(manifest, f, indent=2)
               f.write('\n')
 
-          bucket.put_object_from_file('releases/latest.json', mirrored_manifest_path)
+          # Root pointer: must re-validate so the Tauri updater sees new releases.
+          # Per-version archive: immutable, default long cache is fine.
+          bucket.put_object_from_file(
+              'releases/latest.json',
+              mirrored_manifest_path,
+              headers={
+                  'Cache-Control': 'max-age=60, must-revalidate',
+                  'Content-Type': 'application/json; charset=utf-8',
+              },
+          )
           bucket.put_object_from_file(f'releases/{version}/latest.json', mirrored_manifest_path)
           print(f'Mirrored latest.json -> {oss_base}/releases/latest.json')
           print(f'Also archived -> {oss_base}/releases/{version}/latest.json')


### PR DESCRIPTION
## Why

`releases/latest.txt`, `install-mac-cn.sh`, and `releases/latest.json` on the OSS / `teamclaw.ucar.cc` mirror are **mutable pointer files** read by the CN one-line install script and the Tauri updater. Today they're uploaded with no `Cache-Control` header, so Alibaba CDN applies its **default TTL** (hours) — the same TTL that's appropriate for the immutable per-version artifacts.

Concrete symptom uncovered while monitoring v0.1.72: ~26 h after v0.1.71 successfully shipped, the CDN was still serving `v0.1.70` from `latest.txt`:

```
$ curl -sI https://teamclaw.ucar.cc/releases/latest.txt
HTTP/1.1 200 OK
X-Cache: HIT TCP_MEM_HIT
Age: 93055                          ← CDN cached for 25.8h
Last-Modified: Sun, 26 Apr 2026 09:17:00 GMT
$ curl -sS https://teamclaw.ucar.cc/releases/latest.txt
v0.1.70                             ← but OSS source is v0.1.71 (CI logged ✅)
```

The v0.1.71 aarch64 OSS-upload step's log confirms the `put_object` call returned success — this is purely a CDN-caching problem.

CN users running the one-line `install-mac-cn.sh` were therefore stuck on v0.1.70, missing v0.1.71 entirely.

## What

Set `Cache-Control: max-age=60, must-revalidate` on the three pointer paths so the CDN re-validates after a 60 s grace window:

| Path                              | Was        | Now (this PR)              |
|-----------------------------------|------------|----------------------------|
| `releases/latest.txt`             | (default)  | `max-age=60, must-revalidate` |
| `install-mac-cn.sh`               | (default)  | `max-age=60, must-revalidate` |
| `releases/latest.json` (root)     | (default)  | `max-age=60, must-revalidate` |
| `releases/<v>/*.dmg` / `*.exe`    | (default)  | unchanged — immutable      |
| `releases/<v>/latest.json`        | (default)  | unchanged — immutable      |

Also adds explicit `Content-Type` (`text/plain` / `text/x-shellscript` / `application/json`) so OSS doesn't fall back to `application/octet-stream`.

## Caveat — this PR only fixes *future* releases

The existing v0.1.71-era CDN entries for `latest.txt` and `install-mac-cn.sh` will keep serving the old contents until their long TTL expires. To make the **v0.1.72** release immediately reach CN install-script users, manually trigger an Alibaba CDN refresh once for:

- `https://teamclaw.ucar.cc/releases/latest.txt`
- `https://teamclaw.ucar.cc/install-mac-cn.sh`
- `https://teamclaw.ucar.cc/releases/latest.json`

(Future-release follow-up: consider wiring an `aliyun cdn RefreshObjectCaches` API call into the workflow once a CDN-scoped RAM key is provisioned, so this is automatic.)

## Test plan
- [ ] YAML parses (verified locally)
- [ ] Next release run uploads pointer objects with the new `Cache-Control` header (check `curl -sI` after upload)
- [ ] After CDN refresh, `curl https://teamclaw.ucar.cc/releases/latest.txt` returns the just-released version

🤖 Generated with [Claude Code](https://claude.com/claude-code)