### PR TITLE
fix(fc): preserve local GoTrue bearer fallback

### DIFF
--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -145,27 +145,38 @@ export function makeBusinessRepoFactory(
       });
     };
   }
-  // Supabase data-plane requests may carry a trusted external (Betly) JWT.
-  // Verify it once at the FC boundary and pass its identity into the repository;
-  // never ask TeamClaw's local GoTrue to re-validate that foreign session.
+  // Supabase data-plane requests normally carry a local GoTrue token. Some
+  // deployments instead use a trusted external (Betly) JWT. When the latter
+  // verifies at the FC boundary, pass its identity to the repository so team
+  // bootstrap does not ask TeamClaw's GoTrue to re-validate that foreign token.
+  // A GoTrue token is intentionally left to the existing Supabase/RLS path.
   return async ({ accessToken }: { accessToken: string }) => {
-    let claims;
+    let caller:
+      | {
+          id: string;
+          isAnonymous: boolean;
+          appMetadata: Record<string, unknown>;
+        }
+      | undefined;
     try {
-      claims = await verifyAccessToken(accessToken, verifyOpts ?? {});
-    } catch (cause) {
-      throw new ApiError(401, "invalid_token", "Invalid or expired access token", { cause });
+      const claims = await verifyAccessToken(accessToken, verifyOpts ?? {});
+      const appMetadata = claims.app_metadata;
+      caller = {
+        id: claims.sub,
+        isAnonymous: claims.is_anonymous === true || claims.isAnonymous === true,
+        appMetadata: appMetadata && typeof appMetadata === "object" ? appMetadata : {},
+      };
+    } catch {
+      // verifyAccessToken validates Better Auth's trusted JWTs, not GoTrue's
+      // local signing key. The repository continues to authenticate a normal
+      // self-hosted Supabase bearer through auth.getUser() and RLS.
     }
-    const appMetadata = claims.app_metadata;
     return createSupabaseBusinessRepository({
       supabaseUrl: SUPABASE_URL_FN(),
       supabasePublicUrl: SUPABASE_PUBLIC_URL_FN(),
       publishableKey: SUPABASE_PUBLISHABLE_KEY(),
       accessToken,
-      caller: {
-        id: claims.sub,
-        isAnonymous: claims.is_anonymous === true || claims.isAnonymous === true,
-        appMetadata: appMetadata && typeof appMetadata === "object" ? appMetadata : {},
-      },
+      caller,
       ...makeDeployDeps(),
     });
   };


### PR DESCRIPTION
Preserves the local GoTrue authentication and RLS path for self-hosted Supabase tokens, while injecting the caller only for successfully verified trusted external JWTs.\n\nThis fixes team bootstrap for Betly-issued cross-database sessions without regressing normal self-host sign-in.\n\nDeployment runs with .