### PR TITLE
fix: unblock agent removal and harden daemon identity rebinding

### DIFF
--- a/apps/daemon/src/backend/cloud_api/messages.rs
+++ b/apps/daemon/src/backend/cloud_api/messages.rs
@@ -202,6 +202,7 @@ impl CloudApiBackend {
         metadata_json: &str,
         model: &str,
         turn_id: &str,
+        reply_to_message_id: &str,
         sequence: u64,
     ) -> BackendResult<()> {
         let metadata = serde_json::from_str(metadata_json).unwrap_or(Value::Null);
@@ -224,7 +225,7 @@ impl CloudApiBackend {
                     kind,
                     metadata,
                     turn_id: empty_to_none(turn_id),
-                    reply_to_message_id: None,
+                    reply_to_message_id: empty_to_none(reply_to_message_id),
                     model: empty_to_none(model),
                     created_at: None,
                 },

--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -302,12 +302,43 @@ impl CloudApiBackend {
         let Some(path) = self.persist_path.as_ref() else {
             return;
         };
-        let cfg = CloudApiConfig {
-            url: self.cfg.url.clone(),
-            refresh_token: refresh_token.to_string(),
-            team_id: self.cfg.team_id.clone(),
-            actor_id: self.cfg.actor_id.clone(),
+        // Never recreate a file removed by `amuxd clear`, and never let a
+        // still-running stale process overwrite credentials written by a later
+        // `amuxd init`. Only the process whose routing identity still matches
+        // the current file is allowed to rotate that file's token.
+        if !path.exists() {
+            tracing::warn!(
+                path = %path.display(),
+                "skipping rotated refresh_token persistence because backend.toml was removed"
+            );
+            return;
+        }
+        let mut cfg = match crate::provider_config::ProviderConfig::load_from_path(path) {
+            Ok(crate::provider_config::ProviderConfig::CloudApi(cfg)) => cfg,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "skipping rotated refresh_token persistence because backend.toml is unreadable"
+                );
+                return;
+            }
         };
+        if cfg.url != self.cfg.url
+            || cfg.team_id != self.cfg.team_id
+            || cfg.actor_id != self.cfg.actor_id
+        {
+            tracing::warn!(
+                path = %path.display(),
+                running_team_id = %self.cfg.team_id,
+                running_actor_id = %self.cfg.actor_id,
+                disk_team_id = %cfg.team_id,
+                disk_actor_id = %cfg.actor_id,
+                "skipping rotated refresh_token persistence because daemon identity was rebound"
+            );
+            return;
+        }
+        cfg.refresh_token = refresh_token.to_string();
         if let Err(e) = crate::provider_config::ProviderConfig::save_cloud_api(path, &cfg) {
             tracing::warn!(
                 error = %e,
@@ -1329,6 +1360,7 @@ impl CloudAgentRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider_config::ProviderConfig;
 
     #[test]
     fn bootstrap_mqtt_prefers_canonical_ws_url_over_tcp_url() {
@@ -1508,7 +1540,10 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let backend_path = dir.path().join("backend.toml");
-        let backend = CloudApiBackend::with_persist_path(config(&server), backend_path.clone());
+        let initial_config = config(&server);
+        ProviderConfig::save_cloud_api(&backend_path, &initial_config).unwrap();
+        let backend =
+            CloudApiBackend::with_persist_path(initial_config, backend_path.clone());
 
         assert_eq!(backend.access_token().await.unwrap(), "at-1");
 
@@ -1522,6 +1557,35 @@ mod tests {
         // Next call (cache expired) must refresh using the rotated token.
         assert_eq!(backend.access_token().await.unwrap(), "at-2");
         // wiremock `.expect(1)` on both mocks is verified on server drop.
+    }
+
+    #[tokio::test]
+    async fn stale_backend_does_not_overwrite_rebound_identity_when_token_rotates() {
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let backend_path = dir.path().join("backend.toml");
+        let old_config = config(&server);
+        ProviderConfig::save_cloud_api(&backend_path, &old_config).unwrap();
+
+        // The running backend captures the old identity. A later `amuxd init`
+        // replaces the file with a newly bound actor before the old process
+        // refreshes its token.
+        let backend = CloudApiBackend::with_persist_path(old_config, backend_path.clone());
+        let rebound = CloudApiConfig {
+            url: server.uri(),
+            refresh_token: "new-binding-refresh".to_string(),
+            team_id: "team-2".to_string(),
+            actor_id: "agent-2".to_string(),
+        };
+        ProviderConfig::save_cloud_api(&backend_path, &rebound).unwrap();
+        let expected = std::fs::read_to_string(&backend_path).unwrap();
+
+        assert_eq!(backend.access_token().await.unwrap(), "access-token");
+
+        let actual = std::fs::read_to_string(&backend_path).unwrap();
+        assert_eq!(actual, expected, "stale daemon must not restore its old identity");
     }
 
     #[tokio::test]

--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -1316,6 +1316,7 @@ impl Backend for CloudApiBackend {
         metadata_json: &str,
         model: &str,
         turn_id: &str,
+        reply_to_message_id: &str,
         sequence: u64,
     ) -> BackendResult<()> {
         self.insert_message_impl(
@@ -1328,6 +1329,7 @@ impl Backend for CloudApiBackend {
             metadata_json,
             model,
             turn_id,
+            reply_to_message_id,
             sequence,
         )
         .await

--- a/apps/daemon/src/backend/deferred.rs
+++ b/apps/daemon/src/backend/deferred.rs
@@ -420,6 +420,7 @@ impl Backend for DeferredBackend {
         metadata_json: &str,
         model: &str,
         turn_id: &str,
+        reply_to_message_id: &str,
         sequence: u64,
     ) -> BackendResult<()> {
         self.inner()?
@@ -433,6 +434,7 @@ impl Backend for DeferredBackend {
                 metadata_json,
                 model,
                 turn_id,
+                reply_to_message_id,
                 sequence,
             )
             .await

--- a/apps/daemon/src/backend/mock.rs
+++ b/apps/daemon/src/backend/mock.rs
@@ -70,6 +70,7 @@ pub struct RecordedMessageInsert {
     pub metadata_json: String,
     pub model: String,
     pub turn_id: String,
+    pub reply_to_message_id: String,
     pub sequence: u64,
 }
 
@@ -660,6 +661,7 @@ impl Backend for MockBackend {
         metadata_json: &str,
         model: &str,
         turn_id: &str,
+        reply_to_message_id: &str,
         sequence: u64,
     ) -> BackendResult<()> {
         self.state
@@ -676,6 +678,7 @@ impl Backend for MockBackend {
                 metadata_json: metadata_json.to_string(),
                 model: model.to_string(),
                 turn_id: turn_id.to_string(),
+                reply_to_message_id: reply_to_message_id.to_string(),
                 sequence,
             });
         Ok(())
@@ -841,12 +844,12 @@ mod tests {
     async fn insert_message_records_each_call_with_metadata() {
         let (be, state) = dyn_backend();
         be.insert_message(
-            "msg-1", "team-x", "sess-1", "actor-y", "text", "hi", "{}", "model-z", "turn-1", 42,
+            "msg-1", "team-x", "sess-1", "actor-y", "text", "hi", "{}", "model-z", "turn-1", "user-1", 42,
         )
         .await
         .unwrap();
         be.insert_message(
-            "msg-2", "team-x", "sess-1", "actor-y", "text", "again", "{}", "", "", 43,
+            "msg-2", "team-x", "sess-1", "actor-y", "text", "again", "{}", "", "", "", 43,
         )
         .await
         .unwrap();
@@ -855,10 +858,12 @@ mod tests {
         assert_eq!(snap.messages_inserted[0].id, "msg-1");
         assert_eq!(snap.messages_inserted[0].content, "hi");
         assert_eq!(snap.messages_inserted[0].model, "model-z");
+        assert_eq!(snap.messages_inserted[0].reply_to_message_id, "user-1");
         assert_eq!(snap.messages_inserted[0].sequence, 42);
         assert_eq!(snap.messages_inserted[1].id, "msg-2");
         assert_eq!(snap.messages_inserted[1].content, "again");
         assert!(snap.messages_inserted[1].model.is_empty());
+        assert!(snap.messages_inserted[1].reply_to_message_id.is_empty());
     }
 
     #[tokio::test]

--- a/apps/daemon/src/backend/mod.rs
+++ b/apps/daemon/src/backend/mod.rs
@@ -440,6 +440,7 @@ pub trait Backend: Send + Sync {
         metadata_json: &str,
         model: &str,
         turn_id: &str,
+        reply_to_message_id: &str,
         sequence: u64,
     ) -> BackendResult<()>;
 }

--- a/apps/daemon/src/channels/acp_handle.rs
+++ b/apps/daemon/src/channels/acp_handle.rs
@@ -441,7 +441,7 @@ impl AmuxdAcpHandle {
             let (turn, _again) = mgr
                 .checkout_turn_for_acp(&outcome.real_acp_sid)
                 .map_err(|e| AcpError::Send(e.to_string()))?;
-            mgr.send_prompt_raw(&turn.agent_id, &prompt, vec![], None)
+            mgr.send_prompt_raw(&turn.agent_id, &prompt, vec![], None, None)
                 .await
                 .map_err(|e| AcpError::Send(e.to_string()))?;
             (turn.agent_id, turn.event_rx)

--- a/apps/daemon/src/channels/acp_handle.rs
+++ b/apps/daemon/src/channels/acp_handle.rs
@@ -441,7 +441,7 @@ impl AmuxdAcpHandle {
             let (turn, _again) = mgr
                 .checkout_turn_for_acp(&outcome.real_acp_sid)
                 .map_err(|e| AcpError::Send(e.to_string()))?;
-            mgr.send_prompt_raw(&turn.agent_id, &prompt, vec![])
+            mgr.send_prompt_raw(&turn.agent_id, &prompt, vec![], None)
                 .await
                 .map_err(|e| AcpError::Send(e.to_string()))?;
             (turn.agent_id, turn.event_rx)

--- a/apps/daemon/src/cli/clear.rs
+++ b/apps/daemon/src/cli/clear.rs
@@ -2,18 +2,31 @@ use crate::config::DaemonConfig;
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Wipe every file the daemon writes to its config dir. Keeps the directory
 /// itself in place.
 pub fn run(force: bool) -> anyhow::Result<()> {
     let config_dir = DaemonConfig::config_dir();
-    let paths = candidate_paths();
+    run_at(force, &DaemonConfig::lock_path(), candidate_paths())
+        .map_err(|e| anyhow::anyhow!("cannot clear {}: {e}", config_dir.display()))
+}
+
+fn run_at(force: bool, lock_path: &std::path::Path, paths: Vec<PathBuf>) -> anyhow::Result<()> {
     let existing: Vec<_> = paths.into_iter().filter(|p| p.exists()).collect();
 
     if existing.is_empty() {
-        println!("Nothing to clear under {}.", config_dir.display());
+        println!("Nothing to clear.");
         return Ok(());
     }
+
+    // Deleting identity files while a daemon is alive is unsafe: that process
+    // still owns the old credentials in memory and can recreate backend.toml
+    // on its next refresh-token rotation. Only take the lock once there is
+    // something to remove — otherwise a no-op clear would fail with "already
+    // running" whenever amuxd is up.
+    let _daemon_lock =
+        crate::cli::process::acquire_daemon_lock_at(lock_path, Duration::ZERO)?;
 
     // Paths are printed in full: they can span the config dir AND the legacy dir.
     println!("Will remove {} file(s):", existing.len());
@@ -126,5 +139,44 @@ mod tests {
             paths.len(),
             "candidate_paths must not list a path twice"
         );
+    }
+
+    #[test]
+    fn clear_refuses_to_delete_config_while_daemon_lock_is_held() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("amuxd.lock");
+        let config_path = dir.path().join("backend.toml");
+        std::fs::write(&config_path, "new identity").unwrap();
+
+        let held_lock = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .unwrap();
+        held_lock.lock().unwrap();
+
+        let error = run_at(true, &lock_path, vec![config_path.clone()]).unwrap_err();
+
+        assert!(error.to_string().contains("already running"));
+        assert_eq!(std::fs::read_to_string(config_path).unwrap(), "new identity");
+    }
+
+    #[test]
+    fn clear_noop_succeeds_even_when_daemon_lock_is_held() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("amuxd.lock");
+
+        let held_lock = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .unwrap();
+        held_lock.lock().unwrap();
+
+        run_at(true, &lock_path, vec![dir.path().join("missing.toml")]).unwrap();
     }
 }

--- a/apps/daemon/src/cli/process.rs
+++ b/apps/daemon/src/cli/process.rs
@@ -66,7 +66,10 @@ pub fn acquire_daemon_lock() -> anyhow::Result<DaemonLockGuard> {
     acquire_daemon_lock_at(&DaemonConfig::lock_path(), LOCK_WAIT)
 }
 
-fn acquire_daemon_lock_at(path: &Path, wait: Duration) -> anyhow::Result<DaemonLockGuard> {
+pub(crate) fn acquire_daemon_lock_at(
+    path: &Path,
+    wait: Duration,
+) -> anyhow::Result<DaemonLockGuard> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -439,26 +439,25 @@ impl crate::http::setup::OnboardingService for DaemonOnboarding {
     }
 }
 
-/// Warn when `daemon.toml` and `backend.toml` disagree on routing identity.
+/// Reject `daemon.toml` and `backend.toml` when they disagree on routing identity.
 /// Auth always uses `backend.toml`; MQTT topics and session routing use
-/// `daemon.toml` `[actor].id` — a mismatch breaks collab even if tokens work.
-fn warn_config_identity_mismatch(config: &DaemonConfig, backend: &Arc<dyn Backend>) {
-    if let Some(team_id) = config.team_id.as_deref() {
-        if team_id != backend.team_id() {
-            warn!(
-                daemon_team_id = %team_id,
-                backend_team_id = %backend.team_id(),
-                "daemon.toml team_id does not match backend.toml; run `amuxd init` to re-onboard"
-            );
-        }
+/// `daemon.toml` `[actor].id` — continuing with a mismatch authenticates as one
+/// actor while publishing presence and commands under another actor's topics.
+fn validate_config_identity(
+    config: &DaemonConfig,
+    backend: &dyn Backend,
+) -> crate::error::Result<()> {
+    let daemon_team_id = config.team_id.as_deref().unwrap_or("<none>");
+    if daemon_team_id != backend.team_id() || config.actor.id != backend.actor_id() {
+        return Err(crate::error::AmuxError::Config(format!(
+            "daemon/backend identity mismatch: daemon.toml team_id={daemon_team_id}, actor_id={}; \
+             backend.toml team_id={}, actor_id={}. Stop amuxd and run `amuxd init` to re-onboard",
+            config.actor.id,
+            backend.team_id(),
+            backend.actor_id(),
+        )));
     }
-    if config.actor.id != backend.actor_id() {
-        warn!(
-            daemon_actor_id = %config.actor.id,
-            backend_actor_id = %backend.actor_id(),
-            "daemon.toml [actor].id does not match backend.toml actor_id; run `amuxd init` to re-onboard"
-        );
-    }
+    Ok(())
 }
 
 /// Best-effort first access token. Failure must not block startup — `run()`
@@ -517,7 +516,7 @@ impl DaemonServer {
         // daemon reports an empty actor_id, which is not a mismatch worth
         // warning about.
         if deferred_backend.is_claimed() {
-            warn_config_identity_mismatch(&config, &backend);
+            validate_config_identity(&config, backend.as_ref())?;
         }
 
         // Best-effort token — `run()`'s outer loop retries before MQTT connect.
@@ -2762,6 +2761,21 @@ pub(crate) mod tests {
 
         assert_eq!(backend.team_id(), "team-test");
         assert_eq!(backend.actor_id(), "agent-actor");
+    }
+
+    #[test]
+    fn config_identity_validation_rejects_split_team_and_actor() {
+        let mut config = test_config();
+        config.team_id = Some("team-config-test".to_string());
+        let backend = test_cloud_api();
+
+        let error = validate_config_identity(&config, backend.as_ref()).unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("daemon.toml team_id=team-config-test"), "{message}");
+        assert!(message.contains("backend.toml team_id=team-test"), "{message}");
+        assert!(message.contains("actor_id=actor-config-test"), "{message}");
+        assert!(message.contains("actor_id=agent-actor"), "{message}");
     }
 
     #[test]

--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -309,7 +309,7 @@ impl DaemonServer {
             let (turn, _again) = mgr
                 .checkout_turn_for_acp(acp_sid)
                 .map_err(|e| anyhow::anyhow!("checkout_turn_for_acp: {e}"))?;
-            mgr.send_prompt_raw(&turn.agent_id, prompt, vec![])
+            mgr.send_prompt_raw(&turn.agent_id, prompt, vec![], None)
                 .await
                 .map_err(|e| anyhow::anyhow!("send_prompt_raw: {e}"))?;
             (turn.agent_id, turn.event_rx)

--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -185,7 +185,7 @@ impl DaemonServer {
                 if !reply.content.is_empty() {
                     if let Some(tc) = self.teamclaw.as_ref() {
                         let actor_id = self.actor_id.clone();
-                        let (model, seq) = {
+                        let (model, seq, reply_to) = {
                             let mut mgr = self.agents.lock().await;
                             let agent_id =
                                 mgr.agent_id_by_acp_session(&acp_sid).unwrap_or_default();
@@ -194,7 +194,11 @@ impl DaemonServer {
                                 .get_handle_mut(&agent_id)
                                 .map(|h| h.next_sequence())
                                 .unwrap_or(0);
-                            (model, seq)
+                            let reply_to = mgr
+                                .get_handle(&agent_id)
+                                .and_then(|h| h.pending_reply_to_message_id.clone())
+                                .unwrap_or_default();
+                            (model, seq, reply_to)
                         };
                         tc.emit_agent_message(
                             &remote_session_id,
@@ -204,6 +208,7 @@ impl DaemonServer {
                             &reply.metadata_json,
                             &model,
                             &reply.turn_id,
+                            &reply_to,
                             seq,
                             true,
                             Some(&self.backend),
@@ -309,7 +314,7 @@ impl DaemonServer {
             let (turn, _again) = mgr
                 .checkout_turn_for_acp(acp_sid)
                 .map_err(|e| anyhow::anyhow!("checkout_turn_for_acp: {e}"))?;
-            mgr.send_prompt_raw(&turn.agent_id, prompt, vec![], None)
+            mgr.send_prompt_raw(&turn.agent_id, prompt, vec![], None, None)
                 .await
                 .map_err(|e| anyhow::anyhow!("send_prompt_raw: {e}"))?;
             (turn.agent_id, turn.event_rx)

--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -115,6 +115,17 @@ impl DaemonServer {
 
     pub(crate) async fn forward_agent_event(&mut self, agent_id: &str, frame: AcpEventFrame) {
         let acp_session_id = frame.acp_session_id.clone();
+        // Sync turn-scoped reply_to from the prompt worker (bound at dequeue).
+        if let Some(reply_to) = frame
+            .turn_reply_to_message_id
+            .as_deref()
+            .filter(|id| !id.is_empty())
+        {
+            let mut agents = self.agents.lock().await;
+            if let Some(handle) = agents.get_handle_mut(agent_id) {
+                handle.pending_reply_to_message_id = Some(reply_to.to_string());
+            }
+        }
         let is_child_event = {
             let agents = self.agents.lock().await;
             agents
@@ -336,28 +347,33 @@ impl DaemonServer {
         // emitted messages (cloud `messages.sequence`). The envelope
         // append below uses the same value, keeping a 1:1 link between an
         // ACP event boundary and the messages that flowed from it.
-        let (emitted, turn_id, seq) = {
+        let (emitted, turn_id, seq, reply_to_message_id, clear_reply_to) = {
             let mut agents = self.agents.lock().await;
             let seq = agents
                 .get_handle_mut(agent_id)
                 .map(|h| h.next_sequence())
                 .unwrap_or(0);
+            let reply_to_message_id = agents
+                .get_handle(agent_id)
+                .and_then(|h| h.pending_reply_to_message_id.clone())
+                .unwrap_or_default();
+            let clear_reply_to = matches!(
+                acp_event.event.as_ref(),
+                Some(amux::acp_event::Event::StatusChange(sc))
+                    if sc.old_status == amux::AgentStatus::Active as i32
+                        && sc.new_status == amux::AgentStatus::Idle as i32
+            );
             match agents.aggregator_mut(agent_id) {
                 Some(agg) if !is_child_event => {
-                    // ingest may transition Active→Idle, which clears
-                    // current_turn_id. Read AFTER ingest so the envelope for
-                    // the final status-change carries an empty turn_id (the
-                    // turn just ended); deltas / completions within an active
-                    // turn capture the still-Some id.
                     let emitted = agg.ingest(&acp_event);
                     let turn_id = agg.current_turn_id().unwrap_or("").to_string();
-                    (emitted, turn_id, seq)
+                    (emitted, turn_id, seq, reply_to_message_id, clear_reply_to)
                 }
                 Some(agg) => {
                     let turn_id = agg.current_turn_id().unwrap_or("").to_string();
-                    (Vec::new(), turn_id, seq)
+                    (Vec::new(), turn_id, seq, reply_to_message_id, clear_reply_to)
                 }
-                None => (Vec::new(), String::new(), seq),
+                None => (Vec::new(), String::new(), seq, reply_to_message_id, clear_reply_to),
             }
         };
         if !collab_sessions.is_empty() && !emitted.is_empty() {
@@ -373,15 +389,6 @@ impl DaemonServer {
                 for msg in emitted {
                     let persist =
                         crate::runtime::turn_aggregator::TurnAggregator::cloud_persistent(&msg);
-                    // Non-persistent kinds (AgentThinking / AgentToolCall /
-                    // AgentToolResult) are already fully covered by the
-                    // acp.event stream below — re-publishing them as
-                    // message.created on session/live just makes iOS
-                    // render the same content twice (folded thinking card
-                    // + plain bubble via handleIncomingChatMessage). Only
-                    // AgentReply needs message.created, since that is the
-                    // turn-finalized form persisted to the cloud backend and used
-                    // by historical replay / other collaborators.
                     if !persist {
                         continue;
                     }
@@ -398,6 +405,7 @@ impl DaemonServer {
                             &metadata_json,
                             &model,
                             &turn_id,
+                            &reply_to_message_id,
                             seq,
                             persist,
                             Some(&self.backend),
@@ -405,6 +413,11 @@ impl DaemonServer {
                         .await;
                     }
                 }
+            }
+        }
+        if clear_reply_to {
+            if let Some(handle) = self.agents.lock().await.get_handle_mut(agent_id) {
+                handle.pending_reply_to_message_id = None;
             }
         }
 
@@ -692,6 +705,8 @@ impl DaemonServer {
                 .await;
                 let requester = (!message.sender_actor_id.is_empty())
                     .then(|| message.sender_actor_id.clone());
+                let reply_to = (!message.message_id.is_empty())
+                    .then(|| message.message_id.clone());
                 let send_res = self
                     .agents
                     .lock()
@@ -701,6 +716,7 @@ impl DaemonServer {
                         message.content.as_str(),
                         attachment_urls.clone(),
                         requester,
+                        reply_to,
                     )
                     .await;
                 let _drained = match send_res {
@@ -711,6 +727,9 @@ impl DaemonServer {
                             drained_silent = d.len(),
                             "route_session_message: send_prompt ok"
                         );
+                        // reply_to is bound when the prompt worker starts this
+                        // turn (via AcpEventFrame) — do not stamp handle here
+                        // or a queued second prompt overwrites the in-flight turn.
                         d
                     }
                     Err(e) => {

--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -690,14 +690,17 @@ impl DaemonServer {
                     &message.sender_actor_id,
                 )
                 .await;
+                let requester = (!message.sender_actor_id.is_empty())
+                    .then(|| message.sender_actor_id.clone());
                 let send_res = self
                     .agents
                     .lock()
                     .await
-                    .send_prompt(
+                    .send_prompt_with_requester(
                         &runtime_id,
                         message.content.as_str(),
                         attachment_urls.clone(),
+                        requester,
                     )
                     .await;
                 let _drained = match send_res {

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -539,14 +539,17 @@ impl DaemonServer {
                                     &sender_actor_id,
                                 )
                                 .await;
+                                let requester = (!sender_actor_id.is_empty())
+                                    .then(|| sender_actor_id.clone());
                                 let send_res = self
                                     .agents
                                     .lock()
                                     .await
-                                    .send_prompt(
+                                    .send_prompt_with_requester(
                                         agent_id,
                                         &prompt.text,
                                         prompt.attachment_urls.clone(),
+                                        requester,
                                     )
                                     .await;
                                 if let Err(e) = send_res {
@@ -672,11 +675,18 @@ impl DaemonServer {
                     .unwrap_or_default();
                 self.prepare_remote_tool_context_for_turn(agent_id, &session_id, &sender_actor_id)
                     .await;
+                let requester =
+                    (!sender_actor_id.is_empty()).then(|| sender_actor_id.clone());
                 let send_res = self
                     .agents
                     .lock()
                     .await
-                    .send_prompt(agent_id, &prompt.text, prompt.attachment_urls.clone())
+                    .send_prompt_with_requester(
+                        agent_id,
+                        &prompt.text,
+                        prompt.attachment_urls.clone(),
+                        requester,
+                    )
                     .await;
                 match send_res {
                     Ok(_drained) => {

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -550,6 +550,7 @@ impl DaemonServer {
                                         &prompt.text,
                                         prompt.attachment_urls.clone(),
                                         requester,
+                                        None,
                                     )
                                     .await;
                                 if let Err(e) = send_res {
@@ -686,6 +687,7 @@ impl DaemonServer {
                         &prompt.text,
                         prompt.attachment_urls.clone(),
                         requester,
+                        None,
                     )
                     .await;
                 match send_res {

--- a/apps/daemon/src/runtime/acp_event_frame.rs
+++ b/apps/daemon/src/runtime/acp_event_frame.rs
@@ -5,6 +5,10 @@ use crate::proto::amux;
 pub struct AcpEventFrame {
     pub acp_session_id: String,
     pub event: amux::AcpEvent,
+    /// User `messages.id` for the in-flight turn that produced this frame.
+    /// Bound when the prompt worker dequeues a job (not at enqueue time), so
+    /// concurrent queued prompts cannot overwrite an earlier turn's stamp.
+    pub turn_reply_to_message_id: Option<String>,
 }
 
 impl AcpEventFrame {
@@ -12,6 +16,12 @@ impl AcpEventFrame {
         Self {
             acp_session_id: acp_session_id.into(),
             event,
+            turn_reply_to_message_id: None,
         }
+    }
+
+    pub fn with_reply_to(mut self, reply_to_message_id: Option<String>) -> Self {
+        self.turn_reply_to_message_id = reply_to_message_id.filter(|id| !id.is_empty());
+        self
     }
 }

--- a/apps/daemon/src/runtime/adapter.rs
+++ b/apps/daemon/src/runtime/adapter.rs
@@ -56,6 +56,8 @@ pub enum AcpCommand {
         attachment_urls: Vec<String>,
         /// Human actor that started this turn; stamped onto PermissionRequest params.
         requester_actor_id: Option<String>,
+        /// User message id that triggered this turn; stamped onto AgentReply emits.
+        reply_to_message_id: Option<String>,
     },
     /// Cancel the current turn for a bound session.
     Cancel { acp_session_id: String },
@@ -178,6 +180,8 @@ struct SessionRoute {
     pending_permissions: HashMap<String, oneshot::Sender<PermissionResolution>>,
     /// Human actor id for the in-flight collab turn (PermissionRequest stamp).
     turn_requester_actor_id: Option<String>,
+    /// User message id for the in-flight turn (AgentReply `reply_to_message_id`).
+    turn_reply_to_message_id: Option<String>,
     tool_progress_deduper: RefCell<ToolProgressDeduper>,
     /// Count of `session_notification` handlers currently between "entered"
     /// and "finished pushing their events onto `event_tx`". The ACP crate
@@ -545,17 +549,21 @@ impl acp::Client for AmuxClient {
                     r.event_tx.clone(),
                     r.notif_inflight.clone(),
                     r.notif_finished.clone(),
+                    r.turn_reply_to_message_id.clone(),
                 )
             })
         };
-        if let Some((event_tx, inflight, finished)) = route {
+        if let Some((event_tx, inflight, finished, turn_reply_to)) = route {
             let _inflight_guard = NotifInflightGuard::new(inflight, finished);
             for event in &events {
                 super::agent_trace::log_acp_event(&session_id, event);
             }
             for event in events {
                 let _ = event_tx
-                    .send(AcpEventFrame::new(session_id.clone(), event))
+                    .send(
+                        AcpEventFrame::new(session_id.clone(), event)
+                            .with_reply_to(turn_reply_to.clone()),
+                    )
                     .await;
             }
         } else {
@@ -947,8 +955,8 @@ mod spawn_path_tests {
 // ---------------------------------------------------------------------------
 
 struct ActiveSession {
-    /// text, attachment_urls, optional turn requester_actor_id
-    prompt_tx: mpsc::Sender<(String, Vec<String>, Option<String>)>,
+    /// Prompt jobs: text, attachments, optional turn requester, optional reply_to.
+    prompt_tx: mpsc::Sender<(String, Vec<String>, Option<String>, Option<String>)>,
 }
 
 fn build_acp_process_command(
@@ -1192,6 +1200,7 @@ async fn attach_acp_session_on_conn(
             is_gateway,
             pending_permissions: HashMap::new(),
             turn_requester_actor_id: None,
+            turn_reply_to_message_id: None,
             tool_progress_deduper: RefCell::new(ToolProgressDeduper::default()),
             notif_inflight: Rc::new(Cell::new(0)),
             notif_finished: Rc::new(Cell::new(0)),
@@ -1257,7 +1266,7 @@ fn spawn_prompt_worker(
     session_id: acp::SessionId,
     event_tx: mpsc::Sender<AcpEventFrame>,
     registry: Rc<RefCell<SessionRegistry>>,
-    mut prompt_rx: mpsc::Receiver<(String, Vec<String>, Option<String>)>,
+    mut prompt_rx: mpsc::Receiver<(String, Vec<String>, Option<String>, Option<String>)>,
 ) {
     let acp_session_key = session_id.to_string();
     tokio::task::spawn_local(async move {
@@ -1274,14 +1283,18 @@ fn spawn_prompt_worker(
             .and_then(|v| v.parse::<u64>().ok())
             .map(Duration::from_secs)
             .unwrap_or_else(|| Duration::from_secs(90));
-        while let Some((text, attachment_urls, requester_actor_id)) = prompt_rx.recv().await {
-            // Bind collab requester to THIS worker iteration only — never at
+        while let Some((text, attachment_urls, requester_actor_id, reply_to_message_id)) =
+            prompt_rx.recv().await
+        {
+            // Bind collab turn stamps to THIS worker iteration only — never at
             // Prompt enqueue time, or a queued second prompt would overwrite
             // the in-flight turn's stamp.
+            let turn_reply_to = reply_to_message_id.filter(|id| !id.is_empty());
             if let Some(route) = registry.borrow_mut().resolve_event_route_mut(&acp_session_key)
             {
                 route.turn_requester_actor_id =
                     requester_actor_id.filter(|id| !id.is_empty());
+                route.turn_reply_to_message_id = turn_reply_to.clone();
             }
 
             let attachment_count = attachment_urls.len();
@@ -1299,7 +1312,10 @@ fn spawn_prompt_worker(
             };
             super::agent_trace::log_acp_event(&acp_session_key, &status_active);
             let _ = event_tx
-                .send(AcpEventFrame::new(acp_session_key.clone(), status_active))
+                .send(
+                    AcpEventFrame::new(acp_session_key.clone(), status_active)
+                        .with_reply_to(turn_reply_to.clone()),
+                )
                 .await;
 
             let mut blocks: Vec<acp::ContentBlock> = vec![text.into()];
@@ -1374,12 +1390,16 @@ fn spawn_prompt_worker(
             };
             super::agent_trace::log_acp_event(&acp_session_key, &status_idle);
             let _ = event_tx
-                .send(AcpEventFrame::new(acp_session_key.clone(), status_idle))
+                .send(
+                    AcpEventFrame::new(acp_session_key.clone(), status_idle)
+                        .with_reply_to(turn_reply_to.clone()),
+                )
                 .await;
 
-            // Clear collab turn requester so it cannot leak into the next turn.
+            // Clear collab turn stamps so they cannot leak into the next turn.
             if let Some(route) = registry.borrow_mut().resolve_event_route_mut(&acp_session_key) {
                 route.turn_requester_actor_id = None;
+                route.turn_reply_to_message_id = None;
             }
 
             let elapsed_ms = turn_started.elapsed().as_millis() as u64;
@@ -1580,7 +1600,7 @@ async fn run_acp_host(
                                 if !initial_prompt.is_empty() {
                                     let _ = active
                                         .prompt_tx
-                                        .send((initial_prompt, Vec::new(), None))
+                                        .send((initial_prompt, Vec::new(), None, None))
                                         .await;
                                 }
                                 continue;
@@ -1605,7 +1625,7 @@ async fn run_acp_host(
                                 let acp_sid = meta.acp_session_id.clone();
                                 let session_id = acp::SessionId::new(acp_sid.clone());
                                 let (prompt_tx, prompt_rx) =
-                                    mpsc::channel::<(String, Vec<String>, Option<String>)>(64);
+                                    mpsc::channel::<(String, Vec<String>, Option<String>, Option<String>)>(64);
                                 spawn_prompt_worker(
                                     conn.clone(),
                                     session_id,
@@ -1619,7 +1639,7 @@ async fn run_acp_host(
                                     if let Some(active) = active_sessions.get(&acp_sid) {
                                         let _ = active
                                             .prompt_tx
-                                            .send((initial_prompt, Vec::new(), None))
+                                            .send((initial_prompt, Vec::new(), None, None))
                                             .await;
                                     }
                                 }
@@ -1643,11 +1663,12 @@ async fn run_acp_host(
                         text,
                         attachment_urls,
                         requester_actor_id,
+                        reply_to_message_id,
                     } => {
                         if let Some(active) = active_sessions.get(&acp_session_id) {
                             if active
                                 .prompt_tx
-                                .send((text, attachment_urls, requester_actor_id))
+                                .send((text, attachment_urls, requester_actor_id, reply_to_message_id))
                                 .await
                                 .is_err()
                             {
@@ -2377,6 +2398,7 @@ mod tests {
                 is_gateway: false,
                 pending_permissions: HashMap::new(),
                 turn_requester_actor_id: None,
+                turn_reply_to_message_id: None,
                 tool_progress_deduper: RefCell::new(ToolProgressDeduper::default()),
                 notif_inflight: Rc::new(Cell::new(0)),
                 notif_finished: Rc::new(Cell::new(0)),

--- a/apps/daemon/src/runtime/adapter.rs
+++ b/apps/daemon/src/runtime/adapter.rs
@@ -947,7 +947,8 @@ mod spawn_path_tests {
 // ---------------------------------------------------------------------------
 
 struct ActiveSession {
-    prompt_tx: mpsc::Sender<(String, Vec<String>)>,
+    /// text, attachment_urls, optional turn requester_actor_id
+    prompt_tx: mpsc::Sender<(String, Vec<String>, Option<String>)>,
 }
 
 fn build_acp_process_command(
@@ -1256,7 +1257,7 @@ fn spawn_prompt_worker(
     session_id: acp::SessionId,
     event_tx: mpsc::Sender<AcpEventFrame>,
     registry: Rc<RefCell<SessionRegistry>>,
-    mut prompt_rx: mpsc::Receiver<(String, Vec<String>)>,
+    mut prompt_rx: mpsc::Receiver<(String, Vec<String>, Option<String>)>,
 ) {
     let acp_session_key = session_id.to_string();
     tokio::task::spawn_local(async move {
@@ -1273,7 +1274,16 @@ fn spawn_prompt_worker(
             .and_then(|v| v.parse::<u64>().ok())
             .map(Duration::from_secs)
             .unwrap_or_else(|| Duration::from_secs(90));
-        while let Some((text, attachment_urls)) = prompt_rx.recv().await {
+        while let Some((text, attachment_urls, requester_actor_id)) = prompt_rx.recv().await {
+            // Bind collab requester to THIS worker iteration only — never at
+            // Prompt enqueue time, or a queued second prompt would overwrite
+            // the in-flight turn's stamp.
+            if let Some(route) = registry.borrow_mut().resolve_event_route_mut(&acp_session_key)
+            {
+                route.turn_requester_actor_id =
+                    requester_actor_id.filter(|id| !id.is_empty());
+            }
+
             let attachment_count = attachment_urls.len();
             super::agent_trace::log_prompt_begin(&acp_session_key, &text, attachment_count);
             let turn_started = Instant::now();
@@ -1570,7 +1580,7 @@ async fn run_acp_host(
                                 if !initial_prompt.is_empty() {
                                     let _ = active
                                         .prompt_tx
-                                        .send((initial_prompt, Vec::new()))
+                                        .send((initial_prompt, Vec::new(), None))
                                         .await;
                                 }
                                 continue;
@@ -1594,7 +1604,8 @@ async fn run_acp_host(
                             Ok(meta) => {
                                 let acp_sid = meta.acp_session_id.clone();
                                 let session_id = acp::SessionId::new(acp_sid.clone());
-                                let (prompt_tx, prompt_rx) = mpsc::channel::<(String, Vec<String>)>(64);
+                                let (prompt_tx, prompt_rx) =
+                                    mpsc::channel::<(String, Vec<String>, Option<String>)>(64);
                                 spawn_prompt_worker(
                                     conn.clone(),
                                     session_id,
@@ -1606,7 +1617,10 @@ async fn run_acp_host(
                                 report_startup(&startup_reporter, Ok(meta));
                                 if !initial_prompt.is_empty() {
                                     if let Some(active) = active_sessions.get(&acp_sid) {
-                                        let _ = active.prompt_tx.send((initial_prompt, Vec::new())).await;
+                                        let _ = active
+                                            .prompt_tx
+                                            .send((initial_prompt, Vec::new(), None))
+                                            .await;
                                     }
                                 }
                             }
@@ -1630,14 +1644,13 @@ async fn run_acp_host(
                         attachment_urls,
                         requester_actor_id,
                     } => {
-                        if let Some(route) =
-                            registry.borrow_mut().resolve_event_route_mut(&acp_session_id)
-                        {
-                            route.turn_requester_actor_id = requester_actor_id
-                                .filter(|id| !id.is_empty());
-                        }
                         if let Some(active) = active_sessions.get(&acp_session_id) {
-                            if active.prompt_tx.send((text, attachment_urls)).await.is_err() {
+                            if active
+                                .prompt_tx
+                                .send((text, attachment_urls, requester_actor_id))
+                                .await
+                                .is_err()
+                            {
                                 if let Some(route) = registry.borrow().sessions.get(&acp_session_id) {
                                     emit_acp_error(
                                         &route.event_tx,

--- a/apps/daemon/src/runtime/adapter.rs
+++ b/apps/daemon/src/runtime/adapter.rs
@@ -54,6 +54,8 @@ pub enum AcpCommand {
         acp_session_id: String,
         text: String,
         attachment_urls: Vec<String>,
+        /// Human actor that started this turn; stamped onto PermissionRequest params.
+        requester_actor_id: Option<String>,
     },
     /// Cancel the current turn for a bound session.
     Cancel { acp_session_id: String },
@@ -163,10 +165,19 @@ enum PermissionResolution {
     Granted { option_id: Option<String> },
 }
 
+/// Stamp the collab turn invoker onto PermissionRequest params (wire format).
+fn stamp_requester_actor_id(params: &mut HashMap<String, String>, requester: Option<&str>) {
+    if let Some(id) = requester.filter(|s| !s.is_empty()) {
+        params.insert("requester_actor_id".to_string(), id.to_string());
+    }
+}
+
 struct SessionRoute {
     event_tx: mpsc::Sender<AcpEventFrame>,
     is_gateway: bool,
     pending_permissions: HashMap<String, oneshot::Sender<PermissionResolution>>,
+    /// Human actor id for the in-flight collab turn (PermissionRequest stamp).
+    turn_requester_actor_id: Option<String>,
     tool_progress_deduper: RefCell<ToolProgressDeduper>,
     /// Count of `session_notification` handlers currently between "entered"
     /// and "finished pushing their events onto `event_tx`". The ACP crate
@@ -410,7 +421,17 @@ impl acp::Client for AmuxClient {
                 route.event_tx.clone()
             };
 
-            let permission_params = tool_call_params(args.tool_call.fields.raw_input.as_ref());
+            let mut permission_params =
+                tool_call_params(args.tool_call.fields.raw_input.as_ref());
+            {
+                let guard = self.registry.borrow();
+                if let Some(route) = guard.resolve_event_route(&session_id) {
+                    stamp_requester_actor_id(
+                        &mut permission_params,
+                        route.turn_requester_actor_id.as_deref(),
+                    );
+                }
+            }
             let _ = event_tx
                 .send(AcpEventFrame::new(
                     session_id.clone(),
@@ -1169,6 +1190,7 @@ async fn attach_acp_session_on_conn(
             event_tx: event_tx.clone(),
             is_gateway,
             pending_permissions: HashMap::new(),
+            turn_requester_actor_id: None,
             tool_progress_deduper: RefCell::new(ToolProgressDeduper::default()),
             notif_inflight: Rc::new(Cell::new(0)),
             notif_finished: Rc::new(Cell::new(0)),
@@ -1344,6 +1366,11 @@ fn spawn_prompt_worker(
             let _ = event_tx
                 .send(AcpEventFrame::new(acp_session_key.clone(), status_idle))
                 .await;
+
+            // Clear collab turn requester so it cannot leak into the next turn.
+            if let Some(route) = registry.borrow_mut().resolve_event_route_mut(&acp_session_key) {
+                route.turn_requester_actor_id = None;
+            }
 
             let elapsed_ms = turn_started.elapsed().as_millis() as u64;
             if stalled {
@@ -1597,7 +1624,18 @@ async fn run_acp_host(
                             }
                         }
                     }
-                    AcpCommand::Prompt { acp_session_id, text, attachment_urls } => {
+                    AcpCommand::Prompt {
+                        acp_session_id,
+                        text,
+                        attachment_urls,
+                        requester_actor_id,
+                    } => {
+                        if let Some(route) =
+                            registry.borrow_mut().resolve_event_route_mut(&acp_session_id)
+                        {
+                            route.turn_requester_actor_id = requester_actor_id
+                                .filter(|id| !id.is_empty());
+                        }
                         if let Some(active) = active_sessions.get(&acp_session_id) {
                             if active.prompt_tx.send((text, attachment_urls)).await.is_err() {
                                 if let Some(route) = registry.borrow().sessions.get(&acp_session_id) {
@@ -2297,6 +2335,25 @@ mod tests {
     }
 
     #[test]
+    fn stamps_requester_actor_id_when_present() {
+        let mut params = HashMap::from([("command".to_string(), "ls".to_string())]);
+        stamp_requester_actor_id(&mut params, Some("actor-a"));
+        assert_eq!(
+            params.get("requester_actor_id").map(String::as_str),
+            Some("actor-a")
+        );
+        assert_eq!(params.get("command").map(String::as_str), Some("ls"));
+    }
+
+    #[test]
+    fn stamp_requester_skips_empty() {
+        let mut params = HashMap::new();
+        stamp_requester_actor_id(&mut params, Some(""));
+        stamp_requester_actor_id(&mut params, None);
+        assert!(!params.contains_key("requester_actor_id"));
+    }
+
+    #[test]
     fn detach_session_prunes_child_to_root_aliases() {
         let (event_tx, _rx) = mpsc::channel(1);
         let mut reg = SessionRegistry::default();
@@ -2306,6 +2363,7 @@ mod tests {
                 event_tx,
                 is_gateway: false,
                 pending_permissions: HashMap::new(),
+                turn_requester_actor_id: None,
                 tool_progress_deduper: RefCell::new(ToolProgressDeduper::default()),
                 notif_inflight: Rc::new(Cell::new(0)),
                 notif_finished: Rc::new(Cell::new(0)),

--- a/apps/daemon/src/runtime/handle.rs
+++ b/apps/daemon/src/runtime/handle.rs
@@ -192,12 +192,14 @@ impl RuntimeHandle {
         &self,
         text: &str,
         attachment_urls: Vec<String>,
+        requester_actor_id: Option<String>,
     ) -> crate::error::Result<()> {
         if let Some(ref tx) = self.cmd_tx {
             tx.send(AcpCommand::Prompt {
                 acp_session_id: self.acp_session_id.clone(),
                 text: text.to_string(),
                 attachment_urls,
+                requester_actor_id,
             })
             .await
             .map_err(|_| crate::error::AmuxError::Agent("ACP command channel closed".into()))

--- a/apps/daemon/src/runtime/handle.rs
+++ b/apps/daemon/src/runtime/handle.rs
@@ -87,6 +87,12 @@ pub struct RuntimeHandle {
     /// queued as silent). Used by Task 9 catch-up logic to replay missed
     /// messages on session reopen.
     pub last_processed_message_id: Option<String>,
+    /// User `messages.id` that triggered the in-flight ACP turn. Stamped onto
+    /// AgentReply emits as `reply_to_message_id` so clients can quote-jump.
+    /// Bound when the prompt worker starts the turn (via AcpEventFrame), not at
+    /// enqueue time — so queued prompts cannot overwrite an earlier turn.
+    /// Cleared on Active→Idle.
+    pub pending_reply_to_message_id: Option<String>,
     /// Human member actor whose client receives remote-tool RPC for this runtime.
     pub remote_tool_member_id: String,
     /// Gateway runtimes auto-allow ACP tool permissions; collab runtimes do not.
@@ -131,6 +137,7 @@ impl RuntimeHandle {
             instruction_delivery: InstructionDelivery::BufferedInject,
             backend_runtime_row_id: None,
             last_processed_message_id: None,
+            pending_reply_to_message_id: None,
             available_models: Vec::new(),
             remote_tool_member_id: String::new(),
             is_gateway: false,
@@ -193,6 +200,7 @@ impl RuntimeHandle {
         text: &str,
         attachment_urls: Vec<String>,
         requester_actor_id: Option<String>,
+        reply_to_message_id: Option<String>,
     ) -> crate::error::Result<()> {
         if let Some(ref tx) = self.cmd_tx {
             tx.send(AcpCommand::Prompt {
@@ -200,6 +208,7 @@ impl RuntimeHandle {
                 text: text.to_string(),
                 attachment_urls,
                 requester_actor_id,
+                reply_to_message_id,
             })
             .await
             .map_err(|_| crate::error::AmuxError::Agent("ACP command channel closed".into()))
@@ -348,6 +357,7 @@ impl RuntimeHandle {
             instruction_delivery: InstructionDelivery::BufferedInject,
             backend_runtime_row_id: None,
             last_processed_message_id: None,
+            pending_reply_to_message_id: None,
             available_models: Vec::new(),
             remote_tool_member_id: String::new(),
             is_gateway: false,

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -698,18 +698,19 @@ impl RuntimeManager {
         text: &str,
         attachment_urls: Vec<String>,
     ) -> crate::error::Result<Vec<String>> {
-        self.send_prompt_with_requester(agent_id, text, attachment_urls, None)
+        self.send_prompt_with_requester(agent_id, text, attachment_urls, None, None)
             .await
     }
 
-    /// Like [`send_prompt`], but stamps `requester_actor_id` onto the ACP turn
-    /// so PermissionRequest events can identify who may approve.
+    /// Like [`send_prompt`], but stamps turn-scoped requester / reply_to onto the
+    /// ACP prompt job (bound when the prompt worker starts the turn).
     pub async fn send_prompt_with_requester(
         &mut self,
         agent_id: &str,
         text: &str,
         attachment_urls: Vec<String>,
         requester_actor_id: Option<String>,
+        reply_to_message_id: Option<String>,
     ) -> crate::error::Result<Vec<String>> {
         let (final_text, drained_ids, drained_messages, drained_injected, drained_next_context) =
             if let Some(handle) = self.agents.get_mut(agent_id) {
@@ -750,7 +751,13 @@ impl RuntimeManager {
             };
 
         if let Err(err) = self
-            .send_prompt_raw(agent_id, &final_text, attachment_urls, requester_actor_id)
+            .send_prompt_raw(
+                agent_id,
+                &final_text,
+                attachment_urls,
+                requester_actor_id,
+                reply_to_message_id,
+            )
             .await
         {
             if let Some(handle) = self.agents.get_mut(agent_id) {
@@ -782,10 +789,14 @@ impl RuntimeManager {
         text: &str,
         attachment_urls: Vec<String>,
         requester_actor_id: Option<String>,
+        reply_to_message_id: Option<String>,
     ) -> crate::error::Result<()> {
         #[cfg(test)]
         {
-            let _ = (&attachment_urls, &requester_actor_id);
+            let _ = (
+                &attachment_urls,
+                &requester_actor_id,
+            );
             if let Some(message) = self.send_failures.remove(agent_id) {
                 return Err(crate::error::AmuxError::Agent(message));
             }
@@ -799,18 +810,22 @@ impl RuntimeManager {
                 .insert(agent_id.to_string(), text.to_string());
             if let Some(event_tx) = event_tx {
                 let text = text.to_string();
+                let reply_to = reply_to_message_id.clone();
                 tokio::spawn(async move {
                     let _ = event_tx
-                        .send(AcpEventFrame::new(
-                            "",
-                            amux::AcpEvent {
-                                event: Some(amux::acp_event::Event::Output(amux::AcpOutput {
-                                    text,
-                                    is_complete: true,
-                                })),
-                                model: String::new(),
-                            },
-                        ))
+                        .send(
+                            AcpEventFrame::new(
+                                "",
+                                amux::AcpEvent {
+                                    event: Some(amux::acp_event::Event::Output(amux::AcpOutput {
+                                        text,
+                                        is_complete: true,
+                                    })),
+                                    model: String::new(),
+                                },
+                            )
+                            .with_reply_to(reply_to),
+                        )
                         .await;
                 });
             }
@@ -835,7 +850,7 @@ impl RuntimeManager {
             })?;
             handle.bump_activity();
             handle
-                .send_prompt(text, attachment_urls, requester_actor_id)
+                .send_prompt(text, attachment_urls, requester_actor_id, reply_to_message_id)
                 .await
         }
     }

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -698,6 +698,19 @@ impl RuntimeManager {
         text: &str,
         attachment_urls: Vec<String>,
     ) -> crate::error::Result<Vec<String>> {
+        self.send_prompt_with_requester(agent_id, text, attachment_urls, None)
+            .await
+    }
+
+    /// Like [`send_prompt`], but stamps `requester_actor_id` onto the ACP turn
+    /// so PermissionRequest events can identify who may approve.
+    pub async fn send_prompt_with_requester(
+        &mut self,
+        agent_id: &str,
+        text: &str,
+        attachment_urls: Vec<String>,
+        requester_actor_id: Option<String>,
+    ) -> crate::error::Result<Vec<String>> {
         let (final_text, drained_ids, drained_messages, drained_injected, drained_next_context) =
             if let Some(handle) = self.agents.get_mut(agent_id) {
                 let drained_messages = handle.pending_silent.clone();
@@ -737,7 +750,7 @@ impl RuntimeManager {
             };
 
         if let Err(err) = self
-            .send_prompt_raw(agent_id, &final_text, attachment_urls)
+            .send_prompt_raw(agent_id, &final_text, attachment_urls, requester_actor_id)
             .await
         {
             if let Some(handle) = self.agents.get_mut(agent_id) {
@@ -768,10 +781,11 @@ impl RuntimeManager {
         agent_id: &str,
         text: &str,
         attachment_urls: Vec<String>,
+        requester_actor_id: Option<String>,
     ) -> crate::error::Result<()> {
         #[cfg(test)]
         {
-            let _ = &attachment_urls;
+            let _ = (&attachment_urls, &requester_actor_id);
             if let Some(message) = self.send_failures.remove(agent_id) {
                 return Err(crate::error::AmuxError::Agent(message));
             }
@@ -820,7 +834,9 @@ impl RuntimeManager {
                 crate::error::AmuxError::Agent(format!("agent {} not found", agent_id))
             })?;
             handle.bump_activity();
-            handle.send_prompt(text, attachment_urls).await
+            handle
+                .send_prompt(text, attachment_urls, requester_actor_id)
+                .await
         }
     }
 

--- a/apps/daemon/src/teamclaw/message_store.rs
+++ b/apps/daemon/src/teamclaw/message_store.rs
@@ -243,4 +243,14 @@ mod tests {
         let proto = MessageStore::to_proto(&msg);
         assert_eq!(proto.kind, teamclaw::MessageKind::System as i32);
     }
+
+    #[test]
+    fn test_to_proto_preserves_reply_to_message_id() {
+        let mut msg = make_message("m1", "s1", "hello");
+        msg.reply_to_message_id = "parent-9".to_string();
+        msg.turn_id = "turn-9".to_string();
+        let proto = MessageStore::to_proto(&msg);
+        assert_eq!(proto.reply_to_message_id, "parent-9");
+        assert_eq!(proto.turn_id, "turn-9");
+    }
 }

--- a/apps/daemon/src/teamclaw/session_manager.rs
+++ b/apps/daemon/src/teamclaw/session_manager.rs
@@ -1201,6 +1201,7 @@ impl SessionManager {
         metadata_json: &str,
         model: &str,
         turn_id: &str,
+        reply_to_message_id: &str,
         sequence: u64,
         persist_backend: bool,
         backend: Option<&std::sync::Arc<dyn Backend>>,
@@ -1218,6 +1219,7 @@ impl SessionManager {
             model: model.to_string(),
             metadata_json: metadata_json.to_string(),
             turn_id: turn_id.to_string(),
+            reply_to_message_id: reply_to_message_id.to_string(),
             ..Default::default()
         };
 
@@ -1261,6 +1263,7 @@ impl SessionManager {
                 let meta_owned = metadata_json.to_string();
                 let model_owned = model.to_string();
                 let turn_owned = turn_id.to_string();
+                let reply_to_owned = reply_to_message_id.to_string();
                 let sb_clone = sb.clone();
                 tokio::spawn(async move {
                     if let Err(e) = sb_clone
@@ -1274,6 +1277,7 @@ impl SessionManager {
                             &meta_owned,
                             &model_owned,
                             &turn_owned,
+                            &reply_to_owned,
                             sequence,
                         )
                         .await
@@ -2116,5 +2120,35 @@ mod tests {
 
         let result = sm.sessions_for_agent("agent1");
         assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn emit_agent_message_persists_reply_to_message_id() {
+        let tmp = TempDir::new().unwrap();
+        let sm = dummy_session_manager(tmp.path());
+
+        sm.emit_agent_message(
+            "s-quote",
+            "agent-a",
+            teamclaw::MessageKind::AgentReply,
+            "final answer",
+            "{}",
+            "model-x",
+            "turn-quote",
+            "user-parent-1",
+            7,
+            false,
+            None,
+        )
+        .await;
+
+        let store = MessageStore::load(tmp.path(), "s-quote").unwrap();
+        assert_eq!(store.messages.len(), 1);
+        let msg = &store.messages[0];
+        assert_eq!(msg.reply_to_message_id, "user-parent-1");
+        assert_eq!(msg.turn_id, "turn-quote");
+        assert_eq!(msg.content, "final answer");
+        let proto = MessageStore::to_proto(msg);
+        assert_eq!(proto.reply_to_message_id, "user-parent-1");
     }
 }

--- a/apps/daemon/tests/http_apps.rs
+++ b/apps/daemon/tests/http_apps.rs
@@ -238,6 +238,7 @@ impl Backend for CredentialMockBackend {
         _metadata_json: &str,
         _model: &str,
         _turn_id: &str,
+        _reply_to_message_id: &str,
         _sequence: u64,
     ) -> BackendResult<()> {
         unimplemented!("not used by seed test")

--- a/apps/desktop/src/commands/daemon_onboarding.rs
+++ b/apps/desktop/src/commands/daemon_onboarding.rs
@@ -157,4 +157,12 @@ mod tests {
     fn returns_none_when_missing() {
         assert!(parse_init_outcome("nothing here").is_none());
     }
+
+    #[test]
+    fn rebind_stops_service_and_process_before_rewriting_identity() {
+        assert_eq!(
+            rebind_prelude(),
+            [["uninstall-service"].as_slice(), ["stop"].as_slice()]
+        );
+    }
 }

--- a/docs/debug/remove-agent-public-actors-schema-drift.md
+++ b/docs/debug/remove-agent-public-actors-schema-drift.md
@@ -1,0 +1,171 @@
+# 删除旧 Agent 失败：`public.actors` schema drift
+
+日期：2026-07-17
+
+## 现象
+
+切换到新的 team 后，左侧 `RECENTS` 仍显示旧的 agent，例如 `MACPRO`。用户尝试从侧边栏删除该 agent 时，UI toast 报错：
+
+```text
+Remove failed: relation "public.actors" does not exist
+```
+
+截图中同时可以看到：
+
+- `RECENTS` 中仍有 `MACPRO`，右侧标记为 `Agent`。
+- 左下角本机 daemon 卡片显示另一个 agent：`J60GP07WVG`。
+- 删除 `MACPRO` 失败后，它仍然留在 actor 列表中。
+
+## 复现路径
+
+1. 登录 TeamClaw Desktop。
+2. 切换到一个新的 team。
+3. 让本机 daemon 重新绑定或进入新 team，使左下角显示当前本机 agent。
+4. 观察左侧 `RECENTS`。
+5. 如果旧 agent（如 `MACPRO`）仍显示，右键或打开详情尝试 `Remove from team`。
+6. 删除失败，toast 显示 `relation "public.actors" does not exist`。
+7. 刷新 actor 列表后旧 agent 仍显示。
+
+## 当前显示逻辑
+
+`RECENTS` 不是本机 daemon 的专用显示位。它来自当前 team 的 actor directory：
+
+- `ActorsSection` 通过 `useActorsForTeam()` 读取当前 team 的 actor directory。
+  - `packages/app/src/components/sidebar/ActorsSection.tsx`
+- `useActorsForTeam()` 来自 `actor-directory-store`，加载顺序是本地 cache first，然后用 Cloud API `listActorDirectory(teamId)` 覆盖。
+  - `packages/app/src/stores/actor-directory-store.ts`
+- `getRecentContactActors()` 只保留有 `last_active_at` 或 presence 在线的 actor，并会把当前用户的 `defaultAgentId` 置顶。
+  - `packages/app/src/components/sidebar/sidebar-list-helpers.ts`
+- 本机 daemon agent 会被 `ActorsSection` 排除出 `RECENTS`，改由左下角 `LocalDaemonCard` 独立显示。
+  - `packages/app/src/components/sidebar/LocalDaemonCard.tsx`
+
+因此：
+
+- 左下角 `J60GP07WVG` 是当前本机 daemon agent。
+- `RECENTS` 中的 `MACPRO` 是当前 team actor directory 返回的 actor，或当前用户默认 agent 置顶结果。
+- 如果 `MACPRO` 被服务端 directory 返回，前端不会认为它“不存在”。
+
+## 问题根因判断
+
+这不太像单纯前端脏缓存，原因是删除动作本身返回了数据库错误：
+
+```text
+relation "public.actors" does not exist
+```
+
+当前项目已迁到 `amux.*` schema。baseline 中 `amux.remove_team_actor` 仍包含旧表引用：
+
+```sql
+from public.actors
+delete from public.team_members
+delete from public.agents
+delete from public.members
+delete from public.agent_member_access
+delete from public.daemon_invites
+```
+
+位置：
+
+- `services/supabase/migrations/20260601000000_baseline.sql`
+
+FC Supabase repository 的删除路径调用的是：
+
+```ts
+supabase.rpc("remove_team_actor", { p_actor_id: actorId })
+```
+
+位置：
+
+- `services/fc/src/lib/supabase-repo.ts`
+
+因为 live DB 上 `public.actors` 不存在，删除 RPC 执行失败。actor 没有被删除，后续 actor directory 仍然返回这条旧 agent，所以侧边栏继续显示。
+
+## 为什么切 team 后旧 agent 还在
+
+切换 team 的代码只会：
+
+1. 调用 Cloud API 激活新 team。
+2. 更新本地 auth session。
+3. 重载当前 team。
+4. 调用 daemon onboarding refresh 检查本机 daemon 和当前 team 的绑定状态。
+
+它不会自动删除旧 team 或旧 actor，也不会在切 team 时清理服务端残留 agent。
+
+相关位置：
+
+- `packages/app/src/stores/current-team.ts`
+- `packages/app/src/stores/daemon-onboarding.ts`
+
+如果旧 agent 已经错误地存在于当前 team 的 actor directory，切 team 不会自动修复它。
+
+## 临时处理方案
+
+不改代码也可以临时处理（在 DB 手工删）。**先查再删**，把下面 `<team_id>` / `<actor_id>` 换成实际值。
+
+### 1) 查出要删的 agent
+
+```sql
+select a.id, a.display_name, a.actor_type, a.last_active_at, ag.status, ag.visibility
+from amux.actors a
+left join amux.agents ag on ag.id = a.id
+where a.team_id = '<team_id>'
+  and a.actor_type = 'agent'
+order by a.display_name;
+```
+
+### 2) 删单个 agent（与 RPC 同序，避开 RESTRICT）
+
+```sql
+begin;
+
+-- optional: 看有没有 RESTRICT 引用会挡删除
+select 'apps' as src, id from amux.apps where created_by_actor_id = '<actor_id>'
+union all
+select 'idea_activities', id::text from amux.idea_activities where actor_id = '<actor_id>'
+union all
+select 'amuxc_files', id from amux.amuxc_files where updated_by = '<actor_id>'
+union all
+select 'amuxc_file_versions', id::text from amux.amuxc_file_versions where created_by = '<actor_id>';
+
+delete from amux.agent_member_access
+ where agent_id = '<actor_id>' or member_id = '<actor_id>';
+
+delete from amux.team_members where member_id = '<actor_id>';
+
+delete from amux.agents where id = '<actor_id>';
+delete from amux.actors where id = '<actor_id>';
+
+commit;
+```
+
+若第 2 步因 FK RESTRICT 失败，先处理那些引用行，或等正式 migration 上线后走 UI 删除。
+
+### 3) 更快的临时方案：只修函数，然后走 UI
+
+直接在 live DB 执行 migration 文件内容：
+
+`services/supabase/migrations/20260718000000_fix_remove_team_actor_amux.sql`
+
+然后在桌面端再点 Remove。合并进 `main` 后 `self-host-deploy` 也会自动 apply。
+
+## 正式修复方向
+
+已落地（2026-07-18）：
+
+1. Migration：`services/supabase/migrations/20260718000000_fix_remove_team_actor_amux.sql`
+2. 函数体全部改为 `amux.*`，并去掉已删除的 `daemon_invites` 引用
+3. FC：`supabase.schema("amux").rpc("remove_team_actor", ...)`
+4. pgTAP：`024_remove_team_actor_owned_agents.sql` 改用 `amux.*`
+5. FC 单测断言 RPC 带 `schema: "amux"`
+
+应用 migration 到 live DB 后，在 UI 重新删除旧 agent 即可。
+
+## 验证建议
+
+修复完成后至少验证：
+
+1. UI 删除旧 agent 不再报 `public.actors`。
+2. 删除后 `GET /v1/teams/:teamId/actors` 不再返回该 actor。
+3. `RECENTS` 不再显示该 actor。
+4. 删除 member 时，其拥有的 agent 仍按预期级联删除。
+5. 删除最后一个 owner / 删除自己 / 非 owner-admin 删除仍保持原有保护逻辑。

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "rust:build": "node scripts/rust-cli.js build --manifest-path apps/desktop/Cargo.toml",
     "daemon:run": "node scripts/run-daemon.js",
     "daemon:ctl": "scripts/amuxdctl.sh",
+    "dev:daemon": "scripts/dev-daemon.sh",
+    "dev:desktop": "scripts/dev-desktop.sh",
     "reset:local": "scripts/reset-local-state.sh",
     "daemon:build": "cargo build -p amuxd",
     "daemon:test": "cargo test -p amuxd",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -124,6 +124,9 @@ import {
 } from "@/lib/session-list-preview";
 import { executeAgentTurnFlush } from "@/lib/agent-turn-flush";
 import {
+  resolvePendingAgentReplyTo,
+} from "@/lib/pending-agent-reply-to";
+import {
   bufferStreamDelta,
   flushStreamDeltasFor,
   flushAllStreamDeltas,
@@ -968,6 +971,14 @@ function AppContent() {
       actorId,
       snapshot,
     );
+    const pendingReplyTo = resolvePendingAgentReplyTo(
+      sessionId,
+      actorId,
+      syntheticReply.replyToMessageId,
+    );
+    if (pendingReplyTo) {
+      syntheticReply.replyToMessageId = pendingReplyTo;
+    }
     logInterruptMsgDiag("flush.interrupted.start", {
       sessionId,
       actorId,
@@ -1077,6 +1088,15 @@ function AppContent() {
         ...flushDecision,
       });
       return false;
+    }
+
+    const pendingReplyTo = resolvePendingAgentReplyTo(
+      sessionId,
+      actorId,
+      mergedReply.replyToMessageId,
+    );
+    if (pendingReplyTo) {
+      mergedReply.replyToMessageId = pendingReplyTo;
     }
 
     logInterruptMsgDiag("flush.start", {
@@ -1483,7 +1503,7 @@ function AppContent() {
                 sessionId: m.sessionId,
                 turnId: m.turnId || null,
                 senderActorId: m.senderActorId || null,
-                replyToMessageId: null,
+                replyToMessageId: m.replyToMessageId?.trim() || null,
                 kind: kindStr,
                 content: m.content,
                 metadataJson: m.metadataJson || null,
@@ -1683,7 +1703,8 @@ function AppContent() {
                 clearTerminalFlushPending(agentStreamKey(sid, actorId));
                 useV2StreamingStore.getState().beginPlanningPlaceholder(sid, actorId);
               } else if (isTerminalAgentStatus(sc.newStatus)) {
-                terminalFlushPendingRef.current[agentStreamKey(sid, actorId)] = true;
+                const streamKey = agentStreamKey(sid, actorId);
+                terminalFlushPendingRef.current[streamKey] = true;
                 const flushed = flushTurnAgentReply(
                   sid,
                   actorId,
@@ -1696,42 +1717,35 @@ function AppContent() {
                   newStatus: sc.newStatus,
                   flushed,
                   ...summarizePendingReplies(
-                    pendingStreamRepliesRef.current[agentStreamKey(sid, actorId)],
+                    pendingStreamRepliesRef.current[streamKey],
                   ),
                   ...summarizeStreamEntry(
-                    useV2StreamingStore.getState().byKey[agentStreamKey(sid, actorId)],
+                    useV2StreamingStore.getState().byKey[streamKey],
                     "live",
                   ),
                 });
-                if (!flushed) {
-                  const streamEntry = useV2StreamingStore.getState().byKey[
-                    agentStreamKey(sid, actorId)
-                  ];
+                if (flushed) {
+                  clearTerminalFlushPending(streamKey);
+                } else {
+                  const streamEntry =
+                    useV2StreamingStore.getState().byKey[streamKey];
                   if (streamEntryHasVisibleContent(streamEntry)) {
-                    const interruptedPending = useV2StreamingStore
-                      .getState()
-                      .isInterruptedFlushPending(sid, actorId);
-                    logInterruptMsgDiag("mqtt.statusChange.terminal.finishOnly", {
+                    // Live Dock only shows active streams; when daemon
+                    // message.created lags statusChange.terminal, flush from
+                    // the in-memory transcript instead of dropping the turn.
+                    const eagerFlushed = flushInterruptedStreamArtifacts(
+                      sid,
+                      actorId,
+                      "mqtt.statusChange.terminal.eager",
+                    );
+                    logInterruptMsgDiag("mqtt.statusChange.terminal.eager", {
                       sessionId: sid,
                       actorId,
-                      interruptedPending,
+                      eagerFlushed,
                       ...summarizeStreamEntry(streamEntry, "live"),
                     });
-                    if (interruptedPending) {
-                      const eagerFlushed = flushInterruptedStreamArtifacts(
-                        sid,
-                        actorId,
-                        "mqtt.statusChange.terminal.finishOnly",
-                      );
-                      if (eagerFlushed) {
-                        useV2StreamingStore
-                          .getState()
-                          .clearInterruptedFlushPending(sid, actorId);
-                      } else {
-                        useV2StreamingStore.getState().finishSessionActor(sid, actorId, {
-                          reason: "statusChange.terminal",
-                        });
-                      }
+                    if (eagerFlushed) {
+                      clearTerminalFlushPending(streamKey);
                     } else {
                       useV2StreamingStore.getState().finishSessionActor(sid, actorId, {
                         reason: "statusChange.terminal",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -109,6 +109,7 @@ import {
   streamActorIdFromLiveEvent,
 } from "@/lib/teamclaw-events";
 import { handleAcpPermissionRequest } from "@/lib/teamclaw/handle-acp-permission-request";
+import { handleSessionEventPermissionResolved } from "@/lib/teamclaw/handle-session-event-permission-resolved";
 import { tryBindChildFromPermission } from "@/lib/teamclaw/subagent-acp-binding";
 import { routeSubagentAcpEvent } from "@/lib/teamclaw/subagent-acp-route";
 import {
@@ -1523,6 +1524,22 @@ function AppContent() {
             return;
           }
 
+          // Case 2a: SessionEvent (e.g. PermissionResolved) arrives as
+          // LiveEventEnvelope event_type=acp.event with Amux payload.sessionEvent.
+          // Must run outside `if (decoded.acpEvent)` — that field is only set for
+          // payload.case === "acpEvent".
+          if (decoded.amuxEnvelope?.payload?.case === "sessionEvent") {
+            const se = decoded.amuxEnvelope.payload.value?.event;
+            if (se?.case === "permissionResolved") {
+              const requestId = (se.value as { requestId?: string })?.requestId ?? "";
+              handleSessionEventPermissionResolved({
+                requestId,
+                sessionIdHint: sid,
+              });
+            }
+            return;
+          }
+
           // Case 2: streaming acp.event
           if (decoded.acpEvent) {
             // Dev-only one-way latency probe (no-op unless the local daemon
@@ -1786,6 +1803,7 @@ function AppContent() {
                   toolName: pr.toolName ?? "",
                   description: pr.description ?? "",
                   params: pr.params ?? {},
+                  requesterActorId: pr.params?.requester_actor_id?.trim() || undefined,
                   options: (pr.options ?? []).map((o) => ({
                     optionId: o.optionId ?? "",
                     kind: o.kind ?? "",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -124,6 +124,7 @@ import {
 } from "@/lib/session-list-preview";
 import { executeAgentTurnFlush } from "@/lib/agent-turn-flush";
 import {
+  removePendingAgentReplyTo,
   resolvePendingAgentReplyTo,
 } from "@/lib/pending-agent-reply-to";
 import {
@@ -1437,6 +1438,13 @@ function AppContent() {
               // real reply doesn't duplicate it (survives reload otherwise).
               if (senderActorId && msg.kind === MessageKind.AGENT_REPLY) {
                 removeInterruptedStreamPlaceholderForRealReply(sid, senderActorId);
+                // Direct-append skips flushTurnAgentReply — still drop the
+                // stamped parent from the local FIFO so a later flush cannot
+                // reuse a stale user message id.
+                const stampedReplyTo = msg.replyToMessageId?.trim();
+                if (stampedReplyTo) {
+                  removePendingAgentReplyTo(sid, senderActorId, stampedReplyTo);
+                }
               }
               useSessionMessageStore.getState().appendMessage(sid, decoded.message);
             }

--- a/packages/app/src/components/chat/AgentProcessCollapsible.tsx
+++ b/packages/app/src/components/chat/AgentProcessCollapsible.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+/** Quiet disclosure for completed-turn process (thinking + tools) above final text. */
+export function AgentProcessCollapsible({
+  children,
+  summary,
+  defaultOpen = false,
+  className,
+}: {
+  children: React.ReactNode;
+  summary?: string;
+  defaultOpen?: boolean;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(defaultOpen);
+
+  return (
+    <div
+      className={cn("mb-2", className)}
+      data-testid="agent-process-collapsible"
+      data-open={open ? "true" : "false"}
+    >
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex max-w-full items-center gap-1.5 rounded py-0.5 text-left text-[12px] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ChevronDown
+              className={cn(
+                "h-3 w-3 shrink-0 text-faint transition-transform duration-200",
+                open && "rotate-180",
+              )}
+            />
+            <span className="font-medium">
+              {t("chat.process", "处理过程")}
+            </span>
+            {summary ? (
+              <>
+                <span className="text-faint" aria-hidden>
+                  ·
+                </span>
+                <span className="truncate font-mono text-[11px] text-faint">
+                  {summary}
+                </span>
+              </>
+            ) : null}
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="mt-2 space-y-1 border-l border-border pl-[18px]">
+            {children}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}

--- a/packages/app/src/components/chat/AgentReplyQuote.tsx
+++ b/packages/app/src/components/chat/AgentReplyQuote.tsx
@@ -1,0 +1,125 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+
+/** Soft-strip quote (style B): faint pad + author + inline AGENT pills + body. */
+export function AgentReplyQuote({
+  authorName,
+  content,
+  onJump,
+  className,
+}: {
+  authorName: string;
+  /** Parent user message content (may include `[Mentioned agents: …]` prefix). */
+  content: string;
+  onJump: () => void;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const { agentNames, body } = React.useMemo(
+    () => parseReplyQuoteContent(content),
+    [content],
+  );
+
+  return (
+    <button
+      type="button"
+      data-testid="agent-reply-quote"
+      onClick={onJump}
+      className={cn(
+        "mb-1.5 block w-full max-w-[440px] rounded-md bg-[rgba(26,26,20,0.035)] px-[9px] py-[5px] text-left transition-colors hover:bg-[rgba(26,26,20,0.055)] dark:bg-white/[0.04] dark:hover:bg-white/[0.07]",
+        className,
+      )}
+    >
+      <span className="mb-0.5 block text-[10.5px] text-faint">
+        {t("chat.replyToPrefix", "回复")}{" "}
+        <em className="not-italic font-semibold text-muted-foreground">{authorName}</em>
+      </span>
+      <span className="block truncate text-[12.5px] leading-[1.45] text-ink-2 dark:text-[#c8d0d8]">
+        {agentNames.map((name) => (
+          <span
+            key={name}
+            className="mr-1.5 inline-flex items-center gap-1 align-[-2px] whitespace-nowrap"
+            data-testid="agent-reply-quote-pill"
+          >
+            <span className="font-mono text-[8.5px] font-semibold tracking-[0.04em] text-coral leading-none">
+              AGENT
+            </span>
+            <span className="text-[12px] font-semibold text-foreground leading-none">
+              {formatAgentAtLabel(name)}
+            </span>
+          </span>
+        ))}
+        {body || (agentNames.length === 0 ? "…" : null)}
+      </span>
+    </button>
+  );
+}
+
+function formatAgentAtLabel(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "";
+  return trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
+}
+
+/** Parse parent content into inline agent pills + body text (no separate mention row). */
+export function parseReplyQuoteContent(
+  content: string,
+  maxBodyLen = 80,
+): { agentNames: string[]; body: string } {
+  let rest = content.trim();
+  const agentNames: string[] = [];
+
+  const agentMatch = rest.match(/^\[Mentioned agents: ([^\]]+)\](?:\r?\n)?/);
+  if (agentMatch) {
+    for (const part of (agentMatch[1] ?? "").split(",")) {
+      const name = part.trim();
+      if (name) agentNames.push(name);
+    }
+    rest = rest.slice(agentMatch[0].length).replace(/^\s+/, "");
+  }
+
+  // Drop human-mention metadata prefixes; quote focuses on agent pills + body.
+  const humanMatch = rest.match(/^\[Mentioned humans: ([^\]]+)\](?:\r?\n)?/);
+  if (humanMatch) {
+    rest = rest.slice(humanMatch[0].length).replace(/^\s+/, "");
+  }
+
+  // Legacy free-form @mentions at the start of body.
+  rest = rest.replace(/^(?:@\S+\s*)+/, "").trim();
+
+  // Strip leftover instruction metadata lines if any.
+  rest = rest
+    .replace(/\[Mentioned:[^\]]*\|instruction:[^\]]*\]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  const body =
+    rest.length <= maxBodyLen
+      ? rest
+      : `${rest.slice(0, Math.max(0, maxBodyLen - 1)).trimEnd()}…`;
+
+  return { agentNames, body };
+}
+
+/** @deprecated Prefer parseReplyQuoteContent — kept for call sites that only need text. */
+export function formatReplyQuoteSnippet(content: string, maxLen = 80): string {
+  return parseReplyQuoteContent(content, maxLen).body;
+}
+
+export function jumpToMessageById(messageId: string): boolean {
+  const id = messageId.trim();
+  if (!id) return false;
+  const el = document.querySelector(
+    `[data-testid="chat-message"][data-message-id="${CSS.escape(id)}"]`,
+  ) as HTMLElement | null;
+  if (!el) return false;
+  el.scrollIntoView({ behavior: "smooth", block: "center" });
+  el.classList.remove("agent-reply-quote-flash");
+  void el.offsetWidth;
+  el.classList.add("agent-reply-quote-flash");
+  window.setTimeout(() => {
+    el.classList.remove("agent-reply-quote-flash");
+  }, 1100);
+  return true;
+}

--- a/packages/app/src/components/chat/ChatInputArea.tsx
+++ b/packages/app/src/components/chat/ChatInputArea.tsx
@@ -580,7 +580,7 @@ export function ChatInputArea({
             <PromptInputTextarea
               placeholder={
                 isStreaming
-                  ? t('chat.inputPlaceholderQueue', 'Type to queue message...')
+                  ? t('chat.inputPlaceholderContinue', 'Continue typing...')
                   : attachedFiles.length > 0
                     ? t('chat.inputPlaceholderDescription', 'Add a description...')
                     : t('chat.inputPlaceholderMention', 'Mention with @, reference files with #...')

--- a/packages/app/src/components/chat/ChatMessage.tsx
+++ b/packages/app/src/components/chat/ChatMessage.tsx
@@ -18,6 +18,7 @@ import {
 import { ToolCallCard } from "./ToolCallCard";
 import { StreamMarkdown } from "./StreamMarkdown";
 import { ThinkingBlock } from "./ThinkingBlock";
+import { AgentProcessCollapsible } from "./AgentProcessCollapsible";
 import { UserMessageWithMentions } from "./UserMessageWithMentions";
 import { MessageStatusDot } from "./MessageStatusDot";
 import { ActorLabel } from "./ActorLabel";
@@ -26,6 +27,13 @@ import { MessageTokenSummary } from "./MessageTokenSummary";
 import { MessageFeedback } from "./MessageFeedback";
 import { MessageStarRating } from "./MessageStarRating";
 import { RetrievedChunksCard } from "./RetrievedChunksCard";
+import { splitAssistantProcessAndFinalParts } from "@/lib/agent-reply-transcript";
+import {
+  AgentReplyQuote,
+  jumpToMessageById,
+} from "./AgentReplyQuote";
+import { useActorDisplayName } from "@/hooks/useActorDisplayName";
+import { useCurrentTeamStore } from "@/stores/current-team";
 
 /** Renders a single message with all its parts. Memoized to avoid re-renders when siblings change. */
 export const ChatMessage = React.memo(function ChatMessage({
@@ -35,6 +43,7 @@ export const ChatMessage = React.memo(function ChatMessage({
   shouldShowThinking = true,
   showStarRating = false,
   tokenGroupInfo,
+  replyToMessage,
 }: {
   message: StoreMessage;
   activeSessionId?: string | null;
@@ -45,10 +54,25 @@ export const ChatMessage = React.memo(function ChatMessage({
     hideTokenUsage: boolean;
     groupSummary?: { steps: number; totalInput: number; totalOutput: number; totalCost: number };
   };
+  /** Parent user message when this assistant turn quotes one. */
+  replyToMessage?: StoreMessage | null;
 }) {
   const { t } = useTranslation();
   const isUser = message.role === "user";
   const [copied, setCopied] = React.useState(false);
+  const replyAuthorResolved = useActorDisplayName(replyToMessage?.senderActorId);
+  const myActorId = useCurrentTeamStore((s) => s.currentMember?.id);
+  const replyAuthorName = React.useMemo(() => {
+    if (!replyToMessage) return "";
+    if (
+      myActorId &&
+      replyToMessage.senderActorId &&
+      replyToMessage.senderActorId === myActorId
+    ) {
+      return t("chat.you", "你");
+    }
+    return replyAuthorResolved || t("chat.someone", "某人");
+  }, [replyToMessage, myActorId, replyAuthorResolved, t]);
 
   // Use streaming content for the actively streaming message.
   // PERF: Only the streaming message subscribes to high-frequency updates (trigger/content).
@@ -126,11 +150,33 @@ export const ChatMessage = React.memo(function ChatMessage({
   );
   const hasOrderedToolParts = orderedRenderableParts.some((p) => p.type === "tool-call");
   const hasOrderedReasoningParts = orderedRenderableParts.some((p) => p.type === "reasoning");
+  const { processParts: orderedProcessParts, finalTextParts: orderedTextParts } =
+    React.useMemo(
+      () => splitAssistantProcessAndFinalParts(orderedRenderableParts),
+      [orderedRenderableParts],
+    );
   const shouldRenderOrderedAssistantParts =
     !isUser &&
     (hasOrderedToolParts ||
       (hasOrderedReasoningParts &&
         (orderedRenderableParts.some((p) => p.type === "text") || !textContent)));
+
+  const fallbackProcessSummary = React.useMemo(() => {
+    const bits: string[] = [];
+    if (hasReasoning) bits.push("Thinking");
+    if (hasToolCalls && !hasOrderedToolParts) {
+      bits.push(`${latestMessage.toolCalls!.length} tool`);
+    }
+    return bits.join(" · ") || undefined;
+  }, [hasReasoning, hasToolCalls, hasOrderedToolParts, latestMessage.toolCalls]);
+
+  const orderedProcessSummary = React.useMemo(() => {
+    const toolCount = orderedProcessParts.filter((p) => p.type === "tool-call").length;
+    const bits: string[] = [];
+    if (hasOrderedReasoningParts) bits.push("Thinking");
+    if (toolCount > 0) bits.push(`${toolCount} tool`);
+    return bits.join(" · ") || undefined;
+  }, [orderedProcessParts, hasOrderedReasoningParts]);
 
   const hasActiveToolCalls =
     latestMessage.toolCalls?.some(
@@ -236,7 +282,33 @@ export const ChatMessage = React.memo(function ChatMessage({
         modelOverride={message.modelID}
         isUser={isUser}
       />
-      {/* Thinking indicator - MUST be first for assistant messages during streaming */}
+      {!isUser && replyToMessage ? (
+        <AgentReplyQuote
+          authorName={replyAuthorName}
+          content={replyToMessage.content || ""}
+          onJump={() => jumpToMessageById(replyToMessage.id)}
+        />
+      ) : null}
+      {/* Reasoning / tools — collapsed「处理过程」above final text when not streaming */}
+      {!isUser &&
+        !latestMessage.isStreaming &&
+        !shouldRenderOrderedAssistantParts &&
+        (hasReasoning || (hasToolCalls && !hasOrderedToolParts)) && (
+          <div className="mb-0.5 pl-1">
+            <AgentProcessCollapsible summary={fallbackProcessSummary}>
+              {hasReasoning ? (
+                <ThinkingBlock content={reasoningContent} isOpen={false} />
+              ) : null}
+              {hasToolCalls && !hasOrderedToolParts
+                ? latestMessage.toolCalls!.map((toolCall) => (
+                    <ToolCallCard key={toolCall.id} toolCall={toolCall} />
+                  ))
+                : null}
+            </AgentProcessCollapsible>
+          </div>
+        )}
+
+      {/* Streaming-only thinking indicator (live path uses Composer dock) */}
       {showThinkingOnly && !hasReasoning && (
         <div className="flex items-start gap-2 pl-1 mb-2">
           <ThinkingBlock
@@ -261,12 +333,15 @@ export const ChatMessage = React.memo(function ChatMessage({
         </div>
       )}
 
-      {/* Reasoning block - always before main content */}
-      {!isUser && hasReasoning && !hasOrderedReasoningParts && (
+      {/* Legacy streaming reasoning (v1) — keep above content while streaming */}
+      {!isUser &&
+        hasReasoning &&
+        !hasOrderedReasoningParts &&
+        latestMessage.isStreaming && (
         <div className="mb-0.5">
           <ThinkingBlock
             content={reasoningContent}
-            isStreaming={latestMessage.isStreaming && !textContent && !hasToolCalls}
+            isStreaming={!textContent && !hasToolCalls}
             isOpen={false}
           />
         </div>
@@ -316,8 +391,44 @@ export const ChatMessage = React.memo(function ChatMessage({
       {/* Assistant message - either dynamic UI or text */}
       {!isUser && shouldRenderOrderedAssistantParts && (
         <div className="mt-2 space-y-1">
-          {orderedRenderableParts.map((part, index) => {
+          {orderedProcessParts.length > 0 && !latestMessage.isStreaming ? (
+            <AgentProcessCollapsible summary={orderedProcessSummary}>
+              {orderedProcessParts.map((part) => {
+                if (part.type === "reasoning") {
+                  const reasoningText = part.text || part.content || "";
+                  if (!reasoningText) return null;
+                  return (
+                    <ThinkingBlock
+                      key={part.id}
+                      content={reasoningText}
+                      isOpen={false}
+                    />
+                  );
+                }
+                if (part.type === "tool-call" && part.toolCall) {
+                  return <ToolCallCard key={part.id} toolCall={part.toolCall} />;
+                }
+                if (part.type === "text") {
+                  const partText = part.text || part.content || "";
+                  if (!partText) return null;
+                  return (
+                    <Message key={part.id} from="assistant" basePath={basePath}>
+                      <MessageContent>
+                        <MessageResponse>{partText}</MessageResponse>
+                      </MessageContent>
+                    </Message>
+                  );
+                }
+                return null;
+              })}
+            </AgentProcessCollapsible>
+          ) : null}
+          {(latestMessage.isStreaming
+            ? orderedRenderableParts
+            : orderedTextParts
+          ).map((part, index, arr) => {
             if (part.type === "reasoning") {
+              if (!latestMessage.isStreaming) return null;
               const reasoningText = part.text || part.content || "";
               if (!reasoningText) return null;
               return (
@@ -325,27 +436,24 @@ export const ChatMessage = React.memo(function ChatMessage({
                   key={part.id}
                   content={reasoningText}
                   isStreaming={
-                    latestMessage.isStreaming &&
-                    index === orderedRenderableParts.length - 1 &&
-                    !textContent
+                    index === arr.length - 1 && !textContent
                   }
                   isOpen={false}
                 />
               );
             }
             if (part.type === "tool-call" && part.toolCall) {
+              if (!latestMessage.isStreaming) return null;
               return <ToolCallCard key={part.id} toolCall={part.toolCall} />;
             }
+            if (part.type !== "text") return null;
             const partText = part.text || part.content || "";
             if (!partText) return null;
             const isGrowingPart =
-              latestMessage.isStreaming &&
-              index === orderedRenderableParts.length - 1;
+              latestMessage.isStreaming && index === arr.length - 1;
             return (
               <Message key={part.id} from="assistant" basePath={basePath}>
                 <MessageContent>
-                  {/* PERF: while streaming, render through the stable-block
-                      splitter so only the growing tail re-parses per frame. */}
                   {isGrowingPart ? (
                     <StreamMarkdown text={partText} />
                   ) : (
@@ -355,6 +463,18 @@ export const ChatMessage = React.memo(function ChatMessage({
               </Message>
             );
           })}
+          {!latestMessage.isStreaming &&
+            orderedTextParts.length === 0 &&
+            textContent &&
+            // Mid-turn narrations already live inside process; don't re-render
+            // message.content as a duplicate final body.
+            !orderedProcessParts.some((part) => part.type === "text") && (
+              <Message from="assistant" basePath={basePath}>
+                <MessageContent>
+                  <MessageResponse>{textContent}</MessageResponse>
+                </MessageContent>
+              </Message>
+            )}
           {latestMessage.isStreaming && textContent && (
             <span className="inline-flex items-center gap-0.5 ml-1.5 align-middle">
               <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-[bounce_1s_ease-in-out_infinite]" />
@@ -415,8 +535,11 @@ export const ChatMessage = React.memo(function ChatMessage({
         </div>
       )}
 
-      {/* Tool calls */}
-      {!isUser && hasToolCalls && !hasOrderedToolParts && (
+      {/* Tool calls — only while streaming on fallback path; completed uses process shell above */}
+      {!isUser &&
+        hasToolCalls &&
+        !hasOrderedToolParts &&
+        latestMessage.isStreaming && (
         <div className="mt-1 space-y-0.5 pl-1">
           {latestMessage.toolCalls!.map((toolCall) => (
             <ToolCallCard key={toolCall.id} toolCall={toolCall} />

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -18,6 +18,7 @@ import { useTeamModeStore } from "@/stores/team-mode";
 import { useCurrentTeamStore } from "@/stores/current-team";
 import { TEAMCLAW_DIR, CONFIG_FILE_NAME, TEAM_REPO_DIR } from "@/lib/build-config";
 import { adaptTeamclawMessages } from "@/lib/v2-message-adapter";
+import { notePendingAgentReplyTo } from "@/lib/pending-agent-reply-to";
 import { logInterruptMsgDiag } from "@/lib/interrupt-msg-diag";
 import { useAuthStore } from "@/stores/auth-store";
 import { bumpSessionListLastMessage } from "@/lib/session-list-preview";
@@ -78,7 +79,6 @@ import {
   selectPersistedPlanForSession,
   type StreamingPlanEntry,
 } from "@/stores/v2-streaming-store";
-import { StreamingAgentBubble } from "./StreamingAgentBubble";
 import { uploadAttachment } from "@/lib/attachment-upload";
 import { loadSessionActiveModel } from "@/lib/session-active-model";
 import { ensureSessionLiveSubscribed } from "@/lib/session-live-subscriptions";
@@ -536,21 +536,6 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     [activeSessionId, engagedUiEntries, removeAgentForSession, addAgentForSession],
   );
 
-  const activeStreamingAgents = React.useMemo(() => {
-    const seen = new Set<string>();
-    const agents: Array<{ actorId: string; displayName?: string }> = [];
-    for (const entry of v2Streams) {
-      if (!isStreamInterruptible(entry) || seen.has(entry.actorId)) continue;
-      seen.add(entry.actorId);
-      const engaged = engagedAgents.find((agent) => agent.id === entry.actorId);
-      agents.push({
-        actorId: entry.actorId,
-        displayName: engaged?.displayName,
-      });
-    }
-    return agents;
-  }, [v2Streams, engagedAgents]);
-
   // Existing sessions can be reopened after a reload with no in-memory
   // engaged agents selected. Solo sessions (2 participants: 1 human + 1 agent)
   // auto-engage the agent pill so sends still trigger a reply.
@@ -795,6 +780,26 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     () => adaptTeamclawMessages(displayMessagesRaw),
     [displayMessagesRaw],
   );
+
+  const activeStreamingAgents = React.useMemo(() => {
+    const seen = new Set<string>();
+    const agents: Array<{
+      actorId: string;
+      displayName?: string;
+      entry: (typeof v2Streams)[number];
+    }> = [];
+    for (const entry of v2Streams) {
+      if (!isStreamInterruptible(entry) || seen.has(entry.actorId)) continue;
+      seen.add(entry.actorId);
+      const engaged = engagedAgents.find((agent) => agent.id === entry.actorId);
+      agents.push({
+        actorId: entry.actorId,
+        displayName: engaged?.displayName,
+        entry,
+      });
+    }
+    return agents;
+  }, [v2Streams, engagedAgents]);
 
   const SESSION_FADE_MS = 150;
 
@@ -1479,6 +1484,10 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
               useSessionMessageStore.getState().messages[sid]?.length ?? 0,
           });
 
+          if (agentRuntimeIdsForSend.length > 0) {
+            notePendingAgentReplyTo(sid, agentRuntimeIdsForSend, messageId);
+          }
+
           // 2. Enqueue to outbox — status dot beside the bubble tracks
           //    pending/inFlight/delivered. Network + runtime work continue
           //    asynchronously after the bubble is visible.
@@ -1983,8 +1992,8 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
       ? error
       : null;
 
-  // Keep inactive current-turn streams visible until releaseActorAfterPersist
-  // moves artifacts into the persisted ChatMessage (see StreamingAgentBubble).
+  // Live streams render in Composer Live Dock. Keep displayV2Streams for
+  // timeline diagnostics only (inactive/archived still live in the store).
   const v2DisplayRevision = useV2StreamingStore((s) =>
     displaySessionId ? (s.revisionBySession[displaySessionId] ?? 0) : 0,
   );
@@ -2042,19 +2051,9 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     displaySessionId ? (s.bySession[displaySessionId]?.length ?? 0) > 0 : false,
   );
   const messageBottomContent = !isViewingChild &&
-    (displayV2Streams.length > 0 || visibleSessionError || visibleError || hasSessionNotices) ? (
+    (visibleSessionError || visibleError || hasSessionNotices) ? (
     <>
       {hasSessionNotices ? <SessionNoticeList sessionId={displaySessionId} /> : null}
-      {displayV2Streams.map((entry) => (
-        <StreamingAgentBubble
-          key={
-            "archiveId" in entry && entry.archiveId
-              ? `archived::${entry.archiveId}`
-              : `current::${entry.actorId}::${entry.streamId}`
-          }
-          entry={entry}
-        />
-      ))}
       {visibleSessionError ? (
         <SessionErrorAlert
           error={visibleSessionError}

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -1484,13 +1484,11 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
               useSessionMessageStore.getState().messages[sid]?.length ?? 0,
           });
 
-          if (agentRuntimeIdsForSend.length > 0) {
-            notePendingAgentReplyTo(sid, agentRuntimeIdsForSend, messageId);
-          }
-
           // 2. Enqueue to outbox — status dot beside the bubble tracks
           //    pending/inFlight/delivered. Network + runtime work continue
           //    asynchronously after the bubble is visible.
+          //    notePendingAgentReplyTo only after enqueue succeeds so a failed
+          //    send cannot leave stale FIFO ids for a later agent turn.
           let workspaceIdHint: string | null = null;
           if (agentRuntimeIdsForSend.length > 0 && teamIdForSend) {
             let localDaemonActorId: string | null = null;
@@ -1534,6 +1532,9 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
             teamId: teamIdForSend,
             messageId,
           });
+          if (agentRuntimeIdsForSend.length > 0) {
+            notePendingAgentReplyTo(sid, agentRuntimeIdsForSend, messageId);
+          }
 
           bumpSessionListLastMessage(sid, outgoing, { at: new Date().toISOString() });
 

--- a/packages/app/src/components/chat/ComposerStack.tsx
+++ b/packages/app/src/components/chat/ComposerStack.tsx
@@ -1,15 +1,17 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { Square } from "lucide-react";
+import { ChevronDown, Maximize2, Minimize2, Square } from "lucide-react";
 import { actorAvatarColor } from "@/lib/actor-color";
 import { resolveApprovalAnchorActorId } from "@/lib/permission-actor";
 import { useActorDisplayName } from "@/hooks/useActorDisplayName";
 import { cn } from "@/lib/utils";
 import type { Todo } from "@/stores/session-types";
 import type { QueuedMessage } from "@/stores/session";
+import type { AgentStreamEntry } from "@/stores/v2-streaming-store";
 import { PermissionApprovalPanel } from "./PermissionApprovalPanel";
 import { PermissionWaitingBanner } from "./PermissionWaitingBanner";
 import { ComposerPlanSlot } from "./ComposerPlanSlot";
+import { StreamingAgentBubble } from "./StreamingAgentBubble";
 import {
   composerGlassChildClass,
   composerGlassFillClass,
@@ -23,7 +25,57 @@ import { usePendingPermissionsQueue } from "./use-pending-permissions-queue";
 export type ActiveStreamingAgent = {
   actorId: string;
   displayName?: string;
+  /** Live stream entry for expandable dock panel. */
+  entry?: AgentStreamEntry;
 };
+
+const LIVE_INLINE_SCROLL_CLASS =
+  "max-h-[220px] overflow-y-auto border-t border-border/50 bg-gradient-to-b from-[#fbf9f4] to-white px-3 py-2.5";
+
+const LIVE_FLOAT_SCROLL_CLASS =
+  "min-h-0 flex-1 overflow-y-auto bg-gradient-to-b from-[#fbf9f4] to-white px-3 py-2.5";
+
+function useLiveScrollFollow(active: boolean, entry: AgentStreamEntry | undefined) {
+  const liveScrollRef = React.useRef<HTMLDivElement>(null);
+  const stickToBottomRef = React.useRef(true);
+
+  const scrollLiveToBottom = React.useCallback(() => {
+    const el = liveScrollRef.current;
+    if (!el) return;
+    const targetTop = Math.max(0, el.scrollHeight - el.clientHeight);
+    if (Math.abs(el.scrollTop - targetTop) < 2) return;
+    el.scrollTop = targetTop;
+  }, []);
+
+  React.useEffect(() => {
+    if (!active || !entry?.active) {
+      stickToBottomRef.current = true;
+    }
+  }, [active, entry?.active, entry?.actorId]);
+
+  React.useEffect(() => {
+    if (!active || !entry || !stickToBottomRef.current) return;
+    const frame = requestAnimationFrame(() => scrollLiveToBottom());
+    return () => cancelAnimationFrame(frame);
+  }, [
+    active,
+    entry?.lastUpdate,
+    entry?.parts.length,
+    entry?.outputText.length,
+    entry?.thinkingText.length,
+    entry?.toolCalls.length,
+    scrollLiveToBottom,
+  ]);
+
+  const handleLiveScroll = React.useCallback(() => {
+    const el = liveScrollRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickToBottomRef.current = distanceFromBottom < 24;
+  }, []);
+
+  return { liveScrollRef, handleLiveScroll };
+}
 
 function ComposerAgentStrip({
   actorId,
@@ -33,6 +85,11 @@ function ComposerAgentStrip({
   onInterrupt,
   roundsTop = false,
   embeddedInGlass = false,
+  expanded,
+  enlarged,
+  onToggleExpand,
+  onToggleEnlarge,
+  entry,
 }: {
   actorId: string;
   displayNameHint?: string;
@@ -41,63 +98,292 @@ function ComposerAgentStrip({
   onInterrupt: (agentId: string) => void;
   roundsTop?: boolean;
   embeddedInGlass?: boolean;
+  expanded: boolean;
+  enlarged: boolean;
+  onToggleExpand: () => void;
+  onToggleEnlarge: () => void;
+  entry?: AgentStreamEntry;
 }) {
   const { t } = useTranslation();
   const resolvedName = useActorDisplayName(actorId);
   const displayName = displayNameHint || resolvedName || actorId.slice(0, 8);
   const colors = actorAvatarColor(actorId);
   const initial = displayName.trim().charAt(0).toUpperCase() || "A";
+  const canExpand = Boolean(entry);
+  const showInlinePanel = expanded && canExpand && !enlarged;
+  const { liveScrollRef, handleLiveScroll } = useLiveScrollFollow(showInlinePanel, entry);
+
+  const expandClasses = cn(
+    "grid transition-[grid-template-rows] duration-[360ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+    showInlinePanel ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+  );
 
   return (
     <div
       className={cn(
-        "box-border flex min-h-9 w-full items-center gap-2.5 px-3.5 py-[7px]",
+        "box-border w-full",
         embeddedInGlass ? composerGlassChildClass : composerGlassSurfaceClass,
         composerStackRowDividerClass,
         !embeddedInGlass && roundsTop && "overflow-hidden rounded-t-[14px]",
       )}
       data-testid="streaming-agent-row"
       data-actor-id={actorId}
+      data-expanded={expanded && canExpand ? "true" : "false"}
+      data-enlarged={enlarged ? "true" : "false"}
     >
-      <span
-        className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-md text-[10px] font-semibold text-white ring-[1.5px] ring-coral"
-        style={{ backgroundColor: colors.bg }}
-        aria-hidden
+      <div
+        className={cn(
+          "box-border flex min-h-9 w-full items-center gap-1 px-2 py-[7px] pr-3.5",
+          enlarged && "bg-[#fdf0ed]",
+        )}
       >
-        {initial}
-      </span>
-      <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-2">
-        <span className="text-[12.5px] font-semibold text-foreground">{displayName}</span>
-        <span
-          className={cn(
-            "text-[11px] text-faint",
-            !waitingForApproval && "text-muted-foreground",
-          )}
-        >
-          {waitingForApproval ? (
-            t("chat.streamingBar.waitingApproval", "Waiting for your approval…")
-          ) : (
-            <>
-              {t("chat.streamingBar.streamingActive", "正在回复")}
+        {canExpand ? (
+          <button
+            type="button"
+            data-testid="streaming-agent-strip"
+            className="box-border flex min-h-9 min-w-0 flex-1 items-center gap-2.5 rounded-lg px-1.5 text-left hover:bg-black/[0.02]"
+            aria-expanded={expanded}
+            aria-label={
+              expanded
+                ? t("chat.streamingBar.collapse", "收起")
+                : t("chat.streamingBar.expand", "展开")
+            }
+            onClick={onToggleExpand}
+          >
+            <ChevronDown
+              className={cn(
+                "h-3.5 w-3.5 shrink-0 text-faint transition-transform duration-200",
+                expanded && "rotate-180 text-coral",
+              )}
+              aria-hidden
+            />
+            <span
+              className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-md text-[10px] font-semibold text-white ring-[1.5px] ring-coral"
+              style={{ backgroundColor: colors.bg }}
+              aria-hidden
+            >
+              {initial}
+            </span>
+            <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-2">
+              <span className="text-[12.5px] font-semibold text-foreground">
+                {displayName}
+              </span>
               <span
-                className="ml-1.5 inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-coral align-middle"
-                aria-hidden
-              />
-            </>
-          )}
-        </span>
+                className={cn(
+                  "text-[11px] text-faint",
+                  !waitingForApproval && "text-muted-foreground",
+                )}
+              >
+                {waitingForApproval ? (
+                  t("chat.streamingBar.waitingApproval", "Waiting for your approval…")
+                ) : (
+                  <>
+                    {t("chat.streamingBar.streamingActive", "正在回复")}
+                    <span
+                      className="ml-1.5 inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-coral align-middle"
+                      aria-hidden
+                    />
+                  </>
+                )}
+              </span>
+            </div>
+          </button>
+        ) : (
+          <div
+            data-testid="streaming-agent-strip"
+            className="box-border flex min-h-9 min-w-0 flex-1 items-center gap-2.5 px-1.5"
+          >
+            <span
+              className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-md text-[10px] font-semibold text-white ring-[1.5px] ring-coral"
+              style={{ backgroundColor: colors.bg }}
+              aria-hidden
+            >
+              {initial}
+            </span>
+            <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-2">
+              <span className="text-[12.5px] font-semibold text-foreground">
+                {displayName}
+              </span>
+              <span
+                className={cn(
+                  "text-[11px] text-faint",
+                  !waitingForApproval && "text-muted-foreground",
+                )}
+              >
+                {waitingForApproval ? (
+                  t("chat.streamingBar.waitingApproval", "Waiting for your approval…")
+                ) : (
+                  <>
+                    {t("chat.streamingBar.streamingActive", "正在回复")}
+                    <span
+                      className="ml-1.5 inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-coral align-middle"
+                      aria-hidden
+                    />
+                  </>
+                )}
+              </span>
+            </div>
+          </div>
+        )}
+        {canExpand && expanded ? (
+          <button
+            type="button"
+            data-testid="streaming-agent-enlarge"
+            className={cn(
+              "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border-0 bg-transparent text-faint transition-colors hover:bg-selected hover:text-foreground",
+              enlarged && "text-coral hover:bg-coral/10 hover:text-coral",
+            )}
+            aria-label={
+              enlarged
+                ? t("chat.streamingBar.restore", "还原")
+                : t("chat.streamingBar.enlarge", "放大")
+            }
+            aria-pressed={enlarged}
+            onClick={onToggleEnlarge}
+          >
+            {enlarged ? (
+              <Minimize2 className="h-3.5 w-3.5" />
+            ) : (
+              <Maximize2 className="h-3.5 w-3.5" />
+            )}
+          </button>
+        ) : null}
+        {showInterrupt ? (
+          <button
+            type="button"
+            data-testid="streaming-agent-stop"
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-coral/15 text-coral transition-colors hover:bg-coral/25"
+            aria-label={t("chat.interruptAgent", "Interrupt {{name}}", {
+              name: displayName,
+            })}
+            onClick={() => onInterrupt(actorId)}
+          >
+            <Square className="h-2.5 w-2.5 fill-current" />
+          </button>
+        ) : null}
       </div>
-      {showInterrupt ? (
-        <button
-          type="button"
-          data-testid="streaming-agent-stop"
-          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-coral/15 text-coral transition-colors hover:bg-coral/25"
-          aria-label={t("chat.interruptAgent", "Interrupt {{name}}", { name: displayName })}
-          onClick={() => onInterrupt(actorId)}
+
+      <div
+        className={expandClasses}
+        data-testid="streaming-agent-live-panel"
+        data-open={showInlinePanel ? "true" : "false"}
+      >
+        <div className="min-h-0 overflow-hidden">
+          {entry && showInlinePanel ? (
+            <div
+              ref={liveScrollRef}
+              onScroll={handleLiveScroll}
+              data-testid="streaming-agent-live-scroll"
+              className={LIVE_INLINE_SCROLL_CLASS}
+            >
+              <StreamingAgentBubble entry={entry} variant="dock" />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LiveEnlargeFloat({
+  agent,
+  onRestore,
+  onInterrupt,
+  showInterrupt,
+}: {
+  agent: ActiveStreamingAgent;
+  onRestore: () => void;
+  onInterrupt?: (agentId: string) => void;
+  showInterrupt: boolean;
+}) {
+  const { t } = useTranslation();
+  const entry = agent.entry!;
+  const resolvedName = useActorDisplayName(agent.actorId);
+  const displayName =
+    agent.displayName || resolvedName || agent.actorId.slice(0, 8);
+  const colors = actorAvatarColor(agent.actorId);
+  const initial = displayName.trim().charAt(0).toUpperCase() || "A";
+  const { liveScrollRef, handleLiveScroll } = useLiveScrollFollow(true, entry);
+  const restoreRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    restoreRef.current?.focus();
+  }, []);
+
+  React.useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      onRestore();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onRestore]);
+
+  return (
+    <div
+      data-testid="streaming-agent-live-float"
+      className="pointer-events-auto absolute inset-x-0 bottom-full z-30 mb-2 flex h-[min(620px,72vh)] max-h-[min(620px,72vh)] flex-col overflow-hidden rounded-[14px] border border-border bg-paper shadow-[0_22px_48px_-18px_rgba(20,20,15,0.28)]"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("chat.streamingBar.enlarge", "放大")}
+    >
+      <div className="flex shrink-0 items-center gap-2.5 border-b border-border/50 px-3.5 py-[9px]">
+        <ChevronDown
+          className="h-3.5 w-3.5 shrink-0 rotate-180 text-coral"
+          aria-hidden
+        />
+        <span
+          className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-md text-[10px] font-semibold text-white ring-[1.5px] ring-coral"
+          style={{ backgroundColor: colors.bg }}
+          aria-hidden
         >
-          <Square className="h-2.5 w-2.5 fill-current" />
+          {initial}
+        </span>
+        <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-2">
+          <span className="text-[12.5px] font-semibold text-foreground">
+            {displayName}
+          </span>
+          <span className="text-[11px] text-muted-foreground">
+            {t("chat.streamingBar.streamingActive", "正在回复")}
+            <span
+              className="ml-1.5 inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-coral align-middle"
+              aria-hidden
+            />
+          </span>
+        </div>
+        <button
+          ref={restoreRef}
+          type="button"
+          data-testid="streaming-agent-float-restore"
+          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border-0 bg-transparent text-coral transition-colors hover:bg-coral/10"
+          aria-label={t("chat.streamingBar.restore", "还原")}
+          onClick={onRestore}
+        >
+          <Minimize2 className="h-3.5 w-3.5" />
         </button>
-      ) : null}
+        {showInterrupt && onInterrupt ? (
+          <button
+            type="button"
+            data-testid="streaming-agent-float-stop"
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-coral/15 text-coral transition-colors hover:bg-coral/25"
+            aria-label={t("chat.interruptAgent", "Interrupt {{name}}", {
+              name: displayName,
+            })}
+            onClick={() => onInterrupt(agent.actorId)}
+          >
+            <Square className="h-2.5 w-2.5 fill-current" />
+          </button>
+        ) : null}
+      </div>
+      <div
+        ref={liveScrollRef}
+        onScroll={handleLiveScroll}
+        data-testid="streaming-agent-live-scroll"
+        className={LIVE_FLOAT_SCROLL_CLASS}
+      >
+        <StreamingAgentBubble entry={entry} variant="dock" />
+      </div>
     </div>
   );
 }
@@ -132,6 +418,83 @@ export function ComposerStack({
   const streamingActorIds = React.useMemo(
     () => agents.map((agent) => agent.actorId),
     [agents],
+  );
+
+  const newestActorId = React.useMemo(() => {
+    let bestId: string | null = null;
+    let bestTs = -1;
+    for (const agent of agents) {
+      const ts = agent.entry?.lastUpdate ?? 0;
+      if (ts >= bestTs) {
+        bestTs = ts;
+        bestId = agent.actorId;
+      }
+    }
+    return bestId ?? agents[0]?.actorId ?? null;
+  }, [agents]);
+
+  const [expandedActorId, setExpandedActorId] = React.useState<string | null>(
+    null,
+  );
+  const [enlargedActorId, setEnlargedActorId] = React.useState<string | null>(
+    null,
+  );
+  const [userPinnedExpand, setUserPinnedExpand] = React.useState(false);
+
+  React.useEffect(() => {
+    const ids = new Set(agents.map((agent) => agent.actorId));
+    if (agents.length === 0) {
+      setExpandedActorId(null);
+      setEnlargedActorId(null);
+      setUserPinnedExpand(false);
+      return;
+    }
+    if (expandedActorId && !ids.has(expandedActorId)) {
+      setExpandedActorId(newestActorId);
+      setEnlargedActorId(null);
+      setUserPinnedExpand(false);
+      return;
+    }
+    if (enlargedActorId && !ids.has(enlargedActorId)) {
+      setEnlargedActorId(null);
+    }
+    if (!userPinnedExpand) {
+      setExpandedActorId(newestActorId);
+    } else if (expandedActorId === null && newestActorId) {
+      // User closed all panels — stay closed until they open one.
+    }
+  }, [agents, newestActorId, expandedActorId, enlargedActorId, userPinnedExpand]);
+
+  const toggleExpand = React.useCallback((actorId: string) => {
+    setUserPinnedExpand(true);
+    setExpandedActorId((prev) => {
+      if (prev === actorId) {
+        setEnlargedActorId(null);
+        return null;
+      }
+      setEnlargedActorId(null);
+      return actorId;
+    });
+  }, []);
+
+  const toggleEnlarge = React.useCallback((actorId: string) => {
+    setUserPinnedExpand(true);
+    setExpandedActorId(actorId);
+    setEnlargedActorId((prev) => (prev === actorId ? null : actorId));
+  }, []);
+
+  const restoreEnlarge = React.useCallback(() => {
+    setEnlargedActorId(null);
+  }, []);
+
+  const enlargedAgent = React.useMemo(
+    () =>
+      enlargedActorId
+        ? agents.find(
+            (agent) => agent.actorId === enlargedActorId && Boolean(agent.entry),
+          )
+        : undefined,
+    [agents, enlargedActorId],
   );
 
   const anchorActorId = React.useMemo(
@@ -170,7 +533,19 @@ export function ComposerStack({
   );
 
   return (
-    <div data-testid="composer-stack" className={composerStackShellClass}>
+    <div
+      data-testid="composer-stack"
+      className={cn(composerStackShellClass, "relative")}
+    >
+      {enlargedAgent ? (
+        <LiveEnlargeFloat
+          agent={enlargedAgent}
+          onRestore={restoreEnlarge}
+          onInterrupt={onInterrupt}
+          showInterrupt={Boolean(onInterrupt) && anchorActorId !== enlargedAgent.actorId}
+        />
+      ) : null}
+
       {showTopChrome ? (
         <div className="box-border w-full overflow-hidden rounded-t-[14px]">
           {showAgentSection ? (
@@ -234,6 +609,11 @@ export function ComposerStack({
                           onInterrupt={onInterrupt ?? (() => {})}
                           roundsTop={!hasPermissionChrome && index === 0}
                           embeddedInGlass={hasPermissionChrome}
+                          expanded={expandedActorId === agent.actorId}
+                          enlarged={enlargedActorId === agent.actorId}
+                          onToggleExpand={() => toggleExpand(agent.actorId)}
+                          onToggleEnlarge={() => toggleEnlarge(agent.actorId)}
+                          entry={agent.entry}
                         />
                       );
                     })

--- a/packages/app/src/components/chat/ComposerStack.tsx
+++ b/packages/app/src/components/chat/ComposerStack.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import type { Todo } from "@/stores/session-types";
 import type { QueuedMessage } from "@/stores/session";
 import { PermissionApprovalPanel } from "./PermissionApprovalPanel";
+import { PermissionWaitingBanner } from "./PermissionWaitingBanner";
 import { ComposerPlanSlot } from "./ComposerPlanSlot";
 import {
   composerGlassChildClass,
@@ -123,6 +124,7 @@ export function ComposerStack({
     sessionPermissionMode,
     currentEntry,
     queuedCount,
+    waitingRequesterActorId,
     onReplyStart,
     onReplyRollback,
   } = usePendingPermissionsQueue();
@@ -142,20 +144,27 @@ export function ComposerStack({
     agents.length === 0 &&
     sessionPermissionMode !== "fullAccess";
 
+  const showWaitingOnly =
+    currentEntry === null &&
+    waitingRequesterActorId !== null &&
+    agents.length === 0;
+
   const hasApproval = currentEntry !== null;
-  const showAgentSection = agents.length > 0 || showApprovalOnly;
+  const hasPermissionChrome =
+    hasApproval || waitingRequesterActorId !== null;
+  const showAgentSection = agents.length > 0 || showApprovalOnly || showWaitingOnly;
   const showPlan = todos.length > 0 || queue.length > 0;
   const showTopChrome = showAgentSection || showPlan;
   const planRoundsTop = showPlan && !showAgentSection;
 
   const approvalExpandClasses = cn(
     "grid transition-[grid-template-rows] duration-[400ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-    hasApproval ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+    hasPermissionChrome ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
   );
 
   const approvalPanelMotionClasses = cn(
     "box-border w-full origin-bottom transition-[transform,opacity] duration-[380ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-    hasApproval
+    hasPermissionChrome
       ? "translate-y-0 opacity-100 delay-75"
       : "translate-y-3 opacity-0 motion-safe:delay-0",
   );
@@ -170,18 +179,18 @@ export function ComposerStack({
                 data-testid="streaming-agent-shell"
                 className={cn(
                   "box-border w-full overflow-hidden",
-                  hasApproval && "rounded-t-[14px]",
-                  hasApproval && composerGlassFillClass,
+                  hasPermissionChrome && "rounded-t-[14px]",
+                  hasPermissionChrome && composerGlassFillClass,
                 )}
               >
                 <div
                   data-testid="composer-approval-chrome"
-                  className={cn(hasApproval && "rounded-t-[14px]")}
+                  className={cn(hasPermissionChrome && "rounded-t-[14px]")}
                 >
                   <div
                     className={approvalExpandClasses}
                     data-testid="pending-permission-expand"
-                    data-open={hasApproval ? "true" : "false"}
+                    data-open={hasPermissionChrome ? "true" : "false"}
                   >
                     <div className="min-h-0 overflow-hidden">
                       {currentEntry ? (
@@ -197,12 +206,21 @@ export function ComposerStack({
                             composerStackRowDividerClass,
                           )}
                         />
+                      ) : waitingRequesterActorId ? (
+                        <PermissionWaitingBanner
+                          requesterActorId={waitingRequesterActorId}
+                          appearance="glass"
+                          className={cn(
+                            approvalPanelMotionClasses,
+                            composerStackRowDividerClass,
+                          )}
+                        />
                       ) : null}
                     </div>
                   </div>
                 </div>
 
-                {!showApprovalOnly
+                {!showApprovalOnly && !showWaitingOnly
                   ? agents.map((agent, index) => {
                       const isAnchor =
                         anchorActorId === agent.actorId && currentEntry !== null;
@@ -214,8 +232,8 @@ export function ComposerStack({
                           waitingForApproval={isAnchor}
                           showInterrupt={Boolean(onInterrupt) && !isAnchor}
                           onInterrupt={onInterrupt ?? (() => {})}
-                          roundsTop={!hasApproval && index === 0}
-                          embeddedInGlass={hasApproval}
+                          roundsTop={!hasPermissionChrome && index === 0}
+                          embeddedInGlass={hasPermissionChrome}
                         />
                       );
                     })

--- a/packages/app/src/components/chat/MessageList.tsx
+++ b/packages/app/src/components/chat/MessageList.tsx
@@ -195,6 +195,15 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
       return info;
     }, [renderedMessages]);
 
+    // Full timeline — parent of a quote may sit above the visible window.
+    const messagesById = React.useMemo(() => {
+      const map = new Map<string, Message>();
+      for (const message of messages) {
+        map.set(message.id, message);
+      }
+      return map;
+    }, [messages]);
+
     // ── Local state ──────────────────────────────────────────────────────
     const [showScrollButton, setShowScrollButton] = React.useState(false);
     const [inputAreaHeight, setInputAreaHeight] = React.useState(DEFAULT_INPUT_AREA_HEIGHT);
@@ -560,6 +569,11 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
                                   tokenGroupInfo={tokenGroupInfo.get(
                                     message.id,
                                   )}
+                                  replyToMessage={
+                                    message.replyToMessageId
+                                      ? messagesById.get(message.replyToMessageId) ?? null
+                                      : null
+                                  }
                                 />
                               </ErrorBoundary>
                             </div>
@@ -587,6 +601,11 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
                                 index === lastCompletedAssistantIdx
                               }
                               tokenGroupInfo={tokenGroupInfo.get(message.id)}
+                              replyToMessage={
+                                message.replyToMessageId
+                                  ? messagesById.get(message.replyToMessageId) ?? null
+                                  : null
+                              }
                             />
                           </ErrorBoundary>
                         </div>

--- a/packages/app/src/components/chat/PermissionWaitingBanner.tsx
+++ b/packages/app/src/components/chat/PermissionWaitingBanner.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { useActorDisplayName } from "@/hooks/useActorDisplayName";
+import { cn } from "@/lib/utils";
+import { composerGlassChildClass } from "./composer-glass";
+
+/**
+ * Read-only strip for collab bystanders while another member’s approval
+ * is outstanding (Phase 2.5). No Allow / Deny / Always Allow.
+ */
+export function PermissionWaitingBanner({
+  requesterActorId,
+  appearance = "card",
+  className,
+}: {
+  requesterActorId: string;
+  appearance?: "card" | "glass";
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const resolvedName = useActorDisplayName(requesterActorId);
+  const displayName =
+    resolvedName?.trim() || requesterActorId.trim().slice(0, 8) || "…";
+
+  return (
+    <section
+      data-testid="pending-permission-waiting"
+      aria-live="polite"
+      className={cn(
+        "px-3.5 py-2.5",
+        appearance === "glass"
+          ? composerGlassChildClass
+          : "border-t border-border-soft bg-gradient-to-b from-[#fffdfb] to-paper dark:from-card dark:to-card",
+        className,
+      )}
+    >
+      <p className="text-[12.5px] font-medium text-ink-2">
+        {t("chat.permissionCard.waitingForApproval", "等待 {{name}} 批准", {
+          name: displayName,
+        })}
+      </p>
+    </section>
+  );
+}

--- a/packages/app/src/components/chat/StreamingAgentBubble.tsx
+++ b/packages/app/src/components/chat/StreamingAgentBubble.tsx
@@ -130,7 +130,8 @@ export const StreamingAgentBubble = React.memo(function StreamingAgentBubble({
   variant = "default",
 }: {
   entry: AgentStreamEntry;
-  variant?: "default" | "nested";
+  /** `dock` hides ActorLabel — Composer agent strip already shows identity. */
+  variant?: "default" | "nested" | "dock";
 }) {
   // After finalize (active=false), the persisted AGENT_REPLY ChatMessage
   // takes over the reply text — suppress outputText here to avoid showing
@@ -140,6 +141,7 @@ export const StreamingAgentBubble = React.memo(function StreamingAgentBubble({
   // Plan entries are NOT rendered here — they surface in the TodoList dock
   // above the prompt input (v1 style).
   const isNested = variant === "nested";
+  const isDock = variant === "dock";
   const skipToolNames = React.useMemo(
     () => (isNested ? new Set(["task"]) : undefined),
     [isNested],
@@ -204,7 +206,7 @@ export const StreamingAgentBubble = React.memo(function StreamingAgentBubble({
     }
   }, [entry.active, awaitingNextEvent, hasTranscriptText]);
 
-  // Nested subagent streams already sit inside TaskToolCard — skip idle dots there.
+  // Nested/dock: nested skips idle dots (TaskToolCard); dock keeps dots for live feel.
   const showStreamLoadingDots = !isNested;
   // Align with agent bar on statusChange ACTIVE — show immediately, no idle debounce.
   const showPlanningInitial =
@@ -230,14 +232,14 @@ export const StreamingAgentBubble = React.memo(function StreamingAgentBubble({
 
   return (
     <div
-      className="mb-1.5"
+      className={isDock ? "mb-0" : "mb-1.5"}
       data-testid="v2-streaming-agent"
       data-session-id={entry.sessionId}
       data-actor-id={entry.actorId}
       data-active={entry.active ? "true" : "false"}
       data-variant={variant}
     >
-      {!isNested ? (
+      {!isNested && !isDock ? (
         <ActorLabel senderActorId={entry.actorId} isUser={false} />
       ) : null}
       <Message from="assistant">

--- a/packages/app/src/components/chat/__tests__/AgentReplyQuote.test.tsx
+++ b/packages/app/src/components/chat/__tests__/AgentReplyQuote.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  AgentReplyQuote,
+  formatReplyQuoteSnippet,
+  parseReplyQuoteContent,
+} from "../AgentReplyQuote";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string, options?: Record<string, unknown>) => {
+      const template = fallback ?? key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_, token: string) =>
+        String(options?.[token] ?? `{{${token}}}`),
+      );
+    },
+  }),
+}));
+
+describe("AgentReplyQuote", () => {
+  it("renders soft-strip with inline agent pill and jumps on click", () => {
+    const onJump = vi.fn();
+    render(
+      <AgentReplyQuote
+        authorName="你"
+        content="[Mentioned agents: JJJJ]\nsleep10"
+        onJump={onJump}
+      />,
+    );
+    const quote = screen.getByTestId("agent-reply-quote");
+    expect(quote.textContent).toContain("你");
+    expect(quote.textContent).toContain("sleep10");
+    expect(quote.textContent).not.toContain("[Mentioned agents:");
+    const pill = screen.getByTestId("agent-reply-quote-pill");
+    expect(pill.textContent).toContain("AGENT");
+    expect(pill.textContent).toContain("@JJJJ");
+    fireEvent.click(quote);
+    expect(onJump).toHaveBeenCalledOnce();
+  });
+
+  it("parses mentioned agents into pills and strips body noise", () => {
+    expect(
+      parseReplyQuoteContent("[Mentioned agents: JJJJ, Research]\nsleep10"),
+    ).toEqual({
+      agentNames: ["JJJJ", "Research"],
+      body: "sleep10",
+    });
+    expect(parseReplyQuoteContent("@JJJJ sleep10")).toEqual({
+      agentNames: [],
+      body: "sleep10",
+    });
+    expect(formatReplyQuoteSnippet("a".repeat(100)).endsWith("…")).toBe(true);
+  });
+});

--- a/packages/app/src/components/chat/__tests__/ChatMessage-streaming.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ChatMessage-streaming.test.tsx
@@ -280,16 +280,28 @@ describe('ChatMessage streaming typewriter', () => {
     });
 
     const { container } = render(<ChatMessage message={message} />);
-    const text = container.textContent ?? '';
+    let text = container.textContent ?? '';
     expect(text).not.toContain('Plan first.');
     expect(text).not.toContain('Plan second.');
     expect(text).not.toContain('Plan third.');
-    expect(text).toContain('Before tool.');
+    // Mid-turn narration lives inside collapsed「处理过程」.
+    expect(text).not.toContain('Before tool.');
     expect(text).toContain('After tool.');
 
-    const thinkingButtons = Array.from(container.querySelectorAll('button')).filter((button) =>
-      button.textContent?.includes('Thinking Process'),
+    const processTrigger = container.querySelector(
+      '[data-testid="agent-process-collapsible"] button',
     );
+    expect(processTrigger).toBeTruthy();
+    fireEvent.click(processTrigger!);
+
+    text = container.textContent ?? '';
+    expect(text).toContain('Before tool.');
+    expect(text).not.toContain('Plan first.');
+
+    const thinkingButtons = Array.from(container.querySelectorAll('button')).filter((button) => {
+      const label = button.textContent ?? '';
+      return label.includes('Thinking Process') || label.includes('思考过程');
+    });
     expect(thinkingButtons).toHaveLength(3);
 
     fireEvent.click(thinkingButtons[0]);

--- a/packages/app/src/components/chat/__tests__/ComposerStack.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ComposerStack.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { useSessionStore } from "@/stores/session";
 import { resetSessionPermissionModesForTests } from "@/lib/session-permission-mode";
 import { ComposerStack } from "../ComposerStack";
@@ -18,6 +18,32 @@ vi.mock("react-i18next", () => ({
 vi.mock("@/hooks/useActorDisplayName", () => ({
   useActorDisplayName: (actorId: string) => `Agent-${actorId}`,
 }));
+
+vi.mock("../StreamingAgentBubble", () => ({
+  StreamingAgentBubble: ({ entry, variant }: { entry: { actorId: string }; variant?: string }) => (
+    <div data-testid="v2-streaming-agent" data-variant={variant} data-actor-id={entry.actorId}>
+      live
+    </div>
+  ),
+}));
+
+function makeEntry(actorId: string, lastUpdate: number) {
+  return {
+    sessionId: "sess-1",
+    actorId,
+    outputText: "hello",
+    thinkingText: "",
+    parts: [],
+    toolCalls: [],
+    planEntries: [],
+    pendingPermissionsByRequestId: {},
+    errorMessage: null,
+    errorDetails: null,
+    lastUpdate,
+    active: true,
+    streamId: `sess-1::${actorId}::1`,
+  };
+}
 
 describe("ComposerStack", () => {
   beforeEach(() => {
@@ -70,5 +96,128 @@ describe("ComposerStack", () => {
 
     expect(screen.getByTestId("pending-permission-card")).toBeTruthy();
     expect(screen.queryByTestId("streaming-agent-stop")).toBeNull();
+  });
+
+  it("expands at most one live panel and renders dock bubble", () => {
+    render(
+      <ComposerStack
+        agents={[
+          { actorId: "a1", displayName: "A1", entry: makeEntry("a1", 1) as never },
+          { actorId: "a2", displayName: "A2", entry: makeEntry("a2", 2) as never },
+        ]}
+        onInterrupt={vi.fn()}
+      >
+        <div>input</div>
+      </ComposerStack>,
+    );
+
+    const rows = screen.getAllByTestId("streaming-agent-row");
+    expect(rows).toHaveLength(2);
+    // Newest (a2) expanded by default
+    expect(rows[1]?.getAttribute("data-expanded")).toBe("true");
+    expect(rows[0]?.getAttribute("data-expanded")).toBe("false");
+    expect(screen.getByTestId("v2-streaming-agent").getAttribute("data-variant")).toBe("dock");
+
+    const strips = screen.getAllByTestId("streaming-agent-strip");
+    fireEvent.click(strips[0]!);
+    expect(screen.getAllByTestId("streaming-agent-row")[0]?.getAttribute("data-expanded")).toBe(
+      "true",
+    );
+    expect(screen.getAllByTestId("streaming-agent-row")[1]?.getAttribute("data-expanded")).toBe(
+      "false",
+    );
+  });
+
+  it("scrolls the live panel to bottom as stream content grows", async () => {
+    const entry = makeEntry("a1", 1) as never;
+    const { rerender } = render(
+      <ComposerStack
+        agents={[{ actorId: "a1", displayName: "A1", entry }]}
+        onInterrupt={vi.fn()}
+      >
+        <div>input</div>
+      </ComposerStack>,
+    );
+
+    const scrollEl = screen.getByTestId("streaming-agent-live-scroll");
+    Object.defineProperty(scrollEl, "clientHeight", { configurable: true, value: 100 });
+    Object.defineProperty(scrollEl, "scrollHeight", { configurable: true, value: 400 });
+    scrollEl.scrollTop = 0;
+
+    const taller = { ...makeEntry("a1", 2), outputText: "hello\n".repeat(40) } as never;
+    rerender(
+      <ComposerStack
+        agents={[{ actorId: "a1", displayName: "A1", entry: taller }]}
+        onInterrupt={vi.fn()}
+      >
+        <div>input</div>
+      </ComposerStack>,
+    );
+
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+    expect(screen.getByTestId("streaming-agent-live-scroll").scrollTop).toBe(300);
+  });
+
+  it("enlarges live process into an out-of-flow float panel", () => {
+    render(
+      <ComposerStack
+        agents={[{ actorId: "a1", displayName: "A1", entry: makeEntry("a1", 1) as never }]}
+        onInterrupt={vi.fn()}
+      >
+        <div>input</div>
+      </ComposerStack>,
+    );
+
+    expect(screen.getByTestId("streaming-agent-row").getAttribute("data-expanded")).toBe(
+      "true",
+    );
+    expect(screen.getByTestId("streaming-agent-live-panel").getAttribute("data-open")).toBe(
+      "true",
+    );
+    expect(screen.queryByTestId("streaming-agent-live-float")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("streaming-agent-enlarge"));
+
+    expect(screen.getByTestId("streaming-agent-row").getAttribute("data-enlarged")).toBe(
+      "true",
+    );
+    expect(screen.getByTestId("streaming-agent-live-panel").getAttribute("data-open")).toBe(
+      "false",
+    );
+    expect(screen.getByTestId("streaming-agent-live-float")).toBeTruthy();
+    expect(screen.getByTestId("streaming-agent-live-scroll")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("streaming-agent-float-restore"));
+
+    expect(screen.getByTestId("streaming-agent-row").getAttribute("data-enlarged")).toBe(
+      "false",
+    );
+    expect(screen.getByTestId("streaming-agent-live-panel").getAttribute("data-open")).toBe(
+      "true",
+    );
+    expect(screen.queryByTestId("streaming-agent-live-float")).toBeNull();
+  });
+
+  it("restores the enlarge float on Escape", () => {
+    render(
+      <ComposerStack
+        agents={[{ actorId: "a1", displayName: "A1", entry: makeEntry("a1", 1) as never }]}
+        onInterrupt={vi.fn()}
+      >
+        <div>input</div>
+      </ComposerStack>,
+    );
+
+    fireEvent.click(screen.getByTestId("streaming-agent-enlarge"));
+    expect(screen.getByTestId("streaming-agent-live-float")).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(screen.queryByTestId("streaming-agent-live-float")).toBeNull();
+    expect(screen.getByTestId("streaming-agent-row").getAttribute("data-enlarged")).toBe(
+      "false",
+    );
   });
 });

--- a/packages/app/src/components/chat/__tests__/StreamingAgentBubble.test.tsx
+++ b/packages/app/src/components/chat/__tests__/StreamingAgentBubble.test.tsx
@@ -57,6 +57,58 @@ describe("StreamingAgentBubble", () => {
     expect(planning.querySelectorAll(".stream-loading-dot")).toHaveLength(3);
   });
 
+  it("hides ActorLabel for dock variant", () => {
+    const { getByTestId, rerender, container } = render(
+      <StreamingAgentBubble
+        entry={{
+          sessionId: "s1",
+          actorId: "agent-a",
+          outputText: "hi",
+          thinkingText: "",
+          parts: [],
+          toolCalls: [],
+          planEntries: [],
+          pendingPermissionsByRequestId: {},
+          errorMessage: null,
+          errorDetails: null,
+          lastUpdate: Date.now(),
+          active: true,
+          streamId: "s1::agent-a::stream-1",
+        }}
+      />,
+    );
+
+    expect(getByTestId("v2-streaming-agent").getAttribute("data-variant")).toBe(
+      "default",
+    );
+
+    rerender(
+      <StreamingAgentBubble
+        variant="dock"
+        entry={{
+          sessionId: "s1",
+          actorId: "agent-a",
+          outputText: "hi",
+          thinkingText: "",
+          parts: [],
+          toolCalls: [],
+          planEntries: [],
+          pendingPermissionsByRequestId: {},
+          errorMessage: null,
+          errorDetails: null,
+          lastUpdate: Date.now(),
+          active: true,
+          streamId: "s1::agent-a::stream-1",
+        }}
+      />,
+    );
+
+    expect(getByTestId("v2-streaming-agent").getAttribute("data-variant")).toBe("dock");
+    expect(getByTestId("v2-streaming-agent").className).toContain("mb-0");
+    // dock omits the actor name row that default renders above the bubble
+    void container;
+  });
+
   it("keeps planning dots visible for tool-first streams before text arrives", () => {
     const { getByTestId } = render(
       <StreamingAgentBubble

--- a/packages/app/src/components/chat/use-pending-permissions-queue.ts
+++ b/packages/app/src/components/chat/use-pending-permissions-queue.ts
@@ -1,5 +1,8 @@
 import * as React from "react";
-import { collectAcpStreamingPermissions } from "@/lib/teamclaw/acp-permission-entries";
+import {
+  collectAcpBystanderWaitingPermissions,
+  collectAcpStreamingPermissions,
+} from "@/lib/teamclaw/acp-permission-entries";
 import { useSessionPermissionMode } from "@/lib/session-permission-mode";
 import { useSessionStore } from "@/stores/session";
 import { useV2StreamingStore } from "@/stores/v2-streaming-store";
@@ -18,6 +21,11 @@ export function usePendingPermissionsQueue() {
   const acpStreamingPermissions = React.useMemo(() => {
     const streamByKey = useV2StreamingStore.getState().byKey;
     return collectAcpStreamingPermissions(activeSessionId, streamByKey);
+  }, [activeSessionId, streamRevision]);
+
+  const waitingPermissions = React.useMemo(() => {
+    const streamByKey = useV2StreamingStore.getState().byKey;
+    return collectAcpBystanderWaitingPermissions(activeSessionId, streamByKey);
   }, [activeSessionId, streamRevision]);
 
   const baseVisiblePermissions = React.useMemo(
@@ -49,6 +57,10 @@ export function usePendingPermissionsQueue() {
 
   const currentEntry = visiblePermissions[0] ?? null;
   const queuedCount = visiblePermissions.length;
+  const waitingEntry = waitingPermissions[0] ?? null;
+  const waitingRequesterActorId =
+    (waitingEntry?.permission.metadata?.requester_actor_id as string | undefined)?.trim() ||
+    null;
 
   const onReplyStart = React.useCallback((permissionId: string) => {
     setDismissedIds((current) =>
@@ -66,6 +78,7 @@ export function usePendingPermissionsQueue() {
     visiblePermissions,
     currentEntry,
     queuedCount,
+    waitingRequesterActorId,
     onReplyStart,
     onReplyRollback,
   };

--- a/packages/app/src/components/onboarding/__tests__/JoinTeamFlow.test.tsx
+++ b/packages/app/src/components/onboarding/__tests__/JoinTeamFlow.test.tsx
@@ -17,6 +17,10 @@ vi.mock('@/lib/auth/session-store', () => ({
   getFreshAccessToken: vi.fn(async () => 'test-token'),
 }))
 
+vi.mock('@/lib/server-config', () => ({
+  getEffectiveServerConfigSync: () => ({ cloudApiUrl: 'https://runtime.example.test' }),
+}))
+
 import { JoinTeamFlow } from '../JoinTeamFlow'
 import { useTeamShareStore } from '@/stores/team-share'
 

--- a/packages/app/src/lib/__tests__/acp-permission-entries.test.ts
+++ b/packages/app/src/lib/__tests__/acp-permission-entries.test.ts
@@ -1,11 +1,19 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   buildPendingEntryFromAcpPermission,
+  collectAcpBystanderWaitingPermissions,
   collectAcpStreamingPermissions,
 } from "@/lib/teamclaw/acp-permission-entries";
+import { useCurrentTeamStore } from "@/stores/current-team";
 import { useV2StreamingStore } from "@/stores/v2-streaming-store";
 
 describe("acp permission entries", () => {
+  beforeEach(() => {
+    useCurrentTeamStore.setState({
+      currentMember: { id: "me-actor", display_name: "Me" } as never,
+    });
+  });
+
   it("maps bash tool permission for the approval card", () => {
     const entry = buildPendingEntryFromAcpPermission("sess-1", "agent-1", {
       requestId: "perm-1",
@@ -50,6 +58,71 @@ describe("acp permission entries", () => {
     expect(rows[0]?.permission.id).toBe("p1");
   });
 
+  it("hides interactive queue for bystander when requester is stamped", () => {
+    const byKey = {
+      "sess-a::agent-1": {
+        sessionId: "sess-a",
+        actorId: "agent-1",
+        pendingPermissionsByRequestId: {
+          p1: {
+            requestId: "p1",
+            toolName: "bash",
+            description: "ls",
+            params: { requester_actor_id: "other-actor" },
+            requesterActorId: "other-actor",
+          },
+        },
+      },
+    };
+    expect(collectAcpStreamingPermissions("sess-a", byKey)).toHaveLength(0);
+    const waiting = collectAcpBystanderWaitingPermissions("sess-a", byKey);
+    expect(waiting).toHaveLength(1);
+    expect(waiting[0]?.permission.metadata?.requester_actor_id).toBe("other-actor");
+  });
+
+  it("keeps interactive queue for requester and for legacy empty stamp", () => {
+    expect(
+      collectAcpStreamingPermissions("sess-a", {
+        "sess-a::agent-1": {
+          sessionId: "sess-a",
+          actorId: "agent-1",
+          pendingPermissionsByRequestId: {
+            mine: {
+              requestId: "mine",
+              toolName: "bash",
+              description: "ls",
+              params: { requester_actor_id: "me-actor" },
+              requesterActorId: "me-actor",
+            },
+            legacy: {
+              requestId: "legacy",
+              toolName: "bash",
+              description: "pwd",
+              params: {},
+            },
+          },
+        },
+      }),
+    ).toHaveLength(2);
+    expect(
+      collectAcpBystanderWaitingPermissions("sess-a", {
+        "sess-a::agent-1": {
+          sessionId: "sess-a",
+          actorId: "agent-1",
+          pendingPermissionsByRequestId: {
+            mine: {
+              requestId: "mine",
+              toolName: "bash",
+              description: "ls",
+              params: { requester_actor_id: "me-actor" },
+              requesterActorId: "me-actor",
+            },
+          },
+        },
+      }),
+    ).toHaveLength(0);
+  });
+
   it("collects multiple parallel subagent permissions for one actor", () => {
     const rows = collectAcpStreamingPermissions("sess-a", {
       "sess-a::agent-1": {
@@ -88,6 +161,9 @@ describe("acp permission entries", () => {
 
 describe("parallel permission queue in v2 store", () => {
   beforeEach(() => {
+    useCurrentTeamStore.setState({
+      currentMember: { id: "me-actor", display_name: "Me" } as never,
+    });
     useV2StreamingStore.setState({
       byKey: {},
       revisionBySession: {},

--- a/packages/app/src/lib/__tests__/agent-reply-transcript.test.ts
+++ b/packages/app/src/lib/__tests__/agent-reply-transcript.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   deriveAgentReplyContent,
   joinTextPartsFromParts,
+  splitAssistantProcessAndFinalParts,
   stripPriorTranscriptTextPrefix,
 } from "@/lib/agent-reply-transcript";
 
@@ -65,5 +66,49 @@ describe("agent reply transcript", () => {
     ] as never;
     const pending = [{ messageId: "m1", content: final }] as never;
     expect(deriveAgentReplyContent(parts, pending)).toBe(`${intro}\n\n${final}`);
+  });
+
+  it("splits process vs final after last tool or trailing thinking", () => {
+    const mid1 = "Now trying remaining tools:";
+    const mid2 = "More tools:";
+    const final = "全部工具执行完毕。汇总：";
+    const parts = [
+      { type: "reasoning", text: "plan" },
+      { type: "text", text: mid1 },
+      { type: "tool-call", toolCall: { id: "t1" } },
+      { type: "text", text: mid2 },
+      { type: "tool-call", toolCall: { id: "t2" } },
+      { type: "reasoning", text: "wrap up" },
+      { type: "text", text: final },
+    ];
+    const { processParts, finalTextParts } = splitAssistantProcessAndFinalParts(parts);
+    expect(processParts.map((p) => p.type)).toEqual([
+      "reasoning",
+      "text",
+      "tool-call",
+      "text",
+      "tool-call",
+      "reasoning",
+    ]);
+    expect(finalTextParts.map((p) => (p as { text?: string }).text)).toEqual([final]);
+  });
+
+  it("treats all text as final when there is no process activity", () => {
+    const parts = [{ type: "text", text: "Hello only." }];
+    const { processParts, finalTextParts } = splitAssistantProcessAndFinalParts(parts);
+    expect(processParts).toEqual([]);
+    expect(finalTextParts).toEqual(parts);
+  });
+
+  it("keeps mid-turn narration in process when there is no trailing final text", () => {
+    const mid = "Now trying remaining tools:";
+    const parts = [
+      { type: "text", text: mid },
+      { type: "tool-call", toolCall: { id: "t1" } },
+    ];
+    const { processParts, finalTextParts } = splitAssistantProcessAndFinalParts(parts);
+    expect(processParts.map((p) => p.type)).toEqual(["text", "tool-call"]);
+    expect(finalTextParts).toEqual([]);
+    expect(processParts.some((p) => p.type === "text")).toBe(true);
   });
 });

--- a/packages/app/src/lib/__tests__/pending-agent-reply-to.test.ts
+++ b/packages/app/src/lib/__tests__/pending-agent-reply-to.test.ts
@@ -45,4 +45,11 @@ describe("pending-agent-reply-to", () => {
     expect(resolvePendingAgentReplyTo("s1", "agent-a", "")).toBe("u1");
     expect(resolvePendingAgentReplyTo("s1", "agent-a", null)).toBeNull();
   });
+
+  it("direct-append drain via remove leaves other queued parents intact", () => {
+    notePendingAgentReplyTo("s1", ["agent-a"], "u1");
+    notePendingAgentReplyTo("s1", ["agent-a"], "u2");
+    expect(removePendingAgentReplyTo("s1", "agent-a", "u1")).toBe(true);
+    expect(peekPendingAgentReplyTo("s1", "agent-a")).toBe("u2");
+  });
 });

--- a/packages/app/src/lib/__tests__/pending-agent-reply-to.test.ts
+++ b/packages/app/src/lib/__tests__/pending-agent-reply-to.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  clearPendingAgentReplyToForTests,
+  notePendingAgentReplyTo,
+  peekPendingAgentReplyTo,
+  removePendingAgentReplyTo,
+  resolvePendingAgentReplyTo,
+  takePendingAgentReplyTo,
+} from "@/lib/pending-agent-reply-to";
+
+describe("pending-agent-reply-to", () => {
+  beforeEach(() => {
+    clearPendingAgentReplyToForTests();
+  });
+
+  it("FIFO per agent so concurrent mentions map to the right turns", () => {
+    notePendingAgentReplyTo("s1", ["agent-a"], "u1");
+    notePendingAgentReplyTo("s1", ["agent-a"], "u2");
+    expect(peekPendingAgentReplyTo("s1", "agent-a")).toBe("u1");
+    expect(takePendingAgentReplyTo("s1", "agent-a")).toBe("u1");
+    expect(takePendingAgentReplyTo("s1", "agent-a")).toBe("u2");
+    expect(takePendingAgentReplyTo("s1", "agent-a")).toBeNull();
+  });
+
+  it("isolates queues by actor", () => {
+    notePendingAgentReplyTo("s1", ["a1", "a2"], "u-shared");
+    expect(takePendingAgentReplyTo("s1", "a1")).toBe("u-shared");
+    expect(takePendingAgentReplyTo("s1", "a2")).toBe("u-shared");
+  });
+
+  it("removes a stamped id from mid-queue so desync does not poison later turns", () => {
+    notePendingAgentReplyTo("s1", ["agent-a"], "u1");
+    notePendingAgentReplyTo("s1", ["agent-a"], "u2");
+    notePendingAgentReplyTo("s1", ["agent-a"], "u3");
+    expect(removePendingAgentReplyTo("s1", "agent-a", "u2")).toBe(true);
+    expect(takePendingAgentReplyTo("s1", "agent-a")).toBe("u1");
+    expect(takePendingAgentReplyTo("s1", "agent-a")).toBe("u3");
+  });
+
+  it("resolve prefers daemon stamp and dequeues that id anywhere", () => {
+    notePendingAgentReplyTo("s1", ["agent-a"], "u1");
+    notePendingAgentReplyTo("s1", ["agent-a"], "u2");
+    expect(resolvePendingAgentReplyTo("s1", "agent-a", "u2")).toBe("u2");
+    expect(peekPendingAgentReplyTo("s1", "agent-a")).toBe("u1");
+    expect(resolvePendingAgentReplyTo("s1", "agent-a", "")).toBe("u1");
+    expect(resolvePendingAgentReplyTo("s1", "agent-a", null)).toBeNull();
+  });
+});

--- a/packages/app/src/lib/__tests__/v2-message-adapter.test.ts
+++ b/packages/app/src/lib/__tests__/v2-message-adapter.test.ts
@@ -17,6 +17,7 @@ function tmsg(o: {
   metadataJson?: string;
   model?: string;
   turnId?: string;
+  replyToMessageId?: string;
   t?: number;
   sessionId?: string;
   sequence?: number;
@@ -31,6 +32,7 @@ function tmsg(o: {
     metadataJson: o.metadataJson ?? "",
     model: o.model ?? "",
     turnId: o.turnId ?? "",
+    replyToMessageId: o.replyToMessageId ?? "",
     createdAt: BigInt(o.t ?? 0),
   });
   if (o.sequence !== undefined) {
@@ -685,5 +687,53 @@ describe("adaptTeamclawMessages", () => {
     expect(result[0].timestamp).toEqual(new Date(10 * 1000));
     // content joined in sorted order
     expect(result[0].content).toBe("first\n\nsecond");
+  });
+
+  it("passes replyToMessageId through single and grouped turns", () => {
+    const single = adaptTeamclawMessages([
+      tmsg({
+        kind: MessageKind.AGENT_REPLY,
+        content: "hi",
+        turnId: "t-reply",
+        replyToMessageId: "user-1",
+      }),
+    ]);
+    expect(single?.[0]?.replyToMessageId).toBe("user-1");
+
+    const grouped = adaptTeamclawMessages([
+      tmsg({
+        kind: MessageKind.AGENT_THINKING,
+        content: "think",
+        turnId: "t-g",
+        replyToMessageId: "",
+      }),
+      tmsg({
+        kind: MessageKind.AGENT_REPLY,
+        content: "done",
+        turnId: "t-g",
+        replyToMessageId: "user-9",
+      }),
+    ]);
+    expect(grouped?.[0]?.replyToMessageId).toBe("user-9");
+  });
+
+  it("keeps replyToMessageId on mergedPersistedParts path (completed stream)", () => {
+    const partsJson = JSON.stringify([
+      { id: "p1", type: "reasoning", text: "think", content: "think" },
+      { id: "p2", type: "text", text: "final", content: "final" },
+    ]);
+    const result = adaptTeamclawMessages([
+      tmsg({
+        kind: MessageKind.AGENT_REPLY,
+        content: "final",
+        turnId: "t-parts",
+        replyToMessageId: "user-parent",
+        partsJson,
+      }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.replyToMessageId).toBe("user-parent");
+    expect(result?.[0]?.turnId).toBe("t-parts");
+    expect(result?.[0]?.parts?.some((p) => p.type === "text")).toBe(true);
   });
 });

--- a/packages/app/src/lib/agent-reply-transcript.ts
+++ b/packages/app/src/lib/agent-reply-transcript.ts
@@ -47,6 +47,42 @@ export function priorTextBodiesBeforeLastTool(parts: MessagePart[]): string[] {
 }
 
 /**
+ * Split a completed assistant transcript into process vs final reply.
+ *
+ * Boundary = last non-text process activity (`reasoning` | `tool-call`), not
+ * merely the last tool-call — a trailing thinking block may sit after tools
+ * and before the final answer text.
+ *
+ * - process: everything through that last activity (keeps interleaved mid-turn
+ *   narrations in chronological order with tools/thinking)
+ * - final: trailing contiguous `text` parts after that boundary
+ * - no process activity: process empty, all text is final
+ */
+export function splitAssistantProcessAndFinalParts<T extends TranscriptPart>(
+  parts: T[],
+): { processParts: T[]; finalTextParts: T[] } {
+  let lastProcessIndex = -1;
+  for (let index = 0; index < parts.length; index += 1) {
+    const type = parts[index]?.type;
+    if (type === "reasoning" || type === "tool-call") {
+      lastProcessIndex = index;
+    }
+  }
+  if (lastProcessIndex < 0) {
+    return {
+      processParts: [],
+      finalTextParts: parts.filter((part) => part.type === "text"),
+    };
+  }
+  return {
+    processParts: parts.slice(0, lastProcessIndex + 1),
+    finalTextParts: parts
+      .slice(lastProcessIndex + 1)
+      .filter((part) => part.type === "text"),
+  };
+}
+
+/**
  * When acp.output sends a cumulative chunk after tools, keep only the post-tool
  * suffix so earlier text parts are not duplicated.
  */

--- a/packages/app/src/lib/agent-turn-flush.ts
+++ b/packages/app/src/lib/agent-turn-flush.ts
@@ -20,7 +20,7 @@ export function buildAgentReplyMessageRow(
     sessionId: reply.sessionId,
     turnId: reply.turnId || null,
     senderActorId: reply.senderActorId || null,
-    replyToMessageId: null,
+    replyToMessageId: reply.replyToMessageId?.trim() || null,
     kind: "agent_reply",
     content: reply.content,
     metadataJson: reply.metadataJson || null,
@@ -94,7 +94,10 @@ export function bumpPreviewFromAgentReply(
   });
 }
 
-/** Shared post-persist commit: store, cache, release stream, session preview. */
+/** Shared post-persist commit: store, cache, release stream, session preview.
+ * UI handoff order: put AGENT_REPLY (with partsJson) into the message store
+ * before releasing the live stream, so ChatMessage can show「处理过程」
+ * without a blank gap after the Composer dock closes. */
 export function commitFlushedAgentReply(
   sessionId: string,
   actorId: string,

--- a/packages/app/src/lib/pending-agent-reply-to.ts
+++ b/packages/app/src/lib/pending-agent-reply-to.ts
@@ -1,0 +1,93 @@
+/**
+ * Per-(session, agent) FIFO of user message ids that should become
+ * `replyToMessageId` on the next agent turn flush when the daemon did not
+ * stamp one. Push on local send; consume on flush so concurrent @mentions stay
+ * ordered (u1,u2 → a1 replies to u1, a2 to u2).
+ *
+ * When the daemon stamps a reply_to, remove that id from anywhere in the queue
+ * (not only the head) so a scrambled FIFO cannot keep poisoning later turns.
+ */
+const queues = new Map<string, string[]>();
+
+function key(sessionId: string, actorId: string): string {
+  return `${sessionId}::${actorId}`;
+}
+
+export function notePendingAgentReplyTo(
+  sessionId: string,
+  actorIds: readonly string[],
+  userMessageId: string,
+): void {
+  const id = userMessageId.trim();
+  if (!sessionId || !id || actorIds.length === 0) return;
+  for (const actorId of actorIds) {
+    if (!actorId) continue;
+    const k = key(sessionId, actorId);
+    const q = queues.get(k) ?? [];
+    q.push(id);
+    queues.set(k, q);
+  }
+}
+
+/** Peek without consuming — for live dock while the turn is still open. */
+export function peekPendingAgentReplyTo(
+  sessionId: string,
+  actorId: string,
+): string | null {
+  const q = queues.get(key(sessionId, actorId));
+  return q?.[0] ?? null;
+}
+
+/** Consume the oldest pending id for this agent (one per flushed turn). */
+export function takePendingAgentReplyTo(
+  sessionId: string,
+  actorId: string,
+): string | null {
+  const k = key(sessionId, actorId);
+  const q = queues.get(k);
+  if (!q?.length) return null;
+  const next = q.shift() ?? null;
+  if (q.length === 0) queues.delete(k);
+  else queues.set(k, q);
+  return next;
+}
+
+/** Remove the first matching id anywhere in the queue (daemon-stamped path). */
+export function removePendingAgentReplyTo(
+  sessionId: string,
+  actorId: string,
+  messageId: string,
+): boolean {
+  const id = messageId.trim();
+  if (!sessionId || !actorId || !id) return false;
+  const k = key(sessionId, actorId);
+  const q = queues.get(k);
+  if (!q?.length) return false;
+  const idx = q.indexOf(id);
+  if (idx < 0) return false;
+  q.splice(idx, 1);
+  if (q.length === 0) queues.delete(k);
+  else queues.set(k, q);
+  return true;
+}
+
+/**
+ * Prefer daemon stamp; otherwise take FIFO head. Always dequeue the stamp
+ * when present so the queue stays aligned with completed turns.
+ */
+export function resolvePendingAgentReplyTo(
+  sessionId: string,
+  actorId: string,
+  stampedReplyTo: string | null | undefined,
+): string | null {
+  const stamped = stampedReplyTo?.trim() || "";
+  if (stamped) {
+    removePendingAgentReplyTo(sessionId, actorId, stamped);
+    return stamped;
+  }
+  return takePendingAgentReplyTo(sessionId, actorId);
+}
+
+export function clearPendingAgentReplyToForTests(): void {
+  queues.clear();
+}

--- a/packages/app/src/lib/session-export/collect.ts
+++ b/packages/app/src/lib/session-export/collect.ts
@@ -25,6 +25,7 @@ export function messageRowsToProto(rows: MessageRow[]): TeamclawMessage[] {
       content: r.content ?? "",
       model: r.model ?? "",
       turnId: r.turnId ?? "",
+      replyToMessageId: r.replyToMessageId ?? "",
       metadataJson: r.metadataJson ?? "",
       createdAt: BigInt(Math.floor(new Date(r.createdAt).getTime() / 1000)),
     });

--- a/packages/app/src/lib/teamclaw/__tests__/flush-session-pending-permissions.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/flush-session-pending-permissions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   replyAcpPermission: vi.fn(() => Promise.resolve()),
+  currentMemberId: "me-actor" as string | null,
   byKey: {} as Record<
     string,
     {
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => ({
           toolName: string;
           description: string;
           params: Record<string, string>;
+          requesterActorId?: string;
         }
       >;
     }
@@ -30,12 +32,23 @@ vi.mock("@/stores/v2-streaming-store", () => ({
   },
 }));
 
+vi.mock("@/stores/current-team", () => ({
+  useCurrentTeamStore: {
+    getState: () => ({
+      currentMember: mocks.currentMemberId
+        ? { id: mocks.currentMemberId }
+        : null,
+    }),
+  },
+}));
+
 import { flushSessionPendingPermissions } from "../flush-session-pending-permissions";
 
 describe("flushSessionPendingPermissions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.byKey = {};
+    mocks.currentMemberId = "me-actor";
   });
 
   it("auto-allows all pending permissions for the session", async () => {
@@ -122,6 +135,39 @@ describe("flushSessionPendingPermissions", () => {
     await flushSessionPendingPermissions("sess-1");
 
     expect(mocks.replyAcpPermission).toHaveBeenCalledTimes(3);
+  });
+
+  it("skips bystander-stamped pending permissions", async () => {
+    mocks.byKey["sess-1::agent-a"] = {
+      sessionId: "sess-1",
+      actorId: "agent-a",
+      pendingPermissionsByRequestId: {
+        mine: {
+          requestId: "mine",
+          toolName: "bash",
+          description: "",
+          params: { requester_actor_id: "me-actor" },
+          requesterActorId: "me-actor",
+        },
+        theirs: {
+          requestId: "theirs",
+          toolName: "bash",
+          description: "",
+          params: { requester_actor_id: "other-actor" },
+          requesterActorId: "other-actor",
+        },
+      },
+    };
+
+    await flushSessionPendingPermissions("sess-1");
+
+    expect(mocks.replyAcpPermission).toHaveBeenCalledTimes(1);
+    expect(mocks.replyAcpPermission).toHaveBeenCalledWith({
+      sessionId: "sess-1",
+      agentActorId: "agent-a",
+      requestId: "mine",
+      decision: "allow",
+    });
   });
 
   it("keeps pending when auto-allow fails", async () => {

--- a/packages/app/src/lib/teamclaw/__tests__/handle-acp-permission-request.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/handle-acp-permission-request.test.ts
@@ -22,6 +22,16 @@ vi.mock("@/stores/v2-streaming-store", () => ({
   },
 }));
 
+vi.mock("@/stores/current-team", () => ({
+  useCurrentTeamStore: {
+    getState: () => ({ currentMember: { id: "member-me" } }),
+  },
+}));
+
+vi.mock("@/lib/teamclaw/handle-session-event-permission-resolved", () => ({
+  wasPermissionRecentlyResolved: () => false,
+}));
+
 import {
   handleAcpPermissionRequest,
   resetAcpPermissionInFlightForTests,

--- a/packages/app/src/lib/teamclaw/__tests__/handle-session-event-permission-resolved.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/handle-session-event-permission-resolved.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findV2PendingPermission: vi.fn(),
+  clearPermissionRequest: vi.fn(),
+  setState: vi.fn(),
+}));
+
+vi.mock("@/lib/teamclaw/reply-acp-permission", () => ({
+  findV2PendingPermission: mocks.findV2PendingPermission,
+}));
+
+vi.mock("@/stores/v2-streaming-store", () => ({
+  useV2StreamingStore: {
+    getState: () => ({
+      clearPermissionRequest: mocks.clearPermissionRequest,
+    }),
+  },
+}));
+
+vi.mock("@/stores/session", () => ({
+  useSessionStore: {
+    setState: mocks.setState,
+  },
+}));
+
+import {
+  handleSessionEventPermissionResolved,
+  resetPermissionResolvedTtlForTests,
+  wasPermissionRecentlyResolved,
+} from "../handle-session-event-permission-resolved";
+
+describe("handleSessionEventPermissionResolved", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetPermissionResolvedTtlForTests();
+  });
+
+  it("clears v2 pending via requestId scan and marks resolved TTL", () => {
+    mocks.findV2PendingPermission.mockReturnValue({
+      sessionId: "sess-1",
+      actorId: "agent-1",
+      request: { requestId: "perm-1" },
+    });
+
+    handleSessionEventPermissionResolved({ requestId: "perm-1" });
+
+    expect(mocks.clearPermissionRequest).toHaveBeenCalledWith(
+      "sess-1",
+      "agent-1",
+      "perm-1",
+    );
+    expect(wasPermissionRecentlyResolved("perm-1")).toBe(true);
+    expect(mocks.setState).toHaveBeenCalled();
+  });
+
+  it("still marks TTL when no pending entry exists (reorder)", () => {
+    mocks.findV2PendingPermission.mockReturnValue(null);
+
+    handleSessionEventPermissionResolved({ requestId: "perm-late" });
+
+    expect(mocks.clearPermissionRequest).not.toHaveBeenCalled();
+    expect(wasPermissionRecentlyResolved("perm-late")).toBe(true);
+  });
+
+  it("ignores empty requestId", () => {
+    handleSessionEventPermissionResolved({ requestId: "  " });
+    expect(mocks.findV2PendingPermission).not.toHaveBeenCalled();
+    expect(wasPermissionRecentlyResolved("")).toBe(false);
+  });
+});

--- a/packages/app/src/lib/teamclaw/acp-permission-entries.ts
+++ b/packages/app/src/lib/teamclaw/acp-permission-entries.ts
@@ -1,6 +1,8 @@
 import type { PendingPermissionEntry } from "@/stores/session-types";
 import type { StreamingPermissionRequest } from "@/stores/v2-streaming-store";
 import { shouldAutoAllowSessionPermissions } from "@/lib/session-permission-mode";
+import { canCurrentMemberActOnPermission } from "@/lib/teamclaw/handle-acp-permission-request";
+import { useCurrentTeamStore } from "@/stores/current-team";
 
 function inferPermissionType(toolName: string): string {
   const n = toolName.toLowerCase();
@@ -25,6 +27,8 @@ export function buildPendingEntryFromAcpPermission(
     req.params.cmd ??
     req.description ??
     req.toolName;
+  const requesterActorId =
+    req.requesterActorId?.trim() || req.params.requester_actor_id?.trim() || "";
 
   return {
     permission: {
@@ -35,6 +39,7 @@ export function buildPendingEntryFromAcpPermission(
       metadata: {
         ...req.params,
         _acp_agent_actor_id: agentActorId,
+        ...(requesterActorId ? { requester_actor_id: requesterActorId } : {}),
       },
       always: [],
     },
@@ -46,26 +51,59 @@ export function buildPendingEntryFromAcpPermission(
   };
 }
 
-export function collectAcpStreamingPermissions(
-  activeSessionId: string | null,
-  byKey: Record<
-    string,
-    {
-      sessionId: string;
-      actorId: string;
-      pendingPermissionsByRequestId: Record<string, StreamingPermissionRequest>;
-    }
-  >,
-): PendingPermissionEntry[] {
-  if (!activeSessionId) return [];
-  if (shouldAutoAllowSessionPermissions(activeSessionId)) return [];
-  const out: PendingPermissionEntry[] = [];
+type StreamKeyEntry = {
+  sessionId: string;
+  actorId: string;
+  pendingPermissionsByRequestId: Record<string, StreamingPermissionRequest>;
+};
+
+function forEachPendingInSession(
+  activeSessionId: string,
+  byKey: Record<string, StreamKeyEntry>,
+  visit: (entry: StreamKeyEntry, pending: StreamingPermissionRequest) => void,
+): void {
   for (const entry of Object.values(byKey)) {
     if (entry.sessionId !== activeSessionId) continue;
     for (const pending of Object.values(entry.pendingPermissionsByRequestId)) {
       if (!pending.requestId?.trim()) continue;
-      out.push(buildPendingEntryFromAcpPermission(entry.sessionId, entry.actorId, pending));
+      visit(entry, pending);
     }
   }
+}
+
+/** Interactive Allow/Deny queue — excludes bystander-stamped requests. */
+export function collectAcpStreamingPermissions(
+  activeSessionId: string | null,
+  byKey: Record<string, StreamKeyEntry>,
+): PendingPermissionEntry[] {
+  if (!activeSessionId) return [];
+  if (shouldAutoAllowSessionPermissions(activeSessionId)) return [];
+  const me = useCurrentTeamStore.getState().currentMember?.id ?? null;
+  const out: PendingPermissionEntry[] = [];
+  forEachPendingInSession(activeSessionId, byKey, (entry, pending) => {
+    if (!canCurrentMemberActOnPermission(pending, me)) return;
+    out.push(buildPendingEntryFromAcpPermission(entry.sessionId, entry.actorId, pending));
+  });
+  return out;
+}
+
+/**
+ * Pending permissions stamped for another member — used for the read-only
+ * “等待 XXX 批准” banner (Phase 2.5). Legacy empty requester is excluded.
+ */
+export function collectAcpBystanderWaitingPermissions(
+  activeSessionId: string | null,
+  byKey: Record<string, StreamKeyEntry>,
+): PendingPermissionEntry[] {
+  if (!activeSessionId) return [];
+  const me = useCurrentTeamStore.getState().currentMember?.id ?? null;
+  const out: PendingPermissionEntry[] = [];
+  forEachPendingInSession(activeSessionId, byKey, (entry, pending) => {
+    const requester =
+      pending.requesterActorId?.trim() || pending.params?.requester_actor_id?.trim() || "";
+    if (!requester) return;
+    if (canCurrentMemberActOnPermission(pending, me)) return;
+    out.push(buildPendingEntryFromAcpPermission(entry.sessionId, entry.actorId, pending));
+  });
   return out;
 }

--- a/packages/app/src/lib/teamclaw/flush-session-pending-permissions.ts
+++ b/packages/app/src/lib/teamclaw/flush-session-pending-permissions.ts
@@ -1,3 +1,4 @@
+import { canCurrentMemberActOnPermission } from "@/lib/teamclaw/handle-acp-permission-request";
 import { replyAcpPermission } from "@/lib/teamclaw/reply-acp-permission";
 import { useV2StreamingStore } from "@/stores/v2-streaming-store";
 
@@ -17,6 +18,8 @@ export async function flushSessionPendingPermissions(sessionId: string): Promise
     for (const req of Object.values(entry.pendingPermissionsByRequestId)) {
       const requestId = req.requestId?.trim() ?? "";
       if (!requestId) continue;
+      // Bystander-stamped requests must not be auto-granted via fullAccess flush.
+      if (!canCurrentMemberActOnPermission(req)) continue;
       pending.push({
         sessionId: entry.sessionId,
         actorId: entry.actorId,

--- a/packages/app/src/lib/teamclaw/handle-acp-permission-request.ts
+++ b/packages/app/src/lib/teamclaw/handle-acp-permission-request.ts
@@ -1,9 +1,30 @@
 import { shouldAutoAllowSessionPermissions } from "@/lib/session-permission-mode";
 import { replyAcpPermission } from "@/lib/teamclaw/reply-acp-permission";
+import { wasPermissionRecentlyResolved } from "@/lib/teamclaw/handle-session-event-permission-resolved";
 import type { StreamingPermissionRequest } from "@/stores/v2-streaming-store";
 import { useV2StreamingStore } from "@/stores/v2-streaming-store";
+import { useCurrentTeamStore } from "@/stores/current-team";
 
 const inFlightRequestIds = new Set<string>();
+
+function requesterActorIdFromRequest(request: StreamingPermissionRequest): string {
+  return (
+    request.requesterActorId?.trim() ||
+    request.params?.requester_actor_id?.trim() ||
+    ""
+  );
+}
+
+/** Interactive / auto-allow allowed when legacy (empty) or current member is requester. */
+export function canCurrentMemberActOnPermission(
+  request: StreamingPermissionRequest,
+  currentMemberId?: string | null,
+): boolean {
+  const requester = requesterActorIdFromRequest(request);
+  if (!requester) return true; // legacy daemon
+  const me = (currentMemberId ?? useCurrentTeamStore.getState().currentMember?.id ?? "").trim();
+  return Boolean(me) && me === requester;
+}
 
 export async function handleAcpPermissionRequest(args: {
   sessionId: string;
@@ -16,14 +37,36 @@ export async function handleAcpPermissionRequest(args: {
     return;
   }
 
+  if (wasPermissionRecentlyResolved(requestId)) {
+    return;
+  }
+
   if (inFlightRequestIds.has(requestId)) {
     return;
   }
 
   const store = useV2StreamingStore.getState();
-  const writePending = () => {
-    store.setPermissionRequest(args.sessionId, args.agentActorId, args.request);
+  const normalized: StreamingPermissionRequest = {
+    ...args.request,
+    requestId,
+    requesterActorId:
+      args.request.requesterActorId?.trim() ||
+      args.request.params?.requester_actor_id?.trim() ||
+      undefined,
   };
+
+  const writePending = () => {
+    store.setPermissionRequest(args.sessionId, args.agentActorId, normalized);
+  };
+
+  const canAct = canCurrentMemberActOnPermission(normalized);
+
+  // Bystander with stamped requester: still store pending for waiting banner,
+  // but never auto-allow or show interactive controls (UI filters separately).
+  if (!canAct) {
+    writePending();
+    return;
+  }
 
   if (!shouldAutoAllowSessionPermissions(args.sessionId)) {
     writePending();

--- a/packages/app/src/lib/teamclaw/handle-session-event-permission-resolved.ts
+++ b/packages/app/src/lib/teamclaw/handle-session-event-permission-resolved.ts
@@ -1,0 +1,75 @@
+import { findV2PendingPermission } from "@/lib/teamclaw/reply-acp-permission";
+import { useSessionStore } from "@/stores/session";
+import { useV2StreamingStore } from "@/stores/v2-streaming-store";
+
+/** How long a resolved requestId suppresses a late PermissionRequest. */
+const RESOLVED_TTL_MS = 60_000;
+
+const resolvedAtByRequestId = new Map<string, number>();
+
+function pruneResolved(now = Date.now()): void {
+  for (const [id, at] of resolvedAtByRequestId) {
+    if (now - at > RESOLVED_TTL_MS) {
+      resolvedAtByRequestId.delete(id);
+    }
+  }
+}
+
+/** True if this requestId was recently cleared via PermissionResolved. */
+export function wasPermissionRecentlyResolved(requestId: string): boolean {
+  const trimmed = requestId.trim();
+  if (!trimmed) return false;
+  pruneResolved();
+  const at = resolvedAtByRequestId.get(trimmed);
+  if (at == null) return false;
+  if (Date.now() - at > RESOLVED_TTL_MS) {
+    resolvedAtByRequestId.delete(trimmed);
+    return false;
+  }
+  return true;
+}
+
+export function markPermissionResolved(requestId: string): void {
+  const trimmed = requestId.trim();
+  if (!trimmed) return;
+  pruneResolved();
+  resolvedAtByRequestId.set(trimmed, Date.now());
+}
+
+/**
+ * Clear a pending ACP permission on every client after SessionEvent.PermissionResolved.
+ * Locates by requestId scan so envelope actorId/runtimeId mismatches cannot leave sticky cards.
+ */
+export function handleSessionEventPermissionResolved(args: {
+  requestId: string;
+  /** Optional hint; ignored for lookup — findV2PendingPermission scans all keys. */
+  sessionIdHint?: string;
+}): void {
+  const requestId = args.requestId.trim();
+  if (!requestId) return;
+
+  markPermissionResolved(requestId);
+
+  const located = findV2PendingPermission(requestId);
+  if (located) {
+    useV2StreamingStore
+      .getState()
+      .clearPermissionRequest(located.sessionId, located.actorId, requestId);
+  }
+
+  useSessionStore.setState((state) => {
+    if (!state.pendingPermissions.some((e) => e.permission.id === requestId)) {
+      return {};
+    }
+    return {
+      pendingPermissions: state.pendingPermissions.filter(
+        (e) => e.permission.id !== requestId,
+      ),
+    };
+  });
+}
+
+/** Test helper */
+export function resetPermissionResolvedTtlForTests(): void {
+  resolvedAtByRequestId.clear();
+}

--- a/packages/app/src/lib/v2-message-adapter.ts
+++ b/packages/app/src/lib/v2-message-adapter.ts
@@ -50,6 +50,8 @@ function parseMentionDeliverySnapshot(
 export function adaptTeamclawMessageToSdk(m: TeamclawMessage): SdkMessage {
   const mentionActorIds = parseDisplayMentionActorIds(m);
   const mentionDeliverySnapshot = parseMentionDeliverySnapshot(m);
+  const replyTo = m.replyToMessageId?.trim() || undefined;
+  const turnId = m.turnId?.trim() || undefined;
   return {
     id: m.messageId,
     sessionId: m.sessionId,
@@ -59,6 +61,8 @@ export function adaptTeamclawMessageToSdk(m: TeamclawMessage): SdkMessage {
     mentionActorIds,
     mentionDeliverySnapshot,
     modelID: m.model || undefined,
+    replyToMessageId: replyTo,
+    turnId,
     parts: [
       {
         id: `${m.messageId}-p0`,
@@ -265,6 +269,15 @@ function compareTeamclawMessages(a: TeamclawMessage, b: TeamclawMessage): number
   return a.messageId.localeCompare(b.messageId);
 }
 
+/** Prefer the first non-empty reply_to on a same-turn group. */
+function firstNonEmptyReplyToMessageId(group: TeamclawMessage[]): string | undefined {
+  for (const message of group) {
+    const id = message.replyToMessageId?.trim();
+    if (id) return id;
+  }
+  return undefined;
+}
+
 /** Collapse a run of consecutive same-(senderActorId, turnId) assistant
  * messages into one SdkMessage. Thinking → reasoning part. Tool calls →
  * toolCalls[] matched with results by metadata.tool_id. Replies →
@@ -390,6 +403,8 @@ function buildTurnSdkMessage(group: TeamclawMessage[]): SdkMessage {
       modelID: canonicalModelID,
       parts: mergedPersistedParts,
       toolCalls: canonicalToolCalls,
+      replyToMessageId: firstNonEmptyReplyToMessageId(group),
+      turnId: group[0]?.turnId?.trim() || undefined,
       timestamp: new Date(Number(group[0].createdAt) * 1000),
     };
   }
@@ -420,6 +435,8 @@ function buildTurnSdkMessage(group: TeamclawMessage[]): SdkMessage {
         modelID: canonicalModelID,
         parts: canonicalParts,
         toolCalls: canonicalToolCalls,
+        replyToMessageId: firstNonEmptyReplyToMessageId(group),
+        turnId: group[0]?.turnId?.trim() || undefined,
         timestamp: new Date(Number(group[0].createdAt) * 1000),
       };
     }
@@ -481,6 +498,8 @@ function buildTurnSdkMessage(group: TeamclawMessage[]): SdkMessage {
     modelID,
     parts,
     toolCalls,
+    replyToMessageId: firstNonEmptyReplyToMessageId(group),
+    turnId: group[0]?.turnId?.trim() || undefined,
     timestamp: new Date(Number(group[0].createdAt) * 1000),
   };
 }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -301,7 +301,6 @@
     "thinking": "Thinking...",
     "thinkingProcess": "Thinking Process",
     "process": "Process",
-    "replyTo": "Reply to {{name}}",
     "replyToPrefix": "Reply to",
     "you": "You",
     "someone": "Someone",
@@ -328,6 +327,7 @@
       "waitingExternalPathApproval": "Confirmation is required before accessing a path outside the workspace",
       "childSessionWaitingApproval": "A child session is waiting for your approval",
       "toolInvocationWaitingApproval": "A tool call is waiting for your approval",
+      "waitingForApproval": "Waiting for {{name}} to approve",
       "queuePosition": "{{current}} / {{total}}",
       "approvalSectionAria": "Permission approval",
       "approve": "Allow"
@@ -458,7 +458,6 @@
     "outgoing": {
       "humanMentionInstruction": "This message also mentions human {{name}}"
     },
-    "inputPlaceholderQueue": "Type to queue message...",
     "inputPlaceholderContinue": "Continue typing...",
     "newSession": "New Session",
     "refreshMessages": "Refresh messages",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -300,12 +300,21 @@
     "generatingComponents": "Generating... ({{count}} components)",
     "thinking": "Thinking...",
     "thinkingProcess": "Thinking Process",
+    "process": "Process",
+    "replyTo": "Reply to {{name}}",
+    "replyToPrefix": "Reply to",
+    "you": "You",
+    "someone": "Someone",
     "messagesQueued": "{{count}} messages queued",
     "showMore": "Show more",
     "showLess": "Show less",
     "streamingBar": {
       "streamingActive": "Replying",
-      "waitingApproval": "Waiting for your approval…"
+      "waitingApproval": "Waiting for your approval…",
+      "expand": "Expand",
+      "collapse": "Collapse",
+      "enlarge": "Enlarge",
+      "restore": "Restore"
     },
     "permissionCard": {
       "requestExecuteCommand": "requests to execute a command",
@@ -450,6 +459,7 @@
       "humanMentionInstruction": "This message also mentions human {{name}}"
     },
     "inputPlaceholderQueue": "Type to queue message...",
+    "inputPlaceholderContinue": "Continue typing...",
     "newSession": "New Session",
     "refreshMessages": "Refresh messages",
     "startingAgent": "Starting agent...",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -300,12 +300,21 @@
     "generatingComponents": "生成中... ({{count}} 个组件)",
     "thinking": "思考中...",
     "thinkingProcess": "思考过程",
+    "process": "处理过程",
+    "replyTo": "回复 {{name}}",
+    "replyToPrefix": "回复",
+    "you": "你",
+    "someone": "某人",
     "messagesQueued": "{{count}} 条消息排队中",
     "showMore": "展开全文",
     "showLess": "收起",
     "streamingBar": {
       "streamingActive": "正在回复",
-      "waitingApproval": "等待你审批后继续…"
+      "waitingApproval": "等待你审批后继续…",
+      "expand": "展开",
+      "collapse": "收起",
+      "enlarge": "放大",
+      "restore": "还原"
     },
     "permissionCard": {
       "requestExecuteCommand": "请求执行命令",
@@ -450,6 +459,7 @@
       "humanMentionInstruction": "这条信息还提及了人类 {{name}}"
     },
     "inputPlaceholderQueue": "输入消息以加入队列...",
+    "inputPlaceholderContinue": "继续输入...",
     "newSession": "新会话",
     "refreshMessages": "刷新消息",
     "startingAgent": "正在启动助手...",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -301,7 +301,6 @@
     "thinking": "思考中...",
     "thinkingProcess": "思考过程",
     "process": "处理过程",
-    "replyTo": "回复 {{name}}",
     "replyToPrefix": "回复",
     "you": "你",
     "someone": "某人",
@@ -328,6 +327,7 @@
       "waitingExternalPathApproval": "读取工作区外路径前需要你的确认",
       "childSessionWaitingApproval": "子会话正在等待你的审批",
       "toolInvocationWaitingApproval": "工具调用正在等待你的审批",
+      "waitingForApproval": "等待 {{name}} 批准",
       "queuePosition": "第 {{current}} / {{total}} 条",
       "approvalSectionAria": "权限审批",
       "approve": "允许"
@@ -458,7 +458,6 @@
     "outgoing": {
       "humanMentionInstruction": "这条信息还提及了人类 {{name}}"
     },
-    "inputPlaceholderQueue": "输入消息以加入队列...",
     "inputPlaceholderContinue": "继续输入...",
     "newSession": "新会话",
     "refreshMessages": "刷新消息",

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -171,6 +171,10 @@ export interface Message {
   sendAttempt?: number;
   /** Mirrors `OutboxRow.last_error` — shown in tooltip on failed bubble. */
   sendError?: string;
+  /** User message this agent reply is responding to (quote / jump target). */
+  replyToMessageId?: string | null;
+  /** ACP turn correlation id when available (debug / grouping). */
+  turnId?: string | null;
 }
 
 export interface PlanEntry {

--- a/packages/app/src/stores/v2-streaming-store.ts
+++ b/packages/app/src/stores/v2-streaming-store.ts
@@ -34,6 +34,11 @@ export interface StreamingPermissionRequest {
   params: Record<string, string>;
   /** ACP PermissionOption list from the agent (OpenCode: once / always / reject). */
   options?: Array<{ optionId: string; kind: string; name: string }>;
+  /**
+   * Human actor that started this agent turn (from params.requester_actor_id).
+   * Empty/undefined = legacy daemon; interactive UI shown to everyone.
+   */
+  requesterActorId?: string;
 }
 
 export interface AgentStreamEntry {

--- a/packages/app/src/styles/globals.css
+++ b/packages/app/src/styles/globals.css
@@ -985,6 +985,25 @@ input,
     }
 }
 
+/* Quote-reply jump highlight on the parent user bubble */
+@keyframes agent-reply-quote-flash {
+    0% {
+        box-shadow: 0 0 0 0 rgba(232, 90, 74, 0.45);
+    }
+    30% {
+        box-shadow: 0 0 0 3px rgba(232, 90, 74, 0.28);
+        background-color: #fdf0ed;
+    }
+    100% {
+        box-shadow: none;
+        background-color: transparent;
+    }
+}
+.agent-reply-quote-flash {
+    animation: agent-reply-quote-flash 1.1s ease;
+    border-radius: 12px;
+}
+
 .stream-loading-dot {
     animation: stream-loading-dot 1s ease-in-out infinite;
 }

--- a/scripts/build-windows-daemon.sh
+++ b/scripts/build-windows-daemon.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# build-windows-daemon.sh — Cross-compile amuxd for Windows (x86_64) on macOS,
+# then package amuxd.exe + a README + a PowerShell setup script into a zip.
+#
+# The zip is self-contained: copy it to a Windows machine, unzip, edit
+# setup.ps1 to fill in the invite URL, run setup.ps1.
+#
+# Prerequisites (auto-checked):
+#   - Rust + target x86_64-pc-windows-gnu
+#   - mingw-w64 (brew install mingw-w64) — needed by ring's C build
+#
+# Usage:
+#   scripts/build-windows-daemon.sh                          # all defaults
+#   scripts/build-windows-daemon.sh --cloud-api-url https://copilot.example.io
+#   scripts/build-windows-daemon.sh --mqtt-url wss://copilot.example.io/mqtt
+#   scripts/build-windows-daemon.sh --skip-build             # reuse existing binary
+#   scripts/build-windows-daemon.sh --output /tmp/my-daemon.zip
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+TARGET="x86_64-pc-windows-gnu"
+DAEMON_VERSION="$(grep '^version' apps/daemon/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')"
+GIT_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+
+# ── defaults (overridable via flags) ────────────────────────────────────────
+CLOUD_API_URL=""
+MQTT_URL=""
+SKIP_BUILD=0
+OUTPUT_ZIP="${ROOT_DIR}/target/amuxd-windows-${DAEMON_VERSION}-${GIT_SHA}.zip"
+EXTRA_CARGO_ARGS=()
+
+# ── parse args ──────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cloud-api-url)  CLOUD_API_URL="$2"; shift 2 ;;
+    --mqtt-url)       MQTT_URL="$2"; shift 2 ;;
+    --skip-build)     SKIP_BUILD=1; shift ;;
+    --output)         OUTPUT_ZIP="$2"; shift 2 ;;
+    --target)         TARGET="$2"; shift 2 ;;
+    --)               shift; EXTRA_CARGO_ARGS+=("$@"); break ;;
+    -h|--help)
+      sed -n '2,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "error: unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+say()  { printf '\033[1;36m▸ %s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m⚠ %s\033[0m\n' "$*" >&2; }
+err()  { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; }
+
+# ── 1. prerequisite checks ──────────────────────────────────────────────────
+say "checking prerequisites"
+
+# rust target
+if ! rustup target list --installed 2>/dev/null | grep -q "${TARGET}"; then
+  say "installing rust target ${TARGET}"
+  rustup target add "${TARGET}"
+fi
+
+# mingw-w64 (only for gnu target)
+if [[ "${TARGET}" == *"-gnu" ]]; then
+  MINGW_GCC="x86_64-w64-mingw32-gcc"
+  if ! command -v "${MINGW_GCC}" &>/dev/null; then
+    warn "mingw-w64 not found — installing via Homebrew"
+    brew install mingw-w64
+  fi
+  if ! command -v "${MINGW_GCC}" &>/dev/null; then
+    err "mingw-w64 install failed. Run: brew install mingw-w64"
+    exit 1
+  fi
+  say "found ${MINGW_GCC}: $(command -v ${MINGW_GCC})"
+fi
+
+# ── 2. build ────────────────────────────────────────────────────────────────
+if [[ "${SKIP_BUILD}" -eq 0 ]]; then
+  say "building amuxd ${DAEMON_VERSION} for ${TARGET} (${GIT_BRANCH}@${GIT_SHA})"
+  # ring needs to know the C cross-compiler; cc crate auto-detects x86_64-w64-mingw32-gcc
+  # but we set the env explicitly for robustness.
+  export CC_x86_64_pc_windows_gnu="${MINGW_GCC:-x86_64-w64-mingw32-gcc}"
+  export AR_x86_64_pc_windows_gnu="x86_64-w64-mingw32-ar"
+  cargo build -p amuxd --release --target "${TARGET}" ${EXTRA_CARGO_ARGS[@]+"${EXTRA_CARGO_ARGS[@]}"}
+fi
+
+BINARY="target/${TARGET}/release/amuxd.exe"
+if [[ ! -f "${BINARY}" ]]; then
+  err "binary not found: ${BINARY}"
+  exit 1
+fi
+
+BINARY_SIZE="$(du -h "${BINARY}" | cut -f1)"
+say "built: ${BINARY} (${BINARY_SIZE})"
+
+# ── 3. stage package contents ───────────────────────────────────────────────
+STAGE_DIR="$(mktemp -d)"
+trap 'rm -rf "${STAGE_DIR}"' EXIT
+
+mkdir -p "${STAGE_DIR}/amuxd-windows"
+
+# copy binary
+cp "${BINARY}" "${STAGE_DIR}/amuxd-windows/amuxd.exe"
+
+# ── 4. generate setup.ps1 ───────────────────────────────────────────────────
+# The setup script runs on the Windows target machine. It:
+#   1. copies amuxd.exe to ~/.amuxd/bin/
+#   2. sets TEAMCLAW_CLOUD_API_URL (if provided)
+#   3. runs amuxd init with the invite URL (if provided)
+#   4. registers the scheduled task (install-service)
+#   5. starts the daemon
+say "generating setup.ps1"
+
+# Escape values for PowerShell single-quoted strings
+ps_escape() { echo "$1" | sed "s/'/''/g"; }
+
+cat > "${STAGE_DIR}/amuxd-windows/setup.ps1" << PS_EOF
+# setup.ps1 — Configure and start amuxd on Windows.
+#
+# Edit the variables below, then run in PowerShell:
+#   .\setup.ps1
+# Or with an invite URL:
+#   .\setup.ps1 -InviteUrl 'teamclaw://invite?token=...'
+#
+# To re-onboard with a different invite, run:
+#   .\setup.ps1 -InviteUrl 'teamclaw://invite?...' -Force
+param(
+    [string]\$InviteUrl = '',
+    [string]\$CloudApiUrl = '$(ps_escape "${CLOUD_API_URL}")',
+    [string]\$MqttUrl = '$(ps_escape "${MQTT_URL}")',
+    [switch]\$Force,
+    [switch]\$SkipInit,
+    [switch]\$SkipService
+)
+
+\$ErrorActionPreference = 'Stop'
+\$ScriptDir = Split-Path -Parent \$MyInvocation.MyCommand.Path
+\$AmuxdHome = Join-Path \$env:USERPROFILE '.amuxd'
+\$BinDir = Join-Path \$AmuxdHome 'bin'
+\$ExePath = Join-Path \$BinDir 'amuxd.exe'
+
+Write-Host '[setup] amuxd Windows setup' -ForegroundColor Cyan
+Write-Host "[setup] binary: \$ExePath"
+Write-Host "[setup] cloud API: \$CloudApiUrl"
+if (\$MqttUrl) { Write-Host "[setup] MQTT URL: \$MqttUrl" }
+
+# 1. install binary
+Write-Host '[setup] installing binary...' -ForegroundColor Cyan
+New-Item -ItemType Directory -Force -Path \$BinDir | Out-Null
+Copy-Item (Join-Path \$ScriptDir 'amuxd.exe') \$ExePath -Force
+Write-Host '[setup] binary installed.' -ForegroundColor Green
+
+# 2. set environment variable (persistent, user-level)
+if (\$CloudApiUrl) {
+    [Environment]::SetEnvironmentVariable('TEAMCLAW_CLOUD_API_URL', \$CloudApiUrl, 'User')
+    \$env:TEAMCLAW_CLOUD_API_URL = \$CloudApiUrl
+    Write-Host "[setup] set TEAMCLAW_CLOUD_API_URL = \$CloudApiUrl" -ForegroundColor Green
+}
+
+# 3. onboarding (amuxd init)
+if (-not \$SkipInit) {
+    if (\$InviteUrl) {
+        Write-Host '[setup] running onboarding...' -ForegroundColor Cyan
+        & \$ExePath init \$InviteUrl
+        if (\$LASTEXITCODE -ne 0) {
+            Write-Error "amuxd init failed (exit \$LASTEXITCODE)"
+            exit 1
+        }
+        Write-Host '[setup] onboarding complete.' -ForegroundColor Green
+    } else {
+        Write-Host '[setup] no invite URL provided — skipping onboarding.' -ForegroundColor Yellow
+        Write-Host '[setup] run: amuxd.exe init "teamclaw://invite?token=..."' -ForegroundColor Yellow
+    }
+}
+
+# 4. register service (scheduled task / autostart)
+if (-not \$SkipService) {
+    Write-Host '[setup] registering service...' -ForegroundColor Cyan
+    & \$ExePath install-service
+    if (\$LASTEXITCODE -ne 0) {
+        Write-Warning "install-service failed (exit \$LASTEXITCODE); starting manually"
+    }
+    Write-Host '[setup] service registered.' -ForegroundColor Green
+}
+
+# 5. start daemon
+Write-Host '[setup] starting daemon...' -ForegroundColor Cyan
+& \$ExePath start
+if (\$LASTEXITCODE -ne 0) {
+    Write-Warning "amuxd start exited with code \$LASTEXITCODE (may already be running)"
+}
+Write-Host '[setup] done.' -ForegroundColor Green
+Write-Host ''
+Write-Host 'Useful commands:' -ForegroundColor Cyan
+Write-Host '  amuxd.exe status     # check if daemon is running'
+Write-Host '  amuxd.exe stop       # stop the daemon'
+Write-Host '  amuxd.exe config list # view current config'
+Write-Host '  amuxd.exe doctor     # run diagnostics'
+PS_EOF
+
+# ── 5. generate README ──────────────────────────────────────────────────────
+say "generating README.md"
+
+cat > "${STAGE_DIR}/amuxd-windows/README.md" << MD_EOF
+# amuxd Windows Daemon v${DAEMON_VERSION}
+
+Build: ${GIT_BRANCH}@${GIT_SHA}
+Target: ${TARGET}
+Date: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+
+## Quick start
+
+1. Unzip this archive on a Windows machine.
+2. Edit \`setup.ps1\` or pass parameters, then run in PowerShell:
+
+\`\`\`powershell
+# Option A: provide values as parameters
+.\setup.ps1 -CloudApiUrl 'https://copilot.accounting.i.test.shopee.io' \`
+            -InviteUrl 'teamclaw://invite?token=YOUR_TOKEN&cloud_api_url=https%3A%2F%2Fcopilot.accounting.i.test.shopee.io'
+
+# Option B: interactive (no invite URL — just installs the binary)
+.\setup.ps1 -SkipInit
+\`\`\`
+
+3. Check status:
+
+\`\`\`powershell
+amuxd.exe status
+\`\`\`
+
+## What setup.ps1 does
+
+1. Copies \`amuxd.exe\` to \`%USERPROFILE%\.amuxd\bin\amuxd.exe\`
+2. Sets \`TEAMCLAW_CLOUD_API_URL\` as a persistent user env var
+3. Runs \`amuxd init\` with the invite URL (creates \`backend.toml\` + \`daemon.toml\`)
+4. Registers a Windows scheduled task (login autostart) via \`amuxd install-service\`
+5. Starts the daemon
+
+## Manual setup (without setup.ps1)
+
+\`\`\`powershell
+# 1. Install binary
+mkdir %USERPROFILE%\.amuxd\bin
+copy amuxd.exe %USERPROFILE%\.amuxd\bin\
+
+# 2. Set Cloud API URL
+setx TEAMCLAW_CLOUD_API_URL "https://copilot.accounting.i.test.shopee.io"
+
+# 3. Onboard with invite
+%USERPROFILE%\.amuxd\bin\amuxd.exe init "teamclaw://invite?token=YOUR_TOKEN"
+
+# 4. Register autostart
+%USERPROFILE%\.amuxd\bin\amuxd.exe install-service
+
+# 5. Start
+%USERPROFILE%\.amuxd\bin\amuxd.exe start
+\`\`\`
+
+## Configuration files
+
+| File | Location | Purpose |
+|------|----------|---------|
+| \`backend.toml\` | \`%USERPROFILE%\\.amuxd\backend.toml\` | Cloud API credentials (refresh token, team ID, actor ID) |
+| \`daemon.toml\` | \`%USERPROFILE%\\.amuxd\daemon.toml\` | Daemon config (MQTT, agents, HTTP) |
+
+## Network endpoints
+
+- **Cloud API**: \`$(if [[ -n "${CLOUD_API_URL}" ]]; then echo "${CLOUD_API_URL}"; else echo "<set via --cloud-api-url or setup.ps1 -CloudApiUrl>"; fi)\`
+- **MQTT WS**: \`$(if [[ -n "${MQTT_URL}" ]]; then echo "${MQTT_URL}"; else echo "<auto-resolved from Cloud API /v1/config/bootstrap>"; fi)\`
+
+The MQTT broker URL is auto-discovered: at startup the daemon calls \`GET /v1/config/bootstrap\` on the Cloud API, which returns the \`mqtt.url\` (e.g. \`wss://host/mqtt\`).
+
+## Useful commands
+
+\`\`\`powershell
+amuxd.exe status          # check daemon status
+amuxd.exe stop            # stop running daemon
+amuxd.exe config list     # view full config
+amuxd.exe config get mqtt.broker_url
+amuxd.exe config set mqtt.broker_url "wss://host/mqtt"
+amuxd.exe doctor          # run diagnostics
+amuxd.exe uninstall-service  # remove autostart task
+\`\`\`
+
+## Firewall
+
+Allow outbound HTTPS (443) for \`amuxd.exe\` — both Cloud API and MQTT-over-WSS use port 443.
+MD_EOF
+
+# ── 6. generate .env.example ────────────────────────────────────────────────
+say "generating .env.example"
+
+cat > "${STAGE_DIR}/amuxd-windows/.env.example" << ENV_EOF
+# Set these in PowerShell before running setup.ps1, or pass as parameters.
+# Cloud API endpoint (required for onboarding)
+TEAMCLAW_CLOUD_API_URL=${CLOUD_API_URL:-https://copilot.accounting.i.test.shopee.io}
+
+# MQTT broker URL (optional — auto-discovered from Cloud API bootstrap)
+# MQTT_URL=wss://copilot.accounting.i.test.shopee.io/mqtt
+
+# MQTT username/password (optional — auto-discovered from Cloud API bootstrap)
+# MQTT_USERNAME=teamclaw
+# MQTT_PASSWORD=teamclaw2026
+ENV_EOF
+
+# ── 7. zip ──────────────────────────────────────────────────────────────────
+say "packaging zip"
+mkdir -p "$(dirname "${OUTPUT_ZIP}")"
+
+# remove old zip if exists
+rm -f "${OUTPUT_ZIP}"
+
+# zip from inside the stage dir so paths are clean
+(cd "${STAGE_DIR}" && zip -r "${OUTPUT_ZIP}" amuxd-windows/)
+
+ZIP_SIZE="$(du -h "${OUTPUT_ZIP}" | cut -f1)"
+
+# ── 8. report ───────────────────────────────────────────────────────────────
+echo
+say "build complete"
+echo "  version : ${DAEMON_VERSION}"
+echo "  git     : ${GIT_BRANCH}@${GIT_SHA}"
+echo "  target  : ${TARGET}"
+echo "  binary  : ${BINARY} (${BINARY_SIZE})"
+echo "  zip     : ${OUTPUT_ZIP} (${ZIP_SIZE})"
+echo
+if [[ -z "${CLOUD_API_URL}" ]]; then
+  warn "Cloud API URL not set — edit setup.ps1 or pass --cloud-api-url"
+fi
+echo "Next: copy the zip to a Windows machine, unzip, run setup.ps1"

--- a/scripts/dev-daemon.sh
+++ b/scripts/dev-daemon.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEFAULT_CLOUD_API_URL="https://api.teamclaw-dev.ucar.cc"
+CLOUD_API_URL="${1:-${TEAMCLAW_CLOUD_API_URL:-${DEFAULT_CLOUD_API_URL}}}"
+LOG_DIR="${ROOT_DIR}/logs/dev"
+LOG_FILE="${LOG_DIR}/amuxd.log"
+
+export CARGO_TARGET_DIR="${ROOT_DIR}/.cargo-target"
+export TEAMCLAW_CLOUD_API_URL="${CLOUD_API_URL}"
+export RUST_LOG="${RUST_LOG:-info,amuxd=debug,agent_trace=info}"
+
+mkdir -p "${LOG_DIR}"
+cd "${ROOT_DIR}"
+
+echo "==> Cloud API: ${TEAMCLAW_CLOUD_API_URL}"
+echo "==> Log file: ${LOG_FILE}"
+echo "==> Stopping existing amuxd processes"
+
+if [[ -x "${HOME}/.amuxd/bin/amuxd" ]]; then
+  "${HOME}/.amuxd/bin/amuxd" stop >/dev/null 2>&1 || true
+fi
+
+if [[ -x "${CARGO_TARGET_DIR}/debug/amuxd" ]]; then
+  "${CARGO_TARGET_DIR}/debug/amuxd" stop >/dev/null 2>&1 || true
+fi
+
+echo "==> Building latest amuxd"
+cargo build -p amuxd
+
+echo "==> Starting amuxd from latest debug build"
+exec "${CARGO_TARGET_DIR}/debug/amuxd" start 2>&1 | tee "${LOG_FILE}"

--- a/scripts/dev-desktop.sh
+++ b/scripts/dev-desktop.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEFAULT_CLOUD_API_URL="https://api.teamclaw-dev.ucar.cc"
+CLOUD_API_URL="${1:-${VITE_CLOUD_API_URL:-${DEFAULT_CLOUD_API_URL}}}"
+LOG_DIR="${ROOT_DIR}/logs/dev"
+LOG_FILE="${LOG_DIR}/desktop.log"
+
+export VITE_CLOUD_API_URL="${CLOUD_API_URL}"
+export RUST_LOG="${RUST_LOG:-info,teamclaw=debug,amux=debug}"
+
+mkdir -p "${LOG_DIR}"
+cd "${ROOT_DIR}"
+
+echo "==> Cloud API: ${VITE_CLOUD_API_URL}"
+echo "==> Log file: ${LOG_FILE}"
+echo "==> Starting desktop dev build"
+exec pnpm tauri:dev 2>&1 | tee "${LOG_FILE}"

--- a/scripts/test-agent-reply-quote-flow.sh
+++ b/scripts/test-agent-reply-quote-flow.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Verify agent quote-reply data flow:
+#   daemon emit → local messages.toml reply_to_message_id
+#   client FIFO stamp → adaptTeamclawMessages keeps replyTo on partsJson path
+# Starts a freshly built amuxd in the background, runs tests, then stops it.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+export CARGO_TARGET_DIR="${ROOT_DIR}/.cargo-target"
+export RUST_LOG="${RUST_LOG:-info,amuxd=info}"
+
+AMUXD_BIN="${CARGO_TARGET_DIR}/debug/amuxd"
+LOG_DIR="${ROOT_DIR}/logs/dev"
+LOG_FILE="${LOG_DIR}/agent-reply-quote-flow.log"
+STARTED_BY_US=0
+
+cleanup() {
+  if [[ "${STARTED_BY_US}" -eq 1 ]]; then
+    echo "==> Stopping amuxd (started by this script)"
+    if [[ -x "${AMUXD_BIN}" ]]; then
+      "${AMUXD_BIN}" stop >/dev/null 2>&1 || true
+    fi
+    if [[ -x "${HOME}/.amuxd/bin/amuxd" ]]; then
+      "${HOME}/.amuxd/bin/amuxd" stop >/dev/null 2>&1 || true
+    fi
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "${LOG_DIR}"
+
+echo "==> [1/5] Stop any existing amuxd"
+if [[ -x "${HOME}/.amuxd/bin/amuxd" ]]; then
+  "${HOME}/.amuxd/bin/amuxd" stop >/dev/null 2>&1 || true
+fi
+if [[ -x "${AMUXD_BIN}" ]]; then
+  "${AMUXD_BIN}" stop >/dev/null 2>&1 || true
+fi
+sleep 1
+
+echo "==> [2/5] Build amuxd"
+cargo build -p amuxd
+
+echo "==> [3/5] Start amuxd in background"
+STARTED_BY_US=1
+# `amuxd start` keeps the parent attached on this build; background + poll status.
+nohup "${AMUXD_BIN}" start >>"${LOG_FILE}" 2>&1 </dev/null &
+disown || true
+for i in $(seq 1 80); do
+  status_out="$("${AMUXD_BIN}" status 2>&1 || true)"
+  # Avoid matching "not running".
+  if echo "${status_out}" | grep -Eq '^amuxd: running'; then
+    echo "    ${status_out}"
+    break
+  fi
+  if [[ "${i}" -eq 80 ]]; then
+    echo "ERROR: amuxd failed to become ready; status=${status_out}" >&2
+    tail -40 "${LOG_FILE}" >&2 || true
+    exit 1
+  fi
+  sleep 0.25
+done
+
+echo "==> [4/5] Daemon unit tests (reply_to persist + cloud insert stamp)"
+# Single TESTNAME filter matches all three:
+#   emit_agent_message_persists_reply_to_message_id
+#   insert_message_records_each_call_with_metadata (asserts reply_to)
+#   test_to_proto_preserves_reply_to_message_id
+cargo test -p amuxd --bin amuxd reply_to -- --nocapture
+
+echo "==> [5/5] Client adapter + FIFO + quote UI tests"
+pnpm --filter @teamclaw/app exec vitest run \
+  src/lib/__tests__/v2-message-adapter.test.ts \
+  src/lib/__tests__/pending-agent-reply-to.test.ts \
+  src/components/chat/__tests__/AgentReplyQuote.test.tsx
+
+# Guard: live dock must not wire peekPending / replyQuote anymore
+if rg -n "peekPendingAgentReplyTo|replyQuote" \
+  packages/app/src/components/chat/ChatPanel.tsx \
+  packages/app/src/components/chat/ComposerStack.tsx; then
+  echo "ERROR: live dock still references reply quote / peekPending" >&2
+  exit 1
+fi
+
+echo "==> PASS: agent reply-quote data flow checks succeeded"

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -492,7 +492,11 @@ export function createSupabaseBusinessRepository(options) {
     },
 
     async removeTeamActor(_teamId, actorId) {
-      const { error } = await supabase.rpc("remove_team_actor", { p_actor_id: actorId });
+      // Explicit amux schema: client default is already amux, but keep this
+      // belt-and-suspenders so we never resolve a stale public.remove_team_actor.
+      const { error } = await supabase
+        .schema("amux")
+        .rpc("remove_team_actor", { p_actor_id: actorId });
       if (error) throw error;
 
       // Best-effort: delete the removed actor's LiteLLM key (replaces the

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -672,6 +672,7 @@ test("removeTeamActor still succeeds when LiteLLM key deletion fails", async () 
 
   const rpc = rpcCalls.find((c) => c.name === "remove_team_actor");
   assert.ok(rpc, "expected remove_team_actor RPC call");
+  assert.equal(rpc.schema, "amux", "must call amux.remove_team_actor explicitly");
 });
 
 test("removeTeamActor deletes the actor's LiteLLM key exactly once with the deterministic key value", async () => {
@@ -979,14 +980,14 @@ function fakeSupabase({
   onUpsert = null,
   upsertData = null,
 } = {}) {
-  return {
+  const client: any = {
     auth: auth ?? {
       async getUser() {
         return { data: { user: null }, error: null };
       },
     },
-    async rpc(name, args) {
-      rpcCalls.push({ name, args });
+    async rpc(name, args, schema = null) {
+      rpcCalls.push(schema ? { name, args, schema } : { name, args });
       if (onRpc) onRpc(name, args);
       return { data: rpcData[name] ?? [], error: rpcErrors[name] ?? null };
     },
@@ -997,7 +998,18 @@ function fakeSupabase({
         upsertData,
       });
     },
+    schema(name) {
+      return {
+        rpc(rpcName, args) {
+          return client.rpc(rpcName, args, name);
+        },
+        from(table) {
+          return client.from(table);
+        },
+      };
+    },
   };
+  return client;
 }
 
 function createTableQuery(table: any, calls: any, data: any, error: any, hooks: any = {}) {

--- a/services/supabase/migrations/20260718000000_fix_remove_team_actor_amux.sql
+++ b/services/supabase/migrations/20260718000000_fix_remove_team_actor_amux.sql
@@ -1,0 +1,100 @@
+-- Fix: DELETE /v1/teams/:id/actors/:actorId fails with
+--   relation "public.actors" does not exist
+--
+-- Baseline shipped amux.remove_team_actor with hard-coded public.* table refs
+-- and search_path = public,auth,app. After S2 moved business tables to amux,
+-- the function body still pointed at the now-missing public.actors (and related
+-- tables). Listing still works via amux.actor_directory, so stale agents stay
+-- visible in RECENTS while Remove always 500s.
+--
+-- Same class of bug as 20260609000000_actor_directory_contact_amux.sql:
+-- SECURITY DEFINER function bodies are text and do not follow a table's schema
+-- move. Rewrite against amux.* and drop the obsolete daemon_invites delete
+-- (that table was removed; see tests/001_schema_shape.sql hasnt_table).
+
+create or replace function amux.remove_team_actor(p_actor_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path to 'amux', 'public', 'auth'
+as $$
+declare
+  v_team_id uuid;
+  v_actor_type text;
+  v_caller_actor uuid := amux.current_actor_id();
+  v_owned_agent_id uuid;
+begin
+  if v_caller_actor is null then
+    raise exception 'remove_team_actor requires authentication'
+      using errcode = '42501';
+  end if;
+
+  select team_id, actor_type
+    into v_team_id, v_actor_type
+  from amux.actors
+  where id = p_actor_id;
+
+  if v_team_id is null then
+    raise exception 'actor not found'
+      using errcode = '23503';
+  end if;
+
+  if v_caller_actor = p_actor_id then
+    raise exception 'cannot remove your own actor'
+      using errcode = '42501';
+  end if;
+
+  if amux.current_team_role(v_team_id) not in ('owner', 'admin') then
+    raise exception 'remove_team_actor requires owner or admin'
+      using errcode = '42501';
+  end if;
+
+  if v_actor_type = 'member' and exists (
+    select 1 from amux.team_members
+     where team_id = v_team_id and member_id = p_actor_id and role = 'owner'
+  ) then
+    if (select count(*) from amux.team_members
+          where team_id = v_team_id and role = 'owner') <= 1 then
+      raise exception 'cannot remove the last owner'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  -- Member removal: cascade-delete agents they own before dropping the member row.
+  if v_actor_type = 'member' then
+    for v_owned_agent_id in
+      select id from amux.agents where owner_member_id = p_actor_id
+    loop
+      delete from amux.agent_member_access
+       where agent_id = v_owned_agent_id or member_id = v_owned_agent_id;
+
+      delete from amux.team_members
+       where member_id = v_owned_agent_id;
+
+      -- actors delete cascades to agents (agents.id -> actors.id).
+      delete from amux.actors where id = v_owned_agent_id;
+    end loop;
+  end if;
+
+  delete from amux.agent_member_access
+   where agent_id = p_actor_id or member_id = p_actor_id;
+
+  delete from amux.team_members where member_id = p_actor_id;
+
+  if v_actor_type = 'member' then
+    delete from amux.members where id = p_actor_id;
+  else
+    delete from amux.agents where id = p_actor_id;
+  end if;
+
+  delete from amux.actors where id = p_actor_id;
+end;
+$$;
+
+comment on function amux.remove_team_actor(uuid) is
+  'Owner/admin: remove a team actor (member or agent). Cascades owned agents when removing a member. Reads/writes amux.* only.';
+
+revoke all on function amux.remove_team_actor(uuid) from public;
+grant execute on function amux.remove_team_actor(uuid) to anon;
+grant execute on function amux.remove_team_actor(uuid) to authenticated;
+grant execute on function amux.remove_team_actor(uuid) to service_role;

--- a/services/supabase/tests/024_remove_team_actor_owned_agents.sql
+++ b/services/supabase/tests/024_remove_team_actor_owned_agents.sql
@@ -1,5 +1,6 @@
 -- services/supabase/tests/024_remove_team_actor_owned_agents.sql
 -- Admin removing a member who owns agent(s) should cascade-delete those agents.
+-- Post-S2: all business tables live in amux; remove_team_actor must too.
 begin;
 
 create or replace function pg_temp.as_member(p_user uuid)
@@ -29,38 +30,39 @@ begin
      '00000000-0000-0000-0000-000000000000', false)
   on conflict do nothing;
 
-  insert into public.members (id, user_id, status)
-  values
-    (v_owner_mem,  v_owner_uid,  'active'),
-    (v_member_mem, v_member_uid, 'active');
-
-  insert into public.teams (id, slug, name)
+  insert into amux.teams (id, slug, name)
   values (v_team, 'rm-own-' || left(v_team::text, 8), 'Remove Owned Agents');
 
-  insert into public.actors (id, team_id, actor_type, display_name, user_id)
+  -- actors first (members/agents.id FK → actors.id)
+  insert into amux.actors (id, team_id, actor_type, display_name, user_id)
   values
     (v_owner_mem,  v_team, 'member', 'Owner',  v_owner_uid),
     (v_member_mem, v_team, 'member', 'Member', v_member_uid);
 
-  insert into public.team_members (team_id, member_id, role)
+  insert into amux.members (id, status)
+  values
+    (v_owner_mem,  'active'),
+    (v_member_mem, 'active');
+
+  insert into amux.team_members (team_id, member_id, role)
   values
     (v_team, v_owner_mem,  'owner'),
     (v_team, v_member_mem, 'member');
 
-  insert into public.actors (id, team_id, actor_type, display_name)
+  insert into amux.actors (id, team_id, actor_type, display_name)
   values (v_agent_actor, v_team, 'agent', 'MemberAgent');
 
-  insert into public.agents (id, agent_kind, status, owner_member_id)
-  values (v_agent_actor, 'daemon', 'active', v_member_mem);
+  insert into amux.agents (id, status, owner_member_id)
+  values (v_agent_actor, 'active', v_member_mem);
 
   perform pg_temp.as_member(v_owner_uid);
-  perform public.remove_team_actor(v_member_mem);
+  perform amux.remove_team_actor(v_member_mem);
 
-  if exists (select 1 from public.actors where id = v_member_mem) then
+  if exists (select 1 from amux.actors where id = v_member_mem) then
     raise exception 'member actor should be deleted';
   end if;
 
-  if exists (select 1 from public.actors where id = v_agent_actor) then
+  if exists (select 1 from amux.actors where id = v_agent_actor) then
     raise exception 'owned agent actor should be deleted';
   end if;
 end;


### PR DESCRIPTION
## Summary
- Fix `amux.remove_team_actor` schema drift (`public.actors` → `amux.*`) so UI Remove agent no longer fails with `relation "public.actors" does not exist`.
- Harden daemon rebinding: reject `daemon.toml` / `backend.toml` identity mismatch at startup, refuse `amuxd clear` while the daemon lock is held, and skip refresh-token persistence when `backend.toml` was rebound or deleted.
- Add local `pnpm dev:daemon` / `dev:desktop` helpers and a Windows daemon packaging script.

## Test plan
- [ ] Apply migration `20260718000000_fix_remove_team_actor_amux.sql` (or merge to main for self-host deploy), then Remove a stale agent in the desktop UI — should succeed without `public.actors` error
- [ ] Confirm `GET /v1/teams/:teamId/actors` no longer returns the removed agent; RECENTS updates after refresh
- [ ] Start amuxd with mismatched `daemon.toml` / `backend.toml` identities — process should exit with the re-onboard error
- [ ] With amuxd running, `amuxd clear` should refuse; with no config files, clear should noop even if the lock is held
- [ ] After `amuxd init` rebinds identity, a stale process must not overwrite the new `backend.toml` on token refresh


Made with [Cursor](https://cursor.com)