### PR TITLE
fix: stabilize desktop agent sessions and timestamps

### DIFF
--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -3,6 +3,22 @@
 
 use super::*;
 
+/// The local fast-path starts before cloud workspace resolution and therefore
+/// legitimately has no workspace id. A concurrent focus/ensure request for
+/// the same directory has the canonical id; it must reuse that runtime rather
+/// than interrupting its active turn.
+fn same_runtime_workspace(
+    existing_worktree: &str,
+    existing_workspace_id: &str,
+    requested_worktree: &str,
+    requested_workspace_id: &str,
+) -> bool {
+    existing_workspace_id == requested_workspace_id
+        || (!existing_worktree.is_empty()
+            && existing_worktree == requested_worktree
+            && (existing_workspace_id.is_empty() || requested_workspace_id.is_empty()))
+}
+
 impl DaemonServer {
     /// Bind remote-tool routing to a live runtime and persist the host-level MCP config.
     /// Route selection is message-level via `remote_context_id`; this binding is
@@ -256,7 +272,12 @@ impl DaemonServer {
                     Some(h)
                         if reuse.is_none()
                             && h.agent_type == agent_type
-                            && h.workspace_id == ws_id =>
+                            && same_runtime_workspace(
+                                &h.worktree,
+                                &h.workspace_id,
+                                &resolved_worktree,
+                                &ws_id,
+                            ) =>
                     {
                         reuse = Some(rid);
                     }
@@ -968,5 +989,36 @@ impl DaemonServer {
                 error,
             })),
         }
+    }
+}
+
+#[cfg(test)]
+mod workspace_binding_tests {
+    use super::same_runtime_workspace;
+
+    #[test]
+    fn local_fast_path_and_canonical_workspace_id_share_one_runtime() {
+        assert!(same_runtime_workspace(
+            "/Users/test/project",
+            "",
+            "/Users/test/project",
+            "workspace-1",
+        ));
+        assert!(same_runtime_workspace(
+            "/Users/test/project",
+            "workspace-1",
+            "/Users/test/project",
+            "",
+        ));
+    }
+
+    #[test]
+    fn different_known_workspace_ids_remain_distinct() {
+        assert!(!same_runtime_workspace(
+            "/Users/test/project",
+            "workspace-1",
+            "/Users/test/project",
+            "workspace-2",
+        ));
     }
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -138,6 +138,7 @@ import {
   messageKindUpdatesSessionPreview,
 } from "@/lib/session-list-preview";
 import { executeAgentTurnFlush } from "@/lib/agent-turn-flush";
+import { unixTimestampSecondsToIso } from "@/lib/message-timestamp";
 import { resolveInterruptedPlaceholdersToDrop } from "@/lib/interrupted-stream-placeholder";
 import {
   removePendingAgentReplyTo,
@@ -1674,10 +1675,10 @@ function AppContent() {
               const listStore = useSessionListStore.getState();
               const sessionInList = listStore.rows.some((r) => r.id === sid);
               if (sessionInList) {
-                const createdAtSec = Number(decoded.message.createdAt);
+                const createdAtSec = decoded.message.createdAt;
                 bumpSessionListLastMessage(sid, decoded.message.content, {
-                  at: Number.isFinite(createdAtSec) && createdAtSec > 0
-                    ? new Date(createdAtSec * 1000).toISOString()
+                  at: createdAtSec > 0n
+                    ? unixTimestampSecondsToIso(createdAtSec)
                     : undefined,
                 });
               } else {
@@ -1726,7 +1727,7 @@ function AppContent() {
                 model: m.model || null,
                 mentionsJson: null,
                 origin: "mqtt-live",
-                createdAt: new Date(Number(m.createdAt) * 1000).toISOString(),
+                createdAt: unixTimestampSecondsToIso(m.createdAt),
                 updatedAt: now,
                 deletedAt: null,
                 syncedAt: now,

--- a/packages/app/src/lib/__tests__/daemon-onboarding-identity.test.ts
+++ b/packages/app/src/lib/__tests__/daemon-onboarding-identity.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearDaemonOnboardingIdentity,
+  readDaemonOnboardingIdentity,
+  writeDaemonOnboardingIdentity,
+} from '../daemon-onboarding-identity'
+
+describe('daemon onboarding identity', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('round-trips the team and user that provisioned the daemon', () => {
+    writeDaemonOnboardingIdentity({ teamId: 'team-1', userId: 'user-1' })
+    expect(readDaemonOnboardingIdentity()).toEqual({ teamId: 'team-1', userId: 'user-1' })
+  })
+
+  it('clears a binding after a daemon reset', () => {
+    writeDaemonOnboardingIdentity({ teamId: 'team-1', userId: 'user-1' })
+    clearDaemonOnboardingIdentity()
+    expect(readDaemonOnboardingIdentity()).toBeNull()
+  })
+})

--- a/packages/app/src/lib/__tests__/message-timestamp.test.ts
+++ b/packages/app/src/lib/__tests__/message-timestamp.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeUnixTimestampSeconds,
+  unixTimestampSecondsToIso,
+} from "@/lib/message-timestamp";
+
+describe("message timestamps", () => {
+  it("keeps canonical Unix seconds unchanged", () => {
+    expect(normalizeUnixTimestampSeconds(1_754_058_252n)).toBe(1_754_058_252n);
+  });
+
+  it("normalizes legacy milliseconds before they reach local cache or sorting", () => {
+    expect(normalizeUnixTimestampSeconds(1_754_058_252_000n)).toBe(1_754_058_252n);
+    expect(unixTimestampSecondsToIso(1_754_058_252_000n)).toBe(
+      "2025-08-01T14:24:12.000Z",
+    );
+  });
+
+  it("accepts finer legacy timestamp units and rejects invalid values", () => {
+    expect(normalizeUnixTimestampSeconds(1_754_058_252_000_000n)).toBe(1_754_058_252n);
+    expect(normalizeUnixTimestampSeconds(0n)).toBe(0n);
+  });
+});

--- a/packages/app/src/lib/agent-turn-flush.ts
+++ b/packages/app/src/lib/agent-turn-flush.ts
@@ -10,13 +10,14 @@ import { flushStreamDeltasFor } from "@/lib/stream-delta-buffer";
 import {
   registerFlushedTurn,
 } from "@/lib/flushed-turn-registry";
+import { normalizeUnixTimestampSeconds, unixTimestampSecondsToIso } from "@/lib/message-timestamp";
 
 export function buildAgentReplyMessageRow(
   teamId: string,
   reply: TeamclawMessage,
 ): MessageRow {
   const now = new Date().toISOString();
-  const createdAtSec = Number(reply.createdAt);
+  const createdAtSec = normalizeUnixTimestampSeconds(reply.createdAt);
   return {
     id: reply.messageId,
     teamId,
@@ -30,10 +31,7 @@ export function buildAgentReplyMessageRow(
     model: reply.model || null,
     mentionsJson: null,
     origin: "mqtt-live",
-    createdAt:
-      Number.isFinite(createdAtSec) && createdAtSec > 0
-        ? new Date(createdAtSec * 1000).toISOString()
-        : now,
+    createdAt: unixTimestampSecondsToIso(createdAtSec, now),
     updatedAt: now,
     deletedAt: null,
     syncedAt: now,
@@ -103,12 +101,9 @@ export function bumpPreviewFromAgentReply(
   } catch {
     // keep raw content
   }
-  const createdAtSec = Number(reply.createdAt);
+  const createdAtSec = normalizeUnixTimestampSeconds(reply.createdAt);
   bumpSessionListLastMessage(sessionId, preview, {
-    at:
-      Number.isFinite(createdAtSec) && createdAtSec > 0
-        ? new Date(createdAtSec * 1000).toISOString()
-        : undefined,
+    at: createdAtSec > 0n ? unixTimestampSecondsToIso(createdAtSec) : undefined,
   });
 }
 

--- a/packages/app/src/lib/auth/auth-client.refresh.test.ts
+++ b/packages/app/src/lib/auth/auth-client.refresh.test.ts
@@ -44,9 +44,9 @@ describe("auth-client refresh — establishing a session from a refresh-only res
     expect(getSession()?.user?.id).toBe("user-123");
   });
 
-  it("preserves the live session's user when refreshing (does not let the JWT override it)", async () => {
-    // The refresh JWT carries a different sub; the existing user must win so a
-    // routine refresh never silently swaps identity.
+  it("uses the adopted token's user when switching to a phone-linked team", async () => {
+    // switch_active_team returns a refresh token for the member account in the
+    // target org. Its JWT subject must replace the prior linked identity.
     const jwt = makeJwt({ sub: "jwt-sub-should-not-win", email: "live@y.z" });
     const fetchImpl = vi.fn().mockResolvedValue(
       new Response(
@@ -66,8 +66,8 @@ describe("auth-client refresh — establishing a session from a refresh-only res
       },
       "SIGNED_IN",
     );
-    const out = await adoptRefreshToken("rt-old");
-    expect(out.user?.id).toBe("existing-1");
+    const out = await adoptRefreshToken("rt-for-linked-team");
+    expect(out.user?.id).toBe("jwt-sub-should-not-win");
     expect(out.access_token).toBe(jwt);
     expect(out.refresh_token).toBe("rt3");
   });

--- a/packages/app/src/lib/auth/auth-client.ts
+++ b/packages/app/src/lib/auth/auth-client.ts
@@ -117,7 +117,11 @@ function userFromAccessToken(token: string): AuthUser | null {
   };
 }
 
-function normalizeRefreshSession(data: unknown, current: Session | null): Session {
+function normalizeRefreshSession(
+  data: unknown,
+  current: Session | null,
+  reason: "refresh" | "adopt" = "refresh",
+): Session {
   if (!data || typeof data !== "object") return data as Session;
   const row = data as Partial<Session> & {
     accessToken?: unknown;
@@ -134,7 +138,14 @@ function normalizeRefreshSession(data: unknown, current: Session | null): Sessio
   // access token's own claims. Without a user, AuthGate sees no session and
   // bounces back to the login screen.
   if (typeof row.accessToken === "string" && typeof row.refreshToken === "string") {
-    const user = current?.user ?? userFromAccessToken(row.accessToken);
+    // A normal token renewal must retain the current profile because the
+    // refresh response has no user object. An adopted token, however, is
+    // deliberately minted for a different phone-linked account by
+    // switch_active_team; its JWT subject is the authoritative identity.
+    const tokenUser = userFromAccessToken(row.accessToken);
+    const user = reason === "adopt"
+      ? tokenUser ?? current?.user
+      : current?.user ?? tokenUser;
     if (user) {
       return {
         ...(current ?? {}),
@@ -190,9 +201,9 @@ export function createAuthClient(opts: AuthClientOptions): AuthClient {
 
   // Wire the refresher into the SessionStore so timer-driven refreshes work.
   configureSessionStore({
-    refresher: async (refreshToken: string) => {
+    refresher: async (refreshToken: string, reason) => {
       const data = await post("/v1/auth/refresh", { refreshToken });
-      return normalizeRefreshSession(data, getSession());
+      return normalizeRefreshSession(data, getSession(), reason);
     },
   });
 

--- a/packages/app/src/lib/auth/session-store.ts
+++ b/packages/app/src/lib/auth/session-store.ts
@@ -18,7 +18,8 @@ const STORAGE_KEY = "teamclaw.session.v1";
 const CHANNEL_NAME = "teamclaw.auth";
 const REFRESH_LEEWAY_SECONDS = 60;
 
-type Refresher = (refreshToken: string) => Promise<Session>;
+type RefreshReason = "refresh" | "adopt";
+type Refresher = (refreshToken: string, reason: RefreshReason) => Promise<Session>;
 
 let cachedSession: Session | null | undefined = undefined; // undefined = not yet hydrated
 let listeners = new Set<AuthListener>();
@@ -323,7 +324,7 @@ export function refreshSession(): Promise<Session> {
   const stale = () => authGeneration !== startGeneration;
   inFlightRefresh = (async () => {
     try {
-      const next = await fn(refreshToken);
+      const next = await fn(refreshToken, "refresh");
       // Session was cleared or replaced while this refresh was in flight
       // (e.g. the user signed out). Do NOT re-install the old identity.
       if (stale()) {
@@ -361,7 +362,7 @@ export function refreshSession(): Promise<Session> {
  */
 export async function adoptRefreshToken(refreshToken: string): Promise<Session> {
   if (!refresher) throw new Error("SessionStore not configured with a refresher.");
-  const next = await refresher(refreshToken);
+  const next = await refresher(refreshToken, "adopt");
   setSession(next, "TOKEN_REFRESHED");
   return next;
 }

--- a/packages/app/src/lib/daemon-onboarding-identity.ts
+++ b/packages/app/src/lib/daemon-onboarding-identity.ts
@@ -1,0 +1,42 @@
+import { appStoragePrefix } from '@/lib/build-config'
+
+const STORAGE_KEY = `${appStoragePrefix}-daemon-onboarding-identity`
+
+export type DaemonOnboardingIdentity = {
+  teamId: string
+  userId: string
+}
+
+/**
+ * The account which most recently provisioned this machine's daemon. A daemon
+ * is single-team, but its Cloud credentials are also owned by a user; teamId
+ * alone is therefore insufficient after a phone-linked identity switch.
+ */
+export function readDaemonOnboardingIdentity(): DaemonOnboardingIdentity | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    const value = JSON.parse(raw) as Partial<DaemonOnboardingIdentity>
+    if (!value.teamId || !value.userId) return null
+    return { teamId: value.teamId, userId: value.userId }
+  } catch {
+    return null
+  }
+}
+
+export function writeDaemonOnboardingIdentity(identity: DaemonOnboardingIdentity): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(identity))
+  } catch {
+    // Local storage is an optimization. A missing record never prevents the
+    // daemon wizard from recovering a machine.
+  }
+}
+
+export function clearDaemonOnboardingIdentity(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    /* ignore unavailable local storage */
+  }
+}

--- a/packages/app/src/lib/message-timestamp.ts
+++ b/packages/app/src/lib/message-timestamp.ts
@@ -1,0 +1,37 @@
+/**
+ * TeamClaw protobuf message timestamps are canonically Unix seconds.  A few
+ * older live publishers sent Unix milliseconds instead, which otherwise puts
+ * a message tens of thousands of years into the future after UI conversion.
+ */
+const MAX_UNIX_SECONDS = 10_000_000_000;
+
+export function normalizeUnixTimestampSeconds(
+  value: bigint | number | string | null | undefined,
+): bigint {
+  let numeric: number;
+  if (typeof value === "bigint") {
+    numeric = Number(value);
+  } else if (typeof value === "number") {
+    numeric = value;
+  } else if (typeof value === "string") {
+    numeric = Number(value);
+  } else {
+    return 0n;
+  }
+
+  if (!Number.isFinite(numeric) || numeric <= 0) return 0n;
+  // Accept milliseconds, microseconds, and nanoseconds defensively. A
+  // seconds value remains unchanged; repeatedly dividing makes this safe for
+  // legacy publishers that used a finer unit.
+  while (numeric > MAX_UNIX_SECONDS) numeric /= 1000;
+  return BigInt(Math.floor(numeric));
+}
+
+export function unixTimestampSecondsToIso(
+  value: bigint | number | string | null | undefined,
+  fallback = new Date().toISOString(),
+): string {
+  const seconds = normalizeUnixTimestampSeconds(value);
+  if (seconds <= 0n) return fallback;
+  return new Date(Number(seconds) * 1000).toISOString();
+}

--- a/packages/app/src/lib/session-export/collect.ts
+++ b/packages/app/src/lib/session-export/collect.ts
@@ -5,6 +5,7 @@ import {
   type Message as TeamclawMessage,
 } from "@/lib/proto/teamclaw_pb";
 import type { MessageRow } from "@/lib/local-cache";
+import { normalizeUnixTimestampSeconds } from "@/lib/message-timestamp";
 
 const kindMap: Record<string, MessageKind> = {
   text: MessageKind.TEXT,
@@ -27,7 +28,9 @@ export function messageRowsToProto(rows: MessageRow[]): TeamclawMessage[] {
       turnId: r.turnId ?? "",
       replyToMessageId: r.replyToMessageId ?? "",
       metadataJson: r.metadataJson ?? "",
-      createdAt: BigInt(Math.floor(new Date(r.createdAt).getTime() / 1000)),
+      // Normalizing here also repairs existing local-cache rows written by a
+      // legacy millisecond live event without mutating the cache during read.
+      createdAt: normalizeUnixTimestampSeconds(new Date(r.createdAt).getTime()),
     });
     if (r.partsJson) {
       Object.assign(proto, { partsJson: r.partsJson });

--- a/packages/app/src/lib/teamclaw-events.test.ts
+++ b/packages/app/src/lib/teamclaw-events.test.ts
@@ -54,6 +54,27 @@ describe("decodeLiveEvent", () => {
     const decoded = decodeLiveEvent(new Uint8Array([0xff, 0xff, 0xff]));
     expect(decoded === null || decoded!.message === undefined).toBe(true);
   });
+
+  it("normalizes a legacy millisecond message timestamp to seconds", () => {
+    const message = create(MessageSchema, {
+      messageId: "m-ms",
+      sessionId: "s1",
+      senderActorId: "a1",
+      kind: MessageKind.TEXT,
+      createdAt: BigInt(1_754_058_252_000),
+    });
+    const live = create(LiveEventEnvelopeSchema, {
+      eventType: "message.created",
+      sessionId: "s1",
+      body: toBinary(
+        SessionMessageEnvelopeSchema,
+        create(SessionMessageEnvelopeSchema, { message }),
+      ),
+    });
+
+    expect(decodeLiveEvent(toBinary(LiveEventEnvelopeSchema, live))?.message?.createdAt)
+      .toBe(BigInt(1_754_058_252));
+  });
 });
 
 describe("sessionIdFromTopic", () => {

--- a/packages/app/src/lib/teamclaw-events.ts
+++ b/packages/app/src/lib/teamclaw-events.ts
@@ -11,6 +11,7 @@ import {
   type AcpEvent,
   type Envelope as AmuxEnvelope,
 } from "@/lib/proto/amux_pb";
+import { normalizeUnixTimestampSeconds } from "@/lib/message-timestamp";
 
 export interface DecodedLiveEvent {
   envelope: LiveEventEnvelope;
@@ -34,8 +35,16 @@ export function decodeLiveEvent(bytes: Uint8Array): DecodedLiveEvent | null {
   if (envelope.eventType === "message.created" && envelope.body && envelope.body.length > 0) {
     try {
       const sessionMessage = fromBinary(SessionMessageEnvelopeSchema, envelope.body);
-      decoded.sessionMessage = sessionMessage;
-      decoded.message = sessionMessage.message;
+      // Normalize at the live-event boundary so every consumer (streaming,
+      // cache, preview and render) sees the canonical seconds unit.
+      const message = sessionMessage.message
+        ? {
+            ...sessionMessage.message,
+            createdAt: normalizeUnixTimestampSeconds(sessionMessage.message.createdAt),
+          }
+        : undefined;
+      decoded.sessionMessage = { ...sessionMessage, message };
+      decoded.message = message;
     } catch {
       // ignore body decode failure; envelope still valid for caller inspection
     }

--- a/packages/app/src/stores/__tests__/daemon-onboarding-refresh.test.ts
+++ b/packages/app/src/stores/__tests__/daemon-onboarding-refresh.test.ts
@@ -11,6 +11,10 @@ const h = vi.hoisted(() => ({
   invokeCalls: [] as string[],
   registerArgs: null as { workspacePath?: string } | null,
   installServiceShouldThrow: false,
+  currentUserId: 'user-1' as string | null,
+  localActorId: 'actor-1' as string | null,
+  ownedAgents: [] as Array<{ agent_id: string; display_name: string; is_owner: boolean; visibility?: string }>,
+  createInviteCalls: [] as Array<Record<string, unknown>>,
 }))
 
 vi.mock('@/lib/utils', () => ({ isTauri: () => h.isTauriVal }))
@@ -18,9 +22,24 @@ vi.mock('@tauri-apps/api/path', () => ({
   homeDir: async () => '/home/u',
   join: async (...parts: string[]) => parts.join('/'),
 }))
-vi.mock('@/lib/backend', () => ({ getBackend: () => ({}) }))
+vi.mock('@/lib/backend', () => ({
+  getBackend: () => ({
+    teams: {
+      createTeamInvite: vi.fn(async (input: Record<string, unknown>) => {
+        h.createInviteCalls.push(input)
+        return { token: 'invite-token' }
+      }),
+    },
+    actors: {
+      listConnectedAgents: vi.fn(async () => h.ownedAgents),
+    },
+  }),
+}))
 vi.mock('@/stores/current-team', () => ({
   useCurrentTeamStore: { getState: () => ({ team: h.currentTeam }) },
+}))
+vi.mock('@/stores/auth-store', () => ({
+  useAuthStore: { getState: () => ({ session: h.currentUserId ? { user: { id: h.currentUserId } } : null }) },
 }))
 vi.mock('@/stores/workspace', () => ({
   useWorkspaceStore: {
@@ -39,12 +58,16 @@ vi.mock('@/lib/daemon-local-client', () => ({
   fetchDaemonCloudAuthStatus: vi.fn(async () => 'unknown'),
 }))
 vi.mock('@/lib/daemon-agent-admin', () => ({
-  getLocalDaemonActorId: vi.fn(async () => null),
+  getLocalDaemonActorId: vi.fn(async () => h.localActorId),
 }))
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(async (cmd: string, args?: unknown) => {
     h.invokeCalls.push(cmd)
     if (cmd === 'get_daemon_team_id') return h.daemonTeam
+    if (cmd === 'daemon_init') {
+      h.daemonTeam = h.currentTeam?.id ?? null
+      return { actorId: 'actor-1', teamId: h.daemonTeam }
+    }
     if (cmd === 'daemon_ensure_running' || cmd === 'daemon_restart_managed') {
       if (h.installServiceShouldThrow) throw new Error('managed amuxd start boom')
       return undefined
@@ -84,6 +107,11 @@ beforeEach(() => {
   h.invokeCalls = []
   h.registerArgs = null
   h.installServiceShouldThrow = false
+  h.currentUserId = 'user-1'
+  h.localActorId = 'actor-1'
+  h.ownedAgents = [{ agent_id: 'actor-1', display_name: 'Mac daemon', is_owner: true }]
+  h.createInviteCalls = []
+  localStorage.clear()
   reset()
 })
 
@@ -125,6 +153,19 @@ describe('daemon-onboarding refresh() orchestration', () => {
     expect(h.invokeCalls).toEqual(['get_daemon_team_id'])
   })
 
+  it('reprovisions a new local actor when the user explicitly switches teams', async () => {
+    h.currentTeam = { id: 't1' }
+    h.daemonTeam = 't2'
+    h.probeQueue = [{ ok: true, baseUrl: 'http://127.0.0.1:1' }]
+
+    await useDaemonOnboardingStore.getState().refresh({ forceTeamRebind: true })
+
+    expect(h.createInviteCalls).toHaveLength(1)
+    expect(h.createInviteCalls[0]).toMatchObject({ targetActorId: null, kind: 'agent' })
+    expect(h.invokeCalls).toContain('daemon_init')
+    expect(h.invokeCalls).toContain('daemon_restart_managed')
+  })
+
   it('ready when team matches and the daemon is already healthy', async () => {
     h.currentTeam = { id: 't1' }
     h.daemonTeam = 't1'
@@ -135,6 +176,39 @@ describe('daemon-onboarding refresh() orchestration', () => {
     expect(h.invokeCalls).not.toContain('daemon_ensure_running')
     expect(h.invokeCalls).not.toContain('daemon_restart_managed')
     expect(h.invokeCalls).not.toContain('daemon_install_service')
+  })
+
+  it('rebinds when the same team is entered under a different linked user', async () => {
+    const { writeDaemonOnboardingIdentity } = await import('@/lib/daemon-onboarding-identity')
+    writeDaemonOnboardingIdentity({ teamId: 't1', userId: 'previous-user' })
+    h.currentTeam = { id: 't1' }
+    h.daemonTeam = 't1'
+    h.currentUserId = 'linked-user'
+    h.ownedAgents = [{ agent_id: 'actor-1', display_name: 'Mac daemon', is_owner: true }]
+    h.probeQueue = [{ ok: true, baseUrl: 'http://127.0.0.1:1' }]
+
+    await useDaemonOnboardingStore.getState().refresh()
+
+    expect(h.createInviteCalls).toHaveLength(1)
+    expect(h.createInviteCalls[0]).toMatchObject({ targetActorId: 'actor-1', kind: 'agent' })
+    expect(h.invokeCalls).toContain('daemon_init')
+    expect(h.invokeCalls).toContain('daemon_restart_managed')
+  })
+
+  it('migrates a legacy daemon when its local actor is not owned by the current user', async () => {
+    h.currentTeam = { id: 't1' }
+    h.daemonTeam = 't1'
+    h.currentUserId = 'linked-user'
+    // No stored identity: the old build did not persist one. The actor is not
+    // in this linked user's owned list, so a fresh local actor is provisioned.
+    h.ownedAgents = []
+    h.probeQueue = [{ ok: true, baseUrl: 'http://127.0.0.1:1' }]
+
+    await useDaemonOnboardingStore.getState().refresh()
+
+    expect(h.createInviteCalls).toHaveLength(1)
+    expect(h.createInviteCalls[0]).toMatchObject({ targetActorId: null, kind: 'agent' })
+    expect(h.invokeCalls).toContain('daemon_init')
   })
 
   it('ready registers the active workspace when it is a real project dir', async () => {

--- a/packages/app/src/stores/current-team.test.ts
+++ b/packages/app/src/stores/current-team.test.ts
@@ -221,6 +221,18 @@ describe("enterTeam", () => {
     expect(useCurrentTeamStore.getState().team?.id).toBe("team-2");
   });
 
+  it("resolves the member with the identity returned by the activated session", async () => {
+    teamsMock.activateTeam.mockResolvedValueOnce({ actorId: null, teamId: "team-2", refreshToken: "rt-2" });
+    authMock.adoptSession.mockResolvedValueOnce({ user: { id: "linked-user" } });
+    teamsMock.getTeam.mockResolvedValueOnce({ id: "team-2", name: "Quiet Falcon", slug: "quiet-falcon" });
+    directoryMock.getCurrentTeamMember.mockResolvedValueOnce(ACTIVE_MEMBER);
+
+    await useCurrentTeamStore.getState().enterTeam("team-2");
+
+    expect(directoryMock.getCurrentTeamMember).toHaveBeenCalledWith("team-2", "linked-user");
+    expect(useCurrentTeamStore.getState().teamUserId).toBe("linked-user");
+  });
+
   it("skips activation when the caller knows the team is already in the active org", async () => {
     teamsMock.activateTeam = vi.fn();
     teamsMock.getTeam.mockResolvedValueOnce(ACTIVE_TEAM);

--- a/packages/app/src/stores/current-team.ts
+++ b/packages/app/src/stores/current-team.ts
@@ -98,7 +98,7 @@ interface State {
    * Internal: only safe when the team is already inside the active org.
    * Every other caller must use `enterTeam`.
    */
-  reloadAndSwitchTo: (teamId: string) => Promise<void>;
+  reloadAndSwitchTo: (teamId: string, opts?: { userId?: string }) => Promise<void>;
   enterTeam: (teamId: string, opts?: { assumeActive?: boolean }) => Promise<void>;
   switchToTeam: (teamId: string) => Promise<void>;
   setActiveTeam: (team: CurrentTeam) => Promise<void>;
@@ -170,7 +170,7 @@ export const useCurrentTeamStore = create<State>((set, get) => ({
     });
   },
 
-  reloadAndSwitchTo: async (teamId: string) => {
+  reloadAndSwitchTo: async (teamId: string, opts) => {
     const session = useAuthStore.getState().session;
     if (!session) {
       await setLocalCacheTeamGate(null);
@@ -191,13 +191,18 @@ export const useCurrentTeamStore = create<State>((set, get) => ({
       return;
     }
     const activeTeam = data ? { id: data.id, name: data.name, slug: data.slug ?? "" } : null;
+    // `activateTeam` can adopt a refresh token for a different phone-linked
+    // user. Prefer that freshly returned identity over an auth-store listener
+    // tick, otherwise the team is resolved for the prior user and ChatPanel
+    // later cannot find its member actor.
+    const userId = opts?.userId ?? session.user.id;
     const currentMember = activeTeam
-      ? await loadCurrentMember(activeTeam.id, session.user.id)
+      ? await loadCurrentMember(activeTeam.id, userId)
       : null;
     set({
       team: activeTeam,
       currentMember,
-      teamUserId: activeTeam ? session.user.id : null,
+      teamUserId: activeTeam ? userId : null,
       loading: false,
     });
   },
@@ -221,18 +226,24 @@ export const useCurrentTeamStore = create<State>((set, get) => ({
    * `listCurrentUserTeams`, which is itself an active-org listing.
    */
   enterTeam: async (teamId: string, opts) => {
+    let activatedUserId: string | undefined
     if (!opts?.assumeActive) {
       const { refreshToken } = await getBackend().teams.activateTeam(teamId);
       // Installs the JWT carrying the new org_id (fires onAuthStateChange →
       // auth-store.session). Without this the org switch is server-only and
       // the very next request still authenticates as the old org.
-      if (refreshToken) await getBackend().auth.adoptSession(refreshToken);
+      if (refreshToken) {
+        const adopted = await getBackend().auth.adoptSession(refreshToken);
+        activatedUserId = adopted?.user?.id;
+      }
     }
-    await get().reloadAndSwitchTo(teamId);
+    await get().reloadAndSwitchTo(teamId, { userId: activatedUserId });
   },
 
   switchToTeam: async (teamId: string) => {
     set({ loading: true, error: null });
+    const previousUserId = useAuthStore.getState().session?.user?.id ?? null;
+    const previousTeamId = get().team?.id ?? null;
     try {
       await get().enterTeam(teamId);
     } catch (error) {
@@ -244,7 +255,11 @@ export const useCurrentTeamStore = create<State>((set, get) => ({
       const { isTauri } = await import("@/lib/utils");
       if (isTauri()) {
         const { useDaemonOnboardingStore } = await import("./daemon-onboarding");
-        await useDaemonOnboardingStore.getState().refresh();
+        const currentUserId = useAuthStore.getState().session?.user?.id ?? null;
+        await useDaemonOnboardingStore.getState().refresh({
+          forceIdentityRebind: !!previousUserId && !!currentUserId && previousUserId !== currentUserId,
+          forceTeamRebind: !!previousTeamId && previousTeamId !== teamId,
+        });
       }
     } catch (e) {
       console.warn("[CurrentTeam] daemon refresh after switch failed", e);

--- a/packages/app/src/stores/daemon-onboarding.ts
+++ b/packages/app/src/stores/daemon-onboarding.ts
@@ -12,6 +12,12 @@ import {
 import { getLocalDaemonActorId } from '@/lib/daemon-agent-admin'
 import { markStartup } from '@/lib/startup-perf'
 import { appScheme } from '@/lib/build-config'
+import {
+  clearDaemonOnboardingIdentity,
+  readDaemonOnboardingIdentity,
+  writeDaemonOnboardingIdentity,
+} from '@/lib/daemon-onboarding-identity'
+import { useAuthStore } from '@/stores/auth-store'
 
 /**
  * After onboarding a local daemon, adopt it as the user's default agent — but
@@ -66,7 +72,7 @@ type DaemonOnboardingState = {
   /** Last auto-heal failure (e.g. caller doesn't own the agent). Non-null
    * suppresses further automatic attempts; the banner offers a manual retry. */
   healError: string | null
-  refresh: () => Promise<void>
+  refresh: (opts?: { forceIdentityRebind?: boolean; forceTeamRebind?: boolean }) => Promise<void>
   loadOwnedAgents: () => Promise<void>
   createNewAgent: (name: string, visibility: Visibility) => Promise<void>
   bindExistingAgent: (agentId: string, displayName: string) => Promise<void>
@@ -81,6 +87,15 @@ async function daemonTeamId(): Promise<string | null> {
   if (!isTauri()) return null
   const { invoke } = await import('@tauri-apps/api/core')
   return (await invoke<string | null>('get_daemon_team_id')) ?? null
+}
+
+function currentAuthUserId(): string | null {
+  return useAuthStore.getState().session?.user?.id ?? null
+}
+
+function rememberDaemonIdentity(teamId: string): void {
+  const userId = currentAuthUserId()
+  if (userId) writeDaemonOnboardingIdentity({ teamId, userId })
 }
 
 /** Run create-invite → amuxd init → install-service. Returns the claimed agentId. */
@@ -193,7 +208,7 @@ export const useDaemonOnboardingStore = create<DaemonOnboardingState>((set, get)
   healing: false,
   healError: null,
 
-  refresh: async () => {
+  refresh: async (opts) => {
     if (!isTauri()) {
       set({ status: 'ready', loaded: true })
       return
@@ -204,10 +219,85 @@ export const useDaemonOnboardingStore = create<DaemonOnboardingState>((set, get)
     markStartup('daemon-teamid:end')
     const base = computeOnboardingStatus(dTeam, currentTeamId)
     if (base !== 'ready') {
+      if (base === 'mismatch' && opts?.forceTeamRebind && currentTeamId) {
+        // The user explicitly chose another team. amuxd is single-team, so
+        // keep the old Team's agent intact and provision a new local agent for
+        // the target Team instead of making the user reset the whole daemon.
+        set({ status: 'starting', loaded: true, busy: true, error: null })
+        try {
+          await onboard(currentTeamId, 'Local daemon', null)
+          rememberDaemonIdentity(currentTeamId)
+          invalidateDaemonConnection()
+        } catch (e) {
+          set({ status: 'error', loaded: true, error: String(e) })
+          return
+        } finally {
+          set({ busy: false })
+        }
+        // Re-read daemon.toml and health after init/restart before releasing
+        // the auth gate to the chat UI.
+        await get().refresh()
+        return
+      }
       // unknown / needs-onboard / mismatch — team-level, handled by the wizard.
       set({ status: base, loaded: true })
       markStartup('daemon-refresh:end')
       return
+    }
+    const currentUserId = currentAuthUserId()
+    const recorded = readDaemonOnboardingIdentity()
+    let localActorId: string | null = null
+    let ownedLocalAgent: OwnedAgent | undefined
+    let legacyActorOwnedByCurrentUser = true
+    // Existing installs predate the local identity record. Migrate safely by
+    // asking the Cloud API whether this user owns the local actor. A missing
+    // owner means the daemon credential was minted by another linked account.
+    if (currentUserId && !recorded) {
+      try {
+        localActorId = await getLocalDaemonActorId()
+        if (localActorId) {
+          await get().loadOwnedAgents()
+          ownedLocalAgent = get().ownedAgents.find((agent) => agent.agentId === localActorId)
+          legacyActorOwnedByCurrentUser = !!ownedLocalAgent
+        }
+      } catch (e) {
+        // A transient directory failure must not turn a healthy daemon into a
+        // blocking onboarding error. Retry on the next refresh instead.
+        console.warn('[daemon-onboarding] unable to check legacy daemon ownership', e)
+      }
+    }
+    const identityChanged = !!currentUserId && (
+      opts?.forceIdentityRebind ||
+      (recorded?.teamId === currentTeamId && recorded.userId !== currentUserId) ||
+      (!recorded && !legacyActorOwnedByCurrentUser)
+    )
+    if (identityChanged) {
+      // Same team does not imply the same daemon authority. Rebind under the
+      // newly selected linked account before it publishes commands/workspaces.
+      set({ status: 'starting', loaded: true, busy: true, error: null })
+      try {
+        localActorId ??= await getLocalDaemonActorId()
+        if (!ownedLocalAgent) {
+          await get().loadOwnedAgents()
+          ownedLocalAgent = localActorId
+            ? get().ownedAgents.find((agent) => agent.agentId === localActorId)
+            : undefined
+        }
+        if (ownedLocalAgent) {
+          await onboard(currentTeamId!, ownedLocalAgent.displayName, ownedLocalAgent.agentId)
+        } else {
+          // The prior daemon belongs to another linked account. Preserve it
+          // and create this account's local actor instead of stealing it.
+          await onboard(currentTeamId!, 'Local daemon', null)
+        }
+        rememberDaemonIdentity(currentTeamId!)
+        invalidateDaemonConnection()
+      } catch (e) {
+        set({ status: 'error', loaded: true, error: String(e) })
+        return
+      } finally {
+        set({ busy: false })
+      }
     }
     // Onboarded to the current team: also verify running + token valid, auto-recover.
     const first = await probeDaemonHttp()
@@ -260,6 +350,7 @@ export const useDaemonOnboardingStore = create<DaemonOnboardingState>((set, get)
     set({ busy: true, error: null })
     try {
       const agentId = await onboard(teamId, name, null)
+      rememberDaemonIdentity(teamId)
       if (visibility === 'personal') {
         await getBackend().actors.makeAgentPersonal(agentId)
       }
@@ -278,6 +369,7 @@ export const useDaemonOnboardingStore = create<DaemonOnboardingState>((set, get)
     set({ busy: true, error: null })
     try {
       const claimedAgentId = await onboard(teamId, displayName, agentId)
+      rememberDaemonIdentity(teamId)
       await adoptAsDefaultAgentIfUnset(teamId, claimedAgentId)
       await get().refresh()
     } catch (e) {
@@ -293,6 +385,7 @@ export const useDaemonOnboardingStore = create<DaemonOnboardingState>((set, get)
     try {
       const { invoke } = await import('@tauri-apps/api/core')
       await invoke('daemon_clear')
+      clearDaemonOnboardingIdentity()
       // Verify rather than assume. `amuxd clear` exiting 0 does not prove the
       // binding is gone — the config dir has been resurrected from the legacy
       // dir before, and a live daemon can rewrite the file. Without this check
@@ -362,6 +455,7 @@ export const useDaemonOnboardingStore = create<DaemonOnboardingState>((set, get)
       // init` to write fresh credentials, then restart the desktop-managed
       // amuxd so it reloads backend.toml.
       await onboard(teamId, owned.displayName, actorId)
+      rememberDaemonIdentity(teamId)
       invalidateDaemonConnection()
       const authOk = await waitForDaemonCloudAuthOk()
       set({ cloudAuthExpired: !authOk })


### PR DESCRIPTION
## Summary
- preserve the daemon runtime when the fast workspace identity resolves to its canonical ID
- adopt linked team identities from refreshed external JWTs
- normalize legacy millisecond live-message timestamps to Unix seconds
- repair historical local-cache reads without deleting user data

## Verification
- `pnpm --filter @teamclaw/app exec vitest run src/lib/__tests__/message-timestamp.test.ts src/lib/teamclaw-events.test.ts`
- `pnpm --filter @teamclaw/app typecheck`
- `cargo test --manifest-path apps/daemon/Cargo.toml --bin amuxd workspace_binding_tests --quiet`
- `cargo fmt --check --manifest-path apps/daemon/Cargo.toml`