### PR TITLE
fix(storage): unify official Dev/Prod namespace to ~/.teamclaw

### DIFF
--- a/apps/daemon/src/team_shared_env.rs
+++ b/apps/daemon/src/team_shared_env.rs
@@ -178,7 +178,7 @@ fn resolve_env_secret_with(
             return Some(secret);
         }
     }
-    teamclaw_runtime_env::env_catalog::resolve_team_env_secret(workspace_root, team_id)
+    teamclaw_runtime_env::env_catalog::resolve_team_env_secret(workspace_root, team_id, None)
 }
 
 /// Load decrypted team shared env for a workspace.

--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -121,6 +121,20 @@ fn main() {
     println!("cargo:rustc-env=APP_SHORT_NAME={}", short_name);
     println!("cargo:warning=Using APP_SHORT_NAME={}", short_name);
 
+    let is_official = short_name == "teamclaw" || short_name == "teamclawdev";
+    let teamclaw_dir = if is_official {
+        ".teamclaw".to_string()
+    } else {
+        format!(".{}", short_name)
+    };
+    let config_file_name = if is_official {
+        "teamclaw.json".to_string()
+    } else {
+        format!("{}.json", short_name)
+    };
+    println!("cargo:rustc-env=TEAMCLAW_DIR={}", teamclaw_dir);
+    println!("cargo:rustc-env=CONFIG_FILE_NAME={}", config_file_name);
+
     // Export updater config from build.config.json (comma-separated for runtime fallback)
     let updater_endpoints = resolve_updater_endpoints(&config);
     if !updater_endpoints.is_empty() {

--- a/apps/desktop/crates/teamclaw-introspect/src/capabilities.rs
+++ b/apps/desktop/crates/teamclaw-introspect/src/capabilities.rs
@@ -282,6 +282,7 @@ fn build_env_vars(workspace: &str) -> Result<Value, String> {
     let listings = teamclaw_runtime_env::env_catalog::load_agent_env_listings(
         std::path::Path::new(workspace),
         None,
+        None,
     );
     let safe: Vec<Value> = listings
         .into_iter()

--- a/apps/desktop/crates/teamclaw-introspect/src/env_vars.rs
+++ b/apps/desktop/crates/teamclaw-introspect/src/env_vars.rs
@@ -11,6 +11,7 @@ pub async fn handle(workspace: &str, api_port: u16, arguments: &Value) -> Result
             let listings = teamclaw_runtime_env::env_catalog::load_agent_env_listings(
                 std::path::Path::new(workspace),
                 None,
+                None,
             );
             let entries: Vec<Value> = listings
                 .into_iter()

--- a/apps/desktop/src/commands/cron/mod.rs
+++ b/apps/desktop/src/commands/cron/mod.rs
@@ -84,7 +84,7 @@ impl Default for CronScope {
 fn global_cron_root() -> Result<String, String> {
     let base = dirs::config_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join(crate::commands::APP_SHORT_NAME)
+        .join(crate::commands::home_storage_dir_name())
         .join("cron-global");
     std::fs::create_dir_all(&base).map_err(|e| format!("Failed to create global cron dir: {e}"))?;
     Ok(base.to_string_lossy().to_string())

--- a/apps/desktop/src/commands/diagnostics.rs
+++ b/apps/desktop/src/commands/diagnostics.rs
@@ -208,7 +208,11 @@ fn gather_team_env_diagnostics(workspace_path: &str, team_id: Option<&str>) -> T
         .unwrap_or(0);
 
     let secret_configured =
-        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(ws, team_id_trimmed.as_deref())
+        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(
+            ws,
+            team_id_trimmed.as_deref(),
+            None,
+        )
             .is_some();
 
     TeamEnvDiagnostics {

--- a/apps/desktop/src/commands/env_vars.rs
+++ b/apps/desktop/src/commands/env_vars.rs
@@ -9,7 +9,12 @@ const LEGACY_MIGRATION_MARKER_KEY: &str = "_localPersonalSecretsMigrationComplet
 /// Disk-based path for the legacy plaintext env blob written by older versions.
 /// Read-only now (kept as a one-time migration source); never written.
 fn env_blob_fallback_path() -> Option<std::path::PathBuf> {
-    dirs::home_dir().map(|h| h.join(concat!(".", env!("APP_SHORT_NAME"), "/env-blob.json")))
+    dirs::home_dir().map(|h| {
+        h.join(format!(
+            ".{}/env-blob.json",
+            super::home_storage_dir_name()
+        ))
+    })
 }
 
 /// Read the env blob from the disk fallback file.
@@ -444,6 +449,7 @@ pub async fn env_catalog_list(
     workspace_path: Option<String>,
 ) -> Result<teamclaw_runtime_env::env_catalog::EnvCatalog, String> {
     let workspace_path = resolve_workspace_path(workspace_path, &window, &registry)?;
+    super::storage_migration::migrate_workspace_storage_namespace(&workspace_path);
     // team_id is required for the `_team_secret.{team_id}` personal-blob secret
     // fallback: when `teamclaw.json` carries no inline `team.envSecret` (the
     // common case), passing None here leaves every team var undecryptable.
@@ -451,6 +457,7 @@ pub async fn env_catalog_list(
     Ok(teamclaw_runtime_env::env_catalog::load_env_catalog(
         Path::new(&workspace_path),
         team_id,
+        Some(super::APP_SHORT_NAME),
     ))
 }
 
@@ -524,8 +531,12 @@ pub async fn team_env_diagnostics(
         .unwrap_or(0);
 
     let secret_configured =
-        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(ws, team_id_trimmed.as_deref())
-            .is_some();
+        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(
+            ws,
+            team_id_trimmed.as_deref(),
+            Some(super::APP_SHORT_NAME),
+        )
+        .is_some();
 
     Ok(TeamEnvDiagnostics {
         team_id_present: team_id_trimmed.is_some(),
@@ -907,7 +918,10 @@ mod tests {
         let workspace_dir = tempdir().unwrap();
         let _home = HomeGuard::set(home_dir.path());
 
-        let legacy_blob_dir = home_dir.path().join(concat!(".", env!("APP_SHORT_NAME")));
+        let legacy_blob_dir = home_dir.path().join(format!(
+            ".{}",
+            teamclaw_runtime_env::OFFICIAL_STORAGE_DIR
+        ));
         std::fs::create_dir_all(&legacy_blob_dir).unwrap();
 
         let mut legacy_blob = serde_json::Map::new();

--- a/apps/desktop/src/commands/local_secret_store.rs
+++ b/apps/desktop/src/commands/local_secret_store.rs
@@ -39,7 +39,8 @@ impl SecretStorePaths {
     pub(crate) fn for_home_dir() -> Result<Self, String> {
         let home = dirs::home_dir().ok_or_else(|| "Home directory not found".to_string())?;
         Ok(Self::for_base_dir(
-            home.join(concat!(".", env!("APP_SHORT_NAME")))
+            home
+                .join(format!(".{}", super::home_storage_dir_name()))
                 .join("secrets"),
         ))
     }

--- a/apps/desktop/src/commands/mod.rs
+++ b/apps/desktop/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub mod setup;
 pub mod shared_secrets;
 pub mod shared_secrets_crypto;
 pub mod skillssh;
+pub mod storage_migration;
 pub mod stt;
 pub mod system_appearance;
 pub mod team;
@@ -50,15 +51,18 @@ pub mod workspace_files;
 use crate::process_util::CommandNoWindow;
 
 /// The short application name, injected at compile time via `build.rs`.
-#[allow(dead_code)]
 pub const APP_SHORT_NAME: &str = env!("APP_SHORT_NAME");
-/// Directory name for all TeamClaw local config/data files, created under the workspace root.
-pub const TEAMCLAW_DIR: &str = concat!(".", env!("APP_SHORT_NAME"));
+/// Workspace metadata directory (`.teamclaw` for official builds).
+pub const TEAMCLAW_DIR: &str = env!("TEAMCLAW_DIR");
 /// Subfolder inside workspace where the team repo is cloned / symlinked.
 /// Fixed across brands — must match the daemon's `TEAM_LINK_NAME` (`teamclaw-team`).
 pub const TEAM_REPO_DIR: &str = "teamclaw-team";
-/// Config file name (e.g. `teamclaw.json`).
-pub const CONFIG_FILE_NAME: &str = concat!(env!("APP_SHORT_NAME"), ".json");
+/// Workspace config file name (`teamclaw.json` for official builds).
+pub const CONFIG_FILE_NAME: &str = env!("CONFIG_FILE_NAME");
+/// Home-directory storage folder name without leading dot (`teamclaw` for official).
+pub fn home_storage_dir_name() -> &'static str {
+    teamclaw_runtime_env::resolve_storage_dir_name(APP_SHORT_NAME)
+}
 
 #[tauri::command]
 pub fn greet(name: &str) -> String {

--- a/apps/desktop/src/commands/shared_secrets.rs
+++ b/apps/desktop/src/commands/shared_secrets.rs
@@ -306,7 +306,10 @@ pub fn try_lazy_init_from_workspace(
     if !teamclaw_config_path(workspace).exists() {
         return Err("No team configured for this workspace".to_string());
     }
-    let env_secret = teamclaw_runtime_env::env_catalog::resolve_team_env_secret(workspace, team_id)
+    let env_secret =
+        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(workspace, team_id, Some(
+            super::APP_SHORT_NAME,
+        ))
         .ok_or_else(|| {
             "Team shared environment variables are not initialized for this workspace".to_string()
         })?;

--- a/apps/desktop/src/commands/storage_migration.rs
+++ b/apps/desktop/src/commands/storage_migration.rs
@@ -1,0 +1,225 @@
+//! One-shot migration: legacy official Dev paths (`teamclawdev`) → canonical `teamclaw`.
+//!
+//! White-label brands (`copilot361`, …) are untouched (Decision 2 = B).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use teamclaw_runtime_env::{
+    is_official_brand, LEGACY_OFFICIAL_DEV_CONFIG_FILE, LEGACY_OFFICIAL_DEV_STORAGE_DIR,
+    OFFICIAL_STORAGE_DIR, STORAGE_NAMESPACE_MIGRATION_MARKER, WORKSPACE_CONFIG_FILE,
+    WORKSPACE_META_DIR,
+};
+
+use super::APP_SHORT_NAME;
+
+fn home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}
+
+fn migration_marker_path(home: &Path) -> PathBuf {
+    home.join(format!(".{OFFICIAL_STORAGE_DIR}"))
+        .join("migrations")
+        .join(STORAGE_NAMESPACE_MIGRATION_MARKER)
+}
+
+fn merge_json_objects(
+    base: &mut serde_json::Map<String, serde_json::Value>,
+    overlay: serde_json::Map<String, serde_json::Value>,
+) {
+    for (key, value) in overlay {
+        match base.get_mut(&key) {
+            Some(existing) if existing.is_object() && value.is_object() => {
+                if let (Some(a), Some(b)) = (existing.as_object_mut(), value.as_object()) {
+                    merge_json_objects(a, b.clone());
+                }
+            }
+            Some(existing) if key == "envVars" && existing.is_array() && value.is_array() => {
+                let mut keys = std::collections::HashSet::new();
+                let mut merged = existing.as_array().cloned().unwrap_or_default();
+                for entry in &merged {
+                    if let Some(k) = entry.get("key").and_then(|v| v.as_str()) {
+                        keys.insert(k.to_string());
+                    }
+                }
+                for entry in value.as_array().into_iter().flatten() {
+                    if let Some(k) = entry.get("key").and_then(|v| v.as_str()) {
+                        if keys.insert(k.to_string()) {
+                            merged.push(entry.clone());
+                        }
+                    }
+                }
+                *existing = serde_json::Value::Array(merged);
+            }
+            None => {
+                base.insert(key, value);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn copy_file_if_newer(src: &Path, dst: &Path) -> Result<(), String> {
+    if !src.is_file() {
+        return Ok(());
+    }
+    if dst.exists() {
+        let src_meta = fs::metadata(src).map_err(|e| e.to_string())?;
+        let dst_meta = fs::metadata(dst).map_err(|e| e.to_string())?;
+        if let (Ok(sm), Ok(dm)) = (src_meta.modified(), dst_meta.modified()) {
+            if dm >= sm {
+                return Ok(());
+            }
+        }
+    }
+    if let Some(parent) = dst.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    fs::copy(src, dst).map_err(|e| format!("copy {} → {}: {e}", src.display(), dst.display()))?;
+    Ok(())
+}
+
+fn merge_tree(src: &Path, dst: &Path) -> Result<(), String> {
+    if !src.exists() {
+        return Ok(());
+    }
+    if src.is_file() {
+        return copy_file_if_newer(src, dst);
+    }
+    fs::create_dir_all(dst).map_err(|e| e.to_string())?;
+    for entry in fs::read_dir(src).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        merge_tree(&entry.path(), &dst.join(entry.file_name()))?;
+    }
+    Ok(())
+}
+
+fn migrate_home_storage(home: &Path) -> Result<(), String> {
+    let legacy = home.join(format!(".{LEGACY_OFFICIAL_DEV_STORAGE_DIR}"));
+    let canonical = home.join(format!(".{OFFICIAL_STORAGE_DIR}"));
+    if !legacy.exists() {
+        return Ok(());
+    }
+
+    merge_tree(&legacy.join("secrets"), &canonical.join("secrets"))?;
+    for name in ["local-cache.db", "cached-path.txt", "env-blob.json"] {
+        copy_file_if_newer(&legacy.join(name), &canonical.join(name))?;
+    }
+    Ok(())
+}
+
+fn migrate_workspace_meta(workspace: &Path) -> Result<(), String> {
+    let legacy_dir = workspace.join(format!(".{LEGACY_OFFICIAL_DEV_STORAGE_DIR}"));
+    let canonical_dir = workspace.join(WORKSPACE_META_DIR);
+    if !legacy_dir.exists() {
+        return Ok(());
+    }
+
+    fs::create_dir_all(&canonical_dir).map_err(|e| e.to_string())?;
+
+    let legacy_config = legacy_dir.join(LEGACY_OFFICIAL_DEV_CONFIG_FILE);
+    let canonical_config = canonical_dir.join(WORKSPACE_CONFIG_FILE);
+    if legacy_config.is_file() {
+        if canonical_config.is_file() {
+            let legacy_val: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&legacy_config).map_err(|e| e.to_string())?)
+                    .map_err(|e| e.to_string())?;
+            let mut base_val: serde_json::Value = fs::read_to_string(&canonical_config)
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or(serde_json::json!({}));
+            if let (Some(base), Some(overlay)) = (base_val.as_object_mut(), legacy_val.as_object()) {
+                merge_json_objects(base, overlay.clone());
+            }
+            fs::write(
+                &canonical_config,
+                serde_json::to_string_pretty(&base_val).map_err(|e| e.to_string())?,
+            )
+            .map_err(|e| e.to_string())?;
+        } else {
+            fs::copy(&legacy_config, &canonical_config).map_err(|e| e.to_string())?;
+        }
+    }
+
+    for name in [
+        "knowledge.db",
+        "rag-config.json",
+        "stats.json",
+        "cron-jobs.json",
+        "sessions.json",
+    ] {
+        copy_file_if_newer(&legacy_dir.join(name), &canonical_dir.join(name))?;
+    }
+    merge_tree(&legacy_dir.join("bm25_index"), &canonical_dir.join("bm25_index"))?;
+    merge_tree(&legacy_dir.join("cron-runs"), &canonical_dir.join("cron-runs"))?;
+    Ok(())
+}
+
+/// Migrate legacy official Dev storage into canonical `teamclaw` paths. Idempotent.
+pub fn migrate_official_storage_namespace() {
+    if !is_official_brand(APP_SHORT_NAME) {
+        return;
+    }
+    let Some(home) = home_dir() else {
+        return;
+    };
+    let marker = migration_marker_path(&home);
+    if marker.is_file() {
+        return;
+    }
+
+    if let Err(err) = migrate_home_storage(&home) {
+        eprintln!("[storage_migration] home migration failed: {err}");
+        return;
+    }
+
+    if let Err(err) = (|| {
+        fs::create_dir_all(marker.parent().ok_or_else(|| "marker parent missing".to_string())?)
+            .map_err(|e| e.to_string())?;
+        fs::write(&marker, chrono::Utc::now().to_rfc3339()).map_err(|e| e.to_string())
+    })() {
+        eprintln!("[storage_migration] failed to write marker: {err}");
+    }
+}
+
+/// Migrate a workspace directory when it is opened or registered.
+pub fn migrate_workspace_storage_namespace(workspace_path: &str) {
+    if !is_official_brand(APP_SHORT_NAME) {
+        return;
+    }
+    let workspace = Path::new(workspace_path);
+    if let Err(err) = migrate_workspace_meta(workspace) {
+        eprintln!(
+            "[storage_migration] workspace {} migration failed: {err}",
+            workspace.display()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_json_objects_unions_env_vars_by_key() {
+        let mut base = serde_json::json!({
+            "envVars": [{"key": "a", "description": "keep"}],
+            "locale": "en"
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let overlay = serde_json::json!({
+            "envVars": [{"key": "b", "description": "new"}],
+            "team": {"sharedDirName": "teamclaw"}
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        merge_json_objects(&mut base, overlay);
+        let env_vars = base.get("envVars").unwrap().as_array().unwrap();
+        assert_eq!(env_vars.len(), 2);
+        assert!(base.get("team").is_some());
+        assert_eq!(base.get("locale").unwrap(), "en");
+    }
+}

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -268,6 +268,7 @@ pub fn run() {
 
     // Fix PATH before anything else so all child processes can find tools
     fix_path_env();
+    commands::storage_migration::migrate_official_storage_namespace();
     eprintln!(
         "[Startup] fix_path_env: {:.1}ms",
         startup_t0.elapsed().as_secs_f64() * 1000.0

--- a/build.config.dev.json
+++ b/build.config.dev.json
@@ -5,7 +5,7 @@
   },
   "app": {
     "name": "TeamClaw Dev",
-    "shortName": "teamclawdev",
+    "shortName": "teamclaw",
     "palette": "default"
   },
   "features": {

--- a/crates/teamclaw-runtime-env/src/env_catalog.rs
+++ b/crates/teamclaw-runtime-env/src/env_catalog.rs
@@ -13,10 +13,9 @@ use tracing::warn;
 
 use crate::team_crypto::{self, EncryptedEnvelope};
 use crate::team_provider;
-
-const TEAMCLAW_DIR: &str = ".teamclaw";
-const CONFIG_FILE_NAME: &str = "teamclaw.json";
-const SECRETS_SUBDIR: &str = "_secrets";
+use crate::{
+    is_official_brand, WORKSPACE_CONFIG_FILE, WORKSPACE_META_DIR,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -73,17 +72,28 @@ pub struct AgentEnvListing {
     pub category: Option<String>,
 }
 
-fn teamclaw_config_path(workspace: &Path) -> PathBuf {
-    workspace.join(TEAMCLAW_DIR).join(CONFIG_FILE_NAME)
+const SECRETS_SUBDIR: &str = "_secrets";
+
+fn workspace_config_path(workspace: &Path, brand_short_name: &str) -> PathBuf {
+    if is_official_brand(brand_short_name) {
+        workspace.join(WORKSPACE_META_DIR).join(WORKSPACE_CONFIG_FILE)
+    } else {
+        workspace
+            .join(format!(".{brand_short_name}"))
+            .join(format!("{brand_short_name}.json"))
+    }
 }
 
-pub fn read_teamclaw_config(workspace: &Path) -> Option<serde_json::Value> {
-    let body = std::fs::read_to_string(teamclaw_config_path(workspace)).ok()?;
+fn read_teamclaw_config_for_brand(
+    workspace: &Path,
+    brand_short_name: &str,
+) -> Option<serde_json::Value> {
+    let body = std::fs::read_to_string(workspace_config_path(workspace, brand_short_name)).ok()?;
     serde_json::from_str(&body).ok()
 }
 
-fn read_team_json_env_secret(workspace: &Path) -> Option<String> {
-    read_teamclaw_config(workspace)?
+fn read_team_json_env_secret(workspace: &Path, brand_short_name: &str) -> Option<String> {
+    read_teamclaw_config_for_brand(workspace, brand_short_name)?
         .get("team")?
         .get("envSecret")?
         .as_str()
@@ -96,16 +106,22 @@ fn read_team_json_env_secret(workspace: &Path) -> Option<String> {
 pub fn resolve_team_env_secret(
     workspace: &Path,
     team_id: Option<&str>,
+    brand_short_name: Option<&str>,
 ) -> Option<String> {
-    if let Some(secret) = read_team_json_env_secret(workspace) {
+    let brand = brand_short_name.unwrap_or("teamclaw");
+    if let Some(secret) = read_team_json_env_secret(workspace, brand) {
         return Some(secret);
     }
     let team_id = team_id.filter(|id| !id.trim().is_empty())?;
     let blob_key = format!("_team_secret.{team_id}");
-    crate::personal_secrets::load_personal_env()
+    crate::personal_secrets::load_personal_env_for_brand(brand)
         .ok()
         .and_then(|env| env.get(&blob_key).cloned())
         .filter(|s| !s.trim().is_empty())
+}
+
+pub fn read_teamclaw_config(workspace: &Path) -> Option<serde_json::Value> {
+    read_teamclaw_config_for_brand(workspace, "teamclaw")
 }
 
 /// Team shared directory for writes: `{workspace}/{sharedDirName}`.
@@ -267,9 +283,13 @@ fn load_team_env_metas_from_dir(secrets_dir: &Path, env_secret: &str) -> Vec<Tea
 /// When the local team secret is missing or wrong, keys are still listed (from
 /// the file names) with `decrypted: false`. A decrypted listing always wins over
 /// an undecrypted one for the same key across candidate directories.
-pub fn load_team_env_listings(workspace: &Path, team_id: Option<&str>) -> Vec<TeamEnvListing> {
+pub fn load_team_env_listings(
+    workspace: &Path,
+    team_id: Option<&str>,
+    brand_short_name: Option<&str>,
+) -> Vec<TeamEnvListing> {
     let shared_dir_name = team_provider::resolve_shared_dir_name(workspace);
-    let env_secret = resolve_team_env_secret(workspace, team_id);
+    let env_secret = resolve_team_env_secret(workspace, team_id, brand_short_name);
 
     let mut out: Vec<TeamEnvListing> = Vec::new();
     let mut index: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
@@ -298,8 +318,12 @@ pub fn load_team_env_listings(workspace: &Path, team_id: Option<&str>) -> Vec<Te
     out
 }
 
-pub fn load_personal_env_listings(workspace: &Path) -> Vec<PersonalEnvListing> {
-    let Some(config) = read_teamclaw_config(workspace) else {
+pub fn load_personal_env_listings(
+    workspace: &Path,
+    brand_short_name: Option<&str>,
+) -> Vec<PersonalEnvListing> {
+    let brand = brand_short_name.unwrap_or("teamclaw");
+    let Some(config) = read_teamclaw_config_for_brand(workspace, brand) else {
         return Vec::new();
     };
     config
@@ -327,17 +351,25 @@ pub fn load_personal_env_listings(workspace: &Path) -> Vec<PersonalEnvListing> {
         .unwrap_or_default()
 }
 
-pub fn load_env_catalog(workspace: &Path, team_id: Option<&str>) -> EnvCatalog {
+pub fn load_env_catalog(
+    workspace: &Path,
+    team_id: Option<&str>,
+    brand_short_name: Option<&str>,
+) -> EnvCatalog {
     EnvCatalog {
-        personal: load_personal_env_listings(workspace),
-        team: load_team_env_listings(workspace, team_id),
+        personal: load_personal_env_listings(workspace, brand_short_name),
+        team: load_team_env_listings(workspace, team_id, brand_short_name),
     }
 }
 
 /// Personal `envVars` index merged with team keys — shape used by agent tools.
-pub fn load_agent_env_listings(workspace: &Path, team_id: Option<&str>) -> Vec<AgentEnvListing> {
-    let personal = load_personal_env_listings(workspace);
-    let team = load_team_env_listings(workspace, team_id);
+pub fn load_agent_env_listings(
+    workspace: &Path,
+    team_id: Option<&str>,
+    brand_short_name: Option<&str>,
+) -> Vec<AgentEnvListing> {
+    let personal = load_personal_env_listings(workspace, brand_short_name);
+    let team = load_team_env_listings(workspace, team_id, brand_short_name);
 
     let mut out: Vec<AgentEnvListing> = personal
         .into_iter()
@@ -427,7 +459,7 @@ mod tests {
         )
         .unwrap();
 
-        let team = load_team_env_listings(tmp.path(), None);
+        let team = load_team_env_listings(tmp.path(), None, None);
         assert_eq!(team.len(), 1);
         assert_eq!(team[0].key_id, "git_key");
         assert_eq!(team[0].description, "desc");
@@ -456,7 +488,7 @@ mod tests {
         )
         .unwrap();
 
-        let team = load_team_env_listings(tmp.path(), None);
+        let team = load_team_env_listings(tmp.path(), None, None);
         assert_eq!(team.len(), 1, "key must stay visible, not vanish");
         assert_eq!(team[0].key_id, "api_key");
         assert!(!team[0].decrypted, "wrong key → marked not decrypted");
@@ -483,7 +515,7 @@ mod tests {
         )
         .unwrap();
 
-        let team = load_team_env_listings(tmp.path(), None);
+        let team = load_team_env_listings(tmp.path(), None, None);
         assert_eq!(team.len(), 1);
         assert_eq!(team[0].key_id, "api_key");
         assert!(!team[0].decrypted);
@@ -518,7 +550,7 @@ mod tests {
         )
         .unwrap();
 
-        let listings = load_agent_env_listings(tmp.path(), None);
+        let listings = load_agent_env_listings(tmp.path(), None, None);
         let keys: Vec<_> = listings.iter().map(|entry| entry.key.as_str()).collect();
         assert!(keys.contains(&"tc_api_key"));
         assert!(keys.contains(&"mine"));
@@ -579,11 +611,11 @@ mod tests {
 
         // Without team_id the inline secret is missing → None (this was the bug:
         // the write/delete path passed None and hard-errored).
-        assert_eq!(resolve_team_env_secret(workspace.path(), None), None);
+        assert_eq!(resolve_team_env_secret(workspace.path(), None, None), None);
 
         // With team_id the personal-blob fallback resolves the secret.
         assert_eq!(
-            resolve_team_env_secret(workspace.path(), Some(team_id)).as_deref(),
+            resolve_team_env_secret(workspace.path(), Some(team_id), None).as_deref(),
             Some(env_secret.as_str())
         );
     }

--- a/crates/teamclaw-runtime-env/src/lib.rs
+++ b/crates/teamclaw-runtime-env/src/lib.rs
@@ -6,6 +6,7 @@ pub mod merge;
 pub mod opencode_config;
 pub mod opencode_db;
 pub mod personal_secrets;
+pub mod storage_namespace;
 pub mod team_crypto;
 pub mod team_provider;
 pub mod team_provider_sync;
@@ -26,7 +27,14 @@ pub use team_provider_sync::{
     sync_team_provider_on_disk, SecretResolveScope, TeamProviderSyncResult,
 };
 
-pub const APP_SECRETS_DIR: &str = "teamclaw";
+pub use storage_namespace::{
+    is_official_brand, resolve_storage_dir_name, LEGACY_OFFICIAL_DEV_CONFIG_FILE,
+    LEGACY_OFFICIAL_DEV_STORAGE_DIR, OFFICIAL_STORAGE_DIR, STORAGE_NAMESPACE_MIGRATION_MARKER,
+    WORKSPACE_CONFIG_FILE, WORKSPACE_META_DIR,
+};
+
+/// Same as [`OFFICIAL_STORAGE_DIR`] — kept for existing call sites.
+pub const APP_SECRETS_DIR: &str = OFFICIAL_STORAGE_DIR;
 pub const DEFAULT_TEAM_REPO_DIR: &str = "teamclaw-team";
 
 #[derive(Debug, Clone, Default)]

--- a/crates/teamclaw-runtime-env/src/personal_secrets.rs
+++ b/crates/teamclaw-runtime-env/src/personal_secrets.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use tracing::warn;
 
-use crate::APP_SECRETS_DIR;
+use crate::{resolve_storage_dir_name, OFFICIAL_STORAGE_DIR};
 
 #[derive(Debug, Clone)]
 struct SecretStorePaths {
@@ -23,10 +23,10 @@ struct EncryptedBlobFile {
 }
 
 impl SecretStorePaths {
-    fn for_home_dir() -> Option<Self> {
+    fn for_storage_dir(storage_dir: &str) -> Option<Self> {
         let home = dirs::home_dir()?;
         Some(Self::for_base_dir(
-            home.join(format!(".{}", APP_SECRETS_DIR)).join("secrets"),
+            home.join(format!(".{storage_dir}")).join("secrets"),
         ))
     }
 
@@ -78,14 +78,28 @@ fn string_env_from_map(map: serde_json::Map<String, serde_json::Value>) -> HashM
 }
 
 pub fn load_personal_env() -> anyhow::Result<HashMap<String, String>> {
-    let Some(paths) = SecretStorePaths::for_home_dir() else {
+    load_personal_env_for_storage_dir(OFFICIAL_STORAGE_DIR)
+}
+
+/// Load decrypted personal env vars for a build `brand_short_name` (`teamclaw`,
+/// `teamclawdev`, `copilot361`, …). Official brands resolve to `~/.teamclaw/secrets`.
+pub fn load_personal_env_for_brand(brand_short_name: &str) -> anyhow::Result<HashMap<String, String>> {
+    load_personal_env_for_storage_dir(resolve_storage_dir_name(brand_short_name))
+}
+
+fn load_personal_env_for_storage_dir(storage_dir: &str) -> anyhow::Result<HashMap<String, String>> {
+    let Some(paths) = SecretStorePaths::for_storage_dir(storage_dir) else {
         return Ok(HashMap::new());
     };
 
     match read_secret_blob(&paths) {
         Ok(map) => Ok(string_env_from_map(map)),
         Err(err) => {
-            warn!(error = %err, "Failed to read personal secrets; using empty env");
+            warn!(
+                storage_dir,
+                error = %err,
+                "Failed to read personal secrets; using empty env"
+            );
             Ok(HashMap::new())
         }
     }
@@ -140,7 +154,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let _home = HomeGuard::set(dir.path());
 
-        let secrets_dir = dir.path().join(format!(".{}", APP_SECRETS_DIR)).join("secrets");
+        let secrets_dir = dir
+            .path()
+            .join(format!(".{OFFICIAL_STORAGE_DIR}"))
+            .join("secrets");
         let paths = SecretStorePaths::for_base_dir(secrets_dir);
         let mut map = serde_json::Map::new();
         map.insert("my_key".into(), serde_json::Value::String("secret".into()));
@@ -156,7 +173,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let _home = HomeGuard::set(dir.path());
 
-        let secrets_dir = dir.path().join(format!(".{}", APP_SECRETS_DIR)).join("secrets");
+        let secrets_dir = dir
+            .path()
+            .join(format!(".{OFFICIAL_STORAGE_DIR}"))
+            .join("secrets");
         let paths = SecretStorePaths::for_base_dir(secrets_dir);
         let mut map = serde_json::Map::new();
         map.insert("str_key".into(), serde_json::Value::String("value".into()));
@@ -184,7 +204,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let _home = HomeGuard::set(dir.path());
 
-        let secrets_dir = dir.path().join(format!(".{}", APP_SECRETS_DIR)).join("secrets");
+        let secrets_dir = dir
+            .path()
+            .join(format!(".{OFFICIAL_STORAGE_DIR}"))
+            .join("secrets");
         std::fs::create_dir_all(&secrets_dir).unwrap();
         let paths = SecretStorePaths::for_base_dir(secrets_dir);
         let mut map = serde_json::Map::new();

--- a/crates/teamclaw-runtime-env/src/storage_namespace.rs
+++ b/crates/teamclaw-runtime-env/src/storage_namespace.rs
@@ -1,0 +1,64 @@
+//! Canonical on-disk namespace for official TeamClaw builds vs white-label brands.
+//!
+//! Official Production + Dev share `~/.teamclaw` and `{workspace}/.teamclaw/`.
+//! White-label builds keep `~/.{shortName}` / `{workspace}/.{shortName}/`.
+
+/// Home + workspace storage dir name for official builds (`~/.teamclaw`).
+pub const OFFICIAL_STORAGE_DIR: &str = "teamclaw";
+
+/// Legacy official Dev dir name before namespace unification.
+pub const LEGACY_OFFICIAL_DEV_STORAGE_DIR: &str = "teamclawdev";
+
+/// Workspace metadata directory for official builds (`.teamclaw/`).
+pub const WORKSPACE_META_DIR: &str = ".teamclaw";
+
+/// Primary workspace config file for official builds.
+pub const WORKSPACE_CONFIG_FILE: &str = "teamclaw.json";
+
+/// Legacy Dev workspace config file name.
+pub const LEGACY_OFFICIAL_DEV_CONFIG_FILE: &str = "teamclawdev.json";
+
+/// One-shot migration marker under `~/.teamclaw/migrations/`.
+pub const STORAGE_NAMESPACE_MIGRATION_MARKER: &str = "official-storage-namespace-v1";
+
+/// Whether `short_name` identifies an official TeamClaw build (Prod or Dev).
+pub fn is_official_brand(short_name: &str) -> bool {
+    matches!(
+        short_name,
+        OFFICIAL_STORAGE_DIR | LEGACY_OFFICIAL_DEV_STORAGE_DIR
+    )
+}
+
+/// Resolve the home-directory storage folder name (`teamclaw`, `copilot361`, …).
+pub fn resolve_storage_dir_name(short_name: &str) -> &str {
+    if is_official_brand(short_name) {
+        OFFICIAL_STORAGE_DIR
+    } else {
+        short_name
+    }
+}
+
+/// Legacy official Dev home dir (`teamclawdev`) when migrating an existing install.
+pub fn legacy_official_home_dir_name(short_name: &str) -> Option<&'static str> {
+    if short_name == LEGACY_OFFICIAL_DEV_STORAGE_DIR {
+        Some(LEGACY_OFFICIAL_DEV_STORAGE_DIR)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn official_brands_share_teamclaw_storage() {
+        assert!(is_official_brand("teamclaw"));
+        assert!(is_official_brand("teamclawdev"));
+        assert!(!is_official_brand("copilot361"));
+
+        assert_eq!(resolve_storage_dir_name("teamclaw"), "teamclaw");
+        assert_eq!(resolve_storage_dir_name("teamclawdev"), "teamclaw");
+        assert_eq!(resolve_storage_dir_name("copilot361"), "copilot361");
+    }
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "rust:check": "node scripts/rust-cli.js check --manifest-path apps/desktop/Cargo.toml",
     "rust:build": "node scripts/rust-cli.js build --manifest-path apps/desktop/Cargo.toml",
     "daemon:run": "node scripts/run-daemon.js",
+    "daemon:deploy": "scripts/deploy-daemon-binaries.sh",
     "daemon:ctl": "scripts/amuxdctl.sh",
     "dev:daemon": "scripts/dev-daemon.sh",
     "dev:desktop": "scripts/dev-desktop.sh",

--- a/packages/app/src/components/settings/GeneralSection.tsx
+++ b/packages/app/src/components/settings/GeneralSection.tsx
@@ -31,12 +31,13 @@ import { useCurrentTeamStore } from '@/stores/current-team'
 import { getBackend } from '@/lib/backend'
 import { SettingCard, SectionHeader, ToggleSwitch } from './shared'
 import { useAcpDebugStore } from '@/stores/acp-debug-store'
-import { appShortName, buildConfig } from '@/lib/build-config'
+import { appStoragePrefix, buildConfig } from '@/lib/build-config'
+import { NOTIFICATION_LEVEL_KEY } from '@/lib/notification-service'
 import { LANGUAGE_OPTIONS, getPreferredLanguage, normalizeSupportedLanguage, persistLanguage } from '@/lib/locale'
 import { getEffectiveServerConfig, type ServerConfig } from '@/lib/server-config'
 
 // Theme helpers
-const THEME_STORAGE_KEY = `${buildConfig.app.shortName ?? 'teamclaw'}-theme`
+const THEME_STORAGE_KEY = `${appStoragePrefix}-theme`
 const DEFAULT_THEME = buildConfig.defaults?.theme || 'system'
 
 function applyTheme(theme: string) {
@@ -136,14 +137,14 @@ export const GeneralSection = React.memo(function GeneralSection() {
 
   const [notificationLevel, setNotificationLevelState] = React.useState(() => {
     try {
-      const stored = localStorage.getItem(`${appShortName}-notification-level`)
+      const stored = localStorage.getItem(NOTIFICATION_LEVEL_KEY)
       if (stored === 'all' || stored === 'important' || stored === 'mute') return stored
     } catch { /* ignore */ }
     return 'important'
   })
   const setNotificationLevel = React.useCallback((level: string) => {
     setNotificationLevelState(level)
-    try { localStorage.setItem(`${appShortName}-notification-level`, level) } catch { /* ignore */ }
+    try { localStorage.setItem(NOTIFICATION_LEVEL_KEY, level) } catch { /* ignore */ }
   }, [])
   const acpStreamDebugEnabled = useAcpDebugStore((s) => s.enabled)
   const setAcpStreamDebugEnabled = useAcpDebugStore((s) => s.setEnabled)

--- a/packages/app/src/components/settings/PromptSection.tsx
+++ b/packages/app/src/components/settings/PromptSection.tsx
@@ -5,14 +5,14 @@ import { invoke } from '@tauri-apps/api/core'
 import { Button } from '@/components/ui/button'
 import { SettingCard, SectionHeader } from './shared'
 import { toast } from 'sonner'
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 import { isTauri } from '@/lib/utils'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { encodeWorkspaceId, reloadDaemonRuntime } from '@/lib/daemon-local-client'
 
 // Legacy global storage key — kept only for one-time migration into
 // per-workspace teamclaw.json.
-const LEGACY_STORAGE_KEY = `${appShortName}-system-prompt`
+const LEGACY_STORAGE_KEY = `${appStoragePrefix}-system-prompt`
 
 export const PromptSection = React.memo(function PromptSection() {
   const { t } = useTranslation()

--- a/packages/app/src/components/settings/SkillsSection.tsx
+++ b/packages/app/src/components/settings/SkillsSection.tsx
@@ -39,7 +39,7 @@ import {
   deleteDaemonSkill,
 } from '@/lib/daemon-local-client'
 import { cn } from '@/lib/utils'
-import { appDisplayName } from '@/lib/build-config'
+import { appDisplayName, TEAMCLAW_DIR } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -415,7 +415,7 @@ ${skillContent.trim()}`
         const home = await homeDir()
         skillsDir = `${home.replace(/\/$/, '')}/.config/opencode/skills`
       } else {
-        skillsDir = `${workspacePath}/.teamclaw/skills`
+        skillsDir = `${workspacePath}/${TEAMCLAW_DIR}/skills`
       }
 
       if (!(await exists(skillsDir))) {
@@ -474,7 +474,7 @@ ${skillContent.trim()}`
         )
         if (!deleted) {
           const { remove } = await import('@tauri-apps/plugin-fs')
-          const baseDir = targetSkill.dirPath ?? `${workspacePath}/.teamclaw/skills`
+          const baseDir = targetSkill.dirPath ?? `${workspacePath}/${TEAMCLAW_DIR}/skills`
           await remove(`${baseDir}/${targetSkill.filename}`, { recursive: true })
         }
       }

--- a/packages/app/src/components/workspace/FileBrowser.tsx
+++ b/packages/app/src/components/workspace/FileBrowser.tsx
@@ -91,7 +91,9 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
   React.useEffect(() => {
     if (workspacePath) void refreshOssSync(workspacePath)
   }, [workspacePath, refreshOssSync])
-  const showOssSync = !isCustomRoot && !!ossTeamId
+  // Caller-provided actionIcons (KnowledgeBrowser git sync, TeamSharedFilesBrowser
+  // git/oss sync) already own the toolbar sync button — don't duplicate OSS sync.
+  const showOssSync = !isCustomRoot && !!ossTeamId && !actionIcons
 
   // When rootPaths is provided, create virtual root folder nodes for each path.
   // When rootPath is provided, extract its subtree from the global fileTree.

--- a/packages/app/src/components/workspace/__tests__/FileBrowser.test.tsx
+++ b/packages/app/src/components/workspace/__tests__/FileBrowser.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type MockFileNode = {
@@ -107,6 +107,18 @@ vi.mock("../FileTree", () => ({
   },
 }));
 
+const ossSyncState = vi.hoisted(() => ({
+  teamId: "team-1" as string | null,
+  syncing: false,
+  refresh: vi.fn().mockResolvedValue(undefined),
+  syncNow: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/stores/oss-sync", () => ({
+  useOssSyncStore: (selector: (state: typeof ossSyncState) => unknown) =>
+    selector(ossSyncState),
+}));
+
 vi.mock("@/stores/workspace", () => ({
   useWorkspaceStore: Object.assign(
     (selector: (state: Record<string, unknown>) => unknown) =>
@@ -138,6 +150,25 @@ describe("FileBrowser", () => {
     vi.clearAllMocks();
     mockFileTree = [];
     latestNodesProp = undefined;
+    ossSyncState.teamId = "team-1";
+  });
+
+  it("hides built-in OSS sync when the caller already supplies actionIcons", () => {
+    render(
+      <FileBrowser
+        variant="panel"
+        actionIcons={<button data-testid="caller-sync">Sync</button>}
+      />,
+    );
+
+    expect(screen.getByTestId("caller-sync")).toBeTruthy();
+    expect(screen.queryByTestId("filebrowser-oss-sync")).toBeNull();
+  });
+
+  it("shows built-in OSS sync for workspace root when no actionIcons are provided", () => {
+    render(<FileBrowser variant="panel" />);
+
+    expect(screen.getByTestId("filebrowser-oss-sync")).toBeTruthy();
   });
 
   it("retries loading custom root ancestors after the global tree becomes available", async () => {

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -33,7 +33,8 @@ import { useTeamModeStore } from "@/stores/team-mode";
 import { useTeamShareStore } from "@/stores/team-share";
 import { useOssSyncStore } from "@/stores/oss-sync";
 import { getSkillDirectories, loadAllSkills } from "@/lib/git/skill-loader";
-import { appShortName, DEFAULT_WORKSPACE_PATH, TEAM_REPO_DIR } from "@/lib/build-config";
+import { appStoragePrefix, DEFAULT_WORKSPACE_PATH, TEAM_REPO_DIR } from "@/lib/build-config";
+import { WORKSPACE_STORAGE_KEY } from "@/stores/workspace";
 import { markStartup } from "@/lib/startup-perf";
 
 export const SKILLS_CHANGED_EVENT = "skills-files-changed";
@@ -110,7 +111,7 @@ export function useWorkspaceInit() {
           await setWorkspace(windowParams.workspace);
         } else {
           try {
-            const savedPath = localStorage.getItem(`${appShortName}-workspace-path`);
+            const savedPath = localStorage.getItem(WORKSPACE_STORAGE_KEY);
             let restored = false;
             if (savedPath) {
               let canRestore = true;
@@ -130,7 +131,7 @@ export function useWorkspaceInit() {
                 restored = true;
               } else {
                 console.log("[App] Saved workspace no longer exists, clearing restore path:", savedPath);
-                localStorage.removeItem(`${appShortName}-workspace-path`);
+                localStorage.removeItem(WORKSPACE_STORAGE_KEY);
               }
             }
 
@@ -735,7 +736,7 @@ export function useSetupGuide(workspaceReady: boolean) {
   useEffect(() => {
     const debugForceSetup = (() => {
       try {
-        return localStorage.getItem(`${appShortName}-debug-force-setup`) === "1";
+        return localStorage.getItem(`${appStoragePrefix}-debug-force-setup`) === "1";
       } catch {
         return false;
       }

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -172,7 +172,21 @@ function deriveShortName(name: string): string {
   return name.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()
 }
 
+const OFFICIAL_BRAND_SHORT_NAMES = new Set(['teamclaw', 'teamclawdev'])
+
+/** Official TeamClaw Prod/Dev builds share one on-disk + localStorage namespace. */
+export function isOfficialBrand(shortName: string): boolean {
+  return OFFICIAL_BRAND_SHORT_NAMES.has(shortName)
+}
+
+/** Home dir + localStorage prefix (`teamclaw` for official builds). */
+export function resolveStorageDirName(shortName: string): string {
+  return isOfficialBrand(shortName) ? 'teamclaw' : shortName
+}
+
 export const appShortName: string = buildConfig.app.shortName ?? deriveShortName(buildConfig.app.name)
+/** Prefix for localStorage keys — unified `teamclaw` for official builds (Decision 1 = B). */
+export const appStoragePrefix: string = resolveStorageDirName(appShortName)
 /** The product name to show users. Prefer this over `buildConfig.app.name` in
  *  any UI string — `app.name` is the bundle identity and may differ. */
 export const appDisplayName: string = buildConfig.app.displayName ?? buildConfig.app.name
@@ -180,11 +194,11 @@ export const appScheme: string = buildConfig.app.scheme ?? 'teamclaw'
 /** Local agent runtime for this build. Defaults to opencode. */
 export const localAgent: 'opencode' | 'pi' = buildConfig.localAgent === 'pi' ? 'pi' : 'opencode'
 export const DEFAULT_WORKSPACE_PATH = `~/${buildConfig.app.name}`
-export const TEAMCLAW_DIR = `.${appShortName}`
+export const TEAMCLAW_DIR = isOfficialBrand(appShortName) ? '.teamclaw' : `.${appShortName}`
 /** Team share link + global sync dir name. Fixed across brands so daemon, git, and all clients agree. */
 export const TEAM_REPO_DIR = 'teamclaw-team'
-export const CONFIG_FILE_NAME = `${appShortName}.json`
-export const TEAM_SYNCED_EVENT = `${appShortName}-team-synced`
+export const CONFIG_FILE_NAME = isOfficialBrand(appShortName) ? 'teamclaw.json' : `${appShortName}.json`
+export const TEAM_SYNCED_EVENT = `${appStoragePrefix}-team-synced`
 
 /** Baked Chrome-extension pack config (`extensions` in build.config*.json). */
 export const extensionPack: ExtensionPackConfig = parseExtensionPackConfig(

--- a/packages/app/src/lib/git/skill-loader.ts
+++ b/packages/app/src/lib/git/skill-loader.ts
@@ -4,7 +4,7 @@ import { homeDir } from '@tauri-apps/api/path'
 import type { SkillWithSource, SkillSource } from './types'
 import { INHERENT_SKILL_NAMES, shouldIncludeDesktopControlSkill } from './types'
 import type { ClawHubLockfile } from '@/lib/clawhub/types'
-import { appDisplayName, TEAM_REPO_DIR } from '@/lib/build-config'
+import { appDisplayName, TEAMCLAW_DIR, TEAM_REPO_DIR } from '@/lib/build-config'
 import i18n from '@/lib/i18n'
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -128,7 +128,7 @@ export async function getSkillDirectories(workspacePath: string | null): Promise
   ])
 
   if (workspacePath) {
-    dirs.add(`${workspacePath}/.teamclaw/skills`)
+    dirs.add(`${workspacePath}/${TEAMCLAW_DIR}/skills`)
     dirs.add(`${workspacePath}/.claude/skills`)
     dirs.add(`${workspacePath}/.agents/skills`)
 
@@ -188,7 +188,7 @@ export async function loadAllSkills(
   //    Skills whose dirname matches INHERENT_SKILL_NAMES are marked as 'builtin'.
   //    Skills whose dirname matches a ClawHub lockfile entry are marked as 'clawhub'.
   if (workspacePath) {
-    const localDir = `${workspacePath}/.teamclaw/skills`
+    const localDir = `${workspacePath}/${TEAMCLAW_DIR}/skills`
     const localSkills = await loadSkillsFromDir(localDir, 'local')
     for (const skill of localSkills) {
       if (INHERENT_SKILL_NAMES.has(skill.filename)) {
@@ -236,7 +236,7 @@ export async function loadAllSkills(
 
   // 7. Scan plugin cache for skills installed via teamclaw.json "plugin" array
   if (workspacePath) {
-    const pluginCacheDir = `${workspacePath}/.teamclaw/cache/agent/node_modules`
+    const pluginCacheDir = `${workspacePath}/${TEAMCLAW_DIR}/cache/agent/node_modules`
     try {
       if (await exists(pluginCacheDir)) {
         const pluginEntries = await readDir(pluginCacheDir)
@@ -361,11 +361,11 @@ export function getSourceLabel(source: SkillSource): string {
 export function getSourceDirHint(source: SkillSource): string {
   switch (source) {
     case 'local':
-      return '.teamclaw/skills/'
+      return `${TEAMCLAW_DIR}/skills/`
     case 'claude':
       return '.claude/skills/'
     case 'clawhub':
-      return '.teamclaw/skills/ (ClawHub)'
+      return `${TEAMCLAW_DIR}/skills/ (ClawHub)`
     case 'shared':
       return '.agents/skills/'
     case 'team':

--- a/packages/app/src/lib/local-daemon-identity.ts
+++ b/packages/app/src/lib/local-daemon-identity.ts
@@ -1,8 +1,8 @@
 /** Tracks amuxd re-init: previous local actor ids are "stale" for engaged pills. */
 
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 
-const PERSISTED_LOCAL_DAEMON_ACTOR_KEY = `${appShortName}-local-daemon-actor-id`
+const PERSISTED_LOCAL_DAEMON_ACTOR_KEY = `${appStoragePrefix}-local-daemon-actor-id`
 
 const supersededLocalActorIds = new Set<string>()
 let lastKnownLocalActorId: string | null = null

--- a/packages/app/src/lib/locale.ts
+++ b/packages/app/src/lib/locale.ts
@@ -1,6 +1,6 @@
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 
-export const LANGUAGE_STORAGE_KEY = `${appShortName}-language`
+export const LANGUAGE_STORAGE_KEY = `${appStoragePrefix}-language`
 export const SUPPORTED_LANGUAGES = ['en', 'zh-CN'] as const
 
 export type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number]

--- a/packages/app/src/lib/notification-service.ts
+++ b/packages/app/src/lib/notification-service.ts
@@ -4,7 +4,7 @@ import {
 } from "@tauri-apps/plugin-notification";
 import { getPermissionPolicy } from "@/lib/permission-policy";
 import { isTauri } from "@/lib/utils";
-import { appShortName } from "@/lib/build-config";
+import { appStoragePrefix } from "@/lib/build-config";
 
 // --- Types ---
 
@@ -12,7 +12,7 @@ export type NotificationType = "action_required" | "task_completed" | "info";
 
 export type NotificationLevel = "all" | "important" | "mute";
 
-const NOTIFICATION_LEVEL_KEY = `${appShortName}-notification-level`;
+export const NOTIFICATION_LEVEL_KEY = `${appStoragePrefix}-notification-level`;
 const DEFAULT_LEVEL: NotificationLevel = "important";
 const THROTTLE_WINDOW_MS = 5000; // 5 seconds dedup window for task_completed
 

--- a/packages/app/src/lib/permission-policy.ts
+++ b/packages/app/src/lib/permission-policy.ts
@@ -1,13 +1,13 @@
 // --- Permission Policy ---
 // Global permission policy configuration for controlling permission request behavior.
-// Persisted in localStorage under '${appShortName}-permission-policy'.
+// Persisted in localStorage under '${appStoragePrefix}-permission-policy'.
 
-import { appShortName } from "@/lib/build-config";
+import { appStoragePrefix } from "@/lib/build-config";
 
 export type PermissionPolicy = "ask" | "batch" | "bypass";
 
-const PERMISSION_POLICY_KEY = `${appShortName}-permission-policy`;
-const PERMISSION_BATCH_DONE_KEY = `${appShortName}-permission-batch-done`;
+const PERMISSION_POLICY_KEY = `${appStoragePrefix}-permission-policy`;
+const PERMISSION_BATCH_DONE_KEY = `${appStoragePrefix}-permission-batch-done`;
 const DEFAULT_POLICY: PermissionPolicy = "ask";
 const VALID_POLICIES: ReadonlySet<string> = new Set(["ask", "batch", "bypass"]);
 

--- a/packages/app/src/lib/roles/loader.ts
+++ b/packages/app/src/lib/roles/loader.ts
@@ -14,9 +14,11 @@ import type { SkillSource } from "@/lib/git/types"
 import { isTauri } from "@/lib/utils"
 import { encodeWorkspaceId, getDaemonRolesSkillsState, putDaemonRole, deleteDaemonRole } from "@/lib/daemon-local-client"
 
-const ROLE_ROOT = ".teamclaw/roles"
-const ROLE_SKILL_DIR = ".teamclaw/roles/skills"
-const ROLE_CONFIG_PATH = ".teamclaw/roles/config.json"
+import { TEAMCLAW_DIR } from "@/lib/build-config"
+
+const ROLE_ROOT = `${TEAMCLAW_DIR}/roles`
+const ROLE_SKILL_DIR = `${TEAMCLAW_DIR}/roles/skills`
+const ROLE_CONFIG_PATH = `${TEAMCLAW_DIR}/roles/config.json`
 const ROLE_SKILL_DIR_NAME = "skills"
 
 const SECTION_NAMES = {
@@ -310,7 +312,7 @@ async function loadRolesSkillsWorkspaceStateFromFs(
       content: skill.content,
       description: extractSkillDescription(skill.content, skill.name),
       source: skill.source,
-      dirPath: skill.dirPath ?? `${workspacePath}/.teamclaw/skills`,
+      dirPath: skill.dirPath ?? `${workspacePath}/${TEAMCLAW_DIR}/skills`,
       linkedRoles: roleUsageBySkill[skill.filename] ?? [],
       isRoleSkill: false,
     })
@@ -507,7 +509,7 @@ export async function deleteRole(workspacePath: string, roleSlug: string, roleFi
 
 export async function loadAttachableSkills(workspacePath: string): Promise<AttachableSkill[]> {
   const { skills } = await loadAllSkills(workspacePath)
-  const workspaceSkillRoot = `${workspacePath}/.teamclaw/skills`
+  const workspaceSkillRoot = `${workspacePath}/${TEAMCLAW_DIR}/skills`
   return skills
     .filter((skill) => skill.source === "local" && skill.dirPath === workspaceSkillRoot)
     .map((skill) => ({
@@ -569,7 +571,7 @@ export async function attachSkillToRole(input: AttachSkillToRoleInput): Promise<
     throw new Error(`Role "${roleSlug}" does not exist`)
   }
 
-  const sourceDir = `${workspacePath}/.teamclaw/skills/${skillSlug}`
+  const sourceDir = `${workspacePath}/${TEAMCLAW_DIR}/skills/${skillSlug}`
   const sourceSkillPath = `${sourceDir}/SKILL.md`
   if (!(await exists(sourceSkillPath))) {
     throw new Error(`Skill "${skillSlug}" is not available for role attachment`)

--- a/packages/app/src/lib/session-permission-mode.ts
+++ b/packages/app/src/lib/session-permission-mode.ts
@@ -1,10 +1,10 @@
 import { useSyncExternalStore } from "react";
-import { appShortName } from "@/lib/build-config";
+import { appStoragePrefix } from "@/lib/build-config";
 
 export type SessionPermissionMode = "default" | "fullAccess";
 
-const STORAGE_KEY = `${appShortName}-session-permission-modes`;
-const CHANGE_EVENT = `${appShortName}-session-permission-modes-changed`;
+const STORAGE_KEY = `${appStoragePrefix}-session-permission-modes`;
+const CHANGE_EVENT = `${appStoragePrefix}-session-permission-modes-changed`;
 const MAX_ENTRIES = 200;
 
 type StoredPayload = {

--- a/packages/app/src/lib/startup-perf.ts
+++ b/packages/app/src/lib/startup-perf.ts
@@ -21,7 +21,7 @@
  * packaged build to turn the timeline log on, or call `dumpStartupTimeline()`
  * from the devtools console at any time.
  */
-import { appShortName } from "./build-config";
+import { appStoragePrefix } from "./build-config";
 
 export type StartupStamp = { name: string; t: number };
 
@@ -32,7 +32,7 @@ let settleTimer: ReturnType<typeof setTimeout> | null = null;
 function dumpEnabled(): boolean {
   if (import.meta.env.DEV) return true;
   try {
-    return localStorage.getItem(`${appShortName}-perf`) === "1";
+    return localStorage.getItem(`${appStoragePrefix}-perf`) === "1";
   } catch {
     return false;
   }

--- a/packages/app/src/lib/storage-migration.ts
+++ b/packages/app/src/lib/storage-migration.ts
@@ -1,0 +1,38 @@
+import { appStoragePrefix, isOfficialBrand, appShortName } from '@/lib/build-config'
+
+const MIGRATION_MARKER = 'teamclaw-localstorage-namespace-v1'
+
+const LEGACY_OFFICIAL_PREFIXES = ['teamclawdev']
+
+/**
+ * One-shot migration: `teamclawdev-*` localStorage keys → `teamclaw-*` for
+ * official builds (Decision 1 = B). Idempotent.
+ */
+export function migrateOfficialLocalStorage(): void {
+  if (typeof localStorage === 'undefined') return
+  if (!isOfficialBrand(appShortName)) return
+  if (localStorage.getItem(MIGRATION_MARKER) === '1') return
+
+  for (const legacyPrefix of LEGACY_OFFICIAL_PREFIXES) {
+    if (legacyPrefix === appStoragePrefix) continue
+    const keysToMove: string[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (key?.startsWith(`${legacyPrefix}-`)) {
+        keysToMove.push(key)
+      }
+    }
+    for (const oldKey of keysToMove) {
+      const newKey = `${appStoragePrefix}-${oldKey.slice(legacyPrefix.length + 1)}`
+      if (localStorage.getItem(newKey) == null) {
+        const value = localStorage.getItem(oldKey)
+        if (value != null) {
+          localStorage.setItem(newKey, value)
+        }
+      }
+      localStorage.removeItem(oldKey)
+    }
+  }
+
+  localStorage.setItem(MIGRATION_MARKER, '1')
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -10,7 +10,10 @@ import { LocalAgentPanelApp } from './components/LocalAgentPanelApp'
 import './styles/globals.css'
 import './stores/dev-expose'
 import './lib/i18n'; // Initialize i18n
-import { appShortName, buildConfig } from './lib/build-config'
+import { appStoragePrefix, buildConfig } from './lib/build-config'
+import { migrateOfficialLocalStorage } from './lib/storage-migration'
+
+migrateOfficialLocalStorage()
 import { ensureBundledAmuxdCurrent } from './lib/daemon-version-upgrade'
 import { initJwtBridge } from './lib/jwt-bridge'
 import { installConsoleCapture } from './lib/console-capture'
@@ -38,7 +41,7 @@ installConsoleCapture()
 
 // Apply persisted theme immediately to prevent flash of wrong theme
 ;(() => {
-  const theme = localStorage.getItem(`${appShortName}-theme`) || buildConfig.defaults?.theme || 'system'
+  const theme = localStorage.getItem(`${appStoragePrefix}-theme`) || buildConfig.defaults?.theme || 'system'
   const root = document.documentElement
   if (theme === 'dark') {
     root.classList.add('dark')

--- a/packages/app/src/stores/acp-debug-store.ts
+++ b/packages/app/src/stores/acp-debug-store.ts
@@ -1,9 +1,9 @@
 import { create } from "zustand";
 import { appendAcpDebugLineToFile } from "@/lib/acp-debug-file-log";
-import { appShortName } from "@/lib/build-config";
+import { appStoragePrefix } from "@/lib/build-config";
 import type { AcpEvent } from "@/lib/proto/amux_pb";
 
-const ACP_DEBUG_ENABLED_KEY = `${appShortName}-acp-stream-debug`;
+const ACP_DEBUG_ENABLED_KEY = `${appStoragePrefix}-acp-stream-debug`;
 
 function readAcpDebugEnabled(): boolean {
   if (import.meta.env.VITE_ACP_DEBUG_STREAM === "true") return true;

--- a/packages/app/src/stores/deps.ts
+++ b/packages/app/src/stores/deps.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { isTauri } from '@/lib/utils'
 import { loadFromStorage, saveToStorage } from '@/lib/storage'
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 
 export interface DependencyInfo {
   name: string
@@ -42,9 +42,9 @@ interface DepInstallProgressEvent {
 
 // ─── Persistent setup status ─────────────────────────────────────────────────
 
-const DEPS_SETUP_KEY = `${appShortName}-deps-setup-status`
+const DEPS_SETUP_KEY = `${appStoragePrefix}-deps-setup-status`
 /** First-run welcome screen seen flag (shown once, before dependency setup). */
-const WELCOME_SEEN_KEY = `${appShortName}-welcome-seen`
+const WELCOME_SEEN_KEY = `${appStoragePrefix}-welcome-seen`
 /** Re-check interval: 24 hours */
 const RECHECK_TTL_MS = 24 * 60 * 60 * 1000
 
@@ -152,13 +152,13 @@ interface DepsState {
 
 
 /**
- * Debug: set localStorage.setItem(`${appShortName}-debug-force-setup`, '1') to force
+ * Debug: set localStorage.setItem(`${appStoragePrefix}-debug-force-setup`, '1') to force
  * SetupGuide to show in browser dev mode with mock dependency data.
- * Remove the key to disable: localStorage.removeItem(`${appShortName}-debug-force-setup`)
+ * Remove the key to disable: localStorage.removeItem(`${appStoragePrefix}-debug-force-setup`)
  */
 const isDebugForceSetup = () => {
   try {
-    return localStorage.getItem(`${appShortName}-debug-force-setup`) === '1'
+    return localStorage.getItem(`${appStoragePrefix}-debug-force-setup`) === '1'
   } catch {
     return false
   }

--- a/packages/app/src/stores/git-repos.ts
+++ b/packages/app/src/stores/git-repos.ts
@@ -3,10 +3,10 @@ import type { GitRepo, GitRepoConfig, RepoSyncStatus } from '@/lib/git/types'
 import { gitManager } from '@/lib/git/manager'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { loadFromStorage, saveToStorage } from '@/lib/storage'
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 
 // Storage key for persisting repo state
-const STORAGE_KEY = `${appShortName}-git-repos`
+const STORAGE_KEY = `${appStoragePrefix}-git-repos`
 
 interface GitReposState {
   /** Whether git CLI is available on the system */

--- a/packages/app/src/stores/git-settings.ts
+++ b/packages/app/src/stores/git-settings.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { GitStatus } from '@/lib/git/service'
 import { loadFromStorage, saveToStorage } from '@/lib/storage'
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 
 // Default color scheme for Git statuses
 const DEFAULT_STATUS_COLORS: Record<GitStatus, string> = {
@@ -16,7 +16,7 @@ const DEFAULT_STATUS_COLORS: Record<GitStatus, string> = {
 }
 
 // Storage key for persisting settings
-const STORAGE_KEY = `${appShortName}-git-settings`
+const STORAGE_KEY = `${appStoragePrefix}-git-settings`
 
 interface GitSettingsState {
   /** Whether to show Git status indicators in the file tree */

--- a/packages/app/src/stores/provider.ts
+++ b/packages/app/src/stores/provider.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { toast } from 'sonner'
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 import { invoke } from '@tauri-apps/api/core'
 import { workspaceScopedKey } from '@/lib/storage'
 import { sessionFlowLog } from '@/lib/session-flow-log'
@@ -29,7 +29,7 @@ import {
 } from '@/lib/opencode/config'
 import { TEAM_SHARED_PROVIDER_ID } from '@/lib/team-provider'
 
-const SELECTED_MODEL_BASE = `${appShortName}-selected-model`
+const SELECTED_MODEL_BASE = `${appStoragePrefix}-selected-model`
 const DEFAULT_CONNECTABLE_PROVIDERS: ProviderEntry[] = [
   { id: 'openai', name: 'OpenAI', configured: false },
 ]

--- a/packages/app/src/stores/session-pins.ts
+++ b/packages/app/src/stores/session-pins.ts
@@ -1,6 +1,6 @@
-import { appShortName } from "@/lib/build-config";
+import { appStoragePrefix } from "@/lib/build-config";
 
-const STORAGE_KEY = `${appShortName}-pinned-sessions`;
+const STORAGE_KEY = `${appStoragePrefix}-pinned-sessions`;
 
 type PinnedSessionStorage = Record<string, string[]>;
 

--- a/packages/app/src/stores/setup.ts
+++ b/packages/app/src/stores/setup.ts
@@ -1,14 +1,14 @@
 import { create } from 'zustand'
 import { isTauri } from '@/lib/utils'
 import { markStartup } from '@/lib/startup-perf'
-import { appShortName, localAgent } from '@/lib/build-config'
+import { appStoragePrefix, localAgent } from '@/lib/build-config'
 
 // Cache the last-known "all required deps satisfied" verdict so a returning user
 // (deps already installed) is never gated behind the cold `setup_list_requirements`
 // probe, which spawns `amuxd doctor` and costs ~4s on first launch (macOS
 // Gatekeeper). The probe still runs in the background to refresh this flag; the
 // daemon-onboarding gate remains the real backstop if a dependency is missing.
-const SETUP_OK_KEY = `${appShortName}-setup-ok`
+const SETUP_OK_KEY = `${appStoragePrefix}-setup-ok`
 
 /** True if a prior probe confirmed all required deps were present. Sync, cheap. */
 export function setupPreviouslySatisfied(): boolean {

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -8,13 +8,13 @@ import { useTeamShareStore } from './team-share'
 import { useCurrentTeamStore } from './current-team'
 import { isTauri } from '@/lib/utils'
 import { workspaceScopedKey } from '@/lib/storage'
-import { appShortName, buildConfig, TEAM_REPO_DIR, type TeamModelOption } from '@/lib/build-config'
+import { appStoragePrefix, buildConfig, TEAM_REPO_DIR, type TeamModelOption } from '@/lib/build-config'
 
 
 const TEAM_PROVIDER_ID = TEAM_SHARED_PROVIDER_ID
 
-const TEAM_MODEL_BASE = `${appShortName}-team-model`
-const PRE_TEAM_MODEL_BASE = `${appShortName}-pre-team-model`
+const TEAM_MODEL_BASE = `${appStoragePrefix}-team-model`
+const PRE_TEAM_MODEL_BASE = `${appStoragePrefix}-pre-team-model`
 
 function teamModelKey(): string {
   return workspaceScopedKey(TEAM_MODEL_BASE, useWorkspaceStore.getState().workspacePath)

--- a/packages/app/src/stores/voice-input.ts
+++ b/packages/app/src/stores/voice-input.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
-import { appShortName } from '@/lib/build-config';
+import { appStoragePrefix } from '@/lib/build-config';
 
-const VOICE_ENABLED_KEY = `${appShortName}-voice-enabled`;
+const VOICE_ENABLED_KEY = `${appStoragePrefix}-voice-enabled`;
 
 /** Store for global voice input: transcript is stored after recording, user decides where to put it */
 interface VoiceInputState {

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { UNSUPPORTED_BINARY_EXTENSIONS } from "@/components/viewers/UnsupportedFileViewer";
 import { isTauri } from '@/lib/utils'
 import { ensureGitignoreEntries } from '@/lib/gitignore-manager'
-import { appDisplayName, appShortName, TEAM_REPO_DIR } from '@/lib/build-config'
+import { appDisplayName, appStoragePrefix, TEAM_REPO_DIR } from '@/lib/build-config'
 import { useTeamModeStore } from './team-mode'
 
 // Start watching a directory for file changes
@@ -170,7 +170,7 @@ function getFolderName(path: string): string {
   return parts[parts.length - 1] || path;
 }
 
-export const WORKSPACE_STORAGE_KEY = `${appShortName}-workspace-path`;
+export const WORKSPACE_STORAGE_KEY = `${appStoragePrefix}-workspace-path`;
 
 async function readWorkspaceTextFile(
   workspacePath: string,

--- a/scripts/deploy-daemon-binaries.sh
+++ b/scripts/deploy-daemon-binaries.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# deploy-daemon-binaries — build amuxd + teamclaw-introspect from the current
+# checkout and overwrite ~/.amuxd/bin/{amuxd,teamclaw-introspect}, then reload
+# the user service (launchd / systemd).
+#
+# Uses .cargo-target/ (same as pnpm rust:build / dev:daemon), not target/.
+#
+# Usage:
+#   scripts/deploy-daemon-binaries.sh              # debug build, overwrite + reload
+#   scripts/deploy-daemon-binaries.sh --release    # release build
+#   scripts/deploy-daemon-binaries.sh --skip-build # use existing .cargo-target/<profile>/*
+#   scripts/deploy-daemon-binaries.sh --no-reload  # copy only, don't touch the service
+#   scripts/deploy-daemon-binaries.sh --no-sidecar # don't refresh apps/desktop/binaries/*
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${ROOT_DIR}/.cargo-target}"
+
+LABEL="cc.ucar.amuxd"
+AMUXD_HOME="${HOME}/.amuxd"
+BIN_DIR="${AMUXD_HOME}/bin"
+PLIST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+
+PROFILE="debug"
+SKIP_BUILD=0
+NO_RELOAD=0
+NO_SIDECAR=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release)    PROFILE="release"; shift ;;
+    --debug)      PROFILE="debug"; shift ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    --no-reload)  NO_RELOAD=1; shift ;;
+    --no-sidecar) NO_SIDECAR=1; shift ;;
+    -h|--help)
+      sed -n '2,13p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "error: unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*)
+  AMUXD_NAME="amuxd.exe"
+  INTROSPECT_NAME="teamclaw-introspect.exe"
+  SIDE_EXT=".exe"
+  ;;
+*)
+  AMUXD_NAME="amuxd"
+  INTROSPECT_NAME="teamclaw-introspect"
+  SIDE_EXT=""
+  ;;
+esac
+
+TARGET="${TARGET:-$(rustc -vV 2>/dev/null | awk '/^host:/{print $2}')}"
+SRC_AMUXD="${CARGO_TARGET_DIR}/${PROFILE}/${AMUXD_NAME}"
+SRC_INTROSPECT="${CARGO_TARGET_DIR}/${PROFILE}/${INTROSPECT_NAME}"
+DEST_AMUXD="${BIN_DIR}/${AMUXD_NAME}"
+DEST_INTROSPECT="${BIN_DIR}/${INTROSPECT_NAME}"
+SIDECAR_AMUXD="${ROOT_DIR}/apps/desktop/binaries/amuxd-${TARGET}${SIDE_EXT}"
+SIDECAR_INTROSPECT="${ROOT_DIR}/apps/desktop/binaries/teamclaw-introspect-${TARGET}${SIDE_EXT}"
+
+GIT_SHA="$(git -C "${ROOT_DIR}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+GIT_BRANCH="$(git -C "${ROOT_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+GIT_DIRTY=""
+git -C "${ROOT_DIR}" diff --quiet 2>/dev/null || GIT_DIRTY=" (dirty)"
+
+say() { printf '\033[1;36m▸ %s\033[0m\n' "$*"; }
+
+install_binary() {
+  local src="$1"
+  local dest="$2"
+  [[ -x "${src}" ]] || { echo "error: built binary not found at ${src}" >&2; exit 1; }
+  say "installing -> ${dest}"
+  mkdir -p "$(dirname "${dest}")"
+  local tmp="${dest}.new.$$"
+  cp "${src}" "${tmp}"
+  chmod +x "${tmp}"
+  mv -f "${tmp}" "${dest}"
+}
+
+refresh_sidecar() {
+  local src="$1"
+  local dest="$2"
+  say "refreshing bundled sidecar -> ${dest}"
+  mkdir -p "$(dirname "${dest}")"
+  local tmp="${dest}.new.$$"
+  cp "${src}" "${tmp}"
+  chmod +x "${tmp}"
+  mv -f "${tmp}" "${dest}"
+}
+
+# ── 1. build ────────────────────────────────────────────────────────────────
+if [[ "${SKIP_BUILD}" -eq 0 ]]; then
+  say "building amuxd + teamclaw-introspect (${PROFILE}) from ${GIT_BRANCH}@${GIT_SHA}${GIT_DIRTY}"
+  RELEASE_FLAG=()
+  if [[ "${PROFILE}" == "release" ]]; then
+    RELEASE_FLAG=(--release)
+  fi
+  cargo build -p amuxd "${RELEASE_FLAG[@]}"
+  cargo build --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect "${RELEASE_FLAG[@]}"
+fi
+
+# ── 2. detect platform service manager ──────────────────────────────────────
+OS="$(uname -s)"
+UID_NUM="$(id -u)"
+
+service_running() {
+  case "${OS}" in
+    Darwin) launchctl print "gui/${UID_NUM}/${LABEL}" >/dev/null 2>&1 ;;
+    *)      systemctl --user is-active --quiet amuxd 2>/dev/null ;;
+  esac
+}
+
+stop_service() {
+  case "${OS}" in
+    Darwin) launchctl bootout "gui/${UID_NUM}/${LABEL}" 2>/dev/null || true ;;
+    Linux)  systemctl --user stop amuxd 2>/dev/null || true ;;
+  esac
+}
+
+start_service() {
+  case "${OS}" in
+    Darwin)
+      if [[ -f "${PLIST}" ]]; then
+        local i
+        for i in 1 2 3 4 5; do
+          if launchctl bootstrap "gui/${UID_NUM}" "${PLIST}" 2>/dev/null; then
+            return 0
+          fi
+          sleep 0.5
+        done
+        echo "warn: launchctl bootstrap did not succeed; try: launchctl bootstrap gui/${UID_NUM} ${PLIST}" >&2
+      else
+        say "no launchd plist yet — registering service via 'amuxd install-service'"
+        "${DEST_AMUXD}" install-service
+      fi
+      ;;
+    Linux)
+      systemctl --user restart amuxd 2>/dev/null \
+        || { say "no systemd unit yet — registering via 'amuxd install-service'"; "${DEST_AMUXD}" install-service; }
+      ;;
+    *) echo "warn: unknown OS '${OS}', binaries copied but service not reloaded" >&2 ;;
+  esac
+}
+
+# ── 3. stop, replace binaries, reload ───────────────────────────────────────
+WAS_RUNNING=0
+if service_running; then WAS_RUNNING=1; fi
+
+if [[ "${NO_RELOAD}" -eq 0 && "${WAS_RUNNING}" -eq 1 ]]; then
+  say "stopping ${LABEL}"
+  stop_service
+  for _ in $(seq 1 20); do service_running || break; sleep 0.25; done
+fi
+
+install_binary "${SRC_AMUXD}" "${DEST_AMUXD}"
+install_binary "${SRC_INTROSPECT}" "${DEST_INTROSPECT}"
+printf '%s  %s@%s%s  %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "${GIT_BRANCH}" "${GIT_SHA}" "${GIT_DIRTY}" "${PROFILE}" \
+  > "${BIN_DIR}/amuxd.deployed"
+
+if [[ "${NO_SIDECAR}" -eq 0 && -n "${TARGET}" ]]; then
+  refresh_sidecar "${SRC_AMUXD}" "${SIDECAR_AMUXD}"
+  refresh_sidecar "${SRC_INTROSPECT}" "${SIDECAR_INTROSPECT}"
+elif [[ "${NO_SIDECAR}" -eq 0 ]]; then
+  echo "warn: could not resolve host target (rustc missing?) — skipped sidecar refresh" >&2
+fi
+
+if [[ "${NO_RELOAD}" -eq 1 ]]; then
+  say "skipped service reload (--no-reload); restart it yourself to pick up the new binaries"
+else
+  say "reloading service"
+  start_service
+fi
+
+# ── 4. report ───────────────────────────────────────────────────────────────
+echo
+say "deployed amuxd + teamclaw-introspect  (${GIT_BRANCH}@${GIT_SHA}${GIT_DIRTY}, ${PROFILE})"
+for dest in "${DEST_AMUXD}" "${DEST_INTROSPECT}"; do
+  stat -f "  %N : %Sm  %z bytes" -t "%Y-%m-%d %H:%M:%S" "${dest}" 2>/dev/null \
+    || stat -c "  %n : %y  %s bytes" "${dest}" 2>/dev/null || true
+done
+if [[ "${NO_SIDECAR}" -eq 0 && -n "${TARGET}" ]]; then
+  echo "  sidecars: apps/desktop/binaries/{amuxd,teamclaw-introspect}-${TARGET}${SIDE_EXT}"
+fi
+if [[ "${NO_RELOAD}" -eq 0 && "${OS}" == "Darwin" ]]; then
+  PID="$(launchctl print "gui/${UID_NUM}/${LABEL}" 2>/dev/null | awk -F'= ' '/[^a-z]pid =/{print $2; exit}')"
+  echo "  service: ${LABEL}  pid=${PID:-<not running>}"
+  echo "  logs   : tail -f ${AMUXD_HOME}/amuxd.out.log"
+fi


### PR DESCRIPTION
## Summary

- Unify official TeamClaw Prod + Dev onto a single on-disk and localStorage namespace: `~/.teamclaw/`, `{workspace}/.teamclaw/teamclaw.json`, and `teamclaw-*` localStorage keys. White-label builds keep `~/.{shortName}` unchanged.
- Add lazy migration from legacy Dev paths (`~/.teamclawdev`, `.teamclawdev/`, `teamclawdev-*` localStorage) and align `teamclaw-runtime-env` secret lookup with the desktop secret store — fixes Team Shared env vars showing "Saved" while the Env Variables list reported missing local secrets on Dev builds.
- Set `build.config.dev.json` `shortName` to `teamclaw` so new Dev builds write to the canonical paths.
- Minor: hide duplicate OSS sync toolbar button when `FileBrowser` already receives `actionIcons`; add `scripts/deploy-daemon-binaries.sh` + `pnpm daemon:deploy` for local amuxd binary refresh.

## Test plan

- [ ] `cargo test -p teamclaw-runtime-env`
- [ ] `cargo test --lib env_vars::tests` (desktop)
- [ ] `pnpm typecheck`
- [ ] Fresh Dev build: save a Team Shared secret → Env Variables list shows decrypted team keys (no "本地密钥缺失")
- [ ] Existing install with `~/.teamclawdev` data: first launch migrates secrets/workspace config into `~/.teamclaw` / `.teamclaw/`
- [ ] localStorage prefs from `teamclawdev-*` keys migrate to `teamclaw-*` on app startup
- [ ] White-label build (if available): still uses `~/.{shortName}` and `{shortName}-*` keys


Made with [Cursor](https://cursor.com)