### PR TITLE
feat: initialize a team from an empty org picker row

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -153,7 +153,8 @@ jobs:
                     20260730000000_update_agent_defaults_cursor.sql \
                     20260731000000_fix_workspaces_insert_rls.sql \
                     20260801000000_prefer_org_named_team_on_onboarding.sql \
-                    20260801010000_team_bootstrap_and_discovery.sql
+                    20260801010000_team_bootstrap_and_discovery.sql \
+                    20260801020000_empty_org_team_picker.sql
                   do
                     if [ "$(psql -Atc "select exists (select 1 from _selfhost.schema_migrations where filename = \$\$${migration}\$\$)")" = "t" ]; then
                       echo "skip external migration: $migration"

--- a/docs/openapi/teamclaw-api.v1.yaml
+++ b/docs/openapi/teamclaw-api.v1.yaml
@@ -83,6 +83,16 @@ paths:
           schema:
             type: string
             enum: [all, discoverable]
+        - name: includeEmptyOrgs
+          in: query
+          required: false
+          description: >-
+            Only with `scope=all`: include organization picker rows for orgs
+            that do not yet have a team. Such a row has `itemType: org` and
+            `teamId: null`; select it with `POST /v1/teams/bootstrap` and its
+            `orgId` to initialize the org-named team.
+          schema:
+            type: boolean
       responses:
         "200":
           description: Current user's teams.
@@ -174,9 +184,9 @@ paths:
       operationId: bootstrapTeam
       summary: Bootstrap the first team in the current organization
       description: >-
-        For a non-anonymous user with no visible or joinable teams, atomically
-        creates an owner team named after the current organization and creates
-        its member actor. It never joins an existing team implicitly.
+        Creates an owner team named after the current organization (or the
+        explicit empty picker `orgId`) and creates its member actor atomically.
+        It never joins an existing team implicitly.
       tags: [Teams]
       requestBody:
         required: false
@@ -187,6 +197,10 @@ paths:
               properties:
                 displayName:
                   type: [string, "null"]
+                orgId:
+                  description: Organization selected from an `itemType: org` picker row.
+                  type: [string, "null"]
+                  format: uuid
       responses:
         "200":
           description: Bootstrapped team.

--- a/packages/app/src/components/auth/AuthGate.tsx
+++ b/packages/app/src/components/auth/AuthGate.tsx
@@ -89,7 +89,7 @@ export function AuthGate({ children }: AuthGateProps) {
     let cancelled = false;
     void (async () => {
       try {
-        const teams = await getBackend().teams.listAllMyTeams();
+        const teams = await getBackend().teams.listAllMyTeams({ includeEmptyOrgs: true });
         if (!cancelled) setMyTeams(teams);
       } catch (e) {
         console.warn("[AuthGate] listAllMyTeams failed", e);
@@ -184,7 +184,7 @@ export function AuthGate({ children }: AuthGateProps) {
       let teamSet = false;
       let bootErr: unknown = null;
       try {
-        const allTeams = await getBackend().teams.listAllMyTeams();
+        const allTeams = await getBackend().teams.listAllMyTeams({ includeEmptyOrgs: true });
         markStartup("team-list:end");
         if (allTeams.length > 0) {
           // Do not auto-select the first row: the chooser makes the org then

--- a/packages/app/src/components/auth/TeamPicker.tsx
+++ b/packages/app/src/components/auth/TeamPicker.tsx
@@ -25,7 +25,7 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
 
   // Highlight the last-used team; on first login (no history) fall back to the
   // first team so there's always a visible pre-selection.
-  const highlightId = lastUsedTeamId ?? teams[0]?.id ?? null;
+  const highlightId = lastUsedTeamId ?? teams.find((item) => item.itemType !== "org")?.id ?? null;
 
   // Group by org, preserving first-seen order. Teams without an org name fall
   // into a single "ungrouped" bucket.
@@ -42,6 +42,12 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
     setError(null);
     setBusyId(team.id);
     try {
+      if (team.itemType === "org") {
+        const created = await getBackend().teams.bootstrapTeam({ orgId: team.orgId ?? team.id });
+        await switchToTeam(created.id);
+        onDone();
+        return;
+      }
       // Public DEFAULT_ORG teams the caller hasn't joined yet: enroll as a
       // plain member first so switchToTeam (and every team-scoped RPC after it)
       // has membership. Idempotent server-side.
@@ -102,7 +108,8 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
               </span>
               <div className="flex flex-col gap-2">
                 {orgTeams.map((team) => {
-                  const active = team.id === highlightId;
+                  const emptyOrg = team.itemType === "org";
+                  const active = !emptyOrg && team.id === highlightId;
                   const isLastUsed = team.id === lastUsedTeamId;
                   const switching = busyId === team.id;
                   const joinable = team.isMember === false;
@@ -119,14 +126,16 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
                     >
                       <span className="flex min-w-0 items-center gap-2">
                         <span className="min-w-0 truncate text-[13px] font-medium text-foreground">
-                          {team.name}
+                          {emptyOrg
+                            ? t("teamPicker.initializeOrg", "Initialize {{org}}", { org: team.name })
+                            : team.name}
                         </span>
-                        {isLastUsed && (
+                        {!emptyOrg && isLastUsed && (
                           <span className="shrink-0 rounded-full bg-selected px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
                             {t("teamPicker.lastUsed", "Last used")}
                           </span>
                         )}
-                        {joinable && (
+                        {joinable && !emptyOrg && (
                           <span className="shrink-0 rounded-full border border-border px-1.5 py-0.5 text-[10px] font-medium text-faint">
                             {t("teamPicker.public", "Public")}
                           </span>
@@ -135,7 +144,9 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
                       {switching ? (
                         <span className="flex shrink-0 items-center gap-1.5 text-[11.5px] text-muted-foreground">
                           <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          {joinable
+                          {emptyOrg
+                            ? t("teamPicker.initializing", "Initializing…")
+                            : joinable
                             ? t("teamPicker.joining", "Joining…")
                             : t("teamPicker.switching", "Switching…")}
                         </span>

--- a/packages/app/src/components/auth/__tests__/TeamPicker.test.tsx
+++ b/packages/app/src/components/auth/__tests__/TeamPicker.test.tsx
@@ -2,6 +2,13 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { TeamPicker } from "../TeamPicker";
 
+const { bootstrapTeam } = vi.hoisted(() => ({
+  bootstrapTeam: vi.fn(async () => ({ id: "created-team", name: "Empty Org", slug: "empty-org" })),
+}));
+vi.mock("@/lib/backend", () => ({
+  getBackend: () => ({ teams: { bootstrapTeam } }),
+}));
+
 // Selector-style mock of the current-team store: the component reads it via
 // useCurrentTeamStore((s) => s.switchToTeam).
 const switchToTeam = vi.fn(async () => {});
@@ -59,6 +66,13 @@ describe("TeamPicker", () => {
     ];
     render(<TeamPicker teams={sameOrg} onDone={() => {}} />);
     expect(screen.queryByText(/同一时间只能在一个组织内工作/)).not.toBeInTheDocument();
+  });
+
+  it("initializes an empty org before activating its newly created team", async () => {
+    render(<TeamPicker teams={[{ id: "o-empty", name: "Empty Org", orgId: "o-empty", orgName: "Empty Org", itemType: "org", teamId: null }]} onDone={() => {}} />);
+    fireEvent.click(screen.getByText("初始化 Empty Org"));
+    await vi.waitFor(() => expect(bootstrapTeam).toHaveBeenCalledWith({ orgId: "o-empty" }));
+    await vi.waitFor(() => expect(switchToTeam).toHaveBeenCalledWith("created-team"));
   });
 
 });

--- a/packages/app/src/lib/backend/cloud-api/teams.ts
+++ b/packages/app/src/lib/backend/cloud-api/teams.ts
@@ -17,6 +17,8 @@ type CloudMembershipTeam = {
   orgName: string | null;
   visibility?: "public" | "private";
   isMember?: boolean;
+  itemType?: "team" | "org";
+  teamId?: string | null;
 };
 
 type CloudInvite = {
@@ -103,8 +105,9 @@ export function createTeamsModule(client: CloudApiClient): TeamsBackend {
         `/v1/teams/${encodeURIComponent(teamId)}/actors/${encodeURIComponent(actorId)}`,
       );
     },
-    async listAllMyTeams() {
-      const page = await client.get<Page<CloudMembershipTeam>>(`/v1/teams?scope=all`);
+    async listAllMyTeams({ includeEmptyOrgs = false } = {}) {
+      const suffix = includeEmptyOrgs ? "&includeEmptyOrgs=true" : "";
+      const page = await client.get<Page<CloudMembershipTeam>>(`/v1/teams?scope=all${suffix}`);
       return page.items.map((r) => ({
         id: r.id,
         name: r.name,
@@ -113,6 +116,8 @@ export function createTeamsModule(client: CloudApiClient): TeamsBackend {
         orgName: r.orgName,
         visibility: r.visibility,
         isMember: r.isMember !== false,
+        itemType: r.itemType ?? "team",
+        teamId: r.teamId ?? r.id,
       }));
     },
     async listDiscoverableTeams() {

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -351,6 +351,10 @@ export interface MembershipTeam {
    * `true` means the caller is already an actor in the team.
    */
   isMember?: boolean;
+  /** An empty org returned by the login picker, not an activatable team. */
+  itemType?: "team" | "org";
+  /** Null for an empty-org picker row; otherwise the same value as `id`. */
+  teamId?: string | null;
 }
 
 export interface TeamInviteResult {
@@ -458,7 +462,7 @@ export interface TeamsBackend {
    * First-team onboarding only. Creates an owner team named after the caller's
    * current organization, together with the member actor, in one transaction.
    */
-  bootstrapTeam(input?: { displayName?: string | null }): Promise<TeamSummary>;
+  bootstrapTeam(input?: { displayName?: string | null; orgId?: string | null }): Promise<TeamSummary>;
   renameTeam(teamId: string, name: string): Promise<TeamSummary>;
   /**
    * Graduate the caller out of the shared DEFAULT_ORG into their own org:
@@ -468,7 +472,7 @@ export interface TeamsBackend {
   upgradeAccount(input: { teamId: string; orgName: string; contact?: string | null }): Promise<{ orgId: string; teamId: string; teamName: string }>;
   createTeamInvite(input: TeamInviteInput): Promise<TeamInviteResult>;
   removeTeamActor(teamId: string, actorId: string): Promise<void>;
-  listAllMyTeams(): Promise<MembershipTeam[]>;
+  listAllMyTeams(args?: { includeEmptyOrgs?: boolean }): Promise<MembershipTeam[]>;
   /** Public teams that may be browsed before a user joins one. */
   listDiscoverableTeams(): Promise<MembershipTeam[]>;
   /**

--- a/services/fc/src/lib/routes/teams.ts
+++ b/services/fc/src/lib/routes/teams.ts
@@ -8,7 +8,8 @@ export function registerTeams(router) {
     // Omitted preserves the active-org member listing.
     const scope = ctx.query?.get?.("scope") ?? null;
     if (scope === "all") {
-      const items = await ctx.repository.listAllMyTeams();
+      const includeEmptyOrgs = ctx.query?.get?.("includeEmptyOrgs") === "true";
+      const items = await ctx.repository.listAllMyTeams({ includeEmptyOrgs });
       return { body: { items, nextCursor: null } };
     }
     if (scope === "discoverable") {
@@ -69,6 +70,7 @@ export function registerTeams(router) {
     const body = ctx.json;
     const team = await ctx.repository.bootstrapTeam({
       displayName: optionalStringOrNull(body.displayName, "displayName"),
+      orgId: optionalStringOrNull(body.orgId, "orgId"),
     });
     return { body: team };
   });

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -314,23 +314,26 @@ export function createSupabaseBusinessRepository(options) {
     // picker). The `list_all_my_teams` function lives in the `amux` schema and is
     // SECURITY DEFINER (it bypasses teams_org_guard). The default client schema
     // here is `amux`, so it resolves via a plain `.rpc(...)` like create_team etc.
-    async listAllMyTeams() {
+    async listAllMyTeams({ includeEmptyOrgs = false } = {}) {
       // Cross-org team picker source: member teams plus every public team the
       // caller may join. The legacy argument remains for RPC signature
       // compatibility during rollout.
       const defaultOrgId = process.env.DEFAULT_ORG_ID || null;
       const { data, error } = await supabase.rpc("list_teams_for_picker", {
         p_default_org_id: defaultOrgId,
+        p_include_empty_orgs: includeEmptyOrgs,
       });
       if (error) throw error;
       return (data ?? []).map((r: any) => ({
-        id: r.team_id,
-        name: r.team_name,
+        id: r.team_id ?? r.org_id,
+        name: r.team_name ?? r.org_name,
         slug: r.team_slug ?? null,
         orgId: r.org_id ?? null,
         orgName: r.org_name ?? null,
         visibility: r.visibility ?? "private",
         isMember: r.is_member !== false,
+        itemType: r.item_type === "org" ? "org" : "team",
+        teamId: r.team_id ?? null,
       }));
     },
 
@@ -445,10 +448,16 @@ export function createSupabaseBusinessRepository(options) {
         if (orgErr) throw orgErr;
         fallbackOrg = (provisioned as string | null) ?? null;
       }
-      const { data, error } = await supabase.rpc("bootstrap_current_org_team", {
-        p_fallback_org: fallbackOrg,
-        p_display_name: input?.displayName ?? null,
-      });
+      const selectedOrgId = input?.orgId ?? null;
+      const { data, error } = selectedOrgId
+        ? await supabase.rpc("bootstrap_selected_org_team", {
+          p_org_id: selectedOrgId,
+          p_display_name: input?.displayName ?? null,
+        })
+        : await supabase.rpc("bootstrap_current_org_team", {
+          p_fallback_org: fallbackOrg,
+          p_display_name: input?.displayName ?? null,
+        });
       if (error) throw error;
       const row = requiredRow(data, "teams.bootstrapTeam");
       return mapTeam({ id: row.team_id ?? row.id, name: row.team_name ?? row.name, slug: row.team_slug ?? row.slug });

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -404,6 +404,25 @@ test("bootstrapTeam uses the boundary-verified caller without local GoTrue looku
   assert.equal(team.id, "team-bootstrap");
 });
 
+test("bootstrapTeam targets an explicitly selected empty org", async () => {
+  const rpcCalls: any[] = [];
+  const repo = createRepo(fakeSupabase({
+    rpcCalls,
+    rpcData: {
+      bootstrap_selected_org_team: [{ team_id: "team-bootstrap", team_name: "Other Org", team_slug: "other-org" }],
+    },
+  }), {
+    caller: { id: "betly-user-1", isAnonymous: false, appMetadata: { org_id: "betly-org-1" } },
+  });
+
+  await repo.bootstrapTeam({ orgId: "selected-org", displayName: "Betly User" });
+
+  assert.deepEqual(rpcCalls, [{
+    name: "bootstrap_selected_org_team",
+    args: { p_org_id: "selected-org", p_display_name: "Betly User" },
+  }]);
+});
+
 test("enableShareMode oss calls enable_team_share rpc with null git fields", async () => {
   const rpcCalls = [];
   const repo = createRepo(fakeSupabaseForShareMode({

--- a/services/fc/test/teams-activate.test.ts
+++ b/services/fc/test/teams-activate.test.ts
@@ -30,23 +30,23 @@ function makeApp({
   } as any);
 }
 
-test("GET /v1/teams?scope=all calls listAllMyTeams and returns orgName", async () => {
-  let called = false;
+test("GET /v1/teams?scope=all forwards empty-org picker opt-in and returns orgName", async () => {
+  let received: any;
   const app = makeApp({
-    listAllMyTeams: async () => {
-      called = true;
+    listAllMyTeams: async (args: any) => {
+      received = args;
       return [
         { id: "t1", name: "Alpha", slug: "alpha", orgId: "o1", orgName: "Org One" },
         { id: "t2", name: "Beta", slug: "beta", orgId: "o2", orgName: "Org Two" },
       ];
     },
   });
-  const res = await app.request("/v1/teams?scope=all", {
+  const res = await app.request("/v1/teams?scope=all&includeEmptyOrgs=true", {
     headers: { authorization: "Bearer x" },
   });
   assert.equal(res.status, 200);
   const body = (await res.json()) as any;
-  assert.equal(called, true);
+  assert.deepEqual(received, { includeEmptyOrgs: true });
   assert.equal(body.items.length, 2);
   assert.equal(body.items[0].orgName, "Org One");
   assert.equal(body.nextCursor, null);
@@ -82,8 +82,25 @@ test("POST /v1/teams/bootstrap delegates atomic first-team creation", async () =
     body: JSON.stringify({ displayName: "Boss" }),
   });
   assert.equal(res.status, 200);
-  assert.deepEqual(input, { displayName: "Boss" });
+  assert.deepEqual(input, { displayName: "Boss", orgId: null });
   assert.equal((await res.json() as any).name, "Org One");
+});
+
+test("POST /v1/teams/bootstrap forwards an explicitly selected empty org", async () => {
+  let input: any;
+  const app = makeApp({
+    bootstrapTeam: async (received: any) => {
+      input = received;
+      return { id: "org-team", name: "Org One", slug: "org-one" };
+    },
+  });
+  const res = await app.request("/v1/teams/bootstrap", {
+    method: "POST",
+    headers: { authorization: "Bearer x", "content-type": "application/json" },
+    body: JSON.stringify({ orgId: "00000000-0000-4000-8000-000000000001" }),
+  });
+  assert.equal(res.status, 200);
+  assert.deepEqual(input, { displayName: null, orgId: "00000000-0000-4000-8000-000000000001" });
 });
 
 test("GET /v1/teams (no scope) keeps the active-org listing", async () => {

--- a/services/supabase/migrations/20260801020000_empty_org_team_picker.sql
+++ b/services/supabase/migrations/20260801020000_empty_org_team_picker.sql
@@ -1,0 +1,119 @@
+-- Let the authenticated desktop picker show tenant orgs which have no team
+-- yet. Selecting one creates its org-named owner team in a single transaction.
+
+drop function if exists amux.list_teams_for_picker(uuid);
+
+create function amux.list_teams_for_picker(
+  p_default_org_id uuid default null,
+  p_include_empty_orgs boolean default false
+)
+returns table(
+  team_id uuid,
+  team_name text,
+  team_slug text,
+  org_id uuid,
+  org_name text,
+  visibility text,
+  is_member boolean,
+  item_type text
+)
+language sql stable security definer
+set search_path to 'amux', 'public', 'auth'
+as $$
+  with mine as (
+    select t.id, t.name, t.slug, t.oid, t.visibility, true as is_member, 'team'::text as item_type
+      from amux.teams t
+     where exists (select 1 from amux.actors a where a.user_id = auth.uid() and a.team_id = t.id)
+  ), public_teams as (
+    select t.id, t.name, t.slug, t.oid, t.visibility, false as is_member, 'team'::text as item_type
+      from amux.teams t
+     where t.visibility = 'public'
+       and not exists (select 1 from amux.actors a where a.user_id = auth.uid() and a.team_id = t.id)
+  ), combined as (
+    select * from mine union all select * from public_teams
+  ), empty_orgs as (
+    select null::uuid as id, null::text as name, null::text as slug, o.id as oid,
+           'private'::text as visibility, true as is_member, 'org'::text as item_type
+      from public.orgs o
+     where p_include_empty_orgs
+       and not exists (select 1 from amux.teams t where t.oid = o.id)
+  )
+  select * from (
+    select c.id as team_id, c.name as team_name, c.slug as team_slug, c.oid as org_id,
+           o.name as org_name, c.visibility, c.is_member, c.item_type
+      from combined c
+      left join public.orgs o on o.id = c.oid
+    union all
+    select e.id, e.name, e.slug, e.oid, o.name, e.visibility, e.is_member, e.item_type
+      from empty_orgs e
+      join public.orgs o on o.id = e.oid
+  ) picker_items
+  order by item_type, org_name nulls last, team_name;
+$$;
+
+grant execute on function amux.list_teams_for_picker(uuid, boolean) to authenticated, service_role;
+
+create or replace function amux.bootstrap_selected_org_team(
+  p_org_id uuid,
+  p_display_name text default null
+)
+returns table(team_id uuid, team_name text, team_slug text, member_id uuid, role text, workspace_id uuid, workspace_name text)
+language plpgsql security definer
+set search_path to 'amux', 'public', 'auth', 'extensions'
+as $function$
+declare
+  v_user_id uuid := auth.uid();
+  v_org_name text;
+  v_team_id uuid := gen_random_uuid();
+  v_member_id uuid := gen_random_uuid();
+  v_workspace_id uuid;
+  v_slug_base text;
+  v_slug text;
+  v_suffix integer := 1;
+  v_nickname text;
+  v_display_name text;
+  v_adjectives text[] := array['Curious','Brave','Calm','Eager','Lively','Mellow','Nimble','Quick','Quiet','Sunny','Witty','Zesty','Bright','Daring','Gentle','Jolly','Keen','Plucky','Spry','Sparkling'];
+  v_animals text[] := array['Otter','Panda','Falcon','Fox','Heron','Lynx','Owl','Puffin','Quokka','Raven','Seal','Tapir','Viper','Walrus','Yak','Zebra','Badger','Cougar','Dolphin','Hare'];
+begin
+  if v_user_id is null then
+    raise exception 'bootstrap_selected_org_team requires an authenticated user' using errcode = '42501';
+  end if;
+  if exists (select 1 from auth.users where id = v_user_id and coalesce(is_anonymous, false)) then
+    raise exception 'anonymous users cannot bootstrap a team' using errcode = '42501';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(p_org_id::text, 0));
+  select name into v_org_name from public.orgs where id = p_org_id;
+  if nullif(btrim(v_org_name), '') is null then
+    raise exception 'organization not found' using errcode = 'P0002';
+  end if;
+  if exists (select 1 from amux.teams where oid = p_org_id) then
+    raise exception 'organization already has a team' using errcode = '23505';
+  end if;
+
+  v_slug_base := lower(regexp_replace(v_org_name, '[^a-zA-Z0-9]+', '-', 'g'));
+  v_slug_base := trim(both '-' from v_slug_base);
+  if v_slug_base = '' then v_slug_base := 'team'; end if;
+  v_slug := v_slug_base;
+  while exists (select 1 from amux.teams where slug = v_slug) loop
+    v_suffix := v_suffix + 1;
+    v_slug := format('%s-%s', v_slug_base, v_suffix);
+  end loop;
+  select nickname into v_nickname from public.users where id = v_user_id limit 1;
+  v_display_name := coalesce(nullif(btrim(v_nickname), ''), nullif(btrim(p_display_name), ''),
+    v_adjectives[((hashtextextended(v_member_id::text, 11) % 20 + 20) % 20) + 1] || ' ' ||
+    v_animals[((hashtextextended(v_member_id::text, 29) % 20 + 20) % 20) + 1]);
+
+  insert into amux.teams (id, name, slug, oid) values (v_team_id, v_org_name, v_slug, p_org_id);
+  insert into amux.actors (id, team_id, actor_type, user_id, display_name, last_active_at)
+    values (v_member_id, v_team_id, 'member', v_user_id, v_display_name, now());
+  insert into amux.members (id, status) values (v_member_id, 'active');
+  insert into amux.team_members (team_id, member_id, role) values (v_team_id, v_member_id, 'owner');
+  insert into amux.workspaces (team_id, created_by_member_id, name, path)
+    values (v_team_id, v_member_id, 'General', null) returning id into v_workspace_id;
+  insert into amux.team_workspace_config (team_id) values (v_team_id);
+  return query select v_team_id, v_org_name, v_slug, v_member_id, 'owner'::text, v_workspace_id, 'General'::text;
+end;
+$function$;
+
+grant execute on function amux.bootstrap_selected_org_team(uuid, text) to authenticated, service_role;


### PR DESCRIPTION
Adds empty-org rows to the authenticated team picker behind `includeEmptyOrgs=true`. Selecting one atomically creates an org-named team, owner actor, and workspace before activation. Includes the external Supabase migration and self-host migration runner entry.