### PR TITLE
fix: recover from unresponsive main webview

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ mod commands;
 pub mod process_util;
 pub mod sentry_utils;
 mod telemetry;
+mod webview_recovery;
 
 /// Get the mtime of the user's shell profile file as a u64 (seconds since epoch).
 /// Returns 0 if the file doesn't exist or can't be read.
@@ -1022,6 +1023,9 @@ pub fn run() {
             match event {
                 #[cfg(target_os = "macos")]
                 tauri::RunEvent::Reopen { .. } => {
+                    if webview_recovery::request_restart_if_main_webview_unhealthy(app, "macOS reopen") {
+                        return;
+                    }
                     // Always show the main window when the dock icon is clicked.
                     // Tauri's `has_visible_windows` can report `true` even when
                     // the window was hidden via `win.hide()`, so we ignore it and
@@ -1029,6 +1033,19 @@ pub fn run() {
                     let state = app.state::<commands::spotlight::SpotlightState>();
                     commands::spotlight::show_main_window(app.clone(), state);
                     maybe_emit_app_active(app);
+                }
+                tauri::RunEvent::Resumed => {
+                    let app_handle = app.clone();
+                    std::thread::spawn(move || {
+                        std::thread::sleep(std::time::Duration::from_millis(750));
+                        let app_for_probe = app_handle.clone();
+                        let _ = app_handle.run_on_main_thread(move || {
+                            webview_recovery::request_restart_if_main_webview_unhealthy(
+                                &app_for_probe,
+                                "event loop resume",
+                            );
+                        });
+                    });
                 }
                 tauri::RunEvent::Exit => {
                     // Kill the OpenCode sidecar synchronously.

--- a/src-tauri/src/webview_recovery.rs
+++ b/src-tauri/src/webview_recovery.rs
@@ -1,0 +1,67 @@
+use tauri::Manager;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MainWebviewProbe {
+    Healthy,
+    MissingWindow,
+    Unresponsive,
+}
+
+pub fn should_restart_for_probe(probe: MainWebviewProbe) -> bool {
+    matches!(
+        probe,
+        MainWebviewProbe::MissingWindow | MainWebviewProbe::Unresponsive
+    )
+}
+
+pub fn probe_main_webview(app: &tauri::AppHandle) -> MainWebviewProbe {
+    let Some(window) = app.get_webview_window("main") else {
+        return MainWebviewProbe::MissingWindow;
+    };
+
+    match window.url() {
+        Ok(_) => MainWebviewProbe::Healthy,
+        Err(err) => {
+            eprintln!("[WebViewRecovery] main webview URL probe failed: {err}");
+            MainWebviewProbe::Unresponsive
+        }
+    }
+}
+
+pub fn request_restart_if_main_webview_unhealthy(
+    app: &tauri::AppHandle,
+    reason: &str,
+) -> bool {
+    let probe = probe_main_webview(app);
+    if !should_restart_for_probe(probe) {
+        return false;
+    }
+
+    let message = format!(
+        "[WebViewRecovery] Requesting app restart after {reason}; main webview probe: {probe:?}"
+    );
+    eprintln!("{message}");
+    crate::sentry_utils::capture_warning(&message);
+    app.request_restart();
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{should_restart_for_probe, MainWebviewProbe};
+
+    #[test]
+    fn restarts_when_main_webview_is_unresponsive() {
+        assert!(should_restart_for_probe(MainWebviewProbe::Unresponsive));
+    }
+
+    #[test]
+    fn does_not_restart_when_main_webview_is_healthy() {
+        assert!(!should_restart_for_probe(MainWebviewProbe::Healthy));
+    }
+
+    #[test]
+    fn restarts_when_main_webview_is_missing() {
+        assert!(should_restart_for_probe(MainWebviewProbe::MissingWindow));
+    }
+}


### PR DESCRIPTION
## Summary
- Add a main WebView health probe that treats missing or unresponsive WebView IPC as recoverable failure.
- Probe on macOS dock reopen and event-loop resume, then request an app restart so the existing exit cleanup handles sidecars.
- Cover the restart decision logic with focused Rust unit tests.

## Test Plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml webview_recovery::tests -- --nocapture`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
