### PR TITLE
fix(daemon): harden opencode turn lifecycle close paths

### DIFF
--- a/apps/daemon/src/runtime/opencode_http/client.rs
+++ b/apps/daemon/src/runtime/opencode_http/client.rs
@@ -175,6 +175,30 @@ impl ServeClient {
         Self::check(resp, "prompt_async").await.map(|_| ())
     }
 
+    /// GET /session/{id}/message → the session's persisted messages
+    /// (`[{info, parts}, …]`, oldest first). Used to reconcile a turn after
+    /// an SSE gap: the event stream has no replay, so lost tail parts and a
+    /// missed `session.idle` are recovered from this snapshot instead.
+    pub async fn session_messages(
+        &self,
+        directory: &str,
+        session_id: &str,
+    ) -> crate::error::Result<Vec<serde_json::Value>> {
+        let resp = self
+            .req(
+                reqwest::Method::GET,
+                &format!("/session/{session_id}/message"),
+                directory,
+            )
+            .send()
+            .await
+            .map_err(|e| crate::error::AmuxError::Agent(format!("session messages: {e}")))?;
+        let resp = Self::check(resp, "session messages").await?;
+        resp.json()
+            .await
+            .map_err(|e| crate::error::AmuxError::Agent(format!("session messages body: {e}")))
+    }
+
     /// GET /session/status → map of session id to current status
     /// (`{"ses_x": {"type": "retry", "message": …, "next": …}}`). The only
     /// reliable way to observe provider-retry state: the SSE `session.status`

--- a/apps/daemon/src/runtime/opencode_http/events.rs
+++ b/apps/daemon/src/runtime/opencode_http/events.rs
@@ -54,6 +54,12 @@ async fn sse_loop(shared: Arc<Shared>, directory: String) {
                 info!(directory = %directory, "opencode SSE subscribed");
                 backoff = BACKOFF_MIN;
                 shared.mark_sse_connected(&directory);
+                // Events emitted while the stream was down are gone (no
+                // replay) — read back anything an active turn missed.
+                tokio::spawn(reconcile_turns_after_reconnect(
+                    Arc::clone(&shared),
+                    directory.clone(),
+                ));
                 let mut stream = resp.bytes_stream();
                 let mut buf = Vec::new();
                 while let Some(chunk) = stream.next().await {
@@ -93,6 +99,79 @@ async fn sse_loop(shared: Arc<Shared>, directory: String) {
         // Nothing left to route for? Keep the subscription anyway — sessions
         // for this directory may be re-attached after a daemon-side resume.
         tokio::time::sleep(BACKOFF_MIN).await;
+    }
+}
+
+/// After an SSE (re)subscribe, events emitted during the gap are lost — the
+/// stream has no cursor/replay. For every turn still marked active in this
+/// directory, read the persisted messages back and replay the tail through
+/// the normal translate path: suffix-diffing and tool-signature dedupe drop
+/// everything already emitted, so only the missing pieces reach clients.
+/// When opencode finished the turn during the gap (last assistant message
+/// carries `time.completed`), the missed `session.idle` is synthesized so the
+/// turn closes instead of hanging until the watchdog aborts it as stalled.
+async fn reconcile_turns_after_reconnect(shared: Arc<Shared>, directory: String) {
+    let session_ids: Vec<String> = {
+        let routes = shared.routes.lock();
+        routes
+            .iter()
+            .filter(|(_, r)| {
+                r.directory == directory && r.turn_active && r.parent_session_id.is_none()
+            })
+            .map(|(id, _)| id.clone())
+            .collect()
+    };
+    if session_ids.is_empty() {
+        return;
+    }
+    let client = match shared.serve.ensure().await {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    for session_id in session_ids {
+        let messages = match client.session_messages(&directory, &session_id).await {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(session_id, error = %e, "post-reconnect message read failed");
+                continue;
+            }
+        };
+        // Only the tail can have been lost mid-turn: the current user prompt
+        // plus the assistant response being generated.
+        let tail = messages.len().saturating_sub(2);
+        let mut assistant_completed = false;
+        for message in &messages[tail..] {
+            let info = message
+                .get("info")
+                .cloned()
+                .unwrap_or(serde_json::json!({}));
+            handle_event(
+                &shared,
+                &serde_json::json!({"type": "message.updated", "properties": {"info": info}}),
+            )
+            .await;
+            if let Some(parts) = message.get("parts").and_then(|v| v.as_array()) {
+                for part in parts {
+                    handle_event(
+                        &shared,
+                        &serde_json::json!({"type": "message.part.updated", "properties": {"part": part}}),
+                    )
+                    .await;
+                }
+            }
+            if info.get("role").and_then(|v| v.as_str()) == Some("assistant") {
+                assistant_completed = info
+                    .pointer("/time/completed")
+                    .is_some_and(|v| !v.is_null());
+            }
+        }
+        if assistant_completed {
+            info!(
+                session_id,
+                "turn finished during SSE gap; synthesizing session.idle"
+            );
+            handle_session_idle(&shared, &session_id).await;
+        }
     }
 }
 
@@ -160,6 +239,19 @@ async fn handle_event(shared: &Arc<Shared>, event: &serde_json::Value) {
                 let events = translate::translate_event(&mut route.translate, event_type, &props);
                 if !events.is_empty() {
                     route.turn_saw_output = true;
+                }
+                // Track in-flight tool calls: while one is running, opencode
+                // emits nothing, so the stuck-turn watchdog widens its budget.
+                for ev in &events {
+                    match ev.event.as_ref() {
+                        Some(amux::acp_event::Event::ToolUse(tu)) => {
+                            route.tools_in_flight.insert(tu.tool_id.clone());
+                        }
+                        Some(amux::acp_event::Event::ToolResult(tr)) => {
+                            route.tools_in_flight.remove(&tr.tool_id);
+                        }
+                        _ => {}
+                    }
                 }
                 let out = (events, route.event_tx.clone(), route.turn_reply_to.clone());
                 // Keep parent's stuck-turn clock alive while the subagent works.
@@ -603,13 +695,24 @@ async fn handle_session_idle(shared: &Arc<Shared>, session_id: &str) {
         let Some(route) = routes.get_mut(session_id) else {
             return;
         };
-        if !route.turn_active {
-            None
-        } else {
+        route.tools_in_flight.clear();
+        if route.turn_active {
             route.turn_active = false;
             let reply_to = route.turn_reply_to.take();
             route.turn_requester = None;
             Some((route.event_tx.clone(), reply_to))
+        } else if route.parent_session_id.is_none() {
+            // The turn was already closed daemon-side (watchdog abort, cancel
+            // fallback, failed submit) while opencode kept running. Whatever
+            // streamed in after that close sits in the aggregator with no
+            // terminal event to flush it — emit the Active→Idle anyway; an
+            // aggregator with empty buffers emits nothing, so this is
+            // idempotent. Child (task-subagent) sessions must not get this:
+            // their frames ride the parent's channel and a synthetic idle
+            // would flush the parent's turn mid-run.
+            Some((route.event_tx.clone(), None))
+        } else {
+            None
         }
     };
     if let Some((event_tx, reply_to)) = closed {

--- a/apps/daemon/src/runtime/opencode_http/mod.rs
+++ b/apps/daemon/src/runtime/opencode_http/mod.rs
@@ -6,7 +6,7 @@
 //! surface (`AcpCommand`, `AcpStartupMetadata`, `OpencodeHost`) keeps the old
 //! names and signatures so `RuntimeManager` / gateway plumbing is unchanged.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -79,6 +79,10 @@ pub(crate) struct Route {
     /// apart from a transient blip, so we don't wait out the [`FIRST_OUTPUT_TIMEOUT`]
     /// window when the backoff itself never grows past it.
     pub(crate) retry_streak: Option<(String, u32)>,
+    /// Tool call ids currently in flight (ToolUse seen, no ToolResult yet).
+    /// opencode emits no SSE events while a tool runs, so the stuck-turn
+    /// watchdog must not treat that silence as a stalled model.
+    pub(crate) tools_in_flight: HashSet<String>,
     pub(crate) translate: TranslateState,
     /// MCP server names amuxd injected into the worktree's `opencode.json`
     /// for this session (gateway `send` tool / remote tools). Pruned back out
@@ -214,6 +218,15 @@ impl Shared {
         ids
     }
 
+    /// True while any tool call is in flight on this turn — on the parent
+    /// session or on a task-subagent child riding its channel.
+    pub(super) fn turn_has_tool_in_flight(&self, parent_session_id: &str) -> bool {
+        let ids = self.session_ids_for_user_wait(parent_session_id);
+        let routes = self.routes.lock();
+        ids.iter()
+            .any(|id| routes.get(id).is_some_and(|r| !r.tools_in_flight.is_empty()))
+    }
+
     pub(super) fn turn_waiting_on_user(&self, parent_session_id: &str) -> bool {
         let wait_ids = self.session_ids_for_user_wait(parent_session_id);
         let has_perm = self
@@ -296,6 +309,7 @@ impl Shared {
             turn_seq: 0,
             turn_saw_output: false,
             turn_last_event_at: std::time::Instant::now(),
+            tools_in_flight: HashSet::new(),
             translate: TranslateState::default(),
             injected_mcp: Vec::new(),
             parent_session_id: Some(parent_id.to_string()),
@@ -786,6 +800,7 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
                 turn_seq: 0,
                 turn_saw_output: false,
                 turn_last_event_at: std::time::Instant::now(),
+                tools_in_flight: HashSet::new(),
                 translate: TranslateState::default(),
                 injected_mcp,
                 parent_session_id: None,
@@ -880,6 +895,7 @@ async fn do_prompt(
         route.turn_saw_output = false;
         route.turn_last_event_at = std::time::Instant::now();
         route.retry_streak = None;
+        route.tools_in_flight.clear();
         (
             route.event_tx.clone(),
             route.directory.clone(),
@@ -956,6 +972,7 @@ async fn do_prompt(
                 route.turn_active = false;
                 route.turn_reply_to = None;
                 route.turn_requester = None;
+                route.tools_in_flight.clear();
             }
         }
         emit_frame(
@@ -972,6 +989,10 @@ async fn do_prompt(
 const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// Give up on a turn that produced no output and no retry status after this.
 pub(crate) const FIRST_OUTPUT_TIMEOUT: Duration = Duration::from_secs(120);
+/// Silence budget while a tool call is in flight. opencode sends no SSE
+/// events while a tool runs (long bash, builds, slow MCP calls), so model
+/// silence is expected then — only give up after this much larger bound.
+pub(crate) const TOOL_SILENCE_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 
 /// A failed upstream provider request (out of credit, usage limit, rate
 /// limit) is invisible on the happy path: opencode keeps the assistant
@@ -1055,6 +1076,28 @@ fn spawn_stuck_turn_watchdog(shared: &Arc<Shared>, session_id: &str, turn_seq: u
                 }
             }
             if silent_for >= FIRST_OUTPUT_TIMEOUT {
+                if shared.turn_has_tool_in_flight(&session_id) {
+                    if silent_for < TOOL_SILENCE_TIMEOUT {
+                        continue;
+                    }
+                    warn!(
+                        session_id,
+                        timeout_s = TOOL_SILENCE_TIMEOUT.as_secs(),
+                        "in-flight tool silent past its budget; aborting stuck opencode turn"
+                    );
+                    abort_turn_with_error(
+                        &shared,
+                        &session_id,
+                        "tool stalled".to_string(),
+                        format!(
+                            "A tool call produced no result for {}s. The turn was \
+                             aborted; try again.",
+                            TOOL_SILENCE_TIMEOUT.as_secs()
+                        ),
+                    )
+                    .await;
+                    return;
+                }
                 warn!(
                     session_id,
                     timeout_s = FIRST_OUTPUT_TIMEOUT.as_secs(),
@@ -1118,6 +1161,7 @@ fn take_active_turn(route: &mut Route) -> Option<(mpsc::Sender<AcpEventFrame>, O
     }
     route.turn_active = false;
     route.turn_requester = None;
+    route.tools_in_flight.clear();
     Some((route.event_tx.clone(), route.turn_reply_to.take()))
 }
 
@@ -1158,6 +1202,7 @@ pub(crate) async fn abort_turn_with_error(
         }
         route.turn_active = false;
         route.turn_requester = None;
+        route.tools_in_flight.clear();
         (
             route.event_tx.clone(),
             route.directory.clone(),
@@ -1176,6 +1221,100 @@ pub(crate) async fn abort_turn_with_error(
             event: Some(amux::acp_event::Event::Error(amux::AcpError {
                 message,
                 details,
+            })),
+            model: String::new(),
+        },
+        reply_to.clone(),
+    )
+    .await;
+    emit_frame(
+        &event_tx,
+        session_id,
+        translate::status_change(amux::AgentStatus::Active, amux::AgentStatus::Idle),
+        reply_to,
+    )
+    .await;
+}
+
+/// After a successful `POST /abort`, how long to wait for opencode's own
+/// `session.error` + `session.idle` to close the turn before forcing it.
+const CANCEL_CLOSE_GRACE: Duration = Duration::from_secs(10);
+
+/// User-initiated interrupt. On the happy path opencode answers the abort
+/// with `session.error` (MessageAbortedError) + `session.idle` over SSE and
+/// those close the turn. The close must not depend on that though: when the
+/// abort call itself fails the turn is force-closed immediately, and even a
+/// successful abort is backstopped by a grace timer in case the terminal SSE
+/// events are lost to a gap — otherwise the client never leaves "replying…"
+/// and cannot even re-interrupt.
+async fn cancel_turn(shared: &Arc<Shared>, session_id: &str) {
+    let (directory, turn_seq) = {
+        let routes = shared.routes.lock();
+        match routes.get(session_id) {
+            Some(route) => (route.directory.clone(), route.turn_seq),
+            None => (String::new(), 0),
+        }
+    };
+    let abort_ok = match shared.serve.ensure().await {
+        Ok(client) => match client.abort(&directory, session_id).await {
+            Ok(()) => {
+                crate::runtime::agent_trace::log_cancel(session_id, true, "");
+                true
+            }
+            Err(e) => {
+                let err = e.to_string();
+                crate::runtime::agent_trace::log_cancel(session_id, false, &err);
+                warn!(session_id, error = %err, "opencode abort failed");
+                false
+            }
+        },
+        Err(e) => {
+            warn!(error = %e, "cancel: serve unavailable");
+            false
+        }
+    };
+    if !abort_ok {
+        force_close_interrupted_turn(shared, session_id, turn_seq).await;
+        return;
+    }
+    let shared = Arc::clone(shared);
+    let session_id = session_id.to_string();
+    tokio::spawn(async move {
+        tokio::time::sleep(CANCEL_CLOSE_GRACE).await;
+        force_close_interrupted_turn(&shared, &session_id, turn_seq).await;
+    });
+}
+
+/// Close a turn that a cancel could not (or did not) close through opencode:
+/// emit the abort-shaped `Error` (so the aggregator produces the durable
+/// interrupted AgentReply, keeping any partial prose) followed by the
+/// Active→Idle terminal. No-op when the turn already closed or a newer
+/// prompt took the route over.
+async fn force_close_interrupted_turn(shared: &Arc<Shared>, session_id: &str, turn_seq: u64) {
+    let (event_tx, reply_to) = {
+        let mut routes = shared.routes.lock();
+        let Some(route) = routes.get_mut(session_id) else {
+            return;
+        };
+        if !route.turn_active || route.turn_seq != turn_seq {
+            return;
+        }
+        route.turn_active = false;
+        route.turn_requester = None;
+        route.tools_in_flight.clear();
+        (route.event_tx.clone(), route.turn_reply_to.take())
+    };
+    warn!(
+        session_id,
+        "turn did not close after cancel; forcing interrupted close"
+    );
+    emit_frame(
+        &event_tx,
+        session_id,
+        amux::AcpEvent {
+            event: Some(amux::acp_event::Event::Error(amux::AcpError {
+                message: "TurnInterrupted".to_string(),
+                details: "The turn was stopped by the user.".to_string(),
             })),
             model: String::new(),
         },
@@ -1322,25 +1461,7 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                 .await;
             }
             AcpCommand::Cancel { acp_session_id } => {
-                let directory = shared
-                    .routes
-                    .lock()
-                    .get(&acp_session_id)
-                    .map(|r| r.directory.clone())
-                    .unwrap_or_default();
-                match shared.serve.ensure().await {
-                    Ok(client) => match client.abort(&directory, &acp_session_id).await {
-                        Ok(()) => {
-                            crate::runtime::agent_trace::log_cancel(&acp_session_id, true, "")
-                        }
-                        Err(e) => {
-                            let err = e.to_string();
-                            crate::runtime::agent_trace::log_cancel(&acp_session_id, false, &err);
-                            warn!(acp_session_id, error = %err, "opencode abort failed");
-                        }
-                    },
-                    Err(e) => warn!(error = %e, "cancel: serve unavailable"),
-                }
+                cancel_turn(&shared, &acp_session_id).await;
             }
             AcpCommand::ResolvePermission {
                 request_id,
@@ -1653,6 +1774,7 @@ mod pool_tests {
                 turn_seq: 0,
                 turn_saw_output: false,
                 turn_last_event_at: std::time::Instant::now(),
+                tools_in_flight: HashSet::new(),
                 translate: TranslateState::default(),
                 injected_mcp: vec!["amuxd-send".to_string()],
                 parent_session_id: None,
@@ -1685,6 +1807,7 @@ mod turn_activity_tests {
             turn_last_event_at: std::time::Instant::now()
                 .checked_sub(std::time::Duration::from_secs(90))
                 .unwrap_or_else(std::time::Instant::now),
+            tools_in_flight: HashSet::new(),
             translate: TranslateState::default(),
             injected_mcp: Vec::new(),
             parent_session_id: None,
@@ -1795,6 +1918,7 @@ mod turn_activity_tests {
                     turn_seq: 0,
                     turn_saw_output: false,
                     turn_last_event_at: std::time::Instant::now(),
+                    tools_in_flight: HashSet::new(),
                     translate: TranslateState::default(),
                     injected_mcp: Vec::new(),
                     parent_session_id: Some("ses_parent".to_string()),

--- a/apps/daemon/src/runtime/opencode_http/translate.rs
+++ b/apps/daemon/src/runtime/opencode_http/translate.rs
@@ -206,7 +206,15 @@ fn translate_part_updated(
             // sessions with deltas don't double-emit, and sessions without
             // deltas still stream incremental text.
             if text.len() > meta.emitted {
-                let chunk = text[meta.emitted..].to_string();
+                // `emitted` is accumulated from delta byte lengths; if the
+                // full text ever disagrees with the delta concatenation the
+                // boundary can land mid-character — back off to the nearest
+                // char boundary instead of panicking on the byte slice.
+                let mut start = meta.emitted.min(text.len());
+                while start > 0 && !text.is_char_boundary(start) {
+                    start -= 1;
+                }
+                let chunk = text[start..].to_string();
                 meta.emitted = text.len();
                 if chunk.is_empty() {
                     vec![]
@@ -237,7 +245,10 @@ fn translate_tool_part(
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
-    // Dedupe repeated identical updates (opencode re-sends the whole part).
+    // Dedupe repeated identical updates (opencode re-sends the whole part;
+    // the post-reconnect reconcile replays persisted parts). A terminal
+    // status re-sent with the same input is always redundant too — the
+    // output can't have changed after completion.
     let sig = format!(
         "{status}|{}",
         tool_state
@@ -245,7 +256,7 @@ fn translate_tool_part(
             .map(|v| v.to_string())
             .unwrap_or_default()
     );
-    if state.tool_last_sig.get(part_id) == Some(&sig) && matches!(status, "pending" | "running") {
+    if state.tool_last_sig.get(part_id) == Some(&sig) {
         return vec![];
     }
     state.tool_last_sig.insert(part_id.to_string(), sig);
@@ -587,6 +598,47 @@ mod tests {
             }
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    #[test]
+    fn suffix_slice_survives_non_char_boundary() {
+        let mut s = TranslateState::default();
+        assistant_msg(&mut s, "msg_a1");
+        // A delta whose byte length lands mid-character in the later full
+        // text ("你" is 3 bytes; claim 4 were emitted).
+        ev(
+            &mut s,
+            "message.part.delta",
+            serde_json::json!({"sessionID":"ses_1","messageID":"msg_a1","partID":"prt_9","field":"text","delta":"你a"}),
+        );
+        let e = ev(
+            &mut s,
+            "message.part.updated",
+            serde_json::json!({"sessionID":"ses_1","part":{
+                "id":"prt_9","messageID":"msg_a1","sessionID":"ses_1","type":"text","text":"你好世界"
+            },"time":1.0}),
+        );
+        // Must not panic; emits from the nearest char boundary at or below.
+        assert_eq!(e.len(), 1);
+        match e[0].event.as_ref().unwrap() {
+            amux::acp_event::Event::Output(o) => assert_eq!(o.text, "好世界"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn completed_tool_part_resend_is_deduped() {
+        let mut s = TranslateState::default();
+        let completed = serde_json::json!({"sessionID":"ses_1","part":{
+            "id":"prt_t","messageID":"msg_a1","sessionID":"ses_1","type":"tool",
+            "callID":"call_1","tool":"bash",
+            "state":{"status":"completed","input":{"command":"ls"},"output":"a.txt\n",
+                     "title":"List files","metadata":{},"time":{"start":1,"end":2}}
+        },"time":2.0});
+        let first = ev(&mut s, "message.part.updated", completed.clone());
+        assert_eq!(first.len(), 1);
+        // Replayed by the post-reconnect reconcile → must not double-emit.
+        assert!(ev(&mut s, "message.part.updated", completed).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## 问题

opencode 本地 agent 三个用户可见故障,根因都是 turn 收尾只依赖 SSE 的 `session.idle` 单点事件:

1. **结束了但 final 消息没打出来** — turn 被 daemon 侧提前关闭(watchdog 中止 / 提交失败 / detach)后,真正的 `session.idle` 被静默吞掉,聚合器里缓存的最终文本永远不 flush;SSE 断线期间的尾部事件无重放,永久丢失。
2. **莫名其妙结束** — opencode 在工具运行期间不发任何 SSE 事件,120 秒静默 watchdog 把超过 2 分钟的 bash/构建/MCP 调用当成 "model stalled" 直接 abort。
3. **中断了不知道结束没** — `Cancel` 只调 `POST /abort` 然后指望 opencode 回 terminal 事件;abort 失败或事件丢失时客户端什么都收不到,永远停在"回复中",连再次中断都不行。

## 修复

**Cancel 强制收尾**(`mod.rs`)
- `cancel_turn`:abort 失败立即强制收尾;成功也挂 10 秒兜底,terminal SSE 事件丢了照样收尾。
- 强制收尾发 abort 形态的 `TurnInterrupted` Error(聚合器据此产出 durable interrupted reply,保留部分文本)+ `Active→Idle`;`turn_seq` 防护避免误关新 prompt。

**watchdog 工具豁免**(`mod.rs` + `events.rs`)
- Route 追踪 `tools_in_flight`(含 task 子会话),工具在飞时静默预算从 120 秒放宽到 60 分钟。

**session.idle 兜底 + SSE 重连对账**(`events.rs` + `client.rs`)
- `session.idle` 遇到已提前关闭的父会话 turn 时,仍发 `Active→Idle` flush 聚合器滞留内容(空 buffer 幂等;子会话排除,避免误关父 turn)。
- SSE 重连后回读 `GET /session/{id}/message`(新增端点),把尾部消息重放进正常 translate 去重路径补齐丢失内容;断线期间 turn 已完成(assistant `time.completed`)则补发丢失的 idle 收尾。

**附带加固**(`translate.rs`,配单测)
- 后缀切片非字符边界 panic 修复(原本会带死整个目录的 SSE 任务且不重启)。
- completed/error 工具事件的重复下发去重(对账重放依赖)。

## 验证

- `cargo test --bin amuxd`:969 passed, 0 failed
- clippy 警告数与改动前持平(119,均为存量)
- 新增单测:非字符边界后缀、completed 工具重放去重

🤖 Generated with [Claude Code](https://claude.com/claude-code)