### PR TITLE
Fix code-based OAuth completion in LLM settings

### DIFF
--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -102,6 +102,8 @@ export const LLMSection = React.memo(function LLMSection() {
   const [oauthPending, setOAuthPending] = React.useState(false)
   const [oauthInstructions, setOAuthInstructions] = React.useState('')
   const [oauthUrl, setOAuthUrl] = React.useState('')
+  const [oauthMethodType, setOAuthMethodType] = React.useState<'auto' | 'code' | null>(null)
+  const [oauthCodeInput, setOAuthCodeInput] = React.useState('')
   const [oauthCodeCopied, setOAuthCodeCopied] = React.useState(false)
 
   // Disconnect confirmation state
@@ -176,6 +178,8 @@ export const LLMSection = React.memo(function LLMSection() {
     setOAuthPending(false)
     setOAuthInstructions('')
     setOAuthUrl('')
+    setOAuthMethodType(null)
+    setOAuthCodeInput('')
     setConnectDialogOpen(true)
   }
 
@@ -205,16 +209,42 @@ export const LLMSection = React.memo(function LLMSection() {
     await open(result.url)
     setOAuthUrl(result.url)
     setOAuthInstructions(result.instructions)
+    setOAuthMethodType(result.methodType)
+    setOAuthCodeInput('')
     setOAuthPending(true)
     setIsConnecting(false)
-    // For Device Flow ("auto"), sidecar polls internally — kick off callback in background
-    completeOAuthCallback(connectingProviderId, methodIndex).then((success) => {
+    if (result.methodType === 'auto') {
+      // For Device Flow ("auto"), sidecar polls internally — kick off callback in background
+      completeOAuthCallback(connectingProviderId, methodIndex).then((success) => {
+        if (success) {
+          setConnectDialogOpen(false)
+          setOAuthPending(false)
+          setOAuthMethodType(null)
+          setOAuthCodeInput('')
+          restartOpenCodeAndRefresh()
+        }
+      })
+    }
+  }
+
+  const handleOAuthCodeSubmit = async () => {
+    const code = oauthCodeInput.trim()
+    if (!code) return
+    const methodIndex = getProviderOAuthMethodIndex(connectingProviderId)
+    if (methodIndex === -1) return
+    setIsConnecting(true)
+    try {
+      const success = await completeOAuthCallback(connectingProviderId, methodIndex, code)
       if (success) {
         setConnectDialogOpen(false)
         setOAuthPending(false)
-        restartOpenCodeAndRefresh()
+        setOAuthMethodType(null)
+        setOAuthCodeInput('')
+        await restartOpenCodeAndRefresh()
       }
-    })
+    } finally {
+      setIsConnecting(false)
+    }
   }
 
   const handleCopyOAuthCode = async () => {
@@ -660,7 +690,13 @@ export const LLMSection = React.memo(function LLMSection() {
 
       {/* Connect Provider Dialog */}
       <Dialog open={connectDialogOpen} onOpenChange={(open) => {
-        if (!open) { setOAuthPending(false); setOAuthInstructions(''); setOAuthUrl('') }
+        if (!open) {
+          setOAuthPending(false)
+          setOAuthInstructions('')
+          setOAuthUrl('')
+          setOAuthMethodType(null)
+          setOAuthCodeInput('')
+        }
         setConnectDialogOpen(open)
       }}>
         <DialogContent className="sm:max-w-md">
@@ -687,10 +723,27 @@ export const LLMSection = React.memo(function LLMSection() {
                   </Button>
                 )}
               </div>
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Loader2 className="h-3.5 w-3.5 animate-spin shrink-0" />
-                {t('settings.llm.oauthPolling', 'Waiting for authorization...')}
-              </div>
+              {oauthMethodType === 'code' ? (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">{t('settings.llm.authorizationCode', 'Authorization code')}</label>
+                  <Input
+                    value={oauthCodeInput}
+                    onChange={(e) => setOAuthCodeInput(e.target.value)}
+                    placeholder={t('settings.llm.authorizationCodePlaceholder', 'Paste authorization code')}
+                    className="h-10"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && oauthCodeInput.trim()) {
+                        handleOAuthCodeSubmit()
+                      }
+                    }}
+                  />
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin shrink-0" />
+                  {t('settings.llm.oauthPolling', 'Waiting for authorization...')}
+                </div>
+              )}
               <Button variant="outline" size="sm" className="gap-2 w-full" onClick={async () => {
                 const { open } = await import('@tauri-apps/plugin-shell')
                 open(oauthUrl)
@@ -759,11 +812,35 @@ export const LLMSection = React.memo(function LLMSection() {
           <DialogFooter>
             <Button
               variant="outline"
-              onClick={() => { setOAuthPending(false); setConnectDialogOpen(false) }}
+              onClick={() => {
+                setOAuthPending(false)
+                setOAuthMethodType(null)
+                setOAuthCodeInput('')
+                setConnectDialogOpen(false)
+              }}
               disabled={isConnecting}
             >
               {t('common.cancel', 'Cancel')}
             </Button>
+            {oauthPending && oauthMethodType === 'code' && (
+              <Button
+                onClick={handleOAuthCodeSubmit}
+                disabled={isConnecting || !oauthCodeInput.trim()}
+                className="gap-2"
+              >
+                {isConnecting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {t('settings.llm.connecting', 'Connecting...')}
+                  </>
+                ) : (
+                  <>
+                    <Link className="h-4 w-4" />
+                    {t('settings.llm.completeAuthorization', 'Complete authorization')}
+                  </>
+                )}
+              </Button>
+            )}
             {!oauthPending && (
               <Button
                 onClick={handleConnectSubmit}

--- a/packages/app/src/components/settings/__tests__/LLMSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/LLMSection.test.tsx
@@ -1,44 +1,63 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+const mocks = vi.hoisted(() => {
+  const providerState = {
+    providers: [] as Array<{ id: string; name: string; configured: boolean }>,
+    providersLoading: false,
+    configuredProviders: [] as Array<{ id: string; name: string; models: Array<{ id: string; name: string }> }>,
+    customProviderIds: [] as string[],
+    authMethods: {} as Record<string, Array<{ type: 'oauth' | 'api'; label: string }>>,
+    refreshAuthMethods: vi.fn(),
+    refreshProviders: vi.fn(),
+    refreshConfiguredProviders: vi.fn(),
+    refreshCustomProviderIds: vi.fn(),
+    connectProvider: vi.fn(),
+    connectProviderOAuth: vi.fn(),
+    completeOAuthCallback: vi.fn(),
+    addCustomProvider: vi.fn(),
+    updateCustomProvider: vi.fn(),
+    getCustomProvider: vi.fn(),
+    removeCustomProvider: vi.fn(),
+    disconnectProvider: vi.fn(),
+    initAll: vi.fn(),
+  }
+  const workspaceState = { workspacePath: '/test', openCodeReady: true, setOpenCodeBootstrapped: vi.fn() }
+  return {
+    providerState,
+    workspaceState,
+    shellOpen: vi.fn(),
+    restartOpencode: vi.fn(),
+  }
+})
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (k: string, d?: string) => d ?? k, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+  useTranslation: () => ({
+    t: (k: string, d?: string | { defaultValue?: string }) =>
+      typeof d === 'string' ? d : d?.defaultValue ?? k,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
 }))
 vi.mock('@/stores/provider', () => ({
   useProviderStore: vi.fn((sel: (s: any) => any) => {
-    const state = {
-      providers: [],
-      providersLoading: false,
-      configuredProviders: [],
-      customProviderIds: [],
-      authMethods: {},
-      refreshAuthMethods: vi.fn(),
-      refreshProviders: vi.fn(),
-      refreshConfiguredProviders: vi.fn(),
-      refreshCustomProviderIds: vi.fn(),
-      connectProvider: vi.fn(),
-      addCustomProvider: vi.fn(),
-      removeCustomProvider: vi.fn(),
-      disconnectProvider: vi.fn(),
-      initAll: vi.fn(),
-    }
-    return sel(state)
+    return sel(mocks.providerState)
   }),
 }))
 vi.mock('@/stores/workspace', () => ({
   useWorkspaceStore: vi.fn((sel: (s: any) => any) => {
-    const state = { workspacePath: '/test' }
-    return sel(state)
+    return sel(mocks.workspaceState)
   }),
 }))
 vi.mock('@/stores/team-mode', () => ({
   useTeamModeStore: vi.fn((sel: (s: any) => any) => {
-    const state = { teamMode: false, teamModelConfig: null }
+    const state = { teamMode: false, teamModelConfig: null, devUnlocked: false, teamModelOptions: [], switchTeamModel: vi.fn() }
     return sel(state)
   }),
 }))
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/plugin-shell', () => ({ open: mocks.shellOpen }))
 vi.mock('@/lib/opencode/sdk-client', () => ({ initOpenCodeClient: vi.fn() }))
+vi.mock('@/lib/opencode/restart', () => ({ restartOpencode: mocks.restartOpencode }))
 vi.mock('@/lib/utils', () => ({ cn: (...a: string[]) => a.join(' ') }))
 vi.mock('../shared', () => ({
   SettingCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -48,6 +67,17 @@ vi.mock('../shared', () => ({
 import { LLMSection } from '../LLMSection'
 
 describe('LLMSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.providerState.providers = []
+    mocks.providerState.providersLoading = false
+    mocks.providerState.configuredProviders = []
+    mocks.providerState.customProviderIds = []
+    mocks.providerState.authMethods = {}
+    mocks.workspaceState.workspacePath = '/test'
+    mocks.workspaceState.openCodeReady = true
+  })
+
   it('renders the LLM Model title', () => {
     render(<LLMSection />)
     expect(screen.getByText('LLM Model')).toBeTruthy()
@@ -56,5 +86,37 @@ describe('LLMSection', () => {
   it('shows no providers message when empty', () => {
     render(<LLMSection />)
     expect(screen.getByText('No providers available')).toBeTruthy()
+  })
+
+  it('waits for an authorization code before completing code-based OAuth providers', async () => {
+    mocks.providerState.providers = [{ id: 'openai', name: 'OpenAI', configured: false }]
+    mocks.providerState.authMethods = {
+      openai: [{ type: 'oauth', label: 'Browser login' }],
+    }
+    mocks.providerState.connectProviderOAuth.mockResolvedValueOnce({
+      status: 'pending',
+      url: 'https://auth.example.test/openai',
+      instructions: 'Paste the authorization code from the browser.',
+      methodType: 'code',
+    })
+    mocks.providerState.completeOAuthCallback.mockResolvedValueOnce(true)
+
+    render(<LLMSection />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Login with browser' }))
+
+    await waitFor(() => {
+      expect(mocks.shellOpen).toHaveBeenCalledWith('https://auth.example.test/openai')
+    })
+    expect(mocks.providerState.completeOAuthCallback).not.toHaveBeenCalled()
+
+    const codeInput = await screen.findByPlaceholderText('Paste authorization code')
+    fireEvent.change(codeInput, { target: { value: 'oa-code-123' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Complete authorization' }))
+
+    await waitFor(() => {
+      expect(mocks.providerState.completeOAuthCallback).toHaveBeenCalledWith('openai', 0, 'oa-code-123')
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Track OAuth method type in the LLM provider connection dialog.
- Require users to paste and submit authorization codes for code-based OAuth providers before completing the callback.
- Add a regression test covering OpenAI-style code-based OAuth completion.

## Test Plan
- [x] pnpm --filter @teamclaw/app exec vitest run src/components/settings/__tests__/LLMSection.test.tsx
- [x] pnpm --filter @teamclaw/app typecheck