### PR TITLE
chore(dev): allowlist admin.mx5.cn for Web SSO session injection

### DIFF
--- a/build.config.dev.json
+++ b/build.config.dev.json
@@ -18,7 +18,13 @@
       "wecom": true,
       "wechat": true
     },
-    "auth": { "google": false, "wechat": false, "phone": false, "webSSO": true },
+    "auth": {
+      "google": false,
+      "wechat": false,
+      "phone": false,
+      "webSSO": true,
+      "webSSOHosts": ["admin.mx5.cn"]
+    },
     "teamShareBrowser": true,
     "apps": true
   },


### PR DESCRIPTION
## Why

Partner admin console auto-login is fully implemented on both sides and has never run once.

`adminSsoInjectionFor` (`lib/admin-sso-inject.ts`) hands the storage key and serialized session to `webview_create`; `build_supabase_session_script` (`webview.rs:312`) seeds it at documentStart so the SPA's bundle finds itself already signed in. The native re-check `host_allows_session_injection` tests the URL host against `WEBSSO_ADMIN_HOSTS`, which `build.rs:155` only emits when `features.auth.webSSOHosts` is present.

No build config ever set it. The allowlist was empty, so every injection was refused.

## The host

Not a guess. The dev build's Cloud API — `teamclaw-api.ucar.cc`, per this file's own `cloudApiUrl` — already serves this from the unauthenticated `/v1/config/public`:

```json
{"webSso":{"loginUrl":"https://admin.mx5.cn/sign-in","storageKey":"sb-supa-auth-token"}}
```

The frontend derives its allowlist host from that same value, so this pins the native side to the host the backend already declares. Both layers now agree instead of one silently vetoing.

Verified baked: `BUILD_ENV=dev` compilation prints `Using WEBSSO_ADMIN_HOSTS=admin.mx5.cn`.

## Scope

Dev flavor only. `production` and `teal` leave `features.auth` empty, so injection stays off there until their own config opts in.

Worth knowing: `api.teamclaw-dev.ucar.cc` returns `{}` from `/v1/config/public` — its `WEBSSO_LOGIN_URL` is unset — so Web SSO only works on builds pointing at `teamclaw-api.ucar.cc`. The dev flavor does.

## Testing

`BUILD_ENV=dev pnpm tauri:dev`, sign in, then open an `admin.mx5.cn` URL in-app; it should land signed in. Note `build_supabase_session_script` only writes when the key is absent, so clear an existing `sb-supa-auth-token` in the webview before re-testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
