### PR TITLE
Cron Run Now instant jump + nightly OSS beta release

### DIFF
--- a/.github/workflows/nightly-release-oss.yml
+++ b/.github/workflows/nightly-release-oss.yml
@@ -1,0 +1,92 @@
+name: Nightly OSS Release (multi-brand)
+
+# Nightly beta release for the OSS brands. Every night this:
+#   1. Bumps the desktop beta version by one (0.2.28-beta.1 -> 0.2.28-beta.2;
+#      or, from a stable X.Y.Z, starts X.Y.(Z+1)-beta.1) and commits that bump
+#      to `main`. The commit — NOT a git tag — is what advances the beta number,
+#      so `release.yml` (which triggers on `push: tags: v*`) is never fired.
+#   2. Dispatches release-oss.yml once per brand (copilot361 + betly) with the
+#      new `v<version>` tag input. That workflow re-syncs the four version
+#      sources on its runner, verifies the bump, and publishes each brand to its
+#      own OSS prefix — clients force-upgrade because the bundled amuxd version
+#      strictly increased.
+#
+# release-oss.yml stays one-brand-per-run by design (per-brand concurrency
+# groups guard each brand's latest.json), so we dispatch it twice rather than
+# adding a brand matrix there.
+#
+# NOTE ON TOKENS: pushing the bump to `main` and dispatching another workflow
+# both need write scopes. The default GITHUB_TOKEN works UNLESS `main` is a
+# protected branch (its pushes can't bypass protection). If so, set a repo
+# secret NIGHTLY_DISPATCH_PAT (a PAT / GitHub App token with `contents:write` +
+# `actions:write` and bypass on main); it takes precedence below.
+
+on:
+  schedule:
+    - cron: "0 16 * * *" # 16:00 UTC = 00:00 (24:00) Asia/Shanghai
+  workflow_dispatch: {}
+
+# Never let two nightly runs bump the version concurrently — the later push
+# would race the earlier one on main.
+concurrency:
+  group: nightly-release-oss
+  cancel-in-progress: false
+
+permissions:
+  contents: write # commit + push the version bump to main
+  actions: write # dispatch release-oss.yml
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          # Use the PAT (needed if main is protected) when present, else the
+          # default token. `token` controls the credentials persisted for push.
+          token: ${{ secrets.NIGHTLY_DISPATCH_PAT || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Compute next beta version
+        id: ver
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2016  # $ inside the node -e '...' are JS template literals, not shell.
+          NEXT="$(node -e '
+            const v = require("./package.json").version;
+            const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-beta\.(\d+))?$/);
+            if (!m) { console.error("unsupported version for nightly beta: " + v); process.exit(1); }
+            const [, MA, MI, PA, BETA] = m;
+            const next = BETA !== undefined
+              ? `${MA}.${MI}.${PA}-beta.${Number(BETA) + 1}`
+              : `${MA}.${MI}.${Number(PA) + 1}-beta.1`;
+            console.log(next);
+          ')"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Next beta version: $NEXT"
+
+      - name: Bump the four version sources
+        run: node scripts/bump-desktop-version.mjs "${{ steps.ver.outputs.next }}"
+
+      - name: Commit + push bump to main
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore(release): nightly beta v${{ steps.ver.outputs.next }}"
+          git push origin HEAD:main
+
+      - name: Dispatch release-oss.yml for each brand
+        env:
+          GH_TOKEN: ${{ secrets.NIGHTLY_DISPATCH_PAT || secrets.GITHUB_TOKEN }}
+          TAG: v${{ steps.ver.outputs.next }}
+        run: |
+          set -euo pipefail
+          for brand in copilot361 betly; do
+            echo "Dispatching release-oss for $brand @ $TAG"
+            gh workflow run release-oss.yml --ref main -f brand="$brand" -f tag="$TAG"
+          done

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -285,6 +285,14 @@ pub(crate) enum SockCommand {
         payload: serde_json::Value,
         reply_tx: oneshot::Sender<String>,
     },
+    /// Eagerly create the cloud session for a cron run (no ACP turn), so the
+    /// desktop can stamp `session_id` into the run record and navigate to the
+    /// session within seconds of "Run Now". Reply is
+    /// `{ "ok": true, "result": { "session_id": ... } }` or `{ "ok": false, "error": ... }`.
+    CronPrepareSession {
+        payload: serde_json::Value,
+        reply_tx: oneshot::Sender<String>,
+    },
     /// Fetch a fresh WeChat (iLink) bot QR code. One-shot HTTP call to the
     /// ilink backend via `teamclaw_gateway::wechat::fetch_qr_code`. Reply is
     /// `{ok, result?, error?}` where result is the raw `WeChatQrLoginResponse`.
@@ -1467,6 +1475,13 @@ impl DaemonServer {
                                 };
                                 let _ = reply_tx.send(resp.to_string());
                             }
+                            Some(SockCommand::CronPrepareSession { payload, reply_tx }) => {
+                                let resp = match self.handle_cron_prepare_session(&payload).await {
+                                    Ok(v) => serde_json::json!({ "ok": true, "result": v }),
+                                    Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
+                                };
+                                let _ = reply_tx.send(resp.to_string());
+                            }
                             Some(SockCommand::WechatQrStart { reply_tx }) => {
                                 let base_url = teamclaw_gateway::wechat_config::default_ilink_base_url();
                                 let resp = match teamclaw_gateway::wechat::fetch_qr_code(&base_url).await {
@@ -1838,6 +1853,13 @@ impl DaemonServer {
                             }
                             Some(SockCommand::PromptAwait { payload, reply_tx }) => {
                                 let resp = match self.handle_prompt_await(&payload).await {
+                                    Ok(v) => serde_json::json!({ "ok": true, "result": v }),
+                                    Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
+                                };
+                                let _ = reply_tx.send(resp.to_string());
+                            }
+                            Some(SockCommand::CronPrepareSession { payload, reply_tx }) => {
+                                let resp = match self.handle_cron_prepare_session(&payload).await {
                                     Ok(v) => serde_json::json!({ "ok": true, "result": v }),
                                     Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
                                 };
@@ -2261,6 +2283,32 @@ where
                                 }
                                 Err(_) => {
                                     warn!("amuxd.sock: prompt-await reply dropped");
+                                }
+                            }
+                        } else if cmd == "cron-prepare-session" {
+                            let (reply_tx, reply_rx) = oneshot::channel();
+                            if tx
+                                .send(SockCommand::CronPrepareSession {
+                                    payload: v,
+                                    reply_tx,
+                                })
+                                .await
+                                .is_err()
+                            {
+                                return;
+                            }
+                            match reply_rx.await {
+                                Ok(body) => {
+                                    let mut stream = reader.into_inner();
+                                    if let Err(e) = stream.write_all(body.as_bytes()).await {
+                                        warn!("amuxd.sock: cron-prepare-session write failed: {e}");
+                                        return;
+                                    }
+                                    let _ = stream.write_all(b"\n").await;
+                                    let _ = stream.shutdown().await;
+                                }
+                                Err(_) => {
+                                    warn!("amuxd.sock: cron-prepare-session reply dropped");
                                 }
                             }
                         } else {

--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -29,6 +29,13 @@ use super::DaemonServer;
 #[derive(Debug, Default)]
 pub(crate) struct CronSessionCache {
     inner: HashMap<String, (String, String)>,
+    /// Cloud `sessions.id` created eagerly by `cron-prepare-session`, before the
+    /// (slow) ACP runtime spawn. Keyed by `session_key`. `handle_prompt_await`
+    /// consumes this so it reuses the already-created cloud session instead of
+    /// creating a second one. Lets the desktop stamp `session_id` into the run
+    /// record — and navigate — seconds after "Run Now", without waiting for the
+    /// runtime to cold-start.
+    prepared: HashMap<String, String>,
 }
 
 impl CronSessionCache {
@@ -50,6 +57,21 @@ impl CronSessionCache {
     ) {
         self.inner
             .insert(key.into(), (cloud_session_id.into(), acp_session_id.into()));
+    }
+
+    /// Records a pre-created cloud session id for `key` (see `prepared`).
+    pub(crate) fn insert_prepared(&mut self, key: impl Into<String>, cloud_session_id: impl Into<String>) {
+        self.prepared.insert(key.into(), cloud_session_id.into());
+    }
+
+    /// Returns the pre-created cloud session id for `key` without consuming it.
+    pub(crate) fn get_prepared(&self, key: &str) -> Option<String> {
+        self.prepared.get(key).cloned()
+    }
+
+    /// Removes and returns the pre-created cloud session id for `key`.
+    pub(crate) fn take_prepared(&mut self, key: &str) -> Option<String> {
+        self.prepared.remove(key)
     }
 }
 
@@ -106,19 +128,15 @@ impl DaemonServer {
                     anyhow::bail!("no local agent runtime");
                 }
 
-                let primary_agent_actor_id = self.actor_id.clone();
-                let title = match parsed.job_name {
-                    Some(n) if !n.is_empty() => {
-                        format!("Cron: {}", n.chars().take(60).collect::<String>())
-                    }
-                    _ => "Cron job".to_string(),
+                // Reuse the cloud session `cron-prepare-session` already created
+                // for this run (the common path when Run Now goes through the
+                // scheduler); otherwise create it now (e.g. scheduled runs).
+                let sb_sid = match self.cron_sessions.take_prepared(parsed.session_key) {
+                    Some(prepared) => prepared,
+                    None => self
+                        .create_cron_cloud_session(&team_id, parsed.job_name)
+                        .await?,
                 };
-
-                let sb_sid = self
-                    .backend
-                    .create_cron_session(&team_id, &primary_agent_actor_id, &title)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("create_cron_session: {e}"))?;
 
                 // Resolve the job's pinned backend (if any) against the
                 // daemon's configured agents. `None` (no agent_type on the
@@ -244,6 +262,81 @@ impl DaemonServer {
                 "agent_error": e.to_string(),
             })),
         }
+    }
+
+    /// Cron cloud session title, matching what the desktop expects: `Cron: <job
+    /// name, first 60 chars>`, falling back to `Cron job`.
+    fn cron_session_title(job_name: Option<&str>) -> String {
+        match job_name {
+            Some(n) if !n.is_empty() => {
+                format!("Cron: {}", n.chars().take(60).collect::<String>())
+            }
+            _ => "Cron job".to_string(),
+        }
+    }
+
+    /// Create the cloud `sessions` row for a cron run (seeding the primary agent
+    /// + human admins as participants so the desktop can see/open it). Returns
+    /// the cloud session id. Shared by `cron-prepare-session` and the
+    /// prompt-await create path.
+    async fn create_cron_cloud_session(
+        &self,
+        team_id: &str,
+        job_name: Option<&str>,
+    ) -> anyhow::Result<String> {
+        let primary_agent_actor_id = self.actor_id.clone();
+        let title = Self::cron_session_title(job_name);
+        self.backend
+            .create_cron_session(team_id, &primary_agent_actor_id, &title)
+            .await
+            .map_err(|e| anyhow::anyhow!("create_cron_session: {e}"))
+    }
+
+    /// Eagerly create the cloud session for a cron run and cache it, returning
+    /// `{ "session_id": "<uuid>" }`. Fast (no ACP runtime spawn), so the desktop
+    /// scheduler can stamp `session_id` into the run record — and the UI can
+    /// navigate to the session — within a second or two of "Run Now", long
+    /// before the (cold-starting) runtime finishes the turn. The subsequent
+    /// `prompt-await` reuses this cached session instead of creating a new one.
+    pub(super) async fn handle_cron_prepare_session(
+        &mut self,
+        payload: &serde_json::Value,
+    ) -> anyhow::Result<serde_json::Value> {
+        let session_key = payload
+            .get("session_key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("cron-prepare-session: missing 'session_key'"))?;
+        if !session_key.starts_with("cron/") {
+            anyhow::bail!("cron-prepare-session: session_key must start with 'cron/'");
+        }
+        let job_name = payload
+            .get("job_name")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty());
+
+        // Idempotent: if this run's session already exists (prepared or fully
+        // paired), return it rather than creating a duplicate.
+        if let Some((sb, _)) = self.cron_sessions.get_pair(session_key) {
+            return Ok(serde_json::json!({ "session_id": sb }));
+        }
+        if let Some(sb) = self.cron_sessions.get_prepared(session_key) {
+            return Ok(serde_json::json!({ "session_id": sb }));
+        }
+
+        let team_id = self
+            .config
+            .team_id
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("daemon has no team_id; run `amuxd init` first"))?;
+
+        let sb_sid = self.create_cron_cloud_session(&team_id, job_name).await?;
+        self.cron_sessions.insert_prepared(session_key, &sb_sid);
+        info!(
+            session_key = %session_key,
+            session_id = %sb_sid,
+            "cron: prepared cloud session (eager)"
+        );
+        Ok(serde_json::json!({ "session_id": sb_sid }))
     }
 
     /// Persist the cron job prompt as a `text` message on the cloud session.

--- a/apps/desktop/src/commands/cron/amuxd_client.rs
+++ b/apps/desktop/src/commands/cron/amuxd_client.rs
@@ -168,6 +168,110 @@ pub async fn prompt_await_at(
     })
 }
 
+/// Eagerly create the cloud session for a cron run via amuxd's
+/// `cron-prepare-session` command, returning the cloud `sessions.id`. This is
+/// fast (no ACP runtime spawn / turn), so the scheduler can stamp `session_id`
+/// into the run record — and the desktop UI can navigate to the session —
+/// within a second or two of "Run Now". The subsequent `prompt-await` for the
+/// same `session_key` reuses this session.
+pub async fn prepare_cron_session(
+    session_key: &str,
+    job_name: Option<&str>,
+) -> Result<String, String> {
+    #[cfg(windows)]
+    {
+        let _ = (session_key, job_name);
+        return Err(AMUXD_UNSUPPORTED.into());
+    }
+    #[cfg(unix)]
+    {
+        let path = crate::commands::gateway::sock_path();
+        prepare_cron_session_at(&path, session_key, job_name).await
+    }
+}
+
+#[cfg(windows)]
+pub async fn prepare_cron_session_at(
+    _sock_path: &Path,
+    _session_key: &str,
+    _job_name: Option<&str>,
+) -> Result<String, String> {
+    Err(AMUXD_UNSUPPORTED.into())
+}
+
+#[cfg(unix)]
+pub async fn prepare_cron_session_at(
+    sock_path: &Path,
+    session_key: &str,
+    job_name: Option<&str>,
+) -> Result<String, String> {
+    let mut req = serde_json::json!({
+        "cmd": "cron-prepare-session",
+        "session_key": session_key,
+    });
+    if let Some(name) = job_name.filter(|s| !s.is_empty()) {
+        req["job_name"] = serde_json::Value::String(name.to_string());
+    }
+
+    let mut stream = UnixStream::connect(sock_path)
+        .await
+        .map_err(|e| format!("amuxd unreachable at {}: {e}", sock_path.display()))?;
+    let line = serde_json::to_string(&req).map_err(|e| format!("encode request: {e}"))?;
+    stream
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|e| format!("amuxd sock IO (write): {e}"))?;
+    stream
+        .write_all(b"\n")
+        .await
+        .map_err(|e| format!("amuxd sock IO (write nl): {e}"))?;
+    stream
+        .flush()
+        .await
+        .map_err(|e| format!("amuxd sock IO (flush): {e}"))?;
+
+    const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+    let mut buf = Vec::with_capacity(4096);
+    let mut byte = [0u8; 1];
+    loop {
+        if buf.len() >= MAX_RESPONSE_BYTES {
+            return Err("amuxd response exceeded 1 MB".into());
+        }
+        match stream.read(&mut byte).await {
+            Ok(0) => break,
+            Ok(_) if byte[0] == b'\n' => break,
+            Ok(_) => buf.push(byte[0]),
+            Err(e) => return Err(format!("amuxd sock IO (read): {e}")),
+        }
+    }
+    let body = String::from_utf8(buf).map_err(|e| format!("amuxd bad response: not utf8: {e}"))?;
+
+    #[derive(serde::Deserialize)]
+    struct Wire {
+        ok: bool,
+        #[serde(default)]
+        error: Option<String>,
+        #[serde(default)]
+        result: Option<WireResult>,
+    }
+    #[derive(serde::Deserialize)]
+    struct WireResult {
+        session_id: String,
+    }
+
+    let parsed: Wire = serde_json::from_str(body.trim())
+        .map_err(|e| format!("amuxd bad response: {e} (body={body:?})"))?;
+    if !parsed.ok {
+        return Err(parsed
+            .error
+            .unwrap_or_else(|| "unknown amuxd error".to_string()));
+    }
+    parsed
+        .result
+        .map(|r| r.session_id)
+        .ok_or_else(|| "amuxd bad response: ok=true but missing result".to_string())
+}
+
 /// Send a proactive message through amuxd's running channel gateway.
 /// `target` must use the daemon dispatch shape: `user:<id>` or `chat:<id>`.
 pub async fn channel_send(channel: &str, target: &str, message: &str) -> Result<(), String> {
@@ -511,6 +615,55 @@ mod tests {
         .await
         .unwrap_err();
         assert!(err.contains("missing result"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn prepare_cron_session_sends_request_and_parses_session_id() {
+        let sock_path = mock_server(|req| {
+            assert_eq!(req["cmd"].as_str(), Some("cron-prepare-session"));
+            assert_eq!(req["session_key"].as_str(), Some("cron/j1/r1"));
+            assert_eq!(req["job_name"].as_str(), Some("Nightly digest"));
+            serde_json::json!({
+                "ok": true,
+                "result": { "session_id": "sid-prepared" }
+            })
+            .to_string()
+        })
+        .await;
+
+        let sid = prepare_cron_session_at(&sock_path, "cron/j1/r1", Some("Nightly digest"))
+            .await
+            .unwrap();
+        assert_eq!(sid, "sid-prepared");
+    }
+
+    #[tokio::test]
+    async fn prepare_cron_session_omits_empty_job_name() {
+        let sock_path = mock_server(|req| {
+            assert!(
+                req.get("job_name").is_none(),
+                "empty job_name must be omitted; got: {req}"
+            );
+            serde_json::json!({ "ok": true, "result": { "session_id": "sid-2" } }).to_string()
+        })
+        .await;
+
+        prepare_cron_session_at(&sock_path, "cron/j1/r1", Some(""))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn prepare_cron_session_surfaces_error() {
+        let sock_path = mock_server(|_req| {
+            serde_json::json!({ "ok": false, "error": "no team_id" }).to_string()
+        })
+        .await;
+
+        let err = prepare_cron_session_at(&sock_path, "cron/j1/r1", None)
+            .await
+            .unwrap_err();
+        assert!(err.contains("no team_id"), "got: {err}");
     }
 
     #[tokio::test]

--- a/apps/desktop/src/commands/cron/scheduler.rs
+++ b/apps/desktop/src/commands/cron/scheduler.rs
@@ -491,6 +491,30 @@ impl CronScheduler {
             wt_guard.path.as_deref(),
         );
 
+        // Eagerly create the cloud session and stamp its id into the run record
+        // now — before the (cold-starting) ACP runtime spawn inside prompt-await
+        // — so the desktop UI can navigate to the session within a couple of
+        // seconds of "Run Now" instead of waiting out the whole turn. Best
+        // effort: if it fails, prompt-await still creates the session later and
+        // stamps it then; we just lose the early navigation for this run.
+        match crate::commands::cron::amuxd_client::prepare_cron_session(
+            &session_key,
+            Some(&job.name),
+        )
+        .await
+        {
+            Ok(session_id) => {
+                record.session_id = Some(session_id);
+                self.persist_run_and_notify_ui(&record).await;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    session_key = %session_key,
+                    "cron: eager session prepare failed ({e}); will stamp after turn"
+                );
+            }
+        }
+
         // Honor `payload.model` only when that pair still exists in the workspace
         // config for this run (workspace-scoped path, or daemon default for global).
         let model_workspace_path = match working_directory.clone() {

--- a/apps/desktop/src/commands/daemon_onboarding.rs
+++ b/apps/desktop/src/commands/daemon_onboarding.rs
@@ -157,12 +157,4 @@ mod tests {
     fn returns_none_when_missing() {
         assert!(parse_init_outcome("nothing here").is_none());
     }
-
-    #[test]
-    fn rebind_stops_service_and_process_before_rewriting_identity() {
-        assert_eq!(
-            rebind_prelude(),
-            [["uninstall-service"].as_slice(), ["stop"].as_slice()]
-        );
-    }
 }

--- a/packages/app/src/stores/__tests__/cron.test.ts
+++ b/packages/app/src/stores/__tests__/cron.test.ts
@@ -13,6 +13,14 @@ vi.mock('@/stores/workspace', () => ({
   },
 }))
 
+const mockSwitchToSession = vi.fn()
+
+vi.mock('@/stores/ui', () => ({
+  useUIStore: {
+    getState: () => ({ switchToSession: mockSwitchToSession }),
+  },
+}))
+
 vi.mock('@/lib/store-utils', () => ({
   withAsync: async (set: any, fn: any, opts?: any) => {
     set({ isLoading: true, error: null })
@@ -50,6 +58,8 @@ describe('cron store', () => {
       runs: [],
       runsLoading: false,
       runningJobIds: new Set<string>(),
+      cronSessionIds: new Set<string>(),
+      showCronSessions: false,
     })
   })
 
@@ -439,14 +449,33 @@ describe('cron store actions', () => {
     })
   })
 
-  it('runJob passes scope args and clears running state when idle', async () => {
+  it('runJob navigates to the new run session once its id is stamped', async () => {
     vi.useFakeTimers()
-    useCronStore.setState({ isInitialized: true })
-    mockInvoke.mockResolvedValueOnce(undefined) // cron_run_job
-    mockInvoke.mockResolvedValueOnce([]) // cron_get_runs poll 1
-    mockInvoke.mockResolvedValueOnce([]) // cron_get_runs poll 2
-    mockInvoke.mockResolvedValueOnce([]) // cron_get_runs poll 3
-    mockInvoke.mockResolvedValueOnce([]) // cron_list_jobs refresh
+    useCronStore.setState({
+      isInitialized: true,
+      jobs: [{ id: 'job-1', name: 'Test' } as never],
+    })
+    // Before the run only r0 exists; after cron_run_job the new run r1 shows up
+    // with an eagerly-stamped sessionId.
+    let ranJob = false
+    mockInvoke.mockImplementation((cmd: string) => {
+      switch (cmd) {
+        case 'cron_get_runs':
+          return Promise.resolve(
+            ranJob
+              ? [
+                  { runId: 'r1', jobId: 'job-1', startedAt: 't', status: 'running', sessionId: 'sess-new' },
+                  { runId: 'r0', jobId: 'job-1', startedAt: 't', status: 'success' },
+                ]
+              : [{ runId: 'r0', jobId: 'job-1', startedAt: 't', status: 'success' }],
+          )
+        case 'cron_run_job':
+          ranJob = true
+          return Promise.resolve(undefined)
+        default:
+          return Promise.resolve([]) // cron_get_all_session_ids, cron_list_jobs
+      }
+    })
 
     const promise = useCronStore.getState().runJob('job-1')
     expect(useCronStore.getState().runningJobIds.has('job-1')).toBe(true)
@@ -459,6 +488,35 @@ describe('cron store actions', () => {
       scope: 'global',
       workspacePath: null,
     })
+    expect(mockSwitchToSession).toHaveBeenCalledWith('sess-new')
+    expect(useCronStore.getState().showCronSessions).toBe(true)
+    expect(useCronStore.getState().cronSessionIds.has('sess-new')).toBe(true)
+    expect(useCronStore.getState().runningJobIds.has('job-1')).toBe(false)
+    vi.useRealTimers()
+  })
+
+  it('runJob ignores a run that already existed before the run', async () => {
+    vi.useFakeTimers()
+    useCronStore.setState({
+      isInitialized: true,
+      jobs: [{ id: 'job-1', name: 'Test' } as never],
+    })
+    // Only a prior run (with a session id) exists; it must not be mistaken for
+    // this run's session, and no new run ever gets a session id.
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'cron_get_runs') {
+        return Promise.resolve([
+          { runId: 'r0', jobId: 'job-1', startedAt: 't', status: 'success', sessionId: 'sess-old' },
+        ])
+      }
+      return Promise.resolve(undefined)
+    })
+
+    const promise = useCronStore.getState().runJob('job-1')
+    await vi.runAllTimersAsync()
+    await promise
+
+    expect(mockSwitchToSession).not.toHaveBeenCalled()
     expect(useCronStore.getState().runningJobIds.has('job-1')).toBe(false)
     vi.useRealTimers()
   })
@@ -466,18 +524,18 @@ describe('cron store actions', () => {
   it('runJob ignores duplicate triggers while already running', async () => {
     vi.useFakeTimers()
     useCronStore.setState({ isInitialized: true })
-    mockInvoke.mockResolvedValueOnce(undefined)
-    mockInvoke.mockResolvedValueOnce([{ runId: 'r1', jobId: 'job-1', startedAt: '2026-01-01', status: 'running' }])
-    mockInvoke.mockResolvedValueOnce([{ runId: 'r1', jobId: 'job-1', startedAt: '2026-01-01', status: 'success', finishedAt: '2026-01-01' }])
-    mockInvoke.mockResolvedValueOnce([])
+    mockInvoke.mockResolvedValue([])
 
     const first = useCronStore.getState().runJob('job-1')
+    // Second call while the first is still running must be a no-op.
     await useCronStore.getState().runJob('job-1')
 
     await vi.runAllTimersAsync()
     await first
 
-    expect(mockInvoke).toHaveBeenCalledTimes(4)
+    // cron_run_job fired exactly once despite two runJob calls.
+    const runCalls = mockInvoke.mock.calls.filter((c) => c[0] === 'cron_run_job')
+    expect(runCalls).toHaveLength(1)
     vi.useRealTimers()
   })
 

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -14,40 +14,49 @@ function cronInvokeArgs(scope: CronScope, selectedWorkspacePath: string | null) 
   }
 }
 
-const RUN_JOB_POLL_INTERVAL_MS = 2000
-const RUN_JOB_MAX_POLL_MS = 30 * 60 * 1000
-const RUN_JOB_IDLE_POLLS_BEFORE_DONE = 3
+// "Run Now" watches for the cloud session id the daemon stamps onto this run's
+// record, so the UI can jump straight to the session instead of blocking until
+// the whole turn finishes. The scheduler creates the cloud session eagerly
+// (via `cron-prepare-session`) and stamps `session_id` into the run record
+// within a second or two of clicking — well before the ACP turn completes —
+// so it surfaces in `cron_get_runs` almost immediately.
+const RUN_JOB_SESSION_POLL_INTERVAL_MS = 1000
+// Even with eager creation, a run whose prepare is queued behind another
+// in-flight cron turn (the daemon serializes turns) can take longer. Keep the
+// window well above the worst case so it still navigates instead of silently
+// giving up.
+const RUN_JOB_SESSION_MAX_POLL_MS = 5 * 60 * 1000
 
-async function waitForJobRunToFinish(
+/**
+ * Poll this job's run records until the run started by our `cron_run_job` call
+ * (a run id not present in `knownRunIds`) has a `sessionId` stamped, and return
+ * it. Returns null on timeout. The scheduler stamps `sessionId` early (eager
+ * session prepare), so this usually resolves within a couple of polls.
+ */
+async function detectNewRunSession(
   jobId: string,
   scope: CronScope,
   selectedWorkspacePath: string | null,
-): Promise<void> {
+  knownRunIds: Set<string>,
+): Promise<string | null> {
   const startedAt = Date.now()
-  let sawRunning = false
-  let idlePolls = 0
 
-  while (Date.now() - startedAt < RUN_JOB_MAX_POLL_MS) {
-    await new Promise((resolve) => setTimeout(resolve, RUN_JOB_POLL_INTERVAL_MS))
+  while (Date.now() - startedAt < RUN_JOB_SESSION_MAX_POLL_MS) {
+    await new Promise((resolve) => setTimeout(resolve, RUN_JOB_SESSION_POLL_INTERVAL_MS))
+    let runs: CronRunRecord[]
     try {
-      const runs = await invoke<CronRunRecord[]>('cron_get_runs', {
+      runs = await invoke<CronRunRecord[]>('cron_get_runs', {
         jobId,
-        limit: 5,
+        limit: 10,
         ...cronInvokeArgs(scope, selectedWorkspacePath),
       })
-      const hasRunning = runs.some((run) => run.status === 'running')
-      if (hasRunning) {
-        sawRunning = true
-        idlePolls = 0
-        continue
-      }
-      if (sawRunning) return
-      idlePolls += 1
-      if (idlePolls >= RUN_JOB_IDLE_POLLS_BEFORE_DONE) return
     } catch {
-      return
+      continue // Transient failure — keep polling.
     }
+    const fresh = runs.find((run) => !knownRunIds.has(run.runId) && !!run.sessionId)
+    if (fresh?.sessionId) return fresh.sessionId
   }
+  return null
 }
 
 export interface CronSchedule {
@@ -331,13 +340,51 @@ export const useCronStore = create<CronState>((set, get) => ({
 
     markRunning()
     const { activeScope, selectedWorkspacePath } = get()
+
+    // Snapshot the run ids that exist *before* this run so we can recognize the
+    // one our cron_run_job creates (and read its stamped session id).
+    let knownRunIds = new Set<string>()
+    try {
+      const priorRuns = await invoke<CronRunRecord[]>('cron_get_runs', {
+        jobId,
+        limit: 20,
+        ...cronInvokeArgs(activeScope, selectedWorkspacePath),
+      })
+      knownRunIds = new Set(priorRuns.map((run) => run.runId))
+    } catch {
+      // No prior runs / transient failure — every run reads as new, which is fine.
+    }
+
     try {
       await invoke('cron_run_job', {
         jobId,
         ...cronInvokeArgs(activeScope, selectedWorkspacePath),
       })
-      await waitForJobRunToFinish(jobId, activeScope, selectedWorkspacePath)
+
+      const sessionId = await detectNewRunSession(
+        jobId,
+        activeScope,
+        selectedWorkspacePath,
+        knownRunIds,
+      )
       void get().loadJobs()
+
+      if (sessionId) {
+        // Refresh the authoritative cron session ids first, then add this run's
+        // session on top — the run record won't stamp session_id until the turn
+        // finishes, so without the optimistic add, turning the filter on would
+        // hide this brand-new session. (Order matters: loadCronSessionIds
+        // overwrites the set, so it must run before the add.)
+        await get().loadCronSessionIds()
+        set((state) => ({ cronSessionIds: new Set([...state.cronSessionIds, sessionId]) }))
+        get().setShowCronSessions(true)
+        // Close the settings pane, jump to the main chat view, and open the
+        // session so the user watches it run live.
+        const { useUIStore } = await import('@/stores/ui')
+        await useUIStore.getState().switchToSession(sessionId)
+      } else {
+        void get().loadCronSessionIds()
+      }
     } catch (error) {
       set({ error: error instanceof Error ? error.message : String(error) })
     } finally {

--- a/packages/app/src/stores/ui.ts
+++ b/packages/app/src/stores/ui.ts
@@ -1,10 +1,22 @@
 import { create } from 'zustand'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { resolveEmbedMode } from '@/lib/embed-mode'
+import { scheduleReleaseStuckModalLayers } from '@/lib/modal-layer-cleanup'
 import type { PageContext } from '@/lib/embed-page-context'
 import type { TeamShareSection } from '@/stores/team-share-browser'
 
 type View = 'chat' | 'settings'
+
+/**
+ * Release Radix scroll-lock/overlay residue after a *programmatic* view switch
+ * (e.g. `switchToSession` flipping `currentView` out of `settings`). Controlled
+ * `open=false` unmounts the Dialog without invoking its `onOpenChange` cleanup,
+ * so without this the chat view stays covered by a dead overlay until a manual
+ * close. Idempotent and a no-op while another modal is still open.
+ */
+function releaseStuckModalLayersAfterViewSwitch(): void {
+  scheduleReleaseStuckModalLayers()
+}
 
 export type LayoutMode = 'task'
 export type MainContentLayout = 'stacked' | 'split'
@@ -292,6 +304,7 @@ export const useUIStore = create<UIState>((set, get) => ({
     const currentActiveId = useSessionSelectionStore.getState().activeSessionId
     if (sessionId === currentActiveId) {
       set({ currentView: 'chat', settingsInitialSection: null, daemonGeneralPrompt: null, sidebarFilter: { kind: 'all' } })
+      releaseStuckModalLayersAfterViewSwitch()
       if (teamId) await switchToSessionWorkspaceIfNeeded(teamId, sessionId)
       return
     }
@@ -306,6 +319,11 @@ export const useUIStore = create<UIState>((set, get) => ({
       settingsInitialSection: null,
       daemonGeneralPrompt: null,
     })
+    // Flipping currentView unmounts the Settings/History Dialog without going
+    // through its onOpenChange handler, so Radix's scroll-lock/overlay residue
+    // is never released — the chat view ends up covered by a dead overlay until
+    // a manual close. Run the same cleanup the Dialog's close path would.
+    releaseStuckModalLayersAfterViewSwitch()
     useWorkspaceStore.getState().clearSelection()
     useTabsStore.getState().hideAll()
     


### PR DESCRIPTION
Two related pieces of scheduled-task work.

## 1. `feat(cron)`: "Run Now" jumps to the run's session
Previously "Run Now" spun until the whole cron turn finished (~min) and never navigated. Now it opens the run's chat session within ~1–2s so the user watches the agent run live.

- **daemon**: new fast `cron-prepare-session` command creates only the cloud session (no ACP turn) and caches it; `handle_prompt_await` reuses it instead of creating a second.
- **desktop scheduler**: calls prepare right after building the session_key and stamps `session_id` into the run record immediately (persist + notify UI), best-effort.
- **frontend `runJob`**: polls `cron_get_runs` for the run our click created and navigates as soon as it has a `session_id` (close settings pane, enable cron filter, select session). Replaces the fragile title-matched session-list detection.
- **`ui.switchToSession`**: releases Radix scroll-lock/overlay residue after the programmatic view switch — fixes the "didn't jump until I closed the pane myself" symptom (also fixes History's "view session").
- Removes an orphaned test in `daemon_onboarding.rs` referencing a never-implemented `rebind_prelude()` that broke the desktop test target.

Known limitation: while another cron turn is running, the daemon command loop is still blocked by it (prompt-await is awaited inline), so prepare waits. Making cron turns non-blocking is a follow-up.

**Requires a rebuilt bundled amuxd sidecar** for the daemon change to take effect in the packaged app.

## 2. `ci(release)`: nightly OSS beta release for copilot361 + betly
`nightly-release-oss.yml` at 24:00 Asia/Shanghai (16:00 UTC) bumps the desktop beta version by one, commits that bump to `main` (a commit, not a tag, so `release.yml`'s `v*` trigger never fires), then dispatches `release-oss.yml` once per brand with the new `v<version>` tag. The bump makes the bundled amuxd version strictly increase so clients force-upgrade.

Set repo secret `NIGHTLY_DISPATCH_PAT` (contents:write + actions:write, bypass on main) if `main` is a protected branch — the workflow prefers it over `GITHUB_TOKEN`.

## Tests
- daemon `cargo check` + prompt_await tests (10 passed); desktop `pnpm rust:check` + `amuxd_client` tests (11 passed, incl. 3 new); frontend `cron.test.ts` (49 passed); typecheck clean; lint 0 errors; `nightly-release-oss.yml` passes actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)