### PR TITLE
feat(daemon): fix cursor permission/MCP, add Claude Agent SDK backend

### DIFF
--- a/apps/daemon/claude-bridge/package-lock.json
+++ b/apps/daemon/claude-bridge/package-lock.json
@@ -1,0 +1,365 @@
+{
+  "name": "@teamclaw/claude-bridge",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@teamclaw/claude-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.77.tgz",
+      "integrity": "sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.33.5",
+        "@img/sharp-darwin-x64": "^0.33.5",
+        "@img/sharp-linux-arm": "^0.33.5",
+        "@img/sharp-linux-arm64": "^0.33.5",
+        "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-linuxmusl-arm64": "^0.33.5",
+        "@img/sharp-linuxmusl-x64": "^0.33.5",
+        "@img/sharp-win32-x64": "^0.33.5"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/apps/daemon/claude-bridge/package.json
+++ b/apps/daemon/claude-bridge/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@teamclaw/claude-bridge",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "JSONL RPC sidecar wrapping @anthropic-ai/claude-agent-sdk for amuxd",
+  "main": "src/main.mjs",
+  "scripts": { "start": "node src/main.mjs --mode rpc" },
+  "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.1.0" },
+  "engines": { "node": ">=20" }
+}

--- a/apps/daemon/claude-bridge/src/main.mjs
+++ b/apps/daemon/claude-bridge/src/main.mjs
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+/**
+ * JSONL RPC bridge between amuxd (Rust) and @anthropic-ai/claude-agent-sdk.
+ *
+ * Same wire protocol as cursor-bridge, so the Rust client/process/event layers
+ * are shared shapes:
+ *   Request:  { "id": "...", "method": "...", "params": { ... } }
+ *   Response: { "id": "...", "result": { ... } }
+ *   Error:    { "id": "...", "error": "..." }
+ *   Event:    { "event": "...", "sessionId": "...", ... }
+ *
+ * The Agent SDK runs in *streaming input* mode: each session owns an async
+ * iterable of user messages that we push into, which is what makes
+ * `interrupt()` / `setModel()` / `setPermissionMode()` available at all — they
+ * are control-protocol calls and only exist on a streaming query.
+ */
+import readline from 'node:readline'
+import { query, AbortError } from '@anthropic-ai/claude-agent-sdk'
+
+/**
+ * @typedef {{
+ *   q: import('@anthropic-ai/claude-agent-sdk').Query,
+ *   input: PushQueue,
+ *   cwd: string,
+ *   sessionId: string,
+ *   model: string,
+ *   turnActive: boolean,
+ * }} Session
+ */
+
+/** @type {Map<string, Session>} */
+const sessions = new Map()
+
+/** requestId → resolve fn for a pending canUseTool callback. */
+const pendingPermissions = new Map()
+
+let nextPermissionId = 1
+
+function emit(obj) {
+  process.stdout.write(`${JSON.stringify(obj)}\n`)
+}
+
+/**
+ * Push-driven async iterable. The SDK pulls user messages from this; `push`
+ * hands one over (waking a blocked pull), `close` ends the session's input.
+ */
+class PushQueue {
+  constructor() {
+    this.items = []
+    this.waiting = []
+    this.done = false
+  }
+
+  push(item) {
+    const waiter = this.waiting.shift()
+    if (waiter) waiter({ value: item, done: false })
+    else this.items.push(item)
+  }
+
+  close() {
+    this.done = true
+    for (const waiter of this.waiting.splice(0)) waiter({ value: undefined, done: true })
+  }
+
+  [Symbol.asyncIterator]() {
+    return {
+      next: () => {
+        if (this.items.length > 0) return Promise.resolve({ value: this.items.shift(), done: false })
+        if (this.done) return Promise.resolve({ value: undefined, done: true })
+        return new Promise((resolve) => this.waiting.push(resolve))
+      },
+      return: () => {
+        this.close()
+        return Promise.resolve({ value: undefined, done: true })
+      },
+    }
+  }
+}
+
+function userMessage(text, sessionId) {
+  return {
+    type: 'user',
+    session_id: sessionId ?? '',
+    parent_tool_use_id: null,
+    message: { role: 'user', content: [{ type: 'text', text }] },
+  }
+}
+
+function paramsToObject(input) {
+  if (input == null || typeof input !== 'object' || Array.isArray(input)) {
+    return { input: JSON.stringify(input ?? null) }
+  }
+  const out = {}
+  for (const [k, v] of Object.entries(input)) {
+    out[k] = typeof v === 'string' ? v : JSON.stringify(v)
+  }
+  return out
+}
+
+function toolResultText(content) {
+  if (content == null) return ''
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .map((b) => (b?.type === 'text' && typeof b.text === 'string' ? b.text : JSON.stringify(b)))
+      .join('\n')
+  }
+  try {
+    return JSON.stringify(content)
+  } catch {
+    return String(content)
+  }
+}
+
+/**
+ * The permission gate. Blocks until amuxd answers, so the daemon — not this
+ * process — decides how long a human may take. `full_access` sessions never
+ * reach here: they run with permissionMode `bypassPermissions`.
+ */
+function makeCanUseTool(sessionKey) {
+  return (toolName, input, { signal, suggestions, toolUseID }) =>
+    new Promise((resolve) => {
+      const requestId = `perm-${nextPermissionId++}`
+      const settle = (result) => {
+        if (!pendingPermissions.delete(requestId)) return
+        resolve(result)
+      }
+      pendingPermissions.set(requestId, { settle, input })
+
+      // An aborted turn must not leave the SDK waiting on us forever.
+      signal?.addEventListener?.('abort', () =>
+        settle({ behavior: 'deny', message: 'Turn was cancelled.', interrupt: true }),
+      )
+
+      emit({
+        event: 'permission_request',
+        sessionId: sessionKey,
+        requestId,
+        toolName,
+        toolUseId: toolUseID,
+        input: paramsToObject(input),
+        // Non-empty means the SDK can persist an "always allow" for this tool.
+        canAlways: Array.isArray(suggestions) && suggestions.length > 0,
+        suggestions: suggestions ?? [],
+      })
+    })
+}
+
+function handleAssistantMessage(sessionKey, message) {
+  for (const block of message.message?.content ?? []) {
+    if (block.type === 'text' && block.text) {
+      emit({ event: 'assistant_delta', sessionId: sessionKey, text: block.text })
+    } else if (block.type === 'thinking' && block.thinking) {
+      emit({ event: 'thinking_delta', sessionId: sessionKey, text: block.thinking })
+    } else if (block.type === 'tool_use') {
+      emit({
+        event: 'tool_start',
+        sessionId: sessionKey,
+        toolCallId: block.id,
+        toolName: block.name,
+        args: paramsToObject(block.input),
+      })
+    }
+  }
+}
+
+/** Tool results arrive as `user` messages carrying tool_result blocks. */
+function handleUserMessage(sessionKey, message) {
+  const content = message.message?.content
+  if (!Array.isArray(content)) return
+  for (const block of content) {
+    if (block.type !== 'tool_result') continue
+    emit({
+      event: 'tool_end',
+      sessionId: sessionKey,
+      toolCallId: block.tool_use_id,
+      summary: toolResultText(block.content),
+      isError: block.is_error === true,
+    })
+  }
+}
+
+async function pumpSession(sessionKey, session) {
+  try {
+    for await (const message of session.q) {
+      switch (message.type) {
+        case 'system':
+          if (message.subtype === 'init') {
+            session.sessionId = message.session_id
+            session.model = message.model ?? session.model
+          }
+          break
+        case 'assistant':
+          handleAssistantMessage(sessionKey, message)
+          break
+        case 'user':
+          handleUserMessage(sessionKey, message)
+          break
+        case 'result': {
+          if (message.subtype !== 'success') {
+            emit({
+              event: 'run_error',
+              sessionId: sessionKey,
+              message: (message.errors ?? []).join('; ') || message.subtype,
+            })
+          }
+          // modelUsage is keyed by the model that actually ran the turn — the
+          // authoritative reading, unlike whatever we last asked for.
+          const used = Object.keys(message.modelUsage ?? {})
+          if (used.length > 0) session.model = used[used.length - 1]
+          session.turnActive = false
+          emit({
+            event: 'turn_end',
+            sessionId: sessionKey,
+            status: message.subtype,
+            model: session.model,
+            costUsd: message.total_cost_usd,
+          })
+          break
+        }
+        default:
+          break
+      }
+    }
+  } catch (err) {
+    if (!(err instanceof AbortError)) {
+      emit({ event: 'run_error', sessionId: sessionKey, message: String(err?.message ?? err) })
+    }
+    session.turnActive = false
+    emit({ event: 'turn_end', sessionId: sessionKey, status: 'error' })
+  } finally {
+    // Nothing more will arrive for this session; release anything still blocked.
+    for (const [requestId, pending] of [...pendingPermissions]) {
+      pending.settle({ behavior: 'deny', message: 'Session ended.', interrupt: true })
+      pendingPermissions.delete(requestId)
+    }
+  }
+}
+
+function mcpServersOption(mcpServers) {
+  if (!mcpServers || typeof mcpServers !== 'object' || Array.isArray(mcpServers)) return {}
+  return Object.keys(mcpServers).length > 0 ? { mcpServers } : {}
+}
+
+async function startSession(params, resume) {
+  const cwd = params.cwd
+  if (!cwd) throw new Error('cwd is required')
+  const sessionKey = `pending-${nextPermissionId++}`
+  const input = new PushQueue()
+
+  const fullAccess = params.permissionMode === 'bypassPermissions'
+  const q = query({
+    prompt: input,
+    options: {
+      cwd,
+      ...(params.model ? { model: params.model } : {}),
+      ...(resume ? { resume } : {}),
+      ...mcpServersOption(params.mcpServers),
+      permissionMode: params.permissionMode ?? 'default',
+      // bypassPermissions never consults canUseTool; wiring it anyway would be
+      // dead code that hides which mode is actually in force.
+      ...(fullAccess ? {} : { canUseTool: makeCanUseTool(sessionKey) }),
+    },
+  })
+
+  const session = {
+    q,
+    input,
+    cwd,
+    sessionId: resume ?? '',
+    model: params.model ?? '',
+    turnActive: false,
+  }
+  sessions.set(sessionKey, session)
+  void pumpSession(sessionKey, session)
+
+  // The SDK emits system/init only once it has spun up; the session id it
+  // carries is what we persist for resume. Nudge it with an empty turn only if
+  // the caller gave no initial prompt — otherwise the prompt itself starts it.
+  input.push(userMessage(params.initialPrompt || 'Ready.', session.sessionId))
+  session.turnActive = true
+  emit({ event: 'turn_start', sessionId: sessionKey })
+
+  const deadline = Date.now() + 60_000
+  while (!session.sessionId && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 25))
+  }
+  if (!session.sessionId) throw new Error('claude session did not initialize within 60s')
+  return { sessionKey, session }
+}
+
+async function handleRequest(req) {
+  const { id, method, params = {} } = req
+  try {
+    switch (method) {
+      case 'list_models': {
+        const existing = [...sessions.values()][0]
+        if (!existing) {
+          emit({ id, result: { models: [] } })
+          break
+        }
+        const models = await existing.q.supportedModels()
+        emit({
+          id,
+          result: {
+            models: models.map((m) => ({
+              id: `claude/${m.value}`,
+              displayName: m.displayName ?? m.value,
+              providerName: 'claude',
+              description: m.description ?? '',
+            })),
+          },
+        })
+        break
+      }
+      case 'create_session':
+      case 'resume_session': {
+        const resume = method === 'resume_session' ? params.sessionId : undefined
+        if (method === 'resume_session' && !resume) throw new Error('sessionId is required')
+        const { sessionKey, session } = await startSession(params, resume)
+        emit({ id, result: { sessionKey, sessionId: session.sessionId, model: session.model } })
+        break
+      }
+      case 'send': {
+        const session = sessions.get(params.sessionKey)
+        if (!session) throw new Error(`unknown session ${params.sessionKey}`)
+        if (!params.text) throw new Error('text is required')
+        if (params.model && params.model !== session.model) {
+          await session.q.setModel(params.model)
+          session.model = params.model
+        }
+        session.turnActive = true
+        emit({ event: 'turn_start', sessionId: params.sessionKey })
+        session.input.push(userMessage(params.text, session.sessionId))
+        emit({ id, result: { ok: true } })
+        break
+      }
+      case 'cancel': {
+        const session = sessions.get(params.sessionKey)
+        if (session) await session.q.interrupt()
+        emit({ id, result: { ok: true } })
+        break
+      }
+      case 'set_model': {
+        const session = sessions.get(params.sessionKey)
+        if (!session) throw new Error(`unknown session ${params.sessionKey}`)
+        // A real control-protocol call — takes effect on the next turn.
+        await session.q.setModel(params.model || undefined)
+        session.model = params.model ?? ''
+        emit({ id, result: { model: session.model } })
+        break
+      }
+      case 'get_session_info': {
+        const session = sessions.get(params.sessionKey)
+        if (!session) throw new Error(`unknown session ${params.sessionKey}`)
+        emit({
+          id,
+          result: {
+            sessionId: session.sessionId,
+            cwd: session.cwd,
+            // Reported by the SDK (init / result.modelUsage), not our request.
+            ...(session.model ? { sdkModel: `claude/${session.model}` } : {}),
+          },
+        })
+        break
+      }
+      case 'resolve_permission': {
+        const pending = pendingPermissions.get(params.requestId)
+        if (!pending) {
+          emit({ id, result: { ok: false, reason: 'unknown request' } })
+          break
+        }
+        if (params.granted) {
+          pending.settle({
+            behavior: 'allow',
+            updatedInput: pending.input,
+            // "Always allow" rides the SDK's own suggestions so the rule it
+            // persists matches what the tool call actually needs.
+            ...(params.always && Array.isArray(params.suggestions) && params.suggestions.length > 0
+              ? { updatedPermissions: params.suggestions }
+              : {}),
+          })
+        } else {
+          pending.settle({
+            behavior: 'deny',
+            message: params.message || 'The user rejected this tool call.',
+            interrupt: params.interrupt === true,
+          })
+        }
+        emit({ id, result: { ok: true } })
+        break
+      }
+      case 'close_session': {
+        const session = sessions.get(params.sessionKey)
+        if (session) {
+          session.input.close()
+          sessions.delete(params.sessionKey)
+        }
+        emit({ id, result: { ok: true } })
+        break
+      }
+      default:
+        emit({ id, error: `unknown method: ${method}` })
+    }
+  } catch (err) {
+    emit({ id, error: String(err?.message ?? err) })
+  }
+}
+
+async function main() {
+  const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity })
+  for await (const line of rl) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    let req
+    try {
+      req = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (req?.method && req?.id != null) void handleRequest(req)
+  }
+  for (const session of sessions.values()) session.input.close()
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/daemon/cursor-bridge/src/main.mjs
+++ b/apps/daemon/cursor-bridge/src/main.mjs
@@ -35,6 +35,15 @@ function sdkModelFromFlat(flat) {
   return model || 'composer-2.5'
 }
 
+/**
+ * AgentOptions.mcpServers is a Record<string, McpServerConfig> — not an array.
+ * Drop the field entirely when there is nothing to bridge.
+ */
+function mcpServersOption(mcpServers) {
+  if (!mcpServers || typeof mcpServers !== 'object' || Array.isArray(mcpServers)) return {}
+  return Object.keys(mcpServers).length > 0 ? { mcpServers } : {}
+}
+
 function apiKeyFromEnv() {
   const key = process.env.CURSOR_API_KEY?.trim()
   if (!key) throw new Error('CURSOR_API_KEY is not set')
@@ -131,14 +140,6 @@ function handleStreamEvent(agentId, runId, message) {
         })
       }
       break
-    case 'request':
-      emit({
-        event: 'permission_request',
-        agentId,
-        runId,
-        requestId: message.request_id,
-      })
-      break
     default:
       break
   }
@@ -202,8 +203,11 @@ async function handleRequest(req) {
         const agent = await Agent.create({
           apiKey: apiKeyFromEnv(),
           model: { id: model },
-          local: { cwd, settingSources: [] },
-          ...(params.mcpServers?.length ? { mcpServers: params.mcpServers } : {}),
+          // "project" is what makes the SDK read <cwd>/.cursor/hooks.json —
+          // amuxd's preToolUse permission gate lives there. It also enables the
+          // workspace's own rules/AGENTS.md, matching opencode and pi.
+          local: { cwd, settingSources: ['project'] },
+          ...mcpServersOption(params.mcpServers),
         })
         agents.set(agent.agentId, { agent, cwd, model })
         emit({
@@ -220,7 +224,8 @@ async function handleRequest(req) {
         if (!agentId) throw new Error('agentId is required')
         const agent = await Agent.resume(agentId, {
           apiKey: apiKeyFromEnv(),
-          ...(params.mcpServers?.length ? { mcpServers: params.mcpServers } : {}),
+          // Inline MCP is not persisted by the SDK: resume must re-send it.
+          ...mcpServersOption(params.mcpServers),
         })
         const model = sdkModelFromFlat(params.model) || 'composer-2.5'
         agents.set(agent.agentId, { agent, cwd: params.cwd ?? process.cwd(), model })
@@ -239,8 +244,14 @@ async function handleRequest(req) {
         if (!agentId || !text) throw new Error('agentId and text are required')
         const entry = agents.get(agentId)
         if (!entry) throw new Error(`unknown agent ${agentId}`)
-        const run = await entry.agent.send(text)
-        emit({ id, result: { runId: run.id } })
+        // SendOptions.model is what actually switches the model — mutating our
+        // own bookkeeping never reached the agent. Passed on every send, so the
+        // selection survives a set_model between turns.
+        // The daemon carries the selection on every send; fall back to what we
+        // last recorded when it says nothing.
+        if (params.model) entry.model = sdkModelFromFlat(params.model)
+        const run = await entry.agent.send(text, { model: { id: entry.model } })
+        emit({ id, result: { runId: run.id, model: flatModelId(entry.model) } })
         void streamRun(agentId, run)
         break
       }
@@ -256,6 +267,8 @@ async function handleRequest(req) {
         break
       }
       case 'set_model': {
+        // Takes effect on the next send (the SDK has no standalone model
+        // setter); same "applies next turn" semantics as the opencode backend.
         const agentId = params.agentId
         const model = sdkModelFromFlat(params.model)
         const entry = agents.get(agentId)
@@ -268,14 +281,20 @@ async function handleRequest(req) {
         const agentId = params.agentId
         const entry = agents.get(agentId)
         if (!entry) throw new Error(`unknown agent ${agentId}`)
+        // `agent.model` is the SDK's own current selection, updated after each
+        // successful send. `requestedModel` is merely what we last asked for —
+        // the two are reported separately so the daemon's MRU only ever learns
+        // from the former.
+        const sdkModel = entry.agent.model?.id
         emit({
           id,
-          result: { agentId, model: flatModelId(entry.model), cwd: entry.cwd },
+          result: {
+            agentId,
+            cwd: entry.cwd,
+            requestedModel: flatModelId(entry.model),
+            ...(sdkModel ? { sdkModel: flatModelId(sdkModel) } : {}),
+          },
         })
-        break
-      }
-      case 'resolve_permission': {
-        emit({ id, result: { ok: true } })
         break
       }
       case 'dispose_agent': {

--- a/apps/daemon/src/cli/cursor_permission_hook.rs
+++ b/apps/daemon/src/cli/cursor_permission_hook.rs
@@ -1,0 +1,135 @@
+//! `amuxd cursor-permission-hook` — the Cursor `preToolUse` gate.
+//!
+//! Spawned by `@cursor/sdk` once per tool call (see
+//! `runtime/cursor_sdk/hooks.rs`). Reads the hook request as JSON on stdin,
+//! asks amuxd over `amuxd.sock`, and writes the SDK's response body on stdout:
+//!
+//! ```json
+//! { "permission": "allow" }
+//! { "permission": "deny", "user_message": "...", "agent_message": "..." }
+//! ```
+//!
+//! Fail-open by design: any transport problem prints `allow` and exits 0. The
+//! daemon is what blocks on the human, so this process can sit for minutes —
+//! its ceiling is the `timeout` we write into `hooks.json`.
+
+use std::io::{Read, Write};
+use std::path::Path;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+/// Longer than the daemon's own resolve timeout so the daemon, not the socket
+/// read, is what decides an unanswered request.
+const SOCK_TIMEOUT: Duration =
+    Duration::from_secs(crate::runtime::cursor_sdk::hooks::HOOK_TIMEOUT_SECS);
+
+pub fn run(sock_path: &Path, worktree: &str) -> anyhow::Result<()> {
+    let mut body = String::new();
+    std::io::stdin().read_to_string(&mut body)?;
+    let response = decide(sock_path, worktree, &body);
+
+    let mut stdout = std::io::stdout();
+    writeln!(stdout, "{response}")?;
+    stdout.flush()?;
+    Ok(())
+}
+
+fn allow() -> Value {
+    json!({ "permission": "allow" })
+}
+
+fn decide(sock_path: &Path, worktree: &str, stdin_body: &str) -> Value {
+    let request: Value = match serde_json::from_str(stdin_body.trim()) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[amuxd cursor-permission-hook] unparseable request: {e}");
+            return allow();
+        }
+    };
+
+    let payload = json!({
+        "cmd": "cursor-permission",
+        "worktree": worktree,
+        "request": request,
+    });
+
+    let raw = match super::mcp_server::sock_roundtrip_with_read_timeout(
+        sock_path,
+        &payload.to_string(),
+        SOCK_TIMEOUT,
+    ) {
+        Ok(raw) => raw,
+        Err(e) => {
+            eprintln!("[amuxd cursor-permission-hook] amuxd.sock failed: {e}");
+            return allow();
+        }
+    };
+
+    parse_reply(&raw)
+}
+
+/// `{ "ok": true, "result": { "permission": ... } }` → the hook body. Anything
+/// else (malformed, `ok:false`, missing result) allows.
+fn parse_reply(raw: &str) -> Value {
+    let parsed: Value = match serde_json::from_str(raw.trim()) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[amuxd cursor-permission-hook] bad daemon reply: {e}");
+            return allow();
+        }
+    };
+    if parsed.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        let err = parsed
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+        eprintln!("[amuxd cursor-permission-hook] daemon error: {err}");
+        return allow();
+    }
+    match parsed.get("result") {
+        Some(result) if result.get("permission").is_some() => result.clone(),
+        _ => allow(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_reply_passes_a_deny_through() {
+        let body =
+            parse_reply(r#"{"ok":true,"result":{"permission":"deny","user_message":"nope"}}"#);
+        assert_eq!(body["permission"], json!("deny"));
+        assert_eq!(body["user_message"], json!("nope"));
+    }
+
+    #[test]
+    fn parse_reply_fails_open_on_every_bad_shape() {
+        for raw in [
+            "not json",
+            r#"{"ok":false,"error":"boom"}"#,
+            r#"{"ok":true}"#,
+            r#"{"ok":true,"result":{}}"#,
+        ] {
+            assert_eq!(parse_reply(raw)["permission"], json!("allow"), "raw={raw}");
+        }
+    }
+
+    #[test]
+    fn unparseable_stdin_fails_open_without_touching_the_socket() {
+        let body = decide(Path::new("/nonexistent.sock"), "/w", "}{");
+        assert_eq!(body["permission"], json!("allow"));
+    }
+
+    #[test]
+    fn unreachable_daemon_fails_open() {
+        let body = decide(
+            Path::new("/nonexistent/amuxd.sock"),
+            "/w",
+            r#"{"tool_name":"shell","tool_input":{"command":"ls"}}"#,
+        );
+        assert_eq!(body["permission"], json!("allow"));
+    }
+}

--- a/apps/daemon/src/cli/mod.rs
+++ b/apps/daemon/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod channel;
 pub mod clear;
 pub mod config_cmd;
+pub mod cursor_permission_hook;
 pub mod doctor;
 pub mod install_opencode;
 pub mod mcp_server;
@@ -111,6 +112,9 @@ pub enum Commands {
     /// Run the remote-tools MCP server on stdio. Proxies browser/client tools
     /// to the bound TeamClaw client over MQTT RPC.
     RemoteToolsMcp(RemoteToolsMcpArgs),
+    /// Cursor `preToolUse` hook. Spawned by `@cursor/sdk` per tool call;
+    /// reads the hook request on stdin and prints an allow/deny decision.
+    CursorPermissionHook(CursorPermissionHookArgs),
 }
 
 #[derive(Args, Debug)]
@@ -230,6 +234,15 @@ pub struct RemoteToolsMcpArgs {
     /// Member actor that owns the RPC topic (`amux/{team}/{id}/rpc/req`).
     #[arg(long, alias = "client-actor-id", default_value = "")]
     pub member_actor_id: String,
+    #[arg(long)]
+    pub sock: Option<std::path::PathBuf>,
+}
+
+#[derive(Args, Debug)]
+pub struct CursorPermissionHookArgs {
+    /// Worktree the calling agent runs in; used to resolve the session.
+    #[arg(long, default_value = "")]
+    pub worktree: String,
     #[arg(long)]
     pub sock: Option<std::path::PathBuf>,
 }

--- a/apps/daemon/src/config/daemon_config.rs
+++ b/apps/daemon/src/config/daemon_config.rs
@@ -239,10 +239,27 @@ pub struct AgentsConfig {
     pub codex: Option<AgentBackendConfig>,
     #[serde(default)]
     pub cursor: Option<CursorAgentConfig>,
+    #[serde(default)]
+    pub claude: Option<ClaudeAgentConfig>,
 }
 
 /// Cursor SDK backend settings (`agents.local_agent = "cursor"`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaudeAgentConfig {
+    /// Anthropic API key. Optional: with none set the Agent SDK falls back to
+    /// the host's own `claude` login (subscription auth).
+    #[serde(default)]
+    pub api_key: Option<String>,
+    /// Sidecar launch command (default: `node …/claude-bridge/src/main.mjs --mode rpc`).
+    #[serde(default)]
+    pub bridge_command: Option<Vec<String>>,
+    /// Preferred model (SDK id, e.g. `claude-opus-5`). Empty = SDK default.
+    #[serde(default)]
+    pub default_model: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct CursorAgentConfig {
     /// Cursor API key. Falls back to `CURSOR_API_KEY` when unset.
     #[serde(default)]
@@ -272,6 +289,7 @@ impl Default for AgentsConfig {
             opencode: None,
             codex: None,
             cursor: None,
+            claude: None,
         }
     }
 }

--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -15,7 +15,7 @@ pub mod workspace_path;
 mod workspace_resolver;
 
 pub use daemon_config::{
-    ActorConfig, AgentBackendConfig, AgentsConfig, CursorAgentConfig, DaemonConfig, DiscordChannel,
+    ActorConfig, AgentBackendConfig, AgentsConfig, ClaudeAgentConfig, CursorAgentConfig, DaemonConfig, DiscordChannel,
     EmailChannel, FeishuChannel, HttpConfig, KookChannel, MqttConfig, TransportKind, WeChatChannel,
     WeComChannel, BOOTSTRAP_ACTOR_NAME,
 };

--- a/apps/daemon/src/daemon/runtime_resolution.rs
+++ b/apps/daemon/src/daemon/runtime_resolution.rs
@@ -86,6 +86,7 @@ pub(crate) fn agent_type_from_name(name: &str) -> Option<amux::AgentType> {
         "codex" => Some(amux::AgentType::Codex),
         "claude" | "claude_code" | "claude-code" => Some(amux::AgentType::ClaudeCode),
         "pi" => Some(amux::AgentType::Pi),
+        "cursor" => Some(amux::AgentType::Cursor),
         _ => None,
     }
 }
@@ -98,6 +99,7 @@ fn agent_type_name(agent_type: amux::AgentType) -> Option<&'static str> {
         amux::AgentType::Codex => Some("codex"),
         amux::AgentType::ClaudeCode => Some("claude-code"),
         amux::AgentType::Pi => Some("pi"),
+        amux::AgentType::Cursor => Some("cursor"),
         amux::AgentType::Unknown => None,
     }
 }

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -294,6 +294,12 @@ pub(crate) enum SockCommand {
         payload: serde_json::Value,
         reply_tx: oneshot::Sender<String>,
     },
+    /// Cursor `preToolUse` approval from `amuxd cursor-permission-hook`. The
+    /// handler blocks on a human, so it must never run inline on this loop.
+    CursorPermission {
+        payload: serde_json::Value,
+        reply_tx: oneshot::Sender<String>,
+    },
     /// Drive one ACP turn to completion for a cron-style logical session.
     /// `payload` is the raw JSON envelope; `handle_prompt_await` parses it
     /// and runs the turn against the local primary agent. `reply_tx`
@@ -1573,6 +1579,17 @@ impl DaemonServer {
                                 self.spawn_remote_tool_sock_handler(payload, reply_tx)
                                     .await;
                             }
+                            Some(SockCommand::CursorPermission { payload, reply_tx }) => {
+                                tokio::spawn(async move {
+                                    let result =
+                                        crate::runtime::cursor_sdk::permission::handle(&payload)
+                                            .await;
+                                    let _ = reply_tx.send(
+                                        serde_json::json!({ "ok": true, "result": result })
+                                            .to_string(),
+                                    );
+                                });
+                            }
                             Some(SockCommand::LocalRpc { payload, reply_tx }) => {
                                 let reply = self.dispatch_local_rpc(&payload).await;
                                 let _ = reply_tx.send(reply);
@@ -1978,6 +1995,17 @@ impl DaemonServer {
                             Some(SockCommand::RemoteToolCall { payload, reply_tx }) => {
                                 self.spawn_remote_tool_sock_handler(payload, reply_tx)
                                     .await;
+                            }
+                            Some(SockCommand::CursorPermission { payload, reply_tx }) => {
+                                tokio::spawn(async move {
+                                    let result =
+                                        crate::runtime::cursor_sdk::permission::handle(&payload)
+                                            .await;
+                                    let _ = reply_tx.send(
+                                        serde_json::json!({ "ok": true, "result": result })
+                                            .to_string(),
+                                    );
+                                });
                             }
                             Some(SockCommand::LocalRpc { payload, reply_tx }) => {
                                 let reply = self.dispatch_local_rpc(&payload).await;
@@ -2400,6 +2428,32 @@ where
                                 }
                                 Err(_) => {
                                     warn!("amuxd.sock: remote-tool-call reply dropped");
+                                }
+                            }
+                        } else if cmd == "cursor-permission" {
+                            let (reply_tx, reply_rx) = oneshot::channel();
+                            if tx
+                                .send(SockCommand::CursorPermission {
+                                    payload: v,
+                                    reply_tx,
+                                })
+                                .await
+                                .is_err()
+                            {
+                                return;
+                            }
+                            match reply_rx.await {
+                                Ok(body) => {
+                                    let mut stream = reader.into_inner();
+                                    if let Err(e) = stream.write_all(body.as_bytes()).await {
+                                        warn!("amuxd.sock: cursor-permission write failed: {e}");
+                                        return;
+                                    }
+                                    let _ = stream.write_all(b"\n").await;
+                                    let _ = stream.shutdown().await;
+                                }
+                                Err(_) => {
+                                    warn!("amuxd.sock: cursor-permission reply dropped");
                                 }
                             }
                         } else if cmd == "prompt-await" {

--- a/apps/daemon/src/main.rs
+++ b/apps/daemon/src/main.rs
@@ -221,6 +221,13 @@ fn main() -> anyhow::Result<()> {
             let _ = (&args.session_id, &args.team_id, &args.member_actor_id);
             cli::remote_tools_mcp::run(&sock)?;
         }
+        Commands::CursorPermissionHook(args) => {
+            let sock = args
+                .sock
+                .clone()
+                .unwrap_or_else(config::DaemonConfig::sock_path);
+            cli::cursor_permission_hook::run(&sock, &args.worktree)?;
+        }
         Commands::TestClient { config, action } => {
             tracing_subscriber::fmt()
                 .with_env_filter(

--- a/apps/daemon/src/runtime/backend.rs
+++ b/apps/daemon/src/runtime/backend.rs
@@ -288,6 +288,7 @@ pub fn create_backend(local_agent: &str) -> Box<dyn AgentBackend> {
     match local_agent {
         "pi" => Box::new(super::pi_rpc::PiRpcBackend::new()),
         "cursor" => Box::new(super::cursor_sdk::CursorSdkBackend::new()),
+        "claude" => Box::new(super::claude_agent::ClaudeAgentBackend::new()),
         "opencode" => Box::new(OpencodeHttpBackend::new()),
         other => {
             warn!(

--- a/apps/daemon/src/runtime/claude_agent/events.rs
+++ b/apps/daemon/src/runtime/claude_agent/events.rs
@@ -1,4 +1,10 @@
-//! cursor-bridge stdout event routing.
+//! claude-bridge stdout event routing.
+//!
+//! Unlike `cursor_sdk`, permission requests arrive **on this stream** rather
+//! than out-of-band: the Agent SDK's `canUseTool` callback lives inside the
+//! bridge process, so the bridge simply blocks and emits a `permission_request`
+//! event. That removes the whole hooks-file / socket-callback apparatus the
+//! cursor backend needs.
 
 use std::sync::Arc;
 
@@ -7,9 +13,9 @@ use tracing::{debug, info, warn};
 
 use crate::proto::amux;
 use crate::runtime::acp_event_frame::AcpEventFrame;
-
 use crate::runtime::sidecar::client::SidecarClient;
-use super::{translate, Shared};
+
+use super::{permission, translate, Shared};
 
 pub(super) fn spawn_reader(
     shared: Arc<Shared>,
@@ -26,7 +32,7 @@ pub(super) fn spawn_reader(
                 Ok(0) => break,
                 Ok(_) => {}
                 Err(e) => {
-                    warn!(worktree, error = %e, "cursor stdout read error");
+                    warn!(worktree, error = %e, "claude stdout read error");
                     break;
                 }
             }
@@ -37,7 +43,7 @@ pub(super) fn spawn_reader(
             let json: serde_json::Value = match serde_json::from_str(trimmed) {
                 Ok(v) => v,
                 Err(e) => {
-                    debug!(worktree, error = %e, "cursor stdout non-JSON dropped");
+                    debug!(worktree, error = %e, "claude stdout non-JSON dropped");
                     continue;
                 }
             };
@@ -51,7 +57,7 @@ pub(super) fn spawn_reader(
         }
         close_all_turns_for_worktree(&shared, &worktree).await;
         client.fail_all_pending();
-        info!(worktree, "cursor bridge stdout closed");
+        info!(worktree, "claude bridge stdout closed");
     });
 }
 
@@ -68,13 +74,32 @@ async fn close_all_turns_for_worktree(shared: &Arc<Shared>, worktree: &str) {
     }
 }
 
+/// The bridge keys events by its own session handle; map it to our acp id.
+fn acp_session_for(shared: &Arc<Shared>, session_key: &str) -> Option<String> {
+    shared.session_keys.lock().get(session_key).cloned()
+}
+
 async fn handle_event(shared: &Arc<Shared>, event: &serde_json::Value) {
     let event_name = event.get("event").and_then(|v| v.as_str()).unwrap_or("");
-    let agent_id = event.get("agentId").and_then(|v| v.as_str()).unwrap_or("");
-    if agent_id.is_empty() {
+    let session_key = event
+        .get("sessionId")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    if session_key.is_empty() {
         return;
     }
-    let session_id = format!("{}{}", super::SESSION_ID_PREFIX, agent_id);
+    let Some(session_id) = acp_session_for(shared, session_key) else {
+        debug!(
+            session_key,
+            event_name, "claude event before session was routed; dropped"
+        );
+        return;
+    };
+
+    if event_name == "permission_request" {
+        permission::handle_request(shared, &session_id, session_key, event).await;
+        return;
+    }
 
     if event_name == "turn_end" {
         close_turn(shared, &session_id).await;
@@ -85,30 +110,30 @@ async fn handle_event(shared: &Arc<Shared>, event: &serde_json::Value) {
         let Some(route) = routes.get_mut(&session_id) else {
             debug!(
                 session_id,
-                event_name, "cursor event for unrouted session dropped"
+                event_name, "claude event for unrouted session dropped"
             );
             return;
         };
         if event_name == "turn_start" {
             route.turn_active = true;
         }
-        // `turn_end` carries the model the run actually used (`result.model`) —
-        // the only authoritative reading we get. A `set_model` the SDK silently
-        // declined would otherwise leave the route lying about its model.
+        // `turn_end` carries the model that actually ran the turn (the SDK's
+        // `result.modelUsage` key), which is the only authoritative reading.
         if event_name == "turn_end" {
             if let Some(model) = event
                 .get("model")
                 .and_then(|v| v.as_str())
                 .filter(|m| !m.is_empty())
             {
-                if route.model != model {
-                    debug!(session_id, from = %route.model, to = model, "cursor run model changed");
-                    route.model = model.to_string();
+                let flat = super::flat_model_id(model);
+                if route.model != flat {
+                    debug!(session_id, from = %route.model, to = %flat, "claude run model changed");
+                    route.model = flat;
                 }
             }
         }
         (
-            translate::translate_event(&mut route.translate, event),
+            translate::translate_event(event),
             route.event_tx.clone(),
             route.turn_reply_to.clone(),
         )

--- a/apps/daemon/src/runtime/claude_agent/mod.rs
+++ b/apps/daemon/src/runtime/claude_agent/mod.rs
@@ -1,0 +1,824 @@
+//! Claude Agent SDK backend (`claude-bridge` + `@anthropic-ai/claude-agent-sdk`).
+//!
+//! Peer of `runtime/cursor_sdk/` behind [`AgentBackend`]: one Node sidecar per
+//! worktree (JSONL over stdin/stdout), sessions keyed as `claude:<sdkSessionId>`.
+//!
+//! Two things it gets for free that the other sidecar backend does not:
+//!
+//! * **Permissions** are an in-process `canUseTool` callback, so approval is a
+//!   plain event on the existing stream — no hooks file, no socket callback.
+//! * **`setModel`** is a real control-protocol call, so a model switch actually
+//!   takes effect instead of only updating bookkeeping.
+//!
+//! The bridge owns a second session identifier (`sessionKey`) because the SDK's
+//! own `session_id` only exists after `system/init` arrives, while events start
+//! flowing immediately. `session_keys` maps one to the other.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use crate::config::{ClaudeAgentConfig, DaemonConfig};
+use crate::proto::amux;
+use crate::runtime::acp_event_frame::AcpEventFrame;
+use crate::runtime::backend::{AcpCommand, AcpStartupMetadata, AgentBackend};
+use crate::runtime::manager::AgentLaunchConfig;
+use crate::runtime::opencode_http::translate::status_change;
+use crate::runtime::permission_policy::PermissionPolicy;
+use crate::runtime::sidecar::mcp;
+
+mod events;
+pub mod permission;
+pub mod process;
+pub mod translate;
+
+use permission::PendingPermission;
+use process::ClaudeProcessPool;
+
+pub const SESSION_ID_PREFIX: &str = "claude:";
+
+/// TeamClaw model ids are `provider/model`; the SDK speaks the bare id.
+pub fn flat_model_id(sdk_model: &str) -> String {
+    if sdk_model.starts_with("claude/") {
+        sdk_model.to_string()
+    } else {
+        format!("claude/{sdk_model}")
+    }
+}
+
+pub fn sdk_model_id(flat: &str) -> String {
+    flat.strip_prefix("claude/").unwrap_or(flat).to_string()
+}
+
+pub(crate) struct Route {
+    pub(crate) event_tx: mpsc::Sender<AcpEventFrame>,
+    pub(crate) permission: PermissionPolicy,
+    pub(crate) worktree: String,
+    /// Bridge-side handle used to address `send` / `cancel` / `set_model`.
+    pub(crate) session_key: String,
+    pub(crate) turn_active: bool,
+    pub(crate) turn_reply_to: Option<String>,
+    pub(crate) turn_requester: Option<String>,
+    pub(crate) model: String,
+}
+
+pub(crate) struct Shared {
+    pub(crate) pool: ClaudeProcessPool,
+    pub(crate) routes: parking_lot::Mutex<HashMap<String, Route>>,
+    pub(crate) permissions: parking_lot::Mutex<HashMap<String, PendingPermission>>,
+    /// bridge sessionKey → acp session id.
+    pub(crate) session_keys: parking_lot::Mutex<HashMap<String, String>>,
+    /// bridge sessionKey → canonical worktree (to find the owning process).
+    pub(crate) session_worktrees: parking_lot::Mutex<HashMap<String, String>>,
+}
+
+impl Shared {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            pool: ClaudeProcessPool::new(),
+            routes: parking_lot::Mutex::new(HashMap::new()),
+            permissions: parking_lot::Mutex::new(HashMap::new()),
+            session_keys: parking_lot::Mutex::new(HashMap::new()),
+            session_worktrees: parking_lot::Mutex::new(HashMap::new()),
+        })
+    }
+}
+
+pub(crate) fn canonical_dir(worktree: &str) -> String {
+    std::fs::canonicalize(worktree)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| worktree.to_string())
+}
+
+fn apply_claude_config(pool: &ClaudeProcessPool, claude: Option<&ClaudeAgentConfig>) {
+    let Some(cfg) = claude else {
+        return;
+    };
+    pool.configure(
+        cfg.bridge_command.clone(),
+        cfg.api_key.clone(),
+        cfg.default_model.clone(),
+    );
+}
+
+fn load_claude_pool_config(pool: &ClaudeProcessPool) {
+    let cfg = DaemonConfig::load(&DaemonConfig::default_path()).ok();
+    apply_claude_config(pool, cfg.as_ref().and_then(|c| c.agents.claude.as_ref()));
+}
+
+fn models_from_list(result: &serde_json::Value) -> Vec<amux::ModelInfo> {
+    result
+        .get("models")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| {
+                    let id = m.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                    if id.is_empty() {
+                        return None;
+                    }
+                    Some(amux::ModelInfo {
+                        id: id.to_string(),
+                        display_name: m
+                            .get("displayName")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(id)
+                            .to_string(),
+                        provider_name: "claude".to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Same ordering as the pi and opencode backends: an explicit override wins,
+/// then the device MRU (availability-checked), then whatever the SDK picks —
+/// we say nothing rather than pinning an arbitrary catalog entry.
+fn pick_initial_model(
+    available: &[amux::ModelInfo],
+    override_model: Option<&str>,
+    model_mru: &[String],
+    default_model: &str,
+) -> Option<String> {
+    if let Some(m) = override_model.filter(|s| !s.is_empty()) {
+        return Some(m.to_string());
+    }
+    let catalog: Vec<String> = available.iter().map(|m| m.id.clone()).collect();
+    let configured = Some(default_model)
+        .filter(|d| !d.is_empty())
+        .map(flat_model_id);
+    crate::config::first_available(
+        configured.into_iter().chain(model_mru.iter().cloned()),
+        &catalog,
+    )
+}
+
+/// The bridge's permission mode for a policy. `bypassPermissions` is what makes
+/// gateway/cron turns run unattended — the SDK then never calls `canUseTool`.
+fn permission_mode(policy: PermissionPolicy) -> &'static str {
+    if policy.is_full_access() {
+        "bypassPermissions"
+    } else {
+        "default"
+    }
+}
+
+struct AttachArgs {
+    worktree: String,
+    resume_acp_session_id: Option<String>,
+    mcp_config_path: Option<PathBuf>,
+    initial_model_override: Option<String>,
+    model_mru: Vec<String>,
+    initial_prompt: String,
+    event_tx: mpsc::Sender<AcpEventFrame>,
+    permission: PermissionPolicy,
+    forbid_new_session_fallback: bool,
+}
+
+async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMetadata, String> {
+    load_claude_pool_config(&shared.pool);
+    let worktree = canonical_dir(&args.worktree);
+    let mcp_servers = mcp::assemble(&worktree, args.mcp_config_path.as_deref());
+    let proc = shared
+        .pool
+        .ensure(shared, &worktree)
+        .map_err(|e| e.to_string())?;
+
+    // The catalog needs a live session, so it is only populated once one
+    // exists; an empty list on the very first attach is expected, not an error.
+    let available_models = proc
+        .client
+        .request("list_models", serde_json::json!({}))
+        .await
+        .map(|resp| models_from_list(&resp))
+        .unwrap_or_default();
+
+    let default_model = DaemonConfig::load(&DaemonConfig::default_path())
+        .ok()
+        .and_then(|c| c.agents.claude.and_then(|x| x.default_model))
+        .unwrap_or_default();
+    let initial_flat = pick_initial_model(
+        &available_models,
+        args.initial_model_override.as_deref(),
+        &args.model_mru,
+        &default_model,
+    );
+
+    let mut params = serde_json::json!({
+        "cwd": worktree,
+        "mcpServers": serde_json::Value::Object(mcp_servers),
+        "permissionMode": permission_mode(args.permission),
+        "initialPrompt": args.initial_prompt,
+    });
+    if let Some(flat) = initial_flat.as_deref() {
+        params["model"] = serde_json::json!(sdk_model_id(flat));
+    }
+
+    let resume_session_id = args
+        .resume_acp_session_id
+        .as_deref()
+        .and_then(|id| id.strip_prefix(SESSION_ID_PREFIX))
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    let resp = if let Some(sdk_session) = resume_session_id {
+        let mut resume_params = params.clone();
+        resume_params["sessionId"] = serde_json::json!(sdk_session);
+        match proc.client.request("resume_session", resume_params).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                if args.forbid_new_session_fallback {
+                    return Err(format!(
+                        "claude session {sdk_session} not resumable (new-session fallback forbidden): {e}"
+                    ));
+                }
+                warn!(sdk_session, error = %e, "claude resume failed; creating new session");
+                proc.client
+                    .request("create_session", params)
+                    .await
+                    .map_err(|e| e.to_string())?
+            }
+        }
+    } else {
+        proc.client
+            .request("create_session", params)
+            .await
+            .map_err(|e| e.to_string())?
+    };
+
+    let session_key = resp
+        .get("sessionKey")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "claude create_session missing sessionKey".to_string())?
+        .to_string();
+    let sdk_session_id = resp
+        .get("sessionId")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "claude create_session missing sessionId".to_string())?
+        .to_string();
+    let acp_session_id = format!("{SESSION_ID_PREFIX}{sdk_session_id}");
+    let model = resp
+        .get("model")
+        .and_then(|v| v.as_str())
+        .filter(|m| !m.is_empty())
+        .map(flat_model_id)
+        .or_else(|| initial_flat.clone())
+        .unwrap_or_default();
+
+    shared
+        .session_keys
+        .lock()
+        .insert(session_key.clone(), acp_session_id.clone());
+    shared
+        .session_worktrees
+        .lock()
+        .insert(session_key.clone(), worktree.clone());
+    shared.routes.lock().insert(
+        acp_session_id.clone(),
+        Route {
+            event_tx: args.event_tx,
+            permission: args.permission,
+            worktree: worktree.clone(),
+            session_key,
+            // startSession sends the opening turn itself, so the session is
+            // already mid-turn by the time we get here.
+            turn_active: true,
+            turn_reply_to: None,
+            turn_requester: None,
+            model: model.clone(),
+        },
+    );
+
+    info!(
+        session_id = %acp_session_id,
+        worktree = %worktree,
+        models = available_models.len(),
+        model = %model,
+        "claude session attached"
+    );
+    Ok(AcpStartupMetadata {
+        available_models,
+        initial_model: (!model.is_empty()).then_some(model),
+        acp_session_id,
+    })
+}
+
+async fn emit_frame(
+    event_tx: &mpsc::Sender<AcpEventFrame>,
+    session_id: &str,
+    ev: amux::AcpEvent,
+    reply_to: Option<String>,
+) {
+    crate::runtime::agent_trace::log_acp_event(session_id, &ev);
+    let _ = event_tx
+        .send(AcpEventFrame::new(session_id.to_string(), ev).with_reply_to(reply_to))
+        .await;
+}
+
+async fn do_prompt(
+    shared: &Arc<Shared>,
+    session_id: &str,
+    text: String,
+    attachment_urls: Vec<String>,
+    requester_actor_id: Option<String>,
+    reply_to_message_id: Option<String>,
+) {
+    let reply_to = reply_to_message_id.filter(|id| !id.is_empty());
+    let (event_tx, worktree, session_key, model) = {
+        let mut routes = shared.routes.lock();
+        let Some(route) = routes.get_mut(session_id) else {
+            warn!(session_id, "prompt for unknown claude session");
+            return;
+        };
+        route.turn_active = true;
+        route.turn_reply_to = reply_to.clone();
+        route.turn_requester = requester_actor_id.filter(|id| !id.is_empty());
+        (
+            route.event_tx.clone(),
+            route.worktree.clone(),
+            route.session_key.clone(),
+            route.model.clone(),
+        )
+    };
+
+    crate::runtime::agent_trace::log_prompt_begin(session_id, &text, attachment_urls.len());
+    emit_frame(
+        &event_tx,
+        session_id,
+        status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
+        reply_to.clone(),
+    )
+    .await;
+
+    let mut message = text;
+    if !attachment_urls.is_empty() {
+        message.push_str("\n\nAttachments:\n");
+        for url in &attachment_urls {
+            message.push_str(url);
+            message.push('\n');
+        }
+    }
+
+    let result = match shared.pool.ensure(shared, &worktree) {
+        Ok(proc) => {
+            let mut params = serde_json::json!({
+                "sessionKey": session_key,
+                "text": message,
+            });
+            if !model.is_empty() {
+                params["model"] = serde_json::json!(sdk_model_id(&model));
+            }
+            proc.client.request("send", params).await
+        }
+        Err(e) => Err(e),
+    };
+
+    if let Err(e) = result {
+        let details = e.to_string();
+        crate::runtime::agent_trace::log_prompt_end(session_id, false, &details, 0);
+        emit_frame(
+            &event_tx,
+            session_id,
+            amux::AcpEvent {
+                event: Some(amux::acp_event::Event::Error(amux::AcpError {
+                    message: "claude prompt failed".to_string(),
+                    details,
+                })),
+                model: String::new(),
+            },
+            reply_to.clone(),
+        )
+        .await;
+        {
+            let mut routes = shared.routes.lock();
+            if let Some(route) = routes.get_mut(session_id) {
+                route.turn_active = false;
+                route.turn_reply_to = None;
+                route.turn_requester = None;
+            }
+        }
+        emit_frame(
+            &event_tx,
+            session_id,
+            status_change(amux::AgentStatus::Active, amux::AgentStatus::Idle),
+            reply_to,
+        )
+        .await;
+    }
+}
+
+/// Look up a route's (worktree, sessionKey) pair for a bridge call.
+fn target_for(shared: &Arc<Shared>, session_id: &str) -> Option<(String, String)> {
+    let routes = shared.routes.lock();
+    let route = routes.get(session_id)?;
+    Some((route.worktree.clone(), route.session_key.clone()))
+}
+
+async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand>) {
+    while let Some(cmd) = cmd_rx.recv().await {
+        match cmd {
+            AcpCommand::AttachSession {
+                worktree,
+                resume_acp_session_id,
+                mcp_config_path,
+                initial_model_override,
+                model_mru,
+                initial_prompt,
+                event_tx,
+                startup_tx,
+                permission,
+                forbid_new_session_fallback,
+            } => {
+                let result = attach(
+                    &shared,
+                    AttachArgs {
+                        worktree,
+                        resume_acp_session_id,
+                        mcp_config_path,
+                        initial_model_override,
+                        model_mru,
+                        initial_prompt,
+                        event_tx,
+                        permission,
+                        forbid_new_session_fallback,
+                    },
+                )
+                .await;
+                let _ = startup_tx.send(result);
+            }
+            AcpCommand::Prompt {
+                acp_session_id,
+                text,
+                attachment_urls,
+                requester_actor_id,
+                reply_to_message_id,
+            } => {
+                do_prompt(
+                    &shared,
+                    &acp_session_id,
+                    text,
+                    attachment_urls,
+                    requester_actor_id,
+                    reply_to_message_id,
+                )
+                .await;
+            }
+            AcpCommand::Cancel { acp_session_id } => {
+                if let Some((worktree, session_key)) = target_for(&shared, &acp_session_id) {
+                    if let Ok(proc) = shared.pool.ensure(&shared, &worktree) {
+                        let _ = proc
+                            .client
+                            .request("cancel", serde_json::json!({ "sessionKey": session_key }))
+                            .await;
+                    }
+                }
+                // interrupt() does not always produce a terminal result
+                // message; close_turn is idempotent so a later one is a no-op.
+                events::close_turn(&shared, &acp_session_id).await;
+            }
+            AcpCommand::ResolvePermission {
+                request_id,
+                granted,
+                option_id,
+            } => permission::resolve(&shared, &request_id, granted, option_id.as_deref()).await,
+            AcpCommand::SetModel {
+                acp_session_id,
+                model_id,
+            } => {
+                let target = {
+                    let mut routes = shared.routes.lock();
+                    routes.get_mut(&acp_session_id).map(|route| {
+                        route.model = flat_model_id(&model_id);
+                        (route.worktree.clone(), route.session_key.clone())
+                    })
+                };
+                let Some((worktree, session_key)) = target else {
+                    warn!(acp_session_id, "set_model for unknown claude session");
+                    continue;
+                };
+                if let Ok(proc) = shared.pool.ensure(&shared, &worktree) {
+                    match proc
+                        .client
+                        .request(
+                            "set_model",
+                            serde_json::json!({
+                                "sessionKey": session_key,
+                                "model": sdk_model_id(&model_id),
+                            }),
+                        )
+                        .await
+                    {
+                        Ok(_) => info!(acp_session_id, model_id = %model_id, "claude model set"),
+                        Err(e) => warn!(acp_session_id, error = %e, "claude set_model failed"),
+                    }
+                }
+            }
+            AcpCommand::DetachSession { acp_session_id } => {
+                let removed = shared.routes.lock().remove(&acp_session_id);
+                if let Some(route) = removed {
+                    shared.session_keys.lock().remove(&route.session_key);
+                    shared.session_worktrees.lock().remove(&route.session_key);
+                    shared
+                        .permissions
+                        .lock()
+                        .retain(|_, p| p.session_key != route.session_key);
+                    if let Ok(proc) = shared.pool.ensure(&shared, &route.worktree) {
+                        let _ = proc
+                            .client
+                            .request(
+                                "close_session",
+                                serde_json::json!({ "sessionKey": route.session_key }),
+                            )
+                            .await;
+                    }
+                }
+            }
+            AcpCommand::AnswerQuestion { request_id, .. } => {
+                // Claude Code has no blocking `question` tool; nothing to route.
+                warn!(request_id, "claude backend: AnswerQuestion unsupported");
+            }
+            AcpCommand::Shutdown => {
+                shared.pool.kill_all();
+            }
+        }
+    }
+}
+
+pub struct ClaudeAgentBackend {
+    shared: Arc<Shared>,
+    cmd_tx: std::sync::OnceLock<mpsc::Sender<AcpCommand>>,
+}
+
+impl ClaudeAgentBackend {
+    pub fn new() -> Self {
+        let shared = Shared::new();
+        load_claude_pool_config(&shared.pool);
+        Self {
+            shared,
+            cmd_tx: std::sync::OnceLock::new(),
+        }
+    }
+
+    fn command_sender(&self) -> mpsc::Sender<AcpCommand> {
+        self.cmd_tx
+            .get_or_init(|| {
+                let (tx, rx) = mpsc::channel::<AcpCommand>(64);
+                tokio::spawn(command_loop(Arc::clone(&self.shared), rx));
+                tx
+            })
+            .clone()
+    }
+}
+
+impl Default for ClaudeAgentBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AgentBackend for ClaudeAgentBackend {
+    async fn attach_session(
+        &mut self,
+        _agent_type: amux::AgentType,
+        _launch: &AgentLaunchConfig,
+        extra_env: HashMap<String, String>,
+        force_env_override: bool,
+        worktree: String,
+        resume_acp_session_id: Option<String>,
+        mcp_config_path: Option<PathBuf>,
+        initial_model_override: Option<String>,
+        model_mru: Vec<String>,
+        initial_prompt: String,
+        event_tx: mpsc::Sender<AcpEventFrame>,
+        permission: PermissionPolicy,
+        forbid_new_session_fallback: bool,
+    ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
+        load_claude_pool_config(&self.shared.pool);
+        self.shared
+            .pool
+            .merge_extra_env(&extra_env, force_env_override);
+        let cmd_tx = self.command_sender();
+        // The opening prompt rides the create_session call — the SDK's
+        // streaming-input mode needs a first message to start the session at
+        // all, so there is no separate follow-up Prompt to send.
+        let startup = attach(
+            &self.shared,
+            AttachArgs {
+                worktree,
+                resume_acp_session_id,
+                mcp_config_path,
+                initial_model_override,
+                model_mru,
+                initial_prompt,
+                event_tx,
+                permission,
+                forbid_new_session_fallback,
+            },
+        )
+        .await
+        .map_err(crate::error::AmuxError::Agent)?;
+        Ok((cmd_tx, startup))
+    }
+
+    async fn prewarm(&mut self, _launch_configs: &HashMap<amux::AgentType, AgentLaunchConfig>) {
+        load_claude_pool_config(&self.shared.pool);
+    }
+
+    async fn prewarm_with_env(
+        &mut self,
+        _launch_configs: &HashMap<amux::AgentType, AgentLaunchConfig>,
+        extra_env: HashMap<String, String>,
+        force_env_override: bool,
+        worktree: Option<&str>,
+    ) {
+        load_claude_pool_config(&self.shared.pool);
+        self.shared
+            .pool
+            .merge_extra_env(&extra_env, force_env_override);
+        if let Some(worktree) = worktree.filter(|w| !w.is_empty()) {
+            let worktree = canonical_dir(worktree);
+            if let Err(e) = self.shared.pool.ensure(&self.shared, &worktree) {
+                warn!(worktree, error = %e, "claude prewarm failed");
+            } else {
+                info!(worktree, "claude bridge prewarmed");
+            }
+        }
+    }
+
+    fn evict_agent_types(&mut self, _agent_types: &[amux::AgentType]) -> usize {
+        self.shared.pool.kill_all()
+    }
+
+    fn host_count(&self) -> usize {
+        self.shared.pool.live_count()
+    }
+
+    /// Only `sdkModel` — what the SDK reports (init / `result.modelUsage`) — may
+    /// teach the device MRU; echoing our own request back would defeat the
+    /// point of this hook.
+    async fn session_model(&mut self, worktree: &str, backend_session_id: &str) -> Option<String> {
+        let session_key = {
+            let routes = self.shared.routes.lock();
+            routes.get(backend_session_id)?.session_key.clone()
+        };
+        let worktree = canonical_dir(worktree);
+        let proc = self.shared.pool.get(&worktree)?;
+        let resp = proc
+            .client
+            .request(
+                "get_session_info",
+                serde_json::json!({ "sessionKey": session_key }),
+            )
+            .await
+            .ok()?;
+        resp.get("sdkModel")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    }
+
+    async fn model_catalog(
+        &mut self,
+        workspace_path: &Path,
+    ) -> crate::error::Result<Vec<amux::ModelInfo>> {
+        load_claude_pool_config(&self.shared.pool);
+        let worktree = canonical_dir(&workspace_path.to_string_lossy());
+        let proc = match self
+            .shared
+            .pool
+            .get(&worktree)
+            .or_else(|| self.shared.pool.any_live())
+        {
+            Some(proc) => proc,
+            None => self.shared.pool.ensure(&self.shared, &worktree)?,
+        };
+        let resp = proc
+            .client
+            .request("list_models", serde_json::json!({}))
+            .await?;
+        Ok(models_from_list(&resp))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model(id: &str) -> amux::ModelInfo {
+        amux::ModelInfo {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            provider_name: "claude".to_string(),
+        }
+    }
+
+    #[test]
+    fn model_ids_round_trip_through_the_flat_form() {
+        assert_eq!(flat_model_id("claude-opus-5"), "claude/claude-opus-5");
+        // Already flat ids are left alone rather than double-prefixed.
+        assert_eq!(
+            flat_model_id("claude/claude-opus-5"),
+            "claude/claude-opus-5"
+        );
+        assert_eq!(sdk_model_id("claude/claude-opus-5"), "claude-opus-5");
+        assert_eq!(sdk_model_id("claude-opus-5"), "claude-opus-5");
+    }
+
+    #[test]
+    fn permission_mode_maps_full_access_to_bypass() {
+        assert_eq!(permission_mode(PermissionPolicy::Full), "bypassPermissions");
+        assert_eq!(permission_mode(PermissionPolicy::Ask), "default");
+    }
+
+    #[test]
+    fn pick_initial_model_prefers_override_then_config_then_mru() {
+        let available = vec![
+            model("claude/claude-opus-5"),
+            model("claude/claude-sonnet-5"),
+        ];
+
+        assert_eq!(
+            pick_initial_model(
+                &available,
+                Some("claude/claude-sonnet-5"),
+                &[],
+                "claude-opus-5"
+            ),
+            Some("claude/claude-sonnet-5".to_string())
+        );
+        // Configured default wins over the MRU when it is actually available.
+        assert_eq!(
+            pick_initial_model(
+                &available,
+                None,
+                &["claude/claude-sonnet-5".to_string()],
+                "claude-opus-5"
+            ),
+            Some("claude/claude-opus-5".to_string())
+        );
+        // An unavailable default falls through to the MRU.
+        assert_eq!(
+            pick_initial_model(
+                &available,
+                None,
+                &["claude/claude-sonnet-5".to_string()],
+                "claude-retired-9"
+            ),
+            Some("claude/claude-sonnet-5".to_string())
+        );
+    }
+
+    #[test]
+    fn pick_initial_model_says_nothing_when_nothing_resolves() {
+        // Deliberately None rather than "first in the catalog": with no signal
+        // we let the SDK apply its own default (same as the pi backend).
+        assert_eq!(
+            pick_initial_model(&[model("claude/claude-opus-5")], None, &[], ""),
+            None
+        );
+        assert_eq!(pick_initial_model(&[], None, &[], ""), None);
+    }
+
+    #[test]
+    fn an_empty_catalog_does_not_discard_a_configured_model() {
+        // The catalog needs a live session, so the first attach always sees an
+        // empty one. Empty means "unknown", not "unavailable" — dropping the
+        // user's configured model there would silently ignore their setting.
+        assert_eq!(
+            pick_initial_model(&[], None, &[], "claude-opus-5"),
+            Some("claude/claude-opus-5".to_string())
+        );
+        assert_eq!(
+            pick_initial_model(&[], None, &["claude/claude-sonnet-5".to_string()], ""),
+            Some("claude/claude-sonnet-5".to_string())
+        );
+    }
+
+    #[test]
+    fn models_from_list_skips_entries_without_an_id() {
+        let resp = serde_json::json!({"models": [
+            {"id": "claude/claude-opus-5", "displayName": "Opus 5"},
+            {"displayName": "no id"},
+            {"id": ""}
+        ]});
+        let models = models_from_list(&resp);
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "claude/claude-opus-5");
+        assert_eq!(models[0].display_name, "Opus 5");
+        assert_eq!(models[0].provider_name, "claude");
+        assert!(models_from_list(&serde_json::json!({})).is_empty());
+    }
+
+    #[tokio::test]
+    async fn host_count_zero_without_processes() {
+        let backend = ClaudeAgentBackend::new();
+        assert_eq!(backend.host_count(), 0);
+    }
+}

--- a/apps/daemon/src/runtime/claude_agent/permission.rs
+++ b/apps/daemon/src/runtime/claude_agent/permission.rs
@@ -1,0 +1,268 @@
+//! Permission requests from the Agent SDK's `canUseTool` callback.
+//!
+//! The whole loop is in-process on the bridge side: `canUseTool` returns a
+//! promise, so the bridge blocks the tool call until we answer. That means —
+//! unlike `cursor_sdk` — there is no hooks file in the user's repo, no socket
+//! round-trip through a spawned helper, and a deny genuinely stops the call
+//! with a message the model reads.
+//!
+//! Because the SDK is blocked rather than polling, this path **fails closed**:
+//! if we cannot route the request, denying is correct (the turn continues with
+//! a refusal the model can react to), whereas allowing would run a tool nobody
+//! approved.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::Value;
+use tracing::warn;
+
+use crate::proto::amux;
+use crate::runtime::acp_event_frame::AcpEventFrame;
+use crate::runtime::opencode_http::translate::permission_options;
+
+use super::Shared;
+
+pub(crate) struct PendingPermission {
+    /// Bridge-side session handle, needed to address the reply.
+    pub(crate) session_key: String,
+    /// The SDK's own "always allow" rule suggestions, echoed back verbatim on
+    /// an `always` grant so the persisted rule matches the real tool call.
+    pub(crate) suggestions: Value,
+    pub(crate) can_always: bool,
+}
+
+fn describe(tool_name: &str, input: &Value) -> String {
+    for key in ["command", "file_path", "path", "url", "pattern", "query"] {
+        if let Some(v) = input.get(key).and_then(|v| v.as_str()) {
+            if !v.is_empty() {
+                return format!("{tool_name}: {v}");
+            }
+        }
+    }
+    tool_name.to_string()
+}
+
+fn params_from_input(input: &Value) -> HashMap<String, String> {
+    match input {
+        Value::Object(map) => map
+            .iter()
+            .map(|(k, v)| {
+                let s = match v {
+                    Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                };
+                (k.clone(), s)
+            })
+            .collect(),
+        _ => HashMap::new(),
+    }
+}
+
+/// Options to show the human. "Always allow" is offered only when the SDK
+/// supplied rule suggestions — otherwise the grant could not be persisted and
+/// the button would silently behave like a one-shot allow.
+fn options_for(can_always: bool) -> Vec<amux::AcpPermissionOption> {
+    permission_options()
+        .into_iter()
+        .filter(|o| can_always || o.option_id != "always")
+        .collect()
+}
+
+/// Route one `permission_request` event to clients. Registers the pending
+/// request; the answer arrives later as `AcpCommand::ResolvePermission`.
+pub(super) async fn handle_request(
+    shared: &Arc<Shared>,
+    session_id: &str,
+    session_key: &str,
+    event: &Value,
+) {
+    let request_id = event
+        .get("requestId")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    if request_id.is_empty() {
+        return;
+    }
+    let tool_name = event
+        .get("toolName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("tool")
+        .to_string();
+    let input = event
+        .get("input")
+        .cloned()
+        .unwrap_or_else(|| Value::Object(Default::default()));
+    let can_always = event
+        .get("canAlways")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    // Snapshot under the lock, then decide — the guard must not be alive
+    // across an await (parking_lot guards are not Send).
+    let snapshot = shared.routes.lock().get(session_id).map(|route| {
+        (
+            route.event_tx.clone(),
+            route.turn_requester.clone(),
+            route.turn_reply_to.clone(),
+        )
+    });
+    let Some((event_tx, requester, reply_to)) = snapshot else {
+        warn!(
+            session_id,
+            request_id, "claude permission for unknown session; denying"
+        );
+        deny_unrouted(shared, session_key, &request_id).await;
+        return;
+    };
+
+    let mut params = params_from_input(&input);
+    params.insert("request_id".to_string(), request_id.clone());
+    if let Some(actor) = requester {
+        params.insert("requester_actor_id".to_string(), actor);
+    }
+
+    shared.permissions.lock().insert(
+        request_id.clone(),
+        PendingPermission {
+            session_key: session_key.to_string(),
+            suggestions: event
+                .get("suggestions")
+                .cloned()
+                .unwrap_or(Value::Array(Vec::new())),
+            can_always,
+        },
+    );
+
+    let ev = amux::AcpEvent {
+        event: Some(amux::acp_event::Event::PermissionRequest(
+            amux::AcpPermissionRequest {
+                request_id: request_id.clone(),
+                tool_name: tool_name.clone(),
+                description: describe(&tool_name, &input),
+                params,
+                options: options_for(can_always),
+            },
+        )),
+        model: String::new(),
+    };
+    crate::runtime::agent_trace::log_acp_event(session_id, &ev);
+    if event_tx
+        .send(AcpEventFrame::new(session_id.to_string(), ev).with_reply_to(reply_to))
+        .await
+        .is_err()
+    {
+        shared.permissions.lock().remove(&request_id);
+        warn!(
+            session_id,
+            "claude permission: event channel closed; denying"
+        );
+        deny_unrouted(shared, session_key, &request_id).await;
+    }
+}
+
+async fn deny_unrouted(shared: &Arc<Shared>, session_key: &str, request_id: &str) {
+    reply(
+        shared,
+        session_key,
+        request_id,
+        serde_json::json!({
+            "requestId": request_id,
+            "granted": false,
+            "message": "TeamClaw could not route this approval request.",
+            "interrupt": true,
+        }),
+    )
+    .await;
+}
+
+async fn reply(shared: &Arc<Shared>, session_key: &str, request_id: &str, params: Value) {
+    let worktree = shared
+        .session_worktrees
+        .lock()
+        .get(session_key)
+        .cloned()
+        .unwrap_or_default();
+    let Some(proc) = shared.pool.get(&worktree) else {
+        warn!(request_id, worktree, "claude permission reply: bridge gone");
+        return;
+    };
+    if let Err(e) = proc.client.request("resolve_permission", params).await {
+        warn!(request_id, error = %e, "claude permission reply failed");
+    }
+}
+
+/// Answer a pending request (from `AcpCommand::ResolvePermission`).
+pub(crate) async fn resolve(
+    shared: &Arc<Shared>,
+    request_id: &str,
+    granted: bool,
+    option_id: Option<&str>,
+) {
+    let Some(pending) = shared.permissions.lock().remove(request_id) else {
+        warn!(request_id, "no pending claude permission");
+        return;
+    };
+    let always = granted && option_id == Some("always") && pending.can_always;
+    let params = if granted {
+        serde_json::json!({
+            "requestId": request_id,
+            "granted": true,
+            "always": always,
+            "suggestions": pending.suggestions,
+        })
+    } else {
+        serde_json::json!({
+            "requestId": request_id,
+            "granted": false,
+            "message": "The user rejected this tool call. Pick another approach or ask what to do instead.",
+            // A bare rejection with no guidance should stop the turn rather
+            // than let the model keep hammering at the same action.
+            "interrupt": true,
+        })
+    };
+    reply(shared, &pending.session_key, request_id, params).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn describe_prefers_the_most_specific_input_field() {
+        assert_eq!(
+            describe("Bash", &json!({"command": "rm -rf /", "cwd": "/w"})),
+            "Bash: rm -rf /"
+        );
+        assert_eq!(
+            describe("Read", &json!({"file_path": "/w/a.rs"})),
+            "Read: /w/a.rs"
+        );
+        assert_eq!(describe("Grep", &json!({"pattern": "TODO"})), "Grep: TODO");
+        assert_eq!(describe("Weird", &json!({"n": 1})), "Weird");
+    }
+
+    #[test]
+    fn always_is_offered_only_when_the_sdk_can_persist_it() {
+        let with = options_for(true);
+        assert_eq!(with.len(), 3);
+        assert!(with.iter().any(|o| o.option_id == "always"));
+
+        let without = options_for(false);
+        assert_eq!(without.len(), 2);
+        assert!(!without.iter().any(|o| o.option_id == "always"));
+        // once / reject must survive.
+        assert!(without.iter().any(|o| o.option_id == "once"));
+        assert!(without.iter().any(|o| o.option_id == "reject"));
+    }
+
+    #[test]
+    fn params_stringify_non_string_values() {
+        let params = params_from_input(&json!({"a": "x", "n": 3}));
+        assert_eq!(params.get("a").map(String::as_str), Some("x"));
+        assert_eq!(params.get("n").map(String::as_str), Some("3"));
+        assert!(params_from_input(&json!("scalar")).is_empty());
+    }
+}

--- a/apps/daemon/src/runtime/claude_agent/process.rs
+++ b/apps/daemon/src/runtime/claude_agent/process.rs
@@ -1,22 +1,29 @@
-//! Per-worktree cursor-bridge process pool.
+//! Per-worktree claude-bridge process pool.
+//!
+//! Structurally the same as `cursor_sdk/process.rs`: one Node child per
+//! canonical worktree, respawned when the env fingerprint changes. The
+//! differences are the bridge path and that the API key is *optional* — the
+//! Agent SDK falls back to whatever `claude` login already exists on the host,
+//! so refusing to spawn without a key would break subscription users.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::runtime::sidecar::client::SidecarClient;
+
 use super::{events, Shared};
 
-pub(crate) struct CursorProcess {
+pub(crate) struct ClaudeProcess {
     pub(crate) client: SidecarClient,
     child: parking_lot::Mutex<tokio::process::Child>,
     env_fingerprint: String,
 }
 
-impl CursorProcess {
+impl ClaudeProcess {
     pub(crate) fn is_alive(&self) -> bool {
         matches!(self.child.lock().try_wait(), Ok(None))
     }
@@ -26,8 +33,8 @@ impl CursorProcess {
     }
 }
 
-pub(crate) struct CursorProcessPool {
-    procs: parking_lot::Mutex<HashMap<String, Arc<CursorProcess>>>,
+pub(crate) struct ClaudeProcessPool {
+    procs: parking_lot::Mutex<HashMap<String, Arc<ClaudeProcess>>>,
     bridge_command: parking_lot::Mutex<Option<Vec<String>>>,
     api_key: parking_lot::Mutex<Option<String>>,
     default_model: parking_lot::Mutex<String>,
@@ -36,13 +43,13 @@ pub(crate) struct CursorProcessPool {
     force_env_override: parking_lot::Mutex<bool>,
 }
 
-impl CursorProcessPool {
+impl ClaudeProcessPool {
     pub(crate) fn new() -> Self {
         Self {
             procs: parking_lot::Mutex::new(HashMap::new()),
             bridge_command: parking_lot::Mutex::new(None),
             api_key: parking_lot::Mutex::new(None),
-            default_model: parking_lot::Mutex::new("composer-2.5".to_string()),
+            default_model: parking_lot::Mutex::new(String::new()),
             extra_env: parking_lot::Mutex::new(HashMap::new()),
             force_env_override: parking_lot::Mutex::new(false),
         }
@@ -101,7 +108,7 @@ impl CursorProcessPool {
         )
     }
 
-    pub(crate) fn get(&self, worktree: &str) -> Option<Arc<CursorProcess>> {
+    pub(crate) fn get(&self, worktree: &str) -> Option<Arc<ClaudeProcess>> {
         let mut procs = self.procs.lock();
         match procs.get(worktree) {
             Some(p) if p.is_alive() => Some(Arc::clone(p)),
@@ -113,7 +120,7 @@ impl CursorProcessPool {
         }
     }
 
-    pub(crate) fn any_live(&self) -> Option<Arc<CursorProcess>> {
+    pub(crate) fn any_live(&self) -> Option<Arc<ClaudeProcess>> {
         self.procs
             .lock()
             .values()
@@ -126,7 +133,7 @@ impl CursorProcessPool {
     }
 
     pub(crate) fn kill_all(&self) -> usize {
-        let procs: Vec<Arc<CursorProcess>> = self.procs.lock().drain().map(|(_, p)| p).collect();
+        let procs: Vec<Arc<ClaudeProcess>> = self.procs.lock().drain().map(|(_, p)| p).collect();
         let mut killed = 0;
         for p in procs {
             if p.is_alive() {
@@ -141,13 +148,13 @@ impl CursorProcessPool {
         &self,
         shared: &Arc<Shared>,
         worktree: &str,
-    ) -> crate::error::Result<Arc<CursorProcess>> {
+    ) -> crate::error::Result<Arc<ClaudeProcess>> {
         let want = self.env_fingerprint();
         if let Some(p) = self.get(worktree) {
             if p.env_fingerprint == want {
                 return Ok(p);
             }
-            info!(worktree, "cursor bridge env changed; respawning");
+            info!(worktree, "claude bridge env changed; respawning");
             p.kill();
             self.procs.lock().remove(worktree);
         }
@@ -162,7 +169,7 @@ impl CursorProcessPool {
         &self,
         shared: &Arc<Shared>,
         worktree: &str,
-    ) -> crate::error::Result<Arc<CursorProcess>> {
+    ) -> crate::error::Result<Arc<ClaudeProcess>> {
         let bridge = self
             .bridge_command
             .lock()
@@ -170,22 +177,13 @@ impl CursorProcessPool {
             .unwrap_or_else(default_bridge_command);
         if bridge.is_empty() {
             return Err(crate::error::AmuxError::Agent(
-                "cursor bridge command is empty".into(),
+                "claude bridge command is empty".into(),
             ));
         }
 
-        let api_key = self
-            .api_key
-            .lock()
-            .clone()
-            .or_else(|| std::env::var("CURSOR_API_KEY").ok())
-            .filter(|k| !k.trim().is_empty())
-            .ok_or_else(|| {
-                crate::error::AmuxError::Agent(
-                    "CURSOR_API_KEY is not set; configure [agents.cursor].api_key or the env var"
-                        .into(),
-                )
-            })?;
+        // Optional on purpose: with no key the Agent SDK uses the host's own
+        // `claude` login (subscription auth), which is the common desktop case.
+        let api_key = self.api_key.lock().clone().filter(|k| !k.trim().is_empty());
 
         let mut cmd = tokio::process::Command::new(&bridge[0]);
         for arg in bridge.iter().skip(1) {
@@ -209,16 +207,19 @@ impl CursorProcessPool {
                 cmd.env(k, v);
             }
         }
-        // Always win over any injected duplicate.
-        cmd.env("CURSOR_API_KEY", api_key);
+        // Only override when we actually have one; otherwise leave whatever
+        // the host env provides so the SDK's own auth resolution still works.
+        if let Some(api_key) = api_key {
+            cmd.env("ANTHROPIC_API_KEY", api_key);
+        }
 
-        info!(worktree, bridge = ?bridge, "spawning cursor-bridge");
+        info!(worktree, bridge = ?bridge, "spawning claude-bridge");
         let mut child = cmd.spawn().map_err(|e| {
             let hint = if e.kind() == std::io::ErrorKind::NotFound {
-                "node or cursor-bridge not found; run npm install in apps/daemon/cursor-bridge"
+                "node or claude-bridge not found; run npm install in apps/daemon/claude-bridge"
                     .to_string()
             } else {
-                format!("spawn cursor-bridge: {e}")
+                format!("spawn claude-bridge: {e}")
             };
             crate::error::AmuxError::Agent(hint)
         })?;
@@ -226,11 +227,11 @@ impl CursorProcessPool {
         let stdin = child
             .stdin
             .take()
-            .ok_or_else(|| crate::error::AmuxError::Agent("cursor stdin unavailable".into()))?;
+            .ok_or_else(|| crate::error::AmuxError::Agent("claude stdin unavailable".into()))?;
         let stdout = child
             .stdout
             .take()
-            .ok_or_else(|| crate::error::AmuxError::Agent("cursor stdout unavailable".into()))?;
+            .ok_or_else(|| crate::error::AmuxError::Agent("claude stdout unavailable".into()))?;
         if let Some(stderr) = child.stderr.take() {
             tokio::spawn(async move {
                 let mut reader = BufReader::new(stderr);
@@ -242,7 +243,7 @@ impl CursorProcessPool {
                         Ok(_) => {
                             let trimmed = line.trim();
                             if !trimmed.is_empty() {
-                                tracing::debug!(target: "cursor_bridge", "{trimmed}");
+                                tracing::debug!(target: "claude_bridge", "{trimmed}");
                             }
                         }
                     }
@@ -258,7 +259,7 @@ impl CursorProcessPool {
             client.clone(),
         );
 
-        Ok(Arc::new(CursorProcess {
+        Ok(Arc::new(ClaudeProcess {
             client,
             child: parking_lot::Mutex::new(child),
             env_fingerprint: self.env_fingerprint(),
@@ -267,7 +268,7 @@ impl CursorProcessPool {
 }
 
 pub fn default_bridge_main() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("cursor-bridge/src/main.mjs")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("claude-bridge/src/main.mjs")
 }
 
 pub fn default_bridge_command() -> Vec<String> {
@@ -294,6 +295,6 @@ mod tests {
     fn default_bridge_command_includes_main_script() {
         let cmd = default_bridge_command();
         assert_eq!(cmd[0], "node");
-        assert!(cmd[1].ends_with("cursor-bridge/src/main.mjs"));
+        assert!(cmd[1].ends_with("claude-bridge/src/main.mjs"));
     }
 }

--- a/apps/daemon/src/runtime/claude_agent/translate.rs
+++ b/apps/daemon/src/runtime/claude_agent/translate.rs
@@ -1,0 +1,231 @@
+//! claude-bridge events → `amux::AcpEvent`.
+//!
+//! Same vocabulary as `cursor_sdk/translate.rs` and `opencode_http/translate.rs`
+//! — the client protocol is backend-neutral, so a new backend's only job here is
+//! to map its own event names onto these blocks.
+
+use std::collections::HashMap;
+
+use crate::proto::amux;
+use crate::runtime::opencode_http::translate::truncate_tool_summary;
+
+fn text_event(thinking: bool, text: String) -> amux::AcpEvent {
+    let event = if thinking {
+        amux::acp_event::Event::Thinking(amux::AcpThinking { text })
+    } else {
+        amux::acp_event::Event::Output(amux::AcpOutput {
+            text,
+            is_complete: false,
+        })
+    };
+    amux::AcpEvent {
+        event: Some(event),
+        model: String::new(),
+    }
+}
+
+fn params_from_map(args: &serde_json::Value) -> HashMap<String, String> {
+    match args {
+        serde_json::Value::Object(map) => map
+            .iter()
+            .map(|(k, v)| {
+                let s = match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                };
+                (k.clone(), s)
+            })
+            .collect(),
+        _ => HashMap::new(),
+    }
+}
+
+/// Claude Code's built-in tool names → the shared `tool_kind` vocabulary.
+pub fn tool_kind(name: &str) -> &'static str {
+    match name {
+        "Bash" | "BashOutput" | "KillShell" => "execute",
+        "Edit" | "Write" | "NotebookEdit" => "edit",
+        "Read" => "read",
+        "Glob" | "Grep" => "search",
+        "WebFetch" | "WebSearch" => "fetch",
+        _ => "other",
+    }
+}
+
+pub fn translate_event(event: &serde_json::Value) -> Vec<amux::AcpEvent> {
+    let name = event.get("event").and_then(|v| v.as_str()).unwrap_or("");
+    let text = || {
+        event
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+
+    match name {
+        "assistant_delta" => {
+            let text = text();
+            if text.is_empty() {
+                return Vec::new();
+            }
+            vec![text_event(false, text)]
+        }
+        "thinking_delta" => {
+            let text = text();
+            if text.is_empty() {
+                return Vec::new();
+            }
+            vec![text_event(true, text)]
+        }
+        "tool_start" => {
+            let tool_name = event
+                .get("toolName")
+                .and_then(|v| v.as_str())
+                .unwrap_or("tool")
+                .to_string();
+            vec![amux::AcpEvent {
+                event: Some(amux::acp_event::Event::ToolUse(amux::AcpToolUse {
+                    tool_id: event
+                        .get("toolCallId")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    tool_name: tool_name.clone(),
+                    description: String::new(),
+                    params: params_from_map(event.get("args").unwrap_or(&serde_json::Value::Null)),
+                    tool_kind: tool_kind(&tool_name).to_string(),
+                    raw_input_json: event.get("args").map(|v| v.to_string()).unwrap_or_default(),
+                    raw_output_json: String::new(),
+                    content: vec![],
+                    locations: vec![],
+                    status: "in_progress".to_string(),
+                })),
+                model: String::new(),
+            }]
+        }
+        "tool_end" => {
+            let is_error = event
+                .get("isError")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            vec![amux::AcpEvent {
+                event: Some(amux::acp_event::Event::ToolResult(amux::AcpToolResult {
+                    tool_id: event
+                        .get("toolCallId")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    success: !is_error,
+                    summary: truncate_tool_summary(
+                        event
+                            .get("summary")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                    ),
+                    raw_output_json: String::new(),
+                    content: vec![],
+                })),
+                model: String::new(),
+            }]
+        }
+        "run_error" => {
+            let message = event
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("claude run error")
+                .to_string();
+            vec![amux::AcpEvent {
+                event: Some(amux::acp_event::Event::Error(amux::AcpError {
+                    message: message.clone(),
+                    details: message,
+                })),
+                model: String::new(),
+            }]
+        }
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn one(event: serde_json::Value) -> amux::AcpEvent {
+        let mut out = translate_event(&event);
+        assert_eq!(out.len(), 1, "expected exactly one event");
+        out.remove(0)
+    }
+
+    #[test]
+    fn tool_kind_maps_claude_code_builtins() {
+        assert_eq!(tool_kind("Bash"), "execute");
+        assert_eq!(tool_kind("Edit"), "edit");
+        assert_eq!(tool_kind("Read"), "read");
+        assert_eq!(tool_kind("Grep"), "search");
+        assert_eq!(tool_kind("WebFetch"), "fetch");
+        assert_eq!(tool_kind("mcp__foo__bar"), "other");
+    }
+
+    #[test]
+    fn assistant_and_thinking_deltas_split_by_kind() {
+        let out = one(json!({"event": "assistant_delta", "text": "hi"}));
+        assert!(matches!(out.event, Some(amux::acp_event::Event::Output(_))));
+        let out = one(json!({"event": "thinking_delta", "text": "hmm"}));
+        assert!(matches!(
+            out.event,
+            Some(amux::acp_event::Event::Thinking(_))
+        ));
+    }
+
+    #[test]
+    fn empty_text_deltas_are_dropped() {
+        assert!(translate_event(&json!({"event": "assistant_delta", "text": ""})).is_empty());
+        assert!(translate_event(&json!({"event": "thinking_delta"})).is_empty());
+    }
+
+    #[test]
+    fn tool_start_carries_kind_and_params() {
+        let out = one(json!({
+            "event": "tool_start", "toolCallId": "t1", "toolName": "Bash",
+            "args": {"command": "ls", "timeout": 5}
+        }));
+        let Some(amux::acp_event::Event::ToolUse(use_)) = out.event else {
+            panic!("expected ToolUse");
+        };
+        assert_eq!(use_.tool_id, "t1");
+        assert_eq!(use_.tool_kind, "execute");
+        assert_eq!(use_.params.get("command").map(String::as_str), Some("ls"));
+        assert_eq!(use_.params.get("timeout").map(String::as_str), Some("5"));
+    }
+
+    #[test]
+    fn tool_end_maps_error_flag_to_success() {
+        let Some(amux::acp_event::Event::ToolResult(ok)) =
+            one(json!({"event": "tool_end", "toolCallId": "t1", "summary": "done"})).event
+        else {
+            panic!("expected ToolResult");
+        };
+        assert!(ok.success);
+        assert_eq!(ok.summary, "done");
+
+        let Some(amux::acp_event::Event::ToolResult(bad)) =
+            one(json!({"event": "tool_end", "toolCallId": "t1", "isError": true})).event
+        else {
+            panic!("expected ToolResult");
+        };
+        assert!(!bad.success);
+    }
+
+    #[test]
+    fn unknown_and_lifecycle_events_translate_to_nothing() {
+        // turn_start / turn_end drive route state, not the event stream.
+        for name in ["turn_start", "turn_end", "permission_request", "bogus"] {
+            assert!(
+                translate_event(&json!({"event": name})).is_empty(),
+                "{name} should not translate"
+            );
+        }
+    }
+}

--- a/apps/daemon/src/runtime/cursor_sdk/hooks.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/hooks.rs
@@ -1,0 +1,227 @@
+//! TeamClaw's `preToolUse` gate in `<worktree>/.cursor/hooks.json`.
+//!
+//! `@cursor/sdk` has no out-of-band approval API: the only way to gate a local
+//! agent's tool call is a Cursor hook — the SDK spawns the hook's `command`,
+//! feeds it the request on stdin, and reads `{"permission":"allow"|"deny"}` off
+//! stdout. `preToolUse` is the one generic step (`tool_name` + `tool_input` +
+//! `cwd` for every tool); `deny` turns the call into a `permission_denied`
+//! rejection the model sees.
+//!
+//! Hooks are discovered from setting sources, and the `project` source resolves
+//! from the *first* `local.cwd` entry only (`Array.isArray(cwd) ? cwd[0] : cwd`
+//! in the SDK), so the file has to live in the worktree itself — a sidecar
+//! directory passed as a second root is never scanned.
+//!
+//! The file is shared with whatever the user already put there, so we merge:
+//! entries whose command contains [`HOOK_MARKER`] are ours and get replaced,
+//! everything else is preserved verbatim.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+use tracing::warn;
+
+/// Substring identifying a TeamClaw-managed hook entry.
+pub const HOOK_MARKER: &str = "cursor-permission-hook";
+
+/// How long the hook process waits for a human before giving up. The SDK reads
+/// this per entry (`timeout`, in seconds) — its default is far too short for a
+/// person to actually answer.
+pub const HOOK_TIMEOUT_SECS: u64 = 600;
+
+pub fn hooks_path(worktree: &str) -> PathBuf {
+    Path::new(worktree).join(".cursor").join("hooks.json")
+}
+
+fn our_entry(amuxd_bin: &Path, sock: &Path, worktree: &str) -> Value {
+    json!({
+        "command": format!(
+            "{} {HOOK_MARKER} --sock={} --worktree={}",
+            shell_quote(&amuxd_bin.to_string_lossy()),
+            shell_quote(&sock.to_string_lossy()),
+            shell_quote(worktree),
+        ),
+        "timeout": HOOK_TIMEOUT_SECS,
+    })
+}
+
+/// Single-quote a path for the shell the SDK runs hook commands through.
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+fn is_ours(entry: &Value) -> bool {
+    entry
+        .get("command")
+        .and_then(|v| v.as_str())
+        .is_some_and(|c| c.contains(HOOK_MARKER))
+}
+
+/// Merge our `preToolUse` entry into an existing hooks document, preserving
+/// every user-authored entry and dropping stale copies of our own.
+pub fn merge_document(existing: Option<Value>, ours: Value) -> Value {
+    let mut root = match existing {
+        Some(Value::Object(map)) => Value::Object(map),
+        _ => json!({}),
+    };
+    root["version"] = json!(1);
+    if !root.get("hooks").map(|h| h.is_object()).unwrap_or(false) {
+        root["hooks"] = json!({});
+    }
+    let step = root["hooks"]["preToolUse"].take();
+    let mut entries: Vec<Value> = match step {
+        Value::Array(items) => items.into_iter().filter(|e| !is_ours(e)).collect(),
+        _ => Vec::new(),
+    };
+    // Ours runs first: a user hook that denies still denies, but we never make
+    // a human answer for a call their own hook would have blocked outright.
+    entries.insert(0, ours);
+    root["hooks"]["preToolUse"] = Value::Array(entries);
+    root
+}
+
+/// Write (or refresh) the gate in `<worktree>/.cursor/hooks.json`.
+pub fn ensure(worktree: &str, amuxd_bin: &Path, sock: &Path) -> std::io::Result<PathBuf> {
+    let path = hooks_path(worktree);
+    let existing = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|body| serde_json::from_str::<Value>(&body).ok());
+    let merged = merge_document(existing, our_entry(amuxd_bin, sock, worktree));
+    let body = serde_json::to_string_pretty(&merged)?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Skip the write when nothing changed so we don't touch mtime (and thus the
+    // user's git status) on every attach.
+    if std::fs::read_to_string(&path).ok().as_deref() == Some(body.as_str()) {
+        return Ok(path);
+    }
+    std::fs::write(&path, &body)?;
+    exclude_from_git(worktree);
+    Ok(path)
+}
+
+/// Best-effort: keep the managed file out of `git status` via
+/// `.git/info/exclude`. Only touches repos where it is not already ignored, and
+/// never rewrites the user's `.gitignore`.
+fn exclude_from_git(worktree: &str) {
+    let info = Path::new(worktree).join(".git").join("info");
+    if !info.is_dir() {
+        return;
+    }
+    let exclude = info.join("exclude");
+    let current = std::fs::read_to_string(&exclude).unwrap_or_default();
+    let line = ".cursor/hooks.json";
+    if current.lines().any(|l| l.trim() == line) {
+        return;
+    }
+    let mut next = current;
+    if !next.is_empty() && !next.ends_with('\n') {
+        next.push('\n');
+    }
+    next.push_str("# TeamClaw cursor permission gate\n");
+    next.push_str(line);
+    next.push('\n');
+    if let Err(e) = std::fs::write(&exclude, next) {
+        warn!(worktree, error = %e, "cursor: .git/info/exclude update failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ours() -> Value {
+        json!({ "command": "'/bin/amuxd' cursor-permission-hook --sock='/s'", "timeout": 600 })
+    }
+
+    #[test]
+    fn merge_into_empty_document_creates_the_step() {
+        let doc = merge_document(None, ours());
+        assert_eq!(doc["version"], json!(1));
+        assert_eq!(doc["hooks"]["preToolUse"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn merge_preserves_user_entries_and_other_steps() {
+        let existing = json!({
+            "version": 1,
+            "hooks": {
+                "preToolUse": [{ "command": "./scripts/audit.sh" }],
+                "afterFileEdit": [{ "command": "./scripts/fmt.sh" }]
+            }
+        });
+        let doc = merge_document(Some(existing), ours());
+        let pre = doc["hooks"]["preToolUse"].as_array().unwrap();
+        assert_eq!(pre.len(), 2);
+        assert!(is_ours(&pre[0]), "ours runs first");
+        assert_eq!(pre[1]["command"], json!("./scripts/audit.sh"));
+        assert_eq!(
+            doc["hooks"]["afterFileEdit"][0]["command"],
+            json!("./scripts/fmt.sh")
+        );
+    }
+
+    #[test]
+    fn merge_replaces_a_stale_copy_of_our_own_entry() {
+        let existing = json!({
+            "hooks": { "preToolUse": [
+                { "command": "'/old/amuxd' cursor-permission-hook --sock='/old'" },
+                { "command": "./keep.sh" }
+            ]}
+        });
+        let doc = merge_document(Some(existing), ours());
+        let pre = doc["hooks"]["preToolUse"].as_array().unwrap();
+        assert_eq!(pre.len(), 2);
+        assert_eq!(pre[0]["command"], ours()["command"]);
+        assert_eq!(pre[1]["command"], json!("./keep.sh"));
+    }
+
+    #[test]
+    fn merge_survives_a_garbage_document() {
+        let doc = merge_document(Some(json!("not an object")), ours());
+        assert_eq!(doc["hooks"]["preToolUse"].as_array().unwrap().len(), 1);
+        let doc = merge_document(Some(json!({ "hooks": 42 })), ours());
+        assert_eq!(doc["hooks"]["preToolUse"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn ensure_writes_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path().to_string_lossy().into_owned();
+        let bin = Path::new("/usr/local/bin/amuxd");
+        let sock = Path::new("/tmp/amuxd.sock");
+
+        let path = ensure(&worktree, bin, sock).unwrap();
+        let first = std::fs::read_to_string(&path).unwrap();
+        assert!(first.contains(HOOK_MARKER));
+        assert!(first.contains("\"timeout\": 600"));
+
+        ensure(&worktree, bin, sock).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), first);
+    }
+
+    #[test]
+    fn ensure_registers_the_file_in_git_info_exclude() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path().to_string_lossy().into_owned();
+        std::fs::create_dir_all(dir.path().join(".git/info")).unwrap();
+
+        ensure(&worktree, Path::new("/bin/amuxd"), Path::new("/s.sock")).unwrap();
+        let exclude = std::fs::read_to_string(dir.path().join(".git/info/exclude")).unwrap();
+        assert!(exclude.contains(".cursor/hooks.json"));
+
+        // Second run must not duplicate the line.
+        std::fs::remove_file(hooks_path(&worktree)).unwrap();
+        ensure(&worktree, Path::new("/bin/amuxd"), Path::new("/s.sock")).unwrap();
+        let exclude = std::fs::read_to_string(dir.path().join(".git/info/exclude")).unwrap();
+        assert_eq!(exclude.matches(".cursor/hooks.json").count(), 1);
+    }
+
+    #[test]
+    fn shell_quote_escapes_single_quotes() {
+        assert_eq!(shell_quote("/a/b"), "'/a/b'");
+        assert_eq!(shell_quote("/it's"), r"'/it'\''s'");
+    }
+}

--- a/apps/daemon/src/runtime/cursor_sdk/mod.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/mod.rs
@@ -19,11 +19,15 @@ use crate::runtime::manager::AgentLaunchConfig;
 use crate::runtime::opencode_http::translate::status_change;
 use crate::runtime::permission_policy::PermissionPolicy;
 
-pub mod client;
 mod events;
+pub mod hooks;
+pub mod permission;
 pub mod process;
 pub mod translate;
 
+use crate::runtime::sidecar::mcp;
+
+use permission::PendingPermission;
 use process::CursorProcessPool;
 use translate::TranslateState;
 
@@ -39,12 +43,6 @@ pub(crate) struct Route {
     pub(crate) turn_requester: Option<String>,
     pub(crate) translate: TranslateState,
     pub(crate) model: String,
-}
-
-pub(crate) struct PendingPermission {
-    pub(crate) session_id: String,
-    pub(crate) agent_id: String,
-    pub(crate) request_id: String,
 }
 
 pub(crate) struct Shared {
@@ -63,7 +61,19 @@ impl Shared {
     }
 }
 
-fn canonical_dir(worktree: &str) -> String {
+/// Process-global backend state.
+///
+/// The `preToolUse` hook arrives on `amuxd.sock`, which is served by the daemon
+/// loop — it has no handle on the `AgentBackend` box owned by `RuntimeManager`.
+/// There is at most one local backend per daemon, so the route + pending tables
+/// live here instead, reachable from both sides.
+static SHARED: std::sync::OnceLock<Arc<Shared>> = std::sync::OnceLock::new();
+
+pub(crate) fn shared() -> Arc<Shared> {
+    Arc::clone(SHARED.get_or_init(Shared::new))
+}
+
+pub(crate) fn canonical_dir(worktree: &str) -> String {
     std::fs::canonicalize(worktree)
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|_| worktree.to_string())
@@ -115,12 +125,6 @@ fn models_from_list(result: &serde_json::Value) -> Vec<amux::ModelInfo> {
         .unwrap_or_default()
 }
 
-fn sdk_model_from_flat(flat: &str) -> String {
-    flat.strip_prefix("cursor/")
-        .unwrap_or(flat)
-        .to_string()
-}
-
 fn pick_initial_model(
     available: &[amux::ModelInfo],
     override_model: Option<&str>,
@@ -150,6 +154,7 @@ fn pick_initial_model(
 struct AttachArgs {
     worktree: String,
     resume_acp_session_id: Option<String>,
+    mcp_config_path: Option<PathBuf>,
     initial_model_override: Option<String>,
     model_mru: Vec<String>,
     event_tx: mpsc::Sender<AcpEventFrame>,
@@ -157,9 +162,29 @@ struct AttachArgs {
     forbid_new_session_fallback: bool,
 }
 
+/// Install the `preToolUse` gate in the worktree. Best-effort: a worktree we
+/// cannot write to loses interactive approval (the SDK simply finds no hook),
+/// which is no worse than the state before the gate existed.
+fn install_permission_hook(worktree: &str) {
+    let amuxd_bin = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(error = %e, "cursor: current_exe() failed; permission hook not installed");
+            return;
+        }
+    };
+    let sock = DaemonConfig::sock_path();
+    match hooks::ensure(worktree, &amuxd_bin, &sock) {
+        Ok(path) => info!(path = %path.display(), "cursor permission hook installed"),
+        Err(e) => warn!(worktree, error = %e, "cursor permission hook install failed"),
+    }
+}
+
 async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMetadata, String> {
     load_cursor_pool_config(&shared.pool);
     let worktree = canonical_dir(&args.worktree);
+    install_permission_hook(&worktree);
+    let mcp_servers = mcp::assemble(&worktree, args.mcp_config_path.as_deref());
     let proc = shared
         .pool
         .ensure(shared, &worktree)
@@ -183,8 +208,6 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
         &args.model_mru,
         &default_model,
     );
-    let sdk_model = sdk_model_from_flat(&initial_flat);
-
     let resume_agent_id = args
         .resume_acp_session_id
         .as_deref()
@@ -192,16 +215,29 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
         .filter(|s| !s.is_empty())
         .map(str::to_string);
 
+    // The SDK does not persist inline MCP, so resume has to re-send the whole
+    // manifest exactly like create does.
+    let mcp_servers = serde_json::Value::Object(mcp_servers);
+    let create_params = |extra: serde_json::Value| {
+        let mut params = serde_json::json!({
+            "cwd": worktree,
+            "model": initial_flat,
+            "mcpServers": mcp_servers,
+        });
+        if let (Some(obj), Some(extra)) = (params.as_object_mut(), extra.as_object()) {
+            for (k, v) in extra {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+        params
+    };
+
     let create_resp = if let Some(agent_id) = resume_agent_id {
         match proc
             .client
             .request(
                 "resume_agent",
-                serde_json::json!({
-                    "agentId": agent_id,
-                    "cwd": worktree,
-                    "model": initial_flat,
-                }),
+                create_params(serde_json::json!({ "agentId": agent_id })),
             )
             .await
         {
@@ -214,26 +250,14 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
                 }
                 warn!(agent_id, error = %e, "cursor resume failed; creating new agent");
                 proc.client
-                    .request(
-                        "create_agent",
-                        serde_json::json!({
-                            "cwd": worktree,
-                            "model": initial_flat,
-                        }),
-                    )
+                    .request("create_agent", create_params(serde_json::json!({})))
                     .await
                     .map_err(|e| e.to_string())?
             }
         }
     } else {
         proc.client
-            .request(
-                "create_agent",
-                serde_json::json!({
-                    "cwd": worktree,
-                    "model": initial_flat,
-                }),
-            )
+            .request("create_agent", create_params(serde_json::json!({})))
             .await
             .map_err(|e| e.to_string())?
     };
@@ -259,8 +283,6 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
             model: initial_flat.clone(),
         },
     );
-
-    let _ = sdk_model;
 
     Ok(AcpStartupMetadata {
         available_models,
@@ -290,7 +312,7 @@ async fn do_prompt(
     reply_to_message_id: Option<String>,
 ) {
     let reply_to = reply_to_message_id.filter(|id| !id.is_empty());
-    let (event_tx, worktree, agent_id) = {
+    let (event_tx, worktree, agent_id, model) = {
         let mut routes = shared.routes.lock();
         let Some(route) = routes.get_mut(session_id) else {
             warn!(session_id, "prompt for unknown cursor session");
@@ -303,6 +325,7 @@ async fn do_prompt(
             route.event_tx.clone(),
             route.worktree.clone(),
             route.agent_id.clone(),
+            route.model.clone(),
         )
     };
 
@@ -329,7 +352,13 @@ async fn do_prompt(
             proc.client
                 .request(
                     "send",
-                    serde_json::json!({ "agentId": agent_id, "text": message }),
+                    // The daemon's route is the source of truth for the model,
+                    // exactly as in the opencode backend's `PromptBody`.
+                    serde_json::json!({
+                        "agentId": agent_id,
+                        "text": message,
+                        "model": model,
+                    }),
                 )
                 .await
         }
@@ -370,43 +399,13 @@ async fn do_prompt(
     }
 }
 
-async fn resolve_permission(
-    shared: &Arc<Shared>,
-    request_id: &str,
-    granted: bool,
-) {
-    let Some(pending) = shared.permissions.lock().remove(request_id) else {
-        warn!(request_id, "no pending cursor permission");
-        return;
-    };
-    let worktree = shared
-        .routes
-        .lock()
-        .get(&pending.session_id)
-        .map(|r| r.worktree.clone())
-        .unwrap_or_default();
-    let Some(proc) = shared.pool.get(&worktree) else {
-        return;
-    };
-    let _ = proc
-        .client
-        .request(
-            "resolve_permission",
-            serde_json::json!({
-                "agentId": pending.agent_id,
-                "requestId": pending.request_id,
-                "granted": granted,
-            }),
-        )
-        .await;
-}
-
 async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand>) {
     while let Some(cmd) = cmd_rx.recv().await {
         match cmd {
             AcpCommand::AttachSession {
                 worktree,
                 resume_acp_session_id,
+                mcp_config_path,
                 initial_model_override,
                 model_mru,
                 initial_prompt,
@@ -414,13 +413,13 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                 startup_tx,
                 permission,
                 forbid_new_session_fallback,
-                ..
             } => {
                 let result = attach(
                     &shared,
                     AttachArgs {
                         worktree,
                         resume_acp_session_id,
+                        mcp_config_path,
                         initial_model_override,
                         model_mru,
                         event_tx,
@@ -467,10 +466,7 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                 if let Ok(proc) = shared.pool.ensure(&shared, &worktree) {
                     let _ = proc
                         .client
-                        .request(
-                            "cancel",
-                            serde_json::json!({ "agentId": agent_id }),
-                        )
+                        .request("cancel", serde_json::json!({ "agentId": agent_id }))
                         .await;
                 }
                 events::close_turn(&shared, &acp_session_id).await;
@@ -478,8 +474,8 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
             AcpCommand::ResolvePermission {
                 request_id,
                 granted,
-                ..
-            } => resolve_permission(&shared, &request_id, granted).await,
+                option_id,
+            } => permission::resolve(&shared, &request_id, granted, option_id.as_deref()),
             AcpCommand::SetModel {
                 acp_session_id,
                 model_id,
@@ -522,7 +518,7 @@ pub struct CursorSdkBackend {
 
 impl CursorSdkBackend {
     pub fn new() -> Self {
-        let shared = Shared::new();
+        let shared = shared();
         load_cursor_pool_config(&shared.pool);
         Self {
             shared,
@@ -557,7 +553,7 @@ impl AgentBackend for CursorSdkBackend {
         force_env_override: bool,
         worktree: String,
         resume_acp_session_id: Option<String>,
-        _mcp_config_path: Option<PathBuf>,
+        mcp_config_path: Option<PathBuf>,
         initial_model_override: Option<String>,
         model_mru: Vec<String>,
         initial_prompt: String,
@@ -575,6 +571,7 @@ impl AgentBackend for CursorSdkBackend {
             AttachArgs {
                 worktree,
                 resume_acp_session_id,
+                mcp_config_path,
                 initial_model_override,
                 model_mru,
                 event_tx,
@@ -631,11 +628,12 @@ impl AgentBackend for CursorSdkBackend {
         self.shared.pool.live_count()
     }
 
-    async fn session_model(
-        &mut self,
-        worktree: &str,
-        backend_session_id: &str,
-    ) -> Option<String> {
+    /// Only `sdkModel` — the SDK's own `agent.model`, updated after each
+    /// successful send — is allowed to teach the device MRU. The bridge also
+    /// reports `requestedModel` (what we last asked for); feeding that back
+    /// would just echo our own guess into the MRU, which is what this method's
+    /// contract exists to prevent.
+    async fn session_model(&mut self, worktree: &str, backend_session_id: &str) -> Option<String> {
         let session_id = backend_session_id.strip_prefix(SESSION_ID_PREFIX)?;
         let worktree = canonical_dir(worktree);
         let proc = self.shared.pool.get(&worktree)?;
@@ -647,7 +645,10 @@ impl AgentBackend for CursorSdkBackend {
             )
             .await
             .ok()?;
-        resp.get("model").and_then(|v| v.as_str()).map(str::to_string)
+        resp.get("sdkModel")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
     }
 
     async fn model_catalog(
@@ -693,10 +694,5 @@ mod tests {
             ),
             "cursor/claude-sonnet-5"
         );
-    }
-
-    #[test]
-    fn sdk_model_from_flat_strips_provider() {
-        assert_eq!(sdk_model_from_flat("cursor/composer-2.5"), "composer-2.5");
     }
 }

--- a/apps/daemon/src/runtime/cursor_sdk/permission.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/permission.rs
@@ -1,0 +1,462 @@
+//! The `preToolUse` hook's daemon side: surface the request to a human, wait,
+//! answer `allow` / `deny`.
+//!
+//! Flow: SDK → `amuxd cursor-permission-hook` (spawned per tool call) →
+//! `amuxd.sock` → here → `AcpPermissionRequest` to clients → human →
+//! `AcpCommand::ResolvePermission` → [`resolve`] → back down the same wire.
+//!
+//! Deliberately fail-open: an unroutable request, an unknown worktree or a
+//! resolution timeout answers `allow`. A `preToolUse` gate that fails closed
+//! bricks every tool call in the session the moment anything upstream hiccups,
+//! which is a far worse failure than the pre-existing "no gate at all".
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::sync::oneshot;
+use tracing::{info, warn};
+
+use crate::proto::amux;
+use crate::runtime::acp_event_frame::AcpEventFrame;
+use crate::runtime::opencode_http::translate::permission_options;
+
+use super::{canonical_dir, Shared};
+
+/// Ceiling on how long a client may leave a request unanswered. Slightly under
+/// the hook's own `timeout` so we answer before the SDK gives up on us.
+const RESOLVE_TIMEOUT: Duration = Duration::from_secs(super::hooks::HOOK_TIMEOUT_SECS - 15);
+
+pub(crate) struct PendingPermission {
+    #[allow(dead_code)]
+    pub(crate) session_id: String,
+    /// Canonical worktree, for a persisted "always" grant.
+    pub(crate) worktree: String,
+    pub(crate) tool_name: String,
+    /// Fired by [`resolve`] with the human's answer.
+    pub(crate) responder: oneshot::Sender<bool>,
+}
+
+fn allow() -> Value {
+    json!({ "permission": "allow" })
+}
+
+fn deny(tool_name: &str) -> Value {
+    json!({
+        "permission": "deny",
+        "user_message": format!("{tool_name} was rejected by the TeamClaw user"),
+        "agent_message": format!(
+            "The user rejected this {tool_name} call. Do not retry it; \
+             pick another approach or ask what to do instead."
+        ),
+    })
+}
+
+/// Human-readable one-liner for the approval UI.
+fn describe(tool_name: &str, tool_input: &Value) -> String {
+    for key in ["command", "file_path", "path", "url", "query"] {
+        if let Some(v) = tool_input.get(key).and_then(|v| v.as_str()) {
+            if !v.is_empty() {
+                return format!("{tool_name}: {v}");
+            }
+        }
+    }
+    tool_name.to_string()
+}
+
+fn params_from_input(tool_input: &Value) -> HashMap<String, String> {
+    match tool_input {
+        Value::Object(map) => map
+            .iter()
+            .map(|(k, v)| {
+                let s = match v {
+                    Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                };
+                (k.clone(), s)
+            })
+            .collect(),
+        _ => HashMap::new(),
+    }
+}
+
+/// Route a hook request to the session running in `worktree`. A worktree can
+/// host more than one runtime session, but only the one mid-turn can be making
+/// a tool call, so an active turn is the discriminator.
+fn route_for_worktree(shared: &Arc<Shared>, worktree: &str) -> Option<RouteSnapshot> {
+    let routes = shared.routes.lock();
+    let mut candidates: Vec<&String> = routes
+        .iter()
+        .filter(|(_, r)| r.worktree == worktree)
+        .map(|(id, _)| id)
+        .collect();
+    candidates.sort();
+    let chosen = candidates
+        .iter()
+        .find(|id| routes.get(**id).is_some_and(|r| r.turn_active))
+        .or_else(|| candidates.first())?;
+    let route = routes.get(*chosen)?;
+    Some(RouteSnapshot {
+        session_id: (*chosen).clone(),
+        event_tx: route.event_tx.clone(),
+        full_access: route.permission.is_full_access(),
+        requester: route.turn_requester.clone(),
+        reply_to: route.turn_reply_to.clone(),
+    })
+}
+
+struct RouteSnapshot {
+    session_id: String,
+    event_tx: tokio::sync::mpsc::Sender<AcpEventFrame>,
+    full_access: bool,
+    requester: Option<String>,
+    reply_to: Option<String>,
+}
+
+/// Handle one `{cmd:"cursor-permission", worktree, request}` sock envelope.
+/// Always resolves to a hook response body.
+pub async fn handle(payload: &Value) -> Value {
+    let shared = super::shared();
+    let request = payload.get("request").unwrap_or(&Value::Null);
+    let tool_name = request
+        .get("tool_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("tool")
+        .to_string();
+    let tool_input = request
+        .get("tool_input")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    let worktree = payload
+        .get("worktree")
+        .and_then(|v| v.as_str())
+        .map(canonical_dir)
+        .unwrap_or_default();
+
+    let Some(route) = route_for_worktree(&shared, &worktree) else {
+        warn!(
+            worktree,
+            tool_name, "cursor permission: no session for worktree; allowing"
+        );
+        return allow();
+    };
+
+    if route.full_access {
+        return allow();
+    }
+    if always_allowed(&worktree, &tool_name) {
+        return allow();
+    }
+
+    let request_id = format!("cursor-perm-{}", uuid_v4());
+    let (tx, rx) = oneshot::channel();
+    shared.permissions.lock().insert(
+        request_id.clone(),
+        PendingPermission {
+            session_id: route.session_id.clone(),
+            worktree: worktree.clone(),
+            tool_name: tool_name.clone(),
+            responder: tx,
+        },
+    );
+
+    let mut params = params_from_input(&tool_input);
+    if let Some(actor) = route.requester.clone() {
+        params.insert("requester_actor_id".to_string(), actor);
+    }
+    params.insert("request_id".to_string(), request_id.clone());
+    let ev = amux::AcpEvent {
+        event: Some(amux::acp_event::Event::PermissionRequest(
+            amux::AcpPermissionRequest {
+                request_id: request_id.clone(),
+                tool_name: tool_name.clone(),
+                description: describe(&tool_name, &tool_input),
+                params,
+                options: permission_options(),
+            },
+        )),
+        model: String::new(),
+    };
+    crate::runtime::agent_trace::log_acp_event(&route.session_id, &ev);
+    if route
+        .event_tx
+        .send(AcpEventFrame::new(route.session_id.clone(), ev).with_reply_to(route.reply_to))
+        .await
+        .is_err()
+    {
+        shared.permissions.lock().remove(&request_id);
+        warn!(
+            session_id = %route.session_id,
+            "cursor permission: event channel closed; allowing"
+        );
+        return allow();
+    }
+
+    match tokio::time::timeout(RESOLVE_TIMEOUT, rx).await {
+        Ok(Ok(true)) => allow(),
+        Ok(Ok(false)) => deny(&tool_name),
+        Ok(Err(_)) => {
+            warn!(request_id, "cursor permission: resolver dropped; allowing");
+            allow()
+        }
+        Err(_) => {
+            shared.permissions.lock().remove(&request_id);
+            warn!(
+                request_id,
+                tool_name, "cursor permission: timed out; allowing"
+            );
+            allow()
+        }
+    }
+}
+
+/// Answer a pending request. `option_id == "always"` also persists a
+/// worktree-scoped grant for that tool name, since the SDK has no notion of a
+/// standing approval we could hand back to it.
+pub(crate) fn resolve(
+    shared: &Arc<Shared>,
+    request_id: &str,
+    granted: bool,
+    option_id: Option<&str>,
+) {
+    let Some(pending) = shared.permissions.lock().remove(request_id) else {
+        warn!(request_id, "no pending cursor permission");
+        return;
+    };
+    if granted && option_id == Some("always") {
+        let PendingPermission {
+            worktree,
+            tool_name,
+            ..
+        } = &pending;
+        if let Err(e) = persist_always(worktree, tool_name) {
+            warn!(worktree, tool_name, error = %e, "cursor always-allow write failed");
+        } else {
+            info!(worktree, tool_name, "cursor always-allow persisted");
+        }
+    }
+    let _ = pending.responder.send(granted);
+}
+
+// ---------------------------------------------------------------------------
+// "Always allow" store — worktree → tool names
+// ---------------------------------------------------------------------------
+
+fn always_store_path() -> PathBuf {
+    crate::config::DaemonConfig::config_dir().join("cursor-permissions.json")
+}
+
+fn read_always_store() -> Value {
+    std::fs::read_to_string(always_store_path())
+        .ok()
+        .and_then(|b| serde_json::from_str::<Value>(&b).ok())
+        .filter(|v| v.is_object())
+        .unwrap_or_else(|| json!({}))
+}
+
+fn always_allowed(worktree: &str, tool_name: &str) -> bool {
+    read_always_store()
+        .get(worktree)
+        .and_then(|v| v.as_array())
+        .is_some_and(|tools| tools.iter().any(|t| t.as_str() == Some(tool_name)))
+}
+
+fn persist_always(worktree: &str, tool_name: &str) -> std::io::Result<()> {
+    if worktree.is_empty() {
+        return Ok(());
+    }
+    let mut store = read_always_store();
+    let entry = store
+        .as_object_mut()
+        .expect("read_always_store returns an object")
+        .entry(worktree.to_string())
+        .or_insert_with(|| json!([]));
+    let tools = match entry.as_array_mut() {
+        Some(tools) => tools,
+        None => {
+            *entry = json!([]);
+            entry.as_array_mut().expect("just set to an array")
+        }
+    };
+    if !tools.iter().any(|t| t.as_str() == Some(tool_name)) {
+        tools.push(json!(tool_name));
+    }
+    let path = always_store_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, serde_json::to_string_pretty(&store)?)
+}
+
+/// Random-enough request id without pulling in a uuid dependency for one call.
+fn uuid_v4() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    format!("{nanos:x}-{:x}", std::process::id())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn describe_prefers_the_most_specific_input_field() {
+        assert_eq!(
+            describe("shell", &json!({ "command": "rm -rf /", "cwd": "/w" })),
+            "shell: rm -rf /"
+        );
+        assert_eq!(
+            describe("write", &json!({ "file_path": "/w/a.rs" })),
+            "write: /w/a.rs"
+        );
+        assert_eq!(describe("weird", &json!({ "n": 3 })), "weird");
+        assert_eq!(describe("empty", &json!({ "command": "" })), "empty");
+    }
+
+    #[test]
+    fn params_stringify_non_string_values() {
+        let params = params_from_input(&json!({ "a": "x", "n": 3, "b": true }));
+        assert_eq!(params.get("a"), Some(&"x".to_string()));
+        assert_eq!(params.get("n"), Some(&"3".to_string()));
+        assert_eq!(params.get("b"), Some(&"true".to_string()));
+        assert!(params_from_input(&json!("scalar")).is_empty());
+    }
+
+    #[test]
+    fn deny_body_carries_both_messages() {
+        let body = deny("shell");
+        assert_eq!(body["permission"], json!("deny"));
+        assert!(body["user_message"].as_str().unwrap().contains("shell"));
+        assert!(body["agent_message"].as_str().unwrap().contains("retry"));
+    }
+
+    /// Register a route on the process-global backend state. Each test uses a
+    /// distinct worktree so the shared tables do not collide under `cargo test`.
+    fn register_route(
+        worktree: &str,
+        permission: crate::runtime::permission_policy::PermissionPolicy,
+    ) -> (String, tokio::sync::mpsc::Receiver<AcpEventFrame>) {
+        let (event_tx, event_rx) = tokio::sync::mpsc::channel(8);
+        let session_id = format!("cursor:agent-for-{worktree}");
+        super::super::shared().routes.lock().insert(
+            session_id.clone(),
+            super::super::Route {
+                event_tx,
+                permission,
+                worktree: worktree.to_string(),
+                agent_id: "agent".into(),
+                turn_active: true,
+                turn_reply_to: Some("msg-1".into()),
+                turn_requester: Some("actor-1".into()),
+                translate: Default::default(),
+                model: "cursor/composer-2.5".into(),
+            },
+        );
+        (session_id, event_rx)
+    }
+
+    fn request(tool: &str) -> Value {
+        json!({
+            "worktree": "/tmp/does-not-need-to-exist",
+            "request": { "tool_name": tool, "tool_input": { "command": "rm -rf /" } }
+        })
+    }
+
+    #[tokio::test]
+    async fn full_access_allows_without_asking_anyone() {
+        let worktree = "/tmp/cursor-perm-full";
+        let (_id, mut rx) = register_route(
+            worktree,
+            crate::runtime::permission_policy::PermissionPolicy::Full,
+        );
+        let mut payload = request("shell");
+        payload["worktree"] = json!(worktree);
+
+        let body = handle(&payload).await;
+        assert_eq!(body["permission"], json!("allow"));
+        assert!(
+            rx.try_recv().is_err(),
+            "full access must not surface a request"
+        );
+    }
+
+    #[tokio::test]
+    async fn ask_policy_surfaces_a_request_and_honours_a_denial() {
+        let worktree = "/tmp/cursor-perm-deny";
+        let (_id, mut rx) = register_route(
+            worktree,
+            crate::runtime::permission_policy::PermissionPolicy::Ask,
+        );
+        let mut payload = request("shell");
+        payload["worktree"] = json!(worktree);
+
+        let decision = tokio::spawn(async move { handle(&payload).await });
+
+        let frame = rx.recv().await.expect("a permission request is emitted");
+        let amux::acp_event::Event::PermissionRequest(req) =
+            frame.event.event.clone().expect("event present")
+        else {
+            panic!("expected a PermissionRequest, got {:?}", frame.event.event);
+        };
+        assert_eq!(req.tool_name, "shell");
+        assert_eq!(req.description, "shell: rm -rf /");
+        assert_eq!(
+            req.params.get("requester_actor_id").map(String::as_str),
+            Some("actor-1")
+        );
+        assert_eq!(req.options.len(), 3, "once / always / reject");
+
+        resolve(
+            &super::super::shared(),
+            &req.request_id,
+            false,
+            Some("reject"),
+        );
+
+        let body = decision.await.unwrap();
+        assert_eq!(body["permission"], json!("deny"));
+        assert!(body["agent_message"].is_string());
+    }
+
+    #[tokio::test]
+    async fn ask_policy_honours_an_approval() {
+        let worktree = "/tmp/cursor-perm-allow";
+        let (_id, mut rx) = register_route(
+            worktree,
+            crate::runtime::permission_policy::PermissionPolicy::Ask,
+        );
+        let mut payload = request("write");
+        payload["worktree"] = json!(worktree);
+
+        let decision = tokio::spawn(async move { handle(&payload).await });
+        let frame = rx.recv().await.expect("a permission request is emitted");
+        let amux::acp_event::Event::PermissionRequest(req) =
+            frame.event.event.clone().expect("event present")
+        else {
+            panic!("expected a PermissionRequest");
+        };
+        resolve(&super::super::shared(), &req.request_id, true, Some("once"));
+
+        assert_eq!(decision.await.unwrap()["permission"], json!("allow"));
+    }
+
+    #[test]
+    fn resolving_an_unknown_request_is_a_no_op() {
+        resolve(&super::super::shared(), "no-such-request", true, None);
+    }
+
+    #[tokio::test]
+    async fn unroutable_request_fails_open() {
+        let body = handle(&json!({
+            "worktree": "/nonexistent/worktree",
+            "request": { "tool_name": "shell", "tool_input": { "command": "ls" } }
+        }))
+        .await;
+        assert_eq!(body["permission"], json!("allow"));
+    }
+}

--- a/apps/daemon/src/runtime/cursor_sdk/translate.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/translate.rs
@@ -52,7 +52,10 @@ fn tool_kind(name: &str) -> &'static str {
     }
 }
 
-pub fn translate_event(state: &mut TranslateState, event: &serde_json::Value) -> Vec<amux::AcpEvent> {
+pub fn translate_event(
+    state: &mut TranslateState,
+    event: &serde_json::Value,
+) -> Vec<amux::AcpEvent> {
     let name = event.get("event").and_then(|v| v.as_str()).unwrap_or("");
     let run_id = event.get("runId").and_then(|v| v.as_str()).unwrap_or("");
 
@@ -94,10 +97,7 @@ pub fn translate_event(state: &mut TranslateState, event: &serde_json::Value) ->
                     description: String::new(),
                     params,
                     tool_kind: tool_kind(&tool_name).to_string(),
-                    raw_input_json: event
-                        .get("args")
-                        .map(|v| v.to_string())
-                        .unwrap_or_default(),
+                    raw_input_json: event.get("args").map(|v| v.to_string()).unwrap_or_default(),
                     raw_output_json: String::new(),
                     content: vec![],
                     locations: vec![],
@@ -117,7 +117,10 @@ pub fn translate_event(state: &mut TranslateState, event: &serde_json::Value) ->
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
-            let is_error = event.get("isError").and_then(|v| v.as_bool()).unwrap_or(false);
+            let is_error = event
+                .get("isError")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
             vec![amux::AcpEvent {
                 event: Some(amux::acp_event::Event::ToolResult(amux::AcpToolResult {
                     tool_id: tool_call_id,

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub mod acp_event_frame;
+pub mod claude_agent;
 pub mod cursor_sdk;
 pub mod backend;
 pub mod opencode_http;
@@ -14,6 +15,7 @@ mod instruction_delivery;
 pub mod managed_llm;
 mod manager;
 pub mod permission_policy;
+pub mod sidecar;
 pub mod refresh;
 pub mod supervisor;
 pub mod turn_aggregator;

--- a/apps/daemon/src/runtime/sidecar/client.rs
+++ b/apps/daemon/src/runtime/sidecar/client.rs
@@ -1,4 +1,9 @@
-//! JSONL command client for one cursor-bridge child process.
+//! JSONL command client for one sidecar child process.
+//!
+//! Shared by every sidecar-style backend (`cursor_sdk`, `claude_agent`): the
+//! wire shape is `{id, method, params}` out, `{id, result|error}` back, with
+//! events (no `id`) interleaved on the same stdout stream and routed by the
+//! owning backend rather than here.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -18,9 +23,9 @@ struct Inner {
 }
 
 #[derive(Clone)]
-pub struct CursorClient(Arc<Inner>);
+pub struct SidecarClient(Arc<Inner>);
 
-impl CursorClient {
+impl SidecarClient {
     pub fn new(stdin: tokio::process::ChildStdin) -> Self {
         Self(Arc::new(Inner {
             stdin: tokio::sync::Mutex::new(stdin),
@@ -31,17 +36,17 @@ impl CursorClient {
 
     async fn write_line(&self, value: &serde_json::Value) -> crate::error::Result<()> {
         let mut line = serde_json::to_string(value)
-            .map_err(|e| crate::error::AmuxError::Agent(format!("cursor command encode: {e}")))?;
+            .map_err(|e| crate::error::AmuxError::Agent(format!("sidecar command encode: {e}")))?;
         line.push('\n');
         let mut stdin = self.0.stdin.lock().await;
         stdin
             .write_all(line.as_bytes())
             .await
-            .map_err(|e| crate::error::AmuxError::Agent(format!("cursor stdin write: {e}")))?;
+            .map_err(|e| crate::error::AmuxError::Agent(format!("sidecar stdin write: {e}")))?;
         stdin
             .flush()
             .await
-            .map_err(|e| crate::error::AmuxError::Agent(format!("cursor stdin flush: {e}")))
+            .map_err(|e| crate::error::AmuxError::Agent(format!("sidecar stdin flush: {e}")))
     }
 
     pub async fn request(
@@ -63,23 +68,26 @@ impl CursorClient {
             Ok(Ok(v)) => v,
             Ok(Err(_)) => {
                 return Err(crate::error::AmuxError::Agent(format!(
-                    "cursor {method}: bridge exited before responding"
+                    "{method}: bridge exited before responding"
                 )))
             }
             Err(_) => {
                 self.0.pending.lock().remove(&id);
                 return Err(crate::error::AmuxError::Agent(format!(
-                    "cursor {method}: response timed out"
+                    "{method}: response timed out"
                 )));
             }
         };
 
         if let Some(err) = response.get("error").and_then(|v| v.as_str()) {
             return Err(crate::error::AmuxError::Agent(format!(
-                "cursor {method} failed: {err}"
+                "{method} failed: {err}"
             )));
         }
-        Ok(response.get("result").cloned().unwrap_or(serde_json::Value::Null))
+        Ok(response
+            .get("result")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null))
     }
 
     pub fn resolve_response(&self, response: &serde_json::Value) -> bool {
@@ -92,7 +100,7 @@ impl CursorClient {
                 true
             }
             None => {
-                warn!(id, "cursor response with no pending request");
+                warn!(id, "sidecar response with no pending request");
                 false
             }
         }

--- a/apps/daemon/src/runtime/sidecar/mcp.rs
+++ b/apps/daemon/src/runtime/sidecar/mcp.rs
@@ -1,0 +1,247 @@
+//! Workspace MCP manifest → `@cursor/sdk` `AgentOptions.mcpServers`.
+//!
+//! Two sources, merged (remote-tools wins on a name clash):
+//!
+//! 1. `mcp_config_path` — the host-level `remote-tools-host.json` written by
+//!    `remote_tools::mcp_config`, shape `{"mcpServers": {name: {command, args}}}`.
+//! 2. `<worktree>/opencode.json` `mcp` map — the MCP SSOT (team + inherent +
+//!    user servers all merge into it), same source pi bridges through its
+//!    extension.
+//!
+//! The SDK wants `Record<string, McpServerConfig>` (`options.d.ts:235`) where a
+//! stdio entry is `{type:"stdio", command: string, args: string[], env}` — note
+//! `command` is a *string*, unlike opencode.json's `command: string[]`.
+//! Non-stdio servers map to `{type:"http", url, headers}`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde_json::{json, Map, Value};
+
+/// Servers keyed by name, ready to hand to `create_agent` / `resume_agent`.
+pub type McpServers = Map<String, Value>;
+
+/// Split an opencode `command: ["cmd", "arg", ...]` array into the SDK's
+/// `(command, args)` pair. Returns None for an empty / non-string array.
+fn split_command(command: &[Value]) -> Option<(String, Vec<Value>)> {
+    let head = command.first()?.as_str()?.to_string();
+    if head.is_empty() {
+        return None;
+    }
+    if !command.iter().all(|a| a.is_string()) {
+        return None;
+    }
+    Some((head, command[1..].to_vec()))
+}
+
+/// One `opencode.json` `mcp` entry → an SDK server config.
+fn server_from_opencode_entry(entry: &Map<String, Value>) -> Option<Value> {
+    if entry.get("enabled").and_then(|v| v.as_bool()) == Some(false) {
+        return None;
+    }
+    if entry.get("type").and_then(|v| v.as_str()) == Some("remote") {
+        let url = entry.get("url").and_then(|v| v.as_str())?;
+        if url.is_empty() {
+            return None;
+        }
+        let mut out = json!({ "type": "http", "url": url });
+        if let Some(headers) = entry.get("headers").and_then(|v| v.as_object()) {
+            out["headers"] = Value::Object(headers.clone());
+        }
+        return Some(out);
+    }
+    let command = entry.get("command").and_then(|v| v.as_array())?;
+    let (command, args) = split_command(command)?;
+    let mut out = json!({ "type": "stdio", "command": command });
+    if !args.is_empty() {
+        out["args"] = Value::Array(args);
+    }
+    // opencode calls it `environment`; the SDK calls it `env`.
+    if let Some(env) = entry.get("environment").and_then(|v| v.as_object()) {
+        if !env.is_empty() {
+            out["env"] = Value::Object(env.clone());
+        }
+    }
+    Some(out)
+}
+
+/// `{"mcpServers": {name: {command: "x", args: [...]}}}` → SDK servers. This is
+/// the amuxd-written host config shape, where `command` is already a string.
+pub fn servers_from_mcp_config_value(root: &Value) -> McpServers {
+    let mut out = Map::new();
+    let Some(servers) = root.get("mcpServers").and_then(|v| v.as_object()) else {
+        return out;
+    };
+    for (name, server) in servers {
+        let Some(command) = server.get("command").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if command.is_empty() {
+            continue;
+        }
+        let mut entry = json!({ "type": "stdio", "command": command });
+        if let Some(args) = server.get("args").and_then(|v| v.as_array()) {
+            if !args.is_empty() {
+                entry["args"] = Value::Array(args.clone());
+            }
+        }
+        if let Some(env) = server.get("env").and_then(|v| v.as_object()) {
+            if !env.is_empty() {
+                entry["env"] = Value::Object(env.clone());
+            }
+        }
+        out.insert(name.clone(), entry);
+    }
+    out
+}
+
+/// `opencode.json` value → SDK servers.
+pub fn servers_from_opencode_value(root: &Value) -> McpServers {
+    let mut out = Map::new();
+    let Some(mcp) = root.get("mcp").and_then(|v| v.as_object()) else {
+        return out;
+    };
+    // BTreeMap first so the output order is stable across runs (the map feeds
+    // the process fingerprint / logs).
+    let ordered: BTreeMap<&String, &Value> = mcp.iter().collect();
+    for (name, server) in ordered {
+        let Some(entry) = server.as_object() else {
+            continue;
+        };
+        if let Some(cfg) = server_from_opencode_entry(entry) {
+            out.insert(name.clone(), cfg);
+        }
+    }
+    out
+}
+
+fn read_json(path: &Path) -> Option<Value> {
+    let body = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&body).ok()
+}
+
+/// Assemble every MCP server a cursor session should see. Missing or malformed
+/// files contribute nothing rather than failing the attach.
+pub fn assemble(worktree: &str, mcp_config_path: Option<&Path>) -> McpServers {
+    let mut out = read_json(&Path::new(worktree).join("opencode.json"))
+        .map(|v| servers_from_opencode_value(&v))
+        .unwrap_or_default();
+    // remote-tools is daemon-owned; it wins over a same-named workspace entry.
+    if let Some(extra) = mcp_config_path
+        .and_then(read_json)
+        .map(|v| servers_from_mcp_config_value(&v))
+    {
+        for (name, cfg) in extra {
+            out.insert(name, cfg);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opencode_local_server_maps_to_stdio_command_and_args() {
+        let root = json!({
+            "mcp": {
+                "ctx7": {
+                    "type": "local",
+                    "command": ["npx", "-y", "ctx7-mcp"],
+                    "environment": { "TOKEN": "t" }
+                }
+            }
+        });
+        let servers = servers_from_opencode_value(&root);
+        assert_eq!(
+            servers.get("ctx7"),
+            Some(&json!({
+                "type": "stdio",
+                "command": "npx",
+                "args": ["-y", "ctx7-mcp"],
+                "env": { "TOKEN": "t" }
+            }))
+        );
+    }
+
+    #[test]
+    fn opencode_remote_server_maps_to_http() {
+        let root = json!({
+            "mcp": { "r": { "type": "remote", "url": "https://x/mcp",
+                            "headers": { "Authorization": "Bearer t" } } }
+        });
+        assert_eq!(
+            servers_from_opencode_value(&root).get("r"),
+            Some(&json!({
+                "type": "http",
+                "url": "https://x/mcp",
+                "headers": { "Authorization": "Bearer t" }
+            }))
+        );
+    }
+
+    #[test]
+    fn disabled_and_malformed_servers_are_dropped() {
+        let root = json!({
+            "mcp": {
+                "off": { "command": ["x"], "enabled": false },
+                "no-command": { "type": "local" },
+                "empty-command": { "command": [] },
+                "non-string-args": { "command": ["x", 3] },
+                "remote-no-url": { "type": "remote" }
+            }
+        });
+        assert!(servers_from_opencode_value(&root).is_empty());
+    }
+
+    #[test]
+    fn remote_tools_host_config_maps_to_stdio() {
+        let root = json!({
+            "mcpServers": {
+                "amuxd-remote-tools": {
+                    "command": "/usr/local/bin/amuxd",
+                    "args": ["remote-tools-mcp", "--sock=/tmp/amuxd.sock"]
+                }
+            }
+        });
+        assert_eq!(
+            servers_from_mcp_config_value(&root).get("amuxd-remote-tools"),
+            Some(&json!({
+                "type": "stdio",
+                "command": "/usr/local/bin/amuxd",
+                "args": ["remote-tools-mcp", "--sock=/tmp/amuxd.sock"]
+            }))
+        );
+        assert!(servers_from_mcp_config_value(&json!({})).is_empty());
+    }
+
+    #[test]
+    fn assemble_merges_both_sources_with_remote_tools_winning() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("opencode.json"),
+            r#"{"mcp":{"ws":{"command":["ws-bin"]},
+                      "amuxd-remote-tools":{"command":["stale"]}}}"#,
+        )
+        .unwrap();
+        let host = dir.path().join("remote-tools-host.json");
+        std::fs::write(
+            &host,
+            r#"{"mcpServers":{"amuxd-remote-tools":{"command":"amuxd","args":["remote-tools-mcp"]}}}"#,
+        )
+        .unwrap();
+
+        let servers = assemble(&dir.path().to_string_lossy(), Some(&host));
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers["ws"]["command"], json!("ws-bin"));
+        assert_eq!(servers["amuxd-remote-tools"]["command"], json!("amuxd"));
+    }
+
+    #[test]
+    fn assemble_tolerates_missing_files() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(assemble(&dir.path().to_string_lossy(), None).is_empty());
+        assert!(assemble("/nonexistent/worktree", Some(Path::new("/nope.json"))).is_empty());
+    }
+}

--- a/apps/daemon/src/runtime/sidecar/mod.rs
+++ b/apps/daemon/src/runtime/sidecar/mod.rs
@@ -1,0 +1,13 @@
+//! Pieces shared by sidecar-style agent backends.
+//!
+//! A "sidecar backend" spawns a Node child per worktree and speaks JSONL over
+//! its stdin/stdout. `cursor_sdk` and `claude_agent` are both built this way,
+//! and these two modules are the parts that are genuinely identical between
+//! them — the JSONL request/response client, and the translation of TeamClaw's
+//! MCP manifest into the `{stdio|http}` server map both SDKs accept.
+//!
+//! Everything else (event vocabulary, session identity, permission semantics)
+//! differs per SDK and lives in the backend's own module.
+
+pub mod client;
+pub mod mcp;

--- a/docs/architecture/adding-an-agent-backend.md
+++ b/docs/architecture/adding-an-agent-backend.md
@@ -1,0 +1,267 @@
+# 接入一个新 Agent Type：适配文档与要点
+
+> 面向的问题：TeamClaw 现在有 opencode / pi / cursor / claude 四个 local agent
+> backend。本文记录**再接一个需要改什么、哪些坑是共性的**，以及四个已有实现
+> 在每个适配点上的真实做法对比。
+>
+> 前置阅读：[`apps/daemon/src/runtime/backend.rs`](../../apps/daemon/src/runtime/backend.rs)
+> 是唯一的抽象边界，看懂它就看懂了一半。
+
+## 0. 一句话架构
+
+```
+客户端（Tauri / iOS / gateway）
+        │  只认 amux.proto，不知道有几种 backend
+        ↓
+   RuntimeManager
+        │  AcpCommand ↓ / AcpEvent ↑     ← 这条边界不能因为新 backend 而变
+        ↓
+   dyn AgentBackend
+        ├── opencode_http/   全局单进程 `opencode serve`，HTTP + SSE
+        ├── pi_rpc/          每 worktree 一个 `pi --mode rpc`，JSONL
+        ├── cursor_sdk/      每 worktree 一个 Node sidecar，JSONL
+        └── claude_agent/    每 worktree 一个 Node sidecar，JSONL
+```
+
+**核心约束：协议零改动。** 新 backend 的全部工作是把它自己的世界翻译成
+`AcpCommand` / `amux::AcpEvent` 这套既有词汇。任何"为了新 backend 改 proto /
+改前端"的冲动，都应该先怀疑是翻译层没做够。唯一的例外见 §3.7（agent_type 枚举）。
+
+## 1. 必须落地的清单
+
+按依赖顺序，缺一项就是半成品。带 ⚠️ 的是**已经踩过的坑**，在 §3 展开。
+
+| # | 落点 | 文件 | 备注 |
+|---|---|---|---|
+| 1 | 实现 `AgentBackend` | `runtime/<name>/mod.rs` | 12 个方法，其中 `session_model` 有默认实现 |
+| 2 | 工厂注册 | `runtime/backend.rs` `create_backend()` | 一行 match arm |
+| 3 | 配置结构体 | `config/daemon_config.rs` | `[agents.<name>]`；同时导出到 `config/mod.rs` |
+| 4 | 事件翻译 | `runtime/<name>/translate.rs` | 对齐 `opencode_http/translate.rs` 的词汇表 |
+| 5 | 会话 ID 前缀 | `SESSION_ID_PREFIX` | `<name>:<后端自己的 id>`，自包含以便重启后 resume |
+| 6 | MCP 透传 ⚠️ | 复用 `runtime/sidecar/mcp.rs` | 见 §3.1 |
+| 7 | 权限闭环 ⚠️ | `runtime/<name>/permission.rs` | 见 §3.2，**这是最容易做成空转的一项** |
+| 8 | 模型选择与回灌 ⚠️ | `pick_initial_model` + `session_model` | 见 §3.3 / §3.4 |
+| 9 | agent_type 枚举 | `proto/amux.proto` + `runtime_resolution.rs` | 见 §3.7 |
+| 10 | 分发路径 ⚠️ | doctor + install + 打包 | 见 §3.6，**cursor 至今没做，只能在开发机跑** |
+| 11 | 前端设置页 | `LLMSectionRouter.tsx` + `DaemonGeneralSection.tsx` | runtime picker 加一项 + 自己的 LLM 面板 |
+
+## 2. 可以直接复用的东西
+
+`runtime/sidecar/` 是为"Node sidecar + JSONL"这类 backend 抽出来的共享层，
+`cursor_sdk` 和 `claude_agent` 都用它：
+
+| 模块 | 内容 | 为什么能共享 |
+|---|---|---|
+| `sidecar/client.rs` | JSONL 请求/响应客户端（`{id,method,params}` ↔ `{id,result\|error}`，120s 超时，pending 表） | 与具体 SDK 无关，纯传输 |
+| `sidecar/mcp.rs` | `opencode.json` 的 `mcp` 表 + remote-tools host config → SDK 的 `mcpServers` record | Cursor SDK 与 Claude Agent SDK 的 MCP 形状**逐字相同**：stdio `{type,command:string,args,env}`、http `{type:"http",url,headers}` |
+
+其它三处虽然长得像但**不要盲抄**：`process.rs`（进程池）、`events.rs`（stdout
+路由）、`translate.rs`（事件翻译）。它们的骨架相同、语义不同，见 §3。
+
+另外，非 sidecar 类后端（HTTP、纯二进制 RPC）用不上 `sidecar/`，直接实现
+trait 即可 —— opencode 和 pi 就是这样。
+
+## 3. 适配要点（每一条都对应一次真实返工）
+
+### 3.1 MCP 透传：别忘了 `mcp_config_path`
+
+`attach_session` 的 `mcp_config_path` 参数指向 daemon 写的
+`remote-tools-host.json`，里面是 `amuxd-remote-tools`（`get_page_dom` /
+`show_page_nav_links`）。**除它之外**还要读 worktree 的 `opencode.json` 的 `mcp`
+表 —— 那是 MCP 的 SSOT，团队/继承/用户三层配置都合并在里面。
+
+| backend | 做法 |
+|---|---|
+| opencode | 原生读 `opencode.json`，什么都不用做 |
+| pi | 没有原生 MCP，靠 pi extension 代理（`TEAMCLAW_MCP_SERVERS` 环境变量） |
+| cursor | `sidecar::mcp::assemble()` → `Agent.create({mcpServers})` |
+| claude | 同上 → `query({options:{mcpServers}})` |
+
+**坑（cursor 首版踩过）**：SDK 侧 `mcpServers` 是 `Record<string, Config>`
+而非数组，且 stdio 的 `command` 是**字符串** + `args` 数组，与 `opencode.json`
+的 `command: string[]` 形状不同。传错形状不会报错，只会静默地一个 server 都不加载。
+
+**坑**：inline MCP 通常不被 SDK 持久化，**resume 时必须重传整份清单**。
+
+### 3.2 权限闭环：先搞清楚 SDK 到底有没有带外审批通道
+
+这是最贵的一课。三种可能，先判定属于哪种再动手：
+
+| 机制 | 谁有 | 特征 |
+|---|---|---|
+| **协议内审批** | opencode (`permission.asked`)、pi（extension dialog）、**Claude Agent SDK**（`canUseTool` 进程内回调） | SDK 主动问、并阻塞等你答。最好做。 |
+| **只有 hook** | **Cursor SDK** | 没有任何 respond API，只能靠 `.cursor/hooks.json` 里的 `preToolUse` 命令，SDK spawn 它、读 stdout 的 `{"permission":"allow"\|"deny"}` |
+| **完全没有** | —— | 只能静态策略，或者放弃非 full-access 场景 |
+
+判定方法：**读 `.d.ts`，别读文档**。cursor 的 `SDKRequestMessage` 只有一个
+`request_id`、没有工具信息也没有 respond 方法，光看名字会以为是审批信号，实际
+是 cloud reviewer 的东西、本地 run 根本不触发。首版就是接错了这个信号。
+
+**必答的三个问题：**
+
+1. **full access 会话怎么绕过？** gateway / cron 无人值守，等审批就是挂死。
+   claude 用 `permissionMode: 'bypassPermissions'`（SDK 直接不调回调），
+   cursor 在 hook 里直接返回 allow。
+2. **fail-open 还是 fail-closed？** 取决于**谁在等**：
+   - cursor 的 hook 进程是 SDK spawn 的、有超时，路由失败时 **fail-open**——
+     一个 fail-closed 的 `preToolUse` 网关会在任何上游抖动时废掉会话里的每一次
+     工具调用。
+   - claude 的 `canUseTool` 是被阻塞的进程内 promise，路由失败时 **fail-closed**——
+     拒绝会让模型收到一条 refusal 继续跑，而放行等于执行了没人批准的工具。
+
+   两者相反，且都是对的。照抄另一个后端的选择会出事。
+3. **"始终允许"能不能真的持久化？** 能就带上 SDK 自己的 rule 建议
+   （claude 的 `suggestions` → `updatedPermissions`）；不能就**别显示这个按钮**
+   （`options_for(can_always)`），否则用户点了以为生效、实际等同一次性放行。
+
+事件载荷别偷懒：`tool_name` / `description` / `params` 要填真值。cursor 首版全
+是占位符（`tool_name: "cursor"`、`options: vec![]`），UI 上就是一个不知道在批
+什么的框。
+
+### 3.3 初始模型选择：不要 `available.first()`
+
+统一口径（pi 的注释里写了这条经验，claude 照抄）：
+
+```
+显式 override → 配置的默认值 → 设备 MRU → 什么都不说（让 SDK 用自己的默认）
+```
+
+每一步都要对**实时目录**做可用性校验。两个反面：
+
+- `available.first()`：拿到目录里碰巧排第一的那个，毫无可用性语义。
+- 目录为空就返回 None：目录往往需要一个 live session 才拿得到，**首次 attach
+  必然是空的**。空 = 未知，不是不可用 —— 此时应该保留用户配置的值。
+  `config::first_available` 已经内建了这个语义（`available.is_empty()` 时直接
+  返回首个候选），直接用它。
+
+### 3.4 `session_model()`：只能回报后端自己说的值
+
+trait 文档写得很清楚：这个方法用来教设备 MRU 学到它的第一个条目，所以必须返回
+**后端报告的**模型，不是我们要求的。
+
+cursor 首版让 bridge 返回自己记的 `entry.model`，等于把我们的猜测回灌进 MRU。
+正确来源：
+
+| backend | 权威来源 |
+|---|---|
+| opencode | `session_model()` 查 HTTP |
+| cursor | `agent.model`（SDK 自己的 selection，每次 send 后更新）+ `turn_end` 的 `result.model.id` |
+| claude | `system/init` 的 `model` + `result.modelUsage` 的 key |
+
+bridge 侧把"我们要求的"和"SDK 报告的"分成两个字段返回
+（`requestedModel` / `sdkModel`），Rust 侧只读后者 —— 这样不会再混淆。
+
+### 3.5 `SetModel`：确认它真的改了模型
+
+cursor 首版的 `set_model` 只改了 bridge 里的一个 map，既不 dispose+recreate
+Agent 也不影响正在跑的 run —— UI 上切换成功、实际没变。
+
+先在 `.d.ts` 里找**真正的**切换点：
+
+- Claude Agent SDK：`Query.setModel(model)` 是 control-protocol 调用，真改
+  （前提是 streaming input 模式，见 §3.8）。
+- Cursor SDK：没有独立 setter，模型在 `agent.send(text, { model })` 里传，
+  所以 daemon 的 route 是 source of truth，每次 prompt 都带上。
+- opencode：同样是 prompt body 里带（`PromptBody { model, parts }`）。
+
+规律：**如果 SDK 没有独立 setter，就让 daemon 的 route 持有模型、每次 prompt
+带过去**，而不是在 sidecar 里存一份状态。
+
+### 3.6 分发：`env!("CARGO_MANIFEST_DIR")` 是个陷阱
+
+Sidecar 脚本路径千万别写成
+`env!("CARGO_MANIFEST_DIR")/xxx-bridge/src/main.mjs` —— 打包进 Tauri 的 amuxd
+里，这是 CI 构建机的 checkout 路径，用户机上不存在。**cursor 现在就是这样，
+所以只有手动 `npm install` 过的开发机能用。**
+
+一个能出开发机的 sidecar backend 需要：
+
+- `<name>_install/` 里有 `run_install()`，不能只有 `doctor()`
+  （对照 `opencode_install` / `pi_install`）
+- bridge 的 `node_modules` 有人装：它不在 pnpm workspace 里
+  （`apps/*` 只匹配一层，`apps/daemon` 也没有 package.json），
+  根目录 `pnpm install` 装不到它
+- `tauri.conf.json` 的 `resources` / `externalBin` 里有它
+- `amuxd doctor` 报告 node、脚本、依赖、凭证四项（这项 cursor 做了）
+
+### 3.7 agent_type 枚举
+
+`proto/amux.proto` 的 `AgentType` 要加一项，否则会话在存储和上报里带的是别的
+类型，`evict_agent_types` 也只能一刀切。加完记得补
+`daemon/runtime_resolution.rs` 里两个 match（`agent_type_from_name` /
+`agent_type_name`）—— 后者是穷尽匹配，不补就编译不过（这是好事）。
+
+claude 复用已有的 `AGENT_TYPE_CLAUDE_CODE = 1`；cursor 这次补上了
+`AGENT_TYPE_CURSOR = 5`。
+
+### 3.8 SDK 的"模式"往往决定了你有哪些能力
+
+Claude Agent SDK 的 `interrupt()` / `setModel()` / `setPermissionMode()` 都是
+control-protocol 调用，**只在 streaming input 模式下存在**。所以 bridge 必须把
+`prompt` 传成一个 async iterable（我们用一个 push 队列）而不是字符串 —— 传字符串
+就等于放弃取消和切模型。
+
+同类问题：Cursor SDK 的 `local.cwd` 支持数组，但只有 `cwd[0]` 用于 executor 和
+setting sources 解析，其余元素只用于 PR 归因遥测。曾经想靠多根把 hooks.json 放
+到仓库外，实测不成立。
+
+**通用做法：动手前先在 `.d.ts` 里确认能力的前置条件，别按文档的乐观描述设计。**
+
+### 3.9 别在 await 上持有 `parking_lot` 锁
+
+`Shared.routes` 用的是 `parking_lot::Mutex`，它的 guard 不是 `Send`。
+在 guard 存活期间 `.await` 会得到一句非常绕的
+`future cannot be sent between threads safely`。
+
+固定写法：先在锁里 clone 出快照，锁释放后再决策 + await。
+
+```rust
+let snapshot = shared.routes.lock().get(session_id).map(|r| (r.event_tx.clone(), ...));
+let Some((event_tx, ...)) = snapshot else { ...; return; };
+```
+
+### 3.10 turn 生命周期必须自己兜底
+
+`Cancel` 之后不要指望后端一定会补一个 `turn_end`：pi 不可靠，cursor 的
+`run.cancel()` 也不保证。统一在 `Cancel` 分支里调一次 `close_turn`
+（它 guard 在 `turn_active` 上，是幂等的），否则 UI 永远停在"回复中"。
+
+prompt 提交失败同理：没有 turn 会开始，也就没有 turn 会结束，必须手动
+`Active → Idle`。
+
+## 4. 四个后端的适配点对比
+
+| | opencode | pi | cursor | claude |
+|---|---|---|---|---|
+| 进程模型 | 全局单 `opencode serve` | 每 worktree 一个 | 每 worktree 一个 Node | 每 worktree 一个 Node |
+| 传输 | HTTP + SSE | JSONL | JSONL（`sidecar/client.rs`） | JSONL（同左） |
+| 会话 ID | opencode session id | `pi:<session 文件路径>` | `cursor:<agentId>` | `claude:<sdk session_id>` |
+| MCP | 原生 | extension 桥接 | `sidecar/mcp.rs` | `sidecar/mcp.rs` |
+| 权限 | `permission.asked` | extension confirm dialog | `.cursor/hooks.json` 的 `preToolUse` | `canUseTool` 进程内回调 |
+| 权限失败方向 | 等待 | 等待 | **fail-open** | **fail-closed** |
+| 取消 | `POST abort` | `abort` | `run.cancel()` | `Query.interrupt()` |
+| 切模型 | prompt body 带 | `set_model` RPC | send 时带（无 setter） | `Query.setModel()` |
+| 模型目录 | `/config/providers` | `get_available_models` | `Cursor.models.list()` | `Query.supportedModels()` |
+| 可出开发机 | ✅ | ✅ | ❌（§3.6） | ❌（§3.6） |
+
+## 5. 最小验收清单
+
+一个 backend 可以说"接完了"的判据：
+
+- [ ] 单会话 prompt → 看到流式 Output → 回到 Idle
+- [ ] 工具调用产生 ToolUse / ToolResult，`tool_kind` 映射正确
+- [ ] 非 full-access 会话弹出审批框，**点拒绝后模型确实收到拒绝**
+- [ ] full access 会话（cron / gateway）全程不弹框、不挂起
+- [ ] `amuxd-remote-tools` 在该 backend 下可调用
+- [ ] 切模型后**下一轮**确实用了新模型（看 `turn_end` 上报的值，不是 UI 状态）
+- [ ] daemon 重启后 resume 成功，且 MCP 清单重传
+- [ ] 取消一个进行中的 turn，UI 不卡在"回复中"
+- [ ] `amuxd doctor` 能诊断缺失的依赖和凭证
+- [ ] 在**没有开发环境**的机器上能跑（§3.6）
+
+## 6. 参考实现
+
+- 后端抽象：[`apps/daemon/src/runtime/backend.rs`](../../apps/daemon/src/runtime/backend.rs)
+- 共享 sidecar 层：[`apps/daemon/src/runtime/sidecar/`](../../apps/daemon/src/runtime/sidecar/)
+- 四个实现：`runtime/opencode_http/`、`runtime/pi_rpc/`、`runtime/cursor_sdk/`、`runtime/claude_agent/`
+- 单后端设计稿：[`cursor-sdk-backend.md`](./cursor-sdk-backend.md)、[`pi-agent-backend.md`](./pi-agent-backend.md)

--- a/docs/architecture/cursor-sdk-backend.md
+++ b/docs/architecture/cursor-sdk-backend.md
@@ -27,7 +27,7 @@
 | 模型目录 | `/config/providers` | `get_available_models` | `Cursor.models.list()` |
 | 鉴权 | opencode provider key / LiteLLM | LiteLLM via pi provider | `CURSOR_API_KEY`（用户或 team service account） |
 | MCP | `opencode.json` mcp 表 | pi extension 桥接 | SDK inline MCP on `Agent.create` / `send` |
-| 权限审批 | opencode `permission.asked` | pi extension `confirm` dialog | SDK hooks（见 §5）或 gateway 自动放行 |
+| 权限审批 | opencode `permission.asked` | pi extension `confirm` dialog | worktree `.cursor/hooks.json` 的 `preToolUse` hook（见 §5）|
 | 取消 | `POST abort` | `abort` | `run.cancel()`（需 `run.supports("cancel")`） |
 
 ## 3. 目标架构
@@ -50,9 +50,10 @@
 **下行**：sidecar 把 `run.stream()` 事件逐条写 stdout → Rust `translate.rs`
 → `AcpEventFrame` → 既有 `turn_aggregator` / MQTT / SSE。
 
-**权限**：sidecar 收到 SDK 需人工确认的事件 → 写 `permission_request` 行 →
-Rust 发 `AcpPermissionRequest` → 客户端审批 → `ResolvePermission` → sidecar
-写回 SDK。
+**权限**：SDK 执行 worktree `.cursor/hooks.json` 的 `preToolUse` hook →
+`amuxd cursor-permission-hook` 走 `amuxd.sock` 问 daemon → daemon 发
+`AcpPermissionRequest` → 客户端审批 → `ResolvePermission` → hook 进程打印
+`{"permission":"allow"|"deny"}` 给 SDK。见 §6.5。
 
 协议边界不变：客户端只认 `amux.proto`；`acp_session_id` 前缀 `cursor:`
 区分后端，resume 时剥前缀调 `Agent.resume`。
@@ -65,6 +66,9 @@ Rust 发 `AcpPermissionRequest` → 客户端审批 → `ResolvePermission` → 
 |---|---|
 | `process.rs` | 每 canonical worktree 拉起 Node sidecar；env 注入 `CURSOR_API_KEY`、MCP JSON；kill_on_drop；指纹变更时 respawn |
 | `client.rs` | JSONL 命令写 stdin（带 `id` 关联 response）：`create_agent`、`resume_agent`、`send`、`cancel`、`set_model`、`list_models`、`dispose` |
+| `mcp.rs` | `opencode.json` `mcp` + remote-tools host config → SDK `mcpServers` record |
+| `hooks.rs` | 在 worktree 写/合并 `.cursor/hooks.json` 的 `preToolUse` 网关 |
+| `permission.rs` | hook 请求 → `AcpPermissionRequest` → 等人 → allow/deny |
 | `events.rs` | stdout 逐行解析（`\n` 切分），按 `cursor:<agentId>` 路由 `AcpEventFrame` |
 | `translate.rs` | SDK 事件 → `amux::AcpEvent`（对齐 `opencode_http/translate.rs` 词汇表） |
 | `mod.rs` | `CursorSdkBackend` + route 表 + pending permission 表 |
@@ -106,7 +110,8 @@ node /path/to/cursor-bridge/main.mjs --mode rpc
 Sidecar 职责：
 
 - 持有 `Agent` 实例；进程退出时 `Symbol.asyncDispose`
-- `create_agent` / `resume_agent` 时**显式**传 `local: { cwd, settingSources: [] }`
+- `create_agent` / `resume_agent` 时**显式**传 `local: { cwd, settingSources: ["project"] }`
+  （`[]` 会把 hooks 一起关掉，权限网关就失效了）
 - 每次 `send` 后 `await run.wait()`，区分 `CursorAgentError`（startup）与
   `result.status === "error"`（run failed）
 - 日志 `agentId` + `runId` 到 stderr（Rust 可采集）
@@ -153,7 +158,7 @@ const SESSION_ID_PREFIX: &str = "cursor:";
 | tool result | `ToolResult { tool_call_id, summary, is_error }` |
 | run finished | `StatusChange { status: Idle }` + 可选 `AgentReply` meta |
 | run error | `AcpError` + `StatusChange { status: Error }` |
-| permission / confirm（hooks） | `PermissionRequest` |
+| `preToolUse` hook 调用（不是 stream 事件） | `PermissionRequest` |
 
 `tool_kind` 映射（与 pi/opencode 对齐）：`read`→read, `edit`/`write`→edit,
 `bash`/`terminal`→execute, 其余→other。
@@ -163,15 +168,40 @@ const SESSION_ID_PREFIX: &str = "cursor:";
 TeamClaw 已在 worktree 物化 MCP 配置（`opencode.json` / daemon workspace API）。
 Cursor 后端**不读 opencode.json 的 provider 段**，只复用 MCP 清单：
 
-1. attach 时 daemon 把 workspace 已启用 MCP 转为 SDK `mcpServers` 数组
-   （stdio: command/args/env；HTTP: url/headers）
+1. attach 时 daemon 把 workspace 已启用 MCP 转为 SDK `mcpServers` **record**
+   （stdio: `{type,command:string,args,env}`；HTTP: `{type:"http",url,headers}`）
 2. `amuxd-remote-tools` 保留为 stdio server（与 pi extension 桥同等优先级）
 3. **inline MCP 在每次 `resume_agent` / `send` 时重传**（SDK 限制）
 4. `.cursor/skills` / TeamClaw skills：第一版不自动映射；后续评估 SDK
    `settingSources` 或 system prompt 注入
 
-`is_gateway` 会话：permission hooks 在 sidecar 内直接 auto-grant（对齐
-opencode gateway 行为）。
+`is_gateway` 会话：daemon 在 hook 回调里直接 allow（对齐 opencode gateway
+行为），不弹审批。
+
+## 6.5 实测修正（对 `@cursor/sdk@1.0.24` 的核对）
+
+设计稿写作时的三处假设与 SDK 实际行为不符，实现按后者：
+
+1. **SDK 没有带外审批 API。** `SDKRequestMessage`（`messages.d.ts:70`）只带一个
+   `request_id`，没有工具信息也没有 respond 方法，且是 cloud reviewer 信号，
+   本地 run 不触发。本地唯一的审批机制是 Cursor hooks：SDK spawn hook 命令、
+   喂 stdin、读 stdout 的 `{"permission":"allow"|"deny"}`，`deny` 会把该调用变成
+   `permission_denied` 拒绝。用 `preToolUse` 这一个通用步骤覆盖所有工具
+   （payload 带 `tool_name` / `tool_input` / `cwd`），每条 hook 的 `timeout`
+   （秒）可配，所以 hook 进程可以阻塞着等人。
+2. **`settingSources: []` 会连 hooks 一起关掉**，因此改为 `["project"]`；
+   顺带 worktree 自己的 rules / AGENTS.md 也开始生效（与 opencode/pi 一致）。
+3. **`mcpServers` 是 `Record<string, McpServerConfig>` 而非数组**
+   （`options.d.ts:235`）；stdio 项的 `command` 是**字符串**+`args` 数组，
+   与 `opencode.json` 的 `command: string[]` 形状不同，需转换。
+
+hooks 文件只能放在 worktree 内：`local.cwd` 传数组时 SDK 只取第一个根
+（`Array.isArray(cwd) ? cwd[0] : cwd`）来解析 setting sources，旁路目录不会被扫描。
+写入时与用户已有 `.cursor/hooks.json` 合并（只替换带 `cursor-permission-hook`
+标记的条目），并登记进 `.git/info/exclude`。
+
+审批链路 fail-open：路由不到会话、事件通道关闭、超时都返回 allow —— 一个
+fail-closed 的 `preToolUse` 网关会在任何上游抖动时废掉会话里的每一次工具调用。
 
 ## 7. 配置落点
 

--- a/proto/amux.proto
+++ b/proto/amux.proto
@@ -345,6 +345,7 @@ enum AgentType {
   AGENT_TYPE_OPENCODE = 2;
   AGENT_TYPE_CODEX = 3;
   AGENT_TYPE_PI = 4;
+  AGENT_TYPE_CURSOR = 5;
 }
 
 message WorkspaceInfo {


### PR DESCRIPTION
四个 local agent backend：**opencode / pi / cursor / claude**。

## cursor：权限闭环与 MCP 透传

权限接错了信号。`SDKRequestMessage`（`messages.d.ts:70`）只带一个 `request_id`——没有工具信息也没有 respond 方法——而且是 cloud reviewer 的东西，本地 run 根本不触发；bridge 的 `resolve_permission` 本来就是空转。

SDK 本地唯一的审批机制是 Cursor hooks：SDK spawn hook 命令、把请求喂给 stdin、读 stdout 的 `{"permission":"allow"|"deny"}`，每条 hook 的 `timeout` 由我们控制。所以改成：

```
SDK preToolUse hook → amuxd cursor-permission-hook → amuxd.sock
  → permission::handle → AcpPermissionRequest → 人
  → ResolvePermission → hook 打印 deny → SDK 拒绝该调用
```

- `settingSources` 从 `[]` 改为 `["project"]`——`[]` 会让 SDK 完全不读 hooks，权限网关无从谈起；顺带 workspace 自己的 rules/AGENTS.md 也生效了，与 opencode/pi 对齐。
- `hooks.json` 与用户已有文件合并（只替换带 `cursor-permission-hook` 标记的条目），并登记进 `.git/info/exclude`。
- 事件带上真实的 `tool_name` / `description` / `params` 和 once/always/reject 三选项；`always` 落在 daemon 自己的 `cursor-permissions.json`。
- **整链路 fail-open**：fail-closed 的 `preToolUse` 网关会在任何上游抖动时废掉会话里的每一次工具调用。

MCP：`mcp_config_path` 之前被忽略，bridge 又把 `mcpServers` 当数组判断。它是 `Record<string, McpServerConfig>`，stdio 项的 `command` 是**字符串** + `args` 数组，与 `opencode.json` 的 `command: string[]` 形状不同。现在 `amuxd-remote-tools` 和 workspace 里所有 MCP server 都能到达 agent，resume 时重传整份清单。

顺带修掉：`SetModel` 只改了 bridge 里的 map（SDK 实际通过 `SendOptions.model` 切换）；`session_model` 把我们自己的猜测回灌进设备 MRU，而不是 SDK 报告的值。

## claude：新后端

`@anthropic-ai/claude-agent-sdk` 挂在同一个 `AgentBackend` trait 下，每 worktree 一个 Node sidecar。两处比 cursor 好：

- **权限是进程内 `canUseTool` 回调**——审批就是 stdout 上的普通事件，不需要往用户仓库写 hooks 文件、不需要 socket 回调。方向与 cursor **相反**：SDK 正被阻塞着，所以 **fail-closed**（拒绝让模型收到 refusal 继续跑，放行等于执行了没人批准的工具）。
- **`Query.setModel()` 是真的控制协议调用**，代价是必须以 streaming-input 模式驱动 SDK（`interrupt()` / `setModel()` 只在该模式下存在）。

## 共享层

`runtime/sidecar/` 收纳两个 sidecar 后端逐字相同的部分：JSONL 客户端 + MCP 清单组装。补上 proto 里缺失的 `AGENT_TYPE_CURSOR`。

`docs/architecture/adding-an-agent-backend.md` 记录接一个新 agent type 的真实成本，含四后端逐项对比表和最小验收清单。

## 验证与缺口

daemon 全量单测 **932 passed / 0 failed**，clippy 零 error，只格式化了本次涉及的文件。

未被自动化覆盖：**sock dispatch 那一跳**（与 `remote-tool-call`/`prompt-await` 逐字同构，但没跑起真 daemon 打过），以及**两个 bridge 与真实 SDK 的联调**（本机无 `CURSOR_API_KEY` / `ANTHROPIC_API_KEY`）。

两个 bridge **都还没有分发路径**：脚本路径在构建期写死，且没有任何步骤安装 `node_modules`，目前只有手动装过依赖的开发机能跑（文档 §3.6 已记录）。claude 的前端设置页分支也还没加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)