### PR TITLE
fix: unbreak main — 3 breaks (amuxd compile, frontend lint, dead i18n key)

### DIFF
--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -311,6 +311,7 @@ impl DaemonServer {
                     "",
                     "",
                     "",
+                    "",
                     0,
                 )
                 .await

--- a/packages/app/src/lib/backend/cloud-api/__tests__/http.test.ts
+++ b/packages/app/src/lib/backend/cloud-api/__tests__/http.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { CloudApiError, createCloudApiClient } from "../http";
+import { createCloudApiClient } from "../http";
 
 const sessionMocks = vi.hoisted(() => ({
   accessToken: "token-a",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1118,7 +1118,6 @@
       "teamSharedModelTooltip": "Configure the team-shared AI model proxy and model list",
       "teamSharedBadge": "Team Shared",
       "teamSharedNoModelsDetected": "No models detected",
-      "teamSharedModelsCount": "{{count}} shared models",
       "teamSharedReadOnly": "Only the team owner can edit",
       "refreshTooltip": "Refresh providers from OpenCode",
       "refreshing": "Refreshing...",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1118,7 +1118,6 @@
       "teamSharedModelTooltip": "配置团队共享 AI 模型的代理地址与模型列表",
       "teamSharedBadge": "团队共享",
       "teamSharedNoModelsDetected": "未检测到可用模型",
-      "teamSharedModelsCount": "{{count}} 个共享模型",
       "teamSharedReadOnly": "仅团队 owner 可编辑",
       "refreshTooltip": "从 OpenCode 刷新提供商",
       "refreshing": "刷新中...",


### PR DESCRIPTION
main 当前**同时有两处坏点**，任何发布/合并都会挂。两个都是各自 CI 通过、合并后从未一起编译/lint 的语义冲突。

## 1. amuxd 编译不过 🔴 (E0061)

```
error[E0061]: this method takes 11 arguments but 10 arguments were supplied
  --> apps/daemon/src/daemon/server/cron.rs:304:18
     - argument #10 of type `&str` is missing   // reply_to_message_id
```

`backend/mod.rs:432` 的 `insert_message` 新增了第 10 个参数 `reply_to_message_id: &str`（在 `sequence` 之前），`cron.rs:304` 的新调用点漏传。cron 用户 prompt 无 reply 目标，补 `""`，与该调用已有的 metadata_json / model / turn_id 空串一致，也和权威调用点 `teamclaw/session_manager.rs:1270` 一致。本地 `cargo build -p amuxd` 通过。

## 2. 前端 lint 不过 🔴

```
error  'CloudApiError' is defined but never used  @typescript-eslint/no-unused-vars
  --> packages/app/src/lib/backend/cloud-api/__tests__/http.test.ts:2
```

新增的 cloud-api http 测试 import 了 `CloudApiError` 却没用，`eslint .` 直接 fail。删掉未用 import。本地 eslint 该文件已 clean。

## 背景

发现于手动触发 copilot361 OSS 发布（run 29797250501，已取消以免浪费 ~40min 构建额度）。这是重新测量/优化发布耗时的前置条件。

## 为什么会漏进 main

两处都是 `require branches up to date` 未开启导致的：各 PR 独立 CI 通过，合并 commit 本身从未被 CI。建议后续考虑开启该分支保护。

🤖 Generated with [Claude Code](https://claude.com/claude-code)