### PR TITLE
chore(ios): restore the Sign In with Apple / push entitlements

### DIFF
--- a/apps/ios/AMUX.xcodeproj/project.pbxproj
+++ b/apps/ios/AMUX.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		9E532B070FBC309D7EB883CE /* AMUXSessionMessageRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AMUXSessionMessageRegressionTests.swift; sourceTree = "<group>"; };
 		A57443CB6DA7A01B751BBA00 /* OnboardingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViews.swift; sourceTree = "<group>"; };
 		AA5C333674232A156EF5A6D1 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
+		AC8A7DFE566257A39578823C /* AMUX.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AMUX.entitlements; sourceTree = "<group>"; };
 		B26E4EC39A79E60BACC23B33 /* AMUXUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = AMUXUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C07BD2A492D93FDCCB10637D /* AMUXUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AMUXUITests.swift; sourceTree = "<group>"; };
 		E16412C0DABEF538623C6257 /* AMUXAuthUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AMUXAuthUITests.swift; sourceTree = "<group>"; };
@@ -108,6 +109,7 @@
 		DE118744A87DC657033FEE83 /* AMUXApp */ = {
 			isa = PBXGroup;
 			children = (
+				AC8A7DFE566257A39578823C /* AMUX.entitlements */,
 				499D508CBB7FB4FD1F584D9D /* AMUXApp.swift */,
 				537E64EAD78ACC7946325945 /* Analytics.swift */,
 				25D67C6EB2C2948CCFE684D1 /* Assets.xcassets */,
@@ -328,6 +330,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = AMUXApp/AMUX.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 43G5A6G9QV;
@@ -348,6 +351,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = AMUXApp/AMUX.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 43G5A6G9QV;

--- a/apps/ios/AMUXApp/AMUX.entitlements
+++ b/apps/ios/AMUXApp/AMUX.entitlements
@@ -5,6 +5,6 @@
 	<key>com.apple.developer.applesignin</key>
 	<array><string>Default</string></array>
 	<key>aps-environment</key>
-	<string>development</string>
+	<string>production</string>
 </dict>
 </plist>

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -36,10 +36,7 @@ targets:
     settings:
       base:
         INFOPLIST_FILE: AMUXApp/Info.plist
-        # CODE_SIGN_ENTITLEMENTS temporarily removed — see
-        # AMUXApp/AMUX.entitlements.disabled. Restore after enabling
-        # "Sign In with Apple" on the App ID and running
-        # `fastlane match appstore --force` to refresh the profile.
+        CODE_SIGN_ENTITLEMENTS: AMUXApp/AMUX.entitlements
         PRODUCT_BUNDLE_IDENTIFIER: tech.teamclaw.mobile
         DEVELOPMENT_TEAM: 43G5A6G9QV
         MARKETING_VERSION: "1.1.5"


### PR DESCRIPTION
## 改动

把 iOS 的 entitlements 从「临时停用」状态恢复回来：

- `apps/ios/AMUX.entitlements.disabled` → `apps/ios/AMUXApp/AMUX.entitlements`（回到真实文件名和位置）
- `project.yml` 里被注释掉的 `CODE_SIGN_ENTITLEMENTS` 重新接上
- `aps-environment` 从 `development` 改为 `production` —— TestFlight / App Store 构建签的是生产 APNs 环境

内容仍是原来那两项：`com.apple.developer.applesignin` + `aps-environment`。

`project.pbxproj` 是生成物，`xcodegen generate` 可以从 `project.yml` 逐字节复现当前这份，二者无漂移。全仓也没有别处仍引用旧的 `.disabled` 路径。

## ⚠️ 发布前提（合并 ≠ 可发版）

本 PR 删掉的那段注释写明了恢复条件：**App ID 上启用 "Sign In with Apple"，并跑 `fastlane match appstore --force` 刷新描述文件。**

`apps/ios/fastlane/Fastfile:8,26` 用的是 `match(type: "appstore", readonly: true)` —— CI **不会**自行重新生成 profile。若 match 仓库里那份描述文件尚未包含这两项 entitlement，打 `ios-v*` tag 触发 `testflight.yml` 会直接失败在签名/entitlements 不匹配上。

我无法从本地验证 match 仓库中 profile 的实际内容（需要仓库访问 + 解密密钥）。**合并前请先确认该前提已满足**，或先合并、但推迟打 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)