### PR TITLE
fix(workspaces): team-scoped RLS for multi-team workspace inserts

### DIFF
--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -1046,13 +1046,28 @@ export function createSupabaseBusinessRepository(options) {
     },
 
     async upsertWorkspace(input) {
+      // AUTHZ: created_by is ALWAYS resolved server-side from the authenticated
+      // caller scoped to the target team. Any client-supplied
+      // `input.createdByMemberId` is ignored — a multi-team user's client can
+      // send the wrong team's member actor id (stale current-team value), which
+      // the workspaces INSERT RLS WITH CHECK then rejects. Deriving it here
+      // guarantees the row satisfies the team-scoped policy regardless of what
+      // the client sends (mirrors createSession / createApp).
+      const { data: userData, error: userErr } = await supabase.auth.getUser();
+      if (userErr) throw userErr;
+      const userId = userData?.user?.id;
+      if (!userId) throw new ApiError(401, "unauthorized", "no authenticated user");
+      const resolved = await this.resolveCurrentMemberActor(input.teamId, userId);
+      if (!resolved?.id) throw new ApiError(403, "forbidden", "not a member of this team");
+      const createdByMemberId = resolved.id;
+
       const row = {
         id: input.id,
         team_id: input.teamId,
         name: input.name,
         path: input.path ?? input.slug ?? null,
         agent_id: input.agentId ?? null,
-        created_by_member_id: input.createdByMemberId ?? null,
+        created_by_member_id: createdByMemberId,
         archived: input.archived ?? false,
       };
       const { data, error } = await supabase

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -1430,10 +1430,13 @@ function appsSupabase({ seed = {}, actorRow = { id: "actor-app-1" }, calls = [] 
           ctx.update = row;
           return builder;
         },
-        upsert(row: any) {
-          calls.push({ table, op: "upsert", row });
-          // session_participants seeding etc. — resolve immediately.
-          return Promise.resolve({ data: null, error: null });
+        upsert(row: any, options?: any) {
+          ctx.op = "upsert";
+          calls.push({ table, op: "upsert", row, options });
+          const upserted = { ...row, id: row.id ?? `${table}-id-1` };
+          state[table] = [upserted];
+          ctx.inserted = upserted;
+          return builder;
         },
         eq(column: string, value: any) {
           ctx.filters[column] = value;
@@ -1446,7 +1449,7 @@ function appsSupabase({ seed = {}, actorRow = { id: "actor-app-1" }, calls = [] 
         // table rows (used by listApps).
         limit() { return builder; },
         single() {
-          if (ctx.op === "insert") return Promise.resolve({ data: ctx.inserted, error: null });
+          if (ctx.op === "insert" || ctx.op === "upsert") return Promise.resolve({ data: ctx.inserted, error: null });
           if (ctx.op === "update") {
             const base = state[table]?.[0] ?? {};
             const merged = { ...base, ...ctx.update };
@@ -1807,6 +1810,37 @@ test("apps: createSession omits app_id when no appId given", async () => {
   });
   const insert = calls.find((c) => c.table === "sessions" && c.op === "insert");
   assert.ok(!("app_id" in (insert?.row ?? {})), "app_id must be absent for plain sessions");
+});
+
+test("upsertWorkspace resolves createdByMemberId server-side (ignores client spoof)", async () => {
+  // Same multi-team bug as createSession: client may send another team's member
+  // id; workspaces INSERT RLS requires the team-scoped actor.
+  const calls: any[] = [];
+  const repo = appsRepo(appsSupabase({ actorRow: { id: "actor-team-b" }, calls }));
+  const out = await repo.upsertWorkspace({
+    teamId: "team-b",
+    name: "Alpha",
+    path: "/tmp/alpha",
+    agentId: "agent-1",
+    createdByMemberId: "actor-SPOOFED-team-a",
+  });
+  const upsert = calls.find((c) => c.table === "workspaces" && c.op === "upsert");
+  assert.equal(
+    upsert?.row.created_by_member_id,
+    "actor-team-b",
+    "created_by must be the server-resolved team actor, not the client value",
+  );
+  assert.equal(upsert?.row.team_id, "team-b");
+  assert.equal(out.teamId, "team-b");
+  assert.equal(out.name, "Alpha");
+});
+
+test("upsertWorkspace returns 403 when the caller is not a member of the team", async () => {
+  const repo = appsRepo(appsSupabase({ actorRow: null }));
+  await assert.rejects(
+    () => repo.upsertWorkspace({ teamId: "team-b", name: "Nope", path: "/tmp/x" }),
+    (err: any) => err?.statusCode === 403,
+  );
 });
 
 test("createSession is server-authoritative for created_by (ignores client createdByActorId)", async () => {

--- a/services/supabase/migrations/20260731000000_fix_workspaces_insert_rls.sql
+++ b/services/supabase/migrations/20260731000000_fix_workspaces_insert_rls.sql
@@ -1,0 +1,27 @@
+-- Fix workspaces INSERT RLS for multi-team users.
+--
+-- workspaces_insert_if_team_member previously required
+--   created_by_member_id = amux.current_member_id()
+-- but current_member_id() returns the caller's *oldest* active member actor
+-- across ALL teams (no team filter). A user in team A (older) and team B who
+-- creates a workspace in team B with their team-B member id fails RLS even
+-- though they are a legitimate member — the classic current_member_id
+-- multi-team bug already documented in FC authz helpers.
+--
+-- Daemon agents use a separate auth user, so workspaces_agent_write
+-- (is_current_agent) does not cover the human "add workspace" path either.
+--
+-- Fix: compare against the team-scoped helper, matching sessions/apps insert
+-- policies (created_by_* = current_actor_id_for_team(team_id)).
+
+drop policy if exists workspaces_insert_if_team_member on amux.workspaces;
+
+create policy workspaces_insert_if_team_member on amux.workspaces
+  for insert to authenticated
+  with check (
+    amux.is_team_member(team_id)
+    and (
+      created_by_member_id is null
+      or created_by_member_id = amux.current_actor_id_for_team(team_id)
+    )
+  );

--- a/services/supabase/tests/026_workspaces_insert_rls.sql
+++ b/services/supabase/tests/026_workspaces_insert_rls.sql
@@ -1,0 +1,82 @@
+-- services/supabase/tests/026_workspaces_insert_rls.sql
+-- Multi-team users can insert a workspace in team B with team B's member id
+-- even when their oldest member actor lives on team A (current_member_id bug).
+begin;
+
+create or replace function pg_temp.as_member(p_user uuid)
+returns void language plpgsql as $$
+begin
+  perform set_config('request.jwt.claims',
+                     json_build_object('sub', p_user::text, 'role', 'authenticated')::text,
+                     true);
+  perform set_config('role', 'authenticated', true);
+end;
+$$;
+
+do $$
+declare
+  v_team_a     uuid := gen_random_uuid();
+  v_team_b     uuid := gen_random_uuid();
+  v_uid        uuid := gen_random_uuid();
+  v_member_a   uuid := gen_random_uuid();
+  v_member_b   uuid := gen_random_uuid();
+  v_other_uid  uuid := gen_random_uuid();
+  v_other_mem  uuid := gen_random_uuid();
+  v_ws_id      uuid;
+begin
+  insert into auth.users (id, email, aud, role, instance_id, is_anonymous)
+  values
+    (v_uid, 'ws-multi@amux.test', 'authenticated', 'authenticated',
+     '00000000-0000-0000-0000-000000000000', false),
+    (v_other_uid, 'ws-other@amux.test', 'authenticated', 'authenticated',
+     '00000000-0000-0000-0000-000000000000', false)
+  on conflict do nothing;
+
+  insert into amux.teams (id, slug, name)
+  values
+    (v_team_a, 'ws-rls-a-' || substr(v_team_a::text, 1, 8), 'WS RLS Team A'),
+    (v_team_b, 'ws-rls-b-' || substr(v_team_b::text, 1, 8), 'WS RLS Team B');
+
+  -- Team A member created first → current_member_id() would return v_member_a.
+  insert into amux.actors (id, team_id, actor_type, user_id, display_name)
+  values
+    (v_member_a, v_team_a, 'member', v_uid, 'Me@A'),
+    (v_member_b, v_team_b, 'member', v_uid, 'Me@B'),
+    (v_other_mem, v_team_b, 'member', v_other_uid, 'Other@B');
+  insert into amux.members (id, status)
+  values (v_member_a, 'active'), (v_member_b, 'active'), (v_other_mem, 'active');
+  insert into amux.team_members (team_id, member_id, role)
+  values
+    (v_team_a, v_member_a, 'owner'),
+    (v_team_b, v_member_b, 'member'),
+    (v_team_b, v_other_mem, 'member');
+
+  perform pg_temp.as_member(v_uid);
+
+  -- Allowed: insert in team B attributed to the team-B member actor.
+  insert into amux.workspaces (team_id, created_by_member_id, name, path)
+  values (v_team_b, v_member_b, 'Team B Workspace', '/tmp/team-b-ws')
+  returning id into v_ws_id;
+
+  if v_ws_id is null then
+    raise exception 'expected workspace insert in team B to succeed';
+  end if;
+
+  -- Denied: spoof another member as created_by.
+  begin
+    insert into amux.workspaces (team_id, created_by_member_id, name)
+    values (v_team_b, v_other_mem, 'Spoofed');
+    raise exception 'creator spoofing should be blocked';
+  exception
+    when insufficient_privilege then null;
+    when others then
+      if sqlstate is distinct from '42501' then
+        raise;
+      end if;
+  end;
+
+  perform set_config('role', 'postgres', true);
+end;
+$$;
+
+rollback;


### PR DESCRIPTION
## Summary
- Fixes `Failed to add workspace: new row violates row-level security policy for table "workspaces"` for users in multiple teams.
- Root cause: `workspaces_insert_if_team_member` compared `created_by_member_id` to `amux.current_member_id()`, which returns the oldest member actor across all teams (not team-scoped). Daemon agents use a separate auth user, so `workspaces_agent_write` does not cover this path.
- Migration updates the INSERT policy to use `current_actor_id_for_team(team_id)` (same pattern as sessions/apps). FC `upsertWorkspace` resolves `created_by_member_id` server-side so stale/spoofed client ids cannot trip RLS.

## Test plan
- [ ] Unit: `cd services/fc && node --import tsx --test --test-name-pattern='upsertWorkspace' test/supabase-repo.test.ts`
- [ ] After deploy (migration + FC): as a multi-team user, add a workspace from the local daemon card in a non-oldest team — should succeed
- [ ] Confirm creator spoofing still rejected (pgTAP `026_workspaces_insert_rls.sql` / live insert with another member's id)


Made with [Cursor](https://cursor.com)