### PR TITLE
fix(ci): serialize releases per brand, not per brand+tag

### DIFF
--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -35,8 +35,16 @@ on:
         required: true
         type: string
 
+# Keyed on brand alone, deliberately: every release of a brand overwrites that
+# brand's single latest.json, so two releases of the SAME brand are never safe to
+# run concurrently regardless of tag. Including the tag here left them in
+# separate groups, so on 2026-07-16 a betly v0.2.24-beta.5 run started 3 minutes
+# earlier but finished 2 minutes later than a v0.2.25-beta.1 run and clobbered
+# the manifest back to the older version — last writer wins, and build duration,
+# not version order, decides the winner. Different brands publish to different
+# prefixes and still run in parallel.
 concurrency:
-  group: release-oss-${{ inputs.brand }}-${{ inputs.tag }}
+  group: release-oss-${{ inputs.brand }}
   cancel-in-progress: true
 
 # Per-brand values (bucket, endpoint, prefix, CDN base, app name) are exported


### PR DESCRIPTION
## The bug

`concurrency.group` was `release-oss-<brand>-<tag>`. Two releases of the **same
brand** with **different tags** therefore landed in different groups and ran
concurrently — but they both overwrite that brand's single `latest.json`.

Whoever finishes last wins, and finish order is decided by build duration, not
by version order. A slow older release silently overwrites a fast newer one.

## It already happened

Today, on betly:

| Time | Event |
|---|---|
| 08:38:24 | `v0.2.24-beta.5` triggered |
| 08:41:11 | `v0.2.25-beta.1` triggered |
| 09:18:04 | `v0.2.25-beta.1` finishes → `latest.json` = 0.2.25-beta.1 |
| 09:19:45 | `v0.2.24-beta.5` finishes → `latest.json` = **0.2.24-beta.5** |

betly users are being offered 0.2.24-beta.5 while the 0.2.25-beta.1 artifacts sit
on OSS, fully uploaded and unreachable — only the manifest points elsewhere.

## The fix

Key the group on `brand` alone. Same-brand releases now serialize, and with
`cancel-in-progress: true` the newest trigger wins deterministically. Different
brands publish under different prefixes and are unaffected — they still run in
parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)