### PR TITLE
fix(wecom): correctly identify xlsx/docx/pptx instead of zip

### DIFF
--- a/src-tauri/crates/teamclaw-gateway/src/wecom.rs
+++ b/src-tauri/crates/teamclaw-gateway/src/wecom.rs
@@ -107,9 +107,9 @@ fn compress_image(bytes: &[u8], max_bytes: usize) -> Result<Vec<u8>, String> {
 
 /// Detect MIME type from file magic bytes.
 ///
-/// Returns `application/zip` for OOXML (xlsx/docx/pptx) since the magic alone
-/// cannot distinguish OOXML subtypes — callers should prefer the filename hint
-/// (see `resolve_mime`) to recover the precise OOXML type.
+/// For ZIP-based files, attempts to distinguish OOXML subtypes (xlsx/docx/pptx)
+/// by inspecting the ZIP directory entries. Falls back to `application/zip` if
+/// the content cannot be identified as OOXML.
 fn detect_mime_from_magic(bytes: &[u8]) -> Option<String> {
     if bytes.len() < 4 {
         return None;
@@ -135,13 +135,145 @@ fn detect_mime_from_magic(bytes: &[u8]) -> Option<String> {
         || bytes.starts_with(&[0x50, 0x4B, 0x05, 0x06])
         || bytes.starts_with(&[0x50, 0x4B, 0x07, 0x08])
     {
-        Some("application/zip".into())
+        // Try to identify OOXML subtypes by peeking at ZIP entry names.
+        // OOXML packages always contain well-known directory prefixes.
+        Some(detect_ooxml_from_zip(bytes).unwrap_or_else(|| "application/zip".into()))
     // Compound File Binary Format (legacy MS Office: .xls / .doc / .ppt)
     } else if bytes.len() >= 8 && bytes[..8] == [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1] {
         Some("application/x-cfb".into())
     } else {
         None
     }
+}
+
+/// Attempt to identify OOXML subtype by scanning ZIP local file header entries.
+///
+/// Instead of pulling in the full `zip` crate, we do a lightweight scan of the
+/// ZIP local file headers (signature 0x50 0x4B 0x03 0x04) and inspect the
+/// stored file names for well-known OOXML directory prefixes:
+///   - `xl/`   → xlsx (Excel)
+///   - `word/` → docx (Word)
+///   - `ppt/`  → pptx (PowerPoint)
+///   - `[Content_Types].xml` → confirms OOXML but subtype unknown
+///
+/// Returns `Some(mime)` if an OOXML subtype is identified, `None` otherwise
+/// (caller should fall back to `application/zip`).
+fn detect_ooxml_from_zip(bytes: &[u8]) -> Option<String> {
+    // ZIP local file header structure:
+    //   offset 0:  signature (4 bytes) = PK\x03\x04
+    //   offset 26: filename length (2 bytes, little-endian)
+    //   offset 28: extra field length (2 bytes, little-endian)
+    //   offset 30: filename (variable length)
+    //   followed by: extra field, then file data (or not, for stored entries)
+    //
+    // We scan up to 20 entries or 64KB (whichever comes first) to keep this fast.
+    let limit = bytes.len().min(65536);
+    let mut offset = 0;
+    let mut entries_scanned = 0;
+    let max_entries = 20;
+
+    let mut has_content_types = false;
+
+    while offset + 30 <= limit && entries_scanned < max_entries {
+        // Check for local file header signature
+        if bytes[offset..offset + 4] != [0x50, 0x4B, 0x03, 0x04] {
+            break;
+        }
+
+        let fname_len =
+            u16::from_le_bytes([bytes[offset + 26], bytes[offset + 27]]) as usize;
+        let extra_len =
+            u16::from_le_bytes([bytes[offset + 28], bytes[offset + 29]]) as usize;
+        let compressed_size =
+            u32::from_le_bytes([
+                bytes[offset + 18],
+                bytes[offset + 19],
+                bytes[offset + 20],
+                bytes[offset + 21],
+            ]) as usize;
+
+        if offset + 30 + fname_len > limit {
+            break;
+        }
+
+        let fname_bytes = &bytes[offset + 30..offset + 30 + fname_len];
+        if let Ok(fname) = std::str::from_utf8(fname_bytes) {
+            let fname_lower = fname.to_ascii_lowercase();
+            if fname_lower.starts_with("xl/") || fname_lower == "xl" {
+                return Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet".into());
+            }
+            if fname_lower.starts_with("word/") || fname_lower == "word" {
+                return Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document".into());
+            }
+            if fname_lower.starts_with("ppt/") || fname_lower == "ppt" {
+                return Some("application/vnd.openxmlformats-officedocument.presentationml.presentation".into());
+            }
+            if fname_lower == "[content_types].xml" {
+                has_content_types = true;
+            }
+        }
+
+        // Advance to next entry: header(30) + filename + extra + compressed data
+        offset += 30 + fname_len + extra_len + compressed_size;
+        entries_scanned += 1;
+    }
+
+    // If we found [Content_Types].xml but no specific prefix, it's still likely
+    // OOXML — return xlsx as the most common case (better than zip).
+    if has_content_types {
+        return Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet".into());
+    }
+
+    None
+}
+
+/// Extract filename from a Content-Disposition header value.
+///
+/// Handles both `filename="name.ext"` and `filename*=UTF-8''encoded` forms.
+/// Returns `None` if no filename can be extracted.
+fn extract_filename_from_content_disposition(header: &str) -> Option<String> {
+    let lower = header.to_ascii_lowercase();
+
+    // Try filename*= (RFC 5987 / RFC 6266) first — it supports UTF-8
+    if let Some(pos) = lower.find("filename*=") {
+        let after = &header[pos + "filename*=".len()..];
+        // Format: charset'language'value (e.g. UTF-8''%E6%8A%A5%E8%A1%A8.xlsx)
+        if let Some(tick_pos) = after.find("''") {
+            let encoded = after[tick_pos + 2..]
+                .split(';')
+                .next()
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"');
+            if !encoded.is_empty() {
+                // URL-decode the filename
+                if let Ok(decoded) = urlencoding::decode(encoded) {
+                    let name = decoded.into_owned();
+                    if !name.is_empty() {
+                        return Some(name);
+                    }
+                }
+            }
+        }
+    }
+
+    // Fall back to plain filename= parameter.
+    // Note: "filename*=" does NOT contain "filename=" as a substring
+    // (the * comes before =), so a simple find is safe.
+    if let Some(pos) = lower.find("filename=") {
+        let after = &header[pos + "filename=".len()..];
+        let name = if let Some(stripped) = after.strip_prefix('"') {
+            // Quoted string
+            stripped.split('"').next().unwrap_or("").to_string()
+        } else {
+            after.split(';').next().unwrap_or("").trim().to_string()
+        };
+        if !name.is_empty() {
+            return Some(name);
+        }
+    }
+
+    None
 }
 
 /// Decide the MIME type for a downloaded media payload.
@@ -1259,6 +1391,14 @@ impl WeComGateway {
             return Err(format!("HTTP {}", resp.status()));
         }
 
+        // Try to extract filename from Content-Disposition header as a fallback
+        // when the caller has no filename_hint (e.g. WeCom file messages).
+        let cd_filename = resp
+            .headers()
+            .get("content-disposition")
+            .and_then(|v| v.to_str().ok())
+            .and_then(extract_filename_from_content_disposition);
+
         let raw_bytes = resp
             .bytes()
             .await
@@ -1272,17 +1412,23 @@ impl WeComGateway {
             raw_bytes.to_vec()
         };
 
+        // Use caller-provided filename_hint first, then Content-Disposition filename
+        let effective_hint = filename_hint
+            .map(|s| s.to_string())
+            .or(cd_filename);
+
         // Resolve MIME: filename hint first (precise for OOXML), magic bytes second,
         // application/octet-stream as last resort. Defaulting to image/png caused
         // Excel/Office files to be silently saved as .png — see ext_from_filename.
-        let content_type = resolve_mime(&bytes, filename_hint);
+        let content_type = resolve_mime(&bytes, effective_hint.as_deref());
 
         println!(
-            "[WeCom] Downloaded file: {} bytes (raw {}), mime={}, filename={:?}",
+            "[WeCom] Downloaded file: {} bytes (raw {}), mime={}, filename_hint={:?}, effective_hint={:?}",
             bytes.len(),
             raw_bytes.len(),
             content_type,
-            filename_hint
+            filename_hint,
+            effective_hint
         );
 
         // Compress image if too large for AI model (limit ~258KB base64 → ~190KB raw)
@@ -2861,13 +3007,102 @@ mod mime_tests {
     }
 
     #[test]
-    fn resolve_mime_xlsx_without_filename_returns_zip_not_png() {
-        // Regression: previously fell to "image/png" because magic byte detection
-        // had no ZIP rule and there was no filename to fall back on.
+    fn resolve_mime_plain_zip_without_filename_returns_zip() {
+        // A minimal ZIP header with no recognizable OOXML entries → application/zip.
         let bytes = [0x50, 0x4B, 0x03, 0x04];
         let mime = resolve_mime(&bytes, None);
         assert_eq!(mime, "application/zip");
         assert_ne!(mime, "image/png");
+    }
+
+    #[test]
+    fn detect_ooxml_xlsx_from_zip_entries() {
+        // Simulate a minimal xlsx ZIP with an entry named "xl/workbook.xml"
+        let entry_name = b"xl/workbook.xml";
+        let mut bytes = Vec::new();
+        // Local file header
+        bytes.extend_from_slice(&[0x50, 0x4B, 0x03, 0x04]); // signature
+        bytes.extend_from_slice(&[0x14, 0x00]); // version needed
+        bytes.extend_from_slice(&[0x00, 0x00]); // flags
+        bytes.extend_from_slice(&[0x00, 0x00]); // compression method (stored)
+        bytes.extend_from_slice(&[0x00, 0x00]); // last mod time
+        bytes.extend_from_slice(&[0x00, 0x00]); // last mod date
+        bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // crc32
+        bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // compressed size
+        bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // uncompressed size
+        bytes.extend_from_slice(&(entry_name.len() as u16).to_le_bytes()); // filename length
+        bytes.extend_from_slice(&[0x00, 0x00]); // extra field length
+        bytes.extend_from_slice(entry_name); // filename
+        let mime = resolve_mime(&bytes, None);
+        assert_eq!(mime, XLSX_MIME);
+    }
+
+    #[test]
+    fn detect_ooxml_docx_from_zip_entries() {
+        // Simulate a minimal docx ZIP with an entry named "word/document.xml"
+        let entry_name = b"word/document.xml";
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[0x50, 0x4B, 0x03, 0x04]);
+        bytes.extend_from_slice(&[0x14, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        bytes.extend_from_slice(&(entry_name.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(&[0x00, 0x00]);
+        bytes.extend_from_slice(entry_name);
+        let mime = resolve_mime(&bytes, None);
+        assert_eq!(mime, "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+    }
+
+    #[test]
+    fn detect_ooxml_pptx_from_zip_entries() {
+        // Simulate a minimal pptx ZIP with an entry named "ppt/presentation.xml"
+        let entry_name = b"ppt/presentation.xml";
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[0x50, 0x4B, 0x03, 0x04]);
+        bytes.extend_from_slice(&[0x14, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        bytes.extend_from_slice(&(entry_name.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(&[0x00, 0x00]);
+        bytes.extend_from_slice(entry_name);
+        let mime = resolve_mime(&bytes, None);
+        assert_eq!(mime, "application/vnd.openxmlformats-officedocument.presentationml.presentation");
+    }
+
+    #[test]
+    fn content_disposition_extracts_filename() {
+        assert_eq!(
+            extract_filename_from_content_disposition(r#"attachment; filename="report.xlsx""#),
+            Some("report.xlsx".to_string())
+        );
+    }
+
+    #[test]
+    fn content_disposition_extracts_utf8_filename() {
+        assert_eq!(
+            extract_filename_from_content_disposition(
+                "attachment; filename*=UTF-8''%E6%8A%A5%E8%A1%A8.xlsx"
+            ),
+            Some("\u{62a5}\u{8868}.xlsx".to_string())
+        );
+    }
+
+    #[test]
+    fn content_disposition_returns_none_for_missing() {
+        assert_eq!(
+            extract_filename_from_content_disposition("attachment"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
WeCom file message callbacks do not include a filename field, so filename_hint is always None. Previously, detect_mime_from_magic returned 'application/zip' for all ZIP-based files (including OOXML), causing xlsx files to be saved as .zip in .uploads/.

## Changes:
- Add detect_ooxml_from_zip() that scans ZIP local file headers for well-known OOXML directory prefixes (xl/ → xlsx, word/ → docx, ppt/ → pptx) without pulling in the zip crate
- Update detect_mime_from_magic() to call detect_ooxml_from_zip() when ZIP magic bytes are detected
- Add extract_filename_from_content_disposition() to extract filename from HTTP Content-Disposition header as a secondary fallback
- Update download_as_data_url() to try Content-Disposition filename when caller-provided filename_hint is None
- Add 6 new tests covering OOXML detection and Content-Disposition parsing

## Description

When uploading Excel files (.xlsx) via WeCom (企业微信) gateway, the files are incorrectly saved as `.zip` in the `.uploads/` directory, causing downstream scripts/tools to fail.

**Root cause:** WeCom file message callbacks do NOT include a `filename` field — only `url` and `aeskey`. This means `filename_hint` is always `None` in `download_as_data_url()`. The MIME detection falls back to magic bytes, but xlsx and zip share identical magic bytes (`PK\x03\x04`), so the file is misidentified as `application/zip`.

**Fix:** Two complementary improvements:
1. **OOXML content detection** (`detect_ooxml_from_zip`): When ZIP magic bytes are detected, scan ZIP local file headers for well-known OOXML directory prefixes (`xl/` → xlsx, `word/` → docx, `ppt/` → pptx). Lightweight scan (up to 20 entries / 64KB) without pulling in the `zip` crate.
2. **Content-Disposition fallback** (`extract_filename_from_content_disposition`): Extract filename from HTTP `Content-Disposition` header when downloading files, as a secondary fallback when `filename_hint` is not available.

## Related Issue

N/A (discovered in production usage)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

**Verification performed:**
- `cargo fmt --check` — no formatting issues
- `cargo clippy -p teamclaw-gateway -- -D warnings` — no warnings
- `cargo test -p teamclaw-gateway -- mime_tests` — 22 tests pass, including 6 new

**New tests added:**
- `detect_ooxml_xlsx_from_zip_entries`
- `detect_ooxml_docx_from_zip_entries`
- `detect_ooxml_pptx_from_zip_entries`
- `content_disposition_extracts_filename`
- `content_disposition_extracts_utf8_filename`
- `content_disposition_returns_none_for_missing`

