### PR TITLE
fix(deploy): retry git fetch and litellm pull on the ECS box

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -30,7 +30,19 @@ jobs:
             cd /opt/teamclaw
 
             echo "=== git pull ==="
-            git fetch origin main
+            # This ECS box reaches github.com over https unreliably: a bare fetch
+            # fails roughly 2 times in 5 with "GnuTLS recv error (-110)", and it
+            # burns ~90s stalling first. lowSpeed* aborts a stalled transfer after
+            # 20s so a retry can actually happen inside the job's timeout.
+            git config http.lowSpeedLimit 1000
+            git config http.lowSpeedTime 20
+            fetched=""
+            for i in 1 2 3 4 5 6 7 8; do
+              if git fetch origin main; then fetched=yes; echo "  fetch ok (attempt $i)"; break; fi
+              echo "  fetch attempt $i failed; retrying in 10s"
+              sleep 10
+            done
+            [ -n "$fetched" ] || { echo "git fetch failed after 8 attempts"; exit 1; }
             git reset --hard origin/main
 
             cd deploy/self-host
@@ -68,7 +80,20 @@ jobs:
             docker compose build fc
 
             echo "=== pull litellm (up --pull never will not fetch it) ==="
-            docker compose pull litellm
+            # Same flaky path to ghcr.io as the git fetch above; the image is
+            # ~500MB so a cold pull is slow and worth retrying rather than
+            # failing the whole deploy. Skipped once the image is present.
+            if docker image inspect ghcr.io/berriai/litellm-database:v1.83.3-stable >/dev/null 2>&1; then
+              echo "  litellm image already present"
+            else
+              pulled=""
+              for i in 1 2 3 4 5; do
+                if docker compose pull litellm; then pulled=yes; echo "  pull ok (attempt $i)"; break; fi
+                echo "  pull attempt $i failed; retrying in 15s"
+                sleep 15
+              done
+              [ -n "$pulled" ] || { echo "litellm image pull failed after 5 attempts"; exit 1; }
+            fi
 
             echo "=== up ==="
             docker compose up -d --pull never --remove-orphans


### PR DESCRIPTION
Both deploy runs triggered by #482 failed at the very first step:

```
fatal: unable to access 'https://github.com/different-ai-studio/teamclaw.git/':
GnuTLS recv error (-110): The TLS connection was non-properly terminated.
```

**This is not transient.** Measured from the ECS box itself, `git ls-remote` against github.com **fails 2 times out of 5**, and a stalled fetch hangs ~90s before erroring. A bare `git fetch` therefore gives every deploy a ~40% chance of failing outright — re-running is a coin flip, not a fix (I re-ran once; it failed identically).

## Changes

- `http.lowSpeedLimit`/`http.lowSpeedTime` abort a stalled transfer after 20s instead of stalling ~90s. This is what makes retrying viable inside the job timeout.
- `git fetch` gets 8 attempts.
- `docker compose pull litellm` reaches ghcr.io over the same flaky path and the image is ~500MB, so it retries too — and is **skipped when the image is already present**, since a cold pull from this region is slow enough that re-downloading it every deploy matters.

## Verification

- The same retry loop, run by hand on the box, **fetched successfully on attempt 2**.
- Workflow YAML parses; the embedded deploy script passes `sh -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)