### PR TITLE
fix(fc): reuse archived workspaces on upsert

### DIFF
--- a/services/fc/src/lib/pg-repo/workspaces.ts
+++ b/services/fc/src/lib/pg-repo/workspaces.ts
@@ -9,7 +9,7 @@
  *    columns added in migration 0003_complex_synch.sql.
  */
 
-import { and, desc, eq, inArray, lt } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, lt, or } from "drizzle-orm";
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { workspaces, teamWorkspaceConfig } from "../../db/schema/index.js";
 
@@ -18,6 +18,44 @@ const iso = (d: Date | string | null | undefined): string | null =>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DbLike = PgDatabase<any, any>;
+
+function normalizeWorkspacePath(path: string | null | undefined): string | null {
+  if (path == null) return null;
+  const trimmed = path.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/\/+$/, "") || trimmed;
+}
+
+function agentIdCondition(agentId: string | null | undefined) {
+  return agentId ? eq(workspaces.agentId, agentId) : isNull(workspaces.agentId);
+}
+
+function pathLookupCondition(teamId: string, normalizedPath: string) {
+  return and(
+    eq(workspaces.teamId, teamId),
+    or(eq(workspaces.path, normalizedPath), eq(workspaces.path, `${normalizedPath}/`)),
+  );
+}
+
+async function findUniqueWorkspaceName(
+  db: DbLike,
+  teamId: string,
+  agentId: string | null | undefined,
+  baseName: string,
+): Promise<string> {
+  let candidate = baseName;
+  let suffix = 2;
+  while (true) {
+    const [existing] = await db
+      .select({ id: workspaces.id })
+      .from(workspaces)
+      .where(and(eq(workspaces.teamId, teamId), agentIdCondition(agentId), eq(workspaces.name, candidate)))
+      .limit(1);
+    if (!existing) return candidate;
+    candidate = `${baseName} (${suffix})`;
+    suffix += 1;
+  }
+}
 
 function mapWorkspace(r: any) {
   return {
@@ -80,14 +118,47 @@ export function makeWorkspacesRepo(db: DbLike) {
       archived?: boolean;
     }) {
       let targetId = input.id ?? null;
+      const normalizedPath = normalizeWorkspacePath(input.path);
+      let resolvedName = input.name;
 
-      if (!targetId && input.path) {
+      if (!targetId && normalizedPath) {
         const [existing] = await db
           .select({ id: workspaces.id })
           .from(workspaces)
-          .where(and(eq(workspaces.teamId, input.teamId), eq(workspaces.path, input.path)))
+          .where(pathLookupCondition(input.teamId, normalizedPath))
           .limit(1);
         if (existing) targetId = existing.id;
+      }
+
+      if (!targetId) {
+        const [existingByName] = await db
+          .select({ id: workspaces.id, path: workspaces.path, archived: workspaces.archived })
+          .from(workspaces)
+          .where(
+            and(
+              eq(workspaces.teamId, input.teamId),
+              agentIdCondition(input.agentId),
+              eq(workspaces.name, resolvedName),
+            ),
+          )
+          .limit(1);
+
+        if (existingByName) {
+          const existingPath = normalizeWorkspacePath(existingByName.path);
+          if (normalizedPath && existingPath === normalizedPath) {
+            targetId = existingByName.id;
+          } else if (existingByName.archived) {
+            // Re-bind an archived row instead of violating (team_id, agent_id, name).
+            targetId = existingByName.id;
+          } else {
+            resolvedName = await findUniqueWorkspaceName(
+              db,
+              input.teamId,
+              input.agentId,
+              resolvedName,
+            );
+          }
+        }
       }
 
       if (targetId) {
@@ -95,8 +166,8 @@ export function makeWorkspacesRepo(db: DbLike) {
           .values({
             id: targetId,
             teamId: input.teamId,
-            name: input.name,
-            path: input.path ?? null,
+            name: resolvedName,
+            path: normalizedPath,
             agentId: input.agentId ?? null,
             createdByMemberId: input.createdByMemberId ?? null,
             archived: input.archived ?? false,
@@ -104,8 +175,8 @@ export function makeWorkspacesRepo(db: DbLike) {
           .onConflictDoUpdate({
             target: workspaces.id,
             set: {
-              name: input.name,
-              path: input.path ?? null,
+              name: resolvedName,
+              path: normalizedPath,
               agentId: input.agentId ?? null,
               archived: input.archived ?? false,
               updatedAt: new Date(),
@@ -118,8 +189,8 @@ export function makeWorkspacesRepo(db: DbLike) {
       const [r] = await (db.insert(workspaces) as any)
         .values({
           teamId: input.teamId,
-          name: input.name,
-          path: input.path ?? null,
+          name: resolvedName,
+          path: normalizedPath,
           agentId: input.agentId ?? null,
           createdByMemberId: input.createdByMemberId ?? null,
           archived: input.archived ?? false,

--- a/services/fc/test/pg-repo-workspaces.test.ts
+++ b/services/fc/test/pg-repo-workspaces.test.ts
@@ -165,6 +165,93 @@ test("pg-repo [workspaces]: upsertWorkspace cross-team same-path creates distinc
   assert.equal((count.rows[0] as { n: number }).n, 2, "both T1 and T2 workspaces should exist for same path");
 });
 
+test("pg-repo [workspaces]: upsertWorkspace disambiguates name when same agent already has that name at another path", async () => {
+  const { pg, repo } = await makeRepo();
+  await seedTeam(pg, T1, "t1-name-collision-slug");
+  const agentId = "d0000000-0000-0000-0000-000000000001";
+
+  await repo.upsertWorkspace({
+    teamId: T1,
+    agentId,
+    name: "teamclaw",
+    path: "/Users/me/code/teamclaw",
+  });
+
+  const second = await repo.upsertWorkspace({
+    teamId: T1,
+    agentId,
+    name: "teamclaw",
+    path: "/Users/me/other/teamclaw",
+  });
+
+  assert.equal(second.name, "teamclaw (2)");
+  assert.equal(second.slug, "/Users/me/other/teamclaw");
+
+  const count = await pg.query(
+    "SELECT count(*)::int AS n FROM workspaces WHERE team_id = $1 AND agent_id = $2",
+    [T1, agentId],
+  );
+  assert.equal((count.rows[0] as { n: number }).n, 2);
+});
+
+test("pg-repo [workspaces]: upsertWorkspace reuses archived row with same name instead of inserting", async () => {
+  const { pg, repo } = await makeRepo();
+  await seedTeam(pg, T1, "t1-archived-reuse-slug");
+  const agentId = "d0000000-0000-0000-0000-000000000002";
+
+  const archived = await repo.upsertWorkspace({
+    teamId: T1,
+    agentId,
+    name: "legacy",
+    path: "/Users/me/legacy",
+    archived: true,
+  });
+
+  const restored = await repo.upsertWorkspace({
+    teamId: T1,
+    agentId,
+    name: "legacy",
+    path: "/Users/me/legacy-new",
+    archived: false,
+  });
+
+  assert.equal(restored.id, archived.id);
+  assert.equal(restored.archived, false);
+  assert.equal(restored.slug, "/Users/me/legacy-new");
+
+  const count = await pg.query(
+    "SELECT count(*)::int AS n FROM workspaces WHERE team_id = $1 AND name = $2",
+    [T1, "legacy"],
+  );
+  assert.equal((count.rows[0] as { n: number }).n, 1);
+});
+
+test("pg-repo [workspaces]: upsertWorkspace dedups path with trailing slash", async () => {
+  const { pg, repo } = await makeRepo();
+  await seedTeam(pg, T1, "t1-trailing-slash-slug");
+
+  const first = await repo.upsertWorkspace({
+    teamId: T1,
+    name: "slash-test",
+    path: "/tmp/slash-test/",
+  });
+
+  const second = await repo.upsertWorkspace({
+    teamId: T1,
+    name: "slash-test",
+    path: "/tmp/slash-test",
+  });
+
+  assert.equal(second.id, first.id);
+  assert.equal(second.slug, "/tmp/slash-test");
+
+  const count = await pg.query(
+    "SELECT count(*)::int AS n FROM workspaces WHERE team_id = $1 AND path IN ($2, $3)",
+    [T1, "/tmp/slash-test", "/tmp/slash-test/"],
+  );
+  assert.equal((count.rows[0] as { n: number }).n, 1);
+});
+
 // ── getWorkspace ──────────────────────────────────────────────────────────────
 
 test("pg-repo [workspaces]: getWorkspace returns named workspace", async () => {


### PR DESCRIPTION
## Summary

- Fix `POST /v1/workspaces` failing with `workspaces_team_id_agent_id_name_key` when re-adding a sidebar-archived workspace (soft delete leaves the row in DB).
- Extend `upsertWorkspace` to reuse archived rows by `(teamId, agentId, name)`, normalize paths (trailing slash), and auto-disambiguate active name collisions across different directories.
- Add pg-repo tests for archived reuse, name collision, and path normalization.

## Test plan

- [ ] `cd services/fc && pnpm test -- test/pg-repo-workspaces.test.ts`
- [ ] Sidebar: archive a workspace, then re-add the same folder — should succeed and show in the list again
- [ ] Add two different folders with the same basename under the same agent — second should appear as `name (2)` instead of erroring


Made with [Cursor](https://cursor.com)