### PR TITLE
fix(app): WYSIWYG agent mentions and session list glass sync

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1452,7 +1452,6 @@ function AppContent() {
               .refreshSession(sid, teamId)
               .catch((e) => {
                 console.warn("[participants] refresh failed:", e);
-                useSessionParticipantStore.getState().invalidateSessions([sid]);
               });
             return;
           }

--- a/packages/app/src/components/chat/AgentSelectorDock.tsx
+++ b/packages/app/src/components/chat/AgentSelectorDock.tsx
@@ -49,6 +49,8 @@ interface AgentSelectorDockProps {
   agentToBackendType: Map<string, string>
   /** Remove a single agent (clicked the X on the chip / "Remove" in dropdown). */
   onRemoveAgent: (agentId: string) => void
+  /** Solo session: agent pill is mandatory and cannot be removed. */
+  agentMentionLocked?: boolean
 }
 
 export { resolveAgentAvailableModels } from '@/lib/agent-available-models'
@@ -84,6 +86,7 @@ export function AgentSelectorDock({
   agentToRuntimeId,
   agentToBackendType,
   onRemoveAgent,
+  agentMentionLocked = false,
 }: AgentSelectorDockProps) {
   const runtimeStates = useRuntimeStateStore((s) => s.byRuntimeId)
   const uiStateByAgentId = React.useMemo(
@@ -115,6 +118,7 @@ export function AgentSelectorDock({
             backendType={backendType}
             runtimeInfo={runtimeEntry?.info}
             uiState={uiStateByAgentId.get(agent.id) ?? 'connecting'}
+            mentionLocked={agentMentionLocked}
             onRemove={() => {
               if (activeSessionId) {
                 useAgentModelPickStore.getState().clearPick(activeSessionId, agent.id)
@@ -139,6 +143,7 @@ function AgentPill({
   backendType,
   runtimeInfo,
   uiState,
+  mentionLocked = false,
   onRemove,
 }: {
   sessionIdProp: string | null
@@ -147,6 +152,7 @@ function AgentPill({
   backendType: string | undefined
   runtimeInfo: RuntimeInfo | undefined
   uiState: SessionAgentUiState
+  mentionLocked?: boolean
   onRemove: () => void
 }) {
   const { t } = useTranslation()
@@ -443,6 +449,7 @@ function AgentPill({
             </div>
           }
           footer={
+            mentionLocked ? undefined : (
             <div className="p-1">
               <button
                 type="button"
@@ -456,6 +463,7 @@ function AgentPill({
                 {t('chat.agentSelector.removeMention', 'Remove mention')}
               </button>
             </div>
+            )
           }
         />
       </PopoverContent>

--- a/packages/app/src/components/chat/ChatInputArea.tsx
+++ b/packages/app/src/components/chat/ChatInputArea.tsx
@@ -185,6 +185,8 @@ interface ChatInputAreaProps {
   onRetryOfflineAgents?: () => void;
   onEngageAgent: (agent: AttachedAgent) => void;
   onRemoveAgent: (agentId: string) => void;
+  /** Solo (1 human + 1 agent): pill is always on and cannot be removed. */
+  agentMentionLocked?: boolean;
   activeStreamingAgents?: ReadonlyArray<ActiveStreamingAgent>;
   onInterruptAgent?: (agentId: string) => void;
 }
@@ -262,6 +264,7 @@ export function ChatInputArea({
   onRetryOfflineAgents,
   onEngageAgent = () => {},
   onRemoveAgent = () => {},
+  agentMentionLocked = false,
   activeStreamingAgents = [],
   onInterruptAgent,
 }: ChatInputAreaProps) {
@@ -573,6 +576,7 @@ export function ChatInputArea({
               onRemoveAgent={onRemoveAgent}
               onSwitchToLocalAgent={onSwitchToLocalAgent}
               onRetryOffline={onRetryOfflineAgents}
+              agentMentionLocked={agentMentionLocked}
             />
           ) : null}
 
@@ -629,6 +633,7 @@ export function ChatInputArea({
                 agentToRuntimeId={agentToRuntimeId}
                 agentToBackendType={agentToBackendType}
                 onRemoveAgent={onRemoveAgent}
+                agentMentionLocked={agentMentionLocked}
               />
             </PromptInputTools>
 

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -87,7 +87,7 @@ import { uploadAttachment } from "@/lib/attachment-upload";
 import { loadSessionActiveModel } from "@/lib/session-active-model";
 import { resolveSessionEstablishedModel } from "@/lib/session-established-model";
 import { ensureSessionLiveSubscribed } from "@/lib/session-live-subscriptions";
-import { resolveActorIdsFromAtText } from "@/lib/resolve-text-mentions";
+import { resolveSessionMentionActorIds } from "@/lib/resolve-session-mention-ids";
 import { stripPickerPersonMentionsFromText } from "@/lib/strip-person-mentions";
 import {
   expandMemberMentionTokensInText,
@@ -132,68 +132,6 @@ function buildEnhancedChip(
   return `[${label}: ${name}|instruction:You must call ${toolCall} before any other action.]`;
 }
 
-async function resolveMentionActorIdsForSession(
-  sessionId: string,
-  memberIds: string[],
-  agentIds: string[],
-  messageText = "",
-): Promise<string[]> {
-  const fromText = await resolveActorIdsFromAtText(sessionId, messageText);
-  if (fromText.agentIds.length > 0) {
-    const engaged = useEngagedAgentStore.getState();
-    let participants: Array<{ id: string; display_name?: string | null }>;
-    try {
-      participants = await getBackend().sessionMembers.listParticipants(sessionId);
-    } catch {
-      participants = [];
-    }
-    for (const agentId of fromText.agentIds) {
-      const row = participants.find((p) => p.id === agentId);
-      engaged.addAgent(sessionId, {
-        id: agentId,
-        displayName: row?.display_name || "AI",
-      });
-      break;
-    }
-  }
-
-  const explicit = Array.from(
-    new Set([
-      ...memberIds,
-      ...agentIds.slice(0, 1),
-      ...fromText.memberIds,
-      ...(fromText.agentIds[0] ? [fromText.agentIds[0]] : []),
-    ]),
-  );
-  if (explicit.length > 0) return explicit;
-
-  // No explicit mentions. If the user explicitly cleared the engaged agents
-  // ("Remove mention" → engagedAgents went from non-empty to empty), honor
-  // that intent — sending without @ should NOT silently re-engage anyone.
-  // Without this guard the fallback below would auto-mention the sole
-  // session agent and effectively undo the user's Remove Mention click.
-  if (useEngagedAgentStore.getState().wasExplicitlyCleared[sessionId]) {
-    return [];
-  }
-
-  let participants: Array<{ id: string; actor_type?: string | null; display_name?: string | null }>;
-  try {
-    participants = await getBackend().sessionMembers.listParticipants(sessionId);
-  } catch (participantError) {
-    console.warn("[ChatPanel] failed to load session participants:", participantError);
-    return [];
-  }
-
-  const agents = participants.filter((row) => isAgentActorType(row.actor_type));
-
-  // Sole-agent send fallback: any session with exactly one agent participant
-  // routes to that agent when the user sends without @. This is independent
-  // of isSoloAgentSession, which only gates open-time pill auto-engage.
-  return agents.length === 1
-    ? [agents[0].id]
-    : [];
-}
-
 // ─── Main component ────────────────────────────────────────────────────────
 
 interface ChatPanelProps {
@@ -216,6 +154,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     if (!activeSessionId) return;
     void ensureParticipants([activeSessionId]);
   }, [activeSessionId, ensureParticipants]);
+
   const error = useSessionStore(s => s.error);
   const errorSessionId = useSessionStore(s => s.errorSessionId);
   const isConnected = useSessionStore(s => s.isConnected);
@@ -505,6 +444,27 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     activeStreamingAgentIds,
   );
 
+  const sessionParticipants = useSessionParticipantStore((s) =>
+    activeSessionId ? s.participantsBySession[activeSessionId] : undefined,
+  );
+  const participantsLoading = useSessionParticipantStore((s) =>
+    activeSessionId ? s.loadingBySession[activeSessionId] ?? false : false,
+  );
+  const isSoloAgentSessionActive = React.useMemo(
+    () =>
+      sessionParticipants
+        ? isSoloAgentSession(sessionParticipants.map((p) => ({ isAgent: p.isAgent })))
+        : false,
+    [sessionParticipants],
+  );
+
+  // Re-fetch after roster invalidation (e.g. second agent invited → solo unlocks).
+  React.useEffect(() => {
+    if (!activeSessionId) return;
+    if (sessionParticipants !== undefined || participantsLoading) return;
+    void ensureParticipants([activeSessionId]);
+  }, [activeSessionId, sessionParticipants, participantsLoading, ensureParticipants]);
+
   const prevActiveSessionRef = React.useRef<string | null>(null);
   React.useEffect(() => {
     const prev = prevActiveSessionRef.current;
@@ -523,11 +483,12 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
   );
   const removeAgentForSession = React.useCallback(
     (agentId: string) => {
+      if (isSoloAgentSessionActive) return;
       const sid = useSessionSelectionStore.getState().activeSessionId;
       if (!sid) return;
       useEngagedAgentStore.getState().removeAgent(sid, agentId);
     },
-    [],
+    [isSoloAgentSessionActive],
   );
   const handleSwitchToLocalAgent = React.useCallback(
     (local: AttachedAgent) => {
@@ -567,24 +528,47 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     [activeSessionId, engagedUiEntries, removeAgentForSession, addAgentForSession],
   );
 
-  // Existing sessions can be reopened after a reload with no in-memory
-  // engaged agents selected. Solo sessions (2 participants: 1 human + 1 agent)
-  // auto-engage the agent pill so sends still trigger a reply.
-  // Note: send-time mention fallback (resolveMentionActorIdsForSession) still
-  // auto-mentions the sole session agent in multi-person sessions — only this
-  // open-time pill auto-engage is restricted to solo pairs.
-  // Runs at most once per sessionId per app lifetime so that explicitly
-  // removing a mention ("Remove mention" in the agent pill dropdown) isn't
-  // immediately undone by this effect re-firing on engagedAgents.length 1→0.
-  const autoEngagedSessionsRef = React.useRef<Set<string>>(new Set());
+  // Solo sessions (1 human + 1 agent): always show the agent pill so sends
+  // route WYSIWYG. Re-engage whenever the pill is missing. When a second
+  // agent (or member) joins, roster updates → no longer solo → pill unlocks.
   React.useEffect(() => {
     if (!activeSessionId) return;
-    if (autoEngagedSessionsRef.current.has(activeSessionId)) return;
-    if (engagedAgents.length > 0) {
-      autoEngagedSessionsRef.current.add(activeSessionId);
+    if (engagedAgents.length > 0) return;
+
+    const ensureRuntime = (agentActorId: string) => {
+      const teamId =
+        useSessionListStore.getState().rows.find((r) => r.id === activeSessionId)?.team_id ??
+        useCurrentTeamStore.getState().team?.id ??
+        null;
+      if (!teamId) return;
+      void import("@/lib/teamclaw/ensure-agent-runtime").then(({ ensureAgentRuntimesForSession }) => {
+        void ensureAgentRuntimesForSession({
+          sessionId: activeSessionId,
+          teamId,
+          agentActorIds: [agentActorId],
+          reason: "session_auto_engage",
+        });
+      });
+    };
+
+    const engageFromRoster = (
+      roster: Array<{ isAgent: boolean; actorId: string; displayName: string }>,
+    ) => {
+      if (!isSoloAgentSession(roster)) return false;
+      const sole = roster.find((p) => p.isAgent);
+      if (!sole) return false;
+      useEngagedAgentStore.getState().setAgents(activeSessionId, [{
+        id: sole.actorId,
+        displayName: sole.displayName || "AI",
+      }]);
+      ensureRuntime(sole.actorId);
+      return true;
+    };
+
+    if (sessionParticipants !== undefined) {
+      engageFromRoster(sessionParticipants);
       return;
     }
-    autoEngagedSessionsRef.current.add(activeSessionId);
 
     let cancelled = false;
     void (async () => {
@@ -595,34 +579,19 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
         return;
       }
       if (cancelled) return;
-
-      if (isSoloAgentSession(actors)) {
-        const soleAgent = actors.find((row) => isAgentActorType(row.actor_type))!;
-        useEngagedAgentStore.getState().setAgents(activeSessionId, [{
-          id: soleAgent.id,
-          displayName: soleAgent.display_name || "AI",
-        }]);
-        const teamId =
-          useSessionListStore.getState().rows.find((r) => r.id === activeSessionId)?.team_id ??
-          useCurrentTeamStore.getState().team?.id ??
-          null;
-        if (teamId) {
-          void import("@/lib/teamclaw/ensure-agent-runtime").then(({ ensureAgentRuntimesForSession }) => {
-            void ensureAgentRuntimesForSession({
-              sessionId: activeSessionId,
-              teamId,
-              agentActorIds: [soleAgent.id],
-              reason: "session_auto_engage",
-            });
-          });
-        }
-      }
+      engageFromRoster(
+        actors.map((row) => ({
+          isAgent: isAgentActorType(row.actor_type),
+          actorId: row.id,
+          displayName: row.display_name?.trim() || "AI",
+        })),
+      );
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [activeSessionId, engagedAgents.length]);
+  }, [activeSessionId, engagedAgents.length, sessionParticipants]);
 
   const sessionRow = useSessionListStore(s => s.rows.find(r => r.id === activeSessionId));
   // Team is workspace-scoped: every session in `rows` shares the same team_id.
@@ -1265,12 +1234,14 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     setAttachedFiles([]);
     setImageFiles([]);
 
-    // Single engaged agent: @ a new agent replaces the dock pill.
-    const agentForSend = extraMentionAgents[0] ?? engagedAgents[0] ?? null;
+    // WYSIWYG: pill in footer, typed @, or explicit extra on first send.
+    const engagedFromStore = useEngagedAgentStore.getState().get(sid);
+    const agentForSend =
+      extraMentionAgents[0] ?? engagedAgents[0] ?? engagedFromStore ?? null;
     const memberIds = mentions.map((m) => m.id);
     const agentIds = agentForSend ? [agentForSend.id] : [];
     const displayMentionActorIds = Array.from(new Set(agentIds.filter(Boolean)));
-    const mentionActorIds = await resolveMentionActorIdsForSession(
+    const mentionActorIds = await resolveSessionMentionActorIds(
       sid,
       memberIds,
       agentIds,
@@ -1832,9 +1803,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
         sessionId,
       });
 
-      // Auto-engage + auto-mention ONLY when there's exactly one agent
-      // (no members). Anything more ambiguous leaves the dock empty and
-      // routes to the user.
+      // Solo create: mount the pill before send so mention is WYSIWYG.
       const soleAgent =
         picks.members.length === 0 && picks.agents.length === 1
           ? picks.agents[0]
@@ -1842,13 +1811,9 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
       if (soleAgent) {
         useEngagedAgentStore.getState().setAgents(sessionId, [soleAgent]);
       }
-      const autoMentionAgents: AttachedAgent[] = soleAgent ? [soleAgent] : [];
-      await sendIntoSession(sessionId, firstMessage, autoMentionAgents);
+      await sendIntoSession(sessionId, firstMessage);
 
-      // Fire-and-forget runtime spawn for agents that outbox won't cover.
-      // Sole-agent create auto-mentions → outbox_send already ensures; skip
-      // duplicate session_create ensure for those ids.
-      const autoMentioned = new Set(autoMentionAgents.map((a) => a.id));
+      const autoMentioned = soleAgent ? new Set([soleAgent.id]) : new Set<string>();
       const agentsNeedingCreateEnsure = agentIds.filter((id) => !autoMentioned.has(id));
       if (agentsNeedingCreateEnsure.length > 0) {
         sessionFlowLog("session_create.runtime_start.begin", {
@@ -2397,6 +2362,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
               });
             }}
             onRemoveAgent={removeAgentForSession}
+            agentMentionLocked={isSoloAgentSessionActive}
             activeStreamingAgents={activeStreamingAgents}
             onInterruptAgent={handleInterruptAgent}
             imageFiles={imageFiles}

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -452,10 +452,10 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
   );
   const isSoloAgentSessionActive = React.useMemo(
     () =>
-      sessionParticipants
+      sessionParticipants && !participantsLoading
         ? isSoloAgentSession(sessionParticipants.map((p) => ({ isAgent: p.isAgent })))
         : false,
-    [sessionParticipants],
+    [sessionParticipants, participantsLoading],
   );
 
   // Re-fetch after roster invalidation (e.g. second agent invited → solo unlocks).

--- a/packages/app/src/components/chat/EngagedAgentOfflineBanner.tsx
+++ b/packages/app/src/components/chat/EngagedAgentOfflineBanner.tsx
@@ -11,6 +11,7 @@ type Props = {
   onRemoveAgent: (agentId: string) => void
   onSwitchToLocalAgent?: (agent: AttachedAgent) => void
   onRetryOffline?: () => void
+  agentMentionLocked?: boolean
 }
 
 function filterActionable(entries: EngagedAgentUiEntry[]): EngagedAgentUiEntry[] {
@@ -48,6 +49,7 @@ export function EngagedAgentOfflineBanner({
   onRemoveAgent,
   onSwitchToLocalAgent,
   onRetryOffline,
+  agentMentionLocked = false,
 }: Props) {
   const { t } = useTranslation()
   const actionable = filterActionable(entries)
@@ -88,7 +90,7 @@ export function EngagedAgentOfflineBanner({
             {t('chat.sessionAgent.switchToLocal')}
           </button>
         ) : null}
-        {actionable.length === 1 ? (
+        {agentMentionLocked ? null : actionable.length === 1 ? (
           <button
             type="button"
             className="text-ink-2 hover:text-foreground underline-offset-2 hover:underline"

--- a/packages/app/src/components/chat/MentionPopover.tsx
+++ b/packages/app/src/components/chat/MentionPopover.tsx
@@ -2,8 +2,12 @@ import * as React from 'react'
 import { User, Sparkles, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
-import { getBackend } from '@/lib/backend'
 import { useSessionSelectionStore } from '@/stores/session-selection-store'
+import { useCurrentTeamStore } from '@/stores/current-team'
+import {
+  useSessionParticipantStore,
+  type SessionParticipantInfo,
+} from '@/stores/session-participant-store'
 import {
   presenceOnlineFlag,
   resolveAgentDevicePresenceSync,
@@ -39,24 +43,22 @@ type MentionItem = ParticipantRow & { itemType: 'member' | 'agent' }
 
 type PopoverStep = 'browse' | 'confirm'
 
-const cache = new Map<string, { fetchedAt: number; rows: ParticipantRow[] }>()
-const CACHE_TTL_MS = 30_000
-
-/** @internal — test helper only */
-export function __clearCacheForTest() { cache.clear() }
-
-async function fetchParticipants(sessionId: string): Promise<ParticipantRow[]> {
-  const hit = cache.get(sessionId)
-  if (hit && Date.now() - hit.fetchedAt < CACHE_TTL_MS) return hit.rows
-  const rows: ParticipantRow[] = (await getBackend().sessionMembers.listParticipants(sessionId))
-    .filter((a) => a.actor_type === 'member' || a.actor_type === 'agent')
-    .map((a) => ({
-      id: a.id,
-      actor_type: a.actor_type as 'member' | 'agent',
-      display_name: a.display_name || '',
+export function participantsToMentionRows(
+  participants: SessionParticipantInfo[],
+  excludeMemberActorId?: string | null,
+): ParticipantRow[] {
+  return participants
+    .filter(
+      (p) =>
+        p.isAgent ||
+        !excludeMemberActorId ||
+        p.actorId !== excludeMemberActorId,
+    )
+    .map((p) => ({
+      id: p.actorId,
+      actor_type: p.isAgent ? 'agent' : 'member',
+      display_name: p.displayName,
     }))
-  cache.set(sessionId, { fetchedAt: Date.now(), rows })
-  return rows
 }
 
 function filter(rows: ParticipantRow[], query: string): ParticipantRow[] {
@@ -114,11 +116,19 @@ export function MentionPopover({
 }: MentionPopoverProps) {
   const { t } = useTranslation()
   const sessionId = useSessionSelectionStore(s => s.currentSessionId)
+  const currentMemberActorId = useCurrentTeamStore(s => s.currentMember?.id ?? null)
+  const ensureParticipants = useSessionParticipantStore(s => s.ensureParticipants)
+  const sessionParticipants = useSessionParticipantStore(s =>
+    sessionId ? s.participantsBySession[sessionId] : undefined,
+  )
+  const loading = useSessionParticipantStore(s =>
+    sessionId ? s.loadingBySession[sessionId] ?? false : false,
+  )
+  const loadError = useSessionParticipantStore(s =>
+    sessionId ? s.errorBySession[sessionId] ?? null : null,
+  )
   // Keep a subscription so agent status labels refresh with presence changes.
   useActorPresenceStore((s) => s.byActorId)
-  const [rows, setRows] = React.useState<ParticipantRow[]>([])
-  const [loading, setLoading] = React.useState(false)
-  const [error, setError] = React.useState(false)
   const [step, setStep] = React.useState<PopoverStep>('browse')
   const [pendingMember, setPendingMember] = React.useState<MentionedPerson | null>(null)
   const [highlightedIndex, setHighlightedIndex] = React.useState(0)
@@ -135,15 +145,13 @@ export function MentionPopover({
 
   React.useEffect(() => {
     if (!open || !sessionId) return
-    let cancelled = false
-    setLoading(true)
-    setError(false)
-    fetchParticipants(sessionId)
-      .then(r => { if (!cancelled) setRows(r) })
-      .catch(() => { if (!cancelled) setError(true) })
-      .finally(() => { if (!cancelled) setLoading(false) })
-    return () => { cancelled = true }
-  }, [open, sessionId])
+    void ensureParticipants([sessionId])
+  }, [open, sessionId, ensureParticipants])
+
+  const rows = React.useMemo(
+    () => participantsToMentionRows(sessionParticipants ?? [], currentMemberActorId),
+    [sessionParticipants, currentMemberActorId],
+  )
 
   const filtered = React.useMemo(() => filter(rows, searchQuery), [rows, searchQuery])
   const members = React.useMemo(
@@ -317,7 +325,9 @@ export function MentionPopover({
 
   if (!open) return null
 
-  const isEmpty = !loading && !error && filtered.length === 0
+  const showLoading = loading && sessionParticipants === undefined
+  const showError = Boolean(loadError)
+  const isEmpty = !showLoading && !showError && filtered.length === 0
   let currentIndex = 0
   const agentName = engagedAgent?.displayName ?? ''
   const memberName = pendingMember?.name ?? ''
@@ -379,13 +389,13 @@ export function MentionPopover({
         </div>
       ) : (
         <div ref={listRef} className="max-h-60 overflow-y-auto p-1">
-          {loading && (
+          {showLoading && (
             <div className="flex items-center justify-center gap-2 py-8 text-xs text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
               {t('common.loading')}
             </div>
           )}
-          {error && (
+          {showError && (
             <div className="py-6 text-center text-xs text-muted-foreground">
               {t('chat.mentionPopoverError')}
             </div>

--- a/packages/app/src/components/chat/SessionActorSheet.tsx
+++ b/packages/app/src/components/chat/SessionActorSheet.tsx
@@ -645,7 +645,7 @@ export function SessionActorPanel({ sessionId, teamId }: SessionActorPanelProps)
     setPendingRemove(null)
     try {
       await getBackend().sessionMembers.removeParticipant(sessionId, actor.id)
-      useSessionParticipantStore.getState().invalidateSessions([sessionId])
+      await useSessionParticipantStore.getState().refreshSession(sessionId, teamId)
     } catch (deleteErr) {
       console.error('[SessionActorSheet] remove failed:', deleteErr)
       // Rollback
@@ -684,7 +684,7 @@ export function SessionActorPanel({ sessionId, teamId }: SessionActorPanelProps)
       await getBackend().sessionMembers.addParticipant(sessionId, candidate.id)
 
       if (candidate.actor_type !== 'agent') {
-        useSessionParticipantStore.getState().invalidateSessions([sessionId])
+        await useSessionParticipantStore.getState().refreshSession(sessionId, teamId)
         return
       }
 
@@ -724,7 +724,7 @@ export function SessionActorPanel({ sessionId, teamId }: SessionActorPanelProps)
         console.warn('[SessionActorSheet] runtimeStart threw (non-fatal):', rpcErr)
       }
       // RuntimeInfo retain will arrive via store subscription and update the dot/model automatically
-      useSessionParticipantStore.getState().invalidateSessions([sessionId])
+      await useSessionParticipantStore.getState().refreshSession(sessionId, teamId)
     } catch (e) {
       console.error('[SessionActorSheet] add actor failed:', e)
       // Rollback

--- a/packages/app/src/components/chat/__tests__/AgentSelectorDock.test.tsx
+++ b/packages/app/src/components/chat/__tests__/AgentSelectorDock.test.tsx
@@ -294,6 +294,21 @@ describe('AgentSelectorDock', () => {
     expect(screen.queryByText('mimo-v2.5-free')).not.toBeInTheDocument()
   })
 
+  it('hides Remove mention when agentMentionLocked (solo session)', async () => {
+    render(
+      <AgentSelectorDock
+        {...dockProps({
+          activeSessionId: 'session-1',
+          engagedAgents: [{ id: 'a-1', displayName: 'Solo Bot' }],
+          agentMentionLocked: true,
+        })}
+      />,
+    )
+
+    await userEvent.click(await screen.findByRole('button', { name: /Solo Bot/i }))
+    expect(screen.queryByText(/Remove mention/i)).not.toBeInTheDocument()
+  })
+
   it('shows offline pill suffix from engagedUiEntries', async () => {
     render(
       <AgentSelectorDock

--- a/packages/app/src/components/chat/__tests__/MentionPopover.test.tsx
+++ b/packages/app/src/components/chat/__tests__/MentionPopover.test.tsx
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MentionPopover, __clearCacheForTest } from '../MentionPopover'
+import { MentionPopover } from '../MentionPopover'
 import type { AttachedAgent } from '@/packages/ai/prompt-input-insert-hooks'
+import {
+  useSessionParticipantStore,
+  type SessionParticipantInfo,
+} from '@/stores/session-participant-store'
 
 const mockSelect = vi.fn()
-const listParticipants = vi.fn()
+const mockEnsureParticipants = vi.fn(async () => {})
 
 const STRINGS: Record<string, string> = {
   'chat.mentionPopoverTitle': 'Mention people or agents',
@@ -23,15 +27,11 @@ const STRINGS: Record<string, string> = {
   'common.loading': 'Loading...',
 }
 
-vi.mock('@/lib/backend', () => ({
-  getBackend: () => ({
-    sessionMembers: {
-      listParticipants,
-    },
-  }),
-}))
 vi.mock('@/stores/session-selection-store', () => ({
   useSessionSelectionStore: (sel: any) => sel({ currentSessionId: 'sess-1' }),
+}))
+vi.mock('@/stores/current-team', () => ({
+  useCurrentTeamStore: (sel: any) => sel({ currentMember: { id: 'm-self' } }),
 }))
 vi.mock('@/stores/auth-store', () => ({
   useAuthStore: (sel: any) => sel({ session: { user: { id: 'user-1' } } }),
@@ -53,22 +53,47 @@ vi.mock('react-i18next', () => ({
 
 const engagedAgent: AttachedAgent = { id: 'a-mac', displayName: 'MACPRO' }
 
-beforeEach(() => {
-  mockSelect.mockReset()
-  listParticipants.mockReset()
-  __clearCacheForTest()
-})
-
-function mockParticipants(rows: Array<{ id: string; actor_type: 'member' | 'agent'; display_name: string }>) {
-  listParticipants.mockResolvedValue(rows)
+function toStoreRows(
+  rows: Array<{ id: string; actor_type: 'member' | 'agent'; display_name: string }>,
+): SessionParticipantInfo[] {
+  return rows.map((r) => ({
+    actorId: r.id,
+    displayName: r.display_name,
+    avatarUrl: null,
+    isAgent: r.actor_type === 'agent',
+  }))
 }
 
+function seedParticipants(
+  rows: SessionParticipantInfo[],
+  opts?: { loading?: boolean; error?: string | null },
+) {
+  useSessionParticipantStore.setState({
+    participantsBySession: { 'sess-1': rows },
+    loadingBySession: { 'sess-1': opts?.loading ?? false },
+    errorBySession: { 'sess-1': opts?.error ?? null },
+    ensureParticipants: mockEnsureParticipants,
+  })
+}
+
+beforeEach(() => {
+  mockSelect.mockReset()
+  mockEnsureParticipants.mockReset()
+  useSessionParticipantStore.setState({
+    participantsBySession: {},
+    loadingBySession: {},
+    errorBySession: {},
+    ensureParticipants: mockEnsureParticipants,
+  })
+})
+
 describe('MentionPopover', () => {
-  it('renders member and agent groups with icons after fetching session_participants', async () => {
-    mockParticipants([
+  it('renders member and agent groups with icons from session-participant-store', async () => {
+    seedParticipants(toStoreRows([
+      { id: 'm-self', actor_type: 'member', display_name: 'Haigang Ye' },
       { id: 'm-1', actor_type: 'member', display_name: 'Alice' },
       { id: 'a-1', actor_type: 'agent', display_name: 'Reviewer Bot' },
-    ])
+    ]))
     render(
       <MentionPopover
         open={true}
@@ -78,19 +103,53 @@ describe('MentionPopover', () => {
         onSelectAgent={vi.fn()}
       />,
     )
-    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument())
+    expect(screen.queryByText('Haigang Ye')).not.toBeInTheDocument()
+    expect(screen.getByText('Alice')).toBeInTheDocument()
     expect(screen.getByText('Reviewer Bot')).toBeInTheDocument()
     expect(screen.getByText('Members')).toBeInTheDocument()
     expect(screen.getByText('Agents')).toBeInTheDocument()
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    expect(mockEnsureParticipants).toHaveBeenCalledWith(['sess-1'])
+  })
+
+  it('reflects store updates without reopening the popover', async () => {
+    seedParticipants(toStoreRows([
+      { id: 'm-1', actor_type: 'member', display_name: 'Alice' },
+    ]))
+    const { rerender } = render(
+      <MentionPopover
+        open={true}
+        onOpenChange={() => {}}
+        searchQuery=""
+        onSelectMember={vi.fn()}
+        onSelectAgent={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.queryByText('My Agent')).not.toBeInTheDocument()
+
+    seedParticipants(toStoreRows([
+      { id: 'm-1', actor_type: 'member', display_name: 'Alice' },
+      { id: 'a-new', actor_type: 'agent', display_name: 'My Agent' },
+    ]))
+    rerender(
+      <MentionPopover
+        open={true}
+        onOpenChange={() => {}}
+        searchQuery=""
+        onSelectMember={vi.fn()}
+        onSelectAgent={vi.fn()}
+      />,
+    )
+    await waitFor(() => expect(screen.getByText('My Agent')).toBeInTheDocument())
   })
 
   it('filters participants using inline searchQuery from the composer', async () => {
-    mockParticipants([
+    seedParticipants(toStoreRows([
       { id: 'm-1', actor_type: 'member', display_name: 'Alice' },
       { id: 'm-2', actor_type: 'member', display_name: 'Bob' },
       { id: 'a-1', actor_type: 'agent', display_name: 'Reviewer Bot' },
-    ])
+    ]))
     render(
       <MentionPopover
         open={true}
@@ -100,7 +159,7 @@ describe('MentionPopover', () => {
         onSelectAgent={vi.fn()}
       />,
     )
-    await waitFor(() => expect(screen.getByText('Bob')).toBeInTheDocument())
+    expect(screen.getByText('Bob')).toBeInTheDocument()
     expect(screen.queryByText('Alice')).not.toBeInTheDocument()
     expect(screen.queryByText('Reviewer Bot')).not.toBeInTheDocument()
   })
@@ -108,10 +167,10 @@ describe('MentionPopover', () => {
   it('calls onSelectMember when a member is clicked without an engaged agent', async () => {
     const onSelectMember = vi.fn()
     const onSelectAgent = vi.fn()
-    mockParticipants([
+    seedParticipants(toStoreRows([
       { id: 'm-1', actor_type: 'member', display_name: 'Alice' },
       { id: 'a-1', actor_type: 'agent', display_name: 'Reviewer Bot' },
-    ])
+    ]))
     const user = userEvent.setup()
     render(
       <MentionPopover
@@ -122,7 +181,6 @@ describe('MentionPopover', () => {
         onSelectAgent={onSelectAgent}
       />,
     )
-    await waitFor(() => screen.getByText('Alice'))
     await user.click(screen.getByText('Alice'))
     expect(onSelectMember).toHaveBeenCalledWith({ id: 'm-1', name: 'Alice' })
     await user.click(screen.getByText('Reviewer Bot'))
@@ -131,9 +189,9 @@ describe('MentionPopover', () => {
 
   it('shows E2 confirm step when @-mentioning a human with an engaged agent', async () => {
     const onSelectMember = vi.fn()
-    mockParticipants([
+    seedParticipants(toStoreRows([
       { id: 'm-1', actor_type: 'member', display_name: 'Alice' },
-    ])
+    ]))
     const user = userEvent.setup()
     render(
       <MentionPopover
@@ -145,7 +203,6 @@ describe('MentionPopover', () => {
         onSelectAgent={vi.fn()}
       />,
     )
-    await waitFor(() => screen.getByText('Alice'))
     await user.click(screen.getByText('Alice'))
     expect(onSelectMember).not.toHaveBeenCalled()
     expect(screen.getByText('Keep the engaged agent?')).toBeInTheDocument()
@@ -156,9 +213,9 @@ describe('MentionPopover', () => {
   it('confirms keep-agent via keyboard in E2 step', async () => {
     const onSelectMember = vi.fn()
     const onOpenChange = vi.fn()
-    mockParticipants([
+    seedParticipants(toStoreRows([
       { id: 'm-1', actor_type: 'member', display_name: 'Alice' },
-    ])
+    ]))
     render(
       <MentionPopover
         open={true}
@@ -169,7 +226,6 @@ describe('MentionPopover', () => {
         onSelectAgent={vi.fn()}
       />,
     )
-    await waitFor(() => screen.getByText('Alice'))
     fireEvent.keyDown(document, { key: 'Enter', bubbles: true })
     await waitFor(() => screen.getByText('Keep MACPRO, @Alice'))
     fireEvent.keyDown(document, { key: 'Enter', bubbles: true })
@@ -182,9 +238,9 @@ describe('MentionPopover', () => {
 
   it('confirms clear-agent via keyboard in E2 step', async () => {
     const onSelectMember = vi.fn()
-    mockParticipants([
+    seedParticipants(toStoreRows([
       { id: 'm-1', actor_type: 'member', display_name: 'Alice' },
-    ])
+    ]))
     render(
       <MentionPopover
         open={true}
@@ -195,7 +251,6 @@ describe('MentionPopover', () => {
         onSelectAgent={vi.fn()}
       />,
     )
-    await waitFor(() => screen.getByText('Alice'))
     fireEvent.keyDown(document, { key: 'Enter', bubbles: true })
     await waitFor(() => screen.getByText('Clear MACPRO, @Alice'))
     fireEvent.keyDown(document, { key: 'ArrowDown', bubbles: true })
@@ -207,9 +262,9 @@ describe('MentionPopover', () => {
   })
 
   it('returns to browse list on Escape in E2 confirm step', async () => {
-    mockParticipants([
+    seedParticipants(toStoreRows([
       { id: 'm-1', actor_type: 'member', display_name: 'Alice' },
-    ])
+    ]))
     render(
       <MentionPopover
         open={true}
@@ -220,7 +275,6 @@ describe('MentionPopover', () => {
         onSelectAgent={vi.fn()}
       />,
     )
-    await waitFor(() => screen.getByText('Alice'))
     fireEvent.keyDown(document, { key: 'Enter', bubbles: true })
     await waitFor(() => screen.getByText('Keep the engaged agent?'))
     fireEvent.keyDown(document, { key: 'Escape', bubbles: true })
@@ -230,9 +284,9 @@ describe('MentionPopover', () => {
 
   it('confirms clear-agent via mouse in E2 step', async () => {
     const onSelectMember = vi.fn()
-    mockParticipants([
+    seedParticipants(toStoreRows([
       { id: 'm-1', actor_type: 'member', display_name: 'Alice' },
-    ])
+    ]))
     const user = userEvent.setup()
     render(
       <MentionPopover
@@ -244,7 +298,6 @@ describe('MentionPopover', () => {
         onSelectAgent={vi.fn()}
       />,
     )
-    await waitFor(() => screen.getByText('Alice'))
     await user.click(screen.getByText('Alice'))
     await user.click(screen.getByText('Clear MACPRO, @Alice'))
     expect(onSelectMember).toHaveBeenCalledWith(
@@ -256,10 +309,10 @@ describe('MentionPopover', () => {
   it('selects agent directly without E2 confirm when engaged agent exists', async () => {
     const onSelectAgent = vi.fn()
     const onSelectMember = vi.fn()
-    mockParticipants([
+    seedParticipants(toStoreRows([
       { id: 'm-1', actor_type: 'member', display_name: 'Alice' },
       { id: 'a-1', actor_type: 'agent', display_name: 'Reviewer Bot' },
-    ])
+    ]))
     const user = userEvent.setup()
     render(
       <MentionPopover
@@ -271,7 +324,6 @@ describe('MentionPopover', () => {
         onSelectAgent={onSelectAgent}
       />,
     )
-    await waitFor(() => screen.getByText('Reviewer Bot'))
     await user.click(screen.getByText('Reviewer Bot'))
     expect(onSelectAgent).toHaveBeenCalledWith({
       id: 'a-1',
@@ -282,7 +334,7 @@ describe('MentionPopover', () => {
   })
 
   it('shows empty state when participants list is empty', async () => {
-    mockParticipants([])
+    seedParticipants([])
     render(
       <MentionPopover
         open={true}
@@ -292,11 +344,11 @@ describe('MentionPopover', () => {
         onSelectAgent={vi.fn()}
       />,
     )
-    await waitFor(() => expect(screen.getByText(/no one to mention/i)).toBeInTheDocument())
+    expect(screen.getByText(/no one to mention/i)).toBeInTheDocument()
   })
 
-  it('shows error state when supabase returns an error', async () => {
-    listParticipants.mockRejectedValue(new Error('rls denied'))
+  it('shows error state when store reports a load error', async () => {
+    seedParticipants([], { error: 'rls denied' })
     render(
       <MentionPopover
         open={true}
@@ -306,6 +358,6 @@ describe('MentionPopover', () => {
         onSelectAgent={vi.fn()}
       />,
     )
-    await waitFor(() => expect(screen.getByText(/failed to load participants/i)).toBeInTheDocument())
+    expect(screen.getByText(/failed to load participants/i)).toBeInTheDocument()
   })
 })

--- a/packages/app/src/components/sidebar/SessionLiquidGlass.tsx
+++ b/packages/app/src/components/sidebar/SessionLiquidGlass.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
+/** Matches SessionListColumn C2 dock grid transition + virtualizer remeasure delay. */
+const ROW_LAYOUT_SETTLE_MS = 280
+
 type SessionLiquidGlassProps = {
   /** Positioning root that wraps the session rows (must be `position: relative`). */
   rootRef: React.RefObject<HTMLElement | null>
@@ -29,6 +32,7 @@ export function SessionLiquidGlass({
   const [moving, setMoving] = React.useState(false)
   const prevIdRef = React.useRef<string | null | undefined>(null)
   const moveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const layoutSettleTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const syncFrameRef = React.useRef<number | null>(null)
 
@@ -94,19 +98,37 @@ export function SessionLiquidGlass({
   }, [scrollRef, sync])
 
   React.useEffect(() => {
+    if (disabled || !activeSessionId) return
+    sync()
+    if (layoutSettleTimerRef.current) clearTimeout(layoutSettleTimerRef.current)
+    layoutSettleTimerRef.current = setTimeout(() => {
+      layoutSettleTimerRef.current = null
+      sync()
+    }, ROW_LAYOUT_SETTLE_MS)
+    return () => {
+      if (layoutSettleTimerRef.current) {
+        clearTimeout(layoutSettleTimerRef.current)
+        layoutSettleTimerRef.current = null
+      }
+    }
+  }, [activeSessionId, disabled, layoutKey, sync])
+
+  React.useEffect(() => {
     const root = rootRef.current
     if (!root || !activeSessionId || disabled) return
-    const row = Array.from(
-      root.querySelectorAll<HTMLElement>('[data-testid="v2-session-row"]'),
-    ).find((el) => el.getAttribute('data-session-id') === activeSessionId)
-    if (!row || typeof ResizeObserver === 'undefined') return
+    if (typeof ResizeObserver === 'undefined') return
+
+    const rows = root.querySelectorAll<HTMLElement>('[data-testid="v2-session-row"]')
+    if (rows.length === 0) return
+
     const ro = new ResizeObserver(() => sync())
-    ro.observe(row)
+    rows.forEach((row) => ro.observe(row))
     return () => ro.disconnect()
   }, [rootRef, activeSessionId, disabled, layoutKey, sync])
 
   React.useEffect(() => () => {
     if (moveTimerRef.current) clearTimeout(moveTimerRef.current)
+    if (layoutSettleTimerRef.current) clearTimeout(layoutSettleTimerRef.current)
     if (syncFrameRef.current != null) cancelAnimationFrame(syncFrameRef.current)
   }, [])
 

--- a/packages/app/src/components/sidebar/__tests__/SessionLiquidGlass.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SessionLiquidGlass.test.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { SessionLiquidGlass } from '../SessionLiquidGlass'
+
+function SessionListFixture({ activeSessionId }: { activeSessionId: string }) {
+  const rootRef = React.useRef<HTMLDivElement>(null)
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+
+  return (
+    <div ref={scrollRef} style={{ height: 400, overflow: 'auto' }}>
+      <div ref={rootRef} style={{ position: 'relative' }}>
+        <SessionLiquidGlass
+          rootRef={rootRef}
+          scrollRef={scrollRef}
+          activeSessionId={activeSessionId}
+          layoutKey="test"
+        />
+        <div data-testid="v2-session-row" data-session-id="pinned-1">
+          pinned
+        </div>
+        <div data-testid="v2-session-row" data-session-id="active-1">
+          active
+        </div>
+      </div>
+    </div>
+  )
+}
+
+describe('SessionLiquidGlass', () => {
+  const observe = vi.fn()
+  const disconnect = vi.fn()
+
+  beforeEach(() => {
+    observe.mockReset()
+    disconnect.mockReset()
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = observe
+        disconnect = disconnect
+        unobserve = vi.fn()
+        constructor(_callback: ResizeObserverCallback) {}
+      },
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('observes every session row, not only the active one', () => {
+    render(<SessionListFixture activeSessionId="active-1" />)
+    expect(observe).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/app/src/lib/__tests__/resolve-session-mention-ids.test.ts
+++ b/packages/app/src/lib/__tests__/resolve-session-mention-ids.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listParticipants: vi.fn(),
+}));
+
+vi.mock("@/lib/backend", () => ({
+  getBackend: () => ({
+    sessionMembers: { listParticipants: mocks.listParticipants },
+  }),
+}));
+
+vi.mock("@/lib/resolve-text-mentions", () => ({
+  resolveActorIdsFromAtText: vi.fn(async () => ({
+    agentIds: [] as string[],
+    memberIds: [] as string[],
+  })),
+}));
+
+import { resolveActorIdsFromAtText } from "@/lib/resolve-text-mentions";
+import { resolveSessionMentionActorIds } from "@/lib/resolve-session-mention-ids";
+import { useEngagedAgentStore } from "@/stores/engaged-agent-store";
+
+describe("resolveSessionMentionActorIds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useEngagedAgentStore.setState({ bySession: {} });
+    mocks.listParticipants.mockResolvedValue([]);
+  });
+
+  it("returns engaged pill agent id when provided", async () => {
+    const ids = await resolveSessionMentionActorIds(
+      "session-1",
+      [],
+      ["agent-1"],
+    );
+    expect(ids).toEqual(["agent-1"]);
+  });
+
+  it("returns member ids from explicit mentions", async () => {
+    const ids = await resolveSessionMentionActorIds(
+      "session-1",
+      ["member-1"],
+      [],
+    );
+    expect(ids).toEqual(["member-1"]);
+  });
+
+  it("does not fallback to sole session agent when nothing is explicit", async () => {
+    mocks.listParticipants.mockResolvedValue([
+      { id: "agent-1", actor_type: "agent", display_name: "Bot" },
+      { id: "member-1", actor_type: "member", display_name: "Alice" },
+      { id: "member-2", actor_type: "member", display_name: "Bob" },
+    ]);
+
+    const ids = await resolveSessionMentionActorIds("session-1", [], []);
+    expect(ids).toEqual([]);
+  });
+
+  it("merges typed @agent from message text", async () => {
+    vi.mocked(resolveActorIdsFromAtText).mockResolvedValueOnce({
+      agentIds: ["agent-2"],
+      memberIds: [],
+    });
+    mocks.listParticipants.mockResolvedValue([
+      { id: "agent-2", actor_type: "agent", display_name: "MAC" },
+    ]);
+
+    const ids = await resolveSessionMentionActorIds(
+      "session-1",
+      [],
+      [],
+      "@MAC hello",
+    );
+    expect(ids).toEqual(["agent-2"]);
+    expect(useEngagedAgentStore.getState().bySession["session-1"]).toEqual([
+      { id: "agent-2", displayName: "MAC" },
+    ]);
+  });
+});

--- a/packages/app/src/lib/__tests__/resolve-session-mention-ids.test.ts
+++ b/packages/app/src/lib/__tests__/resolve-session-mention-ids.test.ts
@@ -2,6 +2,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   listParticipants: vi.fn(),
+  participantStoreState: {
+    participantsBySession: {} as Record<
+      string,
+      Array<{ actorId: string; displayName: string; avatarUrl: null; isAgent: boolean }>
+    >,
+  },
+}));
+
+vi.mock("@/stores/session-participant-store", () => ({
+  useSessionParticipantStore: {
+    getState: () => mocks.participantStoreState,
+  },
 }));
 
 vi.mock("@/lib/backend", () => ({
@@ -25,6 +37,7 @@ describe("resolveSessionMentionActorIds", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useEngagedAgentStore.setState({ bySession: {} });
+    mocks.participantStoreState.participantsBySession = {};
     mocks.listParticipants.mockResolvedValue([]);
   });
 
@@ -55,6 +68,29 @@ describe("resolveSessionMentionActorIds", () => {
 
     const ids = await resolveSessionMentionActorIds("session-1", [], []);
     expect(ids).toEqual([]);
+  });
+
+  it("fallbacks to the sole agent in solo sessions when nothing is explicit", async () => {
+    mocks.participantStoreState.participantsBySession = {
+      "session-1": [
+        { actorId: "member-1", displayName: "Alice", avatarUrl: null, isAgent: false },
+        { actorId: "agent-1", displayName: "Bot", avatarUrl: null, isAgent: true },
+      ],
+    };
+
+    const ids = await resolveSessionMentionActorIds("session-1", [], []);
+    expect(ids).toEqual(["agent-1"]);
+    expect(mocks.listParticipants).not.toHaveBeenCalled();
+  });
+
+  it("fallbacks to the sole agent in solo sessions via backend when roster is uncached", async () => {
+    mocks.listParticipants.mockResolvedValue([
+      { id: "member-1", actor_type: "member", display_name: "Alice" },
+      { id: "agent-1", actor_type: "agent", display_name: "Bot" },
+    ]);
+
+    const ids = await resolveSessionMentionActorIds("session-1", [], []);
+    expect(ids).toEqual(["agent-1"]);
   });
 
   it("merges typed @agent from message text", async () => {

--- a/packages/app/src/lib/__tests__/resolve-session-mention-ids.test.ts
+++ b/packages/app/src/lib/__tests__/resolve-session-mention-ids.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
       string,
       Array<{ actorId: string; displayName: string; avatarUrl: null; isAgent: boolean }>
     >,
+    loadingBySession: {} as Record<string, boolean>,
   },
 }));
 
@@ -38,6 +39,7 @@ describe("resolveSessionMentionActorIds", () => {
     vi.clearAllMocks();
     useEngagedAgentStore.setState({ bySession: {} });
     mocks.participantStoreState.participantsBySession = {};
+    mocks.participantStoreState.loadingBySession = {};
     mocks.listParticipants.mockResolvedValue([]);
   });
 
@@ -91,6 +93,25 @@ describe("resolveSessionMentionActorIds", () => {
 
     const ids = await resolveSessionMentionActorIds("session-1", [], []);
     expect(ids).toEqual(["agent-1"]);
+  });
+
+  it("ignores stale solo cache while roster refresh is in flight", async () => {
+    mocks.participantStoreState.participantsBySession = {
+      "session-1": [
+        { actorId: "member-1", displayName: "Alice", avatarUrl: null, isAgent: false },
+        { actorId: "agent-1", displayName: "Bot", avatarUrl: null, isAgent: true },
+      ],
+    };
+    mocks.participantStoreState.loadingBySession = { "session-1": true };
+    mocks.listParticipants.mockResolvedValue([
+      { id: "member-1", actor_type: "member", display_name: "Alice" },
+      { id: "member-2", actor_type: "member", display_name: "Bob" },
+      { id: "agent-1", actor_type: "agent", display_name: "Bot" },
+    ]);
+
+    const ids = await resolveSessionMentionActorIds("session-1", [], []);
+    expect(ids).toEqual([]);
+    expect(mocks.listParticipants).toHaveBeenCalledWith("session-1");
   });
 
   it("merges typed @agent from message text", async () => {

--- a/packages/app/src/lib/__tests__/session-empty-thread-starters.test.ts
+++ b/packages/app/src/lib/__tests__/session-empty-thread-starters.test.ts
@@ -32,6 +32,12 @@ describe('session-empty-thread-starters', () => {
     expect(isSoloAgentSession([you(), agent('a1', 'MAC')])).toBe(true)
   })
 
+  it('isSoloAgentSession is false when a second agent joins', () => {
+    expect(
+      isSoloAgentSession([you(), agent('a1', 'MAC'), agent('a2', 'BOT')]),
+    ).toBe(false)
+  })
+
   it('isSoloAgentSession is false when a second human joins', () => {
     expect(isSoloAgentSession([you(), member('m1', 'Matt'), agent('a1', 'MAC')])).toBe(false)
   })

--- a/packages/app/src/lib/reset-client-chat-state.ts
+++ b/packages/app/src/lib/reset-client-chat-state.ts
@@ -54,7 +54,6 @@ export function resetClientChatState(): void {
   useStreamingStore.getState().clearAllChildStreaming();
   useEngagedAgentStore.setState({
     bySession: {},
-    wasExplicitlyCleared: {},
   });
   useSessionNoticeStore.setState({ bySession: {} });
   useAgentModelPickStore.setState({ bySessionAgent: {} });

--- a/packages/app/src/lib/resolve-session-mention-ids.ts
+++ b/packages/app/src/lib/resolve-session-mention-ids.ts
@@ -1,6 +1,38 @@
 import { getBackend } from "@/lib/backend";
+import { isAgentActorType } from "@/lib/actor-type";
 import { resolveActorIdsFromAtText } from "@/lib/resolve-text-mentions";
+import { isSoloAgentSession } from "@/lib/session-empty-thread-starters";
 import { useEngagedAgentStore } from "@/stores/engaged-agent-store";
+import {
+  useSessionParticipantStore,
+} from "@/stores/session-participant-store";
+
+function soleAgentIdFromRoster(
+  roster: Array<{ isAgent: boolean; actorId: string }>,
+): string | null {
+  if (!isSoloAgentSession(roster.map((p) => ({ isAgent: p.isAgent })))) return null;
+  return roster.find((p) => p.isAgent)?.actorId ?? null;
+}
+
+async function resolveSoleAgentIdIfSoloSession(sessionId: string): Promise<string | null> {
+  const cached = useSessionParticipantStore.getState().participantsBySession[sessionId];
+  if (cached !== undefined) {
+    return soleAgentIdFromRoster(cached);
+  }
+
+  try {
+    const rows = await getBackend().sessionMembers.listParticipants(sessionId);
+    const roster = rows
+      .filter((row) => row.actor_type === "member" || isAgentActorType(row.actor_type))
+      .map((row) => ({
+        actorId: row.id,
+        isAgent: isAgentActorType(row.actor_type),
+      }));
+    return soleAgentIdFromRoster(roster);
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Resolve `mention_actor_ids` for an outgoing message — WYSIWYG only.
@@ -10,7 +42,9 @@ import { useEngagedAgentStore } from "@/stores/engaged-agent-store";
  * - `@displayName` typed in the message body
  * - human member @ tokens / picker mentions (memberIds)
  *
- * There is no send-time fallback that silently @-mentions a session agent.
+ * There is no send-time fallback that silently @-mentions a session agent,
+ * except in solo sessions (exactly one human + one agent) where routing must
+ * stay reliable while the roster or pill is still loading.
  */
 export async function resolveSessionMentionActorIds(
   sessionId: string,
@@ -39,10 +73,16 @@ export async function resolveSessionMentionActorIds(
     }
   }
 
+  let effectiveAgentIds = agentIds.slice(0, 1);
+  if (effectiveAgentIds.length === 0 && fromText.agentIds.length === 0) {
+    const soleAgentId = await resolveSoleAgentIdIfSoloSession(sessionId);
+    if (soleAgentId) effectiveAgentIds = [soleAgentId];
+  }
+
   return Array.from(
     new Set([
       ...memberIds,
-      ...agentIds.slice(0, 1),
+      ...effectiveAgentIds,
       ...fromText.memberIds,
       ...(fromText.agentIds[0] ? [fromText.agentIds[0]] : []),
     ]),

--- a/packages/app/src/lib/resolve-session-mention-ids.ts
+++ b/packages/app/src/lib/resolve-session-mention-ids.ts
@@ -15,8 +15,10 @@ function soleAgentIdFromRoster(
 }
 
 async function resolveSoleAgentIdIfSoloSession(sessionId: string): Promise<string | null> {
-  const cached = useSessionParticipantStore.getState().participantsBySession[sessionId];
-  if (cached !== undefined) {
+  const store = useSessionParticipantStore.getState();
+  const cached = store.participantsBySession[sessionId];
+  const loading = store.loadingBySession[sessionId] ?? false;
+  if (cached !== undefined && !loading) {
     return soleAgentIdFromRoster(cached);
   }
 

--- a/packages/app/src/lib/resolve-session-mention-ids.ts
+++ b/packages/app/src/lib/resolve-session-mention-ids.ts
@@ -1,0 +1,50 @@
+import { getBackend } from "@/lib/backend";
+import { resolveActorIdsFromAtText } from "@/lib/resolve-text-mentions";
+import { useEngagedAgentStore } from "@/stores/engaged-agent-store";
+
+/**
+ * Resolve `mention_actor_ids` for an outgoing message — WYSIWYG only.
+ *
+ * Agent routing follows what the user explicitly chose:
+ * - engaged-agent pill in the composer footer
+ * - `@displayName` typed in the message body
+ * - human member @ tokens / picker mentions (memberIds)
+ *
+ * There is no send-time fallback that silently @-mentions a session agent.
+ */
+export async function resolveSessionMentionActorIds(
+  sessionId: string,
+  memberIds: string[],
+  agentIds: string[],
+  messageText = "",
+): Promise<string[]> {
+  const fromText = await resolveActorIdsFromAtText(sessionId, messageText);
+
+  // Keep the pill in sync when the user typed `@AgentName` inline.
+  if (fromText.agentIds.length > 0) {
+    const engaged = useEngagedAgentStore.getState();
+    let participants: Array<{ id: string; display_name?: string | null }>;
+    try {
+      participants = await getBackend().sessionMembers.listParticipants(sessionId);
+    } catch {
+      participants = [];
+    }
+    for (const agentId of fromText.agentIds) {
+      const row = participants.find((p) => p.id === agentId);
+      engaged.addAgent(sessionId, {
+        id: agentId,
+        displayName: row?.display_name || "AI",
+      });
+      break;
+    }
+  }
+
+  return Array.from(
+    new Set([
+      ...memberIds,
+      ...agentIds.slice(0, 1),
+      ...fromText.memberIds,
+      ...(fromText.agentIds[0] ? [fromText.agentIds[0]] : []),
+    ]),
+  );
+}

--- a/packages/app/src/lib/session-empty-thread-starters.ts
+++ b/packages/app/src/lib/session-empty-thread-starters.ts
@@ -19,7 +19,8 @@ function isAgentParticipant(p: SoloSessionParticipant): boolean {
   return false
 }
 
-/** Exactly one agent and one other participant (solo human + agent pair). */
+/** Exactly one agent and one other participant (solo human + agent pair).
+ *  Adding another agent or member makes this false → agent pill becomes removable. */
 export function isSoloAgentSession(participants: SoloSessionParticipant[]): boolean {
   const agents = participants.filter(isAgentParticipant)
   return agents.length === 1 && participants.length === 2

--- a/packages/app/src/stores/__tests__/session-daemon-send.test.ts
+++ b/packages/app/src/stores/__tests__/session-daemon-send.test.ts
@@ -182,13 +182,43 @@ describe('session store daemon send path', () => {
     expect(mocks.mqttPublish).toHaveBeenCalledTimes(1)
   })
 
-  it('auto-mentions the sole agent when no engaged agent is selected', async () => {
+  it('does not auto-mention the sole agent when no engaged agent is selected', async () => {
     const { useSessionStore } = await import('../session-store')
 
     mocks.listParticipants.mockResolvedValue([
       { id: 'agent-1', actor_type: 'agent' },
       { id: 'member-1', actor_type: 'member' },
     ])
+
+    useSessionStore.setState({
+      activeSessionId: 'a1ca8f06-94ee-4fb5-bdfb-194a5606062f',
+      currentSessionId: 'a1ca8f06-94ee-4fb5-bdfb-194a5606062f',
+      sessions: [{
+        id: 'a1ca8f06-94ee-4fb5-bdfb-194a5606062f',
+        title: 'Collab Session',
+        messages: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }],
+    })
+
+    await useSessionStore.getState().sendMessage('hello daemon')
+
+    expect(mocks.backendInsertOutgoingMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { mention_actor_ids: [] },
+      }),
+    )
+  })
+
+  it('mentions the engaged pill agent on send (WYSIWYG)', async () => {
+    const { useSessionStore } = await import('../session-store')
+    const { useEngagedAgentStore } = await import('../engaged-agent-store')
+
+    useEngagedAgentStore.getState().setAgents('a1ca8f06-94ee-4fb5-bdfb-194a5606062f', [{
+      id: 'agent-1',
+      displayName: 'Bot',
+    }])
 
     useSessionStore.setState({
       activeSessionId: 'a1ca8f06-94ee-4fb5-bdfb-194a5606062f',
@@ -245,7 +275,7 @@ describe('session store daemon send path', () => {
     expect(sessionMessage.message?.model).toBe('opencode/qwen3.6-plus-free')
   })
 
-  it('treats personal_agent participants as agent mentions for daemon sessions', async () => {
+  it('does not auto-mention personal_agent without an engaged pill', async () => {
     const { useSessionStore } = await import('../session-store')
 
     mocks.listParticipants.mockResolvedValue([
@@ -269,7 +299,7 @@ describe('session store daemon send path', () => {
 
     expect(mocks.backendInsertOutgoingMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: { mention_actor_ids: ['agent-1'] },
+        metadata: { mention_actor_ids: [] },
       }),
     )
   })

--- a/packages/app/src/stores/__tests__/session-daemon-send.test.ts
+++ b/packages/app/src/stores/__tests__/session-daemon-send.test.ts
@@ -182,12 +182,42 @@ describe('session store daemon send path', () => {
     expect(mocks.mqttPublish).toHaveBeenCalledTimes(1)
   })
 
-  it('does not auto-mention the sole agent when no engaged agent is selected', async () => {
+  it('auto-mentions the sole agent in solo sessions when no engaged pill is selected', async () => {
     const { useSessionStore } = await import('../session-store')
 
     mocks.listParticipants.mockResolvedValue([
       { id: 'agent-1', actor_type: 'agent' },
       { id: 'member-1', actor_type: 'member' },
+    ])
+
+    useSessionStore.setState({
+      activeSessionId: 'a1ca8f06-94ee-4fb5-bdfb-194a5606062f',
+      currentSessionId: 'a1ca8f06-94ee-4fb5-bdfb-194a5606062f',
+      sessions: [{
+        id: 'a1ca8f06-94ee-4fb5-bdfb-194a5606062f',
+        title: 'Collab Session',
+        messages: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }],
+    })
+
+    await useSessionStore.getState().sendMessage('hello daemon')
+
+    expect(mocks.backendInsertOutgoingMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { mention_actor_ids: ['agent-1'] },
+      }),
+    )
+  })
+
+  it('does not auto-mention an agent in multi-person sessions without an engaged pill', async () => {
+    const { useSessionStore } = await import('../session-store')
+
+    mocks.listParticipants.mockResolvedValue([
+      { id: 'agent-1', actor_type: 'agent' },
+      { id: 'member-1', actor_type: 'member' },
+      { id: 'member-2', actor_type: 'member' },
     ])
 
     useSessionStore.setState({
@@ -275,7 +305,7 @@ describe('session store daemon send path', () => {
     expect(sessionMessage.message?.model).toBe('opencode/qwen3.6-plus-free')
   })
 
-  it('does not auto-mention personal_agent without an engaged pill', async () => {
+  it('auto-mentions personal_agent in solo sessions without an engaged pill', async () => {
     const { useSessionStore } = await import('../session-store')
 
     mocks.listParticipants.mockResolvedValue([
@@ -299,7 +329,7 @@ describe('session store daemon send path', () => {
 
     expect(mocks.backendInsertOutgoingMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: { mention_actor_ids: [] },
+        metadata: { mention_actor_ids: ['agent-1'] },
       }),
     )
   })

--- a/packages/app/src/stores/engaged-agent-store.ts
+++ b/packages/app/src/stores/engaged-agent-store.ts
@@ -9,13 +9,6 @@ function normalizeEngagedAgents(agents: AttachedAgent[]): AttachedAgent[] {
  * renders a single agent pill; @-mentioning another agent replaces it. */
 interface State {
   bySession: Record<string, AttachedAgent[]>;
-  /** True when the user actively removed the last agent from a session
-   * ("Remove mention" in the pill dropdown). Send-time mention resolvers
-   * read this to suppress the "auto-mention the sole session agent"
-   * fallback — if the user explicitly cleared mentions, sending without
-   * @ should NOT re-engage the agent. Reset by `addAgent`/`setAgents`
-   * (non-empty) since re-engaging counts as new intent. */
-  wasExplicitlyCleared: Record<string, boolean>;
   /** Replace the engaged-agents list for a session. */
   setAgents: (sessionId: string, agents: AttachedAgent[]) => void;
   /** Replace the engaged agent for a session. Used by @-mention. */
@@ -35,28 +28,16 @@ interface State {
 
 export const useEngagedAgentStore = create<State>((set, getState) => ({
   bySession: {},
-  wasExplicitlyCleared: {},
   setAgents: (sessionId, agents) =>
-    set((s) => {
-      const normalized = normalizeEngagedAgents(agents);
-      return {
-      bySession: { ...s.bySession, [sessionId]: normalized },
-      wasExplicitlyCleared: {
-        ...s.wasExplicitlyCleared,
-        // Re-engaging (non-empty) clears the "explicitly empty" flag;
-        // setAgents([]) is a programmatic reset (not user intent), keep flag.
-        [sessionId]:
-          normalized.length > 0 ? false : s.wasExplicitlyCleared[sessionId] ?? false,
-      },
-    };
-    }),
+    set((s) => ({
+      bySession: { ...s.bySession, [sessionId]: normalizeEngagedAgents(agents) },
+    })),
   addAgent: (sessionId, agent) =>
     set((s) => {
       const prev = s.bySession[sessionId] ?? [];
       if (prev.length === 1 && prev[0]?.id === agent.id) return s;
       return {
         bySession: { ...s.bySession, [sessionId]: [agent] },
-        wasExplicitlyCleared: { ...s.wasExplicitlyCleared, [sessionId]: false },
       };
     }),
   removeAgent: (sessionId, agentId) =>
@@ -67,19 +48,13 @@ export const useEngagedAgentStore = create<State>((set, getState) => ({
       if (next.length === prev.length) return s;
       return {
         bySession: { ...s.bySession, [sessionId]: next },
-        wasExplicitlyCleared: {
-          ...s.wasExplicitlyCleared,
-          [sessionId]: next.length === 0,
-        },
       };
     }),
   clearSession: (sessionId) =>
     set((s) => {
       const nextBy = { ...s.bySession };
       delete nextBy[sessionId];
-      const nextFlag = { ...s.wasExplicitlyCleared };
-      delete nextFlag[sessionId];
-      return { bySession: nextBy, wasExplicitlyCleared: nextFlag };
+      return { bySession: nextBy };
     }),
   getAgents: (sessionId) =>
     sessionId
@@ -95,10 +70,6 @@ export const useEngagedAgentStore = create<State>((set, getState) => ({
       bySession: {
         ...s.bySession,
         [sessionId]: agent ? [agent] : [],
-      },
-      wasExplicitlyCleared: {
-        ...s.wasExplicitlyCleared,
-        [sessionId]: agent ? false : s.wasExplicitlyCleared[sessionId] ?? false,
       },
     })),
 }));

--- a/packages/app/src/stores/session-messages.ts
+++ b/packages/app/src/stores/session-messages.ts
@@ -27,45 +27,14 @@ import {
 } from "@/stores/streaming";
 import { trackEvent } from "@/lib/analytics";
 import { insertMessageSorted } from "@/lib/insert-message-sorted";
-import { isAgentActorType } from "@/lib/actor-type";
 import {
   resolvePendingPermissionActivityOwner,
   resolvePendingQuestionActivityOwner,
 } from "@/lib/session-list-activity";
+import { resolveSessionMentionActorIds } from "@/lib/resolve-session-mention-ids";
 
 type SessionSet = (fn: ((state: SessionState) => Partial<SessionState>) | Partial<SessionState>) => void;
 type SessionGet = () => SessionState;
-
-async function resolveMentionActorIdsForSession(
-  sessionId: string,
-  engagedAgentId: string | null,
-): Promise<string[]> {
-  if (engagedAgentId) return [engagedAgentId];
-
-  // Honor an explicit "Remove mention" — see matching guard in ChatPanel's
-  // copy of this resolver. Without it the sole-agent fallback below would
-  // silently re-engage the agent the user just unpinned.
-  if (useEngagedAgentStore.getState().wasExplicitlyCleared[sessionId]) {
-    return [];
-  }
-
-  let participants: Array<{ id: string; actor_type?: string | null }>;
-  try {
-    participants = await getBackend().sessionMembers.listParticipants(sessionId);
-  } catch (participantError) {
-    console.warn("[SendMessage] failed to load session participants:", participantError);
-    return [];
-  }
-
-  const agents = participants.filter((row) => isAgentActorType(row.actor_type));
-
-  // Sole-agent send fallback — see ChatPanel.resolveMentionActorIdsForSession.
-  // Multi-person sessions still route to the sole agent here; only open-time
-  // pill auto-engage is restricted to solo pairs (isSoloAgentSession).
-  return agents.length === 1
-    ? [agents[0].id]
-    : [];
-}
 
 export function createMessageActions(set: SessionSet, get: SessionGet) {
   async function ensureDaemonSessionForSend(content: string): Promise<string | null> {
@@ -153,9 +122,10 @@ export function createMessageActions(set: SessionSet, get: SessionGet) {
     }
 
     const engagedAgent = useEngagedAgentStore.getState().get(sessionId);
-    const mentionActorIds = await resolveMentionActorIdsForSession(
+    const mentionActorIds = await resolveSessionMentionActorIds(
       sessionId,
-      engagedAgent?.id ?? null,
+      [],
+      engagedAgent ? [engagedAgent.id] : [],
     );
     const messageId = crypto.randomUUID();
     const createdAt = BigInt(Math.floor(Date.now() / 1000));

--- a/packages/app/src/stores/session-participant-store.test.ts
+++ b/packages/app/src/stores/session-participant-store.test.ts
@@ -139,14 +139,30 @@ describe("session-participant-store", () => {
     ]);
   });
 
-  it("marks invalidated sessions loading while keeping cached roster", async () => {
+  it("clears loading on invalidate while keeping cached roster", async () => {
     await useSessionParticipantStore.getState().ensureParticipants(["s1"]);
+    useSessionParticipantStore.setState({
+      loadingBySession: { s1: true },
+    });
 
     useSessionParticipantStore.getState().invalidateSessions(["s1"]);
 
     const state = useSessionParticipantStore.getState();
     expect(state.participantsBySession.s1).toHaveLength(2);
-    expect(state.loadingBySession.s1).toBe(true);
+    expect(state.loadingBySession.s1).toBe(false);
+  });
+
+  it("clears loading when refreshSession fails", async () => {
+    await useSessionParticipantStore.getState().ensureParticipants(["s1"]);
+    const sync = await import("@/lib/sync/session-participant-sync");
+    vi.mocked(sync.syncParticipantsForSession).mockRejectedValueOnce(new Error("sync failed"));
+
+    await useSessionParticipantStore.getState().refreshSession("s1", "team-1");
+
+    const state = useSessionParticipantStore.getState();
+    expect(state.loadingBySession.s1).toBe(false);
+    expect(state.errorBySession.s1).toBe("sync failed");
+    expect(state.participantsBySession.s1).toHaveLength(2);
   });
 
   it("syncs before refreshing when team id is available", async () => {

--- a/packages/app/src/stores/session-participant-store.test.ts
+++ b/packages/app/src/stores/session-participant-store.test.ts
@@ -139,12 +139,14 @@ describe("session-participant-store", () => {
     ]);
   });
 
-  it("invalidates cached sessions", async () => {
+  it("marks invalidated sessions loading while keeping cached roster", async () => {
     await useSessionParticipantStore.getState().ensureParticipants(["s1"]);
 
     useSessionParticipantStore.getState().invalidateSessions(["s1"]);
 
-    expect(useSessionParticipantStore.getState().participantsBySession.s1).toBeUndefined();
+    const state = useSessionParticipantStore.getState();
+    expect(state.participantsBySession.s1).toHaveLength(2);
+    expect(state.loadingBySession.s1).toBe(true);
   });
 
   it("syncs before refreshing when team id is available", async () => {

--- a/packages/app/src/stores/session-participant-store.ts
+++ b/packages/app/src/stores/session-participant-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { getBackend } from "@/lib/backend";
+import { isAgentActorType } from "@/lib/actor-type";
 import {
   loadActorsByIds,
   loadSessionParticipants,
@@ -13,6 +14,10 @@ export type SessionParticipantInfo = {
   avatarUrl: string | null;
   isAgent: boolean;
 };
+
+function isMentionableParticipant(actorType: string | null | undefined): boolean {
+  return actorType === "member" || isAgentActorType(actorType);
+}
 
 type State = {
   participantsBySession: Record<string, SessionParticipantInfo[]>;
@@ -28,12 +33,12 @@ async function loadParticipantInfoFromCloud(
 ): Promise<SessionParticipantInfo[]> {
   const actors = await getBackend().sessionMembers.listParticipants(sessionId);
   return actors
-    .filter((a) => a.actor_type === "member" || a.actor_type === "agent")
+    .filter((a) => isMentionableParticipant(a.actor_type))
     .map((actor) => ({
       actorId: actor.id,
       displayName: actor.display_name?.trim() || actor.id,
       avatarUrl: actor.avatar_url ?? null,
-      isAgent: actor.actor_type === "agent",
+      isAgent: isAgentActorType(actor.actor_type),
     }));
 }
 
@@ -53,7 +58,7 @@ async function loadParticipantInfoFromLocalCache(
         actorId: actor.id,
         displayName: actor.displayName,
         avatarUrl: actor.avatarUrl ?? null,
-        isAgent: actor.actorType === "agent",
+        isAgent: isAgentActorType(actor.actorType),
       };
     })
     .filter((p): p is SessionParticipantInfo => p !== null);

--- a/packages/app/src/stores/session-participant-store.ts
+++ b/packages/app/src/stores/session-participant-store.ts
@@ -23,7 +23,10 @@ type State = {
   participantsBySession: Record<string, SessionParticipantInfo[]>;
   loadingBySession: Record<string, boolean>;
   errorBySession: Record<string, string | null>;
-  ensureParticipants: (sessionIds: string[]) => Promise<void>;
+  ensureParticipants: (
+    sessionIds: string[],
+    options?: { force?: boolean },
+  ) => Promise<void>;
   refreshSession: (sessionId: string, teamId?: string | null) => Promise<void>;
   invalidateSessions: (sessionIds: string[]) => void;
 };
@@ -75,11 +78,13 @@ export const useSessionParticipantStore = create<State>((set, get) => ({
   participantsBySession: {},
   loadingBySession: {},
   errorBySession: {},
-  ensureParticipants: async (sessionIds) => {
+  ensureParticipants: async (sessionIds, options) => {
+    const force = options?.force ?? false;
     const unique = Array.from(new Set(sessionIds)).filter(Boolean);
     const missing = unique.filter((sessionId) => {
-      if (get().loadingBySession[sessionId]) return false
+      if (!force && get().loadingBySession[sessionId]) return false
       const cached = get().participantsBySession[sessionId]
+      if (force) return true
       if (cached === undefined) return true
       // Extension/web: retry empty cache (legacy loadSessionParticipants stub).
       if (!isTauri() && cached.length === 0) return true
@@ -132,19 +137,20 @@ export const useSessionParticipantStore = create<State>((set, get) => ({
       await syncParticipantsForSession(sessionId, teamId, { full: true });
     }
     get().invalidateSessions([sessionId]);
-    await get().ensureParticipants([sessionId]);
+    await get().ensureParticipants([sessionId], { force: true });
   },
   invalidateSessions: (sessionIds) => {
-    const ids = new Set(sessionIds);
-    if (ids.size === 0) return;
-    set((state) => {
-      const participantsBySession = { ...state.participantsBySession };
-      const errorBySession = { ...state.errorBySession };
-      for (const sessionId of ids) {
-        delete participantsBySession[sessionId];
-        delete errorBySession[sessionId];
-      }
-      return { participantsBySession, errorBySession };
-    });
+    const ids = Array.from(new Set(sessionIds)).filter(Boolean);
+    if (ids.length === 0) return;
+    set((state) => ({
+      loadingBySession: {
+        ...state.loadingBySession,
+        ...Object.fromEntries(ids.map((sessionId) => [sessionId, true])),
+      },
+      errorBySession: {
+        ...state.errorBySession,
+        ...Object.fromEntries(ids.map((sessionId) => [sessionId, null])),
+      },
+    }));
   },
 }));

--- a/packages/app/src/stores/session-participant-store.ts
+++ b/packages/app/src/stores/session-participant-store.ts
@@ -133,11 +133,34 @@ export const useSessionParticipantStore = create<State>((set, get) => ({
     );
   },
   refreshSession: async (sessionId, teamId = null) => {
-    if (teamId) {
-      await syncParticipantsForSession(sessionId, teamId, { full: true });
+    set((state) => ({
+      loadingBySession: {
+        ...state.loadingBySession,
+        [sessionId]: true,
+      },
+      errorBySession: {
+        ...state.errorBySession,
+        [sessionId]: null,
+      },
+    }));
+
+    try {
+      if (teamId) {
+        await syncParticipantsForSession(sessionId, teamId, { full: true });
+      }
+      await get().ensureParticipants([sessionId], { force: true });
+    } catch (error) {
+      set((state) => ({
+        loadingBySession: {
+          ...state.loadingBySession,
+          [sessionId]: false,
+        },
+        errorBySession: {
+          ...state.errorBySession,
+          [sessionId]: error instanceof Error ? error.message : String(error),
+        },
+      }));
     }
-    get().invalidateSessions([sessionId]);
-    await get().ensureParticipants([sessionId], { force: true });
   },
   invalidateSessions: (sessionIds) => {
     const ids = Array.from(new Set(sessionIds)).filter(Boolean);
@@ -145,7 +168,7 @@ export const useSessionParticipantStore = create<State>((set, get) => ({
     set((state) => ({
       loadingBySession: {
         ...state.loadingBySession,
-        ...Object.fromEntries(ids.map((sessionId) => [sessionId, true])),
+        ...Object.fromEntries(ids.map((sessionId) => [sessionId, false])),
       },
       errorBySession: {
         ...state.errorBySession,


### PR DESCRIPTION
## Summary

- **WYSIWYG agent mentions**: remove send-time implicit `@` agent fallback; mentions come only from the engaged-agent pill, member `@`, or text `@Name` via shared `resolve-session-mention-ids.ts`.
- **Solo session pill**: auto-engage and lock Remove when exactly 1 human + 1 agent; unlock after a second agent/member joins (`SessionActorSheet` refresh + participant store).
- **MentionPopover (plan C)**: read `session-participant-store` instead of a private 30s cache; recognize `personal_agent` / `role_agent`; hide the current user from the picker.
- **Session list glass**: observe all row resizes and resync after dock animation so the selection overlay stays aligned when a pinned row expands its action dock.

## Test plan

- [x] `pnpm exec vitest run` — 75 related unit tests in `packages/app`
- [ ] Solo session: pill auto-attached, Remove hidden; send routes to agent
- [ ] Multi-person session without pill/`@`: agent does not reply
- [ ] Invite agent in multi-person session: `@` list updates immediately
- [ ] `@` picker does not list self
- [ ] Select non-pinned session, expand last pinned row more-actions: selection glass stays aligned


Made with [Cursor](https://cursor.com)