### PR TITLE
feat(extension): finish Chrome extension branding — scoped hosts, branded identity, and a Web Store listing kit

### DIFF
--- a/.github/actions/brand-setup/action.yml
+++ b/.github/actions/brand-setup/action.yml
@@ -75,6 +75,19 @@ runs:
           cp -R .branding-src/branding/. ./branding/
         fi
 
+        # Chrome extension assets are per-brand, so they come from brands/<brand>/
+        # rather than the shared branding/ tree — two brands publishing different
+        # Web Store items must not read each other's icons and screenshots.
+        # Landing them at branding/extension/ keeps the path that
+        # scripts/lib/branding.js resolveExtensionIconPlan already reads.
+        if [ -d "$src/extension" ]; then
+          mkdir -p ./branding/extension
+          cp -R "$src/extension/." ./branding/extension/
+          echo "Extension assets: $(find ./branding/extension -type f | wc -l | tr -d ' ') file(s) from ${src}/extension"
+        else
+          echo "Extension assets: none (${src}/extension not present) — default icons and no listing kit"
+        fi
+
         BRAND="$BRAND" python3 - <<'PY'
         import json, os
 
@@ -124,8 +137,16 @@ runs:
             print(f'::error::app.shortName must be 1-20 chars of [a-z0-9]; got {app_slug!r}')
             raise SystemExit(1)
 
+        # Each brand publishes to its own Web Store item, so the item ID belongs
+        # to the brand rather than to a single repo-level secret that whichever
+        # brand ran last would overwrite. The OAuth credentials stay repo-level:
+        # they authenticate the publisher account, not the item. Empty here means
+        # "fall back to the CHROME_EXTENSION_ID secret".
+        chrome = meta.get('chromeWebStore') or {}
+
         out = {
             'BRAND': brand,
+            'CHROME_EXTENSION_ID': chrome.get('extensionId') or '',
             'APP_NAME': app_name,
             'APP_PRODUCT_NAME': product_name,
             'APP_SLUG': app_slug,

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -77,7 +77,8 @@ jobs:
       # Applies build.config.json (brand name + branding/extension/icons, if the
       # branding repo shipped them) onto apps/extension/manifest.json BEFORE the
       # bundle build, mirroring scripts/update-tauri-config.js for desktop.
-      # Host scoping reads `extensions.domains` (same source as the side-panel gate).
+      # Host scoping reads `extensions.domains` / `extension.hosts` via
+      # resolveExtensionPack (same source as the side-panel gate).
       - name: Apply branding to extension manifest + icons
         run: node scripts/update-extension-manifest.js
 
@@ -86,23 +87,46 @@ jobs:
           BUILD_ENV: production
         run: pnpm --filter @teamclaw/extension build
 
+      # The Web Store API cannot write listing metadata (media.upload + publish
+      # are the only mutating endpoints), so screenshots, store copy and the
+      # privacy answers ship as a reviewed artifact for manual entry instead.
+      # Runs after the build so it can validate the justifications against the
+      # permissions the packaged manifest actually requests.
+      - name: Build Chrome Web Store listing kit
+        run: node scripts/build-extension-listing-kit.js
+
       - name: Zip extension
         run: |
           cd apps/extension/dist
           zip -r ../../../extension.zip .
+          cd "$GITHUB_WORKSPACE"
+          if [ -d listing-kit ]; then
+            zip -r listing-kit.zip listing-kit
+          fi
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
         with:
           name: chrome-extension
-          path: extension.zip
+          # listing-kit.zip is absent for a brand that ships no extension assets,
+          # so an unmatched path must not fail the build.
+          path: |
+            extension.zip
+            listing-kit.zip
           retention-days: 30
 
       - name: Attach to GitHub Release
         if: startsWith(github.ref, 'refs/tags/ext-v')
         uses: softprops/action-gh-release@v3
         with:
-          files: extension.zip
+          files: |
+            extension.zip
+            listing-kit.zip
+          # A brand that ships no extension/ assets produces no listing-kit.zip.
+          # The action's own default is already false, but it is declared only in
+          # an input description rather than a `default:` key — pinning it here
+          # keeps a brand without store assets from failing its release.
+          fail_on_unmatched_files: false
           generate_release_notes: true
 
       # Publishes to the Chrome Web Store via the Chrome Web Store API. Needs a
@@ -110,14 +134,32 @@ jobs:
       # https://www.googleapis.com/auth/chromewebstore) and an existing draft
       # listing's item ID. Until those secrets are configured this step is a
       # no-op — the zip above can still be uploaded to the dashboard by hand.
+      #
+      # The item ID comes from the brand (brand.json → chromeWebStore.extensionId,
+      # exported by brand-setup into $GITHUB_ENV, so it arrives here by plain env
+      # inheritance) and each brand thus publishes to its own listing; the repo
+      # secret is the fallback for a brand that declares none. The fallback is
+      # resolved in bash rather than as `${{ env.CHROME_EXTENSION_ID || ... }}`:
+      # a step's env block reading the env context under the key it is itself
+      # defining is undocumented behaviour, and getting it wrong would silently
+      # publish one brand's package over another brand's Web Store item.
+      # Only the package is uploaded here — listing metadata is in listing-kit.zip
+      # and has to be entered by hand, the API has no endpoint for it.
       - name: Publish to Chrome Web Store
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
         env:
-          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_EXTENSION_ID_FALLBACK: ${{ secrets.CHROME_EXTENSION_ID }}
           CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
           CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
           CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
         run: |
+          CHROME_EXTENSION_ID="${CHROME_EXTENSION_ID:-}"
+          if [ -n "$CHROME_EXTENSION_ID" ]; then
+            echo "Web Store item: ${CHROME_EXTENSION_ID} (from brand ${BRAND:-?})"
+          else
+            CHROME_EXTENSION_ID="$CHROME_EXTENSION_ID_FALLBACK"
+            echo "Web Store item: repo-level CHROME_EXTENSION_ID secret (brand declares none)"
+          fi
           if [ -z "$CHROME_EXTENSION_ID" ] || [ -z "$CHROME_CLIENT_ID" ] || [ -z "$CHROME_CLIENT_SECRET" ] || [ -z "$CHROME_REFRESH_TOKEN" ]; then
             echo "ℹ️ Chrome Web Store secrets not configured (CHROME_EXTENSION_ID / CHROME_CLIENT_ID / CHROME_CLIENT_SECRET / CHROME_REFRESH_TOKEN)."
             echo "   Built extension.zip is available as a workflow artifact for manual upload."

--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,11 @@ apps/desktop/icons/ios/
 # Brand owners supply branding/<brand>/{logo.png,theme.json} + build.config.<brand>.json
 # locally; the white-label build reads them from disk at build time.
 /branding/
+# Chrome Web Store listing kit, assembled from branding/extension/ at release
+# time and attached to the Release — a build output, not a source.
+/listing-kit/
+/listing-kit.zip
+/extension.zip
 # Ignore all root build.config.<brand>.json except the in-repo flavors.
 /build.config.*.json
 !/build.config.example.json

--- a/apps/extension/build.mjs
+++ b/apps/extension/build.mjs
@@ -13,7 +13,7 @@ const appDir = resolve(here, '../../packages/app')
 const linkHoverShared = resolve(appDir, 'src/lib/extension-link-hover')
 const linkSessionShared = resolve(appDir, 'src/lib/extension-link-session')
 const nodeRequire = createRequire(import.meta.url)
-const { parseExtensionsConfig, domainsToSidePanelCsv } = nodeRequire(
+const { resolveExtensionPack, domainsToSidePanelCsv } = nodeRequire(
   resolve(repoRoot, 'scripts/lib/extension-config.js'),
 )
 
@@ -63,7 +63,7 @@ function loadMergedBuildConfig() {
 }
 
 const mergedBuildConfig = loadMergedBuildConfig()
-const extensionPack = parseExtensionsConfig(mergedBuildConfig.extensions)
+const extensionPack = resolveExtensionPack(mergedBuildConfig)
 const domainsCsv = domainsToSidePanelCsv(extensionPack.domains)
 const extensionSettingsBake = extensionPack.settings
 

--- a/apps/extension/build.mjs
+++ b/apps/extension/build.mjs
@@ -13,7 +13,7 @@ const appDir = resolve(here, '../../packages/app')
 const linkHoverShared = resolve(appDir, 'src/lib/extension-link-hover')
 const linkSessionShared = resolve(appDir, 'src/lib/extension-link-session')
 const nodeRequire = createRequire(import.meta.url)
-const { resolveExtensionPack, domainsToSidePanelCsv } = nodeRequire(
+const { resolveExtensionPack, domainsToSidePanelCsv, SIDE_PANEL_PRUNE_DIRS } = nodeRequire(
   resolve(repoRoot, 'scripts/lib/extension-config.js'),
 )
 
@@ -96,6 +96,17 @@ execSync(`pnpm ${webBuildScript}`, {
   },
 })
 cpSync(resolve(appDir, 'dist'), resolve(dist, 'sidepanel'), { recursive: true })
+
+// vite copies packages/app/public/ verbatim, so anything parked there ships in
+// a package that is publicly downloadable from the Chrome Web Store. Drop the
+// directories nothing in the side panel requests — see SIDE_PANEL_PRUNE_DIRS
+// for what and why, and the guardrail tests that keep the list honest.
+for (const dir of SIDE_PANEL_PRUNE_DIRS) {
+  const target = resolve(dist, 'sidepanel', dir)
+  if (!existsSync(target)) continue
+  rmSync(target, { recursive: true, force: true })
+  console.log('[extension] pruned sidepanel/%s (not requested at runtime)', dir)
+}
 
 // 2) Bundle background (module worker) + content script (IIFE).
 await build({

--- a/docs/chrome-extension-design.md
+++ b/docs/chrome-extension-design.md
@@ -392,16 +392,44 @@ Chrome → `chrome://extensions` → 开发者模式 → 「加载已解压的�
 - push tag `ext-v*`（打包产物随 GitHub Release 附件发布，与桌面 `v*` tag 规则并行、互不影响）
 - `workflow_dispatch`（手动跑，`publish` 输入项默认勾选自动发布，取消勾选则只产出 zip）
 
-**品牌注入**：复用桌面 `release.yml` 同一套 `BRANDING_REPO` / `BRANDING_REPO_PAT` / `BRANDING_CONFIG_FILE`
-私有仓库拉取机制（见该 workflow 的 "Fetch branding assets" step）。拉下来的 `branding/` 目录里，
-扩展专属资产放在：
+**品牌注入**：`.github/actions/brand-setup` 从私有 enterprise-branding 仓库取
+`brands/<brand>/`，落地两部分：
 
-- `branding/extension/icons/icon-{16,48,128}.png` — 预先切好三种尺寸（不在 CI 里做图片转换）
-- `build.config.copilot361.json` 里的 `app.name`（可选 `app.version`）
+- `brands/<brand>/build.config.json` → 仓库根的 `build.config.json`
+- `brands/<brand>/extension/` → `branding/extension/`（**按品牌隔离**；共享的
+  `branding/<palette>/` 是按调色板分的，两个品牌发的是两个不同的 Web Store 条目，
+  扩展资产不能共用）
+
+`branding/extension/` 的结构：
+
+```
+icons/icon-{16,48,128}.png    预先切好三种尺寸（不在 CI 里做图片转换）
+listing.json                  商店文案：description / category / language / visibility
+privacy.json                  Privacy 页答案：singlePurpose / permissionJustifications / ...
+listing/screenshots/*.png     1280x800 或 640x400，24-bit PNG 无 alpha，最多 5 张
+listing/promo-small/*.png     440x280
+listing/promo-marquee/*.png   1400x560
+```
 
 `scripts/update-extension-manifest.js` 在 build 前把这些合并进 `apps/extension/manifest.json`
-（同名/同版本才覆盖，逻辑与 `scripts/update-tauri-config.js` 对齐）。没有配置 branding 仓库或对应
-文件时该脚本是纯 no-op，保持默认 TeamClaw 品牌。
+（逻辑与 `scripts/update-tauri-config.js` 对齐）：`app.name` → `name` + `action.default_title`，
+`extension.description` → `description`（Chrome 上限 132 字符，超了直接报错而不是静默截断），
+host 白名单 → `host_permissions` + `content_scripts.matches`。没有配置 branding 仓库时是纯
+no-op，保持默认 TeamClaw 品牌。
+
+> **host 白名单的两种写法**。仓库自己的配置用 `extensions.domains`
+> （见 `build.config.example.json`），而 branding 仓库里每个品牌用的都是
+> `extension.hosts`。二者都必须能用 —— 在 `scripts/lib/extension-config.js`
+> 的 `resolveExtensionPack` 里统一处理。这里曾经只读前者，导致品牌声明的域名收窄
+> 全部失效，本该只跑在 10 个 Shopee 域名上的扩展带着 `<all_urls>` 去过审。
+
+**Listing kit**：Chrome Web Store API v2 只有 `media.upload` 和
+`publishers.items.{publish,fetchStatus,cancelSubmission,setPublishedDeployPercentage}`，
+**没有任何接口能写 listing 元数据** —— 描述、截图、宣传图、分类、Privacy 答案全部只能在
+开发者后台手填。所以 `scripts/build-extension-listing-kit.js` 把 branding 仓库里的这些内容
+组装成 `listing-kit.zip`（校验过尺寸/alpha 的图片 + 一份可直接粘贴的 README），随 Release
+一起产出，人工照着填一次。它同时会拿打包后的 manifest 反查：声明了却没写理由的权限、空的
+商店描述、缺失的截图，都会以 `::warning::` 报出来。
 
 **Chrome Web Store 自动发布**（可选，需要一次性手动准备）：
 

--- a/docs/chrome-webstore-privacy-practices.md
+++ b/docs/chrome-webstore-privacy-practices.md
@@ -1,5 +1,16 @@
 # Chrome Web Store — Privacy practices 填写内容（copilot361）
 
+> **已被 branding 仓库取代。** 这份文案是随品牌变的，现在的来源是
+> enterprise-branding 仓库的 `brands/<brand>/extension/privacy.json`，由
+> `scripts/build-extension-listing-kit.js` 组装进 `listing-kit.zip`。
+>
+> 特别注意下面 host 权限那段的说辞——"必须全站而不是白名单"——是给**未收窄的
+> TeamClaw** 写的。copilot361 的品牌配置声明了 10 个 Shopee 域名，收窄修好之后
+> 这段话就与事实不符了，别再照抄。每个品牌的说辞跟它自己 manifest 里的权限保持
+> 一致，由 listing kit 脚本交叉校验。
+>
+> 本文件保留作为编写这类文案的参考范例。
+
 去 [开发者后台](https://chrome.google.com/webstore/devconsole) → 该插件条目 → **Privacy practices** tab，
 按下面内容填。都是根据 `apps/extension/` 现有代码（manifest.json + background.ts + content-script.ts）
 如实描述的，如果之后加了新权限/新数据用途要记得回来同步改。

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -50,6 +50,12 @@ const baseConfig = readJSON(path.join(rootDir, 'build.config.json'))
 const envConfig = buildEnv ? readJSON(path.join(rootDir, `build.config.${buildEnv}.json`)) : null
 const buildConfig = deepMerge(baseConfig || {}, envConfig)
 
+// Same resolver the extension build uses, so `extension.hosts` (branding repo)
+// and `extensions.settings` (repo configs) reach the app identically.
+const { resolveExtensionPack } = nodeRequire(
+  path.join(rootDir, 'scripts/lib/extension-config.js'),
+) as { resolveExtensionPack: (buildConfig: unknown) => { settings: unknown } }
+
 const { resolveBrandTheme, generateBrandThemeCss, extractRootTokenNames } =
   nodeRequire(path.join(rootDir, 'scripts/lib/brand-theme.js')) as {
     resolveBrandTheme: (buildConfig: unknown, repoRoot: string) => { palette: string; tokens: Record<string, string> } | null
@@ -132,9 +138,7 @@ export default defineConfig({
   },
   define: {
     __BUILD_CONFIG__: JSON.stringify(buildConfig),
-    __TEAMCLAW_EXTENSION_SETTINGS__: JSON.stringify(
-      (buildConfig as { extensions?: { settings?: unknown } }).extensions?.settings ?? {},
-    ),
+    __TEAMCLAW_EXTENSION_SETTINGS__: JSON.stringify(resolveExtensionPack(buildConfig).settings),
     // Inject build config defaults into import.meta.env so they work without .env files
     'import.meta.env.VITE_LOCALE': JSON.stringify((buildConfig as any).defaults?.locale ?? ''),
     'import.meta.env.PACKAGE_VERSION': JSON.stringify(

--- a/scripts/build-extension-listing-kit.js
+++ b/scripts/build-extension-listing-kit.js
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+/**
+ * Assemble the Chrome Web Store "listing kit" for the current brand.
+ *
+ * The Web Store API (v2) can only upload a package and publish it —
+ * media.upload, publishers.items.{publish,fetchStatus,cancelSubmission,
+ * setPublishedDeployPercentage}. There is no endpoint for listing metadata, so
+ * screenshots, promo tiles, the store description and the privacy-practices
+ * answers can only be entered by hand in the developer dashboard.
+ *
+ * Keeping them in the branding repo anyway buys version control and review;
+ * this script turns that source of truth into a single reviewed artifact —
+ * validated images plus a paste-ready checklist — so the manual step is
+ * transcription rather than authorship.
+ *
+ * Input  : branding/extension/{listing.json,privacy.json,listing/**}
+ *          (placed by .github/actions/brand-setup from brands/<brand>/extension/)
+ * Output : listing-kit/ + listing-kit.zip-able directory
+ * No-op  : when branding/extension is absent (unbranded builds).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const srcDir = path.join(repoRoot, 'branding/extension');
+const outDir = path.join(repoRoot, 'listing-kit');
+
+/** Chrome Web Store's published asset rules. */
+const IMAGE_SPECS = {
+  screenshots: { sizes: [[1280, 800], [640, 400]], max: 5, required: true },
+  'promo-small': { sizes: [[440, 280]], max: 1, required: false },
+  'promo-marquee': { sizes: [[1400, 560]], max: 1, required: false },
+};
+
+function readJSON(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read a PNG's dimensions and colour type straight from the IHDR chunk, which
+ * always occupies a fixed offset right after the 8-byte signature. Avoids
+ * pulling an image library into CI for what is a 25-byte read.
+ * Returns null for anything that is not a PNG (JPEG is legal for the store, so
+ * callers treat null as "cannot verify" rather than "invalid").
+ */
+function readPngHeader(filePath) {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(26);
+    if (fs.readSync(fd, buf, 0, 26, 0) < 26) return null;
+    const isPng = buf.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+    if (!isPng) return null;
+    return {
+      width: buf.readUInt32BE(16),
+      height: buf.readUInt32BE(20),
+      // 6 = truecolour with alpha, 4 = greyscale with alpha. The store rejects
+      // both for screenshots and tiles ("24-bit PNG (no alpha)").
+      hasAlpha: buf.readUInt8(25) === 6 || buf.readUInt8(25) === 4,
+    };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function collectImages(kind) {
+  const dir = path.join(srcDir, 'listing', kind);
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => /\.(png|jpe?g)$/i.test(f))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+const problems = [];
+
+function validateImages(kind, files) {
+  const spec = IMAGE_SPECS[kind];
+  if (files.length === 0) {
+    if (spec.required) {
+      problems.push(
+        `${kind}: none found in branding/extension/listing/${kind}/ — the Web Store requires at least one screenshot`
+      );
+    }
+    return;
+  }
+  if (files.length > spec.max) {
+    problems.push(`${kind}: ${files.length} files but the store accepts at most ${spec.max}`);
+  }
+  for (const file of files) {
+    const header = readPngHeader(file);
+    if (!header) continue; // JPEG — legal, dimensions unverified here.
+    const matches = spec.sizes.some(([w, h]) => header.width === w && header.height === h);
+    if (!matches) {
+      const allowed = spec.sizes.map(([w, h]) => `${w}x${h}`).join(' or ');
+      problems.push(
+        `${path.basename(file)}: ${header.width}x${header.height} — ${kind} must be ${allowed}`
+      );
+    }
+    if (header.hasAlpha) {
+      problems.push(`${path.basename(file)}: has an alpha channel — the store requires 24-bit PNG without alpha`);
+    }
+  }
+}
+
+function section(title, body) {
+  return `## ${title}\n\n${body}\n`;
+}
+
+function fencedBlock(text) {
+  return '```\n' + String(text).trim() + '\n```';
+}
+
+function main() {
+  if (!fs.existsSync(srcDir)) {
+    console.log('ℹ️ No branding/extension found — skipping listing kit (unbranded build)');
+    return 0;
+  }
+
+  const listing = readJSON(path.join(srcDir, 'listing.json')) || {};
+  const privacy = readJSON(path.join(srcDir, 'privacy.json')) || {};
+  const manifest = readJSON(path.join(repoRoot, 'apps/extension/manifest.json')) || {};
+
+  fs.rmSync(outDir, { recursive: true, force: true });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const copied = {};
+  for (const kind of Object.keys(IMAGE_SPECS)) {
+    const files = collectImages(kind);
+    validateImages(kind, files);
+    copied[kind] = [];
+    if (files.length === 0) continue;
+    const destDir = path.join(outDir, kind);
+    fs.mkdirSync(destDir, { recursive: true });
+    for (const file of files) {
+      const dest = path.join(destDir, path.basename(file));
+      fs.copyFileSync(file, dest);
+      copied[kind].push(path.basename(file));
+    }
+  }
+
+  // The dashboard's store description is a separate, much longer field than the
+  // manifest description Chrome shows in the toolbar; only the latter is capped
+  // at 132 chars. Reusing the short one is what left the listing at 31 chars.
+  const storeDescription = listing.description || '';
+  if (!storeDescription) {
+    problems.push('listing.json: `description` is empty — the store listing needs real copy, not the manifest one-liner');
+  }
+
+  const permissionJustifications = privacy.permissionJustifications || {};
+  const declaredPermissions = [
+    ...(manifest.permissions || []),
+    ...(manifest.host_permissions?.length ? ['host_permissions'] : []),
+  ];
+  for (const permission of declaredPermissions) {
+    if (!permissionJustifications[permission]) {
+      problems.push(
+        `privacy.json: no justification for "${permission}" which the packaged manifest requests`
+      );
+    }
+  }
+
+  const lines = [
+    `# Chrome Web Store listing kit — ${manifest.name || 'unknown'} ${manifest.version || ''}`.trim(),
+    '',
+    'The Web Store API cannot write any of this. Paste it into the developer',
+    'dashboard by hand: https://chrome.google.com/webstore/devconsole',
+    '',
+    section(
+      'Store listing → Product details',
+      [
+        `- **Title** (from package): \`${manifest.name || ''}\``,
+        `- **Summary** (from package): \`${manifest.description || ''}\``,
+        `- **Category**: ${listing.category || '(unset in listing.json)'}`,
+        `- **Language**: ${listing.language || '(unset in listing.json)'}`,
+        '',
+        '**Description**',
+        '',
+        storeDescription ? fencedBlock(storeDescription) : '_(missing — set `description` in listing.json)_',
+      ].join('\n')
+    ),
+    section(
+      'Store listing → Graphic assets',
+      Object.entries(copied)
+        .map(([kind, files]) =>
+          files.length ? `- **${kind}**: ${files.join(', ')} (in \`${kind}/\`)` : `- **${kind}**: none`
+        )
+        .join('\n')
+    ),
+    section(
+      'Privacy → Single purpose',
+      privacy.singlePurpose
+        ? fencedBlock(privacy.singlePurpose)
+        : '_(missing — set `singlePurpose` in privacy.json)_'
+    ),
+    section(
+      'Privacy → Permission justifications',
+      Object.keys(permissionJustifications).length
+        ? Object.entries(permissionJustifications)
+            .map(([permission, text]) => `**${permission}**\n\n${fencedBlock(text)}`)
+            .join('\n\n')
+        : '_(missing — set `permissionJustifications` in privacy.json)_'
+    ),
+    section(
+      'Privacy → Remote code & data usage',
+      [
+        `- **Remote code**: ${privacy.usesRemoteCode ? 'Yes' : 'No, I am not using remote code'}`,
+        `- **Data collected**: ${(privacy.dataCollected || []).join(', ') || '(none declared)'}`,
+        `- **Privacy policy URL**: ${privacy.privacyPolicyUrl || '(unset in privacy.json)'}`,
+      ].join('\n')
+    ),
+    section(
+      'Distribution',
+      [
+        `- **Visibility**: ${listing.visibility || '(unset in listing.json)'}`,
+        `- **Regions**: ${listing.regions || 'all'}`,
+        '',
+        'Note: Private/unlisted items are still fully reviewed. For internal-only',
+        'rollout, prefer Workspace admin force-install by extension ID.',
+      ].join('\n')
+    ),
+  ];
+
+  fs.writeFileSync(path.join(outDir, 'README.md'), lines.join('\n'));
+
+  const total = Object.values(copied).reduce((n, files) => n + files.length, 0);
+  console.log(`✓ Listing kit: ${total} image(s) + README.md → listing-kit/`);
+
+  if (problems.length) {
+    console.log('');
+    for (const problem of problems) console.log(`::warning::listing kit — ${problem}`);
+    console.log(`\n⚠️ ${problems.length} listing problem(s) above will cause or contribute to a review rejection.`);
+  }
+  return 0;
+}
+
+process.exit(main());

--- a/scripts/lib/branding.js
+++ b/scripts/lib/branding.js
@@ -92,21 +92,50 @@ function applyIdentityToTauriConf(tauriConf, buildConfig) {
 /**
  * Apply the configured app name/short name to a parsed extension manifest.json
  * object (mutates it). Both fields are browser-facing labels, so they follow
- * `app.displayName` and fall back to `app.name`. Returns true if anything changed.
+ * `app.displayName` and fall back to `app.name`.
+ *
+ * The description follows the same brand, read from `extension.description`
+ * (or `extensions.description`). Leaving it unbranded is what shipped a
+ * "Copilot 361" package still describing itself as TeamClaw — the Chrome Web
+ * Store shows the package name and description side by side, and a mismatch
+ * between them reads to a reviewer as a misleading listing.
+ *
+ * Returns true if anything changed.
  */
 function applyNameToExtensionManifest(manifest, buildConfig) {
-  const app = (buildConfig && buildConfig.app) || {};
+  const cfg = buildConfig || {};
+  const app = cfg.app || {};
+  const extensionBlock =
+    (cfg.extension && typeof cfg.extension === "object" ? cfg.extension : null) ||
+    (cfg.extensions && typeof cfg.extensions === "object" ? cfg.extensions : null) ||
+    {};
   const name = app.displayName || app.name;
-  if (!name) return false;
+  const description = extensionBlock.description || app.description;
   let changed = false;
-  if (manifest.name !== name) {
-    manifest.name = name;
+
+  if (name) {
+    if (manifest.name !== name) {
+      manifest.name = name;
+      changed = true;
+    }
+    if (manifest.action && manifest.action.default_title !== name) {
+      manifest.action.default_title = name;
+      changed = true;
+    }
+  }
+
+  if (description && manifest.description !== description) {
+    // Chrome truncates past 132 chars in the toolbar tooltip and rejects >132
+    // in the manifest, so fail the build rather than ship a silently cut label.
+    if (String(description).length > 132) {
+      throw new Error(
+        `brand identity: extension description is ${String(description).length} chars — Chrome allows at most 132`
+      );
+    }
+    manifest.description = description;
     changed = true;
   }
-  if (manifest.action && manifest.action.default_title !== name) {
-    manifest.action.default_title = name;
-    changed = true;
-  }
+
   return changed;
 }
 

--- a/scripts/lib/branding.test.js
+++ b/scripts/lib/branding.test.js
@@ -144,3 +144,36 @@ test("applyNameToExtensionManifest falls back to app.name when displayName is un
   assert.strictEqual(changed, true);
   assert.strictEqual(manifest.name, "TeamClaw");
 });
+
+// Regression: the name was branded but the description was not, so the
+// "Copilot 361" package reached review still describing itself as TeamClaw.
+test("applyNameToExtensionManifest brands the description from extension.description", () => {
+  const manifest = { name: "TeamClaw", description: "TeamClaw sidebar", action: { default_title: "TeamClaw" } };
+  const changed = applyNameToExtensionManifest(manifest, {
+    app: { name: "Acme" },
+    extension: { description: "Acme sidebar" },
+  });
+  assert.strictEqual(changed, true);
+  assert.strictEqual(manifest.name, "Acme");
+  assert.strictEqual(manifest.description, "Acme sidebar");
+});
+
+test("applyNameToExtensionManifest accepts the canonical extensions.description too", () => {
+  const manifest = { name: "TeamClaw", description: "old" };
+  applyNameToExtensionManifest(manifest, { app: { name: "Acme" }, extensions: { description: "new" } });
+  assert.strictEqual(manifest.description, "new");
+});
+
+test("applyNameToExtensionManifest leaves the description alone when the brand sets none", () => {
+  const manifest = { name: "TeamClaw", description: "kept" };
+  applyNameToExtensionManifest(manifest, { app: { name: "Acme" } });
+  assert.strictEqual(manifest.description, "kept");
+});
+
+test("applyNameToExtensionManifest rejects a description Chrome would refuse", () => {
+  const manifest = { name: "TeamClaw", description: "short" };
+  assert.throws(
+    () => applyNameToExtensionManifest(manifest, { extension: { description: "x".repeat(133) } }),
+    /at most 132/
+  );
+});

--- a/scripts/lib/extension-config.js
+++ b/scripts/lib/extension-config.js
@@ -3,6 +3,13 @@
 /**
  * Chrome extension pack options from `build.config*.json` → `extensions`.
  * No CLI / env overrides — config file is the only source.
+ *
+ * Two spellings reach this module and both must work. The repo's own configs
+ * (build.config.example.json) use `extensions.domains`; every brand in the
+ * enterprise-branding repo uses `extension.hosts`. Until this was reconciled,
+ * `extension.hosts` parsed to nothing, so brands that meant to scope the
+ * extension to a handful of domains silently shipped `<all_urls>` instead.
+ * `resolveExtensionPack` is the single entry point that accepts either.
  */
 
 function asStringList(raw) {
@@ -48,7 +55,7 @@ function toChromeMatchPattern(raw) {
 
 function parseExtensionsConfig(raw) {
   const row = raw && typeof raw === 'object' ? raw : {}
-  const domainsRaw = asStringList(row.domains)
+  const domainsRaw = [...asStringList(row.domains), ...asStringList(row.hosts)]
   const domains = []
   const seen = new Set()
   for (const item of domainsRaw) {
@@ -77,6 +84,35 @@ function parseExtensionsConfig(raw) {
   }
 }
 
+/**
+ * Resolve the extension pack from a whole merged build config, accepting both
+ * the `extensions` (repo) and `extension` (branding repo) blocks. When both are
+ * present the canonical `extensions` block wins on scalars and settings, while
+ * host lists from either spelling are unioned — a brand that adds `extension.hosts`
+ * on top of a repo default should widen the allowlist, not silently replace it.
+ */
+function resolveExtensionPack(buildConfig) {
+  const cfg = buildConfig && typeof buildConfig === 'object' ? buildConfig : {}
+  const canonical = cfg.extensions && typeof cfg.extensions === 'object' ? cfg.extensions : {}
+  const alias = cfg.extension && typeof cfg.extension === 'object' ? cfg.extension : {}
+
+  return parseExtensionsConfig({
+    ...alias,
+    ...canonical,
+    domains: [
+      ...asStringList(canonical.domains),
+      ...asStringList(canonical.hosts),
+      ...asStringList(alias.domains),
+      ...asStringList(alias.hosts),
+    ],
+    solo: canonical.solo === true || alias.solo === true,
+    settings: {
+      ...(alias.settings && typeof alias.settings === 'object' ? alias.settings : {}),
+      ...(canonical.settings && typeof canonical.settings === 'object' ? canonical.settings : {}),
+    },
+  })
+}
+
 function domainsToChromeMatchPatterns(domains) {
   const out = []
   const seen = new Set()
@@ -95,6 +131,7 @@ function domainsToSidePanelCsv(domains) {
 
 module.exports = {
   parseExtensionsConfig,
+  resolveExtensionPack,
   toSidePanelDomain,
   toChromeMatchPattern,
   domainsToChromeMatchPatterns,

--- a/scripts/lib/extension-config.js
+++ b/scripts/lib/extension-config.js
@@ -129,6 +129,52 @@ function domainsToSidePanelCsv(domains) {
   return parseExtensionsConfig({ domains }).domains.join(',')
 }
 
+/**
+ * Directories under `packages/app/public/` that vite copies verbatim into the
+ * app bundle but which nothing in the side panel ever requests, and which the
+ * extension package therefore must not carry to the Chrome Web Store.
+ *
+ * `public/` means "ship this", so anything parked there reaches a published,
+ * publicly downloadable package. That put eight internal design prototypes and
+ * a TeamClaw mascot into a Copilot 361 build — brand-leaking dead weight in an
+ * artifact a store reviewer unzips.
+ *
+ * Pruning is deliberately a small, named allowlist rather than a heuristic:
+ * deleting an asset that IS requested at runtime shows up as a broken image in
+ * production, not as a build failure. The guardrail test in
+ * extension-config.test.js greps packages/app/src for references to each entry,
+ * so adding one that is actually in use fails the suite instead of the UI.
+ */
+const SIDE_PANEL_PRUNE_DIRS = [
+  // Design prototypes: standalone HTML mockups kept for reference. Nothing
+  // imports or links them; they are read by opening the file directly.
+  'prototypes',
+  // TeamClaw mascot frames, requested only by LobsterLoader — see the exception
+  // below for why that reference does not make them live.
+  'lobster',
+]
+
+/**
+ * A pruned directory may still be named by a source file without being live, if
+ * that file is itself unreachable. Each exception below records the one file
+ * allowed to reference a pruned directory, plus the export whose absence from
+ * every import statement is what makes the reference dead.
+ *
+ * This exists so the dead-ness is asserted rather than assumed. The alternative
+ * — deleting the component — would also satisfy the guardrail, but throws away
+ * working code on the strength of a grep. Encoding the claim means the day
+ * someone imports LobsterLoader, the suite fails and says to drop `lobster`
+ * from the prune list, instead of the mascot quietly vanishing from the UI.
+ */
+const PRUNE_REFERENCE_EXCEPTIONS = [
+  {
+    dir: 'lobster',
+    file: 'packages/app/src/components/auth/LobsterLoader.tsx',
+    symbol: 'LobsterLoader',
+    reason: 'exported but never imported — dead in every build',
+  },
+]
+
 module.exports = {
   parseExtensionsConfig,
   resolveExtensionPack,
@@ -136,4 +182,6 @@ module.exports = {
   toChromeMatchPattern,
   domainsToChromeMatchPatterns,
   domainsToSidePanelCsv,
+  SIDE_PANEL_PRUNE_DIRS,
+  PRUNE_REFERENCE_EXCEPTIONS,
 }

--- a/scripts/lib/extension-config.test.js
+++ b/scripts/lib/extension-config.test.js
@@ -1,0 +1,68 @@
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert");
+const {
+  parseExtensionsConfig,
+  resolveExtensionPack,
+  domainsToChromeMatchPatterns,
+} = require("./extension-config");
+
+test("resolveExtensionPack reads the repo's extensions.domains spelling", () => {
+  const pack = resolveExtensionPack({ extensions: { domains: ["*.example.com"] } });
+  assert.deepStrictEqual(pack.domains, ["*.example.com"]);
+});
+
+// Regression: every brand in the enterprise-branding repo declares
+// `extension.hosts`, which parsed to nothing under the old `extensions.domains`
+// -only reader. The manifest then kept its <all_urls> default, so brands that
+// meant to scope to a handful of domains shipped full host access to review.
+test("resolveExtensionPack reads the branding repo's extension.hosts spelling", () => {
+  const pack = resolveExtensionPack({
+    extension: { hosts: ["https://*.shopee.io/*", "https://*.seamoney.io/*"] },
+  });
+  assert.deepStrictEqual(pack.domains, ["*.shopee.io", "*.seamoney.io"]);
+  assert.deepStrictEqual(domainsToChromeMatchPatterns(pack.domains), [
+    "https://*.shopee.io/*",
+    "https://*.seamoney.io/*",
+  ]);
+});
+
+test("resolveExtensionPack unions both spellings and dedupes", () => {
+  const pack = resolveExtensionPack({
+    extensions: { domains: ["*.example.com"] },
+    extension: { hosts: ["https://*.example.com/*", "https://*.other.com/*"] },
+  });
+  assert.deepStrictEqual(pack.domains, ["*.example.com", "*.other.com"]);
+});
+
+test("resolveExtensionPack yields no domains when neither block is present", () => {
+  const pack = resolveExtensionPack({ app: { name: "TeamClaw" } });
+  assert.deepStrictEqual(pack.domains, []);
+  assert.strictEqual(pack.solo, false);
+});
+
+test("resolveExtensionPack tolerates a missing or non-object config", () => {
+  for (const input of [undefined, null, "nope", 42]) {
+    assert.deepStrictEqual(resolveExtensionPack(input).domains, []);
+  }
+});
+
+test("resolveExtensionPack honours solo from either block", () => {
+  assert.strictEqual(resolveExtensionPack({ extensions: { solo: true } }).solo, true);
+  assert.strictEqual(resolveExtensionPack({ extension: { solo: true } }).solo, true);
+  assert.strictEqual(resolveExtensionPack({ extension: { solo: false } }).solo, false);
+});
+
+test("resolveExtensionPack lets the canonical block win on settings", () => {
+  const pack = resolveExtensionPack({
+    extension: { settings: { hideButton: true } },
+    extensions: { settings: { hideButton: false, linkHover: { domains: ["a.com"] } } },
+  });
+  assert.strictEqual(pack.settings.hideButton, false);
+  assert.deepStrictEqual(pack.settings.linkHover.domains, ["a.com"]);
+});
+
+test("parseExtensionsConfig still accepts a bare domains row", () => {
+  const pack = parseExtensionsConfig({ domains: ["https://*.a.com/*", "*.a.com"] });
+  assert.deepStrictEqual(pack.domains, ["*.a.com"]);
+});

--- a/scripts/lib/extension-config.test.js
+++ b/scripts/lib/extension-config.test.js
@@ -1,10 +1,14 @@
 "use strict";
 const test = require("node:test");
 const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
 const {
   parseExtensionsConfig,
   resolveExtensionPack,
   domainsToChromeMatchPatterns,
+  SIDE_PANEL_PRUNE_DIRS,
+  PRUNE_REFERENCE_EXCEPTIONS,
 } = require("./extension-config");
 
 test("resolveExtensionPack reads the repo's extensions.domains spelling", () => {
@@ -65,4 +69,74 @@ test("resolveExtensionPack lets the canonical block win on settings", () => {
 test("parseExtensionsConfig still accepts a bare domains row", () => {
   const pack = parseExtensionsConfig({ domains: ["https://*.a.com/*", "*.a.com"] });
   assert.deepStrictEqual(pack.domains, ["*.a.com"]);
+});
+
+// --- side-panel prune list -------------------------------------------------
+// Pruning an asset the side panel actually requests is invisible at build time
+// and shows up as a broken image in a published extension. These two tests are
+// the reason the list can be trusted: one proves each entry exists to be
+// pruned, the other proves nothing references it.
+
+const repoRoot = path.resolve(__dirname, "../..");
+const publicDir = path.join(repoRoot, "packages/app/public");
+const srcDir = path.join(repoRoot, "packages/app/src");
+
+function walk(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+test("every pruned directory actually exists under packages/app/public", () => {
+  for (const dir of SIDE_PANEL_PRUNE_DIRS) {
+    assert.ok(
+      fs.existsSync(path.join(publicDir, dir)),
+      `${dir} is on the prune list but not in packages/app/public — stale entry, drop it`
+    );
+  }
+});
+
+test("no pruned directory is referenced from live packages/app/src code", () => {
+  const sources = walk(srcDir).filter((f) => /\.(ts|tsx|js|jsx|css|html)$/.test(f));
+  const excused = new Set(PRUNE_REFERENCE_EXCEPTIONS.map((e) => path.join(repoRoot, e.file)));
+  for (const dir of SIDE_PANEL_PRUNE_DIRS) {
+    const offenders = sources
+      .filter((file) => !excused.has(file))
+      .filter((file) => fs.readFileSync(file, "utf8").includes(`/${dir}/`));
+    assert.deepStrictEqual(
+      offenders.map((f) => path.relative(repoRoot, f)),
+      [],
+      `packages/app/public/${dir}/ is on the extension prune list but is referenced above — ` +
+        `pruning it would ship a broken asset. Either stop referencing it, add a documented ` +
+        `entry to PRUNE_REFERENCE_EXCEPTIONS, or drop it from SIDE_PANEL_PRUNE_DIRS.`
+    );
+  }
+});
+
+test("every prune exception is genuinely dead — its export is never imported", () => {
+  const sources = walk(srcDir).filter((f) => /\.(ts|tsx|js|jsx)$/.test(f));
+  for (const exception of PRUNE_REFERENCE_EXCEPTIONS) {
+    const self = path.join(repoRoot, exception.file);
+    assert.ok(fs.existsSync(self), `${exception.file} no longer exists — drop the exception`);
+
+    const importers = sources
+      .filter((file) => file !== self)
+      .filter((file) => {
+        const text = fs.readFileSync(file, "utf8");
+        // Any import naming the symbol, static or dynamic, in any brace layout.
+        return new RegExp(`\\b${exception.symbol}\\b`).test(text);
+      });
+
+    assert.deepStrictEqual(
+      importers.map((f) => path.relative(repoRoot, f)),
+      [],
+      `${exception.symbol} is now referenced by the files above, so ` +
+        `packages/app/public/${exception.dir}/ is live and must not be pruned — ` +
+        `remove "${exception.dir}" from SIDE_PANEL_PRUNE_DIRS.`
+    );
+  }
 });

--- a/scripts/update-extension-manifest.js
+++ b/scripts/update-extension-manifest.js
@@ -2,7 +2,11 @@
 
 const fs = require('fs');
 const path = require('path');
-const { applyNameToExtensionManifest, resolveExtensionIconPlan } = require('./lib/branding');
+const {
+  applyNameToExtensionManifest,
+  resolveExtensionIconPlan,
+  resolveLogoPlan,
+} = require('./lib/branding');
 const {
   resolveExtensionPack,
   domainsToChromeMatchPatterns,
@@ -93,4 +97,27 @@ if (iconPlan) {
   }
 } else {
   console.log('ℹ️ No branding/extension/icons found — keeping default icons');
+}
+
+// The side panel renders /logo.png and /logo-64.png (welcome, login, about,
+// file tree). Those live in packages/app/public/ and were only ever rebranded
+// by scripts/update-tauri-config.js — the desktop path. Nothing applied them
+// for the extension, so a package correctly named "Copilot 361" opened onto a
+// side panel still showing the TeamClaw mark.
+//
+// Unlike the desktop flow this copies app.logo straight through instead of
+// resizing it via `tauri icon`: the extension pipeline deliberately does no
+// image conversion in CI, and both slots are rendered at CSS sizes anyway.
+const logoPlan = resolveLogoPlan(buildConfig, rootDir);
+if (logoPlan) {
+  if (!fs.existsSync(logoPlan.source)) {
+    console.error(`✗ app.logo source not found: ${logoPlan.source}`);
+    process.exit(1);
+  }
+  for (const target of logoPlan.publicLogoTargets) {
+    fs.copyFileSync(logoPlan.source, target);
+    console.log(`✓ Wrote in-app logo: ${path.relative(rootDir, target)}`);
+  }
+} else {
+  console.log('ℹ️ No app.logo configured — keeping default in-app logo');
 }

--- a/scripts/update-extension-manifest.js
+++ b/scripts/update-extension-manifest.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const { applyNameToExtensionManifest, resolveExtensionIconPlan } = require('./lib/branding');
 const {
-  parseExtensionsConfig,
+  resolveExtensionPack,
   domainsToChromeMatchPatterns,
 } = require('./lib/extension-config');
 
@@ -54,13 +54,13 @@ const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 let updated = false;
 
 if (applyNameToExtensionManifest(manifest, buildConfig)) {
-  console.log(`✓ Updated extension name: ${manifest.name}`);
+  console.log(`✓ Updated extension identity: ${manifest.name} — ${manifest.description}`);
   updated = true;
 }
 
-// Brand-scoped host access from `extensions.domains` (e.g. *.shopee.io).
-// Non-empty → override host_permissions + content_scripts.matches.
-const extensionPack = parseExtensionsConfig(buildConfig.extensions);
+// Brand-scoped host access from `extensions.domains` / `extension.hosts`
+// (e.g. *.shopee.io). Non-empty → override host_permissions + content_scripts.matches.
+const extensionPack = resolveExtensionPack(buildConfig);
 const brandHosts = domainsToChromeMatchPatterns(extensionPack.domains);
 if (brandHosts.length > 0) {
   manifest.host_permissions = [...brandHosts];


### PR DESCRIPTION
Completes the white-labelling of the Chrome extension. Everything here was found by building a real `copilot361` package and unzipping it.

## The bug that mattered most

Host scoping silently did nothing. The repo's own configs spell the allowlist `extensions.domains`; every brand in the enterprise-branding repo spells it `extension.hosts`. Only the former was ever read.

So copilot361 — which declares ten Shopee/SeaMoney domains — kept the manifest's `<all_urls>` default and went to Chrome Web Store review **asking for full-web access it did not want and could not justify**. `resolveExtensionPack` is now the single entry point, accepts either spelling, and unions the lists so a brand widens a repo default rather than silently replacing it. All three call sites go through it: the extension build, the manifest updater, and vite's side-panel DOMAINS gate.

## Four brand mismatches in the packaged artifact

| | before | after |
|---|---|---|
| `manifest.description` | TeamClaw's Chinese one-liner | brand's `extension.description` |
| `icons/icon-{16,48,128}` | TeamClaw mark | brand's, from `brands/<brand>/extension/icons/` |
| `sidepanel/logo{,-64}.png` | TeamClaw mark | brand's `app.logo` |
| `sidepanel/{lobster,prototypes}/` | shipped | pruned |

The description mismatch is the sharpest: Chrome shows package name and description side by side, so "Copilot 361" described as TeamClaw reads to a reviewer as a misleading listing. A description over Chrome's 132-char limit now fails the build instead of being silently truncated.

The side-panel logo was a pipeline gap, not a missing asset — `/logo.png` and `/logo-64.png` were only ever rebranded by `update-tauri-config.js`, the desktop path. Supplying extension icons would not have fixed it.

`public/` means "ship this", so anything parked there reaches a publicly downloadable package: that was eight internal design prototypes (142 KB) and the TeamClaw mascot frames (299 KB), neither of which the side panel requests.

## The listing kit

The Web Store API cannot write listing metadata — `media.upload` and `publishers.items.*` are the only mutating endpoints. Store copy, screenshots, promo tiles and privacy answers can only be typed into the dashboard by hand.

Keeping them in the branding repo anyway buys version control and review. `scripts/build-extension-listing-kit.js` turns that into one reviewed artifact — validated images plus a paste-ready README — so the manual step is transcription, not authorship. It runs after the build so it can cross-check justifications against the permissions the packaged manifest actually requests, and reports problems as `::warning::` rather than failing the release. PNG dimensions come from a 26-byte IHDR read, so CI needs no image library.

Extension assets come from `brands/<brand>/extension/` rather than the shared `branding/` tree — two brands publishing different Web Store items must not read each other's icons and screenshots. The item ID likewise moves to the brand, so each publishes to its own listing instead of racing for one repo-level secret.

## Guardrails, not assumptions

Pruning an asset that IS requested is invisible at build time and surfaces as a broken image in a published extension. So the prune list is guarded: one test asserts each entry exists, another that no live source references it.

`lobster/` is named by `LobsterLoader.tsx` — a component exported and never imported — so it carries a documented exception, plus a third test that asserts that dead-ness by failing the moment anything imports `LobsterLoader`. That is deliberately kept instead of deleting the component: the guardrail makes the claim checkable without discarding working code on the strength of a grep. Negative-tested by adding an import and confirming the suite goes red.

The Web Store item-ID fallback is resolved in bash rather than `${{ env.X || secrets.X }}`, because a step's env block reading the env context under the key it is itself defining is undocumented behaviour — and getting it wrong would publish one brand's package over another brand's item.

## Verification

Built copilot361 end to end against the real branding repo and unzipped the result:

```
name                  Copilot 361
description           AI assistant sidebar for Shopee and SeaMoney…
host_permissions      10 domains, zero <all_urls>
icons/icon-{16,48,128}.png   brand
sidepanel/logo{,-64}.png     brand
lobster/ prototypes/         gone
```

5.2 MB → 4.8 MB, no TeamClaw traces left.

`node --test scripts/lib/*.test.js` → 65/65 (11 new). `pnpm typecheck` clean.

## Companion changes

Merged into the enterprise-branding repo: [#4](https://github.com/different-ai-studio/teamclaw-enterprise-branding/pull/4) (store copy, privacy answers, `extension.description`) and [#5](https://github.com/different-ai-studio/teamclaw-enterprise-branding/pull/5) (the three icon sizes).

## Still open

- **Screenshots** — the listing kit's one remaining warning. At least one 1280x800 or 640x400 24-bit PNG without alpha; has to be captured from a running side panel.
- **`dataCollected` does not tick *Authentication information***. Sign-in is email OTP so no password exists, but Google defines that category as "passwords, credentials, security question, or PIN". Flagged in branding #4; a one-line change if we'd rather be conservative.
- **Desktop ships the same dead assets** (`lobster/`, `prototypes/`). Left alone — the desktop bundle is not publicly listed, and the fix touches the desktop build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)