### PR TITLE
fix(app): quiet agent message chrome and dark-mode contrast

### DIFF
--- a/packages/app/src/components/chat/ActorLabel.tsx
+++ b/packages/app/src/components/chat/ActorLabel.tsx
@@ -3,7 +3,8 @@ import { useActorDisplayName, useAgentModelByActor } from "@/hooks/useActorDispl
 
 /** Subtle "actor name [· model]" label rendered above each message bubble.
  * Right-aligned for user messages, left-aligned for assistant. Skipped
- * when no senderActorId is available (legacy v1 messages). */
+ * when no senderActorId is available (legacy v1 messages).
+ * Model slides out left→right on hover; slides back on leave. */
 export function ActorLabel({
   senderActorId,
   modelOverride,
@@ -23,12 +24,37 @@ export function ActorLabel({
   return (
     <div
       className={cn(
-        "px-1 mb-0.5 text-[11px] text-muted-foreground/70",
-        isUser ? "text-right" : "text-left",
+        "group/actor-label mb-0.5 flex items-baseline px-1 text-[11px] text-muted-foreground/70",
+        isUser ? "justify-end" : "justify-start",
       )}
     >
-      <span>{name}</span>
-      {!isUser && model && <span> · {model}</span>}
+      <span className="shrink-0">{name}</span>
+      {!isUser && model ? (
+        <span
+          className={cn(
+            "inline-grid min-w-0 transition-[grid-template-columns] duration-200 ease-out",
+            "grid-cols-[0fr]",
+            "group-hover/actor-label:grid-cols-[1fr]",
+            "group-hover/msg:grid-cols-[1fr]",
+            "group-focus-within/msg:grid-cols-[1fr]",
+          )}
+        >
+          <span className="min-w-0 overflow-hidden">
+            <span
+              className={cn(
+                "inline-block whitespace-nowrap will-change-transform",
+                "-translate-x-1.5 opacity-0 transition-[transform,opacity] duration-200 ease-out",
+                "group-hover/actor-label:translate-x-0 group-hover/actor-label:opacity-100",
+                "group-hover/msg:translate-x-0 group-hover/msg:opacity-100",
+                "group-focus-within/msg:translate-x-0 group-focus-within/msg:opacity-100",
+              )}
+            >
+              {" · "}
+              {model}
+            </span>
+          </span>
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/packages/app/src/components/chat/AgentProcessCollapsible.tsx
+++ b/packages/app/src/components/chat/AgentProcessCollapsible.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDown } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import {
   Collapsible,
   CollapsibleContent,
@@ -33,14 +33,8 @@ export function AgentProcessCollapsible({
         <CollapsibleTrigger asChild>
           <button
             type="button"
-            className="inline-flex max-w-full items-center gap-1.5 rounded py-0.5 text-left text-[12px] text-muted-foreground transition-colors hover:text-foreground"
+            className="group/process inline-flex max-w-full cursor-pointer items-center gap-1.5 rounded py-0.5 text-left text-[12px] text-muted-foreground transition-colors hover:text-foreground"
           >
-            <ChevronDown
-              className={cn(
-                "h-3 w-3 shrink-0 text-faint transition-transform duration-200",
-                open && "rotate-180",
-              )}
-            />
             <span className="font-medium">
               {t("chat.process", "处理过程")}
             </span>
@@ -54,6 +48,13 @@ export function AgentProcessCollapsible({
                 </span>
               </>
             ) : null}
+            <ChevronRight
+              className={cn(
+                "h-3 w-3 shrink-0 text-faint opacity-0 transition-[opacity,transform] duration-200 group-hover/process:opacity-100",
+                open && "rotate-90",
+              )}
+              aria-hidden
+            />
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>

--- a/packages/app/src/components/chat/AgentReplyQuote.tsx
+++ b/packages/app/src/components/chat/AgentReplyQuote.tsx
@@ -28,7 +28,7 @@ export function AgentReplyQuote({
       data-testid="agent-reply-quote"
       onClick={onJump}
       className={cn(
-        "mb-1.5 flex w-full max-w-[440px] items-center gap-1.5 rounded-md border-l-2 border-coral/40 bg-[rgba(26,26,20,0.035)] py-[4px] pl-[7px] pr-[9px] text-left transition-colors hover:bg-[rgba(26,26,20,0.06)] dark:bg-white/[0.04] dark:hover:bg-white/[0.07]",
+        "mb-1.5 flex w-full max-w-[440px] cursor-pointer items-center gap-1.5 rounded-md border-l-2 border-coral/40 bg-[rgba(26,26,20,0.035)] py-[4px] pl-[7px] pr-[9px] text-left transition-colors hover:bg-[rgba(26,26,20,0.06)] dark:bg-white/[0.04] dark:hover:bg-white/[0.07]",
         className,
       )}
     >

--- a/packages/app/src/components/chat/ComposerStack.tsx
+++ b/packages/app/src/components/chat/ComposerStack.tsx
@@ -30,10 +30,10 @@ export type ActiveStreamingAgent = {
 };
 
 const LIVE_INLINE_SCROLL_CLASS =
-  "max-h-[220px] overflow-y-auto border-t border-border/50 bg-gradient-to-b from-[#fbf9f4] to-white px-3 py-2.5";
+  "max-h-[220px] overflow-y-auto border-t border-border/50 bg-gradient-to-b from-[#fbf9f4] to-white px-3 py-2.5 dark:from-background dark:to-paper";
 
 const LIVE_FLOAT_SCROLL_CLASS =
-  "min-h-0 flex-1 overflow-y-auto bg-gradient-to-b from-[#fbf9f4] to-white px-3 py-2.5";
+  "min-h-0 flex-1 overflow-y-auto bg-gradient-to-b from-[#fbf9f4] to-white px-3 py-2.5 dark:from-background dark:to-paper";
 
 function useLiveScrollFollow(active: boolean, entry: AgentStreamEntry | undefined) {
   const liveScrollRef = React.useRef<HTMLDivElement>(null);

--- a/packages/app/src/components/chat/PermissionApprovalPanel.tsx
+++ b/packages/app/src/components/chat/PermissionApprovalPanel.tsx
@@ -109,7 +109,7 @@ export function PermissionApprovalPanel({
             type="button"
             onClick={() => void handleReply("allow")}
             disabled={submitting}
-            className="w-full rounded-lg bg-foreground px-3 py-1.5 text-center text-[12px] font-semibold text-[#fefdfa] transition-opacity hover:opacity-90 disabled:opacity-50"
+            className="w-full rounded-lg bg-foreground px-3 py-1.5 text-center text-[12px] font-semibold text-background transition-opacity hover:opacity-90 disabled:opacity-50"
           >
             {t("chat.permissionCard.approve", "Allow")}
           </button>

--- a/packages/app/src/components/chat/StreamingAgentBubble.tsx
+++ b/packages/app/src/components/chat/StreamingAgentBubble.tsx
@@ -14,6 +14,7 @@ import { ActorLabel } from "./ActorLabel";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { StreamMarkdown } from "./StreamMarkdown";
 import type { MessagePart } from "@/stores/session-types";
+import { cn } from "@/lib/utils";
 
 function StreamRevealedResponse({
   text,
@@ -232,7 +233,7 @@ export const StreamingAgentBubble = React.memo(function StreamingAgentBubble({
 
   return (
     <div
-      className={isDock ? "mb-0" : "mb-1.5"}
+      className={cn("group/msg", isDock ? "mb-0" : "mb-1.5")}
       data-testid="v2-streaming-agent"
       data-session-id={entry.sessionId}
       data-actor-id={entry.actorId}

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -594,7 +594,7 @@ export function SessionListColumn({
                 className={cn(
                   'mt-0.5 mr-2.5 inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[4px] border-[1.5px]',
                   isBatchChecked
-                    ? 'border-foreground bg-foreground text-[#fefdfa]'
+                    ? 'border-foreground bg-foreground text-background'
                     : 'border-foreground/20 bg-paper',
                 )}
               >
@@ -1056,7 +1056,7 @@ export function SessionListColumn({
             <Button
               type="button"
               size="sm"
-              className="h-8 min-w-[4.5rem] flex-1 bg-foreground text-[12px] font-semibold text-[#fefdfa] hover:bg-foreground/90 sm:flex-none"
+              className="h-8 min-w-[4.5rem] flex-1 bg-foreground text-[12px] font-semibold text-background hover:bg-foreground/90 sm:flex-none"
               disabled={batchSelectedIds.size === 0 || batchArchiving}
               onClick={() => setBatchConfirmOpen(true)}
               data-testid="v2-session-batch-archive"

--- a/packages/app/src/styles/globals.css
+++ b/packages/app/src/styles/globals.css
@@ -988,11 +988,24 @@ input,
 /* Quote-reply jump highlight on the parent user bubble */
 @keyframes agent-reply-quote-flash {
     0% {
-        box-shadow: 0 0 0 0 rgba(232, 90, 74, 0.45);
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--coral) 18%, transparent);
     }
     30% {
-        box-shadow: 0 0 0 3px rgba(232, 90, 74, 0.28);
-        background-color: #fdf0ed;
+        box-shadow: 0 0 0 2px color-mix(in srgb, var(--coral) 12%, transparent);
+        background-color: color-mix(in srgb, var(--coral) 5%, transparent);
+    }
+    100% {
+        box-shadow: none;
+        background-color: transparent;
+    }
+}
+@keyframes agent-reply-quote-flash-dark {
+    0% {
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--coral) 22%, transparent);
+    }
+    30% {
+        box-shadow: 0 0 0 2px color-mix(in srgb, var(--coral) 14%, transparent);
+        background-color: color-mix(in srgb, var(--coral) 7%, transparent);
     }
     100% {
         box-shadow: none;
@@ -1002,6 +1015,9 @@ input,
 .agent-reply-quote-flash {
     animation: agent-reply-quote-flash 1.1s ease;
     border-radius: 12px;
+}
+.dark .agent-reply-quote-flash {
+    animation: agent-reply-quote-flash-dark 1.1s ease;
 }
 
 .stream-loading-dot {


### PR DESCRIPTION
## Summary
- Soften agent message hierarchy: model name slides in on hover; process chevron moves to the right and appears on hover (→ collapsed / ↓ open); reply-to and process headers use pointer cursor.
- Fix dark-mode contrast: Allow / batch Archive / checkbox use `text-background` with `bg-foreground`; live agent dock scroll uses dark paper gradient; reply-to jump flash uses subtle coral mix (no bright `#fdf0ed` flash).

## Test plan
- [ ] Dark mode: permission Allow button readable; live agent output strip above composer is dark, not white
- [ ] Dark/light: click Reply-to — jump highlight is subtle, not a bright flash
- [ ] Agent message: default shows name only; hover reveals model with left→right slide
- [ ] Process header: chevron on the right, only on hover; collapsed →, expanded ↓; cursor pointer
- [ ] Reply-to row: cursor pointer
- [ ] Session list batch select: checkbox checkmark and Archive button readable in dark mode


Made with [Cursor](https://cursor.com)