### PR TITLE
fix: editor undo, new-session UX, Windows team join

### DIFF
--- a/packages/app/src/components/editors/CodeEditor.tsx
+++ b/packages/app/src/components/editors/CodeEditor.tsx
@@ -303,17 +303,41 @@ export function CodeEditor({
     if (!view) return;
 
     const currentDoc = view.state.doc.toString();
-    if (currentDoc !== content) {
-      isExternalUpdate.current = true;
-      view.dispatch({
-        changes: { from: 0, to: currentDoc.length, insert: content },
-        // Don't pollute the undo history with external content syncs.
-        // Without this, React re-renders triggered by undo/redo can insert
-        // a "sync" transaction into the history stack, breaking further undos.
-        annotations: Transaction.addToHistory.of(false),
-      });
-      isExternalUpdate.current = false;
+    if (currentDoc === content) return;
+
+    // Use a minimal diff (common prefix + common suffix) instead of a wholesale
+    // replacement. Even with `Transaction.addToHistory.of(false)`, the history
+    // extension calls `state.addMapping(tr.changes.desc)` which maps every prior
+    // undo/redo entry through this transaction's changes. A wholesale replace of
+    // the entire document collapses every prior entry to an empty change, so
+    // `addMappingToBranch` drops them all — leaving only one step of undo
+    // available after any external sync. Narrowing the change to just the
+    // differing region preserves history outside that region.
+    let prefix = 0;
+    const minLen = Math.min(currentDoc.length, content.length);
+    while (
+      prefix < minLen &&
+      currentDoc.charCodeAt(prefix) === content.charCodeAt(prefix)
+    ) {
+      prefix++;
     }
+    let oldEnd = currentDoc.length;
+    let newEnd = content.length;
+    while (
+      oldEnd > prefix &&
+      newEnd > prefix &&
+      currentDoc.charCodeAt(oldEnd - 1) === content.charCodeAt(newEnd - 1)
+    ) {
+      oldEnd--;
+      newEnd--;
+    }
+
+    isExternalUpdate.current = true;
+    view.dispatch({
+      changes: { from: prefix, to: oldEnd, insert: content.slice(prefix, newEnd) },
+      annotations: Transaction.addToHistory.of(false),
+    });
+    isExternalUpdate.current = false;
   }, [content]);
 
   // Update git gutter when originalContent changes

--- a/packages/app/src/components/editors/__tests__/code-editor-undo.test.ts
+++ b/packages/app/src/components/editors/__tests__/code-editor-undo.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import { EditorState, Transaction } from '@codemirror/state';
+import { history, historyField, undo } from '@codemirror/commands';
+
+/**
+ * Reproduce the undo behavior of CodeEditor's external content sync.
+ *
+ * The bug (commit 47af973 partially fixed): when the editor's `content` prop
+ * differs from the editor's doc, a sync transaction replaces the doc. Even
+ * with `Transaction.addToHistory.of(false)`, CM6's history extension calls
+ * `state.addMapping(tr.changes.desc)` which maps every prior history entry
+ * through the new transaction's changes. A wholesale replacement collapses
+ * every prior entry to an empty change, dropping them all — leaving only
+ * the most recent edit available for undo.
+ *
+ * The fix: dispatch a minimal diff (common prefix/suffix shrink) instead of
+ * a wholesale replacement, so history outside the changed region survives.
+ */
+
+function computeMinimalChange(
+  oldStr: string,
+  newStr: string,
+): { from: number; to: number; insert: string } | null {
+  if (oldStr === newStr) return null;
+  let prefix = 0;
+  const minLen = Math.min(oldStr.length, newStr.length);
+  while (prefix < minLen && oldStr.charCodeAt(prefix) === newStr.charCodeAt(prefix)) {
+    prefix++;
+  }
+  let oldEnd = oldStr.length;
+  let newEnd = newStr.length;
+  while (
+    oldEnd > prefix &&
+    newEnd > prefix &&
+    oldStr.charCodeAt(oldEnd - 1) === newStr.charCodeAt(newEnd - 1)
+  ) {
+    oldEnd--;
+    newEnd--;
+  }
+  return { from: prefix, to: oldEnd, insert: newStr.slice(prefix, newEnd) };
+}
+
+function applyExternalSync(
+  state: EditorState,
+  newContent: string,
+  mode: 'wholesale' | 'minimal-diff',
+): EditorState {
+  const currentDoc = state.doc.toString();
+  if (currentDoc === newContent) return state;
+  const change =
+    mode === 'wholesale'
+      ? { from: 0, to: currentDoc.length, insert: newContent }
+      : computeMinimalChange(currentDoc, newContent)!;
+  return state.update({
+    changes: change,
+    annotations: Transaction.addToHistory.of(false),
+  }).state;
+}
+
+function makeEdit(state: EditorState, change: { from: number; to: number; insert: string }) {
+  return state.update({
+    changes: change,
+    userEvent: 'input.type',
+    // Force each test edit into its own history group.
+    annotations: Transaction.time.of(state.field(historyField).prevTime + 10_000),
+  }).state;
+}
+
+function runUndo(state: EditorState): EditorState {
+  let result = state;
+  undo({
+    state,
+    dispatch: (tr) => {
+      result = tr.state;
+    },
+  });
+  return result;
+}
+
+describe('CodeEditor external content sync — history preservation', () => {
+  const baseExtensions = [history()];
+
+  it('round-trip sync (no actual diff) does not drop history', () => {
+    let state = EditorState.create({ doc: '', extensions: baseExtensions });
+    state = makeEdit(state, { from: 0, to: 0, insert: 'a' });
+    state = makeEdit(state, { from: 1, to: 1, insert: 'b' });
+    state = makeEdit(state, { from: 2, to: 2, insert: 'c' });
+
+    // No-op sync (doc already matches) — both modes are equivalent here.
+    state = applyExternalSync(state, 'abc', 'minimal-diff');
+
+    state = runUndo(state);
+    expect(state.doc.toString()).toBe('ab');
+    state = runUndo(state);
+    expect(state.doc.toString()).toBe('a');
+    state = runUndo(state);
+    expect(state.doc.toString()).toBe('');
+  });
+
+  it('REGRESSION: wholesale sync drops history (only one undo works)', () => {
+    let state = EditorState.create({ doc: '', extensions: baseExtensions });
+    state = makeEdit(state, { from: 0, to: 0, insert: 'a' });
+    state = makeEdit(state, { from: 1, to: 1, insert: 'b' });
+    state = makeEdit(state, { from: 2, to: 2, insert: 'c' });
+
+    // External sync that DOES change the doc, using the old wholesale strategy.
+    // Even a one-character change at the end becomes a from:0 to:3 replacement.
+    state = applyExternalSync(state, 'abcd', 'wholesale');
+
+    // Pre-fix behavior: undo only goes back one step.
+    state = runUndo(state);
+    expect(state.doc.toString()).not.toBe('ab');
+    // History is gone — further undos do nothing.
+    const before = state.doc.toString();
+    state = runUndo(state);
+    expect(state.doc.toString()).toBe(before);
+  });
+
+  it('FIX: minimal-diff sync preserves history outside the changed region', () => {
+    let state = EditorState.create({ doc: '', extensions: baseExtensions });
+    state = makeEdit(state, { from: 0, to: 0, insert: 'a' });
+    state = makeEdit(state, { from: 1, to: 1, insert: 'b' });
+    state = makeEdit(state, { from: 2, to: 2, insert: 'c' });
+
+    // External one-character append using minimal-diff: the change is just
+    // {from: 3, to: 3, insert: 'd'}, which doesn't overlap any prior history
+    // entry, so addMapping leaves prior entries intact.
+    state = applyExternalSync(state, 'abcd', 'minimal-diff');
+
+    state = runUndo(state);
+    expect(state.doc.toString()).toBe('abd');
+    state = runUndo(state);
+    expect(state.doc.toString()).toBe('ad');
+    state = runUndo(state);
+    expect(state.doc.toString()).toBe('d');
+  });
+});
+
+describe('computeMinimalChange', () => {
+  it('returns null for identical strings', () => {
+    expect(computeMinimalChange('hello', 'hello')).toBeNull();
+  });
+
+  it('finds an append at the end', () => {
+    expect(computeMinimalChange('abc', 'abcd')).toEqual({
+      from: 3,
+      to: 3,
+      insert: 'd',
+    });
+  });
+
+  it('finds a prepend at the start', () => {
+    expect(computeMinimalChange('abc', 'xabc')).toEqual({
+      from: 0,
+      to: 0,
+      insert: 'x',
+    });
+  });
+
+  it('finds a middle replacement', () => {
+    expect(computeMinimalChange('hello world', 'hello there')).toEqual({
+      from: 6,
+      to: 11,
+      insert: 'there',
+    });
+  });
+
+  it('finds a deletion', () => {
+    expect(computeMinimalChange('abcdef', 'abef')).toEqual({
+      from: 2,
+      to: 4,
+      insert: '',
+    });
+  });
+
+  it('handles empty old string', () => {
+    expect(computeMinimalChange('', 'abc')).toEqual({
+      from: 0,
+      to: 0,
+      insert: 'abc',
+    });
+  });
+
+  it('handles empty new string', () => {
+    expect(computeMinimalChange('abc', '')).toEqual({
+      from: 0,
+      to: 3,
+      insert: '',
+    });
+  });
+});

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -552,7 +552,10 @@ export function TeamGitConfig() {
       // success to the user immediately, then run the slow clone in background.
       if (fcEndpoint) {
         setConnectStep('Registering with team service...')
-        const nodeId = await tauriInvoke<string>('get_device_node_id')
+        // `get_persistent_device_id` returns the same iroh node_id but is
+        // registered on every platform; `get_device_node_id` lives in the
+        // p2p-gated module and is missing on Windows builds.
+        const nodeId = await tauriInvoke<string>('get_persistent_device_id')
         const fcUrl = `${fcEndpoint.replace(/\/+$/, '')}/ai/add-member`
         const fcResp = await fetch(fcUrl, {
           method: 'POST',

--- a/packages/app/src/stores/ui.ts
+++ b/packages/app/src/stores/ui.ts
@@ -148,16 +148,23 @@ export const useUIStore = create<UIState>((set, get) => ({
         import('@/stores/tabs').then(({ useTabsStore }) => {
           import('@/stores/streaming').then(({ useStreamingStore }) => {
             // Close any open UI elements and return to chat view
-            set({ 
-              currentView: 'chat', 
-              settingsInitialSection: null, 
-              embeddedSettingsSection: null 
+            set({
+              currentView: 'chat',
+              settingsInitialSection: null,
+              embeddedSettingsSection: null
             })
             useWorkspaceStore.getState().clearSelection()
             useWorkspaceStore.getState().closePanel()
-            useTabsStore.getState().hideAll()
+            // Only deactivate the editor multi-tab pane in stacked layout —
+            // in stacked mode chat and tabs share the same slot, so we need
+            // to hide tabs to reveal the chat view. In split layout the
+            // chat pane is already visible alongside the tabs, so closing
+            // them just makes the user's open files vanish for no reason.
+            if (get().mainContentLayout === 'stacked') {
+              useTabsStore.getState().hideAll()
+            }
             useStreamingStore.getState().clearStreaming()
-            
+
             // Clear session state to show "Start a New Chat" UI
             // Actual session will be created when user sends first message
             useSessionStore.setState({

--- a/packages/app/src/stores/ui.ts
+++ b/packages/app/src/stores/ui.ts
@@ -142,17 +142,21 @@ export const useUIStore = create<UIState>((set, get) => ({
   closeEmbeddedSettingsSection: () => set({ embeddedSettingsSection: null }),
 
   startNewChat: () => {
+    // Switch to chat view synchronously so settings (full-page or embedded)
+    // hides immediately — waiting on the dynamic imports below would leave
+    // the settings UI visible until the import chain resolves.
+    set({
+      currentView: 'chat',
+      settingsInitialSection: null,
+      embeddedSettingsSection: null,
+    })
+    const isStacked = get().mainContentLayout === 'stacked'
+
     // Import session and other stores lazily to avoid circular dependencies
     import('@/stores/session').then(({ useSessionStore }) => {
       import('@/stores/workspace').then(({ useWorkspaceStore }) => {
         import('@/stores/tabs').then(({ useTabsStore }) => {
           import('@/stores/streaming').then(({ useStreamingStore }) => {
-            // Close any open UI elements and return to chat view
-            set({
-              currentView: 'chat',
-              settingsInitialSection: null,
-              embeddedSettingsSection: null
-            })
             useWorkspaceStore.getState().clearSelection()
             useWorkspaceStore.getState().closePanel()
             // Only deactivate the editor multi-tab pane in stacked layout —
@@ -160,7 +164,7 @@ export const useUIStore = create<UIState>((set, get) => ({
             // to hide tabs to reveal the chat view. In split layout the
             // chat pane is already visible alongside the tabs, so closing
             // them just makes the user's open files vanish for no reason.
-            if (get().mainContentLayout === 'stacked') {
+            if (isStacked) {
               useTabsStore.getState().hideAll()
             }
             useStreamingStore.getState().clearStreaming()


### PR DESCRIPTION
## Summary

Four independent bug fixes:

- **Editor undo regression** — `CodeEditor` external-content sync was wiping the entire undo/redo stack via CM6's `state.addMapping` whenever the parent's `content` prop diverged from the editor doc (e.g. file reload after save, agent edit). The previous `Transaction.addToHistory.of(false)` fix only stopped the sync from being *added* to history; the wholesale `{from:0, to:doc.length, insert:content}` replacement still collapsed every prior history entry through the position-mapping pass. Switched to a minimal-diff (common-prefix + common-suffix shrink) so history outside the changed region survives.
- **New-session closes editor tabs in split layout** — `startNewChat` always called `useTabsStore.hideAll()`, which made open code/Tiptap files vanish for users running in the side-by-side layout where chat and tabs are visible simultaneously. Now only hides tabs when `mainContentLayout === 'stacked'` (where chat and tabs share the same slot).
- **Settings stays visible briefly on new chat** — the `set({ currentView: 'chat' })` call lived inside four nested dynamic-import `.then()` chains, so the settings UI stayed up until every import resolved. Hoisted the view-flip and settings-flag reset out of the import chain so it runs synchronously on click.
- **Windows: command get_device_node_id not found** — `get_device_node_id` lives in `team_p2p.rs` behind `#[cfg(feature = \"p2p\")]`, which is off in Windows builds. Swapped the team-join flow to `get_persistent_device_id` from `oss_commands.rs`, which is registered on every platform and delegates to the same `oss_commands::get_device_id()` implementation (identical return value).

## Test plan

- [ ] Open a code file → type → undo. All edits unwound (already worked).
- [ ] Open a code file → type → save (triggers file-watcher reload). Then undo. All prior edits still unwound — history not wiped by the reload sync.
- [ ] Open a code file → have an agent edit a different region of the file. Then undo. Prior typed edits outside the agent's diff region survive.
- [ ] Split layout, multiple file tabs open, click New Chat. Tabs stay visible and active.
- [ ] Stacked layout, file tab open, click New Chat. Tabs hide, chat view shows (regression check — old behavior preserved).
- [ ] Open Settings → Team → click New Chat from sidebar. Settings closes immediately, no perceptible delay.
- [ ] Windows build: Settings → Team → paste invite code → Join. No "command get_device_node_id not found"; flow registers with FC and proceeds.
- [ ] `pnpm test:unit` passes (2 pre-existing app-sidebar failures, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)