### PR TITLE
fix(gateway): open browser and surface auth URL for Gmail OAuth

### DIFF
--- a/packages/app/src/components/settings/channels/Email.tsx
+++ b/packages/app/src/components/settings/channels/Email.tsx
@@ -49,6 +49,7 @@ export function EmailChannel() {
     emailHasChanges,
     emailIsTesting,
     emailTestResult,
+    gmailAuthUrl,
     saveEmailConfig,
     startEmailGateway,
     stopEmailGateway,
@@ -373,6 +374,26 @@ export function EmailChannel() {
                     </span>
                   )}
                 </div>
+                {gmailAuthUrl && (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 dark:border-amber-900/50 dark:bg-amber-900/20 p-3 space-y-2">
+                    <p className="text-xs text-amber-700 dark:text-amber-300">
+                      {t(
+                        'settings.channels.email.gmailAuthUrlHint',
+                        "If your browser didn't open automatically, copy the URL below and open it manually to complete authorization.",
+                      )}
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <Input readOnly value={gmailAuthUrl} className="text-xs font-mono" />
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => navigator.clipboard.writeText(gmailAuthUrl)}
+                      >
+                        {t('settings.channels.email.copy', 'Copy')}
+                      </Button>
+                    </div>
+                  </div>
+                )}
                 {emailTestResult && (
                   <div className={cn(
                     'flex items-center gap-2 text-sm p-2 rounded',

--- a/packages/app/src/stores/channels-store.ts
+++ b/packages/app/src/stores/channels-store.ts
@@ -96,6 +96,7 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
   emailHasChanges: false,
   emailIsTesting: false,
   emailTestResult: null,
+  gmailAuthUrl: null,
 
   // Compose all channel actions
   ...createDiscordActions(set),

--- a/packages/app/src/stores/channels-types.ts
+++ b/packages/app/src/stores/channels-types.ts
@@ -306,6 +306,10 @@ export interface ChannelsState {
   emailHasChanges: boolean
   emailIsTesting: boolean
   emailTestResult: { success: boolean; message: string } | null
+  /// Set when a Gmail OAuth flow is in progress and yup_oauth2 has produced
+  /// the auth URL. Surfaced so the UI can display it for manual copy/paste
+  /// when the system browser fails to auto-open. Cleared when the flow ends.
+  gmailAuthUrl: string | null
 
   // KOOK state
   kook: KookConfig | null

--- a/packages/app/src/stores/channels/email.ts
+++ b/packages/app/src/stores/channels/email.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
 import type {
   EmailConfig,
   EmailGatewayStatusResponse,
@@ -125,11 +126,18 @@ export function createEmailActions(set: ChannelsSet) {
     },
 
     gmailAuthorize: async (clientId: string, clientSecret: string, email: string) => {
-      set({ emailIsLoading: true, emailTestResult: null })
+      set({ emailIsLoading: true, emailTestResult: null, gmailAuthUrl: null })
+      // The Rust command emits `gmail-auth-url` once yup_oauth2 has the auth URL.
+      // We surface it on state so the UI can show it for manual copy/paste in
+      // case the system browser fails to auto-open.
+      const unlisten = await listen<string>('gmail-auth-url', (event) => {
+        set({ gmailAuthUrl: event.payload })
+      })
       try {
         await invoke<string>('gmail_authorize', { clientId, clientSecret, email })
         set({
           emailIsLoading: false,
+          gmailAuthUrl: null,
           emailTestResult: {
             success: true,
             message: 'Gmail authorized successfully',
@@ -140,12 +148,15 @@ export function createEmailActions(set: ChannelsSet) {
         const errorMessage = error instanceof Error ? error.message : String(error)
         set({
           emailIsLoading: false,
+          gmailAuthUrl: null,
           emailTestResult: {
             success: false,
             message: errorMessage,
           },
         })
         return false
+      } finally {
+        unlisten()
       }
     },
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5748,6 +5748,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10632,6 +10662,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11871,6 +11911,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "webbrowser",
  "wiremock 0.6.5",
  "yup-oauth2",
 ]
@@ -13316,6 +13357,22 @@ dependencies = [
  "phf_codegen 0.13.1",
  "string_cache 0.9.0",
  "string_cache_codegen 0.6.1",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
 ]
 
 [[package]]

--- a/src-tauri/crates/teamclaw-gateway/Cargo.toml
+++ b/src-tauri/crates/teamclaw-gateway/Cargo.toml
@@ -13,6 +13,7 @@ native-tls = "0.2"
 mail-parser = "0.9"
 lettre = { version = "0.11", features = ["native-tls", "smtp-transport"] }
 yup-oauth2 = "12"
+webbrowser = "1"
 flate2 = "1"
 
 # WebSocket-based gateways (Kook, Feishu, WeChat, WeCom)

--- a/src-tauri/crates/teamclaw-gateway/src/email.rs
+++ b/src-tauri/crates/teamclaw-gateway/src/email.rs
@@ -92,6 +92,42 @@ const GMAIL_SCOPE: &str = "https://mail.google.com/";
 /// Token file name stored in workspace TEAMCLAW_DIR
 const TOKEN_FILE_NAME: &str = "email-tokens.json";
 
+// ==================== OAuth2 Flow Delegate ====================
+
+/// Type-erased callback for delivering the auth URL to the caller (e.g. so
+/// the UI can display it for manual copy/paste if `webbrowser::open` fails).
+pub type AuthUrlCallback = Box<dyn Fn(&str) + Send + Sync + 'static>;
+
+/// Custom `InstalledFlowDelegate` that opens the auth URL in the system
+/// browser AND forwards it to a caller-provided callback. The default
+/// delegate from yup-oauth2 only `println!`s the URL to stdout, which is
+/// invisible inside a packaged Tauri desktop app.
+struct BrowserOpenerDelegate {
+    on_url: AuthUrlCallback,
+}
+
+impl yup_oauth2::authenticator_delegate::InstalledFlowDelegate for BrowserOpenerDelegate {
+    fn present_user_url<'a>(
+        &'a self,
+        url: &'a str,
+        _need_code: bool,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<String, String>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            (self.on_url)(url);
+            // Best-effort browser open. If it fails (no default browser, sandbox,
+            // etc.), the URL is still surfaced via on_url for manual copy/paste.
+            if let Err(e) = webbrowser::open(url) {
+                eprintln!("[Gmail OAuth] Failed to open browser: {}", e);
+            }
+            // HTTPRedirect flow doesn't need a code from the user; the local
+            // listener captures the redirect.
+            Ok(String::new())
+        })
+    }
+}
+
 // ==================== OAuth2 Token Manager ====================
 
 /// Manages Gmail OAuth2 tokens with auto-refresh
@@ -130,14 +166,17 @@ impl GmailTokenManager {
         }
     }
 
-    /// Perform the OAuth2 authorization flow (opens browser)
-    async fn authorize(&self) -> Result<String, String> {
+    /// Perform the OAuth2 authorization flow. The provided callback receives
+    /// the auth URL when the flow is ready to present it; the default delegate
+    /// will also try to open it in the system browser.
+    async fn authorize(&self, on_url: AuthUrlCallback) -> Result<String, String> {
         let secret = self.build_secret();
         let auth = yup_oauth2::InstalledFlowAuthenticator::builder(
             secret,
             yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
         )
         .persist_tokens_to_disk(&self.token_path)
+        .flow_delegate(Box::new(BrowserOpenerDelegate { on_url }))
         .build()
         .await
         .map_err(|e| format!("Failed to build authenticator: {}", e))?;
@@ -430,9 +469,10 @@ impl EmailGateway {
         client_secret: &str,
         email: &str,
         workspace_path: &str,
+        on_url: AuthUrlCallback,
     ) -> Result<String, String> {
         let token_manager = GmailTokenManager::new(client_id, client_secret, email, workspace_path);
-        token_manager.authorize().await
+        token_manager.authorize(on_url).await
     }
 
     pub async fn check_gmail_auth(workspace_path: &str) -> bool {

--- a/src-tauri/crates/teamclaw-gateway/src/lib.rs
+++ b/src-tauri/crates/teamclaw-gateway/src/lib.rs
@@ -20,7 +20,7 @@ pub mod wecom_config;
 
 pub use config::*;
 pub use discord::DiscordGateway;
-pub use email::EmailGateway;
+pub use email::{AuthUrlCallback, EmailGateway};
 pub use feishu::FeishuGateway;
 pub use feishu_config::*;
 pub use kook::KookGateway;

--- a/src-tauri/src/commands/gateway/mod.rs
+++ b/src-tauri/src/commands/gateway/mod.rs
@@ -5,7 +5,7 @@ pub use teamclaw_gateway::*;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use tauri::State;
+use tauri::{AppHandle, Emitter, State};
 
 use crate::commands::opencode::OpenCodeState;
 
@@ -558,17 +558,25 @@ pub async fn test_email_connection(email: email_config::EmailConfig) -> Result<S
     EmailGateway::test_connection(&email).await
 }
 
-/// Authorize Gmail OAuth2 (opens browser)
+/// Authorize Gmail OAuth2. Opens the auth URL in the system browser AND
+/// emits a `gmail-auth-url` event with the URL so the UI can display it
+/// for manual copy/paste (in case the browser auto-open fails).
 #[tauri::command]
 pub async fn gmail_authorize(
     client_id: String,
     client_secret: String,
     email: String,
+    app: AppHandle,
     opencode_state: State<'_, OpenCodeState>,
 ) -> Result<String, String> {
     let workspace_path = crate::commands::opencode::current_workspace_path(&opencode_state)?;
 
-    EmailGateway::gmail_authorize(&client_id, &client_secret, &email, &workspace_path).await
+    let app_for_callback = app.clone();
+    let on_url: teamclaw_gateway::AuthUrlCallback = Box::new(move |url: &str| {
+        let _ = app_for_callback.emit("gmail-auth-url", url.to_string());
+    });
+
+    EmailGateway::gmail_authorize(&client_id, &client_secret, &email, &workspace_path, on_url).await
 }
 
 /// Check if Gmail OAuth2 tokens exist


### PR DESCRIPTION
## Summary

- The default `yup_oauth2::InstalledFlowDelegate` only `println!`s the auth URL to stdout — invisible inside a packaged Tauri desktop app — so the "授权 Gmail" button spins forever waiting on an OAuth callback that can never arrive.
- Add a custom `BrowserOpenerDelegate` that opens the URL in the system browser via the `webbrowser` crate AND forwards it through a callback.
- The `gmail_authorize` Tauri command forwards the URL via a `gmail-auth-url` event so the settings UI can render it with a Copy button as a fallback when the system browser fails to auto-open.

## Test plan

- [ ] `pnpm rust:check` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm tauri:dev`: enter valid Gmail OAuth credentials, click "授权 Gmail"
  - Browser opens to Google's consent page automatically
  - Auth URL appears in an amber-bordered box below the button
  - "Copy" button copies the URL to clipboard
  - After granting consent in the browser, button switches to "Authorized" state
- [ ] `pnpm tauri:dev` on a system where `webbrowser::open` fails: URL is still surfaced in the UI for manual copy/paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)