### PR TITLE
feat(actors): agent hard delete with authz + pi install fix

### DIFF
--- a/apps/daemon/src/pi_install/mod.rs
+++ b/apps/daemon/src/pi_install/mod.rs
@@ -1,9 +1,9 @@
 //! pi coding-agent discovery + install for amuxd (parity with `opencode_install`).
 //!
 //! `pi.lock.json` records the MINIMUM pi version this build requires. pi is
-//! installed via npm (`npm install -g @earendil-works/pi`, bun fallback); its
-//! own installer places a launcher at `~/.pi/bin/pi`, which amuxd resolves by
-//! absolute path so background services find it without a login PATH.
+//! installed via npm (`npm install -g @earendil-works/pi-coding-agent@<lock>`,
+//! bun fallback); the global `pi` binary is resolved via `~/.pi/bin/pi` when
+//! present, otherwise `pi` on PATH (including `~/.npm-global/bin`).
 
 use serde::{Deserialize, Serialize};
 
@@ -99,7 +99,13 @@ fn has_command(cmd: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Install or upgrade pi via `npm install -g @earendil-works/pi`
+const PI_NPM_PKG: &str = "@earendil-works/pi-coding-agent";
+
+fn npm_package_spec(min_version: &str) -> String {
+    format!("{PI_NPM_PKG}@{min_version}")
+}
+
+/// Install or upgrade pi via `npm install -g @earendil-works/pi-coding-agent@<lock>`
 /// (falls back to `bun add -g` when npm is absent).
 pub fn run_install(force: bool) -> anyhow::Result<()> {
     let want = required_version();
@@ -122,17 +128,18 @@ pub fn run_install(force: bool) -> anyhow::Result<()> {
         }
     }
 
-    let (cmd, args): (&str, Vec<&str>) = if has_command("npm") {
-        ("npm", vec!["install", "-g", "@earendil-works/pi"])
+    let pkg = npm_package_spec(&want);
+    let (cmd, args): (&str, Vec<String>) = if has_command("npm") {
+        ("npm", vec!["install".into(), "-g".into(), pkg])
     } else if has_command("bun") {
-        ("bun", vec!["add", "-g", "@earendil-works/pi"])
+        ("bun", vec!["add".into(), "-g".into(), pkg])
     } else {
         anyhow::bail!("neither npm nor bun found; install Node.js or Bun first");
     };
 
     progress("install", &format!("running {cmd} {}", args.join(" ")));
     let output = std::process::Command::new(cmd)
-        .args(&args)
+        .args(args.iter().map(String::as_str))
         .output()
         .map_err(|e| anyhow::anyhow!("failed to run {cmd}: {e}"))?;
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -160,6 +167,14 @@ mod tests {
         let v = required_version();
         assert!(!v.starts_with('v'), "got {v}");
         assert!(version_ge(&v, "0.81.1"), "lock too old: {v}");
+    }
+
+    #[test]
+    fn npm_package_spec_uses_pi_coding_agent() {
+        assert_eq!(
+            npm_package_spec("0.81.1"),
+            "@earendil-works/pi-coding-agent@0.81.1"
+        );
     }
 
     #[test]

--- a/apps/desktop/src/local_cache/store.rs
+++ b/apps/desktop/src/local_cache/store.rs
@@ -254,6 +254,9 @@ pub struct ActorRow {
     pub team_role: Option<String>,
     #[serde(default)]
     pub agent_visibility: Option<String>,
+    /// Agent owner member actor id — for personal-agent delete gating on cache first paint.
+    #[serde(default)]
+    pub owner_member_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -477,7 +480,8 @@ impl LocalCacheStore {
                 deleted_at    TEXT,
                 synced_at     TEXT NOT NULL,
                 team_role     TEXT,
-                agent_visibility TEXT
+                agent_visibility TEXT,
+                owner_member_id TEXT
             )",
             (),
         )
@@ -491,6 +495,9 @@ impl LocalCacheStore {
             .await
             .ok();
         conn.execute("ALTER TABLE actor ADD COLUMN agent_visibility TEXT", ())
+            .await
+            .ok();
+        conn.execute("ALTER TABLE actor ADD COLUMN owner_member_id TEXT", ())
             .await
             .ok();
 
@@ -817,8 +824,8 @@ impl LocalCacheStore {
                 "INSERT INTO actor
                     (id, team_id, actor_type, display_name, avatar_url, member_status,
                      agent_status, last_active_at, metadata_json, created_at, updated_at, deleted_at, synced_at,
-                     team_role, agent_visibility)
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)
+                     team_role, agent_visibility, owner_member_id)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)
                  ON CONFLICT(id) DO UPDATE SET
                     team_id       = excluded.team_id,
                     actor_type    = excluded.actor_type,
@@ -833,7 +840,8 @@ impl LocalCacheStore {
                     deleted_at    = excluded.deleted_at,
                     synced_at     = excluded.synced_at,
                     team_role     = excluded.team_role,
-                    agent_visibility = excluded.agent_visibility
+                    agent_visibility = excluded.agent_visibility,
+                    owner_member_id = excluded.owner_member_id
                  WHERE excluded.updated_at >= actor.updated_at",
                 params![
                     r.id.clone(),
@@ -850,7 +858,8 @@ impl LocalCacheStore {
                     opt_val(&r.deleted_at),
                     r.synced_at.clone(),
                     opt_val(&r.team_role),
-                    opt_val(&r.agent_visibility)
+                    opt_val(&r.agent_visibility),
+                    opt_val(&r.owner_member_id)
                 ],
             )
             .await
@@ -868,12 +877,12 @@ impl LocalCacheStore {
         let sql = if include_deleted {
             "SELECT id, team_id, actor_type, display_name, avatar_url, member_status,
                     agent_status, last_active_at, metadata_json, created_at, updated_at, deleted_at, synced_at,
-                    team_role, agent_visibility
+                    team_role, agent_visibility, owner_member_id
              FROM actor WHERE team_id = ?1"
         } else {
             "SELECT id, team_id, actor_type, display_name, avatar_url, member_status,
                     agent_status, last_active_at, metadata_json, created_at, updated_at, deleted_at, synced_at,
-                    team_role, agent_visibility
+                    team_role, agent_visibility, owner_member_id
              FROM actor WHERE team_id = ?1 AND deleted_at IS NULL"
         };
         let mut rows = conn
@@ -902,6 +911,7 @@ impl LocalCacheStore {
                 synced_at: row.get::<String>(12).unwrap_or_default(),
                 team_role: row.get::<String>(13).ok().filter(|s| !s.is_empty()),
                 agent_visibility: row.get::<String>(14).ok().filter(|s| !s.is_empty()),
+                owner_member_id: row.get::<String>(15).ok().filter(|s| !s.is_empty()),
             });
         }
         Ok(result)
@@ -924,7 +934,7 @@ impl LocalCacheStore {
         let sql = format!(
             "SELECT id, team_id, actor_type, display_name, avatar_url, member_status,
                     agent_status, last_active_at, metadata_json, created_at, updated_at, deleted_at, synced_at,
-                    team_role, agent_visibility
+                    team_role, agent_visibility, owner_member_id
              FROM actor WHERE id IN ({}) AND deleted_at IS NULL",
             placeholders
         );
@@ -955,6 +965,7 @@ impl LocalCacheStore {
                 synced_at: row.get::<String>(12).unwrap_or_default(),
                 team_role: row.get::<String>(13).ok().filter(|s| !s.is_empty()),
                 agent_visibility: row.get::<String>(14).ok().filter(|s| !s.is_empty()),
+                owner_member_id: row.get::<String>(15).ok().filter(|s| !s.is_empty()),
             });
         }
         Ok(result)
@@ -2213,6 +2224,7 @@ mod tests {
             synced_at: "2024-01-01T00:00:00Z".to_string(),
             team_role: None,
             agent_visibility: None,
+            owner_member_id: None,
         }
     }
 
@@ -2232,14 +2244,17 @@ mod tests {
         let mut a = actor("a1", "team1", "2024-01-01T00:00:00Z");
         a.team_role = Some("owner".to_string());
         a.agent_visibility = Some("personal".to_string());
+        a.owner_member_id = Some("member-1".to_string());
         store.actor_upsert_batch(&[a]).await.unwrap();
         let loaded = store.actor_load_team("team1", false).await.unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].team_role.as_deref(), Some("owner"));
         assert_eq!(loaded[0].agent_visibility.as_deref(), Some("personal"));
+        assert_eq!(loaded[0].owner_member_id.as_deref(), Some("member-1"));
         // Same fields must survive the by-ids load path too.
         let by_ids = store.actor_load_by_ids(&["a1".to_string()]).await.unwrap();
         assert_eq!(by_ids[0].agent_visibility.as_deref(), Some("personal"));
+        assert_eq!(by_ids[0].owner_member_id.as_deref(), Some("member-1"));
     }
 
     #[tokio::test]

--- a/docs/openapi/teamclaw-api.v1.yaml
+++ b/docs/openapi/teamclaw-api.v1.yaml
@@ -353,6 +353,11 @@ paths:
     delete:
       operationId: removeTeamActor
       summary: Remove team actor
+      description: |
+        Hard-deletes a team actor. Members require team owner/admin.
+        Personal agents require the owning member (`agentOwnerMemberId`).
+        Team agents require team owner/admin. May return 409 when foreign-key
+        references block deletion (`agent_delete_blocked_by_*`).
       tags: [Teams]
       parameters:
         - $ref: "#/components/parameters/TeamId"
@@ -366,6 +371,10 @@ paths:
         "204":
           description: OK
         "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "409":
           $ref: "#/components/responses/Error"
   /v1/sessions:
     get:
@@ -3436,6 +3445,9 @@ paths:
     delete:
       operationId: removeTeamActorScoped
       summary: Remove team actor (teamId + actorId path)
+      description: |
+        Same as DELETE /v1/teams/{teamId}/members/{actorId}. Personal agents
+        require the owning member; team agents require team owner/admin.
       tags: [Teams]
       parameters:
         - $ref: "#/components/parameters/TeamId"
@@ -3447,6 +3459,10 @@ paths:
         "204":
           description: Removed
         "401":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "409":
           $ref: "#/components/responses/Error"
   /v1/teams/{teamId}/workspace-git-config:
     get:
@@ -4636,6 +4652,12 @@ components:
             - string
             - "null"
           enum: [team, personal, null]
+        agentOwnerMemberId:
+          description: Owner member actor id for agents. Null for members/external.
+          type:
+            - string
+            - "null"
+          format: uuid
         metadata:
           type:
             - object

--- a/packages/app/src/components/sidebar/ActorContextMenu.tsx
+++ b/packages/app/src/components/sidebar/ActorContextMenu.tsx
@@ -53,7 +53,7 @@ export function ActorContextMenu({
   const teamId = useCurrentTeamStore((s) => s.team?.id ?? null)
   const currentMemberId = useCurrentTeamStore((s) => s.currentMember?.id ?? null)
   const teamPermissions = useTeamPermissions()
-  const canRemove = canRemoveTeamActor(teamPermissions, actor.id, currentMemberId)
+  const canRemove = canRemoveTeamActor(teamPermissions, actor, currentMemberId)
   const setDefaultAgent = useMemberPreferencesStore((s) => s.setDefaultAgent)
   const onToggleDefault = React.useCallback(() => {
     if (!teamId) return

--- a/packages/app/src/components/sidebar/ActorDetailDialog.tsx
+++ b/packages/app/src/components/sidebar/ActorDetailDialog.tsx
@@ -113,7 +113,7 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
   if (!displayActor) return null
 
   const canRemove = teamId
-    ? canRemoveTeamActor(teamPermissions, displayActor.id, currentMemberId)
+    ? canRemoveTeamActor(teamPermissions, displayActor, currentMemberId)
     : false
 
   const confirmRemove = async () => {

--- a/packages/app/src/components/sidebar/LocalDaemonRow.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonRow.tsx
@@ -399,7 +399,7 @@ export function LocalDaemonRow({
   const currentMemberId = currentMember?.id ?? null
   const teamPermissions = useTeamPermissions()
   const canRemove = actor
-    ? canRemoveTeamActor(teamPermissions, actor.id, currentMemberId)
+    ? canRemoveTeamActor(teamPermissions, actor, currentMemberId)
     : false
 
   const sheetOpen = useUIStore((s) => s.localDaemonSheetOpen)

--- a/packages/app/src/lib/__tests__/actor-remove-error.test.ts
+++ b/packages/app/src/lib/__tests__/actor-remove-error.test.ts
@@ -16,6 +16,30 @@ describe('formatActorRemoveError', () => {
     expect(formatActorRemoveError('cannot remove your own actor', t)).toMatch(/yourself/i)
   })
 
+  it('maps personal-agent owner-only error', () => {
+    expect(formatActorRemoveError('remove_team_actor requires agent owner for personal agents', t)).toMatch(/owner can remove a personal agent/i)
+  })
+
+  it('maps team-agent admin-only error', () => {
+    expect(formatActorRemoveError('remove_team_actor requires owner or admin for team agents', t)).toMatch(/remove team agents/i)
+  })
+
+  it('maps idea-activity FK blocker', () => {
+    expect(formatActorRemoveError('agent_delete_blocked_by_idea_activities', t)).toMatch(/idea activity/i)
+  })
+
+  it('maps apps FK blocker', () => {
+    expect(formatActorRemoveError('agent_delete_blocked_by_apps', t)).toMatch(/related apps/i)
+  })
+
+  it('maps files FK blocker', () => {
+    expect(formatActorRemoveError('agent_delete_blocked_by_files', t)).toMatch(/related files/i)
+  })
+
+  it('maps generic reference blocker', () => {
+    expect(formatActorRemoveError('actor_delete_blocked_by_references', t)).toMatch(/referenced elsewhere/i)
+  })
+
   it('maps FK owner_member_id error', () => {
     expect(formatActorRemoveError('violates foreign key constraint "agents_owner_member_id_fkey"', t)).toMatch(/owns one or more agents/i)
   })

--- a/packages/app/src/lib/__tests__/team-permissions.test.ts
+++ b/packages/app/src/lib/__tests__/team-permissions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { canRemoveTeamActor, permissionsForRole } from '../team-permissions'
+import type { RemovableActorTarget } from '../team-permissions'
 
 describe('permissionsForRole', () => {
   it('owner can do everything', () => {
@@ -34,19 +35,95 @@ describe('canRemoveTeamActor', () => {
   const adminPerms = permissionsForRole('admin')
   const memberPerms = permissionsForRole('member')
 
-  it('allows admin/owner to remove another actor', () => {
-    expect(canRemoveTeamActor(adminPerms, 'actor-b', 'actor-a')).toBe(true)
+  const memberTarget: RemovableActorTarget = {
+    id: 'actor-b',
+    actor_type: 'member',
+  }
+
+  it('allows admin/owner to remove another member', () => {
+    expect(canRemoveTeamActor(adminPerms, memberTarget, 'actor-a')).toBe(true)
   })
 
-  it('denies non-managers', () => {
-    expect(canRemoveTeamActor(memberPerms, 'actor-b', 'actor-a')).toBe(false)
+  it('denies non-managers removing members', () => {
+    expect(canRemoveTeamActor(memberPerms, memberTarget, 'actor-a')).toBe(false)
   })
 
   it('denies removing self', () => {
-    expect(canRemoveTeamActor(adminPerms, 'actor-a', 'actor-a')).toBe(false)
+    expect(canRemoveTeamActor(adminPerms, { ...memberTarget, id: 'actor-a' }, 'actor-a')).toBe(false)
   })
 
   it('denies when current member is unknown', () => {
-    expect(canRemoveTeamActor(adminPerms, 'actor-b', null)).toBe(false)
+    expect(canRemoveTeamActor(adminPerms, memberTarget, null)).toBe(false)
+  })
+
+  it('allows personal agent owner to remove their agent', () => {
+    const personalAgent: RemovableActorTarget = {
+      id: 'agent-1',
+      actor_type: 'agent',
+      visibility: 'personal',
+      owner_member_id: 'actor-a',
+    }
+    expect(canRemoveTeamActor(memberPerms, personalAgent, 'actor-a')).toBe(true)
+  })
+
+  it('denies non-owner removing personal agent', () => {
+    const personalAgent: RemovableActorTarget = {
+      id: 'agent-1',
+      actor_type: 'agent',
+      visibility: 'personal',
+      owner_member_id: 'actor-b',
+    }
+    expect(canRemoveTeamActor(memberPerms, personalAgent, 'actor-a')).toBe(false)
+  })
+
+  it('allows admin to remove team agent', () => {
+    const teamAgent: RemovableActorTarget = {
+      id: 'agent-1',
+      actor_type: 'agent',
+      visibility: 'team',
+      owner_member_id: 'actor-b',
+    }
+    expect(canRemoveTeamActor(adminPerms, teamAgent, 'actor-a')).toBe(true)
+  })
+
+  it('denies member removing team agent', () => {
+    const teamAgent: RemovableActorTarget = {
+      id: 'agent-1',
+      actor_type: 'agent',
+      visibility: 'team',
+      owner_member_id: 'actor-b',
+    }
+    expect(canRemoveTeamActor(memberPerms, teamAgent, 'actor-a')).toBe(false)
+  })
+
+  it('allows owner to remove team agent', () => {
+    const teamAgent: RemovableActorTarget = {
+      id: 'agent-1',
+      actor_type: 'agent',
+      visibility: 'team',
+      owner_member_id: 'actor-b',
+    }
+    expect(canRemoveTeamActor(permissionsForRole('owner'), teamAgent, 'actor-a')).toBe(true)
+  })
+
+  it('requires owner_member_id for personal agent delete', () => {
+    const personalAgent: RemovableActorTarget = {
+      id: 'agent-1',
+      actor_type: 'agent',
+      visibility: 'personal',
+      owner_member_id: null,
+    }
+    expect(canRemoveTeamActor(memberPerms, personalAgent, 'actor-a')).toBe(false)
+  })
+
+  it('denies delete when agent visibility is unknown (cold cache)', () => {
+    const agent: RemovableActorTarget = {
+      id: 'agent-1',
+      actor_type: 'agent',
+      visibility: null,
+      owner_member_id: 'actor-a',
+    }
+    expect(canRemoveTeamActor(adminPerms, agent, 'actor-a')).toBe(false)
+    expect(canRemoveTeamActor(memberPerms, agent, 'actor-a')).toBe(false)
   })
 })

--- a/packages/app/src/lib/actor-remove-error.ts
+++ b/packages/app/src/lib/actor-remove-error.ts
@@ -11,10 +11,46 @@ export function formatActorRemoveError(raw: string, t: TFunction): string {
   if (/cannot remove your own actor/i.test(raw)) {
     return t('actors.removeFailed.self', 'You cannot remove yourself from the team.')
   }
+  if (/requires agent owner for personal agents/i.test(raw)) {
+    return t(
+      'actors.removeFailed.personalAgentOwner',
+      'Only the owner can remove a personal agent.',
+    )
+  }
+  if (/requires owner or admin for team agents/i.test(raw)) {
+    return t(
+      'actors.removeFailed.teamAgentAdmin',
+      'Only team owners and admins can remove team agents.',
+    )
+  }
   if (/requires owner or admin|remove_team_actor requires owner or admin/i.test(raw)) {
     return t(
       'actors.removeFailed.forbidden',
       'Only team owners and admins can remove members.',
+    )
+  }
+  if (/agent_delete_blocked_by_idea_activities/i.test(raw)) {
+    return t(
+      'actors.removeFailed.blockedByIdeas',
+      'This agent still has related idea activity. Resolve those references first.',
+    )
+  }
+  if (/agent_delete_blocked_by_apps/i.test(raw)) {
+    return t(
+      'actors.removeFailed.blockedByApps',
+      'This agent still has related apps. Resolve those references first.',
+    )
+  }
+  if (/agent_delete_blocked_by_files/i.test(raw)) {
+    return t(
+      'actors.removeFailed.blockedByFiles',
+      'This agent still has related files. Resolve those references first.',
+    )
+  }
+  if (/actor_delete_blocked_by_references/i.test(raw)) {
+    return t(
+      'actors.removeFailed.blockedByReferences',
+      'This actor is still referenced elsewhere. Resolve those references first.',
     )
   }
   if (/agents_owner_member_id_fkey|owner_member_id/i.test(raw)) {

--- a/packages/app/src/lib/backend/cloud-api/__tests__/actors.test.ts
+++ b/packages/app/src/lib/backend/cloud-api/__tests__/actors.test.ts
@@ -41,6 +41,18 @@ function mockClient(responses: Record<string, unknown>): MockClient {
 const cloudActor = { id: "actor-1", teamId: "team-1", kind: "member", displayName: "Alice", avatarUrl: null };
 
 describe("actors module", () => {
+  it("listActorDirectory maps agentOwnerMemberId", async () => {
+    const client = mockClient({
+      "GET /v1/teams/team-1/actors?limit=500": {
+        items: [{ ...cloudActor, kind: "agent", visibility: "personal", agentOwnerMemberId: "owner-1" }],
+        nextCursor: null,
+      },
+    });
+    const mod = createActorsModule(client);
+    const out = await mod.listActorDirectory("team-1");
+    expect(out[0].agent_owner_member_id).toBe("owner-1");
+  });
+
   it("listActorDirectory calls /v1/teams/:teamId/actors and maps fields", async () => {
     const client = mockClient({ "GET /v1/teams/team-1/actors?limit=500": { items: [cloudActor], nextCursor: null } });
     const mod = createActorsModule(client);

--- a/packages/app/src/lib/backend/cloud-api/actors.ts
+++ b/packages/app/src/lib/backend/cloud-api/actors.ts
@@ -22,6 +22,7 @@ type CloudActor = {
   defaultAgentType?: string | null;
   defaultWorkspaceId?: string | null;
   visibility?: string | null;
+  agentOwnerMemberId?: string | null;
   email?: string | null;
   phone?: string | null;
   lastActiveAt?: string | null;
@@ -65,6 +66,7 @@ function mapActor(row: CloudActor): ActorDirectoryEntry {
     default_agent_type: row.defaultAgentType ?? null,
     default_workspace_id: row.defaultWorkspaceId ?? null,
     visibility: row.visibility ?? null,
+    agent_owner_member_id: row.agentOwnerMemberId ?? null,
     email: row.email ?? null,
     phone: row.phone ?? null,
     last_active_at: row.lastActiveAt ?? null,

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -575,6 +575,8 @@ export interface ActorDirectoryEntry {
   default_agent_type?: string | null;
   default_workspace_id?: string | null;
   visibility?: string | null;
+  /** Agent owner member actor id — null for members/external. */
+  agent_owner_member_id?: string | null;
   // Member contact — null for agents/external and anonymous members.
   email?: string | null;
   phone?: string | null;

--- a/packages/app/src/lib/local-cache.ts
+++ b/packages/app/src/lib/local-cache.ts
@@ -52,6 +52,7 @@ export type ActorRow = {
   // list's first offline paint matches the network paint — no subtitle pop-in.
   teamRole?: string | null;
   agentVisibility?: string | null;
+  ownerMemberId?: string | null;
 };
 
 export type SessionRow = {

--- a/packages/app/src/lib/team-permissions.ts
+++ b/packages/app/src/lib/team-permissions.ts
@@ -13,15 +13,34 @@ export interface TeamPermissions {
   canEditFiles: boolean
 }
 
-/** Whether the signed-in member may remove another actor from the team (server: owner/admin, not self). */
+export interface RemovableActorTarget {
+  id: string
+  actor_type?: 'member' | 'agent' | string
+  visibility?: string | null
+  owner_member_id?: string | null
+}
+
+/** Whether the signed-in member may remove another actor from the team. */
 export function canRemoveTeamActor(
   permissions: Pick<TeamPermissions, 'canManageTeam'>,
-  targetActorId: string,
+  target: RemovableActorTarget,
   currentMemberId: string | null | undefined,
 ): boolean {
-  if (!permissions.canManageTeam) return false
   if (!currentMemberId) return false
-  return targetActorId !== currentMemberId
+  if (target.id === currentMemberId) return false
+
+  if (target.actor_type === 'agent') {
+    if (target.visibility === 'personal') {
+      return currentMemberId === target.owner_member_id
+    }
+    if (target.visibility === 'team') {
+      return permissions.canManageTeam
+    }
+    // Unknown visibility (e.g. cold cache before network reconcile): hide delete.
+    return false
+  }
+
+  return permissions.canManageTeam
 }
 
 export function permissionsForRole(role: string | null | undefined): TeamPermissions {

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -3064,6 +3064,12 @@
       "lastOwner": "Cannot remove the last team owner. Promote another member first.",
       "self": "You cannot remove yourself from the team.",
       "forbidden": "Only team owners and admins can remove members.",
+      "personalAgentOwner": "Only the owner can remove a personal agent.",
+      "teamAgentAdmin": "Only team owners and admins can remove team agents.",
+      "blockedByIdeas": "This agent still has related idea activity. Resolve those references first.",
+      "blockedByApps": "This agent still has related apps. Resolve those references first.",
+      "blockedByFiles": "This agent still has related files. Resolve those references first.",
+      "blockedByReferences": "This actor is still referenced elsewhere. Resolve those references first.",
       "ownsAgents": "This member still owns one or more agents. Remove or reassign those agents first.",
       "notFound": "This actor is no longer in the team."
     },

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -3064,6 +3064,12 @@
       "lastOwner": "无法移除最后一位团队 Owner，请先提升其他成员。",
       "self": "不能将自己移出团队。",
       "forbidden": "仅团队 Owner 和管理员可以移除成员。",
+      "personalAgentOwner": "仅 Agent 的拥有者可以移除个人 Agent。",
+      "teamAgentAdmin": "仅团队 Owner 和管理员可以移除团队 Agent。",
+      "blockedByIdeas": "该 Agent 仍有关联的想法动态，请先处理这些引用。",
+      "blockedByApps": "该 Agent 仍有关联的应用，请先处理这些引用。",
+      "blockedByFiles": "该 Agent 仍有关联的文件，请先处理这些引用。",
+      "blockedByReferences": "该 Actor 仍被其他地方引用，请先处理这些引用。",
       "ownsAgents": "该成员仍拥有 Agent，请先移除或转移这些 Agent。",
       "notFound": "该成员已不在团队中。"
     },

--- a/packages/app/src/stores/__tests__/actor-directory-store.test.ts
+++ b/packages/app/src/stores/__tests__/actor-directory-store.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { mapCacheRow } from '@/stores/actor-directory-store'
+
+describe('mapCacheRow', () => {
+  it('maps ownerMemberId from libsql cache for personal-agent delete gating', () => {
+    const row = mapCacheRow({
+      id: 'agent-1',
+      teamId: 'team-1',
+      actorType: 'agent',
+      displayName: 'My Bot',
+      memberStatus: null,
+      agentStatus: 'active',
+      lastActiveAt: null,
+      teamRole: null,
+      agentVisibility: 'personal',
+      ownerMemberId: 'member-42',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      syncedAt: '2026-01-01T00:00:00Z',
+    })
+
+    expect(row.actor_type).toBe('agent')
+    expect(row.visibility).toBe('personal')
+    expect(row.owner_member_id).toBe('member-42')
+  })
+})

--- a/packages/app/src/stores/actor-directory-store.ts
+++ b/packages/app/src/stores/actor-directory-store.ts
@@ -55,6 +55,8 @@ export type ActorRow = {
   team_role?: string | null
   // Agent: 'team' | 'personal'. Member: undefined.
   visibility?: string | null
+  /** Agent owner member actor id — used for personal-agent delete gating. */
+  owner_member_id?: string | null
   // Member contact — null for agents and anonymous members. Only carried on the
   // network directory row (the libsql first-paint cache does not persist it).
   email?: string | null
@@ -92,7 +94,7 @@ interface DirectoryState {
   refetch: (teamId: string) => Promise<void>
 }
 
-function mapCacheRow(r: CachedActorRow): ActorRow {
+export function mapCacheRow(r: CachedActorRow): ActorRow {
   return {
     id: r.id,
     actor_type: r.actorType === 'agent' ? 'agent' : 'member',
@@ -102,6 +104,7 @@ function mapCacheRow(r: CachedActorRow): ActorRow {
     last_active_at: r.lastActiveAt ?? null,
     team_role: r.teamRole ?? null,
     visibility: r.agentVisibility ?? null,
+    owner_member_id: r.ownerMemberId ?? null,
   }
 }
 
@@ -132,6 +135,7 @@ async function writeCache(teamId: string, rows: ActorRow[]): Promise<void> {
     lastActiveAt: r.last_active_at,
     teamRole: r.team_role,
     agentVisibility: r.visibility,
+    ownerMemberId: r.owner_member_id,
     createdAt: now,
     updatedAt: now,
     syncedAt: now,
@@ -199,6 +203,7 @@ export const useActorDirectoryStore = create<DirectoryState>((set, get) => {
         created_at: row.created_at ?? null,
         team_role: row.team_role ?? null,
         visibility: row.visibility ?? null,
+        owner_member_id: row.agent_owner_member_id ?? null,
         email: row.email ?? null,
         phone: row.phone ?? null,
       }))

--- a/services/fc/src/lib/pg-repo/actors.ts
+++ b/services/fc/src/lib/pg-repo/actors.ts
@@ -80,6 +80,7 @@ function mapDirectoryActorRow(r: any) {
     defaultAgentType: (r.defaultAgentType ?? null) as string | null,
     defaultWorkspaceId: (r.defaultWorkspaceId ?? null) as string | null,
     visibility: (r.agentVisibility ?? null) as string | null,
+    agentOwnerMemberId: (r.ownerMemberId ?? null) as string | null,
     lastActiveAt: iso(r.lastActiveAt),
     createdAt: iso(r.createdAt),
     updatedAt: iso(r.updatedAt),
@@ -199,7 +200,7 @@ export function makeActorsRepo(db: DbLike, ctx: ActorsCtx = {}) {
         .limit(limit);
 
       return {
-        items: rows.map(mapActorRow),
+        items: rows.map(mapDirectoryActorRow),
       };
     },
 

--- a/services/fc/src/lib/pg-repo/authz.ts
+++ b/services/fc/src/lib/pg-repo/authz.ts
@@ -12,7 +12,7 @@
  * querying actors/members directly.
  */
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { actors, agents, agentMemberAccess, teamMembers } from "../../db/schema/index.js";
 import { ApiError } from "../http-utils.js";
 
@@ -124,6 +124,130 @@ export async function checkAgentOwnership(
     .limit(1);
   return !!ag && ag.ownerMemberId === actorId;
 }
+
+/**
+ * Returns the caller's team role (owner/admin/member), or null if not a member.
+ */
+export async function resolveTeamRole(
+  db: DbLike,
+  userId: string,
+  teamId: string,
+): Promise<string | null> {
+  const actorId = await resolveActorForTeam(db, userId, teamId);
+  if (!actorId) return null;
+  const [row] = await db
+    .select({ role: teamMembers.role })
+    .from(teamMembers)
+    .where(and(eq(teamMembers.teamId, teamId), eq(teamMembers.memberId, actorId)))
+    .limit(1);
+  return row?.role ?? null;
+}
+
+export interface RemovableActorTarget {
+  id: string;
+  actor_type?: string | null;
+  visibility?: string | null;
+  ownerMemberId?: string | null;
+}
+
+/**
+ * Application-layer mirror of amux.remove_team_actor authz.
+ * Throws ApiError on denial; returns caller actor id on success.
+ */
+export async function assertCanRemoveTeamActor(
+  db: DbLike,
+  userId: string,
+  teamId: string,
+  target: RemovableActorTarget,
+): Promise<string> {
+  const callerActorId = await requireActorForTeam(db, userId, teamId);
+
+  if (callerActorId === target.id) {
+    throw new ApiError(403, "forbidden", "cannot remove your own actor");
+  }
+
+  const [actorRow] = await db
+    .select({ actorType: actors.actorType, teamId: actors.teamId })
+    .from(actors)
+    .where(eq(actors.id, target.id))
+    .limit(1);
+
+  if (!actorRow || actorRow.teamId !== teamId) {
+    throw new ApiError(404, "not_found", "actor not found");
+  }
+
+  if (actorRow.actorType === "agent") {
+    const [ag] = await db
+      .select({ visibility: agents.visibility, ownerMemberId: agents.ownerMemberId })
+      .from(agents)
+      .where(eq(agents.id, target.id))
+      .limit(1);
+
+    if (ag?.visibility === "personal") {
+      if (callerActorId !== ag.ownerMemberId) {
+        throw new ApiError(
+          403,
+          "forbidden",
+          "remove_team_actor requires agent owner for personal agents",
+        );
+      }
+      return callerActorId;
+    }
+
+    const role = await resolveTeamRole(db, userId, teamId);
+    if (role !== "owner" && role !== "admin") {
+      throw new ApiError(
+        403,
+        "forbidden",
+        ag?.visibility === "team"
+          ? "remove_team_actor requires owner or admin for team agents"
+          : "remove_team_actor requires owner or admin",
+      );
+    }
+    return callerActorId;
+  }
+
+  const role = await resolveTeamRole(db, userId, teamId);
+  if (role !== "owner" && role !== "admin") {
+    throw new ApiError(403, "forbidden", "remove_team_actor requires owner or admin");
+  }
+
+  if (actorRow.actorType === "member") {
+    const [targetMembership] = await db
+      .select({ role: teamMembers.role })
+      .from(teamMembers)
+      .where(and(eq(teamMembers.teamId, teamId), eq(teamMembers.memberId, target.id)))
+      .limit(1);
+
+    if (targetMembership?.role === "owner") {
+      const [countRow] = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(teamMembers)
+        .where(and(eq(teamMembers.teamId, teamId), eq(teamMembers.role, "owner")));
+      if ((countRow?.count ?? 0) <= 1) {
+        throw new ApiError(403, "forbidden", "cannot remove the last owner");
+      }
+    }
+  }
+
+  return callerActorId;
+}
+
+function mapActorDeleteFkError(raw: string): ApiError {
+  const msg = raw.toLowerCase();
+  if (msg.includes("idea_activities")) {
+    return new ApiError(409, "conflict", "agent_delete_blocked_by_idea_activities");
+  }
+  if (msg.includes("apps") && msg.includes("actor")) {
+    return new ApiError(409, "conflict", "agent_delete_blocked_by_apps");
+  }
+  if (msg.includes("amuxc_file")) {
+    return new ApiError(409, "conflict", "agent_delete_blocked_by_files");
+  }
+  return new ApiError(409, "conflict", "actor_delete_blocked_by_references");
+}
+
+export { mapActorDeleteFkError };
 
 /**
  * Returns the permission_level for (actorId, agentId) from agentMemberAccess,

--- a/services/fc/src/lib/pg-repo/index.ts
+++ b/services/fc/src/lib/pg-repo/index.ts
@@ -71,7 +71,7 @@ export function createPgBusinessRepository({ db, accessToken, userId, callerActo
     setLiteLlmBudget: (teamId: string, input: { maxBudget?: unknown }) => teamsRepo.setLiteLlmBudget(teamId, input, teamsCtx),
     getLiteLlmUsage: (teamId: string, opts?: { range?: string; date?: string }) => teamsRepo.getLiteLlmUsage(teamId, opts ?? {}, teamsCtx),
     disableShareMode: (teamId: string) => teamsRepo.disableShareMode(teamId, teamsCtx),
-    removeTeamActor: (teamId: string, actorId: string) => teamsRepo.removeTeamActor(teamId, actorId),
+    removeTeamActor: (teamId: string, actorId: string) => teamsRepo.removeTeamActor(teamId, actorId, teamsCtx),
     // Account upgrade (default-org → own org) is org-model-specific and only
     // implemented on the supabase backend (postgres has no org model).
     upgradeAccount: async () => {

--- a/services/fc/src/lib/pg-repo/teams.ts
+++ b/services/fc/src/lib/pg-repo/teams.ts
@@ -1,11 +1,11 @@
-import { and, asc, eq, exists, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, exists, inArray, isNull, or, sql } from "drizzle-orm";
 import { aliasedTable } from "drizzle-orm";
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { teams, teamWorkspaceConfig, actors, members, teamMembers, teamInvites } from "../../db/schema/index.js";
 import { workspaces } from "../../db/schema/workspaces.js";
 import { agentMemberAccess, agents } from "../../db/schema/agents.js";
 import { ApiError } from "../http-utils.js";
-import { requireActorForTeam, requireTeamOwner, checkAgentOwnership } from "./authz.js";
+import { requireActorForTeam, requireTeamOwner, checkAgentOwnership, assertCanRemoveTeamActor, mapActorDeleteFkError } from "./authz.js";
 import { computeRange, getLiteLlmSql, queryTeamUsage, type ComputedRange, type TeamUsage } from "../litellm-usage.js";
 import { rollUpUsageByOwner, type UsageOwner } from "../usage-attribution.js";
 import { randomBytes, randomUUID } from "node:crypto";
@@ -788,26 +788,84 @@ export function makeTeamsRepo(db: PgDatabase<any, any>, deps: TeamsRepoDeps = {}
     },
 
     /**
-     * Removes an actor and all associated rows (cascade):
-     * agentMemberAccess → team_members → agents/members → actors
+     * Removes an actor and all associated rows (cascade).
+     * Authz mirrors amux.remove_team_actor (personal agent → owner; team agent → admin).
      */
-    async removeTeamActor(_teamId: string, actorId: string) {
-      await (db as any).transaction(async (tx: any) => {
-        // Delete agent_member_access rows where this actor is the member
-        await tx.delete(agentMemberAccess).where(eq(agentMemberAccess.memberId, actorId));
+    async removeTeamActor(teamId: string, actorId: string, ctx: { userId?: string } = {}) {
+      if (!ctx.userId) {
+        throw new ApiError(401, "unauthorized", "remove_team_actor requires authentication");
+      }
 
-        // Delete team_members rows for this actor (memberId = actorId for members)
-        await tx.delete(teamMembers).where(eq(teamMembers.memberId, actorId));
+      const [targetActor] = await db
+        .select({ actorType: actors.actorType, teamId: actors.teamId })
+        .from(actors)
+        .where(eq(actors.id, actorId))
+        .limit(1);
 
-        // Delete agents row (if actor is an agent)
-        await tx.delete(agents).where(eq(agents.id, actorId));
+      if (!targetActor || targetActor.teamId !== teamId) {
+        throw new ApiError(404, "not_found", "actor not found");
+      }
 
-        // Delete members row (if actor is a member)
-        await tx.delete(members).where(eq(members.id, actorId));
+      let agentMeta: { visibility: string | null; ownerMemberId: string | null } | null = null;
+      if (targetActor.actorType === "agent") {
+        const [ag] = await db
+          .select({ visibility: agents.visibility, ownerMemberId: agents.ownerMemberId })
+          .from(agents)
+          .where(eq(agents.id, actorId))
+          .limit(1);
+        agentMeta = ag ?? null;
+      }
 
-        // Finally delete the actor itself
-        await tx.delete(actors).where(eq(actors.id, actorId));
+      await assertCanRemoveTeamActor(db, ctx.userId, teamId, {
+        id: actorId,
+        actor_type: targetActor.actorType,
+        visibility: agentMeta?.visibility ?? null,
+        ownerMemberId: agentMeta?.ownerMemberId ?? null,
       });
+
+      try {
+        await (db as any).transaction(async (tx: any) => {
+          if (targetActor.actorType === "member") {
+            const ownedAgents = await tx
+              .select({ id: agents.id })
+              .from(agents)
+              .where(eq(agents.ownerMemberId, actorId));
+
+            for (const owned of ownedAgents) {
+              await tx.delete(agentMemberAccess).where(
+                or(
+                  eq(agentMemberAccess.agentId, owned.id),
+                  eq(agentMemberAccess.memberId, owned.id),
+                ),
+              );
+              await tx.delete(teamMembers).where(eq(teamMembers.memberId, owned.id));
+              await tx.delete(actors).where(eq(actors.id, owned.id));
+            }
+          }
+
+          await tx.delete(agentMemberAccess).where(
+            or(
+              eq(agentMemberAccess.agentId, actorId),
+              eq(agentMemberAccess.memberId, actorId),
+            ),
+          );
+          await tx.delete(teamMembers).where(eq(teamMembers.memberId, actorId));
+
+          if (targetActor.actorType === "member") {
+            await tx.delete(members).where(eq(members.id, actorId));
+          } else {
+            await tx.delete(agents).where(eq(agents.id, actorId));
+          }
+
+          await tx.delete(actors).where(eq(actors.id, actorId));
+        });
+      } catch (e) {
+        const msg = (e as Error)?.message ?? String(e);
+        if (/foreign key|violates foreign key|23503/i.test(msg)) {
+          throw mapActorDeleteFkError(msg);
+        }
+        throw e;
+      }
 
       // Best-effort: delete the removed actor's LiteLLM key (replaces the
       // legacy POST /ai/remove-member endpoint). Runs AFTER the transaction

--- a/services/fc/src/lib/supabase-repo/shared.ts
+++ b/services/fc/src/lib/supabase-repo/shared.ts
@@ -97,7 +97,7 @@ export const SESSION_FULL_COLUMNS =
   "id, team_id, title, mode, idea_id, primary_agent_id, created_by_actor_id, summary, last_message_preview, last_message_at, acp_session_id, binding, source, cron_job_id, created_at, updated_at";
 
 export const ACTOR_DIRECTORY_COLUMNS =
-  "id, team_id, actor_type, user_id, invited_by_actor_id, display_name, avatar_url, team_role, member_status, agent_status, agent_types, default_agent_type, default_workspace_id, agent_visibility, last_active_at, created_at, updated_at, user_email, user_phone";
+  "id, team_id, actor_type, user_id, invited_by_actor_id, display_name, avatar_url, team_role, member_status, agent_status, agent_types, default_agent_type, default_workspace_id, agent_visibility, owner_member_id, last_active_at, created_at, updated_at, user_email, user_phone";
 
 export function mapSessionFull(row) {
   return {
@@ -138,6 +138,7 @@ export function mapDirectoryActor(row) {
     defaultAgentType: row?.default_agent_type ?? null,
     defaultWorkspaceId: row?.default_workspace_id ?? null,
     visibility: row?.agent_visibility ?? null,
+    agentOwnerMemberId: row?.owner_member_id ?? null,
     lastActiveAt: row?.last_active_at ?? null,
     createdAt: row?.created_at ?? null,
     updatedAt: row?.updated_at ?? null,

--- a/services/fc/test/pg-repo-actors.test.ts
+++ b/services/fc/test/pg-repo-actors.test.ts
@@ -113,18 +113,35 @@ test("upsertExternalActor is idempotent (returns same actorId on second call)", 
 
 // ── listTeamActors ────────────────────────────────────────────────────────────
 
-test("listTeamActors returns items with canonical contract keys", async () => {
+test("listTeamActors returns agentOwnerMemberId for agents", async () => {
   const { db } = await makeTestDb();
   const team = await seedTeam(db);
-  await seedMemberActor(db, team.id);
-  const repo = createPgBusinessRepository({ db });
+  const member = await seedMemberActor(db, team.id);
+  await seedAgentActor(db, team.id, member.id, "personal");
+  const repo = createPgBusinessRepository({ db, callerActorId: member.id });
+
+  const page = await repo.listTeamActors(team.id, { kind: "agent", limit: 200 });
+  assert.equal(page.items.length, 1);
+  assert.equal(page.items[0].agentOwnerMemberId, member.id);
+  assert.equal(page.items[0].visibility, "personal");
+});
+
+test("listTeamActors returns directory fields needed for actor management UI", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const member = await seedMemberActor(db, team.id);
+  await seedAgentActor(db, team.id, member.id, "team");
+  const repo = createPgBusinessRepository({ db, callerActorId: member.id });
 
   const page = await repo.listTeamActors(team.id, { kind: null, limit: 200 });
   assert.ok(Array.isArray(page.items), "items must be an array");
-  assert.ok(page.items.length >= 1, "must have at least one actor");
+  assert.ok(page.items.length >= 2, "must have member + agent");
 
-  const expected = ["id", "teamId", "kind", "displayName", "avatarUrl", "metadata"].sort();
-  assert.deepEqual(Object.keys(page.items[0]).sort(), expected);
+  const memberRow = page.items.find((a: any) => a.kind === "member");
+  const agentRow = page.items.find((a: any) => a.kind === "agent");
+  assert.ok(memberRow?.teamRole, "member row should expose teamRole");
+  assert.equal(agentRow?.visibility, "team");
+  assert.equal(agentRow?.agentOwnerMemberId, member.id);
 });
 
 test("listTeamActors kind filter returns only matching actors", async () => {

--- a/services/fc/test/pg-repo-authz-fk.test.ts
+++ b/services/fc/test/pg-repo-authz-fk.test.ts
@@ -1,0 +1,27 @@
+/**
+ * mapActorDeleteFkError — stable delete-blocker tokens (parity with amux.remove_team_actor RPC).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mapActorDeleteFkError } from "../src/lib/pg-repo/authz.js";
+
+test("mapActorDeleteFkError maps idea_activities FK to stable token", () => {
+  const err = mapActorDeleteFkError('update or delete on table "agents" violates foreign key constraint "idea_activities_actor_id_fkey" on table "idea_activities"');
+  assert.equal(err.message, "agent_delete_blocked_by_idea_activities");
+  assert.equal(err.statusCode, 409);
+});
+
+test("mapActorDeleteFkError maps apps created_by_actor FK to stable token", () => {
+  const err = mapActorDeleteFkError('violates foreign key constraint "apps_created_by_actor_id_fkey"');
+  assert.equal(err.message, "agent_delete_blocked_by_apps");
+});
+
+test("mapActorDeleteFkError maps amuxc_files FK to stable token", () => {
+  const err = mapActorDeleteFkError('violates foreign key constraint "amuxc_files_updated_by_fkey" on table "amuxc_files"');
+  assert.equal(err.message, "agent_delete_blocked_by_files");
+});
+
+test("mapActorDeleteFkError falls back to generic reference token", () => {
+  const err = mapActorDeleteFkError("some other foreign key violation");
+  assert.equal(err.message, "actor_delete_blocked_by_references");
+});

--- a/services/fc/test/pg-repo-authz.test.ts
+++ b/services/fc/test/pg-repo-authz.test.ts
@@ -1,0 +1,141 @@
+/**
+ * pg-repo-authz — application-layer authz for remove_team_actor parity.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { eq } from "drizzle-orm";
+import { makeTestDb } from "./db/pglite.js";
+import { createPgBusinessRepository } from "../src/lib/pg-repo/index.js";
+import { assertCanRemoveTeamActor } from "../src/lib/pg-repo/authz.js";
+import { actors, members, teamMembers, agents } from "../src/db/schema/index.js";
+
+async function seedMember(
+  db: any,
+  teamId: string,
+  opts: { userId: string; role?: string; displayName?: string },
+) {
+  const [actor] = await db.insert(actors).values({
+    teamId,
+    actorType: "member",
+    displayName: opts.displayName ?? "Member",
+    userId: opts.userId,
+  }).returning();
+  await db.insert(members).values({ id: actor.id, status: "active" });
+  await db.insert(teamMembers).values({
+    teamId,
+    memberId: actor.id,
+    role: opts.role ?? "member",
+  });
+  return actor;
+}
+
+async function seedAgent(
+  db: any,
+  teamId: string,
+  ownerMemberId: string,
+  visibility: "personal" | "team",
+) {
+  const [agentActor] = await db.insert(actors).values({
+    teamId,
+    actorType: "agent",
+    displayName: visibility === "personal" ? "Personal Bot" : "Team Bot",
+  }).returning();
+  await db.insert(agents).values({
+    id: agentActor.id,
+    agentKind: "daemon",
+    status: "active",
+    visibility,
+    ownerMemberId,
+  });
+  return agentActor;
+}
+
+test("assertCanRemoveTeamActor allows personal-agent owner", async () => {
+  const { db } = await makeTestDb();
+  const ownerUserId = `user-${Math.random()}`;
+  const repo = createPgBusinessRepository({ db, userId: ownerUserId });
+  const team = await repo.createTeam({ name: "Authz Personal Team" });
+
+  const ownerMember = await db.query.actors.findFirst({ where: eq(actors.teamId, team.id) });
+  assert.ok(ownerMember);
+
+  const memberUserId = `user-${Math.random()}`;
+  const memberActor = await seedMember(db, team.id, { userId: memberUserId });
+  const personalAgent = await seedAgent(db, team.id, memberActor.id, "personal");
+
+  await assert.doesNotReject(() =>
+    assertCanRemoveTeamActor(db, memberUserId, team.id, {
+      id: personalAgent.id,
+      actor_type: "agent",
+      visibility: "personal",
+      ownerMemberId: memberActor.id,
+    }),
+  );
+});
+
+test("assertCanRemoveTeamActor rejects non-owner deleting personal agent", async () => {
+  const { db } = await makeTestDb();
+  const ownerUserId = `user-${Math.random()}`;
+  const repo = createPgBusinessRepository({ db, userId: ownerUserId });
+  const team = await repo.createTeam({ name: "Authz Personal Deny Team" });
+
+  const ownerMember = await db.query.actors.findFirst({ where: eq(actors.teamId, team.id) });
+  assert.ok(ownerMember);
+
+  const memberActor = await seedMember(db, team.id, { userId: `user-${Math.random()}` });
+  const personalAgent = await seedAgent(db, team.id, memberActor.id, "personal");
+
+  await assert.rejects(
+    () =>
+      assertCanRemoveTeamActor(db, ownerUserId, team.id, {
+        id: personalAgent.id,
+        actor_type: "agent",
+        visibility: "personal",
+        ownerMemberId: memberActor.id,
+      }),
+    (e: any) => /requires agent owner for personal agents/i.test(String(e?.message ?? e)),
+  );
+});
+
+test("assertCanRemoveTeamActor rejects member deleting team agent", async () => {
+  const { db } = await makeTestDb();
+  const ownerUserId = `user-${Math.random()}`;
+  const repo = createPgBusinessRepository({ db, userId: ownerUserId });
+  const team = await repo.createTeam({ name: "Authz Team Agent Team" });
+
+  const memberUserId = `user-${Math.random()}`;
+  const memberActor = await seedMember(db, team.id, { userId: memberUserId });
+  const teamAgent = await seedAgent(db, team.id, memberActor.id, "team");
+
+  await assert.rejects(
+    () =>
+      assertCanRemoveTeamActor(db, memberUserId, team.id, {
+        id: teamAgent.id,
+        actor_type: "agent",
+        visibility: "team",
+        ownerMemberId: memberActor.id,
+      }),
+    (e: any) => /requires owner or admin for team agents/i.test(String(e?.message ?? e)),
+  );
+});
+
+test("assertCanRemoveTeamActor allows admin to delete team agent", async () => {
+  const { db } = await makeTestDb();
+  const ownerUserId = `user-${Math.random()}`;
+  const adminUserId = `user-${Math.random()}`;
+  const repo = createPgBusinessRepository({ db, userId: ownerUserId });
+  const team = await repo.createTeam({ name: "Authz Team Agent Admin Team" });
+
+  await seedMember(db, team.id, { userId: adminUserId, role: "admin" });
+  const ownerActor = await seedMember(db, team.id, { userId: `user-${Math.random()}`, role: "member" });
+  const teamAgent = await seedAgent(db, team.id, ownerActor.id, "team");
+
+  await assert.doesNotReject(() =>
+    assertCanRemoveTeamActor(db, adminUserId, team.id, {
+      id: teamAgent.id,
+      actor_type: "agent",
+      visibility: "team",
+      ownerMemberId: ownerActor.id,
+    }),
+  );
+});

--- a/services/fc/test/pg-repo-teams-rpc.test.ts
+++ b/services/fc/test/pg-repo-teams-rpc.test.ts
@@ -203,14 +203,143 @@ test("removeTeamActor: deletes actor + members + team_members rows", async () =>
   assert.equal(tmAfter.length, 0, "team_members rows must be deleted");
 });
 
-test("removeTeamActor: no-throw when actor does not exist (idempotent)", async () => {
+test("removeTeamActor: throws not_found when actor does not exist", async () => {
   const { db } = await makeTestDb();
   const userId = `user-${Math.random()}`;
   const repo = createPgBusinessRepository({ db, userId });
   const team = await repo.createTeam({ name: "Ghost Team" });
 
-  // Should not throw
-  await repo.removeTeamActor(team.id, "00000000-0000-0000-0000-000000000099");
+  await assert.rejects(
+    () => repo.removeTeamActor(team.id, "00000000-0000-0000-0000-000000000099"),
+    (e: any) => e?.message?.includes("actor not found"),
+  );
+});
+
+test("removeTeamActor: personal agent owner can delete; other member cannot", async () => {
+  const { db } = await makeTestDb();
+  const ownerUserId = `user-${Math.random()}`;
+  const memberUserId = `user-${Math.random()}`;
+  const ownerRepo = createPgBusinessRepository({ db, userId: ownerUserId });
+  const memberRepo = createPgBusinessRepository({ db, userId: memberUserId });
+  const team = await ownerRepo.createTeam({ name: "Personal Agent Delete Team" });
+
+  const [memberActor] = await db.insert(actors).values({
+    teamId: team.id,
+    actorType: "member",
+    displayName: "Agent Owner Member",
+    userId: memberUserId,
+  }).returning();
+  await db.insert(members).values({ id: memberActor.id, status: "active" });
+  await db.insert(teamMembers).values({ teamId: team.id, memberId: memberActor.id, role: "member" });
+
+  const [personalAgent] = await db.insert(actors).values({
+    teamId: team.id,
+    actorType: "agent",
+    displayName: "Personal Agent",
+  }).returning();
+  await db.insert(agents).values({
+    id: personalAgent.id,
+    agentKind: "daemon",
+    status: "active",
+    visibility: "personal",
+    ownerMemberId: memberActor.id,
+  });
+
+  await assert.rejects(
+    () => ownerRepo.removeTeamActor(team.id, personalAgent.id),
+    (e: any) => /requires agent owner for personal agents/i.test(String(e?.message ?? e)),
+  );
+
+  await memberRepo.removeTeamActor(team.id, personalAgent.id);
+
+  const after = await db.select().from(actors).where(eq(actors.id, personalAgent.id));
+  assert.equal(after.length, 0, "personal agent must be deleted by owner member");
+});
+
+test("removeTeamActor: team agent requires admin; member cannot delete", async () => {
+  const { db } = await makeTestDb();
+  const ownerUserId = `user-${Math.random()}`;
+  const memberUserId = `user-${Math.random()}`;
+  const ownerRepo = createPgBusinessRepository({ db, userId: ownerUserId });
+  const memberRepo = createPgBusinessRepository({ db, userId: memberUserId });
+  const team = await ownerRepo.createTeam({ name: "Team Agent Delete Team" });
+
+  const [memberActor] = await db.insert(actors).values({
+    teamId: team.id,
+    actorType: "member",
+    displayName: "Regular Member",
+    userId: memberUserId,
+  }).returning();
+  await db.insert(members).values({ id: memberActor.id, status: "active" });
+  await db.insert(teamMembers).values({ teamId: team.id, memberId: memberActor.id, role: "member" });
+
+  const [teamAgent] = await db.insert(actors).values({
+    teamId: team.id,
+    actorType: "agent",
+    displayName: "Shared Team Agent",
+  }).returning();
+  await db.insert(agents).values({
+    id: teamAgent.id,
+    agentKind: "daemon",
+    status: "active",
+    visibility: "team",
+    ownerMemberId: memberActor.id,
+  });
+
+  await assert.rejects(
+    () => memberRepo.removeTeamActor(team.id, teamAgent.id),
+    (e: any) => /requires owner or admin for team agents/i.test(String(e?.message ?? e)),
+  );
+
+  await ownerRepo.removeTeamActor(team.id, teamAgent.id);
+
+  const after = await db.select().from(actors).where(eq(actors.id, teamAgent.id));
+  assert.equal(after.length, 0, "team agent must be deleted by team owner");
+});
+
+test("removeTeamActor: team admin (not owner) can delete team agent", async () => {
+  const { db } = await makeTestDb();
+  const ownerUserId = `user-${Math.random()}`;
+  const adminUserId = `user-${Math.random()}`;
+  const ownerRepo = createPgBusinessRepository({ db, userId: ownerUserId });
+  const adminRepo = createPgBusinessRepository({ db, userId: adminUserId });
+  const team = await ownerRepo.createTeam({ name: "Team Agent Admin Delete Team" });
+
+  const [adminActor] = await db.insert(actors).values({
+    teamId: team.id,
+    actorType: "member",
+    displayName: "Team Admin",
+    userId: adminUserId,
+  }).returning();
+  await db.insert(members).values({ id: adminActor.id, status: "active" });
+  await db.insert(teamMembers).values({ teamId: team.id, memberId: adminActor.id, role: "admin" });
+
+  const [memberActor] = await db.insert(actors).values({
+    teamId: team.id,
+    actorType: "member",
+    displayName: "Agent Owner Member",
+    userId: `user-${Math.random()}`,
+  }).returning();
+  await db.insert(members).values({ id: memberActor.id, status: "active" });
+  await db.insert(teamMembers).values({ teamId: team.id, memberId: memberActor.id, role: "member" });
+
+  const [teamAgent] = await db.insert(actors).values({
+    teamId: team.id,
+    actorType: "agent",
+    displayName: "Team Scoped Agent",
+  }).returning();
+  await db.insert(agents).values({
+    id: teamAgent.id,
+    agentKind: "daemon",
+    status: "active",
+    visibility: "team",
+    ownerMemberId: memberActor.id,
+  });
+
+  await adminRepo.removeTeamActor(team.id, teamAgent.id);
+
+  const after = await db.select().from(actors).where(eq(actors.id, teamAgent.id));
+  assert.equal(after.length, 0, "team admin must be able to delete team agent");
 });
 
 test("removeTeamActor: deleting a member also removes agents they own", async () => {

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -1151,8 +1151,42 @@ test("listTeamActors selects actor_directory columns without removed agent_kind"
   const selectCall = tableCalls.find((c) => c.table === "actor_directory" && c.op === "select");
   assert.ok(selectCall, "expected actor_directory select");
   assert.ok(!selectCall.columns.includes("agent_kind"), "must not select removed agent_kind column");
+  assert.ok(selectCall.columns.includes("owner_member_id"), "must select owner_member_id for delete gating");
   assert.equal(page.items[0].defaultAgentType, "claude");
   assert.equal(page.items[0].agentKind, null);
+});
+
+test("listTeamActors maps owner_member_id to agentOwnerMemberId", async () => {
+  const tableCalls = [];
+  const repo = createRepo(fakeSupabase({
+    tableCalls,
+    tableData: {
+      actor_directory: [{
+        id: "agent-1",
+        team_id: "team-1",
+        actor_type: "agent",
+        user_id: null,
+        invited_by_actor_id: null,
+        display_name: "Bot",
+        avatar_url: null,
+        team_role: null,
+        member_status: null,
+        agent_status: "active",
+        agent_types: ["claude"],
+        default_agent_type: "claude",
+        default_workspace_id: null,
+        agent_visibility: "personal",
+        owner_member_id: "member-1",
+        last_active_at: null,
+        created_at: "2026-05-27T01:00:00Z",
+        updated_at: "2026-05-27T01:00:00Z",
+      }],
+    },
+  }));
+
+  const page = await repo.listTeamActors("team-1", { limit: 10 });
+  assert.equal(page.items[0].agentOwnerMemberId, "member-1");
+  assert.equal(page.items[0].visibility, "personal");
 });
 
 test("ensureAgentTypes updates the caller's own agent actor, not an arbitrary team agent", async () => {

--- a/services/supabase/migrations/20260729100000_agent_delete_authz.sql
+++ b/services/supabase/migrations/20260729100000_agent_delete_authz.sql
@@ -1,0 +1,151 @@
+-- Agent delete authz: personal agents → owner only; team agents → owner/admin.
+-- FK blockers → stable error tokens for client messaging.
+-- actor_directory: expose owner_member_id for client-side remove gating.
+
+create or replace function amux.remove_team_actor(p_actor_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path to 'amux', 'public', 'auth'
+as $$
+declare
+  v_team_id uuid;
+  v_actor_type text;
+  v_caller_actor uuid := amux.current_actor_id();
+  v_owned_agent_id uuid;
+  v_agent_visibility text;
+  v_agent_owner_member_id uuid;
+begin
+  if v_caller_actor is null then
+    raise exception 'remove_team_actor requires authentication'
+      using errcode = '42501';
+  end if;
+
+  select team_id, actor_type
+    into v_team_id, v_actor_type
+  from amux.actors
+  where id = p_actor_id;
+
+  if v_team_id is null then
+    raise exception 'actor not found'
+      using errcode = '23503';
+  end if;
+
+  if v_caller_actor = p_actor_id then
+    raise exception 'cannot remove your own actor'
+      using errcode = '42501';
+  end if;
+
+  if v_actor_type = 'agent' then
+    select visibility, owner_member_id
+      into v_agent_visibility, v_agent_owner_member_id
+    from amux.agents
+    where id = p_actor_id;
+
+    if v_agent_visibility = 'personal' then
+      if v_caller_actor is distinct from v_agent_owner_member_id then
+        raise exception 'remove_team_actor requires agent owner for personal agents'
+          using errcode = '42501';
+      end if;
+    elsif v_agent_visibility = 'team' then
+      if amux.current_team_role(v_team_id) not in ('owner', 'admin') then
+        raise exception 'remove_team_actor requires owner or admin for team agents'
+          using errcode = '42501';
+      end if;
+    else
+      if amux.current_team_role(v_team_id) not in ('owner', 'admin') then
+        raise exception 'remove_team_actor requires owner or admin'
+          using errcode = '42501';
+      end if;
+    end if;
+  else
+    if amux.current_team_role(v_team_id) not in ('owner', 'admin') then
+      raise exception 'remove_team_actor requires owner or admin'
+        using errcode = '42501';
+    end if;
+  end if;
+
+  if v_actor_type = 'member' and exists (
+    select 1 from amux.team_members
+     where team_id = v_team_id and member_id = p_actor_id and role = 'owner'
+  ) then
+    if (select count(*) from amux.team_members
+          where team_id = v_team_id and role = 'owner') <= 1 then
+      raise exception 'cannot remove the last owner'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  begin
+    -- Member removal: cascade-delete agents they own before dropping the member row.
+    if v_actor_type = 'member' then
+      for v_owned_agent_id in
+        select id from amux.agents where owner_member_id = p_actor_id
+      loop
+        delete from amux.agent_member_access
+         where agent_id = v_owned_agent_id or member_id = v_owned_agent_id;
+
+        delete from amux.team_members
+         where member_id = v_owned_agent_id;
+
+        delete from amux.actors where id = v_owned_agent_id;
+      end loop;
+    end if;
+
+    delete from amux.agent_member_access
+     where agent_id = p_actor_id or member_id = p_actor_id;
+
+    delete from amux.team_members where member_id = p_actor_id;
+
+    if v_actor_type = 'member' then
+      delete from amux.members where id = p_actor_id;
+    else
+      delete from amux.agents where id = p_actor_id;
+    end if;
+
+    delete from amux.actors where id = p_actor_id;
+  exception
+    when foreign_key_violation then
+      raise exception '%', case
+        when sqlerrm ilike '%idea_activities%' then 'agent_delete_blocked_by_idea_activities'
+        when sqlerrm ilike '%apps_created_by%' or sqlerrm ilike '%apps_%actor%' then 'agent_delete_blocked_by_apps'
+        when sqlerrm ilike '%amuxc_file%' then 'agent_delete_blocked_by_files'
+        else 'actor_delete_blocked_by_references'
+      end
+      using errcode = '23503';
+  end;
+end;
+$$;
+
+comment on function amux.remove_team_actor(uuid) is
+  'Remove a team actor. Members: owner/admin. Personal agents: owner_member only. Team agents: owner/admin. Cascades owned agents when removing a member.';
+
+drop view if exists amux.actor_directory;
+
+create view amux.actor_directory
+  with (security_invoker = true)
+as
+select
+  a.id, a.team_id, a.actor_type, a.user_id, a.invited_by_actor_id,
+  a.display_name, a.avatar_url, a.last_active_at, a.created_at, a.updated_at,
+  m.status      as member_status,
+  tm.role       as team_role,
+  ag.agent_types,
+  ag.default_agent_type,
+  ag.default_workspace_id,
+  ag.visibility as agent_visibility,
+  ag.status     as agent_status,
+  ag.owner_member_id,
+  c.email       as user_email,
+  c.phone       as user_phone
+from amux.actors a
+left join amux.members      m  on m.id         = a.id
+left join amux.team_members tm on tm.member_id = a.id
+left join amux.agents       ag on ag.id        = a.id
+left join lateral amux.actor_user_contact(a.user_id) c
+  on a.actor_type <> 'agent' and a.user_id is not null
+where a.actor_type <> 'agent'
+   or ag.visibility = 'team'
+   or ag.owner_member_id = amux.current_actor_id_for_team(a.team_id);
+
+grant select on amux.actor_directory to authenticated;

--- a/services/supabase/tests/025_agent_delete_authz.sql
+++ b/services/supabase/tests/025_agent_delete_authz.sql
@@ -1,0 +1,167 @@
+-- services/supabase/tests/025_agent_delete_authz.sql
+-- Personal agents: owner_member only. Team agents: owner/admin.
+-- FK blockers surface stable error tokens.
+begin;
+
+create or replace function pg_temp.as_member(p_user uuid)
+returns void language plpgsql as $$
+begin
+  perform set_config('request.jwt.claims',
+                     json_build_object('sub', p_user::text, 'role', 'authenticated')::text,
+                     true);
+  perform set_config('role', 'authenticated', true);
+end;
+$$;
+
+do $$
+declare
+  v_team           uuid := gen_random_uuid();
+  v_owner_uid      uuid := gen_random_uuid();
+  v_member_uid     uuid := gen_random_uuid();
+  v_admin_uid      uuid := gen_random_uuid();
+  v_owner_mem      uuid := gen_random_uuid();
+  v_member_mem     uuid := gen_random_uuid();
+  v_admin_mem      uuid := gen_random_uuid();
+  v_personal_agent uuid := gen_random_uuid();
+  v_team_agent     uuid := gen_random_uuid();
+  v_idea_id        uuid := gen_random_uuid();
+  v_apps_agent     uuid := gen_random_uuid();
+begin
+  insert into auth.users (id, email, aud, role, instance_id, is_anonymous)
+  values
+    (v_owner_uid,  'del-owner@amux.test',  'authenticated', 'authenticated',
+     '00000000-0000-0000-0000-000000000000', false),
+    (v_member_uid, 'del-member@amux.test', 'authenticated', 'authenticated',
+     '00000000-0000-0000-0000-000000000000', false),
+    (v_admin_uid,  'del-admin@amux.test',  'authenticated', 'authenticated',
+     '00000000-0000-0000-0000-000000000000', false)
+  on conflict do nothing;
+
+  insert into amux.teams (id, slug, name)
+  values (v_team, 'del-auth-' || left(v_team::text, 8), 'Agent Delete Authz');
+
+  insert into amux.actors (id, team_id, actor_type, display_name, user_id)
+  values
+    (v_owner_mem,  v_team, 'member', 'Owner',  v_owner_uid),
+    (v_member_mem, v_team, 'member', 'Member', v_member_uid),
+    (v_admin_mem,  v_team, 'member', 'Admin',  v_admin_uid);
+
+  insert into amux.members (id, status)
+  values
+    (v_owner_mem,  'active'),
+    (v_member_mem, 'active'),
+    (v_admin_mem,  'active');
+
+  insert into amux.team_members (team_id, member_id, role)
+  values
+    (v_team, v_owner_mem,  'owner'),
+    (v_team, v_member_mem, 'member'),
+    (v_team, v_admin_mem,  'admin');
+
+  insert into amux.actors (id, team_id, actor_type, display_name)
+  values
+    (v_personal_agent, v_team, 'agent', 'Personal Bot'),
+    (v_team_agent,     v_team, 'agent', 'Team Bot');
+
+  insert into amux.agents (id, status, visibility, owner_member_id)
+  values
+    (v_personal_agent, 'active', 'personal', v_member_mem),
+    (v_team_agent,     'active', 'team',     v_member_mem);
+
+  -- Non-owner member cannot delete personal agent.
+  perform pg_temp.as_member(v_member_uid);
+  begin
+    perform amux.remove_team_actor(v_personal_agent);
+    raise exception 'expected personal-agent delete denial for non-owner';
+  exception
+    when insufficient_privilege then null;
+    when others then
+      if sqlerrm not ilike '%requires agent owner for personal agents%' then
+        raise;
+      end if;
+  end;
+
+  -- Owner member can delete their personal agent.
+  perform amux.remove_team_actor(v_personal_agent);
+  if exists (select 1 from amux.actors where id = v_personal_agent) then
+    raise exception 'personal agent should be deleted by owner';
+  end if;
+
+  -- Regular member cannot delete team agent.
+  perform pg_temp.as_member(v_member_uid);
+  begin
+    perform amux.remove_team_actor(v_team_agent);
+    raise exception 'expected team-agent delete denial for member';
+  exception
+    when insufficient_privilege then null;
+    when others then
+      if sqlerrm not ilike '%requires owner or admin for team agents%' then
+        raise;
+      end if;
+  end;
+
+  -- Admin can delete team agent.
+  perform pg_temp.as_member(v_admin_uid);
+  perform amux.remove_team_actor(v_team_agent);
+  if exists (select 1 from amux.actors where id = v_team_agent) then
+    raise exception 'team agent should be deleted by admin';
+  end if;
+
+  -- FK blocker: idea activity referencing agent actor.
+  insert into amux.actors (id, team_id, actor_type, display_name)
+  values (v_team_agent, v_team, 'agent', 'Blocked Bot');
+
+  insert into amux.agents (id, status, visibility, owner_member_id)
+  values (v_team_agent, 'active', 'team', v_member_mem);
+
+  insert into amux.ideas (id, team_id, title, status, created_by_actor_id)
+  values (v_idea_id, v_team, 'Blocked idea', 'open', v_owner_mem);
+
+  insert into amux.idea_activities (team_id, idea_id, actor_id, activity_type, content)
+  values (v_team, v_idea_id, v_team_agent, 'progress', 'still referenced');
+
+  perform pg_temp.as_member(v_admin_uid);
+  begin
+    perform amux.remove_team_actor(v_team_agent);
+    raise exception 'expected FK blocker for idea activity';
+  exception
+    when others then
+      if sqlerrm not ilike '%agent_delete_blocked_by_idea_activities%' then
+        raise;
+      end if;
+  end;
+
+  -- FK blocker: app created_by_actor referencing agent.
+  insert into amux.actors (id, team_id, actor_type, display_name)
+  values (v_apps_agent, v_team, 'agent', 'Apps Blocked Bot');
+
+  insert into amux.agents (id, status, visibility, owner_member_id)
+  values (v_apps_agent, 'active', 'team', v_member_mem);
+
+  insert into amux.apps (team_id, created_by_actor_id, name, slug, type)
+  values (v_team, v_apps_agent, 'Blocked App', 'blocked-app', 'static_web');
+
+  perform pg_temp.as_member(v_admin_uid);
+  begin
+    perform amux.remove_team_actor(v_apps_agent);
+    raise exception 'expected FK blocker for apps';
+  exception
+    when others then
+      if sqlerrm not ilike '%agent_delete_blocked_by_apps%' then
+        raise;
+      end if;
+  end;
+end;
+$$;
+
+select plan(3);
+
+select has_column('amux', 'actor_directory', 'owner_member_id',
+  'actor_directory exposes owner_member_id for client delete gating');
+
+select pass('remove_team_actor enforces personal/team authz and FK blockers');
+
+select pass('remove_team_actor surfaces agent_delete_blocked_by_apps');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

- **Agent hard delete**: extend `amux.remove_team_actor` so personal agents require `owner_member_id`, team agents require team owner/admin; FK blockers return stable tokens (`agent_delete_blocked_by_*`). Expose `owner_member_id` on `actor_directory` and wire client delete gating in Actors view (context menu), error copy, libsql cache, and FC pg-repo parity.
- **Pi install fix** (included on branch): daemon setup wizard installs `@earendil-works/pi-coding-agent` from `pi.lock.json` instead of the non-existent `@earendil-works/pi` npm package.

## Test plan

- [ ] Apply migration `20260729100000_agent_delete_authz.sql` and run pgTAP `025_agent_delete_authz.sql`
- [ ] `cd services/fc && npm install && node --import tsx --test test/pg-repo-authz-fk.test.ts test/pg-repo-authz.test.ts test/pg-repo-teams-rpc.test.ts`
- [ ] `pnpm test:unit` — `team-permissions`, `actor-remove-error`, `actor-directory-store`, `actors` cloud-api tests
- [ ] Desktop: open team Actors, verify personal agent delete only for owner; team agent delete for admin/owner; FK errors show readable messages
- [ ] Daemon setup: run pi install step and confirm npm package resolves


Made with [Cursor](https://cursor.com)