### PR TITLE
fix(team): stop silently deleting _meta/provider.json on member join

### DIFF
--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -31,7 +31,12 @@ import { HostLlmConfig } from './HostLlmConfig'
 import { useTeamMembersStore } from '@/stores/team-members'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { buildConfig, TEAM_SYNCED_EVENT, TEAM_REPO_DIR } from '@/lib/build-config'
-import { buildTeamProviderConfig, loadTeamProviderFormState, saveTeamProviderFile } from '@/lib/team-provider'
+import {
+  buildTeamProviderConfig,
+  loadTeamProviderFormState,
+  removeTeamProviderFile,
+  saveTeamProviderFile,
+} from '@/lib/team-provider'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -197,16 +202,11 @@ export function TeamGitConfig() {
   // Detect if current URL is HTTPS (needs token auth)
   const isHttpsUrl = gitUrl.trim().startsWith('https://') || gitUrl.trim().startsWith('http://')
 
-  // Provider config queued during fast-path join — written only after the
-  // background clone completes, otherwise saveTeamProviderFile would
-  // mkdir teamclaw-team/_meta and break the subsequent git clone.
-  type PendingProviderSave = {
-    workspacePath: string
-    hostLlm: boolean
-    llmUrl: string
-    llmModels: { id: string; name: string }[]
-  }
-  const pendingProviderSaveRef = React.useRef<PendingProviderSave | null>(null)
+  // Workspace path queued during fast-path join — used after the background
+  // clone completes to refresh in-memory team config from the freshly cloned
+  // _meta files. We no longer write provider.json here on the joining
+  // member's behalf (that used to silently delete the team's shared file).
+  const pendingProviderSaveRef = React.useRef<{ workspacePath: string } | null>(null)
 
   // ─── Initialize: check git + load config ─────────────────────────────────
 
@@ -279,26 +279,24 @@ export function TeamGitConfig() {
       unlistenCompleted = await listen<{ teamId: string; message: string }>(
         'team:git-join-clone-completed',
         async () => {
-          // Now that teamclaw-team/_meta/ exists, flush any queued provider save.
-          const pending = pendingProviderSaveRef.current
-          if (pending) {
-            pendingProviderSaveRef.current = null
+          // After clone completes, the cloned repo already contains the
+          // owner's _meta/provider.json (if any). A joining member must NOT
+          // overwrite it with their own (typically empty) form state — doing
+          // so would write a null provider, which used to silently delete the
+          // shared file for the entire team. Just refresh the in-memory team
+          // config from the freshly cloned files.
+          const ws = pendingProviderSaveRef.current?.workspacePath
+          pendingProviderSaveRef.current = null
+          if (ws) {
             try {
-              await saveTeamProviderFile(
-                pending.workspacePath,
-                buildTeamProviderConfig(pending.hostLlm, pending.llmUrl, pending.llmModels),
-                pending.hostLlm ? pending.llmModels[0]?.id : undefined,
-              )
-              // Push the new team provider into the running sidecar without
-              // waiting for the 1s file-watcher debounce.
               const { useTeamModeStore } = await import('@/stores/team-mode')
               const store = useTeamModeStore.getState()
-              await store.loadTeamConfig(pending.workspacePath)
+              await store.loadTeamConfig(ws)
               if (useTeamModeStore.getState().teamMode) {
-                await store.applyTeamModelToOpenCode(pending.workspacePath, true)
+                await store.applyTeamModelToOpenCode(ws, true)
               }
             } catch (err) {
-              console.warn('[Team Join] Deferred provider save failed:', err)
+              console.warn('[Team Join] Post-clone team config refresh failed:', err)
             }
           }
           teamMembersStore.loadMembers()
@@ -369,7 +367,17 @@ export function TeamGitConfig() {
         ...workspaceArgs,
       })
       if (workspacePath) {
-        await saveTeamProviderFile(workspacePath, buildTeamProviderConfig(hostLlm, llmUrl, llmModels), hostLlm ? llmModels[0]?.id : undefined)
+        const providerConfig = buildTeamProviderConfig(hostLlm, llmUrl, llmModels)
+        if (providerConfig) {
+          await saveTeamProviderFile(workspacePath, providerConfig, llmModels[0]?.id)
+        } else if (!hostLlm) {
+          // Owner / manager explicitly turned off the team's shared LLM.
+          // This is the ONLY path that should remove the shared provider
+          // file — saveTeamProviderFile no longer auto-deletes on null.
+          await removeTeamProviderFile(workspacePath)
+        }
+        // Otherwise: hostLlm=true but URL/models incomplete → leave the
+        // existing provider.json intact instead of silently deleting it.
       }
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : String(err))
@@ -598,16 +606,9 @@ export function TeamGitConfig() {
           ...(gitBranchTrim ? { gitBranch: gitBranchTrim } : {}),
         }
         await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
-        // Defer saveTeamProviderFile until the background clone finishes — it
-        // would otherwise mkdir teamclaw-team/_meta and break git clone's
-        // empty-target requirement.
+        // Stash workspacePath so the post-clone hook can refresh team config.
         if (workspacePath) {
-          pendingProviderSaveRef.current = {
-            workspacePath,
-            hostLlm,
-            llmUrl,
-            llmModels,
-          }
+          pendingProviderSaveRef.current = { workspacePath }
         }
         setTeamConfig(newConfig)
 
@@ -661,9 +662,10 @@ export function TeamGitConfig() {
       }
       await tauriInvoke('save_team_config', { team: newConfig, ...workspaceArgs })
       if (workspacePath) {
-        await saveTeamProviderFile(workspacePath, buildTeamProviderConfig(hostLlm, llmUrl, llmModels), hostLlm ? llmModels[0]?.id : undefined)
-        // Push the new team provider into the running sidecar without
-        // waiting for the 1s file-watcher debounce.
+        // Member-side join: do NOT write provider.json — the cloned repo
+        // already contains the owner's shared provider config (if any).
+        // Writing the joining member's form state used to silently delete
+        // the team's provider.json when the form was empty.
         const { useTeamModeStore } = await import('@/stores/team-mode')
         const store = useTeamModeStore.getState()
         await store.loadTeamConfig(workspacePath)

--- a/packages/app/src/components/settings/team/TeamOSSConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamOSSConfig.tsx
@@ -12,7 +12,12 @@ import { TeamMemberList } from '@/components/settings/TeamMemberList'
 import { VersionHistorySection } from './VersionHistorySection'
 import { invoke } from '@tauri-apps/api/core'
 import { buildConfig } from '@/lib/build-config'
-import { buildTeamProviderConfig, loadTeamProviderFormState, saveTeamProviderFile } from '@/lib/team-provider'
+import {
+  buildTeamProviderConfig,
+  loadTeamProviderFormState,
+  removeTeamProviderFile,
+  saveTeamProviderFile,
+} from '@/lib/team-provider'
 import type { DeviceInfo } from '@/lib/git/types'
 import { useTeamModeStore } from '@/stores/team-mode'
 import { useProviderStore } from '@/stores/provider'
@@ -314,11 +319,13 @@ export function TeamOSSConfig() {
         llmModelName: cfgHostLlm ? (cfgLlmModels[0]?.name || undefined) : undefined,
         llmModels: cfgHostLlm && cfgLlmModels.length > 0 ? JSON.stringify(cfgLlmModels) : undefined,
       })
-      await saveTeamProviderFile(
-        workspacePath,
-        buildTeamProviderConfig(cfgHostLlm, cfgLlmUrl, cfgLlmModels),
-        cfgHostLlm ? cfgLlmModels[0]?.id : undefined,
-      )
+      const cfgProviderConfig = buildTeamProviderConfig(cfgHostLlm, cfgLlmUrl, cfgLlmModels)
+      if (cfgProviderConfig) {
+        await saveTeamProviderFile(workspacePath, cfgProviderConfig, cfgLlmModels[0]?.id)
+      } else if (!cfgHostLlm) {
+        // Owner / manager explicitly turned off the team's shared LLM.
+        await removeTeamProviderFile(workspacePath)
+      }
     } catch {
       // error is set in the store
     } finally {

--- a/packages/app/src/components/settings/team/TeamP2PConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamP2PConfig.tsx
@@ -24,7 +24,12 @@ import { HostLlmConfig } from './HostLlmConfig'
 import { cn, isTauri, copyToClipboard } from '@/lib/utils'
 import { toast } from 'sonner'
 import { buildConfig, TEAMCLAW_DIR, TEAM_REPO_DIR } from '@/lib/build-config'
-import { buildTeamProviderConfig, loadTeamProviderFormState, saveTeamProviderFile } from '@/lib/team-provider'
+import {
+  buildTeamProviderConfig,
+  loadTeamProviderFormState,
+  removeTeamProviderFile,
+  saveTeamProviderFile,
+} from '@/lib/team-provider'
 import { useTeamModeStore } from '@/stores/team-mode'
 import { useP2pEngineStore } from '@/stores/p2p-engine'
 import { useTeamMembersStore } from '@/stores/team-members'
@@ -431,11 +436,13 @@ export function TeamP2PConfig() {
         workspacePath,
       })
       if (workspacePath) {
-        await saveTeamProviderFile(
-          workspacePath,
-          buildTeamProviderConfig(cfgHostLlm, cfgLlmUrl, cfgLlmModels),
-          cfgHostLlm ? cfgLlmModels[0]?.id : undefined,
-        )
+        const providerConfig = buildTeamProviderConfig(cfgHostLlm, cfgLlmUrl, cfgLlmModels)
+        if (providerConfig) {
+          await saveTeamProviderFile(workspacePath, providerConfig, cfgLlmModels[0]?.id)
+        } else if (!cfgHostLlm) {
+          // Owner / manager explicitly turned off the team's shared LLM.
+          await removeTeamProviderFile(workspacePath)
+        }
       }
     } catch (err) {
       setP2pError(err instanceof Error ? err.message : String(err))

--- a/packages/app/src/lib/__tests__/team-provider.test.ts
+++ b/packages/app/src/lib/__tests__/team-provider.test.ts
@@ -112,4 +112,37 @@ describe('team provider file helpers', () => {
     expect(mockAddCustomProviderToConfig).not.toHaveBeenCalled()
     expect(mockRemoveCustomProviderFromConfig).not.toHaveBeenCalled()
   })
+
+  it('saveTeamProviderFile is a no-op on null provider (no implicit deletion)', async () => {
+    // Regression: previously, passing null deleted _meta/provider.json.
+    // That caused team-wide loss whenever a member joined with an empty form
+    // and the deletion got auto-committed by the next sync.
+    mockExists.mockResolvedValue(true) // provider.json exists on disk
+    const { saveTeamProviderFile } = await import('@/lib/team-provider')
+
+    await saveTeamProviderFile('/workspace', null)
+
+    expect(mockRemove).not.toHaveBeenCalled()
+    expect(mockWriteTextFile).not.toHaveBeenCalled()
+  })
+
+  it('removeTeamProviderFile deletes provider.json when present', async () => {
+    mockExists.mockImplementation(
+      async (path: string) => path === '/workspace/teamclaw-team/_meta/provider.json',
+    )
+    const { removeTeamProviderFile } = await import('@/lib/team-provider')
+
+    await removeTeamProviderFile('/workspace')
+
+    expect(mockRemove).toHaveBeenCalledWith('/workspace/teamclaw-team/_meta/provider.json')
+  })
+
+  it('removeTeamProviderFile is a no-op when provider.json is absent', async () => {
+    mockExists.mockResolvedValue(false)
+    const { removeTeamProviderFile } = await import('@/lib/team-provider')
+
+    await removeTeamProviderFile('/workspace')
+
+    expect(mockRemove).not.toHaveBeenCalled()
+  })
 })

--- a/packages/app/src/lib/team-provider.ts
+++ b/packages/app/src/lib/team-provider.ts
@@ -69,14 +69,15 @@ export async function saveTeamProviderFile(
   provider: CustomProviderConfig | null,
   defaultModel?: string,
 ): Promise<void> {
-  const path = teamProviderFilePath(workspacePath)
-  if (!provider) {
-    if (await exists(path)) {
-      await remove(path)
-    }
-    return
-  }
+  // No-op when provider is null. Earlier this function would silently delete
+  // _meta/provider.json on null, which caused the team's shared provider config
+  // to vanish whenever a member joined with an empty form (their default
+  // hostLlm=false → buildTeamProviderConfig → null → delete). Auto-sync then
+  // committed and pushed the deletion to the whole team. Use the explicit
+  // `removeTeamProviderFile` below when you actually mean to remove it.
+  if (!provider) return
 
+  const path = teamProviderFilePath(workspacePath)
   const metaDir = teamProviderMetaDir(workspacePath)
   if (!(await exists(metaDir))) {
     await mkdir(metaDir, { recursive: true })
@@ -98,6 +99,19 @@ export async function saveTeamProviderFile(
   }
 
   await writeTextFile(path, JSON.stringify(file, null, 2))
+}
+
+/**
+ * Explicitly remove the shared team provider file. Should only be called when
+ * an authorised user (owner / manager) deliberately turns off the team's
+ * shared LLM hosting from Service Config — never as a side-effect of joining
+ * or other implicit flows.
+ */
+export async function removeTeamProviderFile(workspacePath: string): Promise<void> {
+  const path = teamProviderFilePath(workspacePath)
+  if (await exists(path)) {
+    await remove(path)
+  }
 }
 
 export async function loadTeamProviderFormState(workspacePath: string): Promise<TeamProviderFormState | null> {


### PR DESCRIPTION
## Summary

Reported: in git-team mode, `_meta/provider.json` keeps mysteriously vanishing for the whole team — owner commits it, then sometime later it's gone for everyone.

## Root cause

\`packages/app/src/lib/team-provider.ts:saveTeamProviderFile(_, null)\` silently removes \`_meta/provider.json\` from disk. \`buildTeamProviderConfig(enabled, baseUrl, models)\` returns \`null\` whenever the form's hostLlm checkbox is off, the URL is empty, or the model list is empty — i.e. the **default state** for any member who hasn't configured hosted LLM.

Combined repro:

1. Owner creates the team, enables hostLlm, commits \`_meta/provider.json\`.
2. A new member joins. Their TeamGitConfig form starts with \`hostLlm = !!buildConfig.team.llm.baseUrl\` — typically \`false\` for OSS builds — and empty model list.
3. Both join paths called \`saveTeamProviderFile(workspacePath, buildTeamProviderConfig(...))\` with that empty form state:
   - Fast-path invite-code join: deferred save fires on \`team:git-join-clone-completed\` (TeamGitConfig.tsx:287).
   - Legacy manual join: TeamGitConfig.tsx:664.
4. \`null\` provider → silent \`remove(_meta/provider.json)\`.
5. The next auto-sync's \`git add -A && commit && push\` propagated the deletion to the entire team. Owner's file vanished with no obvious cause.

## Fix

- \`saveTeamProviderFile\` now no-ops when \`provider\` is null. It no longer deletes anything.
- Add an explicit \`removeTeamProviderFile(workspacePath)\` for the only legitimate deletion path: an owner / manager turning off the team's shared LLM in Service Config.
- Strip the joining-member \`saveTeamProviderFile\` calls from both the fast-path deferred handler and the legacy \`handleJoin\` flow. Members never write the team's shared file — the cloned repo already contains the owner's \`provider.json\` if any. Post-clone we still refresh in-memory team config from the freshly cloned files.
- Wire \`removeTeamProviderFile\` into the three Service Config save handlers (TeamGitConfig, TeamP2PConfig, TeamOSSConfig) so an explicit \"turn off shared LLM\" still works for owner / manager.
- Tests cover the no-op-on-null behaviour and the new explicit remove helper.

## Test plan

- [ ] Owner creates a git team with hostLlm enabled → \`_meta/provider.json\` is written and committed.
- [ ] New member joins via invite code → \`_meta/provider.json\` survives (was being deleted).
- [ ] New member joins via manual flow → same, survives.
- [ ] Owner toggles hostLlm off in Service Config and clicks Save → \`_meta/provider.json\` is removed (intent preserved).
- [ ] Owner toggles hostLlm on with empty models and clicks Save → existing \`_meta/provider.json\` is left intact rather than silently deleted.
- [ ] \`pnpm test:unit\` covers \`team-provider.test.ts\` and the team config component tests (10 tests pass locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)