### PR TITLE
fix: restore image attachments for agent prompts + sidebar polish

### DIFF
--- a/apps/daemon/src/runtime/claude_agent/mod.rs
+++ b/apps/daemon/src/runtime/claude_agent/mod.rs
@@ -330,6 +330,8 @@ async fn do_prompt(
     reply_to_message_id: Option<String>,
 ) {
     let reply_to = reply_to_message_id.filter(|id| !id.is_empty());
+    let resolved =
+        crate::runtime::prompt_attachments::resolve_all(&attachment_urls).await;
     let (event_tx, worktree, session_key, model) = {
         let mut routes = shared.routes.lock();
         let Some(route) = routes.get_mut(session_id) else {
@@ -357,13 +359,7 @@ async fn do_prompt(
     .await;
 
     let mut message = text;
-    if !attachment_urls.is_empty() {
-        message.push_str("\n\nAttachments:\n");
-        for url in &attachment_urls {
-            message.push_str(url);
-            message.push('\n');
-        }
-    }
+    crate::runtime::prompt_attachments::append_to_message(&mut message, &resolved);
 
     let result = match shared.pool.ensure(shared, &worktree) {
         Ok(proc) => {

--- a/apps/daemon/src/runtime/cursor_sdk/mod.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/mod.rs
@@ -312,6 +312,8 @@ async fn do_prompt(
     reply_to_message_id: Option<String>,
 ) {
     let reply_to = reply_to_message_id.filter(|id| !id.is_empty());
+    let resolved =
+        crate::runtime::prompt_attachments::resolve_all(&attachment_urls).await;
     let (event_tx, worktree, agent_id, model) = {
         let mut routes = shared.routes.lock();
         let Some(route) = routes.get_mut(session_id) else {
@@ -339,13 +341,7 @@ async fn do_prompt(
     .await;
 
     let mut message = text;
-    if !attachment_urls.is_empty() {
-        message.push_str("\n\nAttachments:\n");
-        for url in &attachment_urls {
-            message.push_str(url);
-            message.push('\n');
-        }
-    }
+    crate::runtime::prompt_attachments::append_to_message(&mut message, &resolved);
 
     let result = match shared.pool.ensure(shared, &worktree) {
         Ok(proc) => {

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -15,6 +15,7 @@ mod instruction_delivery;
 pub mod managed_llm;
 mod manager;
 pub mod permission_policy;
+pub mod prompt_attachments;
 pub mod refresh;
 pub mod sidecar;
 pub mod supervisor;

--- a/apps/daemon/src/runtime/opencode_http/mod.rs
+++ b/apps/daemon/src/runtime/opencode_http/mod.rs
@@ -863,6 +863,10 @@ async fn do_prompt(
     reply_to_message_id: Option<String>,
 ) {
     let reply_to = reply_to_message_id.filter(|id| !id.is_empty());
+    // Resolve before marking the turn active so download latency does not
+    // consume the stuck-turn watchdog budget.
+    let resolved =
+        crate::runtime::prompt_attachments::resolve_all(&attachment_urls).await;
     let (event_tx, directory, model, turn_seq) = {
         let mut routes = shared.routes.lock();
         let Some(route) = routes.get_mut(session_id) else {
@@ -894,19 +898,31 @@ async fn do_prompt(
     .await;
 
     let mut parts = vec![PromptPart::Text { text }];
-    for url in &attachment_urls {
-        let filename = url
-            .split('?')
-            .next()
-            .unwrap_or(url)
-            .rsplit('/')
-            .next()
-            .map(str::to_string);
-        parts.push(PromptPart::File {
-            mime: guess_mime(url).to_string(),
-            url: url.clone(),
-            filename,
-        });
+    for att in &resolved {
+        match att {
+            crate::runtime::prompt_attachments::ResolvedAttachment::Image { .. } => {
+                let (mime, url, filename) = att.opencode_file_fields();
+                parts.push(PromptPart::File {
+                    mime,
+                    url,
+                    filename,
+                });
+            }
+            crate::runtime::prompt_attachments::ResolvedAttachment::Link { url, .. } => {
+                // Failed image downloads fall back to Link; opencode rejects HTTPS
+                // image URLs, so omit those rather than surfacing ImageInvalidDataUrlError.
+                if crate::runtime::prompt_attachments::is_image_attachment_url(url) {
+                    warn!(url = %url, "skipping unresolved image attachment for opencode prompt");
+                    continue;
+                }
+                let (mime, url, filename) = att.opencode_file_fields();
+                parts.push(PromptPart::File {
+                    mime,
+                    url,
+                    filename,
+                });
+            }
+        }
     }
     let body = PromptBody { model, parts };
 

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -428,6 +428,8 @@ async fn do_prompt(
     reply_to_message_id: Option<String>,
 ) {
     let reply_to = reply_to_message_id.filter(|id| !id.is_empty());
+    let resolved =
+        crate::runtime::prompt_attachments::resolve_all(&attachment_urls).await;
     let (event_tx, worktree, session_path) = {
         let mut routes = shared.routes.lock();
         let Some(route) = routes.get_mut(session_id) else {
@@ -453,16 +455,8 @@ async fn do_prompt(
     )
     .await;
 
-    // pi's prompt takes inline base64 images only; attachment URLs are
-    // appended to the message text for now.
     let mut message = text;
-    if !attachment_urls.is_empty() {
-        message.push_str("\n\nAttachments:\n");
-        for url in &attachment_urls {
-            message.push_str(url);
-            message.push('\n');
-        }
-    }
+    crate::runtime::prompt_attachments::append_to_message(&mut message, &resolved);
 
     let result = match ensure_active(shared, session_id, &worktree, &session_path).await {
         Ok(proc) => {

--- a/apps/daemon/src/runtime/prompt_attachments.rs
+++ b/apps/daemon/src/runtime/prompt_attachments.rs
@@ -1,0 +1,279 @@
+//! Resolve session attachment URLs into runtime-ready payloads.
+//!
+//! Cloud clients upload images to Supabase and pass HTTPS URLs in
+//! `attachment_urls`. opencode serve requires image `File` parts to use
+//! `data:` URLs; pi/claude/cursor backends also need inline data URLs rather
+//! than bare storage links. This module downloads, optionally downscales
+//! (#710), and formats attachments for all runtimes.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use base64::Engine as _;
+use tracing::warn;
+
+static IMAGE_EXTS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp", "bmp"];
+
+/// Longest edge cap for images inlined into prompts.
+const PROMPT_IMAGE_MAX_DIMENSION: u32 = 2048;
+/// Images at or below this byte size are inlined as-is.
+const PROMPT_IMAGE_SKIP_BELOW_BYTES: usize = 512 * 1024;
+
+/// A storage URL resolved for prompt delivery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedAttachment {
+    /// Image bytes encoded as `data:{mime};base64,...`.
+    Image {
+        data_url: String,
+        mime: String,
+        filename: Option<String>,
+    },
+    /// Non-image file referenced by its original HTTPS URL.
+    Link {
+        url: String,
+        filename: String,
+        mime: String,
+    },
+}
+
+/// Return the (path-without-query, extension) for a URL.
+pub fn path_and_ext(url: &str) -> (&str, String) {
+    let path = url.split('?').next().unwrap_or(url);
+    let ext = path.rsplit('.').next().unwrap_or("").to_lowercase();
+    (path, ext)
+}
+
+pub fn mime_from_ext(ext: &str) -> &'static str {
+    match ext {
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "bmp" => "image/bmp",
+        "pdf" => "application/pdf",
+        "txt" | "md" => "text/plain",
+        _ => "application/octet-stream",
+    }
+}
+
+fn filename_from_path(path: &str) -> String {
+    path.rsplit('/').next().unwrap_or("attachment").to_string()
+}
+
+pub fn format_data_url(mime: &str, bytes: &[u8]) -> String {
+    let data = base64::engine::general_purpose::STANDARD.encode(bytes);
+    format!("data:{mime};base64,{data}")
+}
+
+fn attachment_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("attachment reqwest client")
+    })
+}
+
+/// True when the URL path looks like an image we must inline as a data URL.
+pub fn is_image_attachment_url(url: &str) -> bool {
+    IMAGE_EXTS.contains(&path_and_ext(url).1.as_str())
+}
+
+/// Download and resolve attachment URLs. On fetch/decode failure, falls back
+/// to the original HTTPS link so text backends still see the reference; opencode
+/// skips failed image fallbacks (HTTPS images are rejected by serve).
+pub async fn resolve_all(urls: &[String]) -> Vec<ResolvedAttachment> {
+    let mut out = Vec::with_capacity(urls.len());
+    for url in urls {
+        match resolve_one(url).await {
+            Ok(resolved) => out.push(resolved),
+            Err(err) => {
+                warn!(url = %url, err = %err, "attachment fetch failed; using remote link fallback");
+                let (path, ext) = path_and_ext(url);
+                out.push(ResolvedAttachment::Link {
+                    url: url.clone(),
+                    filename: filename_from_path(path),
+                    mime: mime_from_ext(&ext).to_string(),
+                });
+            }
+        }
+    }
+    out
+}
+
+async fn resolve_one(url: &str) -> anyhow::Result<ResolvedAttachment> {
+    if url.starts_with("data:") {
+        let mime = url
+            .strip_prefix("data:")
+            .and_then(|rest| rest.split(';').next())
+            .unwrap_or("application/octet-stream")
+            .to_string();
+        return Ok(ResolvedAttachment::Image {
+            data_url: url.to_string(),
+            mime,
+            filename: None,
+        });
+    }
+
+    let (path, ext) = path_and_ext(url);
+    if IMAGE_EXTS.contains(&ext.as_str()) {
+        let bytes = attachment_client()
+            .get(url)
+            .send()
+            .await?
+            .error_for_status()?
+            .bytes()
+            .await?
+            .to_vec();
+        let mime = mime_from_ext(&ext);
+        let (bytes, mime) = compress_image_for_prompt(bytes, mime).await;
+        let data_url = format_data_url(mime, &bytes);
+        return Ok(ResolvedAttachment::Image {
+            data_url,
+            mime: mime.to_string(),
+            filename: Some(filename_from_path(path)),
+        });
+    }
+
+    Ok(ResolvedAttachment::Link {
+        url: url.to_string(),
+        filename: filename_from_path(path),
+        mime: mime_from_ext(&ext).to_string(),
+    })
+}
+
+async fn compress_image_for_prompt(bytes: Vec<u8>, mime: &'static str) -> (Vec<u8>, &'static str) {
+    if mime == "image/gif" || bytes.len() <= PROMPT_IMAGE_SKIP_BELOW_BYTES {
+        return (bytes, mime);
+    }
+    let original_len = bytes.len();
+    let input = bytes.clone();
+    let compressed = tokio::task::spawn_blocking(move || -> Option<Vec<u8>> {
+        let img = match image::load_from_memory(&input) {
+            Ok(img) => img,
+            Err(err) => {
+                tracing::warn!("attachment image decode failed, inlining original: {err}");
+                return None;
+            }
+        };
+        let img = if img.width().max(img.height()) > PROMPT_IMAGE_MAX_DIMENSION {
+            img.resize(
+                PROMPT_IMAGE_MAX_DIMENSION,
+                PROMPT_IMAGE_MAX_DIMENSION,
+                image::imageops::FilterType::Triangle,
+            )
+        } else {
+            img
+        };
+        let mut out = std::io::Cursor::new(Vec::new());
+        let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut out, 85);
+        if let Err(err) = img.to_rgb8().write_with_encoder(encoder) {
+            tracing::warn!("attachment image re-encode failed, inlining original: {err}");
+            return None;
+        }
+        let encoded = out.into_inner();
+        (encoded.len() < original_len).then_some(encoded)
+    })
+    .await;
+    match compressed {
+        Ok(Some(encoded)) => (encoded, "image/jpeg"),
+        Ok(None) => (bytes, mime),
+        Err(err) => {
+            tracing::warn!("attachment image compression task failed: {err}");
+            (bytes, mime)
+        }
+    }
+}
+
+impl ResolvedAttachment {
+    pub fn opencode_file_fields(&self) -> (String, String, Option<String>) {
+        match self {
+            ResolvedAttachment::Image {
+                data_url,
+                mime,
+                filename,
+            } => (mime.clone(), data_url.clone(), filename.clone()),
+            ResolvedAttachment::Link {
+                url,
+                filename,
+                mime,
+            } => (mime.clone(), url.clone(), Some(filename.clone())),
+        }
+    }
+}
+
+/// Append resolved attachments to a text prompt (pi / claude-code / cursor).
+pub fn append_to_message(message: &mut String, attachments: &[ResolvedAttachment]) {
+    if attachments.is_empty() {
+        return;
+    }
+    message.push_str("\n\nAttachments:\n");
+    for att in attachments {
+        match att {
+            ResolvedAttachment::Image { data_url, filename, .. } => {
+                if let Some(name) = filename {
+                    message.push_str(name);
+                    message.push_str(": ");
+                }
+                message.push_str(data_url);
+                message.push('\n');
+            }
+            ResolvedAttachment::Link { url, filename, .. } => {
+                message.push_str(filename);
+                message.push_str(": ");
+                message.push_str(url);
+                message.push('\n');
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_and_ext_strips_query_before_extension() {
+        let url = "https://x.supabase.co/storage/v1/object/public/attachments/t/s/abc/photo.png?token=eyJ.foo.bar";
+        let (path, ext) = path_and_ext(url);
+        assert!(path.ends_with("photo.png"));
+        assert_eq!(ext, "png");
+    }
+
+    #[test]
+    fn format_data_url_prefix() {
+        let url = format_data_url("image/png", b"\x89PNG");
+        assert!(url.starts_with("data:image/png;base64,"));
+    }
+
+    #[test]
+    fn mime_from_ext_maps_common_images() {
+        assert_eq!(mime_from_ext("jpeg"), "image/jpeg");
+        assert_eq!(mime_from_ext("webp"), "image/webp");
+        assert_eq!(mime_from_ext("pdf"), "application/pdf");
+    }
+
+    #[test]
+    fn is_image_attachment_url_strips_query() {
+        let url = "https://x/y/photo.png?token=eyJ.foo.bar";
+        assert!(is_image_attachment_url(url));
+        assert!(!is_image_attachment_url("https://x/y/doc.pdf"));
+    }
+
+    #[test]
+    fn append_to_message_inlines_image_data_url() {
+        let mut message = String::from("hello");
+        append_to_message(
+            &mut message,
+            &[ResolvedAttachment::Image {
+                data_url: "data:image/png;base64,abc".into(),
+                mime: "image/png".into(),
+                filename: Some("shot.png".into()),
+            }],
+        );
+        assert!(message.contains("Attachments:"));
+        assert!(message.contains("shot.png:"));
+        assert!(message.contains("data:image/png;base64,abc"));
+    }
+}

--- a/build.config.dev.json
+++ b/build.config.dev.json
@@ -1,5 +1,5 @@
 {
-  "cloudApiUrl": "https://teamclaw-api.ucar.cc",
+  "cloudApiUrl": "https://api.teamclaw-dev.ucar.cc",
   "team": {
     "lockLlmConfig": false
   },

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -67,6 +67,7 @@ import { useMCPFileWatcher } from "@/hooks/useMCPFileWatcher";
 
 import { AppSidebar } from "@/components/app-sidebar";
 import { SidebarSecondColumn } from "@/components/sidebar/SidebarSecondColumn";
+import { SIDEBAR_INTERACTIVE_CURSOR } from "@/components/sidebar/sidebar-interactive-cursor";
 import { NarrowChatHeader } from "@/components/responsive/NarrowChatHeader";
 import { useLayoutBreakpoint } from "@/hooks/use-layout-breakpoint";
 import { TeamShareDetailPane } from "@/components/teamshare/TeamShareDetailPane";
@@ -2637,7 +2638,7 @@ function AppContent() {
     <>
       {breakpoint === 'wide' && <AppSidebar />}
       {breakpoint !== 'narrow' && (
-        <div className="w-(--session-list-width) shrink-0 h-svh overflow-hidden">
+        <div className={cn('w-(--session-list-width) shrink-0 h-svh overflow-hidden', SIDEBAR_INTERACTIVE_CURSOR)}>
           <SidebarSecondColumn showNewSessionActions={breakpoint === 'medium'} />
         </div>
       )}

--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -34,6 +34,7 @@ import { SessionSearchDialog } from "@/components/sidebar/session-search-dialog"
 import { SessionDetailDialog, type SessionDetailListHints } from "@/components/sidebar/SessionDetailDialog"
 import { NavRail } from "@/components/sidebar/NavRail"
 import { LocalDaemonCard } from "@/components/sidebar/LocalDaemonCard"
+import { SIDEBAR_INTERACTIVE_CURSOR } from "@/components/sidebar/sidebar-interactive-cursor"
 import { useMqttConnected } from "@/hooks/useMqttConnected"
 import { recoverMqttConnection } from "@/stores/mqtt-reconnect"
 
@@ -391,7 +392,7 @@ function SidebarUserAccountMenu() {
   )
 }
 
-export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+export function AppSidebar({ className, ...props }: React.ComponentProps<typeof Sidebar>) {
   const { t } = useTranslation()
   const activeSessionId = useSessionStore(s => s.activeSessionId)
   const sessionActivityMap = useSessionListActivityMap(activeSessionId)
@@ -407,7 +408,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   }
 
   return (
-    <Sidebar variant="sidebar" {...props}>
+    <Sidebar variant="sidebar" className={cn(SIDEBAR_INTERACTIVE_CURSOR, className)} {...props}>
       <SessionDetailDialog
         sessionId={detailSessionId}
         teamId={teamId}

--- a/packages/app/src/components/responsive/NarrowChatHeader.tsx
+++ b/packages/app/src/components/responsive/NarrowChatHeader.tsx
@@ -10,6 +10,8 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { SessionListColumn } from '@/components/sidebar/SessionListColumn'
+import { SIDEBAR_INTERACTIVE_CURSOR } from '@/components/sidebar/sidebar-interactive-cursor'
+import { cn } from '@/lib/utils'
 import { TrafficLights } from '@/components/ui/traffic-lights'
 import { hideExtensionSettingsButton } from '@/lib/build-config'
 import { capabilities } from '@/lib/platform'
@@ -144,7 +146,7 @@ export function NarrowChatHeader() {
           <SheetHeader className="sr-only">
             <SheetTitle>{t('sidebar.sessions', 'Sessions')}</SheetTitle>
           </SheetHeader>
-          <div className="flex-1 min-h-0">
+          <div className={cn('flex-1 min-h-0', SIDEBAR_INTERACTIVE_CURSOR)}>
             <SessionListColumn onDismiss={() => setSheetOpen(false)} />
           </div>
         </SheetContent>

--- a/packages/app/src/components/sidebar/LocalDaemonCard.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonCard.tsx
@@ -88,7 +88,7 @@ export function LocalDaemonCard() {
       />
       <div
         className={cn(
-          'group/local-daemon flex max-h-[45vh] flex-col overflow-y-auto rounded-xl bg-paper p-2 shadow-[0_2px_8px_rgba(28,27,25,0.05),0_1px_2px_rgba(28,27,25,0.03)] ring-1 ring-black/[0.05] transition-[max-height,box-shadow] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:ring-white/10 [&_button:not(:disabled)]:cursor-pointer',
+          'group/local-daemon flex max-h-[45vh] flex-col overflow-y-auto rounded-xl bg-paper p-2 shadow-[0_2px_8px_rgba(28,27,25,0.05),0_1px_2px_rgba(28,27,25,0.03)] ring-1 ring-black/[0.05] transition-[max-height,box-shadow] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:ring-white/10',
           daemonMqttDisconnected && 'ring-1 ring-amber-400/45',
         )}
       >

--- a/packages/app/src/components/sidebar/LocalDaemonRow.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonRow.tsx
@@ -430,22 +430,29 @@ export function LocalDaemonRow({
   const [loading, setLoading] = React.useState(false)
   const [creating, setCreating] = React.useState(false)
   const [retrying, setRetrying] = React.useState(false)
+  const workspacesRef = React.useRef(workspaces)
+  workspacesRef.current = workspaces
 
+  // Prefetch as soon as the card mounts — don't wait for sheet expand. Opening
+  // the sheet mid-fetch used to mutate content height during the 300ms
+  // grid-rows animation and felt like dropped frames.
   const loadWorkspaces = React.useCallback(async () => {
     if (!teamId || !agentId) return
-    setLoading(true)
+    const isInitial = workspacesRef.current.length === 0
+    if (isInitial) setLoading(true)
     try {
       const ws = await listDaemonWorkspaces(teamId, agentId)
       setWorkspaces(ws.filter((w) => !w.archived))
       void syncSessionWorkspaces(teamId).catch(() => {})
     } finally {
-      setLoading(false)
+      if (isInitial) setLoading(false)
     }
   }, [teamId, agentId])
 
   React.useEffect(() => {
-    if (sheetOpen && !daemonOffline) void loadWorkspaces()
-  }, [sheetOpen, daemonOffline, loadWorkspaces])
+    if (daemonOffline) return
+    void loadWorkspaces()
+  }, [daemonOffline, loadWorkspaces])
 
   const handleNewWorkspace = async () => {
     if (!teamId || !agentId || creating || daemonOffline) return

--- a/packages/app/src/components/sidebar/LocalDaemonRow.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonRow.tsx
@@ -432,27 +432,38 @@ export function LocalDaemonRow({
   const [retrying, setRetrying] = React.useState(false)
   const workspacesRef = React.useRef(workspaces)
   workspacesRef.current = workspaces
+  const loadGenerationRef = React.useRef(0)
 
   // Prefetch as soon as the card mounts — don't wait for sheet expand. Opening
   // the sheet mid-fetch used to mutate content height during the 300ms
   // grid-rows animation and felt like dropped frames.
-  const loadWorkspaces = React.useCallback(async () => {
+  const loadWorkspaces = React.useCallback(async (opts?: { forceLoading?: boolean }) => {
     if (!teamId || !agentId) return
-    const isInitial = workspacesRef.current.length === 0
-    if (isInitial) setLoading(true)
+    const generation = loadGenerationRef.current
+    const showLoading = opts?.forceLoading ?? workspacesRef.current.length === 0
+    if (showLoading) setLoading(true)
     try {
       const ws = await listDaemonWorkspaces(teamId, agentId)
+      if (generation !== loadGenerationRef.current) return
       setWorkspaces(ws.filter((w) => !w.archived))
       void syncSessionWorkspaces(teamId).catch(() => {})
     } finally {
-      if (isInitial) setLoading(false)
+      if (showLoading && generation === loadGenerationRef.current) {
+        setLoading(false)
+      }
     }
   }, [teamId, agentId])
 
   React.useEffect(() => {
     if (daemonOffline) return
-    void loadWorkspaces()
-  }, [daemonOffline, loadWorkspaces])
+    if (!teamId || !agentId) {
+      setWorkspaces([])
+      return
+    }
+    loadGenerationRef.current += 1
+    setWorkspaces([])
+    void loadWorkspaces({ forceLoading: true })
+  }, [daemonOffline, teamId, agentId, loadWorkspaces])
 
   const handleNewWorkspace = async () => {
     if (!teamId || !agentId || creating || daemonOffline) return

--- a/packages/app/src/components/sidebar/sidebar-interactive-cursor.ts
+++ b/packages/app/src/components/sidebar/sidebar-interactive-cursor.ts
@@ -1,0 +1,9 @@
+/** Pointer cursor for interactive controls inside sidebar surfaces. */
+export const SIDEBAR_INTERACTIVE_CURSOR = [
+  '[&_button:not(:disabled)]:cursor-pointer',
+  '[&_[data-slot=button]:not(:disabled)]:cursor-pointer',
+  '[&_a[href]]:cursor-pointer',
+  '[&_[role=menuitem]:not([data-disabled])]:!cursor-pointer',
+  '[&_[role=option]:not([data-disabled])]:!cursor-pointer',
+  '[&_[role=button]:not([aria-disabled=true])]:cursor-pointer',
+].join(' ')


### PR DESCRIPTION
## Summary

- **daemon**: restore image attachment delivery to agent runtimes. The opencode serve migration (a447972e) dropped the old ACP adapter's `build_attachment_block`, so Supabase HTTPS URLs went straight into opencode `File` parts — which require base64 data URLs — failing every image prompt with `ImageInvalidDataUrlError`. New `runtime/prompt_attachments` module downloads (30s timeout + `error_for_status`), downscales oversized images (#710), and inlines data URLs for opencode/pi/claude/cursor. Resolution runs before the turn is marked active so downloads don't consume the stuck-turn watchdog budget; failed fetches fall back to the original link.
- **sidebar**: preload daemon workspaces on mount so the local-daemon sheet's 300ms grid-rows expand animation no longer janks from mid-animation list loading.
- **sidebar**: consolidate the interactive `cursor-pointer` rule into `SIDEBAR_INTERACTIVE_CURSOR`, applied across sidebar, second column, and narrow session sheet.
- **config**: point dev `cloudApiUrl` at `api.teamclaw-dev.ucar.cc` (the documented endpoint).

## Test plan

- [x] `cargo check --bin amuxd` passes
- [x] `prompt_attachments` unit tests pass (path/ext parsing, data-URL format, message append)
- [x] 3 rounds of Bugbot review on the daemon change (timeout, error-status, watchdog interaction fixed; final round clean)
- [ ] Manual: restart amuxd, paste an image → @agent → agent describes the image (opencode)
- [ ] Manual: expand/collapse the local daemon card — animation smooth on cold start

Made with [Cursor](https://cursor.com)