### PR TITLE
fix(extension): stop the production config from clobbering the brand name

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -82,9 +82,15 @@ jobs:
       - name: Apply branding to extension manifest + icons
         run: node scripts/update-extension-manifest.js
 
+      # Do NOT set BUILD_ENV. It selects build.config.<env>.json, and
+      # BUILD_ENV=production deep-merges build.config.production.json OVER the
+      # brand's build.config.json — whose app block is {"name": "TeamClaw",
+      # "shortName": "teamclaw"}, so every branded package shipped a side panel
+      # announcing itself as TeamClaw next to the brand's own logo. The brand's
+      # build.config.json is the sole source; vite builds in production mode
+      # regardless. release-oss.yml already documents this trap for the desktop
+      # pipeline; this job was still walking into it.
       - name: Build extension
-        env:
-          BUILD_ENV: production
         run: pnpm --filter @teamclaw/extension build
 
       # The Web Store API cannot write listing metadata (media.upload + publish

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="app-short-name" content="__APP_SHORT_NAME__" />
     <meta name="app-palette" content="__PALETTE__" />
-    <title>TeamClaw</title>
+    <title>__APP_NAME__</title>
     <style>
       /* Skeleton — covers the viewport until the workspace is bootstrapped.
          Mirrors the real three-column shell (sidebar / session list / main)

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -101,8 +101,14 @@ export default defineConfig({
       name: 'inject-app-short-name',
       transformIndexHtml(html) {
         const palette = ((buildConfig as any).app?.palette as string) || 'default'
+        // The <title> was hardcoded to "TeamClaw", so every branded build —
+        // desktop window title and extension side panel alike — announced the
+        // wrong product before React had rendered anything.
+        const app = (buildConfig as any).app || {}
+        const displayName = (app.displayName as string) || (app.name as string) || 'TeamClaw'
         return html
           .replace(/__APP_SHORT_NAME__/g, sn as string)
+          .replace(/__APP_NAME__/g, displayName)
           .replace(/__PALETTE__/g, palette)
           .replace(/<!--__BRAND_THEME__-->/g, brandThemeStyle)
       },


### PR DESCRIPTION
Found while screenshotting the packaged side panel for the Web Store listing: it said **TeamClaw** under the Copilot 361 logo.


## The pipeline discarded the brand name

`release-extension.yml` sets `BUILD_ENV: production`, which makes vite deep-merge `build.config.production.json` **over** the brand's `build.config.json`. That file's app block is:

```json
"app": { "name": "TeamClaw", "shortName": "teamclaw" }
```

The overlay wins, so the brand name `brand-setup` wrote was thrown away in every branded extension release — login screen, About panel, and everywhere else `appDisplayName` reaches (10+ components).

`release-oss.yml` **already documents this exact trap** and omits `BUILD_ENV` for the desktop pipeline:

> Do NOT set BUILD_ENV: … BUILD_ENV=production deep-merges build.config.production.json OVER the brand's build.config.json, silently baking the wrong backend AND clobbering app.name back to "TeamClaw".

The extension job was still walking into it. Dropping it is safe: the brand's `build.config.json` carries its own `cloudApiUrl`, and vite builds in production mode regardless of `BUILD_ENV`.

## The title was hardcoded

`<title>TeamClaw</title>` in `packages/app/index.html` — so the tab and side panel header said TeamClaw for every brand, on desktop too. `index.html` already carries `__APP_SHORT_NAME__` and `__PALETTE__` placeholders that `transformIndexHtml` fills, so the title now uses the same mechanism via `__APP_NAME__` (`app.displayName` → `app.name` → `TeamClaw`).

## Verification

Built the brand with `CI=1` and no `BUILD_ENV` (what CI will now do):

```
<title>Copilot 361</title>        ← was TeamClaw
build-config chunk: Copilot 361   ← was absent
```

And built with no brand config at all — both fall back to `TeamClaw`, so the default product is unaffected.

`pnpm typecheck` clean. `node --test scripts/lib/*.test.js` 65/65.

## Two brand leaks left, both needing a product decision

Not fixed here because neither is a build bug:

- **Tagline** `auth.tagline` — "AI Ally · AI Teammate" is TeamClaw's positioning, shown on every brand's login screen. It is a locale string, so making it brand-configurable is a different shape of change.
- **Backend hostname in the login footer** — the side panel prints `api.teamclaw-dev.ucar.cc` under the sign-in card. Correct, but it puts an infrastructure hostname on a public Chrome Web Store screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
