### PR TITLE
fix(self-host): target external Supabase backend

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -19,12 +19,17 @@ jobs:
         uses: appleboy/ssh-action@v1.2.5
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          TRUSTED_EXTERNAL_JWT_SECRET: ${{ secrets.TRUSTED_EXTERNAL_JWT_SECRET }}
+          FC_SUPABASE_URL: ${{ secrets.FC_SUPABASE_URL }}
+          FC_SUPABASE_PUBLIC_URL: ${{ secrets.FC_SUPABASE_PUBLIC_URL }}
+          FC_SUPABASE_ANON_KEY: ${{ secrets.FC_SUPABASE_ANON_KEY }}
+          FC_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.FC_SUPABASE_SERVICE_ROLE_KEY }}
         with:
           host: ${{ secrets.ECS_HOST }}
           username: ${{ secrets.ECS_USER }}
           key: ${{ secrets.ECS_SSH_PRIVATE_KEY }}
           command_timeout: 30m
-          envs: DEEPSEEK_API_KEY
+          envs: DEEPSEEK_API_KEY,TRUSTED_EXTERNAL_JWT_SECRET,FC_SUPABASE_URL,FC_SUPABASE_PUBLIC_URL,FC_SUPABASE_ANON_KEY,FC_SUPABASE_SERVICE_ROLE_KEY
           script: |
             set -e
             cd /opt/teamclaw
@@ -63,6 +68,11 @@ jobs:
             # Self-host runs against its bundled Supabase data plane. Set this
             # explicitly so a stale server .env cannot select the postgres mode.
             upsert_env BACKEND_KIND "supabase"
+            upsert_env TRUSTED_EXTERNAL_JWT_SECRET "$TRUSTED_EXTERNAL_JWT_SECRET"
+            upsert_env FC_SUPABASE_URL "$FC_SUPABASE_URL"
+            upsert_env FC_SUPABASE_PUBLIC_URL "$FC_SUPABASE_PUBLIC_URL"
+            upsert_env FC_SUPABASE_ANON_KEY "$FC_SUPABASE_ANON_KEY"
+            upsert_env FC_SUPABASE_SERVICE_ROLE_KEY "$FC_SUPABASE_SERVICE_ROLE_KEY"
             # Point FC at the bundled gateway explicitly. Left blank, FC's client
             # falls back to the hosted https://ai.ucar.cc.
             upsert_env LITELLM_URL "http://litellm:4000"

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -206,10 +206,14 @@ services:
       PORT: "9000"
       HOST: "0.0.0.0"
       BACKEND_KIND: "${BACKEND_KIND:-supabase}"
-      SUPABASE_URL: "http://kong:8000"
-      SUPABASE_PUBLIC_URL: "https://${SUPABASE_DOMAIN}"
-      SUPABASE_ANON_KEY: "${ANON_KEY}"
-      SUPABASE_SERVICE_ROLE_KEY: "${SERVICE_ROLE_KEY}"
+      # FC may target a separately hosted Supabase project. Keep the bundled
+      # stack and its volumes untouched as the fallback / rollback path.
+      FC_SUPABASE_URL: "${FC_SUPABASE_URL:-}"
+      SUPABASE_URL: "${FC_SUPABASE_URL:-http://kong:8000}"
+      SUPABASE_PUBLIC_URL: "${FC_SUPABASE_PUBLIC_URL:-https://${SUPABASE_DOMAIN}}"
+      SUPABASE_ANON_KEY: "${FC_SUPABASE_ANON_KEY:-${ANON_KEY}}"
+      TRUSTED_EXTERNAL_JWT_SECRET: "${TRUSTED_EXTERNAL_JWT_SECRET:-}"
+      SUPABASE_SERVICE_ROLE_KEY: "${FC_SUPABASE_SERVICE_ROLE_KEY:-${SERVICE_ROLE_KEY}}"
       # The ONE broker address: FC's own inbox publisher dials it AND
       # /v1/config/bootstrap hands it to clients. The separate
       # MQTT_PUBLIC_BROKER_URL override is gone (it defaulted to "", `""` is not

--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -145,41 +145,14 @@ export function makeBusinessRepoFactory(
       });
     };
   }
-  // Supabase data-plane requests normally carry a local GoTrue token. Some
-  // deployments instead use a trusted external (Betly) JWT. When the latter
-  // verifies at the FC boundary, pass its identity to the repository so team
-  // bootstrap does not ask TeamClaw's GoTrue to re-validate that foreign token.
-  // A GoTrue token is intentionally left to the existing Supabase/RLS path.
-  return async ({ accessToken }: { accessToken: string }) => {
-    let caller:
-      | {
-          id: string;
-          isAnonymous: boolean;
-          appMetadata: Record<string, unknown>;
-        }
-      | undefined;
-    try {
-      const claims = await verifyAccessToken(accessToken, verifyOpts ?? {});
-      const appMetadata = claims.app_metadata;
-      caller = {
-        id: claims.sub,
-        isAnonymous: claims.is_anonymous === true || claims.isAnonymous === true,
-        appMetadata: appMetadata && typeof appMetadata === "object" ? (appMetadata as Record<string, unknown>) : {},
-      };
-    } catch {
-      // verifyAccessToken validates Better Auth's trusted JWTs, not GoTrue's
-      // local signing key. The repository continues to authenticate a normal
-      // self-hosted Supabase bearer through auth.getUser() and RLS.
-    }
-    return createSupabaseBusinessRepository({
+  return ({ accessToken }: { accessToken: string }) =>
+    createSupabaseBusinessRepository({
       supabaseUrl: SUPABASE_URL_FN(),
       supabasePublicUrl: SUPABASE_PUBLIC_URL_FN(),
       publishableKey: SUPABASE_PUBLISHABLE_KEY(),
       accessToken,
-      caller,
       ...makeDeployDeps(),
     });
-  };
 }
 
 // The single Hono app owns ALL routing (OPTIONS, /v1, /sync, admin, 404, 500,

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createClient as defaultCreateClient } from "@supabase/supabase-js";
+import { verifyTrustedExternalJwt } from "./trusted-external-jwt.js";
 import { ApiError } from "./http-utils.js";
 import { isLegalStatusTransition } from "./pg-repo/app-status.js";
 import { isLegalFcTransition } from "./provisioning/app-fc-status.js";
@@ -124,10 +125,6 @@ export function createSupabaseBusinessRepository(options) {
     supabasePublicUrl = supabaseUrl,
     publishableKey,
     accessToken,
-    // Identity verified at the Cloud API boundary. This is essential for
-    // trusted external JWTs: supabase.auth.getUser() only understands the
-    // local GoTrue issuer and would reject a valid Betly session.
-    caller: verifiedCaller,
     createClient = defaultCreateClient,
     createServiceRoleClient: createServiceRoleClientOpt,
     provisionLiteLlm,
@@ -139,6 +136,7 @@ export function createSupabaseBusinessRepository(options) {
     queryLiteLlmUsage = (litellmTeamId, range) => queryTeamUsage(getLiteLlmSql(), litellmTeamId, range),
     // Injectable for tests; defaults to the shared LiteLLM HTTP client.
     litellmFetch: litellmFetchOpt,
+    trustedExternalJwtSecret = process.env.TRUSTED_EXTERNAL_JWT_SECRET,
   } = options;
 
   if (!supabaseUrl) throw new Error("SUPABASE_URL is required");
@@ -155,18 +153,16 @@ export function createSupabaseBusinessRepository(options) {
     },
   });
 
-  async function caller() {
-    if (verifiedCaller?.id) return verifiedCaller;
-    // Compatibility for direct repository consumers/tests. Production business
-    // requests always supply verifiedCaller through makeBusinessRepoFactory.
-    const { data, error } = await supabase.auth.getUser();
-    if (error) throw error;
-    if (!data?.user?.id) throw new ApiError(401, "unauthorized", "no authenticated user");
-    return {
-      id: data.user.id,
-      isAnonymous: data.user.is_anonymous === true,
-      appMetadata: data.user.app_metadata ?? {},
-    };
+  // A partner-issued session has no auth.sessions row in this Supabase project.
+  // Its JWT is verified locally only when the explicit trust secret is set.
+  async function getCurrentUser() {
+    if (!trustedExternalJwtSecret) return supabase.auth.getUser();
+    try {
+      const user = await verifyTrustedExternalJwt(accessToken, trustedExternalJwtSecret);
+      return { data: { user }, error: null };
+    } catch (cause) {
+      return { data: { user: null }, error: cause };
+    }
   }
 
   async function requireCallerTeamOwner(targetTeamId) {
@@ -403,11 +399,14 @@ export function createSupabaseBusinessRepository(options) {
       // carries no org. Same order as before: JWT app_metadata.org_id →
       // DEFAULT_ORG_ID → lazily provisioned personal org. The RPC prefers the
       // authoritative token org and only uses this fallback when that is null.
-      const currentCaller = await caller();
+      const { data: caller, error: callerErr } = await getCurrentUser();
+      if (callerErr || !caller?.user?.id) {
+        throw new ApiError(401, "missing_auth", "authenticated user required");
+      }
       let fallbackOrg: string | null =
-        (currentCaller.appMetadata as any)?.org_id ?? null;
+        (caller.user.app_metadata as any)?.org_id ?? null;
       if (!fallbackOrg) fallbackOrg = defaultOrgId;
-      if (!fallbackOrg && currentCaller.id) {
+      if (!fallbackOrg) {
         const { data: provisioned, error: orgErr } =
           await supabase.rpc("ensure_personal_org");
         if (orgErr) throw orgErr;
@@ -432,13 +431,16 @@ export function createSupabaseBusinessRepository(options) {
     },
 
     async bootstrapTeam(input) {
-      const currentCaller = await caller();
-      if (currentCaller.isAnonymous) {
+      const { data: caller, error: callerErr } = await getCurrentUser();
+      if (callerErr || !caller?.user?.id) {
+        throw new ApiError(401, "missing_auth", "authenticated user required");
+      }
+      if (caller.user.is_anonymous) {
         throw new ApiError(403, "anonymous_not_allowed", "sign in to create a team");
       }
       const defaultOrgId = process.env.DEFAULT_ORG_ID || null;
-      let fallbackOrg: string | null = (currentCaller.appMetadata as any)?.org_id ?? defaultOrgId;
-      if (!fallbackOrg && currentCaller.id) {
+      let fallbackOrg: string | null = (caller.user.app_metadata as any)?.org_id ?? defaultOrgId;
+      if (!fallbackOrg) {
         const { data: provisioned, error: orgErr } = await supabase.rpc("ensure_personal_org");
         if (orgErr) throw orgErr;
         fallbackOrg = (provisioned as string | null) ?? null;

--- a/services/fc/src/lib/trusted-external-jwt.ts
+++ b/services/fc/src/lib/trusted-external-jwt.ts
@@ -1,0 +1,28 @@
+import { jwtVerify } from "jose";
+
+type TrustedUser = {
+  id: string;
+  app_metadata: Record<string, unknown>;
+};
+
+/**
+ * Validates a JWT issued by a separately hosted, explicitly trusted Supabase
+ * Auth instance. GoTrue's /user endpoint additionally requires its local
+ * auth.sessions row, which is not shared between the two projects.
+ */
+export async function verifyTrustedExternalJwt(token: string, secret: string): Promise<TrustedUser> {
+  const { payload } = await jwtVerify(token, new TextEncoder().encode(secret), {
+    algorithms: ["HS256"],
+    audience: "authenticated",
+  });
+  if (typeof payload.sub !== "string" || payload.sub.length === 0) {
+    throw new Error("jwt_missing_sub");
+  }
+  const appMetadata = payload.app_metadata;
+  return {
+    id: payload.sub,
+    app_metadata: appMetadata && typeof appMetadata === "object" && !Array.isArray(appMetadata)
+      ? appMetadata as Record<string, unknown>
+      : {},
+  };
+}


### PR DESCRIPTION
Routes the self-host FC data plane to deployment-injected Supabase credentials, preserving the bundled local Supabase stack as fallback. Also adds trusted external JWT caller resolution for bootstrap and other FC business paths.