### PR TITLE
fix(self-host): wait for PostgREST's schema cache before e2e

### DIFF
--- a/deploy/self-host/smoke/run-e2e.sh
+++ b/deploy/self-host/smoke/run-e2e.sh
@@ -17,6 +17,46 @@ KONG_IP=$(docker inspect supabase-kong \
 [ -n "$FC_IP" ]   || { echo "FAIL: teamclaw-self-host-fc-1 not running"; exit 1; }
 [ -n "$KONG_IP" ] || { echo "FAIL: supabase-kong not running"; exit 1; }
 
+# ── Wait for PostgREST's schema cache ──────────────────────────────────────
+#
+# `docker compose up -d` restarts supabase-rest, which then rebuilds its schema
+# cache from Postgres. Until that finishes every request through it answers 503
+# `PGRST002 Could not query the database for the schema cache`. The deploy
+# workflow waits for litellm, fc, and caddy — but nothing waits for this, so a
+# fast runner fires the suite into a warming database and every DB-backed test
+# fails at `POST /v1/teams`, with the rest cascading off the team that was never
+# created. That is a deploy that reports failure while the deployment is fine.
+#
+# supabase-rest has no healthcheck to depend on, so probe it directly: its root
+# serves the OpenAPI document once the cache is loaded. Probing the container
+# rather than going through Kong keeps this apikey-free.
+REST_IP=$(docker inspect supabase-rest \
+  --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 2>/dev/null || echo "")
+
+if [ -z "$REST_IP" ]; then
+  # The all-in-one image runs PostgREST as a plain process, not its own
+  # container. Nothing to probe — let the suite report whatever it finds.
+  echo "note: supabase-rest container not found; skipping schema-cache wait"
+else
+  echo "=== wait for postgrest schema cache ==="
+  i=0
+  until [ "$i" -ge 60 ]; do
+    code=$(curl -s -o /tmp/pgrst-probe.$$ -w '%{http_code}' -m 5 \
+      "http://$REST_IP:3000/" 2>/dev/null || echo "000")
+    if [ "$code" = "200" ] && ! grep -q PGRST002 /tmp/pgrst-probe.$$ 2>/dev/null; then
+      rm -f /tmp/pgrst-probe.$$
+      echo "  postgrest ready after ${i}s"
+      break
+    fi
+    i=$((i + 1))
+    sleep 1
+  done
+  rm -f /tmp/pgrst-probe.$$
+  # Deliberately not fatal: if PostgREST is genuinely broken the suite's own
+  # assertions say so with far better diagnostics than a bare timeout here.
+  [ "$i" -lt 60 ] || echo "WARN: postgrest still not serving after 60s; running the suite anyway"
+fi
+
 cd "$REPO_ROOT/services/fc"
 FC_E2E=1 \
 FC_E2E_BASE_URL="http://$FC_IP:9000" \


### PR DESCRIPTION
Follow-up to #638. Fixes the flake that failed [run 30427369531](https://github.com/different-ai-studio/teamclaw/actions/runs/30427369531) while the deployment itself was healthy.

## Problem

`docker compose up -d` restarts `supabase-rest`, which then rebuilds its schema cache from Postgres. Until that finishes, every request through it answers 503:

```
PGRST002 — Could not query the database for the schema cache. Retrying.
```

`self-host-deploy.yml` waits for **litellm**, **fc**, and **caddy** — but nothing waits for PostgREST. On a fast runner the suite fires into a warming database:

```
not ok 1 - POST /v1/teams creates a team
  createTeam failed (500): {"code":"schema_drift","upstreamCode":"PGRST002"}
```

…and the six later failures all cascade off the team that was never created. Net effect: a deploy that reports **failure** while the deployment is **fine**. (In that run the Auth, Runtime config, and Storage suites all passed — only the DB-backed ones raced.)

## Fix

Probe `supabase-rest` directly in `run-e2e.sh` until its root serves the OpenAPI document without `PGRST002`.

- **In the script, not the workflow** — protects every caller, not just CI.
- **Direct to the container, not through Kong** — no apikey needed.
- **Direct probe rather than `depends_on`** — `supabase-rest` has no healthcheck to depend on.
- **Capped at 60s and non-fatal** — if PostgREST is genuinely broken, the suite's own assertions diagnose it far better than a bare timeout here. It warns and runs anyway.
- **Skipped when the container is absent** — the all-in-one image runs PostgREST as a plain process.

## Verification

`sh -n` clean. The loop was exercised against a mocked `curl` in three scenarios — ready on the 4th attempt, never ready, ready immediately — confirming it breaks at the right iteration, warns on timeout, and never trips `set -e`:

```
== ready on 4th attempt:   postgrest ready after 3s
== never ready:            WARN: postgrest still not serving after 60s; running the suite anyway
== ready immediately:      postgrest ready after 0s
```

Real behaviour against a cold stack can only be confirmed by the deploy this PR triggers on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)