### PR TITLE
chore(release): bump desktop to v0.3.1-beta.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "amuxd"
-version = "0.3.1-beta.13"
+version = "0.3.1-beta.14"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10698,7 +10698,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaw"
-version = "0.3.1-beta.13"
+version = "0.3.1-beta.14"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.3.1-beta.13"
+version = "0.3.1-beta.14"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaw"
-version = "0.3.1-beta.13"
+version = "0.3.1-beta.14"
 description = "TeamClaw - AI Agent Desktop Platform"
 authors = ["TeamClaw Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClaw",
-  "version": "0.3.1-beta.13",
+  "version": "0.3.1-beta.14",
   "identifier": "com.teamclaw.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclaw/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclaw",
-  "version": "0.3.1-beta.13",
+  "version": "0.3.1-beta.14",
   "private": true,
   "description": "TeamClaw - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump the four desktop version sources (+ Cargo.lock) to `0.3.1-beta.14` so we can publish a new **copilot361** OSS build that includes the draft-first new-session fix (#672).

## Test plan
- [ ] CI green
- [ ] After merge: dispatch `release-oss.yml` with `brand=copilot361` and `tag=v0.3.1-beta.14`


Made with [Cursor](https://cursor.com)