### PR TITLE
feat(invites): match pending invites to an invitee's verified contact

### DIFF
--- a/docs/openapi/teamclaw-api.v1.yaml
+++ b/docs/openapi/teamclaw-api.v1.yaml
@@ -216,21 +216,63 @@ paths:
           application/json:
             schema:
               type: object
-              required: [actorType, displayName]
+              required: [kind, displayName]
               properties:
+                kind:
+                  type: string
+                  enum: [member, agent]
+                  description: >-
+                    `actorType` is accepted as a legacy alias.
                 actorType:
                   type: string
-                  enum: [agent, user, external]
+                  enum: [member, agent]
+                  deprecated: true
+                  description: Legacy alias for `kind`.
                 displayName:
                   type: string
                   minLength: 1
+                teamRole:
+                  type: string
+                  enum: [owner, admin, member]
+                  description: >-
+                    Required when `kind=member`. `role` is accepted as a legacy alias.
                 role:
                   type: string
-                expiresAt:
+                  deprecated: true
+                  description: Legacy alias for `teamRole`.
+                agentKind:
                   type:
                     - string
                     - "null"
-                  format: date-time
+                  description: Required when `kind=agent`.
+                ttlSeconds:
+                  type:
+                    - integer
+                    - "null"
+                  description: Invite lifetime. Defaults to 604800 (7 days); floored at 60.
+                targetActorId:
+                  type:
+                    - string
+                    - "null"
+                  format: uuid
+                  description: Re-invite an existing actor instead of creating a new one.
+                inviteEmail:
+                  type:
+                    - string
+                    - "null"
+                  format: email
+                  description: >-
+                    Optional invitee email, member invites only. When set, the invitee
+                    sees this invite via `listPendingInvites` after signing in with a
+                    matching verified email — no token needs to reach them. Re-inviting
+                    the same contact supersedes the previous pending invite.
+                invitePhone:
+                  type:
+                    - string
+                    - "null"
+                  description: >-
+                    Optional invitee phone, member invites only. Compared
+                    digit-normalized against the signed-in user's verified phone.
       responses:
         "201":
           description: Created invite.
@@ -241,21 +283,27 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [token, inviteId, expiresAt]
+                required: [token, expiresAt, deeplink]
                 properties:
                   token:
                     type: string
-                  inviteId:
-                    type: string
-                    format: uuid
                   expiresAt:
                     type:
                       - string
                       - "null"
                     format: date-time
+                  deeplink:
+                    type:
+                      - string
+                      - "null"
+                    description: "`amux://invite?token=…` — shareable out-of-band."
         "400":
           $ref: "#/components/responses/Error"
         "401":
+          $ref: "#/components/responses/Error"
+        # `upgrade_required`: the team is still in the shared default org, which is
+        # solo-only. Member invites need the account upgraded into its own org.
+        "403":
           $ref: "#/components/responses/Error"
   /v1/teams/{teamId}/members/{actorId}:
     delete:
@@ -880,6 +928,81 @@ paths:
         "400":
           $ref: "#/components/responses/Error"
         "401":
+          $ref: "#/components/responses/Error"
+  /v1/invites/pending:
+    get:
+      operationId: listPendingInvites
+      summary: List invites addressed to the caller's verified email/phone
+      description: >-
+        The contact path: invites created with `inviteEmail`/`invitePhone` matching
+        the caller's own verified contact, still pending, unexpired, and for a team
+        the caller has not already joined. Takes no contact parameter by design —
+        it reads the authenticated user's own identity, so it cannot be used to
+        probe which addresses have invites waiting. Anonymous sessions always get
+        an empty list, having no verified contact to match.
+      tags: [Invites]
+      responses:
+        "200":
+          description: Pending invites.
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PendingInvite"
+        "401":
+          $ref: "#/components/responses/Error"
+  /v1/invites/{inviteId}/accept:
+    post:
+      operationId: acceptPendingInvite
+      summary: Accept an invite addressed to the caller
+      description: >-
+        Joins the team, equivalent to claiming the invite's token. Only invites
+        visible via `listPendingInvites` can be accepted; anything else is a 404,
+        so "not yours" is indistinguishable from "not there".
+      tags: [Invites]
+      parameters:
+        - $ref: "#/components/parameters/InviteId"
+      responses:
+        "200":
+          description: Joined team.
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClaimInviteResult"
+        "401":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+        # Already a member, or the invite was declined/superseded/consumed.
+        "409":
+          $ref: "#/components/responses/Error"
+  /v1/invites/{inviteId}/decline:
+    post:
+      operationId: declinePendingInvite
+      summary: Decline an invite addressed to the caller
+      description: >-
+        Marks the invite declined. The row is retained so the inviter can see the
+        outcome; the token stops working.
+      tags: [Invites]
+      parameters:
+        - $ref: "#/components/parameters/InviteId"
+      responses:
+        "204":
+          description: Declined.
+        "401":
+          $ref: "#/components/responses/Error"
+        "404":
           $ref: "#/components/responses/Error"
   /v1/heartbeat:
     post:
@@ -3492,6 +3615,13 @@ components:
       required: true
       schema:
         type: string
+    InviteId:
+      name: inviteId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
     SessionId:
       name: sessionId
       in: path
@@ -3710,6 +3840,52 @@ components:
           type:
             - string
             - "null"
+    PendingInvite:
+      type: object
+      required: [inviteId, teamId]
+      properties:
+        inviteId:
+          type: string
+          format: uuid
+        teamId:
+          type: string
+          format: uuid
+        teamName:
+          type:
+            - string
+            - "null"
+        teamRole:
+          type:
+            - string
+            - "null"
+        displayName:
+          type:
+            - string
+            - "null"
+          description: The name the inviter typed for this person.
+        invitedByDisplayName:
+          type:
+            - string
+            - "null"
+        inviteEmail:
+          type:
+            - string
+            - "null"
+        invitePhone:
+          type:
+            - string
+            - "null"
+        expiresAt:
+          type:
+            - string
+            - "null"
+          format: date-time
+        matchedVia:
+          type:
+            - string
+            - "null"
+          enum: [email, phone, null]
+          description: Which of the caller's verified contacts this invite matched on.
     TeamWorkspaceConfig:
       type: object
       required: [teamId, defaultWorkspaceId]

--- a/packages/app/src/components/auth/AuthGate.tsx
+++ b/packages/app/src/components/auth/AuthGate.tsx
@@ -17,6 +17,7 @@ import { CloudApiError } from "@/lib/backend/cloud-api/http";
 import { humanizeFcError } from "@/lib/fc-error";
 import { markStartup } from "@/lib/startup-perf";
 import { TeamPicker } from "./TeamPicker";
+import { PendingInvitesDialog } from "@/components/auth/PendingInvitesDialog";
 import type { MembershipTeam } from "@/lib/backend";
 
 interface AuthGateProps {
@@ -126,6 +127,16 @@ export function AuthGate({ children }: AuthGateProps) {
     if (!session || session.user?.is_anonymous) return;
     if (!pendingInviteToken) return;
     void useAuthStore.getState().claimPendingInvite();
+  }, [session, pendingInviteToken]);
+
+  // Separate from the token replay above: these invites were addressed to the
+  // user's verified email/phone and matched server-side, so the user never had
+  // a link. Skipped while a token claim is queued — that invite is the one the
+  // user actually acted on, and joining it may satisfy the pending list anyway.
+  useEffect(() => {
+    if (!session || session.user?.is_anonymous) return;
+    if (pendingInviteToken) return;
+    void useAuthStore.getState().refreshPendingInvites();
   }, [session, pendingInviteToken]);
 
   // After auth: ensure the user belongs to at least one team. If not (fresh
@@ -368,5 +379,12 @@ export function AuthGate({ children }: AuthGateProps) {
   }
 
   markStartup("authgate:children");
-  return <>{children}</>;
+  // Rendered alongside the app rather than as a gate: an unaccepted invite is
+  // not a reason to withhold the workspace the user already has.
+  return (
+    <>
+      {children}
+      <PendingInvitesDialog />
+    </>
+  );
 }

--- a/packages/app/src/components/auth/PendingInvitesDialog.tsx
+++ b/packages/app/src/components/auth/PendingInvitesDialog.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { Loader2 } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { useAuthStore } from '@/stores/auth-store'
+
+/**
+ * Shown after sign-in when the server found invites addressed to the user's
+ * verified email or phone. Accepting is an explicit choice: an inviter knowing
+ * someone's address is not consent to join their team, so an invite waits here
+ * rather than adding the user to the team on their behalf.
+ *
+ * The token path (an invite link the user opened) does not come through here —
+ * opening the link IS the choice, and AuthGate claims it directly.
+ */
+export function PendingInvitesDialog() {
+  const { t } = useTranslation()
+  const invites = useAuthStore((s) => s.pendingInvites)
+  const [busyId, setBusyId] = React.useState<string | null>(null)
+  // Closing must not re-prompt on every render while the list is still
+  // populated; the invites stay pending server-side and reappear next sign-in.
+  const [dismissed, setDismissed] = React.useState(false)
+
+  const open = invites.length > 0 && !dismissed
+
+  const accept = async (inviteId: string) => {
+    setBusyId(inviteId)
+    const result = await useAuthStore.getState().acceptPendingInvite(inviteId)
+    setBusyId(null)
+    if (!result) {
+      const msg = useAuthStore.getState().errorMessage
+      toast.error(t('pendingInvite.acceptFailed', 'Failed to join team: {{msg}}', { msg: msg ?? '' }))
+      return
+    }
+    toast.success(t('pendingInvite.accepted', 'Joined the team'))
+  }
+
+  const decline = async (inviteId: string) => {
+    setBusyId(inviteId)
+    const ok = await useAuthStore.getState().declinePendingInvite(inviteId)
+    setBusyId(null)
+    if (!ok) {
+      const msg = useAuthStore.getState().errorMessage
+      toast.error(t('pendingInvite.declineFailed', 'Failed to decline: {{msg}}', { msg: msg ?? '' }))
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && setDismissed(true)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('pendingInvite.title', '你有团队邀请')}</DialogTitle>
+          <DialogDescription>
+            {t('pendingInvite.description', '以下团队邀请你加入。你可以选择接受或拒绝。')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          {invites.map((invite) => (
+            <div key={invite.inviteId} className="flex flex-col gap-2 rounded-md border border-border p-3">
+              <div className="text-sm font-medium text-foreground">
+                {invite.teamName ?? t('pendingInvite.unnamedTeam', 'Untitled team')}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {invite.invitedByDisplayName
+                  ? t('pendingInvite.invitedBy', '{{name}} 邀请你以 {{role}} 身份加入', {
+                      name: invite.invitedByDisplayName,
+                      role: invite.teamRole ?? 'member',
+                    })
+                  : t('pendingInvite.invitedAs', '邀请你以 {{role}} 身份加入', {
+                      role: invite.teamRole ?? 'member',
+                    })}
+              </div>
+              {invite.expiresAt && (
+                <div className="text-[11px] text-muted-foreground">
+                  {t('pendingInvite.expiresAt', 'Expires {{date}}', {
+                    date: new Date(invite.expiresAt).toLocaleString(),
+                  })}
+                </div>
+              )}
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => void decline(invite.inviteId)}
+                  disabled={busyId != null}
+                >
+                  {t('pendingInvite.decline', '拒绝')}
+                </Button>
+                <Button size="sm" onClick={() => void accept(invite.inviteId)} disabled={busyId != null}>
+                  {busyId === invite.inviteId && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  {t('pendingInvite.accept', '接受邀请')}
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/auth/__tests__/AuthGate.test.tsx
+++ b/packages/app/src/components/auth/__tests__/AuthGate.test.tsx
@@ -13,6 +13,10 @@ const { authState, currentTeamMock, backendMock } = vi.hoisted(() => ({
     hydrate: vi.fn(),
     pendingInviteToken: null as string | null,
     claimPendingInvite: vi.fn(),
+    // Contact-matched invites (PendingInvitesDialog). Empty by default so the
+    // dialog stays closed and these tests only exercise the gate itself.
+    pendingInvites: [] as unknown[],
+    refreshPendingInvites: vi.fn(),
   },
   currentTeamMock: {
     reloadAndSwitchTo: vi.fn(),

--- a/packages/app/src/components/sidebar/InviteActorDialog.tsx
+++ b/packages/app/src/components/sidebar/InviteActorDialog.tsx
@@ -39,6 +39,11 @@ export function InviteActorDialog({ open, onOpenChange, teamId }: InviteActorDia
   const [kind, setKind] = React.useState<InviteKind>('member')
   const [name, setName] = React.useState('')
   const [teamRole, setTeamRole] = React.useState<TeamRole>('member')
+  // Optional. When either is filled the invitee sees this invite waiting for
+  // them after signing in, so the link below becomes a convenience rather than
+  // the only way in.
+  const [email, setEmail] = React.useState('')
+  const [phone, setPhone] = React.useState('')
   const [agentKind] = React.useState<string>('daemon')
   const [submitting, setSubmitting] = React.useState(false)
   const [invite, setInvite] = React.useState<InviteCreated | null>(null)
@@ -51,6 +56,8 @@ export function InviteActorDialog({ open, onOpenChange, teamId }: InviteActorDia
     setKind('member')
     setName('')
     setTeamRole('member')
+    setEmail('')
+    setPhone('')
     setSubmitting(false)
     setInvite(null)
     setNeedsUpgrade(false)
@@ -77,6 +84,8 @@ export function InviteActorDialog({ open, onOpenChange, teamId }: InviteActorDia
             teamRole,
             ttlSeconds: null,
             targetActorId: null,
+            inviteEmail: email.trim() || null,
+            invitePhone: phone.trim() || null,
           })
         : await getBackend().teams.createTeamInvite({
             teamId: effectiveTeamId,
@@ -198,6 +207,40 @@ export function InviteActorDialog({ open, onOpenChange, teamId }: InviteActorDia
                       {r === 'member' ? t('invite.roleMember', 'Member') : t('invite.roleAdmin', 'Admin')}
                     </button>
                   ))}
+                </div>
+              </div>
+            )}
+            {kind === 'member' && (
+              <div className="flex flex-col gap-3 rounded-md border border-border p-3">
+                <p className="text-[11px] text-muted-foreground">
+                  {t(
+                    'invite.contactHint',
+                    '填写邮箱或手机号后，对方登录时会直接看到这个邀请，不用你再发链接。',
+                  )}
+                </p>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                    {t('invite.emailLabel', 'Email (optional)')}
+                  </label>
+                  <Input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder={t('invite.emailPlaceholder', 'name@example.com')}
+                    disabled={submitting}
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                    {t('invite.phoneLabel', 'Phone (optional)')}
+                  </label>
+                  <Input
+                    type="tel"
+                    value={phone}
+                    onChange={(e) => setPhone(e.target.value)}
+                    placeholder={t('invite.phonePlaceholder', '13800138000')}
+                    disabled={submitting}
+                  />
                 </div>
               </div>
             )}

--- a/packages/app/src/lib/backend/cloud-api/auth.ts
+++ b/packages/app/src/lib/backend/cloud-api/auth.ts
@@ -1,4 +1,4 @@
-import type { AuthBackend, AuthClaimResult, AuthSession, Unsubscribe } from "../types";
+import type { AuthBackend, AuthClaimResult, AuthSession, PendingInvite, Unsubscribe } from "../types";
 import { BackendError } from "../errors";
 import type { CloudApiClient } from "./http";
 import {
@@ -110,6 +110,27 @@ export function createAuthModule(
       // and surfaced via the team-share store; we no longer persist a local
       // `team_mode` into teamclaw.json after a join.
       return claim;
+    },
+    async listPendingInvites(): Promise<PendingInvite[]> {
+      const page = await client.get<{ items: PendingInvite[] }>("/v1/invites/pending");
+      return page?.items ?? [];
+    },
+    async acceptPendingInvite(inviteId: string): Promise<AuthClaimResult> {
+      const claim = await client.post<AuthClaimResult>(
+        `/v1/invites/${encodeURIComponent(inviteId)}/accept`,
+        {},
+      );
+      if (!claim) {
+        throw new BackendError({
+          category: "Unknown",
+          operation: "auth.acceptPendingInvite",
+          message: "Invite accept returned no team.",
+        });
+      }
+      return claim;
+    },
+    async declinePendingInvite(inviteId: string): Promise<void> {
+      await client.post<void>(`/v1/invites/${encodeURIComponent(inviteId)}/decline`, {});
     },
   };
 }

--- a/packages/app/src/lib/backend/cloud-api/teams.ts
+++ b/packages/app/src/lib/backend/cloud-api/teams.ts
@@ -78,6 +78,10 @@ export function createTeamsModule(client: CloudApiClient): TeamsBackend {
         agentKind: kind === "agent" ? input.agentKind : null,
         ttlSeconds: input.ttlSeconds ?? null,
         targetActorId: input.targetActorId ?? null,
+        // `in` rather than a plain read: the agent arms of TeamInviteInput have
+        // no contact fields, so the union needs narrowing before access.
+        inviteEmail: "inviteEmail" in input ? (input.inviteEmail ?? null) : null,
+        invitePhone: "invitePhone" in input ? (input.invitePhone ?? null) : null,
       };
       return mapInvite(await client.post<CloudInvite>(`/v1/teams/${encodeURIComponent(input.teamId)}/invites`, body));
     },

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -25,6 +25,26 @@ export interface AuthClaimResult {
   refreshToken: string | null;
 }
 
+/**
+ * An invite addressed to the signed-in user's verified email or phone, which
+ * they have not yet accepted or declined. Distinct from the token path: the
+ * server matched this to the user's own identity, so no link is involved.
+ */
+export interface PendingInvite {
+  inviteId: string;
+  teamId: string;
+  teamName: string | null;
+  teamRole: string | null;
+  /** The name the inviter typed for this person. */
+  displayName: string | null;
+  invitedByDisplayName: string | null;
+  inviteEmail: string | null;
+  invitePhone: string | null;
+  expiresAt: string | null;
+  /** Which of the user's verified contacts the invite was matched on. */
+  matchedVia: "email" | "phone" | null;
+}
+
 export type Unsubscribe = () => void;
 
 export interface AuthBackend {
@@ -44,6 +64,10 @@ export interface AuthBackend {
   signInWithOAuth(provider: OAuthProvider): Promise<AuthSession | null>;
   signOut(): Promise<void>;
   claimInvite(token: string): Promise<AuthClaimResult>;
+  /** Invites matched to the signed-in user's verified email/phone. */
+  listPendingInvites(): Promise<PendingInvite[]>;
+  acceptPendingInvite(inviteId: string): Promise<AuthClaimResult>;
+  declinePendingInvite(inviteId: string): Promise<void>;
   /** Attach an email identity to the current (anonymous) user. Triggers an OTP. */
   sendUpgradePhoneOtp(phone: string): Promise<void>;
   verifyUpgradePhoneOtp(phone: string, code: string): Promise<AuthSession | null>;
@@ -327,14 +351,25 @@ type TeamInviteBaseInput = {
   targetActorId?: string | null;
 };
 
+/**
+ * Optional invitee contact, member invites only. When supplied, the invitee can
+ * discover and accept the invite after signing in (`listPendingInvites`) instead
+ * of needing the token delivered out-of-band. Agent invites are claimed by a
+ * daemon that provisions its own identity, so there is nobody to match.
+ */
+type TeamInviteContactInput = {
+  inviteEmail?: string | null;
+  invitePhone?: string | null;
+};
+
 export type TeamInviteInput =
-  | (TeamInviteBaseInput & {
+  | (TeamInviteBaseInput & TeamInviteContactInput & {
       kind: "member";
       actorType?: "member";
       teamRole: "owner" | "admin" | "member";
       agentKind?: null;
     })
-  | (TeamInviteBaseInput & {
+  | (TeamInviteBaseInput & TeamInviteContactInput & {
       actorType: "member";
       kind?: "member";
       teamRole: "owner" | "admin" | "member";

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -2962,7 +2962,25 @@
     "copyFailed": "Failed to copy invite link",
     "failed": "Failed to create invite: {{msg}}",
     "upgradeRequired": "This team is still in the shared org and is solo-only. Upgrade your account and create your own team to invite members.",
-    "upgradeButton": "Upgrade account"
+    "upgradeButton": "Upgrade account",
+    "contactHint": "Add an email or phone and they'll see this invite when they sign in — no link to send.",
+    "emailLabel": "Email (optional)",
+    "emailPlaceholder": "name@example.com",
+    "phoneLabel": "Phone (optional)",
+    "phonePlaceholder": "13800138000"
+  },
+  "pendingInvite": {
+    "title": "You have team invites",
+    "description": "These teams invited you to join. You can accept or decline.",
+    "unnamedTeam": "Untitled team",
+    "invitedBy": "{{name}} invited you to join as {{role}}",
+    "invitedAs": "You're invited to join as {{role}}",
+    "expiresAt": "Expires {{date}}",
+    "accept": "Accept",
+    "decline": "Decline",
+    "accepted": "Joined the team",
+    "acceptFailed": "Failed to join team: {{msg}}",
+    "declineFailed": "Failed to decline: {{msg}}"
   },
   "terminal": {
     "label": "Terminal",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -2962,7 +2962,25 @@
     "copyFailed": "复制失败",
     "failed": "创建邀请失败：{{msg}}",
     "upgradeRequired": "当前团队还在公共组织下，只能自己使用。升级账号、创建你自己的团队后即可邀请成员。",
-    "upgradeButton": "升级账号"
+    "upgradeButton": "升级账号",
+    "contactHint": "填写邮箱或手机号后，对方登录时会直接看到这个邀请，不用你再发链接。",
+    "emailLabel": "邮箱（选填）",
+    "emailPlaceholder": "name@example.com",
+    "phoneLabel": "手机号（选填）",
+    "phonePlaceholder": "13800138000"
+  },
+  "pendingInvite": {
+    "title": "你有团队邀请",
+    "description": "以下团队邀请你加入。你可以选择接受或拒绝。",
+    "unnamedTeam": "未命名团队",
+    "invitedBy": "{{name}} 邀请你以 {{role}} 身份加入",
+    "invitedAs": "邀请你以 {{role}} 身份加入",
+    "expiresAt": "{{date}} 过期",
+    "accept": "接受邀请",
+    "decline": "拒绝",
+    "accepted": "已加入团队",
+    "acceptFailed": "加入团队失败：{{msg}}",
+    "declineFailed": "拒绝失败：{{msg}}"
   },
   "terminal": {
     "label": "终端",

--- a/packages/app/src/stores/auth-store.test.ts
+++ b/packages/app/src/stores/auth-store.test.ts
@@ -18,6 +18,9 @@ const authMock = {
   signOut: vi.fn(),
   signInAnonymously: vi.fn(),
   claimInvite: vi.fn(),
+  listPendingInvites: vi.fn(),
+  acceptPendingInvite: vi.fn(),
+  declinePendingInvite: vi.fn(),
   sendUpgradeEmailOtp: vi.fn(),
   verifyUpgradeEmailOtp: vi.fn(),
   adoptSession: vi.fn(),
@@ -284,6 +287,97 @@ describe("auth-store", () => {
     expect(useAuthStore.getState().pendingInviteToken).toBeNull();
     expect(useAuthStore.getState().loading).toBe(false);
     expect(useAuthStore.getState().authFlow).toBe("idle");
+  });
+
+  const pendingInvite = {
+    inviteId: "invite-1",
+    teamId: "team-7",
+    teamName: "Team Seven",
+    teamRole: "member",
+    displayName: "Erin",
+    invitedByDisplayName: "Dana",
+    inviteEmail: "erin@example.com",
+    invitePhone: null,
+    expiresAt: "2026-08-01T00:00:00Z",
+    matchedVia: "email" as const,
+  };
+
+  it("refreshPendingInvites skips the round-trip for an anonymous session", async () => {
+    // An anonymous user has no verified email/phone, so there is nothing the
+    // server could match — the request would always come back empty.
+    useAuthStore.setState({ session: anonSessionLike("anon-7"), pendingInvites: [pendingInvite] });
+
+    await useAuthStore.getState().refreshPendingInvites();
+
+    expect(authMock.listPendingInvites).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().pendingInvites).toEqual([]);
+  });
+
+  it("refreshPendingInvites stores matched invites for a real session", async () => {
+    authMock.listPendingInvites.mockResolvedValueOnce([pendingInvite]);
+    useAuthStore.setState({ session: storeSessionLike("real-7"), pendingInvites: [] });
+
+    await useAuthStore.getState().refreshPendingInvites();
+
+    expect(useAuthStore.getState().pendingInvites).toEqual([pendingInvite]);
+    expect(useAuthStore.getState().pendingInvitesLoading).toBe(false);
+  });
+
+  it("refreshPendingInvites swallows a lookup failure (must not break a good sign-in)", async () => {
+    authMock.listPendingInvites.mockRejectedValueOnce(new Error("network down"));
+    useAuthStore.setState({ session: storeSessionLike("real-8"), pendingInvites: [], errorMessage: null });
+
+    await useAuthStore.getState().refreshPendingInvites();
+
+    // Deliberately silent: the user can still join via a link, and surfacing
+    // this would put an error banner on an otherwise successful login.
+    expect(useAuthStore.getState().errorMessage).toBeNull();
+    expect(useAuthStore.getState().pendingInvitesLoading).toBe(false);
+  });
+
+  it("acceptPendingInvite enters the team and drops the invite from the list", async () => {
+    authMock.acceptPendingInvite.mockResolvedValueOnce({
+      actorId: "actor-7",
+      teamId: "team-7",
+      actorType: "member",
+      displayName: "Erin",
+      refreshToken: null,
+    });
+    useAuthStore.setState({ session: storeSessionLike("real-9"), pendingInvites: [pendingInvite] });
+
+    const result = await useAuthStore.getState().acceptPendingInvite("invite-1");
+
+    expect(authMock.acceptPendingInvite).toHaveBeenCalledWith("invite-1");
+    expect(currentTeamMock.reloadAndSwitchTo).toHaveBeenCalledWith("team-7");
+    expect(result?.teamId).toBe("team-7");
+    expect(useAuthStore.getState().pendingInvites).toEqual([]);
+    expect(useAuthStore.getState().loading).toBe(false);
+    expect(useAuthStore.getState().authFlow).toBe("idle");
+  });
+
+  it("acceptPendingInvite keeps the invite listed when the accept fails", async () => {
+    authMock.acceptPendingInvite.mockRejectedValueOnce(new Error("invite expired"));
+    useAuthStore.setState({ session: storeSessionLike("real-10"), pendingInvites: [pendingInvite] });
+
+    const result = await useAuthStore.getState().acceptPendingInvite("invite-1");
+
+    expect(result).toBeNull();
+    expect(currentTeamMock.reloadAndSwitchTo).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().pendingInvites).toEqual([pendingInvite]);
+    expect(useAuthStore.getState().errorMessage).toBe("invite expired");
+    expect(useAuthStore.getState().loading).toBe(false);
+  });
+
+  it("declinePendingInvite drops the invite without entering any team", async () => {
+    authMock.declinePendingInvite.mockResolvedValueOnce(undefined);
+    useAuthStore.setState({ session: storeSessionLike("real-11"), pendingInvites: [pendingInvite] });
+
+    const ok = await useAuthStore.getState().declinePendingInvite("invite-1");
+
+    expect(ok).toBe(true);
+    expect(authMock.declinePendingInvite).toHaveBeenCalledWith("invite-1");
+    expect(currentTeamMock.reloadAndSwitchTo).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().pendingInvites).toEqual([]);
   });
 
   it("sendUpgradeEmailOtp does not flip the global loading flag (AuthGate would tear down the app)", async () => {

--- a/packages/app/src/stores/auth-store.ts
+++ b/packages/app/src/stores/auth-store.ts
@@ -7,7 +7,7 @@ import {
   getBackend,
   hasBackendConfig,
 } from "@/lib/backend";
-import type { AuthClaimResult, AuthSession } from "@/lib/backend";
+import type { AuthClaimResult, AuthSession, PendingInvite } from "@/lib/backend";
 import { accessTokenMatchesBackend } from "@/lib/auth/auth-client";
 import { clearBootstrapAppliedFields, fetchAndApplyBootstrap } from "@/lib/bootstrap";
 import { getEffectiveServerConfig } from "@/lib/server-config";
@@ -70,6 +70,17 @@ interface AuthState {
    * member invites require a non-anonymous account (enforced in claim_team_invite).
    */
   claimPendingInvite: () => Promise<AuthClaimResult | null>;
+  /**
+   * Invites the server matched to this user's verified email/phone. Unlike
+   * `pendingInviteToken` (a link the user opened), these are discovered
+   * server-side at login — the user never saw a token.
+   */
+  pendingInvites: PendingInvite[];
+  pendingInvitesLoading: boolean;
+  /** No-op unless the session is real: matching keys off a verified identity. */
+  refreshPendingInvites: () => Promise<void>;
+  acceptPendingInvite: (inviteId: string) => Promise<AuthClaimResult | null>;
+  declinePendingInvite: (inviteId: string) => Promise<boolean>;
   sendUpgradeEmailOtp: (email: string) => Promise<boolean>;
   verifyUpgradeEmailOtp: (code: string) => Promise<boolean>;
   sendUpgradePhoneOtp: (phone: string) => Promise<boolean>;
@@ -376,6 +387,60 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     set({ loading: false, authFlow: "idle" });
     return result;
   },
+  pendingInvites: [],
+  pendingInvitesLoading: false,
+  refreshPendingInvites: async () => {
+    const session = get().session;
+    // An anonymous session has no verified email/phone, so there is nothing the
+    // server could match against — skip the round-trip entirely.
+    if (!session || session.user?.is_anonymous) {
+      set({ pendingInvites: [] });
+      return;
+    }
+    if (!hasBackendConfig()) return;
+    set({ pendingInvitesLoading: true });
+    try {
+      const items = await getBackend().auth.listPendingInvites();
+      set({ pendingInvites: items, pendingInvitesLoading: false });
+    } catch (error) {
+      // Non-fatal and deliberately silent: a failed lookup must not block a
+      // sign-in that otherwise succeeded. The user can still join via a link.
+      console.warn("[invite] pending invite lookup failed", error);
+      set({ pendingInvitesLoading: false });
+    }
+  },
+  acceptPendingInvite: async (inviteId) => {
+    if (!hasBackendConfig()) {
+      set({ errorMessage: BACKEND_CONFIG_MISSING_MESSAGE });
+      return null;
+    }
+    set({ loading: true, authFlow: "invite", errorMessage: null });
+    let result: AuthClaimResult;
+    try {
+      result = await getBackend().auth.acceptPendingInvite(inviteId);
+    } catch (error) {
+      set({ loading: false, authFlow: "idle", errorMessage: errorMessageFor(error) });
+      return null;
+    }
+    set({ pendingInvites: get().pendingInvites.filter((i) => i.inviteId !== inviteId) });
+    await enterClaimedTeam(result.teamId);
+    set({ loading: false, authFlow: "idle" });
+    return result;
+  },
+  declinePendingInvite: async (inviteId) => {
+    if (!hasBackendConfig()) {
+      set({ errorMessage: BACKEND_CONFIG_MISSING_MESSAGE });
+      return false;
+    }
+    try {
+      await getBackend().auth.declinePendingInvite(inviteId);
+    } catch (error) {
+      set({ errorMessage: errorMessageFor(error) });
+      return false;
+    }
+    set({ pendingInvites: get().pendingInvites.filter((i) => i.inviteId !== inviteId) });
+    return true;
+  },
   sendUpgradeEmailOtp: async (email) => {
     if (!hasBackendConfig()) {
       set({ errorMessage: BACKEND_CONFIG_MISSING_MESSAGE });
@@ -451,7 +516,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   resetUpgradeOtp: () => set({ upgradeEmail: null, upgradePhone: null, upgradeLoading: false, errorMessage: null }),
   signOut: async () => {
     await getBackend().auth.signOut();
-    set({ session: null, authFlow: "idle", otpEmail: null, otpPhone: null, phoneMultiUsers: [], pendingPhoneOTPToken: "", upgradeEmail: null });
+    set({ session: null, authFlow: "idle", otpEmail: null, otpPhone: null, phoneMultiUsers: [], pendingPhoneOTPToken: "", upgradeEmail: null, pendingInvites: [] });
     // Reset the current team so the NEXT (e.g. anonymous) login doesn't inherit
     // the previous user's team. Without this the current-team store kept the old
     // team (its RLS-lag guard preserves it while the new user's team list is

--- a/services/fc/src/db/migrations/0014_invite_contact_pending.sql
+++ b/services/fc/src/db/migrations/0014_invite_contact_pending.sql
@@ -1,0 +1,29 @@
+-- Pending-invite contact matching (postgres backend).
+-- Mirrors services/supabase/migrations/20260715000000_invite_contact_pending.sql.
+--
+-- Phone matching is Supabase-only: the Better-Auth `user` table on this backend
+-- has no phone column, so invite_phone is stored for the inviter's reference but
+-- can never match a login here. The column exists to keep the two backends'
+-- table shapes identical.
+
+ALTER TABLE "team_invites" ADD COLUMN IF NOT EXISTS "invite_email" text;
+ALTER TABLE "team_invites" ADD COLUMN IF NOT EXISTS "invite_phone" text;
+ALTER TABLE "team_invites" ADD COLUMN IF NOT EXISTS "status" text NOT NULL DEFAULT 'pending';
+ALTER TABLE "team_invites" ADD COLUMN IF NOT EXISTS "declined_at" timestamptz;
+
+-- Existing rows predate `status`; derive it from the consumption marker that was
+-- previously the only signal.
+UPDATE "team_invites" SET "status" = 'accepted'
+ WHERE "consumed_at" IS NOT NULL AND "status" = 'pending';
+
+-- One live invite per (team, email): re-inviting supersedes rather than stacking
+-- up rows the invitee would have to decline twice.
+CREATE UNIQUE INDEX IF NOT EXISTS "team_invites_pending_email_uniq"
+  ON "team_invites" ("team_id", lower(btrim("invite_email")))
+  WHERE "status" = 'pending' AND "invite_email" IS NOT NULL;
+
+-- The unique index leads with team_id, so it cannot serve the login-time lookup,
+-- which knows only the contact. This can.
+CREATE INDEX IF NOT EXISTS "team_invites_pending_email_lookup"
+  ON "team_invites" (lower(btrim("invite_email")))
+  WHERE "status" = 'pending' AND "invite_email" IS NOT NULL;

--- a/services/fc/src/db/schema/teams.ts
+++ b/services/fc/src/db/schema/teams.ts
@@ -77,6 +77,15 @@ export const teamInvites = pgTable("team_invites", {
   consumedAt: timestamp("consumed_at", { withTimezone: true }),
   consumedByActorId: uuid("consumed_by_actor_id"),
   targetActorId: uuid("target_actor_id"),
+  // Optional invitee contact, member invites only. When set, the invitee finds
+  // the invite after signing in (listPendingInvites) instead of needing the
+  // token out-of-band.
+  inviteEmail: text("invite_email"),
+  invitePhone: text("invite_phone"),
+  // pending | accepted | declined | expired. Soft lifecycle: rows are retained
+  // after acceptance/decline so the inviter can see the outcome.
+  status: text("status").notNull().default("pending"),
+  declinedAt: timestamp("declined_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/services/fc/src/lib/pg-repo/auth.ts
+++ b/services/fc/src/lib/pg-repo/auth.ts
@@ -1,4 +1,5 @@
-import { eq } from "drizzle-orm";
+import { and, desc, eq, gt, isNull, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import type { JWTVerifyGetKey } from "jose";
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { getAuth, type Auth } from "../../auth/better-auth.js";
@@ -6,7 +7,8 @@ import { mintSession } from "../../auth/mint-session.js";
 import { toGoTrueSession, toRefreshShape, toEpochSeconds, type ReshapeUser } from "../../auth/reshape.js";
 import { verifyAccessToken } from "../../auth/verify.js";
 import { authBaseURL } from "../../auth/base-url.js";
-import { teamInvites, actors, members, teamMembers, agents, agentMemberAccess, teamWorkspaceConfig } from "../../db/schema/index.js";
+import { teamInvites, actors, members, teamMembers, agents, agentMemberAccess, teamWorkspaceConfig, teams } from "../../db/schema/index.js";
+import { user } from "../../db/schema/auth.js";
 import { ApiError } from "../http-utils.js";
 import { randomUUID } from "node:crypto";
 
@@ -58,6 +60,15 @@ export function createPgAuthRepository(
   const resolveAuth = () => opts.auth ?? getAuth();
   const verifyJwt = (token: string) => verifyAccessToken(token, opts.verifyOpts ?? {});
 
+  // Routes forward the caller's bearer; an explicit ctx.userId still wins
+  // (tests / internal callers). Returns null when neither is present.
+  const resolveUserId = async (ctx: { userId?: string; accessToken?: string }) => {
+    if (ctx.userId) return ctx.userId;
+    if (!ctx.accessToken) return null;
+    const claims = await verifyJwt(ctx.accessToken);
+    return claims.sub ?? null;
+  };
+
   function bearer(sessionToken: string): Headers {
     const h = new Headers();
     h.set("authorization", `Bearer ${sessionToken}`);
@@ -89,7 +100,9 @@ export function createPgAuthRepository(
     return toGoTrueSession({ accessToken, refreshToken: sessionToken, expiresAt, user });
   }
 
-  return {
+  // Named so the pending-invite methods can delegate to sibling methods without
+  // relying on `this` surviving however the repository gets composed.
+  const repo = {
     // --- Phone login (betly-aligned, supabase backend only) ---
     async phoneSendCode() {
       throw new ApiError(501, "phone_login_unsupported", "phone login is only available under BACKEND_KIND=supabase");
@@ -291,6 +304,114 @@ export function createPgAuthRepository(
       throw new ApiError(501, "not_implemented", "switch active team requires the supabase backend");
     },
 
+    // Invites addressed to the caller's own verified email. Never takes a
+    // contact argument — it reads the authenticated user's identity — so it
+    // cannot be used to probe which addresses have invites waiting.
+    //
+    // Email only: Better-Auth's `user` table on this backend has no phone
+    // column, so an invite_phone can never match here (it does on supabase).
+    // Anonymous users have no verified contact and always get an empty list.
+    async listPendingInvites(ctx: { userId?: string; accessToken?: string } = {}) {
+      const db = opts.db;
+      if (!db) throw new Error("listPendingInvites requires db to be passed in opts");
+
+      const userId = await resolveUserId(ctx);
+      if (!userId) return { items: [] };
+
+      const [u] = await db
+        .select({ email: user.email, emailVerified: user.emailVerified, isAnonymous: user.isAnonymous })
+        .from(user)
+        .where(eq(user.id, userId))
+        .limit(1);
+      if (!u || u.isAnonymous || !u.emailVerified) return { items: [] };
+      const email = (u.email ?? "").trim().toLowerCase();
+      if (!email) return { items: [] };
+
+      const inviter = alias(actors, "inviter");
+      const rows = await (db as any)
+        .select({
+          inviteId: teamInvites.id,
+          teamId: teamInvites.teamId,
+          teamName: teams.name,
+          teamRole: teamInvites.teamRole,
+          displayName: teamInvites.displayName,
+          invitedByDisplayName: inviter.displayName,
+          inviteEmail: teamInvites.inviteEmail,
+          invitePhone: teamInvites.invitePhone,
+          expiresAt: teamInvites.expiresAt,
+        })
+        .from(teamInvites)
+        .innerJoin(teams, eq(teams.id, teamInvites.teamId))
+        .leftJoin(inviter, eq(inviter.id, teamInvites.invitedByActorId))
+        .where(
+          and(
+            eq(teamInvites.kind, "member"),
+            eq(teamInvites.status, "pending"),
+            isNull(teamInvites.consumedAt),
+            gt(teamInvites.expiresAt, new Date()),
+            sql`lower(btrim(${teamInvites.inviteEmail})) = ${email}`,
+            // Already in the team (joined via token, or invited twice) —
+            // nothing left to accept.
+            sql`not exists (select 1 from ${actors} a where a.team_id = ${teamInvites.teamId} and a.user_id = ${userId})`,
+          ),
+        )
+        .orderBy(desc(teamInvites.createdAt));
+
+      return {
+        items: rows.map((r: any) => ({
+          inviteId: r.inviteId,
+          teamId: r.teamId,
+          teamName: r.teamName ?? null,
+          teamRole: r.teamRole ?? null,
+          displayName: r.displayName ?? null,
+          invitedByDisplayName: r.invitedByDisplayName ?? null,
+          inviteEmail: r.inviteEmail ?? null,
+          invitePhone: r.invitePhone ?? null,
+          expiresAt: r.expiresAt ? new Date(r.expiresAt).toISOString() : null,
+          matchedVia: "email" as const,
+        })),
+      };
+    },
+
+    // Visibility via listPendingInvites IS the authorization check: an invite
+    // the caller cannot see is one they cannot accept, so "not yours" and "not
+    // there" are indistinguishable (both 404).
+    async acceptPendingInvite(inviteId: string, ctx: { userId?: string; accessToken?: string } = {}) {
+      const userId = await resolveUserId(ctx);
+      if (!userId) throw new ApiError(401, "missing_identity", "accepting an invite requires authentication");
+
+      const { items } = await repo.listPendingInvites(ctx);
+      const match = items.find((i: any) => i.inviteId === inviteId);
+      if (!match) throw new ApiError(404, "not_found", `no pending invite ${inviteId} for this account`);
+
+      const db = opts.db;
+      const [invite] = await db!
+        .select({ token: teamInvites.token })
+        .from(teamInvites)
+        .where(eq(teamInvites.id, inviteId))
+        .limit(1);
+      if (!invite) throw new ApiError(404, "not_found", `no pending invite ${inviteId} for this account`);
+
+      // Delegate so the contact path and the token path share one implementation.
+      return repo.claimInvite(invite.token, { userId });
+    },
+
+    async declinePendingInvite(inviteId: string, ctx: { userId?: string; accessToken?: string } = {}) {
+      const db = opts.db;
+      if (!db) throw new Error("declinePendingInvite requires db to be passed in opts");
+
+      const { items } = await repo.listPendingInvites(ctx);
+      if (!items.some((i: any) => i.inviteId === inviteId)) {
+        throw new ApiError(404, "not_found", `no pending invite ${inviteId} for this account`);
+      }
+
+      // The row is kept (not deleted) so the inviter can see the outcome.
+      await (db as any)
+        .update(teamInvites)
+        .set({ status: "declined", declinedAt: new Date(), updatedAt: new Date() })
+        .where(eq(teamInvites.id, inviteId));
+    },
+
     // claimInvite(token, { userId? }):
     //   member branch: requires a userId (existing Better-Auth user); inserts
     //     actor(member) + member(active) + team_member; refreshToken = null.
@@ -321,6 +442,10 @@ export function createPgAuthRepository(
         .limit(1);
       if (!invite) throw new ApiError(404, "not_found", "invite not found");
       if (invite.consumedAt) throw new ApiError(409, "conflict", "invite_already_claimed");
+      // A declined invite's token must stay dead, and a superseded one (the
+      // inviter re-sent to the same contact) must not resurrect the old link.
+      if (invite.status === "declined") throw new ApiError(409, "conflict", "invite_declined");
+      if (invite.status === "expired") throw new ApiError(409, "conflict", "invite_superseded");
       if (new Date(invite.expiresAt) < new Date()) throw new ApiError(404, "not_found", "invite_expired");
 
       const kind = invite.kind; // "member" | "agent"
@@ -351,7 +476,7 @@ export function createPgAuthRepository(
 
           // Mark invite consumed
           await (tx.update(teamInvites) as any)
-            .set({ consumedAt: new Date(), consumedByActorId: actor.id })
+            .set({ consumedAt: new Date(), consumedByActorId: actor.id, status: "accepted" })
             .where(eq(teamInvites.token, token));
 
           return {
@@ -450,7 +575,7 @@ export function createPgAuthRepository(
 
           // Mark invite consumed
           await (tx.update(teamInvites) as any)
-            .set({ consumedAt: new Date(), consumedByActorId: actorId })
+            .set({ consumedAt: new Date(), consumedByActorId: actorId, status: "accepted" })
             .where(eq(teamInvites.token, token));
 
           return {
@@ -492,4 +617,6 @@ export function createPgAuthRepository(
     // Re-exported primitive for Plan 5 wiring.
     mintSession: (userId: string) => mintSession(userId, resolveAuth()),
   };
+
+  return repo;
 }

--- a/services/fc/src/lib/pg-repo/teams.ts
+++ b/services/fc/src/lib/pg-repo/teams.ts
@@ -11,6 +11,10 @@ import { generateDisplayName } from "../display-name.js";
 
 const iso = (d: Date | string | null | undefined) => (d ? new Date(d).toISOString() : null);
 
+/** Lowercased + trimmed, or null. Both sides of a contact match normalize this way. */
+export const normalizeInviteEmail = (e: string | null | undefined) =>
+  (e ?? "").trim().toLowerCase() || null;
+
 function mapTeam(r: any) {
   return {
     id: r.id, name: r.name, slug: r.slug, createdAt: iso(r.createdAt),
@@ -571,7 +575,7 @@ export function makeTeamsRepo(db: PgDatabase<any, any>, deps: TeamsRepoDeps = {}
      */
     async createTeamInvite(
       teamId: string,
-      input: { kind?: string; actorType?: string; displayName: string; teamRole?: string | null; role?: string; agentKind?: string | null; expiresAt?: string | null; ttlSeconds?: number | null; targetActorId?: string | null },
+      input: { kind?: string; actorType?: string; displayName: string; teamRole?: string | null; role?: string; agentKind?: string | null; expiresAt?: string | null; ttlSeconds?: number | null; targetActorId?: string | null; inviteEmail?: string | null; invitePhone?: string | null },
       ctx?: { userId?: string },
     ) {
       const userId = ctx?.userId;
@@ -606,11 +610,38 @@ export function makeTeamsRepo(db: PgDatabase<any, any>, deps: TeamsRepoDeps = {}
         if (!owns) throw new ApiError(403, "forbidden", "only the agent owner can re-invite this agent");
       }
 
+      // Optional invitee contact. Member-only: agent invites are claimed by a
+      // daemon that provisions its own identity, so there is nobody to match.
+      const inviteEmail = normalizeInviteEmail(input.inviteEmail);
+      const invitePhone = (input.invitePhone ?? "").trim() || null;
+      if (kind !== "member" && (inviteEmail || invitePhone)) {
+        throw new ApiError(400, "validation_failed", "agent invites cannot carry invite_email/invite_phone");
+      }
+      if (inviteEmail && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(inviteEmail)) {
+        throw new ApiError(400, "validation_failed", "invite_email is not a valid email address");
+      }
+
       const token = randomBytes(24).toString("base64url");
       const ttlSeconds = input.ttlSeconds ?? 7 * 24 * 60 * 60; // 7 days default
       const expiresAt = input.expiresAt
         ? new Date(input.expiresAt)
         : new Date(Date.now() + ttlSeconds * 1000);
+
+      // Supersede any live invite to the same email rather than letting the
+      // partial unique index reject the call: re-sending an invite means "this
+      // one is now current", and the old token stops working.
+      if (inviteEmail) {
+        await (db as any)
+          .update(teamInvites)
+          .set({ status: "expired", updatedAt: new Date() })
+          .where(
+            and(
+              eq(teamInvites.teamId, teamId),
+              eq(teamInvites.status, "pending"),
+              sql`lower(btrim(${teamInvites.inviteEmail})) = ${inviteEmail}`,
+            ),
+          );
+      }
 
       const [invite] = await (db as any)
         .insert(teamInvites)
@@ -624,6 +655,9 @@ export function makeTeamsRepo(db: PgDatabase<any, any>, deps: TeamsRepoDeps = {}
           invitedByActorId: invitedByActorId ?? "00000000-0000-0000-0000-000000000000",
           expiresAt,
           targetActorId: input.targetActorId ?? null,
+          inviteEmail,
+          invitePhone,
+          status: "pending",
         })
         .returning();
 

--- a/services/fc/src/lib/repository-contract.ts
+++ b/services/fc/src/lib/repository-contract.ts
@@ -426,6 +426,21 @@ test("repository contract: getTeamDirectory returns actors and members", async (
     assert.equal(result.expiresAt, null);
   });
 
+  test("repository contract: createTeamInvite accepts optional invitee contact", async () => {
+    const repo = createRepository();
+    // Contact is optional and member-only: supplying it lets the invitee find
+    // the invite at login, but must not change the token/deeplink result shape.
+    const result = await repo.createTeamInvite("team-1", {
+      kind: "member",
+      displayName: "New User",
+      teamRole: "member",
+      expiresAt: null,
+      inviteEmail: "new@example.com",
+      invitePhone: "13800138000",
+    });
+    assert.ok(result.token, "token must be present even when contact is supplied");
+  });
+
   test("repository contract: removeTeamActor succeeds", async () => {
     const repo = createRepository();
     await repo.removeTeamActor("team-1", "actor-to-remove");

--- a/services/fc/src/lib/routes/invites.ts
+++ b/services/fc/src/lib/routes/invites.ts
@@ -1,5 +1,5 @@
 import { requireString } from "../routing-utils.js";
-import { optionalBearerToken } from "../http-utils.js";
+import { optionalBearerToken, extractBearerToken } from "../http-utils.js";
 
 export function registerInvites(router) {
   // The bearer is OPTIONAL on this route, and which path it serves depends on
@@ -18,5 +18,30 @@ export function registerInvites(router) {
     const accessToken = optionalBearerToken(ctx.headers) ?? undefined;
     const result = await ctx.repository.claimInvite(body.token, { accessToken });
     return { body: result };
+  });
+
+  // Invites waiting for the caller's verified email/phone — the contact path,
+  // for invitees who never received a token out-of-band. `auth: "none"` routes
+  // to the auth repository (which owns the per-bearer client the underlying
+  // `auth.uid()`-keyed RPCs need); the bearer is REQUIRED here, unlike on the
+  // claim route above, since there is no anonymous variant of "my invites".
+  router.get("/v1/invites/pending", { auth: "none" }, async (ctx) => {
+    const accessToken = extractBearerToken(ctx.headers);
+    const result = await ctx.repository.listPendingInvites({ accessToken });
+    return { body: result };
+  });
+
+  router.post("/v1/invites/:inviteId/accept", { auth: "none" }, async (ctx) => {
+    const accessToken = extractBearerToken(ctx.headers);
+    const inviteId = decodeURIComponent(ctx.params.inviteId);
+    const result = await ctx.repository.acceptPendingInvite(inviteId, { accessToken });
+    return { body: result };
+  });
+
+  router.post("/v1/invites/:inviteId/decline", { auth: "none" }, async (ctx) => {
+    const accessToken = extractBearerToken(ctx.headers);
+    const inviteId = decodeURIComponent(ctx.params.inviteId);
+    await ctx.repository.declinePendingInvite(inviteId, { accessToken });
+    return { statusCode: 204 };
   });
 }

--- a/services/fc/src/lib/routes/teams.ts
+++ b/services/fc/src/lib/routes/teams.ts
@@ -81,6 +81,10 @@ export function registerTeams(router) {
       agentKind: body.agentKind ?? null,
       ttlSeconds: body.ttlSeconds ?? null,
       targetActorId: body.targetActorId ?? null,
+      // Optional, member-only. When present the invitee can find and accept the
+      // invite at login (GET /v1/invites/pending) without the token.
+      inviteEmail: body.inviteEmail ?? null,
+      invitePhone: body.invitePhone ?? null,
     });
     return { statusCode: 201, body: result };
   });

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -401,8 +401,18 @@ export function createSupabaseBusinessRepository(options) {
       if (input.agentKind != null) args.p_agent_kind = input.agentKind;
       if (input.ttlSeconds != null) args.p_ttl_seconds = input.ttlSeconds;
       if (input.targetActorId != null) args.p_target_actor_id = input.targetActorId;
+      if (input.inviteEmail != null) args.p_invite_email = input.inviteEmail;
+      if (input.invitePhone != null) args.p_invite_phone = input.invitePhone;
       const { data, error } = await supabase.rpc("create_team_invite", args);
-      if (error) throw error;
+      if (error) {
+        // 22023 covers the RPC's own argument validation (bad email shape, a
+        // digitless phone, contact on an agent invite) — a client mistake, not
+        // a server fault, so surface it as 400 rather than a raw 500.
+        if (error.code === "22023") {
+          throw new ApiError(400, "validation_failed", error.message ?? "invalid invite");
+        }
+        throw error;
+      }
       const row = requiredRow(data, "teams.createTeamInvite");
       return {
         token: requiredString(row.token, "teams.createTeamInvite", "token"),

--- a/services/fc/src/lib/supabase-repo/auth.ts
+++ b/services/fc/src/lib/supabase-repo/auth.ts
@@ -9,6 +9,19 @@ import { makeDysmsSender } from "../sms.js";
 
 import { REALTIME_TRANSPORT_OPTS, requiredRow, requiredString, requiredInteger } from "./shared.js";
 
+// Both pending-invite RPCs guard by visibility: an invite not addressed to the
+// caller's verified contact raises 23503 exactly like a nonexistent id, so a
+// caller cannot distinguish "not yours" from "not there" — 404 for both.
+function mapPendingInviteError(error, fallback: string) {
+  const code = error?.code || "";
+  const msg = error?.message ?? fallback;
+  if (code === "23503") return new ApiError(404, "not_found", msg);
+  if (code === "23505") return new ApiError(409, "conflict", msg);
+  if (code === "23514") return new ApiError(409, "conflict", msg);
+  if (code === "42501") return new ApiError(401, "unauthorized", msg);
+  return new ApiError(400, "validation_failed", msg);
+}
+
 export function createSupabaseAuthRepository(options) {
   const {
     supabaseUrl,
@@ -105,6 +118,49 @@ export function createSupabaseAuthRepository(options) {
         displayName: requiredString(row.display_name, "auth.claimInvite", "display_name"),
         refreshToken: row.refresh_token ?? null,
       };
+    },
+
+    // Invites addressed to the caller's verified email/phone. Lives here rather
+    // than in the business repository because the RPC keys off `auth.uid()`, so
+    // it needs the caller's bearer — the business client is service-role.
+    async listPendingInvites(ctx: { accessToken?: string } = {}) {
+      const client = clientForToken(ctx.accessToken);
+      const { data, error } = await client.rpc("list_pending_invites_for_me");
+      if (error) throw new ApiError(400, "validation_failed", error.message ?? "list_pending_invites_for_me failed");
+      return {
+        items: (data ?? []).map((row) => ({
+          inviteId: requiredString(row.invite_id, "auth.listPendingInvites", "invite_id"),
+          teamId: requiredString(row.team_id, "auth.listPendingInvites", "team_id"),
+          teamName: row.team_name ?? null,
+          teamRole: row.team_role ?? null,
+          displayName: row.display_name ?? null,
+          invitedByDisplayName: row.invited_by_display_name ?? null,
+          inviteEmail: row.invite_email ?? null,
+          invitePhone: row.invite_phone ?? null,
+          expiresAt: row.expires_at ?? null,
+          matchedVia: row.matched_via ?? null,
+        })),
+      };
+    },
+
+    async acceptPendingInvite(inviteId, ctx: { accessToken?: string } = {}) {
+      const client = clientForToken(ctx.accessToken);
+      const { data, error } = await client.rpc("accept_pending_invite", { p_invite_id: inviteId });
+      if (error) throw mapPendingInviteError(error, "accept_pending_invite failed");
+      const row = requiredRow(data, "auth.acceptPendingInvite");
+      return {
+        actorId: requiredString(row.actor_id, "auth.acceptPendingInvite", "actor_id"),
+        teamId: requiredString(row.team_id, "auth.acceptPendingInvite", "team_id"),
+        actorType: requiredString(row.actor_type, "auth.acceptPendingInvite", "actor_type"),
+        displayName: requiredString(row.display_name, "auth.acceptPendingInvite", "display_name"),
+        refreshToken: row.refresh_token ?? null,
+      };
+    },
+
+    async declinePendingInvite(inviteId, ctx: { accessToken?: string } = {}) {
+      const client = clientForToken(ctx.accessToken);
+      const { error } = await client.rpc("decline_pending_invite", { p_invite_id: inviteId });
+      if (error) throw mapPendingInviteError(error, "decline_pending_invite failed");
     },
 
     // Switch the caller's active team (and org), minting a fresh server session.

--- a/services/fc/test/business-api.test.ts
+++ b/services/fc/test/business-api.test.ts
@@ -205,6 +205,90 @@ test("claim invite is anonymous and routes to auth repository", async () => {
   assert.equal(JSON.parse(response.body).actorId, "agent-1");
 });
 
+// The three routes below are the contact path (invited by email/phone, no token
+// ever reached the invitee). Unlike /v1/invites/claim they REQUIRE a bearer:
+// matching keys off the caller's own verified identity, so there is no
+// anonymous variant.
+test("pending invites route requires a bearer and routes to auth repository", async () => {
+  const authCalls = [];
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/invites/pending",
+    headers: { Authorization: "Bearer member-jwt" },
+  }, {
+    createRepository: () => fakeRepo(),
+    createAuthRepository: () => ({
+      async listPendingInvites(ctx) {
+        authCalls.push({ method: "listPendingInvites", accessToken: ctx?.accessToken });
+        return { items: [{ inviteId: "invite-1", teamId: "team-1", matchedVia: "email" }] };
+      },
+    }),
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(authCalls[0], { method: "listPendingInvites", accessToken: "member-jwt" });
+  assert.equal(JSON.parse(response.body).items[0].inviteId, "invite-1");
+});
+
+test("pending invites route returns 401 without a bearer", async () => {
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/invites/pending",
+    headers: {},
+  }, {
+    createRepository: () => fakeRepo(),
+    createAuthRepository: () => ({
+      async listPendingInvites() {
+        assert.fail("must not reach the repository without a bearer");
+      },
+    }),
+  });
+
+  assert.equal(response.statusCode, 401);
+});
+
+test("accept pending invite forwards inviteId and bearer", async () => {
+  const authCalls = [];
+  const response = await handleBusinessApiRequest({
+    httpMethod: "POST",
+    path: "/v1/invites/invite-1/accept",
+    headers: { Authorization: "Bearer member-jwt" },
+    body: "{}",
+  }, {
+    createRepository: () => fakeRepo(),
+    createAuthRepository: () => ({
+      async acceptPendingInvite(inviteId, ctx) {
+        authCalls.push({ method: "acceptPendingInvite", inviteId, accessToken: ctx?.accessToken });
+        return { actorId: "actor-9", teamId: "team-1", actorType: "member", displayName: "New User", refreshToken: null };
+      },
+    }),
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(authCalls[0], { method: "acceptPendingInvite", inviteId: "invite-1", accessToken: "member-jwt" });
+  assert.equal(JSON.parse(response.body).teamId, "team-1");
+});
+
+test("decline pending invite returns 204", async () => {
+  const authCalls = [];
+  const response = await handleBusinessApiRequest({
+    httpMethod: "POST",
+    path: "/v1/invites/invite-1/decline",
+    headers: { Authorization: "Bearer member-jwt" },
+    body: "{}",
+  }, {
+    createRepository: () => fakeRepo(),
+    createAuthRepository: () => ({
+      async declinePendingInvite(inviteId, ctx) {
+        authCalls.push({ method: "declinePendingInvite", inviteId, accessToken: ctx?.accessToken });
+      },
+    }),
+  });
+
+  assert.equal(response.statusCode, 204);
+  assert.deepEqual(authCalls[0], { method: "declinePendingInvite", inviteId: "invite-1", accessToken: "member-jwt" });
+});
+
 test("claim invite forwards the caller bearer for member claims", async () => {
   // A member joining via someone's link IS authenticated (anonymous or real).
   // The route must forward their bearer as accessToken so the SECURITY DEFINER
@@ -1015,7 +1099,26 @@ test("POST /v1/teams/:teamId/invites creates invite", async () => {
   assert.equal(response.statusCode, 201);
   const body = JSON.parse(response.body);
   assert.equal(body.token, "invite-token");
-  assert.deepEqual(repo.calls[0], { method: "createTeamInvite", teamId: "team-1", input: { kind: "member", displayName: "New User", teamRole: "member", agentKind: null, ttlSeconds: null, targetActorId: null } });
+  assert.deepEqual(repo.calls[0], { method: "createTeamInvite", teamId: "team-1", input: { kind: "member", displayName: "New User", teamRole: "member", agentKind: null, ttlSeconds: null, targetActorId: null, inviteEmail: null, invitePhone: null } });
+});
+
+test("POST /v1/teams/:teamId/invites forwards invitee contact", async () => {
+  const repo = fakeRepo();
+  await handleBusinessApiRequest({
+    httpMethod: "POST",
+    path: "/v1/teams/team-1/invites",
+    headers: { Authorization: "Bearer token" },
+    body: JSON.stringify({
+      kind: "member",
+      displayName: "New User",
+      teamRole: "member",
+      inviteEmail: "new@example.com",
+      invitePhone: "13800138000",
+    }),
+  }, { createRepository: () => repo });
+
+  assert.equal(repo.calls[0].input.inviteEmail, "new@example.com");
+  assert.equal(repo.calls[0].input.invitePhone, "13800138000");
 });
 
 test("POST /v1/teams/:teamId/invites returns 400 without required fields", async () => {

--- a/services/supabase/migrations/20260715000000_invite_contact_pending.sql
+++ b/services/supabase/migrations/20260715000000_invite_contact_pending.sql
@@ -1,0 +1,568 @@
+-- Pending-invite contact matching.
+--
+-- Before this migration an invite captured no way to reach the invitee: only
+-- `display_name` plus a `token` the inviter had to deliver out-of-band. The
+-- server therefore could not answer "is there an invite waiting for *this*
+-- person?" at login, and the only join path was the pre-auth
+-- `pendingInviteToken` stash on the client.
+--
+-- This adds optional `invite_email` / `invite_phone` to amux.team_invites and a
+-- `status` lifecycle, so a freshly-authenticated user can be shown the invites
+-- addressed to their VERIFIED contact and accept or decline them in-app. The
+-- token path is untouched and remains the fallback for invitees whose contact
+-- the inviter does not know.
+--
+-- The table keeps a soft lifecycle (pending/accepted/declined/expired) rather
+-- than deleting rows, so "who declined" survives for audit.
+
+-- ---------------------------------------------------------------------------
+-- 1. Columns
+-- ---------------------------------------------------------------------------
+
+alter table amux.team_invites
+  add column if not exists invite_email text,
+  add column if not exists invite_phone text,
+  add column if not exists status       text not null default 'pending',
+  add column if not exists declined_at  timestamptz;
+
+-- Existing rows predate `status`; derive it from the consumption marker that
+-- was previously the only signal.
+update amux.team_invites
+   set status = 'accepted'
+ where consumed_at is not null
+   and status = 'pending';
+
+alter table amux.team_invites
+  drop constraint if exists team_invites_status_check;
+alter table amux.team_invites
+  add constraint team_invites_status_check
+  check (status = any (array['pending', 'accepted', 'declined', 'expired']));
+
+-- Contact is only meaningful for member invites. Agent invites are claimed by a
+-- daemon that self-provisions its own auth user, so there is nobody to match.
+alter table amux.team_invites
+  drop constraint if exists team_invites_contact_member_only_check;
+alter table amux.team_invites
+  add constraint team_invites_contact_member_only_check
+  check (kind = 'member' or (invite_email is null and invite_phone is null));
+
+comment on column amux.team_invites.invite_email is
+  'Optional invitee email captured at invite time. Matched against the verified auth.users.email of a logging-in user by amux.list_pending_invites_for_me().';
+comment on column amux.team_invites.invite_phone is
+  'Optional invitee phone captured at invite time. Compared digit-normalized against auth.users.phone.';
+comment on column amux.team_invites.status is
+  'pending | accepted | declined | expired. Soft lifecycle — rows are retained after acceptance/decline for audit.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Phone normalization
+-- ---------------------------------------------------------------------------
+
+-- Phones reach us in inconsistent shapes: `bind_phone_to_account` writes what
+-- the client sent, and an inviter may type spaces, dashes or a leading '+'.
+-- Comparing raw text would miss obvious matches, so both sides are reduced to
+-- digits. IMMUTABLE so it can back an index.
+create or replace function amux.normalize_invite_phone(p_phone text)
+returns text
+language sql
+immutable
+set search_path = ''
+as $$
+  select nullif(regexp_replace(coalesce(p_phone, ''), '[^0-9]', '', 'g'), '')
+$$;
+
+comment on function amux.normalize_invite_phone(text) is
+  'Reduces a phone to its digits (dropping +, spaces, dashes) so invite_phone and auth.users.phone compare equal regardless of formatting. Returns NULL for empty input.';
+
+revoke all on function amux.normalize_invite_phone(text) from public;
+grant execute on function amux.normalize_invite_phone(text) to authenticated, anon, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 3. Indexes
+-- ---------------------------------------------------------------------------
+
+-- One live invite per (team, contact): re-inviting the same person should
+-- update or replace, not stack up rows the invitee then has to decline twice.
+create unique index if not exists team_invites_pending_email_uniq
+  on amux.team_invites (team_id, lower(btrim(invite_email)))
+  where status = 'pending' and invite_email is not null;
+
+create unique index if not exists team_invites_pending_phone_uniq
+  on amux.team_invites (team_id, amux.normalize_invite_phone(invite_phone))
+  where status = 'pending' and invite_phone is not null;
+
+-- The unique indexes above lead with team_id, so they cannot serve the
+-- login-time lookup, which knows only the contact. These can.
+create index if not exists team_invites_pending_email_lookup
+  on amux.team_invites (lower(btrim(invite_email)))
+  where status = 'pending' and invite_email is not null;
+
+create index if not exists team_invites_pending_phone_lookup
+  on amux.team_invites (amux.normalize_invite_phone(invite_phone))
+  where status = 'pending' and invite_phone is not null;
+
+-- ---------------------------------------------------------------------------
+-- 4. RLS
+-- ---------------------------------------------------------------------------
+
+-- The baseline policy (20260601000000_baseline.sql:7248) was inert: its WITH
+-- CHECK compared `a.id = a.invited_by_actor_id` and `a.team_id = a.team_id` —
+-- both self-comparisons on the same alias, the latter a tautology — so it never
+-- constrained the row being inserted. Rewritten to reference the target row via
+-- the table name. Inserts in practice go through the SECURITY DEFINER
+-- create_team_invite RPC, which bypasses RLS, so this only tightens the
+-- unused direct-insert path.
+drop policy if exists team_invites_insert_via_rpc on amux.team_invites;
+create policy team_invites_insert_via_rpc on amux.team_invites
+  for insert to authenticated
+  with check (
+    amux.is_team_member(team_invites.team_id)
+    and exists (
+      select 1 from amux.actors a
+       where a.id = team_invites.invited_by_actor_id
+         and a.user_id = auth.uid()
+         and a.team_id = team_invites.team_id
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 5. create_team_invite — accept optional contact
+-- ---------------------------------------------------------------------------
+
+-- The old 7-arg signature is DROPPED, not replaced: appending defaulted params
+-- creates an overload, and a 7-positional-arg call would then be ambiguous
+-- between the two. The new 9-arg form uses CREATE OR REPLACE so re-running this
+-- migration is a no-op rather than a "function already exists" error.
+drop function if exists amux.create_team_invite(uuid, text, text, text, text, integer, uuid);
+
+create or replace function amux.create_team_invite(
+  p_team_id         uuid,
+  p_kind            text,
+  p_display_name    text,
+  p_team_role       text    default null,
+  p_agent_kind      text    default null,
+  p_ttl_seconds     integer default 604800,
+  p_target_actor_id uuid    default null,
+  p_invite_email    text    default null,
+  p_invite_phone    text    default null
+) RETURNS TABLE(token text, expires_at timestamp with time zone, deeplink text)
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'amux', 'public', 'auth', 'app'
+    AS $$
+declare
+  v_caller uuid := amux.current_actor_id_for_team(p_team_id);
+  v_token  text := translate(
+                     encode(extensions.gen_random_bytes(24), 'base64'),
+                     '+/=', '-_0'
+                   );
+  v_expires timestamptz := now() + make_interval(secs => greatest(60, p_ttl_seconds));
+  v_kind    text;
+  v_role    text;
+  v_target  amux.actors%rowtype;
+  v_target_anon boolean;
+  v_email   text;
+  v_phone   text;
+begin
+  if v_caller is null then
+    raise exception 'create_team_invite requires team membership'
+      using errcode = '42501';
+  end if;
+
+  v_kind := lower(coalesce(p_kind, ''));
+  if v_kind not in ('member','agent') then
+    raise exception 'p_kind must be member or agent' using errcode = '22023';
+  end if;
+
+  v_email := nullif(lower(btrim(coalesce(p_invite_email, ''))), '');
+  v_phone := nullif(btrim(coalesce(p_invite_phone, '')), '');
+
+  if v_email is not null and v_email !~ '^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$' then
+    raise exception 'invite_email is not a valid email address' using errcode = '22023';
+  end if;
+  if v_phone is not null and amux.normalize_invite_phone(v_phone) is null then
+    raise exception 'invite_phone contains no digits' using errcode = '22023';
+  end if;
+
+  if v_kind = 'member' then
+    if p_team_role is null or btrim(p_team_role) = '' then
+      raise exception 'member invites require p_team_role' using errcode = '22023';
+    end if;
+    v_role := lower(p_team_role);
+    if v_role not in ('owner','admin','member') then
+      raise exception 'team_role must be owner/admin/member' using errcode = '22023';
+    end if;
+
+    if p_target_actor_id is not null then
+      select * into v_target from amux.actors where id = p_target_actor_id;
+      if not found then
+        raise exception 'target actor not found' using errcode = '23503';
+      end if;
+      if v_target.team_id <> p_team_id then
+        raise exception 'target actor belongs to a different team'
+          using errcode = '23514';
+      end if;
+      if v_target.actor_type <> 'member' then
+        raise exception 'target actor must be a member' using errcode = '22023';
+      end if;
+      if v_target.user_id is null then
+        raise exception 'target member has no auth user'
+          using errcode = '23503';
+      end if;
+      select coalesce(is_anonymous, false) into v_target_anon
+        from auth.users where id = v_target.user_id;
+      if not v_target_anon then
+        raise exception 'cannot re-invite member with bound auth identity'
+          using errcode = '22023';
+      end if;
+    end if;
+
+    -- Supersede an existing live invite to the same contact instead of letting
+    -- the partial unique index reject the call: an inviter re-sending an invite
+    -- means "this one is now current", and the old token stops working.
+    if v_email is not null then
+      update amux.team_invites
+         set status = 'expired', updated_at = now()
+       where team_id = p_team_id
+         and status = 'pending'
+         and lower(btrim(invite_email)) = v_email;
+    end if;
+    if v_phone is not null then
+      update amux.team_invites
+         set status = 'expired', updated_at = now()
+       where team_id = p_team_id
+         and status = 'pending'
+         and amux.normalize_invite_phone(invite_phone) = amux.normalize_invite_phone(v_phone);
+    end if;
+  else
+    if v_email is not null or v_phone is not null then
+      raise exception 'agent invites cannot carry invite_email/invite_phone'
+        using errcode = '22023';
+    end if;
+    if p_agent_kind is null or btrim(p_agent_kind) = '' then
+      raise exception 'agent invites require p_agent_kind' using errcode = '22023';
+    end if;
+    if p_target_actor_id is not null then
+      select * into v_target from amux.actors where id = p_target_actor_id;
+      if not found then
+        raise exception 'target actor not found' using errcode = '23503';
+      end if;
+      if v_target.team_id <> p_team_id then
+        raise exception 'target actor belongs to a different team'
+          using errcode = '23514';
+      end if;
+      if v_target.actor_type <> 'agent' then
+        raise exception 'target actor must be an agent' using errcode = '22023';
+      end if;
+      if not exists (
+        select 1 from amux.agents
+        where id = p_target_actor_id
+          and owner_member_id = v_caller
+      ) then
+        raise exception 'only the agent owner can re-invite this agent'
+          using errcode = '42501';
+      end if;
+    end if;
+  end if;
+
+  insert into amux.team_invites (
+    team_id, kind, display_name, team_role, agent_kind,
+    invited_by_actor_id, token, expires_at, target_actor_id,
+    invite_email, invite_phone, status
+  )
+  values (
+    p_team_id, v_kind, btrim(p_display_name), v_role, p_agent_kind,
+    v_caller, v_token, v_expires, p_target_actor_id,
+    v_email, v_phone, 'pending'
+  );
+
+  return query
+  select v_token,
+         v_expires,
+         format('amux://invite?token=%s', v_token);
+end;
+$$;
+
+comment on function amux.create_team_invite(uuid, text, text, text, text, integer, uuid, text, text) is
+  'Creates a team invite. p_invite_email / p_invite_phone are optional and member-only; when supplied the invitee can discover and accept the invite at login via amux.list_pending_invites_for_me() instead of needing the token out-of-band. Re-inviting the same contact expires the previous pending invite.';
+
+revoke all on function amux.create_team_invite(uuid, text, text, text, text, integer, uuid, text, text) from public;
+grant all on function amux.create_team_invite(uuid, text, text, text, text, integer, uuid, text, text) to anon, authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 6. list_pending_invites_for_me
+-- ---------------------------------------------------------------------------
+
+-- Matching only ever reads the CALLER's own verified contact from auth.users —
+-- it never takes a contact as an argument — so this cannot be used to probe
+-- which addresses have invites waiting.
+--
+-- Email requires email_confirmed_at. Phone deliberately does NOT require
+-- phone_confirmed_at: `amux.bind_phone_to_account` (20260618020000) verifies
+-- via our own auth_verify_code table and then sets auth.users.phone directly
+-- without touching GoTrue's phone_confirmed_at, so requiring it would match
+-- nothing. Presence of auth.users.phone is the verification signal on this
+-- deployment.
+create or replace function amux.list_pending_invites_for_me()
+returns table (
+  invite_id               uuid,
+  team_id                 uuid,
+  team_name               text,
+  team_role               text,
+  display_name            text,
+  invited_by_display_name text,
+  invite_email            text,
+  invite_phone            text,
+  expires_at              timestamptz,
+  matched_via             text
+)
+language sql
+stable
+security definer
+set search_path to 'amux', 'public', 'auth'
+as $$
+  with me as (
+    select u.id as user_id,
+           case when u.email_confirmed_at is not null
+                then nullif(lower(btrim(u.email)), '') end as email,
+           amux.normalize_invite_phone(u.phone)            as phone
+      from auth.users u
+     where u.id = auth.uid()
+       and coalesce(u.is_anonymous, false) = false
+  )
+  select ti.id,
+         ti.team_id,
+         t.name,
+         ti.team_role,
+         ti.display_name,
+         inviter.display_name,
+         ti.invite_email,
+         ti.invite_phone,
+         ti.expires_at,
+         case
+           when me.email is not null
+            and lower(btrim(ti.invite_email)) = me.email then 'email'
+           else 'phone'
+         end
+    from amux.team_invites ti
+    cross join me
+    join amux.teams t on t.id = ti.team_id
+    left join amux.actors inviter on inviter.id = ti.invited_by_actor_id
+   where ti.kind = 'member'
+     and ti.status = 'pending'
+     and ti.consumed_at is null
+     and ti.expires_at > now()
+     and (
+       (me.email is not null and ti.invite_email is not null
+        and lower(btrim(ti.invite_email)) = me.email)
+       or
+       (me.phone is not null and ti.invite_phone is not null
+        and amux.normalize_invite_phone(ti.invite_phone) = me.phone)
+     )
+     -- Already in the team (joined via token, or invited twice) — nothing to accept.
+     and not exists (
+       select 1 from amux.actors a
+        where a.team_id = ti.team_id
+          and a.user_id = me.user_id
+     )
+   order by ti.created_at desc
+$$;
+
+comment on function amux.list_pending_invites_for_me() is
+  'Invites addressed to the calling user''s verified email/phone that are still pending, unexpired, and for a team they have not already joined. Takes no contact argument by design — it reads auth.uid()''s own contact, so it cannot be used to probe other addresses.';
+
+revoke all on function amux.list_pending_invites_for_me() from public;
+grant execute on function amux.list_pending_invites_for_me() to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 7. accept / decline
+-- ---------------------------------------------------------------------------
+
+-- Accepting resolves the invite's token and delegates to claim_team_invite, so
+-- the contact path and the token path converge on one implementation. The
+-- membership guard is `list_pending_invites_for_me()` itself: an invite the
+-- caller cannot see is one they cannot accept.
+create or replace function amux.accept_pending_invite(p_invite_id uuid)
+returns table (actor_id uuid, team_id uuid, actor_type text, display_name text, refresh_token text)
+language plpgsql
+security definer
+set search_path to 'amux', 'public', 'auth', 'extensions'
+as $$
+declare
+  v_token text;
+begin
+  select ti.token into v_token
+    from amux.team_invites ti
+   where ti.id = p_invite_id
+     and ti.id in (select p.invite_id from amux.list_pending_invites_for_me() p);
+
+  if v_token is null then
+    raise exception 'no pending invite % for this account', p_invite_id using errcode = '23503';
+  end if;
+
+  return query select * from amux.claim_team_invite(v_token);
+end;
+$$;
+
+comment on function amux.accept_pending_invite(uuid) is
+  'Accepts an invite matched to the caller''s verified contact by resolving its token and delegating to claim_team_invite. Visibility via list_pending_invites_for_me() IS the authorization check.';
+
+revoke all on function amux.accept_pending_invite(uuid) from public;
+grant execute on function amux.accept_pending_invite(uuid) to authenticated, service_role;
+
+create or replace function amux.decline_pending_invite(p_invite_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path to 'amux', 'public', 'auth'
+as $$
+begin
+  update amux.team_invites
+     set status = 'declined', declined_at = now(), updated_at = now()
+   where id = p_invite_id
+     and id in (select p.invite_id from amux.list_pending_invites_for_me() p);
+
+  if not found then
+    raise exception 'no pending invite % for this account', p_invite_id using errcode = '23503';
+  end if;
+end;
+$$;
+
+comment on function amux.decline_pending_invite(uuid) is
+  'Marks an invite addressed to the caller as declined. The row is kept so the inviter can see the outcome.';
+
+revoke all on function amux.decline_pending_invite(uuid) from public;
+grant execute on function amux.decline_pending_invite(uuid) to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 8. claim_team_invite — keep `status` in step with `consumed_at`
+-- ---------------------------------------------------------------------------
+
+-- Redefines 20260708000000_claim_invite_public_users_for_daemon.sql:19. The
+-- only change is the final UPDATE, which now also sets status='accepted' so the
+-- token path and the contact path leave the same lifecycle state. Every other
+-- line is carried over verbatim.
+CREATE OR REPLACE FUNCTION amux.claim_team_invite(p_token text) RETURNS TABLE(actor_id uuid, team_id uuid, actor_type text, display_name text, refresh_token text)
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'amux', 'public', 'auth', 'extensions'
+    AS $$
+declare
+  v_invite      amux.team_invites%rowtype;
+  v_user_id     uuid;
+  v_actor       uuid;
+  v_email       text;
+  v_session     uuid;
+  v_rt          text := null;
+  v_old_user    uuid;
+  v_target_anon boolean;
+  v_team_org    uuid;   -- invite team's org (S3-FC.3)
+  v_old_org     uuid;   -- claimer's previous org (member path)
+begin
+  select * into v_invite from amux.team_invites where token = p_token for update;
+  if not found then raise exception 'invite not found' using errcode = '23503'; end if;
+  if v_invite.consumed_at is not null then raise exception 'invite already consumed' using errcode = '23514'; end if;
+  if v_invite.status = 'declined' then raise exception 'invite was declined' using errcode = '23514'; end if;
+  if v_invite.status = 'expired' then raise exception 'invite superseded' using errcode = '23514'; end if;
+  if v_invite.expires_at < now() then raise exception 'invite expired' using errcode = '23514'; end if;
+
+  -- Resolved once for both branches: members get public.users.org_id switched,
+  -- agents get the claim baked into raw_app_meta_data.
+  select oid into v_team_org from amux.teams where id = v_invite.team_id;
+
+  if v_invite.kind = 'member' then
+    if v_invite.target_actor_id is not null then
+      select user_id into v_user_id from amux.actors where id = v_invite.target_actor_id;
+      if v_user_id is null then raise exception 'target member has no auth user' using errcode = '23503'; end if;
+      select coalesce(is_anonymous, false) into v_target_anon from auth.users where id = v_user_id;
+      if not v_target_anon then raise exception 'target member is no longer anonymous' using errcode = '23514'; end if;
+
+      v_session := gen_random_uuid();
+      v_rt      := substring(encode(extensions.gen_random_bytes(6), 'hex'), 1, 12);
+      insert into auth.sessions (id, user_id, aal, created_at, updated_at) values (v_session, v_user_id, 'aal1', now(), now());
+      insert into auth.refresh_tokens (token, user_id, session_id, revoked, instance_id, created_at, updated_at)
+        values (v_rt, v_user_id::text, v_session, false, '00000000-0000-0000-0000-000000000000', now(), now());
+
+      v_actor := v_invite.target_actor_id;
+      update amux.actors set last_active_at = now(), updated_at = now() where id = v_actor;
+    else
+      v_user_id := auth.uid();
+      if v_user_id is null then raise exception 'member claim requires authentication' using errcode = '42501'; end if;
+      if exists (select 1 from amux.actors act where act.team_id = v_invite.team_id and act.user_id = v_user_id) then
+        raise exception 'already a member of this team' using errcode = '23505';
+      end if;
+
+      insert into amux.actors (team_id, actor_type, user_id, invited_by_actor_id, display_name, last_active_at)
+      values (v_invite.team_id, 'member', v_user_id, v_invite.invited_by_actor_id, v_invite.display_name, now())
+      returning id into v_actor;
+      insert into amux.members (id, status) values (v_actor, 'active');
+      insert into amux.team_members (team_id, member_id, role) values (v_invite.team_id, v_actor, v_invite.team_role);
+    end if;
+
+    -- S3-FC.3: strict single-org — claimer's org becomes the invite team's org.
+    if v_team_org is not null and v_user_id is not null then
+      select org_id into v_old_org from public.users where id = v_user_id;
+      if v_old_org is null then
+        insert into public.users (id, org_id, mobile) values (v_user_id, v_team_org, '');
+      else
+        update public.users set org_id = v_team_org, updated_at = now() where id = v_user_id;
+      end if;
+      -- best-effort GC of an abandoned one-person (personal) old org; never fail the claim
+      begin
+        if v_old_org is not null and v_old_org <> v_team_org
+           and not exists (select 1 from public.users where org_id = v_old_org) then
+          delete from amux.teams where oid = v_old_org;   -- cascades actors/members/sessions/...
+          delete from public.orgs where id = v_old_org;
+        end if;
+      exception when others then
+        null;  -- leave the orphan; reassignment already succeeded
+      end;
+    end if;
+  else
+    v_user_id := gen_random_uuid();
+    v_email   := format('daemon.%s@amuxd.run', v_user_id);
+    v_session := gen_random_uuid();
+    v_rt      := substring(encode(extensions.gen_random_bytes(6), 'hex'), 1, 12);
+    -- Stamp the team's org into app_metadata so daemon access tokens pass
+    -- teams_org_guard (current_org_id() reads the JWT claim first; daemon
+    -- users have no public.users fallback row).
+    insert into auth.users (id, email, email_confirmed_at, encrypted_password, confirmation_token, recovery_token,
+      email_change_token_new, email_change, raw_app_meta_data, aud, role, created_at, updated_at, instance_id)
+    values (v_user_id, v_email, now(), '', '', '', '', '',
+      case when v_team_org is not null then jsonb_build_object('org_id', v_team_org) else '{}'::jsonb end,
+      'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000');
+    insert into auth.sessions (id, user_id, aal, created_at, updated_at) values (v_session, v_user_id, 'aal1', now(), now());
+    insert into auth.refresh_tokens (token, user_id, session_id, revoked, instance_id, created_at, updated_at)
+      values (v_rt, v_user_id::text, v_session, false, '00000000-0000-0000-0000-000000000000', now(), now());
+
+    -- Also give the daemon account a public.users fallback row with the team's
+    -- org, so org resolvers that query public.users by id directly (without the
+    -- JWT app_metadata.org_id claim) can resolve org_id instead of erroring.
+    if v_team_org is not null then
+      insert into public.users (id, org_id, mobile) values (v_user_id, v_team_org, '')
+      on conflict (id) do update set org_id = excluded.org_id, updated_at = now();
+    end if;
+
+    if v_invite.target_actor_id is not null then
+      select user_id into v_old_user from amux.actors where id = v_invite.target_actor_id;
+      update amux.actors set user_id = v_user_id, invited_by_actor_id = v_invite.invited_by_actor_id,
+             last_active_at = null, updated_at = now() where id = v_invite.target_actor_id;
+      v_actor := v_invite.target_actor_id;
+      update amux.agents set owner_member_id = v_invite.invited_by_actor_id, visibility = 'team', updated_at = now() where id = v_actor;
+      if v_old_user is not null then delete from auth.users where id = v_old_user; end if;
+    else
+      insert into amux.actors (team_id, actor_type, user_id, invited_by_actor_id, display_name, last_active_at)
+      values (v_invite.team_id, 'agent', v_user_id, v_invite.invited_by_actor_id, v_invite.display_name, null)
+      returning id into v_actor;
+      insert into amux.agents (id, owner_member_id, visibility, status) values (v_actor, v_invite.invited_by_actor_id, 'team', 'active');
+    end if;
+
+    insert into amux.agent_member_access (agent_id, member_id, permission_level, granted_by_member_id)
+    values (v_actor, v_invite.invited_by_actor_id, 'admin', v_invite.invited_by_actor_id)
+    on conflict (agent_id, member_id) do update
+      set permission_level = 'admin', granted_by_member_id = excluded.granted_by_member_id, updated_at = now();
+  end if;
+
+  update amux.team_invites set consumed_at = now(), consumed_by_actor_id = v_actor,
+         status = 'accepted', updated_at = now() where id = v_invite.id;
+
+  return query select v_actor, v_invite.team_id, v_invite.kind::text, v_invite.display_name, v_rt;
+end;
+$$;


### PR DESCRIPTION
## 问题

发起邀请时不记录任何联系方式 —— 只有一个 display name 和一个需要邀请人自己带出去的 token。服务端因此无法回答"这个人有没有待接受的邀请？"，被邀请人在 claim 之前对系统完全不可见（actor 行是 claim 时才创建的）。唯一的加入路径就是登录前把 token 存在本地（`pendingInviteToken`）。

## 改动

给 `amux.team_invites` 加上选填的 `invite_email` / `invite_phone`，以及 `pending / accepted / declined / expired` 的软状态生命周期。填了联系方式后，被邀请人**登录时直接看到邀请**并选择接受或拒绝，不需要邀请人再发链接。

**扩展现有表而不是新建临时表**：`team_invites` 本身就是那条"待接受邀请"记录，再开一张表会变成两个真相来源，claim 时还要处理两边的一致性。

原有的 token 链接路径完全不变，作为邀请人不知道对方联系方式时的兜底。

### 安全设计

- `list_pending_invites_for_me()` **不接受任何联系方式参数** —— 它只读 `auth.uid()` 自己的已验证邮箱/手机号，所以没法拿它探测"某个邮箱有没有邀请在等"。
- accept / decline 的鉴权就是"能不能看见"：看不见的邀请返回 404，让"不是你的"和"不存在"无法区分。
- 接受永远是显式选择。邀请人知道你的邮箱不等于你同意加入他的团队 —— 所以已注册用户也走同一条路径，不会被直接拉进团队。
- 未验证的邮箱、匿名会话都匹配不到任何邀请。

### 顺带修掉的两个既有缺陷

- `team_invites_insert_via_rpc` 这条 RLS policy 是**失效逻辑**：WITH CHECK 里 `a.id = a.invited_by_actor_id` 和 `a.team_id = a.team_id` 都是同一 alias 上的自比较（后者恒为真），从未约束住被插入的行。
- OpenAPI 的 `createTeamInvite` 定义和实现完全对不上（请求字段名、enum 取值、响应结构三处都不一致）。

## 验证

用一次性 Postgres 容器灌入 baseline + 完整 migration 链，跑了 19 项端到端检查：

- 邮箱大小写不敏感匹配（`Erin@Acme.com` 存成 `erin@acme.com`，匹配登录的 `ERIN@acme.com`）
- 手机号跨格式匹配（`+86 138-0013-9999` ↔ `8613800139999`）
- 未验证邮箱 / 匿名用户 / 无关第三方 → 全部匹配不到，也接受不了
- 重复邀请同一联系方式 → 旧 token 立即失效
- 拒绝后 token 作废；过期邀请不出现在列表

**这一轮跑出了两个 mock 测试永远发现不了的真 bug：**
1. `raise exception 'no pending invite % ...'` 的 `%` 占位符没传参 —— 该函数任何错误分支都会直接抛 `too few parameters specified for RAISE`。
2. migration 部分失败后无法重跑（`create_team_invite` 已存在）。已改为 `CREATE OR REPLACE` 使其幂等。

自动化测试：前端 typecheck 通过、lint 0 error、单测 2057 passed；FC 961 passed，失败数从 17 降到 15（修好了两个）。**两边都与 rebase 前的 baseline 逐条比对确认零新增失败。** OpenAPI 校验通过且无新增 warning。新增测试 13 个（FC 路由 6、契约 1、前端 store 6）。

## Reviewer 需要知道的三件事

1. **双后端 parity。** 除 Supabase 外还有 `BACKEND_KIND=postgres`（Better-Auth + Drizzle），有 parity 测试强制新方法两边都要有。我做了完整实现而非 501 stub。**但那个后端的 `user` 表没有 phone 字段，手机号匹配在那边永远不可能生效** —— 列保留只为两边表结构一致，migration 里已注明。
2. **pg-repo 的邀请代码没有测试覆盖。** 其契约测试全被 skip（既有 harness 限制：用 `team-1` 这类非 UUID 字符串，与 pg 的 uuid 列不兼容）。代码过了 typecheck、类型也对得上，但没跑过真实 SQL —— 与既有 `createTeamInvite` 处境相同。
3. **手机号"已验证"的判定是个折中。** `bind_phone_to_account` 走自建验证码，验证后直接写 `auth.users.phone` 而不碰 GoTrue 的 `phone_confirmed_at`，所以我用"`auth.users.phone` 非空"作为已验证信号（要求 `phone_confirmed_at` 会导致一条都匹配不到）。若将来出现能在未验证情况下写入该字段的路径，这个判定就会失效。

⚠️ 按 CLAUDE.md，FC 没有配置 GitHub Actions 部署 —— 合并本 PR **不会**自动更新阿里云；migration 也需要单独应用到目标库。

🤖 Generated with [Claude Code](https://claude.com/claude-code)