### PR TITLE
fix: keep empty org picker migration self-host compatible

### DIFF
--- a/services/supabase/migrations/20260801030000_scope_empty_org_picker_to_user.sql
+++ b/services/supabase/migrations/20260801030000_scope_empty_org_picker_to_user.sql
@@ -35,7 +35,6 @@ as $$
       from public.users u
      where u.org_id is not null
        and (u.id = auth.uid() or u.auth_user_id = auth.uid())
-       and coalesce(u.deleted_at, null) is null
     union
     select distinct t.oid
       from amux.actors a


### PR DESCRIPTION
Removes the saas-only users.deleted_at reference so the bundled self-host Supabase migration can complete and start FC.