### PR TITLE
fix(workspace): open files inside symlinked folders

### DIFF
--- a/packages/app/src/stores/__tests__/workspace-load-directory.test.ts
+++ b/packages/app/src/stores/__tests__/workspace-load-directory.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockReadDir = vi.fn();
 const mockStat = vi.fn();
+const mockInvoke = vi.fn();
 
 vi.mock("@/lib/utils", () => ({
   isTauri: () => true,
@@ -12,11 +13,16 @@ vi.mock("@tauri-apps/plugin-fs", () => ({
   stat: (...args: unknown[]) => mockStat(...args),
 }));
 
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
 import { useWorkspaceStore } from "../workspace";
 
 describe("workspace loadDirectory", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockInvoke.mockResolvedValue([]);
     useWorkspaceStore.setState({
       workspacePath: "/workspace",
       fileTree: [],
@@ -26,23 +32,20 @@ describe("workspace loadDirectory", () => {
   });
 
   it("treats symlinked directories as directories", async () => {
-    mockReadDir.mockResolvedValue([
+    mockInvoke.mockResolvedValue([
       {
         name: "linked-dir",
-        isDirectory: false,
-        isFile: false,
-        isSymlink: true,
+        path: "/workspace/linked-dir",
+        type: "directory",
       },
     ]);
-    mockStat.mockResolvedValue({
-      isDirectory: true,
-      isFile: false,
-      isSymlink: false,
-    });
 
     const result = await useWorkspaceStore.getState().loadDirectory(".");
 
-    expect(mockStat).toHaveBeenCalledWith("/workspace/linked-dir");
+    expect(mockInvoke).toHaveBeenCalledWith("read_workspace_directory", {
+      workspacePath: "/workspace",
+      path: "/workspace",
+    });
     expect(result).toEqual([
       {
         name: "linked-dir",
@@ -53,23 +56,20 @@ describe("workspace loadDirectory", () => {
   });
 
   it("keeps symlinked files as files", async () => {
-    mockReadDir.mockResolvedValue([
+    mockInvoke.mockResolvedValue([
       {
         name: "linked-file.ts",
-        isDirectory: false,
-        isFile: false,
-        isSymlink: true,
+        path: "/workspace/linked-file.ts",
+        type: "file",
       },
     ]);
-    mockStat.mockResolvedValue({
-      isDirectory: false,
-      isFile: true,
-      isSymlink: false,
-    });
 
     const result = await useWorkspaceStore.getState().loadDirectory(".");
 
-    expect(mockStat).toHaveBeenCalledWith("/workspace/linked-file.ts");
+    expect(mockInvoke).toHaveBeenCalledWith("read_workspace_directory", {
+      workspacePath: "/workspace",
+      path: "/workspace",
+    });
     expect(result).toEqual([
       {
         name: "linked-file.ts",
@@ -79,24 +79,21 @@ describe("workspace loadDirectory", () => {
     ]);
   });
 
-  it("treats alias-like ambiguous entries as directories via stat fallback", async () => {
-    mockReadDir.mockResolvedValue([
+  it("treats directory entries from the workspace reader as directories", async () => {
+    mockInvoke.mockResolvedValue([
       {
         name: "skills",
-        isDirectory: false,
-        isFile: false,
-        isSymlink: false,
+        path: "/workspace/skills",
+        type: "directory",
       },
     ]);
-    mockStat.mockResolvedValue({
-      isDirectory: true,
-      isFile: false,
-      isSymlink: false,
-    });
 
     const result = await useWorkspaceStore.getState().loadDirectory(".");
 
-    expect(mockStat).toHaveBeenCalledWith("/workspace/skills");
+    expect(mockInvoke).toHaveBeenCalledWith("read_workspace_directory", {
+      workspacePath: "/workspace",
+      path: "/workspace",
+    });
     expect(result).toEqual([
       {
         name: "skills",
@@ -106,28 +103,51 @@ describe("workspace loadDirectory", () => {
     ]);
   });
 
-  it("treats ambiguous linked files as files via stat fallback", async () => {
-    mockReadDir.mockResolvedValue([
+  it("treats file entries from the workspace reader as files", async () => {
+    mockInvoke.mockResolvedValue([
       {
         name: "linked-file.md",
-        isDirectory: false,
-        isFile: false,
-        isSymlink: false,
+        path: "/workspace/linked-file.md",
+        type: "file",
       },
     ]);
-    mockStat.mockResolvedValue({
-      isDirectory: false,
-      isFile: true,
-      isSymlink: false,
-    });
 
     const result = await useWorkspaceStore.getState().loadDirectory(".");
 
-    expect(mockStat).toHaveBeenCalledWith("/workspace/linked-file.md");
+    expect(mockInvoke).toHaveBeenCalledWith("read_workspace_directory", {
+      workspacePath: "/workspace",
+      path: "/workspace",
+    });
     expect(result).toEqual([
       {
         name: "linked-file.md",
         path: "/workspace/linked-file.md",
+        type: "file",
+      },
+    ]);
+  });
+
+  it("lists a symlink directory through the workspace reader when fs scope would reject the target", async () => {
+    mockInvoke.mockResolvedValue([
+      {
+        name: "README.md",
+        path: "/workspace/ac360-link/README.md",
+        type: "file",
+      },
+    ]);
+
+    const result = await useWorkspaceStore.getState().loadDirectory("/workspace/ac360-link");
+
+    expect(mockReadDir).not.toHaveBeenCalled();
+    expect(mockStat).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledWith("read_workspace_directory", {
+      workspacePath: "/workspace",
+      path: "/workspace/ac360-link",
+    });
+    expect(result).toEqual([
+      {
+        name: "README.md",
+        path: "/workspace/ac360-link/README.md",
         type: "file",
       },
     ]);

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -228,6 +228,14 @@ async function readWorkspaceBinaryFile(
   return new Uint8Array(bytes);
 }
 
+async function readWorkspaceDirectory(
+  workspacePath: string,
+  path: string,
+): Promise<FileNode[]> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<FileNode[]>("read_workspace_directory", { workspacePath, path });
+}
+
 // Update only the target node's children, creating new references only along
 // the path from root to target. Siblings and unrelated subtrees keep their
 // original references, preserving React.memo effectiveness.
@@ -615,11 +623,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
 
     try {
-      const { readDir, stat } = await import("@tauri-apps/plugin-fs");
       const fullPath = path === "." ? workspacePath : path;
       console.log("[Workspace] Loading directory:", fullPath);
-      const entries = await readDir(fullPath);
-      console.log("[Workspace] Found", entries.length, "entries");
+      const nodes = await readWorkspaceDirectory(workspacePath, fullPath);
+      console.log("[Workspace] Found", nodes.length, "entries");
 
       let advancedMode = false;
       try {
@@ -627,28 +634,6 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         advancedMode = useUIStore.getState().advancedMode;
       } catch { /* keep basic mode */ }
 
-      const nodes: FileNode[] = await Promise.all(
-        entries.map(async (entry) => {
-          const entryPath = `${fullPath}/${entry.name}`;
-          let isDirectory = entry.isDirectory;
-          const needsStatResolution = !entry.isDirectory && !entry.isFile;
-
-          if (!isDirectory && needsStatResolution) {
-            try {
-              const resolved = await stat(entryPath);
-              isDirectory = resolved.isDirectory;
-            } catch (error) {
-              console.warn("[Workspace] Failed to resolve ambiguous file tree entry:", entryPath, error);
-            }
-          }
-
-          return {
-            name: entry.name,
-            path: entryPath,
-            type: isDirectory ? "directory" : "file",
-          } as FileNode;
-        }),
-      );
       const visibleNodes = nodes.filter(
         (node) => !shouldHideFileTreeEntry(node, workspacePath, advancedMode),
       );

--- a/src-tauri/src/commands/workspace_files.rs
+++ b/src-tauri/src/commands/workspace_files.rs
@@ -1,5 +1,13 @@
 use std::path::{Component, Path, PathBuf};
 
+#[derive(Debug, serde::Serialize)]
+pub struct WorkspaceDirectoryEntry {
+    name: String,
+    path: String,
+    #[serde(rename = "type")]
+    kind: String,
+}
+
 fn normalize_absolute_path(path: &Path) -> Result<PathBuf, String> {
     if !path.is_absolute() {
         return Err(format!("Path must be absolute: {}", path.display()));
@@ -38,6 +46,45 @@ fn resolve_workspace_view_path(workspace_path: &str, path: &str) -> Result<PathB
 }
 
 #[tauri::command]
+pub fn read_workspace_directory(
+    workspace_path: String,
+    path: String,
+) -> Result<Vec<WorkspaceDirectoryEntry>, String> {
+    let target = resolve_workspace_view_path(&workspace_path, &path)?;
+    let entries = std::fs::read_dir(&target)
+        .map_err(|e| format!("Failed to read directory '{}': {}", target.display(), e))?;
+
+    let mut result = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|e| {
+            format!(
+                "Failed to read directory entry in '{}': {}",
+                target.display(),
+                e
+            )
+        })?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        let entry_path = target.join(&name);
+        let metadata = std::fs::metadata(&entry_path)
+            .or_else(|_| std::fs::symlink_metadata(&entry_path))
+            .map_err(|e| format!("Failed to read metadata '{}': {}", entry_path.display(), e))?;
+        let kind = if metadata.is_dir() {
+            "directory"
+        } else {
+            "file"
+        };
+
+        result.push(WorkspaceDirectoryEntry {
+            name,
+            path: entry_path.to_string_lossy().to_string(),
+            kind: kind.to_string(),
+        });
+    }
+
+    Ok(result)
+}
+
+#[tauri::command]
 pub fn read_workspace_text_file(workspace_path: String, path: String) -> Result<String, String> {
     let target = resolve_workspace_view_path(&workspace_path, &path)?;
     std::fs::read_to_string(&target)
@@ -49,4 +96,71 @@ pub fn read_workspace_binary_file(workspace_path: String, path: String) -> Resul
     let target = resolve_workspace_view_path(&workspace_path, &path)?;
     std::fs::read(&target)
         .map_err(|e| format!("Failed to read binary file '{}': {}", target.display(), e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_paths_outside_workspace_view() {
+        let workspace = "/tmp/workspace";
+        let result = read_workspace_directory(workspace.to_string(), "/tmp/other".to_string());
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("outside workspace view"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lists_files_inside_symlinked_directory_using_view_path() {
+        use std::os::unix::fs::symlink;
+
+        let workspace = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+        std::fs::write(external.path().join("README.md"), "linked content").unwrap();
+        symlink(external.path(), workspace.path().join("linked-dir")).unwrap();
+
+        let entries = read_workspace_directory(
+            workspace.path().to_string_lossy().to_string(),
+            workspace
+                .path()
+                .join("linked-dir")
+                .to_string_lossy()
+                .to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "README.md");
+        assert_eq!(entries[0].kind, "file");
+        assert_eq!(
+            entries[0].path,
+            workspace
+                .path()
+                .join("linked-dir")
+                .join("README.md")
+                .to_string_lossy()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolves_symlinked_directory_entries_as_directories() {
+        use std::os::unix::fs::symlink;
+
+        let workspace = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+        symlink(external.path(), workspace.path().join("linked-dir")).unwrap();
+
+        let entries = read_workspace_directory(
+            workspace.path().to_string_lossy().to_string(),
+            workspace.path().to_string_lossy().to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "linked-dir");
+        assert_eq!(entries[0].kind, "directory");
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -577,6 +577,7 @@ pub fn run() {
             commands::webview::webview_find_in_page,
             commands::webview::webview_clear_find,
             commands::webview::webview_set_zoom,
+            commands::workspace_files::read_workspace_directory,
             commands::workspace_files::read_workspace_text_file,
             commands::workspace_files::read_workspace_binary_file,
             commands::app_settings::get_spotlight_shortcut,


### PR DESCRIPTION
## Summary
- Add a backend workspace directory reader that preserves workspace-view paths while resolving symlink target types.
- Route file tree directory loading through the workspace reader so symlinked folders can be expanded even when Tauri FS scope rejects the real target.
- Add frontend and Rust regression coverage for symlinked directory entries and files inside symlinked folders.

## Test Plan
- pnpm --filter @teamclaw/app exec vitest run src/stores/__tests__/workspace-load-directory.test.ts src/stores/__tests__/workspace-select-file.test.ts
- pnpm --filter @teamclaw/app typecheck
- cargo fmt --check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml workspace_files