### PR TITLE
fix(lint): drop the orphaned CloudApiError import in App.tsx

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -232,7 +232,6 @@ import {
   readPendingSessionDeeplink,
   stashPendingSessionDeeplink,
 } from "@/lib/open-session-deeplink";
-import { CloudApiError } from "@/lib/backend/cloud-api/http";
 import { useCurrentTeamStore } from "@/stores/current-team";
 import { useTeamShareStore, isShareModeLocked } from "@/stores/team-share";
 import { resolveCurrentMemberActorId } from "@/lib/current-actor";


### PR DESCRIPTION
`main` is currently red on `Lint, Typecheck & Test`, which blocks **every open PR branched off it** (#641, #644, and any others).

```
packages/app/src/App.tsx
  235:10  error  'CloudApiError' is defined but never used  @typescript-eslint/no-unused-vars
✖ 1 error
```

## Cause

`7bde4943` ("fix(app): restore session deeplink navigation after team switch", merged via #642) moved the deeplink join's `try/catch` out of `App.tsx` and into the new `lib/open-session-deeplink.ts`, but left the import behind.

## Why deleting it is safe

The branches that used it moved intact — `lib/open-session-deeplink.ts:69-71`:

```ts
if (err instanceof CloudApiError && err.status === 403) {
  ...
} else if (err instanceof CloudApiError && err.status === 404) {
```

so this removes an import and nothing else. I checked this specifically rather than deleting on the lint error alone — an unused import can just as easily mean handling that was *dropped* by mistake. Here it was relocated.

## Verification

- `pnpm lint` → **0 errors** (59 pre-existing warnings unchanged)
- `pnpm typecheck` → clean
- `open-session-deeplink.test.ts` → 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)