### PR TITLE
fix(release-oss): unbreak the windows job for branded releases

### DIFF
--- a/.github/actions/brand-setup/action.yml
+++ b/.github/actions/brand-setup/action.yml
@@ -79,11 +79,17 @@ runs:
         import json, os
 
         brand = os.environ['BRAND']
-        cfg = json.load(open('build.config.json'))
+        # encoding= is not optional: a brand's page copy is free text and is
+        # routinely Chinese, while Python on the Windows runner defaults open()
+        # to the cp1252 locale codec. Reading UTF-8 through cp1252 either raises
+        # (betly's "尝鲜版" carries 0x9d, which cp1252 leaves undefined) or, worse,
+        # silently mojibakes any brand whose bytes happen to dodge the five
+        # undefined ones. Pin UTF-8 on every handle so the platform can't decide.
+        cfg = json.load(open('build.config.json', encoding='utf-8'))
         app = cfg.get('app', {})
 
         meta_path = f'.branding-src/brands/{brand}/brand.json'
-        meta = json.load(open(meta_path)) if os.path.isfile(meta_path) else {}
+        meta = json.load(open(meta_path, encoding='utf-8')) if os.path.isfile(meta_path) else {}
         oss = meta.get('oss') or {}
 
         def pick(value, fallback_env):
@@ -132,13 +138,13 @@ runs:
             'CDN_REFRESH_REGION': oss.get('cdnRefreshRegion') or '',
             'BRAND_MAC_EXTRA_ARGS': (meta.get('build') or {}).get('macExtraArgs') or '',
         }
-        with open(os.environ['GITHUB_ENV'], 'a') as f:
+        with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as f:
             for k, v in out.items():
                 f.write(f'{k}={v}\n')
 
         # brand.json's page block is consumed by the publish job; pass it as a file
         # rather than env vars so free-text copy can contain anything.
-        json.dump(meta.get('page') or {}, open('brand-page.json', 'w'))
+        json.dump(meta.get('page') or {}, open('brand-page.json', 'w', encoding='utf-8'))
 
         print(f'Brand         : {brand} ({app_name} / {product_name}.app)')
         print(f'Backend       : {cfg.get("cloudApiUrl")}')

--- a/scripts/sync-cargo-lock-version.sh
+++ b/scripts/sync-cargo-lock-version.sh
@@ -10,20 +10,27 @@ DESKTOP_VERSION="$(node -e "console.log(require('./package.json').version)")"
 echo "Syncing Cargo.lock for desktop v${DESKTOP_VERSION}…"
 cargo build --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect -p amuxd >/dev/null
 
-LOCK_TEAMCLAW="$(node -e "
+# \r? on every newline: the repo ships no .gitattributes, so Git for Windows
+# checks Cargo.lock out with CRLF endings on the windows runner. An \n-anchored
+# regex silently misses there, node exits non-zero with no output, and `set -e`
+# kills this script with no diagnostic at all — which is exactly how it failed.
+lock_version() {
+  node -e "
 const fs = require('fs');
 const lock = fs.readFileSync('Cargo.lock', 'utf8');
-const m = lock.match(/\\[\\[package\\]\\]\\nname = \"teamclaw\"\\nversion = \"([^\"]+)\"/);
-if (!m) process.exit(1);
+const name = process.argv[1];
+const re = new RegExp('\\\\[\\\\[package\\\\]\\\\]\\\\r?\\\\nname = \"' + name + '\"\\\\r?\\\\nversion = \"([^\"]+)\"');
+const m = lock.match(re);
+if (!m) {
+  console.error('✗ Cargo.lock has no [[package]] entry for ' + name);
+  process.exit(1);
+}
 console.log(m[1]);
-")"
-LOCK_AMUXD="$(node -e "
-const fs = require('fs');
-const lock = fs.readFileSync('Cargo.lock', 'utf8');
-const m = lock.match(/\\[\\[package\\]\\]\\nname = \"amuxd\"\\nversion = \"([^\"]+)\"/);
-if (!m) process.exit(1);
-console.log(m[1]);
-")"
+" "$1"
+}
+
+LOCK_TEAMCLAW="$(lock_version teamclaw)"
+LOCK_AMUXD="$(lock_version amuxd)"
 
 if [[ "$LOCK_TEAMCLAW" != "$DESKTOP_VERSION" || "$LOCK_AMUXD" != "$DESKTOP_VERSION" ]]; then
   echo "✗ Cargo.lock mismatch after build:"


### PR DESCRIPTION
Two Windows-only defects that make `release-oss.yml` unable to publish any brand. Both have been latent since the multi-brand pipeline landed in #498, and both are invisible on macOS and Linux — every non-Windows job passes the same steps.

Found while trying to cut the first `copilot361` release and a `betly` release in parallel; the Windows job failed in each, for a *different* reason.

## 1. `brand-setup` decoded brand JSON through cp1252

`action.yml` read `build.config.json` / `brand.json` with a bare `open()`. Python on the windows runner defaults `open()` to the cp1252 locale codec, so UTF-8 brand copy is decoded wrong:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 269
```

betly's page copy contains `尝鲜版`; `尝` is `E5 B0 9D`, and `0x9d` is one of the five bytes cp1252 leaves undefined — so `Resolve brand` raised and the job died.

The quieter half of this bug: **`copilot361` passed the same step only by luck.** Its Chinese happens to avoid all five undefined bytes, so it decoded to mojibake instead of raising. A brand whose copy dodges those bytes silently corrupts rather than fails.

Fixed by pinning `encoding='utf-8'` on every handle (both reads, the `GITHUB_ENV` append, and the `brand-page.json` write) so the platform locale can't decide how brand copy is read.

## 2. `sync-cargo-lock-version.sh` assumed LF line endings

The script matched `Cargo.lock` with an `\n`-anchored regex. The repo ships no `.gitattributes` and `Cargo.lock` is LF in the index, so Git for Windows checks it out as CRLF. The regex missed, `node` exited 1 printing nothing, and `set -e` killed the script **with no diagnostic at all** — the CI log just stops after `Syncing Cargo.lock for desktop v0.2.24…` and reports exit 1.

Fixed by tolerating `\r?\n`, de-duplicating the two near-identical `node -e` blocks into one `lock_version` helper, and printing a real error when a package is genuinely absent — so this can never fail silently again.

## Verification

Reproduced both failures locally and confirmed the fixes against them, rather than only reasoning about them:

| Case | Before | After |
|---|---|---|
| `sync-cargo-lock-version.sh` vs CRLF `Cargo.lock` | exit 1, no output | exit 0, syncs |
| `sync-cargo-lock-version.sh` vs LF `Cargo.lock` | exit 0 | exit 0 (unchanged) |
| `brand.json` read as cp1252 | `UnicodeDecodeError` | n/a |
| `brand.json` read as utf-8 | n/a | `Beta 尝鲜版` |

`bash -n` clean; the CRLF case was tested against a byte-for-byte CRLF copy of the real `Cargo.lock`, and the script was exercised end-to-end with `cargo` stubbed.

## Not fixed here — separate blocker

`copilot361` also cannot publish because the shared OSS key has no write access to its bucket:

```
oss2.exceptions.AccessDenied: 403 — You have no right to access this object
because of bucket acl.  Host: copilot361-public.oss-cn-hongkong.aliyuncs.com
```

That needs `oss:PutObject` on `copilot361-public/*` granted to the RAM user — infrastructure, not code. `betly` is unaffected (it writes to the shared TeamClaw bucket). With this PR merged, betly can release; copilot361 additionally needs that grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
