### PR TITLE
fix(supabase): stop switch_active_team rewriting public.users.org_id

### DIFF
--- a/services/supabase/migrations/20260802120000_switch_active_team_no_org_id_update.sql
+++ b/services/supabase/migrations/20260802120000_switch_active_team_no_org_id_update.sql
@@ -1,0 +1,60 @@
+-- switch_active_team must not rewrite public.users.org_id.
+--
+-- Betly (and other partner tenants) key each public.users row to one org.
+-- Overwriting org_id when activating a TeamClaw team corrupts that binding and
+-- surfaces outside TeamClaw. Keep phone-linked actor resolution + session mint
+-- for the actor's user_id; leave org_id untouched.
+
+create or replace function amux.switch_active_team(p_team_id uuid)
+returns table(actor_id uuid, team_id uuid, refresh_token text)
+language plpgsql security definer
+set search_path to 'amux', 'public', 'auth', 'app'
+as $function$
+declare
+  v_caller_id uuid := auth.uid();
+  v_mobile text;
+  v_actor uuid;
+  v_member_user_id uuid;
+  v_rt text;
+begin
+  if v_caller_id is null then
+    raise exception 'switch requires authentication' using errcode = '42501';
+  end if;
+
+  select nullif(btrim(u.mobile), '') into v_mobile
+    from public.users u
+   where u.id = v_caller_id
+   limit 1;
+
+  select a.id, a.user_id into v_actor, v_member_user_id
+    from amux.actors a
+   where a.team_id = p_team_id
+     and (
+       a.user_id = v_caller_id
+       or (
+         v_mobile is not null
+         and exists (
+           select 1
+             from public.users u
+            where u.id = a.user_id
+              and u.mobile = v_mobile
+         )
+       )
+     )
+   order by case when a.user_id = v_caller_id then 0 else 1 end, a.created_at asc
+   limit 1;
+  if v_actor is null then
+    raise exception 'not a member of this team' using errcode = '42501';
+  end if;
+
+  if not exists (select 1 from auth.users where id = v_member_user_id) then
+    raise exception 'linked team identity not found' using errcode = '42501';
+  end if;
+
+  v_rt := auth._mint_session(v_member_user_id);
+  update amux.actors set last_active_at = now(), updated_at = now() where id = v_actor;
+  return query select v_actor, p_team_id, v_rt;
+end;
+$function$;
+
+grant execute on function amux.switch_active_team(uuid) to authenticated, service_role;

--- a/services/supabase/tests/022_switch_active_team.sql
+++ b/services/supabase/tests/022_switch_active_team.sql
@@ -18,7 +18,7 @@ exception
 end;
 $$;
 
-select plan(7);
+select plan(8);
 
 -- ---------------------------------------------------------------------------
 -- Task 2: list_all_my_teams returns teams across ALL orgs the caller belongs to.
@@ -64,25 +64,33 @@ select ok(
   'annotates org id');
 
 -- ---------------------------------------------------------------------------
--- Task 3: switch_active_team — switching to a member team flips active org to that
--- team's oid and returns a refresh token; switching to a non-member team raises 42501.
+-- Task 3: switch_active_team — returns a refresh token for the actor identity
+-- without rewriting public.users.org_id (partner tenants bind one row per org).
+-- Switching to a non-member team raises 42501.
 -- ---------------------------------------------------------------------------
 do $$
 declare
   v_uid   uuid;
   v_teamB uuid;
-  v_orgB  uuid;
+  v_orgA  uuid;
+  v_org_before uuid;
   v_rt    text;
 begin
-  select id, oid into v_teamB, v_orgB from amux.teams where slug = 'team-b';
+  select id into v_teamB from amux.teams where slug = 'team-b';
+  select id into v_orgA from public.orgs where name = 'Org A';
   -- 复用上面的 fixture 用户：经 team-b 的 actor 确定地定位它（不依赖未过滤表上的 limit 1）。
   select a.user_id into v_uid from amux.actors a where a.team_id = v_teamB;
+  select org_id into v_org_before from public.users where auth_user_id = v_uid;
   select refresh_token into v_rt from amux.switch_active_team(v_teamB);
   perform ok(v_rt is not null, 'switch returns a refresh token');
   perform is(
     (select org_id from public.users where auth_user_id = v_uid),
-    v_orgB,
-    'switch updates active org to target team org');
+    v_org_before,
+    'switch does not rewrite public.users.org_id');
+  perform is(
+    v_org_before,
+    v_orgA,
+    'fixture still on original org after switch');
 end $$;
 
 -- 非成员的 team 调用被拒（42501）。


### PR DESCRIPTION
## Summary
- `amux.switch_active_team` no longer `UPDATE`s `public.users.org_id` when activating a team.
- Keeps phone-linked actor resolution and `_mint_session` for the actor's `user_id`.
- Partner tenants (e.g. Betly) bind one `public.users` row per org; overwriting `org_id` on team switch corrupted admin bindings outside TeamClaw (`admin_type >= 2` org lists).

## Test plan
- [ ] Apply `20260802120000_switch_active_team_no_org_id_update.sql` (or deploy migrate) and confirm `switch_active_team` body has no `update public.users`.
- [ ] Activate a team under a different org: session mint still works; `public.users.org_id` unchanged.
- [ ] Run `services/supabase/tests/022_switch_active_team.sql` (asserts org_id is preserved).
- [ ] On partner RDS already hotfixed: no further action needed beyond merging for self-host/main parity.


Made with [Cursor](https://cursor.com)