### PR TITLE
fix(desktop): upgrade reqwest to fix Cloud API TLS on SGW gateways

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4063,20 +4063,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c78f9338483cb7e630c8474b07268983c6bd5acee012e4211f9f7bb21b070"
@@ -7936,7 +7922,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -7946,8 +7931,6 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -7956,7 +7939,6 @@ dependencies = [
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -7976,6 +7958,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.13",
@@ -7995,6 +7978,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.38",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -8264,18 +8248,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
@@ -8300,18 +8272,6 @@ dependencies = [
  "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -8393,16 +8353,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -8546,16 +8496,6 @@ dependencies = [
  "once_cell",
  "selectors 0.25.0",
  "tendril 0.4.3",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -10375,7 +10315,7 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "rumqttc",
  "rustls 0.23.38",
  "scraper",
@@ -10451,7 +10391,7 @@ dependencies = [
  "nanoid",
  "native-tls",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serenity",
@@ -10501,7 +10441,7 @@ dependencies = [
  "notify-debouncer-full",
  "pulldown-cmark",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2",
@@ -10801,16 +10741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
  "tokio",
 ]
 

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -43,7 +43,7 @@ teamclaw-types = { path = "../../crates/teamclaw-types" }
 teamclaw-runtime-env = { path = "../../crates/teamclaw-runtime-env" }
 indexmap = { version = "2", features = ["serde"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "net", "process", "io-util"] }
-reqwest = { version = "0.11", features = ["json", "blocking", "stream", "rustls-tls-native-roots"], default-features = false }
+reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "stream", "rustls-tls-native-roots"] }
 rumqttc = { version = "0.24", features = ["websocket"] }
 notify = { version = "8", features = ["macos_fsevent"] }
 notify-debouncer-mini = "0.7"

--- a/apps/desktop/crates/teamclaw-rag/Cargo.toml
+++ b/apps/desktop/crates/teamclaw-rag/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "fs"] }
-reqwest = { version = "0.11", features = ["json", "rustls-tls-native-roots"], default-features = false }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 tracing = "0.1"
 regex = "1"
 uuid = { version = "1", features = ["v4"] }

--- a/apps/desktop/src/commands/oss_sync/fc_client.rs
+++ b/apps/desktop/src/commands/oss_sync/fc_client.rs
@@ -61,10 +61,15 @@ pub struct FcClient {
 
 impl FcClient {
     pub fn new(base_url: String, jwt: String) -> Self {
-        // A stalled Cloud API host must surface as an error, never an infinite
-        // hang — see FC_REQUEST_TIMEOUT. `build()` only fails on a fatal TLS/
-        // runtime misconfig; fall back to the un-timed default rather than panic.
+        // Force HTTP/1.1 and rustls — mirrors the daemon Cloud API client.
+        // reqwest 0.12+ is required: 0.11 fails TLS to some SGW-fronted hosts
+        // with "error trying to connect: bad protocol version". HTTP/1.1 also
+        // avoids FC idle HTTP/2 stream reuse bugs after ~60 s. `build()` only
+        // fails on a fatal TLS/runtime misconfig; fall back to the un-timed
+        // default rather than panic.
         let client = Client::builder()
+            .http1_only()
+            .use_rustls_tls()
             .timeout(FC_REQUEST_TIMEOUT)
             .connect_timeout(FC_CONNECT_TIMEOUT)
             .build()

--- a/crates/teamclaw-gateway/Cargo.toml
+++ b/crates/teamclaw-gateway/Cargo.toml
@@ -32,7 +32,7 @@ thiserror = "2"
 
 # Core
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "net", "process", "io-util", "fs"] }
-reqwest = { version = "0.11", features = ["json", "blocking", "stream", "rustls-tls-native-roots"], default-features = false }
+reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "stream", "rustls-tls-native-roots"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 futures = "0.3"


### PR DESCRIPTION
## Summary
- Upgrade desktop HTTP stack from `reqwest 0.11` to `0.12` (also `teamclaw-rag` and `teamclaw-gateway`) so Cloud API calls succeed against SGW-fronted hosts that previously failed with `error trying to connect: bad protocol version`.
- Force `FcClient` to use HTTP/1.1 + rustls, matching the daemon Cloud API client and avoiding idle HTTP/2 stream reuse issues.

## Test plan
- [x] `cargo check --manifest-path apps/desktop/Cargo.toml`
- [ ] Rebuild desktop (`pnpm tauri:dev` or `pnpm tauri:build`)
- [ ] Settings → Team Shared → Enable on `https://copilot.accounting.i.test.shopee.io` — confirm share-mode POST succeeds (no TLS error)


Made with [Cursor](https://cursor.com)