### PR TITLE
fix: opencode refresh stability, daemon CPU, and faster reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10343,6 +10343,7 @@ dependencies = [
  "teamclaw-rag",
  "teamclaw-runtime-env",
  "teamclaw-stt",
+ "teamclaw-transport",
  "teamclaw-types",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "image 0.25.10",
  "libc",
  "mime",
+ "notify",
  "parking_lot",
  "prost 0.13.5",
  "prost-types",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -50,6 +50,9 @@ subtle = "2"
 getrandom = "0.2"
 flate2 = "1"
 walkdir = "2"
+# Event-driven filesystem watching (FSEvents/inotify/ReadDirectoryChangesW) for
+# runtime refresh — replaces the old 350ms recursive-walk poll loop.
+notify = { version = "8", features = ["macos_fsevent"] }
 # Archive unpack (opencode release assets: zip on macOS/Windows, tar.gz on Linux)
 zip = { version = "5", default-features = false, features = ["deflate"] }
 tar = "0.4"

--- a/apps/daemon/src/daemon/collab_runtime_ensure.rs
+++ b/apps/daemon/src/daemon/collab_runtime_ensure.rs
@@ -104,7 +104,7 @@ impl DaemonServer {
                 "resume_stored_collab_runtimes: resuming stored runtime with prior ACP session"
             );
 
-            self.suppress_internal_opencode_writes(&stored.worktree);
+            // opencode.json suppress is inside assemble (after managed-LLM await).
             let runtime_env = match self
                 .assemble_spawn_runtime_env_for_worktree(&stored.worktree, &stored.workspace_id)
                 .await

--- a/apps/daemon/src/daemon/runtime_env.rs
+++ b/apps/daemon/src/daemon/runtime_env.rs
@@ -100,8 +100,10 @@ impl DaemonServer {
         worktree: &str,
         workspace_id: &str,
     ) -> Result<SpawnRuntimeEnv, String> {
-        crate::runtime::supervisor::ensure_inherent_mcp(Path::new(worktree))
-            .map_err(|e| format!("ensure_inherent_mcp failed: {e}"))?;
+        // Async lookups first — these must not race the refresh-watch suppress
+        // window. Managed-LLM cloud fetch can exceed INTERNAL_WRITE_SUPPRESS
+        // (3s); if we suppress *before* that await and only write afterward,
+        // opencode.json rewrites leak as Pending "OpenCode config" banners.
         let team_id = self.resolve_workspace_team_id(workspace_id).await;
         let managed_llm = match team_id.as_deref() {
             Some(tid) => self.resolve_managed_llm(tid).await,
@@ -116,6 +118,13 @@ impl DaemonServer {
             .cloud_auth_health()
             .map(|_| crate::config::DaemonConfig::cloud_token_path())
             .map(|p| p.to_string_lossy().into_owned());
+
+        // Suppress immediately before sync disk writes (inherent MCP, provider.team,
+        // secret-ref resolve). Callers must not rely on a suppress issued before
+        // the awaits above.
+        self.suppress_internal_opencode_writes(worktree);
+        crate::runtime::supervisor::ensure_inherent_mcp(Path::new(worktree))
+            .map_err(|e| format!("ensure_inherent_mcp failed: {e}"))?;
         crate::runtime::env_assembly::assemble_spawn_runtime_env(
             Path::new(worktree),
             team_id.as_deref(),

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -475,7 +475,7 @@ impl DaemonServer {
                         let session_id = stored.session_id.clone();
                         info!(agent_id, "lazy-resuming historical session");
                         let remote_workspace_id = (!ws_id.is_empty()).then_some(ws_id.clone());
-                        self.suppress_internal_opencode_writes(&worktree);
+                        // opencode.json suppress is inside assemble (after managed-LLM await).
                         let runtime_env = match self
                             .assemble_spawn_runtime_env_for_worktree(&worktree, &ws_id)
                             .await

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -519,7 +519,8 @@ impl DaemonServer {
             sync_team_shared_dir_for_workspace(Path::new(&resolved_worktree), &config);
         }
 
-        self.suppress_internal_opencode_writes(&resolved_worktree);
+        // Refresh-watch suppress for opencode.json is owned by
+        // `assemble_spawn_runtime_env_for_worktree` (after managed-LLM await).
         let runtime_env = self
             .assemble_spawn_runtime_env_for_worktree(&resolved_worktree, &ws_id)
             .await

--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -574,6 +574,66 @@ mod tests {
         assert!(coordinator.workspace_state(&workspace_id).await.is_none());
     }
 
+    /// Spawn env assembly awaits managed-LLM longer than a short suppress window.
+    /// Suppressing *before* that await lets the window expire; the subsequent
+    /// opencode.json write is recorded as Pending. Suppressing *after* the await
+    /// (immediately before disk writes) covers the write — the production order
+    /// in `assemble_spawn_runtime_env_for_worktree`.
+    #[tokio::test]
+    async fn suppress_after_await_covers_opencode_write_unlike_suppress_before_await() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = workspace_runtime_id(dir.path());
+        let workspaces = vec![WatchedWorkspace {
+            workspace_id: workspace_id.clone(),
+            workspace_path: dir.path().to_path_buf(),
+        }];
+        let opencode = dir.path().join("opencode.json");
+        let content = r#"{"$schema":"https://opencode.ai/config.json"}"#;
+
+        // --- buggy order: suppress → await past window → write ---
+        let leaky = RuntimeRefreshCoordinator::new();
+        let mut debounce = RefreshDebounce::new(Duration::from_millis(1));
+        leaky.suppress_workspace_watch(
+            &workspace_id,
+            &[RefreshChangeKind::OpencodeJson],
+            Duration::from_millis(30),
+        );
+        tokio::time::sleep(Duration::from_millis(45)).await;
+        std::fs::write(&opencode, content).unwrap();
+        record_classified_changes(
+            &leaky,
+            &mut debounce,
+            &workspaces,
+            None,
+            &opencode,
+            Instant::now(),
+        )
+        .await;
+        let leaked = leaky.workspace_state(&workspace_id).await.unwrap();
+        assert!(leaked.change_kinds.contains(&RefreshChangeKind::OpencodeJson));
+
+        // --- fixed order: await → suppress → write ---
+        let covered = RuntimeRefreshCoordinator::new();
+        let mut debounce = RefreshDebounce::new(Duration::from_millis(1));
+        tokio::time::sleep(Duration::from_millis(45)).await;
+        covered.suppress_workspace_watch(
+            &workspace_id,
+            &[RefreshChangeKind::OpencodeJson],
+            Duration::from_secs(5),
+        );
+        std::fs::write(&opencode, content).unwrap();
+        record_classified_changes(
+            &covered,
+            &mut debounce,
+            &workspaces,
+            None,
+            &opencode,
+            Instant::now(),
+        )
+        .await;
+        assert!(covered.workspace_state(&workspace_id).await.is_none());
+    }
+
     #[tokio::test]
     async fn watch_registry_supports_add_and_remove() {
         let registry = RefreshWatchRegistry::new(Vec::new());

--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -1,20 +1,26 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use tokio::sync::RwLock;
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tokio::sync::{Notify, RwLock};
 use tokio::time::MissedTickBehavior;
 use tracing::warn;
-use walkdir::WalkDir;
 
 use crate::config::global_team_store::TEAM_LINK_NAME;
 use crate::runtime::RuntimeSupervisor;
 
 use super::{RefreshChangeKind, RefreshSource, RuntimeRefreshCoordinator};
 
-const WATCH_POLL_INTERVAL: Duration = Duration::from_millis(350);
+/// How often the watch loop reconciles OS watches against the registry absent an
+/// explicit change signal. This performs only cheap `is_dir()` checks on the
+/// handful of `watch_roots` — never a recursive tree walk — so it stays
+/// negligible regardless of workspace size. Actual edits arrive via the OS event
+/// stream, not this tick; the tick only picks up roots that appear/disappear
+/// (e.g. a `.claude/skills` dir created after arm time).
+const WATCH_RECONCILE_INTERVAL: Duration = Duration::from_secs(2);
 const WATCH_DEBOUNCE_WINDOW: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,6 +39,9 @@ pub struct ClassifiedChange {
 #[derive(Debug)]
 pub struct RefreshWatchRegistry {
     workspaces: RwLock<HashMap<PathBuf, WatchedWorkspace>>,
+    /// Wakes the watch loop so a workspace add/remove re-arms the OS watchers
+    /// immediately instead of waiting for the next periodic reconcile tick.
+    changed: Notify,
 }
 
 impl RefreshWatchRegistry {
@@ -44,6 +53,7 @@ impl RefreshWatchRegistry {
                     .map(|workspace| (workspace.workspace_path.clone(), workspace))
                     .collect(),
             ),
+            changed: Notify::new(),
         })
     }
 
@@ -52,10 +62,12 @@ impl RefreshWatchRegistry {
             .write()
             .await
             .insert(workspace.workspace_path.clone(), workspace);
+        self.changed.notify_one();
     }
 
     pub async fn remove_workspace_path(&self, workspace_path: &Path) {
         self.workspaces.write().await.remove(workspace_path);
+        self.changed.notify_one();
     }
 
     async fn snapshot(&self) -> Vec<WatchedWorkspace> {
@@ -155,70 +167,10 @@ pub fn classify_change_path(
     changes
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct PathStamp {
-    is_dir: bool,
-    len: u64,
-    modified_secs: u64,
-    modified_nanos: u32,
-}
-
 #[derive(Debug, Clone)]
 struct WatchRoot {
     path: PathBuf,
     recursive: bool,
-}
-
-fn path_stamp(path: &Path) -> Option<PathStamp> {
-    let metadata = std::fs::metadata(path).ok()?;
-    let modified = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
-    let duration = modified
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_else(|_| Duration::from_secs(0));
-    Some(PathStamp {
-        is_dir: metadata.is_dir(),
-        len: metadata.len(),
-        modified_secs: duration.as_secs(),
-        modified_nanos: duration.subsec_nanos(),
-    })
-}
-
-fn snapshot_root(root: &WatchRoot) -> HashMap<PathBuf, PathStamp> {
-    let mut snapshot = HashMap::new();
-    if root.recursive {
-        if !root.path.exists() {
-            return snapshot;
-        }
-        for entry in WalkDir::new(&root.path).into_iter().filter_map(Result::ok) {
-            let path = entry.path().to_path_buf();
-            if let Some(stamp) = path_stamp(&path) {
-                snapshot.insert(path, stamp);
-            }
-        }
-        return snapshot;
-    }
-
-    if let Some(stamp) = path_stamp(&root.path) {
-        snapshot.insert(root.path.clone(), stamp);
-    }
-    snapshot
-}
-
-fn diff_paths(
-    previous: &HashMap<PathBuf, PathStamp>,
-    current: &HashMap<PathBuf, PathStamp>,
-) -> Vec<PathBuf> {
-    let mut changed = Vec::new();
-    let mut keys: HashSet<&PathBuf> = previous.keys().collect();
-    keys.extend(current.keys());
-
-    for key in keys {
-        if previous.get(key) != current.get(key) {
-            changed.push(key.clone());
-        }
-    }
-
-    changed
 }
 
 fn watch_roots(workspaces: &[WatchedWorkspace], home: Option<&Path>) -> Vec<WatchRoot> {
@@ -321,6 +273,85 @@ async fn record_classified_changes(
     }
 }
 
+/// Map the declarative `watch_roots` to the concrete directories handed to the
+/// OS watcher, deduped by path.
+///
+/// OS watchers (FSEvents / inotify / ReadDirectoryChangesW) watch *directories*,
+/// so a non-recursive file root (`opencode.json`, `teamclaw.json`) is covered by
+/// watching its parent directory shallowly — this also survives atomic saves
+/// (write-temp + rename) that would break a watch pinned to the file's inode.
+/// Only directories that currently exist are returned; missing roots are armed
+/// later by the reconcile tick once they appear. A path wanted recursively wins
+/// over the same path wanted shallowly.
+fn desired_watch_targets(
+    workspaces: &[WatchedWorkspace],
+    home: Option<&Path>,
+) -> HashMap<PathBuf, RecursiveMode> {
+    let mut targets: HashMap<PathBuf, RecursiveMode> = HashMap::new();
+    for root in watch_roots(workspaces, home) {
+        let (path, mode) = if root.recursive {
+            (root.path, RecursiveMode::Recursive)
+        } else {
+            match root.path.parent() {
+                Some(parent) => (parent.to_path_buf(), RecursiveMode::NonRecursive),
+                None => continue,
+            }
+        };
+        if !path.is_dir() {
+            continue;
+        }
+        targets
+            .entry(path)
+            .and_modify(|existing| {
+                if mode == RecursiveMode::Recursive {
+                    *existing = RecursiveMode::Recursive;
+                }
+            })
+            .or_insert(mode);
+    }
+    targets
+}
+
+/// Arm/disarm OS watches so the live set matches `desired`. Failures are logged
+/// and retried on the next reconcile (the desired path may have just vanished).
+fn reconcile_watches(
+    watcher: &mut RecommendedWatcher,
+    desired: &HashMap<PathBuf, RecursiveMode>,
+    watched: &mut HashSet<PathBuf>,
+) {
+    let stale: Vec<PathBuf> = watched
+        .iter()
+        .filter(|path| !desired.contains_key(*path))
+        .cloned()
+        .collect();
+    for path in stale {
+        let _ = watcher.unwatch(&path);
+        watched.remove(&path);
+    }
+    for (path, mode) in desired {
+        if watched.contains(path) {
+            continue;
+        }
+        match watcher.watch(path, *mode) {
+            Ok(()) => {
+                watched.insert(path.clone());
+            }
+            Err(error) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    %error,
+                    "failed to arm filesystem refresh watch; will retry"
+                );
+            }
+        }
+    }
+}
+
+/// Access events (opens/reads) are pure noise for config/skill refresh.
+fn is_relevant_event(kind: &EventKind) -> bool {
+    !matches!(kind, EventKind::Access(_))
+}
+
 pub fn start_refresh_watchers(
     refresh: Arc<RuntimeRefreshCoordinator>,
     workspaces: Vec<WatchedWorkspace>,
@@ -329,43 +360,67 @@ pub fn start_refresh_watchers(
     let registry = RefreshWatchRegistry::new(workspaces);
     let watch_registry = Arc::clone(&registry);
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(WATCH_POLL_INTERVAL);
-        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        // The notify callback runs on notify's own thread; bridge its events to
+        // this async loop through an unbounded channel. Event volume is bounded
+        // downstream by classification + debounce, so no backpressure is needed.
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PathBuf>();
+        let mut watcher = match RecommendedWatcher::new(
+            move |result: notify::Result<Event>| {
+                let Ok(event) = result else { return };
+                if !is_relevant_event(&event.kind) {
+                    return;
+                }
+                for path in event.paths {
+                    let _ = event_tx.send(path);
+                }
+            },
+            Config::default(),
+        ) {
+            Ok(watcher) => watcher,
+            Err(error) => {
+                warn!(%error, "failed to create filesystem watcher; runtime refresh disabled");
+                return;
+            }
+        };
 
-        let mut snapshots: HashMap<PathBuf, HashMap<PathBuf, PathStamp>> = HashMap::new();
+        let mut watched: HashSet<PathBuf> = HashSet::new();
         let mut debounce = RefreshDebounce::new(WATCH_DEBOUNCE_WINDOW);
+        let mut reconcile = tokio::time::interval(WATCH_RECONCILE_INTERVAL);
+        reconcile.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        let reconcile_now =
+            |watcher: &mut RecommendedWatcher, watched: &mut HashSet<PathBuf>, workspaces: &[WatchedWorkspace]| {
+                let desired = desired_watch_targets(workspaces, home.as_deref());
+                reconcile_watches(watcher, &desired, watched);
+            };
+
+        {
+            let workspaces = watch_registry.snapshot().await;
+            reconcile_now(&mut watcher, &mut watched, &workspaces);
+        }
 
         loop {
-            interval.tick().await;
-
-            let workspaces = watch_registry.snapshot().await;
-            let roots = watch_roots(&workspaces, home.as_deref());
-            let active_roots: HashSet<_> = roots.iter().map(|root| root.path.clone()).collect();
-            snapshots.retain(|path, _| active_roots.contains(path));
-
-            let mut changed_paths = Vec::new();
-            for root in &roots {
-                let next = snapshot_root(root);
-                let previous = snapshots
-                    .entry(root.path.clone())
-                    .or_insert_with(|| next.clone());
-                changed_paths.extend(diff_paths(previous, &next));
-                *previous = next;
-            }
-
-            changed_paths.sort();
-            changed_paths.dedup();
-
-            for path in changed_paths {
-                record_classified_changes(
-                    &refresh,
-                    &mut debounce,
-                    &workspaces,
-                    home.as_deref(),
-                    &path,
-                    Instant::now(),
-                )
-                .await;
+            tokio::select! {
+                _ = reconcile.tick() => {
+                    let workspaces = watch_registry.snapshot().await;
+                    reconcile_now(&mut watcher, &mut watched, &workspaces);
+                }
+                _ = watch_registry.changed.notified() => {
+                    let workspaces = watch_registry.snapshot().await;
+                    reconcile_now(&mut watcher, &mut watched, &workspaces);
+                }
+                Some(path) = event_rx.recv() => {
+                    let workspaces = watch_registry.snapshot().await;
+                    record_classified_changes(
+                        &refresh,
+                        &mut debounce,
+                        &workspaces,
+                        home.as_deref(),
+                        &path,
+                        Instant::now(),
+                    )
+                    .await;
+                }
             }
         }
     });
@@ -652,6 +707,45 @@ mod tests {
         assert_eq!(
             registry.workspace_paths().await,
             vec![PathBuf::from("/tmp/ws-2")]
+        );
+    }
+
+    #[test]
+    fn desired_targets_map_existing_dirs_and_skip_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        // Only this recursive skill root exists; the other skill/_secrets roots do not.
+        std::fs::create_dir_all(ws.join(".claude/skills")).unwrap();
+
+        let workspaces = vec![WatchedWorkspace {
+            workspace_id: "ws-1".to_string(),
+            workspace_path: ws.to_path_buf(),
+        }];
+
+        let targets = desired_watch_targets(&workspaces, None);
+
+        // The recursive skill dir is watched recursively.
+        assert_eq!(
+            targets.get(&ws.join(".claude/skills")),
+            Some(&RecursiveMode::Recursive),
+            "existing skills dir should be watched recursively"
+        );
+        // `opencode.json` (a file root) is covered by its parent (the workspace
+        // root) watched shallowly, since the workspace root exists.
+        assert_eq!(
+            targets.get(ws),
+            Some(&RecursiveMode::NonRecursive),
+            "workspace root should be watched non-recursively for config files"
+        );
+        // A skill root that does not exist is not armed.
+        assert!(
+            !targets.contains_key(&ws.join(".agents/skills")),
+            "missing skills dir must be excluded until it is created"
+        );
+        // `.teamclaw/teamclaw.json`'s parent does not exist here, so it is skipped.
+        assert!(
+            !targets.contains_key(&ws.join(".teamclaw")),
+            "missing config parent dir must be excluded"
         );
     }
 }

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -41,6 +41,7 @@ prost-types = "0.13"
 teamclaw-proto = { path = "../../crates/teamclaw-proto" }
 teamclaw-types = { path = "../../crates/teamclaw-types" }
 teamclaw-runtime-env = { path = "../../crates/teamclaw-runtime-env" }
+teamclaw-transport = { path = "../../crates/teamclaw-transport" }
 indexmap = { version = "2", features = ["serde"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "net", "process", "io-util"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "stream", "rustls-tls-native-roots"] }

--- a/apps/desktop/src/mqtt/client.rs
+++ b/apps/desktop/src/mqtt/client.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use rumqttc::{AsyncClient, EventLoop, LastWill, MqttOptions, QoS, TlsConfiguration, Transport};
 use std::sync::Arc;
 use std::time::Duration;
+use teamclaw_transport::MqttBroker;
 use tokio::sync::Mutex;
 
 pub struct ClientConfig {
@@ -22,26 +23,37 @@ pub struct MqttClient {
 }
 
 impl MqttClient {
+    fn resolve_broker(cfg: &ClientConfig) -> MqttBroker {
+        let broker_url = cfg
+            .broker_url
+            .as_deref()
+            .filter(|url| !url.trim().is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                let scheme = if cfg.use_tls { "mqtts" } else { "mqtt" };
+                format!("{}://{}:{}", scheme, cfg.broker_host, cfg.broker_port)
+            });
+        MqttBroker::parse(&broker_url)
+    }
+
     pub fn connect(cfg: ClientConfig) -> Result<Self> {
-        let broker_url = cfg.broker_url.as_deref().unwrap_or_default();
-        let is_websocket = broker_url.starts_with("ws://") || broker_url.starts_with("wss://");
-        let broker_address = if is_websocket {
-            broker_url
-        } else {
-            cfg.broker_host.as_str()
-        };
-        let mut opts = MqttOptions::new(&cfg.client_id, broker_address, cfg.broker_port);
+        let broker = Self::resolve_broker(&cfg);
+        let mut opts = MqttOptions::new(
+            &cfg.client_id,
+            broker.connection_address(),
+            broker.port,
+        );
         opts.set_credentials(&cfg.username, &cfg.password);
         opts.set_clean_session(false);
         opts.set_keep_alive(Duration::from_secs(30));
         // Attachments + ACP events can be a few hundred KB. Keep room.
         opts.set_max_packet_size(4 * 1024 * 1024, 4 * 1024 * 1024);
 
-        if broker_url.starts_with("ws://") {
-            opts.set_transport(Transport::Ws);
-        } else if broker_url.starts_with("wss://") {
+        if broker.is_websocket() && broker.use_tls {
             opts.set_transport(Transport::wss_with_default_config());
-        } else if cfg.use_tls {
+        } else if broker.is_websocket() {
+            opts.set_transport(Transport::Ws);
+        } else if broker.use_tls {
             // `TlsConfiguration::default()` (use-rustls) loads the OS native
             // trust roots and builds a `ClientConfig` with no client auth.
             // Good enough for connecting to a public broker over TLS.
@@ -65,6 +77,27 @@ impl MqttClient {
             event_loop: Arc::new(Mutex::new(event_loop)),
             client_id: cfg.client_id,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wss_bootstrap_url_uses_port_443_not_js_fallback_1883() {
+        let broker = MqttClient::resolve_broker(&ClientConfig {
+            broker_url: Some("wss://mqtt.example.com/mqtt".into()),
+            broker_host: "mqtt.example.com".into(),
+            broker_port: 1883,
+            client_id: "teamclaw-test".into(),
+            username: "actor".into(),
+            password: "token".into(),
+            team_id: "team-1".into(),
+            use_tls: true,
+        });
+        assert_eq!(broker.connection_address(), "wss://mqtt.example.com/mqtt");
+        assert_eq!(broker.port, 443);
     }
 }
 

--- a/packages/app/src/components/chat/AgentSelectorDock.tsx
+++ b/packages/app/src/components/chat/AgentSelectorDock.tsx
@@ -12,7 +12,6 @@ import {
   CommandSeparator,
 } from '@/components/ui/command'
 import { useRuntimeStateStore } from '@/stores/runtime-state-store'
-import { setModel } from '@/lib/teamclaw-rpc'
 import { resolveAgentAvailableModels } from '@/lib/agent-available-models'
 import { sessionFlowError, sessionFlowLog } from '@/lib/session-flow-log'
 import { RuntimeLifecycle, AgentStatus, type RuntimeInfo } from '@/lib/proto/amux_pb'
@@ -20,13 +19,15 @@ import {
   backendTypeFromRuntimeEntry,
   agentModelDisplayLabel,
   isAgentModelRowSelected,
-  resolveRuntimeIdForAgent,
   resolveRuntimeStateEntryForAgent,
   resolveSetModelId,
   selectAgentModel,
 } from '@/lib/runtime-state-resolve'
+import { ensureRuntimeThenSetModel } from '@/lib/teamclaw/ensure-agent-runtime'
 import { useAgentModelPickStore } from '@/stores/agent-model-pick-store'
 import { useSessionSelectionStore } from '@/stores/session-selection-store'
+import { useCurrentTeamStore } from '@/stores/current-team'
+import { useSessionListStore } from '@/stores/session-list-store'
 import { useLocalDaemonActorId } from '@/lib/daemon-agent-admin'
 import { cn } from '@/lib/utils'
 import type { AttachedAgent } from '@/packages/ai/prompt-input-insert-hooks'
@@ -280,32 +281,33 @@ function AgentPill({
   const handlePickModel = React.useCallback(async (modelId: string) => {
     const freshByRuntimeId = useRuntimeStateStore.getState().byRuntimeId
     const rpcModelId = resolveSetModelId(agent.id, modelId, freshByRuntimeId)
-    const liveRuntimeId = resolveRuntimeIdForAgent(agent.id, freshByRuntimeId, dbRuntimeId)
+    const teamId =
+      useSessionListStore.getState().rows.find((r) => r.id === sessionId)?.team_id ??
+      useCurrentTeamStore.getState().team?.id ??
+      null
 
     sessionFlowLog('agent_selector.model_pick.begin', {
       agentId: agent.id,
       agentName: agent.displayName,
-      runtimeId: liveRuntimeId,
       dbRuntimeId,
+      teamId,
       effectiveModelId,
       modelId,
       rpcModelId,
       availableModelIds: availableModels.map((m) => m.id),
     })
 
-    // ── Step 1: store the pick FIRST. The pick is the source of truth from
-    // this point on. Persisted to localStorage; survives reload. Subsequent
-    // MQTT retains for this agent cannot override it (selectAgentModel
-    // prefers pick over retain).
+    // Store the pick FIRST. Survives reload; MQTT retains cannot override it.
     if (sessionId) {
       useAgentModelPickStore.getState().setPick(sessionId, agent.id, rpcModelId)
     }
 
-    if (!liveRuntimeId) {
-      sessionFlowLog('agent_selector.model_pick.deferred_until_runtime', {
+    if (!sessionId || !teamId) {
+      sessionFlowLog('agent_selector.model_pick.deferred_until_session', {
         agentId: agent.id,
         modelId,
         sessionId,
+        teamId,
       })
       const { toast } = await import('sonner')
       toast.success(t('chat.agentSelector.modelPickSaved', '模型已选择'), {
@@ -317,56 +319,28 @@ function AgentPill({
       return
     }
 
-    // ── Step 2: best-effort apply on the daemon. If this fails, the pick
-    // stays — the next runtimeStart / send flow re-applies it via
-    // startAgentRuntimesAsync → setModel.
+    // Ask daemon for the live spawn (runtimeStart, with dedup), then setModel
+    // with that authoritative id — never guess from MQTT/DB hints.
     try {
-      const result = await setModel({
-        targetActorId: agent.id, // route by the agent's actor_id
-        runtimeId: liveRuntimeId,
+      const { runtimeId } = await ensureRuntimeThenSetModel({
+        sessionId,
+        teamId,
+        agentActorId: agent.id,
         modelId: rpcModelId,
       })
       sessionFlowLog('agent_selector.model_pick.ok', {
         agentId: agent.id,
-        runtimeId: liveRuntimeId,
+        runtimeId,
         modelId: rpcModelId,
         sessionId,
-        result,
       })
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
-      // "agent not found" usually means the daemon spawn id rotated. One
-      // 400ms re-resolve usually catches the new spawn id from a fresh
-      // retain.
-      const retried =
-        /agent\s+.+\s+not found/i.test(message) &&
-        (await (async () => {
-          await new Promise((r) => setTimeout(r, 400))
-          const fresh = useRuntimeStateStore.getState().byRuntimeId
-          const retryRuntimeId = resolveRuntimeIdForAgent(agent.id, fresh, dbRuntimeId)
-          if (!retryRuntimeId || retryRuntimeId === liveRuntimeId) return false
-          try {
-            await setModel({
-              targetActorId: agent.id,
-              runtimeId: retryRuntimeId,
-              modelId: rpcModelId,
-            })
-            sessionFlowLog('agent_selector.model_pick.ok_after_retry', {
-              agentId: agent.id,
-              runtimeId: retryRuntimeId,
-              modelId: rpcModelId,
-            })
-            return true
-          } catch {
-            return false
-          }
-        })())
-      if (retried) return
-
       sessionFlowError('agent_selector.model_pick.failed', e, {
         agentId: agent.id,
-        runtimeId: liveRuntimeId,
         modelId: rpcModelId,
+        sessionId,
+        teamId,
       })
       const { toast } = await import('sonner')
       toast.error(t('chat.agentSelector.modelChangeFailed', 'Failed to change model'), {
@@ -376,7 +350,7 @@ function AgentPill({
           { message },
         ),
       })
-      console.error('[AgentSelectorDock] setModel failed (pick preserved)', e)
+      console.error('[AgentSelectorDock] ensureRuntimeThenSetModel failed (pick preserved)', e)
     }
   }, [agent.id, agent.displayName, dbRuntimeId, sessionId, t, effectiveModelId, availableModels])
 

--- a/packages/app/src/components/chat/__tests__/AgentSelectorDock.test.tsx
+++ b/packages/app/src/components/chat/__tests__/AgentSelectorDock.test.tsx
@@ -27,6 +27,22 @@ vi.mock('@/lib/teamclaw-rpc', () => ({
   setModel: vi.fn(),
 }))
 
+vi.mock('@/lib/teamclaw/ensure-agent-runtime', () => ({
+  ensureRuntimeThenSetModel: vi.fn(),
+}))
+
+vi.mock('@/stores/current-team', () => ({
+  useCurrentTeamStore: {
+    getState: () => ({ team: { id: 'team-1' } }),
+  },
+}))
+
+vi.mock('@/stores/session-list-store', () => ({
+  useSessionListStore: {
+    getState: () => ({ rows: [{ id: 'session-1', team_id: 'team-1' }] }),
+  },
+}))
+
 function dockProps(
   partial: Partial<React.ComponentProps<typeof AgentSelectorDock>> &
     Pick<React.ComponentProps<typeof AgentSelectorDock>, 'engagedAgents'>,

--- a/packages/app/src/components/sidebar/LocalDaemonRow.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonRow.tsx
@@ -33,6 +33,7 @@ import { useCurrentTeamStore } from '@/stores/current-team'
 import { useDaemonOnboardingStore } from '@/stores/daemon-onboarding'
 import { useMemberPreferencesStore } from '@/stores/member-preferences-store'
 import { recoverMqttConnection } from '@/stores/mqtt-reconnect'
+import { requestDaemonProbe } from '@/lib/daemon-probe-signal'
 import { type LocalDaemonRuntimeStatus } from '@/hooks/use-local-daemon-http-status'
 import { workspacePathsMatch } from '@/stores/session-utils'
 import { cn } from '@/lib/utils'
@@ -491,10 +492,18 @@ export function LocalDaemonRow({
   const handleRetryConnection = async () => {
     if (retrying || daemonBusy) return
     setRetrying(true)
+    // Kick the actual MQTT reconnect and a fresh status probe *first*, without
+    // waiting on the cloud calls below. Right after an outage those calls can
+    // sit in long timeouts; blocking the reconnect behind them is what made the
+    // click feel dead. Fire-and-forget so recovery starts immediately.
+    void recoverMqttConnection()
+    requestDaemonProbe()
     try {
       await checkCloudSession({ allowRetryAfterHealError: true })
       await refreshDaemon()
-      await recoverMqttConnection()
+      // Reflect the refreshed daemon/cloud state now instead of on the next
+      // 20s poll tick.
+      requestDaemonProbe()
       const { cloudAuthExpired, healError } = useDaemonOnboardingStore.getState()
       if (cloudAuthExpired && healError) {
         toast.error(healError)
@@ -517,6 +526,7 @@ export function LocalDaemonRow({
 
   const handleMqttReconnect = () => {
     void recoverMqttConnection()
+    requestDaemonProbe()
     openSettings('general')
   }
 

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -36,6 +36,7 @@ import { loadSessionIdsForActor } from '@/lib/session-by-actor'
 import { loadSessionIdsForWorkspace } from '@/lib/session-by-workspace'
 import { actorAvatarColor } from '@/lib/actor-color'
 import { useSessionWorkspaceLabels } from '@/hooks/use-session-workspace-labels'
+import { compareSessionListByRecency } from '@/lib/session-list-sort'
 
 /**
  * Merged row shape consumed by the rendering pipeline. Combines list-canonical
@@ -47,6 +48,7 @@ type ListRow = {
   title: string
   teamId: string
   lastMessageAt: Date | null
+  createdAt: Date | null
   lastMessagePreview: string | null
   ideaId: string | null
   isPinned: boolean
@@ -59,6 +61,7 @@ function entryToRow(entry: SessionListEntry, isPinned: boolean): ListRow {
     title: entry.title,
     teamId: entry.team_id,
     lastMessageAt: entry.last_message_at ? new Date(entry.last_message_at) : null,
+    createdAt: entry.created_at ? new Date(entry.created_at) : null,
     lastMessagePreview: entry.last_message_preview,
     ideaId: entry.idea_id,
     isPinned,
@@ -278,12 +281,7 @@ export function SessionListColumn({
       base = base.filter((r) => workspaceSessionIds.has(r.id))
     }
 
-    return base.sort((a, b) => {
-      if (!a.lastMessageAt && !b.lastMessageAt) return 0
-      if (!a.lastMessageAt) return -1
-      if (!b.lastMessageAt) return 1
-      return b.lastMessageAt.getTime() - a.lastMessageAt.getTime()
-    })
+    return base.sort(compareSessionListByRecency)
   }, [listRows, pinnedSessionIds, cronSessionIds, showCronSessions, filter, actorSessionIds, workspaceSessionIds])
 
   const { pinnedRows, regularRows } = React.useMemo(() => {

--- a/packages/app/src/hooks/use-local-daemon-http-status.ts
+++ b/packages/app/src/hooks/use-local-daemon-http-status.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { mergeAgentDevicePresence, noteLocalDaemonSignals } from '@/lib/agent-device-reachability'
 import { probeDaemonHttp } from '@/lib/daemon-local-client'
+import { onDaemonProbeRequested } from '@/lib/daemon-probe-signal'
 import { getDaemonMqttConnected } from '@/lib/daemon-agent-admin'
 import { QUICK_CHAT_DAEMON_PROBE_INTERVAL_MS } from '@/lib/session-agent-probe'
 import { useDaemonOnboardingStore } from '@/stores/daemon-onboarding'
@@ -29,9 +30,13 @@ export function useLocalDaemonHttpStatus(enabled = true): LocalDaemonHttpStatus 
     setStatus('checking')
     void runProbe()
     const interval = setInterval(() => void runProbe(), QUICK_CHAT_DAEMON_PROBE_INTERVAL_MS)
+    // Let Retry / network-online force an immediate re-probe instead of waiting
+    // out the poll interval.
+    const unsubscribe = onDaemonProbeRequested(() => void runProbe())
     return () => {
       cancelled = true
       clearInterval(interval)
+      unsubscribe()
     }
   }, [daemonReady, enabled])
 
@@ -105,9 +110,11 @@ export function useLocalDaemonRuntimeStatus(
 
     void poll()
     const interval = setInterval(() => void poll(), QUICK_CHAT_DAEMON_PROBE_INTERVAL_MS)
+    const unsubscribe = onDaemonProbeRequested(() => void poll())
     return () => {
       cancelled = true
       clearInterval(interval)
+      unsubscribe()
     }
   }, [actorId, daemonOnboardingReady, enabled, httpStatus])
 

--- a/packages/app/src/lib/__tests__/agent-model-multi-check-evidence.test.tsx
+++ b/packages/app/src/lib/__tests__/agent-model-multi-check-evidence.test.tsx
@@ -245,6 +245,10 @@ vi.mock("@/lib/teamclaw-rpc", () => ({
   setModel: vi.fn(),
 }));
 
+vi.mock("@/lib/teamclaw/ensure-agent-runtime", () => ({
+  ensureRuntimeThenSetModel: vi.fn(),
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (_k: string, fb?: string) => fb ?? _k,

--- a/packages/app/src/lib/__tests__/runtime-state-resolve.test.ts
+++ b/packages/app/src/lib/__tests__/runtime-state-resolve.test.ts
@@ -327,6 +327,22 @@ describe("resolveCommandRuntimeId", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("prefers a newer live spawn over a stale db hint when no session scope", () => {
+    const now = Date.now();
+    const byRuntimeId = {
+      "rt-stale": { ...entry("agent-a", "rt-stale"), lastUpdated: now - 1000 },
+      "rt-live": { ...entry("agent-a", "rt-live"), lastUpdated: now },
+      "agent-a": { ...entry("agent-a", "rt-stale"), lastUpdated: now - 1000 },
+    };
+    expect(
+      resolveCommandRuntimeId({
+        agentId: "agent-a",
+        dbRuntimeId: "rt-stale",
+        byRuntimeId,
+      }),
+    ).toBe("rt-live");
+  });
 });
 
 describe("normalizeAgentModelId", () => {

--- a/packages/app/src/lib/__tests__/session-create.test.ts
+++ b/packages/app/src/lib/__tests__/session-create.test.ts
@@ -601,7 +601,7 @@ describe('startAgentRuntimesAsync', () => {
     })
 
     const { startAgentRuntimesAsync } = await import('../session-create')
-    const failures = await startAgentRuntimesAsync({
+    const { failures } = await startAgentRuntimesAsync({
       sessionId: 'sess-1',
       teamId: 'team-1',
       agentActorIds: ['remote-agent'],
@@ -620,7 +620,7 @@ describe('startAgentRuntimesAsync', () => {
     mockRuntimeStart.mockRejectedValueOnce(new Error('RPC timeout'))
 
     const { startAgentRuntimesAsync } = await import('../session-create')
-    const failures = await startAgentRuntimesAsync({
+    const { failures } = await startAgentRuntimesAsync({
       sessionId: 'sess-1',
       teamId: 'team-1',
       agentActorIds: ['remote-agent'],
@@ -629,5 +629,31 @@ describe('startAgentRuntimesAsync', () => {
     expect(failures).toEqual([
       { agentActorId: 'remote-agent', code: 'runtime_rpc_failed', reason: 'RPC timeout' },
     ])
+  })
+
+  it('returns accepted runtime ids and can skip post-start setModel', async () => {
+    mockTables({
+      runtimes: [],
+      actors: [{ id: 'remote-agent', agent_types: ['opencode'], default_agent_type: 'opencode' }],
+    })
+    mockRuntimeStart.mockResolvedValueOnce({
+      accepted: true,
+      runtimeId: 'spawn-abc',
+      sessionId: 'sess-1',
+      rejectedReason: '',
+    })
+
+    const { startAgentRuntimesAsync } = await import('../session-create')
+    const { failures, runtimeIdsByAgent } = await startAgentRuntimesAsync({
+      sessionId: 'sess-1',
+      teamId: 'team-1',
+      agentActorIds: ['remote-agent'],
+      modelId: 'opencode/big-pickle',
+      skipModelApply: true,
+    })
+
+    expect(failures).toEqual([])
+    expect(runtimeIdsByAgent).toEqual({ 'remote-agent': 'spawn-abc' })
+    expect(mockSetModel).not.toHaveBeenCalled()
   })
 })

--- a/packages/app/src/lib/__tests__/session-list-sort.test.ts
+++ b/packages/app/src/lib/__tests__/session-list-sort.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { sortSessionListRows } from "@/lib/session-list-sort";
+
+describe("session-list-sort", () => {
+  it("orders by last_message_at desc with nulls last", () => {
+    const rows = sortSessionListRows([
+      { id: "empty-old", last_message_at: null, created_at: "2026-07-21T02:00:00.000Z" },
+      { id: "recent", last_message_at: "2026-07-21T10:00:00.000Z", created_at: "2026-07-21T09:00:00.000Z" },
+      { id: "empty-new", last_message_at: null, created_at: "2026-07-21T08:00:00.000Z" },
+      { id: "older", last_message_at: "2026-07-21T09:00:00.000Z", created_at: "2026-07-21T08:30:00.000Z" },
+    ]);
+
+    expect(rows.map((row) => row.id)).toEqual([
+      "recent",
+      "older",
+      "empty-new",
+      "empty-old",
+    ]);
+  });
+});

--- a/packages/app/src/lib/daemon-probe-signal.ts
+++ b/packages/app/src/lib/daemon-probe-signal.ts
@@ -1,0 +1,32 @@
+/**
+ * Lightweight fan-out so imperative actions (the "Retry connection" button, a
+ * `window 'online'` event) can ask every live daemon-status probe to run *now*
+ * instead of waiting for its next 20s poll tick. The status hooks
+ * (`useLocalDaemonHttpStatus` / `useLocalDaemonRuntimeStatus`) register their
+ * probe callback here for as long as they're mounted; callers fire
+ * `requestDaemonProbe()` to trigger a one-shot re-probe without recreating the
+ * hooks' intervals.
+ */
+
+type Listener = () => void
+
+const listeners = new Set<Listener>()
+
+/** Register a probe callback; returns an unsubscribe. Used by status hooks. */
+export function onDaemonProbeRequested(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** Ask all mounted daemon-status probes to run immediately (best-effort). */
+export function requestDaemonProbe(): void {
+  for (const listener of listeners) {
+    try {
+      listener()
+    } catch {
+      // A single misbehaving probe must not block the others.
+    }
+  }
+}

--- a/packages/app/src/lib/e2e/v2-control.ts
+++ b/packages/app/src/lib/e2e/v2-control.ts
@@ -19,6 +19,7 @@ import { useSessionStore } from "@/stores/session";
 import { useUIStore } from "@/stores/ui";
 import { useV2StreamingStore } from "@/stores/v2-streaming-store";
 import { useWorkspaceStore } from "@/stores/workspace";
+import { sortSessionListRows } from "@/lib/session-list-sort";
 
 type SeedActor = {
   id?: string;
@@ -307,12 +308,7 @@ function participantActorIds(session: SeedSession, actors: NormalizedActor[]): s
 }
 
 function sortRows(rows: SessionListEntry[]): SessionListEntry[] {
-  return [...rows].sort((a, b) => {
-    if (!a.last_message_at && !b.last_message_at) return 0;
-    if (!a.last_message_at) return -1;
-    if (!b.last_message_at) return 1;
-    return b.last_message_at.localeCompare(a.last_message_at);
-  });
+  return sortSessionListRows(rows);
 }
 
 function sameSessionRows(a: SessionListEntry[], b: SessionListEntry[]): boolean {

--- a/packages/app/src/lib/runtime-state-resolve.ts
+++ b/packages/app/src/lib/runtime-state-resolve.ts
@@ -155,6 +155,17 @@ export function resolveCommandRuntimeId(args: {
     return mqttRuntimeId;
   }
 
+  // DB hint and the chosen mqtt entry can agree on a stale spawn id (both still
+  // marked ACTIVE in the local cache). Prefer any other live retain for this
+  // agent, but only on the session-agnostic path (setModel from the agent pill).
+  // Permission/cancel targets pass sessionRuntimeIds and must not hop sessions.
+  if (!sessionIds || sessionIds.size === 0) {
+    const liveSpawnId = findLiveRuntimeIdForAgent(trimmedAgent, args.byRuntimeId);
+    if (liveSpawnId && liveSpawnId !== dbId) {
+      return liveSpawnId;
+    }
+  }
+
   if (dbId) return dbId;
 
   if (mqttLive && mqttRuntimeId && sessionSafe) return mqttRuntimeId;

--- a/packages/app/src/lib/seed-runtime-state.ts
+++ b/packages/app/src/lib/seed-runtime-state.ts
@@ -22,8 +22,19 @@ export function seedRuntimeStateAfterStart(args: {
   if (!daemonActorId || !runtimeId) return;
 
   const store = useRuntimeStateStore.getState();
-  const existing = store.byRuntimeId[runtimeId] ?? store.byRuntimeId[daemonActorId];
-  if (existing) return;
+  const existingMirror = store.byRuntimeId[daemonActorId];
+  const existingSpawn = store.byRuntimeId[runtimeId];
+  // Idempotent when this spawn is already indexed. Do NOT skip just because a
+  // mirror entry exists — after runtimeStart returns a NEW spawn id the old
+  // agent-UUID retain can still point at a dead spawn (e.g. MQTT was down when
+  // the previous session stopped). Skipping then leaves setModel targeting the
+  // stale id while the daemon holds the fresh one.
+  if (
+    existingSpawn?.info.runtimeId === runtimeId &&
+    existingMirror?.info.runtimeId === runtimeId
+  ) {
+    return;
+  }
 
   const info: RuntimeInfo = create(RuntimeInfoSchema, {
     runtimeId,

--- a/packages/app/src/lib/session-create.ts
+++ b/packages/app/src/lib/session-create.ts
@@ -326,6 +326,18 @@ export interface StartAgentRuntimesArgs {
   rpcTimeoutMs?: number
   /** Suppress workspace-layer toasts; caller surfaces failures. */
   suppressWorkspaceToast?: boolean
+  /**
+   * When true, skip the post-start setModel fanout. Callers that need an
+   * authoritative spawn id (e.g. model-picker) apply the model themselves
+   * with the returned `runtimeIdsByAgent` value.
+   */
+  skipModelApply?: boolean
+}
+
+export type StartAgentRuntimesResult = {
+  failures: RuntimeStartFailure[]
+  /** agentActorId → spawn id accepted by the daemon for this batch. */
+  runtimeIdsByAgent: Record<string, string>
 }
 
 export type RuntimeStartFailureCode =
@@ -378,9 +390,12 @@ function pickAgentBackend(
  * Daemon-published RuntimeInfo retains will update the runtime-state-store
  * asynchronously as the runtimes come up.
  */
-export async function startAgentRuntimesAsync(args: StartAgentRuntimesArgs): Promise<RuntimeStartFailure[]> {
-  if (args.agentActorIds.length === 0) return []
+export async function startAgentRuntimesAsync(
+  args: StartAgentRuntimesArgs,
+): Promise<StartAgentRuntimesResult> {
+  if (args.agentActorIds.length === 0) return { failures: [], runtimeIdsByAgent: {} }
   const failures: RuntimeStartFailure[] = []
+  const runtimeIdsByAgent: Record<string, string> = {}
   const localWorkspacePath = useWorkspaceStore.getState().workspacePath?.trim() || ''
   const rpcTimeoutMs = args.rpcTimeoutMs ?? RUNTIME_START_RPC_TIMEOUT_MS
   let createdByMemberId: string | null = null
@@ -593,11 +608,14 @@ export async function startAgentRuntimesAsync(args: StartAgentRuntimesArgs): Pro
           runtimeId: result.runtimeId,
           agentType,
         })
+        if (result.runtimeId.trim()) {
+          runtimeIdsByAgent[agentActorId] = result.runtimeId.trim()
+        }
         const normalizedModelId = resolvedModelId
           ? normalizeAgentModelId(agentActorId, resolvedModelId, byRuntimeId) ??
             resolvedModelId
           : undefined
-        if (normalizedModelId) {
+        if (normalizedModelId && !args.skipModelApply) {
           sessionFlowLog('runtime_start.set_model.begin', {
             sessionId: args.sessionId,
             teamId: args.teamId,
@@ -668,5 +686,5 @@ export async function startAgentRuntimesAsync(args: StartAgentRuntimesArgs): Pro
     agentType: args.agentType,
     failureCount: failures.length,
   })
-  return failures
+  return { failures, runtimeIdsByAgent }
 }

--- a/packages/app/src/lib/session-list-sort.ts
+++ b/packages/app/src/lib/session-list-sort.ts
@@ -1,0 +1,34 @@
+export type SessionListSortKey = {
+  id: string;
+  last_message_at?: string | null;
+  lastMessageAt?: Date | null;
+  created_at?: string | null;
+  createdAt?: Date | null;
+};
+
+function lastMessageAtMs(row: SessionListSortKey): number | null {
+  if (row.lastMessageAt instanceof Date) return row.lastMessageAt.getTime();
+  if (row.last_message_at) return new Date(row.last_message_at).getTime();
+  return null;
+}
+
+function createdAtValue(row: SessionListSortKey): string {
+  if (row.createdAt instanceof Date) return row.createdAt.toISOString();
+  return row.created_at ?? "";
+}
+
+/** Match backend listSessions: last_message_at DESC NULLS LAST, created_at DESC, id DESC. */
+export function compareSessionListByRecency(a: SessionListSortKey, b: SessionListSortKey): number {
+  const aLast = lastMessageAtMs(a);
+  const bLast = lastMessageAtMs(b);
+  if (aLast != null && bLast == null) return -1;
+  if (aLast == null && bLast != null) return 1;
+  if (aLast != null && bLast != null && aLast !== bLast) return bLast - aLast;
+  const byCreated = createdAtValue(b).localeCompare(createdAtValue(a));
+  if (byCreated !== 0) return byCreated;
+  return b.id.localeCompare(a.id);
+}
+
+export function sortSessionListRows<T extends SessionListSortKey>(rows: T[]): T[] {
+  return [...rows].sort(compareSessionListByRecency);
+}

--- a/packages/app/src/lib/teamclaw/__tests__/ensure-runtime-then-set-model.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/ensure-runtime-then-set-model.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  startAgentRuntimesAsync: vi.fn(),
+  setModel: vi.fn(),
+  waitForTeamclawRpcReady: vi.fn(),
+  resolveAgentDevicePresence: vi.fn(),
+  listParticipants: vi.fn(),
+  addParticipant: vi.fn(),
+  resolveSessionWorkspaceHintForRuntimeStart: vi.fn(),
+  mqttConnected: true as boolean | null,
+}))
+
+vi.mock('@/lib/session-create', () => ({
+  startAgentRuntimesAsync: (...args: unknown[]) => mocks.startAgentRuntimesAsync(...args),
+}))
+
+vi.mock('@/lib/teamclaw-rpc', () => ({
+  setModel: (...args: unknown[]) => mocks.setModel(...args),
+  waitForTeamclawRpcReady: (...args: unknown[]) => mocks.waitForTeamclawRpcReady(...args),
+}))
+
+vi.mock('@/lib/agent-device-reachability', () => ({
+  resolveAgentDevicePresence: (...args: unknown[]) => mocks.resolveAgentDevicePresence(...args),
+}))
+
+vi.mock('@/lib/backend', () => ({
+  getBackend: () => ({
+    sessionMembers: {
+      listParticipants: (...args: unknown[]) => mocks.listParticipants(...args),
+      addParticipant: (...args: unknown[]) => mocks.addParticipant(...args),
+    },
+  }),
+}))
+
+vi.mock('@/lib/teamclaw/resolve-runtime-start-workspace', () => ({
+  resolveSessionWorkspaceHintForRuntimeStart: (...args: unknown[]) =>
+    mocks.resolveSessionWorkspaceHintForRuntimeStart(...args),
+}))
+
+vi.mock('@/stores/mqtt-reconnect', () => ({
+  useMqttReconnectStore: {
+    getState: () => ({ connected: mocks.mqttConnected }),
+  },
+}))
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: {
+    getState: () => ({ workspacePath: '/tmp/ws' }),
+  },
+}))
+
+vi.mock('@/lib/utils', () => ({
+  isTauri: () => false,
+}))
+
+vi.mock('@/lib/i18n', () => ({
+  default: { t: (_k: string, fallback?: string) => fallback ?? _k },
+}))
+
+describe('ensureRuntimeThenSetModel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.mqttConnected = true
+    mocks.waitForTeamclawRpcReady.mockResolvedValue(true)
+    mocks.resolveAgentDevicePresence.mockResolvedValue('online')
+    mocks.listParticipants.mockResolvedValue([{ id: 'agent-1' }])
+    mocks.resolveSessionWorkspaceHintForRuntimeStart.mockResolvedValue('ws-1')
+    mocks.startAgentRuntimesAsync.mockResolvedValue({
+      failures: [],
+      runtimeIdsByAgent: { 'agent-1': 'spawn-live' },
+    })
+    mocks.setModel.mockResolvedValue({ success: true })
+  })
+
+  it('runtimeStarts then setModels with the daemon-returned spawn id', async () => {
+    const { ensureRuntimeThenSetModel } = await import('../ensure-agent-runtime')
+    const result = await ensureRuntimeThenSetModel({
+      sessionId: 'sess-1',
+      teamId: 'team-1',
+      agentActorId: 'agent-1',
+      modelId: 'opencode/big-pickle',
+    })
+
+    expect(result).toEqual({ runtimeId: 'spawn-live' })
+    expect(mocks.startAgentRuntimesAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-1',
+        teamId: 'team-1',
+        agentActorIds: ['agent-1'],
+        modelId: 'opencode/big-pickle',
+        skipModelApply: true,
+      }),
+    )
+    expect(mocks.setModel).toHaveBeenCalledWith({
+      targetActorId: 'agent-1',
+      runtimeId: 'spawn-live',
+      modelId: 'opencode/big-pickle',
+      timeoutMs: expect.any(Number),
+    })
+  })
+
+  it('throws when runtimeStart fails instead of guessing a stale spawn id', async () => {
+    mocks.startAgentRuntimesAsync.mockResolvedValue({
+      failures: [{ agentActorId: 'agent-1', code: 'runtime_rejected', reason: 'daemon busy' }],
+      runtimeIdsByAgent: {},
+    })
+
+    const { ensureRuntimeThenSetModel } = await import('../ensure-agent-runtime')
+    await expect(
+      ensureRuntimeThenSetModel({
+        sessionId: 'sess-1',
+        teamId: 'team-1',
+        agentActorId: 'agent-1',
+        modelId: 'opencode/big-pickle',
+      }),
+    ).rejects.toThrow('daemon busy')
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('throws when mqtt is disconnected', async () => {
+    mocks.mqttConnected = false
+    const { ensureRuntimeThenSetModel } = await import('../ensure-agent-runtime')
+    await expect(
+      ensureRuntimeThenSetModel({
+        sessionId: 'sess-1',
+        teamId: 'team-1',
+        agentActorId: 'agent-1',
+        modelId: 'opencode/big-pickle',
+      }),
+    ).rejects.toThrow('mqtt disconnected')
+    expect(mocks.startAgentRuntimesAsync).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/lib/teamclaw/ensure-agent-runtime.ts
+++ b/packages/app/src/lib/teamclaw/ensure-agent-runtime.ts
@@ -10,7 +10,7 @@ import {
   type RuntimeStartFailure,
   type RuntimeStartFailureCode,
 } from "@/lib/session-create";
-import { waitForTeamclawRpcReady } from "@/lib/teamclaw-rpc";
+import { setModel, waitForTeamclawRpcReady } from "@/lib/teamclaw-rpc";
 import { useRuntimeStateStore } from "@/stores/runtime-state-store";
 import { resolveRuntimeStateEntryForAgent } from "@/lib/runtime-state-resolve";
 import { resolveSessionWorkspaceHintForRuntimeStart } from "@/lib/teamclaw/resolve-runtime-start-workspace";
@@ -129,6 +129,120 @@ export type EnsureAgentRuntimeArgs = {
   workspaceIdHint?: string;
   reason?: string;
 };
+
+export type EnsureRuntimeThenSetModelArgs = {
+  sessionId: string;
+  teamId: string;
+  agentActorId: string;
+  modelId: string;
+};
+
+/**
+ * Model-picker path: ask the daemon for the live spawn via runtimeStart
+ * (dedup reuse when still alive), then setModel with that authoritative
+ * runtimeId. Never resolves spawn id from MQTT/DB hints — those go stale
+ * across daemon restarts while the UI still looks "ready".
+ */
+export async function ensureRuntimeThenSetModel(
+  args: EnsureRuntimeThenSetModelArgs,
+): Promise<{ runtimeId: string }> {
+  const agentActorId = args.agentActorId.trim();
+  const modelId = args.modelId.trim();
+  if (!args.sessionId || !args.teamId || !agentActorId || !modelId) {
+    throw new Error("sessionId, teamId, agentActorId, and modelId are required");
+  }
+
+  const mqttConnected = useMqttReconnectStore.getState().connected;
+  if (mqttConnected === false) {
+    throw new Error("mqtt disconnected");
+  }
+
+  const rpcReady = await waitForTeamclawRpcReady(20_000);
+  if (!rpcReady) {
+    throw new Error("teamclaw RPC not ready");
+  }
+
+  const { eligible, failures: gateFailures } = await gateAgentsForRuntimeStart([agentActorId]);
+  if (gateFailures.length > 0) {
+    throw new Error(gateFailures[0]!.reason || "device offline");
+  }
+  if (eligible.length === 0) {
+    throw new Error("agent not eligible for runtimeStart");
+  }
+
+  try {
+    await ensureAgentIsSessionParticipant(args.sessionId, agentActorId);
+  } catch (error) {
+    sessionFlowError("ensure_runtime_then_set_model.add_participant_failed", error, {
+      sessionId: args.sessionId,
+      agentActorId,
+    });
+  }
+
+  const localWorkspacePath = useWorkspaceStore.getState().workspacePath?.trim() || null;
+  let localDaemonActorId: string | null = null;
+  const { isTauri } = await import("@/lib/utils");
+  if (isTauri()) {
+    try {
+      const { getLocalDaemonActorId } = await import("@/lib/daemon-agent-admin");
+      localDaemonActorId = await getLocalDaemonActorId();
+    } catch {
+      localDaemonActorId = null;
+    }
+  }
+  const workspaceIdHint =
+    (await resolveSessionWorkspaceHintForRuntimeStart({
+      teamId: args.teamId,
+      localWorkspacePath,
+      sessionId: args.sessionId,
+      agentActorIds: [agentActorId],
+      localDaemonActorId,
+    })) || undefined;
+
+  sessionFlowLog("ensure_runtime_then_set_model.begin", {
+    sessionId: args.sessionId,
+    teamId: args.teamId,
+    agentActorId,
+    modelId,
+    workspaceIdHint: workspaceIdHint ?? null,
+  });
+
+  const { failures, runtimeIdsByAgent } = await startAgentRuntimesAsync({
+    sessionId: args.sessionId,
+    teamId: args.teamId,
+    agentActorIds: [agentActorId],
+    modelId,
+    workspaceIdHint,
+    rpcTimeoutMs: RUNTIME_START_RPC_TIMEOUT_MS,
+    suppressWorkspaceToast: true,
+    // Apply below so callers observe setModel failures (start path swallows them).
+    skipModelApply: true,
+  });
+  if (failures.length > 0) {
+    throw new Error(failures[0]!.reason || "runtimeStart failed");
+  }
+
+  const runtimeId = runtimeIdsByAgent[agentActorId]?.trim();
+  if (!runtimeId) {
+    throw new Error("runtimeStart did not return a runtime id");
+  }
+
+  await setModel({
+    targetActorId: agentActorId,
+    runtimeId,
+    modelId,
+    timeoutMs: RUNTIME_START_RPC_TIMEOUT_MS,
+  });
+
+  sessionFlowLog("ensure_runtime_then_set_model.ok", {
+    sessionId: args.sessionId,
+    teamId: args.teamId,
+    agentActorId,
+    runtimeId,
+    modelId,
+  });
+  return { runtimeId };
+}
 
 /**
  * Idempotent: ensure session live subscription, session membership, and
@@ -263,7 +377,7 @@ export async function ensureAgentRuntimesForSession(args: EnsureAgentRuntimeArgs
       localWorkspacePath,
     });
 
-    const runtimeFailures = await startAgentRuntimesAsync({
+    const { failures: runtimeFailures } = await startAgentRuntimesAsync({
       sessionId: args.sessionId,
       teamId: args.teamId,
       agentActorIds: eligible,

--- a/packages/app/src/stores/mqtt-reconnect.ts
+++ b/packages/app/src/stores/mqtt-reconnect.ts
@@ -144,6 +144,18 @@ export const useMqttReconnectStore = create<MqttReconnectState>((set, get) => ({
     void (async () => {
       const utils = await import('@/lib/utils').catch(() => null)
       if (!utils) return
+      // Network came back: force a fast credential-refresh + reconnect and an
+      // immediate daemon status re-probe, rather than waiting out the Rust
+      // event loop's ≤60s backoff and the 20s status poll. `recoverMqttCredentials`
+      // (auto mode) is cooldown-throttled so a flapping link can't spam it.
+      if (typeof window !== 'undefined') {
+        window.addEventListener('online', () => {
+          void recoverMqttCredentials(get)
+          void import('@/lib/daemon-probe-signal')
+            .then((m) => m.requestDaemonProbe())
+            .catch(() => {})
+        })
+      }
       if (!utils.isTauri()) {
         // Browser path: subscribe to browser MQTT state/error from the browser bridge
         const browserBridge = await import('@/lib/mqtt-browser-bridge').catch(() => null)

--- a/packages/app/src/stores/session-list-store.test.ts
+++ b/packages/app/src/stores/session-list-store.test.ts
@@ -64,6 +64,37 @@ describe("session-list-store", () => {
     } as never);
   });
 
+  it("sorts rows by last_message_at desc with nulls last after load", async () => {
+    mocks.listCurrentActorSessions.mockResolvedValueOnce({
+      rows: [
+        sessionRow({
+          id: "empty-old",
+          last_message_at: null,
+          created_at: "2026-07-21T02:00:00.000Z",
+        }),
+        sessionRow({
+          id: "recent",
+          last_message_at: "2026-07-21T10:00:00.000Z",
+          created_at: "2026-07-21T09:00:00.000Z",
+        }),
+        sessionRow({
+          id: "older",
+          last_message_at: "2026-07-21T09:00:00.000Z",
+          created_at: "2026-07-21T08:30:00.000Z",
+        }),
+      ],
+    });
+
+    const { useSessionListStore } = await import("./session-list-store");
+    await useSessionListStore.getState().loadFirstPage();
+
+    expect(useSessionListStore.getState().rows.map((row) => row.id)).toEqual([
+      "recent",
+      "older",
+      "empty-old",
+    ]);
+  });
+
   it("loads the first page from the current actor session RPC", async () => {
     mocks.listCurrentActorSessions.mockResolvedValueOnce({
       rows: [sessionRow({ has_unread: true })],

--- a/packages/app/src/stores/session-list-store.ts
+++ b/packages/app/src/stores/session-list-store.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/local-cache";
 import { removeLinkSessionEntriesForSession } from "@/lib/extension-link-session";
 import type { SessionListCursor, SessionListPage } from "@/lib/backend/types";
+import { sortSessionListRows } from "@/lib/session-list-sort";
 
 // localStorage key for the most-recently-known teamId. Persisted so that
 // on first ever app boot the libsql phase-1 hydrate can fire — without it,
@@ -100,19 +101,8 @@ function mapCacheToEntry(r: SessionRow): SessionListEntry {
   };
 }
 
-/** Sort entries: null last_message_at first, then by last_message_at DESC */
 function sortEntries(entries: SessionListEntry[]): SessionListEntry[] {
-  return [...entries].sort((a, b) => {
-    if (!a.last_message_at && b.last_message_at) return -1;
-    if (a.last_message_at && !b.last_message_at) return 1;
-    if (a.last_message_at && b.last_message_at) {
-      const byLastMessage = b.last_message_at.localeCompare(a.last_message_at);
-      if (byLastMessage !== 0) return byLastMessage;
-    }
-    const byCreated = (b.created_at ?? "").localeCompare(a.created_at ?? "");
-    if (byCreated !== 0) return byCreated;
-    return b.id.localeCompare(a.id);
-  });
+  return sortSessionListRows(entries);
 }
 
 interface State {


### PR DESCRIPTION
## Summary

- **Opencode refresh / model switching:** Move `opencode.json` watch suppression to immediately before disk writes so managed-LLM awaits no longer expire the window and trigger false reload banners. Route model picks through `runtimeStart → setModel` with authoritative spawn ids; fix desktop MQTT WSS URLs to use port 443 via `teamclaw-transport`.
- **Session list:** Align client-side sort with Cloud API nulls-last ordering so empty sessions no longer float to the top and the sidebar reads by recency.
- **Daemon CPU:** Replace the 350ms recursive `WalkDir` refresh poll with event-driven `notify` (FSEvents / inotify / ReadDirectoryChangesW) so large skill trees no longer peg amuxd.
- **Reconnect UX:** On Retry / `window online`, kick MQTT reconnect and daemon status probes immediately instead of waiting on slow cloud calls and the 20s poll tick (`daemon-probe-signal` fan-out + reordered `LocalDaemonRow` handler).

## Test plan

- [ ] Edit a skill file under a large workspace — confirm runtime refresh still fires and amuxd CPU stays low (~idle, not ~60%)
- [ ] Switch models in chat — no spurious opencode reload banner; agent uses the selected model
- [ ] Session list: empty sessions sort after active ones (matches API order)
- [ ] Disconnect network for ~30s, reconnect — sidebar daemon card should recover without waiting for the full MQTT backoff; Retry connection should feel responsive
- [ ] `pnpm typecheck` and affected unit tests pass locally


Made with [Cursor](https://cursor.com)