### PR TITLE
fix(fc): bootstrap teams with trusted external JWT

### DIFF
--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -145,14 +145,30 @@ export function makeBusinessRepoFactory(
       });
     };
   }
-  return ({ accessToken }: { accessToken: string }) =>
-    createSupabaseBusinessRepository({
+  // Supabase data-plane requests may carry a trusted external (Betly) JWT.
+  // Verify it once at the FC boundary and pass its identity into the repository;
+  // never ask TeamClaw's local GoTrue to re-validate that foreign session.
+  return async ({ accessToken }: { accessToken: string }) => {
+    let claims;
+    try {
+      claims = await verifyAccessToken(accessToken, verifyOpts ?? {});
+    } catch (cause) {
+      throw new ApiError(401, "invalid_token", "Invalid or expired access token", { cause });
+    }
+    const appMetadata = claims.app_metadata;
+    return createSupabaseBusinessRepository({
       supabaseUrl: SUPABASE_URL_FN(),
       supabasePublicUrl: SUPABASE_PUBLIC_URL_FN(),
       publishableKey: SUPABASE_PUBLISHABLE_KEY(),
       accessToken,
+      caller: {
+        id: claims.sub,
+        isAnonymous: claims.is_anonymous === true || claims.isAnonymous === true,
+        appMetadata: appMetadata && typeof appMetadata === "object" ? appMetadata : {},
+      },
       ...makeDeployDeps(),
     });
+  };
 }
 
 // The single Hono app owns ALL routing (OPTIONS, /v1, /sync, admin, 404, 500,

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -124,6 +124,10 @@ export function createSupabaseBusinessRepository(options) {
     supabasePublicUrl = supabaseUrl,
     publishableKey,
     accessToken,
+    // Identity verified at the Cloud API boundary. This is essential for
+    // trusted external JWTs: supabase.auth.getUser() only understands the
+    // local GoTrue issuer and would reject a valid Betly session.
+    caller: verifiedCaller,
     createClient = defaultCreateClient,
     createServiceRoleClient: createServiceRoleClientOpt,
     provisionLiteLlm,
@@ -150,6 +154,20 @@ export function createSupabaseBusinessRepository(options) {
       },
     },
   });
+
+  async function caller() {
+    if (verifiedCaller?.id) return verifiedCaller;
+    // Compatibility for direct repository consumers/tests. Production business
+    // requests always supply verifiedCaller through makeBusinessRepoFactory.
+    const { data, error } = await supabase.auth.getUser();
+    if (error) throw error;
+    if (!data?.user?.id) throw new ApiError(401, "unauthorized", "no authenticated user");
+    return {
+      id: data.user.id,
+      isAnonymous: data.user.is_anonymous === true,
+      appMetadata: data.user.app_metadata ?? {},
+    };
+  }
 
   async function requireCallerTeamOwner(targetTeamId) {
     const { data: authData, error: authErr } = await supabase.auth.getUser();
@@ -385,11 +403,11 @@ export function createSupabaseBusinessRepository(options) {
       // carries no org. Same order as before: JWT app_metadata.org_id →
       // DEFAULT_ORG_ID → lazily provisioned personal org. The RPC prefers the
       // authoritative token org and only uses this fallback when that is null.
-      const { data: caller } = await supabase.auth.getUser();
+      const currentCaller = await caller();
       let fallbackOrg: string | null =
-        (caller?.user?.app_metadata as any)?.org_id ?? null;
+        (currentCaller.appMetadata as any)?.org_id ?? null;
       if (!fallbackOrg) fallbackOrg = defaultOrgId;
-      if (!fallbackOrg && caller?.user?.id) {
+      if (!fallbackOrg && currentCaller.id) {
         const { data: provisioned, error: orgErr } =
           await supabase.rpc("ensure_personal_org");
         if (orgErr) throw orgErr;
@@ -414,13 +432,13 @@ export function createSupabaseBusinessRepository(options) {
     },
 
     async bootstrapTeam(input) {
-      const { data: caller } = await supabase.auth.getUser();
-      if (caller?.user?.is_anonymous) {
+      const currentCaller = await caller();
+      if (currentCaller.isAnonymous) {
         throw new ApiError(403, "anonymous_not_allowed", "sign in to create a team");
       }
       const defaultOrgId = process.env.DEFAULT_ORG_ID || null;
-      let fallbackOrg: string | null = (caller?.user?.app_metadata as any)?.org_id ?? defaultOrgId;
-      if (!fallbackOrg && caller?.user?.id) {
+      let fallbackOrg: string | null = (currentCaller.appMetadata as any)?.org_id ?? defaultOrgId;
+      if (!fallbackOrg && currentCaller.id) {
         const { data: provisioned, error: orgErr } = await supabase.rpc("ensure_personal_org");
         if (orgErr) throw orgErr;
         fallbackOrg = (provisioned as string | null) ?? null;

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -296,7 +296,7 @@ function fakeSupabaseForShareMode(rpcData, rpcCalls = []) {
   });
 }
 
-test("createTeam routes to join_or_create_org_team with the caller's JWT org as fallback", async () => {
+test("createTeam routes to create_team with the caller's JWT org as fallback", async () => {
   const rpcCalls = [];
   const prev = process.env.DEFAULT_ORG_ID;
   process.env.DEFAULT_ORG_ID = "org-default";
@@ -309,7 +309,7 @@ test("createTeam routes to join_or_create_org_team with the caller's JWT org as 
         },
       },
       rpcData: {
-        join_or_create_org_team: [{
+        create_team: [{
           team_id: "team-9",
           team_name: "香蕉攀岩",
           team_slug: "banana",
@@ -321,18 +321,17 @@ test("createTeam routes to join_or_create_org_team with the caller's JWT org as 
 
     const team = await repo.createTeam({ displayName: "梁江" });
 
-    // Caller's real org wins as the fallback stamp; default org is passed so the
-    // RPC can tell "this is a real customer org" and join its default team.
+    // Caller's real org wins as the fallback stamp; explicit creation never
+    // silently joins an existing organization team.
     assert.deepEqual(rpcCalls, [{
-      name: "join_or_create_org_team",
+      name: "create_team",
       args: {
-        p_fallback_org: "org-real",
-        p_default_org_id: "org-default",
         p_name: null,
         p_slug: null,
         p_display_name: "梁江",
         p_litellm_team_id: null,
         p_ai_gateway_endpoint: null,
+        p_oid: "org-real",
       },
     }]);
     assert.equal(team.id, "team-9");
@@ -357,7 +356,7 @@ test("createTeam falls back to DEFAULT_ORG_ID when the caller carries no org", a
         },
       },
       rpcData: {
-        join_or_create_org_team: [{
+        create_team: [{
           team_id: "team-solo",
           team_name: "Zesty Falcon",
           team_slug: "zesty-falcon",
@@ -370,14 +369,39 @@ test("createTeam falls back to DEFAULT_ORG_ID when the caller carries no org", a
     await repo.createTeam({ name: "My Team", slug: "my-team" });
 
     assert.equal(rpcCalls.length, 1);
-    assert.equal(rpcCalls[0].name, "join_or_create_org_team");
-    assert.equal(rpcCalls[0].args.p_fallback_org, "org-default");
+    assert.equal(rpcCalls[0].name, "create_team");
+    assert.equal(rpcCalls[0].args.p_oid, "org-default");
     assert.equal(rpcCalls[0].args.p_name, "My Team");
     assert.equal(rpcCalls[0].args.p_slug, "my-team");
   } finally {
     if (prev === undefined) delete process.env.DEFAULT_ORG_ID;
     else process.env.DEFAULT_ORG_ID = prev;
   }
+});
+
+test("bootstrapTeam uses the boundary-verified caller without local GoTrue lookup", async () => {
+  const rpcCalls: any[] = [];
+  const repo = createRepo(fakeSupabase({
+    rpcCalls,
+    auth: {
+      async getUser() {
+        throw new Error("TeamClaw GoTrue must not be called for a trusted external JWT");
+      },
+    },
+    rpcData: {
+      bootstrap_current_org_team: [{ team_id: "team-bootstrap", team_name: "Betly", team_slug: "betly" }],
+    },
+  }), {
+    caller: { id: "betly-user-1", isAnonymous: false, appMetadata: { org_id: "betly-org-1" } },
+  });
+
+  const team = await repo.bootstrapTeam({ displayName: "Betly User" });
+
+  assert.deepEqual(rpcCalls, [{
+    name: "bootstrap_current_org_team",
+    args: { p_fallback_org: "betly-org-1", p_display_name: "Betly User" },
+  }]);
+  assert.equal(team.id, "team-bootstrap");
 });
 
 test("enableShareMode oss calls enable_team_share rpc with null git fields", async () => {


### PR DESCRIPTION
Reuse FC-boundary verified caller identity for Supabase bootstrap/create flows so trusted Betly JWTs do not hit TeamClaw local GoTrue. Includes regression coverage.