### PR TITLE
fix(app): dismiss narrow session sheet on row select

### DIFF
--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -383,7 +383,11 @@ export function SessionListColumn({
     return ''
   })()
 
-  const handleSelectSession = (id: string) => useUIStore.getState().switchToSession(id)
+  const handleSelectSession = (id: string) => {
+    void useUIStore.getState().switchToSession(id)
+    // Narrow sheet / embed: selecting a session should close the list overlay.
+    onDismiss?.()
+  }
 
   const showNewChatButton = embedMode || (showNewSessionActions && !compactHeader)
 

--- a/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
@@ -273,6 +273,19 @@ describe('SessionListColumn', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1)
   })
 
+  it('dismisses the sheet when a session row is selected', () => {
+    const onDismiss = vi.fn()
+    const switchToSession = vi.spyOn(useUIStore.getState(), 'switchToSession').mockResolvedValue()
+    render(<SessionListColumn onDismiss={onDismiss} />)
+
+    const row = screen.getAllByTestId('v2-session-row').find((el) => el.getAttribute('data-session-id') === 's1')
+    expect(row).toBeTruthy()
+    fireEvent.click(row!)
+    expect(switchToSession).toHaveBeenCalledWith('s1')
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+    switchToSession.mockRestore()
+  })
+
   it('creates a session directly from the new chat button in embed mode', async () => {
     useUIStore.setState({ embedMode: true })
     const onDismiss = vi.fn()


### PR DESCRIPTION
## Summary
- In the narrow/extension session sheet, selecting a row switched the active session but left the list overlay open.
- Call `onDismiss` after `switchToSession` so the sheet closes (desktop sidebar unchanged — it does not pass `onDismiss`).

## Test plan
- [ ] Narrow / extension UI: open Sessions sheet → click a session → sheet closes and chat shows
- [ ] Click the already-active session → sheet still closes
- [ ] Wide layout: session list stays as a column (no sheet dismiss behavior)
- [ ] `pnpm exec vitest run src/components/sidebar/__tests__/SessionListColumn.test.tsx -t "dismisses the sheet"`


Made with [Cursor](https://cursor.com)