### PR TITLE
fix(mqtt): take the broker address from the Cloud API instead of the bundle

### DIFF
--- a/apps/expo/README.md
+++ b/apps/expo/README.md
@@ -67,12 +67,18 @@ Create `apps/expo/.env` from `.env.example` and provide:
 
 - `EXPO_PUBLIC_SUPABASE_URL`
 - `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
-- `EXPO_PUBLIC_MQTT_URL` only when overriding the default native broker
+- `EXPO_PUBLIC_MQTT_URL` only when pinning a broker for local development
 
 These values are required for the Expo app to start correctly. If either one is
 missing, the current app bootstrap fails instead of falling back to a limited
-onboarding shell. MQTT defaults to `mqtts://ai.ucar.cc:8883` and uses the
-native Android bridge when available.
+onboarding shell.
+
+The MQTT broker address is **not** bundled: `resolveMqttUrl` fetches it from
+`GET /v1/config/bootstrap` (server-side `MQTT_PUBLIC_TCP_BROKER_URL` /
+`MQTT_PUBLIC_BROKER_URL`) and caches it in AsyncStorage, so a broker that moves
+does not need an app release. `EXPO_PUBLIC_MQTT_URL` overrides the fetch; with
+neither an override nor a cached address the app simply does not connect. The
+native Android bridge is used when available.
 
 ## Install
 

--- a/apps/expo/app/(app)/(tabs)/sessions/[sessionId].tsx
+++ b/apps/expo/app/(app)/(tabs)/sessions/[sessionId].tsx
@@ -30,7 +30,7 @@ import { impactLight, selectionTick, successTone } from "../../../../src/lib/hap
 import { showToast } from "../../../../src/ui/Toast";
 import { supabase } from "../../../../src/lib/supabase/client";
 import { getDb } from "../../../../src/lib/db/sqlite";
-import { getOptionalMqttUrl } from "../../../../src/lib/mqtt/config";
+import { getKnownMqttUrl } from "../../../../src/lib/mqtt/config";
 import {
   createRuntimeCommandSender,
   resolvePermissionRuntimeTarget,
@@ -180,7 +180,7 @@ export default function SessionDetailRoute() {
         },
         getTeamActors: () => teamActorsRef.current,
         mqtt: mqttSnapshot ?? noOpMqtt,
-        mqttUrl: getOptionalMqttUrl(),
+        mqttUrl: getKnownMqttUrl(),
         outbox: { dao, sender },
         sessionId,
         teamId: currentTeam.id,

--- a/apps/expo/app/(app)/mqtt-debug.tsx
+++ b/apps/expo/app/(app)/mqtt-debug.tsx
@@ -12,7 +12,7 @@ import {
   type MqttDebugStatus,
 } from "../../src/features/debug/mqtt-debug-state";
 import type { ConnectionState } from "../../src/lib/mqtt/team-mqtt";
-import { getOptionalMqttUrl } from "../../src/lib/mqtt/config";
+import { getKnownMqttUrl } from "../../src/lib/mqtt/config";
 import { StatusDot, type StatusDotKind } from "../../src/ui/atoms/StatusDot";
 import { PrimaryButton } from "../../src/ui/button";
 import { AppCard } from "../../src/ui/card";
@@ -57,7 +57,7 @@ export default function MqttDebugRoute() {
   const router = useRouter();
   const { retryBootstrap, state } = useOnboarding();
   const mqtt = useTeamMqtt();
-  const mqttUrl = getOptionalMqttUrl();
+  const mqttUrl = getKnownMqttUrl();
   const [observedState, setObservedState] = useState<ConnectionState | null>(null);
   const [lastEventAt, setLastEventAt] = useState<Date | null>(null);
   const href = routeToHref(state.route);

--- a/apps/expo/app/_layout.tsx
+++ b/apps/expo/app/_layout.tsx
@@ -36,7 +36,7 @@ import { supabase } from "../src/lib/supabase/client";
 import { colors } from "../src/ui/theme";
 import { appStatusBarProps } from "../src/ui/status-bar";
 import { createTeamMqttClient, type TeamMqttClient } from "../src/lib/mqtt/team-mqtt";
-import { getOptionalMqttUrl } from "../src/lib/mqtt/config";
+import { resolveMqttUrl } from "../src/lib/mqtt/config";
 import { createAgentAccessApi } from "../src/features/actors/agent-access-api";
 import { createRuntimeStateSubscriber } from "../src/features/actors/runtime-state-subscriber";
 import {
@@ -303,15 +303,19 @@ function OnboardingProvider({ children }: { children: ReactNode }) {
     if (state.route !== "ready") return;
     if (!state.currentTeam || !state.currentMemberActorId) return;
 
-    const mqttUrl = getOptionalMqttUrl();
-    if (!mqttUrl) return;
-
     let disposed = false;
 
     void (async () => {
       const { data: sessionData } = await supabase.auth.getSession();
       const accessToken = sessionData?.session?.access_token ?? null;
       if (!accessToken || disposed) return;
+
+      // Broker address comes from the Cloud API (cached across launches), so a
+      // moved broker doesn't need an app release. No address → don't connect.
+      const mqttUrl = await resolveMqttUrl({
+        getAccessToken: supabaseAccessToken(supabase),
+      });
+      if (!mqttUrl || disposed) return;
 
       const mqtt = createTeamMqttClient({
         url: mqttUrl,

--- a/apps/expo/src/lib/mqtt/config.ts
+++ b/apps/expo/src/lib/mqtt/config.ts
@@ -1,6 +1,82 @@
-const DEFAULT_NATIVE_MQTT_URL = "mqtts://ai.ucar.cc:8883";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { cloudApiBaseUrl, createCloudApiClient } from "../cloud-api/client";
 
-export function getOptionalMqttUrl(): string | null {
+// The broker address is env-driven server-side and delivered by
+// `GET /v1/config/bootstrap`, not baked into the bundle: a broker that moves
+// must not require an app release. The last address is cached so a cold or
+// offline launch can still connect.
+
+const CACHE_KEY = "teamclaw.mqtt.broker-url";
+
+type StorageLike = Pick<typeof AsyncStorage, "getItem" | "setItem" | "removeItem">;
+
+type BootstrapConfig = {
+  mqtt?: { url?: string; tcpUrl?: string } | null;
+};
+
+let lastResolvedUrl: string | null = null;
+
+/** An explicit build-time override always wins (local dev against a test broker). */
+export function getMqttUrlOverride(): string | null {
   const url = process.env.EXPO_PUBLIC_MQTT_URL?.trim();
-  return url && url.length > 0 ? url : DEFAULT_NATIVE_MQTT_URL;
+  return url && url.length > 0 ? url : null;
+}
+
+/**
+ * The address most recently resolved in this process, for UI and controllers
+ * that need it synchronously. Null until the first `resolveMqttUrl` — which the
+ * root layout runs before it connects, so screens downstream of a live
+ * connection always see an address.
+ */
+export function getKnownMqttUrl(): string | null {
+  return getMqttUrlOverride() ?? lastResolvedUrl;
+}
+
+/** Last broker address handed out by the Cloud API, or null if never fetched. */
+export async function getCachedMqttUrl(
+  storage: StorageLike = AsyncStorage,
+): Promise<string | null> {
+  const cached = (await storage.getItem(CACHE_KEY))?.trim();
+  return cached && cached.length > 0 ? cached : null;
+}
+
+/**
+ * Resolve the broker address: build-time override → Cloud API → cached address
+ * from the last successful fetch. Returns null when none of the three yields an
+ * address, in which case the caller simply does not connect — there is no
+ * bundled host to fall back on, because an address baked into a release
+ * outlives the server it points at.
+ */
+export async function resolveMqttUrl(args: {
+  getAccessToken: () => Promise<string | null>;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  storage?: StorageLike;
+}): Promise<string | null> {
+  const override = getMqttUrlOverride();
+  if (override) return override;
+
+  const storage = args.storage ?? AsyncStorage;
+  try {
+    const client = createCloudApiClient({
+      baseUrl: args.baseUrl ?? cloudApiBaseUrl(),
+      getAccessToken: args.getAccessToken,
+      fetchImpl: args.fetchImpl,
+    });
+    const config = await client.get<BootstrapConfig>("/v1/config/bootstrap");
+    // `tcpUrl` first: the native MQTT client dials the raw broker, while `url`
+    // may be the WebSocket address meant for browsers.
+    const url = (config.mqtt?.tcpUrl ?? config.mqtt?.url)?.trim();
+    if (url) {
+      await storage.setItem(CACHE_KEY, url);
+      lastResolvedUrl = url;
+      return url;
+    }
+  } catch {
+    // Offline, unauthenticated, or the endpoint is unavailable — fall through
+    // to whatever the last successful fetch cached.
+  }
+  const cached = await getCachedMqttUrl(storage);
+  if (cached) lastResolvedUrl = cached;
+  return cached;
 }

--- a/apps/expo/src/test/expo-mqtt.test.ts
+++ b/apps/expo/src/test/expo-mqtt.test.ts
@@ -99,7 +99,7 @@ describe("createExpoMqttAdapter", () => {
     adapter.onMessage((message) => messages.push(message));
 
     await adapter.connect({
-      url: "mqtts://ai.ucar.cc:8883",
+      url: "mqtts://broker.example.com:8883",
       options: {
         clientId: "client-1",
         username: "actor-1",
@@ -119,7 +119,7 @@ describe("createExpoMqttAdapter", () => {
     await adapter.disconnect();
 
     expect(nativeModule.connect).toHaveBeenCalledWith({
-      host: "ai.ucar.cc",
+      host: "broker.example.com",
       port: 8883,
       useTls: true,
       username: "actor-1",

--- a/apps/expo/src/test/mqtt-config.test.ts
+++ b/apps/expo/src/test/mqtt-config.test.ts
@@ -1,17 +1,86 @@
 import { describe, expect, it, vi } from "vitest";
 
-describe("getOptionalMqttUrl", () => {
-  it("defaults to the native TeamClaw broker when no env override exists", async () => {
-    vi.stubEnv("EXPO_PUBLIC_MQTT_URL", "");
-    const { getOptionalMqttUrl } = await import("../lib/mqtt/config");
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: { getItem: async () => null, setItem: async () => {}, removeItem: async () => {} },
+}));
 
-    expect(getOptionalMqttUrl()).toBe("mqtts://ai.ucar.cc:8883");
-  });
+function memoryStorage(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    items: store,
+    getItem: async (k: string) => store.get(k) ?? null,
+    setItem: async (k: string, v: string) => void store.set(k, v),
+    removeItem: async (k: string) => void store.delete(k),
+  };
+}
 
+function jsonFetch(body: unknown, status = 200): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+const auth = { getAccessToken: async () => "test-token" };
+
+describe("resolveMqttUrl", () => {
   it("uses the Expo MQTT env override when present", async () => {
     vi.stubEnv("EXPO_PUBLIC_MQTT_URL", " mqtts://broker.example.com:8883 ");
-    const { getOptionalMqttUrl } = await import("../lib/mqtt/config");
+    const { resolveMqttUrl } = await import("../lib/mqtt/config");
 
-    expect(getOptionalMqttUrl()).toBe("mqtts://broker.example.com:8883");
+    const url = await resolveMqttUrl({ ...auth, baseUrl: "https://fc.example.com" });
+    expect(url).toBe("mqtts://broker.example.com:8883");
+  });
+
+  it("prefers the Cloud API tcpUrl over the WebSocket url and caches it", async () => {
+    vi.stubEnv("EXPO_PUBLIC_MQTT_URL", "");
+    const { resolveMqttUrl } = await import("../lib/mqtt/config");
+    const storage = memoryStorage();
+
+    const url = await resolveMqttUrl({
+      ...auth,
+      baseUrl: "https://fc.example.com",
+      fetchImpl: jsonFetch({
+        mqtt: { url: "wss://mqtt.example.com/mqtt", tcpUrl: "mqtts://mqtt.example.com:8883" },
+      }),
+      storage,
+    });
+
+    expect(url).toBe("mqtts://mqtt.example.com:8883");
+    expect(storage.items.get("teamclaw.mqtt.broker-url")).toBe("mqtts://mqtt.example.com:8883");
+  });
+
+  it("falls back to the cached address when the Cloud API is unreachable", async () => {
+    vi.stubEnv("EXPO_PUBLIC_MQTT_URL", "");
+    const { resolveMqttUrl } = await import("../lib/mqtt/config");
+    const storage = memoryStorage({
+      "teamclaw.mqtt.broker-url": "mqtts://cached.example.com:8883",
+    });
+
+    const url = await resolveMqttUrl({
+      ...auth,
+      baseUrl: "https://fc.example.com",
+      fetchImpl: (async () => {
+        throw new Error("offline");
+      }) as unknown as typeof fetch,
+      storage,
+    });
+
+    expect(url).toBe("mqtts://cached.example.com:8883");
+  });
+
+  it("returns null when nothing has ever handed out an address", async () => {
+    vi.stubEnv("EXPO_PUBLIC_MQTT_URL", "");
+    const { resolveMqttUrl } = await import("../lib/mqtt/config");
+
+    const url = await resolveMqttUrl({
+      ...auth,
+      baseUrl: "https://fc.example.com",
+      fetchImpl: jsonFetch({ webSso: { loginUrl: "https://example.com" } }),
+      storage: memoryStorage(),
+    });
+
+    expect(url).toBeNull();
   });
 });

--- a/apps/ios/AMUXApp/ContentView.swift
+++ b/apps/ios/AMUXApp/ContentView.swift
@@ -80,6 +80,9 @@ struct ContentView: View {
             if let team = onboarding.currentContext?.team {
                 OnboardingLocalCacheBootstrapper.ensureWorkspaceExists(team: team, modelContext: modelContext)
             }
+            // Broker address before dial: it lives in Cloud API env, not the
+            // bundle, so a moved broker doesn't need an App Store release.
+            await refreshBrokerConfig()
             await connectMQTT()
         }
     }
@@ -225,6 +228,33 @@ struct ContentView: View {
             logger.info("MQTT trace recording enabled → \(url.path)")
         } catch {
             logger.error("Failed to start MQTT trace recorder: \(error)")
+        }
+    }
+
+    /// Pull the broker address from `GET /v1/config/bootstrap` and hand it to
+    /// the PairingManager (which caches it and ignores it when the user has
+    /// chosen their own server). Best-effort: on failure the cached address
+    /// from the last successful fetch is what `connectMQTT` dials.
+    private func refreshBrokerConfig() async {
+        guard let config = CloudAPIConfigurationStore.configuration() else { return }
+        // Resolve the bearer up front so the client's token closure captures a
+        // plain String rather than the non-Sendable coordinator.
+        let token: String
+        do {
+            token = try await onboarding.accessToken()
+        } catch {
+            logger.error("Failed to get access token for broker config: \(error)")
+            return
+        }
+        let client = CloudAPIClient(configuration: config, accessToken: { token })
+        do {
+            guard let endpoint = try await ServerBrokerConfig.fetch(client: client) else {
+                logger.warning("Cloud API returned no MQTT broker config")
+                return
+            }
+            pairing.applyServerBrokerConfig(endpoint)
+        } catch {
+            logger.error("Failed to fetch broker config: \(error)")
         }
     }
 

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/PairingManager.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/PairingManager.swift
@@ -11,18 +11,44 @@ public final class PairingManager {
     private var userOverride: Bool = false
 
     private let store: CredentialStore
+    private let brokerCache: BrokerConfigCache
 
-    public init(store: CredentialStore = UserDefaultsCredentialStore()) {
+    public init(
+        store: CredentialStore = UserDefaultsCredentialStore(),
+        brokerCache: BrokerConfigCache = UserDefaultsBrokerConfigCache()
+    ) {
         self.store = store
+        self.brokerCache = brokerCache
         // Honour a stored broker host ONLY when the user explicitly set it.
-        // Otherwise always (re-)apply the bundled default, so a changed default
-        // propagates across app updates instead of being shadowed by a host an
-        // older build auto-persisted.
+        // Otherwise (re-)apply the address the Cloud API last handed out, so a
+        // moved broker propagates instead of being shadowed by a host an older
+        // build auto-persisted.
         if let c = try? store.load(), c.userOverride {
             apply(c)
         } else {
             applyDefaults()
         }
+    }
+
+    /// Adopt the broker address the Cloud API just handed out. A user-chosen
+    /// server (Settings / pairing deeplink) always wins, but the address is
+    /// still cached so it takes over if the user later clears their override.
+    public func applyServerBrokerConfig(_ endpoint: MQTTEndpoint) {
+        brokerCache.save(endpoint)
+        guard !userOverride else { return }
+        guard endpoint.host != brokerHost
+            || endpoint.port != brokerPort
+            || endpoint.useTLS != useTLS
+        else { return }
+        let credentials = PairingCredentials(
+            brokerHost: endpoint.host,
+            brokerPort: endpoint.port,
+            useTLS: endpoint.useTLS,
+            authToken: authToken,
+            userOverride: false
+        )
+        try? store.save(credentials)
+        apply(credentials)
     }
 
     /// Legacy MQTT pairing deeplink flow. iOS no longer invokes this — use
@@ -54,12 +80,16 @@ public final class PairingManager {
         try store.clear()
     }
 
+    /// No user override: fall back to the cached Cloud API address. When there
+    /// is none (first launch, or a deployment with no broker configured) the
+    /// manager stays unpaired rather than dialling a bundled host — an address
+    /// baked into the binary outlives the server it points at.
     private func applyDefaults() {
-        let services = SharedDefaults.services
+        let cached = brokerCache.load()
         let defaults = PairingCredentials(
-            brokerHost: services.mqttHost,
-            brokerPort: services.mqttPort,
-            useTLS: services.mqttUseTls,
+            brokerHost: cached?.host ?? "",
+            brokerPort: cached?.port ?? SharedDefaults.services.mqttPort,
+            useTLS: cached?.useTLS ?? SharedDefaults.services.mqttUseTls,
             authToken: authToken,
             userOverride: false
         )

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/Resources/services.default.json
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/Resources/services.default.json
@@ -1,6 +1,5 @@
 {
   "cloudApiUrl": "https://teamclaw-api.ucar.cc",
-  "mqttHost": "transport.service.ucar.cc",
   "mqttPort": 1883,
   "mqttUseTls": false
 }

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/ServerBrokerConfig.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/ServerBrokerConfig.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// A resolved MQTT broker address: what `MQTTService.connect` needs.
+public struct MQTTEndpoint: Equatable, Sendable, Codable {
+    public var host: String
+    public var port: Int
+    public var useTLS: Bool
+
+    public init(host: String, port: Int, useTLS: Bool) {
+        self.host = host
+        self.port = port
+        self.useTLS = useTLS
+    }
+
+    /// Parse a broker address from the Cloud API. Accepts a scheme-qualified URL
+    /// (`mqtts://host:8883`, `mqtt://host:1883`, `wss://host/mqtt`) or a bare
+    /// `host:port`. `defaultUseTLS` decides TLS only when the string carries no
+    /// scheme to decide it.
+    public static func parse(_ raw: String, defaultUseTLS: Bool = false) -> MQTTEndpoint? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        var rest = trimmed
+        var useTLS = defaultUseTLS
+        var sawScheme = false
+        if let separator = trimmed.range(of: "://") {
+            let scheme = trimmed[trimmed.startIndex..<separator.lowerBound].lowercased()
+            rest = String(trimmed[separator.upperBound...])
+            sawScheme = true
+            switch scheme {
+            case "mqtts", "ssl", "tls", "wss", "https": useTLS = true
+            case "mqtt", "tcp", "ws", "http": useTLS = false
+            default: return nil
+            }
+        }
+
+        // Drop any path/query (`wss://host/mqtt`) — CocoaMQTT dials host:port.
+        if let slash = rest.firstIndex(of: "/") { rest = String(rest[rest.startIndex..<slash]) }
+        guard !rest.isEmpty else { return nil }
+
+        let parts = rest.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        let host = String(parts[0])
+        guard !host.isEmpty else { return nil }
+
+        if parts.count > 1, let port = Int(parts[1]), port > 0, port <= 65535 {
+            return MQTTEndpoint(host: host, port: port, useTLS: useTLS)
+        }
+        // No explicit port. A scheme-qualified URL implies the standard MQTT
+        // port for its transport; a bare host falls back to the bundled default.
+        let port = sawScheme ? (useTLS ? 8883 : 1883) : SharedDefaults.services.mqttPort
+        return MQTTEndpoint(host: host, port: port, useTLS: useTLS)
+    }
+}
+
+/// `GET /v1/config/bootstrap` response (the subset iOS consumes). The broker
+/// address is env-driven server-side, which is why it is fetched rather than
+/// bundled — a moved broker must not require an App Store release.
+struct BootstrapConfigResponse: Decodable, Sendable {
+    struct MQTTBlock: Decodable, Sendable {
+        let url: String?
+        let tcpUrl: String?
+        let useTls: Bool?
+    }
+
+    let mqtt: MQTTBlock?
+}
+
+/// Last broker address handed out by the Cloud API, kept on disk so a cold
+/// launch (or an offline one) can connect before `/v1/config/bootstrap` answers.
+public protocol BrokerConfigCache: AnyObject, Sendable {
+    func save(_ endpoint: MQTTEndpoint)
+    func load() -> MQTTEndpoint?
+    func clear()
+}
+
+// @unchecked Sendable is safe: UserDefaults is documented as thread-safe.
+public final class UserDefaultsBrokerConfigCache: BrokerConfigCache, @unchecked Sendable {
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func save(_ endpoint: MQTTEndpoint) {
+        defaults.set(endpoint.host, forKey: Keys.host)
+        defaults.set(endpoint.port, forKey: Keys.port)
+        defaults.set(endpoint.useTLS, forKey: Keys.useTLS)
+    }
+
+    public func load() -> MQTTEndpoint? {
+        guard let host = defaults.string(forKey: Keys.host), !host.isEmpty else { return nil }
+        let port = defaults.object(forKey: Keys.port) != nil
+            ? defaults.integer(forKey: Keys.port)
+            : SharedDefaults.services.mqttPort
+        return MQTTEndpoint(
+            host: host,
+            port: port > 0 ? port : SharedDefaults.services.mqttPort,
+            useTLS: defaults.bool(forKey: Keys.useTLS)
+        )
+    }
+
+    public func clear() {
+        for key in Keys.all { defaults.removeObject(forKey: key) }
+    }
+
+    private enum Keys {
+        static let host = "teamclaw_server_broker_host"
+        static let port = "teamclaw_server_broker_port"
+        static let useTLS = "teamclaw_server_broker_use_tls"
+        static let all = [host, port, useTLS]
+    }
+}
+
+public enum ServerBrokerConfig {
+    /// Fetch the broker address from the Cloud API. Returns nil when the server
+    /// ships no MQTT block (broker not configured for that deployment).
+    ///
+    /// `tcpUrl` wins over `url`: CocoaMQTT speaks raw MQTT, while `url` may be
+    /// the WebSocket address meant for browser clients.
+    public static func fetch(client: CloudAPIClient) async throws -> MQTTEndpoint? {
+        let config: BootstrapConfigResponse = try await client.get("/v1/config/bootstrap")
+        guard let mqtt = config.mqtt else { return nil }
+        let raw = mqtt.tcpUrl ?? mqtt.url
+        guard let raw else { return nil }
+        return MQTTEndpoint.parse(raw, defaultUseTLS: mqtt.useTls ?? false)
+    }
+}

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/SharedDefaults.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/SharedDefaults.swift
@@ -1,8 +1,12 @@
 import Foundation
 
+/// Values baked into the app bundle. Deliberately holds NO broker host: the
+/// broker address comes from the Cloud API (`GET /v1/config/bootstrap`, see
+/// `ServerBrokerConfig`) and is cached on device, so moving the broker does not
+/// need an App Store release. Only the transport fallbacks stay here, for
+/// parsing an address that omits a port or scheme.
 public struct ServicesDefaults: Codable, Sendable {
     public let cloudApiUrl: String?
-    public let mqttHost: String
     public let mqttPort: Int
     public let mqttUseTls: Bool
 }

--- a/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/PairingManagerTests.swift
+++ b/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/PairingManagerTests.swift
@@ -14,6 +14,23 @@ struct PairingManagerTests {
         func clear() throws { saved = nil }
     }
 
+    // Keeps the server-handed broker address out of the shared UserDefaults so
+    // tests don't leak state into each other (or into the simulator).
+    final class InMemoryBrokerCache: BrokerConfigCache, @unchecked Sendable {
+        var endpoint: MQTTEndpoint?
+        init(_ endpoint: MQTTEndpoint? = nil) { self.endpoint = endpoint }
+        func save(_ endpoint: MQTTEndpoint) { self.endpoint = endpoint }
+        func load() -> MQTTEndpoint? { endpoint }
+        func clear() { endpoint = nil }
+    }
+
+    private func makeManager(
+        store: CredentialStore,
+        cache: BrokerConfigCache = InMemoryBrokerCache()
+    ) -> PairingManager {
+        PairingManager(store: store, brokerCache: cache)
+    }
+
     @Test("pairs from a valid teamclaw:// URL with mqtts broker")
     func pairsFromValidURL() throws {
         let store = InMemoryStore()
@@ -97,18 +114,70 @@ struct PairingManagerTests {
         #expect(manager.authToken == "t")
     }
 
-    @Test("ignores an auto-applied stored host and re-applies the bundled default")
+    @Test("ignores an auto-applied stored host and re-applies the cached server address")
     func ignoresStaleAutoDefaultOnInit() throws {
         let store = InMemoryStore()
         // Host persisted by an older build (no user override) must NOT win over
-        // the current bundled default.
+        // the address the Cloud API last handed out.
         store.saved = PairingCredentials(
             brokerHost: "stale.example.com", brokerPort: 1883, useTLS: false,
             authToken: "", userOverride: false
         )
-        let manager = PairingManager(store: store)
-        #expect(manager.brokerHost == SharedDefaults.services.mqttHost)
-        #expect(manager.brokerHost != "stale.example.com")
+        let cache = InMemoryBrokerCache(
+            MQTTEndpoint(host: "broker.from-server", port: 8883, useTLS: true)
+        )
+        let manager = makeManager(store: store, cache: cache)
+        #expect(manager.brokerHost == "broker.from-server")
+        #expect(manager.brokerPort == 8883)
+        #expect(manager.useTLS)
+    }
+
+    @Test("stays unpaired when nothing has been handed out yet")
+    func staysUnpairedWithoutServerConfig() throws {
+        let store = InMemoryStore()
+        store.saved = PairingCredentials(
+            brokerHost: "stale.example.com", brokerPort: 1883, useTLS: false,
+            authToken: "", userOverride: false
+        )
+        let manager = makeManager(store: store)
+        // No bundled host to fall back on — a baked-in address outlives the
+        // server it points at, which is exactly the bug this replaces.
+        #expect(manager.brokerHost == "")
+        #expect(!manager.isPaired)
+    }
+
+    @Test("adopts the server broker address and caches it")
+    func adoptsServerBrokerConfig() throws {
+        let store = InMemoryStore()
+        let cache = InMemoryBrokerCache()
+        let manager = makeManager(store: store, cache: cache)
+
+        manager.applyServerBrokerConfig(
+            MQTTEndpoint(host: "broker.example.com", port: 8883, useTLS: true)
+        )
+
+        #expect(manager.brokerHost == "broker.example.com")
+        #expect(manager.brokerPort == 8883)
+        #expect(manager.useTLS)
+        #expect(manager.isPaired)
+        #expect(cache.endpoint?.host == "broker.example.com")
+        #expect(store.saved?.userOverride == false)
+    }
+
+    @Test("a user-chosen server survives a server broker address")
+    func userOverrideBeatsServerBrokerConfig() throws {
+        let store = InMemoryStore()
+        let cache = InMemoryBrokerCache()
+        let manager = makeManager(store: store, cache: cache)
+        try manager.updateMQTTServer(host: "my.own.broker")
+
+        manager.applyServerBrokerConfig(
+            MQTTEndpoint(host: "broker.example.com", port: 8883, useTLS: true)
+        )
+
+        #expect(manager.brokerHost == "my.own.broker")
+        // Still cached, so it takes over once the override is cleared.
+        #expect(cache.endpoint?.host == "broker.example.com")
     }
 
     @Test("unpair clears state and store")

--- a/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/ServerBrokerConfigTests.swift
+++ b/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/ServerBrokerConfigTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import Foundation
+@testable import AMUXCore
+
+@Suite("ServerBrokerConfig")
+struct ServerBrokerConfigTests {
+
+    @Test("parses a scheme-qualified TLS broker URL")
+    func parsesMqttsURL() {
+        let endpoint = MQTTEndpoint.parse("mqtts://broker.example.com:8883")
+        #expect(endpoint == MQTTEndpoint(host: "broker.example.com", port: 8883, useTLS: true))
+    }
+
+    @Test("parses a plaintext broker URL")
+    func parsesMqttURL() {
+        let endpoint = MQTTEndpoint.parse("mqtt://broker.example.com:1883")
+        #expect(endpoint == MQTTEndpoint(host: "broker.example.com", port: 1883, useTLS: false))
+    }
+
+    @Test("drops the path from a WebSocket URL")
+    func parsesWebSocketURL() {
+        let endpoint = MQTTEndpoint.parse("wss://mqtt.example.com/mqtt")
+        // No explicit port: the scheme implies the standard TLS MQTT port.
+        #expect(endpoint == MQTTEndpoint(host: "mqtt.example.com", port: 8883, useTLS: true))
+    }
+
+    @Test("a bare host:port keeps the caller's TLS default")
+    func parsesBareHostPort() {
+        let endpoint = MQTTEndpoint.parse("broker.example.com:1884", defaultUseTLS: true)
+        #expect(endpoint == MQTTEndpoint(host: "broker.example.com", port: 1884, useTLS: true))
+    }
+
+    @Test("rejects empty and unknown-scheme addresses")
+    func rejectsGarbage() {
+        #expect(MQTTEndpoint.parse("") == nil)
+        #expect(MQTTEndpoint.parse("   ") == nil)
+        #expect(MQTTEndpoint.parse("ftp://broker.example.com") == nil)
+        #expect(MQTTEndpoint.parse("mqtts://") == nil)
+    }
+
+    @Test("prefers tcpUrl over the WebSocket url")
+    func fetchPrefersTcpURL() async throws {
+        let client = makeClient(body: """
+        {"mqtt":{"url":"wss://mqtt.example.com/mqtt","tcpUrl":"mqtts://mqtt.example.com:8883"}}
+        """)
+        let endpoint = try await ServerBrokerConfig.fetch(client: client)
+        #expect(endpoint == MQTTEndpoint(host: "mqtt.example.com", port: 8883, useTLS: true))
+    }
+
+    @Test("falls back to url when no tcpUrl is offered")
+    func fetchFallsBackToURL() async throws {
+        let client = makeClient(body: """
+        {"mqtt":{"url":"mqtt://mqtt.example.com:1883"}}
+        """)
+        let endpoint = try await ServerBrokerConfig.fetch(client: client)
+        #expect(endpoint == MQTTEndpoint(host: "mqtt.example.com", port: 1883, useTLS: false))
+    }
+
+    @Test("returns nil when the deployment configures no broker")
+    func fetchWithoutMqttBlock() async throws {
+        let client = makeClient(body: #"{"webSso":{"loginUrl":"https://example.com"}}"#)
+        #expect(try await ServerBrokerConfig.fetch(client: client) == nil)
+    }
+
+    private func makeClient(body: String) -> CloudAPIClient {
+        CloudAPIClient(
+            configuration: CloudAPIConfiguration(baseURL: URL(string: "https://api.example.com")!),
+            accessToken: { "test-token" },
+            send: { request in
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+                )!
+                return (Data(body.utf8), response)
+            }
+        )
+    }
+}

--- a/apps/ios/Packages/AMUXUI/Sources/AMUXUI/Settings/SettingsView.swift
+++ b/apps/ios/Packages/AMUXUI/Sources/AMUXUI/Settings/SettingsView.swift
@@ -68,13 +68,15 @@ public struct SettingsView: View {
         CloudAPIConfigurationStore.storedCloudAPIURL() ?? "—"
     }
 
-    /// The MQTT broker host the app connects to (bundled default unless
-    /// overridden in Settings). Useful when diagnosing connection issues.
+    /// The MQTT broker host the app connects to — a Settings override, else the
+    /// address the Cloud API handed out at bootstrap. Useful when diagnosing
+    /// connection issues. Nothing is bundled, so "—" means bootstrap has not
+    /// answered yet on this device.
     private var mqttBrokerAddress: String {
         let host = UserDefaults.standard.string(forKey: "teamclaw_broker_host")?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if let host, !host.isEmpty { return host }
-        return SharedDefaults.services.mqttHost ?? "—"
+        return UserDefaultsBrokerConfigCache().load()?.host ?? "—"
     }
 
     private var currentActor: CachedActor? {


### PR DESCRIPTION
## Why

Two dead broker hosts were baked into shipped bundles:

- iOS — `transport.service.ucar.cc` in `AMUXCore/Resources/services.default.json`
- Expo — `mqtts://ai.ucar.cc:8883` in `src/lib/mqtt/config.ts`

An address compiled into a release outlives the server it points at, and moving a broker should not require an App Store submission.

FC already publishes the address at `GET /v1/config/bootstrap`, built from `MQTT_PUBLIC_TCP_BROKER_URL` / `MQTT_PUBLIC_BROKER_URL` (`services/fc/src/lib/routes/config.ts`). Both clients now fetch it there and cache it on device.

`tcpUrl` is preferred over `url`: CocoaMQTT and the RN native bridge dial the raw broker, while `url` may be the WebSocket address meant for browsers.

## iOS

- **`ServerBrokerConfig.swift`** (new) — `MQTTEndpoint.parse` handles `mqtts://`, `mqtt://`, `wss://host/mqtt`, and bare `host:port`; `ServerBrokerConfig.fetch` calls the endpoint; `UserDefaultsBrokerConfigCache` persists the result.
- **`services.default.json`** — `mqttHost` removed. Only `mqttPort` / `mqttUseTls` remain, as fallbacks for parsing an address that omits a port or scheme.
- **`PairingManager`** — with no user override it reads the cache; `applyServerBrokerConfig` adopts a freshly fetched address (a Settings-chosen server still wins, and the server address is cached so it takes over if the override is cleared). With nothing cached it stays **unpaired** rather than dialling a bundled host.
- **`ContentView`** — refreshes the address before `connectMQTT`; on failure the cached address is what gets dialled.
- **`SettingsView`** — the About row reads the cache.

## Expo

- **`resolveMqttUrl`** — `EXPO_PUBLIC_MQTT_URL` override → Cloud API → AsyncStorage cache → `null`, in which case the app simply does not connect.
- **`getKnownMqttUrl`** — sync accessor for `mqtt-debug.tsx` and `sessions/[sessionId].tsx`, which run after the root layout has resolved the address.
- `expo-mqtt.test.ts` fixtures moved off the dead host onto `broker.example.com`.
- README documents where the address comes from.

## Verification

- `swift build` + `swift test` — 20 passing (8 new: URL parsing, tcpUrl preference, no-broker case, cache fallback, user-override precedence)
- `pnpm ios:build` — **BUILD SUCCEEDED**
- `vitest` — 24 passing (4 new resolve cases)
- Expo `tsc --noEmit` — 14 errors, identical to the pre-change baseline (all pre-existing `ColorValue` errors in `(tabs)/_layout.tsx`)

## Not in scope

The desktop app gets its broker address from the same server config already, so nothing is hardcoded there — but the value the server currently returns is still the dead host. Fixing that means updating `MQTT_PUBLIC_BROKER_URL` on the box, outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)