### PR TITLE
build: split app.displayName from app.name

### DIFF
--- a/build.config.example.json
+++ b/build.config.example.json
@@ -5,6 +5,7 @@
   },
   "app": {
     "name": "TeamClaw",
+    "displayName": "TeamClaw",
     "shortName": "teamclaw",
     "palette": "default",
     "logo": "branding/acme/logo.png",

--- a/build.config.example.json
+++ b/build.config.example.json
@@ -26,7 +26,7 @@
       "wecom": true,
       "wechat": true
     },
-    "auth": { "google": false, "wechat": false, "phone": false },
+    "auth": { "google": false, "wechat": false, "phone": false, "webSSO": false },
     "teamShareBrowser": false
   },
   "opencode": {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -12,7 +12,7 @@ import { Toaster, toast } from "sonner";
 import { cn, isTauri, removeStartupSkeleton } from "@/lib/utils";
 import { capabilities } from "@/lib/platform";
 import { scheduleReleaseStuckModalLayers } from "@/lib/modal-layer-cleanup";
-import { buildConfig } from "@/lib/build-config";
+import { appDisplayName, buildConfig } from "@/lib/build-config";
 import { buildSessionDeeplink } from "@/lib/session-deeplink";
 import { markStartup } from "@/lib/startup-perf";
 import {
@@ -2171,7 +2171,7 @@ function AppContent() {
             data-tauri-drag-region
           >
             {collapsedInsetLeading}
-            <span className="font-medium">{buildConfig.app.name}</span>
+            <span className="font-medium">{appDisplayName}</span>
           </header>
           <div className="flex flex-1 items-center justify-center">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />

--- a/packages/app/src/components/SetupGuide.tsx
+++ b/packages/app/src/components/SetupGuide.tsx
@@ -19,7 +19,7 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useDepsStore, type DependencyInfo } from '@/stores/deps'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 
 export type { DependencyInfo }
 
@@ -593,7 +593,7 @@ export function SetupGuide({ onContinue }: SetupGuideProps) {
   }
 
   const phaseDescription = {
-    overview: t('setup.intro', { defaultValue: '{{appName}} needs a few tools to work properly. Install the missing dependencies to get started.', appName: buildConfig.app.name }),
+    overview: t('setup.intro', { defaultValue: '{{appName}} needs a few tools to work properly. Install the missing dependencies to get started.', appName: appDisplayName }),
     customize: t('setup.customizeIntro', 'Choose which dependencies to install. Required tools are pre-selected.'),
     installing: t('setup.installingIntro', 'Please wait while dependencies are being installed...'),
     results: t('setup.resultsIntro', 'Installation has finished. See the results below.'),

--- a/packages/app/src/components/auth/LoginScreen.tsx
+++ b/packages/app/src/components/auth/LoginScreen.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "@/stores/auth-store";
-import { buildConfig } from "@/lib/build-config";
+import { appDisplayName, buildConfig } from "@/lib/build-config";
 import { hasBackendConfig } from "@/lib/backend";
 import { getEffectiveServerConfigSync } from "@/lib/server-config";
 import { useAppVersion } from "@/lib/version";
@@ -182,14 +182,14 @@ export function LoginScreen({ embedded = false, onBack }: LoginScreenProps) {
         <div className="mb-8 flex flex-col items-center gap-3">
           <img
             src="/logo.png"
-            alt={`${buildConfig.app.name} logo`}
+            alt={`${appDisplayName} logo`}
             width={128}
             height={128}
             className="h-20 w-20 object-contain"
           />
           <div className="text-center">
             <h1 className="text-[22px] font-semibold tracking-tight text-foreground">
-              {buildConfig.app.name}
+              {appDisplayName}
             </h1>
             <p className="mt-1 text-[13px] text-muted-foreground">
               {t("auth.tagline", "AI Ally · AI Teammate")}

--- a/packages/app/src/components/auth/WelcomeScreen.tsx
+++ b/packages/app/src/components/auth/WelcomeScreen.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
-import { buildConfig } from "@/lib/build-config";
+import { appDisplayName } from "@/lib/build-config";
 import { useAppVersion } from "@/lib/version";
 
 /**
@@ -20,10 +20,10 @@ export function WelcomeScreen({ onContinue }: { onContinue: () => void }) {
         <div className="flex flex-1 flex-col items-center justify-center text-center">
           <img
             src="/logo.png"
-            alt={`${buildConfig.app.name} logo`}
+            alt={`${appDisplayName} logo`}
             className="mb-5 h-20 w-20 object-contain"
           />
-          <h1 className="text-[30px] font-semibold text-foreground">{buildConfig.app.name}</h1>
+          <h1 className="text-[30px] font-semibold text-foreground">{appDisplayName}</h1>
           <p className="mt-3 max-w-sm text-[14px] leading-6 text-ink-2">
             {t("auth.onboarding.tagline", "Choose how to enter TeamClaw.")}
           </p>

--- a/packages/app/src/components/settings/AboutSection.tsx
+++ b/packages/app/src/components/settings/AboutSection.tsx
@@ -13,7 +13,7 @@ import {
   RefreshCw,
   AlertCircle,
 } from "lucide-react";
-import { buildConfig } from "@/lib/build-config";
+import { appDisplayName, buildConfig } from "@/lib/build-config";
 import { useUpdaterStore } from "@/stores/updater";
 import { useAppVersion } from "@/lib/version";
 import { Button } from "@/components/ui/button";
@@ -53,11 +53,11 @@ export const AboutSection = React.memo(function AboutSection() {
           <div className="flex items-center gap-4">
             <img
               src="/logo-64.png"
-              alt={`${buildConfig.app.name} Logo`}
+              alt={`${appDisplayName} Logo`}
               className="h-14 w-14 object-contain"
             />
             <div>
-              <h4 className="font-semibold text-base">{buildConfig.app.name}</h4>
+              <h4 className="font-semibold text-base">{appDisplayName}</h4>
               <p className="text-[13px] text-muted-foreground">
                 Version {appVersion}
               </p>
@@ -221,10 +221,10 @@ export const AboutSection = React.memo(function AboutSection() {
         <p className="text-[13px] text-muted-foreground flex items-center justify-center gap-1">
           {t("settings.about.madeWith", "Made with")}{" "}
           <Heart className="h-4 w-4 text-red-500 fill-red-500" />{" "}
-          {t("settings.about.byTeam", { defaultValue: "by {{appName}} Team", appName: buildConfig.app.name })}
+          {t("settings.about.byTeam", { defaultValue: "by {{appName}} Team", appName: appDisplayName })}
         </p>
         <p className="text-xs text-muted-foreground mt-2">
-          &copy; 2024 {buildConfig.app.name}. All rights reserved.
+          &copy; 2024 {appDisplayName}. All rights reserved.
         </p>
       </div>
     </div>

--- a/packages/app/src/components/settings/DependenciesSection.tsx
+++ b/packages/app/src/components/settings/DependenciesSection.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn, isTauri, copyToClipboard } from '@/lib/utils'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { useDepsStore } from '@/stores/deps'
 import type { DependencyInfo } from '@/stores/deps'
 
@@ -165,7 +165,7 @@ export function DependenciesSection() {
         <SectionHeader
           icon={Package}
           title={t('settings.deps.title', 'Dependencies')}
-          description={t('settings.deps.description', { defaultValue: 'External tools required by {{appName}}', appName: buildConfig.app.name })}
+          description={t('settings.deps.description', { defaultValue: 'External tools required by {{appName}}', appName: appDisplayName })}
           iconColor="text-teal-500"
         />
         <SettingCard>
@@ -182,7 +182,7 @@ export function DependenciesSection() {
       <SectionHeader
         icon={Package}
         title={t('settings.deps.title', 'Dependencies')}
-        description={t('settings.deps.description', { defaultValue: 'External tools required by {{appName}}', appName: buildConfig.app.name })}
+        description={t('settings.deps.description', { defaultValue: 'External tools required by {{appName}}', appName: appDisplayName })}
         iconColor="text-teal-500"
       />
 

--- a/packages/app/src/components/settings/MCPSection.tsx
+++ b/packages/app/src/components/settings/MCPSection.tsx
@@ -18,7 +18,7 @@ import {
 import { useMCPStore, type MCPServerConfig } from '@/stores/mcp'
 import { useDepsStore } from '@/stores/deps'
 import { cn } from '@/lib/utils'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -429,7 +429,7 @@ export const MCPSection = React.memo(function MCPSection() {
           <h4 className="font-medium mb-4 flex items-center gap-2">
             <Shield className="h-4 w-4 text-blue-500" />
             {t('settings.mcp.inherentMCP')}
-            <span className="text-xs font-normal text-muted-foreground ml-auto">{t('settings.mcp.managedByTeamClaw', { defaultValue: 'Managed by {{appName}}', appName: buildConfig.app.name })}</span>
+            <span className="text-xs font-normal text-muted-foreground ml-auto">{t('settings.mcp.managedByTeamClaw', { defaultValue: 'Managed by {{appName}}', appName: appDisplayName })}</span>
           </h4>
           <div className="space-y-3">
             {inherentEntries.map(([name, config]) => {

--- a/packages/app/src/components/settings/PrivacySection.tsx
+++ b/packages/app/src/components/settings/PrivacySection.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Shield } from 'lucide-react'
 import { useTelemetryStore } from '@/stores/telemetry'
 import { cn } from '@/lib/utils'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { ToggleSwitch } from './shared'
 
 export function PrivacySection() {
@@ -29,7 +29,7 @@ export function PrivacySection() {
             {t('settings.privacy.title', 'Privacy & Telemetry')}
           </h3>
           <p className="mt-1 text-[12.5px] text-muted-foreground">
-            {t('settings.privacy.description', { defaultValue: 'Control anonymous usage data collection to help improve {{appName}}.', appName: buildConfig.app.name })}
+            {t('settings.privacy.description', { defaultValue: 'Control anonymous usage data collection to help improve {{appName}}.', appName: appDisplayName })}
           </p>
         </div>
       </div>

--- a/packages/app/src/components/settings/SkillsSection.tsx
+++ b/packages/app/src/components/settings/SkillsSection.tsx
@@ -39,7 +39,7 @@ import {
   deleteDaemonSkill,
 } from '@/lib/daemon-local-client'
 import { cn } from '@/lib/utils'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -1259,7 +1259,7 @@ ${skillContent.trim()}`
                         {t('settings.skills.inherentSkills', 'Inherent Skills')}
                       </span>
                       <div className="flex-1 h-px bg-blue-200/60 dark:bg-blue-800/40" />
-                      <span className="text-[11px] text-muted-foreground">{t('settings.skills.managedByTeamClaw', { defaultValue: 'Managed by {{appName}}', appName: buildConfig.app.name })}</span>
+                      <span className="text-[11px] text-muted-foreground">{t('settings.skills.managedByTeamClaw', { defaultValue: 'Managed by {{appName}}', appName: appDisplayName })}</span>
                     </div>
                     {renderSkillGrid(builtinSkills)}
                   </div>

--- a/packages/app/src/components/settings/channels/DiscordDialogs.tsx
+++ b/packages/app/src/components/settings/channels/DiscordDialogs.tsx
@@ -18,7 +18,7 @@ import {
   Zap,
 } from 'lucide-react'
 import { cn, openExternalUrl, copyToClipboard as copyToClipboardUtil } from '@/lib/utils'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -37,7 +37,7 @@ import { ToggleSwitch } from './shared'
 
 // Setup Wizard Component - steps built with t() inside component
 const getDiscordWizardSteps = (t: (key: string, options?: Record<string, unknown>) => string) => [
-  { id: 'intro', title: t('settings.channels.discord.welcome', { defaultValue: 'Welcome to Discord Setup' }), description: t('settings.channels.discord.welcomeDesc', { defaultValue: "Let's connect your Discord bot to {{appName}} in a few simple steps.", appName: buildConfig.app.name }) },
+  { id: 'intro', title: t('settings.channels.discord.welcome', { defaultValue: 'Welcome to Discord Setup' }), description: t('settings.channels.discord.welcomeDesc', { defaultValue: "Let's connect your Discord bot to {{appName}} in a few simple steps.", appName: appDisplayName }) },
   { id: 'create-app', title: t('settings.channels.discord.createApp', { defaultValue: 'Create Discord Application' }), description: t('settings.channels.discord.createAppDesc', { defaultValue: 'First, we need to create a Discord application and bot.' }) },
   { id: 'get-token', title: t('settings.channels.discord.getToken', { defaultValue: 'Get Your Bot Token' }), description: t('settings.channels.discord.getTokenDesc', { defaultValue: "Copy your bot's secret token to authenticate." }) },
   { id: 'permissions', title: t('settings.channels.discord.permissions', { defaultValue: 'Configure Permissions' }), description: t('settings.channels.discord.permissionsDesc', { defaultValue: 'Set up the required permissions for your bot.' }) },
@@ -120,9 +120,9 @@ export function SetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.discord.connectTitle', { defaultValue: 'Connect Discord to {{appName}}', appName: buildConfig.app.name })}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.discord.connectTitle', { defaultValue: 'Connect Discord to {{appName}}', appName: appDisplayName })}</h3>
               <p className="text-[13px] text-muted-foreground">
-                {`This wizard will guide you through creating a Discord bot and connecting it to ${buildConfig.app.name}.`}
+                {`This wizard will guide you through creating a Discord bot and connecting it to ${appDisplayName}.`}
                 You'll be able to interact with AI directly from Discord channels and DMs.
               </p>
             </div>
@@ -162,7 +162,7 @@ export function SetupWizard({
                     <ol className="list-decimal list-inside space-y-2 text-blue-800 dark:text-blue-200">
                       <li>{t('settings.channels.discord.createBotStep1', 'Go to the Discord Developer Portal')}</li>
                       <li>{t('settings.channels.discord.createBotStep2', 'Click "New Application"')}</li>
-                      <li>{t('settings.channels.discord.createBotStep3', { defaultValue: 'Enter a name (e.g., "{{appName}} Bot") and create', appName: buildConfig.app.name })}</li>
+                      <li>{t('settings.channels.discord.createBotStep3', { defaultValue: 'Enter a name (e.g., "{{appName}} Bot") and create', appName: appDisplayName })}</li>
                       <li>{t('settings.channels.discord.createBotStep4', 'Navigate to "Bot" in the left sidebar')}</li>
                       <li>{t('settings.channels.discord.createBotStep5', 'Click "Add Bot" to create a bot user')}</li>
                     </ol>

--- a/packages/app/src/components/settings/channels/Email.tsx
+++ b/packages/app/src/components/settings/channels/Email.tsx
@@ -19,7 +19,7 @@ import {
   Globe,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -483,14 +483,14 @@ export function EmailChannel() {
                 {t('settings.channels.email.displayName', 'Bot Display Name')}
               </label>
               <Input
-                placeholder={t('settings.channels.email.displayNamePlaceholder', { defaultValue: '{{appName}} Agent', appName: buildConfig.app.name })}
+                placeholder={t('settings.channels.email.displayNamePlaceholder', { defaultValue: '{{appName}} Agent', appName: appDisplayName })}
                 value={emailLocalConfig.displayName}
                 onChange={(e) => updateEmailLocalConfig({ displayName: e.target.value })}
               />
               <p className="text-xs text-muted-foreground">
                 {t('settings.channels.email.displayNameHint', 'Name shown in the From header of reply emails, e.g.')}{' '}
                 <span className="font-mono">
-                  {emailLocalConfig.displayName.trim() || `${buildConfig.app.name} Agent`}
+                  {emailLocalConfig.displayName.trim() || `${appDisplayName} Agent`}
                   {' <'}
                   {(() => {
                     const baseEmail = emailLocalConfig.provider === 'gmail'

--- a/packages/app/src/components/settings/channels/EmailSetupWizard.tsx
+++ b/packages/app/src/components/settings/channels/EmailSetupWizard.tsx
@@ -13,7 +13,7 @@ import {
   ExternalLink,
 } from 'lucide-react'
 import { cn, openExternalUrl } from '@/lib/utils'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -36,7 +36,7 @@ const EMAIL_WIZARD_STEPS = [
     titleKey: 'settings.channels.email.wizardIntroTitle',
     title: 'Welcome to Email Setup',
     descKey: 'settings.channels.email.wizardIntroDesc',
-    description: `Let's connect your email to ${buildConfig.app.name} as a communication channel.`,
+    description: `Let's connect your email to ${appDisplayName} as a communication channel.`,
   },
   {
     id: 'provider',
@@ -161,7 +161,7 @@ export function EmailSetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.email.connectTitle', { defaultValue: 'Connect Email to {{appName}}', appName: buildConfig.app.name })}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.email.connectTitle', { defaultValue: 'Connect Email to {{appName}}', appName: appDisplayName })}</h3>
               <p className="text-[13px] text-muted-foreground">
                 {t('settings.channels.email.connectDesc', 'This wizard will guide you through setting up email as a communication channel. The bot will monitor your inbox, process incoming emails through AI, and send threaded replies.')}
               </p>

--- a/packages/app/src/components/settings/channels/Feishu.tsx
+++ b/packages/app/src/components/settings/channels/Feishu.tsx
@@ -20,7 +20,7 @@ import {
   Zap,
 } from 'lucide-react'
 import { cn, openExternalUrl } from '@/lib/utils'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -49,7 +49,7 @@ const FEISHU_WIZARD_STEPS = [
     titleKey: 'settings.channels.feishu.wizardIntroTitle',
     title: 'Welcome to Feishu Setup',
     descKey: 'settings.channels.feishu.wizardIntroDesc',
-    description: `Let's connect your Feishu bot to ${buildConfig.app.name} in a few simple steps.`,
+    description: `Let's connect your Feishu bot to ${appDisplayName} in a few simple steps.`,
   },
   {
     id: 'create-app',
@@ -145,9 +145,9 @@ function FeishuSetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.feishu.connectTitle', { defaultValue: 'Connect Feishu to {{appName}}', appName: buildConfig.app.name })}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.feishu.connectTitle', { defaultValue: 'Connect Feishu to {{appName}}', appName: appDisplayName })}</h3>
               <p className="text-[13px] text-muted-foreground">
-                {t('settings.channels.feishu.connectDesc', { defaultValue: "This wizard will guide you through creating a Feishu app and connecting it to {{appName}}. You'll be able to interact with AI directly from Feishu chats.", appName: buildConfig.app.name })}
+                {t('settings.channels.feishu.connectDesc', { defaultValue: "This wizard will guide you through creating a Feishu app and connecting it to {{appName}}. You'll be able to interact with AI directly from Feishu chats.", appName: appDisplayName })}
               </p>
             </div>
 
@@ -185,7 +185,7 @@ function FeishuSetupWizard({
                   <ol className="list-decimal list-inside space-y-2 text-blue-800 dark:text-blue-200">
                     <li>{t('settings.channels.feishu.createAppStep1', 'Go to the Feishu Developer Portal')}</li>
                     <li>{t('settings.channels.feishu.createAppStep2', 'Click "Create Custom App"')}</li>
-                    <li>{t('settings.channels.feishu.createAppStep3', { defaultValue: 'Enter a name (e.g., "{{appName}} Bot") and description', appName: buildConfig.app.name })}</li>
+                    <li>{t('settings.channels.feishu.createAppStep3', { defaultValue: 'Enter a name (e.g., "{{appName}} Bot") and description', appName: appDisplayName })}</li>
                     <li>{t('settings.channels.feishu.createAppStep4', 'Select your organization')}</li>
                     <li>{t('settings.channels.feishu.createAppStep5', 'Click "Create"')}</li>
                   </ol>

--- a/packages/app/src/components/settings/channels/KookDialogs.tsx
+++ b/packages/app/src/components/settings/channels/KookDialogs.tsx
@@ -15,7 +15,7 @@ import {
   ExternalLink,
 } from 'lucide-react'
 import { cn, openExternalUrl } from '@/lib/utils'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -39,7 +39,7 @@ const KOOK_WIZARD_STEPS = [
     titleKey: 'settings.channels.kook.wizardIntroTitle',
     title: 'Welcome to KOOK Setup',
     descKey: 'settings.channels.kook.wizardIntroDesc',
-    description: `Let's connect your KOOK bot to ${buildConfig.app.name} in a few simple steps.`,
+    description: `Let's connect your KOOK bot to ${appDisplayName} in a few simple steps.`,
   },
   {
     id: 'create-bot',
@@ -138,9 +138,9 @@ export function KookSetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.kook.connectTitle', { defaultValue: 'Connect KOOK to {{appName}}', appName: buildConfig.app.name })}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.kook.connectTitle', { defaultValue: 'Connect KOOK to {{appName}}', appName: appDisplayName })}</h3>
               <p className="text-[13px] text-muted-foreground">
-                {t('settings.channels.kook.connectDesc', { defaultValue: "This wizard will guide you through creating a KOOK bot and connecting it to {{appName}}. You'll be able to interact with AI directly from KOOK servers and DMs.", appName: buildConfig.app.name })}
+                {t('settings.channels.kook.connectDesc', { defaultValue: "This wizard will guide you through creating a KOOK bot and connecting it to {{appName}}. You'll be able to interact with AI directly from KOOK servers and DMs.", appName: appDisplayName })}
               </p>
             </div>
 
@@ -178,7 +178,7 @@ export function KookSetupWizard({
                   <ol className="list-decimal list-inside space-y-2 text-orange-800 dark:text-orange-200">
                     <li>{t('settings.channels.kook.createBotStep1', 'Go to the KOOK Developer Portal')}</li>
                     <li>{t('settings.channels.kook.createBotStep2', 'Click "Create Application"')}</li>
-                    <li>{t('settings.channels.kook.createBotStep3', { defaultValue: 'Enter a name (e.g., "{{appName}} Bot") and icon', appName: buildConfig.app.name })}</li>
+                    <li>{t('settings.channels.kook.createBotStep3', { defaultValue: 'Enter a name (e.g., "{{appName}} Bot") and icon', appName: appDisplayName })}</li>
                     <li>{t('settings.channels.kook.createBotStep4', 'Select "Bot" type')}</li>
                     <li>{t('settings.channels.kook.createBotStep5', 'Click "Create"')}</li>
                   </ol>

--- a/packages/app/src/components/settings/channels/Wechat.tsx
+++ b/packages/app/src/components/settings/channels/Wechat.tsx
@@ -14,7 +14,7 @@ import {
   RefreshCw,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -42,7 +42,7 @@ const WECHAT_WIZARD_STEPS = [
     titleKey: 'settings.channels.wechat.wizardIntroTitle',
     title: 'Welcome to WeChat Setup',
     descKey: 'settings.channels.wechat.wizardIntroDesc',
-    description: `Let's connect your WeChat account to ${buildConfig.app.name} via ClawBot.`,
+    description: `Let's connect your WeChat account to ${appDisplayName} via ClawBot.`,
   },
   {
     id: 'scan',
@@ -178,7 +178,7 @@ function WeChatSetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.wechat.connectTitle', { defaultValue: 'Connect WeChat to {{appName}}', appName: buildConfig.app.name })}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.wechat.connectTitle', { defaultValue: 'Connect WeChat to {{appName}}', appName: appDisplayName })}</h3>
               <p className="text-[13px] text-muted-foreground">
                 {t('settings.channels.wechat.connectDesc', "This wizard will connect your WeChat account via ClawBot. You'll scan a QR code with WeChat on your iPhone to log in.")}
               </p>

--- a/packages/app/src/components/settings/channels/Wecom.tsx
+++ b/packages/app/src/components/settings/channels/Wecom.tsx
@@ -18,7 +18,7 @@ import {
 } from 'lucide-react'
 import { QRCodeSVG } from 'qrcode.react'
 import { cn } from '@/lib/utils'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -52,7 +52,7 @@ const WECOM_WIZARD_STEPS = [
     titleKey: 'settings.channels.wecom.wizardIntroTitle',
     title: 'Welcome to WeCom Setup',
     descKey: 'settings.channels.wecom.wizardIntroDesc',
-    description: `Let's connect your WeCom AI bot to ${buildConfig.app.name} in a few simple steps.`,
+    description: `Let's connect your WeCom AI bot to ${appDisplayName} in a few simple steps.`,
   },
   {
     id: 'choose-method',
@@ -244,9 +244,9 @@ function WeComSetupWizard({
             </div>
 
             <div className="text-center space-y-2">
-              <h3 className="text-lg font-semibold">{t('settings.channels.wecom.connectTitle', { defaultValue: 'Connect WeCom to {{appName}}', appName: buildConfig.app.name })}</h3>
+              <h3 className="text-lg font-semibold">{t('settings.channels.wecom.connectTitle', { defaultValue: 'Connect WeCom to {{appName}}', appName: appDisplayName })}</h3>
               <p className="text-[13px] text-muted-foreground">
-                {t('settings.channels.wecom.connectDesc', { defaultValue: "This wizard will guide you through creating a WeCom AI bot and connecting it to {{appName}}. You'll be able to interact with AI directly from WeCom chats.", appName: buildConfig.app.name })}
+                {t('settings.channels.wecom.connectDesc', { defaultValue: "This wizard will guide you through creating a WeCom AI bot and connecting it to {{appName}}. You'll be able to interact with AI directly from WeCom chats.", appName: appDisplayName })}
               </p>
             </div>
 
@@ -488,7 +488,7 @@ function WeComSetupWizard({
             {t(currentStep.titleKey, currentStep.title)}
           </DialogTitle>
           <DialogDescription>
-            {t(currentStep.descKey, { defaultValue: currentStep.description, appName: buildConfig.app.name })}
+            {t(currentStep.descKey, { defaultValue: currentStep.description, appName: appDisplayName })}
           </DialogDescription>
         </DialogHeader>
 

--- a/packages/app/src/components/settings/team/TeamGitConfig.tsx
+++ b/packages/app/src/components/settings/team/TeamGitConfig.tsx
@@ -26,7 +26,7 @@ import { useWorkspaceStore } from '@/stores/workspace'
 import { useCurrentTeamStore } from '@/stores/current-team'
 import { useTeamShareStore, isShareModeLocked } from '@/stores/team-share'
 import { linkDaemonTeamWorkspace } from '@/lib/daemon-local-client'
-import { buildConfig, TEAM_SYNCED_EVENT, TEAM_REPO_DIR } from '@/lib/build-config'
+import { appDisplayName, TEAM_SYNCED_EVENT, TEAM_REPO_DIR } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import {
   AlertDialog,
@@ -62,7 +62,7 @@ interface DaemonSyncStatus {
 
 async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   if (!isTauri()) {
-    throw new Error(`Team feature requires ${buildConfig.app.name} desktop app (Tauri not available)`)
+    throw new Error(`Team feature requires ${appDisplayName} desktop app (Tauri not available)`)
   }
   const { invoke } = await import('@tauri-apps/api/core')
   return invoke<T>(cmd, args)
@@ -619,7 +619,7 @@ function TeamGitConfigConnected({
           <CollapsibleContent>
             <div className="mt-4 pt-4 border-t space-y-4 text-[13px] text-muted-foreground">
               <p>
-                {t('settings.team.repoGuide.intro', { defaultValue: 'A shared repository for your team to centrally manage Agent Skills, MCP configurations, and knowledge documents. Use the structure below so {{appName}} can sync correctly.', appName: buildConfig.app.name })}
+                {t('settings.team.repoGuide.intro', { defaultValue: 'A shared repository for your team to centrally manage Agent Skills, MCP configurations, and knowledge documents. Use the structure below so {{appName}} can sync correctly.', appName: appDisplayName })}
               </p>
               <div>
                 <h5 className="font-medium text-foreground mb-1.5">
@@ -653,7 +653,7 @@ function TeamGitConfigConnected({
                   {t('settings.team.repoGuide.usageTitle', 'Usage')}
                 </h5>
                 <ol className="list-decimal list-inside space-y-1">
-                  <li>{t('settings.team.repoGuide.usage1', { defaultValue: 'Clone the repo; {{appName}} will create a {{teamRepoDir}} folder in your workspace.', appName: buildConfig.app.name, teamRepoDir: sharedDirName })}</li>
+                  <li>{t('settings.team.repoGuide.usage1', { defaultValue: 'Clone the repo; {{appName}} will create a {{teamRepoDir}} folder in your workspace.', appName: appDisplayName, teamRepoDir: sharedDirName })}</li>
                   <li>{t('settings.team.repoGuide.usage2', 'Whitelist .gitignore: only the three directories are tracked.')}</li>
                   <li>{t('settings.team.repoGuide.usage3', 'In Cursor, use @ to reference Skills and Knowledge.')}</li>
                 </ol>

--- a/packages/app/src/components/telemetry/TelemetryConsentDialog.tsx
+++ b/packages/app/src/components/telemetry/TelemetryConsentDialog.tsx
@@ -12,7 +12,7 @@ import {
   AlertDialogCancel,
 } from '@/components/ui/alert-dialog'
 import { useTelemetryStore } from '@/stores/telemetry'
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 
 interface TelemetryConsentDialogProps {
   open: boolean
@@ -44,10 +44,10 @@ export function TelemetryConsentDialog({
             <BarChart3 className="h-6 w-6 text-primary" />
           </div>
           <AlertDialogTitle className="text-center">
-            {t('telemetry.consent.title', { appName: buildConfig.app.name })}
+            {t('telemetry.consent.title', { appName: appDisplayName })}
           </AlertDialogTitle>
           <AlertDialogDescription className="text-center">
-            {t('telemetry.consent.description', { appName: buildConfig.app.name })}
+            {t('telemetry.consent.description', { appName: appDisplayName })}
           </AlertDialogDescription>
         </AlertDialogHeader>
 

--- a/packages/app/src/lib/__tests__/build-config.test.ts
+++ b/packages/app/src/lib/__tests__/build-config.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { buildConfig } from "@/lib/build-config";
+import { buildConfig, appDisplayName } from "@/lib/build-config";
 
 describe("build-config auth.webSSO", () => {
   it("defaults webSSO to false in the fallback config", () => {
     // When no build.config.*.json overrides auth, webSSO must be off.
     expect(buildConfig.features.auth?.webSSO ?? false).toBe(false);
+  });
+});
+
+describe("build-config app.displayName", () => {
+  it("falls back to app.name when displayName is unset", () => {
+    // app.name stays the bundle identity; displayName only overrides the label.
+    expect(appDisplayName).toBe(buildConfig.app.displayName ?? buildConfig.app.name);
   });
 });

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -24,7 +24,15 @@ export interface BuildConfig {
     lockLlmConfig: boolean
   }
   app: {
+    /** Bundle identity: drives `productName`, the .app / installer filename, and
+     *  the derived `shortName`. Keep it filename-clean (ASCII, no spaces is
+     *  safest) — for the human-facing label use `displayName` instead. */
     name: string
+    /** Human-facing label: the window title and every in-app mention of the
+     *  product. Omitted → falls back to `app.name`. Set this when the UI name
+     *  should differ from the bundle name (e.g. name "TeamClaw" keeps the .app
+     *  and download URL clean while displayName "TeamClaw 龙虾团" shows in the UI). */
+    displayName?: string
     shortName?: string
     /** Visual palette flavor. Omitted / "default" → Editorial Calm.
      *  "teal" → anodized-teal build flavor (see styles/globals.css). Applied
@@ -136,6 +144,9 @@ function deriveShortName(name: string): string {
 }
 
 export const appShortName: string = buildConfig.app.shortName ?? deriveShortName(buildConfig.app.name)
+/** The product name to show users. Prefer this over `buildConfig.app.name` in
+ *  any UI string — `app.name` is the bundle identity and may differ. */
+export const appDisplayName: string = buildConfig.app.displayName ?? buildConfig.app.name
 export const appScheme: string = buildConfig.app.scheme ?? 'teamclaw'
 export const DEFAULT_WORKSPACE_PATH = `~/${buildConfig.app.name}`
 export const TEAMCLAW_DIR = `.${appShortName}`

--- a/packages/app/src/lib/git/skill-loader.ts
+++ b/packages/app/src/lib/git/skill-loader.ts
@@ -4,7 +4,7 @@ import { homeDir } from '@tauri-apps/api/path'
 import type { SkillWithSource, SkillSource } from './types'
 import { INHERENT_SKILL_NAMES, shouldIncludeDesktopControlSkill } from './types'
 import type { ClawHubLockfile } from '@/lib/clawhub/types'
-import { buildConfig, TEAM_REPO_DIR } from '@/lib/build-config'
+import { appDisplayName, TEAM_REPO_DIR } from '@/lib/build-config'
 import i18n from '@/lib/i18n'
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -371,7 +371,7 @@ export function getSourceDirHint(source: SkillSource): string {
     case 'team':
       return `${TEAM_REPO_DIR}/skills/ (team share)`
     case 'builtin':
-      return i18n.t('skills.builtinPath', { app: buildConfig.app.name })
+      return i18n.t('skills.builtinPath', { app: appDisplayName })
     case 'plugin':
       return 'teamclaw.json → plugin'
     case 'personal':

--- a/packages/app/src/stores/channels-types.ts
+++ b/packages/app/src/stores/channels-types.ts
@@ -1,5 +1,5 @@
 // Channel type definitions and default configs — extracted from channels.ts
-import { buildConfig } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 
 // Gateway status types
 export type GatewayStatus = 'disconnected' | 'connecting' | 'connected' | 'error'
@@ -294,7 +294,7 @@ export const defaultEmailConfig: EmailConfig = {
   allowedSenders: [],
   labels: [],
   replyAllNew: false,
-  displayName: `${buildConfig.app.name} Agent`,
+  displayName: `${appDisplayName} Agent`,
 }
 
 // Channels store state interface

--- a/packages/app/src/stores/session-permissions.ts
+++ b/packages/app/src/stores/session-permissions.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/daemon-local-client";
 import { replyPermissionById } from "@/lib/teamclaw/reply-acp-permission";
 import { isTauri } from "@/lib/utils";
-import { buildConfig } from "@/lib/build-config";
+import { appDisplayName } from "@/lib/build-config";
 import { notificationService } from "@/lib/notification-service";
 import { shouldAutoAuthorize } from "@/lib/permission-policy";
 import type { PermissionAskedEvent } from "./session-types";
@@ -240,7 +240,7 @@ export function createPermissionActions(set: SessionSet, get: SessionGet) {
 
     notificationService.send(
       "action_required",
-      `${buildConfig.app.name} - Authorization required`,
+      `${appDisplayName} - Authorization required`,
       `${sessionTitle} \u2014 requesting ${permissionType} permission`,
       event.sessionID,
       async () => {

--- a/packages/app/src/stores/session-questions.ts
+++ b/packages/app/src/stores/session-questions.ts
@@ -11,7 +11,7 @@ const getAgentClient: () => any = () =>
     },
   });
 import { notificationService } from "@/lib/notification-service";
-import { buildConfig } from "@/lib/build-config";
+import { appDisplayName } from "@/lib/build-config";
 import type {
   QuestionAskedEvent,
 } from "./session-types";
@@ -244,7 +244,7 @@ export function createQuestionActions(set: SessionSet, get: SessionGet) {
 
         notificationService.send(
           "action_required",
-          `${buildConfig.app.name} - \u9700\u8981\u56de\u7b54`,
+          `${appDisplayName} - \u9700\u8981\u56de\u7b54`,
           `${sessionTitle} \u2014 AI \u6709\u95ee\u9898\u9700\u8981\u4f60\u56de\u7b54`,
           event.sessionId,
           async () => {

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { UNSUPPORTED_BINARY_EXTENSIONS } from "@/components/viewers/UnsupportedFileViewer";
 import { isTauri } from '@/lib/utils'
 import { ensureGitignoreEntries } from '@/lib/gitignore-manager'
-import { appShortName, buildConfig, TEAM_REPO_DIR } from '@/lib/build-config'
+import { appDisplayName, appShortName, TEAM_REPO_DIR } from '@/lib/build-config'
 import { useTeamModeStore } from './team-mode'
 
 // Start watching a directory for file changes
@@ -355,7 +355,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       import('@tauri-apps/api/core')
         .then(async (m) => {
           await Promise.all([
-            m.invoke('set_window_title', { title: `${buildConfig.app.name} — ${wsName}` }),
+            m.invoke('set_window_title', { title: `${appDisplayName} — ${wsName}` }),
             m.invoke('register_window_workspace', { workspacePath: expandedPath }),
           ]);
           const { default: i18n } = await import('@/lib/i18n');

--- a/scripts/lib/branding.js
+++ b/scripts/lib/branding.js
@@ -3,19 +3,23 @@ const path = require("path");
 
 /**
  * Apply the configured app name to a parsed tauri.conf.json object (mutates it).
- * Sets `productName` and the first window's `title`. Returns true if anything changed.
+ * `app.name` is the bundle identity → `productName` (the .app / installer
+ * filename). `app.displayName` is the human-facing label → the first window's
+ * `title`; it falls back to `app.name` when unset. Setting only `displayName`
+ * renames the window without touching the bundle. Returns true if anything changed.
  */
 function applyNameToTauriConf(tauriConf, buildConfig) {
-  const name = buildConfig && buildConfig.app && buildConfig.app.name;
-  if (!name) return false;
+  const app = (buildConfig && buildConfig.app) || {};
+  const name = app.name;
+  const displayName = app.displayName || name;
   let changed = false;
-  if (tauriConf.productName !== name) {
+  if (name && tauriConf.productName !== name) {
     tauriConf.productName = name;
     changed = true;
   }
   const win = tauriConf.app && Array.isArray(tauriConf.app.windows) && tauriConf.app.windows[0];
-  if (win && win.title !== name) {
-    win.title = name;
+  if (displayName && win && win.title !== displayName) {
+    win.title = displayName;
     changed = true;
   }
   return changed;
@@ -87,10 +91,12 @@ function applyIdentityToTauriConf(tauriConf, buildConfig) {
 
 /**
  * Apply the configured app name/short name to a parsed extension manifest.json
- * object (mutates it). Returns true if anything changed.
+ * object (mutates it). Both fields are browser-facing labels, so they follow
+ * `app.displayName` and fall back to `app.name`. Returns true if anything changed.
  */
 function applyNameToExtensionManifest(manifest, buildConfig) {
-  const name = buildConfig && buildConfig.app && buildConfig.app.name;
+  const app = (buildConfig && buildConfig.app) || {};
+  const name = app.displayName || app.name;
   if (!name) return false;
   let changed = false;
   if (manifest.name !== name) {

--- a/scripts/lib/branding.test.js
+++ b/scripts/lib/branding.test.js
@@ -25,6 +25,22 @@ test("applyNameToTauriConf tolerates missing windows array", () => {
   assert.strictEqual(conf.productName, "Acme");
 });
 
+test("applyNameToTauriConf titles the window with displayName, keeping productName on app.name", () => {
+  const conf = { productName: "OldName", app: { windows: [{ title: "OldName" }] } };
+  const changed = applyNameToTauriConf(conf, { app: { name: "TeamClaw", displayName: "TeamClaw 龙虾团" } });
+  assert.strictEqual(changed, true);
+  assert.strictEqual(conf.productName, "TeamClaw");
+  assert.strictEqual(conf.app.windows[0].title, "TeamClaw 龙虾团");
+});
+
+test("applyNameToTauriConf renames only the window when app.name is absent", () => {
+  const conf = { productName: "TeamClaw", app: { windows: [{ title: "TeamClaw" }] } };
+  const changed = applyNameToTauriConf(conf, { app: { displayName: "TeamClaw 龙虾团" } });
+  assert.strictEqual(changed, true);
+  assert.strictEqual(conf.productName, "TeamClaw");
+  assert.strictEqual(conf.app.windows[0].title, "TeamClaw 龙虾团");
+});
+
 const path = require("node:path");
 const { resolveLogoPlan } = require("./branding");
 
@@ -110,4 +126,21 @@ test("applyIdentityToTauriConf creates the deep-link path when missing", () => {
   const changed = applyIdentityToTauriConf(conf, { app: { scheme: "acme" } });
   assert.strictEqual(changed, true);
   assert.deepStrictEqual(conf.plugins["deep-link"].desktop.schemes, ["acme"]);
+});
+
+const { applyNameToExtensionManifest } = require("./branding");
+
+test("applyNameToExtensionManifest prefers displayName over app.name", () => {
+  const manifest = { name: "OldName", action: { default_title: "OldName" } };
+  const changed = applyNameToExtensionManifest(manifest, { app: { name: "TeamClaw", displayName: "TeamClaw 龙虾团" } });
+  assert.strictEqual(changed, true);
+  assert.strictEqual(manifest.name, "TeamClaw 龙虾团");
+  assert.strictEqual(manifest.action.default_title, "TeamClaw 龙虾团");
+});
+
+test("applyNameToExtensionManifest falls back to app.name when displayName is unset", () => {
+  const manifest = { name: "OldName", action: { default_title: "OldName" } };
+  const changed = applyNameToExtensionManifest(manifest, { app: { name: "TeamClaw" } });
+  assert.strictEqual(changed, true);
+  assert.strictEqual(manifest.name, "TeamClaw");
 });

--- a/scripts/update-extension-manifest.js
+++ b/scripts/update-extension-manifest.js
@@ -50,7 +50,7 @@ const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 let updated = false;
 
 if (applyNameToExtensionManifest(manifest, buildConfig)) {
-  console.log(`✓ Updated extension name: ${buildConfig.app.name}`);
+  console.log(`✓ Updated extension name: ${manifest.name}`);
   updated = true;
 }
 

--- a/scripts/update-tauri-config.js
+++ b/scripts/update-tauri-config.js
@@ -55,7 +55,7 @@ const tauriConf = JSON.parse(fs.readFileSync(tauriConfPath, 'utf8'));
 let updated = false;
 
 if (applyNameToTauriConf(tauriConf, buildConfig)) {
-  console.log(`✓ Updated productName/window title: ${buildConfig.app.name}`);
+  console.log(`✓ Updated productName: ${tauriConf.productName} / window title: ${tauriConf.app?.windows?.[0]?.title}`);
   updated = true;
 }
 


### PR DESCRIPTION
## `app.displayName` — separate the display name from the app name

`app.name` drove both the bundle identity and every user-facing label, so a brand wanting a Chinese UI name had to either ship it in the `.app` filename and download URL, or patch `tauri.conf.json` again after branding ran.

| Field | Controls |
|---|---|
| `app.name` | `productName`, `.app` / installer filename, derived `shortName`, workspace path |
| `app.displayName` *(new, optional)* | Window title + all in-app product mentions |

`displayName` falls back to `app.name`, so the field is purely additive — existing brand configs behave exactly as before.

`scripts/lib/branding.js` now reads the two from separate fields, so a build setting only `displayName` renames the window without touching the bundle. This removes the need for a post-branding `tauri.conf.json` overwrite in `build-app.sh`.

The UI reads a new `appDisplayName` export instead of `buildConfig.app.name` (47 call sites / 23 files). Filesystem-facing uses — workspace path, `.gitignore` markers — keep `app.name`. The Chrome extension's `manifest.name` / `default_title` follow `displayName`, since both are browser-facing labels rather than filenames.

Also adds the previously-undocumented `features.auth.webSSO` to `build.config.example.json`.

## Scope

Frontend + build scripts only (`build.config.example.json`, `packages/app/src/**`, `scripts/**`). No deploy-triggering paths.

## Verification

`pnpm typecheck` clean; `pnpm lint` 0 errors; 19/19 branding tests pass (4 new, covering the split including a displayName-only build that renames the window but not the bundle); `build-config` vitest 2/2.

CI's "Lint, Typecheck & Test" is red on a pre-existing failure unrelated to this branch: `no-useless-assignment` in `packages/app/src/lib/remote-tools/rpc-server.ts:91`, a file this PR does not touch. The latest CI run on `main` fails identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)