### PR TITLE
fix(updater): make "Restart Now" actually relaunch the app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "amuxd"
-version = "0.3.1-beta.3"
+version = "0.3.1-beta.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10205,7 +10205,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaw"
-version = "0.3.1-beta.3"
+version = "0.3.1-beta.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/desktop/src/commands/updater.rs
+++ b/apps/desktop/src/commands/updater.rs
@@ -11,6 +11,8 @@ use std::collections::HashMap;
 use std::io::Cursor;
 #[cfg(target_os = "macos")]
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::sync::OnceLock;
 use tauri::{AppHandle, Emitter, Runtime};
 
 const DEFAULT_REPO_OWNER: &str = "different-ai-studio";
@@ -405,6 +407,25 @@ fn get_app_bundle_path() -> Result<PathBuf, String> {
         .ok_or_else(|| "Cannot determine .app bundle path from executable".to_string())
 }
 
+/// The `.app` bundle path captured before any update replaces it on disk.
+#[cfg(target_os = "macos")]
+static STARTING_BUNDLE_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Record the running `.app` bundle path at startup.
+///
+/// `install_update` renames the live bundle away and moves a fresh one into its
+/// place, so anything resolved *after* an install can point at a bundle that no
+/// longer exists. Restart must relaunch the path captured here.
+pub fn remember_app_bundle_path() {
+    #[cfg(target_os = "macos")]
+    match get_app_bundle_path() {
+        Ok(path) => {
+            let _ = STARTING_BUNDLE_PATH.set(path);
+        }
+        Err(e) => log::warn!("[updater] cannot resolve .app bundle path at startup: {e}"),
+    }
+}
+
 /// Returns true when `path` looks like a macOS application bundle directory.
 #[cfg(target_os = "macos")]
 fn is_app_bundle(path: &Path) -> bool {
@@ -790,4 +811,84 @@ pub async fn download_and_install_update<R: Runtime>(
     install_update(&bytes)?;
 
     Ok(())
+}
+
+/// Quit and relaunch the app so an installed update takes effect.
+///
+/// This deliberately does not use `tauri_plugin_process::relaunch`. That path
+/// re-execs the binary from inside the dying process and skips LaunchServices,
+/// which after an in-place bundle replacement can leave no visible app at all
+/// — the window disappears (or never goes away) and nothing comes back.
+/// Instead we hand the relaunch to `open(1)` in a detached shell that outlives
+/// this process, then exit through the normal Tauri path so `RunEvent::Exit`
+/// still stops amuxd and the terminal registry.
+#[tauri::command]
+pub async fn restart_app<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    relaunch_and_exit(app)
+}
+
+#[cfg(target_os = "macos")]
+fn relaunch_and_exit<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    let bundle = STARTING_BUNDLE_PATH
+        .get()
+        .cloned()
+        .or_else(|| get_app_bundle_path().ok())
+        .ok_or_else(|| "Cannot determine .app bundle path to relaunch".to_string())?;
+
+    if !bundle.exists() {
+        return Err(format!(
+            "App bundle {} no longer exists; cannot relaunch",
+            bundle.display()
+        ));
+    }
+
+    // `sleep 1` gives this process time to tear down amuxd before the new
+    // instance starts supervising its own daemon. `-n` forces a new instance
+    // instead of reactivating the one that is on its way out.
+    let script = format!(
+        "sleep 1; exec /usr/bin/open -n {}",
+        shell_quote(&bundle.to_string_lossy())
+    );
+    std::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(&script)
+        .spawn()
+        .map_err(|e| format!("Failed to schedule relaunch: {e}"))?;
+
+    log::info!("[updater] relaunch scheduled for {}", bundle.display());
+    app.exit(0);
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn relaunch_and_exit<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    app.request_restart();
+    Ok(())
+}
+
+/// Single-quote a path for `/bin/sh -c`.
+#[cfg(target_os = "macos")]
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod shell_quote_tests {
+    use super::shell_quote;
+
+    #[test]
+    fn quotes_plain_path() {
+        assert_eq!(
+            shell_quote("/Applications/TeamClaw.app"),
+            "'/Applications/TeamClaw.app'"
+        );
+    }
+
+    #[test]
+    fn quotes_path_with_spaces_and_quote() {
+        assert_eq!(
+            shell_quote("/My Apps/Team's.app"),
+            r"'/My Apps/Team'\''s.app'"
+        );
+    }
 }

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -461,6 +461,7 @@ pub fn run() {
             commands::skillssh::npx_skills_list,
             commands::updater::check_update,
             commands::updater::download_and_install_update,
+            commands::updater::restart_app,
             commands::git::git_check_available,
             commands::git::git_clone,
             commands::git::git_pull,
@@ -598,6 +599,9 @@ pub fn run() {
         ])
         .setup(|app| {
             let setup_t0 = std::time::Instant::now();
+
+            // Capture the .app bundle path before an update can replace it on disk.
+            commands::updater::remember_app_bundle_path();
 
             // Register aptabase here (inside setup) so the Tokio runtime is available
             // for its internal `tokio::spawn` polling loop.

--- a/packages/app/src/components/updater/UpdateDialog.tsx
+++ b/packages/app/src/components/updater/UpdateDialog.tsx
@@ -84,6 +84,7 @@ export function UpdateDialogContainer() {
   const { t } = useTranslation()
   const { update, checkForUpdates, retryUpdate, restart } = useUpdaterStore()
   const [dismissed, setDismissed] = useState(false)
+  const [restarting, setRestarting] = useState(false)
 
   // Check for updates on app startup (3s delay) and every 4 hours
   useEffect(() => {
@@ -120,6 +121,18 @@ export function UpdateDialogContainer() {
   const handleDismiss = useCallback(() => {
     setDismissed(true)
   }, [])
+
+  const handleRestart = useCallback(() => {
+    setRestarting(true)
+    void restart()
+  }, [restart])
+
+  // A failed restart flips the store to `error`; let the user try again.
+  useEffect(() => {
+    if (update.state !== "ready") {
+      setRestarting(false)
+    }
+  }, [update.state])
 
   // Updates download/install in the background; only prompt the user to restart (or report failure).
   const showDialog =
@@ -192,12 +205,19 @@ export function UpdateDialogContainer() {
         <DialogFooter>
           {update.state === "ready" && (
             <>
-              <Button variant="outline" onClick={handleDismiss} className="w-full sm:w-auto">
+              <Button
+                variant="outline"
+                onClick={handleDismiss}
+                disabled={restarting}
+                className="w-full sm:w-auto"
+              >
                 {t('updater.restartLater', 'Restart later')}
               </Button>
-              <Button onClick={restart} className="w-full sm:w-auto">
-                <RefreshCw className="h-4 w-4 mr-2" />
-                {t('updater.restartNow', 'Restart Now')}
+              <Button onClick={handleRestart} disabled={restarting} className="w-full sm:w-auto">
+                <RefreshCw className={`h-4 w-4 mr-2${restarting ? " animate-spin" : ""}`} />
+                {restarting
+                  ? t('updater.restarting', 'Restarting…')
+                  : t('updater.restartNow', 'Restart Now')}
               </Button>
             </>
           )}

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -869,6 +869,7 @@
     "failed": "Update Failed",
     "releaseNotes": "Release Notes",
     "restartNow": "Restart Now",
+    "restarting": "Restarting…",
     "restartLater": "Restart later",
     "restartRecommendation": "The update is installed. We recommend restarting soon to use the new version.",
     "restartToApply": "The update has been installed. Restart to apply changes.",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -869,6 +869,7 @@
     "failed": "更新失败",
     "releaseNotes": "更新说明",
     "restartNow": "立即重启",
+    "restarting": "正在重启…",
     "restartLater": "稍后重启",
     "restartRecommendation": "更新已安装，建议尽快重启以使用新版本。",
     "restartToApply": "更新已安装。请重启以应用更改。",

--- a/packages/app/src/stores/updater.ts
+++ b/packages/app/src/stores/updater.ts
@@ -186,14 +186,29 @@ export const useUpdaterStore = create<UpdaterStore>((set, get) => ({
 
   restart: async () => {
     try {
-      const { relaunch } = await import("@tauri-apps/plugin-process")
-      await relaunch()
+      const { invoke } = await import("@tauri-apps/api/core")
+      await invoke("restart_app")
+      // `restart_app` exits the process; if we are still alive a moment later
+      // the relaunch never took, so tell the user instead of leaving the
+      // dialog looking like the click did nothing.
+      setTimeout(() => {
+        const cur = get().update
+        if (cur.state === "ready") {
+          set({
+            update: {
+              ...cur,
+              state: "error",
+              errorMessage: "Failed to restart. Please quit and reopen the app manually.",
+            },
+          })
+        }
+      }, 5000)
     } catch (err) {
       console.error("[Updater] Relaunch failed:", err)
       set({
         update: {
           state: "error",
-          errorMessage: "Failed to restart. Please restart manually.",
+          errorMessage: `Failed to restart: ${String(err)}. Please restart manually.`,
         },
       })
     }


### PR DESCRIPTION
## 问题

更新弹窗上的「立即重启」点了没有任何反应 —— 点击确实落到了 handler 上，但界面纹丝不动。

`useUpdaterStore.restart()` 走的是 `@tauri-apps/plugin-process` 的 `relaunch()`，即 `invoke('plugin:process|restart')` → `AppHandle::request_restart()` → Tauri 在**将死的进程内部** re-exec 自己的二进制。

这条路在本项目里特别脆弱，原因在安装逻辑：`install_update` 会把**正在运行的** `.app` 先 rename 到临时目录，把新解压的 bundle 移到原位置，最后删掉备份。所以按下「立即重启」时，当前进程执行的那份 bundle 已经被换掉了。Tauri 这时按路径 spawn、绕开 LaunchServices，失败了也只是 `log::error!` 然后 `exit(0)`。

整条链路**没有一环把失败告诉前端**：`invoke` 正常 resolve 返回 `()`，store state 一点没变，弹窗原样杵在那儿。失败根本没有可见出口。

## 改动

- 启动时用 `OnceLock` 缓存 `.app` bundle 路径，赶在更新替换它**之前**。
- 新增 `restart_app` 命令：把重启交给一个脱离的 `/bin/sh -c 'sleep 1; exec open -n <bundle>'`，然后走 `app.exit(0)` 正常退出。`open -n` 走 LaunchServices 并强制开新实例；shell 比当前进程活得久；`sleep 1` 让老实例跑完 `RunEvent::Exit` 拆解（amuxd supervisor、terminal registry），避免新实例上来就跟老实例抢守护 daemon。非 macOS 退回 `request_restart()`。
- store 在 reject 时显示真实错误串；5 秒后进程还活着就把弹窗翻成 error 提示手动退出。**静默无反应现在不可能再发生。**
- 弹窗按钮点击后置灰 + 转圈显示「正在重启…」。`AboutSection` 调的是同一个 store action，一并修好。
- 顺带把 Cargo.lock 刷新到 beta.4（上次版本号 bump 时 lockfile 没跟着重新生成）。

## 验证

`cargo clippy -D warnings`、`cargo fmt --check`、`pnpm typecheck`、改动文件的 eslint、新增的 `shell_quote` 单测 —— 全过。

⚠️ **没有实机复现过**：updater 在 dev 构建里是硬关闭的（`import.meta.env.DEV` / `cfg!(debug_assertions)`），端到端还需要一个真实签名构建 + 一个可用更新来确认。上面的定位是读安装→重启这条代码路径推出来的，改动本身覆盖了「进程没退」和「退了但没起来」两种情况。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
