### PR TITLE
feat(history): per-file commit history viewer for team repo files

### DIFF
--- a/packages/app/src/components/FileEditor.tsx
+++ b/packages/app/src/components/FileEditor.tsx
@@ -20,6 +20,7 @@ import {
   RotateCw,
   Files,
   Eye,
+  History,
 } from "lucide-react";
 import { cn, isTauri } from "@/lib/utils";
 import { TEAM_REPO_DIR } from "@/lib/build-config";
@@ -51,6 +52,7 @@ const LazyTiptapMarkdownEditor = lazy(
 );
 const LazyCodeEditor = lazy(() => import("@/components/editors/CodeEditor"));
 const LazyDiffRenderer = lazy(() => import("@/components/diff/DiffRenderer"));
+const LazyFileHistoryView = lazy(() => import("@/components/history/FileHistoryView"));
 
 // Viewers - lazy loaded
 const LazyPDFViewer = lazy(
@@ -373,6 +375,7 @@ export function FileEditor({
   const [isSaving, setIsSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [showDiff, setShowDiff] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
   const [showPreview, setShowPreview] = useState(supportsPreview(filename) === "html");
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
   const [externalUpdateType, setExternalUpdateType] = useState<
@@ -404,9 +407,22 @@ export function FileEditor({
       ? filePath.slice(workspacePath.length + 1)
       : (filePath ?? "");
 
+  const teamRepoPath = useMemo(
+    () =>
+      workspacePath ? `${workspacePath.replace(/\/+$/, '')}/${TEAM_REPO_DIR}` : null,
+    [workspacePath],
+  )
+
+  const relativeTeamPath = useMemo(() => {
+    if (!teamRepoPath || !filePath) return null
+    const norm = filePath.replace(/\/+$/, '')
+    if (!norm.startsWith(teamRepoPath + '/')) return null
+    return norm.slice(teamRepoPath.length + 1)
+  }, [teamRepoPath, filePath])
+
   // Fetch the file's content from git HEAD for gutter decorations (team files only)
   useEffect(() => {
-    if (!isTauri() || !workspacePath || !filePath || !isTeamFile) {
+    if (!isTauri() || !teamRepoPath || !relativeTeamPath || !isTeamFile) {
       setGitHeadContent(null);
       return;
     }
@@ -415,14 +431,7 @@ export function FileEditor({
 
     (async () => {
       try {
-        const teamRepoPath = `${workspacePath.replace(/\/+$/, "")}/${TEAM_REPO_DIR}`;
-        const normalizedFile = filePath.replace(/\/+$/, "");
-        let relativePath = normalizedFile;
-        if (normalizedFile.startsWith(teamRepoPath + "/")) {
-          relativePath = normalizedFile.slice(teamRepoPath.length + 1);
-        }
-
-        const headContent = await gitManager.showFile(teamRepoPath, relativePath);
+        const headContent = await gitManager.showFile(teamRepoPath, relativeTeamPath);
         if (!cancelled) {
           setGitHeadContent(headContent);
         }
@@ -436,7 +445,7 @@ export function FileEditor({
     return () => {
       cancelled = true;
     };
-  }, [workspacePath, filePath, isTeamFile]);
+  }, [teamRepoPath, relativeTeamPath, isTeamFile]);
 
   // Check if this file supports preview
   const previewType = supportsPreview(filename);
@@ -764,7 +773,14 @@ export function FileEditor({
           {/* Diff toggle - icon only */}
           {hasChanges && (
             <button
-              onClick={() => setShowDiff(!showDiff)}
+              onClick={() => {
+                if (showDiff) {
+                  setShowDiff(false);
+                } else {
+                  setShowDiff(true);
+                  setShowHistory(false);
+                }
+              }}
               className={`p-1.5 rounded transition-colors ${
                 showDiff
                   ? "text-primary bg-primary/10"
@@ -781,6 +797,27 @@ export function FileEditor({
               ) : (
                 <GitCompare className="h-4 w-4" />
               )}
+            </button>
+          )}
+
+          {isTeamFile && (
+            <button
+              onClick={() => {
+                if (showHistory) {
+                  setShowHistory(false);
+                } else {
+                  setShowHistory(true);
+                  setShowDiff(false);
+                }
+              }}
+              className={`p-1.5 rounded transition-colors ${
+                showHistory
+                  ? "text-primary bg-primary/10"
+                  : "text-muted-foreground hover:bg-muted"
+              }`}
+              title={t("app.viewHistory", "View history")}
+            >
+              <History className="h-4 w-4" />
             </button>
           )}
 
@@ -852,8 +889,23 @@ export function FileEditor({
 
       {/* Editor / Diff / Preview - file-type-routed */}
       <div className="flex-1 overflow-hidden">
-        {/* Conflict diff view for markdown */}
-        {isMarkdown && showConflictDiff && conflictAgentContent !== null ? (
+        {/* History view */}
+        {showHistory && teamRepoPath && relativeTeamPath ? (
+          <Suspense
+            fallback={
+              <div className="flex items-center justify-center h-full">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+              </div>
+            }
+          >
+            <LazyFileHistoryView
+              repoPath={teamRepoPath}
+              relativePath={relativeTeamPath}
+              filePath={filePath}
+              isDark={isDark}
+            />
+          </Suspense>
+        ) : isMarkdown && showConflictDiff && conflictAgentContent !== null ? (
           <Suspense
             fallback={
               <div className="flex items-center justify-center h-full">

--- a/packages/app/src/components/FileEditor.tsx
+++ b/packages/app/src/components/FileEditor.tsx
@@ -800,7 +800,7 @@ export function FileEditor({
             </button>
           )}
 
-          {isTeamFile && (
+          {isTeamFile && isTauri() && (
             <button
               onClick={() => {
                 if (showHistory) {

--- a/packages/app/src/components/__tests__/FileEditor.test.tsx
+++ b/packages/app/src/components/__tests__/FileEditor.test.tsx
@@ -9,8 +9,9 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+const isTauriMock = vi.fn(() => false)
 vi.mock('@/lib/utils', () => ({
-  isTauri: () => false,
+  isTauri: () => isTauriMock(),
   cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
 }))
 
@@ -144,6 +145,7 @@ describe('FileEditor', () => {
   })
 
   it('renders the history button for team files and toggles history view', async () => {
+    isTauriMock.mockReturnValue(true)
     render(
       <FileEditor
         content=""
@@ -157,5 +159,6 @@ describe('FileEditor', () => {
     await waitFor(() =>
       expect(screen.getByText('该文件还没有提交历史')).toBeDefined(),
     )
+    isTauriMock.mockReturnValue(false)
   })
 })

--- a/packages/app/src/components/__tests__/FileEditor.test.tsx
+++ b/packages/app/src/components/__tests__/FileEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import React from 'react'
 
 // Mock all heavy dependencies
@@ -41,7 +41,10 @@ vi.mock('@/hooks/use-git-status', () => ({
 }))
 
 vi.mock('@/lib/git/manager', () => ({
-  gitManager: { showFile: vi.fn().mockRejectedValue(new Error('not tracked')) },
+  gitManager: {
+    showFile: vi.fn().mockRejectedValue(new Error('not tracked')),
+    logFile: vi.fn().mockResolvedValue([]),
+  },
 }))
 
 vi.mock('@/components/editors/utils', () => ({
@@ -67,7 +70,7 @@ vi.mock('@/components/viewers/UnsupportedFileViewer', () => ({
   UNSUPPORTED_BINARY_EXTENSIONS: new Set(['exe', 'dll']),
 }))
 
-import { getFileType, FileContentViewer } from '@/components/FileEditor'
+import { getFileType, FileContentViewer, FileEditor } from '@/components/FileEditor'
 
 describe('FileEditor', () => {
   it('getFileType classifies images correctly', () => {
@@ -126,5 +129,33 @@ describe('FileEditor', () => {
     const iframe = container.querySelector('iframe[title="logo.svg"]')
     expect(iframe).toBeTruthy()
     expect(iframe?.getAttribute('src')).toBe(svgDataUrl)
+  })
+
+  it('does not render the history button for non-team files', () => {
+    render(
+      <FileEditor
+        content=""
+        filename="note.md"
+        filePath="/workspace/note.md"
+        onClose={() => {}}
+      />,
+    )
+    expect(screen.queryByTitle(/查看历史|View history|历史/i)).toBeNull()
+  })
+
+  it('renders the history button for team files and toggles history view', async () => {
+    render(
+      <FileEditor
+        content=""
+        filename="note.md"
+        filePath="/workspace/teamclaw-team/skills/note.md"
+        onClose={() => {}}
+      />,
+    )
+    const button = await screen.findByTitle(/查看历史|View history|历史/i)
+    fireEvent.click(button)
+    await waitFor(() =>
+      expect(screen.getByText('该文件还没有提交历史')).toBeDefined(),
+    )
   })
 })

--- a/packages/app/src/components/history/CommitList.tsx
+++ b/packages/app/src/components/history/CommitList.tsx
@@ -1,0 +1,65 @@
+import { Loader2 } from 'lucide-react'
+import type { GitLogEntry } from '@/lib/git/types'
+
+interface CommitListProps {
+  commits: GitLogEntry[]
+  selectedSha: string | null
+  onSelect: (sha: string) => void
+  onLoadMore: () => void
+  hasMore: boolean
+  loadingMore: boolean
+}
+
+function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime()
+  if (Number.isNaN(t)) return iso
+  const diffSec = Math.round((t - Date.now()) / 1000)
+  const abs = Math.abs(diffSec)
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+  if (abs < 60) return rtf.format(diffSec, 'second')
+  if (abs < 3600) return rtf.format(Math.round(diffSec / 60), 'minute')
+  if (abs < 86400) return rtf.format(Math.round(diffSec / 3600), 'hour')
+  return rtf.format(Math.round(diffSec / 86400), 'day')
+}
+
+export function CommitList({
+  commits,
+  selectedSha,
+  onSelect,
+  onLoadMore,
+  hasMore,
+  loadingMore,
+}: CommitListProps) {
+  return (
+    <div className="flex flex-col h-full overflow-y-auto">
+      {commits.map((c) => {
+        const active = c.sha === selectedSha
+        return (
+          <button
+            key={c.sha}
+            type="button"
+            onClick={() => onSelect(c.sha)}
+            className={`text-left px-3 py-2 border-b border-border/50 transition-colors ${
+              active ? 'text-primary bg-primary/10' : 'hover:bg-muted'
+            }`}
+          >
+            <div className="text-xs text-muted-foreground truncate">
+              {formatRelative(c.isoTime)} · {c.author}
+            </div>
+            <div className="text-sm truncate">{c.subject}</div>
+          </button>
+        )
+      })}
+      {hasMore && (
+        <button
+          type="button"
+          onClick={onLoadMore}
+          disabled={loadingMore}
+          className="px-3 py-2 text-xs text-muted-foreground hover:bg-muted disabled:opacity-50"
+        >
+          {loadingMore ? <Loader2 className="h-3 w-3 animate-spin inline" /> : '加载更多'}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/packages/app/src/components/history/FileHistoryView.tsx
+++ b/packages/app/src/components/history/FileHistoryView.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useState, lazy, Suspense, useCallback } from 'react'
+import { Loader2 } from 'lucide-react'
+import { gitManager } from '@/lib/git/manager'
+import type { GitLogEntry } from '@/lib/git/types'
+import { CommitList } from './CommitList'
+
+const LazyDiffRenderer = lazy(() => import('@/components/diff/DiffRenderer'))
+
+const PAGE_SIZE = 50
+const MAX_DIFF_BYTES = 256 * 1024
+const NULL_SCAN_BYTES = 8192
+
+interface FileHistoryViewProps {
+  repoPath: string
+  relativePath: string
+  filePath: string
+  isDark: boolean
+}
+
+function isBinaryOrTooLarge(text: string): boolean {
+  if (text.length > MAX_DIFF_BYTES) return true
+  const sample = text.slice(0, NULL_SCAN_BYTES)
+  for (let i = 0; i < sample.length; i++) {
+    if (sample.charCodeAt(i) === 0) return true
+  }
+  return false
+}
+
+export function FileHistoryView({
+  repoPath,
+  relativePath,
+  filePath,
+  isDark,
+}: FileHistoryViewProps) {
+  const [commits, setCommits] = useState<GitLogEntry[]>([])
+  const [selectedSha, setSelectedSha] = useState<string | null>(null)
+  const [before, setBefore] = useState<string | null>(null)
+  const [after, setAfter] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [loadingDiff, setLoadingDiff] = useState(false)
+  const [hasMore, setHasMore] = useState(false)
+  const [listError, setListError] = useState<string | null>(null)
+  const [diffError, setDiffError] = useState<string | null>(null)
+
+  const fetchInitial = useCallback(() => {
+    setLoading(true)
+    setListError(null)
+    return gitManager
+      .logFile(repoPath, relativePath, PAGE_SIZE, 0)
+      .then((entries) => {
+        setCommits(entries)
+        setHasMore(entries.length === PAGE_SIZE)
+        setSelectedSha(entries.length > 0 ? entries[0].sha : null)
+        setLoading(false)
+      })
+      .catch((err: unknown) => {
+        setListError(err instanceof Error ? err.message : String(err))
+        setLoading(false)
+      })
+  }, [repoPath, relativePath])
+
+  // (Re)load when target file changes.
+  useEffect(() => {
+    setCommits([])
+    setSelectedSha(null)
+    setBefore(null)
+    setAfter(null)
+    setListError(null)
+    setDiffError(null)
+    setHasMore(false)
+    void fetchInitial()
+  }, [fetchInitial])
+
+  // Fetch diff for selected commit.
+  useEffect(() => {
+    if (!selectedSha) {
+      setBefore(null)
+      setAfter(null)
+      setDiffError(null)
+      return
+    }
+    const entry = commits.find((c) => c.sha === selectedSha)
+    if (!entry) return
+
+    let cancelled = false
+    setLoadingDiff(true)
+    setDiffError(null)
+
+    const afterPromise = gitManager.showFile(repoPath, relativePath, selectedSha)
+    const beforePromise: Promise<string | null> =
+      entry.parentSha === ''
+        ? Promise.resolve('')
+        : gitManager.showFile(repoPath, relativePath, entry.parentSha)
+
+    Promise.all([beforePromise, afterPromise])
+      .then(([b, a]) => {
+        if (cancelled) return
+        if (a === null) {
+          setDiffError(`无法加载该提交的内容 (${selectedSha.slice(0, 7)})`)
+          setBefore(null)
+          setAfter(null)
+        } else {
+          setBefore(b ?? '')
+          setAfter(a)
+        }
+        setLoadingDiff(false)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setDiffError(err instanceof Error ? err.message : String(err))
+        setLoadingDiff(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [selectedSha, repoPath, relativePath, commits])
+
+  const handleLoadMore = () => {
+    setLoadingMore(true)
+    gitManager
+      .logFile(repoPath, relativePath, PAGE_SIZE, commits.length)
+      .then((entries) => {
+        setCommits((prev) => [...prev, ...entries])
+        setHasMore(entries.length === PAGE_SIZE)
+        setLoadingMore(false)
+      })
+      .catch((err: unknown) => {
+        setListError(err instanceof Error ? err.message : String(err))
+        setLoadingMore(false)
+      })
+  }
+
+  const showEmpty = !loading && !listError && commits.length === 0
+  const showSizeGuard =
+    after !== null && (isBinaryOrTooLarge(after) || (before !== null && isBinaryOrTooLarge(before)))
+
+  return (
+    <div className="flex h-full">
+      <div className="w-[30%] min-w-[260px] flex flex-col border-r border-border">
+        {loading ? (
+          <div className="flex items-center justify-center h-full">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : listError ? (
+          <div className="p-3 text-xs text-red-500">
+            {listError}
+            <button type="button" onClick={fetchInitial} className="ml-2 underline">
+              重试
+            </button>
+          </div>
+        ) : (
+          <CommitList
+            commits={commits}
+            selectedSha={selectedSha}
+            onSelect={setSelectedSha}
+            onLoadMore={handleLoadMore}
+            hasMore={hasMore}
+            loadingMore={loadingMore}
+          />
+        )}
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {showEmpty ? (
+          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+            该文件还没有提交历史
+          </div>
+        ) : loadingDiff ? (
+          <div className="flex items-center justify-center h-full">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : diffError ? (
+          <div className="flex items-center justify-center h-full text-sm text-red-500">
+            {diffError}
+          </div>
+        ) : showSizeGuard ? (
+          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+            文件过大或为二进制，跳过 diff
+          </div>
+        ) : after !== null ? (
+          <Suspense
+            fallback={
+              <div className="flex items-center justify-center h-full">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              </div>
+            }
+          >
+            <LazyDiffRenderer
+              before={before ?? ''}
+              after={after}
+              filePath={filePath}
+              isDark={isDark}
+            />
+          </Suspense>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export default FileHistoryView

--- a/packages/app/src/components/history/FileHistoryView.tsx
+++ b/packages/app/src/components/history/FileHistoryView.tsx
@@ -82,7 +82,7 @@ export function FileHistoryView({
     setListError(null)
     setDiffError(null)
     setHasMore(false)
-    loadMoreGenRef.current++           // <-- add this
+    loadMoreGenRef.current++
     void fetchInitial()
   }, [fetchInitial])
 

--- a/packages/app/src/components/history/FileHistoryView.tsx
+++ b/packages/app/src/components/history/FileHistoryView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, lazy, Suspense, useCallback } from 'react'
+import { useEffect, useState, lazy, Suspense, useCallback, useMemo, useRef } from 'react'
 import { Loader2 } from 'lucide-react'
 import { gitManager } from '@/lib/git/manager'
 import type { GitLogEntry } from '@/lib/git/types'
@@ -7,8 +7,10 @@ import { CommitList } from './CommitList'
 const LazyDiffRenderer = lazy(() => import('@/components/diff/DiffRenderer'))
 
 const PAGE_SIZE = 50
-const MAX_DIFF_BYTES = 256 * 1024
-const NULL_SCAN_BYTES = 8192
+// Heuristic: code-unit count, not byte count. Big-enough strings are slow
+// regardless of encoding, so a code-unit ceiling is sufficient as a sanity guard.
+const MAX_DIFF_CHARS = 256 * 1024
+const NULL_SCAN_CHARS = 8192
 
 interface FileHistoryViewProps {
   repoPath: string
@@ -18,8 +20,8 @@ interface FileHistoryViewProps {
 }
 
 function isBinaryOrTooLarge(text: string): boolean {
-  if (text.length > MAX_DIFF_BYTES) return true
-  const sample = text.slice(0, NULL_SCAN_BYTES)
+  if (text.length > MAX_DIFF_CHARS) return true
+  const sample = text.slice(0, NULL_SCAN_CHARS)
   for (let i = 0; i < sample.length; i++) {
     if (sample.charCodeAt(i) === 0) return true
   }
@@ -43,9 +45,20 @@ export function FileHistoryView({
   const [listError, setListError] = useState<string | null>(null)
   const [diffError, setDiffError] = useState<string | null>(null)
 
+  const loadMoreGenRef = useRef(0)
+
+  const selectedEntry = useMemo(
+    () => commits.find((c) => c.sha === selectedSha) ?? null,
+    [commits, selectedSha],
+  )
+
   const fetchInitial = useCallback(() => {
     setLoading(true)
     setListError(null)
+    setBefore(null)
+    setAfter(null)
+    setDiffError(null)
+    setLoadingDiff(false)
     return gitManager
       .logFile(repoPath, relativePath, PAGE_SIZE, 0)
       .then((entries) => {
@@ -69,19 +82,18 @@ export function FileHistoryView({
     setListError(null)
     setDiffError(null)
     setHasMore(false)
+    loadMoreGenRef.current++           // <-- add this
     void fetchInitial()
   }, [fetchInitial])
 
   // Fetch diff for selected commit.
   useEffect(() => {
-    if (!selectedSha) {
+    if (!selectedSha || !selectedEntry) {
       setBefore(null)
       setAfter(null)
       setDiffError(null)
       return
     }
-    const entry = commits.find((c) => c.sha === selectedSha)
-    if (!entry) return
 
     let cancelled = false
     setLoadingDiff(true)
@@ -89,9 +101,9 @@ export function FileHistoryView({
 
     const afterPromise = gitManager.showFile(repoPath, relativePath, selectedSha)
     const beforePromise: Promise<string | null> =
-      entry.parentSha === ''
+      selectedEntry.parentSha === ''
         ? Promise.resolve('')
-        : gitManager.showFile(repoPath, relativePath, entry.parentSha)
+        : gitManager.showFile(repoPath, relativePath, selectedEntry.parentSha)
 
     Promise.all([beforePromise, afterPromise])
       .then(([b, a]) => {
@@ -115,26 +127,31 @@ export function FileHistoryView({
     return () => {
       cancelled = true
     }
-  }, [selectedSha, repoPath, relativePath, commits])
+  }, [selectedSha, selectedEntry, repoPath, relativePath])
 
-  const handleLoadMore = () => {
+  const handleLoadMore = useCallback(() => {
+    if (loadingMore) return
+    const gen = ++loadMoreGenRef.current
     setLoadingMore(true)
     gitManager
       .logFile(repoPath, relativePath, PAGE_SIZE, commits.length)
       .then((entries) => {
+        if (gen !== loadMoreGenRef.current) return
         setCommits((prev) => [...prev, ...entries])
         setHasMore(entries.length === PAGE_SIZE)
         setLoadingMore(false)
       })
       .catch((err: unknown) => {
+        if (gen !== loadMoreGenRef.current) return
         setListError(err instanceof Error ? err.message : String(err))
         setLoadingMore(false)
       })
-  }
+  }, [repoPath, relativePath, commits.length, loadingMore])
 
   const showEmpty = !loading && !listError && commits.length === 0
-  const showSizeGuard =
-    after !== null && (isBinaryOrTooLarge(after) || (before !== null && isBinaryOrTooLarge(before)))
+  const beforeTooLarge = before !== null && isBinaryOrTooLarge(before)
+  const afterTooLarge = after !== null && isBinaryOrTooLarge(after)
+  const showSizeGuard = afterTooLarge || beforeTooLarge
 
   return (
     <div className="flex h-full">

--- a/packages/app/src/components/history/__tests__/CommitList.test.tsx
+++ b/packages/app/src/components/history/__tests__/CommitList.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CommitList } from '../CommitList'
+import type { GitLogEntry } from '@/lib/git/types'
+
+const sample: GitLogEntry[] = [
+  {
+    sha: 'a'.repeat(40),
+    parentSha: 'b'.repeat(40),
+    author: 'Alice',
+    isoTime: '2026-04-27T10:00:00+00:00',
+    subject: 'second',
+  },
+  {
+    sha: 'b'.repeat(40),
+    parentSha: '',
+    author: 'Bob',
+    isoTime: '2026-04-26T10:00:00+00:00',
+    subject: 'first',
+  },
+]
+
+describe('CommitList', () => {
+  it('renders a row per commit with subject and author', () => {
+    render(
+      <CommitList
+        commits={sample}
+        selectedSha={null}
+        onSelect={() => {}}
+        onLoadMore={() => {}}
+        hasMore={false}
+        loadingMore={false}
+      />,
+    )
+    expect(screen.getByText('second')).toBeDefined()
+    expect(screen.getByText('first')).toBeDefined()
+    expect(screen.getByText(/Alice/)).toBeDefined()
+    expect(screen.getByText(/Bob/)).toBeDefined()
+  })
+
+  it('calls onSelect with the row sha when clicked', () => {
+    const onSelect = vi.fn()
+    render(
+      <CommitList
+        commits={sample}
+        selectedSha={null}
+        onSelect={onSelect}
+        onLoadMore={() => {}}
+        hasMore={false}
+        loadingMore={false}
+      />,
+    )
+    fireEvent.click(screen.getByText('first'))
+    expect(onSelect).toHaveBeenCalledWith(sample[1].sha)
+  })
+
+  it('renders the "load more" button when hasMore=true and triggers onLoadMore', () => {
+    const onLoadMore = vi.fn()
+    render(
+      <CommitList
+        commits={sample}
+        selectedSha={null}
+        onSelect={() => {}}
+        onLoadMore={onLoadMore}
+        hasMore={true}
+        loadingMore={false}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: '加载更多' })
+    fireEvent.click(btn)
+    expect(onLoadMore).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the "load more" button when hasMore=false', () => {
+    render(
+      <CommitList
+        commits={sample}
+        selectedSha={null}
+        onSelect={() => {}}
+        onLoadMore={() => {}}
+        hasMore={false}
+        loadingMore={false}
+      />,
+    )
+    expect(screen.queryByRole('button', { name: '加载更多' })).toBeNull()
+  })
+
+  it('disables the "load more" button while loadingMore', () => {
+    render(
+      <CommitList
+        commits={sample}
+        selectedSha={null}
+        onSelect={() => {}}
+        onLoadMore={() => {}}
+        hasMore={true}
+        loadingMore={true}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: '' }) as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+})

--- a/packages/app/src/components/history/__tests__/FileHistoryView.test.tsx
+++ b/packages/app/src/components/history/__tests__/FileHistoryView.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import type { GitLogEntry } from '@/lib/git/types'
+
+const logFileMock = vi.fn()
+const showFileMock = vi.fn()
+
+vi.mock('@/lib/git/manager', () => ({
+  gitManager: {
+    logFile: (...args: unknown[]) => logFileMock(...args),
+    showFile: (...args: unknown[]) => showFileMock(...args),
+  },
+}))
+
+vi.mock('@/components/diff/DiffRenderer', () => ({
+  default: ({ before, after, filePath }: { before: string; after: string; filePath: string }) => (
+    <div data-testid="diff-renderer" data-before={before} data-after={after} data-filepath={filePath} />
+  ),
+}))
+
+import { FileHistoryView } from '../FileHistoryView'
+
+const initial: GitLogEntry = {
+  sha: 'newsha'.padEnd(40, '0'),
+  parentSha: 'oldsha'.padEnd(40, '0'),
+  author: 'Alice',
+  isoTime: '2026-04-27T10:00:00+00:00',
+  subject: 'second',
+}
+const previous: GitLogEntry = {
+  sha: 'oldsha'.padEnd(40, '0'),
+  parentSha: '',
+  author: 'Bob',
+  isoTime: '2026-04-26T10:00:00+00:00',
+  subject: 'first',
+}
+
+describe('FileHistoryView', () => {
+  beforeEach(() => {
+    logFileMock.mockReset()
+    showFileMock.mockReset()
+  })
+
+  it('loads commits, auto-selects the first, and renders its diff', async () => {
+    logFileMock.mockResolvedValueOnce([initial, previous])
+    showFileMock.mockImplementation((_path: string, _file: string, ref: string) => {
+      if (ref === initial.sha) return Promise.resolve('AFTER')
+      if (ref === initial.parentSha) return Promise.resolve('BEFORE')
+      return Promise.resolve(null)
+    })
+
+    render(
+      <FileHistoryView
+        repoPath="/repo"
+        relativePath="a.txt"
+        filePath="/repo/a.txt"
+        isDark={false}
+      />,
+    )
+
+    await waitFor(() => expect(logFileMock).toHaveBeenCalledWith('/repo', 'a.txt', 50, 0))
+    await waitFor(() => {
+      const node = screen.getByTestId('diff-renderer')
+      expect(node.getAttribute('data-before')).toBe('BEFORE')
+      expect(node.getAttribute('data-after')).toBe('AFTER')
+      expect(node.getAttribute('data-filepath')).toBe('/repo/a.txt')
+    })
+  })
+
+  it('skips the parent fetch for the initial commit and passes empty before', async () => {
+    logFileMock.mockResolvedValueOnce([previous]) // only the first commit ever
+    showFileMock.mockImplementation((_p: string, _f: string, ref: string) => {
+      if (ref === previous.sha) return Promise.resolve('AFTER')
+      throw new Error(`unexpected ref: ${ref}`)
+    })
+
+    render(
+      <FileHistoryView
+        repoPath="/repo"
+        relativePath="a.txt"
+        filePath="/repo/a.txt"
+        isDark={false}
+      />,
+    )
+
+    await waitFor(() => {
+      const node = screen.getByTestId('diff-renderer')
+      expect(node.getAttribute('data-before')).toBe('')
+      expect(node.getAttribute('data-after')).toBe('AFTER')
+    })
+    expect(showFileMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders empty state when commit list is empty', async () => {
+    logFileMock.mockResolvedValueOnce([])
+
+    render(
+      <FileHistoryView
+        repoPath="/repo"
+        relativePath="ghost.txt"
+        filePath="/repo/ghost.txt"
+        isDark={false}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('该文件还没有提交历史')).toBeDefined()
+    })
+    expect(showFileMock).not.toHaveBeenCalled()
+  })
+
+  it('renders a retry banner when logFile rejects, and retries on click', async () => {
+    logFileMock.mockRejectedValueOnce(new Error('git not available'))
+    logFileMock.mockResolvedValueOnce([initial])
+    showFileMock.mockResolvedValue('CONTENT')
+
+    render(
+      <FileHistoryView
+        repoPath="/repo"
+        relativePath="a.txt"
+        filePath="/repo/a.txt"
+        isDark={false}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText(/git not available/)).toBeDefined())
+    fireEvent.click(screen.getByRole('button', { name: '重试' }))
+    await waitFor(() => expect(logFileMock).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(screen.getByTestId('diff-renderer')).toBeDefined())
+  })
+
+  it('renders a diff error placeholder when showFile fails for selected commit', async () => {
+    logFileMock.mockResolvedValueOnce([initial])
+    showFileMock.mockResolvedValue(null) // both before & after resolve to null
+
+    render(
+      <FileHistoryView
+        repoPath="/repo"
+        relativePath="a.txt"
+        filePath="/repo/a.txt"
+        isDark={false}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText(/无法加载该提交的内容/)).toBeDefined())
+  })
+
+  it('appends results when "load more" is clicked', async () => {
+    const page1 = Array.from({ length: 50 }, (_, i) => ({
+      ...initial,
+      sha: `s1-${i}`.padEnd(40, '0'),
+      subject: `c1-${i}`,
+    }))
+    const page2 = [
+      { ...previous, sha: 'next-page'.padEnd(40, '0'), subject: 'c2-0' },
+    ]
+    logFileMock.mockResolvedValueOnce(page1).mockResolvedValueOnce(page2)
+    showFileMock.mockResolvedValue('X')
+
+    render(
+      <FileHistoryView
+        repoPath="/repo"
+        relativePath="a.txt"
+        filePath="/repo/a.txt"
+        isDark={false}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText('c1-0')).toBeDefined())
+    fireEvent.click(screen.getByRole('button', { name: '加载更多' }))
+    await waitFor(() => expect(logFileMock).toHaveBeenLastCalledWith('/repo', 'a.txt', 50, 50))
+    await waitFor(() => expect(screen.getByText('c2-0')).toBeDefined())
+  })
+
+  it('resets state and reloads when relativePath changes', async () => {
+    logFileMock.mockResolvedValueOnce([initial])
+    showFileMock.mockResolvedValue('CONTENT')
+
+    const { rerender } = render(
+      <FileHistoryView
+        repoPath="/repo"
+        relativePath="a.txt"
+        filePath="/repo/a.txt"
+        isDark={false}
+      />,
+    )
+    await waitFor(() => expect(logFileMock).toHaveBeenCalledWith('/repo', 'a.txt', 50, 0))
+
+    logFileMock.mockResolvedValueOnce([previous])
+    rerender(
+      <FileHistoryView
+        repoPath="/repo"
+        relativePath="b.txt"
+        filePath="/repo/b.txt"
+        isDark={false}
+      />,
+    )
+    await waitFor(() => expect(logFileMock).toHaveBeenLastCalledWith('/repo', 'b.txt', 50, 0))
+  })
+})

--- a/packages/app/src/components/history/__tests__/FileHistoryView.test.tsx
+++ b/packages/app/src/components/history/__tests__/FileHistoryView.test.tsx
@@ -148,7 +148,7 @@ describe('FileHistoryView', () => {
   it('appends results when "load more" is clicked', async () => {
     const page1 = Array.from({ length: 50 }, (_, i) => ({
       ...initial,
-      sha: `s1-${i}`.padEnd(40, '0'),
+      sha: `s1-${String(i).padStart(3, '0')}`.padEnd(40, '0'),
       subject: `c1-${i}`,
     }))
     const page2 = [

--- a/packages/app/src/lib/git/__tests__/manager-logFile.test.ts
+++ b/packages/app/src/lib/git/__tests__/manager-logFile.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const invokeMock = vi.fn()
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}))
+
+vi.mock('@tauri-apps/api/path', () => ({
+  homeDir: vi.fn().mockResolvedValue('/home'),
+  join: (...parts: string[]) => Promise.resolve(parts.join('/')),
+  dirname: (p: string) => Promise.resolve(p.split('/').slice(0, -1).join('/')),
+}))
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  exists: vi.fn().mockResolvedValue(false),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  readTextFile: vi.fn().mockResolvedValue('{}'),
+  writeTextFile: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { gitManager } from '../manager'
+import type { GitLogEntry } from '../types'
+
+describe('gitManager.logFile', () => {
+  beforeEach(() => {
+    invokeMock.mockReset()
+  })
+
+  it('invokes git_log_file with the right args and returns entries', async () => {
+    const stub: GitLogEntry[] = [
+      {
+        sha: 'abc123',
+        parentSha: 'def456',
+        author: 'Alice',
+        isoTime: '2026-04-27T10:00:00+00:00',
+        subject: 'first commit',
+      },
+    ]
+    invokeMock.mockResolvedValueOnce(stub)
+
+    const out = await gitManager.logFile('/repo', 'a.txt', 50, 0)
+
+    expect(invokeMock).toHaveBeenCalledWith('git_log_file', {
+      path: '/repo',
+      file: 'a.txt',
+      limit: 50,
+      skip: 0,
+    })
+    expect(out).toEqual(stub)
+  })
+
+  it('propagates errors from invoke', async () => {
+    invokeMock.mockRejectedValueOnce(new Error('boom'))
+    await expect(gitManager.logFile('/repo', 'a.txt', 50, 0)).rejects.toThrow('boom')
+  })
+})

--- a/packages/app/src/lib/git/manager.ts
+++ b/packages/app/src/lib/git/manager.ts
@@ -4,6 +4,7 @@ import { mkdir, exists } from '@tauri-apps/plugin-fs'
 import type {
   GitCommandResult,
   GitStatusResult,
+  GitLogEntry,
   GitRepo,
   GitRepoConfig,
   RepoSource,
@@ -172,6 +173,24 @@ export class GitManager {
       // File doesn't exist at this ref (new file) or not a git repo
       return null
     }
+  }
+
+  /**
+   * Read commit history for a single file (paginated).
+   * Returns entries newest-first. Empty array means "no commits touched this file".
+   */
+  async logFile(
+    localPath: string,
+    file: string,
+    limit: number,
+    skip: number,
+  ): Promise<GitLogEntry[]> {
+    return invoke<GitLogEntry[]>('git_log_file', {
+      path: localPath,
+      file,
+      limit,
+      skip,
+    })
   }
 
   // ─── Repository Management ─────────────────────────────────────────────

--- a/packages/app/src/lib/git/types.ts
+++ b/packages/app/src/lib/git/types.ts
@@ -21,6 +21,17 @@ export interface GitStatusResult {
   clean: boolean
 }
 
+/** A single commit entry from `git log --follow` for a file */
+export interface GitLogEntry {
+  sha: string
+  /** First-parent SHA. Empty string for the initial commit. */
+  parentSha: string
+  author: string
+  /** Strict ISO 8601 (e.g. "2026-04-27T10:00:00+00:00"). */
+  isoTime: string
+  subject: string
+}
+
 // ─── Repository Types ──────────────────────────────────────────────────────
 
 /** Source type of a git-managed repository */

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -348,10 +348,12 @@ pub fn git_log_file(
     let skip_arg = format!("--skip={}", skip);
     let pretty = "--pretty=format:%H%x09%P%x09%an%x09%aI%x09%s";
 
+    // --first-parent keeps the log consistent with parent_sha (which is always first-parent).
     let result = run_git(
         &[
             "log",
             "--follow",
+            "--first-parent",
             &max_count_arg,
             &skip_arg,
             pretty,

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -318,3 +318,212 @@ pub fn git_show_file(
     let spec = format!("{}:{}", r, file);
     run_git(&["show", &spec], &path)
 }
+
+/// 1.11 - Read commit history for a single file.
+///
+/// Runs `git log --follow ...` and returns parsed entries newest-first.
+/// `limit` defaults to 50, `skip` defaults to 0.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitLogEntry {
+    pub sha: String,
+    /// First-parent SHA. Empty string for the initial commit.
+    pub parent_sha: String,
+    pub author: String,
+    /// Strict ISO 8601 (`%aI`).
+    pub iso_time: String,
+    pub subject: String,
+}
+
+#[tauri::command]
+pub fn git_log_file(
+    path: String,
+    file: String,
+    limit: Option<u32>,
+    skip: Option<u32>,
+) -> Result<Vec<GitLogEntry>, String> {
+    let limit = limit.unwrap_or(50);
+    let skip = skip.unwrap_or(0);
+    let max_count_arg = format!("--max-count={}", limit);
+    let skip_arg = format!("--skip={}", skip);
+    let pretty = "--pretty=format:%H%x09%P%x09%an%x09%aI%x09%s";
+
+    let result = run_git(
+        &[
+            "log",
+            "--follow",
+            &max_count_arg,
+            &skip_arg,
+            pretty,
+            "--",
+            &file,
+        ],
+        &path,
+    )?;
+
+    if !result.success {
+        return Err(format!("git log failed: {}", result.stderr.trim()));
+    }
+
+    let mut entries = Vec::new();
+    for line in result.stdout.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(5, '\t');
+        let sha = parts.next().unwrap_or("").to_string();
+        let parents = parts.next().unwrap_or("");
+        let author = parts.next().unwrap_or("").to_string();
+        let iso_time = parts.next().unwrap_or("").to_string();
+        let subject = parts.next().unwrap_or("").to_string();
+
+        if sha.is_empty() {
+            continue;
+        }
+
+        let parent_sha = parents.split_whitespace().next().unwrap_or("").to_string();
+
+        entries.push(GitLogEntry {
+            sha,
+            parent_sha,
+            author,
+            iso_time,
+            subject,
+        });
+    }
+
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn run(repo: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .status()
+            .expect("git command should run");
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path();
+        run(path, &["init", "-q", "-b", "main"]);
+        run(path, &["config", "user.email", "t@t.t"]);
+        run(path, &["config", "user.name", "Test"]);
+        run(path, &["config", "commit.gpgsign", "false"]);
+        dir
+    }
+
+    fn commit_file(repo: &TempDir, file: &str, content: &str, msg: &str) {
+        let p = repo.path().join(file);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).expect("create parent dir");
+        }
+        fs::write(&p, content).expect("write file");
+        run(repo.path(), &["add", file]);
+        run(repo.path(), &["commit", "-q", "-m", msg]);
+    }
+
+    fn repo_path(dir: &TempDir) -> String {
+        dir.path().to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn returns_commits_newest_first_with_all_fields() {
+        let repo = init_repo();
+        commit_file(&repo, "a.txt", "v1", "first");
+        commit_file(&repo, "a.txt", "v2", "second");
+        commit_file(&repo, "a.txt", "v3", "third");
+
+        let entries = git_log_file(repo_path(&repo), "a.txt".into(), Some(50), Some(0))
+            .expect("git_log_file ok");
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].subject, "third");
+        assert_eq!(entries[1].subject, "second");
+        assert_eq!(entries[2].subject, "first");
+        for e in &entries {
+            assert_eq!(e.author, "Test");
+            assert!(!e.sha.is_empty());
+            assert!(!e.iso_time.is_empty());
+        }
+        assert_eq!(entries[0].parent_sha, entries[1].sha);
+        assert_eq!(entries[1].parent_sha, entries[2].sha);
+        assert_eq!(entries[2].parent_sha, "");
+    }
+
+    #[test]
+    fn initial_commit_has_empty_parent_sha() {
+        let repo = init_repo();
+        commit_file(&repo, "a.txt", "v1", "first");
+
+        let entries =
+            git_log_file(repo_path(&repo), "a.txt".into(), None, None).expect("git_log_file ok");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].parent_sha, "");
+    }
+
+    #[test]
+    fn follows_renames() {
+        let repo = init_repo();
+        commit_file(&repo, "old.txt", "v1", "orig");
+        run(repo.path(), &["mv", "old.txt", "new.txt"]);
+        run(repo.path(), &["commit", "-q", "-m", "rename"]);
+        commit_file(&repo, "new.txt", "v2", "after rename");
+
+        let entries =
+            git_log_file(repo_path(&repo), "new.txt".into(), None, None).expect("git_log_file ok");
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].subject, "after rename");
+        assert_eq!(entries[1].subject, "rename");
+        assert_eq!(entries[2].subject, "orig");
+    }
+
+    #[test]
+    fn limit_and_skip_honored() {
+        let repo = init_repo();
+        for i in 0..5 {
+            commit_file(&repo, "a.txt", &format!("v{}", i), &format!("c{}", i));
+        }
+
+        let entries = git_log_file(repo_path(&repo), "a.txt".into(), Some(2), Some(2))
+            .expect("git_log_file ok");
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].subject, "c2");
+        assert_eq!(entries[1].subject, "c1");
+    }
+
+    #[test]
+    fn never_committed_file_returns_empty_vec() {
+        let repo = init_repo();
+        commit_file(&repo, "a.txt", "v1", "first");
+
+        let entries = git_log_file(repo_path(&repo), "ghost.txt".into(), None, None)
+            .expect("git_log_file ok");
+
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn subject_with_tab_survives_parsing() {
+        let repo = init_repo();
+        commit_file(&repo, "a.txt", "v1", "msg with\ttab inside");
+
+        let entries =
+            git_log_file(repo_path(&repo), "a.txt".into(), None, None).expect("git_log_file ok");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].subject, "msg with\ttab inside");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -420,6 +420,7 @@ pub fn run() {
             commands::git::git_diff,
             commands::git::git_checkout_file,
             commands::git::git_show_file,
+            commands::git::git_log_file,
             commands::team::get_team_status,
             commands::team::update_team_llm_config,
             commands::team::team_check_git_installed,


### PR DESCRIPTION
## Summary

- New 🕐 toolbar button in the FileEditor for files under `teamclaw-team/` opens a master-detail view: left list of commits that touched the file, right diff (selected commit vs its first parent) reusing the existing `LazyDiffRenderer`. Read-only.
- Backend: new `git_log_file` Tauri command (`git log --follow --first-parent ...`, paginated 50/page) plus 6 tempdir-based unit tests. Existing `git_show_file` reused for content fetches.
- Frontend: new `gitManager.logFile`, `GitLogEntry` type, `CommitList` + `FileHistoryView` components. `FileEditor` adds `showHistory` state, the toolbar button, mutual exclusion with the existing diff toggle, and an editor-area routing branch. `isTauri()` gate matches the spec.
- Solves the "diff disappears after auto-commit" confusion the user observed on `.leaderboard/<machine>.local.json` — now you can scroll back through any team file's history.

## Architecture

- One round-trip per page (`git_log_file`), then on commit selection two `git_show_file` calls (or one for the initial commit). No new IPC protocol — reuses the existing `run_git` helper and `invoke` boundary.
- Race protection in `FileHistoryView`: `useCallback` + generation counter on "load more" so file-switches don't append stale results; memoized `selectedEntry` so pagination doesn't re-trigger the diff effect; retry path resets diff state cleanly.
- Binary/oversize guard (256K UTF-16 code units) skips diff rendering with a placeholder.

## Test plan

- [x] Rust unit tests: `cargo test --manifest-path src-tauri/Cargo.toml -- commands::git::tests` (6 tests — newest-first order, initial commit empty parent, rename follow, limit/skip, never-committed file, tab in subject)
- [x] Frontend unit tests: `pnpm --filter @teamclaw/app exec vitest run src/components/history src/components/__tests__/FileEditor.test.tsx src/lib/git/__tests__/manager-logFile.test.ts` (22 tests across 4 files)
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter @teamclaw/app exec eslint src/components/FileEditor.tsx src/components/history` clean
- [ ] Manual: open `.leaderboard/<machine>.local.json` → 🕐 → list + diff render → switch commits → "加载更多" → toggle off
- [ ] Manual: file with rename history → list spans rename
- [ ] Manual: brand-new uncommitted file under `teamclaw-team/` → "该文件还没有提交历史"
- [ ] Manual: non-team file (e.g. `.claude/CLAUDE.md`) → no 🕐 button
- [ ] Manual: click diff → click 🕐 → highlights flip (mutual exclusion both ways)

## Deferred (follow-ups, not blocking)

- `formatRelative` only granular to days; long histories on high-frequency files will say "120 days ago" instead of "4 months".
- `showSizeGuard` suppresses the diff if EITHER side is large; could pass `''` for an oversized `before` to still render "delete from huge file" diffs.
- `FileEditor` test relies implicitly on `useTeamModeStore`'s default `myRole = null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)