### PR TITLE
fix(desktop): pass runtime Cloud API URL into team-share commands

### DIFF
--- a/apps/desktop/src/commands/oss_sync/mod.rs
+++ b/apps/desktop/src/commands/oss_sync/mod.rs
@@ -53,6 +53,18 @@ pub(crate) fn get_fc_endpoint(_workspace_path: &str) -> String {
     default_fc_endpoint().trim_end_matches('/').to_string()
 }
 
+/// Normalize the Cloud API endpoint supplied by the renderer for a native
+/// command. Runtime server selection lives in the web renderer, so native
+/// commands must use this value instead of the URL baked into the binary.
+pub(crate) fn resolve_runtime_fc_endpoint(cloud_api_url: &str) -> Result<String, String> {
+    let parsed = url::Url::parse(cloud_api_url.trim())
+        .map_err(|_| "cloudApiUrl must be a valid http(s) URL".to_string())?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return Err("cloudApiUrl must be a valid http(s) URL".to_string());
+    }
+    Ok(cloud_api_url.trim().trim_end_matches('/').to_string())
+}
+
 /// The default Cloud API endpoint used when a workspace's `teamclaw.json` does
 /// not pin an explicit `fc_endpoint`.
 ///
@@ -131,5 +143,19 @@ mod fc_endpoint_tests {
             d.starts_with("https://"),
             "default endpoint must be https: {d}"
         );
+    }
+
+    #[test]
+    fn runtime_endpoint_uses_the_renderer_url_and_normalizes_a_trailing_slash() {
+        assert_eq!(
+            resolve_runtime_fc_endpoint("https://copilot.accounting.i.test.shopee.io/").unwrap(),
+            "https://copilot.accounting.i.test.shopee.io"
+        );
+    }
+
+    #[test]
+    fn runtime_endpoint_rejects_non_http_urls() {
+        assert!(resolve_runtime_fc_endpoint("file:///tmp/teamclaw").is_err());
+        assert!(resolve_runtime_fc_endpoint("not a url").is_err());
     }
 }

--- a/apps/desktop/src/commands/team_share/disconnect.rs
+++ b/apps/desktop/src/commands/team_share/disconnect.rs
@@ -14,7 +14,7 @@ use tauri::{State, WebviewWindow};
 use tracing::info;
 
 use crate::commands::oss_sync::fc_client::FcClient;
-use crate::commands::oss_sync::get_fc_endpoint;
+use crate::commands::oss_sync::resolve_runtime_fc_endpoint;
 use crate::commands::team::resolve_workspace_path;
 use crate::commands::team_share::custom_git;
 use crate::commands::team_share::enable::load_team_workspaces;
@@ -132,7 +132,12 @@ fn clear_workspace_team_local_config(workspace_path: &str, team_id: &str) -> Res
     Ok(())
 }
 
-async fn collect_workspace_paths(team_id: &str, primary: &str, access_token: &str) -> Vec<String> {
+async fn collect_workspace_paths(
+    team_id: &str,
+    primary: &str,
+    access_token: &str,
+    cloud_api_url: &str,
+) -> Vec<String> {
     let mut seen = HashSet::new();
     let mut out = Vec::new();
     fn push(p: &str, seen: &mut HashSet<String>, out: &mut Vec<String>) {
@@ -143,18 +148,22 @@ async fn collect_workspace_paths(team_id: &str, primary: &str, access_token: &st
         out.push(t.to_string());
     }
     push(primary, &mut seen, &mut out);
-    for w in load_team_workspaces(team_id, primary, access_token).await {
+    for w in load_team_workspaces(team_id, primary, access_token, cloud_api_url).await {
         push(&w.path, &mut seen, &mut out);
     }
     out
 }
 
 async fn disable_cloud_share_mode(
-    workspace_path: &str,
+    _workspace_path: &str,
     team_id: &str,
     access_token: &str,
+    cloud_api_url: &str,
 ) -> Result<(), String> {
-    let fc = FcClient::new(get_fc_endpoint(workspace_path), access_token.to_string());
+    let fc = FcClient::new(
+        resolve_runtime_fc_endpoint(cloud_api_url)?,
+        access_token.to_string(),
+    );
     let path = format!("/v1/teams/{team_id}/share-mode");
     fc.delete_json(&path).await.map_err(|e| e.to_string())?;
     Ok(())
@@ -166,6 +175,7 @@ pub async fn team_disconnect_repo(
     team_id: Option<String>,
     workspace_path: Option<String>,
     access_token: Option<String>,
+    cloud_api_url: String,
     window: WebviewWindow,
     registry: State<'_, crate::commands::window::WindowRegistry>,
 ) -> Result<serde_json::Value, String> {
@@ -184,9 +194,9 @@ pub async fn team_disconnect_repo(
         .filter(|s| !s.trim().is_empty())
         .ok_or_else(|| "accessToken is required to clear cloud team-share binding".to_string())?;
 
-    disable_cloud_share_mode(&workspace_path, &team_id, &token).await?;
+    disable_cloud_share_mode(&workspace_path, &team_id, &token, &cloud_api_url).await?;
 
-    let paths = collect_workspace_paths(&team_id, &workspace_path, &token).await;
+    let paths = collect_workspace_paths(&team_id, &workspace_path, &token, &cloud_api_url).await;
     for path in &paths {
         remove_workspace_team_repo_entry(path)?;
         remove_legacy_workspace_team_repo(path)?;

--- a/apps/desktop/src/commands/team_share/enable.rs
+++ b/apps/desktop/src/commands/team_share/enable.rs
@@ -20,7 +20,7 @@ use serde_json::json;
 
 use crate::commands::oss_sync::error::SyncError;
 use crate::commands::oss_sync::fc_client::FcClient;
-use crate::commands::oss_sync::get_fc_endpoint;
+use crate::commands::oss_sync::resolve_runtime_fc_endpoint;
 use crate::commands::team_share::custom_git;
 use crate::commands::team_sync_proxy;
 use crate::commands::{team_secret_store, TEAM_REPO_DIR};
@@ -135,12 +135,15 @@ fn ensure_team_repo_dir(_workspace_path: &str) -> Result<(), String> {
 }
 
 async fn post_share_mode(
-    workspace_path: &str,
+    cloud_api_url: &str,
     team_id: &str,
     body: &serde_json::Value,
     access_token: &str,
 ) -> Result<(), String> {
-    let fc = FcClient::new(get_fc_endpoint(workspace_path), access_token.to_string());
+    let fc = FcClient::new(
+        resolve_runtime_fc_endpoint(cloud_api_url)?,
+        access_token.to_string(),
+    );
     let path = format!("/v1/teams/{}/share-mode", team_id);
     // The /v1 share-mode endpoint returns 409 once a team's mode is locked.
     // FcClient::map_fc_response maps any 409 to SyncError::Conflict (its CAS
@@ -163,6 +166,7 @@ pub async fn enable_oss_impl(
     workspace_path: String,
     access_token: String,
     team_secret_hex: Option<String>,
+    cloud_api_url: String,
 ) -> Result<EnableShareResult, String> {
     // Lock the share mode on the server FIRST. If it is already locked (409),
     // post_share_mode returns a clear error and we bail out BEFORE mutating any
@@ -170,7 +174,7 @@ pub async fn enable_oss_impl(
     // break decryption of data already synced under the original secret.
     info!(team_id = %team_id, share_mode = "oss", "team_share_enable_oss: locking share-mode on FC");
     post_share_mode(
-        &workspace_path,
+        &cloud_api_url,
         &team_id,
         &json!({ "mode": "oss" }),
         &access_token,
@@ -202,8 +206,16 @@ pub async fn team_share_enable_oss(
     workspace_path: String,
     access_token: String,
     team_secret_hex: Option<String>,
+    cloud_api_url: String,
 ) -> Result<EnableShareResult, String> {
-    enable_oss_impl(team_id, workspace_path, access_token, team_secret_hex).await
+    enable_oss_impl(
+        team_id,
+        workspace_path,
+        access_token,
+        team_secret_hex,
+        cloud_api_url,
+    )
+    .await
 }
 
 // ─── enable_managed_git ──────────────────────────────────────────────────
@@ -213,11 +225,15 @@ pub async fn enable_managed_git_impl(
     workspace_path: String,
     access_token: String,
     team_secret_hex: Option<String>,
+    cloud_api_url: String,
 ) -> Result<EnableShareResult, String> {
     let secret = resolve_team_secret_hex(team_secret_hex)?;
     team_secret_store::save_team_secret(&workspace_path, &team_id, &secret)?;
 
-    let fc = FcClient::new(get_fc_endpoint(&workspace_path), access_token.clone());
+    let fc = FcClient::new(
+        resolve_runtime_fc_endpoint(&cloud_api_url)?,
+        access_token.clone(),
+    );
 
     // Provision the managed git repo via FC.
     let create_resp = fc
@@ -265,7 +281,7 @@ pub async fn enable_managed_git_impl(
         }
     });
     info!(team_id = %team_id, share_mode = "managed_git", remote_url = %repo_url, "team_share_enable_managed_git: locking share-mode on FC");
-    post_share_mode(&workspace_path, &team_id, &body, &access_token).await?;
+    post_share_mode(&cloud_api_url, &team_id, &body, &access_token).await?;
     info!(team_id = %team_id, share_mode = "managed_git", "team_share_enable_managed_git: share-mode locked");
 
     ensure_team_repo_dir(&workspace_path)?;
@@ -293,8 +309,16 @@ pub async fn team_share_enable_managed_git(
     workspace_path: String,
     access_token: String,
     team_secret_hex: Option<String>,
+    cloud_api_url: String,
 ) -> Result<EnableShareResult, String> {
-    enable_managed_git_impl(team_id, workspace_path, access_token, team_secret_hex).await
+    enable_managed_git_impl(
+        team_id,
+        workspace_path,
+        access_token,
+        team_secret_hex,
+        cloud_api_url,
+    )
+    .await
 }
 
 // ─── enable_custom_git ──────────────────────────────────────────────────
@@ -305,6 +329,7 @@ pub async fn enable_custom_git_impl(
     input: GitEnableInput,
     access_token: String,
     team_secret_hex: Option<String>,
+    cloud_api_url: String,
 ) -> Result<EnableShareResult, String> {
     if input.auth_kind != "ssh_key" && input.auth_kind != "https_token" {
         return Err(format!(
@@ -361,7 +386,7 @@ pub async fn enable_custom_git_impl(
         local_ssh = local_ssh,
         "team_share_enable_custom_git: locking share-mode on FC"
     );
-    post_share_mode(&workspace_path, &team_id, &body, &access_token).await?;
+    post_share_mode(&cloud_api_url, &team_id, &body, &access_token).await?;
     info!(team_id = %team_id, share_mode = "custom_git", "team_share_enable_custom_git: share-mode locked");
 
     ensure_team_repo_dir(&workspace_path)?;
@@ -402,6 +427,7 @@ pub async fn team_share_enable_custom_git(
     input: GitEnableInput,
     access_token: String,
     team_secret_hex: Option<String>,
+    cloud_api_url: String,
 ) -> Result<EnableShareResult, String> {
     enable_custom_git_impl(
         team_id,
@@ -409,6 +435,7 @@ pub async fn team_share_enable_custom_git(
         input,
         access_token,
         team_secret_hex,
+        cloud_api_url,
     )
     .await
 }
@@ -503,8 +530,9 @@ pub async fn get_share_status_impl(
     team_id: String,
     workspace_path: String,
     access_token: String,
+    cloud_api_url: String,
 ) -> Result<serde_json::Value, String> {
-    let fc = FcClient::new(get_fc_endpoint(&workspace_path), access_token);
+    let fc = FcClient::new(resolve_runtime_fc_endpoint(&cloud_api_url)?, access_token);
     let path = format!("/v1/teams/{}/share-mode", team_id);
     let mut value = fc.get_json(&path).await.map_err(|e| e.to_string())?;
     // Augment the server share-mode payload with local link + global-path info
@@ -527,8 +555,9 @@ pub async fn team_share_get_status(
     team_id: String,
     workspace_path: String,
     access_token: String,
+    cloud_api_url: String,
 ) -> Result<serde_json::Value, String> {
-    get_share_status_impl(team_id, workspace_path, access_token).await
+    get_share_status_impl(team_id, workspace_path, access_token, cloud_api_url).await
 }
 
 // ─── team_sync_paths ───────────────────────────────────────────────────────
@@ -619,13 +648,21 @@ fn filter_workspaces_present_on_disk(items: Vec<RegistryWorkspace>) -> Vec<Regis
 /// behavior's fail-open semantics for this settings-UI-only surface.
 pub(crate) async fn load_team_workspaces(
     team_id: &str,
-    workspace_path: &str,
+    _workspace_path: &str,
     access_token: &str,
+    cloud_api_url: &str,
 ) -> Vec<RegistryWorkspace> {
-    if team_id.trim().is_empty() || access_token.trim().is_empty() {
+    if team_id.trim().is_empty()
+        || access_token.trim().is_empty()
+        || cloud_api_url.trim().is_empty()
+    {
         return vec![];
     }
-    let fc = FcClient::new(get_fc_endpoint(workspace_path), access_token.to_string());
+    let endpoint = match resolve_runtime_fc_endpoint(cloud_api_url) {
+        Ok(endpoint) => endpoint,
+        Err(_) => return vec![],
+    };
+    let fc = FcClient::new(endpoint, access_token.to_string());
     let path = format!(
         "/v1/workspaces?teamId={}&limit=200",
         urlencoding::encode(team_id)
@@ -695,6 +732,7 @@ pub async fn team_sync_paths_impl(
     team_id: String,
     workspace_path: String,
     access_token: Option<String>,
+    cloud_api_url: Option<String>,
 ) -> TeamSyncPaths {
     let real_dir = global_team_dir_display(&team_id);
     let real_dir_exists = real_dir
@@ -718,15 +756,16 @@ pub async fn team_sync_paths_impl(
     // token; when the caller doesn't have one handy (best-effort settings-UI
     // surface), we still show the current workspace above and simply skip
     // the rest rather than failing the whole command.
-    let token = access_token.unwrap_or_default();
-    for w in load_team_workspaces(&team_id, &workspace_path, &token).await {
-        let is_current = canon_path(&w.path) == current_canon;
-        let name = if w.display_name.is_empty() {
-            basename_or(&w.path)
-        } else {
-            w.display_name.clone()
-        };
-        push_workspace_link(&mut links, &mut seen, &w.path, name, is_current);
+    if let (Some(token), Some(cloud_api_url)) = (access_token, cloud_api_url) {
+        for w in load_team_workspaces(&team_id, &workspace_path, &token, &cloud_api_url).await {
+            let is_current = canon_path(&w.path) == current_canon;
+            let name = if w.display_name.is_empty() {
+                basename_or(&w.path)
+            } else {
+                w.display_name.clone()
+            };
+            push_workspace_link(&mut links, &mut seen, &w.path, name, is_current);
+        }
     }
 
     TeamSyncPaths {
@@ -741,8 +780,9 @@ pub async fn team_sync_paths(
     team_id: String,
     workspace_path: String,
     access_token: Option<String>,
+    cloud_api_url: Option<String>,
 ) -> Result<TeamSyncPaths, String> {
-    Ok(team_sync_paths_impl(team_id, workspace_path, access_token).await)
+    Ok(team_sync_paths_impl(team_id, workspace_path, access_token, cloud_api_url).await)
 }
 
 #[cfg(test)]
@@ -817,8 +857,16 @@ mod link_status_tests {
     async fn load_team_workspaces_short_circuits_without_team_or_token() {
         // No network involved: empty team_id / access_token both bail before
         // any HTTP call is attempted, so this is safe to run in CI.
-        assert!(load_team_workspaces("", "/tmp", "token").await.is_empty());
-        assert!(load_team_workspaces("team-1", "/tmp", "").await.is_empty());
+        assert!(
+            load_team_workspaces("", "/tmp", "token", "https://example.test")
+                .await
+                .is_empty()
+        );
+        assert!(
+            load_team_workspaces("team-1", "/tmp", "", "https://example.test")
+                .await
+                .is_empty()
+        );
     }
 
     #[tokio::test]
@@ -827,7 +875,7 @@ mod link_status_tests {
         let ws_path = ws.path().to_str().unwrap().to_string();
         // No access token → the cloud fetch is skipped entirely (best-effort),
         // so this stays a pure local-disk test like the pre-refactor version.
-        let out = team_sync_paths_impl("team-xyz".into(), ws_path.clone(), None).await;
+        let out = team_sync_paths_impl("team-xyz".into(), ws_path.clone(), None, None).await;
 
         // Current workspace is always present and flagged, even when it isn't
         // team-bound in the cloud list yet. With no teamclaw-team entry on

--- a/apps/desktop/src/commands/team_share/join.rs
+++ b/apps/desktop/src/commands/team_share/join.rs
@@ -18,7 +18,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::commands::oss_sync::fc_client::FcClient;
-use crate::commands::oss_sync::get_fc_endpoint;
+use crate::commands::oss_sync::resolve_runtime_fc_endpoint;
 use crate::commands::team_sync_proxy;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -32,8 +32,9 @@ pub async fn team_share_join_existing_impl(
     team_id: String,
     workspace_path: String,
     access_token: String,
+    cloud_api_url: String,
 ) -> Result<JoinExistingResult, String> {
-    let fc = FcClient::new(get_fc_endpoint(&workspace_path), access_token);
+    let fc = FcClient::new(resolve_runtime_fc_endpoint(&cloud_api_url)?, access_token);
     let cfg: serde_json::Value = fc
         .get_json(&format!("/v1/teams/{}/workspace-config", team_id))
         .await
@@ -80,6 +81,7 @@ pub async fn team_share_join_existing(
     team_id: String,
     workspace_path: String,
     access_token: String,
+    cloud_api_url: String,
 ) -> Result<JoinExistingResult, String> {
-    team_share_join_existing_impl(team_id, workspace_path, access_token).await
+    team_share_join_existing_impl(team_id, workspace_path, access_token, cloud_api_url).await
 }

--- a/apps/desktop/src/commands/team_share/mod.rs
+++ b/apps/desktop/src/commands/team_share/mod.rs
@@ -34,7 +34,7 @@ pub use join::{team_share_join_existing, team_share_join_existing_impl, JoinExis
 use serde::{Deserialize, Serialize};
 
 use crate::commands::oss_sync::fc_client::FcClient;
-use crate::commands::oss_sync::get_fc_endpoint;
+use crate::commands::oss_sync::resolve_runtime_fc_endpoint;
 
 /// Result of the slim `team_share::create_team` Tauri command.
 ///
@@ -59,8 +59,9 @@ pub async fn team_share_create(
     name: String,
     workspace_path: String,
     access_token: String,
+    cloud_api_url: String,
 ) -> Result<CreateTeamResult, String> {
-    create_team(name, workspace_path, access_token).await
+    create_team(name, workspace_path, access_token, cloud_api_url).await
 }
 
 /// Library entry point (also called from integration tests).
@@ -69,10 +70,11 @@ pub async fn team_share_create(
 /// passed straight to `FcClient` instead of reading a stale cached token.
 pub async fn create_team(
     name: String,
-    workspace_path: String,
+    _workspace_path: String,
     access_token: String,
+    cloud_api_url: String,
 ) -> Result<CreateTeamResult, String> {
-    let fc = FcClient::new(get_fc_endpoint(&workspace_path), access_token);
+    let fc = FcClient::new(resolve_runtime_fc_endpoint(&cloud_api_url)?, access_token);
     let row = fc
         .create_team(&name, None)
         .await

--- a/apps/desktop/tests/team_share_smoke.rs
+++ b/apps/desktop/tests/team_share_smoke.rs
@@ -96,6 +96,7 @@ async fn create_team_slim_only_calls_v1_teams_and_returns_id_slug() {
         "alpha".to_string(),
         workspace.clone(),
         "test-jwt".to_string(),
+        server.uri(),
     )
     .await
     .expect("create_team should succeed");
@@ -157,6 +158,7 @@ async fn enable_oss_provisions_secret_and_local_dir() {
         workspace.clone(),
         "test-jwt".to_string(),
         None,
+        server.uri(),
     )
     .await
     .expect("enable_oss should succeed");
@@ -215,6 +217,7 @@ async fn enable_oss_uses_provided_team_secret() {
         workspace.clone(),
         "test-jwt".to_string(),
         Some(provided.to_uppercase()),
+        server.uri(),
     )
     .await
     .expect("enable_oss with provided secret should succeed");
@@ -294,6 +297,7 @@ async fn enable_custom_git_writes_git_config() {
         input,
         "test-jwt".to_string(),
         None,
+        server.uri(),
     )
     .await
     .expect("enable_custom_git should succeed");
@@ -332,6 +336,7 @@ async fn join_existing_writes_config_when_share_enabled() {
         "t1".to_string(),
         workspace.clone(),
         "test-jwt".to_string(),
+        server.uri(),
     )
     .await
     .expect("join should succeed");
@@ -380,6 +385,7 @@ async fn join_existing_noop_when_share_not_opened() {
         "t2".to_string(),
         workspace.clone(),
         "test-jwt".to_string(),
+        server.uri(),
     )
     .await
     .expect("join should succeed");

--- a/packages/app/src/components/onboarding/JoinTeamFlow.tsx
+++ b/packages/app/src/components/onboarding/JoinTeamFlow.tsx
@@ -6,6 +6,7 @@ import { Loader2 } from 'lucide-react'
 import { TeamSecretEntry } from '@/components/settings/team/TeamSecretEntry'
 import { linkDaemonTeamWorkspace } from '@/lib/daemon-local-client'
 import { getFreshAccessToken } from '@/lib/auth/session-store'
+import { getEffectiveServerConfigSync } from '@/lib/server-config'
 
 type Phase = 'loading' | 'not_opened' | 'initializing' | 'secret_prompt' | 'error'
 
@@ -49,10 +50,13 @@ export function JoinTeamFlow({ teamId, workspacePath, onDone }: Props) {
     ;(async () => {
       try {
         const accessToken = await getFreshAccessToken()
+        const cloudApiUrl = getEffectiveServerConfigSync().cloudApiUrl
+        if (!cloudApiUrl) throw new Error('Cloud API URL is not configured')
         const status = await invoke<StatusResponse>('team_share_get_status', {
           teamId,
           workspacePath,
           accessToken,
+          cloudApiUrl,
         })
         if (cancelled) return
         if (status?.mode == null) {
@@ -64,6 +68,7 @@ export function JoinTeamFlow({ teamId, workspacePath, onDone }: Props) {
           teamId,
           workspacePath,
           accessToken,
+          cloudApiUrl,
         })
         if (cancelled) return
         if (!res.initialized) {

--- a/packages/app/src/components/settings/team/TeamSyncPaths.tsx
+++ b/packages/app/src/components/settings/team/TeamSyncPaths.tsx
@@ -4,6 +4,7 @@ import { Copy, Check, FolderGit2, Link2 } from 'lucide-react'
 
 import { cn, isTauri, copyToClipboard } from '@/lib/utils'
 import { getFreshAccessToken } from '@/lib/auth/session-store'
+import { getEffectiveServerConfigSync } from '@/lib/server-config'
 
 /**
  * TeamSyncPaths — shows *where team content physically lives* and *every
@@ -107,10 +108,12 @@ export function TeamSyncPaths({
         // this needs an access token. If the token fetch fails we still show
         // the current workspace (the command tolerates a missing token).
         const accessToken = await getFreshAccessToken().catch(() => null)
+        const cloudApiUrl = getEffectiveServerConfigSync().cloudApiUrl ?? null
         const res = await invoke<TeamSyncPathsData>('team_sync_paths', {
           teamId: pathTeamId,
           workspacePath,
           accessToken,
+          cloudApiUrl,
         })
         if (!cancelled) setData(res)
       } catch {

--- a/packages/app/src/components/settings/team/__tests__/TeamShareSection.test.tsx
+++ b/packages/app/src/components/settings/team/__tests__/TeamShareSection.test.tsx
@@ -31,6 +31,10 @@ vi.mock('@/lib/auth/session-store', () => ({
   getFreshAccessToken: vi.fn(async () => 'test-token'),
 }))
 
+vi.mock('@/lib/server-config', () => ({
+  getEffectiveServerConfigSync: () => ({ cloudApiUrl: 'https://runtime.example.test' }),
+}))
+
 // ---------------------------------------------------------------------------
 // SUT — imported after mocks
 // ---------------------------------------------------------------------------
@@ -95,6 +99,7 @@ describe('TeamShareSection', () => {
       teamId: 'team-1',
       workspacePath: '/workspace',
       accessToken: 'test-token',
+      cloudApiUrl: 'https://runtime.example.test',
     })
   })
 
@@ -201,6 +206,7 @@ describe('TeamShareSection', () => {
         teamId: 'team-1',
         workspacePath: '/workspace',
         accessToken: 'test-token',
+        cloudApiUrl: 'https://runtime.example.test',
         teamSecretHex: null,
       })
     })

--- a/packages/app/src/components/team/CreateTeamDialog.tsx
+++ b/packages/app/src/components/team/CreateTeamDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { getFreshAccessToken } from '@/lib/auth/session-store'
+import { getEffectiveServerConfigSync } from '@/lib/server-config'
 import { Label } from '@/components/ui/label'
 
 export interface CreateTeamDialogResult {
@@ -56,10 +57,13 @@ export function CreateTeamDialog({
     setError(null)
     try {
       const accessToken = await getFreshAccessToken()
+      const cloudApiUrl = getEffectiveServerConfigSync().cloudApiUrl
+      if (!cloudApiUrl) throw new Error('Cloud API URL is not configured')
       const r = await invoke<CreateTeamDialogResult>('team_share_create', {
         name: trimmed,
         workspacePath,
         accessToken,
+        cloudApiUrl,
       })
       onCreated?.(r)
       setName('')

--- a/packages/app/src/components/team/__tests__/CreateTeamDialog.test.tsx
+++ b/packages/app/src/components/team/__tests__/CreateTeamDialog.test.tsx
@@ -17,6 +17,10 @@ vi.mock('@/lib/auth/session-store', () => ({
 
 import { CreateTeamDialog } from '../CreateTeamDialog'
 
+vi.mock('@/lib/server-config', () => ({
+  getEffectiveServerConfigSync: () => ({ cloudApiUrl: 'https://runtime.example.test' }),
+}))
+
 function Harness({
   onCreated,
 }: {
@@ -66,6 +70,7 @@ describe('CreateTeamDialog', () => {
         name: 'alpha',
         workspacePath: '/ws',
         accessToken: 'test-token',
+        cloudApiUrl: 'https://runtime.example.test',
       })
     })
     await waitFor(() => {

--- a/packages/app/src/stores/team-share.ts
+++ b/packages/app/src/stores/team-share.ts
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { isTauri } from '@/lib/utils'
 import { getFreshAccessToken } from '@/lib/auth/session-store'
 import { linkDaemonTeamWorkspace } from '@/lib/daemon-local-client'
+import { getEffectiveServerConfigSync } from '@/lib/server-config'
 
 // ---------------------------------------------------------------------------
 // Types — mirror FC GET /v1/teams/:id/share-mode response (camelCase JSON)
@@ -121,6 +122,12 @@ const EMPTY_STATUS: ShareStatus = {
   enabledAt: null,
 }
 
+function getCloudApiUrlForNativeCommand(): string {
+  const cloudApiUrl = getEffectiveServerConfigSync().cloudApiUrl
+  if (!cloudApiUrl) throw new Error('Cloud API URL is not configured')
+  return cloudApiUrl
+}
+
 /** Coalesce concurrent refresh calls for the same team + workspace. */
 let shareRefreshInflight: Promise<ShareStatus> | null = null
 let shareRefreshInflightKey: string | null = null
@@ -145,10 +152,12 @@ export const useTeamShareStore = create<TeamShareState>((set, get) => ({
       set({ loading: true, lastError: null })
       try {
         const accessToken = await getFreshAccessToken()
+        const cloudApiUrl = getCloudApiUrlForNativeCommand()
         const raw = await invoke<ShareStatus>('team_share_get_status', {
           teamId,
           workspacePath,
           accessToken,
+          cloudApiUrl,
         })
         const next = normalizeShareStatus({
           mode: (raw?.mode ?? null) as ShareMode,
@@ -175,10 +184,12 @@ export const useTeamShareStore = create<TeamShareState>((set, get) => ({
 
   async enableOss(teamId, workspacePath, teamSecretHex) {
     const accessToken = await getFreshAccessToken()
+    const cloudApiUrl = getCloudApiUrlForNativeCommand()
     const res = await invoke<EnableShareResult>('team_share_enable_oss', {
       teamId,
       workspacePath,
       accessToken,
+      cloudApiUrl,
       teamSecretHex: teamSecretHex?.trim() || null,
     })
     // Materialize the daemon's global dir + workspace symlink now (best-effort)
@@ -190,12 +201,14 @@ export const useTeamShareStore = create<TeamShareState>((set, get) => ({
 
   async enableManagedGit(teamId, workspacePath, teamSecretHex) {
     const accessToken = await getFreshAccessToken()
+    const cloudApiUrl = getCloudApiUrlForNativeCommand()
     const res = await invoke<EnableShareResult>(
       'team_share_enable_managed_git',
       {
         teamId,
         workspacePath,
         accessToken,
+        cloudApiUrl,
         teamSecretHex: teamSecretHex?.trim() || null,
       },
     )
@@ -206,6 +219,7 @@ export const useTeamShareStore = create<TeamShareState>((set, get) => ({
 
   async enableCustomGit(teamId, workspacePath, input, teamSecretHex) {
     const accessToken = await getFreshAccessToken()
+    const cloudApiUrl = getCloudApiUrlForNativeCommand()
     const res = await invoke<EnableShareResult>(
       'team_share_enable_custom_git',
       {
@@ -213,6 +227,7 @@ export const useTeamShareStore = create<TeamShareState>((set, get) => ({
         workspacePath,
         input,
         accessToken,
+        cloudApiUrl,
         teamSecretHex: teamSecretHex?.trim() || null,
       },
     )
@@ -248,10 +263,12 @@ export const useTeamShareStore = create<TeamShareState>((set, get) => ({
       throw new Error('Team share disconnect requires the desktop app')
     }
     const accessToken = await getFreshAccessToken()
+    const cloudApiUrl = getCloudApiUrlForNativeCommand()
     await invoke<{ success: boolean; message: string }>('team_disconnect_repo', {
       teamId,
       workspacePath,
       accessToken,
+      cloudApiUrl,
     })
     set({ status: { ...EMPTY_STATUS }, lastError: null })
     try {


### PR DESCRIPTION
## Summary
- Thread `cloudApiUrl` from the renderer's `getEffectiveServerConfigSync()` into all native team-share Tauri commands (create, enable, join, disconnect, sync paths, status).
- Add `resolve_runtime_fc_endpoint()` to validate the runtime URL before constructing `FcClient`, so custom server selection (#504) applies to team-share flows instead of the compile-time `CLOUD_API_URL` baked into the binary.

## Test plan
- [x] `cargo test --manifest-path apps/desktop/Cargo.toml --test team_share_smoke`
- [x] `vitest run` for `TeamShareSection.test.tsx` and `CreateTeamDialog.test.tsx`
- [ ] Desktop: pick a custom Cloud API server in onboarding, then create/enable/join a team — confirm FC calls hit the selected host (not the default build config URL)


Made with [Cursor](https://cursor.com)