### PR TITLE
fix(ci): stop compiling the shared dep graph twice per release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,10 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
+          # apps/desktop is a member of the root workspace, so cargo puts its
+          # output under the root target/, not apps/desktop/target/.
           workspaces: |
-            ./apps/desktop -> target
+            . -> target
 
       - name: Create stub sidecar binaries (tauri-build requires them to exist)
         run: |

--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -115,8 +115,10 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
+          # apps/desktop and apps/daemon are members of the root workspace, so
+          # cargo puts every member's output under the root target/.
           workspaces: |
-            ./apps/desktop -> target
+            . -> target
           key: ${{ matrix.target }}
 
       - name: Install protoc (for prost_build)
@@ -181,8 +183,9 @@ jobs:
           (
             set -e
             echo "Building teamclaw-introspect for ${{ matrix.target }}..."
-            cargo build --release --locked --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect --target ${{ matrix.target }} --target-dir apps/desktop/target
-            cp apps/desktop/target/${{ matrix.target }}/release/teamclaw-introspect apps/desktop/binaries/teamclaw-introspect-${{ matrix.target }}
+            TARGET_DIR="$(cargo metadata --format-version 1 --no-deps --manifest-path apps/desktop/Cargo.toml | jq -r .target_directory)"
+            cargo build --release --locked --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect --target ${{ matrix.target }}
+            cp "$TARGET_DIR/${{ matrix.target }}/release/teamclaw-introspect" apps/desktop/binaries/teamclaw-introspect-${{ matrix.target }}
             chmod +x apps/desktop/binaries/teamclaw-introspect-${{ matrix.target }}
             echo "teamclaw-introspect ready"
           ) > /tmp/introspect.log 2>&1 &
@@ -191,8 +194,9 @@ jobs:
           (
             set -e
             echo "Building amuxd for ${{ matrix.target }}..."
-            cargo build --release --locked --manifest-path apps/daemon/Cargo.toml -p amuxd --target ${{ matrix.target }} --target-dir apps/desktop/target
-            cp apps/desktop/target/${{ matrix.target }}/release/amuxd apps/desktop/binaries/amuxd-${{ matrix.target }}
+            TARGET_DIR="$(cargo metadata --format-version 1 --no-deps --manifest-path apps/daemon/Cargo.toml | jq -r .target_directory)"
+            cargo build --release --locked --manifest-path apps/daemon/Cargo.toml -p amuxd --target ${{ matrix.target }}
+            cp "$TARGET_DIR/${{ matrix.target }}/release/amuxd" apps/desktop/binaries/amuxd-${{ matrix.target }}
             chmod +x apps/desktop/binaries/amuxd-${{ matrix.target }}
             echo "amuxd ready"
           ) > /tmp/amuxd.log 2>&1 &
@@ -427,8 +431,10 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
+          # apps/desktop and apps/daemon are members of the root workspace, so
+          # cargo puts every member's output under the root target/.
           workspaces: |
-            ./apps/desktop -> target
+            . -> target
 
       - name: Install protoc (for prost_build)
         shell: bash
@@ -467,15 +473,17 @@ jobs:
       - name: Build teamclaw-introspect sidecar
         shell: bash
         run: |
-          cargo build --release --locked --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect --target-dir apps/desktop/target
-          cp apps/desktop/target/release/teamclaw-introspect.exe apps/desktop/binaries/teamclaw-introspect-x86_64-pc-windows-msvc.exe
+          TARGET_DIR="$(cargo metadata --format-version 1 --no-deps --manifest-path apps/desktop/Cargo.toml | jq -r .target_directory)"
+          cargo build --release --locked --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect
+          cp "$TARGET_DIR/release/teamclaw-introspect.exe" apps/desktop/binaries/teamclaw-introspect-x86_64-pc-windows-msvc.exe
           echo "teamclaw-introspect ready"
 
       - name: Build amuxd sidecar
         shell: bash
         run: |
-          cargo build --release --locked --manifest-path apps/daemon/Cargo.toml -p amuxd --target-dir apps/desktop/target
-          cp apps/desktop/target/release/amuxd.exe apps/desktop/binaries/amuxd-x86_64-pc-windows-msvc.exe
+          TARGET_DIR="$(cargo metadata --format-version 1 --no-deps --manifest-path apps/daemon/Cargo.toml | jq -r .target_directory)"
+          cargo build --release --locked --manifest-path apps/daemon/Cargo.toml -p amuxd
+          cp "$TARGET_DIR/release/amuxd.exe" apps/desktop/binaries/amuxd-x86_64-pc-windows-msvc.exe
           echo "amuxd sidecar ready"
 
       - name: Finalize tauri.conf.json (version from tag + frontend prebuilt + OSS updater endpoint)
@@ -644,12 +652,15 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: ./apps/daemon -> target
+          # apps/daemon is a member of the root workspace, so its output lands
+          # under the root target/, not apps/daemon/target/.
+          workspaces: . -> target
           key: amuxd-${{ matrix.target }}
 
       - name: Build amuxd
         run: |
           mkdir -p apps/desktop/binaries
+          TARGET_DIR="$(cargo metadata --format-version 1 --no-deps --manifest-path apps/daemon/Cargo.toml | jq -r .target_directory)"
           # NB: no --locked — the repo's Cargo.lock drifts slightly from
           # Cargo.toml and the desktop build (tauri-action) tolerates it by
           # updating the lock; match that here rather than hard-failing.
@@ -660,11 +671,11 @@ jobs:
             # Cross.toml's pre-build installs libssl-dev:arm64 + protoc there and
             # points openssl-sys at the arm64 multiarch lib/include dirs.
             cargo install cross --locked --version 0.2.5
-            cross build --release --manifest-path apps/daemon/Cargo.toml -p amuxd --target ${{ matrix.target }} --target-dir apps/desktop/target
+            cross build --release --manifest-path apps/daemon/Cargo.toml -p amuxd --target ${{ matrix.target }}
           else
-            cargo build --release --manifest-path apps/daemon/Cargo.toml -p amuxd --target ${{ matrix.target }} --target-dir apps/desktop/target
+            cargo build --release --manifest-path apps/daemon/Cargo.toml -p amuxd --target ${{ matrix.target }}
           fi
-          cp apps/desktop/target/${{ matrix.target }}/release/amuxd apps/desktop/binaries/amuxd-${{ matrix.target }}
+          cp "$TARGET_DIR/${{ matrix.target }}/release/amuxd" apps/desktop/binaries/amuxd-${{ matrix.target }}
           chmod +x apps/desktop/binaries/amuxd-${{ matrix.target }}
 
       - name: Upload standalone amuxd to OSS + emit amuxd fragment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,8 +119,10 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
+          # apps/desktop and apps/daemon are members of the root workspace, so
+          # cargo puts every member's output under the root target/.
           workspaces: |
-            ./apps/desktop -> target
+            . -> target
           key: ${{ matrix.target }}
 
       - name: Install protoc (for prost_build)
@@ -170,8 +172,9 @@ jobs:
           (
             set -e
             echo "Building teamclaw-introspect for ${{ matrix.target }}..."
-            cargo build --release --locked --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect --target ${{ matrix.target }} --target-dir apps/desktop/target
-            cp apps/desktop/target/${{ matrix.target }}/release/teamclaw-introspect apps/desktop/binaries/teamclaw-introspect-${{ matrix.target }}
+            TARGET_DIR="$(cargo metadata --format-version 1 --no-deps --manifest-path apps/desktop/Cargo.toml | jq -r .target_directory)"
+            cargo build --release --locked --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect --target ${{ matrix.target }}
+            cp "$TARGET_DIR/${{ matrix.target }}/release/teamclaw-introspect" apps/desktop/binaries/teamclaw-introspect-${{ matrix.target }}
             chmod +x apps/desktop/binaries/teamclaw-introspect-${{ matrix.target }}
             echo "teamclaw-introspect ready"
           ) > /tmp/introspect.log 2>&1 &
@@ -181,8 +184,9 @@ jobs:
           (
             set -e
             echo "Building amuxd for ${{ matrix.target }}..."
-            cargo build --release --locked --manifest-path apps/daemon/Cargo.toml -p amuxd --target ${{ matrix.target }} --target-dir apps/desktop/target
-            cp apps/desktop/target/${{ matrix.target }}/release/amuxd apps/desktop/binaries/amuxd-${{ matrix.target }}
+            TARGET_DIR="$(cargo metadata --format-version 1 --no-deps --manifest-path apps/daemon/Cargo.toml | jq -r .target_directory)"
+            cargo build --release --locked --manifest-path apps/daemon/Cargo.toml -p amuxd --target ${{ matrix.target }}
+            cp "$TARGET_DIR/${{ matrix.target }}/release/amuxd" apps/desktop/binaries/amuxd-${{ matrix.target }}
             chmod +x apps/desktop/binaries/amuxd-${{ matrix.target }}
             echo "amuxd ready"
           ) > /tmp/amuxd.log 2>&1 &
@@ -375,8 +379,10 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
+          # apps/desktop and apps/daemon are members of the root workspace, so
+          # cargo puts every member's output under the root target/.
           workspaces: |
-            ./apps/desktop -> target
+            . -> target
 
       - name: Install protoc (for prost_build)
         shell: bash
@@ -412,15 +418,17 @@ jobs:
       - name: Build teamclaw-introspect sidecar
         shell: bash
         run: |
-          cargo build --release --locked --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect --target-dir apps/desktop/target
-          cp apps/desktop/target/release/teamclaw-introspect.exe apps/desktop/binaries/teamclaw-introspect-x86_64-pc-windows-msvc.exe
+          TARGET_DIR="$(cargo metadata --format-version 1 --no-deps --manifest-path apps/desktop/Cargo.toml | jq -r .target_directory)"
+          cargo build --release --locked --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect
+          cp "$TARGET_DIR/release/teamclaw-introspect.exe" apps/desktop/binaries/teamclaw-introspect-x86_64-pc-windows-msvc.exe
           echo "teamclaw-introspect ready"
 
       - name: Build amuxd sidecar
         shell: bash
         run: |
-          cargo build --release --locked --manifest-path apps/daemon/Cargo.toml -p amuxd --target-dir apps/desktop/target
-          cp apps/desktop/target/release/amuxd.exe apps/desktop/binaries/amuxd-x86_64-pc-windows-msvc.exe
+          TARGET_DIR="$(cargo metadata --format-version 1 --no-deps --manifest-path apps/daemon/Cargo.toml | jq -r .target_directory)"
+          cargo build --release --locked --manifest-path apps/daemon/Cargo.toml -p amuxd
+          cp "$TARGET_DIR/release/amuxd.exe" apps/desktop/binaries/amuxd-x86_64-pc-windows-msvc.exe
           echo "amuxd sidecar ready"
 
       # Skip beforeBuildCommand since frontend is already built above

--- a/scripts/rust-build-env.js
+++ b/scripts/rust-build-env.js
@@ -99,8 +99,9 @@ function createRustBuildEnv(baseEnv = process.env, scriptDir = __dirname) {
     }
   }
 
-  // Only override CARGO_TARGET_DIR locally; in CI, tauri-action expects
-  // the default apps/desktop/target/ path for artifact discovery.
+  // Only override CARGO_TARGET_DIR locally. In CI, leave cargo's own default in
+  // place — apps/desktop is a root workspace member, so that default is the
+  // workspace root target/, which is where tauri-action discovers the bundle.
   if (!env.CARGO_TARGET_DIR && !baseEnv.GITHUB_ACTIONS) {
     env.CARGO_TARGET_DIR = path.join(repoRoot, ".cargo-target");
   }


### PR DESCRIPTION
Closes #496

## What was wrong

`apps/desktop` and `apps/daemon` are both members of the root workspace, so cargo resolves every member's target dir to the workspace root `target/`. The sidecar builds forced `--target-dir apps/desktop/target`, which is a *second, separate* target dir — so the shared dependency graph got compiled once for the sidecars and again for the Tauri bundle.

```console
$ cd apps/desktop && cargo metadata --format-version 1 --no-deps | jq -r .target_directory
<repo>/target                     # ← not apps/desktop/target
```

## A second bug the issue didn't mention

The `rust-cache` config carried the same wrong path (`./apps/desktop -> target`), so it was caching the **sidecar-only** directory and never the root `target/` where the Tauri build actually runs — meaning that cache has been missing on every run. Fixed in `release.yml`, `release-oss.yml`, and `ci.yml` (the CI clippy job had it too).

## Changes

- Drop `--target-dir apps/desktop/target` from every sidecar build; read the output path from `cargo metadata` instead, so the copy stays correct whether or not `CARGO_TARGET_DIR` is set.
- Point `rust-cache` at `. -> target` in `release.yml`, `release-oss.yml`, and `ci.yml`.
- Correct the stale comment in `scripts/rust-build-env.js` — cargo's default for a workspace member is the workspace root, not `apps/desktop/target`. That comment only held if `apps/desktop` were a standalone crate.

## Notes on the issue's framing

- There's no `release-beta.yml` in this repo; the affected workflows are `release.yml` and `release-oss.yml` (including its Linux `cross` job).
- `scripts/ensure-{amuxd,introspect}-sidecar.js` have the same stale `apps/desktop/target` fallback, but I left them alone — they're only reachable from `tauri-cli.js`/`rust-cli.js`, which never run in CI and always get `CARGO_TARGET_DIR` set locally, so the fallback is unreachable today.

## Verification

- `cargo metadata` resolves to the workspace root from both `apps/desktop` and `apps/daemon`.
- A real `cargo build -p amuxd --target aarch64-apple-darwin` with the flag dropped landed the binary at exactly the `$TARGET_DIR/<target>/<profile>/amuxd` path the workflows now copy from.
- All three workflows parse as valid YAML.
- Not verifiable locally: the Windows `cross`/`jq` path — that only proves out on a real CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)