### PR TITLE
fix: initialize empty org with public team

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -159,7 +159,9 @@ jobs:
                     20260801040000_scope_empty_org_picker_by_phone.sql \
                     20260801050000_authorize_empty_org_bootstrap_by_phone.sql \
                     20260801060000_phone_linked_org_team_picker.sql \
-                    20260801070000_switch_phone_linked_team_identity.sql
+                    20260801070000_switch_phone_linked_team_identity.sql \
+                    20260801080000_bootstrap_empty_org_public_team.sql \
+                    20260801090000_switch_linked_identity_without_conflict.sql
                   do
                     if [ "$(psql -Atc "select exists (select 1 from _selfhost.schema_migrations where filename = \$\$${migration}\$\$)")" = "t" ]; then
                       echo "skip external migration: $migration"

--- a/services/supabase/migrations/20260801080000_bootstrap_empty_org_public_team.sql
+++ b/services/supabase/migrations/20260801080000_bootstrap_empty_org_public_team.sql
@@ -1,0 +1,81 @@
+-- An org with no selectable teams is initialized with its public default team.
+
+create or replace function amux.bootstrap_selected_org_team(
+  p_org_id uuid,
+  p_display_name text default null
+)
+returns table(team_id uuid, team_name text, team_slug text, member_id uuid, role text, workspace_id uuid, workspace_name text)
+language plpgsql security definer
+set search_path to 'amux', 'public', 'auth', 'extensions'
+as $function$
+declare
+  v_user_id uuid := auth.uid();
+  v_mobile text;
+  v_org_name text;
+  v_team_id uuid := gen_random_uuid();
+  v_member_id uuid := gen_random_uuid();
+  v_workspace_id uuid;
+  v_slug_base text;
+  v_slug text;
+  v_suffix integer := 1;
+  v_nickname text;
+  v_display_name text;
+  v_adjectives text[] := array['Curious','Brave','Calm','Eager','Lively','Mellow','Nimble','Quick','Quiet','Sunny','Witty','Zesty','Bright','Daring','Gentle','Jolly','Keen','Plucky','Spry','Sparkling'];
+  v_animals text[] := array['Otter','Panda','Falcon','Fox','Heron','Lynx','Owl','Puffin','Quokka','Raven','Seal','Tapir','Viper','Walrus','Yak','Zebra','Badger','Cougar','Dolphin','Hare'];
+begin
+  if v_user_id is null then
+    raise exception 'bootstrap_selected_org_team requires an authenticated user' using errcode = '42501';
+  end if;
+  if exists (select 1 from auth.users where id = v_user_id and coalesce(is_anonymous, false)) then
+    raise exception 'anonymous users cannot bootstrap a team' using errcode = '42501';
+  end if;
+
+  select nullif(btrim(u.mobile), '') into v_mobile
+    from public.users u
+   where u.id = v_user_id
+   limit 1;
+  if v_mobile is null then
+    raise exception 'current user has no mobile' using errcode = '42501';
+  end if;
+  if not exists (
+    select 1 from public.users u where u.org_id = p_org_id and u.mobile = v_mobile
+  ) then
+    raise exception 'organization is not available to current user' using errcode = '42501';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(p_org_id::text, 0));
+  select name into v_org_name from public.orgs where id = p_org_id;
+  if nullif(btrim(v_org_name), '') is null then
+    raise exception 'organization not found' using errcode = 'P0002';
+  end if;
+  if exists (select 1 from amux.teams where oid = p_org_id) then
+    raise exception 'organization already has a team' using errcode = '23505';
+  end if;
+
+  v_slug_base := lower(regexp_replace(v_org_name, '[^a-zA-Z0-9]+', '-', 'g'));
+  v_slug_base := trim(both '-' from v_slug_base);
+  if v_slug_base = '' then v_slug_base := 'team'; end if;
+  v_slug := v_slug_base;
+  while exists (select 1 from amux.teams where slug = v_slug) loop
+    v_suffix := v_suffix + 1;
+    v_slug := format('%s-%s', v_slug_base, v_suffix);
+  end loop;
+  select nickname into v_nickname from public.users where id = v_user_id limit 1;
+  v_display_name := coalesce(nullif(btrim(v_nickname), ''), nullif(btrim(p_display_name), ''),
+    v_adjectives[((hashtextextended(v_member_id::text, 11) % 20 + 20) % 20) + 1] || ' ' ||
+    v_animals[((hashtextextended(v_member_id::text, 29) % 20 + 20) % 20) + 1]);
+
+  insert into amux.teams (id, name, slug, oid, visibility)
+    values (v_team_id, v_org_name, v_slug, p_org_id, 'public');
+  insert into amux.actors (id, team_id, actor_type, user_id, display_name, last_active_at)
+    values (v_member_id, v_team_id, 'member', v_user_id, v_display_name, now());
+  insert into amux.members (id, status) values (v_member_id, 'active');
+  insert into amux.team_members (team_id, member_id, role) values (v_team_id, v_member_id, 'owner');
+  insert into amux.workspaces (team_id, created_by_member_id, name, path)
+    values (v_team_id, v_member_id, 'General', null) returning id into v_workspace_id;
+  insert into amux.team_workspace_config (team_id) values (v_team_id);
+  return query select v_team_id, v_org_name, v_slug, v_member_id, 'owner'::text, v_workspace_id, 'General'::text;
+end;
+$function$;
+
+grant execute on function amux.bootstrap_selected_org_team(uuid, text) to authenticated, service_role;

--- a/services/supabase/migrations/20260801090000_switch_linked_identity_without_conflict.sql
+++ b/services/supabase/migrations/20260801090000_switch_linked_identity_without_conflict.sql
@@ -1,0 +1,54 @@
+-- External Betly users are keyed by public.users.id. This database does not
+-- guarantee the legacy auth_user_id unique index used by the baseline upsert.
+
+create or replace function amux.switch_active_team(p_team_id uuid)
+returns table(actor_id uuid, team_id uuid, refresh_token text)
+language plpgsql security definer
+set search_path to 'amux', 'public', 'auth', 'app'
+as $function$
+declare
+  v_caller_id uuid := auth.uid();
+  v_mobile text;
+  v_actor uuid;
+  v_member_user_id uuid;
+  v_team_org uuid;
+  v_rt text;
+begin
+  if v_caller_id is null then
+    raise exception 'switch requires authentication' using errcode = '42501';
+  end if;
+  select nullif(btrim(u.mobile), '') into v_mobile
+    from public.users u where u.id = v_caller_id limit 1;
+
+  select a.id, a.user_id into v_actor, v_member_user_id
+    from amux.actors a
+   where a.team_id = p_team_id
+     and (
+       a.user_id = v_caller_id
+       or (v_mobile is not null and exists (
+         select 1 from public.users u where u.id = a.user_id and u.mobile = v_mobile
+       ))
+     )
+   order by case when a.user_id = v_caller_id then 0 else 1 end, a.created_at asc
+   limit 1;
+  if v_actor is null then
+    raise exception 'not a member of this team' using errcode = '42501';
+  end if;
+
+  select oid into v_team_org from amux.teams where id = p_team_id;
+  if v_team_org is not null then
+    update public.users
+       set org_id = v_team_org, updated_at = now()
+     where id = v_member_user_id;
+    if not found then
+      raise exception 'linked team identity not found' using errcode = '42501';
+    end if;
+  end if;
+
+  v_rt := auth._mint_session(v_member_user_id);
+  update amux.actors set last_active_at = now(), updated_at = now() where id = v_actor;
+  return query select v_actor, p_team_id, v_rt;
+end;
+$function$;
+
+grant execute on function amux.switch_active_team(uuid) to authenticated, service_role;

--- a/services/supabase/tests/029_empty_org_public_bootstrap.sql
+++ b/services/supabase/tests/029_empty_org_public_bootstrap.sql
@@ -1,0 +1,48 @@
+begin;
+
+select plan(3);
+
+create temporary table empty_org_bootstrap_fixture (
+  team_id uuid not null,
+  expected_org_name text not null
+);
+
+do $$
+declare
+  v_user uuid := gen_random_uuid();
+  v_org uuid := gen_random_uuid();
+  v_team uuid;
+begin
+  insert into auth.users (id, aud, role, created_at, updated_at, instance_id)
+  values (v_user, 'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000');
+  insert into public.orgs (id, name) values (v_org, 'Empty Phone Org');
+  insert into public.users (id, auth_user_id, org_id, mobile)
+  values (v_user, v_user, v_org, '13800009993');
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_user, 'role', 'authenticated')::text, true);
+  perform set_config('role', 'authenticated', true);
+  select team_id into v_team from amux.bootstrap_selected_org_team(v_org, 'Owner');
+  insert into empty_org_bootstrap_fixture values (v_team, 'Empty Phone Org');
+end $$;
+
+select is(
+  (select t.name from amux.teams t join empty_org_bootstrap_fixture f on f.team_id = t.id),
+  expected_org_name,
+  'empty org bootstrap names the team after its org'
+) from empty_org_bootstrap_fixture;
+select is(
+  (select t.visibility from amux.teams t join empty_org_bootstrap_fixture f on f.team_id = t.id),
+  'public',
+  'empty org bootstrap creates a public team'
+);
+select ok(
+  exists(
+    select 1
+      from amux.actors a
+      join empty_org_bootstrap_fixture f on f.team_id = a.team_id
+  ),
+  'empty org bootstrap adds the selecting user as a member'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Create a public org-named team for empty-org picker selections and remove the unavailable auth_user_id conflict target from linked identity switching.