### PR TITLE
fix(extension): use browser file picker for chat attach button

### DIFF
--- a/packages/app/src/components/chat/ChatInputArea.tsx
+++ b/packages/app/src/components/chat/ChatInputArea.tsx
@@ -615,7 +615,10 @@ export function ChatInputArea({
 
           <PromptInputFooter>
             <PromptInputTools>
-              <FileInputButton onFilesSelected={onFilesChange} />
+              <FileInputButton
+                onFilesSelected={onFilesChange}
+                onBrowserFilesSelected={handlePastedFiles}
+              />
               <PermissionApprovalModeSelect sessionId={activeSessionId} />
 
               {/* Engaged agent pills — model is chosen per agent on each pill. */}

--- a/packages/app/src/components/chat/FileInputButton.tsx
+++ b/packages/app/src/components/chat/FileInputButton.tsx
@@ -1,12 +1,31 @@
+import * as React from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { capabilities } from "@/lib/platform";
 
 interface FileInputButtonProps {
+  /** Desktop (Tauri): absolute filesystem paths from the native dialog. */
   onFilesSelected: (paths: string[]) => void;
+  /**
+   * Extension / web: browser File objects from `<input type="file">`.
+   * Callers should route these through the same path as paste/drop.
+   */
+  onBrowserFilesSelected?: (files: File[]) => void;
 }
 
-export function FileInputButton({ onFilesSelected }: FileInputButtonProps) {
+export function FileInputButton({
+  onFilesSelected,
+  onBrowserFilesSelected,
+}: FileInputButtonProps) {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
   const handleClick = async () => {
+    // Extension / web: no Tauri dialog — trigger a hidden file input instead.
+    if (!capabilities.tauriInvoke) {
+      inputRef.current?.click();
+      return;
+    }
+
     try {
       const { open } = await import("@tauri-apps/plugin-dialog");
       const selected = await open({
@@ -23,15 +42,37 @@ export function FileInputButton({ onFilesSelected }: FileInputButtonProps) {
     }
   };
 
+  const handleBrowserChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const list = e.target.files;
+    if (list && list.length > 0) {
+      onBrowserFilesSelected?.(Array.from(list));
+    }
+    // Allow re-selecting the same file(s).
+    e.target.value = "";
+  };
+
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
-      onClick={handleClick}
-    >
-      <Plus className="h-4 w-4" />
-    </Button>
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+        onClick={handleClick}
+        aria-label="Attach files"
+      >
+        <Plus className="h-4 w-4" />
+      </Button>
+      {!capabilities.tauriInvoke ? (
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          className="hidden"
+          data-testid="file-input-browser"
+          onChange={handleBrowserChange}
+        />
+      ) : null}
+    </>
   );
 }

--- a/packages/app/src/components/chat/__tests__/FileInputButton.test.tsx
+++ b/packages/app/src/components/chat/__tests__/FileInputButton.test.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FileInputButton } from '../FileInputButton'
+
+const platformState = vi.hoisted(() => ({ tauriInvoke: false }))
+
+vi.mock('@/lib/platform', () => ({
+  capabilities: {
+    get tauriInvoke() {
+      return platformState.tauriInvoke
+    },
+  },
+}))
+
+const openDialog = vi.fn()
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: (...args: unknown[]) => openDialog(...args),
+}))
+
+describe('FileInputButton', () => {
+  beforeEach(() => {
+    platformState.tauriInvoke = false
+    openDialog.mockReset()
+  })
+
+  it('opens a browser file input when Tauri is unavailable', () => {
+    const onFilesSelected = vi.fn()
+    const onBrowserFilesSelected = vi.fn()
+    render(
+      <FileInputButton
+        onFilesSelected={onFilesSelected}
+        onBrowserFilesSelected={onBrowserFilesSelected}
+      />,
+    )
+
+    const input = screen.getByTestId('file-input-browser') as HTMLInputElement
+    const clickSpy = vi.spyOn(input, 'click')
+
+    fireEvent.click(screen.getByRole('button', { name: /attach files/i }))
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(openDialog).not.toHaveBeenCalled()
+
+    const file = new File(['hello'], 'note.txt', { type: 'text/plain' })
+    fireEvent.change(input, { target: { files: [file] } })
+    expect(onBrowserFilesSelected).toHaveBeenCalledWith([file])
+    expect(onFilesSelected).not.toHaveBeenCalled()
+  })
+
+  it('uses the Tauri dialog on desktop', async () => {
+    platformState.tauriInvoke = true
+    openDialog.mockResolvedValue(['/tmp/a.png'])
+    const onFilesSelected = vi.fn()
+    const onBrowserFilesSelected = vi.fn()
+
+    render(
+      <FileInputButton
+        onFilesSelected={onFilesSelected}
+        onBrowserFilesSelected={onBrowserFilesSelected}
+      />,
+    )
+
+    expect(screen.queryByTestId('file-input-browser')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /attach files/i }))
+    await vi.waitFor(() => {
+      expect(openDialog).toHaveBeenCalledTimes(1)
+      expect(onFilesSelected).toHaveBeenCalledWith(['/tmp/a.png'])
+    })
+    expect(onBrowserFilesSelected).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Chrome extension / web has no Tauri dialog, so the composer `+` attach button silently failed after catching the error.
- Fall back to a hidden `<input type="file">` when Tauri is unavailable, and route selected files through the existing paste/drop attachment path.
- Desktop keeps the native Tauri file dialog.

## Test plan
- [ ] Extension side panel: click `+` → OS/browser file picker opens
- [ ] Select image(s) → preview appears in composer; send uploads as before
- [ ] Desktop app: `+` still opens Tauri dialog and attaches by path
- [ ] `pnpm exec vitest run src/components/chat/__tests__/FileInputButton.test.tsx`


Made with [Cursor](https://cursor.com)