### PR TITLE
fix(desktop): surface daemon secret-delivery failures to the user

### DIFF
--- a/apps/desktop/src/commands/team_share/enable.rs
+++ b/apps/desktop/src/commands/team_share/enable.rs
@@ -415,27 +415,31 @@ pub async fn team_share_enable_custom_git(
 
 // ─── set_team_secret ────────────────────────────────────────────────────
 
+/// Save the team secret and hand it to the daemon.
+///
+/// Returns `Some(warning)` when the local save succeeded but the daemon did
+/// not take delivery. That stays non-fatal — the local copy is the
+/// contractually-required outcome and the daemon's sweep catches up once
+/// reachable — but it is returned rather than logged: the daemon's own copy is
+/// the system of record for decrypting `_secrets/`, so until delivery lands
+/// the team's shared env vars are dead and only the user can retry.
 pub async fn set_team_secret_impl(
     team_id: String,
     secret_hex: String,
     workspace_path: String,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     let normalized = secret_hex.trim().to_ascii_lowercase();
     if normalized.len() != 64 || !normalized.chars().all(|c| c.is_ascii_hexdigit()) {
         return Err("team secret must be exactly 64 hex characters".to_string());
     }
     team_secret_store::save_team_secret(&workspace_path, &team_id, &normalized)?;
 
-    // A joiner sets the team secret here; deliver it to the daemon and link
-    // this workspace so the daemon can sync. Non-fatal: saving the local copy
-    // (above) is the contractually-required outcome, and the daemon's sweep
-    // will catch up once reachable.
-    if let Some(warning) =
-        deliver_secrets_and_link(&team_id, &workspace_path, Some(&normalized), None, None).await
-    {
-        eprintln!("team_share_set_team_secret: {warning}");
+    let warning =
+        deliver_secrets_and_link(&team_id, &workspace_path, Some(&normalized), None, None).await;
+    if let Some(w) = &warning {
+        info!("team_share_set_team_secret: {w}");
     }
-    Ok(())
+    Ok(warning)
 }
 
 #[tauri::command]
@@ -443,7 +447,7 @@ pub async fn team_share_set_team_secret(
     team_id: String,
     secret_hex: String,
     workspace_path: String,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     set_team_secret_impl(team_id, secret_hex, workspace_path).await
 }
 

--- a/packages/app/src/components/settings/team/EnableShareWizard.tsx
+++ b/packages/app/src/components/settings/team/EnableShareWizard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
 
 import {
   Dialog,
@@ -20,7 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { useTeamShareStore } from '@/stores/team-share'
+import { useTeamShareStore, type EnableShareResult } from '@/stores/team-share'
 import { humanizeFcError } from '@/lib/fc-error'
 import { resolveSecretHex } from './TeamSecretEntry'
 
@@ -88,12 +89,13 @@ export function EnableShareWizard({
     setError(null)
     try {
       const secret = await optionalTeamSecret()
+      let res: EnableShareResult
       if (mode === 'oss') {
-        await enableOss(teamId, workspacePath, secret)
+        res = await enableOss(teamId, workspacePath, secret)
       } else if (mode === 'managed_git') {
-        await enableManagedGit(teamId, workspacePath, secret)
+        res = await enableManagedGit(teamId, workspacePath, secret)
       } else {
-        await enableCustomGit(
+        res = await enableCustomGit(
           teamId,
           workspacePath,
           {
@@ -104,6 +106,16 @@ export function EnableShareWizard({
           },
           secret,
         )
+      }
+      // Share is on server-side, so the wizard is done and closes — but the
+      // daemon may not have taken the secret, which leaves shared env vars
+      // dead. Hold the toast open: this needs a retry, not a glance.
+      if (res.cloneWarning) {
+        toast.warning(t('settings.teamShare.daemonDeliveryFailed'), {
+          description: res.cloneWarning,
+          duration: Infinity,
+          closeButton: true,
+        })
       }
       onSuccess?.()
       reset()

--- a/packages/app/src/components/settings/team/TeamSecretEntry.tsx
+++ b/packages/app/src/components/settings/team/TeamSecretEntry.tsx
@@ -56,6 +56,9 @@ export function TeamSecretEntry({ teamId, workspacePath, onSaved, allowGenerate 
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [savedOk, setSavedOk] = useState(false)
+  // Saved locally, but the daemon never took delivery — shared env vars stay
+  // dead until this is retried, so it must not read as a plain success.
+  const [warning, setWarning] = useState<string | null>(null)
 
   // Seed the field with the currently-saved secret so re-entering the panel
   // shows the configured value instead of a blank box. Only prefill while the
@@ -84,10 +87,12 @@ export function TeamSecretEntry({ teamId, workspacePath, onSaved, allowGenerate 
     setSaving(true)
     setError(null)
     setSavedOk(false)
+    setWarning(null)
     try {
       const secretHex = await resolveSecretHex(trimmed)
-      await setSecret(teamId, secretHex, workspacePath)
-      setSavedOk(true)
+      const deliveryWarning = await setSecret(teamId, secretHex, workspacePath)
+      if (deliveryWarning) setWarning(deliveryWarning)
+      else setSavedOk(true)
       onSaved?.()
     } catch (e) {
       setError(String(e))
@@ -110,6 +115,7 @@ export function TeamSecretEntry({ teamId, workspacePath, onSaved, allowGenerate 
           setValue(e.target.value)
           setError(null)
           setSavedOk(false)
+          setWarning(null)
         }}
       />
       <div className="flex items-center gap-3">
@@ -125,6 +131,7 @@ export function TeamSecretEntry({ teamId, workspacePath, onSaved, allowGenerate 
               setValue(randomSecretHex())
               setError(null)
               setSavedOk(false)
+              setWarning(null)
             }}
             disabled={saving}
           >
@@ -138,6 +145,12 @@ export function TeamSecretEntry({ teamId, workspacePath, onSaved, allowGenerate 
       </div>
       <p className="text-[11.5px] text-muted-foreground">{t('settings.teamSecret.hint')}</p>
       {error && <p className="text-[12px] text-red-500">{error}</p>}
+      {warning && (
+        <p className="text-[12px] text-amber-600">
+          {t('settings.teamSecret.daemonDeliveryFailed')}
+          <span className="ml-1 text-muted-foreground">{warning}</span>
+        </p>
+      )}
     </div>
   )
 }

--- a/packages/app/src/components/settings/team/__tests__/TeamShareSection.test.tsx
+++ b/packages/app/src/components/settings/team/__tests__/TeamShareSection.test.tsx
@@ -291,4 +291,44 @@ describe('TeamSecretEntry', () => {
       expect(screen.getByText(/已保存/)).toBeTruthy()
     })
   })
+
+  it('surfaces a daemon delivery warning instead of reporting success', async () => {
+    // The command resolves (the local save worked) but hands back a warning:
+    // the daemon never took the secret, so shared env vars stay dead.
+    mockInvoke.mockImplementation(async (cmd: string) =>
+      cmd === 'team_share_set_team_secret' ? 'daemon secret delivery deferred: connection refused' : null,
+    )
+
+    render(<TeamSecretEntry teamId="team-1" workspacePath="/workspace" />)
+
+    const input = screen.getByLabelText(/团队密钥/)
+    fireEvent.change(input, { target: { value: 'ab'.repeat(32) } })
+    const saveBtn = screen.getByRole('button', { name: /保存/ }) as HTMLButtonElement
+    await waitFor(() => expect(saveBtn.disabled).toBe(false))
+    fireEvent.click(saveBtn)
+
+    await waitFor(() => {
+      expect(screen.getByText(/daemon 未接收/)).toBeTruthy()
+    })
+    // The whole point: this must not read as a clean save. Match the success
+    // string exactly — the warning copy itself opens with "已保存到本地".
+    expect(screen.queryByText('已保存。')).toBeNull()
+    expect(screen.getByText(/connection refused/)).toBeTruthy()
+  })
+
+  it('reports a clean save when the daemon takes delivery', async () => {
+    // `null` warning = delivered. Guards against the warning branch latching on.
+    mockInvoke.mockResolvedValue(null)
+
+    render(<TeamSecretEntry teamId="team-1" workspacePath="/workspace" />)
+
+    const input = screen.getByLabelText(/团队密钥/)
+    fireEvent.change(input, { target: { value: 'cd'.repeat(32) } })
+    const saveBtn = screen.getByRole('button', { name: /保存/ }) as HTMLButtonElement
+    await waitFor(() => expect(saveBtn.disabled).toBe(false))
+    fireEvent.click(saveBtn)
+
+    await waitFor(() => expect(screen.getByText(/已保存/)).toBeTruthy())
+    expect(screen.queryByText(/daemon 未接收/)).toBeNull()
+  })
 })

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -2525,6 +2525,7 @@
     },
     "teamShare": {
       "enableTitle": "Enable team sharing",
+      "daemonDeliveryFailed": "Team share is on, but the daemon didn't accept the secret",
       "enableDescription": "Choose a team sharing mode. It cannot be changed once enabled, so choose carefully.",
       "shareModeLegend": "Sharing mode",
       "modeOssDesc": "Use Alibaba Cloud OSS as the sharing backend (default)",
@@ -2582,6 +2583,7 @@
       "hint": "Use any passphrase you share with members, or click Generate for a random key.",
       "generate": "Generate",
       "savedOk": "Saved.",
+      "daemonDeliveryFailed": "Saved locally, but the daemon didn't accept it — shared env vars stay unavailable until you retry.",
       "updateSectionTitle": "Update team secret",
       "updateSectionDesc": "Members must use the same secret to decrypt shared environment variables."
     }

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -2525,6 +2525,7 @@
     },
     "teamShare": {
       "enableTitle": "开通团队共享",
+      "daemonDeliveryFailed": "团队共享已开启，但 daemon 未接收密钥",
       "enableDescription": "选择团队共享模式。开通后不可切换，请谨慎选择。",
       "shareModeLegend": "共享模式",
       "modeOssDesc": "使用阿里云 OSS 作为共享后端（默认）",
@@ -2582,6 +2583,7 @@
       "hint": "可使用与成员共享的任意口令，或点击「生成」得到随机密钥。",
       "generate": "生成",
       "savedOk": "已保存。",
+      "daemonDeliveryFailed": "已保存到本地，但 daemon 未接收 —— 在重试成功前，共享环境变量不可用。",
       "updateSectionTitle": "更新团队密钥",
       "updateSectionDesc": "成员需使用相同密钥才能解密共享环境变量。"
     }

--- a/packages/app/src/stores/team-share.ts
+++ b/packages/app/src/stores/team-share.ts
@@ -97,11 +97,17 @@ export interface TeamShareState {
     input: CustomGitInput,
     teamSecretHex?: string,
   ): Promise<EnableShareResult>
+  /**
+   * Save the team secret and deliver it to the daemon. Resolves to a warning
+   * string when the save succeeded but the daemon did not take delivery — the
+   * daemon's copy is what decrypts shared env vars, so until it lands they
+   * stay dead. `null` on full success.
+   */
   setSecret(
     teamId: string,
     secretHex: string,
     workspacePath: string,
-  ): Promise<void>
+  ): Promise<string | null>
   /** Read back the locally-stored team secret; `null` when none is saved. */
   getSecret(teamId: string, workspacePath: string): Promise<string | null>
   /** Local teardown + cloud share-mode reset → wizard can run again. */
@@ -216,11 +222,12 @@ export const useTeamShareStore = create<TeamShareState>((set, get) => ({
   },
 
   async setSecret(teamId, secretHex, workspacePath) {
-    await invoke<void>('team_share_set_team_secret', {
+    const warning = await invoke<string | null>('team_share_set_team_secret', {
       teamId,
       secretHex,
       workspacePath,
     })
+    return warning ?? null
   },
 
   async getSecret(teamId, workspacePath) {


### PR DESCRIPTION
## 问题

把 secret 交付给 daemon 失败是**故意**不致命的 —— 跑到那一步时 FC 的 share-mode POST 已经提交，daemon 临时不可达不该让整个 enable 失败。这个设计是对的。

但「非致命」变成了「不可见」：

- enable 路径返回 `clone_warning`，它自己的 doc comment 写着 *"Frontend should surface this so the user can retry"* —— 然而 UI 里没有任何地方渲染它。`EnableShareWizard` 直接丢弃返回值，然后 `onSuccess?.()` 关窗报成功。
- joiner 路径（`set_team_secret_impl`）只 `eprintln!`，warning 连前端都到不了。

这份沉默在 #508 之后变得更严重：daemon 自己那份 secret 现在是解密 `_secrets/` 的 system of record，交付不到就等于**团队共享环境变量全哑**，而且只有用户能重试。

## 改动

保持非致命，但让它可见：

- `set_team_secret_impl` 返回 warning 而不是打日志。`TeamSecretEntry` 内联黄字显示，并且**不给**绿色的「已保存」—— 这次保存没有达成用户要的结果，不该读起来像成功。
- `EnableShareWizard` 用 `duration: Infinity` 弹 toast。向导照常关闭（共享在服务端确实开了），但一个需要重试的失败不该按计时器自己消失。

i18n 中英文都加了。

## 验证

- TeamShareSection.test.tsx 新增 2 个用例：交付失败时显示 warning 且**不**显示成功、交付成功时正常显示成功。10 个用例全过。
- typecheck / eslint（0 error）/ `cargo clippy -D warnings` / `cargo fmt --check` 全过。

`pnpm test:unit` 里有 12 个失败，全部在 useAppInit / session-pins / SessionListColumn / daemon-version-upgrade —— 我 stash 掉改动在干净 main 上复现了同样的失败，属既有问题，与本 PR 无关。

未加测试：`EnableShareWizard` 的 toast 分支（该组件目前没有测试文件，没有现成 harness）。

## 顺带发现（本 PR 未处理）

`packages/app/src/locales/en.json` 和 `zh-CN.json` 存在**重复 key**（`mentionPopoverNoMatch`、`copyShareLink`、`shareLinkCopied`、`shareLinkCopyFailed`，以及重复的顶层 `session` 块）。任何用 `json.load`/`json.dump` 回写这些文件的工具都会静默吃掉前一份定义 —— 我用脚本加 key 时就踩到了，已改为纯文本编辑。建议单独修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)