### PR TITLE
fix(deps): resolve opencode by absolute path in dependency check

### DIFF
--- a/apps/desktop/src/commands/deps.rs
+++ b/apps/desktop/src/commands/deps.rs
@@ -39,6 +39,33 @@ pub struct DepInstallProgress {
     pub error: Option<String>,
 }
 
+/// Resolve the program to probe for a dependency's `--version` check.
+///
+/// For most tools this is just the dependency name looked up on PATH. opencode
+/// is the exception: its official installer hardcodes `~/.opencode/bin`, which is
+/// NOT on the PATH a GUI app inherits when launched from Finder — so a bare
+/// `Command::new("opencode")` probe fails even though the binary is installed and
+/// amuxd (which resolves it by absolute path) runs it fine. Mirror amuxd's
+/// resolution order here: `~/.opencode/bin/opencode` (absolute) -> PATH fallback.
+/// See apps/daemon/src/opencode_install/mod.rs `resolve_binary`.
+fn probe_program(name: &str) -> String {
+    if name != "opencode" {
+        return name.to_string();
+    }
+    let bin = if cfg!(windows) {
+        "opencode.exe"
+    } else {
+        "opencode"
+    };
+    if let Some(home) = dirs::home_dir() {
+        let p = home.join(".opencode").join("bin").join(bin);
+        if p.exists() {
+            return p.to_string_lossy().to_string();
+        }
+    }
+    "opencode".to_string()
+}
+
 /// Check a single dependency by running `cmd --version` (or a variant).
 /// Returns a DependencyInfo with installed status and parsed version.
 fn check_single_dependency(
@@ -50,7 +77,10 @@ fn check_single_dependency(
     affected_features: Vec<String>,
     priority: u8,
 ) -> DependencyInfo {
-    let output = Command::new(name).no_window().args(version_args).output();
+    let output = Command::new(probe_program(name))
+        .no_window()
+        .args(version_args)
+        .output();
 
     match output {
         Ok(o) if o.status.success() => {
@@ -507,4 +537,30 @@ async fn run_install<R: Runtime>(app: &AppHandle<R>, name: &str) -> bool {
     }
 
     success
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_program_passes_through_non_opencode() {
+        assert_eq!(probe_program("git"), "git");
+        assert_eq!(probe_program("node"), "node");
+    }
+
+    #[test]
+    fn probe_program_resolves_opencode_absolute_when_present() {
+        // opencode's official installer targets ~/.opencode/bin; when that binary
+        // exists the probe must use its absolute path, not the bare PATH name a
+        // Finder-launched GUI can't resolve.
+        let bin = if cfg!(windows) { "opencode.exe" } else { "opencode" };
+        let expected = dirs::home_dir().map(|h| h.join(".opencode").join("bin").join(bin));
+        let got = probe_program("opencode");
+        match expected {
+            Some(p) if p.exists() => assert_eq!(got, p.to_string_lossy()),
+            // No installed binary in this environment: falls back to PATH lookup.
+            _ => assert_eq!(got, "opencode"),
+        }
+    }
 }


### PR DESCRIPTION
## Problem

First-run **需要设置 (Setup required)** gets stuck: `opencode` shows as missing (red 必需) and the gate never clears, even though opencode is installed and `amuxd install-opencode` reports it satisfied. Hitting **重新检查 / 安装所有必需项** loops forever.

Root cause: the dependency check probed opencode with a bare `Command::new("opencode")`, which only searches `PATH`. opencode's official installer hardcodes `~/.opencode/bin` (upstream), and that dir is **not** on the `PATH` a GUI app inherits when launched from Finder. So the desktop check fails while amuxd — which resolves opencode by absolute path — runs it fine. The daemon already documents this exact hazard in `apps/daemon/src/opencode_install/mod.rs`:

> The absolute step matters for a background service whose PATH excludes ~/.opencode/bin.

The desktop deps check simply never got the same treatment.

## Fix

Add `probe_program(name)` in `apps/desktop/src/commands/deps.rs` that mirrors amuxd's `resolve_binary` order for opencode: probe `~/.opencode/bin/opencode` (`.exe` on Windows) by absolute path first, fall back to a PATH lookup. Every other dependency still probes by bare name — no behavior change for brew/git/gh/node/python3.

## Testing

- `cargo check -p teamclaw` ✅
- Added unit tests: pass-through for non-opencode names; opencode resolves to the absolute `~/.opencode/bin` path when the binary exists, else falls back to `"opencode"`.

## Note

A customer hit this in the field. Immediate unblock without shipping this build is to symlink the binary onto PATH:

```bash
ln -sf ~/.opencode/bin/opencode /opt/homebrew/bin/opencode
```

then re-check. This PR fixes the root cause so no symlink is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)