### PR TITLE
fix(fc): document MQTT_PUBLIC_* and refuse to deploy without a public broker

### DIFF
--- a/services/fc/.env.example
+++ b/services/fc/.env.example
@@ -24,7 +24,24 @@ REGION=cn-shenzhen
 ENDPOINT=https://oss-cn-shenzhen.aliyuncs.com
 
 # --- MQTT ---
+# Two different things, easy to confuse:
+#
+# MQTT_BROKER_URL is how *FC itself* reaches the broker (the inbox publisher in
+# push-deps.ts). It is typically an internal address and is NEVER sent to
+# clients.
+#
+# MQTT_PUBLIC_BROKER_URL is the address handed to clients by
+# GET /v1/config/bootstrap. Leaving it empty makes buildMqttConfig() fall back
+# to MQTT_BROKER_URL — an internal address clients cannot reach — or, if that
+# is empty too, omit the whole `mqtt` block while still answering 200. That
+# silent shape took real-time sync down for a day (issue #634): clients get no
+# broker and nothing reports an error. Always set it to the PUBLIC hostname.
 MQTT_BROKER_URL=
+MQTT_PUBLIC_BROKER_URL=
+# Raw-TCP address for clients whose MQTT stack can't do WebSocket (iOS
+# CocoaMQTT, Expo). Only needed when MQTT_PUBLIC_BROKER_URL is a ws(s):// URL —
+# with an mqtt:// public broker those clients already use it directly.
+MQTT_PUBLIC_TCP_BROKER_URL=
 
 # --- LiteLLM (optional) ---
 LITELLM_URL=

--- a/services/fc/deploy-aliyun-fc.sh
+++ b/services/fc/deploy-aliyun-fc.sh
@@ -72,6 +72,34 @@ for _v in APNS_PRIVATE_KEY_P8 APNS_KEY_ID APNS_TEAM_ID APNS_TOPIC APNS_ENV \
 done
 [ -n "$_backfilled" ] && echo "NOTE: backfilled empty test vars with placeholders:$_backfilled"
 
+# MQTT_PUBLIC_BROKER_URL is deliberately NOT in the backfill list above, and is
+# checked instead. It is the address `GET /v1/config/bootstrap` hands to
+# clients, and an empty one is the single worst failure this script can ship:
+# buildMqttConfig() falls back to MQTT_BROKER_URL (an internal address clients
+# cannot reach) or omits the `mqtt` block entirely — while still answering 200.
+# Every client then has no broker, and nothing anywhere logs an error. That is
+# how real-time sync went down for a day in issue #634.
+#
+# A placeholder would be worse than nothing here, so refuse instead. Deploys
+# that genuinely don't need MQTT (pure smoke tests) opt out explicitly.
+if [ -z "${MQTT_PUBLIC_BROKER_URL:-}" ] && [ "${ALLOW_EMPTY_MQTT:-}" != "1" ]; then
+  echo "ERROR: MQTT_PUBLIC_BROKER_URL is empty in $ENV_FILE." >&2
+  echo "       This is the broker address delivered to clients. Deploying" >&2
+  echo "       without it produces a bootstrap that answers 200 with no \`mqtt\`" >&2
+  echo "       block, silently leaving every client with no broker (#634)." >&2
+  echo "" >&2
+  echo "       Set it to the PUBLIC broker hostname, e.g." >&2
+  echo "         MQTT_PUBLIC_BROKER_URL=mqtt://mqtt.example.com:1883" >&2
+  echo "" >&2
+  echo "       For a smoke test that genuinely does not need MQTT:" >&2
+  echo "         ALLOW_EMPTY_MQTT=1 ./deploy-aliyun-fc.sh $FUNCTION_NAME $ENV_FILE" >&2
+  exit 1
+fi
+if [ -z "${MQTT_PUBLIC_BROKER_URL:-}" ]; then
+  echo "WARN: deploying with an empty MQTT_PUBLIC_BROKER_URL (ALLOW_EMPTY_MQTT=1)."
+  echo "      Clients will receive no broker from /v1/config/bootstrap."
+fi
+
 # Tell s.yaml which function to deploy.
 export FC_FUNCTION_NAME="$FUNCTION_NAME"
 export BACKEND_KIND="${BACKEND_KIND:-supabase}"


### PR DESCRIPTION
Follow-up to #638. Closes the **config-source** half of #634 — the half that explains why "没人记得改过它".

## Problem

`services/fc/.env.example` listed only:

```sh
# --- MQTT ---
MQTT_BROKER_URL=
```

Copy that to `.env.*.local`, fill it in, run `deploy-aliyun-fc.sh`, and you ship a function with **no `MQTT_PUBLIC_BROKER_URL` at all** — not forgotten, just never present in the file to begin with. `s.yaml` resolves `${env('MQTT_PUBLIC_BROKER_URL', '')}` to empty and the deploy succeeds silently.

The two variables are easy to confuse and do completely different jobs:

| | Purpose | Sent to clients? |
|---|---|---|
| `MQTT_BROKER_URL` | How **FC itself** reaches the broker (inbox publisher in `push-deps.ts`) — typically internal | **No** |
| `MQTT_PUBLIC_BROKER_URL` | What `/v1/config/bootstrap` **hands to clients** | **Yes** |

With the public one empty, `buildMqttConfig()` falls back to the internal address clients cannot reach, or omits the `mqtt` block entirely — **and still answers 200**. Every client ends up with no broker and nothing anywhere logs an error.

## Changes

1. **`.env.example`** — add `MQTT_PUBLIC_BROKER_URL` and `MQTT_PUBLIC_TCP_BROKER_URL`, with the distinction above spelled out inline so the next person copying this file cannot miss it.

2. **`deploy-aliyun-fc.sh`** — refuse to deploy when `MQTT_PUBLIC_BROKER_URL` is empty, with an error that names the variable, shows the expected form, and explains the consequence.

This is the last unguarded path to a "answers 200 without an address" deployment. #638 added the same gate for self-host (`run-e2e.sh` asserts bootstrap returns `mqtt.url`); the Alibaba FC path had nothing.

## Deliberate choices

- **Not added to the placeholder backfill list.** The script already backfills empty `APNS_*` / `MQTT_USERNAME` / `MQTT_PASSWORD` with `test-placeholder` for smoke deploys. A placeholder *broker address* would be strictly worse than a refused deploy — it produces exactly the "looks configured, isn't reachable" state this is meant to prevent.
- **Opt-out rather than hard block.** This script is for non-production test functions, where a deploy genuinely may not need MQTT. `ALLOW_EMPTY_MQTT=1` matches the existing `FORCE=1` / `RUN_MIGRATIONS=1` style, and still prints a warning.

## Verification

`bash -n` clean. Guard exercised in all three states:

```
== empty, no opt-out:          ERROR: refused  (exit 1)
== empty + ALLOW_EMPTY_MQTT=1: WARN: proceeding empty  -> continues
== set:                        -> continues to deploy
```

Not verified against a real `s deploy` — that needs Aliyun credentials and would deploy a function.

## Note on the live `teamclaw-api`

This PR does not fix the running deployment. It makes the next deploy of it *correct by construction* — the operator fills `MQTT_PUBLIC_BROKER_URL` into their env file and runs the script, which now refuses if they don't. #634 §9 item 1 stays open until that deploy happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)