### PR TITLE
fix(daemon): decrypt team env from the daemon's own secret store

### DIFF
--- a/apps/daemon/src/cli/mod.rs
+++ b/apps/daemon/src/cli/mod.rs
@@ -125,10 +125,14 @@ pub struct TeamArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum TeamAction {
-    /// Provision the sync credentials a headless daemon cannot obtain on its
-    /// own. `managed_git` needs nothing here — the daemon fetches that
-    /// credential from the cloud. `oss` and `custom_git` secrets are user-held
-    /// and have no server-side copy, so they must be supplied here.
+    /// Provision the secrets a headless daemon cannot obtain on its own.
+    ///
+    /// Two unrelated things live here. `--team-secret` decrypts the team's
+    /// shared env vars (`_secrets/`) and is needed under EVERY share mode; it
+    /// is user-held and has no server-side copy. `--git-credential` logs in to
+    /// a `custom_git` remote; `managed_git` needs no credential here because
+    /// the daemon fetches that one from the cloud — but it still needs
+    /// `--team-secret`.
     Secrets(TeamSecretsArgs),
 }
 
@@ -147,11 +151,13 @@ pub enum TeamSecretsAction {
         /// Team to write. Defaults to `team_id` from daemon.toml.
         #[arg(long)]
         team_id: Option<String>,
-        /// OSS team secret, 64 hex chars (`oss` share mode).
-        #[arg(long)]
-        oss_secret: Option<String>,
-        /// Git credential (`custom_git`): `user:token` when the team's auth
-        /// kind is https_token, or an SSH private key when it is ssh_key.
+        /// Team secret, 64 hex chars. Decrypts the team's shared env vars
+        /// under every share mode, and encrypts blobs under `oss`.
+        #[arg(long, alias = "oss-secret")]
+        team_secret: Option<String>,
+        /// Git credential for a `custom_git` remote: `user:token` when the
+        /// team's auth kind is https_token, or an SSH private key when it is
+        /// ssh_key. Not needed for `managed_git`.
         #[arg(long)]
         git_credential: Option<String>,
         /// Read the git credential from a file, e.g. an SSH private key.

--- a/apps/daemon/src/cli/team_secrets.rs
+++ b/apps/daemon/src/cli/team_secrets.rs
@@ -18,13 +18,13 @@ pub fn run(args: TeamArgs) -> anyhow::Result<()> {
     match secrets.action {
         TeamSecretsAction::Set {
             team_id,
-            oss_secret,
+            team_secret,
             git_credential,
             git_credential_file,
             git_branch,
         } => set(
             team_id,
-            oss_secret,
+            team_secret,
             git_credential,
             git_credential_file,
             git_branch,
@@ -62,14 +62,14 @@ fn resolve_team_id(explicit: Option<String>) -> anyhow::Result<String> {
         })
 }
 
-/// The OSS secret is HKDF input keying material, not an opaque token: it must
-/// decode to exactly 32 bytes or every blob fails to decrypt. Reject it here
-/// rather than at the next sync tick.
-fn validate_oss_secret(secret: &str) -> anyhow::Result<()> {
+/// The team secret is HKDF input keying material, not an opaque token: it must
+/// decode to exactly 32 bytes or every blob and env var fails to decrypt.
+/// Reject it here rather than at the next sync tick or agent spawn.
+fn validate_team_secret(secret: &str) -> anyhow::Result<()> {
     let ok = secret.len() == 64 && secret.chars().all(|c| c.is_ascii_hexdigit());
     if !ok {
         anyhow::bail!(
-            "--oss-secret must be 64 hex chars (32 bytes), got {} char(s)",
+            "--team-secret must be 64 hex chars (32 bytes), got {} char(s)",
             secret.len()
         );
     }
@@ -78,7 +78,7 @@ fn validate_oss_secret(secret: &str) -> anyhow::Result<()> {
 
 fn set(
     team_id: Option<String>,
-    oss_secret: Option<String>,
+    team_secret: Option<String>,
     git_credential: Option<String>,
     git_credential_file: Option<PathBuf>,
     git_branch: Option<String>,
@@ -98,19 +98,19 @@ fn set(
         (None, None) => None,
     };
 
-    let oss_secret = oss_secret.map(|s| s.trim().to_string());
-    if let Some(s) = &oss_secret {
-        validate_oss_secret(s)?;
+    let team_secret = team_secret.map(|s| s.trim().to_string());
+    if let Some(s) = &team_secret {
+        validate_team_secret(s)?;
     }
 
-    if oss_secret.is_none() && git_credential.is_none() && git_branch.is_none() {
+    if team_secret.is_none() && git_credential.is_none() && git_branch.is_none() {
         anyhow::bail!(
-            "nothing to set: pass --oss-secret, --git-credential/--git-credential-file, or --git-branch"
+            "nothing to set: pass --team-secret, --git-credential/--git-credential-file, or --git-branch"
         );
     }
 
     let incoming = TeamSecrets {
-        oss_team_secret: oss_secret,
+        oss_team_secret: team_secret,
         // The daemon self-supplies its own cloud bearer for OSS sync, so this
         // field is intentionally not settable here.
         user_jwt: None,
@@ -138,10 +138,10 @@ fn show(team_id: Option<String>) -> anyhow::Result<()> {
 
 fn print_state(store: &SecretStore, team_id: &str) -> anyhow::Result<()> {
     let s = store.load(team_id).map_err(|e| anyhow::anyhow!("{e}"))?;
-    println!("  oss_team_secret = {}", mask(s.oss_team_secret.as_deref()));
-    println!("  git_credential  = {}", mask(s.git_credential.as_deref()));
+    println!("  team_secret    = {}", mask(s.oss_team_secret.as_deref()));
+    println!("  git_credential = {}", mask(s.git_credential.as_deref()));
     println!(
-        "  git_branch      = {}",
+        "  git_branch     = {}",
         s.git_branch.as_deref().unwrap_or("(unset)")
     );
     Ok(())
@@ -182,13 +182,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn oss_secret_must_be_64_hex() {
-        assert!(validate_oss_secret(&"ab".repeat(32)).is_ok());
-        assert!(validate_oss_secret(&"AB".repeat(32)).is_ok());
+    fn team_secret_must_be_64_hex() {
+        assert!(validate_team_secret(&"ab".repeat(32)).is_ok());
+        assert!(validate_team_secret(&"AB".repeat(32)).is_ok());
         // Too short, and the length is what a user is most likely to get wrong.
-        assert!(validate_oss_secret("abcd").is_err());
+        assert!(validate_team_secret("abcd").is_err());
         // Right length, but 'z' is not hex — would fail at HKDF decode.
-        assert!(validate_oss_secret(&"z".repeat(64)).is_err());
+        assert!(validate_team_secret(&"z".repeat(64)).is_err());
     }
 
     #[test]

--- a/apps/daemon/src/sync/secret_store.rs
+++ b/apps/daemon/src/sync/secret_store.rs
@@ -16,6 +16,13 @@ use crate::sync::oss::crypto::{decrypt_blob, encrypt_blob};
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TeamSecrets {
+    /// The team secret, despite the OSS-flavoured name. It is not OSS-specific:
+    /// OSS sync uses it to encrypt blobs, and *every* share mode uses it to
+    /// derive the key for `_secrets/` team-env decryption (see
+    /// `team_shared_env::derive_key`). Read it via
+    /// [`SecretStore::team_secret`]. The name is load-bearing on the wire —
+    /// it matches the desktop's `ossTeamSecret` field in
+    /// `POST /v1/team/secrets` — so it stays put.
     #[serde(default)]
     pub oss_team_secret: Option<String>,
     #[serde(default)]
@@ -167,6 +174,18 @@ impl SecretStore {
     /// The stored git branch, if any.
     pub fn git_branch(&self, team_id: &str) -> Option<String> {
         self.load(team_id).ok().and_then(|s| s.git_branch)
+    }
+
+    /// The stored team secret, or `None` when unset/blank.
+    ///
+    /// This daemon's copy is the system of record: it is the only source a
+    /// standalone install can be handed one, whether by `amuxd team secrets set`
+    /// or by the desktop's `POST /v1/team/secrets`.
+    pub fn team_secret(&self, team_id: &str) -> Option<String> {
+        self.load(team_id)
+            .ok()
+            .and_then(|s| s.oss_team_secret)
+            .filter(|s| !s.trim().is_empty())
     }
 
     /// Resolve just the OSS team secret: store > config env_secret.

--- a/apps/daemon/src/team_shared_env.rs
+++ b/apps/daemon/src/team_shared_env.rs
@@ -188,6 +188,41 @@ pub fn load_team_env(
     load_team_env_from_secrets_dir(&secrets_dir, env_secret)
 }
 
+/// The team env decryption key: this daemon's own store first.
+///
+/// The secret is not tied to a share mode — `_secrets/` rides along in the
+/// shared dir under OSS *and* both git modes, so every mode needs it. It is
+/// also not the git credential: that one logs in to the remote, this one
+/// decrypts what the remote carries.
+///
+/// The daemon's store wins because it is the only source a standalone install
+/// can be handed one (`amuxd team secrets set`, or the desktop's
+/// `POST /v1/team/secrets`). The workspace `teamclaw.json` and the desktop's
+/// `_team_secret.{team_id}` blob remain as fallbacks so installs predating
+/// daemon-side custody keep decrypting untouched.
+fn resolve_env_secret(workspace_root: &Path, team_id: Option<&str>) -> Option<String> {
+    resolve_env_secret_with(
+        &crate::sync::secret_store::SecretStore::new(),
+        workspace_root,
+        team_id,
+    )
+}
+
+/// `resolve_env_secret` over an explicit store, so tests can exercise the
+/// precedence without reaching for the real `$HOME`.
+fn resolve_env_secret_with(
+    store: &crate::sync::secret_store::SecretStore,
+    workspace_root: &Path,
+    team_id: Option<&str>,
+) -> Option<String> {
+    if let Some(team_id) = team_id.filter(|id| !id.trim().is_empty()) {
+        if let Some(secret) = store.team_secret(team_id) {
+            return Some(secret);
+        }
+    }
+    teamclaw_runtime_env::env_catalog::resolve_team_env_secret(workspace_root, team_id)
+}
+
 /// Load decrypted team shared env for a workspace.
 ///
 /// Does not require `team.enabled` in `teamclaw.json`. Git-backed teams usually
@@ -198,13 +233,11 @@ pub fn load_team_env_for_workspace(
     team_id: Option<&str>,
 ) -> HashMap<String, String> {
     let shared_dir_name = read_team_json_shared_dir_name(workspace_root);
-    let Some(env_secret) =
-        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(workspace_root, team_id)
-    else {
+    let Some(env_secret) = resolve_env_secret(workspace_root, team_id) else {
         if team_id.is_some() {
             warn!(
                 workspace = %workspace_root.display(),
-                "team env secret missing (team.envSecret or _team_secret blob)"
+                "team env secret missing; set it with `amuxd team secrets set --team-secret <64-hex>`"
             );
         }
         return HashMap::new();
@@ -242,7 +275,86 @@ pub fn load_team_env_for_workspace(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sync::secret_store::{SecretStore, TeamSecrets};
     use aes_gcm::aead::Aead;
+
+    fn store_with_secret(base: &Path, team_id: &str, secret: &str) -> SecretStore {
+        let store = SecretStore::with_base(base.to_path_buf());
+        store
+            .merge(
+                team_id,
+                &TeamSecrets {
+                    oss_team_secret: Some(secret.to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        store
+    }
+
+    /// The standalone-daemon case: nothing in the workspace, no desktop blob —
+    /// only what `amuxd team secrets set` (or the desktop's push) left behind.
+    #[test]
+    fn env_secret_resolves_from_daemon_store_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let secret = "5a".repeat(32);
+        let store = store_with_secret(home.path(), "t-1", &secret);
+
+        let got = resolve_env_secret_with(&store, tmp.path(), Some("t-1"));
+        assert_eq!(got.as_deref(), Some(secret.as_str()));
+    }
+
+    /// The daemon's own copy is the system of record, so it outranks a stale
+    /// `team.envSecret` left in a workspace's teamclaw.json.
+    #[test]
+    fn daemon_store_wins_over_workspace_teamclaw_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let config_dir = tmp.path().join(".teamclaw");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("teamclaw.json"),
+            serde_json::json!({ "team": { "envSecret": "11".repeat(32) } }).to_string(),
+        )
+        .unwrap();
+        let store = store_with_secret(home.path(), "t-1", &"22".repeat(32));
+
+        let got = resolve_env_secret_with(&store, tmp.path(), Some("t-1"));
+        assert_eq!(got.as_deref(), Some("22".repeat(32).as_str()));
+    }
+
+    /// Compat: an install that predates daemon-side custody has an empty store
+    /// and must keep decrypting from teamclaw.json.
+    #[test]
+    fn falls_back_to_teamclaw_json_when_store_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let secret = "33".repeat(32);
+        let config_dir = tmp.path().join(".teamclaw");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("teamclaw.json"),
+            serde_json::json!({ "team": { "envSecret": secret } }).to_string(),
+        )
+        .unwrap();
+        let store = SecretStore::with_base(home.path().to_path_buf());
+
+        let got = resolve_env_secret_with(&store, tmp.path(), Some("t-1"));
+        assert_eq!(got.as_deref(), Some(secret.as_str()));
+    }
+
+    /// A team_id is required to key into the store; without one the store is
+    /// skipped rather than consulted with a blank key.
+    #[test]
+    fn blank_team_id_skips_the_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let store = store_with_secret(home.path(), "   ", &"44".repeat(32));
+
+        assert!(resolve_env_secret_with(&store, tmp.path(), Some("   ")).is_none());
+        assert!(resolve_env_secret_with(&store, tmp.path(), None).is_none());
+    }
 
     fn encrypted_secret_file(env_secret: &str, key_id: &str, key_value: &str) -> String {
         let key = derive_key(env_secret).unwrap();


### PR DESCRIPTION
## 问题

team secret 和 git 凭据是两件不同的事，这块代码一直把它们混为一谈：

- **git 凭据**（PAT / SSH key）—— 登录远端用的
- **team secret**（64-hex）—— 解密远端**内容**用的

`_secrets/`（团队环境变量）跟着共享目录一起同步，OSS 和两个 git 模式都有它，所以**每种 share mode 都需要 team secret**。`managed_git` 不需要凭据（daemon 自己从云端取），不等于它不需要 secret。

daemon 其实一直**收到**了这个 secret（桌面端三种模式都通过 `POST /v1/team/secrets` 推，`enable.rs:190/:277/:387`），也**存下来**了 —— 它只是从不读自己那份。

`load_team_env_for_workspace` 的解析只认两个来源：workspace 的 `.teamclaw/teamclaw.json` → `team.envSecret`，或者**桌面端**的 `~/.teamclaw/secrets/personal-secrets.json.enc` → `_team_secret.<team_id>`。独立安装的 daemon 两个都没有。结果：每次 agent 启动（`env_assembly.rs:24`、`server.rs:80`）都 `warn!("team env secret missing")`，然后拿一个空 env map 去跑。

## 改动

**daemon 自己的 store 成为 system of record**（`~/.amuxd/teams/<id>/secrets.enc`）—— 它是独立安装唯一可能被塞进 secret 的地方，无论通过 `amuxd team secrets set` 还是桌面端推送。

解析顺序：daemon store → `teamclaw.json` 的 `team.envSecret` → 桌面端 blob。后两者保留为 fallback，让早于 daemon 托管的存量安装继续正常解密 —— 原有那批 teamclaw.json 的测试一行未改全部通过，这是存量不受影响的证据。

CLI flag 从 `--oss-secret` 改名为 `--team-secret`，旧名保留为别名。旧名字在撒谎：这个值从来不是 OSS 专用的。存储字段 `oss_team_secret` 和 wire 上的 `ossTeamSecret` 保持不动 —— 那是跟桌面端的契约。

## 未改动

桌面端「把 secret 发给 daemon」这一步**已经是现状**，三种模式加 joiner 路径全都推，无需改造。

## 验证

- 771 个单测全绿，新增 4 个解析优先级测试，其中 `env_secret_resolves_from_daemon_store_alone` 正是独立安装场景（无 workspace 配置、无桌面 blob）
- CLI 新旧 flag 实跑验证

未做端到端实证：没有真起一个 daemon 跑 agent 去看环境变量注入。逻辑与单测覆盖到位，但真机验证欠缺。

## 已知遗留（本 PR 未处理）

桌面端推送 secret 给 daemon 失败是**静默**的（只记成 `clone_warning`，joiner 路径只 `eprintln!`）。现在 daemon 那份是 system of record，推送失败就等于团队环境变量全哑 —— 这个失败模式比以前更值得报出来。

🤖 Generated with [Claude Code](https://claude.com/claude-code)