### PR TITLE
fix(editor): avoid WYSIWYG for large markdown files

### DIFF
--- a/packages/app/src/components/FileEditor.tsx
+++ b/packages/app/src/components/FileEditor.tsx
@@ -384,7 +384,7 @@ export function FileEditor({
   const previousContentRef = useRef(content);
 
   // --- Markdown auto-save & conflict state ---
-  const isMarkdown = getEditorType(filename) === "markdown";
+  const isMarkdown = supportsPreview(filename) === "markdown";
   const tiptapEditorRef = useRef<import("@/components/editors/TiptapMarkdownEditor").TiptapEditorHandle>(null);
 
   // Conflict state for markdown files
@@ -945,7 +945,7 @@ export function FileEditor({
         ) : (
           (() => {
             // Route to appropriate editor based on file type
-            const editorType = getEditorType(filename, filePath);
+            const editorType = getEditorType(filename, filePath, content);
 
             if (editorType === "markdown") {
               return (

--- a/packages/app/src/components/__tests__/FileEditor-large-markdown.test.tsx
+++ b/packages/app/src/components/__tests__/FileEditor-large-markdown.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  isTauri: () => false,
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({
+      targetLine: null,
+      targetHeading: null,
+      workspacePath: '/workspace',
+    }),
+}))
+
+vi.mock('@/stores/session', () => ({
+  useSessionStore: Object.assign(
+    (sel: (s: Record<string, unknown>) => unknown) => sel({ sessionDiff: [] }),
+    { getState: () => ({ sendMessage: vi.fn() }) },
+  ),
+}))
+
+vi.mock('@/stores/ui', () => ({
+  useUIStore: Object.assign(
+    (sel: (s: Record<string, unknown>) => unknown) => sel({}),
+    { getState: () => ({ setFileModeRightTab: vi.fn() }) },
+  ),
+}))
+
+vi.mock('@/stores/team-mode', () => ({
+  useTeamModeStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({ myRole: 'owner' }),
+}))
+
+vi.mock('@/lib/git/manager', () => ({
+  gitManager: {
+    showFile: vi.fn().mockRejectedValue(new Error('not tracked')),
+    logFile: vi.fn().mockResolvedValue([]),
+  },
+}))
+
+vi.mock('@/components/editors/useAutoSave', () => ({
+  useAutoSave: () => ({
+    saveStatus: 'saved',
+    isSelfWrite: vi.fn().mockResolvedValue(false),
+    saveNow: vi.fn(),
+    cancelPendingSave: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/editors/ConflictBanner', () => ({
+  ConflictBanner: () => null,
+}))
+
+vi.mock('@/components/editors/TiptapMarkdownEditor', () => ({
+  default: React.forwardRef(() => <div data-testid="tiptap-markdown-editor" />),
+}))
+
+vi.mock('@/components/editors/CodeEditor', () => ({
+  default: () => <div data-testid="code-editor" />,
+}))
+
+vi.mock('@/components/diff/DiffRenderer', () => ({
+  default: () => <div data-testid="diff-renderer" />,
+}))
+
+vi.mock('@/components/version/FileHistoryView', () => ({
+  default: () => <div data-testid="file-history-view" />,
+}))
+
+import { MAX_MARKDOWN_WYSIWYG_CHARS } from '@/components/editors/utils'
+import { FileEditor } from '@/components/FileEditor'
+
+describe('FileEditor large markdown routing', () => {
+  it('uses CodeMirror for large markdown documents', async () => {
+    const content = '# Issue Review\n\n' + 'A'.repeat(MAX_MARKDOWN_WYSIWYG_CHARS + 1)
+
+    render(
+      <FileEditor
+        content={content}
+        filename="SPAYS-17321.md"
+        filePath="/workspace/knowledge/SPAYS-17321.md"
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(await screen.findByTestId('code-editor')).toBeTruthy()
+    expect(screen.queryByTestId('tiptap-markdown-editor')).toBeNull()
+  })
+
+  it('keeps small markdown documents in the Tiptap editor', async () => {
+    render(
+      <FileEditor
+        content="# Notes\n\nSmall file"
+        filename="README.md"
+        filePath="/workspace/README.md"
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(await screen.findByTestId('tiptap-markdown-editor')).toBeTruthy()
+    expect(screen.queryByTestId('code-editor')).toBeNull()
+  })
+})

--- a/packages/app/src/components/editors/__tests__/utils.test.ts
+++ b/packages/app/src/components/editors/__tests__/utils.test.ts
@@ -73,6 +73,18 @@ describe('getEditorType', () => {
   it('returns "markdown" when no filePath is provided for .md', () => {
     expect(getEditorType('SKILL.md')).toBe('markdown');
   });
+
+  it('routes large markdown files to the code editor to avoid WYSIWYG parse freezes', () => {
+    const largeMarkdown = '# Issue Review\n\n' + 'A'.repeat(512 * 1024 + 1);
+
+    expect(getEditorType('SPAYS-17321.md', '/workspace/knowledge/SPAYS-17321.md', largeMarkdown)).toBe('code');
+  });
+
+  it('keeps smaller markdown files in the WYSIWYG editor', () => {
+    const markdown = '# Notes\n\nSmall enough for rich editing.';
+
+    expect(getEditorType('README.md', '/workspace/README.md', markdown)).toBe('markdown');
+  });
 });
 
 describe('isSkillFile', () => {

--- a/packages/app/src/components/editors/utils.ts
+++ b/packages/app/src/components/editors/utils.ts
@@ -5,16 +5,27 @@
 
 export type EditorType = 'markdown' | 'code';
 
+export const MAX_MARKDOWN_WYSIWYG_CHARS = 512 * 1024;
+
+function isMarkdownExtension(filename: string): boolean {
+  const ext = filename.split('.').pop()?.toLowerCase();
+  return ext === 'md' || ext === 'markdown';
+}
+
 /**
  * Determine which editor type to use for a given filename.
  * HTML files are routed to the code editor (with optional preview via supportsPreview).
  * Skill files (SKILL.md inside skills directories) use code editor for raw editing.
+ * Very large Markdown files use CodeMirror because parsing the whole document
+ * into a Tiptap/ProseMirror tree can freeze the renderer thread.
  */
-export function getEditorType(filename: string, filePath?: string): EditorType {
+export function getEditorType(filename: string, filePath?: string, content?: string): EditorType {
   // Skill markdown files should use CodeMirror for raw frontmatter editing
   if (filePath && isSkillFile(filePath)) return 'code';
-  const ext = filename.split('.').pop()?.toLowerCase();
-  if (ext === 'md' || ext === 'markdown') return 'markdown';
+  if (isMarkdownExtension(filename)) {
+    if (content && content.length > MAX_MARKDOWN_WYSIWYG_CHARS) return 'code';
+    return 'markdown';
+  }
   return 'code';
 }
 


### PR DESCRIPTION
## Summary
- Route Markdown files larger than 512 KiB to CodeMirror instead of Tiptap WYSIWYG to avoid renderer freezes while opening large documents.
- Keep smaller Markdown files in the existing WYSIWYG editor and preserve Markdown auto-save behavior for both paths.
- Add routing tests for large and small Markdown documents.

## Test Plan
- [x] pnpm --filter @teamclaw/app exec vitest run src/components/__tests__/FileEditor.test.tsx src/components/__tests__/FileEditor-large-markdown.test.tsx src/components/editors/__tests__/utils.test.ts
- [x] pnpm --filter @teamclaw/app typecheck
- [x] pnpm --filter @teamclaw/app exec eslint src/components/FileEditor.tsx src/components/editors/utils.ts src/components/editors/__tests__/utils.test.ts src/components/__tests__/FileEditor-large-markdown.test.tsx