### PR TITLE
feat(agent-type): claude-code as a first-class runtime + stop swallowing addParticipant failures

### DIFF
--- a/apps/daemon/src/daemon/runtime_resolution.rs
+++ b/apps/daemon/src/daemon/runtime_resolution.rs
@@ -21,11 +21,13 @@ fn configured_local_agent(config: &DaemonConfig) -> Option<amux::AgentType> {
             .codex
             .is_some()
             .then_some(amux::AgentType::Codex),
-        "claude-code" | "claude_code" | "claude" => config
-            .agents
-            .claude_code
-            .is_some()
-            .then_some(amux::AgentType::ClaudeCode),
+        // No config-section dependency, same as pi: `default_launch_configs()`
+        // always carries a ClaudeCode entry (binary "claude"), so the backend is
+        // runnable as soon as it is selected. Requiring `[agents.claude_code]`
+        // made claude-code unselectable on any machine where auto-discovery had
+        // not written that section — which is every fresh install, since
+        // `agent_discover` only detects opencode.
+        "claude-code" | "claude_code" | "claude" => Some(amux::AgentType::ClaudeCode),
         _ => None,
     }
 }
@@ -386,6 +388,30 @@ mod tests {
             supported_agent_type_names(&cfg),
             vec!["claude-code".to_string()]
         );
+    }
+
+    #[test]
+    fn claude_code_is_selectable_without_a_config_section() {
+        // `default_launch_configs()` always carries a ClaudeCode entry, so the
+        // backend runs as soon as it is selected — same deal as pi. Requiring
+        // `[agents.claude_code]` made it unselectable on a fresh install, where
+        // `agent_discover` only ever writes the opencode section.
+        for spelling in ["claude-code", "claude_code", "claude"] {
+            let mut cfg = base_config();
+            cfg.agents.local_agent = spelling.to_string();
+            assert!(cfg.agents.claude_code.is_none());
+
+            assert_eq!(
+                resolve_requested_agent_type(&cfg, amux::AgentType::Opencode),
+                amux::AgentType::ClaudeCode,
+                "{spelling} should reroute to claude"
+            );
+            assert_eq!(
+                supported_agent_type_names(&cfg),
+                vec!["claude-code".to_string()],
+                "{spelling} should advertise the canonical wire name"
+            );
+        }
     }
 
     #[test]

--- a/apps/daemon/src/http/workspaces.rs
+++ b/apps/daemon/src/http/workspaces.rs
@@ -488,7 +488,8 @@ fn backend_label(backend: &str) -> &'static str {
         "opencode" => "OpenCode",
         "pi" => "Pi",
         "cursor" => "Cursor",
-        "claude" => "Claude Code",
+        // Wire name and launch-config `backend_type` spell this differently.
+        "claude-code" | "claude" => "Claude Code",
         "codex" => "Codex",
         _ => "Agent",
     }
@@ -522,7 +523,12 @@ fn catalog_models_from_opencode_json(opencode_providers: &[ProviderInfo]) -> Vec
 /// no codex backend module and `create_backend` has no arm for it, so a
 /// codex-configured daemon runs opencode. Serving a "Codex" group would name a
 /// runtime that never starts.
-const SUPPORTED_CATALOG_BACKENDS: [&str; 4] = ["opencode", "pi", "cursor", "claude"];
+/// Note these are the *wire* names produced by
+/// `runtime_resolution::agent_type_name` (what `configured_agent_types` holds),
+/// which is not the same vocabulary as `AgentLaunchConfig.backend_type`: claude
+/// is `"claude-code"` here and `"claude"` there. Both spellings are accepted so
+/// a caller using either one still gets its group.
+const SUPPORTED_CATALOG_BACKENDS: [&str; 5] = ["opencode", "pi", "cursor", "claude-code", "claude"];
 
 /// Build the catalog from the configured backend list. The single configured
 /// local backend (per `supported_agent_type_names`) is served using

--- a/packages/app/src/components/icons/agent-brand-icons.tsx
+++ b/packages/app/src/components/icons/agent-brand-icons.tsx
@@ -1,10 +1,19 @@
 /**
- * Brand marks for the local-agent runtimes, drawn to match the reference logos
- * (Downloads/opencode.png, Downloads/pi-agent-logo.png). Both use `currentColor`
- * so they render as a white glyph inside the coral chip container in the sidebar,
+ * Brand marks for the local-agent runtimes. All use `currentColor` so they
+ * render as a white glyph inside the coral chip container in the sidebar,
  * exactly like the lucide icons they replace.
  *
- * Geometry is on a 28×28 grid sampled from the source PNGs.
+ * Two provenances, hence two viewBoxes — each mark keeps its source grid rather
+ * than being re-plotted onto a shared one, since re-scaling by hand is how
+ * traced geometry drifts:
+ *
+ *  - opencode / pi: hand-drawn on a 28×28 grid sampled from the reference PNGs
+ *    (Downloads/opencode.png, Downloads/pi-agent-logo.png).
+ *  - claude / cursor: the upstream vector marks, 16×16 and 24×24 respectively.
+ *
+ * These identify third-party runtimes in our own UI — nominative use. The marks
+ * remain the trademarks of Anthropic and Anysphere; do not restyle them into
+ * something that reads as a TeamClaw mark.
  */
 
 /** opencode: a bordered portrait square with a hollow slot (evenodd cuts the hole). */
@@ -25,6 +34,31 @@ export function PiAgentMark({ className }: { className?: string }) {
   return (
     <svg viewBox="0 0 28 28" fill="currentColor" xmlns="http://www.w3.org/2000/svg" className={className}>
       <path d="M6 6h4v16H6zM10 6h8v4h-8zM14 10h4v4h-4zM10 14h4v4h-4zM18 14h4v8h-4z" />
+    </svg>
+  )
+}
+
+/**
+ * Claude Code: the Anthropic starburst — an off-kilter radial burst, not a
+ * letterform. Upstream vector on a 16×16 grid (Bootstrap Icons' `claude`).
+ */
+export function ClaudeMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg" className={className}>
+      <path d="m3.127 10.604 3.135-1.76.053-.153-.053-.085H6.11l-.525-.032-1.791-.048-1.554-.065-1.505-.08-.38-.081L0 7.832l.036-.234.32-.214.455.04 1.009.069 1.513.105 1.097.064 1.626.17h.259l.036-.105-.089-.065-.068-.064-1.566-1.062-1.695-1.121-.887-.646-.48-.327-.243-.306-.104-.67.435-.48.585.04.15.04.593.456 1.267.981 1.654 1.218.242.202.097-.068.012-.049-.109-.181-.9-1.626-.96-1.655-.428-.686-.113-.411a2 2 0 0 1-.068-.484l.496-.674L4.446 0l.662.089.279.242.411.94.666 1.48 1.033 2.014.302.597.162.553.06.17h.105v-.097l.085-1.134.157-1.392.154-1.792.052-.504.25-.605.497-.327.387.186.319.456-.045.294-.19 1.23-.37 1.93-.243 1.29h.142l.161-.16.654-.868 1.097-1.372.484-.545.565-.601.363-.287h.686l.505.751-.226.775-.707.895-.585.759-.839 1.13-.524.904.048.072.125-.012 1.897-.403 1.024-.186 1.223-.21.553.258.06.263-.218.536-1.307.323-1.533.307-2.284.54-.028.02.032.04 1.029.098.44.024h1.077l2.005.15.525.346.315.424-.053.323-.807.411-3.631-.863-.872-.218h-.12v.073l.726.71 1.331 1.202 1.667 1.55.084.383-.214.302-.226-.032-1.464-1.101-.565-.497-1.28-1.077h-.084v.113l.295.432 1.557 2.34.08.718-.112.234-.404.141-.444-.08-.911-1.28-.94-1.44-.759-1.291-.093.053-.448 4.821-.21.246-.484.186-.403-.307-.214-.496.214-.98.258-1.28.21-1.016.19-1.263.112-.42-.008-.028-.092.012-.953 1.307-1.448 1.957-1.146 1.227-.274.109-.477-.247.045-.44.266-.39 1.586-2.018.956-1.25.617-.723-.004-.105h-.036l-4.212 2.736-.75.096-.324-.302.04-.496.154-.162 1.267-.871z" />
+    </svg>
+  )
+}
+
+/**
+ * Cursor: the layered cube seen corner-on, hollowed by the second subpath.
+ * Needs `evenodd` — with the default nonzero rule the cut-out fills solid.
+ * Upstream vector on a 24×24 grid.
+ */
+export function CursorMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" className={className}>
+      <path fillRule="evenodd" clipRule="evenodd" d="M22.106 5.68L12.5.135a.998.998 0 00-.998 0L1.893 5.68a.84.84 0 00-.419.726v11.186c0 .3.16.577.42.727l9.607 5.547a.999.999 0 00.998 0l9.608-5.547a.84.84 0 00.42-.727V6.407a.84.84 0 00-.42-.726zm-.603 1.176L12.228 22.92c-.063.108-.228.064-.228-.061V12.34a.59.59 0 00-.295-.51l-9.11-5.26c-.107-.062-.063-.228.062-.228h18.55c.264 0 .428.286.296.514z" />
     </svg>
   )
 }

--- a/packages/app/src/components/settings/ClaudeLLMSection.tsx
+++ b/packages/app/src/components/settings/ClaudeLLMSection.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Cpu, Terminal, Info } from 'lucide-react'
+import { AgentType } from '@/lib/proto/amux_pb'
+import { useRuntimeStateStore } from '@/stores/runtime-state-store'
+import { getKnownLocalDaemonActorId } from '@/lib/local-daemon-identity'
+import { groupAgentModelOptions } from '@/lib/agent-available-models'
+import { SectionHeader, SettingCard } from './shared'
+
+/**
+ * Claude Code LLM settings — read-only, for the same reason as `PiLLMSection`.
+ *
+ * The `claude` CLI owns its own credentials on the host (`claude /login`, or a
+ * long-lived token from `claude setup-token`); the daemon has no
+ * connect/OAuth/custom-provider path for it, so there is nothing to configure
+ * here. The pane shows the models the running claude runtime advertises and
+ * points at the CLI for auth.
+ *
+ * Note the claude backend reports a fixed model table rather than probing a
+ * provider list, so this list changes only with the daemon's own table — unlike
+ * opencode, where it follows `opencode.json`.
+ */
+export function ClaudeLLMSection() {
+  const { t } = useTranslation()
+  const byRuntimeId = useRuntimeStateStore((s) => s.byRuntimeId)
+
+  const models = React.useMemo(() => {
+    const localId = getKnownLocalDaemonActorId()
+    let best: { models: { id?: string; displayName?: string }[]; lastUpdated: number } | null = null
+    for (const entry of Object.values(byRuntimeId)) {
+      if (entry.info.agentType !== AgentType.CLAUDE_CODE) continue
+      if (localId && entry.daemonActorId !== localId) continue
+      if (!best || entry.lastUpdated > best.lastUpdated) {
+        best = { models: entry.info.availableModels ?? [], lastUpdated: entry.lastUpdated }
+      }
+    }
+    const seen = new Set<string>()
+    return (best?.models ?? [])
+      .map((m) => ({
+        id: m.id?.trim() ?? '',
+        displayName: m.displayName?.trim() || m.id?.trim() || '',
+      }))
+      .filter((m) => m.id && !seen.has(m.id) && seen.add(m.id))
+  }, [byRuntimeId])
+
+  const groups = React.useMemo(() => groupAgentModelOptions(models), [models])
+
+  return (
+    <div>
+      <SectionHeader
+        icon={Cpu}
+        title={t('settings.claudeLlm.title', 'Claude Code 模型')}
+        description={t(
+          'settings.claudeLlm.description',
+          'claude 运行时自带的模型，由主机上的 claude 凭证管理。',
+        )}
+      />
+
+      <SettingCard className="mb-4">
+        <div className="flex items-start gap-3 p-4">
+          <Info className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="text-[12.5px] leading-relaxed text-muted-foreground">
+            <p>
+              {t(
+                'settings.claudeLlm.loginHint',
+                'Claude Code 的凭证由 claude CLI 自己管理，不通过 opencode.json。要登录，请在主机终端运行：',
+              )}
+            </p>
+            <code className="mt-2 inline-flex items-center gap-1.5 rounded-md bg-panel px-2 py-1 font-mono text-[12px] text-foreground">
+              <Terminal className="h-3.5 w-3.5" />
+              claude /login
+            </code>
+            <p className="mt-2">
+              {t(
+                'settings.claudeLlm.loginHintAfter',
+                '登录后回到这里刷新。若本机未安装 claude 命令，运行时无法启动。',
+              )}
+            </p>
+          </div>
+        </div>
+      </SettingCard>
+
+      {models.length === 0 ? (
+        <SettingCard>
+          <div className="p-6 text-center text-[12.5px] text-muted-foreground">
+            {t(
+              'settings.claudeLlm.empty',
+              '暂无可用模型。请确认本机已安装 claude 命令并完成登录，且 claude 运行时在线。',
+            )}
+          </div>
+        </SettingCard>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {groups.map((group) => (
+            <SettingCard key={group.providerName}>
+              <div className="border-b border-border-soft px-4 py-2.5">
+                <div className="flex items-center justify-between">
+                  <span className="font-mono text-[12.5px] font-medium text-foreground">
+                    {group.providerName}
+                  </span>
+                  <span className="text-[11px] text-faint">
+                    {t('settings.claudeLlm.modelCount', '{{count}} 个模型', {
+                      count: group.models.length,
+                    })}
+                  </span>
+                </div>
+              </div>
+              <ul className="divide-y divide-border-soft">
+                {group.models.map((m) => (
+                  <li
+                    key={m.id}
+                    className="flex items-center justify-between px-4 py-2.5 text-[12.5px]"
+                  >
+                    <span className="text-foreground">{m.displayName}</span>
+                    <span className="font-mono text-[11px] text-faint">{m.id}</span>
+                  </li>
+                ))}
+              </ul>
+            </SettingCard>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/app/src/components/settings/DaemonGeneralSection.tsx
+++ b/packages/app/src/components/settings/DaemonGeneralSection.tsx
@@ -538,6 +538,7 @@ export function DaemonGeneralSection() {
                       <SelectItem value="opencode" className="font-mono text-[12px]">opencode</SelectItem>
                       <SelectItem value="pi" className="font-mono text-[12px]">pi</SelectItem>
                       <SelectItem value="cursor" className="font-mono text-[12px]">cursor</SelectItem>
+                      <SelectItem value="claude-code" className="font-mono text-[12px]">claude-code</SelectItem>
                     </SelectContent>
                   </Select>
                   {switchingAgent && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}

--- a/packages/app/src/components/settings/LLMSectionRouter.tsx
+++ b/packages/app/src/components/settings/LLMSectionRouter.tsx
@@ -4,6 +4,7 @@ import { isTauri } from '@/lib/utils'
 import { OpenCodeLLMSection } from './LLMSection'
 import { PiLLMSection } from './PiLLMSection'
 import { CursorLLMSection } from './CursorLLMSection'
+import { ClaudeLLMSection } from './ClaudeLLMSection'
 
 /**
  * LLM settings dispatcher. The local agent runtime determines both the logic
@@ -11,6 +12,9 @@ import { CursorLLMSection } from './CursorLLMSection'
  * serve (connect, OAuth, custom providers); pi owns its own credentials on the
  * host (`pi /login`) and only exposes a read-only model catalog. We branch on
  * `agents.local_agent` so each runtime gets its own pane.
+ *
+ * pi, cursor and claude-code all own their credentials outside opencode.json, so
+ * their panes are read-only catalogs; only opencode gets the provider UI.
  */
 export function LLMSection() {
   const [agent, setAgent] = React.useState<DaemonLocalAgent | null>(null)
@@ -37,5 +41,6 @@ export function LLMSection() {
   if (agent === null) return null
   if (agent === 'pi') return <PiLLMSection />
   if (agent === 'cursor') return <CursorLLMSection />
+  if (agent === 'claude-code') return <ClaudeLLMSection />
   return <OpenCodeLLMSection />
 }

--- a/packages/app/src/components/settings/MCPSection.tsx
+++ b/packages/app/src/components/settings/MCPSection.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/components/ui/dialog'
 import { SettingCard, SectionHeader, ToggleSwitch } from './shared'
 import { AddMCPDialog } from './AddMCPDialog'
+import type { DaemonLocalAgent } from '@/lib/daemon-local-client'
 
 // MCP names that are always auto-injected by TeamClaw and cannot be deleted
 const INHERENT_MCP_NAMES = new Set(['playwright', 'chrome-control', 'autoui', 'teamclaw-introspect'])
@@ -336,7 +337,7 @@ export const MCPSection = React.memo(function MCPSection() {
   // The local runtime determines how these servers are consumed: opencode reads
   // opencode.json natively; pi has no native MCP, so the TeamClaw extension
   // spawns each enabled local server and proxies its tools.
-  const [localAgent, setLocalAgent] = React.useState<'opencode' | 'pi' | 'cursor'>('opencode')
+  const [localAgent, setLocalAgent] = React.useState<DaemonLocalAgent>('opencode')
   React.useEffect(() => {
     void (async () => {
       try {
@@ -405,7 +406,12 @@ export const MCPSection = React.memo(function MCPSection() {
             ? t('settings.mcp.piBridgeNote', 'pi 无原生 MCP，已启用的本地 server 由 TeamClaw 扩展桥接为 pi 工具')
             : localAgent === 'cursor'
               ? t('settings.mcp.cursorBridgeNote', 'Cursor SDK 第一版尚未桥接 workspace MCP')
-              : t('settings.mcp.opencodeNote', 'opencode 原生从 opencode.json 加载这些 server')}
+              : localAgent === 'claude-code'
+                ? t(
+                    'settings.mcp.claudeBridgeNote',
+                    'Claude Code 从它自己的配置加载 MCP，不读 opencode.json',
+                  )
+                : t('settings.mcp.opencodeNote', 'opencode 原生从 opencode.json 加载这些 server')}
         </span>
       </div>
 

--- a/packages/app/src/components/sidebar/LocalDaemonRow.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonRow.tsx
@@ -3,19 +3,22 @@ import { useTranslation } from 'react-i18next'
 import {
   ArrowLeftRight,
   Bot,
-  MousePointer2,
   Loader2,
   Plus,
   RefreshCw,
   Settings,
-  Sparkles,
   Star,
   Trash2,
   User,
   UserMinus,
   LifeBuoy,
 } from 'lucide-react'
-import { OpencodeMark, PiAgentMark } from '@/components/icons/agent-brand-icons'
+import {
+  ClaudeMark,
+  CursorMark,
+  OpencodeMark,
+  PiAgentMark,
+} from '@/components/icons/agent-brand-icons'
 import { open } from '@tauri-apps/plugin-dialog'
 import { toast } from 'sonner'
 import type { ActorRow as ActorRowData } from '@/components/panel/ActorsView'
@@ -111,11 +114,11 @@ function AgentTypeIcon({ agentType }: { agentType?: string | null }) {
   const className = 'h-4 w-4'
   switch (agentType) {
     case 'claude-code':
-      return <Sparkles className={className} strokeWidth={2} />
+      return <ClaudeMark className={className} />
     case 'opencode':
       return <OpencodeMark className={className} />
     case 'cursor':
-      return <MousePointer2 className={className} strokeWidth={2} />
+      return <CursorMark className={className} />
     case 'pi':
       return <PiAgentMark className={className} />
     default:

--- a/packages/app/src/lib/__tests__/local-daemon-model-catalog.test.ts
+++ b/packages/app/src/lib/__tests__/local-daemon-model-catalog.test.ts
@@ -39,7 +39,7 @@ describe('fetchLocalDaemonModels', () => {
       ['opencode', 'opencode'],
       ['pi', 'pi'],
       ['cursor', 'cursor'],
-      ['claude-code', 'claude'],
+      ['claude-code', 'claude-code'],
     ] as const) {
       getDaemonModelCatalog.mockResolvedValueOnce(catalog(groupId, ['prov/a', 'prov/b']))
       const models = await fetchLocalDaemonModels('/w1', backendType)
@@ -49,9 +49,11 @@ describe('fetchLocalDaemonModels', () => {
     }
   })
 
-  it('maps every claude spelling onto the daemon "claude" group id', async () => {
+  it('maps every claude spelling onto the daemon "claude-code" wire name', async () => {
+    // The group id is `agent_type_name(ClaudeCode)` = "claude-code", not the
+    // launch-config `backend_type` spelling "claude".
     for (const spelling of ['claude', 'claude_code', 'claude-code']) {
-      getDaemonModelCatalog.mockResolvedValueOnce(catalog('claude', ['anthropic/opus']))
+      getDaemonModelCatalog.mockResolvedValueOnce(catalog('claude-code', ['anthropic/opus']))
       const models = await fetchLocalDaemonModels('/w1', spelling)
       expect(models, `${spelling} should resolve`).toHaveLength(1)
     }

--- a/packages/app/src/lib/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon-local-client.ts
@@ -275,7 +275,14 @@ async function daemonFetchData<T>(path: string, init?: RequestInit): Promise<T> 
 // ─── Local agent runtime (`agents.local_agent` in daemon.toml) ────────────────
 
 /** The local agent runtimes the daemon can drive. */
-export type DaemonLocalAgent = 'opencode' | 'pi' | 'cursor'
+/**
+ * Local agent runtimes the daemon can actually run — one arm each in
+ * `runtime::backend::create_backend`.
+ *
+ * `codex` is absent on purpose: it has no backend module, so a daemon
+ * configured for it runs opencode.
+ */
+export type DaemonLocalAgent = 'opencode' | 'pi' | 'cursor' | 'claude-code'
 
 interface DaemonConfigEntry {
   key: string
@@ -294,11 +301,22 @@ export async function getDaemonLocalAgent(): Promise<DaemonLocalAgent> {
     // 404 = key absent → daemon default. Anything else: fall back conservatively.
     return 'opencode'
   }
-  return result.data.value === 'pi'
-    ? 'pi'
-    : result.data.value === 'cursor'
-      ? 'cursor'
-      : 'opencode'
+  switch (result.data.value) {
+    case 'pi':
+      return 'pi'
+    case 'cursor':
+      return 'cursor'
+    // The daemon accepts all three spellings (`config::runtime_resolution`), and
+    // since `backend::agent_type_for_local_agent` maps every one of them to the
+    // claude backend, reporting them as opencode — as this used to — mislabels
+    // the runtime and routes the LLM pane to the wrong settings UI.
+    case 'claude':
+    case 'claude-code':
+    case 'claude_code':
+      return 'claude-code'
+    default:
+      return 'opencode'
+  }
 }
 
 /**

--- a/packages/app/src/lib/local-daemon-model-catalog.ts
+++ b/packages/app/src/lib/local-daemon-model-catalog.ts
@@ -37,12 +37,14 @@ function catalogBackendId(backendType: string | null | undefined): string | null
       return 'pi'
     case 'cursor':
       return 'cursor'
-    // The daemon labels this group "claude" (`AgentLaunchConfig.backend_type`),
-    // not "claude-code".
+    // The group id is the daemon's *wire* name for the type
+    // (`runtime_resolution::agent_type_name`), which is "claude-code" — not the
+    // `AgentLaunchConfig.backend_type` spelling ("claude"). Both are accepted
+    // server-side, so match on the wire name here.
     case 'claude-code':
     case 'claude':
     case 'claude_code':
-      return 'claude'
+      return 'claude-code'
     default:
       return null
   }

--- a/packages/app/src/lib/session-create.ts
+++ b/packages/app/src/lib/session-create.ts
@@ -363,6 +363,19 @@ export type RuntimeStartFailureCode =
   | 'transport_offline'
   | 'workspace_rpc_timeout'
   | 'workspace_ensure_failed'
+  /**
+   * Adding the agent to `session_participants` failed, so runtimeStart was not
+   * attempted.
+   *
+   * `sessions` carries participant-only RLS (see `joinSession` in the Cloud
+   * API's `supabase-repo`, which needs a SECURITY DEFINER RPC precisely to get
+   * around it). A daemon that is not a participant therefore cannot read the
+   * session it was just asked to start, and its lookup comes back as
+   * `fetch_session_with_participants failed: not found: session not found` —
+   * a message that points at the wrong thing entirely. This code exists so the
+   * real cause is reported instead of that downstream symptom.
+   */
+  | 'session_participant_failed'
   | 'runtime_rejected'
   | 'runtime_rpc_failed'
   | 'unknown'

--- a/packages/app/src/lib/teamclaw/__tests__/ensure-agent-runtime-participant.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/ensure-agent-runtime-participant.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  startAgentRuntimesAsync: vi.fn(),
+  resolveAgentDevicePresence: vi.fn(),
+  listParticipants: vi.fn(),
+  addParticipant: vi.fn(),
+  resolveSessionWorkspaceHintForRuntimeStart: vi.fn(),
+  waitForTeamclawRpcReady: vi.fn(),
+  toastError: vi.fn(),
+  reportRuntimeStartFailure: vi.fn(),
+  recordRuntimeEnsureAttempt: vi.fn(),
+}))
+
+vi.mock('@/lib/session-create', () => ({
+  startAgentRuntimesAsync: (...a: unknown[]) => mocks.startAgentRuntimesAsync(...a),
+}))
+vi.mock('@/lib/teamclaw-rpc', () => ({
+  setModel: vi.fn(),
+  waitForTeamclawRpcReady: (...a: unknown[]) => mocks.waitForTeamclawRpcReady(...a),
+}))
+vi.mock('@/lib/agent-device-reachability', () => ({
+  resolveAgentDevicePresence: (...a: unknown[]) => mocks.resolveAgentDevicePresence(...a),
+}))
+vi.mock('@/lib/backend', () => ({
+  getBackend: () => ({
+    sessionMembers: {
+      listParticipants: (...a: unknown[]) => mocks.listParticipants(...a),
+      addParticipant: (...a: unknown[]) => mocks.addParticipant(...a),
+    },
+  }),
+}))
+vi.mock('@/lib/session-live-subscriptions', () => ({
+  ensureSessionLiveSubscribed: vi.fn(async () => {}),
+  ensureTeamSessionLiveSubscribed: vi.fn(async () => {}),
+}))
+vi.mock('@/lib/teamclaw/resolve-runtime-start-workspace', () => ({
+  resolveSessionWorkspaceHintForRuntimeStart: (...a: unknown[]) =>
+    mocks.resolveSessionWorkspaceHintForRuntimeStart(...a),
+}))
+vi.mock('@/lib/teamclaw/runtime-ensure-scheduler', () => ({
+  recordRuntimeEnsureAttempt: (...a: unknown[]) => mocks.recordRuntimeEnsureAttempt(...a),
+  isRuntimeEnsureWakeReason: () => false,
+  shouldSkipAlreadyReadyRuntimeEnsure: () => false,
+}))
+vi.mock('@/lib/telemetry/runtime-error-report', () => ({
+  reportRuntimeEnsureCrash: vi.fn(),
+  reportRuntimeRpcNotReady: vi.fn(),
+  reportRuntimeStartFailure: (...a: unknown[]) => mocks.reportRuntimeStartFailure(...a),
+}))
+vi.mock('@/stores/mqtt-reconnect', () => ({
+  useMqttReconnectStore: { getState: () => ({ connected: true }) },
+}))
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: { getState: () => ({ workspacePath: '/tmp/ws' }) },
+}))
+vi.mock('@/stores/runtime-state-store', () => ({
+  useRuntimeStateStore: { getState: () => ({ byRuntimeId: {} }) },
+}))
+vi.mock('@/lib/runtime-state-resolve', () => ({
+  // Non-empty so the post-start "wait for the retain" loop exits immediately;
+  // otherwise every test that reaches runtimeStart burns its full 12s budget.
+  resolveRuntimeStateEntryForAgent: () => ({
+    info: { availableModels: [{ id: 'prov/model' }] },
+  }),
+}))
+vi.mock('@/lib/utils', () => ({ isTauri: () => false }))
+vi.mock('@/lib/i18n', () => ({
+  default: { t: (key: string, second?: unknown) => (typeof second === 'string' ? second : key) },
+}))
+vi.mock('sonner', () => ({ toast: { error: (...a: unknown[]) => mocks.toastError(...a) } }))
+vi.mock('@/stores/acp-debug-store', () => ({
+  useAcpDebugStore: { getState: () => ({ append: vi.fn() }) },
+}))
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+describe('ensureAgentRuntimesForSession — participant failures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.waitForTeamclawRpcReady.mockResolvedValue(true)
+    mocks.resolveAgentDevicePresence.mockResolvedValue('online')
+    mocks.listParticipants.mockResolvedValue([])
+    mocks.addParticipant.mockResolvedValue(undefined)
+    mocks.resolveSessionWorkspaceHintForRuntimeStart.mockResolvedValue('ws-1')
+    mocks.startAgentRuntimesAsync.mockResolvedValue({
+      failures: [],
+      runtimeIdsByAgent: {},
+    })
+  })
+
+  it('drops an agent whose participant row could not be created', async () => {
+    mocks.addParticipant.mockRejectedValue(new Error('rls denied'))
+
+    const { ensureAgentRuntimesForSession } = await import('../ensure-agent-runtime')
+    await ensureAgentRuntimesForSession({
+      sessionId: 'sess-1',
+      teamId: 'team-1',
+      agentActorIds: ['agent-1'],
+    })
+    await flush()
+
+    // Nothing may be started: the daemon could not read the session anyway, and
+    // its "session not found" would blame the wrong thing.
+    expect(mocks.startAgentRuntimesAsync).not.toHaveBeenCalled()
+    expect(mocks.reportRuntimeStartFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentActorId: 'agent-1',
+        code: 'session_participant_failed',
+        reason: 'rls denied',
+      }),
+      expect.anything(),
+    )
+    expect(mocks.toastError).toHaveBeenCalled()
+  })
+
+  it('starts the agents that did join and drops only the one that failed', async () => {
+    mocks.addParticipant.mockImplementation(async (_sessionId: string, actorId: string) => {
+      if (actorId === 'agent-bad') throw new Error('rls denied')
+    })
+
+    const { ensureAgentRuntimesForSession } = await import('../ensure-agent-runtime')
+    await ensureAgentRuntimesForSession({
+      sessionId: 'sess-1',
+      teamId: 'team-1',
+      agentActorIds: ['agent-ok', 'agent-bad'],
+    })
+    await flush()
+
+    expect(mocks.startAgentRuntimesAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ agentActorIds: ['agent-ok'] }),
+    )
+    // The batch bookkeeping must not claim an attempt for the dropped agent.
+    expect(mocks.recordRuntimeEnsureAttempt).toHaveBeenCalledWith('sess-1', ['agent-ok'])
+  })
+
+  it('starts every agent when all participant rows are in place', async () => {
+    const { ensureAgentRuntimesForSession } = await import('../ensure-agent-runtime')
+    await ensureAgentRuntimesForSession({
+      sessionId: 'sess-1',
+      teamId: 'team-1',
+      agentActorIds: ['agent-1', 'agent-2'],
+    })
+    await flush()
+
+    expect(mocks.startAgentRuntimesAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ agentActorIds: ['agent-1', 'agent-2'] }),
+    )
+    expect(mocks.reportRuntimeStartFailure).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/lib/teamclaw/__tests__/ensure-runtime-then-set-model.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/ensure-runtime-then-set-model.test.ts
@@ -55,7 +55,21 @@ vi.mock('@/lib/utils', () => ({
 }))
 
 vi.mock('@/lib/i18n', () => ({
-  default: { t: (_k: string, fallback?: string) => fallback ?? _k },
+  default: {
+    // Mirror i18next's two shapes: `t(key, fallback)` and `t(key, vars)`. The
+    // naive fallback-only stub returned the options object itself, so any
+    // message built from interpolated vars stringified to "[object Object]".
+    t: (key: string, second?: string | Record<string, unknown>) => {
+      if (typeof second === 'string' || second === undefined) return second ?? key
+      const vars = second
+      return Object.entries(vars).reduce<string>(
+        (acc, [name, value]) => acc.replaceAll(`{{${name}}}`, String(value)),
+        `${key} ${Object.keys(vars)
+          .map((n) => `{{${n}}}`)
+          .join(' ')}`,
+      )
+    },
+  },
 }))
 
 describe('ensureRuntimeThenSetModel', () => {
@@ -116,6 +130,44 @@ describe('ensureRuntimeThenSetModel', () => {
       }),
     ).rejects.toThrow('daemon busy')
     expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('aborts instead of starting a runtime the daemon could not read', async () => {
+    // `sessions` is participant-only RLS. Starting anyway made the daemon report
+    // "fetch_session_with_participants failed: not found: session not found",
+    // which blames the session rather than this failed permission step.
+    mocks.listParticipants.mockResolvedValue([])
+    mocks.addParticipant.mockRejectedValue(new Error('row-level security violation'))
+
+    const { ensureRuntimeThenSetModel } = await import('../ensure-agent-runtime')
+    await expect(
+      ensureRuntimeThenSetModel({
+        sessionId: 'sess-1',
+        teamId: 'team-1',
+        agentActorId: 'agent-1',
+        modelId: 'opencode/big-pickle',
+      }),
+    ).rejects.toThrow(/row-level security violation/)
+
+    expect(mocks.startAgentRuntimesAsync).not.toHaveBeenCalled()
+    expect(mocks.setModel).not.toHaveBeenCalled()
+  })
+
+  it('still starts the runtime when the agent is already a participant', async () => {
+    // addParticipant is skipped entirely in this case, so a previously-joined
+    // agent must not be affected by the abort above.
+    mocks.listParticipants.mockResolvedValue([{ id: 'agent-1' }])
+
+    const { ensureRuntimeThenSetModel } = await import('../ensure-agent-runtime')
+    await expect(
+      ensureRuntimeThenSetModel({
+        sessionId: 'sess-1',
+        teamId: 'team-1',
+        agentActorId: 'agent-1',
+        modelId: 'opencode/big-pickle',
+      }),
+    ).resolves.toEqual({ runtimeId: 'spawn-live' })
+    expect(mocks.addParticipant).not.toHaveBeenCalled()
   })
 
   it('throws when mqtt is disconnected', async () => {

--- a/packages/app/src/lib/teamclaw/ensure-agent-runtime.ts
+++ b/packages/app/src/lib/teamclaw/ensure-agent-runtime.ts
@@ -75,6 +75,11 @@ function failureDescription(failure: RuntimeStartFailure): string {
       return trimmed || i18n.t("daemon.agentRuntime.workspaceRpcTimeoutDesc", { shortId });
     case "workspace_ensure_failed":
       return trimmed || i18n.t("daemon.agentRuntime.workspaceEnsureFailedDesc", { shortId });
+    case "session_participant_failed":
+      return i18n.t("daemon.agentRuntime.sessionParticipantFailedDesc", {
+        shortId,
+        reason: trimmed || i18n.t("errors.unknownError", "Unknown error"),
+      });
     case "runtime_rejected":
       return trimmed || i18n.t("daemon.agentRuntime.notStartedDesc", { shortId });
     case "runtime_rpc_failed":
@@ -207,10 +212,21 @@ async function runEnsureRuntimeThenSetModel(
   try {
     await ensureAgentIsSessionParticipant(args.sessionId, agentActorId);
   } catch (error) {
+    // Do NOT continue to runtimeStart. `sessions` is participant-only RLS, so a
+    // daemon that is not a participant cannot read the session and the start
+    // fails with "session not found" — which reads as data loss rather than a
+    // permission step that did not happen.
     sessionFlowError("ensure_runtime_then_set_model.add_participant_failed", error, {
       sessionId: args.sessionId,
       agentActorId,
     });
+    const failure: RuntimeStartFailure = {
+      agentActorId,
+      code: "session_participant_failed",
+      reason: error instanceof Error ? error.message : String(error),
+    };
+    reportRuntimeStartFailure(failure, { sessionId: args.sessionId, teamId: args.teamId });
+    throw new Error(failureDescription(failure), { cause: error });
   }
 
   const localWorkspacePath = useWorkspaceStore.getState().workspacePath?.trim() || null;
@@ -378,31 +394,58 @@ export async function ensureAgentRuntimesForSession(args: EnsureAgentRuntimeArgs
       return;
     }
 
-    const { eligible, failures: gateFailures } = await gateAgentsForRuntimeStart(agentActorIds);
+    const { eligible: gatedAgents, failures: gateFailures } =
+      await gateAgentsForRuntimeStart(agentActorIds);
     if (gateFailures.length > 0) {
       notifyRuntimeStartFailures(gateFailures, errorContext);
     }
-    if (eligible.length === 0) {
+    if (gatedAgents.length === 0) {
       logDebug("client:ensure_runtime_all_gated", { gateFailures }, { sessionId: args.sessionId });
       return;
     }
 
-    await Promise.all(
-      eligible.map(async (agentActorId) => {
-        try {
-          await ensureAgentIsSessionParticipant(args.sessionId, agentActorId);
-        } catch (error) {
-          sessionFlowError("ensure_agent_runtime.add_participant_failed", error, {
-            sessionId: args.sessionId,
-            agentActorId,
-          });
-          logDebug("client:add_participant_failed", { agentActorId, error: String(error) }, {
-            sessionId: args.sessionId,
-            actorId: agentActorId,
-          });
-        }
-      }),
-    );
+    // Agents whose participant row could not be created are dropped from the
+    // batch rather than started anyway. `sessions` is participant-only RLS, so
+    // starting them would fail in the daemon as "session not found", blaming the
+    // session instead of the permission step that actually failed.
+    const participantFailures: RuntimeStartFailure[] = [];
+    const eligible = (
+      await Promise.all(
+        gatedAgents.map(async (agentActorId) => {
+          try {
+            await ensureAgentIsSessionParticipant(args.sessionId, agentActorId);
+            return agentActorId;
+          } catch (error) {
+            sessionFlowError("ensure_agent_runtime.add_participant_failed", error, {
+              sessionId: args.sessionId,
+              agentActorId,
+            });
+            logDebug("client:add_participant_failed", { agentActorId, error: String(error) }, {
+              sessionId: args.sessionId,
+              actorId: agentActorId,
+            });
+            participantFailures.push({
+              agentActorId,
+              code: "session_participant_failed",
+              reason: error instanceof Error ? error.message : String(error),
+            });
+            return null;
+          }
+        }),
+      )
+    ).filter((agentActorId): agentActorId is string => agentActorId !== null);
+
+    if (participantFailures.length > 0) {
+      notifyRuntimeStartFailures(participantFailures, errorContext);
+    }
+    if (eligible.length === 0) {
+      logDebug(
+        "client:ensure_runtime_all_participant_failed",
+        { participantFailures },
+        { sessionId: args.sessionId },
+      );
+      return;
+    }
 
     const localWorkspacePath = useWorkspaceStore.getState().workspacePath?.trim() || null
     let localDaemonActorId: string | null = null

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -3233,6 +3233,7 @@
       "transportOfflineDesc": "Desktop MQTT is disconnected. Runtime start will retry when the broker connection is restored.",
       "workspaceRpcTimeoutDesc": "Agent {{shortId}} did not respond to workspace sync over MQTT within the timeout window.",
       "workspaceEnsureFailedDesc": "Agent {{shortId}}: failed to sync the workspace with the daemon before starting.",
+      "sessionParticipantFailedDesc": "Could not add agent {{shortId}} to this session, so its runtime was not started. The agent must be a session participant before it can read the session. ({{reason}})",
       "startFailedTitle": "Failed to start Agent runtime",
       "emptyReply": "Agent returned no output. The selected model may be unavailable or misconfigured.",
       "providerStalled": "The model provider stopped responding. It may be unavailable or rate-limited — please retry or switch models.",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1311,6 +1311,14 @@
       "showLess": "Show Less",
       "showMore": "Show More"
     },
+    "claudeLlm": {
+      "title": "Claude Code Models",
+      "description": "Models bundled with the claude runtime, managed by the claude credentials on this machine.",
+      "loginHint": "Claude Code manages its own credentials through the claude CLI, not through opencode.json. To sign in, run this on the host terminal:",
+      "loginHintAfter": "After signing in, come back and refresh. If the claude command is not installed on this machine, the runtime cannot start.",
+      "empty": "No models available yet. Make sure the claude command is installed and signed in, and the claude runtime is online.",
+      "modelCount": "{{count}} models"
+    },
     "piLlm": {
       "title": "Pi Models",
       "description": "Models and providers bundled with the pi runtime, managed by pi's own credentials on this machine.",
@@ -1329,6 +1337,7 @@
     },
     "mcp": {
       "cursorBridgeNote": "The first Cursor SDK release does not bridge workspace MCP yet",
+      "claudeBridgeNote": "Claude Code loads MCP from its own config, not opencode.json",
       "restart": "Restart",
       "restarting": "Restarting...",
       "title": "MCP Servers",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1311,6 +1311,14 @@
       "showLess": "收起",
       "showMore": "显示更多"
     },
+    "claudeLlm": {
+      "title": "Claude Code 模型",
+      "description": "claude 运行时自带的模型，由主机上的 claude 凭证管理。",
+      "loginHint": "Claude Code 的凭证由 claude CLI 自己管理，不通过 opencode.json。要登录，请在主机终端运行：",
+      "loginHintAfter": "登录后回到这里刷新。若本机未安装 claude 命令，运行时无法启动。",
+      "empty": "暂无可用模型。请确认本机已安装 claude 命令并完成登录，且 claude 运行时在线。",
+      "modelCount": "{{count}} 个模型"
+    },
     "piLlm": {
       "title": "Pi 模型",
       "description": "pi 运行时自带的模型与 provider，由主机上的 pi 凭证管理。",
@@ -1329,6 +1337,7 @@
     },
     "mcp": {
       "cursorBridgeNote": "Cursor SDK 第一版尚未桥接 workspace MCP",
+      "claudeBridgeNote": "Claude Code 从它自己的配置加载 MCP，不读 opencode.json",
       "restart": "重启",
       "restarting": "重启中...",
       "title": "MCP 服务器",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -3233,6 +3233,7 @@
       "transportOfflineDesc": "Desktop MQTT 已断开。Broker 重连后将自动重试启动 runtime。",
       "workspaceRpcTimeoutDesc": "Agent {{shortId}} 在超时时间内未通过 MQTT 响应 workspace 同步。",
       "workspaceEnsureFailedDesc": "Agent {{shortId}}：启动前未能将 workspace 同步到 daemon。",
+      "sessionParticipantFailedDesc": "无法把 Agent {{shortId}} 加入本会话，因此没有启动它的 runtime。Agent 必须先成为会话参与者才能读取该会话。({{reason}})",
       "startFailedTitle": "启动 Agent runtime 失败",
       "emptyReply": "Agent 没有返回任何内容，所选模型可能不可用或配置异常。",
       "providerStalled": "模型服务长时间无响应，可能不可用或被限流，请重试或切换模型。",


### PR DESCRIPTION
Two commits. The second was branched off the first before it had its own PR, so both land here.

---

## 1. `fix(runtime)`: stop swallowing addParticipant failures before runtimeStart

`ensureAgentIsSessionParticipant` sat in a try/catch that only logged, then execution continued straight into runtimeStart. `sessions` carries **participant-only RLS** — the Cloud API's `joinSession` needs a SECURITY DEFINER RPC precisely to get around it — so a daemon that is not a participant cannot read the session it was just asked to start. Its lookup surfaced as:

```
Agent runtime not started
fetch_session_with_participants failed: not found: session not found
```

which reads as a missing session rather than a permission step that never happened. The genuine cause was visible only in the ACP debug log as `add_participant_failed`.

Both call sites now stop:

- `ensureRuntimeThenSetModel` throws with the real reason (original error attached as `cause`); nothing starts.
- `ensureAgentRuntimesForSession` drops just that agent from the batch and reports it, leaving healthy agents to start. `recordRuntimeEnsureAttempt` no longer claims an attempt for the dropped agent.

Adds a dedicated `session_participant_failed` code so the toast names the actual problem instead of falling through to the generic "did not respond to runtimeStart" description.

Also fixes the test i18n stub, which implemented only `t(key, fallback)` and returned the options object for `t(key, vars)` — any message built from interpolated vars stringified to `[object Object]`, so a test asserting on such a message could not have caught a regression.

---

## 2. `feat(agent-type)`: claude-code selectable, real claude/cursor marks

**claude-code was unselectable.** The settings picker offered only opencode / pi / cursor, and `DaemonLocalAgent` had the same three members — despite `create_backend` having a claude arm and a `claude_agent/` module behind it.

**claude was reported as opencode.** `getDaemonLocalAgent` mapped anything not pi or cursor to `'opencode'`, so a daemon configured `local_agent = "claude"` displayed as opencode *and* got the OpenCode provider pane from `LLMSectionRouter`. A mislabel, not just a missing option. It now recognises all three spellings the daemon accepts and routes to a new read-only `ClaudeLLMSection`, modelled on `PiLLMSection` — the claude CLI owns its credentials on the host, so there is nothing for us to configure.

**claude-code needed a config section to be runnable.** `configured_local_agent` required `[agents.claude_code]`, but `agent_discover::discover_and_merge` only ever detects opencode, so that section is absent on a fresh install — selecting claude-code would have produced a daemon advertising no agent type at all. Requirement dropped, exactly as pi already does: `default_launch_configs()` always carries a ClaudeCode entry, so the backend runs once selected.

### Fixes a naming bug from #656

`configured_agent_types` holds *wire* names from `runtime_resolution::agent_type_name`, where claude is `"claude-code"`. But `SUPPORTED_CATALOG_BACKENDS` and the client's `catalogBackendId` were matching `"claude"` — the `AgentLaunchConfig.backend_type` spelling. **Two different vocabularies**, so claude-code would still have been served no catalog group. Both spellings are now accepted and `backend_label` handles either.

### Icons

`ClaudeMark` and `CursorMark` replace the generic lucide `Sparkles` / `MousePointer2` placeholders, using the upstream vectors (Anthropic's starburst on a 16×16 grid; Cursor's corner-on cube on 24×24, which needs `evenodd` or its cut-out fills solid). Each keeps its source viewBox rather than being re-plotted onto the 28×28 grid the hand-drawn opencode/pi marks use — re-scaling traced geometry by hand is how it drifts. All four were rasterised against the coral chip background and checked visually. Nominative use of third-party marks; the file notes they remain Anthropic's and Anysphere's trademarks.

---

## Testing

- Daemon: 952 + 665 + 666 + 665 + 668 green. New test: all three claude spellings resolve and advertise `claude-code` with **no** `[agents.claude_code]` section present.
- clippy clean; `rustfmt` applied per-file (a bare `cargo fmt` on this crate reformats ~51 unrelated files and CI does not fmt-check it).
- Frontend: typecheck clean, lint 0 errors, 2400 passed. New tests for the participant abort (single-agent and batch, including partial failure) and the catalog wire-name mapping.
- i18n parity guards pass (`settings.claudeLlm.*` and `settings.mcp.claudeBridgeNote` added in both locales).
- Full suite at exactly the 5 failures present on a clean tree before these branches (`useAppInit` ×4 expecting `~/TeamClaw` vs local `~/TeamClaw Dev`, plus a `build-config` webSSO default).
- **Not run against a live daemon** — verifying the new pane and icons in situ needs `local_agent` actually switched to claude-code with the `claude` CLI installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)