### PR TITLE
feat(extension): per-brand scoped hosts + published privacy policy

### DIFF
--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -6,6 +6,16 @@ import { openSidePanelFromUserGesture } from './lib/open-side-panel'
 
 const SIDE_PANEL_PATH = 'sidepanel/index.html'
 
+/**
+ * Hosts the extension is scoped to, read from the (brand-injected) manifest so
+ * this stays in sync with host_permissions without hardcoding any brand's
+ * domains. Falls back to all http/https for a non-branded build.
+ */
+const SCOPED_TAB_URLS =
+  chrome.runtime.getManifest().host_permissions?.length
+    ? chrome.runtime.getManifest().host_permissions!
+    : ['http://*/*', 'https://*/*']
+
 chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
   .catch((e) => console.warn('[bg] setPanelBehavior failed', e))
@@ -39,7 +49,7 @@ async function injectContentScript(tabId: number): Promise<void> {
 
 /** Content scripts in manifest only attach on navigation — backfill open tabs. */
 async function injectOpenHttpTabs(): Promise<void> {
-  const tabs = await chrome.tabs.query({ url: ['http://*/*', 'https://*/*'] })
+  const tabs = await chrome.tabs.query({ url: SCOPED_TAB_URLS })
   await Promise.all(
     tabs.map(async (tab) => {
       if (!tab.id) return

--- a/scripts/publish-oss-release.py
+++ b/scripts/publish-oss-release.py
@@ -515,6 +515,39 @@ Write-Host 'Done. amuxd is running as a background service. Check: amuxd status'
     bucket.put_object(f"{prefix}/install-amuxd.ps1", install_amuxd_ps1.encode(),
                       headers={**short_cache, "Content-Type": "text/plain; charset=utf-8"})
 
+    # Privacy policy — brand-generic template with {{APP_NAME}} substituted.
+    # Published at {cdn}/{prefix}/privacy.html so the Chrome Web Store listing can
+    # point its "Privacy policy URL" here (e.g. download.copilot361.com/releases/privacy.html).
+    privacy_tpl_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "templates", "privacy.html"
+    )
+    if os.path.isfile(privacy_tpl_path):
+        with open(privacy_tpl_path, encoding="utf-8") as f:
+            privacy_html = f.read()
+        # Contact precedence: PRIVACY_CONTACT env → brand config
+        # (app.privacyContact / page.privacyContact) → domain-derived fallback.
+        # Contact precedence: PRIVACY_CONTACT env → brand.json's page block
+        # (page_cfg.privacyContact) → build config app block → domain fallback.
+        contact = (
+            os.environ.get("PRIVACY_CONTACT")
+            or page_cfg.get("privacyContact")
+            or (build_config.get("app") or {}).get("privacyContact")
+            or f"support@{app_slug}.com"
+        )
+        privacy_html = (
+            privacy_html.replace("{{APP_NAME}}", html.escape(app_name))
+            .replace("{{UPDATED}}", datetime.now(timezone.utc).strftime("%Y-%m-%d"))
+            .replace("{{CONTACT}}", html.escape(contact))
+        )
+        bucket.put_object(
+            f"{prefix}/privacy.html",
+            privacy_html.encode(),
+            headers={**short_cache, "Content-Type": "text/html; charset=utf-8"},
+        )
+        print(f"✅ {cdn}/{prefix}/privacy.html  (privacy policy)")
+    else:
+        print("::warning::privacy.html template missing — skipped privacy policy upload")
+
     logo = resolve_logo(build_config)
     if logo:
         bucket.put_object_from_file(f"{prefix}/logo.png", logo,

--- a/scripts/templates/privacy.html
+++ b/scripts/templates/privacy.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>{{APP_NAME}} — Privacy Policy</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { max-width: 720px; margin: 0 auto; padding: 48px 20px 96px;
+    font: 16px/1.6 -apple-system, "Segoe UI", Roboto, "PingFang SC", sans-serif;
+    color: #1a1a1a; }
+  @media (prefers-color-scheme: dark) { body { color: #e8e8e8; background: #141414; } }
+  h1 { font-size: 28px; margin: 0 0 4px; }
+  h2 { font-size: 18px; margin: 32px 0 8px; }
+  .muted { opacity: .6; font-size: 14px; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .92em; }
+  ul { padding-left: 20px; }
+</style>
+</head>
+<body>
+  <h1>{{APP_NAME}} Privacy Policy</h1>
+  <p class="muted">Last updated: {{UPDATED}}</p>
+
+  <p>
+    {{APP_NAME}} is a browser extension that shows an AI chat side panel and lets
+    you send the content of a web page you are viewing to a {{APP_NAME}} agent.
+    This policy explains what data the extension handles and how.
+  </p>
+
+  <h2>What we handle</h2>
+  <ul>
+    <li>
+      <strong>Web page content</strong> — the text, DOM, and any selected text of
+      a page, captured <em>only</em> when you explicitly invoke {{APP_NAME}} (for
+      example by opening the side panel for the page or sharing a link). The
+      extension does not passively read or collect your browsing across sites.
+    </li>
+    <li>
+      <strong>Extension settings</strong> — your preferences (such as per-site
+      link-hover settings) are stored locally in your browser via the extension
+      <code>storage</code> API.
+    </li>
+  </ul>
+
+  <h2>How it is used</h2>
+  <p>
+    Page content you choose to share is sent to the {{APP_NAME}} agent backend so
+    the agent can respond to your request. It is used solely to provide the chat
+    functionality you asked for. We do <strong>not</strong> sell or transfer your
+    data to third parties, do not use it for any purpose unrelated to the
+    extension's single purpose, and do not use it to determine creditworthiness or
+    for lending.
+  </p>
+
+  <h2>Permissions</h2>
+  <ul>
+    <li><code>sidePanel</code> — renders the {{APP_NAME}} chat interface.</li>
+    <li><code>activeTab</code> / host access — reads the current page's content when you invoke the extension.</li>
+    <li><code>scripting</code> — injects the content script that extracts page content.</li>
+    <li><code>tabs</code> — identifies the active tab and opens/navigates URLs you share with the agent.</li>
+    <li><code>storage</code> — stores your settings locally in the browser.</li>
+  </ul>
+
+  <h2>Data retention</h2>
+  <p>
+    Settings remain in local browser storage until you remove the extension or
+    clear them. Shared page content is processed to fulfil your request and is not
+    retained beyond what is needed to operate the service.
+  </p>
+
+  <h2>Contact</h2>
+  <p>
+    Questions about this policy: <a href="mailto:{{CONTACT}}">{{CONTACT}}</a>.
+  </p>
+</body>
+</html>

--- a/scripts/update-extension-manifest.js
+++ b/scripts/update-extension-manifest.js
@@ -54,6 +54,23 @@ if (applyNameToExtensionManifest(manifest, buildConfig)) {
   updated = true;
 }
 
+// Brand-scoped host access: a brand may narrow the extension to a fixed set of
+// match patterns (e.g. copilot361 -> Shopee/SeaMoney internal domains) instead
+// of the base manifest's all-hosts default. When `extension.hosts` is a
+// non-empty array, it overrides BOTH host_permissions and every content-script
+// matches list. Absent -> base manifest (all http/https) is kept.
+const brandHosts = buildConfig.extension && buildConfig.extension.hosts;
+if (Array.isArray(brandHosts) && brandHosts.length > 0) {
+  manifest.host_permissions = [...brandHosts];
+  if (Array.isArray(manifest.content_scripts)) {
+    for (const cs of manifest.content_scripts) {
+      cs.matches = [...brandHosts];
+    }
+  }
+  console.log(`✓ Scoped extension hosts to ${brandHosts.length} pattern(s)`);
+  updated = true;
+}
+
 // Chrome Web Store requires x.y.z(.w) version numbers — mirror app version if set.
 if (buildConfig.app && buildConfig.app.version && manifest.version !== buildConfig.app.version) {
   manifest.version = buildConfig.app.version;


### PR DESCRIPTION
## What

- **Per-brand scoped hosts**: `update-extension-manifest.js` now honors `extension.hosts` from a brand's build config, overriding `host_permissions` + `content_scripts.matches` at build time. Removes hardcoded domains from the shared manifest; base manifest keeps the all-http/https default for local/dev builds.
- **background.ts**: tab-injection scope derived from the (brand-injected) manifest `host_permissions` at runtime instead of an all-sites query.
- **Privacy policy**: `publish-oss-release.py` + `scripts/templates/privacy.html` render and publish a brand-generic privacy policy to `{cdn}/{prefix}/privacy.html` (copilot361: https://download.copilot361.com/releases/privacy.html) for the Chrome Web Store 'Privacy policy URL'. Contact email from brand config `privacyContact`, overridable via `PRIVACY_CONTACT`.

## Companion PR

Branding repo `teamclaw-enterprise-branding#2` sets `extension.hosts` + `privacyContact` for copilot361 (Shopee/SeaMoney) and betly (adminclimb/mx5/ucar). This PR must merge first for those to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)