### PR TITLE
fix(release): match Cargo.lock blocks on CRLF checkouts

### DIFF
--- a/scripts/lib/cargo-lock-version.js
+++ b/scripts/lib/cargo-lock-version.js
@@ -47,8 +47,11 @@ function syncCargoLockVersions(lockText, version, packages = WORKSPACE_MEMBERS) 
   let text = lockText;
 
   for (const name of packages) {
+    // `\r?` before each newline: the Windows release runner checks out with
+    // core.autocrlf=true, so Cargo.lock arrives CRLF and an \n-only pattern
+    // matches nothing — every package lands in `missing` and the caller aborts.
     const block = new RegExp(
-      `(\\[\\[package\\]\\]\\nname = "${escapeRegExp(name)}"\\nversion = ")([^"]+)(")`,
+      `(\\[\\[package\\]\\]\\r?\\nname = "${escapeRegExp(name)}"\\r?\\nversion = ")([^"]+)(")`,
     );
     const match = text.match(block);
     if (!match) {

--- a/scripts/lib/cargo-lock-version.test.js
+++ b/scripts/lib/cargo-lock-version.test.js
@@ -74,6 +74,19 @@ test("a dependency merely naming a member is not rewritten", () => {
   assert.equal(out.text, text);
 });
 
+test("a CRLF lockfile is rewritten and keeps its line endings", () => {
+  // The Windows release runner checks out with core.autocrlf=true. An \n-only
+  // pattern found nothing there, so the bump script aborted with "Cargo.lock has
+  // no entry for: teamclaw, amuxd" and took the whole nightly build down.
+  const before = lock("0.3.1-beta.8", "0.3.1-beta.8").replace(/\n/g, "\r\n");
+  const out = syncCargoLockVersions(before, "0.3.1-beta.9");
+  assert.deepEqual(out.missing, []);
+  assert.deepEqual(out.changed.sort(), ["amuxd", "teamclaw"]);
+  assert.match(out.text, /name = "teamclaw"\r\nversion = "0\.3\.1-beta\.9"/);
+  assert.match(out.text, /name = "amuxd"\r\nversion = "0\.3\.1-beta\.9"/);
+  assert.ok(!/[^\r]\n/.test(out.text), "must not introduce bare LF into a CRLF file");
+});
+
 test("the member list is the two crates the bump script rewrites", () => {
   assert.deepEqual([...WORKSPACE_MEMBERS].sort(), ["amuxd", "teamclaw"]);
 });


### PR DESCRIPTION
## What broke

The nightly OSS release has been failing on `build-windows` since ef4f8866 landed — both brands, every night, while the four macOS/Linux jobs pass. Last night (7/28) that meant no Windows installer and no `publish-manifest`, so `v0.3.1-beta.9` was bumped onto main but never actually published.

The step that dies is *Sync + verify version bump*:

```
Cargo.lock has no entry for: teamclaw, amuxd — refusing to guess.
```

## Why

`syncCargoLockVersions` anchored its block regex on a literal `\n` between `[[package]]`, `name`, and `version`. GitHub's Windows runners check out with `core.autocrlf=true`, so `Cargo.lock` arrives CRLF and the pattern matches nothing. Both members land in `missing`, which the caller treats as a hard error — correctly, since silently skipping is the exact drift that hard error exists to prevent. It just happened to be tripped by line endings rather than a genuinely absent package.

Reproduced against the pre-fix code: feeding it a CRLF lockfile returns `missing = ["teamclaw"]`.

## The fix

`\r?` before each newline, so both checkouts match. The replacement writes back through the same capture groups, so a CRLF file stays CRLF and an LF file stays LF — the new test asserts no bare LF is introduced.

A `.gitattributes` pinning `Cargo.lock` to LF would also work, but only for that one file; making the pattern line-ending agnostic fixes the class.

## Verification

- New regression test fails against `origin/main`'s version of the module, passes here.
- `node --test scripts/lib/cargo-lock-version.test.js` — 8/8 pass.

## After merge

Re-dispatch `release-oss.yml` at `v0.3.1-beta.9` for both brands (`copilot361`, `betly`) to fill in the release that was lost last night.

🤖 Generated with [Claude Code](https://claude.com/claude-code)