### PR TITLE
feat(app): quick-open automation panel from local daemon card

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -77,6 +77,7 @@ import { UpdateDialogContainer } from "@/components/updater/UpdateDialog";
 import { RightPanel } from "@/components/panel";
 import { ExtensionSettings, Settings } from "@/components/settings";
 import { FeedbackDialog } from "@/components/settings/FeedbackDialog";
+import { AutomationPanelDialog } from "@/components/settings/AutomationPanelDialog";
 import { CloseToTrayHost } from "@/components/CloseToTrayDialog";
 import {
   Dialog,
@@ -2627,6 +2628,7 @@ function AppContent() {
           </div>
         </SidebarInset>
         {settingsModal}
+        <AutomationPanelDialog />
       </>
     );
   }
@@ -2846,6 +2848,7 @@ function AppContent() {
         </div>
       </SidebarInset>
       {settingsModal}
+      <AutomationPanelDialog />
     </>
   );
 }

--- a/packages/app/src/components/settings/AutomationPanelDialog.tsx
+++ b/packages/app/src/components/settings/AutomationPanelDialog.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { X } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { useUIStore } from '@/stores/ui'
+import { SettingsSectionBody } from './section-registry'
+
+export function AutomationPanelDialog() {
+  const { t } = useTranslation()
+  const open = useUIStore((s) => s.automationPanelOpen)
+  const setOpen = useUIStore((s) => s.setAutomationPanelOpen)
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent
+        aria-label={t('sidebar.localDaemonAutomation', 'Automation')}
+        className="flex h-[min(780px,calc(100vh-5rem))] w-[min(720px,calc(100vw-4rem))] max-w-none grid-cols-none flex-col gap-0 overflow-hidden rounded-[14px] border-border bg-paper p-0 shadow-2xl sm:max-w-none"
+        showCloseButton={false}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        <DialogHeader className="flex h-10 shrink-0 flex-row items-center justify-end border-b border-border-soft bg-paper px-3 py-0">
+          <DialogTitle className="sr-only">
+            {t('sidebar.localDaemonAutomation', 'Automation')}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            {t(
+              'settings.cron.automationDesc',
+              'Schedule recurring tasks for your AI agent. Jobs run automatically and can deliver results through configured channels.',
+            )}
+          </DialogDescription>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-selected hover:text-foreground"
+            onClick={() => setOpen(false)}
+            aria-label={t('common.close', 'Close')}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </DialogHeader>
+        <SettingsSectionBody section="automation" />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/sidebar/LocalDaemonCard.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonCard.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { getBackend } from '@/lib/backend'
-import { formatActorRemoveError } from '@/lib/actor-remove-error'
 import { useActorsForTeam, type ActorRow as ActorRowData } from '@/components/panel/ActorsView'
 import { LocalDaemonRow } from '@/components/sidebar/LocalDaemonRow'
 import { getLocalDaemonAgent } from '@/lib/daemon-agent-admin'
@@ -10,16 +8,6 @@ import { getKnownLocalDaemonActorId, noteLocalDaemonActorId } from '@/lib/local-
 import { useLocalDaemonRuntimeStatus } from '@/hooks/use-local-daemon-http-status'
 import { cn } from '@/lib/utils'
 import { ActorDetailDialog } from '@/components/sidebar/ActorDetailDialog'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
 import { useMemberPreferencesStore } from '@/stores/member-preferences-store'
 
 /**
@@ -29,7 +17,7 @@ import { useMemberPreferencesStore } from '@/stores/member-preferences-store'
  * coral-emphasized styling from looking out of place among the recent contacts.
  *
  * Self-contained: it resolves the local daemon actor itself and owns the
- * detail / remove dialogs and copy handlers (ActorsSection no longer renders
+ * detail dialog and copy handlers (ActorsSection no longer renders
  * the daemon row, it only filters the daemon out of the Recents list).
  */
 export function LocalDaemonCard() {
@@ -38,8 +26,6 @@ export function LocalDaemonCard() {
   const defaultAgentId = useMemberPreferencesStore((s) => s.defaultAgentId)
 
   const [detailFor, setDetailFor] = React.useState<ActorRowData | null>(null)
-  const [removeFor, setRemoveFor] = React.useState<ActorRowData | null>(null)
-  const [removing, setRemoving] = React.useState(false)
 
   const [localDaemonAgentId, setLocalDaemonAgentId] = React.useState<string | null>(null)
   React.useEffect(() => {
@@ -90,22 +76,6 @@ export function LocalDaemonCard() {
     }
   }
 
-  const confirmRemove = async () => {
-    if (!removeFor || !teamId) return
-    setRemoving(true)
-    try {
-      await getBackend().teams.removeTeamActor(teamId, removeFor.id)
-      toast.success(t('actors.removed', 'Removed from team'))
-      setRemoveFor(null)
-      refetch()
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error)
-      toast.error(formatActorRemoveError(msg, t))
-    } finally {
-      setRemoving(false)
-    }
-  }
-
   if (!localDaemonActor) return null
 
   return (
@@ -116,27 +86,9 @@ export function LocalDaemonCard() {
         onOpenChange={(open) => { if (!open) setDetailFor(null) }}
         onRemoved={refetch}
       />
-      <AlertDialog open={!!removeFor} onOpenChange={(open) => { if (!open) setRemoveFor(null) }}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t('actors.removeConfirm.titleAgent', 'Remove agent?')}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('actors.removeConfirm.body', 'Remove {{name}} from the team. This cannot be undone.', { name: removeFor?.display_name })}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={removing}>{t('common.cancel', 'Cancel')}</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmRemove} disabled={removing}>
-              {t('actors.removeConfirm.cta', 'Remove')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
       <div
         className={cn(
-          'group/local-daemon flex max-h-[45vh] flex-col overflow-y-auto rounded-xl bg-paper p-2 shadow-[0_2px_8px_rgba(28,27,25,0.05),0_1px_2px_rgba(28,27,25,0.03)] ring-1 ring-black/[0.05] transition-[max-height,box-shadow] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:ring-white/10',
+          'group/local-daemon flex max-h-[45vh] flex-col overflow-y-auto rounded-xl bg-paper p-2 shadow-[0_2px_8px_rgba(28,27,25,0.05),0_1px_2px_rgba(28,27,25,0.03)] ring-1 ring-black/[0.05] transition-[max-height,box-shadow] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:ring-white/10 [&_button:not(:disabled)]:cursor-pointer',
           daemonMqttDisconnected && 'ring-1 ring-amber-400/45',
         )}
       >
@@ -147,7 +99,6 @@ export function LocalDaemonCard() {
           onViewDetail={setDetailFor}
           onCopyName={handleCopyName}
           onCopyId={handleCopyId}
-          onRequestRemove={setRemoveFor}
         />
       </div>
     </>

--- a/packages/app/src/components/sidebar/LocalDaemonRow.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonRow.tsx
@@ -3,14 +3,14 @@ import { useTranslation } from 'react-i18next'
 import {
   ArrowLeftRight,
   Bot,
+  ChevronRight,
+  Clock,
   Loader2,
   Plus,
   RefreshCw,
   Settings,
   Star,
   Trash2,
-  User,
-  UserMinus,
   LifeBuoy,
 } from 'lucide-react'
 import {
@@ -30,7 +30,6 @@ import {
 } from '@/lib/daemon-workspaces'
 import { syncSessionWorkspaces } from '@/lib/session-workspace-sync'
 import { amuxAgentTypeFromBackend } from '@/lib/amux-agent-type'
-import { canRemoveTeamActor, useTeamPermissions } from '@/lib/team-permissions'
 import { useUIStore } from '@/stores/ui'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useCurrentTeamStore } from '@/stores/current-team'
@@ -49,7 +48,6 @@ interface Props {
   onViewDetail: (actor: ActorRowData) => void
   onCopyName: (actor: ActorRowData) => void
   onCopyId: (actor: ActorRowData) => void
-  onRequestRemove: (actor: ActorRowData) => void
 }
 
 function workspaceNameFromPath(path: string): string {
@@ -175,7 +173,7 @@ function SheetMenuItem({
       disabled={disabled}
       onClick={onClick}
       className={cn(
-        'flex w-full items-center gap-2 rounded-lg px-2.5 py-[7px] text-left text-[12.5px] transition-colors',
+        'flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-[7px] text-left text-[12.5px] transition-colors',
         destructive
           ? 'text-destructive hover:bg-destructive/8'
           : 'text-ink-2 hover:bg-selected hover:text-foreground',
@@ -199,6 +197,7 @@ function SheetHeader({
   statusLabel,
   expanded,
   onHandleClick,
+  onAvatarClick,
 }: {
   displayName: string
   actorId: string
@@ -210,6 +209,7 @@ function SheetHeader({
   statusLabel: string
   expanded: boolean
   onHandleClick: () => void
+  onAvatarClick: () => void
 }) {
   const { t } = useTranslation()
   const headTitle = `${displayName} · ${shortenActorId(actorId)}`
@@ -243,19 +243,21 @@ function SheetHeader({
         )}
       >
         <div className="flex items-center gap-2.5" title={headTitle}>
-          <span
+          <button
+            type="button"
+            onClick={onAvatarClick}
             className={cn(
-              'flex h-7 w-7 shrink-0 items-center justify-center self-center rounded-md',
+              'flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center self-center rounded-md transition-colors hover:brightness-[1.04]',
               runtimeStatus === 'offline'
-                ? 'bg-foreground/10 text-muted-foreground'
+                ? 'bg-foreground/10 text-muted-foreground hover:bg-foreground/15'
                 : runtimeStatus === 'daemonMqttDisconnected'
-                  ? 'bg-amber-400/15 text-amber-800'
-                  : 'bg-coral text-white',
+                  ? 'bg-amber-400/15 text-amber-800 hover:bg-amber-400/25'
+                  : 'bg-coral text-white hover:brightness-[1.06]',
             )}
-            aria-hidden
+            aria-label={t('actors.contextMenu.viewProfile', 'View profile')}
           >
             <AgentTypeIcon agentType={agentType} />
-          </span>
+          </button>
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-1.5">
               <div className="truncate text-[12.5px] font-semibold leading-tight">{displayName}</div>
@@ -344,7 +346,7 @@ function WorkspaceRow({
         type="button"
         onClick={onSelect}
         className={cn(
-          'flex min-w-0 flex-1 items-center gap-2 rounded-lg py-[6px] pl-1.5 pr-2.5 text-left text-[12.5px] transition-colors',
+          'flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-lg py-[6px] pl-1.5 pr-2.5 text-left text-[12.5px] transition-colors',
           active ? 'font-semibold text-foreground' : 'text-ink-2',
         )}
         title={ws.path ?? ws.name}
@@ -365,7 +367,7 @@ function WorkspaceRow({
             onSwitch()
           }}
           disabled={!ws.path || isCurrent}
-          className="rounded-md p-1 text-faint hover:bg-selected hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+          className="cursor-pointer rounded-md p-1 text-faint hover:bg-selected hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
           title={switchLabel}
           aria-label={switchLabel}
         >
@@ -377,7 +379,7 @@ function WorkspaceRow({
             e.stopPropagation()
             onDelete()
           }}
-          className="rounded-md p-1 text-faint hover:bg-destructive/10 hover:text-destructive"
+          className="cursor-pointer rounded-md p-1 text-faint hover:bg-destructive/10 hover:text-destructive"
           title={deleteLabel}
           aria-label={deleteLabel}
         >
@@ -397,16 +399,10 @@ export function LocalDaemonRow({
   runtimeStatus,
   isDefault = false,
   onViewDetail,
-  onRequestRemove,
 }: Props) {
   const { t } = useTranslation()
   const teamId = useCurrentTeamStore((s) => s.team?.id ?? null)
   const currentMember = useCurrentTeamStore((s) => s.currentMember)
-  const currentMemberId = currentMember?.id ?? null
-  const teamPermissions = useTeamPermissions()
-  const canRemove = actor
-    ? canRemoveTeamActor(teamPermissions, actor, currentMemberId)
-    : false
 
   const sheetOpen = useUIStore((s) => s.localDaemonSheetOpen)
   const toggleSheet = useUIStore((s) => s.toggleLocalDaemonSheet)
@@ -415,6 +411,7 @@ export function LocalDaemonRow({
   const filter = useUIStore((s) => s.sidebarFilter)
   const setFilter = useUIStore((s) => s.setSidebarFilter)
   const openSettings = useUIStore((s) => s.openSettings)
+  const openAutomationPanel = useUIStore((s) => s.openAutomationPanel)
   const setDefaultAgent = useMemberPreferencesStore((s) => s.setDefaultAgent)
 
   const currentWorkspacePath = useWorkspaceStore((s) => s.workspacePath)
@@ -547,6 +544,11 @@ export function LocalDaemonRow({
     openSettings('general')
   }
 
+  const handleOpenAutomation = () => {
+    setSheetOpen(false)
+    openAutomationPanel()
+  }
+
   if (!actor) return null
 
   const workspaceLabel = currentWorkspaceName || t('workspace.selectWorkspace', 'Select Workspace')
@@ -586,7 +588,7 @@ export function LocalDaemonRow({
 
   return (
     <div className="overflow-hidden">
-      <div className={cn('px-2.5 pb-2.5', sheetOpen ? 'pt-2' : 'pt-1')}>
+      <div className={cn(sheetOpen ? 'px-0 pb-2 pt-1' : 'p-0')}>
         <SheetHeader
           displayName={actor.display_name}
           actorId={actor.id}
@@ -597,6 +599,7 @@ export function LocalDaemonRow({
           runtimeStatus={runtimeStatus}
           statusLabel={statusLabel}
           onHandleClick={toggleSheet}
+          onAvatarClick={() => onViewDetail(actor)}
           expanded={sheetOpen}
         />
 
@@ -604,7 +607,7 @@ export function LocalDaemonRow({
           <button
             type="button"
             onClick={handleDaemonMqttReconnect}
-            className="mb-2 flex w-full items-start rounded-lg border border-amber-400/45 bg-amber-400/10 px-2 py-1.5 text-left transition-colors hover:bg-amber-400/20"
+            className="mb-2 flex w-full cursor-pointer items-start rounded-lg border border-amber-400/45 bg-amber-400/10 px-2 py-1.5 text-left transition-colors hover:bg-amber-400/20"
           >
             <span className="min-w-0 flex-1 leading-tight">
               <span className="block truncate text-[11.5px] font-semibold text-foreground">
@@ -622,6 +625,22 @@ export function LocalDaemonRow({
             </span>
           </button>
         ) : null}
+
+        <button
+          type="button"
+          onClick={handleOpenAutomation}
+          className={cn(
+            'mt-2 flex w-full cursor-pointer items-center gap-2 rounded-lg bg-background px-2.5 py-1.5 text-left transition-colors hover:bg-selected',
+            sheetOpen && 'mb-2',
+          )}
+          aria-label={t('sidebar.localDaemonAutomationAria', 'Open automation settings')}
+        >
+          <Clock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-ink-2">
+            {t('sidebar.localDaemonAutomation', 'Automation')}
+          </span>
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-faint" aria-hidden />
+        </button>
 
         <div
           className={cn(
@@ -679,7 +698,7 @@ export function LocalDaemonRow({
                         type="button"
                         onClick={() => void handleNewWorkspace()}
                         disabled={creating}
-                        className="rounded-md p-0.5 text-faint hover:bg-selected hover:text-foreground disabled:opacity-40"
+                        className="cursor-pointer rounded-md p-0.5 text-faint hover:bg-selected hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
                         title={t('sidebar.newWorkspace', 'New workspace')}
                         aria-label={t('sidebar.newWorkspace', 'New workspace')}
                       >
@@ -701,15 +720,6 @@ export function LocalDaemonRow({
                     >
                       {t('sidebar.localDaemonDaemonSettings', 'Daemon settings')}
                     </SheetMenuItem>
-                    <SheetMenuItem
-                      icon={<User className="h-3.5 w-3.5" />}
-                      onClick={() => {
-                        setSheetOpen(false)
-                        onViewDetail(actor)
-                      }}
-                    >
-                      {t('actors.contextMenu.viewProfile', 'View profile')}
-                    </SheetMenuItem>
                   </SheetGroup>
                 </>
               )}
@@ -724,18 +734,6 @@ export function LocalDaemonRow({
                     ? t('actors.contextMenu.removeDefault', 'Remove as default agent')
                     : t('actors.contextMenu.setDefault', 'Set as default agent')}
                 </SheetMenuItem>
-                {canRemove ? (
-                  <SheetMenuItem
-                    icon={<UserMinus className="h-3.5 w-3.5" />}
-                    destructive
-                    onClick={() => {
-                      setSheetOpen(false)
-                      onRequestRemove(actor)
-                    }}
-                  >
-                    {t('actors.contextMenu.remove', 'Remove from team')}
-                  </SheetMenuItem>
-                ) : null}
               </SheetGroup>
             </div>
           </div>

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -818,6 +818,8 @@
     "localDaemonGroupDevice": "Device",
     "localDaemonGroupTeam": "Team",
     "localDaemonDaemonSettings": "Daemon settings",
+    "localDaemonAutomation": "Automation",
+    "localDaemonAutomationAria": "Open automation tasks",
     "localDaemonRetrying": "Retrying…",
     "ideas": "Ideas"
   },

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -818,6 +818,8 @@
     "localDaemonGroupDevice": "设备",
     "localDaemonGroupTeam": "团队",
     "localDaemonDaemonSettings": "Daemon 设置",
+    "localDaemonAutomation": "自动化",
+    "localDaemonAutomationAria": "打开自动化任务",
     "localDaemonRetrying": "正在重试…",
     "ideas": "想法"
   },

--- a/packages/app/src/stores/ui.ts
+++ b/packages/app/src/stores/ui.ts
@@ -79,6 +79,8 @@ interface UIState {
   localDaemonExpanded: boolean
   /** Action sheet open (⋯ menu). */
   localDaemonSheetOpen: boolean
+  /** Standalone automation panel (CronSection) without opening full Settings. */
+  automationPanelOpen: boolean
   draftIdeaId: string | null
   /** Modal "新会话" dialog (NavRail ▾ menu + intercepted send-with-no-session). */
   newSessionDialogOpen: boolean
@@ -95,6 +97,9 @@ interface UIState {
   toggleLocalDaemon: () => void
   toggleLocalDaemonSheet: () => void
   setLocalDaemonSheetOpen: (open: boolean) => void
+  openAutomationPanel: () => void
+  closeAutomationPanel: () => void
+  setAutomationPanelOpen: (open: boolean) => void
   setDraftIdeaId: (ideaId: string) => void
   clearDraftIdeaId: () => void
   setView: (view: View) => void
@@ -149,6 +154,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   teamShareCollapsed: true,
   localDaemonExpanded: false,
   localDaemonSheetOpen: false,
+  automationPanelOpen: false,
   draftIdeaId: null,
   newSessionDialogOpen: false,
   newSessionDialogInitialMessage: null,
@@ -393,6 +399,10 @@ export const useUIStore = create<UIState>((set, get) => ({
   toggleLocalDaemon: () => set((s) => ({ localDaemonExpanded: !s.localDaemonExpanded })),
   toggleLocalDaemonSheet: () => set((s) => ({ localDaemonSheetOpen: !s.localDaemonSheetOpen })),
   setLocalDaemonSheetOpen: (open) => set({ localDaemonSheetOpen: open }),
+
+  openAutomationPanel: () => set({ automationPanelOpen: true }),
+  closeAutomationPanel: () => set({ automationPanelOpen: false }),
+  setAutomationPanelOpen: (open) => set({ automationPanelOpen: open }),
   setDraftIdeaId: (ideaId) => set({ draftIdeaId: ideaId }),
   clearDraftIdeaId: () => set({ draftIdeaId: null }),
 


### PR DESCRIPTION
## Summary
- Add a standalone **Automation** dialog that reuses `CronSection` via `SettingsSectionBody`, so scheduled jobs can be managed without opening full Settings.
- Streamline the sidebar **local daemon card**: always-visible automation chip, avatar opens profile, remove redundant menu items, and improve pointer/hover affordances.

## Test plan
- [ ] Click **自动化 / Automation** on the local daemon card → standalone panel opens (not Settings)
- [ ] Panel shows Global/Workspace tabs, New Job, and empty state consistent with Settings → Automation
- [ ] Close button dismisses the panel; underlying chat view stays unchanged
- [ ] Avatar click opens actor detail dialog
- [ ] Expanded daemon sheet still works (workspace list, daemon settings, default agent)
- [ ] `pnpm typecheck` passes


Made with [Cursor](https://cursor.com)