### PR TITLE
perf(ci): stop burning ~10min per OSS release on wasted compiles

### DIFF
--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -70,6 +70,16 @@ jobs:
           - target: x86_64-apple-darwin
             runner: macos-latest
     runs-on: ${{ matrix.runner }}
+    # Job-level, not step-level: these used to sit only on the tauri-action step,
+    # so the amuxd and teamclaw-introspect sidecar builds (and the Cargo.lock
+    # sync) compiled with no sccache at all — despite sharing most of their
+    # dependency graph with the tauri build that follows. Every cargo invocation
+    # in this job now shares one sccache. The `Setup sccache` step still has to
+    # run before the first cargo call for this to work; it does.
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -255,9 +265,6 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           DEVICE_JWT_SECRET: ${{ secrets.DEVICE_JWT_SECRET }}
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: sccache
-          CARGO_INCREMENTAL: "0"
         with:
           # BRAND_MAC_EXTRA_ARGS comes from brand.json build.macExtraArgs — betly
           # passes --features beta-devtools to enable the WebKit inspector in the
@@ -389,6 +396,12 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    # See build-macos: hoisted off the tauri-action step so the amuxd (~495s) and
+    # introspect (~87s) sidecar builds get sccache too.
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -510,9 +523,6 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           DEVICE_JWT_SECRET: ${{ secrets.DEVICE_JWT_SECRET }}
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: sccache
-          CARGO_INCREMENTAL: "0"
         with:
           args: "--bundles nsis -- --no-default-features"
 

--- a/scripts/sync-cargo-lock-version.sh
+++ b/scripts/sync-cargo-lock-version.sh
@@ -8,7 +8,16 @@ cd "$REPO_ROOT"
 DESKTOP_VERSION="$(node -e "console.log(require('./package.json').version)")"
 
 echo "Syncing Cargo.lock for desktop v${DESKTOP_VERSION}…"
-cargo build --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect -p amuxd >/dev/null
+# Re-resolve ONLY the workspace members, so the `teamclaw` / `amuxd` entries pick
+# up the version just written into their Cargo.toml. Third-party dependencies are
+# left pinned exactly as the lock has them — this is not `generate-lockfile`.
+#
+# This used to be a `cargo build` of teamclaw-introspect + amuxd, relying on the
+# fact that any build refreshes the lock as a side effect. That worked, but it
+# paid for two full debug compiles (~290s on the windows runner, ~190s on macOS,
+# per release job) and threw the artifacts away — they are debug profile, so they
+# did not even warm the release build that follows.
+cargo update --workspace --manifest-path apps/desktop/Cargo.toml
 
 # \r? on every newline: the repo ships no .gitattributes, so Git for Windows
 # checks Cargo.lock out with CRLF endings on the windows runner. An \n-anchored
@@ -39,7 +48,11 @@ if [[ "$LOCK_TEAMCLAW" != "$DESKTOP_VERSION" || "$LOCK_AMUXD" != "$DESKTOP_VERSI
   exit 1
 fi
 
-echo "Verifying cargo build --locked…"
-cargo build --locked --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect -p amuxd >/dev/null
+# Prove the lock is complete and consistent with every Cargo.toml, which is the
+# only thing the subsequent `cargo build --locked` steps need from it. `cargo
+# metadata --locked` resolves the full graph and fails if the lock would have to
+# change — same guarantee as the old verification build, without compiling.
+echo "Verifying Cargo.lock is up to date (--locked)…"
+cargo metadata --locked --format-version 1 --manifest-path apps/desktop/Cargo.toml >/dev/null
 
 echo "✓ Cargo.lock synced (teamclaw + amuxd = ${DESKTOP_VERSION})"


### PR DESCRIPTION
## 背景

`release-oss.yml` 一次 ~45 分钟，关键路径是 **build-windows（2714s）**。从成功 run [`29554588459`](https://github.com/different-ai-studio/teamclaw/actions/runs/29554588459) 拉的逐步耗时：

| 步骤 | 耗时 |
|---|---|
| tauri-action（真正的 release 编译） | 1216s |
| Build amuxd sidecar | 495s |
| Sync + verify version bump | 287s |
| Post Rust cache | 181s |

本 PR 处理其中两处**纯浪费**，不改动构建产物本身。

## 1. Cargo.lock 同步不再靠编译

`scripts/sync-cargo-lock-version.sh` 原本跑两次 `cargo build`（一次刷 lock，一次 `--locked` 复验），利用「任何 build 都会顺带重写 Cargo.lock」这个副作用。代价是 windows ~287s、macOS 两个 job 各 ~189s，而产物直接丢弃——且是 debug profile，连后续 release 构建的缓存都热不了。

换成 `cargo update --workspace`（只重解析 workspace 成员，第三方 pin 不动，**不是** `generate-lockfile`）+ `cargo metadata --locked`（同样能证明 lock 与所有 Cargo.toml 一致，但不编译）。

本地实测 **287s → 4s**。

## 2. sccache 覆盖到全部 cargo 调用

`SCCACHE_GHA_ENABLED` / `RUSTC_WRAPPER` / `CARGO_INCREMENTAL` 原本只挂在 tauri-action 那一步的 `env:` 上，所以 amuxd sidecar（windows 495s）和 teamclaw-introspect（87s）**完全没走 sccache** 就裸编译了一遍——尽管它们和紧随其后的 tauri 构建共享绝大部分依赖树。提到 `build-macos` / `build-windows` 的 job 级。

`build-amuxd-linux` 刻意不动：它没有 sccache-action，且跑 `cargo install cross`，job 级 `RUSTC_WRAPPER` 会波及它。

## 验证

本地验证了三点：
- 版本变更时 lock 中 `teamclaw` / `amuxd` 确实被刷成新版本
- `cargo metadata --locked` 在 lock 陈旧时**会**失败（原脚本的把关能力未削弱）
- 改动后 `verify-release-version-bump.sh` 仍然通过

## 已知未验证项

- **#2 的收益是推断的，无法本地实测**，真实数字要等第一次 run。且首次 run 因 sccache 缓存冷会偏慢，**看第二次才准**。
- `release.yml`（GitHub Release 那条线）大概率有同样两个问题，本 PR 未涉及。

🤖 Generated with [Claude Code](https://claude.com/claude-code)