### PR TITLE
fix(app): restore session deeplink navigation after team switch

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -226,6 +226,12 @@ import { Button } from "@/components/ui/button";
 import { onOpenUrl, getCurrent } from "@tauri-apps/plugin-deep-link";
 import { parseInviteDeeplink, claimInviteToken } from "@/lib/invite-deeplink";
 import { parseSessionDeeplink } from "@/lib/session-deeplink";
+import {
+  completePendingSessionDeeplink,
+  openSessionFromDeeplink,
+  readPendingSessionDeeplink,
+  stashPendingSessionDeeplink,
+} from "@/lib/open-session-deeplink";
 import { CloudApiError } from "@/lib/backend/cloud-api/http";
 import { useCurrentTeamStore } from "@/stores/current-team";
 import { useTeamShareStore, isShareModeLocked } from "@/stores/team-share";
@@ -882,6 +888,13 @@ function AppContent() {
     }
     prevChatIdentityRef.current = chatIdentityKey;
   }, [chatIdentityKey]);
+
+  // Resume a cross-team session deeplink after enterTeam() clears chat state.
+  useEffect(() => {
+    if (!userId || !currentTeamId) return;
+    if (!readPendingSessionDeeplink()) return;
+    void completePendingSessionDeeplink();
+  }, [userId, currentTeamId, chatIdentityKey]);
 
   // Report this desktop install's tauri client version once per team selection.
   useEffect(() => {
@@ -2834,32 +2847,8 @@ function App() {
       for (const raw of urls) {
         const sessionId = parseSessionDeeplink(raw);
         if (!sessionId) continue;
-        // Best-effort: only act for a real signed-in user. No stash / no
-        // cold-start resume — a non-logged-in launch just drops the link.
-        const authState = useAuthStore.getState();
-        if (!authState.session || authState.session.user?.is_anonymous) continue;
-        try {
-          const session = await getBackend().sessions.joinSession(sessionId);
-          const teamId = session.team_id;
-          const currentTeamId = useCurrentTeamStore.getState().team?.id ?? null;
-          if (teamId && teamId !== currentTeamId) {
-            // The linked session can live in a team outside the active org.
-            await useCurrentTeamStore.getState().enterTeam(teamId);
-          }
-          await useUIStore.getState().switchToSession(sessionId);
-          // Refresh the session list so the freshly-joined session appears in
-          // the left column without waiting for a remount.
-          await useSessionListStore.getState().load();
-        } catch (err) {
-          if (err instanceof CloudApiError && err.status === 403) {
-            toast.error(i18n.t("session.deeplink.noAccess", "无权访问该会话"));
-          } else if (err instanceof CloudApiError && err.status === 404) {
-            toast.error(i18n.t("session.deeplink.notFound", "会话不存在或已被删除"));
-          } else {
-            toast.error(i18n.t("session.deeplink.openFailed", "打开会话失败"));
-          }
-          console.error("[session-deeplink] join failed", err);
-        }
+        stashPendingSessionDeeplink(sessionId);
+        await openSessionFromDeeplink(sessionId);
       }
     }
 
@@ -2871,6 +2860,16 @@ function App() {
 
     return () => { unlisten?.(); };
   }, []);
+
+  // Cold-start resume: the OS may deliver the session link before auth hydrates.
+  const authSession = useAuthStore((s) => s.session);
+  useEffect(() => {
+    if (!isTauri()) return;
+    if (!authSession || authSession.user?.is_anonymous) return;
+    const pending = readPendingSessionDeeplink();
+    if (!pending) return;
+    void openSessionFromDeeplink(pending.sessionId);
+  }, [authSession]);
 
   // Extracted hooks — initialization, setup guide, telemetry consent
   useTauriBodyClass();

--- a/packages/app/src/__tests__/open-session-deeplink.test.ts
+++ b/packages/app/src/__tests__/open-session-deeplink.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const UUID = '33c0b7a2-385d-4f77-b92c-9801819530bd'
+const TEAM_A = 'team-a'
+const TEAM_B = 'team-b'
+
+const mocks = vi.hoisted(() => ({
+  joinSession: vi.fn(),
+  enterTeam: vi.fn(),
+  switchToSession: vi.fn(),
+  load: vi.fn(),
+  session: { user: { id: 'user-1', is_anonymous: false } } as
+    | { user: { id: string; is_anonymous?: boolean } }
+    | null,
+  teamId: 'team-a' as string | null,
+}))
+
+vi.mock('@/lib/backend', () => ({
+  getBackend: () => ({
+    sessions: { joinSession: mocks.joinSession },
+  }),
+}))
+
+vi.mock('@/stores/auth-store', () => ({
+  useAuthStore: {
+    getState: () => ({ session: mocks.session }),
+  },
+}))
+
+vi.mock('@/stores/current-team', () => ({
+  useCurrentTeamStore: {
+    getState: () => ({
+      team: mocks.teamId ? { id: mocks.teamId } : null,
+      enterTeam: mocks.enterTeam,
+    }),
+  },
+}))
+
+vi.mock('@/stores/ui', () => ({
+  useUIStore: {
+    getState: () => ({ switchToSession: mocks.switchToSession }),
+  },
+}))
+
+vi.mock('@/stores/session-list-store', () => ({
+  useSessionListStore: {
+    getState: () => ({ load: mocks.load }),
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}))
+
+import {
+  clearPendingSessionDeeplink,
+  completePendingSessionDeeplink,
+  openSessionFromDeeplink,
+  readPendingSessionDeeplink,
+  stashPendingSessionDeeplink,
+} from '@/lib/open-session-deeplink'
+
+describe('openSessionFromDeeplink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mocks.session = { user: { id: 'user-1', is_anonymous: false } }
+    mocks.teamId = TEAM_A
+    mocks.joinSession.mockResolvedValue({ team_id: TEAM_A })
+    mocks.enterTeam.mockResolvedValue(undefined)
+    mocks.switchToSession.mockResolvedValue(undefined)
+    mocks.load.mockResolvedValue(undefined)
+  })
+
+  it('stashes the session when auth is not ready', async () => {
+    mocks.session = null
+    const ok = await openSessionFromDeeplink(UUID)
+    expect(ok).toBe(false)
+    expect(readPendingSessionDeeplink()?.sessionId).toBe(UUID)
+    expect(mocks.joinSession).not.toHaveBeenCalled()
+  })
+
+  it('navigates immediately when the session is in the active team', async () => {
+    const ok = await openSessionFromDeeplink(UUID)
+    expect(ok).toBe(true)
+    expect(mocks.joinSession).toHaveBeenCalledWith(UUID)
+    expect(mocks.enterTeam).not.toHaveBeenCalled()
+    expect(mocks.switchToSession).toHaveBeenCalledWith(UUID)
+    expect(mocks.load).toHaveBeenCalled()
+    expect(readPendingSessionDeeplink()).toBeNull()
+  })
+
+  it('defers navigation across team switches', async () => {
+    mocks.joinSession.mockResolvedValue({ team_id: TEAM_B })
+    mocks.teamId = TEAM_A
+
+    const ok = await openSessionFromDeeplink(UUID)
+    expect(ok).toBe(true)
+    expect(mocks.enterTeam).toHaveBeenCalledWith(TEAM_B)
+    expect(mocks.switchToSession).not.toHaveBeenCalled()
+    expect(readPendingSessionDeeplink()).toEqual({ sessionId: UUID, teamId: TEAM_B })
+  })
+})
+
+describe('completePendingSessionDeeplink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mocks.session = { user: { id: 'user-1', is_anonymous: false } }
+    mocks.teamId = TEAM_B
+    mocks.switchToSession.mockResolvedValue(undefined)
+    mocks.load.mockResolvedValue(undefined)
+  })
+
+  it('opens the stashed session once the target team is active', async () => {
+    stashPendingSessionDeeplink(UUID, TEAM_B)
+    const ok = await completePendingSessionDeeplink()
+    expect(ok).toBe(true)
+    expect(mocks.switchToSession).toHaveBeenCalledWith(UUID)
+    expect(readPendingSessionDeeplink()).toBeNull()
+  })
+
+  it('waits until the active team matches the pending target team', async () => {
+    stashPendingSessionDeeplink(UUID, TEAM_B)
+    mocks.teamId = TEAM_A
+    const ok = await completePendingSessionDeeplink()
+    expect(ok).toBe(false)
+    expect(mocks.switchToSession).not.toHaveBeenCalled()
+    expect(readPendingSessionDeeplink()?.sessionId).toBe(UUID)
+  })
+})
+
+describe('pending session deeplink storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('round-trips through localStorage', () => {
+    stashPendingSessionDeeplink(UUID, TEAM_A)
+    expect(readPendingSessionDeeplink()).toEqual({ sessionId: UUID, teamId: TEAM_A })
+    clearPendingSessionDeeplink()
+    expect(readPendingSessionDeeplink()).toBeNull()
+  })
+})

--- a/packages/app/src/lib/open-session-deeplink.ts
+++ b/packages/app/src/lib/open-session-deeplink.ts
@@ -1,0 +1,130 @@
+import { getBackend } from '@/lib/backend'
+import { CloudApiError } from '@/lib/backend/cloud-api/http'
+import { useAuthStore } from '@/stores/auth-store'
+import { useCurrentTeamStore } from '@/stores/current-team'
+import { useSessionListStore } from '@/stores/session-list-store'
+import { useUIStore } from '@/stores/ui'
+import i18n from '@/lib/i18n'
+import { toast } from 'sonner'
+
+const PENDING_SESSION_DEEPLINK_KEY = 'teamclaw.pendingSessionDeeplink'
+
+export type PendingSessionDeeplink = {
+  sessionId: string
+  teamId: string | null
+}
+
+function readPendingRaw(): PendingSessionDeeplink | null {
+  try {
+    const raw = localStorage.getItem(PENDING_SESSION_DEEPLINK_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as PendingSessionDeeplink
+    if (!parsed?.sessionId) return null
+    return {
+      sessionId: parsed.sessionId,
+      teamId: parsed.teamId ?? null,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function readPendingSessionDeeplink(): PendingSessionDeeplink | null {
+  return readPendingRaw()
+}
+
+export function stashPendingSessionDeeplink(
+  sessionId: string,
+  teamId: string | null = null,
+): void {
+  const payload: PendingSessionDeeplink = { sessionId, teamId }
+  try {
+    localStorage.setItem(PENDING_SESSION_DEEPLINK_KEY, JSON.stringify(payload))
+  } catch {
+    // Private mode / quota — in-memory only via zustand-less module state is
+    // enough for hot delivery; cold launch just retries from getCurrent().
+  }
+}
+
+export function clearPendingSessionDeeplink(): void {
+  try {
+    localStorage.removeItem(PENDING_SESSION_DEEPLINK_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+function isAuthedRealUser(): boolean {
+  const session = useAuthStore.getState().session
+  return Boolean(session && !session.user?.is_anonymous)
+}
+
+async function navigateToSession(sessionId: string): Promise<void> {
+  await useUIStore.getState().switchToSession(sessionId)
+  await useSessionListStore.getState().load()
+  clearPendingSessionDeeplink()
+}
+
+function reportOpenFailure(err: unknown): void {
+  if (err instanceof CloudApiError && err.status === 403) {
+    toast.error(i18n.t('session.deeplink.noAccess', '无权访问该会话'))
+  } else if (err instanceof CloudApiError && err.status === 404) {
+    toast.error(i18n.t('session.deeplink.notFound', '会话不存在或已被删除'))
+  } else {
+    toast.error(i18n.t('session.deeplink.openFailed', '打开会话失败'))
+  }
+  console.error('[session-deeplink] open failed', err)
+}
+
+/**
+ * Join the linked session and navigate to it. When the session lives in a
+ * different team, activate that team first and defer navigation until the
+ * chat-state reset triggered by the org switch has finished — otherwise
+ * resetClientChatState clears the selection we just set.
+ */
+export async function openSessionFromDeeplink(sessionId: string): Promise<boolean> {
+  if (!isAuthedRealUser()) {
+    stashPendingSessionDeeplink(sessionId)
+    return false
+  }
+
+  try {
+    const session = await getBackend().sessions.joinSession(sessionId)
+    const teamId = session.team_id ?? null
+    const currentTeamId = useCurrentTeamStore.getState().team?.id ?? null
+
+    if (teamId && teamId !== currentTeamId) {
+      stashPendingSessionDeeplink(sessionId, teamId)
+      await useCurrentTeamStore.getState().enterTeam(teamId)
+      return true
+    }
+
+    await navigateToSession(sessionId)
+    return true
+  } catch (err) {
+    clearPendingSessionDeeplink()
+    reportOpenFailure(err)
+    return false
+  }
+}
+
+/**
+ * Finish a cross-team deeplink after enterTeam() and resetClientChatState().
+ */
+export async function completePendingSessionDeeplink(): Promise<boolean> {
+  const pending = readPendingSessionDeeplink()
+  if (!pending) return false
+  if (!isAuthedRealUser()) return false
+
+  const currentTeamId = useCurrentTeamStore.getState().team?.id ?? null
+  if (pending.teamId && pending.teamId !== currentTeamId) return false
+
+  try {
+    await navigateToSession(pending.sessionId)
+    return true
+  } catch (err) {
+    clearPendingSessionDeeplink()
+    reportOpenFailure(err)
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- Fix `teamclaw://session/<uuid>` opening an empty chat when the linked session lives in another team by deferring navigation until `enterTeam()` and `resetClientChatState()` finish.
- Stash pending session deeplinks on cold start and resume them once auth hydrates, so launch-time links are no longer dropped.
- Extract deeplink open/resume logic into `open-session-deeplink.ts` with unit tests.

## Test plan
- [x] `pnpm exec vitest run src/__tests__/open-session-deeplink.test.ts` (packages/app)
- [ ] Open a session deeplink in the same team while the app is already running; verify messages load.
- [ ] Open a session deeplink for a session in another team; verify team switch completes and messages load.
- [ ] Cold-launch the desktop app via `teamclaw://session/<uuid>` while signed in; verify the target session opens with history visible.


Made with [Cursor](https://cursor.com)