### PR TITLE
fix(notifications): 桌面通知从未触发 — actor id 被锁死为 null

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -232,7 +232,6 @@ import {
   readPendingSessionDeeplink,
   stashPendingSessionDeeplink,
 } from "@/lib/open-session-deeplink";
-import { CloudApiError } from "@/lib/backend/cloud-api/http";
 import { useCurrentTeamStore } from "@/stores/current-team";
 import { useTeamShareStore, isShareModeLocked } from "@/stores/team-share";
 import { resolveCurrentMemberActorId } from "@/lib/current-actor";

--- a/packages/app/src/hooks/__tests__/useDesktopNotifications.test.tsx
+++ b/packages/app/src/hooks/__tests__/useDesktopNotifications.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const { ensurePermission, createDispatcher, loadPrefs, authState } = vi.hoisted(() => ({
+  ensurePermission: vi.fn(),
+  createDispatcher: vi.fn(),
+  loadPrefs: vi.fn(),
+  authState: { userId: null as string | null },
+}));
+
+vi.mock('@/lib/utils', () => ({ isTauri: () => true }));
+vi.mock('@/lib/notifications/desktop-notifier', () => ({ ensurePermission }));
+vi.mock('@/lib/notifications/message-dispatcher', () => ({ createDispatcher }));
+vi.mock('@/lib/notifications/preferences', () => ({
+  loadPrefs,
+  isInDndWindow: () => false,
+  isSessionMuted: vi.fn().mockResolvedValue(false),
+}));
+vi.mock('@/stores/auth-store', () => ({
+  useAuthStore: (selector: (s: unknown) => unknown) =>
+    selector({ session: authState.userId ? { user: { id: authState.userId } } : null }),
+}));
+vi.mock('@/stores/session-list-store', () => ({
+  useSessionListStore: { getState: () => ({ rows: [] }) },
+}));
+vi.mock('@/stores/session-store', () => ({
+  useSessionStore: { getState: () => ({ currentSessionId: null }) },
+}));
+vi.mock('@/stores/actors-store', () => ({
+  useActorsStore: { getState: () => ({ get: () => null }) },
+}));
+
+import { useDesktopNotifications, getDispatcher } from '../useDesktopNotifications';
+
+describe('useDesktopNotifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The dispatcher lives at module scope; a signed-out render clears it so
+    // state does not leak between tests.
+    authState.userId = null;
+    renderHook(() => useDesktopNotifications(null));
+    authState.userId = 'user-1';
+    ensurePermission.mockResolvedValue(true);
+    loadPrefs.mockResolvedValue({ enabled: true, dnd_start_min: null, dnd_end_min: null, dnd_tz: 'UTC' });
+    createDispatcher.mockImplementation((deps: unknown) => ({ deps, maybeNotify: vi.fn() }));
+  });
+
+  it('defers init until the actor id resolves, then builds a dispatcher with it', async () => {
+    // App.tsx resolves the actor id asynchronously, so the first render passes null.
+    const { rerender } = renderHook(({ actorId }) => useDesktopNotifications(actorId), {
+      initialProps: { actorId: null as string | null },
+    });
+    await waitFor(() => expect(ensurePermission).not.toHaveBeenCalled());
+    expect(getDispatcher()).toBeNull();
+
+    rerender({ actorId: 'actor-1' });
+    await waitFor(() => expect(getDispatcher()).not.toBeNull());
+    expect(createDispatcher.mock.calls[0][0]).toMatchObject({ currentActorId: 'actor-1' });
+  });
+
+  it('re-inits when the actor id changes (team switch)', async () => {
+    const { rerender } = renderHook(({ actorId }) => useDesktopNotifications(actorId), {
+      initialProps: { actorId: 'actor-1' as string | null },
+    });
+    await waitFor(() => expect(createDispatcher).toHaveBeenCalledTimes(1));
+
+    rerender({ actorId: 'actor-2' });
+    await waitFor(() => expect(createDispatcher).toHaveBeenCalledTimes(2));
+    expect(createDispatcher.mock.calls[1][0]).toMatchObject({ currentActorId: 'actor-2' });
+  });
+
+  it('does not re-init for an unchanged actor id', async () => {
+    const { rerender } = renderHook(({ actorId }) => useDesktopNotifications(actorId), {
+      initialProps: { actorId: 'actor-1' as string | null },
+    });
+    await waitFor(() => expect(createDispatcher).toHaveBeenCalledTimes(1));
+
+    rerender({ actorId: 'actor-1' });
+    await waitFor(() => expect(createDispatcher).toHaveBeenCalledTimes(1));
+  });
+
+  it('installs no dispatcher when the OS denies permission', async () => {
+    ensurePermission.mockResolvedValue(false);
+    renderHook(() => useDesktopNotifications('actor-1'));
+    await waitFor(() => expect(ensurePermission).toHaveBeenCalledTimes(1));
+    expect(createDispatcher).not.toHaveBeenCalled();
+    expect(getDispatcher()).toBeNull();
+  });
+});

--- a/packages/app/src/hooks/useDesktopNotifications.ts
+++ b/packages/app/src/hooks/useDesktopNotifications.ts
@@ -37,26 +37,36 @@ export function getDispatcher(): Dispatcher | null {
  * @param currentActorId  The actor-table `id` for the signed-in user in the
  *   current team.  Resolved in App.tsx via
  *   `SELECT id FROM actors WHERE user_id = $userId AND team_id = $teamId`.
- *   Pass `null` until the query resolves; the effect re-runs when it arrives.
+ *   Pass `null` until the query resolves; init is deferred until it arrives.
  *
- * Idempotency: ranRef prevents double-init when deps haven't changed.
- * Sign-out: userId → null clears the dispatcher and resets the init flag.
+ * Idempotency: initKeyRef prevents double-init for the same (userId, actorId).
+ * Sign-out: userId → null clears the dispatcher and resets the init key.
  */
 export function useDesktopNotifications(currentActorId: string | null = null) {
   const userId = useAuthStore((s) => s.session?.user?.id ?? null);
-  const ranRef = useRef(false);
+  const initKeyRef = useRef<string | null>(null);
 
   // Clear dispatcher on sign-out so stale user context is never used.
   useEffect(() => {
     if (!userId) {
       activeDispatcher = null;
-      ranRef.current = false;
+      initKeyRef.current = null;
     }
   }, [userId]);
 
   useEffect(() => {
-    if (!isTauri() || !userId || ranRef.current) return;
-    ranRef.current = true;
+    if (!isTauri() || !userId) return;
+    // App.tsx resolves the actor id asynchronously (MQTT wiring effect), so on
+    // first render it is still null. A dispatcher built with a null actor id
+    // can never notify — it cannot tell our own messages apart from other
+    // people's — so wait for the real id instead of latching on the null one.
+    if (!currentActorId) return;
+
+    // Re-init whenever the (user, actor) pair changes — e.g. team switch — and
+    // retry after a failed init (permission denied, prefs load error).
+    const initKey = `${userId}|${currentActorId}`;
+    if (initKeyRef.current === initKey) return;
+    initKeyRef.current = initKey;
 
     // Capture both at creation time to avoid stale closures.
     const capturedUserId = userId;
@@ -64,14 +74,20 @@ export function useDesktopNotifications(currentActorId: string | null = null) {
 
     void (async () => {
       const granted = await ensurePermission();
-      if (!granted) return;
+      if (!granted) {
+        console.warn('[notifications] OS permission not granted — desktop notifications disabled');
+        if (initKeyRef.current === initKey) initKeyRef.current = null;
+        return;
+      }
 
       const prefs = await loadPrefs(capturedUserId);
       if (!prefs.enabled) return;
 
+      // A newer (userId, actorId) pair started initialising while we awaited —
+      // let it win rather than installing a stale dispatcher.
+      if (initKeyRef.current !== initKey) return;
+
       activeDispatcher = createDispatcher({
-        // currentActorId may be null if the actors query hasn't returned yet.
-        // The dispatcher skips notification when currentActorId is null (safe).
         currentActorId: capturedActorId,
 
         isParticipant: async (sid) => {
@@ -105,6 +121,6 @@ export function useDesktopNotifications(currentActorId: string | null = null) {
       });
     })();
   // Re-run when userId or currentActorId changes (e.g. team switch).
-  // ranRef ensures we don't init twice for the same (userId, actorId) pair.
+  // initKeyRef ensures we don't init twice for the same (userId, actorId) pair.
   }, [userId, currentActorId]);
 }


### PR DESCRIPTION
## 问题

桌面端收到消息后**一条系统通知都不会弹**。

## 根因

`App.tsx:790` 调用 `useDesktopNotifications(myActorId)`,而 `myActorId` 是在 MQTT wiring effect 里异步解析的(`App.tsx:1267-1281`),首次渲染必然为 `null`。

旧代码用布尔 `ranRef` 做幂等:登录后 `userId` 一到位就立即 init 并置 `ranRef = true`,此时捕获的 `capturedActorId` 还是 `null`;等真正的 actorId 到达、effect 重跑时,已被 `ranRef` 挡住。于是 dispatcher 永久带着 `currentActorId: null`,而 `message-dispatcher.ts:29` 的第一道判断就是:

```ts
if (!deps.currentActorId || msg.sender_actor_id === deps.currentActorId) return;
```

→ 每条消息都在这里返回,通知永远不弹。

链路其余部分本身是好的:`capabilities/default.json` 已声明 `notification:allow-show`,`lib.rs:316` 已注册插件,`App.tsx:1648` MQTT 入口已调用 `maybeNotify`。

## 改动

- 布尔 `ranRef` → `initKeyRef`,key 为 `${userId}|${actorId}`:
  - actorId 为 `null` 时**不 init**(带 null actorId 的 dispatcher 本来也无法工作),等它到位再建;
  - actorId 变化(团队切换)时重建;
  - 同一对不重复 init。
- 权限被 OS 拒绝时清掉 init key 并打 warn,不再永久锁死。
- stale-init 保护:await 期间若有更新的 (userId, actorId) 开始初始化,旧的那次不覆盖。

## 测试

新增 `packages/app/src/hooks/__tests__/useDesktopNotifications.test.tsx`(4 例)。第一例"延迟到 actorId 到位再 init"就是针对旧代码的回归测试。

本地已跑:通知相关 4 个测试文件 18 例全绿、`pnpm typecheck` 干净、改动文件 eslint 干净。

## 范围说明

本 PR 只修 MQTT 这条消息入口。本地 agent 回复 / SSE 等其他入口目前仍不触发通知;另外 `lib/notification-service.ts` 是并存的第二套通知逻辑(窗口可见即抑制、按 level 过滤),两套重复,值得后续合并 — 均不在本 PR 范围内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)