### PR TITLE
test: fix the three classes of flaky test

### DIFF
--- a/packages/app/src/components/chat/__tests__/ChatMessage-streaming.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ChatMessage-streaming.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, act, fireEvent } from '@testing-library/react';
 import { useStreamingStore } from '@/stores/streaming';
 import { useSessionStore, sessionLookupCache } from '@/stores/session';
+import * as ChatMessageModule from '../ChatMessage';
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 
@@ -76,9 +77,13 @@ describe('ChatMessage streaming typewriter', () => {
     vi.restoreAllMocks();
   });
 
-  async function importChatMessage() {
-    const mod = await import('../ChatMessage');
-    return mod.ChatMessage;
+  // Kept as a function so call sites stay unchanged, but the module is now
+  // resolved statically at file-eval time. Importing it inside each test spent
+  // that test's 5s budget on Vite transforming a large dependency tree, which
+  // under a fully parallel run was enough to time out — and the render then
+  // landed after cleanup, leaking DOM into the next test.
+  function importChatMessage() {
+    return ChatMessageModule.ChatMessage;
   }
 
   it('displays streamingContent from streaming store during active streaming', async () => {

--- a/packages/app/src/components/panel/__tests__/RightPanel-interactions.test.tsx
+++ b/packages/app/src/components/panel/__tests__/RightPanel-interactions.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { RightPanel } from '@/components/panel/RightPanel';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -64,7 +65,6 @@ describe('RightPanel interactions', () => {
   describe('tab content rendering based on store state', () => {
     it('shows shortcuts tab when store activeTab is shortcuts', async () => {
       mockStoreState.activeTab = 'shortcuts';
-      const { RightPanel } = await import('@/components/panel/RightPanel');
       render(React.createElement(RightPanel));
       expect(screen.getByTestId('shortcuts-panel')).toBeDefined();
       expect(screen.queryByTestId('session-diff')).toBeNull();
@@ -73,7 +73,6 @@ describe('RightPanel interactions', () => {
 
     it('shows diff tab when store activeTab is diff', async () => {
       mockStoreState.activeTab = 'diff';
-      const { RightPanel } = await import('@/components/panel/RightPanel');
       render(React.createElement(RightPanel));
       expect(screen.getByText('No changes yet')).toBeDefined();
       expect(screen.queryByText('No tasks yet')).toBeNull();
@@ -81,7 +80,6 @@ describe('RightPanel interactions', () => {
 
     it('shows session list when store activeTab is session', async () => {
       mockStoreState.activeTab = 'session';
-      const { RightPanel } = await import('@/components/panel/RightPanel');
       render(React.createElement(RightPanel));
       expect(screen.getByTestId('session-list')).toBeDefined();
       expect(screen.queryByText('No tasks yet')).toBeNull();
@@ -89,7 +87,6 @@ describe('RightPanel interactions', () => {
 
     it('shows shortcuts panel when store activeTab is shortcuts', async () => {
       mockStoreState.activeTab = 'shortcuts';
-      const { RightPanel } = await import('@/components/panel/RightPanel');
       render(React.createElement(RightPanel));
       expect(screen.getByTestId('shortcuts-panel')).toBeDefined();
     });
@@ -98,7 +95,6 @@ describe('RightPanel interactions', () => {
   describe('defaultTab overrides store tab', () => {
     it('uses defaultTab over store activeTab', async () => {
       mockStoreState.activeTab = 'shortcuts'; // store says shortcuts
-      const { RightPanel } = await import('@/components/panel/RightPanel');
       render(React.createElement(RightPanel, { defaultTab: 'diff' })); // but prop says diff
       expect(screen.getByText('No changes yet')).toBeDefined();
       expect(screen.queryByTestId('shortcuts-panel')).toBeNull();
@@ -107,7 +103,6 @@ describe('RightPanel interactions', () => {
 
   describe('data flow: props vs store fallback', () => {
     it('uses provided diff prop instead of store data', async () => {
-      const { RightPanel } = await import('@/components/panel/RightPanel');
       const customDiff = [
         { path: '/src/a.ts', before: 'old', after: 'new' },
       ];
@@ -117,14 +112,12 @@ describe('RightPanel interactions', () => {
     });
 
     it('uses shortcuts tab from store when no override is provided', async () => {
-      const { RightPanel } = await import('@/components/panel/RightPanel');
       render(React.createElement(RightPanel));
       expect(screen.getByTestId('shortcuts-panel')).toBeDefined();
     });
 
     it('passes knowledge browser props through to KnowledgeBrowser', async () => {
       mockStoreState.activeTab = 'files';
-      const { RightPanel } = await import('@/components/panel/RightPanel');
       render(React.createElement(RightPanel, {
         knowledgeBrowserProps: {
           hidePanelToolbar: true,
@@ -139,7 +132,6 @@ describe('RightPanel interactions', () => {
 
   describe('compact mode', () => {
     it('applies compact padding class for tasks tab', async () => {
-      const { RightPanel } = await import('@/components/panel/RightPanel');
       const { container: compactEl } = render(React.createElement(RightPanel, { compact: true }));
       const { container: normalEl } = render(React.createElement(RightPanel, { compact: false }));
       // Compact should use p-1, normal should use p-2
@@ -149,7 +141,6 @@ describe('RightPanel interactions', () => {
 
     it('removes padding for session and actors tabs', async () => {
       mockStoreState.activeTab = 'session';
-      const { RightPanel } = await import('@/components/panel/RightPanel');
       const { container } = render(React.createElement(RightPanel));
       // session/actors tabs should not have p-1 or p-2
       const className = container.firstElementChild?.className || '';
@@ -161,7 +152,6 @@ describe('RightPanel interactions', () => {
   describe('only one tab content is rendered at a time', () => {
     it('does not render multiple tabs simultaneously', async () => {
       mockStoreState.activeTab = 'shortcuts';
-      const { RightPanel } = await import('@/components/panel/RightPanel');
       render(React.createElement(RightPanel));
 
       // Only shortcuts should be visible

--- a/packages/app/src/components/panel/__tests__/RightPanel.test.tsx
+++ b/packages/app/src/components/panel/__tests__/RightPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import React from 'react'
+import { RightPanel } from '@/components/panel/RightPanel';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -44,19 +45,16 @@ beforeEach(() => {
 
 describe('RightPanel', () => {
   it('renders shortcuts tab from store', async () => {
-    const { RightPanel } = await import('@/components/panel/RightPanel')
     render(React.createElement(RightPanel))
     expect(screen.getByTestId('shortcuts-panel')).toBeDefined()
   })
 
   it('renders diff tab when defaultTab=diff', async () => {
-    const { RightPanel } = await import('@/components/panel/RightPanel')
     render(React.createElement(RightPanel, { defaultTab: 'diff' }))
     expect(screen.getByText('No changes yet')).toBeDefined()
   })
 
   it('renders shortcuts panel when defaultTab=shortcuts', async () => {
-    const { RightPanel } = await import('@/components/panel/RightPanel')
     render(React.createElement(RightPanel, { defaultTab: 'shortcuts' }))
     expect(screen.getByTestId('shortcuts-panel')).toBeDefined()
   })

--- a/packages/app/src/components/settings/__tests__/DiagnosticsSection.reset.test.tsx
+++ b/packages/app/src/components/settings/__tests__/DiagnosticsSection.reset.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DiagnosticReport } from '@/lib/diagnostic-report'
+import { DiagnosticsSection } from '../DiagnosticsSection';
 
 const forceResetMock = vi.hoisted(() => vi.fn(async () => {}))
 
@@ -142,7 +143,6 @@ describe('DiagnosticsSection daemon reset remediation', () => {
 
   it('shows remediation banner when report qualifies for daemon reset', async () => {
     diagnosticsState.report = sampleReport
-    const { DiagnosticsSection } = await import('../DiagnosticsSection')
     render(<DiagnosticsSection />)
 
     expect(screen.getByText('建议重置本地 daemon')).toBeTruthy()
@@ -151,7 +151,6 @@ describe('DiagnosticsSection daemon reset remediation', () => {
 
   it('runs forceReset and opens onboarding wizard after confirmation', async () => {
     diagnosticsState.report = sampleReport
-    const { DiagnosticsSection } = await import('../DiagnosticsSection')
     render(<DiagnosticsSection />)
 
     fireEvent.click(screen.getByRole('button', { name: '重置本地 daemon' }))

--- a/packages/app/src/hooks/__tests__/useAppInit.test.ts
+++ b/packages/app/src/hooks/__tests__/useAppInit.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
+// Derived from `buildConfig.app.name`, so it is brand- and config-dependent —
+// a local run bakes in build.config.dev.json and gets `~/TeamClaw Dev`. These
+// tests are about "falls back to the default workspace", not about which brand
+// is being built, so they assert the constant rather than a literal.
+import { DEFAULT_WORKSPACE_PATH } from '@/lib/build-config'
 
 // --- Hoist mocks ---
 const {
@@ -260,7 +265,7 @@ describe('useWorkspaceInit', () => {
       expect(localStorage.getItem('teamclaw-workspace-path')).toBeNull()
       expect(result.current.initialWorkspaceResolved).toBe(true)
     })
-    expect(mockSetWorkspace).toHaveBeenCalledWith('~/TeamClaw')
+    expect(mockSetWorkspace).toHaveBeenCalledWith(DEFAULT_WORKSPACE_PATH)
   })
 
   it('uses the default workspace when nothing is saved', async () => {
@@ -270,7 +275,7 @@ describe('useWorkspaceInit', () => {
     await waitFor(() => {
       expect(result.current.initialWorkspaceResolved).toBe(true)
     })
-    expect(mockSetWorkspace).toHaveBeenCalledWith('~/TeamClaw')
+    expect(mockSetWorkspace).toHaveBeenCalledWith(DEFAULT_WORKSPACE_PATH)
   })
 
   it('uses the default workspace on first launch even when a team is known', async () => {
@@ -283,7 +288,7 @@ describe('useWorkspaceInit', () => {
     await waitFor(() => {
       expect(result.current.initialWorkspaceResolved).toBe(true)
     })
-    expect(mockSetWorkspace).toHaveBeenCalledWith('~/TeamClaw')
+    expect(mockSetWorkspace).toHaveBeenCalledWith(DEFAULT_WORKSPACE_PATH)
   })
 
   it('uses the default workspace on first launch in Tauri when no team is known', async () => {
@@ -296,7 +301,7 @@ describe('useWorkspaceInit', () => {
     await waitFor(() => {
       expect(result.current.initialWorkspaceResolved).toBe(true)
     })
-    expect(mockSetWorkspace).toHaveBeenCalledWith('~/TeamClaw')
+    expect(mockSetWorkspace).toHaveBeenCalledWith(DEFAULT_WORKSPACE_PATH)
   })
 })
 

--- a/packages/app/src/lib/__tests__/build-config.test.ts
+++ b/packages/app/src/lib/__tests__/build-config.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { buildConfig, appDisplayName } from "@/lib/build-config";
+import {
+  buildConfig,
+  appDisplayName,
+  FALLBACK_BUILD_CONFIG,
+} from "@/lib/build-config";
 
 describe("build-config auth.webSSO", () => {
   it("defaults webSSO to false in the fallback config", () => {
-    // When no build.config.*.json overrides auth, webSSO must be off.
-    expect(buildConfig.features.auth?.webSSO ?? false).toBe(false);
+    // Assert the fallback itself, not the merged `buildConfig`: a local run
+    // bakes in build.config.dev.json, which turns webSSO on deliberately, so
+    // reading the merged value made this test fail on every dev machine while
+    // passing on CI.
+    expect(FALLBACK_BUILD_CONFIG.features.auth?.webSSO ?? false).toBe(false);
   });
 });
 

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -140,7 +140,15 @@ export function hasAnyChannel(channels: boolean | ChannelsFeatureConfig): boolea
   return Object.values(channels).some(Boolean)
 }
 
-const fallback: BuildConfig = {
+/**
+ * Values used when no `build.config.*.json` is baked in.
+ *
+ * Exported because it is a contract worth asserting on: features that must be
+ * opt-in (webSSO) have to default off here, and a test that reads the merged
+ * `buildConfig` instead cannot check that — locally the merge has already
+ * layered `build.config.dev.json` on top.
+ */
+export const FALLBACK_BUILD_CONFIG: BuildConfig = {
   team: {
     lockLlmConfig: false,
   },
@@ -169,8 +177,8 @@ function deepMerge(base: any, override: any): any {
 }
 
 export const buildConfig: BuildConfig = typeof __BUILD_CONFIG__ !== 'undefined' && __BUILD_CONFIG__
-  ? deepMerge(fallback, __BUILD_CONFIG__) as BuildConfig
-  : fallback
+  ? deepMerge(FALLBACK_BUILD_CONFIG, __BUILD_CONFIG__) as BuildConfig
+  : FALLBACK_BUILD_CONFIG
 
 function deriveShortName(name: string): string {
   return name.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()

--- a/packages/app/src/stores/mqtt-reconnect.test.ts
+++ b/packages/app/src/stores/mqtt-reconnect.test.ts
@@ -162,6 +162,27 @@ describe('resetMqttReconnectRecovery', () => {
   })
 })
 
+/**
+ * Poll until `check()` holds, instead of sleeping a fixed amount and hoping.
+ *
+ * `ensureWired()` reaches the bridge through a dynamic `import()`, so the
+ * subscription lands an unpredictable number of microtasks later. This suite
+ * used to wait a flat 20ms for that, which is plenty on a dev laptop and not
+ * always enough on a CI runner — `stateHandler` was still null, and calling it
+ * threw `stateHandler is not a function`. That single gamble was behind every
+ * red CI run on main over the last 25 builds.
+ *
+ * Must only be used on real timers.
+ */
+async function waitFor(check: () => boolean, label: string, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (check()) return
+    await new Promise((r) => setTimeout(r, 5))
+  }
+  throw new Error(`waitFor(${label}): condition still false after ${timeoutMs}ms`)
+}
+
 describe('useMqttReconnectStore — ensureWired browser path', () => {
   let stateHandler: ((state: 'connecting' | 'connected' | 'disconnected') => void) | null = null
   let errorHandler: ((message: string) => void) | null = null
@@ -206,8 +227,7 @@ describe('useMqttReconnectStore — ensureWired browser path', () => {
     store.setState({ _wired: false, connected: null, lastError: null })
     store.getState().ensureWired()
 
-    // Allow async dynamic imports to settle
-    await new Promise((r) => setTimeout(r, 20))
+    await waitFor(() => stateHandler !== null && errorHandler !== null, 'bridge subscribed')
 
     expect(stateHandler).not.toBeNull()
     expect(errorHandler).not.toBeNull()
@@ -235,7 +255,7 @@ describe('useMqttReconnectStore — ensureWired browser path', () => {
     const { useMqttReconnectStore: store, BROWSER_RECONNECT_GRACE_MS } = await import('./mqtt-reconnect')
     store.setState({ _wired: false, connected: null, lastError: null, nonce: 0 })
     store.getState().ensureWired()
-    await new Promise((r) => setTimeout(r, 20))
+    await waitFor(() => stateHandler !== null, 'bridge subscribed')
 
     vi.useFakeTimers()
     try {
@@ -248,7 +268,7 @@ describe('useMqttReconnectStore — ensureWired browser path', () => {
     } finally {
       vi.useRealTimers()
     }
-    await new Promise((r) => setTimeout(r, 20))
+    await waitFor(() => vi.mocked(refreshSession).mock.calls.length > 0, 'refreshSession called')
 
     expect(refreshSession).toHaveBeenCalledOnce()
     expect(store.getState().nonce).toBe(1)
@@ -260,7 +280,7 @@ describe('useMqttReconnectStore — ensureWired browser path', () => {
     const { useMqttReconnectStore: store, BROWSER_RECONNECT_GRACE_MS } = await import('./mqtt-reconnect')
     store.setState({ _wired: false, connected: null, lastError: null, nonce: 0 })
     store.getState().ensureWired()
-    await new Promise((r) => setTimeout(r, 20))
+    await waitFor(() => stateHandler !== null, 'bridge subscribed')
 
     vi.useFakeTimers()
     try {
@@ -271,6 +291,8 @@ describe('useMqttReconnectStore — ensureWired browser path', () => {
     } finally {
       vi.useRealTimers()
     }
+    // Negative assertion: there is no condition to poll for, and waiting longer
+    // than necessary only makes a false pass less likely, never a false fail.
     await new Promise((r) => setTimeout(r, 20))
 
     expect(refreshSession).not.toHaveBeenCalled()
@@ -284,10 +306,10 @@ describe('useMqttReconnectStore — ensureWired browser path', () => {
     store.setState({ _wired: false, connected: null, lastError: null, nonce: 0 })
     store.getState().ensureWired()
 
-    await new Promise((r) => setTimeout(r, 20))
+    await waitFor(() => errorHandler !== null, 'bridge subscribed')
     errorHandler!('Connection refused: bad_username_or_password')
     expect(store.getState().lastError).toBe('Connection refused: bad_username_or_password')
-    await new Promise((r) => setTimeout(r, 20))
+    await waitFor(() => vi.mocked(refreshSession).mock.calls.length > 0, 'refreshSession called')
 
     expect(refreshSession).toHaveBeenCalledOnce()
     expect(store.getState().nonce).toBe(1)

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -158,6 +158,14 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    // A few suites must import their subject inside the test (their vi.mock
+    // factories close over variables that are not initialized at module-eval
+    // time). Under a fully parallel run those transforms queue behind hundreds
+    // of other files, and the default 5s was tight enough to trip — the test
+    // then timed out while its `render()` was still in flight, so the DOM
+    // landed after cleanup and leaked into the next test. A genuinely hung
+    // test still fails, just later.
+    testTimeout: 15000,
     setupFiles: [path.resolve(__dirname, 'src/test/vitest-setup.ts')],
     include: [
       'src/**/*.test.ts',


### PR DESCRIPTION
Found by replaying main's last 25 CI runs and by re-running the suite six times on an unchanged tree. Three unrelated causes.

## 1. `mqtt-reconnect` — the only test that has actually reddened CI

**Every** red CI run on main in the last 25 builds involved this one file:

| when | commit | what failed |
|---|---|---|
| 13:33 | `969b25ca` | mqtt-reconnect ×2 |
| 11:06 | `ad09db52` | mqtt-reconnect + fmt/clippy/daemon (those three were real, fixed in #678) |
| 09:17 | `3c5109e7` | mqtt-reconnect |
| 04:39 | `0730b790` | mqtt-reconnect |

`ensureWired()` reaches the bridge through a dynamic `import()`, and the suite waited a flat `setTimeout(r, 20)` for it. Plenty on a dev laptop; not always enough on a CI runner, where `stateHandler` was still `null` and calling it threw `TypeError: stateHandler is not a function`.

Six load-bearing sleeps became a polled `waitFor` on the condition each actually depends on (handler assigned / `refreshSession` called). The seventh is a negative assertion — nothing to poll for, and waiting longer there can only reduce false passes, never cause false failures — so it stays a fixed wait, now with a comment saying why.

Notably this **never failed locally**, not once in 6 full runs. The machine is too fast to lose that race.

## 2. `useAppInit` / `build-config` — green on CI, permanently red locally

Both assert hardcoded fallback values but read config that a local run has already merged `build.config.dev.json` into (`webSSO: true`, `app.name: "TeamClaw Dev"`). So they fail on every dev machine, 6/6 rounds — five reds that every developer has to mentally filter out on every run.

- `build-config` now asserts the newly exported `FALLBACK_BUILD_CONFIG`, which is the thing the test means to check. `__BUILD_CONFIG__` is a Vite `define` replacement, so a test cannot un-inject it — asserting the fallback object directly is the only way to test the fallback.
- `useAppInit` asserts `DEFAULT_WORKSPACE_PATH` instead of the brand-specific literal `~/TeamClaw`. These tests are about "falls back to the default workspace", not about which brand is being built.

## 3. Parallel-only failures — 7 files, up to 7 reds per full run

`RightPanel-interactions` (5/6 rounds), `RightPanel`, `ChatMessage-streaming`, `TeamSection-legacy`/`-tabs`, `auth-store`, `DiagnosticsSection.reset`. All 7 pass when run together in isolation; they only fail in the full 414-file parallel run.

It looked like state leakage — `Found multiple elements by [data-testid="session-list"]` — but the actual chain is timing:

> importing the subject **inside** each test spends that test's 5s budget transforming a large dependency tree, queued behind hundreds of other files → timeout → the test aborts while its `render()` is still in flight → the DOM lands *after* cleanup → leaks into the next test.

Four files now import their subject statically; their `vi.mock` calls are hoisted, so nothing required the dynamic form. The two `TeamSection` suites keep it — their mock factories close over variables not initialized at module-eval time, and converting them fails outright with `Cannot access 'mockInvoke' before initialization`. `testTimeout` goes to 15s so the remaining dynamic imports have headroom; a genuinely hung test still fails, just later.

## Verification

Same harness, six consecutive full runs:

| | before | after |
|---|---|---|
| failures per round | 7, 7, 7, 5, … | **0, 0, 0, 0, 0, 0** |

`pnpm typecheck` clean, `pnpm lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)