### PR TITLE
fix(team): activate the server-side org before entering a team

### DIFF
--- a/apps/desktop/src/local_cache/commands.rs
+++ b/apps/desktop/src/local_cache/commands.rs
@@ -66,13 +66,28 @@ async fn current_team(state: &LocalCacheState) -> Option<String> {
     state.current_team_id.read().await.clone()
 }
 
+/// Machine-readable prefix for a gate rejection. The frontend classifies on
+/// this token, so it must not drift; the parenthesised detail is for humans.
+pub(crate) const ERR_TEAM_GATE_MISMATCH: &str = "local_cache: team_gate_mismatch";
+/// A caller handed a team-scoped command an empty team id. That is a bug in
+/// the caller, not a gate rejection, and reporting it as one sent us chasing
+/// the wrong thing — keep it a separate code.
+pub(crate) const ERR_EMPTY_TEAM_ID: &str = "local_cache: empty_team_id";
+
+fn gate_mismatch(scope: &str, current: &str, found: &str) -> String {
+    format!(
+        "{} ({}: current={}, found={})",
+        ERR_TEAM_GATE_MISMATCH, scope, current, found
+    )
+}
+
 async fn assert_team(state: &LocalCacheState, team_id: &str) -> Result<(), String> {
+    if team_id.is_empty() {
+        return Err(format!("{} (requested)", ERR_EMPTY_TEAM_ID));
+    }
     if let Some(current) = current_team(state).await {
         if current != team_id {
-            return Err(format!(
-                "local_cache: team gate mismatch (current={}, requested={})",
-                current, team_id
-            ));
+            return Err(gate_mismatch("requested", &current, team_id));
         }
     }
     Ok(())
@@ -85,10 +100,7 @@ async fn assert_team_opt(state: &LocalCacheState, looked_up: Option<&str>) -> Re
     match looked_up {
         None => Ok(()),
         Some(t) if t == current => Ok(()),
-        Some(t) => Err(format!(
-            "local_cache: team gate mismatch (current={}, row_team={})",
-            current, t
-        )),
+        Some(t) => Err(gate_mismatch("row", &current, t)),
     }
 }
 
@@ -120,10 +132,7 @@ pub async fn local_cache_actor_upsert_batch(
 ) -> Result<(), String> {
     if let Some(current) = current_team(&state).await {
         if let Some(bad) = rows.iter().find(|r| r.team_id != current) {
-            return Err(format!(
-                "local_cache: team gate mismatch in actor batch (current={}, row_team={})",
-                current, bad.team_id
-            ));
+            return Err(gate_mismatch("actor", &current, bad.team_id.as_str()));
         }
     }
     let db = get_db(&state).await?;
@@ -180,10 +189,7 @@ pub async fn local_cache_session_upsert_batch(
 ) -> Result<(), String> {
     if let Some(current) = current_team(&state).await {
         if let Some(bad) = rows.iter().find(|r| r.team_id != current) {
-            return Err(format!(
-                "local_cache: team gate mismatch in session batch (current={}, row_team={})",
-                current, bad.team_id
-            ));
+            return Err(gate_mismatch("session", &current, bad.team_id.as_str()));
         }
     }
     let db = get_db(&state).await?;
@@ -223,9 +229,10 @@ pub async fn local_cache_session_workspace_upsert_batch(
 ) -> Result<(), String> {
     if let Some(current) = current_team(&state).await {
         if let Some(bad) = rows.iter().find(|r| r.team_id != current) {
-            return Err(format!(
-                "local_cache: team gate mismatch in session_workspace batch (current={}, row_team={})",
-                current, bad.team_id
+            return Err(gate_mismatch(
+                "session_workspace",
+                &current,
+                bad.team_id.as_str(),
             ));
         }
     }
@@ -259,10 +266,7 @@ pub async fn local_cache_session_participant_upsert_batch(
             if seen.insert(r.session_id.clone()) {
                 if let Some(owner) = db.team_for_session(&r.session_id).await? {
                     if owner != current {
-                        return Err(format!(
-                            "local_cache: team gate mismatch in participant batch (current={}, session_team={})",
-                            current, owner
-                        ));
+                        return Err(gate_mismatch("participant", &current, owner.as_str()));
                     }
                 }
             }
@@ -305,10 +309,7 @@ pub async fn local_cache_message_upsert_batch(
 ) -> Result<(), String> {
     if let Some(current) = current_team(&state).await {
         if let Some(bad) = rows.iter().find(|r| r.team_id != current) {
-            return Err(format!(
-                "local_cache: team gate mismatch in message batch (current={}, row_team={})",
-                current, bad.team_id
-            ));
+            return Err(gate_mismatch("message", &current, bad.team_id.as_str()));
         }
     }
     let db = get_db(&state).await?;
@@ -410,10 +411,7 @@ pub async fn local_cache_idea_upsert_batch(
 ) -> Result<(), String> {
     if let Some(current) = current_team(&state).await {
         if let Some(bad) = rows.iter().find(|r| r.team_id != current) {
-            return Err(format!(
-                "local_cache: team gate mismatch in idea batch (current={}, row_team={})",
-                current, bad.team_id
-            ));
+            return Err(gate_mismatch("idea", &current, bad.team_id.as_str()));
         }
     }
     let db = get_db(&state).await?;
@@ -458,10 +456,7 @@ pub async fn local_cache_claim_upsert_batch(
             if seen.insert(r.idea_id.clone()) {
                 if let Some(owner) = db.team_for_idea(&r.idea_id).await? {
                     if owner != current {
-                        return Err(format!(
-                            "local_cache: team gate mismatch in claim batch (current={}, idea_team={})",
-                            current, owner
-                        ));
+                        return Err(gate_mismatch("claim", &current, owner.as_str()));
                     }
                 }
             }
@@ -509,10 +504,7 @@ pub async fn local_cache_submission_upsert_batch(
             if seen.insert(r.idea_id.clone()) {
                 if let Some(owner) = db.team_for_idea(&r.idea_id).await? {
                     if owner != current {
-                        return Err(format!(
-                            "local_cache: team gate mismatch in submission batch (current={}, idea_team={})",
-                            current, owner
-                        ));
+                        return Err(gate_mismatch("submission", &current, owner.as_str()));
                     }
                 }
             }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2791,7 +2791,9 @@ function App() {
         }
         try {
           const claim = await claimInviteToken(token);
-          await useCurrentTeamStore.getState().reloadAndSwitchTo(claim.teamId);
+          // enterTeam, not reloadAndSwitchTo: the claim switched the org
+          // server-side but this client still holds the pre-claim JWT.
+          await useCurrentTeamStore.getState().enterTeam(claim.teamId);
           // Re-onboard the local daemon to the freshly-claimed team. The
           // daemon-onboarding store's refresh() detects the team mismatch and
           // the DaemonOnboardingWizard handles re-onboard. Best-effort only.
@@ -2841,7 +2843,8 @@ function App() {
           const teamId = session.team_id;
           const currentTeamId = useCurrentTeamStore.getState().team?.id ?? null;
           if (teamId && teamId !== currentTeamId) {
-            await useCurrentTeamStore.getState().reloadAndSwitchTo(teamId);
+            // The linked session can live in a team outside the active org.
+            await useCurrentTeamStore.getState().enterTeam(teamId);
           }
           await useUIStore.getState().switchToSession(sessionId);
           // Refresh the session list so the freshly-joined session appears in

--- a/packages/app/src/components/auth/AuthGate.tsx
+++ b/packages/app/src/components/auth/AuthGate.tsx
@@ -181,6 +181,27 @@ export function AuthGate({ children }: AuthGateProps) {
       void setLocalCacheTeamGate(snapshot.team.id);
       setBootstrap("ready");
       markStartup("team-bootstrap:end");
+      // The cached team is not proof that it is still inside the server-side
+      // active org: the user may have switched orgs elsewhere, or last entered
+      // this team through a path that never activated it. Restoring it blindly
+      // leaves the client pinned to a team every request will be refused for,
+      // and no later code path notices. Probe once in the background (RLS
+      // hides an out-of-org team, so this throws) and self-heal by activating.
+      // Off the critical path — first paint already happened.
+      void (async () => {
+        try {
+          await getBackend().teams.getTeam(snapshot.team!.id);
+        } catch (probeErr) {
+          console.warn("[AuthGate] cached team is outside the active org, re-activating", probeErr);
+          try {
+            await useCurrentTeamStore.getState().enterTeam(snapshot.team!.id);
+            const { useSessionListStore } = await import("@/stores/session-list-store");
+            await useSessionListStore.getState().load();
+          } catch (healErr) {
+            console.warn("[AuthGate] cached-team self-heal failed", healErr);
+          }
+        }
+      })();
       return;
     }
 

--- a/packages/app/src/components/auth/TeamPicker.tsx
+++ b/packages/app/src/components/auth/TeamPicker.tsx
@@ -69,6 +69,21 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
           {t("teamPicker.subtitle", "You belong to multiple teams. Pick one to continue.")}
         </p>
 
+        {/*
+          Strict single-org: entering a team moves the account's active org, and
+          teams in the other orgs become unreadable until you switch back. The
+          picker lists them all regardless (it is a cross-org listing), so
+          without this the choice looks free and is not.
+        */}
+        {groups.size > 1 && (
+          <p className="mt-2 text-[11.5px] leading-4 text-faint">
+            {t(
+              "teamPicker.singleOrgNotice",
+              "You can work in one organization at a time. Choosing a team here leaves the other organizations' teams inaccessible until you switch back.",
+            )}
+          </p>
+        )}
+
         {error && (
           <p
             role="alert"

--- a/packages/app/src/components/auth/UpgradeToOrgDialog.tsx
+++ b/packages/app/src/components/auth/UpgradeToOrgDialog.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { getBackend } from "@/lib/backend";
-import { adoptRefreshToken } from "@/lib/auth";
 import { useCurrentTeamStore } from "@/stores/current-team";
 
 interface Props {
@@ -59,9 +58,7 @@ export function UpgradeToOrgDialog({ open, onOpenChange }: Props) {
       // The team was reparented to the new org and renamed, and the account's
       // org claim changed — mint a fresh session for the team so the new org_id
       // takes effect, then reload the (renamed) team into the store.
-      const act = await getBackend().teams.activateTeam(teamId);
-      if (act.refreshToken) await adoptRefreshToken(act.refreshToken);
-      await useCurrentTeamStore.getState().reloadAndSwitchTo(teamId);
+      await useCurrentTeamStore.getState().enterTeam(teamId);
       onOpenChange(false);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));

--- a/packages/app/src/components/auth/__tests__/TeamPicker.test.tsx
+++ b/packages/app/src/components/auth/__tests__/TeamPicker.test.tsx
@@ -43,4 +43,22 @@ describe("TeamPicker", () => {
     render(<TeamPicker teams={teams} onDone={() => {}} />);
     expect(screen.queryByText("最后使用")).not.toBeInTheDocument();
   });
+
+  // Strict single-org: entering a team moves the account's active org, so the
+  // other orgs' teams stop being readable. The picker lists them all anyway,
+  // which makes the choice look free — say so when it isn't.
+  it("warns that only one organization is usable at a time when orgs span more than one", () => {
+    render(<TeamPicker teams={teams} onDone={() => {}} />);
+    expect(screen.getByText(/同一时间只能在一个组织内工作/)).toBeInTheDocument();
+  });
+
+  it("omits the single-org warning when every team is in one org", () => {
+    const sameOrg = [
+      { id: "t1", name: "Alpha", slug: "alpha", orgId: "o1", orgName: "Org One" },
+      { id: "t3", name: "Gamma", slug: "gamma", orgId: "o1", orgName: "Org One" },
+    ];
+    render(<TeamPicker teams={sameOrg} onDone={() => {}} />);
+    expect(screen.queryByText(/同一时间只能在一个组织内工作/)).not.toBeInTheDocument();
+  });
+
 });

--- a/packages/app/src/lib/__tests__/local-cache-team-id-guard.test.ts
+++ b/packages/app/src/lib/__tests__/local-cache-team-id-guard.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  reportLocalCacheEmptyTeamId: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mocks.invoke(...args),
+}))
+
+vi.mock('@/lib/utils', () => ({ isTauri: () => true }))
+vi.mock('@/lib/platform', () => ({ isChromeExtension: () => false }))
+
+vi.mock('@/lib/telemetry/local-cache-error-report', () => ({
+  reportLocalCacheEmptyTeamId: (...args: unknown[]) => mocks.reportLocalCacheEmptyTeamId(...args),
+}))
+
+import {
+  loadActorsForTeam,
+  loadIdeasForTeam,
+  loadSessionWorkspacesForTeam,
+  loadSessionsForTeam,
+} from '@/lib/local-cache'
+
+beforeEach(() => {
+  mocks.invoke.mockReset().mockResolvedValue([])
+  mocks.reportLocalCacheEmptyTeamId.mockReset()
+})
+
+/**
+ * A blank team id used to reach the Rust gate and come back as a *gate
+ * mismatch* with an empty `requested=`, which reads like the team state
+ * diverged when the caller simply had no team yet. Stop it at the boundary.
+ */
+describe('team-scoped loaders reject a blank team id', () => {
+  const cases: Array<[string, (teamId: string) => Promise<unknown[]>]> = [
+    ['actor_load_team', (id) => loadActorsForTeam(id)],
+    ['session_load_team', (id) => loadSessionsForTeam(id)],
+    ['idea_load_team', (id) => loadIdeasForTeam(id)],
+    ['session_workspace_load_team', (id) => loadSessionWorkspacesForTeam(id, 'member-1')],
+  ]
+
+  for (const [command, call] of cases) {
+    it(`${command}: returns empty and reports instead of invoking`, async () => {
+      await expect(call('')).resolves.toEqual([])
+      await expect(call('   ')).resolves.toEqual([])
+      expect(mocks.invoke).not.toHaveBeenCalled()
+      expect(mocks.reportLocalCacheEmptyTeamId).toHaveBeenCalledWith(command)
+    })
+  }
+
+  it('still invokes for a real team id', async () => {
+    await loadSessionsForTeam('team-1')
+    expect(mocks.invoke).toHaveBeenCalledWith('local_cache_session_load_team', {
+      teamId: 'team-1',
+      includeDeleted: false,
+    })
+    expect(mocks.reportLocalCacheEmptyTeamId).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/lib/cron-session-messages.ts
+++ b/packages/app/src/lib/cron-session-messages.ts
@@ -32,7 +32,7 @@ export async function ensureCronSessionVisible(sessionId: string): Promise<void>
   // Switch teams if needed
   const activeTeamId = useCurrentTeamStore.getState().team?.id ?? null;
   if (activeTeamId !== teamId) {
-    await useCurrentTeamStore.getState().reloadAndSwitchTo(teamId);
+    await useCurrentTeamStore.getState().enterTeam(teamId);
   }
 
   // Skip upsert if already in list (may have been added by a previous call)

--- a/packages/app/src/lib/local-cache.ts
+++ b/packages/app/src/lib/local-cache.ts
@@ -1,6 +1,21 @@
 import { invoke } from "@tauri-apps/api/core";
 import { isChromeExtension } from "@/lib/platform";
 import { isTauri } from "@/lib/utils";
+import { reportLocalCacheEmptyTeamId } from "@/lib/telemetry/local-cache-error-report";
+
+/**
+ * Team-scoped loaders must never be called with a blank team id.
+ *
+ * Doing so used to reach the Rust gate and come back as a *gate mismatch*
+ * ("requested=" with nothing after it), which reads like the team state
+ * diverged when in fact the caller simply had no team yet. Catch it here,
+ * return empty, and report with a stack so the caller can be found.
+ */
+function hasTeamId(command: string, teamId: string | null | undefined): teamId is string {
+  if (teamId && teamId.trim()) return true;
+  reportLocalCacheEmptyTeamId(command);
+  return false;
+}
 
 // ── team gate ──────────────────────────────────────────────────────────────
 
@@ -193,6 +208,7 @@ export async function loadActorsForTeam(
   includeDeleted = false,
 ): Promise<ActorRow[]> {
   if (!isTauri()) return [];
+  if (!hasTeamId("actor_load_team", teamId)) return [];
   return invoke("local_cache_actor_load_team", { teamId, includeDeleted });
 }
 
@@ -221,6 +237,7 @@ export async function loadSessionsForTeam(
   includeDeleted = false,
 ): Promise<SessionRow[]> {
   if (!isTauri()) return [];
+  if (!hasTeamId("session_load_team", teamId)) return [];
   return invoke("local_cache_session_load_team", { teamId, includeDeleted });
 }
 
@@ -244,6 +261,7 @@ export async function loadSessionWorkspacesForTeam(
   viewerMemberId: string,
 ): Promise<SessionWorkspaceRow[]> {
   if (!isTauri() || !viewerMemberId.trim()) return [];
+  if (!hasTeamId("session_workspace_load_team", teamId)) return [];
   return invoke("local_cache_session_workspace_load_team", {
     teamId,
     viewerMemberId,
@@ -395,6 +413,7 @@ export async function loadIdeasForTeam(
   includeDeleted = false,
 ): Promise<IdeaRow[]> {
   if (!isTauri()) return [];
+  if (!hasTeamId("idea_load_team", teamId)) return [];
   return invoke("local_cache_idea_load_team", { teamId, includeDeleted });
 }
 

--- a/packages/app/src/lib/teamclaw/ensure-agent-runtime.ts
+++ b/packages/app/src/lib/teamclaw/ensure-agent-runtime.ts
@@ -24,6 +24,12 @@ import {
   RUNTIME_START_RPC_TIMEOUT_MS,
 } from "@/lib/teamclaw/runtime-rpc-timeouts";
 import { sessionFlowError, sessionFlowLog } from "@/lib/session-flow-log";
+import {
+  reportRuntimeEnsureCrash,
+  reportRuntimeRpcNotReady,
+  reportRuntimeStartFailure,
+  type RuntimeErrorContext,
+} from "@/lib/telemetry/runtime-error-report";
 import { useWorkspaceStore } from "@/stores/workspace";
 import { useMqttReconnectStore } from "@/stores/mqtt-reconnect";
 
@@ -78,8 +84,14 @@ function failureDescription(failure: RuntimeStartFailure): string {
   }
 }
 
-function notifyRuntimeStartFailures(failures: RuntimeStartFailure[]): void {
+function notifyRuntimeStartFailures(
+  failures: RuntimeStartFailure[],
+  context: RuntimeErrorContext = {},
+): void {
   if (failures.length === 0) return;
+  for (const failure of failures) {
+    reportRuntimeStartFailure(failure, context);
+  }
   void import("sonner").then(({ toast }) => {
     for (const failure of failures) {
       toast.error(i18n.t("daemon.agentRuntime.notStartedTitle"), {
@@ -150,6 +162,22 @@ export type EnsureRuntimeThenSetModelArgs = {
  * across daemon restarts while the UI still looks "ready".
  */
 export async function ensureRuntimeThenSetModel(
+  args: EnsureRuntimeThenSetModelArgs,
+): Promise<{ runtimeId: string }> {
+  try {
+    return await runEnsureRuntimeThenSetModel(args);
+  } catch (error) {
+    reportRuntimeEnsureCrash(error, {
+      sessionId: args.sessionId,
+      teamId: args.teamId,
+      agentActorId: args.agentActorId,
+      trigger: "set_model",
+    });
+    throw error;
+  }
+}
+
+async function runEnsureRuntimeThenSetModel(
   args: EnsureRuntimeThenSetModelArgs,
 ): Promise<{ runtimeId: string }> {
   const agentActorId = args.agentActorId.trim();
@@ -305,6 +333,12 @@ export async function ensureAgentRuntimesForSession(args: EnsureAgentRuntimeArgs
   const existing = inFlight.get(key);
   if (existing) return existing.promise;
 
+  const errorContext: RuntimeErrorContext = {
+    sessionId: args.sessionId,
+    teamId: args.teamId,
+    trigger: reason,
+  };
+
   const work = (async () => {
     logDebug(
       "client:ensure_runtime_begin",
@@ -320,7 +354,7 @@ export async function ensureAgentRuntimesForSession(args: EnsureAgentRuntimeArgs
           code: "transport_offline" as RuntimeStartFailureCode,
           reason: "mqtt disconnected",
         }));
-        notifyRuntimeStartFailures(transportFailures);
+        notifyRuntimeStartFailures(transportFailures, errorContext);
         logDebug("client:transport_offline", { mqttConnected }, { sessionId: args.sessionId });
         return;
       }
@@ -335,6 +369,7 @@ export async function ensureAgentRuntimesForSession(args: EnsureAgentRuntimeArgs
     const rpcReady = await waitForTeamclawRpcReady(20_000);
     if (!rpcReady) {
       logDebug("client:rpc_not_ready", { waitedMs: 20_000 }, { sessionId: args.sessionId });
+      reportRuntimeRpcNotReady(20_000, errorContext);
       void import("sonner").then(({ toast }) => {
         toast.error(i18n.t("daemon.agentRuntime.rpcNotReadyTitle"), {
           description: i18n.t("daemon.agentRuntime.rpcNotReadyDesc"),
@@ -345,7 +380,7 @@ export async function ensureAgentRuntimesForSession(args: EnsureAgentRuntimeArgs
 
     const { eligible, failures: gateFailures } = await gateAgentsForRuntimeStart(agentActorIds);
     if (gateFailures.length > 0) {
-      notifyRuntimeStartFailures(gateFailures);
+      notifyRuntimeStartFailures(gateFailures, errorContext);
     }
     if (eligible.length === 0) {
       logDebug("client:ensure_runtime_all_gated", { gateFailures }, { sessionId: args.sessionId });
@@ -421,7 +456,7 @@ export async function ensureAgentRuntimesForSession(args: EnsureAgentRuntimeArgs
       rpcTimeoutMs: RUNTIME_START_RPC_TIMEOUT_MS,
       suppressWorkspaceToast: true,
     });
-    notifyRuntimeStartFailures(runtimeFailures);
+    notifyRuntimeStartFailures(runtimeFailures, errorContext);
 
     const retainDeadline = Date.now() + 12_000;
     while (Date.now() < retainDeadline) {
@@ -459,6 +494,7 @@ export async function ensureAgentRuntimesForSession(args: EnsureAgentRuntimeArgs
     );
   })().catch((error) => {
     sessionFlowError("ensure_agent_runtime.failed", error, args);
+    reportRuntimeEnsureCrash(error, errorContext);
     logDebug("client:ensure_runtime_failed", { error: String(error) }, { sessionId: args.sessionId });
     void import("sonner").then(({ toast }) => {
       toast.error(i18n.t("daemon.agentRuntime.startFailedTitle"), {

--- a/packages/app/src/lib/telemetry/__tests__/local-cache-error-report.test.ts
+++ b/packages/app/src/lib/telemetry/__tests__/local-cache-error-report.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+  setLocalCacheTeamGate: vi.fn(),
+  currentTeam: { id: 'team-1' } as { id: string } | null,
+}))
+
+vi.mock('@sentry/react', () => ({
+  captureMessage: (...args: unknown[]) => mocks.captureMessage(...args),
+  captureException: (...args: unknown[]) => mocks.captureException(...args),
+}))
+
+vi.mock('@/stores/current-team', () => ({
+  useCurrentTeamStore: { getState: () => ({ team: mocks.currentTeam }) },
+  setLocalCacheTeamGate: (...args: unknown[]) => mocks.setLocalCacheTeamGate(...args),
+}))
+
+import {
+  __resetSentryModuleForTest,
+  __resetTelemetryThrottleForTest,
+} from '@/lib/telemetry/capture'
+import {
+  classifyLocalCacheFailure,
+  reportLocalCacheEmptyTeamId,
+  reportLocalCacheFailure,
+} from '@/lib/telemetry/local-cache-error-report'
+
+async function flush(): Promise<void> {
+  await import('@sentry/react')
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+beforeEach(() => {
+  __resetTelemetryThrottleForTest()
+  __resetSentryModuleForTest()
+  mocks.captureMessage.mockClear()
+  mocks.setLocalCacheTeamGate.mockClear()
+  mocks.currentTeam = { id: 'team-1' }
+})
+
+describe('classifyLocalCacheFailure', () => {
+  it('matches the codes emitted by local_cache/commands.rs', () => {
+    expect(
+      classifyLocalCacheFailure(
+        'local_cache: team_gate_mismatch (session: current=team-2, found=team-1)',
+      ),
+    ).toBe('team_gate_mismatch')
+    expect(classifyLocalCacheFailure('local_cache: empty_team_id (requested)')).toBe(
+      'empty_team_id',
+    )
+    expect(classifyLocalCacheFailure('db is locked')).toBe('unknown')
+    expect(classifyLocalCacheFailure(undefined)).toBe('unknown')
+  })
+
+  it('does not confuse the empty-team-id code with a real gate mismatch', () => {
+    // These used to arrive as the same prose string, which sent the
+    // investigation after a team-state divergence that was not happening.
+    const gate = classifyLocalCacheFailure('local_cache: team_gate_mismatch (row: ...)')
+    const empty = classifyLocalCacheFailure('local_cache: empty_team_id (requested)')
+    expect(gate).not.toBe(empty)
+  })
+})
+
+describe('reportLocalCacheFailure', () => {
+  it('reports at warning level with ids kept out of the message', async () => {
+    const error = new Error(
+      'local_cache: team_gate_mismatch (session: current=team-2, found=team-1)',
+    )
+    reportLocalCacheFailure('session_load_team', error, { teamId: 'team-1' })
+    await flush()
+
+    const [message, options] = mocks.captureMessage.mock.calls[0] as [
+      string,
+      Record<string, never>,
+    ]
+    expect(message).toBe('local_cache_failed: session_load_team (team_gate_mismatch)')
+    expect(message).not.toContain('team-1')
+    expect(options).toMatchObject({
+      level: 'warning',
+      fingerprint: ['local_cache', 'session_load_team', 'team_gate_mismatch'],
+      extra: { teamId: 'team-1' },
+    })
+  })
+
+  it('re-pins the local-cache gate to the current team after a mismatch', async () => {
+    reportLocalCacheFailure('session_load_team', new Error('local_cache: team_gate_mismatch (x)'))
+    await flush()
+    expect(mocks.setLocalCacheTeamGate).toHaveBeenCalledWith('team-1')
+  })
+
+  it('does not touch the gate for unrelated failures', async () => {
+    reportLocalCacheFailure('session_load_team', new Error('db is locked'))
+    await flush()
+    expect(mocks.setLocalCacheTeamGate).not.toHaveBeenCalled()
+  })
+
+  it('throttles repeats of the same (command, kind)', async () => {
+    const error = new Error('local_cache: team_gate_mismatch (x)')
+    reportLocalCacheFailure('session_load_team', error)
+    reportLocalCacheFailure('session_load_team', error)
+    await flush()
+    expect(mocks.captureMessage).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('reportLocalCacheEmptyTeamId', () => {
+  it('captures the call site, which is the only clue to the offending caller', async () => {
+    reportLocalCacheEmptyTeamId('session_load_team')
+    await flush()
+
+    const [message, options] = mocks.captureMessage.mock.calls[0] as [
+      string,
+      { extra: { callSite: string }; fingerprint: string[] },
+    ]
+    expect(message).toBe('local_cache_empty_team_id: session_load_team')
+    expect(options.fingerprint).toEqual(['local_cache', 'session_load_team', 'empty_team_id'])
+    expect(options.extra.callSite).toContain('local_cache empty team id')
+  })
+})

--- a/packages/app/src/lib/telemetry/__tests__/runtime-error-report.test.ts
+++ b/packages/app/src/lib/telemetry/__tests__/runtime-error-report.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+vi.mock('@sentry/react', () => ({
+  captureMessage: (...args: unknown[]) => mocks.captureMessage(...args),
+  captureException: (...args: unknown[]) => mocks.captureException(...args),
+}))
+
+import {
+  __resetRuntimeErrorReportThrottleForTest,
+  __resetSentryModuleForTest,
+  classifyRuntimeFailureReason,
+  reportRuntimeEnsureCrash,
+  reportRuntimeRpcNotReady,
+  reportRuntimeStartFailure,
+} from '@/lib/telemetry/runtime-error-report'
+
+/** The capture path is a dynamic import — let it resolve before asserting. */
+async function flush(): Promise<void> {
+  await import('@sentry/react')
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+let now = 1_700_000_000_000
+
+beforeEach(() => {
+  __resetRuntimeErrorReportThrottleForTest()
+  __resetSentryModuleForTest()
+  mocks.captureMessage.mockClear()
+  mocks.captureException.mockClear()
+  now = 1_700_000_000_000
+  vi.spyOn(Date, 'now').mockImplementation(() => now)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('classifyRuntimeFailureReason', () => {
+  it('separates the timeouts that all arrive as runtime_rpc_failed', () => {
+    expect(classifyRuntimeFailureReason('rpc timeout after 20000ms')).toBe('rpc_timeout')
+    expect(classifyRuntimeFailureReason('local rpc timeout after 10000ms')).toBe(
+      'local_rpc_timeout',
+    )
+    expect(classifyRuntimeFailureReason('teamclaw-rpc not initialized')).toBe(
+      'rpc_not_initialized',
+    )
+    expect(classifyRuntimeFailureReason('teamclaw-rpc: targetActorId required')).toBe(
+      'rpc_not_initialized',
+    )
+    expect(classifyRuntimeFailureReason('mqtt disconnected')).toBe('mqtt_disconnected')
+    expect(classifyRuntimeFailureReason('device offline')).toBe('device_offline')
+    expect(classifyRuntimeFailureReason('runtimeStart rejected')).toBe('daemon_rejected')
+    expect(classifyRuntimeFailureReason('')).toBe('unknown')
+    expect(classifyRuntimeFailureReason(undefined)).toBe('unknown')
+  })
+})
+
+describe('reportRuntimeStartFailure', () => {
+  it('keeps ids out of the message and fingerprints on (kind, code, reasonKind)', async () => {
+    reportRuntimeStartFailure(
+      {
+        agentActorId: '8e822115-2e7c-4f92-97fe-a49b24f53a15',
+        code: 'runtime_rpc_failed',
+        reason: 'rpc timeout after 20000ms',
+      },
+      { sessionId: 'sess-1', teamId: 'team-1', trigger: 'send' },
+    )
+    await flush()
+
+    expect(mocks.captureMessage).toHaveBeenCalledTimes(1)
+    const [message, options] = mocks.captureMessage.mock.calls[0] as [
+      string,
+      Record<string, never>,
+    ]
+    expect(message).toBe('runtime_start_failure: runtime_rpc_failed')
+    expect(message).not.toContain('8e822115')
+    expect(message).not.toContain('20000')
+    expect(options).toMatchObject({
+      level: 'error',
+      fingerprint: ['runtime', 'runtime_start_failure', 'runtime_rpc_failed', 'rpc_timeout'],
+      tags: {
+        runtime_error_kind: 'runtime_start_failure',
+        runtime_failure_code: 'runtime_rpc_failed',
+        runtime_failure_reason_kind: 'rpc_timeout',
+      },
+      extra: {
+        reason: 'rpc timeout after 20000ms',
+        sessionId: 'sess-1',
+        teamId: 'team-1',
+        agentActorId: '8e822115-2e7c-4f92-97fe-a49b24f53a15',
+        trigger: 'send',
+      },
+    })
+  })
+
+  it('downgrades expected offline states to warning', async () => {
+    reportRuntimeStartFailure({
+      agentActorId: 'agent-1',
+      code: 'device_offline',
+      reason: 'device offline',
+    })
+    reportRuntimeStartFailure({
+      agentActorId: 'agent-2',
+      code: 'transport_offline',
+      reason: 'mqtt disconnected',
+    })
+    await flush()
+
+    expect(mocks.captureMessage).toHaveBeenCalledTimes(2)
+    for (const call of mocks.captureMessage.mock.calls) {
+      expect((call[1] as { level: string }).level).toBe('warning')
+    }
+  })
+
+  it('throttles the same (code, agent) within the window but not after it', async () => {
+    const failure = {
+      agentActorId: 'agent-1',
+      code: 'device_offline' as const,
+      reason: 'device offline',
+    }
+    reportRuntimeStartFailure(failure)
+    reportRuntimeStartFailure(failure)
+    reportRuntimeStartFailure(failure)
+    await flush()
+    expect(mocks.captureMessage).toHaveBeenCalledTimes(1)
+
+    now += 60_001
+    reportRuntimeStartFailure(failure)
+    await flush()
+    expect(mocks.captureMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not throttle a different agent with the same code', async () => {
+    reportRuntimeStartFailure({
+      agentActorId: 'agent-1',
+      code: 'device_offline',
+      reason: 'device offline',
+    })
+    reportRuntimeStartFailure({
+      agentActorId: 'agent-2',
+      code: 'device_offline',
+      reason: 'device offline',
+    })
+    await flush()
+    expect(mocks.captureMessage).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('reportRuntimeRpcNotReady', () => {
+  it('reports once per session within the window', async () => {
+    reportRuntimeRpcNotReady(20_000, { sessionId: 'sess-1' })
+    reportRuntimeRpcNotReady(20_000, { sessionId: 'sess-1' })
+    reportRuntimeRpcNotReady(20_000, { sessionId: 'sess-2' })
+    await flush()
+
+    expect(mocks.captureMessage).toHaveBeenCalledTimes(2)
+    expect(mocks.captureMessage.mock.calls[0]?.[0]).toBe('rpc_not_ready: unknown')
+  })
+})
+
+describe('reportRuntimeEnsureCrash', () => {
+  it('captures the exception with the runtime fingerprint', async () => {
+    const error = new Error('rpc timeout after 20000ms')
+    reportRuntimeEnsureCrash(error, { sessionId: 'sess-1', trigger: 'set_model' })
+    await flush()
+
+    expect(mocks.captureException).toHaveBeenCalledTimes(1)
+    const [captured, options] = mocks.captureException.mock.calls[0] as [
+      Error,
+      Record<string, never>,
+    ]
+    expect(captured).toBe(error)
+    expect(options).toMatchObject({
+      level: 'error',
+      fingerprint: ['runtime', 'ensure_runtime_crash', 'none', 'rpc_timeout'],
+      tags: { runtime_failure_reason_kind: 'rpc_timeout' },
+    })
+  })
+
+  it('separates crashes by trigger so set_model is not swallowed by ensure', async () => {
+    const error = new Error('rpc timeout after 20000ms')
+    reportRuntimeEnsureCrash(error, { sessionId: 'sess-1', trigger: 'send' })
+    reportRuntimeEnsureCrash(error, { sessionId: 'sess-1', trigger: 'set_model' })
+    await flush()
+
+    expect(mocks.captureException).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/app/src/lib/telemetry/capture.ts
+++ b/packages/app/src/lib/telemetry/capture.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared Sentry plumbing for the telemetry reporters in this directory.
+ *
+ * Grouping rule every reporter must follow: never interpolate ids, durations,
+ * or raw reasons into `message`. Sentry fingerprints on message text, and
+ * embedded UUIDs shatter one problem into dozens of issues — the
+ * `team gate mismatch` reports fragmented into four separate issues exactly
+ * that way. Ids belong in tags/extra with an explicit `fingerprint`.
+ */
+
+export type TelemetryLevel = 'warning' | 'error'
+
+export type TelemetryCaptureArgs = {
+  /** Stable across occurrences — no ids, no numbers. */
+  message: string
+  level: TelemetryLevel
+  tags: Record<string, string>
+  extra: Record<string, unknown>
+  fingerprint: string[]
+  /** When present, captured as an exception instead of a message. */
+  error?: unknown
+}
+
+/**
+ * One shared import for every capture. Kept lazy so hot paths do not pull
+ * Sentry in eagerly, and memoized so a burst of reports in the same tick
+ * resolves against a single module promise (concurrent dynamic imports of the
+ * same module do not reliably settle).
+ */
+let sentryModule: Promise<typeof import('@sentry/react')> | null = null
+
+export function loadSentry(): Promise<typeof import('@sentry/react')> {
+  sentryModule ??= import('@sentry/react')
+  return sentryModule
+}
+
+/** @internal test hook */
+export function __resetSentryModuleForTest(): void {
+  sentryModule = null
+}
+
+const lastReportedAt = new Map<string, number>()
+
+/**
+ * True when `key` has not been reported inside `windowMs`. Reporters that sit
+ * on retry/wake loops must throttle, or one persistent fault produces hundreds
+ * of identical events.
+ */
+export function shouldReportThrottled(key: string, windowMs: number): boolean {
+  const now = Date.now()
+  const previous = lastReportedAt.get(key)
+  if (previous !== undefined && now - previous < windowMs) return false
+  lastReportedAt.set(key, now)
+  return true
+}
+
+/** @internal test hook */
+export function __resetTelemetryThrottleForTest(): void {
+  lastReportedAt.clear()
+}
+
+export function truncateForExtra(value: string | undefined, maxLength = 300): string {
+  const trimmed = (value ?? '').trim()
+  return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength)}…` : trimmed
+}
+
+export function captureTelemetry({
+  message,
+  level,
+  tags,
+  extra,
+  fingerprint,
+  error,
+}: TelemetryCaptureArgs): void {
+  void loadSentry()
+    .then((Sentry) => {
+      if (error !== undefined) {
+        Sentry.captureException(error, { level, tags, extra, fingerprint })
+        return
+      }
+      Sentry.captureMessage(message, { level, tags, extra, fingerprint })
+    })
+    .catch(() => {
+      // Telemetry must never break the path it observes.
+    })
+}

--- a/packages/app/src/lib/telemetry/local-cache-error-report.ts
+++ b/packages/app/src/lib/telemetry/local-cache-error-report.ts
@@ -1,0 +1,67 @@
+import {
+  captureTelemetry,
+  shouldReportThrottled,
+  truncateForExtra,
+} from '@/lib/telemetry/capture'
+
+/**
+ * Sentry reporting for the libsql local-cache layer.
+ *
+ * The cache is a best-effort accelerator: every read/write here is allowed to
+ * fail without blocking the cloud-backed render path. That makes silent
+ * swallowing tempting and wrong — a persistent `team gate mismatch` is a real
+ * defect that has to stay visible. Report it, then carry on.
+ */
+
+export type LocalCacheFailureKind =
+  /** Current-team gate rejected the row/team the caller asked for. */
+  | 'team_gate_mismatch'
+  /** The caller passed an empty team id — a bug in the caller, not the gate. */
+  | 'empty_team_id'
+  /** Anything else (db open failure, serialization, ...). */
+  | 'unknown'
+
+const THROTTLE_WINDOW_MS = 60_000
+
+export function classifyLocalCacheFailure(reason: string | undefined): LocalCacheFailureKind {
+  const lower = (reason ?? '').trim().toLowerCase()
+  if (!lower) return 'unknown'
+  if (lower.includes('team gate mismatch')) {
+    // `requested=` / `row_team=` with nothing after it means the caller handed
+    // the command an empty team id; that is a different bug from a real gate
+    // mismatch and must not share a fingerprint with it.
+    return /(requested|row_team|session_team|idea_team)=\s*\)/.test(lower)
+      ? 'empty_team_id'
+      : 'team_gate_mismatch'
+  }
+  return 'unknown'
+}
+
+/**
+ * Report a local-cache failure. Throttled per (command, kind) so a team that
+ * stays mismatched cannot produce hundreds of identical events — the previous
+ * unhandled-rejection path did exactly that.
+ */
+export function reportLocalCacheFailure(
+  command: string,
+  error: unknown,
+  context: { teamId?: string | null; sessionId?: string | null } = {},
+): void {
+  const reason = error instanceof Error ? error.message : String(error)
+  const kind = classifyLocalCacheFailure(reason)
+  if (!shouldReportThrottled(`local_cache|${command}|${kind}`, THROTTLE_WINDOW_MS)) return
+
+  captureTelemetry({
+    message: `local_cache_failed: ${command} (${kind})`,
+    // The cache failing degrades performance, not correctness — the caller is
+    // required to carry on without it. Warning, not error.
+    level: 'warning',
+    fingerprint: ['local_cache', command, kind],
+    tags: { local_cache_command: command, local_cache_failure_kind: kind },
+    extra: {
+      reason: truncateForExtra(reason),
+      teamId: context.teamId ?? null,
+      sessionId: context.sessionId ?? null,
+    },
+  })
+}

--- a/packages/app/src/lib/telemetry/local-cache-error-report.ts
+++ b/packages/app/src/lib/telemetry/local-cache-error-report.ts
@@ -23,17 +23,18 @@ export type LocalCacheFailureKind =
 
 const THROTTLE_WINDOW_MS = 60_000
 
+/**
+ * Codes emitted by `apps/desktop/src/local_cache/commands.rs`. Matched as
+ * stable tokens rather than prose so the two sides can't drift apart silently.
+ */
+const ERR_TEAM_GATE_MISMATCH = 'local_cache: team_gate_mismatch'
+const ERR_EMPTY_TEAM_ID = 'local_cache: empty_team_id'
+
 export function classifyLocalCacheFailure(reason: string | undefined): LocalCacheFailureKind {
-  const lower = (reason ?? '').trim().toLowerCase()
-  if (!lower) return 'unknown'
-  if (lower.includes('team gate mismatch')) {
-    // `requested=` / `row_team=` with nothing after it means the caller handed
-    // the command an empty team id; that is a different bug from a real gate
-    // mismatch and must not share a fingerprint with it.
-    return /(requested|row_team|session_team|idea_team)=\s*\)/.test(lower)
-      ? 'empty_team_id'
-      : 'team_gate_mismatch'
-  }
+  const text = (reason ?? '').trim()
+  if (!text) return 'unknown'
+  if (text.includes(ERR_EMPTY_TEAM_ID)) return 'empty_team_id'
+  if (text.includes(ERR_TEAM_GATE_MISMATCH)) return 'team_gate_mismatch'
   return 'unknown'
 }
 
@@ -64,4 +65,42 @@ export function reportLocalCacheFailure(
       sessionId: context.sessionId ?? null,
     },
   })
+
+  if (kind === 'team_gate_mismatch') void repairTeamGate()
+}
+
+/**
+ * A team-scoped cache call was made with no team id. The command never runs,
+ * so there is no error to attach — capture the call site instead, which is the
+ * only thing that identifies the offending caller.
+ */
+export function reportLocalCacheEmptyTeamId(command: string): void {
+  if (!shouldReportThrottled(`local_cache_empty_team|${command}`, THROTTLE_WINDOW_MS)) return
+  captureTelemetry({
+    message: `local_cache_empty_team_id: ${command}`,
+    level: 'warning',
+    fingerprint: ['local_cache', command, 'empty_team_id'],
+    tags: { local_cache_command: command, local_cache_failure_kind: 'empty_team_id' },
+    extra: { callSite: truncateForExtra(new Error('local_cache empty team id').stack, 2000) },
+  })
+}
+
+/**
+ * A gate mismatch means the backend gate and the team the UI is working on
+ * have diverged — the gate was moved (team switch, `load()` resolving a
+ * different team) while this caller still held the old one.
+ *
+ * Re-pinning the gate to the current team is cheap, idempotent, and local: it
+ * does not touch the server-side active org, so it cannot fight `enterTeam`.
+ * Without it the divergence persists for the rest of the session and every
+ * subsequent cache call fails the same way.
+ */
+async function repairTeamGate(): Promise<void> {
+  try {
+    const { useCurrentTeamStore, setLocalCacheTeamGate } = await import('@/stores/current-team')
+    const teamId = useCurrentTeamStore.getState().team?.id ?? null
+    if (teamId) await setLocalCacheTeamGate(teamId)
+  } catch {
+    // Best-effort repair; the caller has already degraded gracefully.
+  }
 }

--- a/packages/app/src/lib/telemetry/runtime-error-report.ts
+++ b/packages/app/src/lib/telemetry/runtime-error-report.ts
@@ -1,0 +1,197 @@
+import type { RuntimeStartFailure, RuntimeStartFailureCode } from '@/lib/session-create'
+
+/**
+ * Sentry reporting for the agent-runtime startup path.
+ *
+ * These failures only ever surfaced as toasts, so their real-world frequency
+ * was invisible — Sentry held zero events for `rpc timeout` or `runtimeStart`
+ * even though the toasts fire regularly.
+ *
+ * Grouping rule: never interpolate ids, durations, or raw reasons into the
+ * captured message. Sentry fingerprints on message text, and embedded UUIDs
+ * shatter one problem into dozens of issues (see the `team gate mismatch`
+ * issues, which fragmented exactly that way). Ids go in tags/extra; the
+ * fingerprint is (kind, code, reasonKind).
+ */
+
+export type RuntimeErrorKind =
+  /** A per-agent failure from the runtimeStart fanout or its gates. */
+  | 'runtime_start_failure'
+  /** MQTT/RPC never became ready, so runtimeStart was never attempted. */
+  | 'rpc_not_ready'
+  /** The ensure-runtime batch itself threw. */
+  | 'ensure_runtime_crash'
+
+/**
+ * Sub-classification of a failure `reason`. `RuntimeStartFailureCode` alone
+ * cannot distinguish "the daemon took too long" from "we never managed to
+ * publish" — both arrive as `runtime_rpc_failed`.
+ */
+export type RuntimeFailureReasonKind =
+  | 'rpc_timeout'
+  | 'local_rpc_timeout'
+  | 'rpc_not_initialized'
+  | 'mqtt_publish_failed'
+  | 'mqtt_disconnected'
+  | 'device_offline'
+  | 'daemon_rejected'
+  | 'unknown'
+
+export type RuntimeErrorContext = {
+  sessionId?: string
+  teamId?: string
+  agentActorId?: string
+  /** Why ensure-runtime ran (send, wake, reconnect, ...). */
+  trigger?: string
+}
+
+const THROTTLE_WINDOW_MS = 60_000
+const MAX_REASON_LENGTH = 300
+
+const lastReportedAt = new Map<string, number>()
+
+/** @internal test hook */
+export function __resetRuntimeErrorReportThrottleForTest(): void {
+  lastReportedAt.clear()
+}
+
+export function classifyRuntimeFailureReason(reason: string | undefined): RuntimeFailureReasonKind {
+  const lower = (reason ?? '').trim().toLowerCase()
+  if (!lower) return 'unknown'
+  if (lower.includes('local rpc timeout')) return 'local_rpc_timeout'
+  if (lower.includes('rpc timeout')) return 'rpc_timeout'
+  if (lower.includes('not initialized') || lower.includes('actorid required')) {
+    return 'rpc_not_initialized'
+  }
+  if (lower.includes('mqtt disconnected') || lower.includes('mqtt not connected')) {
+    return 'mqtt_disconnected'
+  }
+  if (lower.includes('device offline')) return 'device_offline'
+  if (lower.includes('publish')) return 'mqtt_publish_failed'
+  if (lower.includes('rejected')) return 'daemon_rejected'
+  return 'unknown'
+}
+
+/** Offline transports are expected states, not defects — keep them off the error feed. */
+function levelForCode(code: RuntimeStartFailureCode | undefined): 'warning' | 'error' {
+  return code === 'device_offline' || code === 'transport_offline' ? 'warning' : 'error'
+}
+
+function shouldReport(key: string, now: number): boolean {
+  const previous = lastReportedAt.get(key)
+  if (previous !== undefined && now - previous < THROTTLE_WINDOW_MS) return false
+  lastReportedAt.set(key, now)
+  return true
+}
+
+function truncateReason(reason: string | undefined): string {
+  const trimmed = (reason ?? '').trim()
+  return trimmed.length > MAX_REASON_LENGTH ? `${trimmed.slice(0, MAX_REASON_LENGTH)}…` : trimmed
+}
+
+/**
+ * One shared import for every capture. Kept lazy so the runtime path does not
+ * pull Sentry in eagerly, and memoized so a burst of failures in the same tick
+ * resolves against a single module promise.
+ */
+let sentryModule: Promise<typeof import('@sentry/react')> | null = null
+
+function loadSentry(): Promise<typeof import('@sentry/react')> {
+  sentryModule ??= import('@sentry/react')
+  return sentryModule
+}
+
+/** @internal test hook */
+export function __resetSentryModuleForTest(): void {
+  sentryModule = null
+}
+
+type CaptureArgs = {
+  kind: RuntimeErrorKind
+  code?: RuntimeStartFailureCode
+  reason?: string
+  error?: unknown
+  context: RuntimeErrorContext
+}
+
+function capture({ kind, code, reason, error, context }: CaptureArgs): void {
+  const reasonKind = classifyRuntimeFailureReason(reason)
+  const fingerprint = ['runtime', kind, code ?? 'none', reasonKind]
+  const tags: Record<string, string> = {
+    runtime_error_kind: kind,
+    runtime_failure_code: code ?? 'none',
+    runtime_failure_reason_kind: reasonKind,
+  }
+  const extra: Record<string, unknown> = {
+    reason: truncateReason(reason),
+    sessionId: context.sessionId ?? null,
+    teamId: context.teamId ?? null,
+    agentActorId: context.agentActorId ?? null,
+    trigger: context.trigger ?? null,
+  }
+  const level = levelForCode(code)
+
+  void loadSentry()
+    .then((Sentry) => {
+      if (error !== undefined) {
+        Sentry.captureException(error, { level, tags, extra, fingerprint })
+        return
+      }
+      Sentry.captureMessage(`${kind}: ${code ?? reasonKind}`, {
+        level,
+        tags,
+        extra,
+        fingerprint,
+      })
+    })
+    .catch(() => {
+      // Telemetry must never break the runtime path.
+    })
+}
+
+/**
+ * Report one per-agent runtimeStart failure. Throttled per
+ * (kind, code, agent) so the wake/focus/reconnect ensure loop cannot flood
+ * Sentry with the same offline daemon.
+ */
+export function reportRuntimeStartFailure(
+  failure: RuntimeStartFailure,
+  context: RuntimeErrorContext = {},
+): void {
+  const key = `runtime_start_failure|${failure.code}|${failure.agentActorId}`
+  if (!shouldReport(key, Date.now())) return
+  capture({
+    kind: 'runtime_start_failure',
+    code: failure.code,
+    reason: failure.reason,
+    context: { ...context, agentActorId: failure.agentActorId },
+  })
+}
+
+export function reportRuntimeRpcNotReady(
+  waitedMs: number,
+  context: RuntimeErrorContext = {},
+): void {
+  const key = `rpc_not_ready|${context.sessionId ?? ''}`
+  if (!shouldReport(key, Date.now())) return
+  capture({
+    kind: 'rpc_not_ready',
+    reason: `teamclaw rpc not ready after ${waitedMs}ms`,
+    context,
+  })
+}
+
+export function reportRuntimeEnsureCrash(
+  error: unknown,
+  context: RuntimeErrorContext = {},
+): void {
+  const reason = error instanceof Error ? error.message : String(error)
+  const key = [
+    'ensure_runtime_crash',
+    classifyRuntimeFailureReason(reason),
+    context.trigger ?? '',
+    context.sessionId ?? '',
+  ].join('|')
+  if (!shouldReport(key, Date.now())) return
+  capture({ kind: 'ensure_runtime_crash', reason, error, context })
+}

--- a/packages/app/src/lib/telemetry/runtime-error-report.ts
+++ b/packages/app/src/lib/telemetry/runtime-error-report.ts
@@ -1,17 +1,23 @@
 import type { RuntimeStartFailure, RuntimeStartFailureCode } from '@/lib/session-create'
+import {
+  captureTelemetry,
+  shouldReportThrottled,
+  truncateForExtra,
+  type TelemetryLevel,
+} from '@/lib/telemetry/capture'
+
+export {
+  __resetSentryModuleForTest,
+  __resetTelemetryThrottleForTest as __resetRuntimeErrorReportThrottleForTest,
+} from '@/lib/telemetry/capture'
 
 /**
  * Sentry reporting for the agent-runtime startup path.
  *
  * These failures only ever surfaced as toasts, so their real-world frequency
  * was invisible — Sentry held zero events for `rpc timeout` or `runtimeStart`
- * even though the toasts fire regularly.
- *
- * Grouping rule: never interpolate ids, durations, or raw reasons into the
- * captured message. Sentry fingerprints on message text, and embedded UUIDs
- * shatter one problem into dozens of issues (see the `team gate mismatch`
- * issues, which fragmented exactly that way). Ids go in tags/extra; the
- * fingerprint is (kind, code, reasonKind).
+ * even though the toasts fire regularly. See `capture.ts` for the grouping
+ * rule every reporter here follows.
  */
 
 export type RuntimeErrorKind =
@@ -46,14 +52,6 @@ export type RuntimeErrorContext = {
 }
 
 const THROTTLE_WINDOW_MS = 60_000
-const MAX_REASON_LENGTH = 300
-
-const lastReportedAt = new Map<string, number>()
-
-/** @internal test hook */
-export function __resetRuntimeErrorReportThrottleForTest(): void {
-  lastReportedAt.clear()
-}
 
 export function classifyRuntimeFailureReason(reason: string | undefined): RuntimeFailureReasonKind {
   const lower = (reason ?? '').trim().toLowerCase()
@@ -73,37 +71,8 @@ export function classifyRuntimeFailureReason(reason: string | undefined): Runtim
 }
 
 /** Offline transports are expected states, not defects — keep them off the error feed. */
-function levelForCode(code: RuntimeStartFailureCode | undefined): 'warning' | 'error' {
+function levelForCode(code: RuntimeStartFailureCode | undefined): TelemetryLevel {
   return code === 'device_offline' || code === 'transport_offline' ? 'warning' : 'error'
-}
-
-function shouldReport(key: string, now: number): boolean {
-  const previous = lastReportedAt.get(key)
-  if (previous !== undefined && now - previous < THROTTLE_WINDOW_MS) return false
-  lastReportedAt.set(key, now)
-  return true
-}
-
-function truncateReason(reason: string | undefined): string {
-  const trimmed = (reason ?? '').trim()
-  return trimmed.length > MAX_REASON_LENGTH ? `${trimmed.slice(0, MAX_REASON_LENGTH)}…` : trimmed
-}
-
-/**
- * One shared import for every capture. Kept lazy so the runtime path does not
- * pull Sentry in eagerly, and memoized so a burst of failures in the same tick
- * resolves against a single module promise.
- */
-let sentryModule: Promise<typeof import('@sentry/react')> | null = null
-
-function loadSentry(): Promise<typeof import('@sentry/react')> {
-  sentryModule ??= import('@sentry/react')
-  return sentryModule
-}
-
-/** @internal test hook */
-export function __resetSentryModuleForTest(): void {
-  sentryModule = null
 }
 
 type CaptureArgs = {
@@ -116,37 +85,24 @@ type CaptureArgs = {
 
 function capture({ kind, code, reason, error, context }: CaptureArgs): void {
   const reasonKind = classifyRuntimeFailureReason(reason)
-  const fingerprint = ['runtime', kind, code ?? 'none', reasonKind]
-  const tags: Record<string, string> = {
-    runtime_error_kind: kind,
-    runtime_failure_code: code ?? 'none',
-    runtime_failure_reason_kind: reasonKind,
-  }
-  const extra: Record<string, unknown> = {
-    reason: truncateReason(reason),
-    sessionId: context.sessionId ?? null,
-    teamId: context.teamId ?? null,
-    agentActorId: context.agentActorId ?? null,
-    trigger: context.trigger ?? null,
-  }
-  const level = levelForCode(code)
-
-  void loadSentry()
-    .then((Sentry) => {
-      if (error !== undefined) {
-        Sentry.captureException(error, { level, tags, extra, fingerprint })
-        return
-      }
-      Sentry.captureMessage(`${kind}: ${code ?? reasonKind}`, {
-        level,
-        tags,
-        extra,
-        fingerprint,
-      })
-    })
-    .catch(() => {
-      // Telemetry must never break the runtime path.
-    })
+  captureTelemetry({
+    message: `${kind}: ${code ?? reasonKind}`,
+    level: levelForCode(code),
+    fingerprint: ['runtime', kind, code ?? 'none', reasonKind],
+    tags: {
+      runtime_error_kind: kind,
+      runtime_failure_code: code ?? 'none',
+      runtime_failure_reason_kind: reasonKind,
+    },
+    extra: {
+      reason: truncateForExtra(reason),
+      sessionId: context.sessionId ?? null,
+      teamId: context.teamId ?? null,
+      agentActorId: context.agentActorId ?? null,
+      trigger: context.trigger ?? null,
+    },
+    error,
+  })
 }
 
 /**
@@ -159,7 +115,7 @@ export function reportRuntimeStartFailure(
   context: RuntimeErrorContext = {},
 ): void {
   const key = `runtime_start_failure|${failure.code}|${failure.agentActorId}`
-  if (!shouldReport(key, Date.now())) return
+  if (!shouldReportThrottled(key, THROTTLE_WINDOW_MS)) return
   capture({
     kind: 'runtime_start_failure',
     code: failure.code,
@@ -173,7 +129,7 @@ export function reportRuntimeRpcNotReady(
   context: RuntimeErrorContext = {},
 ): void {
   const key = `rpc_not_ready|${context.sessionId ?? ''}`
-  if (!shouldReport(key, Date.now())) return
+  if (!shouldReportThrottled(key, THROTTLE_WINDOW_MS)) return
   capture({
     kind: 'rpc_not_ready',
     reason: `teamclaw rpc not ready after ${waitedMs}ms`,
@@ -192,6 +148,6 @@ export function reportRuntimeEnsureCrash(
     context.trigger ?? '',
     context.sessionId ?? '',
   ].join('|')
-  if (!shouldReport(key, Date.now())) return
+  if (!shouldReportThrottled(key, THROTTLE_WINDOW_MS)) return
   capture({ kind: 'ensure_runtime_crash', reason, error, context })
 }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -2926,6 +2926,7 @@
   "teamPicker": {
     "title": "Choose a team",
     "subtitle": "You belong to multiple teams. Pick one to continue.",
+    "singleOrgNotice": "You can work in one organization at a time. Choosing a team here leaves the other organizations' teams inaccessible until you switch back.",
     "switching": "Switching…",
     "joining": "Joining…",
     "public": "Public",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -2926,6 +2926,7 @@
   "teamPicker": {
     "title": "选择团队",
     "subtitle": "你属于多个团队，请选择要进入的一个。",
+    "singleOrgNotice": "同一时间只能在一个组织内工作。选择这里的团队后，其它组织的团队将无法访问，直到你切回去。",
     "switching": "切换中…",
     "joining": "加入中…",
     "public": "公开",

--- a/packages/app/src/stores/__tests__/session-list-local-cache-failure.test.ts
+++ b/packages/app/src/stores/__tests__/session-list-local-cache-failure.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The local cache is an accelerator, never a gate. These tests pin the
+ * contract that a rejecting local_cache command (in practice: the current-team
+ * gate disagreeing with the team being loaded) can no longer strand the list
+ * with `loading: true` — the failure mode that produced a permanently spinning
+ * sidebar and the highest-volume unhandled rejection in Sentry.
+ */
+
+const mocks = vi.hoisted(() => ({
+  listCurrentActorSessions: vi.fn(),
+  loadSessionsForTeam: vi.fn(),
+  upsertSessionsBatch: vi.fn(),
+  syncSessionWorkspaces: vi.fn(),
+  reportLocalCacheFailure: vi.fn(),
+}));
+
+vi.mock("@/lib/backend", () => ({
+  getBackend: () => ({
+    sessions: {
+      listCurrentActorSessions: mocks.listCurrentActorSessions,
+      markCurrentActorSessionViewed: vi.fn(),
+      updateSessionTitle: vi.fn(),
+      archiveSession: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("@/lib/utils", () => ({ isTauri: () => true }));
+
+vi.mock("@/lib/local-cache", () => ({
+  loadSessionsForTeam: (...args: unknown[]) => mocks.loadSessionsForTeam(...args),
+  upsertSessionsBatch: (...args: unknown[]) => mocks.upsertSessionsBatch(...args),
+  softDeleteSession: vi.fn(),
+}));
+
+vi.mock("@/lib/session-workspace-sync", () => ({
+  syncSessionWorkspaces: (...args: unknown[]) => mocks.syncSessionWorkspaces(...args),
+}));
+
+vi.mock("@/lib/extension-link-session", () => ({
+  removeLinkSessionEntriesForSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/telemetry/local-cache-error-report", () => ({
+  reportLocalCacheFailure: (...args: unknown[]) => mocks.reportLocalCacheFailure(...args),
+}));
+
+vi.mock("../current-team", () => ({
+  useCurrentTeamStore: { getState: () => ({ team: { id: "team-1" } }) },
+}));
+
+const serverRow = {
+  id: "session-1",
+  title: "Session",
+  team_id: "team-1",
+  mode: "collab",
+  idea_id: null,
+  last_message_at: "2026-07-28T08:00:00.000Z",
+  last_message_preview: "preview",
+  created_at: "2026-07-28T07:59:00.000Z",
+  updated_at: "2026-07-28T08:00:01.000Z",
+  has_unread: false,
+};
+
+const GATE_ERROR = new Error(
+  "local_cache: team gate mismatch in session batch (current=team-2, row_team=team-1)",
+);
+
+async function freshStore() {
+  const { useSessionListStore } = await import("../session-list-store");
+  useSessionListStore.setState({
+    rows: [],
+    loading: false,
+    error: null,
+    pinnedSessionIds: [],
+    highlightedSessionIds: [],
+    hasMore: false,
+    nextCursor: null,
+  });
+  const { useAuthStore } = await import("../auth-store");
+  useAuthStore.setState({ session: { user: { id: "user-1" } } } as never);
+  return useSessionListStore;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  mocks.loadSessionsForTeam.mockResolvedValue([]);
+  mocks.upsertSessionsBatch.mockResolvedValue(undefined);
+  mocks.syncSessionWorkspaces.mockResolvedValue(undefined);
+  mocks.listCurrentActorSessions.mockResolvedValue({ rows: [serverRow], nextCursor: null });
+});
+
+describe("loadFirstPage local-cache resilience", () => {
+  it("still renders server rows and clears loading when the cache hydrate rejects", async () => {
+    mocks.loadSessionsForTeam.mockRejectedValueOnce(GATE_ERROR);
+    const store = await freshStore();
+
+    await expect(store.getState().loadFirstPage()).resolves.toBeUndefined();
+
+    expect(store.getState().loading).toBe(false);
+    expect(store.getState().rows.map((r) => r.id)).toEqual(["session-1"]);
+    expect(mocks.reportLocalCacheFailure).toHaveBeenCalledWith(
+      "session_load_team",
+      GATE_ERROR,
+      { teamId: "team-1" },
+    );
+  });
+
+  it("still renders server rows and clears loading when the cache write rejects", async () => {
+    mocks.upsertSessionsBatch.mockRejectedValueOnce(GATE_ERROR);
+    const store = await freshStore();
+
+    await expect(store.getState().loadFirstPage()).resolves.toBeUndefined();
+
+    expect(store.getState().loading).toBe(false);
+    expect(store.getState().rows.map((r) => r.id)).toEqual(["session-1"]);
+    expect(mocks.reportLocalCacheFailure).toHaveBeenCalledWith(
+      "session_upsert_batch",
+      GATE_ERROR,
+      { teamId: "team-1" },
+    );
+  });
+
+  it("keeps the RPC error path intact — a failing server call still surfaces", async () => {
+    mocks.listCurrentActorSessions.mockRejectedValueOnce(new Error("boom"));
+    const store = await freshStore();
+
+    await store.getState().loadFirstPage();
+
+    expect(store.getState().loading).toBe(false);
+    expect(store.getState().error).toBe("boom");
+  });
+});

--- a/packages/app/src/stores/auth-store.test.ts
+++ b/packages/app/src/stores/auth-store.test.ts
@@ -37,7 +37,9 @@ const session = {
 };
 
 const currentTeamMock = {
-  reloadAndSwitchTo: vi.fn(),
+  // enterTeam is the only supported way in: it activates the team server-side
+  // (moving the active org) before setting the client-side team.
+  enterTeam: vi.fn(),
 };
 
 function storeSessionLike(userId: string) {
@@ -73,7 +75,7 @@ const { useAuthStore } = await import("./auth-store");
 
 beforeEach(() => {
   Object.values(authMock).forEach((fn) => fn.mockReset());
-  currentTeamMock.reloadAndSwitchTo.mockReset();
+  currentTeamMock.enterTeam.mockReset();
   backendConfig.hasConfig = true;
   useAuthStore.setState({
     session: null,
@@ -282,7 +284,7 @@ describe("auth-store", () => {
     const result = await useAuthStore.getState().claimPendingInvite();
 
     expect(authMock.claimInvite).toHaveBeenCalledWith("tok-4");
-    expect(currentTeamMock.reloadAndSwitchTo).toHaveBeenCalledWith("team-4");
+    expect(currentTeamMock.enterTeam).toHaveBeenCalledWith("team-4");
     expect(result?.teamId).toBe("team-4");
     expect(useAuthStore.getState().pendingInviteToken).toBeNull();
     expect(useAuthStore.getState().loading).toBe(false);
@@ -348,7 +350,7 @@ describe("auth-store", () => {
     const result = await useAuthStore.getState().acceptPendingInvite("invite-1");
 
     expect(authMock.acceptPendingInvite).toHaveBeenCalledWith("invite-1");
-    expect(currentTeamMock.reloadAndSwitchTo).toHaveBeenCalledWith("team-7");
+    expect(currentTeamMock.enterTeam).toHaveBeenCalledWith("team-7");
     expect(result?.teamId).toBe("team-7");
     expect(useAuthStore.getState().pendingInvites).toEqual([]);
     expect(useAuthStore.getState().loading).toBe(false);
@@ -362,7 +364,7 @@ describe("auth-store", () => {
     const result = await useAuthStore.getState().acceptPendingInvite("invite-1");
 
     expect(result).toBeNull();
-    expect(currentTeamMock.reloadAndSwitchTo).not.toHaveBeenCalled();
+    expect(currentTeamMock.enterTeam).not.toHaveBeenCalled();
     expect(useAuthStore.getState().pendingInvites).toEqual([pendingInvite]);
     expect(useAuthStore.getState().errorMessage).toBe("invite expired");
     expect(useAuthStore.getState().loading).toBe(false);
@@ -376,7 +378,7 @@ describe("auth-store", () => {
 
     expect(ok).toBe(true);
     expect(authMock.declinePendingInvite).toHaveBeenCalledWith("invite-1");
-    expect(currentTeamMock.reloadAndSwitchTo).not.toHaveBeenCalled();
+    expect(currentTeamMock.enterTeam).not.toHaveBeenCalled();
     expect(useAuthStore.getState().pendingInvites).toEqual([]);
   });
 

--- a/packages/app/src/stores/auth-store.ts
+++ b/packages/app/src/stores/auth-store.ts
@@ -137,7 +137,11 @@ function persistPendingInviteToken(token: string | null): void {
 // After a successful claim, switch into the team and re-onboard the daemon.
 async function enterClaimedTeam(teamId: string): Promise<void> {
   const { useCurrentTeamStore } = await import("@/stores/current-team");
-  await useCurrentTeamStore.getState().reloadAndSwitchTo(teamId);
+  // claim_team_invite moves `public.users.org_id` server-side, but the caller's
+  // JWT was minted before that and the claim returns no refresh token on the
+  // existing-account path. Activate so this client actually authenticates as
+  // the new org — otherwise the team is entered locally and refused remotely.
+  await useCurrentTeamStore.getState().enterTeam(teamId);
   try {
     const { isTauri } = await import("@/lib/utils");
     if (isTauri()) {

--- a/packages/app/src/stores/current-team.test.ts
+++ b/packages/app/src/stores/current-team.test.ts
@@ -4,13 +4,18 @@ const teamsMock = {
   listCurrentUserTeams: vi.fn(),
   getTeam: vi.fn(),
   renameTeam: vi.fn(),
+  activateTeam: vi.fn(),
 };
 const directoryMock = {
   getCurrentTeamMember: vi.fn(),
 };
+const authMock = {
+  adoptSession: vi.fn(),
+};
 const backendMock = {
   teams: teamsMock,
   directory: directoryMock,
+  auth: authMock,
 };
 
 const authState: { session: { user: { id: string } } | null } = {
@@ -46,6 +51,9 @@ const ACTIVE_MEMBER = {
 
 beforeEach(() => {
   teamsMock.listCurrentUserTeams.mockReset();
+  teamsMock.getTeam.mockReset();
+  teamsMock.activateTeam.mockReset();
+  authMock.adoptSession.mockReset();
   directoryMock.getCurrentTeamMember.mockReset();
   authState.session = { user: { id: "anon-1" } };
   localStorage.clear();
@@ -160,5 +168,67 @@ describe("useCurrentTeamStore.load", () => {
     expect(state.team).toEqual(ACTIVE_TEAM);
     expect(state.currentMember).toEqual(ACTIVE_MEMBER);
     expect(directoryMock.getCurrentTeamMember).toHaveBeenCalledWith("team-1", "anon-1");
+  });
+});
+
+describe("load() team selection", () => {
+  const OTHER_TEAM = { id: "team-2", name: "Quiet Falcon", slug: "quiet-falcon" };
+
+  it("keeps the team the user is already on when it is still in the active org", async () => {
+    // Ordered so the held team is NOT first — the old `limit: 1` code took
+    // rows[0] and silently relocated multi-team users on every mount.
+    teamsMock.listCurrentUserTeams.mockResolvedValueOnce([OTHER_TEAM, ACTIVE_TEAM]);
+    directoryMock.getCurrentTeamMember.mockResolvedValueOnce(ACTIVE_MEMBER);
+    useCurrentTeamStore.setState({ team: ACTIVE_TEAM, teamUserId: "anon-1" });
+
+    await useCurrentTeamStore.getState().load();
+
+    expect(useCurrentTeamStore.getState().team).toEqual(ACTIVE_TEAM);
+  });
+
+  it("falls back to the first row when the held team left the active org", async () => {
+    teamsMock.listCurrentUserTeams.mockResolvedValueOnce([OTHER_TEAM]);
+    directoryMock.getCurrentTeamMember.mockResolvedValueOnce(ACTIVE_MEMBER);
+    useCurrentTeamStore.setState({ team: ACTIVE_TEAM, teamUserId: "anon-1" });
+
+    await useCurrentTeamStore.getState().load();
+
+    expect(useCurrentTeamStore.getState().team).toEqual(OTHER_TEAM);
+  });
+});
+
+describe("enterTeam", () => {
+  it("activates and adopts the minted session before setting the team", async () => {
+    const calls: string[] = [];
+    teamsMock.activateTeam = vi.fn(async () => {
+      calls.push("activate");
+      return { actorId: null, teamId: "team-2", refreshToken: "rt-2" };
+    });
+    authMock.adoptSession = vi.fn(async () => {
+      calls.push("adopt");
+      return null;
+    });
+    teamsMock.getTeam.mockImplementation(async () => {
+      calls.push("getTeam");
+      return { id: "team-2", name: "Quiet Falcon", slug: "quiet-falcon" };
+    });
+    directoryMock.getCurrentTeamMember.mockResolvedValueOnce(ACTIVE_MEMBER);
+
+    await useCurrentTeamStore.getState().enterTeam("team-2");
+
+    // Order matters: getTeam before adopt would read with the stale org.
+    expect(calls).toEqual(["activate", "adopt", "getTeam"]);
+    expect(useCurrentTeamStore.getState().team?.id).toBe("team-2");
+  });
+
+  it("skips activation when the caller knows the team is already in the active org", async () => {
+    teamsMock.activateTeam = vi.fn();
+    teamsMock.getTeam.mockResolvedValueOnce(ACTIVE_TEAM);
+    directoryMock.getCurrentTeamMember.mockResolvedValueOnce(ACTIVE_MEMBER);
+
+    await useCurrentTeamStore.getState().enterTeam("team-1", { assumeActive: true });
+
+    expect(teamsMock.activateTeam).not.toHaveBeenCalled();
+    expect(useCurrentTeamStore.getState().team?.id).toBe("team-1");
   });
 });

--- a/packages/app/src/stores/current-team.ts
+++ b/packages/app/src/stores/current-team.ts
@@ -93,7 +93,13 @@ interface State {
   saving: boolean;
   error: string | null;
   load: () => Promise<void>;
+  /**
+   * Set the current team WITHOUT touching the server-side active org.
+   * Internal: only safe when the team is already inside the active org.
+   * Every other caller must use `enterTeam`.
+   */
   reloadAndSwitchTo: (teamId: string) => Promise<void>;
+  enterTeam: (teamId: string, opts?: { assumeActive?: boolean }) => Promise<void>;
   switchToTeam: (teamId: string) => Promise<void>;
   setActiveTeam: (team: CurrentTeam) => Promise<void>;
   rename: (newName: string) => Promise<boolean>;
@@ -118,7 +124,17 @@ export const useCurrentTeamStore = create<State>((set, get) => ({
     set({ loading: true, error: null });
     let row;
     try {
-      row = (await getBackend().teams.listCurrentUserTeams({ limit: 1 }))[0];
+      // Listing the whole active org rather than `limit: 1` is deliberate.
+      // The old code took the first row — an arbitrary pick ordered by
+      // created_at — which silently relocated multi-team users to a team they
+      // never chose on every mount, and dragged the local-cache team gate with
+      // it. That gate then disagreed with the team the rest of the UI was
+      // still working on, which is what produced the `team gate mismatch`
+      // rejections. Keep the held team whenever it is still a member of the
+      // active org; only fall back to the first row when it is not.
+      const rows = await getBackend().teams.listCurrentUserTeams({ limit: 50 });
+      const heldId = get().team?.id;
+      row = (heldId ? rows.find((t) => t.id === heldId) : undefined) ?? rows[0];
     } catch (error) {
       set({ loading: false, error: error instanceof Error ? error.message : String(error) });
       return;
@@ -186,15 +202,39 @@ export const useCurrentTeamStore = create<State>((set, get) => ({
     });
   },
 
+  /**
+   * The single supported way to enter a team.
+   *
+   * TeamClaw is strict single-org: `amux.current_org_id()` gates every
+   * team-scoped RLS policy, and a team outside the active org is invisible —
+   * reads return nothing and writes are denied. Setting the current team
+   * without moving the server-side active org therefore produces a client that
+   * believes it is in a team the server will refuse every request for:
+   * "Failed to create session", an empty session list, and a local-cache gate
+   * pointing at a different team than the UI.
+   *
+   * So: activate first (which mints a session carrying the new org), adopt it,
+   * and only then set the client-side team.
+   *
+   * `assumeActive` skips the activation round-trip. Only pass it when the team
+   * is already known to be in the active org — e.g. it came back from
+   * `listCurrentUserTeams`, which is itself an active-org listing.
+   */
+  enterTeam: async (teamId: string, opts) => {
+    if (!opts?.assumeActive) {
+      const { refreshToken } = await getBackend().teams.activateTeam(teamId);
+      // Installs the JWT carrying the new org_id (fires onAuthStateChange →
+      // auth-store.session). Without this the org switch is server-only and
+      // the very next request still authenticates as the old org.
+      if (refreshToken) await getBackend().auth.adoptSession(refreshToken);
+    }
+    await get().reloadAndSwitchTo(teamId);
+  },
+
   switchToTeam: async (teamId: string) => {
     set({ loading: true, error: null });
     try {
-      // 1) 服务端换 org + 铸新 session。
-      const { refreshToken } = await getBackend().teams.activateTeam(teamId);
-      // 2) 装上带新 org_id 的 JWT（触发 onAuthStateChange → auth-store.session 更新）。
-      await getBackend().auth.adoptSession(refreshToken);
-      // 3) 设当前 team + 后端 team gate（此时 JWT 已是新 org，getTeam 可读）。
-      await get().reloadAndSwitchTo(teamId);
+      await get().enterTeam(teamId);
     } catch (error) {
       set({ loading: false, error: error instanceof Error ? error.message : String(error) });
       throw error;

--- a/packages/app/src/stores/session-list-store.ts
+++ b/packages/app/src/stores/session-list-store.ts
@@ -13,6 +13,7 @@ import {
   type SessionRow,
 } from "@/lib/local-cache";
 import { removeLinkSessionEntriesForSession } from "@/lib/extension-link-session";
+import { reportLocalCacheFailure } from "@/lib/telemetry/local-cache-error-report";
 import type { SessionListCursor, SessionListPage } from "@/lib/backend/types";
 import { sortSessionListRows } from "@/lib/session-list-sort";
 
@@ -250,14 +251,22 @@ export const useSessionListStore = create<State>((set, get) => ({
     // Skip when we already have RPC rows — reloading would flash archived
     // sessions that still sit in libsql until soft-deleted.
     if (isTauri() && teamId && existingRows.length === 0) {
-      const localRows = await loadSessionsForTeam(teamId);
-      if (localRows.length > 0) {
-        set({
-          rows: filterArchivedEntries(
-            sortEntries(localRows.map(mapCacheToEntry)),
-          ),
-        });
-        markStartup("session-list:local-cache");
+      // The cache is an accelerator, never a gate. A rejection here (most
+      // often the current-team gate disagreeing with `teamId`) used to reject
+      // this whole function, leaving `loading: true` forever — the list span
+      // its spinner and the rejection surfaced as an unhandled rejection.
+      try {
+        const localRows = await loadSessionsForTeam(teamId);
+        if (localRows.length > 0) {
+          set({
+            rows: filterArchivedEntries(
+              sortEntries(localRows.map(mapCacheToEntry)),
+            ),
+          });
+          markStartup("session-list:local-cache");
+        }
+      } catch (error) {
+        reportLocalCacheFailure("session_load_team", error, { teamId });
       }
     }
 
@@ -296,7 +305,13 @@ export const useSessionListStore = create<State>((set, get) => ({
         deletedAt: null,
         syncedAt: new Date().toISOString(),
       }));
-      await upsertSessionsBatch(cacheRows);
+      try {
+        await upsertSessionsBatch(cacheRows);
+      } catch (error) {
+        // Same contract as the hydrate above: a cache write must never stop
+        // the freshly-fetched rows from rendering.
+        reportLocalCacheFailure("session_upsert_batch", error, { teamId });
+      }
       // Fire-and-forget: pull session → workspace links from the cloud
       // daemon-runtimes list into the local cache so the session-list
       // workspace filter keeps working offline. Non-fatal: offline / no


### PR DESCRIPTION
## What broke

A colleague with two teams accepted an invite to ours and hit three symptoms: "Failed to create session" on every New session click, a session list that spun forever, and — after a full restart — a session detail pane stuck loading while sending messages still worked.

All three are one root cause.

TeamClaw is strict single-org. `amux.current_org_id()` gates every team-scoped RLS policy (`teams_org_guard`), so a team outside the caller's **active org** is invisible: reads return nothing, writes are denied. The active org only moves in two places server-side — `claim_team_invite` and `switch_active_team` (`POST /v1/teams/:id/activate`).

The client had three ways to set the current team, and only one moved the active org:

| Path | Activated? |
|---|---|
| TeamPicker → `switchToTeam` | ✅ |
| `AuthGate` restoring the cached team on cold start | ❌ |
| `reloadAndSwitchTo` — invite deeplink, `enterClaimedTeam`, session deeplink | ❌ |

`claim_team_invite` moves `public.users.org_id` but returns no refresh token on the existing-account path, and every claim call site discarded the field anyway. So the client entered our team locally while still authenticating as the previous org:

- `resolveCurrentMemberActor` → 0 rows → `myActorId` null → **"Failed to create session"**
- `listCurrentUserTeams({ limit: 1 })` returned a team from the *old* org, and `load()` took row 0 unconditionally — silently relocating the user and dragging the local-cache team gate with it
- the gate then disagreed with the team the UI held → `team gate mismatch` → thrown from two unguarded awaits in `loadFirstPage` → `loading` never cleared → **permanent spinner** + an unhandled rejection

That rejection is the highest-volume issue in Sentry: TEAMCLAW-REACT-74 / 73, ~180 events each across 9 users. Messages still worked throughout because they go over MQTT to the daemon and never touch RLS.

Confirmed against the database: the user's two teams sit in different orgs, and only one matches their active org.

## What this changes

**`enterTeam(teamId)` is now the only way in** — activate, adopt the minted session, then set the client-side team. `reloadAndSwitchTo` stays as its internal tail and is no longer called from business code. `assumeActive` skips the round-trip for teams that came from `listCurrentUserTeams`, which is already an active-org listing, so the cold-start path costs nothing extra.

**AuthGate self-heals.** The optimistic cached-team restore keeps its fast first paint, then probes `getTeam` in the background and re-enters via `enterTeam` when the cached team turns out to be out of org. Nothing noticed before, which is why a restart could not recover.

**`load()` stops relocating multi-team users.** It lists the active org and keeps the held team whenever it is still there, instead of taking row 0 of a `created_at` ordering that had nothing to do with what the user picked.

**A failing local cache can no longer strand the list.** Both awaits in `loadFirstPage` are guarded; server rows always render and `loading` always clears. A cache failure now costs a cold read.

**Local-cache errors got stable codes.** Eight hand-written prose strings in `local_cache/commands.rs` collapse into one `gate_mismatch()` helper behind `local_cache: team_gate_mismatch`, and a blank team id gets its own `local_cache: empty_team_id`. Those two were previously indistinguishable — an empty `requested=` looked like a team divergence and sent this investigation after a problem that wasn't happening.

**Gate mismatches now self-repair.** Re-pinning the gate to the current team is cheap, idempotent, and local — it does not touch the active org, so it cannot fight `enterTeam`. The divergence used to persist for the whole session.

**Blank team ids are refused at the boundary.** The four team-scoped loaders return empty and report the call site — the only lead on TEAMCLAW-REACT-6Z, which is still firing and which none of the above explains.

**TeamPicker says the quiet part.** The picker is a cross-org listing, so it shows teams the choice will make unreadable. It now says so when the listing actually spans orgs.

**Runtime-start failures reach Sentry at all.** They only ever surfaced as toasts — Sentry held zero events for `rpc timeout` or `runtimeStart` despite those toasts firing regularly, so the frequency of the most-complained-about errors was a blind spot. Reports are throttled per (kind, code, agent), and `runtime_rpc_failed` is split into `rpc_timeout` / `local_rpc_timeout` / `rpc_not_initialized` / `mqtt_publish_failed`, which the failure code alone conflates.

Every reporter keeps ids out of the captured message with an explicit fingerprint. Interpolating them is what split the team-gate reports across four separate Sentry issues.

## Testing

- 26 new tests: `enterTeam` call ordering (`activate → adopt → getTeam` — reversed means reading with the stale org), `load()` team retention/fallback, both `loadFirstPage` cache-failure paths, error-code classification, gate self-repair, blank-team guards, TeamPicker notice.
- The `loadFirstPage` regression tests were verified to fail with the guards removed — they catch the real bug, not the fix.
- `pnpm test:unit`: 2295 passed, 12 failed. The 12 are identical to the pre-change baseline (`SessionListColumn`, `useAppInit`, `build-config`, `acp-debug-store`, `session-pins`) and are untouched here.
- `pnpm typecheck` clean; `pnpm lint` 0 errors, warning count unchanged; `cargo fmt --check` clean on the edited file; `pnpm rust:check` passes; both locale files re-verified as parseable (they contain duplicate keys, so they were edited textually).

## Reviewer notes

- `gate_mismatch` changes the error text format to `(scope: current=…, found=…)`. Only the new classifier depends on it — grep found no other consumer — but flagging it in case an ops script matches the old prose.
- `enterTeam` adds one activate round-trip and a token rotation on the invite-deeplink, cron cross-team, and AuthGate self-heal paths. Day-to-day team switching already did this. The normal cold start is unchanged.
- Not included: the user's orphaned old team is left alone. After this change, switching to it from the picker works; the cost is still one org at a time, which is the single-org constraint rather than a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
