### PR TITLE
fix(sidebar): session list selection glass and activity badges

### DIFF
--- a/docs/design-mock/session-activity-badge-variants.html
+++ b/docs/design-mock/session-activity-badge-variants.html
@@ -1,0 +1,609 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Session 卡片 · Activity Badge 方案对比</title>
+<style>
+  :root {
+    --font: "PingFang SC", "Noto Sans SC", -apple-system, BlinkMacSystemFont, "Microsoft YaHei", system-ui, sans-serif;
+    --mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+    --background: #fbfaf7;
+    --paper: #ffffff;
+    --panel: #efece4;
+    --foreground: #1a1a14;
+    --ink-2: #3d3c34;
+    --muted: #75736a;
+    --faint: #a8a6a0;
+    --border-soft: rgba(26,26,20,0.05);
+    --coral: #e85a4a;
+    --wait-bg: rgba(16,185,129,0.10);
+    --wait-fg: #059669;
+    --wait-border: rgba(16,185,129,0.22);
+    --run-fg: #2563eb;
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--font);
+    background: #e8e5df;
+    color: var(--foreground);
+    -webkit-font-smoothing: antialiased;
+    padding: 28px 24px 80px;
+    line-height: 1.5;
+  }
+
+  h1 {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 6px;
+  }
+  .lead {
+    font-size: 13px;
+    color: var(--muted);
+    max-width: 720px;
+    margin-bottom: 28px;
+  }
+  .lead code {
+    font-family: var(--mono);
+    font-size: 11px;
+    background: rgba(0,0,0,0.05);
+    padding: 1px 5px;
+    border-radius: 4px;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 20px;
+    align-items: start;
+  }
+
+  .variant {
+    background: var(--paper);
+    border-radius: 14px;
+    border: 1px solid rgba(26,26,20,0.08);
+    overflow: hidden;
+    box-shadow: 0 2px 12px rgba(20,20,15,0.06);
+  }
+  .variant-head {
+    padding: 14px 16px 10px;
+    border-bottom: 1px solid var(--border-soft);
+    background: linear-gradient(180deg, #faf9f6 0%, #fff 100%);
+  }
+  .variant-head .tag {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--faint);
+    margin-bottom: 4px;
+  }
+  .variant-head h2 {
+    font-size: 15px;
+    font-weight: 700;
+    margin-bottom: 4px;
+  }
+  .variant-head p {
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.55;
+  }
+  .pros {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 8px;
+  }
+  .pros span {
+    font-size: 10.5px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: rgba(16,185,129,0.08);
+    color: #047857;
+    font-weight: 600;
+  }
+  .cons span {
+    background: rgba(232,90,74,0.08);
+    color: #c2410c;
+  }
+
+  .preview-pane {
+    padding: 14px;
+    background: #F8F7F4;
+  }
+  .preview-label {
+    font-size: 10.5px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--faint);
+    margin-bottom: 8px;
+  }
+  .preview-label + .preview-label { margin-top: 14px; }
+
+  /* —— shared session card chrome —— */
+  .list-bg {
+    border-radius: 11px;
+    padding: 4px;
+  }
+  .card {
+    border-radius: 11px;
+    padding: 8px 10px;
+    cursor: default;
+    transition: background 0.15s var(--ease);
+  }
+  .card + .card { margin-top: 2px; }
+  .card:hover { background: rgba(0,0,0,0.035); }
+  .card.active {
+    background: var(--paper);
+    box-shadow: 0 0 0 1px rgba(26,26,20,0.06), 0 1px 4px rgba(20,20,15,0.04);
+  }
+  .card.dim { opacity: 0.55; }
+
+  .row-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+  .title {
+    flex: 1;
+    min-width: 0;
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .time {
+    flex-shrink: 0;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--faint);
+    line-height: 22px;
+  }
+  .workspace {
+    display: block;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--faint);
+    margin-top: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .preview {
+    display: block;
+    font-size: 12px;
+    color: var(--muted);
+    margin-top: 4px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .preview em {
+    font-style: normal;
+    font-weight: 500;
+    color: var(--coral);
+  }
+
+  .badge {
+    flex-shrink: 0;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 16px;
+    padding: 0 7px;
+    border-radius: 999px;
+    background: var(--wait-bg);
+    color: var(--wait-fg);
+    border: 1px solid var(--wait-border);
+    white-space: nowrap;
+  }
+  .badge.short { padding: 0 5px; }
+  .badge.icon {
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    display: inline-grid;
+    place-items: center;
+    font-size: 11px;
+    line-height: 1;
+  }
+  .badge.question {
+    background: rgba(99,102,241,0.10);
+    color: #4f46e5;
+    border-color: rgba(99,102,241,0.20);
+  }
+
+  .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #10b981;
+    box-shadow: 0 0 0 2px rgba(16,185,129,0.25);
+    flex-shrink: 0;
+  }
+  .dot.run {
+    background: var(--run-fg);
+    box-shadow: 0 0 0 2px rgba(37,99,235,0.2);
+  }
+
+  .spin {
+    width: 14px;
+    height: 14px;
+    border: 2px solid rgba(37,99,235,0.2);
+    border-top-color: var(--run-fg);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    flex-shrink: 0;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  .participants {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 4px;
+    min-width: 0;
+  }
+  .avatars {
+    display: flex;
+  }
+  .av {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 1px solid var(--paper);
+    margin-left: -6px;
+    font-size: 8px;
+    font-weight: 700;
+    color: #fff;
+    display: grid;
+    place-items: center;
+  }
+  .av:first-child { margin-left: 0; }
+  .av.a { background: #7c6aad; }
+  .av.b { background: #4a9b8e; border-radius: 3px; }
+  .pcount { font-size: 10.5px; color: var(--faint); }
+
+  .preview-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 4px;
+    min-width: 0;
+  }
+  .preview-row .preview {
+    flex: 1;
+    min-width: 0;
+    margin-top: 0;
+  }
+
+  .accent-wait {
+    border-left: 2px solid #10b981;
+    padding-left: 8px;
+    margin-left: -2px;
+  }
+  .accent-run {
+    border-left: 2px solid var(--run-fg);
+  }
+
+  .height-tag {
+    display: inline-block;
+    margin-left: 6px;
+    font-family: var(--mono);
+    font-size: 9.5px;
+    font-weight: 600;
+    color: var(--faint);
+    vertical-align: middle;
+  }
+  .height-tag.good { color: #059669; }
+  .height-tag.bad { color: #dc2626; }
+
+  .rec {
+    outline: 2px solid rgba(232,90,74,0.35);
+    outline-offset: 2px;
+  }
+  .rec-badge {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: var(--coral);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 700;
+    padding: 3px 8px;
+    border-radius: 6px;
+    letter-spacing: 0.02em;
+  }
+  .variant { position: relative; }
+
+  footer {
+    margin-top: 32px;
+    font-size: 12px;
+    color: var(--muted);
+    max-width: 800px;
+  }
+  footer strong { color: var(--ink-2); }
+</style>
+</head>
+<body>
+
+<h1>Session 卡片 · Activity 状态展示方案</h1>
+<p class="lead">
+  问题：当前 <code>SessionActivityBadge</code> 独占第四行（participants 行），卡片高度 +~20px，影响列表浮层对齐。<br />
+  目标：<strong>不增行高</strong> 或 <strong>仅在有参与者时复用现有行</strong>，同时区分 permission / question / running。
+</p>
+
+<div class="grid">
+
+  <!-- 0 baseline -->
+  <section class="variant">
+    <div class="variant-head">
+      <div class="tag">Baseline · 现状</div>
+      <h2>独立第四行 badge</h2>
+      <p>无参与者时也强制渲染 participants 行，仅放 badge。信息最全，但最撑高。</p>
+      <div class="pros cons"><span>信息完整</span><span>撑高卡片</span><span>浮层易错位</span></div>
+    </div>
+    <div class="preview-pane">
+      <div class="preview-label">有 activity · 无参与者 <span class="height-tag bad">~72px</span></div>
+      <div class="list-bg">
+        <div class="card active accent-wait">
+          <div class="row-title">
+            <span class="title">执行PS</span>
+            <span class="time">Just now</span>
+          </div>
+          <span class="workspace">TeamClaw Dev</span>
+          <span class="preview"><em>@MYBOT</em> 执行ps</span>
+          <div class="participants">
+            <span class="flex-1"></span>
+            <span class="badge">Awaiting confirmation</span>
+          </div>
+        </div>
+      </div>
+      <div class="preview-label">对照 · 普通卡片 <span class="height-tag good">~52px</span></div>
+      <div class="list-bg">
+        <div class="card dim">
+          <div class="row-title">
+            <span class="title">hello你好</span>
+            <span class="time">20m ago</span>
+          </div>
+          <span class="preview">普通预览一行</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- A -->
+  <section class="variant rec">
+    <div class="rec-badge">推荐 A</div>
+    <div class="variant-head">
+      <div class="tag">方案 A</div>
+      <h2>标题行 Meta 内联</h2>
+      <p>badge 放在时间戳左侧，与 unread / NEW 同级。零增行，扫视路径自然。</p>
+      <div class="pros"><span>零增行</span><span>实现简单</span><span>与现有 meta 一致</span></div>
+    </div>
+    <div class="preview-pane">
+      <div class="preview-label">permission · 等待确认</div>
+      <div class="list-bg">
+        <div class="card active">
+          <div class="row-title">
+            <span class="title">执行PS</span>
+            <span class="badge short">待确认</span>
+            <span class="time">Just now</span>
+          </div>
+          <span class="workspace">TeamClaw Dev</span>
+          <span class="preview"><em>@MYBOT</em> 执行ps</span>
+        </div>
+      </div>
+      <div class="preview-label">question · 等待回答</div>
+      <div class="list-bg">
+        <div class="card">
+          <div class="row-title">
+            <span class="title">Skill: codebase-downloader</span>
+            <span class="badge short question">待回答</span>
+            <span class="time">5m ago</span>
+          </div>
+          <span class="preview">Continue with download?</span>
+        </div>
+      </div>
+      <div class="preview-label">running</div>
+      <div class="list-bg">
+        <div class="card">
+          <div class="row-title">
+            <span class="title">重构 auth 模块</span>
+            <span class="spin" title="Running"></span>
+            <span class="time">Just now</span>
+          </div>
+          <span class="preview">正在分析依赖…</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- B -->
+  <section class="variant">
+    <div class="variant-head">
+      <div class="tag">方案 B</div>
+      <h2>状态点 + 短标签</h2>
+      <p>标题前加 7px 状态点（绿=等待、蓝=运行），meta 区仅 2 字缩写「确认」「回答」。</p>
+      <div class="pros"><span>零增行</span><span>视觉更 quiet</span><span>密度高</span></div>
+    </div>
+    <div class="preview-pane">
+      <div class="list-bg">
+        <div class="card active">
+          <div class="row-title">
+            <span class="dot"></span>
+            <span class="title">执行PS</span>
+            <span class="badge short" style="background:transparent;border-color:transparent;color:var(--wait-fg);padding:0 4px;">确认</span>
+            <span class="time">Just now</span>
+          </div>
+          <span class="workspace">TeamClaw Dev</span>
+          <span class="preview"><em>@MYBOT</em> 执行ps</span>
+        </div>
+      </div>
+      <div class="preview-label" style="margin-top:12px">running</div>
+      <div class="list-bg">
+        <div class="card">
+          <div class="row-title">
+            <span class="dot run"></span>
+            <span class="title">A股有哪些长期优质的公…</span>
+            <span class="time">7m ago</span>
+          </div>
+          <span class="preview">分析报告中…</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- C -->
+  <section class="variant">
+    <div class="variant-head">
+      <div class="tag">方案 C</div>
+      <h2>预览行末尾 inline</h2>
+      <p>badge 与 preview 同一行 flex，预览 truncate，badge 固定右侧。无 workspace 时尤其紧凑。</p>
+      <div class="pros"><span>零增行</span><span>badge 贴内容上下文</span></div>
+    </div>
+    <div class="preview-pane">
+      <div class="list-bg">
+        <div class="card active">
+          <div class="row-title">
+            <span class="title">执行PS</span>
+            <span class="time">Just now</span>
+          </div>
+          <span class="workspace">TeamClaw Dev</span>
+          <div class="preview-row">
+            <span class="preview"><em>@MYBOT</em> 执行ps</span>
+            <span class="badge">待确认</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- D -->
+  <section class="variant rec">
+    <div class="rec-badge">推荐 D</div>
+    <div class="variant-head">
+      <div class="tag">方案 D</div>
+      <h2>仅图标 pill（hover 全文）</h2>
+      <p>标题行放 18px 图标 pill（✓ permission / ? question / spinner），完整文案走 <code>title</code> tooltip。</p>
+      <div class="pros"><span>零增行</span><span>最省宽度</span><span>i18n 友好</span></div>
+    </div>
+    <div class="preview-pane">
+      <div class="list-bg">
+        <div class="card active" title="Awaiting confirmation">
+          <div class="row-title">
+            <span class="title">执行PS</span>
+            <span class="badge icon" title="Awaiting confirmation">✓</span>
+            <span class="time">Just now</span>
+          </div>
+          <span class="workspace">TeamClaw Dev</span>
+          <span class="preview"><em>@MYBOT</em> 执行ps</span>
+        </div>
+      </div>
+      <div class="preview-label" style="margin-top:12px">question / running</div>
+      <div class="list-bg">
+        <div class="card" title="Awaiting answer">
+          <div class="row-title">
+            <span class="title">Skill: downloader</span>
+            <span class="badge icon question" title="Awaiting answer">?</span>
+            <span class="time">5m ago</span>
+          </div>
+        </div>
+        <div class="card" style="margin-top:2px">
+          <div class="row-title">
+            <span class="title">重构模块</span>
+            <span class="spin"></span>
+            <span class="time">Just now</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- E -->
+  <section class="variant">
+    <div class="variant-head">
+      <div class="tag">方案 E</div>
+      <h2>左缘状态条（替代 badge 文本）</h2>
+      <p>选中态已有 coral 左条；等待态改 emerald 细条 + 无文字。状态靠颜色区分，零增行。</p>
+      <div class="pros"><span>零增行</span><span>Editorial Calm</span><span>需 legend 说明</span></div>
+    </div>
+    <div class="preview-pane">
+      <div class="list-bg">
+        <div class="card active accent-wait">
+          <div class="row-title">
+            <span class="title">执行PS</span>
+            <span class="time">Just now</span>
+          </div>
+          <span class="workspace">TeamClaw Dev</span>
+          <span class="preview"><em>@MYBOT</em> 执行ps</span>
+        </div>
+      </div>
+      <p style="font-size:11px;color:var(--muted);margin-top:10px;">
+        ◆ 左条 emerald = 等待用户 · coral = 选中 · 无条 = 普通
+      </p>
+    </div>
+  </section>
+
+  <!-- F -->
+  <section class="variant">
+    <div class="variant-head">
+      <div class="tag">方案 F · 混合</div>
+      <h2>有参与者才占行；solo 走 Meta</h2>
+      <p>仅当 participants 行本就要显示时，badge 放该行右侧；solo session 的 activity 回退到方案 A。</p>
+      <div class="pros"><span>兼顾两种场景</span><span>逻辑稍复杂</span></div>
+    </div>
+    <div class="preview-pane">
+      <div class="preview-label">solo + activity → Meta（不增行）</div>
+      <div class="list-bg">
+        <div class="card active">
+          <div class="row-title">
+            <span class="title">执行PS</span>
+            <span class="badge short">待确认</span>
+            <span class="time">Just now</span>
+          </div>
+          <span class="preview"><em>@MYBOT</em> 执行ps</span>
+        </div>
+      </div>
+      <div class="preview-label" style="margin-top:12px">多人 + activity → 复用 participants 行</div>
+      <div class="list-bg">
+        <div class="card">
+          <div class="row-title">
+            <span class="title">团队评审</span>
+            <span class="time">1h ago</span>
+          </div>
+          <span class="preview">@alice 看下这个 PR</span>
+          <div class="participants">
+            <div class="avatars">
+              <div class="av a">A</div>
+              <div class="av b">M</div>
+            </div>
+            <span class="pcount">3 位</span>
+            <span class="flex-1"></span>
+            <span class="badge">待确认</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+<footer>
+  <strong>选型建议：</strong>
+  日常 solo 会话最多 → 优先 <strong>A（中文短标签「待确认/待回答」）</strong> 或 <strong>D（图标 + tooltip）</strong>；
+  若希望更 quiet → <strong>E 左条</strong> 可与选中 coral 左条互斥设计。
+  确定方案后我再改 <code>SessionListColumn.tsx</code> 的 <code>SessionActivityBadge</code> 位置与条件渲染。
+  <br /><br />
+  本地预览：<code>open docs/design-mock/session-activity-badge-variants.html</code>
+</footer>
+
+</body>
+</html>

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -5,7 +5,6 @@ import { useTeamShareStore, isShareModeLocked } from "@/stores/team-share"
 import { UpgradeAccountDialog } from "@/components/auth/UpgradeAccountDialog"
 
 import { useSessionStore } from "@/stores/session"
-import { useStreamingStore } from "@/stores/streaming"
 import { useUIStore } from "@/stores/ui"
 import { useWorkspaceStore } from "@/stores/workspace"
 import { useCronStore } from "@/stores/cron"
@@ -30,7 +29,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { TrafficLights } from "@/components/ui/traffic-lights"
-import { buildSessionListActivityMap } from "@/lib/session-list-activity"
+import { useSessionListActivityMap } from "@/hooks/use-session-list-activity-map"
 import { SessionSearchDialog } from "@/components/sidebar/session-search-dialog"
 import { SessionDetailDialog, type SessionDetailListHints } from "@/components/sidebar/SessionDetailDialog"
 import { NavRail } from "@/components/sidebar/NavRail"
@@ -351,45 +350,13 @@ function SidebarUserAccountMenu() {
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { t } = useTranslation()
-  const allSessions = useSessionStore(s => s.sessions)
   const activeSessionId = useSessionStore(s => s.activeSessionId)
-  const sessionStatuses = useSessionStore(s => s.sessionStatuses) || {}
-  const pendingQuestionIdsBySession = useSessionStore(s => s.pendingQuestionIdsBySession) || {}
-  const pendingQuestions = useSessionStore(s => s.pendingQuestions) || []
-  const pendingPermissions = useSessionStore(s => s.pendingPermissions) || []
-  const streamingMessageId = useStreamingStore(s => s.streamingMessageId)
-  const childSessionStreaming = useStreamingStore(s => s.childSessionStreaming)
+  const sessionActivityMap = useSessionListActivityMap(activeSessionId)
   const teamId = useCurrentTeamStore((s) => s.team?.id ?? null)
 
   const [detailSessionId, setDetailSessionId] = React.useState<string | null>(null)
   const [detailHints, setDetailHints] = React.useState<SessionDetailListHints | null>(null)
 
-  const sessionActivityMap = React.useMemo(
-    () =>
-      buildSessionListActivityMap({
-        sessions: allSessions,
-        activeSessionId,
-        sessionStatuses,
-        pendingQuestionIdsBySession,
-        pendingQuestions,
-        pendingPermissions,
-        streamingMessageId,
-        streamingChildSessionIds: Object.values(childSessionStreaming)
-          .filter((state) => state?.isStreaming)
-          .map((state) => state.sessionId),
-      }),
-    [
-      activeSessionId,
-      allSessions,
-      childSessionStreaming,
-      pendingPermissions,
-      pendingQuestionIdsBySession,
-      pendingQuestions,
-      sessionStatuses,
-      streamingMessageId,
-    ],
-  )
-  
   const openSettings = useUIStore(s => s.openSettings)
 
   const handleSelectSession = (id: string) => {

--- a/packages/app/src/components/sidebar/SessionLiquidGlass.tsx
+++ b/packages/app/src/components/sidebar/SessionLiquidGlass.tsx
@@ -30,7 +30,9 @@ export function SessionLiquidGlass({
   const prevIdRef = React.useRef<string | null | undefined>(null)
   const moveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const sync = React.useCallback(() => {
+  const syncFrameRef = React.useRef<number | null>(null)
+
+  const measureAndApply = React.useCallback(() => {
     const root = rootRef.current
     const glass = glassRef.current
     if (!root || !glass || disabled || !activeSessionId) {
@@ -56,6 +58,17 @@ export function SessionLiquidGlass({
     setVisible(true)
   }, [rootRef, activeSessionId, disabled])
 
+  /** Coalesce scroll/resize/observer bursts into one measure per frame. */
+  const sync = React.useCallback(() => {
+    if (syncFrameRef.current != null) {
+      cancelAnimationFrame(syncFrameRef.current)
+    }
+    syncFrameRef.current = requestAnimationFrame(() => {
+      syncFrameRef.current = null
+      measureAndApply()
+    })
+  }, [measureAndApply])
+
   React.useLayoutEffect(() => {
     const idChanged = prevIdRef.current !== activeSessionId
     if (idChanged && activeSessionId && prevIdRef.current != null && prevIdRef.current !== undefined) {
@@ -64,8 +77,9 @@ export function SessionLiquidGlass({
       moveTimerRef.current = setTimeout(() => setMoving(false), 420)
     }
     prevIdRef.current = activeSessionId ?? null
-    sync()
-  }, [sync, activeSessionId, layoutKey, disabled])
+    // Synchronous — avoid one frame of stale geometry after list re-order.
+    measureAndApply()
+  }, [measureAndApply, activeSessionId, layoutKey, disabled])
 
   React.useEffect(() => {
     const scroll = scrollRef.current
@@ -93,6 +107,7 @@ export function SessionLiquidGlass({
 
   React.useEffect(() => () => {
     if (moveTimerRef.current) clearTimeout(moveTimerRef.current)
+    if (syncFrameRef.current != null) cancelAnimationFrame(syncFrameRef.current)
   }, [])
 
   return (

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { Search, Loader2, MessageSquare, Pin, Archive, Pencil, Ellipsis, Info, SquarePen, Users, X, ListChecks, Check } from 'lucide-react'
+import { Search, Loader2, MessageSquare, Pin, Archive, Pencil, Ellipsis, Info, SquarePen, Users, X, ListChecks, Check, HelpCircle, Stamp, Clock } from 'lucide-react'
 import { useSessionStore } from '@/stores/session'
-import { useStreamingStore } from '@/stores/streaming'
 import { useUIStore } from '@/stores/ui'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useCronStore } from '@/stores/cron'
@@ -37,12 +36,14 @@ import {
 import { cn } from '@/lib/utils'
 import { formatRelativeTime } from '@/lib/date-format'
 import { useTypeAhead } from '@/hooks/use-type-ahead'
-import { buildSessionListActivityMap, type SessionListActivity } from '@/lib/session-list-activity'
+import type { SessionListActivity } from '@/lib/session-list-activity'
+import { useSessionListActivityMap } from '@/hooks/use-session-list-activity-map'
 import { loadSessionIdsForActor } from '@/lib/session-by-actor'
 import { loadSessionIdsForWorkspace } from '@/lib/session-by-workspace'
 import { actorAvatarColor } from '@/lib/actor-color'
 import { useSessionWorkspaceLabels } from '@/hooks/use-session-workspace-labels'
 import { compareSessionListByRecency } from '@/lib/session-list-sort'
+import { buildSessionListGlassLayoutKey } from '@/lib/session-list-glass-layout-key'
 import { isScheduledSession } from '@/lib/session-origin'
 
 /**
@@ -120,15 +121,61 @@ type VirtualRow =
   | { key: string; kind: 'divider' }
   | { key: string; kind: 'session'; row: ListRow }
 
+function sessionActivityLabel(
+  activity: SessionListActivity,
+  t: (key: string, fallback: string) => string,
+): string {
+  if (activity.state === 'running') return t('sidebar.sessionRunning', 'Running')
+  if (activity.kind === 'question') return t('sessions.detail.awaitingQuestion', 'Awaiting answer')
+  if (activity.kind === 'permission') return t('sidebar.awaitingConfirmation', 'Awaiting confirmation')
+  return t('sessions.detail.waiting', 'Waiting')
+}
+
+/** D方案：18px 图标 pill，完整文案走 title / aria-label；不增行高。 */
 function SessionActivityBadge({ activity }: { activity?: SessionListActivity }) {
   const { t } = useTranslation()
   if (!activity) return null
+
+  const label = sessionActivityLabel(activity, t)
+
   if (activity.state === 'running') {
-    return <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-primary" aria-label={t('sidebar.sessionRunning', 'Running')} />
+    return (
+      <span
+        className="mr-1 inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center"
+        title={label}
+        aria-label={label}
+        data-testid="v2-session-activity-badge"
+        data-kind="streaming"
+      >
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
+      </span>
+    )
   }
+
+  const isQuestion = activity.kind === 'question'
+  const isPermission = activity.kind === 'permission'
   return (
-    <span className="min-w-0 shrink rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold leading-4 text-emerald-600">
-      <span className="block truncate">{t('sidebar.awaitingConfirmation', 'Awaiting confirmation')}</span>
+    <span
+      className={cn(
+        'mr-1 inline-grid h-[18px] w-[18px] shrink-0 place-items-center rounded-full border',
+        isQuestion
+          ? 'border-indigo-500/20 bg-indigo-500/10 text-indigo-600'
+          : isPermission
+            ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600'
+            : 'border-amber-500/20 bg-amber-500/10 text-amber-700',
+      )}
+      title={label}
+      aria-label={label}
+      data-testid="v2-session-activity-badge"
+      data-kind={activity.kind}
+    >
+      {isQuestion ? (
+        <HelpCircle className="h-3 w-3" strokeWidth={2.5} aria-hidden />
+      ) : isPermission ? (
+        <Stamp className="h-3 w-3" strokeWidth={2.5} aria-hidden />
+      ) : (
+        <Clock className="h-3 w-3" strokeWidth={2.5} aria-hidden />
+      )}
     </span>
   )
 }
@@ -179,18 +226,10 @@ export function SessionListColumn({
   const listHasMore = useSessionListStore((s) => s.hasMore)
   const loadMoreSessions = useSessionListStore((s) => s.loadMore)
 
-  // Activity badges still read legacy compat state until the activity store is
-  // extracted. List actions and row state are v2-owned.
-  const allSessions = useSessionStore((s) => s.sessions)
+  // Activity badges: useSessionListActivityMap (legacy + v2 ACP permissions).
   const activeSessionId = useSessionSelectionStore((s) => s.activeSessionId)
   const pinnedSessionIds = useSessionListStore((s) => s.pinnedSessionIds)
   const highlightedSessionIds = useSessionListStore((s) => s.highlightedSessionIds)
-  const sessionStatuses = useSessionStore((s) => s.sessionStatuses) || {}
-  const pendingQuestionIdsBySession = useSessionStore((s) => s.pendingQuestionIdsBySession) || {}
-  const pendingQuestions = useSessionStore((s) => s.pendingQuestions) || []
-  const pendingPermissions = useSessionStore((s) => s.pendingPermissions) || []
-  const streamingMessageId = useStreamingStore((s) => s.streamingMessageId)
-  const childSessionStreaming = useStreamingStore((s) => s.childSessionStreaming)
   const archiveSession = useSessionStore((s) => s.archiveSession)
   const updateSessionTitle = useSessionListStore((s) => s.updateSessionTitle)
   const toggleSessionPinned = useSessionListStore((s) => s.toggleSessionPinned)
@@ -336,7 +375,6 @@ export function SessionListColumn({
     gap: 2,
     getItemKey: (index) => virtualRows[index].key,
   })
-  const glassLayoutKey = `${activeSessionId ?? ''}:${actionsOpenSessionId ?? ''}:${filteredRows.length}:${pinnedRows.length}:${shouldVirtualize ? 1 : 0}`
 
   React.useEffect(() => {
     if (!shouldVirtualize) return
@@ -359,31 +397,32 @@ export function SessionListColumn({
     void ensureParticipants(filteredRows.map((r) => r.id))
   }, [ensureParticipants, filteredRows, visibleIds])
 
-  const sessionActivityMap = React.useMemo(
-    () =>
-      buildSessionListActivityMap({
-        sessions: allSessions,
-        activeSessionId,
-        sessionStatuses,
-        pendingQuestionIdsBySession,
-        pendingQuestions,
-        pendingPermissions,
-        streamingMessageId,
-        streamingChildSessionIds: Object.values(childSessionStreaming)
-          .filter((state) => state?.isStreaming)
-          .map((state) => state.sessionId),
-      }),
-    [
+  const sessionActivityMap = useSessionListActivityMap(activeSessionId)
+
+  const glassLayoutKey = React.useMemo(() => {
+    const rowOrder = virtualRows.map((v) => (v.kind === 'session' ? v.row.id : v.key))
+    const rowLayoutHints: Array<{ sessionId: string; participantCount: number }> = []
+    for (const v of virtualRows) {
+      if (v.kind !== 'session') continue
+      const participantCount = participantsBySession[v.row.id]?.length ?? 0
+      if (participantCount > 0) {
+        rowLayoutHints.push({ sessionId: v.row.id, participantCount })
+      }
+    }
+    return buildSessionListGlassLayoutKey({
       activeSessionId,
-      allSessions,
-      childSessionStreaming,
-      pendingPermissions,
-      pendingQuestionIdsBySession,
-      pendingQuestions,
-      sessionStatuses,
-      streamingMessageId,
-    ],
-  )
+      actionsOpenSessionId,
+      rowOrder,
+      rowLayoutHints,
+      shouldVirtualize,
+    })
+  }, [
+    activeSessionId,
+    actionsOpenSessionId,
+    participantsBySession,
+    shouldVirtualize,
+    virtualRows,
+  ])
 
   const title = (() => {
     if (filter.kind === 'all') {
@@ -654,7 +693,7 @@ export function SessionListColumn({
             ) : null}
             <div className="flex min-w-0 flex-1 flex-col items-start gap-1">
               {/* Title row: title + meta + sibling more (more stops propagation). */}
-              <div className="flex w-full min-w-0 items-center gap-1.5">
+              <div className="flex w-full min-w-0 items-center gap-1.5 overflow-hidden">
                 {row.isPinned && <Pin className="h-3 w-3 shrink-0 fill-amber-500/20 text-amber-500" />}
                 {isRenaming ? (
                   <div
@@ -676,7 +715,7 @@ export function SessionListColumn({
                     >
                       {row.title || t('chat.newChat', 'New Chat')}
                     </span>
-                    <div className="flex shrink-0 items-center">
+                    <div className="flex min-w-0 shrink-0 items-center">
                       {!isActive && row.hasUnread && (
                         <span
                           className="mr-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-coral"
@@ -688,6 +727,7 @@ export function SessionListColumn({
                           {t('chat.newSessionBadge', 'NEW')}
                         </span>
                       )}
+                      {activity ? <SessionActivityBadge activity={activity} /> : null}
                       {row.lastMessageAt && (
                         <span className="shrink-0 px-0.5 text-[11px] leading-[22px] tabular-nums text-faint">
                           {formatRelativeTime(row.lastMessageAt)}
@@ -764,42 +804,36 @@ export function SessionListColumn({
                   )}
                 </span>
               )}
-              {!isRenaming && ((parts.length > 0 && !isSoloWithLocalAgent) || activity) && (
+              {!isRenaming && parts.length > 0 && !isSoloWithLocalAgent && (
                 <div className="flex w-full items-center gap-1.5" data-testid="v2-session-row-participants">
-                  {parts.length > 0 && !isSoloWithLocalAgent && (
-                    <>
-                      <div className="flex -space-x-1.5">
-                        {parts.slice(0, 3).map((p) => {
-                          const c = actorAvatarColor(p.actorId)
-                          return (
-                            <Avatar
-                              key={p.actorId}
-                              className={cn(
-                                'h-4 w-4 ring-1 ring-paper',
-                                p.isAgent ? 'rounded-[3px]' : 'rounded-full',
-                              )}
-                            >
-                              {p.avatarUrl && <AvatarImage src={p.avatarUrl} alt={p.displayName} />}
-                              <AvatarFallback
-                                className={cn(
-                                  'text-[8px] font-semibold',
-                                  p.isAgent ? 'rounded-[3px]' : 'rounded-full',
-                                )}
-                                style={{ background: c.bg, color: c.fg }}
-                              >
-                                {p.displayName.slice(0, 1).toUpperCase()}
-                              </AvatarFallback>
-                            </Avatar>
-                          )
-                        })}
-                      </div>
-                      <span className="text-[10.5px] text-faint">
-                        {t('sidebar.participantCount', { count: parts.length, defaultValue: '{{count}} 位' })}
-                      </span>
-                    </>
-                  )}
-                  <span className="flex-1" />
-                  <SessionActivityBadge activity={activity} />
+                  <div className="flex -space-x-1.5">
+                    {parts.slice(0, 3).map((p) => {
+                      const c = actorAvatarColor(p.actorId)
+                      return (
+                        <Avatar
+                          key={p.actorId}
+                          className={cn(
+                            'h-4 w-4 ring-1 ring-paper',
+                            p.isAgent ? 'rounded-[3px]' : 'rounded-full',
+                          )}
+                        >
+                          {p.avatarUrl && <AvatarImage src={p.avatarUrl} alt={p.displayName} />}
+                          <AvatarFallback
+                            className={cn(
+                              'text-[8px] font-semibold',
+                              p.isAgent ? 'rounded-[3px]' : 'rounded-full',
+                            )}
+                            style={{ background: c.bg, color: c.fg }}
+                          >
+                            {p.displayName.slice(0, 1).toUpperCase()}
+                          </AvatarFallback>
+                        </Avatar>
+                      )
+                    })}
+                  </div>
+                  <span className="text-[10.5px] text-faint">
+                    {t('sidebar.participantCount', { count: parts.length, defaultValue: '{{count}} 位' })}
+                  </span>
                 </div>
               )}
 

--- a/packages/app/src/hooks/__tests__/use-session-list-activity-map.test.ts
+++ b/packages/app/src/hooks/__tests__/use-session-list-activity-map.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { buildSessionListActivityMap } from "@/lib/session-list-activity";
+import { useSessionStore } from "@/stores/session";
+import { useV2StreamingStore } from "@/stores/v2-streaming-store";
+import { useSessionListActivityMap } from "@/hooks/use-session-list-activity-map";
+import { renderHook } from "@testing-library/react";
+
+describe("useSessionListActivityMap", () => {
+  beforeEach(() => {
+    useSessionStore.setState({
+      sessions: [{ id: "sess-a", title: "A", messages: [], updatedAt: new Date(), createdAt: new Date() }],
+      activeSessionId: "sess-a",
+      pendingPermissions: [],
+      pendingQuestions: [],
+      pendingQuestionIdsBySession: {},
+      sessionStatuses: {},
+    });
+    useV2StreamingStore.setState({
+      byKey: {
+        "sess-a::agent-1": {
+          sessionId: "sess-a",
+          actorId: "agent-1",
+          outputText: "",
+          thinkingText: "",
+          parts: [],
+          toolCalls: [],
+          planEntries: [],
+          pendingPermissionsByRequestId: {
+            "perm-1": {
+              requestId: "perm-1",
+              toolName: "bash",
+              description: "ls",
+              params: {},
+            },
+          },
+          errorMessage: null,
+          errorDetails: null,
+          lastUpdate: 0,
+          active: true,
+          streamId: "s1",
+        },
+      },
+    } as never);
+  });
+
+  it("surfaces v2 ACP permission activity on the session list", () => {
+    const { result } = renderHook(() => useSessionListActivityMap("sess-a"));
+    expect(result.current.get("sess-a")).toEqual(
+      expect.objectContaining({
+        state: "waiting",
+        kind: "permission",
+      }),
+    );
+  });
+});
+
+describe("buildSessionListActivityMap v2 permission merge", () => {
+  it("dedupes legacy and acp permissions by id", () => {
+    const map = buildSessionListActivityMap({
+      sessions: [{ id: "sess-a", title: "A", messages: [], updatedAt: new Date(), createdAt: new Date() }],
+      activeSessionId: "sess-a",
+      sessionStatuses: {},
+      pendingQuestionIdsBySession: {},
+      pendingQuestions: [],
+      pendingPermissions: [
+        {
+          permission: { id: "perm-1", sessionID: "sess-a", permission: "bash" },
+          childSessionId: null,
+        },
+        {
+          permission: { id: "perm-2", sessionID: "sess-a", permission: "write" },
+          childSessionId: null,
+        },
+      ],
+      streamingMessageId: null,
+      streamingChildSessionIds: [],
+    });
+    expect(map.get("sess-a")?.kind).toBe("permission");
+  });
+});

--- a/packages/app/src/hooks/use-session-list-activity-map.ts
+++ b/packages/app/src/hooks/use-session-list-activity-map.ts
@@ -1,0 +1,70 @@
+import * as React from "react";
+import { useSessionStore } from "@/stores/session";
+import { useStreamingStore } from "@/stores/streaming";
+import { useV2StreamingStore } from "@/stores/v2-streaming-store";
+import { buildSessionListActivityMap } from "@/lib/session-list-activity";
+import type { PendingPermissionEntry } from "@/stores/session-types";
+import {
+  collectAcpStreamingPermissionsForList,
+  selectStreamingPermissionSnapshot,
+} from "@/lib/teamclaw/acp-permission-entries";
+
+function mergePendingPermissionEntries(
+  ...groups: PendingPermissionEntry[][]
+): PendingPermissionEntry[] {
+  const byId = new Map<string, PendingPermissionEntry>();
+  for (const group of groups) {
+    for (const entry of group) {
+      const id = entry.permission?.id;
+      if (id) byId.set(id, entry);
+    }
+  }
+  return Array.from(byId.values());
+}
+
+export function useSessionListActivityMap(activeSessionId: string | null) {
+  const allSessions = useSessionStore((s) => s.sessions);
+  const sessionStatuses = useSessionStore((s) => s.sessionStatuses) || {};
+  const pendingQuestionIdsBySession =
+    useSessionStore((s) => s.pendingQuestionIdsBySession) || {};
+  const pendingQuestions = useSessionStore((s) => s.pendingQuestions) || [];
+  const legacyPendingPermissions =
+    useSessionStore((s) => s.pendingPermissions) || [];
+  const streamingMessageId = useStreamingStore((s) => s.streamingMessageId);
+  const childSessionStreaming = useStreamingStore((s) => s.childSessionStreaming);
+  const permissionSnapshot = useV2StreamingStore((s) =>
+    selectStreamingPermissionSnapshot(s.byKey),
+  );
+
+  return React.useMemo(
+    () =>
+      buildSessionListActivityMap({
+        sessions: allSessions,
+        activeSessionId,
+        sessionStatuses,
+        pendingQuestionIdsBySession,
+        pendingQuestions,
+        pendingPermissions: mergePendingPermissionEntries(
+          legacyPendingPermissions,
+          collectAcpStreamingPermissionsForList(
+            useV2StreamingStore.getState().byKey,
+          ),
+        ),
+        streamingMessageId,
+        streamingChildSessionIds: Object.values(childSessionStreaming)
+          .filter((state) => state?.isStreaming)
+          .map((state) => state.sessionId),
+      }),
+    [
+      activeSessionId,
+      allSessions,
+      childSessionStreaming,
+      legacyPendingPermissions,
+      pendingQuestionIdsBySession,
+      pendingQuestions,
+      permissionSnapshot,
+      sessionStatuses,
+      streamingMessageId,
+    ],
+  );
+}

--- a/packages/app/src/lib/__tests__/acp-permission-entries.test.ts
+++ b/packages/app/src/lib/__tests__/acp-permission-entries.test.ts
@@ -3,6 +3,8 @@ import {
   buildPendingEntryFromAcpPermission,
   collectAcpBystanderWaitingPermissions,
   collectAcpStreamingPermissions,
+  collectAcpStreamingPermissionsForList,
+  selectStreamingPermissionSnapshot,
 } from "@/lib/teamclaw/acp-permission-entries";
 import { useCurrentTeamStore } from "@/stores/current-team";
 import { useV2StreamingStore } from "@/stores/v2-streaming-store";
@@ -25,6 +27,39 @@ describe("acp permission entries", () => {
     expect(entry.permission.permission).toBe("bash");
     expect(entry.permission.patterns).toEqual(["ls -la"]);
     expect(entry.permission.metadata?._acp_agent_actor_id).toBe("agent-1");
+  });
+
+  it("collects pending permissions across all sessions for list badges", () => {
+    const byKey = {
+      "sess-a::agent-1": {
+        sessionId: "sess-a",
+        actorId: "agent-1",
+        pendingPermissionsByRequestId: {
+          p1: {
+            requestId: "p1",
+            toolName: "bash",
+            description: "echo hi",
+            params: {},
+          },
+        },
+      },
+      "sess-b::agent-2": {
+        sessionId: "sess-b",
+        actorId: "agent-2",
+        pendingPermissionsByRequestId: {
+          p2: {
+            requestId: "p2",
+            toolName: "bash",
+            description: "pwd",
+            params: {},
+          },
+        },
+      },
+    };
+    expect(collectAcpStreamingPermissionsForList(byKey)).toHaveLength(2);
+    expect(selectStreamingPermissionSnapshot(byKey)).toBe(
+      "sess-a:p1|sess-b:p2",
+    );
   });
 
   it("collects pending permissions for the active session only", () => {

--- a/packages/app/src/lib/__tests__/session-list-glass-layout-key.test.ts
+++ b/packages/app/src/lib/__tests__/session-list-glass-layout-key.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { buildSessionListGlassLayoutKey } from '@/lib/session-list-glass-layout-key'
+
+describe('buildSessionListGlassLayoutKey', () => {
+  const base = {
+    activeSessionId: 's-active',
+    actionsOpenSessionId: null as string | null,
+    rowOrder: ['s-a', 's-b', 's-c'],
+    rowLayoutHints: [] as Array<{ sessionId: string; participantCount: number }>,
+    shouldVirtualize: false,
+  }
+
+  it('changes when row order changes (re-sort after send)', () => {
+    const before = buildSessionListGlassLayoutKey(base)
+    const after = buildSessionListGlassLayoutKey({
+      ...base,
+      rowOrder: ['s-active', 's-a', 's-b'],
+    })
+    expect(before).not.toBe(after)
+  })
+
+  it('stays stable when only inactive preview text would change elsewhere', () => {
+    const a = buildSessionListGlassLayoutKey(base)
+    const b = buildSessionListGlassLayoutKey({ ...base })
+    expect(a).toBe(b)
+  })
+
+  it('changes when participants load on a row', () => {
+    const before = buildSessionListGlassLayoutKey(base)
+    const after = buildSessionListGlassLayoutKey({
+      ...base,
+      rowLayoutHints: [{ sessionId: 's-b', participantCount: 2 }],
+    })
+    expect(before).not.toBe(after)
+  })
+
+  it('ignores activity-only hints (badge is inline in title row)', () => {
+    const a = buildSessionListGlassLayoutKey(base)
+    const b = buildSessionListGlassLayoutKey({ ...base, rowLayoutHints: [] })
+    expect(a).toBe(b)
+  })
+})

--- a/packages/app/src/lib/session-list-glass-layout-key.ts
+++ b/packages/app/src/lib/session-list-glass-layout-key.ts
@@ -1,0 +1,31 @@
+/**
+ * Fingerprint for SessionLiquidGlass resync.
+ *
+ * The glass pill tracks DOM geometry via getBoundingClientRect. It must
+ * re-measure when row *order* or row *height* changes while activeSessionId
+ * stays the same (e.g. bumpLastMessage re-sort, activity badge, participants
+ * loading). Keep this string compact — it is recomputed on each list render.
+ */
+export function buildSessionListGlassLayoutKey(input: {
+  activeSessionId: string | null | undefined
+  actionsOpenSessionId: string | null | undefined
+  /** Render order — session ids plus structural keys (pinned header / divider). */
+  rowOrder: readonly string[]
+  /** Sessions whose participants sub-row affects card height. */
+  rowLayoutHints: readonly { sessionId: string; participantCount: number }[]
+  shouldVirtualize: boolean
+}): string {
+  const order = input.rowOrder.join('|')
+  let layoutHints = ''
+  for (const hint of input.rowLayoutHints) {
+    if (hint.participantCount === 0) continue
+    layoutHints += `${hint.sessionId}:${hint.participantCount};`
+  }
+  return [
+    input.activeSessionId ?? '',
+    input.actionsOpenSessionId ?? '',
+    order,
+    layoutHints,
+    input.shouldVirtualize ? '1' : '0',
+  ].join('\0')
+}

--- a/packages/app/src/lib/teamclaw/acp-permission-entries.ts
+++ b/packages/app/src/lib/teamclaw/acp-permission-entries.ts
@@ -71,6 +71,38 @@ function forEachPendingInSession(
   }
 }
 
+/**
+ * Compact fingerprint of pending ACP permissions across all sessions.
+ * Used as a Zustand selector so the session list does not re-render on
+ * unrelated streaming deltas.
+ */
+export function selectStreamingPermissionSnapshot(
+  byKey: Record<string, StreamKeyEntry>,
+): string {
+  const parts: string[] = [];
+  for (const entry of Object.values(byKey)) {
+    const ids = Object.keys(entry.pendingPermissionsByRequestId).sort();
+    if (ids.length === 0) continue;
+    parts.push(`${entry.sessionId}:${ids.join(",")}`);
+  }
+  return parts.sort().join("|");
+}
+
+/** All pending ACP permissions for sidebar activity badges (every session). */
+export function collectAcpStreamingPermissionsForList(
+  byKey: Record<string, StreamKeyEntry>,
+): PendingPermissionEntry[] {
+  const out: PendingPermissionEntry[] = [];
+  for (const entry of Object.values(byKey)) {
+    if (shouldAutoAllowSessionPermissions(entry.sessionId)) continue;
+    for (const pending of Object.values(entry.pendingPermissionsByRequestId)) {
+      if (!pending.requestId?.trim()) continue;
+      out.push(buildPendingEntryFromAcpPermission(entry.sessionId, entry.actorId, pending));
+    }
+  }
+  return out;
+}
+
 /** Interactive Allow/Deny queue — excludes bystander-stamped requests. */
 export function collectAcpStreamingPermissions(
   activeSessionId: string | null,


### PR DESCRIPTION
## Summary
- Resync the session list liquid-glass selection pill when row order or participant rows change (fixes misalignment after send/re-sort).
- Wire v2 ACP streaming permissions into sidebar session activity badges via a shared hook and lightweight permission snapshot selector.
- Move waiting/running activity into compact title-row icon pills (stamp for approval, help for questions) so solo sessions no longer gain an extra row.

## Test plan
- [x] `pnpm exec vitest run` on session list, glass layout key, ACP permission entries, app-sidebar tests (46 passed)
- [ ] Select a non-top session, send a message, confirm selection glass follows the row to the top
- [ ] Trigger a v2 permission request and confirm stamp badge appears without increasing card height
- [ ] Long session title truncates correctly with badge + timestamp visible


Made with [Cursor](https://cursor.com)