### PR TITLE
release(desktop): v0.2.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "amuxd"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "aes-gcm",
  "agent-client-protocol",
@@ -10270,7 +10270,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaw"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.2.26"
+version = "0.2.27"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaw"
-version = "0.2.26"
+version = "0.2.27"
 description = "TeamClaw - AI Agent Desktop Platform"
 authors = ["TeamClaw Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClaw",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "identifier": "com.teamclaw.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclaw/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclaw",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "private": true,
   "description": "TeamClaw - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
## Summary

Automated desktop release bump **→ v0.2.27** via `scripts/release-desktop.sh`.

- Version sources + `Cargo.lock` (teamclaw/amuxd) aligned
- Local frontend build + preflight passed

## Test plan

- [ ] CI green on PR
- [ ] Tag `v0.2.27` triggers Release workflow
- [ ] GitHub Release assets published (macOS DMG + Windows NSIS)