### PR TITLE
fix(windows): suppress console popups on every subprocess spawn

### DIFF
--- a/src-tauri/src/commands/cron/scheduler.rs
+++ b/src-tauri/src/commands/cron/scheduler.rs
@@ -10,6 +10,7 @@ use super::delivery::DeliveryManager;
 use super::storage::CronStorage;
 use super::types::*;
 use crate::commands::gateway::SessionMapping;
+use crate::process_util::CommandNoWindow;
 
 /// The cron scheduler that runs as a background task
 #[derive(Debug)]
@@ -324,6 +325,7 @@ impl CronScheduler {
     /// Create a git worktree for isolated job execution.
     fn create_worktree(workspace: &str, worktree_path: &str, branch: &str) -> Result<(), String> {
         let output = std::process::Command::new("git")
+            .no_window()
             .current_dir(workspace)
             .args(["worktree", "add", "--detach", worktree_path, branch])
             .output()
@@ -344,6 +346,7 @@ impl CronScheduler {
     /// Remove a git worktree. Falls back to rm -rf + prune if git remove fails.
     fn remove_worktree(workspace: &str, worktree_path: &str) {
         let result = std::process::Command::new("git")
+            .no_window()
             .current_dir(workspace)
             .args(["worktree", "remove", "--force", worktree_path])
             .output();
@@ -359,6 +362,7 @@ impl CronScheduler {
                 );
                 let _ = std::fs::remove_dir_all(worktree_path);
                 let _ = std::process::Command::new("git")
+                    .no_window()
                     .current_dir(workspace)
                     .args(["worktree", "prune"])
                     .output();

--- a/src-tauri/src/commands/deps.rs
+++ b/src-tauri/src/commands/deps.rs
@@ -4,6 +4,8 @@ use tauri::{AppHandle, Emitter, Runtime};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as AsyncCommand;
 
+use crate::process_util::CommandNoWindow;
+
 /// Installation commands for each platform
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlatformInstallCommands {
@@ -48,7 +50,7 @@ fn check_single_dependency(
     affected_features: Vec<String>,
     priority: u8,
 ) -> DependencyInfo {
-    let output = Command::new(name).args(version_args).output();
+    let output = Command::new(name).no_window().args(version_args).output();
 
     match output {
         Ok(o) if o.status.success() => {
@@ -262,7 +264,7 @@ pub async fn install_dependency<R: Runtime>(
 ) -> Result<bool, String> {
     // On macOS, if the dependency requires brew and brew is not installed, install brew first
     if requires_brew(&name) {
-        let brew_check = Command::new("brew").arg("--version").output();
+        let brew_check = Command::new("brew").no_window().arg("--version").output();
         let brew_installed = matches!(brew_check, Ok(o) if o.status.success());
         if !brew_installed {
             let brew_result = run_install(&app, "brew").await;
@@ -324,6 +326,7 @@ async fn run_install<R: Runtime>(app: &AppHandle<R>, name: &str) -> bool {
     };
 
     let child = AsyncCommand::new(shell)
+        .no_window()
         .args(&shell_args)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 
+use crate::process_util::CommandNoWindow;
+
 /// Result of a git command execution
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitCommandResult {
@@ -30,6 +32,7 @@ pub struct GitStatusResult {
 /// Run a git command in a given directory, returning structured output
 fn run_git(args: &[&str], cwd: &str) -> Result<GitCommandResult, String> {
     let output = Command::new("git")
+        .no_window()
         .args(args)
         .current_dir(cwd)
         .output()
@@ -62,6 +65,7 @@ fn run_git_checked(args: &[&str], cwd: &str) -> Result<String, String> {
 #[tauri::command]
 pub fn git_check_available() -> Result<GitCommandResult, String> {
     let output = Command::new("git")
+        .no_window()
         .args(["--version"])
         .output()
         .map_err(|e| format!("Git is not available: {}", e))?;

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -12,6 +12,7 @@ use tokio::process::Command as TokioCommand;
 use tokio::time::timeout;
 
 use super::opencode::OpenCodeState;
+use crate::process_util::CommandNoWindow;
 
 /// MCP Server configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -263,6 +264,7 @@ async fn test_local_server(
 
     // Try to spawn the process
     let mut cmd = TokioCommand::new(program);
+    cmd.no_window();
     cmd.args(args);
     cmd.current_dir(workspace_path);
     cmd.stdin(Stdio::null());
@@ -519,6 +521,7 @@ async fn query_local_server_tools(
     let args = &command[1..];
 
     let mut cmd = TokioCommand::new(program);
+    cmd.no_window();
     cmd.args(args)
         .current_dir(workspace_path)
         .stdin(std::process::Stdio::piped())

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -38,6 +38,9 @@ pub mod webview;
 pub mod window;
 pub mod workspace_files;
 
+#[cfg(target_os = "windows")]
+use crate::process_util::CommandNoWindow;
+
 /// The short application name, injected at compile time via `build.rs`.
 #[allow(dead_code)]
 pub const APP_SHORT_NAME: &str = env!("APP_SHORT_NAME");
@@ -102,6 +105,7 @@ pub fn open_with_default_app(path: String) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
         std::process::Command::new("cmd")
+            .no_window()
             .args(["/C", "start", "", &path])
             .spawn()
             .map_err(|e| format!("Failed to open file: {}", e))?;
@@ -131,7 +135,10 @@ pub fn open_in_terminal(path: String) -> Result<(), String> {
 
     #[cfg(target_os = "windows")]
     {
+        // Hide the outer launcher's console; `start` spawns the user-visible
+        // terminal in its own new console as intended.
         std::process::Command::new("cmd")
+            .no_window()
             .args(["/C", "start", "cmd", "/K", &format!("cd /d {}", path)])
             .spawn()
             .map_err(|e| format!("Failed to open terminal: {}", e))?;

--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -8,6 +8,8 @@ use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
 use tokio::sync::mpsc;
 
+use crate::process_util::CommandNoWindow;
+
 /// Default port for the OpenCode server.
 /// Used for the first/main workspace instance and for dev mode.
 pub const DEFAULT_PORT: u16 = 13141;
@@ -2177,7 +2179,7 @@ async fn kill_process_on_port(port: u16) -> bool {
 async fn kill_process_on_port_windows(port: u16) -> bool {
     use std::process::Command;
 
-    let output = Command::new("netstat").args(["-ano"]).output();
+    let output = Command::new("netstat").no_window().args(["-ano"]).output();
 
     let Ok(output) = output else {
         println!("[OpenCode] Failed to run netstat on port {}", port);
@@ -2209,7 +2211,7 @@ async fn kill_process_on_port_windows(port: u16) -> bool {
             continue;
         }
         println!("[OpenCode] Killing zombie process {} on port {}", pid, port);
-        let _ = Command::new("taskkill").args(["/PID", pid, "/F"]).output();
+        let _ = Command::new("taskkill").no_window().args(["/PID", pid, "/F"]).output();
         killed_any = true;
     }
 
@@ -2587,6 +2589,7 @@ pub async fn get_opencode_project_id(workspace_path: String) -> Result<String, S
     let normalized = workspace_path.trim_end_matches('/');
 
     let output = std::process::Command::new("sqlite3")
+        .no_window()
         .args([&db_path, "-json", "SELECT id, worktree FROM project;"])
         .output()
         .map_err(|e| format!("Failed to run sqlite3: {}", e))?;
@@ -2645,6 +2648,7 @@ pub async fn read_opencode_allowlist(workspace_path: String) -> Result<Vec<Allow
     let db_path = get_opencode_db_path(&workspace_path)?;
 
     let output = std::process::Command::new("sqlite3")
+        .no_window()
         .args([
             &db_path,
             "-json",
@@ -2707,6 +2711,7 @@ pub async fn write_opencode_allowlist(
 
     if rules.is_empty() {
         let output = std::process::Command::new("sqlite3")
+            .no_window()
             .args([
                 &db_path,
                 &format!(
@@ -2734,6 +2739,7 @@ pub async fn write_opencode_allowlist(
         );
 
         let output = std::process::Command::new("sqlite3")
+            .no_window()
             .args([&db_path, &sql])
             .output()
             .map_err(|e| format!("Failed to run sqlite3: {}", e))?;

--- a/src-tauri/src/commands/skillssh.rs
+++ b/src-tauri/src/commands/skillssh.rs
@@ -33,6 +33,8 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use crate::process_util::CommandNoWindow;
+
 const SKILLSSH_URL: &str = "https://skills.sh";
 const REQUEST_TIMEOUT_SECS: u64 = 30;
 
@@ -1107,6 +1109,7 @@ pub async fn install_skill_from_git_url(
 
     // Clone repo with shallow depth
     let status = Command::new("git")
+        .no_window()
         .args(&[
             "clone",
             "--depth",
@@ -1613,6 +1616,7 @@ fn run_npx_skills(args: &[&str], cwd: Option<&str>) -> Result<String, String> {
     use std::process::Command;
 
     let mut cmd = Command::new("npx");
+    cmd.no_window();
     cmd.args(args);
     cmd.env("DISABLE_TELEMETRY", "1");
 

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -7,6 +7,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::commands::mcp::{self, MCPServerConfig};
 use crate::commands::opencode::OpenCodeState;
+use crate::process_util::CommandNoWindow;
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -156,6 +157,7 @@ pub struct WorkspaceGitCheckResult {
 /// Run a git command in a given directory
 fn run_git(args: &[&str], cwd: &str) -> Result<(bool, String, String), String> {
     let output = Command::new("git")
+        .no_window()
         .args(args)
         .current_dir(cwd)
         .env("GIT_TERMINAL_PROMPT", "0") // Never prompt for credentials interactively
@@ -808,7 +810,7 @@ pub fn update_team_llm_config(
 /// 1.1 - Check if git is installed on the system
 #[tauri::command]
 pub fn team_check_git_installed() -> Result<GitCheckResult, String> {
-    match Command::new("git").args(["--version"]).output() {
+    match Command::new("git").no_window().args(["--version"]).output() {
         Ok(output) => {
             let success = output.status.success();
             let version = if success {
@@ -1675,6 +1677,7 @@ pub async fn team_generate_gitignore(
 /// errors so the sync flow is never blocked by precheck telemetry.
 fn detect_precheck_breach(team_dir: &str) -> Option<(Vec<SyncPrecheckFile>, u64)> {
     let output = Command::new("git")
+        .no_window()
         .args(["status", "--porcelain", "-z", "-uall"])
         .current_dir(team_dir)
         .env("GIT_TERMINAL_PROMPT", "0")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,6 +38,7 @@ use tauri_plugin_aptabase::EventTracker;
 use tauri_plugin_global_shortcut::ShortcutState;
 
 mod commands;
+pub mod process_util;
 pub mod sentry_utils;
 mod telemetry;
 
@@ -124,7 +125,9 @@ fn fix_path_env() {
     }
 
     // Spawn a login shell to get the full PATH
+    use crate::process_util::CommandNoWindow;
     let output = std::process::Command::new(&shell)
+        .no_window()
         .args(["-l", "-c", "echo $PATH"])
         .output();
 

--- a/src-tauri/src/process_util.rs
+++ b/src-tauri/src/process_util.rs
@@ -1,0 +1,43 @@
+//! Cross-platform child-process spawning helpers.
+//!
+//! On Windows, spawning a console subprocess from a GUI app pops a flashing
+//! cmd window unless the parent sets the `CREATE_NO_WINDOW` creation flag
+//! (0x08000000). Every git/sqlite3/netstat/taskkill/npx call in this crate
+//! goes through `std::process::Command` or `tokio::process::Command`, so we
+//! provide a tiny trait extension that hides the window on Windows and is a
+//! no-op on Unix.
+//!
+//! Usage:
+//! ```ignore
+//! use crate::process_util::CommandNoWindow;
+//! Command::new("git").no_window().args(["status"]).output()?;
+//! ```
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+pub trait CommandNoWindow {
+    /// Hide the spawned console window on Windows. No-op elsewhere.
+    fn no_window(&mut self) -> &mut Self;
+}
+
+impl CommandNoWindow for std::process::Command {
+    fn no_window(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            self.creation_flags(CREATE_NO_WINDOW);
+        }
+        self
+    }
+}
+
+impl CommandNoWindow for tokio::process::Command {
+    fn no_window(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            self.creation_flags(CREATE_NO_WINDOW);
+        }
+        self
+    }
+}


### PR DESCRIPTION
## Symptom

Reported on Windows: every team auto-sync cycle pops several flashing `cmd` terminal windows. Same flash also visible on git operations (file history viewer, git gutter), MCP server start, sqlite3 admin queries, etc.

## Root cause

On Windows, spawning a console subprocess from a GUI app pops a console window **unless** the parent sets `CREATE_NO_WINDOW` (0x08000000) on the process creation flags. A grep across `src-tauri/` showed **zero** callers setting this flag — every `Command::new(...)` was a popup waiting to happen. Auto-sync just makes it most obvious because it runs `git status`, `git fetch`, `git add`, `git commit`, `git reset --hard`, and `git remote set-url` in quick succession.

## Fix

Add a tiny `CommandNoWindow` trait in a new `process_util.rs` (~25 lines) that hides the window on Windows and is a no-op on Unix. Implemented for both `std::process::Command` and `tokio::process::Command`. Apply `.no_window()` at every spawn site:

- `commands/team.rs` — the hot path: `run_git()` (auto-sync), `--version` probe, precheck status
- `commands/git.rs` — file history viewer / git gutter helpers
- `commands/cron/scheduler.rs` — worktree add/remove/prune
- `commands/opencode.rs` — `netstat`/`taskkill` (Windows) and `sqlite3` admin queries
- `commands/skillssh.rs` — `git clone` for skill discovery, `npx skills` runner
- `commands/deps.rs` — version probes, `brew --version`, install shell launcher
- `commands/mcp.rs` — MCP server `TokioCommand` spawns
- `commands/mod.rs` — `cmd /C start` launchers (`open_with_default_app`, `open_in_terminal`); the inner cmd `start` spawns still get their own console as intended for `open_in_terminal`
- `lib.rs` — login-shell PATH probe at startup

## Test plan

- [ ] **Windows:** join a team, wait for auto-sync — no terminal flashes
- [ ] **Windows:** trigger git history viewer / git gutter on a file — no flash
- [ ] **Windows:** start an MCP server — no flash for the MCP process
- [ ] **Windows:** `Open in terminal` from the file menu — terminal still opens (this one MUST show)
- [ ] **macOS / Linux:** all the above behave identically (trait is a no-op there)
- [ ] `pnpm rust:check` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)