### PR TITLE
feat(sessions): mark scheduled-origin sessions with source + cron_job_id

### DIFF
--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -1299,6 +1299,7 @@ impl Backend for CloudApiBackend {
         team_id: &str,
         primary_agent_actor_id: &str,
         title: &str,
+        cron_job_id: Option<&str>,
     ) -> BackendResult<String> {
         #[derive(serde::Serialize)]
         struct Body<'a> {
@@ -1307,6 +1308,8 @@ impl Backend for CloudApiBackend {
             #[serde(rename = "primaryAgentActorId")]
             primary_agent_actor_id: &'a str,
             title: &'a str,
+            #[serde(rename = "cronJobId", skip_serializing_if = "Option::is_none")]
+            cron_job_id: Option<&'a str>,
         }
         #[derive(serde::Deserialize)]
         struct Resp {
@@ -1320,6 +1323,7 @@ impl Backend for CloudApiBackend {
                     team_id,
                     primary_agent_actor_id,
                     title,
+                    cron_job_id,
                 },
                 None,
             )
@@ -2185,7 +2189,7 @@ mod tests {
             .await;
         let backend = CloudApiBackend::new(config(&server));
         let session_id = backend
-            .create_cron_session("team-1", "agent-1", "Daily summary")
+            .create_cron_session("team-1", "agent-1", "Daily summary", Some("job-1"))
             .await
             .unwrap();
         assert_eq!(session_id, "session-cron-1");

--- a/apps/daemon/src/backend/deferred.rs
+++ b/apps/daemon/src/backend/deferred.rs
@@ -416,9 +416,10 @@ impl Backend for DeferredBackend {
         team_id: &str,
         primary_agent_actor_id: &str,
         title: &str,
+        cron_job_id: Option<&str>,
     ) -> BackendResult<String> {
         self.inner()?
-            .create_cron_session(team_id, primary_agent_actor_id, title)
+            .create_cron_session(team_id, primary_agent_actor_id, title, cron_job_id)
             .await
     }
 

--- a/apps/daemon/src/backend/mock.rs
+++ b/apps/daemon/src/backend/mock.rs
@@ -113,6 +113,7 @@ pub struct RecordedCronSession {
     pub team_id: String,
     pub primary_agent_actor_id: String,
     pub title: String,
+    pub cron_job_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -629,6 +630,7 @@ impl Backend for MockBackend {
         team_id: &str,
         primary_agent_actor_id: &str,
         title: &str,
+        cron_job_id: Option<&str>,
     ) -> BackendResult<String> {
         let mut st = self.state.lock().unwrap();
         let sid = format!("mock-cron-sess-{}", st.cron_sessions.len() + 1);
@@ -636,6 +638,7 @@ impl Backend for MockBackend {
             team_id: team_id.to_string(),
             primary_agent_actor_id: primary_agent_actor_id.to_string(),
             title: title.to_string(),
+            cron_job_id: cron_job_id.map(|s| s.to_string()),
         });
         st.session_participants_upserted
             .push((sid.clone(), primary_agent_actor_id.to_string()));
@@ -914,7 +917,7 @@ mod tests {
             .insert("agent-1".into(), vec!["admin-1".into(), "admin-2".into()]);
 
         let sid = be
-            .create_cron_session("team-x", "agent-1", "Cron job")
+            .create_cron_session("team-x", "agent-1", "Cron job", Some("job-x"))
             .await
             .unwrap();
         assert!(sid.starts_with("mock-cron-sess-"));

--- a/apps/daemon/src/backend/mod.rs
+++ b/apps/daemon/src/backend/mod.rs
@@ -426,11 +426,16 @@ pub trait Backend: Send + Sync {
 
     /// Create a `sessions` row for a cron-triggered turn and seed
     /// participants (primary agent + that agent's admin members).
+    ///
+    /// `cron_job_id` is the desktop-local cron job id (`cron/<jobId>/<runId>`
+    /// middle segment), persisted as `sessions.cron_job_id` to mark
+    /// scheduled-origin sessions.
     async fn create_cron_session(
         &self,
         team_id: &str,
         primary_agent_actor_id: &str,
         title: &str,
+        cron_job_id: Option<&str>,
     ) -> BackendResult<String>;
 
     /// Insert one row into `public.messages` from the daemon's runtime.

--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -160,8 +160,12 @@ impl DaemonServer {
                 let sb_sid = match self.cron_sessions.take_prepared(parsed.session_key) {
                     Some(prepared) => prepared,
                     None => {
-                        self.create_cron_cloud_session(&team_id, parsed.job_name)
-                            .await?
+                        self.create_cron_cloud_session(
+                            &team_id,
+                            parsed.session_key,
+                            parsed.job_name,
+                        )
+                        .await?
                     }
                 };
 
@@ -356,14 +360,27 @@ impl DaemonServer {
     async fn create_cron_cloud_session(
         &self,
         team_id: &str,
+        session_key: &str,
         job_name: Option<&str>,
     ) -> anyhow::Result<String> {
         let primary_agent_actor_id = self.actor_id.clone();
         let title = Self::cron_session_title(job_name);
+        // session_key is `cron/<jobId>/<runId>`; the job id is the middle
+        // segment. Marks the cloud session as scheduled-origin so clients no
+        // longer have to scan the daemon's local run history to know.
+        let cron_job_id = Self::cron_job_id_from_session_key(session_key);
         self.backend
-            .create_cron_session(team_id, &primary_agent_actor_id, &title)
+            .create_cron_session(team_id, &primary_agent_actor_id, &title, cron_job_id)
             .await
             .map_err(|e| anyhow::anyhow!("create_cron_session: {e}"))
+    }
+
+    /// Extract `<jobId>` from a `cron/<jobId>/<runId>` session key.
+    fn cron_job_id_from_session_key(session_key: &str) -> Option<&str> {
+        session_key
+            .strip_prefix("cron/")
+            .and_then(|rest| rest.split('/').next())
+            .filter(|s| !s.is_empty())
     }
 
     /// Eagerly create the cloud session for a cron run and cache it, returning
@@ -403,7 +420,9 @@ impl DaemonServer {
             .clone()
             .ok_or_else(|| anyhow::anyhow!("daemon has no team_id; run `amuxd init` first"))?;
 
-        let sb_sid = self.create_cron_cloud_session(&team_id, job_name).await?;
+        let sb_sid = self
+            .create_cron_cloud_session(&team_id, session_key, job_name)
+            .await?;
         self.cron_sessions.insert_prepared(session_key, &sb_sid);
         info!(
             session_key = %session_key,
@@ -626,10 +645,30 @@ impl DaemonServer {
 #[cfg(test)]
 mod tests {
     use super::CronSessionCache;
+    use crate::daemon::server::DaemonServer;
     use crate::backend::mock::MockBackend;
     use crate::backend::{AgentDefaults, Backend, WorkspaceRow};
     use crate::daemon::server::tests::test_server_with_cloud_api;
     use std::sync::Arc;
+
+    #[test]
+    fn cron_job_id_parsed_from_session_key() {
+        assert_eq!(
+            DaemonServer::cron_job_id_from_session_key("cron/job-abc/run-123"),
+            Some("job-abc")
+        );
+        // Missing run segment still yields the job id.
+        assert_eq!(
+            DaemonServer::cron_job_id_from_session_key("cron/job-abc"),
+            Some("job-abc")
+        );
+        // Non-cron keys and empty job segments yield None.
+        assert_eq!(
+            DaemonServer::cron_job_id_from_session_key("gateway/wecom/x"),
+            None
+        );
+        assert_eq!(DaemonServer::cron_job_id_from_session_key("cron//run"), None);
+    }
 
     #[tokio::test]
     async fn resolve_cron_default_workspace_uses_resolvable_agent_default() {

--- a/apps/daemon/tests/http_apps.rs
+++ b/apps/daemon/tests/http_apps.rs
@@ -228,6 +228,7 @@ impl Backend for CredentialMockBackend {
         _team_id: &str,
         _primary_agent_actor_id: &str,
         _title: &str,
+        _cron_job_id: Option<&str>,
     ) -> BackendResult<String> {
         unimplemented!("not used by seed test")
     }

--- a/apps/desktop/src/commands/cron/mod.rs
+++ b/apps/desktop/src/commands/cron/mod.rs
@@ -415,26 +415,6 @@ pub async fn cron_get_runs(
     Ok(instance.storage.get_runs(&job_id, Some(limit)).await)
 }
 
-/// Get all session IDs created by cron jobs for the calling window's workspace.
-#[tauri::command]
-pub async fn cron_get_all_session_ids(
-    window: tauri::WebviewWindow,
-    registry: State<'_, crate::commands::window::WindowRegistry>,
-    cron_state: State<'_, CronState>,
-    scope: Option<CronScope>,
-    workspace_path: Option<String>,
-) -> Result<Vec<String>, String> {
-    let instance = require_instance(
-        scope.unwrap_or_default(),
-        workspace_path,
-        &window,
-        &registry,
-        &cron_state,
-    )
-    .await?;
-    Ok(instance.storage.get_all_session_ids().await)
-}
-
 /// Refresh delivery configs (no-op now — `DeliveryManager` reads config on demand).
 #[tauri::command]
 pub async fn cron_refresh_delivery() -> Result<(), String> {

--- a/apps/desktop/src/commands/cron/storage.rs
+++ b/apps/desktop/src/commands/cron/storage.rs
@@ -397,45 +397,6 @@ impl CronStorage {
         }
     }
 
-    /// Collect all session IDs created by cron jobs (across all jobs).
-    /// Used by the frontend to filter cron sessions from the session list.
-    pub async fn get_all_session_ids(&self) -> Vec<String> {
-        let workspace = self.workspace_path.read().await;
-        let Some(ws) = workspace.as_ref() else {
-            return Vec::new();
-        };
-
-        let runs_dir = Self::runs_dir(ws);
-        if !runs_dir.exists() {
-            return Vec::new();
-        }
-
-        let mut session_ids = std::collections::HashSet::new();
-
-        if let Ok(entries) = std::fs::read_dir(&runs_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-                    continue;
-                }
-                if let Ok(content) = std::fs::read_to_string(&path) {
-                    for line in content.lines() {
-                        if line.trim().is_empty() {
-                            continue;
-                        }
-                        if let Ok(record) = serde_json::from_str::<CronRunRecord>(line) {
-                            if let Some(sid) = record.session_id {
-                                session_ids.insert(sid);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        session_ids.into_iter().collect()
-    }
-
     /// Get run history for a job (most recent first, with optional limit)
     /// Get run history for a job.
     ///

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -424,7 +424,6 @@ pub fn run() {
             commands::cron::cron_toggle_enabled,
             commands::cron::cron_run_job,
             commands::cron::cron_get_runs,
-            commands::cron::cron_get_all_session_ids,
             commands::cron::cron_refresh_delivery,
             commands::daemon_installer::install_local_daemon,
             commands::daemon_installer::daemon_status,

--- a/apps/desktop/src/local_cache/store.rs
+++ b/apps/desktop/src/local_cache/store.rs
@@ -270,6 +270,10 @@ pub struct SessionRow {
     pub last_message_at: Option<String>,
     pub created_by: Option<String>,
     pub metadata_json: Option<String>,
+    /// How the session was created: 'user' | 'cron' | 'gateway'.
+    pub source: Option<String>,
+    /// For source='cron', the cron job id that created it.
+    pub cron_job_id: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     pub deleted_at: Option<String>,
@@ -511,6 +515,8 @@ impl LocalCacheStore {
                 last_message_at      TEXT,
                 created_by           TEXT,
                 metadata_json        TEXT,
+                source               TEXT,
+                cron_job_id          TEXT,
                 created_at           TEXT NOT NULL,
                 updated_at           TEXT NOT NULL,
                 deleted_at           TEXT,
@@ -520,6 +526,14 @@ impl LocalCacheStore {
         )
         .await
         .map_err(|e| format!("Failed to create session table: {}", e))?;
+
+        // Additive migrations for existing DBs (idempotent; ignore errors).
+        conn.execute("ALTER TABLE session ADD COLUMN source TEXT", ())
+            .await
+            .ok();
+        conn.execute("ALTER TABLE session ADD COLUMN cron_job_id TEXT", ())
+            .await
+            .ok();
 
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_session_team ON session(team_id, last_message_at)",
@@ -967,8 +981,9 @@ impl LocalCacheStore {
                 "INSERT INTO session
                     (id, team_id, title, mode, primary_agent_id, idea_id, summary,
                      last_message_preview, last_message_at, created_by, metadata_json,
+                     source, cron_job_id,
                      created_at, updated_at, deleted_at, synced_at)
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17)
                  ON CONFLICT(id) DO UPDATE SET
                     team_id              = excluded.team_id,
                     title                = excluded.title,
@@ -980,6 +995,8 @@ impl LocalCacheStore {
                     last_message_at      = excluded.last_message_at,
                     created_by           = excluded.created_by,
                     metadata_json        = excluded.metadata_json,
+                    source               = excluded.source,
+                    cron_job_id          = excluded.cron_job_id,
                     created_at           = excluded.created_at,
                     updated_at           = excluded.updated_at,
                     deleted_at           = excluded.deleted_at,
@@ -997,6 +1014,8 @@ impl LocalCacheStore {
                     opt_val(&r.last_message_at),
                     opt_val(&r.created_by),
                     opt_val(&r.metadata_json),
+                    opt_val(&r.source),
+                    opt_val(&r.cron_job_id),
                     r.created_at.clone(),
                     r.updated_at.clone(),
                     opt_val(&r.deleted_at),
@@ -1018,11 +1037,13 @@ impl LocalCacheStore {
         let sql = if include_deleted {
             "SELECT id, team_id, title, mode, primary_agent_id, idea_id, summary,
                     last_message_preview, last_message_at, created_by, metadata_json,
+                    source, cron_job_id,
                     created_at, updated_at, deleted_at, synced_at
              FROM session WHERE team_id = ?1 ORDER BY last_message_at DESC"
         } else {
             "SELECT id, team_id, title, mode, primary_agent_id, idea_id, summary,
                     last_message_preview, last_message_at, created_by, metadata_json,
+                    source, cron_job_id,
                     created_at, updated_at, deleted_at, synced_at
              FROM session WHERE team_id = ?1 AND deleted_at IS NULL ORDER BY last_message_at DESC"
         };
@@ -1048,10 +1069,12 @@ impl LocalCacheStore {
                 last_message_at: row.get::<String>(8).ok().filter(|s| !s.is_empty()),
                 created_by: row.get::<String>(9).ok().filter(|s| !s.is_empty()),
                 metadata_json: row.get::<String>(10).ok().filter(|s| !s.is_empty()),
-                created_at: row.get::<String>(11).unwrap_or_default(),
-                updated_at: row.get::<String>(12).unwrap_or_default(),
-                deleted_at: row.get::<String>(13).ok().filter(|s| !s.is_empty()),
-                synced_at: row.get::<String>(14).unwrap_or_default(),
+                source: row.get::<String>(11).ok().filter(|s| !s.is_empty()),
+                cron_job_id: row.get::<String>(12).ok().filter(|s| !s.is_empty()),
+                created_at: row.get::<String>(13).unwrap_or_default(),
+                updated_at: row.get::<String>(14).unwrap_or_default(),
+                deleted_at: row.get::<String>(15).ok().filter(|s| !s.is_empty()),
+                synced_at: row.get::<String>(16).unwrap_or_default(),
             });
         }
         Ok(result)
@@ -2287,6 +2310,8 @@ mod tests {
             last_message_at: None,
             created_by: None,
             metadata_json: None,
+            source: None,
+            cron_job_id: None,
             created_at: "2024-01-01T00:00:00Z".to_string(),
             updated_at: "2024-01-01T00:00:00Z".to_string(),
             deleted_at: None,
@@ -2375,6 +2400,28 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn session_source_and_cron_job_id_round_trip() {
+        let (store, _dir) = new_store().await;
+        let mut cron = session("s-cron", "teamA");
+        cron.source = Some("cron".to_string());
+        cron.cron_job_id = Some("job-42".to_string());
+        store
+            .session_upsert_batch(&[cron, session("s-user", "teamA")])
+            .await
+            .unwrap();
+
+        let rows = store.session_load_team("teamA", false).await.unwrap();
+        let loaded_cron = rows.iter().find(|r| r.id == "s-cron").unwrap();
+        assert_eq!(loaded_cron.source.as_deref(), Some("cron"));
+        assert_eq!(loaded_cron.cron_job_id.as_deref(), Some("job-42"));
+
+        // A plain session has no source/cron marker after the round-trip.
+        let loaded_user = rows.iter().find(|r| r.id == "s-user").unwrap();
+        assert_eq!(loaded_user.source, None);
+        assert_eq!(loaded_user.cron_job_id, None);
     }
 
     #[tokio::test]

--- a/docs/openapi/teamclaw-api.v1.yaml
+++ b/docs/openapi/teamclaw-api.v1.yaml
@@ -3741,6 +3741,20 @@ components:
             - "null"
         hasUnread:
           type: boolean
+        source:
+          description: >-
+            How the session was created. 'user' for normal sessions, 'cron' for
+            sessions auto-created by a scheduled task, 'gateway' for gateway
+            (WeCom etc.) bindings.
+          type: string
+          enum: [user, cron, gateway]
+        cronJobId:
+          description: >-
+            For source='cron', the desktop-local cron job id that created this
+            session (a daemon-local string id, not a cloud reference).
+          type:
+            - string
+            - "null"
         createdAt:
           type:
             - string

--- a/packages/app/src/components/chat/SessionList.tsx
+++ b/packages/app/src/components/chat/SessionList.tsx
@@ -137,11 +137,16 @@ export function SessionList({ compact, onSessionSelected }: SessionListProps) {
   const showCronSessions = useCronStore(s => s.showCronSessions)
 
   const parentSessions = useMemo(() => {
+    // Persisted `source` is the authority for scheduled-origin sessions; the
+    // `cronSessionIds` overlay is only an optimistic fallback for a just-created
+    // cron session whose row hasn't synced `source` yet.
+    const isCron = (s: typeof allSessions[number]) =>
+      s.source === 'cron' || cronSessionIds.has(s.id)
     return allSessions.filter(s => {
       if (s.parentID) return false
       return showCronSessions
-        ? cronSessionIds.has(s.id)
-        : !cronSessionIds.has(s.id) || s.id === activeSessionId
+        ? isCron(s)
+        : !isCron(s) || s.id === activeSessionId
     })
   }, [allSessions, cronSessionIds, showCronSessions, activeSessionId])
 

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -64,6 +64,7 @@ type ListRow = {
   ideaId: string | null
   isPinned: boolean
   hasUnread: boolean
+  source: string | null
 }
 
 function entryToRow(entry: SessionListEntry, isPinned: boolean): ListRow {
@@ -77,6 +78,7 @@ function entryToRow(entry: SessionListEntry, isPinned: boolean): ListRow {
     ideaId: entry.idea_id,
     isPinned,
     hasUnread: entry.has_unread,
+    source: entry.source ?? null,
   }
 }
 
@@ -282,9 +284,11 @@ export function SessionListColumn({
     let base = listRows.map((r) => entryToRow(r, pinnedSet.has(r.id)))
     const isClockView = filter.kind === 'all' && showCronSessions
 
-    base = base.filter((r) =>
-      isClockView ? cronSessionIds.has(r.id) : !cronSessionIds.has(r.id),
-    )
+    // A session is scheduled-origin when its persisted `source` says so. The
+    // local `cronSessionIds` overlay is kept only as an optimistic fallback for
+    // a just-created cron session whose list row hasn't synced `source` yet.
+    const isCron = (r: ListRow) => r.source === 'cron' || cronSessionIds.has(r.id)
+    base = base.filter((r) => (isClockView ? isCron(r) : !isCron(r)))
 
     if (filter.kind === 'pinned') {
       base = base.filter((r) => r.isPinned)

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -649,9 +649,14 @@ export function useCronInit() {
     (async () => {
       const { listen } = await import("@tauri-apps/api/event");
       if (cancelled) return;
+      // Scheduled sessions are now identified by their persisted `source ===
+      // 'cron'`, so a cron-session change just needs the session list re-pulled
+      // (the fresh rows carry `source`); no separate id scan.
       unlisten = await listen("cron:cron-sessions-updated", () => {
-        useCronStore.getState().loadCronSessionIds().catch((err: unknown) => {
-          console.warn("[App] Cron session IDs refresh failed (non-critical):", err);
+        void import("@/stores/session-list-store").then(({ useSessionListStore }) =>
+          useSessionListStore.getState().load(),
+        ).catch((err: unknown) => {
+          console.warn("[App] Session list refresh failed (non-critical):", err);
         });
       });
 

--- a/packages/app/src/lib/backend/cloud-api/sessions.ts
+++ b/packages/app/src/lib/backend/cloud-api/sessions.ts
@@ -19,6 +19,8 @@ type CloudSession = {
   lastMessageAt: string | null;
   lastMessagePreview: string | null;
   hasUnread: boolean;
+  source?: string | null;
+  cronJobId?: string | null;
   createdAt: string | null;
   updatedAt: string | null;
 };
@@ -45,6 +47,8 @@ function mapSessionDetail(row: CloudSessionDetail): SessionDetailRow {
     last_message_preview: row.lastMessagePreview,
     acp_session_id: row.acpSessionId ?? null,
     binding: row.binding ?? null,
+    source: row.source ?? null,
+    cron_job_id: row.cronJobId ?? null,
     created_at: row.createdAt,
     updated_at: row.updatedAt,
   };
@@ -62,6 +66,8 @@ function mapSession(row: CloudSession) {
     mode: row.mode,
     idea_id: row.ideaId,
     has_unread: row.hasUnread,
+    source: row.source ?? null,
+    cron_job_id: row.cronJobId ?? null,
     created_at: row.createdAt,
     updated_at: row.updatedAt,
   };

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -88,6 +88,10 @@ export interface SessionListEntry {
   mode: "solo" | "collab" | "control";
   idea_id: string | null;
   has_unread: boolean;
+  /** How the session was created: 'user' | 'cron' | 'gateway'. */
+  source?: string | null;
+  /** For source='cron', the cron job id that created it. */
+  cron_job_id?: string | null;
   created_at: string | null;
   updated_at: string | null;
 }
@@ -103,6 +107,8 @@ export interface SessionSyncRow {
   last_message_preview?: string | null;
   last_message_at?: string | null;
   created_by_actor_id?: string | null;
+  source?: string | null;
+  cron_job_id?: string | null;
   created_at: string;
   updated_at: string;
   archived_at?: string | null;
@@ -155,6 +161,8 @@ export interface SessionDetailRow {
   last_message_preview: string | null;
   acp_session_id: string | null;
   binding: string | null;
+  source?: string | null;
+  cron_job_id?: string | null;
   created_at: string | null;
   updated_at: string | null;
 }

--- a/packages/app/src/lib/local-cache.ts
+++ b/packages/app/src/lib/local-cache.ts
@@ -51,6 +51,8 @@ export type SessionRow = {
   lastMessageAt?: string | null;
   createdBy?: string | null;
   metadataJson?: string | null;
+  source?: string | null;
+  cronJobId?: string | null;
   createdAt: string;
   updatedAt: string;
   deletedAt?: string | null;

--- a/packages/app/src/lib/sync/session-sync.ts
+++ b/packages/app/src/lib/sync/session-sync.ts
@@ -26,6 +26,8 @@ function mapRow(r: SessionSyncRow): cache.SessionRow {
     lastMessageAt: r.last_message_at ?? null,
     createdBy: r.created_by_actor_id ?? null,
     metadataJson: null,
+    source: r.source ?? null,
+    cronJobId: r.cron_job_id ?? null,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
     deletedAt: null,

--- a/packages/app/src/stores/__tests__/cron.test.ts
+++ b/packages/app/src/stores/__tests__/cron.test.ts
@@ -73,7 +73,6 @@ describe('cron store', () => {
   it('init calls cron_init and loads jobs', async () => {
     mockInvoke.mockResolvedValueOnce(undefined) // cron_init
     mockInvoke.mockResolvedValueOnce([]) // cron_list_jobs via loadJobs
-    mockInvoke.mockResolvedValueOnce([]) // cron_get_all_session_ids via loadCronSessionIds
     await useCronStore.getState().init()
     expect(mockInvoke).toHaveBeenCalledWith('cron_init', {
       scope: 'global',
@@ -88,7 +87,6 @@ describe('cron store', () => {
       selectedWorkspacePath: null,
     })
     mockInvoke.mockResolvedValueOnce(undefined)
-    mockInvoke.mockResolvedValueOnce([])
     mockInvoke.mockResolvedValueOnce([])
 
     await useCronStore.getState().init()
@@ -106,7 +104,6 @@ describe('cron store', () => {
     })
     mockInvoke.mockResolvedValueOnce(undefined) // cron_init
     mockInvoke.mockResolvedValueOnce([]) // cron_list_jobs
-    mockInvoke.mockResolvedValueOnce([]) // cron_get_all_session_ids
 
     await useCronStore.getState().init()
 
@@ -440,7 +437,6 @@ describe('cron store actions', () => {
     useCronStore.setState({ isInitialized: true })
     mockInvoke.mockResolvedValueOnce(undefined) // cron_init
     mockInvoke.mockResolvedValueOnce([]) // cron_list_jobs
-    mockInvoke.mockResolvedValueOnce([]) // cron_get_all_session_ids
     await useCronStore.getState().reinit()
     expect(useCronStore.getState().isInitialized).toBe(true)
     expect(mockInvoke).toHaveBeenNthCalledWith(1, 'cron_init', {
@@ -473,7 +469,7 @@ describe('cron store actions', () => {
           ranJob = true
           return Promise.resolve(undefined)
         default:
-          return Promise.resolve([]) // cron_get_all_session_ids, cron_list_jobs
+          return Promise.resolve([]) // cron_list_jobs, etc.
       }
     })
 
@@ -537,16 +533,6 @@ describe('cron store actions', () => {
     const runCalls = mockInvoke.mock.calls.filter((c) => c[0] === 'cron_run_job')
     expect(runCalls).toHaveLength(1)
     vi.useRealTimers()
-  })
-
-  it('loadCronSessionIds passes scope args', async () => {
-    mockInvoke.mockResolvedValueOnce(['sess-1'])
-    await useCronStore.getState().loadCronSessionIds()
-    expect(mockInvoke).toHaveBeenCalledWith('cron_get_all_session_ids', {
-      scope: 'global',
-      workspacePath: null,
-    })
-    expect(useCronStore.getState().cronSessionIds).toEqual(new Set(['sess-1']))
   })
 
   it('refreshDelivery invokes cron_refresh_delivery', async () => {

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -152,7 +152,10 @@ interface CronState {
   activeScope: CronScope
   selectedWorkspacePath: string | null
 
-  // All session IDs created by cron (for filtering in session list)
+  // Optimistic overlay of just-created cron session ids, for the session-list
+  // filter. Scheduled sessions are identified by their persisted `source ===
+  // 'cron'`; this set only covers a freshly-created session whose list row
+  // hasn't synced `source` yet (see runJob).
   cronSessionIds: Set<string>
   // Toggle to show only cron sessions in the session list
   showCronSessions: boolean
@@ -170,7 +173,6 @@ interface CronState {
   setScope: (scope: CronScope) => Promise<void>
   setSelectedWorkspacePath: (workspacePath: string | null) => Promise<void>
   loadJobs: () => Promise<void>
-  loadCronSessionIds: () => Promise<void>
   addJob: (request: CreateCronJobRequest) => Promise<CronJob>
   updateJob: (request: UpdateCronJobRequest) => Promise<CronJob>
   removeJob: (jobId: string) => Promise<void>
@@ -209,7 +211,7 @@ export const useCronStore = create<CronState>((set, get) => ({
     try {
       await invoke('cron_init', cronInvokeArgs(get().activeScope, get().selectedWorkspacePath))
       set({ isInitialized: true })
-      await Promise.all([get().loadJobs(), get().loadCronSessionIds()])
+      await get().loadJobs()
     } catch (error) {
       console.error('[Cron] Init failed:', error)
       set({ error: error instanceof Error ? error.message : String(error) })
@@ -221,7 +223,7 @@ export const useCronStore = create<CronState>((set, get) => ({
       set({ isInitialized: false })
       await invoke('cron_init', cronInvokeArgs(get().activeScope, get().selectedWorkspacePath))
       set({ isInitialized: true })
-      await Promise.all([get().loadJobs(), get().loadCronSessionIds()])
+      await get().loadJobs()
     } catch (error) {
       console.error('[Cron] Re-init failed:', error)
       set({ error: error instanceof Error ? error.message : String(error) })
@@ -370,38 +372,22 @@ export const useCronStore = create<CronState>((set, get) => ({
       void get().loadJobs()
 
       if (sessionId) {
-        // Refresh the authoritative cron session ids first, then add this run's
-        // session on top. The backend eagerly creates the session and stamps
-        // session_id before the turn runs, but cron_get_all_session_ids can lag
-        // that write by a beat, so without the optimistic add, turning the filter
-        // on could momentarily hide this brand-new session. (Order matters:
-        // loadCronSessionIds overwrites the set, so it must run before the add.)
-        await get().loadCronSessionIds()
+        // Optimistically mark this brand-new session as cron-origin. Scheduled
+        // sessions are identified by their persisted `source === 'cron'`, but
+        // the list row for a session created moments ago may not have synced
+        // that field yet, so seed the overlay to avoid a flicker when the filter
+        // is on. The synced `source` takes over on the next list refresh.
         set((state) => ({ cronSessionIds: new Set([...state.cronSessionIds, sessionId]) }))
         get().setShowCronSessions(true)
         // Close the settings pane, jump to the main chat view, and open the
         // session so the user watches it run live.
         const { useUIStore } = await import('@/stores/ui')
         await useUIStore.getState().switchToSession(sessionId)
-      } else {
-        void get().loadCronSessionIds()
       }
     } catch (error) {
       set({ error: error instanceof Error ? error.message : String(error) })
     } finally {
       markIdle()
-    }
-  },
-
-  loadCronSessionIds: async () => {
-    try {
-      const ids = await invoke<string[]>(
-        'cron_get_all_session_ids',
-        cronInvokeArgs(get().activeScope, get().selectedWorkspacePath),
-      )
-      set({ cronSessionIds: new Set(ids) })
-    } catch (error) {
-      console.error('[Cron] Failed to load cron session IDs:', error)
     }
   },
 

--- a/packages/app/src/stores/session-list-store.ts
+++ b/packages/app/src/stores/session-list-store.ts
@@ -82,6 +82,10 @@ export interface SessionListEntry {
   mode: "solo" | "collab" | "control";
   idea_id: string | null;
   has_unread: boolean;
+  /** How the session was created: 'user' | 'cron' | 'gateway'. */
+  source?: string | null;
+  /** For source='cron', the cron job id that created it. */
+  cron_job_id?: string | null;
   created_at: string | null;
   updated_at: string | null;
 }
@@ -96,6 +100,8 @@ function mapCacheToEntry(r: SessionRow): SessionListEntry {
     mode: (r.mode as SessionListEntry["mode"]) ?? "solo",
     idea_id: r.ideaId ?? null,
     has_unread: false,
+    source: r.source ?? null,
+    cron_job_id: r.cronJobId ?? null,
     created_at: r.createdAt ?? null,
     updated_at: r.updatedAt ?? null,
   };
@@ -253,6 +259,8 @@ export const useSessionListStore = create<State>((set, get) => ({
         lastMessageAt: r.last_message_at ?? null,
         createdBy: null,
         metadataJson: null,
+        source: r.source ?? null,
+        cronJobId: r.cron_job_id ?? null,
         createdAt: r.created_at ?? new Date().toISOString(),
         updatedAt: r.updated_at ?? new Date().toISOString(),
         deletedAt: null,

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -256,6 +256,8 @@ function adaptSessionRow(r: Compat): Compat {
     messages: [],
     parentID: null,
     ideaId: r.idea_id ?? null,
+    source: r.source ?? undefined,
+    cronJobId: r.cron_job_id ?? null,
   };
 }
 

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -197,6 +197,11 @@ export interface Session {
   isArchived?: boolean;
   archivedAt?: Date;
   ideaId?: string | null;
+  /** How the session was created. 'cron' marks sessions auto-created by a
+   *  scheduled task; undefined/'user' for normal sessions. */
+  source?: "user" | "cron" | "gateway";
+  /** For source='cron', the cron job id that created this session. */
+  cronJobId?: string | null;
 }
 
 // Child session (subagent) streaming state

--- a/services/fc/src/db/migrations/0015_sessions_source_cron_job_id.sql
+++ b/services/fc/src/db/migrations/0015_sessions_source_cron_job_id.sql
@@ -1,0 +1,20 @@
+-- Session origin marker (postgres backend).
+-- Mirrors services/supabase/migrations/20260723000000_sessions_source_cron_job_id.sql.
+--
+--   source      — 'user' (default) | 'cron' | 'gateway'.
+--   cron_job_id — for source='cron', the desktop-local cron job id that created
+--                 the session (a daemon-local string id, not a cloud FK).
+
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "source" text NOT NULL DEFAULT 'user';
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "cron_job_id" text;
+
+-- Backfill origin for pre-existing cron sessions from their gateway binding key.
+UPDATE "sessions"
+SET "source" = 'cron',
+    "cron_job_id" = split_part("binding", '/', 2)
+WHERE "source" = 'user'
+  AND "binding" LIKE 'cron/%';
+
+CREATE INDEX IF NOT EXISTS "sessions_cron_job_id_idx"
+  ON "sessions" ("cron_job_id")
+  WHERE "cron_job_id" IS NOT NULL;

--- a/services/fc/src/db/schema/sessions.ts
+++ b/services/fc/src/db/schema/sessions.ts
@@ -18,6 +18,11 @@ export const sessions = pgTable("sessions", {
   acpSessionId: text("acp_session_id"),
   /** Gateway binding key (unique per team); used by ensureGatewaySession */
   binding: text("binding"),
+  /** How the session was created: 'user' (default) | 'cron' | 'gateway'. */
+  source: text("source").notNull().default("user"),
+  /** For source='cron': the desktop-local cron job id that created it
+   *  (a daemon-local string id, not a cloud FK). */
+  cronJobId: text("cron_job_id"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 }, (t) => ({

--- a/services/fc/src/lib/pg-repo/sessions.ts
+++ b/services/fc/src/lib/pg-repo/sessions.ts
@@ -78,6 +78,8 @@ function mapSessionFull(r: any, participants: any[] = []) {
     hasUnread: false,
     acpSessionId: r.acpSessionId ?? null,
     binding: r.binding ?? null,
+    source: r.source ?? "user",
+    cronJobId: r.cronJobId ?? null,
     createdAt: iso(r.createdAt)!,
     updatedAt: iso(r.updatedAt)!,
     participants,
@@ -108,6 +110,8 @@ function mapSessionSyncRow(r: any) {
     last_message_preview: r.lastMessagePreview ?? null,
     last_message_at: iso(r.lastMessageAt),
     created_by_actor_id: r.createdByActorId ?? null,
+    source: r.source ?? "user",
+    cron_job_id: r.cronJobId ?? null,
     created_at: iso(r.createdAt),
     updated_at: iso(r.updatedAt),
   };
@@ -213,6 +217,8 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
           sessions.title,
           sessions.last_message_preview AS "lastMessagePreview",
           sessions.last_message_at AS "lastMessageAt",
+          sessions.source,
+          sessions.cron_job_id AS "cronJobId",
           sessions.created_at AS "createdAt",
           sessions.updated_at AS "updatedAt",
           CASE
@@ -242,6 +248,8 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
         lastMessageAt: iso(r.lastMessageAt),
         lastMessagePreview: r.lastMessagePreview ?? null,
         hasUnread: r.hasUnread === true,
+        source: r.source ?? "user",
+        cronJobId: r.cronJobId ?? null,
         createdAt: iso(r.createdAt)!,
         updatedAt: iso(r.updatedAt)!,
       }));
@@ -520,6 +528,7 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
           primaryAgentId: input.primaryAgentActorId,
           createdByActorId: input.primaryAgentActorId,
           binding: input.binding,
+          source: "gateway",
         })
         .returning();
 
@@ -553,6 +562,7 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
       primaryAgentActorId: string;
       title: string;
       createdByActorId?: string;
+      cronJobId?: string | null;
     }) {
       const id = input.id ?? crypto.randomUUID();
       const [r] = await (db.insert(sessions) as any)
@@ -563,6 +573,8 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
           mode: "collab",
           primaryAgentId: input.primaryAgentActorId,
           createdByActorId: input.createdByActorId ?? input.primaryAgentActorId,
+          source: "cron",
+          cronJobId: input.cronJobId ?? null,
         })
         .returning();
 
@@ -628,6 +640,8 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
         summary: r.summary ?? null,
         lastMessageAt: iso(r.lastMessageAt),
         lastMessagePreview: r.lastMessagePreview ?? null,
+        source: r.source ?? "user",
+        cronJobId: r.cronJobId ?? null,
         participantCount: counts[r.id] ?? 0,
         hasUnread: false,
         createdAt: iso(r.createdAt)!,

--- a/services/fc/src/lib/routes/sessions.ts
+++ b/services/fc/src/lib/routes/sessions.ts
@@ -136,6 +136,7 @@ export function registerSessions(router) {
     for (const k of ["teamId", "primaryAgentActorId", "title"]) {
       requireString(body[k], k);
     }
+    // cronJobId is optional (daemon-local id); passed through when present.
     const out = await ctx.repository.createCronSession(body);
     return { body: out };
   });

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -2174,6 +2174,8 @@ export function createSupabaseBusinessRepository(options) {
         title: input.title,
         mode: "collab",
         primary_agent_id: input.primaryAgentActorId,
+        source: "cron",
+        cron_job_id: input.cronJobId ?? null,
       };
       if (input.createdByActorId) insertRow.created_by_actor_id = input.createdByActorId;
       else insertRow.created_by_actor_id = input.primaryAgentActorId;

--- a/services/fc/src/lib/supabase-repo/shared.ts
+++ b/services/fc/src/lib/supabase-repo/shared.ts
@@ -94,7 +94,7 @@ export function mapApp(r: any) {
 }
 
 export const SESSION_FULL_COLUMNS =
-  "id, team_id, title, mode, idea_id, primary_agent_id, created_by_actor_id, summary, last_message_preview, last_message_at, acp_session_id, binding, created_at, updated_at";
+  "id, team_id, title, mode, idea_id, primary_agent_id, created_by_actor_id, summary, last_message_preview, last_message_at, acp_session_id, binding, source, cron_job_id, created_at, updated_at";
 
 export const ACTOR_DIRECTORY_COLUMNS =
   "id, team_id, actor_type, user_id, invited_by_actor_id, display_name, avatar_url, team_role, member_status, agent_status, agent_types, default_agent_type, default_workspace_id, agent_visibility, last_active_at, created_at, updated_at, user_email, user_phone";
@@ -114,6 +114,8 @@ export function mapSessionFull(row) {
     hasUnread: false,
     acpSessionId: row?.acp_session_id ?? null,
     binding: row?.binding ?? null,
+    source: row?.source ?? "user",
+    cronJobId: row?.cron_job_id ?? null,
     createdAt: row?.created_at ?? null,
     updatedAt: row?.updated_at ?? null,
   };

--- a/services/fc/test/pg-repo-sessions.test.ts
+++ b/services/fc/test/pg-repo-sessions.test.ts
@@ -57,6 +57,7 @@ test("listSessions returns canonical contract keys for actor-visible sessions", 
   const contractKeys = [
     "id", "teamId", "title", "mode", "ideaId",
     "lastMessageAt", "lastMessagePreview", "hasUnread",
+    "source", "cronJobId",
     "createdAt", "updatedAt",
   ].sort();
   assert.deepEqual(Object.keys(rows[0]).sort(), contractKeys);

--- a/services/supabase/migrations/20260723000000_sessions_source_cron_job_id.sql
+++ b/services/supabase/migrations/20260723000000_sessions_source_cron_job_id.sql
@@ -1,0 +1,33 @@
+-- Mark how a session was created and, for scheduled ones, which cron job made it.
+--
+-- Before this, the only way to know a session was auto-created by a scheduled
+-- (cron) task was to scan the desktop daemon's local run-history .jsonl files
+-- (cron/storage.rs get_all_session_ids) — device-local, not shared, not
+-- queryable. These two columns move that fact onto the session row itself:
+--
+--   source      — 'user' (default) | 'cron' | 'gateway'. Semantic origin marker,
+--                 extensible to future sources (api, subagent, ...).
+--   cron_job_id — for source='cron', the desktop-local cron job id that created
+--                 it (a daemon-local string id, NOT a cloud FK). Lets us answer
+--                 "which sessions did this scheduled task create".
+--
+-- Idempotent (IF NOT EXISTS) so the self-host apply-migrations loop can re-run.
+
+ALTER TABLE amux.sessions
+  ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'user';
+
+ALTER TABLE amux.sessions
+  ADD COLUMN IF NOT EXISTS cron_job_id text;
+
+-- Backfill: sessions whose gateway binding key is a cron key (`cron/<job>/<run>`)
+-- predate this column. Recover their origin from the binding.
+UPDATE amux.sessions
+SET source = 'cron',
+    cron_job_id = split_part(binding, '/', 2)
+WHERE source = 'user'
+  AND binding LIKE 'cron/%';
+
+-- Partial index for the common "list this cron job's sessions" query.
+CREATE INDEX IF NOT EXISTS sessions_cron_job_id_idx
+  ON amux.sessions (cron_job_id)
+  WHERE cron_job_id IS NOT NULL;


### PR DESCRIPTION
## 背景

Session 之前没有一个**持久化、可查询**的字段来标识它是否由定时（cron）任务自动创建。唯一的信号存在桌面 daemon 本地的 run-history `.jsonl` 里（`cron/storage.rs` 的 `get_all_session_ids`）—— 设备本地、不跨端、不可 SQL 查询。

## 方案

给 session 加两列并端到端接通：

- **`source`** — `'user'`（默认）｜ `'cron'` ｜ `'gateway'`。可扩展的来源标记，可索引可过滤。
- **`cron_job_id`** — 当 `source='cron'` 时，创建它的桌面本地 cron job id（daemon 本地字符串，非云端 FK）。

## 改动范围

- **DB**：supabase migration 加两列 + 从 `cron/<job>/<run>` 的 gateway binding 回填历史 cron session + partial index；FC drizzle migration 镜像一份（供 pglite 测试库）。
- **FC Cloud API**：`createCronSession` 写 `source='cron'` + `cronJobId`，`ensureGatewaySession` 写 `source='gateway'`；所有读路径 / sync row / OpenAPI `Session` schema 带出字段。
- **daemon**：`Backend::create_cron_session` 新增 `cron_job_id` 参数（从 `cron/<jobId>/<runId>` session key 解析），覆盖全部 impl。
- **前端**：`source` 经 cloud-api mapper → list store → libsql 缓存（新列 + 幂等 `ALTER TABLE` 迁移）→ `Session` 模型全程流通。session 列表的 cron 过滤器改用 `source === 'cron'`（`cronSessionIds` 降级为“刚创建”的乐观兜底），替掉 jsonl 扫描。
- **清理**：删除已死的 `cron_get_all_session_ids` 命令 + `get_all_session_ids` storage 方法。

## 手工迁移

生产 Postgres（`amux` schema）需手工执行 `services/supabase/migrations/20260723000000_sessions_source_cron_job_id.sql`。libsql 缓存在 app 启动时自动 `ALTER TABLE ADD COLUMN` 补列，无需手工。

## 验证

- FC `232 passed`；daemon `cargo check --tests` 0 error + cron/backend 单测通过（含新增 `cron_job_id_from_session_key` 解析测试）。
- desktop `cargo check --tests` 0 error；`local_cache` `13 passed`（含新增 source/cron_job_id 缓存往返测试）。
- 前端 `typecheck` 0 error；sync + cron + cloud-api 单测通过。
- ⚠️ `SessionListColumn.test.tsx` 有 3 个 pinned 相关失败，已在干净 base commit 复现，为 main 上**预先存在**、与本次无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)