### PR TITLE
fix: address CI lint and unit failures

### DIFF
--- a/packages/app/src/components/chat/CommandPopover.tsx
+++ b/packages/app/src/components/chat/CommandPopover.tsx
@@ -409,7 +409,7 @@ export function CommandPopover({
         {/* Hint bar */}
         <div className="flex items-center gap-3 px-3 py-1.5 text-[10px] text-muted-foreground/60 border-t">
           <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↑↓</kbd> {t('chat.commandPopover.navigate', 'navigate')}</span>
-          <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">↵/Tab</kbd> {t('chat.commandPopover.select', 'select')}</span>
+          <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">{t('chat.commandPopover.enterOrTab', '↵/Tab')}</kbd> {t('chat.commandPopover.select', 'select')}</span>
           <span><kbd className="px-1 py-0.5 rounded bg-muted text-[9px] font-mono">Esc</kbd> {t('chat.commandPopover.close', 'close')}</span>
         </div>
       </div>

--- a/packages/app/src/components/chat/FileMentionPopover.tsx
+++ b/packages/app/src/components/chat/FileMentionPopover.tsx
@@ -100,6 +100,8 @@ export function FileMentionPopover({
   const [isLoading, setIsLoading] = React.useState(false)
   const [highlightedIndex, setHighlightedIndex] = React.useState(0)
   const listRef = React.useRef<HTMLDivElement>(null)
+  const filteredEntriesRef = React.useRef<FlatEntry[]>([])
+  const highlightedIndexRef = React.useRef(0)
 
   // Recursively scan workspace on open
   React.useEffect(() => {
@@ -147,6 +149,14 @@ export function FileMentionPopover({
   }, [allEntries, searchQuery])
 
   React.useEffect(() => {
+    filteredEntriesRef.current = filteredEntries
+  }, [filteredEntries])
+
+  React.useEffect(() => {
+    highlightedIndexRef.current = highlightedIndex
+  }, [highlightedIndex])
+
+  React.useEffect(() => {
     setHighlightedIndex(0)
   }, [filteredEntries])
 
@@ -164,29 +174,40 @@ export function FileMentionPopover({
 
   // Keyboard navigation
   React.useEffect(() => {
-    if (!open || filteredEntries.length === 0) return
+    if (!open) return
 
     const onKeyDown = (e: KeyboardEvent) => {
+      const currentEntries = filteredEntriesRef.current
+      if (currentEntries.length === 0) return
+
       if (e.key === "ArrowDown") {
         e.preventDefault()
         e.stopPropagation()
-        setHighlightedIndex(i => (i + 1) % filteredEntries.length)
+        setHighlightedIndex(i => {
+          const nextIndex = (i + 1) % currentEntries.length
+          highlightedIndexRef.current = nextIndex
+          return nextIndex
+        })
       } else if (e.key === "ArrowUp") {
         e.preventDefault()
         e.stopPropagation()
-        setHighlightedIndex(i => (i - 1 + filteredEntries.length) % filteredEntries.length)
+        setHighlightedIndex(i => {
+          const nextIndex = (i - 1 + currentEntries.length) % currentEntries.length
+          highlightedIndexRef.current = nextIndex
+          return nextIndex
+        })
       } else if ((e.key === "Enter" || e.key === "Tab") && !e.shiftKey) {
         if (e.key === "Enter" && (e.isComposing || e.keyCode === 229)) return
         e.preventDefault()
         e.stopPropagation()
-        const entry = filteredEntries[highlightedIndex]
+        const entry = currentEntries[highlightedIndexRef.current]
         if (entry) handleSelect(entry)
       }
     }
 
     document.addEventListener("keydown", onKeyDown, true)
     return () => document.removeEventListener("keydown", onKeyDown, true)
-  }, [open, filteredEntries, highlightedIndex, handleSelect])
+  }, [open, handleSelect])
 
   if (!open) return null
 

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -262,6 +262,7 @@
       "commands": "{{count}} command",
       "commands_plural": "{{count}} commands",
       "navigate": "navigate",
+      "enterOrTab": "↵/Tab",
       "select": "select",
       "close": "close",
       "description": "Description"
@@ -1403,6 +1404,8 @@
         "gmailAddressPlaceholder": "your-email@gmail.com",
         "authorizeGmail": "Authorize Gmail",
         "reauthorize": "Re-authorize",
+        "gmailAuthUrlHint": "Open this authorization URL in your browser, then paste the returned code.",
+        "copy": "Copy",
         "authorized": "Authorized",
         "imapHost": "IMAP Host",
         "imapPort": "IMAP Port",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -262,6 +262,7 @@
       "commands": "{{count}} 个命令",
       "commands_plural": "{{count}} 个命令",
       "navigate": "导航",
+      "enterOrTab": "↵/Tab",
       "select": "选择",
       "close": "关闭",
       "description": "说明"
@@ -1403,6 +1404,8 @@
         "gmailAddressPlaceholder": "your-email@gmail.com",
         "authorizeGmail": "授权 Gmail",
         "reauthorize": "重新授权",
+        "gmailAuthUrlHint": "在浏览器中打开此授权链接，然后粘贴返回的授权码。",
+        "copy": "复制",
         "authorized": "已授权",
         "imapHost": "IMAP 服务器",
         "imapPort": "IMAP 端口",

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -34,14 +34,12 @@ fn resolve_updater_endpoint(config: &serde_json::Value) -> Option<String> {
         return Some(endpoint);
     }
 
-    updater["endpoints"]
-        .as_array()
-        .and_then(|endpoints| {
-            endpoints
-                .iter()
-                .filter_map(|endpoint| endpoint.as_str())
-                .find_map(resolve_updater_url)
-        })
+    updater["endpoints"].as_array().and_then(|endpoints| {
+        endpoints
+            .iter()
+            .filter_map(|endpoint| endpoint.as_str())
+            .find_map(resolve_updater_url)
+    })
 }
 
 fn main() {

--- a/src-tauri/src/commands/cron/scheduler.rs
+++ b/src-tauri/src/commands/cron/scheduler.rs
@@ -112,10 +112,6 @@ impl CronScheduler {
         }
     }
 
-    pub(crate) fn normalize_legacy_timeout_record(record: &mut CronRunRecord) {
-        normalize_legacy_timeout_status(record);
-    }
-
     pub(crate) fn reconcile_interrupted_run(
         mut record: CronRunRecord,
         assistant_text: Option<String>,
@@ -1316,7 +1312,7 @@ mod tests {
             Some("partial output\n\n---\n⚠️ AI response was cut short after 180s timeout."),
         );
 
-        CronScheduler::normalize_legacy_timeout_record(&mut record);
+        normalize_legacy_timeout_status(&mut record);
 
         assert_eq!(record.status, RunStatus::Timeout);
     }

--- a/src-tauri/src/webview_recovery.rs
+++ b/src-tauri/src/webview_recovery.rs
@@ -28,10 +28,7 @@ pub fn probe_main_webview(app: &tauri::AppHandle) -> MainWebviewProbe {
     }
 }
 
-pub fn request_restart_if_main_webview_unhealthy(
-    app: &tauri::AppHandle,
-    reason: &str,
-) -> bool {
+pub fn request_restart_if_main_webview_unhealthy(app: &tauri::AppHandle, reason: &str) -> bool {
     let probe = probe_main_webview(app);
     if !should_restart_for_probe(probe) {
         return false;


### PR DESCRIPTION
## Summary
- add missing locale keys for email setup and command popover hints
- stabilize FileMentionPopover keyboard selection after async file loading
- apply rustfmt output and remove an unused cron scheduler wrapper so Clippy passes with -D warnings

## Verification
- pnpm lint (0 errors, existing warnings only)
- pnpm typecheck
- pnpm test:unit (171 files, 1147 tests passed)
- cargo fmt --check --manifest-path src-tauri/Cargo.toml
- cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings