### PR TITLE
fix(apps): FC_ENDPOINT is reserved by Function Compute — rename to APPS_FC_ENDPOINT

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -63,7 +63,7 @@ ENDPOINT=https://oss-cn-shenzhen.aliyuncs.com
 
 # ── Apps module (per-app git repo + FC function + Postgres schema) ─────
 # All optional. Without CODEUP_*, creating an app fails at the repo step;
-# without APPS_DB_ADMIN_URL or FC_ENDPOINT/ALIYUN_ACCOUNT_ID, "deploy" returns
+# without APPS_DB_ADMIN_URL or APPS_FC_ENDPOINT/ALIYUN_ACCOUNT_ID, "deploy" returns
 # 503 deploy_unavailable instead of half-provisioning.
 CODEUP_ORG_ID=
 CODEUP_PAT=
@@ -71,9 +71,9 @@ CODEUP_BOT_USERNAME=teamclaw
 # Same RDS instance as the control plane, DIFFERENT database (teamclaw_apps).
 APPS_DB_ADMIN_URL=
 # Account-scoped FC 3.0 data-plane host — NOT the OSS ENDPOINT above. Either
-# set FC_ENDPOINT directly, or ALIYUN_ACCOUNT_ID to have it composed as
+# set APPS_FC_ENDPOINT directly, or ALIYUN_ACCOUNT_ID to have it composed as
 # <accountId>.<REGION>.fc.aliyuncs.com.
-FC_ENDPOINT=
+APPS_FC_ENDPOINT=
 ALIYUN_ACCOUNT_ID=
 
 # ── iOS push (optional; all five needed together) ──────────────────────

--- a/deploy/self-host/README.md
+++ b/deploy/self-host/README.md
@@ -754,7 +754,7 @@ All variables live in `.env` (copied from `.env.example`).
 | `ENDPOINT` | no | OSS endpoint URL |
 | `CODEUP_ORG_ID` / `CODEUP_PAT` / `CODEUP_BOT_USERNAME` | for apps | Managed-git org + PAT used to create each app's repo. Missing → `POST /v1/apps` fails at the repo step |
 | `APPS_DB_ADMIN_URL` | for apps | Admin connection to the shared `teamclaw_apps` database (same RDS instance, different database). Missing → app deploy returns 503 `deploy_unavailable` |
-| `FC_ENDPOINT` / `ALIYUN_ACCOUNT_ID` | for apps | Account-scoped FC 3.0 data-plane host (`<accountId>.<region>.fc.aliyuncs.com`). Not the OSS `ENDPOINT`; set one of the two |
+| `APPS_FC_ENDPOINT` / `ALIYUN_ACCOUNT_ID` | for apps | Account-scoped FC 3.0 data-plane host (`<accountId>.<region>.fc.aliyuncs.com`). Not the OSS `ENDPOINT`; set one of the two |
 | `LITELLM_URL` | no | 留空即用内置网关（compose 默认 `http://litellm:4000`）。仅在改用**外部**网关时才设置 |
 | `LITELLM_MASTER_KEY` | auto | `gen-secrets.sh` 生成（`sk-` 前缀）；LiteLLM 管理凭证,同时交给 FC |
 | `LITELLM_UI_USERNAME` | no | 管理 UI 用户名（默认 `admin`） |

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -237,8 +237,8 @@ services:
       APPS_DB_ADMIN_URL: "${APPS_DB_ADMIN_URL:-}"
       # The FC 3.0 data-plane host is account-scoped
       # (<accountId>.<region>.fc.aliyuncs.com) and is NOT the OSS ENDPOINT.
-      # Set FC_ENDPOINT, or ALIYUN_ACCOUNT_ID to have it composed.
-      FC_ENDPOINT: "${FC_ENDPOINT:-}"
+      # Set APPS_FC_ENDPOINT, or ALIYUN_ACCOUNT_ID to have it composed.
+      APPS_FC_ENDPOINT: "${APPS_FC_ENDPOINT:-}"
       ALIYUN_ACCOUNT_ID: "${ALIYUN_ACCOUNT_ID:-}"
       # Optional partner-integration features, all off unless set here. This
       # `environment:` map is an explicit allowlist — a var absent from it never

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -89,7 +89,7 @@ export interface BuildConfig {
     /** Apps module: build full-stack apps (per-app workspace/git + FC deploy).
      *  Off by default; on in build.config.dev.json. Enabling it in a shipped
      *  build also needs the deploy env (CODEUP_*, APPS_DB_ADMIN_URL,
-     *  FC_ENDPOINT/ALIYUN_ACCOUNT_ID) on that build's Cloud API, or deploy
+     *  APPS_FC_ENDPOINT/ALIYUN_ACCOUNT_ID) on that build's Cloud API, or deploy
      *  answers 503 deploy_unavailable. */
     apps?: boolean
   }

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -51,7 +51,7 @@ resources:
         # FC 3.0 data-plane host for the apps module's own function calls. It is
         # account-scoped (<accountId>.<region>.fc.aliyuncs.com) and unrelated to
         # the OSS ENDPOINT above. Set one of the two.
-        FC_ENDPOINT: ${env('FC_ENDPOINT', '')}
+        APPS_FC_ENDPOINT: ${env('APPS_FC_ENDPOINT', '')}
         ALIYUN_ACCOUNT_ID: ${env('ALIYUN_ACCOUNT_ID', '')}
         PUSH_WEBHOOK_SECRET: ${env('PUSH_WEBHOOK_SECRET')}
         CRON_TRIGGER_SECRET: ${env('CRON_TRIGGER_SECRET', '')}

--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -53,7 +53,7 @@ export function syncGetQueryToBody(event: any) {
 
 // Deploy provisioning deps (FC function + optionally a Postgres schema).
 // Returns {} when FC is unconfigured so deployApp/finalizeDeploy surface 503
-// rather than crashing at import. FC_ENDPOINT/ALIYUN_ACCOUNT_ID counts as
+// rather than crashing at import. APPS_FC_ENDPOINT/ALIYUN_ACCOUNT_ID counts as
 // "configured": without it every FC call fails deep inside the SDK.
 //
 // The apps database is a SEPARATE, softer requirement — only `data_app` needs

--- a/services/fc/src/lib/provisioning/fc-client.ts
+++ b/services/fc/src/lib/provisioning/fc-client.ts
@@ -16,12 +16,16 @@ export function accountIdFromRoleArn(arn: string | undefined): string | null {
  * `<accountId>.<region>.fc.aliyuncs.com`. The OSS `ENDPOINT` env (oss.ts) is a
  * different host and is NOT reusable.
  *
- * Resolution order: an explicit `FC_ENDPOINT`, then `ALIYUN_ACCOUNT_ID`, then
- * the account id embedded in `ROLE_ARN` — which every deployment that can talk
- * to OSS already has, so app deploys need no new configuration at all.
+ * Resolution order: an explicit `APPS_FC_ENDPOINT`, then `ALIYUN_ACCOUNT_ID`,
+ * then the account id embedded in `ROLE_ARN` — which every deployment that can
+ * talk to OSS already has, so app deploys need no new configuration at all.
+ *
+ * The override is NOT called `FC_ENDPOINT`: that name is reserved by Alibaba
+ * Function Compute, which rejects the whole deploy with
+ * `InvalidArgument: The environment variable name 'FC_ENDPOINT' is reserved`.
  */
 export function resolveFcEndpoint(): string | null {
-  const explicit = process.env.FC_ENDPOINT?.trim();
+  const explicit = process.env.APPS_FC_ENDPOINT?.trim();
   if (explicit) return explicit;
   const accountId =
     process.env.ALIYUN_ACCOUNT_ID?.trim() || accountIdFromRoleArn(process.env.ROLE_ARN);
@@ -35,7 +39,7 @@ export function fcEndpoint(): string {
   // error that named no variable at all. Fail with the config problem instead.
   if (!endpoint) {
     throw new Error(
-      "FC endpoint is not configured: set FC_ENDPOINT, ALIYUN_ACCOUNT_ID, or a ROLE_ARN to derive it from",
+      "FC endpoint is not configured: set APPS_FC_ENDPOINT, ALIYUN_ACCOUNT_ID, or a ROLE_ARN to derive it from",
     );
   }
   return endpoint;

--- a/services/fc/test/provisioning/fc-client.test.ts
+++ b/services/fc/test/provisioning/fc-client.test.ts
@@ -70,16 +70,16 @@ test("accountIdFromRoleArn reads the account out of a RAM role ARN", () => {
 
 test("fcEndpoint resolves explicit host, then account id, then ROLE_ARN", () => {
   const prev = {
-    endpoint: process.env.FC_ENDPOINT,
+    endpoint: process.env.APPS_FC_ENDPOINT,
     account: process.env.ALIYUN_ACCOUNT_ID,
     role: process.env.ROLE_ARN,
   };
-  delete process.env.FC_ENDPOINT;
+  delete process.env.APPS_FC_ENDPOINT;
   delete process.env.ALIYUN_ACCOUNT_ID;
   delete process.env.ROLE_ARN;
   try {
     // Previously composed the literal host "undefined.<region>.fc.aliyuncs.com".
-    assert.throws(() => fcEndpoint(), /FC_ENDPOINT, ALIYUN_ACCOUNT_ID, or a ROLE_ARN/);
+    assert.throws(() => fcEndpoint(), /APPS_FC_ENDPOINT, ALIYUN_ACCOUNT_ID, or a ROLE_ARN/);
 
     // Any deployment that can reach OSS already has ROLE_ARN, so app deploys
     // need no new configuration.
@@ -89,10 +89,10 @@ test("fcEndpoint resolves explicit host, then account id, then ROLE_ARN", () => 
     process.env.ALIYUN_ACCOUNT_ID = "999";
     assert.match(fcEndpoint(), /^999\./, "explicit account id beats the ARN");
 
-    process.env.FC_ENDPOINT = "https://explicit.example";
+    process.env.APPS_FC_ENDPOINT = "https://explicit.example";
     assert.equal(fcEndpoint(), "https://explicit.example", "explicit host wins outright");
   } finally {
-    for (const [k, v] of [["FC_ENDPOINT", prev.endpoint], ["ALIYUN_ACCOUNT_ID", prev.account], ["ROLE_ARN", prev.role]] as const) {
+    for (const [k, v] of [["APPS_FC_ENDPOINT", prev.endpoint], ["ALIYUN_ACCOUNT_ID", prev.account], ["ROLE_ARN", prev.role]] as const) {
       if (v === undefined) delete process.env[k]; else process.env[k] = v;
     }
   }


### PR DESCRIPTION
Alibaba Function Compute reserves `FC_ENDPOINT` and rejects any deploy declaring it:

```
InvalidArgument: code: 400, The environment variable name 'FC_ENDPOINT' is reserved by Function Compute
```

So the variable added in #626 made the Alibaba FC target — the **belayo live** environment — impossible to deploy at all. The self-host target accepted it happily, which is exactly how a breakage that only affects one of two deploy targets stays invisible.

Renamed to `APPS_FC_ENDPOINT` across both targets, the code, `.env.example` and the README, with the reason recorded next to the resolver. Nothing had the old name set anywhere — it was introduced days ago and has always been blank — so there is no value to migrate.

Found while deploying belayo live by hand, and verified there: the deploy now succeeds, the function carries `APPS_FC_ENDPOINT` with no `FC_ENDPOINT`, and `/v1/config/public`, `/v1/apps`, `/v1/teams` all answer as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)