### PR TITLE
fix(i18n): audit multilingual coverage

### DIFF
--- a/packages/app/src/components/FileEditor.tsx
+++ b/packages/app/src/components/FileEditor.tsx
@@ -737,7 +737,7 @@ export function FileEditor({
                   ? "text-blue-600 hover:bg-blue-100 dark:hover:bg-blue-900/30"
                   : "text-muted-foreground/50"
               }`}
-              title={isModified ? `Save (⌘S)` : t("app.noChanges", "No changes")}
+              title={isModified ? `${t("common.save", "Save")} (⌘S)` : t("app.noChanges", "No changes")}
             >
               {isSaving ? (
                 <Loader2 className="h-4 w-4 animate-spin" />

--- a/packages/app/src/components/NodeStatusPopover.tsx
+++ b/packages/app/src/components/NodeStatusPopover.tsx
@@ -1,4 +1,6 @@
 import * as React from "react"
+import { useTranslation } from "react-i18next"
+import type { TFunction } from "i18next"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Separator } from "@/components/ui/separator"
 import { useP2pEngineStore, type PeerConnection } from "@/stores/p2p-engine"
@@ -21,40 +23,40 @@ function connectionDot(connection: PeerConnection): string {
   }
 }
 
-function connectionLabel(connection: PeerConnection, lastSeenSecsAgo: number): string {
+function connectionLabel(connection: PeerConnection, lastSeenSecsAgo: number, t: TFunction): string {
   switch (connection) {
     case "active":
-      return "Online"
+      return t("nodeStatus.online", "Online")
     case "stale": {
-      if (lastSeenSecsAgo < 60) return `Stale ${lastSeenSecsAgo}s`
+      if (lastSeenSecsAgo < 60) return t("nodeStatus.staleSeconds", { count: lastSeenSecsAgo })
       const mins = Math.floor(lastSeenSecsAgo / 60)
-      return `Stale ${mins}m`
+      return t("nodeStatus.staleMinutes", { count: mins })
     }
     case "lost": {
-      if (lastSeenSecsAgo < 60) return `Offline ${lastSeenSecsAgo}s`
+      if (lastSeenSecsAgo < 60) return t("nodeStatus.offlineSeconds", { count: lastSeenSecsAgo })
       const mins = Math.floor(lastSeenSecsAgo / 60)
-      if (mins < 60) return `Offline ${mins}m`
+      if (mins < 60) return t("nodeStatus.offlineMinutes", { count: mins })
       const hrs = Math.floor(mins / 60)
-      return `Offline ${hrs}h`
+      return t("nodeStatus.offlineHours", { count: hrs })
     }
     case "unknown":
     default:
-      return "Unknown"
+      return t("nodeStatus.unknown", "Unknown")
   }
 }
 
-function formatLastSync(iso: string | null): string {
-  if (!iso) return "Never"
+function formatLastSync(iso: string | null, t: TFunction): string {
+  if (!iso) return t("common.never", "Never")
   const date = new Date(iso)
   const secsAgo = Math.floor((Date.now() - date.getTime()) / 1000)
-  if (secsAgo < 5) return "Just now"
-  if (secsAgo < 60) return `${secsAgo}s ago`
+  if (secsAgo < 5) return t("common.justNow", "Just now")
+  if (secsAgo < 60) return t("nodeStatus.secondsAgo", { count: secsAgo })
   const mins = Math.floor(secsAgo / 60)
-  if (mins < 60) return `${mins}m ago`
+  if (mins < 60) return t("nodeStatus.minutesAgoShort", { count: mins })
   const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h ago`
+  if (hrs < 24) return t("nodeStatus.hoursAgoShort", { count: hrs })
   const days = Math.floor(hrs / 24)
-  return `${days}d ago`
+  return t("nodeStatus.daysAgoShort", { count: days })
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
@@ -74,8 +76,9 @@ interface MemberRowProps {
 }
 
 function MemberRow({ name, role, isLocal, connection, lastSeenSecsAgo }: MemberRowProps) {
+  const { t } = useTranslation()
   const dotColor = isLocal ? "bg-blue-500" : connectionDot(connection)
-  const label = isLocal ? "This device" : connectionLabel(connection, lastSeenSecsAgo)
+  const label = isLocal ? t("nodeStatus.thisDevice", "This device") : connectionLabel(connection, lastSeenSecsAgo, t)
   const labelColor = isLocal
     ? "text-blue-500"
     : connection === "active"
@@ -105,6 +108,7 @@ function MemberRow({ name, role, isLocal, connection, lastSeenSecsAgo }: MemberR
 // ─── Main component ───────────────────────────────────────────────────────────
 
 export function NodeStatusPopover({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation()
   const snapshot = useP2pEngineStore((s) => s.snapshot)
   const fetchSnapshot = useP2pEngineStore((s) => s.fetch)
   const members = useTeamMembersStore((s) => s.members)
@@ -150,12 +154,12 @@ export function NodeStatusPopover({ children }: { children: React.ReactNode }) {
     : "bg-red-500"
 
   const statusLabel = isHealthy
-    ? "Connected"
+    ? t("nodeStatus.connected", "Connected")
     : isDegraded
-    ? "Degraded"
+    ? t("nodeStatus.degraded", "Degraded")
     : isReconnecting
-    ? "Reconnecting..."
-    : "Disconnected"
+    ? t("nodeStatus.reconnecting", "Reconnecting...")
+    : t("nodeStatus.disconnected", "Disconnected")
 
   const showEngineInfo = !isHealthy && streamHealth !== "healthy"
 
@@ -226,11 +230,11 @@ export function NodeStatusPopover({ children }: { children: React.ReactNode }) {
         {showEngineInfo && (
           <div className="mb-2 space-y-0.5">
             <p className="text-[10px] text-muted-foreground">
-              Engine: {streamHealth}
+              {t("nodeStatus.engine", "Engine")}: {streamHealth}
             </p>
             {restartCount > 0 && (
               <p className="text-[10px] text-muted-foreground">
-                Restarts: {restartCount}
+                {t("nodeStatus.restarts", "Restarts")}: {restartCount}
               </p>
             )}
           </div>
@@ -239,15 +243,15 @@ export function NodeStatusPopover({ children }: { children: React.ReactNode }) {
         {/* ── Stats ── */}
         <div className="space-y-1 mb-1">
           <div className="flex items-center justify-between">
-            <span className="text-[10px] text-muted-foreground">Last sync</span>
-            <span className="text-[10px] text-foreground">{formatLastSync(lastSyncAt)}</span>
+            <span className="text-[10px] text-muted-foreground">{t("nodeStatus.lastSync", "Last sync")}</span>
+            <span className="text-[10px] text-foreground">{formatLastSync(lastSyncAt, t)}</span>
           </div>
           <div className="flex items-center justify-between">
-            <span className="text-[10px] text-muted-foreground">Synced files</span>
+            <span className="text-[10px] text-muted-foreground">{t("nodeStatus.syncedFiles", "Synced files")}</span>
             <span className="text-[10px] text-foreground">{syncedFiles}</span>
           </div>
           <div className="flex items-center justify-between">
-            <span className="text-[10px] text-muted-foreground">Pending files</span>
+            <span className="text-[10px] text-muted-foreground">{t("nodeStatus.pendingFiles", "Pending files")}</span>
             <span
               className={cn(
                 "text-[10px]",
@@ -264,7 +268,7 @@ export function NodeStatusPopover({ children }: { children: React.ReactNode }) {
           <>
             <Separator className="my-2" />
             <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1.5">
-              Team Members ({sortedRows.length})
+              {t("nodeStatus.teamMembers", { count: sortedRows.length })}
             </p>
             <div className="space-y-0.5">
               {sortedRows.map((row) => (

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -67,6 +67,7 @@ const WORKSPACE_QUICK_SECTIONS: {
 
 // Status indicator for the active session in the sidebar
 function SidebarSessionStatusIndicator() {
+  const { t } = useTranslation()
   const sessionStatus = useSessionStore(s => s.sessionStatus)
   const pendingPermissions = useSessionStore(s => s.pendingPermissions)
   const pendingQuestions = useSessionStore(s => s.pendingQuestions)
@@ -75,7 +76,7 @@ function SidebarSessionStatusIndicator() {
   if (pendingPermissions.length > 0 || pendingQuestions.length > 0) {
     return (
       <span className="shrink-0 text-[10px] font-medium text-emerald-500 bg-emerald-500/10 px-1.5 py-0.5 rounded-full">
-        等待确认
+        {t('chat.waitingForConfirmationShort', 'Waiting')}
       </span>
     )
   }
@@ -220,7 +221,7 @@ export function SidebarSecondarySessionActions({
         className="h-7 w-7 text-muted-foreground hover:text-foreground disabled:opacity-40"
         disabled={!hasWorkspace}
         onClick={() => includeSearchDialog && setSearchOpen(true)}
-        title={hasWorkspace ? "Search (⌘K)" : t('sidebar.selectWorkspaceFirst', 'Please select a workspace first')}
+        title={hasWorkspace ? t('sidebar.searchWithShortcut', 'Search (⌘K)') : t('sidebar.selectWorkspaceFirst', 'Please select a workspace first')}
       >
         <Search className="h-4 w-4" />
       </Button>
@@ -282,7 +283,7 @@ export function SidebarSecondarySessionActions({
                 )}
                 disabled={!hasWorkspace}
                 onClick={() => includeSearchDialog && setSearchOpen(true)}
-                title={hasWorkspace ? "Search (⌘K)" : t('sidebar.selectWorkspaceFirst', 'Please select a workspace first')}
+                title={hasWorkspace ? t('sidebar.searchWithShortcut', 'Search (⌘K)') : t('sidebar.selectWorkspaceFirst', 'Please select a workspace first')}
               >
                 <Search className="h-4 w-4" />
               </Button>
@@ -376,7 +377,10 @@ function DefaultKnowledgeHeaderControls({
       }>('team_sync_repo', { force: false, workspacePath })
       if (result.needsConfirmation) {
         const { toast } = await import('sonner')
-        toast.warning(`检测到 ${result.newFiles?.length ?? 0} 个较大的新文件待同步，请在设置 → 团队中确认`)
+        toast.warning(t('settings.team.syncPrecheckToast', {
+          count: result.newFiles?.length ?? 0,
+          defaultValue: 'Detected {{count}} large new files to sync. Confirm in Settings > Team.',
+        }))
         return
       }
       const { toast } = await import('sonner')
@@ -395,7 +399,7 @@ function DefaultKnowledgeHeaderControls({
       setSyncing(false)
       useTeamModeStore.setState({ teamGitSyncing: false })
     }
-  }, [refreshFileTree, syncing, workspacePath])
+  }, [refreshFileTree, syncing, t, workspacePath])
 
   const iconButtonClass =
     'h-7 w-7 shrink-0 rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
@@ -837,7 +841,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   )}
                   {session.id !== activeSessionId && isHighlighted && (
                     <span className="shrink-0 text-[10px] font-medium text-emerald-500 bg-emerald-500/10 px-1.5 py-0.5 rounded-full">
-                      NEW
+                      {t('chat.newSessionBadge', 'NEW')}
                     </span>
                   )}
                 </>
@@ -848,7 +852,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 <span className="text-[10px] text-muted-foreground">
                   {formatDate(session.updatedAt)}
                   {session.messageCount !== undefined && (
-                    <> · {session.messageCount} messages</>
+                    <> · {t('chat.messageCountShort', { count: session.messageCount })}</>
                   )}
                 </span>
                 {session.id === activeSessionId && (

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -836,7 +836,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
             className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
             <ArrowLeft size={14} />
-            <span>返回主会话</span>
+            <span>{t("chat.backToMainSession", "Back to main session")}</span>
           </button>
           <div className="flex items-center gap-1.5 ml-auto text-xs text-muted-foreground">
             <Bot size={12} />

--- a/packages/app/src/components/chat/CommandPopover.tsx
+++ b/packages/app/src/components/chat/CommandPopover.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import { Command as CommandIcon, Zap, Loader2, UserRound } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { getOpenCodeClient, type Command as OpenCodeCommand } from '@/lib/opencode/sdk-client'
@@ -95,6 +96,7 @@ export function CommandPopover({
   searchQuery,
   onSelect,
 }: CommandPopoverProps) {
+  const { t } = useTranslation()
   const workspacePath = useWorkspaceStore(s => s.workspacePath)
   const [commands, setCommands] = React.useState<OpenCodeCommand[]>([])
   const [roles, setRoles] = React.useState<RoleEntry[]>([])
@@ -267,7 +269,9 @@ export function CommandPopover({
       <div className="w-64 flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-3 py-2 text-[10px] text-muted-foreground border-b bg-muted/30">
-          <span className="font-medium">Select role, skill, or command</span>
+          <span className="font-medium">
+            {t('chat.commandPopover.prompt', 'Select role, skill, or command')}
+          </span>
           {searchQuery && (
             <span className="text-[9px] text-primary font-mono">
               {searchQuery}
@@ -275,7 +279,7 @@ export function CommandPopover({
           )}
           {!searchQuery && totalCount > 0 && (
             <span className="text-[9px]">
-              {totalCount} items
+              {t('chat.commandPopover.itemCount', { count: totalCount })}
             </span>
           )}
         </div>
@@ -285,20 +289,20 @@ export function CommandPopover({
         {isLoading ? (
           <div className="flex items-center justify-center gap-2 py-8 text-xs text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
-            Loading...
+            {t('common.loading', 'Loading...')}
           </div>
         ) : totalCount === 0 ? (
           <div className="py-8 text-center text-xs text-muted-foreground">
             {searchQuery
-              ? `No match for "${searchQuery}"`
-              : "No skills or commands found"}
+              ? t('chat.commandPopover.noMatch', { query: searchQuery })
+              : t('chat.commandPopover.empty', 'No skills or commands found')}
           </div>
         ) : (
           <>
             {filteredRoles.length > 0 && (
               <>
                 <div className="px-2 py-1.5 text-[10px] font-semibold text-muted-foreground">
-                  Roles ({filteredRoles.length})
+                  {t('chat.commandPopover.roles', { count: filteredRoles.length })}
                 </div>
                 {filteredRoles.map((role) => {
                   const index = currentIndex++
@@ -335,7 +339,7 @@ export function CommandPopover({
             {filteredSkills.length > 0 && (
               <>
                 <div className="px-2 py-1.5 text-[10px] font-semibold text-muted-foreground">
-                  Skills ({filteredSkills.length})
+                  {t('chat.commandPopover.skills', { count: filteredSkills.length })}
                 </div>
                 {filteredSkills.map((skill) => {
                   const index = currentIndex++
@@ -372,7 +376,7 @@ export function CommandPopover({
             {filteredCommands.length > 0 && (
               <>
                 <div className="px-2 py-1.5 text-[10px] font-semibold text-muted-foreground">
-                  Commands ({filteredCommands.length})
+                  {t('chat.commandPopover.commands', { count: filteredCommands.length })}
                 </div>
                 {filteredCommands.map((cmd) => {
                   const index = currentIndex++
@@ -404,9 +408,9 @@ export function CommandPopover({
 
         {/* Hint bar */}
         <div className="flex items-center gap-3 px-3 py-1.5 text-[10px] text-muted-foreground/60 border-t">
-          <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↑↓</kbd> navigate</span>
-          <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↵</kbd> select</span>
-          <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">Esc</kbd> close</span>
+          <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↑↓</kbd> {t('chat.commandPopover.navigate', 'navigate')}</span>
+          <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↵</kbd> {t('chat.commandPopover.select', 'select')}</span>
+          <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">Esc</kbd> {t('chat.commandPopover.close', 'close')}</span>
         </div>
       </div>
 
@@ -414,7 +418,7 @@ export function CommandPopover({
       {highlightedItem && highlightedItem.description && (
         <div className="w-80 border-l bg-muted/20 flex flex-col">
           <div className="px-3 py-2 text-[10px] font-semibold text-muted-foreground border-b bg-muted/30">
-            Description
+            {t('chat.commandPopover.description', 'Description')}
           </div>
           <div className="p-3 text-[10px] text-muted-foreground leading-relaxed overflow-y-auto flex-1 max-h-80">
             {highlightedItem.description}

--- a/packages/app/src/components/chat/MessageStarRating.tsx
+++ b/packages/app/src/components/chat/MessageStarRating.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import { Star } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useTelemetryStore } from '@/stores/telemetry'
@@ -10,6 +11,7 @@ interface MessageStarRatingProps {
 }
 
 export function MessageStarRating({ sessionId, messageId }: MessageStarRatingProps) {
+  const { t } = useTranslation()
   const setStarRating = useTelemetryStore((s) => s.setStarRating)
   const removeStarRating = useTelemetryStore((s) => s.removeStarRating)
   const starRatingCache = useTelemetryStore((s) => s.starRatingCache)
@@ -40,7 +42,7 @@ export function MessageStarRating({ sessionId, messageId }: MessageStarRatingPro
       )}
     >
       <span className="text-xs text-muted-foreground/60 select-none">
-        How was this result?
+        {t('telemetry.rating.question', 'How was this result?')}
       </span>
       <div
         className="inline-flex items-center gap-0"
@@ -59,7 +61,7 @@ export function MessageStarRating({ sessionId, messageId }: MessageStarRatingPro
                   ? 'text-amber-400'
                   : 'text-muted-foreground/30 hover:text-amber-400/60',
               )}
-              title={`${star} star${star > 1 ? 's' : ''}`}
+              title={t('telemetry.rating.starLabel', { count: star })}
             >
               <Star
                 className="h-3.5 w-3.5"

--- a/packages/app/src/components/chat/SessionList.tsx
+++ b/packages/app/src/components/chat/SessionList.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { MessageSquare, Loader2 } from 'lucide-react'
 import { useSessionStore } from '@/stores/session'
@@ -26,6 +27,7 @@ interface SessionListItemProps {
 }
 
 function SessionStatusIndicator({ compact }: { compact?: boolean }) {
+  const { t } = useTranslation()
   const sessionStatus = useSessionStore(s => s.sessionStatus)
   const pendingPermissions = useSessionStore(s => s.pendingPermissions)
   const pendingQuestions = useSessionStore(s => s.pendingQuestions)
@@ -34,7 +36,7 @@ function SessionStatusIndicator({ compact }: { compact?: boolean }) {
   if (pendingPermissions.length > 0 || pendingQuestions.length > 0) {
     return (
       <span className="shrink-0 text-[10px] font-medium text-emerald-600 bg-emerald-500/10 px-1.5 py-0.5 rounded-full">
-        等待确认
+        {t('chat.waitingForConfirmationShort', 'Waiting')}
       </span>
     )
   }
@@ -59,6 +61,8 @@ const SessionListItem = React.memo(function SessionListItem({
   onSelect,
   children,
 }: SessionListItemProps) {
+  const { t } = useTranslation()
+
   return (
     <div>
       <button
@@ -92,14 +96,14 @@ const SessionListItem = React.memo(function SessionListItem({
                 <SessionStatusIndicator compact={compact} />
               ) : isHighlighted ? (
                 <span className="shrink-0 text-[10px] font-medium text-emerald-600 bg-emerald-500/10 px-1.5 py-0.5 rounded-full">
-                  NEW
+                  {t('chat.newSessionBadge', 'NEW')}
                 </span>
               ) : null}
             </div>
             <span className={cn("text-muted-foreground/70", compact ? "text-xs" : "text-xs")}>
               {formatRelativeDate(session.updatedAt)}
               {session.messageCount !== undefined && (
-                <> · {session.messageCount} msgs</>
+                <> · {t('chat.messageCountShort', { count: session.messageCount })}</>
               )}
             </span>
           </div>

--- a/packages/app/src/components/history/CommitList.tsx
+++ b/packages/app/src/components/history/CommitList.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Loader2 } from 'lucide-react'
 import type { GitLogEntry } from '@/lib/git/types'
 
@@ -10,12 +11,12 @@ interface CommitListProps {
   loadingMore: boolean
 }
 
-function formatRelative(iso: string): string {
+function formatRelative(iso: string, language: string): string {
   const t = new Date(iso).getTime()
   if (Number.isNaN(t)) return iso
   const diffSec = Math.round((t - Date.now()) / 1000)
   const abs = Math.abs(diffSec)
-  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+  const rtf = new Intl.RelativeTimeFormat(language, { numeric: 'auto' })
   if (abs < 60) return rtf.format(diffSec, 'second')
   if (abs < 3600) return rtf.format(Math.round(diffSec / 60), 'minute')
   if (abs < 86400) return rtf.format(Math.round(diffSec / 3600), 'hour')
@@ -30,6 +31,8 @@ export function CommitList({
   hasMore,
   loadingMore,
 }: CommitListProps) {
+  const { t, i18n } = useTranslation()
+
   return (
     <div className="flex flex-col h-full overflow-y-auto">
       {commits.map((c) => {
@@ -44,7 +47,7 @@ export function CommitList({
             }`}
           >
             <div className="text-xs text-muted-foreground truncate">
-              {formatRelative(c.isoTime)} · {c.author}
+              {formatRelative(c.isoTime, i18n.language)} · {c.author}
             </div>
             <div className="text-sm truncate">{c.subject}</div>
           </button>
@@ -57,7 +60,7 @@ export function CommitList({
           disabled={loadingMore}
           className="px-3 py-2 text-xs text-muted-foreground hover:bg-muted disabled:opacity-50"
         >
-          {loadingMore ? <Loader2 className="h-3 w-3 animate-spin inline" /> : '加载更多'}
+          {loadingMore ? <Loader2 className="h-3 w-3 animate-spin inline" /> : t('sidebar.loadMore', 'Load More')}
         </button>
       )}
     </div>

--- a/packages/app/src/components/history/FileHistoryView.tsx
+++ b/packages/app/src/components/history/FileHistoryView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, lazy, Suspense, useCallback, useMemo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Loader2 } from 'lucide-react'
 import { gitManager } from '@/lib/git/manager'
 import type { GitLogEntry } from '@/lib/git/types'
@@ -34,6 +35,7 @@ export function FileHistoryView({
   filePath,
   isDark,
 }: FileHistoryViewProps) {
+  const { t } = useTranslation()
   const [commits, setCommits] = useState<GitLogEntry[]>([])
   const [selectedSha, setSelectedSha] = useState<string | null>(null)
   const [before, setBefore] = useState<string | null>(null)
@@ -109,7 +111,10 @@ export function FileHistoryView({
       .then(([b, a]) => {
         if (cancelled) return
         if (a === null) {
-          setDiffError(`无法加载该提交的内容 (${selectedSha.slice(0, 7)})`)
+          setDiffError(t('history.loadCommitContentFailed', {
+            sha: selectedSha.slice(0, 7),
+            defaultValue: 'Unable to load content for this commit ({{sha}})',
+          }))
           setBefore(null)
           setAfter(null)
         } else {
@@ -127,7 +132,7 @@ export function FileHistoryView({
     return () => {
       cancelled = true
     }
-  }, [selectedSha, selectedEntry, repoPath, relativePath])
+  }, [selectedSha, selectedEntry, repoPath, relativePath, t])
 
   const handleLoadMore = useCallback(() => {
     if (loadingMore) return
@@ -164,7 +169,7 @@ export function FileHistoryView({
           <div className="p-3 text-xs text-red-500">
             {listError}
             <button type="button" onClick={fetchInitial} className="ml-2 underline">
-              重试
+              {t('common.retry', 'Retry')}
             </button>
           </div>
         ) : (
@@ -181,7 +186,7 @@ export function FileHistoryView({
       <div className="flex-1 overflow-hidden">
         {showEmpty ? (
           <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-            该文件还没有提交历史
+            {t('history.noFileHistory', 'This file has no commit history yet')}
           </div>
         ) : loadingDiff ? (
           <div className="flex items-center justify-center h-full">
@@ -193,7 +198,7 @@ export function FileHistoryView({
           </div>
         ) : showSizeGuard ? (
           <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-            文件过大或为二进制，跳过 diff
+            {t('history.diffSkippedTooLarge', 'File is too large or binary, skipping diff')}
           </div>
         ) : after !== null ? (
           <Suspense

--- a/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
+++ b/packages/app/src/components/knowledge/KnowledgeBrowser.tsx
@@ -48,9 +48,10 @@ export function KnowledgeBrowser({
         totalBytes?: number
       }>('team_sync_repo', { force: false, workspacePath })
       if (result.needsConfirmation) {
-        toast.warning(
-          `检测到 ${result.newFiles?.length ?? 0} 个较大的新文件待同步，请在设置 → 团队中确认`,
-        )
+        toast.warning(t('settings.team.syncPrecheckToast', {
+          count: result.newFiles?.length ?? 0,
+          defaultValue: 'Detected {{count}} large new files to sync. Confirm in Settings > Team.',
+        }))
         return
       }
       if (result.success) {
@@ -69,7 +70,7 @@ export function KnowledgeBrowser({
       setSyncing(false)
       useTeamModeStore.setState({ teamGitSyncing: false })
     }
-  }, [syncing, refreshFileTree, workspacePath])
+  }, [syncing, refreshFileTree, t, workspacePath])
 
   if (!workspacePath) return null
 

--- a/packages/app/src/components/settings/GeneralSection.tsx
+++ b/packages/app/src/components/settings/GeneralSection.tsx
@@ -36,7 +36,7 @@ import { useSuggestionsStore } from '@/stores/suggestions'
 import { useUIStore } from '@/stores/ui'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { appShortName, buildConfig } from '@/lib/build-config'
-import { getPreferredLanguage, persistLanguage } from '@/lib/locale'
+import { LANGUAGE_OPTIONS, getPreferredLanguage, normalizeSupportedLanguage, persistLanguage } from '@/lib/locale'
 
 // Theme helpers
 const THEME_STORAGE_KEY = `${buildConfig.app.shortName ?? 'teamclaw'}-theme`
@@ -288,20 +288,24 @@ export const GeneralSection = React.memo(function GeneralSection() {
   <Select
     value={language}
     onValueChange={(value) => {
-      setLanguage(value);
-      i18next.changeLanguage(value);
-      persistLanguage(value);
+      const normalizedValue = normalizeSupportedLanguage(value);
+      setLanguage(normalizedValue);
+      i18next.changeLanguage(normalizedValue);
+      persistLanguage(normalizedValue);
       // Sync locale to config file for gateway i18n
-      invoke('set_config_locale', { locale: value }).catch(console.error);
+      invoke('set_config_locale', { locale: normalizedValue }).catch(console.error);
     }}
   >
     <SelectTrigger className="h-11">
       <SelectValue />
     </SelectTrigger>
     <SelectContent>
-      <SelectItem value="en">🇺🇸 {t('common.english', 'English')}</SelectItem>
-      <SelectItem value="zh-CN">🇨🇳 {t('common.chinese', '中文')}</SelectItem>
-      <SelectItem value="ja">🇯🇵 {t('common.japanese', '日本語')}</SelectItem>
+      {LANGUAGE_OPTIONS.map((option) => (
+        <SelectItem key={option.value} value={option.value}>
+          {option.value === 'en' ? '🇺🇸 ' : '🇨🇳 '}
+          {t(option.labelKey, option.fallback)}
+        </SelectItem>
+      ))}
     </SelectContent>
   </Select>
 </div>

--- a/packages/app/src/components/telemetry/TelemetryConsentDialog.tsx
+++ b/packages/app/src/components/telemetry/TelemetryConsentDialog.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import { BarChart3, Shield, Eye, EyeOff } from 'lucide-react'
 import {
   AlertDialog,
@@ -22,6 +23,7 @@ export function TelemetryConsentDialog({
   open,
   onComplete,
 }: TelemetryConsentDialogProps) {
+  const { t } = useTranslation()
   const setConsent = useTelemetryStore((s) => s.setConsent)
 
   const handleGrant = React.useCallback(async () => {
@@ -42,10 +44,10 @@ export function TelemetryConsentDialog({
             <BarChart3 className="h-6 w-6 text-primary" />
           </div>
           <AlertDialogTitle className="text-center">
-            {`帮助改善 ${buildConfig.app.name}`}
+            {t('telemetry.consent.title', { appName: buildConfig.app.name })}
           </AlertDialogTitle>
           <AlertDialogDescription className="text-center">
-            {`允许 ${buildConfig.app.name} 收集匿名使用数据，帮助我们改善 Agent 质量。`}
+            {t('telemetry.consent.description', { appName: buildConfig.app.name })}
           </AlertDialogDescription>
         </AlertDialogHeader>
 
@@ -53,27 +55,27 @@ export function TelemetryConsentDialog({
           <div className="flex items-start gap-3 text-sm">
             <Eye className="h-4 w-4 mt-0.5 text-green-500 shrink-0" />
             <div>
-              <p className="font-medium text-foreground">收集内容</p>
+              <p className="font-medium text-foreground">{t('telemetry.consent.collectTitle')}</p>
               <p className="text-muted-foreground text-xs mt-0.5">
-                会话时长、Token 消耗、工具调用统计、反馈评分、模型信息
+                {t('telemetry.consent.collectDescription')}
               </p>
             </div>
           </div>
           <div className="flex items-start gap-3 text-sm">
             <EyeOff className="h-4 w-4 mt-0.5 text-red-500 shrink-0" />
             <div>
-              <p className="font-medium text-foreground">绝不收集</p>
+              <p className="font-medium text-foreground">{t('telemetry.consent.neverCollectTitle')}</p>
               <p className="text-muted-foreground text-xs mt-0.5">
-                对话内容、代码、文件路径、项目名称、个人信息
+                {t('telemetry.consent.neverCollectDescription')}
               </p>
             </div>
           </div>
           <div className="flex items-start gap-3 text-sm">
             <Shield className="h-4 w-4 mt-0.5 text-blue-500 shrink-0" />
             <div>
-              <p className="font-medium text-foreground">随时可改</p>
+              <p className="font-medium text-foreground">{t('telemetry.consent.changeAnytimeTitle')}</p>
               <p className="text-muted-foreground text-xs mt-0.5">
-                可在 Settings &gt; System &gt; Privacy &amp; Telemetry 中随时关闭
+                {t('telemetry.consent.changeAnytimeDescription')}
               </p>
             </div>
           </div>
@@ -81,10 +83,10 @@ export function TelemetryConsentDialog({
 
         <AlertDialogFooter>
           <AlertDialogCancel onClick={handleDeny}>
-            暂不开启
+            {t('telemetry.consent.deny')}
           </AlertDialogCancel>
           <AlertDialogAction onClick={handleGrant}>
-            允许分析
+            {t('telemetry.consent.allow')}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/packages/app/src/components/version/VersionHistoryTab.tsx
+++ b/packages/app/src/components/version/VersionHistoryTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useVersionHistoryStore } from '@/stores/version-history'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { VersionedFileList } from '@/components/version/VersionedFileList'
@@ -6,6 +7,7 @@ import { VersionList } from '@/components/version/VersionList'
 import { VersionPreview } from '@/components/version/VersionPreview'
 
 export function VersionHistoryTab() {
+  const { t } = useTranslation()
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
 
   const {
@@ -83,8 +85,8 @@ export function VersionHistoryTab() {
       {/* Left: Versioned file list */}
       <div className="w-[220px] shrink-0 border-r flex flex-col overflow-hidden">
         <div className="border-b px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-          文件列表
-          {loading && <span className="ml-2 text-[10px] font-normal normal-case">加载中...</span>}
+          {t('versionHistory.fileList', 'File list')}
+          {loading && <span className="ml-2 text-[10px] font-normal normal-case">{t('common.loading', 'Loading...')}</span>}
         </div>
         <div className="flex-1 overflow-hidden">
           <VersionedFileList
@@ -101,7 +103,7 @@ export function VersionHistoryTab() {
       {/* Middle: Version list */}
       <div className="w-[200px] shrink-0 border-r flex flex-col overflow-hidden">
         <div className="border-b px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-          版本历史
+          {t('versionHistory.title', 'Version history')}
         </div>
         <div className="flex-1 overflow-hidden">
           {selectedFile ? (
@@ -114,7 +116,7 @@ export function VersionHistoryTab() {
             />
           ) : (
             <div className="flex h-full items-center justify-center text-xs text-muted-foreground px-3 text-center">
-              请从左侧选择文件
+              {t('versionHistory.selectFilePrompt', 'Select a file from the left')}
             </div>
           )}
         </div>

--- a/packages/app/src/components/version/VersionList.tsx
+++ b/packages/app/src/components/version/VersionList.tsx
@@ -1,8 +1,10 @@
+import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
 import { cn } from '@/lib/utils'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import type { FileVersion } from '@/stores/version-history'
 
-function formatRelativeTime(isoString: string): string {
+function formatRelativeTime(isoString: string, t: TFunction, language: string): string {
   const date = new Date(isoString)
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
@@ -11,11 +13,11 @@ function formatRelativeTime(isoString: string): string {
   const diffHours = Math.floor(diffMins / 60)
   const diffDays = Math.floor(diffHours / 24)
 
-  if (diffSecs < 60) return '刚刚'
-  if (diffMins < 60) return `${diffMins} 分钟前`
-  if (diffHours < 24) return `${diffHours} 小时前`
-  if (diffDays < 30) return `${diffDays} 天前`
-  return date.toLocaleDateString('zh-CN')
+  if (diffSecs < 60) return t('common.justNow')
+  if (diffMins < 60) return t('common.minutesAgo', { count: diffMins })
+  if (diffHours < 24) return t('common.hoursAgo', { count: diffHours })
+  if (diffDays < 30) return t('common.daysAgo', { count: diffDays })
+  return date.toLocaleDateString(language)
 }
 
 interface VersionListProps {
@@ -33,12 +35,16 @@ export function VersionList({
   currentUpdatedBy,
   currentUpdatedAt,
 }: VersionListProps) {
+  const { t, i18n } = useTranslation()
+
   return (
     <ScrollArea className="h-full">
       <div className="py-2">
         {currentUpdatedBy && (
           <>
-            <div className="px-3 py-1 text-xs font-medium text-muted-foreground">当前版本</div>
+            <div className="px-3 py-1 text-xs font-medium text-muted-foreground">
+              {t('versionHistory.currentVersion', 'Current version')}
+            </div>
             <div
               className={cn(
                 'mx-1 cursor-pointer rounded-md px-3 py-2',
@@ -48,13 +54,13 @@ export function VersionList({
               )}
               onClick={() => onSelect(-1)}
             >
-              <div className="text-sm font-medium">当前文件</div>
+              <div className="text-sm font-medium">{t('versionHistory.currentFile', 'Current file')}</div>
               <div className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
                 <span>{currentUpdatedBy}</span>
                 {currentUpdatedAt && (
                   <>
                     <span>·</span>
-                    <span>{formatRelativeTime(currentUpdatedAt)}</span>
+                    <span>{formatRelativeTime(currentUpdatedAt, t, i18n.language)}</span>
                   </>
                 )}
               </div>
@@ -62,9 +68,13 @@ export function VersionList({
           </>
         )}
 
-        <div className="mt-2 px-3 py-1 text-xs font-medium text-muted-foreground">历史版本</div>
+        <div className="mt-2 px-3 py-1 text-xs font-medium text-muted-foreground">
+          {t('versionHistory.historicalVersionsTitle', 'Historical versions')}
+        </div>
         {versions.length === 0 && (
-          <div className="px-3 py-2 text-xs text-muted-foreground">暂无历史版本</div>
+          <div className="px-3 py-2 text-xs text-muted-foreground">
+            {t('versionHistory.noHistoricalVersions', 'No historical versions')}
+          </div>
         )}
         {versions.map((version, i) => {
           const isSelected = selectedIndex === version.index
@@ -77,11 +87,13 @@ export function VersionList({
               )}
               onClick={() => onSelect(version.index)}
             >
-              <div className="text-sm">版本 {versions.length - i}</div>
+              <div className="text-sm">
+                {t('versionHistory.versionLabel', { number: versions.length - i })}
+              </div>
               <div className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
                 <span>{version.updatedBy}</span>
                 <span>·</span>
-                <span>{formatRelativeTime(version.updatedAt)}</span>
+                <span>{formatRelativeTime(version.updatedAt, t, i18n.language)}</span>
               </div>
             </div>
           )

--- a/packages/app/src/components/version/VersionPreview.tsx
+++ b/packages/app/src/components/version/VersionPreview.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Button } from '@/components/ui/button'
@@ -108,12 +109,13 @@ export function VersionPreview({
   onRestore,
   restoring,
 }: VersionPreviewProps) {
+  const { t } = useTranslation()
   const [tab, setTab] = useState<TabMode>('content')
 
   if (!version) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-        请选择一个历史版本
+        {t('versionHistory.selectVersionPrompt', 'Select a historical version')}
       </div>
     )
   }
@@ -132,7 +134,7 @@ export function VersionPreview({
                 : 'text-muted-foreground hover:bg-accent/50'
             )}
           >
-            内容
+            {t('versionHistory.contentTab', 'Content')}
           </button>
           <button
             onClick={() => setTab('diff')}
@@ -143,7 +145,7 @@ export function VersionPreview({
                 : 'text-muted-foreground hover:bg-accent/50'
             )}
           >
-            与当前对比
+            {t('versionHistory.diffTab', 'Compare with current')}
           </button>
         </div>
 
@@ -151,19 +153,26 @@ export function VersionPreview({
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button size="sm" variant="outline" disabled={restoring}>
-                {restoring ? '恢复中...' : '恢复此版本'}
+                {restoring
+                  ? t('versionHistory.restoring', 'Restoring...')
+                  : t('versionHistory.restoreThisVersion', 'Restore this version')}
               </Button>
             </AlertDialogTrigger>
             <AlertDialogContent size="sm">
               <AlertDialogHeader>
-                <AlertDialogTitle>恢复此版本？</AlertDialogTitle>
+                <AlertDialogTitle>{t('versionHistory.restoreTitle', 'Restore this version?')}</AlertDialogTitle>
                 <AlertDialogDescription>
-                  文件将恢复到本地草稿，不会立即同步给团队。下次同步时，此变更将自动推送。
+                  {t(
+                    'versionHistory.restoreDescription',
+                    'The file will be restored to the local draft and will not sync to the team immediately. This change will be pushed automatically on the next sync.',
+                  )}
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
-                <AlertDialogCancel>取消</AlertDialogCancel>
-                <AlertDialogAction onClick={onRestore}>确认恢复</AlertDialogAction>
+                <AlertDialogCancel>{t('common.cancel', 'Cancel')}</AlertDialogCancel>
+                <AlertDialogAction onClick={onRestore}>
+                  {t('versionHistory.confirmRestore', 'Restore')}
+                </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
@@ -180,7 +189,7 @@ export function VersionPreview({
           <SimpleDiff oldContent={currentContent} newContent={version.content} />
         ) : (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground p-4">
-            当前内容不可用
+            {t('versionHistory.currentContentUnavailable', 'Current content is unavailable')}
           </div>
         )}
       </ScrollArea>

--- a/packages/app/src/components/version/VersionedFileList.tsx
+++ b/packages/app/src/components/version/VersionedFileList.tsx
@@ -1,20 +1,21 @@
+import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import type { VersionedFileInfo } from '@/stores/version-history'
 
-const DOC_TYPE_LABELS: Record<string, string> = {
-  skill: 'Skills',
-  mcp: 'MCP',
-  knowledge: 'Knowledge',
-  meta: 'Meta',
+const DOC_TYPE_LABELS: Record<string, { key: string; fallback: string }> = {
+  skill: { key: 'versionHistory.docType.skill', fallback: 'Skills' },
+  mcp: { key: 'versionHistory.docType.mcp', fallback: 'MCP' },
+  knowledge: { key: 'versionHistory.docType.knowledge', fallback: 'Knowledge' },
+  meta: { key: 'versionHistory.docType.meta', fallback: 'Meta' },
 }
 
-const FILTER_OPTIONS: { label: string; value: string | null }[] = [
-  { label: '全部', value: null },
-  { label: 'Skills', value: 'skill' },
-  { label: 'MCP', value: 'mcp' },
-  { label: 'Knowledge', value: 'knowledge' },
-  { label: 'Meta', value: 'meta' },
+const FILTER_OPTIONS: { key: string; fallback: string; value: string | null }[] = [
+  { key: 'versionHistory.filterAll', fallback: 'All', value: null },
+  { key: 'versionHistory.docType.skill', fallback: 'Skills', value: 'skill' },
+  { key: 'versionHistory.docType.mcp', fallback: 'MCP', value: 'mcp' },
+  { key: 'versionHistory.docType.knowledge', fallback: 'Knowledge', value: 'knowledge' },
+  { key: 'versionHistory.docType.meta', fallback: 'Meta', value: 'meta' },
 ]
 
 function getFileName(filePath: string): string {
@@ -38,6 +39,7 @@ export function VersionedFileList({
   docTypeFilter,
   onFilterChange,
 }: VersionedFileListProps) {
+  const { t } = useTranslation()
   const filteredFiles = docTypeFilter
     ? files.filter((f) => f.docType === docTypeFilter)
     : files
@@ -46,9 +48,9 @@ export function VersionedFileList({
     <div className="flex h-full flex-col">
       {/* Filter row */}
       <div className="flex flex-wrap gap-1 border-b px-3 py-2">
-        {FILTER_OPTIONS.map(({ label, value }) => (
+        {FILTER_OPTIONS.map(({ key, fallback, value }) => (
           <button
-            key={label}
+            key={key}
             onClick={() => onFilterChange(value)}
             className={cn(
               'rounded-full px-2.5 py-0.5 text-xs transition-colors',
@@ -57,7 +59,7 @@ export function VersionedFileList({
                 : 'bg-muted text-muted-foreground hover:bg-muted/80'
             )}
           >
-            {label}
+            {t(key, fallback)}
           </button>
         ))}
       </div>
@@ -66,13 +68,16 @@ export function VersionedFileList({
       <ScrollArea className="flex-1">
         <div className="py-1">
           {filteredFiles.length === 0 && (
-            <div className="px-3 py-4 text-center text-xs text-muted-foreground">暂无文件</div>
+            <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+              {t('versionHistory.noFiles', 'No files')}
+            </div>
           )}
           {filteredFiles.map((file) => {
             const isSelected =
               selectedPath === file.path && selectedDocType === file.docType
             const fileName = getFileName(file.path)
-            const docLabel = DOC_TYPE_LABELS[file.docType] ?? file.docType
+            const docTypeLabel = DOC_TYPE_LABELS[file.docType]
+            const docLabel = docTypeLabel ? t(docTypeLabel.key, docTypeLabel.fallback) : file.docType
 
             return (
               <div
@@ -97,7 +102,7 @@ export function VersionedFileList({
                   </span>
                 </div>
                 <div className="mt-0.5 text-xs text-muted-foreground">
-                  {file.versionCount} 个版本
+                  {t('versionHistory.versionCount', { count: file.versionCount })}
                 </div>
               </div>
             )

--- a/packages/app/src/components/workspace/FileTreeNode.tsx
+++ b/packages/app/src/components/workspace/FileTreeNode.tsx
@@ -513,12 +513,12 @@ export const FileTreeItem = React.memo(function FileTreeItem({
               useTabsStore.getState().openTab({
                 type: "native",
                 target: "version-history",
-                label: "版本历史",
+                label: t("versionHistory.title", "Version history"),
               })
             })}
           >
             <History className="h-4 w-4" />
-            版本历史
+            {t("versionHistory.title", "Version history")}
           </ContextMenuItem>
         )}
         <ContextMenuSeparator />

--- a/packages/app/src/lib/__tests__/locale.test.ts
+++ b/packages/app/src/lib/__tests__/locale.test.ts
@@ -1,5 +1,10 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import ts from 'typescript'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { appShortName } from '@/lib/build-config'
+import en from '../../locales/en.json'
+import zhCN from '../../locales/zh-CN.json'
 
 const store: Record<string, string> = {}
 
@@ -19,6 +24,177 @@ function setNavigatorLanguage(language: string, languages: string[] = [language]
     configurable: true,
     value: languages,
   })
+}
+
+function flattenLocaleKeys(value: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(value).flatMap(([key, nestedValue]) => {
+    const nextKey = prefix ? `${prefix}.${key}` : key
+    if (nestedValue && typeof nestedValue === 'object' && !Array.isArray(nestedValue)) {
+      return flattenLocaleKeys(nestedValue as Record<string, unknown>, nextKey)
+    }
+    return nextKey
+  })
+}
+
+function collectSourceFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (['__tests__', 'coverage', 'dist', 'locales', 'node_modules'].includes(entry.name)) {
+        return []
+      }
+      return collectSourceFiles(fullPath)
+    }
+
+    if (!/\.(tsx?|jsx?)$/.test(entry.name) || /\.d\.ts$/.test(entry.name) || /\.(test|spec)\./.test(entry.name)) {
+      return []
+    }
+
+    return fullPath
+  })
+}
+
+function collectTranslationKeys(): string[] {
+  const root = path.resolve(process.cwd(), 'src')
+  const keys = new Set<string>()
+
+  for (const file of collectSourceFiles(root)) {
+    const source = fs.readFileSync(file, 'utf8')
+    const sourceFile = ts.createSourceFile(
+      file,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+    )
+
+    const visit = (node: ts.Node) => {
+      if (ts.isCallExpression(node)) {
+        const expression = node.expression.getText(sourceFile)
+        const firstArg = node.arguments[0]
+        if (
+          (expression === 't' || expression.endsWith('.t') || expression === 'i18n.t' || expression.endsWith('i18n.t')) &&
+          firstArg &&
+          ts.isStringLiteralLike(firstArg)
+        ) {
+          keys.add(firstArg.text)
+        }
+      }
+
+      ts.forEachChild(node, visit)
+    }
+
+    visit(sourceFile)
+  }
+
+  return [...keys].sort()
+}
+
+const RENDERED_TEXT_SCAN_FILES = [
+  'components/NodeStatusPopover.tsx',
+  'components/app-sidebar.tsx',
+  'components/chat/CommandPopover.tsx',
+  'components/chat/MessageStarRating.tsx',
+  'components/history/CommitList.tsx',
+  'components/history/FileHistoryView.tsx',
+  'components/telemetry/TelemetryConsentDialog.tsx',
+  'components/version/VersionHistoryTab.tsx',
+  'components/version/VersionList.tsx',
+  'components/version/VersionPreview.tsx',
+  'components/version/VersionedFileList.tsx',
+  'components/workspace/FileTreeNode.tsx',
+  'lib/dynamic-ui/DynamicUI.tsx',
+]
+
+function isTranslationCall(node: ts.CallExpression, sourceFile: ts.SourceFile): boolean {
+  const expression = node.expression.getText(sourceFile)
+  return expression === 't' || expression.endsWith('.t') || expression === 'i18n.t' || expression.endsWith('i18n.t')
+}
+
+function containsUserFacingText(text: string): boolean {
+  return /[\p{Script=Han}]|[A-Za-z]{2,}/u.test(text)
+}
+
+function normalizeJsxText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+const IGNORED_RENDERED_TEXT_LITERALS = new Set([
+  'Esc',
+  'added',
+  'content',
+  'git',
+  'knowledge',
+  'removed',
+  'session',
+  'shortcuts',
+])
+
+function collectRenderedTextLiterals(): string[] {
+  const root = path.resolve(process.cwd(), 'src')
+  const hardcoded = new Set<string>()
+
+  for (const relativeFile of RENDERED_TEXT_SCAN_FILES) {
+    const file = path.join(root, relativeFile)
+    const source = fs.readFileSync(file, 'utf8')
+    const sourceFile = ts.createSourceFile(
+      file,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+    )
+
+    const add = (node: ts.Node, value: string) => {
+      const text = normalizeJsxText(value)
+      if (!text || !containsUserFacingText(text)) return
+      if (IGNORED_RENDERED_TEXT_LITERALS.has(text)) return
+      const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+      hardcoded.add(`${relativeFile}:${line + 1}: ${text}`)
+    }
+
+    const visitExpression = (node: ts.Node) => {
+      if (ts.isJsxElement(node) || ts.isJsxFragment(node) || ts.isJsxSelfClosingElement(node)) {
+        visit(node)
+        return
+      }
+
+      if (ts.isCallExpression(node) && isTranslationCall(node, sourceFile)) {
+        return
+      }
+
+      if (ts.isStringLiteralLike(node)) {
+        add(node, node.text)
+        return
+      }
+
+      if (ts.isNoSubstitutionTemplateLiteral(node)) {
+        add(node, node.text)
+        return
+      }
+
+      if (ts.isTemplateExpression(node)) {
+        add(node, node.getText(sourceFile))
+        return
+      }
+
+      ts.forEachChild(node, visitExpression)
+    }
+
+    const visit = (node: ts.Node) => {
+      if (ts.isJsxText(node)) {
+        add(node, node.getText(sourceFile))
+      } else if (ts.isJsxExpression(node) && node.expression && !ts.isJsxAttribute(node.parent)) {
+        visitExpression(node.expression)
+      }
+
+      ts.forEachChild(node, visit)
+    }
+
+    visit(sourceFile)
+  }
+
+  return [...hardcoded].sort()
 }
 
 describe('locale helpers', () => {
@@ -50,5 +226,28 @@ describe('locale helpers', () => {
     const { getPreferredLanguage } = await import('../locale')
 
     expect(getPreferredLanguage()).toBe('en')
+  })
+
+  it('only advertises languages that have frontend translation resources', async () => {
+    const { SUPPORTED_LANGUAGES } = await import('../locale')
+
+    expect(SUPPORTED_LANGUAGES).toEqual(['en', 'zh-CN'])
+  })
+
+  it('keeps English and Simplified Chinese locale keys in sync', () => {
+    expect(flattenLocaleKeys(zhCN).sort()).toEqual(flattenLocaleKeys(en).sort())
+  })
+
+  it('keeps every statically referenced translation key in locale resources', () => {
+    const enKeys = new Set(flattenLocaleKeys(en))
+    const zhKeys = new Set(flattenLocaleKeys(zhCN))
+
+    const missingKeys = collectTranslationKeys().filter((key) => !enKeys.has(key) || !zhKeys.has(key))
+
+    expect(missingKeys).toEqual([])
+  })
+
+  it('keeps high-visibility rendered text behind translations', () => {
+    expect(collectRenderedTextLiterals()).toEqual([])
   })
 })

--- a/packages/app/src/lib/dynamic-ui/DynamicUI.tsx
+++ b/packages/app/src/lib/dynamic-ui/DynamicUI.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { useTranslation } from "react-i18next"
 import type { UITree } from "@json-render/core"
 import { JSONUIProvider, Renderer } from "@json-render/react"
 import { componentRegistry, fallbackComponent } from "./registry"
@@ -61,6 +62,7 @@ interface DynamicUIMessageProps {
 }
 
 export function DynamicUIMessage({ tree, loading = false }: DynamicUIMessageProps) {
+  const { t } = useTranslation()
   const [formData, setFormData] = React.useState<Record<string, unknown>>({})
 
   const handleDataChange = (path: string, value: unknown) => {
@@ -91,7 +93,7 @@ export function DynamicUIMessage({ tree, loading = false }: DynamicUIMessageProp
       return (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-          <span>正在生成界面...</span>
+          <span>{t("dynamicUi.generating", "Generating interface...")}</span>
         </div>
       )
     }

--- a/packages/app/src/lib/i18n.ts
+++ b/packages/app/src/lib/i18n.ts
@@ -1,6 +1,6 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import { getPreferredLanguage, normalizeSupportedLanguage, persistLanguage } from './locale';
+import { getPreferredLanguage, isSupportedLanguage, normalizeSupportedLanguage, persistLanguage } from './locale';
 
 // Import translation files
 import enTranslation from '../locales/en.json';
@@ -11,25 +11,29 @@ import zhCnTranslation from '../locales/zh-CN.json';
 //   'en'               → English only
 //   'zh-CN'            → Chinese only
 const FORCED_LOCALE = import.meta.env.VITE_LOCALE as string | undefined;
+const forcedSupportedLocale =
+  FORCED_LOCALE && FORCED_LOCALE !== 'all' && isSupportedLanguage(FORCED_LOCALE)
+    ? FORCED_LOCALE
+    : undefined;
 
 const allResources = {
   en: { translation: enTranslation },
   'zh-CN': { translation: zhCnTranslation },
 };
 
-const resources = FORCED_LOCALE && FORCED_LOCALE !== 'all'
-  ? { [FORCED_LOCALE]: allResources[FORCED_LOCALE as keyof typeof allResources] }
+const resources = forcedSupportedLocale
+  ? { [forcedSupportedLocale]: allResources[forcedSupportedLocale] }
   : allResources;
 
 const getUserLanguage = (): string => {
-  if (FORCED_LOCALE && FORCED_LOCALE !== 'all') {
-    return FORCED_LOCALE;
+  if (forcedSupportedLocale) {
+    return forcedSupportedLocale;
   }
 
   return normalizeSupportedLanguage(getPreferredLanguage());
 };
 
-const defaultLng = FORCED_LOCALE && FORCED_LOCALE !== 'all' ? FORCED_LOCALE : 'en';
+const defaultLng = forcedSupportedLocale ?? 'en';
 
 i18n
   .use(initReactI18next) // Passes i18n down to react-i18next

--- a/packages/app/src/lib/locale.ts
+++ b/packages/app/src/lib/locale.ts
@@ -1,6 +1,22 @@
 import { appShortName } from '@/lib/build-config'
 
 export const LANGUAGE_STORAGE_KEY = `${appShortName}-language`
+export const SUPPORTED_LANGUAGES = ['en', 'zh-CN'] as const
+
+export type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number]
+
+export const LANGUAGE_OPTIONS: Array<{
+  value: SupportedLanguage
+  labelKey: string
+  fallback: string
+}> = [
+  { value: 'en', labelKey: 'common.english', fallback: 'English' },
+  { value: 'zh-CN', labelKey: 'common.chinese', fallback: '中文' },
+]
+
+export function isSupportedLanguage(language: string | null | undefined): language is SupportedLanguage {
+  return SUPPORTED_LANGUAGES.includes(language as SupportedLanguage)
+}
 
 function getStorage(): Storage | undefined {
   if (typeof window !== 'undefined' && window.localStorage) {

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -43,7 +43,11 @@
     "daysAgo": "{{count}} day ago",
     "daysAgo_plural": "{{count}} days ago",
     "refresh": "Refresh",
-    "or": "or"
+    "or": "or",
+    "dismiss": "Dismiss",
+    "more": "More",
+    "showLess": "Show less",
+    "showMore": "Show more"
   },
   "navigation": {
     "home": "Home",
@@ -56,7 +60,10 @@
     "changes": "Changes",
     "tasks": "Tasks",
     "session": "Session",
-    "shortcuts": "Shortcuts"
+    "shortcuts": "Shortcuts",
+    "knowledge": "Knowledge",
+    "hideTabs": "Hide files",
+    "restoreTabs": "Show files"
   },
   "panel": {
     "tasks": {
@@ -206,14 +213,49 @@
         "submitting": "Submitting...",
         "preparing": "Preparing...",
         "submitAnswer": "Submit Answer"
-      }
+      },
+      "argCount": "{{count}} args"
     },
     "voiceInputStart": "Start voice input",
     "voiceInputStop": "Stop recording",
     "voiceInputUnsupported": "Voice input is not supported",
     "voiceInputPermissionDenied": "Microphone permission denied",
     "voiceInputNoSession": "Please select or create a session first",
-    "voiceInputInsertToChat": "Insert to chat"
+    "voiceInputInsertToChat": "Insert to chat",
+    "inputPlaceholderDescription": "Add a description...",
+    "inputPlaceholderMention": "Type @ to reference files...",
+    "inputPlaceholderQueue": "Type to queue message...",
+    "newSession": "New Session",
+    "refreshMessages": "Refresh messages",
+    "startingAgent": "Starting agent...",
+    "taskRunning": "Task running...",
+    "voiceInputChecking": "Checking microphone...",
+    "voiceInputDesktopNoTranscript": "Speech-to-text is not supported in the desktop app. Use the web version for voice input.",
+    "voiceInputNoMicrophone": "No microphone detected",
+    "voiceInputRecognizing": "Recognizing...",
+    "waitingForAgent": "Sessions are ready. Waiting for agent runtime to finish starting.",
+    "backToMainSession": "Back to main session",
+    "waitingForConfirmationShort": "Waiting",
+    "newSessionBadge": "NEW",
+    "messageCountShort": "{{count}} msg",
+    "messageCountShort_plural": "{{count}} msgs",
+    "commandPopover": {
+      "prompt": "Select role, skill, or command",
+      "itemCount": "{{count}} item",
+      "itemCount_plural": "{{count}} items",
+      "noMatch": "No match for \"{{query}}\"",
+      "empty": "No skills or commands found",
+      "roles": "{{count}} role",
+      "roles_plural": "{{count}} roles",
+      "skills": "{{count}} skill",
+      "skills_plural": "{{count}} skills",
+      "commands": "{{count}} command",
+      "commands_plural": "{{count}} commands",
+      "navigate": "navigate",
+      "select": "select",
+      "close": "close",
+      "description": "Description"
+    }
   },
   "onboarding": {
     "common": {
@@ -308,8 +350,27 @@
     "pasteFailed": "Paste failed",
     "externalDropped": "Copied {{count}} file(s)",
     "externalDropFailed": "Failed to copy files",
+    "addToAgent": "Add to Agent",
+    "openWithDefault": "Open with Default App",
+    "duplicate": "Duplicate",
+    "openInTerminal": "Open in Terminal",
+    "noGitChanges": "No git changes",
+    "collapseAll": "Collapse All",
+    "showAll": "Show all files",
+    "showGitChanged": "Show git changed files only",
+    "undone": "Undone: {{desc}}",
+    "undoFailed": "Cannot undo this operation",
+    "confirmDeleteTitle": "Delete \"{{name}}\"?",
+    "confirmBatchDeleteTitle": "Delete {{count}} items?",
+    "confirmDeleteFileDesc": "This will permanently delete this file.",
+    "confirmDeleteDirDesc": "This will permanently delete this folder and all its contents.",
+    "confirmBatchDeleteDesc": "This will permanently delete all selected items. This action cannot be undone for directories.",
     "teamLastSyncTooltip": "Last sync: {{time}}",
-    "teamSyncing": "Syncing…"
+    "teamSyncing": "Syncing…",
+    "duplicateFailed": "Duplicate failed",
+    "duplicated": "Duplicated",
+    "pathCopied": "Path copied",
+    "undo": "Undo: {{desc}}"
   },
   "git": {
     "modified": "Modified",
@@ -345,7 +406,12 @@
     "unpin": "Unpin",
     "loadMore": "Load More",
     "loadingMore": "Loading...",
-    "settings": "Settings"
+    "settings": "Settings",
+    "archive": "Archive",
+    "rename": "Rename",
+    "showAllSessions": "Show all sessions",
+    "showCronSessions": "Show scheduled sessions",
+    "searchWithShortcut": "Search (⌘K)"
   },
   "setup": {
     "title": "Setup Required",
@@ -356,7 +422,24 @@
     "getStarted": "Get Started",
     "continue": "Continue",
     "intro": "TeamClaw needs a few tools to work properly. Please install the missing dependencies below.",
-    "optionalHint": "{{count}} optional {{singular}} missing. You can install {{pronoun}} later from Settings."
+    "optionalHint": "{{count}} optional {{singular}} missing. You can install {{pronoun}} later from Settings.",
+    "back": "Back",
+    "customize": "Customize",
+    "customizeIntro": "Choose which dependencies to install. Required tools are pre-selected.",
+    "customizeTitle": "Select Dependencies",
+    "installAllRequired": "Install All Required",
+    "installFailed": "{{count}} failed to install",
+    "installSelected": "Install Selected",
+    "installSuccess": "{{count}} installed successfully",
+    "installing": "Installing",
+    "installingIntro": "Please wait while dependencies are being installed...",
+    "installingTitle": "Installing Dependencies",
+    "passwordPrompt": "You may be prompted for your system password by macOS to complete the Homebrew installation.",
+    "resultsIntro": "Installation has finished. See the results below.",
+    "resultsTitle": "Installation Complete",
+    "retryFailed": "Retry Failed",
+    "skip": "Skip",
+    "waitingForOutput": "Waiting for output..."
   },
   "errors": {
     "somethingWentWrong": "Something went wrong",
@@ -370,7 +453,12 @@
     "recoveryHint": "An unexpected error occurred. You can try to recover or reload the application.",
     "fileNotFound": "File not found",
     "accessDenied": "Access denied",
-    "networkError": "Network error occurred"
+    "networkError": "Network error occurred",
+    "authenticationError": "Authentication Error",
+    "error": "Error",
+    "quotaExceeded": "Quota Exceeded",
+    "rateLimited": "Rate Limited",
+    "serverError": "Server Error"
   },
   "updater": {
     "available": "Update Available",
@@ -387,7 +475,8 @@
     "isAvailable": "is available.",
     "pleaseWait": "Please wait while the update is being downloaded.",
     "restartToApply": "The update has been installed. Restart to apply changes.",
-    "updateError": "An error occurred during the update process."
+    "updateError": "An error occurred during the update process.",
+    "retry": "Retry"
   },
   "detail": {
     "searchResults": "Search Results",
@@ -484,7 +573,15 @@
       "compiled": "Compiled file",
       "design": "Design file",
       "other": "Binary file"
-    }
+    },
+    "discardChanges": "Don't Save",
+    "saveAndClose": "Save",
+    "saving": "Saving...",
+    "switchToSplitLayout": "Switch to split layout",
+    "switchToStackedLayout": "Switch to stacked layout",
+    "unsavedChangesMessage": "You have unsaved changes in this file. Do you want to save before closing?",
+    "unsavedChangesTitle": "Unsaved Changes",
+    "viewHistory": "View history"
   },
   "settings": {
     "title": "Settings",
@@ -639,7 +736,20 @@
       "disconnecting": "Disconnecting...",
       "disconnect": "Disconnect",
       "managedByTeam": "Managed by team",
-      "managedByTeamDesc": "Model configuration is managed by team admin, no personal configuration needed."
+      "managedByTeamDesc": "Model configuration is managed by team admin, no personal configuration needed.",
+      "connectDescriptionOAuth": "Connect via your browser subscription or enter an API key.",
+      "copied": "Copied!",
+      "copyCode": "Copy code",
+      "loginWithBrowser": "Login with browser",
+      "oauthPolling": "Waiting for authorization...",
+      "oauthWaiting": "Browser opened. Complete authorization and return here.",
+      "or": "or",
+      "reopenBrowser": "Re-open browser",
+      "authorizationCode": "Authorization code",
+      "authorizationCodePlaceholder": "Paste authorization code",
+      "completeAuthorization": "Complete authorization",
+      "showLess": "Show Less",
+      "showMore": "Show More"
     },
     "prompt": {
       "title": "Prompt",
@@ -791,7 +901,9 @@
       "noWorkspace": "No workspace selected",
       "inherentMCP": "Built-in MCP",
       "managedByTeamClaw": "Managed by TeamClaw",
-      "customMCP": "Custom MCP"
+      "customMCP": "Custom MCP",
+      "inherentEnvHint": "Fill them in Settings → Environment Variables, then restart OpenCode to apply.",
+      "inherentEnvNotice": "This server's environment variables are managed in Environment Variables. Configure the following variables there:"
     },
     "skills": {
       "title": "Skills",
@@ -1007,7 +1119,12 @@
           "rerankModel": "Rerank Model",
           "rerankTopKDesc": "Number of initial results to retrieve before reranking"
         }
-      }
+      },
+      "autoIndexed": "Files auto-indexed to knowledge base",
+      "configChanged": "Index configuration changed",
+      "needsReindex": "Configuration changes detected (embedding model or chunking parameters). A full re-index is required for changes to take effect.",
+      "rebuildNow": "Rebuild Now",
+      "rebuilding": "Rebuilding..."
     },
     "channels": {
       "disconnected": "Disconnected",
@@ -1412,7 +1529,34 @@
         "wizardVerifyTitle": "Connection Verified",
         "wizardVerifyDesc": "Your WeChat is connected.",
         "wizardCompleteTitle": "Setup Complete",
-        "wizardCompleteDesc": "Your WeChat channel is ready."
+        "wizardCompleteDesc": "Your WeChat channel is ready.",
+        "accountId": "Account ID",
+        "authExpired": "Login session expired",
+        "authExpiredDesc": "Please scan the QR code again to re-login.",
+        "baseUrl": "Base URL",
+        "clickToGetQr": "Click below to generate a QR code for WeChat login.",
+        "completeMessage": "Your WeChat connection is configured. Click \"Finish\" to save your settings and start using it.",
+        "connectDesc": "This wizard will connect your WeChat account via ClawBot. You'll scan a QR code with WeChat on your iPhone to log in.",
+        "connectTitle": "Connect WeChat to {{appName}}",
+        "connectionInfo": "Connection Info",
+        "gateway": "WeChat Gateway",
+        "getQrCode": "Get QR Code",
+        "iosRequired": "iPhone Required",
+        "iosRequiredDesc": "WeChat on iOS is required for QR code login",
+        "loadingQr": "Generating QR code...",
+        "loginSuccess": "Login Successful!",
+        "loginSuccessDesc": "Your WeChat account has been connected to ClawBot.",
+        "nextStepMessage": "Send a message in WeChat to test the connection!",
+        "quickSetupDesc": "Scan and connect in under a minute",
+        "reLogin": "Re-login",
+        "retry": "Retry",
+        "scanInstructions": "Open WeChat on your iPhone and scan this QR code to log in.",
+        "secure": "Secure Connection",
+        "secureDesc": "Credentials stored locally, never sent to our servers",
+        "setupDesc": "Connect your WeChat account by scanning a QR code.",
+        "setupTitle": "Set up WeChat Integration",
+        "waitingConfirm": "QR scanned — please confirm on your phone...",
+        "waitingScan": "Waiting for scan..."
       },
       "wecom": {
         "chooseMethod": "Choose Setup Method",
@@ -1431,7 +1575,30 @@
         "scanTimeout": "QR code expired. Please try again.",
         "scanError": "Failed to get QR code. Please try again or use manual input.",
         "retryQr": "Retry",
-        "switchToManual": "Switch to Manual Input"
+        "switchToManual": "Switch to Manual Input",
+        "activeSessions": "Active Sessions",
+        "botCredentials": "Bot Credentials",
+        "botId": "Bot ID",
+        "botIdPlaceholder": "Enter your WeCom bot ID",
+        "completeMessage": "Your WeCom bot is now configured. Click \"Finish\" to save your settings and start using the bot.",
+        "connectDesc": "This wizard will guide you through creating a WeCom AI bot and connecting it to {{appName}}. You'll be able to interact with AI directly from WeCom chats.",
+        "connectTitle": "Connect WeCom to {{appName}}",
+        "copyChatId": "Copy Chat ID",
+        "credentialsEntered": "Credentials entered",
+        "credentialsPortalHint": "In the WeCom Admin Console, go to your AI Bot settings:",
+        "credentialsSecretDesc": "Never share your Bot Secret. It is stored locally on your device.",
+        "credentialsSecretWarning": "Keep your credentials secret!",
+        "encodingAesKey": "Encoding AES Key",
+        "encodingAesKeyPlaceholder": "43-character key for attachment decryption",
+        "gateway": "WeCom Gateway",
+        "getQrCode": "Get QR Code",
+        "longConnection": "Long Connection",
+        "longConnectionDesc": "No public server needed, runs locally via WebSocket",
+        "nextStepMessage": "Send a message to your bot in WeCom to test!",
+        "secret": "Secret",
+        "secretPlaceholder": "Enter your WeCom bot secret",
+        "setupDesc": "Connect a WeCom AI bot to interact with AI from WeCom chats.",
+        "setupTitle": "Set up WeCom Integration"
       }
     },
     "cron": {
@@ -1509,7 +1676,14 @@
       "useWorktreeDesc": "Execute in a temporary git worktree copy",
       "worktreeBranch": "Branch",
       "worktreeBranchPlaceholder": "main",
-      "viewConversation": "View Conversation"
+      "viewConversation": "View Conversation",
+      "execution": "Execution",
+      "modelOverrideHint": "Select a model or use workspace default.",
+      "modelSelected": "Using: {{model}}",
+      "noModels": "No models configured. Please configure providers in LLM Settings first.",
+      "timeout": "Timeout (seconds)",
+      "timeoutHint": "Max time for AI to respond. Auto-aborts if exceeded (30-900s, default 180s).",
+      "useDefaultModel": "Use default model"
     },
     "team": {
       "checkingWorkspace": "Checking workspace...",
@@ -1677,6 +1851,7 @@
       "syncPrecheckDesc": "About to sync {{count}} new files, {{size}} total. Confirm to continue.",
       "syncPrecheckMore": "… and {{count}} more files",
       "syncPrecheckTitle": "Large number of new files detected",
+      "syncPrecheckToast": "Detected {{count}} large new files to sync. Confirm in Settings > Team.",
       "teamCreatedDesc": "Share these credentials with your team members so they can join.",
       "teamCreatedDescInvite": "Share the invite code below with your team members — they just paste it to join.",
       "teamCreatedTitle": "Team Created Successfully",
@@ -1758,7 +1933,8 @@
       "approveFailed": "Approval failed: {{error}}",
       "restoreComplete": "Restore complete: {{count}} files restored",
       "restoreFailed": "Restore failed: {{error}}",
-      "noVersionHistory": "No file version records"
+      "noVersionHistory": "No file version records",
+      "p2pConfiguredNotConnected": "Team is configured but not connected. Peers may be offline or unreachable."
     },
     "deps": {
       "copied": "Copied!",
@@ -1771,7 +1947,11 @@
       "installedCount": "{{installed}}/{{total}} installed",
       "recheck": "Re-check",
       "required": "Required",
-      "optional": "Optional"
+      "optional": "Optional",
+      "install": "Install",
+      "installed": "Installed",
+      "installing": "Installing...",
+      "retry": "Retry"
     },
     "plugins": {
       "title": "Plugins",
@@ -1853,8 +2033,22 @@
       "error": {
         "keyRequired": "Key is required",
         "valueRequired": "Value is required",
-        "invalidKey": "Key must contain only letters, digits, and underscores"
-      }
+        "invalidKey": "Key must contain only letters, digits, and underscores",
+        "invalidKeyShared": "Shared key must be lowercase letters, digits, underscores (max 64 chars)"
+      },
+      "configChanged": "Environment Variables Changed",
+      "hideValue": "Hide value",
+      "hintTeam": "Team variables are encrypted and synced to all team members. They cannot be viewed after saving.",
+      "needRestart": "Need restart",
+      "notConfigured": "Not configured",
+      "restart": "Restart OpenCode",
+      "restartToApply": "Restart OpenCode to apply the new environment variables to MCP servers.",
+      "scopePersonal": "Personal",
+      "scopeSystem": "System",
+      "scopeTeam": "Team",
+      "shareHint": "This variable will be encrypted and synced to all team members.",
+      "shareWithTeam": "Share with team",
+      "showValue": "Show value"
     },
     "shortcuts": {
       "title": "Shortcuts",
@@ -1947,7 +2141,59 @@
       "totalSkills_other": "{{count}} skills",
       "topSkills": "Top Skills This Team",
       "calls": "calls",
-      "usedBy": "{{n}} members"
+      "usedBy": "{{n}} members",
+      "totalSkills": "{{count}} skills"
+    },
+    "permissions": {
+      "allow": "Allow",
+      "allowDesc": "Auto-approve without prompting",
+      "allowlist": "Command Allowlist",
+      "allowlistDesc": "Commands marked as \"Always Allow\". Takes effect after agent restart.",
+      "ask": "Ask",
+      "askDesc": "Prompt for approval each time",
+      "config": "Permission Configuration",
+      "configDesc": "Configure default permission policies for agent tools",
+      "configInfo": "Permission Actions",
+      "deny": "Deny",
+      "denyDesc": "Block the action",
+      "desc": "Manage agent permissions and command allowlist",
+      "noAllowlist": "No commands have been allowlisted yet",
+      "noWorkspace": "No workspace selected. Please select a workspace first.",
+      "saveAndApply": "Save & Apply",
+      "saving": "Applying...",
+      "title": "Permission Management"
+    },
+    "sharedSecrets": {
+      "add": "Add Secret",
+      "addDescription": "Add a new shared secret that will be encrypted and synced across your team.",
+      "addFirst": "Add Your First Secret",
+      "addTitle": "Add Shared Secret",
+      "category": "Category",
+      "count": "{{count}} secret(s) stored",
+      "delete": "Delete",
+      "deleteDescription": "Are you sure you want to delete \"{{key}}\"? This will remove the secret from disk and cannot be undone.",
+      "deleteTitle": "Delete Shared Secret",
+      "description": "Description",
+      "descriptionPlaceholder": "e.g. OpenAI API key for the team",
+      "edit": "Edit",
+      "editDescription": "Update the value for this shared secret. The new value will be synced to all team members.",
+      "editTitle": "Edit Shared Secret",
+      "emptyDescription": "Share encrypted secrets with your team. Values are encrypted using the team key and synced via P2P.",
+      "emptyTitle": "No shared secrets yet",
+      "error": {
+        "invalidKey": "Key ID must contain only lowercase letters, digits, and underscores",
+        "keyRequired": "Key ID is required",
+        "valueRequired": "Value is required"
+      },
+      "hintBody": "Secrets are encrypted using your team's shared key and stored as .enc.json files. They are synced to all team members via P2P and OSS. Values are write-only — they cannot be viewed after saving.",
+      "hintTitle": "How it works",
+      "keyId": "Key ID",
+      "on": "on",
+      "optional": "optional",
+      "sectionDescription": "Encrypted secrets shared across your team — synced via P2P and stored on disk",
+      "title": "Shared Secrets",
+      "updatedBy": "Updated by",
+      "value": "Value"
     }
   },
   "skillssh": {
@@ -1996,7 +2242,19 @@
     "installed": "Installed",
     "installSkill": "Install Skill",
     "installSkillDesc": "Choose where to install",
-    "viewOnGitHub": "View on GitHub"
+    "viewOnGitHub": "View on GitHub",
+    "allUpToDate": "All skills are up to date",
+    "checkUpdates": "Check Updates",
+    "installFromSource": "Install from Source",
+    "installFromSourceDesc": "Install skills via npx skills add — supports GitHub shorthand (owner/repo), full URLs, and direct skill paths",
+    "manageDesc": "Check for updates or update all installed skills via npx skills",
+    "manageInstalled": "Manage Installed Skills",
+    "reinstall": "Reinstall",
+    "sourcePlaceholder": "owner/repo or https://github.com/owner/repo",
+    "sourceRequired": "Please enter a source (owner/repo or URL)",
+    "supportedFormats": "Supported formats:",
+    "uninstall": "Uninstall",
+    "updateAll": "Update All"
   },
   "knowledge": {
     "stats": {
@@ -2051,13 +2309,152 @@
       "startWatcherFailed": "Failed to start file watcher",
       "watcherStopped": "File watcher stopped",
       "stopWatcherFailed": "Failed to stop file watcher"
+    },
+    "gitSync": "Sync Team"
+  },
+  "versionHistory": {
+    "title": "Version history",
+    "fileList": "File list",
+    "selectFilePrompt": "Select a file from the left",
+    "docType": {
+      "skill": "Skills",
+      "mcp": "MCP",
+      "knowledge": "Knowledge",
+      "meta": "Meta"
+    },
+    "filterAll": "All",
+    "noFiles": "No files",
+    "versionCount": "{{count}} version",
+    "versionCount_plural": "{{count}} versions",
+    "currentVersion": "Current version",
+    "currentFile": "Current file",
+    "historicalVersionsTitle": "Historical versions",
+    "noHistoricalVersions": "No historical versions",
+    "versionLabel": "Version {{number}}",
+    "selectVersionPrompt": "Select a historical version",
+    "contentTab": "Content",
+    "diffTab": "Compare with current",
+    "restoring": "Restoring...",
+    "restoreThisVersion": "Restore this version",
+    "restoreTitle": "Restore this version?",
+    "restoreDescription": "The file will be restored to the local draft and will not sync to the team immediately. This change will be pushed automatically on the next sync.",
+    "confirmRestore": "Restore",
+    "currentContentUnavailable": "Current content is unavailable"
+  },
+  "telemetry": {
+    "consent": {
+      "title": "Help improve {{appName}}",
+      "description": "Allow {{appName}} to collect anonymous usage data to help us improve agent quality.",
+      "collectTitle": "Collected",
+      "collectDescription": "Session duration, token usage, tool call statistics, feedback ratings, and model information",
+      "neverCollectTitle": "Never collected",
+      "neverCollectDescription": "Conversation content, code, file paths, project names, or personal information",
+      "changeAnytimeTitle": "Change anytime",
+      "changeAnytimeDescription": "You can turn this off anytime in Settings > System > Privacy & Telemetry",
+      "deny": "Not now",
+      "allow": "Allow analytics"
+    },
+    "rating": {
+      "question": "How was this result?",
+      "starLabel": "{{count}} star",
+      "starLabel_plural": "{{count}} stars"
     }
+  },
+  "nodeStatus": {
+    "connected": "Connected",
+    "degraded": "Degraded",
+    "reconnecting": "Reconnecting...",
+    "disconnected": "Disconnected",
+    "online": "Online",
+    "unknown": "Unknown",
+    "thisDevice": "This device",
+    "engine": "Engine",
+    "restarts": "Restarts",
+    "lastSync": "Last sync",
+    "syncedFiles": "Synced files",
+    "pendingFiles": "Pending files",
+    "teamMembers": "{{count}} team member",
+    "teamMembers_plural": "{{count}} team members",
+    "staleSeconds": "Stale {{count}}s",
+    "staleMinutes": "Stale {{count}}m",
+    "offlineSeconds": "Offline {{count}}s",
+    "offlineMinutes": "Offline {{count}}m",
+    "offlineHours": "Offline {{count}}h",
+    "secondsAgo": "{{count}}s ago",
+    "minutesAgoShort": "{{count}}m ago",
+    "hoursAgoShort": "{{count}}h ago",
+    "daysAgoShort": "{{count}}d ago"
   },
   "shortcuts": {
     "personal": "Personal",
     "team": "Team",
+    "newShortcut": "New Shortcut",
     "refreshTeam": "Refresh Team Shortcuts",
     "configure": "Configure Personal Shortcuts",
-    "configurePersonal": "Configure Personal Shortcuts"
+    "configurePersonal": "Configure Personal Shortcuts",
+    "backToSidebar": "Back to sidebar"
+  },
+  "clawhub": {
+    "author": "Author",
+    "changelog": "Changelog",
+    "downloads": "downloads",
+    "empty": "No skills available",
+    "emptyHint": "Check back later for new skills",
+    "install": "Install",
+    "installed": "Installed",
+    "loadMore": "Load More",
+    "malwareBlocked": "This skill is flagged as malware and cannot be installed.",
+    "noResults": "No skills found",
+    "noResultsHint": "Try different search terms",
+    "refresh": "Refresh",
+    "searchPlaceholder": "Search ClawHub skills...",
+    "stars": "stars",
+    "suspicious": "This skill is flagged as suspicious. Review carefully before installing.",
+    "uninstall": "Uninstall",
+    "update": "Update",
+    "updated": "Updated",
+    "version": "Version",
+    "viewOnClawHub": "View on ClawHub"
+  },
+  "diff": {
+    "agentActions": "Agent Actions",
+    "clickToCopy": "Click to copy path",
+    "collapseAll": "Collapse all",
+    "expandAll": "Expand all",
+    "explainChange": "Explain Change",
+    "generatePatch": "Generate Patch",
+    "openFile": "Open File",
+    "pathCopied": "Path copied",
+    "revertFailed": "Failed to revert file",
+    "revertFile": "Revert File",
+    "reverted": "File reverted",
+    "reviewCode": "Review Code",
+    "suggestRefactor": "Suggest Refactor"
+  },
+  "editor": {
+    "acceptAgent": "Accept Agent",
+    "conflictMessage": "Agent modified this file. You have unsaved changes.",
+    "documentRewrittenByAgent": "Document rewritten by agent",
+    "imagePasteFailed": "Failed to upload image",
+    "keepMine": "Keep Mine",
+    "uploadingImage": "Uploading image...",
+    "viewDiff": "View Diff"
+  },
+  "mainContent": {
+    "selectShortcut": "Select a shortcut to get started"
+  },
+  "history": {
+    "loadCommitContentFailed": "Unable to load content for this commit ({{sha}})",
+    "noFileHistory": "This file has no commit history yet",
+    "diffSkippedTooLarge": "File is too large or binary, skipping diff"
+  },
+  "dynamicUi": {
+    "generating": "Generating interface..."
+  },
+  "nativeContent": {
+    "notFound": "Component not found"
+  },
+  "team": {
+    "viewerReadOnly": "Read-only mode — you don't have edit permissions"
   }
 }

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -43,7 +43,11 @@
     "daysAgo": "{{count}} 天前",
     "daysAgo_plural": "{{count}} 天前",
     "refresh": "刷新",
-    "or": "或"
+    "or": "或",
+    "dismiss": "忽略",
+    "more": "更多",
+    "showLess": "收起",
+    "showMore": "展开更多"
   },
   "navigation": {
     "home": "首页",
@@ -57,7 +61,9 @@
     "tasks": "任务",
     "session": "会话",
     "shortcuts": "快捷方式",
-    "knowledge": "文档"
+    "knowledge": "文档",
+    "hideTabs": "隐藏文件",
+    "restoreTabs": "显示文件"
   },
   "panel": {
     "tasks": {
@@ -207,14 +213,49 @@
         "submitting": "提交中...",
         "preparing": "准备中...",
         "submitAnswer": "提交回答"
-      }
+      },
+      "argCount": "{{count}} 个参数"
     },
     "voiceInputStart": "开始语音输入",
     "voiceInputStop": "停止录音",
     "voiceInputUnsupported": "语音输入不支持",
     "voiceInputPermissionDenied": "麦克风权限被拒绝",
     "voiceInputNoSession": "请先选择或创建会话",
-    "voiceInputInsertToChat": "插入到聊天"
+    "voiceInputInsertToChat": "插入到聊天",
+    "inputPlaceholderDescription": "添加描述...",
+    "inputPlaceholderMention": "输入 @ 引用文件...",
+    "inputPlaceholderQueue": "输入消息以加入队列...",
+    "newSession": "新会话",
+    "refreshMessages": "刷新消息",
+    "startingAgent": "正在启动助手...",
+    "taskRunning": "任务运行中...",
+    "voiceInputChecking": "正在检查麦克风...",
+    "voiceInputDesktopNoTranscript": "桌面应用暂不支持语音转文字。请使用 Web 版本进行语音输入。",
+    "voiceInputNoMicrophone": "未检测到麦克风",
+    "voiceInputRecognizing": "识别中...",
+    "waitingForAgent": "会话已准备好。正在等待助手运行时完成启动。",
+    "backToMainSession": "返回主会话",
+    "waitingForConfirmationShort": "待确认",
+    "newSessionBadge": "新",
+    "messageCountShort": "{{count}} 条消息",
+    "messageCountShort_plural": "{{count}} 条消息",
+    "commandPopover": {
+      "prompt": "选择角色、技能或命令",
+      "itemCount": "{{count}} 项",
+      "itemCount_plural": "{{count}} 项",
+      "noMatch": "没有匹配 \"{{query}}\" 的结果",
+      "empty": "未找到技能或命令",
+      "roles": "{{count}} 个角色",
+      "roles_plural": "{{count}} 个角色",
+      "skills": "{{count}} 个技能",
+      "skills_plural": "{{count}} 个技能",
+      "commands": "{{count}} 个命令",
+      "commands_plural": "{{count}} 个命令",
+      "navigate": "导航",
+      "select": "选择",
+      "close": "关闭",
+      "description": "说明"
+    }
   },
   "onboarding": {
     "common": {
@@ -325,7 +366,11 @@
     "confirmDeleteDirDesc": "此操作将永久删除该文件夹及其所有内容。",
     "confirmBatchDeleteDesc": "此操作将永久删除所有选中项。文件夹删除后无法撤销。",
     "teamLastSyncTooltip": "最后同步：{{time}}",
-    "teamSyncing": "同步中…"
+    "teamSyncing": "同步中…",
+    "duplicateFailed": "创建副本失败",
+    "duplicated": "已创建副本",
+    "pathCopied": "路径已复制",
+    "undo": "撤销：{{desc}}"
   },
   "git": {
     "modified": "已修改",
@@ -361,7 +406,12 @@
     "unpin": "取消固定",
     "loadMore": "加载更多",
     "loadingMore": "加载中...",
-    "settings": "设置"
+    "settings": "设置",
+    "archive": "归档",
+    "rename": "重命名",
+    "showAllSessions": "显示全部会话",
+    "showCronSessions": "显示定时会话",
+    "searchWithShortcut": "搜索 (⌘K)"
   },
   "setup": {
     "title": "需要设置",
@@ -372,7 +422,24 @@
     "getStarted": "开始使用",
     "continue": "继续",
     "intro": "TeamClaw 需要一些工具才能正常工作。请安装以下缺失的依赖项。",
-    "optionalHint": "缺少 {{count}} 个可选{{singular}}。您可以从设置中稍后安装{{pronoun}}。"
+    "optionalHint": "缺少 {{count}} 个可选{{singular}}。您可以从设置中稍后安装{{pronoun}}。",
+    "back": "返回",
+    "customize": "自定义",
+    "customizeIntro": "选择要安装的依赖。必需工具已预先选中。",
+    "customizeTitle": "选择依赖",
+    "installAllRequired": "安装所有必需项",
+    "installFailed": "{{count}} 项安装失败",
+    "installSelected": "安装所选项",
+    "installSuccess": "{{count}} 项已成功安装",
+    "installing": "安装中",
+    "installingIntro": "正在安装依赖，请稍候...",
+    "installingTitle": "正在安装依赖",
+    "passwordPrompt": "macOS 可能会要求输入系统密码，以完成 Homebrew 安装。",
+    "resultsIntro": "安装已完成。请查看下方结果。",
+    "resultsTitle": "安装完成",
+    "retryFailed": "重试失败项",
+    "skip": "跳过",
+    "waitingForOutput": "等待输出..."
   },
   "errors": {
     "somethingWentWrong": "出了点问题",
@@ -386,7 +453,12 @@
     "recoveryHint": "发生了意外错误。您可以尝试恢复或重新加载应用程序。",
     "fileNotFound": "文件未找到",
     "accessDenied": "访问被拒绝",
-    "networkError": "发生网络错误"
+    "networkError": "发生网络错误",
+    "authenticationError": "认证错误",
+    "error": "错误",
+    "quotaExceeded": "额度已用尽",
+    "rateLimited": "请求频率受限",
+    "serverError": "服务器错误"
   },
   "updater": {
     "available": "有可用更新",
@@ -403,7 +475,8 @@
     "isAvailable": "可用。",
     "pleaseWait": "请等待更新下载完成。",
     "restartToApply": "更新已安装。请重启以应用更改。",
-    "updateError": "更新过程中发生错误。"
+    "updateError": "更新过程中发生错误。",
+    "retry": "重试"
   },
   "detail": {
     "searchResults": "搜索结果",
@@ -500,7 +573,15 @@
       "compiled": "编译文件",
       "design": "设计文件",
       "other": "二进制文件"
-    }
+    },
+    "discardChanges": "不保存",
+    "saveAndClose": "保存",
+    "saving": "保存中...",
+    "switchToSplitLayout": "切换到分栏布局",
+    "switchToStackedLayout": "切换到堆叠布局",
+    "unsavedChangesMessage": "此文件有未保存的更改。关闭前要保存吗？",
+    "unsavedChangesTitle": "未保存的更改",
+    "viewHistory": "查看历史"
   },
   "settings": {
     "title": "设置",
@@ -655,7 +736,20 @@
       "disconnecting": "断开中...",
       "disconnect": "断开连接",
       "managedByTeam": "由团队统一管理",
-      "managedByTeamDesc": "当前配置由团队管理员统一设置，无需个人配置。"
+      "managedByTeamDesc": "当前配置由团队管理员统一设置，无需个人配置。",
+      "connectDescriptionOAuth": "通过浏览器订阅连接，或输入 API Key。",
+      "copied": "已复制！",
+      "copyCode": "复制代码",
+      "loginWithBrowser": "用浏览器登录",
+      "oauthPolling": "正在等待授权...",
+      "oauthWaiting": "浏览器已打开。完成授权后回到这里。",
+      "or": "或",
+      "reopenBrowser": "重新打开浏览器",
+      "authorizationCode": "授权码",
+      "authorizationCodePlaceholder": "粘贴授权码",
+      "completeAuthorization": "完成授权",
+      "showLess": "收起",
+      "showMore": "显示更多"
     },
     "prompt": {
       "title": "提示词",
@@ -807,7 +901,9 @@
       "noWorkspace": "未选择工作区",
       "inherentMCP": "内置 MCP",
       "managedByTeamClaw": "由 TeamClaw 管理",
-      "customMCP": "自定义 MCP"
+      "customMCP": "自定义 MCP",
+      "inherentEnvHint": "在“设置 → 环境变量”中填写后，重启 OpenCode 即可生效。",
+      "inherentEnvNotice": "此服务器的环境变量由“环境变量”设置统一管理，请前往配置以下变量："
     },
     "skills": {
       "title": "技能",
@@ -1023,7 +1119,12 @@
           "rerankModel": "Rerank 模型",
           "rerankTopKDesc": "重排序前获取的初始结果数量"
         }
-      }
+      },
+      "autoIndexed": "文件已自动索引到知识库",
+      "configChanged": "索引配置已更改",
+      "needsReindex": "检测到配置变更（嵌入模型或分块参数）。需要完整重建索引后变更才会生效。",
+      "rebuildNow": "立即重建",
+      "rebuilding": "重建中..."
     },
     "channels": {
       "disconnected": "断开连接",
@@ -1428,7 +1529,34 @@
         "wizardVerifyTitle": "连接已验证",
         "wizardVerifyDesc": "微信已成功连接。",
         "wizardCompleteTitle": "设置完成",
-        "wizardCompleteDesc": "微信渠道已就绪。"
+        "wizardCompleteDesc": "微信渠道已就绪。",
+        "accountId": "账号 ID",
+        "authExpired": "登录会话已过期",
+        "authExpiredDesc": "请重新扫描二维码登录。",
+        "baseUrl": "基础 URL",
+        "clickToGetQr": "点击下方按钮生成微信登录二维码。",
+        "completeMessage": "微信连接已配置。点击“完成”保存设置并开始使用。",
+        "connectDesc": "此向导将通过 ClawBot 连接你的微信账号。你需要用 iPhone 上的微信扫描二维码登录。",
+        "connectTitle": "将微信连接到 {{appName}}",
+        "connectionInfo": "连接信息",
+        "gateway": "微信网关",
+        "getQrCode": "获取二维码",
+        "iosRequired": "需要 iPhone",
+        "iosRequiredDesc": "二维码登录需要 iOS 版微信",
+        "loadingQr": "正在生成二维码...",
+        "loginSuccess": "登录成功！",
+        "loginSuccessDesc": "你的微信账号已连接到 ClawBot。",
+        "nextStepMessage": "在微信中发送一条消息来测试连接！",
+        "quickSetupDesc": "一分钟内扫码完成连接",
+        "reLogin": "重新登录",
+        "retry": "重试",
+        "scanInstructions": "打开 iPhone 上的微信，扫描此二维码登录。",
+        "secure": "安全连接",
+        "secureDesc": "凭证仅保存在本地，不会发送到我们的服务器",
+        "setupDesc": "通过扫描二维码连接你的微信账号。",
+        "setupTitle": "设置微信集成",
+        "waitingConfirm": "已扫码，请在手机上确认...",
+        "waitingScan": "等待扫码..."
       },
       "wecom": {
         "chooseMethod": "选择接入方式",
@@ -1447,7 +1575,30 @@
         "scanTimeout": "二维码已过期，请重试。",
         "scanError": "获取二维码失败，请重试或使用手动输入。",
         "retryQr": "重试",
-        "switchToManual": "切换为手动输入"
+        "switchToManual": "切换为手动输入",
+        "activeSessions": "活跃会话",
+        "botCredentials": "机器人凭证",
+        "botId": "机器人 ID",
+        "botIdPlaceholder": "输入企业微信机器人 ID",
+        "completeMessage": "企业微信机器人已配置。点击“完成”保存设置并开始使用。",
+        "connectDesc": "此向导将引导你创建企业微信 AI 机器人并连接到 {{appName}}。之后你可以直接在企业微信聊天中与 AI 互动。",
+        "connectTitle": "将企业微信连接到 {{appName}}",
+        "copyChatId": "复制聊天 ID",
+        "credentialsEntered": "凭证已填写",
+        "credentialsPortalHint": "在企业微信管理后台中，进入你的 AI 机器人设置：",
+        "credentialsSecretDesc": "请勿分享 Bot Secret。它会保存在你的本机设备上。",
+        "credentialsSecretWarning": "请妥善保管你的凭证！",
+        "encodingAesKey": "Encoding AES Key",
+        "encodingAesKeyPlaceholder": "用于附件解密的 43 位密钥",
+        "gateway": "企业微信网关",
+        "getQrCode": "获取二维码",
+        "longConnection": "长连接",
+        "longConnectionDesc": "无需公网服务器，通过本地 WebSocket 运行",
+        "nextStepMessage": "在企业微信中给机器人发消息进行测试！",
+        "secret": "Secret",
+        "secretPlaceholder": "输入企业微信机器人 Secret",
+        "setupDesc": "连接企业微信 AI 机器人，以便在企业微信聊天中与 AI 互动。",
+        "setupTitle": "设置企业微信集成"
       }
     },
     "cron": {
@@ -1525,7 +1676,14 @@
       "useWorktreeDesc": "在临时 git worktree 副本中执行",
       "worktreeBranch": "分支",
       "worktreeBranchPlaceholder": "main",
-      "viewConversation": "查看对话"
+      "viewConversation": "查看对话",
+      "execution": "执行",
+      "modelOverrideHint": "选择一个模型，或使用工作区默认模型。",
+      "modelSelected": "使用：{{model}}",
+      "noModels": "未配置模型。请先在 LLM 设置中配置提供商。",
+      "timeout": "超时（秒）",
+      "timeoutHint": "AI 响应的最长时间。超过后自动中止（30-900 秒，默认 180 秒）。",
+      "useDefaultModel": "使用默认模型"
     },
     "team": {
       "checkingWorkspace": "检查工作区...",
@@ -1693,6 +1851,7 @@
       "syncPrecheckDesc": "即将同步 {{count}} 个新文件，共 {{size}}。请确认是否继续。",
       "syncPrecheckMore": "… 及另外 {{count}} 个文件",
       "syncPrecheckTitle": "检测到较多新文件",
+      "syncPrecheckToast": "检测到 {{count}} 个较大的新文件待同步，请在设置 > 团队中确认。",
       "teamCreatedDesc": "将这些凭据分享给团队成员以便加入。",
       "teamCreatedDescInvite": "将下方邀请码分享给团队成员 — 粘贴即可加入。",
       "teamCreatedTitle": "团队创建成功",
@@ -1774,7 +1933,8 @@
       "approveFailed": "审批失败: {{error}}",
       "restoreComplete": "恢复完成: {{count}} 个文件已恢复",
       "restoreFailed": "恢复失败: {{error}}",
-      "noVersionHistory": "暂无文件版本记录"
+      "noVersionHistory": "暂无文件版本记录",
+      "p2pConfiguredNotConnected": "团队已配置但尚未连接。成员可能离线或无法访问。"
     },
     "deps": {
       "copied": "已复制！",
@@ -1787,7 +1947,11 @@
       "installedCount": "{{installed}}/{{total}} 已安装",
       "recheck": "重新检查",
       "required": "必需",
-      "optional": "可选"
+      "optional": "可选",
+      "install": "安装",
+      "installed": "已安装",
+      "installing": "安装中...",
+      "retry": "重试"
     },
     "plugins": {
       "title": "插件",
@@ -1869,8 +2033,22 @@
       "error": {
         "keyRequired": "键名不能为空",
         "valueRequired": "值不能为空",
-        "invalidKey": "键名只能包含字母、数字和下划线"
-      }
+        "invalidKey": "键名只能包含字母、数字和下划线",
+        "invalidKeyShared": "共享变量名只能包含小写字母、数字和下划线（最多 64 个字符）"
+      },
+      "configChanged": "环境变量已更改",
+      "hideValue": "隐藏值",
+      "hintTeam": "团队变量会加密并同步给所有团队成员。保存后无法查看其值。",
+      "needRestart": "需要重启",
+      "notConfigured": "未配置",
+      "restart": "重启 OpenCode",
+      "restartToApply": "重启 OpenCode 以将新的环境变量应用到 MCP 服务器。",
+      "scopePersonal": "个人",
+      "scopeSystem": "系统",
+      "scopeTeam": "团队",
+      "shareHint": "此变量将被加密并同步给所有团队成员。",
+      "shareWithTeam": "与团队共享",
+      "showValue": "显示值"
     },
     "shortcuts": {
       "title": "快捷方式",
@@ -1959,10 +2137,63 @@
       "you": "你",
       "skillRank": "Skill 排名",
       "skillInvocations": "Skill 调用",
+      "totalSkills_one": "{{count}} 次 skill",
       "totalSkills_other": "{{count}} 次 skill",
       "topSkills": "团队最常用 Skills",
       "calls": "次",
-      "usedBy": "{{n}} 人用过"
+      "usedBy": "{{n}} 人用过",
+      "totalSkills": "{{count}} 个技能"
+    },
+    "permissions": {
+      "allow": "允许",
+      "allowDesc": "无需提示，自动批准",
+      "allowlist": "命令白名单",
+      "allowlistDesc": "标记为“始终允许”的命令。助手重启后生效。",
+      "ask": "询问",
+      "askDesc": "每次都提示审批",
+      "config": "权限配置",
+      "configDesc": "配置助手工具的默认权限策略",
+      "configInfo": "权限操作",
+      "deny": "拒绝",
+      "denyDesc": "阻止此操作",
+      "desc": "管理助手权限和命令白名单",
+      "noAllowlist": "尚未将任何命令加入白名单",
+      "noWorkspace": "未选择工作区。请先选择一个工作区。",
+      "saveAndApply": "保存并应用",
+      "saving": "应用中...",
+      "title": "权限管理"
+    },
+    "sharedSecrets": {
+      "add": "添加密钥",
+      "addDescription": "添加一个新的共享密钥，它会被加密并同步到团队中。",
+      "addFirst": "添加第一个密钥",
+      "addTitle": "添加共享密钥",
+      "category": "类别",
+      "count": "已存储 {{count}} 个密钥",
+      "delete": "删除",
+      "deleteDescription": "确定要删除“{{key}}”吗？这会从磁盘移除该密钥，且无法撤销。",
+      "deleteTitle": "删除共享密钥",
+      "description": "描述",
+      "descriptionPlaceholder": "例如：团队使用的 OpenAI API Key",
+      "edit": "编辑",
+      "editDescription": "更新此共享密钥的值。新值会同步给所有团队成员。",
+      "editTitle": "编辑共享密钥",
+      "emptyDescription": "与团队共享加密密钥。值会使用团队密钥加密，并通过 P2P 同步。",
+      "emptyTitle": "暂无共享密钥",
+      "error": {
+        "invalidKey": "Key ID 只能包含小写字母、数字和下划线",
+        "keyRequired": "Key ID 为必填项",
+        "valueRequired": "值为必填项"
+      },
+      "hintBody": "密钥会使用团队共享密钥加密，并以 .enc.json 文件存储。它们会通过 P2P 和 OSS 同步给所有团队成员。值为只写，保存后无法查看。",
+      "hintTitle": "工作方式",
+      "keyId": "Key ID",
+      "on": "于",
+      "optional": "可选",
+      "sectionDescription": "团队共享的加密密钥，通过 P2P 同步并存储在磁盘上",
+      "title": "共享密钥",
+      "updatedBy": "更新者",
+      "value": "值"
     }
   },
   "skillssh": {
@@ -2011,7 +2242,19 @@
     "installed": "已安装",
     "installSkill": "安装技能",
     "installSkillDesc": "选择安装位置",
-    "viewOnGitHub": "在 GitHub 上查看"
+    "viewOnGitHub": "在 GitHub 上查看",
+    "allUpToDate": "所有技能都是最新的",
+    "checkUpdates": "检查更新",
+    "installFromSource": "从来源安装",
+    "installFromSourceDesc": "通过 npx skills add 安装技能，支持 GitHub 简写（owner/repo）、完整 URL 和直接技能路径",
+    "manageDesc": "通过 npx skills 检查更新或更新所有已安装技能",
+    "manageInstalled": "管理已安装技能",
+    "reinstall": "重新安装",
+    "sourcePlaceholder": "owner/repo 或 https://github.com/owner/repo",
+    "sourceRequired": "请输入来源（owner/repo 或 URL）",
+    "supportedFormats": "支持的格式：",
+    "uninstall": "卸载",
+    "updateAll": "全部更新"
   },
   "knowledge": {
     "stats": {
@@ -2066,13 +2309,152 @@
       "startWatcherFailed": "启动文件监控失败",
       "watcherStopped": "文件监控已停止",
       "stopWatcherFailed": "停止文件监控失败"
+    },
+    "gitSync": "同步团队"
+  },
+  "versionHistory": {
+    "title": "版本历史",
+    "fileList": "文件列表",
+    "selectFilePrompt": "请从左侧选择文件",
+    "docType": {
+      "skill": "技能",
+      "mcp": "MCP",
+      "knowledge": "知识库",
+      "meta": "元数据"
+    },
+    "filterAll": "全部",
+    "noFiles": "暂无文件",
+    "versionCount": "{{count}} 个版本",
+    "versionCount_plural": "{{count}} 个版本",
+    "currentVersion": "当前版本",
+    "currentFile": "当前文件",
+    "historicalVersionsTitle": "历史版本",
+    "noHistoricalVersions": "暂无历史版本",
+    "versionLabel": "版本 {{number}}",
+    "selectVersionPrompt": "请选择一个历史版本",
+    "contentTab": "内容",
+    "diffTab": "与当前对比",
+    "restoring": "恢复中...",
+    "restoreThisVersion": "恢复此版本",
+    "restoreTitle": "恢复此版本？",
+    "restoreDescription": "文件将恢复到本地草稿，不会立即同步给团队。下次同步时，此变更将自动推送。",
+    "confirmRestore": "确认恢复",
+    "currentContentUnavailable": "当前内容不可用"
+  },
+  "telemetry": {
+    "consent": {
+      "title": "帮助改善 {{appName}}",
+      "description": "允许 {{appName}} 收集匿名使用数据，帮助我们改善 Agent 质量。",
+      "collectTitle": "收集内容",
+      "collectDescription": "会话时长、Token 消耗、工具调用统计、反馈评分、模型信息",
+      "neverCollectTitle": "绝不收集",
+      "neverCollectDescription": "对话内容、代码、文件路径、项目名称、个人信息",
+      "changeAnytimeTitle": "随时可改",
+      "changeAnytimeDescription": "可在设置 > 系统 > 隐私与遥测中随时关闭",
+      "deny": "暂不开启",
+      "allow": "允许分析"
+    },
+    "rating": {
+      "question": "这次结果怎么样？",
+      "starLabel": "{{count}} 星",
+      "starLabel_plural": "{{count}} 星"
     }
+  },
+  "nodeStatus": {
+    "connected": "已连接",
+    "degraded": "连接异常",
+    "reconnecting": "重连中...",
+    "disconnected": "未连接",
+    "online": "在线",
+    "unknown": "未知",
+    "thisDevice": "本机",
+    "engine": "引擎",
+    "restarts": "重启次数",
+    "lastSync": "上次同步",
+    "syncedFiles": "已同步文件",
+    "pendingFiles": "待同步文件",
+    "teamMembers": "{{count}} 位团队成员",
+    "teamMembers_plural": "{{count}} 位团队成员",
+    "staleSeconds": "{{count}} 秒未响应",
+    "staleMinutes": "{{count}} 分钟未响应",
+    "offlineSeconds": "离线 {{count}} 秒",
+    "offlineMinutes": "离线 {{count}} 分钟",
+    "offlineHours": "离线 {{count}} 小时",
+    "secondsAgo": "{{count}} 秒前",
+    "minutesAgoShort": "{{count}} 分钟前",
+    "hoursAgoShort": "{{count}} 小时前",
+    "daysAgoShort": "{{count}} 天前"
   },
   "shortcuts": {
     "personal": "个人",
     "team": "团队",
+    "newShortcut": "新建快捷方式",
     "refreshTeam": "刷新团队快捷方式",
     "configure": "设置个人收藏",
-    "configurePersonal": "设置个人收藏"
+    "configurePersonal": "设置个人收藏",
+    "backToSidebar": "返回侧边栏"
+  },
+  "clawhub": {
+    "author": "作者",
+    "changelog": "更新日志",
+    "downloads": "下载",
+    "empty": "暂无可用技能",
+    "emptyHint": "稍后再来查看新技能",
+    "install": "安装",
+    "installed": "已安装",
+    "loadMore": "加载更多",
+    "malwareBlocked": "此技能被标记为恶意软件，无法安装。",
+    "noResults": "未找到技能",
+    "noResultsHint": "试试其他搜索词",
+    "refresh": "刷新",
+    "searchPlaceholder": "搜索 ClawHub 技能...",
+    "stars": "星标",
+    "suspicious": "此技能被标记为可疑。安装前请仔细检查。",
+    "uninstall": "卸载",
+    "update": "更新",
+    "updated": "已更新",
+    "version": "版本",
+    "viewOnClawHub": "在 ClawHub 上查看"
+  },
+  "diff": {
+    "agentActions": "助手操作",
+    "clickToCopy": "点击复制路径",
+    "collapseAll": "全部折叠",
+    "expandAll": "全部展开",
+    "explainChange": "解释变更",
+    "generatePatch": "生成补丁",
+    "openFile": "打开文件",
+    "pathCopied": "路径已复制",
+    "revertFailed": "还原文件失败",
+    "revertFile": "还原文件",
+    "reverted": "文件已还原",
+    "reviewCode": "审查代码",
+    "suggestRefactor": "建议重构"
+  },
+  "editor": {
+    "acceptAgent": "接受助手版本",
+    "conflictMessage": "助手修改了此文件，而你还有未保存的更改。",
+    "documentRewrittenByAgent": "文档已被助手重写",
+    "imagePasteFailed": "图片上传失败",
+    "keepMine": "保留我的版本",
+    "uploadingImage": "正在上传图片...",
+    "viewDiff": "查看差异"
+  },
+  "mainContent": {
+    "selectShortcut": "选择一个快捷方式开始"
+  },
+  "history": {
+    "loadCommitContentFailed": "无法加载该提交的内容 ({{sha}})",
+    "noFileHistory": "该文件还没有提交历史",
+    "diffSkippedTooLarge": "文件过大或为二进制，跳过 diff"
+  },
+  "dynamicUi": {
+    "generating": "正在生成界面..."
+  },
+  "nativeContent": {
+    "notFound": "组件未找到"
+  },
+  "team": {
+    "viewerReadOnly": "只读模式 - 你没有编辑权限"
   }
 }


### PR DESCRIPTION
## Summary
- Restrict advertised frontend languages to locales with resources and guard unsupported VITE_LOCALE values.
- Fill missing en/zh-CN keys and move high-visibility UI text behind i18n translations.
- Add locale coverage tests for key parity, statically referenced translation keys, and rendered text in high-visibility components.

## Test Plan
- [x] pnpm exec vitest run src/lib/__tests__/locale.test.ts src/__tests__/i18n.test.ts
- [x] pnpm typecheck