### PR TITLE
perf(ci): sccache all cargo builds + drop target/ cache in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,14 @@ jobs:
           - target: x86_64-apple-darwin
             runner: macos-latest
     runs-on: ${{ matrix.runner }}
+    # Job-level, not step-level: these used to sit only on the tauri-action step,
+    # so the introspect + amuxd sidecar builds in "Build all (parallel)" compiled
+    # with no sccache despite sharing most of their dependency graph with the
+    # tauri build. Every cargo invocation in this job now shares one sccache.
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v7
 
@@ -124,6 +132,12 @@ jobs:
           workspaces: |
             . -> target
           key: ${{ matrix.target }}
+          # sccache (wired via the job-level RUSTC_WRAPPER) already caches every
+          # crate's compiled output, so caching target/ here too is redundant and
+          # both caches compete for the repo's shared 10 GB Actions cache. Keep
+          # only the ~/.cargo registry cache and let sccache own compilation; also
+          # drops the multi-minute "Post Rust cache" save of a large target/ dir.
+          cache-targets: false
 
       - name: Install protoc (for prost_build)
         run: brew install protobuf
@@ -285,9 +299,6 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           UPDATER_GITHUB_TOKEN: ${{ secrets.UPDATER_GITHUB_TOKEN }}
           DEVICE_JWT_SECRET: ${{ secrets.DEVICE_JWT_SECRET }}
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: sccache
-          CARGO_INCREMENTAL: "0"
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "${{ steps.release_notes.outputs.app_name }} ${{ github.ref_name }}"
@@ -302,6 +313,12 @@ jobs:
     permissions:
       contents: write
     runs-on: windows-latest
+    # See release-macos: hoisted off the tauri-action step so the introspect and
+    # amuxd sidecar builds get sccache too.
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v7
 
@@ -383,6 +400,10 @@ jobs:
           # cargo puts every member's output under the root target/.
           workspaces: |
             . -> target
+          # See release-macos: sccache owns compiled artifacts, so caching target/
+          # here is redundant and competes with sccache for the shared 10 GB
+          # Actions cache. Keep only ~/.cargo and cut the "Post Rust cache" save.
+          cache-targets: false
 
       - name: Install protoc (for prost_build)
         shell: bash
@@ -478,9 +499,6 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           DEVICE_JWT_SECRET: ${{ secrets.DEVICE_JWT_SECRET }}
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: sccache
-          CARGO_INCREMENTAL: "0"
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "${{ steps.release_notes.outputs.app_name }} ${{ github.ref_name }}"


### PR DESCRIPTION
## 背景

把在 `release-oss.yml` 上验证过的两处**零成本**提速（Windows 关键路径 −35%，2714s→1777s）搬到 `release.yml`（GitHub Release 那条 tag 触发的线）。

## 改动

1. **sccache 提到 job 级**（release-macos / release-windows）：原本只挂在 tauri-action step 上，introspect + amuxd sidecar 编译全程没走 sccache，尽管它们和紧随其后的 tauri 编译共享绝大部分依赖树。
2. **`cache-targets: false`**：sccache 已接管逐 crate 编译产物，rust-cache 再缓存整个 target/ 是重复的，还和 sccache 争抢共享 10GB Actions 缓存；顺带砍掉 "Post Rust cache" 的存盘时间。

## 不适用的一项

第一轮那个 Cargo.lock 免编译优化**这里用不上**：release.yml 从 tag commit 构建（版本已提交），且 `verify-version-bump` gate 在 ubuntu 上只跑校验脚本、不做 cargo build，本来就没有双重编译可砍。

## 预期

和 release-oss 一样，**大头收益落在第二次 tag 发布**（sccache 缓存变热后）。首次会因冷缓存略慢，属正常。

改动纯 CI 配置，零成本、不涉及计费。

🤖 Generated with [Claude Code](https://claude.com/claude-code)