### PR TITLE
fix(expo): drop the cached MQTT broker on sign-out

### DIFF
--- a/apps/expo/src/features/onboarding/onboarding-store.ts
+++ b/apps/expo/src/features/onboarding/onboarding-store.ts
@@ -1,3 +1,4 @@
+import { clearCachedMqttUrl } from "../../lib/mqtt/config";
 import {
   initialOnboardingState,
   onboardingReducer,
@@ -262,6 +263,11 @@ export function createOnboardingController(api: OnboardingApi) {
   const signOut = async () => {
     const token = beginOperation();
     await api.signOut();
+    // The cached broker was fetched with the outgoing user's token and belongs
+    // to their deployment, so it must not survive into the next session. Web
+    // clears the same state from its own signOut, via
+    // clearBootstrapAppliedFields.
+    await clearCachedMqttUrl();
     dispatchIfCurrent(token, { type: "signedOut" });
   };
 

--- a/apps/expo/src/lib/mqtt/config.ts
+++ b/apps/expo/src/lib/mqtt/config.ts
@@ -41,6 +41,29 @@ export async function getCachedMqttUrl(
 }
 
 /**
+ * Forget the cached broker. Called on sign-out.
+ *
+ * The cache exists so a cold or offline launch can still connect, but it
+ * outlives the account it was fetched for. Sign out of one deployment and into
+ * another on the same device and the fallback would hand the new session the
+ * old deployment's broker — which it would then dial with the new user's token,
+ * failing in a way that looks like a broker outage rather than stale config.
+ *
+ * Best-effort: a storage error here must not block sign-out, and the in-process
+ * value is dropped either way, so the next resolve starts from the API.
+ */
+export async function clearCachedMqttUrl(
+  storage: StorageLike = AsyncStorage,
+): Promise<void> {
+  lastResolvedUrl = null;
+  try {
+    await storage.removeItem(CACHE_KEY);
+  } catch {
+    // Nothing actionable — the in-process value is already cleared.
+  }
+}
+
+/**
  * Resolve the broker address: build-time override → Cloud API → cached address
  * from the last successful fetch. Returns null when none of the three yields an
  * address, in which case the caller simply does not connect — there is no

--- a/apps/expo/src/test/mqtt-config.test.ts
+++ b/apps/expo/src/test/mqtt-config.test.ts
@@ -83,4 +83,71 @@ describe("resolveMqttUrl", () => {
 
     expect(url).toBeNull();
   });
+
+  it("clearCachedMqttUrl drops the stored address and the in-process one", async () => {
+    vi.stubEnv("EXPO_PUBLIC_MQTT_URL", "");
+    vi.resetModules();
+    const { resolveMqttUrl, clearCachedMqttUrl, getKnownMqttUrl, getCachedMqttUrl } =
+      await import("../lib/mqtt/config");
+    const storage = memoryStorage();
+
+    await resolveMqttUrl({
+      ...auth,
+      baseUrl: "https://fc.example.com",
+      fetchImpl: jsonFetch({ mqtt: { tcpUrl: "mqtts://mqtt.example.com:8883" } }),
+      storage,
+    });
+    expect(getKnownMqttUrl()).toBe("mqtts://mqtt.example.com:8883");
+
+    await clearCachedMqttUrl(storage);
+
+    expect(getKnownMqttUrl()).toBeNull();
+    expect(await getCachedMqttUrl(storage)).toBeNull();
+    expect(storage.items.has("teamclaw.mqtt.broker-url")).toBe(false);
+  });
+
+  // The whole point of clearing: the next account must not inherit the previous
+  // deployment's broker through the offline fallback.
+  it("stops a cleared address being used as the offline fallback", async () => {
+    vi.stubEnv("EXPO_PUBLIC_MQTT_URL", "");
+    vi.resetModules();
+    const { resolveMqttUrl, clearCachedMqttUrl } = await import("../lib/mqtt/config");
+    const storage = memoryStorage();
+
+    await resolveMqttUrl({
+      ...auth,
+      baseUrl: "https://fc.example.com",
+      fetchImpl: jsonFetch({ mqtt: { tcpUrl: "mqtts://deployment-a.example.com:8883" } }),
+      storage,
+    });
+    await clearCachedMqttUrl(storage);
+
+    const offline = (async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+    const url = await resolveMqttUrl({
+      ...auth,
+      baseUrl: "https://fc.example.com",
+      fetchImpl: offline,
+      storage,
+    });
+
+    expect(url).toBeNull();
+  });
+
+  it("clearCachedMqttUrl survives a storage that throws", async () => {
+    vi.stubEnv("EXPO_PUBLIC_MQTT_URL", "");
+    vi.resetModules();
+    const { clearCachedMqttUrl } = await import("../lib/mqtt/config");
+
+    await expect(
+      clearCachedMqttUrl({
+        getItem: async () => null,
+        setItem: async () => {},
+        removeItem: async () => {
+          throw new Error("storage unavailable");
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/expo/src/test/onboarding-store.test.ts
+++ b/apps/expo/src/test/onboarding-store.test.ts
@@ -4,6 +4,25 @@ import type {
   BootstrapResult,
   OnboardingState,
 } from "../features/onboarding/onboarding-types";
+
+// signOut clears the device-cached MQTT broker, which reaches AsyncStorage.
+// Backing the mock with a real map rather than no-ops lets the sign-out test
+// assert the entry is actually gone instead of that a function was called.
+const storageMock = vi.hoisted(() => {
+  const items = new Map<string, string>();
+  return {
+    items,
+    api: {
+      getItem: async (key: string) => items.get(key) ?? null,
+      setItem: async (key: string, value: string) => void items.set(key, value),
+      removeItem: async (key: string) => void items.delete(key),
+    },
+  };
+});
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: storageMock.api,
+}));
 type OnboardingApi = ReturnType<
   (typeof import("../lib/supabase/onboarding-api"))["createOnboardingApi"]
 >;
@@ -313,6 +332,30 @@ describe("createOnboardingController", () => {
       currentMemberActorId: null,
       isAnonymous: false,
     });
+  });
+
+  // The broker address is cached on the device so a cold or offline launch can
+  // still connect, which means it outlives the account it was fetched for.
+  // Without this, signing out of one deployment and into another on the same
+  // device hands the new session the old broker whenever the config fetch fails.
+  it("signOut drops the cached broker so the next account cannot inherit it", async () => {
+    storageMock.items.set("teamclaw.mqtt.broker-url", "mqtts://deployment-a.example.com:8883");
+
+    const { createOnboardingController } = await loadController();
+    const api = createApiMock({
+      getCurrentSession: vi.fn().mockResolvedValue({ user: { id: "user-1" } }),
+      loadBootstrap: vi.fn().mockResolvedValue({
+        isAnonymous: false,
+        team: { id: "team-1", name: "Team Claw", slug: "team-claw", role: "owner" },
+        memberActorId: "member-1",
+      } satisfies BootstrapResult),
+    });
+    const controller = createOnboardingController(api);
+    await controller.bootstrap();
+
+    await controller.signOut();
+
+    expect(storageMock.items.has("teamclaw.mqtt.broker-url")).toBe(false);
   });
 
   it("ignores a stale signOut completion after a newer requestOtp", async () => {


### PR DESCRIPTION
Follow-up to #620.

## The gap

#620 caches the resolved broker in AsyncStorage so a cold or offline launch can still connect — good. But nothing ever clears it, and the cache outlives the account it was fetched for.

Sign out of one deployment and into another on the same device, and `resolveMqttUrl`'s offline fallback hands the new session **the previous deployment's broker**, which it then dials with the new user's token. It fails looking like a broker outage rather than stale config, and the address was only ever correct for whoever fetched it.

Web has cleared the equivalent state from its own `signOut` since bootstrap existed — `clearBootstrapAppliedFields` in `packages/app/src/lib/bootstrap.ts`, for exactly this reason. The Expo path had no counterpart.

## The fix

`clearCachedMqttUrl` removes the stored key and the in-process value, called from the onboarding store's `signOut`. Best-effort: a storage failure must not block signing out, and the in-process value is dropped either way, so the next resolve starts from the API rather than a stale disk entry.

## On the test mock

Importing the config module into the onboarding store pulls AsyncStorage into that store's test environment, which broke 15 existing tests. `onboarding-store.test.ts` now mocks it, **backed by a real map rather than no-ops** — that is what lets the new test assert the entry is genuinely gone instead of that a function was called.

## Verification

- **Negative-tested**: removing the `clearCachedMqttUrl()` call turns the new test red; restoring it goes green again. A passing test proves nothing on its own here.
- Expo suite **340/340**.
- `tsc` reports the same **14 pre-existing errors** as `main`, in three files this change does not touch. (CI's `pnpm typecheck` only covers `@teamclaw/app`, so Expo's tsc is not gated — worth knowing, not fixed here.)

## Not covered

#620 also routed iOS through the same endpoint (`ServerBrokerConfig.swift`, `SharedDefaults.swift`). If iOS persists the broker the same way, it likely wants the same clear on sign-out — I have not read that path closely enough to claim it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)