### PR TITLE
fix(runtime): auto-select first model and route subagent permissions

### DIFF
--- a/apps/daemon/src/runtime/opencode_http/events.rs
+++ b/apps/daemon/src/runtime/opencode_http/events.rs
@@ -135,6 +135,7 @@ async fn handle_event(shared: &Arc<Shared>, event: &serde_json::Value) {
     match event_type {
         "permission.asked" => handle_permission_asked(shared, &session_id, &props).await,
         "session.idle" => handle_session_idle(shared, &session_id).await,
+        "session.created" => handle_session_created(shared, &session_id, &props).await,
         "session.updated" => handle_session_updated(shared, &session_id, &props).await,
         "session.status" => handle_session_status(shared, &session_id, &props).await,
         "question.asked" => handle_question_asked(shared, &session_id, &props).await,
@@ -155,11 +156,21 @@ async fn handle_event(shared: &Arc<Shared>, event: &serde_json::Value) {
                 if route.turn_active && super::is_turn_progress_event(event_type) {
                     route.turn_last_event_at = std::time::Instant::now();
                 }
+                let parent_id = route.parent_session_id.clone();
                 let events = translate::translate_event(&mut route.translate, event_type, &props);
                 if !events.is_empty() {
                     route.turn_saw_output = true;
                 }
-                (events, route.event_tx.clone(), route.turn_reply_to.clone())
+                let out = (events, route.event_tx.clone(), route.turn_reply_to.clone());
+                // Keep parent's stuck-turn clock alive while the subagent works.
+                if let Some(parent_id) = parent_id {
+                    if let Some(parent) = routes.get_mut(&parent_id) {
+                        if parent.turn_active && super::is_turn_progress_event(event_type) {
+                            parent.turn_last_event_at = std::time::Instant::now();
+                        }
+                    }
+                }
+                out
             };
             for ev in events {
                 crate::runtime::agent_trace::log_acp_event(&session_id, &ev);
@@ -183,7 +194,27 @@ async fn handle_permission_asked(
         .and_then(|v| v.as_str())
         .unwrap_or_default()
         .to_string();
-    let (permission, directory, event_tx, requester) = {
+
+    // Subagent sessions created by opencode `task` are not attach()'d by amuxd.
+    // Register a lightweight child route (parent event_tx + directory) so the
+    // ask reaches the desktop while reply still targets this session_id.
+    if !shared.routes.lock().contains_key(session_id) {
+        if let Some(parent_id) = resolve_parent_session_id(shared, session_id).await {
+            if !shared.ensure_child_route(session_id, &parent_id) {
+                warn!(
+                    session_id,
+                    parent_id = %parent_id,
+                    "permission.asked: parent route missing; dropping"
+                );
+                return;
+            }
+        } else {
+            warn!(session_id, "permission.asked for unrouted session");
+            return;
+        }
+    }
+
+    let (permission, directory, event_tx, requester, is_child) = {
         let routes = shared.routes.lock();
         let Some(route) = routes.get(session_id) else {
             warn!(session_id, "permission.asked for unrouted session");
@@ -194,6 +225,7 @@ async fn handle_permission_asked(
             route.directory.clone(),
             route.event_tx.clone(),
             route.turn_requester.clone(),
+            route.parent_session_id.is_some(),
         )
     };
 
@@ -212,20 +244,95 @@ async fn handle_permission_asked(
         return;
     }
 
+    // Reply path looks up this map by request id → opencode session id. Keep
+    // the *child* id here even when frames ride the parent's event_tx.
     shared
         .permissions
         .lock()
         .insert(permission_id.clone(), session_id.to_string());
-    let ev = translate::permission_request_event(props, requester.as_deref());
+    let child_sid = is_child.then_some(session_id);
+    let ev = translate::permission_request_event(props, requester.as_deref(), child_sid);
     crate::runtime::agent_trace::log_acp_event(session_id, &ev);
     let reply_to = shared
         .routes
         .lock()
         .get(session_id)
         .and_then(|r| r.turn_reply_to.clone());
+    shared.touch_turn_transport_activity(session_id);
     let _ = event_tx
         .send(AcpEventFrame::new(session_id, ev).with_reply_to(reply_to))
         .await;
+}
+
+/// opencode `session.created` / updated Session objects carry `parentID` for
+/// task subagents. Register a child→parent route alias early so later
+/// permission / tool events are not dropped as "unrouted".
+async fn handle_session_created(shared: &Arc<Shared>, session_id: &str, props: &serde_json::Value) {
+    maybe_register_subagent_route(shared, session_id, props);
+}
+
+fn session_info_parent_id(props: &serde_json::Value) -> Option<String> {
+    props
+        .pointer("/info/parentID")
+        .or_else(|| props.get("parentID"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+fn maybe_register_subagent_route(shared: &Arc<Shared>, session_id: &str, props: &serde_json::Value) {
+    let Some(parent_id) = session_info_parent_id(props) else {
+        return;
+    };
+    let _ = shared.ensure_child_route(session_id, &parent_id);
+}
+
+/// Look up `Session.parentID` for an unrouted child via `GET /session/{id}`
+/// across known worktree directories.
+async fn resolve_parent_session_id(shared: &Arc<Shared>, child_id: &str) -> Option<String> {
+    {
+        let routes = shared.routes.lock();
+        if let Some(parent) = routes
+            .get(child_id)
+            .and_then(|r| r.parent_session_id.clone())
+        {
+            return Some(parent);
+        }
+    }
+    let directories: Vec<String> = {
+        let routes = shared.routes.lock();
+        let mut dirs: Vec<String> = routes.values().map(|r| r.directory.clone()).collect();
+        dirs.sort();
+        dirs.dedup();
+        dirs
+    };
+    if directories.is_empty() {
+        return None;
+    }
+    let client = shared.serve.ensure().await.ok()?;
+    for directory in directories {
+        match client.get_session(&directory, child_id).await {
+            Ok(Some(session)) => {
+                return session
+                    .get("parentID")
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+            }
+            Ok(None) => continue,
+            Err(e) => {
+                debug!(
+                    child_id,
+                    directory = %directory,
+                    error = %e,
+                    "get_session while resolving subagent parent failed"
+                );
+            }
+        }
+    }
+    None
 }
 
 /// opencode's `question` tool asks the user to pick/type answers. Register
@@ -242,6 +349,21 @@ async fn handle_question_asked(shared: &Arc<Shared>, session_id: &str, props: &s
     let Some(request_id) = props.get("id").and_then(|v| v.as_str()) else {
         return;
     };
+    if !shared.routes.lock().contains_key(session_id) {
+        if let Some(parent_id) = resolve_parent_session_id(shared, session_id).await {
+            if !shared.ensure_child_route(session_id, &parent_id) {
+                warn!(
+                    session_id,
+                    parent_id = %parent_id,
+                    "question.asked: parent route missing; dropping"
+                );
+                return;
+            }
+        } else {
+            warn!(session_id, "question.asked for unrouted session");
+            return;
+        }
+    }
     let full_access = {
         let routes = shared.routes.lock();
         match routes.get(session_id) {
@@ -401,6 +523,9 @@ async fn handle_session_status(shared: &Arc<Shared>, session_id: &str, props: &s
 /// `session_title` raw control event; the daemon server decides whether the
 /// TeamClaw session still carries a default title worth replacing.
 async fn handle_session_updated(shared: &Arc<Shared>, session_id: &str, props: &serde_json::Value) {
+    // Task subagents may only surface parentID on updated (or we missed created).
+    maybe_register_subagent_route(shared, session_id, props);
+
     let title = props
         .pointer("/info/title")
         .and_then(|v| v.as_str())
@@ -415,6 +540,10 @@ async fn handle_session_updated(shared: &Arc<Shared>, session_id: &str, props: &
         let Some(route) = routes.get(session_id) else {
             return;
         };
+        // Subagent title updates are noise for the TeamClaw session title.
+        if route.parent_session_id.is_some() {
+            return;
+        }
         (route.event_tx.clone(), route.turn_reply_to.clone())
     };
     let ev = amux::AcpEvent {

--- a/apps/daemon/src/runtime/opencode_http/events.rs
+++ b/apps/daemon/src/runtime/opencode_http/events.rs
@@ -387,6 +387,7 @@ async fn handle_question_asked(shared: &Arc<Shared>, session_id: &str, props: &s
         .questions
         .lock()
         .insert(request_id.to_string(), session_id.to_string());
+    shared.touch_turn_transport_activity(session_id);
     forward_question_raw(shared, session_id, "question_asked", props).await;
 }
 

--- a/apps/daemon/src/runtime/opencode_http/mod.rs
+++ b/apps/daemon/src/runtime/opencode_http/mod.rs
@@ -77,6 +77,11 @@ pub(crate) struct Route {
     /// for this session (gateway `send` tool / remote tools). Pruned back out
     /// on detach / re-attach so stale entries don't accumulate.
     pub(crate) injected_mcp: Vec<String>,
+    /// Set when this route is a lightweight alias for an opencode `task`
+    /// subagent session (`Session.parentID`). Frames still carry the child
+    /// `acp_session_id`; only the delivery channel / directory / permission
+    /// policy are inherited from the parent attach.
+    pub(crate) parent_session_id: Option<String>,
 }
 
 pub(crate) struct Shared {
@@ -169,11 +174,60 @@ impl Shared {
 
     pub(super) fn touch_turn_transport_activity(&self, session_id: &str) {
         let mut routes = self.routes.lock();
+        let parent_id = routes
+            .get(session_id)
+            .and_then(|r| r.parent_session_id.clone());
+        let now = std::time::Instant::now();
         if let Some(route) = routes.get_mut(session_id) {
             if route.turn_active {
-                route.turn_last_event_at = std::time::Instant::now();
+                route.turn_last_event_at = now;
             }
         }
+        // Subagent progress must keep the parent's stuck-turn watchdog alive.
+        if let Some(parent_id) = parent_id {
+            if let Some(route) = routes.get_mut(&parent_id) {
+                if route.turn_active {
+                    route.turn_last_event_at = now;
+                }
+            }
+        }
+    }
+
+    /// Register a lightweight route for an opencode task subagent session so
+    /// its SSE events (`permission.asked`, tool deltas, …) are forwarded on
+    /// the parent's `event_tx` while keeping `acp_session_id` = child.
+    pub(super) fn ensure_child_route(&self, child_id: &str, parent_id: &str) -> bool {
+        if child_id.is_empty() || parent_id.is_empty() || child_id == parent_id {
+            return false;
+        }
+        let mut routes = self.routes.lock();
+        if routes.contains_key(child_id) {
+            return true;
+        }
+        let Some(parent) = routes.get(parent_id) else {
+            return false;
+        };
+        let child = Route {
+            event_tx: parent.event_tx.clone(),
+            permission: parent.permission,
+            directory: parent.directory.clone(),
+            model: None,
+            turn_active: false,
+            turn_reply_to: parent.turn_reply_to.clone(),
+            turn_requester: parent.turn_requester.clone(),
+            turn_seq: 0,
+            turn_saw_output: false,
+            turn_last_event_at: std::time::Instant::now(),
+            translate: TranslateState::default(),
+            injected_mcp: Vec::new(),
+            parent_session_id: Some(parent_id.to_string()),
+        };
+        routes.insert(child_id.to_string(), child);
+        info!(
+            child_id,
+            parent_id, "registered lightweight opencode subagent route"
+        );
+        true
     }
 
     pub(super) fn refresh_active_turn_clocks_for_directory(&self, directory: &str) {
@@ -655,6 +709,7 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
                 turn_last_event_at: std::time::Instant::now(),
                 translate: TranslateState::default(),
                 injected_mcp,
+                parent_session_id: None,
             },
         );
         orphaned_turn
@@ -1210,8 +1265,20 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                 None => warn!(model_id = %model_id, "set_model: expected provider/model id"),
             },
             AcpCommand::DetachSession { acp_session_id } => {
-                let (pruned, orphaned_turn) = {
+                let (pruned, orphaned_turn, detached_session_ids) = {
                     let mut routes = shared.routes.lock();
+                    let mut detached_session_ids = vec![acp_session_id.clone()];
+                    // Drop lightweight subagent aliases that pointed at this
+                    // parent before removing the parent itself.
+                    routes.retain(|id, route| {
+                        if route.parent_session_id.as_deref() == Some(acp_session_id.as_str())
+                        {
+                            detached_session_ids.push(id.clone());
+                            false
+                        } else {
+                            true
+                        }
+                    });
                     let removed = routes.remove(&acp_session_id);
                     let mut orphaned_turn = None;
                     let pruned = removed.map(|mut route| {
@@ -1226,16 +1293,17 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                         );
                         (route.directory, names)
                     });
-                    (pruned, orphaned_turn)
+                    (pruned, orphaned_turn, detached_session_ids)
                 };
                 close_orphaned_turn(&acp_session_id, orphaned_turn).await;
                 if let Some((directory, names)) = pruned {
                     prune_mcp_servers_from_worktree(&directory, &names);
                 }
-                shared
-                    .permissions
-                    .lock()
-                    .retain(|_, sid| sid != &acp_session_id);
+                shared.permissions.lock().retain(|_, sid| {
+                    !detached_session_ids
+                        .iter()
+                        .any(|detached| detached == sid)
+                });
                 info!(acp_session_id, "opencode session detached");
             }
             AcpCommand::Shutdown => {
@@ -1478,6 +1546,7 @@ mod pool_tests {
                 turn_last_event_at: std::time::Instant::now(),
                 translate: TranslateState::default(),
                 injected_mcp: vec!["amuxd-send".to_string()],
+                parent_session_id: None,
             },
         );
         let candidates = vec!["amuxd-send".to_string(), "remote-tools".to_string()];
@@ -1508,6 +1577,7 @@ mod turn_activity_tests {
                 .unwrap_or_else(std::time::Instant::now),
             translate: TranslateState::default(),
             injected_mcp: Vec::new(),
+            parent_session_id: None,
         }
     }
 
@@ -1544,6 +1614,110 @@ mod turn_activity_tests {
         assert!(taken.is_none());
         close_orphaned_turn("ses_1", taken).await;
         assert!(rx.try_recv().is_err(), "no spurious idle for an idle route");
+    }
+
+    #[test]
+    fn ensure_child_route_aliases_parent_delivery_channel() {
+        let shared = Shared::new();
+        {
+            let mut routes = shared.routes.lock();
+            routes.insert("ses_parent".to_string(), test_route("/ws"));
+        }
+        assert!(shared.ensure_child_route("ses_child", "ses_parent"));
+        let routes = shared.routes.lock();
+        let child = routes.get("ses_child").expect("child route");
+        let parent = routes.get("ses_parent").expect("parent route");
+        assert_eq!(child.parent_session_id.as_deref(), Some("ses_parent"));
+        assert_eq!(child.directory, parent.directory);
+        assert!(!child.turn_active);
+        // Second call is idempotent.
+        drop(routes);
+        assert!(shared.ensure_child_route("ses_child", "ses_parent"));
+    }
+
+    #[test]
+    fn child_progress_refreshes_parent_watchdog_clock() {
+        let shared = Shared::new();
+        {
+            let mut routes = shared.routes.lock();
+            routes.insert("ses_parent".to_string(), test_route("/ws"));
+        }
+        assert!(shared.ensure_child_route("ses_child", "ses_parent"));
+        {
+            let mut routes = shared.routes.lock();
+            let parent = routes.get_mut("ses_parent").unwrap();
+            parent.turn_last_event_at = std::time::Instant::now()
+                .checked_sub(std::time::Duration::from_secs(90))
+                .unwrap();
+        }
+        shared.touch_turn_transport_activity("ses_child");
+        let elapsed = shared
+            .routes
+            .lock()
+            .get("ses_parent")
+            .unwrap()
+            .turn_last_event_at
+            .elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "parent turn clock should refresh from child activity"
+        );
+    }
+
+    #[test]
+    fn detach_clears_permissions_for_parent_and_child_routes() {
+        let shared = Shared::new();
+        {
+            let mut routes = shared.routes.lock();
+            routes.insert("ses_parent".to_string(), test_route("/ws"));
+            let parent_tx = routes.get("ses_parent").unwrap().event_tx.clone();
+            routes.insert(
+                "ses_child".to_string(),
+                Route {
+                    event_tx: parent_tx,
+                    permission: PermissionPolicy::Ask,
+                    directory: "/ws".to_string(),
+                    model: None,
+                    turn_active: false,
+                    turn_reply_to: None,
+                    turn_requester: None,
+                    turn_seq: 0,
+                    turn_saw_output: false,
+                    turn_last_event_at: std::time::Instant::now(),
+                    translate: TranslateState::default(),
+                    injected_mcp: Vec::new(),
+                    parent_session_id: Some("ses_parent".to_string()),
+                },
+            );
+        }
+        {
+            let mut perms = shared.permissions.lock();
+            perms.insert("perm_parent".to_string(), "ses_parent".to_string());
+            perms.insert("perm_child".to_string(), "ses_child".to_string());
+            perms.insert("perm_other".to_string(), "ses_other".to_string());
+        }
+
+        {
+            let mut routes = shared.routes.lock();
+            let mut detached_session_ids = vec!["ses_parent".to_string()];
+            routes.retain(|id, route| {
+                if route.parent_session_id.as_deref() == Some("ses_parent") {
+                    detached_session_ids.push(id.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+            routes.remove("ses_parent");
+            shared.permissions.lock().retain(|_, sid| {
+                !detached_session_ids.iter().any(|detached| detached == sid)
+            });
+        }
+
+        let remaining = shared.permissions.lock();
+        assert!(!remaining.contains_key("perm_parent"));
+        assert!(!remaining.contains_key("perm_child"));
+        assert_eq!(remaining.get("perm_other"), Some(&"ses_other".to_string()));
     }
 
     #[test]

--- a/apps/daemon/src/runtime/opencode_http/mod.rs
+++ b/apps/daemon/src/runtime/opencode_http/mod.rs
@@ -193,6 +193,59 @@ impl Shared {
         }
     }
 
+    /// Parent session id plus any registered task-subagent child alias ids.
+    /// Pending permissions/questions on children must pause the parent's
+    /// stuck-turn watchdog the same way top-level asks do.
+    pub(super) fn session_ids_for_user_wait(&self, parent_session_id: &str) -> Vec<String> {
+        let routes = self.routes.lock();
+        let mut ids = vec![parent_session_id.to_string()];
+        for (id, route) in routes.iter() {
+            if route.parent_session_id.as_deref() == Some(parent_session_id) {
+                ids.push(id.clone());
+            }
+        }
+        ids
+    }
+
+    pub(super) fn turn_waiting_on_user(&self, parent_session_id: &str) -> bool {
+        let wait_ids = self.session_ids_for_user_wait(parent_session_id);
+        let has_perm = self
+            .permissions
+            .lock()
+            .values()
+            .any(|sid| wait_ids.iter().any(|id| id == sid));
+        if has_perm {
+            return true;
+        }
+        self.questions
+            .lock()
+            .values()
+            .any(|sid| wait_ids.iter().any(|id| id == sid))
+    }
+
+    /// After re-attaching a parent session (new `event_tx`), refresh any
+    /// lightweight child alias routes so they forward on the live channel.
+    pub(super) fn sync_child_routes_from_parent(&self, parent_id: &str) {
+        let mut routes = self.routes.lock();
+        let Some(parent) = routes.get(parent_id) else {
+            return;
+        };
+        let event_tx = parent.event_tx.clone();
+        let permission = parent.permission;
+        let directory = parent.directory.clone();
+        let turn_reply_to = parent.turn_reply_to.clone();
+        let turn_requester = parent.turn_requester.clone();
+        for route in routes.values_mut() {
+            if route.parent_session_id.as_deref() == Some(parent_id) {
+                route.event_tx = event_tx.clone();
+                route.permission = permission;
+                route.directory = directory.clone();
+                route.turn_reply_to = turn_reply_to.clone();
+                route.turn_requester = turn_requester.clone();
+            }
+        }
+    }
+
     /// Register a lightweight route for an opencode task subagent session so
     /// its SSE events (`permission.asked`, tool deltas, …) are forwarded on
     /// the parent's `event_tx` while keeping `acp_session_id` = child.
@@ -201,7 +254,25 @@ impl Shared {
             return false;
         }
         let mut routes = self.routes.lock();
-        if routes.contains_key(child_id) {
+        if let Some(child) = routes.get(child_id) {
+            if child.parent_session_id.as_deref() != Some(parent_id) {
+                return false;
+            }
+            let Some(parent) = routes.get(parent_id) else {
+                return false;
+            };
+            let event_tx = parent.event_tx.clone();
+            let permission = parent.permission;
+            let directory = parent.directory.clone();
+            let turn_reply_to = parent.turn_reply_to.clone();
+            let turn_requester = parent.turn_requester.clone();
+            if let Some(child) = routes.get_mut(child_id) {
+                child.event_tx = event_tx;
+                child.permission = permission;
+                child.directory = directory;
+                child.turn_reply_to = turn_reply_to;
+                child.turn_requester = turn_requester;
+            }
             return true;
         }
         let Some(parent) = routes.get(parent_id) else {
@@ -715,6 +786,7 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
         orphaned_turn
     };
     close_orphaned_turn(&session_id, orphaned_turn).await;
+    shared.sync_child_routes_from_parent(&session_id);
 
     info!(
         session_id = %session_id,
@@ -903,17 +975,7 @@ fn spawn_stuck_turn_watchdog(shared: &Arc<Shared>, session_id: &str, turn_seq: u
             // Waiting on the USER (pending permission or question) is not a
             // stall — stand by until it resolves (resolution refreshes
             // turn_last_event_at).
-            let waiting_on_user = {
-                let p = shared.permissions.lock();
-                let has_perm = p.values().any(|sid| sid == &session_id);
-                drop(p);
-                has_perm
-                    || shared
-                        .questions
-                        .lock()
-                        .values()
-                        .any(|sid| sid == &session_id)
-            };
+            let waiting_on_user = shared.turn_waiting_on_user(&session_id);
             if waiting_on_user {
                 continue;
             }
@@ -1300,6 +1362,11 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                     prune_mcp_servers_from_worktree(&directory, &names);
                 }
                 shared.permissions.lock().retain(|_, sid| {
+                    !detached_session_ids
+                        .iter()
+                        .any(|detached| detached == sid)
+                });
+                shared.questions.lock().retain(|_, sid| {
                     !detached_session_ids
                         .iter()
                         .any(|detached| detached == sid)
@@ -1696,6 +1763,12 @@ mod turn_activity_tests {
             perms.insert("perm_child".to_string(), "ses_child".to_string());
             perms.insert("perm_other".to_string(), "ses_other".to_string());
         }
+        {
+            let mut questions = shared.questions.lock();
+            questions.insert("q_parent".to_string(), "ses_parent".to_string());
+            questions.insert("q_child".to_string(), "ses_child".to_string());
+            questions.insert("q_other".to_string(), "ses_other".to_string());
+        }
 
         {
             let mut routes = shared.routes.lock();
@@ -1712,12 +1785,77 @@ mod turn_activity_tests {
             shared.permissions.lock().retain(|_, sid| {
                 !detached_session_ids.iter().any(|detached| detached == sid)
             });
+            shared.questions.lock().retain(|_, sid| {
+                !detached_session_ids.iter().any(|detached| detached == sid)
+            });
         }
 
         let remaining = shared.permissions.lock();
         assert!(!remaining.contains_key("perm_parent"));
         assert!(!remaining.contains_key("perm_child"));
         assert_eq!(remaining.get("perm_other"), Some(&"ses_other".to_string()));
+        let remaining_q = shared.questions.lock();
+        assert!(!remaining_q.contains_key("q_parent"));
+        assert!(!remaining_q.contains_key("q_child"));
+        assert_eq!(remaining_q.get("q_other"), Some(&"ses_other".to_string()));
+    }
+
+    #[test]
+    fn child_pending_permission_pauses_parent_watchdog_wait() {
+        let shared = Shared::new();
+        {
+            let mut routes = shared.routes.lock();
+            routes.insert("ses_parent".to_string(), test_route("/ws"));
+        }
+        assert!(shared.ensure_child_route("ses_child", "ses_parent"));
+        assert!(
+            !shared.turn_waiting_on_user("ses_parent"),
+            "no pending interaction yet"
+        );
+        shared
+            .permissions
+            .lock()
+            .insert("perm_child".to_string(), "ses_child".to_string());
+        assert!(
+            shared.turn_waiting_on_user("ses_parent"),
+            "child permission should pause parent watchdog"
+        );
+    }
+
+    #[test]
+    fn sync_child_routes_follows_parent_reattach_channel() {
+        let shared = Shared::new();
+        let (tx_old, _rx_old) = mpsc::channel(1);
+        let (tx_new, mut rx_new) = mpsc::channel(1);
+        {
+            let mut routes = shared.routes.lock();
+            let mut parent = test_route("/ws");
+            parent.event_tx = tx_old;
+            routes.insert("ses_parent".to_string(), parent);
+        }
+        assert!(shared.ensure_child_route("ses_child", "ses_parent"));
+        {
+            let mut routes = shared.routes.lock();
+            routes.get_mut("ses_parent").unwrap().event_tx = tx_new;
+        }
+        shared.sync_child_routes_from_parent("ses_parent");
+        let child_tx = shared
+            .routes
+            .lock()
+            .get("ses_child")
+            .unwrap()
+            .event_tx
+            .clone();
+        child_tx
+            .try_send(AcpEventFrame::new(
+                "ses_child",
+                translate::status_change(amux::AgentStatus::Active, amux::AgentStatus::Idle),
+            ))
+            .expect("child route should use the refreshed parent channel");
+        assert!(
+            rx_new.try_recv().is_ok(),
+            "frame should arrive on the new parent channel"
+        );
     }
 
     #[test]

--- a/apps/daemon/src/runtime/opencode_http/translate.rs
+++ b/apps/daemon/src/runtime/opencode_http/translate.rs
@@ -360,9 +360,14 @@ pub fn permission_response_for(granted: bool, option_id: Option<&str>) -> &'stat
 
 /// Build the `AcpPermissionRequest` proto for a `permission.asked` event.
 /// `props` is the event's `properties` object (a `PermissionRequest`).
+///
+/// When `child_session_id` is set (opencode task subagent), stamp it into
+/// params so the desktop can bind the ask to the parent task tool while the
+/// reply still targets that child session id.
 pub fn permission_request_event(
     props: &serde_json::Value,
     requester_actor_id: Option<&str>,
+    child_session_id: Option<&str>,
 ) -> amux::AcpEvent {
     let id = props.get("id").and_then(|v| v.as_str()).unwrap_or("");
     let permission = props
@@ -387,6 +392,19 @@ pub fn permission_request_event(
         if !joined.is_empty() {
             params.entry("patterns".to_string()).or_insert(joined);
         }
+    }
+    if let Some(call_id) = props
+        .pointer("/tool/callID")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        params
+            .entry("toolCallId".to_string())
+            .or_insert_with(|| call_id.to_string());
+    }
+    if let Some(child) = child_session_id.map(str::trim).filter(|s| !s.is_empty()) {
+        params.insert("childSessionId".to_string(), child.to_string());
     }
     if let Some(requester) = requester_actor_id.filter(|s| !s.is_empty()) {
         params.insert("requester_actor_id".to_string(), requester.to_string());
@@ -616,13 +634,18 @@ mod tests {
             "patterns":["ls *"],"metadata":{"command":"ls"},"always":["bash"],
             "tool":{"messageID":"msg_1","callID":"call_1"}
         });
-        let e = permission_request_event(&props, Some("actor-a"));
+        let e = permission_request_event(&props, Some("actor-a"), Some("ses_child"));
         match e.event.as_ref().unwrap() {
             amux::acp_event::Event::PermissionRequest(p) => {
                 assert_eq!(p.request_id, "per_1");
                 assert_eq!(p.tool_name, "bash");
                 assert_eq!(p.params.get("command"), Some(&"ls".to_string()));
                 assert_eq!(p.params.get("patterns"), Some(&"ls *".to_string()));
+                assert_eq!(p.params.get("toolCallId"), Some(&"call_1".to_string()));
+                assert_eq!(
+                    p.params.get("childSessionId"),
+                    Some(&"ses_child".to_string())
+                );
                 assert_eq!(
                     p.params.get("requester_actor_id"),
                     Some(&"actor-a".to_string())

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1697,8 +1697,52 @@ function AppContent() {
             if (acpSid) {
               const streamStore = useV2StreamingStore.getState();
               const eventCase = decoded.acpEvent.event?.case;
-              if (eventCase !== "permissionRequest") {
-                const parentToolId = streamStore.childAcpSessionToToolId[acpSid];
+              const parentToolId = streamStore.childAcpSessionToToolId[acpSid];
+              if (eventCase === "permissionRequest") {
+                // Subagent permission must surface on the parent actor immediately.
+                // Do NOT buffer waiting for task→child bind: opencode often asks
+                // before task rawOutput carries sessionId, and a buffered ask
+                // never renders a card (agent hangs forever).
+                // Do NOT bind via params.toolCallId — that is the child tool
+                // (e.g. bash), not the parent task tool id.
+                const pr2 = decoded.acpEvent.event?.value as {
+                  requestId?: string;
+                  toolName?: string;
+                  description?: string;
+                  params?: Record<string, string>;
+                  options?: Array<{ optionId?: string; kind?: string; name?: string }>;
+                };
+                const childSid =
+                  pr2.params?.childSessionId?.trim() || acpSid;
+                const bindTo =
+                  parentToolId ??
+                  resolveOrphanSubagentParentToolId(sid, actorId, streamStore);
+                if (bindTo && childSid) {
+                  tryBindChildFromPermission(sid, actorId, childSid, bindTo);
+                }
+                void handleAcpPermissionRequest({
+                  sessionId: sid,
+                  agentActorId: actorId,
+                  request: {
+                    requestId: pr2.requestId ?? "",
+                    toolName: pr2.toolName ?? "",
+                    description: pr2.description ?? "",
+                    params: {
+                      ...(pr2.params ?? {}),
+                      childSessionId: childSid,
+                      ...(bindTo ? {} : { _subagent_unbound_task: "1" }),
+                    },
+                    requesterActorId:
+                      pr2.params?.requester_actor_id?.trim() || undefined,
+                    options: (pr2.options ?? []).map((o) => ({
+                      optionId: o.optionId ?? "",
+                      kind: o.kind ?? "",
+                      name: o.name ?? "",
+                    })),
+                  },
+                });
+                return;
+              } else {
                 if (parentToolId) {
                   routeSubagentAcpEvent(sid, actorId, parentToolId, decoded.acpEvent);
                   return;
@@ -1715,17 +1759,55 @@ function AppContent() {
                 actorId,
                 streamStoreForOrphan,
               );
-              if (
-                orphanTaskToolId &&
-                shouldRouteOrphanSubagentEvent(decoded.acpEvent, orphanTaskToolId)
-              ) {
-                routeSubagentAcpEvent(
-                  sid,
-                  actorId,
-                  orphanTaskToolId,
-                  decoded.acpEvent,
-                );
-                return;
+              if (orphanTaskToolId) {
+                const orphanEventCase = decoded.acpEvent.event?.case;
+                if (orphanEventCase === "permissionRequest") {
+                  // Orphan subagent permission (no acpSid on envelope): route
+                  // to the single unbound calling task tool.
+                  const prO = decoded.acpEvent.event?.value as {
+                    requestId?: string;
+                    toolName?: string;
+                    description?: string;
+                    params?: Record<string, string>;
+                    options?: Array<{ optionId?: string; kind?: string; name?: string }>;
+                  };
+                  const childSid = prO.params?.childSessionId?.trim() ?? "";
+                  if (childSid) {
+                    tryBindChildFromPermission(
+                      sid,
+                      actorId,
+                      childSid,
+                      orphanTaskToolId,
+                    );
+                  }
+                  void handleAcpPermissionRequest({
+                    sessionId: sid,
+                    agentActorId: actorId,
+                    request: {
+                      requestId: prO.requestId ?? "",
+                      toolName: prO.toolName ?? "",
+                      description: prO.description ?? "",
+                      params: prO.params ?? {},
+                      requesterActorId:
+                        prO.params?.requester_actor_id?.trim() || undefined,
+                      options: (prO.options ?? []).map((o) => ({
+                        optionId: o.optionId ?? "",
+                        kind: o.kind ?? "",
+                        name: o.name ?? "",
+                      })),
+                    },
+                  });
+                  return;
+                }
+                if (shouldRouteOrphanSubagentEvent(decoded.acpEvent, orphanTaskToolId)) {
+                  routeSubagentAcpEvent(
+                    sid,
+                    actorId,
+                    orphanTaskToolId,
+                    decoded.acpEvent,
+                  );
+                  return;
+                }
               }
             }
 
@@ -2037,12 +2119,19 @@ function AppContent() {
                 description: pr.description,
                 isDoomLoop: pr.toolName === "doom_loop",
               });
-              tryBindChildFromPermission(
-                sid,
-                actorId,
-                pr.params?.childSessionId ?? "",
-                pr.params?.toolCallId,
-              );
+              // params.toolCallId is the tool that asked (bash/…), not the parent
+              // task tool — only bind when we can resolve the parent task id.
+              const childSid = pr.params?.childSessionId?.trim() ?? "";
+              if (childSid) {
+                const orphanTask = resolveOrphanSubagentParentToolId(
+                  sid,
+                  actorId,
+                  useV2StreamingStore.getState(),
+                );
+                if (orphanTask) {
+                  tryBindChildFromPermission(sid, actorId, childSid, orphanTask);
+                }
+              }
               void handleAcpPermissionRequest({
                 sessionId: sid,
                 agentActorId: actorId,
@@ -2051,7 +2140,8 @@ function AppContent() {
                   toolName: pr.toolName ?? "",
                   description: pr.description ?? "",
                   params: pr.params ?? {},
-                  requesterActorId: pr.params?.requester_actor_id?.trim() || undefined,
+                  requesterActorId:
+                    pr.params?.requester_actor_id?.trim() || undefined,
                   options: (pr.options ?? []).map((o) => ({
                     optionId: o.optionId ?? "",
                     kind: o.kind ?? "",

--- a/packages/app/src/components/chat/AgentSelectorDock.tsx
+++ b/packages/app/src/components/chat/AgentSelectorDock.tsx
@@ -246,6 +246,39 @@ function AgentPill({
     runtimeInfoLoading,
   ])
 
+  // Catalog is visible but nothing was user-/runtime-selected. Persist the
+  // first advertised model as a session pick so reload/send keep a real id
+  // (and the dropdown shows a checkmark). `selectAgentModel` already falls
+  // back to available[0] for display; this makes that choice durable.
+  React.useEffect(() => {
+    if (!sessionId) return
+    if (effectiveUiState === 'offline' || effectiveUiState === 'stale') return
+    if (runtimeInfoLoading) return
+    if (availableModels.length === 0) return
+    if (useAgentModelPickStore.getState().getPick(sessionId, agent.id)) return
+    if (sessionEstablishedModel?.trim()) return
+    if (liveRuntimeInfo?.currentModel?.trim()) return
+    const firstId = availableModels[0]?.id?.trim()
+    if (!firstId) return
+    const rpcModelId = resolveSetModelId(agent.id, firstId, byRuntimeId)
+    sessionFlowLog('agent_selector.model_auto_select', {
+      agentId: agent.id,
+      sessionId,
+      modelId: rpcModelId,
+      availableModelIds: availableModels.map((m) => m.id),
+    })
+    useAgentModelPickStore.getState().setPick(sessionId, agent.id, rpcModelId)
+  }, [
+    sessionId,
+    agent.id,
+    effectiveUiState,
+    runtimeInfoLoading,
+    availableModels,
+    sessionEstablishedModel,
+    liveRuntimeInfo?.currentModel,
+    byRuntimeId,
+  ])
+
   const handlePickModel = React.useCallback(async (modelId: string) => {
     const freshByRuntimeId = useRuntimeStateStore.getState().byRuntimeId
     const rpcModelId = resolveSetModelId(agent.id, modelId, freshByRuntimeId)

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -95,7 +95,12 @@ import {
   textHasMemberMentionTokens,
 } from "@/lib/member-mention-token";
 import { buildStructuredMentionLines } from "@/lib/outgoing-mention-content";
-import { selectAgentModel, providerModelKeyFromOption } from "@/lib/runtime-state-resolve";
+import { resolveAgentAvailableModels } from "@/lib/agent-available-models";
+import {
+  selectAgentModel,
+  providerModelKeyFromOption,
+  resolveRuntimeStateEntryForAgent,
+} from "@/lib/runtime-state-resolve";
 import {
   sessionFlowError,
   sessionFlowLog,
@@ -1479,13 +1484,18 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
             useSessionMessageStore.getState().messages[sid],
             agentRuntimeIdsForSend[0] ?? "",
           );
+          const sendAgentId = agentRuntimeIdsForSend[0] ?? "";
+          const sendByRuntimeId = useRuntimeStateStore.getState().byRuntimeId;
+          const availableForSend = resolveAgentAvailableModels(
+            resolveRuntimeStateEntryForAgent(sendAgentId, sendByRuntimeId)?.info,
+          );
           const outgoingModel =
-            agentRuntimeIdsForSend.length > 0
+            sendAgentId
               ? selectAgentModel({
                   sessionId: sid,
-                  agentId: agentRuntimeIdsForSend[0],
-                  available: [],
-                  byRuntimeId: useRuntimeStateStore.getState().byRuntimeId,
+                  agentId: sendAgentId,
+                  available: availableForSend,
+                  byRuntimeId: sendByRuntimeId,
                   providerFallback: selectedModelKey ?? undefined,
                   sessionEstablishedModel: establishedForSend,
                 }).modelId || ""

--- a/packages/app/src/components/chat/__tests__/AgentSelectorDock.test.tsx
+++ b/packages/app/src/components/chat/__tests__/AgentSelectorDock.test.tsx
@@ -196,6 +196,44 @@ describe('AgentSelectorDock', () => {
     expect(screen.queryByText('Big Pickle')).not.toBeInTheDocument()
   })
 
+  it('auto-selects the first advertised model when none is selected', async () => {
+    mocks.runtimeStates = {
+      'runtime-1': {
+        daemonActorId: 'a-1',
+        lastUpdated: Date.now(),
+        info: {
+          availableModels: [
+            { id: 'shopee/gpt-5.5', displayName: 'GPT-5.5' },
+            { id: 'opencode/other', displayName: 'Other' },
+          ],
+          currentModel: '',
+          state: RuntimeLifecycle.ACTIVE,
+        },
+      },
+    }
+
+    render(
+      <AgentSelectorDock
+        {...dockProps({
+          activeSessionId: 'session-1',
+          engagedAgents: [{ id: 'a-1', displayName: 'SPRBOT' }],
+          agentToRuntimeId: new Map([['a-1', 'runtime-1']]),
+        })}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(useAgentModelPickStore.getState().getPick('session-1', 'a-1')).toBe(
+        'shopee/gpt-5.5',
+      )
+    })
+
+    await userEvent.click(await screen.findByRole('button', { name: /SPRBOT/i }))
+    const selected = document.querySelector('[data-model-selected="true"]')
+    expect(selected).toBeTruthy()
+    expect(selected?.textContent).toContain('GPT-5.5')
+  })
+
   it('shows no-models hint when ACP retain has no available_models and runtime is active', async () => {
     mocks.runtimeStates = {
       'runtime-1': {

--- a/packages/app/src/components/chat/__tests__/PermissionCard.test.tsx
+++ b/packages/app/src/components/chat/__tests__/PermissionCard.test.tsx
@@ -323,7 +323,7 @@ describe('PendingPermissionInline', () => {
     render(<PendingPermissionInline />);
 
     expect(screen.getByText('child-owned-command')).toBeTruthy();
-    expect(screen.getByText('A child session is waiting for your approval')).toBeTruthy();
+    expect(screen.getByText('A subagent is waiting for your approval')).toBeTruthy();
   });
 
   it('uses the same stacked approval UI for tool-attached and child-session permissions together', async () => {

--- a/packages/app/src/components/chat/permission-presentation.ts
+++ b/packages/app/src/components/chat/permission-presentation.ts
@@ -142,10 +142,15 @@ export function getPermissionCardPresentation(
           "Confirmation is required before accessing a path outside the workspace",
         )
     : entry.childSessionId
-      ? t(
-          "chat.permissionCard.childSessionWaitingApproval",
-          "A child session is waiting for your approval",
-        )
+      ? metadata?._subagent_unbound_task
+        ? t(
+            "chat.permissionCard.subagentUnboundTaskWaitingApproval",
+            "A subagent task is waiting for approval (specific task not yet identified)",
+          )
+        : t(
+            "chat.permissionCard.childSessionWaitingApproval",
+            "A subagent is waiting for your approval",
+          )
       : sourceToolLabel
         ? t("chat.permissionCard.sourceToolInvocation", "From {{tool}} tool call", {
             tool: sourceToolLabel,

--- a/packages/app/src/lib/__tests__/runtime-state-resolve.test.ts
+++ b/packages/app/src/lib/__tests__/runtime-state-resolve.test.ts
@@ -184,6 +184,23 @@ describe("selectAgentModel — canonical model resolver", () => {
     expect(res.modelId).toBe("");
   });
 
+  it("falls back to the first advertised model when catalog is present", () => {
+    const emptyRetain = {
+      [agentUuid]: {
+        ...entry(agentUuid, "rt-1", available),
+        info: { ...entry(agentUuid, "rt-1", available).info, currentModel: "" },
+      },
+    };
+    const res = selectAgentModel({
+      sessionId,
+      agentId: agentUuid,
+      available,
+      byRuntimeId: emptyRetain,
+    });
+    expect(res.source).toBe("fallback");
+    expect(res.modelId).toBe("big-pickle");
+  });
+
   it("canonicalizes short pick to advertised prefixed id", () => {
     useAgentModelPickStore.getState().setPick(sessionId, agentUuid, "mimo-v2.5-free");
     const prefixed = [{ id: "opencode/mimo-v2.5-free", displayName: "Mimo" }];

--- a/packages/app/src/lib/runtime-state-resolve.ts
+++ b/packages/app/src/lib/runtime-state-resolve.ts
@@ -478,10 +478,6 @@ export function selectAgentModel(args: {
   // resolves it when a runtime starts, so `RuntimeInfo.currentModel` — the
   // retain checked just above — already carries the answer, and carries it
   // for gateway and cron runtimes too, which could never see localStorage.
-  //
-  // Guessing here would also be unchecked: `available` comes from the retain,
-  // so when there is no retain there is no catalog to validate a guess
-  // against, and the pill would advertise a model that may not run.
 
   const fallback = args.providerFallback?.trim() ?? "";
   if (fallback) {
@@ -494,6 +490,14 @@ export function selectAgentModel(args: {
       ),
       source: "fallback",
     };
+  }
+
+  // Live catalog is present but nothing else selected — use the first
+  // advertised model. Callers that pass `available: []` skip this on purpose;
+  // prefer passing the retain catalog so UI and send stay aligned.
+  const firstAvailable = args.available[0]?.id?.trim() ?? "";
+  if (firstAvailable) {
+    return { modelId: firstAvailable, source: "fallback" };
   }
 
   return { modelId: "", source: "none" };

--- a/packages/app/src/lib/session-create.ts
+++ b/packages/app/src/lib/session-create.ts
@@ -5,8 +5,10 @@ import { resolveAmuxAgentType } from '@/lib/amux-agent-type'
 import { seedRuntimeStateAfterStart } from '@/lib/seed-runtime-state'
 import {
   normalizeAgentModelId,
+  resolveRuntimeStateEntryForAgent,
   selectAgentModel,
 } from '@/lib/runtime-state-resolve'
+import { resolveAgentAvailableModels } from '@/lib/agent-available-models'
 import { useAgentModelPickStore } from '@/stores/agent-model-pick-store'
 import { useRuntimeStateStore } from '@/stores/runtime-state-store'
 import { useWorkspaceStore } from '@/stores/workspace'
@@ -531,10 +533,13 @@ export async function startAgentRuntimesAsync(
     const agentType = args.agentType ?? resolveAmuxAgentType(backendType)
     const byRuntimeId = useRuntimeStateStore.getState().byRuntimeId
     const userPick = useAgentModelPickStore.getState().getPick(args.sessionId, agentActorId)
+    const available = resolveAgentAvailableModels(
+      resolveRuntimeStateEntryForAgent(agentActorId, byRuntimeId)?.info,
+    )
     const resolvedModelId = selectAgentModel({
       sessionId: args.sessionId,
       agentId: agentActorId,
-      available: [],
+      available,
       byRuntimeId,
       providerFallback: args.modelIdByAgent?.[agentActorId] ?? args.modelId,
     }).modelId || undefined

--- a/packages/app/src/lib/teamclaw/subagent-acp-route.ts
+++ b/packages/app/src/lib/teamclaw/subagent-acp-route.ts
@@ -5,6 +5,7 @@ import {
   normalizeToolResultEvent,
   normalizeToolUseEvent,
 } from "@/lib/live-agent-stream";
+import { handleAcpPermissionRequest } from "@/lib/teamclaw/handle-acp-permission-request";
 import { useV2StreamingStore } from "@/stores/v2-streaming-store";
 
 /** Route a child-session ACP event into nested subagent stream state. */
@@ -51,6 +52,32 @@ export function routeSubagentAcpEvent(
       summary: tr.summary,
       content: tr.content,
       rawOutput: tr.rawOutput,
+    });
+    return;
+  }
+  if (event?.case === "permissionRequest") {
+    const pr = event.value as {
+      requestId?: string;
+      toolName?: string;
+      description?: string;
+      params?: Record<string, string>;
+      options?: Array<{ optionId?: string; kind?: string; name?: string }>;
+    };
+    void handleAcpPermissionRequest({
+      sessionId,
+      agentActorId: actorId,
+      request: {
+        requestId: pr.requestId ?? "",
+        toolName: pr.toolName ?? "",
+        description: pr.description ?? "",
+        params: pr.params ?? {},
+        requesterActorId: pr.params?.requester_actor_id?.trim() || undefined,
+        options: (pr.options ?? []).map((o) => ({
+          optionId: o.optionId ?? "",
+          kind: o.kind ?? "",
+          name: o.name ?? "",
+        })),
+      },
     });
     return;
   }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -319,7 +319,8 @@
       "requestedSkill": "Requested skill",
       "sourceToolInvocation": "From {{tool}} tool call",
       "waitingExternalPathApproval": "Confirmation is required before accessing a path outside the workspace",
-      "childSessionWaitingApproval": "A child session is waiting for your approval",
+      "childSessionWaitingApproval": "A subagent is waiting for your approval",
+      "subagentUnboundTaskWaitingApproval": "A subagent task is waiting for approval (specific task not yet identified)",
       "toolInvocationWaitingApproval": "A tool call is waiting for your approval",
       "waitingForApproval": "Waiting for {{name}} to approve",
       "queuePosition": "{{current}} / {{total}}",
@@ -1092,6 +1093,14 @@
         "daemonErrLog": "Daemon stderr",
         "acpLog": "ACP stream",
         "noLog": "No log file or file missing"
+      },
+      "resetRemediation": {
+        "title": "Consider resetting the local daemon",
+        "description": "The issues below are often resolved by clearing the local daemon binding and re-initializing. Team shared directories (~/.amuxd/teams/) are not affected.",
+        "action": "Reset local daemon",
+        "confirmTitle": "Reset local daemon?",
+        "confirmDescription": "This clears the local daemon identity and config files. You will need to bind an agent again. Team shared files are not deleted.",
+        "confirmAction": "Confirm reset"
       }
     },
     "nav": {
@@ -1525,7 +1534,15 @@
       "mqttConnected": "Connected",
       "mqttDisconnected": "Disconnected",
       "mqttUnknown": "Unknown",
-      "switchTimeout": "Switched runtime, but the daemon did not confirm in time. It may still be restarting."
+      "switchTimeout": "Switched runtime, but the daemon did not confirm in time. It may still be restarting.",
+      "manualReset": {
+        "title": "Troubleshooting",
+        "description": "If the local daemon is in a bad state and other recovery steps fail, you can clear the local binding and re-initialize. Team shared directories (~/.amuxd/teams/) are not deleted.",
+        "action": "Reset local daemon",
+        "confirmTitle": "Reset local daemon?",
+        "confirmDescription": "This deletes the local daemon identity and config files (daemon.toml, backend.toml, etc.). You will need to bind an agent again. Type RESET to confirm.",
+        "confirmAction": "Confirm reset"
+      }
     },
     "daemonOnboarding": {
       "startingTitle": "Starting service…",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -319,7 +319,8 @@
       "requestedSkill": "请求的技能",
       "sourceToolInvocation": "来自 {{tool}} 工具调用",
       "waitingExternalPathApproval": "读取工作区外路径前需要你的确认",
-      "childSessionWaitingApproval": "子会话正在等待你的审批",
+      "childSessionWaitingApproval": "Subagent 正在等待你的审批",
+      "subagentUnboundTaskWaitingApproval": "Subagent 任务等待审批（未能定位具体任务）",
       "toolInvocationWaitingApproval": "工具调用正在等待你的审批",
       "waitingForApproval": "等待 {{name}} 批准",
       "queuePosition": "第 {{current}} / {{total}} 条",
@@ -1092,6 +1093,14 @@
         "daemonErrLog": "Daemon stderr",
         "acpLog": "ACP stream",
         "noLog": "暂无日志或文件不存在"
+      },
+      "resetRemediation": {
+        "title": "建议重置本地 daemon",
+        "description": "以下问题通常可通过清除本机 daemon 绑定并重新初始化解决。团队共享目录（~/.amuxd/teams/）不会受影响。",
+        "action": "重置本地 daemon",
+        "confirmTitle": "重置本地 daemon？",
+        "confirmDescription": "将清除本机 daemon 的身份与配置文件，之后需要重新绑定 agent。团队共享文件不会删除。",
+        "confirmAction": "确认重置"
       }
     },
     "nav": {
@@ -1525,7 +1534,15 @@
       "mqttConnected": "已连接",
       "mqttDisconnected": "未连接",
       "mqttUnknown": "未知",
-      "switchTimeout": "已切换运行时，但 daemon 未能及时确认，可能仍在重启中。"
+      "switchTimeout": "已切换运行时，但 daemon 未能及时确认，可能仍在重启中。",
+      "manualReset": {
+        "title": "疑难问题排查",
+        "description": "若本机 daemon 状态异常且其他方式无法恢复，可清除本地绑定并重新初始化。团队共享目录（~/.amuxd/teams/）不会删除。",
+        "action": "重置本地 daemon",
+        "confirmTitle": "重置本地 daemon？",
+        "confirmDescription": "将删除本机 daemon 的身份与配置文件（daemon.toml、backend.toml 等），之后需要重新绑定 agent。请输入 RESET 确认。",
+        "confirmAction": "确认重置"
+      }
     },
     "daemonOnboarding": {
       "startingTitle": "正在启动服务…",


### PR DESCRIPTION
## Summary

- **Model picker**: when a runtime has models but none is selected, auto-pick the first available model on load / session create / send — fixes `ProviderModelNotFoundError` when the UI showed a placeholder without a checkmark.
- **Subagent permissions (daemon)**: register lightweight child routes for opencode `task` subagent sessions (`parentID`); forward `permission.asked` / `question.asked` on the parent channel while keeping `acp_session_id` = child; refresh parent turn watchdog from child activity; clear parent + child pending permissions on detach.
- **Subagent permissions (frontend)**: render approval cards immediately when `acpSid` is present (no longer buffer until task bind); preserve `requester_actor_id` for multi-member ACL; show a clearer subtitle when parallel tasks cannot be bound to a specific Task card.

## Test plan

- [x] `cargo test --bin amuxd detach_clears_permissions ensure_child_route permission_request_maps`
- [x] `vitest` — `handle-acp-permission-request`, `PermissionCard`, `acp-permission-entries`, `AgentSelectorDock`, `runtime-state-resolve`
- [x] Manual: Subagent `task` + bash approval card appears and can be approved
- [ ] Manual: multi-member session — bystander sees waiting banner, cannot auto-allow another member's request
- [ ] Manual: detach parent session clears stale child pending permissions


Made with [Cursor](https://cursor.com)