### PR TITLE
fix(team): avoid creating git team dir before clone

### DIFF
--- a/src-tauri/src/commands/shared_secrets.rs
+++ b/src-tauri/src/commands/shared_secrets.rs
@@ -67,8 +67,15 @@ pub fn validate_key_id(key_id: &str) -> Result<(), String> {
 // File I/O helpers
 // ---------------------------------------------------------------------------
 
-/// Returns the `_secrets/` directory inside `team_dir`, creating it if needed.
+/// Returns the `_secrets/` directory inside an existing `team_dir`, creating the
+/// subdirectory if needed.
 pub fn secrets_dir(team_dir: &Path) -> Result<PathBuf, String> {
+    if !team_dir.exists() {
+        return Err(format!(
+            "secrets_dir: team dir does not exist: {}",
+            team_dir.display()
+        ));
+    }
     let dir = team_dir.join(SECRETS_DIR);
     std::fs::create_dir_all(&dir)
         .map_err(|e| format!("secrets_dir: failed to create {}: {}", dir.display(), e))?;
@@ -153,7 +160,20 @@ pub fn load_all_secrets(state: &SharedSecretsState) -> Result<(), String> {
         dk.ok_or_else(|| "load_all_secrets: derived_key not set".to_string())?
     };
 
-    let dir = secrets_dir(&team_dir)?;
+    let dir = team_dir.join(SECRETS_DIR);
+
+    if !dir.exists() {
+        let mut secrets = state
+            .secrets
+            .lock()
+            .map_err(|e| format!("load_all_secrets: lock secrets: {e}"))?;
+        secrets.clear();
+        log::info!(
+            "shared_secrets: no secrets directory at {}, treating as empty",
+            dir.display()
+        );
+        return Ok(());
+    }
 
     let mut new_map: HashMap<String, SecretEntry> = HashMap::new();
 
@@ -435,4 +455,22 @@ pub async fn shared_secret_list(
     let mut list: Vec<SecretMeta> = secrets.values().map(SecretMeta::from).collect();
     list.sort_by(|a, b| a.key_id.cmp(&b.key_id));
     Ok(list)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_shared_secrets_does_not_create_missing_team_dir() {
+        let workspace_dir = tempfile::tempdir().unwrap();
+        let team_dir = workspace_dir.path().join(crate::commands::TEAM_REPO_DIR);
+        let state = SharedSecretsState::default();
+        let team_secret = "00".repeat(32);
+
+        let result = init_shared_secrets(&state, &team_secret, &team_dir);
+
+        assert!(result.is_ok());
+        assert!(!team_dir.exists());
+    }
 }

--- a/src-tauri/src/commands/team_unified.rs
+++ b/src-tauri/src/commands/team_unified.rs
@@ -189,31 +189,17 @@ fn git_manifest_path(workspace_path: &str) -> std::path::PathBuf {
         .join("members.json")
 }
 
-/// Read manifest, auto-creating with self as owner if missing.
+/// Read the Git team manifest without creating files.
+///
+/// Git clone requires the target `teamclaw-team` path to be absent or empty.
+/// During invite-code joins the UI can briefly mark team mode as enabled while
+/// the clone is still running in the background; member reads must not create
+/// `_meta/members.json` in that window.
 fn read_git_manifest(workspace_path: &str) -> Result<TeamManifest, String> {
     let path = git_manifest_path(workspace_path);
-    if let Ok(content) = std::fs::read_to_string(&path) {
-        return serde_json::from_str(&content)
-            .map_err(|e| format!("Failed to parse members.json: {}", e));
-    }
-    // Auto-create with self as owner
-    let node_id = super::oss_commands::get_device_id()?;
-    let manifest = TeamManifest {
-        owner_node_id: node_id.clone(),
-        members: vec![TeamMember {
-            node_id,
-            name: String::new(),
-            role: MemberRole::Owner,
-            shortcuts_role: Vec::new(),
-            label: String::new(),
-            platform: std::env::consts::OS.to_string(),
-            arch: std::env::consts::ARCH.to_string(),
-            hostname: gethostname::gethostname().to_string_lossy().to_string(),
-            added_at: chrono::Utc::now().to_rfc3339(),
-        }],
-    };
-    write_git_manifest(workspace_path, &manifest)?;
-    Ok(manifest)
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read _meta/members.json: {}", e))?;
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse members.json: {}", e))
 }
 
 fn write_git_manifest(workspace_path: &str, manifest: &TeamManifest) -> Result<(), String> {
@@ -224,6 +210,23 @@ fn write_git_manifest(workspace_path: &str, manifest: &TeamManifest) -> Result<(
     let json = serde_json::to_string_pretty(manifest)
         .map_err(|e| format!("Failed to serialize members.json: {}", e))?;
     std::fs::write(&path, json).map_err(|e| format!("Failed to write members.json: {}", e))
+}
+
+#[cfg(test)]
+mod git_manifest_tests {
+    use super::*;
+
+    #[test]
+    fn read_git_manifest_does_not_create_team_dir_when_missing() {
+        let workspace_dir = tempfile::tempdir().unwrap();
+        let workspace_path = workspace_dir.path().to_string_lossy().to_string();
+        let team_dir = workspace_dir.path().join(crate::commands::TEAM_REPO_DIR);
+
+        let result = read_git_manifest(&workspace_path);
+
+        assert!(result.is_err());
+        assert!(!team_dir.exists());
+    }
 }
 
 /// Get the list of team members from the active sync mode.


### PR DESCRIPTION
## Summary
- Prevent Git team member reads from auto-creating `teamclaw-team/_meta/members.json` before invite-code background clone completes.
- Make shared-secret loading side-effect free when `teamclaw-team/_secrets` is missing, so OpenCode startup cannot create the clone target early.
- Add regression tests covering both no-create paths.

## Test plan
- `cargo test --manifest-path "src-tauri/Cargo.toml" does_not_create`
- `pnpm rust:check`


Made with [Cursor](https://cursor.com)