### PR TITLE
fix(app): draft-first new session — create on first send

### DIFF
--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -45,7 +45,7 @@ import { Button } from "@/components/ui/button";
 import { LocalAgentWelcomeEmptyState } from "./LocalAgentWelcomeEmptyState";
 import { SessionEmptyThreadState } from "./SessionEmptyThreadState";
 import { createQuickSession, describeQuickSessionFailure, type QuickSessionFailureReason } from "@/lib/create-quick-session";
-import { createQuickEmptySession } from "@/lib/quick-empty-session";
+import { promoteCreatedSessionToUi } from "@/lib/promote-created-session";
 import { isSoloAgentSession } from "@/lib/session-empty-thread-starters";
 
 import type { Message } from "@/stores/session";
@@ -418,10 +418,26 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
   // engagedAgents is per-session: each @-mentioned agent shows as a pill in
   // the prompt-input toolbar. Switching away from a session and back
   // restores its engaged set rather than carrying one across sessions.
-  // For brand-new chats (activeSessionId === null), the list is empty.
-  const engagedAgents = useEngagedAgentStore((s) =>
+  // Draft-first chats (no session yet) surface the preselected agent as a
+  // synthetic pill so the composer matches what first-send will create.
+  const sessionEngagedAgents = useEngagedAgentStore((s) =>
     activeSessionId ? s.bySession[activeSessionId] ?? EMPTY_AGENTS : EMPTY_AGENTS,
   );
+  const engagedAgents = React.useMemo(() => {
+    if (sessionEngagedAgents.length > 0) return sessionEngagedAgents;
+    if (
+      !activeSessionId &&
+      draftPreselectedActor?.kind === 'agent'
+    ) {
+      return [
+        {
+          id: draftPreselectedActor.id,
+          displayName: draftPreselectedActor.displayName,
+        },
+      ];
+    }
+    return EMPTY_AGENTS;
+  }, [activeSessionId, draftPreselectedActor, sessionEngagedAgents]);
   const engagedAgentIds = React.useMemo(
     () => engagedAgents.map((a) => a.id),
     [engagedAgents],
@@ -1638,20 +1654,36 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
                 agents: [],
                 members: [{ id: draftPreselectedActor.id, displayName: draftPreselectedActor.displayName }],
               };
+        const draftActorId = draftPreselectedActor.id;
+        // Keep draftPreselectedActor until the new session is active —
+        // clearing it first flashes LocalAgentWelcomeEmptyState ("… is
+        // waiting on this device") for the duration of createSessionShell.
+        setWelcomeSessionStarting(true);
         try {
-          localStorage.removeItem(`teamclaw-actor-draft:${draftPreselectedActor.id}`);
-        } catch {
-          /* localStorage disabled */
+          const created = await createSessionAndSendFirst(message, picks);
+          if (created) {
+            try {
+              localStorage.removeItem(`teamclaw-actor-draft:${draftActorId}`);
+            } catch {
+              /* localStorage disabled */
+            }
+            useUIStore.getState().clearActorDraft();
+          }
+        } finally {
+          setWelcomeSessionStarting(false);
         }
-        useUIStore.getState().clearActorDraft();
-        await createSessionAndSendFirst(message, picks);
         return;
       }
       if (welcomeQuickChatAgent) {
-        await createSessionAndSendFirst(message, {
-          agents: [{ id: welcomeQuickChatAgent.id, displayName: welcomeQuickChatAgent.displayName }],
-          members: [],
-        });
+        setWelcomeSessionStarting(true);
+        try {
+          await createSessionAndSendFirst(message, {
+            agents: [{ id: welcomeQuickChatAgent.id, displayName: welcomeQuickChatAgent.displayName }],
+            members: [],
+          });
+        } finally {
+          setWelcomeSessionStarting(false);
+        }
         return;
       }
       useUIStore.getState().openNewSessionDialog(message.text ?? null);
@@ -1671,7 +1703,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
       members: { id: string; displayName: string }[]
       agents: { id: string; displayName: string }[]
     },
-  ) => {
+  ): Promise<boolean> => {
     const teamIdForSend = sheetTeamId;
     sessionFlowLog("session_create.begin", {
       teamId: teamIdForSend,
@@ -1682,7 +1714,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     if (!teamIdForSend) {
       sessionFlowLog("session_create.missing_team", {}, "warn");
       console.error('[ChatPanel] no team_id available; cannot create session');
-      return;
+      return false;
     }
 
     const authSession = useAuthStore.getState().session;
@@ -1691,7 +1723,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
         teamId: teamIdForSend,
       }, "warn");
       console.error('[ChatPanel] no auth session');
-      return;
+      return false;
     }
     const myActorId = await resolveCurrentMemberActorId(
       teamIdForSend,
@@ -1709,7 +1741,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
       console.error('[ChatPanel] no actor record for user in team', teamIdForSend);
       const { toast } = await import('sonner');
       toast.error(t('chat.newSessionPicker.createError', 'Failed to create session'));
-      return;
+      return false;
     }
 
     // Initial title: "ActorName (HH:mm)" when we have exactly one
@@ -1760,39 +1792,21 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
         useUIStore.getState().clearDraftIdeaId();
       }
 
-      // Subscribe to the new session's live topic before publishing the
-      // first message — otherwise the daemon's acp.event + message.created
-      // can arrive before the reactive per-rows subscribe catches up.
-      sessionFlowLog("session_create.subscribe_live.begin", {
+      // Optimistic list row + switch — do not await a full session-list
+      // refetch before the user can see the new chat / send completes.
+      sessionFlowLog("session_create.promote.begin", {
         teamId: teamIdForSend,
         sessionId,
       });
-      await ensureSessionLiveSubscribed(teamIdForSend, sessionId).catch((e) => {
-        console.warn('[ChatPanel] live subscribe failed (non-fatal):', e);
-      });
-      sessionFlowLog("session_create.subscribe_live.ok", {
+      await promoteCreatedSessionToUi({
+        sessionId,
         teamId: teamIdForSend,
-        sessionId,
+        title: titleSource,
+        ideaId: draftIdeaId,
+        lastMessagePreview: (firstMessage.text ?? '').trim().slice(0, 120) || null,
       });
-
-      // Refresh session-list-store so the new row appears in the sidebar
-      // and sendIntoSession can find it by id.
-      sessionFlowLog("session_create.session_list_reload.begin", {
+      sessionFlowLog("session_create.promote.ok", {
         teamId: teamIdForSend,
-        sessionId,
-      });
-      await useSessionListStore.getState().load();
-      sessionFlowLog("session_create.session_list_reload.ok", {
-        teamId: teamIdForSend,
-        sessionId,
-        rowCount: useSessionListStore.getState().rows.length,
-      });
-      useSessionStore.getState().addHighlightedSession(sessionId);
-      sessionFlowLog("session_create.switch.begin", {
-        sessionId,
-      });
-      await useUIStore.getState().switchToSession(sessionId);
-      sessionFlowLog("session_create.switch.ok", {
         sessionId,
       });
 
@@ -1831,6 +1845,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
           agentActorIds: agentIds,
         });
       }
+      return true;
     } catch (e) {
       sessionFlowError("session_create.failed", e, {
         teamId: teamIdForSend,
@@ -1838,6 +1853,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
       console.error('[ChatPanel] session creation failed:', e);
       const { toast } = await import('sonner');
       toast.error(t('chat.newSessionPicker.createError', 'Failed to create session'));
+      return false;
     }
   };
 
@@ -1879,38 +1895,6 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
       setWelcomeSessionStarting(false);
     }
   }, [welcomeQuickChatAgent, welcomeSessionStarting]);
-
-  const handleStartDraftSession = React.useCallback(async () => {
-    if (welcomeSessionStarting || !draftPreselectedActor) return;
-    setWelcomeSessionStarting(true);
-    try {
-      const actor = draftPreselectedActor;
-      const created = await createQuickEmptySession({
-        additionalActorIds: [actor.id],
-        titleName: actor.displayName,
-        engagedAgent:
-          actor.kind === 'agent'
-            ? { id: actor.id, displayName: actor.displayName }
-            : null,
-        agentActorIdsForRuntime: actor.kind === 'agent' ? [actor.id] : [],
-        runtimeReason: 'actor_draft_start',
-      });
-      if (!created) {
-        toast.error(t('chat.newSessionPicker.createError', 'Failed to create session'));
-        return;
-      }
-      try {
-        localStorage.removeItem(`teamclaw-actor-draft:${actor.id}`);
-      } catch {
-        /* localStorage disabled */
-      }
-    } catch (e) {
-      console.error('[ChatPanel] actor draft start failed', e);
-      toast.error(t('chat.newSessionPicker.createError', 'Failed to create session'));
-    } finally {
-      setWelcomeSessionStarting(false);
-    }
-  }, [draftPreselectedActor, t, welcomeSessionStarting]);
 
   const handleOpenAgentSettings = React.useCallback(() => {
     useUIStore.getState().openSettings('daemonGeneral');
@@ -1968,27 +1952,20 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
             )}
           >
             {draftPreselectedActor.kind === 'agent'
-              ? t('chat.draftWithAgentHint', '点击下方开始与该 Agent 的新会话')
-              : t('chat.draftWithMemberHint', '点击下方开始与该成员的新会话')}
+              ? t('chat.draftWithAgentHint', '在下方输入消息，发送后创建与该 Agent 的会话')
+              : t('chat.draftWithMemberHint', '在下方输入消息，发送后创建与该成员的会话')}
           </p>
-          <Button
-            type="button"
-            size="sm"
-            className="mt-4 bg-coral text-white hover:bg-coral/90"
-            disabled={welcomeSessionStarting}
-            onClick={() => void handleStartDraftSession()}
-          >
-            {welcomeSessionStarting ? (
-              <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-            ) : null}
-            {t('chat.draftStartConversation', '开始对话')}
-          </Button>
           <SessionContinueBanner
             actorId={draftPreselectedActor.id}
             actorName={draftPreselectedActor.displayName}
           />
         </div>
       );
+    }
+    // Creating the first session from welcome/draft — keep the thread blank
+    // instead of flashing the "… is waiting on this device" welcome card.
+    if (welcomeSessionStarting) {
+      return null;
     }
     if (!compact) {
       return (
@@ -2024,7 +2001,6 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     welcomeQuickChatAgent,
     welcomeQuickChatLoading,
     welcomeSessionStarting,
-    handleStartDraftSession,
     handleStartLocalAgentSession,
     handleLocalAgentQuickAction,
     handleOpenAgentSettings,
@@ -2301,7 +2277,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
             {t("chat.restoreArchivedHint", "Restore this session to continue chatting")}
           </div>
         </div>
-      ) : !isViewingChild && activeSessionId && (
+      ) : !isViewingChild ? (
         activeInputQuestion ? (
           <QuestionInputDock
             compact={compact}
@@ -2374,7 +2350,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
           />
           </>
         )
-      )}
+      ) : null}
 
       {terminalOpen && workspacePath && (
         <TerminalPanel

--- a/packages/app/src/components/chat/NewSessionDialog.tsx
+++ b/packages/app/src/components/chat/NewSessionDialog.tsx
@@ -8,14 +8,12 @@ import { Button } from '@/components/ui/button'
 import { useUIStore } from '@/stores/ui'
 import { useAuthStore } from '@/stores/auth-store'
 import { useCurrentTeamStore } from '@/stores/current-team'
-import { useSessionListStore } from '@/stores/session-list-store'
-import { useSessionStore } from '@/stores/session'
 import { resolveCurrentMemberActorId } from '@/lib/current-actor'
 import { syncActorsForTeam } from '@/lib/sync/actor-sync'
 import { useActorDirectory } from '@/stores/actor-directory-store'
 import { actorAvatarColor } from '@/lib/actor-color'
 import { createSessionWithFirstMessage } from '@/lib/session-create'
-import { ensureSessionLiveSubscribed } from '@/lib/session-live-subscriptions'
+import { promoteCreatedSessionToUi } from '@/lib/promote-created-session'
 import { useEngagedAgentStore } from '@/stores/engaged-agent-store'
 import { cn } from '@/lib/utils'
 import { useMemberPreferencesStore } from '@/stores/member-preferences-store'
@@ -144,15 +142,13 @@ export function NewSessionDialog() {
       }
       const additionalActorIds = Array.from(picked)
       const agentActorIds = pickedActors.filter((p) => p.actor_type === 'agent').map((p) => p.id)
+      const trimmed = message.trim()
       const { sessionId } = await createSessionWithFirstMessage({
         teamId,
         creatorActorId,
         additionalActorIds,
         agentActorIds,
-        messageText: message,
-      })
-      await ensureSessionLiveSubscribed(teamId, sessionId).catch((e) => {
-        console.warn('[NewSessionDialog] live subscribe failed (non-fatal):', e)
+        messageText: trimmed,
       })
       const agentPicks = pickedActors.filter((p) => p.actor_type === 'agent')
       if (agentPicks.length > 0) {
@@ -164,9 +160,12 @@ export function NewSessionDialog() {
           })),
         )
       }
-      await useSessionListStore.getState().load()
-      useSessionStore.getState().addHighlightedSession(sessionId)
-      await useUIStore.getState().switchToSession(sessionId)
+      await promoteCreatedSessionToUi({
+        sessionId,
+        teamId,
+        title: trimmed.split('\n')[0]?.trim().slice(0, 80) || 'New chat',
+        lastMessagePreview: trimmed.slice(0, 120) || null,
+      })
       closeDialog()
     } catch (e) {
       console.error('[NewSessionDialog] create failed:', e)

--- a/packages/app/src/components/chat/__tests__/NewSessionDialog.test.tsx
+++ b/packages/app/src/components/chat/__tests__/NewSessionDialog.test.tsx
@@ -6,10 +6,12 @@ const mocks = vi.hoisted(() => ({
   closeNewSessionDialog: vi.fn(),
   switchToSession: vi.fn(),
   loadSessions: vi.fn(),
+  upsertRows: vi.fn(),
   addHighlightedSession: vi.fn(),
   createSessionWithFirstMessage: vi.fn(),
   ensureSessionLiveSubscribed: vi.fn(),
   listActorDirectory: vi.fn(),
+  requestComposerFocus: vi.fn(),
 }))
 
 vi.mock('react-i18next', () => ({
@@ -43,6 +45,7 @@ vi.mock('@/stores/ui', () => ({
       getState: () => ({
         closeNewSessionDialog: mocks.closeNewSessionDialog,
         switchToSession: mocks.switchToSession,
+        requestComposerFocus: mocks.requestComposerFocus,
       }),
     },
   ),
@@ -78,7 +81,10 @@ vi.mock('@/stores/current-team', () => ({
 
 vi.mock('@/stores/session-list-store', () => ({
   useSessionListStore: {
-    getState: () => ({ load: mocks.loadSessions }),
+    getState: () => ({
+      load: mocks.loadSessions,
+      upsertRows: mocks.upsertRows,
+    }),
   },
 }))
 

--- a/packages/app/src/components/responsive/__tests__/NarrowChatHeader.test.tsx
+++ b/packages/app/src/components/responsive/__tests__/NarrowChatHeader.test.tsx
@@ -45,7 +45,7 @@ describe('NarrowChatHeader', () => {
     useUIStore.setState({ embedMode: true, currentView: 'chat' })
     useSessionSelectionStore.setState({ activeSessionId: null })
     createQuickSession.mockReset()
-    createQuickSession.mockResolvedValue({ ok: true, sessionId: 'sess-new', agentDisplayName: 'MACPRO' })
+    createQuickSession.mockResolvedValue({ ok: true, agentDisplayName: 'MACPRO' })
   })
 
   it('hides the new chat button on the welcome page', () => {

--- a/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
@@ -109,7 +109,7 @@ describe('SessionListColumn', () => {
     setPinnedStorage({ 'team-1': ['s1'] })
     useUIStore.setState({ sidebarFilter: { kind: 'all' }, embedMode: false })
     createQuickSession.mockReset()
-    createQuickSession.mockResolvedValue({ ok: true, sessionId: 'sess-new', agentDisplayName: 'MACPRO' })
+    createQuickSession.mockResolvedValue({ ok: true, agentDisplayName: 'MACPRO' })
     useSessionListStore.setState({
       rows: [
         mkRow({ id: 's1', title: 'Alpha', ideaId: null }),

--- a/packages/app/src/lib/__tests__/create-quick-session.test.ts
+++ b/packages/app/src/lib/__tests__/create-quick-session.test.ts
@@ -4,7 +4,8 @@ import { createQuickSession } from '../create-quick-session'
 const mocks = vi.hoisted(() => ({
   teamId: 'team-1' as string | null,
   target: null as { agentId: string; displayName: string; source: 'local' } | null,
-  created: { sessionId: 'sess-1' } as { sessionId: string } | null,
+  enterActorDraft: vi.fn(),
+  requestComposerFocus: vi.fn(),
 }))
 
 vi.mock('@/stores/current-team', () => ({
@@ -19,12 +20,17 @@ vi.mock('@/stores/workspace', () => ({
   },
 }))
 
-vi.mock('../resolve-quick-chat-target', () => ({
-  resolveQuickChatTarget: vi.fn(async () => mocks.target),
+vi.mock('@/stores/ui', () => ({
+  useUIStore: {
+    getState: () => ({
+      enterActorDraft: mocks.enterActorDraft,
+      requestComposerFocus: mocks.requestComposerFocus,
+    }),
+  },
 }))
 
-vi.mock('../quick-empty-session', () => ({
-  createQuickEmptySession: vi.fn(async () => mocks.created),
+vi.mock('../resolve-quick-chat-target', () => ({
+  resolveQuickChatTarget: vi.fn(async () => mocks.target),
 }))
 
 describe('createQuickSession', () => {
@@ -32,7 +38,6 @@ describe('createQuickSession', () => {
     vi.clearAllMocks()
     mocks.teamId = 'team-1'
     mocks.target = { agentId: 'a1', displayName: 'Bot', source: 'local' }
-    mocks.created = { sessionId: 'sess-1' }
   })
 
   it('fails with no_team when no team', async () => {
@@ -45,37 +50,37 @@ describe('createQuickSession', () => {
     expect(await createQuickSession()).toEqual({ ok: false, reason: 'no_agent' })
   })
 
-  it('fails with no_actor when createQuickEmptySession returns null', async () => {
-    mocks.created = null
-    expect(await createQuickSession()).toEqual({ ok: false, reason: 'no_actor' })
-  })
-
-  it('fails with server_error when createQuickEmptySession throws', async () => {
-    const { createQuickEmptySession } = await import('../quick-empty-session')
+  it('fails with server_error when resolver throws', async () => {
+    const { resolveQuickChatTarget } = await import('../resolve-quick-chat-target')
     const boom = new Error('backend down')
-    vi.mocked(createQuickEmptySession).mockRejectedValueOnce(boom)
+    vi.mocked(resolveQuickChatTarget).mockRejectedValueOnce(boom)
     const result = await createQuickSession()
     expect(result).toEqual({ ok: false, reason: 'server_error', error: boom })
   })
 
-  it('creates session with resolved target', async () => {
-    const { createQuickEmptySession } = await import('../quick-empty-session')
+  it('enters actor draft without creating a session', async () => {
+    const { resolveQuickChatTarget } = await import('../resolve-quick-chat-target')
     const result = await createQuickSession()
-    expect(result).toEqual({ ok: true, sessionId: 'sess-1', agentDisplayName: 'Bot' })
-    expect(createQuickEmptySession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        additionalActorIds: ['a1'],
-        titleName: 'Bot',
-        runtimeReason: 'quick_session_local',
-      }),
-    )
+    expect(result).toEqual({ ok: true, agentDisplayName: 'Bot' })
+    expect(mocks.enterActorDraft).toHaveBeenCalledWith({
+      id: 'a1',
+      displayName: 'Bot',
+      kind: 'agent',
+    })
+    expect(mocks.requestComposerFocus).toHaveBeenCalled()
+    expect(resolveQuickChatTarget).toHaveBeenCalled()
   })
 
   it('uses target override without calling resolver again', async () => {
     const { resolveQuickChatTarget } = await import('../resolve-quick-chat-target')
     const override = { agentId: 'a2', displayName: 'Cloud', source: 'team_default' as const }
     const result = await createQuickSession(override)
-    expect(result).toEqual({ ok: true, sessionId: 'sess-1', agentDisplayName: 'Cloud' })
+    expect(result).toEqual({ ok: true, agentDisplayName: 'Cloud' })
     expect(resolveQuickChatTarget).not.toHaveBeenCalled()
+    expect(mocks.enterActorDraft).toHaveBeenCalledWith({
+      id: 'a2',
+      displayName: 'Cloud',
+      kind: 'agent',
+    })
   })
 })

--- a/packages/app/src/lib/__tests__/promote-created-session.test.ts
+++ b/packages/app/src/lib/__tests__/promote-created-session.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  upsertRows: vi.fn(),
+  load: vi.fn().mockResolvedValue(undefined),
+  addHighlightedSession: vi.fn(),
+  switchToSession: vi.fn().mockResolvedValue(undefined),
+  requestComposerFocus: vi.fn(),
+  ensureSessionLiveSubscribed: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/stores/session-list-store', () => ({
+  useSessionListStore: {
+    getState: () => ({
+      upsertRows: mocks.upsertRows,
+      load: mocks.load,
+    }),
+  },
+}))
+
+vi.mock('@/stores/session', () => ({
+  useSessionStore: {
+    getState: () => ({ addHighlightedSession: mocks.addHighlightedSession }),
+  },
+}))
+
+vi.mock('@/stores/ui', () => ({
+  useUIStore: {
+    getState: () => ({
+      switchToSession: mocks.switchToSession,
+      requestComposerFocus: mocks.requestComposerFocus,
+    }),
+  },
+}))
+
+vi.mock('@/lib/session-live-subscriptions', () => ({
+  ensureSessionLiveSubscribed: (...a: unknown[]) => mocks.ensureSessionLiveSubscribed(...a),
+}))
+
+describe('promoteCreatedSessionToUi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('upserts the row, switches immediately, and reconciles list in background', async () => {
+    const { promoteCreatedSessionToUi } = await import('../promote-created-session')
+    await promoteCreatedSessionToUi({
+      sessionId: 'sess-1',
+      teamId: 'team-1',
+      title: 'Hello',
+      lastMessagePreview: 'Hello world',
+      focusComposer: true,
+    })
+
+    expect(mocks.upsertRows).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'sess-1',
+        team_id: 'team-1',
+        title: 'Hello',
+        last_message_preview: 'Hello world',
+        mode: 'collab',
+      }),
+    ])
+    expect(mocks.addHighlightedSession).toHaveBeenCalledWith('sess-1')
+    expect(mocks.switchToSession).toHaveBeenCalledWith('sess-1')
+    expect(mocks.requestComposerFocus).toHaveBeenCalled()
+    expect(mocks.ensureSessionLiveSubscribed).toHaveBeenCalledWith('team-1', 'sess-1')
+    expect(mocks.load).toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/lib/__tests__/quick-daemon-session.test.ts
+++ b/packages/app/src/lib/__tests__/quick-daemon-session.test.ts
@@ -2,74 +2,36 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   getLocalDaemonAgent: vi.fn(),
-  resolveCurrentMemberActorId: vi.fn(),
-  createSessionShell: vi.fn(),
-  ensureSessionLiveSubscribed: vi.fn(),
-  sessionListLoad: vi.fn(),
-  switchToSession: vi.fn(),
+  enterActorDraft: vi.fn(),
   requestComposerFocus: vi.fn(),
-  setAgents: vi.fn(),
-  addHighlightedSession: vi.fn(),
-  clearDraftIdeaId: vi.fn(),
-  draftIdeaId: null as string | null,
 }))
 
 vi.mock('@/lib/daemon-agent-admin', () => ({
   getLocalDaemonAgent: (...a: unknown[]) => mocks.getLocalDaemonAgent(...a),
 }))
-vi.mock('@/lib/current-actor', () => ({
-  resolveCurrentMemberActorId: (...a: unknown[]) => mocks.resolveCurrentMemberActorId(...a),
-}))
-vi.mock('@/lib/session-create', () => ({
-  createSessionShell: (...a: unknown[]) => mocks.createSessionShell(...a),
-}))
-vi.mock('@/lib/session-live-subscriptions', () => ({
-  ensureSessionLiveSubscribed: (...a: unknown[]) => mocks.ensureSessionLiveSubscribed(...a),
-}))
-vi.mock('@/stores/session-list-store', () => ({
-  useSessionListStore: { getState: () => ({ load: mocks.sessionListLoad }) },
-}))
+
 vi.mock('@/stores/ui', () => ({
   useUIStore: {
     getState: () => ({
-      switchToSession: mocks.switchToSession,
+      enterActorDraft: mocks.enterActorDraft,
       requestComposerFocus: mocks.requestComposerFocus,
-      draftIdeaId: mocks.draftIdeaId,
-      clearDraftIdeaId: mocks.clearDraftIdeaId,
     }),
   },
 }))
-vi.mock('@/stores/session', () => ({
-  useSessionStore: { getState: () => ({ addHighlightedSession: mocks.addHighlightedSession }) },
-}))
-vi.mock('@/stores/engaged-agent-store', () => ({
-  useEngagedAgentStore: { getState: () => ({ setAgents: mocks.setAgents }) },
-}))
-vi.mock('@/stores/auth-store', () => ({
-  useAuthStore: { getState: () => ({ session: { user: { id: 'user-1' } } }) },
-}))
+
 vi.mock('@/stores/current-team', () => ({
   useCurrentTeamStore: {
     getState: () => ({ team: { id: 'team-1' }, currentMember: { id: 'mem-1' } }),
   },
 }))
-vi.mock('@/lib/teamclaw/ensure-agent-runtime', () => ({
-  ensureAgentRuntimesForSession: vi.fn().mockResolvedValue(undefined),
-}))
 
 describe('createQuickDaemonSession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.draftIdeaId = null
     mocks.getLocalDaemonAgent.mockResolvedValue({
       id: 'agent-mac',
       displayName: 'MACPRO AI',
     })
-    mocks.resolveCurrentMemberActorId.mockResolvedValue('actor-me')
-    mocks.createSessionShell.mockResolvedValue({ sessionId: 'sess-new' })
-    mocks.ensureSessionLiveSubscribed.mockResolvedValue(undefined)
-    mocks.sessionListLoad.mockResolvedValue(undefined)
-    mocks.switchToSession.mockResolvedValue(undefined)
   })
 
   it('returns null when no local daemon agent', async () => {
@@ -77,25 +39,18 @@ describe('createQuickDaemonSession', () => {
     const { createQuickDaemonSession } = await import('../quick-daemon-session')
     const result = await createQuickDaemonSession()
     expect(result).toBeNull()
-    expect(mocks.createSessionShell).not.toHaveBeenCalled()
+    expect(mocks.enterActorDraft).not.toHaveBeenCalled()
   })
 
-  it('creates shell with creator + agent and switches session', async () => {
+  it('enters draft with local agent without creating a session', async () => {
     const { createQuickDaemonSession } = await import('../quick-daemon-session')
     const result = await createQuickDaemonSession()
-    expect(result).toEqual({ sessionId: 'sess-new', agentDisplayName: 'MACPRO AI' })
-    expect(mocks.createSessionShell).toHaveBeenCalledWith(
-      expect.objectContaining({
-        teamId: 'team-1',
-        creatorActorId: 'actor-me',
-        additionalActorIds: ['agent-mac'],
-        title: expect.stringMatching(/^MACPRO AI \(\d{2}:\d{2}\)$/),
-      }),
-    )
-    expect(mocks.setAgents).toHaveBeenCalledWith('sess-new', [
-      { id: 'agent-mac', displayName: 'MACPRO AI' },
-    ])
-    expect(mocks.switchToSession).toHaveBeenCalledWith('sess-new')
+    expect(result).toEqual({ agentDisplayName: 'MACPRO AI' })
+    expect(mocks.enterActorDraft).toHaveBeenCalledWith({
+      id: 'agent-mac',
+      displayName: 'MACPRO AI',
+      kind: 'agent',
+    })
     expect(mocks.requestComposerFocus).toHaveBeenCalled()
   })
 })

--- a/packages/app/src/lib/create-quick-session.ts
+++ b/packages/app/src/lib/create-quick-session.ts
@@ -1,59 +1,56 @@
-import { createQuickEmptySession } from '@/lib/quick-empty-session'
 import { resolveQuickChatTarget, type QuickChatTarget } from '@/lib/resolve-quick-chat-target'
 import { useCurrentTeamStore } from '@/stores/current-team'
+import { useUIStore } from '@/stores/ui'
 import { useWorkspaceStore } from '@/stores/workspace'
 
 /**
- * Why a quick session could not be created. Callers branch on this to show the
+ * Why a quick draft could not be opened. Callers branch on this to show the
  * RIGHT message instead of a blanket "agent offline" toast:
  * - `no_team`      — no team selected/joined yet.
  * - `no_agent`     — no target agent resolvable (no local daemon agent, and
  *                    both the member default and team default are unset). This
  *                    is NOT a connectivity problem — guide the user to set a
  *                    default agent.
- * - `no_actor`     — the caller's own member actor id could not be resolved.
- *                    An identity/session problem, surfaced as a real failure.
- * - `server_error` — session creation threw (backend/transport error).
+ * - `no_actor`     — retained for toast mapping compatibility; draft-first
+ *                    no longer hits this path.
+ * - `server_error` — target resolution threw (backend/transport error).
  */
 export type QuickSessionFailureReason = 'no_team' | 'no_agent' | 'no_actor' | 'server_error'
 
 export type QuickSessionOutcome =
-  | { ok: true; sessionId: string; agentDisplayName: string }
+  | { ok: true; agentDisplayName: string }
   | { ok: false; reason: QuickSessionFailureReason; error?: unknown }
 
+/**
+ * Open a local draft chat with the resolved default agent. Does NOT create a
+ * backend session — that happens when the user sends the first message.
+ */
 export async function createQuickSession(
   targetOverride?: QuickChatTarget | null,
 ): Promise<QuickSessionOutcome> {
   const teamId = useCurrentTeamStore.getState().team?.id ?? null
   if (!teamId) return { ok: false, reason: 'no_team' }
 
-  const target =
-    targetOverride ??
-    (await resolveQuickChatTarget(teamId, {
-      workspacePath: useWorkspaceStore.getState().workspacePath,
-    }))
-  if (!target) return { ok: false, reason: 'no_agent' }
-
-  let created: { sessionId: string } | null
+  let target: QuickChatTarget | null
   try {
-    created = await createQuickEmptySession({
-      additionalActorIds: [target.agentId],
-      titleName: target.displayName,
-      engagedAgent: { id: target.agentId, displayName: target.displayName },
-      agentActorIdsForRuntime: [target.agentId],
-      runtimeReason: `quick_session_${target.source}`,
-    })
+    target =
+      targetOverride ??
+      (await resolveQuickChatTarget(teamId, {
+        workspacePath: useWorkspaceStore.getState().workspacePath,
+      }))
   } catch (error) {
-    // createSessionShell throws on backend/transport failures. This is a real
-    // "creation failed" — do NOT mislabel it as "agent offline".
     return { ok: false, reason: 'server_error', error }
   }
+  if (!target) return { ok: false, reason: 'no_agent' }
 
-  // createQuickEmptySession returns null only when the creator's member actor
-  // id can't be resolved (or team/auth is missing) — a distinct identity issue.
-  if (!created) return { ok: false, reason: 'no_actor' }
+  useUIStore.getState().enterActorDraft({
+    id: target.agentId,
+    displayName: target.displayName,
+    kind: 'agent',
+  })
+  useUIStore.getState().requestComposerFocus()
 
-  return { ok: true, sessionId: created.sessionId, agentDisplayName: target.displayName }
+  return { ok: true, agentDisplayName: target.displayName }
 }
 
 /**
@@ -76,17 +73,17 @@ export function describeQuickSessionFailure(
       }
     case 'no_team':
       return {
-        title: t('chat.quickSessionCreateError', '无法创建会话'),
+        title: t('chat.quickSessionCreateError', '无法开始新对话'),
         description: t('chat.quickSessionNoTeamHint', '请先选择或加入一个团队后再试。'),
       }
     case 'no_actor':
     case 'server_error':
     default:
       return {
-        title: t('chat.quickSessionServerError', '创建会话失败'),
+        title: t('chat.quickSessionServerError', '无法开始新对话'),
         description: t(
           'chat.quickSessionServerErrorDesc',
-          '服务器暂时无法创建会话，请稍后重试。',
+          '暂时无法准备新对话，请稍后重试。',
         ),
       }
   }

--- a/packages/app/src/lib/promote-created-session.ts
+++ b/packages/app/src/lib/promote-created-session.ts
@@ -1,0 +1,52 @@
+import { ensureSessionLiveSubscribed } from '@/lib/session-live-subscriptions'
+import { useSessionListStore, type SessionListEntry } from '@/stores/session-list-store'
+import { useSessionStore } from '@/stores/session'
+import { useUIStore } from '@/stores/ui'
+
+export type PromoteCreatedSessionArgs = {
+  sessionId: string
+  teamId: string
+  title: string
+  ideaId?: string | null
+  /** Optional preview when the opening message is already known. */
+  lastMessagePreview?: string | null
+  focusComposer?: boolean
+}
+
+/**
+ * Make a just-created session visible and active without waiting on a full
+ * session-list refetch. MQTT subscribe + list reconcile run in the background.
+ */
+export async function promoteCreatedSessionToUi(
+  args: PromoteCreatedSessionArgs,
+): Promise<void> {
+  const now = new Date().toISOString()
+  const preview = args.lastMessagePreview?.trim() || null
+  const row: SessionListEntry = {
+    id: args.sessionId,
+    title: args.title,
+    team_id: args.teamId,
+    last_message_at: preview ? now : null,
+    last_message_preview: preview,
+    mode: 'collab',
+    idea_id: args.ideaId ?? null,
+    has_unread: false,
+    created_at: now,
+    updated_at: now,
+  }
+
+  useSessionListStore.getState().upsertRows([row])
+  useSessionStore.getState().addHighlightedSession(args.sessionId)
+
+  void ensureSessionLiveSubscribed(args.teamId, args.sessionId).catch((e) => {
+    console.warn('[promote-created-session] live subscribe failed (non-fatal):', e)
+  })
+  void useSessionListStore.getState().load().catch((e) => {
+    console.warn('[promote-created-session] session list reconcile failed (non-fatal):', e)
+  })
+
+  await useUIStore.getState().switchToSession(args.sessionId)
+  if (args.focusComposer) {
+    useUIStore.getState().requestComposerFocus()
+  }
+}

--- a/packages/app/src/lib/quick-daemon-session.ts
+++ b/packages/app/src/lib/quick-daemon-session.ts
@@ -1,15 +1,15 @@
 import { getLocalDaemonAgent } from '@/lib/daemon-agent-admin'
-import { createQuickEmptySession } from '@/lib/quick-empty-session'
 import { useCurrentTeamStore } from '@/stores/current-team'
+import { useUIStore } from '@/stores/ui'
 
 export type QuickDaemonSessionResult = {
-  sessionId: string
   agentDisplayName: string
 }
 
 /**
- * One-click session: current member + local amuxd agent, no opening message.
- * Returns null when team/auth/member/agent prerequisites are missing.
+ * Open a draft chat with the local amuxd agent. Does NOT create a backend
+ * session — that happens on the first outgoing message.
+ * Returns null when team/agent prerequisites are missing.
  */
 export async function createQuickDaemonSession(): Promise<QuickDaemonSessionResult | null> {
   const teamId = useCurrentTeamStore.getState().team?.id ?? null
@@ -19,14 +19,11 @@ export async function createQuickDaemonSession(): Promise<QuickDaemonSessionResu
   if (!agent?.id) return null
 
   const displayName = agent.displayName || agent.id
-  const created = await createQuickEmptySession({
-    additionalActorIds: [agent.id],
-    titleName: displayName,
-    engagedAgent: { id: agent.id, displayName },
-    agentActorIdsForRuntime: [agent.id],
-    runtimeReason: 'quick_daemon_session',
+  useUIStore.getState().enterActorDraft({
+    id: agent.id,
+    displayName,
+    kind: 'agent',
   })
-
-  if (!created) return null
-  return { sessionId: created.sessionId, agentDisplayName: displayName }
+  useUIStore.getState().requestComposerFocus()
+  return { agentDisplayName: displayName }
 }

--- a/packages/app/src/lib/quick-empty-session.ts
+++ b/packages/app/src/lib/quick-empty-session.ts
@@ -1,88 +1,12 @@
-import { resolveCurrentMemberActorId } from '@/lib/current-actor'
-import { createSessionShell } from '@/lib/session-create'
-import { ensureSessionLiveSubscribed } from '@/lib/session-live-subscriptions'
-import { markSessionNeedsAutoTitle } from '@/lib/session-auto-title'
-import { useAuthStore } from '@/stores/auth-store'
-import { useCurrentTeamStore } from '@/stores/current-team'
-import { useEngagedAgentStore } from '@/stores/engaged-agent-store'
-import { useSessionListStore } from '@/stores/session-list-store'
-import { useSessionStore } from '@/stores/session'
-import { useUIStore } from '@/stores/ui'
-
-export type QuickEmptySessionInput = {
-  additionalActorIds: string[]
-  /** Session list title: "Name (HH:mm)" when set. */
-  titleName: string
-  /** Auto-engage in composer when exactly one agent participant. */
-  engagedAgent?: { id: string; displayName: string } | null
-  /** Agent actors to spawn runtimes for (fire-and-forget). */
-  agentActorIdsForRuntime?: string[]
-  runtimeReason?: string
-}
+/**
+ * @deprecated Prefer draft-first (`enterActorDraft` / `createQuickSession`).
+ * Empty shell creation before the first message is intentionally avoided —
+ * sessions are created when the user sends.
+ */
 
 export function soloParticipantSessionTitle(displayName: string): string {
   const pad = (n: number) => n.toString().padStart(2, '0')
   const now = new Date()
   const hhmm = `${pad(now.getHours())}:${pad(now.getMinutes())}`
   return `${displayName} (${hhmm})`
-}
-
-/**
- * Create an empty session shell, switch into it, and focus the composer.
- * Shared by quick local-agent chat and actor-draft "开始对话".
- */
-export async function createQuickEmptySession(
-  input: QuickEmptySessionInput,
-): Promise<{ sessionId: string } | null> {
-  const teamId = useCurrentTeamStore.getState().team?.id ?? null
-  const currentMemberId = useCurrentTeamStore.getState().currentMember?.id ?? null
-  const authUserId = useAuthStore.getState().session?.user?.id ?? null
-  if (!teamId || !authUserId) return null
-
-  const creatorActorId = await resolveCurrentMemberActorId(teamId, authUserId, {
-    currentTeamId: teamId,
-    currentMemberId,
-  })
-  if (!creatorActorId) return null
-
-  const draftIdeaId = useUIStore.getState().draftIdeaId ?? null
-  const { sessionId } = await createSessionShell({
-    teamId,
-    creatorActorId,
-    title: soloParticipantSessionTitle(input.titleName),
-    additionalActorIds: input.additionalActorIds,
-    ideaId: draftIdeaId,
-  })
-  markSessionNeedsAutoTitle(sessionId)
-
-  if (draftIdeaId) {
-    useUIStore.getState().clearDraftIdeaId()
-  }
-
-  await ensureSessionLiveSubscribed(teamId, sessionId).catch((e) => {
-    console.warn('[createQuickEmptySession] live subscribe failed (non-fatal):', e)
-  })
-
-  if (input.engagedAgent) {
-    useEngagedAgentStore.getState().setAgents(sessionId, [input.engagedAgent])
-  }
-
-  await useSessionListStore.getState().load()
-  useSessionStore.getState().addHighlightedSession(sessionId)
-  await useUIStore.getState().switchToSession(sessionId)
-  useUIStore.getState().requestComposerFocus()
-
-  const runtimeAgentIds = input.agentActorIdsForRuntime ?? []
-  if (runtimeAgentIds.length > 0) {
-    void import('@/lib/teamclaw/ensure-agent-runtime').then(({ ensureAgentRuntimesForSession }) => {
-      void ensureAgentRuntimesForSession({
-        sessionId,
-        teamId,
-        agentActorIds: runtimeAgentIds,
-        reason: input.runtimeReason ?? 'quick_empty_session',
-      })
-    })
-  }
-
-  return { sessionId }
 }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -270,7 +270,7 @@
       "routingMultiAgent": "Multiple agents — @ a name to choose who replies.",
       "participantCount": "{{count}} participants · Waiting for the first message"
     },
-    "draftStartConversation": "Start conversation",
+
     "backToActiveSession": "Back to active session",
     "archivedSession": "Archived session",
     "restoreSession": "Restore",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -470,8 +470,8 @@
     "messageCountShort_plural": "{{count}} msgs",
     "draftContinueBanner": "{{count}} session in progress with {{name}}",
     "draftContinueRecent": "Recent sessions",
-    "draftWithAgentHint": "Tap below to start a new session with this agent",
-    "draftWithMemberHint": "Tap below to start a new session with this member",
+    "draftWithAgentHint": "Type below — a session is created when you send",
+    "draftWithMemberHint": "Type below — a session is created when you send",
     "untitledSession": "(Untitled)",
     "agentSelector": {
       "noModels": "No models advertised",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -270,7 +270,7 @@
       "routingMultiAgent": "多位 Agent 在场——请 @名字 指定回复对象。",
       "participantCount": "{{count}} 位参与者 · 等待第一条消息"
     },
-    "draftStartConversation": "开始对话",
+
     "backToActiveSession": "返回活跃会话",
     "archivedSession": "归档会话",
     "restoreSession": "恢复",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -470,8 +470,8 @@
     "messageCountShort_plural": "{{count}} 条消息",
     "draftContinueBanner": "与 {{name}} 还有 {{count}} 个进行中",
     "draftContinueRecent": "最近会话",
-    "draftWithAgentHint": "点击下方开始与该 Agent 的新会话",
-    "draftWithMemberHint": "点击下方开始与该成员的新会话",
+    "draftWithAgentHint": "在下方输入消息，发送后创建与该 Agent 的会话",
+    "draftWithMemberHint": "在下方输入消息，发送后创建与该成员的会话",
     "untitledSession": "(未命名)",
     "agentSelector": {
       "noModels": "暂无可用模型",

--- a/packages/app/src/stores/session-loader.ts
+++ b/packages/app/src/stores/session-loader.ts
@@ -128,6 +128,7 @@ export function createLoaderActions(set: SessionSet, _get: SessionGet) {
         const soleAgent = agentRows.length === 1 ? agentRows[0] : null;
 
         const { createSessionShell } = await import("@/lib/session-create");
+        const { promoteCreatedSessionToUi } = await import("@/lib/promote-created-session");
         const { sessionId } = await createSessionShell({
           teamId: currentTeam.id,
           creatorActorId,
@@ -135,7 +136,11 @@ export function createLoaderActions(set: SessionSet, _get: SessionGet) {
           additionalActorIds: soleAgent ? [soleAgent.id] : [],
         });
 
-        await useSessionListStore.getState().load();
+        await promoteCreatedSessionToUi({
+          sessionId,
+          teamId: currentTeam.id,
+          title: "New chat",
+        });
         trackEvent("session_started");
 
         const now = new Date();

--- a/packages/app/src/stores/session-messages.ts
+++ b/packages/app/src/stores/session-messages.ts
@@ -68,14 +68,21 @@ export function createMessageActions(set: SessionSet, get: SessionGet) {
         : null;
 
     const { createSessionShell } = await import("@/lib/session-create");
+    const { promoteCreatedSessionToUi } = await import("@/lib/promote-created-session");
+    const title = content.trim().slice(0, 80) || "New chat";
     const { sessionId } = await createSessionShell({
       teamId: currentTeam.id,
       creatorActorId,
-      title: content.trim().slice(0, 80) || "New chat",
+      title,
       additionalActorIds: soleAgent ? [soleAgent.id] : [],
     });
 
-    await useSessionListStore.getState().load();
+    await promoteCreatedSessionToUi({
+      sessionId,
+      teamId: currentTeam.id,
+      title,
+      lastMessagePreview: content.trim().slice(0, 120) || null,
+    });
     set({
       activeSessionId: sessionId,
       currentSessionId: sessionId,


### PR DESCRIPTION
## Summary
- New Chat / ⌘N / quick create enter a local actor draft (no `POST /v1/sessions` until the first message).
- First-send creates the session shell, optimistically upserts the list row, switches immediately, and reconciles the session list in the background (no more awaiting a full `load()` before the UI flips).
- Keep the draft (and suppress the welcome empty state) until create+switch succeeds, so sending no longer flashes “Mac-mini-8 is waiting on this device”.
- Show the composer in draft / no-session states so users can type without a dead “开始对话” gate.

## Test plan
- [ ] Click New Chat / ⌘N → lands on draft with agent name + bottom composer (no network create yet)
- [ ] Type and send first message → session appears in list, switches without welcome-page flash
- [ ] Actor-row draft path: pick an actor, send → same create-on-send behavior
- [ ] New Session dialog: create with opening message still works
- [ ] Failed create keeps draft so the user can retry
- [ ] `pnpm exec vitest run` for the touched quick-session / promote / NewSessionDialog tests


Made with [Cursor](https://cursor.com)