### PR TITLE
fix: scope team picker to phone-linked orgs

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -157,7 +157,9 @@ jobs:
                     20260801020000_empty_org_team_picker.sql \
                     20260801030000_scope_empty_org_picker_to_user.sql \
                     20260801040000_scope_empty_org_picker_by_phone.sql \
-                    20260801050000_authorize_empty_org_bootstrap_by_phone.sql
+                    20260801050000_authorize_empty_org_bootstrap_by_phone.sql \
+                    20260801060000_phone_linked_org_team_picker.sql \
+                    20260801070000_switch_phone_linked_team_identity.sql
                   do
                     if [ "$(psql -Atc "select exists (select 1 from _selfhost.schema_migrations where filename = \$\$${migration}\$\$)")" = "t" ]; then
                       echo "skip external migration: $migration"

--- a/services/supabase/migrations/20260801060000_phone_linked_org_team_picker.sql
+++ b/services/supabase/migrations/20260801060000_phone_linked_org_team_picker.sql
@@ -1,0 +1,78 @@
+-- A phone is the identity link between a user's tenant accounts. The picker
+-- must be complete per linked org, rather than mixing global public teams with
+-- only the caller's single user_id membership.
+
+create or replace function amux.list_teams_for_picker(
+  p_default_org_id uuid default null,
+  p_include_empty_orgs boolean default false
+)
+returns table(team_id uuid, team_name text, team_slug text, org_id uuid, org_name text, visibility text, is_member boolean, item_type text)
+language sql stable security definer
+set search_path to 'amux', 'public', 'auth'
+as $$
+  with current_identity as (
+    select u.id, nullif(btrim(u.mobile), '') as mobile
+      from public.users u
+     where u.id = auth.uid()
+     limit 1
+  ), related_users as (
+    -- Retain the caller even when a legacy record has no phone, then expand
+    -- only through the shared phone when it is available.
+    select auth.uid() as id
+     where auth.uid() is not null
+    union
+    select u.id
+      from public.users u
+      join current_identity c on c.mobile is not null and u.mobile = c.mobile
+  ), related_orgs as (
+    select distinct u.org_id
+      from public.users u
+      join related_users ru on ru.id = u.id
+     where u.org_id is not null
+  ), member_teams as (
+    select t.id, t.name, t.slug, t.oid, t.visibility, true as is_member, 'team'::text as item_type
+      from amux.teams t
+     where t.oid in (select org_id from related_orgs)
+       and exists (
+         select 1
+           from amux.actors a
+           join related_users ru on ru.id = a.user_id
+          where a.team_id = t.id
+       )
+  ), public_teams as (
+    select t.id, t.name, t.slug, t.oid, t.visibility, false as is_member, 'team'::text as item_type
+      from amux.teams t
+     where t.oid in (select org_id from related_orgs)
+       and t.visibility = 'public'
+       and not exists (
+         select 1
+           from amux.actors a
+           join related_users ru on ru.id = a.user_id
+          where a.team_id = t.id
+       )
+  ), empty_orgs as (
+    select null::uuid as id, null::text as name, null::text as slug, o.id as oid,
+           'private'::text as visibility, true as is_member, 'org'::text as item_type
+      from public.orgs o
+      join related_orgs ro on ro.org_id = o.id
+     where p_include_empty_orgs
+       and not exists (select 1 from amux.teams t where t.oid = o.id)
+  )
+  select * from (
+    select t.id as team_id, t.name as team_name, t.slug as team_slug, t.oid as org_id,
+           o.name as org_name, t.visibility, t.is_member, t.item_type
+      from (
+        select * from member_teams
+        union all
+        select * from public_teams
+      ) t
+      join public.orgs o on o.id = t.oid
+    union all
+    select e.id, e.name, e.slug, e.oid, o.name, e.visibility, e.is_member, e.item_type
+      from empty_orgs e
+      join public.orgs o on o.id = e.oid
+  ) picker_items
+  order by org_name nulls last, item_type, team_name;
+$$;
+
+grant execute on function amux.list_teams_for_picker(uuid, boolean) to authenticated, service_role;

--- a/services/supabase/migrations/20260801070000_switch_phone_linked_team_identity.sql
+++ b/services/supabase/migrations/20260801070000_switch_phone_linked_team_identity.sql
@@ -1,0 +1,62 @@
+-- When a picker row belongs to another tenant identity with the same phone,
+-- switch to that actor's user before minting the replacement auth session.
+
+create or replace function amux.switch_active_team(p_team_id uuid)
+returns table(actor_id uuid, team_id uuid, refresh_token text)
+language plpgsql security definer
+set search_path to 'amux', 'public', 'auth', 'app'
+as $function$
+declare
+  v_caller_id uuid := auth.uid();
+  v_mobile text;
+  v_actor uuid;
+  v_member_user_id uuid;
+  v_team_org uuid;
+  v_rt text;
+begin
+  if v_caller_id is null then
+    raise exception 'switch requires authentication' using errcode = '42501';
+  end if;
+
+  select nullif(btrim(u.mobile), '') into v_mobile
+    from public.users u
+   where u.id = v_caller_id
+   limit 1;
+
+  select a.id, a.user_id into v_actor, v_member_user_id
+    from amux.actors a
+   where a.team_id = p_team_id
+     and (
+       a.user_id = v_caller_id
+       or (
+         v_mobile is not null
+         and exists (
+           select 1
+             from public.users u
+            where u.id = a.user_id
+              and u.mobile = v_mobile
+         )
+       )
+     )
+   order by case when a.user_id = v_caller_id then 0 else 1 end, a.created_at asc
+   limit 1;
+  if v_actor is null then
+    raise exception 'not a member of this team' using errcode = '42501';
+  end if;
+
+  select oid into v_team_org from amux.teams where id = p_team_id;
+  if v_team_org is not null then
+    insert into public.users (auth_user_id, org_id)
+    values (v_member_user_id, v_team_org)
+    on conflict (auth_user_id) where auth_user_id is not null do update
+      set org_id = excluded.org_id, updated_at = now();
+  end if;
+
+  v_rt := auth._mint_session(v_member_user_id);
+  update amux.actors set last_active_at = now(), updated_at = now() where id = v_actor;
+
+  return query select v_actor, p_team_id, v_rt;
+end;
+$function$;
+
+grant execute on function amux.switch_active_team(uuid) to authenticated, service_role;

--- a/services/supabase/tests/028_phone_linked_org_picker.sql
+++ b/services/supabase/tests/028_phone_linked_org_picker.sql
@@ -1,0 +1,81 @@
+begin;
+
+select plan(6);
+
+create temporary table phone_picker_fixture (
+  caller_id uuid not null,
+  linked_id uuid not null,
+  org_a uuid not null,
+  org_b uuid not null,
+  linked_private_team uuid not null
+);
+
+do $$
+declare
+  v_caller uuid := gen_random_uuid();
+  v_linked uuid := gen_random_uuid();
+  v_other uuid := gen_random_uuid();
+  v_org_a uuid := gen_random_uuid();
+  v_org_b uuid := gen_random_uuid();
+  v_org_other uuid := gen_random_uuid();
+  v_team_linked uuid := gen_random_uuid();
+begin
+  insert into auth.users (id, aud, role, created_at, updated_at, instance_id)
+  values
+    (v_caller, 'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000'),
+    (v_linked, 'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000'),
+    (v_other, 'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000');
+  insert into public.orgs (id, name)
+  values (v_org_a, 'Phone Org A'), (v_org_b, 'Phone Org B'), (v_org_other, 'Other Org');
+  insert into public.users (id, auth_user_id, org_id, mobile)
+  values
+    (v_caller, v_caller, v_org_a, '13800009991'),
+    (v_linked, v_linked, v_org_b, '13800009991'),
+    (v_other, v_other, v_org_other, '13800009992');
+  insert into amux.teams (id, name, slug, oid, visibility)
+  values
+    (gen_random_uuid(), 'Caller private', 'phone-caller-private', v_org_a, 'private'),
+    (v_team_linked, 'Linked private', 'phone-linked-private', v_org_b, 'private'),
+    (gen_random_uuid(), 'A public', 'phone-a-public', v_org_a, 'public'),
+    (gen_random_uuid(), 'B public', 'phone-b-public', v_org_b, 'public'),
+    (gen_random_uuid(), 'Hidden private', 'phone-hidden-private', v_org_b, 'private'),
+    (gen_random_uuid(), 'Other public', 'phone-other-public', v_org_other, 'public');
+  insert into amux.actors (id, team_id, actor_type, user_id, display_name)
+  select gen_random_uuid(), t.id, 'member', v_caller, 'Caller'
+    from amux.teams t where t.slug = 'phone-caller-private';
+  insert into amux.actors (id, team_id, actor_type, user_id, display_name)
+  values (gen_random_uuid(), v_team_linked, 'member', v_linked, 'Linked');
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_caller, 'role', 'authenticated')::text, true);
+  perform set_config('role', 'authenticated', true);
+  insert into phone_picker_fixture values (v_caller, v_linked, v_org_a, v_org_b, v_team_linked);
+end $$;
+
+select is(
+  (select count(*)::int from amux.list_teams_for_picker(null, true)),
+  4,
+  'picker returns only member and public teams in phone-linked orgs'
+);
+select ok(
+  exists(select 1 from amux.list_teams_for_picker(null, true) where team_slug = 'phone-linked-private' and is_member),
+  'picker includes a private team joined by a same-phone identity'
+);
+select ok(
+  exists(select 1 from amux.list_teams_for_picker(null, true) where team_slug = 'phone-b-public' and not is_member),
+  'picker includes public teams in every phone-linked org'
+);
+select ok(
+  not exists(select 1 from amux.list_teams_for_picker(null, true) where team_slug = 'phone-hidden-private'),
+  'picker excludes private teams with no phone-linked membership'
+);
+select ok(
+  not exists(select 1 from amux.list_teams_for_picker(null, true) where team_slug = 'phone-other-public'),
+  'picker excludes teams outside phone-linked orgs'
+);
+select ok(
+  (select refresh_token is not null from amux.switch_active_team(linked_private_team) limit 1),
+  'switching a linked private team mints the linked identity session'
+) from phone_picker_fixture;
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Returns only each phone-linked org's member teams and public teams, and switches to the linked actor identity when entering a private member team.