### PR TITLE
Add production data guard permissions

### DIFF
--- a/packages/app/src/components/chat/PermissionCard.tsx
+++ b/packages/app/src/components/chat/PermissionCard.tsx
@@ -107,7 +107,11 @@ function getPermissionCardPresentation(entry: PendingPermissionEntry, t: Transla
     return permType
   })()
 
-  const subtitle = isExternal
+  const productionGuardLabel = entry.productionRisk
+    ? t("chat.permissionCard.productionGuard", "Production data guard")
+    : null
+  const productionGuardReason = entry.productionRisk?.reasons.join(", ")
+  const subtitle = productionGuardReason || (isExternal
     ? sourceToolLabel
       ? t("chat.permissionCard.sourceToolInvocation", "来自 {{tool}} 工具调用", { tool: sourceToolLabel })
       : t("chat.permissionCard.waitingExternalPathApproval", "读取工作区外路径前需要你的确认")
@@ -115,9 +119,15 @@ function getPermissionCardPresentation(entry: PendingPermissionEntry, t: Transla
       ? t("chat.permissionCard.childSessionWaitingApproval", "子会话正在等待你的审批")
       : sourceToolLabel
         ? t("chat.permissionCard.sourceToolInvocation", "来自 {{tool}} 工具调用", { tool: sourceToolLabel })
-        : t("chat.permissionCard.toolInvocationWaitingApproval", "工具调用正在等待你的审批")
+        : t("chat.permissionCard.toolInvocationWaitingApproval", "工具调用正在等待你的审批"))
 
-  return { meta, detail: summarizePermissionDetail(detail, permType), subtitle }
+  return {
+    meta,
+    detail: summarizePermissionDetail(detail, permType),
+    subtitle,
+    productionGuardLabel,
+    allowAlways: entry.productionRisk?.allowAlways !== false,
+  }
 }
 
 function buildPendingEntryFromToolPermission(
@@ -211,7 +221,8 @@ function PermissionEntryCard({
     if (decided !== null) setDecided(null)
   }
 
-  const { meta, detail, subtitle } = getPermissionCardPresentation(entry, t)
+  const presentation = getPermissionCardPresentation(entry, t)
+  const { meta, detail, subtitle } = presentation
 
   const handleReply = async (d: "allow" | "deny" | "always") => {
     setSubmitting(true)
@@ -245,6 +256,11 @@ function PermissionEntryCard({
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2">
                 <div className="text-[13px] font-semibold text-foreground">{meta.subject} {meta.title}</div>
+                {presentation.productionGuardLabel ? (
+                  <span className="shrink-0 rounded-full border border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300">
+                    {presentation.productionGuardLabel}
+                  </span>
+                ) : null}
                 {pendingCount > 1 ? (
                   <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
                     {t("chat.permissionCard.pendingCount", "{{count}} pending", { count: pendingCount })}
@@ -272,14 +288,16 @@ function PermissionEntryCard({
                 >
                   {t("permission.deny", "拒绝")}
                 </button>
-                <button
-                  type="button"
-                  onClick={() => handleReply("always")}
-                  disabled={submitting}
-                  className="shrink-0 rounded-[9px] border border-[#e5eaf0] bg-white px-[10px] py-[5px] text-[12px] font-medium text-[#475569] transition-colors hover:bg-muted/70 hover:text-foreground disabled:opacity-50 dark:border-border dark:bg-background dark:text-muted-foreground"
-                >
-                  {t("permission.alwaysAllow", "总是允许")}
-                </button>
+                {presentation.allowAlways ? (
+                  <button
+                    type="button"
+                    onClick={() => handleReply("always")}
+                    disabled={submitting}
+                    className="shrink-0 rounded-[9px] border border-[#e5eaf0] bg-white px-[10px] py-[5px] text-[12px] font-medium text-[#475569] transition-colors hover:bg-muted/70 hover:text-foreground disabled:opacity-50 dark:border-border dark:bg-background dark:text-muted-foreground"
+                  >
+                    {t("permission.alwaysAllow", "总是允许")}
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   onClick={() => handleReply("allow")}

--- a/packages/app/src/components/chat/__tests__/PermissionCard.test.tsx
+++ b/packages/app/src/components/chat/__tests__/PermissionCard.test.tsx
@@ -39,6 +39,12 @@ const sessionState = {
       metadata?: Record<string, string>;
     };
     childSessionId: string | null;
+    productionRisk?: {
+      level: 'production_data';
+      reasons: string[];
+      matchedRules: string[];
+      allowAlways: false;
+    };
   }>,
   replyPermission: vi.fn(() => Promise.resolve()),
 };
@@ -167,6 +173,34 @@ describe('PendingPermissionInline', () => {
     await waitFor(() => {
       expect(replyMock).toHaveBeenCalledWith('perm-1', 'allow');
     });
+  });
+
+  it('renders production-risk permission without an always-allow action', async () => {
+    sessionState.pendingPermissions = [
+      {
+        permission: {
+          id: 'perm-prod-1',
+          permission: 'bash',
+          patterns: ['pnpm sync-prod-orders'],
+        },
+        childSessionId: null,
+        productionRisk: {
+          level: 'production_data',
+          reasons: ['Sync production orders'],
+          matchedRules: ['sync-prod-orders'],
+          allowAlways: false,
+        },
+      },
+    ];
+
+    const { PendingPermissionInline } = await import('../PermissionCard');
+    render(<PendingPermissionInline />);
+
+    expect(screen.getByText('Production data guard')).toBeTruthy();
+    expect(screen.getByText('Sync production orders')).toBeTruthy();
+    expect(screen.queryByText('总是允许')).toBeNull();
+    expect(screen.getByText('允许')).toBeTruthy();
+    expect(screen.getByText('拒绝')).toBeTruthy();
   });
 
   it('promotes the next queued permission immediately before reply resolves', async () => {

--- a/packages/app/src/components/settings/PermissionManagementSection.tsx
+++ b/packages/app/src/components/settings/PermissionManagementSection.tsx
@@ -13,6 +13,7 @@ import {
   AlertTriangle,
   Save,
   Database,
+  Plus,
 } from 'lucide-react'
 import { invoke } from '@tauri-apps/api/core'
 import { useWorkspaceStore } from '@/stores/workspace'
@@ -20,6 +21,8 @@ import { restartOpencode } from '@/lib/opencode/restart'
 import { cn, isTauri } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
 import {
   Select,
   SelectContent,
@@ -28,8 +31,14 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { SettingCard, SectionHeader } from './shared'
-import { readTextFile, writeTextFile, exists } from '@tauri-apps/plugin-fs'
+import { readTextFile, writeTextFile, exists, mkdir } from '@tauri-apps/plugin-fs'
 import { invalidatePermissionConfigCache } from '@/stores/session-permissions'
+import { TEAMCLAW_DIR } from '@/lib/build-config'
+import {
+  evaluateProductionGuard,
+  type ProductionGuardConfig,
+  type ProductionGuardRule,
+} from '@/lib/dangerous-command-policy'
 
 type PermissionAction = 'allow' | 'ask' | 'deny'
 
@@ -65,6 +74,20 @@ interface PermissionConfig {
   skill?: PermissionAction
   external_directory?: PermissionAction
   doom_loop?: PermissionAction
+}
+
+type ProductionGuardStatus = 'missing' | 'active' | 'disabled' | 'invalid'
+
+interface ProductionGuardState {
+  status: ProductionGuardStatus
+  config: ProductionGuardConfig | null
+  error?: string
+}
+
+interface NewProductionGuardRuleForm {
+  id: string
+  label: string
+  commandIncludes: string
 }
 
 // TeamClaw defaults: destructive operations require approval, read-only auto-approved.
@@ -111,6 +134,54 @@ const PERMISSION_LABELS: Record<keyof PermissionConfig, { label: string; desc: s
   doom_loop: { label: 'Doom Loop Guard', desc: 'Prevent infinite loops', icon: AlertTriangle },
 }
 
+function getProductionGuardStatusLabel(status: ProductionGuardStatus) {
+  switch (status) {
+    case 'active':
+      return 'Active'
+    case 'disabled':
+      return 'Disabled'
+    case 'invalid':
+      return 'Config invalid'
+    case 'missing':
+      return 'Not configured'
+  }
+}
+
+function getProductionGuardStatusClass(status: ProductionGuardStatus) {
+  switch (status) {
+    case 'active':
+      return 'bg-green-500/15 text-green-600 dark:text-green-400 border-green-500/20'
+    case 'disabled':
+      return 'bg-amber-500/15 text-amber-600 dark:text-amber-400 border-amber-500/20'
+    case 'invalid':
+      return 'bg-red-500/15 text-red-600 dark:text-red-400 border-red-500/20'
+    case 'missing':
+      return 'bg-muted text-muted-foreground border-border'
+  }
+}
+
+function getProductionGuardMatchers(rule: ProductionGuardRule) {
+  const match = rule.match
+  if (!match) return []
+
+  const rows: Array<{ label: string; values: string[] }> = []
+  if (match.commandIncludes?.length) rows.push({ label: 'Command includes', values: match.commandIncludes })
+  return rows
+}
+
+function splitRuleValues(value: string) {
+  return value
+    .split(/\n|,/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+const EMPTY_PRODUCTION_GUARD_FORM: NewProductionGuardRuleForm = {
+  id: '',
+  label: '',
+  commandIncludes: '',
+}
+
 export const PermissionManagementSection = React.memo(function PermissionManagementSection() {
   const { t } = useTranslation()
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
@@ -125,6 +196,20 @@ export const PermissionManagementSection = React.memo(function PermissionManagem
   const [loadingConfig, setLoadingConfig] = React.useState(false)
   const [savingConfig, setSavingConfig] = React.useState(false)
   const [configModified, setConfigModified] = React.useState(false)
+
+  // Local production data guard config
+  const [productionGuard, setProductionGuard] = React.useState<ProductionGuardState>({
+    status: 'missing',
+    config: null,
+  })
+  const [loadingProductionGuard, setLoadingProductionGuard] = React.useState(false)
+  const [savingProductionGuard, setSavingProductionGuard] = React.useState(false)
+  const [showAddProductionGuardRule, setShowAddProductionGuardRule] = React.useState(false)
+  const [newProductionGuardRule, setNewProductionGuardRule] =
+    React.useState<NewProductionGuardRuleForm>(EMPTY_PRODUCTION_GUARD_FORM)
+  const [productionGuardFormError, setProductionGuardFormError] = React.useState<string | null>(null)
+  const [testCommand, setTestCommand] = React.useState('')
+  const [testResult, setTestResult] = React.useState<string | null>(null)
 
   // Look up project_id from the DB project table based on workspace path
   const fetchProjectId = React.useCallback(async () => {
@@ -199,6 +284,113 @@ export const PermissionManagementSection = React.memo(function PermissionManagem
     }
   }, [workspacePath])
 
+  const loadProductionGuardConfig = React.useCallback(async () => {
+    if (!workspacePath) return
+
+    setLoadingProductionGuard(true)
+    try {
+      const configPath = `${workspacePath}/${TEAMCLAW_DIR}/production-guard.json`
+      if (!(await exists(configPath))) {
+        setProductionGuard({ status: 'missing', config: null })
+        return
+      }
+
+      const config = JSON.parse(await readTextFile(configPath)) as ProductionGuardConfig
+      setProductionGuard({
+        status: config.enabled === false ? 'disabled' : 'active',
+        config,
+      })
+    } catch (error) {
+      setProductionGuard({
+        status: 'invalid',
+        config: null,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    } finally {
+      setLoadingProductionGuard(false)
+    }
+  }, [workspacePath])
+
+  const writeProductionGuardConfig = React.useCallback(async (config: ProductionGuardConfig) => {
+    if (!workspacePath) return
+
+    const configDir = `${workspacePath}/${TEAMCLAW_DIR}`
+    const configPath = `${configDir}/production-guard.json`
+    setSavingProductionGuard(true)
+    try {
+      if (!(await exists(configDir))) {
+        await mkdir(configDir, { recursive: true })
+      }
+
+      await writeTextFile(configPath, JSON.stringify(config, null, 2))
+      setProductionGuard({
+        status: config.enabled === false ? 'disabled' : 'active',
+        config,
+      })
+      setTestResult(null)
+    } catch (error) {
+      setProductionGuardFormError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setSavingProductionGuard(false)
+    }
+  }, [workspacePath])
+
+  const addProductionGuardRule = React.useCallback(async () => {
+    setProductionGuardFormError(null)
+    const id = newProductionGuardRule.id.trim()
+    if (!id) {
+      setProductionGuardFormError('Rule ID is required.')
+      return
+    }
+
+    const currentConfig: ProductionGuardConfig = productionGuard.config || {
+      version: 1,
+      enabled: true,
+      rules: [],
+    }
+    const currentRules = currentConfig.rules || []
+    if (currentRules.some((rule) => rule.id === id)) {
+      setProductionGuardFormError('Rule ID already exists.')
+      return
+    }
+
+    const commandIncludes = splitRuleValues(newProductionGuardRule.commandIncludes)
+
+    if (commandIncludes.length === 0) {
+      setProductionGuardFormError('Command includes is required.')
+      return
+    }
+
+    const rule: ProductionGuardRule = {
+      id,
+      label: newProductionGuardRule.label.trim() || id,
+      match: { commandIncludes },
+      risk: 'production_data',
+      approval: { mode: 'always_ask', allowAlways: false },
+    }
+
+    await writeProductionGuardConfig({
+      version: currentConfig.version || 1,
+      enabled: currentConfig.enabled !== false,
+      rules: [...currentRules, rule],
+    })
+
+    setNewProductionGuardRule(EMPTY_PRODUCTION_GUARD_FORM)
+    setShowAddProductionGuardRule(false)
+  }, [newProductionGuardRule, productionGuard.config, writeProductionGuardConfig])
+
+  const deleteProductionGuardRule = React.useCallback(async (ruleId: string) => {
+    if (!productionGuard.config) return
+    setProductionGuardFormError(null)
+
+    await writeProductionGuardConfig({
+      ...productionGuard.config,
+      version: productionGuard.config.version || 1,
+      enabled: productionGuard.config.enabled !== false,
+      rules: (productionGuard.config.rules || []).filter((rule) => rule.id !== ruleId),
+    })
+  }, [productionGuard.config, writeProductionGuardConfig])
+
   // Save permission config to opencode.json and restart OpenCode to apply
   const savePermissionConfig = React.useCallback(async () => {
     if (!workspacePath) return
@@ -242,7 +434,8 @@ export const PermissionManagementSection = React.memo(function PermissionManagem
     fetchProjectId()
     loadAllowlist()
     loadPermissionConfig()
-  }, [fetchProjectId, loadAllowlist, loadPermissionConfig])
+    loadProductionGuardConfig()
+  }, [fetchProjectId, loadAllowlist, loadPermissionConfig, loadProductionGuardConfig])
 
   // Only show rules for the current workspace project (and global), deduplicated.
   // Project-specific rules take precedence over global ones.
@@ -277,6 +470,30 @@ export const PermissionManagementSection = React.memo(function PermissionManagem
 
     return result
   }, [allowlistRows, currentProjectId])
+
+  const broadAllowlistRules = React.useMemo(
+    () =>
+      allRules.filter(({ rule }) =>
+        rule.permission === 'bash' &&
+        rule.action === 'allow' &&
+        (rule.pattern.trim() === '*' || rule.pattern.includes('*')),
+      ),
+    [allRules],
+  )
+
+  const productionGuardRules = React.useMemo(
+    () => productionGuard.config?.rules || [],
+    [productionGuard.config],
+  )
+
+  const testProductionGuardCommand = React.useCallback(() => {
+    const result = evaluateProductionGuard(testCommand, productionGuard.config)
+    setTestResult(
+      result.level === 'production_data'
+        ? `Matched: ${result.matchedRules.join(', ')}`
+        : 'No production guard rule matched this command.',
+    )
+  }, [productionGuard.config, testCommand])
 
   if (!workspacePath) {
     return (
@@ -349,7 +566,11 @@ export const PermissionManagementSection = React.memo(function PermissionManagem
                 >
                   <Terminal className="h-4 w-4 text-amber-500 shrink-0" />
                   <div className="flex-1 min-w-0">
-                    <code className="text-sm font-mono">{entry.rule.permission}: {entry.rule.pattern}</code>
+                    <code className="text-sm font-mono">
+                      <span>{entry.rule.permission}</span>
+                      <span>: </span>
+                      <span>{entry.rule.pattern}</span>
+                    </code>
                   </div>
                   <Badge
                     variant={entry.rule.action === 'allow' ? 'default' : 'destructive'}
@@ -376,6 +597,248 @@ export const PermissionManagementSection = React.memo(function PermissionManagem
           </div>
         )}
 
+      </SettingCard>
+
+      {/* Production Guard Section */}
+      <SettingCard>
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h4 className="text-sm font-semibold flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-red-500" />
+              {t('settings.permissions.productionGuard', 'Production Data Guard')}
+            </h4>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t(
+                'settings.permissions.productionGuardDesc',
+                'Local workspace rules that force approval before commands can touch production data.',
+              )}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge
+              variant="outline"
+              className={cn('text-xs', getProductionGuardStatusClass(productionGuard.status))}
+            >
+              {getProductionGuardStatusLabel(productionGuard.status)}
+            </Badge>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setShowAddProductionGuardRule((value) => !value)
+                setProductionGuardFormError(null)
+              }}
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Add Rule
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={loadProductionGuardConfig}
+              disabled={loadingProductionGuard}
+            >
+              {loadingProductionGuard ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <FileText className="h-3.5 w-3.5" />
+            <code>{TEAMCLAW_DIR}/production-guard.json</code>
+          </div>
+
+          {productionGuard.status === 'invalid' && (
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/20">
+              <AlertTriangle className="h-4 w-4 text-red-500 mt-0.5 shrink-0" />
+              <div className="text-xs text-red-600 dark:text-red-400">
+                <p className="font-medium">Production guard is disabled until this file is fixed.</p>
+                {productionGuard.error && <p className="mt-1 font-mono">{productionGuard.error}</p>}
+              </div>
+            </div>
+          )}
+
+          {productionGuard.status === 'missing' && (
+            <div className="text-sm text-muted-foreground p-3 rounded-lg border bg-muted/20">
+              {t(
+                'settings.permissions.productionGuardMissing',
+                'No production guard file was found for this workspace.',
+              )}
+            </div>
+          )}
+
+          {showAddProductionGuardRule && (
+            <div className="p-3 rounded-lg border bg-muted/20 space-y-3">
+              <div className="grid gap-3 md:grid-cols-2">
+                <label className="space-y-1">
+                  <span className="text-xs font-medium">Rule ID</span>
+                  <Input
+                    aria-label="Rule ID"
+                    value={newProductionGuardRule.id}
+                    onChange={(event) =>
+                      setNewProductionGuardRule((prev) => ({ ...prev, id: event.target.value }))
+                    }
+                    placeholder="biz-code-delete"
+                  />
+                </label>
+                <label className="space-y-1">
+                  <span className="text-xs font-medium">Label</span>
+                  <Input
+                    aria-label="Label"
+                    value={newProductionGuardRule.label}
+                    onChange={(event) =>
+                      setNewProductionGuardRule((prev) => ({ ...prev, label: event.target.value }))
+                    }
+                    placeholder="biz code delete"
+                  />
+                </label>
+              </div>
+
+              <label className="space-y-1 block">
+                <span className="text-xs font-medium">Command includes</span>
+                <Textarea
+                  aria-label="Command includes"
+                  value={newProductionGuardRule.commandIncludes}
+                  onChange={(event) =>
+                    setNewProductionGuardRule((prev) => ({ ...prev, commandIncludes: event.target.value }))
+                  }
+                  placeholder="scripts/delete_biz_codes.py"
+                  className="min-h-16 font-mono text-xs"
+                />
+              </label>
+
+              {productionGuardFormError && (
+                <p className="text-xs text-red-600 dark:text-red-400">{productionGuardFormError}</p>
+              )}
+
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setNewProductionGuardRule(EMPTY_PRODUCTION_GUARD_FORM)
+                    setShowAddProductionGuardRule(false)
+                    setProductionGuardFormError(null)
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={addProductionGuardRule}
+                  disabled={savingProductionGuard}
+                >
+                  {savingProductionGuard ? (
+                    <Loader2 className="h-4 w-4 animate-spin mr-1" />
+                  ) : (
+                    <Save className="h-4 w-4 mr-1" />
+                  )}
+                  Save Rule
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {productionGuard.status !== 'invalid' && productionGuardRules.length > 0 && (
+            <div className="space-y-2">
+              {productionGuardRules.map((rule) => (
+                <div key={rule.id} className="p-3 rounded-lg border bg-muted/20 space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">{rule.label || rule.id}</p>
+                      <p className="text-xs text-muted-foreground font-mono">{rule.id}</p>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <Badge variant="outline" className="text-xs">
+                        {rule.risk || 'production_data'}
+                      </Badge>
+                      <Badge variant="outline" className="text-xs">
+                        {rule.approval?.mode === 'always_ask' ? 'always ask' : 'ask'}
+                      </Badge>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                        aria-label={`Delete production guard rule ${rule.id}`}
+                        onClick={() => deleteProductionGuardRule(rule.id)}
+                        disabled={savingProductionGuard}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+
+                  {getProductionGuardMatchers(rule).map((matcher) => (
+                    <div key={matcher.label} className="space-y-1">
+                      <p className="text-xs text-muted-foreground">{matcher.label}</p>
+                      <div className="flex flex-wrap gap-2">
+                        {matcher.values.map((value) => (
+                          <code
+                            key={value}
+                            className="text-xs px-2 py-1 rounded border bg-background break-all"
+                          >
+                            {value}
+                          </code>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {broadAllowlistRules.length > 0 && (
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
+              <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
+              <div className="text-xs text-amber-700 dark:text-amber-300 space-y-2">
+                <p className="font-medium">Potential Bypasses</p>
+                <p>
+                  Broad bash allowlist rules can auto-approve commands before a focused guard rule
+                  gets a chance to ask.
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {broadAllowlistRules.map((entry) => (
+                    <code
+                      key={`${entry.projectId}-${entry.index}-bypass`}
+                      className="px-2 py-1 rounded border border-amber-500/20 bg-background"
+                    >
+                      {entry.rule.pattern}
+                    </code>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-2 pt-1">
+            <Textarea
+              value={testCommand}
+              onChange={(event) => setTestCommand(event.target.value)}
+              placeholder="Paste a command to test production guard matching"
+              className="min-h-20 font-mono text-xs"
+            />
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-xs text-muted-foreground">
+                {testResult || 'Run a local check against the loaded production guard rules.'}
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={testProductionGuardCommand}
+                disabled={!testCommand.trim() || productionGuard.status === 'invalid'}
+              >
+                Test Command
+              </Button>
+            </div>
+          </div>
+        </div>
       </SettingCard>
 
       {/* Permission Config Section */}

--- a/packages/app/src/components/settings/__tests__/PermissionManagementSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/PermissionManagementSection.test.tsx
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
+
+const fsMock = vi.hoisted(() => ({
+  readTextFile: vi.fn(),
+  writeTextFile: vi.fn(),
+  exists: vi.fn(),
+  mkdir: vi.fn(),
+}))
+
+const invokeMock = vi.hoisted(() => vi.fn())
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -10,17 +19,18 @@ vi.mock('react-i18next', () => ({
 }))
 
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn().mockResolvedValue('global'),
+  invoke: invokeMock,
 }))
 
 vi.mock('@tauri-apps/plugin-fs', () => ({
-  readTextFile: vi.fn().mockResolvedValue('{}'),
-  writeTextFile: vi.fn().mockResolvedValue(undefined),
-  exists: vi.fn().mockResolvedValue(false),
+  readTextFile: fsMock.readTextFile,
+  writeTextFile: fsMock.writeTextFile,
+  exists: fsMock.exists,
+  mkdir: fsMock.mkdir,
 }))
 
 vi.mock('@/lib/utils', () => ({
-  isTauri: () => false,
+  isTauri: () => true,
   cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
 }))
 
@@ -39,12 +49,20 @@ vi.mock('@/components/ui/badge', () => ({
     React.createElement('span', null, children),
 }))
 
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: React.ComponentProps<'input'>) => React.createElement('input', props),
+}))
+
 vi.mock('@/components/ui/select', () => ({
   Select: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
   SelectContent: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
   SelectItem: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
   SelectTrigger: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
   SelectValue: () => React.createElement('span'),
+}))
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: React.ComponentProps<'textarea'>) => React.createElement('textarea', props),
 }))
 
 vi.mock('@/components/settings/shared', () => ({
@@ -59,12 +77,50 @@ vi.mock('lucide-react', () => {
   return {
     Shield: stub, Trash2: stub, RefreshCw: stub, Loader2: stub,
     Terminal: stub, FileEdit: stub, FileText: stub, Check: stub,
-    X: stub, AlertTriangle: stub, Save: stub, Database: stub,
+    X: stub, AlertTriangle: stub, Save: stub, Database: stub, Plus: stub,
   }
 })
 
 beforeEach(() => {
   vi.clearAllMocks()
+  invokeMock.mockImplementation((command: string) => {
+    if (command === 'get_opencode_project_id') return Promise.resolve('global')
+    if (command === 'read_opencode_allowlist') {
+      return Promise.resolve([
+        {
+          project_id: 'global',
+          rules: [
+            { permission: 'bash', pattern: 'python3 *', action: 'allow' },
+          ],
+        },
+      ])
+    }
+    return Promise.resolve(undefined)
+  })
+  fsMock.exists.mockResolvedValue(true)
+  fsMock.mkdir.mockResolvedValue(undefined)
+  fsMock.writeTextFile.mockResolvedValue(undefined)
+  fsMock.readTextFile.mockImplementation((path: string) => {
+    if (path.endsWith('/opencode.json')) {
+      return Promise.resolve(JSON.stringify({ permission: { bash: 'ask' } }))
+    }
+    if (path.endsWith('/.teamclaw/production-guard.json')) {
+      return Promise.resolve(JSON.stringify({
+        version: 1,
+        enabled: true,
+        rules: [
+          {
+            id: 'biz-code-delete',
+            label: 'biz code delete',
+            match: { commandIncludes: ['scripts/delete_biz_codes.py'] },
+            risk: 'production_data',
+            approval: { mode: 'always_ask', allowAlways: false },
+          },
+        ],
+      }))
+    }
+    return Promise.resolve('{}')
+  })
 })
 
 describe('PermissionManagementSection', () => {
@@ -73,17 +129,154 @@ describe('PermissionManagementSection', () => {
     render(React.createElement(PermissionManagementSection))
     expect(screen.getByTestId('section-header')).toBeDefined()
     expect(screen.getByText('Permission Management')).toBeDefined()
+    expect(await screen.findByText('Active')).toBeDefined()
   })
 
   it('renders permission configuration section', async () => {
     const { PermissionManagementSection } = await import('@/components/settings/PermissionManagementSection')
     render(React.createElement(PermissionManagementSection))
     expect(screen.getByText('Permission Configuration')).toBeDefined()
+    expect(await screen.findByText('Active')).toBeDefined()
   })
 
   it('renders allowlist section', async () => {
     const { PermissionManagementSection } = await import('@/components/settings/PermissionManagementSection')
     render(React.createElement(PermissionManagementSection))
     expect(screen.getByText('Command Allowlist')).toBeDefined()
+    expect(await screen.findByText('Active')).toBeDefined()
+  })
+
+  it('renders production guard rules and broad allowlist diagnostics', async () => {
+    const { PermissionManagementSection } = await import('@/components/settings/PermissionManagementSection')
+    render(React.createElement(PermissionManagementSection))
+
+    expect(await screen.findByText('Production Data Guard')).toBeDefined()
+    expect(await screen.findByText('Active')).toBeDefined()
+    expect(await screen.findByText('biz code delete')).toBeDefined()
+    expect(await screen.findByText('scripts/delete_biz_codes.py')).toBeDefined()
+    expect(await screen.findByText('Potential Bypasses')).toBeDefined()
+    expect(await screen.findAllByText('python3 *')).toHaveLength(2)
+  })
+
+  it('tests pasted commands against production guard rules', async () => {
+    const { PermissionManagementSection } = await import('@/components/settings/PermissionManagementSection')
+    render(React.createElement(PermissionManagementSection))
+
+    const input = await screen.findByPlaceholderText('Paste a command to test production guard matching')
+    fireEvent.change(input, {
+      target: {
+        value: 'cd /workspace/teamclaw-team/skills/biz-code-delete && python3 scripts/delete_biz_codes.py --env test',
+      },
+    })
+    fireEvent.click(screen.getByText('Test Command'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Matched: biz-code-delete')).toBeDefined()
+    })
+  })
+
+  it('shows invalid production guard config state', async () => {
+    fsMock.readTextFile.mockImplementation((path: string) => {
+      if (path.endsWith('/opencode.json')) {
+        return Promise.resolve(JSON.stringify({ permission: { bash: 'ask' } }))
+      }
+      if (path.endsWith('/.teamclaw/production-guard.json')) {
+        return Promise.resolve('{ invalid json')
+      }
+      return Promise.resolve('{}')
+    })
+
+    const { PermissionManagementSection } = await import('@/components/settings/PermissionManagementSection')
+    render(React.createElement(PermissionManagementSection))
+
+    expect(await screen.findByText('Config invalid')).toBeDefined()
+    expect(await screen.findByText(/Production guard is disabled/)).toBeDefined()
+  })
+
+  it('adds a production guard rule and writes the workspace config', async () => {
+    const { PermissionManagementSection } = await import('@/components/settings/PermissionManagementSection')
+    render(React.createElement(PermissionManagementSection))
+
+    fireEvent.click(await screen.findByText('Add Rule'))
+    expect(screen.queryByLabelText('Paths')).toBeNull()
+    expect(screen.queryByLabelText('Regex')).toBeNull()
+    expect(screen.queryByLabelText('Environment')).toBeNull()
+
+    fireEvent.change(screen.getByLabelText('Rule ID'), { target: { value: 'orders-prod-delete' } })
+    fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'orders prod delete' } })
+    fireEvent.change(screen.getByLabelText('Command includes'), {
+      target: { value: 'scripts/delete_orders.py\n--env prod' },
+    })
+    fireEvent.click(screen.getByText('Save Rule'))
+
+    await waitFor(() => expect(fsMock.writeTextFile).toHaveBeenCalled())
+    const [path, content] = fsMock.writeTextFile.mock.calls.at(-1) as [string, string]
+    const config = JSON.parse(content)
+
+    expect(path).toBe('/test/.teamclaw/production-guard.json')
+    expect(config.rules).toHaveLength(2)
+    expect(config.rules[1]).toMatchObject({
+      id: 'orders-prod-delete',
+      label: 'orders prod delete',
+      match: { commandIncludes: ['scripts/delete_orders.py', '--env prod'] },
+      risk: 'production_data',
+      approval: { mode: 'always_ask', allowAlways: false },
+    })
+  })
+
+  it('deletes a production guard rule and writes the workspace config', async () => {
+    const { PermissionManagementSection } = await import('@/components/settings/PermissionManagementSection')
+    render(React.createElement(PermissionManagementSection))
+
+    fireEvent.click(await screen.findByLabelText('Delete production guard rule biz-code-delete'))
+
+    await waitFor(() => expect(fsMock.writeTextFile).toHaveBeenCalled())
+    const [, content] = fsMock.writeTextFile.mock.calls.at(-1) as [string, string]
+    const config = JSON.parse(content)
+
+    expect(config.rules).toEqual([])
+  })
+
+  it('creates the production guard config when adding the first rule', async () => {
+    fsMock.exists.mockImplementation((path: string) => {
+      if (path.endsWith('/.teamclaw') || path.endsWith('/.teamclaw/production-guard.json')) {
+        return Promise.resolve(false)
+      }
+      return Promise.resolve(true)
+    })
+    fsMock.readTextFile.mockImplementation((path: string) => {
+      if (path.endsWith('/opencode.json')) {
+        return Promise.resolve(JSON.stringify({ permission: { bash: 'ask' } }))
+      }
+      return Promise.resolve('{}')
+    })
+
+    const { PermissionManagementSection } = await import('@/components/settings/PermissionManagementSection')
+    render(React.createElement(PermissionManagementSection))
+
+    fireEvent.click(await screen.findByText('Add Rule'))
+    fireEvent.change(screen.getByLabelText('Rule ID'), { target: { value: 'first-prod-rule' } })
+    fireEvent.change(screen.getByLabelText('Command includes'), {
+      target: { value: 'dangerous-script.py' },
+    })
+    fireEvent.click(screen.getByText('Save Rule'))
+
+    await waitFor(() => expect(fsMock.writeTextFile).toHaveBeenCalled())
+    const [path, content] = fsMock.writeTextFile.mock.calls.at(-1) as [string, string]
+    const config = JSON.parse(content)
+
+    expect(fsMock.mkdir).toHaveBeenCalledWith('/test/.teamclaw', { recursive: true })
+    expect(path).toBe('/test/.teamclaw/production-guard.json')
+    expect(config).toMatchObject({
+      version: 1,
+      enabled: true,
+      rules: [
+        {
+          id: 'first-prod-rule',
+          label: 'first-prod-rule',
+          match: { commandIncludes: ['dangerous-script.py'] },
+        },
+      ],
+    })
   })
 })

--- a/packages/app/src/lib/__tests__/dangerous-command-policy.test.ts
+++ b/packages/app/src/lib/__tests__/dangerous-command-policy.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  evaluateProductionGuard,
+  extractPermissionCommand,
+  type ProductionGuardConfig,
+} from '../dangerous-command-policy'
+
+describe('dangerous-command-policy', () => {
+  const config: ProductionGuardConfig = {
+    version: 1,
+    enabled: true,
+    rules: [
+      {
+        id: 'sync-prod-orders',
+        label: 'Sync production orders',
+        match: {
+          commandIncludes: ['scripts/sync-prod-orders.ts', 'pnpm sync-prod-orders'],
+        },
+        risk: 'production_data',
+        approval: {
+          mode: 'always_ask',
+          allowAlways: false,
+        },
+      },
+    ],
+  }
+
+  it('extracts command text from permission metadata before patterns', () => {
+    expect(
+      extractPermissionCommand({
+        id: 'perm-1',
+        sessionID: 'session-1',
+        permission: 'bash',
+        patterns: ['fallback command'],
+        metadata: { command: 'pnpm sync-prod-orders' },
+      }),
+    ).toBe('pnpm sync-prod-orders')
+  })
+
+  it('marks configured production scripts as production data risk', () => {
+    const risk = evaluateProductionGuard('pnpm sync-prod-orders --limit 10', config)
+
+    expect(risk).toMatchObject({
+      level: 'production_data',
+      matchedRules: ['sync-prod-orders'],
+      allowAlways: false,
+    })
+    if (risk.level === 'production_data') {
+      expect(risk.reasons.join(' ')).toContain('Sync production orders')
+    }
+  })
+
+  it('does not flag unrelated commands', () => {
+    expect(evaluateProductionGuard('pnpm test', config)).toEqual({ level: 'normal' })
+  })
+
+  it('ignores rules when the guard is disabled', () => {
+    expect(evaluateProductionGuard('pnpm sync-prod-orders', { ...config, enabled: false })).toEqual({
+      level: 'normal',
+    })
+  })
+})

--- a/packages/app/src/lib/dangerous-command-policy.ts
+++ b/packages/app/src/lib/dangerous-command-policy.ts
@@ -1,0 +1,130 @@
+import { TEAMCLAW_DIR } from '@/lib/build-config'
+import type { PermissionAskedEvent } from '@/lib/opencode/sdk-types'
+import { isTauri } from '@/lib/utils'
+
+export type ProductionGuardRisk = 'production_data'
+
+export interface ProductionGuardMatch {
+  commandIncludes?: string[]
+  paths?: string[]
+  commandRegex?: string[]
+  envIncludes?: Record<string, string>
+}
+
+export interface ProductionGuardRule {
+  id: string
+  label?: string
+  match?: ProductionGuardMatch
+  risk?: ProductionGuardRisk
+  approval?: {
+    mode?: 'always_ask'
+    allowAlways?: boolean
+  }
+}
+
+export interface ProductionGuardConfig {
+  version?: 1
+  enabled?: boolean
+  rules?: ProductionGuardRule[]
+}
+
+export type CommandRisk =
+  | { level: 'normal' }
+  | {
+      level: 'production_data'
+      reasons: string[]
+      matchedRules: string[]
+      allowAlways: false
+    }
+
+export function extractPermissionCommand(event: PermissionAskedEvent): string {
+  const metadata = event.metadata as Record<string, unknown> | undefined
+  const metadataCommand = metadata?.command
+  if (typeof metadataCommand === 'string' && metadataCommand.trim()) {
+    return metadataCommand.trim()
+  }
+
+  return (event.patterns || []).join(' ').trim()
+}
+
+function includesAny(command: string, values: string[] | undefined) {
+  if (!values || values.length === 0) return false
+  const normalized = command.toLowerCase()
+  return values.some((value) => normalized.includes(value.toLowerCase()))
+}
+
+function matchesRegex(command: string, values: string[] | undefined) {
+  if (!values || values.length === 0) return false
+  return values.some((value) => {
+    try {
+      return new RegExp(value, 'i').test(command)
+    } catch {
+      return false
+    }
+  })
+}
+
+function matchesEnv(command: string, envIncludes: Record<string, string> | undefined) {
+  if (!envIncludes || Object.keys(envIncludes).length === 0) return false
+  const normalized = command.toLowerCase()
+  return Object.entries(envIncludes).some(([key, value]) =>
+    normalized.includes(`${key.toLowerCase()}=${String(value).toLowerCase()}`),
+  )
+}
+
+function matchesRule(command: string, rule: ProductionGuardRule) {
+  const match = rule.match
+  if (!match) return false
+  return (
+    includesAny(command, match.commandIncludes) ||
+    includesAny(command, match.paths) ||
+    matchesRegex(command, match.commandRegex) ||
+    matchesEnv(command, match.envIncludes)
+  )
+}
+
+export function evaluateProductionGuard(
+  command: string,
+  config: ProductionGuardConfig | null | undefined,
+): CommandRisk {
+  if (!command.trim()) return { level: 'normal' }
+  if (!config || config.enabled === false) return { level: 'normal' }
+
+  const matchedRules = (config.rules || [])
+    .filter((rule) => (rule.risk || 'production_data') === 'production_data')
+    .filter((rule) => matchesRule(command, rule))
+
+  if (matchedRules.length === 0) return { level: 'normal' }
+
+  return {
+    level: 'production_data',
+    reasons: matchedRules.map((rule) => rule.label || rule.id),
+    matchedRules: matchedRules.map((rule) => rule.id),
+    allowAlways: false,
+  }
+}
+
+export async function readProductionGuardConfig(
+  workspacePath: string | null | undefined,
+): Promise<ProductionGuardConfig | null> {
+  if (!workspacePath || !isTauri()) return null
+
+  try {
+    const { readTextFile, exists } = await import('@tauri-apps/plugin-fs')
+    const configPath = `${workspacePath}/${TEAMCLAW_DIR}/production-guard.json`
+    if (!(await exists(configPath))) return null
+    return JSON.parse(await readTextFile(configPath)) as ProductionGuardConfig
+  } catch (error) {
+    console.error('[ProductionGuard] Failed to read production guard config:', error)
+    return null
+  }
+}
+
+export async function getProductionGuardRiskForPermission(
+  event: PermissionAskedEvent,
+  workspacePath: string | null | undefined,
+): Promise<CommandRisk> {
+  if (event.permission !== 'bash' && event.permission !== 'execute') return { level: 'normal' }
+  const config = await readProductionGuardConfig(workspacePath)
+  return evaluateProductionGuard(extractPermissionCommand(event), config)
+}

--- a/packages/app/src/stores/__tests__/session-permissions.test.ts
+++ b/packages/app/src/stores/__tests__/session-permissions.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+const permissionPolicyMock = vi.hoisted(() => ({
+  shouldAutoAuthorize: vi.fn(() => false),
+}))
+
+const productionGuardMock = vi.hoisted(() => ({
+  getProductionGuardRiskForPermission: vi.fn(async () => ({ level: 'normal' as const })),
+}))
+
 const mockReplyPermission = vi.fn().mockResolvedValue(undefined)
 const mockListPermissions = vi.fn().mockResolvedValue([])
 
@@ -31,7 +39,11 @@ vi.mock('@/lib/notification-service', () => ({
 }))
 
 vi.mock('@/lib/permission-policy', () => ({
-  shouldAutoAuthorize: () => false,
+  shouldAutoAuthorize: permissionPolicyMock.shouldAutoAuthorize,
+}))
+
+vi.mock('@/lib/dangerous-command-policy', () => ({
+  getProductionGuardRiskForPermission: productionGuardMock.getProductionGuardRiskForPermission,
 }))
 
 vi.mock('@/stores/workspace', () => ({
@@ -53,6 +65,8 @@ vi.mock('@/stores/session-internals', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
+  permissionPolicyMock.shouldAutoAuthorize.mockReturnValue(false)
+  productionGuardMock.getProductionGuardRiskForPermission.mockResolvedValue({ level: 'normal' })
 })
 
 describe('createPermissionActions', () => {
@@ -131,6 +145,54 @@ describe('createPermissionActions', () => {
 
     expect(store.pendingPermissions).toHaveLength(2)
     expect(store.pendingPermissions.map((e) => e.permission.id)).toEqual(['perm-1', 'perm-2'])
+  })
+
+  it('queues production-risk bash permissions even when auto-authorization is enabled', async () => {
+    permissionPolicyMock.shouldAutoAuthorize.mockReturnValue(true)
+    productionGuardMock.getProductionGuardRiskForPermission.mockResolvedValue({
+      level: 'production_data',
+      reasons: ['Sync production orders'],
+      matchedRules: ['sync-prod-orders'],
+      allowAlways: false,
+    })
+
+    const { createPermissionActions } = await import('@/stores/session-permissions')
+    const store = {
+      activeSessionId: 'session-1',
+      sessions: [{ id: 'session-1', title: 'S', messages: [] }],
+      pendingPermissions: [] as Array<{
+        permission: { id: string };
+        childSessionId: string | null;
+        productionRisk?: { level: string; matchedRules: string[] };
+      }>,
+      setActiveSession: vi.fn(),
+    }
+    const set = vi.fn((fn: unknown) => {
+      if (typeof fn === 'function') {
+        Object.assign(store, (fn as (s: typeof store) => Partial<typeof store>)(store))
+      } else {
+        Object.assign(store, fn)
+      }
+    })
+    const get = vi.fn(() => store)
+    const actions = createPermissionActions(set as any, get as any)
+
+    await actions.handlePermissionAsked({
+      id: 'perm-prod-1',
+      sessionID: 'session-1',
+      permission: 'bash',
+      patterns: ['pnpm sync-prod-orders'],
+    })
+
+    expect(mockReplyPermission).not.toHaveBeenCalled()
+    expect(store.pendingPermissions).toHaveLength(1)
+    expect(store.pendingPermissions[0]).toMatchObject({
+      permission: { id: 'perm-prod-1' },
+      productionRisk: {
+        level: 'production_data',
+        matchedRules: ['sync-prod-orders'],
+      },
+    })
   })
 
   it('queues child-session tool permissions even when the child session already exists locally', async () => {

--- a/packages/app/src/stores/session-permissions.ts
+++ b/packages/app/src/stores/session-permissions.ts
@@ -5,6 +5,10 @@ import { isTauri } from "@/lib/utils";
 import { buildConfig } from "@/lib/build-config";
 import { notificationService } from "@/lib/notification-service";
 import { shouldAutoAuthorize } from "@/lib/permission-policy";
+import {
+  getProductionGuardRiskForPermission,
+  type CommandRisk,
+} from "@/lib/dangerous-command-policy";
 import type { PermissionAskedEvent } from "@/lib/opencode/sdk-types";
 import { useWorkspaceStore } from "@/stores/workspace";
 import type {
@@ -19,6 +23,8 @@ import {
   pendingPermissionBuffer,
   attachPermissionToToolCall,
 } from "./session-internals";
+
+type ProductionDataRisk = Extract<CommandRisk, { level: "production_data" }>;
 
 /**
  * Cache of permission config from opencode.json.
@@ -189,8 +195,62 @@ export function createPermissionActions(set: SessionSet, get: SessionGet) {
     return { isChild, childSessionId: isChild ? sessionId : null };
   };
 
+  const queuePermissionEvent = (
+    event: PermissionAskedEvent,
+    productionRisk?: ProductionDataRisk,
+  ) => {
+    const {
+      sessions: currentSessions,
+      setActiveSession: navigateToSession,
+    } = get();
+
+    const { isChild, childSessionId } = classifyPermissionSession(event.sessionID);
+
+    if (event.tool?.callID && !isChild && !productionRisk) {
+      const attached = attachPermissionToToolCall(event);
+      if (!attached) {
+        pendingPermissionBuffer.set(event.tool.callID, event);
+      }
+    } else {
+      set((state) => ({
+        pendingPermissions: [
+          ...state.pendingPermissions.filter((e) => e.permission.id !== event.id),
+          { permission: event, childSessionId, productionRisk },
+        ].slice(-20),
+      }));
+    }
+
+    const session = currentSessions.find((s) => s.id === event.sessionID);
+    const sessionTitle = session?.title || "Session";
+    const permissionType = event.permission || "unknown";
+
+    notificationService.send(
+      "action_required",
+      `${buildConfig.app.name} - Authorization required`,
+      `${sessionTitle} \u2014 requesting ${permissionType} permission`,
+      event.sessionID,
+      async () => {
+        try {
+          await navigateToSession(event.sessionID);
+          const appWindow = getCurrentWindow();
+          await appWindow.setFocus();
+          await appWindow.unminimize();
+        } catch {
+          // Ignore focus errors
+        }
+      },
+    );
+  };
+
   return {
-    handlePermissionAsked: (event: PermissionAskedEvent) => {
+    handlePermissionAsked: async (event: PermissionAskedEvent) => {
+      const workspacePath = useWorkspaceStore.getState().workspacePath;
+      const productionRisk = await getProductionGuardRiskForPermission(event, workspacePath);
+      if (productionRisk.level === "production_data") {
+        queuePermissionEvent(event, productionRisk);
+        return;
+      }
+
       // Check permission policy -- auto-authorize if bypass or batch-done
       if (shouldAutoAuthorize()) {
         const client = getOpenCodeClient();
@@ -218,50 +278,7 @@ export function createPermissionActions(set: SessionSet, get: SessionGet) {
         return;
       }
 
-      const {
-        sessions: currentSessions,
-        setActiveSession: navigateToSession,
-      } = get();
-
-      const { isChild, childSessionId } = classifyPermissionSession(event.sessionID);
-
-      if (event.tool?.callID && !isChild) {
-        const attached = attachPermissionToToolCall(event);
-        if (!attached) {
-          pendingPermissionBuffer.set(event.tool.callID, event);
-        }
-      } else {
-        set((state) => ({
-          pendingPermissions: [
-            ...state.pendingPermissions.filter((e) => e.permission.id !== event.id),
-            { permission: event, childSessionId },
-          ].slice(-20), // Safety cap
-        }));
-      }
-
-      // Send notification for permission requests
-      {
-        const session = currentSessions.find((s) => s.id === event.sessionID);
-        const sessionTitle = session?.title || "Session";
-        const permissionType = event.permission || "unknown";
-
-        notificationService.send(
-          "action_required",
-          `${buildConfig.app.name} - Authorization required`,
-          `${sessionTitle} \u2014 requesting ${permissionType} permission`,
-          event.sessionID,
-          async () => {
-            try {
-              await navigateToSession(event.sessionID);
-              const appWindow = getCurrentWindow();
-              await appWindow.setFocus();
-              await appWindow.unminimize();
-            } catch {
-              // Ignore focus errors
-            }
-          },
-        );
-      }
+      queuePermissionEvent(event);
     },
 
     replyPermission: async (
@@ -388,40 +405,52 @@ export function createPermissionActions(set: SessionSet, get: SessionGet) {
         const permissions = await client.listPermissions();
         if (!permissions || permissions.length === 0) return;
 
-        if (shouldAutoAuthorize()) {
+        const autoAuthorize = shouldAutoAuthorize();
+        if (autoAuthorize) {
           console.log("[Session] Auto-authorizing polled permissions (policy: bypass/batch-done)");
-          for (const perm of permissions) {
+        }
+
+        const permissionsToQueue: Array<{
+          permission: PermissionAskedEvent;
+          productionRisk?: ProductionDataRisk;
+        }> = [];
+
+        for (const perm of permissions) {
+          const workspacePath = useWorkspaceStore.getState().workspacePath;
+          const productionRisk = await getProductionGuardRiskForPermission(perm, workspacePath);
+          if (productionRisk.level === "production_data") {
+            permissionsToQueue.push({ permission: perm, productionRisk });
+            continue;
+          }
+
+          if (autoAuthorize) {
             client.replyPermission(perm.id, { reply: "always" }).catch((err) => {
               console.error("[Session] Failed to auto-reply polled permission:", err);
             });
+            continue;
           }
-          return;
-        }
 
-        // Auto-authorize permissions that are set to "allow" in opencode.json or already "Always Allowed"
-        {
-          const remaining = permissions.filter((perm) => {
-            if (perm.permission && _permConfigCache?.[perm.permission] === "allow") {
-              client.replyPermission(perm.id, { reply: "once" }).catch((err) => {
-                console.error("[Session] Failed to auto-reply polled permission from config:", err);
-              });
-              return false;
-            }
-            if (perm.permission && _alwaysAllowedPermissions.has(perm.permission)) {
-              client.replyPermission(perm.id, { reply: "always" }).catch((err) => {
-                console.error("[Session] Failed to auto-reply polled always-allowed permission:", err);
-              });
-              return false;
-            }
-            return true;
-          });
-          if (remaining.length === 0) return;
-        }
+          if (perm.permission && _permConfigCache?.[perm.permission] === "allow") {
+            client.replyPermission(perm.id, { reply: "once" }).catch((err) => {
+              console.error("[Session] Failed to auto-reply polled permission from config:", err);
+            });
+            continue;
+          }
+          if (perm.permission && _alwaysAllowedPermissions.has(perm.permission)) {
+            client.replyPermission(perm.id, { reply: "always" }).catch((err) => {
+              console.error("[Session] Failed to auto-reply polled always-allowed permission:", err);
+            });
+            continue;
+          }
 
-        for (const permission of permissions) {
+          permissionsToQueue.push({ permission: perm });
+        }
+        if (permissionsToQueue.length === 0) return;
+
+        for (const { permission, productionRisk } of permissionsToQueue) {
           const { isChild, childSessionId } = classifyPermissionSession(permission.sessionID);
 
-          if (permission.tool?.callID && !isChild) {
+          if (permission.tool?.callID && !isChild && !productionRisk) {
             const session = getSessionById(activeSessionId);
             const alreadyAttached = session?.messages.some((m) =>
               m.toolCalls?.some((tc) => tc.permission?.id === permission.id),
@@ -441,7 +470,7 @@ export function createPermissionActions(set: SessionSet, get: SessionGet) {
             set((state) => ({
               pendingPermissions: [
                 ...state.pendingPermissions,
-                { permission, childSessionId },
+                { permission, childSessionId, productionRisk },
               ].slice(-20),
             }));
           }

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -28,6 +28,7 @@ import type {
   ToolExecutingEvent,
   QuestionAskedEvent,
 } from '@/lib/opencode/sdk-types';
+import type { CommandRisk } from '@/lib/dangerous-command-policy';
 
 // Re-export types for convenience
 export type { PermissionAskedEvent };
@@ -37,6 +38,7 @@ export interface PendingPermissionEntry {
   childSessionId: string | null;
   sourceToolName?: string | null;
   sourceToolCallId?: string | null;
+  productionRisk?: Extract<CommandRisk, { level: "production_data" }>;
 }
 
 export interface ToolCallPermission {


### PR DESCRIPTION
## Summary
- add a workspace-local production guard policy for bash permissions
- force production-risk commands through approval even when auto-authorization or allowlist rules would otherwise bypass prompts
- add a settings UI to view, test, add, and delete simplified command-include guard rules

## Tests
- pnpm --filter @teamclaw/app exec vitest run src/components/settings/__tests__/PermissionManagementSection.test.tsx src/lib/__tests__/dangerous-command-policy.test.ts src/stores/__tests__/session-permissions.test.ts src/components/chat/__tests__/PermissionCard.test.tsx
- pnpm --filter @teamclaw/app typecheck