### PR TITLE
fix(extension): hide scheduled-session filter in embed mode

### DIFF
--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -863,7 +863,7 @@ export function SessionListColumn({
               <Search className="h-4 w-4" />
             </Button>
           ) : null}
-          {!batchSelecting && filter.kind === 'all' && (
+          {!batchSelecting && !embedMode && filter.kind === 'all' && (
             <Button
               variant="ghost"
               size="icon"

--- a/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
@@ -300,15 +300,15 @@ describe('SessionListColumn', () => {
     })
   })
 
-  it('enables search and cron buttons in embed mode without a local workspace', () => {
+  it('enables search and hides cron filter in embed mode without a local workspace', () => {
     useUIStore.setState({ embedMode: true })
     useWorkspaceStore.setState({ workspacePath: null })
     render(<SessionListColumn onDismiss={() => {}} />)
 
     expect(screen.getByRole('button', { name: /Search|搜索/ })).not.toBeDisabled()
     expect(
-      screen.getByRole('button', { name: /Show scheduled sessions|Show all sessions|定时/ }),
-    ).not.toBeDisabled()
+      screen.queryByRole('button', { name: /Show scheduled sessions|Show all sessions|定时/ }),
+    ).not.toBeInTheDocument()
   })
 
   it('enters batch select mode and archives selected sessions', async () => {


### PR DESCRIPTION
## Summary
- Hide the scheduled-sessions (clock) filter button in the session list when running in extension embed mode.
- No change to session list filtering logic.

## Test plan
- [ ] Extension / embed: session list header has no clock / scheduled filter button
- [ ] Desktop: scheduled filter button still works as before
- [ ] `pnpm --filter @teamclaw/app exec vitest run src/components/sidebar/__tests__/SessionListColumn.test.tsx -t 'embed mode'`


Made with [Cursor](https://cursor.com)