### PR TITLE
fix(fc): declare the env vars neither manifest had, and fix a dead one

### DIFF
--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -176,6 +176,13 @@ services:
       SUPABASE_SERVICE_ROLE_KEY: "${SERVICE_ROLE_KEY}"
       MQTT_BROKER_URL: "mqtt://emqx:1883"
       MQTT_PUBLIC_BROKER_URL: "${MQTT_PUBLIC_BROKER_URL:-}"
+      # Raw-TCP broker address handed to clients whose MQTT stack can't do
+      # WebSocket (rumqttc on desktop/daemon, CocoaMQTT on iOS). EMQX publishes
+      # 1883 to the host above, so this is typically mqtt://<MQTT_DOMAIN>:1883.
+      # Blank = /v1/config/bootstrap omits `mqtt.tcpUrl` and those clients have
+      # only the WS URL. (The all-in-one image sets this from render-config.sh;
+      # it writes FC's env directly, so it was never affected by this map.)
+      MQTT_PUBLIC_TCP_BROKER_URL: "${MQTT_PUBLIC_TCP_BROKER_URL:-}"
       MQTT_USERNAME: "fc-service"
       MQTT_PASSWORD: "${MQTT_SERVICE_TOKEN}"
       MQTT_USE_TLS: "false"
@@ -187,6 +194,27 @@ services:
       BUCKET: "${BUCKET:-teamclaw-team}"
       REGION: "${REGION:-cn-shenzhen}"
       ENDPOINT: "${ENDPOINT:-}"
+      # Path-style addressing (bucket in the path, not the hostname). Required by
+      # MinIO and most non-Alibaba S3-compatible stores; leave blank for OSS.
+      S3_FORCE_PATH_STYLE: "${S3_FORCE_PATH_STYLE:-}"
+      # Extra browser origins allowed by FC's CORS middleware, comma-separated.
+      # tauri:// and localhost are always allowed, so this is only needed for a
+      # web client on some other origin.
+      CORS_ORIGINS: "${CORS_ORIGINS:-}"
+      # CDN-fronted blob GETs (OSS egress reduction). Both DOMAIN and AUTH_KEY
+      # must be set to enable; otherwise callers fall back to OSS presigned GET.
+      CDN_DOMAIN: "${CDN_DOMAIN:-}"
+      CDN_AUTH_KEY: "${CDN_AUTH_KEY:-}"
+      CDN_SCHEME: "${CDN_SCHEME:-}"
+      # Apps module — provisions per-app Alibaba FC functions. Only meaningful
+      # if that module is enabled and targeting Alibaba FC.
+      ALIYUN_ACCOUNT_ID: "${ALIYUN_ACCOUNT_ID:-}"
+      FC_ENDPOINT: "${FC_ENDPOINT:-}"
+      PG_CONNECT_TIMEOUT: "${PG_CONNECT_TIMEOUT:-}"
+      PG_IDLE_TIMEOUT: "${PG_IDLE_TIMEOUT:-}"
+      # Overrides the endpoint advertised to clients as the AI gateway. Blank
+      # derives it from LITELLM_URL below, which is correct for this stack.
+      AI_GATEWAY_ENDPOINT: "${AI_GATEWAY_ENDPOINT:-}"
       # Shared secret for POST /push/dispatch (the Supabase message-insert
       # webhook). Unset = every request to that route is rejected, which is why
       # it is safe to ship blank; set it here and in the webhook to enable push.
@@ -241,7 +269,10 @@ services:
       OTP_EMAIL_SMTP_PORT: "${OTP_EMAIL_SMTP_PORT:-}"
       OTP_EMAIL_SMTP_USER: "${OTP_EMAIL_SMTP_USER:-}"
       OTP_EMAIL_SMTP_PASS: "${OTP_EMAIL_SMTP_PASS:-}"
-      OTP_EMAIL_SMTP_FROM: "${OTP_EMAIL_SMTP_FROM:-}"
+      # Defaults to the SMTP username when blank.
+      OTP_EMAIL_FROM: "${OTP_EMAIL_FROM:-}"
+      # Defaults to "true" (implicit TLS on 465). Set "false" for STARTTLS/587.
+      OTP_EMAIL_SMTP_SECURE: "${OTP_EMAIL_SMTP_SECURE:-}"
       # CORS_HANDLED_BY_PROXY is deliberately NOT passed through: this stack's
       # Caddy is a transparent proxy that adds no CORS headers (see
       # caddy/Caddyfile), so FC's Hono middleware must keep owning CORS. Setting

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -46,6 +46,26 @@ resources:
         # only by apps provisioning (CREATE SCHEMA / CREATE ROLE). Never sent
         # to clients.
         APPS_DB_ADMIN_URL: ${env('APPS_DB_ADMIN_URL', '')}
+        PG_CONNECT_TIMEOUT: ${env('PG_CONNECT_TIMEOUT', '')}
+        PG_IDLE_TIMEOUT: ${env('PG_IDLE_TIMEOUT', '')}
+        # Per-app Alibaba FC provisioning (apps module).
+        ALIYUN_ACCOUNT_ID: ${env('ALIYUN_ACCOUNT_ID', '')}
+        FC_ENDPOINT: ${env('FC_ENDPOINT', '')}
+        # Path-style S3 addressing; blank for Alibaba OSS.
+        S3_FORCE_PATH_STYLE: ${env('S3_FORCE_PATH_STYLE', '')}
+        # Extra browser origins for FC's CORS middleware, comma-separated.
+        CORS_ORIGINS: ${env('CORS_ORIGINS', '')}
+        # CDN-fronted blob GETs; needs DOMAIN + AUTH_KEY together.
+        CDN_DOMAIN: ${env('CDN_DOMAIN', '')}
+        CDN_AUTH_KEY: ${env('CDN_AUTH_KEY', '')}
+        CDN_SCHEME: ${env('CDN_SCHEME', '')}
+        # Overrides the AI gateway endpoint advertised to clients; blank derives
+        # it from LITELLM_URL.
+        AI_GATEWAY_ENDPOINT: ${env('AI_GATEWAY_ENDPOINT', '')}
+        # Raw-TCP broker for clients without WebSocket (daemon, iOS).
+        MQTT_PUBLIC_TCP_BROKER_URL: ${env('MQTT_PUBLIC_TCP_BROKER_URL', '')}
+        # HTTP-triggered cron guard (/internal/cron). Blank = route rejects all.
+        CRON_TRIGGER_SECRET: ${env('CRON_TRIGGER_SECRET', '')}
         PUSH_WEBHOOK_SECRET: ${env('PUSH_WEBHOOK_SECRET')}
         SUPABASE_URL: ${env('SUPABASE_URL')}
         SUPABASE_PUBLIC_URL: ${env('SUPABASE_PUBLIC_URL', '')}
@@ -57,6 +77,9 @@ resources:
         APNS_TOPIC: ${env('APNS_TOPIC')}
         APNS_ENV: ${env('APNS_ENV')}
         MQTT_BROKER_URL: ${env('MQTT_BROKER_URL')}
+        # Public-facing broker address handed to clients. Falls back to
+        # MQTT_BROKER_URL, which is wrong whenever that is an internal address.
+        MQTT_PUBLIC_BROKER_URL: ${env('MQTT_PUBLIC_BROKER_URL', '')}
         MQTT_USERNAME: ${env('MQTT_USERNAME')}
         MQTT_PASSWORD: ${env('MQTT_PASSWORD')}
         MQTT_USE_TLS: ${env('MQTT_USE_TLS', '')}
@@ -86,7 +109,8 @@ resources:
         OTP_EMAIL_SMTP_PORT: ${env('OTP_EMAIL_SMTP_PORT', '')}
         OTP_EMAIL_SMTP_USER: ${env('OTP_EMAIL_SMTP_USER', '')}
         OTP_EMAIL_SMTP_PASS: ${env('OTP_EMAIL_SMTP_PASS', '')}
-        OTP_EMAIL_SMTP_FROM: ${env('OTP_EMAIL_SMTP_FROM', '')}
+        OTP_EMAIL_FROM: ${env('OTP_EMAIL_FROM', '')}
+        OTP_EMAIL_SMTP_SECURE: ${env('OTP_EMAIL_SMTP_SECURE', '')}
         APPLE_CLIENT_ID: ${env('APPLE_CLIENT_ID', '')}
         APPLE_CLIENT_SECRET: ${env('APPLE_CLIENT_SECRET', '')}
         GOOGLE_CLIENT_ID: ${env('GOOGLE_CLIENT_ID', '')}


### PR DESCRIPTION
> **Stacked on #494** (which is stacked on #493). Merge those first and this retargets automatically.

13 vars are read by `services/fc` but appeared in **neither** `s.yaml` nor the self-host compose — unsettable on *both* deploy paths, with nothing to say so.

## Added to both manifests (blank defaults, no behaviour change)

| Var(s) | Gates |
|---|---|
| `CORS_ORIGINS` | extra browser origins for FC's CORS middleware |
| `S3_FORCE_PATH_STYLE` | MinIO / non-Alibaba S3-compatible stores |
| `CDN_DOMAIN`, `CDN_AUTH_KEY`, `CDN_SCHEME` | CDN-fronted blob GETs (OSS egress) |
| `AI_GATEWAY_ENDPOINT` | overrides the gateway endpoint advertised to clients |
| `ALIYUN_ACCOUNT_ID`, `FC_ENDPOINT` | apps-module per-app FC provisioning |
| `PG_CONNECT_TIMEOUT`, `PG_IDLE_TIMEOUT` | apps-module Postgres pool |
| `MQTT_PUBLIC_TCP_BROKER_URL` | raw-TCP broker for non-WebSocket clients |
| `OTP_EMAIL_FROM`, `OTP_EMAIL_SMTP_SECURE` | OTP mail sender / TLS mode |

## The dead one

`s.yaml` declared **`OTP_EMAIL_SMTP_FROM`**. `otp-delivery.ts` reads **`OTP_EMAIL_FROM`**:

```js
const from = process.env.OTP_EMAIL_FROM ?? user;
```

Nothing reads the `SMTP_` variant. Configuring the sender address as documented did nothing, and the From header silently fell back to the SMTP username. Renamed in `s.yaml` — and in compose, where #494 had faithfully copied the typo across.

## Two more gaps this surfaced

- **`MQTT_PUBLIC_TCP_BROKER_URL` was missing from compose**, so `/v1/config/bootstrap` could not advertise `mqtt.tcpUrl` on that path and clients whose MQTT stack can't do WebSocket (rumqttc on desktop/daemon, CocoaMQTT on iOS) had only the WS URL. The all-in-one image was never affected — `render-config.sh` writes FC's env directly, bypassing the compose map.
- **`s.yaml` had no `MQTT_PUBLIC_BROKER_URL`**, and the code falls back to `MQTT_BROKER_URL` — i.e. hands clients an internal address whenever that one is internal.

## Deliberately still excluded

- `HOST` / `PORT` — compose-only; Alibaba FC supplies its own runtime port.
- `CORS_HANDLED_BY_PROXY` — compose-excluded on purpose, see #494.

Every other var the code reads is now declared on both paths.

## Not dead, despite looking it

`BACKEND_KIND`, `LITELLM_DB_NAME`, `SUPABASE_ANON_KEY` show up as "declared but unread" to a `process.env.X` grep because they are read through a destructured env object (`env.LITELLM_DB_NAME`). They are live; left alone. Flagging so the next parity pass doesn't delete them.

## Verification

```
$ docker compose --env-file .env.example config
```

- all 13 resolve to `''` → no behaviour change
- `OTP_EMAIL_SMTP_FROM` gone, `CORS_HANDLED_BY_PROXY` still absent
- `BACKEND_KIND` = `'supabase'`, `MQTT_BROKER_URL` = `'mqtt://emqx:1883'` — existing values intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)