### PR TITLE
fix(auth): use JWT expiry and restore workspace paths

### DIFF
--- a/apps/ios/AMUXApp/ContentView.swift
+++ b/apps/ios/AMUXApp/ContentView.swift
@@ -102,10 +102,14 @@ struct ContentView: View {
                 readyView
             case .failed:
                 OnboardingErrorView(
-                    message: onboarding.errorMessage ?? "Unknown setup error."
-                ) {
-                    Task { await onboarding.bootstrap() }
-                }
+                    message: onboarding.errorMessage ?? "Unknown setup error.",
+                    onRetry: {
+                        Task { await onboarding.bootstrap() }
+                    },
+                    onSignOut: {
+                        signOut()
+                    }
+                )
             }
         }
         .task {

--- a/apps/ios/AMUXApp/OnboardingViews.swift
+++ b/apps/ios/AMUXApp/OnboardingViews.swift
@@ -65,6 +65,7 @@ struct CreateTeamView: View {
 struct OnboardingErrorView: View {
     let message: String
     let onRetry: () -> Void
+    var onSignOut: (() -> Void)? = nil
 
     var body: some View {
         ContentUnavailableView(
@@ -73,10 +74,20 @@ struct OnboardingErrorView: View {
             description: Text(message)
         )
         .overlay(alignment: .bottom) {
-            Button("Retry") {
-                onRetry()
+            VStack(spacing: 12) {
+                Button("Retry") {
+                    onRetry()
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("onboardingError.retryButton")
+
+                if let onSignOut {
+                    Button("Sign Out", role: .destructive) {
+                        onSignOut()
+                    }
+                    .accessibilityIdentifier("onboardingError.signOutButton")
+                }
             }
-            .buttonStyle(.borderedProminent)
             .padding(.bottom, 48)
         }
     }

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/CloudAPI/Auth/SessionStore.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/CloudAPI/Auth/SessionStore.swift
@@ -43,10 +43,37 @@ public actor SessionStore {
 
     public func accessToken() async throws -> String {
         guard let s = session else { throw AuthRequired.notAuthenticated }
-        if s.expiresAt.timeIntervalSinceNow <= refreshLeadSeconds {
+        if Self.effectiveExpiry(of: s).timeIntervalSinceNow <= refreshLeadSeconds {
             return try await refreshLocked().accessToken
         }
         return s.accessToken
+    }
+
+    /// When the stored `expiresAt` and the access token's own `exp` disagree, the
+    /// token wins: a server that reports its refresh-credential lifetime here
+    /// (FC's Better-Auth backend did — ~7d session expiry for a ~15m JWT) would
+    /// otherwise park us on a dead token, and every Cloud API read 401s with
+    /// "Invalid or expired access token" until the session lapses. Taking the
+    /// earlier of the two also recovers sessions already persisted with a bad
+    /// expiry, since their `exp` is in the past.
+    static func effectiveExpiry(of session: StoredSession) -> Date {
+        guard let claimed = jwtExpiry(session.accessToken) else { return session.expiresAt }
+        return min(claimed, session.expiresAt)
+    }
+
+    /// `exp` of a JWT, read without verifying the signature — this only reads the
+    /// lifetime the issuer advertised, it is not an authorization decision.
+    static func jwtExpiry(_ token: String) -> Date? {
+        let segments = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard segments.count == 3 else { return nil }
+        var payload = String(segments[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        payload += String(repeating: "=", count: (4 - payload.count % 4) % 4)
+        guard let data = Data(base64Encoded: payload),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let exp = json["exp"] as? NSNumber else { return nil }
+        return Date(timeIntervalSince1970: exp.doubleValue)
     }
 
     public func forceRefresh() async throws {
@@ -107,7 +134,7 @@ public actor SessionStore {
     private func scheduleProactiveRefresh() {
         refreshTask?.cancel()
         guard let s = session else { return }
-        let delay = max(0, s.expiresAt.timeIntervalSinceNow - refreshLeadSeconds)
+        let delay = max(0, Self.effectiveExpiry(of: s).timeIntervalSinceNow - refreshLeadSeconds)
         refreshTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             if Task.isCancelled { return }

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/CloudAPI/CloudAPIRepositories.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/CloudAPI/CloudAPIRepositories.swift
@@ -202,7 +202,7 @@ public actor CloudAPIWorkspaceRepository: WorkspaceRepository {
                 id: row.id,
                 teamID: row.teamId,
                 agentID: row.agentId,
-                path: row.path ?? "",
+                path: row.resolvedPath,
                 displayName: row.name
             )
         }
@@ -1199,7 +1199,13 @@ private struct CloudWorkspace: Decodable, Sendable {
     let teamId: String
     let name: String
     let path: String?
+    /// The Cloud API sends the local directory as both `path` and `slug`; some
+    /// backends only fill `slug`. Desktop and the daemon already fall back to
+    /// it, so `resolvedPath` keeps iOS from rendering pathless workspaces.
+    let slug: String?
     let agentId: String?
+
+    var resolvedPath: String { path ?? slug ?? "" }
 }
 
 private struct CloudMarkViewedRequest: Encodable, Sendable {

--- a/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/Auth/SessionStoreTests.swift
+++ b/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/Auth/SessionStoreTests.swift
@@ -44,6 +44,53 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(try storage.load()?.refreshToken, "rt1")
     }
 
+    /// FC's Better-Auth backend reported the ~7d session expiry as the
+    /// access-token expiry, so the store sat on a JWT that had already died and
+    /// every Cloud API read failed with "Invalid or expired access token".
+    /// The token's own `exp` must win over the server-reported expiry.
+    func testAccessTokenRefreshesWhenJWTExpiryPrecedesStoredExpiry() async throws {
+        let storage = InMemorySessionStorage()
+        let deadJWT = Self.jwt(expiringAt: Date().addingTimeInterval(-60))
+        try storage.save(StoredSession(accessToken: deadJWT, refreshToken: "rt",
+            expiresAt: Date().addingTimeInterval(7 * 24 * 3600), isAnonymous: false, email: nil))
+        let count = LockedBox<Int>(); count.set(0)
+        let store = SessionStore(baseURL: URL(string: "https://c")!, storage: storage,
+            send: refreshResponder(at: 9_000_000_000, count: count))
+        await store.start()
+
+        // The proactive timer fires immediately for an already-expired token, so
+        // it may win the race with this call — either way the dead JWT must be
+        // replaced rather than handed out.
+        let token = try await store.accessToken()
+        XCTAssertNotEqual(token, deadJWT)
+        XCTAssertTrue(token.hasPrefix("at"), "expected a refreshed token, got \(token)")
+        XCTAssertGreaterThanOrEqual(count.get() ?? 0, 1)
+    }
+
+    func testJWTExpiryReadsExpClaimAndIgnoresNonJWTs() {
+        let expiry = Date(timeIntervalSince1970: 1_800_000_000)
+        XCTAssertEqual(
+            SessionStore.jwtExpiry(Self.jwt(expiringAt: expiry))?.timeIntervalSince1970,
+            expiry.timeIntervalSince1970
+        )
+        XCTAssertNil(SessionStore.jwtExpiry("opaque-session-token"))
+        XCTAssertNil(SessionStore.jwtExpiry("a.b.c"))
+    }
+
+    /// Unsigned stand-in for a real access token: only the payload's `exp` is read.
+    private static func jwt(expiringAt date: Date) -> String {
+        func segment(_ object: [String: Any]) -> String {
+            let data = try! JSONSerialization.data(withJSONObject: object)
+            return data.base64EncodedString()
+                .replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "=", with: "")
+        }
+        let header = segment(["alg": "HS256", "typ": "JWT"])
+        let payload = segment(["sub": "user-1", "exp": Int(date.timeIntervalSince1970)])
+        return "\(header).\(payload).signature"
+    }
+
     func testAccessTokenWithNoSessionThrowsNotAuthenticated() async {
         let store = SessionStore(baseURL: URL(string: "https://c")!, storage: InMemorySessionStorage(),
             send: { _ in (Data(), HTTPURLResponse(url: URL(string: "https://c")!, statusCode: 200, httpVersion: nil, headerFields: nil)!) })

--- a/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/CloudAPIRepositoryTests.swift
+++ b/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/CloudAPIRepositoryTests.swift
@@ -290,7 +290,9 @@ struct CloudAPIRepositoryTests {
                         { "id": "ws-1", "teamId": "team-1", "name": "Main",
                           "path": "~/code/app", "agentId": "actor-2" },
                         { "id": "ws-2", "teamId": "team-1", "name": "Scratch",
-                          "path": null, "agentId": null }
+                          "path": null, "agentId": null },
+                        { "id": "ws-3", "teamId": "team-1", "name": "SlugOnly",
+                          "slug": "~/code/slug-only", "agentId": "actor-2" }
                       ],
                       "nextCursor": null
                     }
@@ -305,10 +307,12 @@ struct CloudAPIRepositoryTests {
 
         let workspaces = try await CloudAPIWorkspaceRepository(client: client)
             .listWorkspaces(teamID: "team-1", agentID: nil)
-        #expect(workspaces.map(\.id) == ["ws-1", "ws-2"])
+        #expect(workspaces.map(\.id) == ["ws-1", "ws-2", "ws-3"])
         #expect(workspaces.first?.path == "~/code/app")
         // null path must decode to empty string, not a decode failure.
-        #expect(workspaces.last?.path == "")
+        #expect(workspaces[1].path == "")
+        // A backend that only fills `slug` must still yield a usable path.
+        #expect(workspaces.last?.path == "~/code/slug-only")
     }
 
     @Test

--- a/services/fc/src/auth/reshape.ts
+++ b/services/fc/src/auth/reshape.ts
@@ -2,6 +2,8 @@
 // envelopes that TeamClaw clients (iOS / Expo / Web / daemon) consume verbatim.
 // Do NOT change these shapes — they are the fixed client contract.
 
+import { decodeJwt } from "jose";
+
 export type ReshapeUser = {
   id?: string;
   email?: string | null;
@@ -39,6 +41,19 @@ export function toGoTrueSession(s: ReshapeSession) {
 // camelCase refresh shape (NOT GoTrue) — what refreshAccessToken returns.
 export function toRefreshShape(s: { accessToken: string; refreshToken: string; expiresAt: number }) {
   return { accessToken: s.accessToken, refreshToken: s.refreshToken, expiresAt: s.expiresAt };
+}
+
+// `exp` (epoch seconds) of a minted access-token JWT, or null when the token
+// is unparseable / carries no exp. Signature verification is irrelevant here:
+// the token was just minted by us and this only reads its own advertised
+// lifetime.
+export function accessTokenExpiry(accessToken: string): number | null {
+  try {
+    const { exp } = decodeJwt(accessToken);
+    return typeof exp === "number" ? exp : null;
+  } catch {
+    return null;
+  }
 }
 
 // Better-Auth timestamps are Date | ISO string. Normalize to epoch seconds.

--- a/services/fc/src/lib/pg-repo/auth.ts
+++ b/services/fc/src/lib/pg-repo/auth.ts
@@ -4,7 +4,7 @@ import type { JWTVerifyGetKey } from "jose";
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { getAuth, type Auth } from "../../auth/better-auth.js";
 import { mintSession } from "../../auth/mint-session.js";
-import { toGoTrueSession, toRefreshShape, toEpochSeconds, type ReshapeUser } from "../../auth/reshape.js";
+import { toGoTrueSession, toRefreshShape, toEpochSeconds, accessTokenExpiry, type ReshapeUser } from "../../auth/reshape.js";
 import { verifyAccessToken } from "../../auth/verify.js";
 import { authBaseURL } from "../../auth/base-url.js";
 import { teamInvites, actors, members, teamMembers, agents, agentMemberAccess, teamWorkspaceConfig, teams } from "../../db/schema/index.js";
@@ -44,6 +44,8 @@ async function seedMemberKeyForTeam(db: PgDatabase<any, any>, teamId: string, ac
 //     -> `{ token: <JWT> }`. The JWT has sub=userId, iss=aud=baseURL (matches
 //     verify.ts), exp ~15m.
 //   - Session (refresh) expiry comes from auth.api.getSession(...).session.expiresAt.
+//     It is ~7d and describes the REFRESH credential, so it must never be
+//     reported as the envelope's `expires_at` (see envelopeExpiry below).
 export function createPgAuthRepository(
   opts: {
     auth?: Auth;
@@ -88,6 +90,19 @@ export function createPgAuthRepository(
     return toEpochSeconds(s?.session?.expiresAt);
   }
 
+  // `expires_at` describes the ACCESS token, so it comes from the JWT's own
+  // `exp` (~15m) — NOT the session expiry (~7d). Clients schedule their refresh
+  // off this value: reporting the session expiry made them sit on a JWT that
+  // died 15 minutes in, and every authenticated read 401'd with
+  // "Invalid or expired access token" until the session itself lapsed.
+  // The session expiry is still a ceiling (refreshing past it fails anyway) and
+  // the fallback for a JWT without `exp`.
+  function envelopeExpiry(accessToken: string, sessionExp: number | null): number | null {
+    const jwtExp = accessTokenExpiry(accessToken);
+    if (jwtExp == null) return sessionExp;
+    return sessionExp == null ? jwtExp : Math.min(jwtExp, sessionExp);
+  }
+
   // Turn a Better-Auth sign-in result ({ token, user }) into the GoTrue envelope:
   // access_token = freshly minted JWT, refresh_token = the session token.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -96,7 +111,7 @@ export function createPgAuthRepository(
     const user = result?.user;
     if (!sessionToken || !user) throw new Error("auth_signin_no_session");
     const accessToken = await jwtFor(auth, sessionToken);
-    const expiresAt = await sessionExpiry(auth, sessionToken);
+    const expiresAt = envelopeExpiry(accessToken, await sessionExpiry(auth, sessionToken));
     return toGoTrueSession({ accessToken, refreshToken: sessionToken, expiresAt, user });
   }
 
@@ -166,8 +181,9 @@ export function createPgAuthRepository(
       const session = await auth.api.getSession({ headers: bearer(refreshToken) });
       if (!session?.session) throw new Error("invalid_refresh_token");
       const accessToken = await jwtFor(auth, refreshToken);
-      const expiresAt = toEpochSeconds(session.session.expiresAt);
-      if (expiresAt == null) throw new Error("invalid_refresh_token");
+      const sessionExp = toEpochSeconds(session.session.expiresAt);
+      if (sessionExp == null) throw new Error("invalid_refresh_token");
+      const expiresAt = envelopeExpiry(accessToken, sessionExp) ?? sessionExp;
       return toRefreshShape({ accessToken, refreshToken, expiresAt });
     },
 

--- a/services/fc/src/lib/pg-repo/workspaces.ts
+++ b/services/fc/src/lib/pg-repo/workspaces.ts
@@ -62,7 +62,13 @@ function mapWorkspace(r: any) {
     id: r.id,
     teamId: r.teamId,
     name: r.name,
+    // `path` and `agentId` are part of the OpenAPI Workspace schema and the
+    // supabase repo has always emitted them. Omitting them here left clients
+    // that read `path` (iOS) with pathless workspaces, and clients that filter
+    // by owning device with no agent to match.
+    path: r.path ?? null,
     slug: r.path ?? null,
+    agentId: r.agentId ?? null,
     archived: r.archived === true,
     metadata: null,
     createdAt: iso(r.createdAt)!,

--- a/services/fc/test/auth-pg.test.ts
+++ b/services/fc/test/auth-pg.test.ts
@@ -64,6 +64,28 @@ test("refreshAccessToken returns camelCase { accessToken, refreshToken, expiresA
   assert.ok(Number.isInteger(refreshed.expiresAt), "expiresAt integer epoch seconds");
 });
 
+// Clients (iOS SessionStore, desktop, daemon) schedule their refresh off
+// `expires_at`. Reporting the ~7d SESSION expiry there let a ~15m JWT die
+// unnoticed, after which every authenticated request 401'd with
+// "Invalid or expired access token" until the session itself lapsed.
+test("expires_at describes the access-token JWT, not the 7-day session", async () => {
+  const { repo } = await setup();
+  const env = await repo.signInAnonymous();
+
+  const signInJwtExp = decodeJwt(env.access_token).exp;
+  assert.equal(env.expires_at, signInJwtExp, "sign-in expires_at == JWT exp");
+
+  const refreshed = await repo.refreshAccessToken({ refreshToken: env.refresh_token! });
+  const refreshJwtExp = decodeJwt(refreshed.accessToken).exp;
+  assert.equal(refreshed.expiresAt, refreshJwtExp, "refresh expiresAt == JWT exp");
+
+  const now = Math.floor(Date.now() / 1000);
+  assert.ok(
+    refreshed.expiresAt - now < 24 * 60 * 60,
+    `access-token expiry must be short-lived, got ${refreshed.expiresAt - now}s`,
+  );
+});
+
 test("issued access_token JWT: sub == user id, iss/aud == baseURL, verifyAccessToken agrees", async () => {
   const { repo, keyset } = await setup();
   const env = await repo.signInAnonymous();

--- a/services/fc/test/pg-repo-workspaces.test.ts
+++ b/services/fc/test/pg-repo-workspaces.test.ts
@@ -53,7 +53,7 @@ test("pg-repo [workspaces]: listWorkspaces returns items with contract keys", as
   assert.ok(Array.isArray(items));
   assert.ok(items.length >= 1, "must include at least one workspace");
   assert.deepEqual(Object.keys(items[0]).sort(), [
-    "archived", "createdAt", "id", "metadata", "name", "slug", "teamId", "updatedAt",
+    "agentId", "archived", "createdAt", "id", "metadata", "name", "path", "slug", "teamId", "updatedAt",
   ].sort());
   assert.equal(items[0].id, W1);
   assert.equal(items[0].name, "Alpha");
@@ -298,15 +298,35 @@ test("pg-repo [workspaces]: patchWorkspace binds and unbinds agentId", async () 
   await seedTeam(pg, T1, "t1-patch-agent-slug");
   await seedWorkspace(pg, W1, T1, "Alpha");
 
-  // mapWorkspace doesn't surface agentId, so assert the column directly.
   const AGENT = "11111111-1111-4111-8111-111111111111";
-  await repo.patchWorkspace(W1, { agentId: AGENT });
-  const bound = await pg.query("SELECT agent_id FROM workspaces WHERE id = $1", [W1]);
-  assert.equal((bound.rows[0] as { agent_id: string | null }).agent_id, AGENT);
+  const bound = await repo.patchWorkspace(W1, { agentId: AGENT });
+  assert.equal(bound?.agentId, AGENT);
+  const boundRow = await pg.query("SELECT agent_id FROM workspaces WHERE id = $1", [W1]);
+  assert.equal((boundRow.rows[0] as { agent_id: string | null }).agent_id, AGENT);
 
-  await repo.patchWorkspace(W1, { agentId: null });
-  const unbound = await pg.query("SELECT agent_id FROM workspaces WHERE id = $1", [W1]);
-  assert.equal((unbound.rows[0] as { agent_id: string | null }).agent_id, null);
+  const unbound = await repo.patchWorkspace(W1, { agentId: null });
+  assert.equal(unbound?.agentId, null);
+  const unboundRow = await pg.query("SELECT agent_id FROM workspaces WHERE id = $1", [W1]);
+  assert.equal((unboundRow.rows[0] as { agent_id: string | null }).agent_id, null);
+});
+
+test("pg-repo [workspaces]: listWorkspaces carries path and agentId so clients can resolve the local directory", async () => {
+  const { pg, repo } = await makeRepo();
+  await seedTeam(pg, T1, "t1-path-agent-slug");
+  const AGENT = "22222222-2222-4222-8222-222222222222";
+
+  await repo.upsertWorkspace({
+    teamId: T1,
+    agentId: AGENT,
+    name: "teamclaw",
+    path: "/Users/me/code/teamclaw",
+  });
+
+  const { items } = await repo.listWorkspaces({ teamId: T1, limit: 50, cursor: null, agentId: AGENT });
+  assert.equal(items.length, 1);
+  assert.equal(items[0].path, "/Users/me/code/teamclaw");
+  assert.equal(items[0].slug, "/Users/me/code/teamclaw");
+  assert.equal(items[0].agentId, AGENT);
 });
 
 // ── getTeamWorkspaceConfig null ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- report FC Better-Auth session expiry from the minted access-token JWT instead of the longer refresh-session lifetime
- make iOS recover both newly returned and already persisted sessions whose access token expires before the stored session expiry
- restore `path` and `agentId` in the PG workspace response and let iOS fall back from `path` to `slug`
- add a sign-out action to the iOS onboarding error state

## Why

FC minted short-lived access-token JWTs but exposed the roughly seven-day refresh-session expiry. Clients therefore kept using an expired JWT and received `Invalid or expired access token` until the refresh credential itself expired.

The PG workspace mapper also omitted fields already present in the API contract, leaving iOS with pathless workspaces and no owning-agent identity.

## Verification

- `swift test --filter SessionStoreTests|CloudAPIRepositoryTests` — 14 passed
- `npx tsx --test test/auth-pg.test.ts test/pg-repo-workspaces.test.ts` — 33 passed
- clean cherry-pick onto current `origin/main` (`bf3a6b5b`, including #702)
