### PR TITLE
chore(fc): stop the local deploy script from migrating the database

### DIFF
--- a/services/fc/deploy-aliyun-fc.sh
+++ b/services/fc/deploy-aliyun-fc.sh
@@ -7,6 +7,7 @@
 #       - refuses to deploy to `teamclaw-sync` unless explicitly forced
 #       - requires an explicit env file (no implicit/stale .env)
 #       - prints the target + a confirmation prompt before `s deploy`
+#       - does NOT touch the database unless RUN_MIGRATIONS=1
 #
 # Usage:
 #   ./deploy-aliyun-fc.sh <function-name> [env-file]
@@ -14,6 +15,7 @@
 # Examples:
 #   ./deploy-aliyun-fc.sh teamclaw-api-test                 # uses .env.test.local
 #   ./deploy-aliyun-fc.sh teamclaw-api-test .env.staging.local
+#   RUN_MIGRATIONS=1 ./deploy-aliyun-fc.sh teamclaw-api-test   # also migrate
 #
 # The env file must define (at minimum):
 #   ACCESS_KEY_ID, ACCESS_KEY_SECRET   (Aliyun credentials)
@@ -92,17 +94,43 @@ case "$ans" in
   *) echo "Aborted."; exit 0 ;;
 esac
 
-# ── Database migrations ──────────────────────────────────────────────────────
-# Run pending SQL migrations from services/supabase/migrations/ before deploy.
-# Requires DATABASE_URL (public endpoint) to be set in the env file.
-# Skipped when DATABASE_URL is empty (e.g. supabase-only deploys with no RDS).
+# ── Database migrations (OPT-IN) ─────────────────────────────────────────────
+# Deploying code and migrating a database are separate decisions with very
+# different blast radii, so this script does NOT migrate by default. Merely
+# having DATABASE_URL in an env file is not consent to run DDL against it —
+# that used to be enough, which meant a routine code deploy silently applied
+# every pending migration to whatever database the env file happened to name.
+#
+# Run migrations yourself, or opt in explicitly with RUN_MIGRATIONS=1.
 MIGRATIONS_DIR="$(dirname "$0")/../supabase/migrations"
-if [ -n "${DATABASE_URL:-}" ]; then
-  echo "==> Running database migrations"
+if [ "${RUN_MIGRATIONS:-}" != "1" ]; then
+  echo "==> Skipping database migrations (default)"
+  echo "    Migrations are applied by a human, not by this script."
+  if [ -n "${DATABASE_URL:-}" ]; then
+    echo "    To apply them here instead, re-run with RUN_MIGRATIONS=1."
+    echo "    To apply them by hand:"
+    echo "      for f in \$(ls $MIGRATIONS_DIR/*.sql | grep -v baseline | sort); do"
+    echo "        psql \"\$DATABASE_URL\" -f \"\$f\""
+    echo "      done"
+  fi
+elif [ -z "${DATABASE_URL:-}" ]; then
+  echo "ERROR: RUN_MIGRATIONS=1 but DATABASE_URL is unset in $ENV_FILE." >&2
+  exit 1
+else
+  echo "==> Running database migrations (RUN_MIGRATIONS=1)"
   if ! command -v psql >/dev/null 2>&1; then
     echo "ERROR: psql not found. Install postgresql-client to run migrations." >&2
     exit 1
   fi
+  # Migrating is the irreversible half of this script, so make the target
+  # explicit and confirm it separately from the deploy prompt above. Redact the
+  # credentials — DATABASE_URL carries the password inline.
+  echo "    target: $(printf '%s' "$DATABASE_URL" | sed -E 's#://[^@/]*@#://***@#')"
+  read -r -p "    Apply pending migrations to this database? [y/N] " mig_ans
+  case "$mig_ans" in
+    y|Y|yes|YES) ;;
+    *) echo "Aborted."; exit 0 ;;
+  esac
   # Only apply incremental migrations (skip the baseline squash file).
   for migration in $(ls "$MIGRATIONS_DIR"/*.sql 2>/dev/null | grep -v baseline | sort); do
     filename="$(basename "$migration")"
@@ -110,8 +138,6 @@ if [ -n "${DATABASE_URL:-}" ]; then
     psql "$DATABASE_URL" -f "$migration" 2>&1 | grep -v "^$" || true
   done
   echo "    migrations done."
-else
-  echo "NOTE: DATABASE_URL not set — skipping database migrations."
 fi
 
 command -v s >/dev/null 2>&1 || npm install -g @serverless-devs/s


### PR DESCRIPTION
## 问题

`services/fc/deploy-aliyun-fc.sh` 把「部署代码」和「迁移数据库」这两件爆炸半径完全不同的事绑在了一起：

```sh
if [ -n "${DATABASE_URL:-}" ]; then
  echo "==> Running database migrations"
  ...
  psql "$DATABASE_URL" -f "$migration"
```

env 文件里**存在** `DATABASE_URL` 就被当成了执行 DDL 的授权。结果是一次普通的代码部署会静默地把 `services/supabase/migrations/` 下所有未应用的迁移打到那个 env 文件恰好指向的数据库上 —— 而且发生在部署**之前**，没有独立的确认提示。

## 改动

迁移改为 `RUN_MIGRATIONS=1` 显式 opt-in。

| 情况 | 行为 |
|---|---|
| 默认（不设 `RUN_MIGRATIONS`） | 跳过，打印手工执行的 `psql` 循环 |
| `RUN_MIGRATIONS=1` + 有 `DATABASE_URL` | 单独打印目标库并二次确认（`[y/N]`），确认后才执行 |
| `RUN_MIGRATIONS=1` 但缺 `DATABASE_URL` | 报错退出，不再静默跳过 |

两点细节：

- **独立于部署确认的二次确认。** 迁移是这个脚本里唯一不可逆的部分，值得单独问一次，而不是被上面那个 `Deploy '$FUNCTION_NAME'?` 的 y 一并带过。
- **凭据遮蔽。** `DATABASE_URL` 内联着密码，直接 echo 会把它泄漏到终端以及脚本所在的任何 CI 日志里，所以打印时经 `sed -E 's#://[^@/]*@#://***@#'` 处理成 `postgresql://***@host:5432/db`。

## 验证

三条分支都实跑过：

- 默认（有 `DATABASE_URL`，不设 `RUN_MIGRATIONS`）→ 跳过并打印手工命令 ✓
- `RUN_MIGRATIONS=1` 无 `DATABASE_URL` → `exit 1` ✓
- `RUN_MIGRATIONS=1` 有 `DATABASE_URL`，提示处回 `n` → `Aborted.`，且目标显示为 `postgresql://***@pgm-x.rds.aliyuncs.com:5432/supabase_db` ✓

`bash -n` 语法通过。`shellcheck` 剩余的 2 个 warning（`SC2163`、`SC2010`）都在本 PR 未触及的原有代码上，没有顺手改。

注：`/Volumes/openbeta/workspace/teamclaw-v2` 那份同名脚本仍是旧的自动迁移行为，不在本仓库范围内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)