### PR TITLE
fix(sessions): carry source through the session-list read path

### DIFF
--- a/packages/app/src/components/chat/SessionList.tsx
+++ b/packages/app/src/components/chat/SessionList.tsx
@@ -9,6 +9,7 @@ import { useUIStore } from '@/stores/ui'
 import { useCronStore } from '@/stores/cron'
 import { cn } from '@/lib/utils'
 import { formatRelativeDate } from '@/lib/date-format'
+import { isScheduledSession } from '@/lib/session-origin'
 import {
   resolvePendingPermissionActivityOwner,
   resolvePendingQuestionActivityOwner,
@@ -137,11 +138,7 @@ export function SessionList({ compact, onSessionSelected }: SessionListProps) {
   const showCronSessions = useCronStore(s => s.showCronSessions)
 
   const parentSessions = useMemo(() => {
-    // Persisted `source` is the authority for scheduled-origin sessions; the
-    // `cronSessionIds` overlay is only an optimistic fallback for a just-created
-    // cron session whose row hasn't synced `source` yet.
-    const isCron = (s: typeof allSessions[number]) =>
-      s.source === 'cron' || cronSessionIds.has(s.id)
+    const isCron = (s: typeof allSessions[number]) => isScheduledSession(s, cronSessionIds)
     return allSessions.filter(s => {
       if (s.parentID) return false
       return showCronSessions

--- a/packages/app/src/components/sidebar/NavRail.tsx
+++ b/packages/app/src/components/sidebar/NavRail.tsx
@@ -21,6 +21,7 @@ import { ActorsSection } from '@/components/sidebar/ActorsSection'
 import { TeamShareNavSection } from '@/components/sidebar/TeamShareNavSection'
 import { NewChatSplitButton } from '@/components/sidebar/NewChatSplitButton'
 import { buildConfig } from '@/lib/build-config'
+import { isScheduledSession } from '@/lib/session-origin'
 import { cn } from '@/lib/utils'
 
 interface TopEntryProps {
@@ -73,13 +74,13 @@ export function NavRail() {
   const [creating, setCreating] = React.useState(false)
 
   const sessionsCount = React.useMemo(
-    () => listRows.filter((r) => !cronSessionIds.has(r.id)).length,
+    () => listRows.filter((r) => !isScheduledSession(r, cronSessionIds)).length,
     [listRows, cronSessionIds],
   )
 
   const pinnedCount = React.useMemo(() => {
     const visibleIds = new Set(
-      listRows.filter((r) => !cronSessionIds.has(r.id)).map((r) => r.id),
+      listRows.filter((r) => !isScheduledSession(r, cronSessionIds)).map((r) => r.id),
     )
     return pinnedSessionIds.filter((id) => visibleIds.has(id)).length
   }, [listRows, pinnedSessionIds, cronSessionIds])

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -48,6 +48,7 @@ import { loadSessionIdsForWorkspace } from '@/lib/session-by-workspace'
 import { actorAvatarColor } from '@/lib/actor-color'
 import { useSessionWorkspaceLabels } from '@/hooks/use-session-workspace-labels'
 import { compareSessionListByRecency } from '@/lib/session-list-sort'
+import { isScheduledSession } from '@/lib/session-origin'
 
 /**
  * Merged row shape consumed by the rendering pipeline. Combines list-canonical
@@ -284,10 +285,7 @@ export function SessionListColumn({
     let base = listRows.map((r) => entryToRow(r, pinnedSet.has(r.id)))
     const isClockView = filter.kind === 'all' && showCronSessions
 
-    // A session is scheduled-origin when its persisted `source` says so. The
-    // local `cronSessionIds` overlay is kept only as an optimistic fallback for
-    // a just-created cron session whose list row hasn't synced `source` yet.
-    const isCron = (r: ListRow) => r.source === 'cron' || cronSessionIds.has(r.id)
+    const isCron = (r: ListRow) => isScheduledSession(r, cronSessionIds)
     base = base.filter((r) => (isClockView ? isCron(r) : !isCron(r)))
 
     if (filter.kind === 'pinned') {

--- a/packages/app/src/lib/session-origin.ts
+++ b/packages/app/src/lib/session-origin.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared "is this session scheduled-origin?" predicate.
+ *
+ * A session is scheduled-origin when its persisted `source` says so. The
+ * device-local `cronSessionIds` overlay is only an optimistic fallback for a
+ * just-created cron session whose list row hasn't synced `source` yet.
+ *
+ * This lives in one place because the surfaces that split the list into
+ * "chat" vs "scheduled" — NavRail's counts, SessionListColumn, SessionList —
+ * drifted apart once already: the latter two moved to `source` while NavRail
+ * kept counting on the overlay alone, so cron sessions stayed in the 会话
+ * badge even after they'd been filtered out of the list itself.
+ */
+export function isScheduledSession(
+  row: { id: string; source?: string | null },
+  cronSessionIds: ReadonlySet<string>,
+): boolean {
+  return row.source === 'cron' || cronSessionIds.has(row.id)
+}

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -1891,7 +1891,7 @@ export function createSupabaseBusinessRepository(options) {
 
     async listTeamSessionsFull(teamId) {
       const FULL_COLUMNS =
-        "id, team_id, title, mode, primary_agent_id, idea_id, summary, last_message_preview, last_message_at, created_by_actor_id, created_at, updated_at";
+        "id, team_id, title, mode, primary_agent_id, idea_id, summary, last_message_preview, last_message_at, created_by_actor_id, source, cron_job_id, created_at, updated_at";
       const { data: sessionRows, error: sessionErr } = await supabase
         .from("sessions")
         .select(FULL_COLUMNS)
@@ -1923,6 +1923,8 @@ export function createSupabaseBusinessRepository(options) {
         summary: row.summary ?? null,
         lastMessageAt: row.last_message_at ?? null,
         lastMessagePreview: row.last_message_preview ?? null,
+        source: row.source ?? "user",
+        cronJobId: row.cron_job_id ?? null,
         participantCount: counts[row.id] ?? 0,
         hasUnread: false,
         createdAt: row.created_at ?? null,
@@ -1958,7 +1960,7 @@ export function createSupabaseBusinessRepository(options) {
 
     async listSessionsForTeamSince(teamId, updatedAfter) {
       const SESSION_SYNC_COLUMNS =
-        "id, team_id, title, mode, primary_agent_id, idea_id, summary, last_message_preview, last_message_at, created_by_actor_id, created_at, updated_at";
+        "id, team_id, title, mode, primary_agent_id, idea_id, summary, last_message_preview, last_message_at, created_by_actor_id, source, cron_job_id, created_at, updated_at";
       let q = supabase
         .from("sessions")
         .select(SESSION_SYNC_COLUMNS)

--- a/services/fc/src/lib/supabase-repo/shared.ts
+++ b/services/fc/src/lib/supabase-repo/shared.ts
@@ -201,6 +201,12 @@ export function mapSession(row) {
     hasUnread: row?.has_unread === true,
     createdAt: row?.created_at ?? null,
     updatedAt: row?.updated_at ?? null,
+    // Origin marker. List rows come from the list_current_actor_sessions RPC,
+    // which only started returning these in 20260727000000 — default to 'user'
+    // so a stale database still yields the pre-cron-filter behaviour instead of
+    // an undefined that the client would read as "unknown origin".
+    source: row?.source ?? "user",
+    cronJobId: row?.cron_job_id ?? null,
   };
 }
 

--- a/services/supabase/migrations/20260727000000_sessions_source_read_path.sql
+++ b/services/supabase/migrations/20260727000000_sessions_source_read_path.sql
@@ -1,0 +1,143 @@
+-- Make `sessions.source` actually reach the client, and repair the backfill.
+--
+-- 20260723000000 added amux.sessions.source / cron_job_id and wired the write
+-- path (createCronSession inserts source='cron'), but the session-list READ
+-- path never carried the value: `amux.list_current_actor_sessions` — the RPC
+-- behind GET /v1/sessions — has a fixed RETURNS TABLE(...) signature that was
+-- never updated, so `source` was silently dropped before it left the database.
+-- The UI's cron filter (SessionListColumn `r.source === 'cron'`) therefore saw
+-- null on every row and fell back to the device-local `cronSessionIds` overlay.
+--
+-- Two fixes here:
+--
+--   1. Recreate the RPC with source + cron_job_id in its result columns.
+--      RETURNS TABLE is part of the signature, so CREATE OR REPLACE cannot
+--      widen it — the function must be dropped and recreated, and its grants
+--      re-applied (baseline.sql:7830-7833).
+--   2. Redo the backfill. The 20260723 version keyed on
+--      `binding LIKE 'cron/%'`, assuming scheduled sessions carried their
+--      `cron/<job>/<run>` key in `sessions.binding`. They do not — `binding` is
+--      NULL on every row ever written, so that UPDATE matched nothing and all
+--      pre-existing cron sessions stayed at source='user'. The only surviving
+--      signal on those legacy rows is the daemon-generated title, which is
+--      always `Cron: <job name>` (apps/daemon/src/daemon/server/cron.rs:347).
+--      cron_job_id is unrecoverable for them and stays NULL.
+--
+-- Idempotent so the self-host apply-migrations loop can re-run it.
+
+-- 1. RPC: carry source + cron_job_id through to the list response.
+
+DROP FUNCTION IF EXISTS amux.list_current_actor_sessions(
+  integer, timestamp with time zone, timestamp with time zone, uuid
+);
+
+CREATE FUNCTION amux.list_current_actor_sessions(
+  p_limit integer DEFAULT 50,
+  p_before_last_message_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_before_created_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_before_id uuid DEFAULT NULL::uuid
+) RETURNS TABLE(
+  id uuid,
+  title text,
+  team_id uuid,
+  mode text,
+  idea_id uuid,
+  last_message_at timestamp with time zone,
+  last_message_preview text,
+  created_at timestamp with time zone,
+  updated_at timestamp with time zone,
+  has_unread boolean,
+  source text,
+  cron_job_id text
+)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public', 'app'
+AS $function$
+  with current_actor as (
+    select amux.current_actor_id() as actor_id
+  )
+  select
+    s.id,
+    s.title,
+    s.team_id,
+    s.mode,
+    s.idea_id,
+    s.last_message_at,
+    s.last_message_preview,
+    s.created_at,
+    s.updated_at,
+    (
+      s.last_message_at is not null
+      and s.last_message_at > coalesce(srm.last_read_at, '-infinity'::timestamptz)
+    ) as has_unread,
+    s.source,
+    s.cron_job_id
+  from amux.sessions s
+  cross join current_actor ca
+  left join amux.session_read_markers srm
+    on srm.session_id = s.id
+   and srm.actor_id = ca.actor_id
+  where amux.is_session_participant(s.id)
+    and s.archived_at is null
+    and (
+      p_before_id is null
+      or (
+        case
+          when p_before_last_message_at is null then
+            s.last_message_at is not null
+            or (
+              s.last_message_at is null
+              and (
+                s.created_at < p_before_created_at
+                or (s.created_at = p_before_created_at and s.id < p_before_id)
+              )
+            )
+          when s.last_message_at is null then false
+          when s.last_message_at < p_before_last_message_at then true
+          when s.last_message_at = p_before_last_message_at then
+            s.created_at < p_before_created_at
+            or (s.created_at = p_before_created_at and s.id < p_before_id)
+          else false
+        end
+      )
+    )
+  order by
+    s.last_message_at desc nulls first,
+    s.created_at desc,
+    s.id desc
+  limit greatest(1, least(coalesce(p_limit, 50), 100));
+$function$;
+
+REVOKE ALL ON FUNCTION amux.list_current_actor_sessions(
+  p_limit integer,
+  p_before_last_message_at timestamp with time zone,
+  p_before_created_at timestamp with time zone,
+  p_before_id uuid
+) FROM PUBLIC;
+GRANT ALL ON FUNCTION amux.list_current_actor_sessions(
+  p_limit integer,
+  p_before_last_message_at timestamp with time zone,
+  p_before_created_at timestamp with time zone,
+  p_before_id uuid
+) TO anon;
+GRANT ALL ON FUNCTION amux.list_current_actor_sessions(
+  p_limit integer,
+  p_before_last_message_at timestamp with time zone,
+  p_before_created_at timestamp with time zone,
+  p_before_id uuid
+) TO authenticated;
+GRANT ALL ON FUNCTION amux.list_current_actor_sessions(
+  p_limit integer,
+  p_before_last_message_at timestamp with time zone,
+  p_before_created_at timestamp with time zone,
+  p_before_id uuid
+) TO service_role;
+
+-- 2. Backfill legacy scheduled sessions the 20260723 binding-based UPDATE
+--    missed. Title is the only origin signal left on those rows.
+
+UPDATE amux.sessions
+SET source = 'cron'
+WHERE source = 'user'
+  AND title LIKE 'Cron: %';


### PR DESCRIPTION
## 问题

cron / 普通会话的区分（#577）在真机上从来没生效过：会话列表的时钟过滤看到的 `source` 恒为 `null`，静默回退到设备本地的 `cronSessionIds` overlay，结果是**点时钟图标列表为空，而 cron 会话全部混在普通列表里**。

两个独立的成因。

### 1. supabase repo 在每条读路径上都把 `source` 丢了

pg-repo 后端全程正确，所以测试一直是绿的 —— 但生产跑的是 `BACKEND_KIND=supabase`（`deploy/self-host/docker-compose.yml:172`、`services/fc/s.yaml:71` 都默认 supabase）。

| 位置 | 问题 |
|---|---|
| `amux.list_current_actor_sessions` | `GET /v1/sessions` 背后的 RPC，`RETURNS TABLE(...)` 是固定签名。20260723 加了列却没重建函数，值在数据库内部就被丢掉了 |
| `supabase-repo/shared.ts` `mapSession` | 没有 `source` / `cronJobId`，兄弟函数 `mapSessionFull` 有 |
| `SESSION_SYNC_COLUMNS` | `GET /v1/sync/sessions` 不选这两列，往本地 libsql 缓存写 null —— 离线重绘也救不回来 |
| `listTeamSessionsFull` | 同样漏了，和 `pg-repo/sessions.ts:632`（有返回）不一致 |

`docs/openapi/teamclaw-api.v1.yaml:3808` 早就声明了 `source` 枚举，所以这属于实现偏离契约。

### 2. 20260723 的 backfill 是空操作

它按 `binding LIKE 'cron/%'` 匹配，假定调度会话把 `cron/<job>/<run>` 存在 `sessions.binding` 里。实际上 **`binding` 在写过的每一行上都是 NULL**：

```sql
select binding, count(*) from amux.sessions group by 1;
--  binding = NULL, count = 1707
```

所以历史 cron 会话一条都没被标记。本 PR 改用那些行上唯一还在的信号 —— daemon 生成的 `Cron: <job name>` 标题（`apps/daemon/src/daemon/server/cron.rs:347`）重新回填。`cron_job_id` 对它们无从恢复，留 NULL。

## 改动

- **新增** `services/supabase/migrations/20260727000000_sessions_source_read_path.sql` — DROP + CREATE 重建 RPC（`RETURNS TABLE` 属于签名，`CREATE OR REPLACE` 无法加列，所以授权也要重新给），并重做回填。幂等。
- `services/fc/` 四处补上 `source` / `cron_job_id`。
- **新增** `packages/app/src/lib/session-origin.ts` — 抽出 `isScheduledSession()`，三个调用点统一。顺带修了 `NavRail`：列表本身已经改用 `source` 之后，它的计数和已读集合还只认 `cronSessionIds` overlay，导致 cron 会话即使被过滤出列表，仍然在「会话」徽标里计数。

## 验证

migration 已手工应用到唯一环境（`supabase.teamclaw-dev.ucar.cc`）：

- RPC 结果列现在含 `source text, cron_job_id text`；授权 `anon` / `authenticated` / `service_role` 各一条 EXECUTE，owner 为 `postgres`（与同 schema 的 `current_actor_id` / `is_session_participant` 一致）。非 SECURITY DEFINER，RLS 语义未变。
- 回填 `affected_rows: 1133`，`source='cron'` 从 6 → 1139。回填前扫过标题分布，8 个不同标题全部是 job 名（`auto investigate `、`dod单`、`Test` 等），没有用户手写的伪装标题。

CI 会重跑 migration，两段都幂等（`DROP ... IF EXISTS`，回填 UPDATE 现在匹配 0 行）。

`pnpm typecheck` 通过。

⚠️ **已知的既有失败（与本 PR 无关）**：`SessionListColumn.test.tsx` 有 3 个 pinned 渲染相关的测试失败（`filters to pinned sessions in "pinned" mode` 等）。我 stash 到干净树上验证过，改动前同样失败，是另一个已存在的回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)