### PR TITLE
feat(desktop): add daemon reset troubleshooting entry points

### DIFF
--- a/packages/app/src/components/settings/DaemonGeneralSection.tsx
+++ b/packages/app/src/components/settings/DaemonGeneralSection.tsx
@@ -31,6 +31,7 @@ import {
 import { useUIStore } from '@/stores/ui'
 import { cn, isTauri } from '@/lib/utils'
 import { SectionHeader, SettingCard } from './shared'
+import { DaemonManualResetCard } from './DaemonManualResetCard'
 
 const permissionLevels: AgentPermissionLevel[] = ['view', 'prompt', 'admin']
 
@@ -661,6 +662,10 @@ export function DaemonGeneralSection() {
             </div>
           </SettingCard>
         </>
+      )}
+
+      {isTauri() && (
+        <DaemonManualResetCard onResetComplete={() => setRebinding(true)} />
       )}
     </div>
 

--- a/packages/app/src/components/settings/DaemonManualResetCard.tsx
+++ b/packages/app/src/components/settings/DaemonManualResetCard.tsx
@@ -1,0 +1,145 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Loader2, RotateCcw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { SettingCard } from './shared'
+import { useDaemonOnboardingStore } from '@/stores/daemon-onboarding'
+
+const RESET_CONFIRM_TEXT = 'RESET'
+
+export function DaemonManualResetCard({
+  onResetComplete,
+}: {
+  onResetComplete: () => void
+}) {
+  const { t } = useTranslation()
+  const forceReset = useDaemonOnboardingStore((s) => s.forceReset)
+  const busy = useDaemonOnboardingStore((s) => s.busy)
+
+  const [confirmOpen, setConfirmOpen] = React.useState(false)
+  const [confirmText, setConfirmText] = React.useState('')
+  const [resetError, setResetError] = React.useState<string | null>(null)
+
+  const canConfirm = confirmText.trim() === RESET_CONFIRM_TEXT
+
+  const handleReset = React.useCallback(async () => {
+    setResetError(null)
+    try {
+      await forceReset()
+      const err = useDaemonOnboardingStore.getState().error
+      if (err) {
+        setResetError(err)
+        return
+      }
+      setConfirmOpen(false)
+      setConfirmText('')
+      onResetComplete()
+    } catch (err) {
+      setResetError(err instanceof Error ? err.message : String(err))
+    }
+  }, [forceReset, onResetComplete])
+
+  return (
+    <>
+      <SettingCard>
+        <div className="space-y-3">
+          <div>
+            <h4 className="text-[13px] font-semibold text-foreground">
+              {t('settings.daemonGeneral.manualReset.title', '疑难问题排查')}
+            </h4>
+            <p className="mt-1 text-[12.5px] leading-relaxed text-muted-foreground">
+              {t(
+                'settings.daemonGeneral.manualReset.description',
+                '若本机 daemon 状态异常且其他方式无法恢复，可清除本地绑定并重新初始化。团队共享目录（~/.amuxd/teams/）不会删除。',
+              )}
+            </p>
+          </div>
+          {resetError && !confirmOpen && (
+            <p className="text-[12px] text-destructive">{resetError}</p>
+          )}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-9 gap-2 border-destructive/30 text-destructive hover:bg-destructive/5"
+            disabled={busy}
+            onClick={() => {
+              setConfirmText('')
+              setResetError(null)
+              setConfirmOpen(true)
+            }}
+          >
+            {busy ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RotateCcw className="h-4 w-4" />
+            )}
+            {t('settings.daemonGeneral.manualReset.action', '重置本地 daemon')}
+          </Button>
+        </div>
+      </SettingCard>
+
+      <Dialog
+        open={confirmOpen}
+        onOpenChange={(open) => {
+          setConfirmOpen(open)
+          if (!open) setConfirmText('')
+        }}
+      >
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>
+              {t('settings.daemonGeneral.manualReset.confirmTitle', '重置本地 daemon？')}
+            </DialogTitle>
+            <DialogDescription>
+              {t(
+                'settings.daemonGeneral.manualReset.confirmDescription',
+                '将删除本机 daemon 的身份与配置文件（daemon.toml、backend.toml 等），之后需要重新绑定 agent。请输入 RESET 确认。',
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            autoFocus
+            value={confirmText}
+            onChange={(e) => setConfirmText(e.target.value)}
+            placeholder={RESET_CONFIRM_TEXT}
+            autoComplete="off"
+            spellCheck={false}
+            disabled={busy}
+            className="font-mono"
+          />
+          {resetError && confirmOpen && (
+            <p className="text-[12px] text-destructive">{resetError}</p>
+          )}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={busy}
+              onClick={() => setConfirmOpen(false)}
+            >
+              {t('common.cancel', '取消')}
+            </Button>
+            <Button
+              type="button"
+              disabled={!canConfirm || busy}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-40"
+              onClick={() => void handleReset()}
+            >
+              {t('settings.daemonGeneral.manualReset.confirmAction', '确认重置')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/packages/app/src/components/settings/DaemonResetRemediationCard.tsx
+++ b/packages/app/src/components/settings/DaemonResetRemediationCard.tsx
@@ -1,0 +1,151 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { AlertTriangle, Loader2, RotateCcw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { SettingCard } from './shared'
+import { DaemonOnboardingWizard } from '@/components/auth/DaemonOnboardingWizard'
+import { useDaemonOnboardingStore } from '@/stores/daemon-onboarding'
+import {
+  collectDaemonResetRemediation,
+  type DiagnosticCheck,
+  type DiagnosticReport,
+} from '@/lib/diagnostic-report'
+
+export function DaemonResetRemediationCard({
+  report,
+}: {
+  report: DiagnosticReport
+}) {
+  const { t } = useTranslation()
+  const forceReset = useDaemonOnboardingStore((s) => s.forceReset)
+  const onboardingBusy = useDaemonOnboardingStore((s) => s.busy)
+  const onboardingStatus = useDaemonOnboardingStore((s) => s.status)
+  const healError = useDaemonOnboardingStore((s) => s.healError)
+
+  const remediation = React.useMemo(
+    () =>
+      collectDaemonResetRemediation(report.checks, {
+        cloudAuthHealFailed: Boolean(healError),
+        teamMismatch: onboardingStatus === 'mismatch',
+      }),
+    [healError, onboardingStatus, report.checks],
+  )
+
+  const [confirmOpen, setConfirmOpen] = React.useState(false)
+  const [showWizard, setShowWizard] = React.useState(false)
+  const [resetError, setResetError] = React.useState<string | null>(null)
+
+  const handleReset = React.useCallback(async () => {
+    setResetError(null)
+    try {
+      await forceReset()
+      if (useDaemonOnboardingStore.getState().error) {
+        setResetError(useDaemonOnboardingStore.getState().error)
+        return
+      }
+      setShowWizard(true)
+    } catch (err) {
+      setResetError(err instanceof Error ? err.message : String(err))
+    }
+  }, [forceReset])
+
+  if (!remediation.suggest) return null
+
+  return (
+    <>
+      <SettingCard className="border-amber-500/25 bg-amber-500/5">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+          <div className="min-w-0 flex-1 space-y-3">
+            <div>
+              <h4 className="text-[13px] font-semibold text-foreground">
+                {t('settings.diagnostics.resetRemediation.title', '建议重置本地 daemon')}
+              </h4>
+              <p className="mt-1 text-[12.5px] leading-relaxed text-muted-foreground">
+                {t(
+                  'settings.diagnostics.resetRemediation.description',
+                  '以下问题通常可通过清除本机 daemon 绑定并重新初始化解决。团队共享目录（~/.amuxd/teams/）不会受影响。',
+                )}
+              </p>
+            </div>
+            <ul className="space-y-1">
+              {remediation.triggers.map((check: DiagnosticCheck) => (
+                <li key={`${check.id}-${check.resetTrigger ?? check.message}`} className="text-[12px] text-muted-foreground">
+                  <span className="font-medium text-foreground">{check.title}</span>
+                  {' — '}
+                  {check.message}
+                </li>
+              ))}
+            </ul>
+            {resetError && (
+              <p className="text-[12px] text-destructive">{resetError}</p>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 gap-2 border-destructive/30 text-destructive hover:bg-destructive/5"
+              disabled={onboardingBusy}
+              onClick={() => setConfirmOpen(true)}
+            >
+              {onboardingBusy ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RotateCcw className="h-4 w-4" />
+              )}
+              {t('settings.diagnostics.resetRemediation.action', '重置本地 daemon')}
+            </Button>
+          </div>
+        </div>
+      </SettingCard>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t('settings.diagnostics.resetRemediation.confirmTitle', '重置本地 daemon？')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t(
+                'settings.diagnostics.resetRemediation.confirmDescription',
+                '将清除本机 daemon 的身份与配置文件，之后需要重新绑定 agent。团队共享文件不会删除。',
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common.cancel', '取消')}</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={(e) => {
+                e.preventDefault()
+                setConfirmOpen(false)
+                void handleReset()
+              }}
+            >
+              {t('settings.diagnostics.resetRemediation.confirmAction', '确认重置')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {showWizard && (
+        <div className="fixed inset-0 z-50">
+          <DaemonOnboardingWizard
+            onDone={() => {
+              setShowWizard(false)
+            }}
+          />
+        </div>
+      )}
+    </>
+  )
+}

--- a/packages/app/src/components/settings/DiagnosticsSection.tsx
+++ b/packages/app/src/components/settings/DiagnosticsSection.tsx
@@ -26,6 +26,7 @@ import {
   type DiagnosticStatus,
 } from '@/lib/diagnostic-report'
 import { LiveDebugConsole } from './LiveDebugConsole'
+import { DaemonResetRemediationCard } from './DaemonResetRemediationCard'
 
 function statusDot(status: DiagnosticStatus) {
   switch (status) {
@@ -234,6 +235,8 @@ export const DiagnosticsSection = React.memo(function DiagnosticsSection() {
               ))}
             </div>
           </SettingCard>
+
+          <DaemonResetRemediationCard report={report} />
 
           <SettingCard>
             <h4 className="text-[13px] font-semibold mb-3">

--- a/packages/app/src/components/settings/__tests__/DaemonManualResetCard.test.tsx
+++ b/packages/app/src/components/settings/__tests__/DaemonManualResetCard.test.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const forceResetMock = vi.hoisted(() => vi.fn(async () => {}))
+
+const onboardingState = vi.hoisted(() => ({
+  busy: false,
+  error: null as string | null,
+  forceReset: forceResetMock,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+vi.mock('@/stores/daemon-onboarding', () => ({
+  useDaemonOnboardingStore: Object.assign(
+    (selector: (state: typeof onboardingState) => unknown) => selector(onboardingState),
+    { getState: () => onboardingState },
+  ),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: string; size?: string }) => (
+    <button {...props}>{children}</button>
+  ),
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+describe('DaemonManualResetCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    onboardingState.busy = false
+    onboardingState.error = null
+  })
+
+  it('requires typing RESET before confirming manual daemon reset', async () => {
+    const onResetComplete = vi.fn()
+    const { DaemonManualResetCard } = await import('../DaemonManualResetCard')
+    render(<DaemonManualResetCard onResetComplete={onResetComplete} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '重置本地 daemon' }))
+    const confirmButton = screen.getByRole('button', { name: '确认重置' })
+    expect(confirmButton).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText('RESET'), { target: { value: 'RESET' } })
+    expect(confirmButton).not.toBeDisabled()
+
+    fireEvent.click(confirmButton)
+
+    await waitFor(() => {
+      expect(forceResetMock).toHaveBeenCalledTimes(1)
+      expect(onResetComplete).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/app/src/components/settings/__tests__/DiagnosticsSection.reset.test.tsx
+++ b/packages/app/src/components/settings/__tests__/DiagnosticsSection.reset.test.tsx
@@ -1,0 +1,167 @@
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DiagnosticReport } from '@/lib/diagnostic-report'
+
+const forceResetMock = vi.hoisted(() => vi.fn(async () => {}))
+
+const diagnosticsState = vi.hoisted(() => ({
+  report: null as DiagnosticReport | null,
+}))
+
+const sampleReport: DiagnosticReport = {
+  schemaVersion: 1,
+  generatedAt: '2026-01-01T00:00:00.000Z',
+  app: { version: '1.0.0', buildFlavor: 'default', platform: 'MacIntel', tauri: true },
+  summary: { ok: 0, warn: 0, fail: 1 },
+  checks: [
+    {
+      id: 'daemon_http',
+      title: '本地 Daemon',
+      status: 'fail',
+      message: 'daemon 令牌无效，需重启应用',
+      resetTrigger: 'daemon_http_token_invalid',
+    },
+  ],
+  details: {} as DiagnosticReport['details'],
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/utils')>()
+  return {
+    ...actual,
+    isTauri: () => true,
+    openExternalUrl: vi.fn(),
+  }
+})
+
+vi.mock('@/stores/ui', () => ({
+  useUIStore: (selector: (state: { openSettings: () => void }) => unknown) =>
+    selector({ openSettings: vi.fn() }),
+}))
+
+vi.mock('@/stores/diagnostics-store', () => ({
+  useDiagnosticsStore: (
+    selector: (state: { report: DiagnosticReport | null; setReport: (r: DiagnosticReport) => void }) => unknown,
+  ) => selector({ report: diagnosticsState.report, setReport: vi.fn() }),
+}))
+
+const onboardingState = vi.hoisted(() => ({
+  status: 'ready' as string,
+  busy: false,
+  healError: null as string | null,
+  error: null as string | null,
+  forceReset: forceResetMock,
+}))
+
+vi.mock('@/stores/daemon-onboarding', () => ({
+  useDaemonOnboardingStore: Object.assign(
+    (
+      selector: (state: typeof onboardingState) => unknown,
+    ) => selector(onboardingState),
+    {
+      getState: () => onboardingState,
+    },
+  ),
+}))
+
+vi.mock('@/lib/diagnostic-report', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/diagnostic-report')>()
+  return {
+    ...actual,
+    collectDiagnosticReport: vi.fn(),
+    copyDiagnosticReport: vi.fn(),
+    saveDiagnosticZip: vi.fn(),
+  }
+})
+
+vi.mock('../LiveDebugConsole', () => ({
+  LiveDebugConsole: () => <div data-testid="live-debug-console" />,
+}))
+
+vi.mock('@/components/auth/DaemonOnboardingWizard', () => ({
+  DaemonOnboardingWizard: ({ onDone }: { onDone: () => void }) => (
+    <div data-testid="daemon-onboarding-wizard">
+      <button type="button" onClick={onDone}>
+        wizard-done
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: string; size?: string }) => (
+    <button {...props}>{children}</button>
+  ),
+}))
+
+vi.mock('@/components/ui/alert-dialog', () => ({
+  AlertDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="alert-dialog">{children}</div> : null,
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogCancel: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  AlertDialogAction: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}))
+
+describe('DiagnosticsSection daemon reset remediation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    diagnosticsState.report = null
+    onboardingState.status = 'ready'
+    onboardingState.busy = false
+    onboardingState.healError = null
+    onboardingState.error = null
+  })
+
+  it('shows remediation banner when report qualifies for daemon reset', async () => {
+    diagnosticsState.report = sampleReport
+    const { DiagnosticsSection } = await import('../DiagnosticsSection')
+    render(<DiagnosticsSection />)
+
+    expect(screen.getByText('建议重置本地 daemon')).toBeTruthy()
+    expect(screen.getByText('daemon 令牌无效，需重启应用')).toBeTruthy()
+  })
+
+  it('runs forceReset and opens onboarding wizard after confirmation', async () => {
+    diagnosticsState.report = sampleReport
+    const { DiagnosticsSection } = await import('../DiagnosticsSection')
+    render(<DiagnosticsSection />)
+
+    fireEvent.click(screen.getByRole('button', { name: '重置本地 daemon' }))
+    expect(screen.getByTestId('alert-dialog')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: '确认重置' }))
+
+    await waitFor(() => {
+      expect(forceResetMock).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByTestId('daemon-onboarding-wizard')).toBeTruthy()
+  })
+})

--- a/packages/app/src/lib/__tests__/daemon-reset-remediation.test.ts
+++ b/packages/app/src/lib/__tests__/daemon-reset-remediation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectDaemonResetRemediation,
+  type DiagnosticCheck,
+} from '@/lib/diagnostic-report'
+
+describe('collectDaemonResetRemediation', () => {
+  it('suggests reset when daemon HTTP token is invalid', () => {
+    const checks: DiagnosticCheck[] = [
+      {
+        id: 'daemon_http',
+        title: '本地 Daemon',
+        status: 'fail',
+        message: 'daemon 令牌无效，需重启应用',
+        resetTrigger: 'daemon_http_token_invalid',
+      },
+    ]
+
+    const result = collectDaemonResetRemediation(checks)
+
+    expect(result.suggest).toBe(true)
+    expect(result.triggers).toHaveLength(1)
+    expect(result.triggers[0]?.resetTrigger).toBe('daemon_http_token_invalid')
+  })
+
+  it('does not suggest reset when daemon is merely not running', () => {
+    const checks: DiagnosticCheck[] = [
+      {
+        id: 'daemon_http',
+        title: '本地 Daemon',
+        status: 'fail',
+        message: 'amuxd 未运行或无法访问',
+      },
+    ]
+
+    const result = collectDaemonResetRemediation(checks)
+
+    expect(result.suggest).toBe(false)
+    expect(result.triggers).toHaveLength(0)
+  })
+
+  it('suggests reset when daemon port file is missing', () => {
+    const checks: DiagnosticCheck[] = [
+      {
+        id: 'daemon_http',
+        title: '本地 Daemon',
+        status: 'fail',
+        message: '未找到 daemon 配置（可能尚未初始化）',
+        resetTrigger: 'daemon_http_port_missing',
+      },
+    ]
+
+    const result = collectDaemonResetRemediation(checks)
+
+    expect(result.suggest).toBe(true)
+    expect(result.triggers[0]?.resetTrigger).toBe('daemon_http_port_missing')
+  })
+
+  it('suggests reset for unreadable daemon info when probe succeeded', () => {
+    const checks: DiagnosticCheck[] = [
+      {
+        id: 'daemon_info',
+        title: 'Daemon 云同步',
+        status: 'warn',
+        message: '无法读取 daemon 详情',
+        resetTrigger: 'daemon_info_unreadable',
+      },
+    ]
+
+    expect(collectDaemonResetRemediation(checks).suggest).toBe(true)
+  })
+
+  it('only suggests reset for expired cloud auth after auto-heal failed', () => {
+    const checks: DiagnosticCheck[] = [
+      {
+        id: 'daemon_info',
+        title: 'Daemon 云同步',
+        status: 'fail',
+        message: 'daemon 云认证已过期，需重新 onboarding',
+        resetTrigger: 'daemon_cloud_auth_expired',
+      },
+    ]
+
+    expect(collectDaemonResetRemediation(checks).suggest).toBe(false)
+    expect(
+      collectDaemonResetRemediation(checks, { cloudAuthHealFailed: true }).suggest,
+    ).toBe(true)
+  })
+
+  it('suggests reset when onboarding reports team mismatch', () => {
+    const result = collectDaemonResetRemediation([], { teamMismatch: true })
+
+    expect(result.suggest).toBe(true)
+    expect(result.triggers[0]?.resetTrigger).toBe('daemon_team_mismatch')
+  })
+})

--- a/packages/app/src/lib/__tests__/diagnostic-report.test.ts
+++ b/packages/app/src/lib/__tests__/diagnostic-report.test.ts
@@ -236,4 +236,18 @@ describe('collectDiagnosticReport', () => {
     expect(mqttConfig?.status).toBe('ok')
     expect(mqttConfig?.message).toContain('JWT')
   })
+
+  it('tags token_invalid daemon probe with a reset trigger', async () => {
+    const { probeDaemonHttp } = await import('@/lib/daemon-local-client')
+    vi.mocked(probeDaemonHttp).mockResolvedValueOnce({
+      ok: false,
+      reason: 'token_invalid',
+    })
+
+    const { collectDiagnosticReport } = await import('@/lib/diagnostic-report')
+    const report = await collectDiagnosticReport()
+    const daemonHttp = report.checks.find((c) => c.id === 'daemon_http')
+
+    expect(daemonHttp?.resetTrigger).toBe('daemon_http_token_invalid')
+  })
 })

--- a/packages/app/src/lib/diagnostic-report.ts
+++ b/packages/app/src/lib/diagnostic-report.ts
@@ -31,6 +31,14 @@ import type { SettingsSection } from '@/stores/ui'
 
 export type DiagnosticStatus = 'ok' | 'warn' | 'fail'
 
+/** Qualifying reasons to offer `amuxd clear` from diagnostics. */
+export type DaemonResetTrigger =
+  | 'daemon_http_token_invalid'
+  | 'daemon_http_port_missing'
+  | 'daemon_info_unreadable'
+  | 'daemon_cloud_auth_expired'
+  | 'daemon_team_mismatch'
+
 export interface DiagnosticCheck {
   id: string
   title: string
@@ -38,6 +46,55 @@ export interface DiagnosticCheck {
   message: string
   hint?: string
   hintSection?: SettingsSection
+  resetTrigger?: DaemonResetTrigger
+}
+
+export interface DaemonResetRemediationContext {
+  /** When true, cloud-auth expiry qualifies for reset (auto-heal already failed). */
+  cloudAuthHealFailed?: boolean
+  teamMismatch?: boolean
+}
+
+export interface DaemonResetRemediation {
+  suggest: boolean
+  triggers: DiagnosticCheck[]
+}
+
+const ALWAYS_RESET_TRIGGERS = new Set<DaemonResetTrigger>([
+  'daemon_http_token_invalid',
+  'daemon_http_port_missing',
+  'daemon_info_unreadable',
+  'daemon_team_mismatch',
+])
+
+export function collectDaemonResetRemediation(
+  checks: DiagnosticCheck[],
+  context: DaemonResetRemediationContext = {},
+): DaemonResetRemediation {
+  const triggers: DiagnosticCheck[] = []
+
+  for (const check of checks) {
+    if (!check.resetTrigger) continue
+    if (ALWAYS_RESET_TRIGGERS.has(check.resetTrigger)) {
+      triggers.push(check)
+      continue
+    }
+    if (check.resetTrigger === 'daemon_cloud_auth_expired' && context.cloudAuthHealFailed) {
+      triggers.push(check)
+    }
+  }
+
+  if (context.teamMismatch) {
+    triggers.push({
+      id: 'daemon_team_mismatch',
+      title: 'Daemon 团队绑定',
+      status: 'fail',
+      message: '本机 daemon 绑定的团队与当前登录团队不一致',
+      resetTrigger: 'daemon_team_mismatch',
+    })
+  }
+
+  return { suggest: triggers.length > 0, triggers }
 }
 
 export interface TeamEnvDiagnostics {
@@ -662,6 +719,12 @@ function buildDaemonHttpCheck(probe: DaemonHttpProbe): DiagnosticCheck {
     ipc_error: '无法读取 daemon 连接信息',
   }
   const reason = probe.ok ? 'not_running' : probe.reason
+  const resetTrigger: DaemonResetTrigger | undefined =
+    reason === 'token_invalid'
+      ? 'daemon_http_token_invalid'
+      : reason === 'port_file_missing'
+        ? 'daemon_http_port_missing'
+        : undefined
   return {
     id: 'daemon_http',
     title: '本地 Daemon',
@@ -669,6 +732,7 @@ function buildDaemonHttpCheck(probe: DaemonHttpProbe): DiagnosticCheck {
     message: messages[reason as keyof typeof messages] ?? 'daemon 不可用',
     hint: '设置 → Daemon → 通用，检查 onboarding 状态',
     hintSection: 'daemonGeneral',
+    resetTrigger,
   }
 }
 
@@ -689,6 +753,7 @@ function buildDaemonInfoCheck(info: DaemonInfoBody | null, probeOk: boolean): Di
       status: 'warn',
       message: '无法读取 daemon 详情',
       hintSection: 'daemonGeneral',
+      resetTrigger: 'daemon_info_unreadable',
     }
   }
   if (info.cloud_auth?.status === 'expired') {
@@ -699,6 +764,7 @@ function buildDaemonInfoCheck(info: DaemonInfoBody | null, probeOk: boolean): Di
       message: 'daemon 云认证已过期，需重新 onboarding',
       hint: '设置 → Daemon → 通用 → 重新绑定',
       hintSection: 'daemonGeneral',
+      resetTrigger: 'daemon_cloud_auth_expired',
     }
   }
   const advertise = info.agent_types_advertise


### PR DESCRIPTION
## Summary

- Add `collectDaemonResetRemediation()` to detect when `amuxd clear` is the right fix (token invalid, missing port file, unreadable daemon info, cloud auth expired after auto-heal failed, team mismatch).
- **Diagnostics → 诊断与支持**: show an aggregated remediation banner with one-click reset → onboarding wizard overlay.
- **Settings → 本地 Agent**: add a manual troubleshooting card with strong confirmation (type `RESET`) → rebind overlay. Uses `Dialog` instead of `AlertDialog` so the confirmation input is focusable.

Reuses existing `forceReset()` → `daemon_clear` (stop managed amuxd + `amuxd clear --force`). Does not change `amuxd clear` behavior or delete team data under `~/.amuxd/teams/`.

## Test plan

- [x] `pnpm exec vitest run` on remediation unit tests, diagnostic-report integration, DiagnosticsSection reset UI, DaemonManualResetCard RESET gate (14 tests)
- [ ] Desktop: Settings → 本地 Agent → 重置本地 daemon → type RESET → confirm → onboarding wizard opens
- [ ] Desktop: Settings → 诊断与支持 → run diagnostics with daemon token invalid → remediation banner → reset → wizard opens
- [ ] Verify `~/.amuxd/teams/` is preserved after reset


Made with [Cursor](https://cursor.com)