### PR TITLE
chore(deploy): inspect external Supabase drift

### DIFF
--- a/.github/workflows/external-supabase-inspect.yml
+++ b/.github/workflows/external-supabase-inspect.yml
@@ -1,0 +1,40 @@
+name: Inspect External Supabase Drift
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    environment: self-host-production
+    steps:
+      - name: Read external Supabase metadata from ECS
+        uses: appleboy/ssh-action@v1.2.5
+        env:
+          BELAYO_TEST_RDS_PRIVATE_HOST: ${{ secrets.BELAYO_TEST_RDS_PRIVATE_HOST }}
+          BELAYO_TEST_RDS_PORT: ${{ secrets.BELAYO_TEST_RDS_PORT }}
+          BELAYO_TEST_RDS_USER: ${{ secrets.BELAYO_TEST_RDS_USER }}
+          BELAYO_TEST_RDS_PASSWORD: ${{ secrets.BELAYO_TEST_RDS_PASSWORD }}
+        with:
+          host: ${{ secrets.ECS_HOST }}
+          username: ${{ secrets.ECS_USER }}
+          key: ${{ secrets.ECS_SSH_PRIVATE_KEY }}
+          command_timeout: 5m
+          envs: BELAYO_TEST_RDS_PRIVATE_HOST,BELAYO_TEST_RDS_PORT,BELAYO_TEST_RDS_USER,BELAYO_TEST_RDS_PASSWORD
+          script: |
+            set -eu
+            docker run --rm --network host \
+              -e PGPASSWORD="$BELAYO_TEST_RDS_PASSWORD" \
+              -e PGHOST="$BELAYO_TEST_RDS_PRIVATE_HOST" \
+              -e PGPORT="${BELAYO_TEST_RDS_PORT:-5432}" \
+              -e PGUSER="$BELAYO_TEST_RDS_USER" \
+              -e PGDATABASE=postgres \
+              postgres:15-alpine sh -ceu '
+                if [ -n "$(psql -Atc "select to_regclass('"'"'_selfhost.schema_migrations'"'"')")" ]; then
+                  psql -Atc "select '"'"'MIGRATION:'"'"' || filename from _selfhost.schema_migrations order by filename"
+                else
+                  echo MIGRATION_MARKER_ABSENT
+                fi
+                psql -Atc "select '"'"'TABLE:'"'"' || schemaname || '"'"'.'"'"' || tablename from pg_tables where schemaname in ('"'"'amux'"'"', '"'"'auth'"'"', '"'"'public'"'"') order by 1"
+                psql -Atc "select '"'"'RPC:'"'"' || n.nspname || '"'"'.'"'"' || p.proname || '"'"'('"'"' || pg_get_function_identity_arguments(p.oid) || '"'"')'"'"' from pg_proc p join pg_namespace n on n.oid = p.pronamespace where n.nspname = '"'"'amux'"'"' order by 1"
+              '


### PR DESCRIPTION
Adds a manually triggered, read-only ECS/RDS metadata inspection workflow. It does not run migrations or deploy services.