### PR TITLE
feat(daemon): let a headless daemon obtain team-share credentials

### DIFF
--- a/apps/daemon/src/backend/mock.rs
+++ b/apps/daemon/src/backend/mock.rs
@@ -170,6 +170,9 @@ pub struct MockState {
     /// Per-team `managed_llm_config` overrides. Missing entries fall back to
     /// `ManagedLlmConfig::default()` (i.e. managed LLM disabled).
     pub managed_llm_configs: HashMap<String, ManagedLlmConfig>,
+    /// Per-team `managed_git_credential` overrides. A missing entry errors,
+    /// mirroring a cloud API that has no credential to hand out.
+    pub managed_git_credentials: HashMap<String, ManagedGitCredential>,
 }
 
 #[derive(Clone, Debug)]
@@ -245,19 +248,21 @@ impl Backend for MockBackend {
             .unwrap_or_default())
     }
 
-    async fn managed_git_credential(
-        &self,
-        _team_id: &str,
-    ) -> BackendResult<ManagedGitCredential> {
-        // B1 stub: no managed-git credential is wired into the mock yet. B2
-        // adds a real mock; tests that don't exercise the seed path never hit
-        // this, and returning an error (not `unimplemented!()`) keeps any
-        // accidental caller from panicking the test process.
-        Err(BackendError::Provider {
-            provider: "mock",
-            code: None,
-            message: "managed_git_credential not supported by MockBackend".into(),
-        })
+    async fn managed_git_credential(&self, team_id: &str) -> BackendResult<ManagedGitCredential> {
+        // Tests that need a credential seed `state().managed_git_credentials`.
+        // An unseeded team errors rather than panicking, so an accidental
+        // caller fails its own assertion instead of the test process.
+        self.state
+            .lock()
+            .unwrap()
+            .managed_git_credentials
+            .get(team_id)
+            .cloned()
+            .ok_or_else(|| BackendError::Provider {
+                provider: "mock",
+                code: None,
+                message: format!("no managed-git credential seeded for {team_id}"),
+            })
     }
 
     async fn get_effective_default_agent(&self, _team_id: &str) -> BackendResult<Option<String>> {

--- a/apps/daemon/src/cli/mod.rs
+++ b/apps/daemon/src/cli/mod.rs
@@ -7,6 +7,7 @@ pub mod mcp_server;
 pub mod process;
 pub mod remote_tools_mcp;
 pub mod service;
+pub mod team_secrets;
 pub mod test_client;
 
 use clap::{Args, Parser, Subcommand};
@@ -67,6 +68,8 @@ pub enum Commands {
     Channel(ChannelArgs),
     /// Read and edit daemon.toml values by dotted key.
     Config(ConfigArgs),
+    /// Manage team-share state for this daemon.
+    Team(TeamArgs),
     /// Report install status of opencode / git / amuxd as JSON.
     Doctor,
     /// Download and install the opencode binary into ~/.amuxd/bin/opencode.
@@ -112,6 +115,67 @@ pub enum ConfigAction {
     Set { key: String, value: String },
     /// Remove one config value by dotted key.
     Unset { key: String },
+}
+
+#[derive(Args, Debug)]
+pub struct TeamArgs {
+    #[command(subcommand)]
+    pub action: TeamAction,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TeamAction {
+    /// Provision the sync credentials a headless daemon cannot obtain on its
+    /// own. `managed_git` needs nothing here — the daemon fetches that
+    /// credential from the cloud. `oss` and `custom_git` secrets are user-held
+    /// and have no server-side copy, so they must be supplied here.
+    Secrets(TeamSecretsArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct TeamSecretsArgs {
+    #[command(subcommand)]
+    pub action: TeamSecretsAction,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TeamSecretsAction {
+    /// Set one or more secrets. Omitted fields keep their stored value.
+    /// Restart the daemon afterwards: the sync timer snapshots its workspace
+    /// list at startup.
+    Set {
+        /// Team to write. Defaults to `team_id` from daemon.toml.
+        #[arg(long)]
+        team_id: Option<String>,
+        /// OSS team secret, 64 hex chars (`oss` share mode).
+        #[arg(long)]
+        oss_secret: Option<String>,
+        /// Git credential (`custom_git`): `user:token` when the team's auth
+        /// kind is https_token, or an SSH private key when it is ssh_key.
+        #[arg(long)]
+        git_credential: Option<String>,
+        /// Read the git credential from a file, e.g. an SSH private key.
+        /// Avoids putting it in shell history.
+        #[arg(long, conflicts_with = "git_credential")]
+        git_credential_file: Option<PathBuf>,
+        /// Branch for git-backed sync. The cloud API does not carry this, so
+        /// without it git falls back to the remote's default branch.
+        #[arg(long)]
+        git_branch: Option<String>,
+    },
+    /// Show which secrets are set. Values are masked.
+    Show {
+        #[arg(long)]
+        team_id: Option<String>,
+    },
+    /// Remove all stored secrets for a team.
+    Clear {
+        #[arg(long)]
+        team_id: Option<String>,
+        /// Skip the interactive confirmation prompt.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Args, Debug)]

--- a/apps/daemon/src/cli/team_secrets.rs
+++ b/apps/daemon/src/cli/team_secrets.rs
@@ -1,0 +1,207 @@
+//! `amuxd team secrets` — provision team-share credentials on a daemon that has
+//! no desktop app to push them over `POST /v1/team/secrets`.
+//!
+//! Writes the same store the HTTP path does (`~/.amuxd/teams/<id>/secrets.enc`),
+//! offline: the daemon need not be running, and a running daemon picks the
+//! secrets up on its next sync tick without a reload signal.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use crate::config::DaemonConfig;
+use crate::sync::secret_store::{SecretStore, TeamSecrets};
+
+use super::{TeamAction, TeamArgs, TeamSecretsAction};
+
+pub fn run(args: TeamArgs) -> anyhow::Result<()> {
+    let TeamAction::Secrets(secrets) = args.action;
+    match secrets.action {
+        TeamSecretsAction::Set {
+            team_id,
+            oss_secret,
+            git_credential,
+            git_credential_file,
+            git_branch,
+        } => set(
+            team_id,
+            oss_secret,
+            git_credential,
+            git_credential_file,
+            git_branch,
+        ),
+        TeamSecretsAction::Show { team_id } => show(team_id),
+        TeamSecretsAction::Clear { team_id, force } => clear(team_id, force),
+    }
+}
+
+/// The team this daemon is bound to. `amuxd init` writes it; the daemon is
+/// single-team, so an explicit `--team-id` is only for unusual cases.
+fn resolve_team_id(explicit: Option<String>) -> anyhow::Result<String> {
+    if let Some(id) = explicit {
+        let id = id.trim().to_string();
+        if id.is_empty() {
+            anyhow::bail!("--team-id is empty");
+        }
+        return Ok(id);
+    }
+    let path = DaemonConfig::default_path();
+    let config = DaemonConfig::load(&path).map_err(|e| {
+        anyhow::anyhow!(
+            "read {}: {e}\nRun `amuxd init <teamclaw://invite?token=...>` first, or pass --team-id.",
+            path.display()
+        )
+    })?;
+    config
+        .team_id
+        .filter(|t| !t.trim().is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "no team_id in {}.\nRun `amuxd init <teamclaw://invite?token=...>` first, or pass --team-id.",
+                path.display()
+            )
+        })
+}
+
+/// The OSS secret is HKDF input keying material, not an opaque token: it must
+/// decode to exactly 32 bytes or every blob fails to decrypt. Reject it here
+/// rather than at the next sync tick.
+fn validate_oss_secret(secret: &str) -> anyhow::Result<()> {
+    let ok = secret.len() == 64 && secret.chars().all(|c| c.is_ascii_hexdigit());
+    if !ok {
+        anyhow::bail!(
+            "--oss-secret must be 64 hex chars (32 bytes), got {} char(s)",
+            secret.len()
+        );
+    }
+    Ok(())
+}
+
+fn set(
+    team_id: Option<String>,
+    oss_secret: Option<String>,
+    git_credential: Option<String>,
+    git_credential_file: Option<PathBuf>,
+    git_branch: Option<String>,
+) -> anyhow::Result<()> {
+    let team_id = resolve_team_id(team_id)?;
+
+    let git_credential = match (git_credential, git_credential_file) {
+        (Some(c), _) => Some(c),
+        // Trailing newlines are near-universal in key files and would corrupt
+        // an SSH PEM or an https `user:token` pair.
+        (None, Some(path)) => Some(
+            std::fs::read_to_string(&path)
+                .map_err(|e| anyhow::anyhow!("read {}: {e}", path.display()))?
+                .trim_end()
+                .to_string(),
+        ),
+        (None, None) => None,
+    };
+
+    let oss_secret = oss_secret.map(|s| s.trim().to_string());
+    if let Some(s) = &oss_secret {
+        validate_oss_secret(s)?;
+    }
+
+    if oss_secret.is_none() && git_credential.is_none() && git_branch.is_none() {
+        anyhow::bail!(
+            "nothing to set: pass --oss-secret, --git-credential/--git-credential-file, or --git-branch"
+        );
+    }
+
+    let incoming = TeamSecrets {
+        oss_team_secret: oss_secret,
+        // The daemon self-supplies its own cloud bearer for OSS sync, so this
+        // field is intentionally not settable here.
+        user_jwt: None,
+        git_credential,
+        git_branch,
+    };
+
+    let store = SecretStore::new();
+    store
+        .merge(&team_id, &incoming)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    println!("✓ secrets updated for team {team_id}");
+    print_state(&store, &team_id)?;
+    println!("\nRestart the daemon (`amuxd stop && amuxd start`) so the sync timer picks up this team's workspaces.");
+    Ok(())
+}
+
+fn show(team_id: Option<String>) -> anyhow::Result<()> {
+    let team_id = resolve_team_id(team_id)?;
+    let store = SecretStore::new();
+    println!("team {team_id}");
+    print_state(&store, &team_id)
+}
+
+fn print_state(store: &SecretStore, team_id: &str) -> anyhow::Result<()> {
+    let s = store.load(team_id).map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!("  oss_team_secret = {}", mask(s.oss_team_secret.as_deref()));
+    println!("  git_credential  = {}", mask(s.git_credential.as_deref()));
+    println!(
+        "  git_branch      = {}",
+        s.git_branch.as_deref().unwrap_or("(unset)")
+    );
+    Ok(())
+}
+
+/// Show enough to tell two secrets apart, never enough to use one.
+fn mask(value: Option<&str>) -> String {
+    match value {
+        None => "(unset)".to_string(),
+        Some(v) if v.len() <= 8 => "(set)".to_string(),
+        Some(v) => format!("(set, {}…{})", &v[..4], &v[v.len() - 4..]),
+    }
+}
+
+fn clear(team_id: Option<String>, force: bool) -> anyhow::Result<()> {
+    let team_id = resolve_team_id(team_id)?;
+    let store = SecretStore::new();
+
+    if !force {
+        print!("Remove all stored secrets for team {team_id}? [y/N]: ");
+        std::io::stdout().flush()?;
+        let mut buf = String::new();
+        std::io::stdin().read_line(&mut buf)?;
+        let answer = buf.trim().to_lowercase();
+        if answer != "y" && answer != "yes" {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    store.clear(&team_id).map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!("✓ secrets cleared for team {team_id}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oss_secret_must_be_64_hex() {
+        assert!(validate_oss_secret(&"ab".repeat(32)).is_ok());
+        assert!(validate_oss_secret(&"AB".repeat(32)).is_ok());
+        // Too short, and the length is what a user is most likely to get wrong.
+        assert!(validate_oss_secret("abcd").is_err());
+        // Right length, but 'z' is not hex — would fail at HKDF decode.
+        assert!(validate_oss_secret(&"z".repeat(64)).is_err());
+    }
+
+    #[test]
+    fn mask_reveals_only_the_edges() {
+        assert_eq!(mask(None), "(unset)");
+        // A short value has no safe middle to elide.
+        assert_eq!(mask(Some("short")), "(set)");
+        assert_eq!(mask(Some("0123456789abcdef")), "(set, 0123…cdef)");
+    }
+
+    #[test]
+    fn explicit_team_id_wins_and_rejects_blank() {
+        assert_eq!(resolve_team_id(Some("t-1".into())).unwrap(), "t-1");
+        assert!(resolve_team_id(Some("   ".into())).is_err());
+    }
+}

--- a/apps/daemon/src/main.rs
+++ b/apps/daemon/src/main.rs
@@ -51,6 +51,9 @@ fn main() -> anyhow::Result<()> {
         Commands::Clear { force } => {
             cli::clear::run(force)?;
         }
+        Commands::Team(args) => {
+            cli::team_secrets::run(args)?;
+        }
         Commands::Start {
             daemonize: _,
             config,

--- a/apps/daemon/src/sync/dispatch.rs
+++ b/apps/daemon/src/sync/dispatch.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use crate::sync::git::GitCredential;
 use crate::sync::secret_store::SecretStore;
-
 
 /// Whether an FC `share-mode` value selects git-backed sync (vs OSS / disabled).
 pub fn git_mode(mode: &str) -> bool {
@@ -78,6 +78,38 @@ impl SyncDispatcher {
             .and_then(|b| b.cloud_base_url())
             .filter(|u| !u.trim().is_empty())
             .ok_or_else(|| "FC endpoint not configured: no cloud backend URL available".to_string())
+    }
+
+    /// The credential for git-backed sync.
+    ///
+    /// The secret store wins when it holds one: the desktop may have pushed it,
+    /// or `amuxd team secrets set` may have placed a deliberate override that a
+    /// re-fetch would silently undo. Falling back to the cloud is only valid for
+    /// `managed_git`, where the cloud is the credential's system of record —
+    /// `custom_git` and `oss` secrets are user-held and have no server-side copy,
+    /// so a headless daemon can only get those from the CLI.
+    async fn resolve_git_credential(
+        &self,
+        team_id: &str,
+        mode: &str,
+        auth_kind: Option<&str>,
+    ) -> Result<GitCredential, String> {
+        let stored = self.secrets.git_credential(team_id, auth_kind)?;
+        if !matches!(stored, GitCredential::None) || mode != "managed_git" {
+            return Ok(stored);
+        }
+        let backend = self
+            .backend
+            .as_ref()
+            .ok_or_else(|| "no cloud backend for managed-git credential".to_string())?;
+        let cred = backend
+            .managed_git_credential(team_id)
+            .await
+            .map_err(|e| format!("fetch managed-git credential: {e}"))?;
+        Ok(GitCredential::HttpsToken(format!(
+            "{}:{}",
+            cred.username, cred.token
+        )))
     }
 
     /// FC bearer for OSS sync: the daemon's own auto-refreshing cloud token.
@@ -159,8 +191,8 @@ impl SyncDispatcher {
             Some(m) if git_mode(m) => {
                 let secrets = self.secrets.load(team_id)?;
                 let cred = self
-                    .secrets
-                    .git_credential(team_id, share.git_auth_kind.as_deref())?;
+                    .resolve_git_credential(team_id, m, share.git_auth_kind.as_deref())
+                    .await?;
                 let cfg = git::TeamSharedGitConfig {
                     git_url: share.git_remote_url.clone(),
                     // FC has no branch; the secret store provides it (else git
@@ -237,6 +269,98 @@ mod tests {
         assert!(!git_mode("oss"));
         assert!(!git_mode(""));
         assert!(!git_mode("whatever"));
+    }
+
+    use crate::backend::mock::MockBackend;
+    use crate::backend::ManagedGitCredential;
+    use crate::sync::secret_store::TeamSecrets;
+
+    /// A dispatcher over a throwaway secret store, plus the mock backend so
+    /// tests can seed (or withhold) the cloud's managed-git credential.
+    fn dispatcher_with_mock(tmp: &tempfile::TempDir) -> (SyncDispatcher, Arc<MockBackend>) {
+        let backend = Arc::new(MockBackend::new());
+        let store = SecretStore::with_base(tmp.path().to_path_buf());
+        let d = SyncDispatcher::new(store, Some(backend.clone()));
+        (d, backend)
+    }
+
+    #[tokio::test]
+    async fn managed_git_falls_back_to_cloud_credential_when_store_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (d, backend) = dispatcher_with_mock(&tmp);
+        backend.state().managed_git_credentials.insert(
+            "t".into(),
+            ManagedGitCredential {
+                username: "bot".into(),
+                token: "pat123".into(),
+            },
+        );
+        // This is the headless case: no desktop ever pushed a credential.
+        let cred = d
+            .resolve_git_credential("t", "managed_git", Some("https_token"))
+            .await
+            .unwrap();
+        assert!(matches!(cred, GitCredential::HttpsToken(c) if c == "bot:pat123"));
+    }
+
+    #[tokio::test]
+    async fn stored_credential_wins_over_cloud_for_managed_git() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (d, backend) = dispatcher_with_mock(&tmp);
+        backend.state().managed_git_credentials.insert(
+            "t".into(),
+            ManagedGitCredential {
+                username: "bot".into(),
+                token: "pat123".into(),
+            },
+        );
+        d.secrets()
+            .merge(
+                "t",
+                &TeamSecrets {
+                    git_credential: Some("stored:override".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let cred = d
+            .resolve_git_credential("t", "managed_git", Some("https_token"))
+            .await
+            .unwrap();
+        assert!(matches!(cred, GitCredential::HttpsToken(c) if c == "stored:override"));
+    }
+
+    #[tokio::test]
+    async fn custom_git_never_fetches_from_cloud() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (d, backend) = dispatcher_with_mock(&tmp);
+        // Seeded, and still must not be used: a custom_git remote is not the
+        // managed remote, so the managed credential would be the wrong secret.
+        backend.state().managed_git_credentials.insert(
+            "t".into(),
+            ManagedGitCredential {
+                username: "bot".into(),
+                token: "pat123".into(),
+            },
+        );
+        let cred = d
+            .resolve_git_credential("t", "custom_git", Some("https_token"))
+            .await
+            .unwrap();
+        assert!(matches!(cred, GitCredential::None));
+    }
+
+    #[tokio::test]
+    async fn managed_git_surfaces_cloud_fetch_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (d, _backend) = dispatcher_with_mock(&tmp);
+        // Nothing stored, nothing seeded: the error must name the fetch, not
+        // masquerade as a missing local secret.
+        let err = d
+            .resolve_git_credential("t", "managed_git", Some("https_token"))
+            .await
+            .unwrap_err();
+        assert!(err.contains("managed-git credential"), "got: {err}");
     }
     #[test]
     fn fc_endpoint_errors_without_backend() {

--- a/apps/daemon/src/sync/secret_store.rs
+++ b/apps/daemon/src/sync/secret_store.rs
@@ -120,6 +120,15 @@ impl SecretStore {
         std::fs::write(&path, blob).map_err(|e| format!("write secrets: {e}"))
     }
 
+    /// Remove a team's stored secrets. Absent secrets are not an error.
+    pub fn clear(&self, team_id: &str) -> Result<(), String> {
+        match std::fs::remove_file(self.secrets_path(team_id)) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(format!("remove secrets: {e}")),
+        }
+    }
+
     /// Merge non-None fields from `incoming` into the stored secrets.
     pub fn merge(&self, team_id: &str, incoming: &TeamSecrets) -> Result<(), String> {
         let mut current = self.load(team_id)?;


### PR DESCRIPTION
## 问题

单独装 daemon（没有桌面端）、被邀请进团队后，share mode 能自动发现，但内容永远同步不起来。

secret 进入 daemon 的**唯一**通路是 `POST /v1/team/secrets`，而调用它的只有桌面端。没有环境变量、没有 CLI、没有 keychain、也没有从 Cloud API 拉取。结果：

- `oss` → `no OSS team secret for <id>`
- git 模式 → `GitCredential::None`，私有仓库克隆失败

## 改动

按「secret 归谁所有」分成两条路：

**managed_git —— daemon 自取。** 云端本来就是这个凭据的 system of record（`GET /v1/teams/:id/managed-git-credential` 早就存在，只是同步路径从没用过，此前唯一调用方是 app seeding）。抽出 `resolve_git_credential`：store 里有就用 store，没有且模式是 `managed_git` 才去云端取。

store 优先是刻意的 —— 桌面推过的、或手工设的 override，不该被一次静默 re-fetch 冲掉。`custom_git` 明确不走这条回退：它的远端不是 managed 远端，拿 managed 凭据是错的密钥。

**oss / custom_git —— 只能靠 CLI。** 这两种 secret 是用户自持、服务端根本没有副本，再多云端管道也救不了。新增 `amuxd team secrets set|show|clear`，写的是 HTTP 路径同一个加密 store（`~/.amuxd/teams/<id>/secrets.enc`），离线可用，daemon 不用在跑。

几个实现上的判断：

- `--oss-secret` 写入前校验 64-hex —— 它是 HKDF 的 IKM 而不是不透明 token（`team_shared_env.rs:26`），错了要等到下一个 sync tick 才炸
- `--git-credential-file` trim 尾部换行，否则 SSH PEM 和 `user:token` 都会被污染
- `show` 只露首尾 4 位
- `user_jwt` 故意不可设 —— daemon 自己有会刷新的 cloud token（`dispatch.rs` `oss_jwt()`）

`MockBackend::managed_git_credential` 改成可通过 `state().managed_git_credentials` seed（stub 自己留的 TODO），这是回退逻辑能脱离真实远端测试的前提。

## 验证

- daemon 全套测试绿：767 单测 + 4 个集成套件（新增 4 个 dispatch 测试、3 个 CLI 测试）
- CLI 在临时 HOME 里实跑了全部路径：确认 blob 是 AMXC 加密的、`secret.key` 是 0600、merge 不覆盖已有字段、缺 team_id 时报错指向 `amuxd init`

## 未包含

同步定时器的 workspace 列表是 spawn 时快照的，所以设完 secret 仍需重启 daemon。这个限制是既有的，本 PR 没动，CLI 输出和 `--help` 里都写明了提示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)