### PR TITLE
style: cargo fmt apps/desktop

### DIFF
--- a/apps/desktop/src/commands/env_vars.rs
+++ b/apps/desktop/src/commands/env_vars.rs
@@ -447,10 +447,7 @@ pub async fn env_catalog_list(
     // team_id is required for the `_team_secret.{team_id}` personal-blob secret
     // fallback: when `teamclaw.json` carries no inline `team.envSecret` (the
     // common case), passing None here leaves every team var undecryptable.
-    let team_id = team_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
+    let team_id = team_id.as_deref().map(str::trim).filter(|s| !s.is_empty());
     Ok(teamclaw_runtime_env::env_catalog::load_env_catalog(
         Path::new(&workspace_path),
         team_id,
@@ -526,11 +523,9 @@ pub async fn team_env_diagnostics(
         })
         .unwrap_or(0);
 
-    let secret_configured = teamclaw_runtime_env::env_catalog::resolve_team_env_secret(
-        ws,
-        team_id_trimmed.as_deref(),
-    )
-    .is_some();
+    let secret_configured =
+        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(ws, team_id_trimmed.as_deref())
+            .is_some();
 
     Ok(TeamEnvDiagnostics {
         team_id_present: team_id_trimmed.is_some(),

--- a/apps/desktop/src/mqtt/client.rs
+++ b/apps/desktop/src/mqtt/client.rs
@@ -38,11 +38,7 @@ impl MqttClient {
 
     pub fn connect(cfg: ClientConfig) -> Result<Self> {
         let broker = Self::resolve_broker(&cfg);
-        let mut opts = MqttOptions::new(
-            &cfg.client_id,
-            broker.connection_address(),
-            broker.port,
-        );
+        let mut opts = MqttOptions::new(&cfg.client_id, broker.connection_address(), broker.port);
         opts.set_credentials(&cfg.username, &cfg.password);
         opts.set_clean_session(false);
         opts.set_keep_alive(Duration::from_secs(30));


### PR DESCRIPTION
Fixes the non-required Rust Format & Clippy CI job that went red on #558: `apps/desktop/src/commands/env_vars.rs` and `mqtt/client.rs` were not fmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)