### PR TITLE
chore: bump desktop version to 0.2.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "amuxd"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "aes-gcm",
  "agent-client-protocol",
@@ -10270,7 +10270,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaw"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.2.25"
+version = "0.2.26"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaw"
-version = "0.2.25"
+version = "0.2.26"
 description = "TeamClaw - AI Agent Desktop Platform"
 authors = ["TeamClaw Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClaw",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "identifier": "com.teamclaw.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclaw/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclaw",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "private": true,
   "description": "TeamClaw - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
为 copilot361 的 OSS 发布准备。

四个规范来源全部 0.2.25 → 0.2.26（`scripts/bump-desktop-version.mjs` 生成，未手工编辑），`Cargo.lock` 已同步：

- `package.json`
- `apps/desktop/Cargo.toml`
- `apps/desktop/tauri.conf.json`
- `apps/daemon/Cargo.toml`（打包的 amuxd sidecar）

`./scripts/verify-release-version-bump.sh 0.2.26` 通过。

> 注：`release-oss.yml` 会在构建时按 `tag` 输入调 `bump-desktop-version.mjs --allow-noop` 同步版本，所以严格来说不提这个 commit 也能发。提它是为了让仓库里写的版本和实际发布的一致——v0.2.25 当时就是一致的。

合并后 dispatch `release-oss.yml`，`brand=copilot361` + `tag=v0.2.26`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)