### PR TITLE
fix(opencode): resolve teamclaw-introspect binary on Windows

### DIFF
--- a/src-tauri/src/commands/opencode.rs
+++ b/src-tauri/src/commands/opencode.rs
@@ -877,6 +877,27 @@ const KNOWN_TRIPLES: &[&str] = &[
     "aarch64-pc-windows-msvc",
 ];
 
+/// Resolve a candidate executable path, checking with and (on Windows) without
+/// `.exe` extension. Returns the first variant that exists on disk.
+///
+/// Tauri's `externalBin` mechanism appends `.exe` on Windows when bundling, and
+/// `cargo build` outputs `<name>.exe` on Windows in dev. Path joins in this file
+/// generally omit the extension, so this helper bridges that.
+fn resolve_executable(path: std::path::PathBuf) -> Option<std::path::PathBuf> {
+    if path.exists() {
+        return Some(path);
+    }
+    if cfg!(windows) {
+        let mut with_exe = path.into_os_string();
+        with_exe.push(".exe");
+        let with_exe = std::path::PathBuf::from(with_exe);
+        if with_exe.exists() {
+            return Some(with_exe);
+        }
+    }
+    None
+}
+
 /// Ensure opencode.json exists and has a `permission` section with TeamClaw defaults.
 ///
 /// OpenCode's built-in default is `"*": "allow"` (everything auto-approved).
@@ -1011,18 +1032,18 @@ fn ensure_inherent_config(workspace_path: &str) -> Result<(), String> {
                     let dev_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
                         .join("binaries")
                         .join(format!("teamclaw-introspect-{}", triple));
-                    if dev_path.exists() {
-                        return Some(dev_path.to_string_lossy().to_string());
+                    if let Some(p) = resolve_executable(dev_path) {
+                        return Some(p.to_string_lossy().to_string());
                     }
                     // Production: sidecar is next to the main exe
                     // Tauri may strip the triple suffix when bundling
                     let prod_path_with_triple = dir.join(format!("teamclaw-introspect-{}", triple));
-                    if prod_path_with_triple.exists() {
-                        return Some(prod_path_with_triple.to_string_lossy().to_string());
+                    if let Some(p) = resolve_executable(prod_path_with_triple) {
+                        return Some(p.to_string_lossy().to_string());
                     }
                     let prod_path = dir.join("teamclaw-introspect");
-                    if prod_path.exists() {
-                        return Some(prod_path.to_string_lossy().to_string());
+                    if let Some(p) = resolve_executable(prod_path) {
+                        return Some(p.to_string_lossy().to_string());
                     }
                     None
                 });
@@ -1866,8 +1887,8 @@ fn resolve_sidecar_binary_paths(workspace_path: &str) -> Result<(), String> {
                                     let abs_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
                                         .join("binaries")
                                         .join(format!("teamclaw-introspect-{}", target_triple));
-                                    if abs_path.exists() {
-                                        let new_cmd = abs_path.to_string_lossy().to_string();
+                                    if let Some(resolved) = resolve_executable(abs_path) {
+                                        let new_cmd = resolved.to_string_lossy().to_string();
                                         println!(
                                             "[OpenCode] Resolved MCP '{}' binary: {} -> {}",
                                             name, cmd_str, new_cmd


### PR DESCRIPTION
## Summary

- The runtime path resolution joined paths like `binaries/teamclaw-introspect-<triple>` and `<exe-dir>/teamclaw-introspect` without the `.exe` suffix. The actual file on Windows is named with `.exe` (cargo output in dev; Tauri-bundled name in prod), so `Path::exists()` always returned `false` and the inherent MCP got silently skipped with `[Config] teamclaw-introspect binary not found, skipping MCP registration`.
- Add a `resolve_executable` helper that, on Windows, also checks `<path>.exe`. Use it for both the inherent MCP registration and the legacy `./binaries/teamclaw-introspect` config migration.
- Existing broken Windows installs self-heal: the existing `needs_introspect` check at the top of the registration block already re-runs registration when the saved binary path doesn't exist, so the next launch picks up the corrected `.exe` path.

`build.rs` already handled `.exe` for its build-time existence check (line 162-166) — this bug was purely runtime path resolution.

## Test plan

- [ ] `pnpm rust:check` passes (verified locally)
- [ ] `cargo clippy -p teamclaw -- -D warnings` clean (verified locally)
- [ ] On Windows: launch app → check launch log shows `[Config] Added inherent 'teamclaw-introspect' MCP config` (not the "binary not found" message)
- [ ] On Windows: `teamclaw-introspect` MCP appears as available/usable in the settings UI
- [ ] On macOS / Linux: regression check — MCP still registers correctly (no `.exe` suffix is appended on non-Windows platforms)
- [ ] Existing Windows installs with the stale (no-`.exe`) config self-heal on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)