### PR TITLE
fix(app): unify agent device reachability and reduce redundant runtime ensures

### DIFF
--- a/docs/architecture/agent-device-reachability-and-runtime-ensure.md
+++ b/docs/architecture/agent-device-reachability-and-runtime-ensure.md
@@ -1,0 +1,323 @@
+# Agent 设备可达性 & Runtime Ensure 流程
+
+**维护者文档** — 说明桌面客户端如何判断「agent 的 daemon 是否在线」，以及何时 / 为何触发 `runtimeStart`。
+
+**相关修复：** stale MQTT LWT offline retain 导致误报 `device_offline` toast（`Agent runtime not started`）。
+
+**最后更新：** 2026-07-21
+
+---
+
+## 1. 一句话结论
+
+**「agent 设备是否在线」与「会话 ACP runtime 是否已启动」是两层信号。**  
+设备层由 `agent-device-reachability.ts` 统一 merge；runtime 层由 `runtime-state-store` + `ensureAgentRuntimesForSession` 负责。  
+**本机 daemon 的 `/v1/info.mqtt_connected` 优先于 MQTT broker 上的 LWT retain**，避免 daemon 实际在跑却被 gate 成 offline。
+
+---
+
+## 2. 两层信号（不要混用）
+
+| 层 | MQTT topic | Store | 含义 |
+|----|------------|-------|------|
+| **设备 / Daemon 在线** | `amux/{team}/{actor}/state` | `useActorPresenceStore` | 该 actor 的 amuxd 进程是否与 broker 保持连接（含 LWT） |
+| **会话 Runtime 状态** | `amux/{team}/{actor}/runtime/{id}/state` | `useRuntimeStateStore` | 某次 ACP spawn 的生命周期（ACTIVE / IDLE / …）及 `availableModels` |
+
+典型误踩坑：
+
+- **Runtime retain 仍在 ACTIVE**，但 daemon 已死 → 设备层 offline，runtime retain 可能滞后。
+- **设备层 MQTT retain 仍是 offline**（stale LWT），但 daemon 已重连且 `/v1/info.mqtt_connected=true` → 修复前会误 toast；修复后 merge 为 online。
+
+```mermaid
+flowchart TB
+  subgraph device ["设备层 (ActorPresence)"]
+    LWT["Broker LWT retain<br/>amux/.../state"]
+    Info["Daemon GET /v1/info<br/>mqtt_connected"]
+    Merge["mergeAgentDevicePresence()"]
+    LWT --> Merge
+    Info --> Merge
+  end
+
+  subgraph runtime ["Runtime 层 (RuntimeInfo)"]
+    Retain["MQTT retain<br/>.../runtime/{id}/state"]
+    Ensure["ensureAgentRuntimesForSession<br/>→ runtimeStart RPC"]
+    Retain --> Ensure
+  end
+
+  Merge -->|"offline → gate 拦截"| Ensure
+  Merge -->|"online → 继续"| Ensure
+  Ensure --> Retain
+```
+
+---
+
+## 3. 设备可达性 — 单一 merge 规则
+
+**源文件：** `packages/app/src/lib/agent-device-reachability.ts`
+
+### 3.1 输入
+
+| 字段 | 来源 |
+|------|------|
+| `mqttOnline` | `useActorPresenceStore.byActorId[agentId].online` |
+| `isLocalDaemon` | `getKnownLocalDaemonActorId() === agentId` |
+| `daemonMqttConnected` | `GET /v1/info` → `mqtt_connected`（仅本机 daemon） |
+| `localHttpOk` | `probeDaemonHttp()` → healthz + token exchange |
+
+### 3.2 `mergeAgentDevicePresence()` 优先级
+
+**本机 daemon（`isLocalDaemon === true`）：**
+
+1. `daemonMqttConnected === true` → **`online`**（覆盖 stale offline **和** ghost online retain）
+2. `daemonMqttConnected === false` → **`offline`**
+3. 否则看 MQTT retain：
+   - `mqttOnline === true` → online
+   - `mqttOnline === false` + `localHttpOk === true` → **`unknown`**（HTTP 通但 daemon mqtt 未知）
+   - `mqttOnline === false` + `localHttpOk === false` → offline
+   - retain 缺失 + `localHttpOk === true` → online（bootstrap）
+
+**远端 agent：**
+
+- MQTT online → online
+- MQTT offline → offline
+- retain 缺失 → unknown（**never 直接当 offline**）
+
+### 3.3 Sync vs Async
+
+| API | 用途 | 数据源 |
+|-----|------|--------|
+| `resolveAgentDevicePresenceSync()` | Sidebar、Actor 列表、pill 过滤、绿点 | MQTT store + **5s TTL cache** |
+| `resolveAgentDevicePresence()` | `runtimeStart` 前的 **gate** | 必要时拉 `/v1/info`，写入 cache |
+
+**Cache：** `noteLocalDaemonSignals()` / `LOCAL_DAEMON_SIGNAL_CACHE_TTL_MS = 5000`。  
+由 `use-local-daemon-http-status`、`resolveLocalDaemonSignals()` 预热。
+
+> **维护注意：** daemon 刚 stop 的 ~5s 内，cache 里可能仍是 `daemonMqttConnected: true`，UI/gate 会短暂显示 online。cache 过期后会正确变为 offline。这是设计 trade-off，不是 stale LWT bug。
+
+### 3.4 本机 actor 身份
+
+**源文件：** `packages/app/src/lib/local-daemon-identity.ts`
+
+- `noteLocalDaemonActorId(id)` — 从 `/v1/info` 或 sidebar 写入，持久化到 `localStorage`（`{appShortName}-local-daemon-actor-id`）
+- `getKnownLocalDaemonActorId()` — sync merge 判断「是否本机 agent」
+
+---
+
+## 4. Runtime Ensure 主流程
+
+**源文件：** `packages/app/src/lib/teamclaw/ensure-agent-runtime.ts`
+
+### 4.1 调用链
+
+```
+ensureAgentRuntimesForSession(args)
+  ├─ shouldSkipAlreadyReadyRuntimeEnsure? → return（wake 路径跳过）
+  ├─ inFlight dedupe（同 session + agents）
+  ├─ Desktop MQTT disconnected? → toast transport_offline
+  ├─ ensureSessionLiveSubscribed
+  ├─ waitForTeamclawRpcReady(20s)
+  ├─ gateAgentsForRuntimeStart
+  │     └─ resolveAgentDevicePresence() per agent
+  │           offline → failure code device_offline（toast）
+  ├─ ensureAgentIsSessionParticipant
+  ├─ resolveSessionWorkspaceHintForRuntimeStart
+  ├─ startAgentRuntimesAsync（MQTT runtimeStart RPC）
+  └─ 等 runtime retain 出现 models（最多 12s）
+```
+
+### 4.2 Gate 失败码
+
+| code | 含义 | 常见原因 |
+|------|------|----------|
+| `device_offline` | merge 结果为 offline | 真 offline、或修复前的 stale LWT |
+| `transport_offline` | Desktop MQTT 断 | `useMqttReconnectStore.connected === false` |
+| `runtime_rejected` / `runtime_rpc_failed` | RPC 层失败 | daemon busy、workspace 问题 |
+| `workspace_*` | workspace ensure 超时 / 失败 | 团队 share 未就绪 |
+
+Toast 文案：`daemon.agentRuntime.notStartedTitle` + `failureDescription()`。
+
+### 4.3 超时常量
+
+**源文件：** `packages/app/src/lib/teamclaw/runtime-rpc-timeouts.ts`
+
+- `DEVICE_PRESENCE_GATE_TIMEOUT_MS = 2000` — gate 等 MQTT retain
+- `RUNTIME_START_RPC_TIMEOUT_MS = 20000` — runtimeStart RPC
+
+---
+
+## 5. Runtime Ensure 调度 — 何时 skip
+
+**源文件：** `packages/app/src/lib/teamclaw/runtime-ensure-scheduler.ts`
+
+### 5.1 Reason 分类
+
+**Wake 路径（可 skip 已 ready runtime）：**
+
+| reason | 触发方 |
+|--------|--------|
+| `session_focus` | 切换会话 |
+| `session_runtime_wake` | 同会话 pill 变 connecting |
+| `session_runtime_retry` | 15s 定时重试 |
+| `mqtt_reconnect_ensure` | Desktop MQTT 重连 |
+| `session_auto_engage` | 打开 sole-agent 会话自动 engage |
+
+**Bind 路径（永不 skip，必须能绑新会话）：**
+
+| reason | 触发方 |
+|--------|--------|
+| `session_create` | 新建会话（非 auto-mention 的 agent） |
+| `outbox_send` | 发消息 / outbox |
+| `mention_pill` | @ agent pill |
+| `offline_banner_retry` | 用户点 offline banner 重试 |
+
+`shouldSkipAlreadyReadyRuntimeEnsure()`：wake reason **且** 所有 agent 的 MQTT retain 已是 `ACTIVE` + 有 `availableModels` → 跳过 `runtimeStart`。
+
+**Throttle：** 同 `sessionId + agentIds` 3s 内不重复 ensure（`RUNTIME_ENSURE_MIN_INTERVAL_MS`）。
+
+### 5.2 新建 sole-agent 会话的去重
+
+**源文件：** `packages/app/src/components/chat/ChatPanel.tsx`
+
+ sole member + sole agent 创建会话时会 **auto-mention** → `outbox_send` 已 ensure。  
+ 此时打日志 `session_create.runtime_start.delegated_to_outbox`，**不再**发 `session_create` ensure，避免重复 RPC。
+
+---
+
+## 6. UI 消费方（统一走 merge）
+
+| 表面 | 文件 | API |
+|------|------|-----|
+| Sidebar Actor 行 | `ActorRow.tsx`, `ActorsView.tsx` | `resolveActorOnlineStatus()` → sync merge |
+| @ 提及弹层 | `MentionPopover.tsx` | 同上 |
+| 会话参与者绿点 | `SessionActorSheet.tsx` | sync merge |
+| Agent pill 状态 | `use-engaged-agent-ui-states.ts` | merge + runtime retain |
+| 本机 daemon 卡片 | `use-local-daemon-http-status.ts` | `mergeAgentDevicePresence` + probe |
+| Actor 目录在线 | `lib/actor-online.ts` | agent 走 sync merge；member 走 `last_active_at` |
+
+**原则：** 不要再直接读 `useActorPresenceStore.byActorId[id].online` 当最终 UI 结论（本机 agent 除外需 merge）。
+
+---
+
+## 7. Session focus 唤醒逻辑
+
+**源文件：** `packages/app/src/hooks/use-ensure-engaged-runtimes-on-session-focus.ts`
+
+- **切换会话：** `session_focus` → `agentIdsNeedingRecoverableRuntimeWake`
+  - 含 `connecting`
+  - 含 `offline` **但** `resolveAgentDevicePresenceSync !== 'offline'`（排除 hard offline）
+- **同会话内：** 只对 **新变 connecting** 的 agent 发 `session_runtime_wake`（不对 offline 反复 wake）
+- **15s 定时：** `session_runtime_retry`，条件同 recoverable wake
+
+MQTT 重连：**`use-reensure-runtimes-on-mqtt-reconnect.ts`** → `mqtt_reconnect_ensure`。
+
+---
+
+## 8. 调试手册
+
+### 8.1 日志
+
+| 渠道 | 过滤 / 操作 |
+|------|-------------|
+| Console | `[session-flow]` — 创建会话、ensure、delegated_to_outbox、skip_already_ready |
+| Settings → General | **ACP stream debug** — `client:runtime_start_failed`, `client:ensure_runtime_begin` |
+| Console | `window.__teamclawMqttDiag()` — Desktop MQTT、team、presence store 快照 |
+
+### 8.2 本机 daemon
+
+```bash
+curl -s -H "Authorization: Bearer $(cat ~/.amuxd/amuxd.http.token)" \
+  "http://127.0.0.1:$(cat ~/.amuxd/amuxd.http.port)/v1/info" | python3 -m json.tool
+```
+
+关注：`actor_id`、`mqtt_connected`。
+
+### 8.3 开发态 App 内注入（tauri-mcp）
+
+`execute_js` **不会 await Promise**。需用「写入 `window.__tcTest` + 轮询」模式，或跑仓库内 live 脚本（见 §9）。
+
+### 8.4 常见问题排查
+
+| 现象 | 先查 |
+|------|------|
+| `device_offline` toast | `/v1/info.mqtt_connected` vs presence store raw；是否本机 agent |
+| `transport_offline` toast | Desktop MQTT（`__teamclawMqttDiag`），不是 daemon |
+| pill 长期 connecting | runtime retain 是否有 models；ensure 是否被 skip/throttle |
+| Sidebar 与 pill 状态不一致 | 是否有人绕开 merge 直读 presence store |
+| daemon 停后仍显示 online ~5s | signal cache TTL，见 §3.3 |
+
+---
+
+## 9. 测试
+
+### 9.1 单元测试
+
+```bash
+cd packages/app && pnpm exec vitest run \
+  src/lib/__tests__/agent-device-reachability.test.ts \
+  src/lib/teamclaw/__tests__/ensure-agent-runtime-presence.test.ts \
+  src/lib/teamclaw/__tests__/runtime-ensure-scheduler.test.ts \
+  src/hooks/__tests__/use-ensure-engaged-runtimes-on-session-focus.test.ts \
+  src/lib/__tests__/actor-online.test.ts
+```
+
+### 9.2 功能 E2E（tauri-mcp）
+
+需 `pnpm tauri:dev` 运行且 `/tmp/tauri-mcp.sock` 存在：
+
+```bash
+pnpm exec vitest run --config vitest.config.e2e.ts \
+  tests/functional/chat-session-send.test.ts
+```
+
+### 9.3 Live 验证脚本（维护者本地）
+
+在 dev App 运行时，可用 tauri-mcp 注入 stale offline 并断言 merge（脚本示例曾放于 `/tmp/teamclaw-reachability-live.mts`）。  
+核心断言：
+
+- inject `mqttOnline=false` + `daemonMqttConnected=true` → `async === 'online'`
+- amuxd stop + cache 过期 → `async === 'offline'`
+- amuxd restart + stale offline retain → `async === 'online'`
+
+**注意：** `scripts/amuxdctl.sh start` 会触发 cargo build，较慢；快速停启可用：
+
+```bash
+.cargo-target/debug/amuxd stop
+.cargo-target/debug/amuxd start --daemonize
+```
+
+---
+
+## 10. 相关文件索引
+
+| 职责 | 路径 |
+|------|------|
+| Merge 规则 + sync/async resolve | `packages/app/src/lib/agent-device-reachability.ts` |
+| 本机 actor id | `packages/app/src/lib/local-daemon-identity.ts` |
+| MQTT presence store | `packages/app/src/stores/actor-presence-store.ts` |
+| Runtime retain store | `packages/app/src/stores/runtime-state-store.ts` |
+| Ensure 入口 | `packages/app/src/lib/teamclaw/ensure-agent-runtime.ts` |
+| Skip / throttle | `packages/app/src/lib/teamclaw/runtime-ensure-scheduler.ts` |
+| Focus / retry hooks | `packages/app/src/hooks/use-ensure-engaged-runtimes-on-session-focus.ts` |
+| MQTT 重连 ensure | `packages/app/src/hooks/use-reensure-runtimes-on-mqtt-reconnect.ts` |
+| Outbox send ensure | `packages/app/src/services/outbox-sender.ts` |
+| Actor 在线（目录） | `packages/app/src/lib/actor-online.ts` |
+| Daemon HTTP / sidebar status | `packages/app/src/hooks/use-local-daemon-http-status.ts` |
+| runtimeStart RPC | `packages/app/src/lib/session-create.ts` |
+
+---
+
+## 11. 修改指南（给后续开发者）
+
+1. **新增「agent 是否在线」UI** → 用 `resolveAgentDevicePresenceSync` 或 `resolveActorOnlineStatus`，不要直读 MQTT store。
+2. **新增 ensure 调用点** → 选对 `reason`：绑新会话用 bind reason；切 tab / 重连用 wake reason。
+3. **改 merge 规则** → 同时更新 `agent-device-reachability.test.ts` 与 `ensure-agent-runtime-presence.test.ts`。
+4. **改 skip 逻辑** → 更新 `runtime-ensure-scheduler.test.ts` 与 focus hook 测试。
+5. **不要**把 Desktop MQTT 断连与 daemon device offline 混为一谈 — gate 里两者分开处理。
+
+---
+
+## 12. 延伸阅读
+
+- Daemon 侧 agent 发现 / advertise：`docs/architecture/agent-backend-discovery-and-advertise.md`
+- Runtime 与 interrupt 陈旧 spawn：`docs/debug/interrupt-agent-stale-runtime.md`
+- tauri-mcp 测试：`apps/desktop/tauri-plugin-mcp-local/README.md`

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -1749,22 +1749,32 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
       const autoMentionAgents: AttachedAgent[] = soleAgent ? [soleAgent] : [];
       await sendIntoSession(sessionId, firstMessage, autoMentionAgents);
 
-      // Fire-and-forget runtime spawn — UI has already moved into the
-      // session; status dots update via RuntimeInfo subscriptions.
-      if (picks.agents.length > 0) {
+      // Fire-and-forget runtime spawn for agents that outbox won't cover.
+      // Sole-agent create auto-mentions → outbox_send already ensures; skip
+      // duplicate session_create ensure for those ids.
+      const autoMentioned = new Set(autoMentionAgents.map((a) => a.id));
+      const agentsNeedingCreateEnsure = agentIds.filter((id) => !autoMentioned.has(id));
+      if (agentsNeedingCreateEnsure.length > 0) {
         sessionFlowLog("session_create.runtime_start.begin", {
           teamId: teamIdForSend,
           sessionId,
-          agentActorIds: agentIds,
+          agentActorIds: agentsNeedingCreateEnsure,
+          skippedAutoMentioned: agentIds.filter((id) => autoMentioned.has(id)),
         });
         void import("@/lib/teamclaw/ensure-agent-runtime").then(({ ensureAgentRuntimesForSession }) => {
           void ensureAgentRuntimesForSession({
             sessionId,
             teamId: teamIdForSend,
-            agentActorIds: agentIds,
+            agentActorIds: agentsNeedingCreateEnsure,
             modelId: selectedModelKey ?? undefined,
             reason: "session_create",
           });
+        });
+      } else if (agentIds.length > 0) {
+        sessionFlowLog("session_create.runtime_start.delegated_to_outbox", {
+          teamId: teamIdForSend,
+          sessionId,
+          agentActorIds: agentIds,
         });
       }
     } catch (e) {

--- a/packages/app/src/components/chat/MentionPopover.tsx
+++ b/packages/app/src/components/chat/MentionPopover.tsx
@@ -4,6 +4,10 @@ import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 import { getBackend } from '@/lib/backend'
 import { useSessionSelectionStore } from '@/stores/session-selection-store'
+import {
+  presenceOnlineFlag,
+  resolveAgentDevicePresenceSync,
+} from '@/lib/agent-device-reachability'
 import { useActorPresenceStore } from '@/stores/actor-presence-store'
 import { isSupersededLocalAgent } from '@/lib/local-daemon-identity'
 import { type MentionedPerson } from '@/packages/ai/prompt-input'
@@ -110,7 +114,8 @@ export function MentionPopover({
 }: MentionPopoverProps) {
   const { t } = useTranslation()
   const sessionId = useSessionSelectionStore(s => s.currentSessionId)
-  const presenceByActor = useActorPresenceStore((s) => s.byActorId)
+  // Keep a subscription so agent status labels refresh with presence changes.
+  useActorPresenceStore((s) => s.byActorId)
   const [rows, setRows] = React.useState<ParticipantRow[]>([])
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState(false)
@@ -429,13 +434,13 @@ export function MentionPopover({
               </div>
               {agents.map(a => {
                 const index = currentIndex++
-                const presence = presenceByActor[a.id]
+                const online = presenceOnlineFlag(resolveAgentDevicePresenceSync(a.id))
                 const stale = isSupersededLocalAgent(a.id)
                 const statusLabel = stale
                   ? t('chat.sessionAgent.mentionStale')
-                  : presence?.online === false
+                  : online === false
                     ? t('chat.sessionAgent.mentionOffline')
-                    : presence?.online === true
+                    : online === true
                       ? null
                       : t('chat.sessionAgent.mentionConnecting')
                 return (

--- a/packages/app/src/components/chat/SessionActorSheet.tsx
+++ b/packages/app/src/components/chat/SessionActorSheet.tsx
@@ -17,6 +17,10 @@ import { syncActorsForTeam } from '@/lib/sync/actor-sync'
 import { syncParticipantsForSession } from '@/lib/sync/session-participant-sync'
 import { cn } from '@/lib/utils'
 import { useRuntimeStateStore } from '@/stores/runtime-state-store'
+import {
+  presenceOnlineFlag,
+  resolveAgentDevicePresenceSync,
+} from '@/lib/agent-device-reachability'
 import { useActorPresenceStore } from '@/stores/actor-presence-store'
 import { RuntimeLifecycle, AgentStatus, type RuntimeInfo } from '@/lib/proto/amux_pb'
 import { resolveAmuxAgentType } from '@/lib/amux-agent-type'
@@ -228,12 +232,13 @@ function ActorRowView({
   const { t } = useTranslation()
   const isAgent = actor.actor_type === 'agent'
   const initials = actor.display_name?.slice(0, 2).toUpperCase() || ''
-  // For agents, presence is keyed by the agent's actor id. `undefined` (no
-  // retain yet) ≠ `false` (LWT fired): only the explicit `false` should
-  // suppress the green dot.
-  const agentDeviceOnline = useActorPresenceStore((s) =>
-    isAgent ? s.byActorId[actor.id]?.online : undefined,
-  )
+  // Shared device-presence merge (same rule as runtime gate / sidebar).
+  // Subscribe to MQTT presence so re-renders happen; resolve via sync helper
+  // which can override stale LWT with cached local daemon signals.
+  useActorPresenceStore((s) => (isAgent ? s.byActorId[actor.id]?.online : undefined))
+  const agentDeviceOnline = isAgent
+    ? presenceOnlineFlag(resolveAgentDevicePresenceSync(actor.id))
+    : undefined
   const { color: dotColor, breathing } = computeDotStateAndAnimation(actor, runtimeInfo, agentDeviceOnline)
   // For agents, show "<backend type> · <model>" — e.g. "claude · claude-opus-4-7".
   // backend type = default_agent_type (claude | opencode | codex).

--- a/packages/app/src/components/panel/ActorsView.tsx
+++ b/packages/app/src/components/panel/ActorsView.tsx
@@ -64,12 +64,10 @@ function ActorRowView({
   // For an agent with no presence entry at all (daemon never connected
   // since the app launched), fall back to last_active_at so freshly-loaded
   // sessions don't show every agent as gray during the first second.
-  const agentPresence = useActorPresenceStore((s) => isAgent ? s.byActorId[actor.id] : undefined)
+  // Subscribe so agent rows re-render when MQTT presence / local cache changes.
+  useActorPresenceStore((s) => (isAgent ? s.byActorId[actor.id]?.online : undefined))
   const currentMemberActorId = useCurrentTeamStore((s) => s.currentMember?.id ?? null)
-  const online = resolveActorOnlineStatus(actor, {
-    currentMemberActorId,
-    agentPresence,
-  })
+  const online = resolveActorOnlineStatus(actor, { currentMemberActorId })
   const status = actor.actor_type === 'member' ? actor.member_status : actor.agent_status
   const initial = actor.display_name?.trim().slice(0, 1).toUpperCase() || ''
   const enterActorDraft = useUIStore((s) => s.enterActorDraft)

--- a/packages/app/src/components/sidebar/ActorRow.tsx
+++ b/packages/app/src/components/sidebar/ActorRow.tsx
@@ -32,9 +32,10 @@ export function ActorRow({
 }: Props) {
   const { t } = useTranslation()
   const isAgent = actor.actor_type === 'agent'
-  const agentPresence = useActorPresenceStore((s) => isAgent ? s.byActorId[actor.id] : undefined)
+  // Subscribe so agent rows re-render when MQTT presence / local cache changes.
+  useActorPresenceStore((s) => (isAgent ? s.byActorId[actor.id]?.online : undefined))
   const currentMemberActorId = useCurrentTeamStore((s) => s.currentMember?.id ?? null)
-  const online = resolveActorOnlineStatus(actor, { currentMemberActorId, agentPresence })
+  const online = resolveActorOnlineStatus(actor, { currentMemberActorId })
   const c = actorAvatarColor(actor.id)
 
   return (

--- a/packages/app/src/hooks/__tests__/use-ensure-engaged-runtimes-on-session-focus.test.ts
+++ b/packages/app/src/hooks/__tests__/use-ensure-engaged-runtimes-on-session-focus.test.ts
@@ -43,25 +43,20 @@ describe('agentIdsNeedingRuntimeWake', () => {
     ).toBe(true)
   })
 
-  it('hasRecoverableNonReadyAgent excludes LWT-offline agents', () => {
-    expect(
-      hasRecoverableNonReadyAgent(
-        [entry('a1', 'offline')],
-        { a1: { online: false } },
-      ),
-    ).toBe(false)
-    expect(
-      hasRecoverableNonReadyAgent(
-        [entry('a1', 'offline')],
-        { a1: { online: true } },
-      ),
-    ).toBe(true)
-    expect(
-      hasRecoverableNonReadyAgent(
-        [entry('a1', 'offline')],
-        {},
-      ),
-    ).toBe(true)
+  it('hasRecoverableNonReadyAgent excludes LWT-offline agents', async () => {
+    const { useActorPresenceStore } = await import('@/stores/actor-presence-store')
+    useActorPresenceStore.setState({
+      byActorId: { a1: { online: false, displayName: 'a', lastUpdated: 0 } },
+    })
+    expect(hasRecoverableNonReadyAgent([entry('a1', 'offline')])).toBe(false)
+
+    useActorPresenceStore.setState({
+      byActorId: { a1: { online: true, displayName: 'a', lastUpdated: 0 } },
+    })
+    expect(hasRecoverableNonReadyAgent([entry('a1', 'offline')])).toBe(true)
+
+    useActorPresenceStore.setState({ byActorId: {} })
+    expect(hasRecoverableNonReadyAgent([entry('a1', 'offline')])).toBe(true)
   })
 })
 

--- a/packages/app/src/hooks/__tests__/use-local-daemon-http-status.test.ts
+++ b/packages/app/src/hooks/__tests__/use-local-daemon-http-status.test.ts
@@ -46,13 +46,25 @@ describe('resolveLocalDaemonRuntimeStatus', () => {
     ).toBe('mqttDisconnected')
   })
 
-  it('returns offline when presence is explicitly offline and mqtt is up', () => {
+  it('stays checking when presence is offline but HTTP is up and daemon mqtt is still unknown', () => {
     expect(
       resolveLocalDaemonRuntimeStatus({
         daemonOnboardingReady: true,
         httpStatus: 'online',
         presenceOnline: false,
         mqttConnected: true,
+      }),
+    ).toBe('checking')
+  })
+
+  it('returns offline when presence and daemon mqtt both report offline', () => {
+    expect(
+      resolveLocalDaemonRuntimeStatus({
+        daemonOnboardingReady: true,
+        httpStatus: 'online',
+        presenceOnline: false,
+        mqttConnected: true,
+        daemonMqttConnected: false,
       }),
     ).toBe('offline')
   })

--- a/packages/app/src/hooks/use-engaged-agent-ui-states.ts
+++ b/packages/app/src/hooks/use-engaged-agent-ui-states.ts
@@ -5,6 +5,7 @@ import {
   probeAgentReachability,
   type AgentReachability,
 } from '@/lib/agent-reachability-probe'
+import { mergeAgentDevicePresence } from '@/lib/agent-device-reachability'
 import { resolveRuntimeStateEntryForAgent } from '@/lib/runtime-state-resolve'
 import {
   SESSION_AGENT_CONNECTING_TIMEOUT_MS,
@@ -69,7 +70,6 @@ function computeProvisionalState(
   const entry = resolveRuntimeStateEntryForAgent(agent.id, byRuntimeId, dbRuntimeId)
   const runtimeInfo = entry?.info
   const availableModelCount = resolveAgentAvailableModels(runtimeInfo).length
-  const presenceOnline = presenceByActor[agent.id]?.online
   const since = connectingSinceByAgent[agent.id]
   const connectingTimedOut =
     since !== undefined && now - since >= SESSION_AGENT_CONNECTING_TIMEOUT_MS
@@ -77,6 +77,19 @@ function computeProvisionalState(
   const reachabilityFailed = reachability === 'unreachable'
   const localId = getKnownLocalDaemonActorId()
   const isLocalAgent = !!localId && agent.id === localId
+  const mqttOnline = presenceByActor[agent.id]?.online
+  const devicePresence = mergeAgentDevicePresence({
+    mqttOnline,
+    isLocalDaemon: isLocalAgent,
+    localHttpOk:
+      isLocalAgent && reachability === 'reachable'
+        ? true
+        : isLocalAgent && reachability === 'unreachable'
+          ? false
+          : null,
+  })
+  const presenceOnline =
+    devicePresence === 'online' ? true : devicePresence === 'offline' ? false : undefined
 
   return resolveSessionAgentUiState({
     presenceOnline,

--- a/packages/app/src/hooks/use-ensure-engaged-runtimes-on-session-focus.ts
+++ b/packages/app/src/hooks/use-ensure-engaged-runtimes-on-session-focus.ts
@@ -1,22 +1,47 @@
 import * as React from 'react'
+import { resolveAgentDevicePresenceSync } from '@/lib/agent-device-reachability'
 import { ensureAgentRuntimesForSession } from '@/lib/teamclaw/ensure-agent-runtime'
 import type { EngagedAgentUiEntry } from '@/hooks/use-engaged-agent-ui-states'
-import { shouldSkipThrottledRuntimeEnsure, resetRuntimeEnsureThrottle } from '@/lib/teamclaw/runtime-ensure-scheduler'
+import {
+  agentsHaveLiveRuntimeModels,
+  shouldSkipAlreadyReadyRuntimeEnsure,
+  shouldSkipThrottledRuntimeEnsure,
+  resetRuntimeEnsureThrottle,
+} from '@/lib/teamclaw/runtime-ensure-scheduler'
 import { useActorPresenceStore } from '@/stores/actor-presence-store'
 
-/** Agents that may recover via runtimeStart (excludes stale and LWT-offline). */
+function isDeviceOfflineForWake(agentId: string): boolean {
+  return resolveAgentDevicePresenceSync(agentId) === 'offline'
+}
+
+/** Agents that may recover via runtimeStart (excludes stale, ready, live-retain, hard-offline). */
 export function agentIdsNeedingRecoverableRuntimeWake(
   entries: ReadonlyArray<EngagedAgentUiEntry>,
-  presenceByActor: Record<string, { online: boolean } | undefined>,
+  _presenceByActor?: Record<string, { online: boolean } | undefined>,
 ): string[] {
   return entries
     .filter((e) => {
       if (e.uiState === 'stale' || e.uiState === 'ready') return false
+      if (agentsHaveLiveRuntimeModels([e.agent.id])) return false
       if (e.uiState === 'connecting') return true
       if (e.uiState === 'offline') {
-        return presenceByActor[e.agent.id]?.online !== false
+        // Shared merge: LWT-offline remote stays out; local stale LWT may still wake.
+        return !isDeviceOfflineForWake(e.agent.id)
       }
       return false
+    })
+    .map((e) => e.agent.id)
+}
+
+/** Same-session signature wakes: only connecting (offline recovers on focus / retry). */
+export function agentIdsNeedingConnectingWake(
+  entries: ReadonlyArray<EngagedAgentUiEntry>,
+): string[] {
+  return entries
+    .filter((e) => {
+      if (e.uiState !== 'connecting') return false
+      if (agentsHaveLiveRuntimeModels([e.agent.id])) return false
+      return true
     })
     .map((e) => e.agent.id)
 }
@@ -36,20 +61,20 @@ export function hasConnectingEngagedAgent(
   return entries.some((e) => e.uiState === 'connecting')
 }
 
-/** Offline pills that may recover (transport glitch), excluding LWT-offline agents. */
+/** Offline pills that may recover (transport glitch), excluding hard-offline agents. */
 export function hasRecoverableOfflineEngagedAgent(
   entries: ReadonlyArray<EngagedAgentUiEntry>,
-  presenceByActor: Record<string, { online: boolean } | undefined>,
+  _presenceByActor?: Record<string, { online: boolean } | undefined>,
 ): boolean {
   return entries.some((e) => {
     if (e.uiState !== 'offline') return false
-    return presenceByActor[e.agent.id]?.online !== false
+    return !isDeviceOfflineForWake(e.agent.id)
   })
 }
 
 export function hasRecoverableNonReadyAgent(
   entries: ReadonlyArray<EngagedAgentUiEntry>,
-  presenceByActor: Record<string, { online: boolean } | undefined>,
+  presenceByActor?: Record<string, { online: boolean } | undefined>,
 ): boolean {
   return (
     hasConnectingEngagedAgent(entries) ||
@@ -88,16 +113,12 @@ export function useEnsureEngagedRuntimesOnSessionFocus(args: {
   )
 
   const tryEnsure = React.useCallback(
-    (reason: string) => {
+    (reason: string, agentActorIds: string[]) => {
       const sessionId = args.sessionId?.trim() || null
       const teamId = args.teamId?.trim() || null
       if (!sessionId || !teamId) return
-
-      const agentActorIds = agentIdsNeedingRecoverableRuntimeWake(
-        engagedUiEntriesRef.current,
-        useActorPresenceStore.getState().byActorId,
-      )
       if (agentActorIds.length === 0) return
+      if (shouldSkipAlreadyReadyRuntimeEnsure(agentActorIds, reason)) return
       if (shouldSkipThrottledRuntimeEnsure(sessionId, agentActorIds)) return
 
       void ensureAgentRuntimesForSession({
@@ -120,8 +141,14 @@ export function useEnsureEngagedRuntimesOnSessionFocus(args: {
 
     if (!sessionId || !args.teamId?.trim()) return
 
-    tryEnsure(focusChanged ? 'session_focus' : 'session_runtime_wake')
-  }, [args.sessionId, args.teamId, engagedSignature, tryEnsure])
+    const entries = engagedUiEntriesRef.current
+    if (focusChanged) {
+      tryEnsure('session_focus', agentIdsNeedingRecoverableRuntimeWake(entries, presenceByActor))
+      return
+    }
+    // Same session: only wake newly-connecting agents. Offline recovers via retry.
+    tryEnsure('session_runtime_wake', agentIdsNeedingConnectingWake(entries))
+  }, [args.sessionId, args.teamId, engagedSignature, tryEnsure, presenceByActor])
 
   React.useEffect(() => {
     const sessionId = args.sessionId?.trim() || null
@@ -130,7 +157,10 @@ export function useEnsureEngagedRuntimesOnSessionFocus(args: {
     if (!hasRecoverableNonReadyAgent(args.engagedUiEntries, presenceByActor)) return
 
     const timer = window.setInterval(() => {
-      tryEnsure('session_runtime_retry')
+      tryEnsure(
+        'session_runtime_retry',
+        agentIdsNeedingRecoverableRuntimeWake(engagedUiEntriesRef.current, presenceByActor),
+      )
     }, STALE_RUNTIME_RETRY_MS)
 
     return () => window.clearInterval(timer)

--- a/packages/app/src/hooks/use-local-daemon-http-status.ts
+++ b/packages/app/src/hooks/use-local-daemon-http-status.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { mergeAgentDevicePresence, noteLocalDaemonSignals } from '@/lib/agent-device-reachability'
 import { probeDaemonHttp } from '@/lib/daemon-local-client'
 import { getDaemonMqttConnected } from '@/lib/daemon-agent-admin'
 import { QUICK_CHAT_DAEMON_PROBE_INTERVAL_MS } from '@/lib/session-agent-probe'
@@ -58,14 +59,16 @@ export function resolveLocalDaemonRuntimeStatus(input: {
   // HTTP reachable: surface Desktop MQTT disconnect before stale presence can
   // read as "online".
   if (input.mqttConnected === false) return 'mqttDisconnected'
-  if (input.httpStatus === 'online') {
-    // Trust the daemon's live mqtt_connected flag over a brief stale offline
-    // retain that can appear during JWT rotation / broker reconnect.
-    if (input.daemonMqttConnected === true) return 'online'
-    if (input.daemonMqttConnected === false) return 'offline'
-  }
-  if (input.presenceOnline === false) return 'offline'
-  if (input.httpStatus === 'online') return 'online'
+
+  // Shared device-reachability merge (same rule as runtime-start gate).
+  const devicePresence = mergeAgentDevicePresence({
+    mqttOnline: input.presenceOnline,
+    isLocalDaemon: true,
+    daemonMqttConnected: input.daemonMqttConnected ?? null,
+    localHttpOk: input.httpStatus === 'online' ? true : null,
+  })
+  if (devicePresence === 'online') return 'online'
+  if (devicePresence === 'offline') return 'offline'
   return 'checking'
 }
 
@@ -83,7 +86,7 @@ export function useLocalDaemonRuntimeStatus(
   const [daemonMqttConnected, setDaemonMqttConnected] = React.useState<boolean | null>(null)
 
   React.useEffect(() => {
-    if (!enabled || !daemonOnboardingReady) {
+    if (!enabled || !daemonOnboardingReady || !actorId) {
       setDaemonMqttConnected(null)
       return
     }
@@ -91,7 +94,13 @@ export function useLocalDaemonRuntimeStatus(
     let cancelled = false
     const poll = async () => {
       const connected = await getDaemonMqttConnected()
-      if (!cancelled) setDaemonMqttConnected(connected)
+      if (cancelled) return
+      setDaemonMqttConnected(connected)
+      noteLocalDaemonSignals({
+        actorId,
+        daemonMqttConnected: connected,
+        localHttpOk: httpStatus === 'online' ? true : httpStatus === 'offline' ? false : null,
+      })
     }
 
     void poll()
@@ -100,7 +109,7 @@ export function useLocalDaemonRuntimeStatus(
       cancelled = true
       clearInterval(interval)
     }
-  }, [daemonOnboardingReady, enabled])
+  }, [actorId, daemonOnboardingReady, enabled, httpStatus])
 
   return resolveLocalDaemonRuntimeStatus({
     daemonOnboardingReady,

--- a/packages/app/src/hooks/use-reensure-runtimes-on-mqtt-reconnect.ts
+++ b/packages/app/src/hooks/use-reensure-runtimes-on-mqtt-reconnect.ts
@@ -6,6 +6,7 @@ import {
 import type { EngagedAgentUiEntry } from '@/hooks/use-engaged-agent-ui-states'
 import {
   resetRuntimeEnsureThrottle,
+  shouldSkipAlreadyReadyRuntimeEnsure,
   shouldSkipThrottledRuntimeEnsure,
 } from '@/lib/teamclaw/runtime-ensure-scheduler'
 import { useActorPresenceStore } from '@/stores/actor-presence-store'
@@ -47,6 +48,7 @@ export function useReensureRuntimesOnMqttReconnect(args: {
       presenceByActor,
     )
     if (agentActorIds.length === 0) return
+    if (shouldSkipAlreadyReadyRuntimeEnsure(agentActorIds, 'mqtt_reconnect_ensure')) return
 
     resetRuntimeEnsureThrottle()
     if (shouldSkipThrottledRuntimeEnsure(sessionId, agentActorIds)) return

--- a/packages/app/src/lib/__tests__/actor-online.test.ts
+++ b/packages/app/src/lib/__tests__/actor-online.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { resolveActorOnlineStatus } from '@/lib/actor-online'
+import { __resetLocalDaemonSignalCacheForTest } from '@/lib/agent-device-reachability'
+import { __resetLocalDaemonIdentityForTest } from '@/lib/local-daemon-identity'
+import { useActorPresenceStore } from '@/stores/actor-presence-store'
 
 describe('resolveActorOnlineStatus', () => {
   const member = {
@@ -7,6 +10,12 @@ describe('resolveActorOnlineStatus', () => {
     actor_type: 'member' as const,
     last_active_at: '2020-01-01T00:00:00.000Z',
   }
+
+  beforeEach(() => {
+    __resetLocalDaemonSignalCacheForTest()
+    __resetLocalDaemonIdentityForTest()
+    useActorPresenceStore.setState({ byActorId: {} })
+  })
 
   it('treats the current member as online even when last_active_at is stale', () => {
     expect(resolveActorOnlineStatus(member, { currentMemberActorId: 'member-1' })).toBe(true)
@@ -16,9 +25,19 @@ describe('resolveActorOnlineStatus', () => {
     expect(resolveActorOnlineStatus(member, { currentMemberActorId: 'member-2' })).toBe(false)
   })
 
-  it('prefers MQTT presence for agents', () => {
+  it('falls back to agentPresence when MQTT store has no retain', () => {
     const agent = { id: 'agent-1', actor_type: 'agent' as const, last_active_at: null }
     expect(resolveActorOnlineStatus(agent, { agentPresence: { online: true } })).toBe(true)
     expect(resolveActorOnlineStatus(agent, { agentPresence: { online: false } })).toBe(false)
+  })
+
+  it('prefers shared device-presence merge from the MQTT store', () => {
+    const agent = { id: 'agent-1', actor_type: 'agent' as const, last_active_at: null }
+    useActorPresenceStore.getState().upsert('agent-1', {
+      online: true,
+      displayName: 'a',
+      lastUpdated: Date.now(),
+    })
+    expect(resolveActorOnlineStatus(agent, { agentPresence: { online: false } })).toBe(true)
   })
 })

--- a/packages/app/src/lib/__tests__/agent-device-reachability.test.ts
+++ b/packages/app/src/lib/__tests__/agent-device-reachability.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetLocalDaemonSignalCacheForTest,
+  mergeAgentDevicePresence,
+  noteLocalDaemonSignals,
+  presenceOnlineFlag,
+  resolveAgentDevicePresenceSync,
+} from "@/lib/agent-device-reachability";
+import { __resetLocalDaemonIdentityForTest, noteLocalDaemonActorId } from "@/lib/local-daemon-identity";
+import { useActorPresenceStore } from "@/stores/actor-presence-store";
+
+describe("mergeAgentDevicePresence", () => {
+  it("returns online when MQTT says online for a remote agent", () => {
+    expect(
+      mergeAgentDevicePresence({
+        mqttOnline: true,
+        isLocalDaemon: false,
+      }),
+    ).toBe("online");
+  });
+
+  it("returns offline for remote agents when MQTT says offline", () => {
+    expect(
+      mergeAgentDevicePresence({
+        mqttOnline: false,
+        isLocalDaemon: false,
+        daemonMqttConnected: true,
+        localHttpOk: true,
+      }),
+    ).toBe("offline");
+  });
+
+  it("overrides stale offline retain when local daemon mqtt is connected", () => {
+    expect(
+      mergeAgentDevicePresence({
+        mqttOnline: false,
+        isLocalDaemon: true,
+        daemonMqttConnected: true,
+      }),
+    ).toBe("online");
+  });
+
+  it("overrides ghost online retain when local daemon mqtt is down", () => {
+    expect(
+      mergeAgentDevicePresence({
+        mqttOnline: true,
+        isLocalDaemon: true,
+        daemonMqttConnected: false,
+        localHttpOk: true,
+      }),
+    ).toBe("offline");
+  });
+
+  it("keeps offline when local daemon mqtt reports disconnected", () => {
+    expect(
+      mergeAgentDevicePresence({
+        mqttOnline: false,
+        isLocalDaemon: true,
+        daemonMqttConnected: false,
+        localHttpOk: true,
+      }),
+    ).toBe("offline");
+  });
+
+  it("returns unknown for local daemon when offline retain and only HTTP is up", () => {
+    expect(
+      mergeAgentDevicePresence({
+        mqttOnline: false,
+        isLocalDaemon: true,
+        daemonMqttConnected: null,
+        localHttpOk: true,
+      }),
+    ).toBe("unknown");
+  });
+
+  it("bootstraps local daemon to online when retain is missing and HTTP is up", () => {
+    expect(
+      mergeAgentDevicePresence({
+        mqttOnline: undefined,
+        isLocalDaemon: true,
+        localHttpOk: true,
+      }),
+    ).toBe("online");
+  });
+
+  it("returns unknown when retain is missing for a remote agent", () => {
+    expect(
+      mergeAgentDevicePresence({
+        mqttOnline: undefined,
+        isLocalDaemon: false,
+      }),
+    ).toBe("unknown");
+  });
+});
+
+describe("resolveAgentDevicePresenceSync", () => {
+  beforeEach(() => {
+    __resetLocalDaemonSignalCacheForTest();
+    __resetLocalDaemonIdentityForTest();
+    useActorPresenceStore.setState({ byActorId: {} });
+  });
+
+  it("maps MQTT online/offline for remote agents", () => {
+    useActorPresenceStore.getState().upsert("remote", {
+      online: true,
+      displayName: "r",
+      lastUpdated: Date.now(),
+    });
+    expect(resolveAgentDevicePresenceSync("remote")).toBe("online");
+    expect(presenceOnlineFlag("online")).toBe(true);
+
+    useActorPresenceStore.getState().upsert("remote", {
+      online: false,
+      displayName: "r",
+      lastUpdated: Date.now(),
+    });
+    expect(resolveAgentDevicePresenceSync("remote")).toBe("offline");
+  });
+
+  it("uses cached local daemon mqtt to override stale offline retain", () => {
+    noteLocalDaemonActorId("local-agent");
+    noteLocalDaemonSignals({ actorId: "local-agent", daemonMqttConnected: true });
+    useActorPresenceStore.getState().upsert("local-agent", {
+      online: false,
+      displayName: "b001",
+      lastUpdated: Date.now(),
+    });
+    expect(resolveAgentDevicePresenceSync("local-agent")).toBe("online");
+  });
+});
+
+describe("resolveAgentDevicePresence fast-path", () => {
+  beforeEach(() => {
+    __resetLocalDaemonSignalCacheForTest();
+    __resetLocalDaemonIdentityForTest();
+    useActorPresenceStore.setState({ byActorId: {} });
+  });
+
+  it("returns sync online immediately for a known-remote agent", async () => {
+    const { resolveAgentDevicePresence } = await import("@/lib/agent-device-reachability");
+    noteLocalDaemonActorId("local-agent");
+    useActorPresenceStore.getState().upsert("remote", {
+      online: true,
+      displayName: "r",
+      lastUpdated: Date.now(),
+    });
+    await expect(resolveAgentDevicePresence("remote", { timeoutMs: 2_000 })).resolves.toBe("online");
+  });
+});

--- a/packages/app/src/lib/actor-online.ts
+++ b/packages/app/src/lib/actor-online.ts
@@ -1,3 +1,5 @@
+import { resolveAgentDevicePresenceSync } from '@/lib/agent-device-reachability'
+
 export type ActorOnlineRow = {
   id: string
   actor_type: 'member' | 'agent'
@@ -11,7 +13,12 @@ export function isActorOnline(lastActiveAt: string | null): boolean {
   return Date.now() - t < 5 * 60 * 1000
 }
 
-/** Resolve online/offline for a directory row, overlaying MQTT agent presence. */
+/**
+ * Resolve online/offline for a directory row.
+ *
+ * Agents use the shared device-presence merge (MQTT store + local daemon cache).
+ * `agentPresence` remains as a test/fallback when the store has no retain yet.
+ */
 export function resolveActorOnlineStatus(
   actor: ActorOnlineRow,
   options: {
@@ -21,8 +28,11 @@ export function resolveActorOnlineStatus(
 ): boolean {
   const isAgent = actor.actor_type === 'agent'
   if (isAgent) {
-    const presence = options.agentPresence
-    return presence ? presence.online : isActorOnline(actor.last_active_at)
+    const merged = resolveAgentDevicePresenceSync(actor.id)
+    if (merged === 'online') return true
+    if (merged === 'offline') return false
+    if (options.agentPresence) return options.agentPresence.online
+    return isActorOnline(actor.last_active_at)
   }
   if (options.currentMemberActorId && actor.id === options.currentMemberActorId) {
     return true

--- a/packages/app/src/lib/agent-device-reachability.ts
+++ b/packages/app/src/lib/agent-device-reachability.ts
@@ -1,0 +1,230 @@
+import { getKnownLocalDaemonActorId } from "@/lib/local-daemon-identity";
+import { useActorPresenceStore } from "@/stores/actor-presence-store";
+import { DEVICE_PRESENCE_GATE_TIMEOUT_MS } from "@/lib/teamclaw/runtime-rpc-timeouts";
+
+export type AgentDevicePresence = "online" | "offline" | "unknown";
+
+const LOCAL_DAEMON_SIGNAL_CACHE_TTL_MS = 5_000;
+
+type LocalDaemonSignalCache = {
+  actorId: string;
+  daemonMqttConnected: boolean | null;
+  localHttpOk: boolean | null;
+  at: number;
+};
+
+let localDaemonSignalCache: LocalDaemonSignalCache | null = null;
+
+/** @internal test helper */
+export function __resetLocalDaemonSignalCacheForTest(): void {
+  localDaemonSignalCache = null;
+}
+
+export function noteLocalDaemonSignals(input: {
+  actorId: string;
+  daemonMqttConnected?: boolean | null;
+  localHttpOk?: boolean | null;
+}): void {
+  const actorId = input.actorId.trim();
+  if (!actorId) return;
+  const prev = localDaemonSignalCache?.actorId === actorId ? localDaemonSignalCache : null;
+  localDaemonSignalCache = {
+    actorId,
+    daemonMqttConnected:
+      input.daemonMqttConnected !== undefined
+        ? input.daemonMqttConnected
+        : (prev?.daemonMqttConnected ?? null),
+    localHttpOk:
+      input.localHttpOk !== undefined ? input.localHttpOk : (prev?.localHttpOk ?? null),
+    at: Date.now(),
+  };
+}
+
+function readCachedLocalDaemonSignals(actorId: string): {
+  daemonMqttConnected: boolean | null;
+  localHttpOk: boolean | null;
+} | null {
+  const cache = localDaemonSignalCache;
+  if (!cache || cache.actorId !== actorId) return null;
+  if (Date.now() - cache.at > LOCAL_DAEMON_SIGNAL_CACHE_TTL_MS) return null;
+  return {
+    daemonMqttConnected: cache.daemonMqttConnected,
+    localHttpOk: cache.localHttpOk,
+  };
+}
+
+/**
+ * Single merge rule for "is this agent's daemon reachable?".
+ *
+ * - For the local desktop daemon, live `/v1/info.mqtt_connected` is the
+ *   strongest signal: it overrides both stale offline LWT and ghost online retain.
+ * - MQTT `online: true` / `false` otherwise apply (remote agents: LWT is authoritative).
+ * - Missing MQTT retain is `unknown`, never offline (except when local HTTP proves down
+ *   after an offline retain with unknown daemon mqtt).
+ */
+export function mergeAgentDevicePresence(input: {
+  mqttOnline: boolean | undefined;
+  isLocalDaemon: boolean;
+  /** From daemon GET /v1/info — authoritative over stale LWT / ghost retain when known. */
+  daemonMqttConnected?: boolean | null;
+  /** Local HTTP probe result; only consulted when MQTT retain is missing or override needs a fallback. */
+  localHttpOk?: boolean | null;
+}): AgentDevicePresence {
+  if (input.isLocalDaemon) {
+    if (input.daemonMqttConnected === true) return "online";
+    if (input.daemonMqttConnected === false) return "offline";
+  }
+
+  if (input.mqttOnline === true) return "online";
+
+  if (input.mqttOnline === false) {
+    if (!input.isLocalDaemon) return "offline";
+    if (input.localHttpOk === true) return "unknown";
+    if (input.localHttpOk === false) return "offline";
+    return "offline";
+  }
+
+  // Retain missing / not yet known.
+  if (input.isLocalDaemon && input.localHttpOk === true) return "online";
+  if (input.isLocalDaemon && input.localHttpOk === false) return "unknown";
+  return "unknown";
+}
+
+export function presenceOnlineFlag(presence: AgentDevicePresence): boolean | undefined {
+  if (presence === "online") return true;
+  if (presence === "offline") return false;
+  return undefined;
+}
+
+/**
+ * Sync presence for UI / wake filters. Uses MQTT store + known local actor id +
+ * short-lived local daemon signal cache (warmed by sidebar / async resolve).
+ */
+export function resolveAgentDevicePresenceSync(agentActorId: string): AgentDevicePresence {
+  const id = agentActorId.trim();
+  if (!id) return "unknown";
+
+  const mqttOnline = useActorPresenceStore.getState().byActorId[id]?.online;
+  const localId = getKnownLocalDaemonActorId();
+  const isLocalDaemon = !!localId && localId === id;
+  const cached = isLocalDaemon ? readCachedLocalDaemonSignals(id) : null;
+
+  return mergeAgentDevicePresence({
+    mqttOnline,
+    isLocalDaemon,
+    daemonMqttConnected: cached?.daemonMqttConnected ?? null,
+    localHttpOk: cached?.localHttpOk ?? null,
+  });
+}
+
+async function resolveLocalDaemonSignals(agentActorId: string): Promise<{
+  isLocalDaemon: boolean;
+  daemonMqttConnected: boolean | null;
+  localHttpOk: boolean | null;
+}> {
+  const { isTauri } = await import("@/lib/utils");
+  if (!isTauri()) {
+    return { isLocalDaemon: false, daemonMqttConnected: null, localHttpOk: null };
+  }
+
+  const knownLocal = getKnownLocalDaemonActorId();
+  if (knownLocal && knownLocal !== agentActorId) {
+    return { isLocalDaemon: false, daemonMqttConnected: null, localHttpOk: null };
+  }
+
+  const cached = readCachedLocalDaemonSignals(agentActorId);
+  if (cached && (cached.daemonMqttConnected !== null || cached.localHttpOk !== null)) {
+    // Still confirm identity when cache hit without knownLocal yet.
+    if (knownLocal === agentActorId) {
+      return { isLocalDaemon: true, ...cached };
+    }
+  }
+
+  const { getLocalDaemonActorId, getDaemonMqttConnected } = await import("@/lib/daemon-agent-admin");
+  const localId = await getLocalDaemonActorId();
+  if (localId !== agentActorId) {
+    return { isLocalDaemon: false, daemonMqttConnected: null, localHttpOk: null };
+  }
+
+  const daemonMqttConnected = await getDaemonMqttConnected();
+  if (daemonMqttConnected === true || daemonMqttConnected === false) {
+    noteLocalDaemonSignals({ actorId: agentActorId, daemonMqttConnected, localHttpOk: null });
+    return { isLocalDaemon: true, daemonMqttConnected, localHttpOk: null };
+  }
+
+  const { probeDaemonHttp } = await import("@/lib/daemon-local-client");
+  const probe = await probeDaemonHttp();
+  noteLocalDaemonSignals({
+    actorId: agentActorId,
+    daemonMqttConnected: null,
+    localHttpOk: probe.ok,
+  });
+  return { isLocalDaemon: true, daemonMqttConnected: null, localHttpOk: probe.ok };
+}
+
+/**
+ * Resolve whether an agent's daemon is reachable (async; may wait briefly for MQTT retain).
+ *
+ * Fast-path only when safe:
+ * - known remote agent with MQTT retain already online/offline
+ * - known local agent whose daemonMqtt cache is warm (merge already applied)
+ * Otherwise fall through so local `/v1/info` can override stale/ghost retains.
+ */
+export async function resolveAgentDevicePresence(
+  agentActorId: string,
+  opts?: { timeoutMs?: number },
+): Promise<AgentDevicePresence> {
+  const knownLocal = getKnownLocalDaemonActorId();
+  if (knownLocal && knownLocal !== agentActorId) {
+    const syncRemote = resolveAgentDevicePresenceSync(agentActorId);
+    if (syncRemote === "online" || syncRemote === "offline") {
+      return syncRemote;
+    }
+  } else if (knownLocal === agentActorId) {
+    const cached = readCachedLocalDaemonSignals(agentActorId);
+    if (cached?.daemonMqttConnected === true || cached?.daemonMqttConnected === false) {
+      return resolveAgentDevicePresenceSync(agentActorId);
+    }
+  }
+
+  const timeoutMs = opts?.timeoutMs ?? DEVICE_PRESENCE_GATE_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const entry = useActorPresenceStore.getState().byActorId[agentActorId];
+    if (entry?.online === true || entry?.online === false) {
+      const knownLocal = getKnownLocalDaemonActorId();
+      // Remote + online: no need to hit local HTTP/info.
+      if (entry.online === true && knownLocal && knownLocal !== agentActorId) {
+        return "online";
+      }
+      if (entry.online === true && !knownLocal) {
+        // Might still be the local daemon before identity is noted — check once.
+        const local = await resolveLocalDaemonSignals(agentActorId);
+        return mergeAgentDevicePresence({
+          mqttOnline: true,
+          isLocalDaemon: local.isLocalDaemon,
+          daemonMqttConnected: local.daemonMqttConnected,
+          localHttpOk: local.localHttpOk,
+        });
+      }
+      const local = await resolveLocalDaemonSignals(agentActorId);
+      return mergeAgentDevicePresence({
+        mqttOnline: entry.online,
+        isLocalDaemon: local.isLocalDaemon,
+        daemonMqttConnected: local.daemonMqttConnected,
+        localHttpOk: local.localHttpOk,
+      });
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  const entry = useActorPresenceStore.getState().byActorId[agentActorId];
+  const local = await resolveLocalDaemonSignals(agentActorId);
+  return mergeAgentDevicePresence({
+    mqttOnline: entry?.online,
+    isLocalDaemon: local.isLocalDaemon,
+    daemonMqttConnected: local.daemonMqttConnected,
+    localHttpOk: local.localHttpOk,
+  });
+}

--- a/packages/app/src/lib/teamclaw/__tests__/ensure-agent-runtime-presence.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/ensure-agent-runtime-presence.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetLocalDaemonActorId = vi.fn();
+const mockGetDaemonMqttConnected = vi.fn();
 const mockProbeDaemonHttp = vi.fn();
 
 vi.mock("@/lib/daemon-agent-admin", () => ({
   getLocalDaemonActorId: () => mockGetLocalDaemonActorId(),
+  getDaemonMqttConnected: () => mockGetDaemonMqttConnected(),
 }));
 
 vi.mock("@/lib/daemon-local-client", () => ({
@@ -16,10 +18,16 @@ vi.mock("@/lib/utils", () => ({
 }));
 
 describe("resolveAgentDevicePresence", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers();
     mockGetLocalDaemonActorId.mockReset();
+    mockGetDaemonMqttConnected.mockReset();
     mockProbeDaemonHttp.mockReset();
+    mockGetDaemonMqttConnected.mockResolvedValue(null);
+    const { __resetLocalDaemonSignalCacheForTest } = await import("@/lib/agent-device-reachability");
+    const { __resetLocalDaemonIdentityForTest } = await import("@/lib/local-daemon-identity");
+    __resetLocalDaemonSignalCacheForTest();
+    __resetLocalDaemonIdentityForTest();
   });
 
   afterEach(async () => {
@@ -69,6 +77,52 @@ describe("resolveAgentDevicePresence", () => {
     });
 
     await expect(resolveAgentDevicePresence("agent-1", { timeoutMs: 0 })).resolves.toBe("offline");
+  });
+
+  it("returns online for the local daemon when MQTT is stale offline but daemon mqtt is connected", async () => {
+    const { resolveAgentDevicePresence } = await import("../ensure-agent-runtime");
+    const { useActorPresenceStore } = await import("@/stores/actor-presence-store");
+
+    mockGetLocalDaemonActorId.mockResolvedValue("local-agent");
+    mockGetDaemonMqttConnected.mockResolvedValue(true);
+    useActorPresenceStore.getState().upsert("local-agent", {
+      online: false,
+      displayName: "b001-agent",
+      lastUpdated: Date.now(),
+    });
+
+    await expect(resolveAgentDevicePresence("local-agent", { timeoutMs: 0 })).resolves.toBe("online");
+    expect(mockProbeDaemonHttp).not.toHaveBeenCalled();
+  });
+
+  it("returns offline for the local daemon when MQTT ghost-online but daemon mqtt is down", async () => {
+    const { resolveAgentDevicePresence } = await import("../ensure-agent-runtime");
+    const { useActorPresenceStore } = await import("@/stores/actor-presence-store");
+
+    mockGetLocalDaemonActorId.mockResolvedValue("local-agent");
+    mockGetDaemonMqttConnected.mockResolvedValue(false);
+    useActorPresenceStore.getState().upsert("local-agent", {
+      online: true,
+      displayName: "b001-agent",
+      lastUpdated: Date.now(),
+    });
+
+    await expect(resolveAgentDevicePresence("local-agent", { timeoutMs: 0 })).resolves.toBe("offline");
+  });
+
+  it("returns offline for the local daemon when both MQTT and daemon mqtt report offline", async () => {
+    const { resolveAgentDevicePresence } = await import("../ensure-agent-runtime");
+    const { useActorPresenceStore } = await import("@/stores/actor-presence-store");
+
+    mockGetLocalDaemonActorId.mockResolvedValue("local-agent");
+    mockGetDaemonMqttConnected.mockResolvedValue(false);
+    useActorPresenceStore.getState().upsert("local-agent", {
+      online: false,
+      displayName: "b001-agent",
+      lastUpdated: Date.now(),
+    });
+
+    await expect(resolveAgentDevicePresence("local-agent", { timeoutMs: 0 })).resolves.toBe("offline");
   });
 
   it("returns unknown when retain is missing and agent is not the local daemon", async () => {

--- a/packages/app/src/lib/teamclaw/__tests__/runtime-ensure-scheduler.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/runtime-ensure-scheduler.test.ts
@@ -1,14 +1,25 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { create } from '@bufbuild/protobuf'
+import { beforeEach, describe, expect, it } from 'vitest'
 import {
+  AgentStatus,
+  RuntimeInfoSchema,
+  RuntimeLifecycle,
+} from '@/lib/proto/amux_pb'
+import {
+  agentsHaveLiveRuntimeModels,
+  isRuntimeEnsureWakeReason,
   recordRuntimeEnsureAttempt,
   resetRuntimeEnsureThrottle,
   runtimeEnsureKey,
+  shouldSkipAlreadyReadyRuntimeEnsure,
   shouldSkipThrottledRuntimeEnsure,
 } from '@/lib/teamclaw/runtime-ensure-scheduler'
+import { useRuntimeStateStore } from '@/stores/runtime-state-store'
 
 describe('runtime-ensure-scheduler', () => {
   beforeEach(() => {
     resetRuntimeEnsureThrottle()
+    useRuntimeStateStore.setState({ byRuntimeId: {} })
   })
 
   it('does not skip before any attempt is recorded', () => {
@@ -34,5 +45,44 @@ describe('runtime-ensure-scheduler', () => {
 
   it('runtimeEnsureKey is stable regardless of agent order', () => {
     expect(runtimeEnsureKey('s', ['b', 'a'])).toBe(runtimeEnsureKey('s', ['a', 'b']))
+  })
+
+  it('classifies wake vs create/send reasons', () => {
+    expect(isRuntimeEnsureWakeReason('session_focus')).toBe(true)
+    expect(isRuntimeEnsureWakeReason('mqtt_reconnect_ensure')).toBe(true)
+    expect(isRuntimeEnsureWakeReason('session_auto_engage')).toBe(true)
+    expect(isRuntimeEnsureWakeReason('session_create')).toBe(false)
+    expect(isRuntimeEnsureWakeReason('outbox_send')).toBe(false)
+    expect(isRuntimeEnsureWakeReason('offline_banner_retry')).toBe(false)
+  })
+
+  it('skips wake ensures when ACTIVE retain already has models', () => {
+    useRuntimeStateStore.getState().upsert(
+      'rt-1',
+      'agent-1',
+      create(RuntimeInfoSchema, {
+        runtimeId: 'rt-1',
+        state: RuntimeLifecycle.ACTIVE,
+        status: AgentStatus.IDLE,
+        availableModels: [{ id: 'm1', displayName: 'Model 1' }],
+      }),
+    )
+    expect(agentsHaveLiveRuntimeModels(['agent-1'])).toBe(true)
+    expect(shouldSkipAlreadyReadyRuntimeEnsure(['agent-1'], 'session_focus')).toBe(true)
+    expect(shouldSkipAlreadyReadyRuntimeEnsure(['agent-1'], 'session_create')).toBe(false)
+  })
+
+  it('does not skip wake ensures when models are missing', () => {
+    useRuntimeStateStore.getState().upsert(
+      'rt-1',
+      'agent-1',
+      create(RuntimeInfoSchema, {
+        runtimeId: 'rt-1',
+        state: RuntimeLifecycle.ACTIVE,
+        status: AgentStatus.IDLE,
+        availableModels: [],
+      }),
+    )
+    expect(shouldSkipAlreadyReadyRuntimeEnsure(['agent-1'], 'session_focus')).toBe(false)
   })
 })

--- a/packages/app/src/lib/teamclaw/ensure-agent-runtime.ts
+++ b/packages/app/src/lib/teamclaw/ensure-agent-runtime.ts
@@ -1,5 +1,9 @@
 import { getBackend } from "@/lib/backend";
 import i18n from "@/lib/i18n";
+import {
+  resolveAgentDevicePresence,
+  type AgentDevicePresence,
+} from "@/lib/agent-device-reachability";
 import { ensureSessionLiveSubscribed, ensureTeamSessionLiveSubscribed } from "@/lib/session-live-subscriptions";
 import {
   startAgentRuntimesAsync,
@@ -7,11 +11,13 @@ import {
   type RuntimeStartFailureCode,
 } from "@/lib/session-create";
 import { waitForTeamclawRpcReady } from "@/lib/teamclaw-rpc";
-import { useActorPresenceStore } from "@/stores/actor-presence-store";
 import { useRuntimeStateStore } from "@/stores/runtime-state-store";
 import { resolveRuntimeStateEntryForAgent } from "@/lib/runtime-state-resolve";
 import { resolveSessionWorkspaceHintForRuntimeStart } from "@/lib/teamclaw/resolve-runtime-start-workspace";
-import { recordRuntimeEnsureAttempt } from "@/lib/teamclaw/runtime-ensure-scheduler";
+import {
+  recordRuntimeEnsureAttempt,
+  shouldSkipAlreadyReadyRuntimeEnsure,
+} from "@/lib/teamclaw/runtime-ensure-scheduler";
 import {
   DEVICE_PRESENCE_GATE_TIMEOUT_MS,
   RUNTIME_START_RPC_TIMEOUT_MS,
@@ -20,53 +26,11 @@ import { sessionFlowError, sessionFlowLog } from "@/lib/session-flow-log";
 import { useWorkspaceStore } from "@/stores/workspace";
 import { useMqttReconnectStore } from "@/stores/mqtt-reconnect";
 
+export type { AgentDevicePresence };
+export { resolveAgentDevicePresence };
+
 type InFlightEntry = { promise: Promise<void>; startedAt: number };
 const inFlight = new Map<string, InFlightEntry>();
-
-export type AgentDevicePresence = "online" | "offline" | "unknown";
-
-/**
- * Resolve whether an agent's daemon is reachable.
- *
- * MQTT retained ActorPresence can arrive slightly after subscribe — `undefined`
- * in actor-presence-store means "not yet known", not offline (see
- * SessionActorSheet computeDotStateAndAnimation). Only explicit `online:
- * false` (LWT) counts as offline. For the local desktop agent, HTTP probe
- * is used as a bootstrap when MQTT retain hasn't landed yet.
- */
-export async function resolveAgentDevicePresence(
-  agentActorId: string,
-  opts?: { timeoutMs?: number },
-): Promise<AgentDevicePresence> {
-  const timeoutMs = opts?.timeoutMs ?? DEVICE_PRESENCE_GATE_TIMEOUT_MS;
-  const deadline = Date.now() + timeoutMs;
-
-  while (Date.now() < deadline) {
-    const entry = useActorPresenceStore.getState().byActorId[agentActorId];
-    if (entry?.online === true) return "online";
-    if (entry?.online === false) return "offline";
-    await new Promise((r) => setTimeout(r, 100));
-  }
-
-  const entry = useActorPresenceStore.getState().byActorId[agentActorId];
-  if (entry?.online === true) return "online";
-  if (entry?.online === false) return "offline";
-
-  const { isTauri } = await import("@/lib/utils");
-  if (isTauri()) {
-    const { getLocalDaemonActorId } = await import("@/lib/daemon-agent-admin");
-    const { probeDaemonHttp } = await import("@/lib/daemon-local-client");
-    const localId = await getLocalDaemonActorId();
-    if (localId === agentActorId) {
-      const probe = await probeDaemonHttp();
-      // HTTP probe failure during bootstrap is not authoritative offline — MQTT
-      // retain may still be in flight.
-      return probe.ok ? "online" : "unknown";
-    }
-  }
-
-  return "unknown";
-}
 
 function logDebug(
   eventCase: string,
@@ -170,15 +134,9 @@ export type EnsureAgentRuntimeArgs = {
  * Idempotent: ensure session live subscription, session membership, and
  * daemon runtimeStart for each agent. Safe to call on @-mention and on send.
  *
- * TODO(perf-runtime-start-throttle): Opening or re-activating a session often
- * fires runtimeStart even when the daemon dedup-reuses an existing runtime.
- * That path still does Cloud session fetch, MQTT live unsub/sub on switch, and
- * full-history `reconcile_runtime_cursor` (see `apply_start_runtime` dedup in
- * amuxd). Consider client-side TTL dedupe by (sessionId, workspace, agentIds)
- * and a daemon fast path that skips full reconcile/catchup when already live.
- *
- * Do NOT implement this TODO unless the user explicitly requests it — ignore
- * during routine work. 无用户明确指令时不要实现本 TODO，日常开发请忽略。
+ * Wake/focus/reconnect reasons skip when MQTT retains already show ACTIVE
+ * runtimes with models (`shouldSkipAlreadyReadyRuntimeEnsure`). Create/send
+ * paths always proceed so a new session can bind.
  */
 export async function ensureAgentRuntimesForSession(args: EnsureAgentRuntimeArgs): Promise<void> {
   const agentActorIds = [...new Set(args.agentActorIds.map((id) => id.trim()).filter(Boolean))];
@@ -186,6 +144,16 @@ export async function ensureAgentRuntimesForSession(args: EnsureAgentRuntimeArgs
 
   const key = `${args.sessionId}::${agentActorIds.slice().sort().join(",")}`;
   const reason = args.reason ?? "unknown";
+  if (shouldSkipAlreadyReadyRuntimeEnsure(agentActorIds, reason)) {
+    sessionFlowLog("ensure_agent_runtime.skip_already_ready", {
+      sessionId: args.sessionId,
+      teamId: args.teamId,
+      reason,
+      agentActorIds,
+    });
+    return;
+  }
+
   const existing = inFlight.get(key);
   if (existing) return existing.promise;
 

--- a/packages/app/src/lib/teamclaw/runtime-ensure-scheduler.ts
+++ b/packages/app/src/lib/teamclaw/runtime-ensure-scheduler.ts
@@ -1,9 +1,56 @@
+import { RuntimeLifecycle } from '@/lib/proto/amux_pb'
+import { resolveRuntimeStateEntryForAgent } from '@/lib/runtime-state-resolve'
+import { useRuntimeStateStore } from '@/stores/runtime-state-store'
+
 export const RUNTIME_ENSURE_MIN_INTERVAL_MS = 3_000
+
+/**
+ * Wake/recover paths — skip when MQTT retain already shows a live runtime.
+ * Bind paths (session_create / outbox_send / mention_pill) always proceed.
+ * offline_banner_retry is excluded: user asked to retry despite retain ghosts.
+ */
+const RUNTIME_ENSURE_WAKE_REASONS = new Set([
+  'session_focus',
+  'session_runtime_wake',
+  'session_runtime_retry',
+  'mqtt_reconnect_ensure',
+  'session_auto_engage',
+])
 
 const lastEnsureRef: { key: string; at: number } = { key: '', at: 0 }
 
 export function runtimeEnsureKey(sessionId: string, agentActorIds: string[]): string {
   return `${sessionId}::${agentActorIds.slice().sort().join(',')}`
+}
+
+export function isRuntimeEnsureWakeReason(reason: string): boolean {
+  return RUNTIME_ENSURE_WAKE_REASONS.has(reason)
+}
+
+/** True when every agent already has an ACTIVE runtime retain with models. */
+export function agentsHaveLiveRuntimeModels(agentActorIds: string[]): boolean {
+  if (agentActorIds.length === 0) return false
+  const byRuntimeId = useRuntimeStateStore.getState().byRuntimeId
+  return agentActorIds.every((agentActorId) => {
+    const entry = resolveRuntimeStateEntryForAgent(agentActorId, byRuntimeId)
+    return (
+      !!entry &&
+      entry.info.state === RuntimeLifecycle.ACTIVE &&
+      entry.info.availableModels.length > 0
+    )
+  })
+}
+
+/**
+ * Skip redundant runtimeStart on focus/reconnect/retry when retains already
+ * show live runtimes. Never skip create/send paths — those bind a new session.
+ */
+export function shouldSkipAlreadyReadyRuntimeEnsure(
+  agentActorIds: string[],
+  reason: string,
+): boolean {
+  if (!isRuntimeEnsureWakeReason(reason)) return false
+  return agentsHaveLiveRuntimeModels(agentActorIds)
 }
 
 /** Returns true when a recent runtime-start attempt for the same session+agents should be skipped. */


### PR DESCRIPTION
## Summary

- Introduce `agent-device-reachability.ts` as the single merge rule for “is this agent’s daemon reachable?” — for the **local desktop daemon**, live `GET /v1/info.mqtt_connected` overrides stale MQTT LWT offline (and ghost online) retain.
- Wire runtime-start gate, sidebar/actor lists, agent pills, and session focus hooks through the shared sync/async helpers instead of ad-hoc MQTT presence reads.
- Reduce redundant `runtimeStart` noise: wake paths (`session_focus`, reconnect, retry, etc.) skip when MQTT retains already show ACTIVE runtimes with models; sole-agent session create delegates ensure to `outbox_send` when auto-mention covers the agent.
- Add maintainer doc: `docs/architecture/agent-device-reachability-and-runtime-ensure.md`.

## Problem

Creating a session with a local agent could toast **“Agent runtime not started” / device offline** while amuxd was healthy (`/v1/info.mqtt_connected: true`). Root cause: runtime gate trusted stale broker LWT offline retain without checking the local daemon’s live MQTT status.

## Test plan

- [x] Unit tests: `agent-device-reachability`, `ensure-agent-runtime-presence`, `runtime-ensure-scheduler`, focus/reconnect hooks, `actor-online`
- [x] Live verification via tauri-mcp: stale offline inject → merge `online`; amuxd stop/restart LWT cycle
- [x] `tests/functional/chat-session-send.test.ts` (tauri-mcp)
- [ ] Manual: create sole-agent session + first message — no `device_offline` toast when daemon live
- [ ] Manual: switch between sessions with ready runtimes — expect `skip_already_ready` in `[session-flow]` logs


Made with [Cursor](https://cursor.com)