### PR TITLE
Prevent telemetry history bulk load on startup

### DIFF
--- a/packages/app/src/stores/__tests__/session-loader.test.ts
+++ b/packages/app/src/stores/__tests__/session-loader.test.ts
@@ -277,4 +277,24 @@ describe('session-loader: createLoaderActions', () => {
     expect(localStorage.setItem).toHaveBeenCalled()
     expect(state.activeSessionId).toBeNull()
   })
+
+  it('loadAllSessionMessages refuses to fetch when too many sessions need messages', async () => {
+    const now = Date.now()
+    mockListSessions.mockResolvedValue(
+      Array.from({ length: 31 }, (_, index) => ({
+        id: `session-${index}`,
+        title: `Session ${index}`,
+        time: { created: now - index, updated: now - index },
+        directory: '/workspace',
+      })),
+    )
+
+    await actions.loadAllSessionMessages('/workspace')
+
+    expect(mockListSessions).toHaveBeenCalledWith({ directory: '/workspace', roots: true })
+    expect(mockGetMessages).not.toHaveBeenCalled()
+    expect(state.dashboardLoading).toBe(false)
+    expect(state.dashboardLoadProgress).toEqual({ loaded: 0, total: 31 })
+    expect(state.dashboardLoadError).toContain('31 sessions')
+  })
 })

--- a/packages/app/src/stores/__tests__/telemetry.test.ts
+++ b/packages/app/src/stores/__tests__/telemetry.test.ts
@@ -1,6 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-vi.mock('@/lib/utils', () => ({ isTauri: () => false }))
+const {
+  mockIsTauri,
+  mockInvoke,
+  mockLoadAllSessionMessages,
+} = vi.hoisted(() => ({
+  mockIsTauri: vi.fn(() => false),
+  mockInvoke: vi.fn(),
+  mockLoadAllSessionMessages: vi.fn(async () => undefined),
+}))
+
+vi.mock('@/lib/utils', () => ({ isTauri: mockIsTauri }))
 vi.mock('@/lib/telemetry/scoring-engine', () => ({
   ScoringEngine: vi.fn().mockImplementation(() => ({ score: vi.fn(async () => []) })),
 }))
@@ -10,19 +20,35 @@ vi.mock('@/lib/telemetry/report-builder', () => ({
 vi.mock('@/stores/session', () => ({
   useSessionStore: Object.assign(
     vi.fn(() => ({})),
-    { getState: () => ({ sessions: [], getSessionMessages: () => [] }) },
+    {
+      getState: () => ({
+        sessions: [],
+        getSessionMessages: () => [],
+        loadAllSessionMessages: mockLoadAllSessionMessages,
+      }),
+    },
   ),
+}))
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: {
+    getState: () => ({ workspacePath: '/tmp/teamclaw-test-workspace' }),
+  },
 }))
 vi.mock('@/lib/opencode/sdk-client', () => ({
   getOpenCodeClient: vi.fn(() => ({ getMessages: vi.fn(async () => []) })),
 }))
-vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mockInvoke }))
 
 // Import after mocks
 const { useTelemetryStore } = await import('@/stores/telemetry')
 
 describe('telemetryStore', () => {
   beforeEach(() => {
+    vi.useRealTimers()
+    mockIsTauri.mockReturnValue(false)
+    mockInvoke.mockReset()
+    mockInvoke.mockResolvedValue('undecided')
+    mockLoadAllSessionMessages.mockClear()
     useTelemetryStore.setState({
       consent: 'undecided',
       deviceId: null,
@@ -31,6 +57,10 @@ describe('telemetryStore', () => {
       starRatingCache: new Map(),
       isGeneratingReports: false,
     })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('initializes with default state', () => {
@@ -42,6 +72,21 @@ describe('telemetryStore', () => {
   it('init sets isInitialized to true in non-tauri env', async () => {
     await useTelemetryStore.getState().init()
     expect(useTelemetryStore.getState().isInitialized).toBe(true)
+  })
+
+  it('does not auto-generate reports during init when consent is already granted', async () => {
+    vi.useFakeTimers()
+    mockIsTauri.mockReturnValue(true)
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'telemetry_get_consent') return 'granted'
+      return undefined
+    })
+
+    await useTelemetryStore.getState().init()
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(useTelemetryStore.getState().consent).toBe('granted')
+    expect(mockLoadAllSessionMessages).not.toHaveBeenCalled()
   })
 
   it('getFeedback returns undefined for unknown message', () => {

--- a/packages/app/src/stores/session-loader.ts
+++ b/packages/app/src/stores/session-loader.ts
@@ -35,6 +35,8 @@ import {
 type SessionSet = (fn: ((state: SessionState) => Partial<SessionState>) | Partial<SessionState>) => void;
 type SessionGet = () => SessionState;
 
+const MAX_BULK_MESSAGE_SESSION_LOAD = 30;
+
 export function createLoaderActions(set: SessionSet, get: SessionGet) {
   return {
     // Reset sessions (clear all session data and cache)
@@ -642,6 +644,16 @@ export function createLoaderActions(set: SessionSet, get: SessionGet) {
         const total = activeSessions.length;
         let loaded = total - sessionsNeedingMessages.length;
         set({ dashboardLoadProgress: { loaded, total } });
+
+        if (sessionsNeedingMessages.length > MAX_BULK_MESSAGE_SESSION_LOAD) {
+          const message = `Skipped loading historical messages: ${sessionsNeedingMessages.length} sessions need messages, above the safe limit of ${MAX_BULK_MESSAGE_SESSION_LOAD}.`;
+          console.warn(`[Session] ${message}`);
+          set({
+            dashboardLoading: false,
+            dashboardLoadError: message,
+          });
+          return;
+        }
 
         const CONCURRENCY = 5;
         const errors: string[] = [];

--- a/packages/app/src/stores/telemetry.ts
+++ b/packages/app/src/stores/telemetry.ts
@@ -148,13 +148,8 @@ export const useTelemetryStore = create<TelemetryState>((set, get) => ({
         isInitialized: true,
       })
 
-      // Generate session reports after a short delay to avoid blocking init
-      if (consent === 'granted') {
-        setTimeout(async () => {
-          const workspacePath = (await import('@/stores/workspace')).useWorkspaceStore.getState().workspacePath
-          get().generateAllSessionReports(workspacePath ?? undefined)
-        }, 5000) // 5 seconds delay
-      }
+      // Keep startup lightweight: historical reports can still be generated
+      // explicitly, but init must not bulk-load all session history into WebView.
     } catch (err) {
       console.error('[telemetry] Failed to initialize:', err)
       set({ isInitialized: true })


### PR DESCRIPTION
## Summary
- Stop telemetry init from automatically bulk-loading historical session messages on startup.
- Add a safe session-count guard for loadAllSessionMessages to skip large history loads.
- Cover startup and bulk-load guards with regression tests.

## Test Plan
- pnpm exec vitest run src/stores/__tests__/session-loader.test.ts src/stores/__tests__/telemetry.test.ts
- pnpm --filter @teamclaw/app typecheck

## Notes
- Created from fork branch bertrand319:codex/telemetry-memory-guard.
- Local workspace has unrelated uncommitted Rust/Cargo changes and an unresolved src-tauri/Cargo.lock conflict; this PR branch contains only the frontend telemetry/session-loader changes.