### PR TITLE
fix(fc): declare POSTGRES_* on both deploy targets so the LiteLLM fallback can run

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -192,6 +192,9 @@ OPENCODE_PROVIDER_NAME=Self-host LLM
 # SITE_URL) from SUPABASE_DOMAIN / FC_DOMAIN above — leave them blank here.
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
+# Superuser the FC container uses for the LiteLLM-usage fallback when
+# DATABASE_URL is blank. Matches the compose Postgres service.
+POSTGRES_USERNAME=postgres
 POSTGRES_DB=postgres
 JWT_EXPIRY=3600
 PGRST_DB_SCHEMAS=public,storage,graphql_public,amux

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -236,6 +236,14 @@ services:
       MQTT_USE_TLS: "false"
       CRON_TRIGGER_SECRET: "${CRON_TRIGGER_SECRET}"
       DATABASE_URL: "${DATABASE_URL:-}"
+      # Parts-based fallback for the same Postgres, mirroring s.yaml.
+      # resolveLiteLlmConnString prefers DATABASE_URL and falls back to these;
+      # declared on both targets so LiteLLM usage degrades instead of 503-ing
+      # when DATABASE_URL is blank. Defaults match the compose Postgres service.
+      POSTGRES_HOST: "${POSTGRES_HOST:-db}"
+      POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
+      POSTGRES_USERNAME: "${POSTGRES_USERNAME:-postgres}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
       ACCESS_KEY_ID: "${ACCESS_KEY_ID:-}"
       ACCESS_KEY_SECRET: "${ACCESS_KEY_SECRET:-}"
       ROLE_ARN: "${ROLE_ARN:-}"

--- a/services/fc/.env.example
+++ b/services/fc/.env.example
@@ -12,8 +12,13 @@ SUPABASE_URL=
 SUPABASE_PUBLIC_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_ANON_KEY=
-# DATABASE_URL / POSTGRES_* for the postgres backend
+# Primary Postgres connection. DATABASE_URL wins; the POSTGRES_* parts are the
+# fallback resolveLiteLlmConnString uses for LiteLLM usage when it is blank.
 DATABASE_URL=
+POSTGRES_HOST=
+POSTGRES_PORT=
+POSTGRES_USERNAME=
+POSTGRES_PASSWORD=
 
 # --- OSS / object storage ---
 ACCESS_KEY_ID=

--- a/services/fc/node_modules
+++ b/services/fc/node_modules
@@ -1,0 +1,1 @@
+/Volumes/openbeta/workspace/teamclaw/services/fc/node_modules

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -96,6 +96,15 @@ resources:
         # Hono's own CORS middleware is skipped — prevents duplicate headers.
         CORS_HANDLED_BY_PROXY: ${env('CORS_HANDLED_BY_PROXY', '')}
         DATABASE_URL: ${env('DATABASE_URL', '')}
+        # Parts-based fallback for the same primary Postgres connection.
+        # `resolveLiteLlmConnString` (lib/litellm-usage.ts) prefers DATABASE_URL
+        # and falls back to these. Without them declared here that fallback was
+        # unreachable in production: LiteLLM usage 503s the moment DATABASE_URL
+        # is blank instead of degrading to the parts it already knows how to use.
+        POSTGRES_HOST: ${env('POSTGRES_HOST', '')}
+        POSTGRES_PORT: ${env('POSTGRES_PORT', '')}
+        POSTGRES_USERNAME: ${env('POSTGRES_USERNAME', '')}
+        POSTGRES_PASSWORD: ${env('POSTGRES_PASSWORD', '')}
         BACKEND_KIND: ${env('BACKEND_KIND', 'supabase')}
         # Phone login (partner-aligned). DEFAULT_ORG_ID = the default tenant new
         # users join; PHONE_EMAIL_DOMAIN = domain of the synthetic auth email


### PR DESCRIPTION
> Rebased and narrowed. The Alibaba infra-id extraction and the `serverSyncedHint` copy fix that were originally in this PR both landed on main in the meantime (#669 and friends), with identical variable names — so this is now only the part that is still missing.

## The bug

`resolveLiteLlmConnString` (`services/fc/src/lib/litellm-usage.ts:163-181`) resolves the LiteLLM database connection like this:

```ts
if (env.LITELLM_DB_URL) return env.LITELLM_DB_URL;
if (env.DATABASE_URL)   { /* swap db name */ }
const host = env.POSTGRES_HOST;
if (host) { /* build from POSTGRES_* parts */ }
throw new ApiError(503, "litellm_usage_unavailable", ...);
```

`POSTGRES_HOST` / `POSTGRES_PORT` / `POSTGRES_USERNAME` / `POSTGRES_PASSWORD` are declared by **neither** deploy target:

- `services/fc/s.yaml` — absent from `environmentVariables`
- `deploy/self-host/docker-compose.yml` — the `fc` service carries only `DATABASE_URL` (the other `POSTGRES_*` references in that file belong to `migrate`, `litellm-init` and the Postgres service itself)

So the third branch is unreachable in production. If `DATABASE_URL` is ever blank, LiteLLM usage 503s instead of degrading to the parts it already knows how to assemble.

Live belayo confirms it — the env file defines `POSTGRES_HOST`, but reading the function back shows it unset, because `s.yaml` never forwarded it.

## The fix

Declare the four on both targets. That also keeps the compose `environment:` allowlist at parity with `s.yaml`, which `deploy-env-parity.test.ts` enforces. Compose defaults match its own Postgres service (`db` / `5432` / `postgres`).

`POSTGRES_USERNAME` is new to the self-host `.env.example` because compose now interpolates it, and a test requires every interpolated variable to be documented there.

Note this is a declaration-only change: nothing reads the parts while `DATABASE_URL` is set, which it is on every current deployment. It removes a latent 503, it does not change behaviour today.

## Testing

- `deploy-env-parity` + `litellm-usage` + `config-route`: **33/33 pass**
- `tsc -p tsconfig.json` (the config the image build uses): clean
- `docker compose config` parses. It also reports a pre-existing `invalid spec: :/var/run/docker.sock:ro` when run locally without the box's `.env` — verified identical on pristine `main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)