### PR TITLE
perf(ci): let sccache own target/, drop it from rust-cache (round 2)

### DIFF
--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -138,6 +138,14 @@ jobs:
           workspaces: |
             . -> target
           key: ${{ matrix.target }}
+          # sccache (set up above, wired via the job-level RUSTC_WRAPPER) already
+          # caches every crate's compiled output. Caching target/ here too is
+          # redundant, and both caches compete for the repo's shared 10 GB Actions
+          # cache — so the target/ copy just evicts sccache entries and lowers the
+          # hit rate. Keep only the ~/.cargo registry/index cache (dep downloads,
+          # which sccache does NOT cover) and let sccache own compilation. Also
+          # drops the multi-minute "Post Rust cache" save of a huge target/ dir.
+          cache-targets: false
 
       - name: Install protoc (for prost_build)
         run: brew install protobuf
@@ -458,6 +466,11 @@ jobs:
           # cargo puts every member's output under the root target/.
           workspaces: |
             . -> target
+          # See build-macos: sccache owns compiled artifacts, so caching target/
+          # here is redundant and competes with sccache for the shared 10 GB
+          # Actions cache. Keep only ~/.cargo, and cut the ~181s "Post Rust cache"
+          # save of the Windows target/ dir.
+          cache-targets: false
 
       - name: Install protoc (for prost_build)
         shell: bash


### PR DESCRIPTION
## 背景

发布提速第二轮。第一轮（#519，已在 main）实测结果：

- **Cargo.lock 免编译同步：287s → 86s（−201s）** ✅ 实打实，不依赖缓存
- **sccache hoist：本轮冷缓存下反而 +102s**（amuxd 495→597s）—— 首次包裹这些 sidecar 编译，冷缓存每次都是 miss+存盘。收益要等缓存变热。

## 本轮改动

给 macOS / Windows 的 `swatinem/rust-cache` 设 `cache-targets: false`：sccache 已接管逐 crate 编译产物，再缓存整个 `target/` 是重复的，且两者争抢仓库共享的 10GB Actions 缓存 —— target/ 副本会挤掉 sccache 条目、压低命中率。只保留 `~/.cargo` registry 缓存（依赖下载，sccache 不覆盖），把 target/ 让给 sccache。顺带砍掉 Windows ~181s / macOS ~73s 的 "Post Rust cache" 存盘。

`build-amuxd-linux` 不动：它没有 sccache，target/ 缓存是它唯一的编译缓存。

## 测量目标

这一版发布（v0.2.29）会同时进入 **sccache 热缓存** 状态。预期观察：amuxd/introspect/tauri 编译因 sccache 命中而显著下降；Post-cache 存盘时间下降。若 amuxd 仍慢，说明 sccache 对这些 crate 效果有限（可能 link 时间主导），需换思路（round 3：larger Windows runner）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)