### PR TITLE
fix(daemon): the model catalog belongs to the device, not to one binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,10 @@ playwright-report/
 .worktrees/
 
 # Tauri MCP plugin (cloned dependency)
+# Dev-only guest-JS package for tauri-mcp. Usually a symlink to
+# apps/desktop/tauri-plugin-mcp-local, so match the bare name too — the
+# trailing-slash form ignores a directory but not a symlink to one.
+.tauri-plugin-mcp
 .tauri-plugin-mcp/
 
 

--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -2,6 +2,7 @@ mod daemon_config;
 pub mod edit;
 pub mod global_team_store;
 mod member_store;
+mod model_catalog;
 mod model_mru;
 pub mod provider_auth;
 mod roles_skills;
@@ -22,6 +23,7 @@ pub use daemon_config::{
 #[cfg(test)]
 pub use daemon_config::ChannelsConfig;
 pub use member_store::{MemberStore, PendingInvite, StoredMember};
+pub use model_catalog::DeviceModelCatalog;
 pub use model_mru::{first_available, ModelMru};
 pub use provider_auth::{
     builtin_provider_auth_methods, merge_live_provider_auth_methods, ProviderAuthMethod,

--- a/apps/daemon/src/config/model_catalog.rs
+++ b/apps/daemon/src/config/model_catalog.rs
@@ -1,0 +1,238 @@
+//! Device-scoped model catalog, keyed by worktree directory.
+//!
+//! # Why this exists
+//!
+//! The model catalog is a property of the *device* — of the one global
+//! `opencode serve` process and the providers configured for a given worktree
+//! (see `runtime::opencode_http::supervisor`: "One serve instance per
+//! daemon"). It is emphatically not a property of a single runtime binding.
+//!
+//! It used to be stored as one, though. `RuntimeHandle::available_models` is
+//! filled from `startup.available_models` at attach time and published in that
+//! handle's retained `runtime/{id}/state`. Every other binding for the same
+//! device — an idle one from yesterday, a historical row replayed out of
+//! `SessionStore` by `publish_all_agent_states` — advertised an **empty**
+//! catalog, because it never had an attach of its own to fill it.
+//!
+//! Clients read that as "this runtime offers no models". The desktop's session
+//! pill treats `availableModelCount == 0` as not-ready and shows 连接中 with no
+//! model name, forever, for any session that is not the most recent spawn.
+//! Observed 2026-07-27: two sessions on the same device, one green with 44
+//! models, one stuck connecting — the difference was solely which binding had
+//! done the attach.
+//!
+//! So the catalog is cached here once per worktree and merged into every
+//! `RuntimeInfo` that would otherwise go out empty.
+//!
+//! # Why it is persisted
+//!
+//! `publish_all_agent_states` runs at startup and after every MQTT reconnect —
+//! before any runtime has attached, so an in-memory-only cache would still be
+//! empty at exactly the moment it is most needed. Persisting means a cold
+//! daemon publishes its last-known catalog instead of nothing.
+//!
+//! A stale entry is safe: this list only populates a picker. The authoritative
+//! check happens on `set_model`, which goes to the live serve. Publishing a
+//! slightly outdated list beats publishing none — the failure mode of "none"
+//! is a session that can never be used.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::proto::amux;
+
+/// One worktree's last-known catalog.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StoredModel {
+    pub id: String,
+    #[serde(default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub provider_name: String,
+}
+
+/// Canonical worktree path → the models that worktree last advertised.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct DeviceModelCatalog {
+    #[serde(default)]
+    pub by_worktree: BTreeMap<String, Vec<StoredModel>>,
+}
+
+impl DeviceModelCatalog {
+    pub fn default_path() -> PathBuf {
+        super::DaemonConfig::migrate_legacy_file("model-catalog.toml")
+    }
+
+    /// Read the store, treating any problem (missing, unreadable, malformed) as
+    /// "no catalog yet". Same convention as [`super::ModelMru`]: a cache must
+    /// never fail startup.
+    pub fn load(path: &Path) -> Self {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            return Self::default();
+        };
+        match toml::from_str::<Self>(&content) {
+            Ok(mut store) => {
+                for models in store.by_worktree.values_mut() {
+                    models.retain(|m| !m.id.trim().is_empty());
+                }
+                store.by_worktree.retain(|_, models| !models.is_empty());
+                store
+            }
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "model catalog unreadable; starting empty");
+                Self::default()
+            }
+        }
+    }
+
+    pub fn save(&self, path: &Path) -> crate::error::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let content = toml::to_string_pretty(self)
+            .map_err(|e| crate::error::AmuxError::Config(e.to_string()))?;
+        std::fs::write(path, content)?;
+        Ok(())
+    }
+
+    /// Replace `worktree`'s catalog. Returns whether anything changed, so the
+    /// caller can skip the disk write on the common "same catalog again" path.
+    ///
+    /// An empty `models` is ignored rather than stored: a failed or not-yet-
+    /// completed probe must not erase a good catalog — that would reintroduce
+    /// exactly the empty-list bug this store exists to prevent.
+    pub fn record(&mut self, worktree: &str, models: &[amux::ModelInfo]) -> bool {
+        let key = worktree.trim();
+        if key.is_empty() || models.is_empty() {
+            return false;
+        }
+        let next: Vec<StoredModel> = models
+            .iter()
+            .filter(|m| !m.id.trim().is_empty())
+            .map(|m| StoredModel {
+                id: m.id.clone(),
+                display_name: m.display_name.clone(),
+                provider_name: m.provider_name.clone(),
+            })
+            .collect();
+        if next.is_empty() {
+            return false;
+        }
+        if self.by_worktree.get(key) == Some(&next) {
+            return false;
+        }
+        self.by_worktree.insert(key.to_string(), next);
+        true
+    }
+
+    /// `worktree`'s last-known catalog as proto, empty when unknown.
+    pub fn models_for(&self, worktree: &str) -> Vec<amux::ModelInfo> {
+        self.by_worktree
+            .get(worktree.trim())
+            .map(|models| {
+                models
+                    .iter()
+                    .map(|m| amux::ModelInfo {
+                        id: m.id.clone(),
+                        display_name: m.display_name.clone(),
+                        provider_name: m.provider_name.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Any known catalog, preferred by exact worktree match.
+    ///
+    /// A historical `SessionStore` row can carry a worktree this device has
+    /// since stopped using (renamed directory, deleted worktree). Falling back
+    /// to *some* catalog from this device is still far more useful than an
+    /// empty list, because every worktree on one device is served by the same
+    /// `opencode serve` with the same provider credentials — the per-worktree
+    /// split exists for workspace-local `opencode.json` overrides, not for
+    /// wholly disjoint model sets.
+    pub fn models_for_or_any(&self, worktree: &str) -> Vec<amux::ModelInfo> {
+        let exact = self.models_for(worktree);
+        if !exact.is_empty() {
+            return exact;
+        }
+        self.by_worktree
+            .values()
+            .next()
+            .map(|models| {
+                models
+                    .iter()
+                    .map(|m| amux::ModelInfo {
+                        id: m.id.clone(),
+                        display_name: m.display_name.clone(),
+                        provider_name: m.provider_name.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model(id: &str) -> amux::ModelInfo {
+        amux::ModelInfo {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            provider_name: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn record_stores_and_dedupes() {
+        let mut cat = DeviceModelCatalog::default();
+        assert!(cat.record("/w1", &[model("a/x"), model("a/y")]));
+        // Same catalog again is a no-op, so callers can skip the disk write.
+        assert!(!cat.record("/w1", &[model("a/x"), model("a/y")]));
+        assert!(cat.record("/w1", &[model("a/x")]));
+        assert_eq!(cat.models_for("/w1").len(), 1);
+    }
+
+    #[test]
+    fn record_ignores_empty_so_a_failed_probe_cannot_erase_a_good_catalog() {
+        let mut cat = DeviceModelCatalog::default();
+        cat.record("/w1", &[model("a/x")]);
+        assert!(!cat.record("/w1", &[]));
+        assert_eq!(cat.models_for("/w1").len(), 1);
+    }
+
+    #[test]
+    fn models_for_or_any_falls_back_to_another_worktree() {
+        let mut cat = DeviceModelCatalog::default();
+        cat.record("/w1", &[model("a/x")]);
+        // Unknown worktree — a historical session row from a directory that no
+        // longer exists still gets this device's catalog.
+        assert_eq!(cat.models_for("/gone").len(), 0);
+        assert_eq!(cat.models_for_or_any("/gone").len(), 1);
+    }
+
+    #[test]
+    fn load_missing_file_is_empty_not_an_error() {
+        let path = std::env::temp_dir().join("amuxd-test-catalog-missing.toml");
+        let _ = std::fs::remove_file(&path);
+        assert!(DeviceModelCatalog::load(&path).by_worktree.is_empty());
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let path = std::env::temp_dir()
+            .join("amuxd-test-model-catalog")
+            .join(format!("{}.toml", uuid::Uuid::new_v4()));
+        let mut cat = DeviceModelCatalog::default();
+        cat.record("/w1", &[model("a/x"), model("a/y")]);
+        cat.save(&path).expect("save");
+        let loaded = DeviceModelCatalog::load(&path);
+        assert_eq!(loaded.models_for("/w1").len(), 2);
+        assert_eq!(loaded.models_for("/w1")[0].id, "a/x");
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -19,14 +19,20 @@ impl DaemonServer {
     /// Now only used by `publish_all_agent_states` to iterate startup/reconnect state.
     /// Per-agent updates should go through `publish_runtime_state_by_id`.
     pub(crate) async fn merged_agent_list(&self) -> amux::AgentList {
-        let mut agent_list = self.agents.lock().await.to_proto_agent_list();
+        let agents = self.agents.lock().await;
+        let mut agent_list = agents.to_proto_agent_list();
         let active_ids: std::collections::HashSet<String> = agent_list
             .runtimes
             .iter()
             .map(|a| a.runtime_id.clone())
             .collect();
-        for session_info in self.sessions.to_proto_agent_list() {
+        for mut session_info in self.sessions.to_proto_agent_list() {
             if !active_ids.contains(&session_info.runtime_id) {
+                // Historical rows carry no catalog of their own — they were
+                // written by a runtime that is no longer attached. Publishing
+                // them empty is what pinned every non-newest session's pill at
+                // "connecting" with no model name.
+                agents.fill_catalog(&mut session_info);
                 agent_list.runtimes.push(session_info);
             }
         }
@@ -36,9 +42,17 @@ impl DaemonServer {
     /// Look up a single agent's current RuntimeInfo — live adapter first, then
     /// the historical session store. Returns `None` if unknown.
     pub(crate) async fn agent_info_by_id(&self, agent_id: &str) -> Option<amux::RuntimeInfo> {
-        match self.agents.lock().await.to_proto_info(agent_id) {
+        let agents = self.agents.lock().await;
+        match agents.to_proto_info(agent_id) {
             Some(info) => Some(info),
-            None => self.sessions.to_proto_agent_info(agent_id),
+            None => {
+                // Same reason as `merged_agent_list`: a historical row must
+                // still advertise the device's catalog, or its session can
+                // never leave "connecting".
+                let mut info = self.sessions.to_proto_agent_info(agent_id)?;
+                agents.fill_catalog(&mut info);
+                Some(info)
+            }
         }
     }
 

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -11,7 +11,7 @@ use super::refresh::RuntimeRefreshCoordinator;
 use std::sync::Arc;
 
 use crate::backend::{AgentRuntimeUpsert, Backend};
-use crate::config::{DaemonConfig, ModelMru};
+use crate::config::{DaemonConfig, DeviceModelCatalog, ModelMru};
 use crate::proto::amux;
 use crate::runtime::acp_event_frame::AcpEventFrame;
 use crate::runtime::turn_aggregator::TurnAggregator;
@@ -196,6 +196,14 @@ pub struct RuntimeManager {
     /// Where [`Self::model_mru`] is persisted. Split out so tests can point at
     /// a tempdir instead of the real config directory.
     model_mru_path: PathBuf,
+    /// Last-known model catalog per worktree for this device. The catalog
+    /// belongs to the one global `opencode serve`, not to any single binding —
+    /// see `config::model_catalog` for why storing it per-handle produced
+    /// sessions that could never leave 连接中.
+    model_catalog: DeviceModelCatalog,
+    /// Where [`Self::model_catalog`] is persisted (same test-isolation split as
+    /// `model_mru_path`).
+    model_catalog_path: PathBuf,
     backend: Option<Arc<dyn Backend>>,
     /// agent_ids that were stopped by the idle sweeper and still need their
     /// terminal `runtime/{id}/state` publish + retain clear. Drained by the
@@ -268,6 +276,12 @@ impl RuntimeManager {
             .join(format!("{}.toml", Uuid::new_v4()));
         #[cfg(not(test))]
         let model_mru_path = ModelMru::default_path();
+        #[cfg(test)]
+        let model_catalog_path = std::env::temp_dir()
+            .join("amuxd-test-model-catalog")
+            .join(format!("{}.toml", Uuid::new_v4()));
+        #[cfg(not(test))]
+        let model_catalog_path = DeviceModelCatalog::default_path();
         Self {
             agents: HashMap::new(),
             aggregators: std::collections::HashMap::new(),
@@ -277,6 +291,8 @@ impl RuntimeManager {
             agent_state: PerAgentRuntimeState::new(),
             model_mru: ModelMru::load(&model_mru_path),
             model_mru_path,
+            model_catalog: DeviceModelCatalog::load(&model_catalog_path),
+            model_catalog_path,
             backend,
             refresh_coordinator: None,
             evicted_pending_publish: Vec::new(),
@@ -573,6 +589,7 @@ impl RuntimeManager {
         self.aggregators
             .insert(agent_id.clone(), TurnAggregator::new());
 
+        self.record_catalog(worktree, &startup.available_models);
         if let Some(h) = self.agents.get_mut(&agent_id) {
             h.available_models = startup.available_models;
             h.acp_session_id = startup.acp_session_id.clone();
@@ -750,6 +767,7 @@ impl RuntimeManager {
             .insert(agent_id.to_string(), TurnAggregator::new());
 
         let new_acp_sid = startup.acp_session_id.clone();
+        self.record_catalog(worktree, &startup.available_models);
         if let Some(h) = self.agents.get_mut(agent_id) {
             h.available_models = startup.available_models;
             h.acp_session_id = startup.acp_session_id;
@@ -820,7 +838,44 @@ impl RuntimeManager {
         &mut self,
         workspace_path: &std::path::Path,
     ) -> crate::error::Result<Vec<amux::ModelInfo>> {
-        self.agent_backend.model_catalog(workspace_path).await
+        let models = self.agent_backend.model_catalog(workspace_path).await?;
+        self.record_catalog(&workspace_path.to_string_lossy(), &models);
+        Ok(models)
+    }
+
+    /// Remember `worktree`'s catalog for this device and persist it.
+    ///
+    /// Called from every path that learns a real catalog (both attach paths and
+    /// the explicit probe). Empty lists are ignored by
+    /// [`DeviceModelCatalog::record`], so a failed probe cannot erase a good one.
+    fn record_catalog(&mut self, worktree: &str, models: &[amux::ModelInfo]) {
+        if !self.model_catalog.record(worktree, models) {
+            return;
+        }
+        if let Err(e) = self.model_catalog.save(&self.model_catalog_path) {
+            tracing::warn!(error = %e, "failed to persist model catalog");
+        }
+    }
+
+    /// This device's last-known catalog for `worktree` (falling back to any
+    /// known worktree). Used to fill `RuntimeInfo.available_models` for
+    /// bindings that never ran an attach of their own.
+    pub fn catalog_for_worktree(&self, worktree: &str) -> Vec<amux::ModelInfo> {
+        self.model_catalog.models_for_or_any(worktree)
+    }
+
+    /// Fill `info.available_models` from the device catalog when the binding
+    /// itself has none.
+    ///
+    /// Every `RuntimeInfo` leaving this daemon goes through here. Without it,
+    /// an idle binding — or a historical `SessionStore` row replayed by
+    /// `publish_all_agent_states` — advertises an empty catalog, and clients
+    /// read that as "no models", which pins the session's pill at 连接中.
+    pub fn fill_catalog(&self, info: &mut amux::RuntimeInfo) {
+        if !info.available_models.is_empty() {
+            return;
+        }
+        info.available_models = self.catalog_for_worktree(&info.worktree);
     }
 
     /// Invalidate long-lived OpenCode/Codex ACP hosts after provider credentials change.
@@ -1169,7 +1224,9 @@ impl RuntimeManager {
                 .map(|(id, h)| {
                     let current = self.agent_state.model_or_default(id);
                     let commands = self.agent_state.commands(id);
-                    h.to_proto_info(current, commands)
+                    let mut info = h.to_proto_info(current, commands);
+                    self.fill_catalog(&mut info);
+                    info
                 })
                 .collect(),
         }
@@ -1181,7 +1238,9 @@ impl RuntimeManager {
         let handle = self.agents.get(agent_id)?;
         let current = self.agent_state.model_or_default(agent_id);
         let commands = self.agent_state.commands(agent_id);
-        Some(handle.to_proto_info(current, commands))
+        let mut info = handle.to_proto_info(current, commands);
+        self.fill_catalog(&mut info);
+        Some(info)
     }
 
     pub fn agent_ids(&self) -> Vec<String> {
@@ -1471,6 +1530,76 @@ impl RuntimeManager {
 mod tests {
     use super::super::handle::PendingMessage;
     use super::*;
+
+    fn catalog_model(id: &str) -> amux::ModelInfo {
+        amux::ModelInfo {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            provider_name: "test".to_string(),
+        }
+    }
+
+    /// The catalog belongs to the device, so a binding that never attached
+    /// still advertises it. Before this, such a binding published an empty
+    /// list and its session's pill could never leave "connecting".
+    #[test]
+    fn fill_catalog_populates_a_binding_that_never_attached() {
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.record_catalog("/w1", &[catalog_model("a/x"), catalog_model("a/y")]);
+
+        let mut info = amux::RuntimeInfo {
+            runtime_id: "rt-idle".into(),
+            worktree: "/w1".into(),
+            ..Default::default()
+        };
+        mgr.fill_catalog(&mut info);
+        assert_eq!(info.available_models.len(), 2);
+    }
+
+    /// A live attach's own catalog is authoritative — never overwritten by the
+    /// cached one.
+    #[test]
+    fn fill_catalog_leaves_a_populated_list_alone() {
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.record_catalog("/w1", &[catalog_model("a/x"), catalog_model("a/y")]);
+
+        let mut info = amux::RuntimeInfo {
+            runtime_id: "rt-live".into(),
+            worktree: "/w1".into(),
+            available_models: vec![catalog_model("live/only")],
+            ..Default::default()
+        };
+        mgr.fill_catalog(&mut info);
+        assert_eq!(info.available_models.len(), 1);
+        assert_eq!(info.available_models[0].id, "live/only");
+    }
+
+    /// A historical row can name a worktree this device no longer uses; one
+    /// serve with one set of provider credentials backs them all, so some
+    /// catalog beats none.
+    #[test]
+    fn fill_catalog_falls_back_across_worktrees() {
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.record_catalog("/w1", &[catalog_model("a/x")]);
+
+        let mut info = amux::RuntimeInfo {
+            runtime_id: "rt-old".into(),
+            worktree: "/deleted-worktree".into(),
+            ..Default::default()
+        };
+        mgr.fill_catalog(&mut info);
+        assert_eq!(info.available_models.len(), 1);
+    }
+
+    /// An empty catalog must never be recorded: a failed probe would otherwise
+    /// erase the good list and reintroduce the bug.
+    #[test]
+    fn record_catalog_ignores_an_empty_probe_result() {
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.record_catalog("/w1", &[catalog_model("a/x")]);
+        mgr.record_catalog("/w1", &[]);
+        assert_eq!(mgr.catalog_for_worktree("/w1").len(), 1);
+    }
 
     #[test]
     fn set_current_model_records_value() {


### PR DESCRIPTION
## The bug

A session bound to anything other than the device's most recent attach sits at
「连接中...」 with no model name, forever. Observed 2026-07-27 on
`liziliudeMacBook-Air`: two sessions, same device, same moment — one green with 44
models, one stuck. Both read the same MQTT retain store.

## Root cause

`available_models` lived on `RuntimeHandle`, filled from `startup.available_models`
at attach time (`runtime/manager.rs`). But the catalog is a property of the one
global `opencode serve` plus the providers configured for a worktree —
`runtime/opencode_http/supervisor.rs:1` opens with *"Global `opencode serve` process
supervisor. One serve instance per daemon"*. It is not a property of a binding.

So every binding that had not itself attached published an **empty** catalog in its
retained `runtime/{id}/state`, and the desktop reads `availableModelCount === 0` as
not-ready (`session-agent-ui-state.ts`), which pins the pill at connecting.

Not an edge case: `publish_all_agent_states` replays a retained RuntimeInfo for every
historical `SessionStore` row at startup and on every MQTT reconnect, and those rows
never attached at all. Measured on one device: **124 retained runtimes, exactly 1
carrying a catalog.**

Live evidence collected before the fix:

| runtime | session | agent_runtimes | catalog | pill |
|---|---|---|---|---|
| `06b11a54` | `dbf4a34e` | running, today | 44 models | 绿 + `default` |
| `bc24b612` | `b5c5ea91` | idle, yesterday | **0** | 连接中 |

## Fix

Cache the catalog once per worktree (`config/model_catalog.rs`), record it from both
attach paths and the explicit probe, and fill any `RuntimeInfo` that would otherwise
go out empty — live handles and historical rows alike.

- Persisted, because `publish_all_agent_states` runs *before* anything attaches; an
  in-memory-only cache would still be empty at exactly the moment it is needed.
- An empty probe result is never recorded, so a failed probe cannot erase a good
  catalog and reintroduce the bug.
- A live attach's own catalog always wins; the cache only fills a gap.
- Unknown worktree falls back to any known catalog — one serve with one set of
  provider credentials backs every worktree on the device, so some catalog beats none.

A stale entry is safe: this list only populates a picker, and `set_model` still
validates against the live serve.

## Verification

- 5 new unit tests (fill / don't-overwrite / cross-worktree fallback / empty-probe
  guard / persistence round-trip). Full daemon suite: **871 passed, 0 failed**.
- `cargo clippy -p amuxd` clean.
- **Live**: rebuilt amuxd, restarted it against the running desktop, then read the
  webview's runtime store over tauri-mcp — all **124/124** of this device's retained
  runtimes now advertise the catalog (68–71 models), up from 1.

## Not addressed

The identity problem underneath: one runtime id is minted per attach
(`manager.rs:528`, `Uuid::new_v4()[..8]`) for a process that has been global since the
opencode HTTP cutover. That is what makes retains grow without bound (339
`agent_runtimes` rows for one device) and forces three client-side resolvers to guess
which id belongs to the session in front of you. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
