### PR TITLE
chore(app): trim redundant success/info toasts

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2778,7 +2778,6 @@ function AppContent() {
                 onClick={async () => {
                   try {
                     await navigator.clipboard.writeText(buildSessionDeeplink(activeSession.id));
-                    toast.success(t("chat.shareLinkCopied", "会话链接已复制"));
                   } catch {
                     toast.error(t("chat.shareLinkCopyFailed", "复制失败"));
                   }

--- a/packages/app/src/components/chat/AgentSelectorDock.tsx
+++ b/packages/app/src/components/chat/AgentSelectorDock.tsx
@@ -351,13 +351,6 @@ function AgentPill({
         sessionId,
         teamId,
       })
-      const { toast } = await import('sonner')
-      toast.success(t('chat.agentSelector.modelPickSaved', '模型已选择'), {
-        description: t(
-          'chat.agentSelector.modelPickSavedHint',
-          '将在发送消息或 runtime 就绪后应用到 Agent',
-        ),
-      })
       return
     }
 

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -1229,14 +1229,6 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
         sessionId: sid,
         engagedAgentIds: engagedAgents.map((a) => a.id),
       }, "warn");
-      void import("sonner").then(({ toast }) => {
-        toast.warning(t("chat.toast.emptyMessageTitle", "请输入消息内容"), {
-          description: t(
-            "chat.toast.emptyMessageWithAgent",
-            "已选择 Agent 时需要输入文字或附件才会发送。",
-          ),
-        });
-      });
       return;
     }
 
@@ -2309,14 +2301,6 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
             onRetryOfflineAgents={handleRetryOfflineAgents}
             onEngageAgent={(a) => {
               if (!activeSessionId) {
-                void import("sonner").then(({ toast }) => {
-                  toast.info(t("chat.toast.sendFirstToCreateSession", "请先发送一条消息创建会话"), {
-                    description: t(
-                      "chat.toast.mentionNeedsOpenSession",
-                      "@ Agent 需要在已打开的会话中使用。",
-                    ),
-                  });
-                });
                 return;
               }
               addAgentForSession(a);

--- a/packages/app/src/components/chat/SessionDiffPanel.tsx
+++ b/packages/app/src/components/chat/SessionDiffPanel.tsx
@@ -89,9 +89,6 @@ export function SessionDiffPanel({ diff, compact: _compact }: SessionDiffPanelPr
     try {
       const { invoke } = await import('@tauri-apps/api/core')
       await invoke('git_checkout_file', { path: workspacePath, file: relativePath })
-      toast.success(t('diff.reverted', 'File reverted'), {
-        description: relativePath,
-      })
     } catch (err) {
       console.error('[SessionDiffPanel] Failed to revert file:', err)
       toast.error(t('diff.revertFailed', 'Failed to revert file'), {

--- a/packages/app/src/components/panel/ActorsView.tsx
+++ b/packages/app/src/components/panel/ActorsView.tsx
@@ -91,7 +91,6 @@ function ActorRowView({
   const handleCopyName = async () => {
     try {
       await navigator.clipboard.writeText(actor.display_name)
-      toast.success(t('actors.copiedName', 'Copied name'))
     } catch {
       toast.error(t('actors.copyFailed', 'Copy failed'))
     }
@@ -100,7 +99,6 @@ function ActorRowView({
   const handleCopyId = async () => {
     try {
       await navigator.clipboard.writeText(actor.id)
-      toast.success(t('actors.copiedId', 'Copied actor ID'))
     } catch {
       toast.error(t('actors.copyFailed', 'Copy failed'))
     }

--- a/packages/app/src/components/settings/DaemonWorkspacesSection.tsx
+++ b/packages/app/src/components/settings/DaemonWorkspacesSection.tsx
@@ -180,12 +180,9 @@ export function DaemonWorkspacesSection() {
         await load()
         if (!registration.daemonRegistered && registration.daemonError) {
           notifyDaemonRegistrationWarning(registration.daemonError)
-        } else {
-          toast.success(t('settings.daemonWorkspaces.addedAsDefault', 'Workspace added and set as default'))
         }
       } else {
         await load()
-        toast.success(t('settings.daemonWorkspaces.added', 'Workspace added'))
       }
       setPath(currentWorkspacePath ?? '')
     } catch (err) {
@@ -205,8 +202,6 @@ export function DaemonWorkspacesSection() {
       await load()
       if (!registration.daemonRegistered && registration.daemonError) {
         notifyDaemonRegistrationWarning(registration.daemonError)
-      } else {
-        toast.success(t('settings.daemonWorkspaces.defaultUpdated', 'Default workspace updated'))
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))

--- a/packages/app/src/components/settings/DiagnosticsSection.tsx
+++ b/packages/app/src/components/settings/DiagnosticsSection.tsx
@@ -105,7 +105,6 @@ export const DiagnosticsSection = React.memo(function DiagnosticsSection() {
     if (!report) return
     try {
       await copyDiagnosticReport(report)
-      toast.success(t('settings.diagnostics.copied', '诊断报告已复制到剪贴板'))
     } catch {
       toast.error(t('settings.diagnostics.copyFailed', '复制失败'))
     }

--- a/packages/app/src/components/settings/ExtensionGeneralSection.tsx
+++ b/packages/app/src/components/settings/ExtensionGeneralSection.tsx
@@ -125,9 +125,6 @@ export const ExtensionGeneralSection = React.memo(function ExtensionGeneralSecti
     setClearingMap(true)
     try {
       await clearLinkSessionMapForTeam(teamId)
-      toast.success(
-        t('settings.extension.linkSessionMap.cleared', 'Cleared link-to-session mappings for this team'),
-      )
     } catch (e) {
       console.error('[extension-settings] clear link session map failed', e)
       toast.error(t('settings.extension.linkSessionMap.clearError', 'Could not clear link mappings'))

--- a/packages/app/src/components/settings/GeneralSection.tsx
+++ b/packages/app/src/components/settings/GeneralSection.tsx
@@ -131,7 +131,6 @@ export const GeneralSection = React.memo(function GeneralSection() {
     const ok = await renameCurrentMember(trimmed)
     if (ok) {
       setDisplayNameDirty(false)
-      toast.success(t('settings.general.displayNameSaved', 'Display name updated'))
     } else {
       toast.error(t('settings.general.displayNameError', 'Could not update display name'))
     }
@@ -172,7 +171,6 @@ export const GeneralSection = React.memo(function GeneralSection() {
       await invoke('set_window_close_preference', {
         action: next === 'ask' ? null : next,
       })
-      toast.success(t('settings.general.closeWindowSaved', 'Close preference updated'))
     } catch {
       toast.error(t('settings.general.closeWindowError', 'Could not update close preference'))
     }
@@ -446,13 +444,11 @@ function ServerAddressCard() {
     try {
       const outcome = await fetchAndApplyBootstrap({ accessToken })
       await reload()
-      if (outcome === 'applied') {
-        toast.success(t('settings.general.mqttRefetchApplied', 'Broker updated from server'))
-      } else if (outcome === 'cloud-empty') {
+      if (outcome === 'cloud-empty') {
         toast.error(
           t('settings.general.mqttRefetchEmpty', 'Server still returns no MQTT configuration'),
         )
-      } else {
+      } else if (outcome !== 'applied') {
         toast.error(t('settings.general.mqttRefetchFailed', 'Could not reach the server'))
       }
     } finally {
@@ -528,7 +524,6 @@ function ServerAddressCard() {
                   className="ml-auto h-6 px-2 text-[11px]"
                   onClick={() => {
                     void recoverMqttConnection()
-                    toast.success(t('settings.general.mqttReconnecting', 'Reconnecting…'))
                   }}
                 >
                   {t('settings.general.mqttReconnect', 'Reconnect')}

--- a/packages/app/src/components/settings/LiveDebugConsole.tsx
+++ b/packages/app/src/components/settings/LiveDebugConsole.tsx
@@ -242,7 +242,6 @@ export const LiveDebugConsole = React.memo(function LiveDebugConsole() {
     const text = entries.map(formatConsoleEntry).join('\n')
     try {
       await navigator.clipboard.writeText(text)
-      toast.success(t('settings.diagnostics.liveConsole.consoleCopied', 'Console 日志已复制'))
     } catch {
       toast.error(t('settings.diagnostics.copyFailed', '复制失败'))
     }
@@ -252,7 +251,6 @@ export const LiveDebugConsole = React.memo(function LiveDebugConsole() {
     if (!snapshot) return
     try {
       await navigator.clipboard.writeText(JSON.stringify(snapshot, null, 2))
-      toast.success(t('settings.diagnostics.liveConsole.stateCopied', '运行状态已复制'))
     } catch {
       toast.error(t('settings.diagnostics.copyFailed', '复制失败'))
     }

--- a/packages/app/src/components/settings/PromptSection.tsx
+++ b/packages/app/src/components/settings/PromptSection.tsx
@@ -57,10 +57,6 @@ export const PromptSection = React.memo(function PromptSection() {
   const handleSave = React.useCallback(async () => {
     try {
       await invoke('save_system_prompt', { prompt: systemPrompt, workspacePath: workspacePath ?? undefined })
-      toast.success(
-        t('settings.prompt.saveSuccess', 'System prompt saved successfully'),
-        { duration: 2000 }
-      )
       if (workspacePath) {
         try {
           await reloadDaemonRuntime(encodeWorkspaceId(workspacePath))

--- a/packages/app/src/components/settings/__tests__/ExtensionGeneralSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/ExtensionGeneralSection.test.tsx
@@ -124,7 +124,7 @@ describe('ExtensionGeneralSection', () => {
 
     await waitFor(() => {
       expect(clearLinkSessionMapForTeam).toHaveBeenCalledWith('team-1')
-      expect(toast.success).toHaveBeenCalled()
     })
+    expect(toast.success).not.toHaveBeenCalled()
   })
 })

--- a/packages/app/src/components/sidebar/ActorDetailDialog.tsx
+++ b/packages/app/src/components/sidebar/ActorDetailDialog.tsx
@@ -201,7 +201,6 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
   const copyId = async () => {
     try {
       await navigator.clipboard.writeText(displayActor.id)
-      toast.success(t('actors.copiedId', 'Copied actor ID'))
     } catch {
       toast.error(t('actors.copyFailed', 'Copy failed'))
     }
@@ -275,7 +274,6 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
     if (!reinvite) return
     try {
       await navigator.clipboard.writeText(reinvite.deeplink)
-      toast.success(t('invite.copied', 'Invite link copied'))
     } catch {
       toast.error(t('invite.copyFailed', 'Failed to copy invite link'))
     }

--- a/packages/app/src/components/sidebar/ActorsSection.tsx
+++ b/packages/app/src/components/sidebar/ActorsSection.tsx
@@ -71,7 +71,6 @@ export function ActorsSection() {
   const handleCopyName = async (actor: ActorRowData) => {
     try {
       await navigator.clipboard.writeText(actor.display_name)
-      toast.success(t('actors.copiedName', 'Copied name'))
     } catch {
       toast.error(t('actors.copyFailed', 'Copy failed'))
     }
@@ -80,7 +79,6 @@ export function ActorsSection() {
   const handleCopyId = async (actor: ActorRowData) => {
     try {
       await navigator.clipboard.writeText(actor.id)
-      toast.success(t('actors.copiedId', 'Copied actor ID'))
     } catch {
       toast.error(t('actors.copyFailed', 'Copy failed'))
     }

--- a/packages/app/src/components/sidebar/AppsListColumn.tsx
+++ b/packages/app/src/components/sidebar/AppsListColumn.tsx
@@ -117,9 +117,12 @@ function AppItemRow({ app, onClick, onRename }: RowProps) {
   const handleCopyUrl = React.useCallback(async (e: React.SyntheticEvent) => {
     e.stopPropagation()
     if (!app.fcEndpoint) return
-    await navigator.clipboard.writeText(app.fcEndpoint)
-    const { toast } = await import('sonner')
-    toast.success(t('apps.urlCopied', '已复制部署地址'))
+    try {
+      await navigator.clipboard.writeText(app.fcEndpoint)
+    } catch {
+      const { toast } = await import('sonner')
+      toast.error(t('apps.urlCopyFailed', '复制失败'))
+    }
   }, [app.fcEndpoint, t])
 
   return (

--- a/packages/app/src/components/sidebar/CreateIdeaDialog.tsx
+++ b/packages/app/src/components/sidebar/CreateIdeaDialog.tsx
@@ -51,7 +51,6 @@ export function CreateIdeaDialog({ open, onOpenChange, teamId, onCreated }: Crea
         workspaceId: null,
         body: description.trim() || null,
       })
-      toast.success(t('ideas.created', 'Idea created'))
       onCreated?.()
       onOpenChange(false)
     } catch (e) {

--- a/packages/app/src/components/sidebar/IdeaDetailDialog.tsx
+++ b/packages/app/src/components/sidebar/IdeaDetailDialog.tsx
@@ -147,7 +147,6 @@ export function IdeaDetailDialog({ idea, onOpenChange, onChanged }: Props) {
         status,
         workspaceId: detail.workspace_id,
       })
-      toast.success(t('ideas.detail.saved', 'Idea saved'))
       onChanged?.()
       await loadDetail()
     } catch (e) {
@@ -167,7 +166,6 @@ export function IdeaDetailDialog({ idea, onOpenChange, onChanged }: Props) {
         content: activityText.trim(),
       })
       setActivityText('')
-      toast.success(t('ideas.detail.activityPosted', 'Activity posted'))
       onChanged?.()
       await loadDetail()
     } catch (e) {

--- a/packages/app/src/components/sidebar/IdeasSection.tsx
+++ b/packages/app/src/components/sidebar/IdeasSection.tsx
@@ -44,7 +44,6 @@ export function IdeasSection() {
   const handleChangeStatus = async (idea: IdeaRowData, status: IdeaStatus) => {
     try {
       await updateIdeaStatus(idea.id, status)
-      toast.success(t('ideas.statusUpdated', 'Status updated'))
       refetch()
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
@@ -55,7 +54,6 @@ export function IdeasSection() {
   const handleCopyId = async (idea: IdeaRowData) => {
     try {
       await navigator.clipboard.writeText(idea.id)
-      toast.success(t('ideas.copiedId', 'Copied idea ID'))
     } catch {
       toast.error(t('ideas.copyFailed', 'Copy failed'))
     }
@@ -66,7 +64,6 @@ export function IdeasSection() {
     setDeleting(true)
     try {
       await getBackend().ideas.archiveIdea(deleteFor.id)
-      toast.success(t('ideas.archived', 'Idea deleted'))
       if (filter.kind === 'idea' && filter.ideaId === deleteFor.id) {
         setFilter({ kind: 'all' })
       }

--- a/packages/app/src/components/sidebar/InviteActorDialog.tsx
+++ b/packages/app/src/components/sidebar/InviteActorDialog.tsx
@@ -125,7 +125,6 @@ export function InviteActorDialog({ open, onOpenChange, teamId }: InviteActorDia
     if (!invite) return
     try {
       await navigator.clipboard.writeText(invite.deeplink)
-      toast.success(t('invite.copied', 'Invite link copied'))
     } catch {
       toast.error(t('invite.copyFailed', 'Failed to copy invite link'))
     }

--- a/packages/app/src/components/sidebar/LocalDaemonCard.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonCard.tsx
@@ -61,7 +61,6 @@ export function LocalDaemonCard() {
   const handleCopyName = async (actor: ActorRowData) => {
     try {
       await navigator.clipboard.writeText(actor.display_name)
-      toast.success(t('actors.copiedName', 'Copied name'))
     } catch {
       toast.error(t('actors.copyFailed', 'Copy failed'))
     }
@@ -70,7 +69,6 @@ export function LocalDaemonCard() {
   const handleCopyId = async (actor: ActorRowData) => {
     try {
       await navigator.clipboard.writeText(actor.id)
-      toast.success(t('actors.copiedId', 'Copied actor ID'))
     } catch {
       toast.error(t('actors.copyFailed', 'Copy failed'))
     }

--- a/packages/app/src/components/sidebar/LocalDaemonRow.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonRow.tsx
@@ -490,7 +490,6 @@ export function LocalDaemonRow({
       })
       await useWorkspaceStore.getState().setWorkspace(path)
       await loadWorkspaces()
-      toast.success(t('sidebar.workspaceAdded', 'Workspace added'))
     } catch (err) {
       toast.error(t('sidebar.workspaceAddFailed', 'Failed to add workspace: {{msg}}', { msg: err instanceof Error ? err.message : String(err) }))
     } finally {
@@ -502,7 +501,6 @@ export function LocalDaemonRow({
     if (!ws.path) return
     try {
       await useWorkspaceStore.getState().setWorkspace(ws.path)
-      toast.success(t('sidebar.workspaceSwitched', 'Switched to {{name}}', { name: ws.name }))
     } catch (err) {
       toast.error(t('sidebar.workspaceSwitchFailed', 'Failed to switch workspace: {{msg}}', { msg: err instanceof Error ? err.message : String(err) }))
     }
@@ -512,7 +510,6 @@ export function LocalDaemonRow({
     try {
       await updateDaemonWorkspace({ workspaceId: ws.id, name: ws.name, path: ws.path ?? '', archived: true })
       await loadWorkspaces()
-      toast.success(t('sidebar.workspaceDeleted', 'Workspace deleted'))
     } catch (err) {
       toast.error(t('sidebar.workspaceDeleteFailed', 'Failed to delete workspace: {{msg}}', { msg: err instanceof Error ? err.message : String(err) }))
     }

--- a/packages/app/src/components/sidebar/RenameIdeaDialog.tsx
+++ b/packages/app/src/components/sidebar/RenameIdeaDialog.tsx
@@ -42,7 +42,6 @@ export function RenameIdeaDialog({ ideaId, initialTitle, open, onOpenChange, onR
     setSubmitting(true)
     try {
       await renameIdea(ideaId, trimmed)
-      toast.success(t('ideas.renamed', 'Idea renamed'))
       onRenamed?.()
       onOpenChange(false)
     } catch (e) {

--- a/packages/app/src/components/sidebar/SessionDetailDialog.tsx
+++ b/packages/app/src/components/sidebar/SessionDetailDialog.tsx
@@ -213,10 +213,9 @@ export function SessionDetailDialog({
   const acpLineCount = acpLines.filter((line) => line.sessionId === displaySessionId).length
   const showOpenSession = activeSessionId !== displaySessionId
 
-  const copyText = async (label: string, value: string) => {
+  const copyText = async (_label: string, value: string) => {
     try {
       await navigator.clipboard.writeText(value)
-      toast.success(t('sessions.detail.copied', 'Copied {{label}}', { label }))
     } catch {
       toast.error(t('actors.copyFailed', 'Copy failed'))
     }

--- a/packages/app/src/components/teamshare/KnowledgeDetail.tsx
+++ b/packages/app/src/components/teamshare/KnowledgeDetail.tsx
@@ -53,7 +53,6 @@ export function KnowledgeDetail({ path }: { path: string }) {
       const { writeTextFile } = await import('@tauri-apps/plugin-fs')
       await writeTextFile(path, content)
       setBaseline(content)
-      toast.success(t('teamShare.saved', 'Saved'))
     } catch (e) {
       toast.error(t('teamShare.saveFailed', 'Save failed: {{msg}}', { msg: e instanceof Error ? e.message : String(e) }))
     } finally {

--- a/packages/app/src/components/teamshare/SkillDetail.tsx
+++ b/packages/app/src/components/teamshare/SkillDetail.tsx
@@ -40,7 +40,6 @@ export function SkillDetail({ slug }: { slug: string }) {
       })
       if (saved === null) throw new Error('daemon rejected the update')
       await loadSection('skills', { force: true })
-      toast.success(t('teamShare.saved', 'Saved'))
     } catch (e) {
       toast.error(t('teamShare.saveFailed', 'Save failed: {{msg}}', { msg: e instanceof Error ? e.message : String(e) }))
     } finally {

--- a/packages/app/src/components/workspace/FileBrowser.tsx
+++ b/packages/app/src/components/workspace/FileBrowser.tsx
@@ -170,11 +170,8 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
 
         e.preventDefault()
         if (undoStack.length === 0) return
-        const lastOp = undoStack[undoStack.length - 1]
         undo().then((success) => {
-          if (success) {
-            toast.success(t('fileExplorer.undone', 'Undone: {{desc}}', { desc: lastOp.description }))
-          } else {
+          if (!success) {
             toast.error(t('fileExplorer.undoFailed', 'Cannot undo this operation'))
           }
         })
@@ -186,11 +183,8 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
 
   const handleUndo = React.useCallback(async () => {
     if (undoStack.length === 0) return
-    const lastOp = undoStack[undoStack.length - 1]
     const success = await undo()
-    if (success) {
-      toast.success(t('fileExplorer.undone', 'Undone: {{desc}}', { desc: lastOp.description }))
-    } else {
+    if (!success) {
       toast.error(t('fileExplorer.undoFailed', 'Cannot undo this operation'))
     }
   }, [undo, undoStack, t])

--- a/packages/app/src/components/workspace/FileTree.tsx
+++ b/packages/app/src/components/workspace/FileTree.tsx
@@ -633,18 +633,15 @@ export function FileTree({
   // ── Clipboard handlers for context menu ──
   const handleCut = useCallback((paths: string[]) => {
     setClipboard(paths, 'cut');
-    toast.success(t('fileExplorer.cut', 'Cut {{count}} item(s)', { count: paths.length }));
-  }, [setClipboard, t]);
+  }, [setClipboard]);
 
   const handleCopy = useCallback((paths: string[]) => {
     setClipboard(paths, 'copy');
-    toast.success(t('fileExplorer.copied', 'Copied {{count}} item(s)', { count: paths.length }));
-  }, [setClipboard, t]);
+  }, [setClipboard]);
 
   const handlePaste = useCallback(async (targetDir: string) => {
     const success = await pasteFiles(targetDir);
     if (success) {
-      toast.success(t('fileExplorer.pasted', 'Pasted'));
       await expandDirectory(targetDir);
     } else {
       toast.error(t('fileExplorer.pasteFailed', 'Paste failed'));
@@ -655,7 +652,6 @@ export function FileTree({
   const handleDuplicate = useCallback(async (path: string) => {
     const success = await duplicateItem(path);
     if (success) {
-      toast.success(t('fileExplorer.duplicated', 'Duplicated'));
       await refreshFileTree();
     } else {
       toast.error(t('fileExplorer.duplicateFailed', 'Duplicate failed'));
@@ -830,7 +826,6 @@ export function FileTree({
           const paths = selectedFiles.length > 0 ? selectedFiles : (focusedPath ? [focusedPath] : []);
           if (paths.length > 0) {
             setClipboard(paths, 'copy');
-            toast.success(t('fileExplorer.copied', 'Copied {{count}} item(s)', { count: paths.length }));
           }
           return;
         }
@@ -839,7 +834,6 @@ export function FileTree({
           const paths = selectedFiles.length > 0 ? selectedFiles : (focusedPath ? [focusedPath] : []);
           if (paths.length > 0) {
             setClipboard(paths, 'cut');
-            toast.success(t('fileExplorer.cut', 'Cut {{count}} item(s)', { count: paths.length }));
           }
           return;
         }
@@ -858,7 +852,6 @@ export function FileTree({
             if (targetDir) {
               const success = await pasteFiles(targetDir);
               if (success) {
-                toast.success(t('fileExplorer.pasted', 'Pasted'));
                 await expandDirectory(targetDir);
               } else {
                 toast.error(t('fileExplorer.pasteFailed', 'Paste failed'));
@@ -1140,7 +1133,6 @@ export function FileTree({
           const { copyExternalFiles } = await import('./file-tree-operations');
           const success = await copyExternalFiles(paths, targetDir);
           if (success) {
-            toast.success(t('fileExplorer.externalDropped', 'Copied {{count}} file(s)', { count: paths.length }));
             await refreshFileTree();
             if (targetDir !== workspacePath) {
               await expandDirectory(targetDir);

--- a/packages/app/src/hooks/useChannelConfig.ts
+++ b/packages/app/src/hooks/useChannelConfig.ts
@@ -101,7 +101,6 @@ export function useChannelConfig<TConfig extends object>(
       if (isRunning) {
         setHasChanges(true)
       }
-      toast.success(i18n.t('settings.channels.saveSuccess', 'Changes saved'))
     } catch (err) {
       toast.error(i18n.t('settings.channels.saveError', 'Failed to save changes'), {
         description: err instanceof Error ? err.message : undefined,

--- a/packages/app/src/lib/utils.ts
+++ b/packages/app/src/lib/utils.ts
@@ -25,10 +25,9 @@ export function removeStartupSkeleton(): void {
   document.getElementById("skeleton")?.remove()
 }
 
-export async function copyToClipboard(text: string, successMessage?: string): Promise<void> {
+export async function copyToClipboard(text: string, _successMessage?: string): Promise<void> {
   try {
     await navigator.clipboard.writeText(text)
-    if (successMessage) toast.success(successMessage)
   } catch {
     toast.error('Failed to copy')
   }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -9,7 +9,6 @@
     "manageInSettings": "Manage in settings",
     "selectPrompt": "Select a {{section}} item to view it here.",
     "save": "Save",
-    "saved": "Saved",
     "saveFailed": "Save failed: {{msg}}",
     "readFailed": "Could not read file: {{msg}}",
     "edit": "Edit",
@@ -203,8 +202,8 @@
   },
   "session": {
     "deeplink": {
-      "noAccess": "You do not have access to this session",
-      "notFound": "Session not found or deleted",
+      "noAccess": "You don't have access to this session",
+      "notFound": "Session not found or has been deleted",
       "openFailed": "Failed to open session"
     }
   },
@@ -270,7 +269,6 @@
       "routingMultiAgent": "Multiple agents — @ a name to choose who replies.",
       "participantCount": "{{count}} participants · Waiting for the first message"
     },
-
     "backToActiveSession": "Back to active session",
     "archivedSession": "Archived session",
     "restoreSession": "Restore",
@@ -434,11 +432,9 @@
     },
     "mentionPopoverTitle": "Mention people or agents",
     "mentionPopoverNoMatch": "No match for \"{{query}}\"",
-    "copyShareLink": "Copy session share link",
-    "shareLinkCopied": "Session link copied",
-    "shareLinkCopyFailed": "Failed to copy link",
+    "copyShareLink": "Copy share link",
+    "shareLinkCopyFailed": "Copy failed",
     "mentionEmptyState": "No one to mention in this session yet",
-    "mentionPopoverNoMatch": "No match for \"{{query}}\"",
     "mentionGroupAgents": "Agents",
     "mentionGroupMembers": "Members",
     "mentionPopoverError": "Failed to load participants",
@@ -599,12 +595,8 @@
       "openLog": "Open log in Finder"
     },
     "toast": {
-      "emptyMessageTitle": "Enter a message",
-      "emptyMessageWithAgent": "When an agent is selected, you must enter text or an attachment to send.",
       "mentionRouteFailedTitle": "@Agent set but message can't be routed",
-      "mentionRouteFailedBody": "The message contains no resolvable agent @-mention, so the daemon won't reply. Make sure the agent has joined this session.",
-      "sendFirstToCreateSession": "Send a message first to create a session",
-      "mentionNeedsOpenSession": "@ Agent can only be used in an open session."
+      "mentionRouteFailedBody": "The message contains no resolvable agent @-mention, so the daemon won't reply. Make sure the agent has joined this session."
     },
     "imageViewer": {
       "saveImage": "Save image",
@@ -617,11 +609,7 @@
       "goodResponse": "Good response",
       "poorResponse": "Poor response"
     },
-    "openAgentSettings": "Open agent settings",
-    "copyShareLink": "Copy share link",
-    "mentionPopoverNoMatch": "No match for \"{{query}}\"",
-    "shareLinkCopied": "Session link copied",
-    "shareLinkCopyFailed": "Copy failed"
+    "openAgentSettings": "Open agent settings"
   },
   "onboarding": {
     "common": {
@@ -668,11 +656,7 @@
     "copyFile": "Copy",
     "cutFile": "Cut",
     "pasteFile": "Paste",
-    "copied": "Copied {{count}} item(s)",
-    "cut": "Cut {{count}} item(s)",
-    "pasted": "Pasted",
     "pasteFailed": "Paste failed",
-    "externalDropped": "Copied {{count}} file(s)",
     "externalDropFailed": "Failed to copy files",
     "addToAgent": "Add to Agent",
     "openWithDefault": "Open with Default App",
@@ -682,7 +666,6 @@
     "collapseAll": "Collapse All",
     "showAll": "Show all files",
     "showGitChanged": "Show git changed files only",
-    "undone": "Undone: {{desc}}",
     "undoFailed": "Cannot undo this operation",
     "confirmDeleteTitle": "Delete \"{{name}}\"?",
     "confirmBatchDeleteTitle": "Delete {{count}} items?",
@@ -692,7 +675,6 @@
     "teamLastSyncTooltip": "Last sync: {{time}}",
     "teamSyncing": "Syncing…",
     "duplicateFailed": "Duplicate failed",
-    "duplicated": "Duplicated",
     "pathCopied": "Path copied",
     "undo": "Undo: {{desc}}"
   },
@@ -740,8 +722,7 @@
       "acpLogHint": "{{dir}}/{{sessionId}}.log",
       "revealAcpLog": "Reveal ACP log",
       "openSession": "Open session",
-      "copySessionId": "Copy session ID",
-      "copied": "Copied {{label}}"
+      "copySessionId": "Copy session ID"
     }
   },
   "sidebar": {
@@ -750,12 +731,9 @@
     "workspacesLoading": "Loading workspaces…",
     "noWorkspaces": "No workspaces yet",
     "noWorkspaceSessions": "No sessions in this workspace yet",
-    "workspaceAdded": "Workspace added",
     "workspaceAddFailed": "Failed to add workspace: {{msg}}",
     "switchToWorkspace": "Switch to this workspace",
-    "workspaceSwitched": "Switched to {{name}}",
     "workspaceSwitchFailed": "Failed to switch workspace: {{msg}}",
-    "workspaceDeleted": "Workspace deleted",
     "workspaceDeleteFailed": "Failed to delete workspace: {{msg}}",
     "currentWorkspace": "Current: {{path}}",
     "defaultWorkspace": "Default workspace",
@@ -1003,7 +981,6 @@
     "localPreview": "Local preview",
     "openUrl": "Open deployed URL",
     "copyUrl": "Copy deployed URL",
-    "urlCopied": "Deployed URL copied",
     "revealInFinder": "Reveal folder in Finder",
     "rename": "Rename",
     "delete": "Delete",
@@ -1023,7 +1000,8 @@
     "visibilityTeam": "Team",
     "submit": "Create",
     "cancel": "Cancel",
-    "createError": "Failed to create app"
+    "createError": "Failed to create app",
+    "urlCopyFailed": "Failed to copy deployed URL"
   },
   "settings": {
     "description": "Configure TeamClaw settings.",
@@ -1054,7 +1032,6 @@
       "results": "Check Results",
       "exportTitle": "Export & Feedback",
       "copyReport": "Copy Diagnostic Report",
-      "copied": "Diagnostic report copied to clipboard",
       "copyFailed": "Copy failed",
       "exportZip": "Export ZIP Bundle",
       "exported": "Diagnostic bundle saved",
@@ -1077,11 +1054,9 @@
         "copy": "Copy",
         "clear": "Clear",
         "consoleEmpty": "No console output yet",
-        "consoleCopied": "Console log copied",
         "refreshState": "Refresh snapshot",
         "copyJson": "Copy JSON",
         "loadingState": "Collecting state…",
-        "stateCopied": "Runtime state copied",
         "stateRefreshFailed": "Failed to refresh state: {{message}}",
         "refreshDisk": "Refresh logs",
         "openAppLogs": "App logs folder",
@@ -1140,7 +1115,6 @@
       "displayName": "Display Name",
       "displayNameDesc": "The name teammates see for you",
       "displayNamePlaceholder": "Your name",
-      "displayNameSaved": "Display name updated",
       "displayNameError": "Could not update display name",
       "teamInfo": "Team & Organization",
       "teamName": "Team name",
@@ -1155,7 +1129,6 @@
       "closeWindowAsk": "Ask every time",
       "closeWindowTray": "Minimize to tray (keep agent)",
       "closeWindowQuit": "Quit and stop agent",
-      "closeWindowSaved": "Close preference updated",
       "closeWindowError": "Could not update close preference",
       "notifications": "Notifications",
       "notificationsDesc": "Receive desktop notifications",
@@ -1165,7 +1138,6 @@
       "mqttStatusConnected": "Connected",
       "mqttStatusDisconnected": "Disconnected",
       "mqttReconnect": "Reconnect",
-      "mqttReconnecting": "Reconnecting…",
       "mqttLastError": "Last error",
       "mqttSource": "Source",
       "mqttSourceCache": "Last-known address — the server is not delivering one.",
@@ -1173,7 +1145,6 @@
       "mqttCachedHint": "The server is not delivering an MQTT address; this is the last one that worked.",
       "mqttMissingFromServer": "The server did not deliver an MQTT address. Real-time sync is offline until it is configured.",
       "mqttRefetch": "Retry",
-      "mqttRefetchApplied": "Broker updated from server",
       "mqttRefetchEmpty": "Server still returns no MQTT configuration",
       "mqttRefetchFailed": "Could not reach the server",
       "save": "Save",
@@ -1608,12 +1579,9 @@
       "unknownAgent": "Unknown agent",
       "setDefault": "Set default",
       "defaultPersistFailed": "Failed to save default workspace to cloud. Try again.",
-      "defaultUpdated": "Default workspace updated",
       "defaultSavedDaemonPending": "Default workspace saved",
       "daemonRegisterFailed": "Daemon registration failed: {{message}}",
       "noDaemonDevice": "No local daemon device is connected.",
-      "added": "Workspace added",
-      "addedAsDefault": "Workspace added and set as default",
       "archive": "Archive",
       "archivedTitle": "Archived",
       "restore": "Restore"
@@ -1645,7 +1613,6 @@
       "startSetup": "Start Setup",
       "saveChanges": "Save Changes",
       "saving": "Saving...",
-      "saveSuccess": "Changes saved",
       "saveError": "Failed to save changes",
       "test": "Test",
       "setup": "Setup",
@@ -2212,7 +2179,6 @@
         "title": "Link-to-session mappings",
         "description": "Clear saved associations between allowlisted page links and chat sessions for the current team.",
         "clear": "Clear current team mappings",
-        "cleared": "Cleared link-to-session mappings for this team",
         "clearError": "Could not clear link mappings",
         "noTeam": "Select a team first",
         "confirmTitle": "Clear link mappings?",
@@ -2419,7 +2385,6 @@
       "proTip": "Pro Tip",
       "proTipDesc": "A good system prompt includes your preferred response style, any domain expertise needed, and specific guidelines for the AI to follow.",
       "saveChanges": "Save Changes",
-      "saveSuccess": "System prompt saved successfully",
       "saveError": "Failed to save system prompt",
       "saveReloadWarning": "System prompt saved, but Agent runtime reload failed"
     },
@@ -2880,7 +2845,6 @@
       "documentDeleted": "Document deleted",
       "deleteDocumentFailed": "Failed to delete document",
       "configSavedNeedsReindex": "Configuration saved, but reindexing is required for changes to take effect",
-      "configSaved": "Configuration saved",
       "saveConfigFailed": "Failed to save configuration",
       "watcherStopped": "File watcher stopped",
       "stopWatcherFailed": "Failed to stop file watcher"
@@ -2963,7 +2927,6 @@
     "pathCopied": "Path copied",
     "revertFailed": "Failed to revert file",
     "revertFile": "Revert File",
-    "reverted": "File reverted",
     "reviewCode": "Review Code",
     "suggestRefactor": "Suggest Refactor"
   },
@@ -2996,9 +2959,7 @@
     "joining": "Joining…",
     "public": "Public",
     "ungrouped": "Other",
-    "lastUsed": "Last used",
-    "public": "Public",
-    "joining": "Joining…"
+    "lastUsed": "Last used"
   },
   "team": {
     "viewerReadOnly": "Read-only mode — you don't have edit permissions",
@@ -3083,8 +3044,6 @@
       "body": "Remove {{name}} from the team. This cannot be undone.",
       "cta": "Remove"
     },
-    "copiedName": "Copied name",
-    "copiedId": "Copied actor ID",
     "copyFailed": "Copy failed",
     "removed": "Removed from team",
     "removeFailed": {
@@ -3131,7 +3090,6 @@
     "titlePlaceholder": "Idea title",
     "descriptionPlaceholder": "What's the constraint, what's the win?",
     "createButton": "Create",
-    "created": "Idea created",
     "createFailed": "Failed to create idea: {{msg}}",
     "contextMenu": {
       "view": "View",
@@ -3161,10 +3119,8 @@
       "priorityPlaceholder": "--- Priority",
       "tags": "Tags",
       "loadFailed": "Failed to load idea: {{msg}}",
-      "saved": "Idea saved",
       "saveFailed": "Save failed: {{msg}}",
       "save": "Save",
-      "activityPosted": "Activity posted",
       "activityFailed": "Activity failed: {{msg}}",
       "activityPlaceholder": "Post progress, decision notes, or next action...",
       "postActivity": "Post activity",
@@ -3172,13 +3128,9 @@
       "noActivity": "No activity yet.",
       "unknownActor": "Unknown"
     },
-    "archived": "Idea deleted",
-    "copiedId": "Copied idea ID",
     "copyFailed": "Copy failed",
     "deleteFailed": "Delete failed: {{msg}}",
-    "statusUpdated": "Status updated",
     "statusFailed": "Status update failed: {{msg}}",
-    "renamed": "Idea renamed",
     "renameFailed": "Rename failed: {{msg}}"
   },
   "invite": {
@@ -3197,7 +3149,6 @@
     "expiresAt": "Expires {{date}}",
     "createButton": "Create invite",
     "copy": "Copy",
-    "copied": "Invite link copied",
     "copyFailed": "Failed to copy invite link",
     "failed": "Failed to create invite: {{msg}}",
     "upgradeRequired": "This team is still in the shared org and is solo-only. Upgrade your account and create your own team to invite members.",
@@ -3277,12 +3228,5 @@
   "tabBar": {
     "closeAria": "Close tab",
     "findClose": "Close (Escape)"
-  },
-  "session": {
-    "deeplink": {
-      "noAccess": "You don't have access to this session",
-      "notFound": "Session not found or has been deleted",
-      "openFailed": "Failed to open session"
-    }
   }
 }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -481,9 +481,7 @@
       "noMatchingModels": "No matching models",
       "removeMention": "Remove mention",
       "modelChangeFailed": "Failed to change model",
-      "modelChangeWillRetry": "Pick saved; will reapply on next send. Detail: {{message}}",
-      "modelPickSaved": "Model selected",
-      "modelPickSavedHint": "Will apply to the agent on next send or when its runtime is ready"
+      "modelChangeWillRetry": "Pick saved; will reapply on next send. Detail: {{message}}"
     },
     "sessionAgent": {
       "bannerStaleOne": "{{name}} is no longer linked to this machine's agent — messages may not be processed",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -9,7 +9,6 @@
     "manageInSettings": "在设置中管理",
     "selectPrompt": "选择一项{{section}}在此查看。",
     "save": "保存",
-    "saved": "已保存",
     "saveFailed": "保存失败：{{msg}}",
     "readFailed": "无法读取文件：{{msg}}",
     "edit": "编辑",
@@ -270,7 +269,6 @@
       "routingMultiAgent": "多位 Agent 在场——请 @名字 指定回复对象。",
       "participantCount": "{{count}} 位参与者 · 等待第一条消息"
     },
-
     "backToActiveSession": "返回活跃会话",
     "archivedSession": "归档会话",
     "restoreSession": "恢复",
@@ -433,12 +431,10 @@
       "fullAccess": "完全访问权限"
     },
     "mentionPopoverTitle": "提及人或 agent",
-    "mentionPopoverNoMatch": "没有匹配「{{query}}」的结果",
+    "mentionPopoverNoMatch": "No match for \"{{query}}\"",
     "copyShareLink": "复制会话分享链接",
-    "shareLinkCopied": "会话链接已复制",
     "shareLinkCopyFailed": "复制失败",
     "mentionEmptyState": "当前会话还没有可 @ 的人或 agent",
-    "mentionPopoverNoMatch": "没有匹配「{{query}}」的结果",
     "mentionGroupAgents": "智能体",
     "mentionGroupMembers": "成员",
     "mentionPopoverError": "加载参与者失败",
@@ -599,12 +595,8 @@
       "openLog": "在 Finder 中打开日志"
     },
     "toast": {
-      "emptyMessageTitle": "请输入消息内容",
-      "emptyMessageWithAgent": "已选择 Agent 时需要输入文字或附件才会发送。",
       "mentionRouteFailedTitle": "已 @Agent 但无法路由消息",
-      "mentionRouteFailedBody": "消息未包含可解析的 Agent @-mention，daemon 不会回复。请确认 Agent 已加入此会话。",
-      "sendFirstToCreateSession": "请先发送一条消息创建会话",
-      "mentionNeedsOpenSession": "@ Agent 需要在已打开的会话中使用。"
+      "mentionRouteFailedBody": "消息未包含可解析的 Agent @-mention，daemon 不会回复。请确认 Agent 已加入此会话。"
     },
     "imageViewer": {
       "saveImage": "保存图片",
@@ -617,11 +609,7 @@
       "goodResponse": "回答不错",
       "poorResponse": "回答较差"
     },
-    "openAgentSettings": "打开 Agent 设置",
-    "copyShareLink": "复制会话分享链接",
-    "mentionPopoverNoMatch": "No match for \"{{query}}\"",
-    "shareLinkCopied": "会话链接已复制",
-    "shareLinkCopyFailed": "复制失败"
+    "openAgentSettings": "打开 Agent 设置"
   },
   "onboarding": {
     "common": {
@@ -668,11 +656,7 @@
     "copyFile": "复制",
     "cutFile": "剪切",
     "pasteFile": "粘贴",
-    "copied": "已复制 {{count}} 项",
-    "cut": "已剪切 {{count}} 项",
-    "pasted": "已粘贴",
     "pasteFailed": "粘贴失败",
-    "externalDropped": "已复制 {{count}} 个文件",
     "externalDropFailed": "复制文件失败",
     "addToAgent": "添加到 Agent",
     "openWithDefault": "用默认应用打开",
@@ -682,7 +666,6 @@
     "collapseAll": "全部折叠",
     "showAll": "显示所有文件",
     "showGitChanged": "仅显示 Git 变更文件",
-    "undone": "已撤销：{{desc}}",
     "undoFailed": "无法撤销此操作",
     "confirmDeleteTitle": "删除 \"{{name}}\"？",
     "confirmBatchDeleteTitle": "删除 {{count}} 项？",
@@ -692,7 +675,6 @@
     "teamLastSyncTooltip": "最后同步：{{time}}",
     "teamSyncing": "同步中…",
     "duplicateFailed": "创建副本失败",
-    "duplicated": "已创建副本",
     "pathCopied": "路径已复制",
     "undo": "撤销：{{desc}}"
   },
@@ -740,8 +722,7 @@
       "acpLogHint": "{{dir}}/{{sessionId}}.log",
       "revealAcpLog": "在 Finder 中显示 ACP 日志",
       "openSession": "打开会话",
-      "copySessionId": "复制会话 ID",
-      "copied": "已复制 {{label}}"
+      "copySessionId": "复制会话 ID"
     }
   },
   "sidebar": {
@@ -750,12 +731,9 @@
     "workspacesLoading": "正在加载工作区…",
     "noWorkspaces": "暂无工作区",
     "noWorkspaceSessions": "该工作区下暂无会话",
-    "workspaceAdded": "工作区已添加",
     "workspaceAddFailed": "添加工作区失败：{{msg}}",
     "switchToWorkspace": "切换到此工作区",
-    "workspaceSwitched": "已切换到 {{name}}",
     "workspaceSwitchFailed": "切换工作区失败：{{msg}}",
-    "workspaceDeleted": "工作区已删除",
     "workspaceDeleteFailed": "删除工作区失败：{{msg}}",
     "currentWorkspace": "当前：{{path}}",
     "defaultWorkspace": "默认工作区",
@@ -1003,7 +981,6 @@
     "localPreview": "本地预览",
     "openUrl": "打开部署地址",
     "copyUrl": "复制部署地址",
-    "urlCopied": "已复制部署地址",
     "revealInFinder": "在 Finder 打开目录",
     "rename": "重命名",
     "delete": "删除",
@@ -1023,7 +1000,8 @@
     "visibilityTeam": "团队",
     "submit": "创建",
     "cancel": "取消",
-    "createError": "创建失败"
+    "createError": "创建失败",
+    "urlCopyFailed": "复制失败"
   },
   "settings": {
     "description": "配置 TeamClaw 设置。",
@@ -1054,7 +1032,6 @@
       "results": "检查结果",
       "exportTitle": "导出与反馈",
       "copyReport": "复制诊断报告",
-      "copied": "诊断报告已复制到剪贴板",
       "copyFailed": "复制失败",
       "exportZip": "导出 zip 包",
       "exported": "诊断包已保存",
@@ -1077,11 +1054,9 @@
         "copy": "复制",
         "clear": "清空",
         "consoleEmpty": "暂无 Console 输出",
-        "consoleCopied": "Console 日志已复制",
         "refreshState": "刷新快照",
         "copyJson": "复制 JSON",
         "loadingState": "正在收集状态…",
-        "stateCopied": "运行状态已复制",
         "stateRefreshFailed": "刷新状态失败：{{message}}",
         "refreshDisk": "刷新日志",
         "openAppLogs": "桌面应用日志",
@@ -1140,7 +1115,6 @@
       "displayName": "显示名称",
       "displayNameDesc": "队友看到的你的名字",
       "displayNamePlaceholder": "你的名字",
-      "displayNameSaved": "显示名称已更新",
       "displayNameError": "无法更新显示名称",
       "teamInfo": "团队与组织",
       "teamName": "团队名称",
@@ -1155,7 +1129,6 @@
       "closeWindowAsk": "每次询问",
       "closeWindowTray": "最小化到托盘（保持 Agent）",
       "closeWindowQuit": "退出并停止 Agent",
-      "closeWindowSaved": "关闭偏好已更新",
       "closeWindowError": "无法更新关闭偏好",
       "notifications": "通知",
       "notificationsDesc": "接收桌面通知",
@@ -1165,7 +1138,6 @@
       "mqttStatusConnected": "已连接",
       "mqttStatusDisconnected": "未连接",
       "mqttReconnect": "重连",
-      "mqttReconnecting": "正在重连…",
       "mqttLastError": "上次错误",
       "mqttSource": "来源",
       "mqttSourceCache": "上次可用的地址 —— 云端当前未下发。",
@@ -1173,7 +1145,6 @@
       "mqttCachedHint": "云端未下发 MQTT 地址，这里用的是上次能连通的地址。",
       "mqttMissingFromServer": "云端未下发 MQTT 地址。在配置好之前，实时同步处于离线状态。",
       "mqttRefetch": "重试",
-      "mqttRefetchApplied": "已从云端更新 Broker",
       "mqttRefetchEmpty": "云端仍未返回 MQTT 配置",
       "mqttRefetchFailed": "无法连接云端",
       "save": "保存",
@@ -1608,12 +1579,9 @@
       "unknownAgent": "未知 Agent",
       "setDefault": "设为默认",
       "defaultPersistFailed": "默认 workspace 未能保存到云端，请稍后重试。",
-      "defaultUpdated": "已设为默认 workspace",
       "defaultSavedDaemonPending": "默认 workspace 已保存",
       "daemonRegisterFailed": "Daemon 注册失败：{{message}}",
       "noDaemonDevice": "本机 Daemon 未连接。",
-      "added": "Workspace 已添加",
-      "addedAsDefault": "Workspace 已添加并设为默认",
       "archive": "归档",
       "archivedTitle": "已归档",
       "restore": "恢复"
@@ -1645,7 +1613,6 @@
       "startSetup": "开始设置",
       "saveChanges": "保存更改",
       "saving": "保存中...",
-      "saveSuccess": "更改已保存",
       "saveError": "保存更改失败",
       "test": "测试",
       "setup": "设置",
@@ -2212,7 +2179,6 @@
         "title": "链接与会话映射",
         "description": "清除当前团队下，白名单页面链接与聊天会话之间的已保存关联。",
         "clear": "清除当前团队映射",
-        "cleared": "已清除当前团队的链接-会话映射",
         "clearError": "无法清除链接映射",
         "noTeam": "请先选择团队",
         "confirmTitle": "清除链接映射？",
@@ -2419,7 +2385,6 @@
       "proTip": "专业提示",
       "proTipDesc": "良好的系统提示词应包含您偏好的回复风格、所需的领域专业知识以及 AI 应遵循的具体指南。",
       "saveChanges": "保存更改",
-      "saveSuccess": "系统提示词已保存",
       "saveError": "保存系统提示词失败",
       "saveReloadWarning": "系统提示词已保存，但 Agent 运行时重载失败"
     },
@@ -2880,7 +2845,6 @@
       "documentDeleted": "文档已删除",
       "deleteDocumentFailed": "删除文档失败",
       "configSavedNeedsReindex": "配置已保存，但需要重建索引才能生效",
-      "configSaved": "配置已保存",
       "saveConfigFailed": "保存配置失败",
       "watcherStopped": "文件监控已停止",
       "stopWatcherFailed": "停止文件监控失败"
@@ -2963,7 +2927,6 @@
     "pathCopied": "路径已复制",
     "revertFailed": "还原文件失败",
     "revertFile": "还原文件",
-    "reverted": "文件已还原",
     "reviewCode": "审查代码",
     "suggestRefactor": "建议重构"
   },
@@ -2996,9 +2959,7 @@
     "joining": "加入中…",
     "public": "公开",
     "ungrouped": "其它",
-    "lastUsed": "最后使用",
-    "public": "公开",
-    "joining": "加入中…"
+    "lastUsed": "最后使用"
   },
   "team": {
     "viewerReadOnly": "只读模式 - 你没有编辑权限",
@@ -3083,8 +3044,6 @@
       "body": "将 {{name}} 从团队中移除。此操作无法撤销。",
       "cta": "移除"
     },
-    "copiedName": "已复制名字",
-    "copiedId": "已复制 ID",
     "copyFailed": "复制失败",
     "removed": "已从团队移除",
     "removeFailed": {
@@ -3131,7 +3090,6 @@
     "titlePlaceholder": "想法标题",
     "descriptionPlaceholder": "约束是什么？预期收益是什么？",
     "createButton": "创建",
-    "created": "想法已创建",
     "createFailed": "创建失败：{{msg}}",
     "contextMenu": {
       "view": "查看",
@@ -3161,10 +3119,8 @@
       "priorityPlaceholder": "--- 优先级",
       "tags": "标签",
       "loadFailed": "加载想法失败: {{msg}}",
-      "saved": "想法已保存",
       "saveFailed": "保存失败: {{msg}}",
       "save": "保存",
-      "activityPosted": "动态已发布",
       "activityFailed": "发布动态失败: {{msg}}",
       "activityPlaceholder": "发布进展、决策记录或下一步...",
       "postActivity": "发布动态",
@@ -3172,13 +3128,9 @@
       "noActivity": "暂无动态。",
       "unknownActor": "未知"
     },
-    "archived": "想法已删除",
-    "copiedId": "已复制 ID",
     "copyFailed": "复制失败",
     "deleteFailed": "删除失败: {{msg}}",
-    "statusUpdated": "状态已更新",
     "statusFailed": "状态更新失败: {{msg}}",
-    "renamed": "想法已重命名",
     "renameFailed": "重命名失败: {{msg}}"
   },
   "invite": {
@@ -3197,7 +3149,6 @@
     "expiresAt": "{{date}} 过期",
     "createButton": "创建邀请",
     "copy": "复制",
-    "copied": "邀请链接已复制",
     "copyFailed": "复制失败",
     "failed": "创建邀请失败：{{msg}}",
     "upgradeRequired": "当前团队还在公共组织下，只能自己使用。升级账号、创建你自己的团队后即可邀请成员。",
@@ -3277,12 +3228,5 @@
   "tabBar": {
     "closeAria": "关闭标签页",
     "findClose": "关闭（Esc）"
-  },
-  "session": {
-    "deeplink": {
-      "noAccess": "无权访问该会话",
-      "notFound": "会话不存在或已被删除",
-      "openFailed": "打开会话失败"
-    }
   }
 }

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -481,9 +481,7 @@
       "noMatchingModels": "没有匹配的模型",
       "removeMention": "移除提及",
       "modelChangeFailed": "切换模型失败",
-      "modelChangeWillRetry": "选择已保存，将在下次发送消息时重新应用。详情：{{message}}",
-      "modelPickSaved": "已选择模型",
-      "modelPickSavedHint": "将在发送消息或 runtime 就绪后应用到 Agent"
+      "modelChangeWillRetry": "选择已保存，将在下次发送消息时重新应用。详情：{{message}}"
     },
     "sessionAgent": {
       "bannerStaleOne": "{{name}} 已与当前本机 Agent 断开 — 消息可能不会由 Agent 处理",

--- a/packages/app/src/stores/__tests__/knowledge-store.test.ts
+++ b/packages/app/src/stores/__tests__/knowledge-store.test.ts
@@ -317,7 +317,7 @@ describe('Knowledge Store', () => {
       await useKnowledgeStore.getState().saveConfig(newConfig)
 
       expect(useKnowledgeStore.getState().needsReindex).toBe(false)
-      expect(mockToast.success).toHaveBeenCalledWith('knowledge.toast.configSaved')
+      expect(mockToast.success).not.toHaveBeenCalled()
     })
 
     it('shows error toast on failure', async () => {

--- a/packages/app/src/stores/knowledge.ts
+++ b/packages/app/src/stores/knowledge.ts
@@ -449,8 +449,6 @@ export const useKnowledgeStore = create<KnowledgeState>((set, get) => ({
       
       if (needsReindex) {
         toast.warning(i18n.t('knowledge.toast.configSavedNeedsReindex'))
-      } else {
-        toast.success(i18n.t('knowledge.toast.configSaved'))
       }
     } catch (error) {
       console.error('Failed to save config:', error)

--- a/packages/app/src/stores/provider.ts
+++ b/packages/app/src/stores/provider.ts
@@ -491,7 +491,6 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
       newDisconnected.delete(providerId)
       return { _disconnectedIds: newDisconnected }
     })
-    toast.success('Provider connected', { description: `Successfully connected ${providerId}` })
     await reloadRuntimeAfterProviderChange(workspacePath)
     await Promise.all([get().refreshProviders(), get().refreshConfiguredProviders()])
     return true
@@ -565,9 +564,6 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
       await putDaemonProviderAuth(encodeWorkspaceId(workspacePath), providerId, {
         api_key: trimmedKey,
       })
-      if (providerId !== 'team') {
-        toast.success('Provider connected', { description: `Successfully connected ${providerId}` })
-      }
       set((state) => {
         const newDisconnected = new Set(state._disconnectedIds)
         newDisconnected.delete(providerId)
@@ -594,7 +590,6 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
     try {
       await deleteDaemonProviderAuth(encodeWorkspaceId(workspacePath), providerId)
       await reloadRuntimeAfterProviderChange(workspacePath)
-      toast.success('Provider disconnected', { description: `Successfully disconnected ${providerId}` })
       set((state) => {
         const newDisconnected = new Set(state._disconnectedIds)
         newDisconnected.add(providerId)
@@ -664,9 +659,6 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
       })
       await reloadRuntimeAfterProviderChange(workspacePath)
       await Promise.all([get().refreshProviders(), get().refreshConfiguredProviders()])
-      toast.success('Custom provider added', {
-        description: `${config.name} has been added. Restarting agent...`,
-      })
       return providerId
     } catch (err) {
       console.error('Failed to add custom provider:', err)
@@ -698,9 +690,6 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
       })
       await reloadRuntimeAfterProviderChange(workspacePath)
       await Promise.all([get().refreshProviders(), get().refreshConfiguredProviders()])
-      toast.success('Custom provider updated', {
-        description: `${config.name} has been updated. Restarting agent...`,
-      })
       return true
     } catch (err) {
       console.error('Failed to update custom provider:', err)
@@ -733,9 +722,6 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
     const wsId = encodeWorkspaceId(workspacePath)
     try {
       await deleteDaemonProviderAuth(wsId, providerId)
-      toast.success('Custom provider removed', {
-        description: `Provider has been removed. Restarting agent...`,
-      })
       return true
     } catch (err) {
       console.error('Failed to remove custom provider:', err)

--- a/packages/app/src/stores/workspace-runtime-refresh.ts
+++ b/packages/app/src/stores/workspace-runtime-refresh.ts
@@ -116,14 +116,6 @@ export const useWorkspaceRuntimeRefreshStore = create<WorkspaceRuntimeRefreshSta
           description:
             'Configuration was applied. Start a new session or wait for active runtimes to reload.',
         })
-      } else if (outcome === 'reload_required') {
-        toast.success('Runtime reload queued', {
-          description: 'OpenCode will pick up the pending workspace changes.',
-        })
-      } else if (outcome === 'applied_live') {
-        toast.success('Changes applied', {
-          description: 'The workspace runtime picked up the latest configuration.',
-        })
       }
 
       const refresh = get().refresh


### PR DESCRIPTION
## Summary
- Remove noisy success/info toasts that duplicate existing UI feedback (copy, save/connect, workspace/ideas CRUD, FileTree clipboard).
- Drop chat deferred-model pick toast and empty-send / no-session @-mention hints.
- Keep real errors, actionable warnings (e.g. mention route failed, restart required), and long-running task completion toasts.

## Test plan
- [ ] Copy actor ID / invite / share link — no success toast; failure still toasts
- [ ] Switch model with no session/team — no “Model selected” toast; pick still sticks on pill
- [ ] Send empty message with agent engaged — silently rejected (no warning toast)
- [ ] @ agent before a session exists — silently no-ops (no info toast)
- [ ] Save settings / connect provider / cut-paste files — no success toast; errors still surface
- [ ] Knowledge reindex / diagnostics export — completion toasts still appear

Made with [Cursor](https://cursor.com)