### PR TITLE
chore(self-host): pass through the FC env vars compose was dropping

### DIFF
--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -210,6 +210,43 @@ services:
       # desktop build config, or session injection silently does nothing.
       WEBSSO_LOGIN_URL: "${WEBSSO_LOGIN_URL:-}"
       WEBSSO_STORAGE_KEY: "${WEBSSO_STORAGE_KEY:-}"
+      SMS_DEBUG_MODE: "${SMS_DEBUG_MODE:-}"
+      # APNS — iOS push. POST /push/dispatch mounts unconditionally, so without
+      # these the route authenticates (see PUSH_WEBHOOK_SECRET) and then has
+      # nothing to send with.
+      APNS_ENV: "${APNS_ENV:-}"
+      APNS_KEY_ID: "${APNS_KEY_ID:-}"
+      APNS_TEAM_ID: "${APNS_TEAM_ID:-}"
+      APNS_TOPIC: "${APNS_TOPIC:-}"
+      APNS_PRIVATE_KEY_P8: "${APNS_PRIVATE_KEY_P8:-}"
+      # CodeUp — backs POST /managed-git/create-repo (share mode `managed_git`).
+      CODEUP_ORG_ID: "${CODEUP_ORG_ID:-}"
+      CODEUP_PAT: "${CODEUP_PAT:-}"
+      CODEUP_BOT_USERNAME: "${CODEUP_BOT_USERNAME:-}"
+      # Apps module — per-app Postgres provisioning.
+      APPS_DB_ADMIN_URL: "${APPS_DB_ADMIN_URL:-}"
+      PG_POOL_MAX: "${PG_POOL_MAX:-}"
+      LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD: "${LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD:-}"
+      # Better-Auth. Only reachable with BACKEND_KIND=postgres — on the default
+      # supabase backend `/api/auth/*` is not mounted (app.ts) and GoTrue owns
+      # sign-in, so leave these blank. AUTH_SECRET and AUTH_BASE_URL both throw
+      # on a blank value rather than guessing, so a postgres switch fails loudly.
+      AUTH_SECRET: "${AUTH_SECRET:-}"
+      AUTH_BASE_URL: "${AUTH_BASE_URL:-}"
+      GOOGLE_CLIENT_ID: "${GOOGLE_CLIENT_ID:-}"
+      GOOGLE_CLIENT_SECRET: "${GOOGLE_CLIENT_SECRET:-}"
+      APPLE_CLIENT_ID: "${APPLE_CLIENT_ID:-}"
+      APPLE_CLIENT_SECRET: "${APPLE_CLIENT_SECRET:-}"
+      OTP_EMAIL_SMTP_HOST: "${OTP_EMAIL_SMTP_HOST:-}"
+      OTP_EMAIL_SMTP_PORT: "${OTP_EMAIL_SMTP_PORT:-}"
+      OTP_EMAIL_SMTP_USER: "${OTP_EMAIL_SMTP_USER:-}"
+      OTP_EMAIL_SMTP_PASS: "${OTP_EMAIL_SMTP_PASS:-}"
+      OTP_EMAIL_SMTP_FROM: "${OTP_EMAIL_SMTP_FROM:-}"
+      # CORS_HANDLED_BY_PROXY is deliberately NOT passed through: this stack's
+      # Caddy is a transparent proxy that adds no CORS headers (see
+      # caddy/Caddyfile), so FC's Hono middleware must keep owning CORS. Setting
+      # it here would make FC answer OPTIONS with a bare 204 and emit no
+      # Access-Control-* headers at all, breaking every browser client.
       # Points FC at the bundled gateway. FC now fails closed on a blank value
       # rather than falling back to a hosted endpoint, so this default is a
       # convenience, not a safety net.


### PR DESCRIPTION
> **Stacked on #493** (both touch the same compose block). Base is `fix/push-dispatch-auth-bypass`; merge that first and this retargets to `main`.

The compose `fc:` service uses an explicit `environment:` map, which makes it an **allowlist**: a var absent from it never reaches the container, no matter what the box's `.env` says. `s.yaml` declared **24 vars that compose did not** — so those features were not merely off on self-host, they were *unconfigurable*, with no error to say so.

## Added (23, all empty-defaulted — inert as shipped)

| Group | Vars | What it gates |
|---|---|---|
| APNS | `APNS_ENV/KEY_ID/TEAM_ID/TOPIC/PRIVATE_KEY_P8` | iOS push — `/push/dispatch` mounts unconditionally |
| CodeUp | `CODEUP_ORG_ID/PAT/BOT_USERNAME` | `/managed-git/create-repo` (share mode `managed_git`) |
| Apps module | `APPS_DB_ADMIN_URL`, `PG_POOL_MAX` | per-app Postgres provisioning |
| LiteLLM | `LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD` | default team budget |
| Phone | `SMS_DEBUG_MODE` | return the code instead of sending SMS |
| Better-Auth | `AUTH_SECRET`, `AUTH_BASE_URL`, `GOOGLE_*`, `APPLE_*`, `OTP_EMAIL_SMTP_*` | **`BACKEND_KIND=postgres` only** |

The Better-Auth group is unreachable on the default `supabase` backend — `/api/auth/*` only mounts for postgres (`app.ts`), and GoTrue owns sign-in. But compose *does* offer `BACKEND_KIND=postgres`, so leaving them unsettable made that switch a dead end. `AUTH_SECRET` and `AUTH_BASE_URL` both throw on a blank value rather than guessing, so a postgres switch fails loudly rather than minting tokens with a bogus issuer.

## Deliberately NOT added: `CORS_HANDLED_BY_PROXY`

This is the one var from the gap that should stay out. This stack's Caddy is a transparent proxy that adds **no** CORS headers — the Caddyfile says so explicitly, and warns against changing that. FC's Hono middleware must keep owning CORS. Passing the var through would only offer a way to make FC answer OPTIONS with a bare 204 and emit no `Access-Control-*` headers at all, breaking every browser client. Documented inline so the next parity check doesn't "fix" it.

## Verification

Rendered the real thing rather than eyeballing the YAML:

```
$ docker compose --env-file .env.example config
```

- every new var resolves to `''` → **no behaviour change**, every feature stays off
- `CORS_HANDLED_BY_PROXY` absent from the rendered env
- `BACKEND_KIND` still `'supabase'`, existing vars intact

## Out of scope, reported not fixed

13 vars the code reads that are in **neither** manifest, so they are unsettable on both deploy paths:

`CORS_ORIGINS`, `AI_GATEWAY_ENDPOINT`, `ALIYUN_ACCOUNT_ID`, `CDN_AUTH_KEY`, `CDN_DOMAIN`, `CDN_SCHEME`, `FC_ENDPOINT`, `MQTT_PUBLIC_TCP_BROKER_URL`, `OTP_EMAIL_FROM`, `OTP_EMAIL_SMTP_SECURE`, `PG_CONNECT_TIMEOUT`, `PG_IDLE_TIMEOUT`, `S3_FORCE_PATH_STYLE`

`CORS_ORIGINS` is the notable one — `app.ts` reads it to allow extra browser origins, and today there is no way to set it on self-host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)