### PR TITLE
fix(gateway): stop truncating agent replies at the first tool call

### DIFF
--- a/apps/daemon/src/channels/acp_handle.rs
+++ b/apps/daemon/src/channels/acp_handle.rs
@@ -320,27 +320,63 @@ bound chat, so a simple `send(message=\"…\")` or `send(file_path=\"/tmp/report
     )
 }
 
-#[async_trait]
-impl AcpHandle for AmuxdAcpHandle {
-    async fn create_session(
-        &self,
-        _team_id: &str,
-        binding: &str,
-        _title: &str,
-    ) -> Result<AmuxSessionId, AcpError> {
-        // Channels never call this in the gateway-port architecture — the
-        // SQL store mints the logical acp_session_id via
-        // `ensure_gateway_session`. We keep a consistent implementation in
-        // case future callers use it: hand back the binding as the logical
-        // id; `send_prompt` will lazy-spawn on first use.
-        Ok(binding.to_string())
-    }
+/// How often a streamed turn may push a cumulative-text update to the
+/// caller. The agent emits output far faster than any chat UI wants to
+/// redraw, and each update costs a WebSocket round-trip on the channel
+/// side, so updates are coalesced into at most one per interval.
+const STREAM_UPDATE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(700);
 
-    async fn send_prompt(
+/// Join the reply segments a turn has produced so far into the text a
+/// channel should display. `live` is the not-yet-flushed tail (output that
+/// has arrived but hasn't hit a tool-call or turn-end boundary).
+///
+/// Segments are the runs of prose between tool calls, so blank-line joining
+/// matches how Tauri renders them as separate messages.
+fn compose_reply(segments: &[String], live: &str) -> String {
+    let mut parts: Vec<&str> = segments.iter().map(String::as_str).collect();
+    if !live.trim().is_empty() {
+        parts.push(live);
+    }
+    parts.join("\n\n")
+}
+
+/// Fold one event's aggregator output into the reply being accumulated.
+/// Returns true if a segment was flushed (i.e. the visible text jumped),
+/// which the streaming path uses to push an update immediately rather than
+/// waiting out the throttle interval.
+fn absorb_emitted(
+    emitted: Vec<crate::runtime::turn_aggregator::EmittedMessage>,
+    segments: &mut Vec<String>,
+    live: &mut String,
+) -> bool {
+    let mut flushed = false;
+    for m in emitted {
+        if matches!(m.kind, crate::proto::teamclaw::MessageKind::AgentReply) {
+            // Tool-only turns emit an empty AgentReply at turn end purely to
+            // anchor the turn for clients; it carries no text and must not
+            // add a blank segment.
+            if !m.content.is_empty() {
+                segments.push(m.content);
+            }
+            live.clear();
+            flushed = true;
+        }
+    }
+    flushed
+}
+
+impl AmuxdAcpHandle {
+    /// Drive one ACP turn to completion and return the agent's full reply.
+    ///
+    /// Shared by `send_prompt` and `send_prompt_streamed`; `on_update` is
+    /// `None` for the former. See `send_prompt_streamed` on the trait for the
+    /// cumulative-text/best-effort contract.
+    async fn run_turn(
         &self,
         session: &AmuxSessionId,
         sender_display: &str,
         text: &str,
+        on_update: Option<tokio::sync::mpsc::Sender<String>>,
     ) -> Result<AcpTurnOutcome, AcpError> {
         let outcome = self.resolve_or_spawn(session).await?;
 
@@ -411,6 +447,17 @@ impl AcpHandle for AmuxdAcpHandle {
             (turn.agent_id, turn.event_rx)
         };
 
+        // A turn is only over on Active -> Idle. The aggregator also emits an
+        // `AgentReply` *mid-turn*, every time a tool call interrupts buffered
+        // output (`turn_aggregator.rs` `flush_reply_into`), so returning on
+        // the first one truncates every tool-using turn to whatever preamble
+        // the agent wrote before reaching for its first tool. Accumulate the
+        // segments instead and only return once the runtime goes idle.
+        let mut segments: Vec<String> = Vec::new();
+        let mut live = String::new();
+        let mut last_update = std::time::Instant::now();
+        let mut sent_update = String::new();
+
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5 * 60);
         let result: Result<String, AcpError> = loop {
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
@@ -435,21 +482,46 @@ impl AcpHandle for AmuxdAcpHandle {
                 };
                 break Err(AcpError::Send(format!("ACP turn failed: {details}")));
             }
+
+            // Mirror the aggregator's unflushed reply buffer so streamed
+            // updates can show prose as it arrives rather than only at tool
+            // boundaries. Cleared below whenever the aggregator flushes.
+            if let Some(crate::proto::amux::acp_event::Event::Output(o)) = &event.event.event {
+                live.push_str(&o.text);
+            }
+
+            let turn_ended = matches!(
+                &event.event.event,
+                Some(crate::proto::amux::acp_event::Event::StatusChange(sc))
+                    if sc.old_status == crate::proto::amux::AgentStatus::Active as i32
+                        && sc.new_status == crate::proto::amux::AgentStatus::Idle as i32
+            );
+
             let emitted = {
                 let mut mgr = self.manager.lock().await;
                 mgr.aggregator_mut(&agent_id)
                     .map(|agg| agg.ingest(&event.event))
                     .unwrap_or_default()
             };
-            let mut reply: Option<String> = None;
-            for m in emitted {
-                if matches!(m.kind, crate::proto::teamclaw::MessageKind::AgentReply) {
-                    reply = Some(m.content);
-                    break;
-                }
+            let flushed = absorb_emitted(emitted, &mut segments, &mut live);
+
+            if turn_ended {
+                break Ok(compose_reply(&segments, &live));
             }
-            if let Some(text) = reply {
-                break Ok(text);
+
+            // Best-effort progress updates: coalesced by interval, skipped
+            // when nothing changed, and never allowed to fail the turn.
+            if let Some(tx) = &on_update {
+                let due = flushed || last_update.elapsed() >= STREAM_UPDATE_INTERVAL;
+                if due {
+                    let text = compose_reply(&segments, &live);
+                    if !text.trim().is_empty() && text != sent_update {
+                        if tx.try_send(text.clone()).is_ok() {
+                            sent_update = text;
+                        }
+                        last_update = std::time::Instant::now();
+                    }
+                }
             }
         };
 
@@ -463,6 +535,43 @@ impl AcpHandle for AmuxdAcpHandle {
             reply_text,
             completed: true,
         })
+    }
+}
+
+#[async_trait]
+impl AcpHandle for AmuxdAcpHandle {
+    async fn create_session(
+        &self,
+        _team_id: &str,
+        binding: &str,
+        _title: &str,
+    ) -> Result<AmuxSessionId, AcpError> {
+        // Channels never call this in the gateway-port architecture — the
+        // SQL store mints the logical acp_session_id via
+        // `ensure_gateway_session`. We keep a consistent implementation in
+        // case future callers use it: hand back the binding as the logical
+        // id; `send_prompt` will lazy-spawn on first use.
+        Ok(binding.to_string())
+    }
+
+    async fn send_prompt(
+        &self,
+        session: &AmuxSessionId,
+        sender_display: &str,
+        text: &str,
+    ) -> Result<AcpTurnOutcome, AcpError> {
+        self.run_turn(session, sender_display, text, None).await
+    }
+
+    async fn send_prompt_streamed(
+        &self,
+        session: &AmuxSessionId,
+        sender_display: &str,
+        text: &str,
+        on_update: tokio::sync::mpsc::Sender<String>,
+    ) -> Result<AcpTurnOutcome, AcpError> {
+        self.run_turn(session, sender_display, text, Some(on_update))
+            .await
     }
 
     async fn inject_context(
@@ -832,6 +941,113 @@ mod tests {
             workspace_override: Arc::new(Mutex::new(HashMap::new())),
             bot_configs: Arc::new(HashMap::new()),
         }
+    }
+
+    /// Drive a `TurnAggregator` and `absorb_emitted` — the same pair
+    /// `run_turn` uses — over a scripted event stream.
+    fn segments_from(events: &[amux::AcpEvent]) -> Vec<String> {
+        use crate::runtime::turn_aggregator::TurnAggregator;
+        let mut agg = TurnAggregator::new();
+        let mut segments = Vec::new();
+        let mut live = String::new();
+        for ev in events {
+            absorb_emitted(agg.ingest(ev), &mut segments, &mut live);
+        }
+        segments
+    }
+
+    fn output(text: &str) -> amux::AcpEvent {
+        amux::AcpEvent {
+            event: Some(amux::acp_event::Event::Output(amux::AcpOutput {
+                text: text.into(),
+                is_complete: false,
+            })),
+            model: String::new(),
+        }
+    }
+
+    fn tool_use(name: &str) -> amux::AcpEvent {
+        amux::AcpEvent {
+            event: Some(amux::acp_event::Event::ToolUse(amux::AcpToolUse {
+                tool_id: "t1".into(),
+                tool_name: name.into(),
+                description: String::new(),
+                params: Default::default(),
+                tool_kind: String::new(),
+                raw_input_json: String::new(),
+                raw_output_json: String::new(),
+                content: vec![],
+                locations: vec![],
+                status: String::new(),
+            })),
+            model: String::new(),
+        }
+    }
+
+    fn turn_end() -> amux::AcpEvent {
+        amux::AcpEvent {
+            event: Some(amux::acp_event::Event::StatusChange(amux::AcpStatusChange {
+                old_status: amux::AgentStatus::Active as i32,
+                new_status: amux::AgentStatus::Idle as i32,
+            })),
+            model: String::new(),
+        }
+    }
+
+    /// Regression: a tool call mid-turn makes the aggregator flush an
+    /// `AgentReply` carrying only the prose written *before* the tool. Any
+    /// consumer that stops at the first one ships the agent's "let me go look
+    /// that up:" preamble as the whole answer and drops the real reply — which
+    /// is what WeCom users saw.
+    #[test]
+    fn reply_keeps_every_segment_across_a_tool_call() {
+        let segments = segments_from(&[
+            output("让我再找一下 token 的来源："),
+            tool_use("Read"),
+            output("Token 还没过期！"),
+            turn_end(),
+        ]);
+
+        assert_eq!(
+            segments,
+            vec!["让我再找一下 token 的来源：", "Token 还没过期！"],
+            "the aggregator must surface the pre-tool preamble and the post-tool answer separately"
+        );
+        assert_eq!(
+            compose_reply(&segments, ""),
+            "让我再找一下 token 的来源：\n\nToken 还没过期！"
+        );
+    }
+
+    #[test]
+    fn reply_survives_several_tool_calls() {
+        let segments = segments_from(&[
+            output("first"),
+            tool_use("Read"),
+            tool_use("Grep"),
+            output("second"),
+            tool_use("Bash"),
+            output("third"),
+            turn_end(),
+        ]);
+        assert_eq!(compose_reply(&segments, ""), "first\n\nsecond\n\nthird");
+    }
+
+    /// Tool-only turns emit an empty `AgentReply` at turn end to anchor the
+    /// turn for clients; it must not become a blank segment.
+    #[test]
+    fn tool_only_turn_yields_empty_reply() {
+        let segments = segments_from(&[tool_use("Bash"), turn_end()]);
+        assert!(segments.is_empty());
+        assert_eq!(compose_reply(&segments, ""), "");
+    }
+
+    #[test]
+    fn compose_reply_appends_unflushed_tail() {
+        let segments = vec!["done".to_string()];
+        assert_eq!(compose_reply(&segments, "typing"), "done\n\ntyping");
+        assert_eq!(compose_reply(&segments, "   "), "done");
+        assert_eq!(compose_reply(&[], "typing"), "typing");
     }
 
     #[test]

--- a/crates/teamclaw-gateway/src/acp.rs
+++ b/crates/teamclaw-gateway/src/acp.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use tokio::sync::mpsc;
 
 /// Identifier of an amuxd session that a gateway channel is conversing with.
 /// Opaque to the gateway; resolved against amuxd's runtime manager.
@@ -65,6 +66,30 @@ pub trait AcpHandle: Send + Sync + 'static {
         sender_display: &str,
         text: &str,
     ) -> Result<AcpTurnOutcome, AcpError>;
+
+    /// Same as `send_prompt`, but reports the reply as it grows so channels
+    /// with editable message bubbles can show progress mid-turn.
+    ///
+    /// `on_update` receives the **cumulative** reply text, not deltas — the
+    /// WeCom stream msgtype replaces a bubble's content by re-sending the
+    /// same id, so callers want the whole text every time. Updates are
+    /// best-effort and throttled: a slow or dropped receiver never fails the
+    /// turn, and intermediate updates may be skipped. The returned
+    /// `AcpTurnOutcome` is always authoritative — send it as the final,
+    /// finished bubble regardless of what arrived on the channel.
+    ///
+    /// The default impl ignores `on_update` and delegates to `send_prompt`,
+    /// so channels without progressive rendering need no changes.
+    async fn send_prompt_streamed(
+        &self,
+        session: &AmuxSessionId,
+        sender_display: &str,
+        text: &str,
+        on_update: mpsc::Sender<String>,
+    ) -> Result<AcpTurnOutcome, AcpError> {
+        let _ = on_update;
+        self.send_prompt(session, sender_display, text).await
+    }
 
     /// Inject context without triggering a reply (v1 `noReply: true`).
     /// Kept on the trait for future use; not called by v1-of-port channels.

--- a/crates/teamclaw-gateway/src/wecom.rs
+++ b/crates/teamclaw-gateway/src/wecom.rs
@@ -1511,13 +1511,47 @@ impl WeComGateway {
             .send_stream_chunk(&req_id, &stream_id, "💭 正在思考…", false, &ws_sink)
             .await;
 
+        // Progressive rendering: `send_prompt_streamed` pushes the cumulative
+        // reply text as the agent produces it, and each update overwrites the
+        // same bubble. Runs on its own task so the turn is never blocked by a
+        // slow WebSocket write; dropping `update_tx` (when the turn returns)
+        // closes the channel and ends the task.
+        let (update_tx, mut update_rx) = mpsc::channel::<String>(32);
+        let stream_task = {
+            let req_id = req_id.clone();
+            let stream_id = stream_id.clone();
+            let ws_sink = ws_sink.clone();
+            tokio::spawn(async move {
+                while let Some(text) = update_rx.recv().await {
+                    if let Err(e) =
+                        Self::send_stream_chunk_static(&req_id, &stream_id, &text, false, &ws_sink)
+                            .await
+                    {
+                        eprintln!("[WeCom] Stream update failed: {}", e);
+                        break;
+                    }
+                }
+            })
+        };
+
         // Drive a single ACP turn through amuxd — runs in parallel with the
         // attachment uploads spawned above.
-        let reply = match self
+        let reply_result = self
             .acp
-            .send_prompt(&outcome.acp_session_id, &sender_display_name, &prompt_text)
-            .await
-        {
+            .send_prompt_streamed(
+                &outcome.acp_session_id,
+                &sender_display_name,
+                &prompt_text,
+                update_tx,
+            )
+            .await;
+
+        // Drain pending updates before the final frame: a `finish=false`
+        // chunk landing after `finish=true` would re-open the bubble and
+        // leave stale text in it.
+        let _ = stream_task.await;
+
+        let reply = match reply_result {
             Ok(r) => r,
             Err(e) => {
                 let _ = self
@@ -1878,7 +1912,6 @@ impl WeComGateway {
     }
 
     /// Static version of send_stream_chunk for use in spawned tasks (no &self needed)
-    #[allow(dead_code)]
     async fn send_stream_chunk_static(
         req_id: &str,
         stream_id: &str,


### PR DESCRIPTION
## 问题

企微连上 channel 后，agent 输出一部分就没了，但 Tauri 里内容是完整的。

截图里被截断的回复都以冒号结尾——「让我再找一下 token 的来源：」——这正是 agent 调工具**之前**的开场白，是这个 bug 的签名特征。

## 原因

`AcpHandle::send_prompt`（`apps/daemon/src/channels/acp_handle.rs`）拿到**第一个** `AgentReply` 就 return 整个 turn：

```rust
for m in emitted {
    if matches!(m.kind, MessageKind::AgentReply) {
        reply = Some(m.content);
        break;
    }
}
```

但 `TurnAggregator` 会在 **turn 中途**就吐出 `AgentReply`——每次工具调用打断缓冲输出时都会 `flush_reply_into`（`turn_aggregator.rs:129-135`）。真正的 turn 结束信号是 StatusChange 的 Active→Idle，aggregator 里注明了这是 "the canonical turn ended signal"。

所以：agent 先说「让我再找一下 token 的来源：」→ 准备调工具 → aggregator flush 出这句 → `send_prompt` 立刻返回 → 企微收到并带 `finish=true` 封口。工具跑完后的真答案还在继续产出，但没人接了，只进了 Tauri 的存储。

**这个 bug 不只影响企微。** `send_prompt` 是所有 channel 共用的，discord / 飞书 / kook / 微信 / email 同样会把开场白当成完整回复发出去。

## 改动

**`apps/daemon/src/channels/acp_handle.rs`** — 核心修复。实现体抽成 `run_turn`，累积所有 `AgentReply` 片段，只在 Active→Idle 时返回，片段间空行拼接。tool-only turn 那条用于给客户端锚定 turn 的空 `AgentReply` 会跳过，不产生空片段。所有 channel 一并修好。

**`crates/teamclaw-gateway/src/acp.rs`** — 新增带默认实现的 `send_prompt_streamed`，默认委托给 `send_prompt`，其它 channel 和测试里的 `MockAcp` 都不用改。

**`crates/teamclaw-gateway/src/wecom.rs`** — 接上真流式：独立 task 消费累积文本，用同一个 `stream_id` 以 `finish=false` 持续覆盖气泡；turn 返回后先 join 该 task 再发 `finish=true`，避免迟到的 `finish=false` 把已封口的气泡重新打开。`send_stream_chunk_static` 的 `dead_code` 标注去掉——它现在真的用上了。

## 测试

`cargo test -p teamclaw-gateway -p amuxd` 全绿（743 passed），新增 5 个测试。收集逻辑抽成了 `absorb_emitted` 供生产代码和测试共用，避免测试照抄一份副本。

**局限（reviewer 请注意）**：新测试锁的是 aggregator 会在工具调用处吐多个 `AgentReply`、以及 `absorb_emitted` / `compose_reply` 会全部保留。但「只在 turn 结束才返回」这个 `run_turn` 循环本身的不变量**没有**被直接覆盖——那需要一个能喂事件流的 runtime harness，现在没有。如果有人把 `break` 加回去，这些测试拦不住。

## 待确认

- **未做真机验证**——还没在真实企微里跑过流式效果。
- `STREAM_UPDATE_INTERVAL` 的 700ms 是拍的，没有企微侧 `aibot_respond_msg` 频率限制的依据。若实测被限流，调这个常量即可。
- **长度上限问题依然存在**，与本 bug 无关：wecom.rs 的回复路径没有任何分片，而 cron 路径按 4000 切（`cron/delivery.rs:308`）。而且 wecom.rs 回复路径上的发送结果全部被 `let _ =` 丢弃、从不读企微的 ack，所以服务端拒收是完全静默的。建议另开 issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)