### PR TITLE
fix: track external Supabase migrations

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -79,7 +79,7 @@ jobs:
             upsert_env FC_SUPABASE_SERVICE_ROLE_KEY "$FC_SUPABASE_SERVICE_ROLE_KEY"
 
             if [ -n "$FC_SUPABASE_URL" ]; then
-              echo "=== migrate external Supabase team onboarding ==="
+              echo "=== migrate external Supabase schema ==="
               [ -n "$BELAYO_TEST_RDS_PRIVATE_HOST" ] || { echo "missing BELAYO_TEST_RDS_PRIVATE_HOST"; exit 1; }
               [ -n "$BELAYO_TEST_RDS_USER" ] || { echo "missing BELAYO_TEST_RDS_USER"; exit 1; }
               [ -n "$BELAYO_TEST_RDS_PASSWORD" ] || { echo "missing BELAYO_TEST_RDS_PASSWORD"; exit 1; }
@@ -91,22 +91,77 @@ jobs:
                 -e PGDATABASE=supabase_db \
                 -v "$PWD/../../services/supabase/migrations:/migrations:ro" \
                 postgres:15-alpine sh -ceu '
+                  psql -v ON_ERROR_STOP=1 -c "
+                    create schema if not exists _selfhost;
+                    create table if not exists _selfhost.schema_migrations (
+                      filename text primary key,
+                      applied_at timestamptz not null default now()
+                    );
+                  "
+
+                  # This external database predates the deploy marker. The
+                  # onboarding RPC is only created by the already-applied
+                  # batch below, so record that batch once instead of replaying
+                  # non-idempotent historical functions on every deployment.
+                  if [ "$(psql -Atc "select count(*) from _selfhost.schema_migrations")" = "0" ] \
+                    && [ "$(psql -Atc "select to_regprocedure(\$\$amux.list_teams_for_picker(uuid)\$\$) is not null")" = "t" ]; then
+                    echo "adopt existing external onboarding migrations"
+                    for migration in \
+                      20260618010000_upgrade_account_to_org.sql \
+                      20260618020000_bind_phone_to_account.sql \
+                      20260630000000_add_team_default_agent.sql \
+                      20260706000000_org_default_team_onboarding.sql \
+                      20260715000000_invite_contact_pending.sql \
+                      20260723000000_sessions_source_cron_job_id.sql \
+                      20260723000000_team_visibility.sql \
+                      20260727000000_sessions_source_read_path.sql \
+                      20260727030000_detach_gateway_session.sql \
+                      20260728000000_gateway_session_switch.sql \
+                      20260801000000_prefer_org_named_team_on_onboarding.sql \
+                      20260801010000_team_bootstrap_and_discovery.sql
+                    do
+                      psql -v ON_ERROR_STOP=1 -c "insert into _selfhost.schema_migrations (filename) values (\$\$${migration}\$\$) on conflict do nothing"
+                    done
+                  fi
+
                   for migration in \
+                    20260609000000_actor_directory_contact_amux.sql \
+                    20260615000000_list_my_teams_current_org.sql \
+                    20260618000000_create_team_default_org_personal_name.sql \
                     20260618010000_upgrade_account_to_org.sql \
                     20260618020000_bind_phone_to_account.sql \
+                    20260625000000_team_workspace_config_llm.sql \
                     20260630000000_add_team_default_agent.sql \
+                    20260702000000_fix_teams_rls_membership_write.sql \
+                    20260706000000_add_auth_mint_session.sql \
                     20260706000000_org_default_team_onboarding.sql \
+                    20260706120000_member_sub_own_rpc_req.sql \
+                    20260708000000_claim_invite_public_users_for_daemon.sql \
                     20260715000000_invite_contact_pending.sql \
+                    20260715010000_mint_session_extensions_grant.sql \
+                    20260718000000_fix_remove_team_actor_amux.sql \
+                    20260722000000_agent_runtimes_backend_type_pi.sql \
                     20260723000000_sessions_source_cron_job_id.sql \
                     20260723000000_team_visibility.sql \
                     20260727000000_sessions_source_read_path.sql \
+                    20260727010000_gateway_session_participants_every_call.sql \
+                    20260727020000_gateway_session_unarchive_on_message.sql \
                     20260727030000_detach_gateway_session.sql \
                     20260728000000_gateway_session_switch.sql \
+                    20260729100000_agent_delete_authz.sql \
+                    20260729110000_agent_backend_cursor.sql \
+                    20260730000000_update_agent_defaults_cursor.sql \
+                    20260731000000_fix_workspaces_insert_rls.sql \
                     20260801000000_prefer_org_named_team_on_onboarding.sql \
                     20260801010000_team_bootstrap_and_discovery.sql
                   do
+                    if [ "$(psql -Atc "select exists (select 1 from _selfhost.schema_migrations where filename = \$\$${migration}\$\$)")" = "t" ]; then
+                      echo "skip external migration: $migration"
+                      continue
+                    fi
                     echo "apply external migration: $migration"
                     psql -v ON_ERROR_STOP=1 -f "/migrations/$migration"
+                    psql -v ON_ERROR_STOP=1 -c "insert into _selfhost.schema_migrations (filename) values (\$\$${migration}\$\$)"
                   done
                 '
             fi


### PR DESCRIPTION
External self-host deployments now record applied migration filenames.

- adopt the already-applied onboarding batch once
- apply the remaining active schema migrations once, including actor_directory.owner_member_id
- avoid replaying non-idempotent historical migrations on future deploys