### PR TITLE
fix: archive sessions from secondary workspaces

### DIFF
--- a/packages/app/src/stores/__tests__/session-loader.test.ts
+++ b/packages/app/src/stores/__tests__/session-loader.test.ts
@@ -667,6 +667,24 @@ describe('session-loader: createLoaderActions', () => {
     expect(state.activeSessionId).toBeNull()
   })
 
+  it('archiveSession uses the current workspace when the session has no directory', async () => {
+    const now = Date.now()
+    state.currentWorkspacePath = '/workspace-secondary'
+    state.sessions = [{
+      id: 'sess-1',
+      title: 'Secondary window session',
+      messages: [],
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
+    }]
+    mockArchiveSession.mockResolvedValue(undefined)
+
+    await actions.archiveSession('sess-1')
+
+    expect(mockArchiveSession).toHaveBeenCalledWith('sess-1', '/workspace-secondary')
+    expect(state.sessions).toEqual([])
+  })
+
   it('archiveSession clears streaming state when archiving the active session', async () => {
     const now = Date.now()
     state.sessions = [

--- a/packages/app/src/stores/session-loader.ts
+++ b/packages/app/src/stores/session-loader.ts
@@ -692,7 +692,7 @@ export function createLoaderActions(set: SessionSet, get: SessionGet) {
       try {
         const client = getOpenCodeClient();
         const session = get().sessions.find((s) => s.id === id);
-        const directory = session?.directory;
+        const directory = session?.directory ?? get().currentWorkspacePath ?? undefined;
         const wasActiveSession = get().activeSessionId === id;
         await client.archiveSession(id, directory);
 


### PR DESCRIPTION
## Summary
- Fall back to the session store's current workspace when archiving a session without a directory field.
- Add regression coverage for archiving a secondary-window session list item that lacks directory metadata.

## Test Plan
- pnpm exec vitest run src/stores/__tests__/session-loader.test.ts
- pnpm exec tsc --noEmit