### PR TITLE
Render Mermaid and highlighted code in Markdown preview

### DIFF
--- a/packages/app/src/components/FileEditor.tsx
+++ b/packages/app/src/components/FileEditor.tsx
@@ -53,6 +53,7 @@ const LazyTiptapMarkdownEditor = lazy(
 const LazyCodeEditor = lazy(() => import("@/components/editors/CodeEditor"));
 const LazyDiffRenderer = lazy(() => import("@/components/diff/DiffRenderer"));
 const LazyFileHistoryView = lazy(() => import("@/components/history/FileHistoryView"));
+const LazyMarkdownPreview = lazy(() => import("@/components/markdown/MarkdownPreview"));
 
 // Viewers - lazy loaded
 const LazyPDFViewer = lazy(
@@ -376,7 +377,10 @@ export function FileEditor({
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [showDiff, setShowDiff] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
-  const [showPreview, setShowPreview] = useState(supportsPreview(filename) === "html");
+  const [showPreview, setShowPreview] = useState(() => {
+    const preview = supportsPreview(filename);
+    return preview === "html" || getEditorType(filename, filePath, content) === "markdown";
+  });
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
   const [externalUpdateType, setExternalUpdateType] = useState<
     "updated" | "changed_externally" | null
@@ -747,8 +751,8 @@ export function FileEditor({
             </button>
           )}
 
-          {/* Code toggle - only for HTML files (switch between preview and code) */}
-          {previewType === "html" && (
+          {/* Preview / edit toggle for previewable text formats */}
+          {(previewType === "html" || previewType === "markdown") && (
             <button
               onClick={() => setShowPreview(!showPreview)}
               className={`p-1.5 rounded transition-colors ${
@@ -956,17 +960,25 @@ export function FileEditor({
                     </div>
                   }
                 >
-                  <LazyTiptapMarkdownEditor
-                    ref={tiptapEditorRef}
-                    content={currentContent}
-                    filename={filename}
-                    filePath={filePath}
-                    onChange={(value) => setCurrentContent(value)}
-                    isDark={isDark}
-                    targetLine={targetLine}
-                    targetHeading={targetHeading}
-                    readOnly={isViewerReadOnly}
-                  />
+                  {showPreview && previewType === "markdown" ? (
+                    <LazyMarkdownPreview
+                      content={currentContent}
+                      filePath={filePath}
+                      isDark={isDark}
+                    />
+                  ) : (
+                    <LazyTiptapMarkdownEditor
+                      ref={tiptapEditorRef}
+                      content={currentContent}
+                      filename={filename}
+                      filePath={filePath}
+                      onChange={(value) => setCurrentContent(value)}
+                      isDark={isDark}
+                      targetLine={targetLine}
+                      targetHeading={targetHeading}
+                      readOnly={isViewerReadOnly}
+                    />
+                  )}
                 </Suspense>
               );
             }

--- a/packages/app/src/components/__tests__/FileEditor-large-markdown.test.tsx
+++ b/packages/app/src/components/__tests__/FileEditor-large-markdown.test.tsx
@@ -1,6 +1,14 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { describe, expect, it, vi } from 'vitest'
+
+const mermaidInitializeMock = vi.fn()
+const mermaidRenderMock = vi.fn(async (id: string, code: string) => ({
+  svg: `<svg data-testid="mermaid-svg" data-diagram-id="${id}"><text>${code}</text></svg>`,
+}))
+const codeToHtmlMock = vi.fn((code: string) =>
+  `<pre data-testid="highlighted-code"><code><span style="color:#cf222e">${code}</span></code></pre>`,
+)
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -61,8 +69,29 @@ vi.mock('@/components/editors/ConflictBanner', () => ({
   ConflictBanner: () => null,
 }))
 
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
+  DialogContent: ({ children, className }: React.PropsWithChildren<{ className?: string }>) =>
+    React.createElement('div', { className, 'data-testid': 'dialog-content' }, children),
+  DialogTitle: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
+}))
+
 vi.mock('@/components/editors/TiptapMarkdownEditor', () => ({
   default: React.forwardRef(() => <div data-testid="tiptap-markdown-editor" />),
+}))
+
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: mermaidInitializeMock,
+    render: mermaidRenderMock,
+  },
+}))
+
+vi.mock('@/components/diff/shiki-renderer', () => ({
+  getHighlighter: vi.fn(async () => ({
+    codeToHtml: codeToHtmlMock,
+  })),
+  mapLanguage: (language: string) => (language === 'ts' ? 'typescript' : language),
 }))
 
 vi.mock('@/components/editors/CodeEditor', () => ({
@@ -97,7 +126,7 @@ describe('FileEditor large markdown routing', () => {
     expect(screen.queryByTestId('tiptap-markdown-editor')).toBeNull()
   })
 
-  it('keeps small markdown documents in the Tiptap editor', async () => {
+  it('opens small markdown documents in preview and can switch to the Tiptap editor', async () => {
     render(
       <FileEditor
         content="# Notes\n\nSmall file"
@@ -107,7 +136,62 @@ describe('FileEditor large markdown routing', () => {
       />,
     )
 
+    expect(await screen.findByTestId('markdown-preview')).toBeTruthy()
+    fireEvent.click(screen.getByTitle('Edit mode'))
     expect(await screen.findByTestId('tiptap-markdown-editor')).toBeTruthy()
     expect(screen.queryByTestId('code-editor')).toBeNull()
+  })
+
+  it('renders mermaid diagrams in the markdown file preview', async () => {
+    render(
+      <FileEditor
+        content={[
+          '### Runtime Matching',
+          '',
+          '```mermaid',
+          'sequenceDiagram',
+          '    participant Runtime as Upstream Runtime Job',
+          '    participant CondDB as Upstream Condition DB',
+          '    Runtime->>CondDB: Load enabled NodeCondition list',
+          '```',
+        ].join('\n')}
+        filename="README.md"
+        filePath="/workspace/README.md"
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(await screen.findByTestId('markdown-preview')).toBeTruthy()
+    expect(await screen.findByTestId('mermaid-block')).toBeTruthy()
+    expect(await screen.findByTestId('mermaid-svg')).toBeTruthy()
+    expect(screen.queryByTestId('tiptap-markdown-editor')).toBeNull()
+    expect(mermaidRenderMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^mermaid-/),
+      expect.stringContaining('sequenceDiagram'),
+    )
+  })
+
+  it('syntax highlights code blocks in the markdown file preview', async () => {
+    render(
+      <FileEditor
+        content={[
+          '# Example',
+          '',
+          '```ts',
+          'const answer: number = 42',
+          '```',
+        ].join('\n')}
+        filename="README.md"
+        filePath="/workspace/README.md"
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(await screen.findByTestId('markdown-preview')).toBeTruthy()
+    expect(await screen.findByTestId('highlighted-code')).toBeTruthy()
+    expect(codeToHtmlMock).toHaveBeenCalledWith(
+      'const answer: number = 42',
+      { lang: 'typescript', theme: 'github-light' },
+    )
   })
 })

--- a/packages/app/src/components/markdown/MarkdownPreview.tsx
+++ b/packages/app/src/components/markdown/MarkdownPreview.tsx
@@ -1,0 +1,217 @@
+import * as React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { cn } from "@/lib/utils";
+import { resolveMarkdownImages } from "@/components/editors/image-paste-handler";
+import { MermaidDiagram } from "./MermaidDiagram";
+
+interface MarkdownPreviewProps {
+  content: string;
+  filePath: string;
+  isDark?: boolean;
+  className?: string;
+}
+
+const remarkPlugins = [remarkGfm];
+
+function MarkdownCodeBlock({
+  language,
+  children,
+}: {
+  language: string;
+  children: React.ReactNode;
+}) {
+  const [highlightedHtml, setHighlightedHtml] = React.useState<string | null>(null);
+  const code = String(children).replace(/\n$/, "");
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    if (!language || language === "text") {
+      setHighlightedHtml(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    import("@/components/diff/shiki-renderer").then(
+      async ({ getHighlighter, mapLanguage }) => {
+        if (cancelled) return;
+
+        try {
+          const highlighter = await getHighlighter();
+          const isDarkTheme = document.documentElement.classList.contains("dark");
+          const theme = isDarkTheme ? "github-dark" : "github-light";
+          const lang = mapLanguage(language);
+          const html = highlighter.codeToHtml(code, { lang, theme });
+
+          if (!cancelled) {
+            setHighlightedHtml(html);
+          }
+        } catch {
+          if (!cancelled) {
+            setHighlightedHtml(null);
+          }
+        }
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, language]);
+
+  return (
+    <div className="not-prose my-2 w-full overflow-hidden rounded-lg bg-foreground/[0.02] [overflow-wrap:normal]">
+      <div className="flex items-center justify-between px-3 py-1.5">
+        <span className="text-xs font-mono text-muted-foreground">{language}</span>
+      </div>
+      {highlightedHtml ? (
+        <div
+          className="overflow-x-auto px-3 pb-3 text-sm [overflow-wrap:normal] [&_code]:!bg-transparent [&_code]:!p-0 [&_code]:[overflow-wrap:normal] [&_code]:whitespace-pre [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:[overflow-wrap:normal] [&_pre]:whitespace-pre"
+          dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+        />
+      ) : (
+        <pre className="overflow-x-auto whitespace-pre px-3 pb-3 [overflow-wrap:normal]">
+          <code className="font-mono text-sm text-foreground [overflow-wrap:normal]">
+            {code}
+          </code>
+        </pre>
+      )}
+    </div>
+  );
+}
+
+const markdownComponents = {
+  h1: ({ children }: { children?: React.ReactNode }) => (
+    <h1 className="mb-2 mt-4 text-xl font-semibold text-foreground">{children}</h1>
+  ),
+  h2: ({ children }: { children?: React.ReactNode }) => (
+    <h2 className="mb-2 mt-3 text-lg font-semibold text-foreground">{children}</h2>
+  ),
+  h3: ({ children }: { children?: React.ReactNode }) => (
+    <h3 className="mb-1.5 mt-3 text-base font-semibold text-foreground">{children}</h3>
+  ),
+  p: ({ children }: { children?: React.ReactNode }) => (
+    <p className="my-2 min-w-0 leading-relaxed text-foreground">{children}</p>
+  ),
+  table: ({ children }: { children?: React.ReactNode }) => (
+    <div className="my-3 overflow-x-auto rounded-lg border border-border">
+      <table className="min-w-full border-collapse text-sm">{children}</table>
+    </div>
+  ),
+  thead: ({ children }: { children?: React.ReactNode }) => (
+    <thead className="bg-muted">{children}</thead>
+  ),
+  th: ({ children }: { children?: React.ReactNode }) => (
+    <th className="border-b border-border px-4 py-2.5 text-left font-medium">{children}</th>
+  ),
+  tr: ({ children }: { children?: React.ReactNode }) => (
+    <tr className="border-b border-border last:border-b-0">{children}</tr>
+  ),
+  td: ({ children }: { children?: React.ReactNode }) => (
+    <td className="px-4 py-2.5">{children}</td>
+  ),
+  blockquote: ({ children }: { children?: React.ReactNode }) => (
+    <blockquote className="my-3 border-l-4 border-[#5a7a64] pl-4 italic text-muted-foreground">
+      {children}
+    </blockquote>
+  ),
+  pre: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  code: ({
+    className,
+    children,
+    ...codeProps
+  }: {
+    className?: string;
+    children?: React.ReactNode;
+  }) => {
+    const codeText = String(children);
+    const isInline = !className && !codeText.includes("\n");
+    if (isInline) {
+      return (
+        <code
+          className="rounded bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-[0.9em] leading-snug text-foreground break-words [overflow-wrap:anywhere]"
+          {...codeProps}
+        >
+          {children}
+        </code>
+      );
+    }
+
+    const language = className?.replace("language-", "") || "text";
+    if (language === "mermaid") {
+      return (
+        <MermaidDiagram
+          source={codeText}
+          fallback={<MarkdownCodeBlock language="mermaid">{codeText}</MarkdownCodeBlock>}
+        />
+      );
+    }
+
+    return <MarkdownCodeBlock language={language}>{codeText}</MarkdownCodeBlock>;
+  },
+  a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
+    <a href={href} target="_blank" rel="noopener noreferrer" className="text-[#5a7a64] hover:underline">
+      {children}
+    </a>
+  ),
+  ul: ({ children }: { children?: React.ReactNode }) => (
+    <ul className="my-2 list-disc space-y-1 pl-5">{children}</ul>
+  ),
+  ol: ({ children }: { children?: React.ReactNode }) => (
+    <ol className="my-2 list-decimal space-y-1 pl-5">{children}</ol>
+  ),
+  li: ({ children }: { children?: React.ReactNode }) => (
+    <li className="min-w-0 leading-relaxed">{children}</li>
+  ),
+} as const;
+
+export function MarkdownPreview({
+  content,
+  filePath,
+  isDark = false,
+  className,
+}: MarkdownPreviewProps) {
+  const [resolvedContent, setResolvedContent] = React.useState(content);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    async function resolveContent() {
+      const resolved = await resolveMarkdownImages(content, filePath);
+      if (!cancelled) {
+        setResolvedContent(resolved);
+      }
+    }
+
+    void resolveContent();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [content, filePath]);
+
+  return (
+    <div
+      data-testid="markdown-preview"
+      className={cn(
+        "h-full overflow-auto",
+        isDark ? "bg-[#1e1e1e]" : "bg-white",
+        className,
+      )}
+    >
+      <div className="prose prose-sm max-w-none p-4 text-foreground">
+        <ReactMarkdown
+          remarkPlugins={remarkPlugins}
+          components={markdownComponents}
+        >
+          {resolvedContent}
+        </ReactMarkdown>
+      </div>
+    </div>
+  );
+}
+
+export default MarkdownPreview;

--- a/packages/app/src/components/markdown/MermaidDiagram.tsx
+++ b/packages/app/src/components/markdown/MermaidDiagram.tsx
@@ -1,0 +1,129 @@
+import * as React from "react";
+import { Maximize2 } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+interface MermaidDiagramProps {
+  source: string;
+  className?: string;
+  fallback?: React.ReactNode;
+}
+
+export function MermaidDiagram({
+  source,
+  className,
+  fallback,
+}: MermaidDiagramProps) {
+  const [svg, setSvg] = React.useState<string | null>(null);
+  const [hasError, setHasError] = React.useState(false);
+  const [isPreviewOpen, setIsPreviewOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const diagramId = React.useId().replace(/:/g, "");
+  const diagramSource = React.useMemo(() => source.trim(), [source]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setSvg(null);
+    setHasError(false);
+
+    async function renderDiagram() {
+      try {
+        const { default: mermaid } = await import("mermaid");
+        mermaid.initialize({
+          startOnLoad: false,
+          securityLevel: "strict",
+          theme: document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "default",
+        });
+
+        const rendered = await mermaid.render(
+          `mermaid-${diagramId}`,
+          diagramSource,
+        );
+        if (cancelled) return;
+
+        setSvg(rendered.svg);
+
+        requestAnimationFrame(() => {
+          if (cancelled || !containerRef.current) return;
+          rendered.bindFunctions?.(containerRef.current);
+        });
+      } catch (error) {
+        if (cancelled) return;
+        console.warn("[MermaidDiagram] Render failed, falling back to code block", error);
+        setHasError(true);
+      }
+    }
+
+    void renderDiagram();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [diagramId, diagramSource]);
+
+  if (hasError) {
+    return fallback ?? (
+      <pre className="overflow-x-auto rounded-lg bg-muted p-3 text-sm">
+        <code>{diagramSource}</code>
+      </pre>
+    );
+  }
+
+  return (
+    <>
+      <div
+        data-testid="mermaid-block"
+        className={cn(
+          "relative my-2 overflow-x-auto rounded-lg border border-border bg-background px-3 py-3",
+          className,
+        )}
+      >
+        {svg ? (
+          <>
+            <button
+              type="button"
+              aria-label="放大流程图"
+              title="放大流程图"
+              onClick={() => setIsPreviewOpen(true)}
+              className="absolute right-1.5 top-1.5 z-10 inline-flex h-6 w-6 items-center justify-center rounded-md border border-border/80 bg-background/90 text-muted-foreground opacity-80 shadow-sm backdrop-blur transition hover:bg-accent hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            >
+              <Maximize2 className="h-3.5 w-3.5" />
+            </button>
+            <div
+              ref={containerRef}
+              className="[&_svg]:h-auto [&_svg]:max-w-full"
+              dangerouslySetInnerHTML={{ __html: svg }}
+            />
+          </>
+        ) : (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <div className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            <span>Rendering Mermaid diagram...</span>
+          </div>
+        )}
+      </div>
+      {isPreviewOpen && svg ? (
+        <Dialog open={isPreviewOpen} onOpenChange={setIsPreviewOpen}>
+          <DialogContent className="max-h-[82vh] w-[92vw] !max-w-[92vw] overflow-hidden p-0">
+            <DialogTitle className="sr-only">放大流程图</DialogTitle>
+            <div className="max-h-[82vh] overflow-auto bg-background p-4">
+              <div
+                className="w-max min-w-full [&_svg]:block [&_svg]:h-auto [&_svg]:min-w-[960px] [&_svg]:max-w-none"
+                dangerouslySetInnerHTML={{ __html: svg }}
+              />
+            </div>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+    </>
+  );
+}
+
+export default MermaidDiagram;


### PR DESCRIPTION
## Summary
- Add a Markdown preview path for opened markdown files with Mermaid diagram rendering.
- Add Shiki syntax highlighting for fenced code blocks in the preview.
- Keep large markdown files routed to CodeMirror and allow switching preview files back to edit mode.

## Test Plan
- pnpm --dir packages/app exec vitest run src/components/__tests__/FileEditor-large-markdown.test.tsx
- pnpm --dir packages/app exec tsc --noEmit