### PR TITLE
fix(skills): stop SkillsMarketplace writing state after it unmounts

### DIFF
--- a/packages/app/src/components/settings/SkillsMarketplace.tsx
+++ b/packages/app/src/components/settings/SkillsMarketplace.tsx
@@ -158,12 +158,14 @@ export const SkillsMarketplace = React.memo(function SkillsMarketplace({
       const data = await invoke<SkillsShLeaderboard>("fetch_skillssh_leaderboard", {
         category: categoryParam,
       })
+      if (!mountedRef.current) return
       setLeaderboard(data)
     } catch (err) {
       console.error("[SkillsMarketplace] Failed to fetch leaderboard:", err)
+      if (!mountedRef.current) return
       setError(formatTauriInvokeError(err))
     } finally {
-      setIsLoading(false)
+      if (mountedRef.current) setIsLoading(false)
     }
   }, [isTauri, t, skillsShCategory])
 
@@ -181,16 +183,35 @@ export const SkillsMarketplace = React.memo(function SkillsMarketplace({
       const data = await invoke<SkillsShLeaderboard>("search_skillssh_skills", {
         query: query.trim(),
       })
+      if (!mountedRef.current) return
       setLeaderboard(data)
     } catch (err) {
       console.error("[SkillsMarketplace] Failed to search skills:", err)
+      if (!mountedRef.current) return
       setError(formatTauriInvokeError(err))
     } finally {
-      setIsLoading(false)
+      if (mountedRef.current) setIsLoading(false)
     }
   }, [isTauri, fetchLeaderboard])
 
   const searchTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  /**
+   * loadInstalled is fired un-awaited from a mount effect and awaits dynamic
+   * Tauri imports before setting state, so nothing stops it landing after the
+   * component is gone. React's dispatchSetState reaches for `window` on the way
+   * in, which throws once the surrounding environment is torn down — two
+   * unhandled "window is not defined" errors that failed `vitest run` while all
+   * 2242 tests passed. Outside tests the same race just warns, but it is the
+   * same defect: state written to an unmounted tree.
+   */
+  const mountedRef = React.useRef(true)
+  React.useEffect(
+    () => () => {
+      mountedRef.current = false
+    },
+    [],
+  )
 
   const handleSearchChange = React.useCallback((value: string) => {
     if (externalSearch) {
@@ -236,8 +257,10 @@ export const SkillsMarketplace = React.memo(function SkillsMarketplace({
         }
       }))
 
+      if (!mountedRef.current) return
       setInstalledSlugs(allSlugs)
     } catch {
+      if (!mountedRef.current) return
       setInstalledSlugs(new Set())
     }
   }, [workspacePath])
@@ -258,6 +281,17 @@ export const SkillsMarketplace = React.memo(function SkillsMarketplace({
     searchTimerRef.current = setTimeout(() => {
       void doSearchSkillSh(effectiveSearchQuery)
     }, 300)
+    // The debounce was only ever cleared by the *next* run of this effect, so
+    // unmounting between keystroke and timeout left a live timer that woke up
+    // and searched against a component that no longer existed. Cancelling on
+    // teardown is the fix the mountedRef guards cannot provide — it stops the
+    // work rather than discarding its result.
+    return () => {
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current)
+        searchTimerRef.current = null
+      }
+    }
   }, [effectiveActiveSource, doSearchSkillSh, effectiveSearchQuery, externalSearch])
 
   React.useEffect(() => {


### PR DESCRIPTION
Fixes the flake that failed CI on #601.

## What happened

```
Test Files  382 passed (382)
Tests       2242 passed (2242)
Errors      2 errors            ← fails `vitest run` on its own

ReferenceError: window is not defined
 ❯ dispatchSetState  react-dom-client.development.js:9126
 ❯ src/components/settings/SkillsMarketplace.tsx:241
   originated in SkillsMarketplace.test.tsx
```

Every test passed. The two unhandled errors were enough to exit non-zero.

**Re-running the identical commit went green**, so this is a race rather than a regression — and it can redden any PR at random.

## The defect

`loadInstalled` is fired un-awaited from a mount effect and awaits dynamic Tauri imports before setting state, so nothing stops it landing after the component is gone. React's `dispatchSetState` reads `window` on the way in, which throws once the test environment is torn down. Line 241 is the `catch` branch — in jsdom the `@tauri-apps/plugin-fs` import fails, so that is the path that lands late.

Outside tests the same race only warns, but the defect is identical: state written to an unmounted tree.

## Why the fix is wider than the one line that failed

Guarding only `loadInstalled` would have left the flake a second route in:

| site | how it leaks |
|---|---|
| `loadInstalled` | un-awaited from mount effect, post-await `setInstalledSlugs` (both branches) |
| `fetchLeaderboard` | un-awaited from the **same** mount effect, post-await `setLeaderboard` / `setError` / `setIsLoading` |
| `doSearchSkillSh` | same shape, reached from the debounce |

All three now bail on a `mountedRef` cleared by the unmount cleanup.

The debounce effect needed a different fix: its timer was only ever cleared by the *next* run of the effect, so unmounting between a keystroke and the timeout left a live timer that woke up and searched against a component that no longer existed. It now cancels on teardown — that **stops the work** rather than discarding its result, which a `mountedRef` cannot do.

## On verification — read this before trusting the fix

**This is argued from the mechanism, not from a green run.** The race does not reproduce locally, so no local result can prove it gone, and a single green CI run cannot either — the original commit went green on re-run without any change.

What is verifiable: every post-await state write in the component is now unreachable after unmount, and the pending timer can no longer fire. `pnpm typecheck` clean, ESLint 0 errors, the component's test passes.

If the flake reappears after this, the next place to look is `handleInstallSkillSh` / `confirmInstall` / `openSkillDetail`, which share the pattern but are only reached from user interaction that tests await.

🤖 Generated with [Claude Code](https://claude.com/claude-code)