### PR TITLE
fix(ci): allow OSS release of already-tagged version

### DIFF
--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -145,7 +145,9 @@ jobs:
           VERSION="${VERSION#v}"
           node scripts/bump-desktop-version.mjs "$VERSION" --allow-noop
           ./scripts/sync-cargo-lock-version.sh
-          ./scripts/verify-release-version-bump.sh "$VERSION"
+          # Second arg excludes the tag being published so OSS can ship the same
+          # version after (or alongside) a GitHub Release tag push.
+          ./scripts/verify-release-version-bump.sh "$VERSION" "$VERSION"
 
       # Apply OS-level white-label branding BEFORE the frontend build.
       # tauri-action runs `tauri build` directly and never invokes the
@@ -458,7 +460,9 @@ jobs:
           VERSION="${VERSION#v}"
           node scripts/bump-desktop-version.mjs "$VERSION" --allow-noop
           ./scripts/sync-cargo-lock-version.sh
-          ./scripts/verify-release-version-bump.sh "$VERSION"
+          # Second arg excludes the tag being published so OSS can ship the same
+          # version after (or alongside) a GitHub Release tag push.
+          ./scripts/verify-release-version-bump.sh "$VERSION" "$VERSION"
 
       # See build-macos: brands the OS-level app name/identifier/icons before Vite
       # bundles the in-app logo. No BUILD_ENV — the brand config is authoritative.


### PR DESCRIPTION
## Summary
- OSS `release-oss.yml` called `verify-release-version-bump.sh` without excluding the tag being published.
- After tagging `v0.2.27` for GitHub Release, the copilot361 OSS run failed with "Version 0.2.27 has already been released".
- Align with `release.yml`: pass `"$VERSION" "$VERSION"` so the same tag can ship to OSS.

## Test plan
- [ ] Merge to main
- [ ] Re-dispatch `Release (OSS, multi-brand)` with `brand=copilot361` `tag=v0.2.27`
- [ ] Confirm Sync + verify step passes and publish completes

Made with [Cursor](https://cursor.com)