### PR TITLE
chore: block stray document/secret commits with a pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Blocks two classes of accidental commit:
+#
+#   1. Files that are never source — office documents, archives, key material.
+#   2. Secret-shaped strings in newly staged content.
+#
+# Why this exists: on 2026-07-30 an unscoped `git add -A` swept a private
+# individual's CV out of `.playwright-mcp/` (a Playwright MCP scratch directory)
+# into a commit on this *public* repository. Removing it needed a history
+# rewrite, a force-push, and a request to GitHub Support to purge the blobs from
+# their fork network — none of which fully closes the exposure, because merged
+# pull requests keep the objects reachable.
+#
+# `.gitignore` alone cannot prevent a repeat. It only covers directories someone
+# thought of in advance, and the whole problem was a directory nobody thought
+# about. This hook checks what is actually being committed instead.
+#
+# Escape hatch: `git commit --no-verify`. Deliberately not automatic — if you are
+# committing something that trips this, that should be a decision, not a default.
+
+set -uo pipefail
+
+RED=$'\033[0;31m'; YELLOW=$'\033[0;33m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+fail=0
+
+staged=$(git diff --cached --name-only --diff-filter=ACM)
+[ -z "$staged" ] && exit 0
+
+# ── 1. Extensions that are never source in this repo ─────────────────────────
+# Verified empty across all tracked files when this hook was added, so a hit is
+# always something new rather than an existing file being re-staged.
+never_source='\.(docx?|xlsx?|xls|pptx?|pages|numbers|zip|rar|7z|dmg|p12|pfx|jks|keystore)$'
+# PDFs are separate only so the message can name the likely cause.
+docs=$(echo "$staged" | grep -iE "$never_source|\.pdf$" || true)
+if [ -n "$docs" ]; then
+  echo "${RED}✗ Documents / archives / key stores are not source:${RESET}"
+  echo "$docs" | sed 's/^/    /'
+  echo "  ${DIM}These are the file types that leak personal data. If one is genuinely${RESET}"
+  echo "  ${DIM}part of the project, add an exception to .githooks/pre-commit.${RESET}"
+  fail=1
+fi
+
+# ── 2. Known scratch directories, even if force-added past .gitignore ────────
+scratch=$(echo "$staged" | grep -E '^(\.playwright-mcp|test-results|playwright-report|screenshots|tmp|\.claude)/' || true)
+if [ -n "$scratch" ]; then
+  echo "${RED}✗ Tool scratch output is not source:${RESET}"
+  echo "$scratch" | sed 's/^/    /'
+  fail=1
+fi
+
+# ── 3. Secret-shaped strings in newly staged content ────────────────────────
+# Only the staged diff is scanned, so pre-existing fixtures are not re-flagged
+# unless they change. Test and example paths are skipped: this repo legitimately
+# carries a throwaway APNs P8 in services/fc/test/apns-jwt.test.ts.
+secret_re='(-----BEGIN (RSA|DSA|EC|OPENSSH|PGP)? ?PRIVATE KEY-----|sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{30,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{30,}|crsr_[A-Za-z0-9]{20,})'
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  case "$file" in
+    *test*|*spec*|*fixture*|*mock*|*example*|*sample*|*template*|*.md) continue ;;
+  esac
+  # Added lines only (+ prefix), so deleting a secret does not block the commit
+  # that removes it.
+  if git diff --cached -U0 -- "$file" | grep -qE "^\+.*$secret_re"; then
+    echo "${RED}✗ Possible secret in ${file}${RESET}"
+    git diff --cached -U0 -- "$file" | grep -nE "^\+.*$secret_re" | head -3 | sed 's/^/    /'
+    fail=1
+  fi
+done <<< "$staged"
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "${YELLOW}Commit blocked.${RESET} Usually the fix is to unstage, not to bypass:"
+  echo "    git restore --staged <path>"
+  echo
+  echo "Prefer ${DIM}git add <specific paths>${RESET} over ${DIM}git add -A${RESET} — that is what caused"
+  echo "the incident this hook exists to prevent."
+  echo
+  echo "If you are certain: ${DIM}git commit --no-verify${RESET}"
+  exit 1
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,14 @@ target/
 *.swp
 *.swo
 .DS_Store
-.claude/
+# `.claude/*` not `.claude/` — git will not descend into an ignored *directory*,
+# so the re-includes below would never apply and new shared skills would be
+# silently dropped from commits.
+.claude/*
+!.claude/settings.json
+!.claude/skills/
+!.claude/agents/
+!.claude/workflows/
 .ai
 .agent/
 .cursor/
@@ -170,6 +177,13 @@ apps/desktop/icons/ios/
 !/build.config.teal.json
 
 server.info
-# Playwright MCP scratch output — browser downloads land here and must never
-# be committed (a bare `git add -A` swept a set of them into main once).
+# Tool scratch output. Nothing here is source, and nobody reviews it before
+# committing — which is exactly how a bare `git add -A` swept a private
+# individual's CV out of .playwright-mcp/ into main once. Same failure mode
+# applies to every directory a tool writes into unattended.
 .playwright-mcp/
+test-results/
+playwright-report/
+screenshots/
+tmp/
+

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "TeamClaw - AI Agent Desktop Platform",
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks || true",
     "dev": "pnpm --filter @teamclaw/app dev",
     "expo:dev": "pnpm --filter @teamclaw/expo dev",
     "expo:ios": "pnpm --filter @teamclaw/expo ios",


### PR DESCRIPTION
## Why

Earlier today an unscoped `git add -A` swept a private individual's CV out of `.playwright-mcp/` — a Playwright MCP scratch directory — into a commit on this **public** repository. Undoing it took a history rewrite, a force-push, and a request to GitHub Support to purge the blobs from the fork network. Even that does not fully close the exposure: merged pull requests keep the objects reachable by SHA.

`.gitignore` alone cannot prevent a repeat. It only covers directories someone thought of in advance, and the entire problem was a directory nobody thought about. So this adds both halves.

## `.gitignore`

The rest of the same family of tool-scratch directories that were still unignored: `test-results/`, `playwright-report/`, `screenshots/`, `tmp/`.

Also narrows the pre-existing `.claude/` rule to `.claude/*` and re-includes the shared parts (`settings.json`, `skills/`, `agents/`, `workflows/`). **Git does not descend into an ignored *directory***, so under `.claude/` a re-include is impossible — meaning newly added shared skills would have been silently dropped from commits. This repo already tracks two skills, so that was a live footgun rather than a hypothetical.

Verified with `git check-ignore`:

| path | want | got |
|---|---|---|
| `.claude/skills/sentry-fix/SKILL.md` (tracked) | visible | visible |
| `.claude/skills/new-skill/SKILL.md` (hypothetical) | visible | visible |
| `.claude/settings.json` | visible | visible |
| `.claude/settings.local.json` | ignored | ignored |
| `.claude/history.jsonl` | ignored | ignored |
| `screenshots/`, `tmp/`, `test-results/`, `playwright-report/`, `.playwright-mcp/` | ignored | ignored |

## `.githooks/pre-commit`

Checks what is actually staged rather than where it lives:

1. **Rejects file types that are never source here** — office documents, archives, key stores. Verified this matches **zero** currently tracked files, so any hit is genuinely new rather than an existing file being re-staged.
2. **Rejects the known scratch directories** even when force-added past `.gitignore`.
3. **Scans added lines only** of newly staged content for key material and common token shapes (`sk-`, `ghp_`, `github_pat_`, `AKIA`, `xox*`, `AIza`, `crsr_`, PEM headers). Test/fixture/example paths are skipped, because this repo legitimately carries a throwaway APNs P8 in `services/fc/test/apns-jwt.test.ts`. Scanning added lines only also means the commit that *removes* a secret is never blocked.

Wired through a `prepare` script so `pnpm install` sets `core.hooksPath` with no manual step, with `|| true` so an install without a `.git` directory does not fail.

`git commit --no-verify` still bypasses it. Deliberately not automatic — committing something that trips this should be a decision, not a default.

## Testing

All four paths exercised against the real hook:

| case | result |
|---|---|
| staged `some-resume.pdf` | blocked |
| force-added `screenshots/shot.png` | blocked |
| `ghp_…` token in new source | blocked |
| test fixture containing a PEM header | passes (no false positive) |

The hook also ran against its own commit and passed. That commit staged exactly three paths while unrelated in-progress work sat in the tree — which is the habit this is meant to encourage.

## Not covered

Hooks are local and bypassable, so this is a guard rail, not a control. If you want something that cannot be skipped, the same checks belong in CI against the PR diff — happy to add that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)