### PR TITLE
fix(chat): render question prompts as markdown

### DIFF
--- a/packages/app/src/components/chat/QuestionInputDock.tsx
+++ b/packages/app/src/components/chat/QuestionInputDock.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Check, CornerDownLeft, ChevronLeft, ChevronRight } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -19,6 +21,83 @@ function getOptionValue(option: { label: string; value?: string }) {
 
 function getQuestionId(question: { id?: string }, index: number) {
   return question.id || String(index);
+}
+
+const questionMarkdownPlugins = [remarkGfm];
+
+const questionMarkdownComponents = {
+  h1: ({ children }: { children?: React.ReactNode }) => (
+    <h1 className="mb-1.5 mt-2 text-base font-semibold leading-6 text-foreground first:mt-0">{children}</h1>
+  ),
+  h2: ({ children }: { children?: React.ReactNode }) => (
+    <h2 className="mb-1.5 mt-2 text-[15px] font-semibold leading-6 text-foreground first:mt-0">{children}</h2>
+  ),
+  h3: ({ children }: { children?: React.ReactNode }) => (
+    <h3 className="mb-1.5 mt-2 text-sm font-semibold leading-5 text-foreground first:mt-0">{children}</h3>
+  ),
+  p: ({ children }: { children?: React.ReactNode }) => (
+    <p className="my-1.5 leading-5 first:mt-0 last:mb-0">{children}</p>
+  ),
+  ul: ({ children }: { children?: React.ReactNode }) => (
+    <ul className="my-1.5 list-disc space-y-1 pl-5 first:mt-0 last:mb-0">{children}</ul>
+  ),
+  ol: ({ children }: { children?: React.ReactNode }) => (
+    <ol className="my-1.5 list-decimal space-y-1 pl-5 first:mt-0 last:mb-0">{children}</ol>
+  ),
+  li: ({ children }: { children?: React.ReactNode }) => (
+    <li className="pl-0.5 leading-5">{children}</li>
+  ),
+  blockquote: ({ children }: { children?: React.ReactNode }) => (
+    <blockquote className="my-2 border-l-2 border-border pl-3 text-muted-foreground">{children}</blockquote>
+  ),
+  a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
+    <a className="text-foreground underline underline-offset-2" href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  ),
+  code: ({ className, children }: { className?: string; children?: React.ReactNode }) => {
+    const isBlock = !!className;
+    if (isBlock) {
+      return (
+        <code className="block whitespace-pre font-mono text-[12px] leading-5 text-foreground">
+          {children}
+        </code>
+      );
+    }
+
+    return (
+      <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.92em] leading-snug text-foreground break-words [overflow-wrap:anywhere]">
+        {children}
+      </code>
+    );
+  },
+  pre: ({ children }: { children?: React.ReactNode }) => (
+    <pre className="my-2 overflow-x-auto rounded-md bg-muted px-3 py-2">{children}</pre>
+  ),
+  table: ({ children }: { children?: React.ReactNode }) => (
+    <div className="my-2 overflow-x-auto rounded-md border border-border first:mt-0 last:mb-0">
+      <table className="min-w-full border-collapse text-xs">{children}</table>
+    </div>
+  ),
+  th: ({ children }: { children?: React.ReactNode }) => (
+    <th className="border-b border-border bg-muted px-2 py-1.5 text-left font-semibold text-foreground">{children}</th>
+  ),
+  td: ({ children }: { children?: React.ReactNode }) => (
+    <td className="border-b border-border px-2 py-1.5 last:border-b-0">{children}</td>
+  ),
+} as const;
+
+function QuestionMarkdown({ children }: { children: string }) {
+  return (
+    <div className="mb-3 max-h-72 overflow-y-auto pr-1 text-[13px] leading-5 text-muted-foreground break-words [overflow-wrap:anywhere]">
+      <ReactMarkdown
+        remarkPlugins={questionMarkdownPlugins}
+        components={questionMarkdownComponents}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
 }
 
 export function QuestionInputDock({
@@ -219,9 +298,7 @@ export function QuestionInputDock({
           </div>
 
           <div className="px-4 pb-3 pt-3">
-            <div className="mb-2.5 text-[13px] font-medium leading-5 text-muted-foreground">
-              {currentQuestion.question}
-            </div>
+            <QuestionMarkdown>{currentQuestion.question}</QuestionMarkdown>
 
             <div className="space-y-1">
               {currentQuestion.options?.map((option, optionIndex) => {

--- a/packages/app/src/components/chat/__tests__/QuestionInputDock.test.tsx
+++ b/packages/app/src/components/chat/__tests__/QuestionInputDock.test.tsx
@@ -106,4 +106,29 @@ describe('QuestionInputDock', () => {
     });
     expect(mockAnswerQuestion).not.toHaveBeenCalled();
   });
+
+  it('renders markdown in the question prompt', () => {
+    render(
+      <QuestionInputDock
+        pendingQuestion={{
+          questionId: 'question-event-3',
+          toolCallId: 'tool-call-3',
+          messageId: 'message-3',
+          questions: [
+            {
+              id: 'q-1',
+              header: 'Item #1',
+              question: '### **Title**: choose the `payment_update` path\n\nUse **adopt** when the source matches.',
+              options: [{ label: 'adopt', value: 'adopt' }],
+            },
+          ],
+          source: 'opencode',
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { level: 3, name: /title\s*: choose the payment_update path/i })).toBeTruthy();
+    expect(screen.getByText('payment_update').tagName).toBe('CODE');
+    expect(screen.queryByText(/### \*\*Title\*\*/)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Render question prompt copy with ReactMarkdown/remark-gfm instead of raw text.
- Add compact markdown styling for headings, inline code, lists, quotes, and tables inside the question dock.
- Add a regression test for markdown prompts so `###`, `**`, and backticks are not shown literally.

## Test Plan
- [x] pnpm --filter @teamclaw/app exec vitest run src/components/chat/__tests__/QuestionInputDock.test.tsx
- [x] pnpm --filter @teamclaw/app typecheck
- [x] pnpm --filter @teamclaw/app exec eslint src/components/chat/QuestionInputDock.tsx src/components/chat/__tests__/QuestionInputDock.test.tsx