### PR TITLE
fix: support Windows skill paths

### DIFF
--- a/packages/app/src/components/__tests__/FileEditor.test.tsx
+++ b/packages/app/src/components/__tests__/FileEditor.test.tsx
@@ -5,7 +5,11 @@ import React from 'react'
 // Mock all heavy dependencies
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, fallback: string) => fallback,
+    i18n: { language: 'zh-CN' },
+    t: (key: string, fallback: string) =>
+      ({
+        'history.noFileHistory': '该文件还没有提交历史',
+      })[key] ?? fallback,
   }),
 }))
 

--- a/packages/app/src/components/__tests__/NodeStatusPopover.test.tsx
+++ b/packages/app/src/components/__tests__/NodeStatusPopover.test.tsx
@@ -25,6 +25,45 @@ const teamMembersStoreMock = vi.hoisted(() => ({
   loadCurrentNodeId: vi.fn(),
 }))
 
+vi.mock('react-i18next', () => ({
+  useTranslation: (() => {
+    const translations: Record<string, string> = {
+      'common.justNow': 'Just now',
+      'common.never': 'Never',
+      'nodeStatus.connected': 'Connected',
+      'nodeStatus.degraded': 'Degraded',
+      'nodeStatus.disconnected': 'Disconnected',
+      'nodeStatus.engine': 'Engine',
+      'nodeStatus.lastSync': 'Last sync',
+      'nodeStatus.online': 'Online',
+      'nodeStatus.pendingFiles': 'Pending files',
+      'nodeStatus.reconnecting': 'Reconnecting...',
+      'nodeStatus.restarts': 'Restarts',
+      'nodeStatus.syncedFiles': 'Synced files',
+      'nodeStatus.thisDevice': 'This device',
+      'nodeStatus.unknown': 'Unknown',
+    }
+    const t = (key: string, options?: string | { count?: number }) => {
+      const count = typeof options === 'object' ? options.count ?? 0 : 0
+      if (key === 'nodeStatus.teamMembers') return `Team Members (${count})`
+      if (key === 'nodeStatus.secondsAgo') return `${count}s ago`
+      if (key === 'nodeStatus.minutesAgoShort') return `${count}m ago`
+      if (key === 'nodeStatus.hoursAgoShort') return `${count}h ago`
+      if (key === 'nodeStatus.daysAgoShort') return `${count}d ago`
+      if (key === 'nodeStatus.staleSeconds') return `${count}s ago`
+      if (key === 'nodeStatus.staleMinutes') return `${count}m ago`
+      if (key === 'nodeStatus.offlineSeconds') return `${count}s offline`
+      if (key === 'nodeStatus.offlineMinutes') return `${count}m offline`
+      if (key === 'nodeStatus.offlineHours') return `${count}h offline`
+      return translations[key] ?? (typeof options === 'string' ? options : key)
+    }
+    return () => ({
+      i18n: { language: 'en' },
+      t,
+    })
+  })(),
+}))
+
 vi.mock('@/stores/p2p-engine', () => ({
   useP2pEngineStore: (sel: (s: Record<string, unknown>) => unknown) =>
     sel(p2pEngineStoreMock as unknown as Record<string, unknown>),

--- a/packages/app/src/components/chat/__tests__/CommandPopover.test.tsx
+++ b/packages/app/src/components/chat/__tests__/CommandPopover.test.tsx
@@ -9,6 +9,35 @@ const { mockListCommands, mockLoadAllSkills, mockReadSkillPermissions, mockLoadA
   mockLoadAllRoles: vi.fn(),
 }))
 
+vi.mock('react-i18next', () => ({
+  useTranslation: (() => {
+    const t = (key: string, options?: string | { count?: number; query?: string }) => {
+      if (key === 'chat.commandPopover.roles') {
+        return `Roles (${typeof options === 'object' ? options.count ?? 0 : 0})`
+      }
+      if (key === 'chat.commandPopover.skills') {
+        return `Skills (${typeof options === 'object' ? options.count ?? 0 : 0})`
+      }
+      if (key === 'chat.commandPopover.commands') {
+        return `Commands (${typeof options === 'object' ? options.count ?? 0 : 0})`
+      }
+      if (key === 'chat.commandPopover.itemCount') {
+        const count = typeof options === 'object' ? options.count ?? 0 : 0
+        return `${count} items`
+      }
+      if (key === 'chat.commandPopover.noMatch') {
+        const query = typeof options === 'object' ? options.query ?? '' : ''
+        return `No matches for "${query}"`
+      }
+      return typeof options === 'string' ? options : key
+    }
+    return () => ({
+      i18n: { language: 'en' },
+      t,
+    })
+  })(),
+}))
+
 vi.mock('@/lib/utils', async () => {
   const actual = await vi.importActual<typeof import('@/lib/utils')>('@/lib/utils')
   return {

--- a/packages/app/src/components/history/__tests__/CommitList.test.tsx
+++ b/packages/app/src/components/history/__tests__/CommitList.test.tsx
@@ -3,6 +3,19 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { CommitList } from '../CommitList'
 import type { GitLogEntry } from '@/lib/git/types'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: (() => {
+    const t = (key: string, fallback?: string) =>
+      ({
+        'sidebar.loadMore': '加载更多',
+      })[key] ?? fallback ?? key
+    return () => ({
+      i18n: { language: 'zh-CN' },
+      t,
+    })
+  })(),
+}))
+
 const sample: GitLogEntry[] = [
   {
     sha: 'a'.repeat(40),

--- a/packages/app/src/components/history/__tests__/FileHistoryView.test.tsx
+++ b/packages/app/src/components/history/__tests__/FileHistoryView.test.tsx
@@ -18,6 +18,28 @@ vi.mock('@/components/diff/DiffRenderer', () => ({
   ),
 }))
 
+vi.mock('react-i18next', () => ({
+  useTranslation: (() => {
+    const translations: Record<string, string> = {
+      'common.retry': '重试',
+      'history.noFileHistory': '该文件还没有提交历史',
+      'history.diffSkippedTooLarge': '文件过大或为二进制，跳过 diff',
+      'sidebar.loadMore': '加载更多',
+    }
+    const t = (key: string, options?: string | { sha?: string; defaultValue?: string }) => {
+      if (key === 'history.loadCommitContentFailed') {
+        const sha = typeof options === 'object' ? options.sha : undefined
+        return `无法加载该提交的内容 (${sha ?? ''})`
+      }
+      return translations[key] ?? (typeof options === 'string' ? options : key)
+    }
+    return () => ({
+      i18n: { language: 'zh-CN' },
+      t,
+    })
+  })(),
+}))
+
 import { FileHistoryView } from '../FileHistoryView'
 
 const initial: GitLogEntry = {

--- a/packages/app/src/lib/git/__tests__/skill-loader-team-path.test.ts
+++ b/packages/app/src/lib/git/__tests__/skill-loader-team-path.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { TEAM_REPO_DIR } from "@/lib/build-config"
-import { buildSkillInvocationName, loadAllSkills, getSourceDirHint } from "../skill-loader"
+import { buildSkillInvocationName, loadAllSkills, getSourceDirHint, readConfigSkillPaths } from "../skill-loader"
 
 const mockExists = vi.fn()
 const mockReadDir = vi.fn()
@@ -89,6 +89,44 @@ describe("skill-loader dynamic team paths (from opencode.json)", () => {
     const teamSkills = skills.filter((s) => s.source === "team")
 
     expect(teamSkills.some((s) => s.filename === "home-skill")).toBe(true)
+  })
+
+  it("resolves Windows absolute skill paths without prefixing the workspace", async () => {
+    const workspacePath = "C:\\Users\\alice\\project"
+    const absoluteDir = "D:\\shared\\skills"
+
+    mockExists.mockImplementation((path: string) => {
+      if (path === `${workspacePath}/opencode.json`) return Promise.resolve(true)
+      return Promise.resolve(false)
+    })
+    mockReadTextFile.mockImplementation((path: string) => {
+      if (path === `${workspacePath}/opencode.json`) {
+        return Promise.resolve(opencodejson([absoluteDir]))
+      }
+      return Promise.resolve("")
+    })
+
+    await expect(readConfigSkillPaths(workspacePath)).resolves.toEqual([absoluteDir])
+  })
+
+  it("resolves Windows home-relative skill paths", async () => {
+    const workspacePath = "C:\\Users\\alice\\project"
+    mockHomeDir.mockResolvedValue("C:\\Users\\alice")
+
+    mockExists.mockImplementation((path: string) => {
+      if (path === `${workspacePath}/opencode.json`) return Promise.resolve(true)
+      return Promise.resolve(false)
+    })
+    mockReadTextFile.mockImplementation((path: string) => {
+      if (path === `${workspacePath}/opencode.json`) {
+        return Promise.resolve(opencodejson(["~\\shared-skills"]))
+      }
+      return Promise.resolve("")
+    })
+
+    await expect(readConfigSkillPaths(workspacePath)).resolves.toEqual([
+      "C:\\Users\\alice\\shared-skills",
+    ])
   })
 
   it("contributes zero team skills when opencode.json has no skills.paths", async () => {
@@ -201,6 +239,11 @@ describe("skill-loader dynamic team paths (from opencode.json)", () => {
   it("builds namespaced invocation names for bundled skills only", () => {
     expect(buildSkillInvocationName("/home/user/.agents/skills", "brainstorming")).toBe("brainstorming")
     expect(buildSkillInvocationName("/home/user/.agents/skills/superpowers", "brainstorming")).toBe("superpowers/brainstorming")
+  })
+
+  it("builds invocation names from Windows paths", () => {
+    expect(buildSkillInvocationName("C:\\Users\\alice\\.agents\\skills", "brainstorming")).toBe("brainstorming")
+    expect(buildSkillInvocationName("C:\\Users\\alice\\.agents\\skills\\superpowers", "brainstorming")).toBe("superpowers/brainstorming")
   })
 
   it("getSourceDirHint(team) shows opencode.json config reference", () => {

--- a/packages/app/src/lib/git/skill-loader.ts
+++ b/packages/app/src/lib/git/skill-loader.ts
@@ -21,7 +21,24 @@ function extractSkillName(content: string, fallback: string): string {
 }
 
 function getLastPathSegment(path: string): string {
-  return path.replace(/\/+$/, '').split('/').pop() || ''
+  return path.replace(/[\\/]+$/, '').split(/[\\/]/).pop() || ''
+}
+
+function trimTrailingPathSeparators(path: string): string {
+  return path.replace(/[\\/]+$/, '')
+}
+
+function trimLeadingPathSeparators(path: string): string {
+  return path.replace(/^[\\/]+/, '')
+}
+
+function isAbsolutePath(path: string): boolean {
+  return path.startsWith('/') || path.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(path)
+}
+
+function joinPath(parent: string, child: string): string {
+  const separator = parent.includes('\\') ? '\\' : '/'
+  return `${trimTrailingPathSeparators(parent)}${separator}${trimLeadingPathSeparators(child)}`
 }
 
 export function buildSkillInvocationName(parentDir: string, filename: string): string {
@@ -119,15 +136,16 @@ export async function readConfigSkillPaths(workspacePath: string): Promise<strin
     const config = JSON.parse(content)
     const rawPaths: unknown[] = config?.skills?.paths ?? []
     const home = await homeDir()
+    const normalizedHome = trimTrailingPathSeparators(home)
     return rawPaths
       .filter((p): p is string => typeof p === 'string')
-      .map((p) =>
-        p.startsWith('~/') || p === '~'
-          ? p.replace(/^~/, home.replace(/\/$/, ''))
-          : p.startsWith('/')
-            ? p
-            : `${workspacePath}/${p}`,
-      )
+      .map((p) => {
+        if (p === '~') return normalizedHome
+        if (/^~[\\/]/.test(p)) {
+          return joinPath(normalizedHome, p.slice(2))
+        }
+        return isAbsolutePath(p) ? p : joinPath(workspacePath, p)
+      })
   } catch {
     return []
   }
@@ -135,7 +153,7 @@ export async function readConfigSkillPaths(workspacePath: string): Promise<strin
 
 /** Return all known skill directories for the current workspace/user context. */
 export async function getSkillDirectories(workspacePath: string | null): Promise<string[]> {
-  const home = (await homeDir()).replace(/\/$/, '')
+  const home = trimTrailingPathSeparators(await homeDir())
   const dirs = new Set<string>([
     `${home}/.config/opencode/skills`,
     `${home}/.claude/skills`,
@@ -282,7 +300,13 @@ export async function loadAllSkills(
     for (const dirPath of configPaths) {
       const skills = await loadSkillsFromDir(dirPath, 'team')
       // Determine if path is global (starts with ~/ or absolute home path)
-      const isGlobalPath = dirPath.startsWith(home) || dirPath.includes('.config/opencode') || dirPath.includes('.claude') || dirPath.includes('.agents')
+      const normalizedDirPath = dirPath.replace(/\\/g, '/')
+      const normalizedHome = home.replace(/\\/g, '/')
+      const isGlobalPath =
+        normalizedDirPath.startsWith(normalizedHome) ||
+        normalizedDirPath.includes('.config/opencode') ||
+        normalizedDirPath.includes('.claude') ||
+        normalizedDirPath.includes('.agents')
       for (const s of skills) pushSkill({ ...s, isGlobal: isGlobalPath })
     }
   }

--- a/packages/app/src/packages/ai/editable-with-file-chips.tsx
+++ b/packages/app/src/packages/ai/editable-with-file-chips.tsx
@@ -9,6 +9,14 @@ function parseSlashToken(body: string): { type: 'role' | 'skill' | 'command'; na
   return { type: 'skill', name: body }
 }
 
+function containsControlInput(value: string) {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+    if (code <= 0x1f || code === 0x7f || code === 0xfffd) return true
+  }
+  return false
+}
+
 interface EditableWithFileChipsProps {
   value?: string
   onChange?: (value: string) => void
@@ -393,7 +401,7 @@ export const EditableWithFileChips = React.forwardRef<HTMLDivElement, EditableWi
       if (!data) return;
       // Some desktop/webview input methods can surface arrow-key escape bytes as
       // insertText. Text editing keys should move the caret, never mutate content.
-      if (/[\u0000-\u001f\u007f\ufffd]/.test(data)) {
+      if (containsControlInput(data)) {
         e.preventDefault();
       }
     }, [])


### PR DESCRIPTION
## Summary
- Normalize skill-loader path parsing so Windows backslashes do not become part of skill invocation names
- Support Windows absolute paths and home-relative paths in opencode.json skills.paths
- Add regression coverage for Windows skill path handling

## Test Plan
- pnpm --filter @teamclaw/app exec vitest run src/lib/git/__tests__/skill-loader-team-path.test.ts
- pnpm --filter @teamclaw/app typecheck