### PR TITLE
feat(daemon): Cursor SDK backend (Composer) with settings UI

### DIFF
--- a/apps/daemon/cursor-bridge/package-lock.json
+++ b/apps/daemon/cursor-bridge/package-lock.json
@@ -1,0 +1,208 @@
+{
+  "name": "@teamclaw/cursor-bridge",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@teamclaw/cursor-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "@cursor/sdk": "^1.0.24"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+      "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.7.0.tgz",
+      "integrity": "sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@cursor/sdk": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.24.tgz",
+      "integrity": "sha512-pHoVRSiyBMTFBMjhAihvzXbiJSFNs63dULE+11jzCX/s1a7/I7Zp0cC4jWRw1ykckEPcho8QiEEgSR3qBRmDBw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
+        "@connectrpc/connect": "^1.6.1",
+        "@connectrpc/connect-node": "^1.6.1",
+        "@connectrpc/connect-web": "^1.6.1",
+        "@statsig/js-client": "3.31.0",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "optionalDependencies": {
+        "@cursor/sdk-darwin-arm64": "1.0.24",
+        "@cursor/sdk-darwin-x64": "1.0.24",
+        "@cursor/sdk-linux-arm64": "1.0.24",
+        "@cursor/sdk-linux-x64": "1.0.24",
+        "@cursor/sdk-win32-x64": "1.0.24"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-arm64": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.24.tgz",
+      "integrity": "sha512-0RIjcm2CFLuu0N/GnQ3G+8UGIQKv9jEgVkLr2gGjVoEN5UfwA6G3eLO/U6SfnMdFNkftJ9j/efcCHuS/OFPuNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-x64": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.24.tgz",
+      "integrity": "sha512-BmD1hbV0SCIRv9FGIhoM4XgCbWdcVGpjiPXUiIlGaYDM9ZXpmit6x9tx2iSGUIIc7ytpIYsQaSBEUsSQsNl7wQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-arm64": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.24.tgz",
+      "integrity": "sha512-zCZcHwKPopqeXEsja2EmsV6En3hAhd3alnCfKbiYZdE9XQAaTza0XFji7a4uRjKGitlQ0JDIYHRIJg/2nvTkrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-x64": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.24.tgz",
+      "integrity": "sha512-pK80OM4CSB0G8ModhRhb85+FYEROmK8nad6Lj8LDZngQ1ZgJi/nrdgUuHykOtza7T00D14x9Q2l0pwf/ybXxog==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-win32-x64": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.24.tgz",
+      "integrity": "sha512-vU4ossYSuw0adCK0ssZvwCeT6dmdBR29EMdHrB9G89SzIJ9xpodkKKjDL0aN5dEwy7wOKyUJIjprfw/A4U8F5A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "rg": "bin/rg.exe"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@statsig/client-core": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.31.0.tgz",
+      "integrity": "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==",
+      "license": "ISC"
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.31.0.tgz",
+      "integrity": "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==",
+      "license": "ISC",
+      "dependencies": {
+        "@statsig/client-core": "3.31.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/apps/daemon/cursor-bridge/package.json
+++ b/apps/daemon/cursor-bridge/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@teamclaw/cursor-bridge",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "JSONL RPC sidecar wrapping @cursor/sdk for amuxd",
+  "main": "src/main.mjs",
+  "scripts": {
+    "start": "node src/main.mjs --mode rpc"
+  },
+  "dependencies": {
+    "@cursor/sdk": "^1.0.24"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/apps/daemon/cursor-bridge/src/main.mjs
+++ b/apps/daemon/cursor-bridge/src/main.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+/**
+ * JSONL RPC bridge between amuxd (Rust) and @cursor/sdk.
+ *
+ * Protocol:
+ *   Request:  { "id": "...", "method": "...", "params": { ... } }
+ *   Response: { "id": "...", "result": { ... } }
+ *   Error:    { "id": "...", "error": "..." }
+ *   Event:    { "event": "...", "agentId": "...", "runId": "...", ... }
+ */
+import readline from 'node:readline'
+import { Agent, Cursor, CursorAgentError } from '@cursor/sdk'
+
+/** @type {Map<string, { agent: import('@cursor/sdk').Agent, cwd: string, model: string }>} */
+const agents = new Map()
+
+/** @type {Map<string, { agentId: string, run: import('@cursor/sdk').Run | null, cancelled: boolean }>} */
+const activeRuns = new Map()
+
+function emit(obj) {
+  process.stdout.write(`${JSON.stringify(obj)}\n`)
+}
+
+function flatModelId(sdkId) {
+  return `cursor/${sdkId}`
+}
+
+function sdkModelFromFlat(flat) {
+  if (!flat || typeof flat !== 'string') return 'composer-2.5'
+  const slash = flat.indexOf('/')
+  if (slash === -1) return flat
+  const provider = flat.slice(0, slash)
+  const model = flat.slice(slash + 1)
+  if (provider === 'cursor' && model) return model
+  return model || 'composer-2.5'
+}
+
+function apiKeyFromEnv() {
+  const key = process.env.CURSOR_API_KEY?.trim()
+  if (!key) throw new Error('CURSOR_API_KEY is not set')
+  return key
+}
+
+async function disposeAgent(agentId) {
+  const entry = agents.get(agentId)
+  if (!entry) return
+  agents.delete(agentId)
+  try {
+    await entry.agent[Symbol.asyncDispose]?.()
+  } catch {
+    // best-effort
+  }
+}
+
+function paramsToObject(input) {
+  if (input == null) return {}
+  if (typeof input === 'object' && !Array.isArray(input)) {
+    const out = {}
+    for (const [k, v] of Object.entries(input)) {
+      out[k] = typeof v === 'string' ? v : JSON.stringify(v)
+    }
+    return out
+  }
+  return { input: JSON.stringify(input) }
+}
+
+function toolResultText(result) {
+  if (result == null) return ''
+  if (typeof result === 'string') return result
+  try {
+    return JSON.stringify(result)
+  } catch {
+    return String(result)
+  }
+}
+
+function handleStreamEvent(agentId, runId, message) {
+  switch (message.type) {
+    case 'assistant': {
+      for (const block of message.message?.content ?? []) {
+        if (block.type === 'text' && block.text) {
+          emit({ event: 'assistant_delta', agentId, runId, text: block.text })
+        }
+        if (block.type === 'tool_use') {
+          emit({
+            event: 'tool_start',
+            agentId,
+            runId,
+            toolCallId: block.id,
+            toolName: block.name,
+            args: paramsToObject(block.input),
+          })
+        }
+      }
+      break
+    }
+    case 'thinking':
+      if (message.text) {
+        emit({ event: 'thinking_delta', agentId, runId, text: message.text })
+      }
+      break
+    case 'tool_call': {
+      if (message.status === 'running') {
+        emit({
+          event: 'tool_start',
+          agentId,
+          runId,
+          toolCallId: message.call_id,
+          toolName: message.name,
+          args: paramsToObject(message.args),
+        })
+      } else {
+        emit({
+          event: 'tool_end',
+          agentId,
+          runId,
+          toolCallId: message.call_id,
+          summary: toolResultText(message.result),
+          isError: message.status === 'error',
+        })
+      }
+      break
+    }
+    case 'status':
+      if (message.status === 'ERROR') {
+        emit({
+          event: 'run_error',
+          agentId,
+          runId,
+          message: message.message ?? 'cursor run error',
+        })
+      }
+      break
+    case 'request':
+      emit({
+        event: 'permission_request',
+        agentId,
+        runId,
+        requestId: message.request_id,
+      })
+      break
+    default:
+      break
+  }
+}
+
+async function streamRun(agentId, run) {
+  activeRuns.set(agentId, { agentId, run, cancelled: false })
+  emit({ event: 'turn_start', agentId, runId: run.id })
+
+  try {
+    for await (const event of run.stream()) {
+      const state = activeRuns.get(agentId)
+      if (state?.cancelled) break
+      // run.stream() yields SDKMessage directly (assistant, thinking, tool_call, …).
+      handleStreamEvent(agentId, run.id, event)
+    }
+
+    const state = activeRuns.get(agentId)
+    if (!state?.cancelled) {
+      const result = await run.wait()
+      emit({
+        event: 'turn_end',
+        agentId,
+        runId: run.id,
+        status: result.status,
+        model: result.model?.id ? flatModelId(result.model.id) : undefined,
+      })
+    }
+  } catch (err) {
+    const msg = err instanceof CursorAgentError ? err.message : String(err)
+    emit({ event: 'run_error', agentId, runId: run.id, message: msg })
+    emit({ event: 'turn_end', agentId, runId: run.id, status: 'error' })
+  } finally {
+    activeRuns.delete(agentId)
+  }
+}
+
+async function handleRequest(req) {
+  const { id, method, params = {} } = req
+  try {
+    switch (method) {
+      case 'list_models': {
+        const models = await Cursor.models.list({ apiKey: apiKeyFromEnv() })
+        emit({
+          id,
+          result: {
+            models: models.map((m) => ({
+              id: flatModelId(m.id),
+              displayName: m.name ?? m.id,
+              providerName: 'cursor',
+              sdkId: m.id,
+            })),
+          },
+        })
+        break
+      }
+      case 'create_agent': {
+        const cwd = params.cwd
+        if (!cwd) throw new Error('cwd is required')
+        const model = sdkModelFromFlat(params.model)
+        const agent = await Agent.create({
+          apiKey: apiKeyFromEnv(),
+          model: { id: model },
+          local: { cwd, settingSources: [] },
+          ...(params.mcpServers?.length ? { mcpServers: params.mcpServers } : {}),
+        })
+        agents.set(agent.agentId, { agent, cwd, model })
+        emit({
+          id,
+          result: {
+            agentId: agent.agentId,
+            model: flatModelId(model),
+          },
+        })
+        break
+      }
+      case 'resume_agent': {
+        const agentId = params.agentId
+        if (!agentId) throw new Error('agentId is required')
+        const agent = await Agent.resume(agentId, {
+          apiKey: apiKeyFromEnv(),
+          ...(params.mcpServers?.length ? { mcpServers: params.mcpServers } : {}),
+        })
+        const model = sdkModelFromFlat(params.model) || 'composer-2.5'
+        agents.set(agent.agentId, { agent, cwd: params.cwd ?? process.cwd(), model })
+        emit({
+          id,
+          result: {
+            agentId: agent.agentId,
+            model: flatModelId(model),
+          },
+        })
+        break
+      }
+      case 'send': {
+        const agentId = params.agentId
+        const text = params.text
+        if (!agentId || !text) throw new Error('agentId and text are required')
+        const entry = agents.get(agentId)
+        if (!entry) throw new Error(`unknown agent ${agentId}`)
+        const run = await entry.agent.send(text)
+        emit({ id, result: { runId: run.id } })
+        void streamRun(agentId, run)
+        break
+      }
+      case 'cancel': {
+        const agentId = params.agentId
+        const entry = agents.get(agentId)
+        const state = activeRuns.get(agentId)
+        if (state?.run?.supports?.('cancel')) {
+          await state.run.cancel()
+        }
+        if (state) state.cancelled = true
+        emit({ id, result: { ok: true } })
+        break
+      }
+      case 'set_model': {
+        const agentId = params.agentId
+        const model = sdkModelFromFlat(params.model)
+        const entry = agents.get(agentId)
+        if (!entry) throw new Error(`unknown agent ${agentId}`)
+        entry.model = model
+        emit({ id, result: { model: flatModelId(model) } })
+        break
+      }
+      case 'get_agent_info': {
+        const agentId = params.agentId
+        const entry = agents.get(agentId)
+        if (!entry) throw new Error(`unknown agent ${agentId}`)
+        emit({
+          id,
+          result: { agentId, model: flatModelId(entry.model), cwd: entry.cwd },
+        })
+        break
+      }
+      case 'resolve_permission': {
+        emit({ id, result: { ok: true } })
+        break
+      }
+      case 'dispose_agent': {
+        await disposeAgent(params.agentId)
+        emit({ id, result: { ok: true } })
+        break
+      }
+      default:
+        emit({ id, error: `unknown method: ${method}` })
+    }
+  } catch (err) {
+    const msg = err instanceof CursorAgentError ? err.message : String(err)
+    emit({ id, error: msg })
+  }
+}
+
+async function main() {
+  const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity })
+  for await (const line of rl) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    let req
+    try {
+      req = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (req?.method && req?.id != null) {
+      void handleRequest(req)
+    }
+  }
+  for (const agentId of [...agents.keys()]) {
+    await disposeAgent(agentId)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/daemon/src/cli/doctor.rs
+++ b/apps/daemon/src/cli/doctor.rs
@@ -19,6 +19,9 @@ pub fn run() -> anyhow::Result<()> {
     if local_agent == "pi" {
         report.pi = Some(crate::pi_install::doctor());
     }
+    if local_agent == "cursor" {
+        report.cursor = Some(crate::cursor_install::doctor());
+    }
     println!("{}", serde_json::to_string_pretty(&report)?);
     Ok(())
 }

--- a/apps/daemon/src/config/daemon_config.rs
+++ b/apps/daemon/src/config/daemon_config.rs
@@ -223,7 +223,7 @@ pub struct AgentsConfig {
     #[serde(default = "default_true")]
     pub auto_discover: bool,
     /// Local agent runtime backing this daemon: "opencode" (default), "pi",
-    /// "claude-code", or "codex". Seeded from the desktop build config's
+    /// "cursor", "claude-code", or "codex". Seeded from the desktop build config's
     /// `localAgent` during onboarding. See `daemon::runtime_resolution::
     /// configured_local_agent` for how this name is resolved to a runnable
     /// backend — claude-code/codex additionally require their `[agents.*]`
@@ -237,6 +237,26 @@ pub struct AgentsConfig {
     pub opencode: Option<AgentBackendConfig>,
     #[serde(default)]
     pub codex: Option<AgentBackendConfig>,
+    #[serde(default)]
+    pub cursor: Option<CursorAgentConfig>,
+}
+
+/// Cursor SDK backend settings (`agents.local_agent = "cursor"`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CursorAgentConfig {
+    /// Cursor API key. Falls back to `CURSOR_API_KEY` when unset.
+    #[serde(default)]
+    pub api_key: Option<String>,
+    /// Sidecar launch command (default: `node …/cursor-bridge/src/main.mjs --mode rpc`).
+    #[serde(default)]
+    pub bridge_command: Option<Vec<String>>,
+    /// SDK model id (not the flat `cursor/…` id). Default: `composer-2.5`.
+    #[serde(default = "default_cursor_model")]
+    pub default_model: Option<String>,
+}
+
+fn default_cursor_model() -> Option<String> {
+    Some("composer-2.5".to_string())
 }
 
 fn default_local_agent() -> String {
@@ -251,6 +271,7 @@ impl Default for AgentsConfig {
             claude_code: None,
             opencode: None,
             codex: None,
+            cursor: None,
         }
     }
 }

--- a/apps/daemon/src/config/edit.rs
+++ b/apps/daemon/src/config/edit.rs
@@ -25,6 +25,7 @@ use toml::Value;
 const SECRET_LEAF_KEYS: &[&str] = &[
     "password",
     "secret",
+    "api_key",
     "bot_token",
     "app_secret",
     "encoding_aes_key",
@@ -436,6 +437,7 @@ broker_url = "mqtts://broker.example"
 
         // Nested/repeated sections are covered without enumerating indices.
         assert!(super::is_secret_key("channels.wecom.bots.0.secret"));
+        assert!(super::is_secret_key("agents.cursor.api_key"));
 
         assert!(!super::is_secret_key("mqtt.username"));
         assert!(!super::is_secret_key("mqtt.broker_url"));

--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -15,9 +15,9 @@ pub mod workspace_path;
 mod workspace_resolver;
 
 pub use daemon_config::{
-    ActorConfig, AgentBackendConfig, AgentsConfig, DaemonConfig, DiscordChannel, EmailChannel,
-    FeishuChannel, HttpConfig, KookChannel, MqttConfig, TransportKind, WeChatChannel, WeComChannel,
-    BOOTSTRAP_ACTOR_NAME,
+    ActorConfig, AgentBackendConfig, AgentsConfig, CursorAgentConfig, DaemonConfig, DiscordChannel,
+    EmailChannel, FeishuChannel, HttpConfig, KookChannel, MqttConfig, TransportKind, WeChatChannel,
+    WeComChannel, BOOTSTRAP_ACTOR_NAME,
 };
 // Constructed only by the test suite (runtime_resolution / server tests).
 #[cfg(test)]

--- a/apps/daemon/src/cursor_install/mod.rs
+++ b/apps/daemon/src/cursor_install/mod.rs
@@ -1,0 +1,58 @@
+//! Cursor SDK bridge discovery for `amuxd doctor`.
+
+use serde::Serialize;
+
+use crate::runtime::cursor_sdk::process::{default_bridge_command, default_bridge_main};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CursorStatus {
+    pub node_present: bool,
+    pub bridge_script_present: bool,
+    pub api_key_present: bool,
+    pub sdk_installed: bool,
+    pub bridge_command: Vec<String>,
+    pub satisfied: bool,
+}
+
+pub fn doctor() -> CursorStatus {
+    let bridge_command = default_bridge_command();
+    let bridge_script_present = default_bridge_main().is_file();
+    let node_present = which_node().is_some();
+    let api_key_present = std::env::var("CURSOR_API_KEY")
+        .ok()
+        .filter(|k| !k.trim().is_empty())
+        .is_some()
+        || daemon_config_has_cursor_api_key();
+    let sdk_installed = default_bridge_main()
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("node_modules/@cursor/sdk/package.json").is_file())
+        .unwrap_or(false);
+    let satisfied = node_present && bridge_script_present && api_key_present && sdk_installed;
+    CursorStatus {
+        node_present,
+        bridge_script_present,
+        api_key_present,
+        sdk_installed,
+        bridge_command,
+        satisfied,
+    }
+}
+
+fn which_node() -> Option<String> {
+    let out = std::process::Command::new("node")
+        .arg("--version")
+        .output()
+        .ok()?;
+    out.status.success().then(|| "node".to_string())
+}
+
+fn daemon_config_has_cursor_api_key() -> bool {
+    crate::config::DaemonConfig::load(&crate::config::DaemonConfig::default_path())
+        .ok()
+        .and_then(|c| c.agents.cursor)
+        .and_then(|c| c.api_key)
+        .filter(|k| !k.trim().is_empty())
+        .is_some()
+}

--- a/apps/daemon/src/daemon/runtime_resolution.rs
+++ b/apps/daemon/src/daemon/runtime_resolution.rs
@@ -10,6 +10,7 @@ use crate::proto::amux;
 fn configured_local_agent(config: &DaemonConfig) -> Option<amux::AgentType> {
     match config.agents.local_agent.as_str() {
         "pi" => Some(amux::AgentType::Pi),
+        "cursor" => Some(amux::AgentType::Opencode),
         "opencode" => config
             .agents
             .opencode
@@ -81,6 +82,7 @@ pub(crate) fn session_message_model_override(
 pub(crate) fn agent_type_from_name(name: &str) -> Option<amux::AgentType> {
     match name.trim() {
         "opencode" => Some(amux::AgentType::Opencode),
+        "cursor" => Some(amux::AgentType::Opencode),
         "codex" => Some(amux::AgentType::Codex),
         "claude" | "claude_code" | "claude-code" => Some(amux::AgentType::ClaudeCode),
         "pi" => Some(amux::AgentType::Pi),
@@ -113,6 +115,11 @@ pub(crate) fn default_advertised_agent_type(supported_types: &[String]) -> Optio
 /// sections are accepted in config files but only advertised when
 /// `local_agent` selects them.
 pub(crate) fn supported_agent_type_names(config: &DaemonConfig) -> Vec<String> {
+    if config.agents.local_agent == "cursor" {
+        return configured_local_agent(config)
+            .map(|_| vec!["cursor".to_string()])
+            .unwrap_or_default();
+    }
     match configured_local_agent(config).and_then(agent_type_name) {
         Some(name) => vec![name.to_string()],
         None => Vec::new(),

--- a/apps/daemon/src/http/workspaces.rs
+++ b/apps/daemon/src/http/workspaces.rs
@@ -487,6 +487,7 @@ fn backend_label(backend: &str) -> &'static str {
     match backend {
         "opencode" => "OpenCode",
         "pi" => "Pi",
+        "cursor" => "Cursor",
         "claude" => "Claude Code",
         "codex" => "Codex",
         _ => "Agent",
@@ -533,19 +534,19 @@ pub fn build_model_catalog(
     // configured local backend ("opencode" or "pi"); legacy names are skipped
     // defensively.
     for backend in configured_agent_types {
-        if backend != "opencode" && backend != "pi" {
+        if backend != "opencode" && backend != "pi" && backend != "cursor" {
             continue;
         }
         // No static fallback: the live probe first. OpenCode additionally reads
         // the workspace's configured `opencode.json` providers when the probe
-        // is empty; pi has no provider-file fallback. If nothing resolves, the
-        // group is served with no models — clients show the "no models" hint
+        // is empty; pi/cursor have no provider-file fallback. If nothing resolves,
+        // the group is served with no models — clients show the "no models" hint
         // rather than a phantom default.
         let probed: Vec<CatalogModel> = probed_models
             .filter(|m| !m.is_empty())
             .map(catalog_models_from_acp)
             .unwrap_or_default();
-        let models = if !probed.is_empty() || backend == "pi" {
+        let models = if !probed.is_empty() || backend == "pi" || backend == "cursor" {
             probed
         } else {
             catalog_models_from_opencode_json(opencode_providers)

--- a/apps/daemon/src/main.rs
+++ b/apps/daemon/src/main.rs
@@ -15,6 +15,7 @@ mod nats;
 mod onboarding;
 mod opencode_install;
 mod opencode_settings;
+mod cursor_install;
 mod pi_install;
 mod proto;
 mod provider_config;

--- a/apps/daemon/src/opencode_install/mod.rs
+++ b/apps/daemon/src/opencode_install/mod.rs
@@ -458,6 +458,9 @@ pub struct DoctorReport {
     /// pi runtime status; populated only when `agents.local_agent == "pi"`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pi: Option<crate::pi_install::PiStatus>,
+    /// Cursor SDK status; populated only when `agents.local_agent == "cursor"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<crate::cursor_install::CursorStatus>,
 }
 
 /// `<amuxd> --version` -> the first version-like token (clap prints "amuxd X.Y.Z").
@@ -553,6 +556,7 @@ pub fn doctor() -> DoctorReport {
         git,
         amuxd,
         pi: None,
+        cursor: None,
     }
 }
 
@@ -699,9 +703,11 @@ mod tests {
                 satisfied: true,
             },
             pi: None,
+            cursor: None,
         };
         let v: serde_json::Value = serde_json::to_value(&report).unwrap();
         assert!(v.get("pi").is_none(), "pi omitted when None");
+        assert!(v.get("cursor").is_none(), "cursor omitted when None");
         assert_eq!(v["opencode"]["satisfied"], serde_json::json!(true));
         assert!(
             v["opencode"].get("requiredVersion").is_none(),

--- a/apps/daemon/src/runtime/backend.rs
+++ b/apps/daemon/src/runtime/backend.rs
@@ -287,6 +287,7 @@ impl AgentBackend for OpencodeHttpBackend {
 pub fn create_backend(local_agent: &str) -> Box<dyn AgentBackend> {
     match local_agent {
         "pi" => Box::new(super::pi_rpc::PiRpcBackend::new()),
+        "cursor" => Box::new(super::cursor_sdk::CursorSdkBackend::new()),
         "opencode" => Box::new(OpencodeHttpBackend::new()),
         other => {
             warn!(

--- a/apps/daemon/src/runtime/cursor_sdk/client.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/client.rs
@@ -1,0 +1,104 @@
+//! JSONL command client for one cursor-bridge child process.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+use tokio::sync::oneshot;
+use tracing::warn;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+struct Inner {
+    stdin: tokio::sync::Mutex<tokio::process::ChildStdin>,
+    pending: parking_lot::Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>,
+    next_id: AtomicU64,
+}
+
+#[derive(Clone)]
+pub struct CursorClient(Arc<Inner>);
+
+impl CursorClient {
+    pub fn new(stdin: tokio::process::ChildStdin) -> Self {
+        Self(Arc::new(Inner {
+            stdin: tokio::sync::Mutex::new(stdin),
+            pending: parking_lot::Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+        }))
+    }
+
+    async fn write_line(&self, value: &serde_json::Value) -> crate::error::Result<()> {
+        let mut line = serde_json::to_string(value)
+            .map_err(|e| crate::error::AmuxError::Agent(format!("cursor command encode: {e}")))?;
+        line.push('\n');
+        let mut stdin = self.0.stdin.lock().await;
+        stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(|e| crate::error::AmuxError::Agent(format!("cursor stdin write: {e}")))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|e| crate::error::AmuxError::Agent(format!("cursor stdin flush: {e}")))
+    }
+
+    pub async fn request(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> crate::error::Result<serde_json::Value> {
+        let id = format!("tc-{}", self.0.next_id.fetch_add(1, Ordering::Relaxed));
+        let cmd = serde_json::json!({ "id": id, "method": method, "params": params });
+
+        let (tx, rx) = oneshot::channel();
+        self.0.pending.lock().insert(id.clone(), tx);
+        if let Err(e) = self.write_line(&cmd).await {
+            self.0.pending.lock().remove(&id);
+            return Err(e);
+        }
+
+        let response = match tokio::time::timeout(REQUEST_TIMEOUT, rx).await {
+            Ok(Ok(v)) => v,
+            Ok(Err(_)) => {
+                return Err(crate::error::AmuxError::Agent(format!(
+                    "cursor {method}: bridge exited before responding"
+                )))
+            }
+            Err(_) => {
+                self.0.pending.lock().remove(&id);
+                return Err(crate::error::AmuxError::Agent(format!(
+                    "cursor {method}: response timed out"
+                )));
+            }
+        };
+
+        if let Some(err) = response.get("error").and_then(|v| v.as_str()) {
+            return Err(crate::error::AmuxError::Agent(format!(
+                "cursor {method} failed: {err}"
+            )));
+        }
+        Ok(response.get("result").cloned().unwrap_or(serde_json::Value::Null))
+    }
+
+    pub fn resolve_response(&self, response: &serde_json::Value) -> bool {
+        let Some(id) = response.get("id").and_then(|v| v.as_str()) else {
+            return false;
+        };
+        match self.0.pending.lock().remove(id) {
+            Some(tx) => {
+                let _ = tx.send(response.clone());
+                true
+            }
+            None => {
+                warn!(id, "cursor response with no pending request");
+                false
+            }
+        }
+    }
+
+    pub fn fail_all_pending(&self) {
+        self.0.pending.lock().clear();
+    }
+}

--- a/apps/daemon/src/runtime/cursor_sdk/events.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/events.rs
@@ -1,0 +1,205 @@
+//! cursor-bridge stdout event routing.
+
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tracing::{debug, info, warn};
+
+use crate::proto::amux;
+use crate::runtime::acp_event_frame::AcpEventFrame;
+
+use super::client::CursorClient;
+use super::{translate, Shared};
+
+pub(super) fn spawn_reader(
+    shared: Arc<Shared>,
+    worktree: String,
+    stdout: tokio::process::ChildStdout,
+    client: CursorClient,
+) {
+    tokio::spawn(async move {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line).await {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(e) => {
+                    warn!(worktree, error = %e, "cursor stdout read error");
+                    break;
+                }
+            }
+            let trimmed = line.trim_end_matches(['\n', '\r']);
+            if trimmed.is_empty() {
+                continue;
+            }
+            let json: serde_json::Value = match serde_json::from_str(trimmed) {
+                Ok(v) => v,
+                Err(e) => {
+                    debug!(worktree, error = %e, "cursor stdout non-JSON dropped");
+                    continue;
+                }
+            };
+            if json.get("id").is_some() {
+                client.resolve_response(&json);
+                continue;
+            }
+            if json.get("event").is_some() {
+                handle_event(&shared, &json).await;
+            }
+        }
+        close_all_turns_for_worktree(&shared, &worktree).await;
+        client.fail_all_pending();
+        info!(worktree, "cursor bridge stdout closed");
+    });
+}
+
+async fn close_all_turns_for_worktree(shared: &Arc<Shared>, worktree: &str) {
+    let session_ids: Vec<String> = shared
+        .routes
+        .lock()
+        .iter()
+        .filter(|(_, r)| r.worktree == worktree && r.turn_active)
+        .map(|(id, _)| id.clone())
+        .collect();
+    for session_id in session_ids {
+        close_turn(shared, &session_id).await;
+    }
+}
+
+async fn handle_event(shared: &Arc<Shared>, event: &serde_json::Value) {
+    let event_name = event.get("event").and_then(|v| v.as_str()).unwrap_or("");
+    let agent_id = event.get("agentId").and_then(|v| v.as_str()).unwrap_or("");
+    if agent_id.is_empty() {
+        return;
+    }
+    let session_id = format!("{}{}", super::SESSION_ID_PREFIX, agent_id);
+
+    if event_name == "permission_request" {
+        handle_permission(shared, &session_id, event).await;
+        return;
+    }
+
+    if event_name == "turn_end" {
+        close_turn(shared, &session_id).await;
+    }
+
+    let (events, event_tx, reply_to) = {
+        let mut routes = shared.routes.lock();
+        let Some(route) = routes.get_mut(&session_id) else {
+            debug!(session_id, event_name, "cursor event for unrouted session dropped");
+            return;
+        };
+        if event_name == "turn_start" {
+            route.turn_active = true;
+        }
+        (
+            translate::translate_event(&mut route.translate, event),
+            route.event_tx.clone(),
+            route.turn_reply_to.clone(),
+        )
+    };
+
+    for ev in events {
+        crate::runtime::agent_trace::log_acp_event(&session_id, &ev);
+        let _ = event_tx
+            .send(AcpEventFrame::new(session_id.clone(), ev).with_reply_to(reply_to.clone()))
+            .await;
+    }
+}
+
+async fn handle_permission(shared: &Arc<Shared>, session_id: &str, event: &serde_json::Value) {
+    let request_id = event
+        .get("requestId")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    if request_id.is_empty() {
+        return;
+    }
+    let (is_gateway, event_tx, requester, reply_to, worktree, agent_id) = {
+        let routes = shared.routes.lock();
+        let Some(route) = routes.get(session_id) else {
+            return;
+        };
+        (
+            route.is_gateway,
+            route.event_tx.clone(),
+            route.turn_requester.clone(),
+            route.turn_reply_to.clone(),
+            route.worktree.clone(),
+            route.agent_id.clone(),
+        )
+    };
+
+    if is_gateway {
+        if let Some(proc) = shared.pool.get(&worktree) {
+            let _ = proc
+                .client
+                .request(
+                    "resolve_permission",
+                    serde_json::json!({ "agentId": agent_id, "requestId": request_id, "granted": true }),
+                )
+                .await;
+        }
+        return;
+    }
+
+    let mut params = std::collections::HashMap::new();
+    params.insert("request_id".to_string(), request_id.clone());
+    if let Some(actor) = requester {
+        params.insert("requester_actor_id".to_string(), actor);
+    }
+    let ev = amux::AcpEvent {
+        event: Some(amux::acp_event::Event::PermissionRequest(
+            amux::AcpPermissionRequest {
+                request_id: request_id.clone(),
+                tool_name: "cursor".to_string(),
+                description: "Cursor agent permission request".to_string(),
+                params,
+                options: vec![],
+            },
+        )),
+        model: String::new(),
+    };
+    shared.permissions.lock().insert(
+        request_id.clone(),
+        super::PendingPermission {
+            session_id: session_id.to_string(),
+            agent_id,
+            request_id,
+        },
+    );
+    crate::runtime::agent_trace::log_acp_event(session_id, &ev);
+    let _ = event_tx
+        .send(AcpEventFrame::new(session_id.to_string(), ev).with_reply_to(reply_to))
+        .await;
+}
+
+pub(super) async fn close_turn(shared: &Arc<Shared>, session_id: &str) {
+    let closed = {
+        let mut routes = shared.routes.lock();
+        let Some(route) = routes.get_mut(session_id) else {
+            return;
+        };
+        if !route.turn_active {
+            None
+        } else {
+            route.turn_active = false;
+            let reply_to = route.turn_reply_to.take();
+            route.turn_requester = None;
+            Some((route.event_tx.clone(), reply_to))
+        }
+    };
+    if let Some((event_tx, reply_to)) = closed {
+        let ev = crate::runtime::opencode_http::translate::status_change(
+            amux::AgentStatus::Active,
+            amux::AgentStatus::Idle,
+        );
+        crate::runtime::agent_trace::log_acp_event(session_id, &ev);
+        let _ = event_tx
+            .send(AcpEventFrame::new(session_id.to_string(), ev).with_reply_to(reply_to))
+            .await;
+    }
+}

--- a/apps/daemon/src/runtime/cursor_sdk/events.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/events.rs
@@ -118,13 +118,13 @@ async fn handle_permission(shared: &Arc<Shared>, session_id: &str, event: &serde
     if request_id.is_empty() {
         return;
     }
-    let (is_gateway, event_tx, requester, reply_to, worktree, agent_id) = {
+    let (permission, event_tx, requester, reply_to, worktree, agent_id) = {
         let routes = shared.routes.lock();
         let Some(route) = routes.get(session_id) else {
             return;
         };
         (
-            route.is_gateway,
+            route.permission,
             route.event_tx.clone(),
             route.turn_requester.clone(),
             route.turn_reply_to.clone(),
@@ -133,7 +133,7 @@ async fn handle_permission(shared: &Arc<Shared>, session_id: &str, event: &serde
         )
     };
 
-    if is_gateway {
+    if permission.is_full_access() {
         if let Some(proc) = shared.pool.get(&worktree) {
             let _ = proc
                 .client

--- a/apps/daemon/src/runtime/cursor_sdk/mod.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/mod.rs
@@ -1,0 +1,701 @@
+//! Cursor SDK backend (`cursor-bridge` + `@cursor/sdk`).
+//!
+//! Peer of `runtime/pi_rpc/` behind [`AgentBackend`]: one Node sidecar per
+//! worktree (JSONL over stdin/stdout), sessions keyed as `cursor:<agentId>`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use crate::config::{CursorAgentConfig, DaemonConfig};
+use crate::proto::amux;
+use crate::runtime::acp_event_frame::AcpEventFrame;
+use crate::runtime::backend::{AcpCommand, AcpStartupMetadata, AgentBackend};
+use crate::runtime::manager::AgentLaunchConfig;
+use crate::runtime::opencode_http::translate::status_change;
+
+pub mod client;
+mod events;
+pub mod process;
+pub mod translate;
+
+use process::CursorProcessPool;
+use translate::TranslateState;
+
+pub const SESSION_ID_PREFIX: &str = "cursor:";
+
+pub(crate) struct Route {
+    pub(crate) event_tx: mpsc::Sender<AcpEventFrame>,
+    pub(crate) is_gateway: bool,
+    pub(crate) worktree: String,
+    pub(crate) agent_id: String,
+    pub(crate) turn_active: bool,
+    pub(crate) turn_reply_to: Option<String>,
+    pub(crate) turn_requester: Option<String>,
+    pub(crate) translate: TranslateState,
+    pub(crate) model: String,
+}
+
+pub(crate) struct PendingPermission {
+    pub(crate) session_id: String,
+    pub(crate) agent_id: String,
+    pub(crate) request_id: String,
+}
+
+pub(crate) struct Shared {
+    pub(crate) pool: CursorProcessPool,
+    pub(crate) routes: parking_lot::Mutex<HashMap<String, Route>>,
+    pub(crate) permissions: parking_lot::Mutex<HashMap<String, PendingPermission>>,
+}
+
+impl Shared {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            pool: CursorProcessPool::new(),
+            routes: parking_lot::Mutex::new(HashMap::new()),
+            permissions: parking_lot::Mutex::new(HashMap::new()),
+        })
+    }
+}
+
+fn canonical_dir(worktree: &str) -> String {
+    std::fs::canonicalize(worktree)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| worktree.to_string())
+}
+
+fn apply_cursor_config(pool: &CursorProcessPool, cursor: Option<&CursorAgentConfig>) {
+    let Some(cfg) = cursor else {
+        return;
+    };
+    pool.configure(
+        cfg.bridge_command.clone(),
+        cfg.api_key.clone(),
+        cfg.default_model.clone(),
+    );
+}
+
+fn load_cursor_pool_config(pool: &CursorProcessPool) {
+    let cfg = DaemonConfig::load(&DaemonConfig::default_path()).ok();
+    apply_cursor_config(pool, cfg.as_ref().and_then(|c| c.agents.cursor.as_ref()));
+}
+
+fn models_from_list(result: &serde_json::Value) -> Vec<amux::ModelInfo> {
+    result
+        .get("models")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| {
+                    let id = m.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                    if id.is_empty() {
+                        return None;
+                    }
+                    Some(amux::ModelInfo {
+                        id: id.to_string(),
+                        display_name: m
+                            .get("displayName")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(id)
+                            .to_string(),
+                        provider_name: m
+                            .get("providerName")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("cursor")
+                            .to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn sdk_model_from_flat(flat: &str) -> String {
+    flat.strip_prefix("cursor/")
+        .unwrap_or(flat)
+        .to_string()
+}
+
+fn pick_initial_model(
+    available: &[amux::ModelInfo],
+    override_model: Option<&str>,
+    model_mru: &[String],
+    default_model: &str,
+) -> String {
+    if let Some(m) = override_model.filter(|s| !s.is_empty()) {
+        return m.to_string();
+    }
+    for mru in model_mru {
+        if available.iter().any(|m| &m.id == mru) {
+            return mru.clone();
+        }
+    }
+    if available
+        .iter()
+        .any(|m| m.id == format!("cursor/{default_model}"))
+    {
+        return format!("cursor/{default_model}");
+    }
+    available
+        .first()
+        .map(|m| m.id.clone())
+        .unwrap_or_else(|| format!("cursor/{default_model}"))
+}
+
+struct AttachArgs {
+    worktree: String,
+    resume_acp_session_id: Option<String>,
+    initial_model_override: Option<String>,
+    model_mru: Vec<String>,
+    event_tx: mpsc::Sender<AcpEventFrame>,
+    is_gateway: bool,
+    forbid_new_session_fallback: bool,
+}
+
+async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMetadata, String> {
+    load_cursor_pool_config(&shared.pool);
+    let worktree = canonical_dir(&args.worktree);
+    let proc = shared
+        .pool
+        .ensure(shared, &worktree)
+        .map_err(|e| e.to_string())?;
+
+    let models_resp = proc
+        .client
+        .request("list_models", serde_json::json!({}))
+        .await
+        .map_err(|e| e.to_string())?;
+    let available_models = models_from_list(&models_resp);
+
+    let default_model = DaemonConfig::load(&DaemonConfig::default_path())
+        .ok()
+        .and_then(|c| c.agents.cursor.and_then(|x| x.default_model))
+        .unwrap_or_else(|| "composer-2.5".to_string());
+
+    let initial_flat = pick_initial_model(
+        &available_models,
+        args.initial_model_override.as_deref(),
+        &args.model_mru,
+        &default_model,
+    );
+    let sdk_model = sdk_model_from_flat(&initial_flat);
+
+    let resume_agent_id = args
+        .resume_acp_session_id
+        .as_deref()
+        .and_then(|id| id.strip_prefix(SESSION_ID_PREFIX))
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    let create_resp = if let Some(agent_id) = resume_agent_id {
+        match proc
+            .client
+            .request(
+                "resume_agent",
+                serde_json::json!({
+                    "agentId": agent_id,
+                    "cwd": worktree,
+                    "model": initial_flat,
+                }),
+            )
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                if args.forbid_new_session_fallback {
+                    return Err(format!(
+                        "cursor agent {agent_id} not resumable (new-session fallback forbidden): {e}"
+                    ));
+                }
+                warn!(agent_id, error = %e, "cursor resume failed; creating new agent");
+                proc.client
+                    .request(
+                        "create_agent",
+                        serde_json::json!({
+                            "cwd": worktree,
+                            "model": initial_flat,
+                        }),
+                    )
+                    .await
+                    .map_err(|e| e.to_string())?
+            }
+        }
+    } else {
+        proc.client
+            .request(
+                "create_agent",
+                serde_json::json!({
+                    "cwd": worktree,
+                    "model": initial_flat,
+                }),
+            )
+            .await
+            .map_err(|e| e.to_string())?
+    };
+
+    let agent_id = create_resp
+        .get("agentId")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "cursor create_agent missing agentId".to_string())?
+        .to_string();
+    let session_id = format!("{SESSION_ID_PREFIX}{agent_id}");
+
+    shared.routes.lock().insert(
+        session_id.clone(),
+        Route {
+            event_tx: args.event_tx,
+            is_gateway: args.is_gateway,
+            worktree: worktree.clone(),
+            agent_id: agent_id.clone(),
+            turn_active: false,
+            turn_reply_to: None,
+            turn_requester: None,
+            translate: TranslateState::default(),
+            model: initial_flat.clone(),
+        },
+    );
+
+    let _ = sdk_model;
+
+    Ok(AcpStartupMetadata {
+        available_models,
+        initial_model: Some(initial_flat),
+        acp_session_id: session_id,
+    })
+}
+
+async fn emit_frame(
+    event_tx: &mpsc::Sender<AcpEventFrame>,
+    session_id: &str,
+    ev: amux::AcpEvent,
+    reply_to: Option<String>,
+) {
+    crate::runtime::agent_trace::log_acp_event(session_id, &ev);
+    let _ = event_tx
+        .send(AcpEventFrame::new(session_id.to_string(), ev).with_reply_to(reply_to))
+        .await;
+}
+
+async fn do_prompt(
+    shared: &Arc<Shared>,
+    session_id: &str,
+    text: String,
+    attachment_urls: Vec<String>,
+    requester_actor_id: Option<String>,
+    reply_to_message_id: Option<String>,
+) {
+    let reply_to = reply_to_message_id.filter(|id| !id.is_empty());
+    let (event_tx, worktree, agent_id) = {
+        let mut routes = shared.routes.lock();
+        let Some(route) = routes.get_mut(session_id) else {
+            warn!(session_id, "prompt for unknown cursor session");
+            return;
+        };
+        route.turn_active = true;
+        route.turn_reply_to = reply_to.clone();
+        route.turn_requester = requester_actor_id.filter(|id| !id.is_empty());
+        (
+            route.event_tx.clone(),
+            route.worktree.clone(),
+            route.agent_id.clone(),
+        )
+    };
+
+    crate::runtime::agent_trace::log_prompt_begin(session_id, &text, attachment_urls.len());
+    emit_frame(
+        &event_tx,
+        session_id,
+        status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
+        reply_to.clone(),
+    )
+    .await;
+
+    let mut message = text;
+    if !attachment_urls.is_empty() {
+        message.push_str("\n\nAttachments:\n");
+        for url in &attachment_urls {
+            message.push_str(url);
+            message.push('\n');
+        }
+    }
+
+    let result = match shared.pool.ensure(shared, &worktree) {
+        Ok(proc) => {
+            proc.client
+                .request(
+                    "send",
+                    serde_json::json!({ "agentId": agent_id, "text": message }),
+                )
+                .await
+        }
+        Err(e) => Err(e),
+    };
+
+    if let Err(e) = result {
+        let details = e.to_string();
+        crate::runtime::agent_trace::log_prompt_end(session_id, false, &details, 0);
+        emit_frame(
+            &event_tx,
+            session_id,
+            amux::AcpEvent {
+                event: Some(amux::acp_event::Event::Error(amux::AcpError {
+                    message: "cursor prompt failed".to_string(),
+                    details,
+                })),
+                model: String::new(),
+            },
+            reply_to.clone(),
+        )
+        .await;
+        {
+            let mut routes = shared.routes.lock();
+            if let Some(route) = routes.get_mut(session_id) {
+                route.turn_active = false;
+                route.turn_reply_to = None;
+                route.turn_requester = None;
+            }
+        }
+        emit_frame(
+            &event_tx,
+            session_id,
+            status_change(amux::AgentStatus::Active, amux::AgentStatus::Idle),
+            reply_to,
+        )
+        .await;
+    }
+}
+
+async fn resolve_permission(
+    shared: &Arc<Shared>,
+    request_id: &str,
+    granted: bool,
+) {
+    let Some(pending) = shared.permissions.lock().remove(request_id) else {
+        warn!(request_id, "no pending cursor permission");
+        return;
+    };
+    let worktree = shared
+        .routes
+        .lock()
+        .get(&pending.session_id)
+        .map(|r| r.worktree.clone())
+        .unwrap_or_default();
+    let Some(proc) = shared.pool.get(&worktree) else {
+        return;
+    };
+    let _ = proc
+        .client
+        .request(
+            "resolve_permission",
+            serde_json::json!({
+                "agentId": pending.agent_id,
+                "requestId": pending.request_id,
+                "granted": granted,
+            }),
+        )
+        .await;
+}
+
+async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand>) {
+    while let Some(cmd) = cmd_rx.recv().await {
+        match cmd {
+            AcpCommand::AttachSession {
+                worktree,
+                resume_acp_session_id,
+                initial_model_override,
+                model_mru,
+                initial_prompt,
+                event_tx,
+                startup_tx,
+                is_gateway,
+                forbid_new_session_fallback,
+                ..
+            } => {
+                let result = attach(
+                    &shared,
+                    AttachArgs {
+                        worktree,
+                        resume_acp_session_id,
+                        initial_model_override,
+                        model_mru,
+                        event_tx,
+                        is_gateway,
+                        forbid_new_session_fallback,
+                    },
+                )
+                .await;
+                let follow_up = result
+                    .as_ref()
+                    .ok()
+                    .filter(|_| !initial_prompt.is_empty())
+                    .map(|meta| meta.acp_session_id.clone());
+                let _ = startup_tx.send(result);
+                if let Some(session_id) = follow_up {
+                    do_prompt(&shared, &session_id, initial_prompt, Vec::new(), None, None).await;
+                }
+            }
+            AcpCommand::Prompt {
+                acp_session_id,
+                text,
+                attachment_urls,
+                requester_actor_id,
+                reply_to_message_id,
+            } => {
+                do_prompt(
+                    &shared,
+                    &acp_session_id,
+                    text,
+                    attachment_urls,
+                    requester_actor_id,
+                    reply_to_message_id,
+                )
+                .await;
+            }
+            AcpCommand::Cancel { acp_session_id } => {
+                let (worktree, agent_id) = {
+                    let routes = shared.routes.lock();
+                    let Some(route) = routes.get(&acp_session_id) else {
+                        continue;
+                    };
+                    (route.worktree.clone(), route.agent_id.clone())
+                };
+                if let Ok(proc) = shared.pool.ensure(&shared, &worktree) {
+                    let _ = proc
+                        .client
+                        .request(
+                            "cancel",
+                            serde_json::json!({ "agentId": agent_id }),
+                        )
+                        .await;
+                }
+                events::close_turn(&shared, &acp_session_id).await;
+            }
+            AcpCommand::ResolvePermission {
+                request_id,
+                granted,
+                ..
+            } => resolve_permission(&shared, &request_id, granted).await,
+            AcpCommand::SetModel {
+                acp_session_id,
+                model_id,
+            } => {
+                let (worktree, agent_id) = {
+                    let mut routes = shared.routes.lock();
+                    let Some(route) = routes.get_mut(&acp_session_id) else {
+                        continue;
+                    };
+                    route.model = model_id.clone();
+                    (route.worktree.clone(), route.agent_id.clone())
+                };
+                if let Ok(proc) = shared.pool.ensure(&shared, &worktree) {
+                    let _ = proc
+                        .client
+                        .request(
+                            "set_model",
+                            serde_json::json!({ "agentId": agent_id, "model": model_id }),
+                        )
+                        .await;
+                }
+            }
+            AcpCommand::DetachSession { acp_session_id } => {
+                shared.routes.lock().remove(&acp_session_id);
+            }
+            AcpCommand::AnswerQuestion { .. } => {
+                warn!("cursor backend: AnswerQuestion unsupported");
+            }
+            AcpCommand::Shutdown => {
+                shared.pool.kill_all();
+            }
+        }
+    }
+}
+
+pub struct CursorSdkBackend {
+    shared: Arc<Shared>,
+    cmd_tx: std::sync::OnceLock<mpsc::Sender<AcpCommand>>,
+}
+
+impl CursorSdkBackend {
+    pub fn new() -> Self {
+        let shared = Shared::new();
+        load_cursor_pool_config(&shared.pool);
+        Self {
+            shared,
+            cmd_tx: std::sync::OnceLock::new(),
+        }
+    }
+
+    fn command_sender(&self) -> mpsc::Sender<AcpCommand> {
+        self.cmd_tx
+            .get_or_init(|| {
+                let (tx, rx) = mpsc::channel::<AcpCommand>(64);
+                tokio::spawn(command_loop(Arc::clone(&self.shared), rx));
+                tx
+            })
+            .clone()
+    }
+}
+
+impl Default for CursorSdkBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AgentBackend for CursorSdkBackend {
+    async fn attach_session(
+        &mut self,
+        _agent_type: amux::AgentType,
+        _launch: &AgentLaunchConfig,
+        extra_env: HashMap<String, String>,
+        force_env_override: bool,
+        worktree: String,
+        resume_acp_session_id: Option<String>,
+        _mcp_config_path: Option<PathBuf>,
+        initial_model_override: Option<String>,
+        model_mru: Vec<String>,
+        initial_prompt: String,
+        event_tx: mpsc::Sender<AcpEventFrame>,
+        is_gateway: bool,
+        forbid_new_session_fallback: bool,
+    ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
+        load_cursor_pool_config(&self.shared.pool);
+        self.shared
+            .pool
+            .merge_extra_env(&extra_env, force_env_override);
+        let cmd_tx = self.command_sender();
+        let startup = attach(
+            &self.shared,
+            AttachArgs {
+                worktree,
+                resume_acp_session_id,
+                initial_model_override,
+                model_mru,
+                event_tx,
+                is_gateway,
+                forbid_new_session_fallback,
+            },
+        )
+        .await
+        .map_err(crate::error::AmuxError::Agent)?;
+        if !initial_prompt.is_empty() {
+            let _ = cmd_tx
+                .send(AcpCommand::Prompt {
+                    acp_session_id: startup.acp_session_id.clone(),
+                    text: initial_prompt,
+                    attachment_urls: Vec::new(),
+                    requester_actor_id: None,
+                    reply_to_message_id: None,
+                })
+                .await;
+        }
+        Ok((cmd_tx, startup))
+    }
+
+    async fn prewarm(&mut self, _launch_configs: &HashMap<amux::AgentType, AgentLaunchConfig>) {
+        load_cursor_pool_config(&self.shared.pool);
+    }
+
+    async fn prewarm_with_env(
+        &mut self,
+        _launch_configs: &HashMap<amux::AgentType, AgentLaunchConfig>,
+        extra_env: HashMap<String, String>,
+        force_env_override: bool,
+        worktree: Option<&str>,
+    ) {
+        load_cursor_pool_config(&self.shared.pool);
+        self.shared
+            .pool
+            .merge_extra_env(&extra_env, force_env_override);
+        if let Some(worktree) = worktree.filter(|w| !w.is_empty()) {
+            let worktree = canonical_dir(worktree);
+            if let Err(e) = self.shared.pool.ensure(&self.shared, &worktree) {
+                warn!(worktree, error = %e, "cursor prewarm failed");
+            } else {
+                info!(worktree, "cursor bridge prewarmed");
+            }
+        }
+    }
+
+    fn evict_agent_types(&mut self, _agent_types: &[amux::AgentType]) -> usize {
+        self.shared.pool.kill_all()
+    }
+
+    fn host_count(&self) -> usize {
+        self.shared.pool.live_count()
+    }
+
+    async fn session_model(
+        &mut self,
+        worktree: &str,
+        backend_session_id: &str,
+    ) -> Option<String> {
+        let session_id = backend_session_id.strip_prefix(SESSION_ID_PREFIX)?;
+        let worktree = canonical_dir(worktree);
+        let proc = self.shared.pool.get(&worktree)?;
+        let resp = proc
+            .client
+            .request(
+                "get_agent_info",
+                serde_json::json!({ "agentId": session_id }),
+            )
+            .await
+            .ok()?;
+        resp.get("model").and_then(|v| v.as_str()).map(str::to_string)
+    }
+
+    async fn model_catalog(
+        &mut self,
+        workspace_path: &Path,
+    ) -> crate::error::Result<Vec<amux::ModelInfo>> {
+        load_cursor_pool_config(&self.shared.pool);
+        let worktree = canonical_dir(&workspace_path.to_string_lossy());
+        let proc = match self
+            .shared
+            .pool
+            .get(&worktree)
+            .or_else(|| self.shared.pool.any_live())
+        {
+            Some(proc) => proc,
+            None => self.shared.pool.ensure(&self.shared, &worktree)?,
+        };
+        let resp = proc
+            .client
+            .request("list_models", serde_json::json!({}))
+            .await?;
+        Ok(models_from_list(&resp))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pick_initial_model_prefers_override() {
+        let available = vec![amux::ModelInfo {
+            id: "cursor/composer-2.5".into(),
+            display_name: "Composer".into(),
+            provider_name: "cursor".into(),
+        }];
+        assert_eq!(
+            pick_initial_model(
+                &available,
+                Some("cursor/claude-sonnet-5"),
+                &[],
+                "composer-2.5"
+            ),
+            "cursor/claude-sonnet-5"
+        );
+    }
+
+    #[test]
+    fn sdk_model_from_flat_strips_provider() {
+        assert_eq!(sdk_model_from_flat("cursor/composer-2.5"), "composer-2.5");
+    }
+}

--- a/apps/daemon/src/runtime/cursor_sdk/mod.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/mod.rs
@@ -17,6 +17,7 @@ use crate::runtime::acp_event_frame::AcpEventFrame;
 use crate::runtime::backend::{AcpCommand, AcpStartupMetadata, AgentBackend};
 use crate::runtime::manager::AgentLaunchConfig;
 use crate::runtime::opencode_http::translate::status_change;
+use crate::runtime::permission_policy::PermissionPolicy;
 
 pub mod client;
 mod events;
@@ -30,7 +31,7 @@ pub const SESSION_ID_PREFIX: &str = "cursor:";
 
 pub(crate) struct Route {
     pub(crate) event_tx: mpsc::Sender<AcpEventFrame>,
-    pub(crate) is_gateway: bool,
+    pub(crate) permission: PermissionPolicy,
     pub(crate) worktree: String,
     pub(crate) agent_id: String,
     pub(crate) turn_active: bool,
@@ -152,7 +153,7 @@ struct AttachArgs {
     initial_model_override: Option<String>,
     model_mru: Vec<String>,
     event_tx: mpsc::Sender<AcpEventFrame>,
-    is_gateway: bool,
+    permission: PermissionPolicy,
     forbid_new_session_fallback: bool,
 }
 
@@ -248,7 +249,7 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
         session_id.clone(),
         Route {
             event_tx: args.event_tx,
-            is_gateway: args.is_gateway,
+            permission: args.permission,
             worktree: worktree.clone(),
             agent_id: agent_id.clone(),
             turn_active: false,
@@ -411,7 +412,7 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                 initial_prompt,
                 event_tx,
                 startup_tx,
-                is_gateway,
+                permission,
                 forbid_new_session_fallback,
                 ..
             } => {
@@ -423,7 +424,7 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                         initial_model_override,
                         model_mru,
                         event_tx,
-                        is_gateway,
+                        permission,
                         forbid_new_session_fallback,
                     },
                 )
@@ -561,7 +562,7 @@ impl AgentBackend for CursorSdkBackend {
         model_mru: Vec<String>,
         initial_prompt: String,
         event_tx: mpsc::Sender<AcpEventFrame>,
-        is_gateway: bool,
+        permission: PermissionPolicy,
         forbid_new_session_fallback: bool,
     ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
         load_cursor_pool_config(&self.shared.pool);
@@ -577,7 +578,7 @@ impl AgentBackend for CursorSdkBackend {
                 initial_model_override,
                 model_mru,
                 event_tx,
-                is_gateway,
+                permission,
                 forbid_new_session_fallback,
             },
         )

--- a/apps/daemon/src/runtime/cursor_sdk/process.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/process.rs
@@ -1,0 +1,294 @@
+//! Per-worktree cursor-bridge process pool.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tracing::{info, warn};
+
+use super::client::CursorClient;
+use super::{events, Shared};
+
+pub(crate) struct CursorProcess {
+    pub(crate) client: CursorClient,
+    child: parking_lot::Mutex<tokio::process::Child>,
+    env_fingerprint: String,
+}
+
+impl CursorProcess {
+    pub(crate) fn is_alive(&self) -> bool {
+        matches!(self.child.lock().try_wait(), Ok(None))
+    }
+
+    pub(crate) fn kill(&self) {
+        let _ = self.child.lock().start_kill();
+    }
+}
+
+pub(crate) struct CursorProcessPool {
+    procs: parking_lot::Mutex<HashMap<String, Arc<CursorProcess>>>,
+    bridge_command: parking_lot::Mutex<Option<Vec<String>>>,
+    api_key: parking_lot::Mutex<Option<String>>,
+    default_model: parking_lot::Mutex<String>,
+    /// Extra env from spawn assembly; applied on (re)spawn.
+    extra_env: parking_lot::Mutex<HashMap<String, String>>,
+    force_env_override: parking_lot::Mutex<bool>,
+}
+
+impl CursorProcessPool {
+    pub(crate) fn new() -> Self {
+        Self {
+            procs: parking_lot::Mutex::new(HashMap::new()),
+            bridge_command: parking_lot::Mutex::new(None),
+            api_key: parking_lot::Mutex::new(None),
+            default_model: parking_lot::Mutex::new("composer-2.5".to_string()),
+            extra_env: parking_lot::Mutex::new(HashMap::new()),
+            force_env_override: parking_lot::Mutex::new(false),
+        }
+    }
+
+    pub(crate) fn configure(
+        &self,
+        bridge_command: Option<Vec<String>>,
+        api_key: Option<String>,
+        default_model: Option<String>,
+    ) {
+        if let Some(cmd) = bridge_command.filter(|c| !c.is_empty()) {
+            *self.bridge_command.lock() = Some(cmd);
+        }
+        if let Some(key) = api_key.filter(|k| !k.trim().is_empty()) {
+            *self.api_key.lock() = Some(key);
+        }
+        if let Some(model) = default_model.filter(|m| !m.trim().is_empty()) {
+            *self.default_model.lock() = model;
+        }
+    }
+
+    /// Merge session env into the env applied at (re)spawn (first-wins per key).
+    pub(crate) fn merge_extra_env(&self, extra_env: &HashMap<String, String>, force: bool) {
+        if force {
+            *self.force_env_override.lock() = true;
+        }
+        if extra_env.is_empty() {
+            return;
+        }
+        let mut env = self.extra_env.lock();
+        for (k, v) in extra_env {
+            env.entry(k.clone()).or_insert_with(|| v.clone());
+        }
+    }
+
+    fn env_fingerprint(&self) -> String {
+        let cmd = self
+            .bridge_command
+            .lock()
+            .clone()
+            .unwrap_or_else(default_bridge_command);
+        let key = self.api_key.lock().clone().unwrap_or_default();
+        let model = self.default_model.lock().clone();
+        let force = *self.force_env_override.lock();
+        let mut extra: Vec<String> = self
+            .extra_env
+            .lock()
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+        extra.sort();
+        format!(
+            "cmd={cmd:?}\x1fkey={key}\x1fmodel={model}\x1fforce={force}\x1fextra={}",
+            extra.join("\x1e")
+        )
+    }
+
+    pub(crate) fn get(&self, worktree: &str) -> Option<Arc<CursorProcess>> {
+        let mut procs = self.procs.lock();
+        match procs.get(worktree) {
+            Some(p) if p.is_alive() => Some(Arc::clone(p)),
+            Some(_) => {
+                procs.remove(worktree);
+                None
+            }
+            None => None,
+        }
+    }
+
+    pub(crate) fn any_live(&self) -> Option<Arc<CursorProcess>> {
+        self.procs
+            .lock()
+            .values()
+            .find(|p| p.is_alive())
+            .map(Arc::clone)
+    }
+
+    pub(crate) fn live_count(&self) -> usize {
+        self.procs.lock().values().filter(|p| p.is_alive()).count()
+    }
+
+    pub(crate) fn kill_all(&self) -> usize {
+        let procs: Vec<Arc<CursorProcess>> = self.procs.lock().drain().map(|(_, p)| p).collect();
+        let mut killed = 0;
+        for p in procs {
+            if p.is_alive() {
+                p.kill();
+                killed += 1;
+            }
+        }
+        killed
+    }
+
+    pub(crate) fn ensure(
+        &self,
+        shared: &Arc<Shared>,
+        worktree: &str,
+    ) -> crate::error::Result<Arc<CursorProcess>> {
+        let want = self.env_fingerprint();
+        if let Some(p) = self.get(worktree) {
+            if p.env_fingerprint == want {
+                return Ok(p);
+            }
+            info!(worktree, "cursor bridge env changed; respawning");
+            p.kill();
+            self.procs.lock().remove(worktree);
+        }
+        let proc = self.spawn(shared, worktree)?;
+        self.procs
+            .lock()
+            .insert(worktree.to_string(), Arc::clone(&proc));
+        Ok(proc)
+    }
+
+    fn spawn(
+        &self,
+        shared: &Arc<Shared>,
+        worktree: &str,
+    ) -> crate::error::Result<Arc<CursorProcess>> {
+        let bridge = self
+            .bridge_command
+            .lock()
+            .clone()
+            .unwrap_or_else(default_bridge_command);
+        if bridge.is_empty() {
+            return Err(crate::error::AmuxError::Agent(
+                "cursor bridge command is empty".into(),
+            ));
+        }
+
+        let api_key = self
+            .api_key
+            .lock()
+            .clone()
+            .or_else(|| std::env::var("CURSOR_API_KEY").ok())
+            .filter(|k| !k.trim().is_empty())
+            .ok_or_else(|| {
+                crate::error::AmuxError::Agent(
+                    "CURSOR_API_KEY is not set; configure [agents.cursor].api_key or the env var"
+                        .into(),
+                )
+            })?;
+
+        let mut cmd = tokio::process::Command::new(&bridge[0]);
+        for arg in bridge.iter().skip(1) {
+            cmd.arg(arg);
+        }
+        cmd.current_dir(worktree)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        cmd.env(
+            "PATH",
+            crate::runtime::opencode_http::enriched_spawn_path(
+                std::env::var("PATH").ok().as_deref(),
+                dirs::home_dir().as_deref(),
+            ),
+        );
+        let force = *self.force_env_override.lock();
+        for (k, v) in self.extra_env.lock().iter() {
+            if force || std::env::var_os(k).is_none() {
+                cmd.env(k, v);
+            }
+        }
+        // Always win over any injected duplicate.
+        cmd.env("CURSOR_API_KEY", api_key);
+
+        info!(worktree, bridge = ?bridge, "spawning cursor-bridge");
+        let mut child = cmd.spawn().map_err(|e| {
+            let hint = if e.kind() == std::io::ErrorKind::NotFound {
+                "node or cursor-bridge not found; run npm install in apps/daemon/cursor-bridge"
+                    .to_string()
+            } else {
+                format!("spawn cursor-bridge: {e}")
+            };
+            crate::error::AmuxError::Agent(hint)
+        })?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| crate::error::AmuxError::Agent("cursor stdin unavailable".into()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| crate::error::AmuxError::Agent("cursor stdout unavailable".into()))?;
+        if let Some(stderr) = child.stderr.take() {
+            tokio::spawn(async move {
+                let mut reader = BufReader::new(stderr);
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    match reader.read_line(&mut line).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => {
+                            let trimmed = line.trim();
+                            if !trimmed.is_empty() {
+                                tracing::debug!(target: "cursor_bridge", "{trimmed}");
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        let client = CursorClient::new(stdin);
+        events::spawn_reader(Arc::clone(shared), worktree.to_string(), stdout, client.clone());
+
+        Ok(Arc::new(CursorProcess {
+            client,
+            child: parking_lot::Mutex::new(child),
+            env_fingerprint: self.env_fingerprint(),
+        }))
+    }
+}
+
+pub fn default_bridge_main() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("cursor-bridge/src/main.mjs")
+}
+
+pub fn default_bridge_command() -> Vec<String> {
+    vec![
+        "node".to_string(),
+        default_bridge_main().to_string_lossy().into_owned(),
+        "--mode".to_string(),
+        "rpc".to_string(),
+    ]
+}
+
+pub fn resolve_bridge_command(configured: Option<&[String]>) -> Vec<String> {
+    configured
+        .filter(|c| !c.is_empty())
+        .map(|c| c.to_vec())
+        .unwrap_or_else(default_bridge_command)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_bridge_command_includes_main_script() {
+        let cmd = default_bridge_command();
+        assert_eq!(cmd[0], "node");
+        assert!(cmd[1].ends_with("cursor-bridge/src/main.mjs"));
+    }
+}

--- a/apps/daemon/src/runtime/cursor_sdk/translate.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/translate.rs
@@ -1,0 +1,148 @@
+//! cursor-bridge events → `amux::AcpEvent`.
+
+use std::collections::HashMap;
+
+use crate::proto::amux;
+use crate::runtime::opencode_http::translate::truncate_tool_summary;
+
+#[derive(Debug, Default)]
+pub struct TranslateState {
+    emitted_text: HashMap<String, usize>,
+}
+
+impl TranslateState {
+    pub fn reset_turn(&mut self) {
+        self.emitted_text.clear();
+    }
+}
+
+fn text_event(kind: &str, text: String) -> amux::AcpEvent {
+    let event = if kind == "thinking_delta" {
+        amux::acp_event::Event::Thinking(amux::AcpThinking { text })
+    } else {
+        amux::acp_event::Event::Output(amux::AcpOutput {
+            text,
+            is_complete: false,
+        })
+    };
+    amux::AcpEvent {
+        event: Some(event),
+        model: String::new(),
+    }
+}
+
+fn params_from_map(args: &serde_json::Value) -> HashMap<String, String> {
+    match args {
+        serde_json::Value::Object(map) => map
+            .iter()
+            .map(|(k, v)| (k.clone(), v.as_str().unwrap_or(&v.to_string()).to_string()))
+            .collect(),
+        _ => HashMap::new(),
+    }
+}
+
+fn tool_kind(name: &str) -> &'static str {
+    match name {
+        "bash" | "shell" | "terminal" => "execute",
+        "edit" | "write" | "search_replace" => "edit",
+        "read" | "read_file" => "read",
+        "grep" | "glob" | "list_dir" => "search",
+        "web_fetch" => "fetch",
+        _ => "other",
+    }
+}
+
+pub fn translate_event(state: &mut TranslateState, event: &serde_json::Value) -> Vec<amux::AcpEvent> {
+    let name = event.get("event").and_then(|v| v.as_str()).unwrap_or("");
+    let run_id = event.get("runId").and_then(|v| v.as_str()).unwrap_or("");
+
+    match name {
+        "assistant_delta" => {
+            let text = event.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            if text.is_empty() {
+                return Vec::new();
+            }
+            let key = format!("{run_id}:text");
+            let prev = state.emitted_text.get(&key).copied().unwrap_or(0);
+            let full = prev + text.len();
+            state.emitted_text.insert(key, full);
+            vec![text_event("assistant_delta", text.to_string())]
+        }
+        "thinking_delta" => {
+            let text = event.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            if text.is_empty() {
+                return Vec::new();
+            }
+            vec![text_event("thinking_delta", text.to_string())]
+        }
+        "tool_start" => {
+            let tool_call_id = event
+                .get("toolCallId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let tool_name = event
+                .get("toolName")
+                .and_then(|v| v.as_str())
+                .unwrap_or("tool")
+                .to_string();
+            let params = params_from_map(event.get("args").unwrap_or(&serde_json::Value::Null));
+            vec![amux::AcpEvent {
+                event: Some(amux::acp_event::Event::ToolUse(amux::AcpToolUse {
+                    tool_id: tool_call_id,
+                    tool_name: tool_name.clone(),
+                    description: String::new(),
+                    params,
+                    tool_kind: tool_kind(&tool_name).to_string(),
+                    raw_input_json: event
+                        .get("args")
+                        .map(|v| v.to_string())
+                        .unwrap_or_default(),
+                    raw_output_json: String::new(),
+                    content: vec![],
+                    locations: vec![],
+                    status: "in_progress".to_string(),
+                })),
+                model: String::new(),
+            }]
+        }
+        "tool_end" => {
+            let tool_call_id = event
+                .get("toolCallId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let summary = event
+                .get("summary")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let is_error = event.get("isError").and_then(|v| v.as_bool()).unwrap_or(false);
+            vec![amux::AcpEvent {
+                event: Some(amux::acp_event::Event::ToolResult(amux::AcpToolResult {
+                    tool_id: tool_call_id,
+                    success: !is_error,
+                    summary: truncate_tool_summary(summary),
+                    raw_output_json: String::new(),
+                    content: vec![],
+                })),
+                model: String::new(),
+            }]
+        }
+        "run_error" => {
+            let message = event
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("cursor run error")
+                .to_string();
+            vec![amux::AcpEvent {
+                event: Some(amux::acp_event::Event::Error(amux::AcpError {
+                    message: message.clone(),
+                    details: message,
+                })),
+                model: String::new(),
+            }]
+        }
+        _ => Vec::new(),
+    }
+}

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub mod acp_event_frame;
+pub mod cursor_sdk;
 pub mod backend;
 pub mod opencode_http;
 pub mod pi_rpc;

--- a/apps/daemon/src/team_shared_env.rs
+++ b/apps/daemon/src/team_shared_env.rs
@@ -178,7 +178,7 @@ fn resolve_env_secret_with(
             return Some(secret);
         }
     }
-    teamclaw_runtime_env::env_catalog::resolve_team_env_secret(workspace_root, team_id)
+    teamclaw_runtime_env::env_catalog::resolve_team_env_secret(workspace_root, team_id, None)
 }
 
 /// Load decrypted team shared env for a workspace.

--- a/apps/daemon/tests/support/crate_modules.rs
+++ b/apps/daemon/tests/support/crate_modules.rs
@@ -13,6 +13,8 @@ mod http;
 mod mcp_probe;
 #[path = "../../src/opencode_install/mod.rs"]
 mod opencode_install;
+#[path = "../../src/cursor_install/mod.rs"]
+mod cursor_install;
 #[path = "../../src/opencode_settings/mod.rs"]
 mod opencode_settings;
 #[path = "../../src/pi_install/mod.rs"]

--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -121,6 +121,20 @@ fn main() {
     println!("cargo:rustc-env=APP_SHORT_NAME={}", short_name);
     println!("cargo:warning=Using APP_SHORT_NAME={}", short_name);
 
+    let is_official = short_name == "teamclaw" || short_name == "teamclawdev";
+    let teamclaw_dir = if is_official {
+        ".teamclaw".to_string()
+    } else {
+        format!(".{}", short_name)
+    };
+    let config_file_name = if is_official {
+        "teamclaw.json".to_string()
+    } else {
+        format!("{}.json", short_name)
+    };
+    println!("cargo:rustc-env=TEAMCLAW_DIR={}", teamclaw_dir);
+    println!("cargo:rustc-env=CONFIG_FILE_NAME={}", config_file_name);
+
     // Export updater config from build.config.json (comma-separated for runtime fallback)
     let updater_endpoints = resolve_updater_endpoints(&config);
     if !updater_endpoints.is_empty() {

--- a/apps/desktop/crates/teamclaw-introspect/src/capabilities.rs
+++ b/apps/desktop/crates/teamclaw-introspect/src/capabilities.rs
@@ -282,6 +282,7 @@ fn build_env_vars(workspace: &str) -> Result<Value, String> {
     let listings = teamclaw_runtime_env::env_catalog::load_agent_env_listings(
         std::path::Path::new(workspace),
         None,
+        None,
     );
     let safe: Vec<Value> = listings
         .into_iter()

--- a/apps/desktop/crates/teamclaw-introspect/src/env_vars.rs
+++ b/apps/desktop/crates/teamclaw-introspect/src/env_vars.rs
@@ -11,6 +11,7 @@ pub async fn handle(workspace: &str, api_port: u16, arguments: &Value) -> Result
             let listings = teamclaw_runtime_env::env_catalog::load_agent_env_listings(
                 std::path::Path::new(workspace),
                 None,
+                None,
             );
             let entries: Vec<Value> = listings
                 .into_iter()

--- a/apps/desktop/src/commands/cron/mod.rs
+++ b/apps/desktop/src/commands/cron/mod.rs
@@ -84,7 +84,7 @@ impl Default for CronScope {
 fn global_cron_root() -> Result<String, String> {
     let base = dirs::config_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join(crate::commands::APP_SHORT_NAME)
+        .join(crate::commands::home_storage_dir_name())
         .join("cron-global");
     std::fs::create_dir_all(&base).map_err(|e| format!("Failed to create global cron dir: {e}"))?;
     Ok(base.to_string_lossy().to_string())

--- a/apps/desktop/src/commands/diagnostics.rs
+++ b/apps/desktop/src/commands/diagnostics.rs
@@ -208,7 +208,11 @@ fn gather_team_env_diagnostics(workspace_path: &str, team_id: Option<&str>) -> T
         .unwrap_or(0);
 
     let secret_configured =
-        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(ws, team_id_trimmed.as_deref())
+        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(
+            ws,
+            team_id_trimmed.as_deref(),
+            None,
+        )
             .is_some();
 
     TeamEnvDiagnostics {

--- a/apps/desktop/src/commands/env_vars.rs
+++ b/apps/desktop/src/commands/env_vars.rs
@@ -9,7 +9,12 @@ const LEGACY_MIGRATION_MARKER_KEY: &str = "_localPersonalSecretsMigrationComplet
 /// Disk-based path for the legacy plaintext env blob written by older versions.
 /// Read-only now (kept as a one-time migration source); never written.
 fn env_blob_fallback_path() -> Option<std::path::PathBuf> {
-    dirs::home_dir().map(|h| h.join(concat!(".", env!("APP_SHORT_NAME"), "/env-blob.json")))
+    dirs::home_dir().map(|h| {
+        h.join(format!(
+            ".{}/env-blob.json",
+            super::home_storage_dir_name()
+        ))
+    })
 }
 
 /// Read the env blob from the disk fallback file.
@@ -444,6 +449,7 @@ pub async fn env_catalog_list(
     workspace_path: Option<String>,
 ) -> Result<teamclaw_runtime_env::env_catalog::EnvCatalog, String> {
     let workspace_path = resolve_workspace_path(workspace_path, &window, &registry)?;
+    super::storage_migration::migrate_workspace_storage_namespace(&workspace_path);
     // team_id is required for the `_team_secret.{team_id}` personal-blob secret
     // fallback: when `teamclaw.json` carries no inline `team.envSecret` (the
     // common case), passing None here leaves every team var undecryptable.
@@ -451,6 +457,7 @@ pub async fn env_catalog_list(
     Ok(teamclaw_runtime_env::env_catalog::load_env_catalog(
         Path::new(&workspace_path),
         team_id,
+        Some(super::APP_SHORT_NAME),
     ))
 }
 
@@ -524,8 +531,12 @@ pub async fn team_env_diagnostics(
         .unwrap_or(0);
 
     let secret_configured =
-        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(ws, team_id_trimmed.as_deref())
-            .is_some();
+        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(
+            ws,
+            team_id_trimmed.as_deref(),
+            Some(super::APP_SHORT_NAME),
+        )
+        .is_some();
 
     Ok(TeamEnvDiagnostics {
         team_id_present: team_id_trimmed.is_some(),
@@ -907,7 +918,10 @@ mod tests {
         let workspace_dir = tempdir().unwrap();
         let _home = HomeGuard::set(home_dir.path());
 
-        let legacy_blob_dir = home_dir.path().join(concat!(".", env!("APP_SHORT_NAME")));
+        let legacy_blob_dir = home_dir.path().join(format!(
+            ".{}",
+            teamclaw_runtime_env::OFFICIAL_STORAGE_DIR
+        ));
         std::fs::create_dir_all(&legacy_blob_dir).unwrap();
 
         let mut legacy_blob = serde_json::Map::new();

--- a/apps/desktop/src/commands/local_secret_store.rs
+++ b/apps/desktop/src/commands/local_secret_store.rs
@@ -39,7 +39,8 @@ impl SecretStorePaths {
     pub(crate) fn for_home_dir() -> Result<Self, String> {
         let home = dirs::home_dir().ok_or_else(|| "Home directory not found".to_string())?;
         Ok(Self::for_base_dir(
-            home.join(concat!(".", env!("APP_SHORT_NAME")))
+            home
+                .join(format!(".{}", super::home_storage_dir_name()))
                 .join("secrets"),
         ))
     }

--- a/apps/desktop/src/commands/mod.rs
+++ b/apps/desktop/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub mod setup;
 pub mod shared_secrets;
 pub mod shared_secrets_crypto;
 pub mod skillssh;
+pub mod storage_migration;
 pub mod stt;
 pub mod system_appearance;
 pub mod team;
@@ -50,15 +51,18 @@ pub mod workspace_files;
 use crate::process_util::CommandNoWindow;
 
 /// The short application name, injected at compile time via `build.rs`.
-#[allow(dead_code)]
 pub const APP_SHORT_NAME: &str = env!("APP_SHORT_NAME");
-/// Directory name for all TeamClaw local config/data files, created under the workspace root.
-pub const TEAMCLAW_DIR: &str = concat!(".", env!("APP_SHORT_NAME"));
+/// Workspace metadata directory (`.teamclaw` for official builds).
+pub const TEAMCLAW_DIR: &str = env!("TEAMCLAW_DIR");
 /// Subfolder inside workspace where the team repo is cloned / symlinked.
 /// Fixed across brands — must match the daemon's `TEAM_LINK_NAME` (`teamclaw-team`).
 pub const TEAM_REPO_DIR: &str = "teamclaw-team";
-/// Config file name (e.g. `teamclaw.json`).
-pub const CONFIG_FILE_NAME: &str = concat!(env!("APP_SHORT_NAME"), ".json");
+/// Workspace config file name (`teamclaw.json` for official builds).
+pub const CONFIG_FILE_NAME: &str = env!("CONFIG_FILE_NAME");
+/// Home-directory storage folder name without leading dot (`teamclaw` for official).
+pub fn home_storage_dir_name() -> &'static str {
+    teamclaw_runtime_env::resolve_storage_dir_name(APP_SHORT_NAME)
+}
 
 #[tauri::command]
 pub fn greet(name: &str) -> String {

--- a/apps/desktop/src/commands/shared_secrets.rs
+++ b/apps/desktop/src/commands/shared_secrets.rs
@@ -306,7 +306,10 @@ pub fn try_lazy_init_from_workspace(
     if !teamclaw_config_path(workspace).exists() {
         return Err("No team configured for this workspace".to_string());
     }
-    let env_secret = teamclaw_runtime_env::env_catalog::resolve_team_env_secret(workspace, team_id)
+    let env_secret =
+        teamclaw_runtime_env::env_catalog::resolve_team_env_secret(workspace, team_id, Some(
+            super::APP_SHORT_NAME,
+        ))
         .ok_or_else(|| {
             "Team shared environment variables are not initialized for this workspace".to_string()
         })?;

--- a/apps/desktop/src/commands/storage_migration.rs
+++ b/apps/desktop/src/commands/storage_migration.rs
@@ -1,0 +1,225 @@
+//! One-shot migration: legacy official Dev paths (`teamclawdev`) → canonical `teamclaw`.
+//!
+//! White-label brands (`copilot361`, …) are untouched (Decision 2 = B).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use teamclaw_runtime_env::{
+    is_official_brand, LEGACY_OFFICIAL_DEV_CONFIG_FILE, LEGACY_OFFICIAL_DEV_STORAGE_DIR,
+    OFFICIAL_STORAGE_DIR, STORAGE_NAMESPACE_MIGRATION_MARKER, WORKSPACE_CONFIG_FILE,
+    WORKSPACE_META_DIR,
+};
+
+use super::APP_SHORT_NAME;
+
+fn home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}
+
+fn migration_marker_path(home: &Path) -> PathBuf {
+    home.join(format!(".{OFFICIAL_STORAGE_DIR}"))
+        .join("migrations")
+        .join(STORAGE_NAMESPACE_MIGRATION_MARKER)
+}
+
+fn merge_json_objects(
+    base: &mut serde_json::Map<String, serde_json::Value>,
+    overlay: serde_json::Map<String, serde_json::Value>,
+) {
+    for (key, value) in overlay {
+        match base.get_mut(&key) {
+            Some(existing) if existing.is_object() && value.is_object() => {
+                if let (Some(a), Some(b)) = (existing.as_object_mut(), value.as_object()) {
+                    merge_json_objects(a, b.clone());
+                }
+            }
+            Some(existing) if key == "envVars" && existing.is_array() && value.is_array() => {
+                let mut keys = std::collections::HashSet::new();
+                let mut merged = existing.as_array().cloned().unwrap_or_default();
+                for entry in &merged {
+                    if let Some(k) = entry.get("key").and_then(|v| v.as_str()) {
+                        keys.insert(k.to_string());
+                    }
+                }
+                for entry in value.as_array().into_iter().flatten() {
+                    if let Some(k) = entry.get("key").and_then(|v| v.as_str()) {
+                        if keys.insert(k.to_string()) {
+                            merged.push(entry.clone());
+                        }
+                    }
+                }
+                *existing = serde_json::Value::Array(merged);
+            }
+            None => {
+                base.insert(key, value);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn copy_file_if_newer(src: &Path, dst: &Path) -> Result<(), String> {
+    if !src.is_file() {
+        return Ok(());
+    }
+    if dst.exists() {
+        let src_meta = fs::metadata(src).map_err(|e| e.to_string())?;
+        let dst_meta = fs::metadata(dst).map_err(|e| e.to_string())?;
+        if let (Ok(sm), Ok(dm)) = (src_meta.modified(), dst_meta.modified()) {
+            if dm >= sm {
+                return Ok(());
+            }
+        }
+    }
+    if let Some(parent) = dst.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    fs::copy(src, dst).map_err(|e| format!("copy {} → {}: {e}", src.display(), dst.display()))?;
+    Ok(())
+}
+
+fn merge_tree(src: &Path, dst: &Path) -> Result<(), String> {
+    if !src.exists() {
+        return Ok(());
+    }
+    if src.is_file() {
+        return copy_file_if_newer(src, dst);
+    }
+    fs::create_dir_all(dst).map_err(|e| e.to_string())?;
+    for entry in fs::read_dir(src).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        merge_tree(&entry.path(), &dst.join(entry.file_name()))?;
+    }
+    Ok(())
+}
+
+fn migrate_home_storage(home: &Path) -> Result<(), String> {
+    let legacy = home.join(format!(".{LEGACY_OFFICIAL_DEV_STORAGE_DIR}"));
+    let canonical = home.join(format!(".{OFFICIAL_STORAGE_DIR}"));
+    if !legacy.exists() {
+        return Ok(());
+    }
+
+    merge_tree(&legacy.join("secrets"), &canonical.join("secrets"))?;
+    for name in ["local-cache.db", "cached-path.txt", "env-blob.json"] {
+        copy_file_if_newer(&legacy.join(name), &canonical.join(name))?;
+    }
+    Ok(())
+}
+
+fn migrate_workspace_meta(workspace: &Path) -> Result<(), String> {
+    let legacy_dir = workspace.join(format!(".{LEGACY_OFFICIAL_DEV_STORAGE_DIR}"));
+    let canonical_dir = workspace.join(WORKSPACE_META_DIR);
+    if !legacy_dir.exists() {
+        return Ok(());
+    }
+
+    fs::create_dir_all(&canonical_dir).map_err(|e| e.to_string())?;
+
+    let legacy_config = legacy_dir.join(LEGACY_OFFICIAL_DEV_CONFIG_FILE);
+    let canonical_config = canonical_dir.join(WORKSPACE_CONFIG_FILE);
+    if legacy_config.is_file() {
+        if canonical_config.is_file() {
+            let legacy_val: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&legacy_config).map_err(|e| e.to_string())?)
+                    .map_err(|e| e.to_string())?;
+            let mut base_val: serde_json::Value = fs::read_to_string(&canonical_config)
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or(serde_json::json!({}));
+            if let (Some(base), Some(overlay)) = (base_val.as_object_mut(), legacy_val.as_object()) {
+                merge_json_objects(base, overlay.clone());
+            }
+            fs::write(
+                &canonical_config,
+                serde_json::to_string_pretty(&base_val).map_err(|e| e.to_string())?,
+            )
+            .map_err(|e| e.to_string())?;
+        } else {
+            fs::copy(&legacy_config, &canonical_config).map_err(|e| e.to_string())?;
+        }
+    }
+
+    for name in [
+        "knowledge.db",
+        "rag-config.json",
+        "stats.json",
+        "cron-jobs.json",
+        "sessions.json",
+    ] {
+        copy_file_if_newer(&legacy_dir.join(name), &canonical_dir.join(name))?;
+    }
+    merge_tree(&legacy_dir.join("bm25_index"), &canonical_dir.join("bm25_index"))?;
+    merge_tree(&legacy_dir.join("cron-runs"), &canonical_dir.join("cron-runs"))?;
+    Ok(())
+}
+
+/// Migrate legacy official Dev storage into canonical `teamclaw` paths. Idempotent.
+pub fn migrate_official_storage_namespace() {
+    if !is_official_brand(APP_SHORT_NAME) {
+        return;
+    }
+    let Some(home) = home_dir() else {
+        return;
+    };
+    let marker = migration_marker_path(&home);
+    if marker.is_file() {
+        return;
+    }
+
+    if let Err(err) = migrate_home_storage(&home) {
+        eprintln!("[storage_migration] home migration failed: {err}");
+        return;
+    }
+
+    if let Err(err) = (|| {
+        fs::create_dir_all(marker.parent().ok_or_else(|| "marker parent missing".to_string())?)
+            .map_err(|e| e.to_string())?;
+        fs::write(&marker, chrono::Utc::now().to_rfc3339()).map_err(|e| e.to_string())
+    })() {
+        eprintln!("[storage_migration] failed to write marker: {err}");
+    }
+}
+
+/// Migrate a workspace directory when it is opened or registered.
+pub fn migrate_workspace_storage_namespace(workspace_path: &str) {
+    if !is_official_brand(APP_SHORT_NAME) {
+        return;
+    }
+    let workspace = Path::new(workspace_path);
+    if let Err(err) = migrate_workspace_meta(workspace) {
+        eprintln!(
+            "[storage_migration] workspace {} migration failed: {err}",
+            workspace.display()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_json_objects_unions_env_vars_by_key() {
+        let mut base = serde_json::json!({
+            "envVars": [{"key": "a", "description": "keep"}],
+            "locale": "en"
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let overlay = serde_json::json!({
+            "envVars": [{"key": "b", "description": "new"}],
+            "team": {"sharedDirName": "teamclaw"}
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        merge_json_objects(&mut base, overlay);
+        let env_vars = base.get("envVars").unwrap().as_array().unwrap();
+        assert_eq!(env_vars.len(), 2);
+        assert!(base.get("team").is_some());
+        assert_eq!(base.get("locale").unwrap(), "en");
+    }
+}

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -268,6 +268,7 @@ pub fn run() {
 
     // Fix PATH before anything else so all child processes can find tools
     fix_path_env();
+    commands::storage_migration::migrate_official_storage_namespace();
     eprintln!(
         "[Startup] fix_path_env: {:.1}ms",
         startup_t0.elapsed().as_secs_f64() * 1000.0

--- a/build.config.dev.json
+++ b/build.config.dev.json
@@ -5,7 +5,7 @@
   },
   "app": {
     "name": "TeamClaw Dev",
-    "shortName": "teamclawdev",
+    "shortName": "teamclaw",
     "palette": "default"
   },
   "features": {

--- a/crates/teamclaw-runtime-env/src/env_catalog.rs
+++ b/crates/teamclaw-runtime-env/src/env_catalog.rs
@@ -13,10 +13,9 @@ use tracing::warn;
 
 use crate::team_crypto::{self, EncryptedEnvelope};
 use crate::team_provider;
-
-const TEAMCLAW_DIR: &str = ".teamclaw";
-const CONFIG_FILE_NAME: &str = "teamclaw.json";
-const SECRETS_SUBDIR: &str = "_secrets";
+use crate::{
+    is_official_brand, WORKSPACE_CONFIG_FILE, WORKSPACE_META_DIR,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -73,17 +72,28 @@ pub struct AgentEnvListing {
     pub category: Option<String>,
 }
 
-fn teamclaw_config_path(workspace: &Path) -> PathBuf {
-    workspace.join(TEAMCLAW_DIR).join(CONFIG_FILE_NAME)
+const SECRETS_SUBDIR: &str = "_secrets";
+
+fn workspace_config_path(workspace: &Path, brand_short_name: &str) -> PathBuf {
+    if is_official_brand(brand_short_name) {
+        workspace.join(WORKSPACE_META_DIR).join(WORKSPACE_CONFIG_FILE)
+    } else {
+        workspace
+            .join(format!(".{brand_short_name}"))
+            .join(format!("{brand_short_name}.json"))
+    }
 }
 
-pub fn read_teamclaw_config(workspace: &Path) -> Option<serde_json::Value> {
-    let body = std::fs::read_to_string(teamclaw_config_path(workspace)).ok()?;
+fn read_teamclaw_config_for_brand(
+    workspace: &Path,
+    brand_short_name: &str,
+) -> Option<serde_json::Value> {
+    let body = std::fs::read_to_string(workspace_config_path(workspace, brand_short_name)).ok()?;
     serde_json::from_str(&body).ok()
 }
 
-fn read_team_json_env_secret(workspace: &Path) -> Option<String> {
-    read_teamclaw_config(workspace)?
+fn read_team_json_env_secret(workspace: &Path, brand_short_name: &str) -> Option<String> {
+    read_teamclaw_config_for_brand(workspace, brand_short_name)?
         .get("team")?
         .get("envSecret")?
         .as_str()
@@ -96,16 +106,22 @@ fn read_team_json_env_secret(workspace: &Path) -> Option<String> {
 pub fn resolve_team_env_secret(
     workspace: &Path,
     team_id: Option<&str>,
+    brand_short_name: Option<&str>,
 ) -> Option<String> {
-    if let Some(secret) = read_team_json_env_secret(workspace) {
+    let brand = brand_short_name.unwrap_or("teamclaw");
+    if let Some(secret) = read_team_json_env_secret(workspace, brand) {
         return Some(secret);
     }
     let team_id = team_id.filter(|id| !id.trim().is_empty())?;
     let blob_key = format!("_team_secret.{team_id}");
-    crate::personal_secrets::load_personal_env()
+    crate::personal_secrets::load_personal_env_for_brand(brand)
         .ok()
         .and_then(|env| env.get(&blob_key).cloned())
         .filter(|s| !s.trim().is_empty())
+}
+
+pub fn read_teamclaw_config(workspace: &Path) -> Option<serde_json::Value> {
+    read_teamclaw_config_for_brand(workspace, "teamclaw")
 }
 
 /// Team shared directory for writes: `{workspace}/{sharedDirName}`.
@@ -267,9 +283,13 @@ fn load_team_env_metas_from_dir(secrets_dir: &Path, env_secret: &str) -> Vec<Tea
 /// When the local team secret is missing or wrong, keys are still listed (from
 /// the file names) with `decrypted: false`. A decrypted listing always wins over
 /// an undecrypted one for the same key across candidate directories.
-pub fn load_team_env_listings(workspace: &Path, team_id: Option<&str>) -> Vec<TeamEnvListing> {
+pub fn load_team_env_listings(
+    workspace: &Path,
+    team_id: Option<&str>,
+    brand_short_name: Option<&str>,
+) -> Vec<TeamEnvListing> {
     let shared_dir_name = team_provider::resolve_shared_dir_name(workspace);
-    let env_secret = resolve_team_env_secret(workspace, team_id);
+    let env_secret = resolve_team_env_secret(workspace, team_id, brand_short_name);
 
     let mut out: Vec<TeamEnvListing> = Vec::new();
     let mut index: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
@@ -298,8 +318,12 @@ pub fn load_team_env_listings(workspace: &Path, team_id: Option<&str>) -> Vec<Te
     out
 }
 
-pub fn load_personal_env_listings(workspace: &Path) -> Vec<PersonalEnvListing> {
-    let Some(config) = read_teamclaw_config(workspace) else {
+pub fn load_personal_env_listings(
+    workspace: &Path,
+    brand_short_name: Option<&str>,
+) -> Vec<PersonalEnvListing> {
+    let brand = brand_short_name.unwrap_or("teamclaw");
+    let Some(config) = read_teamclaw_config_for_brand(workspace, brand) else {
         return Vec::new();
     };
     config
@@ -327,17 +351,25 @@ pub fn load_personal_env_listings(workspace: &Path) -> Vec<PersonalEnvListing> {
         .unwrap_or_default()
 }
 
-pub fn load_env_catalog(workspace: &Path, team_id: Option<&str>) -> EnvCatalog {
+pub fn load_env_catalog(
+    workspace: &Path,
+    team_id: Option<&str>,
+    brand_short_name: Option<&str>,
+) -> EnvCatalog {
     EnvCatalog {
-        personal: load_personal_env_listings(workspace),
-        team: load_team_env_listings(workspace, team_id),
+        personal: load_personal_env_listings(workspace, brand_short_name),
+        team: load_team_env_listings(workspace, team_id, brand_short_name),
     }
 }
 
 /// Personal `envVars` index merged with team keys — shape used by agent tools.
-pub fn load_agent_env_listings(workspace: &Path, team_id: Option<&str>) -> Vec<AgentEnvListing> {
-    let personal = load_personal_env_listings(workspace);
-    let team = load_team_env_listings(workspace, team_id);
+pub fn load_agent_env_listings(
+    workspace: &Path,
+    team_id: Option<&str>,
+    brand_short_name: Option<&str>,
+) -> Vec<AgentEnvListing> {
+    let personal = load_personal_env_listings(workspace, brand_short_name);
+    let team = load_team_env_listings(workspace, team_id, brand_short_name);
 
     let mut out: Vec<AgentEnvListing> = personal
         .into_iter()
@@ -427,7 +459,7 @@ mod tests {
         )
         .unwrap();
 
-        let team = load_team_env_listings(tmp.path(), None);
+        let team = load_team_env_listings(tmp.path(), None, None);
         assert_eq!(team.len(), 1);
         assert_eq!(team[0].key_id, "git_key");
         assert_eq!(team[0].description, "desc");
@@ -456,7 +488,7 @@ mod tests {
         )
         .unwrap();
 
-        let team = load_team_env_listings(tmp.path(), None);
+        let team = load_team_env_listings(tmp.path(), None, None);
         assert_eq!(team.len(), 1, "key must stay visible, not vanish");
         assert_eq!(team[0].key_id, "api_key");
         assert!(!team[0].decrypted, "wrong key → marked not decrypted");
@@ -483,7 +515,7 @@ mod tests {
         )
         .unwrap();
 
-        let team = load_team_env_listings(tmp.path(), None);
+        let team = load_team_env_listings(tmp.path(), None, None);
         assert_eq!(team.len(), 1);
         assert_eq!(team[0].key_id, "api_key");
         assert!(!team[0].decrypted);
@@ -518,7 +550,7 @@ mod tests {
         )
         .unwrap();
 
-        let listings = load_agent_env_listings(tmp.path(), None);
+        let listings = load_agent_env_listings(tmp.path(), None, None);
         let keys: Vec<_> = listings.iter().map(|entry| entry.key.as_str()).collect();
         assert!(keys.contains(&"tc_api_key"));
         assert!(keys.contains(&"mine"));
@@ -579,11 +611,11 @@ mod tests {
 
         // Without team_id the inline secret is missing → None (this was the bug:
         // the write/delete path passed None and hard-errored).
-        assert_eq!(resolve_team_env_secret(workspace.path(), None), None);
+        assert_eq!(resolve_team_env_secret(workspace.path(), None, None), None);
 
         // With team_id the personal-blob fallback resolves the secret.
         assert_eq!(
-            resolve_team_env_secret(workspace.path(), Some(team_id)).as_deref(),
+            resolve_team_env_secret(workspace.path(), Some(team_id), None).as_deref(),
             Some(env_secret.as_str())
         );
     }

--- a/crates/teamclaw-runtime-env/src/lib.rs
+++ b/crates/teamclaw-runtime-env/src/lib.rs
@@ -6,6 +6,7 @@ pub mod merge;
 pub mod opencode_config;
 pub mod opencode_db;
 pub mod personal_secrets;
+pub mod storage_namespace;
 pub mod team_crypto;
 pub mod team_provider;
 pub mod team_provider_sync;
@@ -26,7 +27,14 @@ pub use team_provider_sync::{
     sync_team_provider_on_disk, SecretResolveScope, TeamProviderSyncResult,
 };
 
-pub const APP_SECRETS_DIR: &str = "teamclaw";
+pub use storage_namespace::{
+    is_official_brand, resolve_storage_dir_name, LEGACY_OFFICIAL_DEV_CONFIG_FILE,
+    LEGACY_OFFICIAL_DEV_STORAGE_DIR, OFFICIAL_STORAGE_DIR, STORAGE_NAMESPACE_MIGRATION_MARKER,
+    WORKSPACE_CONFIG_FILE, WORKSPACE_META_DIR,
+};
+
+/// Same as [`OFFICIAL_STORAGE_DIR`] — kept for existing call sites.
+pub const APP_SECRETS_DIR: &str = OFFICIAL_STORAGE_DIR;
 pub const DEFAULT_TEAM_REPO_DIR: &str = "teamclaw-team";
 
 #[derive(Debug, Clone, Default)]

--- a/crates/teamclaw-runtime-env/src/personal_secrets.rs
+++ b/crates/teamclaw-runtime-env/src/personal_secrets.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use tracing::warn;
 
-use crate::APP_SECRETS_DIR;
+use crate::{resolve_storage_dir_name, OFFICIAL_STORAGE_DIR};
 
 #[derive(Debug, Clone)]
 struct SecretStorePaths {
@@ -23,10 +23,10 @@ struct EncryptedBlobFile {
 }
 
 impl SecretStorePaths {
-    fn for_home_dir() -> Option<Self> {
+    fn for_storage_dir(storage_dir: &str) -> Option<Self> {
         let home = dirs::home_dir()?;
         Some(Self::for_base_dir(
-            home.join(format!(".{}", APP_SECRETS_DIR)).join("secrets"),
+            home.join(format!(".{storage_dir}")).join("secrets"),
         ))
     }
 
@@ -78,14 +78,28 @@ fn string_env_from_map(map: serde_json::Map<String, serde_json::Value>) -> HashM
 }
 
 pub fn load_personal_env() -> anyhow::Result<HashMap<String, String>> {
-    let Some(paths) = SecretStorePaths::for_home_dir() else {
+    load_personal_env_for_storage_dir(OFFICIAL_STORAGE_DIR)
+}
+
+/// Load decrypted personal env vars for a build `brand_short_name` (`teamclaw`,
+/// `teamclawdev`, `copilot361`, …). Official brands resolve to `~/.teamclaw/secrets`.
+pub fn load_personal_env_for_brand(brand_short_name: &str) -> anyhow::Result<HashMap<String, String>> {
+    load_personal_env_for_storage_dir(resolve_storage_dir_name(brand_short_name))
+}
+
+fn load_personal_env_for_storage_dir(storage_dir: &str) -> anyhow::Result<HashMap<String, String>> {
+    let Some(paths) = SecretStorePaths::for_storage_dir(storage_dir) else {
         return Ok(HashMap::new());
     };
 
     match read_secret_blob(&paths) {
         Ok(map) => Ok(string_env_from_map(map)),
         Err(err) => {
-            warn!(error = %err, "Failed to read personal secrets; using empty env");
+            warn!(
+                storage_dir,
+                error = %err,
+                "Failed to read personal secrets; using empty env"
+            );
             Ok(HashMap::new())
         }
     }
@@ -140,7 +154,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let _home = HomeGuard::set(dir.path());
 
-        let secrets_dir = dir.path().join(format!(".{}", APP_SECRETS_DIR)).join("secrets");
+        let secrets_dir = dir
+            .path()
+            .join(format!(".{OFFICIAL_STORAGE_DIR}"))
+            .join("secrets");
         let paths = SecretStorePaths::for_base_dir(secrets_dir);
         let mut map = serde_json::Map::new();
         map.insert("my_key".into(), serde_json::Value::String("secret".into()));
@@ -156,7 +173,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let _home = HomeGuard::set(dir.path());
 
-        let secrets_dir = dir.path().join(format!(".{}", APP_SECRETS_DIR)).join("secrets");
+        let secrets_dir = dir
+            .path()
+            .join(format!(".{OFFICIAL_STORAGE_DIR}"))
+            .join("secrets");
         let paths = SecretStorePaths::for_base_dir(secrets_dir);
         let mut map = serde_json::Map::new();
         map.insert("str_key".into(), serde_json::Value::String("value".into()));
@@ -184,7 +204,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let _home = HomeGuard::set(dir.path());
 
-        let secrets_dir = dir.path().join(format!(".{}", APP_SECRETS_DIR)).join("secrets");
+        let secrets_dir = dir
+            .path()
+            .join(format!(".{OFFICIAL_STORAGE_DIR}"))
+            .join("secrets");
         std::fs::create_dir_all(&secrets_dir).unwrap();
         let paths = SecretStorePaths::for_base_dir(secrets_dir);
         let mut map = serde_json::Map::new();

--- a/crates/teamclaw-runtime-env/src/storage_namespace.rs
+++ b/crates/teamclaw-runtime-env/src/storage_namespace.rs
@@ -1,0 +1,64 @@
+//! Canonical on-disk namespace for official TeamClaw builds vs white-label brands.
+//!
+//! Official Production + Dev share `~/.teamclaw` and `{workspace}/.teamclaw/`.
+//! White-label builds keep `~/.{shortName}` / `{workspace}/.{shortName}/`.
+
+/// Home + workspace storage dir name for official builds (`~/.teamclaw`).
+pub const OFFICIAL_STORAGE_DIR: &str = "teamclaw";
+
+/// Legacy official Dev dir name before namespace unification.
+pub const LEGACY_OFFICIAL_DEV_STORAGE_DIR: &str = "teamclawdev";
+
+/// Workspace metadata directory for official builds (`.teamclaw/`).
+pub const WORKSPACE_META_DIR: &str = ".teamclaw";
+
+/// Primary workspace config file for official builds.
+pub const WORKSPACE_CONFIG_FILE: &str = "teamclaw.json";
+
+/// Legacy Dev workspace config file name.
+pub const LEGACY_OFFICIAL_DEV_CONFIG_FILE: &str = "teamclawdev.json";
+
+/// One-shot migration marker under `~/.teamclaw/migrations/`.
+pub const STORAGE_NAMESPACE_MIGRATION_MARKER: &str = "official-storage-namespace-v1";
+
+/// Whether `short_name` identifies an official TeamClaw build (Prod or Dev).
+pub fn is_official_brand(short_name: &str) -> bool {
+    matches!(
+        short_name,
+        OFFICIAL_STORAGE_DIR | LEGACY_OFFICIAL_DEV_STORAGE_DIR
+    )
+}
+
+/// Resolve the home-directory storage folder name (`teamclaw`, `copilot361`, …).
+pub fn resolve_storage_dir_name(short_name: &str) -> &str {
+    if is_official_brand(short_name) {
+        OFFICIAL_STORAGE_DIR
+    } else {
+        short_name
+    }
+}
+
+/// Legacy official Dev home dir (`teamclawdev`) when migrating an existing install.
+pub fn legacy_official_home_dir_name(short_name: &str) -> Option<&'static str> {
+    if short_name == LEGACY_OFFICIAL_DEV_STORAGE_DIR {
+        Some(LEGACY_OFFICIAL_DEV_STORAGE_DIR)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn official_brands_share_teamclaw_storage() {
+        assert!(is_official_brand("teamclaw"));
+        assert!(is_official_brand("teamclawdev"));
+        assert!(!is_official_brand("copilot361"));
+
+        assert_eq!(resolve_storage_dir_name("teamclaw"), "teamclaw");
+        assert_eq!(resolve_storage_dir_name("teamclawdev"), "teamclaw");
+        assert_eq!(resolve_storage_dir_name("copilot361"), "copilot361");
+    }
+}

--- a/docs/architecture/cursor-sdk-backend.md
+++ b/docs/architecture/cursor-sdk-backend.md
@@ -1,0 +1,336 @@
+# Cursor SDK 后端：Composer 模型接入设计
+
+> 状态：设计稿（2026-07-28）。目标：在 `agents.local_agent` 新增 `"cursor"`
+> 选项，amuxd 通过 **Cursor SDK**（`@cursor/sdk`）驱动 Composer 2.5 等
+> Cursor 自有模型，事件出口仍走 `amux::AcpEvent`，gateway / MQTT / 前端 /
+> iOS **零协议改动**。
+
+## 1. 决策与边界
+
+| 决策 | 理由 |
+|---|---|
+| 走 Cursor SDK，不走 LiteLLM / opencode provider | Composer 不是 OpenAI-compatible raw model API；LiteLLM 无法代理 |
+| Rust daemon + Node sidecar 桥接 | `@cursor/sdk` 是 TypeScript；daemon 是 Rust，与 pi 的「子进程 + JSONL」模式一致 |
+| 第一版只做 **local runtime** | TeamClaw 会话绑定 worktree cwd；cloud VM 需额外 repo 克隆与 PR 流程，延后 |
+| 与 opencode **并存**，不替换 | 用户可在设置里切换 `agents.local_agent`；团队 LiteLLM 仍服务 opencode/pi |
+| 商业 embedding 需单独授权 | Cursor 官方：SDK 是跑 Agent 的接口，不是可嵌入第三方 SaaS 的 model endpoint；对外售卖前联系 hi@cursor.com |
+
+## 2. 三种运行时对比
+
+| | opencode（现状） | pi（已有） | cursor（本方案） |
+|---|---|---|---|
+| 进程模型 | 全局单 `opencode serve`（HTTP + SSE） | 每 worktree 一个 `pi --mode rpc` | 每 worktree 一个 Node sidecar（JSONL RPC） |
+| SDK / 二进制 | 官方 opencode 二进制 | pi npm / 单文件二进制 | `@cursor/sdk` + `node cursor-bridge.mjs` |
+| 会话 ID | opencode session id | `pi:<session-file-path>` | `cursor:<agentId>`（local）或 `cursor:bc-<id>`（cloud，后续） |
+| 恢复 | `GET /session/{id}` + directory | `switch_session` + session dir | `Agent.resume(agentId)` + 重传 inline MCP |
+| 流式事件 | SSE `message.part.delta` | stdout `message_update` | SDK `run.stream()` → assistant/tool 块 |
+| 模型目录 | `/config/providers` | `get_available_models` | `Cursor.models.list()` |
+| 鉴权 | opencode provider key / LiteLLM | LiteLLM via pi provider | `CURSOR_API_KEY`（用户或 team service account） |
+| MCP | `opencode.json` mcp 表 | pi extension 桥接 | SDK inline MCP on `Agent.create` / `send` |
+| 权限审批 | opencode `permission.asked` | pi extension `confirm` dialog | SDK hooks（见 §5）或 gateway 自动放行 |
+| 取消 | `POST abort` | `abort` | `run.cancel()`（需 `run.supports("cancel")`） |
+
+## 3. 目标架构
+
+```
+ Tauri / iOS ── MQTT / 本地 HTTP ──┐
+ 企业微信 gateway ────────────────┤
+                                   ↓
+                            amuxd RuntimeManager
+                                   ↓ AcpCommand / AcpEvent（不变）
+                         runtime/cursor_sdk/（Rust）
+                                   ↓ JSONL stdin/stdout
+                    cursor-bridge（Node，@cursor/sdk）
+                                   ↓ local: { cwd: worktree }
+                         Cursor Agent（Composer 2.5）
+```
+
+**上行**：`Prompt` → sidecar `send` → `agent.send(text)` → 新 run。
+
+**下行**：sidecar 把 `run.stream()` 事件逐条写 stdout → Rust `translate.rs`
+→ `AcpEventFrame` → 既有 `turn_aggregator` / MQTT / SSE。
+
+**权限**：sidecar 收到 SDK 需人工确认的事件 → 写 `permission_request` 行 →
+Rust 发 `AcpPermissionRequest` → 客户端审批 → `ResolvePermission` → sidecar
+写回 SDK。
+
+协议边界不变：客户端只认 `amux.proto`；`acp_session_id` 前缀 `cursor:`
+区分后端，resume 时剥前缀调 `Agent.resume`。
+
+## 4. 新模块：`runtime/cursor_sdk/`（Rust）
+
+对等 `runtime/pi_rpc/`，实现已有 [`AgentBackend`](../../apps/daemon/src/runtime/backend.rs) trait。
+
+| 组件 | 职责 |
+|---|---|
+| `process.rs` | 每 canonical worktree 拉起 Node sidecar；env 注入 `CURSOR_API_KEY`、MCP JSON；kill_on_drop；指纹变更时 respawn |
+| `client.rs` | JSONL 命令写 stdin（带 `id` 关联 response）：`create_agent`、`resume_agent`、`send`、`cancel`、`set_model`、`list_models`、`dispose` |
+| `events.rs` | stdout 逐行解析（`\n` 切分），按 `cursor:<agentId>` 路由 `AcpEventFrame` |
+| `translate.rs` | SDK 事件 → `amux::AcpEvent`（对齐 `opencode_http/translate.rs` 词汇表） |
+| `mod.rs` | `CursorSdkBackend` + route 表 + pending permission 表 |
+
+### 4.1 Sidecar：`apps/daemon/cursor-bridge/`
+
+独立 npm 包（或 daemon 子目录），随 amuxd 分发：
+
+```
+apps/daemon/cursor-bridge/
+  package.json          # @cursor/sdk 依赖 + lock
+  src/main.mjs          # JSONL RPC loop
+  src/agent-pool.mjs    # worktree → Agent 实例（await using 生命周期）
+  src/mcp-mapper.mjs    # TeamClaw MCP 清单 → SDK inline servers
+  src/stream-translate.mjs  # run.stream() → bridge 事件行
+```
+
+**启动命令**（由 `process.rs` spawn）：
+
+```bash
+node /path/to/cursor-bridge/main.mjs --mode rpc
+```
+
+**JSONL 请求/响应**（与 pi_rpc 风格一致，便于 Rust client 复用模式）：
+
+```json
+{"id":"1","method":"create_agent","params":{"cwd":"/ws","model":"composer-2.5","mcpServers":[...]}}
+{"id":"1","result":{"agentId":"abc123","availableModels":[{"id":"cursor/composer-2.5","displayName":"Composer 2.5"}]}}
+```
+
+```json
+{"id":"2","method":"send","params":{"agentId":"abc123","text":"fix the bug","replyToMessageId":"msg-1"}}
+{"event":"assistant_delta","agentId":"abc123","runId":"run-9","text":"Looking at"}
+{"event":"tool_start","agentId":"abc123","runId":"run-9","toolCallId":"t1","toolName":"read","args":{...}}
+{"event":"turn_end","agentId":"abc123","runId":"run-9","status":"finished","model":"cursor/composer-2.5"}
+{"id":"2","result":{"runId":"run-9","status":"finished"}}
+```
+
+Sidecar 职责：
+
+- 持有 `Agent` 实例；进程退出时 `Symbol.asyncDispose`
+- `create_agent` / `resume_agent` 时**显式**传 `local: { cwd, settingSources: [] }`
+- 每次 `send` 后 `await run.wait()`，区分 `CursorAgentError`（startup）与
+  `result.status === "error"`（run failed）
+- 日志 `agentId` + `runId` 到 stderr（Rust 可采集）
+
+### 4.2 会话 ID 与 resume
+
+```rust
+const SESSION_ID_PREFIX: &str = "cursor:";
+// acp_session_id = "cursor:abc123"  →  Agent.resume("abc123")
+// cloud 后续: "cursor:bc-..."       →  Agent.resume("bc-...")
+```
+
+持久化：`SessionStore` 已有 `acp_session_id` 列，无需 schema 变更。daemon
+重启后 `AttachSession { resume_acp_session_id: Some("cursor:abc") }` → sidecar
+`resume_agent` + **重传 MCP**（SDK 不持久化 inline MCP）。
+
+### 4.3 模型 ID 形状
+
+与现有客户端一致：`provider/model`。
+
+| SDK model id | TeamClaw flat id | 说明 |
+|---|---|---|
+| `composer-2.5` | `cursor/composer-2.5` | 默认 |
+| `auto` | `cursor/auto` | 服务端选择 |
+| 带 params 变体 | `cursor/composer-2.5` + MRU 元数据 | params 存 daemon 侧，send 时展开 |
+
+`model_catalog()`：`Cursor.models.list()` 缓存 60s（对齐 `ManagedLlmResolver` TTL
+思路），写入 [`DeviceModelCatalog`](../../apps/daemon/src/config/model_catalog.rs)。
+
+`SetModel`：不销毁 Agent；更新 sidecar 内 model 选择，**下一 turn** 生效
+（与 opencode 行为一致）。若 SDK 要求重建 Agent，sidecar 内部 `dispose` +
+`create` 并对客户端透明。
+
+## 5. 事件翻译（SDK → AcpEvent）
+
+参考 [`pi_rpc/translate.rs`](../../apps/daemon/src/runtime/pi_rpc/translate.rs) 与
+[`opencode_http/translate.rs`](../../apps/daemon/src/runtime/opencode_http/translate.rs)。
+
+| SDK stream 事件 | AcpEvent |
+|---|---|
+| `assistant` + `text` block delta | `Output { text, is_complete: false }` |
+| `assistant` + thinking/reasoning block | `Thinking { text }`（若 SDK 暴露；否则忽略） |
+| tool call start | `ToolUse { tool_call_id, tool_name, params, tool_kind }` |
+| tool result | `ToolResult { tool_call_id, summary, is_error }` |
+| run finished | `StatusChange { status: Idle }` + 可选 `AgentReply` meta |
+| run error | `AcpError` + `StatusChange { status: Error }` |
+| permission / confirm（hooks） | `PermissionRequest` |
+
+`tool_kind` 映射（与 pi/opencode 对齐）：`read`→read, `edit`/`write`→edit,
+`bash`/`terminal`→execute, 其余→other。
+
+## 6. MCP / remote-tools / skills
+
+TeamClaw 已在 worktree 物化 MCP 配置（`opencode.json` / daemon workspace API）。
+Cursor 后端**不读 opencode.json 的 provider 段**，只复用 MCP 清单：
+
+1. attach 时 daemon 把 workspace 已启用 MCP 转为 SDK `mcpServers` 数组
+   （stdio: command/args/env；HTTP: url/headers）
+2. `amuxd-remote-tools` 保留为 stdio server（与 pi extension 桥同等优先级）
+3. **inline MCP 在每次 `resume_agent` / `send` 时重传**（SDK 限制）
+4. `.cursor/skills` / TeamClaw skills：第一版不自动映射；后续评估 SDK
+   `settingSources` 或 system prompt 注入
+
+`is_gateway` 会话：permission hooks 在 sidecar 内直接 auto-grant（对齐
+opencode gateway 行为）。
+
+## 7. 配置落点
+
+### 7.1 Daemon（`~/.amuxd/daemon.toml`）
+
+```toml
+[agents]
+local_agent = "cursor"   # "opencode" | "pi" | "cursor"
+
+[agents.cursor]
+# API key：优先此处，其次环境变量 CURSOR_API_KEY
+api_key = "cursor_..."
+# sidecar 入口；缺省用 bundled cursor-bridge/main.mjs
+bridge_command = ["node", "/path/to/cursor-bridge/main.mjs", "--mode", "rpc"]
+# 第一版固定 local；后续 "cloud"
+runtime = "local"
+# 默认模型（SDK id，非 flat id）
+default_model = "composer-2.5"
+```
+
+密钥存储：走现有 daemon secret 模式（600 权限文件），**不进** team git sync。
+
+### 7.2 Build config（桌面 onboarding 种子）
+
+[`packages/app/src/lib/build-config.ts`](../../packages/app/src/lib/build-config.ts)
+扩展：
+
+```ts
+localAgent?: 'opencode' | 'pi' | 'cursor'
+```
+
+[`create_backend()`](../../apps/daemon/src/runtime/backend.rs) 增加分支：
+
+```rust
+"cursor" => Box::new(super::cursor_sdk::CursorSdkBackend::new()),
+```
+
+### 7.3 前端设置
+
+[`DaemonGeneralSection.tsx`](../../packages/app/src/components/settings/DaemonGeneralSection.tsx)
+runtime picker 增加第三项 **Cursor (Composer)**；切换后 restart amuxd（与 pi 相同流程）。
+
+[`LLMSectionRouter`](../../packages/app/src/components/settings/LLMSectionRouter.tsx)：
+`local_agent === "cursor"` 时隐藏 Team LiteLLM / opencode provider OAuth 卡片，
+改为 **Cursor API Key** 单行（写入 `[agents.cursor].api_key` 或引导用户设
+`CURSOR_API_KEY`）。
+
+### 7.4 Doctor / 安装
+
+`amuxd doctor` 新增检查项：
+
+- Node ≥ 20 可执行
+- `cursor-bridge/node_modules/@cursor/sdk` 存在（或 bundled）
+- `CURSOR_API_KEY` 有效（`Cursor.models.list()` 探针）
+- 可选：Composer 账号是否有模型访问
+
+安装路径对等 `opencode_install` / `pi_install`：
+
+- `amuxd install-cursor-bridge` — npm ci bundled bridge
+- Tauri sidecar 构建期打包 `cursor-bridge/` + `node`（或依赖系统 Node）
+
+## 8. 与现有子系统的交互
+
+| 子系统 | cursor 后端行为 |
+|---|---|
+| `ManagedLlmResolver` | **跳过** — Composer 计费走 Cursor key，不写 `provider.team` |
+| `model-catalog.toml` | 正常写入，`provider_name = "cursor"` |
+| `ModelMru` | 正常；`session_model()` 从 sidecar `get_agent_info` 读取 |
+| workspace provider OAuth API | 返回 409 或空列表（cursor 不用 opencode providers） |
+| cron workspace models | `model_catalog()` 走 Cursor.models.list |
+| iOS | 无改动（读 `RuntimeInfo.available_models`） |
+| gateway (WeCom 等) | 无改动（`RuntimeHandle` / `AcpEvent` 不变） |
+
+## 9. 实施步骤
+
+建议分 4 个 PR，每步可独立回归：
+
+### PR 1 — 骨架 + 设计落地（本文件 + 工厂接线）
+
+1. 本文档进 `docs/architecture/`
+2. `runtime/cursor_sdk/mod.rs` 空实现 + `create_backend("cursor")`
+3. `AgentsConfig` 增加 `[agents.cursor]` 结构体
+4. build-config / 设置页 picker 增加 `cursor`（disabled preview 亦可）
+
+### PR 2 — Sidecar + 最小 prompt 闭环
+
+1. `apps/daemon/cursor-bridge/` — create/send/stream/wait/dispose
+2. Rust `process.rs` + `client.rs` + 集成测试（mock sidecar stdout）
+3. 桌面 tauri-mcp：单会话 prompt → 看到 streaming Output → Idle
+
+### PR 3 — 完整 AcpEvent 面
+
+1. `translate.rs` — tool use/result、error、StatusChange
+2. `Cancel` / `SetModel` / `session_model`
+3. Permission：hooks 或 SDK confirm 事件 → `ResolvePermission`
+4. MCP mapper：workspace MCP → inline servers
+
+### PR 4 — 产品化
+
+1. `install-cursor-bridge` + doctor + Tauri 打包
+2. resume 跨 daemon 重启
+3. `DeviceModelCatalog` 持久化 + model picker 回归
+4. 诊断报告 / Sentry 标签 `local_agent=cursor`
+
+## 10. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| SDK public beta API 变更 | sidecar 独立版本锁；CI 用录制 JSON fixture 测 translate |
+| Node 运行时依赖 | doctor 明确报错；长期可评估 Bun 编译 sidecar 单文件 |
+| Composer 计费与团队 key 混用 | 第一版每设备一个 key；团队 service account 文档化 |
+| MCP 不持久化 on resume | attach/resume/send 统一走 `assemble_mcp_inline()` |
+| 权限语义与 opencode 不一致 | gateway 自动放行 + 桌面审批 UI 复用；差异写进 E2E |
+| SaaS embedding 授权 | 产品化前联系 Cursor；文档标注「内部 / 自用」 |
+| Cloud runtime 复杂度高 | 明确 out-of-scope v1；ID 前缀预留 `bc-` |
+
+## 11. 最小验证脚本（开发期）
+
+在 sidecar 落地前，可用独立脚本验证 key 与模型访问：
+
+```typescript
+// scripts/verify-cursor-sdk.mjs
+import { Agent, Cursor, CursorAgentError } from "@cursor/sdk";
+
+const apiKey = process.env.CURSOR_API_KEY;
+if (!apiKey) throw new Error("set CURSOR_API_KEY");
+
+const models = await Cursor.models.list({ apiKey });
+console.log("models:", models.map((m) => m.id));
+
+await using agent = await Agent.create({
+  apiKey,
+  model: { id: "composer-2.5" },
+  local: { cwd: process.cwd(), settingSources: [] },
+});
+
+const run = await agent.send("Reply with exactly: pong");
+for await (const ev of run.stream()) {
+  if (ev.type === "assistant") {
+    for (const b of ev.message.content) {
+      if (b.type === "text") process.stdout.write(b.text);
+    }
+  }
+}
+const result = await run.wait();
+if (result.status === "error") process.exit(2);
+console.log("\nstatus:", result.status);
+```
+
+```bash
+export CURSOR_API_KEY="cursor_..."
+node scripts/verify-cursor-sdk.mjs
+```
+
+## 12. 参考
+
+- 已有后端抽象：[`apps/daemon/src/runtime/backend.rs`](../../apps/daemon/src/runtime/backend.rs)
+- Pi 对等实现：[`apps/daemon/src/runtime/pi_rpc/`](../../apps/daemon/src/runtime/pi_rpc/)
+- Pi 设计稿：[`pi-agent-backend.md`](./pi-agent-backend.md)
+- Cursor SDK skill（本地）：`~/.cursor/skills-cursor/sdk/SKILL.md`
+- Cursor 文档：[TypeScript SDK](https://cursor.com/docs/sdk/typescript) ·
+  [Composer 2.5](https://cursor.com/docs/models/cursor-composer-2-5)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "rust:check": "node scripts/rust-cli.js check --manifest-path apps/desktop/Cargo.toml",
     "rust:build": "node scripts/rust-cli.js build --manifest-path apps/desktop/Cargo.toml",
     "daemon:run": "node scripts/run-daemon.js",
+    "daemon:deploy": "scripts/deploy-daemon-binaries.sh",
     "daemon:ctl": "scripts/amuxdctl.sh",
     "dev:daemon": "scripts/dev-daemon.sh",
     "dev:desktop": "scripts/dev-desktop.sh",

--- a/packages/app/src/components/settings/CursorLLMSection.tsx
+++ b/packages/app/src/components/settings/CursorLLMSection.tsx
@@ -1,0 +1,213 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { AlertCircle, CheckCircle2, Cpu, ExternalLink, Key, Loader2, Save, Shield } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  getCursorAgentSettings,
+  restartLocalDaemon,
+  saveCursorAgentSettings,
+} from '@/lib/daemon-local-client'
+import { cn, isTauri } from '@/lib/utils'
+import { SectionHeader, SettingCard } from './shared'
+
+const CURSOR_API_KEY_DOCS = 'https://cursor.com/docs/account/teams/admin-api'
+
+export function CursorLLMSection() {
+  const { t } = useTranslation()
+  const [loading, setLoading] = React.useState(true)
+  const [saving, setSaving] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [saved, setSaved] = React.useState(false)
+  const [apiKeyConfigured, setApiKeyConfigured] = React.useState(false)
+  const [apiKeyDraft, setApiKeyDraft] = React.useState('')
+  const [defaultModel, setDefaultModel] = React.useState('composer-2.5')
+
+  const load = React.useCallback(async () => {
+    if (!isTauri()) {
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const settings = await getCursorAgentSettings()
+      setApiKeyConfigured(settings.apiKeyConfigured)
+      setDefaultModel(settings.defaultModel)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    void load()
+  }, [load])
+
+  const handleSave = React.useCallback(async () => {
+    if (!isTauri()) return
+    const trimmedKey = apiKeyDraft.trim()
+    if (!apiKeyConfigured && !trimmedKey) {
+      setError(t('settings.llm.cursorKeyRequired', '请先填写 Cursor API Key'))
+      return
+    }
+    setSaving(true)
+    setError(null)
+    setSaved(false)
+    try {
+      const { requiresRestart } = await saveCursorAgentSettings({
+        ...(trimmedKey ? { apiKey: trimmedKey } : {}),
+        defaultModel: defaultModel.trim() || 'composer-2.5',
+      })
+      if (requiresRestart) {
+        await restartLocalDaemon()
+      }
+      setApiKeyDraft('')
+      setApiKeyConfigured(apiKeyConfigured || Boolean(trimmedKey))
+      setSaved(true)
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }, [apiKeyConfigured, apiKeyDraft, defaultModel, load, t])
+
+  return (
+    <div>
+      <SectionHeader
+        icon={Cpu}
+        title={t('settings.llm.cursorTitle', 'Cursor 模型')}
+        description={t(
+          'settings.llm.cursorDesc',
+          '使用 Cursor SDK（Composer 等）作为本地 Agent 运行时。在此配置 API Key，无需编辑 daemon.toml。',
+        )}
+      />
+
+      <SettingCard>
+        {loading ? (
+          <div className="flex items-center gap-2 p-4 text-[12.5px] text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t('common.loading', '加载中…')}
+          </div>
+        ) : (
+          <div className="space-y-5 p-4">
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 text-[13px] font-medium">
+                <Key className="h-4 w-4 text-muted-foreground" />
+                {t('settings.llm.cursorApiKey', 'Cursor API Key')}
+                {apiKeyConfigured ? (
+                  <span className="inline-flex items-center gap-1 rounded-md border border-border-soft bg-panel px-1.5 py-0.5 font-mono text-[10.5px] font-normal text-muted-foreground">
+                    <CheckCircle2 className="h-3 w-3 text-emerald-600" />
+                    {t('settings.llm.cursorKeyConfigured', '已配置')}
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1 rounded-md border border-coral/30 bg-coral/5 px-1.5 py-0.5 font-mono text-[10.5px] font-normal text-coral">
+                    <AlertCircle className="h-3 w-3" />
+                    {t('settings.llm.cursorKeyMissing', '未配置')}
+                  </span>
+                )}
+              </label>
+              <Input
+                type="password"
+                value={apiKeyDraft}
+                onChange={(e) => {
+                  setApiKeyDraft(e.target.value)
+                  setSaved(false)
+                }}
+                placeholder={
+                  apiKeyConfigured
+                    ? t('settings.llm.cursorKeyPlaceholderSet', '留空则保留现有 Key')
+                    : t('settings.llm.cursorKeyPlaceholder', 'crsr_…')
+                }
+                className="font-mono text-[12.5px]"
+                autoComplete="off"
+              />
+              <p className="flex items-start gap-1.5 text-[11.5px] leading-relaxed text-muted-foreground">
+                <Shield className="mt-0.5 h-3 w-3 shrink-0" />
+                {t(
+                  'settings.llm.cursorKeyStorage',
+                  'Key 仅保存在本机 ~/.amuxd/daemon.toml，经 daemon HTTP 写入，不会上传到 TeamClaw 云端。',
+                )}
+              </p>
+              <a
+                href={CURSOR_API_KEY_DOCS}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-[11.5px] text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              >
+                {t('settings.llm.cursorKeyDocs', '如何获取 Cursor API Key')}
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-[13px] font-medium">
+                {t('settings.llm.cursorDefaultModel', '默认模型')}
+              </label>
+              <Input
+                value={defaultModel}
+                onChange={(e) => {
+                  setDefaultModel(e.target.value)
+                  setSaved(false)
+                }}
+                placeholder="composer-2.5"
+                className="font-mono text-[12.5px]"
+              />
+              <p className="text-[11.5px] text-muted-foreground">
+                {t(
+                  'settings.llm.cursorDefaultModelHint',
+                  '会话首次 attach 时使用；可在聊天输入栏切换其他 Cursor 模型。',
+                )}
+              </p>
+            </div>
+
+            {error ? (
+              <div className="flex items-start gap-2 text-[12.5px] text-red-600">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{error}</span>
+              </div>
+            ) : null}
+
+            {saved ? (
+              <div className="flex items-center gap-2 text-[12.5px] text-emerald-600">
+                <CheckCircle2 className="h-4 w-4" />
+                {t('settings.llm.cursorSaved', '已保存并重启 daemon')}
+              </div>
+            ) : null}
+
+            <div className="flex justify-end">
+              <Button
+                onClick={() => void handleSave()}
+                disabled={saving || (!apiKeyConfigured && !apiKeyDraft.trim())}
+                className="gap-2"
+              >
+                {saving ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                {t('settings.llm.cursorSave', '保存')}
+              </Button>
+            </div>
+          </div>
+        )}
+      </SettingCard>
+
+      {!loading && !apiKeyConfigured ? (
+        <SettingCard className={cn('mt-4 border-coral/20 bg-coral/5')}>
+          <div className="flex items-start gap-3 p-4 text-[12.5px] leading-relaxed text-ink-2">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-coral" />
+            <p>
+              {t(
+                'settings.llm.cursorSetupRequired',
+                'Cursor 运行时需要在上方配置 API Key 后才能回复消息。保存后 daemon 会自动重启。',
+              )}
+            </p>
+          </div>
+        </SettingCard>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/app/src/components/settings/DaemonGeneralSection.tsx
+++ b/packages/app/src/components/settings/DaemonGeneralSection.tsx
@@ -23,6 +23,7 @@ import {
   type TeamMemberOption,
 } from '@/lib/daemon-agent-admin'
 import {
+  getCursorAgentSettings,
   getDaemonLocalAgent,
   setDaemonLocalAgent,
   type DaemonLocalAgent,
@@ -67,6 +68,7 @@ export function DaemonGeneralSection() {
   // the daemon config and restarts amuxd so the new backend takes effect.
   const [localAgent, setLocalAgentState] = React.useState<DaemonLocalAgent | null>(null)
   const [switchingAgent, setSwitchingAgent] = React.useState(false)
+  const [cursorKeyConfigured, setCursorKeyConfigured] = React.useState<boolean | null>(null)
   // When set, render the existing daemon onboarding wizard as an overlay to
   // re-bind the local daemon to the current team.
   const [rebinding, setRebinding] = React.useState(false)
@@ -114,6 +116,16 @@ export function DaemonGeneralSection() {
   React.useEffect(() => {
     void loadLocalAgent()
   }, [loadLocalAgent])
+
+  React.useEffect(() => {
+    if (!isTauri() || localAgent !== 'cursor') {
+      setCursorKeyConfigured(null)
+      return
+    }
+    void getCursorAgentSettings()
+      .then((s) => setCursorKeyConfigured(s.apiKeyConfigured))
+      .catch(() => setCursorKeyConfigured(null))
+  }, [localAgent])
 
   // Switch the local runtime: persist `agents.local_agent`, restart amuxd, then
   // re-poll until the daemon comes back reporting the new runtime. The daemon
@@ -529,10 +541,22 @@ export function DaemonGeneralSection() {
                     <SelectContent>
                       <SelectItem value="opencode" className="font-mono text-[12px]">opencode</SelectItem>
                       <SelectItem value="pi" className="font-mono text-[12px]">pi</SelectItem>
+                      <SelectItem value="cursor" className="font-mono text-[12px]">cursor</SelectItem>
                     </SelectContent>
                   </Select>
                   {switchingAgent && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
                 </dd>
+                {localAgent === 'cursor' && cursorKeyConfigured === false ? (
+                  <>
+                    <dt className="sr-only">Cursor</dt>
+                    <dd className="col-span-2 text-[11.5px] leading-relaxed text-coral">
+                      {t(
+                        'settings.daemonGeneral.cursorKeyHint',
+                        'Cursor 运行时需在「设置 → LLM」中配置 API Key，无需编辑 daemon.toml。',
+                      )}
+                    </dd>
+                  </>
+                ) : null}
                 <dt className="text-muted-foreground">{t('settings.daemonGeneral.agentId', 'Agent ID')}</dt>
                 <dd className="truncate font-mono text-foreground">{agent.id}</dd>
                 <dt className="text-muted-foreground">{t('settings.daemonGeneral.lastActive', 'Last active')}</dt>

--- a/packages/app/src/components/settings/GeneralSection.tsx
+++ b/packages/app/src/components/settings/GeneralSection.tsx
@@ -31,12 +31,13 @@ import { useCurrentTeamStore } from '@/stores/current-team'
 import { getBackend } from '@/lib/backend'
 import { SettingCard, SectionHeader, ToggleSwitch } from './shared'
 import { useAcpDebugStore } from '@/stores/acp-debug-store'
-import { appShortName, buildConfig } from '@/lib/build-config'
+import { appStoragePrefix, buildConfig } from '@/lib/build-config'
+import { NOTIFICATION_LEVEL_KEY } from '@/lib/notification-service'
 import { LANGUAGE_OPTIONS, getPreferredLanguage, normalizeSupportedLanguage, persistLanguage } from '@/lib/locale'
 import { getEffectiveServerConfig, type ServerConfig } from '@/lib/server-config'
 
 // Theme helpers
-const THEME_STORAGE_KEY = `${buildConfig.app.shortName ?? 'teamclaw'}-theme`
+const THEME_STORAGE_KEY = `${appStoragePrefix}-theme`
 const DEFAULT_THEME = buildConfig.defaults?.theme || 'system'
 
 function applyTheme(theme: string) {
@@ -136,14 +137,14 @@ export const GeneralSection = React.memo(function GeneralSection() {
 
   const [notificationLevel, setNotificationLevelState] = React.useState(() => {
     try {
-      const stored = localStorage.getItem(`${appShortName}-notification-level`)
+      const stored = localStorage.getItem(NOTIFICATION_LEVEL_KEY)
       if (stored === 'all' || stored === 'important' || stored === 'mute') return stored
     } catch { /* ignore */ }
     return 'important'
   })
   const setNotificationLevel = React.useCallback((level: string) => {
     setNotificationLevelState(level)
-    try { localStorage.setItem(`${appShortName}-notification-level`, level) } catch { /* ignore */ }
+    try { localStorage.setItem(NOTIFICATION_LEVEL_KEY, level) } catch { /* ignore */ }
   }, [])
   const acpStreamDebugEnabled = useAcpDebugStore((s) => s.enabled)
   const setAcpStreamDebugEnabled = useAcpDebugStore((s) => s.setEnabled)

--- a/packages/app/src/components/settings/LLMSectionRouter.tsx
+++ b/packages/app/src/components/settings/LLMSectionRouter.tsx
@@ -3,6 +3,7 @@ import { getDaemonLocalAgent, type DaemonLocalAgent } from '@/lib/daemon-local-c
 import { isTauri } from '@/lib/utils'
 import { OpenCodeLLMSection } from './LLMSection'
 import { PiLLMSection } from './PiLLMSection'
+import { CursorLLMSection } from './CursorLLMSection'
 
 /**
  * LLM settings dispatcher. The local agent runtime determines both the logic
@@ -34,5 +35,7 @@ export function LLMSection() {
 
   // Until the runtime is known, render nothing to avoid flashing the wrong pane.
   if (agent === null) return null
-  return agent === 'pi' ? <PiLLMSection /> : <OpenCodeLLMSection />
+  if (agent === 'pi') return <PiLLMSection />
+  if (agent === 'cursor') return <CursorLLMSection />
+  return <OpenCodeLLMSection />
 }

--- a/packages/app/src/components/settings/MCPSection.tsx
+++ b/packages/app/src/components/settings/MCPSection.tsx
@@ -336,7 +336,7 @@ export const MCPSection = React.memo(function MCPSection() {
   // The local runtime determines how these servers are consumed: opencode reads
   // opencode.json natively; pi has no native MCP, so the TeamClaw extension
   // spawns each enabled local server and proxies its tools.
-  const [localAgent, setLocalAgent] = React.useState<'opencode' | 'pi'>('opencode')
+  const [localAgent, setLocalAgent] = React.useState<'opencode' | 'pi' | 'cursor'>('opencode')
   React.useEffect(() => {
     void (async () => {
       try {
@@ -403,7 +403,9 @@ export const MCPSection = React.memo(function MCPSection() {
         <span className="text-muted-foreground">
           {localAgent === 'pi'
             ? t('settings.mcp.piBridgeNote', 'pi 无原生 MCP，已启用的本地 server 由 TeamClaw 扩展桥接为 pi 工具')
-            : t('settings.mcp.opencodeNote', 'opencode 原生从 opencode.json 加载这些 server')}
+            : localAgent === 'cursor'
+              ? t('settings.mcp.cursorBridgeNote', 'Cursor SDK 第一版尚未桥接 workspace MCP')
+              : t('settings.mcp.opencodeNote', 'opencode 原生从 opencode.json 加载这些 server')}
         </span>
       </div>
 

--- a/packages/app/src/components/settings/PromptSection.tsx
+++ b/packages/app/src/components/settings/PromptSection.tsx
@@ -5,14 +5,14 @@ import { invoke } from '@tauri-apps/api/core'
 import { Button } from '@/components/ui/button'
 import { SettingCard, SectionHeader } from './shared'
 import { toast } from 'sonner'
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 import { isTauri } from '@/lib/utils'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { encodeWorkspaceId, reloadDaemonRuntime } from '@/lib/daemon-local-client'
 
 // Legacy global storage key — kept only for one-time migration into
 // per-workspace teamclaw.json.
-const LEGACY_STORAGE_KEY = `${appShortName}-system-prompt`
+const LEGACY_STORAGE_KEY = `${appStoragePrefix}-system-prompt`
 
 export const PromptSection = React.memo(function PromptSection() {
   const { t } = useTranslation()

--- a/packages/app/src/components/settings/SkillsSection.tsx
+++ b/packages/app/src/components/settings/SkillsSection.tsx
@@ -39,7 +39,7 @@ import {
   deleteDaemonSkill,
 } from '@/lib/daemon-local-client'
 import { cn } from '@/lib/utils'
-import { appDisplayName } from '@/lib/build-config'
+import { appDisplayName, TEAMCLAW_DIR } from '@/lib/build-config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -415,7 +415,7 @@ ${skillContent.trim()}`
         const home = await homeDir()
         skillsDir = `${home.replace(/\/$/, '')}/.config/opencode/skills`
       } else {
-        skillsDir = `${workspacePath}/.teamclaw/skills`
+        skillsDir = `${workspacePath}/${TEAMCLAW_DIR}/skills`
       }
 
       if (!(await exists(skillsDir))) {
@@ -474,7 +474,7 @@ ${skillContent.trim()}`
         )
         if (!deleted) {
           const { remove } = await import('@tauri-apps/plugin-fs')
-          const baseDir = targetSkill.dirPath ?? `${workspacePath}/.teamclaw/skills`
+          const baseDir = targetSkill.dirPath ?? `${workspacePath}/${TEAMCLAW_DIR}/skills`
           await remove(`${baseDir}/${targetSkill.filename}`, { recursive: true })
         }
       }

--- a/packages/app/src/components/workspace/FileBrowser.tsx
+++ b/packages/app/src/components/workspace/FileBrowser.tsx
@@ -91,7 +91,9 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
   React.useEffect(() => {
     if (workspacePath) void refreshOssSync(workspacePath)
   }, [workspacePath, refreshOssSync])
-  const showOssSync = !isCustomRoot && !!ossTeamId
+  // Caller-provided actionIcons (KnowledgeBrowser git sync, TeamSharedFilesBrowser
+  // git/oss sync) already own the toolbar sync button — don't duplicate OSS sync.
+  const showOssSync = !isCustomRoot && !!ossTeamId && !actionIcons
 
   // When rootPaths is provided, create virtual root folder nodes for each path.
   // When rootPath is provided, extract its subtree from the global fileTree.

--- a/packages/app/src/components/workspace/__tests__/FileBrowser.test.tsx
+++ b/packages/app/src/components/workspace/__tests__/FileBrowser.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type MockFileNode = {
@@ -107,6 +107,18 @@ vi.mock("../FileTree", () => ({
   },
 }));
 
+const ossSyncState = vi.hoisted(() => ({
+  teamId: "team-1" as string | null,
+  syncing: false,
+  refresh: vi.fn().mockResolvedValue(undefined),
+  syncNow: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/stores/oss-sync", () => ({
+  useOssSyncStore: (selector: (state: typeof ossSyncState) => unknown) =>
+    selector(ossSyncState),
+}));
+
 vi.mock("@/stores/workspace", () => ({
   useWorkspaceStore: Object.assign(
     (selector: (state: Record<string, unknown>) => unknown) =>
@@ -138,6 +150,25 @@ describe("FileBrowser", () => {
     vi.clearAllMocks();
     mockFileTree = [];
     latestNodesProp = undefined;
+    ossSyncState.teamId = "team-1";
+  });
+
+  it("hides built-in OSS sync when the caller already supplies actionIcons", () => {
+    render(
+      <FileBrowser
+        variant="panel"
+        actionIcons={<button data-testid="caller-sync">Sync</button>}
+      />,
+    );
+
+    expect(screen.getByTestId("caller-sync")).toBeTruthy();
+    expect(screen.queryByTestId("filebrowser-oss-sync")).toBeNull();
+  });
+
+  it("shows built-in OSS sync for workspace root when no actionIcons are provided", () => {
+    render(<FileBrowser variant="panel" />);
+
+    expect(screen.getByTestId("filebrowser-oss-sync")).toBeTruthy();
   });
 
   it("retries loading custom root ancestors after the global tree becomes available", async () => {

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -33,7 +33,8 @@ import { useTeamModeStore } from "@/stores/team-mode";
 import { useTeamShareStore } from "@/stores/team-share";
 import { useOssSyncStore } from "@/stores/oss-sync";
 import { getSkillDirectories, loadAllSkills } from "@/lib/git/skill-loader";
-import { appShortName, DEFAULT_WORKSPACE_PATH, TEAM_REPO_DIR } from "@/lib/build-config";
+import { appStoragePrefix, DEFAULT_WORKSPACE_PATH, TEAM_REPO_DIR } from "@/lib/build-config";
+import { WORKSPACE_STORAGE_KEY } from "@/stores/workspace";
 import { markStartup } from "@/lib/startup-perf";
 
 export const SKILLS_CHANGED_EVENT = "skills-files-changed";
@@ -110,7 +111,7 @@ export function useWorkspaceInit() {
           await setWorkspace(windowParams.workspace);
         } else {
           try {
-            const savedPath = localStorage.getItem(`${appShortName}-workspace-path`);
+            const savedPath = localStorage.getItem(WORKSPACE_STORAGE_KEY);
             let restored = false;
             if (savedPath) {
               let canRestore = true;
@@ -130,7 +131,7 @@ export function useWorkspaceInit() {
                 restored = true;
               } else {
                 console.log("[App] Saved workspace no longer exists, clearing restore path:", savedPath);
-                localStorage.removeItem(`${appShortName}-workspace-path`);
+                localStorage.removeItem(WORKSPACE_STORAGE_KEY);
               }
             }
 
@@ -735,7 +736,7 @@ export function useSetupGuide(workspaceReady: boolean) {
   useEffect(() => {
     const debugForceSetup = (() => {
       try {
-        return localStorage.getItem(`${appShortName}-debug-force-setup`) === "1";
+        return localStorage.getItem(`${appStoragePrefix}-debug-force-setup`) === "1";
       } catch {
         return false;
       }

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -175,7 +175,21 @@ function deriveShortName(name: string): string {
   return name.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()
 }
 
+const OFFICIAL_BRAND_SHORT_NAMES = new Set(['teamclaw', 'teamclawdev'])
+
+/** Official TeamClaw Prod/Dev builds share one on-disk + localStorage namespace. */
+export function isOfficialBrand(shortName: string): boolean {
+  return OFFICIAL_BRAND_SHORT_NAMES.has(shortName)
+}
+
+/** Home dir + localStorage prefix (`teamclaw` for official builds). */
+export function resolveStorageDirName(shortName: string): string {
+  return isOfficialBrand(shortName) ? 'teamclaw' : shortName
+}
+
 export const appShortName: string = buildConfig.app.shortName ?? deriveShortName(buildConfig.app.name)
+/** Prefix for localStorage keys — unified `teamclaw` for official builds (Decision 1 = B). */
+export const appStoragePrefix: string = resolveStorageDirName(appShortName)
 /** The product name to show users. Prefer this over `buildConfig.app.name` in
  *  any UI string — `app.name` is the bundle identity and may differ. */
 export const appDisplayName: string = buildConfig.app.displayName ?? buildConfig.app.name
@@ -183,11 +197,11 @@ export const appScheme: string = buildConfig.app.scheme ?? 'teamclaw'
 /** Local agent runtime for this build. Defaults to opencode. */
 export const localAgent: 'opencode' | 'pi' = buildConfig.localAgent === 'pi' ? 'pi' : 'opencode'
 export const DEFAULT_WORKSPACE_PATH = `~/${buildConfig.app.name}`
-export const TEAMCLAW_DIR = `.${appShortName}`
+export const TEAMCLAW_DIR = isOfficialBrand(appShortName) ? '.teamclaw' : `.${appShortName}`
 /** Team share link + global sync dir name. Fixed across brands so daemon, git, and all clients agree. */
 export const TEAM_REPO_DIR = 'teamclaw-team'
-export const CONFIG_FILE_NAME = `${appShortName}.json`
-export const TEAM_SYNCED_EVENT = `${appShortName}-team-synced`
+export const CONFIG_FILE_NAME = isOfficialBrand(appShortName) ? 'teamclaw.json' : `${appShortName}.json`
+export const TEAM_SYNCED_EVENT = `${appStoragePrefix}-team-synced`
 
 /** Baked Chrome-extension pack config (`extensions` in build.config*.json). */
 export const extensionPack: ExtensionPackConfig = parseExtensionPackConfig(

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -95,9 +95,10 @@ export interface BuildConfig {
   }
   /** Which local agent runtime this build targets. "opencode" (default) drives
    *  the official opencode over `opencode serve` HTTP; "pi" selects the pi
-   *  coding-agent RPC backend (see docs/architecture/pi-agent-backend.md).
+   *  coding-agent RPC backend; "cursor" selects the Cursor SDK bridge
+   *  (see docs/architecture/cursor-sdk-backend.md).
    *  Flows into the daemon config (`agents.local_agent`) during onboarding. */
-  localAgent?: 'opencode' | 'pi'
+  localAgent?: 'opencode' | 'pi' | 'cursor'
   defaults: {
     theme: string
   }
@@ -195,7 +196,12 @@ export const appStoragePrefix: string = resolveStorageDirName(appShortName)
 export const appDisplayName: string = buildConfig.app.displayName ?? buildConfig.app.name
 export const appScheme: string = buildConfig.app.scheme ?? 'teamclaw'
 /** Local agent runtime for this build. Defaults to opencode. */
-export const localAgent: 'opencode' | 'pi' = buildConfig.localAgent === 'pi' ? 'pi' : 'opencode'
+export const localAgent: 'opencode' | 'pi' | 'cursor' =
+  buildConfig.localAgent === 'pi'
+    ? 'pi'
+    : buildConfig.localAgent === 'cursor'
+      ? 'cursor'
+      : 'opencode'
 export const DEFAULT_WORKSPACE_PATH = `~/${buildConfig.app.name}`
 export const TEAMCLAW_DIR = isOfficialBrand(appShortName) ? '.teamclaw' : `.${appShortName}`
 /** Team share link + global sync dir name. Fixed across brands so daemon, git, and all clients agree. */

--- a/packages/app/src/lib/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon-local-client.ts
@@ -275,7 +275,7 @@ async function daemonFetchData<T>(path: string, init?: RequestInit): Promise<T> 
 // ─── Local agent runtime (`agents.local_agent` in daemon.toml) ────────────────
 
 /** The local agent runtimes the daemon can drive. */
-export type DaemonLocalAgent = 'opencode' | 'pi'
+export type DaemonLocalAgent = 'opencode' | 'pi' | 'cursor'
 
 interface DaemonConfigEntry {
   key: string
@@ -294,7 +294,11 @@ export async function getDaemonLocalAgent(): Promise<DaemonLocalAgent> {
     // 404 = key absent → daemon default. Anything else: fall back conservatively.
     return 'opencode'
   }
-  return result.data.value === 'pi' ? 'pi' : 'opencode'
+  return result.data.value === 'pi'
+    ? 'pi'
+    : result.data.value === 'cursor'
+      ? 'cursor'
+      : 'opencode'
 }
 
 /**
@@ -310,6 +314,83 @@ export async function setDaemonLocalAgent(agent: DaemonLocalAgent): Promise<{ re
   })
   if (!result.ok) throw new Error(result.error || 'failed to set local agent')
   return { requiresRestart: result.data.requiresRestart ?? true }
+}
+
+interface DaemonMutateConfigResponse {
+  key: string
+  requiresReload?: boolean
+  requiresRestart?: boolean
+}
+
+/** Read a single daemon.toml key via `/v1/config/:key`. Returns null when absent (404). */
+export async function getDaemonConfigEntry(key: string): Promise<DaemonConfigEntry | null> {
+  const result = await daemonFetch<DaemonConfigEntry>(`/v1/config/${encodeURIComponent(key)}`)
+  if (!result.ok) {
+    if (result.status === 404) return null
+    throw new Error(result.error || `failed to read config key ${key}`)
+  }
+  return result.data
+}
+
+/** Write a daemon.toml key. Secret values are write-only on read (see `getDaemonConfigEntry`). */
+export async function setDaemonConfigValue(
+  key: string,
+  value: string | number | boolean,
+): Promise<DaemonMutateConfigResponse> {
+  const result = await daemonFetch<DaemonMutateConfigResponse>(`/v1/config/${encodeURIComponent(key)}`, {
+    method: 'PUT',
+    body: JSON.stringify({ value }),
+  })
+  if (!result.ok) throw new Error(result.error || `failed to set config key ${key}`)
+  return result.data
+}
+
+export interface CursorAgentSettings {
+  apiKeyConfigured: boolean
+  defaultModel: string
+}
+
+const CURSOR_DEFAULT_MODEL = 'composer-2.5'
+
+/** Cursor SDK backend settings stored in daemon.toml under `[agents.cursor]`. */
+export async function getCursorAgentSettings(): Promise<CursorAgentSettings> {
+  const [apiKeyEntry, modelEntry] = await Promise.all([
+    getDaemonConfigEntry('agents.cursor.api_key'),
+    getDaemonConfigEntry('agents.cursor.default_model'),
+  ])
+  const defaultModel =
+    typeof modelEntry?.value === 'string' && modelEntry.value.trim()
+      ? modelEntry.value.trim()
+      : CURSOR_DEFAULT_MODEL
+  return {
+    apiKeyConfigured: apiKeyEntry?.secret === true || typeof apiKeyEntry?.value === 'string',
+    defaultModel,
+  }
+}
+
+export async function saveCursorAgentSettings(input: {
+  apiKey?: string
+  defaultModel?: string
+}): Promise<{ requiresRestart: boolean }> {
+  let requiresRestart = false
+  const trimmedKey = input.apiKey?.trim()
+  if (trimmedKey) {
+    const resp = await setDaemonConfigValue('agents.cursor.api_key', trimmedKey)
+    requiresRestart = requiresRestart || (resp.requiresRestart ?? false)
+  }
+  const trimmedModel = input.defaultModel?.trim()
+  if (trimmedModel) {
+    const resp = await setDaemonConfigValue('agents.cursor.default_model', trimmedModel)
+    requiresRestart = requiresRestart || (resp.requiresRestart ?? false)
+  }
+  // agents.* keys always require restart per daemon HTTP config policy.
+  return { requiresRestart: requiresRestart || Boolean(trimmedKey || trimmedModel) }
+}
+
+/** Restart the desktop-managed amuxd after config edits that require it. */
+export async function restartLocalDaemon(): Promise<void> {
+  invalidateDaemonConnection()
+  await invoke('restart_local_daemon')
 }
 
 // ─── Workspace-control types (mirrors Rust workspace_control.rs) ──────────────

--- a/packages/app/src/lib/diagnostic-report.ts
+++ b/packages/app/src/lib/diagnostic-report.ts
@@ -808,8 +808,8 @@ function buildTeamEnvCheck(teamEnv: TeamEnvDiagnostics | null, teamId: string | 
 }
 
 function buildLocalAgentCheck(doctor: unknown | null): DiagnosticCheck {
-  const runtimeKey = localAgent === 'pi' ? 'pi' : 'opencode'
-  const runtimeLabel = localAgent === 'pi' ? 'Pi' : 'OpenCode'
+  const runtimeKey = localAgent === 'pi' ? 'pi' : localAgent === 'cursor' ? 'cursor' : 'opencode'
+  const runtimeLabel = localAgent === 'pi' ? 'Pi' : localAgent === 'cursor' ? 'Cursor' : 'OpenCode'
   const doc = doctor as Record<string, Record<string, unknown>> | null
   const runtime = doc?.[runtimeKey] as { satisfied?: boolean; version?: string } | undefined
 

--- a/packages/app/src/lib/git/skill-loader.ts
+++ b/packages/app/src/lib/git/skill-loader.ts
@@ -4,7 +4,7 @@ import { homeDir } from '@tauri-apps/api/path'
 import type { SkillWithSource, SkillSource } from './types'
 import { INHERENT_SKILL_NAMES, shouldIncludeDesktopControlSkill } from './types'
 import type { ClawHubLockfile } from '@/lib/clawhub/types'
-import { appDisplayName, TEAM_REPO_DIR } from '@/lib/build-config'
+import { appDisplayName, TEAMCLAW_DIR, TEAM_REPO_DIR } from '@/lib/build-config'
 import i18n from '@/lib/i18n'
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -128,7 +128,7 @@ export async function getSkillDirectories(workspacePath: string | null): Promise
   ])
 
   if (workspacePath) {
-    dirs.add(`${workspacePath}/.teamclaw/skills`)
+    dirs.add(`${workspacePath}/${TEAMCLAW_DIR}/skills`)
     dirs.add(`${workspacePath}/.claude/skills`)
     dirs.add(`${workspacePath}/.agents/skills`)
 
@@ -188,7 +188,7 @@ export async function loadAllSkills(
   //    Skills whose dirname matches INHERENT_SKILL_NAMES are marked as 'builtin'.
   //    Skills whose dirname matches a ClawHub lockfile entry are marked as 'clawhub'.
   if (workspacePath) {
-    const localDir = `${workspacePath}/.teamclaw/skills`
+    const localDir = `${workspacePath}/${TEAMCLAW_DIR}/skills`
     const localSkills = await loadSkillsFromDir(localDir, 'local')
     for (const skill of localSkills) {
       if (INHERENT_SKILL_NAMES.has(skill.filename)) {
@@ -236,7 +236,7 @@ export async function loadAllSkills(
 
   // 7. Scan plugin cache for skills installed via teamclaw.json "plugin" array
   if (workspacePath) {
-    const pluginCacheDir = `${workspacePath}/.teamclaw/cache/agent/node_modules`
+    const pluginCacheDir = `${workspacePath}/${TEAMCLAW_DIR}/cache/agent/node_modules`
     try {
       if (await exists(pluginCacheDir)) {
         const pluginEntries = await readDir(pluginCacheDir)
@@ -361,11 +361,11 @@ export function getSourceLabel(source: SkillSource): string {
 export function getSourceDirHint(source: SkillSource): string {
   switch (source) {
     case 'local':
-      return '.teamclaw/skills/'
+      return `${TEAMCLAW_DIR}/skills/`
     case 'claude':
       return '.claude/skills/'
     case 'clawhub':
-      return '.teamclaw/skills/ (ClawHub)'
+      return `${TEAMCLAW_DIR}/skills/ (ClawHub)`
     case 'shared':
       return '.agents/skills/'
     case 'team':

--- a/packages/app/src/lib/local-daemon-identity.ts
+++ b/packages/app/src/lib/local-daemon-identity.ts
@@ -1,8 +1,8 @@
 /** Tracks amuxd re-init: previous local actor ids are "stale" for engaged pills. */
 
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 
-const PERSISTED_LOCAL_DAEMON_ACTOR_KEY = `${appShortName}-local-daemon-actor-id`
+const PERSISTED_LOCAL_DAEMON_ACTOR_KEY = `${appStoragePrefix}-local-daemon-actor-id`
 
 const supersededLocalActorIds = new Set<string>()
 let lastKnownLocalActorId: string | null = null

--- a/packages/app/src/lib/locale.ts
+++ b/packages/app/src/lib/locale.ts
@@ -1,6 +1,6 @@
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 
-export const LANGUAGE_STORAGE_KEY = `${appShortName}-language`
+export const LANGUAGE_STORAGE_KEY = `${appStoragePrefix}-language`
 export const SUPPORTED_LANGUAGES = ['en', 'zh-CN'] as const
 
 export type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number]

--- a/packages/app/src/lib/notification-service.ts
+++ b/packages/app/src/lib/notification-service.ts
@@ -4,7 +4,7 @@ import {
 } from "@tauri-apps/plugin-notification";
 import { getPermissionPolicy } from "@/lib/permission-policy";
 import { isTauri } from "@/lib/utils";
-import { appShortName } from "@/lib/build-config";
+import { appStoragePrefix } from "@/lib/build-config";
 
 // --- Types ---
 
@@ -12,7 +12,7 @@ export type NotificationType = "action_required" | "task_completed" | "info";
 
 export type NotificationLevel = "all" | "important" | "mute";
 
-const NOTIFICATION_LEVEL_KEY = `${appShortName}-notification-level`;
+export const NOTIFICATION_LEVEL_KEY = `${appStoragePrefix}-notification-level`;
 const DEFAULT_LEVEL: NotificationLevel = "important";
 const THROTTLE_WINDOW_MS = 5000; // 5 seconds dedup window for task_completed
 

--- a/packages/app/src/lib/permission-policy.ts
+++ b/packages/app/src/lib/permission-policy.ts
@@ -1,13 +1,13 @@
 // --- Permission Policy ---
 // Global permission policy configuration for controlling permission request behavior.
-// Persisted in localStorage under '${appShortName}-permission-policy'.
+// Persisted in localStorage under '${appStoragePrefix}-permission-policy'.
 
-import { appShortName } from "@/lib/build-config";
+import { appStoragePrefix } from "@/lib/build-config";
 
 export type PermissionPolicy = "ask" | "batch" | "bypass";
 
-const PERMISSION_POLICY_KEY = `${appShortName}-permission-policy`;
-const PERMISSION_BATCH_DONE_KEY = `${appShortName}-permission-batch-done`;
+const PERMISSION_POLICY_KEY = `${appStoragePrefix}-permission-policy`;
+const PERMISSION_BATCH_DONE_KEY = `${appStoragePrefix}-permission-batch-done`;
 const DEFAULT_POLICY: PermissionPolicy = "ask";
 const VALID_POLICIES: ReadonlySet<string> = new Set(["ask", "batch", "bypass"]);
 

--- a/packages/app/src/lib/roles/loader.ts
+++ b/packages/app/src/lib/roles/loader.ts
@@ -14,9 +14,11 @@ import type { SkillSource } from "@/lib/git/types"
 import { isTauri } from "@/lib/utils"
 import { encodeWorkspaceId, getDaemonRolesSkillsState, putDaemonRole, deleteDaemonRole } from "@/lib/daemon-local-client"
 
-const ROLE_ROOT = ".teamclaw/roles"
-const ROLE_SKILL_DIR = ".teamclaw/roles/skills"
-const ROLE_CONFIG_PATH = ".teamclaw/roles/config.json"
+import { TEAMCLAW_DIR } from "@/lib/build-config"
+
+const ROLE_ROOT = `${TEAMCLAW_DIR}/roles`
+const ROLE_SKILL_DIR = `${TEAMCLAW_DIR}/roles/skills`
+const ROLE_CONFIG_PATH = `${TEAMCLAW_DIR}/roles/config.json`
 const ROLE_SKILL_DIR_NAME = "skills"
 
 const SECTION_NAMES = {
@@ -310,7 +312,7 @@ async function loadRolesSkillsWorkspaceStateFromFs(
       content: skill.content,
       description: extractSkillDescription(skill.content, skill.name),
       source: skill.source,
-      dirPath: skill.dirPath ?? `${workspacePath}/.teamclaw/skills`,
+      dirPath: skill.dirPath ?? `${workspacePath}/${TEAMCLAW_DIR}/skills`,
       linkedRoles: roleUsageBySkill[skill.filename] ?? [],
       isRoleSkill: false,
     })
@@ -507,7 +509,7 @@ export async function deleteRole(workspacePath: string, roleSlug: string, roleFi
 
 export async function loadAttachableSkills(workspacePath: string): Promise<AttachableSkill[]> {
   const { skills } = await loadAllSkills(workspacePath)
-  const workspaceSkillRoot = `${workspacePath}/.teamclaw/skills`
+  const workspaceSkillRoot = `${workspacePath}/${TEAMCLAW_DIR}/skills`
   return skills
     .filter((skill) => skill.source === "local" && skill.dirPath === workspaceSkillRoot)
     .map((skill) => ({
@@ -569,7 +571,7 @@ export async function attachSkillToRole(input: AttachSkillToRoleInput): Promise<
     throw new Error(`Role "${roleSlug}" does not exist`)
   }
 
-  const sourceDir = `${workspacePath}/.teamclaw/skills/${skillSlug}`
+  const sourceDir = `${workspacePath}/${TEAMCLAW_DIR}/skills/${skillSlug}`
   const sourceSkillPath = `${sourceDir}/SKILL.md`
   if (!(await exists(sourceSkillPath))) {
     throw new Error(`Skill "${skillSlug}" is not available for role attachment`)

--- a/packages/app/src/lib/session-permission-mode.ts
+++ b/packages/app/src/lib/session-permission-mode.ts
@@ -1,10 +1,10 @@
 import { useSyncExternalStore } from "react";
-import { appShortName } from "@/lib/build-config";
+import { appStoragePrefix } from "@/lib/build-config";
 
 export type SessionPermissionMode = "default" | "fullAccess";
 
-const STORAGE_KEY = `${appShortName}-session-permission-modes`;
-const CHANGE_EVENT = `${appShortName}-session-permission-modes-changed`;
+const STORAGE_KEY = `${appStoragePrefix}-session-permission-modes`;
+const CHANGE_EVENT = `${appStoragePrefix}-session-permission-modes-changed`;
 const MAX_ENTRIES = 200;
 
 type StoredPayload = {

--- a/packages/app/src/lib/startup-perf.ts
+++ b/packages/app/src/lib/startup-perf.ts
@@ -21,7 +21,7 @@
  * packaged build to turn the timeline log on, or call `dumpStartupTimeline()`
  * from the devtools console at any time.
  */
-import { appShortName } from "./build-config";
+import { appStoragePrefix } from "./build-config";
 
 export type StartupStamp = { name: string; t: number };
 
@@ -32,7 +32,7 @@ let settleTimer: ReturnType<typeof setTimeout> | null = null;
 function dumpEnabled(): boolean {
   if (import.meta.env.DEV) return true;
   try {
-    return localStorage.getItem(`${appShortName}-perf`) === "1";
+    return localStorage.getItem(`${appStoragePrefix}-perf`) === "1";
   } catch {
     return false;
   }

--- a/packages/app/src/lib/storage-migration.ts
+++ b/packages/app/src/lib/storage-migration.ts
@@ -1,0 +1,38 @@
+import { appStoragePrefix, isOfficialBrand, appShortName } from '@/lib/build-config'
+
+const MIGRATION_MARKER = 'teamclaw-localstorage-namespace-v1'
+
+const LEGACY_OFFICIAL_PREFIXES = ['teamclawdev']
+
+/**
+ * One-shot migration: `teamclawdev-*` localStorage keys → `teamclaw-*` for
+ * official builds (Decision 1 = B). Idempotent.
+ */
+export function migrateOfficialLocalStorage(): void {
+  if (typeof localStorage === 'undefined') return
+  if (!isOfficialBrand(appShortName)) return
+  if (localStorage.getItem(MIGRATION_MARKER) === '1') return
+
+  for (const legacyPrefix of LEGACY_OFFICIAL_PREFIXES) {
+    if (legacyPrefix === appStoragePrefix) continue
+    const keysToMove: string[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (key?.startsWith(`${legacyPrefix}-`)) {
+        keysToMove.push(key)
+      }
+    }
+    for (const oldKey of keysToMove) {
+      const newKey = `${appStoragePrefix}-${oldKey.slice(legacyPrefix.length + 1)}`
+      if (localStorage.getItem(newKey) == null) {
+        const value = localStorage.getItem(oldKey)
+        if (value != null) {
+          localStorage.setItem(newKey, value)
+        }
+      }
+      localStorage.removeItem(oldKey)
+    }
+  }
+
+  localStorage.setItem(MIGRATION_MARKER, '1')
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -10,7 +10,10 @@ import { LocalAgentPanelApp } from './components/LocalAgentPanelApp'
 import './styles/globals.css'
 import './stores/dev-expose'
 import './lib/i18n'; // Initialize i18n
-import { appShortName, buildConfig } from './lib/build-config'
+import { appStoragePrefix, buildConfig } from './lib/build-config'
+import { migrateOfficialLocalStorage } from './lib/storage-migration'
+
+migrateOfficialLocalStorage()
 import { ensureBundledAmuxdCurrent } from './lib/daemon-version-upgrade'
 import { initJwtBridge } from './lib/jwt-bridge'
 import { installConsoleCapture } from './lib/console-capture'
@@ -38,7 +41,7 @@ installConsoleCapture()
 
 // Apply persisted theme immediately to prevent flash of wrong theme
 ;(() => {
-  const theme = localStorage.getItem(`${appShortName}-theme`) || buildConfig.defaults?.theme || 'system'
+  const theme = localStorage.getItem(`${appStoragePrefix}-theme`) || buildConfig.defaults?.theme || 'system'
   const root = document.documentElement
   if (theme === 'dark') {
     root.classList.add('dark')

--- a/packages/app/src/stores/acp-debug-store.ts
+++ b/packages/app/src/stores/acp-debug-store.ts
@@ -1,9 +1,9 @@
 import { create } from "zustand";
 import { appendAcpDebugLineToFile } from "@/lib/acp-debug-file-log";
-import { appShortName } from "@/lib/build-config";
+import { appStoragePrefix } from "@/lib/build-config";
 import type { AcpEvent } from "@/lib/proto/amux_pb";
 
-const ACP_DEBUG_ENABLED_KEY = `${appShortName}-acp-stream-debug`;
+const ACP_DEBUG_ENABLED_KEY = `${appStoragePrefix}-acp-stream-debug`;
 
 function readAcpDebugEnabled(): boolean {
   if (import.meta.env.VITE_ACP_DEBUG_STREAM === "true") return true;

--- a/packages/app/src/stores/deps.ts
+++ b/packages/app/src/stores/deps.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { isTauri } from '@/lib/utils'
 import { loadFromStorage, saveToStorage } from '@/lib/storage'
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 
 export interface DependencyInfo {
   name: string
@@ -42,9 +42,9 @@ interface DepInstallProgressEvent {
 
 // ─── Persistent setup status ─────────────────────────────────────────────────
 
-const DEPS_SETUP_KEY = `${appShortName}-deps-setup-status`
+const DEPS_SETUP_KEY = `${appStoragePrefix}-deps-setup-status`
 /** First-run welcome screen seen flag (shown once, before dependency setup). */
-const WELCOME_SEEN_KEY = `${appShortName}-welcome-seen`
+const WELCOME_SEEN_KEY = `${appStoragePrefix}-welcome-seen`
 /** Re-check interval: 24 hours */
 const RECHECK_TTL_MS = 24 * 60 * 60 * 1000
 
@@ -152,13 +152,13 @@ interface DepsState {
 
 
 /**
- * Debug: set localStorage.setItem(`${appShortName}-debug-force-setup`, '1') to force
+ * Debug: set localStorage.setItem(`${appStoragePrefix}-debug-force-setup`, '1') to force
  * SetupGuide to show in browser dev mode with mock dependency data.
- * Remove the key to disable: localStorage.removeItem(`${appShortName}-debug-force-setup`)
+ * Remove the key to disable: localStorage.removeItem(`${appStoragePrefix}-debug-force-setup`)
  */
 const isDebugForceSetup = () => {
   try {
-    return localStorage.getItem(`${appShortName}-debug-force-setup`) === '1'
+    return localStorage.getItem(`${appStoragePrefix}-debug-force-setup`) === '1'
   } catch {
     return false
   }

--- a/packages/app/src/stores/git-repos.ts
+++ b/packages/app/src/stores/git-repos.ts
@@ -3,10 +3,10 @@ import type { GitRepo, GitRepoConfig, RepoSyncStatus } from '@/lib/git/types'
 import { gitManager } from '@/lib/git/manager'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { loadFromStorage, saveToStorage } from '@/lib/storage'
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 
 // Storage key for persisting repo state
-const STORAGE_KEY = `${appShortName}-git-repos`
+const STORAGE_KEY = `${appStoragePrefix}-git-repos`
 
 interface GitReposState {
   /** Whether git CLI is available on the system */

--- a/packages/app/src/stores/git-settings.ts
+++ b/packages/app/src/stores/git-settings.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { GitStatus } from '@/lib/git/service'
 import { loadFromStorage, saveToStorage } from '@/lib/storage'
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 
 // Default color scheme for Git statuses
 const DEFAULT_STATUS_COLORS: Record<GitStatus, string> = {
@@ -16,7 +16,7 @@ const DEFAULT_STATUS_COLORS: Record<GitStatus, string> = {
 }
 
 // Storage key for persisting settings
-const STORAGE_KEY = `${appShortName}-git-settings`
+const STORAGE_KEY = `${appStoragePrefix}-git-settings`
 
 interface GitSettingsState {
   /** Whether to show Git status indicators in the file tree */

--- a/packages/app/src/stores/provider.ts
+++ b/packages/app/src/stores/provider.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { toast } from 'sonner'
-import { appShortName } from '@/lib/build-config'
+import { appStoragePrefix } from '@/lib/build-config'
 import { invoke } from '@tauri-apps/api/core'
 import { workspaceScopedKey } from '@/lib/storage'
 import { sessionFlowLog } from '@/lib/session-flow-log'
@@ -29,7 +29,7 @@ import {
 } from '@/lib/opencode/config'
 import { TEAM_SHARED_PROVIDER_ID } from '@/lib/team-provider'
 
-const SELECTED_MODEL_BASE = `${appShortName}-selected-model`
+const SELECTED_MODEL_BASE = `${appStoragePrefix}-selected-model`
 const DEFAULT_CONNECTABLE_PROVIDERS: ProviderEntry[] = [
   { id: 'openai', name: 'OpenAI', configured: false },
 ]

--- a/packages/app/src/stores/session-pins.ts
+++ b/packages/app/src/stores/session-pins.ts
@@ -1,6 +1,6 @@
-import { appShortName } from "@/lib/build-config";
+import { appStoragePrefix } from "@/lib/build-config";
 
-const STORAGE_KEY = `${appShortName}-pinned-sessions`;
+const STORAGE_KEY = `${appStoragePrefix}-pinned-sessions`;
 
 type PinnedSessionStorage = Record<string, string[]>;
 

--- a/packages/app/src/stores/setup.ts
+++ b/packages/app/src/stores/setup.ts
@@ -1,14 +1,14 @@
 import { create } from 'zustand'
 import { isTauri } from '@/lib/utils'
 import { markStartup } from '@/lib/startup-perf'
-import { appShortName, localAgent } from '@/lib/build-config'
+import { appStoragePrefix, localAgent } from '@/lib/build-config'
 
 // Cache the last-known "all required deps satisfied" verdict so a returning user
 // (deps already installed) is never gated behind the cold `setup_list_requirements`
 // probe, which spawns `amuxd doctor` and costs ~4s on first launch (macOS
 // Gatekeeper). The probe still runs in the background to refresh this flag; the
 // daemon-onboarding gate remains the real backstop if a dependency is missing.
-const SETUP_OK_KEY = `${appShortName}-setup-ok`
+const SETUP_OK_KEY = `${appStoragePrefix}-setup-ok`
 
 /** True if a prior probe confirmed all required deps were present. Sync, cheap. */
 export function setupPreviouslySatisfied(): boolean {

--- a/packages/app/src/stores/team-mode.ts
+++ b/packages/app/src/stores/team-mode.ts
@@ -8,13 +8,13 @@ import { useTeamShareStore } from './team-share'
 import { useCurrentTeamStore } from './current-team'
 import { isTauri } from '@/lib/utils'
 import { workspaceScopedKey } from '@/lib/storage'
-import { appShortName, buildConfig, TEAM_REPO_DIR, type TeamModelOption } from '@/lib/build-config'
+import { appStoragePrefix, buildConfig, TEAM_REPO_DIR, type TeamModelOption } from '@/lib/build-config'
 
 
 const TEAM_PROVIDER_ID = TEAM_SHARED_PROVIDER_ID
 
-const TEAM_MODEL_BASE = `${appShortName}-team-model`
-const PRE_TEAM_MODEL_BASE = `${appShortName}-pre-team-model`
+const TEAM_MODEL_BASE = `${appStoragePrefix}-team-model`
+const PRE_TEAM_MODEL_BASE = `${appStoragePrefix}-pre-team-model`
 
 function teamModelKey(): string {
   return workspaceScopedKey(TEAM_MODEL_BASE, useWorkspaceStore.getState().workspacePath)

--- a/packages/app/src/stores/voice-input.ts
+++ b/packages/app/src/stores/voice-input.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
-import { appShortName } from '@/lib/build-config';
+import { appStoragePrefix } from '@/lib/build-config';
 
-const VOICE_ENABLED_KEY = `${appShortName}-voice-enabled`;
+const VOICE_ENABLED_KEY = `${appStoragePrefix}-voice-enabled`;
 
 /** Store for global voice input: transcript is stored after recording, user decides where to put it */
 interface VoiceInputState {

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { UNSUPPORTED_BINARY_EXTENSIONS } from "@/components/viewers/UnsupportedFileViewer";
 import { isTauri } from '@/lib/utils'
 import { ensureGitignoreEntries } from '@/lib/gitignore-manager'
-import { appDisplayName, appShortName, TEAM_REPO_DIR } from '@/lib/build-config'
+import { appDisplayName, appStoragePrefix, TEAM_REPO_DIR } from '@/lib/build-config'
 import { useTeamModeStore } from './team-mode'
 
 // Start watching a directory for file changes
@@ -170,7 +170,7 @@ function getFolderName(path: string): string {
   return parts[parts.length - 1] || path;
 }
 
-export const WORKSPACE_STORAGE_KEY = `${appShortName}-workspace-path`;
+export const WORKSPACE_STORAGE_KEY = `${appStoragePrefix}-workspace-path`;
 
 async function readWorkspaceTextFile(
   workspacePath: string,

--- a/scripts/deploy-daemon-binaries.sh
+++ b/scripts/deploy-daemon-binaries.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# deploy-daemon-binaries — build amuxd + teamclaw-introspect from the current
+# checkout and overwrite ~/.amuxd/bin/{amuxd,teamclaw-introspect}, then reload
+# the user service (launchd / systemd).
+#
+# Uses .cargo-target/ (same as pnpm rust:build / dev:daemon), not target/.
+#
+# Usage:
+#   scripts/deploy-daemon-binaries.sh              # debug build, overwrite + reload
+#   scripts/deploy-daemon-binaries.sh --release    # release build
+#   scripts/deploy-daemon-binaries.sh --skip-build # use existing .cargo-target/<profile>/*
+#   scripts/deploy-daemon-binaries.sh --no-reload  # copy only, don't touch the service
+#   scripts/deploy-daemon-binaries.sh --no-sidecar # don't refresh apps/desktop/binaries/*
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${ROOT_DIR}/.cargo-target}"
+
+LABEL="cc.ucar.amuxd"
+AMUXD_HOME="${HOME}/.amuxd"
+BIN_DIR="${AMUXD_HOME}/bin"
+PLIST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+
+PROFILE="debug"
+SKIP_BUILD=0
+NO_RELOAD=0
+NO_SIDECAR=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release)    PROFILE="release"; shift ;;
+    --debug)      PROFILE="debug"; shift ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    --no-reload)  NO_RELOAD=1; shift ;;
+    --no-sidecar) NO_SIDECAR=1; shift ;;
+    -h|--help)
+      sed -n '2,13p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "error: unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*)
+  AMUXD_NAME="amuxd.exe"
+  INTROSPECT_NAME="teamclaw-introspect.exe"
+  SIDE_EXT=".exe"
+  ;;
+*)
+  AMUXD_NAME="amuxd"
+  INTROSPECT_NAME="teamclaw-introspect"
+  SIDE_EXT=""
+  ;;
+esac
+
+TARGET="${TARGET:-$(rustc -vV 2>/dev/null | awk '/^host:/{print $2}')}"
+SRC_AMUXD="${CARGO_TARGET_DIR}/${PROFILE}/${AMUXD_NAME}"
+SRC_INTROSPECT="${CARGO_TARGET_DIR}/${PROFILE}/${INTROSPECT_NAME}"
+DEST_AMUXD="${BIN_DIR}/${AMUXD_NAME}"
+DEST_INTROSPECT="${BIN_DIR}/${INTROSPECT_NAME}"
+SIDECAR_AMUXD="${ROOT_DIR}/apps/desktop/binaries/amuxd-${TARGET}${SIDE_EXT}"
+SIDECAR_INTROSPECT="${ROOT_DIR}/apps/desktop/binaries/teamclaw-introspect-${TARGET}${SIDE_EXT}"
+
+GIT_SHA="$(git -C "${ROOT_DIR}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+GIT_BRANCH="$(git -C "${ROOT_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+GIT_DIRTY=""
+git -C "${ROOT_DIR}" diff --quiet 2>/dev/null || GIT_DIRTY=" (dirty)"
+
+say() { printf '\033[1;36m▸ %s\033[0m\n' "$*"; }
+
+install_binary() {
+  local src="$1"
+  local dest="$2"
+  [[ -x "${src}" ]] || { echo "error: built binary not found at ${src}" >&2; exit 1; }
+  say "installing -> ${dest}"
+  mkdir -p "$(dirname "${dest}")"
+  local tmp="${dest}.new.$$"
+  cp "${src}" "${tmp}"
+  chmod +x "${tmp}"
+  mv -f "${tmp}" "${dest}"
+}
+
+refresh_sidecar() {
+  local src="$1"
+  local dest="$2"
+  say "refreshing bundled sidecar -> ${dest}"
+  mkdir -p "$(dirname "${dest}")"
+  local tmp="${dest}.new.$$"
+  cp "${src}" "${tmp}"
+  chmod +x "${tmp}"
+  mv -f "${tmp}" "${dest}"
+}
+
+# ── 1. build ────────────────────────────────────────────────────────────────
+if [[ "${SKIP_BUILD}" -eq 0 ]]; then
+  say "building amuxd + teamclaw-introspect (${PROFILE}) from ${GIT_BRANCH}@${GIT_SHA}${GIT_DIRTY}"
+  RELEASE_FLAG=()
+  if [[ "${PROFILE}" == "release" ]]; then
+    RELEASE_FLAG=(--release)
+  fi
+  cargo build -p amuxd "${RELEASE_FLAG[@]}"
+  cargo build --manifest-path apps/desktop/Cargo.toml -p teamclaw-introspect "${RELEASE_FLAG[@]}"
+fi
+
+# ── 2. detect platform service manager ──────────────────────────────────────
+OS="$(uname -s)"
+UID_NUM="$(id -u)"
+
+service_running() {
+  case "${OS}" in
+    Darwin) launchctl print "gui/${UID_NUM}/${LABEL}" >/dev/null 2>&1 ;;
+    *)      systemctl --user is-active --quiet amuxd 2>/dev/null ;;
+  esac
+}
+
+stop_service() {
+  case "${OS}" in
+    Darwin) launchctl bootout "gui/${UID_NUM}/${LABEL}" 2>/dev/null || true ;;
+    Linux)  systemctl --user stop amuxd 2>/dev/null || true ;;
+  esac
+}
+
+start_service() {
+  case "${OS}" in
+    Darwin)
+      if [[ -f "${PLIST}" ]]; then
+        local i
+        for i in 1 2 3 4 5; do
+          if launchctl bootstrap "gui/${UID_NUM}" "${PLIST}" 2>/dev/null; then
+            return 0
+          fi
+          sleep 0.5
+        done
+        echo "warn: launchctl bootstrap did not succeed; try: launchctl bootstrap gui/${UID_NUM} ${PLIST}" >&2
+      else
+        say "no launchd plist yet — registering service via 'amuxd install-service'"
+        "${DEST_AMUXD}" install-service
+      fi
+      ;;
+    Linux)
+      systemctl --user restart amuxd 2>/dev/null \
+        || { say "no systemd unit yet — registering via 'amuxd install-service'"; "${DEST_AMUXD}" install-service; }
+      ;;
+    *) echo "warn: unknown OS '${OS}', binaries copied but service not reloaded" >&2 ;;
+  esac
+}
+
+# ── 3. stop, replace binaries, reload ───────────────────────────────────────
+WAS_RUNNING=0
+if service_running; then WAS_RUNNING=1; fi
+
+if [[ "${NO_RELOAD}" -eq 0 && "${WAS_RUNNING}" -eq 1 ]]; then
+  say "stopping ${LABEL}"
+  stop_service
+  for _ in $(seq 1 20); do service_running || break; sleep 0.25; done
+fi
+
+install_binary "${SRC_AMUXD}" "${DEST_AMUXD}"
+install_binary "${SRC_INTROSPECT}" "${DEST_INTROSPECT}"
+printf '%s  %s@%s%s  %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "${GIT_BRANCH}" "${GIT_SHA}" "${GIT_DIRTY}" "${PROFILE}" \
+  > "${BIN_DIR}/amuxd.deployed"
+
+if [[ "${NO_SIDECAR}" -eq 0 && -n "${TARGET}" ]]; then
+  refresh_sidecar "${SRC_AMUXD}" "${SIDECAR_AMUXD}"
+  refresh_sidecar "${SRC_INTROSPECT}" "${SIDECAR_INTROSPECT}"
+elif [[ "${NO_SIDECAR}" -eq 0 ]]; then
+  echo "warn: could not resolve host target (rustc missing?) — skipped sidecar refresh" >&2
+fi
+
+if [[ "${NO_RELOAD}" -eq 1 ]]; then
+  say "skipped service reload (--no-reload); restart it yourself to pick up the new binaries"
+else
+  say "reloading service"
+  start_service
+fi
+
+# ── 4. report ───────────────────────────────────────────────────────────────
+echo
+say "deployed amuxd + teamclaw-introspect  (${GIT_BRANCH}@${GIT_SHA}${GIT_DIRTY}, ${PROFILE})"
+for dest in "${DEST_AMUXD}" "${DEST_INTROSPECT}"; do
+  stat -f "  %N : %Sm  %z bytes" -t "%Y-%m-%d %H:%M:%S" "${dest}" 2>/dev/null \
+    || stat -c "  %n : %y  %s bytes" "${dest}" 2>/dev/null || true
+done
+if [[ "${NO_SIDECAR}" -eq 0 && -n "${TARGET}" ]]; then
+  echo "  sidecars: apps/desktop/binaries/{amuxd,teamclaw-introspect}-${TARGET}${SIDE_EXT}"
+fi
+if [[ "${NO_RELOAD}" -eq 0 && "${OS}" == "Darwin" ]]; then
+  PID="$(launchctl print "gui/${UID_NUM}/${LABEL}" 2>/dev/null | awk -F'= ' '/[^a-z]pid =/{print $2; exit}')"
+  echo "  service: ${LABEL}  pid=${PID:-<not running>}"
+  echo "  logs   : tail -f ${AMUXD_HOME}/amuxd.out.log"
+fi

--- a/scripts/verify-cursor-sdk.mjs
+++ b/scripts/verify-cursor-sdk.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Smoke test for Cursor SDK feasibility (Composer local agent).
+ * Usage: CURSOR_API_KEY=crsr_... node scripts/verify-cursor-sdk.mjs
+ *
+ * Run from apps/daemon/cursor-bridge after `npm install`, or set NODE_PATH.
+ */
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const bridgeDir = join(here, '../apps/daemon/cursor-bridge')
+const require = createRequire(join(bridgeDir, 'package.json'))
+const { Agent, Cursor, CursorAgentError } = require('@cursor/sdk')
+
+const apiKey = process.env.CURSOR_API_KEY?.trim()
+if (!apiKey) {
+  console.error('Missing CURSOR_API_KEY')
+  process.exit(1)
+}
+
+const cwd = process.env.CURSOR_SDK_CWD || process.cwd()
+
+async function main() {
+  console.log('=== 1. List models ===')
+  const models = await Cursor.models.list({ apiKey })
+  const ids = models.map((m) => m.id)
+  console.log('count:', ids.length)
+  console.log('ids:', ids.slice(0, 20).join(', '), ids.length > 20 ? '...' : '')
+
+  const modelId = ids.includes('composer-2.5') ? 'composer-2.5' : ids[0]
+  if (!modelId) {
+    console.error('No models returned for this key')
+    process.exit(1)
+  }
+  console.log('using model:', modelId)
+
+  console.log('\n=== 2. Local agent prompt ===')
+  console.log('cwd:', cwd)
+
+  const agent = await Agent.create({
+    apiKey,
+    model: { id: modelId },
+    local: { cwd, settingSources: [] },
+  })
+
+  try {
+    console.log('agentId:', agent.agentId)
+
+    const run = await agent.send('Reply with exactly one word: pong')
+    let streamed = ''
+    for await (const event of run.stream()) {
+      if (event.type === 'assistant') {
+        for (const block of event.message.content) {
+          if (block.type === 'text') {
+            streamed += block.text
+            process.stdout.write(block.text)
+          }
+        }
+      }
+    }
+    console.log()
+
+    const result = await run.wait()
+    console.log('runId:', result.id)
+    console.log('status:', result.status)
+    console.log('streamed text:', JSON.stringify(streamed.trim()))
+
+    if (result.status === 'error') {
+      console.error('Run finished with error status')
+      process.exit(2)
+    }
+
+    console.log('\n=== OK: Cursor SDK local agent works ===')
+  } finally {
+    await agent[Symbol.asyncDispose]?.()
+  }
+}
+
+main().catch((err) => {
+  if (err instanceof CursorAgentError) {
+    console.error('CursorAgentError:', err.message, 'retryable=', err.isRetryable)
+    process.exit(1)
+  }
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- Add **Cursor SDK** as a third local agent runtime (`agents.local_agent = "cursor"`), implemented via a `cursor-bridge` Node sidecar that wraps `@cursor/sdk` and translates stream events into ACP (same path as opencode/pi).
- Fix stream parsing in `cursor-bridge` so `run.stream()` events (`assistant`, `thinking`, …) are forwarded correctly — previously only `statusChange` was emitted with no reply text.
- Pass TeamClaw **injected env vars** (personal/team secrets, `actor_id`, `tc_api_key`, etc.) into `cursor-bridge` spawn, matching the pi backend behavior.
- Add **Settings → LLM** UI for Cursor: configure API key and default model via `/v1/config/*`, auto-restart daemon on save — no manual `daemon.toml` editing required.
- Add runtime picker option in **Daemon → General**, doctor checks, model catalog wiring, and `scripts/verify-cursor-sdk.mjs` smoke test.

## Architecture

See `docs/architecture/cursor-sdk-backend.md`.

```
amuxd (Rust) ──JSONL──► cursor-bridge (Node) ──► @cursor/sdk Agent
                              │
                              └── inherits TeamClaw extra_env + CURSOR_API_KEY
```

## Test plan

- [ ] `cd apps/daemon/cursor-bridge && npm install`
- [ ] `CURSOR_API_KEY=crsr_… node scripts/verify-cursor-sdk.mjs` — lists models and returns "pong"
- [ ] `cargo check -p amuxd`
- [ ] Desktop: **Daemon settings → General → Runtime → cursor**, then **Settings → LLM** → save API key
- [ ] Send a message in a session — agent replies with streaming output (not just Active→Idle)
- [ ] Ask agent to `printenv SP_LIVE_SECRET_KEY` (or another injected secret) — value should be present after env reload / re-attach
- [ ] `amuxd doctor` with `local_agent=cursor` reports cursor section satisfied when key + node + bridge are present

## Notes

- MCP bridging for cursor runtime is not in v1 (UI shows a note in MCP settings).
- Cloud advertise may still reject `"cursor"` as agent type until a DB migration allows it — local sessions work regardless.


Made with [Cursor](https://cursor.com)