### PR TITLE
fix(ui): make the whole session card clickable again

### DIFF
--- a/build.config.dev.json
+++ b/build.config.dev.json
@@ -28,7 +28,7 @@
     "teamShareBrowser": true,
     "apps": true
   },
-  "localAgent": "pi",
+  "localAgent": "opencode",
   "defaults": {
     "theme": "system"
   }

--- a/docs/design-mock/chat-inline-code.html
+++ b/docs/design-mock/chat-inline-code.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>行内代码 · 效果图 · 基于 TeamClaw 黑白底</title>
+<style>
+  :root {
+    --font: "PingFang SC", "Noto Sans SC", Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    --mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+  }
+
+  /* App tokens — packages/app/src/styles/globals.css */
+  .t-light {
+    --bg: #fbfaf7;
+    --paper: #ffffff;
+    --panel: #EFEEE9;
+    --selected: #E8E6E0;
+    --ink: #1a1a14;
+    --ink-2: #3d3c34;
+    --mute: #75736a;
+    --faint: #a8a6a0;
+    --border: rgba(26, 26, 20, 0.08);
+    --border-soft: rgba(26, 26, 20, 0.05);
+  }
+  .t-dark {
+    --bg: oklch(0.145 0 0);
+    --paper: oklch(0.205 0 0);
+    --panel: oklch(0.205 0 0);
+    --selected: oklch(0.269 0 0);
+    --ink: oklch(0.985 0 0);
+    --ink-2: oklch(0.85 0 0);
+    --mute: oklch(0.708 0 0);
+    --faint: oklch(0.556 0 0);
+    --border: oklch(1 0 0 / 10%);
+    --border-soft: oklch(1 0 0 / 6%);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--font);
+    background: #e6e3dc;
+    color: #1a1a14;
+    padding: 28px 20px 80px;
+    -webkit-font-smoothing: antialiased;
+  }
+  body.page-dark { background: #0a0a0a; color: rgba(255,255,255,0.72); }
+
+  .page-h { max-width: 1120px; margin: 0 auto 16px; }
+  .page-h h1 { font-size: 16px; font-weight: 650; }
+  .page-h p { margin-top: 6px; font-size: 13px; line-height: 1.55; opacity: 0.72; }
+
+  .tabs {
+    max-width: 1120px; margin: 0 auto 14px;
+    display: flex; flex-wrap: wrap; gap: 6px;
+  }
+  .tabs button {
+    font: inherit; border: none; cursor: pointer;
+    height: 30px; padding: 0 12px; border-radius: 8px;
+    background: rgba(0,0,0,0.05); color: inherit; opacity: 0.75;
+    font-size: 12.5px; font-weight: 560;
+  }
+  body.page-dark .tabs button { background: rgba(255,255,255,0.06); }
+  .tabs button.on {
+    opacity: 1; background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  }
+  body.page-dark .tabs button.on {
+    background: oklch(0.205 0 0); box-shadow: 0 0 0 1px rgba(255,255,255,0.1);
+  }
+
+  .stage {
+    max-width: 1120px; margin: 0 auto;
+    display: grid; gap: 14px;
+  }
+  .stage.dual { grid-template-columns: 1fr 1fr; }
+  @media (max-width: 900px) { .stage.dual { grid-template-columns: 1fr; } }
+
+  .frame {
+    background: var(--bg);
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  }
+  body.page-dark .frame { box-shadow: 0 0 0 1px rgba(255,255,255,0.08); }
+  .frame-label {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border-soft);
+    font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
+    text-transform: uppercase; color: var(--faint);
+    background: var(--paper);
+  }
+  .msg {
+    padding: 18px 22px 22px;
+    color: var(--ink);
+    font-size: 14.5px;
+    line-height: 1.6;
+  }
+  .msg p { margin: 0.4em 0 0.75em; color: var(--ink-2); }
+  .msg p strong { color: var(--ink); font-weight: 600; }
+
+  table {
+    width: 100%; border-collapse: collapse;
+    font-size: 13px; margin: 0.6em 0 1em;
+  }
+  th, td {
+    padding: 7px 10px; text-align: left; vertical-align: top;
+    border: 1px solid var(--border);
+  }
+  th { font-weight: 600; color: var(--ink); }
+  td { color: var(--ink-2); }
+  ul { margin: 0.4em 0 0; padding-left: 1.35em; color: var(--ink-2); }
+  li { margin: 0.28em 0; }
+  .opt-tag {
+    display: inline-block; margin-bottom: 10px;
+    font-size: 11px; font-weight: 650; letter-spacing: 0.04em;
+    color: var(--mute);
+  }
+  .opt-tag b { color: var(--ink); font-weight: 700; }
+
+  /* —— variants —— */
+  code { font-family: var(--mono); font-size: 0.86em; }
+
+  /* 0 · 现状（粉红 Notion） */
+  .v0 code {
+    background: rgba(135,131,120,0.15);
+    color: #eb5757;
+    border-radius: 4px;
+    padding: 0.15em 0.4em;
+  }
+  .t-dark .v0 code {
+    background: rgba(135,131,120,0.28);
+    color: #ff7369;
+  }
+
+  /* 1 · 上一版（描边灰盒）— 你说更丑 */
+  .v1 code {
+    background: color-mix(in srgb, var(--ink) 5.5%, transparent);
+    color: var(--ink-2);
+    border: 1px solid color-mix(in srgb, var(--ink) 7%, transparent);
+    border-radius: 3px;
+    padding: 0.1em 0.32em;
+  }
+
+  /* A · Soft panel — 用 --selected / --panel 填色，无描边 */
+  .va code {
+    background: var(--selected);
+    color: var(--ink);
+    border-radius: 4px;
+    padding: 0.12em 0.36em;
+  }
+
+  /* B · Ghost mono — 无底无边，仅等宽 + 略深字色 */
+  .vb code {
+    background: transparent;
+    color: var(--ink);
+    padding: 0;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+  }
+
+  /* C · Paper inset — paper 上浅 panel 底，极轻 */
+  .vc code {
+    background: var(--panel);
+    color: var(--ink-2);
+    border-radius: 3px;
+    padding: 0.08em 0.3em;
+    box-shadow: inset 0 0 0 1px var(--border-soft);
+  }
+
+  /* D · Underline tick — 底线标记，表格最不吵 */
+  .vd code {
+    background: transparent;
+    color: var(--ink);
+    padding: 0 1px;
+    border-bottom: 1px solid color-mix(in srgb, var(--ink) 22%, transparent);
+    border-radius: 0;
+  }
+
+  .cards { display: none; }
+  .cards.show { display: contents; }
+  .single-card { display: none; }
+  .single-card.show { display: block; }
+
+  .pick {
+    max-width: 1120px; margin: 18px auto 0;
+    padding: 12px 14px; border-radius: 10px;
+    background: rgba(255,255,255,0.7);
+    font-size: 12.5px; line-height: 1.5;
+  }
+  body.page-dark .pick { background: rgba(255,255,255,0.04); }
+  .pick strong { font-weight: 650; }
+</style>
+</head>
+<body>
+  <div class="page-h">
+    <h1>行内代码效果图 · TeamClaw 真实底色</h1>
+    <p>
+      Light：<code style="font-family:var(--mono);font-size:12px">bg #fbfaf7 · paper #fff · panel #EFEEE9 · selected #E8E6E0</code><br />
+      Dark：<code style="font-family:var(--mono);font-size:12px">bg oklch(0.145) · paper/panel oklch(0.205) · selected oklch(0.269)</code>
+      · 用进程表密排场景压测。点方案切换；推荐先看 <b>A / B / D</b>。
+    </p>
+  </div>
+
+  <div class="tabs" id="tabs">
+    <button type="button" data-view="compare" class="on">Light / Dark 对照</button>
+    <button type="button" data-view="v0">0 粉红（旧）</button>
+    <button type="button" data-view="v1">1 描边灰（更丑）</button>
+    <button type="button" data-view="va" class="">A Soft panel</button>
+    <button type="button" data-view="vb">B Ghost mono</button>
+    <button type="button" data-view="vc">C Paper inset</button>
+    <button type="button" data-view="vd">D Underline</button>
+  </div>
+
+  <div class="stage dual" id="stage">
+    <!-- filled by JS -->
+  </div>
+
+  <div class="pick">
+    <strong>怎么选：</strong>
+    表格里 PID/路径很多时，带色盒子会变成「粉斑/灰斑墙」。
+    <b>B</b> 最干净；<b>D</b> 有一点代码感但不抢；<b>A</b> 有 chip 但仍贴面板色。
+    选定后告诉我字母，我再改代码。
+  </div>
+
+<script>
+const SAMPLE = `
+<p>先检查本机进程表中包含 <code>amuxd</code> 的进程，再根据父子进程关系补充关联进程。</p>
+<p>找到 <strong>2</strong> 个活跃主进程，以及几个异常/残留的 <code>--version</code> 进程。</p>
+<table>
+  <thead><tr><th>PID</th><th>PPID</th><th>状态</th><th>进程</th></tr></thead>
+  <tbody>
+    <tr><td><code>39481</code></td><td><code>32232</code></td><td><code>S</code></td><td><code>amuxd-aarch64-apple-darwin start</code></td></tr>
+    <tr><td><code>46344</code></td><td><code>39500</code></td><td><code>S</code></td><td><code>remote-tools-mcp --sock=…/amuxd.sock</code></td></tr>
+    <tr><td><code>33354</code></td><td><code>33352</code></td><td><code>S+</code></td><td><code>node scripts/tauri-cli.js dev --force-amuxd</code></td></tr>
+    <tr><td><code>62329</code></td><td><code>1</code></td><td><code>UE</code></td><td><code>amuxd-aarch64-apple-darwin --version</code></td></tr>
+  </tbody>
+</table>
+<ul>
+  <li>主服务 <code>PID 39481</code>，监听 <code>127.0.0.1:56007</code>，socket <code>~/.amuxd/amuxd.sock</code></li>
+  <li>日志：<code>/Users/haigang.ye/.amuxd/amuxd.managed.log</code></li>
+  <li>孤儿：<code>62329/63504/63690</code>，PPID=<code>1</code>，状态 <code>UE</code></li>
+</ul>
+`;
+
+const VARIANTS = [
+  { id: 'v0', name: '0 · 粉红 Notion', note: '现状/旧稿 · 密排很吵' },
+  { id: 'v1', name: '1 · 描边灰盒', note: '上一版 · 你说更丑' },
+  { id: 'va', name: 'A · Soft panel', note: 'selected 填色 · 无描边' },
+  { id: 'vb', name: 'B · Ghost mono', note: '无底无边 · 仅等宽字' },
+  { id: 'vc', name: 'C · Paper inset', note: 'panel 底 + soft inset' },
+  { id: 'vd', name: 'D · Underline', note: '底线标记 · 表格最安静' },
+];
+
+function frame(theme, variant, labelExtra) {
+  const v = VARIANTS.find(x => x.id === variant);
+  return `
+  <div class="frame ${theme}">
+    <div class="frame-label"><span>${theme === 't-light' ? 'Light · #fbfaf7' : 'Dark · oklch(0.145)'}</span><span>${labelExtra || ''}</span></div>
+    <div class="msg ${variant}">
+      <div class="opt-tag"><b>${v.name}</b> — ${v.note}</div>
+      ${SAMPLE}
+    </div>
+  </div>`;
+}
+
+const stage = document.getElementById('stage');
+const tabs = document.getElementById('tabs');
+
+function render(view) {
+  document.body.classList.toggle('page-dark', view !== 'compare' && false);
+  // page chrome follows dual always light-ish; frames carry theme
+  if (view === 'compare') {
+    stage.className = 'stage dual';
+    // show A as default compare hero? show all pairs stacked — too long.
+    // Compare: show A and B as recommended pair? User wants all options.
+    // Better: dual columns = light/dark for ONE selected; for compare show A light | A dark then note tabs for others.
+    stage.innerHTML = frame('t-light', 'va') + frame('t-dark', 'va')
+      + frame('t-light', 'vb') + frame('t-dark', 'vb')
+      + frame('t-light', 'vd') + frame('t-dark', 'vd');
+    document.body.classList.remove('page-dark');
+    return;
+  }
+  stage.className = 'stage dual';
+  stage.innerHTML = frame('t-light', view) + frame('t-dark', view);
+  document.body.classList.toggle('page-dark', false);
+}
+
+tabs.addEventListener('click', (e) => {
+  const btn = e.target.closest('button[data-view]');
+  if (!btn) return;
+  tabs.querySelectorAll('button').forEach(b => b.classList.toggle('on', b === btn));
+  render(btn.dataset.view);
+});
+
+render('compare');
+</script>
+</body>
+</html>

--- a/docs/design-mock/chat-markdown-notion.html
+++ b/docs/design-mock/chat-markdown-notion.html
@@ -1,0 +1,495 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Chat Markdown · Notion 风 · Light / Dark</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;560;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+  :root {
+    --font: Inter, "PingFang SC", "Noto Sans SC", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  /* —— Notion Light —— */
+  .t-light {
+    --bg: #F7F6F3;
+    --page: #FFFFFF;
+    --ink: #37352F;
+    --ink-2: #6B6B66;
+    --mute: #9B9A97;
+    --hover: rgba(55,53,47,0.08);
+    --line: rgba(55,53,47,0.09);
+    --line-soft: rgba(55,53,47,0.06);
+    --blue: #337EA9;
+    --blue-bg: rgba(51,126,169,0.12);
+    --code-bg: #EFEEE9;
+    --block-bg: #F7F6F3;
+    --callout-bg: rgba(241,178,63,0.14);
+    --green-bg: rgba(15,123,108,0.12);
+    --check: #2EAADC;
+    --av-bg: #37352F;
+    --av-fg: #fff;
+    --kw: #0070f3;
+    --str: #0F7B6C;
+    --key: #6940A5;
+    --bool: #CB912F;
+    --inline-code: #3d3c34;
+    --inline-code-border: rgba(26,26,20,0.05);
+    --shadow: 0 1px 3px rgba(0,0,0,0.04);
+    --chrome-dot-opacity: 0.7;
+  }
+
+  /* —— Notion Dark —— */
+  .t-dark {
+    --bg: #0F0F0F;
+    --page: #191919;
+    --ink: rgba(255,255,255,0.86);
+    --ink-2: rgba(255,255,255,0.55);
+    --mute: rgba(255,255,255,0.36);
+    --hover: rgba(255,255,255,0.08);
+    --line: rgba(255,255,255,0.12);
+    --line-soft: rgba(255,255,255,0.08);
+    --blue: #5B9BC8;
+    --blue-bg: rgba(51,126,169,0.22);
+    --code-bg: oklch(0.205 0 0);
+    --block-bg: #202020;
+    --callout-bg: rgba(233,168,0,0.16);
+    --green-bg: rgba(46,170,145,0.16);
+    --check: #2EAADC;
+    --av-bg: #37352F;
+    --av-fg: rgba(255,255,255,0.9);
+    --kw: #6DB3F8;
+    --str: #4DAB9A;
+    --key: #B088F5;
+    --bool: #E0B45A;
+    --inline-code: oklch(0.85 0 0);
+    --inline-code-border: oklch(1 0 0 / 6%);
+    --shadow: 0 1px 3px rgba(0,0,0,0.35);
+    --chrome-dot-opacity: 0.85;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--font);
+    background: #E8E5DF;
+    color: #1C1B19;
+    -webkit-font-smoothing: antialiased;
+    padding: 28px 20px 72px;
+    transition: background 0.2s var(--ease);
+  }
+  body.page-dark { background: #0A0A0A; color: rgba(255,255,255,0.75); }
+
+  .page-h { max-width: 1180px; margin: 0 auto 14px; }
+  .page-h h1 { font-size: 15px; font-weight: 600; }
+  .page-h p { margin-top: 6px; font-size: 13px; opacity: 0.7; line-height: 1.5; }
+
+  .tabs {
+    max-width: 1180px; margin: 0 auto 14px;
+    display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
+  }
+  .tabs button {
+    font: inherit; border: none; cursor: pointer;
+    height: 30px; padding: 0 12px; border-radius: 8px;
+    background: rgba(0,0,0,0.04); color: inherit; opacity: 0.7;
+    font-size: 12.5px; font-weight: 560;
+  }
+  body.page-dark .tabs button { background: rgba(255,255,255,0.06); }
+  .tabs button:hover { opacity: 1; }
+  .tabs button.on {
+    opacity: 1; background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  }
+  body.page-dark .tabs button.on {
+    background: #191919; box-shadow: 0 0 0 1px rgba(255,255,255,0.1);
+  }
+
+  .stage {
+    max-width: 1180px; margin: 0 auto;
+    display: grid; gap: 14px;
+  }
+  .stage.single { grid-template-columns: minmax(0, 780px); justify-content: center; }
+  .stage.dual { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  @media (max-width: 900px) {
+    .stage.dual { grid-template-columns: 1fr; }
+  }
+
+  .panel { display: none; }
+  .panel.show { display: block; }
+
+  .theme-frame {
+    background: var(--bg);
+    border-radius: 14px;
+    padding: 12px;
+    transition: background 0.2s var(--ease);
+  }
+  .theme-frame .label {
+    font-size: 11px; font-weight: 600; letter-spacing: 0.06em;
+    text-transform: uppercase; color: var(--mute);
+    padding: 2px 4px 10px;
+  }
+
+  .shell {
+    background: var(--page);
+    border-radius: 10px;
+    box-shadow: var(--shadow), 0 0 0 1px var(--line-soft);
+    overflow: hidden;
+    color: var(--ink);
+  }
+
+  .chrome {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--line-soft);
+    display: flex; align-items: center; gap: 8px;
+    font-size: 12px; color: var(--mute);
+  }
+  .dot { width: 8px; height: 8px; border-radius: 50%; background: #E03E3E; opacity: var(--chrome-dot-opacity); }
+  .dot:nth-child(2) { background: #F5C14A; }
+  .dot:nth-child(3) { background: #5CC98B; }
+
+  .thread { padding: 28px 40px 44px; }
+  @media (max-width: 640px) { .thread { padding: 20px 16px 32px; } }
+
+  .meta {
+    display: flex; align-items: center; gap: 8px;
+    margin-bottom: 18px;
+  }
+  .av {
+    width: 24px; height: 24px; border-radius: 4px;
+    background: var(--av-bg); color: var(--av-fg);
+    font-size: 10px; font-weight: 600;
+    display: grid; place-items: center;
+  }
+  .meta .nm { font-size: 14px; font-weight: 600; color: var(--ink); }
+  .meta .tm { font-size: 12px; color: var(--mute); margin-left: 4px; }
+
+  .md {
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--ink);
+  }
+  .md > *:first-child { margin-top: 0 !important; }
+
+  .md h1 {
+    font-size: 1.875em; font-weight: 700; line-height: 1.2;
+    margin: 1.4em 0 0.35em; letter-spacing: -0.015em; color: var(--ink);
+  }
+  .md h2 {
+    font-size: 1.5em; font-weight: 600; line-height: 1.25;
+    margin: 1.25em 0 0.3em; letter-spacing: -0.01em; color: var(--ink);
+  }
+  .md h3 {
+    font-size: 1.25em; font-weight: 600; line-height: 1.3;
+    margin: 1.1em 0 0.25em; color: var(--ink);
+  }
+
+  .md p { margin: 0.35em 0 0.75em; }
+  .md strong { font-weight: 600; }
+  .md em { font-style: italic; }
+  .md del { text-decoration: line-through; color: var(--mute); }
+
+  .md a {
+    color: var(--ink);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, var(--ink) 30%, transparent);
+    text-underline-offset: 2px;
+  }
+  .md a:hover { background: var(--hover); border-radius: 2px; }
+
+  .md code:not(pre code) {
+    font-family: var(--mono);
+    font-size: 86%;
+    background: var(--code-bg);
+    color: var(--inline-code);
+    border: none;
+    box-shadow: inset 0 0 0 1px var(--inline-code-border);
+    border-radius: 3px;
+    padding: 0.08em 0.3em;
+  }
+
+  .md blockquote {
+    margin: 0.6em 0;
+    padding: 0 0 0 14px;
+    border-left: 3px solid currentColor;
+    color: var(--ink-2);
+  }
+  .md blockquote p { margin: 0.2em 0; }
+
+  .md ul, .md ol {
+    margin: 0.4em 0 0.75em;
+    padding-left: 1.6em;
+  }
+  .md li { margin: 0.15em 0; }
+  .md ul { list-style: disc; }
+  .md ol { list-style: decimal; }
+  .md li::marker { color: var(--ink); }
+
+  .md .tasks { list-style: none; padding-left: 0; margin: 0.4em 0 0.75em; }
+  .md .tasks li {
+    display: flex; align-items: flex-start; gap: 8px;
+    padding: 2px 0; margin: 0;
+  }
+  .md .cb {
+    width: 16px; height: 16px; margin-top: 4px; border-radius: 3px;
+    border: 1.5px solid color-mix(in srgb, var(--ink) 35%, transparent);
+    flex-shrink: 0; background: transparent;
+    display: grid; place-items: center;
+  }
+  .t-light .md .cb { background: #fff; }
+  .md .cb.on { background: var(--check); border-color: var(--check); }
+  .md .cb.on::after {
+    content: '';
+    width: 8px; height: 4.5px;
+    border-left: 1.6px solid #fff;
+    border-bottom: 1.6px solid #fff;
+    transform: rotate(-45deg) translateY(-1px);
+  }
+  .md .tasks li.done span:last-child {
+    text-decoration: line-through; color: var(--mute);
+  }
+
+  .md pre {
+    margin: 0.65em 0 0.9em;
+    background: var(--block-bg);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .md .code-h {
+    display: none;
+  }
+  .md pre.show-h .code-h {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 6px 12px 0;
+    font-size: 12px; color: var(--mute); font-family: var(--mono);
+  }
+  .md pre.show-h .code-h button {
+    font: inherit; border: none; background: transparent;
+    color: var(--mute); cursor: pointer; padding: 2px 6px; border-radius: 4px; font-size: 12px;
+  }
+  .md pre.show-h .code-h button:hover { background: var(--hover); color: var(--ink); }
+  .md pre code {
+    display: block; padding: 14px 16px;
+    font-family: var(--mono); font-size: 13.5px; line-height: 1.5;
+    overflow-x: auto; color: var(--ink); background: transparent; border: none;
+  }
+  .md .kw { color: var(--kw); font-weight: 500; }
+  .md .str { color: var(--str); }
+  .md .key { color: var(--key); }
+  .md .bool { color: var(--bool); }
+
+  .md .table-wrap { margin: 0.7em 0 1em; overflow-x: auto; }
+  .md table { width: 100%; border-collapse: collapse; font-size: 14.5px; }
+  .md th, .md td {
+    padding: 7px 10px; text-align: left;
+    border: 1px solid var(--line); vertical-align: top;
+  }
+  .md th { font-weight: 600; }
+  .md tr:hover td { background: var(--hover); }
+
+  .md hr {
+    border: none; margin: 1.25em 0; height: 1px; background: var(--line);
+  }
+
+  .md .callout {
+    display: flex; gap: 10px; align-items: flex-start;
+    margin: 0.7em 0; padding: 14px 14px 14px 12px;
+    border-radius: 4px; background: var(--callout-bg);
+  }
+  .md .callout.blue { background: var(--blue-bg); }
+  .md .callout.green { background: var(--green-bg); }
+  .md .callout .emoji {
+    font-size: 18px; line-height: 1.4; flex-shrink: 0;
+    width: 24px; text-align: center;
+  }
+  .md .callout .lab { font-weight: 600; font-size: 15px; margin-bottom: 2px; color: var(--ink); }
+  .md .callout p { margin: 0; font-size: 15px; color: var(--ink); font-style: normal; }
+
+  .md .img-ph {
+    margin: 0.7em 0; border-radius: 4px; background: var(--block-bg);
+    min-height: 120px; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 8px;
+    color: var(--mute); font-size: 14px;
+  }
+  .md .img-ph svg { width: 28px; height: 28px; opacity: 0.45; }
+
+  .md details { margin: 0.35em 0; border-radius: 4px; }
+  .md details summary {
+    list-style: none; cursor: pointer; display: flex; align-items: center;
+    gap: 4px; padding: 4px 2px; border-radius: 4px; font-weight: 500; user-select: none;
+    color: var(--ink);
+  }
+  .md details summary::-webkit-details-marker { display: none; }
+  .md details summary:hover { background: var(--hover); }
+  .md details summary .tri {
+    width: 20px; height: 20px; display: grid; place-items: center;
+    color: var(--mute); transition: transform 0.12s ease; flex-shrink: 0;
+  }
+  .md details[open] summary .tri { transform: rotate(90deg); }
+  .md details .panel { padding: 2px 2px 8px 24px; color: var(--ink); }
+  .md details .panel p { margin: 0.25em 0; }
+
+  .note {
+    max-width: 1180px; margin: 16px auto 0;
+    padding: 12px 14px; border-radius: 8px;
+    background: rgba(0,0,0,0.04); font-size: 12.5px; line-height: 1.55; opacity: 0.85;
+  }
+  body.page-dark .note { background: rgba(255,255,255,0.05); }
+</style>
+</head>
+<body>
+
+  <div class="page-h">
+    <h1>Chat Markdown · Notion 风格 · Light / Dark</h1>
+    <p>同一套排版，对照 Notion 浅色与暗色。暗色参考 Notion Dark：页面 #191919、正文高亮白、代码块 #202020。</p>
+  </div>
+
+  <div class="tabs">
+    <button type="button" class="on" data-mode="light" onclick="mode('light')">Light</button>
+    <button type="button" data-mode="dark" onclick="mode('dark')">Dark</button>
+    <button type="button" data-mode="both" onclick="mode('both')">左右对照</button>
+  </div>
+
+  <div class="stage single" id="stage">
+    <div class="panel show" id="p-light">
+      <div class="theme-frame t-light">
+        <div class="label">Light</div>
+        <div class="shell" data-host></div>
+      </div>
+    </div>
+    <div class="panel" id="p-dark">
+      <div class="theme-frame t-dark">
+        <div class="label">Dark</div>
+        <div class="shell" data-host></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="note">
+    Dark 下待办勾仍用 Notion 蓝；行内代码偏珊瑚红；语法色略提亮以保证对比度。落地到 TeamClaw 时可映射到现有 dark tokens（paper / muted / border）。
+  </div>
+
+<template id="msg-tpl">
+  <div class="chrome">
+    <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+    <span style="margin-left:8px">消息预览</span>
+  </div>
+  <div class="thread">
+    <div class="meta">
+      <span class="av">MB</span>
+      <span class="nm">MYBOT</span>
+      <span class="tm">11:12</span>
+    </div>
+    <article class="md">
+      <h1>一级标题</h1>
+      <h2>二级标题</h2>
+      <h3>三级标题</h3>
+      <p>这是一段普通段落文字，用来展示正文的行高和字重。</p>
+      <p>
+        <strong>加粗文字</strong> ·
+        <em>斜体文字</em> ·
+        <strong><em>粗斜体</em></strong> ·
+        <del>删除线</del> ·
+        行内代码 <code>const x = 1</code>
+      </p>
+      <blockquote><p>这是一段引用文字，用于展示引用块的样式。</p></blockquote>
+      <ul>
+        <li>无序列表项一</li>
+        <li>无序列表项二</li>
+        <li>无序列表项三</li>
+      </ul>
+      <ol>
+        <li>有序列表项一</li>
+        <li>有序列表项二</li>
+        <li>有序列表项三</li>
+      </ol>
+      <ul class="tasks">
+        <li class="done"><span class="cb on" aria-hidden="true"></span><span>已完成的任务</span></li>
+        <li><span class="cb" aria-hidden="true"></span><span>未完成的任务</span></li>
+      </ul>
+      <pre class="show-h"><div class="code-h"><span>JavaScript</span><button type="button">Copy</button></div><code><span class="kw">function</span> hello() {
+  <span class="kw">return</span> <span class="str">'world'</span>;
+}</code></pre>
+      <pre><code>{
+  <span class="key">"name"</span>: <span class="str">"teamclaw"</span>,
+  <span class="key">"version"</span>: <span class="str">"1.0"</span>,
+  <span class="key">"ok"</span>: <span class="bool">true</span>
+}</code></pre>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>列一</th><th>列二</th><th>列三</th></tr></thead>
+          <tbody>
+            <tr><td>单元格 A1</td><td>单元格 A2</td><td>单元格 A3</td></tr>
+            <tr><td>单元格 B1</td><td>单元格 B2</td><td>单元格 B3</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p><a href="#">这是一个链接</a></p>
+      <div class="img-ph" role="img" aria-label="图片占位">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <rect x="3" y="5" width="18" height="14" rx="1.5"/>
+          <circle cx="9" cy="10" r="1.4"/>
+          <path d="M4 16l4.5-4.5 3.5 3.5 2.5-2.5L20 16"/>
+        </svg>
+        Add an image
+      </div>
+      <hr />
+      <div class="callout">
+        <div class="emoji" aria-hidden="true">💡</div>
+        <div class="body">
+          <div class="lab">提示</div>
+          <p>这是一个 tip 提示块，用于展示 admonition / callout 样式。</p>
+        </div>
+      </div>
+      <div class="callout blue" style="margin-top:8px">
+        <div class="emoji" aria-hidden="true">ℹ️</div>
+        <div class="body"><p>蓝色信息 callout —— Notion 里很常见的第二形态。</p></div>
+      </div>
+      <details open>
+        <summary>
+          <span class="tri" aria-hidden="true">
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M6 3l6 5-6 5V3z"/></svg>
+          </span>
+          点击展开
+        </summary>
+        <div class="panel"><p>这里是折叠内容</p></div>
+      </details>
+    </article>
+  </div>
+</template>
+
+<script>
+  const tpl = document.getElementById('msg-tpl');
+  document.querySelectorAll('[data-host]').forEach((host) => {
+    host.appendChild(tpl.content.cloneNode(true));
+  });
+
+  function mode(m) {
+    document.querySelectorAll('.tabs button').forEach((b) => {
+      b.classList.toggle('on', b.dataset.mode === m);
+    });
+    const stage = document.getElementById('stage');
+    const light = document.getElementById('p-light');
+    const dark = document.getElementById('p-dark');
+    stage.classList.remove('single', 'dual');
+    document.body.classList.toggle('page-dark', m === 'dark');
+
+    if (m === 'both') {
+      stage.classList.add('dual');
+      light.classList.add('show');
+      dark.classList.add('show');
+    } else if (m === 'dark') {
+      stage.classList.add('single');
+      light.classList.remove('show');
+      dark.classList.add('show');
+    } else {
+      stage.classList.add('single');
+      light.classList.add('show');
+      dark.classList.remove('show');
+    }
+  }
+
+  mode('light');
+</script>
+</body>
+</html>

--- a/docs/design-mock/chat-markdown-styles.html
+++ b/docs/design-mock/chat-markdown-styles.html
@@ -1,0 +1,580 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Chat Markdown · 三版样式对照</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;560;600;650;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+  :root {
+    --font: Inter, "PingFang SC", "Noto Sans SC", -apple-system, BlinkMacSystemFont, sans-serif;
+    --mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, monospace;
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+    --bg: #E8E5DF;
+    --paper: #FBFBFA;
+    --elev: #FFFFFF;
+    --ink: #1C1B19;
+    --ink-2: #5C5A54;
+    --mute: #8E8B83;
+    --faint: #B0ADA4;
+    --line: rgba(28,27,25,0.08);
+    --line-soft: rgba(28,27,25,0.05);
+    --coral: #E85A4A;
+    --coral-soft: rgba(232,90,74,0.12);
+    --ok: #2EB872;
+    --ok-soft: rgba(46,184,114,0.12);
+    --code-bg: #F3F1EC;
+    --shadow: 0 2px 10px rgba(28,27,25,0.05), 0 1px 2px rgba(28,27,25,0.03);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--font);
+    background: var(--bg);
+    color: var(--ink);
+    -webkit-font-smoothing: antialiased;
+    padding: 28px 24px 64px;
+  }
+
+  .page-h { max-width: 1280px; margin: 0 auto 18px; }
+  .page-h h1 { font-size: 17px; font-weight: 650; letter-spacing: -0.02em; }
+  .page-h p { margin-top: 6px; font-size: 13px; color: var(--ink-2); line-height: 1.55; max-width: 62ch; }
+
+  .tabs {
+    max-width: 1280px; margin: 0 auto 14px;
+    display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
+  }
+  .tabs button {
+    font: inherit; border: none; cursor: pointer;
+    height: 30px; padding: 0 12px; border-radius: 8px;
+    background: transparent; color: var(--mute); font-size: 12.5px; font-weight: 560;
+    transition: background .15s var(--ease), color .15s;
+  }
+  .tabs button:hover { background: rgba(28,27,25,0.05); color: var(--ink-2); }
+  .tabs button.on { background: var(--elev); color: var(--ink); box-shadow: var(--shadow); }
+  .tabs .hint { margin-left: auto; font-size: 11.5px; color: var(--faint); }
+
+  .stage {
+    max-width: 1280px; margin: 0 auto;
+    display: grid; gap: 14px;
+  }
+  .stage.single { grid-template-columns: minmax(0, 720px); justify-content: center; }
+  .stage.dual { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .stage.triple { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  @media (max-width: 1100px) {
+    .stage.triple { grid-template-columns: 1fr; }
+    .stage.dual { grid-template-columns: 1fr; }
+  }
+
+  .card {
+    background: var(--paper);
+    border-radius: 16px;
+    box-shadow: var(--shadow), 0 0 0 1px var(--line-soft);
+    overflow: hidden;
+    display: none;
+    flex-direction: column;
+    min-height: 0;
+  }
+  .stage.show-all .card,
+  .card.visible { display: flex; }
+
+  .card-h {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--line-soft);
+    display: flex; align-items: baseline; gap: 10px;
+    background: rgba(255,255,255,0.65);
+  }
+  .card-h .name { font-size: 12.5px; font-weight: 650; }
+  .card-h .tag {
+    font-size: 10px; font-weight: 600; letter-spacing: 0.04em;
+    text-transform: uppercase; color: var(--mute);
+    background: rgba(28,27,25,0.045); padding: 2px 7px; border-radius: 999px;
+  }
+  .card-h .desc { font-size: 11.5px; color: var(--mute); margin-left: auto; }
+
+  .msg {
+    padding: 18px 22px 28px;
+    overflow: auto;
+  }
+
+  .meta {
+    display: flex; align-items: center; gap: 8px; margin-bottom: 14px;
+  }
+  .av {
+    width: 22px; height: 22px; border-radius: 6px;
+    background: linear-gradient(145deg, #E85A4A, #C4473A);
+    color: #fff; font-size: 9px; font-weight: 700;
+    display: grid; place-items: center;
+  }
+  .meta .nm { font-size: 12.5px; font-weight: 600; }
+  .meta .ai {
+    font-size: 9.5px; font-weight: 600; letter-spacing: 0.04em;
+    border: 1px solid rgba(232,90,74,0.35); color: var(--coral);
+    padding: 1px 5px; border-radius: 4px;
+  }
+  .meta .tm { font-size: 11px; color: var(--faint); font-family: var(--mono); margin-left: auto; }
+
+  /* shared md base */
+  .md { font-size: 13.5px; line-height: 1.7; color: var(--ink); }
+  .md > *:first-child { margin-top: 0 !important; }
+  .md h1, .md h2, .md h3 { color: var(--ink); letter-spacing: -0.02em; }
+  .md p { margin: 0.7em 0; color: var(--ink); }
+  .md a { color: var(--coral); text-decoration: none; border-bottom: 1px solid rgba(232,90,74,0.25); }
+  .md a:hover { border-bottom-color: var(--coral); }
+  .md strong { font-weight: 650; }
+  .md em { font-style: italic; color: var(--ink-2); }
+  .md del { color: var(--mute); text-decoration: line-through; }
+  .md img {
+    max-width: 100%; border-radius: 10px; margin: 0.8em 0;
+    background: var(--code-bg); min-height: 48px;
+  }
+  .md .img-ph {
+    display: flex; align-items: center; gap: 8px;
+    padding: 14px 16px; border-radius: 10px;
+    border: 1px dashed var(--line); color: var(--mute); font-size: 12.5px;
+    margin: 0.8em 0; background: rgba(28,27,25,0.02);
+  }
+  .md .img-ph svg { width: 18px; height: 18px; opacity: 0.55; }
+  .md details {
+    margin: 0.85em 0; border-radius: 10px; border: 1px solid var(--line-soft);
+    background: rgba(28,27,25,0.02); padding: 2px 12px 8px;
+  }
+  .md details summary {
+    cursor: pointer; font-weight: 560; padding: 8px 0; color: var(--ink-2);
+    list-style: none; display: flex; align-items: center; gap: 6px;
+  }
+  .md details summary::-webkit-details-marker { display: none; }
+  .md details summary::before {
+    content: ''; width: 0; height: 0;
+    border-left: 5px solid var(--mute);
+    border-top: 4px solid transparent;
+    border-bottom: 4px solid transparent;
+    transition: transform .15s var(--ease);
+  }
+  .md details[open] summary::before { transform: rotate(90deg); }
+  .md details p { margin: 0.2em 0 0.5em; color: var(--ink-2); font-size: 13px; }
+
+  /* ========== A · Soft Note ========== */
+  .a .md h1 {
+    font-size: 22px; font-weight: 650; margin: 1.15em 0 0.4em;
+    padding-bottom: 0; border: none;
+  }
+  .a .md h2 {
+    font-size: 17px; font-weight: 650; margin: 1.2em 0 0.35em;
+    padding-bottom: 0; border: none;
+  }
+  .a .md h3 {
+    font-size: 14.5px; font-weight: 620; margin: 1.05em 0 0.3em; color: var(--ink);
+  }
+  .a .md code:not(pre code) {
+    font-family: var(--mono); font-size: 0.9em;
+    background: var(--code-bg); color: #3D3A34;
+    padding: 0.12em 0.4em; border-radius: 5px;
+    border: 1px solid var(--line-soft);
+  }
+  .a .md pre {
+    margin: 0.85em 0; border-radius: 12px; overflow: hidden;
+    background: var(--elev); border: 1px solid var(--line-soft);
+    box-shadow: 0 1px 2px rgba(28,27,25,0.03);
+  }
+  .a .md .code-h {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 7px 12px; background: #F7F6F2;
+    border-bottom: 1px solid var(--line-soft);
+    font-family: var(--mono); font-size: 10.5px; color: var(--mute); font-weight: 500;
+  }
+  .a .md .code-h button {
+    font: inherit; border: none; background: transparent; color: var(--faint);
+    cursor: pointer; padding: 2px 6px; border-radius: 5px;
+  }
+  .a .md .code-h button:hover { background: rgba(28,27,25,0.05); color: var(--ink-2); }
+  .a .md pre code {
+    display: block; padding: 12px 14px; font-family: var(--mono);
+    font-size: 12px; line-height: 1.65; background: transparent; border: none;
+    overflow-x: auto; color: #2A2926;
+  }
+  .a .md .kw { color: #C4473A; } .a .md .str { color: #5B6FA8; }
+  .a .md .key { color: #3D6B8A; } .a .md .bool { color: #2E7A5A; }
+  .a .md blockquote {
+    margin: 0.85em 0; padding: 2px 0 2px 14px;
+    border-left: 2.5px solid rgba(46,184,114,0.55);
+    color: var(--ink-2);
+  }
+  .a .md blockquote p { margin: 0.25em 0; }
+  .a .md ul, .a .md ol { margin: 0.55em 0; padding-left: 1.35em; }
+  .a .md li { margin: 0.28em 0; }
+  .a .md ul { list-style: none; padding-left: 0; }
+  .a .md ul li { padding-left: 1.15em; position: relative; }
+  .a .md ul li::before {
+    content: ''; position: absolute; left: 2px; top: 0.62em;
+    width: 5px; height: 5px; border-radius: 50%; background: var(--ink-2);
+  }
+  .a .md .tasks { list-style: none; padding: 0; }
+  .a .md .tasks li { padding-left: 0; display: flex; gap: 8px; align-items: flex-start; }
+  .a .md .tasks li::before { display: none; }
+  .a .md .cb {
+    width: 15px; height: 15px; margin-top: 3px; border-radius: 4px;
+    border: 1.5px solid rgba(28,27,25,0.2); flex-shrink: 0;
+    display: grid; place-items: center;
+  }
+  .a .md .cb.on { background: var(--ok); border-color: var(--ok); }
+  .a .md .cb.on::after {
+    content: ''; width: 7px; height: 4px; border-left: 1.5px solid #fff;
+    border-bottom: 1.5px solid #fff; transform: rotate(-45deg) translate(0, -1px);
+  }
+  .a .md table {
+    width: 100%; border-collapse: separate; border-spacing: 0;
+    margin: 0.9em 0; font-size: 12.5px;
+    border: 1px solid var(--line-soft); border-radius: 10px; overflow: hidden;
+  }
+  .a .md th, .a .md td {
+    padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--line-soft);
+  }
+  .a .md th { background: #F7F6F2; font-weight: 600; color: var(--ink-2); font-size: 11.5px; }
+  .a .md tr:last-child td { border-bottom: none; }
+  .a .md hr {
+    border: none; height: 1px; background: var(--line-soft); margin: 1.4em 0;
+  }
+  .a .md .callout {
+    margin: 0.9em 0; padding: 10px 12px 10px 14px; border-radius: 10px;
+    background: var(--ok-soft); border-left: 3px solid var(--ok);
+  }
+  .a .md .callout .lab { font-weight: 650; font-size: 12.5px; margin-bottom: 2px; }
+  .a .md .callout p { margin: 0; font-size: 13px; color: var(--ink-2); font-style: italic; }
+
+  /* ========== B · Quiet Structure ========== */
+  .b .msg { background: linear-gradient(180deg, #FCFBF9 0%, #F8F7F4 100%); }
+  .b .md { font-size: 13.5px; line-height: 1.72; }
+  .b .md h1 {
+    font-size: 20px; font-weight: 700; margin: 1.2em 0 0.45em;
+    padding-bottom: 0.35em; border-bottom: 1px solid var(--line);
+  }
+  .b .md h2 {
+    font-size: 16px; font-weight: 650; margin: 1.25em 0 0.4em;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .b .md h2::before {
+    content: ''; width: 3px; height: 0.9em; border-radius: 2px; background: var(--coral);
+    opacity: 0.85;
+  }
+  .b .md h3 {
+    font-size: 13.5px; font-weight: 650; margin: 1.1em 0 0.35em;
+    color: var(--ink-2); text-transform: none; letter-spacing: 0;
+  }
+  .b .md code:not(pre code) {
+    font-family: var(--mono); font-size: 0.88em;
+    background: rgba(28,27,25,0.06); padding: 0.1em 0.38em; border-radius: 4px;
+  }
+  .b .md pre {
+    margin: 0.9em 0; border-radius: 8px; overflow: hidden;
+    background: #1C1B19; color: #EDEAE4;
+  }
+  .b .md .code-h {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 6px 12px; background: rgba(255,255,255,0.06);
+    font-family: var(--mono); font-size: 10.5px; color: rgba(237,234,228,0.55); font-weight: 500;
+  }
+  .b .md .code-h button {
+    font: inherit; border: none; background: transparent; color: rgba(237,234,228,0.45);
+    cursor: pointer; padding: 2px 6px; border-radius: 4px;
+  }
+  .b .md .code-h button:hover { color: #EDEAE4; background: rgba(255,255,255,0.08); }
+  .b .md pre code {
+    display: block; padding: 12px 14px; font-family: var(--mono);
+    font-size: 12px; line-height: 1.65; background: transparent; border: none; overflow-x: auto;
+  }
+  .b .md .kw { color: #F0A8A0; } .b .md .str { color: #B8C7F0; }
+  .b .md .key { color: #9EC9E8; } .b .md .bool { color: #8FD4B0; }
+  .b .md blockquote {
+    margin: 0.9em 0; padding: 10px 14px;
+    background: rgba(28,27,25,0.03); border-radius: 8px;
+    border-left: 3px solid var(--mute); color: var(--ink-2);
+  }
+  .b .md ul, .b .md ol { margin: 0.6em 0; padding-left: 1.4em; }
+  .b .md li { margin: 0.32em 0; }
+  .b .md .tasks { list-style: none; padding: 0; }
+  .b .md .tasks li { display: flex; gap: 9px; align-items: flex-start; }
+  .b .md .cb {
+    width: 16px; height: 16px; margin-top: 2px; border-radius: 4px;
+    border: 1.5px solid rgba(28,27,25,0.22); flex-shrink: 0;
+  }
+  .b .md .cb.on {
+    background: var(--coral); border-color: var(--coral);
+    box-shadow: inset 0 0 0 2px #fff;
+  }
+  .b .md table {
+    width: 100%; border-collapse: collapse; margin: 0.95em 0; font-size: 12.5px;
+  }
+  .b .md th, .b .md td {
+    padding: 9px 11px; text-align: left;
+    border-bottom: 1px solid var(--line);
+  }
+  .b .md th {
+    font-weight: 600; font-size: 11px; text-transform: uppercase;
+    letter-spacing: 0.06em; color: var(--mute); border-bottom-color: var(--ink);
+    border-bottom-width: 1.5px;
+  }
+  .b .md hr {
+    border: none; margin: 1.5em 0; height: 0;
+    border-top: 1px dashed var(--line);
+  }
+  .b .md .callout {
+    margin: 0.95em 0; padding: 12px 14px; border-radius: 8px;
+    background: var(--coral-soft); border: 1px solid rgba(232,90,74,0.18);
+  }
+  .b .md .callout .lab { font-weight: 650; font-size: 12px; color: var(--coral); margin-bottom: 3px; }
+  .b .md .callout p { margin: 0; font-size: 13px; color: var(--ink-2); font-style: normal; }
+  .b .md .img-ph { border-style: solid; border-radius: 8px; }
+
+  /* ========== C · Studio Dense ========== */
+  .c .md { font-size: 13.25px; line-height: 1.65; }
+  .c .md h1 {
+    font-size: 18px; font-weight: 700; margin: 1em 0 0.35em;
+    letter-spacing: -0.025em;
+  }
+  .c .md h2 {
+    font-size: 15px; font-weight: 650; margin: 1.05em 0 0.3em;
+    color: var(--ink);
+  }
+  .c .md h3 {
+    font-size: 13px; font-weight: 650; margin: 0.95em 0 0.25em;
+    color: var(--mute); letter-spacing: 0.02em;
+  }
+  .c .md p { margin: 0.55em 0; }
+  .c .md code:not(pre code) {
+    font-family: var(--mono); font-size: 0.86em; font-weight: 500;
+    background: #EEEBE4; padding: 0.08em 0.35em; border-radius: 3px;
+    color: #2F2D28;
+  }
+  .c .md pre {
+    margin: 0.7em 0; border-radius: 10px; overflow: hidden;
+    background: #EFEEE9; border: 1px solid var(--line);
+  }
+  .c .md .code-h {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 5px 10px; background: rgba(28,27,25,0.035);
+    border-bottom: 1px solid var(--line-soft);
+    font-family: var(--mono); font-size: 10px; color: var(--mute); font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.06em;
+  }
+  .c .md .code-h button {
+    font: inherit; border: none; background: rgba(28,27,25,0.04);
+    color: var(--ink-2); cursor: pointer; padding: 2px 8px; border-radius: 5px;
+    font-size: 10px; letter-spacing: 0; text-transform: none; font-weight: 560;
+  }
+  .c .md .code-h button:hover { background: rgba(28,27,25,0.08); }
+  .c .md pre code {
+    display: block; padding: 10px 12px; font-family: var(--mono);
+    font-size: 11.5px; line-height: 1.6; background: transparent; border: none; overflow-x: auto;
+  }
+  .c .md .kw { color: #B83A2E; font-weight: 500; } .c .md .str { color: #4A6FA5; }
+  .c .md .key { color: #3A6B7A; } .c .md .bool { color: #2A7A58; }
+  .c .md blockquote {
+    margin: 0.7em 0; padding: 0 0 0 12px;
+    border-left: 2px solid var(--ok); color: var(--ink-2); font-size: 13px;
+  }
+  .c .md ul, .c .md ol { margin: 0.45em 0; padding-left: 1.25em; }
+  .c .md li { margin: 0.18em 0; }
+  .c .md ul { list-style: disc; }
+  .c .md .tasks { list-style: none; padding: 0; display: grid; gap: 4px; }
+  .c .md .tasks li {
+    display: flex; gap: 8px; align-items: center;
+    padding: 6px 8px; border-radius: 7px; background: rgba(28,27,25,0.025);
+  }
+  .c .md .cb {
+    width: 14px; height: 14px; border-radius: 3px;
+    border: 1.5px solid rgba(28,27,25,0.25); flex-shrink: 0;
+  }
+  .c .md .cb.on { background: #1C1B19; border-color: #1C1B19; position: relative; }
+  .c .md .cb.on::after {
+    content: ''; position: absolute; left: 3px; top: 1px;
+    width: 6px; height: 3.5px; border-left: 1.5px solid #fff;
+    border-bottom: 1.5px solid #fff; transform: rotate(-45deg);
+  }
+  .c .md table {
+    width: 100%; border-collapse: collapse; margin: 0.75em 0; font-size: 12px;
+    font-variant-numeric: tabular-nums;
+  }
+  .c .md th, .c .md td {
+    padding: 6px 10px; text-align: left; border: 1px solid var(--line);
+  }
+  .c .md th { background: #EFEEE9; font-weight: 650; font-size: 11.5px; }
+  .c .md tr:nth-child(even) td { background: rgba(28,27,25,0.015); }
+  .c .md hr {
+    border: none; height: 1px; margin: 1.15em 0;
+    background: linear-gradient(90deg, transparent, var(--line), transparent);
+  }
+  .c .md .callout {
+    margin: 0.75em 0; padding: 8px 10px; border-radius: 8px;
+    display: grid; grid-template-columns: auto 1fr; gap: 8px; align-items: start;
+    background: #EFEEE9; border: 1px solid var(--line-soft);
+  }
+  .c .md .callout .ico {
+    width: 18px; height: 18px; border-radius: 5px; background: var(--ok-soft);
+    color: #1F7A4D; font-size: 11px; font-weight: 700;
+    display: grid; place-items: center; margin-top: 1px;
+  }
+  .c .md .callout .lab { font-weight: 650; font-size: 12px; }
+  .c .md .callout p { margin: 2px 0 0; font-size: 12.5px; color: var(--ink-2); font-style: normal; }
+  .c .md details { border-radius: 8px; padding: 0 10px 6px; }
+</style>
+</head>
+<body>
+
+  <div class="page-h">
+    <h1>Chat Markdown · 三版样式</h1>
+    <p>
+      基于 Soft Comfort / Editorial Calm 的消息区 Markdown 重设计。三版共用同一份样例内容，
+      方便对照标题、代码块、表格、引用、任务列表与提示块的气质差异。Coral 只作链接/极少量结构点缀。
+    </p>
+  </div>
+
+  <div class="tabs">
+    <button type="button" class="on" data-mode="a" onclick="show('a')">A · Soft Note</button>
+    <button type="button" data-mode="b" onclick="show('b')">B · Quiet Structure</button>
+    <button type="button" data-mode="c" onclick="show('c')">C · Studio Dense</button>
+    <button type="button" data-mode="all" onclick="show('all')">三栏对照</button>
+    <span class="hint">推荐默认采用 A；编码密集会话可切 C</span>
+  </div>
+
+  <div class="stage single" id="stage">
+
+    <!-- A -->
+    <section class="card a visible" data-v="a">
+      <div class="card-h">
+        <span class="name">A · Soft Note</span>
+        <span class="tag">推荐</span>
+        <span class="desc">备忘录气质 · 轻代码卡 · 少分割线</span>
+      </div>
+      <div class="msg">
+        <div class="meta">
+          <span class="av">MB</span>
+          <span class="nm">MYBOT</span>
+          <span class="ai">AI</span>
+          <span class="tm">11:12</span>
+        </div>
+        <div class="md" data-sample></div>
+      </div>
+    </section>
+
+    <!-- B -->
+    <section class="card b" data-v="b">
+      <div class="card-h">
+        <span class="name">B · Quiet Structure</span>
+        <span class="tag">结构感</span>
+        <span class="desc">标题轨线 · 深色代码 · 表格字阶</span>
+      </div>
+      <div class="msg">
+        <div class="meta">
+          <span class="av">MB</span>
+          <span class="nm">MYBOT</span>
+          <span class="ai">AI</span>
+          <span class="tm">11:12</span>
+        </div>
+        <div class="md" data-sample></div>
+      </div>
+    </section>
+
+    <!-- C -->
+    <section class="card c" data-v="c">
+      <div class="card-h">
+        <span class="name">C · Studio Dense</span>
+        <span class="tag">紧凑</span>
+        <span class="desc">更密行距 · 浅底代码 · 任务条</span>
+      </div>
+      <div class="msg">
+        <div class="meta">
+          <span class="av">MB</span>
+          <span class="nm">MYBOT</span>
+          <span class="ai">AI</span>
+          <span class="tm">11:12</span>
+        </div>
+        <div class="md" data-sample></div>
+      </div>
+    </section>
+
+  </div>
+
+<script>
+const SAMPLE = `
+<h1>一级标题</h1>
+<h2>二级标题</h2>
+<h3>三级标题</h3>
+<p>这是一段普通段落文字，用来展示正文的行高和字重。</p>
+<p><strong>加粗文字</strong> · <em>斜体文字</em> · <strong><em>粗斜体</em></strong> · <del>删除线</del> · 行内代码 <code>const x = 1</code></p>
+<blockquote><p>这是一段引用文字，用于展示引用块的样式。</p></blockquote>
+<ul>
+  <li>无序列表项一</li>
+  <li>无序列表项二</li>
+  <li>无序列表项三</li>
+</ul>
+<ol>
+  <li>有序列表项一</li>
+  <li>有序列表项二</li>
+  <li>有序列表项三</li>
+</ol>
+<ul class="tasks">
+  <li><span class="cb on" aria-hidden="true"></span><span>已完成的任务</span></li>
+  <li><span class="cb" aria-hidden="true"></span><span>未完成的任务</span></li>
+</ul>
+<pre><div class="code-h"><span>js</span><button type="button">复制</button></div><code><span class="kw">function</span> hello() {\n  <span class="kw">return</span> <span class="str">'world'</span>;\n}</code></pre>
+<pre><div class="code-h"><span>json</span><button type="button">复制</button></div><code>{\n  <span class="key">"name"</span>: <span class="str">"teamclaw"</span>,\n  <span class="key">"version"</span>: <span class="str">"1.0"</span>,\n  <span class="key">"ok"</span>: <span class="bool">true</span>\n}</code></pre>
+<table>
+  <thead><tr><th>列一</th><th>列二</th><th>列三</th></tr></thead>
+  <tbody>
+    <tr><td>单元格 A1</td><td>单元格 A2</td><td>单元格 A3</td></tr>
+    <tr><td>单元格 B1</td><td>单元格 B2</td><td>单元格 B3</td></tr>
+  </tbody>
+</table>
+<p><a href="#">这是一个链接</a></p>
+<div class="img-ph" role="img" aria-label="图片占位">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="5" width="18" height="14" rx="2"/><circle cx="9" cy="10" r="1.5"/><path d="M4 16l5-5 4 4 3-3 4 4"/></svg>
+  图片加载失败 / 占位
+</div>
+<hr />
+<div class="callout">
+  <div class="ico" style="display:none">!</div>
+  <div>
+    <div class="lab">提示</div>
+    <p>这是一个 tip 提示块，用于展示 admonition / callout 样式。</p>
+  </div>
+</div>
+<details open>
+  <summary>点击展开</summary>
+  <p>这里是折叠内容</p>
+</details>
+`;
+
+function paint() {
+  document.querySelectorAll('[data-sample]').forEach((el) => {
+    el.innerHTML = SAMPLE;
+    // C callout uses icon chip
+    if (el.closest('.c')) {
+      const ico = el.querySelector('.callout .ico');
+      if (ico) ico.style.display = 'grid';
+    }
+  });
+}
+
+function show(mode) {
+  document.querySelectorAll('.tabs button').forEach((b) => {
+    b.classList.toggle('on', b.dataset.mode === mode);
+  });
+  const stage = document.getElementById('stage');
+  const cards = [...document.querySelectorAll('.card')];
+  stage.classList.remove('single', 'dual', 'triple', 'show-all');
+  if (mode === 'all') {
+    stage.classList.add('triple', 'show-all');
+    cards.forEach((c) => c.classList.add('visible'));
+  } else {
+    stage.classList.add('single');
+    cards.forEach((c) => c.classList.toggle('visible', c.dataset.v === mode));
+  }
+}
+
+paint();
+show('a');
+</script>
+</body>
+</html>

--- a/docs/design-mock/session-liquid-glass.html
+++ b/docs/design-mock/session-liquid-glass.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Session 选中 · 液态玻璃浮层</title>
+<style>
+  :root {
+    --font: "PingFang SC", "Noto Sans SC", Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    --mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+    --bg: #fbfaf7;
+    --panel: #EFEEE9;
+    --paper: #ffffff;
+    --ink: #1a1a14;
+    --ink-2: #3d3c34;
+    --mute: #75736a;
+    --faint: #a8a6a0;
+    --border: rgba(26,26,20,0.08);
+    --ease-liquid: cubic-bezier(0.22, 1, 0.36, 1);
+    --ease-spring: cubic-bezier(0.34, 1.3, 0.64, 1);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--font);
+    background: #e4e1da;
+    color: var(--ink);
+    padding: 28px 20px 72px;
+    -webkit-font-smoothing: antialiased;
+  }
+  body.dark-page { background: #0a0a0a; color: rgba(255,255,255,0.75); }
+
+  .page-h { max-width: 980px; margin: 0 auto 14px; }
+  .page-h h1 { font-size: 16px; font-weight: 650; }
+  .page-h p { margin-top: 6px; font-size: 13px; line-height: 1.55; opacity: 0.72; max-width: 62ch; }
+
+  .tabs {
+    max-width: 980px; margin: 0 auto 14px;
+    display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
+  }
+  .tabs button {
+    font: inherit; border: none; cursor: pointer;
+    height: 30px; padding: 0 12px; border-radius: 8px;
+    background: rgba(0,0,0,0.05); color: inherit; opacity: 0.75;
+    font-size: 12.5px; font-weight: 560;
+  }
+  body.dark-page .tabs button { background: rgba(255,255,255,0.06); }
+  .tabs button.on {
+    opacity: 1; background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  }
+  body.dark-page .tabs button.on {
+    background: #1c1c1c; box-shadow: 0 0 0 1px rgba(255,255,255,0.1);
+  }
+  .tabs .hint {
+    margin-left: 4px; font-size: 12px; opacity: 0.55;
+  }
+
+  .stage {
+    max-width: 980px; margin: 0 auto;
+    display: grid;
+    grid-template-columns: 320px 1fr;
+    gap: 14px;
+    align-items: start;
+  }
+  @media (max-width: 820px) {
+    .stage { grid-template-columns: 1fr; }
+  }
+
+  /* —— Session column (Soft Comfort) —— */
+  .col {
+    background: var(--bg);
+    border-radius: 16px;
+    padding: 10px 8px 14px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    position: relative;
+    overflow: hidden;
+  }
+  body.dark-page .col {
+    --bg: oklch(0.145 0 0);
+    --panel: oklch(0.205 0 0);
+    --paper: oklch(0.205 0 0);
+    --ink: oklch(0.985 0 0);
+    --ink-2: oklch(0.85 0 0);
+    --mute: oklch(0.708 0 0);
+    --faint: oklch(0.556 0 0);
+    --border: oklch(1 0 0 / 10%);
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.08);
+  }
+
+  .sec {
+    padding: 8px 10px 6px;
+    font-size: 10.5px; font-weight: 600;
+    letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--faint);
+  }
+
+  .list {
+    position: relative;
+    padding: 2px 4px;
+  }
+
+  /* Liquid glass blob — one shared layer that slides */
+  .glass {
+    position: absolute;
+    left: 4px;
+    right: 4px;
+    top: 0;
+    height: 56px;
+    border-radius: 11px;
+    pointer-events: none;
+    z-index: 0;
+    /* liquid glass */
+    background:
+      linear-gradient(135deg,
+        rgba(255,255,255,0.72) 0%,
+        rgba(255,255,255,0.48) 42%,
+        rgba(255,255,255,0.38) 100%);
+    backdrop-filter: blur(18px) saturate(1.55);
+    -webkit-backdrop-filter: blur(18px) saturate(1.55);
+    box-shadow:
+      0 1px 0 rgba(255,255,255,0.85) inset,
+      0 -1px 0 rgba(26,26,20,0.04) inset,
+      0 2px 8px rgba(28,27,25,0.06),
+      0 1px 2px rgba(28,27,25,0.04),
+      0 0 0 1px rgba(26,26,20,0.06);
+    /* motion */
+    transition:
+      transform 420ms var(--ease-liquid),
+      height 420ms var(--ease-liquid),
+      border-radius 420ms var(--ease-liquid),
+      box-shadow 280ms ease,
+      background 280ms ease;
+    will-change: transform, height;
+    transform: translate3d(0, 0, 0);
+  }
+  .glass.moving {
+    /* slight squash while traveling — liquid feel */
+    border-radius: 13px 13px 10px 10px;
+    box-shadow:
+      0 1px 0 rgba(255,255,255,0.9) inset,
+      0 6px 18px rgba(28,27,25,0.08),
+      0 2px 4px rgba(28,27,25,0.04),
+      0 0 0 1px rgba(26,26,20,0.07);
+  }
+  .glass::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(
+      180deg,
+      rgba(255,255,255,0.55) 0%,
+      rgba(255,255,255,0) 42%
+    );
+    opacity: 0.9;
+    pointer-events: none;
+  }
+  .glass::after {
+    /* specular streak */
+    content: "";
+    position: absolute;
+    top: 1px; left: 10%; right: 28%;
+    height: 1px;
+    border-radius: 1px;
+    background: rgba(255,255,255,0.95);
+    opacity: 0.7;
+    pointer-events: none;
+  }
+
+  body.dark-page .glass {
+    background:
+      linear-gradient(135deg,
+        rgba(255,255,255,0.14) 0%,
+        rgba(255,255,255,0.07) 50%,
+        rgba(255,255,255,0.05) 100%);
+    box-shadow:
+      0 8px 24px rgba(0,0,0,0.35),
+      0 0 0 1px rgba(255,255,255,0.1);
+  }
+  body.dark-page .glass::before {
+    background: linear-gradient(180deg, rgba(255,255,255,0.06), transparent 45%);
+  }
+  body.dark-page .glass::after {
+    display: none;
+  }
+
+  /* Variant: gooey (SVG filter) — optional intensity */
+  .list.gooey .glass {
+    filter: url(#goo);
+  }
+  .list.gooey .row { isolation: isolate; }
+
+  .row {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 4px 8px;
+    width: 100%;
+    padding: 8px 10px;
+    margin: 1px 0;
+    border: none;
+    border-radius: 11px;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    transition: background 150ms var(--ease-liquid);
+  }
+  .row:hover { background: rgba(0,0,0,0.035); }
+  body.dark-page .row:hover { background: rgba(255,255,255,0.05); }
+  .row[aria-selected="true"] { background: transparent; }
+  .row[aria-selected="true"]:hover { background: transparent; }
+
+  .title {
+    font-size: 13px; font-weight: 600; color: var(--ink);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .time {
+    font-size: 11px; font-family: var(--mono); color: var(--faint);
+    white-space: nowrap;
+  }
+  .meta {
+    grid-column: 1 / -1;
+    font-size: 11px; font-family: var(--mono); color: var(--mute);
+  }
+  .preview {
+    grid-column: 1 / -1;
+    font-size: 12px; color: var(--ink-2);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    opacity: 0.85;
+  }
+  .more {
+    position: absolute; top: 8px; right: 8px;
+    width: 22px; height: 22px; border-radius: 6px;
+    display: none; place-items: center;
+    color: var(--mute); font-size: 14px; line-height: 1;
+    background: rgba(0,0,0,0.04);
+  }
+  .row[aria-selected="true"] .more { display: grid; }
+  .row[aria-selected="true"] .time { visibility: hidden; }
+
+  /* —— Side panel notes —— */
+  .notes {
+    background: #fff;
+    border-radius: 16px;
+    padding: 16px 18px;
+    font-size: 13px;
+    line-height: 1.6;
+    color: #3d3c34;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  body.dark-page .notes {
+    background: #161616;
+    color: rgba(255,255,255,0.7);
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.08);
+  }
+  .notes h2 { font-size: 13px; font-weight: 650; color: inherit; margin-bottom: 8px; }
+  .notes ul { padding-left: 1.15em; margin: 0.4em 0 1em; }
+  li { margin: 0.25em 0; }
+  .ok { color: #1f7a4c; font-weight: 600; }
+  body.dark-page .ok { color: #4ade80; }
+  .warn { color: #9a6700; font-weight: 600; }
+  code {
+    font-family: var(--mono); font-size: 0.9em;
+    background: var(--panel, #EFEEE9); padding: 0.08em 0.3em; border-radius: 3px;
+  }
+  body.dark-page code { background: rgba(255,255,255,0.08); }
+
+  .kbd {
+    display: inline-flex; gap: 4px; margin-top: 8px; flex-wrap: wrap;
+  }
+  .kbd button {
+    font: inherit; font-size: 12px; font-weight: 560;
+    height: 28px; padding: 0 10px; border-radius: 7px;
+    border: 1px solid rgba(26,26,20,0.1);
+    background: #fbfaf7; cursor: pointer; color: inherit;
+  }
+  body.dark-page .kbd button {
+    background: #222; border-color: rgba(255,255,255,0.12);
+  }
+</style>
+</head>
+<body>
+  <div class="page-h">
+    <h1>会话列表 · 液态玻璃选中浮层</h1>
+    <p>
+      一个共享的玻璃层贴在列表底层，切换 session 时只改 <code>translateY + height</code>，
+      浮层「顺」过去，而不是每张卡自己亮灭。点列表或用下方按钮试效果。
+    </p>
+  </div>
+
+  <div class="tabs" id="tabs">
+    <button type="button" data-mode="light" class="on">Light</button>
+    <button type="button" data-mode="dark">Dark</button>
+    <button type="button" data-fx="glass" class="on">Glass</button>
+    <button type="button" data-fx="gooey">Gooey（更液）</button>
+    <span class="hint">推荐默认 Glass；Gooey 靠 SVG filter，落地成本更高</span>
+  </div>
+
+  <div class="stage">
+    <div class="col" id="col">
+      <div class="sec">Pinned · 1</div>
+      <div class="list" id="list">
+        <div class="glass" id="glass" aria-hidden="true"></div>
+        <!-- rows injected -->
+      </div>
+    </div>
+
+    <aside class="notes">
+      <h2>可行性</h2>
+      <ul>
+        <li><span class="ok">可行</span> — 单层绝对定位 indicator + FLIP/<code>transform</code>，和 Soft Comfort 现有「白卡浮层」兼容。</li>
+        <li>React 落地：列表 <code>ref</code> 量选中行的 <code>offsetTop/offsetHeight</code>，切 <code>activeSessionId</code> 时更新玻璃层；滚动时同步。</li>
+        <li>需要 <code>backdrop-filter</code>（桌面 Chromium/WebKit 都 OK；列表底色要透一点才看得出玻璃）。</li>
+        <li><span class="warn">注意</span> — 展开 ⋯ dock / 高度变化时要重测；虚拟列表要改成基于可视坐标。</li>
+        <li>Gooey 滤镜好看但脏边/文字模糊风险大，建议先上 Glass。</li>
+      </ul>
+      <h2>推荐动效参数</h2>
+      <ul>
+        <li>时长 ~400ms · <code>cubic-bezier(0.22, 1, 0.36, 1)</code></li>
+        <li>移动中略放大圆角 / 加深阴影（本页 <code>.moving</code>）</li>
+        <li>行本身不再各自 <code>bg-paper shadow</code>，只留玻璃层当选中态</li>
+      </ul>
+      <div class="kbd">
+        <button type="button" id="prev">↑ 上一条</button>
+        <button type="button" id="next">↓ 下一条</button>
+        <button type="button" id="jump">跳到「执行PS」</button>
+      </div>
+    </aside>
+  </div>
+
+  <!-- Gooey filter (optional) -->
+  <svg width="0" height="0" style="position:absolute">
+    <defs>
+      <filter id="goo">
+        <feGaussianBlur in="SourceGraphic" stdDeviation="6" result="blur" />
+        <feColorMatrix in="blur" mode="matrix"
+          values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -7"
+          result="goo" />
+        <feComposite in="SourceGraphic" in2="goo" operator="atop" />
+      </filter>
+    </defs>
+  </svg>
+
+<script>
+const SESSIONS = [
+  { title: 'pwd', time: '51 minutes ago', meta: 'TeamClaw Dev', preview: '/Users/haigang.ye/project/external/teamclaw-next' },
+  { title: '执行PS', time: '51 minutes ago', meta: 'TeamClaw Dev', preview: 'UID   PID  PPID   C STIME   TTY           TIME CMD' },
+  { title: '执行PS', time: 'yesterday', meta: 'TeamClaw Dev', preview: 'UID   PID  PPID   C STIME   TTY           TIME CMD' },
+  { title: '执行PS', time: 'yesterday', meta: 'TeamClaw Dev', preview: 'UID   PID  PPID   C STIME   TTY           TIME CMD' },
+  { title: '执行PS', time: 'yesterday', meta: 'TeamClaw Dev', preview: 'UID   PID  PPID   C STIME   TTY           TIME CMD' },
+  { title: 'socket 排查', time: '2 days ago', meta: 'TeamClaw Dev', preview: '~/.amuxd/amuxd.sock · 127.0.0.1:56007' },
+  { title: 'Markdown 样式', time: '3 days ago', meta: 'TeamClaw Dev', preview: 'Notion light/dark · inline code C' },
+];
+
+const list = document.getElementById('list');
+const glass = document.getElementById('glass');
+let active = 0;
+let moveTimer = null;
+
+function renderRows() {
+  const frag = document.createDocumentFragment();
+  // keep glass as first child
+  [...list.querySelectorAll('.row')].forEach(n => n.remove());
+  SESSIONS.forEach((s, i) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'row';
+    btn.setAttribute('aria-selected', i === active ? 'true' : 'false');
+    btn.dataset.index = String(i);
+    btn.innerHTML = `
+      <span class="title">${s.title}</span>
+      <span class="time">${s.time}</span>
+      <span class="meta">${s.meta}</span>
+      <span class="preview">${s.preview}</span>
+      <span class="more" aria-hidden="true">⋯</span>
+    `;
+    btn.addEventListener('click', () => select(i));
+    frag.appendChild(btn);
+  });
+  list.appendChild(frag);
+}
+
+function select(i) {
+  if (i < 0 || i >= SESSIONS.length) return;
+  active = i;
+  list.querySelectorAll('.row').forEach((row, idx) => {
+    row.setAttribute('aria-selected', idx === active ? 'true' : 'false');
+  });
+  moveGlass(true);
+}
+
+function moveGlass(animate) {
+  const row = list.querySelector(`.row[data-index="${active}"]`);
+  if (!row) return;
+  const listRect = list.getBoundingClientRect();
+  const rowRect = row.getBoundingClientRect();
+  const top = rowRect.top - listRect.top + list.scrollTop;
+  const height = rowRect.height;
+
+  if (animate) {
+    glass.classList.add('moving');
+    clearTimeout(moveTimer);
+    moveTimer = setTimeout(() => glass.classList.remove('moving'), 420);
+  }
+  glass.style.height = `${height}px`;
+  glass.style.transform = `translate3d(0, ${top}px, 0)`;
+}
+
+renderRows();
+requestAnimationFrame(() => moveGlass(false));
+
+document.getElementById('prev').onclick = () => select(Math.max(0, active - 1));
+document.getElementById('next').onclick = () => select(Math.min(SESSIONS.length - 1, active + 1));
+document.getElementById('jump').onclick = () => select(1);
+
+document.getElementById('tabs').addEventListener('click', (e) => {
+  const btn = e.target.closest('button');
+  if (!btn) return;
+  if (btn.dataset.mode) {
+    document.querySelectorAll('[data-mode]').forEach(b => b.classList.toggle('on', b === btn));
+    document.body.classList.toggle('dark-page', btn.dataset.mode === 'dark');
+    requestAnimationFrame(() => moveGlass(false));
+  }
+  if (btn.dataset.fx) {
+    document.querySelectorAll('[data-fx]').forEach(b => b.classList.toggle('on', b === btn));
+    list.classList.toggle('gooey', btn.dataset.fx === 'gooey');
+  }
+});
+
+window.addEventListener('resize', () => moveGlass(false));
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'ArrowDown') { e.preventDefault(); select(active + 1); }
+  if (e.key === 'ArrowUp') { e.preventDefault(); select(active - 1); }
+});
+</script>
+</body>
+</html>

--- a/packages/app/src/components/chat/MessageCard.tsx
+++ b/packages/app/src/components/chat/MessageCard.tsx
@@ -28,101 +28,77 @@ export function MessageCard({ message }: MessageCardProps) {
         {isUser ? (
           <p className="text-sm whitespace-pre-wrap break-words">{message.content}</p>
         ) : (
-          <div className="prose prose-sm max-w-none text-text-primary space-y-4 break-words [overflow-wrap:anywhere]">
+          <div className="chat-md max-w-none break-words text-[14.5px] text-foreground [overflow-wrap:anywhere]">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{
                 // Headings
                 h1: ({ children }) => (
-                  <h1 className="text-xl font-bold mt-6 mb-3 text-text-primary first:mt-0">{children}</h1>
+                  <h1 className="mt-[1.15em] mb-[0.3em] text-[1.5em] font-bold tracking-[-0.015em] text-foreground first:mt-0">{children}</h1>
                 ),
                 h2: ({ children }) => (
-                  <h2 className="text-lg font-bold mt-6 mb-3 text-text-primary first:mt-0">{children}</h2>
+                  <h2 className="mt-[1.1em] mb-[0.25em] text-[1.25em] font-semibold tracking-[-0.01em] text-foreground first:mt-0">{children}</h2>
                 ),
                 h3: ({ children }) => (
-                  <h3 className="text-base font-semibold mt-5 mb-2 text-text-primary first:mt-0">{children}</h3>
+                  <h3 className="mt-[1em] mb-[0.2em] text-[1.1em] font-semibold text-foreground first:mt-0">{children}</h3>
                 ),
                 // Paragraphs
                 p: ({ children }) => (
-                  <p className="mb-4 text-text-primary leading-relaxed">{children}</p>
+                  <p className="my-[0.4em] leading-[1.6] text-foreground">{children}</p>
                 ),
                 // Strong/Bold
                 strong: ({ children }) => (
-                  <strong className="font-semibold text-text-primary">{children}</strong>
+                  <strong className="font-semibold text-foreground">{children}</strong>
                 ),
                 // Custom table styling
                 table: ({ children }) => (
-                  <div className="overflow-x-auto my-5 rounded-lg border border-border">
-                    <table className="min-w-full border-collapse text-sm">
+                  <div className="my-3 overflow-x-auto">
+                    <table className="w-full border-collapse text-[0.92em]">
                       {children}
                     </table>
                   </div>
                 ),
                 thead: ({ children }) => (
-                  <thead className="bg-bg-tertiary">{children}</thead>
+                  <thead>{children}</thead>
                 ),
                 th: ({ children }) => (
-                  <th className="border-b border-border px-4 py-3 text-left font-semibold text-text-primary">
+                  <th className="border border-foreground/[0.09] px-2.5 py-1.5 text-left font-semibold text-foreground dark:border-white/[0.12]">
                     {children}
                   </th>
                 ),
                 tr: ({ children }) => (
-                  <tr className="border-b border-border last:border-b-0">{children}</tr>
+                  <tr className="hover:bg-foreground/[0.03] dark:hover:bg-white/[0.04]">{children}</tr>
                 ),
                 td: ({ children }) => (
-                  <td className="px-4 py-3 text-text-primary">{children}</td>
+                  <td className="border border-foreground/[0.09] px-2.5 py-1.5 text-foreground dark:border-white/[0.12]">{children}</td>
                 ),
                 // Blockquote
                 blockquote: ({ children }) => (
-                  <blockquote className="border-l-4 border-accent-green pl-4 my-4 text-text-secondary italic">
+                  <blockquote className="my-2.5 border-l-[3px] border-current pl-3.5 text-muted-foreground not-italic">
                     {children}
                   </blockquote>
                 ),
-                // Code blocks
-                pre: ({ children }) => (
-                  <pre className="my-4 bg-bg-tertiary rounded-lg overflow-x-auto">
-                    {children}
-                  </pre>
-                ),
-                code: ({ className, children, ...props }) => {
-                  const isInline = !className
-                  return isInline ? (
-                    <code
-                      className="bg-bg-tertiary px-1.5 py-0.5 rounded text-foreground text-sm font-mono break-words [overflow-wrap:anywhere]"
-                      {...props}
-                    >
-                      {children}
-                    </code>
-                  ) : (
-                    <code
-                      className={cn('block p-4 font-mono text-sm leading-relaxed', className)}
-                      {...props}
-                    >
-                      {children}
-                    </code>
-                  )
-                },
-                // Lists
-                ul: ({ children }) => (
-                  <ul className="list-disc pl-5 mb-4 space-y-2">{children}</ul>
-                ),
-                ol: ({ children }) => (
-                  <ol className="list-decimal pl-5 mb-4 space-y-2">{children}</ol>
-                ),
-                li: ({ children }) => (
-                  <li className="text-text-primary leading-relaxed">{children}</li>
-                ),
-                // Links
                 a: ({ children, href }) => (
                   <a
                     href={href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-accent-green hover:underline"
+                    className="rounded-[2px] text-foreground underline decoration-foreground/30 underline-offset-2 hover:bg-foreground/[0.06]"
                   >
                     {children}
                   </a>
                 ),
+                code: ({ className, children }) => {
+                  const isInline = !className
+                  if (isInline) {
+                    return <code className="chat-md-inline-code rounded-[3px] px-[0.3em] py-[0.08em] font-mono text-[0.86em]">{children}</code>
+                  }
+                  return (
+                    <pre className="chat-md-code my-2.5 overflow-x-auto rounded-md p-3.5">
+                      <code className="font-mono text-[13px]">{children}</code>
+                    </pre>
+                  )
+                },
               }}
             >
               {message.content}

--- a/packages/app/src/components/diff/notion-shiki-themes.ts
+++ b/packages/app/src/components/diff/notion-shiki-themes.ts
@@ -1,0 +1,149 @@
+/**
+ * Notion-inspired Shiki themes for chat Markdown code blocks.
+ * Token colors match docs/design-mock/chat-markdown-notion.html.
+ */
+
+import type { ThemeRegistration } from 'shiki';
+
+export const NOTION_LIGHT_THEME_NAME = 'notion-light' as const;
+export const NOTION_DARK_THEME_NAME = 'notion-dark' as const;
+
+/** Design tokens from chat-markdown-notion.html (.t-light) */
+const light = {
+  bg: '#F7F6F3',
+  ink: '#37352F',
+  mute: '#9B9A97',
+  kw: '#0070f3',
+  str: '#0F7B6C',
+  key: '#6940A5',
+  bool: '#CB912F',
+  comment: '#9B9A97',
+} as const;
+
+/** Design tokens from chat-markdown-notion.html (.t-dark) */
+const dark = {
+  bg: '#202020',
+  ink: 'rgba(255, 255, 255, 0.86)',
+  mute: 'rgba(255, 255, 255, 0.36)',
+  kw: '#6DB3F8',
+  str: '#4DAB9A',
+  key: '#B088F5',
+  bool: '#E0B45A',
+  comment: 'rgba(255, 255, 255, 0.36)',
+} as const;
+
+function notionTokenColors(c: {
+  ink: string;
+  mute: string;
+  kw: string;
+  str: string;
+  key: string;
+  bool: string;
+  comment: string;
+}): ThemeRegistration['tokenColors'] {
+  return [
+    {
+      scope: ['comment', 'punctuation.definition.comment', 'string.comment'],
+      settings: { foreground: c.comment, fontStyle: 'italic' },
+    },
+    {
+      scope: [
+        'keyword',
+        'keyword.control',
+        'keyword.operator.new',
+        'storage',
+        'storage.type',
+        'storage.modifier',
+        'constant.language',
+      ],
+      settings: { foreground: c.kw, fontStyle: 'bold' },
+    },
+    {
+      scope: [
+        'string',
+        'string.quoted',
+        'string.template',
+        'string.regexp',
+        'constant.other.symbol',
+        'markup.inline.raw',
+      ],
+      settings: { foreground: c.str },
+    },
+    {
+      scope: [
+        'entity.name.function',
+        'support.function',
+        'meta.function-call',
+        'variable.function',
+      ],
+      settings: { foreground: c.key },
+    },
+    {
+      scope: [
+        'constant.numeric',
+        'constant.language.boolean',
+        'constant.language.null',
+        'constant.language.undefined',
+        'support.constant',
+      ],
+      settings: { foreground: c.bool },
+    },
+    {
+      scope: [
+        'entity.name.type',
+        'entity.name.class',
+        'support.type',
+        'support.class',
+        'entity.other.inherited-class',
+      ],
+      settings: { foreground: c.key },
+    },
+    {
+      scope: [
+        'variable',
+        'variable.other',
+        'variable.parameter',
+        'meta.definition.variable',
+        'support.variable',
+      ],
+      settings: { foreground: c.ink },
+    },
+    {
+      scope: [
+        'meta.object-literal.key',
+        'support.type.property-name',
+        'entity.name.tag',
+        'entity.other.attribute-name',
+      ],
+      settings: { foreground: c.key },
+    },
+    {
+      scope: ['punctuation', 'meta.brace', 'keyword.operator'],
+      settings: { foreground: c.mute },
+    },
+    {
+      scope: ['invalid', 'invalid.illegal'],
+      settings: { foreground: '#eb5757' },
+    },
+  ];
+}
+
+export const notionLightTheme: ThemeRegistration = {
+  name: NOTION_LIGHT_THEME_NAME,
+  type: 'light',
+  colors: {
+    'editor.background': light.bg,
+    'editor.foreground': light.ink,
+  },
+  tokenColors: notionTokenColors(light),
+};
+
+export const notionDarkTheme: ThemeRegistration = {
+  name: NOTION_DARK_THEME_NAME,
+  type: 'dark',
+  colors: {
+    'editor.background': dark.bg,
+    'editor.foreground': dark.ink,
+  },
+  tokenColors: notionTokenColors(dark),
+};

--- a/packages/app/src/components/diff/shiki-renderer.ts
+++ b/packages/app/src/components/diff/shiki-renderer.ts
@@ -1,12 +1,23 @@
 /**
  * ShikiRenderer - Syntax highlighting using Shiki.
- * 
- * Provides lazy-loaded, cached Shiki highlighter for diff rendering.
+ *
+ * Provides lazy-loaded, cached Shiki highlighter for diff rendering
+ * and chat Markdown code blocks (Notion themes).
  */
 
-import type { BundledLanguage, BundledTheme, HighlighterGeneric } from 'shiki';
+import type { BundledLanguage, HighlighterGeneric, ThemeRegistration } from 'shiki';
+import {
+  NOTION_DARK_THEME_NAME,
+  NOTION_LIGHT_THEME_NAME,
+  notionDarkTheme,
+  notionLightTheme,
+} from './notion-shiki-themes';
 
-let highlighterPromise: Promise<HighlighterGeneric<BundledLanguage, BundledTheme>> | null = null;
+export { NOTION_DARK_THEME_NAME, NOTION_LIGHT_THEME_NAME };
+
+type AppTheme = 'github-dark' | 'github-light' | typeof NOTION_LIGHT_THEME_NAME | typeof NOTION_DARK_THEME_NAME;
+
+let highlighterPromise: Promise<HighlighterGeneric<BundledLanguage, AppTheme>> | null = null;
 
 /**
  * Get or create a shared Shiki highlighter instance.
@@ -16,14 +27,19 @@ export async function getHighlighter() {
   if (!highlighterPromise) {
     highlighterPromise = import('shiki').then(({ createHighlighter }) =>
       createHighlighter({
-        themes: ['github-dark', 'github-light'],
+        themes: [
+          'github-dark',
+          'github-light',
+          notionLightTheme as ThemeRegistration,
+          notionDarkTheme as ThemeRegistration,
+        ],
         langs: [
           'typescript', 'javascript', 'python', 'json', 'yaml', 'css',
           'html', 'xml', 'sql', 'shell', 'markdown', 'rust', 'go',
           'java', 'c', 'cpp',
         ],
       }),
-    );
+    ) as Promise<HighlighterGeneric<BundledLanguage, AppTheme>>;
   }
   return highlighterPromise;
 }

--- a/packages/app/src/components/sidebar/SessionLiquidGlass.tsx
+++ b/packages/app/src/components/sidebar/SessionLiquidGlass.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type SessionLiquidGlassProps = {
+  /** Positioning root that wraps the session rows (must be `position: relative`). */
+  rootRef: React.RefObject<HTMLElement | null>
+  /** Scroll parent — used to remeasure on scroll (virtual list). */
+  scrollRef: React.RefObject<HTMLElement | null>
+  activeSessionId: string | null | undefined
+  /** Hide during batch select / empty states. */
+  disabled?: boolean
+  /** Extra deps that change row geometry (dock open, row set, etc.). */
+  layoutKey?: string | number
+}
+
+/**
+ * Shared Soft Comfort “liquid glass” selection pill.
+ * One layer slides via translateY/height instead of per-card paper shadows.
+ */
+export function SessionLiquidGlass({
+  rootRef,
+  scrollRef,
+  activeSessionId,
+  disabled = false,
+  layoutKey,
+}: SessionLiquidGlassProps) {
+  const glassRef = React.useRef<HTMLDivElement>(null)
+  const [visible, setVisible] = React.useState(false)
+  const [moving, setMoving] = React.useState(false)
+  const prevIdRef = React.useRef<string | null | undefined>(null)
+  const moveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const sync = React.useCallback(() => {
+    const root = rootRef.current
+    const glass = glassRef.current
+    if (!root || !glass || disabled || !activeSessionId) {
+      setVisible(false)
+      return
+    }
+
+    const row = Array.from(
+      root.querySelectorAll<HTMLElement>('[data-testid="v2-session-row"]'),
+    ).find((el) => el.getAttribute('data-session-id') === activeSessionId)
+    if (!row) {
+      setVisible(false)
+      return
+    }
+
+    const rootRect = root.getBoundingClientRect()
+    const rowRect = row.getBoundingClientRect()
+    const top = rowRect.top - rootRect.top
+    const height = rowRect.height
+
+    glass.style.transform = `translate3d(0, ${Math.max(0, top)}px, 0)`
+    glass.style.height = `${Math.max(0, height)}px`
+    setVisible(true)
+  }, [rootRef, activeSessionId, disabled])
+
+  React.useLayoutEffect(() => {
+    const idChanged = prevIdRef.current !== activeSessionId
+    if (idChanged && activeSessionId && prevIdRef.current != null && prevIdRef.current !== undefined) {
+      setMoving(true)
+      if (moveTimerRef.current) clearTimeout(moveTimerRef.current)
+      moveTimerRef.current = setTimeout(() => setMoving(false), 420)
+    }
+    prevIdRef.current = activeSessionId ?? null
+    sync()
+  }, [sync, activeSessionId, layoutKey, disabled])
+
+  React.useEffect(() => {
+    const scroll = scrollRef.current
+    if (!scroll) return
+    const onScroll = () => sync()
+    scroll.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', sync)
+    return () => {
+      scroll.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', sync)
+    }
+  }, [scrollRef, sync])
+
+  React.useEffect(() => {
+    const root = rootRef.current
+    if (!root || !activeSessionId || disabled) return
+    const row = Array.from(
+      root.querySelectorAll<HTMLElement>('[data-testid="v2-session-row"]'),
+    ).find((el) => el.getAttribute('data-session-id') === activeSessionId)
+    if (!row || typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(() => sync())
+    ro.observe(row)
+    return () => ro.disconnect()
+  }, [rootRef, activeSessionId, disabled, layoutKey, sync])
+
+  React.useEffect(() => () => {
+    if (moveTimerRef.current) clearTimeout(moveTimerRef.current)
+  }, [])
+
+  return (
+    <div
+      ref={glassRef}
+      aria-hidden
+      data-testid="v2-session-liquid-glass"
+      data-visible={visible ? 'true' : 'false'}
+      data-moving={moving ? 'true' : 'false'}
+      className={cn('session-liquid-glass', moving && 'session-liquid-glass--moving')}
+      style={{ opacity: visible ? 1 : 0 }}
+    />
+  )
+}

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -22,6 +22,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { AnimatedClock } from '@/components/ui/animated-clock'
 import { SessionSearchDialog } from '@/components/sidebar/session-search-dialog'
 import { SessionDetailDialog, type SessionDetailListHints } from '@/components/sidebar/SessionDetailDialog'
+import { SessionLiquidGlass } from '@/components/sidebar/SessionLiquidGlass'
 import { SidebarMenu, SidebarMenuItem } from '@/components/ui/sidebar'
 import {
   AlertDialog,
@@ -326,6 +327,7 @@ export function SessionListColumn({
 
   const shouldVirtualize = virtualRows.length > VIRTUAL_SESSION_THRESHOLD
   const scrollRef = React.useRef<HTMLDivElement>(null)
+  const listRootRef = React.useRef<HTMLDivElement>(null)
   const sessionVirtualizer = useVirtualizer({
     count: shouldVirtualize ? virtualRows.length : 0,
     getScrollElement: () => scrollRef.current,
@@ -334,6 +336,7 @@ export function SessionListColumn({
     gap: 2,
     getItemKey: (index) => virtualRows[index].key,
   })
+  const glassLayoutKey = `${activeSessionId ?? ''}:${actionsOpenSessionId ?? ''}:${filteredRows.length}:${pinnedRows.length}:${shouldVirtualize ? 1 : 0}`
 
   React.useEffect(() => {
     if (!shouldVirtualize) return
@@ -614,11 +617,10 @@ export function SessionListColumn({
           data-active={isActive ? 'true' : 'false'}
           data-batch-checked={isBatchChecked ? 'true' : 'false'}
           className={cn(
-            'my-px w-full rounded-[11px] px-2.5 py-2 transition-[background-color,box-shadow] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
+            'relative z-[1] my-px w-full rounded-[11px] px-2.5 py-2 transition-[background-color] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
             !isRenaming && 'cursor-pointer',
             compactHeader && 'px-2',
-            isActive && !batchSelecting &&
-              'relative z-0 bg-paper shadow-[0_2px_8px_rgba(28,27,25,0.05),0_1px_2px_rgba(28,27,25,0.03)] ring-1 ring-black/[0.05]',
+            // Selection chrome is the shared liquid-glass pill — keep the row transparent when active.
             !isActive && !batchSelecting && 'hover:bg-black/[0.035]',
             isHighlighted && !isActive && !batchSelecting && 'bg-emerald-500/15 ring-1 ring-emerald-500/30',
             batchSelecting && isBatchChecked && 'bg-selected',
@@ -1108,42 +1110,53 @@ export function SessionListColumn({
                 : t('sidebar.noConversations', 'No conversations')}
             </p>
           </div>
-        ) : shouldVirtualize ? (
-          <div
-            style={{ height: `${sessionVirtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}
-            data-testid="v2-session-list-virtual"
-          >
-            {sessionVirtualizer.getVirtualItems().map((virtualItem) => {
-              const v = virtualRows[virtualItem.index]
-              return (
-                <div
-                  key={v.key}
-                  ref={(el) => { if (el) sessionVirtualizer.measureElement(el) }}
-                  data-index={virtualItem.index}
-                  style={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    width: '100%',
-                    transform: `translateY(${virtualItem.start}px)`,
-                  }}
-                >
-                  {renderVirtualRow(v)}
-                </div>
-              )
-            })}
-          </div>
         ) : (
-          <SidebarMenu>
-            {filter.kind === 'all' && pinnedRows.length > 0 && (
-              <>
-                {renderPinnedHeader()}
-                {pinnedRows.map(renderSessionItem)}
-                {regularRows.length > 0 && renderPinnedDivider()}
-              </>
+          <div ref={listRootRef} className="relative">
+            <SessionLiquidGlass
+              rootRef={listRootRef}
+              scrollRef={scrollRef}
+              activeSessionId={activeSessionId}
+              disabled={batchSelecting}
+              layoutKey={glassLayoutKey}
+            />
+            {shouldVirtualize ? (
+              <div
+                style={{ height: `${sessionVirtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}
+                data-testid="v2-session-list-virtual"
+              >
+                {sessionVirtualizer.getVirtualItems().map((virtualItem) => {
+                  const v = virtualRows[virtualItem.index]
+                  return (
+                    <div
+                      key={v.key}
+                      ref={(el) => { if (el) sessionVirtualizer.measureElement(el) }}
+                      data-index={virtualItem.index}
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: '100%',
+                        transform: `translateY(${virtualItem.start}px)`,
+                      }}
+                    >
+                      {renderVirtualRow(v)}
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <SidebarMenu className="gap-0">
+                {filter.kind === 'all' && pinnedRows.length > 0 && (
+                  <>
+                    {renderPinnedHeader()}
+                    {pinnedRows.map(renderSessionItem)}
+                    {regularRows.length > 0 && renderPinnedDivider()}
+                  </>
+                )}
+                {(filter.kind === 'all' ? regularRows : filteredRows).map(renderSessionItem)}
+              </SidebarMenu>
             )}
-            {(filter.kind === 'all' ? regularRows : filteredRows).map(renderSessionItem)}
-          </SidebarMenu>
+          </div>
         )}
         {listHasMore && (
           <div className="px-4 py-3">

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -607,7 +607,7 @@ export function SessionListColumn({
           setActionsOpenSessionId(null)
         }}
       >
-        {/* Soft Comfort capsule — chrome lives here so select / more / dock stay sibling controls. */}
+        {/* Soft Comfort capsule — whole card selects; ⋯ / dock stopPropagation. */}
         <div
           data-testid="v2-session-row"
           data-session-id={row.id}
@@ -615,6 +615,7 @@ export function SessionListColumn({
           data-batch-checked={isBatchChecked ? 'true' : 'false'}
           className={cn(
             'my-px w-full rounded-[11px] px-2.5 py-2 transition-[background-color,box-shadow] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
+            !isRenaming && 'cursor-pointer',
             compactHeader && 'px-2',
             isActive && !batchSelecting &&
               'relative z-0 bg-paper shadow-[0_2px_8px_rgba(28,27,25,0.05),0_1px_2px_rgba(28,27,25,0.03)] ring-1 ring-black/[0.05]',
@@ -622,6 +623,12 @@ export function SessionListColumn({
             isHighlighted && !isActive && !batchSelecting && 'bg-emerald-500/15 ring-1 ring-emerald-500/30',
             batchSelecting && isBatchChecked && 'bg-selected',
           )}
+          onClick={selectSession}
+          onDoubleClick={(e) => {
+            if (batchSelecting || isRenaming) return
+            e.stopPropagation()
+            handleStartRename(e, row.id)
+          }}
         >
           <div className="flex w-full min-w-0 items-start">
             {batchSelecting ? (
@@ -644,30 +651,29 @@ export function SessionListColumn({
               </span>
             ) : null}
             <div className="flex min-w-0 flex-1 flex-col items-start gap-1">
-              {/* Title row: select button | meta | sibling more (no nested buttons). */}
+              {/* Title row: title + meta + sibling more (more stops propagation). */}
               <div className="flex w-full min-w-0 items-center gap-1.5">
                 {row.isPinned && <Pin className="h-3 w-3 shrink-0 fill-amber-500/20 text-amber-500" />}
                 {isRenaming ? (
-                  <SessionRenameInput
-                    defaultValue={row.title}
-                    onConfirm={(v) => handleRenameConfirm(row.id, v)}
-                    onCancel={() => setRenamingSessionId(null)}
-                  />
+                  <div
+                    className="min-w-0 flex-1"
+                    onClick={(e) => e.stopPropagation()}
+                    onDoubleClick={(e) => e.stopPropagation()}
+                  >
+                    <SessionRenameInput
+                      defaultValue={row.title}
+                      onConfirm={(v) => handleRenameConfirm(row.id, v)}
+                      onCancel={() => setRenamingSessionId(null)}
+                    />
+                  </div>
                 ) : (
                   <>
-                    <button
-                      type="button"
+                    <span
                       className="min-w-0 flex-1 truncate text-left text-[13px] font-semibold text-foreground"
                       data-testid="v2-session-row-title"
-                      onClick={selectSession}
-                      onDoubleClick={(e) => {
-                        if (batchSelecting) return
-                        e.stopPropagation()
-                        handleStartRename(e, row.id)
-                      }}
                     >
                       {row.title || t('chat.newChat', 'New Chat')}
-                    </button>
+                    </span>
                     <div className="flex shrink-0 items-center">
                       {!isActive && row.hasUnread && (
                         <span
@@ -697,16 +703,16 @@ export function SessionListColumn({
                           title={t('sidebar.moreActions', 'More actions')}
                           className={cn(
                             'inline-grid h-[22px] place-items-center overflow-hidden rounded-md text-muted-foreground',
-                            'w-0 opacity-0',
+                            'pointer-events-none w-0 opacity-0',
                             'transition-[width,opacity,margin,background-color,color] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
-                            // Hover reveal. Avoid group-focus-within (selecting the row would pin ⋯).
-                            'group-hover/menu-item:ml-0.5 group-hover/menu-item:w-[22px] group-hover/menu-item:opacity-100',
-                            'focus-visible:ml-0.5 focus-visible:w-[22px] focus-visible:opacity-100',
+                            // Hover reveal. Avoid group-focus-within (row focus would pin ⋯).
+                            'group-hover/menu-item:pointer-events-auto group-hover/menu-item:ml-0.5 group-hover/menu-item:w-[22px] group-hover/menu-item:opacity-100',
+                            'focus-visible:pointer-events-auto focus-visible:ml-0.5 focus-visible:w-[22px] focus-visible:opacity-100',
                             // Touch / no-hover: keep a hittable ⋯ without relying on hover.
-                            '[@media(hover:none)]:ml-0.5 [@media(hover:none)]:w-[22px] [@media(hover:none)]:opacity-100',
+                            '[@media(hover:none)]:pointer-events-auto [@media(hover:none)]:ml-0.5 [@media(hover:none)]:w-[22px] [@media(hover:none)]:opacity-100',
                             'hover:bg-black/[0.08] hover:text-foreground dark:hover:bg-white/10',
                             // While dock is open, keep ⋯ visible even after focus moves into the dock.
-                            actionsOpen && 'ml-0.5 w-[22px] bg-black/[0.08] text-foreground opacity-100 dark:bg-white/10',
+                            actionsOpen && 'pointer-events-auto ml-0.5 w-[22px] bg-black/[0.08] text-foreground opacity-100 dark:bg-white/10',
                           )}
                           onClick={(e) => {
                             e.stopPropagation()
@@ -729,81 +735,73 @@ export function SessionListColumn({
                 )}
               </div>
 
-              {!isRenaming && (showWorkspaceSubline || row.lastMessagePreview || ((parts.length > 0 && !isSoloWithLocalAgent) || activity)) && (
-                <button
-                  type="button"
-                  className="flex w-full min-w-0 flex-col items-start gap-1 text-left"
-                  onClick={selectSession}
+              {!isRenaming && showWorkspaceSubline && (
+                <span
+                  className="w-full truncate font-mono text-[10.5px] leading-tight text-faint"
+                  data-testid="v2-session-row-workspace"
                 >
-                  {showWorkspaceSubline && (
-                    <span
-                      className="w-full truncate font-mono text-[10.5px] leading-tight text-faint"
-                      data-testid="v2-session-row-workspace"
-                    >
-                      {workspaceLabel}
-                    </span>
+                  {workspaceLabel}
+                </span>
+              )}
+              {!isRenaming && row.lastMessagePreview && (
+                <span
+                  className={cn(
+                    'w-full truncate text-[12px] leading-snug text-muted-foreground transition-opacity duration-150',
+                    actionsOpen && 'opacity-50',
                   )}
-                  {row.lastMessagePreview && (
-                    <span
-                      className={cn(
-                        'w-full truncate text-[12px] leading-snug text-muted-foreground transition-opacity duration-150',
-                        actionsOpen && 'opacity-50',
-                      )}
-                      data-testid="v2-session-row-preview"
-                    >
-                      {row.lastMessagePreview.split(/(@[\w.\-\u4e00-\u9fff]+)/g).map((part, i) =>
-                        part.startsWith('@') ? (
-                          <em key={i} className="font-medium not-italic text-coral">
-                            {part}
-                          </em>
-                        ) : (
-                          <React.Fragment key={i}>{part}</React.Fragment>
-                        ),
-                      )}
-                    </span>
+                  data-testid="v2-session-row-preview"
+                >
+                  {row.lastMessagePreview.split(/(@[\w.\-\u4e00-\u9fff]+)/g).map((part, i) =>
+                    part.startsWith('@') ? (
+                      <em key={i} className="font-medium not-italic text-coral">
+                        {part}
+                      </em>
+                    ) : (
+                      <React.Fragment key={i}>{part}</React.Fragment>
+                    ),
                   )}
-                  {((parts.length > 0 && !isSoloWithLocalAgent) || activity) && (
-                    <span className="flex w-full items-center gap-1.5" data-testid="v2-session-row-participants">
-                      {parts.length > 0 && !isSoloWithLocalAgent && (
-                        <>
-                          <span className="flex -space-x-1.5">
-                            {parts.slice(0, 3).map((p) => {
-                              const c = actorAvatarColor(p.actorId)
-                              return (
-                                <Avatar
-                                  key={p.actorId}
-                                  className={cn(
-                                    'h-4 w-4 ring-1 ring-paper',
-                                    p.isAgent ? 'rounded-[3px]' : 'rounded-full',
-                                  )}
-                                >
-                                  {p.avatarUrl && <AvatarImage src={p.avatarUrl} alt={p.displayName} />}
-                                  <AvatarFallback
-                                    className={cn(
-                                      'text-[8px] font-semibold',
-                                      p.isAgent ? 'rounded-[3px]' : 'rounded-full',
-                                    )}
-                                    style={{ background: c.bg, color: c.fg }}
-                                  >
-                                    {p.displayName.slice(0, 1).toUpperCase()}
-                                  </AvatarFallback>
-                                </Avatar>
-                              )
-                            })}
-                          </span>
-                          <span className="text-[10.5px] text-faint">
-                            {t('sidebar.participantCount', { count: parts.length, defaultValue: '{{count}} 位' })}
-                          </span>
-                        </>
-                      )}
-                      <span className="flex-1" />
-                      <SessionActivityBadge activity={activity} />
-                    </span>
+                </span>
+              )}
+              {!isRenaming && ((parts.length > 0 && !isSoloWithLocalAgent) || activity) && (
+                <div className="flex w-full items-center gap-1.5" data-testid="v2-session-row-participants">
+                  {parts.length > 0 && !isSoloWithLocalAgent && (
+                    <>
+                      <div className="flex -space-x-1.5">
+                        {parts.slice(0, 3).map((p) => {
+                          const c = actorAvatarColor(p.actorId)
+                          return (
+                            <Avatar
+                              key={p.actorId}
+                              className={cn(
+                                'h-4 w-4 ring-1 ring-paper',
+                                p.isAgent ? 'rounded-[3px]' : 'rounded-full',
+                              )}
+                            >
+                              {p.avatarUrl && <AvatarImage src={p.avatarUrl} alt={p.displayName} />}
+                              <AvatarFallback
+                                className={cn(
+                                  'text-[8px] font-semibold',
+                                  p.isAgent ? 'rounded-[3px]' : 'rounded-full',
+                                )}
+                                style={{ background: c.bg, color: c.fg }}
+                              >
+                                {p.displayName.slice(0, 1).toUpperCase()}
+                              </AvatarFallback>
+                            </Avatar>
+                          )
+                        })}
+                      </div>
+                      <span className="text-[10.5px] text-faint">
+                        {t('sidebar.participantCount', { count: parts.length, defaultValue: '{{count}} 位' })}
+                      </span>
+                    </>
                   )}
-                </button>
+                  <span className="flex-1" />
+                  <SessionActivityBadge activity={activity} />
+                </div>
               )}
 
-              {/* C2 dock — sibling of select/more buttons, expands row height. */}
+              {/* C2 dock — stopPropagation so icon clicks don't also select the session. */}
               {!isRenaming && !batchSelecting && (
                 <div
                   id={actionsId}
@@ -816,6 +814,8 @@ export function SessionListColumn({
                   data-testid="v2-session-row-actions"
                   data-open={actionsOpen ? 'true' : 'false'}
                   aria-hidden={!actionsOpen}
+                  onClick={(e) => e.stopPropagation()}
+                  onDoubleClick={(e) => e.stopPropagation()}
                 >
                   <div className="min-h-0 overflow-hidden">
                     <div

--- a/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
@@ -358,6 +358,18 @@ describe('SessionListColumn', () => {
     switchToSession.mockRestore()
   })
 
+  it('selects a session when clicking dead-zone areas of the card (time / padding)', () => {
+    const switchToSession = vi.spyOn(useUIStore.getState(), 'switchToSession').mockResolvedValue()
+    render(<SessionListColumn />)
+
+    const row = screen.getAllByTestId('v2-session-row').find((el) => el.getAttribute('data-session-id') === 's2')
+    expect(row).toBeTruthy()
+    // Click the capsule itself (padding / non-title regions) — previously a dead zone.
+    fireEvent.click(row!)
+    expect(switchToSession).toHaveBeenCalledWith('s2')
+    switchToSession.mockRestore()
+  })
+
   it('creates a session directly from the new chat button in embed mode', async () => {
     useUIStore.setState({ embedMode: true })
     const onDismiss = vi.fn()

--- a/packages/app/src/packages/ai/message.tsx
+++ b/packages/app/src/packages/ai/message.tsx
@@ -593,9 +593,27 @@ export function ClickableImage({ src, alt, className }: { src: string; alt?: str
 // StableBlock (flag = false) and gets highlighted exactly once.
 export const StreamingTailContext = React.createContext(false)
 
+function useDocumentDarkMode() {
+  const [isDark, setIsDark] = React.useState(() =>
+    typeof document !== 'undefined' && document.documentElement.classList.contains('dark'),
+  )
+
+  React.useEffect(() => {
+    const root = document.documentElement
+    const sync = () => setIsDark(root.classList.contains('dark'))
+    sync()
+    const observer = new MutationObserver(sync)
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  return isDark
+}
+
 // --- Code block with syntax highlighting, language header, and copy button ---
 function CodeBlock({ language, children }: { language: string; children: string }) {
   const isStreamingTail = React.useContext(StreamingTailContext)
+  const isDark = useDocumentDarkMode()
   const [highlightedHtml, setHighlightedHtml] = React.useState<string | null>(null)
   const [copied, setCopied] = React.useState(false)
   const code = String(children).replace(/\n$/, '')
@@ -609,21 +627,27 @@ function CodeBlock({ language, children }: { language: string; children: string 
       setHighlightedHtml(null)
       return () => { cancelled = true }
     }
-    import('@/components/diff/shiki-renderer').then(async ({ getHighlighter, mapLanguage }) => {
-      if (cancelled) return
-      try {
-        const highlighter = await getHighlighter()
-        const isDark = document.documentElement.classList.contains('dark')
-        const theme = isDark ? 'github-dark' : 'github-light'
-        const lang = mapLanguage(language)
-        const html = highlighter.codeToHtml(code, { lang, theme })
-        if (!cancelled) setHighlightedHtml(html)
-      } catch {
-        // Fallback: no highlighting
-      }
-    })
+    import('@/components/diff/shiki-renderer').then(
+      async ({
+        getHighlighter,
+        mapLanguage,
+        NOTION_DARK_THEME_NAME,
+        NOTION_LIGHT_THEME_NAME,
+      }) => {
+        if (cancelled) return
+        try {
+          const highlighter = await getHighlighter()
+          const theme = isDark ? NOTION_DARK_THEME_NAME : NOTION_LIGHT_THEME_NAME
+          const lang = mapLanguage(language)
+          const html = highlighter.codeToHtml(code, { lang, theme })
+          if (!cancelled) setHighlightedHtml(html)
+        } catch {
+          // Fallback: no highlighting
+        }
+      },
+    )
     return () => { cancelled = true }
-  }, [code, language, isStreamingTail])
+  }, [code, language, isStreamingTail, isDark])
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(code)
@@ -632,24 +656,24 @@ function CodeBlock({ language, children }: { language: string; children: string 
   }
 
   return (
-    <div className="not-prose my-2 w-full overflow-hidden rounded-lg bg-foreground/[0.02] [overflow-wrap:normal]">
-      <div className="flex items-center justify-between px-3 py-1.5">
-        <span className="text-xs text-muted-foreground font-mono">{language}</span>
+    <div className="chat-md-code not-prose my-2.5 w-full overflow-hidden rounded-md [overflow-wrap:normal]">
+      <div className="chat-md-code-h flex items-center justify-between px-3 pt-1.5">
+        <span className="font-mono text-xs text-muted-foreground">{language}</span>
         <button
           onClick={handleCopy}
-          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
         >
           {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
         </button>
       </div>
       {highlightedHtml ? (
         <div
-          className="overflow-x-auto px-3 pb-3 text-[12.5px] [overflow-wrap:normal] [&_code]:!bg-transparent [&_code]:!p-0 [&_code]:[overflow-wrap:normal] [&_code]:whitespace-pre [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:[overflow-wrap:normal] [&_pre]:whitespace-pre"
+          className="overflow-x-auto px-4 pb-3.5 pt-1 text-[13px] leading-[1.5] [overflow-wrap:normal] [&_code]:!bg-transparent [&_code]:!p-0 [&_code]:[overflow-wrap:normal] [&_code]:whitespace-pre [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:[overflow-wrap:normal] [&_pre]:whitespace-pre"
           dangerouslySetInnerHTML={{ __html: highlightedHtml }}
         />
       ) : (
-        <pre className="overflow-x-auto whitespace-pre px-3 pb-3 [overflow-wrap:normal]">
-          <code className="font-mono text-[12.5px] text-foreground [overflow-wrap:normal]">{code}</code>
+        <pre className="overflow-x-auto whitespace-pre px-4 pb-3.5 pt-1 [overflow-wrap:normal]">
+          <code className="font-mono text-[13px] leading-[1.5] text-foreground [overflow-wrap:normal]">{code}</code>
         </pre>
       )}
     </div>
@@ -762,36 +786,38 @@ function MermaidBlock({ children }: { children: string }) {
 // Hoisted to module level so the object reference never changes between renders.
 // The `img` component needs basePath, so it's added per-render via useMemo.
 const markdownComponentsBase = {
-  // Heading scale steps down one tick from Tailwind defaults so the chat
-  // panel reads quieter at Direction B's 13px body size.
+  // Notion-inspired scale (chat-tuned: slightly smaller than full Notion page 16px).
   h1: ({ children }: { children?: React.ReactNode }) => (
-    <h1 className="text-lg font-semibold text-foreground mt-4 mb-2">{children}</h1>
+    <h1 className="mt-[1.15em] mb-[0.3em] text-[1.5em] font-bold leading-[1.25] tracking-[-0.015em] text-foreground first:mt-0">{children}</h1>
   ),
   h2: ({ children }: { children?: React.ReactNode }) => (
-    <h2 className="text-base font-semibold text-foreground mt-3 mb-2">{children}</h2>
+    <h2 className="mt-[1.1em] mb-[0.25em] text-[1.25em] font-semibold leading-[1.3] tracking-[-0.01em] text-foreground first:mt-0">{children}</h2>
   ),
   h3: ({ children }: { children?: React.ReactNode }) => (
-    <h3 className="text-sm font-semibold text-foreground mt-3 mb-1.5">{children}</h3>
+    <h3 className="mt-[1em] mb-[0.2em] text-[1.1em] font-semibold leading-[1.35] text-foreground first:mt-0">{children}</h3>
   ),
   p: ({ children }: { children?: React.ReactNode }) => (
-    <p className="my-2 min-w-0 leading-relaxed text-foreground">{children}</p>
+    <p className="my-[0.4em] min-w-0 leading-[1.6] text-foreground">{children}</p>
   ),
   table: ({ children }: { children?: React.ReactNode }) => (
-    <div className="overflow-x-auto rounded-lg border border-border my-3">
-      <table className="min-w-full border-collapse text-sm">{children}</table>
+    <div className="my-3 overflow-x-auto">
+      <table className="w-full border-collapse text-[0.92em]">{children}</table>
     </div>
   ),
-  thead: ({ children }: { children?: React.ReactNode }) => <thead className="bg-muted">{children}</thead>,
+  thead: ({ children }: { children?: React.ReactNode }) => <thead>{children}</thead>,
   th: ({ children }: { children?: React.ReactNode }) => (
-    <th className="border-b border-border px-4 py-2.5 text-left font-medium">{children}</th>
+    <th className="border border-foreground/[0.09] px-2.5 py-1.5 text-left font-semibold text-foreground dark:border-white/[0.12]">{children}</th>
   ),
   tr: ({ children }: { children?: React.ReactNode }) => (
-    <tr className="border-b border-border last:border-b-0">{children}</tr>
+    <tr className="hover:bg-foreground/[0.03] dark:hover:bg-white/[0.04]">{children}</tr>
   ),
-  td: ({ children }: { children?: React.ReactNode }) => <td className="px-4 py-2.5">{children}</td>,
+  td: ({ children }: { children?: React.ReactNode }) => (
+    <td className="border border-foreground/[0.09] px-2.5 py-1.5 align-top text-foreground dark:border-white/[0.12]">{children}</td>
+  ),
   blockquote: ({ children }: { children?: React.ReactNode }) => (
-    <blockquote className="border-l-4 border-[#5a7a64] pl-4 my-3 italic text-muted-foreground">{children}</blockquote>
+    <blockquote className="my-2.5 border-l-[3px] border-current py-0 pl-3.5 text-muted-foreground not-italic">{children}</blockquote>
   ),
+  hr: () => <hr className="my-5 border-0 border-t border-foreground/[0.09] dark:border-white/[0.12]" />,
   pre: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   code: ({ className, children, ...codeProps }: { className?: string; children?: React.ReactNode }) => {
     const codeText = String(children)
@@ -799,7 +825,7 @@ const markdownComponentsBase = {
     if (isInline) {
       return (
         <code
-          className="rounded bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-[0.9em] leading-snug text-foreground break-words [overflow-wrap:anywhere]"
+          className="chat-md-inline-code rounded-[3px] px-[0.3em] py-[0.08em] font-mono text-[0.86em] leading-normal break-words [overflow-wrap:anywhere]"
           {...codeProps}
         >
           {children}
@@ -813,12 +839,58 @@ const markdownComponentsBase = {
     return <CodeBlock language={language}>{codeText}</CodeBlock>
   },
   a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
-    <a href={href} target="_blank" rel="noopener noreferrer" className="text-[#5a7a64] hover:underline">{children}</a>
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="rounded-[2px] text-foreground underline decoration-foreground/30 underline-offset-2 hover:bg-foreground/[0.06] dark:decoration-white/30 dark:hover:bg-white/[0.08]"
+    >
+      {children}
+    </a>
   ),
-  ul: ({ children }: { children?: React.ReactNode }) => <ul className="list-disc pl-5 my-2 space-y-1">{children}</ul>,
-  ol: ({ children }: { children?: React.ReactNode }) => <ol className="list-decimal pl-5 my-2 space-y-1">{children}</ol>,
-  li: ({ children }: { children?: React.ReactNode }) => (
-    <li className="min-w-0 leading-relaxed">{children}</li>
+  ul: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
+    <ul className={cn('my-2 space-y-0.5 pl-6', className?.includes('contains-task-list') ? 'list-none pl-0' : 'list-disc', className)}>
+      {children}
+    </ul>
+  ),
+  ol: ({ children }: { children?: React.ReactNode }) => (
+    <ol className="my-2 list-decimal space-y-0.5 pl-6">{children}</ol>
+  ),
+  li: ({ children, className, ...liProps }: { children?: React.ReactNode; className?: string }) => {
+    const isTask = className?.includes('task-list-item')
+    return (
+      <li
+        className={cn(
+          'min-w-0 leading-[1.6]',
+          isTask && 'chat-md-task flex items-start gap-2',
+          className,
+        )}
+        {...liProps}
+      >
+        {children}
+      </li>
+    )
+  },
+  input: (props: React.ComponentProps<'input'>) => {
+    if (props.type === 'checkbox') {
+      return (
+        <input
+          {...props}
+          className={cn('chat-md-checkbox mt-1 shrink-0', props.className)}
+          disabled
+        />
+      )
+    }
+    return <input {...props} />
+  },
+  strong: ({ children }: { children?: React.ReactNode }) => (
+    <strong className="font-semibold text-foreground">{children}</strong>
+  ),
+  em: ({ children }: { children?: React.ReactNode }) => (
+    <em className="italic">{children}</em>
+  ),
+  del: ({ children }: { children?: React.ReactNode }) => (
+    <del className="text-muted-foreground line-through">{children}</del>
   ),
 } as const;
 
@@ -942,7 +1014,7 @@ export function MessageResponse({
             />
           </div>
         ) : (
-          <div key={index} className="prose prose-sm max-w-none min-w-0 text-[13px] text-foreground space-y-3 break-words [overflow-wrap:anywhere]">
+          <div key={index} className="chat-md max-w-none min-w-0 break-words text-[14.5px] text-foreground [overflow-wrap:anywhere]">
             <MarkdownRenderBoundary content={part.content}>
               <ReactMarkdown
                 remarkPlugins={remarkPluginsStable}

--- a/packages/app/src/styles/globals.css
+++ b/packages/app/src/styles/globals.css
@@ -1179,3 +1179,110 @@ input,
         opacity: 1;
     }
 }
+
+/* Session list — Soft Comfort liquid glass selection pill */
+.session-liquid-glass {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 56px;
+    border-radius: 11px;
+    pointer-events: none;
+    z-index: 0;
+    background: linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.72) 0%,
+        rgba(255, 255, 255, 0.48) 42%,
+        rgba(255, 255, 255, 0.38) 100%
+    );
+    backdrop-filter: blur(18px) saturate(1.55);
+    -webkit-backdrop-filter: blur(18px) saturate(1.55);
+    box-shadow:
+        0 1px 0 rgba(255, 255, 255, 0.85) inset,
+        0 -1px 0 rgba(28, 27, 25, 0.04) inset,
+        0 2px 8px rgba(28, 27, 25, 0.06),
+        0 1px 2px rgba(28, 27, 25, 0.04),
+        0 0 0 1px rgba(26, 26, 20, 0.06);
+    transition:
+        transform 420ms cubic-bezier(0.22, 1, 0.36, 1),
+        height 420ms cubic-bezier(0.22, 1, 0.36, 1),
+        border-radius 420ms cubic-bezier(0.22, 1, 0.36, 1),
+        box-shadow 280ms ease,
+        opacity 160ms ease;
+    will-change: transform, height;
+    transform: translate3d(0, 0, 0);
+}
+
+.session-liquid-glass::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.55) 0%,
+        rgba(255, 255, 255, 0) 42%
+    );
+    opacity: 0.9;
+    pointer-events: none;
+}
+
+.session-liquid-glass::after {
+    content: "";
+    position: absolute;
+    top: 1px;
+    left: 10%;
+    right: 28%;
+    height: 1px;
+    border-radius: 1px;
+    background: rgba(255, 255, 255, 0.95);
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.session-liquid-glass--moving {
+    border-radius: 13px 13px 10px 10px;
+    box-shadow:
+        0 1px 0 rgba(255, 255, 255, 0.9) inset,
+        0 6px 18px rgba(28, 27, 25, 0.08),
+        0 2px 4px rgba(28, 27, 25, 0.04),
+        0 0 0 1px rgba(26, 26, 20, 0.07);
+}
+
+.dark .session-liquid-glass {
+    background: linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.14) 0%,
+        rgba(255, 255, 255, 0.07) 50%,
+        rgba(255, 255, 255, 0.05) 100%
+    );
+    box-shadow:
+        0 8px 24px rgba(0, 0, 0, 0.35),
+        0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.dark .session-liquid-glass::before {
+    background: linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.06),
+        transparent 45%
+    );
+}
+
+/* Dark: no specular top streak — reads as a thick white edge on black. */
+.dark .session-liquid-glass::after {
+    display: none;
+}
+
+.dark .session-liquid-glass--moving {
+    box-shadow:
+        0 8px 28px rgba(0, 0, 0, 0.45),
+        0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .session-liquid-glass {
+        transition: opacity 120ms ease;
+    }
+}

--- a/packages/app/src/styles/globals.css
+++ b/packages/app/src/styles/globals.css
@@ -673,56 +673,74 @@ input,
     pointer-events: none;
 }
 
-/* Markdown preview styles */
-.markdown-preview {
-    line-height: 1.7;
+/* Markdown preview + chat Notion-inspired styles */
+.markdown-preview,
+.chat-md {
+    line-height: 1.6;
     color: var(--foreground);
 }
 
-.markdown-preview h1 {
-    font-size: 2em;
-    font-weight: 700;
-    margin-top: 1.5em;
-    margin-bottom: 0.5em;
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 0.3em;
+.chat-md {
+    font-size: 14.5px;
 }
 
-.markdown-preview h2 {
+.markdown-preview h1,
+.chat-md h1 {
     font-size: 1.5em;
-    font-weight: 600;
-    margin-top: 1.5em;
-    margin-bottom: 0.5em;
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 0.3em;
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    margin-top: 1.15em;
+    margin-bottom: 0.3em;
+    border-bottom: none;
+    padding-bottom: 0;
 }
 
-.markdown-preview h3 {
+.markdown-preview h2,
+.chat-md h2 {
     font-size: 1.25em;
     font-weight: 600;
-    margin-top: 1.25em;
-    margin-bottom: 0.5em;
+    letter-spacing: -0.01em;
+    margin-top: 1.1em;
+    margin-bottom: 0.25em;
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.markdown-preview h3,
+.chat-md h3 {
+    font-size: 1.1em;
+    font-weight: 600;
+    margin-top: 1em;
+    margin-bottom: 0.2em;
 }
 
 .markdown-preview h4,
 .markdown-preview h5,
-.markdown-preview h6 {
+.markdown-preview h6,
+.chat-md h4,
+.chat-md h5,
+.chat-md h6 {
     font-size: 1em;
     font-weight: 600;
-    margin-top: 1em;
-    margin-bottom: 0.5em;
+    margin-top: 0.9em;
+    margin-bottom: 0.2em;
+}
+
+.markdown-preview > :first-child,
+.chat-md > :first-child {
+    margin-top: 0 !important;
 }
 
 .markdown-preview p {
-    margin-top: 0.75em;
+    margin-top: 0.4em;
     margin-bottom: 0.75em;
 }
 
 .markdown-preview ul,
 .markdown-preview ol {
-    margin-top: 0.75em;
+    margin-top: 0.5em;
     margin-bottom: 0.75em;
-    padding-left: 1.5em;
+    padding-left: 1.6em;
 }
 
 .markdown-preview ul {
@@ -734,44 +752,227 @@ input,
 }
 
 .markdown-preview li {
-    margin-top: 0.25em;
-    margin-bottom: 0.25em;
+    margin-top: 0.15em;
+    margin-bottom: 0.15em;
 }
 
 .markdown-preview li > ul,
 .markdown-preview li > ol {
-    margin-top: 0.25em;
-    margin-bottom: 0.25em;
+    margin-top: 0.15em;
+    margin-bottom: 0.15em;
 }
 
 .markdown-preview code {
     font-family:
         "JetBrains Mono", "Fira Code", "SF Mono", Menlo, Monaco, "Courier New",
         monospace;
-    font-size: 0.875em;
-    background-color: var(--muted);
-    padding: 0.2em 0.4em;
-    border-radius: 0.25rem;
+    font-size: 0.86em;
+    background-color: var(--panel);
+    color: var(--ink-2);
+    box-shadow: inset 0 0 0 1px var(--border-soft);
+    border: none;
+    padding: 0.08em 0.3em;
+    border-radius: 3px;
+}
+
+.dark .markdown-preview code {
+    background-color: var(--panel);
+    color: var(--ink-2);
+    box-shadow: inset 0 0 0 1px var(--border-soft);
 }
 
 .markdown-preview pre {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding: 1em;
-    background-color: var(--muted);
-    border-radius: 0.5rem;
+    margin-top: 0.65em;
+    margin-bottom: 0.9em;
+    padding: 0;
+    background-color: #f7f6f3;
+    border-radius: 6px;
     overflow-x: auto;
+}
+
+.dark .markdown-preview pre {
+    background-color: #202020;
 }
 
 .markdown-preview pre code {
     background-color: transparent;
-    padding: 0;
-    font-size: 0.875em;
+    color: inherit;
+    border: none;
+    box-shadow: none;
+    padding: 14px 16px;
+    display: block;
+    font-size: 0.9em;
     line-height: 1.5;
 }
 
 .markdown-preview blockquote {
-    margin-top: 1em;
+    margin-top: 0.6em;
+    margin-bottom: 0.6em;
+    padding-left: 14px;
+    border-left: 3px solid currentColor;
+    color: var(--muted-foreground);
+    font-style: normal;
+}
+
+.markdown-preview a {
+    color: var(--foreground);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, var(--foreground) 30%, transparent);
+    text-underline-offset: 2px;
+}
+
+.markdown-preview a:hover {
+    background: color-mix(in srgb, var(--foreground) 6%, transparent);
+    border-radius: 2px;
+}
+
+.markdown-preview hr {
+    margin-top: 1.25em;
+    margin-bottom: 1.25em;
+    border: 0;
+    border-top: 1px solid color-mix(in srgb, var(--foreground) 9%, transparent);
+}
+
+.markdown-preview table {
+    width: 100%;
+    margin-top: 0.7em;
+    margin-bottom: 1em;
+    border-collapse: collapse;
+    font-size: 0.92em;
+}
+
+.markdown-preview th,
+.markdown-preview td {
+    padding: 7px 10px;
+    border: 1px solid color-mix(in srgb, var(--foreground) 9%, transparent);
+    text-align: left;
+}
+
+.dark .markdown-preview th,
+.dark .markdown-preview td {
+    border-color: color-mix(in srgb, white 12%, transparent);
+}
+
+.markdown-preview th {
+    background-color: transparent;
+    font-weight: 600;
+}
+
+.markdown-preview tr:nth-child(even) {
+    background-color: transparent;
+}
+
+.markdown-preview tr:hover td {
+    background-color: color-mix(in srgb, var(--foreground) 3%, transparent);
+}
+
+.markdown-preview img {
+    max-width: 100%;
+    height: auto;
+    margin-top: 0.7em;
+    margin-bottom: 0.7em;
+    border-radius: 4px;
+}
+
+.markdown-preview strong {
+    font-weight: 600;
+}
+
+.markdown-preview em {
+    font-style: italic;
+}
+
+.markdown-preview del {
+    text-decoration: line-through;
+    color: var(--muted-foreground);
+}
+
+/* Chat Notion code block surface — matches chat-markdown-notion.html */
+.chat-md-code {
+    background: #f7f6f3;
+    color: #37352f;
+}
+
+.dark .chat-md-code {
+    background: #202020;
+    color: rgba(255, 255, 255, 0.86);
+}
+
+.chat-md-code-h {
+    color: var(--muted-foreground);
+}
+
+/* Strip Shiki editor chrome; keep token inline colors */
+.chat-md-code .shiki,
+.chat-md-code .shiki code {
+    background: transparent !important;
+}
+
+/* Inline code — C · Paper inset (panel fill + soft inset hairline) */
+.chat-md-inline-code {
+    background: var(--panel);
+    color: var(--ink-2);
+    box-shadow: inset 0 0 0 1px var(--border-soft);
+    border: none;
+    border-radius: 3px;
+    padding: 0.08em 0.3em;
+    font-size: 0.86em;
+}
+
+.dark .chat-md-inline-code {
+    background: var(--panel);
+    color: var(--ink-2);
+    box-shadow: inset 0 0 0 1px var(--border-soft);
+}
+
+/* GFM task list — Notion blue checkbox */
+.chat-md .contains-task-list,
+.markdown-preview .contains-task-list {
+    list-style: none;
+    padding-left: 0;
+}
+
+.chat-md .task-list-item,
+.markdown-preview .task-list-item,
+.chat-md-task {
+    list-style: none;
+}
+
+.chat-md-checkbox,
+.chat-md input[type="checkbox"],
+.markdown-preview input[type="checkbox"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    margin: 0.2em 0.5em 0 0;
+    border-radius: 3px;
+    border: 1.5px solid color-mix(in srgb, var(--foreground) 35%, transparent);
+    background: transparent;
+    vertical-align: middle;
+    position: relative;
+    flex-shrink: 0;
+}
+
+.chat-md-checkbox:checked,
+.chat-md input[type="checkbox"]:checked,
+.markdown-preview input[type="checkbox"]:checked {
+    background: #2eaadc;
+    border-color: #2eaadc;
+}
+
+.chat-md-checkbox:checked::after,
+.chat-md input[type="checkbox"]:checked::after,
+.markdown-preview input[type="checkbox"]:checked::after {
+    content: "";
+    position: absolute;
+    left: 4px;
+    top: 1px;
+    width: 5px;
+    height: 9px;
+    border: solid white;
+    border-width: 0 1.6px 1.6px 0;
+    transform: rotate(45deg);
 }
 
 /* Git gutter decorations for Monaco Editor */
@@ -844,81 +1045,6 @@ input,
 .dark .monaco-editor .glyph-margin-widgets .git-gutter-modified,
 .dark .monaco-editor .git-gutter-modified {
     background-color: #ca8a04 !important;
-}
-
-.markdown-preview blockquote {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding-left: 1em;
-    border-left: 4px solid var(--border);
-    color: var(--muted-foreground);
-    font-style: italic;
-}
-
-.markdown-preview a {
-    color: oklch(0.546 0.245 262.881);
-    text-decoration: underline;
-}
-
-.markdown-preview a:hover {
-    color: oklch(0.488 0.243 264.376);
-}
-
-.markdown-preview hr {
-    margin-top: 2em;
-    margin-bottom: 2em;
-    border: 0;
-    border-top: 1px solid var(--border);
-}
-
-.markdown-preview table {
-    width: 100%;
-    margin-top: 1em;
-    margin-bottom: 1em;
-    border-collapse: collapse;
-    font-size: 0.875em;
-}
-
-.markdown-preview th,
-.markdown-preview td {
-    padding: 0.5em 1em;
-    border: 1px solid var(--border);
-    text-align: left;
-}
-
-.markdown-preview th {
-    background-color: var(--muted);
-    font-weight: 600;
-}
-
-.markdown-preview tr:nth-child(even) {
-    background-color: var(--muted);
-}
-
-.markdown-preview img {
-    max-width: 100%;
-    height: auto;
-    margin-top: 1em;
-    margin-bottom: 1em;
-    border-radius: 0.5rem;
-}
-
-/* Task list styles */
-.markdown-preview input[type="checkbox"] {
-    margin-right: 0.5em;
-}
-
-.markdown-preview strong {
-    font-weight: 600;
-}
-
-.markdown-preview em {
-    font-style: italic;
-}
-
-.markdown-preview del {
-    text-decoration: line-through;
-    color: var(--muted-foreground);
 }
 
 /* Lobster splash — body breathes, claws wave outward in sync (ported from iOS LobsterSplashView).


### PR DESCRIPTION
## Summary
- Restore full-card click-to-switch on session rows (time / padding / preview all select)
- Keep C2 ⋯ and the inline action dock on `stopPropagation` so they do not steal the switch
- Point `build.config.dev.json` `localAgent` at `opencode`

## Test plan
- [ ] Click session title → switches
- [ ] Click timestamp / card padding / workspace line / preview → switches on first click
- [ ] Hover ⋯ → opens dock without switching; action icons still work
- [ ] `pnpm --filter @teamclaw/app exec vitest run src/components/sidebar/__tests__/SessionListColumn.test.tsx`


Made with [Cursor](https://cursor.com)