### PR TITLE
fix(app): restore dark mode for brand/teal palettes

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -31,13 +31,20 @@
         --sk-bone: oklch(0.3 0 0);
       }
       /* Anodized teal build flavor — mirrors :root[data-palette="teal"] in
-         globals.css so the skeleton's first paint already matches. Outranks
-         .dark so the flavor stays light. */
+         globals.css so the skeleton's first paint already matches. */
       :root[data-palette="teal"] {
         --sk-bg: #f2f0ea;
         --sk-panel: #e5e6e1;
         --sk-border: rgba(32, 36, 42, 0.08);
         --sk-bone: #d5d8d0;
+      }
+      /* Brand/teal + dark: restore dark skeleton surfaces (matches
+         :root.dark[data-palette] in globals.css). */
+      :root.dark[data-palette] {
+        --sk-bg: oklch(0.145 0 0);
+        --sk-panel: oklch(0.205 0 0);
+        --sk-border: oklch(1 0 0 / 10%);
+        --sk-bone: oklch(0.3 0 0);
       }
 
       #skeleton {

--- a/packages/app/src/components/chat/UserMessageWithMentions.tsx
+++ b/packages/app/src/components/chat/UserMessageWithMentions.tsx
@@ -217,7 +217,7 @@ function AgentMentionHeader({ names }: { names: string[] }) {
         <span className="font-mono text-[9px] font-semibold tracking-[0.04em] text-coral shrink-0">
           AGENT
         </span>
-        <span className="text-[12.5px] font-semibold text-[#1a1a14] dark:text-[#eef3f7] truncate">
+        <span className="text-[12.5px] font-semibold text-foreground truncate">
           {labels.join(", ")}
         </span>
       </div>

--- a/packages/app/src/packages/ai/message.tsx
+++ b/packages/app/src/packages/ai/message.tsx
@@ -160,7 +160,7 @@ export function MessageContent({
         // Chat message base — user bubble + assistant note share 13.5px / 1.5.
         "text-[13.5px] leading-[1.5] break-words [overflow-wrap:anywhere] min-w-0",
         from === "user"
-          ? "max-w-[85%] overflow-x-hidden rounded-2xl rounded-br-[6px] px-4 py-3 bg-[#e8edf2] text-[#1f2933] dark:border dark:border-white/8 dark:bg-white/10 dark:backdrop-blur-sm dark:text-[#eef3f7]"
+          ? "max-w-[85%] overflow-x-hidden rounded-2xl rounded-br-[6px] px-4 py-3 bg-[#e8edf2] text-foreground dark:border dark:border-white/8 dark:bg-white/10 dark:backdrop-blur-sm"
           : "overflow-hidden w-full",
         className
       )}

--- a/packages/app/src/styles/globals.css
+++ b/packages/app/src/styles/globals.css
@@ -118,10 +118,13 @@
    Four anchors from the spec: teal #0F6E62 (主色), bright #16998A (亮·交互),
    chalk #F2F0EA (底), basalt #20242A (正文). teal-forward — primary/CTA is
    teal, bright drives interaction/focus/links; the coral accent slot becomes
-   bright teal. Light-only by design: the selector outranks `.dark`
-   (`:root[data-palette]` = (0,1,1) beats `.dark` = (0,1,0)), so toggling dark
-   mode stays on the teal-light surface instead of breaking into a half-grey
-   state. No teal dark variant exists yet — that's intentional.
+   bright teal.
+
+   Light tokens live on `:root[data-palette]` and beat bare `.dark`
+   (attribute+pseudo > class). Dark mode is restored by the shared
+   `:root.dark[data-palette]` surface override below — brand accents
+   (--primary / --coral / --system-accent / --sidebar-primary / --ring)
+   stay on the light palette rule so white-label色不受影响.
    --------------------------------------------------------------------------- */
 :root[data-palette="teal"] {
     --background: #f2f0ea;          /* chalk · 底 */
@@ -165,6 +168,41 @@
     --sidebar-accent-foreground: #20242a;
     --sidebar-border: rgba(32, 36, 42, 0.08);
     --sidebar-ring: rgba(22, 153, 138, 0.4);
+}
+
+/* Dark surfaces for ANY brand / teal palette. Specificity beats
+   `:root[data-palette=…]` so backgrounds switch; omitted accent tokens
+   (--primary, --coral, --system-accent, --sidebar-primary, --ring,
+   --*-foreground for those accents, --coral-soft/foreground) keep the
+   light-palette brand values. Also covers build-time brand-theme.css. */
+:root.dark[data-palette] {
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --paper: oklch(0.205 0 0);
+    --panel: oklch(0.205 0 0);
+    --selected: oklch(0.269 0 0);
+    --ink-2: oklch(0.85 0 0);
+    --faint: oklch(0.556 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.205 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --secondary: oklch(0.269 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --accent: oklch(0.269 0 0);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --border: oklch(1 0 0 / 10%);
+    --border-soft: oklch(1 0 0 / 6%);
+    --input: oklch(1 0 0 / 15%);
+    --sidebar: oklch(0.205 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.556 0 0);
 }
 
 @theme inline {

--- a/scripts/lib/brand-theme.js
+++ b/scripts/lib/brand-theme.js
@@ -21,8 +21,11 @@ function extractRootTokenNames(css) {
 
 /**
  * Validate brand tokens against the allow-list and produce a single CSS rule
- * `:root[data-palette="<palette>"]{…}`. Throws (to fail the build) on an
- * unknown token name or a value containing CSS-breaking characters.
+ * `:root[data-palette="<palette>"]{…}` (light tokens only). Dark surfaces for
+ * any palette are handled once in globals.css via `:root.dark[data-palette]`
+ * so brand accent tokens from this rule still apply in dark mode. Throws (to
+ * fail the build) on an unknown token name or a value containing CSS-breaking
+ * characters.
  */
 function generateBrandThemeCss(palette, tokens, allowedTokens) {
   if (typeof palette !== "string" || !/^[a-zA-Z0-9_-]+$/.test(palette)) {


### PR DESCRIPTION
## Summary
- Brand / teal builds set `data-palette`, whose light CSS tokens outranked `.dark`, so packaged apps stayed light while `dark:` utilities still flipped text — user bubbles became nearly unreadable.
- Add `:root.dark[data-palette]` surface overrides (background/paper/panel/sidebar/…); keep brand accents (`--primary`, `--coral`, `--system-accent`, …) from the light palette.
- Align startup skeleton and switch user-bubble / agent-mention text to `text-foreground`.

## Test plan
- [ ] `BUILD_ENV=teal pnpm tauri:dev:daemon`
- [ ] Confirm `document.documentElement.getAttribute('data-palette') === 'teal'`
- [ ] Switch Settings → Appearance to Dark: whole shell goes dark; `--background` is dark; `--coral` stays brand teal (`#16998a`)
- [ ] User message (with AGENT / @mention) text remains readable
- [ ] Switch back to Light: teal light surfaces + brand accents unchanged
- [ ] Default `pnpm tauri:dev:daemon` (no palette) dark/light still works


Made with [Cursor](https://cursor.com)