### PR TITLE
fix(fc): stop capping every self-host team at $1 of LiteLLM spend

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -78,6 +78,11 @@ LITELLM_UI_USERNAME=admin
 LITELLM_UI_PASSWORD=
 # Host loopback port for the gateway/admin UI.
 LITELLM_PORT=4000
+# Per-team spend cap in USD, written into LiteLLM when a team is provisioned.
+# Blank = no cap, which is the default: cap upstream at the provider key instead.
+# Applies at provisioning time only — raising this does NOT lift the cap on a
+# team that already exists (that needs a LiteLLM /team/update).
+LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD=
 # Upstream provider keys, referenced by litellm/config.yaml via os.environ/.
 # litellm/config.yaml ships a static model_list for DeepSeek (deepseek-v4-flash,
 # deepseek-v4-pro) — set DEEPSEEK_API_KEY to enable them. Additional models can

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -211,6 +211,13 @@ services:
       # convenience, not a safety net.
       LITELLM_URL: "${LITELLM_URL:-http://litellm:4000}"
       LITELLM_MASTER_KEY: "${LITELLM_MASTER_KEY:-}"
+      # Per-team spend cap written at /team/new. Blank = no cap. This was absent
+      # from the allowlist, so FC always saw undefined and fell back to its old
+      # default of 1 — every self-host team hard-stopped after a dollar, and it
+      # surfaced from LiteLLM as budget-exceeded rather than as a config problem.
+      # Note it applies at provisioning time only: changing it never moves a team
+      # that already exists.
+      LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD: "${LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD:-}"
       # Must be set: litellm-init creates the database as `_litellm`, but
       # resolveLiteLlmConnString() defaults to `litellm` (no underscore), so
       # without this the usage queries connect to a database that never exists.

--- a/scripts/lib/env-manifest.test.js
+++ b/scripts/lib/env-manifest.test.js
@@ -105,10 +105,6 @@ const INTENTIONAL_FC_ONLY = {
  * environment map and deleting the entry here.
  */
 const KNOWN_GAPS = {
-  // Absence leaves the default of 1 USD, so every self-host team hard-stops
-  // after a dollar of spend, surfacing from LiteLLM as budget-exceeded rather
-  // than as a config problem.
-  LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD: "self-host teams silently capped at $1 of LiteLLM spend",
   // Default is 1, a serverless tuning. Inert while self-host runs
   // BACKEND_KIND=supabase (getDb() is postgres-only), but serializes every DB
   // request through one connection the moment that flips.

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -33,7 +33,9 @@ resources:
         ENDPOINT: https://oss-cn-shenzhen.aliyuncs.com
         LITELLM_URL: ${env('LITELLM_URL', 'https://ai.ucar.cc')}
         LITELLM_MASTER_KEY: ${env('LITELLM_MASTER_KEY', '')}
-        LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD: ${env('LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD', '1')}
+        # Blank = no cap, matching the compose default. Keep the two targets in
+        # step: a default that differs per target is how the $1 cap went unnoticed.
+        LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD: ${env('LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD', '')}
         # LiteLLM usage reads the `litellm` database on the SAME Postgres instance
         # as the primary FC connection (DATABASE_URL/POSTGRES_*); only the db name
         # differs. Override the db name here if it is not `litellm`.

--- a/services/fc/src/lib/litellm.ts
+++ b/services/fc/src/lib/litellm.ts
@@ -23,12 +23,28 @@ export const LITELLM_URL = () => {
 };
 export const LITELLM_MASTER_KEY = () => process.env.LITELLM_MASTER_KEY || "";
 
-/** Default team max spend (USD) applied on /team/new during provisioning. */
-export const LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD = () => {
-  const raw = process.env.LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD;
-  if (raw === undefined || raw === "") return 1;
+/**
+ * Default team max spend (USD) applied on /team/new during provisioning.
+ * `null` means no cap — LiteLLM treats a null max_budget as unlimited.
+ *
+ * Unset means unlimited, deliberately. This used to default to 1, which capped
+ * every team at a dollar of spend; self-host could not even override it, since
+ * the compose fc environment map never passed the var through. Spend control
+ * belongs at the upstream provider key, not in a default nobody chose.
+ */
+export const LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD = (): number | null => {
+  const raw = process.env.LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD?.trim();
+  if (!raw) return null;
   const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? n : 1;
+  if (!Number.isFinite(n) || n < 0) {
+    // Don't silently apply a cap the operator did not write. Warn and treat it
+    // as unset, matching what an absent var does.
+    console.warn(
+      `[litellm] LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD=${JSON.stringify(raw)} is not a non-negative number; provisioning teams with no budget cap.`,
+    );
+    return null;
+  }
+  return n;
 };
 
 export async function litellmFetch(path: string, method: string, body?: unknown) {


### PR DESCRIPTION
## The bug

`LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD` is declared in `s.yaml` but was **missing
from the compose `fc:` environment map** — an explicit allowlist, so the var
never reached the container.

FC therefore always read `undefined` on self-host and fell back to its default of
`1`, writing `max_budget: 1` into every team at `/team/new`. Every self-host team
hard-stops after **one dollar** of spend, and it surfaces from LiteLLM as
`budget-exceeded` — reading as a usage problem, not a config one. No operator
could override it: the var could not reach FC at all.

This was already logged in `KNOWN_GAPS` (`env-manifest.test.js`) with the note
*"that IS a bug"*, listed only to keep the drift test green. Self-host is the
only environment that runs, so this was live.

## The fix

- **compose** — add the passthrough to the `fc` allowlist.
- **`.env.example`** — document it; it was not mentioned anywhere, so operators
  had no way to know it existed.
- **`env-manifest.test.js`** — drop the `KNOWN_GAPS` entry, per its own
  instructions.
- **`litellm.ts`** — unset now means **unlimited** (`null`), not `$1`. Spend
  control belongs at the upstream provider key, not in a default nobody chose.
  An unparseable value warns and is treated as unset rather than silently
  applying a cap the operator never wrote.
- **`s.yaml`** — default blanked to match compose. A default that differs per
  target is exactly how this went unnoticed.

## Verification

| Value | Returns | |
|---|---|---|
| unset | `null` | unlimited |
| `""` | `null` | unlimited |
| `"100"` | `100` | honoured |
| `"0"` | `0` | explicit hard stop, preserved |
| `"abc"` | `null` + warn | no silent cap |

- `node --test scripts/lib/env-manifest.test.js` → 8/8 pass with the gap entry
  removed, confirming the var is now properly declared.
- `tsc --noEmit` clean — the return type widened to `number | null` and the
  `/team/new` caller accepts it (LiteLLM reads null `max_budget` as no cap).

## Scope

Provisioning-time only. **Teams already created at `$1` keep that cap** until a
LiteLLM `/team/update` moves them — not addressed here, by decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)