### PR TITLE
fix(extension): persist Process locally and use single side panel

### DIFF
--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -10,12 +10,20 @@ chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
   .catch((e) => console.warn('[bg] setPanelBehavior failed', e))
 
-async function enableSidePanelForTab(tabId: number): Promise<void> {
-  await chrome.sidePanel.setOptions({
-    tabId,
-    path: SIDE_PANEL_PATH,
-    enabled: true,
-  })
+/**
+ * Global (window-scoped) panel only.
+ * Never call setOptions({ tabId, path }) — Chrome treats that as a *second*
+ * sidepanel/index.html instance when path matches side_panel.default_path.
+ */
+async function ensureGlobalSidePanel(): Promise<void> {
+  try {
+    await chrome.sidePanel.setOptions({
+      path: SIDE_PANEL_PATH,
+      enabled: true,
+    })
+  } catch (e) {
+    console.warn('[bg] ensureGlobalSidePanel failed', e)
+  }
 }
 
 async function injectContentScript(tabId: number): Promise<void> {
@@ -35,29 +43,33 @@ async function injectOpenHttpTabs(): Promise<void> {
   await Promise.all(
     tabs.map(async (tab) => {
       if (!tab.id) return
-      await enableSidePanelForTab(tab.id)
       await injectContentScript(tab.id)
     }),
   )
 }
 
+async function bootstrapSidePanel(): Promise<void> {
+  await ensureGlobalSidePanel()
+  await injectOpenHttpTabs()
+}
+
 chrome.runtime.onInstalled.addListener(() => {
-  void injectOpenHttpTabs()
+  void bootstrapSidePanel()
 })
 
 chrome.runtime.onStartup.addListener(() => {
-  void injectOpenHttpTabs()
+  void bootstrapSidePanel()
 })
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (isOpenSidePanel(msg)) {
-    const tabId = sender.tab?.id
-    if (!tabId) {
-      sendResponse({ ok: false, error: 'no-tab' })
+    const windowId = sender.tab?.windowId
+    if (windowId == null) {
+      sendResponse({ ok: false, error: 'no-window' })
       return true
     }
 
-    void openSidePanelFromUserGesture(msg, tabId, sender.tab?.windowId).then(sendResponse)
+    void openSidePanelFromUserGesture(msg, windowId).then(sendResponse)
     return true
   }
 

--- a/apps/extension/src/lib/open-side-panel.test.ts
+++ b/apps/extension/src/lib/open-side-panel.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { openSidePanelFromUserGesture } from './open-side-panel'
+import { openSidePanelMsg } from './messages'
+
+type OpenCall = { tabId?: number; windowId?: number }
+type SetOptionsCall = { tabId?: number; path?: string; enabled?: boolean }
+
+describe('openSidePanelFromUserGesture', () => {
+  const openCalls: OpenCall[] = []
+  const setOptionsCalls: SetOptionsCall[] = []
+  let openShouldFailOnce = false
+
+  beforeEach(() => {
+    openCalls.length = 0
+    setOptionsCalls.length = 0
+    openShouldFailOnce = false
+
+    const storageSet = vi.fn(async () => {})
+    ;(globalThis as { chrome: unknown }).chrome = {
+      runtime: { lastError: undefined as { message: string } | undefined },
+      storage: { session: { set: storageSet } },
+      sidePanel: {
+        open: (opts: OpenCall, cb: () => void) => {
+          openCalls.push(opts)
+          if (openShouldFailOnce && openCalls.length === 1) {
+            ;(chrome.runtime as { lastError?: { message: string } }).lastError = {
+              message: 'not enabled',
+            }
+            openShouldFailOnce = false
+            cb()
+            ;(chrome.runtime as { lastError?: { message: string } }).lastError = undefined
+            return
+          }
+          ;(chrome.runtime as { lastError?: { message: string } }).lastError = undefined
+          cb()
+        },
+        setOptions: (opts: SetOptionsCall, cb: () => void) => {
+          setOptionsCalls.push(opts)
+          ;(chrome.runtime as { lastError?: { message: string } }).lastError = undefined
+          cb()
+        },
+      },
+    }
+  })
+
+  it('opens with windowId only (global panel — no tabId)', async () => {
+    const msg = openSidePanelMsg({
+      page: {
+        url: 'https://example.com',
+        title: 't',
+        selection: '',
+        text: '',
+        html: '',
+      },
+      linkKey: 'k',
+      linkUrl: 'https://example.com',
+      linkText: '',
+      source: 'link-hover',
+    })
+    const result = await openSidePanelFromUserGesture(msg, 42)
+    expect(result).toEqual({ ok: true })
+    expect(openCalls).toEqual([{ windowId: 42 }])
+    expect(openCalls[0]).not.toHaveProperty('tabId')
+  })
+
+  it('retry setOptions is global (no tabId path)', async () => {
+    openShouldFailOnce = true
+    const msg = openSidePanelMsg({
+      page: {
+        url: 'https://example.com',
+        title: 't',
+        selection: '',
+        text: '',
+        html: '',
+      },
+      linkKey: 'k',
+      linkUrl: 'https://example.com',
+      linkText: '',
+      source: 'link-hover',
+    })
+    const result = await openSidePanelFromUserGesture(msg, 7)
+    expect(result).toEqual({ ok: true })
+    expect(setOptionsCalls).toEqual([{ path: 'sidepanel/index.html', enabled: true }])
+    expect(setOptionsCalls.every((c) => c.tabId === undefined)).toBe(true)
+    expect(openCalls.every((c) => c.tabId === undefined && c.windowId === 7)).toBe(true)
+  })
+})

--- a/apps/extension/src/lib/open-side-panel.ts
+++ b/apps/extension/src/lib/open-side-panel.ts
@@ -5,19 +5,25 @@ const SIDE_PANEL_PATH = 'sidepanel/index.html'
 export type OpenSidePanelResult = { ok: true } | { ok: false; error: string }
 
 /**
- * Open the side panel in the same synchronous turn as the user click.
- * chrome.sidePanel.open() requires a live user gesture — any await before it
+ * Open the **global** (window-scoped) side panel in the same synchronous turn
+ * as the user click.
+ *
+ * Important: do NOT pass `tabId` to `sidePanel.open` / `setOptions`. Chrome
+ * treats `setOptions({ tabId, path })` with the same path as
+ * `side_panel.default_path` as a *separate* panel instance. Multiple
+ * `sidepanel/index.html` pages then run in parallel (separate React trees,
+ * shared chrome.storage) and corrupt session/message state.
+ *
+ * `chrome.sidePanel.open()` requires a live user gesture — any await before it
  * in the service worker causes a silent no-op. The content-script stashes
  * PENDING_LINK_OPEN_KEY before messaging here; we stash again after open as backup.
  */
 export function openSidePanelFromUserGesture(
   msg: OpenSidePanelMsg,
-  tabId: number,
-  windowId?: number,
+  windowId: number,
 ): Promise<OpenSidePanelResult> {
   return new Promise((resolve) => {
-    const openOpts: chrome.sidePanel.OpenOptions = { tabId }
-    if (windowId !== undefined) openOpts.windowId = windowId
+    const openOpts: chrome.sidePanel.OpenOptions = { windowId }
 
     const stashPayload = () => {
       void chrome.storage.session.set({ [PENDING_LINK_OPEN_KEY]: msg.payload })
@@ -35,17 +41,21 @@ export function openSidePanelFromUserGesture(
         return
       }
 
-      chrome.sidePanel.setOptions({ tabId, path: SIDE_PANEL_PATH, enabled: true }, () => {
-        const setErr = chrome.runtime.lastError
-        if (setErr) {
-          finish(false, setErr.message)
-          return
-        }
-        chrome.sidePanel.open(openOpts, () => {
-          const retryErr = chrome.runtime.lastError
-          finish(!retryErr, retryErr?.message)
-        })
-      })
+      // Global options only — never tabId (would spawn a second instance).
+      chrome.sidePanel.setOptions(
+        { path: SIDE_PANEL_PATH, enabled: true },
+        () => {
+          const setErr = chrome.runtime.lastError
+          if (setErr) {
+            finish(false, setErr.message)
+            return
+          }
+          chrome.sidePanel.open(openOpts, () => {
+            const retryErr = chrome.runtime.lastError
+            finish(!retryErr, retryErr?.message)
+          })
+        },
+      )
     })
   })
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 import i18n from "@/lib/i18n";
 import { Toaster, toast } from "sonner";
 import { cn, isTauri, removeStartupSkeleton } from "@/lib/utils";
-import { capabilities } from "@/lib/platform";
+import { capabilities, isChromeExtension } from "@/lib/platform";
 import { scheduleReleaseStuckModalLayers } from "@/lib/modal-layer-cleanup";
 import { appDisplayName, buildConfig } from "@/lib/build-config";
 import { buildSessionDeeplink } from "@/lib/session-deeplink";
@@ -148,6 +148,11 @@ import {
   summarizePendingReplies,
   summarizeStreamEntry,
 } from "@/lib/interrupt-msg-diag";
+import {
+  logExtMsgDiag,
+  summarizeProtoForExtDiag,
+  summarizeProtosForExtDiag,
+} from "@/lib/extension-msg-diag";
 import { logStreamToolDiag } from "@/lib/stream-tool-diag";
 import { useOutboxStore } from "@/stores/outbox-store";
 import { startOutboxSender } from "@/services/outbox-sender";
@@ -161,6 +166,7 @@ import { getDesktopDeviceId } from "./lib/backend/cloud-api/device-id";
 import { create as createMessage } from "@bufbuild/protobuf";
 import { MessageSchema, MessageKind, type Message as TeamclawMessage } from "@/lib/proto/teamclaw_pb";
 import { messageRowsToProto } from "@/lib/session-export/collect";
+import { historyRowsToMessageRows } from "@/lib/message-history-map";
 import {
   agentStreamKey,
   buildInterruptedStreamAnchor,
@@ -882,12 +888,22 @@ function AppContent() {
   // message store AND the libsql cache, so it never survives a reload as a
   // duplicate bubble alongside the real reply.
   function dropInterruptedPlaceholderRow(sessionId: string, messageId: string) {
+    logExtMsgDiag("interrupt.drop", {
+      sessionId,
+      messageId,
+      isInterrupt: messageId.startsWith("interrupt-"),
+    });
     useSessionMessageStore.getState().removeMessageById(sessionId, messageId);
     void softDeleteMessage(messageId, new Date().toISOString()).catch((e) => {
       console.warn(
         "[interrupt] cache removal of synthetic placeholder failed",
         e,
       );
+      logExtMsgDiag("interrupt.drop.cacheFail", {
+        sessionId,
+        messageId,
+        error: e instanceof Error ? e.message : String(e),
+      });
     });
   }
 
@@ -898,7 +914,17 @@ function AppContent() {
   ) {
     const streamKey = agentStreamKey(sessionId, actorId);
     const placeholder = interruptedStreamFlushRef.current[streamKey];
-    if (!placeholder || !streamId || placeholder.streamId !== streamId) return;
+    if (!placeholder || !streamId || placeholder.streamId !== streamId) {
+      logExtMsgDiag("interrupt.removeByStream.miss", {
+        sessionId,
+        actorId,
+        streamId: streamId ?? null,
+        hasPlaceholder: Boolean(placeholder),
+        placeholderStreamId: placeholder?.streamId ?? null,
+        placeholderMessageId: placeholder?.messageId ?? null,
+      });
+      return;
+    }
     dropInterruptedPlaceholderRow(sessionId, placeholder.messageId);
     delete interruptedStreamFlushRef.current[streamKey];
   }
@@ -915,7 +941,20 @@ function AppContent() {
   ) {
     const streamKey = agentStreamKey(sessionId, actorId);
     const placeholder = interruptedStreamFlushRef.current[streamKey];
-    if (!placeholder) return;
+    if (!placeholder) {
+      logExtMsgDiag("interrupt.removeForRealReply.miss", {
+        sessionId,
+        actorId,
+        note: "real AGENT_REPLY arrived but placeholder ref empty — interrupt may remain → duplicate header",
+      });
+      return;
+    }
+    logExtMsgDiag("interrupt.removeForRealReply.hit", {
+      sessionId,
+      actorId,
+      placeholderMessageId: placeholder.messageId,
+      placeholderStreamId: placeholder.streamId,
+    });
     dropInterruptedPlaceholderRow(sessionId, placeholder.messageId);
     delete interruptedStreamFlushRef.current[streamKey];
   }
@@ -988,6 +1027,13 @@ function AppContent() {
       messageId: syntheticReply.messageId,
       ...summarizeStreamEntry(snapshot, "snapshot"),
     });
+    logExtMsgDiag("flush.interrupted.start", {
+      sessionId,
+      actorId,
+      trigger,
+      ...summarizeProtoForExtDiag(syntheticReply),
+      ...summarizeStreamEntry(snapshot, "snapshot"),
+    });
 
     flushTurnAgentReplyInFlightRef.current[streamKey] = true;
     const streamEntrySnapshot = snapshot;
@@ -1009,6 +1055,14 @@ function AppContent() {
           streamId: snapshot.streamId,
           messageId: enrichedReply.messageId,
         };
+        logExtMsgDiag("flush.interrupted.placeholderRecorded", {
+          sessionId,
+          actorId,
+          ...summarizeProtoForExtDiag(enrichedReply),
+          store: summarizeProtosForExtDiag(
+            useSessionMessageStore.getState().messages[sessionId] ?? [],
+          ),
+        });
       },
     }).finally(() => {
       delete flushTurnAgentReplyInFlightRef.current[streamKey];
@@ -1445,8 +1499,22 @@ function AppContent() {
                 if (stampedReplyTo) {
                   removePendingAgentReplyTo(sid, senderActorId, stampedReplyTo);
                 }
+                logExtMsgDiag("mqtt.agentReply.lateAppend.noPartsPersist", {
+                  sessionId: sid,
+                  actorId: senderActorId,
+                  note: "late AGENT_REPLY after stream detach — append without persistStreamingPartsForReply",
+                  ...summarizeProtoForExtDiag(msg),
+                });
               }
               useSessionMessageStore.getState().appendMessage(sid, decoded.message);
+              if (senderActorId && msg.kind === MessageKind.AGENT_REPLY) {
+                logExtMsgDiag("mqtt.agentReply.lateAppend.storeSnapshot", {
+                  sessionId: sid,
+                  ...summarizeProtosForExtDiag(
+                    useSessionMessageStore.getState().messages[sid] ?? [],
+                  ),
+                });
+              }
             }
 
             if (
@@ -2010,7 +2078,9 @@ function AppContent() {
   //   1. Tauri: hydrate immediately from local libsql cache (no Supabase wait).
   //   2. Background: delta-sync from Supabase (watermark-based), upsert local,
   //      re-render if anything new arrived.
-  //   3. Non-Tauri: full Supabase pull (unchanged behaviour).
+  //   3. Extension: chrome.storage.local cache (same MessageRow shape) + full
+  //      cloud pull; COALESCE preserves local parts_json.
+  //   4. Other Non-Tauri: full backend pull.
   // agent_runtime_event table is no longer read here — those rows were written
   // with origin="mqtt-live" into the message table by new envelope handler code.
   // TODO(cleanup): remove agent_runtime_event table once all clients have
@@ -2020,6 +2090,15 @@ function AppContent() {
   const messageRefreshTrigger = useSessionMessageStore((s) => s.messageRefreshTrigger);
   const messageRefreshForceFull = useSessionMessageStore((s) => s.messageRefreshForceFull);
   const prevRefreshTriggerRef = useRef(0);
+
+  // Extension: prune message cache on sidepanel open (in addition to write/load).
+  useEffect(() => {
+    if (!isChromeExtension()) return;
+    void import("@/lib/extension-message-cache").then(({ pruneExtensionMessageCache }) =>
+      pruneExtensionMessageCache(),
+    );
+  }, []);
+
   useEffect(() => {
     if (!currentSessionId) return;
     if (isV2E2EControlActive()) return;
@@ -2098,7 +2177,76 @@ function AppContent() {
         return;
       }
 
-      // ── Non-Tauri: full backend pull ──────────────────────────────
+      // ── Extension: local-first (chrome.storage) + full cloud pull ─
+      // Same shape as desktop: hydrate cache → upsert cloud rows (COALESCE
+      // parts_json) → re-read. Eviction runs inside the cache writes / load.
+      if (isChromeExtension()) {
+        const { loadMessagesForSession, upsertMessagesBatch } = await import(
+          "@/lib/local-cache"
+        );
+        const localMsgs = await loadMessagesForSession(currentSessionId, false);
+        if (cancelled) return;
+        if (localMsgs.length > 0) {
+          const localProtos = messageRowsToProto(localMsgs);
+          useSessionMessageStore
+            .getState()
+            .setMessages(currentSessionId, localProtos);
+          logExtMsgDiag("history.ext.hydrateLocal", {
+            sessionId: currentSessionId,
+            ...summarizeProtosForExtDiag(localProtos),
+          });
+        }
+
+        let historyRows;
+        try {
+          historyRows = await getBackend().messages.listMessages(currentSessionId);
+        } catch (error) {
+          console.warn(
+            "[history] load failed:",
+            error instanceof Error ? error.message : error,
+          );
+          if (!cancelled && localMsgs.length === 0) {
+            useSessionMessageStore.getState().setMessages(currentSessionId, []);
+          }
+          return;
+        }
+        if (cancelled) return;
+
+        const teamId =
+          useSessionListStore.getState().rows.find((r) => r.id === currentSessionId)
+            ?.team_id ?? "";
+        const memoryBeforeCloud = useSessionMessageStore.getState().messages[
+          currentSessionId
+        ] ?? [];
+        logExtMsgDiag("history.ext.beforeCloudUpsert", {
+          sessionId: currentSessionId,
+          cloudCount: historyRows.length,
+          memory: summarizeProtosForExtDiag(memoryBeforeCloud),
+        });
+        await upsertMessagesBatch(
+          historyRowsToMessageRows(historyRows, {
+            teamId,
+            origin: getBackend().kind,
+          }),
+        );
+        if (cancelled) return;
+
+        const fresh = await loadMessagesForSession(currentSessionId, false);
+        if (!cancelled) {
+          const freshProtos = messageRowsToProto(fresh);
+          useSessionMessageStore
+            .getState()
+            .setMessages(currentSessionId, freshProtos);
+          logExtMsgDiag("history.ext.afterSetMessages", {
+            sessionId: currentSessionId,
+            note: "whole-replace from cache after cloud upsert — check partsLen / interruptCount",
+            ...summarizeProtosForExtDiag(freshProtos),
+          });
+        }
+        return;
+      }
+
+      // ── Non-Tauri web: full backend pull ──────────────────────────
       let historyRows;
       try {
         historyRows = await getBackend().messages.listMessages(currentSessionId);
@@ -2110,17 +2258,26 @@ function AppContent() {
         return;
       }
       if (cancelled) return;
-      const backendMsgs = historyRows.map((r) =>
-        createMessage(MessageSchema, {
+      const backendMsgs = historyRows.map((r) => {
+        const metadataJson =
+          r.metadata == null
+            ? ""
+            : typeof r.metadata === "string"
+              ? r.metadata
+              : JSON.stringify(r.metadata);
+        return createMessage(MessageSchema, {
           messageId: r.id,
           sessionId: r.session_id,
           senderActorId: r.sender_actor_id ?? "",
           kind: kindMap[r.kind] ?? MessageKind.TEXT,
           content: r.content ?? "",
           model: r.model ?? "",
+          turnId: r.turn_id ?? "",
+          replyToMessageId: r.reply_to_message_id ?? "",
+          metadataJson,
           createdAt: BigInt(Math.floor(new Date(r.created_at).getTime() / 1000)),
-        }),
-      );
+        });
+      });
       useSessionMessageStore.getState().setMessages(currentSessionId, backendMsgs);
     })();
     return () => {

--- a/packages/app/src/__tests__/App.test.tsx
+++ b/packages/app/src/__tests__/App.test.tsx
@@ -85,6 +85,8 @@ vi.mock('@/lib/utils', () => ({
   removeStartupSkeleton: () => {},
 }))
 vi.mock('@/lib/platform', () => ({
+  isChromeExtension: () => false,
+  getAppPlatform: () => 'web',
   capabilities: {
     workspace: true,
     tauriInvoke: false,

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -20,6 +20,8 @@ import { TEAMCLAW_DIR, CONFIG_FILE_NAME, TEAM_REPO_DIR } from "@/lib/build-confi
 import { adaptTeamclawMessages } from "@/lib/v2-message-adapter";
 import { notePendingAgentReplyTo } from "@/lib/pending-agent-reply-to";
 import { logInterruptMsgDiag } from "@/lib/interrupt-msg-diag";
+import { logExtMsgDiag } from "@/lib/extension-msg-diag";
+import { isChromeExtension } from "@/lib/platform";
 import { useAuthStore } from "@/stores/auth-store";
 import { bumpSessionListLastMessage } from "@/lib/session-list-preview";
 import { useSessionListStore } from "@/stores/session-list-store";
@@ -2046,6 +2048,33 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
         lastUpdate: entry.lastUpdate,
       })),
     });
+    if (isChromeExtension()) {
+      const assistantTail = timelineMessages
+        .filter((m) => m.role !== "user" && m.role !== "system")
+        .slice(-6);
+      logExtMsgDiag("ui.timeline", {
+        sessionId: displaySessionId,
+        assistantTail: assistantTail.map((m) => ({
+          id: m.id,
+          role: m.role,
+          turnId: m.turnId ?? "",
+          replyTo: m.replyToMessageId ?? "",
+          contentLen: (m.content ?? "").trim().length,
+          isInterrupt: m.id.startsWith("interrupt-"),
+          toolCount: m.toolCalls?.length ?? 0,
+          partTypes: m.parts?.map((p) => p.type) ?? [],
+          hasProcessParts: (m.parts ?? []).some(
+            (p) => p.type === "reasoning" || p.type === "tool-call",
+          ),
+        })),
+        interruptVisible: assistantTail.filter((m) =>
+          m.id.startsWith("interrupt-"),
+        ).length,
+        replyToHeaders: assistantTail.filter((m) =>
+          Boolean(m.replyToMessageId?.trim()),
+        ).length,
+      });
+    }
   }, [displaySessionId, displayMessages, displayV2Streams]);
 
   const hasSessionNotices = useSessionNoticeStore((s) =>

--- a/packages/app/src/lib/__tests__/message-history-map.test.ts
+++ b/packages/app/src/lib/__tests__/message-history-map.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { historyRowsToMessageRows } from "../message-history-map";
+
+describe("historyRowsToMessageRows", () => {
+  it("maps reply_to and metadata", () => {
+    const rows = historyRowsToMessageRows(
+      [
+        {
+          id: "m1",
+          team_id: "t1",
+          session_id: "s1",
+          turn_id: "turn-1",
+          sender_actor_id: "a1",
+          reply_to_message_id: "parent-1",
+          kind: "agent_reply",
+          content: "Done.",
+          metadata: { foo: 1 },
+          model: "deepseek",
+          created_at: "2026-01-01T00:00:00.000Z",
+          updated_at: null,
+        },
+      ],
+      { origin: "cloud_api" },
+    );
+    expect(rows[0]?.replyToMessageId).toBe("parent-1");
+    expect(rows[0]?.turnId).toBe("turn-1");
+    expect(rows[0]?.metadataJson).toBe('{"foo":1}');
+    expect(rows[0]?.origin).toBe("cloud_api");
+  });
+});

--- a/packages/app/src/lib/extension-message-cache/__tests__/extension-message-cache.test.ts
+++ b/packages/app/src/lib/extension-message-cache/__tests__/extension-message-cache.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const store = new Map<string, unknown>();
+
+vi.mock("../chrome-storage", () => ({
+  readChromeStorageLocal: () => ({
+    get: async (keys?: string | string[] | null) => {
+      const out: Record<string, unknown> = {};
+      const list = Array.isArray(keys) ? keys : keys ? [keys] : [...store.keys()];
+      for (const key of list) {
+        if (store.has(key)) out[key] = store.get(key);
+      }
+      return out;
+    },
+    set: async (items: Record<string, unknown>) => {
+      for (const [k, v] of Object.entries(items)) store.set(k, v);
+    },
+    remove: async (keys: string | string[]) => {
+      for (const key of Array.isArray(keys) ? keys : [keys]) store.delete(key);
+    },
+  }),
+}));
+
+import {
+  loadExtensionMessagesForSession,
+  pruneExtensionMessageCache,
+  setExtensionMessageParts,
+  upsertExtensionMessagesBatch,
+} from "../index";
+import { pickSessionsToEvict } from "../evict";
+import {
+  emptyMeta,
+  MAX_BYTES,
+  MAX_SESSIONS,
+  META_KEY,
+  sessionStorageKey,
+  type ExtensionMessageCacheMeta,
+} from "../types";
+import type { MessageRow } from "@/lib/local-cache";
+
+function row(
+  overrides: Partial<MessageRow> & Pick<MessageRow, "id" | "sessionId">,
+): MessageRow {
+  const now = new Date().toISOString();
+  return {
+    teamId: "team-1",
+    kind: "agent_reply",
+    content: "Done.",
+    origin: "mqtt-live",
+    createdAt: now,
+    updatedAt: now,
+    syncedAt: now,
+    ...overrides,
+  };
+}
+
+describe("pickSessionsToEvict", () => {
+  it("evicts oldest sessions beyond MAX_SESSIONS", () => {
+    const meta = emptyMeta();
+    for (let i = 0; i < MAX_SESSIONS + 3; i++) {
+      meta.sessions[`s${i}`] = { lastAccessAt: i, bytes: 10 };
+    }
+    const victims = pickSessionsToEvict(meta, { protectSessionId: "s22" });
+    expect(victims).toEqual(["s0", "s1", "s2"]);
+    expect(victims).not.toContain("s22");
+  });
+
+  it("evicts until under byte budget", () => {
+    const meta = emptyMeta();
+    meta.sessions.a = { lastAccessAt: 1, bytes: MAX_BYTES };
+    meta.sessions.b = { lastAccessAt: 2, bytes: 100 };
+    const victims = pickSessionsToEvict(meta, { protectSessionId: "b" });
+    expect(victims).toEqual(["a"]);
+  });
+});
+
+describe("extension message cache", () => {
+  beforeEach(() => {
+    store.clear();
+  });
+
+  it("upserts and loads messages for a session", async () => {
+    await upsertExtensionMessagesBatch([
+      row({ id: "m1", sessionId: "sess-a", content: "hi" }),
+    ]);
+    const loaded = await loadExtensionMessagesForSession("sess-a");
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]?.content).toBe("hi");
+  });
+
+  it("COALESCE keeps local partsJson when cloud row has none", async () => {
+    await upsertExtensionMessagesBatch([
+      row({
+        id: "m1",
+        sessionId: "sess-a",
+        partsJson: JSON.stringify([{ type: "reasoning", text: "think" }]),
+      }),
+    ]);
+    await upsertExtensionMessagesBatch([
+      row({ id: "m1", sessionId: "sess-a", content: "Done.", partsJson: null }),
+    ]);
+    const loaded = await loadExtensionMessagesForSession("sess-a");
+    expect(loaded[0]?.partsJson).toContain("reasoning");
+    expect(loaded[0]?.content).toBe("Done.");
+  });
+
+  it("setMessageParts attaches parts onto an existing row", async () => {
+    await upsertExtensionMessagesBatch([
+      row({ id: "m1", sessionId: "sess-a" }),
+    ]);
+    const partsJson = JSON.stringify([
+      { type: "tool-call", toolCall: { id: "t1", name: "sleep" } },
+    ]);
+    await setExtensionMessageParts("m1", partsJson);
+    const loaded = await loadExtensionMessagesForSession("sess-a");
+    expect(loaded[0]?.partsJson).toBe(partsJson);
+  });
+
+  it("prunes LRU sessions over the cap", async () => {
+    for (let i = 0; i < MAX_SESSIONS + 2; i++) {
+      await upsertExtensionMessagesBatch([
+        row({ id: `m${i}`, sessionId: `sess-${i}`, content: `c${i}` }),
+      ]);
+    }
+    const meta = store.get(META_KEY) as ExtensionMessageCacheMeta;
+    expect(Object.keys(meta.sessions).length).toBeLessThanOrEqual(MAX_SESSIONS);
+    expect(store.has(sessionStorageKey("sess-0"))).toBe(false);
+  });
+
+  it("pruneExtensionMessageCache can run on open", async () => {
+    store.set(META_KEY, {
+      version: 1,
+      sessions: Object.fromEntries(
+        Array.from({ length: MAX_SESSIONS + 1 }, (_, i) => [
+          `sess-${i}`,
+          { lastAccessAt: i, bytes: 10 },
+        ]),
+      ),
+      idIndex: {},
+    } satisfies ExtensionMessageCacheMeta);
+    for (let i = 0; i < MAX_SESSIONS + 1; i++) {
+      store.set(sessionStorageKey(`sess-${i}`), [
+        row({ id: `m${i}`, sessionId: `sess-${i}` }),
+      ]);
+    }
+    const victims = await pruneExtensionMessageCache({
+      protectSessionId: `sess-${MAX_SESSIONS}`,
+    });
+    expect(victims.length).toBeGreaterThan(0);
+    expect(victims).toContain("sess-0");
+  });
+});

--- a/packages/app/src/lib/extension-message-cache/chrome-storage.ts
+++ b/packages/app/src/lib/extension-message-cache/chrome-storage.ts
@@ -1,0 +1,12 @@
+type ChromeStorageLocal = {
+  get: (
+    keys?: string | string[] | Record<string, unknown> | null,
+  ) => Promise<Record<string, unknown>>;
+  set: (items: Record<string, unknown>) => Promise<void>;
+  remove: (keys: string | string[]) => Promise<void>;
+};
+
+export function readChromeStorageLocal(): ChromeStorageLocal | undefined {
+  return (globalThis as { chrome?: { storage?: { local?: ChromeStorageLocal } } })
+    .chrome?.storage?.local;
+}

--- a/packages/app/src/lib/extension-message-cache/evict.ts
+++ b/packages/app/src/lib/extension-message-cache/evict.ts
@@ -1,0 +1,61 @@
+import type { ExtensionMessageCacheMeta } from "./types";
+import { MAX_BYTES, MAX_SESSIONS, sessionStorageKey } from "./types";
+
+/**
+ * Pick session ids to drop so remaining count ≤ maxSessions and bytes ≤ maxBytes.
+ * Never evicts `protectSessionId`. Oldest `lastAccessAt` first.
+ */
+export function pickSessionsToEvict(
+  meta: ExtensionMessageCacheMeta,
+  opts?: {
+    maxSessions?: number;
+    maxBytes?: number;
+    protectSessionId?: string | null;
+  },
+): string[] {
+  const maxSessions = opts?.maxSessions ?? MAX_SESSIONS;
+  const maxBytes = opts?.maxBytes ?? MAX_BYTES;
+  const protect = opts?.protectSessionId?.trim() || null;
+
+  const victims: string[] = [];
+  let sessionCount = Object.keys(meta.sessions).length;
+  let totalBytes = Object.values(meta.sessions).reduce((n, s) => n + s.bytes, 0);
+
+  const sorted = Object.entries(meta.sessions)
+    .filter(([id]) => id !== protect)
+    .sort((a, b) => a[1].lastAccessAt - b[1].lastAccessAt);
+
+  for (const [sessionId, info] of sorted) {
+    if (sessionCount <= maxSessions && totalBytes <= maxBytes) break;
+    victims.push(sessionId);
+    sessionCount -= 1;
+    totalBytes -= info.bytes;
+  }
+
+  return victims;
+}
+
+export function applyEvictionToMeta(
+  meta: ExtensionMessageCacheMeta,
+  sessionIds: string[],
+): { meta: ExtensionMessageCacheMeta; keysToRemove: string[] } {
+  if (sessionIds.length === 0) {
+    return { meta, keysToRemove: [] };
+  }
+  const next: ExtensionMessageCacheMeta = {
+    version: 1,
+    sessions: { ...meta.sessions },
+    idIndex: { ...meta.idIndex },
+  };
+  const evicted = new Set(sessionIds);
+  for (const id of sessionIds) {
+    delete next.sessions[id];
+  }
+  for (const [messageId, sessionId] of Object.entries(next.idIndex)) {
+    if (evicted.has(sessionId)) delete next.idIndex[messageId];
+  }
+  return {
+    meta: next,
+    keysToRemove: sessionIds.map(sessionStorageKey),
+  };
+}

--- a/packages/app/src/lib/extension-message-cache/index.ts
+++ b/packages/app/src/lib/extension-message-cache/index.ts
@@ -1,0 +1,230 @@
+import type { MessageRow } from "@/lib/local-cache";
+import { readChromeStorageLocal } from "./chrome-storage";
+import { applyEvictionToMeta, pickSessionsToEvict } from "./evict";
+import {
+  emptyMeta,
+  estimateBytes,
+  isMessageRow,
+  META_KEY,
+  sessionStorageKey,
+  type ExtensionMessageCacheMeta,
+} from "./types";
+
+function coalescePartsJson(
+  incoming: string | null | undefined,
+  existing: string | null | undefined,
+): string | null {
+  const next = incoming?.trim() ? incoming : null;
+  if (next) return next;
+  const prev = existing?.trim() ? existing : null;
+  return prev;
+}
+
+function mergeMessageRow(existing: MessageRow | undefined, incoming: MessageRow): MessageRow {
+  if (!existing) return { ...incoming };
+  return {
+    ...existing,
+    ...incoming,
+    partsJson: coalescePartsJson(incoming.partsJson, existing.partsJson),
+  };
+}
+
+function parseSessionRows(raw: unknown): MessageRow[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(isMessageRow);
+}
+
+async function readMeta(): Promise<ExtensionMessageCacheMeta> {
+  const storage = readChromeStorageLocal();
+  if (!storage) return emptyMeta();
+  try {
+    const bag = await storage.get(META_KEY);
+    const raw = bag[META_KEY];
+    if (!raw || typeof raw !== "object") return emptyMeta();
+    const obj = raw as Partial<ExtensionMessageCacheMeta>;
+    return {
+      version: 1,
+      sessions:
+        obj.sessions && typeof obj.sessions === "object" ? { ...obj.sessions } : {},
+      idIndex:
+        obj.idIndex && typeof obj.idIndex === "object" ? { ...obj.idIndex } : {},
+    };
+  } catch {
+    return emptyMeta();
+  }
+}
+
+async function writeMeta(meta: ExtensionMessageCacheMeta): Promise<void> {
+  const storage = readChromeStorageLocal();
+  if (!storage) return;
+  await storage.set({ [META_KEY]: meta });
+}
+
+async function readSessionRows(sessionId: string): Promise<MessageRow[]> {
+  const storage = readChromeStorageLocal();
+  if (!storage) return [];
+  try {
+    const key = sessionStorageKey(sessionId);
+    const bag = await storage.get(key);
+    return parseSessionRows(bag[key]);
+  } catch {
+    return [];
+  }
+}
+
+async function writeSessionRows(
+  sessionId: string,
+  rows: MessageRow[],
+  meta: ExtensionMessageCacheMeta,
+): Promise<ExtensionMessageCacheMeta> {
+  const storage = readChromeStorageLocal();
+  if (!storage) return meta;
+
+  const bytes = estimateBytes(rows);
+  const now = Date.now();
+  const nextMeta: ExtensionMessageCacheMeta = {
+    version: 1,
+    sessions: {
+      ...meta.sessions,
+      [sessionId]: { lastAccessAt: now, bytes },
+    },
+    idIndex: { ...meta.idIndex },
+  };
+  for (const row of rows) {
+    nextMeta.idIndex[row.id] = sessionId;
+  }
+
+  await storage.set({
+    [sessionStorageKey(sessionId)]: rows,
+    [META_KEY]: nextMeta,
+  });
+  return nextMeta;
+}
+
+/** Drop excess sessions by LRU count + byte budget. Optionally protect one session. */
+export async function pruneExtensionMessageCache(opts?: {
+  protectSessionId?: string | null;
+}): Promise<string[]> {
+  const storage = readChromeStorageLocal();
+  if (!storage) return [];
+
+  const meta = await readMeta();
+  const victims = pickSessionsToEvict(meta, {
+    protectSessionId: opts?.protectSessionId,
+  });
+  if (victims.length === 0) return [];
+
+  const { meta: nextMeta, keysToRemove } = applyEvictionToMeta(meta, victims);
+  await storage.remove(keysToRemove);
+  await writeMeta(nextMeta);
+  return victims;
+}
+
+export async function upsertExtensionMessagesBatch(rows: MessageRow[]): Promise<void> {
+  if (rows.length === 0) return;
+  const storage = readChromeStorageLocal();
+  if (!storage) return;
+
+  const bySession = new Map<string, MessageRow[]>();
+  for (const row of rows) {
+    const list = bySession.get(row.sessionId) ?? [];
+    list.push(row);
+    bySession.set(row.sessionId, list);
+  }
+
+  let meta = await readMeta();
+  for (const [sessionId, incoming] of bySession) {
+    const existing = await readSessionRows(sessionId);
+    const byId = new Map(existing.map((r) => [r.id, r]));
+    for (const row of incoming) {
+      byId.set(row.id, mergeMessageRow(byId.get(row.id), row));
+    }
+    const merged = [...byId.values()].sort((a, b) =>
+      a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0,
+    );
+    meta = await writeSessionRows(sessionId, merged, meta);
+  }
+
+  await pruneExtensionMessageCache({
+    protectSessionId: rows[0]?.sessionId ?? null,
+  });
+}
+
+export async function loadExtensionMessagesForSession(
+  sessionId: string,
+  includeDeleted = false,
+): Promise<MessageRow[]> {
+  const rows = await readSessionRows(sessionId);
+  const meta = await readMeta();
+  if (meta.sessions[sessionId]) {
+    const nextMeta: ExtensionMessageCacheMeta = {
+      ...meta,
+      sessions: {
+        ...meta.sessions,
+        [sessionId]: {
+          ...meta.sessions[sessionId],
+          lastAccessAt: Date.now(),
+        },
+      },
+    };
+    await writeMeta(nextMeta);
+  }
+
+  void pruneExtensionMessageCache({ protectSessionId: sessionId });
+
+  if (includeDeleted) return rows;
+  return rows.filter((r) => !r.deletedAt);
+}
+
+export async function setExtensionMessageParts(
+  messageId: string,
+  partsJson: string,
+): Promise<string> {
+  const storage = readChromeStorageLocal();
+  if (!storage) return partsJson;
+
+  const meta = await readMeta();
+  let sessionId = meta.idIndex[messageId];
+  let rows: MessageRow[] = [];
+
+  if (sessionId) {
+    rows = await readSessionRows(sessionId);
+  } else {
+    // Fallback scan if index is stale / missing
+    for (const sid of Object.keys(meta.sessions)) {
+      const candidate = await readSessionRows(sid);
+      if (candidate.some((r) => r.id === messageId)) {
+        sessionId = sid;
+        rows = candidate;
+        break;
+      }
+    }
+  }
+
+  if (!sessionId) {
+    // Message row not cached yet — nothing to attach; caller still keeps partsJson in memory.
+    return partsJson;
+  }
+
+  const nextRows = rows.map((r) =>
+    r.id === messageId ? { ...r, partsJson } : r,
+  );
+  // If message missing from session blob, skip write
+  if (!rows.some((r) => r.id === messageId)) return partsJson;
+
+  await writeSessionRows(sessionId, nextRows, meta);
+  await pruneExtensionMessageCache({ protectSessionId: sessionId });
+  return partsJson;
+}
+
+export async function softDeleteExtensionMessage(
+  id: string,
+  deletedAt: string,
+): Promise<void> {
+  const meta = await readMeta();
+  const sessionId = meta.idIndex[id];
+  if (!sessionId) return;
+  const rows = await readSessionRows(sessionId);
+  const next = rows.map((r) => (r.id === id ? { ...r, deletedAt } : r));
+  await writeSessionRows(sessionId, next, meta);
+}

--- a/packages/app/src/lib/extension-message-cache/types.ts
+++ b/packages/app/src/lib/extension-message-cache/types.ts
@@ -1,0 +1,53 @@
+import type { MessageRow } from "@/lib/local-cache";
+
+/** chrome.storage.local key prefix for per-session message blobs. */
+export const SESSION_KEY_PREFIX = "teamclaw.ext.msg.s.";
+
+/** Index + eviction metadata for the extension message cache. */
+export const META_KEY = "teamclaw.ext.msg.meta";
+
+/** Max sessions retained (LRU). */
+export const MAX_SESSIONS = 20;
+
+/** Soft byte budget for message blobs (leave headroom for other storage keys). */
+export const MAX_BYTES = 6 * 1024 * 1024;
+
+export type SessionMeta = {
+  lastAccessAt: number;
+  bytes: number;
+};
+
+export type ExtensionMessageCacheMeta = {
+  version: 1;
+  /** sessionId → access / size */
+  sessions: Record<string, SessionMeta>;
+  /** messageId → sessionId for O(1) parts updates */
+  idIndex: Record<string, string>;
+};
+
+export function sessionStorageKey(sessionId: string): string {
+  return `${SESSION_KEY_PREFIX}${sessionId}`;
+}
+
+export function emptyMeta(): ExtensionMessageCacheMeta {
+  return { version: 1, sessions: {}, idIndex: {} };
+}
+
+export function estimateBytes(rows: MessageRow[]): number {
+  try {
+    return new TextEncoder().encode(JSON.stringify(rows)).length;
+  } catch {
+    return JSON.stringify(rows).length;
+  }
+}
+
+export function isMessageRow(value: unknown): value is MessageRow {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Record<string, unknown>;
+  return (
+    typeof row.id === "string" &&
+    typeof row.sessionId === "string" &&
+    typeof row.kind === "string" &&
+    typeof row.content === "string"
+  );
+}

--- a/packages/app/src/lib/extension-msg-diag.ts
+++ b/packages/app/src/lib/extension-msg-diag.ts
@@ -1,0 +1,120 @@
+/**
+ * Temporary diagnostics for extension Process / Reply-to / duplicate-header bugs.
+ * DevTools filter: `ext-msg-diag`
+ * Dump: `window.teamclawExtMsgDiagDump()`
+ *
+ * Always logs (not gated on import.meta.env.DEV) so packaged extension builds
+ * still surface evidence in the side panel inspector.
+ */
+
+import type { Message as TeamclawMessage } from "@/lib/proto/teamclaw_pb";
+import { MessageKind } from "@/lib/proto/teamclaw_pb";
+
+const LOG_PREFIX = "[ext-msg-diag]";
+const RING_MAX = 120;
+
+type DiagRecord = {
+  at: string;
+  stage: string;
+  [key: string]: unknown;
+};
+
+const ring: DiagRecord[] = [];
+
+function push(record: DiagRecord): void {
+  ring.push(record);
+  if (ring.length > RING_MAX) ring.shift();
+}
+
+function partsMeta(partsJson: string | null | undefined): {
+  partsLen: number;
+  partTypes: string[];
+} {
+  if (!partsJson?.trim()) return { partsLen: 0, partTypes: [] };
+  try {
+    const parts = JSON.parse(partsJson) as Array<{ type?: string }>;
+    if (!Array.isArray(parts)) return { partsLen: 0, partTypes: ["not-array"] };
+    return {
+      partsLen: parts.length,
+      partTypes: parts.map((p) => p.type ?? "?"),
+    };
+  } catch {
+    return { partsLen: -1, partTypes: ["parse-error"] };
+  }
+}
+
+/** Compact one-line summary of a proto message for Process / duplicate checks. */
+export function summarizeProtoForExtDiag(m: TeamclawMessage): Record<string, unknown> {
+  const partsJson = (m as { partsJson?: string | null }).partsJson ?? null;
+  const id = m.messageId ?? "";
+  return {
+    id,
+    kind: MessageKind[m.kind] ?? m.kind,
+    turnId: m.turnId || "",
+    replyTo: m.replyToMessageId?.trim() || "",
+    contentLen: (m.content ?? "").trim().length,
+    isInterrupt: id.startsWith("interrupt-"),
+    ...partsMeta(partsJson),
+  };
+}
+
+export function summarizeProtosForExtDiag(
+  messages: TeamclawMessage[],
+): Record<string, unknown> {
+  const assistant = messages.filter(
+    (m) =>
+      m.kind === MessageKind.AGENT_REPLY ||
+      m.kind === MessageKind.AGENT_THINKING ||
+      m.kind === MessageKind.AGENT_TOOL_CALL ||
+      m.kind === MessageKind.AGENT_TOOL_RESULT,
+  );
+  const interrupts = assistant.filter((m) => m.messageId.startsWith("interrupt-"));
+  const replies = assistant.filter((m) => m.kind === MessageKind.AGENT_REPLY);
+  const replyTos = replies.filter((m) => Boolean(m.replyToMessageId?.trim()));
+  const withParts = replies.filter((m) => {
+    const p = (m as { partsJson?: string | null }).partsJson;
+    return Boolean(p?.trim());
+  });
+
+  return {
+    total: messages.length,
+    assistantCount: assistant.length,
+    agentReplyCount: replies.length,
+    interruptCount: interrupts.length,
+    replyToCount: replyTos.length,
+    agentReplyWithParts: withParts.length,
+    /** Tail — what you usually see at the bottom of the thread */
+    tail: messages.slice(-8).map(summarizeProtoForExtDiag),
+    interrupts: interrupts.map(summarizeProtoForExtDiag),
+    agentReplies: replies.slice(-6).map(summarizeProtoForExtDiag),
+  };
+}
+
+/** Always-on console + ring buffer. Filter DevTools by `ext-msg-diag`. */
+export function logExtMsgDiag(
+  stage: string,
+  payload: Record<string, unknown> = {},
+): void {
+  const record: DiagRecord = {
+    at: new Date().toISOString(),
+    stage,
+    ...payload,
+  };
+  push(record);
+  console.info(`${LOG_PREFIX} ${stage}`, record);
+}
+
+export function dumpExtMsgDiag(): DiagRecord[] {
+  console.table(ring);
+  return [...ring];
+}
+
+declare global {
+  interface Window {
+    teamclawExtMsgDiagDump?: () => DiagRecord[];
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.teamclawExtMsgDiagDump = dumpExtMsgDiag;
+}

--- a/packages/app/src/lib/local-cache.ts
+++ b/packages/app/src/lib/local-cache.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { isChromeExtension } from "@/lib/platform";
 import { isTauri } from "@/lib/utils";
 
 // ── team gate ──────────────────────────────────────────────────────────────
@@ -278,8 +279,17 @@ export async function softDeleteSessionParticipant(
 // ── message ────────────────────────────────────────────────────────────────
 
 export async function upsertMessagesBatch(rows: MessageRow[]): Promise<void> {
-  if (!isTauri() || rows.length === 0) return;
-  await invoke("local_cache_message_upsert_batch", { rows });
+  if (rows.length === 0) return;
+  if (isTauri()) {
+    await invoke("local_cache_message_upsert_batch", { rows });
+    return;
+  }
+  if (isChromeExtension()) {
+    const { upsertExtensionMessagesBatch } = await import(
+      "@/lib/extension-message-cache"
+    );
+    await upsertExtensionMessagesBatch(rows);
+  }
 }
 
 export async function loadMessagesForSession(
@@ -287,20 +297,36 @@ export async function loadMessagesForSession(
   includeDeleted = false,
   workspacePath?: string | null,
 ): Promise<MessageRow[]> {
-  if (!isTauri()) return [];
-  return invoke("local_cache_message_load_session", {
-    sessionId,
-    includeDeleted,
-    workspacePath: workspacePath ?? null,
-  });
+  if (isTauri()) {
+    return invoke("local_cache_message_load_session", {
+      sessionId,
+      includeDeleted,
+      workspacePath: workspacePath ?? null,
+    });
+  }
+  if (isChromeExtension()) {
+    const { loadExtensionMessagesForSession } = await import(
+      "@/lib/extension-message-cache"
+    );
+    return loadExtensionMessagesForSession(sessionId, includeDeleted);
+  }
+  return [];
 }
 
 export async function softDeleteMessage(
   id: string,
   deletedAt: string,
 ): Promise<void> {
-  if (!isTauri()) return;
-  await invoke("local_cache_message_soft_delete", { id, deletedAt });
+  if (isTauri()) {
+    await invoke("local_cache_message_soft_delete", { id, deletedAt });
+    return;
+  }
+  if (isChromeExtension()) {
+    const { softDeleteExtensionMessage } = await import(
+      "@/lib/extension-message-cache"
+    );
+    await softDeleteExtensionMessage(id, deletedAt);
+  }
 }
 
 /** Merge parts_json into an existing message row without bumping updated_at.
@@ -311,12 +337,20 @@ export async function setMessageParts(
   partsJson: string,
   workspacePath?: string | null,
 ): Promise<string> {
-  if (!isTauri()) return partsJson;
-  return invoke<string>("local_cache_message_set_parts", {
-    messageId,
-    partsJson,
-    workspacePath: workspacePath ?? null,
-  });
+  if (isTauri()) {
+    return invoke<string>("local_cache_message_set_parts", {
+      messageId,
+      partsJson,
+      workspacePath: workspacePath ?? null,
+    });
+  }
+  if (isChromeExtension()) {
+    const { setExtensionMessageParts } = await import(
+      "@/lib/extension-message-cache"
+    );
+    return setExtensionMessageParts(messageId, partsJson);
+  }
+  return partsJson;
 }
 
 export async function enrichMessageParts(

--- a/packages/app/src/lib/message-history-map.ts
+++ b/packages/app/src/lib/message-history-map.ts
@@ -1,0 +1,44 @@
+import type { MessageHistoryRow } from "@/lib/backend/types";
+import type { MessageRow } from "@/lib/local-cache";
+
+/** Map Cloud API history rows into local-cache MessageRow shape. */
+export function historyRowsToMessageRows(
+  rows: MessageHistoryRow[],
+  opts?: { teamId?: string; origin?: string },
+): MessageRow[] {
+  const teamId = opts?.teamId ?? "";
+  const origin = opts?.origin ?? "cloud_api";
+  const now = new Date().toISOString();
+
+  return rows.map((r) => {
+    const metadataJson =
+      r.metadata == null
+        ? null
+        : typeof r.metadata === "string"
+          ? r.metadata
+          : JSON.stringify(r.metadata);
+    const partsJson =
+      Array.isArray(r.parts) && r.parts.length > 0
+        ? JSON.stringify(r.parts)
+        : null;
+    return {
+      id: r.id,
+      teamId: r.team_id || teamId,
+      sessionId: r.session_id,
+      turnId: r.turn_id ?? null,
+      senderActorId: r.sender_actor_id ?? null,
+      replyToMessageId: r.reply_to_message_id ?? null,
+      kind: r.kind,
+      content: r.content ?? "",
+      metadataJson,
+      model: r.model ?? null,
+      mentionsJson: r.mentions ? JSON.stringify(r.mentions) : null,
+      origin,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at ?? r.created_at,
+      deletedAt: null,
+      syncedAt: now,
+      partsJson,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

- Add `chrome.storage.local` message cache for extension mode (same `MessageRow` shape as desktop libsql) so Process (thinking/tools via `partsJson`) survives session switch and sidepanel re-open; LRU eviction caps at 20 sessions / 6MB.
- Extension history load follows desktop local-first flow: hydrate cache → cloud upsert (COALESCE preserves local `partsJson`) → re-render.
- Fix non-Tauri cloud message mapping to include `replyToMessageId`, `turnId`, and `metadataJson`.
- Use window-scoped `sidePanel.open({ windowId })` only — stop per-tab `setOptions({ tabId, path })` that spawned multiple `sidepanel/index.html` instances racing on shared storage.
- Add `[ext-msg-diag]` logging for interrupt/history paths to confirm Process loss and duplicate-header root causes.

## Test plan

- [ ] Reload extension; verify `chrome://extensions` shows only one `sidepanel/index.html` per window after opening from toolbar and link-hover
- [ ] New session: send `@SPRBOT sleep5` — Process and Reply-to persist after switching sessions and re-opening sidepanel
- [ ] Send tool command (`执行ps`) — no duplicate SPRBOT + Reply-to headers
- [ ] DevTools filter `ext-msg-diag`; run `window.teamclawExtMsgDiagDump()` after repro
- [ ] `pnpm exec vitest run packages/app/src/lib/extension-message-cache packages/app/src/lib/__tests__/message-history-map.test.ts`
- [ ] `pnpm --filter @teamclaw/extension test`


Made with [Cursor](https://cursor.com)