### PR TITLE
feat(teams): public/private visibility + self-service join of public default-org teams

### DIFF
--- a/docs/openapi/teamclaw-api.v1.yaml
+++ b/docs/openapi/teamclaw-api.v1.yaml
@@ -67,6 +67,19 @@ paths:
       operationId: listTeams
       summary: List teams
       tags: [Teams]
+      parameters:
+        - name: scope
+          in: query
+          required: false
+          description: |
+            `all` returns the cross-org team picker source: the caller's teams
+            across every org, unioned with PUBLIC teams in the shared
+            DEFAULT_ORG the caller may join (each carrying `isMember`). Omitted
+            returns only teams in the caller's current org that they are an
+            actor in.
+          schema:
+            type: string
+            enum: [all]
       responses:
         "200":
           description: Current user's teams.
@@ -173,25 +186,29 @@ paths:
         "404":
           $ref: "#/components/responses/Error"
     patch:
-      operationId: renameTeam
-      summary: Rename team
+      operationId: updateTeam
+      summary: Update team (rename and/or visibility)
       tags: [Teams]
       parameters:
         - $ref: "#/components/parameters/TeamId"
       requestBody:
         required: true
+        description: At least one of `name` or `visibility` must be provided.
         content:
           application/json:
             schema:
               type: object
-              required: [name]
+              minProperties: 1
               properties:
                 name:
                   type: string
                   minLength: 1
+                visibility:
+                  type: string
+                  enum: [public, private]
       responses:
         "200":
-          description: Renamed team.
+          description: Updated team.
           headers:
             X-Request-Id:
               $ref: "#/components/headers/RequestId"
@@ -202,6 +219,31 @@ paths:
         "400":
           $ref: "#/components/responses/Error"
         "401":
+          $ref: "#/components/responses/Error"
+  /v1/teams/{teamId}/join:
+    post:
+      operationId: joinPublicTeam
+      summary: Join a public team
+      description: |
+        Self-service join of a PUBLIC team in the shared DEFAULT_ORG. Adds the
+        caller as a plain `member` (idempotent if already joined). Rejects
+        teams that are not public DEFAULT_ORG teams with 403.
+      tags: [Teams]
+      parameters:
+        - $ref: "#/components/parameters/TeamId"
+      responses:
+        "200":
+          description: The joined team.
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Team"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
           $ref: "#/components/responses/Error"
   /v1/teams/{teamId}/invites:
     post:
@@ -3714,6 +3756,28 @@ components:
           type:
             - string
             - "null"
+        visibility:
+          description: |
+            Team visibility within its org. `private` (default) teams are
+            invite/bootstrap-only; `public` teams are discoverable and
+            self-service joinable by other users in the shared DEFAULT_ORG.
+          type: string
+          enum: [public, private]
+        orgId:
+          type:
+            - string
+            - "null"
+        orgName:
+          type:
+            - string
+            - "null"
+        isMember:
+          description: |
+            Present in the `GET /v1/teams?scope=all` picker listing. `false`
+            marks a public DEFAULT_ORG team the caller may join via
+            `POST /v1/teams/{teamId}/join`; `true` (or absent) means the caller
+            is already an actor in the team.
+          type: boolean
     Session:
       type: object
       required: [id, teamId, title, mode, hasUnread]

--- a/packages/app/src/components/auth/TeamPicker.tsx
+++ b/packages/app/src/components/auth/TeamPicker.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { AlertCircle, ChevronRight, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { MembershipTeam } from "@/lib/backend";
+import { getBackend } from "@/lib/backend";
 import { useCurrentTeamStore } from "@/stores/current-team";
 
 interface TeamPickerProps {
@@ -37,11 +38,17 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
     else groups.set(key, [team]);
   }
 
-  async function choose(teamId: string) {
+  async function choose(team: MembershipTeam) {
     setError(null);
-    setBusyId(teamId);
+    setBusyId(team.id);
     try {
-      await switchToTeam(teamId);
+      // Public DEFAULT_ORG teams the caller hasn't joined yet: enroll as a
+      // plain member first so switchToTeam (and every team-scoped RPC after it)
+      // has membership. Idempotent server-side.
+      if (team.isMember === false) {
+        await getBackend().teams.joinTeam(team.id);
+      }
+      await switchToTeam(team.id);
       onDone();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -83,12 +90,13 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
                   const active = team.id === highlightId;
                   const isLastUsed = team.id === lastUsedTeamId;
                   const switching = busyId === team.id;
+                  const joinable = team.isMember === false;
                   return (
                     <button
                       key={team.id}
                       type="button"
                       disabled={busyId !== null}
-                      onClick={() => void choose(team.id)}
+                      onClick={() => void choose(team)}
                       className={cn(
                         "group flex items-center justify-between rounded-[12px] border bg-paper px-4 py-3 text-left transition-colors hover:bg-selected disabled:opacity-50",
                         active ? "border-coral" : "border-border",
@@ -103,11 +111,18 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
                             {t("teamPicker.lastUsed", "Last used")}
                           </span>
                         )}
+                        {joinable && (
+                          <span className="shrink-0 rounded-full border border-border px-1.5 py-0.5 text-[10px] font-medium text-faint">
+                            {t("teamPicker.public", "Public")}
+                          </span>
+                        )}
                       </span>
                       {switching ? (
                         <span className="flex shrink-0 items-center gap-1.5 text-[11.5px] text-muted-foreground">
                           <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          {t("teamPicker.switching", "Switching…")}
+                          {joinable
+                            ? t("teamPicker.joining", "Joining…")
+                            : t("teamPicker.switching", "Switching…")}
                         </span>
                       ) : (
                         <ChevronRight className="h-4 w-4 shrink-0 text-faint transition-colors group-hover:text-muted-foreground" />

--- a/packages/app/src/lib/backend/cloud-api/teams.ts
+++ b/packages/app/src/lib/backend/cloud-api/teams.ts
@@ -6,6 +6,7 @@ type CloudTeam = {
   name: string;
   slug: string | null;
   createdAt: string | null;
+  visibility?: "public" | "private";
 };
 
 type CloudMembershipTeam = {
@@ -14,6 +15,8 @@ type CloudMembershipTeam = {
   slug: string | null;
   orgId: string | null;
   orgName: string | null;
+  visibility?: "public" | "private";
+  isMember?: boolean;
 };
 
 type CloudInvite = {
@@ -30,6 +33,7 @@ function mapTeam(row: CloudTeam): TeamSummary {
     name: row.name,
     slug: row.slug,
     created_at: row.createdAt,
+    visibility: row.visibility,
   };
 }
 
@@ -60,6 +64,12 @@ export function createTeamsModule(client: CloudApiClient): TeamsBackend {
     },
     async renameTeam(teamId: string, name: string) {
       return mapTeam(await client.patch<CloudTeam>(`/v1/teams/${encodeURIComponent(teamId)}`, { name }));
+    },
+    async setTeamVisibility(teamId: string, visibility: "public" | "private") {
+      return mapTeam(await client.patch<CloudTeam>(`/v1/teams/${encodeURIComponent(teamId)}`, { visibility }));
+    },
+    async joinTeam(teamId: string) {
+      return mapTeam(await client.post<CloudTeam>(`/v1/teams/${encodeURIComponent(teamId)}/join`, {}));
     },
     async upgradeAccount(input) {
       return client.post<{ orgId: string; teamId: string; teamName: string }>("/v1/account/upgrade", {
@@ -98,6 +108,8 @@ export function createTeamsModule(client: CloudApiClient): TeamsBackend {
         slug: r.slug,
         orgId: r.orgId,
         orgName: r.orgName,
+        visibility: r.visibility,
+        isMember: r.isMember !== false,
       }));
     },
     async activateTeam(teamId: string) {

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -326,6 +326,7 @@ export interface TeamSummary {
   name: string;
   slug?: string | null;
   created_at?: string | null;
+  visibility?: "public" | "private";
 }
 
 export interface MembershipTeam {
@@ -334,6 +335,13 @@ export interface MembershipTeam {
   slug?: string | null;
   orgId?: string | null;
   orgName?: string | null;
+  visibility?: "public" | "private";
+  /**
+   * `false` marks a PUBLIC team in the shared DEFAULT_ORG that the caller can
+   * join self-service (via `joinTeam`) but is not yet a member of. Absent or
+   * `true` means the caller is already an actor in the team.
+   */
+  isMember?: boolean;
 }
 
 export interface TeamInviteResult {
@@ -447,6 +455,13 @@ export interface TeamsBackend {
   createTeamInvite(input: TeamInviteInput): Promise<TeamInviteResult>;
   removeTeamActor(teamId: string, actorId: string): Promise<void>;
   listAllMyTeams(): Promise<MembershipTeam[]>;
+  /**
+   * Self-service join of a PUBLIC team in the shared DEFAULT_ORG (offered in the
+   * post-login picker alongside the caller's own teams). Idempotent.
+   */
+  joinTeam(teamId: string): Promise<TeamSummary>;
+  /** Toggle a team's visibility (public | private) via PATCH /v1/teams/:id. */
+  setTeamVisibility(teamId: string, visibility: "public" | "private"): Promise<TeamSummary>;
   activateTeam(teamId: string): Promise<{ actorId: string | null; teamId: string; refreshToken: string }>;
   getLiteLlmUsage(teamId: string, opts?: { range?: LiteLlmUsageRange; date?: string }): Promise<LiteLlmUsage>;
 }

--- a/services/fc/src/db/migrations/0015_add_teams_visibility.sql
+++ b/services/fc/src/db/migrations/0015_add_teams_visibility.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "teams" ADD COLUMN IF NOT EXISTS "visibility" text NOT NULL DEFAULT 'private';
+CREATE INDEX IF NOT EXISTS "idx_teams_default_org_public" ON "teams" ("oid") WHERE "visibility" = 'public';

--- a/services/fc/src/db/schema/teams.ts
+++ b/services/fc/src/db/schema/teams.ts
@@ -14,6 +14,10 @@ export const teams = pgTable("teams", {
   gitRemoteUrl: text("git_remote_url"),
   gitAuthKind: text("git_auth_kind"),
   gitCredentialRef: text("git_credential_ref"),
+  // Team visibility within its org: 'private' (default, invite/bootstrap-only)
+  // or 'public' (discoverable + self-service joinable by other users in the
+  // shared DEFAULT_ORG via the post-login team picker).
+  visibility: text("visibility").notNull().default("private"),
   // Team-wide default agent preference. FK to agents(id) with ON DELETE SET NULL
   // is declared in the migration SQL only (avoids a teams<->agents Drizzle import cycle).
   defaultAgentId: uuid("default_agent_id"),

--- a/services/fc/src/lib/pg-repo/index.ts
+++ b/services/fc/src/lib/pg-repo/index.ts
@@ -62,6 +62,8 @@ export function createPgBusinessRepository({ db, accessToken, userId, callerActo
     ...makeAttachmentsRepo(),
     listTeams: (args: { limit?: number } = {}) => teamsRepo.listTeams(args, teamsCtx),
     listAllMyTeams: () => teamsRepo.listAllMyTeams(teamsCtx),
+    joinPublicTeam: (teamId: string) => teamsRepo.joinPublicTeam(teamId, teamsCtx),
+    setTeamVisibility: (teamId: string, input: { visibility: string }) => teamsRepo.setTeamVisibility(teamId, input, teamsCtx),
     createTeam: (input: any) => teamsRepo.createTeam(input, teamsCtx),
     createTeamInvite: (teamId: string, input: any) => teamsRepo.createTeamInvite(teamId, input, teamsCtx),
     ensureMemberKey: (teamId: string) => teamsRepo.ensureMemberKey(teamId, teamsCtx),

--- a/services/fc/src/lib/pg-repo/teams.ts
+++ b/services/fc/src/lib/pg-repo/teams.ts
@@ -72,6 +72,7 @@ function mapTeam(r: any) {
     id: r.id, name: r.name, slug: r.slug, createdAt: iso(r.createdAt),
     shareMode: r.shareMode ?? null, shareEnabledAt: iso(r.shareEnabledAt),
     gitRemoteUrl: r.gitRemoteUrl ?? null, gitAuthKind: r.gitAuthKind ?? null,
+    visibility: r.visibility ?? "private",
   };
 }
 
@@ -258,21 +259,82 @@ export function makeTeamsRepo(db: PgDatabase<any, any>, deps: TeamsRepoDeps = {}
     async listAllMyTeams(ctx?: { userId?: string }) {
       const userId = ctx?.userId;
       if (!userId) throw new ApiError(401, "missing_auth", "authenticated user required");
-      const rows = await db
-        .select({ id: teams.id, name: teams.name, slug: teams.slug })
+      const defaultOrgId = process.env.DEFAULT_ORG_ID || null;
+
+      // (a) Teams the caller is already an actor in.
+      const mineRows = await db
+        .select({ id: teams.id, name: teams.name, slug: teams.slug, oid: teams.oid, visibility: teams.visibility })
         .from(teams)
         .innerJoin(actors, eq(actors.teamId, teams.id))
         .where(eq(actors.userId, userId))
         .orderBy(asc(teams.createdAt));
+
       // Dedup by team id (a user could theoretically have >1 actor per team).
       const seen = new Set<string>();
-      const out: Array<{ id: string; name: string; slug: string | null; orgId: null; orgName: null }> = [];
-      for (const r of rows) {
+      const out: Array<{ id: string; name: string; slug: string | null; orgId: string | null; orgName: null; visibility: string; isMember: boolean }> = [];
+      for (const r of mineRows) {
         if (seen.has(r.id)) continue;
         seen.add(r.id);
-        out.push({ id: r.id, name: r.name, slug: r.slug ?? null, orgId: null, orgName: null });
+        out.push({ id: r.id, name: r.name, slug: r.slug ?? null, orgId: r.oid ?? null, orgName: null, visibility: r.visibility ?? "private", isMember: true });
+      }
+
+      // (b) PUBLIC teams in the shared DEFAULT_ORG the caller can join.
+      if (defaultOrgId) {
+        const publicRows = await db
+          .select({ id: teams.id, name: teams.name, slug: teams.slug, oid: teams.oid })
+          .from(teams)
+          .where(and(eq(teams.oid, defaultOrgId), eq(teams.visibility, "public")))
+          .orderBy(asc(teams.createdAt));
+        for (const r of publicRows) {
+          if (seen.has(r.id)) continue;
+          seen.add(r.id);
+          out.push({ id: r.id, name: r.name, slug: r.slug ?? null, orgId: r.oid ?? null, orgName: null, visibility: "public", isMember: false });
+        }
       }
       return out;
+    },
+
+    // Self-service join of a PUBLIC default-org team as a plain member.
+    // Idempotent when the caller is already an actor in the team.
+    async joinPublicTeam(teamId: string, ctx?: { userId?: string }) {
+      const userId = ctx?.userId;
+      if (!userId) throw new ApiError(401, "missing_auth", "authenticated user required");
+      const defaultOrgId = process.env.DEFAULT_ORG_ID || null;
+
+      const [team] = await db.select().from(teams).where(eq(teams.id, teamId)).limit(1);
+      if (!team) throw new ApiError(404, "not_found", "team not found");
+      if (team.visibility !== "public" || !defaultOrgId || team.oid !== defaultOrgId) {
+        throw new ApiError(403, "forbidden", "team is not a joinable public team");
+      }
+
+      const [existing] = await db
+        .select({ id: actors.id })
+        .from(actors)
+        .where(and(eq(actors.teamId, teamId), eq(actors.userId, userId)))
+        .limit(1);
+      if (!existing) {
+        await (db as any).transaction(async (tx: any) => {
+          const actorId = randomUUID();
+          const displayName = generateDisplayName(actorId);
+          await tx.insert(actors).values({ id: actorId, teamId, actorType: "member", displayName, userId });
+          await tx.insert(members).values({ id: actorId, status: "active" });
+          await tx.insert(teamMembers).values({ teamId, memberId: actorId, role: "member" });
+        });
+      }
+      return mapTeam(team);
+    },
+
+    // Visibility toggle (public | private) — PATCH /v1/teams/:id.
+    async setTeamVisibility(teamId: string, { visibility }: { visibility: string }, ctx?: { userId?: string }) {
+      const userId = ctx?.userId;
+      if (!userId) throw new ApiError(401, "missing_auth", "authenticated user required");
+      if (visibility !== "public" && visibility !== "private") {
+        throw new ApiError(400, "validation_failed", "visibility must be 'public' or 'private'");
+      }
+      await requireActorForTeam(db, userId, teamId);
+      const [r] = await (db.update(teams) as any).set({ visibility, updatedAt: new Date() }).where(eq(teams.id, teamId)).returning();
+      if (!r) throw new ApiError(404, "not_found", "team not found");
+      return mapTeam(r);
     },
 
     /**

--- a/services/fc/src/lib/routes/teams.ts
+++ b/services/fc/src/lib/routes/teams.ts
@@ -62,10 +62,33 @@ export function registerTeams(router) {
     return { body: team };
   });
 
+  // PATCH /v1/teams/:id — partial update. Supports `name` (rename) and/or
+  // `visibility` ('public' | 'private'). At least one must be present.
   router.patch("/v1/teams/:teamId", async (ctx) => {
     const body = ctx.json;
-    requireString(body.name, "name");
-    const team = await ctx.repository.renameTeam(ctx.params.teamId, { name: body.name });
+    const hasName = body.name != null;
+    const hasVisibility = body.visibility != null;
+    if (!hasName && !hasVisibility) {
+      requireString(body.name, "name"); // preserves the prior 400 for empty PATCH
+    }
+    let team;
+    if (hasVisibility) {
+      requireString(body.visibility, "visibility");
+      team = await ctx.repository.setTeamVisibility(ctx.params.teamId, {
+        visibility: body.visibility,
+      });
+    }
+    if (hasName) {
+      requireString(body.name, "name");
+      team = await ctx.repository.renameTeam(ctx.params.teamId, { name: body.name });
+    }
+    return { body: team };
+  });
+
+  // POST /v1/teams/:id/join — self-service join of a PUBLIC team in the shared
+  // DEFAULT_ORG (the post-login picker offers these alongside my own teams).
+  router.post("/v1/teams/:teamId/join", async (ctx) => {
+    const team = await ctx.repository.joinPublicTeam(ctx.params.teamId);
     return { body: team };
   });
 

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -302,7 +302,15 @@ export function createSupabaseBusinessRepository(options) {
     // SECURITY DEFINER (it bypasses teams_org_guard). The default client schema
     // here is `amux`, so it resolves via a plain `.rpc(...)` like create_team etc.
     async listAllMyTeams() {
-      const { data, error } = await supabase.rpc("list_all_my_teams");
+      // Cross-org team picker source. `list_teams_for_picker` returns the union
+      // of (a) teams the caller is already an actor in and (b) PUBLIC teams in
+      // the shared DEFAULT_ORG the caller can join self-service. DEFAULT_ORG_ID
+      // is passed server-side (never client-steerable), mirroring the other
+      // onboarding RPCs.
+      const defaultOrgId = process.env.DEFAULT_ORG_ID || null;
+      const { data, error } = await supabase.rpc("list_teams_for_picker", {
+        p_default_org_id: defaultOrgId,
+      });
       if (error) throw error;
       return (data ?? []).map((r: any) => ({
         id: r.team_id,
@@ -310,7 +318,52 @@ export function createSupabaseBusinessRepository(options) {
         slug: r.team_slug ?? null,
         orgId: r.org_id ?? null,
         orgName: r.org_name ?? null,
+        visibility: r.visibility ?? "private",
+        isMember: r.is_member !== false,
       }));
+    },
+
+    // Self-service join of a PUBLIC team in the shared DEFAULT_ORG. Invoked when
+    // the user picks a public team they are not yet a member of. The RPC adds a
+    // plain 'member' actor (idempotent if already joined) and rejects anything
+    // that is not a public default-org team.
+    async joinPublicTeam(teamId) {
+      const defaultOrgId = process.env.DEFAULT_ORG_ID || null;
+      const { data, error } = await supabase.rpc("join_public_team", {
+        p_team_id: teamId,
+        p_default_org_id: defaultOrgId,
+      });
+      if (error) {
+        const code = error?.code || "";
+        if (code === "42501") throw new ApiError(403, "forbidden", error.message ?? "team is not joinable");
+        if (code === "P0002") throw new ApiError(404, "not_found", error.message ?? "team not found");
+        throw error;
+      }
+      const row = requiredRow(data, "teams.joinPublicTeam");
+      return mapTeam({
+        id: row.team_id ?? row.id,
+        name: row.team_name ?? row.name,
+        slug: row.team_slug ?? row.slug,
+      });
+    },
+
+    // Owner/member-scoped visibility toggle (public | private) for a default-org
+    // team, driven by PATCH /v1/teams/:id. RLS on amux.teams gates the write to
+    // team members.
+    async setTeamVisibility(teamId, { visibility }) {
+      if (visibility !== "public" && visibility !== "private") {
+        throw new ApiError(400, "validation_failed", "visibility must be 'public' or 'private'");
+      }
+      const { data, error } = await supabase
+        .schema("amux")
+        .from("teams")
+        .update({ visibility })
+        .eq("id", teamId)
+        .select(TEAM_COLUMNS)
+        .maybeSingle();
+      if (error) throw error;
+      if (!data) throw new ApiError(404, "not_found", "team not found");
+      return mapTeam(data);
     },
 
     async createTeam(input) {

--- a/services/fc/src/lib/supabase-repo/shared.ts
+++ b/services/fc/src/lib/supabase-repo/shared.ts
@@ -30,7 +30,7 @@ export function requiredInteger(value, operation, field) {
 // ── Column constants + row mappers (moved from supabase-repo.ts) ──
 
 export const DEFAULT_ATTACHMENT_BUCKET = "attachments";
-export const TEAM_COLUMNS = "id, name, slug, created_at";
+export const TEAM_COLUMNS = "id, name, slug, created_at, visibility";
 export const MESSAGE_COLUMNS =
   "id, team_id, session_id, turn_id, sender_actor_id, reply_to_message_id, kind, content, metadata, model, created_at, updated_at";
 export const WORKSPACE_COLUMNS =
@@ -183,6 +183,7 @@ export function mapTeam(row) {
     shareEnabledAt: row?.share_enabled_at ?? null,
     gitRemoteUrl: row?.git_remote_url ?? null,
     gitAuthKind: row?.git_auth_kind ?? null,
+    visibility: row?.visibility ?? "private",
   };
 }
 

--- a/services/supabase/migrations/20260723000000_team_visibility.sql
+++ b/services/supabase/migrations/20260723000000_team_visibility.sql
@@ -1,0 +1,153 @@
+-- Team visibility (public | private) + public-team discovery/join.
+--
+-- Goal: within the shared DEFAULT_ORG, teams marked `public` are discoverable by
+-- every user in that org and can be joined self-service from the post-login team
+-- picker. Private teams stay invite/bootstrap-only, exactly as before.
+--
+--   * amux.teams.visibility: 'private' (default) | 'public'.
+--   * amux.list_teams_for_picker(p_default_org_id): the picker's data source —
+--     union of (a) teams the caller is already an actor in (is_member=true) and
+--     (b) public teams in the default org the caller is NOT yet in
+--     (is_member=false).
+--   * amux.join_public_team(p_team_id, p_default_org_id): self-service join of a
+--     public default-org team as a plain 'member'. Unlike the first-team
+--     bootstrap RPCs, this DOES support users who already have an actor (this is
+--     their Nth team), so it must NOT reuse the first-team-only guard.
+--
+-- FC passes DEFAULT_ORG_ID as p_default_org_id, mirroring the other onboarding
+-- RPCs, so the default org is never client-steerable.
+
+alter table amux.teams
+  add column if not exists visibility text not null default 'private';
+
+alter table amux.teams
+  drop constraint if exists teams_visibility_check;
+alter table amux.teams
+  add constraint teams_visibility_check
+  check (visibility in ('public', 'private'));
+
+-- Fast lookup of public teams within a given (default) org.
+create index if not exists idx_teams_default_org_public
+  on amux.teams (oid)
+  where visibility = 'public';
+
+
+-- Picker data source: my teams (any org) ∪ public teams in the default org.
+create or replace function amux.list_teams_for_picker(p_default_org_id uuid default null)
+  returns table(team_id uuid, team_name text, team_slug text, org_id uuid, org_name text, visibility text, is_member boolean)
+  language sql stable security definer
+  set search_path to 'amux', 'public', 'auth'
+  as $$
+  with mine as (
+    select t.id, t.name, t.slug, t.oid, t.visibility, true as is_member
+      from amux.teams t
+     where exists (
+       select 1 from amux.actors a
+        where a.user_id = auth.uid() and a.team_id = t.id
+     )
+  ),
+  public_default as (
+    select t.id, t.name, t.slug, t.oid, t.visibility, false as is_member
+      from amux.teams t
+     where p_default_org_id is not null
+       and t.oid = p_default_org_id
+       and t.visibility = 'public'
+       and not exists (
+         select 1 from amux.actors a
+          where a.user_id = auth.uid() and a.team_id = t.id
+       )
+  ),
+  combined as (
+    select * from mine
+    union all
+    select * from public_default
+  )
+  select c.id, c.name, c.slug, c.oid, o.name, c.visibility, c.is_member
+    from combined c
+    left join public.orgs o on o.id = c.oid
+   order by c.is_member desc, o.name nulls last, c.name;
+$$;
+
+grant execute on function amux.list_teams_for_picker(uuid) to authenticated, service_role;
+
+
+-- Self-service join of a public default-org team as a plain member.
+create or replace function amux.join_public_team(p_team_id uuid, p_default_org_id uuid default null)
+  returns table(
+    team_id        uuid,
+    team_name      text,
+    team_slug      text,
+    member_id      uuid,
+    role           text,
+    workspace_id   uuid,
+    workspace_name text
+  )
+  language plpgsql security definer
+  set search_path to 'amux', 'public', 'auth', 'extensions'
+  as $$
+declare
+  v_user_id      uuid := auth.uid();
+  v_team         amux.teams%rowtype;
+  v_member_id    uuid;
+  v_existing     uuid;
+  v_nickname     text;
+  v_display_name text;
+  v_workspace_id uuid;
+  v_workspace_nm text;
+  v_adjectives   text[] := array['Curious','Brave','Calm','Eager','Lively','Mellow','Nimble','Quick','Quiet','Sunny','Witty','Zesty','Bright','Daring','Gentle','Jolly','Keen','Plucky','Spry','Sparkling'];
+  v_animals      text[] := array['Otter','Panda','Falcon','Fox','Heron','Lynx','Owl','Puffin','Quokka','Raven','Seal','Tapir','Viper','Walrus','Yak','Zebra','Badger','Cougar','Dolphin','Hare'];
+begin
+  if v_user_id is null then
+    raise exception 'join_public_team requires an authenticated user' using errcode = '42501';
+  end if;
+
+  select * into v_team from amux.teams where id = p_team_id;
+  if not found then
+    raise exception 'team not found' using errcode = 'P0002';
+  end if;
+
+  -- Only public teams in the default org are self-service joinable. Anything
+  -- else must go through invites or bootstrap.
+  if v_team.visibility is distinct from 'public'
+     or p_default_org_id is null
+     or v_team.oid is distinct from p_default_org_id then
+    raise exception 'team is not a joinable public team'
+      using errcode = '42501';
+  end if;
+
+  -- Idempotent: if already an actor in this team, just return the existing row.
+  select a.id into v_existing
+    from amux.actors a
+   where a.user_id = v_user_id and a.team_id = p_team_id
+   limit 1;
+
+  if v_existing is not null then
+    v_member_id := v_existing;
+  else
+    select nickname into v_nickname from public.users where id = v_user_id limit 1;
+
+    v_member_id := gen_random_uuid();
+    v_display_name := coalesce(
+      nullif(btrim(v_nickname), ''),
+      v_adjectives[((hashtextextended(v_member_id::text, 11) % 20) + 20) % 20 + 1] || ' ' ||
+      v_animals[((hashtextextended(v_member_id::text, 29) % 20) + 20) % 20 + 1]
+    );
+
+    insert into amux.actors (id, team_id, actor_type, user_id, display_name, last_active_at)
+    values (v_member_id, p_team_id, 'member', v_user_id, v_display_name, now());
+    insert into amux.members (id, status) values (v_member_id, 'active');
+    insert into amux.team_members (team_id, member_id, role) values (p_team_id, v_member_id, 'member');
+  end if;
+
+  select w.id, w.name into v_workspace_id, v_workspace_nm
+    from amux.workspaces w
+   where w.team_id = p_team_id
+   order by w.created_at asc, w.id asc
+   limit 1;
+
+  return query
+    select v_team.id, v_team.name, v_team.slug, v_member_id, 'member'::text, v_workspace_id, v_workspace_nm;
+end;
+$$;
+
+grant execute on function amux.join_public_team(uuid, uuid) to authenticated, service_role;


### PR DESCRIPTION
## 用户故事

**邮箱新注册用户登录后自动进入默认 org（无需邀请）**，登录后的 team 选择页列出「自己的 team」∪「默认 org 下的 public team」（去重、成员优先）。用户可自助发现并加入公开团队，无需等待邀请。

支线：
- 自助加入 public team → 加为普通 member 后进入（幂等）
- 团队成员可切团队 `public`/`private`（默认 private）
- 走邀请的用户不受影响

## 改动

**DB**
- `amux.teams.visibility`（默认 `private` + CHECK）+ public 部分索引
- 新 RPC `list_teams_for_picker(p_default_org_id)`、`join_public_team(...)`（绕过 first-team guard，支持第 N 个 team，幂等）
- postgres 后端同字段迁移 (`0015_add_teams_visibility.sql`)

**FC（supabase + pg 两套后端 parity）**
- `listAllMyTeams` → picker 联合列表（带 `visibility`/`isMember`）
- 新增 `joinPublicTeam`、`setTeamVisibility`
- `PATCH /v1/teams/:id` 支持 `name` 和/或 `visibility`；新增 `POST /v1/teams/:id/join`
- OpenAPI 更新

**客户端**
- `MembershipTeam`/`TeamSummary` 加 `visibility`/`isMember`；backend 加 `joinTeam`/`setTeamVisibility`
- `TeamPicker`：public 打标签，点选未加入时先 join 再 switch

**默认 orgid**：保持服务端 `DEFAULT_ORG_ID` env，无客户端/build-config 改动。

## 验证
- app `pnpm typecheck` ✅
- FC `tsc -p tsconfig.json` build ✅（唯一 test 报错在既有无关文件 `team-provisioning-delete-key.test.ts`）

## 权限
`teams_update_if_member` RLS 保证只有团队成员能改可见性；FC 转发调用方 token。

🤖 Generated with [Claude Code](https://claude.com/claude-code)