### PR TITLE
fix(db): allow cursor and claude-code as agent backend types

### DIFF
--- a/apps/daemon/src/daemon/runtime_resolution.rs
+++ b/apps/daemon/src/daemon/runtime_resolution.rs
@@ -10,7 +10,7 @@ use crate::proto::amux;
 fn configured_local_agent(config: &DaemonConfig) -> Option<amux::AgentType> {
     match config.agents.local_agent.as_str() {
         "pi" => Some(amux::AgentType::Pi),
-        "cursor" => Some(amux::AgentType::Opencode),
+        "cursor" => Some(amux::AgentType::Cursor),
         "opencode" => config
             .agents
             .opencode
@@ -82,11 +82,10 @@ pub(crate) fn session_message_model_override(
 pub(crate) fn agent_type_from_name(name: &str) -> Option<amux::AgentType> {
     match name.trim() {
         "opencode" => Some(amux::AgentType::Opencode),
-        "cursor" => Some(amux::AgentType::Opencode),
+        "cursor" => Some(amux::AgentType::Cursor),
         "codex" => Some(amux::AgentType::Codex),
         "claude" | "claude_code" | "claude-code" => Some(amux::AgentType::ClaudeCode),
         "pi" => Some(amux::AgentType::Pi),
-        "cursor" => Some(amux::AgentType::Cursor),
         _ => None,
     }
 }

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -672,6 +672,12 @@ impl DaemonServer {
             amux::AgentType::Pi,
             AgentLaunchConfig::new("pi", Vec::new(), "pi"),
         );
+        if config.agents.local_agent == "cursor" {
+            launch_configs.insert(
+                amux::AgentType::Cursor,
+                AgentLaunchConfig::new("cursor-bridge", Vec::new(), "cursor"),
+            );
+        }
 
         let members_path = config_path
             .parent()

--- a/services/supabase/migrations/20260729110000_agent_backend_cursor.sql
+++ b/services/supabase/migrations/20260729110000_agent_backend_cursor.sql
@@ -1,0 +1,50 @@
+-- Allow cursor (and claude-code wire name) as agent backend types.
+--
+-- PR #636 added Cursor SDK + Claude Agent SDK backends. Daemon startup calls
+-- POST /v1/agents/types/ensure with defaultAgentType "cursor" (or
+-- "claude-code"), but the agents / agent_runtimes CHECK constraints still
+-- only allowed claude, opencode, codex, pi — so cloud advertise failed with
+-- agents_default_agent_type_check / agent_runtimes_backend_type_check.
+
+ALTER TABLE amux.agents
+    DROP CONSTRAINT IF EXISTS agents_default_agent_type_check;
+
+ALTER TABLE amux.agents
+    ADD CONSTRAINT agents_default_agent_type_check
+    CHECK (
+        default_agent_type IS NULL
+        OR default_agent_type = ANY (
+            ARRAY[
+                'claude'::text,
+                'claude-code'::text,
+                'opencode'::text,
+                'codex'::text,
+                'pi'::text,
+                'cursor'::text
+            ]
+        )
+    );
+
+ALTER TABLE amux.agent_runtimes
+    DROP CONSTRAINT IF EXISTS agent_runtimes_backend_type_check;
+
+ALTER TABLE amux.agent_runtimes
+    ADD CONSTRAINT agent_runtimes_backend_type_check
+    CHECK (
+        backend_type = ANY (
+            ARRAY[
+                'claude'::text,
+                'claude-code'::text,
+                'codex'::text,
+                'opencode'::text,
+                'pi'::text,
+                'cursor'::text
+            ]
+        )
+    );
+
+COMMENT ON COLUMN amux.agents.default_agent_type IS
+    'Preferred runtime backend type when no explicit agent type is requested. Canonical values match agent_runtimes.backend_type: claude, claude-code, opencode, codex, pi, cursor.';
+
+COMMENT ON COLUMN amux.agent_runtimes.backend_type IS
+    'Runtime backend: claude, claude-code, opencode, codex, pi, or cursor.';


### PR DESCRIPTION
## Summary

- Add migration `20260729110000_agent_backend_cursor.sql` to extend `amux.agents.default_agent_type` and `amux.agent_runtimes.backend_type` CHECK constraints with `cursor` and `claude-code`.
- Fix daemon runtime resolution so `local_agent = "cursor"` maps to `AgentType::Cursor` instead of `Opencode`.
- Register a Cursor launch config entry when cursor is the configured local agent.

Fixes daemon cloud sync failing with `agents_default_agent_type_check` when advertising Cursor SDK backend types after PR #636.

## Test plan

- [ ] Apply migration on self-host / company Supabase
- [ ] Restart amuxd with `local_agent = "cursor"` and confirm `POST /v1/agents/types/ensure` returns 204
- [ ] Diagnostics → Daemon 云同步 shows green for cursor-configured daemons
- [ ] `cargo test` in `apps/daemon` for `runtime_resolution` (no regressions)


Made with [Cursor](https://cursor.com)