### PR TITLE
ui(desktop): Soft Comfort sidebars and C2 session more-actions

### DIFF
--- a/docs/design-mock/ios-redesign.html
+++ b/docs/design-mock/ios-redesign.html
@@ -1,0 +1,1127 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>TeamClaw · Soft Comfort UI</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;560;600;650&family=JetBrains+Mono:wght@400;500&display=swap');
+
+  :root {
+    --font: "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", "PingFang SC", "Noto Sans SC", sans-serif;
+    --mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, monospace;
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  /* —— Light: warm paper, soft depth —— */
+  .t-light {
+    --bg: #F3F1EC;
+    --shell: #F8F7F4;
+    --side: #EFEEE9;
+    --list: #F8F7F4;
+    --main: #FBFBFA;
+    --elev: #FFFFFF;
+    --elev-2: #FFFFFF;
+    --ink: #1C1B19;
+    --ink-soft: #5C5A54;
+    --ink-mute: #8E8B83;
+    --ink-faint: #B0ADA4;
+    --line: rgba(28, 27, 25, 0.06);
+    --line-soft: rgba(28, 27, 25, 0.04);
+    --hover: rgba(28, 27, 25, 0.04);
+    --press: rgba(28, 27, 25, 0.07);
+    --accent: #D94A3A;
+    --accent-soft: rgba(217, 74, 58, 0.1);
+    --accent-glow: rgba(217, 74, 58, 0.18);
+    --ok: #3D9B6E;
+    --ok-soft: rgba(61, 155, 110, 0.12);
+    --amber: #A67C52;
+    --amber-soft: rgba(166, 124, 82, 0.12);
+    --user-bg: #2A2926;
+    --user-ink: #FAF9F6;
+    --agent-av: #5A6B7A;
+    --shadow-xs: 0 1px 2px rgba(28, 27, 25, 0.03);
+    --shadow-sm: 0 2px 8px rgba(28, 27, 25, 0.04), 0 1px 2px rgba(28, 27, 25, 0.03);
+    --shadow-md: 0 8px 30px rgba(28, 27, 25, 0.07), 0 2px 8px rgba(28, 27, 25, 0.04);
+    --shadow-lg: 0 16px 48px rgba(28, 27, 25, 0.1), 0 4px 12px rgba(28, 27, 25, 0.05);
+    --ring: 0 0 0 1px rgba(28, 27, 25, 0.05);
+    --win-shadow: 0 24px 64px rgba(28, 27, 25, 0.12), 0 0 0 1px rgba(28, 27, 25, 0.06);
+  }
+
+  /* —— Dark: deep charcoal, soft lamps —— */
+  .t-dark {
+    --bg: #0E0E0D;
+    --shell: #161615;
+    --side: #141413;
+    --list: #181817;
+    --main: #161615;
+    --elev: #1E1E1C;
+    --elev-2: #232321;
+    --ink: #F2F0EA;
+    --ink-soft: #A8A59C;
+    --ink-mute: #7A776E;
+    --ink-faint: #56544D;
+    --line: rgba(242, 240, 234, 0.07);
+    --line-soft: rgba(242, 240, 234, 0.04);
+    --hover: rgba(242, 240, 234, 0.045);
+    --press: rgba(242, 240, 234, 0.08);
+    --accent: #FF7A6B;
+    --accent-soft: rgba(255, 122, 107, 0.14);
+    --accent-glow: rgba(255, 122, 107, 0.22);
+    --ok: #5BBF88;
+    --ok-soft: rgba(91, 191, 136, 0.14);
+    --amber: #D4A574;
+    --amber-soft: rgba(212, 165, 116, 0.14);
+    --user-bg: #2C2B28;
+    --user-ink: #F5F3EE;
+    --agent-av: #6B7C8C;
+    --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.2);
+    --shadow-sm: 0 2px 10px rgba(0, 0, 0, 0.25);
+    --shadow-md: 0 10px 36px rgba(0, 0, 0, 0.35), 0 2px 8px rgba(0, 0, 0, 0.2);
+    --shadow-lg: 0 20px 56px rgba(0, 0, 0, 0.45);
+    --ring: 0 0 0 1px rgba(242, 240, 234, 0.06);
+    --win-shadow: 0 28px 72px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(242, 240, 234, 0.06);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; }
+  body {
+    font-family: var(--font);
+    background: #D8D5CE;
+    color: #1C1B19;
+    -webkit-font-smoothing: antialiased;
+    padding: 14px 16px 16px;
+    overflow: auto;
+  }
+  body.dark-page { background: #080808; color: #F2F0EA; }
+
+  .top {
+    max-width: 1480px;
+    margin: 0 auto 14px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+  .top h1 {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .top p {
+    font-size: 12px;
+    opacity: 0.45;
+  }
+  .top .sp { flex: 1; }
+  .seg {
+    display: inline-flex;
+    padding: 3px;
+    border-radius: 10px;
+    background: rgba(0,0,0,0.06);
+    gap: 2px;
+  }
+  body.dark-page .seg { background: rgba(255,255,255,0.06); }
+  .seg button {
+    border: none;
+    background: transparent;
+    padding: 6px 12px;
+    border-radius: 8px;
+    font: 500 12px/1 var(--font);
+    color: inherit;
+    opacity: 0.5;
+    cursor: pointer;
+    transition: all 0.2s var(--ease);
+  }
+  .seg button.on {
+    background: #fff;
+    opacity: 1;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  }
+  body.dark-page .seg button.on {
+    background: #222;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+  }
+
+  .stage {
+    max-width: 1480px;
+    margin: 0 auto;
+    display: grid;
+    gap: 18px;
+  }
+  .stage.dual { grid-template-columns: 1fr 1fr; }
+  @media (max-width: 1180px) {
+    .stage.dual { grid-template-columns: 1fr; }
+  }
+
+  .cap {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    opacity: 0.4;
+    margin-bottom: 8px;
+    padding-left: 4px;
+  }
+
+  /* —— Window —— */
+  .app {
+    height: min(720px, calc(100vh - 72px));
+    min-height: 560px;
+    border-radius: 16px;
+    background: var(--shell);
+    box-shadow: var(--win-shadow);
+    display: grid;
+    grid-template-columns: 216px 268px 1fr;
+    overflow: hidden;
+    color: var(--ink);
+  }
+  .stage.dual .app {
+    height: min(680px, calc(100vh - 72px));
+  }
+
+  /* SIDE */
+  .side {
+    background: var(--side);
+    border-right: 1px solid var(--line);
+    padding: 14px 10px 10px;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
+  .side .nav,
+  .side .lab,
+  .side .person {
+    flex-shrink: 0;
+  }
+  .side .agent,
+  .side .foot {
+    flex-shrink: 0;
+  }
+  .ws {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 7px 8px;
+    border-radius: 10px;
+    margin-bottom: 8px;
+    transition: background 0.2s var(--ease);
+  }
+  .ws:hover { background: var(--hover); }
+  .mark {
+    width: 22px; height: 22px;
+    border-radius: 7px;
+    background: linear-gradient(145deg, #E85A4A, #C43A2C);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    display: grid; place-items: center;
+    box-shadow: 0 2px 6px var(--accent-glow);
+  }
+  .ws-name {
+    flex: 1;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .chev { color: var(--ink-faint); }
+
+  .new {
+    width: 100%;
+    height: 36px;
+    border: none;
+    border-radius: 10px;
+    background: var(--accent);
+    color: #fff;
+    font: 560 13px/1 var(--font);
+    letter-spacing: -0.01em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+    cursor: pointer;
+    margin-bottom: 12px;
+    box-shadow: 0 4px 14px var(--accent-glow);
+    transition: transform 0.18s var(--ease), filter 0.18s, box-shadow 0.18s;
+  }
+  .new:hover { filter: brightness(1.04); box-shadow: 0 6px 18px var(--accent-glow); }
+  .new:active { transform: scale(0.98); }
+  .new .k {
+    margin-left: 2px;
+    font-size: 10.5px;
+    font-weight: 500;
+    opacity: 0.72;
+    font-family: var(--mono);
+  }
+
+  .nav { display: flex; flex-direction: column; gap: 1px; }
+  .nav a {
+    height: 32px;
+    padding: 0 9px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    font-size: 13px;
+    font-weight: 450;
+    color: var(--ink-soft);
+    text-decoration: none;
+    cursor: pointer;
+    transition: background 0.18s var(--ease), color 0.18s;
+  }
+  .nav a:hover { background: var(--hover); color: var(--ink); }
+  .nav a.on {
+    background: var(--elev);
+    color: var(--ink);
+    font-weight: 560;
+    box-shadow: var(--shadow-xs), var(--ring);
+  }
+  .nav a .n {
+    margin-left: auto;
+    font-size: 11.5px;
+    color: var(--ink-mute);
+    font-variant-numeric: tabular-nums;
+  }
+  .nav a.on .n {
+    background: var(--accent);
+    color: #fff;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 9px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10.5px;
+    font-weight: 600;
+    box-shadow: 0 2px 6px var(--accent-glow);
+  }
+
+  .lab {
+    margin: 16px 9px 5px;
+    font-size: 10.5px;
+    font-weight: 560;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    display: flex;
+    align-items: center;
+  }
+  .lab button {
+    margin-left: auto;
+    width: 20px; height: 20px;
+    border: none;
+    background: transparent;
+    color: var(--ink-faint);
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: all 0.15s;
+  }
+  .lab button:hover { background: var(--hover); color: var(--ink-soft); }
+
+  .person {
+    height: 32px;
+    padding: 0 9px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    font-size: 13px;
+    font-weight: 450;
+    color: var(--ink-soft);
+    cursor: pointer;
+    transition: background 0.18s;
+  }
+  .person:hover { background: var(--hover); color: var(--ink); }
+
+  .av {
+    width: 20px; height: 20px;
+    border-radius: 50%;
+    background: linear-gradient(145deg, #E85A4A, #B83A2E);
+    color: #fff;
+    font-size: 9.5px;
+    font-weight: 650;
+    display: grid; place-items: center;
+    flex-shrink: 0;
+  }
+  .av.sq {
+    border-radius: 6px;
+    background: linear-gradient(145deg, #6A7B8A, #4A5A68);
+    font-family: var(--mono);
+    font-size: 8px;
+  }
+
+  .grow { flex: 1; }
+
+  .agent {
+    margin: 2px 2px 8px;
+    padding: 9px 10px;
+    border-radius: 12px;
+    background: var(--elev);
+    box-shadow: var(--shadow-sm), var(--ring);
+    display: flex;
+    align-items: center;
+    gap: 9px;
+  }
+  .agent .nm {
+    font-size: 12.5px;
+    font-weight: 560;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .agent .sub { font-size: 11px; color: var(--ink-mute); margin-top: 1px; }
+  .dot {
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: var(--ok);
+    box-shadow: 0 0 0 3px var(--ok-soft);
+    animation: pulse 2.4s ease-in-out infinite;
+  }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.55; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dot { animation: none; }
+  }
+
+  .foot {
+    display: flex;
+    align-items: center;
+    padding: 2px;
+    gap: 2px;
+  }
+  .foot button {
+    height: 30px;
+    border: none;
+    background: transparent;
+    border-radius: 8px;
+    padding: 0 8px;
+    font: 450 12px var(--font);
+    color: var(--ink-soft);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: all 0.18s;
+  }
+  .foot button:hover { background: var(--hover); color: var(--ink); }
+  .foot .u { margin-left: auto; }
+
+  /* LIST */
+  .list {
+    background: var(--list);
+    border-right: 1px solid var(--line);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
+  .list-h {
+    height: 48px;
+    padding: 0 14px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .list-h h2 {
+    font-size: 14px;
+    font-weight: 650;
+    letter-spacing: -0.025em;
+  }
+  .list-h .c {
+    font-size: 12px;
+    color: var(--ink-mute);
+    background: var(--hover);
+    padding: 2px 7px;
+    border-radius: 20px;
+  }
+  .list-h .tools { margin-left: auto; display: flex; gap: 2px; }
+  .ib {
+    width: 30px; height: 30px;
+    border: none;
+    background: transparent;
+    border-radius: 8px;
+    color: var(--ink-mute);
+    cursor: pointer;
+    display: grid; place-items: center;
+    transition: all 0.18s var(--ease);
+  }
+  .ib:hover { background: var(--hover); color: var(--ink); }
+
+  .rows {
+    flex: 1;
+    overflow: auto;
+    padding: 4px 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .row {
+    padding: 11px 12px;
+    border-radius: 12px;
+    cursor: pointer;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 3px 8px;
+    transition: background 0.18s var(--ease), box-shadow 0.18s;
+  }
+  .row:hover { background: var(--hover); }
+  .row.on {
+    background: var(--elev);
+    box-shadow: var(--shadow-sm), var(--ring);
+  }
+  .row .t {
+    font-size: 13px;
+    font-weight: 560;
+    letter-spacing: -0.015em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .row .tm {
+    font-size: 11px;
+    color: var(--ink-faint);
+    padding-top: 1px;
+    font-variant-numeric: tabular-nums;
+  }
+  .row .p {
+    grid-column: 1 / -1;
+    font-size: 12px;
+    color: var(--ink-mute);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.4;
+  }
+  .row .p em {
+    font-style: normal;
+    color: var(--accent);
+    font-weight: 500;
+  }
+
+  /* CHAT */
+  .chat {
+    background: var(--main);
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+    position: relative;
+  }
+  .chat::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+      radial-gradient(ellipse 80% 50% at 70% -10%, var(--accent-soft), transparent 55%),
+      radial-gradient(ellipse 60% 40% at 10% 100%, var(--ok-soft), transparent 50%);
+    pointer-events: none;
+    opacity: 0.55;
+  }
+  .chat > * { position: relative; z-index: 1; }
+
+  .chat-h {
+    flex: 0 0 auto;
+    height: 48px;
+    padding: 0 18px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    border-bottom: 1px solid var(--line-soft);
+    background: color-mix(in srgb, var(--main) 82%, transparent);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+  .chat-h h2 {
+    font-size: 14px;
+    font-weight: 650;
+    letter-spacing: -0.025em;
+  }
+  .chat-h .m {
+    font-size: 12px;
+    color: var(--ink-mute);
+    margin-left: 4px;
+  }
+  .chat-h .tools { margin-left: auto; display: flex; gap: 2px; }
+
+  .thread {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+    padding: 20px 28px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .u-msg {
+    align-self: flex-end;
+    max-width: 58%;
+  }
+  .u-msg .who {
+    text-align: right;
+    font-size: 11.5px;
+    font-weight: 500;
+    color: var(--ink-mute);
+    margin-bottom: 6px;
+  }
+  .u-msg .b {
+    background: var(--user-bg);
+    color: var(--user-ink);
+    padding: 11px 15px;
+    border-radius: 18px 18px 6px 18px;
+    font-size: 14px;
+    line-height: 1.55;
+    letter-spacing: -0.01em;
+    box-shadow: var(--shadow-sm);
+  }
+  .u-msg .tag {
+    display: inline-block;
+    font-size: 10.5px;
+    font-weight: 500;
+    opacity: 0.65;
+    margin-bottom: 5px;
+    letter-spacing: 0.02em;
+  }
+
+  .a-msg {
+    display: grid;
+    grid-template-columns: 28px 1fr;
+    gap: 11px;
+    max-width: 620px;
+  }
+  .a-msg .hd {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 7px;
+  }
+  .a-msg .nm { font-size: 13px; font-weight: 600; letter-spacing: -0.01em; }
+  .a-msg .ai {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    color: var(--accent);
+    background: var(--accent-soft);
+    padding: 2px 6px;
+    border-radius: 5px;
+  }
+  .a-msg .tm {
+    margin-left: auto;
+    font-size: 11px;
+    color: var(--ink-faint);
+  }
+  .quote {
+    font-size: 12.5px;
+    color: var(--ink-mute);
+    border-left: 2px solid color-mix(in srgb, var(--ink-faint) 50%, transparent);
+    padding: 2px 0 2px 10px;
+    margin-bottom: 10px;
+  }
+  .quote strong { color: var(--ink-soft); font-weight: 500; }
+  .a-msg .txt {
+    font-size: 14.5px;
+    line-height: 1.7;
+    color: var(--ink);
+    letter-spacing: -0.012em;
+    max-width: 46ch;
+  }
+  .proc {
+    margin-top: 12px;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 12px;
+    color: var(--ink-mute);
+    background: var(--elev);
+    padding: 5px 10px;
+    border-radius: 8px;
+    box-shadow: var(--shadow-xs), var(--ring);
+  }
+  .proc i {
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: var(--ok);
+    box-shadow: 0 0 0 3px var(--ok-soft);
+  }
+
+  /* —— Composer stack: live + approval + input = ONE card —— */
+  .stack-wrap {
+    flex: 0 0 auto;
+    padding: 4px 16px 14px;
+  }
+  .stack {
+    background: var(--elev);
+    border-radius: 14px;
+    box-shadow: var(--shadow-md), var(--ring);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    transition: box-shadow 0.25s var(--ease);
+  }
+  .stack:focus-within {
+    box-shadow: var(--shadow-lg), 0 0 0 1px color-mix(in srgb, var(--accent) 28%, transparent);
+  }
+  .stack-row {
+    flex: 0 0 auto;
+  }
+  .stack-row + .stack-row {
+    border-top: 1px solid var(--line);
+  }
+
+  /* Live / tool strip (above approval when streaming) */
+  .live-row {
+    padding: 10px 14px;
+    background: color-mix(in srgb, var(--elev) 70%, var(--hover));
+  }
+  .live-row .tool {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    background: var(--hover);
+    border-radius: 10px;
+    font-size: 12.5px;
+    color: var(--ink-soft);
+  }
+  .live-row .tool .box {
+    width: 26px; height: 26px;
+    border-radius: 7px;
+    background: var(--elev);
+    box-shadow: var(--ring);
+    display: grid; place-items: center;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--ink);
+  }
+  .live-row .tool code {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    color: var(--ink-mute);
+    margin-left: 4px;
+  }
+  .live-row .tool .ok {
+    margin-left: auto;
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: var(--ok);
+    box-shadow: 0 0 0 3px var(--ok-soft);
+  }
+
+  /* Approval row */
+  .perm-top {
+    display: flex;
+    align-items: stretch;
+  }
+  .perm-info {
+    flex: 1;
+    padding: 12px 14px 10px;
+    min-width: 0;
+  }
+  .perm-info .ey {
+    font-size: 11.5px;
+    font-weight: 500;
+    color: var(--ink-mute);
+    margin-bottom: 6px;
+  }
+  .perm-info .cmd {
+    font-family: var(--mono);
+    font-size: 17px;
+    font-weight: 500;
+    letter-spacing: -0.03em;
+    display: inline-block;
+    background: var(--hover);
+    padding: 3px 8px;
+    border-radius: 7px;
+  }
+  .perm-info .from {
+    margin-top: 5px;
+    font-size: 11.5px;
+    color: var(--ink-faint);
+  }
+  .perm-acts {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+    padding: 10px 12px;
+    min-width: 118px;
+  }
+  .btn {
+    height: 32px;
+    border-radius: 9px;
+    border: none;
+    font: 560 12.5px var(--font);
+    cursor: pointer;
+    padding: 0 12px;
+    transition: transform 0.15s var(--ease), filter 0.15s, background 0.15s;
+  }
+  .btn:active { transform: scale(0.97); }
+  .btn-pri {
+    background: var(--ink);
+    color: var(--main);
+    box-shadow: var(--shadow-sm);
+  }
+  .t-dark .btn-pri {
+    background: #F2F0EA;
+    color: #161615;
+  }
+  .btn-pri:hover { filter: brightness(1.06); }
+  .btn-sec {
+    background: var(--hover);
+    color: var(--ink);
+  }
+  .btn-sec:hover { background: var(--press); }
+  .btn-ghost {
+    background: transparent;
+    color: var(--ink-mute);
+    font-weight: 500;
+  }
+  .btn-ghost:hover { color: var(--accent); background: var(--accent-soft); }
+
+  .perm-meta {
+    padding: 10px 14px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    border-top: 1px solid var(--line-soft);
+  }
+  .wait {
+    font-size: 13px;
+    color: var(--ink-soft);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .wait strong { color: var(--ink); font-weight: 600; }
+  .skill {
+    align-self: flex-start;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--amber);
+    background: var(--amber-soft);
+    padding: 4px 9px;
+    border-radius: 7px;
+  }
+  .skill span {
+    margin-left: 4px;
+    opacity: 0.6;
+    font-size: 11px;
+  }
+  .desc { font-size: 13px; color: var(--ink-soft); line-height: 1.45; }
+
+  /* Input row (same stack) */
+  .comp {
+    background: transparent;
+  }
+  .comp textarea {
+    width: 100%;
+    border: none;
+    outline: none;
+    resize: none;
+    padding: 12px 14px 6px;
+    font: 400 14px/1.5 var(--font);
+    background: transparent;
+    color: var(--ink);
+    min-height: 40px;
+  }
+  .comp textarea::placeholder { color: var(--ink-faint); }
+  .bar {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 10px 10px;
+  }
+  .chip {
+    height: 28px;
+    padding: 0 10px;
+    border: none;
+    background: var(--hover);
+    border-radius: 8px;
+    font: 450 12px var(--font);
+    color: var(--ink-soft);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    transition: all 0.18s;
+  }
+  .chip:hover { background: var(--press); color: var(--ink); }
+  .send {
+    margin-left: auto;
+    height: 32px;
+    padding: 0 14px;
+    border: none;
+    border-radius: 10px;
+    background: var(--accent);
+    color: #fff;
+    font: 560 12.5px var(--font);
+    cursor: pointer;
+    box-shadow: 0 4px 12px var(--accent-glow);
+    transition: transform 0.15s var(--ease), filter 0.15s;
+  }
+  .send:hover { filter: brightness(1.05); }
+  .send:active { transform: scale(0.97); }
+
+  svg.i {
+    width: 15px; height: 15px;
+    stroke: currentColor; fill: none;
+    stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+</style>
+</head>
+<body>
+
+  <div class="top">
+    <div>
+      <h1>TeamClaw · Soft Comfort</h1>
+      <p>丝滑层次 · 柔光阴影 · 双主题</p>
+    </div>
+    <div class="sp"></div>
+    <div class="seg" role="group">
+      <button type="button" class="on" id="b0" onclick="mode('both')">对照</button>
+      <button type="button" id="b1" onclick="mode('light')">白天</button>
+      <button type="button" id="b2" onclick="mode('dark')">黑夜</button>
+    </div>
+  </div>
+
+  <div class="stage dual" id="stage"></div>
+
+  <template id="tpl">
+    <div class="app">
+      <aside class="side">
+        <div class="ws">
+          <div class="mark">T</div>
+          <div class="ws-name">TeamClaw Dev</div>
+          <svg class="i chev" viewBox="0 0 24 24"><path d="M6 9l6 6 6-6"/></svg>
+        </div>
+
+        <button class="new" type="button">
+          <svg class="i" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>
+          New Chat
+          <span class="k">⌘N</span>
+        </button>
+
+        <nav class="nav">
+          <a class="on">
+            <svg class="i" viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+            Sessions <span class="n">6</span>
+          </a>
+          <a>
+            <svg class="i" viewBox="0 0 24 24"><path d="M12 3l2.2 6.8H21l-5.4 4 2.1 6.7L12 16.8 6.3 20.5l2.1-6.7L3 9.8h6.8z"/></svg>
+            Pinned <span class="n">0</span>
+          </a>
+          <a>
+            <svg class="i" viewBox="0 0 24 24"><path d="M9 18h6M10 22h4M12 2a7 7 0 0 1 4 12.5V17H8v-2.5A7 7 0 0 1 12 2z"/></svg>
+            Ideas
+          </a>
+          <a>
+            <svg class="i" viewBox="0 0 24 24"><path d="M15 5l-8 8M14.5 3.5a2 2 0 0 1 3 3L8 16l-4 1 1-4z"/></svg>
+            Shortcuts
+          </a>
+        </nav>
+
+        <div class="lab">Recents <button type="button">+</button></div>
+        <div class="person"><span class="av">H</span> Haigang Ye</div>
+
+        <div class="grow"></div>
+
+        <div class="agent">
+          <span class="av sq">MB</span>
+          <div>
+            <div class="nm">MYBOT <span class="dot"></span></div>
+            <div class="sub">TeamClaw Dev</div>
+          </div>
+        </div>
+
+        <div class="foot">
+          <button type="button">
+            <svg class="i" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+            Settings
+          </button>
+          <button class="u" type="button">
+            <span class="av" style="width:16px;height:16px;font-size:8px">H</span>
+            Haig…
+          </button>
+        </div>
+      </aside>
+
+      <section class="list">
+        <div class="list-h">
+          <h2>Sessions</h2>
+          <span class="c">6</span>
+          <div class="tools">
+            <button class="ib" type="button" aria-label="Search"><svg class="i" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3-3"/></svg></button>
+            <button class="ib" type="button" aria-label="History"><svg class="i" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg></button>
+            <button class="ib" type="button" aria-label="Filter"><svg class="i" viewBox="0 0 24 24"><path d="M4 6h16M7 12h10M10 18h4"/></svg></button>
+          </div>
+        </div>
+        <div class="rows">
+          <div class="row on">
+            <div class="t">执行PS</div>
+            <div class="tm">Just now</div>
+            <div class="p"><em>@MYBOT</em> · bash的ps</div>
+          </div>
+          <div class="row">
+            <div class="t">执行sleep20</div>
+            <div class="tm">23h ago</div>
+            <div class="p">TeamClaw Dev · sleep 20 done</div>
+          </div>
+          <div class="row">
+            <div class="t">执行sleep10</div>
+            <div class="tm">Yesterday</div>
+            <div class="p">TeamClaw Dev · waiting</div>
+          </div>
+          <div class="row">
+            <div class="t">输出500字的散文，随便写</div>
+            <div class="tm">Yesterday</div>
+            <div class="p">秋日的风穿过旧巷…</div>
+          </div>
+          <div class="row">
+            <div class="t">检查本地 daemon 状态</div>
+            <div class="tm">2d ago</div>
+            <div class="p">amuxd · healthy</div>
+          </div>
+          <div class="row">
+            <div class="t">整理本周 standup 纪要</div>
+            <div class="tm">3d ago</div>
+            <div class="p">Markdown draft ready</div>
+          </div>
+        </div>
+      </section>
+
+      <main class="chat">
+        <div class="chat-h">
+          <h2>执行PS</h2>
+          <button class="ib" type="button"><svg class="i" viewBox="0 0 24 24"><path d="M21 12a9 9 0 1 1-2.6-6.3"/><path d="M21 3v6h-6"/></svg></button>
+          <span class="m">2 · just now</span>
+          <div class="tools">
+            <button class="ib" type="button"><svg class="i" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg></button>
+            <button class="ib" type="button"><svg class="i" viewBox="0 0 24 24"><circle cx="9" cy="8" r="3"/><path d="M3 20v-1a5 5 0 0 1 5-5h2a5 5 0 0 1 5 5v1"/><path d="M16 11a3 3 0 1 0 0-6M21 20v-1a4 4 0 0 0-3-3.9"/></svg></button>
+            <button class="ib" type="button"><svg class="i" viewBox="0 0 24 24"><path d="M5 4h11l3 3v13H5z"/><path d="M16 4v3h3"/></svg></button>
+            <button class="ib" type="button"><svg class="i" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M15 4v16"/></svg></button>
+          </div>
+        </div>
+
+        <div class="thread">
+          <div class="u-msg">
+            <div class="who">Haigang Ye</div>
+            <div class="b">
+              <div class="tag">Agent @MYBOT</div>
+              执行PS
+            </div>
+          </div>
+
+          <div class="a-msg">
+            <span class="av sq" style="margin-top:2px;width:24px;height:24px">MB</span>
+            <div>
+              <div class="hd">
+                <span class="nm">MYBOT</span>
+                <span class="ai">AI</span>
+                <span class="tm">刚刚</span>
+              </div>
+              <div class="quote">回复你 · <strong>执行PS</strong></div>
+              <div class="txt">请确认一下：「执行 PS」里的 PS 具体指什么？例如 Photoshop、PowerShell，还是某个页面上的按钮/脚本？</div>
+              <div class="proc"><i></i> Process · 2 tools</div>
+            </div>
+          </div>
+
+          <div class="u-msg">
+            <div class="who">Haigang Ye</div>
+            <div class="b">bash的ps</div>
+          </div>
+        </div>
+
+        <div class="stack-wrap">
+          <!-- ONE shell: approval → live → input (matches ComposerStack) -->
+          <div class="stack" data-testid="composer-stack">
+            <!-- 1. Approval chrome -->
+            <div class="stack-row">
+              <div class="perm-top">
+                <div class="perm-info">
+                  <div class="ey">Bash requests to execute a command</div>
+                  <div class="cmd">ps</div>
+                  <div class="from">From Bash tool call</div>
+                </div>
+                <div class="perm-acts">
+                  <button class="btn btn-pri" type="button">Allow</button>
+                  <button class="btn btn-sec" type="button">Always Allow</button>
+                  <button class="btn btn-ghost" type="button">Deny</button>
+                </div>
+              </div>
+              <div class="perm-meta">
+                <div class="wait">
+                  <span class="av sq" style="width:18px;height:18px;font-size:7px">MB</span>
+                  <span><strong>MYBOT</strong> Waiting for your approval…</span>
+                </div>
+                <div class="skill">using-superpowers <span>Skill</span></div>
+                <div class="desc">执行 ps 查看当前进程。</div>
+              </div>
+            </div>
+
+            <!-- 2. Live / tool strip (agent dock) -->
+            <div class="stack-row live-row">
+              <div class="tool">
+                <div class="box">$</div>
+                <div>Shows current shell processes <code>ps</code></div>
+                <span class="ok"></span>
+              </div>
+            </div>
+
+            <!-- 3. Input zone (same shell, not a second card) -->
+            <div class="stack-row comp" data-testid="composer-input-zone">
+              <textarea rows="1" placeholder="Continue typing…"></textarea>
+              <div class="bar">
+                <button class="chip" type="button"><svg class="i" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg></button>
+                <button class="chip" type="button">Default Permission ▾</button>
+                <button class="chip" type="button">GPT-4.5 ▾</button>
+                <button class="send" type="button">Send →</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </template>
+
+<script>
+  const stage = document.getElementById('stage');
+  const tpl = document.getElementById('tpl');
+
+  function make(theme) {
+    const el = tpl.content.firstElementChild.cloneNode(true);
+    el.classList.add(theme === 'dark' ? 't-dark' : 't-light');
+    return el;
+  }
+
+  function mode(m) {
+    document.getElementById('b0').classList.toggle('on', m === 'both');
+    document.getElementById('b1').classList.toggle('on', m === 'light');
+    document.getElementById('b2').classList.toggle('on', m === 'dark');
+    document.body.classList.toggle('dark-page', m === 'dark');
+
+    stage.innerHTML = '';
+    stage.classList.toggle('dual', m === 'both');
+
+    const themes = m === 'both' ? ['light', 'dark'] : [m];
+    for (const t of themes) {
+      const wrap = document.createElement('div');
+      if (m === 'both') {
+        const cap = document.createElement('div');
+        cap.className = 'cap';
+        cap.textContent = t === 'light' ? 'Light' : 'Dark';
+        wrap.appendChild(cap);
+      }
+      wrap.appendChild(make(t));
+      stage.appendChild(wrap);
+    }
+  }
+
+  mode('both');
+</script>
+</body>
+</html>

--- a/docs/design-mock/session-more-actions-c.html
+++ b/docs/design-mock/session-more-actions-c.html
@@ -1,0 +1,429 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Session More · C2 · 右上角挤时间</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;560;600;650&display=swap');
+
+  :root {
+    --bg: #E8E5DF;
+    --list: #F8F7F4;
+    --paper: #FFFFFF;
+    --ink: #1C1B19;
+    --ink-2: #5C5A54;
+    --mute: #8E8B83;
+    --faint: #B0ADA4;
+    --line: rgba(28,27,25,0.07);
+    --hover: rgba(28,27,25,0.045);
+    --press: rgba(28,27,25,0.08);
+    --coral: #E85A4A;
+    --coral-soft: rgba(232,90,74,0.12);
+    --shadow: 0 2px 8px rgba(28,27,25,0.05), 0 1px 2px rgba(28,27,25,0.03);
+    --ring: 0 0 0 1px rgba(28,27,25,0.05);
+    --font: Inter, -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif;
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+    --col: 268px;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--font);
+    background: var(--bg);
+    color: var(--ink);
+    -webkit-font-smoothing: antialiased;
+    padding: 28px 24px 48px;
+  }
+
+  .page-h { max-width: 760px; margin: 0 auto 16px; }
+  .page-h h1 { font-size: 16px; font-weight: 650; letter-spacing: -0.02em; }
+  .page-h p { margin-top: 6px; font-size: 13px; color: var(--ink-2); line-height: 1.5; }
+
+  .wrap {
+    max-width: 760px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: var(--col) 1fr;
+    gap: 16px;
+    align-items: start;
+  }
+  @media (max-width: 680px) { .wrap { grid-template-columns: 1fr; } }
+
+  .frame {
+    width: var(--col);
+    background: var(--list);
+    border-radius: 14px;
+    box-shadow: var(--shadow), var(--ring);
+    overflow: hidden;
+  }
+  .frame-h {
+    padding: 12px;
+    font-size: 13px; font-weight: 650;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .frame-h .n {
+    font-size: 11px; color: var(--mute);
+    background: var(--hover); padding: 2px 7px; border-radius: 999px;
+  }
+  .list { padding: 4px 8px 12px; display: flex; flex-direction: column; gap: 3px; }
+
+  .note {
+    background: #fff;
+    border-radius: 14px;
+    box-shadow: var(--shadow), var(--ring);
+    padding: 16px 18px;
+    font-size: 12.5px;
+    color: var(--ink-2);
+    line-height: 1.6;
+  }
+  .note h2 { font-size: 13px; font-weight: 650; color: var(--ink); margin-bottom: 8px; }
+  .note ol { padding-left: 1.2em; margin-top: 6px; }
+  .note li { margin-bottom: 6px; }
+  .diagram {
+    margin-top: 12px;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    line-height: 1.7;
+    background: var(--list);
+    border-radius: 8px;
+    padding: 10px 12px;
+    color: var(--ink-2);
+  }
+  .diagram .hi { color: var(--coral); font-weight: 600; }
+
+  .ic {
+    width: 14px; height: 14px;
+    stroke: currentColor; fill: none;
+    stroke-width: 1.65; stroke-linecap: round; stroke-linejoin: round;
+  }
+  button { font-family: inherit; border: none; background: transparent; cursor: pointer; color: inherit; }
+
+  .row {
+    border-radius: 11px;
+    padding: 10px;
+    transition: background 0.15s var(--ease), box-shadow 0.15s;
+  }
+  .row.on {
+    background: var(--paper);
+    box-shadow: var(--shadow), var(--ring);
+  }
+  .row:not(.on):hover { background: var(--hover); }
+
+  /*
+   * Top row layout (RTL-ish trailing cluster):
+   *   [ title .............. ] [ time ][ more ]
+   * Default: more collapsed (width 0) → time sits at far right
+   * Hover:  more expands at FAR RIGHT → time is pushed left
+   */
+  .top {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+  .title {
+    flex: 1;
+    min-width: 0;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.015em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .trailing {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    gap: 0;
+  }
+
+  .time {
+    font-size: 10.5px;
+    color: var(--faint);
+    font-variant-numeric: tabular-nums;
+    line-height: 22px;
+    padding: 0 2px;
+    transition: margin 0.18s var(--ease), transform 0.18s var(--ease);
+  }
+
+  /* More sits AFTER time in DOM = visual far-right corner */
+  .more {
+    width: 0;
+    height: 22px;
+    opacity: 0;
+    overflow: hidden;
+    border-radius: 6px;
+    display: grid;
+    place-items: center;
+    color: var(--mute);
+    pointer-events: none;
+    margin-left: 0;
+    transition:
+      width 0.18s var(--ease),
+      opacity 0.15s var(--ease),
+      margin-left 0.18s var(--ease),
+      background 0.15s,
+      color 0.15s;
+  }
+
+  .row:hover .more,
+  .row:focus-within .more,
+  .row.open .more {
+    width: 22px;
+    opacity: 1;
+    margin-left: 2px;
+    pointer-events: auto;
+  }
+
+  .more:hover { background: var(--press); color: var(--ink); }
+  .row.open .more {
+    background: var(--press);
+    color: var(--ink);
+  }
+
+  .sub {
+    margin-top: 2px;
+    font-size: 11px;
+    color: var(--mute);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .prev {
+    margin-top: 3px;
+    font-size: 12px;
+    color: var(--ink-2);
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .row.open .prev { opacity: 0.5; }
+
+  .actions {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.26s var(--ease);
+  }
+  .row.open .actions { grid-template-rows: 1fr; }
+  .actions > div { overflow: hidden; min-height: 0; }
+  .actions-inner {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--line);
+  }
+  .grid4 {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 4px;
+  }
+  .act {
+    height: 34px;
+    border-radius: 8px;
+    background: var(--hover);
+    display: grid;
+    place-items: center;
+    color: var(--ink-2);
+    transition: background 0.15s, color 0.15s;
+  }
+  .act:hover { background: var(--press); color: var(--ink); }
+  .act.danger:hover { background: var(--coral-soft); color: var(--coral); }
+
+  .hint {
+    margin-top: 10px;
+    padding: 10px 12px;
+    border-top: 1px solid var(--line);
+    font-size: 11.5px;
+    color: var(--mute);
+    line-height: 1.45;
+  }
+
+  /* mini callout states */
+  .states {
+    margin-top: 14px;
+    display: grid;
+    gap: 8px;
+  }
+  .state {
+    border-radius: 10px;
+    background: var(--list);
+    padding: 10px 12px;
+  }
+  .state .lab {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--faint);
+    margin-bottom: 6px;
+  }
+  .state .line {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    color: var(--ink-2);
+  }
+</style>
+</head>
+<body>
+
+  <div class="page-h">
+    <h1>C2 · ⋯ 右上角挤开时间</h1>
+    <p>默认时间贴右；悬停时 ⋯ 从右上角展开，把时间往左挤。时间始终可见。</p>
+  </div>
+
+  <div class="wrap">
+    <div class="frame">
+      <div class="frame-h">Sessions <span class="n">4</span></div>
+      <div class="list">
+
+        <div class="row on" id="r1">
+          <div class="top">
+            <div class="title">执行PS</div>
+            <div class="trailing">
+              <span class="time">5h ago</span>
+              <button class="more" type="button" aria-label="更多操作" title="更多" onclick="toggle('r1')">
+                <svg class="ic" viewBox="0 0 24 24"><circle cx="5" cy="12" r="1.6" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/><circle cx="19" cy="12" r="1.6" fill="currentColor" stroke="none"/></svg>
+              </button>
+            </div>
+          </div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="prev">已执行 ps。当前新增/可见的相关进程包含 shell 与 daemon…</div>
+          <div class="actions"><div>
+            <div class="actions-inner">
+              <div class="grid4">
+                <button class="act" type="button" title="置顶"><svg class="ic" viewBox="0 0 24 24"><path d="M12 3l2.2 6.8H21l-5.4 4 2.1 6.7L12 16.8 6.3 20.5l2.1-6.7L3 9.8h6.8z"/></svg></button>
+                <button class="act" type="button" title="重命名"><svg class="ic" viewBox="0 0 24 24"><path d="M15 5l-8 8M14.5 3.5a2 2 0 0 1 3 3L8 16l-4 1 1-4z"/></svg></button>
+                <button class="act" type="button" title="详情"><svg class="ic" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 10v6M12 7h.01"/></svg></button>
+                <button class="act danger" type="button" title="归档"><svg class="ic" viewBox="0 0 24 24"><path d="M4 8h16M9 8V5h6v3M7 8v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8"/></svg></button>
+              </div>
+            </div>
+          </div></div>
+        </div>
+
+        <div class="row" id="r2">
+          <div class="top">
+            <div class="title">执行sleep20</div>
+            <div class="trailing">
+              <span class="time">23h ago</span>
+              <button class="more" type="button" aria-label="更多操作" title="更多" onclick="toggle('r2')">
+                <svg class="ic" viewBox="0 0 24 24"><circle cx="5" cy="12" r="1.6" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/><circle cx="19" cy="12" r="1.6" fill="currentColor" stroke="none"/></svg>
+              </button>
+            </div>
+          </div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="prev">sleep 20 done</div>
+          <div class="actions"><div>
+            <div class="actions-inner">
+              <div class="grid4">
+                <button class="act" type="button" title="置顶"><svg class="ic" viewBox="0 0 24 24"><path d="M12 3l2.2 6.8H21l-5.4 4 2.1 6.7L12 16.8 6.3 20.5l2.1-6.7L3 9.8h6.8z"/></svg></button>
+                <button class="act" type="button" title="重命名"><svg class="ic" viewBox="0 0 24 24"><path d="M15 5l-8 8M14.5 3.5a2 2 0 0 1 3 3L8 16l-4 1 1-4z"/></svg></button>
+                <button class="act" type="button" title="详情"><svg class="ic" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 10v6M12 7h.01"/></svg></button>
+                <button class="act danger" type="button" title="归档"><svg class="ic" viewBox="0 0 24 24"><path d="M4 8h16M9 8V5h6v3M7 8v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8"/></svg></button>
+              </div>
+            </div>
+          </div></div>
+        </div>
+
+        <div class="row" id="r3">
+          <div class="top">
+            <div class="title">输出500字的散文，随便写</div>
+            <div class="trailing">
+              <span class="time">yesterday</span>
+              <button class="more" type="button" aria-label="更多操作" title="更多" onclick="toggle('r3')">
+                <svg class="ic" viewBox="0 0 24 24"><circle cx="5" cy="12" r="1.6" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/><circle cx="19" cy="12" r="1.6" fill="currentColor" stroke="none"/></svg>
+              </button>
+            </div>
+          </div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="prev">秋日的风穿过旧巷…</div>
+          <div class="actions"><div>
+            <div class="actions-inner">
+              <div class="grid4">
+                <button class="act" type="button" title="置顶"><svg class="ic" viewBox="0 0 24 24"><path d="M12 3l2.2 6.8H21l-5.4 4 2.1 6.7L12 16.8 6.3 20.5l2.1-6.7L3 9.8h6.8z"/></svg></button>
+                <button class="act" type="button" title="重命名"><svg class="ic" viewBox="0 0 24 24"><path d="M15 5l-8 8M14.5 3.5a2 2 0 0 1 3 3L8 16l-4 1 1-4z"/></svg></button>
+                <button class="act" type="button" title="详情"><svg class="ic" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 10v6M12 7h.01"/></svg></button>
+                <button class="act danger" type="button" title="归档"><svg class="ic" viewBox="0 0 24 24"><path d="M4 8h16M9 8V5h6v3M7 8v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8"/></svg></button>
+              </div>
+            </div>
+          </div></div>
+        </div>
+
+        <div class="row">
+          <div class="top">
+            <div class="title">检查本地 daemon 状态</div>
+            <div class="trailing">
+              <span class="time">2d ago</span>
+              <button class="more" type="button" aria-label="更多操作" title="更多">
+                <svg class="ic" viewBox="0 0 24 24"><circle cx="5" cy="12" r="1.6" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/><circle cx="19" cy="12" r="1.6" fill="currentColor" stroke="none"/></svg>
+              </button>
+            </div>
+          </div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="prev">amuxd · healthy</div>
+        </div>
+      </div>
+      <div class="hint">悬停任一行：看右上角 ⋯ 顶出来，时间被往左挤；点开会展开 C2 四图标。</div>
+    </div>
+
+    <div class="note">
+      <h2>布局规则</h2>
+      <ol>
+        <li><strong>默认</strong>：右上角只有时间。</li>
+        <li><strong>悬停</strong>：⋯ 在<strong>最右侧</strong>展开（width 0→22），时间被挤到它左边。</li>
+        <li><strong>时间不消失</strong>，只让位。</li>
+        <li><strong>展开</strong>：⋯→✕，下方 C2 四图标下推，不挡下一卡。</li>
+      </ol>
+
+      <div class="diagram">
+        默认&nbsp;&nbsp;<span>[ 标题 ……………… ] [ 5h ago ]</span><br/>
+        悬停&nbsp;&nbsp;<span>[ 标题 …………… ] [ 5h ago ]<span class="hi">[ ⋯ ]</span></span><br/>
+        展开&nbsp;&nbsp;<span>[ 标题 …………… ] [ 5h ago ]<span class="hi">[ ✕ ]</span></span><br/>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span>+ 下方四图标坞</span>
+      </div>
+
+      <div class="states">
+        <div class="state">
+          <div class="lab">DOM 顺序</div>
+          <div class="line">title → time → more</div>
+        </div>
+        <div class="state">
+          <div class="lab">显隐</div>
+          <div class="line">more: hover | focus-within | open</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+<script>
+  const ICON_MORE = '<svg class="ic" viewBox="0 0 24 24"><circle cx="5" cy="12" r="1.6" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/><circle cx="19" cy="12" r="1.6" fill="currentColor" stroke="none"/></svg>';
+  const ICON_CLOSE = '<svg class="ic" viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18"/></svg>';
+
+  function toggle(id) {
+    document.querySelectorAll('.row.open').forEach((el) => {
+      if (el.id !== id) {
+        el.classList.remove('open');
+        const b = el.querySelector('.more');
+        if (b) {
+          b.innerHTML = ICON_MORE;
+          b.setAttribute('aria-label', '更多操作');
+          b.title = '更多';
+        }
+      }
+    });
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.classList.toggle('open');
+    const open = el.classList.contains('open');
+    const btn = el.querySelector('.more');
+    if (!btn) return;
+    btn.innerHTML = open ? ICON_CLOSE : ICON_MORE;
+    btn.setAttribute('aria-label', open ? '收起' : '更多操作');
+    btn.title = open ? '收起' : '更多';
+  }
+</script>
+</body>
+</html>

--- a/docs/design-mock/session-more-actions.html
+++ b/docs/design-mock/session-more-actions.html
@@ -1,0 +1,669 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Session More Actions — Creative Options</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;560;600;650&family=JetBrains+Mono:wght@450;500&display=swap');
+
+  :root {
+    --bg: #E8E5DF;
+    --list: #F8F7F4;
+    --paper: #FFFFFF;
+    --ink: #1C1B19;
+    --ink-2: #5C5A54;
+    --mute: #8E8B83;
+    --faint: #B0ADA4;
+    --line: rgba(28,27,25,0.07);
+    --hover: rgba(28,27,25,0.045);
+    --press: rgba(28,27,25,0.08);
+    --coral: #E85A4A;
+    --coral-soft: rgba(232,90,74,0.12);
+    --amber: #A67C52;
+    --amber-soft: rgba(166,124,82,0.14);
+    --ok: #3D9B6E;
+    --shadow: 0 2px 8px rgba(28,27,25,0.05), 0 1px 2px rgba(28,27,25,0.03);
+    --ring: 0 0 0 1px rgba(28,27,25,0.05);
+    --font: Inter, -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif;
+    --mono: "JetBrains Mono", ui-monospace, Menlo, monospace;
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--font);
+    background: var(--bg);
+    color: var(--ink);
+    -webkit-font-smoothing: antialiased;
+    padding: 28px 24px 56px;
+  }
+
+  .page-h { max-width: 1200px; margin: 0 auto 18px; }
+  .page-h h1 { font-size: 16px; font-weight: 650; letter-spacing: -0.02em; }
+  .page-h p { margin-top: 6px; font-size: 13px; color: var(--ink-2); line-height: 1.5; max-width: 64ch; }
+
+  .grid {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+  }
+  @media (max-width: 920px) { .grid { grid-template-columns: 1fr; } }
+
+  .variant {
+    background: var(--list);
+    border-radius: 16px;
+    box-shadow: var(--shadow), var(--ring);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    min-height: 440px;
+  }
+  .variant.wide { grid-column: 1 / -1; min-height: 0; }
+  .variant-h {
+    padding: 14px 16px 10px;
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+  }
+  .tag {
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--coral);
+    background: var(--coral-soft);
+    padding: 3px 7px;
+    border-radius: 5px;
+    flex-shrink: 0;
+  }
+  .tag.keep {
+    color: var(--ok);
+    background: rgba(61,155,110,0.12);
+  }
+  .variant-h .meta h2 { font-size: 13.5px; font-weight: 650; letter-spacing: -0.015em; }
+  .variant-h .meta p { font-size: 12px; color: var(--mute); margin-top: 3px; line-height: 1.4; }
+
+  .col {
+    flex: 1;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .row {
+    background: transparent;
+    border-radius: 12px;
+    padding: 11px 12px;
+    position: relative;
+    transition: background 0.15s var(--ease), box-shadow 0.15s, transform 0.2s;
+  }
+  .row.on {
+    background: var(--paper);
+    box-shadow: var(--shadow), var(--ring);
+  }
+  .row .t { display: flex; align-items: baseline; gap: 8px; }
+  .row .title {
+    flex: 1; min-width: 0;
+    font-size: 13px; font-weight: 600; letter-spacing: -0.015em;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .row .time {
+    font-size: 11px; color: var(--faint); flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+  }
+  .row .sub { margin-top: 2px; font-size: 11px; color: var(--mute); }
+  .row .prev {
+    margin-top: 4px; font-size: 12px; color: var(--ink-2); line-height: 1.4;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+
+  .ic {
+    width: 14px; height: 14px;
+    stroke: currentColor; fill: none;
+    stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round;
+  }
+  .ic-sm { width: 13px; height: 13px; }
+  button { font-family: inherit; border: none; background: transparent; cursor: pointer; color: inherit; }
+  .hint {
+    margin-top: auto;
+    padding: 10px 12px;
+    font-size: 11.5px;
+    color: var(--mute);
+    border-top: 1px solid var(--line);
+  }
+
+  /* ========== C KEEP: 文字「更多」+ 胶囊 ========== */
+  .c-preview-row {
+    display: flex; align-items: center; gap: 6px; margin-top: 4px;
+  }
+  .c-preview-row .prev { flex: 1; min-width: 0; margin-top: 0; }
+  .c-more {
+    flex-shrink: 0; height: 24px; padding: 0 8px; border-radius: 6px;
+    font-size: 11px; font-weight: 500; color: var(--mute);
+  }
+  .c-more:hover, .c-row.open .c-more { background: var(--hover); color: var(--ink); }
+  .c-seg { display: grid; grid-template-rows: 0fr; transition: grid-template-rows 0.26s var(--ease); }
+  .c-row.open .c-seg { grid-template-rows: 1fr; }
+  .c-seg > div { overflow: hidden; min-height: 0; }
+  .c-chips { display: flex; flex-wrap: wrap; gap: 6px; padding-top: 8px; }
+  .c-chip {
+    height: 26px; padding: 0 10px; border-radius: 999px;
+    font-size: 11.5px; font-weight: 500; color: var(--ink-2);
+    background: var(--hover);
+    display: inline-flex; align-items: center; gap: 5px;
+  }
+  .c-chip:hover { background: var(--press); color: var(--ink); }
+  .c-chip.danger:hover { background: var(--coral-soft); color: var(--coral); }
+
+  /* ========== F NEW: Command palette strip (typeahead in-row) ========== */
+  .f-row { padding-bottom: 10px; }
+  .f-cmd {
+    display: none;
+    margin-top: 8px;
+    padding: 6px;
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--list) 40%, #fff);
+    border: 1px solid var(--line);
+  }
+  .f-row.open .f-cmd { display: block; animation: fadeUp 0.2s var(--ease); }
+  @keyframes fadeUp {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: none; }
+  }
+  .f-input {
+    width: 100%;
+    height: 30px;
+    border: none;
+    outline: none;
+    background: var(--paper);
+    border-radius: 7px;
+    padding: 0 10px;
+    font: 500 12.5px var(--font);
+    color: var(--ink);
+    box-shadow: var(--ring);
+  }
+  .f-input::placeholder { color: var(--faint); font-weight: 400; }
+  .f-list { margin-top: 4px; display: flex; flex-direction: column; gap: 1px; }
+  .f-item {
+    display: flex; align-items: center; gap: 8px;
+    height: 30px; padding: 0 8px; border-radius: 6px;
+    font-size: 12.5px; font-weight: 500; color: var(--ink-2);
+    text-align: left; width: 100%;
+  }
+  .f-item:hover, .f-item.active { background: var(--paper); color: var(--ink); }
+  .f-item .k {
+    margin-left: auto;
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--faint);
+  }
+  .f-trig {
+    position: absolute; top: 8px; right: 8px;
+    width: 26px; height: 26px; border-radius: 7px;
+    display: grid; place-items: center; color: var(--faint);
+  }
+  .f-trig:hover, .f-row.open .f-trig { background: var(--hover); color: var(--ink); }
+  .f-row .t .time { margin-right: 28px; }
+
+  /* ========== G NEW: Morph title into action verbs ========== */
+  .g-row { min-height: 72px; }
+  .g-face, .g-verbs {
+    transition: opacity 0.22s var(--ease), transform 0.22s var(--ease);
+  }
+  .g-verbs {
+    position: absolute; inset: 0;
+    display: flex; align-items: stretch;
+    opacity: 0; pointer-events: none;
+    transform: scale(0.97);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--paper);
+  }
+  .g-row.morph .g-face { opacity: 0; transform: scale(0.98); pointer-events: none; }
+  .g-row.morph .g-verbs { opacity: 1; pointer-events: auto; transform: none; }
+  .g-verb {
+    flex: 1;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 5px;
+    font-size: 11px; font-weight: 560; color: var(--ink-2);
+    border-right: 1px solid var(--line);
+  }
+  .g-verb:last-child { border-right: none; }
+  .g-verb:hover { background: var(--hover); color: var(--ink); }
+  .g-verb.danger:hover { background: var(--coral-soft); color: var(--coral); }
+  .g-hold {
+    position: absolute; right: 10px; bottom: 10px;
+    font-size: 10px; font-weight: 500; color: var(--faint);
+    letter-spacing: 0.02em;
+  }
+  .g-row.morph .g-hold { display: none; }
+
+  /* ========== H NEW: Radial / pie corner control ========== */
+  .h-wrap { position: relative; }
+  .h-fab {
+    position: absolute;
+    right: 10px; bottom: 10px;
+    width: 28px; height: 28px;
+    border-radius: 50%;
+    background: var(--ink);
+    color: #fff;
+    display: grid; place-items: center;
+    z-index: 3;
+    box-shadow: 0 4px 12px rgba(28,27,25,0.18);
+    transition: transform 0.25s var(--ease), background 0.15s;
+  }
+  .h-row.open .h-fab {
+    background: var(--coral);
+    transform: rotate(45deg);
+  }
+  .h-orbit {
+    position: absolute;
+    right: 10px; bottom: 10px;
+    width: 28px; height: 28px;
+    pointer-events: none;
+  }
+  .h-row.open .h-orbit { pointer-events: auto; }
+  .h-sat {
+    position: absolute;
+    left: 0; top: 0;
+    width: 30px; height: 30px;
+    border-radius: 50%;
+    background: var(--paper);
+    box-shadow: var(--shadow), var(--ring);
+    display: grid; place-items: center;
+    color: var(--ink-2);
+    opacity: 0;
+    transform: translate(0,0) scale(0.4);
+    transition: all 0.28s var(--ease);
+  }
+  .h-sat:hover { color: var(--ink); background: #fff; }
+  .h-sat.danger:hover { color: var(--coral); }
+  .h-row.open .h-sat { opacity: 1; }
+  .h-row.open .h-sat:nth-child(1) { transform: translate(-42px, -4px) scale(1); transition-delay: 0.02s; }
+  .h-row.open .h-sat:nth-child(2) { transform: translate(-34px, -36px) scale(1); transition-delay: 0.05s; }
+  .h-row.open .h-sat:nth-child(3) { transform: translate(-4px, -44px) scale(1); transition-delay: 0.08s; }
+  .h-row.open .h-sat:nth-child(4) { transform: translate(28px, -28px) scale(1); transition-delay: 0.11s; }
+  .h-row .prev { padding-right: 36px; }
+  /* Note: satellites sit inside card — still in-row, not a portal dropdown */
+
+  /* ========== I NEW: Split dual-face card (flip) ========== */
+  .i-scene {
+    perspective: 900px;
+    min-height: 86px;
+  }
+  .i-card {
+    position: relative;
+    width: 100%;
+    min-height: 86px;
+    transform-style: preserve-3d;
+    transition: transform 0.45s var(--ease);
+  }
+  .i-scene.flipped .i-card { transform: rotateY(180deg); }
+  .i-front, .i-back {
+    position: absolute; inset: 0;
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+    border-radius: 12px;
+    background: var(--paper);
+    box-shadow: var(--shadow), var(--ring);
+    padding: 11px 12px;
+  }
+  .i-back {
+    transform: rotateY(180deg);
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(2, 1fr);
+    gap: 4px;
+    padding: 8px;
+  }
+  .i-back button {
+    border-radius: 9px;
+    background: var(--hover);
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 4px;
+    font-size: 11.5px; font-weight: 560; color: var(--ink-2);
+  }
+  .i-back button:hover { background: var(--press); color: var(--ink); }
+  .i-back button.danger:hover { background: var(--coral-soft); color: var(--coral); }
+  .i-flip {
+    position: absolute; top: 8px; right: 8px; z-index: 2;
+    height: 22px; padding: 0 8px; border-radius: 6px;
+    font-size: 10.5px; font-weight: 560; color: var(--mute);
+    background: var(--hover);
+  }
+  .i-flip:hover { color: var(--ink); }
+  .i-scene.flipped .i-flip { display: none; }
+  .i-back .back-close {
+    position: absolute; top: 6px; right: 6px;
+    width: 22px; height: 22px; border-radius: 6px;
+    background: transparent; color: var(--mute);
+    display: grid; place-items: center;
+  }
+
+  /* ========== J NEW: Progressive disclosure — gesture swipe drawer ========== */
+  .j-track {
+    position: relative;
+    overflow: hidden;
+    border-radius: 12px;
+  }
+  .j-track.on { background: var(--paper); box-shadow: var(--shadow), var(--ring); }
+  .j-drawer {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 168px;
+    display: flex;
+    background: var(--ink);
+    transform: translateX(-100%);
+    transition: transform 0.3s var(--ease);
+    z-index: 1;
+  }
+  .j-track.open .j-drawer { transform: translateX(0); }
+  .j-drawer button {
+    flex: 1;
+    color: rgba(255,255,255,0.85);
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 4px;
+    font-size: 10px; font-weight: 500;
+  }
+  .j-drawer button:hover { background: rgba(255,255,255,0.08); color: #fff; }
+  .j-drawer button.danger { color: #FFB4A8; }
+  .j-content {
+    position: relative; z-index: 2;
+    background: inherit;
+    padding: 11px 12px;
+    transition: transform 0.3s var(--ease);
+  }
+  .j-track.open .j-content { transform: translateX(168px); }
+  .j-track.on .j-content { background: var(--paper); }
+  .j-swipe-hint {
+    position: absolute; left: 0; top: 0; bottom: 0; width: 4px;
+    background: linear-gradient(180deg, transparent, var(--coral), transparent);
+    opacity: 0.35; border-radius: 4px 0 0 4px;
+  }
+  .j-btn {
+    margin-top: 6px;
+    height: 22px; padding: 0 8px; border-radius: 5px;
+    font-size: 10.5px; font-weight: 500; color: var(--mute);
+  }
+  .j-btn:hover { background: var(--hover); color: var(--ink); }
+
+  .note {
+    max-width: 1200px;
+    margin: 16px auto 0;
+    padding: 14px 16px;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: var(--shadow), var(--ring);
+    font-size: 12.5px;
+    color: var(--ink-2);
+    line-height: 1.55;
+  }
+  .note strong { color: var(--ink); }
+</style>
+</head>
+<body>
+
+  <div class="page-h">
+    <h1>Session 更多操作 · 新创意（保留 C）</h1>
+    <p>C 原封保留。A/B/D/E 整组换掉，换成五套全新交互隐喻：命令条、态变、卫星钮、翻转、侧滑屉。</p>
+  </div>
+
+  <div class="grid">
+
+    <!-- C KEEP -->
+    <section class="variant">
+      <div class="variant-h">
+        <span class="tag keep">C · 保留</span>
+        <div class="meta">
+          <h2>文字「更多」+ 胶囊行</h2>
+          <p>用「更多」替代 ···，展开 pill chips。语义清晰、触控友好。</p>
+        </div>
+      </div>
+      <div class="col">
+        <div class="row on c-row" id="c1">
+          <div class="t"><div class="title">执行PS</div><div class="time">5 hours ago</div></div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="c-preview-row">
+            <div class="prev">已执行 ps。当前新增/可见的相关进程包含…</div>
+            <button class="c-more" type="button" onclick="toggleC('c1')">更多</button>
+          </div>
+          <div class="c-seg"><div>
+            <div class="c-chips">
+              <button class="c-chip" type="button"><svg class="ic-sm ic" viewBox="0 0 24 24"><path d="M12 3l2.2 6.8H21l-5.4 4 2.1 6.7L12 16.8 6.3 20.5l2.1-6.7L3 9.8h6.8z"/></svg>置顶</button>
+              <button class="c-chip" type="button"><svg class="ic-sm ic" viewBox="0 0 24 24"><path d="M15 5l-8 8M14.5 3.5a2 2 0 0 1 3 3L8 16l-4 1 1-4z"/></svg>重命名</button>
+              <button class="c-chip" type="button"><svg class="ic-sm ic" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 10v6M12 7h.01"/></svg>详情</button>
+              <button class="c-chip danger" type="button"><svg class="ic-sm ic" viewBox="0 0 24 24"><path d="M4 8h16M9 8V5h6v3M7 8v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8"/></svg>归档</button>
+            </div>
+          </div></div>
+        </div>
+        <div class="row">
+          <div class="t"><div class="title">执行sleep20</div><div class="time">23 hours ago</div></div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="c-preview-row">
+            <div class="prev">sleep 20 done</div>
+            <button class="c-more" type="button">更多</button>
+          </div>
+        </div>
+        <div class="row">
+          <div class="t"><div class="title">检查本地 daemon</div><div class="time">2d ago</div></div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="c-preview-row">
+            <div class="prev">amuxd · healthy</div>
+            <button class="c-more" type="button">更多</button>
+          </div>
+        </div>
+      </div>
+      <div class="hint">基准方案 · 已定保留</div>
+    </section>
+
+    <!-- F NEW -->
+    <section class="variant">
+      <div class="variant-h">
+        <span class="tag">F · 新</span>
+        <div class="meta">
+          <h2>行内命令条</h2>
+          <p>点 ⌘ 打开迷你命令面板，可键盘筛选。像把 Spotlight 嵌进这一行。</p>
+        </div>
+      </div>
+      <div class="col">
+        <div class="row on f-row" id="f1">
+          <button class="f-trig" type="button" aria-label="命令" onclick="toggleF('f1')">
+            <svg class="ic" viewBox="0 0 24 24"><path d="M7 7h.01M17 7h.01M7 17h.01M12 12h.01M17 17h.01M9 7h6v2a3 3 0 0 1-3 3h0a3 3 0 0 0-3 3v2h6"/></svg>
+          </button>
+          <div class="t"><div class="title">执行PS</div><div class="time">5 hours ago</div></div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="prev">已执行 ps。当前新增/可见的相关进程包含…</div>
+          <div class="f-cmd">
+            <input class="f-input" placeholder="输入动作：置顶、重命名…" aria-label="过滤操作" oninput="filterF(this)" />
+            <div class="f-list">
+              <button class="f-item active" type="button" data-q="置顶 pin"><svg class="ic" viewBox="0 0 24 24"><path d="M12 3l2.2 6.8H21l-5.4 4 2.1 6.7L12 16.8 6.3 20.5l2.1-6.7L3 9.8h6.8z"/></svg>置顶<span class="k">P</span></button>
+              <button class="f-item" type="button" data-q="重命名 rename"><svg class="ic" viewBox="0 0 24 24"><path d="M15 5l-8 8M14.5 3.5a2 2 0 0 1 3 3L8 16l-4 1 1-4z"/></svg>重命名<span class="k">R</span></button>
+              <button class="f-item" type="button" data-q="详情 detail"><svg class="ic" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 10v6M12 7h.01"/></svg>详情<span class="k">I</span></button>
+              <button class="f-item" type="button" data-q="归档 archive"><svg class="ic" viewBox="0 0 24 24"><path d="M4 8h16M9 8V5h6v3M7 8v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8"/></svg>归档<span class="k">A</span></button>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="t"><div class="title">执行sleep20</div><div class="time">23 hours ago</div></div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="prev">sleep 20 done</div>
+        </div>
+      </div>
+      <div class="hint">一体 · 可键盘 · 动作在行内生长，不盖下一卡</div>
+    </section>
+
+    <!-- G NEW -->
+    <section class="variant">
+      <div class="variant-h">
+        <span class="tag">G · 新</span>
+        <div class="meta">
+          <h2>态变：卡片变动作盘</h2>
+          <p>按住 / 点「动作」整张卡变形四宫格。内容暂时让位给意图。</p>
+        </div>
+      </div>
+      <div class="col">
+        <div class="row on g-row" id="g1">
+          <div class="g-face">
+            <div class="t"><div class="title">执行PS</div><div class="time">5 hours ago</div></div>
+            <div class="sub">TeamClaw Dev</div>
+            <div class="prev">已执行 ps。当前新增/可见的相关进程包含…</div>
+            <span class="g-hold">按住或点右侧 →</span>
+          </div>
+          <div class="g-verbs">
+            <button class="g-verb" type="button"><svg class="ic" viewBox="0 0 24 24"><path d="M12 3l2.2 6.8H21l-5.4 4 2.1 6.7L12 16.8 6.3 20.5l2.1-6.7L3 9.8h6.8z"/></svg>置顶</button>
+            <button class="g-verb" type="button"><svg class="ic" viewBox="0 0 24 24"><path d="M15 5l-8 8M14.5 3.5a2 2 0 0 1 3 3L8 16l-4 1 1-4z"/></svg>重命名</button>
+            <button class="g-verb" type="button"><svg class="ic" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 10v6M12 7h.01"/></svg>详情</button>
+            <button class="g-verb danger" type="button" onclick="document.getElementById('g1').classList.remove('morph')"><svg class="ic" viewBox="0 0 24 24"><path d="M4 8h16M9 8V5h6v3M7 8v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8"/></svg>归档</button>
+          </div>
+        </div>
+        <div class="row">
+          <div class="t"><div class="title">输出500字的散文</div><div class="time">yesterday</div></div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="prev">秋日的风穿过旧巷…</div>
+        </div>
+        <button type="button" style="margin:4px;height:32px;border-radius:8px;background:var(--hover);font-size:12px;font-weight:500" onclick="document.getElementById('g1').classList.toggle('morph')">演示：切换态变</button>
+      </div>
+      <div class="hint">戏剧化 · 零浮层 · 同一矩形内完成意图切换</div>
+    </section>
+
+    <!-- H NEW -->
+    <section class="variant">
+      <div class="variant-h">
+        <span class="tag">H · 新</span>
+        <div class="meta">
+          <h2>卫星钮（角上开花）</h2>
+          <p>一颗 + 钮炸出四颗卫星动作，仍贴在卡片坐标系内，不是系统弹层。</p>
+        </div>
+      </div>
+      <div class="col">
+        <div class="row on h-row h-wrap" id="h1">
+          <div class="t"><div class="title">执行PS</div><div class="time">5 hours ago</div></div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="prev">已执行 ps。当前新增/可见的相关进程包含…</div>
+          <div class="h-orbit">
+            <button class="h-sat" type="button" title="置顶"><svg class="ic" viewBox="0 0 24 24"><path d="M12 3l2.2 6.8H21l-5.4 4 2.1 6.7L12 16.8 6.3 20.5l2.1-6.7L3 9.8h6.8z"/></svg></button>
+            <button class="h-sat" type="button" title="重命名"><svg class="ic" viewBox="0 0 24 24"><path d="M15 5l-8 8M14.5 3.5a2 2 0 0 1 3 3L8 16l-4 1 1-4z"/></svg></button>
+            <button class="h-sat" type="button" title="详情"><svg class="ic" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 10v6M12 7h.01"/></svg></button>
+            <button class="h-sat danger" type="button" title="归档"><svg class="ic" viewBox="0 0 24 24"><path d="M4 8h16M9 8V5h6v3M7 8v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8"/></svg></button>
+          </div>
+          <button class="h-fab" type="button" aria-label="展开动作" onclick="document.getElementById('h1').classList.toggle('open')">
+            <svg class="ic" viewBox="0 0 24 24" style="stroke-width:2"><path d="M12 5v14M5 12h14"/></svg>
+          </button>
+        </div>
+        <div class="row">
+          <div class="t"><div class="title">执行sleep20</div><div class="time">23 hours ago</div></div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="prev">sleep 20 done</div>
+        </div>
+      </div>
+      <div class="hint">有趣 · 空间感 · 注意勿让卫星溢出卡片裁切区</div>
+    </section>
+
+    <!-- I NEW -->
+    <section class="variant">
+      <div class="variant-h">
+        <span class="tag">I · 新</span>
+        <div class="meta">
+          <h2>卡片翻转</h2>
+          <p>正面是会话，背面是 2×2 动作。物理隐喻清晰，完全无弹框。</p>
+        </div>
+      </div>
+      <div class="col">
+        <div class="i-scene" id="i1">
+          <button class="i-flip" type="button" onclick="document.getElementById('i1').classList.add('flipped')">动作</button>
+          <div class="i-card">
+            <div class="i-front">
+              <div class="t"><div class="title">执行PS</div><div class="time">5 hours ago</div></div>
+              <div class="sub">TeamClaw Dev</div>
+              <div class="prev">已执行 ps。当前新增/可见的相关进程包含…</div>
+            </div>
+            <div class="i-back">
+              <button type="button"><svg class="ic" viewBox="0 0 24 24"><path d="M12 3l2.2 6.8H21l-5.4 4 2.1 6.7L12 16.8 6.3 20.5l2.1-6.7L3 9.8h6.8z"/></svg>置顶</button>
+              <button type="button"><svg class="ic" viewBox="0 0 24 24"><path d="M15 5l-8 8M14.5 3.5a2 2 0 0 1 3 3L8 16l-4 1 1-4z"/></svg>重命名</button>
+              <button type="button"><svg class="ic" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 10v6M12 7h.01"/></svg>详情</button>
+              <button class="danger" type="button"><svg class="ic" viewBox="0 0 24 24"><path d="M4 8h16M9 8V5h6v3M7 8v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8"/></svg>归档</button>
+              <button class="back-close" type="button" aria-label="翻回" onclick="event.stopPropagation();document.getElementById('i1').classList.remove('flipped')">
+                <svg class="ic" viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="row" style="margin-top:6px">
+          <div class="t"><div class="title">执行sleep20</div><div class="time">23 hours ago</div></div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="prev">下一张卡完全不被遮挡</div>
+        </div>
+      </div>
+      <div class="hint">记忆点强 · 适合偶尔操作；频繁操作略重</div>
+    </section>
+
+    <!-- J NEW -->
+    <section class="variant wide">
+      <div class="variant-h">
+        <span class="tag">J · 新</span>
+        <div class="meta">
+          <h2>侧滑抽屉（邮件 App 隐喻）</h2>
+          <p>内容右移，露出深色动作屉。一体、不挡下方会话，和「更多」胶囊完全不同语言。</p>
+        </div>
+      </div>
+      <div class="col" style="max-width: 420px;">
+        <div class="j-track on" id="j1">
+          <div class="j-drawer">
+            <button type="button"><svg class="ic" viewBox="0 0 24 24"><path d="M12 3l2.2 6.8H21l-5.4 4 2.1 6.7L12 16.8 6.3 20.5l2.1-6.7L3 9.8h6.8z"/></svg>置顶</button>
+            <button type="button"><svg class="ic" viewBox="0 0 24 24"><path d="M15 5l-8 8M14.5 3.5a2 2 0 0 1 3 3L8 16l-4 1 1-4z"/></svg>改名</button>
+            <button type="button"><svg class="ic" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 10v6M12 7h.01"/></svg>详情</button>
+            <button class="danger" type="button"><svg class="ic" viewBox="0 0 24 24"><path d="M4 8h16M9 8V5h6v3M7 8v11a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8"/></svg>归档</button>
+          </div>
+          <div class="j-content">
+            <span class="j-swipe-hint" aria-hidden="true"></span>
+            <div class="t"><div class="title">执行PS</div><div class="time">5 hours ago</div></div>
+            <div class="sub">TeamClaw Dev</div>
+            <div class="prev">已执行 ps。当前新增/可见的相关进程包含…</div>
+            <button class="j-btn" type="button" onclick="document.getElementById('j1').classList.toggle('open')">演示侧滑</button>
+          </div>
+        </div>
+        <div class="row" style="margin-top:4px">
+          <div class="t"><div class="title">执行sleep20</div><div class="time">23 hours ago</div></div>
+          <div class="sub">TeamClaw Dev</div>
+          <div class="prev">完全可见，不被浮层盖住</div>
+        </div>
+      </div>
+      <div class="hint">移动端直觉强 · 桌面可用按钮触发同等位移</div>
+    </section>
+  </div>
+
+  <div class="note">
+    <strong>对比 C：</strong>
+    F 偏效率/键盘；G 偏戏剧态变；H 偏玩味微交互；I 偏实体隐喻；J 偏系统手势。
+    都和 C 的「文字+胶囊」不是同一套路。挑一版和 C 一起定，或只要 C。
+  </div>
+
+<script>
+  function toggleC(id) {
+    const el = document.getElementById(id);
+    el.classList.toggle('open');
+    const btn = el.querySelector('.c-more');
+    if (btn) btn.textContent = el.classList.contains('open') ? '收起' : '更多';
+  }
+  function toggleF(id) {
+    document.getElementById(id).classList.toggle('open');
+  }
+  function filterF(input) {
+    const q = input.value.trim().toLowerCase();
+    input.closest('.f-cmd').querySelectorAll('.f-item').forEach((item) => {
+      const hay = (item.getAttribute('data-q') || '') + item.textContent;
+      item.style.display = !q || hay.toLowerCase().includes(q) ? '' : 'none';
+    });
+  }
+  document.getElementById('c1').classList.add('open');
+  document.querySelector('#c1 .c-more').textContent = '收起';
+  document.getElementById('f1').classList.add('open');
+</script>
+</body>
+</html>

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -259,7 +259,7 @@ function SidebarUserAccountMenu() {
         <Button
           variant="ghost"
           size="sm"
-          className="h-7 min-w-0 shrink max-w-full gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
+          className="h-8 min-w-0 shrink max-w-full gap-1.5 rounded-lg px-2 text-[12px] text-ink-2 hover:bg-black/[0.04] hover:text-foreground"
           data-testid="sidebar-user-menu-trigger"
         >
           {avatarUrl ? (
@@ -428,7 +428,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           <NavRail />
         </SidebarContent>
 
-        <SidebarFooter className="gap-1 px-2 pb-1 pt-1">
+        <SidebarFooter className="gap-2 px-2.5 pb-2 pt-1">
           <LocalDaemonCard />
           <MqttDisconnectedNotice />
 
@@ -436,7 +436,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-7 shrink-0 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
+                className="h-8 shrink-0 gap-1.5 rounded-lg px-2 text-[12px] text-ink-2 hover:bg-black/[0.04] hover:text-foreground"
                 onClick={() => openSettings()}
               >
                 <Settings className="h-3.5 w-3.5 shrink-0" />

--- a/packages/app/src/components/sidebar/ActorRow.tsx
+++ b/packages/app/src/components/sidebar/ActorRow.tsx
@@ -51,8 +51,8 @@ export function ActorRow({
         type="button"
         onClick={() => onSelect(actor)}
         className={cn(
-          'flex w-full items-center gap-[9px] rounded-md px-[9px] py-[5px] text-left text-[12.5px] transition-colors',
-          active ? 'bg-selected font-semibold text-foreground' : 'text-ink-2 hover:bg-selected/60',
+          'flex w-full items-center gap-[9px] rounded-lg px-[9px] py-[6px] text-left text-[13px] transition-[background-color,color] duration-150',
+          active ? 'bg-paper font-semibold text-foreground shadow-[0_1px_2px_rgba(28,27,25,0.04)] ring-1 ring-black/[0.05]' : 'text-ink-2 hover:bg-black/[0.04]',
         )}
       >
         <div
@@ -74,9 +74,6 @@ export function ActorRow({
             className="h-3 w-3 shrink-0 fill-coral text-coral"
             aria-label={t('actors.defaultAgent', 'Default agent')}
           />
-        )}
-        {isAgent && (
-          <span className="shrink-0 font-mono text-[9px] font-semibold tracking-wider text-coral">{t('actors.type.agent', 'Agent')}</span>
         )}
       </button>
     </ActorContextMenu>

--- a/packages/app/src/components/sidebar/ActorsSection.tsx
+++ b/packages/app/src/components/sidebar/ActorsSection.tsx
@@ -110,7 +110,7 @@ export function ActorsSection() {
         <button
           type="button"
           onClick={toggle}
-          className="group flex flex-1 items-center gap-1.5 rounded-md px-[9px] py-1 text-left text-[10.5px] font-semibold uppercase tracking-[0.08em] text-faint hover:text-foreground"
+          className="group flex flex-1 items-center gap-1.5 rounded-lg px-[9px] py-1.5 text-left text-[10.5px] font-semibold uppercase tracking-[0.08em] text-faint hover:text-foreground"
         >
           {collapsed ? <ChevronRight className="h-[10px] w-[10px]" /> : <ChevronDown className="h-[10px] w-[10px]" />}
           <span>{t('sidebar.actorsSection', 'Recents')}</span>

--- a/packages/app/src/components/sidebar/LocalDaemonCard.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonCard.tsx
@@ -146,8 +146,8 @@ export function LocalDaemonCard() {
       </AlertDialog>
       <div
         className={cn(
-          'group/local-daemon flex max-h-[45vh] flex-col overflow-y-auto rounded-lg border bg-paper p-1 shadow-sm transition-[max-height,border-color] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none',
-          mqttDisconnected ? 'border-[color:var(--coral-soft)]' : 'border-border-soft',
+          'group/local-daemon flex max-h-[45vh] flex-col overflow-y-auto rounded-xl bg-paper p-2 shadow-[0_2px_8px_rgba(28,27,25,0.05),0_1px_2px_rgba(28,27,25,0.03)] ring-1 ring-black/[0.05] transition-[max-height,box-shadow] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:ring-white/10',
+          mqttDisconnected && 'ring-1 ring-[color:var(--coral-soft)]',
         )}
       >
         <LocalDaemonRow

--- a/packages/app/src/components/sidebar/LocalDaemonRow.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonRow.tsx
@@ -120,6 +120,9 @@ function AgentTypeIcon({ agentType }: { agentType?: string | null }) {
   }
 }
 
+/**
+ * Status copy for the local daemon online / offline / MQTT indicators.
+ */
 function localDaemonStatusLabel(
   status: LocalDaemonRuntimeStatus,
   t: (key: string, fallback: string) => string,
@@ -248,10 +251,13 @@ function SheetHeader({
             <AgentTypeIcon agentType={agentType} />
           </span>
           <div className="min-w-0 flex-1">
-            <div className="truncate text-[13px] font-bold leading-tight">{displayName}</div>
+            <div className="flex min-w-0 items-center gap-1.5">
+              <div className="truncate text-[12.5px] font-semibold leading-tight">{displayName}</div>
+              <RuntimeStatusDot status={runtimeStatus} label={statusLabel} />
+            </div>
             <div
               className={cn(
-                'mt-0.5 truncate font-mono text-[11px] leading-snug',
+                'mt-0.5 truncate text-[11px] leading-snug',
                 workspaceUnset ? 'text-faint' : 'text-muted-foreground',
               )}
               title={workspaceUnset ? undefined : workspaceTitle}
@@ -259,7 +265,6 @@ function SheetHeader({
               {workspaceLabel}
             </div>
           </div>
-          <RuntimeStatusDot status={runtimeStatus} label={statusLabel} />
         </div>
       </div>
     </div>

--- a/packages/app/src/components/sidebar/NavRail.tsx
+++ b/packages/app/src/components/sidebar/NavRail.tsx
@@ -52,10 +52,11 @@ function TopEntry({ label, icon: Icon, active, badge, onClick }: TopEntryProps) 
       {badge != null && (
         <span
           className={cn(
-            'shrink-0 tabular-nums',
+            // Same hit box for active/inactive so counts share a right edge.
+            'inline-flex h-[18px] min-w-[18px] shrink-0 items-center justify-center rounded-full px-[5px] text-[10.5px] font-semibold tabular-nums',
             active
-              ? 'inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-coral px-[5px] text-[10.5px] font-semibold text-coral-foreground shadow-[0_2px_6px_rgba(232,90,74,0.28)]'
-              : 'text-[11.5px] tabular-nums text-muted-foreground',
+              ? 'bg-coral text-coral-foreground shadow-[0_2px_6px_rgba(232,90,74,0.28)]'
+              : 'text-muted-foreground',
           )}
         >
           {badge}

--- a/packages/app/src/components/sidebar/NavRail.tsx
+++ b/packages/app/src/components/sidebar/NavRail.tsx
@@ -33,18 +33,16 @@ interface TopEntryProps {
 }
 
 function TopEntry({ label, icon: Icon, active, badge, onClick }: TopEntryProps) {
-  // Direction B quick-link row: tight 7×9 padding, selected (#e7e2d6) fill on
-  // active, no left bar. The coral left bar is reserved for session cards in
-  // the middle column. See AGENTS.md §2 "Sidebar".
+  // Soft Comfort: active = elevated paper capsule; count badge turns coral when active.
   return (
     <button
       type="button"
       onClick={onClick}
       className={cn(
-        'flex w-full items-center gap-2.5 rounded-md px-[9px] py-[7px] text-left text-[13px] transition-colors',
+        'flex w-full items-center gap-2.5 rounded-lg px-[9px] py-[7px] text-left text-[13px] transition-[background-color,box-shadow,color] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
         active
-          ? 'bg-selected font-semibold text-foreground'
-          : 'text-ink-2 hover:bg-selected/60',
+          ? 'bg-paper font-semibold text-foreground shadow-[0_1px_2px_rgba(28,27,25,0.04)] ring-1 ring-black/[0.05]'
+          : 'font-normal text-ink-2 hover:bg-black/[0.04]',
       )}
     >
       <Icon
@@ -52,7 +50,14 @@ function TopEntry({ label, icon: Icon, active, badge, onClick }: TopEntryProps) 
       />
       <span className="min-w-0 flex-1 truncate">{label}</span>
       {badge != null && (
-        <span className="shrink-0 font-mono text-[11px] tabular-nums text-faint">
+        <span
+          className={cn(
+            'shrink-0 tabular-nums',
+            active
+              ? 'inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-coral px-[5px] text-[10.5px] font-semibold text-coral-foreground shadow-[0_2px_6px_rgba(232,90,74,0.28)]'
+              : 'text-[11.5px] tabular-nums text-muted-foreground',
+          )}
+        >
           {badge}
         </span>
       )}
@@ -130,14 +135,14 @@ export function NavRail() {
   }, [handleQuickNewChat])
 
   return (
-    <div className="flex h-full w-full min-w-0 flex-col gap-2 overflow-y-auto px-3 pt-0 pb-3">
+    <div className="flex h-full w-full min-w-0 flex-col gap-2.5 overflow-y-auto px-2.5 pt-0 pb-3">
       <NewChatSplitButton
         quickChatState={quickChatState}
         creating={creating}
         onPrimaryClick={handleQuickNewChat}
       />
 
-      <div className="flex flex-col">
+      <div className="flex flex-col gap-0.5">
         <TopEntry
           label={t('sidebar.sessions', 'Sessions')}
           icon={Inbox}

--- a/packages/app/src/components/sidebar/NewChatSplitButton.tsx
+++ b/packages/app/src/components/sidebar/NewChatSplitButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, Loader2, Plus, SquarePen } from 'lucide-react'
+import { ChevronDown, Loader2, Plus } from 'lucide-react'
 import type { QuickChatState } from '@/hooks/use-quick-chat-readiness'
 import { useUIStore } from '@/stores/ui'
 import { cn } from '@/lib/utils'
@@ -49,7 +49,7 @@ export function NewChatSplitButton({
 
   return (
     <div className="flex w-full flex-col gap-1.5">
-      <div className="flex w-full flex-col overflow-hidden rounded-lg shadow-sm">
+      <div className="flex w-full flex-col overflow-hidden rounded-[10px] shadow-[0_4px_14px_rgba(232,90,74,0.22)]">
         <div className="flex w-full bg-coral">
           <button
             type="button"
@@ -57,17 +57,17 @@ export function NewChatSplitButton({
             disabled={primaryDisabled}
             title={primaryTitle}
             className={cn(
-              'flex min-w-0 flex-1 items-center gap-2 rounded-none px-2.5 py-1.5 text-left text-[13px] font-semibold text-coral-foreground transition-colors',
-              'hover:bg-coral/90 disabled:cursor-not-allowed disabled:opacity-40',
+              'flex min-w-0 flex-1 items-center gap-2 rounded-none px-3 py-2.5 text-left text-[13px] font-semibold tracking-tight text-coral-foreground transition-[filter,background-color] duration-150',
+              'hover:brightness-[1.04] disabled:cursor-not-allowed disabled:opacity-40',
             )}
           >
             {creating ? (
               <Loader2 className="h-[14px] w-[14px] shrink-0 animate-spin" />
             ) : (
-              <SquarePen className="h-[14px] w-[14px] shrink-0" />
+              <Plus className="h-[14px] w-[14px] shrink-0" strokeWidth={2.5} />
             )}
             <span className="min-w-0 flex-1 truncate">{t('chat.newChat', 'New Chat')}</span>
-            <span className="shrink-0 rounded bg-black/15 px-1 py-0.5 font-mono text-[10px] font-medium tracking-tight text-white/95">
+            <span className="ml-auto shrink-0 font-mono text-[10.5px] font-medium tracking-tight text-white/70">
               ⌘N
             </span>
           </button>
@@ -78,8 +78,8 @@ export function NewChatSplitButton({
             aria-expanded={moreOpen}
             onClick={() => setMoreOpen((open) => !open)}
             className={cn(
-              'flex w-8 shrink-0 items-center justify-center rounded-none border-l border-coral-foreground/20 text-coral-foreground transition-colors',
-              'hover:bg-coral/90 disabled:cursor-not-allowed disabled:opacity-40',
+              'flex w-8 shrink-0 items-center justify-center rounded-none border-l border-white/15 text-coral-foreground transition-[filter,background-color] duration-150',
+              'hover:brightness-[1.04] disabled:cursor-not-allowed disabled:opacity-40',
             )}
           >
             <ChevronDown

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -22,7 +22,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { AnimatedClock } from '@/components/ui/animated-clock'
 import { SessionSearchDialog } from '@/components/sidebar/session-search-dialog'
 import { SessionDetailDialog, type SessionDetailListHints } from '@/components/sidebar/SessionDetailDialog'
-import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
+import { SidebarMenu, SidebarMenuItem } from '@/components/ui/sidebar'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -335,6 +335,20 @@ export function SessionListColumn({
     getItemKey: (index) => virtualRows[index].key,
   })
 
+  React.useEffect(() => {
+    if (!shouldVirtualize) return
+    const frame = requestAnimationFrame(() => {
+      sessionVirtualizer.measure()
+    })
+    const timer = window.setTimeout(() => {
+      sessionVirtualizer.measure()
+    }, 280)
+    return () => {
+      cancelAnimationFrame(frame)
+      window.clearTimeout(timer)
+    }
+  }, [actionsOpenSessionId, shouldVirtualize, sessionVirtualizer])
+
   /** Load participants for any visible row we haven't seen yet. */
   const visibleIds = filteredRows.map((r) => r.id).join('|')
   React.useEffect(() => {
@@ -564,6 +578,17 @@ export function SessionListColumn({
       )
     const workspaceLabel = sessionWorkspaceLabels.get(row.id)
     const showWorkspaceSubline = filter.kind !== 'workspace' && !!workspaceLabel
+    const actionsId = `v2-session-actions-${row.id}`
+    const actionBtnClass =
+      'grid h-[34px] place-items-center rounded-lg bg-black/[0.045] text-ink-2 transition-colors hover:bg-black/[0.08] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-white/[0.06] dark:hover:bg-white/10'
+    const selectSession = () => {
+      if (isRenaming) return
+      if (batchSelecting) {
+        toggleBatchSelected(row.id)
+        return
+      }
+      handleSelectSession(row.id)
+    }
     return (
       <SidebarMenuItem
         key={row.id}
@@ -575,38 +600,28 @@ export function SessionListColumn({
           if (next instanceof Node && e.currentTarget.contains(next)) return
           setActionsOpenSessionId((prev) => (prev === row.id ? null : prev))
         }}
+        onKeyDown={(e) => {
+          if (e.key !== 'Escape' || !actionsOpen) return
+          e.preventDefault()
+          e.stopPropagation()
+          setActionsOpenSessionId(null)
+        }}
       >
-        <SidebarMenuButton
-          isActive={isActive && !batchSelecting}
+        {/* Soft Comfort capsule — chrome lives here so select / more / dock stay sibling controls. */}
+        <div
           data-testid="v2-session-row"
           data-session-id={row.id}
-          data-active={isActive ? "true" : "false"}
-          data-batch-checked={isBatchChecked ? "true" : "false"}
+          data-active={isActive ? 'true' : 'false'}
+          data-batch-checked={isBatchChecked ? 'true' : 'false'}
           className={cn(
-            // Soft Comfort: elevated paper capsule when active (no coral left bar).
-            // Horizontal inset comes from the list container padding — do not use
-            // mx-* with w-full or overflow-x-hidden will clip the right edge.
-            'my-px h-auto w-full rounded-[11px] px-2.5 py-2 transition-[background-color,box-shadow] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
+            'my-px w-full rounded-[11px] px-2.5 py-2 transition-[background-color,box-shadow] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
             compactHeader && 'px-2',
             isActive && !batchSelecting &&
-              'relative z-0 bg-paper font-medium shadow-[0_2px_8px_rgba(28,27,25,0.05),0_1px_2px_rgba(28,27,25,0.03)] ring-1 ring-black/[0.05] data-[active=true]:!bg-paper',
+              'relative z-0 bg-paper shadow-[0_2px_8px_rgba(28,27,25,0.05),0_1px_2px_rgba(28,27,25,0.03)] ring-1 ring-black/[0.05]',
             !isActive && !batchSelecting && 'hover:bg-black/[0.035]',
             isHighlighted && !isActive && !batchSelecting && 'bg-emerald-500/15 ring-1 ring-emerald-500/30',
             batchSelecting && isBatchChecked && 'bg-selected',
           )}
-          onClick={() => {
-            if (isRenaming) return
-            if (batchSelecting) {
-              toggleBatchSelected(row.id)
-              return
-            }
-            handleSelectSession(row.id)
-          }}
-          onDoubleClick={(e) => {
-            if (batchSelecting) return
-            e.stopPropagation()
-            handleStartRename(e, row.id)
-          }}
         >
           <div className="flex w-full min-w-0 items-start">
             {batchSelecting ? (
@@ -620,241 +635,245 @@ export function SessionListColumn({
                     ? 'border-foreground bg-foreground text-background'
                     : 'border-foreground/20 bg-paper',
                 )}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  toggleBatchSelected(row.id)
+                }}
               >
                 {isBatchChecked ? <Check className="h-2.5 w-2.5" strokeWidth={3} /> : null}
               </span>
             ) : null}
             <div className="flex min-w-0 flex-1 flex-col items-start gap-1">
-            {/* Title row: [pin] title [unread/NEW] [time][⋯] — ⋯ expands on hover and pushes time left (C2). */}
-            <div className="flex w-full min-w-0 items-center gap-1.5">
-              {row.isPinned && <Pin className="h-3 w-3 shrink-0 text-amber-500 fill-amber-500/20" />}
-              {isRenaming ? (
-                <SessionRenameInput
-                  defaultValue={row.title}
-                  onConfirm={(v) => handleRenameConfirm(row.id, v)}
-                  onCancel={() => setRenamingSessionId(null)}
-                />
-              ) : (
-                <>
-                  <span className={cn(
-                    'min-w-0 flex-1 truncate text-left text-[13px] font-semibold text-foreground',
-                  )}
-                  data-testid="v2-session-row-title"
-                  >
-                    {row.title || t('chat.newChat', 'New Chat')}
-                  </span>
-                  <div className="flex shrink-0 items-center">
-                    {!isActive && row.hasUnread && (
-                      <span
-                        className="mr-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-coral"
-                        aria-label={t('sidebar.unread', 'Unread')}
-                      />
-                    )}
-                    {!isActive && isHighlighted && (
-                      <span className="mr-1.5 shrink-0 rounded-full bg-coral px-1.5 py-px text-[10px] font-semibold leading-4 text-coral-foreground">
-                        {t('chat.newSessionBadge', 'NEW')}
-                      </span>
-                    )}
-                    {row.lastMessageAt && (
-                      <span className="shrink-0 px-0.5 text-[11px] leading-[22px] tabular-nums text-faint">
-                        {formatRelativeTime(row.lastMessageAt)}
-                      </span>
-                    )}
-                    {!batchSelecting && (
-                      <span
-                        role="button"
-                        tabIndex={0}
-                        data-testid="v2-session-row-more"
-                        aria-label={actionsOpen
-                          ? t('sidebar.closeActions', 'Close actions')
-                          : t('sidebar.moreActions', 'More actions')}
-                        aria-expanded={actionsOpen}
-                        title={t('sidebar.moreActions', 'More actions')}
-                        className={cn(
-                          'inline-grid h-[22px] place-items-center overflow-hidden rounded-md text-muted-foreground',
-                          'pointer-events-none w-0 opacity-0',
-                          'transition-[width,opacity,margin,background-color,color] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
-                          // Hover-only reveal. Do NOT use group-focus-within — selecting the row
-                          // focuses SidebarMenuButton and would pin ⋯ visible after mouse leave.
-                          'group-hover/menu-item:pointer-events-auto group-hover/menu-item:ml-0.5 group-hover/menu-item:w-[22px] group-hover/menu-item:opacity-100',
-                          'focus-visible:pointer-events-auto focus-visible:ml-0.5 focus-visible:w-[22px] focus-visible:opacity-100',
-                          'hover:bg-black/[0.08] hover:text-foreground dark:hover:bg-white/10',
-                          actionsOpen && 'bg-black/[0.08] text-foreground dark:bg-white/10',
-                        )}
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setActionsOpenSessionId((prev) => (prev === row.id ? null : row.id))
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.key !== 'Enter' && e.key !== ' ') return
-                          e.preventDefault()
-                          e.stopPropagation()
-                          setActionsOpenSessionId((prev) => (prev === row.id ? null : row.id))
-                        }}
-                      >
-                        {actionsOpen
-                          ? <X className="h-3 w-3" strokeWidth={2} />
-                          : <Ellipsis className="h-3 w-3" strokeWidth={2} />}
-                      </span>
-                    )}
-                  </div>
-                </>
-              )}
-            </div>
-            {!isRenaming && showWorkspaceSubline && (
-              <span
-                className="w-full truncate font-mono text-[10.5px] leading-tight text-faint"
-                data-testid="v2-session-row-workspace"
-              >
-                {workspaceLabel}
-              </span>
-            )}
-            {/* Preview line: single line from last_message_preview. */}
-            {!isRenaming && row.lastMessagePreview && (
-              <div
-                className={cn(
-                  'w-full truncate text-[12px] leading-snug text-muted-foreground transition-opacity duration-150',
-                  actionsOpen && 'opacity-50',
-                )}
-                data-testid="v2-session-row-preview"
-              >
-                {row.lastMessagePreview.split(/(@[\w.\-\u4e00-\u9fff]+)/g).map((part, i) =>
-                  part.startsWith('@') ? (
-                    <em key={i} className="font-medium not-italic text-coral">
-                      {part}
-                    </em>
-                  ) : (
-                    <React.Fragment key={i}>{part}</React.Fragment>
-                  ),
-                )}
-              </div>
-            )}
-            {/* Participants cluster + activity badge */}
-            {!isRenaming && ((parts.length > 0 && !isSoloWithLocalAgent) || activity) && (
-              <div className="flex w-full items-center gap-1.5" data-testid="v2-session-row-participants">
-                {parts.length > 0 && !isSoloWithLocalAgent && (
+              {/* Title row: select button | meta | sibling more (no nested buttons). */}
+              <div className="flex w-full min-w-0 items-center gap-1.5">
+                {row.isPinned && <Pin className="h-3 w-3 shrink-0 fill-amber-500/20 text-amber-500" />}
+                {isRenaming ? (
+                  <SessionRenameInput
+                    defaultValue={row.title}
+                    onConfirm={(v) => handleRenameConfirm(row.id, v)}
+                    onCancel={() => setRenamingSessionId(null)}
+                  />
+                ) : (
                   <>
-                    <div className="flex -space-x-1.5">
-                      {parts.slice(0, 3).map((p) => {
-                        const c = actorAvatarColor(p.actorId)
-                        return (
-                          <Avatar
-                            key={p.actorId}
-                            className={cn(
-                              'h-4 w-4 ring-1 ring-paper',
-                              p.isAgent ? 'rounded-[3px]' : 'rounded-full',
-                            )}
-                          >
-                            {p.avatarUrl && <AvatarImage src={p.avatarUrl} alt={p.displayName} />}
-                            <AvatarFallback
-                              className={cn(
-                                'text-[8px] font-semibold',
-                                p.isAgent ? 'rounded-[3px]' : 'rounded-full',
-                              )}
-                              style={{ background: c.bg, color: c.fg }}
-                            >
-                              {p.displayName.slice(0, 1).toUpperCase()}
-                            </AvatarFallback>
-                          </Avatar>
-                        )
-                      })}
+                    <button
+                      type="button"
+                      className="min-w-0 flex-1 truncate text-left text-[13px] font-semibold text-foreground"
+                      data-testid="v2-session-row-title"
+                      onClick={selectSession}
+                      onDoubleClick={(e) => {
+                        if (batchSelecting) return
+                        e.stopPropagation()
+                        handleStartRename(e, row.id)
+                      }}
+                    >
+                      {row.title || t('chat.newChat', 'New Chat')}
+                    </button>
+                    <div className="flex shrink-0 items-center">
+                      {!isActive && row.hasUnread && (
+                        <span
+                          className="mr-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-coral"
+                          aria-label={t('sidebar.unread', 'Unread')}
+                        />
+                      )}
+                      {!isActive && isHighlighted && (
+                        <span className="mr-1.5 shrink-0 rounded-full bg-coral px-1.5 py-px text-[10px] font-semibold leading-4 text-coral-foreground">
+                          {t('chat.newSessionBadge', 'NEW')}
+                        </span>
+                      )}
+                      {row.lastMessageAt && (
+                        <span className="shrink-0 px-0.5 text-[11px] leading-[22px] tabular-nums text-faint">
+                          {formatRelativeTime(row.lastMessageAt)}
+                        </span>
+                      )}
+                      {!batchSelecting && (
+                        <button
+                          type="button"
+                          data-testid="v2-session-row-more"
+                          aria-label={actionsOpen
+                            ? t('sidebar.closeActions', 'Close actions')
+                            : t('sidebar.moreActions', 'More actions')}
+                          aria-expanded={actionsOpen}
+                          aria-controls={actionsId}
+                          title={t('sidebar.moreActions', 'More actions')}
+                          className={cn(
+                            'inline-grid h-[22px] place-items-center overflow-hidden rounded-md text-muted-foreground',
+                            'w-0 opacity-0',
+                            'transition-[width,opacity,margin,background-color,color] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
+                            // Hover reveal. Avoid group-focus-within (selecting the row would pin ⋯).
+                            'group-hover/menu-item:ml-0.5 group-hover/menu-item:w-[22px] group-hover/menu-item:opacity-100',
+                            'focus-visible:ml-0.5 focus-visible:w-[22px] focus-visible:opacity-100',
+                            // Touch / no-hover: keep a hittable ⋯ without relying on hover.
+                            '[@media(hover:none)]:ml-0.5 [@media(hover:none)]:w-[22px] [@media(hover:none)]:opacity-100',
+                            'hover:bg-black/[0.08] hover:text-foreground dark:hover:bg-white/10',
+                            // While dock is open, keep ⋯ visible even after focus moves into the dock.
+                            actionsOpen && 'ml-0.5 w-[22px] bg-black/[0.08] text-foreground opacity-100 dark:bg-white/10',
+                          )}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setActionsOpenSessionId((prev) => {
+                              if (prev === row.id) return null
+                              requestAnimationFrame(() => {
+                                document.getElementById(`v2-session-action-pin-${row.id}`)?.focus()
+                              })
+                              return row.id
+                            })
+                          }}
+                        >
+                          {actionsOpen
+                            ? <X className="h-3 w-3" strokeWidth={2} />
+                            : <Ellipsis className="h-3 w-3" strokeWidth={2} />}
+                        </button>
+                      )}
                     </div>
-                    <span className="text-[10.5px] text-faint">
-                      {t('sidebar.participantCount', { count: parts.length, defaultValue: '{{count}} 位' })}
-                    </span>
                   </>
                 )}
-                <span className="flex-1" />
-                <SessionActivityBadge activity={activity} />
               </div>
-            )}
-            {/* C2: inline 2×2 icon dock — grid 0fr→1fr pushes the row down (mock session-more-actions-c). */}
-            {!isRenaming && !batchSelecting && (
-              <div
-                className={cn(
-                  'grid w-full transition-[grid-template-rows] duration-[260ms] ease-[cubic-bezier(0.22,1,0.36,1)]',
-                  actionsOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
-                )}
-                data-testid="v2-session-row-actions"
-                data-open={actionsOpen ? 'true' : 'false'}
-                aria-hidden={!actionsOpen}
-              >
-                <div className="min-h-0 overflow-hidden">
-                  <div
-                    className={cn(
-                      'mt-2 border-t border-border-soft pt-2',
-                      !actionsOpen && 'pointer-events-none',
-                    )}
-                  >
-                    <div className="grid grid-cols-4 gap-1">
-                      <span
-                        role="button"
-                        tabIndex={actionsOpen ? 0 : -1}
-                        title={row.isPinned ? t('sidebar.unpin', 'Unpin') : t('sidebar.pinToTop', 'Pin to top')}
-                        aria-label={row.isPinned ? t('sidebar.unpin', 'Unpin') : t('sidebar.pinToTop', 'Pin to top')}
-                        className="grid h-[34px] place-items-center rounded-lg bg-black/[0.045] text-ink-2 transition-colors hover:bg-black/[0.08] hover:text-foreground dark:bg-white/[0.06] dark:hover:bg-white/10"
-                        onClick={(e) => handleTogglePinned(e, row.id)}
-                        onKeyDown={(e) => {
-                          if (e.key !== 'Enter' && e.key !== ' ') return
-                          e.preventDefault()
-                          handleTogglePinned(e, row.id)
-                        }}
-                      >
-                        <Pin className={cn('h-3.5 w-3.5', row.isPinned && 'fill-amber-500/20 text-amber-500')} />
-                      </span>
-                      <span
-                        role="button"
-                        tabIndex={actionsOpen ? 0 : -1}
-                        title={t('sidebar.rename', 'Rename')}
-                        aria-label={t('sidebar.rename', 'Rename')}
-                        className="grid h-[34px] place-items-center rounded-lg bg-black/[0.045] text-ink-2 transition-colors hover:bg-black/[0.08] hover:text-foreground dark:bg-white/[0.06] dark:hover:bg-white/10"
-                        onClick={(e) => handleStartRename(e, row.id)}
-                        onKeyDown={(e) => {
-                          if (e.key !== 'Enter' && e.key !== ' ') return
-                          e.preventDefault()
-                          handleStartRename(e, row.id)
-                        }}
-                      >
-                        <Pencil className="h-3.5 w-3.5" />
-                      </span>
-                      <span
-                        role="button"
-                        tabIndex={actionsOpen ? 0 : -1}
-                        title={t('sidebar.viewDetail', 'View detail')}
-                        aria-label={t('sidebar.viewDetail', 'View detail')}
-                        className="grid h-[34px] place-items-center rounded-lg bg-black/[0.045] text-ink-2 transition-colors hover:bg-black/[0.08] hover:text-foreground dark:bg-white/[0.06] dark:hover:bg-white/10"
-                        onClick={(e) => handleViewDetail(e, row)}
-                        onKeyDown={(e) => {
-                          if (e.key !== 'Enter' && e.key !== ' ') return
-                          e.preventDefault()
-                          handleViewDetail(e, row)
-                        }}
-                      >
-                        <Info className="h-3.5 w-3.5" />
-                      </span>
-                      <span
-                        role="button"
-                        tabIndex={actionsOpen ? 0 : -1}
-                        title={t('sidebar.archive', 'Archive')}
-                        aria-label={t('sidebar.archive', 'Archive')}
-                        className="grid h-[34px] place-items-center rounded-lg bg-black/[0.045] text-ink-2 transition-colors hover:bg-coral-soft hover:text-coral dark:bg-white/[0.06]"
-                        onClick={(e) => { void handleArchive(e, row.id) }}
-                        onKeyDown={(e) => {
-                          if (e.key !== 'Enter' && e.key !== ' ') return
-                          e.preventDefault()
-                          void handleArchive(e, row.id)
-                        }}
-                      >
-                        <Archive className="h-3.5 w-3.5" />
-                      </span>
+
+              {!isRenaming && (showWorkspaceSubline || row.lastMessagePreview || ((parts.length > 0 && !isSoloWithLocalAgent) || activity)) && (
+                <button
+                  type="button"
+                  className="flex w-full min-w-0 flex-col items-start gap-1 text-left"
+                  onClick={selectSession}
+                >
+                  {showWorkspaceSubline && (
+                    <span
+                      className="w-full truncate font-mono text-[10.5px] leading-tight text-faint"
+                      data-testid="v2-session-row-workspace"
+                    >
+                      {workspaceLabel}
+                    </span>
+                  )}
+                  {row.lastMessagePreview && (
+                    <span
+                      className={cn(
+                        'w-full truncate text-[12px] leading-snug text-muted-foreground transition-opacity duration-150',
+                        actionsOpen && 'opacity-50',
+                      )}
+                      data-testid="v2-session-row-preview"
+                    >
+                      {row.lastMessagePreview.split(/(@[\w.\-\u4e00-\u9fff]+)/g).map((part, i) =>
+                        part.startsWith('@') ? (
+                          <em key={i} className="font-medium not-italic text-coral">
+                            {part}
+                          </em>
+                        ) : (
+                          <React.Fragment key={i}>{part}</React.Fragment>
+                        ),
+                      )}
+                    </span>
+                  )}
+                  {((parts.length > 0 && !isSoloWithLocalAgent) || activity) && (
+                    <span className="flex w-full items-center gap-1.5" data-testid="v2-session-row-participants">
+                      {parts.length > 0 && !isSoloWithLocalAgent && (
+                        <>
+                          <span className="flex -space-x-1.5">
+                            {parts.slice(0, 3).map((p) => {
+                              const c = actorAvatarColor(p.actorId)
+                              return (
+                                <Avatar
+                                  key={p.actorId}
+                                  className={cn(
+                                    'h-4 w-4 ring-1 ring-paper',
+                                    p.isAgent ? 'rounded-[3px]' : 'rounded-full',
+                                  )}
+                                >
+                                  {p.avatarUrl && <AvatarImage src={p.avatarUrl} alt={p.displayName} />}
+                                  <AvatarFallback
+                                    className={cn(
+                                      'text-[8px] font-semibold',
+                                      p.isAgent ? 'rounded-[3px]' : 'rounded-full',
+                                    )}
+                                    style={{ background: c.bg, color: c.fg }}
+                                  >
+                                    {p.displayName.slice(0, 1).toUpperCase()}
+                                  </AvatarFallback>
+                                </Avatar>
+                              )
+                            })}
+                          </span>
+                          <span className="text-[10.5px] text-faint">
+                            {t('sidebar.participantCount', { count: parts.length, defaultValue: '{{count}} 位' })}
+                          </span>
+                        </>
+                      )}
+                      <span className="flex-1" />
+                      <SessionActivityBadge activity={activity} />
+                    </span>
+                  )}
+                </button>
+              )}
+
+              {/* C2 dock — sibling of select/more buttons, expands row height. */}
+              {!isRenaming && !batchSelecting && (
+                <div
+                  id={actionsId}
+                  role="group"
+                  aria-label={t('sidebar.moreActions', 'More actions')}
+                  className={cn(
+                    'grid w-full transition-[grid-template-rows] duration-[260ms] ease-[cubic-bezier(0.22,1,0.36,1)]',
+                    actionsOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+                  )}
+                  data-testid="v2-session-row-actions"
+                  data-open={actionsOpen ? 'true' : 'false'}
+                  aria-hidden={!actionsOpen}
+                >
+                  <div className="min-h-0 overflow-hidden">
+                    <div
+                      className={cn(
+                        'mt-2 border-t border-border-soft pt-2',
+                        !actionsOpen && 'pointer-events-none',
+                      )}
+                    >
+                      <div className="grid grid-cols-4 gap-1">
+                        <button
+                          type="button"
+                          id={`v2-session-action-pin-${row.id}`}
+                          tabIndex={actionsOpen ? 0 : -1}
+                          title={row.isPinned ? t('sidebar.unpin', 'Unpin') : t('sidebar.pinToTop', 'Pin to top')}
+                          aria-label={row.isPinned ? t('sidebar.unpin', 'Unpin') : t('sidebar.pinToTop', 'Pin to top')}
+                          className={actionBtnClass}
+                          onClick={(e) => handleTogglePinned(e, row.id)}
+                        >
+                          <Pin className={cn('h-3.5 w-3.5', row.isPinned && 'fill-amber-500/20 text-amber-500')} />
+                        </button>
+                        <button
+                          type="button"
+                          tabIndex={actionsOpen ? 0 : -1}
+                          title={t('sidebar.rename', 'Rename')}
+                          aria-label={t('sidebar.rename', 'Rename')}
+                          className={actionBtnClass}
+                          onClick={(e) => handleStartRename(e, row.id)}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          tabIndex={actionsOpen ? 0 : -1}
+                          title={t('sidebar.viewDetail', 'View detail')}
+                          aria-label={t('sidebar.viewDetail', 'View detail')}
+                          className={actionBtnClass}
+                          onClick={(e) => handleViewDetail(e, row)}
+                        >
+                          <Info className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          tabIndex={actionsOpen ? 0 : -1}
+                          title={t('sidebar.archive', 'Archive')}
+                          aria-label={t('sidebar.archive', 'Archive')}
+                          className={cn(actionBtnClass, 'hover:bg-coral-soft hover:text-coral')}
+                          onClick={(e) => { void handleArchive(e, row.id) }}
+                        >
+                          <Archive className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
             </div>
           </div>
-        </SidebarMenuButton>
+        </div>
       </SidebarMenuItem>
     )
   }

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -20,12 +20,6 @@ import { SidebarCollapseToggle } from '@/components/app-sidebar'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { AnimatedClock } from '@/components/ui/animated-clock'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import { SessionSearchDialog } from '@/components/sidebar/session-search-dialog'
 import { SessionDetailDialog, type SessionDetailListHints } from '@/components/sidebar/SessionDetailDialog'
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
@@ -214,6 +208,8 @@ export function SessionListColumn({
   const [searchOpen, setSearchOpen] = React.useState(false)
   const [creatingSession, setCreatingSession] = React.useState(false)
   const [renamingSessionId, setRenamingSessionId] = React.useState<string | null>(null)
+  /** C2 inline more-actions dock — at most one row open. */
+  const [actionsOpenSessionId, setActionsOpenSessionId] = React.useState<string | null>(null)
   const [detailSessionId, setDetailSessionId] = React.useState<string | null>(null)
   const [detailHints, setDetailHints] = React.useState<SessionDetailListHints | null>(null)
   const [actorSessionIds, setActorSessionIds] = React.useState<Set<string> | null>(null)
@@ -333,9 +329,9 @@ export function SessionListColumn({
   const sessionVirtualizer = useVirtualizer({
     count: shouldVirtualize ? virtualRows.length : 0,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => 64,
+    estimateSize: () => 56,
     overscan: 8,
-    gap: 4,
+    gap: 2,
     getItemKey: (index) => virtualRows[index].key,
   })
 
@@ -386,6 +382,7 @@ export function SessionListColumn({
   })()
 
   const handleSelectSession = (id: string) => {
+    setActionsOpenSessionId(null)
     void useUIStore.getState().switchToSession(id)
     // Narrow sheet / embed: selecting a session should close the list overlay.
     onDismiss?.()
@@ -444,6 +441,7 @@ export function SessionListColumn({
     setBatchSelecting(false)
     setBatchSelectedIds(new Set())
     setBatchConfirmOpen(false)
+    setActionsOpenSessionId(null)
   }, [
     filter.kind,
     filter.kind === 'idea' ? filter.ideaId : '',
@@ -458,6 +456,7 @@ export function SessionListColumn({
   }, [])
 
   const enterBatchSelect = React.useCallback(() => {
+    setActionsOpenSessionId(null)
     setBatchSelecting(true)
     setBatchSelectedIds(new Set())
     setBatchConfirmOpen(false)
@@ -512,7 +511,11 @@ export function SessionListColumn({
     }
   }, [archiveSession, batchArchiving, batchSelectedIds, exitBatchSelect, t])
 
-  const handleStartRename = (e: React.SyntheticEvent, id: string) => { e.stopPropagation(); setRenamingSessionId(id) }
+  const handleStartRename = (e: React.SyntheticEvent, id: string) => {
+    e.stopPropagation()
+    setActionsOpenSessionId(null)
+    setRenamingSessionId(id)
+  }
   const handleRenameConfirm = async (id: string, newTitle: string) => {
     const current = listRows.find((r) => r.id === id)?.title
     if (newTitle.trim() && newTitle !== current) {
@@ -521,13 +524,18 @@ export function SessionListColumn({
     }
     setRenamingSessionId(null)
   }
-  const handleArchive = async (e: React.SyntheticEvent, id: string) => { e.stopPropagation(); await archiveSession(id) }
+  const handleArchive = async (e: React.SyntheticEvent, id: string) => {
+    e.stopPropagation()
+    setActionsOpenSessionId(null)
+    await archiveSession(id)
+  }
   const handleTogglePinned = (e: React.SyntheticEvent, id: string) => {
     e.stopPropagation()
     toggleSessionPinned(id, teamIdFromList || null)
   }
   const handleViewDetail = (e: React.SyntheticEvent, row: ListRow) => {
     e.stopPropagation()
+    setActionsOpenSessionId(null)
     setDetailHints({
       title: row.title,
       ideaId: row.ideaId,
@@ -543,6 +551,7 @@ export function SessionListColumn({
     const isRenaming = renamingSessionId === row.id
     const isActive = row.id === activeSessionId
     const isBatchChecked = batchSelectedIds.has(row.id)
+    const actionsOpen = actionsOpenSessionId === row.id
     const activity = sessionActivityMap.get(row.id)
     const parts = participantsBySession[row.id] ?? []
     // Hide the participants row for solo sessions — only me and/or my own local
@@ -556,7 +565,17 @@ export function SessionListColumn({
     const workspaceLabel = sessionWorkspaceLabels.get(row.id)
     const showWorkspaceSubline = filter.kind !== 'workspace' && !!workspaceLabel
     return (
-      <SidebarMenuItem key={row.id}>
+      <SidebarMenuItem
+        key={row.id}
+        onMouseLeave={() => {
+          setActionsOpenSessionId((prev) => (prev === row.id ? null : prev))
+        }}
+        onBlur={(e) => {
+          const next = e.relatedTarget
+          if (next instanceof Node && e.currentTarget.contains(next)) return
+          setActionsOpenSessionId((prev) => (prev === row.id ? null : prev))
+        }}
+      >
         <SidebarMenuButton
           isActive={isActive && !batchSelecting}
           data-testid="v2-session-row"
@@ -564,12 +583,14 @@ export function SessionListColumn({
           data-active={isActive ? "true" : "false"}
           data-batch-checked={isBatchChecked ? "true" : "false"}
           className={cn(
-            // Direction B: paper-on-paper active state, 2px coral left bar.
-            // See AGENTS.md §2 "Session list".
-            'h-auto rounded-none py-3 pl-4 pr-4 transition-colors',
-            compactHeader && 'pl-2.5 pr-2.5',
+            // Soft Comfort: elevated paper capsule when active (no coral left bar).
+            // Horizontal inset comes from the list container padding — do not use
+            // mx-* with w-full or overflow-x-hidden will clip the right edge.
+            'my-px h-auto w-full rounded-[11px] px-2.5 py-2 transition-[background-color,box-shadow] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
+            compactHeader && 'px-2',
             isActive && !batchSelecting &&
-              "relative z-0 data-[active=true]:!bg-paper data-[active=true]:font-medium before:pointer-events-none before:absolute before:left-0 before:top-0 before:bottom-0 before:z-10 before:w-[2px] before:bg-coral before:content-['']",
+              'relative z-0 bg-paper font-medium shadow-[0_2px_8px_rgba(28,27,25,0.05),0_1px_2px_rgba(28,27,25,0.03)] ring-1 ring-black/[0.05] data-[active=true]:!bg-paper',
+            !isActive && !batchSelecting && 'hover:bg-black/[0.035]',
             isHighlighted && !isActive && !batchSelecting && 'bg-emerald-500/15 ring-1 ring-emerald-500/30',
             batchSelecting && isBatchChecked && 'bg-selected',
           )}
@@ -594,7 +615,7 @@ export function SessionListColumn({
                 aria-checked={isBatchChecked}
                 data-testid="v2-session-row-checkbox"
                 className={cn(
-                  'mt-0.5 mr-2.5 inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[4px] border-[1.5px]',
+                  'mt-0.5 mr-2 inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[4px] border-[1.5px]',
                   isBatchChecked
                     ? 'border-foreground bg-foreground text-background'
                     : 'border-foreground/20 bg-paper',
@@ -603,9 +624,9 @@ export function SessionListColumn({
                 {isBatchChecked ? <Check className="h-2.5 w-2.5" strokeWidth={3} /> : null}
               </span>
             ) : null}
-            <div className="flex min-w-0 flex-1 flex-col items-start gap-1.5">
-            {/* Title row: [pin] title [time] [NEW] */}
-            <div className="flex items-center gap-1.5 w-full">
+            <div className="flex min-w-0 flex-1 flex-col items-start gap-1">
+            {/* Title row: [pin] title [unread/NEW] [time][⋯] — ⋯ expands on hover and pushes time left (C2). */}
+            <div className="flex w-full min-w-0 items-center gap-1.5">
               {row.isPinned && <Pin className="h-3 w-3 shrink-0 text-amber-500 fill-amber-500/20" />}
               {isRenaming ? (
                 <SessionRenameInput
@@ -616,35 +637,73 @@ export function SessionListColumn({
               ) : (
                 <>
                   <span className={cn(
-                    'min-w-0 flex-1 truncate text-left text-[13px]',
-                    isActive ? 'font-semibold text-foreground' : 'font-medium text-foreground',
+                    'min-w-0 flex-1 truncate text-left text-[13px] font-semibold text-foreground',
                   )}
                   data-testid="v2-session-row-title"
                   >
                     {row.title || t('chat.newChat', 'New Chat')}
                   </span>
-                  {row.lastMessageAt && (
-                    <span className="shrink-0 font-mono text-[10.5px] text-faint">
-                      {formatRelativeTime(row.lastMessageAt)}
-                    </span>
-                  )}
-                  {!isActive && row.hasUnread && (
-                    <span
-                      className="h-1.5 w-1.5 shrink-0 rounded-full bg-coral"
-                      aria-label={t('sidebar.unread', 'Unread')}
-                    />
-                  )}
-                  {!isActive && isHighlighted && (
-                    <span className="shrink-0 rounded-full bg-coral px-1.5 py-px text-[10px] font-semibold leading-4 text-coral-foreground">
-                      {t('chat.newSessionBadge', 'NEW')}
-                    </span>
-                  )}
+                  <div className="flex shrink-0 items-center">
+                    {!isActive && row.hasUnread && (
+                      <span
+                        className="mr-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-coral"
+                        aria-label={t('sidebar.unread', 'Unread')}
+                      />
+                    )}
+                    {!isActive && isHighlighted && (
+                      <span className="mr-1.5 shrink-0 rounded-full bg-coral px-1.5 py-px text-[10px] font-semibold leading-4 text-coral-foreground">
+                        {t('chat.newSessionBadge', 'NEW')}
+                      </span>
+                    )}
+                    {row.lastMessageAt && (
+                      <span className="shrink-0 px-0.5 text-[11px] leading-[22px] tabular-nums text-faint">
+                        {formatRelativeTime(row.lastMessageAt)}
+                      </span>
+                    )}
+                    {!batchSelecting && (
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        data-testid="v2-session-row-more"
+                        aria-label={actionsOpen
+                          ? t('sidebar.closeActions', 'Close actions')
+                          : t('sidebar.moreActions', 'More actions')}
+                        aria-expanded={actionsOpen}
+                        title={t('sidebar.moreActions', 'More actions')}
+                        className={cn(
+                          'inline-grid h-[22px] place-items-center overflow-hidden rounded-md text-muted-foreground',
+                          'pointer-events-none w-0 opacity-0',
+                          'transition-[width,opacity,margin,background-color,color] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
+                          // Hover-only reveal. Do NOT use group-focus-within — selecting the row
+                          // focuses SidebarMenuButton and would pin ⋯ visible after mouse leave.
+                          'group-hover/menu-item:pointer-events-auto group-hover/menu-item:ml-0.5 group-hover/menu-item:w-[22px] group-hover/menu-item:opacity-100',
+                          'focus-visible:pointer-events-auto focus-visible:ml-0.5 focus-visible:w-[22px] focus-visible:opacity-100',
+                          'hover:bg-black/[0.08] hover:text-foreground dark:hover:bg-white/10',
+                          actionsOpen && 'bg-black/[0.08] text-foreground dark:bg-white/10',
+                        )}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          setActionsOpenSessionId((prev) => (prev === row.id ? null : row.id))
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key !== 'Enter' && e.key !== ' ') return
+                          e.preventDefault()
+                          e.stopPropagation()
+                          setActionsOpenSessionId((prev) => (prev === row.id ? null : row.id))
+                        }}
+                      >
+                        {actionsOpen
+                          ? <X className="h-3 w-3" strokeWidth={2} />
+                          : <Ellipsis className="h-3 w-3" strokeWidth={2} />}
+                      </span>
+                    )}
+                  </div>
                 </>
               )}
             </div>
             {!isRenaming && showWorkspaceSubline && (
               <span
-                className="w-full truncate font-mono text-[11px] text-faint"
+                className="w-full truncate font-mono text-[10.5px] leading-tight text-faint"
                 data-testid="v2-session-row-workspace"
               >
                 {workspaceLabel}
@@ -653,10 +712,21 @@ export function SessionListColumn({
             {/* Preview line: single line from last_message_preview. */}
             {!isRenaming && row.lastMessagePreview && (
               <div
-                className="w-full truncate text-[12px] leading-[1.45] text-muted-foreground"
+                className={cn(
+                  'w-full truncate text-[12px] leading-snug text-muted-foreground transition-opacity duration-150',
+                  actionsOpen && 'opacity-50',
+                )}
                 data-testid="v2-session-row-preview"
               >
-                {row.lastMessagePreview}
+                {row.lastMessagePreview.split(/(@[\w.\-\u4e00-\u9fff]+)/g).map((part, i) =>
+                  part.startsWith('@') ? (
+                    <em key={i} className="font-medium not-italic text-coral">
+                      {part}
+                    </em>
+                  ) : (
+                    <React.Fragment key={i}>{part}</React.Fragment>
+                  ),
+                )}
               </div>
             )}
             {/* Participants cluster + activity badge */}
@@ -698,53 +768,93 @@ export function SessionListColumn({
                 <SessionActivityBadge activity={activity} />
               </div>
             )}
+            {/* C2: inline 2×2 icon dock — grid 0fr→1fr pushes the row down (mock session-more-actions-c). */}
+            {!isRenaming && !batchSelecting && (
+              <div
+                className={cn(
+                  'grid w-full transition-[grid-template-rows] duration-[260ms] ease-[cubic-bezier(0.22,1,0.36,1)]',
+                  actionsOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+                )}
+                data-testid="v2-session-row-actions"
+                data-open={actionsOpen ? 'true' : 'false'}
+                aria-hidden={!actionsOpen}
+              >
+                <div className="min-h-0 overflow-hidden">
+                  <div
+                    className={cn(
+                      'mt-2 border-t border-border-soft pt-2',
+                      !actionsOpen && 'pointer-events-none',
+                    )}
+                  >
+                    <div className="grid grid-cols-4 gap-1">
+                      <span
+                        role="button"
+                        tabIndex={actionsOpen ? 0 : -1}
+                        title={row.isPinned ? t('sidebar.unpin', 'Unpin') : t('sidebar.pinToTop', 'Pin to top')}
+                        aria-label={row.isPinned ? t('sidebar.unpin', 'Unpin') : t('sidebar.pinToTop', 'Pin to top')}
+                        className="grid h-[34px] place-items-center rounded-lg bg-black/[0.045] text-ink-2 transition-colors hover:bg-black/[0.08] hover:text-foreground dark:bg-white/[0.06] dark:hover:bg-white/10"
+                        onClick={(e) => handleTogglePinned(e, row.id)}
+                        onKeyDown={(e) => {
+                          if (e.key !== 'Enter' && e.key !== ' ') return
+                          e.preventDefault()
+                          handleTogglePinned(e, row.id)
+                        }}
+                      >
+                        <Pin className={cn('h-3.5 w-3.5', row.isPinned && 'fill-amber-500/20 text-amber-500')} />
+                      </span>
+                      <span
+                        role="button"
+                        tabIndex={actionsOpen ? 0 : -1}
+                        title={t('sidebar.rename', 'Rename')}
+                        aria-label={t('sidebar.rename', 'Rename')}
+                        className="grid h-[34px] place-items-center rounded-lg bg-black/[0.045] text-ink-2 transition-colors hover:bg-black/[0.08] hover:text-foreground dark:bg-white/[0.06] dark:hover:bg-white/10"
+                        onClick={(e) => handleStartRename(e, row.id)}
+                        onKeyDown={(e) => {
+                          if (e.key !== 'Enter' && e.key !== ' ') return
+                          e.preventDefault()
+                          handleStartRename(e, row.id)
+                        }}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </span>
+                      <span
+                        role="button"
+                        tabIndex={actionsOpen ? 0 : -1}
+                        title={t('sidebar.viewDetail', 'View detail')}
+                        aria-label={t('sidebar.viewDetail', 'View detail')}
+                        className="grid h-[34px] place-items-center rounded-lg bg-black/[0.045] text-ink-2 transition-colors hover:bg-black/[0.08] hover:text-foreground dark:bg-white/[0.06] dark:hover:bg-white/10"
+                        onClick={(e) => handleViewDetail(e, row)}
+                        onKeyDown={(e) => {
+                          if (e.key !== 'Enter' && e.key !== ' ') return
+                          e.preventDefault()
+                          handleViewDetail(e, row)
+                        }}
+                      >
+                        <Info className="h-3.5 w-3.5" />
+                      </span>
+                      <span
+                        role="button"
+                        tabIndex={actionsOpen ? 0 : -1}
+                        title={t('sidebar.archive', 'Archive')}
+                        aria-label={t('sidebar.archive', 'Archive')}
+                        className="grid h-[34px] place-items-center rounded-lg bg-black/[0.045] text-ink-2 transition-colors hover:bg-coral-soft hover:text-coral dark:bg-white/[0.06]"
+                        onClick={(e) => { void handleArchive(e, row.id) }}
+                        onKeyDown={(e) => {
+                          if (e.key !== 'Enter' && e.key !== ' ') return
+                          e.preventDefault()
+                          void handleArchive(e, row.id)
+                        }}
+                      >
+                        <Archive className="h-3.5 w-3.5" />
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
             </div>
           </div>
         </SidebarMenuButton>
-        {/* Direction B: ellipsis menu sits on row 3 (avatars row), right-aligned.
-            Avoids overlapping title & preview text. AGENTS.md §2.
-            Hidden while renaming / batch-selecting so the trigger does not overlap. */}
-        {!isRenaming && !batchSelecting && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="absolute right-2 bottom-2 h-6 w-6 opacity-0 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 transition-opacity hover:bg-black/10 dark:hover:bg-white/10 rounded-md"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Ellipsis className="h-3 w-3" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                className="text-[13px]"
-                onClick={(e) => handleTogglePinned(e as React.SyntheticEvent, row.id)}
-              >
-                <Pin className="h-3.5 w-3.5 mr-2" />
-                {row.isPinned ? t('sidebar.unpin', 'Unpin') : t('sidebar.pinToTop', 'Pin to top')}
-              </DropdownMenuItem>
-              <DropdownMenuItem className="text-[13px]" onClick={(e) => handleStartRename(e, row.id)}>
-                <Pencil className="h-3.5 w-3.5 mr-2" />
-                {t('sidebar.rename', 'Rename')}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="text-[13px]"
-                onClick={(e) => handleViewDetail(e, row)}
-              >
-                <Info className="h-3.5 w-3.5 mr-2" />
-                {t('sidebar.viewDetail', 'View detail')}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="text-[13px]"
-                onClick={(e) => handleArchive(e as React.SyntheticEvent, row.id)}
-              >
-                <Archive className="h-3.5 w-3.5 mr-2" />
-                {t('sidebar.archive', 'Archive')}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
       </SidebarMenuItem>
     )
   }
@@ -777,7 +887,7 @@ export function SessionListColumn({
   return (
     <div
       ref={columnRef}
-      className="flex h-full flex-col min-w-0 border-r border-border bg-background"
+      className="flex h-full flex-col min-w-0 border-r border-black/[0.06] bg-[#F8F7F4] dark:border-border dark:bg-background"
       data-testid="v2-session-list-column"
     >
       <SessionSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
@@ -799,8 +909,8 @@ export function SessionListColumn({
 
       <div
         className={cn(
-          'flex min-w-0 items-center justify-between gap-1 border-b border-border py-3',
-          compactHeader ? 'px-2' : 'px-4',
+          'flex min-w-0 items-center justify-between gap-1 py-3',
+          compactHeader ? 'px-2' : 'px-3.5',
         )}
         data-tauri-drag-region
       >
@@ -813,12 +923,15 @@ export function SessionListColumn({
         <div className="min-w-0 flex-1">
           <div
             className={cn(
-              'truncate font-bold tracking-tight text-foreground',
-              compactHeader ? 'text-[14px]' : 'text-[15px]',
+              'flex items-center gap-2 truncate font-bold tracking-tight text-foreground',
+              compactHeader ? 'text-[14px]' : 'text-[14px]',
             )}
           >
-            {title}{' '}
-            <span className="font-mono text-[11px] font-normal text-faint">
+            <span className="truncate">{title}</span>
+            <span
+              className="inline-flex h-5 shrink-0 items-center rounded-full bg-black/[0.05] px-2 font-mono text-[11px] font-medium text-muted-foreground dark:bg-white/10"
+              data-testid="v2-session-list-count"
+            >
               · {filteredRows.length}
             </span>
           </div>
@@ -958,7 +1071,7 @@ export function SessionListColumn({
         </div>
       ) : null}
 
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-2">
         {filter.kind === 'actor' && actorLoading ? (
           <div className="flex items-center justify-center py-8">
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />

--- a/packages/app/src/components/sidebar/TeamShareNavSection.tsx
+++ b/packages/app/src/components/sidebar/TeamShareNavSection.tsx
@@ -33,8 +33,10 @@ function SectionRow({ label, icon: Icon, active, count, onClick }: RowProps) {
       type="button"
       onClick={onClick}
       className={cn(
-        'flex w-full items-center gap-2.5 rounded-md px-[9px] py-[7px] text-left text-[13px] transition-colors',
-        active ? 'bg-selected font-semibold text-foreground' : 'text-ink-2 hover:bg-selected/60',
+        'flex w-full items-center gap-2.5 rounded-lg px-[9px] py-[7px] text-left text-[13px] transition-[background-color,box-shadow,color] duration-150',
+        active
+          ? 'bg-paper font-semibold text-foreground shadow-[0_1px_2px_rgba(28,27,25,0.04)] ring-1 ring-black/[0.05]'
+          : 'text-ink-2 hover:bg-black/[0.04]',
       )}
     >
       <Icon className={cn('h-[15px] w-[15px] shrink-0', active ? 'text-foreground' : 'text-muted-foreground')} />

--- a/packages/app/src/components/sidebar/__tests__/ActorRow.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/ActorRow.test.tsx
@@ -41,8 +41,8 @@ function setup(overrides: Partial<React.ComponentProps<typeof ActorRow>> = {}) {
     onCopyId: vi.fn(),
     onRequestRemove: vi.fn(),
   }
-  render(<ActorRow actor={baseActor} active={false} {...handlers} {...overrides} />)
-  return handlers
+  const view = render(<ActorRow actor={baseActor} active={false} {...handlers} {...overrides} />)
+  return { ...handlers, ...view }
 }
 
 function openMenu() {
@@ -59,8 +59,8 @@ describe('ActorRow', () => {
     expect(h.onSelect).toHaveBeenCalledWith(baseActor)
   })
 
-  it('labels agent actors as Agent', () => {
-    setup({
+  it('renders agent actors with a square avatar (no Agent text badge)', () => {
+    const { container } = setup({
       actor: {
         ...baseActor,
         actor_type: 'agent',
@@ -68,8 +68,11 @@ describe('ActorRow', () => {
       },
     })
 
-    expect(screen.getByText('Agent')).toBeInTheDocument()
+    expect(screen.getByText('Macmini')).toBeInTheDocument()
+    expect(screen.queryByText('Agent')).not.toBeInTheDocument()
     expect(screen.queryByText('AI')).not.toBeInTheDocument()
+    expect(container.querySelector('.rounded')).toBeTruthy()
+    expect(container.querySelector('.rounded-full')).toBeNull()
   })
 
   it('right click → View profile → onViewDetail', async () => {

--- a/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
@@ -251,6 +251,37 @@ describe('SessionListColumn', () => {
     expect(screen.getAllByTestId('v2-session-row-actions').every((el) => el.getAttribute('data-open') === 'false')).toBe(true)
   })
 
+  it('keeps only one more-actions dock open at a time', () => {
+    render(<SessionListColumn />)
+    const mores = screen.getAllByTestId('v2-session-row-more')
+    fireEvent.click(mores[0])
+    fireEvent.click(mores[1])
+    const openDocks = screen.getAllByTestId('v2-session-row-actions').filter((el) => el.getAttribute('data-open') === 'true')
+    expect(openDocks).toHaveLength(1)
+  })
+
+  it('closes the more-actions dock on Escape without selecting the session', () => {
+    const switchToSession = vi.spyOn(useUIStore.getState(), 'switchToSession').mockResolvedValue()
+    render(<SessionListColumn />)
+    const more = screen.getAllByTestId('v2-session-row-more')[0]
+    fireEvent.click(more)
+    const row = more.closest('li')!
+    fireEvent.keyDown(row, { key: 'Escape' })
+    expect(screen.getAllByTestId('v2-session-row-actions').every((el) => el.getAttribute('data-open') === 'false')).toBe(true)
+    expect(switchToSession).not.toHaveBeenCalled()
+    switchToSession.mockRestore()
+  })
+
+  it('does not select the session when clicking a dock action', () => {
+    const switchToSession = vi.spyOn(useUIStore.getState(), 'switchToSession').mockResolvedValue()
+    render(<SessionListColumn />)
+    fireEvent.click(screen.getAllByTestId('v2-session-row-more')[0])
+    const open = screen.getAllByTestId('v2-session-row-actions').find((el) => el.getAttribute('data-open') === 'true')
+    fireEvent.click(within(open!).getByLabelText(/重命名|Rename/))
+    expect(switchToSession).not.toHaveBeenCalled()
+    switchToSession.mockRestore()
+  })
+
   it('filters by ideaId in "idea" mode', () => {
     useUIStore.setState({ sidebarFilter: { kind: 'idea', ideaId: 'idea-1', title: 'I' } })
     render(<SessionListColumn />)
@@ -319,9 +350,9 @@ describe('SessionListColumn', () => {
     const switchToSession = vi.spyOn(useUIStore.getState(), 'switchToSession').mockResolvedValue()
     render(<SessionListColumn onDismiss={onDismiss} />)
 
-    const row = screen.getAllByTestId('v2-session-row').find((el) => el.getAttribute('data-session-id') === 's1')
-    expect(row).toBeTruthy()
-    fireEvent.click(row!)
+    const title = screen.getAllByTestId('v2-session-row-title').find((el) => el.textContent === 'Alpha')
+    expect(title).toBeTruthy()
+    fireEvent.click(title!)
     expect(switchToSession).toHaveBeenCalledWith('s1')
     expect(onDismiss).toHaveBeenCalledTimes(1)
     switchToSession.mockRestore()

--- a/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { SessionListColumn } from '../SessionListColumn'
 import { useUIStore } from '@/stores/ui'
 import { useSessionListStore } from '@/stores/session-list-store'
 import { useSessionStore } from '@/stores/session'
 import { useCronStore } from '@/stores/cron'
 import { useWorkspaceStore } from '@/stores/workspace'
+import { appShortName } from '@/lib/build-config'
 
 vi.mock('@/components/sidebar/session-search-dialog', () => ({
   SessionSearchDialog: () => null,
@@ -17,8 +18,13 @@ vi.mock('@/components/sidebar/session-search-dialog', () => ({
 // and stub useSidebar to return an expanded sidebar by default.
 vi.mock('@/components/ui/sidebar', () => ({
   SidebarMenu: ({ children }: { children: React.ReactNode }) => <ul>{children}</ul>,
-  SidebarMenuItem: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-    <li className={['group/menu-item relative list-none', className].filter(Boolean).join(' ')}>{children}</li>
+  SidebarMenuItem: ({ children, className, ...rest }: React.ComponentProps<'li'>) => (
+    <li
+      className={['group/menu-item relative list-none', className].filter(Boolean).join(' ')}
+      {...rest}
+    >
+      {children}
+    </li>
   ),
   SidebarMenuButton: ({ children, isActive: _isActive, ...rest }: React.ComponentProps<'button'> & { isActive?: boolean }) => (
     <button {...rest}>{children}</button>
@@ -61,6 +67,12 @@ vi.mock('@/stores/current-team', () => ({
   ),
 }))
 
+const PINNED_STORAGE_KEY = `${appShortName}-pinned-sessions`
+
+const setPinnedStorage = (idsByTeam: Record<string, string[]>) => {
+  localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify(idsByTeam))
+}
+
 const mkSessionRow = (over: Partial<{
   id: string
   title: string
@@ -94,7 +106,7 @@ const mkRow = (over: Partial<{ id: string; title: string; ideaId: string | null;
 
 describe('SessionListColumn', () => {
   beforeEach(() => {
-    localStorage.setItem('teamclaw-pinned-sessions', JSON.stringify({ 'team-1': ['s1'] }))
+    setPinnedStorage({ 'team-1': ['s1'] })
     useUIStore.setState({ sidebarFilter: { kind: 'all' }, embedMode: false })
     createQuickSession.mockReset()
     createQuickSession.mockResolvedValue({ ok: true, sessionId: 'sess-new', agentDisplayName: 'MACPRO' })
@@ -146,7 +158,7 @@ describe('SessionListColumn', () => {
     expect(screen.getByText('Alpha')).toBeInTheDocument()
     expect(screen.queryByText('Beta')).not.toBeInTheDocument()
     expect(screen.getByText('Gamma')).toBeInTheDocument()
-    expect(screen.getByText(/Sessions|会话/)).toHaveTextContent('· 2')
+    expect(screen.getByTestId('v2-session-list-count')).toHaveTextContent('· 2')
   })
 
   it('shows only cron sessions when the clock view is active', () => {
@@ -157,10 +169,11 @@ describe('SessionListColumn', () => {
     expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
     expect(screen.getByText('Beta')).toBeInTheDocument()
     expect(screen.queryByText('Gamma')).not.toBeInTheDocument()
-    expect(screen.getByText(/Scheduled sessions|定时会话/)).toHaveTextContent('· 1')
+    expect(screen.getByTestId('v2-session-list-count')).toHaveTextContent('· 1')
   })
 
   it('does not let the clock view leak into the Pinned filter', () => {
+    setPinnedStorage({ 'team-1': ['s1', 's2'] })
     useSessionListStore.setState({
       rows: [
         mkSessionRow({ id: 's1', title: 'Pinned regular' }),
@@ -184,6 +197,7 @@ describe('SessionListColumn', () => {
   })
 
   it('shows pinned sessions above regular sessions with a divider in "all" mode', () => {
+    setPinnedStorage({ 'team-1': ['s1'] })
     useSessionListStore.setState({
       rows: [
         mkSessionRow({ id: 's1', title: 'Pinned old', last_message_at: '2026-05-15T08:00:00.000Z' }),
@@ -208,6 +222,33 @@ describe('SessionListColumn', () => {
     render(<SessionListColumn />)
     expect(screen.getByText('Alpha')).toBeInTheDocument()
     expect(screen.queryByText('Beta')).not.toBeInTheDocument()
+  })
+
+  it('opens inline C2 more-actions dock from the trailing more control', () => {
+    render(<SessionListColumn />)
+    const docks = screen.getAllByTestId('v2-session-row-actions')
+    expect(docks.every((el) => el.getAttribute('data-open') === 'false')).toBe(true)
+
+    fireEvent.click(screen.getAllByTestId('v2-session-row-more')[0])
+
+    const open = screen.getAllByTestId('v2-session-row-actions').find((el) => el.getAttribute('data-open') === 'true')
+    expect(open).toBeTruthy()
+    expect(within(open!).getByLabelText(/取消固定|Unpin|固定到顶部|Pin to top/)).toBeInTheDocument()
+    expect(within(open!).getByLabelText(/重命名|Rename/)).toBeInTheDocument()
+    expect(within(open!).getByLabelText(/查看详情|View detail/)).toBeInTheDocument()
+    expect(within(open!).getByLabelText(/归档|Archive/)).toBeInTheDocument()
+  })
+
+  it('collapses the more-actions dock when the session row loses hover', () => {
+    render(<SessionListColumn />)
+    const more = screen.getAllByTestId('v2-session-row-more')[0]
+    fireEvent.click(more)
+    expect(screen.getAllByTestId('v2-session-row-actions').some((el) => el.getAttribute('data-open') === 'true')).toBe(true)
+
+    const row = more.closest('li')
+    expect(row).toBeTruthy()
+    fireEvent.mouseLeave(row!)
+    expect(screen.getAllByTestId('v2-session-row-actions').every((el) => el.getAttribute('data-open') === 'false')).toBe(true)
   })
 
   it('filters by ideaId in "idea" mode', () => {

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -773,6 +773,8 @@
     "noSessionsFound": "No sessions found",
     "pinToTop": "Pin to top",
     "unpin": "Unpin",
+    "moreActions": "More actions",
+    "closeActions": "Close actions",
     "awaitingConfirmation": "Awaiting confirmation",
     "sessionRunning": "Running",
     "loadMore": "Load More",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -773,6 +773,8 @@
     "noSessionsFound": "未找到会话",
     "pinToTop": "固定到顶部",
     "unpin": "取消固定",
+    "moreActions": "更多操作",
+    "closeActions": "关闭操作",
     "awaitingConfirmation": "等待确认",
     "sessionRunning": "运行中",
     "loadMore": "加载更多",

--- a/packages/app/src/styles/globals.css
+++ b/packages/app/src/styles/globals.css
@@ -11,8 +11,8 @@
     --background: #fbfaf7;
     --foreground: #1a1a14;
     --paper: #ffffff;
-    --panel: #efece4;
-    --selected: #e7e2d6;
+    --panel: #EFEEE9;
+    --selected: #E8E6E0;
     --ink-2: #3d3c34;
     --faint: #a8a6a0;
 
@@ -22,11 +22,11 @@
     --popover-foreground: #1a1a14;
     --primary: #1a1a14;
     --primary-foreground: #fefdfa;
-    --secondary: #efece4;
+    --secondary: #EFEEE9;
     --secondary-foreground: #1a1a14;
-    --muted: #efece4;
+    --muted: #EFEEE9;
     --muted-foreground: #75736a;
-    --accent: #e7e2d6;
+    --accent: #E8E6E0;
     --accent-foreground: #1a1a14;
     --destructive: oklch(0.577 0.245 27.325);
     --border: rgba(26, 26, 20, 0.08);
@@ -56,13 +56,13 @@
     --chart-3: oklch(0.398 0.07 227.392);
     --chart-4: oklch(0.828 0.189 84.429);
     --chart-5: oklch(0.769 0.188 70.08);
-    --sidebar: #efece4;
+    --sidebar: #EFEEE9;
     --sidebar-foreground: #1a1a14;
     --sidebar-primary: #1a1a14;
     --sidebar-primary-foreground: #fefdfa;
-    --sidebar-accent: #e7e2d6;
+    --sidebar-accent: #E8E6E0;
     --sidebar-accent-foreground: #1a1a14;
-    --sidebar-border: rgba(26, 26, 20, 0.08);
+    --sidebar-border: rgba(26, 26, 20, 0.06);
     --sidebar-ring: rgba(26, 26, 20, 0.18);
 }
 


### PR DESCRIPTION
## Summary
- Soft Comfort restyle for the left nav + session list (paper capsules, quieter coral usage, denser session rows)
- Replace session-row `DropdownMenu` with C2 hover ⋯ + inline 4-icon dock (pin / rename / detail / archive), with push-down expand animation and collapse on mouse leave
- Keep MYBOT brand runtime icon; add design mocks under `docs/design-mock/`

## Test plan
- [ ] Hover a session row: ⋯ appears and pushes time left; leave hover: ⋯ hides
- [ ] Click ⋯: inline dock expands downward; leave the row: dock collapses
- [ ] Pin / rename / detail / archive still work; only one dock open at a time
- [ ] Active session card has Soft Comfort paper elevation (no coral left bar)
- [ ] MYBOT card still shows runtime brand icon (not letter initials)
- [ ] `pnpm --filter @teamclaw/app exec vitest run src/components/sidebar/__tests__/SessionListColumn.test.tsx`


Made with [Cursor](https://cursor.com)