### PR TITLE
fix(desktop): fail the build when a release binary bakes no CLOUD_API_URL

### DIFF
--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -173,10 +173,42 @@ fn main() {
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
         });
-    if let Some(url) = cloud_api_url {
-        let url = url.trim_end_matches('/');
-        println!("cargo:rustc-env=CLOUD_API_URL={}", url);
-        println!("cargo:warning=Using CLOUD_API_URL={}", url);
+    match cloud_api_url {
+        Some(url) => {
+            let url = url.trim_end_matches('/');
+            println!("cargo:rustc-env=CLOUD_API_URL={}", url);
+            println!("cargo:warning=Using CLOUD_API_URL={}", url);
+        }
+        // A release-profile build with no Cloud API URL produces a binary that
+        // compiles, publishes, and only dies when a user clicks "开通团队共享" —
+        // `default_fc_endpoint` (commands/oss_sync/mod.rs) panics at RUNTIME on
+        // the missing `option_env!("CLOUD_API_URL")`. That shipped once: betly
+        // builds from the old release-beta.yml baked nothing, fell back to the
+        // then-hardcoded `https://cloud.ucar.cc`, and every Team Shared attempt
+        // got `FunctionNotFound: function 'teamclaw-sync' does not exist`.
+        // Fail the build instead, so it cannot leave CI.
+        //
+        // Gated on PROFILE, not CI: `cargo fmt/clippy/check` (ci.yml) and
+        // `tauri dev` run the debug profile with no build.config.json on disk
+        // (it is gitignored) and must keep working. Every pipeline that ships a
+        // binary supplies one — release-oss.yml via brand-setup, release.yml via
+        // BUILD_ENV=production merging build.config.production.json.
+        None if std::env::var("PROFILE").as_deref() == Ok("release") => {
+            panic!(
+                "cloudApiUrl is not set — refusing to bake a release binary with no Cloud API \
+                 endpoint.\nSet it one of these ways:\n  \
+                 • put `cloudApiUrl` in build.config.json (copy build.config.example.json)\n  \
+                 • build with BUILD_ENV=production (merges build.config.production.json)\n  \
+                 • export VITE_CLOUD_API_URL=<url>\nSee apps/desktop/src/commands/oss_sync/mod.rs \
+                 (default_fc_endpoint) for why a binary without this is broken."
+            );
+        }
+        None => {
+            println!(
+                "cargo:warning=No cloudApiUrl in build config — CLOUD_API_URL unset. Fine for \
+                 check/clippy; a release build with this unset is a hard error."
+            );
+        }
     }
 
     let target_triple = std::env::var("TARGET").unwrap_or_default();


### PR DESCRIPTION
## Problem

The belty beta shipped a binary that hit the dead Alibaba FC host `cloud.ucar.cc`, so enabling **团队共享 (Team Shared)** failed with:

```
internal: FC returned HTTP 404 Not Found
{"Code":"FunctionNotFound","Message":"function 'teamclaw-sync' does not exist"}
```

Root cause: root `build.config.json` is gitignored, so at compile time it's the *only* source of `cloudApiUrl`. When it's absent (or lacks the key), `build.rs` silently baked **no** `CLOUD_API_URL`. The Rust team-share / OSS commands (`default_fc_endpoint` in `commands/oss_sync/mod.rs`) then panic at **runtime** on the missing `option_env!("CLOUD_API_URL")` — but the old fallback pointed at the now-deleted `cloud.ucar.cc` FC `teamclaw-sync`. The binary compiled and published fine; it only broke when a user clicked 开通团队共享.

This actually shipped: the old `release-beta.yml` wrote `build.config.json` from the `BUILD_CONFIG_BETA` secret rather than the branding repo, and those binaries had no valid endpoint. (Fixed for new packages by `release-oss.yml` + brand-setup; this PR is the guardrail so it can't recur.)

## Fix

Turn the silent gap into a hard build error — but only where it matters:

- **release profile + no `cloudApiUrl` → `panic!`** with an actionable message. A broken binary can no longer leave CI.
- **debug / check / clippy / dev → warning only**, compiles as before.

Gated on `PROFILE=release`, **not** `CI`: `cargo fmt/clippy/check` and `tauri dev` run the debug profile with no `build.config.json` on disk (gitignored) and must keep working. Every pipeline that ships a binary already supplies one — `release-oss.yml` via brand-setup, `release.yml` via `BUILD_ENV=production` merging `build.config.production.json`.

## Verification

Ran all four locally:

| Scenario | Expected | Result |
|---|---|---|
| debug, no `build.config.json` | pass | ✅ Finished |
| release, no endpoint | fail | ✅ panics with guidance |
| release + `BUILD_ENV=production` (release.yml path) | pass, bakes `api.teamclaw-dev.ucar.cc` | ✅ |
| release + betly brand config (release-oss.yml path) | pass, bakes `teamclaw-api.ucar.cc` | ✅ |

`cargo fmt --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)