### PR TITLE
fix(model-picker): stop the model selector inventing a model when a runtime drops

### DIFF
--- a/packages/app/src/components/chat/AgentSelectorDock.tsx
+++ b/packages/app/src/components/chat/AgentSelectorDock.tsx
@@ -6,6 +6,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { ModelPickerCommand } from '@/components/model/ModelPickerCommand'
 import { useRuntimeStateStore } from '@/stores/runtime-state-store'
 import { resolveAgentAvailableModels } from '@/lib/agent-available-models'
+import { resolveSessionEstablishedModel } from '@/lib/session-established-model'
 import { sessionFlowError, sessionFlowLog } from '@/lib/session-flow-log'
 import { RuntimeLifecycle, AgentStatus, type RuntimeInfo } from '@/lib/proto/amux_pb'
 import {
@@ -185,22 +186,11 @@ function AgentPill({
   const pickEntry = useAgentModelPickStore((s) =>
     sessionId ? s.bySessionAgent[`${sessionId}::${agent.id}`] : undefined,
   )
-  // The model this session already ran with, from its transcript. Prefer the
-  // latest reply authored by THIS agent; fall back to the latest modeled
-  // message. Empty for brand-new sessions, so they keep the last-pick default.
-  const sessionEstablishedModel = useSessionMessageStore((s) => {
-    if (!sessionId) return null
-    const msgs = s.messages[sessionId]
-    if (!msgs?.length) return null
-    let fallback: string | null = null
-    for (let i = msgs.length - 1; i >= 0; i--) {
-      const model = msgs[i].model?.trim()
-      if (!model) continue
-      if (msgs[i].senderActorId === agent.id) return model
-      if (!fallback) fallback = model
-    }
-    return fallback
-  })
+  // The model this session already ran with, from its transcript. Empty for
+  // brand-new sessions, so they keep the last-pick default.
+  const sessionEstablishedModel = useSessionMessageStore((s) =>
+    sessionId ? resolveSessionEstablishedModel(s.messages[sessionId], agent.id) : null,
+  )
 
   const selected = React.useMemo(
     () =>

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -26,6 +26,7 @@ import { useAuthStore } from "@/stores/auth-store";
 import { bumpSessionListLastMessage } from "@/lib/session-list-preview";
 import { useSessionListStore } from "@/stores/session-list-store";
 import { useEngagedAgentStore } from "@/stores/engaged-agent-store";
+import { useAgentModelPickStore } from "@/stores/agent-model-pick-store";
 import { useSessionParticipantStore } from "@/stores/session-participant-store";
 import { useUIStore } from "@/stores/ui";
 import { getBackend } from "@/lib/backend";
@@ -84,6 +85,7 @@ import {
 } from "@/stores/v2-streaming-store";
 import { uploadAttachment } from "@/lib/attachment-upload";
 import { loadSessionActiveModel } from "@/lib/session-active-model";
+import { resolveSessionEstablishedModel } from "@/lib/session-established-model";
 import { ensureSessionLiveSubscribed } from "@/lib/session-live-subscriptions";
 import { resolveActorIdsFromAtText } from "@/lib/resolve-text-mentions";
 import { stripPickerPersonMentionsFromText } from "@/lib/strip-person-mentions";
@@ -531,10 +533,31 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
           entry.uiState === "stale" ||
           entry.uiState === "connecting"
         ) {
+          // Same cleanup the pill's own X does (AgentSelectorDock onRemove):
+          // a dropped agent's model pick must not outlive it, or the local
+          // agent inherits the dead remote's model.
+          useAgentModelPickStore.getState().clearPick(activeSessionId, entry.agent.id);
           removeAgentForSession(entry.agent.id);
         }
       }
       addAgentForSession(local);
+      // Engaging via the mention pill starts a runtime; switching must too.
+      // The local agent's real model only reaches the UI on its RuntimeInfo
+      // retain, so without this the pill has nothing to show and falls through
+      // to a positional default.
+      const teamId =
+        useSessionListStore.getState().rows.find((r) => r.id === activeSessionId)?.team_id ??
+        useCurrentTeamStore.getState().team?.id ??
+        null;
+      if (!teamId) return;
+      void import("@/lib/teamclaw/ensure-agent-runtime").then(({ ensureAgentRuntimesForSession }) => {
+        void ensureAgentRuntimesForSession({
+          sessionId: activeSessionId,
+          teamId,
+          agentActorIds: [local.id],
+          reason: "switch_to_local_agent",
+        });
+      });
     },
     [activeSessionId, engagedUiEntries, removeAgentForSession, addAgentForSession],
   );
@@ -870,6 +893,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
         sessionId: activeSessionId,
         runtimeStates,
         models: providerModels,
+        engagedAgentIds,
       });
       if (cancelled || !resolved) return;
       const nextKey = `${resolved.provider}/${resolved.modelId}`;
@@ -885,7 +909,10 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     return () => {
       cancelled = true;
     };
-  }, [activeSessionId, providerModels, runtimeStates, storeSelectModel]);
+    // engagedAgentIds is in the deps on purpose: swapping the mounted
+    // agent (e.g. remote → local) must re-resolve the picker, not leave it on
+    // whatever the departed agent's runtime row said.
+  }, [activeSessionId, providerModels, runtimeStates, storeSelectModel, engagedAgentIds]);
 
   // ── Team config hot reload via file watcher ─────────────────────────
   React.useEffect(() => {
@@ -1448,18 +1475,10 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
           // session's transcript-established model here too; without it the
           // send path fell through to the agent-level runtime retain, which
           // can belong to another session (显示 A 实跑 B).
-          const establishedForSend = (() => {
-            const msgs = useSessionMessageStore.getState().messages[sid];
-            if (!msgs?.length) return null;
-            let fb: string | null = null;
-            for (let i = msgs.length - 1; i >= 0; i--) {
-              const model = msgs[i].model?.trim();
-              if (!model) continue;
-              if (msgs[i].senderActorId === agentRuntimeIdsForSend[0]) return model;
-              if (!fb) fb = model;
-            }
-            return fb;
-          })();
+          const establishedForSend = resolveSessionEstablishedModel(
+            useSessionMessageStore.getState().messages[sid],
+            agentRuntimeIdsForSend[0] ?? "",
+          );
           const outgoingModel =
             agentRuntimeIdsForSend.length > 0
               ? selectAgentModel({

--- a/packages/app/src/lib/__tests__/session-active-model.test.ts
+++ b/packages/app/src/lib/__tests__/session-active-model.test.ts
@@ -57,4 +57,34 @@ describe('resolveSessionModelFromRuntimeRows', () => {
       source: 'agentRuntimes',
     })
   })
+
+  it('prefers a mounted agent runtime over an earlier row from a departed agent', () => {
+    // Shape of "switch to local agent": the dead remote's row is still in the
+    // session and comes back first, but only the local agent is mounted.
+    const result = resolveSessionModelFromRuntimeRows(
+      [
+        { runtime_id: 'rt-remote', backend_type: 'claude-code', current_model: 'claude-sonnet-4-6' },
+        { runtime_id: 'rt-local', backend_type: 'opencode', current_model: 'opencode/big-pickle' },
+      ],
+      {
+        'rt-remote': { daemonActorId: 'agent-remote', info: { currentModel: 'claude-sonnet-4-6' } } as any,
+        'rt-local': { daemonActorId: 'agent-local', info: { currentModel: 'opencode/big-pickle' } } as any,
+      },
+      models,
+      ['agent-local'],
+    )
+
+    expect(result).toMatchObject({ provider: 'opencode', modelId: 'opencode/big-pickle' })
+  })
+
+  it('keeps row order when no row belongs to a mounted agent', () => {
+    const result = resolveSessionModelFromRuntimeRows(
+      [{ runtime_id: 'rt-remote', backend_type: 'claude-code', current_model: 'claude-sonnet-4-6' }],
+      {},
+      models,
+      ['agent-local'],
+    )
+
+    expect(result).toMatchObject({ modelId: 'claude-sonnet-4-6', source: 'agentRuntimes' })
+  })
 })

--- a/packages/app/src/lib/__tests__/session-established-model.test.ts
+++ b/packages/app/src/lib/__tests__/session-established-model.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import { MessageKind } from '@/lib/proto/teamclaw_pb'
+import { resolveSessionEstablishedModel } from '../session-established-model'
+
+describe('resolveSessionEstablishedModel', () => {
+  const agent = 'agent-local'
+
+  it("prefers the agent's own latest modeled message", () => {
+    const model = resolveSessionEstablishedModel(
+      [
+        { model: 'big-pickle', senderActorId: agent, kind: MessageKind.AGENT_REPLY },
+        { model: 'qwen3.6-plus', senderActorId: 'user-1', kind: MessageKind.TEXT },
+      ],
+      agent,
+    )
+
+    expect(model).toBe('big-pickle')
+  })
+
+  it("falls back to the user's own message when the agent has not replied yet", () => {
+    const model = resolveSessionEstablishedModel(
+      [{ model: 'qwen3.6-plus', senderActorId: 'user-1', kind: MessageKind.TEXT }],
+      agent,
+    )
+
+    expect(model).toBe('qwen3.6-plus')
+  })
+
+  it('never inherits another agent\'s model', () => {
+    // "switch to local agent": the transcript is all remote-agent replies.
+    const model = resolveSessionEstablishedModel(
+      [
+        { model: 'claude-sonnet-4-6', senderActorId: 'agent-remote', kind: MessageKind.AGENT_REPLY },
+        { model: 'claude-sonnet-4-6', senderActorId: 'agent-remote', kind: MessageKind.AGENT_THINKING },
+      ],
+      agent,
+    )
+
+    expect(model).toBeNull()
+  })
+
+  it('skips another agent\'s reply but still sees an older user message', () => {
+    const model = resolveSessionEstablishedModel(
+      [
+        { model: 'qwen3.6-plus', senderActorId: 'user-1', kind: MessageKind.TEXT },
+        { model: 'claude-sonnet-4-6', senderActorId: 'agent-remote', kind: MessageKind.AGENT_REPLY },
+      ],
+      agent,
+    )
+
+    expect(model).toBe('qwen3.6-plus')
+  })
+
+  it('returns null for an empty transcript or a missing agent id', () => {
+    expect(resolveSessionEstablishedModel([], agent)).toBeNull()
+    expect(resolveSessionEstablishedModel(undefined, agent)).toBeNull()
+    expect(
+      resolveSessionEstablishedModel(
+        [{ model: 'big-pickle', senderActorId: agent, kind: MessageKind.AGENT_REPLY }],
+        '  ',
+      ),
+    ).toBeNull()
+  })
+})

--- a/packages/app/src/lib/session-active-model.ts
+++ b/packages/app/src/lib/session-active-model.ts
@@ -43,12 +43,40 @@ function liveRuntimeEntryForRow(
   return resolveRuntimeStateEntryForAgent(runtimeId, runtimeStates, runtimeId)
 }
 
+/**
+ * Rows come back in an arbitrary order and carry no `agent_id`, so "the first
+ * row that resolves" can be a dead agent's runtime — e.g. right after
+ * "switch to local agent", the offline remote's row is still in the session.
+ * Sort the rows whose live retain belongs to a currently-engaged agent first.
+ */
+function orderRowsByEngagedAgents(
+  rows: RuntimeRow[],
+  runtimeStates: Record<string, RuntimeStateEntry>,
+  engagedAgentIds: readonly string[],
+): RuntimeRow[] {
+  const engaged = new Set(engagedAgentIds.map((id) => id.trim()).filter(Boolean));
+  if (engaged.size === 0) return rows;
+
+  const belongsToEngagedAgent = (row: RuntimeRow): boolean => {
+    const runtimeId = row.runtime_id?.trim();
+    if (!runtimeId) return false;
+    const entry = runtimeStates[runtimeId];
+    if (!entry) return false;
+    return engaged.has(entry.daemonActorId) || engaged.has(entry.info.runtimeId);
+  };
+
+  const preferred = rows.filter(belongsToEngagedAgent);
+  if (preferred.length === 0) return rows;
+  return [...preferred, ...rows.filter((row) => !belongsToEngagedAgent(row))];
+}
+
 export function resolveSessionModelFromRuntimeRows(
   rows: RuntimeRow[],
   runtimeStates: Record<string, RuntimeStateEntry>,
   models: ModelOption[],
+  engagedAgentIds: readonly string[] = [],
 ): SessionModelResolution | null {
-  for (const row of rows) {
+  for (const row of orderRowsByEngagedAgents(rows, runtimeStates, engagedAgentIds)) {
     const provider = providerIdForBackendType(row.backend_type)
     if (!provider) continue
 
@@ -79,6 +107,8 @@ export async function loadSessionActiveModel(args: {
   sessionId: string
   runtimeStates: Record<string, RuntimeStateEntry>
   models: ModelOption[]
+  /** Pills currently mounted — their runtimes win over other session rows. */
+  engagedAgentIds?: readonly string[]
 }): Promise<SessionModelResolution | null> {
   sessionFlowLog('session_model.load.begin', {
     sessionId: args.sessionId,
@@ -97,7 +127,12 @@ export async function loadSessionActiveModel(args: {
   }
 
   const rows = data ?? []
-  const resolved = resolveSessionModelFromRuntimeRows(rows, args.runtimeStates, args.models)
+  const resolved = resolveSessionModelFromRuntimeRows(
+    rows,
+    args.runtimeStates,
+    args.models,
+    args.engagedAgentIds ?? [],
+  )
 
   sessionFlowLog('session_model.load.done', {
     sessionId: args.sessionId,

--- a/packages/app/src/lib/session-established-model.ts
+++ b/packages/app/src/lib/session-established-model.ts
@@ -1,0 +1,60 @@
+import { MessageKind } from "@/lib/proto/teamclaw_pb";
+
+/**
+ * "Which model has this session already run with, for THIS agent?"
+ *
+ * Feeds `selectAgentModel({ sessionEstablishedModel })` from both the pill
+ * (AgentSelectorDock) and the send path (ChatPanel). Both used to inline their
+ * own copy of this scan; they must stay identical or the pill shows A while the
+ * prompt runs on B.
+ *
+ * Resolution order, scanning the transcript newest-first:
+ *
+ *  1. The latest message authored by this agent — the strongest evidence.
+ *  2. The latest message that is NOT another agent's output. In practice that
+ *     is the user's own message, which carries the model the user had picked
+ *     when sending, so a session that has never had a reply still resolves.
+ *
+ * Step 2 deliberately skips agent-authored messages from OTHER actors. Without
+ * that guard, swapping agents mid-session (e.g. "switch to local agent" after
+ * the remote one dies) made the new agent inherit the dead agent's model —
+ * it was simply the latest modeled message in the transcript.
+ */
+
+type EstablishedModelMessage = {
+  model?: string;
+  senderActorId?: string;
+  kind?: MessageKind;
+};
+
+function isAgentAuthoredKind(kind: MessageKind | undefined): boolean {
+  switch (kind) {
+    case MessageKind.AGENT_THINKING:
+    case MessageKind.AGENT_TOOL_CALL:
+    case MessageKind.AGENT_TOOL_RESULT:
+    case MessageKind.AGENT_REPLY:
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function resolveSessionEstablishedModel(
+  messages: ReadonlyArray<EstablishedModelMessage> | undefined | null,
+  agentId: string,
+): string | null {
+  const target = agentId.trim();
+  if (!messages?.length || !target) return null;
+
+  let fallback: string | null = null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    const model = message.model?.trim();
+    if (!model) continue;
+    if (message.senderActorId?.trim() === target) return model;
+    // Another agent's model is not this agent's model.
+    if (isAgentAuthoredKind(message.kind)) continue;
+    if (!fallback) fallback = model;
+  }
+  return fallback;
+}

--- a/packages/app/src/stores/__tests__/provider.test.ts
+++ b/packages/app/src/stores/__tests__/provider.test.ts
@@ -308,6 +308,35 @@ describe('provider store initAll', () => {
     expect(useProviderStore.getState().currentModelKey).toBe('scnet/minimax-m2.5')
   })
 
+  it('clears the selection instead of jumping to models[0] when a validated model leaves the catalog', async () => {
+    // A runtime advertising two models, the user on the second one.
+    mocks.getDaemonProviders.mockResolvedValue([
+      { id: 'scnet', display_name: 'Scnet', authenticated: true, models: ['minimax-m2.5', 'kimi-k3'] },
+    ])
+
+    const { useProviderStore } = await import('../provider')
+    await useProviderStore.getState().initAll()
+    await useProviderStore.getState().selectModel('scnet', 'kimi-k3', 'Kimi K3')
+    expect(useProviderStore.getState().currentModelKey).toBe('scnet/kimi-k3')
+
+    // That model's runtime drops off; only the other model remains on offer.
+    mocks.getDaemonProviders.mockResolvedValue([
+      { id: 'scnet', display_name: 'Scnet', authenticated: true, models: ['minimax-m2.5'] },
+    ])
+    await useProviderStore.getState().initAll()
+
+    expect(useProviderStore.getState().currentModelKey).toBeNull()
+    // The choice is kept on disk so it returns with the runtime.
+    expect(localStorage.getItem('teamclaw-selected-model:/workspace/demo')).toBe('scnet/kimi-k3')
+
+    mocks.getDaemonProviders.mockResolvedValue([
+      { id: 'scnet', display_name: 'Scnet', authenticated: true, models: ['minimax-m2.5', 'kimi-k3'] },
+    ])
+    await useProviderStore.getState().initAll()
+
+    expect(useProviderStore.getState().currentModelKey).toBe('scnet/kimi-k3')
+  })
+
   it('does not recover to daemon runtime info from a custom-provider selection', async () => {
     mocks.getDaemonProviders.mockResolvedValue([
       {

--- a/packages/app/src/stores/provider.ts
+++ b/packages/app/src/stores/provider.ts
@@ -385,6 +385,13 @@ export interface ProviderState {
   _disconnectedIds: Set<string>
   _workspacePath: string | null
 
+  // The last model key that was actually found in a non-empty catalog — either
+  // resolved by initAll or picked by the user. Distinguishes "the saved key was
+  // never on offer" (cold start, stale localStorage) from "the key WAS on offer
+  // and the catalog lost it" (a runtime dropped off). Only the latter must
+  // avoid falling back to `models[0]`.
+  _validatedModelKey: string | null
+
   // Actions
   refreshAuthMethods: () => Promise<void>
   connectProviderOAuth: (providerId: string, methodIndex: number) => Promise<
@@ -419,6 +426,7 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
   customProviderIds: [],
   _disconnectedIds: new Set<string>(),
   _workspacePath: null,
+  _validatedModelKey: null,
 
   refreshAuthMethods: async () => {
     const workspacePath = useWorkspaceStore.getState().workspacePath
@@ -740,7 +748,8 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
   // Select a model for the OpenCode-backed settings/chat UI.
   selectModel: async (providerId: string, modelId: string, _modelName: string) => {
     const modelKey = `${providerId}/${modelId}`
-    set({ currentModelKey: modelKey })
+    // A pick always comes from a rendered catalog, so it counts as validated.
+    set({ currentModelKey: modelKey, _validatedModelKey: modelKey })
 
     // Cache in workspace-scoped localStorage as fallback
     localStorage.setItem(selectedModelStorageKey(), modelKey)
@@ -753,7 +762,11 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
     const workspaceChanged =
       previousWorkspacePath !== null && previousWorkspacePath !== workspacePathAtStart
     if (workspaceChanged) {
-      set({ currentModelKey: null, _workspacePath: workspacePathAtStart ?? null })
+      set({
+        currentModelKey: null,
+        _validatedModelKey: null,
+        _workspacePath: workspacePathAtStart ?? null,
+      })
     } else if (previousWorkspacePath === null) {
       set({ _workspacePath: workspacePathAtStart ?? null })
     }
@@ -786,7 +799,7 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
       }
     }
 
-    const { currentModelKey } = get()
+    const { currentModelKey, _validatedModelKey: validatedModelKey } = get()
     const availableModels = get().models
 
     let resolvedKey = currentModelKey
@@ -797,7 +810,21 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
       if (saved && availableModels.find((m) => `${m.provider}/${m.id}` === saved)) {
         resolvedKey = saved
         resolvedSource = 'localStorage'
+      } else if (validatedModelKey && validatedModelKey === currentModelKey) {
+        // This exact key WAS in the catalog before, and now is not: the model
+        // did not go missing, it went AWAY — typically an agent's runtime
+        // dropped off and took its catalog with it. Falling through to
+        // `availableModels[0]` here silently swaps the user onto an unrelated
+        // model (the "突然变成 sonnet" report). Resolve to nothing instead and
+        // let the session/agent resolvers refill it once a runtime is back.
+        // localStorage is deliberately left alone, so the choice comes back
+        // with the runtime.
+        resolvedKey = null
+        resolvedSource = 'unavailable'
       } else if (availableModels.length > 0) {
+        // Never validated (cold start with a stale localStorage key, or the
+        // catalog has changed underneath). First entry beats an empty picker
+        // here — nothing was taken away from the user.
         resolvedKey = `${availableModels[0].provider}/${availableModels[0].id}`
         resolvedSource = 'firstAvailable'
       } else {
@@ -814,7 +841,9 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
     })
 
     if (resolvedKey) {
-      set({ currentModelKey: resolvedKey })
+      // Every path that yields a key here checked it against `availableModels`
+      // (or was carried over from a check on a previous run), so it is validated.
+      set({ currentModelKey: resolvedKey, _validatedModelKey: resolvedKey })
       // Sync workspace-scoped localStorage to be consistent
       localStorage.setItem(selectedModelStorageKey(), resolvedKey)
     } else {


### PR DESCRIPTION
## 问题

远端 agent 掉线后点「换本机 Agent」，模型选择器会突然跳到一个不相干的模型（报告里是 sonnet）。发送路径按 agent 解析，所以实际跑的模型大概率是对的——错的是显示，属于「显示 A 实跑 B」。

## 根因

四条独立路径都能喂出错误的模型，没有一条去问本机 agent 到底在跑什么：

1. **`provider.ts` 的位置兜底** — 远端 runtime 掉线 → 它的 MQTT retain 离开 `runtimeStateStore` → `runtimeModelSignature` 变化 → `initProviderStore()` 重建 catalog → 旧的 `currentModelKey` 匹配不上 → 掉到 `availableModels[0]`（日志里的 `firstAvailable`）。

2. **transcript 串味** — `selectAgentModel` 的 `sessionEstablishedModel` 由扫描 transcript 得出，取不到该 agent 自己的消息时会**退而取任意最后一条带 model 的消息**。切换瞬间 transcript 全是远端 agent 的回复，于是本机 agent 直接继承了它的模型。pill 和发送路径各有一份重复实现。

3. **切换按钮少做一步** — 对比 `onEngageAgent` 会调 `ensureAgentRuntimesForSession`，`handleSwitchToLocalAgent` 是纯 pill 交换，本机 runtime 不启动，真实模型就没有到达 UI 的途径；也没清掉被摘掉 agent 的 model pick（pill 上的 X 本来会做）。

4. **行序决定胜负** — `loadSessionActiveModel` 按返回顺序遍历 session 的所有 runtime 行取第一个能解析的，离线远端的行可能排在前面；且该 effect 的依赖不含挂载的 agent，切 agent 不会重跑。

## 改动

- `stores/provider.ts` — 新增 `_validatedModelKey`，记录「这个 key 确实在真实 catalog 里出现过」。它随 runtime 掉线消失时解析成 `null` 而非 `models[0]`；localStorage 保持不动，runtime 回来时选择自动恢复。冷启动 + 陈旧 saved key 仍走 first-available（既有测试锁定的行为）。
- `lib/session-established-model.ts`（新）— transcript 扫描抽成单一实现，跳过其他 agent 产出的消息（`AGENT_REPLY` / `AGENT_THINKING` / `AGENT_TOOL_*`），但用户自己那条仍然算数——它承载的正是用户当时选的模型。pill 与发送路径改为共用，不再有两份会漂移的拷贝。
- `ChatPanel.tsx` — `handleSwitchToLocalAgent` 补上 `ensureAgentRuntimesForSession` 并清理离场 agent 的 pick；`loadSessionActiveModel` 的 effect 加入 `engagedAgentIds` 依赖。
- `lib/session-active-model.ts` — `resolveSessionModelFromRuntimeRows` 接收挂载的 agent id，按 retain 的 `daemonActorId` 把属于挂载 agent 的行排前。API 返回的行没有 `agent_id`，走客户端 retain 匹配，**未改动 OpenAPI 契约**。

## 验证

- `pnpm typecheck` 通过；`pnpm lint` 0 errors（仅既有 warning）。
- 新增 8 个测试：transcript 跨 agent 泄漏 5、runtime 行排序 2、provider store「validated model 消失」1。
- 全量 `pnpm test:unit`：383 files / 2250 tests，8 files / 16 tests 失败——**与改动前逐一对应**。用 stash 在无改动的分支上单独复跑过这批（useAppInit / RightPanel / SessionListColumn / locale / build-config / acp-debug-store / session-pins / TeamSection-legacy / ChatMessage-streaming），同样失败，属既有问题，本 PR 未触碰。

⚠️ **未做实机验证** —— 需要一个远端 agent 掉线的现场，尚未在真实 app 里点过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)