### PR TITLE
fix(auth): stop the login screen flashing on cold start

### DIFF
--- a/packages/app/src/components/auth/AuthGate.tsx
+++ b/packages/app/src/components/auth/AuthGate.tsx
@@ -331,7 +331,23 @@ export function AuthGate({ children }: AuthGateProps) {
     return <DesktopOnboarding />;
   }
 
-  if (!authHydrated && loading) {
+  // Decide nothing until the initial session restore has settled. This is
+  // deliberately `authHydrated` alone, NOT `authHydrated && loading` and not
+  // `loading` on its own:
+  //
+  //  - as a conjunction it stopped guarding as soon as EITHER signal cleared,
+  //    so a hydrate that resolved without applying a session fell straight
+  //    through to the login branch below (cold-start login flash);
+  //  - `loading` cannot be used here because every auth action shares it
+  //    (sendOtp, verifyOtp, OAuth, WebSSO, invite…). Gating on it would blank
+  //    the login screen the moment a signed-out user submits their code.
+  //
+  // `hydrate` now catches its own failures and always resolves to a defined
+  // state, so this flag means exactly "startup auth is settled" — whether it
+  // settled on a session or on none. It is still set from `.finally()` on
+  // purpose: an unblocked gate showing the login screen beats a gate that never
+  // unblocks and leaves the startup skeleton up forever.
+  if (!authHydrated) {
     return null;
   }
 

--- a/packages/app/src/stores/auth-store.test.ts
+++ b/packages/app/src/stores/auth-store.test.ts
@@ -104,6 +104,37 @@ describe("auth-store", () => {
     expect(useAuthStore.getState().loading).toBe(false);
   });
 
+  // Cold-start login flash: a throwing getSession used to skip the
+  // `set({ session, loading: false })` line entirely, leaving `loading` stuck
+  // at true with `session` null. AuthGate's `.finally()` still marked auth
+  // hydrated, so the gate fell through to the login screen for a user who was
+  // actually signed in — and tore down the startup skeleton on the way.
+  it("hydrate always settles loading, even when the backend throws", async () => {
+    authMock.getSession.mockRejectedValueOnce(new Error("network down"));
+    authMock.onAuthStateChange.mockImplementation(() => {});
+
+    await expect(useAuthStore.getState().hydrate()).resolves.toBeUndefined();
+
+    expect(useAuthStore.getState().loading).toBe(false);
+    expect(useAuthStore.getState().session).toBeNull();
+    expect(useAuthStore.getState().errorMessage).toBe("network down");
+  });
+
+  it("hydrate replaces its auth listener instead of stacking one per call", async () => {
+    // StrictMode double-invokes the effect that calls hydrate, and the
+    // subscription outlives it — without an unsubscribe every cold start left
+    // another listener behind, each re-running bootstrap on every auth event.
+    const unsubscribe = vi.fn();
+    authMock.getSession.mockResolvedValue(null);
+    authMock.onAuthStateChange.mockImplementation(() => unsubscribe);
+
+    await useAuthStore.getState().hydrate();
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    await useAuthStore.getState().hydrate();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
   it("hydrate auth listener stores token compatibility aliases", async () => {
     authMock.getSession.mockResolvedValueOnce(null);
     authMock.onAuthStateChange.mockImplementation((listener) => {

--- a/packages/app/src/stores/auth-store.ts
+++ b/packages/app/src/stores/auth-store.ts
@@ -17,6 +17,11 @@ export type { AuthClaimResult } from "@/lib/backend";
 
 export type AuthFlow = "idle" | "invite";
 
+// Held outside the store because the subscription is process-wide, not part of
+// the rendered state: `hydrate` may run more than once (StrictMode) and each
+// run must replace the previous listener rather than stack another one.
+let unsubscribeAuthState: (() => void) | null = null;
+
 type StoreAuthSession = AuthSession & {
   access_token?: string | null;
   refresh_token?: string | null;
@@ -171,22 +176,38 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   hydrate: async () => {
     set({ loading: true, authFlow: "idle", errorMessage: null });
     markStartup("auth-hydrate:start");
-    let session = await getBackend().auth.getSession();
-    // Drop sessions minted for a different backend (e.g. cloud.ucar.cc) so a
-    // local self-host `.env.local` switch doesn't keep sending stale JWTs.
-    if (session?.accessToken) {
-      const { cloudApiUrl } = await getEffectiveServerConfig();
-      if (!accessTokenMatchesBackend(session.accessToken, cloudApiUrl)) {
-        await getBackend().auth.signOut();
-        session = null;
+    let session: AuthSession | null;
+    try {
+      session = await getBackend().auth.getSession();
+      // Drop sessions minted for a different backend (e.g. cloud.ucar.cc) so a
+      // local self-host `.env.local` switch doesn't keep sending stale JWTs.
+      if (session?.accessToken) {
+        const { cloudApiUrl } = await getEffectiveServerConfig();
+        if (!accessTokenMatchesBackend(session.accessToken, cloudApiUrl)) {
+          await getBackend().auth.signOut();
+          session = null;
+        }
       }
+    } catch (error) {
+      // Every await above must land in a defined state. An unhandled throw here
+      // used to leave `loading` stuck at true with `session` null while
+      // AuthGate's `.finally()` still flipped `authHydrated` — the exact
+      // combination that renders the login screen for an already-signed-in user
+      // on cold start, and tears the startup skeleton down with it.
+      session = null;
+      set({ errorMessage: errorMessageFor(error) });
     }
     markStartup("auth-session:end");
     set({ session: storeSession(session), loading: false });
     if (session) {
       void fetchAndApplyBootstrap({ accessToken: session.accessToken });
     }
-    getBackend().auth.onAuthStateChange((session) => {
+    // StrictMode double-invokes the effect that calls hydrate, and this
+    // subscription outlives it. Drop the previous one first so a cold start
+    // doesn't accumulate listeners that each re-run bootstrap on every auth
+    // event.
+    unsubscribeAuthState?.();
+    unsubscribeAuthState = getBackend().auth.onAuthStateChange((session) => {
       set({ session: storeSession(session) });
       if (session) {
         void fetchAndApplyBootstrap({ accessToken: session.accessToken });


### PR DESCRIPTION
An already-signed-in user saw the **login page flash**, then "Starting daemon…", then the app. Two defects combined.

## Root cause

**1. `hydrate` had no try/catch around its awaits** (`stores/auth-store.ts`). A throwing `getSession()` or `getEffectiveServerConfig()` skipped `set({ session, loading: false })` entirely, leaving `loading` stuck at `true` with `session` null. (Same shape as the `loadFirstPage` bug that tops Sentry — unguarded `await`s that strand a loading flag.)

**2. AuthGate's guard was a conjunction, and the real one was ordered too late** (`components/auth/AuthGate.tsx:334-345`):

```jsx
334  if (!authHydrated && loading) return null;   // ← stops guarding when EITHER clears
338  if (!session) {
339    removeStartupSkeleton();                   // ← irreversible
340    return isTauri() ? <DesktopOnboarding /> : <LoginScreen />;   // ← the flash
341  }
343  if (loading) return null;                    // ← the real guard, too late
```

AuthGate marks `authHydrated` from `.finally()`, so a **rejected** hydrate still unlocked the gate. State `(authHydrated=true, loading=true, session=null)` sails past 334 and renders login.

That the "Starting daemon…" screen appears *after* the flash confirms the diagnosis: daemon refresh is gated on `session && bootstrap === "ready"` (`AuthGate.tsx:117-119`), so it can only run once `session` is non-null — proving `session` was null in the earlier frame.

## Fix

- `hydrate` catches its own failures and always settles into a defined state.
- Gate on `authHydrated` **alone**.
- Unsubscribe the previous `onAuthStateChange` listener before registering a new one.

## Two deliberate non-changes, both load-bearing

- **Not gating on `loading`.** The obvious fix — hoist `if (loading) return null` above the `!session` branch — is **wrong**. `loading` is shared by *every* auth action (`sendOtp`, `verifyOtp`, OAuth, WebSSO, invite — 12 `set({ loading: true })` sites). Gating the login branch on it would blank the login screen the moment a signed-out user submits their OTP.
- **Keeping `.finally()`** rather than switching to `.then()`. With hydrate no longer able to reject, `.finally()` is the safer of the two: an unblocked gate showing login beats a gate that never unblocks and leaves the startup skeleton up forever.

## Verification

Two regression tests added, and **both were confirmed to fail without the source change** (stashed `auth-store.ts`, kept the tests):

```
× hydrate always settles loading, even when the backend throws
× hydrate replaces its auth listener instead of stacking one per call
Tests  2 failed | 32 passed
```

With the fix: `34 passed`. Typecheck clean; auth suites 322/322.

**Not verified by running the app** — I have not reproduced the flash in a live cold start, so which of the failure windows actually fires for this user is still unconfirmed. This fix closes the render-layer window for all of them; it does not diagnose the underlying throw. If you want that pinned down, instrumenting a cold start is the next step.

## ⚠️ `main` is currently lint-red, independent of this PR

`packages/app/src/App.tsx:235` imports `CloudApiError` unused, introduced by `7bde4943` (merged via #642):

```
error  'CloudApiError' is defined but never used  @typescript-eslint/no-unused-vars
✖ 1 error
```

Confirmed present on a clean `origin/main` checkout with everything stashed. **This will fail `Lint, Typecheck & Test` on this PR and every other open PR until it is fixed on main.** Not fixed here to keep this diff to the bug at hand — happy to send the one-line removal separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)