### PR TITLE
fix: keep opencode remote tools registered

### DIFF
--- a/apps/daemon/src/cli/mod.rs
+++ b/apps/daemon/src/cli/mod.rs
@@ -4,8 +4,8 @@ pub mod config_cmd;
 pub mod doctor;
 pub mod install_opencode;
 pub mod mcp_server;
-pub mod remote_tools_mcp;
 pub mod process;
+pub mod remote_tools_mcp;
 pub mod service;
 pub mod test_client;
 
@@ -133,12 +133,12 @@ pub struct McpServerArgs {
 
 #[derive(Args, Debug)]
 pub struct RemoteToolsMcpArgs {
-    #[arg(long)]
+    #[arg(long, default_value = "")]
     pub session_id: String,
-    #[arg(long)]
+    #[arg(long, default_value = "")]
     pub team_id: String,
     /// Member actor that owns the RPC topic (`amux/{team}/{id}/rpc/req`).
-    #[arg(long, alias = "client-actor-id")]
+    #[arg(long, alias = "client-actor-id", default_value = "")]
     pub member_actor_id: String,
     #[arg(long)]
     pub sock: Option<std::path::PathBuf>,

--- a/apps/daemon/src/cli/remote_tools_mcp.rs
+++ b/apps/daemon/src/cli/remote_tools_mcp.rs
@@ -1,27 +1,26 @@
 //! `amuxd remote-tools-mcp` — stdio MCP bridge for client-side remote tools.
 //!
-//! Spawned by ACP agents via per-session `--mcp-config`. Forwards tool calls to
-//! amuxd over `amuxd.sock` (`cmd: "remote-tool-call"`), which publishes an RPC to
-//! the member actor topic; capable online clients reply, others stay silent.
+//! Spawned by ACP agents via host-level MCP config. Forwards tool calls to
+//! amuxd over `amuxd.sock` (`cmd: "remote-tool-call"`). The daemon resolves
+//! the message-level remote_context_id to the member actor topic; capable
+//! online clients reply, others stay silent.
 
 use std::path::Path;
 use std::time::Duration;
 
 use serde_json::{json, Value};
 
-use crate::remote_tools::registry::{all_tool_names, tool_description, tool_input_schema, DEFAULT_TIMEOUT_MS};
+use crate::remote_tools::registry::{
+    all_tool_names, tool_description, tool_input_schema, DEFAULT_TIMEOUT_MS,
+};
 
-pub fn run(session_id: &str, team_id: &str, member_actor_id: &str, sock_path: &Path) -> anyhow::Result<()> {
+pub fn run(sock_path: &Path) -> anyhow::Result<()> {
     use std::io::{BufRead, BufReader, BufWriter, Write};
 
     eprintln!(
-        "[amuxd remote-tools-mcp] starting (session_id={}, team_id={}, member_actor_id={}, sock={})",
-        session_id,
-        team_id,
-        member_actor_id,
+        "[amuxd remote-tools-mcp] starting (host-level, sock={})",
         sock_path.display()
     );
-    let _ = team_id;
 
     let stdin = std::io::stdin();
     let reader = BufReader::new(stdin.lock());
@@ -72,7 +71,7 @@ pub fn run(session_id: &str, team_id: &str, member_actor_id: &str, sock_path: &P
                 "serverInfo": { "name": "amuxd-remote-tools", "version": "0.1.0" }
             })),
             "tools/list" => Ok(json!({ "tools": list_tools() })),
-            "tools/call" => match handle_tool_call(session_id, member_actor_id, sock_path, req.get("params")) {
+            "tools/call" => match handle_tool_call(sock_path, req.get("params")) {
                 Ok(v) => Ok(v),
                 Err(e) => Ok(tool_err(&e)),
             },
@@ -119,12 +118,7 @@ fn tool_err(text: &str) -> Value {
     })
 }
 
-fn handle_tool_call(
-    session_id: &str,
-    member_actor_id: &str,
-    sock_path: &Path,
-    params: Option<&Value>,
-) -> Result<Value, String> {
+fn handle_tool_call(sock_path: &Path, params: Option<&Value>) -> Result<Value, String> {
     let params = params.ok_or_else(|| "missing params".to_string())?;
     let name = params
         .get("name")
@@ -133,14 +127,27 @@ fn handle_tool_call(
     if !crate::remote_tools::registry::is_known_tool(name) {
         return Err(format!("unknown tool: {name}"));
     }
-    let args = params
+    if crate::remote_tools::registry::is_daemon_local_tool(name) {
+        return Ok(tool_ok("null"));
+    }
+    let mut args = params
         .get("arguments")
         .cloned()
         .unwrap_or_else(|| json!({}));
+    let args_obj = args
+        .as_object_mut()
+        .ok_or_else(|| "arguments must be a JSON object".to_string())?;
+    let remote_context_id = args_obj
+        .remove("remote_context_id")
+        .and_then(|v| v.as_str().map(str::to_string))
+        .ok_or_else(|| "missing remote_context_id".to_string())?;
+    if remote_context_id.trim().is_empty() {
+        return Err("missing remote_context_id".to_string());
+    }
 
     let payload = json!({
         "cmd": "remote-tool-call",
-        "session_id": session_id,
+        "remote_context_id": remote_context_id,
         "tool_name": name,
         "arguments": args,
     });
@@ -181,4 +188,31 @@ fn sock_roundtrip_error(err: std::io::Error) -> String {
         return "daemon response timeout: no capable client replied (is the TeamClaw browser extension side panel open and connected?)".to_string();
     }
     format!("amuxd.sock roundtrip failed: {err}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_tool_call_does_not_require_remote_context_id() {
+        let result = handle_tool_call(
+            Path::new("/tmp/nonexistent.sock"),
+            Some(&json!({
+                "name": "show_page_nav_links",
+                "arguments": { "links": ["https://example.com"] }
+            })),
+        )
+        .expect("local tool should return without socket roundtrip");
+
+        assert_eq!(
+            result
+                .get("content")
+                .and_then(|v| v.as_array())
+                .and_then(|items| items.first())
+                .and_then(|item| item.get("text"))
+                .and_then(|v| v.as_str()),
+            Some("null")
+        );
+    }
 }

--- a/apps/daemon/src/daemon/collab_runtime_ensure.rs
+++ b/apps/daemon/src/daemon/collab_runtime_ensure.rs
@@ -177,7 +177,7 @@ impl DaemonServer {
         if let Some(member) = bind_member_actor_id.filter(|s| !s.is_empty()) {
             if let Some(runtime_id) = &out.already_live_first {
                 let team_id = self.config.team_id.clone().unwrap_or_default();
-                self.bind_remote_tool_member(runtime_id, cloud_session_id, member, &team_id)
+                self.ensure_live_runtime_remote_tools(runtime_id, cloud_session_id, member, &team_id)
                     .await;
             }
         }
@@ -206,8 +206,7 @@ impl DaemonServer {
             (!requester_actor_id.is_empty()).then_some(requester_actor_id),
         );
 
-        let bind_member = (!requester_actor_id.is_empty() && !initial_prompt.trim().is_empty())
-            .then_some(requester_actor_id);
+        let bind_member = (!requester_actor_id.is_empty()).then_some(requester_actor_id);
 
         let result = self
             .resume_stored_collab_runtimes(
@@ -227,6 +226,16 @@ impl DaemonServer {
         let runtime_id = result
             .already_live_first
             .or_else(|| result.resumed_runtime_ids.into_iter().next())?;
+
+        if !requester_actor_id.is_empty() {
+            self.ensure_live_runtime_remote_tools(
+                &runtime_id,
+                cloud_session_id,
+                requester_actor_id,
+                &team_id,
+            )
+            .await;
+        }
 
         Some(StartRuntimeOutcome {
             runtime_id,

--- a/apps/daemon/src/daemon/collab_runtime_ensure.rs
+++ b/apps/daemon/src/daemon/collab_runtime_ensure.rs
@@ -177,8 +177,13 @@ impl DaemonServer {
         if let Some(member) = bind_member_actor_id.filter(|s| !s.is_empty()) {
             if let Some(runtime_id) = &out.already_live_first {
                 let team_id = self.config.team_id.clone().unwrap_or_default();
-                self.ensure_live_runtime_remote_tools(runtime_id, cloud_session_id, member, &team_id)
-                    .await;
+                self.ensure_live_runtime_remote_tools(
+                    runtime_id,
+                    cloud_session_id,
+                    member,
+                    &team_id,
+                )
+                .await;
             }
         }
 
@@ -200,12 +205,6 @@ impl DaemonServer {
         }
 
         let team_id = self.config.team_id.clone().unwrap_or_default();
-        let mcp_config_path = crate::remote_tools::resolve_remote_tools_mcp_config_for_resume(
-            cloud_session_id,
-            &team_id,
-            (!requester_actor_id.is_empty()).then_some(requester_actor_id),
-        );
-
         let bind_member = (!requester_actor_id.is_empty()).then_some(requester_actor_id);
 
         let result = self
@@ -218,7 +217,7 @@ impl DaemonServer {
                 initial_prompt,
                 initial_model_override,
                 "runtime_start",
-                mcp_config_path,
+                None,
                 bind_member,
             )
             .await;
@@ -249,12 +248,6 @@ impl DaemonServer {
         session_id: &str,
         requester_actor_id: Option<&str>,
     ) -> bool {
-        let team_id = self.config.team_id.clone().unwrap_or_default();
-        let mcp_config_path = crate::remote_tools::resolve_remote_tools_mcp_config_for_resume(
-            session_id,
-            &team_id,
-            requester_actor_id,
-        );
         let result = self
             .resume_stored_collab_runtimes(
                 session_id,
@@ -262,7 +255,7 @@ impl DaemonServer {
                 "",
                 None,
                 "session_live",
-                mcp_config_path,
+                None,
                 requester_actor_id,
             )
             .await;

--- a/apps/daemon/src/daemon/collab_runtime_ensure.rs
+++ b/apps/daemon/src/daemon/collab_runtime_ensure.rs
@@ -163,7 +163,7 @@ impl DaemonServer {
             .await;
             if let Some(member) = bind_member_actor_id.filter(|s| !s.is_empty()) {
                 let team_id = self.config.team_id.clone().unwrap_or_default();
-                self.bind_remote_tool_member(
+                self.ensure_live_runtime_remote_tools(
                     &stored.runtime_id,
                     cloud_session_id,
                     member,

--- a/apps/daemon/src/daemon/runtime_env.rs
+++ b/apps/daemon/src/daemon/runtime_env.rs
@@ -21,10 +21,7 @@ pub(crate) struct CachedManagedLlm {
 
 impl DaemonServer {
     /// Team ID is resolved from the cloud workspace row by UUID; on a cold resolver cache (e.g. right after daemon restart) a bare-agent spawn with an empty workspace_id yields None team_id until the cache warms — intentional under the cloud-source-of-truth / no-local-store design.
-    pub(super) async fn resolve_workspace_team_id(
-        &self,
-        workspace_id: &str,
-    ) -> Option<String> {
+    pub(super) async fn resolve_workspace_team_id(&self, workspace_id: &str) -> Option<String> {
         let fallback = || {
             self.config
                 .team_id
@@ -64,13 +61,13 @@ impl DaemonServer {
     /// empty-env prewarm.
     pub(super) async fn resolve_primary_prewarm_env(
         &self,
-    ) -> Option<(std::collections::HashMap<String, String>, bool)> {
+    ) -> Option<(String, std::collections::HashMap<String, String>, bool)> {
         let ws = self.cloud_workspace_list().await.into_iter().next()?;
         match self
             .assemble_spawn_runtime_env_for_worktree(&ws.path, &ws.workspace_id)
             .await
         {
-            Ok(env) => Some((env.extra_env, env.force_env_override)),
+            Ok(env) => Some((ws.path, env.extra_env, env.force_env_override)),
             Err(e) => {
                 tracing::warn!(
                     workspace = %ws.path,
@@ -99,10 +96,15 @@ impl DaemonServer {
             }
         };
         let agents = self.agents.clone();
+        let worktree_for_prewarm = worktree.to_string();
         tokio::spawn(async move {
             let mut mgr = agents.lock().await;
-            mgr.prewarm_acp_hosts_with_env(env.extra_env, env.force_env_override)
-                .await;
+            mgr.prewarm_acp_hosts_with_env(
+                env.extra_env,
+                env.force_env_override,
+                Some(worktree_for_prewarm.as_str()),
+            )
+            .await;
         });
     }
 
@@ -111,6 +113,8 @@ impl DaemonServer {
         worktree: &str,
         workspace_id: &str,
     ) -> Result<SpawnRuntimeEnv, String> {
+        crate::runtime::supervisor::ensure_inherent_mcp(Path::new(worktree))
+            .map_err(|e| format!("ensure_inherent_mcp failed: {e}"))?;
         let team_id = self.resolve_workspace_team_id(workspace_id).await;
         let managed_llm = match team_id.as_deref() {
             Some(tid) => self.resolve_managed_llm(tid).await,

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -47,9 +47,9 @@ mod channels;
 mod cron;
 mod messaging;
 mod peers_workspaces;
+mod remote_tools;
 mod rpc;
 mod runtime_lifecycle;
-mod remote_tools;
 use crate::history::EventHistory;
 use crate::mqtt::{publisher::Publisher, subscriber, MqttClient};
 use crate::proto::amux;
@@ -212,6 +212,7 @@ pub struct DaemonServer {
     /// re-attached via `set_local_tee`.
     live_tee: tokio::sync::broadcast::Sender<crate::teamclaw::live::LiveTeeEvent>,
     session_remote_targets: Arc<AsyncMutex<crate::remote_tools::SessionRemoteTargetStore>>,
+    remote_tool_turn_contexts: Arc<AsyncMutex<crate::remote_tools::RemoteToolTurnContextStore>>,
     rpc_client: Arc<AsyncMutex<crate::teamclaw::rpc::RpcClient>>,
 }
 
@@ -565,6 +566,9 @@ impl DaemonServer {
             session_remote_targets: Arc::new(AsyncMutex::new(
                 crate::remote_tools::SessionRemoteTargetStore::default(),
             )),
+            remote_tool_turn_contexts: Arc::new(AsyncMutex::new(
+                crate::remote_tools::RemoteToolTurnContextStore::default(),
+            )),
             rpc_client,
         })
     }
@@ -760,9 +764,13 @@ impl DaemonServer {
             tokio::spawn(async move {
                 let mut mgr = agents.lock().await;
                 match prewarm_env {
-                    Some((extra_env, force_env_override)) => {
-                        mgr.prewarm_acp_hosts_with_env(extra_env, force_env_override)
-                            .await;
+                    Some((worktree, extra_env, force_env_override)) => {
+                        mgr.prewarm_acp_hosts_with_env(
+                            extra_env,
+                            force_env_override,
+                            Some(worktree.as_str()),
+                        )
+                        .await;
                     }
                     None => mgr.prewarm_acp_hosts().await,
                 }
@@ -2701,6 +2709,9 @@ pub(crate) mod tests {
                 live_tee: tokio::sync::broadcast::channel(64).0,
                 session_remote_targets: Arc::new(AsyncMutex::new(
                     crate::remote_tools::SessionRemoteTargetStore::default(),
+                )),
+                remote_tool_turn_contexts: Arc::new(AsyncMutex::new(
+                    crate::remote_tools::RemoteToolTurnContextStore::default(),
                 )),
                 rpc_client: Arc::new(AsyncMutex::new(crate::teamclaw::rpc::RpcClient::new(
                     publisher_handle.clone(),

--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -252,6 +252,10 @@ impl DaemonServer {
             }
             self.publish_runtime_state_by_id(agent_id).await;
             if became_idle {
+                self.remote_tool_turn_contexts
+                    .lock()
+                    .await
+                    .clear_runtime(agent_id);
                 self.flush_pending_remote_tools_mcp_refresh(agent_id).await;
             }
 
@@ -491,6 +495,10 @@ impl DaemonServer {
         );
         for rid in &superseded {
             self.agents.lock().await.stop_agent(rid).await;
+            self.remote_tool_turn_contexts
+                .lock()
+                .await
+                .clear_runtime(rid);
             if let Some(s) = self.sessions.find_by_id_mut(rid) {
                 s.status = amux::AgentStatus::Stopped as i32;
             }
@@ -525,7 +533,8 @@ impl DaemonServer {
             if self
                 .resume_historical_runtimes_for_session(
                     session_id,
-                    (!message.sender_actor_id.is_empty()).then_some(message.sender_actor_id.as_str()),
+                    (!message.sender_actor_id.is_empty())
+                        .then_some(message.sender_actor_id.as_str()),
                 )
                 .await
             {
@@ -675,6 +684,12 @@ impl DaemonServer {
                         }
                     }
                 }
+                self.prepare_remote_tool_context_for_turn(
+                    &runtime_id,
+                    session_id,
+                    &message.sender_actor_id,
+                )
+                .await;
                 let send_res = self
                     .agents
                     .lock()

--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -237,6 +237,8 @@ impl DaemonServer {
 
         // Update agent status if this is a status change event
         if let Some(amux::acp_event::Event::StatusChange(ref sc)) = acp_event.event {
+            let became_idle = sc.old_status == amux::AgentStatus::Active as i32
+                && sc.new_status == amux::AgentStatus::Idle as i32;
             {
                 let mut agents = self.agents.lock().await;
                 if let Some(handle) = agents.get_handle_mut(agent_id) {
@@ -249,6 +251,9 @@ impl DaemonServer {
                 let _ = self.sessions.save(&self.sessions_path);
             }
             self.publish_runtime_state_by_id(agent_id).await;
+            if became_idle {
+                self.flush_pending_remote_tools_mcp_refresh(agent_id).await;
+            }
 
             // Upsert agent_runtimes on status transitions
             {

--- a/apps/daemon/src/daemon/server/remote_tools.rs
+++ b/apps/daemon/src/daemon/server/remote_tools.rs
@@ -8,13 +8,46 @@ use tokio::sync::oneshot;
 use super::DaemonServer;
 
 impl DaemonServer {
+    pub(crate) async fn prepare_remote_tool_context_for_turn(
+        &self,
+        runtime_id: &str,
+        teamclaw_session_id: &str,
+        requester_actor_id: &str,
+    ) {
+        let acp_session_id = {
+            let agents = self.agents.lock().await;
+            agents
+                .get_handle(runtime_id)
+                .map(|h| h.acp_session_id.clone())
+                .unwrap_or_default()
+        };
+        let remote_context_id = self.remote_tool_turn_contexts.lock().await.create(
+            runtime_id,
+            &acp_session_id,
+            teamclaw_session_id,
+            requester_actor_id,
+        );
+        match remote_context_id {
+            Some(id) => {
+                let instructions = crate::remote_tools::remote_context_instructions(&id);
+                if !instructions.is_empty() {
+                    let mut agents = self.agents.lock().await;
+                    if let Some(handle) = agents.get_handle_mut(runtime_id) {
+                        handle.next_prompt_context = instructions;
+                    }
+                }
+            }
+            None => {}
+        }
+    }
+
     pub(crate) async fn spawn_remote_tool_sock_handler(
         &self,
         payload: Value,
         reply_tx: oneshot::Sender<String>,
     ) {
-        let session_id = payload
-            .get("session_id")
+        let remote_context_id = payload
+            .get("remote_context_id")
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
@@ -27,29 +60,30 @@ impl DaemonServer {
             .get("arguments")
             .cloned()
             .unwrap_or_else(|| Value::Object(Default::default()));
-        let member_actor_id = {
-            let agents = self.agents.lock().await;
-            let targets = self.session_remote_targets.lock().await;
-            crate::remote_tools::resolve_member_for_session(&agents, &targets, &session_id)
+        let context = {
+            self.remote_tool_turn_contexts
+                .lock()
+                .await
+                .resolve(&remote_context_id)
         };
         let rpc_client = Arc::clone(&self.rpc_client);
         let actor_id = self.actor_id.clone();
         tokio::spawn(async move {
-            let resp = match member_actor_id {
-                Some(target) => {
+            let resp = match context {
+                Some(context) => {
                     crate::remote_tools::proxy::handle_sock_invoke_for_target(
                         &rpc_client,
                         &actor_id,
-                        &target,
-                        &session_id,
+                        &context.requester_actor_id,
+                        &context.teamclaw_session_id,
                         &tool_name,
                         &arguments,
                     )
                     .await
                 }
                 None => crate::remote_tools::proxy::sock_err(
-                    "no_remote_client",
-                    "no member actor registered for session (runtimeStart not seen recently)",
+                    "invalid_remote_context",
+                    "missing or expired remote_context_id for remote tool call",
                 ),
             };
             let _ = reply_tx.send(resp.to_string());

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -69,9 +69,10 @@ impl DaemonServer {
             Some(Method::RuntimeStop(s)) => self.handle_stop_runtime(&request, s).await,
             Some(Method::RuntimeStart(s)) => self.handle_start_runtime(&request, s).await,
             Some(Method::SetModel(s)) => self.handle_set_model(&request, s).await,
-            Some(Method::RemoteToolInvoke(_)) => {
-                not_yet_implemented(&request, "RemoteToolInvoke is handled by clients, not daemon")
-            }
+            Some(Method::RemoteToolInvoke(_)) => not_yet_implemented(
+                &request,
+                "RemoteToolInvoke is handled by clients, not daemon",
+            ),
             None => RpcResponse {
                 request_id: request.request_id.clone(),
                 success: false,
@@ -447,6 +448,10 @@ impl DaemonServer {
                     .await
                     .is_some();
                 if stopped {
+                    self.remote_tool_turn_contexts
+                        .lock()
+                        .await
+                        .clear_runtime(agent_id);
                     if let Some(session) = self.sessions.find_by_id_mut(agent_id) {
                         session.status = amux::AgentStatus::Stopped as i32;
                         let _ = self.sessions.save(&self.sessions_path);
@@ -486,16 +491,6 @@ impl DaemonServer {
                                 crate::runtime::SpawnRuntimeEnv::default()
                             }
                         };
-                        let mcp_config_path = if session_id.is_empty() {
-                            None
-                        } else {
-                            let team_id = self.config.team_id.clone().unwrap_or_default();
-                            crate::remote_tools::resolve_remote_tools_mcp_config_for_resume(
-                                &session_id,
-                                &team_id,
-                                (!sender_actor_id.is_empty()).then_some(sender_actor_id.as_str()),
-                            )
-                        };
                         let resume_res = self
                             .agents
                             .lock()
@@ -508,8 +503,8 @@ impl DaemonServer {
                                 &ws_id,
                                 remote_workspace_id.as_deref(),
                                 (!session_id.is_empty()).then_some(session_id.as_str()),
-                                &prompt.text,
-                                mcp_config_path,
+                                "",
+                                None,
                                 runtime_env,
                             )
                             .await;
@@ -537,6 +532,43 @@ impl DaemonServer {
                                             warn!(agent_id, model_id = %desired_model, "set_model after resume failed: {}", e);
                                         }
                                     }
+                                }
+                                self.prepare_remote_tool_context_for_turn(
+                                    agent_id,
+                                    &session_id,
+                                    &sender_actor_id,
+                                )
+                                .await;
+                                let send_res = self
+                                    .agents
+                                    .lock()
+                                    .await
+                                    .send_prompt(
+                                        agent_id,
+                                        &prompt.text,
+                                        prompt.attachment_urls.clone(),
+                                    )
+                                    .await;
+                                if let Err(e) = send_res {
+                                    warn!(agent_id, "lazy resume prompt send failed: {}", e);
+                                    self.publish_session_event(
+                                        agent_id,
+                                        amux::SessionEvent {
+                                            event: Some(
+                                                amux::session_event::Event::PromptRejected(
+                                                    amux::PromptRejected {
+                                                        command_id,
+                                                        reason: format!(
+                                                        "failed to send prompt after resume: {}",
+                                                        e
+                                                    ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    )
+                                    .await;
+                                    return;
                                 }
                                 // Update stored session with potentially new acp_session_id
                                 if let Some(s) = self.sessions.find_by_id_mut(agent_id) {
@@ -631,6 +663,15 @@ impl DaemonServer {
                 }
 
                 // Send prompt to agent (respawns if process exited)
+                let session_id = self
+                    .agents
+                    .lock()
+                    .await
+                    .get_handle(agent_id)
+                    .map(|h| h.session_id.clone())
+                    .unwrap_or_default();
+                self.prepare_remote_tool_context_for_turn(agent_id, &session_id, &sender_actor_id)
+                    .await;
                 let send_res = self
                     .agents
                     .lock()

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -5,8 +5,8 @@ use super::*;
 
 impl DaemonServer {
     /// Bind remote-tool routing to a live runtime and persist MCP config.
-    /// Called on new spawn (always) and on dedup/resume only when the user
-    /// actually @mentioned the agent (`initial_prompt` non-empty).
+    /// Called on new spawn and on dedup reuse (bind only — never detach/resume
+    /// mid-turn; see [`Self::ensure_live_runtime_remote_tools`]).
     pub(crate) async fn bind_remote_tool_member(
         &self,
         runtime_id: &str,
@@ -40,6 +40,253 @@ impl DaemonServer {
                 "bind_remote_tool_member: write_remote_tools_mcp_config failed (non-fatal)"
             );
         }
+    }
+
+    async fn mark_remote_tools_mcp_refresh_pending(&self, runtime_id: &str) {
+        let mut agents = self.agents.lock().await;
+        if let Some(h) = agents.get_handle_mut(runtime_id) {
+            h.remote_tools_mcp_refresh_pending = true;
+        }
+    }
+
+    /// Re-register remote-tools MCP via ACP resume. Skips gateway runtimes and
+    /// defers when the runtime is mid-turn (Active). Returns true on success.
+    async fn try_refresh_remote_tools_mcp_attach_for_runtime(
+        &self,
+        runtime_id: &str,
+        session_id: &str,
+        team_id: &str,
+        member_actor_id: Option<&str>,
+    ) -> bool {
+        if session_id.is_empty() {
+            return false;
+        }
+
+        let (is_gateway, is_active, worktree, workspace_id, member_from_handle) = {
+            let agents = self.agents.lock().await;
+            let Some(h) = agents.get_handle(runtime_id) else {
+                return false;
+            };
+            (
+                h.is_gateway,
+                h.status == amux::AgentStatus::Active,
+                h.worktree.clone(),
+                h.workspace_id.clone(),
+                h.remote_tool_member_id.clone(),
+            )
+        };
+
+        if is_gateway {
+            return false;
+        }
+        if is_active {
+            self.mark_remote_tools_mcp_refresh_pending(runtime_id).await;
+            return false;
+        }
+
+        let member = member_actor_id
+            .filter(|s| !s.is_empty())
+            .unwrap_or(member_from_handle.as_str());
+        if member.is_empty() {
+            return false;
+        }
+
+        let Some(mcp_config_path) = crate::remote_tools::resolve_remote_tools_mcp_config_for_resume(
+            session_id,
+            team_id,
+            Some(member),
+        ) else {
+            return false;
+        };
+
+        if worktree.is_empty() {
+            warn!(
+                runtime_id,
+                session_id,
+                "try_refresh_remote_tools_mcp_attach: missing worktree; skipping"
+            );
+            return false;
+        }
+
+        let runtime_env = match self
+            .assemble_spawn_runtime_env_for_worktree(&worktree, &workspace_id)
+            .await
+        {
+            Ok(env) => env,
+            Err(e) => {
+                warn!(
+                    runtime_id,
+                    session_id,
+                    err = %e,
+                    "try_refresh_remote_tools_mcp_attach: assemble runtime env failed"
+                );
+                return false;
+            }
+        };
+
+        if let Err(e) = self
+            .agents
+            .lock()
+            .await
+            .refresh_remote_tools_mcp_attach(runtime_id, mcp_config_path, runtime_env)
+            .await
+        {
+            warn!(
+                runtime_id,
+                session_id,
+                err = %e,
+                "try_refresh_remote_tools_mcp_attach: refresh_remote_tools_mcp_attach failed"
+            );
+            return false;
+        }
+
+        let mut agents = self.agents.lock().await;
+        if let Some(h) = agents.get_handle_mut(runtime_id) {
+            h.remote_tools_mcp_refresh_pending = false;
+        }
+        true
+    }
+
+    /// Flush a deferred MCP refresh after Active→Idle (never detach mid-turn).
+    pub(crate) async fn flush_pending_remote_tools_mcp_refresh(&self, runtime_id: &str) {
+        let snapshot = {
+            let agents = self.agents.lock().await;
+            let Some(h) = agents.get_handle(runtime_id) else {
+                return;
+            };
+            if !h.remote_tools_mcp_refresh_pending {
+                return;
+            }
+            if h.is_gateway || h.session_id.is_empty() {
+                return;
+            }
+            (
+                h.session_id.clone(),
+                h.remote_tool_member_id.clone(),
+            )
+        };
+        let (session_id, member_id) = snapshot;
+        let team_id = self.config.team_id.clone().unwrap_or_default();
+        self.try_refresh_remote_tools_mcp_attach_for_runtime(
+            runtime_id,
+            &session_id,
+            &team_id,
+            Some(&member_id),
+        )
+        .await;
+    }
+
+    /// After spawning a new runtime on a shared worktree, refresh idle peers'
+    /// remote-tools MCP or defer refresh for peers mid-turn.
+    async fn sync_peer_remote_tools_on_worktree(
+        &self,
+        worktree: &str,
+        workspace_id: &str,
+        exclude_runtime_id: &str,
+        team_id: &str,
+    ) {
+        let peers: Vec<(String, String, String, amux::AgentStatus)> = {
+            let agents = self.agents.lock().await;
+            agents
+                .active_handles_for_workspace(worktree, workspace_id)
+                .filter(|(id, h)| {
+                    id.as_str() != exclude_runtime_id
+                        && !h.is_gateway
+                        && !h.session_id.is_empty()
+                        && !h.remote_tool_member_id.is_empty()
+                })
+                .map(|(id, h)| {
+                    (
+                        id.clone(),
+                        h.session_id.clone(),
+                        h.remote_tool_member_id.clone(),
+                        h.status,
+                    )
+                })
+                .collect()
+        };
+
+        for (runtime_id, session_id, member_id, status) in peers {
+            if crate::remote_tools::resolve_remote_tools_mcp_config_for_resume(
+                &session_id,
+                team_id,
+                Some(&member_id),
+            )
+            .is_none()
+            {
+                continue;
+            }
+            match status {
+                amux::AgentStatus::Idle => {
+                    self.try_refresh_remote_tools_mcp_attach_for_runtime(
+                        &runtime_id,
+                        &session_id,
+                        team_id,
+                        Some(&member_id),
+                    )
+                    .await;
+                }
+                amux::AgentStatus::Active => {
+                    self.mark_remote_tools_mcp_refresh_pending(&runtime_id).await;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Keep remote-tools MCP registered on a live collab runtime. Desktop or
+    /// another session attaching to the shared OpenCode host can drop
+    /// per-session MCP; resume paths re-register via ACP resume when safe
+    /// (Idle). Never detach/resume while Active — defer to Idle instead.
+    pub(crate) async fn ensure_live_runtime_remote_tools(
+        &self,
+        runtime_id: &str,
+        session_id: &str,
+        requester_actor_id: &str,
+        team_id: &str,
+    ) {
+        if session_id.is_empty() || requester_actor_id.is_empty() {
+            return;
+        }
+
+        self.bind_remote_tool_member(
+            runtime_id,
+            session_id,
+            requester_actor_id,
+            team_id,
+        )
+        .await;
+
+        let is_gateway = self
+            .agents
+            .lock()
+            .await
+            .get_handle(runtime_id)
+            .map(|h| h.is_gateway)
+            .unwrap_or(false);
+        if is_gateway {
+            return;
+        }
+
+        let is_active = self
+            .agents
+            .lock()
+            .await
+            .get_handle(runtime_id)
+            .map(|h| h.status == amux::AgentStatus::Active)
+            .unwrap_or(false);
+        if is_active {
+            self.mark_remote_tools_mcp_refresh_pending(runtime_id).await;
+            return;
+        }
+
+        self.try_refresh_remote_tools_mcp_attach_for_runtime(
+            runtime_id,
+            session_id,
+            team_id,
+            Some(requester_actor_id),
+        )
+        .await;
     }
 
     /// Spawns a Claude Code subprocess and publishes lifecycle state
@@ -328,7 +575,7 @@ impl DaemonServer {
             // initial attach catchup (e.g. client dedup runtimeStart on send).
             // Replay from the cursor so @-mentioned rows still reach send_prompt.
             self.catchup_runtime(&existing).await;
-            if wants_remote_mcp && !initial_prompt.trim().is_empty() {
+            if wants_remote_mcp {
                 self.bind_remote_tool_member(
                     &existing,
                     session_id,
@@ -581,7 +828,7 @@ impl DaemonServer {
             session_id: session_id.to_string(),
             agent_type: agent_type as i32,
             workspace_id: ws_id.clone(),
-            worktree: resolved_worktree,
+            worktree: resolved_worktree.clone(),
             status: amux::AgentStatus::Active as i32,
             created_at: chrono::Utc::now().timestamp(),
             last_prompt: initial_prompt.to_string(),
@@ -614,6 +861,16 @@ impl DaemonServer {
         // insertion point — the handle is fully populated (session_id,
         // backend_runtime_row_id) and state is ACTIVE.
         self.catchup_runtime(&new_id).await;
+
+        if remote_mcp_ready {
+            self.sync_peer_remote_tools_on_worktree(
+                &resolved_worktree,
+                &ws_id,
+                &new_id,
+                &team_id,
+            )
+            .await;
+        }
 
         Ok(StartRuntimeOutcome {
             runtime_id: new_id,

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -4,9 +4,9 @@
 use super::*;
 
 impl DaemonServer {
-    /// Bind remote-tool routing to a live runtime and persist MCP config.
-    /// Called on new spawn and on dedup reuse (bind only — never detach/resume
-    /// mid-turn; see [`Self::ensure_live_runtime_remote_tools`]).
+    /// Bind remote-tool routing to a live runtime and persist the host-level MCP config.
+    /// Route selection is message-level via `remote_context_id`; this binding is
+    /// retained only for compatibility/diagnostics and must not trigger ACP resume.
     pub(crate) async fn bind_remote_tool_member(
         &self,
         runtime_id: &str,
@@ -28,11 +28,9 @@ impl DaemonServer {
             targets.prune_expired();
             targets.set(session_id, member_actor_id);
         }
-        if let Err(e) = crate::remote_tools::write_remote_tools_mcp_config(
-            session_id,
-            team_id,
-            member_actor_id,
-        ) {
+        if let Err(e) =
+            crate::remote_tools::write_remote_tools_mcp_config(session_id, team_id, member_actor_id)
+        {
             warn!(
                 session_id,
                 runtime_id,
@@ -42,202 +40,28 @@ impl DaemonServer {
         }
     }
 
-    async fn mark_remote_tools_mcp_refresh_pending(&self, runtime_id: &str) {
-        let mut agents = self.agents.lock().await;
-        if let Some(h) = agents.get_handle_mut(runtime_id) {
-            h.remote_tools_mcp_refresh_pending = true;
-        }
-    }
-
-    /// Re-register remote-tools MCP via ACP resume. Skips gateway runtimes and
-    /// defers when the runtime is mid-turn (Active). Returns true on success.
-    async fn try_refresh_remote_tools_mcp_attach_for_runtime(
-        &self,
-        runtime_id: &str,
-        session_id: &str,
-        team_id: &str,
-        member_actor_id: Option<&str>,
-    ) -> bool {
-        if session_id.is_empty() {
-            return false;
-        }
-
-        let (is_gateway, is_active, worktree, workspace_id, member_from_handle) = {
-            let agents = self.agents.lock().await;
-            let Some(h) = agents.get_handle(runtime_id) else {
-                return false;
-            };
-            (
-                h.is_gateway,
-                h.status == amux::AgentStatus::Active,
-                h.worktree.clone(),
-                h.workspace_id.clone(),
-                h.remote_tool_member_id.clone(),
-            )
-        };
-
-        if is_gateway {
-            return false;
-        }
-        if is_active {
-            self.mark_remote_tools_mcp_refresh_pending(runtime_id).await;
-            return false;
-        }
-
-        let member = member_actor_id
-            .filter(|s| !s.is_empty())
-            .unwrap_or(member_from_handle.as_str());
-        if member.is_empty() {
-            return false;
-        }
-
-        let Some(mcp_config_path) = crate::remote_tools::resolve_remote_tools_mcp_config_for_resume(
-            session_id,
-            team_id,
-            Some(member),
-        ) else {
-            return false;
-        };
-
-        if worktree.is_empty() {
-            warn!(
-                runtime_id,
-                session_id,
-                "try_refresh_remote_tools_mcp_attach: missing worktree; skipping"
-            );
-            return false;
-        }
-
-        let runtime_env = match self
-            .assemble_spawn_runtime_env_for_worktree(&worktree, &workspace_id)
-            .await
-        {
-            Ok(env) => env,
-            Err(e) => {
-                warn!(
-                    runtime_id,
-                    session_id,
-                    err = %e,
-                    "try_refresh_remote_tools_mcp_attach: assemble runtime env failed"
-                );
-                return false;
-            }
-        };
-
-        if let Err(e) = self
-            .agents
-            .lock()
-            .await
-            .refresh_remote_tools_mcp_attach(runtime_id, mcp_config_path, runtime_env)
-            .await
-        {
-            warn!(
-                runtime_id,
-                session_id,
-                err = %e,
-                "try_refresh_remote_tools_mcp_attach: refresh_remote_tools_mcp_attach failed"
-            );
-            return false;
-        }
-
+    /// Legacy no-op. Remote-tools MCP is now a host baseline; reattaching a
+    /// session can perturb OpenCode's shared MCP registry.
+    pub(crate) async fn flush_pending_remote_tools_mcp_refresh(&self, runtime_id: &str) {
         let mut agents = self.agents.lock().await;
         if let Some(h) = agents.get_handle_mut(runtime_id) {
             h.remote_tools_mcp_refresh_pending = false;
         }
-        true
     }
 
-    /// Flush a deferred MCP refresh after Active→Idle (never detach mid-turn).
-    pub(crate) async fn flush_pending_remote_tools_mcp_refresh(&self, runtime_id: &str) {
-        let snapshot = {
-            let agents = self.agents.lock().await;
-            let Some(h) = agents.get_handle(runtime_id) else {
-                return;
-            };
-            if !h.remote_tools_mcp_refresh_pending {
-                return;
-            }
-            if h.is_gateway || h.session_id.is_empty() {
-                return;
-            }
-            (
-                h.session_id.clone(),
-                h.remote_tool_member_id.clone(),
-            )
-        };
-        let (session_id, member_id) = snapshot;
-        let team_id = self.config.team_id.clone().unwrap_or_default();
-        self.try_refresh_remote_tools_mcp_attach_for_runtime(
-            runtime_id,
-            &session_id,
-            &team_id,
-            Some(&member_id),
-        )
-        .await;
-    }
-
-    /// After spawning a new runtime on a shared worktree, refresh idle peers'
-    /// remote-tools MCP or defer refresh for peers mid-turn.
+    /// Legacy no-op. Host-level MCP baseline removes the need to refresh peers
+    /// by ACP resume.
     async fn sync_peer_remote_tools_on_worktree(
         &self,
-        worktree: &str,
-        workspace_id: &str,
-        exclude_runtime_id: &str,
-        team_id: &str,
+        _worktree: &str,
+        _workspace_id: &str,
+        _exclude_runtime_id: &str,
+        _team_id: &str,
     ) {
-        let peers: Vec<(String, String, String, amux::AgentStatus)> = {
-            let agents = self.agents.lock().await;
-            agents
-                .active_handles_for_workspace(worktree, workspace_id)
-                .filter(|(id, h)| {
-                    id.as_str() != exclude_runtime_id
-                        && !h.is_gateway
-                        && !h.session_id.is_empty()
-                        && !h.remote_tool_member_id.is_empty()
-                })
-                .map(|(id, h)| {
-                    (
-                        id.clone(),
-                        h.session_id.clone(),
-                        h.remote_tool_member_id.clone(),
-                        h.status,
-                    )
-                })
-                .collect()
-        };
-
-        for (runtime_id, session_id, member_id, status) in peers {
-            if crate::remote_tools::resolve_remote_tools_mcp_config_for_resume(
-                &session_id,
-                team_id,
-                Some(&member_id),
-            )
-            .is_none()
-            {
-                continue;
-            }
-            match status {
-                amux::AgentStatus::Idle => {
-                    self.try_refresh_remote_tools_mcp_attach_for_runtime(
-                        &runtime_id,
-                        &session_id,
-                        team_id,
-                        Some(&member_id),
-                    )
-                    .await;
-                }
-                amux::AgentStatus::Active => {
-                    self.mark_remote_tools_mcp_refresh_pending(&runtime_id).await;
-                }
-                _ => {}
-            }
-        }
     }
 
-    /// Keep remote-tools MCP registered on a live collab runtime. Desktop or
-    /// another session attaching to the shared OpenCode host can drop
-    /// per-session MCP; resume paths re-register via ACP resume when safe
-    /// (Idle). Never detach/resume while Active — defer to Idle instead.
+    /// Keep remote-tools routing metadata on a live collab runtime. MCP itself
+    /// is a host baseline and is not refreshed via per-session ACP resume.
     pub(crate) async fn ensure_live_runtime_remote_tools(
         &self,
         runtime_id: &str,
@@ -249,44 +73,8 @@ impl DaemonServer {
             return;
         }
 
-        self.bind_remote_tool_member(
-            runtime_id,
-            session_id,
-            requester_actor_id,
-            team_id,
-        )
-        .await;
-
-        let is_gateway = self
-            .agents
-            .lock()
-            .await
-            .get_handle(runtime_id)
-            .map(|h| h.is_gateway)
-            .unwrap_or(false);
-        if is_gateway {
-            return;
-        }
-
-        let is_active = self
-            .agents
-            .lock()
-            .await
-            .get_handle(runtime_id)
-            .map(|h| h.status == amux::AgentStatus::Active)
-            .unwrap_or(false);
-        if is_active {
-            self.mark_remote_tools_mcp_refresh_pending(runtime_id).await;
-            return;
-        }
-
-        self.try_refresh_remote_tools_mcp_attach_for_runtime(
-            runtime_id,
-            session_id,
-            team_id,
-            Some(requester_actor_id),
-        )
-        .await;
+        self.bind_remote_tool_member(runtime_id, session_id, requester_actor_id, team_id)
+            .await;
     }
 
     /// Spawns a Claude Code subprocess and publishes lifecycle state
@@ -474,6 +262,10 @@ impl DaemonServer {
         if !superseded.is_empty() {
             for rid in &superseded {
                 self.agents.lock().await.stop_agent(rid).await;
+                self.remote_tool_turn_contexts
+                    .lock()
+                    .await
+                    .clear_runtime(rid);
                 if let Some(s) = self.sessions.find_by_id_mut(rid) {
                     s.status = amux::AgentStatus::Stopped as i32;
                 }
@@ -487,10 +279,27 @@ impl DaemonServer {
         }
 
         if let Some(existing) = existing_runtime {
+            let (existing_acp_session_id, existing_worktree, existing_remote_member) = {
+                let agents = self.agents.lock().await;
+                agents
+                    .get_handle(&existing)
+                    .map(|h| {
+                        (
+                            h.acp_session_id.clone(),
+                            h.worktree.clone(),
+                            h.remote_tool_member_id.clone(),
+                        )
+                    })
+                    .unwrap_or_default()
+            };
             info!(
                 session_id,
                 workspace_id = %ws_id,
                 runtime_id = %existing,
+                acp_session_id = %existing_acp_session_id,
+                handle_worktree = %existing_worktree,
+                remote_tool_member_id = %existing_remote_member,
+                wants_remote_mcp,
                 "apply_start_runtime: dedup hit; reusing existing runtime"
             );
             // TODO(perf-runtime-start-throttle): See the same id on the client
@@ -534,7 +343,22 @@ impl DaemonServer {
                     }
                 }
             }
+            if wants_remote_mcp {
+                self.ensure_live_runtime_remote_tools(
+                    &existing,
+                    session_id,
+                    requester_actor_id,
+                    &team_id,
+                )
+                .await;
+            }
             if !initial_prompt.trim().is_empty() {
+                self.prepare_remote_tool_context_for_turn(
+                    &existing,
+                    session_id,
+                    requester_actor_id,
+                )
+                .await;
                 if let Err(e) = self
                     .agents
                     .lock()
@@ -575,15 +399,6 @@ impl DaemonServer {
             // initial attach catchup (e.g. client dedup runtimeStart on send).
             // Replay from the cursor so @-mentioned rows still reach send_prompt.
             self.catchup_runtime(&existing).await;
-            if wants_remote_mcp {
-                self.ensure_live_runtime_remote_tools(
-                    &existing,
-                    session_id,
-                    requester_actor_id,
-                    &team_id,
-                )
-                .await;
-            }
             return Ok(StartRuntimeOutcome {
                 runtime_id: existing,
                 session_id: session_id.to_string(),
@@ -693,9 +508,7 @@ impl DaemonServer {
             );
         }
 
-        let workspace_team_id = self
-            .resolve_workspace_team_id(&ws_id)
-            .await;
+        let workspace_team_id = self.resolve_workspace_team_id(&ws_id).await;
 
         if let Some(ref team_id) = workspace_team_id {
             let gate = crate::team_link::team_share_gate(self.backend.as_ref(), team_id).await;
@@ -727,7 +540,9 @@ impl DaemonServer {
             ) {
                 Ok(_) => {
                     remote_mcp_ready = true;
-                    Some(crate::remote_tools::remote_tools_mcp_config_path(session_id))
+                    Some(crate::remote_tools::remote_tools_mcp_config_path(
+                        session_id,
+                    ))
                 }
                 Err(e) => {
                     warn!(
@@ -750,7 +565,7 @@ impl DaemonServer {
             .spawn_agent_with_model(
                 agent_type,
                 &resolved_worktree,
-                initial_prompt,
+                "",
                 &ws_id,
                 (!ws_id.is_empty()).then_some(ws_id.as_str()),
                 session_id_opt,
@@ -779,6 +594,25 @@ impl DaemonServer {
         if remote_mcp_ready {
             self.bind_remote_tool_member(&new_id, session_id, requester_actor_id, &team_id)
                 .await;
+        }
+
+        if !initial_prompt.trim().is_empty() {
+            self.prepare_remote_tool_context_for_turn(&new_id, session_id, requester_actor_id)
+                .await;
+            if let Err(e) = self
+                .agents
+                .lock()
+                .await
+                .send_prompt(&new_id, initial_prompt, vec![])
+                .await
+            {
+                warn!(
+                    runtime_id = %new_id,
+                    session_id,
+                    err = %e,
+                    "apply_start_runtime: initial_prompt send_prompt failed"
+                );
+            }
         }
 
         {
@@ -863,13 +697,8 @@ impl DaemonServer {
         self.catchup_runtime(&new_id).await;
 
         if remote_mcp_ready {
-            self.sync_peer_remote_tools_on_worktree(
-                &resolved_worktree,
-                &ws_id,
-                &new_id,
-                &team_id,
-            )
-            .await;
+            self.sync_peer_remote_tools_on_worktree(&resolved_worktree, &ws_id, &new_id, &team_id)
+                .await;
         }
 
         Ok(StartRuntimeOutcome {
@@ -909,6 +738,11 @@ impl DaemonServer {
                 &format!("stop failed for runtime_id: {}", runtime_id),
             );
         }
+
+        self.remote_tool_turn_contexts
+            .lock()
+            .await
+            .clear_runtime(&runtime_id);
 
         self.publish_runtime_stopped(&runtime_id).await;
 

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -576,7 +576,7 @@ impl DaemonServer {
             // Replay from the cursor so @-mentioned rows still reach send_prompt.
             self.catchup_runtime(&existing).await;
             if wants_remote_mcp {
-                self.bind_remote_tool_member(
+                self.ensure_live_runtime_remote_tools(
                     &existing,
                     session_id,
                     requester_actor_id,

--- a/apps/daemon/src/main.rs
+++ b/apps/daemon/src/main.rs
@@ -2,10 +2,10 @@ mod agent_discover;
 mod backend;
 mod channels;
 mod cli;
-mod device_id;
 mod collab;
 mod config;
 mod daemon;
+mod device_id;
 mod error;
 mod history;
 mod http;
@@ -17,8 +17,8 @@ mod opencode_install;
 mod opencode_settings;
 mod proto;
 mod provider_config;
-mod runtime;
 mod remote_tools;
+mod runtime;
 mod service;
 mod sync;
 mod team_link;
@@ -202,12 +202,8 @@ fn main() -> anyhow::Result<()> {
                 .sock
                 .clone()
                 .unwrap_or_else(config::DaemonConfig::sock_path);
-            cli::remote_tools_mcp::run(
-                &args.session_id,
-                &args.team_id,
-                &args.member_actor_id,
-                &sock,
-            )?;
+            let _ = (&args.session_id, &args.team_id, &args.member_actor_id);
+            cli::remote_tools_mcp::run(&sock)?;
         }
         Commands::TestClient { config, action } => {
             tracing_subscriber::fmt()

--- a/apps/daemon/src/remote_tools/mcp_config.rs
+++ b/apps/daemon/src/remote_tools/mcp_config.rs
@@ -1,32 +1,25 @@
 use std::path::PathBuf;
 
 use crate::config::DaemonConfig;
+use tracing::info;
 
-fn sanitize_for_filename(s: &str) -> String {
-    s.chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect()
-}
+pub const REMOTE_TOOLS_MCP_SERVER_NAME: &str = "amuxd-remote-tools";
 
 pub fn remote_tools_mcp_config_path(session_id: &str) -> PathBuf {
+    let _ = session_id;
     DaemonConfig::config_dir()
         .join("mcp-configs")
-        .join(format!("remote-{}.json", sanitize_for_filename(session_id)))
+        .join("remote-tools-host.json")
 }
 
-/// Write per-session MCP config for `amuxd remote-tools-mcp`.
-/// `member_actor_id` is the human member actor — RPC is published to
-/// `amux/{team}/{member_actor_id}/rpc/req` so all of that member's online clients receive it.
+/// Write host-level MCP config for `amuxd remote-tools-mcp`.
+/// Message-level routing is resolved by daemon using `remote_context_id`.
 pub fn write_remote_tools_mcp_config(
     session_id: &str,
     team_id: &str,
     member_actor_id: &str,
 ) -> crate::error::Result<PathBuf> {
-    if session_id.is_empty() || member_actor_id.is_empty() {
-        return Err(crate::error::AmuxError::Agent(
-            "write_remote_tools_mcp_config: session_id and member_actor_id required".into(),
-        ));
-    }
+    let _ = (session_id, team_id, member_actor_id);
 
     let path = remote_tools_mcp_config_path(session_id);
     if let Some(parent) = path.parent() {
@@ -41,15 +34,18 @@ pub fn write_remote_tools_mcp_config(
     let amuxd_bin = std::env::current_exe()
         .map_err(|e| crate::error::AmuxError::Agent(format!("current_exe(): {e}")))?;
     let sock = DaemonConfig::sock_path();
+    info!(
+        path = %path.display(),
+        amuxd_bin = %amuxd_bin.display(),
+        sock = %sock.display(),
+        "write_remote_tools_mcp_config: writing host-level MCP config"
+    );
     let cfg = serde_json::json!({
         "mcpServers": {
-            "amuxd-remote-tools": {
+            REMOTE_TOOLS_MCP_SERVER_NAME: {
                 "command": amuxd_bin.to_string_lossy(),
                 "args": [
                     "remote-tools-mcp",
-                    format!("--session-id={}", session_id),
-                    format!("--team-id={}", team_id),
-                    format!("--member-actor-id={}", member_actor_id),
                     format!("--sock={}", sock.to_string_lossy()),
                 ],
             }
@@ -67,27 +63,16 @@ pub fn write_remote_tools_mcp_config(
     Ok(path)
 }
 
-/// MCP config for `session/resume`: write when requester is known, else reuse on-disk file.
-pub fn resolve_remote_tools_mcp_config_for_resume(
-    session_id: &str,
-    team_id: &str,
-    requester_actor_id: Option<&str>,
-) -> Option<PathBuf> {
-    if session_id.is_empty() {
-        return None;
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_tools_config_path_is_host_level() {
+        assert_eq!(
+            remote_tools_mcp_config_path("session-a"),
+            remote_tools_mcp_config_path("session-b")
+        );
+        assert!(remote_tools_mcp_config_path("session-a").ends_with("remote-tools-host.json"));
     }
-    if let Some(member) = requester_actor_id.filter(|s| !s.is_empty()) {
-        match write_remote_tools_mcp_config(session_id, team_id, member) {
-            Ok(path) => return Some(path),
-            Err(e) => {
-                tracing::warn!(
-                    session_id,
-                    err = %e,
-                    "resolve_remote_tools_mcp_config_for_resume: write failed, trying existing file"
-                );
-            }
-        }
-    }
-    let path = remote_tools_mcp_config_path(session_id);
-    path.is_file().then_some(path)
 }

--- a/apps/daemon/src/remote_tools/mod.rs
+++ b/apps/daemon/src/remote_tools/mod.rs
@@ -2,10 +2,13 @@ pub mod mcp_config;
 pub mod proxy;
 pub mod registry;
 pub mod session_target;
+pub mod turn_context;
 
 pub use mcp_config::{
-    remote_tools_mcp_config_path, resolve_remote_tools_mcp_config_for_resume,
-    write_remote_tools_mcp_config,
+    remote_tools_mcp_config_path, write_remote_tools_mcp_config, REMOTE_TOOLS_MCP_SERVER_NAME,
 };
 pub use registry::{all_tool_names, is_known_tool, tool_input_schema, TOOL_GET_PAGE_DOM};
 pub use session_target::{resolve_member_for_session, SessionRemoteTargetStore};
+pub use turn_context::{
+    inject_remote_context, remote_context_instructions, RemoteToolTurnContextStore,
+};

--- a/apps/daemon/src/remote_tools/registry.rs
+++ b/apps/daemon/src/remote_tools/registry.rs
@@ -24,7 +24,12 @@ pub fn tool_input_schema(tool_name: &str) -> Option<Value> {
     match tool_name {
         TOOL_GET_PAGE_DOM => Some(json!({
             "type": "object",
+            "required": ["remote_context_id"],
             "properties": {
+                "remote_context_id": {
+                    "type": "string",
+                    "description": "Opaque TeamClaw remote tool context id for this reply."
+                },
                 "mode": {
                     "type": "string",
                     "enum": ["outline", "text"],
@@ -84,5 +89,19 @@ mod tests {
         assert!(is_known_tool(TOOL_GET_PAGE_DOM));
         assert!(is_known_tool(TOOL_SHOW_PAGE_NAV_LINKS));
         assert!(!is_known_tool("other"));
+    }
+
+    #[test]
+    fn get_page_dom_requires_remote_context_id() {
+        let schema = tool_input_schema(TOOL_GET_PAGE_DOM).expect("schema");
+        let required = schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .expect("required array");
+        assert!(required.iter().any(|v| v == "remote_context_id"));
+        assert!(schema
+            .pointer("/properties/remote_context_id")
+            .and_then(|v| v.get("type"))
+            .is_some_and(|v| v == "string"));
     }
 }

--- a/apps/daemon/src/remote_tools/turn_context.rs
+++ b/apps/daemon/src/remote_tools/turn_context.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use uuid::Uuid;
+
+const TURN_CONTEXT_TTL: Duration = Duration::from_secs(10 * 60);
+
+#[derive(Debug, Clone)]
+pub struct RemoteToolTurnContext {
+    pub runtime_id: String,
+    pub acp_session_id: String,
+    pub teamclaw_session_id: String,
+    pub requester_actor_id: String,
+    created_at: Instant,
+}
+
+#[derive(Default)]
+pub struct RemoteToolTurnContextStore {
+    by_id: HashMap<String, RemoteToolTurnContext>,
+    current_by_runtime: HashMap<String, String>,
+}
+
+impl RemoteToolTurnContextStore {
+    pub fn create(
+        &mut self,
+        runtime_id: &str,
+        acp_session_id: &str,
+        teamclaw_session_id: &str,
+        requester_actor_id: &str,
+    ) -> Option<String> {
+        if runtime_id.is_empty()
+            || acp_session_id.is_empty()
+            || teamclaw_session_id.is_empty()
+            || requester_actor_id.is_empty()
+        {
+            return None;
+        }
+
+        let id = format!("rtctx_{}", Uuid::new_v4().simple());
+        self.by_id.insert(
+            id.clone(),
+            RemoteToolTurnContext {
+                runtime_id: runtime_id.to_string(),
+                acp_session_id: acp_session_id.to_string(),
+                teamclaw_session_id: teamclaw_session_id.to_string(),
+                requester_actor_id: requester_actor_id.to_string(),
+                created_at: Instant::now(),
+            },
+        );
+        self.current_by_runtime
+            .insert(runtime_id.to_string(), id.clone());
+        Some(id)
+    }
+
+    pub fn resolve(&mut self, id: &str) -> Option<RemoteToolTurnContext> {
+        self.prune_expired();
+        self.by_id.get(id).cloned()
+    }
+
+    pub fn clear_runtime(&mut self, runtime_id: &str) {
+        if let Some(id) = self.current_by_runtime.remove(runtime_id) {
+            self.by_id.remove(&id);
+        }
+        self.by_id.retain(|_, ctx| ctx.runtime_id != runtime_id);
+    }
+
+    pub fn prune_expired(&mut self) {
+        let expired: Vec<String> = self
+            .by_id
+            .iter()
+            .filter_map(|(id, ctx)| {
+                (ctx.created_at.elapsed() > TURN_CONTEXT_TTL).then_some(id.clone())
+            })
+            .collect();
+        for id in expired {
+            self.by_id.remove(&id);
+            self.current_by_runtime.retain(|_, current| current != &id);
+        }
+    }
+}
+
+pub fn inject_remote_context(prompt: &str, remote_context_id: &str) -> String {
+    if remote_context_id.is_empty() {
+        return prompt.to_string();
+    }
+    format!(
+        "{}\n\n{prompt}",
+        remote_context_instructions(remote_context_id)
+    )
+}
+
+pub fn remote_context_instructions(remote_context_id: &str) -> String {
+    if remote_context_id.is_empty() {
+        return String::new();
+    }
+    format!(
+        "TeamClaw remote tool context for this reply:\n\
+         When calling any amuxd-remote-tools tool, include remote_context_id exactly as: {remote_context_id}\n\
+         Do not reuse it after this reply."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_resolve_and_clear_context() {
+        let mut store = RemoteToolTurnContextStore::default();
+        let id = store
+            .create("rt1", "acp1", "session1", "actor1")
+            .expect("context id");
+        let ctx = store.resolve(&id).expect("context");
+        assert_eq!(ctx.requester_actor_id, "actor1");
+        assert_eq!(ctx.teamclaw_session_id, "session1");
+
+        store.clear_runtime("rt1");
+        assert!(store.resolve(&id).is_none());
+    }
+
+    #[test]
+    fn new_context_does_not_invalidate_inflight_contexts() {
+        let mut store = RemoteToolTurnContextStore::default();
+        let first = store.create("rt1", "acp1", "session1", "actor1").unwrap();
+        let second = store.create("rt1", "acp1", "session1", "actor2").unwrap();
+
+        assert_eq!(store.resolve(&first).unwrap().requester_actor_id, "actor1");
+        assert_eq!(store.resolve(&second).unwrap().requester_actor_id, "actor2");
+    }
+
+    #[test]
+    fn injects_prompt_context() {
+        let body = inject_remote_context("hello", "rtctx_1");
+        assert!(body.contains("remote_context_id exactly as: rtctx_1"));
+        assert!(body.ends_with("hello"));
+    }
+
+    #[test]
+    fn builds_context_instructions_without_prompt() {
+        let body = remote_context_instructions("rtctx_1");
+        assert!(body.contains("remote_context_id exactly as: rtctx_1"));
+        assert!(!body.contains("hello"));
+    }
+}

--- a/apps/daemon/src/runtime/acp_host.rs
+++ b/apps/daemon/src/runtime/acp_host.rs
@@ -177,6 +177,7 @@ impl AcpHostPool {
         initial_prompt: String,
         event_tx: mpsc::Sender<AcpEventFrame>,
         is_gateway: bool,
+        forbid_new_session_fallback: bool,
     ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
         let host_cmd = self
             .ensure_host(agent_type, launch, extra_env, force_env_override)
@@ -194,6 +195,7 @@ impl AcpHostPool {
                 event_tx,
                 startup_tx,
                 is_gateway,
+                forbid_new_session_fallback,
             })
             .await
             .map_err(|_| crate::error::AmuxError::Agent("ACP host command channel closed".into()))?;

--- a/apps/daemon/src/runtime/acp_host.rs
+++ b/apps/daemon/src/runtime/acp_host.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use super::adapter::{self, AcpCommand, AcpStartupMetadata};
 use super::manager::AgentLaunchConfig;
@@ -23,6 +23,7 @@ const ATTACH_TIMEOUT: Duration = Duration::from_secs(120);
 struct HostKey {
     agent_type: amux::AgentType,
     env_fingerprint: u64,
+    worktree_fingerprint: u64,
 }
 
 fn env_fingerprint(extra_env: &HashMap<String, String>) -> u64 {
@@ -33,6 +34,25 @@ fn env_fingerprint(extra_env: &HashMap<String, String>) -> u64 {
         k.hash(&mut hasher);
         v.hash(&mut hasher);
     }
+    hasher.finish()
+}
+
+fn worktree_fingerprint(agent_type: amux::AgentType, worktree: Option<&str>) -> u64 {
+    if !matches!(
+        agent_type,
+        amux::AgentType::Opencode | amux::AgentType::Codex
+    ) {
+        return 0;
+    }
+    let Some(worktree) = worktree.filter(|s| !s.is_empty()) else {
+        return 0;
+    };
+    let worktree = std::fs::canonicalize(worktree)
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| worktree.to_string());
+    let mut hasher = DefaultHasher::new();
+    worktree.hash(&mut hasher);
     hasher.finish()
 }
 
@@ -78,7 +98,7 @@ impl AcpHostPool {
     pub async fn prewarm(&mut self, launch_configs: &HashMap<amux::AgentType, AgentLaunchConfig>) {
         for (&agent_type, launch) in launch_configs {
             if let Err(e) = self
-                .ensure_host(agent_type, launch, HashMap::new(), false)
+                .ensure_host(agent_type, launch, HashMap::new(), false, None)
                 .await
             {
                 warn!(?agent_type, error = %e, "ACP host prewarm failed");
@@ -99,10 +119,17 @@ impl AcpHostPool {
         launch_configs: &HashMap<amux::AgentType, AgentLaunchConfig>,
         extra_env: HashMap<String, String>,
         force_env_override: bool,
+        worktree: Option<&str>,
     ) {
         for (&agent_type, launch) in launch_configs {
             if let Err(e) = self
-                .ensure_host(agent_type, launch, extra_env.clone(), force_env_override)
+                .ensure_host(
+                    agent_type,
+                    launch,
+                    extra_env.clone(),
+                    force_env_override,
+                    worktree,
+                )
                 .await
             {
                 warn!(?agent_type, error = %e, "ACP host prewarm (session env) failed");
@@ -118,14 +145,31 @@ impl AcpHostPool {
         launch: &AgentLaunchConfig,
         extra_env: HashMap<String, String>,
         force_env_override: bool,
+        worktree: Option<&str>,
     ) -> crate::error::Result<mpsc::Sender<AcpCommand>> {
         let key = HostKey {
             agent_type,
             env_fingerprint: env_fingerprint(&extra_env),
+            worktree_fingerprint: worktree_fingerprint(agent_type, worktree),
         };
         if let Some(entry) = self.hosts.get(&key) {
+            debug!(
+                ?agent_type,
+                worktree = worktree.unwrap_or(""),
+                env_fingerprint = key.env_fingerprint,
+                worktree_fingerprint = key.worktree_fingerprint,
+                "ACP host pool hit; reusing initialized host"
+            );
             return Ok(entry.cmd_tx.clone());
         }
+
+        info!(
+            ?agent_type,
+            worktree = worktree.unwrap_or(""),
+            env_fingerprint = key.env_fingerprint,
+            worktree_fingerprint = key.worktree_fingerprint,
+            "ACP host pool miss; spawning initialized host"
+        );
 
         let (host_ready_tx, host_ready_rx) = oneshot::channel();
         let cmd_tx = adapter::spawn_acp_host(
@@ -134,6 +178,7 @@ impl AcpHostPool {
             agent_type,
             extra_env,
             force_env_override,
+            worktree.map(str::to_string),
             host_ready_tx,
         )?;
 
@@ -156,9 +201,19 @@ impl AcpHostPool {
             }
         }
 
-        self.hosts.insert(key, HostEntry {
-            cmd_tx: cmd_tx.clone(),
-        });
+        self.hosts.insert(
+            key,
+            HostEntry {
+                cmd_tx: cmd_tx.clone(),
+            },
+        );
+        info!(
+            ?agent_type,
+            worktree = worktree.unwrap_or(""),
+            env_fingerprint = key.env_fingerprint,
+            worktree_fingerprint = key.worktree_fingerprint,
+            "ACP host cached"
+        );
         Ok(cmd_tx)
     }
 
@@ -180,10 +235,15 @@ impl AcpHostPool {
         forbid_new_session_fallback: bool,
     ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
         let host_cmd = self
-            .ensure_host(agent_type, launch, extra_env, force_env_override)
+            .ensure_host(
+                agent_type,
+                launch,
+                extra_env,
+                force_env_override,
+                Some(&worktree),
+            )
             .await?;
-        let (startup_tx, startup_rx) =
-            oneshot::channel::<Result<AcpStartupMetadata, String>>();
+        let (startup_tx, startup_rx) = oneshot::channel::<Result<AcpStartupMetadata, String>>();
 
         host_cmd
             .send(AcpCommand::AttachSession {
@@ -198,7 +258,9 @@ impl AcpHostPool {
                 forbid_new_session_fallback,
             })
             .await
-            .map_err(|_| crate::error::AmuxError::Agent("ACP host command channel closed".into()))?;
+            .map_err(|_| {
+                crate::error::AmuxError::Agent("ACP host command channel closed".into())
+            })?;
 
         let startup = match timeout(ATTACH_TIMEOUT, startup_rx).await {
             Ok(Ok(Ok(meta))) => meta,
@@ -240,6 +302,7 @@ mod tests {
             HostKey {
                 agent_type: amux::AgentType::Opencode,
                 env_fingerprint: 1,
+                worktree_fingerprint: 11,
             },
             HostEntry {
                 cmd_tx: mpsc::channel(1).0,
@@ -249,6 +312,7 @@ mod tests {
             HostKey {
                 agent_type: amux::AgentType::ClaudeCode,
                 env_fingerprint: 2,
+                worktree_fingerprint: 0,
             },
             HostEntry {
                 cmd_tx: mpsc::channel(1).0,
@@ -260,6 +324,18 @@ mod tests {
         assert_eq!(
             pool.hosts.keys().next().unwrap().agent_type,
             amux::AgentType::ClaudeCode
+        );
+    }
+
+    #[test]
+    fn worktree_fingerprint_is_only_used_for_shared_registry_hosts() {
+        assert_ne!(
+            worktree_fingerprint(amux::AgentType::Opencode, Some("/tmp/a")),
+            worktree_fingerprint(amux::AgentType::Opencode, Some("/tmp/b"))
+        );
+        assert_eq!(
+            worktree_fingerprint(amux::AgentType::ClaudeCode, Some("/tmp/a")),
+            worktree_fingerprint(amux::AgentType::ClaudeCode, Some("/tmp/b"))
         );
     }
 }

--- a/apps/daemon/src/runtime/adapter.rs
+++ b/apps/daemon/src/runtime/adapter.rs
@@ -15,6 +15,8 @@ use tracing::{debug, error, info, warn};
 use crate::proto::amux;
 use crate::runtime::acp_event_frame::AcpEventFrame;
 
+const REMOTE_TOOLS_MCP_SERVER_NAME: &str = "amuxd-remote-tools";
+
 mod translate;
 use translate::*;
 
@@ -136,13 +138,11 @@ impl SessionRegistry {
     }
 
     fn resolve_event_route(&self, session_id: &str) -> Option<&SessionRoute> {
-        self.sessions
-            .get(session_id)
-            .or_else(|| {
-                self.child_to_root
-                    .get(session_id)
-                    .and_then(|root| self.sessions.get(root))
-            })
+        self.sessions.get(session_id).or_else(|| {
+            self.child_to_root
+                .get(session_id)
+                .and_then(|root| self.sessions.get(root))
+        })
     }
 
     fn resolve_event_route_mut(&mut self, session_id: &str) -> Option<&mut SessionRoute> {
@@ -280,7 +280,10 @@ impl Drop for NotifInflightGuard {
 /// distinguishes "a handler just completed" from "nothing started yet", so a
 /// turn that is still flushing keeps extending the window while a genuinely
 /// empty turn falls through after one quiet window.
-async fn await_notifications_drained(registry: &Rc<RefCell<SessionRegistry>>, acp_session_id: &str) {
+async fn await_notifications_drained(
+    registry: &Rc<RefCell<SessionRegistry>>,
+    acp_session_id: &str,
+) {
     // Minimum span of no-completions + zero-inflight we require before
     // declaring the pipeline drained. Comfortably longer than the few
     // scheduler ticks it takes the executor to drain `incoming_rx` and run
@@ -396,14 +399,14 @@ impl acp::Client for AmuxClient {
                 let Some(route) = guard.resolve_event_route_mut(&session_id) else {
                     warn!(session_id, "permission request for unknown session");
                     return Ok(acp::RequestPermissionResponse::new(
-                        acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(
-                            acp::PermissionOptionId::new("deny"),
-                        )),
+                        acp::RequestPermissionOutcome::Selected(
+                            acp::SelectedPermissionOutcome::new(acp::PermissionOptionId::new(
+                                "deny",
+                            )),
+                        ),
                     ));
                 };
-                route
-                    .pending_permissions
-                    .insert(request_id.clone(), tx);
+                route.pending_permissions.insert(request_id.clone(), tx);
                 route.event_tx.clone()
             };
 
@@ -427,15 +430,11 @@ impl acp::Client for AmuxClient {
                 .await;
         }
 
-        let resolution = rx
-            .await
-            .unwrap_or(PermissionResolution::Denied);
+        let resolution = rx.await.unwrap_or(PermissionResolution::Denied);
         let option_id = acp_option_for_resolution(&args.options, &resolution);
 
         Ok(acp::RequestPermissionResponse::new(
-            acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(
-                option_id,
-            )),
+            acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(option_id)),
         ))
     }
 
@@ -539,7 +538,11 @@ impl acp::Client for AmuxClient {
                     .await;
             }
         } else {
-            debug!(session_id, event_count = events.len(), "dropped ACP events for detached session");
+            debug!(
+                session_id,
+                event_count = events.len(),
+                "dropped ACP events for detached session"
+            );
         }
         Ok(())
     }
@@ -597,6 +600,135 @@ fn parse_mcp_config_to_acp(path: &std::path::Path) -> anyhow::Result<Option<Vec<
     }
 }
 
+fn mcp_server_name(server: &acp::McpServer) -> &str {
+    match server {
+        acp::McpServer::Http(s) => &s.name,
+        acp::McpServer::Sse(s) => &s.name,
+        acp::McpServer::Stdio(s) => &s.name,
+        _ => "",
+    }
+}
+
+fn mcp_server_names(servers: &[acp::McpServer]) -> Vec<String> {
+    servers
+        .iter()
+        .map(|server| mcp_server_name(server).to_string())
+        .collect()
+}
+
+fn should_attach_remote_tools_baseline(agent_type: amux::AgentType) -> bool {
+    matches!(agent_type, amux::AgentType::Codex)
+}
+
+fn strip_remote_tools_mcp_for_opencode(
+    agent_type: amux::AgentType,
+    servers: &mut Vec<acp::McpServer>,
+) {
+    if agent_type != amux::AgentType::Opencode {
+        return;
+    }
+    let before = servers.len();
+    servers.retain(|server| mcp_server_name(server) != REMOTE_TOOLS_MCP_SERVER_NAME);
+    if servers.len() != before {
+        info!(
+            ?agent_type,
+            server_names = ?mcp_server_names(servers),
+            "remote-tools MCP stripped from ACP attach; OpenCode uses workspace config"
+        );
+    }
+}
+
+fn remote_tools_baseline_mcp_server() -> Option<acp::McpServer> {
+    let amuxd_bin = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(e) => {
+            warn!(error = %e, "remote-tools MCP baseline skipped: current_exe failed");
+            return None;
+        }
+    };
+    let sock = crate::config::DaemonConfig::sock_path();
+    debug!(
+        amuxd_bin = %amuxd_bin.display(),
+        sock = %sock.display(),
+        "remote-tools MCP baseline server built"
+    );
+    Some(acp::McpServer::Stdio(
+        acp::McpServerStdio::new(REMOTE_TOOLS_MCP_SERVER_NAME, amuxd_bin).args(vec![
+            "remote-tools-mcp".to_string(),
+            format!("--sock={}", sock.to_string_lossy()),
+        ]),
+    ))
+}
+
+fn ensure_remote_tools_baseline_mcp(
+    agent_type: amux::AgentType,
+    servers: &mut Vec<acp::McpServer>,
+) {
+    if !should_attach_remote_tools_baseline(agent_type) {
+        return;
+    }
+    if servers
+        .iter()
+        .any(|server| mcp_server_name(server) == REMOTE_TOOLS_MCP_SERVER_NAME)
+    {
+        debug!(
+            ?agent_type,
+            server_names = ?mcp_server_names(servers),
+            "remote-tools MCP baseline already present"
+        );
+        return;
+    }
+    if let Some(server) = remote_tools_baseline_mcp_server() {
+        servers.push(server);
+        info!(
+            ?agent_type,
+            server_names = ?mcp_server_names(servers),
+            "remote-tools MCP baseline inserted"
+        );
+    }
+}
+
+fn opencode_remote_tools_config_summary(worktree: &str) -> String {
+    let path = Path::new(worktree).join("opencode.json");
+    if !path.exists() {
+        return format!("{} missing", path.display());
+    }
+    let body = match std::fs::read_to_string(&path) {
+        Ok(body) => body,
+        Err(e) => return format!("{} read_error={e}", path.display()),
+    };
+    let root: serde_json::Value = match serde_json::from_str(&body) {
+        Ok(root) => root,
+        Err(e) => return format!("{} parse_error={e}", path.display()),
+    };
+    let Some(remote_tools) = root
+        .get("mcp")
+        .and_then(|mcp| mcp.get(REMOTE_TOOLS_MCP_SERVER_NAME))
+    else {
+        return format!(
+            "{} mcp.{} missing",
+            path.display(),
+            REMOTE_TOOLS_MCP_SERVER_NAME
+        );
+    };
+    let enabled = remote_tools
+        .get("enabled")
+        .and_then(|v| v.as_bool())
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "unset".to_string());
+    let command = remote_tools
+        .get("command")
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "missing".to_string());
+    format!(
+        "{} mcp.{} present enabled={} command={}",
+        path.display(),
+        REMOTE_TOOLS_MCP_SERVER_NAME,
+        enabled,
+        command
+    )
+}
+
 fn should_use_claude_agent_acp_wrapper(binary: &str) -> bool {
     let binary_name = Path::new(binary)
         .file_name()
@@ -609,11 +741,7 @@ fn should_use_claude_agent_acp_wrapper(binary: &str) -> bool {
 /// `npx` is `npx.cmd` on Windows; CreateProcess does not apply PATHEXT to a
 /// bare name the way a shell would, so the spawn must name the .cmd file.
 pub(crate) fn npx_program() -> &'static str {
-    if cfg!(windows) {
-        "npx.cmd"
-    } else {
-        "npx"
-    }
+    if cfg!(windows) { "npx.cmd" } else { "npx" }
 }
 
 #[cfg(windows)]
@@ -731,7 +859,7 @@ mod command_selection_tests {
 
 #[cfg(test)]
 mod spawn_path_tests {
-    use super::{enriched_spawn_path, PATH_SEP};
+    use super::{PATH_SEP, enriched_spawn_path};
     use std::path::Path;
 
     // Unix-specific: asserts the homebrew / ~/.local candidate dirs and the
@@ -853,6 +981,7 @@ pub fn spawn_acp_host(
     agent_type: amux::AgentType,
     extra_env: HashMap<String, String>,
     force_env_override: bool,
+    host_worktree: Option<String>,
     host_ready_tx: oneshot::Sender<Result<(), String>>,
 ) -> crate::error::Result<mpsc::Sender<AcpCommand>> {
     let (cmd_tx, cmd_rx) = mpsc::channel::<AcpCommand>(64);
@@ -873,6 +1002,7 @@ pub fn spawn_acp_host(
                     agent_type,
                     extra_env,
                     force_env_override,
+                    host_worktree,
                     cmd_rx,
                     host_ready_tx,
                 )
@@ -904,17 +1034,53 @@ async fn attach_acp_session_on_conn(
     forbid_new_session_fallback: bool,
 ) -> anyhow::Result<AcpStartupMetadata> {
     let worktree_path = std::path::PathBuf::from(worktree);
-    let acp_mcp_servers: Vec<acp::McpServer> = match mcp_config_path.as_ref() {
+    let mut acp_mcp_servers: Vec<acp::McpServer> = match mcp_config_path.as_ref() {
         Some(p) => match parse_mcp_config_to_acp(p) {
-            Ok(Some(v)) => v,
-            Ok(None) => Vec::new(),
+            Ok(Some(v)) => {
+                info!(
+                    ?agent_type,
+                    worktree,
+                    mcp_config_path = %p.display(),
+                    server_names = ?mcp_server_names(&v),
+                    "ACP attach parsed MCP config"
+                );
+                v
+            }
+            Ok(None) => {
+                warn!(
+                    ?agent_type,
+                    worktree,
+                    mcp_config_path = %p.display(),
+                    "ACP attach MCP config had no mcpServers entries"
+                );
+                Vec::new()
+            }
             Err(e) => {
-                warn!(error = %e, "MCP config parse failed; agent will spawn without send tool");
+                warn!(
+                    ?agent_type,
+                    worktree,
+                    mcp_config_path = %p.display(),
+                    error = %e,
+                    "MCP config parse failed; continuing with baseline-only MCP if applicable"
+                );
                 Vec::new()
             }
         },
         None => Vec::new(),
     };
+    strip_remote_tools_mcp_for_opencode(agent_type, &mut acp_mcp_servers);
+    ensure_remote_tools_baseline_mcp(agent_type, &mut acp_mcp_servers);
+    info!(
+        ?agent_type,
+        worktree,
+        resume_acp_session_id = resume_acp_session_id.as_deref().unwrap_or(""),
+        has_remote_tools = acp_mcp_servers
+            .iter()
+            .any(|server| mcp_server_name(server) == REMOTE_TOOLS_MCP_SERVER_NAME),
+        server_names = ?mcp_server_names(&acp_mcp_servers),
+        opencode_config = %opencode_remote_tools_config_summary(worktree),
+        "ACP attach final MCP server set"
+    );
 
     let build_new_req = |cwd: std::path::PathBuf| -> acp::NewSessionRequest {
         let mut req = acp::NewSessionRequest::new(cwd);
@@ -924,16 +1090,15 @@ async fn attach_acp_session_on_conn(
         req
     };
 
-    let build_resume_req = |resume_id: &str, cwd: std::path::PathBuf| -> acp::ResumeSessionRequest {
-        let mut req = acp::ResumeSessionRequest::new(
-            acp::SessionId::new(resume_id.to_string()),
-            cwd,
-        );
-        if !acp_mcp_servers.is_empty() {
-            req = req.mcp_servers(acp_mcp_servers.clone());
-        }
-        req
-    };
+    let build_resume_req =
+        |resume_id: &str, cwd: std::path::PathBuf| -> acp::ResumeSessionRequest {
+            let mut req =
+                acp::ResumeSessionRequest::new(acp::SessionId::new(resume_id.to_string()), cwd);
+            if !acp_mcp_servers.is_empty() {
+                req = req.mcp_servers(acp_mcp_servers.clone());
+            }
+            req
+        };
 
     let t_session = Instant::now();
     let (session_id, acp_lists) = if let Some(ref resume_id) = resume_acp_session_id {
@@ -944,12 +1109,13 @@ async fn attach_acp_session_on_conn(
                 info!(
                     session_id = %sid,
                     resume_ms = t_session.elapsed().as_millis() as u64,
+                    has_remote_tools = acp_mcp_servers
+                        .iter()
+                        .any(|server| mcp_server_name(server) == REMOTE_TOOLS_MCP_SERVER_NAME),
+                    sent_mcp_servers = !acp_mcp_servers.is_empty(),
                     "ACP session resumed on host"
                 );
-                (
-                    sid,
-                    (resp.models, resp.config_options),
-                )
+                (sid, (resp.models, resp.config_options))
             }
             Err(e) => {
                 if forbid_new_session_fallback {
@@ -969,6 +1135,10 @@ async fn attach_acp_session_on_conn(
                 info!(
                     session_id = %sid,
                     new_session_ms = t_session.elapsed().as_millis() as u64,
+                    has_remote_tools = acp_mcp_servers
+                        .iter()
+                        .any(|server| mcp_server_name(server) == REMOTE_TOOLS_MCP_SERVER_NAME),
+                    sent_mcp_servers = !acp_mcp_servers.is_empty(),
                     "ACP session created on host (fallback)"
                 );
                 (sid, (resp.models, resp.config_options))
@@ -983,6 +1153,10 @@ async fn attach_acp_session_on_conn(
         info!(
             session_id = %sid,
             new_session_ms = t_session.elapsed().as_millis() as u64,
+            has_remote_tools = acp_mcp_servers
+                .iter()
+                .any(|server| mcp_server_name(server) == REMOTE_TOOLS_MCP_SERVER_NAME),
+            sent_mcp_servers = !acp_mcp_servers.is_empty(),
             "ACP session created on host"
         );
         (sid, (resp.models, resp.config_options))
@@ -1093,10 +1267,7 @@ fn spawn_prompt_worker(
             };
             super::agent_trace::log_acp_event(&acp_session_key, &status_active);
             let _ = event_tx
-                .send(AcpEventFrame::new(
-                    acp_session_key.clone(),
-                    status_active,
-                ))
+                .send(AcpEventFrame::new(acp_session_key.clone(), status_active))
                 .await;
 
             let mut blocks: Vec<acp::ContentBlock> = vec![text.into()];
@@ -1107,8 +1278,7 @@ fn spawn_prompt_worker(
                 }
             }
 
-            let prompt_fut =
-                conn.prompt(acp::PromptRequest::new(session_id.clone(), blocks));
+            let prompt_fut = conn.prompt(acp::PromptRequest::new(session_id.clone(), blocks));
             tokio::pin!(prompt_fut);
 
             // `true` once the watchdog gives up on a wedged prompt; suppresses
@@ -1172,10 +1342,7 @@ fn spawn_prompt_worker(
             };
             super::agent_trace::log_acp_event(&acp_session_key, &status_idle);
             let _ = event_tx
-                .send(AcpEventFrame::new(
-                    acp_session_key.clone(),
-                    status_idle,
-                ))
+                .send(AcpEventFrame::new(acp_session_key.clone(), status_idle))
                 .await;
 
             let elapsed_ms = turn_started.elapsed().as_millis() as u64;
@@ -1185,12 +1352,7 @@ fn spawn_prompt_worker(
                      It may be unavailable or rate-limited — retry or switch models.",
                     stall_timeout.as_secs()
                 );
-                super::agent_trace::log_prompt_end(
-                    &acp_session_key,
-                    false,
-                    &details,
-                    elapsed_ms,
-                );
+                super::agent_trace::log_prompt_end(&acp_session_key, false, &details, elapsed_ms);
                 emit_acp_error(
                     &event_tx,
                     &acp_session_key,
@@ -1214,14 +1376,14 @@ fn spawn_prompt_worker(
                     }
                     Err(e) => {
                         let details = format!("ACP prompt failed: {e}");
-                        super::agent_trace::log_prompt_end(&acp_session_key, false, &details, elapsed_ms);
-                        emit_acp_error(
-                            &event_tx,
+                        super::agent_trace::log_prompt_end(
                             &acp_session_key,
-                            "ACP prompt failed",
-                            details,
-                        )
-                        .await;
+                            false,
+                            &details,
+                            elapsed_ms,
+                        );
+                        emit_acp_error(&event_tx, &acp_session_key, "ACP prompt failed", details)
+                            .await;
                     }
                 }
             }
@@ -1236,6 +1398,7 @@ async fn run_acp_host(
     agent_type: amux::AgentType,
     extra_env: HashMap<String, String>,
     force_env_override: bool,
+    host_worktree: Option<String>,
     mut cmd_rx: mpsc::Receiver<AcpCommand>,
     host_ready_tx: oneshot::Sender<Result<(), String>>,
 ) -> anyhow::Result<()> {
@@ -1244,15 +1407,28 @@ async fn run_acp_host(
     } else {
         std::collections::HashSet::new()
     };
-    let mut cmd = build_acp_process_command(
-        &binary,
-        &args,
-        agent_type,
-        &extra_env,
-        &force_env_keys,
+    let mut cmd =
+        build_acp_process_command(&binary, &args, agent_type, &extra_env, &force_env_keys);
+    let host_cwd = host_worktree
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(".");
+    let sock_path = crate::config::DaemonConfig::sock_path();
+    let current_exe = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|e| format!("current_exe_error={e}"));
+    info!(
+        ?agent_type,
+        binary = %binary,
+        args = ?args,
+        host_cwd,
+        current_exe = %current_exe,
+        sock = %sock_path.display(),
+        opencode_config = %opencode_remote_tools_config_summary(host_cwd),
+        "ACP host spawning process"
     );
     let mut child = cmd
-        .current_dir(".")
+        .current_dir(host_cwd)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -1278,7 +1454,12 @@ async fn run_acp_host(
         });
     }
 
-    info!(binary = %binary, agent_type = ?agent_type, "ACP host process spawned");
+    info!(
+        binary = %binary,
+        agent_type = ?agent_type,
+        host_cwd,
+        "ACP host process spawned"
+    );
 
     let registry = Rc::new(RefCell::new(SessionRegistry::default()));
     let client = AmuxClient {
@@ -1345,6 +1526,29 @@ async fn run_acp_host(
                             .as_deref()
                             .unwrap_or("new-session")
                             .to_string();
+                        if let Some(resume_id) = resume_acp_session_id.as_deref() {
+                            if let Some(active) = active_sessions.get(resume_id) {
+                                info!(
+                                    session_id = %resume_id,
+                                    "ACP attach skipped: session already active on host"
+                                );
+                                report_startup(
+                                    &startup_reporter,
+                                    Ok(AcpStartupMetadata {
+                                        available_models: crate::runtime::models::available_models_for(agent_type),
+                                        initial_model: None,
+                                        acp_session_id: resume_id.to_string(),
+                                    }),
+                                );
+                                if !initial_prompt.is_empty() {
+                                    let _ = active
+                                        .prompt_tx
+                                        .send((initial_prompt, Vec::new()))
+                                        .await;
+                                }
+                                continue;
+                            }
+                        }
                         let attach_result = attach_acp_session_on_conn(
                             &conn,
                             &registry,
@@ -1495,7 +1699,15 @@ pub fn spawn_acp_agent(
     extra_env: HashMap<String, String>,
 ) -> crate::error::Result<mpsc::Sender<AcpCommand>> {
     let (host_ready_tx, host_ready_rx) = oneshot::channel();
-    let cmd_tx = spawn_acp_host(binary, args, agent_type, extra_env, false, host_ready_tx)?;
+    let cmd_tx = spawn_acp_host(
+        binary,
+        args,
+        agent_type,
+        extra_env,
+        false,
+        Some(worktree.clone()),
+        host_ready_tx,
+    )?;
     let host_cmd = cmd_tx.clone();
     std::thread::Builder::new()
         .name("acp-cli-attach".into())
@@ -1632,6 +1844,105 @@ mod tests {
     }
 
     #[test]
+    fn codex_attach_gets_remote_tools_baseline_mcp() {
+        let mut servers = Vec::new();
+
+        ensure_remote_tools_baseline_mcp(amux::AgentType::Codex, &mut servers);
+
+        assert!(
+            servers
+                .iter()
+                .any(|server| { mcp_server_name(server) == REMOTE_TOOLS_MCP_SERVER_NAME })
+        );
+    }
+
+    #[test]
+    fn opencode_attach_strips_remote_tools_mcp() {
+        let mut servers = vec![acp::McpServer::Stdio(acp::McpServerStdio::new(
+            REMOTE_TOOLS_MCP_SERVER_NAME,
+            "/bin/echo",
+        ))];
+
+        strip_remote_tools_mcp_for_opencode(amux::AgentType::Opencode, &mut servers);
+
+        assert!(
+            servers
+                .iter()
+                .all(|server| { mcp_server_name(server) != REMOTE_TOOLS_MCP_SERVER_NAME })
+        );
+    }
+
+    #[test]
+    fn opencode_desktop_attach_does_not_drop_plugin_remote_tools() {
+        #[derive(Default)]
+        struct FakeOpenCodeHost {
+            global_tools: Vec<String>,
+            next_remote_tools_registration_succeeds: bool,
+        }
+
+        impl FakeOpenCodeHost {
+            fn seed_workspace_remote_tools(&mut self) {
+                self.global_tools = vec![format!(
+                    "{}_{}",
+                    REMOTE_TOOLS_MCP_SERVER_NAME, "get_page_dom"
+                )];
+            }
+
+            fn tools_list(&self) -> &[String] {
+                &self.global_tools
+            }
+
+            fn attach(&mut self, agent_type: amux::AgentType, servers: &mut Vec<acp::McpServer>) {
+                strip_remote_tools_mcp_for_opencode(agent_type, servers);
+                ensure_remote_tools_baseline_mcp(agent_type, servers);
+
+                if servers
+                    .iter()
+                    .any(|server| mcp_server_name(server) == REMOTE_TOOLS_MCP_SERVER_NAME)
+                {
+                    if self.next_remote_tools_registration_succeeds {
+                        self.seed_workspace_remote_tools();
+                    } else {
+                        self.global_tools.clear();
+                    }
+                }
+            }
+        }
+
+        let mut host = FakeOpenCodeHost {
+            global_tools: Vec::new(),
+            next_remote_tools_registration_succeeds: false,
+        };
+        host.seed_workspace_remote_tools();
+
+        let mut plugin_attach_servers = Vec::new();
+        host.attach(amux::AgentType::Opencode, &mut plugin_attach_servers);
+        assert!(
+            host.tools_list()
+                .contains(&"amuxd-remote-tools_get_page_dom".to_string()),
+            "plugin session tools/list starts with remote-tools from workspace opencode.json"
+        );
+
+        let mut desktop_attach_servers = vec![acp::McpServer::Stdio(acp::McpServerStdio::new(
+            REMOTE_TOOLS_MCP_SERVER_NAME,
+            "/bin/false",
+        ))];
+        host.attach(amux::AgentType::Opencode, &mut desktop_attach_servers);
+
+        assert!(
+            host.tools_list()
+                .contains(&"amuxd-remote-tools_get_page_dom".to_string()),
+            "desktop session attach must not re-register amuxd-remote-tools and clear plugin tools/list"
+        );
+        assert!(
+            desktop_attach_servers
+                .iter()
+                .all(|server| mcp_server_name(server) != REMOTE_TOOLS_MCP_SERVER_NAME),
+            "OpenCode receives no per-session amuxd-remote-tools MCP"
+        );
+    }
+
+    #[test]
     fn translates_tool_call_update_raw_input_to_tool_use_update() {
         let update = acp::ToolCallUpdate::new(
             "tool-1",
@@ -1669,7 +1980,9 @@ mod tests {
             acp::ToolCallUpdateFields::new()
                 .kind(acp::ToolKind::Edit)
                 .status(acp::ToolCallStatus::InProgress)
-                .content(vec![acp::Diff::new("src/a.ts", "new\n").old_text("old\n").into()]),
+                .content(vec![
+                    acp::Diff::new("src/a.ts", "new\n").old_text("old\n").into(),
+                ]),
         );
         let events = translate_session_update(acp::SessionUpdate::ToolCallUpdate(update));
 
@@ -1698,7 +2011,9 @@ mod tests {
             acp::ToolCallUpdateFields::new()
                 .status(acp::ToolCallStatus::Completed)
                 .title("Edit src/a.ts")
-                .content(vec![acp::Diff::new("src/a.ts", "new\n").old_text("old\n").into()]),
+                .content(vec![
+                    acp::Diff::new("src/a.ts", "new\n").old_text("old\n").into(),
+                ]),
         );
         let events = translate_session_update(acp::SessionUpdate::ToolCallUpdate(update));
 
@@ -1720,7 +2035,9 @@ mod tests {
             acp::ToolCallUpdateFields::new()
                 .kind(acp::ToolKind::Edit)
                 .status(acp::ToolCallStatus::InProgress)
-                .content(vec![acp::Diff::new("src/a.ts", "new\n").old_text("old\n").into()]),
+                .content(vec![
+                    acp::Diff::new("src/a.ts", "new\n").old_text("old\n").into(),
+                ]),
         );
         let events = translate_session_update(acp::SessionUpdate::ToolCallUpdate(update));
 

--- a/apps/daemon/src/runtime/adapter.rs
+++ b/apps/daemon/src/runtime/adapter.rs
@@ -42,6 +42,8 @@ pub enum AcpCommand {
         /// Gateway sessions auto-allow tool permissions; native runtimes wait
         /// for MQTT approval.
         is_gateway: bool,
+        /// When resuming, fail instead of falling back to `session/new`.
+        forbid_new_session_fallback: bool,
     },
     /// Drop routing state for a session; the host process keeps running.
     DetachSession { acp_session_id: String },
@@ -899,6 +901,7 @@ async fn attach_acp_session_on_conn(
     initial_model_override: Option<String>,
     event_tx: mpsc::Sender<AcpEventFrame>,
     is_gateway: bool,
+    forbid_new_session_fallback: bool,
 ) -> anyhow::Result<AcpStartupMetadata> {
     let worktree_path = std::path::PathBuf::from(worktree);
     let acp_mcp_servers: Vec<acp::McpServer> = match mcp_config_path.as_ref() {
@@ -949,6 +952,11 @@ async fn attach_acp_session_on_conn(
                 )
             }
             Err(e) => {
+                if forbid_new_session_fallback {
+                    return Err(anyhow::anyhow!(
+                        "ACP resume_session failed (new_session fallback forbidden): {e}"
+                    ));
+                }
                 warn!(
                     resume_id,
                     "ACP resume_session failed ({}), falling back to new_session", e
@@ -1329,6 +1337,7 @@ async fn run_acp_host(
                         event_tx,
                         startup_tx,
                         is_gateway,
+                        forbid_new_session_fallback,
                     } => {
                         let startup_reporter: StartupReporter =
                             Arc::new(Mutex::new(Some(startup_tx)));
@@ -1346,6 +1355,7 @@ async fn run_acp_host(
                             initial_model_override,
                             event_tx.clone(),
                             is_gateway,
+                            forbid_new_session_fallback,
                         )
                         .await;
 
@@ -1506,6 +1516,7 @@ pub fn spawn_acp_agent(
                             event_tx,
                             startup_tx,
                             is_gateway: false,
+                            forbid_new_session_fallback: false,
                         })
                         .await;
                 }

--- a/apps/daemon/src/runtime/adapter/translate.rs
+++ b/apps/daemon/src/runtime/adapter/translate.rs
@@ -411,21 +411,13 @@ pub(super) fn tool_output_summary(raw_output: Option<&serde_json::Value>) -> Opt
                 None
             } else {
                 let text = json_value_to_string(value);
-                if text.is_empty() {
-                    None
-                } else {
-                    Some(text)
-                }
+                if text.is_empty() { None } else { Some(text) }
             }
         }
         serde_json::Value::Array(_) => None,
         _ => {
             let text = json_value_to_string(value);
-            if text.is_empty() {
-                None
-            } else {
-                Some(text)
-            }
+            if text.is_empty() { None } else { Some(text) }
         }
     })
 }
@@ -465,11 +457,7 @@ pub(super) fn json_tool_output_text(value: &serde_json::Value) -> Option<String>
         serde_json::Value::Null => None,
         _ => {
             let text = value.to_string();
-            if text.is_empty() {
-                None
-            } else {
-                Some(text)
-            }
+            if text.is_empty() { None } else { Some(text) }
         }
     }
 }
@@ -497,11 +485,7 @@ pub(super) fn json_content_summary(value: &serde_json::Value) -> Option<String> 
         }
     }
     let text = parts.join("\n\n");
-    if text.is_empty() {
-        None
-    } else {
-        Some(text)
-    }
+    if text.is_empty() { None } else { Some(text) }
 }
 
 pub(super) fn tool_content_summary(content: Option<&[acp::ToolCallContent]>) -> Option<String> {
@@ -521,11 +505,7 @@ pub(super) fn tool_content_summary(content: Option<&[acp::ToolCallContent]>) -> 
         }
     }
     let text = parts.join("\n\n");
-    if text.is_empty() {
-        None
-    } else {
-        Some(text)
-    }
+    if text.is_empty() { None } else { Some(text) }
 }
 
 pub(super) fn truncate_tool_summary(summary: String) -> String {
@@ -638,9 +618,7 @@ async fn compress_image_for_prompt(bytes: Vec<u8>, mime: &'static str) -> (Vec<u
 }
 
 /// Parse task tool in-progress metadata for subagent child session binding.
-pub(super) fn extract_task_child_metadata(
-    update: &acp::SessionUpdate,
-) -> Option<(String, String)> {
+pub(super) fn extract_task_child_metadata(update: &acp::SessionUpdate) -> Option<(String, String)> {
     let tcu = match update {
         acp::SessionUpdate::ToolCallUpdate(tcu) => tcu,
         _ => return None,

--- a/apps/daemon/src/runtime/env_assembly.rs
+++ b/apps/daemon/src/runtime/env_assembly.rs
@@ -36,5 +36,6 @@ pub fn assemble_spawn_runtime_env(
         extra_env: bundle.extra_env,
         force_env_override: true,
         opencode_json_original: bundle.opencode_json_original,
+        is_gateway: false,
     })
 }

--- a/apps/daemon/src/runtime/handle.rs
+++ b/apps/daemon/src/runtime/handle.rs
@@ -86,6 +86,11 @@ pub struct RuntimeHandle {
     pub last_processed_message_id: Option<String>,
     /// Human member actor whose client receives remote-tool RPC for this runtime.
     pub remote_tool_member_id: String,
+    /// Gateway runtimes auto-allow ACP tool permissions; collab runtimes do not.
+    pub is_gateway: bool,
+    /// Another session on the shared OpenCode host may have dropped MCP; refresh
+    /// on the next Idle transition (never detach/resume while Active).
+    pub remote_tools_mcp_refresh_pending: bool,
 }
 
 impl RuntimeHandle {
@@ -124,6 +129,8 @@ impl RuntimeHandle {
             last_processed_message_id: None,
             available_models: Vec::new(),
             remote_tool_member_id: String::new(),
+            is_gateway: false,
+            remote_tools_mcp_refresh_pending: false,
         }
     }
 
@@ -336,6 +343,8 @@ impl RuntimeHandle {
             last_processed_message_id: None,
             available_models: Vec::new(),
             remote_tool_member_id: String::new(),
+            is_gateway: false,
+            remote_tools_mcp_refresh_pending: false,
         }
     }
 }

--- a/apps/daemon/src/runtime/handle.rs
+++ b/apps/daemon/src/runtime/handle.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use tokio::sync::{mpsc, Mutex as AsyncMutex};
 
-use super::adapter::AcpCommand;
 use super::acp_event_frame::AcpEventFrame;
+use super::adapter::AcpCommand;
 use super::instruction_delivery::InstructionDelivery;
 use crate::proto::amux;
 
@@ -65,6 +65,9 @@ pub struct RuntimeHandle {
     pub pending_silent: Vec<PendingMessage>,
     /// Instructions queued by `inject_context` (workspace system prompt, /ctx).
     pub injected_context: Vec<InjectedContextItem>,
+    /// One-shot context that must be prepended to the next prompt even when
+    /// session-level injected context is delivered by a native plugin.
+    pub next_prompt_context: String,
     /// How static workspace instructions are delivered for this runtime.
     pub instruction_delivery: InstructionDelivery,
     /// Backend `agent_runtimes.id` for this runtime row. Used to PATCH
@@ -124,6 +127,7 @@ impl RuntimeHandle {
             turn_lock: Arc::new(AsyncMutex::new(())),
             pending_silent: Vec::new(),
             injected_context: Vec::new(),
+            next_prompt_context: String::new(),
             instruction_delivery: InstructionDelivery::BufferedInject,
             backend_runtime_row_id: None,
             last_processed_message_id: None,
@@ -210,8 +214,8 @@ impl RuntimeHandle {
             tx.send(AcpCommand::Cancel {
                 acp_session_id: self.acp_session_id.clone(),
             })
-                .await
-                .map_err(|_| crate::error::AmuxError::Agent("ACP command channel closed".into()))
+            .await
+            .map_err(|_| crate::error::AmuxError::Agent("ACP command channel closed".into()))
         } else {
             Err(crate::error::AmuxError::Agent(
                 "no ACP command channel".into(),
@@ -338,6 +342,7 @@ impl RuntimeHandle {
             turn_lock: Arc::new(AsyncMutex::new(())),
             pending_silent: Vec::new(),
             injected_context: Vec::new(),
+            next_prompt_context: String::new(),
             instruction_delivery: InstructionDelivery::BufferedInject,
             backend_runtime_row_id: None,
             last_processed_message_id: None,

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -683,6 +683,7 @@ impl RuntimeManager {
                 handle.worktree.clone(),
                 handle.acp_session_id.clone(),
                 handle.event_tx.clone(),
+                handle.status,
             )
         };
 
@@ -690,7 +691,7 @@ impl RuntimeManager {
             handle.shutdown().await;
         }
 
-        let (agent_type, worktree, acp_session_id, event_tx) = snapshot;
+        let (agent_type, worktree, acp_session_id, event_tx, prior_status) = snapshot;
         let SpawnRuntimeEnv {
             extra_env,
             force_env_override,
@@ -723,7 +724,7 @@ impl RuntimeManager {
             h.acp_session_id = startup.acp_session_id;
             h.is_gateway = false;
             h.available_models = startup.available_models;
-            h.status = amux::AgentStatus::Active;
+            h.status = prior_status;
         }
         if let Some(model_id) = startup.initial_model {
             self.set_current_model(agent_id, &model_id);

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -45,6 +45,10 @@ pub struct SpawnRuntimeEnv {
     /// Original `opencode.json` before MCP placeholder resolve; restored when the
     /// last runtime on this worktree stops.
     pub opencode_json_original: Option<String>,
+    /// Gateway sessions auto-allow tool permissions and use gateway MCP wiring.
+    /// Remote-tools collab runtimes may also carry an MCP config but must stay
+    /// `is_gateway = false` so permission + MCP repair paths behave correctly.
+    pub is_gateway: bool,
 }
 
 /// Per-agent runtime state checked out of `RuntimeManager` for the duration
@@ -393,6 +397,7 @@ impl RuntimeManager {
             extra_env,
             force_env_override,
             opencode_json_original,
+            is_gateway,
         } = runtime_env;
         self.register_opencode_snapshot(worktree, opencode_json_original, &extra_env);
         let mut handle = RuntimeHandle::new(
@@ -404,9 +409,9 @@ impl RuntimeManager {
         handle.current_prompt = prompt.into();
         handle.session_id = remote_session_id.unwrap_or_default().to_string();
         handle.available_models = crate::runtime::models::available_models_for(agent_type);
+        handle.is_gateway = is_gateway;
 
         let launch = self.launch_config_for(agent_type);
-        let is_gateway = mcp_config_path.is_some();
         let resume_requested = resume_acp_session_id.is_some();
         let (cmd_tx, startup) = self
             .acp_host_pool
@@ -422,6 +427,7 @@ impl RuntimeManager {
                 prompt.to_string(),
                 handle.event_tx.clone(),
                 is_gateway,
+                false,
             )
             .await?;
 
@@ -563,6 +569,7 @@ impl RuntimeManager {
             extra_env,
             force_env_override,
             opencode_json_original,
+            is_gateway,
         } = runtime_env;
         self.register_opencode_snapshot(worktree, opencode_json_original, &extra_env);
 
@@ -573,9 +580,9 @@ impl RuntimeManager {
             workspace_id.into(),
         );
         handle.session_id = remote_session_id.unwrap_or_default().to_string();
+        handle.is_gateway = is_gateway;
 
         let launch = self.launch_config_for(agent_type);
-        let is_gateway = mcp_config_path.is_some();
         let (cmd_tx, startup) = self
             .acp_host_pool
             .attach_session(
@@ -590,6 +597,7 @@ impl RuntimeManager {
                 prompt.to_string(),
                 handle.event_tx.clone(),
                 is_gateway,
+                false,
             )
             .await?;
 
@@ -648,6 +656,84 @@ impl RuntimeManager {
         }
 
         Ok(new_acp_sid)
+    }
+
+    /// Re-register remote-tools MCP on a live collab runtime via
+    /// `session/resume` on the same ACP session id (no `session/new` fallback).
+    pub async fn refresh_remote_tools_mcp_attach(
+        &mut self,
+        agent_id: &str,
+        mcp_config_path: std::path::PathBuf,
+        runtime_env: SpawnRuntimeEnv,
+    ) -> crate::error::Result<()> {
+        let snapshot = {
+            let handle = self.agents.get(agent_id).ok_or_else(|| {
+                crate::error::AmuxError::Agent(format!("agent {agent_id} not found"))
+            })?;
+            if handle.is_gateway {
+                return Ok(());
+            }
+            if handle.acp_session_id.is_empty() {
+                return Err(crate::error::AmuxError::Agent(format!(
+                    "agent {agent_id} has no ACP session id"
+                )));
+            }
+            (
+                handle.agent_type,
+                handle.worktree.clone(),
+                handle.acp_session_id.clone(),
+                handle.event_tx.clone(),
+            )
+        };
+
+        if let Some(handle) = self.agents.get(agent_id) {
+            handle.shutdown().await;
+        }
+
+        let (agent_type, worktree, acp_session_id, event_tx) = snapshot;
+        let SpawnRuntimeEnv {
+            extra_env,
+            force_env_override,
+            opencode_json_original,
+            ..
+        } = runtime_env;
+        self.register_opencode_snapshot(&worktree, opencode_json_original, &extra_env);
+        let launch = self.launch_config_for(agent_type);
+        let (cmd_tx, startup) = self
+            .acp_host_pool
+            .attach_session(
+                agent_type,
+                &launch,
+                extra_env,
+                force_env_override,
+                worktree.clone(),
+                Some(acp_session_id.clone()),
+                Some(mcp_config_path),
+                None,
+                String::new(),
+                event_tx,
+                false,
+                true,
+            )
+            .await?;
+
+        let resumed_sid = startup.acp_session_id.clone();
+        if let Some(h) = self.agents.get_mut(agent_id) {
+            h.cmd_tx = Some(cmd_tx);
+            h.acp_session_id = startup.acp_session_id;
+            h.is_gateway = false;
+            h.available_models = startup.available_models;
+            h.status = amux::AgentStatus::Active;
+        }
+        if let Some(model_id) = startup.initial_model {
+            self.set_current_model(agent_id, &model_id);
+        }
+        info!(
+            agent_id,
+            acp_session_id = %resumed_sid,
+            "remote-tools MCP re-attached via ACP resume"
+        );
+        Ok(())
     }
 
     pub async fn stop_agent(&mut self, agent_id: &str) -> Option<RuntimeHandle> {
@@ -1108,7 +1194,10 @@ impl RuntimeManager {
                 initial_model,
                 mcp_cfg_path,
                 None,
-                SpawnRuntimeEnv::default(),
+                SpawnRuntimeEnv {
+                    is_gateway: true,
+                    ..SpawnRuntimeEnv::default()
+                },
             )
             .await?;
 

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -1,12 +1,10 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tokio::sync::mpsc;
-use tokio::time::{timeout, Duration};
 use tracing::{info, warn};
 use uuid::Uuid;
 
 use super::acp_host::AcpHostPool;
-use super::adapter;
 use super::agent_runtime_state::PerAgentRuntimeState;
 use super::handle::RuntimeHandle;
 use super::refresh::RuntimeRefreshCoordinator;
@@ -300,9 +298,15 @@ impl RuntimeManager {
         &mut self,
         extra_env: HashMap<String, String>,
         force_env_override: bool,
+        worktree: Option<&str>,
     ) {
         self.acp_host_pool
-            .prewarm_with_env(&self.launch_configs, extra_env, force_env_override)
+            .prewarm_with_env(
+                &self.launch_configs,
+                extra_env,
+                force_env_override,
+                worktree,
+            )
             .await;
     }
 
@@ -658,85 +662,6 @@ impl RuntimeManager {
         Ok(new_acp_sid)
     }
 
-    /// Re-register remote-tools MCP on a live collab runtime via
-    /// `session/resume` on the same ACP session id (no `session/new` fallback).
-    pub async fn refresh_remote_tools_mcp_attach(
-        &mut self,
-        agent_id: &str,
-        mcp_config_path: std::path::PathBuf,
-        runtime_env: SpawnRuntimeEnv,
-    ) -> crate::error::Result<()> {
-        let snapshot = {
-            let handle = self.agents.get(agent_id).ok_or_else(|| {
-                crate::error::AmuxError::Agent(format!("agent {agent_id} not found"))
-            })?;
-            if handle.is_gateway {
-                return Ok(());
-            }
-            if handle.acp_session_id.is_empty() {
-                return Err(crate::error::AmuxError::Agent(format!(
-                    "agent {agent_id} has no ACP session id"
-                )));
-            }
-            (
-                handle.agent_type,
-                handle.worktree.clone(),
-                handle.acp_session_id.clone(),
-                handle.event_tx.clone(),
-                handle.status,
-            )
-        };
-
-        if let Some(handle) = self.agents.get(agent_id) {
-            handle.shutdown().await;
-        }
-
-        let (agent_type, worktree, acp_session_id, event_tx, prior_status) = snapshot;
-        let SpawnRuntimeEnv {
-            extra_env,
-            force_env_override,
-            opencode_json_original,
-            ..
-        } = runtime_env;
-        self.register_opencode_snapshot(&worktree, opencode_json_original, &extra_env);
-        let launch = self.launch_config_for(agent_type);
-        let (cmd_tx, startup) = self
-            .acp_host_pool
-            .attach_session(
-                agent_type,
-                &launch,
-                extra_env,
-                force_env_override,
-                worktree.clone(),
-                Some(acp_session_id.clone()),
-                Some(mcp_config_path),
-                None,
-                String::new(),
-                event_tx,
-                false,
-                true,
-            )
-            .await?;
-
-        let resumed_sid = startup.acp_session_id.clone();
-        if let Some(h) = self.agents.get_mut(agent_id) {
-            h.cmd_tx = Some(cmd_tx);
-            h.acp_session_id = startup.acp_session_id;
-            h.is_gateway = false;
-            h.available_models = startup.available_models;
-            h.status = prior_status;
-        }
-        if let Some(model_id) = startup.initial_model {
-            self.set_current_model(agent_id, &model_id);
-        }
-        info!(
-            agent_id,
-            acp_session_id = %resumed_sid,
-            "remote-tools MCP re-attached via ACP resume"
-        );
-        Ok(())
-    }
-
     pub async fn stop_agent(&mut self, agent_id: &str) -> Option<RuntimeHandle> {
         if let Some(mut handle) = self.agents.remove(agent_id) {
             self.aggregators.remove(agent_id);
@@ -773,10 +698,11 @@ impl RuntimeManager {
         text: &str,
         attachment_urls: Vec<String>,
     ) -> crate::error::Result<Vec<String>> {
-        let (final_text, drained_ids, drained_messages, drained_injected) =
+        let (final_text, drained_ids, drained_messages, drained_injected, drained_next_context) =
             if let Some(handle) = self.agents.get_mut(agent_id) {
                 let drained_messages = handle.pending_silent.clone();
                 let drained_injected = handle.injected_context.clone();
+                let drained_next_context = std::mem::take(&mut handle.next_prompt_context);
                 let (injected_prefix, _) = if super::instruction_delivery::skips_buffered_inject(
                     handle.instruction_delivery,
                 ) {
@@ -785,13 +711,24 @@ impl RuntimeManager {
                     handle.flush_injected_context()
                 };
                 let (silent_prefix, drained) = handle.flush_pending_silent();
-                let prefix = format!("{injected_prefix}{silent_prefix}");
+                let next_context_prefix = if drained_next_context.is_empty() {
+                    String::new()
+                } else {
+                    format!("{drained_next_context}\n\n")
+                };
+                let prefix = format!("{injected_prefix}{next_context_prefix}{silent_prefix}");
                 let final_text = if prefix.is_empty() {
                     text.to_string()
                 } else {
                     format!("{prefix}{text}")
                 };
-                (final_text, drained, drained_messages, drained_injected)
+                (
+                    final_text,
+                    drained,
+                    drained_messages,
+                    drained_injected,
+                    drained_next_context,
+                )
             } else {
                 return Err(crate::error::AmuxError::Agent(format!(
                     "agent {} not found",
@@ -806,6 +743,9 @@ impl RuntimeManager {
             if let Some(handle) = self.agents.get_mut(agent_id) {
                 if !drained_injected.is_empty() {
                     handle.injected_context = drained_injected;
+                }
+                if !drained_next_context.is_empty() {
+                    handle.next_prompt_context = drained_next_context;
                 }
                 if !drained_messages.is_empty() {
                     let mut restored = drained_messages;
@@ -1240,11 +1180,13 @@ impl RuntimeManager {
         sender_display: &str,
         text: &str,
     ) -> crate::error::Result<()> {
-        let agent_id = self.agent_id_by_acp_session(acp_session_id).ok_or_else(|| {
-            crate::error::AmuxError::Agent(format!(
-                "no runtime for acp_session_id {acp_session_id}"
-            ))
-        })?;
+        let agent_id = self
+            .agent_id_by_acp_session(acp_session_id)
+            .ok_or_else(|| {
+                crate::error::AmuxError::Agent(format!(
+                    "no runtime for acp_session_id {acp_session_id}"
+                ))
+            })?;
         self.inject_context_for_runtime(&agent_id, sender_display, text)
     }
 
@@ -1254,9 +1196,10 @@ impl RuntimeManager {
         sender_display: &str,
         text: &str,
     ) -> crate::error::Result<()> {
-        let handle = self.agents.get_mut(agent_id).ok_or_else(|| {
-            crate::error::AmuxError::Agent(format!("agent {agent_id} not found"))
-        })?;
+        let handle = self
+            .agents
+            .get_mut(agent_id)
+            .ok_or_else(|| crate::error::AmuxError::Agent(format!("agent {agent_id} not found")))?;
         handle.push_injected_context(sender_display, text);
         Ok(())
     }
@@ -1737,6 +1680,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_prompt_includes_next_prompt_context_when_native_delivery() {
+        let mut mgr = RuntimeManager::test_dummy_with_runtime("rt1");
+        let handle = mgr.get_handle_mut("rt1").unwrap();
+        handle.instruction_delivery = crate::runtime::InstructionDelivery::NativeOpenCodePlugin;
+        handle.next_prompt_context =
+            "When calling get_page_dom, include remote_context_id exactly as: rtctx_1".into();
+
+        mgr.send_prompt("rt1", "hello", vec![]).await.unwrap();
+
+        let sent = mgr.last_sent_to("rt1").expect("sent prompt");
+        assert!(sent.contains("remote_context_id exactly as: rtctx_1"));
+        assert!(sent.ends_with("hello"));
+        assert!(mgr
+            .get_handle("rt1")
+            .unwrap()
+            .next_prompt_context
+            .is_empty());
+    }
+
+    #[tokio::test]
     async fn send_prompt_drains_injected_before_pending_silent() {
         let mut mgr = RuntimeManager::test_dummy_with_runtime("rt1");
         mgr.inject_context_for_runtime("rt1", "system", "请使用中文回答")
@@ -1803,6 +1766,7 @@ mod tests {
         let mut mgr = RuntimeManager::test_dummy_with_runtime("rt1");
         mgr.inject_context_for_runtime("rt1", "system", "请使用中文回答")
             .unwrap();
+        mgr.get_handle_mut("rt1").unwrap().next_prompt_context = "remote ctx".into();
         mgr.fail_next_send_for("rt1", "boom");
 
         let result = mgr.send_prompt("rt1", "real question", vec![]).await;
@@ -1811,6 +1775,10 @@ mod tests {
         let injected = &mgr.get_handle("rt1").unwrap().injected_context;
         assert_eq!(injected.len(), 1);
         assert_eq!(injected[0].content, "请使用中文回答");
+        assert_eq!(
+            mgr.get_handle("rt1").unwrap().next_prompt_context,
+            "remote ctx"
+        );
         assert!(mgr.last_sent_to("rt1").is_none());
     }
 

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -17,6 +17,7 @@ use tracing::{info, warn};
 /// Matches `apps/desktop/src/commands/introspect_api.rs` — desktop Tauri hosts the API.
 const INTROSPECT_API_PORT: u16 = 13144;
 const TEAM_SKILLS_PATH: &str = "teamclaw-team/skills";
+const REMOTE_TOOLS_MCP_SERVER_NAME: &str = "amuxd-remote-tools";
 const INSTRUCTION_PLUGIN_TEMPLATE: &str = include_str!(
     "../../../../packages/app/src/lib/opencode/templates/teamclaw-instruction-plugin.mjs.txt"
 );
@@ -26,8 +27,8 @@ use crate::proto::amux;
 use crate::runtime::{
     acp_catalog_probe,
     refresh::{
-        APPLY_REFRESH_SUPPRESS, INTERNAL_PREPARE_KINDS, INTERNAL_WRITE_SUPPRESS, RefreshChangeKind,
-        RuntimeRefreshCoordinator, WorkspaceRefreshState,
+        RefreshChangeKind, RuntimeRefreshCoordinator, WorkspaceRefreshState,
+        APPLY_REFRESH_SUPPRESS, INTERNAL_PREPARE_KINDS, INTERNAL_WRITE_SUPPRESS,
     },
     AgentLaunchConfig, RuntimeManager,
 };
@@ -133,6 +134,23 @@ pub fn ensure_inherent_mcp(workspace_path: &Path) -> Result<(), WorkspaceControl
 
     let mut changed = false;
 
+    let remote_tools = remote_tools_mcp_config()?;
+    let needs_remote_tools = mcp_obj
+        .get(REMOTE_TOOLS_MCP_SERVER_NAME)
+        .map(|existing| existing != &remote_tools)
+        .unwrap_or(true);
+    info!(
+        workspace = %workspace_path.display(),
+        config_path = %config_path.display(),
+        needs_remote_tools,
+        remote_tools_present = mcp_obj.contains_key(REMOTE_TOOLS_MCP_SERVER_NAME),
+        "ensure_inherent_mcp: remote-tools config checked"
+    );
+    if needs_remote_tools {
+        mcp_obj.insert(REMOTE_TOOLS_MCP_SERVER_NAME.to_string(), remote_tools);
+        changed = true;
+    }
+
     if !mcp_obj.contains_key("playwright") {
         mcp_obj.insert(
             "playwright".to_string(),
@@ -161,8 +179,33 @@ pub fn ensure_inherent_mcp(workspace_path: &Path) -> Result<(), WorkspaceControl
 
     if changed {
         write_json_pretty(&config_path, &config)?;
+        info!(
+            workspace = %workspace_path.display(),
+            config_path = %config_path.display(),
+            "ensure_inherent_mcp: opencode.json updated"
+        );
     }
     Ok(())
+}
+
+fn remote_tools_mcp_config() -> Result<serde_json::Value, WorkspaceControlError> {
+    let amuxd_bin =
+        std::env::current_exe().map_err(|e| WorkspaceControlError::Io(e.to_string()))?;
+    let sock = crate::config::DaemonConfig::sock_path();
+    info!(
+        amuxd_bin = %amuxd_bin.display(),
+        sock = %sock.display(),
+        "ensure_inherent_mcp: building remote-tools config"
+    );
+    Ok(serde_json::json!({
+        "type": "local",
+        "enabled": true,
+        "command": [
+            amuxd_bin.to_string_lossy(),
+            "remote-tools-mcp",
+            format!("--sock={}", sock.to_string_lossy())
+        ]
+    }))
 }
 
 fn resolve_executable(path: PathBuf) -> Option<PathBuf> {
@@ -508,9 +551,7 @@ pub fn ensure_instruction_plugin(workspace_path: &Path) -> Result<(), WorkspaceC
         );
     }
 
-    let plugins = obj
-        .entry("plugin")
-        .or_insert_with(|| serde_json::json!([]));
+    let plugins = obj.entry("plugin").or_insert_with(|| serde_json::json!([]));
     let plugin_list = plugins.as_array_mut().ok_or_else(|| {
         WorkspaceControlError::Parse("opencode.json plugin field is not an array".into())
     })?;
@@ -1054,6 +1095,14 @@ mod tests {
         )
         .unwrap();
         assert!(cfg.get("permission").is_some());
+        assert_eq!(
+            cfg["mcp"][REMOTE_TOOLS_MCP_SERVER_NAME]["enabled"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            cfg["mcp"][REMOTE_TOOLS_MCP_SERVER_NAME]["command"][1],
+            serde_json::json!("remote-tools-mcp")
+        );
 
         assert!(dir
             .path()

--- a/docs/remote-tools.md
+++ b/docs/remote-tools.md
@@ -5,22 +5,22 @@ Agent-side tools that execute on the TeamClaw **client** (Chrome extension, futu
 ## Architecture
 
 ```
-Agent → amuxd remote-tools-mcp (stdio) → daemon.sock → MQTT amux/{team}/{memberActor}/rpc/req
+Agent → amuxd remote-tools-mcp (stdio) → daemon.sock → remote_context_id lookup
+  → MQTT amux/{team}/{memberActor}/rpc/req
   → all online clients for that member actor → capable client replies, others stay silent
 ```
 
-- **Daemon** mounts remote MCP on session-bound `runtimeStart` when spawning a new agent process.
-- **Agent** learns which tools fit the current environment from tool descriptions (and future spawn env vars).
+- **Daemon** installs `amuxd-remote-tools` as a host-level MCP baseline before OpenCode/Codex hosts start.
+- **Agent** receives a per-turn `remote_context_id` instruction and must include it in remote-tool calls.
 - **packages/app** listens on `amux/{team}/{myActorId}/rpc/req`; clients without an executor **do not reply**.
 - **Extension** registers `get_page_dom` executor locally.
 
 ## Routing
 
-1. Each live runtime stores `remote_tool_member_id` — the human member whose browser/client should execute tools.
-2. **New spawn**: bind to `runtimeStart` requester.
-3. **Dedup / resume reuse**: rebind **only when `initial_prompt` is non-empty** (@mention engage). Passive `runtimeStart` (picker refresh, focus) does **not** steal routing.
-4. Tool invoke resolves: live runtime `remote_tool_member_id` → fallback `SessionRemoteTargetStore` (30min TTL).
-5. Daemon publishes one RPC to `amux/{team}/{memberActor}/rpc/req`.
+1. Prompt start creates a short-lived `remote_context_id` for `(runtime, ACP session, team, member actor)`.
+2. The next prompt injects instructions telling the model to pass that exact `remote_context_id`.
+3. MCP invoke resolves `remote_context_id` to the current member actor.
+4. Daemon publishes one RPC to `amux/{team}/{memberActor}/rpc/req`.
 
 ### Security
 
@@ -29,11 +29,11 @@ Agent → amuxd remote-tools-mcp (stdio) → daemon.sock → MQTT amux/{team}/{m
 
 ### Multi-member sessions
 
-When Bob @mentions the agent, routing binds to Bob. When Alice later @mentions, routing rebinds to Alice. A passive `runtimeStart` from the model picker without a user message does not change the bound member.
+When Bob sends a turn, that turn's `remote_context_id` routes to Bob. When Alice later sends a turn in the same agent session, her turn gets a different `remote_context_id` and routes to Alice. The MCP server stays shared at host level; only the tool-call argument selects the target client.
 
-### ACP session resume
+### ACP host reuse
 
-ACP resume is never disabled for remote tools. When a per-session MCP config file exists, `session/resume` receives the same `mcp_servers` as `session/new`, so daemon restarts can restore `get_page_dom` without forcing a new agent process.
+OpenCode/Codex keep a process-level MCP registry, so remote-tools MCP must not be refreshed by per-session ACP resume. The daemon ensures the host starts in the workspace with the inherent MCP config present; `session/resume` does not reattach remote-tools MCP. Host reuse for OpenCode/Codex is keyed by workspace path to avoid cross-workspace registry pollution.
 
 ## Adding a tool
 

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -23,6 +23,7 @@ import { useAuthStore } from "@/stores/auth-store";
 import { bumpSessionListLastMessage } from "@/lib/session-list-preview";
 import { useSessionListStore } from "@/stores/session-list-store";
 import { useEngagedAgentStore } from "@/stores/engaged-agent-store";
+import { useSessionParticipantStore } from "@/stores/session-participant-store";
 import { useUIStore } from "@/stores/ui";
 import { getBackend } from "@/lib/backend";
 import { expandPageLinkTokensInText } from "@/lib/expand-page-link-tokens";
@@ -194,7 +195,13 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
 
   // ── Session store selectors (reactive state only) ────────────────────
   const activeSessionId = useSessionSelectionStore(s => s.activeSessionId);
+  const ensureParticipants = useSessionParticipantStore(s => s.ensureParticipants);
   const sessionPermissionMode = useSessionPermissionMode(activeSessionId);
+
+  React.useEffect(() => {
+    if (!activeSessionId) return;
+    void ensureParticipants([activeSessionId]);
+  }, [activeSessionId, ensureParticipants]);
   const error = useSessionStore(s => s.error);
   const errorSessionId = useSessionStore(s => s.errorSessionId);
   const isConnected = useSessionStore(s => s.isConnected);

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -52,7 +52,11 @@ import { useEngagedAgentRuntimeMap } from "@/hooks/use-engaged-agent-runtime-map
 import { useEngagedAgentUiStates } from "@/hooks/use-engaged-agent-ui-states";
 import { useEnsureEngagedRuntimesOnSessionFocus } from "@/hooks/use-ensure-engaged-runtimes-on-session-focus";
 import { useReensureRuntimesOnMqttReconnect } from "@/hooks/use-reensure-runtimes-on-mqtt-reconnect";
-import { getCurrentDaemonAgent } from "@/lib/daemon-agent-admin";
+import {
+  quickChatLocalDaemonAgent,
+  quickChatWelcomeAgent,
+  useQuickChatReadiness,
+} from "@/hooks/use-quick-chat-readiness";
 import { buildPostSendSessionNotice } from "@/lib/session-agent-notice-text";
 import { useSessionNoticeStore } from "@/stores/session-notice-store";
 import { toMentionDeliverySnapshot } from "@/lib/session-agent-ui-state";
@@ -659,32 +663,16 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     [t],
   );
 
-  const [localDaemonAgent, setLocalDaemonAgent] = React.useState<AttachedAgent | null>(null);
-  const [localDaemonAgentLoading, setLocalDaemonAgentLoading] = React.useState(false);
+  const quickChatState = useQuickChatReadiness();
+  const { agent: welcomeQuickChatAgent, loading: welcomeQuickChatLoading } = React.useMemo(
+    () => quickChatWelcomeAgent(quickChatState),
+    [quickChatState],
+  );
+  const localDaemonAgent = React.useMemo(
+    () => quickChatLocalDaemonAgent(quickChatState),
+    [quickChatState],
+  );
   const [welcomeSessionStarting, setWelcomeSessionStarting] = React.useState(false);
-  React.useEffect(() => {
-    if (!sheetTeamId) {
-      setLocalDaemonAgent(null);
-      setLocalDaemonAgentLoading(false);
-      return;
-    }
-    let cancelled = false;
-    setLocalDaemonAgentLoading(true);
-    void getCurrentDaemonAgent(sheetTeamId).then((row) => {
-      if (cancelled) return;
-      setLocalDaemonAgent(
-        row ? { id: row.id, displayName: row.displayName } : null,
-      );
-      setLocalDaemonAgentLoading(false);
-    }).catch(() => {
-      if (cancelled) return;
-      setLocalDaemonAgent(null);
-      setLocalDaemonAgentLoading(false);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [sheetTeamId]);
 
   const [imageFiles, setImageFiles] = React.useState<File[]>([]);
   const [isRestoringArchived, setIsRestoringArchived] = React.useState(false);
@@ -1603,9 +1591,9 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
         await createSessionAndSendFirst(message, picks);
         return;
       }
-      if (localDaemonAgent) {
+      if (welcomeQuickChatAgent) {
         await createSessionAndSendFirst(message, {
-          agents: [{ id: localDaemonAgent.id, displayName: localDaemonAgent.displayName }],
+          agents: [{ id: welcomeQuickChatAgent.id, displayName: welcomeQuickChatAgent.displayName }],
           members: [],
         });
         return;
@@ -1790,10 +1778,10 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
   };
 
   const handleStartLocalAgentSession = React.useCallback(async () => {
-    if (welcomeSessionStarting || !localDaemonAgent) return;
+    if (welcomeSessionStarting || quickChatState.kind !== 'ready') return;
     setWelcomeSessionStarting(true);
     try {
-      const result = await createQuickSession();
+      const result = await createQuickSession(quickChatState.target);
       if (!result.ok) {
         showQuickSessionFailure(result.reason);
       }
@@ -1803,7 +1791,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     } finally {
       setWelcomeSessionStarting(false);
     }
-  }, [localDaemonAgent, showQuickSessionFailure, welcomeSessionStarting]);
+  }, [quickChatState, showQuickSessionFailure, welcomeSessionStarting]);
 
   // `createSessionAndSendFirst` is re-created every render and closes over
   // volatile values (sheetTeamId, selectedModelKey, resolved actor). The
@@ -1813,20 +1801,20 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
   createSessionAndSendFirstRef.current = createSessionAndSendFirst;
 
   const handleLocalAgentQuickAction = React.useCallback(async (messageText: string) => {
-    if (welcomeSessionStarting || !localDaemonAgent) return;
+    if (welcomeSessionStarting || !welcomeQuickChatAgent) return;
     setWelcomeSessionStarting(true);
     try {
       await createSessionAndSendFirstRef.current(
         { text: messageText, mentions: [] },
         {
-          agents: [{ id: localDaemonAgent.id, displayName: localDaemonAgent.displayName }],
+          agents: [{ id: welcomeQuickChatAgent.id, displayName: welcomeQuickChatAgent.displayName }],
           members: [],
         },
       );
     } finally {
       setWelcomeSessionStarting(false);
     }
-  }, [localDaemonAgent, welcomeSessionStarting]);
+  }, [welcomeQuickChatAgent, welcomeSessionStarting]);
 
   const handleStartDraftSession = React.useCallback(async () => {
     if (welcomeSessionStarting || !draftPreselectedActor) return;
@@ -1947,8 +1935,8 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     if (!compact) {
       return (
         <LocalAgentWelcomeEmptyState
-          agent={localDaemonAgent}
-          agentLoading={localDaemonAgentLoading}
+          agent={welcomeQuickChatAgent}
+          agentLoading={welcomeQuickChatLoading}
           starting={welcomeSessionStarting}
           onStartConversation={() => void handleStartLocalAgentSession()}
           onQuickAction={(message) => void handleLocalAgentQuickAction(message)}
@@ -1964,7 +1952,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
         )}
       >
         <h2 className="mb-1 text-sm font-semibold">
-          {localDaemonAgent?.displayName ?? t("chat.agent", "Agent")}
+          {welcomeQuickChatAgent?.displayName ?? t("chat.agent", "Agent")}
         </h2>
         <p className="text-xs text-muted-foreground">
           {t("chat.askAboutFile", "Ask questions about the file")}
@@ -1975,8 +1963,8 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     compact,
     t,
     draftPreselectedActor,
-    localDaemonAgent,
-    localDaemonAgentLoading,
+    welcomeQuickChatAgent,
+    welcomeQuickChatLoading,
     welcomeSessionStarting,
     handleStartDraftSession,
     handleStartLocalAgentSession,

--- a/packages/app/src/hooks/__tests__/use-quick-chat-readiness.test.ts
+++ b/packages/app/src/hooks/__tests__/use-quick-chat-readiness.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import {
   QUICK_CHAT_STUCK_RETRY_MS,
+  quickChatLocalDaemonAgent,
+  quickChatWelcomeAgent,
   useQuickChatReadiness,
 } from '../use-quick-chat-readiness'
 
@@ -266,5 +268,50 @@ describe('useQuickChatReadiness', () => {
 
     expect(resolveQuickChatTarget).toHaveBeenCalledTimes(callsAfterReady)
     expect(result.current).toEqual({ kind: 'ready', target: readyTarget })
+  })
+})
+
+describe('quickChatWelcomeAgent', () => {
+  it('maps loading to spinner state', () => {
+    expect(quickChatWelcomeAgent({ kind: 'loading' })).toEqual({
+      agent: null,
+      loading: true,
+    })
+  })
+
+  it('maps ready target to welcome agent', () => {
+    expect(
+      quickChatWelcomeAgent({
+        kind: 'ready',
+        target: { agentId: 'a-1', displayName: 'MACPRO', source: 'team_default' },
+      }),
+    ).toEqual({
+      agent: { id: 'a-1', displayName: 'MACPRO' },
+      loading: false,
+    })
+  })
+
+  it('maps no_agent to offline welcome', () => {
+    expect(quickChatWelcomeAgent({ kind: 'no_agent' })).toEqual({
+      agent: null,
+      loading: false,
+    })
+  })
+})
+
+describe('quickChatLocalDaemonAgent', () => {
+  it('returns agent only for local source', () => {
+    expect(
+      quickChatLocalDaemonAgent({
+        kind: 'ready',
+        target: { agentId: 'a-1', displayName: 'MACPRO', source: 'local' },
+      }),
+    ).toEqual({ id: 'a-1', displayName: 'MACPRO' })
+    expect(
+      quickChatLocalDaemonAgent({
+        kind: 'ready',
+        target: { agentId: 'a-1', displayName: 'MACPRO', source: 'team_default' },
+      }),
+    ).toBeNull()
   })
 })

--- a/packages/app/src/hooks/use-quick-chat-readiness.ts
+++ b/packages/app/src/hooks/use-quick-chat-readiness.ts
@@ -14,6 +14,35 @@ export type QuickChatState =
   | { kind: 'no_agent' }
   | { kind: 'ready'; target: QuickChatTarget }
 
+export type QuickChatWelcomeAgent = {
+  id: string
+  displayName: string
+}
+
+/** Map quick-chat readiness to welcome-page agent + loading (NavRail uses the same source). */
+export function quickChatWelcomeAgent(state: QuickChatState): {
+  agent: QuickChatWelcomeAgent | null
+  loading: boolean
+} {
+  if (state.kind === 'loading') return { agent: null, loading: true }
+  if (state.kind === 'ready') {
+    return {
+      agent: {
+        id: state.target.agentId,
+        displayName: state.target.displayName,
+      },
+      loading: false,
+    }
+  }
+  return { agent: null, loading: false }
+}
+
+/** Strict local daemon only — for "switch to local agent" in session banners. */
+export function quickChatLocalDaemonAgent(state: QuickChatState): QuickChatWelcomeAgent | null {
+  if (state.kind !== 'ready' || state.target.source !== 'local') return null
+  return { id: state.target.agentId, displayName: state.target.displayName }
+}
+
 export function useQuickChatReadiness(): QuickChatState {
   const teamId = useCurrentTeamStore((s) => s.team?.id ?? null)
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)

--- a/packages/app/src/lib/remote-tools/rpc-server.test.ts
+++ b/packages/app/src/lib/remote-tools/rpc-server.test.ts
@@ -46,8 +46,6 @@ vi.mock('@/stores/actor-directory-store', () => ({
   },
 }))
 
-const mockEnsureParticipants = vi.hoisted(() => vi.fn(async () => undefined))
-
 vi.mock('@/stores/session-participant-store', () => ({
   useSessionParticipantStore: {
     getState: () => ({
@@ -155,6 +153,41 @@ describe('remote-tools rpc-server', () => {
     expect(text).toContain('forbidden')
   })
 
+  it('replies forbidden when authorization throws', async () => {
+    registerExecutor(TOOL_GET_PAGE_DOM, async () => ({ ok: true }))
+    mockEnsureParticipants.mockRejectedValueOnce(new Error('participants unavailable'))
+    let handler: ((env: { topic: string; bytes: ArrayBuffer }) => void) | undefined
+    mockListen.mockImplementation(async (fn) => {
+      handler = fn
+      return () => undefined
+    })
+
+    await initRemoteToolsRpcServer({ teamId: 'team-1', actorId: 'actor-1' })
+
+    const request = create(RpcRequestSchema, {
+      requestId: 'req-auth-error',
+      requesterActorId: 'daemon-1',
+      method: {
+        case: 'remoteToolInvoke',
+        value: create(RemoteToolInvokeRequestSchema, {
+          sessionId: 'sess-1',
+          toolName: TOOL_GET_PAGE_DOM,
+          argumentsJson: '{}',
+        }),
+      },
+    })
+
+    handler?.({
+      topic: 'amux/team-1/actor-1/rpc/req',
+      bytes: toBinary(RpcRequestSchema, request).buffer,
+    })
+
+    await vi.waitFor(() => expect(mockPublish).toHaveBeenCalled())
+    const text = new TextDecoder().decode(mockPublish.mock.calls[0][1] as Uint8Array)
+    expect(text).toContain('forbidden')
+    expect(text).toContain('remote tool request authorization failed')
+  })
+
   it('dispatches to registered executor', async () => {
     registerExecutor(TOOL_GET_PAGE_DOM, async () => ({ ok: true }))
     let handler: ((env: { topic: string; bytes: ArrayBuffer }) => void) | undefined
@@ -189,7 +222,8 @@ describe('remote-tools rpc-server', () => {
     expect(text).toContain('"ok":true')
   })
 
-  it('drops non-agent requester before loading participants', async () => {
+  it('rejects non-agent requester before loading participants', async () => {
+    registerExecutor(TOOL_GET_PAGE_DOM, async () => ({ ok: true }))
     let handler: ((env: { topic: string; bytes: ArrayBuffer }) => void) | undefined
     mockListen.mockImplementation(async (fn) => {
       handler = fn
@@ -218,6 +252,8 @@ describe('remote-tools rpc-server', () => {
 
     await new Promise((r) => setTimeout(r, 20))
     expect(mockEnsureParticipants).not.toHaveBeenCalled()
-    expect(mockPublish).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(mockPublish).toHaveBeenCalled())
+    const text = new TextDecoder().decode(mockPublish.mock.calls[0][1] as Uint8Array)
+    expect(text).toContain('forbidden')
   })
 })

--- a/packages/app/src/lib/remote-tools/rpc-server.test.ts
+++ b/packages/app/src/lib/remote-tools/rpc-server.test.ts
@@ -1,15 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockSubscribe, mockPublish, mockListen } = vi.hoisted(() => ({
+const { mockSubscribe, mockPublish, mockListen, mockEnsureParticipants, mockListParticipants } = vi.hoisted(() => ({
   mockSubscribe: vi.fn(async () => undefined),
   mockPublish: vi.fn(async () => undefined),
   mockListen: vi.fn(async () => () => undefined),
+  mockEnsureParticipants: vi.fn(async () => undefined),
+  mockListParticipants: vi.fn(async () => []),
 }))
 
 vi.mock('@/lib/mqtt-bridge', () => ({
   mqttSubscribe: mockSubscribe,
   mqttPublish: mockPublish,
   listenForEnvelopes: mockListen,
+}))
+
+vi.mock('@/lib/backend', () => ({
+  getBackend: () => ({
+    actors: {
+      getActorDirectoryEntry: vi.fn(async () => null),
+    },
+    sessionMembers: {
+      listParticipants: mockListParticipants,
+    },
+  }),
 }))
 
 vi.mock('@/stores/actor-directory-store', () => ({
@@ -75,7 +88,7 @@ describe('remote-tools rpc-server', () => {
     expect(mockSubscribe).toHaveBeenCalledWith('amux/team-1/actor-1/rpc/req')
   })
 
-  it('stays silent when executor missing', async () => {
+  it('replies unsupported_platform when executor missing', async () => {
     let handler: ((env: { topic: string; bytes: ArrayBuffer }) => void) | undefined
     mockListen.mockImplementation(async (fn) => {
       handler = fn
@@ -102,8 +115,44 @@ describe('remote-tools rpc-server', () => {
       bytes: toBinary(RpcRequestSchema, request).buffer,
     })
 
-    await new Promise((r) => setTimeout(r, 20))
-    expect(mockPublish).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(mockPublish).toHaveBeenCalled())
+    expect(mockEnsureParticipants).not.toHaveBeenCalled()
+    const text = new TextDecoder().decode(mockPublish.mock.calls[0][1] as Uint8Array)
+    expect(text).toContain('unsupported_platform')
+  })
+
+  it('replies forbidden when executor exists but request is not allowed', async () => {
+    registerExecutor(TOOL_GET_PAGE_DOM, async () => ({ ok: true }))
+    let handler: ((env: { topic: string; bytes: ArrayBuffer }) => void) | undefined
+    mockListen.mockImplementation(async (fn) => {
+      handler = fn
+      return () => undefined
+    })
+
+    await initRemoteToolsRpcServer({ teamId: 'team-1', actorId: 'actor-1' })
+
+    const request = create(RpcRequestSchema, {
+      requestId: 'req-forbidden',
+      requesterActorId: 'daemon-1',
+      method: {
+        case: 'remoteToolInvoke',
+        value: create(RemoteToolInvokeRequestSchema, {
+          sessionId: 'sess-unknown',
+          toolName: TOOL_GET_PAGE_DOM,
+          argumentsJson: '{}',
+        }),
+      },
+    })
+
+    handler?.({
+      topic: 'amux/team-1/actor-1/rpc/req',
+      bytes: toBinary(RpcRequestSchema, request).buffer,
+    })
+
+    await vi.waitFor(() => expect(mockPublish).toHaveBeenCalled())
+    expect(mockEnsureParticipants).toHaveBeenCalledWith(['sess-unknown'])
+    const text = new TextDecoder().decode(mockPublish.mock.calls[0][1] as Uint8Array)
+    expect(text).toContain('forbidden')
   })
 
   it('dispatches to registered executor', async () => {

--- a/packages/app/src/lib/remote-tools/rpc-server.ts
+++ b/packages/app/src/lib/remote-tools/rpc-server.ts
@@ -8,11 +8,9 @@ import {
 } from '@/lib/proto/teamclaw_pb'
 import { listenForEnvelopes, mqttPublish, mqttSubscribe, type IncomingEnvelope } from '@/lib/mqtt-bridge'
 
-import { useSessionParticipantStore } from '@/stores/session-participant-store'
-
 import { getExecutor } from './registry'
 import { REMOTE_TOOL_ERROR } from './types'
-import { isAgentRequesterForRemoteToolRequest, isAllowedRemoteToolRequest } from './validate-request'
+import { authorizeRemoteToolRequest } from './validate-request'
 
 type RpcServerState = {
   teamId: string
@@ -71,13 +69,40 @@ function handleEnvelope(env: IncomingEnvelope): void {
     }
     if (request.method.case !== 'remoteToolInvoke') return
     const invoke = request.method.value
-    if (!isAgentRequesterForRemoteToolRequest(teamId, request)) return
-    const sessionId = invoke.sessionId.trim()
-    if (sessionId) {
-      await useSessionParticipantStore.getState().ensureParticipants([sessionId])
+    const toolName = invoke.toolName
+
+    // Incapable clients (desktop) must skip or reply unsupported_platform so
+    // daemon keeps waiting for the extension — never reply forbidden here.
+    const exec = getExecutor(toolName)
+    if (!exec) {
+      await publishRpcResponse(
+        request,
+        buildRemoteToolResponse(
+          request,
+          false,
+          '',
+          REMOTE_TOOL_ERROR.unsupportedPlatform,
+          `tool not supported on this client: ${toolName}`,
+        ),
+      )
+      return
     }
-    if (!isAllowedRemoteToolRequest(teamId, request, invoke)) return
-    const response = await dispatchRemoteToolInvoke(request, invoke.toolName, invoke.argumentsJson)
+
+    if (!(await authorizeRemoteToolRequest(teamId, request, invoke))) {
+      await publishRpcResponse(
+        request,
+        buildRemoteToolResponse(
+          request,
+          false,
+          '',
+          REMOTE_TOOL_ERROR.forbidden,
+          'remote tool request not allowed for this session',
+        ),
+      )
+      return
+    }
+
+    const response = await dispatchRemoteToolInvoke(request, toolName, invoke.argumentsJson, exec)
     if (!response) return
     await publishRpcResponse(request, response)
   })()
@@ -87,12 +112,8 @@ async function dispatchRemoteToolInvoke(
   request: RpcRequest,
   toolName: string,
   argumentsJson: string,
+  exec: NonNullable<ReturnType<typeof getExecutor>>,
 ): Promise<RpcResponse | null> {
-  const exec = getExecutor(toolName)
-  if (!exec) {
-    return null
-  }
-
   let args: Record<string, unknown> = {}
   if (argumentsJson.trim()) {
     try {

--- a/packages/app/src/lib/remote-tools/rpc-server.ts
+++ b/packages/app/src/lib/remote-tools/rpc-server.ts
@@ -88,7 +88,24 @@ function handleEnvelope(env: IncomingEnvelope): void {
       return
     }
 
-    if (!(await authorizeRemoteToolRequest(teamId, request, invoke))) {
+    let authorized = false
+    try {
+      authorized = await authorizeRemoteToolRequest(teamId, request, invoke)
+    } catch {
+      await publishRpcResponse(
+        request,
+        buildRemoteToolResponse(
+          request,
+          false,
+          '',
+          REMOTE_TOOL_ERROR.forbidden,
+          'remote tool request authorization failed',
+        ),
+      )
+      return
+    }
+
+    if (!authorized) {
       await publishRpcResponse(
         request,
         buildRemoteToolResponse(

--- a/packages/app/src/lib/remote-tools/types.ts
+++ b/packages/app/src/lib/remote-tools/types.ts
@@ -28,4 +28,5 @@ export const REMOTE_TOOL_ERROR = {
   unsupportedPlatform: 'unsupported_platform',
   unknownTool: 'unknown_tool',
   executorError: 'executor_error',
+  forbidden: 'forbidden',
 } as const

--- a/packages/app/src/lib/remote-tools/validate-request.test.ts
+++ b/packages/app/src/lib/remote-tools/validate-request.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from '@bufbuild/protobuf'
 import {
   RemoteToolInvokeRequestSchema,
@@ -8,12 +8,29 @@ import { useActorDirectoryStore } from '@/stores/actor-directory-store'
 import { useSessionParticipantStore } from '@/stores/session-participant-store'
 
 import {
+  authorizeRemoteToolRequest,
   isAgentRequesterForRemoteToolRequest,
   isAllowedRemoteToolRequest,
 } from './validate-request'
 
+const mockGetActorDirectoryEntry = vi.fn()
+const mockListParticipants = vi.fn()
+
+vi.mock('@/lib/backend', () => ({
+  getBackend: () => ({
+    actors: {
+      getActorDirectoryEntry: mockGetActorDirectoryEntry,
+    },
+    sessionMembers: {
+      listParticipants: mockListParticipants,
+    },
+  }),
+}))
+
 describe('isAllowedRemoteToolRequest', () => {
   beforeEach(() => {
+    mockGetActorDirectoryEntry.mockReset()
+    mockListParticipants.mockReset()
     useActorDirectoryStore.setState({ byTeam: {}, activeTeamId: null })
     useSessionParticipantStore.setState({
       participantsBySession: {},
@@ -188,5 +205,111 @@ describe('isAllowedRemoteToolRequest', () => {
     expect(
       isAllowedRemoteToolRequest('team-1', request, request.method.value!),
     ).toBe(true)
+  })
+})
+
+describe('authorizeRemoteToolRequest', () => {
+  beforeEach(() => {
+    mockGetActorDirectoryEntry.mockReset()
+    mockListParticipants.mockReset()
+    useActorDirectoryStore.setState({ byTeam: {}, activeTeamId: null })
+    useSessionParticipantStore.setState({
+      participantsBySession: {},
+      loadingBySession: {},
+      errorBySession: {},
+    })
+  })
+
+  it('falls back to Cloud API when participants cache is empty', async () => {
+    useActorDirectoryStore.setState({
+      byTeam: {
+        'team-1': {
+          actors: [
+            {
+              id: 'agent-1',
+              actor_type: 'agent',
+              display_name: 'Bot',
+              member_status: null,
+              agent_status: 'active',
+              last_active_at: null,
+            },
+          ],
+          loading: false,
+          error: false,
+          started: true,
+        },
+      },
+      activeTeamId: 'team-1',
+    })
+    useSessionParticipantStore.setState({
+      participantsBySession: { 'sess-1': [] },
+      loadingBySession: {},
+      errorBySession: {},
+    })
+    mockListParticipants.mockResolvedValue([
+      {
+        id: 'agent-1',
+        actor_type: 'agent',
+        display_name: 'Bot',
+        avatar_url: null,
+      },
+    ])
+
+    const request = create(RpcRequestSchema, {
+      requesterActorId: 'agent-1',
+      method: {
+        case: 'remoteToolInvoke',
+        value: create(RemoteToolInvokeRequestSchema, {
+          sessionId: 'sess-1',
+          toolName: 'get_page_dom',
+          argumentsJson: '{}',
+        }),
+      },
+    })
+
+    await expect(
+      authorizeRemoteToolRequest('team-1', request, request.method.value!),
+    ).resolves.toBe(true)
+    expect(mockListParticipants).toHaveBeenCalledWith('sess-1')
+  })
+
+  it('falls back to actor directory API when store is cold', async () => {
+    mockGetActorDirectoryEntry.mockResolvedValue({
+      id: 'agent-1',
+      actor_type: 'agent',
+      display_name: 'Bot',
+      avatar_url: null,
+    })
+    useSessionParticipantStore.setState({
+      participantsBySession: {
+        'sess-1': [
+          {
+            actorId: 'agent-1',
+            displayName: 'Bot',
+            avatarUrl: null,
+            isAgent: true,
+          },
+        ],
+      },
+      loadingBySession: {},
+      errorBySession: {},
+    })
+
+    const request = create(RpcRequestSchema, {
+      requesterActorId: 'agent-1',
+      method: {
+        case: 'remoteToolInvoke',
+        value: create(RemoteToolInvokeRequestSchema, {
+          sessionId: 'sess-1',
+          toolName: 'get_page_dom',
+          argumentsJson: '{}',
+        }),
+      },
+    })
+
+    await expect(
+      authorizeRemoteToolRequest('team-1', request, request.method.value!),
+    ).resolves.toBe(true)
+    expect(mockGetActorDirectoryEntry).toHaveBeenCalledWith('agent-1')
   })
 })

--- a/packages/app/src/lib/remote-tools/validate-request.ts
+++ b/packages/app/src/lib/remote-tools/validate-request.ts
@@ -1,4 +1,5 @@
 import type { RemoteToolInvokeRequest, RpcRequest } from '@/lib/proto/teamclaw_pb'
+import { getBackend } from '@/lib/backend'
 import { useActorDirectoryStore } from '@/stores/actor-directory-store'
 import { useSessionParticipantStore } from '@/stores/session-participant-store'
 
@@ -8,14 +9,27 @@ export function isAgentRequesterForRemoteToolRequest(
 ): boolean {
   const requester = request.requesterActorId.trim()
   if (!requester) return false
+  return requesterIsAgentInDirectory(teamId, requester)
+}
+
+function requesterIsAgentInDirectory(teamId: string, requester: string): boolean {
   const actors = useActorDirectoryStore.getState().byTeam[teamId]?.actors ?? []
   const requesterRow = actors.find((a) => a.id === requester)
-  return Boolean(requesterRow && requesterRow.actor_type === 'agent')
+  return requesterRow?.actor_type === 'agent'
+}
+
+function requesterIsAgentInParticipants(
+  participants: Array<{ actorId: string; isAgent: boolean }>,
+  requester: string,
+): boolean {
+  return participants.some((p) => p.actorId === requester && p.isAgent)
 }
 
 /**
  * Reject forged member→member rpc/req injections. Legitimate remote-tool calls
  * are published by the session's agent daemon (`requester_actor_id` = agent).
+ *
+ * Sync check — use only when stores are already warm (tests).
  */
 export function isAllowedRemoteToolRequest(
   teamId: string,
@@ -28,7 +42,7 @@ export function isAllowedRemoteToolRequest(
   const sessionId = invoke.sessionId.trim()
   if (!sessionId) return false
 
-  if (!isAgentRequesterForRemoteToolRequest(teamId, request)) {
+  if (!requesterIsAgentInDirectory(teamId, requester)) {
     return false
   }
 
@@ -38,5 +52,43 @@ export function isAllowedRemoteToolRequest(
     return false
   }
 
-  return participants.some((p) => p.actorId === requester && p.isAgent)
+  return requesterIsAgentInParticipants(participants, requester)
+}
+
+/**
+ * Authorize a remote-tool RPC on capable clients (extension). Loads participants
+ * from Cloud API when the store is cold or poisoned with an empty cache entry.
+ */
+export async function authorizeRemoteToolRequest(
+  teamId: string,
+  request: RpcRequest,
+  invoke: RemoteToolInvokeRequest,
+): Promise<boolean> {
+  const requester = request.requesterActorId.trim()
+  if (!requester) return false
+
+  const sessionId = invoke.sessionId.trim()
+  if (!sessionId) return false
+
+  let requesterIsAgent = requesterIsAgentInDirectory(teamId, requester)
+  if (!requesterIsAgent) {
+    const row = await getBackend().actors.getActorDirectoryEntry(requester)
+    requesterIsAgent = row?.actor_type === 'agent'
+  }
+  if (!requesterIsAgent) return false
+
+  await useSessionParticipantStore.getState().ensureParticipants([sessionId])
+  let participants =
+    useSessionParticipantStore.getState().participantsBySession[sessionId]
+  if (!participants || participants.length === 0) {
+    const apiRows = await getBackend().sessionMembers.listParticipants(sessionId)
+    participants = apiRows.map((actor) => ({
+      actorId: actor.id,
+      displayName: actor.display_name ?? actor.id,
+      avatarUrl: actor.avatar_url ?? null,
+      isAgent: actor.actor_type === 'agent',
+    }))
+  }
+
+  return requesterIsAgentInParticipants(participants, requester)
 }

--- a/packages/app/src/stores/session-participant-store.test.ts
+++ b/packages/app/src/stores/session-participant-store.test.ts
@@ -1,16 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSessionParticipantStore } from "./session-participant-store";
 
-const listParticipants = vi.hoisted(() => vi.fn());
+const { mockListParticipants, mockIsTauri } = vi.hoisted(() => ({
+  mockListParticipants: vi.fn(async () => [] as Array<{
+    id: string;
+    actor_type: string | null;
+    display_name: string | null;
+    avatar_url: string | null;
+  }>),
+  mockIsTauri: vi.fn(() => true),
+}));
 
 vi.mock("@/lib/utils", () => ({
-  isTauri: vi.fn(() => true),
+  isTauri: mockIsTauri,
 }));
 
 vi.mock("@/lib/backend", () => ({
   getBackend: () => ({
     sessionMembers: {
-      listParticipants,
+      listParticipants: mockListParticipants,
     },
   }),
 }));
@@ -34,20 +42,20 @@ vi.mock("@/lib/sync/session-participant-sync", () => ({
   syncParticipantsForSession: vi.fn(async () => 1),
 }));
 
-beforeEach(async () => {
-  const { isTauri } = await import("@/lib/utils");
-  vi.mocked(isTauri).mockReturnValue(true);
-  listParticipants.mockReset();
+beforeEach(() => {
+  mockIsTauri.mockReturnValue(true);
+  mockListParticipants.mockResolvedValue([]);
   useSessionParticipantStore.setState({
     participantsBySession: {},
     loadingBySession: {},
     errorBySession: {},
   });
   vi.clearAllMocks();
+  mockIsTauri.mockReturnValue(true);
 });
 
 describe("session-participant-store", () => {
-  it("loads participants from the local cache", async () => {
+  it("loads participants from the local cache on desktop", async () => {
     await useSessionParticipantStore.getState().ensureParticipants(["s1"]);
 
     expect(useSessionParticipantStore.getState().participantsBySession.s1).toEqual([
@@ -60,6 +68,71 @@ describe("session-participant-store", () => {
       {
         actorId: "agent-1",
         displayName: "Agent One",
+        avatarUrl: null,
+        isAgent: true,
+      },
+    ]);
+  });
+
+  it("loads participants from Cloud API on extension/web", async () => {
+    mockIsTauri.mockReturnValue(false);
+    mockListParticipants.mockResolvedValue([
+      {
+        id: "member-1",
+        actor_type: "member",
+        display_name: "Alice",
+        avatar_url: null,
+      },
+      {
+        id: "daemon-1",
+        actor_type: "agent",
+        display_name: "MACPRO",
+        avatar_url: null,
+      },
+    ]);
+
+    await useSessionParticipantStore.getState().ensureParticipants(["s1"]);
+
+    expect(mockListParticipants).toHaveBeenCalledWith("s1");
+    expect(useSessionParticipantStore.getState().participantsBySession.s1).toEqual([
+      {
+        actorId: "member-1",
+        displayName: "Alice",
+        avatarUrl: null,
+        isAgent: false,
+      },
+      {
+        actorId: "daemon-1",
+        displayName: "MACPRO",
+        avatarUrl: null,
+        isAgent: true,
+      },
+    ]);
+  });
+
+  it("retries empty cache on extension/web", async () => {
+    mockIsTauri.mockReturnValue(false);
+    useSessionParticipantStore.setState({
+      participantsBySession: { s1: [] },
+      loadingBySession: {},
+      errorBySession: {},
+    });
+    mockListParticipants.mockResolvedValue([
+      {
+        id: "daemon-1",
+        actor_type: "agent",
+        display_name: "MACPRO",
+        avatar_url: null,
+      },
+    ]);
+
+    await useSessionParticipantStore.getState().ensureParticipants(["s1"]);
+
+    expect(mockListParticipants).toHaveBeenCalledWith("s1");
+    expect(useSessionParticipantStore.getState().participantsBySession.s1).toEqual([
+      {
+        actorId: "daemon-1",
+        displayName: "MACPRO",
         avatarUrl: null,
         isAgent: true,
       },
@@ -86,9 +159,8 @@ describe("session-participant-store", () => {
   });
 
   it("loads participants from Cloud API in extension/web mode", async () => {
-    const { isTauri } = await import("@/lib/utils");
-    vi.mocked(isTauri).mockReturnValue(false);
-    listParticipants.mockResolvedValue([
+    mockIsTauri.mockReturnValue(false);
+    mockListParticipants.mockResolvedValue([
       {
         id: "member-1",
         team_id: "team-1",
@@ -105,7 +177,7 @@ describe("session-participant-store", () => {
 
     await useSessionParticipantStore.getState().ensureParticipants(["s1"]);
 
-    expect(listParticipants).toHaveBeenCalledWith("s1");
+    expect(mockListParticipants).toHaveBeenCalledWith("s1");
     expect(useSessionParticipantStore.getState().participantsBySession.s1).toEqual([
       {
         actorId: "member-1",

--- a/packages/app/src/stores/session-participant-store.ts
+++ b/packages/app/src/stores/session-participant-store.ts
@@ -72,11 +72,14 @@ export const useSessionParticipantStore = create<State>((set, get) => ({
   errorBySession: {},
   ensureParticipants: async (sessionIds) => {
     const unique = Array.from(new Set(sessionIds)).filter(Boolean);
-    const missing = unique.filter(
-      (sessionId) =>
-        get().participantsBySession[sessionId] === undefined &&
-        !get().loadingBySession[sessionId],
-    );
+    const missing = unique.filter((sessionId) => {
+      if (get().loadingBySession[sessionId]) return false
+      const cached = get().participantsBySession[sessionId]
+      if (cached === undefined) return true
+      // Extension/web: retry empty cache (legacy loadSessionParticipants stub).
+      if (!isTauri() && cached.length === 0) return true
+      return false
+    });
     if (missing.length === 0) return;
 
     set((state) => ({

--- a/scripts/amuxdctl.sh
+++ b/scripts/amuxdctl.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Match scripts/run-daemon.js (pnpm daemon:run) — never use stale target/debug/amuxd.
+CARGO_TARGET_DIR="${ROOT_DIR}/.cargo-target"
+export CARGO_TARGET_DIR
 CONFIG_DIR="${HOME}/Library/Application Support/amux"
 LOG_DIR="${CONFIG_DIR}/logs"
 LOG_FILE="${LOG_DIR}/amuxd.log"
@@ -20,14 +23,19 @@ Commands:
   logs        Tail the daemon log file
 
 Options:
-  --release   Use target/release/amuxd (build if needed)
+  --release   Use .cargo-target/release/amuxd (build if needed)
   --config P  Pass --config <path> to amuxd start
 
 Examples:
   scripts/amuxdctl.sh start
   scripts/amuxdctl.sh restart
+  RUST_LOG=amuxd=debug,agent_trace=info scripts/amuxdctl.sh restart
+  scripts/amuxdctl.sh logs
   scripts/amuxdctl.sh start --foreground
   scripts/amuxdctl.sh start --release --config "$HOME/Library/Application Support/amux/daemon.toml"
+
+Binary: .cargo-target/{debug,release}/amuxd (same as pnpm daemon:run; rebuilt on start/restart).
+Logs:   ~/Library/Application Support/amux/logs/amuxd.log
 EOF
 }
 
@@ -74,27 +82,31 @@ done
 
 cd "${ROOT_DIR}"
 
-ensure_binary() {
+amuxd_bin() {
+  printf '%s/%s/amuxd\n' "${CARGO_TARGET_DIR}" "$1"
+}
+
+cargo_build_amuxd() {
   local profile="$1"
-  local bin_path="${ROOT_DIR}/target/${profile}/amuxd"
-  if [[ ! -x "${bin_path}" ]]; then
-    echo "==> building amuxd (${profile})"
-    cargo build -p amuxd $( [[ "${profile}" == "release" ]] && printf '%s' --release )
-  fi
-  printf '%s\n' "${bin_path}"
+  echo "==> building amuxd (${profile}) → $(amuxd_bin "${profile}")"
+  cargo build -p amuxd $( [[ "${profile}" == "release" ]] && printf '%s' --release )
 }
 
 run_amuxd() {
   local profile="$1"
   shift
   local bin
-  bin="$(ensure_binary "${profile}")"
+  bin="$(amuxd_bin "${profile}")"
+  if [[ ! -x "${bin}" ]]; then
+    cargo_build_amuxd "${profile}"
+  fi
   "${bin}" "$@"
 }
 
 start_daemon() {
   mkdir -p "${LOG_DIR}"
   local profile="$1"
+  cargo_build_amuxd "${profile}"
   local start_args=(start)
   if [[ -n "${CONFIG_PATH}" ]]; then
     start_args+=(--config "${CONFIG_PATH}")

--- a/scripts/simulate-opencode-remote-tools-regression.sh
+++ b/scripts/simulate-opencode-remote-tools-regression.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+cargo test -p amuxd opencode_desktop_attach_does_not_drop_plugin_remote_tools -- --nocapture


### PR DESCRIPTION
## Summary
- Keep OpenCode remote-tools MCP host-level so desktop session attach does not drop plugin get_page_dom tools
- Add message-level remote tool context routing and safer requester/session authorization
- Add regression coverage for OpenCode remote-tools tool registration

## Test Plan
- scripts/simulate-opencode-remote-tools-regression.sh
- cargo check -p amuxd --message-format short
- pnpm --dir packages/app test:unit src/lib/remote-tools/validate-request.test.ts src/stores/session-participant-store.test.ts src/lib/remote-tools/rpc-server.test.ts