### PR TITLE
feat(gateway): /clear becomes /new, and a chat can switch back into its past sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "amuxd"
-version = "0.3.1-beta.4"
+version = "0.3.1-beta.7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10678,7 +10678,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaw"
-version = "0.3.1-beta.4"
+version = "0.3.1-beta.7"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -5,8 +5,8 @@ mod messages;
 use super::{
     AgentDefaults, AgentRuntimeRow, AgentRuntimeUpsert, Backend, BackendError, BackendResult,
     BackendSessionAndParticipants, BootstrapMqttOverride, ClaimResult, CloudAuthSnapshot,
-    ManagedGitCredential, ManagedLlmConfig, ManagedLlmModelInfo, ShareModeConfig, StoredMessage,
-    WorkspaceRow, WorkspaceUpsert,
+    GatewaySessionRow, ManagedGitCredential, ManagedLlmConfig, ManagedLlmModelInfo,
+    ShareModeConfig, StoredMessage, WorkspaceRow, WorkspaceUpsert,
 };
 use crate::provider_config::CloudApiConfig;
 use async_trait::async_trait;
@@ -1132,6 +1132,64 @@ impl Backend for CloudApiBackend {
             )
             .await?;
         Ok(r.detached)
+    }
+
+    async fn rpc_list_gateway_sessions(
+        &self,
+        team_id: &str,
+        gateway_key: &str,
+        limit: u32,
+    ) -> BackendResult<Vec<GatewaySessionRow>> {
+        #[derive(serde::Deserialize)]
+        struct Resp {
+            #[serde(default)]
+            items: Vec<GatewaySessionRow>,
+        }
+        let path = format!(
+            "/v1/sessions/gateway?teamId={}&gatewayKey={}&limit={}",
+            urlencoding::encode(team_id),
+            urlencoding::encode(gateway_key),
+            limit
+        );
+        let r: Resp = self.get(&path).await?;
+        Ok(r.items)
+    }
+
+    async fn rpc_attach_gateway_session(
+        &self,
+        binding: &str,
+        session_id: &str,
+    ) -> BackendResult<Option<String>> {
+        #[derive(serde::Serialize)]
+        struct Body<'a> {
+            binding: &'a str,
+            #[serde(rename = "sessionId")]
+            session_id: &'a str,
+        }
+        #[derive(serde::Deserialize)]
+        struct Resp {
+            #[serde(rename = "acpSessionId", default)]
+            acp_session_id: Option<String>,
+            #[serde(default)]
+            attached: bool,
+        }
+        let r: Resp = self
+            .post(
+                "/v1/sessions/gateway/attach",
+                &Body {
+                    binding,
+                    session_id,
+                },
+                None,
+            )
+            .await?;
+        // A row can be attached while carrying no acp id (a session minted by a
+        // backend that leaves it null); report the switch, not a failure.
+        Ok(if r.attached {
+            Some(r.acp_session_id.unwrap_or_default())
+        } else {
+            None
+        })
     }
 
     async fn rpc_ensure_gateway_session(

--- a/apps/daemon/src/backend/mock.rs
+++ b/apps/daemon/src/backend/mock.rs
@@ -24,8 +24,8 @@ use async_trait::async_trait;
 
 use crate::backend::{
     AgentDefaults, AgentRuntimeRow, AgentRuntimeUpsert, Backend, BackendError, BackendResult,
-    BackendSessionAndParticipants, ClaimResult, ManagedGitCredential, ManagedLlmConfig,
-    ShareModeConfig, StoredMessage, WorkspaceRow, WorkspaceUpsert,
+    BackendSessionAndParticipants, ClaimResult, GatewaySessionRow, ManagedGitCredential,
+    ManagedLlmConfig, ShareModeConfig, StoredMessage, WorkspaceRow, WorkspaceUpsert,
 };
 
 /// Owned snapshot of an `AgentRuntimeUpsert` so tests can assert without
@@ -141,6 +141,8 @@ pub struct MockState {
     pub runtime_cursors_updated: Vec<(String, String)>,
     pub attachments_uploaded: Vec<RecordedAttachment>,
     pub gateway_sessions_ensured: Vec<RecordedGatewayEnsure>,
+    /// `(binding, session_id)` pairs passed to `rpc_attach_gateway_session`.
+    pub gateway_sessions_attached: Vec<(String, String)>,
     pub cron_sessions: Vec<RecordedCronSession>,
 
     // ── Pre-seeded responses for reads ─────────────────────────────────
@@ -152,6 +154,10 @@ pub struct MockState {
     pub agent_permissions: HashMap<(String, String), Option<String>>,
     pub external_actor_results: HashMap<(String, String, String), String>,
     pub ensure_gateway_session_result: Option<(String, String, bool)>,
+    /// One chat's session lineage, keyed by gateway_key (the chat's binding).
+    /// `rpc_attach_gateway_session` accepts only ids present in the list for
+    /// that key, mirroring the SQL function's `gateway_key` guard.
+    pub gateway_sessions_by_key: HashMap<String, Vec<GatewaySessionRow>>,
     pub workspace_results: HashMap<(String, String, String), WorkspaceRow>,
     /// Rows recorded by `upsert_workspace`, keyed by the returned canonical id
     /// — lets `get_workspaces_by_ids` resolve ids seeded via `upsert_workspace`
@@ -514,6 +520,39 @@ impl Backend for MockBackend {
             .gateway_session_index
             .get(acp_session_id)
             .cloned())
+    }
+
+    async fn rpc_list_gateway_sessions(
+        &self,
+        _team_id: &str,
+        gateway_key: &str,
+        limit: u32,
+    ) -> BackendResult<Vec<GatewaySessionRow>> {
+        let st = self.state.lock().unwrap();
+        Ok(st
+            .gateway_sessions_by_key
+            .get(gateway_key)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .take(limit as usize)
+            .collect())
+    }
+
+    async fn rpc_attach_gateway_session(
+        &self,
+        binding: &str,
+        session_id: &str,
+    ) -> BackendResult<Option<String>> {
+        let mut st = self.state.lock().unwrap();
+        st.gateway_sessions_attached
+            .push((binding.to_string(), session_id.to_string()));
+        let rows = st.gateway_sessions_by_key.get(binding);
+        Ok(rows.and_then(|rows| {
+            rows.iter()
+                .find(|r| r.session_id == session_id)
+                .map(|r| r.acp_session_id.clone().unwrap_or_default())
+        }))
     }
 
     async fn rpc_ensure_gateway_session(

--- a/apps/daemon/src/backend/mod.rs
+++ b/apps/daemon/src/backend/mod.rs
@@ -55,7 +55,8 @@ pub mod deferred;
 pub mod records;
 pub use records::{
     AgentRuntimeRow, AgentRuntimeUpsert, BackendParticipantRow, BackendSessionAndParticipants,
-    BackendSessionRow, ClaimResult, StoredMessage, WorkspaceRow, WorkspaceUpsert,
+    BackendSessionRow, ClaimResult, GatewaySessionRow, StoredMessage, WorkspaceRow,
+    WorkspaceUpsert,
 };
 
 /// MQTT settings delivered by `/v1/config/bootstrap`. The full broker URL
@@ -382,6 +383,34 @@ pub trait Backend: Send + Sync {
     /// surface degrade to a plain runtime reset instead of failing `/clear`.
     async fn rpc_detach_gateway_session(&self, _acp_session_id: &str) -> BackendResult<bool> {
         Ok(false)
+    }
+
+    /// One gateway chat's own sessions, newest first: the currently-bound one
+    /// plus every session `/new` detached from it. `gateway_key` is the chat's
+    /// binding, which — unlike `binding` itself — survives a detach.
+    ///
+    /// Default impl reports an empty list so backends without a gateway surface
+    /// answer `/sessions` with "no sessions" rather than an error.
+    async fn rpc_list_gateway_sessions(
+        &self,
+        _team_id: &str,
+        _gateway_key: &str,
+        _limit: u32,
+    ) -> BackendResult<Vec<GatewaySessionRow>> {
+        Ok(Vec::new())
+    }
+
+    /// Point a chat's binding at one of that chat's existing sessions — the
+    /// inverse of `rpc_detach_gateway_session`. Returns the target's
+    /// `acp_session_id` on success, or `None` when the session is unknown or
+    /// belongs to a different chat (which the caller must report as such rather
+    /// than as a completed switch).
+    async fn rpc_attach_gateway_session(
+        &self,
+        _binding: &str,
+        _session_id: &str,
+    ) -> BackendResult<Option<String>> {
+        Ok(None)
     }
 
     /// Resolve (or create) the `sessions` row for a gateway binding.

--- a/apps/daemon/src/backend/records.rs
+++ b/apps/daemon/src/backend/records.rs
@@ -92,6 +92,22 @@ pub struct StoredMessage {
     pub created_at: i64,
 }
 
+/// One row of `GET /v1/sessions/gateway` — a session belonging to a single
+/// gateway chat. `is_current` marks the one the chat is bound to right now;
+/// the rest are earlier generations of the same conversation, kept listable so
+/// `/sessions <n>` can switch back into them.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct GatewaySessionRow {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(rename = "acpSessionId", default)]
+    pub acp_session_id: Option<String>,
+    #[serde(default)]
+    pub title: String,
+    #[serde(rename = "isCurrent", default)]
+    pub is_current: bool,
+}
+
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct BackendSessionRow {
     pub id: String,

--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -23,8 +23,15 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use teamclaw_gateway::{
-    AgentCommand, AgentError, AgentHandle, AmuxSessionId, ModelInfo, TurnOutcome, WorkspaceInfo,
+    AgentCommand, AgentError, AgentHandle, AmuxSessionId, ModelInfo, SessionInfo, TurnOutcome,
+    WorkspaceInfo,
 };
+
+/// How many of a chat's past sessions `/sessions` offers. A long-lived WeCom
+/// conversation accumulates one row per `/new`, and a chat bubble listing
+/// hundreds of them is unreadable — the newest are the ones anyone switches
+/// back to.
+const GATEWAY_SESSION_LIST_LIMIT: u32 = 20;
 
 use crate::backend::Backend;
 use crate::proto::amux;
@@ -190,27 +197,35 @@ impl AmuxdAgentHandle {
             .collect())
     }
 
-    /// The WeCom bot this session belongs to, if any.
+    /// The chat binding this session is bound to, if any.
     ///
     /// Reads the cached binding first and falls back to the `sessions` row,
-    /// because a `/workspace` switch usually arrives before the session has
-    /// ever spawned a runtime — at which point nothing is cached yet.
-    async fn bot_id_for_session(&self, session: &AmuxSessionId) -> Option<String> {
+    /// because a command usually arrives before the session has ever spawned a
+    /// runtime — at which point nothing is cached yet. An empty result means the
+    /// session is not gateway-bound, which callers treat as "no chat history to
+    /// speak of" rather than an error.
+    async fn binding_for_session(&self, session: &AmuxSessionId) -> Option<String> {
         let cached = {
             let map = self.logical_to_acp.lock().await;
             map.get(session).map(|s| s.binding.clone())
         };
-        let binding = match cached {
-            Some(b) if !b.is_empty() => b,
-            _ => self
-                .backend
-                .get_gateway_session_by_acp_id(session)
-                .await
-                .ok()
-                .flatten()
-                .and_then(|(_, binding)| binding)
-                .unwrap_or_default(),
-        };
+        if let Some(b) = cached {
+            if !b.is_empty() {
+                return Some(b);
+            }
+        }
+        self.backend
+            .get_gateway_session_by_acp_id(session)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|(_, binding)| binding)
+            .filter(|b| !b.is_empty())
+    }
+
+    /// The WeCom bot this session belongs to, if any.
+    async fn bot_id_for_session(&self, session: &AmuxSessionId) -> Option<String> {
+        let binding = self.binding_for_session(session).await?;
         bot_id_from_binding(&binding).map(str::to_string)
     }
 
@@ -1029,15 +1044,76 @@ impl AgentHandle for AmuxdAgentHandle {
         self.send_prompt(session, "user", &text).await
     }
 
+    /// This chat's own session history, from the cloud store.
+    ///
+    /// It used to enumerate `logical_to_acp`, which is an in-memory runtime
+    /// cache: it holds at most the currently-live session, forgets everything on
+    /// restart, and is keyed by ACP hex ids that name nothing to a chat user. So
+    /// `/sessions` printed one bare id, and right after `/new` printed "No
+    /// sessions." while the history sat in the database.
+    ///
+    /// The persistent list is keyed on the chat's binding (`gateway_key`), which
+    /// this handle resolves from the active session's row.
     async fn list_sessions(
         &self,
         active_session: &AmuxSessionId,
-    ) -> Result<Vec<(AmuxSessionId, bool)>, AgentError> {
-        let map = self.logical_to_acp.lock().await;
-        Ok(map
-            .keys()
-            .map(|k| (k.clone(), k == active_session))
+    ) -> Result<Vec<SessionInfo>, AgentError> {
+        let Some(binding) = self.binding_for_session(active_session).await else {
+            return Ok(Vec::new());
+        };
+        let rows = self
+            .backend
+            .rpc_list_gateway_sessions(&self.team_id, &binding, GATEWAY_SESSION_LIST_LIMIT)
+            .await
+            .map_err(|e| AgentError::Internal(format!("list_gateway_sessions: {e}")))?;
+        Ok(rows
+            .into_iter()
+            .map(|r| SessionInfo {
+                session_id: r.session_id,
+                title: r.title,
+                is_current: r.is_current,
+            })
             .collect())
+    }
+
+    /// Move this chat's binding onto one of its earlier sessions.
+    ///
+    /// The switch itself is a single server-side operation: sessions are keyed
+    /// by (team, binding), so once the binding points at the target row, the
+    /// next inbound message resolves to it through the same
+    /// `ensure_gateway_session` path as any other message — nothing local needs
+    /// to be rewritten. The runtime map is left alone deliberately: an entry for
+    /// the target that is still live (switching back inside one daemon uptime)
+    /// keeps its conversation context, and one that is gone lazy-spawns on the
+    /// next message exactly as a restart would.
+    async fn switch_session(
+        &self,
+        active_session: &AmuxSessionId,
+        target_session_id: &str,
+    ) -> Result<bool, AgentError> {
+        let Some(binding) = self.binding_for_session(active_session).await else {
+            return Ok(false);
+        };
+        // Stop whatever the outgoing session is doing: its turn would otherwise
+        // keep running and reply into a chat that has moved on.
+        let _ = self.cancel(active_session).await;
+        let attached = self
+            .backend
+            .rpc_attach_gateway_session(&binding, target_session_id)
+            .await
+            .map_err(|e| AgentError::Internal(format!("attach_gateway_session: {e}")))?;
+        match attached {
+            Some(acp) => {
+                tracing::info!(
+                    from_session = %active_session,
+                    to_session = %target_session_id,
+                    to_acp_session = %acp,
+                    "gateway chat switched session"
+                );
+                Ok(true)
+            }
+            None => Ok(false),
+        }
     }
 
     /// Enumerates workspaces from the cloud `amux.workspaces` table
@@ -1612,5 +1688,125 @@ mod tests {
         let overrides = handle.model_override.lock().await;
         let stored = overrides.get("sess-2").cloned().unwrap();
         assert_eq!(stored.1, "opus", "second set_model must overwrite");
+    }
+
+    /// Seed a chat (`binding`) whose lineage is `rows`, bound to `acp` right now.
+    fn seed_chat(
+        backend: &Arc<MockBackend>,
+        acp: &str,
+        binding: &str,
+        rows: Vec<crate::backend::GatewaySessionRow>,
+    ) {
+        let mut st = backend.state();
+        st.gateway_session_index.insert(
+            acp.to_string(),
+            ("session-row".to_string(), Some(binding.to_string())),
+        );
+        st.gateway_sessions_by_key.insert(binding.to_string(), rows);
+    }
+
+    fn gw_row(
+        session_id: &str,
+        acp: &str,
+        title: &str,
+        is_current: bool,
+    ) -> crate::backend::GatewaySessionRow {
+        crate::backend::GatewaySessionRow {
+            session_id: session_id.to_string(),
+            acp_session_id: Some(acp.to_string()),
+            title: title.to_string(),
+            is_current,
+        }
+    }
+
+    #[tokio::test]
+    async fn list_sessions_returns_the_chats_persisted_lineage_not_the_runtime_map() {
+        // The old impl enumerated `logical_to_acp`, so right after `/new` — when
+        // nothing is spawned — `/sessions` answered "No sessions." while the
+        // history sat in the cloud store.
+        let backend = Arc::new(MockBackend::default());
+        seed_chat(
+            &backend,
+            "acp-live",
+            "wecom://bot-1/user/liang",
+            vec![
+                gw_row("s-2", "acp-live", "WeCom DM: LiangLiang", true),
+                gw_row(
+                    "s-1",
+                    "acp-old",
+                    "WeCom DM: LiangLiang (2026-07-26 09:12)",
+                    false,
+                ),
+            ],
+        );
+        let handle = make_handle_with_backend(backend);
+
+        let out = handle
+            .list_sessions(&AmuxSessionId::from("acp-live"))
+            .await
+            .unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].session_id, "s-2");
+        assert!(out[0].is_current);
+        assert_eq!(out[0].title, "WeCom DM: LiangLiang");
+        assert!(!out[1].is_current);
+        assert!(handle.logical_to_acp.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_sessions_is_empty_for_a_session_with_no_chat_binding() {
+        // A session that is not gateway-bound has no chat history to list; the
+        // command must say "No sessions." rather than fail.
+        let handle = make_handle();
+        let out = handle
+            .list_sessions(&AmuxSessionId::from("acp-unbound"))
+            .await
+            .unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn switch_session_moves_the_chats_binding_to_the_target() {
+        let backend = Arc::new(MockBackend::default());
+        seed_chat(
+            &backend,
+            "acp-live",
+            "wecom://bot-1/user/liang",
+            vec![
+                gw_row("s-2", "acp-live", "now", true),
+                gw_row("s-1", "acp-old", "earlier", false),
+            ],
+        );
+        let handle = make_handle_with_backend(backend.clone());
+
+        let switched = handle
+            .switch_session(&AmuxSessionId::from("acp-live"), "s-1")
+            .await
+            .unwrap();
+        assert!(switched);
+        assert_eq!(
+            backend.state().gateway_sessions_attached.as_slice(),
+            &[("wecom://bot-1/user/liang".to_string(), "s-1".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn switch_session_declines_a_session_from_another_chat() {
+        // The guard lives in the backend (`gateway_key` must match), so the
+        // handle has to report the refusal rather than assume success.
+        let backend = Arc::new(MockBackend::default());
+        seed_chat(
+            &backend,
+            "acp-live",
+            "wecom://bot-1/user/liang",
+            vec![gw_row("s-2", "acp-live", "now", true)],
+        );
+        let handle = make_handle_with_backend(backend);
+
+        let switched = handle
+            .switch_session(&AmuxSessionId::from("acp-live"), "s-elsewhere")
+            .await
+            .unwrap();
+        assert!(!switched);
     }
 }

--- a/crates/teamclaw-gateway/src/agent.rs
+++ b/crates/teamclaw-gateway/src/agent.rs
@@ -30,6 +30,20 @@ pub struct TurnOutcome {
     pub completed: bool,
 }
 
+/// One of a chat's sessions, returned by `list_sessions`.
+///
+/// `session_id` is the cloud `sessions.id` — the id `switch_session` takes, and
+/// deliberately not the logical ACP id: the ACP id is what identifies the *live*
+/// runtime, and a detached session usually has no runtime at all.
+#[derive(Debug, Clone)]
+pub struct SessionInfo {
+    pub session_id: String,
+    /// Human-readable title from the session row ("WeCom DM: LiangLiang"), with
+    /// the detach timestamp older generations carry.
+    pub title: String,
+    pub is_current: bool,
+}
+
 /// Workspace entry returned by `list_workspaces`.
 #[derive(Debug, Clone)]
 pub struct WorkspaceInfo {
@@ -154,12 +168,28 @@ pub trait AgentHandle: Send + Sync + 'static {
         input: Option<&str>,
     ) -> Result<TurnOutcome, AgentError>;
 
-    /// List all logical sessions this handle knows about (spawned since last
-    /// daemon restart). Returns `(session_id, is_current)` pairs.
+    /// This chat's own sessions, newest first: the one it is talking to now,
+    /// plus the earlier generations `/new` pushed aside. Persisted — not the
+    /// in-memory runtime map, which forgets everything on daemon restart and
+    /// holds at most the live session.
     async fn list_sessions(
         &self,
         active_session: &AmuxSessionId,
-    ) -> Result<Vec<(AmuxSessionId, bool)>, AgentError>;
+    ) -> Result<Vec<SessionInfo>, AgentError>;
+
+    /// Make one of this chat's earlier sessions current again, so the next
+    /// message continues there instead of in `active_session`.
+    ///
+    /// `Ok(false)` means the target is not a session of this chat — a stale
+    /// number from an old listing, say — and nothing was switched. The default
+    /// impl declines everything, for handles with no persistent session store.
+    async fn switch_session(
+        &self,
+        _active_session: &AmuxSessionId,
+        _target_session_id: &str,
+    ) -> Result<bool, AgentError> {
+        Ok(false)
+    }
 
     /// List workspaces known to the daemon.
     async fn list_workspaces(

--- a/crates/teamclaw-gateway/src/commands.rs
+++ b/crates/teamclaw-gateway/src/commands.rs
@@ -1,4 +1,4 @@
-use crate::agent::{AgentError, AgentHandle, AmuxSessionId, ModelInfo};
+use crate::agent::{AgentError, AgentHandle, AmuxSessionId, ModelInfo, SessionInfo};
 use crate::channel_store::ChannelStore;
 use std::sync::Arc;
 
@@ -118,7 +118,7 @@ enum MetaCommand {
     Sessions(Option<String>),
     Workspace(Option<String>),
     Skills,
-    Clear,
+    New,
     Stop,
     Ctx(String),
 }
@@ -133,7 +133,11 @@ fn parse_meta(name: &str, arg: Option<&str>) -> Option<MetaCommand> {
         // learned the old name.
         "workspace" | "workspaces" => Some(MetaCommand::Workspace(arg.map(str::to_string))),
         "skills" => Some(MetaCommand::Skills),
-        "clear" => Some(MetaCommand::Clear),
+        // `/clear` is gone rather than aliased: it named the wrong operation.
+        // Nothing is cleared — the old session keeps every message, it just
+        // stops being this chat's current one, and `/sessions <n>` can go back
+        // to it. `/new` says that; `/clear` said the opposite.
+        "new" => Some(MetaCommand::New),
         "stop" => Some(MetaCommand::Stop),
         "ctx" => match arg {
             Some(t) if !t.is_empty() => Some(MetaCommand::Ctx(t.to_string())),
@@ -147,12 +151,24 @@ const GATEWAY_HELP: &str = "\
 Gateway commands:
 /help - Show this help
 /model [name] - List or switch models
-/sessions [id] - List sessions
+/sessions [n] - List this chat's sessions, or continue #n
 /workspace [n] - List workspaces, or make #n this bot's default
 /skills - List workspace skills
-/clear - Start new session
+/new - Start a new session (the current one stays in /sessions)
 /stop - Stop current processing
 /ctx <text> - Inject context without reply";
+
+/// What a session shows up as in a `/sessions` listing. Titles are generated
+/// from the chat itself ("WeCom DM: LiangLiang", plus a detach timestamp on
+/// older generations), so an empty one means the row was written by something
+/// that skipped the title — fall back to the id rather than an empty bullet.
+fn session_label(s: &SessionInfo) -> String {
+    if s.title.trim().is_empty() {
+        s.session_id.clone()
+    } else {
+        s.title.clone()
+    }
+}
 
 /// How many catalog entries a `/model` listing shows. A real backend catalog
 /// runs to hundreds of models across every configured provider; a chat bubble
@@ -305,21 +321,59 @@ where
             if sessions.is_empty() {
                 "No sessions.".to_string()
             } else {
+                // Numbered and titled, so the reply is usable as the input for
+                // the next command. It used to print raw ACP hex ids, which
+                // name nothing a chat user can recognise and cannot be typed
+                // back in.
                 let lines: Vec<String> = sessions
                     .iter()
-                    .map(|(id, cur)| {
-                        if *cur {
-                            format!("* {} (current)", id)
-                        } else {
-                            format!("  {}", id)
-                        }
+                    .enumerate()
+                    .map(|(i, s)| {
+                        let marker = if s.is_current { " (current)" } else { "" };
+                        format!("{}. {}{}", i + 1, session_label(s), marker)
                     })
                     .collect();
-                format!("Sessions:\n{}", lines.join("\n"))
+                format!(
+                    "Sessions:\n{}\n\nUsage: /sessions <number> — continue that conversation",
+                    lines.join("\n")
+                )
             }
         }
-        MetaCommand::Sessions(Some(_id)) => {
-            "Session switching is not yet supported. Use /sessions to list sessions.".to_string()
+        MetaCommand::Sessions(Some(arg)) => {
+            let arg = arg.trim();
+            let sessions = agent.list_sessions(session).await?;
+            // A bare number picks from the list just printed; anything else is
+            // taken as a session id, which is what the reply's own ids are.
+            let target = match arg.parse::<usize>() {
+                Ok(n) => match n.checked_sub(1).and_then(|i| sessions.get(i)) {
+                    Some(s) => s.session_id.clone(),
+                    None => {
+                        reply(format!(
+                            "No session #{n}. Use /sessions to list them ({} available).",
+                            sessions.len()
+                        ));
+                        return Ok(true);
+                    }
+                },
+                Err(_) => arg.to_string(),
+            };
+            let already_current = sessions
+                .iter()
+                .any(|s| s.session_id == target && s.is_current);
+            if already_current {
+                "Already in this session.".to_string()
+            } else if agent.switch_session(session, &target).await? {
+                let title = sessions
+                    .iter()
+                    .find(|s| s.session_id == target)
+                    .map(session_label)
+                    .unwrap_or_else(|| target.clone());
+                format!("Switched to: {title}\nThe next message continues that conversation.")
+            } else {
+                "Cannot switch to that session — it is not one of this chat's. \
+                 Use /sessions to list them."
+                    .to_string()
+            }
         }
 
         MetaCommand::Workspace(None) => {
@@ -380,9 +434,11 @@ where
             }
         }
 
-        MetaCommand::Clear => {
+        MetaCommand::New => {
             agent.start_new_session(session).await?;
-            "Started a new session. The next message begins a fresh conversation.".to_string()
+            "Started a new session. The next message begins a fresh conversation \
+             (/sessions to go back to this one)."
+                .to_string()
         }
 
         MetaCommand::Stop => match agent.cancel(session).await {
@@ -504,6 +560,7 @@ mod tests {
         current_model: Option<String>,
         workspace_set_to: Mutex<Option<String>>,
         new_session_called: Mutex<bool>,
+        switched_to: Mutex<Option<String>>,
     }
 
     impl MockAgent {
@@ -515,6 +572,7 @@ mod tests {
                 current_model: None,
                 workspace_set_to: Mutex::new(None),
                 new_session_called: Mutex::new(false),
+                switched_to: Mutex::new(None),
             }
         }
 
@@ -526,6 +584,7 @@ mod tests {
                 current_model: None,
                 workspace_set_to: Mutex::new(None),
                 new_session_called: Mutex::new(false),
+                switched_to: Mutex::new(None),
             }
         }
 
@@ -639,12 +698,35 @@ mod tests {
 
         async fn list_sessions(
             &self,
-            active_session: &AmuxSessionId,
-        ) -> Result<Vec<(AmuxSessionId, bool)>, AgentError> {
+            _active_session: &AmuxSessionId,
+        ) -> Result<Vec<SessionInfo>, AgentError> {
             Ok(vec![
-                (active_session.clone(), true),
-                ("sess-old".to_string(), false),
+                SessionInfo {
+                    session_id: "sess-now".to_string(),
+                    title: "WeCom DM: LiangLiang".to_string(),
+                    is_current: true,
+                },
+                SessionInfo {
+                    session_id: "sess-old".to_string(),
+                    title: "WeCom DM: LiangLiang (2026-07-26 09:12)".to_string(),
+                    is_current: false,
+                },
             ])
+        }
+
+        async fn switch_session(
+            &self,
+            _active_session: &AmuxSessionId,
+            target_session_id: &str,
+        ) -> Result<bool, AgentError> {
+            // Mirrors the real handle: a target outside this chat's own list is
+            // declined rather than silently accepted.
+            if target_session_id == "sess-old" || target_session_id == "sess-now" {
+                *self.switched_to.lock().unwrap() = Some(target_session_id.to_string());
+                Ok(true)
+            } else {
+                Ok(false)
+            }
         }
 
         async fn list_workspaces(
@@ -761,7 +843,7 @@ mod tests {
         let text = reply.unwrap();
         assert!(text.contains("/help"));
         assert!(text.contains("/model"));
-        assert!(text.contains("/clear"));
+        assert!(text.contains("/new"));
         assert!(text.contains("/ctx"));
         // /agents was dropped: opencode is the only backend, so it always
         // listed exactly one entry.
@@ -868,19 +950,99 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn clear_starts_a_new_session_rather_than_only_resetting_the_runtime() {
-        // /clear used to call reset_session, which swaps the runtime but keeps
-        // the same session row — the reply claimed something the user could
-        // not observe anywhere.
+    async fn new_starts_a_new_session_rather_than_only_resetting_the_runtime() {
+        // This used to be `/clear`, which called reset_session: that swaps the
+        // runtime but keeps the same session row — the reply claimed something
+        // the user could not observe anywhere.
         let agent = MockAgent::new();
-        let (result, reply) = run_dispatch(&agent, "clear", None).await;
+        let (result, reply) = run_dispatch(&agent, "new", None).await;
         assert!(result.unwrap());
         assert!(*agent.new_session_called.lock().unwrap());
         assert!(
             !*agent.reset_called.lock().unwrap(),
-            "/clear must not stop at a runtime reset"
+            "/new must not stop at a runtime reset"
         );
         assert!(reply.unwrap().contains("new session"));
+    }
+
+    #[tokio::test]
+    async fn clear_is_no_longer_a_command() {
+        // Removed rather than aliased: nothing is cleared, and `/sessions` can
+        // still reach the session `/new` pushed aside.
+        let agent = MockAgent::new();
+        let (result, _) = run_dispatch(&agent, "clear", None).await;
+        assert!(!result.unwrap(), "/clear must fall through as unknown");
+        assert!(!*agent.new_session_called.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn sessions_lists_numbered_titles_not_raw_ids() {
+        // The old listing printed bare ACP hex ids, which name nothing to a
+        // chat user and cannot be typed back in as an argument.
+        let agent = MockAgent::new();
+        let (result, reply) = run_dispatch(&agent, "sessions", None).await;
+        assert!(result.unwrap());
+        let text = reply.unwrap();
+        assert!(
+            text.contains("1. WeCom DM: LiangLiang (current)"),
+            "got {text}"
+        );
+        assert!(
+            text.contains("2. WeCom DM: LiangLiang (2026-07-26 09:12)"),
+            "got {text}"
+        );
+        assert!(!text.contains("sess-now"), "ids must not leak: {text}");
+        assert!(text.contains("/sessions <number>"), "got {text}");
+    }
+
+    #[tokio::test]
+    async fn sessions_number_switches_to_that_session() {
+        let agent = MockAgent::new();
+        let (result, reply) = run_dispatch(&agent, "sessions", Some("2")).await;
+        assert!(result.unwrap());
+        assert_eq!(
+            agent.switched_to.lock().unwrap().as_deref(),
+            Some("sess-old")
+        );
+        let text = reply.unwrap();
+        assert!(
+            text.starts_with("Switched to: WeCom DM: LiangLiang (2026-07-26"),
+            "got {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sessions_number_for_the_current_session_is_a_no_op() {
+        let agent = MockAgent::new();
+        let (result, reply) = run_dispatch(&agent, "sessions", Some("1")).await;
+        assert!(result.unwrap());
+        assert_eq!(reply.unwrap(), "Already in this session.");
+        assert!(
+            agent.switched_to.lock().unwrap().is_none(),
+            "switching to the current session must not touch the binding"
+        );
+    }
+
+    #[tokio::test]
+    async fn sessions_out_of_range_number_says_how_many_there_are() {
+        let agent = MockAgent::new();
+        let (result, reply) = run_dispatch(&agent, "sessions", Some("9")).await;
+        assert!(result.unwrap());
+        let text = reply.unwrap();
+        assert!(text.contains("No session #9"), "got {text}");
+        assert!(text.contains("2 available"), "got {text}");
+        assert!(agent.switched_to.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn sessions_declined_switch_is_reported_as_such() {
+        // A session id from another chat: the handle declines it, and the reply
+        // must not claim a switch happened.
+        let agent = MockAgent::new();
+        let (result, reply) = run_dispatch(&agent, "sessions", Some("sess-elsewhere")).await;
+        assert!(result.unwrap());
+        assert!(reply.unwrap().contains("not one of this chat's"));
+        assert!(agent.switched_to.lock().unwrap().is_none());
     }
 
     #[tokio::test]
@@ -921,16 +1083,16 @@ mod tests {
     #[tokio::test]
     async fn agent_command_takes_priority_over_meta() {
         let agent = MockAgent::with_agent_commands(vec![AgentCommand {
-            name: "clear".to_string(),
-            description: "agent clear".to_string(),
+            name: "new".to_string(),
+            description: "agent new".to_string(),
             input_hint: None,
         }]);
-        let (result, reply) = run_dispatch(&agent, "clear", None).await;
+        let (result, reply) = run_dispatch(&agent, "new", None).await;
         assert!(result.unwrap());
         let text = reply.unwrap();
-        // Should be the agent response, NOT "Session cleared."
-        assert_eq!(text, "agent handled: clear");
-        assert!(!*agent.reset_called.lock().unwrap());
+        // Should be the agent response, NOT the gateway's own /new reply.
+        assert_eq!(text, "agent handled: new");
+        assert!(!*agent.new_session_called.lock().unwrap());
     }
 
     // ── dispatch_session_slash_cmd (shared by Discord/Feishu/Kook) ────────────

--- a/crates/teamclaw-gateway/src/lib.rs
+++ b/crates/teamclaw-gateway/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod agent;
 pub mod commands;
 pub use agent::{
-    AgentCommand, AgentError, AgentHandle, AmuxSessionId, ModelInfo, TurnOutcome,
+    AgentCommand, AgentError, AgentHandle, AmuxSessionId, ModelInfo, SessionInfo, TurnOutcome,
     WorkspaceInfo,
 };
 

--- a/crates/teamclaw-gateway/src/wecom.rs
+++ b/crates/teamclaw-gateway/src/wecom.rs
@@ -1291,7 +1291,7 @@ impl WeComGateway {
                         | "sessions"
                         | "workspace"
                         | "workspaces"
-                        | "clear"
+                        | "new"
                         | "ctx"
                 );
                 if !needs_session {
@@ -1431,7 +1431,7 @@ impl WeComGateway {
 
         // Slash-command dispatch: two-layer (agent-advertised commands first, then
         // gateway meta-commands: /help, /model, /sessions,
-        // /workspace, /clear, /stop, /ctx).
+        // /workspace, /new, /stop, /ctx).
         if let Some((cmd_name, cmd_arg)) = commands::parse_slash(text_content.trim()) {
             use std::sync::{Arc as SArc, Mutex};
             let reply_cell: SArc<Mutex<Option<String>>> = SArc::new(Mutex::new(None));

--- a/docs/openapi/teamclaw-api.v1.yaml
+++ b/docs/openapi/teamclaw-api.v1.yaml
@@ -781,6 +781,140 @@ paths:
           $ref: "#/components/responses/Error"
         "401":
           $ref: "#/components/responses/Error"
+  /v1/sessions/gateway:
+    get:
+      operationId: listGatewaySessions
+      summary: List one gateway chat's sessions
+      description: >-
+        The sessions belonging to a single gateway chat, newest first: the one
+        the chat is bound to right now plus every earlier generation that `/new`
+        detached from it. Scoped to `gatewayKey` — the chat's binding, which
+        unlike `binding` itself survives a detach — so a chat only ever
+        enumerates its own lineage.
+      tags: [Sessions]
+      parameters:
+        - name: teamId
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: gatewayKey
+          in: query
+          required: true
+          description: The chat's binding, e.g. `wecom://<bot>/user/<id>`.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: The chat's sessions, newest first.
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      required: [sessionId, title, isCurrent]
+                      properties:
+                        sessionId:
+                          type: string
+                          format: uuid
+                        acpSessionId:
+                          type:
+                            - string
+                            - "null"
+                        title:
+                          type:
+                            - string
+                            - "null"
+                        isCurrent:
+                          type: boolean
+                          description: True for the session the chat is bound to now.
+                        lastMessageAt:
+                          type:
+                            - string
+                            - "null"
+                          format: date-time
+                        createdAt:
+                          type:
+                            - string
+                            - "null"
+                          format: date-time
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
+  /v1/sessions/gateway/attach:
+    post:
+      operationId: attachGatewaySession
+      summary: Attach a gateway chat to one of its existing sessions
+      description: >-
+        The inverse of gateway detach: point a chat's binding at one of that
+        chat's own sessions, so the next inbound message continues there.
+        Because sessions are keyed by (teamId, binding), the binding is *moved* —
+        released from its current holder, then set on the target.
+
+
+        Fails soft with `attached: false` when the target does not exist or
+        belongs to a different chat, so one conversation cannot hijack another's
+        session and the caller can report "no such session" rather than a
+        switch that did not happen.
+      tags: [Sessions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [binding, sessionId]
+              properties:
+                binding:
+                  type: string
+                sessionId:
+                  type: string
+                  format: uuid
+      responses:
+        "200":
+          description: Attach result.
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [attached]
+                properties:
+                  sessionId:
+                    type:
+                      - string
+                      - "null"
+                    format: uuid
+                  acpSessionId:
+                    type:
+                      - string
+                      - "null"
+                  attached:
+                    type: boolean
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
   /v1/sessions/cron:
     post:
       operationId: createCronSession

--- a/services/fc/src/db/migrations/0016_sessions_gateway_key.sql
+++ b/services/fc/src/db/migrations/0016_sessions_gateway_key.sql
@@ -1,0 +1,24 @@
+-- The gateway chat a session belongs to, for the session's whole lifetime.
+-- Mirrors services/supabase/migrations/20260728000000_gateway_session_switch.sql
+-- (the column and its index only — the RPC functions in that file are the
+-- supabase path; this backend reaches the same behaviour through Drizzle in
+-- src/lib/pg-repo/sessions.ts).
+--
+-- `binding` cannot serve this purpose: it is the "currently attached" pointer
+-- and `/new` nulls it, so a detached session keeps no trace of its origin.
+-- `gateway_key` is written at create time from the binding and never cleared,
+-- which is what lets one chat enumerate its own past sessions and switch back
+-- into one (`/sessions` → `/sessions <n>`).
+
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "gateway_key" text;
+
+CREATE INDEX IF NOT EXISTS "sessions_gateway_key_idx"
+  ON "sessions" ("team_id", "gateway_key")
+  WHERE "gateway_key" IS NOT NULL;
+
+-- Recoverable only for sessions still attached: a session detached before this
+-- migration has no signal left on the row to recover its chat from.
+UPDATE "sessions"
+SET "gateway_key" = "binding"
+WHERE "gateway_key" IS NULL
+  AND "binding" IS NOT NULL;

--- a/services/fc/src/db/schema/sessions.ts
+++ b/services/fc/src/db/schema/sessions.ts
@@ -16,8 +16,13 @@ export const sessions = pgTable("sessions", {
   lastMessageAt: timestamp("last_message_at", { withTimezone: true }),
   /** ACP / gateway integration: used by getSessionByAcp */
   acpSessionId: text("acp_session_id"),
-  /** Gateway binding key (unique per team); used by ensureGatewaySession */
+  /** Gateway binding key (unique per team); used by ensureGatewaySession.
+   *  This is the "currently attached" pointer: detaching nulls it. */
   binding: text("binding"),
+  /** The gateway chat a session belongs to, for the session's whole lifetime.
+   *  Written at create time from the binding and never cleared, so a chat can
+   *  still enumerate the sessions it detached from (`/sessions` → `/sessions n`). */
+  gatewayKey: text("gateway_key"),
   /** How the session was created: 'user' (default) | 'cron' | 'gateway'. */
   source: text("source").notNull().default("user"),
   /** For source='cron': the desktop-local cron job id that created it

--- a/services/fc/src/lib/pg-repo/sessions.ts
+++ b/services/fc/src/lib/pg-repo/sessions.ts
@@ -16,6 +16,8 @@
  *  - list_current_actor_sessions   → listSessions (Drizzle join on participants)
  *  - mark_current_actor_session_viewed → markSessionViewed (upsert read marker)
  *  - ensure_gateway_session        → ensureGatewaySession (get-or-create on binding)
+ *  - list_gateway_sessions         → listGatewaySessions (one chat's own lineage)
+ *  - attach_gateway_session        → attachGatewaySession (move a chat's binding)
  */
 
 import { and, desc, eq, gt, inArray, isNull, or, sql } from "drizzle-orm";
@@ -422,6 +424,74 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
       return { sessionId: existing.id, detached: true };
     },
 
+    // ── listGatewaySessions ───────────────────────────────────────────────────
+    /**
+     * One gateway chat's own sessions, newest first — the current one plus every
+     * session `/new` detached from it. Scoped to `gatewayKey` (never nulled), so
+     * a chat sees only its own lineage: not another chat's, not the desktop's.
+     */
+    async listGatewaySessions(input: { teamId: string; gatewayKey: string; limit?: number }) {
+      const limit = Math.max(1, Math.min(input.limit ?? 20, 100));
+      const rows = await db
+        .select()
+        .from(sessions)
+        .where(and(eq(sessions.teamId, input.teamId), eq(sessions.gatewayKey, input.gatewayKey)))
+        .orderBy(desc(sql`coalesce(${sessions.lastMessageAt}, ${sessions.createdAt})`), desc(sessions.id))
+        .limit(limit);
+      return {
+        items: rows.map((r) => ({
+          sessionId: r.id,
+          acpSessionId: r.acpSessionId ?? null,
+          title: r.title,
+          isCurrent: r.binding != null && r.binding === input.gatewayKey,
+          lastMessageAt: iso(r.lastMessageAt),
+          createdAt: iso(r.createdAt),
+        })),
+      };
+    },
+
+    // ── attachGatewaySession ──────────────────────────────────────────────────
+    /**
+     * The inverse of `detachGatewaySession`: point a chat's binding at one of
+     * that chat's existing sessions, so the next inbound message continues
+     * there. Because (teamId, binding) is unique, the binding is *moved* —
+     * released from its current holder (same title timestamp suffix detach
+     * applies) and then set on the target, in that order.
+     *
+     * Fails soft with attached=false when the target is unknown or belongs to a
+     * different chat, so a caller cannot hijack another conversation's session
+     * and the gateway can report "no such session" rather than a phantom switch.
+     */
+    async attachGatewaySession(input: { binding: string; sessionId: string }) {
+      const [target] = await db
+        .select()
+        .from(sessions)
+        .where(and(eq(sessions.id, input.sessionId), eq(sessions.gatewayKey, input.binding)))
+        .limit(1);
+      if (!target) return { sessionId: null, acpSessionId: null, attached: false };
+
+      // Already current: idempotent no-op.
+      if (target.binding === input.binding) {
+        return { sessionId: target.id, acpSessionId: target.acpSessionId ?? null, attached: true };
+      }
+
+      const [holder] = await db
+        .select()
+        .from(sessions)
+        .where(and(eq(sessions.teamId, target.teamId), eq(sessions.binding, input.binding)))
+        .limit(1);
+      if (holder) {
+        const stamp = new Date().toISOString().slice(0, 16).replace("T", " ");
+        await db
+          .update(sessions)
+          .set({ binding: null, title: holder.title ? `${holder.title} (${stamp})` : holder.title })
+          .where(eq(sessions.id, holder.id));
+      }
+
+      await db.update(sessions).set({ binding: input.binding }).where(eq(sessions.id, target.id));
+      return { sessionId: target.id, acpSessionId: target.acpSessionId ?? null, attached: true };
+    },
+
     // ── markSessionViewed ─────────────────────────────────────────────────────
     /**
      * AUTHZ (#10): the read marker's actor is ALWAYS resolved server-side from
@@ -564,6 +634,14 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
 
       if (existing) {
         await syncParticipants(existing.id);
+        // Backfill the chat marker on rows that predate it, so a long-running
+        // conversation becomes listable by `/sessions` without a data migration.
+        if (!existing.gatewayKey) {
+          await db
+            .update(sessions)
+            .set({ gatewayKey: input.binding })
+            .where(eq(sessions.id, existing.id));
+        }
         // NOTE: un-archiving on a new message lives in the
         // `amux.ensure_gateway_session` SQL function (the supabase path, which
         // is what production runs). It is deliberately not mirrored here: this
@@ -589,6 +667,7 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
           primaryAgentId: input.primaryAgentActorId,
           createdByActorId: input.primaryAgentActorId,
           binding: input.binding,
+          gatewayKey: input.binding,
           source: "gateway",
         })
         .returning();

--- a/services/fc/src/lib/routes/sessions.ts
+++ b/services/fc/src/lib/routes/sessions.ts
@@ -23,6 +23,23 @@ export function registerSessions(router) {
     return { body: out };
   });
 
+  // One gateway chat's own sessions: the current one plus everything `/new`
+  // detached from it. Keyed on `gatewayKey` (the chat's binding, which survives
+  // detach) so a chat can only enumerate its own lineage. Registered above
+  // `/:sessionId` — otherwise "gateway" is read as a session id.
+  router.get("/v1/sessions/gateway", async (ctx) => {
+    const teamId = ctx.query.get("teamId");
+    const gatewayKey = ctx.query.get("gatewayKey");
+    requireString(teamId, "teamId");
+    requireString(gatewayKey, "gatewayKey");
+    const out = await ctx.repository.listGatewaySessions({
+      teamId,
+      gatewayKey,
+      limit: parseLimit(ctx.query.get("limit")),
+    });
+    return { body: out };
+  });
+
   router.get("/v1/sessions/:sessionId", async (ctx) => {
     const sessionId = decodeURIComponent(ctx.params.sessionId);
     const out = await ctx.repository.getSession(sessionId);
@@ -112,6 +129,20 @@ export function registerSessions(router) {
     const body = ctx.json ?? {};
     requireString(body.acpSessionId, "acpSessionId");
     const out = await ctx.repository.detachGatewaySession(body.acpSessionId);
+    return { body: out };
+  });
+
+  // Point a chat's binding at one of that chat's existing sessions — the
+  // inverse of /gateway/detach. `attached: false` means the target is unknown
+  // or belongs to a different chat; the caller must not report a switch.
+  router.post("/v1/sessions/gateway/attach", async (ctx) => {
+    const body = ctx.json ?? {};
+    requireString(body.binding, "binding");
+    requireString(body.sessionId, "sessionId");
+    const out = await ctx.repository.attachGatewaySession({
+      binding: body.binding,
+      sessionId: body.sessionId,
+    });
     return { body: out };
   });
 

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -2230,6 +2230,40 @@ export function createSupabaseBusinessRepository(options) {
       };
     },
 
+    async listGatewaySessions(input) {
+      const { data, error } = await supabase.rpc("list_gateway_sessions", {
+        p_team_id: input.teamId,
+        p_gateway_key: input.gatewayKey,
+        p_limit: input.limit ?? 20,
+      });
+      if (error) throw error;
+      const rows: any[] = Array.isArray(data) ? data : data ? [data] : [];
+      return {
+        items: rows.map((r) => ({
+          sessionId: r.session_id ?? r.sessionId ?? null,
+          acpSessionId: r.acp_session_id ?? r.acpSessionId ?? null,
+          title: r.title ?? "",
+          isCurrent: (r.is_current ?? r.isCurrent) === true,
+          lastMessageAt: r.last_message_at ?? r.lastMessageAt ?? null,
+          createdAt: r.created_at ?? r.createdAt ?? null,
+        })),
+      };
+    },
+
+    async attachGatewaySession(input) {
+      const { data, error } = await supabase.rpc("attach_gateway_session", {
+        p_binding: input.binding,
+        p_session_id: input.sessionId,
+      });
+      if (error) throw error;
+      const row = Array.isArray(data) ? data[0] : data;
+      return {
+        sessionId: row?.session_id ?? row?.sessionId ?? null,
+        acpSessionId: row?.acp_session_id ?? row?.acpSessionId ?? null,
+        attached: (row?.attached ?? row?.Attached) === true,
+      };
+    },
+
     async createCronSession(input) {
       // Cron sessions are plain `mode='collab'` sessions with no idea_id and
       // a marker in `summary` or metadata. The supabase create_session RPC

--- a/services/fc/test/pg-repo-sessions.test.ts
+++ b/services/fc/test/pg-repo-sessions.test.ts
@@ -473,6 +473,125 @@ test("ensureGatewaySession different bindings in same team create different sess
   assert.equal(r2.created, true);
 });
 
+// ── listGatewaySessions / attachGatewaySession ────────────────────────────────
+
+test("a chat's whole lineage stays listable across detach, and attach switches back", async () => {
+  // `/new` detaches the binding, which is what makes the next message open a
+  // fresh session. Before `gateway_key` that was a one-way door: the detached
+  // row had no trace of which chat it came from, so nothing could name it.
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const actor = await seedActor(db, team.id, { kind: "agent" });
+  const repo = createPgBusinessRepository({ db });
+  const binding = `wecom:room#${Math.random()}`;
+
+  const first = await repo.ensureGatewaySession({
+    teamId: team.id,
+    binding,
+    title: "WeCom DM: LiangLiang",
+    primaryAgentActorId: actor.id,
+    ownerMemberActorIds: [],
+    participantActorIds: [],
+  });
+  const firstAcp = `acp-${Math.random()}`;
+  await db.update(sessions).set({ acpSessionId: firstAcp }).where(eq(sessions.id, first.sessionId));
+
+  // /new
+  const detached = await repo.detachGatewaySession(firstAcp);
+  assert.equal(detached.detached, true);
+
+  // Next message opens a second session under the same binding.
+  const second = await repo.ensureGatewaySession({
+    teamId: team.id,
+    binding,
+    title: "WeCom DM: LiangLiang",
+    primaryAgentActorId: actor.id,
+    ownerMemberActorIds: [],
+    participantActorIds: [],
+  });
+  assert.equal(second.created, true, "detaching must free the binding");
+  assert.notEqual(second.sessionId, first.sessionId);
+
+  const listed = await repo.listGatewaySessions({ teamId: team.id, gatewayKey: binding });
+  assert.equal(listed.items.length, 2, "both generations must be listed");
+  const current = listed.items.filter((i: any) => i.isCurrent);
+  assert.equal(current.length, 1, "exactly one session is current");
+  assert.equal(current[0].sessionId, second.sessionId);
+  assert.ok(
+    listed.items.some((i: any) => i.sessionId === first.sessionId && !i.isCurrent),
+    "the detached session must be listed, not current",
+  );
+
+  // /sessions <n> back to the first one.
+  const attached = await repo.attachGatewaySession({ binding, sessionId: first.sessionId });
+  assert.equal(attached.attached, true);
+  assert.equal(attached.acpSessionId, firstAcp, "the target's ACP id is what resumes");
+
+  const afterSwitch = await repo.listGatewaySessions({ teamId: team.id, gatewayKey: binding });
+  const nowCurrent = afterSwitch.items.filter((i: any) => i.isCurrent);
+  assert.equal(nowCurrent.length, 1, "the binding is unique: only one holder");
+  assert.equal(nowCurrent[0].sessionId, first.sessionId);
+
+  // The session that gave up the binding keeps its history and stays listed.
+  const [displaced] = await db.select().from(sessions).where(eq(sessions.id, second.sessionId));
+  assert.equal(displaced.binding, null);
+  assert.equal(displaced.gatewayKey, binding);
+});
+
+test("attachGatewaySession refuses a session belonging to another chat", async () => {
+  // The guard is what stops one chat from hijacking another's conversation:
+  // the daemon calls this as its agent actor for whatever number a user typed.
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const actor = await seedActor(db, team.id, { kind: "agent" });
+  const repo = createPgBusinessRepository({ db });
+
+  const mine = `wecom:room#mine-${Math.random()}`;
+  const theirs = `wecom:room#theirs-${Math.random()}`;
+  const args = {
+    teamId: team.id,
+    title: "chat",
+    primaryAgentActorId: actor.id,
+    ownerMemberActorIds: [],
+    participantActorIds: [],
+  };
+  await repo.ensureGatewaySession({ ...args, binding: mine });
+  const other = await repo.ensureGatewaySession({ ...args, binding: theirs });
+
+  const out = await repo.attachGatewaySession({ binding: mine, sessionId: other.sessionId });
+  assert.equal(out.attached, false);
+  assert.equal(out.sessionId, null);
+
+  // And the other chat kept its own binding.
+  const [row] = await db.select().from(sessions).where(eq(sessions.id, other.sessionId));
+  assert.equal(row.binding, theirs);
+});
+
+test("listGatewaySessions only returns the requested chat's sessions", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const actor = await seedActor(db, team.id, { kind: "agent" });
+  const repo = createPgBusinessRepository({ db });
+
+  const a = `wecom:room#a-${Math.random()}`;
+  const b = `wecom:room#b-${Math.random()}`;
+  const args = {
+    teamId: team.id,
+    title: "chat",
+    primaryAgentActorId: actor.id,
+    ownerMemberActorIds: [],
+    participantActorIds: [],
+  };
+  const inA = await repo.ensureGatewaySession({ ...args, binding: a });
+  await repo.ensureGatewaySession({ ...args, binding: b });
+
+  const listed = await repo.listGatewaySessions({ teamId: team.id, gatewayKey: a });
+  assert.deepEqual(
+    listed.items.map((i: any) => i.sessionId),
+    [inA.sessionId],
+  );
+});
+
 // ── createCronSession ─────────────────────────────────────────────────────────
 
 test("createCronSession returns sessionId", async () => {

--- a/services/supabase/migrations/20260728000000_gateway_session_switch.sql
+++ b/services/supabase/migrations/20260728000000_gateway_session_switch.sql
@@ -1,0 +1,246 @@
+-- Let a gateway chat list its own past sessions and switch back into one.
+--
+-- `/new` (previously `/clear`) detaches the chat's binding so the next message
+-- opens a fresh session; the old row keeps every message it had. Until now that
+-- was a one-way door: nothing could name those old sessions, let alone re-enter
+-- one. `/sessions` listed the daemon's in-memory logical→ACP map, which holds at
+-- most the currently-live session, so the reply was a single bare hex id — and
+-- right after `/new` it was "No sessions." while the history sat in the database.
+--
+-- Two pieces are missing to make the round trip work:
+--
+--   1. A durable marker of WHICH chat a session belonged to. `binding` cannot
+--      serve: it is the "currently attached" pointer and `detach` nulls it, so a
+--      detached session has no trace of its origin. This adds `gateway_key`,
+--      written at create time from the binding and never cleared, so the whole
+--      lineage of one WeCom conversation stays enumerable.
+--
+--   2. An attach operation — the inverse of detach. Because sessions are keyed
+--      by (team_id, binding) with a unique constraint, attaching means moving
+--      the binding: release it from whoever holds it, then point it at the
+--      target. Both happen in one function call, so the unique constraint is
+--      never transiently violated.
+--
+-- Backfill note: `gateway_key` can only be recovered for sessions that are
+-- still attached (binding is not null). Sessions detached by a `/clear` before
+-- this migration lost their origin and stay unlisted — there is no signal left
+-- on the row to recover it from. New detaches keep working from here on.
+
+-- ── 1. gateway_key: the chat a session belongs to, for its whole lifetime ────
+
+ALTER TABLE amux.sessions
+  ADD COLUMN IF NOT EXISTS gateway_key text;
+
+CREATE INDEX IF NOT EXISTS sessions_gateway_key_idx
+  ON amux.sessions (team_id, gateway_key)
+  WHERE gateway_key IS NOT NULL;
+
+UPDATE amux.sessions
+   SET gateway_key = binding
+ WHERE gateway_key IS NULL
+   AND binding IS NOT NULL;
+
+-- ── 2. ensure_gateway_session: stamp gateway_key (and repair older rows) ─────
+--
+-- Unchanged from 20260727020000 except for the gateway_key writes: the insert
+-- stamps it, and existing rows get it backfilled on their next message so a
+-- session created before this migration becomes listable without a data
+-- migration of its own.
+
+create or replace function amux.ensure_gateway_session(
+  p_team_id uuid,
+  p_binding text,
+  p_title text,
+  p_primary_agent_actor_id uuid,
+  p_owner_member_actor_ids uuid[],
+  p_participant_actor_ids uuid[]
+)
+returns table(session_id uuid, acp_session_id text, created boolean)
+language plpgsql
+security definer
+set search_path to 'amux', 'public', 'extensions'
+as $function$
+declare
+  v_session uuid;
+  v_acp     text;
+  v_created boolean := false;
+begin
+  select s.id, s.acp_session_id
+    into v_session, v_acp
+    from amux.sessions as s
+   where s.team_id = p_team_id
+     and s.binding = p_binding;
+
+  if v_session is null then
+    insert into amux.sessions
+      (team_id, idea_id, created_by_actor_id, primary_agent_id,
+       mode, title, binding, gateway_key, acp_session_id)
+    values
+      (p_team_id,
+       null,
+       p_primary_agent_actor_id,
+       p_primary_agent_actor_id,
+       'collab',
+       p_title,
+       p_binding,
+       p_binding,
+       encode(extensions.gen_random_bytes(16), 'hex'))
+    returning amux.sessions.id, amux.sessions.acp_session_id
+      into v_session, v_acp;
+    v_created := true;
+  else
+    -- Un-archive on inbound traffic (see 20260727020000), and backfill
+    -- gateway_key for rows that predate this migration. `source` is left
+    -- alone: gateway rows created here have always carried the default
+    -- 'user', and the cron path reaches this same function with a
+    -- `cron/<job>/<run>` binding, so there is no single correct value to
+    -- rewrite them to from in here.
+    update amux.sessions
+       set archived_at = null,
+           gateway_key = coalesce(gateway_key, p_binding)
+     where id = v_session
+       and (archived_at is not null or gateway_key is null);
+  end if;
+
+  -- Runs for existing rows too: this is what makes a session that outlived
+  -- the agent which created it reachable again.
+  insert into amux.session_participants (session_id, actor_id)
+    select v_session, participant_actor_id
+      from unnest(
+        array[p_primary_agent_actor_id]
+          || coalesce(p_owner_member_actor_ids, '{}'::uuid[])
+          || coalesce(p_participant_actor_ids,  '{}'::uuid[])
+      ) as participant_actor_id
+     where participant_actor_id is not null
+  on conflict on constraint session_participants_session_id_actor_id_key
+  do nothing;
+
+  return query select v_session, v_acp, v_created;
+end;
+$function$;
+
+-- ── 3. list_gateway_sessions: this chat's own sessions, newest first ─────────
+--
+-- Scoped to one gateway_key, so a WeCom conversation only ever sees its own
+-- lineage — not other chats', and not the desktop's. Archived rows are included
+-- deliberately: archiving hides a chat from the session list, but from inside
+-- the chat itself the conversation is still part of its own history, and
+-- attaching to one un-archives it anyway.
+--
+-- SECURITY DEFINER for the same reason as the two functions above: the daemon
+-- calls this as its agent actor, whose RLS grants do not cover a detached row
+-- (`is_session_participant` still holds, but the row is not reachable through
+-- the session-list RPC once unbound).
+
+create or replace function amux.list_gateway_sessions(
+  p_team_id uuid,
+  p_gateway_key text,
+  p_limit integer default 20
+)
+returns table(
+  session_id uuid,
+  acp_session_id text,
+  title text,
+  is_current boolean,
+  last_message_at timestamp with time zone,
+  created_at timestamp with time zone
+)
+language sql
+stable
+security definer
+set search_path to 'amux', 'public', 'extensions'
+as $function$
+  select s.id,
+         s.acp_session_id,
+         s.title,
+         (s.binding is not null and s.binding = p_gateway_key) as is_current,
+         s.last_message_at,
+         s.created_at
+    from amux.sessions as s
+   where s.team_id = p_team_id
+     and s.gateway_key = p_gateway_key
+   order by coalesce(s.last_message_at, s.created_at) desc, s.id desc
+   limit greatest(1, least(coalesce(p_limit, 20), 100));
+$function$;
+
+grant execute on function amux.list_gateway_sessions(uuid, text, integer) to authenticated;
+
+-- ── 4. attach_gateway_session: the inverse of detach ────────────────────────
+--
+-- Moves a chat's binding onto an existing session of that same chat, so the
+-- next inbound message resolves to it and the conversation continues there.
+--
+-- Guards:
+--   * the target must belong to the same chat (`gateway_key = p_binding`) —
+--     otherwise a chat could hijack another conversation's session, which the
+--     daemon's agent actor has no business doing;
+--   * whoever currently holds the binding is detached first, with the same
+--     title timestamp suffix `detach_gateway_session` applies, so the two
+--     paths produce identically-shaped history;
+--   * attaching un-archives, because the chat is demonstrably in use.
+--
+-- Returns attached=false (with a null session) when the target does not exist
+-- or is not part of this chat's lineage, so the caller can say so rather than
+-- reporting a switch that did not happen.
+
+create or replace function amux.attach_gateway_session(
+  p_binding text,
+  p_session_id uuid
+)
+returns table(session_id uuid, acp_session_id text, attached boolean)
+language plpgsql
+security definer
+set search_path to 'amux', 'public', 'extensions'
+as $function$
+declare
+  v_team    uuid;
+  v_acp     text;
+  v_binding text;
+  v_holder  uuid;
+  v_title   text;
+begin
+  select s.team_id, s.acp_session_id, s.binding
+    into v_team, v_acp, v_binding
+    from amux.sessions as s
+   where s.id = p_session_id
+     and s.gateway_key = p_binding;
+
+  if v_team is null then
+    return query select null::uuid, null::text, false;
+    return;
+  end if;
+
+  -- Already the current session for this chat: nothing to move, and reporting
+  -- it as attached keeps the command idempotent.
+  if v_binding is not null and v_binding = p_binding then
+    update amux.sessions set archived_at = null where id = p_session_id;
+    return query select p_session_id, v_acp, true;
+    return;
+  end if;
+
+  select s.id, s.title
+    into v_holder, v_title
+    from amux.sessions as s
+   where s.team_id = v_team
+     and s.binding = p_binding;
+
+  if v_holder is not null then
+    update amux.sessions
+       set binding = null,
+           title = case
+                     when coalesce(v_title, '') = '' then v_title
+                     else v_title || ' (' || to_char(now(), 'YYYY-MM-DD HH24:MI') || ')'
+                   end
+     where id = v_holder;
+  end if;
+
+  update amux.sessions
+     set binding = p_binding,
+         archived_at = null
+   where id = p_session_id;
+
+  return query select p_session_id, v_acp, true;
+end;
+$function$;
+
+grant execute on function amux.attach_gateway_session(text, uuid) to authenticated;


### PR DESCRIPTION
## 问题

`/clear` 这个名字描述的是一件没有发生的事。它做的是把 chat 的 binding 解绑,让下一条消息开一个新 session,而**旧 session 里每一条消息都还在**。但那是一扇单向门:没有任何东西能叫出那些 session 的名字,更别说回去。

`/sessions` 列的是 daemon 内存里的 logical→ACP map,那张表最多只装当前活着的一个 session,重启即忘。所以:

- `/sessions` 的回复是一个裸的 hex id —— 对聊天里的人没有任何意义,也没法打回去当参数用;
- 刚 `/clear` 完再打 `/sessions`,回复是 "No sessions.",而历史就躺在数据库里。

## 改动

`/clear` → `/new`。是**删掉**不是加别名 —— `/clear` 说的和实际发生的正好相反,留着别名等于把这个误导保留下来。

`/sessions` 现在列这个 chat 真实的会话历史:带编号、带标题,`/sessions <n>` 直接回到那一条。

要让这个来回成立,补了两块:

**1. `gateway_key` —— session 属于哪个 chat 的持久标记**

`binding` 担不了这个职责:它是"当前挂在谁身上"的指针,detach 会把它置空,于是一个被解绑的 session 身上不再留有任何来源痕迹。`gateway_key` 在创建时从 binding 写入,此后永不清除,老行在下一条消息进来时补写。

**2. `attach_gateway_session` —— detach 的逆操作**

session 按 `(team_id, binding)` 唯一,所以"切回去"本质是**搬 binding**:先从当前持有者手上摘下来,再挂到目标上。两步在同一个函数调用里完成,唯一约束不会被瞬时破坏。

两条护栏:
- 目标必须 `gateway_key` 匹配,否则一个 chat 就能劫持另一个 chat 的会话 —— daemon 的 agent actor 没有这个权限;
- 找不到或不属于本 chat 时返回 `attached: false` 而不是报错,让 gateway 能如实说"没这个 session",而不是汇报一次根本没发生的切换。

## 兼容性

本次改动之前被 `/clear` 解绑掉的 session 仍然列不出来 —— 那些行上已经没有任何信号能还原出它属于哪个 chat 了。此后新产生的 detach 都能正常回溯。

## 验证

| 检查 | 结果 |
|---|---|
| `cargo test -p teamclaw-gateway -p amuxd` | 全绿(gateway 94 / daemon 586) |
| `cargo clippy` 两个 crate | 无 error |
| `rustfmt --check` 全部改动文件 | clean |
| `services/fc` `pnpm test` | 1111 tests / 18 fail |
| 同上 baseline(stash 后对比) | 1108 tests / 18 fail |
| `openapi:lint` | valid,6 个 warning 全在既有路径 |

FC 那 18 个失败是既有的(teams / push / workspace-config 那批),与本 PR 无关,已 stash 对比确认;本 PR 新增的 3 个测试全过。

## 已知遗留

- `pnpm typecheck` 里 `pg-repo/sessions.ts` 的 `binding does not exist in type` 是既有的 drizzle 类型推断问题(baseline 就报),新代码只是同类多了 3 处,没在本 PR 处理。
- Discord 的 `/sessions` 仍是 "not supported in v2 yet",不在本次 WeCom 范围内。
- 既有的 `/v1/sessions/gateway/detach` 一直没有 OpenAPI 文档,是另一笔旧账,本 PR 只补了新增的两个端点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)