### PR TITLE
chore: bump desktop version to 0.2.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "amuxd"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "aes-gcm",
  "agent-client-protocol",
@@ -10270,7 +10270,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaw"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.2.24"
+version = "0.2.25"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaw"
-version = "0.2.24"
+version = "0.2.25"
 description = "TeamClaw - AI Agent Desktop Platform"
 authors = ["TeamClaw Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClaw",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "identifier": "com.teamclaw.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclaw/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclaw",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "description": "TeamClaw - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
Unifies the four version files to `0.2.25`, ahead of re-publishing betly and
copilot361.

## Why the files were behind

`finalize-oss-release-conf.py` takes the shipped version from the release tag,
so copilot361 already published as **0.2.25** while `package.json` and friends
still said `0.2.24`. This realigns them.

## Files

- `package.json`, `apps/desktop/tauri.conf.json`, `apps/desktop/Cargo.toml`,
  `apps/daemon/Cargo.toml` → `0.2.25`
- `Cargo.lock` — regenerated with `cargo update --workspace`; touches only the
  two workspace members (`teamclaw`, `amuxd`), no dependency drift. CI builds
  with `--locked`, so a stale lock would fail the release build.

## Context

This unblocks re-publishing both brands with the corrected signing key
(`1D087DF9`). The releases that follow will be `v0.2.25-beta.1` for betly and
`v0.2.25` for copilot361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)