### PR TITLE
Fix cron long runs and chat UI issues

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -30,7 +30,7 @@
     "@codemirror/view": "^6.39.14",
     "@json-render/core": "^0.3.0",
     "@json-render/react": "^0.2.0",
-    "@opencode-ai/sdk": "^1.4.0",
+    "@opencode-ai/sdk": "^1.14.18",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/packages/app/src/components/__tests__/app-sidebar.test.tsx
+++ b/packages/app/src/components/__tests__/app-sidebar.test.tsx
@@ -144,9 +144,13 @@ vi.mock('@/lib/ui-variant', () => ({
 
 vi.mock('@/components/ui/sidebar', () => ({
   Sidebar: ({ children, ...props }: any) => <div data-testid="sidebar" {...props}>{children}</div>,
-  SidebarContent: ({ children }: any) => <div>{children}</div>,
+  SidebarContent: ({ children, className }: any) => (
+    <div data-testid="sidebar-content" className={className}>
+      {children}
+    </div>
+  ),
   SidebarFooter: ({ children }: any) => <div>{children}</div>,
-  SidebarGroup: ({ children }: any) => <div>{children}</div>,
+  SidebarGroup: ({ children, className }: any) => <div className={className}>{children}</div>,
   SidebarHeader: ({ children }: any) => <div>{children}</div>,
   SidebarMenu: ({ children }: any) => <div>{children}</div>,
   SidebarMenuButton: ({ children, onClick, isActive: _isActive, ...props }: any) => (
@@ -555,6 +559,24 @@ describe('AppSidebar', () => {
     render(<AppSidebar />)
     expect(screen.getByText('Settings')).toBeDefined()
     expect(screen.queryByText('设置')).toBeNull()
+  })
+
+  it('workspace mode only scrolls the session list area', () => {
+    uiVariantMocks.workspaceShell = true
+
+    const { container } = render(<AppSidebar />)
+
+    expect(screen.getByTestId('sidebar-content').getAttribute('class')).toContain('overflow-hidden')
+
+    const sessionScrollRegion = container.querySelector('[data-testid="sidebar-session-scroll"]')
+    expect(sessionScrollRegion).not.toBeNull()
+    expect(sessionScrollRegion!.getAttribute('class')).toContain('overflow-y-auto')
+    expect(sessionScrollRegion!.textContent).toContain('Session One')
+    expect(sessionScrollRegion!.textContent).toContain('Session Two')
+    expect(sessionScrollRegion!.textContent).not.toContain('Shortcuts')
+    expect(sessionScrollRegion!.textContent).not.toContain('Automation')
+    expect(sessionScrollRegion!.textContent).not.toContain('Roles & Skills')
+    expect(sessionScrollRegion!.textContent).not.toContain('New Chat')
   })
 
   it('workspace variant preserves the settings footer row', () => {

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -1093,7 +1093,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           </div>
         )}
 
-        <SidebarContent>
+        <SidebarContent className="overflow-hidden">
           {isWorkspaceUIVariant() && (
             <div className="px-1.5 pb-0 pt-0">
               <div className="flex flex-col gap-0.5">
@@ -1144,7 +1144,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           )}
           <SidebarGroup
             className={cn(
-              "min-h-0 flex-1",
+              "min-h-0 flex-1 overflow-hidden",
               isWorkspaceUIVariant() ? "!px-1 !pb-2 !pt-1" : "!px-0 !pb-0 !pt-0",
             )}
           >
@@ -1158,7 +1158,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             )}
 
             {defaultSidebarContent === 'session' && (
-              <>
+              <div
+                data-testid="sidebar-session-scroll"
+                className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
+              >
                 <SidebarMenu>
                   {isLoading && sessions.length === 0 ? (
                     <div className="flex items-center justify-center py-8">
@@ -1218,7 +1221,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     </Button>
                   </div>
                 )}
-              </>
+              </div>
             )}
 
             {defaultSidebarContent === 'knowledge' && (

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -107,6 +107,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
   // ── Session store selectors (reactive state only) ────────────────────
   const activeSessionId = useSessionStore(s => s.activeSessionId);
   const error = useSessionStore(s => s.error);
+  const errorSessionId = useSessionStore(s => s.errorSessionId);
   const isConnected = useSessionStore(s => s.isConnected);
   const streamingMessageId = useStreamingStore(s => s.streamingMessageId);
   const messageQueue = useSessionStore(s => s.messageQueue);
@@ -812,6 +813,29 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     </div>
   ), [compact, t, suggestions, handleSuggestionClick]);
 
+  const visibleSessionError =
+    sessionError?.sessionId && sessionError.sessionId === displaySessionId
+      ? sessionError
+      : null;
+  const visibleError =
+    error && errorSessionId && errorSessionId === displaySessionId
+      ? error
+      : null;
+
+  const messageBottomContent = !isViewingChild ? (
+    visibleSessionError ? (
+      <SessionErrorAlert
+        error={visibleSessionError}
+        onDismiss={clearSessionError}
+      />
+    ) : visibleError ? (
+      <SessionErrorAlert
+        error={visibleError}
+        onDismiss={() => setError(null)}
+      />
+    ) : null
+  ) : null;
+
   // ── Render ────────────────────────────────────────────────────────────
 
   return (
@@ -977,6 +1001,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
             streamingMessageId={streamingMessageId}
             compact={compact}
             emptyState={emptyState}
+            bottomContent={messageBottomContent}
           />
         )}
       </div>
@@ -1036,18 +1061,6 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
                   />
                 ) : null}
                 <PendingPermissionInline />
-                {sessionError && (
-                  <SessionErrorAlert
-                    error={sessionError}
-                    onDismiss={clearSessionError}
-                  />
-                )}
-                {error && !sessionError && (
-                  <SessionErrorAlert
-                    error={error}
-                    onDismiss={() => setError(null)}
-                  />
-                )}
               </>
             }
           />

--- a/packages/app/src/components/chat/CommandPopover.tsx
+++ b/packages/app/src/components/chat/CommandPopover.tsx
@@ -244,8 +244,8 @@ export function CommandPopover({
         e.preventDefault()
         e.stopPropagation()
         setHighlightedIndex(i => (i - 1 + allItems.length) % allItems.length)
-      } else if (e.key === "Enter" && !e.shiftKey) {
-        if (e.isComposing || e.keyCode === 229) return
+      } else if ((e.key === "Enter" || e.key === "Tab") && !e.shiftKey) {
+        if (e.key === "Enter" && (e.isComposing || e.keyCode === 229)) return
         e.preventDefault()
         e.stopPropagation()
         const item = allItems[highlightedIndex]
@@ -409,7 +409,7 @@ export function CommandPopover({
         {/* Hint bar */}
         <div className="flex items-center gap-3 px-3 py-1.5 text-[10px] text-muted-foreground/60 border-t">
           <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↑↓</kbd> {t('chat.commandPopover.navigate', 'navigate')}</span>
-          <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↵</kbd> {t('chat.commandPopover.select', 'select')}</span>
+          <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↵/Tab</kbd> {t('chat.commandPopover.select', 'select')}</span>
           <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">Esc</kbd> {t('chat.commandPopover.close', 'close')}</span>
         </div>
       </div>

--- a/packages/app/src/components/chat/FileMentionPopover.tsx
+++ b/packages/app/src/components/chat/FileMentionPopover.tsx
@@ -175,8 +175,8 @@ export function FileMentionPopover({
         e.preventDefault()
         e.stopPropagation()
         setHighlightedIndex(i => (i - 1 + filteredEntries.length) % filteredEntries.length)
-      } else if (e.key === "Enter" && !e.shiftKey) {
-        if (e.isComposing || e.keyCode === 229) return
+      } else if ((e.key === "Enter" || e.key === "Tab") && !e.shiftKey) {
+        if (e.key === "Enter" && (e.isComposing || e.keyCode === 229)) return
         e.preventDefault()
         e.stopPropagation()
         const entry = filteredEntries[highlightedIndex]
@@ -257,7 +257,7 @@ export function FileMentionPopover({
       {/* Hint bar */}
       <div className="flex items-center gap-3 px-3 py-1.5 text-[10px] text-muted-foreground/60 border-t">
         <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↑↓</kbd> navigate</span>
-        <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↵</kbd> select</span>
+        <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↵/Tab</kbd> select</span>
         <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">Esc</kbd> close</span>
       </div>
     </div>

--- a/packages/app/src/components/chat/MessageList.tsx
+++ b/packages/app/src/components/chat/MessageList.tsx
@@ -136,13 +136,21 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
       let groupStart = -1;
       for (let i = 0; i <= renderedMessages.length; i++) {
         const msg = renderedMessages[i];
-        const isAssistant = msg && msg.role !== "user" && !msg.isStreaming;
+        const isAssistant = msg && msg.role !== "user";
         if (!isAssistant || i === renderedMessages.length) {
           // End of a group — finalize
           if (groupStart !== -1) {
             const groupEnd = i - 1;
             const groupLen = groupEnd - groupStart + 1;
-            if (groupLen > 1) {
+            const groupHasStreaming = renderedMessages
+              .slice(groupStart, groupEnd + 1)
+              .some((groupMessage) => groupMessage.isStreaming);
+
+            if (groupHasStreaming) {
+              for (let j = groupStart; j <= groupEnd; j++) {
+                info.set(renderedMessages[j].id, { hideTokenUsage: true });
+              }
+            } else if (groupLen > 1) {
               let totalInput = 0,
                 totalOutput = 0,
                 totalCost = 0;

--- a/packages/app/src/components/chat/MessageList.tsx
+++ b/packages/app/src/components/chat/MessageList.tsx
@@ -31,6 +31,8 @@ export interface MessageListProps {
   sessionDirectory?: string;
   /** Optional empty-state content rendered when there are no messages (not loading) */
   emptyState?: React.ReactNode;
+  /** Optional content rendered at the bottom of the scrollable message area. */
+  bottomContent?: React.ReactNode;
 }
 
 export interface MessageListHandle {
@@ -50,6 +52,7 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
       compact = false,
       sessionDirectory,
       emptyState,
+      bottomContent,
     },
     ref,
   ) {
@@ -189,6 +192,7 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
     const [showScrollButton, setShowScrollButton] = React.useState(false);
     const [inputAreaHeight, setInputAreaHeight] = React.useState(160);
     const [messageAreaWidth, setMessageAreaWidth] = React.useState(0);
+    const hasBottomContent = Boolean(bottomContent);
 
     // ── Refs ─────────────────────────────────────────────────────────────
     const scrollRef = React.useRef<HTMLDivElement>(null);
@@ -361,6 +365,7 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
       messageQueue.length,
       streamingContentLength,
       streamingUpdateTrigger,
+      hasBottomContent,
     ]);
 
     // Auto-scroll when streaming ends (to show token usage and final content)
@@ -688,6 +693,12 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
                     })
                   );
                 })()}
+              </div>
+            )}
+
+            {bottomContent && (
+              <div className="pt-3">
+                {bottomContent}
               </div>
             )}
           </div>

--- a/packages/app/src/components/chat/__tests__/ChatPanel-submission.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ChatPanel-submission.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor, within } from '@testing-library/react';
 import React from 'react';
 
 // ── Hoisted mocks ────────────────────────────────────────────────────────────
@@ -26,6 +26,7 @@ const workspaceState = {
 const mockSessionState = {
   activeSessionId: 'sess-1',
   error: null,
+  errorSessionId: null as string | null,
   isConnected: true,
   messageQueue: [] as Array<{ id: string; content: string; timestamp: Date }>,
   sessionError: null,
@@ -160,15 +161,18 @@ vi.mock('@/lib/opencode/sdk-client', () => ({
 // Mock child components to isolate ChatPanel behavior
 vi.mock('../MessageList', () => ({
   MessageList: React.forwardRef(function MockMessageList(
-    props: { messages: unknown[]; emptyState?: React.ReactNode },
+    props: { messages: unknown[]; emptyState?: React.ReactNode; bottomContent?: React.ReactNode },
     _ref: unknown,
   ) {
+    const body = props.messages.length === 0 && props.emptyState
+      ? props.emptyState
+      : `${props.messages.length} messages`;
+
     return React.createElement(
       'div',
       { 'data-testid': 'message-list' },
-      props.messages.length === 0 && props.emptyState
-        ? props.emptyState
-        : `${props.messages.length} messages`,
+      body,
+      props.bottomContent && React.createElement('div', { key: 'bottom' }, props.bottomContent),
     );
   }),
 }));
@@ -260,6 +264,7 @@ describe('ChatPanel submission flow', () => {
     workspaceState.openCodeReady = true;
     mockSessionState.activeSessionId = 'sess-1';
     mockSessionState.error = null;
+    mockSessionState.errorSessionId = null;
     mockSessionState.isConnected = true;
     mockSessionState.messageQueue = [];
     mockSessionState.sessionError = null;
@@ -663,17 +668,67 @@ describe('ChatPanel submission flow', () => {
       const { ChatPanel } = await import('../ChatPanel');
       render(React.createElement(ChatPanel));
 
-      expect(screen.getByTestId('session-error')).toBeDefined();
+      expect(within(screen.getByTestId('message-list')).getByTestId('session-error')).toBeDefined();
+      expect(within(screen.getByTestId('chat-input-area')).queryByTestId('session-error')).toBeNull();
     });
 
     it('shows general error when error exists and no sessionError', async () => {
       mockSessionState.error = 'Network error' as unknown as typeof mockSessionState.error;
+      mockSessionState.errorSessionId = 'sess-1';
       mockSessionState.sessionError = null;
 
       const { ChatPanel } = await import('../ChatPanel');
       render(React.createElement(ChatPanel));
 
-      expect(screen.getByTestId('session-error')).toBeDefined();
+      expect(within(screen.getByTestId('message-list')).getByTestId('session-error')).toBeDefined();
+      expect(within(screen.getByTestId('chat-input-area')).queryByTestId('session-error')).toBeNull();
+    });
+
+    it('does not show session error inside another session message list', async () => {
+      mockSessionState.activeSessionId = 'sess-2';
+      mockSessionState.sessions = [
+        ...mockSessionState.sessions,
+        {
+          id: 'sess-2',
+          title: 'Other',
+          messages: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+      mockSessionState.sessionError = {
+        sessionId: 'sess-1',
+        error: { name: 'TestError', data: { message: 'Test error' } },
+      } as unknown as typeof mockSessionState.sessionError;
+
+      const { ChatPanel } = await import('../ChatPanel');
+      render(React.createElement(ChatPanel));
+
+      expect(within(screen.getByTestId('message-list')).queryByTestId('session-error')).toBeNull();
+      expect(within(screen.getByTestId('chat-input-area')).queryByTestId('session-error')).toBeNull();
+    });
+
+    it('does not show a general send error inside another session message list', async () => {
+      mockSessionState.activeSessionId = 'sess-2';
+      mockSessionState.error = 'OpenCode API Error: NotFoundError' as unknown as typeof mockSessionState.error;
+      mockSessionState.errorSessionId = 'sess-1';
+      mockSessionState.sessionError = null;
+      mockSessionState.sessions = [
+        ...mockSessionState.sessions,
+        {
+          id: 'sess-2',
+          title: 'Other',
+          messages: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const { ChatPanel } = await import('../ChatPanel');
+      render(React.createElement(ChatPanel));
+
+      expect(within(screen.getByTestId('message-list')).queryByTestId('session-error')).toBeNull();
+      expect(within(screen.getByTestId('chat-input-area')).queryByTestId('session-error')).toBeNull();
     });
   });
 

--- a/packages/app/src/components/chat/__tests__/CommandPopover.test.tsx
+++ b/packages/app/src/components/chat/__tests__/CommandPopover.test.tsx
@@ -46,6 +46,19 @@ vi.mock('@/lib/utils', async () => {
   }
 })
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallbackOrOptions?: string | { count?: number }) => {
+      if (typeof fallbackOrOptions === 'string') return fallbackOrOptions
+      if (key === 'chat.commandPopover.roles') return `Roles (${fallbackOrOptions?.count})`
+      if (key === 'chat.commandPopover.skills') return `Skills (${fallbackOrOptions?.count})`
+      if (key === 'chat.commandPopover.commands') return `Commands (${fallbackOrOptions?.count})`
+      if (key === 'chat.commandPopover.itemCount') return `${fallbackOrOptions?.count} items`
+      return key
+    },
+  }),
+}))
+
 vi.mock('@/lib/opencode/sdk-client', () => ({
   getOpenCodeClient: () => ({
     listCommands: mockListCommands,
@@ -117,6 +130,35 @@ describe('CommandPopover', () => {
         description: 'Brainstorm first',
       }),
     )
+  })
+
+  it('selects the highlighted item with Tab', async () => {
+    const onSelect = vi.fn()
+    const onOpenChange = vi.fn()
+
+    render(
+      <CommandPopover
+        open={true}
+        onOpenChange={onOpenChange}
+        searchQuery="brain"
+        onSelect={onSelect}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('brainstorming')).toBeTruthy()
+    })
+
+    fireEvent.keyDown(document, { key: 'Tab' })
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'superpowers/brainstorming',
+        description: 'Brainstorm first',
+        _type: 'skill',
+      }),
+    )
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
   it('shows roles in a dedicated group and selects a role mention', async () => {

--- a/packages/app/src/components/chat/__tests__/FileMentionPopover.test.tsx
+++ b/packages/app/src/components/chat/__tests__/FileMentionPopover.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { FileMentionPopover, invalidateFileMentionCache } from '../FileMentionPopover'
+
+const { mockReadDir } = vi.hoisted(() => ({
+  mockReadDir: vi.fn(),
+}))
+
+vi.mock('@/lib/utils', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/utils')>('@/lib/utils')
+  return {
+    ...actual,
+    isTauri: () => true,
+  }
+})
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: (selector: (s: { workspacePath: string }) => unknown) =>
+    selector({ workspacePath: '/workspace/project' }),
+}))
+
+vi.mock('@/stores/team-mode', () => ({
+  useTeamModeStore: {
+    getState: () => ({ devUnlocked: false }),
+  },
+}))
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  readDir: mockReadDir,
+}))
+
+describe('FileMentionPopover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    invalidateFileMentionCache()
+    mockReadDir.mockImplementation(async (dir: string) => {
+      if (dir === '/workspace/project') {
+        return [
+          { name: 'README.md', isDirectory: false },
+          { name: 'src', isDirectory: true },
+        ]
+      }
+      return []
+    })
+  })
+
+  it('selects the highlighted file with Tab', async () => {
+    const onSelect = vi.fn()
+    const onOpenChange = vi.fn()
+
+    render(
+      <FileMentionPopover
+        open={true}
+        onOpenChange={onOpenChange}
+        searchQuery="read"
+        onSearchChange={vi.fn()}
+        onSelect={onSelect}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('README.md')).toBeTruthy()
+    })
+
+    fireEvent.keyDown(document, { key: 'Tab' })
+
+    expect(onSelect).toHaveBeenCalledWith('README.md')
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/packages/app/src/components/chat/__tests__/MessageList.test.tsx
+++ b/packages/app/src/components/chat/__tests__/MessageList.test.tsx
@@ -50,6 +50,22 @@ function makeMessage(overrides: Partial<Message> = {}): Message {
   };
 }
 
+function makeAssistantWithTokens(
+  overrides: Partial<Message> & { input: number; output: number },
+): Message {
+  const { input, output, ...messageOverrides } = overrides;
+  return makeMessage({
+    role: 'assistant',
+    tokens: {
+      input,
+      output,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    ...messageOverrides,
+  });
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────
 
 describe('MessageList', () => {
@@ -145,18 +161,13 @@ describe('MessageList', () => {
     expect(container.textContent).toContain('Message 0');
   });
 
-  it('keeps completed assistant token usage visible while a pending assistant is streaming', () => {
-    const completedAssistant = makeMessage({
+  it('hides completed assistant token usage while the next assistant step is streaming', () => {
+    const completedAssistant = makeAssistantWithTokens({
       id: 'assistant-complete',
-      role: 'assistant',
       content: 'Done',
       timestamp: new Date('2024-01-01T10:00:00Z'),
-      tokens: {
-        input: 2500,
-        output: 33,
-        reasoning: 0,
-        cache: { read: 0, write: 0 },
-      },
+      input: 2500,
+      output: 33,
     });
     const pendingAssistant = makeMessage({
       id: 'pending-assistant',
@@ -175,9 +186,40 @@ describe('MessageList', () => {
       />,
     );
 
-    expect(container.textContent).toContain('↓2.5k');
-    expect(container.textContent).toContain('↑33');
-    expect(container.textContent).toContain('tokens');
+    expect(container.textContent).not.toContain('↓2.5k');
+    expect(container.textContent).not.toContain('↑33');
+    expect(container.textContent).not.toContain('tokens');
+  });
+
+  it('shows one aggregate token total after assistant steps complete', () => {
+    const firstStep = makeAssistantWithTokens({
+      id: 'assistant-step-1',
+      content: 'First step',
+      timestamp: new Date('2024-01-01T10:00:00Z'),
+      input: 2500,
+      output: 33,
+    });
+    const finalStep = makeAssistantWithTokens({
+      id: 'assistant-step-2',
+      content: 'Final step',
+      timestamp: new Date('2024-01-01T10:01:00Z'),
+      input: 500,
+      output: 7,
+    });
+
+    const { container } = render(
+      <MessageList
+        messages={[firstStep, finalStep]}
+        activeSessionId="sess-1"
+        isStreaming={false}
+        streamingMessageId={null}
+      />,
+    );
+
+    expect(container.textContent).toContain('2 steps');
+    expect(container.textContent).toContain('↓3.0k');
+    expect(container.textContent).toContain('↑40');
+    expect((container.textContent?.match(/tokens/g) || []).length).toBe(1);
   });
 
   it('uses an explicit sessionDirectory for relative local image paths', async () => {

--- a/packages/app/src/components/settings/cron/CronHistoryDialog.tsx
+++ b/packages/app/src/components/settings/cron/CronHistoryDialog.tsx
@@ -34,7 +34,7 @@ import {
   type CronRunRecord,
 } from '@/stores/cron'
 
-function RunRecordCard({ run, onViewSession }: { run: CronRunRecord; onViewSession?: (sessionId: string) => void }) {
+export function RunRecordCard({ run, onViewSession }: { run: CronRunRecord; onViewSession?: (sessionId: string) => void }) {
   const { t } = useTranslation()
   const [isHovered, setIsHovered] = React.useState(false)
   const statusColor = getRunStatusColor(run.status)
@@ -46,6 +46,7 @@ function RunRecordCard({ run, onViewSession }: { run: CronRunRecord; onViewSessi
           1000
         ).toFixed(1) + 's'
       : '...'
+  const showHeartbeat = !!run.lastHeartbeatAt && (run.status === 'running' || run.status === 'stale')
 
   return (
     <div className="rounded-lg border p-3 space-y-1.5">
@@ -62,6 +63,9 @@ function RunRecordCard({ run, onViewSession }: { run: CronRunRecord; onViewSessi
           )}
           {run.status === 'running' && (
             <Loader2 className="h-4 w-4 text-blue-500 animate-spin" />
+          )}
+          {run.status === 'stale' && (
+            <AlertCircle className="h-4 w-4 text-yellow-500" />
           )}
           <span className={cn('text-sm font-medium capitalize', statusColor)}>
             {run.status}
@@ -97,6 +101,13 @@ function RunRecordCard({ run, onViewSession }: { run: CronRunRecord; onViewSessi
         <p className="text-xs text-muted-foreground">
           <Send className="h-3 w-3 inline mr-1" />
           {run.deliveryStatus}
+        </p>
+      )}
+
+      {showHeartbeat && (
+        <p className="text-xs text-muted-foreground">
+          <Clock className="h-3 w-3 inline mr-1" />
+          {t('settings.cron.lastHeartbeat', 'Last heartbeat')}: {formatRelativeTime(run.lastHeartbeatAt!)}
         </p>
       )}
 

--- a/packages/app/src/components/settings/cron/CronJobDialog.tsx
+++ b/packages/app/src/components/settings/cron/CronJobDialog.tsx
@@ -97,8 +97,7 @@ export function CronJobDialog({
         setForm(next)
         setAdvancedOptionsOpen(
           next.deliveryEnabled ||
-            next.useWorktree ||
-            next.timeoutSeconds !== defaultFormState.timeoutSeconds,
+            next.useWorktree,
         )
       } else {
         setForm(defaultFormState)
@@ -501,21 +500,6 @@ export function CronJobDialog({
                 <SlidersHorizontal className="h-3.5 w-3.5" />
                 {t('settings.cron.execution', 'Execution')}
               </h4>
-              <div className="space-y-2">
-                <label className="text-sm font-medium">{t('settings.cron.timeout', 'Timeout (seconds)')}</label>
-                <Input
-                  type="number"
-                  min={30}
-                  max={900}
-                  value={form.timeoutSeconds}
-                  onChange={(e) => update({ timeoutSeconds: Math.max(30, Math.min(900, Number(e.target.value) || 180)) })}
-                  className="w-32"
-                />
-                <p className="text-xs text-muted-foreground">
-                  {t('settings.cron.timeoutHint', 'Max time for AI to respond. Auto-aborts if exceeded (30-900s, default 180s).')}
-                </p>
-              </div>
-
               {/* Worktree isolation */}
               <div className="flex items-center justify-between">
                 <div>

--- a/packages/app/src/components/settings/cron/__tests__/CronHistoryDialog.test.tsx
+++ b/packages/app/src/components/settings/cron/__tests__/CronHistoryDialog.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, d?: string) => d ?? _k }),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: Array<string | false | null | undefined>) => args.filter(Boolean).join(' '),
+  isTauri: () => false,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: {
+    getState: () => ({ workspacePath: '/test/workspace' }),
+  },
+}))
+
+vi.mock('@/stores/ui', () => ({
+  useUIStore: {
+    getState: () => ({ switchToSession: vi.fn() }),
+  },
+}))
+
+import { RunRecordCard } from '../CronHistoryDialog'
+
+describe('RunRecordCard', () => {
+  it('shows the last heartbeat for running runs', () => {
+    render(
+      <RunRecordCard
+        run={{
+          runId: 'run-1',
+          jobId: 'job-1',
+          startedAt: new Date(Date.now() - 120_000).toISOString(),
+          lastHeartbeatAt: new Date(Date.now() - 30_000).toISOString(),
+          status: 'running',
+        }}
+      />,
+    )
+
+    expect(screen.getByText(/Last heartbeat:/)).toBeTruthy()
+  })
+
+  it('shows the last heartbeat for stale runs', () => {
+    render(
+      <RunRecordCard
+        run={{
+          runId: 'run-1',
+          jobId: 'job-1',
+          startedAt: new Date(Date.now() - 120_000).toISOString(),
+          finishedAt: new Date(Date.now() - 10_000).toISOString(),
+          lastHeartbeatAt: new Date(Date.now() - 60_000).toISOString(),
+          status: 'stale',
+          error: 'Cron run was interrupted before completion.',
+        }}
+      />,
+    )
+
+    expect(screen.getByText(/Last heartbeat:/)).toBeTruthy()
+  })
+})

--- a/packages/app/src/components/settings/cron/__tests__/CronJobDialog.test.tsx
+++ b/packages/app/src/components/settings/cron/__tests__/CronJobDialog.test.tsx
@@ -56,6 +56,11 @@ vi.mock('@/components/ui/dialog', () => ({
 vi.mock('@/components/ui/scroll-area', () => ({
   ScrollArea: ({ children }: any) => <div>{children}</div>,
 }))
+vi.mock('@/components/ui/collapsible', () => ({
+  Collapsible: ({ children }: any) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: any) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
 vi.mock('@/components/ui/textarea', () => ({
   Textarea: (props: any) => <textarea {...props} />,
 }))
@@ -68,5 +73,31 @@ describe('CronJobDialog', () => {
       <CronJobDialog open={false} onOpenChange={vi.fn()} />
     )
     expect(container.innerHTML).toBe('')
+  })
+
+  it('does not render the deprecated timeout field when editing a legacy job', () => {
+    const now = new Date().toISOString()
+    const { queryByText } = render(
+      <CronJobDialog
+        open
+        onOpenChange={vi.fn()}
+        editJob={{
+          id: 'job-1',
+          name: 'Legacy job',
+          enabled: true,
+          schedule: { kind: 'every', everyMs: 30 * 60 * 1000 },
+          payload: {
+            message: 'legacy',
+            timeoutSeconds: 30,
+          },
+          deleteAfterRun: false,
+          createdAt: now,
+          updatedAt: now,
+        }}
+      />
+    )
+
+    expect(queryByText('Timeout (seconds)')).toBeNull()
+    expect(queryByText(/Auto-aborts if exceeded/)).toBeNull()
   })
 })

--- a/packages/app/src/lib/__tests__/cron-utils.test.ts
+++ b/packages/app/src/lib/__tests__/cron-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultFormState, formStateToPayload, jobToFormState } from '../cron-utils'
+import type { CronJob } from '@/stores/cron'
+
+describe('cron-utils timeout compatibility', () => {
+  it('does not write timeoutSeconds into new or edited job payloads', () => {
+    const payload = formStateToPayload({
+      ...defaultFormState,
+      message: 'run the report',
+    })
+
+    expect(payload).toEqual({ message: 'run the report' })
+    expect('timeoutSeconds' in payload).toBe(false)
+  })
+
+  it('loads legacy jobs with timeoutSeconds without exposing timeout form state', () => {
+    const now = new Date().toISOString()
+    const job: CronJob = {
+      id: 'job-1',
+      name: 'Legacy job',
+      enabled: true,
+      schedule: { kind: 'every', everyMs: 30 * 60 * 1000 },
+      payload: {
+        message: 'legacy',
+        timeoutSeconds: 30,
+      },
+      deleteAfterRun: false,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    const form = jobToFormState(job)
+
+    expect(form.message).toBe('legacy')
+    expect('timeoutSeconds' in form).toBe(false)
+  })
+})

--- a/packages/app/src/lib/cron-utils.ts
+++ b/packages/app/src/lib/cron-utils.ts
@@ -279,7 +279,6 @@ export interface JobFormState {
   cronTz: string
   message: string
   model: string
-  timeoutSeconds: number
   deliveryEnabled: boolean
   deliveryChannel: DeliveryChannel
   deliveryTargetMode: string
@@ -302,7 +301,6 @@ export const defaultFormState: JobFormState = {
   cronTz: '',
   message: '',
   model: '',
-  timeoutSeconds: 180,
   deliveryEnabled: false,
   deliveryChannel: 'discord',
   deliveryTargetMode: 'dm',
@@ -349,7 +347,6 @@ export function jobToFormState(job: CronJob): JobFormState {
     cronTz: job.schedule.tz || '',
     message: job.payload.message,
     model: job.payload.model || '',
-    timeoutSeconds: job.payload.timeoutSeconds ?? 180,
     deliveryEnabled: !!job.delivery,
     deliveryChannel,
     deliveryTargetMode: parsed.mode,
@@ -399,7 +396,6 @@ export function formStateToPayload(form: JobFormState): CronPayload {
   return {
     message: form.message,
     model: form.model || undefined,
-    timeoutSeconds: form.timeoutSeconds !== 180 ? form.timeoutSeconds : undefined,
     useWorktree: form.useWorktree || undefined,
     worktreeBranch: form.useWorktree && form.worktreeBranch ? form.worktreeBranch : undefined,
   }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1698,8 +1698,7 @@
       "modelOverrideHint": "Select a model or use workspace default.",
       "modelSelected": "Using: {{model}}",
       "noModels": "No models configured. Please configure providers in LLM Settings first.",
-      "timeout": "Timeout (seconds)",
-      "timeoutHint": "Max time for AI to respond. Auto-aborts if exceeded (30-900s, default 180s).",
+      "lastHeartbeat": "Last heartbeat",
       "useDefaultModel": "Use default model"
     },
     "team": {

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1698,8 +1698,7 @@
       "modelOverrideHint": "选择一个模型，或使用工作区默认模型。",
       "modelSelected": "使用：{{model}}",
       "noModels": "未配置模型。请先在 LLM 设置中配置提供商。",
-      "timeout": "超时（秒）",
-      "timeoutHint": "AI 响应的最长时间。超过后自动中止（30-900 秒，默认 180 秒）。",
+      "lastHeartbeat": "最后心跳",
       "useDefaultModel": "使用默认模型"
     },
     "team": {

--- a/packages/app/src/packages/ai/__tests__/editable-with-file-chips.test.tsx
+++ b/packages/app/src/packages/ai/__tests__/editable-with-file-chips.test.tsx
@@ -1,8 +1,15 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { EditableWithFileChips } from '../editable-with-file-chips'
+
+const originalExecCommand = document.execCommand
+
+afterEach(() => {
+  document.execCommand = originalExecCommand
+  vi.restoreAllMocks()
+})
 
 function TestHarness({ initialValue }: { initialValue: string }) {
   const [value, setValue] = React.useState(initialValue)
@@ -51,5 +58,61 @@ describe('EditableWithFileChips', () => {
     await waitFor(() => {
       expect(screen.getByTestId('value').textContent).toBe('')
     })
+  })
+
+  it('serializes Chromium native trailing line-break placeholder as one newline', async () => {
+    render(<TestHarness initialValue="" />)
+
+    const editable = document.querySelector('[contenteditable="true"]') as HTMLElement
+    editable.append(
+      document.createTextNode('hello'),
+      document.createTextNode('\n'),
+      document.createTextNode('\n'),
+    )
+    fireEvent.input(editable)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('value').textContent).toBe('hello\n')
+    })
+  })
+
+  it('keeps an existing single text-node trailing newline', async () => {
+    render(<TestHarness initialValue={'hello\n'} />)
+
+    const editable = document.querySelector('[contenteditable="true"]') as HTMLElement
+    expect(editable.childNodes).toHaveLength(1)
+    fireEvent.input(editable)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('value').textContent).toBe('hello\n')
+    })
+  })
+
+  it('does not block native line-break beforeinput events', () => {
+    render(<TestHarness initialValue="hello" />)
+
+    const editable = document.querySelector('[contenteditable="true"]') as HTMLElement
+    const event = new InputEvent('beforeinput', {
+      bubbles: true,
+      cancelable: true,
+      data: '\n',
+      inputType: 'insertLineBreak',
+    })
+
+    editable.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('uses the browser line-break command for Shift+Enter', async () => {
+    document.execCommand = vi.fn((command: string) => command === 'insertLineBreak') as typeof document.execCommand
+
+    render(<TestHarness initialValue="hello" />)
+
+    const editable = document.querySelector('[contenteditable="true"]') as HTMLElement
+    placeCaretAtEnd(editable)
+    fireEvent.keyDown(editable, { key: 'Enter', shiftKey: true })
+
+    expect(document.execCommand).toHaveBeenCalledWith('insertLineBreak')
   })
 })

--- a/packages/app/src/packages/ai/__tests__/message.test.tsx
+++ b/packages/app/src/packages/ai/__tests__/message.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 
 let shouldThrowMarkdown = false
@@ -19,7 +19,9 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 
 vi.mock('@/components/ui/dialog', () => ({
   Dialog: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
-  DialogContent: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
+  DialogContent: ({ children, className }: React.PropsWithChildren<{ className?: string }>) => (
+    React.createElement('div', { className, 'data-testid': 'dialog-content' }, children)
+  ),
   DialogTitle: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
 }))
 
@@ -69,6 +71,7 @@ vi.mock('lucide-react', () => ({
   X: () => React.createElement('span', null, 'X'),
   Copy: () => React.createElement('span', null, 'Copy'),
   Check: () => React.createElement('span', null, 'Check'),
+  Maximize2: () => React.createElement('span', null, 'Maximize2'),
 }))
 
 beforeEach(() => {
@@ -221,6 +224,60 @@ describe('MessageResponse', () => {
       expect(container.querySelector('[data-testid="mermaid-svg"]')).toBeTruthy()
     })
     expect(container.querySelector('pre')).toBeNull()
+  })
+
+  it('opens a larger mermaid preview without rendering the diagram again', async () => {
+    const { Message, MessageContent, MessageResponse } = await import('@/packages/ai/message')
+
+    const mermaidSource = [
+      '```mermaid',
+      'flowchart LR',
+      '  A[Start] --> B[Done]',
+      '```',
+    ].join('\n')
+
+    render(
+      React.createElement(Message, { from: 'assistant' },
+        React.createElement(MessageContent, null,
+          React.createElement(MessageResponse, null, mermaidSource)
+        )
+      )
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mermaid-block')).toBeTruthy()
+      expect(screen.getByTestId('mermaid-svg')).toBeTruthy()
+    })
+
+    expect(mermaidRenderMock).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: '放大流程图' }))
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('mermaid-svg')).toHaveLength(2)
+    })
+    expect(mermaidRenderMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses a compact mermaid preview button and content-sized dialog', async () => {
+    const { Message, MessageContent, MessageResponse } = await import('@/packages/ai/message')
+
+    render(
+      React.createElement(Message, { from: 'assistant' },
+        React.createElement(MessageContent, null,
+          React.createElement(MessageResponse, null, '```mermaid\nflowchart LR\nA --> B\n```')
+        )
+      )
+    )
+
+    const expandButton = await screen.findByRole('button', { name: '放大流程图' })
+    expect(expandButton.className).toContain('h-6 w-6')
+
+    fireEvent.click(expandButton)
+
+    const dialogContent = await screen.findByTestId('dialog-content')
+    expect(dialogContent.className).toContain('max-h-[82vh]')
+    expect(dialogContent.className).not.toContain('h-[86vh]')
   })
 
   it('falls back to a normal mermaid code block when diagram rendering fails', async () => {

--- a/packages/app/src/packages/ai/editable-with-file-chips.tsx
+++ b/packages/app/src/packages/ai/editable-with-file-chips.tsx
@@ -17,6 +17,37 @@ function containsControlInput(value: string) {
   return false
 }
 
+function hasNativeTrailingLineBreakPlaceholder(element: HTMLElement): boolean {
+  const lastChild = element.lastChild
+  const previousChild = lastChild?.previousSibling
+  return (
+    lastChild?.nodeType === Node.TEXT_NODE &&
+    lastChild.textContent === "\n" &&
+    previousChild !== null
+  )
+}
+
+function insertLineBreakAtSelection(editable: HTMLElement): boolean {
+  if (typeof document.execCommand === "function" && document.execCommand("insertLineBreak")) {
+    return true
+  }
+
+  const selection = window.getSelection()
+  if (!selection || selection.rangeCount === 0) return false
+
+  const range = selection.getRangeAt(0)
+  if (!editable.contains(range.commonAncestorContainer)) return false
+
+  selection.deleteFromDocument()
+  const textNode = document.createTextNode("\n")
+  range.insertNode(textNode)
+  range.setStartAfter(textNode)
+  range.collapse(true)
+  selection.removeAllRanges()
+  selection.addRange(range)
+  return true
+}
+
 interface EditableWithFileChipsProps {
   value?: string
   onChange?: (value: string) => void
@@ -174,6 +205,9 @@ export const EditableWithFileChips = React.forwardRef<HTMLDivElement, EditableWi
       }
 
       element.childNodes.forEach(traverse)
+      if (result.endsWith("\n") && hasNativeTrailingLineBreakPlaceholder(element)) {
+        result = result.slice(0, -1)
+      }
       return result
     }, [])
 
@@ -241,6 +275,17 @@ export const EditableWithFileChips = React.forwardRef<HTMLDivElement, EditableWi
     }, [htmlToValue, onChange])
 
     const handleKeyDown = React.useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter" && e.shiftKey) {
+        e.preventDefault()
+        e.stopPropagation()
+
+        const editable = editableRef.current
+        if (editable && insertLineBreakAtSelection(editable)) {
+          handleInput()
+        }
+        return
+      }
+
       // Delete chip with Backspace
       if (e.key === "Backspace") {
         const sel = window.getSelection()
@@ -397,6 +442,8 @@ export const EditableWithFileChips = React.forwardRef<HTMLDivElement, EditableWi
 
     const handleBeforeInput = React.useCallback((e: React.FormEvent<HTMLDivElement>) => {
       const inputEvent = e.nativeEvent as InputEvent;
+      if (inputEvent.inputType === "insertLineBreak" || inputEvent.inputType === "insertParagraph") return;
+
       const data = inputEvent.data;
       if (!data) return;
       // Some desktop/webview input methods can surface arrow-key escape bytes as

--- a/packages/app/src/packages/ai/message.tsx
+++ b/packages/app/src/packages/ai/message.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { readFile } from "@tauri-apps/plugin-fs"
-import { Download, X, Copy, Check } from "lucide-react"
+import { Download, X, Copy, Check, Maximize2 } from "lucide-react"
 
 import { cn, isTauri } from "@/lib/utils"
 import {
@@ -580,6 +580,7 @@ function CodeBlock({ language, children }: { language: string; children: string 
 function MermaidBlock({ children }: { children: string }) {
   const [svg, setSvg] = React.useState<string | null>(null)
   const [hasError, setHasError] = React.useState(false)
+  const [isPreviewOpen, setIsPreviewOpen] = React.useState(false)
   const containerRef = React.useRef<HTMLDivElement | null>(null)
   const diagramId = React.useId().replace(/:/g, '')
   const source = React.useMemo(() => String(children).trim(), [children])
@@ -626,23 +627,49 @@ function MermaidBlock({ children }: { children: string }) {
   }
 
   return (
-    <div
-      data-testid="mermaid-block"
-      className="my-2 overflow-x-auto rounded-lg border border-border bg-background px-3 py-3"
-    >
-      {svg ? (
-        <div
-          ref={containerRef}
-          className="[&_svg]:h-auto [&_svg]:max-w-full"
-          dangerouslySetInnerHTML={{ __html: svg }}
-        />
-      ) : (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <div className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-          <span>Rendering Mermaid diagram...</span>
-        </div>
-      )}
-    </div>
+    <>
+      <div
+        data-testid="mermaid-block"
+        className="relative my-2 overflow-x-auto rounded-lg border border-border bg-background px-3 py-3"
+      >
+        {svg ? (
+          <>
+            <button
+              type="button"
+              aria-label="放大流程图"
+              title="放大流程图"
+              onClick={() => setIsPreviewOpen(true)}
+              className="absolute right-1.5 top-1.5 z-10 inline-flex h-6 w-6 items-center justify-center rounded-md border border-border/80 bg-background/90 text-muted-foreground opacity-80 shadow-sm backdrop-blur transition hover:bg-accent hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            >
+              <Maximize2 className="h-3.5 w-3.5" />
+            </button>
+            <div
+              ref={containerRef}
+              className="[&_svg]:h-auto [&_svg]:max-w-full"
+              dangerouslySetInnerHTML={{ __html: svg }}
+            />
+          </>
+        ) : (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <div className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            <span>Rendering Mermaid diagram...</span>
+          </div>
+        )}
+      </div>
+      {isPreviewOpen && svg ? (
+        <Dialog open={isPreviewOpen} onOpenChange={setIsPreviewOpen}>
+          <DialogContent className="max-h-[82vh] w-[92vw] !max-w-[92vw] overflow-hidden p-0">
+            <DialogTitle className="sr-only">放大流程图</DialogTitle>
+            <div className="max-h-[82vh] overflow-auto bg-background p-4">
+              <div
+                className="w-max min-w-full [&_svg]:block [&_svg]:h-auto [&_svg]:min-w-[960px] [&_svg]:max-w-none"
+                dangerouslySetInnerHTML={{ __html: svg }}
+              />
+            </div>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+    </>
   )
 }
 

--- a/packages/app/src/stores/__tests__/cron.test.ts
+++ b/packages/app/src/stores/__tests__/cron.test.ts
@@ -26,7 +26,14 @@ vi.mock('@/lib/store-utils', () => ({
   },
 }))
 
-import { useCronStore, formatSchedule, formatRelativeTime, getRunStatusColor, getChannelDisplayName } from '@/stores/cron'
+import {
+  useCronStore,
+  formatSchedule,
+  formatRelativeTime,
+  getRunStatusColor,
+  getChannelDisplayName,
+  normalizeCronRunRecord,
+} from '@/stores/cron'
 
 describe('cron store', () => {
   beforeEach(() => {
@@ -93,6 +100,7 @@ describe('cron helpers', () => {
     expect(getRunStatusColor('failed')).toBe('text-red-500')
     expect(getRunStatusColor('timeout')).toBe('text-orange-500')
     expect(getRunStatusColor('running')).toBe('text-blue-500')
+    expect(getRunStatusColor('stale')).toBe('text-yellow-500')
   })
 
   it('getChannelDisplayName returns correct names', () => {
@@ -202,6 +210,20 @@ describe('formatRelativeTime – extended ranges', () => {
 describe('getRunStatusColor – edge cases', () => {
   it('returns muted color for unknown status', () => {
     expect(getRunStatusColor('unknown' as any)).toBe('text-muted-foreground')
+  })
+})
+
+describe('normalizeCronRunRecord', () => {
+  it('maps legacy success records with timeout cut-short summaries to timeout', () => {
+    const record = normalizeCronRunRecord({
+      runId: 'run-1',
+      jobId: 'job-1',
+      startedAt: new Date().toISOString(),
+      status: 'success',
+      responseSummary: 'partial output\n\n---\n⚠️ AI response was cut short after 180s timeout.',
+    })
+
+    expect(record.status).toBe('timeout')
   })
 })
 
@@ -319,6 +341,22 @@ describe('cron store actions', () => {
       limit: 50,
       workspacePath: '/test/workspace',
     })
+  })
+
+  it('loadRuns normalizes legacy timeout-success records before storing them', async () => {
+    mockInvoke.mockResolvedValueOnce([
+      {
+        runId: 'r1',
+        jobId: 'job-1',
+        startedAt: new Date().toISOString(),
+        status: 'success',
+        responseSummary: 'partial output\n\n---\n⚠️ AI response was cut short after 180s timeout.',
+      },
+    ])
+
+    await useCronStore.getState().loadRuns('job-1')
+
+    expect(useCronStore.getState().runs[0].status).toBe('timeout')
   })
 
   it('loadJobs sets jobs from backend', async () => {

--- a/packages/app/src/stores/__tests__/session-messages-behavior.test.ts
+++ b/packages/app/src/stores/__tests__/session-messages-behavior.test.ts
@@ -225,6 +225,7 @@ describe('session store: message behavior', () => {
       const state = useSessionStore.getState();
       // Error should be set
       expect(state.error).toBe('Network failure');
+      expect(state.errorSessionId).toBe('sess-1');
       // Pending assistant message should be removed
       const session = state.sessions.find((s) => s.id === 'sess-1');
       const assistantMsgs = session!.messages.filter((m) => m.role === 'assistant');
@@ -358,9 +359,11 @@ describe('session store: message behavior', () => {
     it('setError sets and clears error', () => {
       useSessionStore.getState().setError('Something went wrong');
       expect(useSessionStore.getState().error).toBe('Something went wrong');
+      expect(useSessionStore.getState().errorSessionId).toBe('sess-1');
 
       useSessionStore.getState().setError(null);
       expect(useSessionStore.getState().error).toBeNull();
+      expect(useSessionStore.getState().errorSessionId).toBeNull();
     });
 
     it('setInactivityWarning toggles warning state', () => {

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -19,7 +19,8 @@ export interface CronSchedule {
 export interface CronPayload {
   message: string
   model?: string // "provider/model"
-  timeoutSeconds?: number // Max seconds for AI to respond (default: 180)
+  /** @deprecated Compatibility only. Runtime ignores this and new saves omit it. */
+  timeoutSeconds?: number
   useWorktree?: boolean
   worktreeBranch?: string
 }
@@ -34,7 +35,7 @@ export interface CronDelivery {
   bestEffort: boolean
 }
 
-export type RunStatus = 'success' | 'failed' | 'timeout' | 'running'
+export type RunStatus = 'success' | 'failed' | 'timeout' | 'running' | 'stale'
 
 export interface CronJob {
   id: string
@@ -57,6 +58,7 @@ export interface CronRunRecord {
   startedAt: string
   finishedAt?: string
   status: RunStatus
+  lastHeartbeatAt?: string
   sessionId?: string
   responseSummary?: string
   deliveryStatus?: string
@@ -249,7 +251,7 @@ export const useCronStore = create<CronState>((set, get) => ({
         limit: limit ?? 50,
         workspacePath,
       })
-      set({ runs, runsLoading: false })
+      set({ runs: runs.map(normalizeCronRunRecord), runsLoading: false })
     } catch (error) {
       console.error('[Cron] Failed to load runs:', error)
       set({ runs: [], runsLoading: false })
@@ -271,6 +273,20 @@ export const useCronStore = create<CronState>((set, get) => ({
 }))
 
 // ==================== Helpers ====================
+
+const LEGACY_TIMEOUT_CUT_SHORT_MARKER = 'AI response was cut short after'
+
+export function normalizeCronRunRecord(record: CronRunRecord): CronRunRecord {
+  const hasLegacyTimeoutText =
+    record.responseSummary?.includes(LEGACY_TIMEOUT_CUT_SHORT_MARKER) ||
+    record.error?.includes(LEGACY_TIMEOUT_CUT_SHORT_MARKER)
+
+  if (record.status === 'success' && hasLegacyTimeoutText) {
+    return { ...record, status: 'timeout' }
+  }
+
+  return record
+}
 
 /** Convert schedule to human-readable string */
 export function formatSchedule(schedule: CronSchedule): string {
@@ -370,6 +386,8 @@ export function getRunStatusColor(status: RunStatus): string {
       return 'text-orange-500'
     case 'running':
       return 'text-blue-500'
+    case 'stale':
+      return 'text-yellow-500'
     default:
       return 'text-muted-foreground'
   }

--- a/packages/app/src/stores/session-loader.ts
+++ b/packages/app/src/stores/session-loader.ts
@@ -90,7 +90,7 @@ export function createLoaderActions(set: SessionSet, get: SessionGet) {
 
     // Load all sessions from OpenCode, filtered by workspace directory
     loadSessions: async (workspacePath?: string) => {
-      set({ isLoading: true, error: null, isLoadingMore: false });
+      set({ isLoading: true, error: null, errorSessionId: null, isLoadingMore: false });
       try {
         const client = getOpenCodeClient();
         const sessions = await client.listSessions(
@@ -351,7 +351,7 @@ export function createLoaderActions(set: SessionSet, get: SessionGet) {
         });
       }
 
-      set({ isLoading: true, error: null });
+      set({ isLoading: true, error: null, errorSessionId: null });
       try {
         const client = getOpenCodeClient();
         const newSession = await client.createSession();

--- a/packages/app/src/stores/session-messages.ts
+++ b/packages/app/src/stores/session-messages.ts
@@ -393,6 +393,7 @@ export function createMessageActions(set: SessionSet, get: SessionGet) {
           return {
             error:
               error instanceof Error ? error.message : "Failed to send message",
+            errorSessionId: activeSessionId,
             sessions: newSessions,
           };
         });

--- a/packages/app/src/stores/session-sse-lifecycle-handlers.ts
+++ b/packages/app/src/stores/session-sse-lifecycle-handlers.ts
@@ -797,7 +797,7 @@ export function createLifecycleHandlers(set: SessionSet, get: SessionGet) {
         }
         useStreamingStore.getState().clearStreaming();
         return {
-          sessionError: event,
+          sessionError: { ...event, sessionId: errorSessionId },
           sessions: newSessions,
         };
       });

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -28,6 +28,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   hasMoreSessions: false,
   visibleSessionCount: UI_PAGE_SIZE,
   error: null,
+  errorSessionId: null,
   isConnected: false,
   selectedModel: null,
   messageQueue: [],
@@ -78,8 +79,11 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   setConnected: (connected: boolean) => {
     set({ isConnected: connected });
   },
-  setError: (error: string | null) => {
-    set({ error });
+  setError: (error: string | null, sessionId?: string | null) => {
+    set((state) => ({
+      error,
+      errorSessionId: error ? (sessionId ?? state.activeSessionId) : null,
+    }));
   },
   setInactivityWarning: (active: boolean) => {
     set({ inactivityWarning: active });

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -182,6 +182,7 @@ export interface SessionState {
   hasMoreSessions: boolean; // Whether there are more sessions to show
   visibleSessionCount: number; // How many sessions are currently visible in sidebar
   error: string | null;
+  errorSessionId: string | null;
   isConnected: boolean;
 
   // Selected model
@@ -323,7 +324,7 @@ export interface SessionState {
 
   // Actions - Connection
   setConnected: (connected: boolean) => void;
-  setError: (error: string | null) => void;
+  setError: (error: string | null, sessionId?: string | null) => void;
   setInactivityWarning: (active: boolean) => void;
 
   // Getters

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,7 +75,7 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0(react@19.2.5)(zod@3.25.76)
       '@opencode-ai/sdk':
-        specifier: ^1.4.0
+        specifier: ^1.14.18
         version: 1.14.18
       '@radix-ui/react-avatar':
         specifier: ^1.1.11

--- a/src-tauri/src/commands/cron/mod.rs
+++ b/src-tauri/src/commands/cron/mod.rs
@@ -75,7 +75,10 @@ pub async fn cron_init(
     let delivery_mgr = DeliveryManager::new(workspace_path.clone());
     cron_state.scheduler.set_delivery(delivery_mgr).await;
 
-    // Step 4: Start the scheduler for the new workspace
+    // Step 4: Reconcile runs left active by a previous app/executor process.
+    cron_state.scheduler.reconcile_interrupted_runs().await;
+
+    // Step 5: Start the scheduler for the new workspace
     cron_state.scheduler.start().await;
 
     println!(

--- a/src-tauri/src/commands/cron/scheduler.rs
+++ b/src-tauri/src/commands/cron/scheduler.rs
@@ -12,6 +12,11 @@ use super::types::*;
 use crate::commands::gateway::SessionMapping;
 use crate::process_util::CommandNoWindow;
 
+const CRON_RUN_HEARTBEAT_INTERVAL_SECS: u64 = 30;
+const OPENCODE_CONNECT_TIMEOUT_SECS: u64 = 30;
+const STALE_RUN_ERROR: &str =
+    "Cron run was interrupted before completion; open the session to inspect the latest state.";
+
 /// The cron scheduler that runs as a background task
 #[derive(Debug)]
 pub struct CronScheduler {
@@ -96,6 +101,89 @@ impl CronScheduler {
     async fn persist_run_and_notify_ui(&self, record: &CronRunRecord) {
         self.storage.update_last_run(record).await;
         self.emit_cron_sessions_updated();
+    }
+
+    fn truncate_response_summary(response: &str) -> String {
+        if response.chars().count() > 500 {
+            let truncated: String = response.chars().take(497).collect();
+            format!("{}...", truncated)
+        } else {
+            response.to_string()
+        }
+    }
+
+    pub(crate) fn normalize_legacy_timeout_record(record: &mut CronRunRecord) {
+        normalize_legacy_timeout_status(record);
+    }
+
+    pub(crate) fn reconcile_interrupted_run(
+        mut record: CronRunRecord,
+        assistant_text: Option<String>,
+        finished_at: DateTime<Utc>,
+    ) -> CronRunRecord {
+        if record.has_legacy_timeout_cut_short_text() {
+            record.status = RunStatus::Timeout;
+            record.finished_at = Some(finished_at);
+            return record;
+        }
+
+        if let Some(text) = assistant_text {
+            record.status = RunStatus::Success;
+            record.response_summary = Some(Self::truncate_response_summary(&text));
+            record.finished_at = Some(finished_at);
+            return record;
+        }
+
+        record.status = RunStatus::Stale;
+        record.finished_at = Some(finished_at);
+        record.error = Some(STALE_RUN_ERROR.to_string());
+        record
+    }
+
+    /// Reconcile runs left in `running` by a previous app/executor process.
+    pub async fn reconcile_interrupted_runs(&self) {
+        let running = self.storage.get_latest_running_runs().await;
+        if running.is_empty() {
+            return;
+        }
+
+        let port = *self.opencode_port.read().await;
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(
+                OPENCODE_CONNECT_TIMEOUT_SECS,
+            ))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+
+        println!(
+            "[Cron] Reconciling {} interrupted run(s) from previous executor",
+            running.len()
+        );
+
+        for record in running {
+            let assistant_text = if record.has_legacy_timeout_cut_short_text() {
+                None
+            } else if let Some(session_id) = record.session_id.as_deref() {
+                let expected_prompt = self
+                    .storage
+                    .get_job(&record.job_id)
+                    .await
+                    .map(|job| job.payload.message);
+                Self::fetch_last_completed_assistant_text_since(
+                    &client,
+                    port,
+                    session_id,
+                    record.started_at,
+                    expected_prompt.as_deref(),
+                )
+                .await
+            } else {
+                None
+            };
+
+            let reconciled = Self::reconcile_interrupted_run(record, assistant_text, Utc::now());
+            self.persist_run_and_notify_ui(&reconciled).await;
+        }
     }
 
     /// Set the OpenCode server port
@@ -415,6 +503,7 @@ impl CronScheduler {
             started_at,
             finished_at: None,
             status: RunStatus::Running,
+            last_heartbeat_at: Some(started_at),
             session_id: None,
             response_summary: None,
             delivery_status: None,
@@ -443,7 +532,7 @@ impl CronScheduler {
             match Self::create_worktree(&my_workspace, &wt_path, branch) {
                 Ok(()) => {
                     record.worktree_path = Some(wt_path.clone());
-                    self.storage.append_run(&record).await;
+                    self.persist_run_and_notify_ui(&record).await;
                     wt_guard.activate(wt_path);
                 }
                 Err(e) => {
@@ -633,28 +722,30 @@ impl CronScheduler {
             }
         }
 
-        // Resolve timeout (user-configured or default, clamped to 30-900 range)
-        let timeout_secs = job
-            .payload
-            .timeout_seconds
-            .unwrap_or(super::types::DEFAULT_TIMEOUT_SECONDS)
-            .max(30)
-            .min(900);
-
         // Check before sending to OpenCode (workspace may have changed)
         check_generation!();
 
         // Step 2: Send message to OpenCode
-        let response = match self
-            .send_to_opencode(
-                port,
-                &session_id,
-                &job.payload.message,
-                model_param.clone(),
-                timeout_secs,
-            )
-            .await
-        {
+        let response_future =
+            self.send_to_opencode(port, &session_id, &job.payload.message, model_param.clone());
+        tokio::pin!(response_future);
+        let heartbeat_every = std::time::Duration::from_secs(CRON_RUN_HEARTBEAT_INTERVAL_SECS);
+        let mut heartbeat_interval = tokio::time::interval_at(
+            tokio::time::Instant::now() + heartbeat_every,
+            heartbeat_every,
+        );
+
+        let response_result = loop {
+            tokio::select! {
+                result = &mut response_future => break result,
+                _ = heartbeat_interval.tick() => {
+                    record.last_heartbeat_at = Some(Utc::now());
+                    self.persist_run_and_notify_ui(&record).await;
+                }
+            }
+        };
+
+        let response = match response_result {
             Ok(text) => text,
             Err(e) => {
                 // Fail immediately without retry. Previous retry logic was too aggressive:
@@ -672,14 +763,7 @@ impl CronScheduler {
             }
         };
 
-        // Truncate response for summary (max 500 characters, safe for multi-byte UTF-8)
-        let summary = if response.chars().count() > 500 {
-            let truncated: String = response.chars().take(497).collect();
-            format!("{}...", truncated)
-        } else {
-            response.clone()
-        };
-        record.response_summary = Some(summary);
+        record.response_summary = Some(Self::truncate_response_summary(&response));
 
         // Check before delivery (workspace may have changed)
         check_generation!();
@@ -981,34 +1065,28 @@ impl CronScheduler {
 
     /// Send a message to OpenCode and wait for the response.
     ///
-    /// Uses `tokio::time::timeout` to prevent indefinite blocking when the AI
-    /// enters an agentic loop. On timeout, aborts the session and fetches
-    /// whatever content was generated so far.
-    ///
     /// Response extraction strategy:
-    /// - **Normal**: parse the POST response (a single Message JSON) and extract
+    /// parse the POST response (a single Message JSON) and extract
     ///   all `type: "text"` parts. This is the complete response for this request.
-    /// - **Timeout**: abort, then GET `/session/{id}/message` and extract text
-    ///   from the **last** assistant message only.
     async fn send_to_opencode(
         &self,
         port: u16,
         session_id: &str,
         content: &str,
         model: Option<(String, String)>,
-        timeout_secs: u64,
     ) -> Result<String, String> {
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(timeout_secs + 60))
+            .connect_timeout(std::time::Duration::from_secs(
+                OPENCODE_CONNECT_TIMEOUT_SECS,
+            ))
             .build()
             .map_err(|e| format!("Failed to create client: {}", e))?;
 
         let url = format!("http://127.0.0.1:{}/session/{}/message", port, session_id);
         println!(
-            "[Cron] Sending to OpenCode: {} content length: {} (timeout: {}s)",
+            "[Cron] Sending to OpenCode: {} content length: {}",
             url,
-            content.len(),
-            timeout_secs
+            content.len()
         );
 
         let mut body = serde_json::json!({
@@ -1026,87 +1104,57 @@ impl CronScheduler {
             println!("[Cron] Using model override: {}/{}", provider_id, model_id);
         }
 
-        let post_future = client
+        let response = client
             .post(&url)
             .header("Content-Type", "application/json")
             .json(&body)
-            .send();
+            .send()
+            .await
+            .map_err(|e| format!("Failed to send message: {}", e))?;
 
-        match tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), post_future).await
-        {
-            Ok(Ok(response)) => {
-                // POST completed within timeout — extract text from the returned Message
-                let status = response.status();
-                if !status.is_success() {
-                    let error_body = response.text().await.unwrap_or_default();
-                    return Err(format!("HTTP {} - {}", status, error_body));
-                }
-
-                let response_text = response
-                    .text()
-                    .await
-                    .map_err(|e| format!("Failed to read response: {}", e))?;
-
-                if response_text.is_empty() {
-                    return Err("Empty response from OpenCode".to_string());
-                }
-
-                let response_json: serde_json::Value = serde_json::from_str(&response_text)
-                    .map_err(|e| format!("Failed to parse response: {}", e))?;
-
-                // Check for error in the response
-                if let Some(error) = response_json["info"]["error"].as_object() {
-                    let error_name = error
-                        .get("name")
-                        .and_then(|n| n.as_str())
-                        .unwrap_or("UnknownError");
-                    let error_message = error
-                        .get("data")
-                        .and_then(|d| d.get("message"))
-                        .and_then(|m| m.as_str())
-                        .unwrap_or("Unknown error occurred");
-                    return Err(format!("{}: {}", error_name, error_message));
-                }
-
-                // Extract all text parts from the response Message
-                let text = Self::extract_text_parts(&response_json);
-                println!(
-                    "[Cron] POST completed, extracted {} chars from response",
-                    text.len()
-                );
-
-                if text.is_empty() {
-                    return Err("No text content in AI response".to_string());
-                }
-                Ok(text)
-            }
-            Ok(Err(e)) => Err(format!("Failed to send message: {}", e)),
-            Err(_) => {
-                // Timeout — abort and salvage whatever was generated
-                println!(
-                    "[Cron] Timeout after {}s, aborting session '{}'...",
-                    timeout_secs, session_id
-                );
-                Self::abort_session(&client, port, session_id).await;
-                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-
-                // Fetch the last assistant message from session history
-                let text = Self::fetch_last_assistant_text(&client, port, session_id).await;
-                match text {
-                    Some(t) if !t.is_empty() => {
-                        println!("[Cron] Salvaged {} chars after timeout", t.len());
-                        Ok(format!(
-                            "{}\n\n---\n⚠️ AI response was cut short after {}s timeout.",
-                            t, timeout_secs
-                        ))
-                    }
-                    _ => Err(format!(
-                        "AI agent timed out after {}s and no response content was captured",
-                        timeout_secs
-                    )),
-                }
-            }
+        let status = response.status();
+        if !status.is_success() {
+            let error_body = response.text().await.unwrap_or_default();
+            return Err(format!("HTTP {} - {}", status, error_body));
         }
+
+        let response_text = response
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read response: {}", e))?;
+
+        if response_text.is_empty() {
+            return Err("Empty response from OpenCode".to_string());
+        }
+
+        let response_json: serde_json::Value = serde_json::from_str(&response_text)
+            .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+        // Check for error in the response
+        if let Some(error) = response_json["info"]["error"].as_object() {
+            let error_name = error
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("UnknownError");
+            let error_message = error
+                .get("data")
+                .and_then(|d| d.get("message"))
+                .and_then(|m| m.as_str())
+                .unwrap_or("Unknown error occurred");
+            return Err(format!("{}: {}", error_name, error_message));
+        }
+
+        // Extract all text parts from the response Message
+        let text = Self::extract_text_parts(&response_json);
+        println!(
+            "[Cron] POST completed, extracted {} chars from response",
+            text.len()
+        );
+
+        if text.is_empty() {
+            return Err("No text content in AI response".to_string());
+        }
+        Ok(text)
     }
 
     /// Extract all `type: "text"` parts from a Message JSON object.
@@ -1127,26 +1175,13 @@ impl CronScheduler {
         texts.join("\n\n")
     }
 
-    /// Abort an OpenCode session. Non-fatal — logs errors but does not propagate.
-    async fn abort_session(client: &reqwest::Client, port: u16, session_id: &str) {
-        let url = format!("http://127.0.0.1:{}/session/{}/abort", port, session_id);
-        match client.post(&url).send().await {
-            Ok(resp) => println!(
-                "[Cron] Abort session '{}': HTTP {}",
-                session_id,
-                resp.status()
-            ),
-            Err(e) => println!("[Cron] Failed to abort session '{}': {}", session_id, e),
-        }
-    }
-
-    /// After a timeout+abort, fetch the **last** assistant message from the
-    /// session and extract its text. Only looks at the final assistant message,
-    /// so it never leaks content from previous runs in reused sessions.
-    async fn fetch_last_assistant_text(
+    /// Fetch the last completed assistant message created after the run started.
+    async fn fetch_last_completed_assistant_text_since(
         client: &reqwest::Client,
         port: u16,
         session_id: &str,
+        started_at: DateTime<Utc>,
+        expected_prompt: Option<&str>,
     ) -> Option<String> {
         let url = format!("http://127.0.0.1:{}/session/{}/message", port, session_id);
         let response = client.get(&url).send().await.ok()?;
@@ -1156,11 +1191,54 @@ impl CronScheduler {
         let body = response.text().await.ok()?;
         let messages: Vec<serde_json::Value> = serde_json::from_str(&body).ok()?;
 
-        // Find the last assistant message and extract its text
+        Self::extract_completed_assistant_text_for_cron_run(&messages, started_at, expected_prompt?)
+    }
+
+    fn message_created_at_or_after(message: &serde_json::Value, started_at: DateTime<Utc>) -> bool {
+        let Some(created) = message["info"]["time"]["created"].as_i64() else {
+            return false;
+        };
+
+        if created > 10_000_000_000 {
+            created >= started_at.timestamp_millis()
+        } else {
+            created >= started_at.timestamp()
+        }
+    }
+
+    fn extract_completed_assistant_text_for_cron_run(
+        messages: &[serde_json::Value],
+        started_at: DateTime<Utc>,
+        expected_prompt: &str,
+    ) -> Option<String> {
+        let expected_prompt = expected_prompt.trim();
+        if expected_prompt.is_empty() {
+            return None;
+        }
+
+        let matching_user_ids: Vec<&str> = messages
+            .iter()
+            .filter(|m| {
+                m["info"]["role"].as_str() == Some("user")
+                    && Self::message_created_at_or_after(m, started_at)
+                    && Self::extract_text_parts(m).trim() == expected_prompt
+            })
+            .filter_map(|m| m["info"]["id"].as_str())
+            .collect();
+
+        let [user_id] = matching_user_ids.as_slice() else {
+            return None;
+        };
+
         messages
             .iter()
             .rev()
-            .find(|m| m["info"]["role"].as_str() == Some("assistant"))
+            .find(|m| {
+                m["info"]["role"].as_str() == Some("assistant")
+                    && m["info"]["parentID"].as_str() == Some(*user_id)
+                    && m["info"]["time"]["completed"].as_i64().is_some()
+                    && Self::message_created_at_or_after(m, started_at)
+            })
             .map(Self::extract_text_parts)
             .filter(|t| !t.is_empty())
     }
@@ -1210,6 +1288,170 @@ mod tests {
             to: to.to_string(),
             best_effort: false,
         }
+    }
+
+    fn make_run_record(status: RunStatus, summary: Option<&str>) -> CronRunRecord {
+        let now = Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0).unwrap();
+        CronRunRecord {
+            run_id: "run-1".to_string(),
+            job_id: "job-1".to_string(),
+            started_at: now,
+            finished_at: None,
+            status,
+            session_id: Some("session-1".to_string()),
+            response_summary: summary.map(str::to_string),
+            delivery_status: None,
+            error: None,
+            worktree_path: None,
+            last_heartbeat_at: None,
+        }
+    }
+
+    // ── run reconciliation ──────────────────────────────────────────────────
+
+    #[test]
+    fn old_success_with_timeout_cut_short_summary_normalizes_to_timeout() {
+        let mut record = make_run_record(
+            RunStatus::Success,
+            Some("partial output\n\n---\n⚠️ AI response was cut short after 180s timeout."),
+        );
+
+        CronScheduler::normalize_legacy_timeout_record(&mut record);
+
+        assert_eq!(record.status, RunStatus::Timeout);
+    }
+
+    #[test]
+    fn interrupted_running_run_with_timeout_cut_short_text_reconciles_to_timeout() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 1, 12, 3, 0).unwrap();
+        let record = make_run_record(
+            RunStatus::Running,
+            Some("partial output\n\n---\n⚠️ AI response was cut short after 180s timeout."),
+        );
+
+        let reconciled = CronScheduler::reconcile_interrupted_run(record, None, now);
+
+        assert_eq!(reconciled.status, RunStatus::Timeout);
+        assert_eq!(reconciled.finished_at, Some(now));
+        assert_eq!(reconciled.session_id.as_deref(), Some("session-1"));
+    }
+
+    #[test]
+    fn interrupted_running_run_with_assistant_text_reconciles_to_success() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 1, 12, 3, 0).unwrap();
+        let record = make_run_record(RunStatus::Running, None);
+
+        let reconciled =
+            CronScheduler::reconcile_interrupted_run(record, Some("complete result".into()), now);
+
+        assert_eq!(reconciled.status, RunStatus::Success);
+        assert_eq!(
+            reconciled.response_summary.as_deref(),
+            Some("complete result")
+        );
+        assert_eq!(reconciled.finished_at, Some(now));
+    }
+
+    #[test]
+    fn interrupted_running_run_without_confirmation_reconciles_to_stale() {
+        let now = Utc.with_ymd_and_hms(2024, 6, 1, 12, 3, 0).unwrap();
+        let record = make_run_record(RunStatus::Running, None);
+
+        let reconciled = CronScheduler::reconcile_interrupted_run(record, None, now);
+
+        assert_eq!(reconciled.status, RunStatus::Stale);
+        assert_eq!(reconciled.finished_at, Some(now));
+        assert_eq!(reconciled.session_id.as_deref(), Some("session-1"));
+        assert!(reconciled.error.unwrap().contains("interrupted"));
+    }
+
+    #[test]
+    fn legacy_payload_timeout_seconds_still_deserializes_for_compatibility() {
+        let payload: CronPayload = serde_json::from_str(
+            r#"{"message":"hello","timeoutSeconds":30,"model":"openai/gpt-4.1"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(payload.message, "hello");
+        assert_eq!(payload.timeout_seconds, Some(30));
+    }
+
+    #[test]
+    fn reconcile_ignores_unrelated_assistant_message_in_reused_session() {
+        let started_at = Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0).unwrap();
+        let messages = vec![
+            serde_json::json!({
+                "info": {
+                    "id": "cron-user",
+                    "role": "user",
+                    "time": { "created": started_at.timestamp() + 1 }
+                },
+                "parts": [{ "type": "text", "text": "cron prompt" }]
+            }),
+            serde_json::json!({
+                "info": {
+                    "id": "other-user",
+                    "role": "user",
+                    "time": { "created": started_at.timestamp() + 2 }
+                },
+                "parts": [{ "type": "text", "text": "other prompt" }]
+            }),
+            serde_json::json!({
+                "info": {
+                    "id": "other-assistant",
+                    "role": "assistant",
+                    "parentID": "other-user",
+                    "time": {
+                        "created": started_at.timestamp() + 3,
+                        "completed": started_at.timestamp() + 4
+                    }
+                },
+                "parts": [{ "type": "text", "text": "other result" }]
+            }),
+        ];
+
+        let result = CronScheduler::extract_completed_assistant_text_for_cron_run(
+            &messages,
+            started_at,
+            "cron prompt",
+        );
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn reconcile_accepts_assistant_message_parented_to_matching_cron_prompt() {
+        let started_at = Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0).unwrap();
+        let messages = vec![
+            serde_json::json!({
+                "info": {
+                    "id": "cron-user",
+                    "role": "user",
+                    "time": { "created": started_at.timestamp() + 1 }
+                },
+                "parts": [{ "type": "text", "text": "cron prompt" }]
+            }),
+            serde_json::json!({
+                "info": {
+                    "id": "cron-assistant",
+                    "role": "assistant",
+                    "parentID": "cron-user",
+                    "time": {
+                        "created": started_at.timestamp() + 2,
+                        "completed": started_at.timestamp() + 3
+                    }
+                },
+                "parts": [{ "type": "text", "text": "cron result" }]
+            }),
+        ];
+
+        let result = CronScheduler::extract_completed_assistant_text_for_cron_run(
+            &messages,
+            started_at,
+            "cron prompt",
+        );
+
+        assert_eq!(result.as_deref(), Some("cron result"));
     }
 
     // ── compute_next_run: At ─────────────────────────────────────────────────

--- a/src-tauri/src/commands/cron/storage.rs
+++ b/src-tauri/src/commands/cron/storage.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use super::types::{CronJob, CronJobsData, CronRunRecord};
+use super::types::{
+    normalize_legacy_timeout_status, CronJob, CronJobsData, CronRunRecord, RunStatus,
+};
 
 /// Persistent storage for cron jobs and run history
 #[derive(Debug)]
@@ -471,10 +473,17 @@ impl CronStorage {
                         .lines()
                         .filter(|l| !l.trim().is_empty())
                         .filter_map(|l| serde_json::from_str(l).ok())
+                        .map(|mut record| {
+                            normalize_legacy_timeout_status(&mut record);
+                            record
+                        })
                         .collect();
 
                     // Most recent first
                     records.reverse();
+
+                    let mut seen_run_ids = std::collections::HashSet::new();
+                    records.retain(|record| seen_run_ids.insert(record.run_id.clone()));
 
                     if let Some(limit) = limit {
                         records.truncate(limit);
@@ -490,5 +499,85 @@ impl CronStorage {
         } else {
             Vec::new()
         }
+    }
+
+    /// Get the latest persisted state for runs that were active when the app stopped.
+    pub async fn get_latest_running_runs(&self) -> Vec<CronRunRecord> {
+        let workspace = self.workspace_path.read().await;
+        let Some(ws) = workspace.as_ref() else {
+            return Vec::new();
+        };
+
+        let runs_dir = Self::runs_dir(ws);
+        if !runs_dir.exists() {
+            return Vec::new();
+        }
+
+        let mut records_by_run_id = std::collections::HashMap::<String, CronRunRecord>::new();
+        if let Ok(entries) = std::fs::read_dir(&runs_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                    continue;
+                }
+                if let Ok(content) = std::fs::read_to_string(&path) {
+                    for line in content.lines().filter(|l| !l.trim().is_empty()) {
+                        if let Ok(mut record) = serde_json::from_str::<CronRunRecord>(line) {
+                            normalize_legacy_timeout_status(&mut record);
+                            records_by_run_id.insert(record.run_id.clone(), record);
+                        }
+                    }
+                }
+            }
+        }
+
+        records_by_run_id
+            .into_values()
+            .filter(|record| record.status == RunStatus::Running)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn make_run(run_id: &str, status: RunStatus) -> CronRunRecord {
+        let started_at = Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0).unwrap();
+        CronRunRecord {
+            run_id: run_id.to_string(),
+            job_id: "job-1".to_string(),
+            started_at,
+            finished_at: None,
+            status,
+            last_heartbeat_at: Some(started_at),
+            session_id: None,
+            response_summary: None,
+            delivery_status: None,
+            error: None,
+            worktree_path: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn get_runs_returns_only_latest_record_for_duplicate_run_id() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let storage = CronStorage::new();
+        storage.init(tempdir.path().to_str().unwrap()).await;
+
+        let running = make_run("run-1", RunStatus::Running);
+        let mut success = make_run("run-1", RunStatus::Success);
+        success.finished_at = Some(Utc.with_ymd_and_hms(2024, 6, 1, 12, 3, 0).unwrap());
+        success.worktree_path = Some("/tmp/worktree".to_string());
+
+        storage.append_run(&running).await;
+        storage.append_run(&success).await;
+
+        let runs = storage.get_runs("job-1", None).await;
+
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].status, RunStatus::Success);
+        assert_eq!(runs[0].worktree_path.as_deref(), Some("/tmp/worktree"));
     }
 }

--- a/src-tauri/src/commands/cron/storage.rs
+++ b/src-tauri/src/commands/cron/storage.rs
@@ -21,48 +21,6 @@ impl Default for CronStorage {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use chrono::Utc;
-    use serde_json::json;
-
-    #[tokio::test]
-    async fn list_jobs_reflects_external_file_changes() {
-        let workspace = tempfile::tempdir().unwrap();
-        let workspace_path = workspace.path().to_str().unwrap();
-        let storage = CronStorage::new();
-
-        storage.init(workspace_path).await;
-        assert!(storage.list_jobs().await.is_empty());
-
-        let now = Utc::now().to_rfc3339();
-        let jobs_path = CronStorage::jobs_path(workspace_path);
-        std::fs::create_dir_all(jobs_path.parent().unwrap()).unwrap();
-        std::fs::write(
-            &jobs_path,
-            serde_json::to_string_pretty(&json!({
-                "jobs": [{
-                    "id": "external-job",
-                    "name": "External job",
-                    "enabled": true,
-                    "schedule": { "kind": "cron", "expr": "0 9 * * *" },
-                    "payload": { "message": "hello" },
-                    "deleteAfterRun": false,
-                    "createdAt": now,
-                    "updatedAt": now
-                }]
-            }))
-            .unwrap(),
-        )
-        .unwrap();
-
-        let jobs = storage.list_jobs().await;
-        assert_eq!(jobs.len(), 1);
-        assert_eq!(jobs[0].id, "external-job");
-    }
-}
-
 impl Clone for CronStorage {
     fn clone(&self) -> Self {
         Self {
@@ -542,6 +500,7 @@ impl CronStorage {
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
+    use serde_json::json;
 
     fn make_run(run_id: &str, status: RunStatus) -> CronRunRecord {
         let started_at = Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0).unwrap();
@@ -579,5 +538,40 @@ mod tests {
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].status, RunStatus::Success);
         assert_eq!(runs[0].worktree_path.as_deref(), Some("/tmp/worktree"));
+    }
+
+    #[tokio::test]
+    async fn list_jobs_reflects_external_file_changes() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_path = workspace.path().to_str().unwrap();
+        let storage = CronStorage::new();
+
+        storage.init(workspace_path).await;
+        assert!(storage.list_jobs().await.is_empty());
+
+        let now = Utc::now().to_rfc3339();
+        let jobs_path = CronStorage::jobs_path(workspace_path);
+        std::fs::create_dir_all(jobs_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &jobs_path,
+            serde_json::to_string_pretty(&json!({
+                "jobs": [{
+                    "id": "external-job",
+                    "name": "External job",
+                    "enabled": true,
+                    "schedule": { "kind": "cron", "expr": "0 9 * * *" },
+                    "payload": { "message": "hello" },
+                    "deleteAfterRun": false,
+                    "createdAt": now,
+                    "updatedAt": now
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let jobs = storage.list_jobs().await;
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].id, "external-job");
     }
 }

--- a/src-tauri/src/commands/cron/types.rs
+++ b/src-tauri/src/commands/cron/types.rs
@@ -34,9 +34,8 @@ pub struct CronSchedule {
     pub tz: Option<String>,
 }
 
-/// Default timeout for cron job AI execution (3 minutes).
-/// This limits how long the AI agent can run before being forcibly aborted.
-pub const DEFAULT_TIMEOUT_SECONDS: u64 = 180;
+/// Legacy marker written by older cron timeout handling when it aborted an AI response.
+pub const LEGACY_TIMEOUT_CUT_SHORT_MARKER: &str = "AI response was cut short after";
 
 /// Payload configuration - what to send to OpenCode
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -47,9 +46,8 @@ pub struct CronPayload {
     /// Optional model override ("provider/model")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
-    /// Max seconds to wait for the AI to respond before aborting the session.
-    /// Prevents the AI agent from running indefinitely in agentic loops.
-    /// Default: 180 (3 minutes). Range: 30–900.
+    /// Deprecated compatibility field. Old job JSON may contain this value, but
+    /// cron execution ignores it and new saves omit it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_seconds: Option<u64>,
     /// Whether to run in an isolated git worktree
@@ -105,6 +103,7 @@ pub enum RunStatus {
     Failed,
     Timeout,
     Running,
+    Stale,
 }
 
 /// A cron job definition
@@ -158,6 +157,9 @@ pub struct CronRunRecord {
     pub finished_at: Option<DateTime<Utc>>,
     /// Run status
     pub status: RunStatus,
+    /// Last executor heartbeat while the run was active
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_heartbeat_at: Option<DateTime<Utc>>,
     /// OpenCode session ID used for this run
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
@@ -173,6 +175,24 @@ pub struct CronRunRecord {
     /// Worktree path used for this run (if worktree mode was enabled)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worktree_path: Option<String>,
+}
+
+impl CronRunRecord {
+    pub fn has_legacy_timeout_cut_short_text(&self) -> bool {
+        self.response_summary
+            .as_deref()
+            .is_some_and(|text| text.contains(LEGACY_TIMEOUT_CUT_SHORT_MARKER))
+            || self
+                .error
+                .as_deref()
+                .is_some_and(|text| text.contains(LEGACY_TIMEOUT_CUT_SHORT_MARKER))
+    }
+}
+
+pub fn normalize_legacy_timeout_status(record: &mut CronRunRecord) {
+    if record.has_legacy_timeout_cut_short_text() && record.status == RunStatus::Success {
+        record.status = RunStatus::Timeout;
+    }
 }
 
 /// Persistent storage structure for all cron jobs


### PR DESCRIPTION
## Summary
- remove cron AI wall-clock timeout behavior, preserve legacy timeout config compatibility, and reconcile stale/timeout run history correctly
- fix chat UI regressions around scoped OpenCode errors, sidebar session-list scrolling, picker Tab selection, and Shift+Enter line breaks
- add a compact Mermaid diagram enlarge button that opens a content-sized preview dialog without re-rendering the diagram
- align @opencode-ai/sdk to the sync API version used by latest upstream and merge duplicate cron storage test modules after rebase

## Test Plan
- ./node_modules/.bin/vitest run src/packages/ai/__tests__/message.test.tsx src/packages/ai/__tests__/editable-with-file-chips.test.tsx src/components/chat/__tests__/CommandPopover.test.tsx src/components/chat/__tests__/FileMentionPopover.test.tsx src/components/chat/__tests__/MessageList.test.tsx src/components/settings/cron/__tests__/CronHistoryDialog.test.tsx src/components/settings/cron/__tests__/CronJobDialog.test.tsx src/lib/__tests__/cron-utils.test.ts src/stores/__tests__/cron.test.ts
- ./node_modules/.bin/tsc --noEmit
- cargo test --manifest-path src-tauri/Cargo.toml -p teamclaw --lib cron
- git diff --check