### PR TITLE
Fix introspect-created cron jobs in Automation settings

### DIFF
--- a/packages/app/src/components/settings/CronSection.tsx
+++ b/packages/app/src/components/settings/CronSection.tsx
@@ -182,11 +182,12 @@ export function CronSection() {
   // Periodically refresh job list while this section is mounted.
   // Refresh jobs periodically (every 30 seconds)
   React.useEffect(() => {
+    loadJobs()
     const interval = setInterval(() => {
       loadJobs()
     }, 30000)
     return () => clearInterval(interval)
-  }, [])
+  }, [loadJobs])
 
   const handleOpenCreate = () => {
     setEditJob(undefined)

--- a/packages/app/src/components/settings/__tests__/CronSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/CronSection.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+
+const mockLoadJobs = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, d?: string) => d ?? _k }),
+}))
+
+vi.mock('@/stores/cron', () => ({
+  useCronStore: () => ({
+    jobs: [],
+    isLoading: false,
+    error: null,
+    loadJobs: mockLoadJobs,
+    removeJob: vi.fn(),
+    toggleEnabled: vi.fn(),
+    runJob: vi.fn(),
+    clearError: vi.fn(),
+  }),
+  formatSchedule: () => 'Cron: 0 9 * * *',
+  formatRelativeTime: () => 'soon',
+  getChannelDisplayName: (channel: string) => channel,
+}))
+
+vi.mock('@/lib/cron-utils', () => ({
+  getDeliveryTargetDisplay: () => 'target',
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...classes: string[]) => classes.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('../shared', () => ({
+  ToggleSwitch: ({ enabled, onChange }: any) => (
+    <input
+      type="checkbox"
+      checked={enabled}
+      onChange={(event) => onChange(event.currentTarget.checked)}
+      readOnly
+    />
+  ),
+}))
+
+vi.mock('../cron/CronJobDialog', () => ({
+  CronJobDialog: () => null,
+}))
+
+vi.mock('../cron/CronHistoryDialog', () => ({
+  CronHistoryDialog: () => null,
+}))
+
+import { CronSection } from '../CronSection'
+
+describe('CronSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads jobs immediately when mounted', async () => {
+    render(<CronSection />)
+
+    await waitFor(() => {
+      expect(mockLoadJobs).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src-tauri/crates/teamclaw-introspect/src/capabilities.rs
+++ b/src-tauri/crates/teamclaw-introspect/src/capabilities.rs
@@ -97,16 +97,12 @@ fn build_overview(workspace: &str) -> Result<Value, String> {
     let members = crate::config::read_team_members(workspace).unwrap_or(json!({}));
     let member_count = members.as_object().map(|m| m.len()).unwrap_or(0);
 
-    let cron_jobs = crate::config::read_cron_jobs(workspace).unwrap_or(json!([]));
-    let cron_total = cron_jobs.as_array().map(|a| a.len()).unwrap_or(0);
+    let cron_jobs = crate::config::cron_jobs_from_value(&crate::config::read_cron_jobs(workspace)?);
+    let cron_total = cron_jobs.len();
     let cron_enabled = cron_jobs
-        .as_array()
-        .map(|a| {
-            a.iter()
-                .filter(|j| j.get("enabled").and_then(|v| v.as_bool()).unwrap_or(false))
-                .count()
-        })
-        .unwrap_or(0);
+        .iter()
+        .filter(|j| j.get("enabled").and_then(|v| v.as_bool()).unwrap_or(false))
+        .count();
 
     Ok(json!({
         "channels": {
@@ -376,7 +372,7 @@ fn build_team_info(workspace: &str) -> Result<Value, String> {
 
 fn build_cron_jobs(workspace: &str) -> Result<Value, String> {
     let raw = crate::config::read_cron_jobs(workspace)?;
-    let jobs = raw.as_array().cloned().unwrap_or_default();
+    let jobs = crate::config::cron_jobs_from_value(&raw);
 
     let safe: Vec<Value> = jobs
         .iter()

--- a/src-tauri/crates/teamclaw-introspect/src/config.rs
+++ b/src-tauri/crates/teamclaw-introspect/src/config.rs
@@ -84,14 +84,27 @@ pub fn write_teamclaw_config(workspace: &str, config: &Value) -> Result<(), Stri
     write_json_file(&config_path(workspace), config)
 }
 
-/// Read `{workspace}/.teamclaw/cron-jobs.json`. Returns `[]` if missing.
+/// Read `{workspace}/.teamclaw/cron-jobs.json`. Returns `{ "jobs": [] }` if missing.
 pub fn read_cron_jobs(workspace: &str) -> Result<Value, String> {
-    read_json_file_or_default(&cron_jobs_path(workspace), Value::Array(vec![]))
+    read_json_file_or_default(
+        &cron_jobs_path(workspace),
+        serde_json::json!({ "jobs": [] }),
+    )
 }
 
 /// Write `{workspace}/.teamclaw/cron-jobs.json`.
 pub fn write_cron_jobs(workspace: &str, data: &Value) -> Result<(), String> {
     write_json_file(&cron_jobs_path(workspace), data)
+}
+
+/// Extract cron jobs from the native `{ jobs: [...] }` shape, while accepting the
+/// legacy bare-array shape written by older introspect versions.
+pub fn cron_jobs_from_value(data: &Value) -> Vec<Value> {
+    data.get("jobs")
+        .and_then(|v| v.as_array())
+        .or_else(|| data.as_array())
+        .cloned()
+        .unwrap_or_default()
 }
 
 /// Read last `limit` lines from `{workspace}/.teamclaw/cron-runs/{job_id}.jsonl`.

--- a/src-tauri/crates/teamclaw-introspect/src/cron.rs
+++ b/src-tauri/crates/teamclaw-introspect/src/cron.rs
@@ -30,6 +30,7 @@ fn action_create(workspace: &str, args: &Value) -> Result<Value, String> {
     let schedule = args
         .get("schedule")
         .ok_or_else(|| "create requires 'schedule'".to_string())?;
+    let schedule = normalize_schedule(schedule)?;
 
     let message = args
         .get("message")
@@ -53,7 +54,7 @@ fn action_create(workspace: &str, args: &Value) -> Result<Value, String> {
     }
 
     job.insert("enabled".to_string(), Value::Bool(true));
-    job.insert("schedule".to_string(), schedule.clone());
+    job.insert("schedule".to_string(), schedule);
     job.insert("payload".to_string(), json!({ "message": message }));
 
     if let Some(d) = delivery {
@@ -70,7 +71,7 @@ fn action_create(workspace: &str, args: &Value) -> Result<Value, String> {
     // Read, append, write
     let mut jobs = read_jobs_array(workspace)?;
     jobs.push(new_job.clone());
-    crate::config::write_cron_jobs(workspace, &Value::Array(jobs))?;
+    write_jobs_array(workspace, jobs)?;
 
     Ok(json!({
         "action": "created",
@@ -102,7 +103,7 @@ fn action_set_enabled(workspace: &str, args: &Value, enabled: bool) -> Result<Va
         return Err(format!("Cron job not found: {job_id}"));
     }
 
-    crate::config::write_cron_jobs(workspace, &Value::Array(jobs))?;
+    write_jobs_array(workspace, jobs)?;
 
     let action = if enabled { "resumed" } else { "paused" };
     Ok(json!({
@@ -128,7 +129,7 @@ fn action_delete(workspace: &str, args: &Value) -> Result<Value, String> {
         return Err(format!("Cron job not found: {job_id}"));
     }
 
-    crate::config::write_cron_jobs(workspace, &Value::Array(updated))?;
+    write_jobs_array(workspace, updated)?;
 
     // Delete run history file if it exists
     let runs_dir = std::path::Path::new(workspace)
@@ -244,7 +245,34 @@ fn action_get_runs(workspace: &str, args: &Value) -> Result<Value, String> {
 
 fn read_jobs_array(workspace: &str) -> Result<Vec<Value>, String> {
     let data = crate::config::read_cron_jobs(workspace)?;
-    Ok(data.as_array().cloned().unwrap_or_default())
+    Ok(crate::config::cron_jobs_from_value(&data))
+}
+
+fn write_jobs_array(workspace: &str, jobs: Vec<Value>) -> Result<(), String> {
+    crate::config::write_cron_jobs(workspace, &json!({ "jobs": jobs }))
+}
+
+fn normalize_schedule(schedule: &Value) -> Result<Value, String> {
+    if let Some(expr) = schedule.as_str() {
+        let expr = expr.trim();
+        if expr.is_empty() {
+            return Err("schedule cron expression cannot be empty".to_string());
+        }
+        return Ok(json!({ "kind": "cron", "expr": expr }));
+    }
+
+    let Some(schedule_obj) = schedule.as_object() else {
+        return Err("schedule must be a cron expression string or schedule object".to_string());
+    };
+
+    if !matches!(
+        schedule_obj.get("kind").and_then(|v| v.as_str()),
+        Some("at" | "every" | "cron")
+    ) {
+        return Err("schedule.kind must be one of: at, every, cron".to_string());
+    }
+
+    Ok(Value::Object(schedule_obj.clone()))
 }
 
 fn require_job_id<'a>(args: &'a Value) -> Result<&'a str, String> {
@@ -288,4 +316,56 @@ fn safe_job_summary(job: &Value) -> Value {
         }
     }
     Value::Object(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn temp_workspace() -> PathBuf {
+        std::env::temp_dir().join(format!("teamclaw-introspect-cron-{}", Uuid::new_v4()))
+    }
+
+    #[tokio::test]
+    async fn create_writes_native_cron_jobs_wrapper_for_cron_expression() {
+        let workspace = temp_workspace();
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let result = handle(
+            workspace.to_str().unwrap(),
+            1420,
+            &json!({
+                "action": "create",
+                "name": "Morning summary",
+                "schedule": "0 9 * * *",
+                "message": "Summarize yesterday's work"
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result["action"], "created");
+
+        let raw = std::fs::read_to_string(workspace.join(".teamclaw/cron-jobs.json")).unwrap();
+        let data: Value = serde_json::from_str(&raw).unwrap();
+        let jobs = data
+            .get("jobs")
+            .and_then(|v| v.as_array())
+            .expect("cron jobs file should use the native { jobs: [...] } shape");
+
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0]["name"], "Morning summary");
+        assert_eq!(jobs[0]["enabled"], true);
+        assert_eq!(
+            jobs[0]["schedule"],
+            json!({ "kind": "cron", "expr": "0 9 * * *" })
+        );
+        assert_eq!(
+            jobs[0]["payload"],
+            json!({ "message": "Summarize yesterday's work" })
+        );
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
 }

--- a/src-tauri/crates/teamclaw-introspect/src/main.rs
+++ b/src-tauri/crates/teamclaw-introspect/src/main.rs
@@ -103,16 +103,36 @@ fn tool_definitions() -> Value {
                         "description": "Human-readable description of what the job does."
                     },
                     "schedule": {
-                        "type": "string",
-                        "description": "Cron expression, e.g. '0 9 * * 1-5' (required for create)."
+                        "description": "Schedule for the job (required for create). A plain string is treated as a 5-field cron expression, e.g. '0 9 * * 1-5'. For one-time or interval jobs, pass an object such as {\"kind\":\"at\",\"at\":\"2026-05-07T09:00:00Z\"}, {\"kind\":\"every\",\"everyMs\":3600000}, or {\"kind\":\"cron\",\"expr\":\"0 9 * * 1-5\",\"tz\":\"Asia/Shanghai\"}.",
+                        "anyOf": [
+                            { "type": "string" },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "kind": { "type": "string", "enum": ["at", "every", "cron"] },
+                                    "at": { "type": "string" },
+                                    "everyMs": { "type": "integer" },
+                                    "expr": { "type": "string" },
+                                    "tz": { "type": "string" }
+                                },
+                                "required": ["kind"]
+                            }
+                        ]
                     },
                     "message": {
                         "type": "string",
                         "description": "Message or prompt to execute on each run (required for create)."
                     },
                     "delivery": {
-                        "type": "string",
-                        "description": "Optional delivery channel for cron results."
+                        "type": "object",
+                        "description": "Optional delivery settings for cron results.",
+                        "properties": {
+                            "mode": { "type": "string", "enum": ["announce", "none"] },
+                            "channel": { "type": "string", "enum": ["discord", "feishu", "email", "kook", "wechat", "wecom"] },
+                            "to": { "type": "string" },
+                            "bestEffort": { "type": "boolean" }
+                        },
+                        "required": ["mode", "channel", "to"]
                     }
                 },
                 "required": ["action"]

--- a/src-tauri/src/commands/cron/storage.rs
+++ b/src-tauri/src/commands/cron/storage.rs
@@ -19,6 +19,48 @@ impl Default for CronStorage {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn list_jobs_reflects_external_file_changes() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_path = workspace.path().to_str().unwrap();
+        let storage = CronStorage::new();
+
+        storage.init(workspace_path).await;
+        assert!(storage.list_jobs().await.is_empty());
+
+        let now = Utc::now().to_rfc3339();
+        let jobs_path = CronStorage::jobs_path(workspace_path);
+        std::fs::create_dir_all(jobs_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &jobs_path,
+            serde_json::to_string_pretty(&json!({
+                "jobs": [{
+                    "id": "external-job",
+                    "name": "External job",
+                    "enabled": true,
+                    "schedule": { "kind": "cron", "expr": "0 9 * * *" },
+                    "payload": { "message": "hello" },
+                    "deleteAfterRun": false,
+                    "createdAt": now,
+                    "updatedAt": now
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let jobs = storage.list_jobs().await;
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].id, "external-job");
+    }
+}
+
 impl Clone for CronStorage {
     fn clone(&self) -> Self {
         Self {
@@ -140,15 +182,46 @@ impl CronStorage {
         }
     }
 
+    /// Reload jobs from disk so changes made by external tools (such as the
+    /// teamclaw-introspect MCP sidecar) become visible to the UI and scheduler.
+    async fn reload_jobs_from_disk(&self) {
+        let workspace = self.workspace_path.read().await.clone();
+        let Some(ws) = workspace.as_ref() else {
+            return;
+        };
+
+        let jobs_path = Self::jobs_path(ws);
+        if !jobs_path.exists() {
+            return;
+        }
+
+        match std::fs::read_to_string(&jobs_path) {
+            Ok(content) => match serde_json::from_str::<CronJobsData>(&content) {
+                Ok(loaded) => {
+                    let mut data = self.data.write().await;
+                    *data = loaded;
+                }
+                Err(e) => {
+                    eprintln!("[Cron] Failed to parse jobs file during reload: {}", e);
+                }
+            },
+            Err(e) => {
+                eprintln!("[Cron] Failed to read jobs file during reload: {}", e);
+            }
+        }
+    }
+
     // ==================== Job CRUD ====================
 
     /// Get all jobs
     pub async fn list_jobs(&self) -> Vec<CronJob> {
+        self.reload_jobs_from_disk().await;
         self.data.read().await.jobs.clone()
     }
 
     /// Get a single job by ID
     pub async fn get_job(&self, job_id: &str) -> Option<CronJob> {
+        self.reload_jobs_from_disk().await;
         self.data
             .read()
             .await


### PR DESCRIPTION
## Summary
- Store teamclaw-introspect cron jobs using the native { jobs: [...] } shape and normalize string cron schedules.
- Reload cron storage from disk before listing or resolving jobs so MCP-created jobs appear in Automation settings and can be run.
- Refresh Automation jobs immediately on mount and add regression coverage for the UI refresh path.

## Test Plan
- rustfmt --edition 2021 --check src-tauri/crates/teamclaw-introspect/src/capabilities.rs src-tauri/crates/teamclaw-introspect/src/config.rs src-tauri/crates/teamclaw-introspect/src/cron.rs src-tauri/crates/teamclaw-introspect/src/main.rs src-tauri/src/commands/cron/storage.rs
- cargo test --manifest-path src-tauri/crates/teamclaw-introspect/Cargo.toml
- CI=true cargo test --manifest-path src-tauri/Cargo.toml commands::cron::storage::tests::list_jobs_reflects_external_file_changes -- --nocapture
- pnpm --dir packages/app exec vitest run src/components/settings/__tests__/CronSection.test.tsx src/stores/__tests__/cron.test.ts

Note: full cargo fmt --manifest-path src-tauri/Cargo.toml --check currently reports an unrelated upstream/main formatting diff in src-tauri/build.rs; this PR leaves that file untouched.