### PR TITLE
fix(fc): restore the container build — cast the sessions update-set type

### DIFF
--- a/services/fc/src/lib/pg-repo/sessions.ts
+++ b/services/fc/src/lib/pg-repo/sessions.ts
@@ -40,6 +40,23 @@ const iso = (d: Date | string | null | undefined): string | null =>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DbLike = PgDatabase<any, any>;
 
+/**
+ * `db.update(sessions)` with the update-set type escaped.
+ *
+ * Drizzle 0.36 collapses `sessions`'s set-source down to its
+ * not-null-without-default columns (`mode`, `teamId`, `title`), so setting any
+ * nullable column — `binding`, `gatewayKey` — fails to typecheck even though
+ * the column plainly exists. Every other pg-repo module hits this and works
+ * around it with the same cast at each call site; centralising it here keeps
+ * the escape hatch documented in one place instead of scattered.
+ *
+ * This matters beyond the editor: the FC container builds with
+ * `tsc -p tsconfig.json`, so an un-cast `.set()` breaks the image build and the
+ * self-host deploy with it.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const updateSessions = (db: DbLike): any => db.update(sessions);
+
 export interface SessionsRepoDeps {
   /** Called after a successful markSessionViewed DB write. Best-effort: errors are
    *  logged and swallowed so the mark-viewed outcome is never affected. */
@@ -417,8 +434,7 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
       }
       const stamp = new Date().toISOString().slice(0, 16).replace("T", " ");
       const title = existing.title ? `${existing.title} (${stamp})` : existing.title;
-      await db
-        .update(sessions)
+      await updateSessions(db)
         .set({ binding: null, title })
         .where(eq(sessions.id, existing.id));
       return { sessionId: existing.id, detached: true };
@@ -482,13 +498,12 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
         .limit(1);
       if (holder) {
         const stamp = new Date().toISOString().slice(0, 16).replace("T", " ");
-        await db
-          .update(sessions)
+        await updateSessions(db)
           .set({ binding: null, title: holder.title ? `${holder.title} (${stamp})` : holder.title })
           .where(eq(sessions.id, holder.id));
       }
 
-      await db.update(sessions).set({ binding: input.binding }).where(eq(sessions.id, target.id));
+      await updateSessions(db).set({ binding: input.binding }).where(eq(sessions.id, target.id));
       return { sessionId: target.id, acpSessionId: target.acpSessionId ?? null, attached: true };
     },
 
@@ -637,8 +652,7 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
         // Backfill the chat marker on rows that predate it, so a long-running
         // conversation becomes listable by `/sessions` without a data migration.
         if (!existing.gatewayKey) {
-          await db
-            .update(sessions)
+          await updateSessions(db)
             .set({ gatewayKey: input.binding })
             .where(eq(sessions.id, existing.id));
         }


### PR DESCRIPTION
## 影响

**self-host 部署自 #594 起一直是红的**,`main` 上的改动没有真正上线过。#596 又加了 3 处同类错误。

FC 镜像的构建步骤是 `tsc -p tsconfig.json`,所以 `src/` 里任何类型错误都会让 `docker compose build fc` 失败,连带整个 `self-host-deploy.yml` 挂掉 —— 包括数据库 migration 那一步。也就是说 `20260728000000_gateway_session_switch.sql` 至今没有被应用。

这里有个容易踩的坑,值得记一笔:`npm run typecheck` 用的是 `tsconfig.test.json`,和构建用的 `tsconfig.json` **不是同一个配置**。本地 typecheck 看着"只有既有报错"不代表镜像构建能过。

## 根因

Drizzle 0.36 把 `sessions` 的 update-set 源类型塌缩成了它三个 `notNull` 且无默认值的列(`mode`、`teamId`、`title`)。于是给任何可空列赋值 —— `binding`、`gatewayKey` —— 都会报 TS2353,尽管这些列明明存在:

```
error TS2353: Object literal may only specify known properties,
and 'binding' does not exist in type '{ mode?: ...; teamId?: ...; title?: ... }'
```

仓库里其他 pg-repo 模块早就撞上过同一个问题,做法是在每个调用点写 `(db.update(table) as any).set(...)`。`sessions.ts` 是唯一没这么做的。

## 改动

把这个 escape hatch 收成一个带说明的 `updateSessions()` helper,而不是再撒四个裸 `as any`,并在注释里点明它会影响容器构建 —— 免得下次又有人以为这只是编辑器噪音。

行为完全不变:cast 只绕开 set-source 的类型,不碰运行时。

## 验证

| 检查 | 之前 | 之后 |
|---|---|---|
| `npm run build`(镜像构建用的那个) | 4 × TS2353 | **通过** |
| `npm run typecheck` | 6 errors | 2(均为无关的既有 test 文件报错) |
| `pnpm test` | 1111 / 18 fail | 1111 / 18 fail(既有,未变) |
| `pg-repo-sessions.test.ts` | 36 pass | 36 pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)