### PR TITLE
refactor(api): paginate the unbounded session/message list endpoints

### DIFF
--- a/apps/expo/src/features/sessions/cloud-api.ts
+++ b/apps/expo/src/features/sessions/cloud-api.ts
@@ -94,6 +94,42 @@ type SessionRuntime = {
   status: string;
 };
 
+/** Server-side cap in FC's `parseLimit`; a larger `limit` is rejected as a 400. */
+const MAX_PAGE_SIZE = 100;
+
+/**
+ * Walks `GET /v1/sessions?teamId=…` to exhaustion.
+ *
+ * Replaces `GET /v1/teams/:teamId/sessions`, which returned a team's whole
+ * session list in one response. That endpoint fell over on large teams: it
+ * counted participants with a query that put every session id in the URL,
+ * which crossed the gateway's request-line limit and surfaced as an opaque
+ * 500. The replacement is paginated, so a caller that wants everything pages.
+ */
+async function listAllTeamSessions(
+  client: { get: <T>(path: string) => Promise<T> },
+  teamId: string,
+): Promise<CloudSessionFull[]> {
+  // Bounded so a server that keeps returning a cursor cannot spin forever.
+  const MAX_PAGES = 100;
+  const all: CloudSessionFull[] = [];
+  let cursor: string | null = null;
+  let pages = 0;
+
+  do {
+    const params = new URLSearchParams({ teamId, limit: String(MAX_PAGE_SIZE) });
+    if (cursor) params.set("cursor", cursor);
+    const response = await client.get<{ items?: CloudSessionFull[]; nextCursor?: string | null }>(
+      `/v1/sessions?${params.toString()}`,
+    );
+    all.push(...(response.items ?? []));
+    cursor = response.nextCursor ?? null;
+    pages += 1;
+  } while (cursor && pages < MAX_PAGES);
+
+  return all;
+}
+
 function mapSession(row: CloudSessionFull): SessionSummary {
   return {
     sessionId: row.id,
@@ -101,9 +137,9 @@ function mapSession(row: CloudSessionFull): SessionSummary {
     title: row.title ?? "",
     summary: row.summary ?? "",
     participantCount: row.participantCount ?? 0,
-    // The team-sessions endpoint does not expose the participant actor id
-    // list. The only consumer (mention resolver) treats it as advisory and
-    // falls back to the full team directory, so an empty list is safe.
+    // The session list does not expose the participant actor id list. The only
+    // consumer (mention resolver) treats it as advisory and falls back to the
+    // full team directory, so an empty list is safe.
     participantActorIds: [],
     lastMessagePreview: row.lastMessagePreview ?? "",
     lastMessageAt: row.lastMessageAt ?? "",
@@ -144,10 +180,7 @@ export function createCloudSessionsApi(options: CreateCloudSessionsApiOptions) {
       // currentActorId is derived server-side from the bearer; kept for
       // signature parity with the legacy Supabase implementation.
       void currentActorId;
-      const response = await client.get<{ items?: CloudSessionFull[] }>(
-        `/v1/teams/${encodeURIComponent(teamId)}/sessions`,
-      );
-      return (response.items ?? []).map(mapSession);
+      return (await listAllTeamSessions(client, teamId)).map(mapSession);
     },
 
     async listSessionsForIdea(
@@ -155,16 +188,20 @@ export function createCloudSessionsApi(options: CreateCloudSessionsApiOptions) {
       ideaId: string,
       limit = 5,
     ): Promise<SessionSummary[]> {
-      // The team-sessions endpoint returns rows ordered by last_message_at
-      // desc and carries ideaId, so we filter client-side to mirror the prior
-      // `sessions.eq(idea_id).order(last_message_at).limit(5)` query.
+      // Filtered by the server. This used to pull the whole team list and
+      // filter in the client, which only worked because the old endpoint was
+      // unpaginated — against a paginated one it would silently miss matches
+      // that fall on a later page. Rows come back ordered by last_message_at
+      // desc, so a plain limit is the top-N.
+      const params = new URLSearchParams({
+        teamId,
+        ideaId,
+        limit: String(Math.min(limit, MAX_PAGE_SIZE)),
+      });
       const response = await client.get<{ items?: CloudSessionFull[] }>(
-        `/v1/teams/${encodeURIComponent(teamId)}/sessions`,
+        `/v1/sessions?${params.toString()}`,
       );
-      return (response.items ?? [])
-        .filter((row) => row.ideaId === ideaId)
-        .slice(0, limit)
-        .map(mapSession);
+      return (response.items ?? []).map(mapSession);
     },
 
     async getSession(teamId: string, sessionId: string): Promise<SessionSummary | null> {

--- a/apps/expo/src/test/cloud-api-provider.test.ts
+++ b/apps/expo/src/test/cloud-api-provider.test.ts
@@ -10,7 +10,7 @@ describe("Expo Cloud API provider", () => {
     vi.stubEnv("EXPO_PUBLIC_BACKEND_KIND", "cloud_api");
     vi.stubEnv("EXPO_PUBLIC_CLOUD_API_URL", "https://fc.example.com");
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
-      if (String(url).endsWith("/v1/teams/team-1/sessions")) {
+      if (String(url).includes("/v1/sessions?")) {
         return response({
           items: [{
             id: "session-1",
@@ -28,6 +28,8 @@ describe("Expo Cloud API provider", () => {
             createdAt: "2026-05-27T00:00:00Z",
             updatedAt: "2026-05-27T01:00:00Z",
           }],
+          // Short page → no cursor, so the pager stops after one request.
+          nextCursor: null,
         });
       }
       if (String(url).endsWith("/v1/sessions/session-1/messages") && init?.method === "POST") {
@@ -55,6 +57,9 @@ describe("Expo Cloud API provider", () => {
     await expect(api.listSessions("team-1")).resolves.toMatchObject([
       { sessionId: "session-1", teamId: "team-1", hasUnread: true },
     ]);
+    // The team filter has to reach the server: post-filtering a paginated list
+    // in the client would drop matches that land on a later page.
+    expect(String(fetchMock.mock.calls[0][0])).toContain("teamId=team-1");
     await expect(api.insertOutgoingMessage({
       id: "message-1",
       teamId: "team-1",

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/CloudAPI/CloudAPIRepositories.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/CloudAPI/CloudAPIRepositories.swift
@@ -28,8 +28,7 @@ public actor CloudAPISessionsRepository: SessionsRepository {
     }
 
     public func listSessions(teamID: String) async throws -> [SessionRecord] {
-        let page: CloudPage<CloudSessionFull> = try await client.get("/v1/teams/\(teamID)/sessions")
-        return page.items.map { row in
+        try await CloudSessionPager.allPages(client: client, teamID: teamID).map { row in
             SessionRecord(
                 id: row.id,
                 teamID: row.teamId,
@@ -74,8 +73,56 @@ public actor CloudAPISessionIDsRepository: SessionIDsRepository {
     }
 
     public func listSessionIDs(teamID: String) async throws -> Set<String> {
-        let page: CloudPage<CloudSessionFull> = try await client.get("/v1/teams/\(teamID)/sessions")
-        return Set(page.items.map(\.id))
+        Set(try await CloudSessionPager.allPages(client: client, teamID: teamID).map(\.id))
+    }
+}
+
+/// Walks `GET /v1/sessions?teamId=…` to exhaustion.
+///
+/// This replaced `GET /v1/teams/:teamID/sessions`, which returned a team's
+/// entire session list in one unpaginated response — and blew up once a team
+/// grew past a couple hundred sessions, because the server built its
+/// participant-count query by putting every session id in a URL. The
+/// replacement is capped at 100 rows per page, so callers that genuinely want
+/// the whole list have to page for it.
+private enum CloudSessionPager {
+    /// Matches the server-side cap in `parseLimit` (MAX_LIST_LIMIT); asking for
+    /// more is a 400, not a bigger page.
+    private static let pageSize = 100
+
+    /// Stops after this many pages so a server that keeps handing back a cursor
+    /// cannot spin the client forever. 100 pages x 100 rows is far beyond any
+    /// real team, so hitting it means something is wrong, not that the team is
+    /// large.
+    private static let maxPages = 100
+
+    static func allPages(client: CloudAPIClient, teamID: String) async throws -> [CloudSessionFull] {
+        var all: [CloudSessionFull] = []
+        var cursor: String?
+        var pages = 0
+
+        repeat {
+            var path = "/v1/sessions?teamId=\(urlEncoded(teamID))&limit=\(pageSize)"
+            if let cursor { path += "&cursor=\(urlEncoded(cursor))" }
+
+            let page: CloudPage<CloudSessionFull> = try await client.get(path)
+            all.append(contentsOf: page.items)
+            cursor = page.nextCursor
+            pages += 1
+        } while cursor != nil && pages < maxPages
+
+        return all
+    }
+
+    /// RFC 3986 unreserved set. Deliberately not `.alphanumerics` (which would
+    /// escape the hyphens in a uuid) nor `.urlQueryAllowed` (which passes `&`
+    /// and `=` through and would let a value forge extra query parameters).
+    private static let unreserved = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    )
+
+    private static func urlEncoded(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: unreserved) ?? value
     }
 }
 

--- a/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/CloudAPIRepositoryTests.swift
+++ b/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/CloudAPIRepositoryTests.swift
@@ -13,7 +13,7 @@ struct CloudAPIRepositoryTests {
             send: { request in
                 await recorder.append(request)
                 let path = request.url?.path ?? ""
-                if path == "/v1/teams/team-1/sessions" {
+                if path == "/v1/sessions" {
                     return try response("""
                     {
                       "items": [
@@ -108,6 +108,12 @@ struct CloudAPIRepositoryTests {
         #expect(messages.first?.mentionActorIDs == [])
         #expect(messages.first?.updatedAt == nil)
         let requests = await recorder.requests
+        // The session list must be team-narrowed server-side and page-capped.
+        // Narrowing in the client would drop rows on later pages now that
+        // /v1/sessions replaced the unpaginated team endpoint.
+        let listQuery = try #require(requests.first { $0.url?.path == "/v1/sessions" }?.url?.query)
+        #expect(listQuery.contains("teamId=team-1"))
+        #expect(listQuery.contains("limit=100"))
         #expect(requests.allSatisfy { $0.value(forHTTPHeaderField: "Authorization") == "Bearer access-token" })
         #expect(requests.map { $0.value(forHTTPHeaderField: "X-Request-Id")?.isEmpty == false }.allSatisfy { $0 })
     }

--- a/docs/openapi/teamclaw-api.v1.yaml
+++ b/docs/openapi/teamclaw-api.v1.yaml
@@ -423,6 +423,14 @@ paths:
     get:
       operationId: listSessions
       summary: List sessions
+      description: |
+        Sessions the calling actor participates in, newest activity first,
+        excluding archived ones. Optionally narrowed to one team and/or one
+        idea.
+
+        This replaced `GET /v1/teams/{teamId}/sessions`, which returned a
+        team's whole session list unpaginated. Callers that want every session
+        in a team pass `teamId` and follow `nextCursor` to exhaustion.
       tags: [Sessions]
       parameters:
         - name: limit
@@ -436,6 +444,21 @@ paths:
           in: query
           schema:
             type: string
+        - name: teamId
+          in: query
+          description: Narrow to a single team.
+          schema:
+            type: string
+            format: uuid
+        - name: ideaId
+          in: query
+          description: >-
+            Narrow to sessions attached to one idea. Applied server-side —
+            filtering the returned page client-side would miss matches on
+            later pages.
+          schema:
+            type: string
+            format: uuid
       responses:
         "200":
           description: Current actor sessions.
@@ -579,54 +602,6 @@ paths:
       responses:
         "204":
           description: OK
-        "401":
-          $ref: "#/components/responses/Error"
-  /v1/teams/{teamId}/sessions:
-    get:
-      operationId: listTeamSessions
-      summary: List all sessions for a team with display-row fields populated
-      description: |
-        Returns the full SessionFull shape (summary, createdByActorId,
-        primaryAgentId, participantCount) for every session in the team that
-        the caller can see. Used by iOS to populate the session list without
-        following up per-row participant queries.
-      tags: [Sessions]
-      parameters:
-        - in: path
-          name: teamId
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        "200":
-          description: Sessions for team.
-          content:
-            application/json:
-              schema:
-                type: object
-                required: [items]
-                properties:
-                  items:
-                    type: array
-                    items:
-                      type: object
-                      required: [id, teamId, title, mode, hasUnread, participantCount]
-                      properties:
-                        id: { type: string }
-                        teamId: { type: string }
-                        title: { type: string }
-                        mode: { type: string }
-                        ideaId: { type: [string, "null"] }
-                        primaryAgentId: { type: [string, "null"] }
-                        createdByActorId: { type: [string, "null"] }
-                        summary: { type: [string, "null"] }
-                        lastMessageAt: { type: [string, "null"], format: date-time }
-                        lastMessagePreview: { type: [string, "null"] }
-                        participantCount: { type: integer }
-                        hasUnread: { type: boolean }
-                        createdAt: { type: [string, "null"], format: date-time }
-                        updatedAt: { type: [string, "null"], format: date-time }
         "401":
           $ref: "#/components/responses/Error"
   /v1/teams/{teamId}/agent-runtimes:
@@ -3268,6 +3243,20 @@ paths:
         - name: since
           in: query
           schema: { type: string, format: date-time }
+        - name: limit
+          in: query
+          description: Page size. Rows are ordered by (updated_at, id) ascending.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: cursor
+          in: query
+          description: >-
+            Opaque keyset cursor from a previous response's `nextCursor`. Omit
+            to start at the beginning.
+          schema: { type: string }
       responses:
         "200":
           description: Session sync rows
@@ -3275,11 +3264,16 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [items]
+                required: [items, nextCursor]
                 properties:
                   items:
                     type: array
                     items: { type: object }
+                  nextCursor:
+                    description: Null on the last page.
+                    type:
+                      - string
+                      - "null"
         "400":
           $ref: "#/components/responses/Error"
   /v1/sync/messages:
@@ -4263,6 +4257,27 @@ components:
           type:
             - string
             - "null"
+        summary:
+          description: >-
+            Display-row field. Previously served only by the removed
+            GET /v1/teams/{teamId}/sessions.
+          type:
+            - string
+            - "null"
+        primaryAgentId:
+          type:
+            - string
+            - "null"
+        createdByActorId:
+          type:
+            - string
+            - "null"
+        participantCount:
+          description: >-
+            Number of participants in the session, counted server-side. It used
+            to be derived by a follow-up query that listed every session id in a
+            URL, which is what outgrew the gateway's request-line limit.
+          type: integer
         createdAt:
           type:
             - string

--- a/services/fc/.gitignore
+++ b/services/fc/.gitignore
@@ -1,4 +1,9 @@
 dist/
+# Both forms on purpose. `node_modules/` only matches a directory, and this repo
+# once committed `services/fc/node_modules` as a symlink pointing at itself —
+# which the trailing-slash pattern does not match, so it slipped into the index
+# and every `git checkout services/fc` recreated the loop, breaking npm here.
+node_modules
 node_modules/
 
 # Local-only manual test-deploy tooling (never committed; FC deploys go via GHA)

--- a/services/fc/node_modules
+++ b/services/fc/node_modules
@@ -1,1 +1,0 @@
-/Volumes/openbeta/workspace/teamclaw/services/fc/node_modules

--- a/services/fc/src/lib/pg-repo/sessions.ts
+++ b/services/fc/src/lib/pg-repo/sessions.ts
@@ -20,7 +20,7 @@
  *  - attach_gateway_session        → attachGatewaySession (move a chat's binding)
  */
 
-import { and, desc, eq, gt, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, or, sql } from "drizzle-orm";
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import {
   sessions,
@@ -163,21 +163,25 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
     // ── List sessions (participant-filtered) ──────────────────────────────────
     /**
      * AUTHZ (#10): lists the CURRENT ACTOR's sessions, resolved from ctx.userId.
-     * The GET /v1/sessions route supplies neither teamId nor actorId, matching
-     * the Supabase RPC `list_current_actor_sessions` (no team filter, scoped to
-     * the authenticated user's participating sessions across all their teams).
+     * Mirrors the Supabase RPC `list_current_actor_sessions`: scoped to the
+     * authenticated user's participating sessions, across all their teams
+     * unless narrowed.
      *
-     * A client-supplied actorId is NEVER trusted. teamId is optional: when given
-     * it narrows the result to that team (still scoped to the user's actors).
-     * When no identity is available the result is empty (fail closed) — an
-     * unauthenticated caller sees nothing rather than every team's sessions.
+     * A client-supplied actorId is NEVER trusted. teamId and ideaId are
+     * optional narrowing filters (still scoped to the user's actors), supplied
+     * by GET /v1/sessions as query params — they are what let this endpoint
+     * replace the removed GET /v1/teams/:teamId/sessions. When no identity is
+     * available the result is empty (fail closed) — an unauthenticated caller
+     * sees nothing rather than every team's sessions.
      */
     async listSessions({
       teamId,
+      ideaId,
       limit = 50,
       cursor = null,
     }: {
       teamId?: string;
+      ideaId?: string;
       limit?: number;
       cursor?: { lastMessageAt?: string | null; createdAt?: string; id?: string } | null;
     } = {}) {
@@ -197,6 +201,11 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
 
       // Optional team narrowing (scoped to the user's actors regardless).
       const teamFilter = teamId ? sql`sessions.team_id = ${teamId}` : sql`TRUE`;
+
+      // Optional idea narrowing. Filtering here rather than in the client is
+      // what keeps "sessions for this idea" correct once the list is paginated
+      // — a client-side filter over page 1 silently misses matches on page 2.
+      const ideaFilter = ideaId ? sql`sessions.idea_id = ${ideaId}` : sql`TRUE`;
 
       let cursorFilter = sql`TRUE`;
       if (cursor) {
@@ -240,6 +249,13 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
           sessions.cron_job_id AS "cronJobId",
           sessions.created_at AS "createdAt",
           sessions.updated_at AS "updatedAt",
+          sessions.summary,
+          sessions.primary_agent_id AS "primaryAgentId",
+          sessions.created_by_actor_id AS "createdByActorId",
+          (
+            SELECT COUNT(*) FROM session_participants sp
+            WHERE sp.session_id = sessions.id
+          )::int AS "participantCount",
           CASE
             WHEN sessions.last_message_at IS NULL THEN FALSE
             WHEN (${readMarkerSubq}) IS NULL THEN TRUE
@@ -248,8 +264,12 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
           END AS "hasUnread"
         FROM sessions
         WHERE (${teamFilter})
+          AND (${ideaFilter})
           AND (${participantFilter})
           AND (${cursorFilter})
+          -- No archived_at filter, unlike the Supabase RPC: this schema has no
+          -- such column (see the note in ensureGatewaySession below). Archive
+          -- semantics live entirely in the supabase path.
         ORDER BY
           sessions.last_message_at DESC NULLS LAST,
           sessions.created_at DESC,
@@ -269,6 +289,10 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
         hasUnread: r.hasUnread === true,
         source: r.source ?? "user",
         cronJobId: r.cronJobId ?? null,
+        summary: r.summary ?? null,
+        primaryAgentId: r.primaryAgentId ?? null,
+        createdByActorId: r.createdByActorId ?? null,
+        participantCount: Number(r.participantCount ?? 0),
         createdAt: iso(r.createdAt)!,
         updatedAt: iso(r.updatedAt)!,
       }));
@@ -749,55 +773,29 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
       return { sessionId: r.id, ...mapSessionFull(r, []) };
     },
 
-    // ── listTeamSessionsFull ──────────────────────────────────────────────────
-    async listTeamSessionsFull(teamId: string) {
+    // ── listSessionsForTeamSince ──────────────────────────────────────────────
+    async listSessionsForTeamSince(
+      teamId: string,
+      updatedAfter: string | null,
+      { limit = 50, cursor = null }: { limit?: number; cursor?: { updatedAt?: string | null; id?: string } | null } = {},
+    ) {
+      const conditions = [eq(sessions.teamId, teamId)];
+      if (updatedAfter) conditions.push(gt(sessions.updatedAt, new Date(updatedAfter)));
+      if (cursor?.updatedAt) {
+        // Keyset: strictly after (updatedAt, id).
+        const cursorUpdatedAt = new Date(cursor.updatedAt);
+        conditions.push(
+          sql`(sessions.updated_at > ${cursorUpdatedAt} OR (sessions.updated_at = ${cursorUpdatedAt} AND sessions.id > ${cursor.id ?? null}))`,
+        );
+      }
+      // Ascending and id-tiebroken so paging is deterministic: this query had no
+      // ORDER BY at all before, which made any cursor meaningless.
       const rows = await db
         .select()
         .from(sessions)
-        .where(eq(sessions.teamId, teamId))
-        .orderBy(desc(sessions.lastMessageAt));
-
-      if (rows.length === 0) return [];
-
-      const ids = rows.map((r) => r.id);
-      const partRows = await db
-        .select({ sessionId: sessionParticipants.sessionId })
-        .from(sessionParticipants)
-        .where(inArray(sessionParticipants.sessionId, ids));
-
-      const counts: Record<string, number> = {};
-      for (const p of partRows) {
-        counts[p.sessionId] = (counts[p.sessionId] ?? 0) + 1;
-      }
-
-      return rows.map((r) => ({
-        id: r.id,
-        teamId: r.teamId,
-        title: r.title ?? "",
-        mode: r.mode ?? "solo",
-        ideaId: r.ideaId ?? null,
-        primaryAgentId: r.primaryAgentId ?? null,
-        createdByActorId: r.createdByActorId ?? null,
-        summary: r.summary ?? null,
-        lastMessageAt: iso(r.lastMessageAt),
-        lastMessagePreview: r.lastMessagePreview ?? null,
-        source: r.source ?? "user",
-        cronJobId: r.cronJobId ?? null,
-        participantCount: counts[r.id] ?? 0,
-        hasUnread: false,
-        createdAt: iso(r.createdAt)!,
-        updatedAt: iso(r.updatedAt)!,
-      }));
-    },
-
-    // ── listSessionsForTeamSince ──────────────────────────────────────────────
-    async listSessionsForTeamSince(teamId: string, updatedAfter: string | null) {
-      const rows = updatedAfter
-        ? await db
-            .select()
-            .from(sessions)
-            .where(and(eq(sessions.teamId, teamId), gt(sessions.updatedAt, new Date(updatedAfter))))
-        : await db.select().from(sessions).where(eq(sessions.teamId, teamId));
+        .where(and(...conditions))
+        .orderBy(asc(sessions.updatedAt), asc(sessions.id))
+        .limit(limit);
       return rows.map(mapSessionSyncRow);
     },
 

--- a/services/fc/src/lib/repository-contract.ts
+++ b/services/fc/src/lib/repository-contract.ts
@@ -16,6 +16,13 @@ export function runBusinessRepositoryContract({ test, assert, createRepository }
       "title",
       "updatedAt",
       "id",
+      // Display-row fields. They used to come from GET /v1/teams/:teamId/sessions;
+      // that endpoint is gone, so both backends must serve them from the list
+      // path or iOS/Expo lose data with no compile-time signal.
+      "summary",
+      "primaryAgentId",
+      "createdByActorId",
+      "participantCount",
     ].sort());
 
     for (let i = 1; i < rows.length; i++) {

--- a/services/fc/src/lib/routes/sessions.ts
+++ b/services/fc/src/lib/routes/sessions.ts
@@ -2,10 +2,15 @@ import { ApiError } from "../http-utils.js";
 import { parseLimit, decodeCursor, nextSessionCursor, requireString } from "../routing-utils.js";
 
 export function registerSessions(router) {
+  // `teamId` / `ideaId` are optional narrowing filters, applied server-side so
+  // they stay correct under pagination. They are what replaced the removed
+  // GET /v1/teams/:teamId/sessions — see 20260802000000.
   router.get("/v1/sessions", async (ctx) => {
     const limit = parseLimit(ctx.query.get("limit"));
     const cursor = decodeCursor(ctx.query.get("cursor"));
-    const items = await ctx.repository.listSessions({ limit, cursor });
+    const teamId = ctx.query.get("teamId") || null;
+    const ideaId = ctx.query.get("ideaId") || null;
+    const items = await ctx.repository.listSessions({ limit, cursor, teamId, ideaId });
     return { body: { items, nextCursor: nextSessionCursor(items, limit) } };
   });
 
@@ -84,11 +89,11 @@ export function registerSessions(router) {
     return { body: out };
   });
 
-  router.get("/v1/teams/:teamId/sessions", async (ctx) => {
-    const teamId = decodeURIComponent(ctx.params.teamId);
-    const items = await ctx.repository.listTeamSessionsFull(teamId);
-    return { body: { items } };
-  });
+  // GET /v1/teams/:teamId/sessions is gone — it fetched a team's entire session
+  // list unpaginated, then filtered participants with an `.in(<every id>)` that
+  // outgrew the gateway's URI limit and surfaced as an opaque 500. Use
+  // GET /v1/sessions?teamId=… instead, which is paginated and carries the same
+  // display-row fields.
 
   router.get("/v1/teams/:teamId/agent-runtimes", async (ctx) => {
     const teamId = decodeURIComponent(ctx.params.teamId);

--- a/services/fc/src/lib/routes/sync.ts
+++ b/services/fc/src/lib/routes/sync.ts
@@ -1,4 +1,5 @@
 import { ApiError } from "../http-utils.js";
+import { parseLimit, decodeSyncCursor, nextSyncCursor } from "../routing-utils.js";
 
 export function registerSync(router) {
   router.get("/v1/sync/actor-directory", async (ctx) => {
@@ -25,12 +26,17 @@ export function registerSync(router) {
     return { body: { items } };
   });
 
+  // Paginated: a first-time sync of a large team used to return every session
+  // row in one response. `limit`/`cursor` are optional — omitting the cursor
+  // starts at the beginning, and `nextCursor` is null on the last page.
   router.get("/v1/sync/sessions", async (ctx) => {
     const teamId = ctx.query.get("teamId");
     if (!teamId) throw new ApiError(400, "validation_failed", "teamId is required");
     const since = ctx.query.get("since") || null;
-    const items = await ctx.repository.listSessionsForTeamSince(teamId, since);
-    return { body: { items } };
+    const limit = parseLimit(ctx.query.get("limit"));
+    const cursor = decodeSyncCursor(ctx.query.get("cursor"));
+    const items = await ctx.repository.listSessionsForTeamSince(teamId, since, { limit, cursor });
+    return { body: { items, nextCursor: nextSyncCursor(items, limit) } };
   });
 
   router.get("/v1/sync/messages", async (ctx) => {

--- a/services/fc/src/lib/routing-utils.ts
+++ b/services/fc/src/lib/routing-utils.ts
@@ -33,6 +33,35 @@ export function nextSessionCursor(items, limit) {
   });
 }
 
+// Sync pagination uses its own cursor shape. The session-list cursor above is
+// keyed on (lastMessageAt, createdAt, id) to match that endpoint's ordering;
+// sync walks forward through (updatedAt, id) instead, because its whole
+// contract is "everything changed since X" and updatedAt is the only column
+// that moves monotonically as rows are touched.
+export function decodeSyncCursor(value) {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    if (!parsed || typeof parsed !== "object") throw new Error("not an object");
+    return {
+      updatedAt: optionalStringOrNull(parsed.updatedAt, "cursor.updatedAt"),
+      id: optionalStringOrNull(parsed.id, "cursor.id"),
+    };
+  } catch (cause) {
+    throw new ApiError(400, "validation_failed", "Invalid cursor", { cause });
+  }
+}
+
+export function nextSyncCursor(items, limit) {
+  if (!Array.isArray(items) || items.length < limit) return null;
+  const last = items[items.length - 1];
+  if (!last) return null;
+  return encodeCursor({
+    updatedAt: last.updated_at ?? last.updatedAt ?? null,
+    id: last.id,
+  });
+}
+
 export function parseLimit(value) {
   if (value === null || value === undefined || value === "") return DEFAULT_LIST_LIMIT;
   const limit = Number(value);

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -1018,12 +1018,17 @@ export function createSupabaseBusinessRepository(options) {
       };
     },
 
-    async listSessions({ limit = 50, cursor = null } = {}) {
+    async listSessions({ limit = 50, cursor = null, teamId = null, ideaId = null }: any = {}) {
       const { data, error } = await supabase.rpc("list_current_actor_sessions", {
         p_limit: limit,
         p_before_last_message_at: cursor?.lastMessageAt ?? null,
         p_before_created_at: cursor?.createdAt ?? null,
         p_before_id: cursor?.id ?? null,
+        // Narrowing happens inside the RPC (20260802000000). Doing it there
+        // rather than post-filtering keeps the result correct under pagination
+        // and is what lets this replace GET /v1/teams/:teamId/sessions.
+        p_team_id: teamId ?? null,
+        p_idea_id: ideaId ?? null,
       });
       if (error) throw error;
       return (data ?? []).map(mapSession);
@@ -1913,49 +1918,6 @@ export function createSupabaseBusinessRepository(options) {
     // --- Team workspace git config (separate column set from
     // existing default/pinned workspace config) ---
 
-    async listTeamSessionsFull(teamId) {
-      const FULL_COLUMNS =
-        "id, team_id, title, mode, primary_agent_id, idea_id, summary, last_message_preview, last_message_at, created_by_actor_id, source, cron_job_id, created_at, updated_at";
-      const { data: sessionRows, error: sessionErr } = await supabase
-        .from("sessions")
-        .select(FULL_COLUMNS)
-        .eq("team_id", teamId)
-        .order("last_message_at", { ascending: false, nullsFirst: false });
-      if (sessionErr) throw sessionErr;
-      const rows = sessionRows ?? [];
-      if (rows.length === 0) return [];
-
-      const ids = rows.map((r) => r.id);
-      const { data: pRows, error: pErr } = await supabase
-        .from("session_participants")
-        .select("session_id")
-        .in("session_id", ids);
-      if (pErr) throw pErr;
-      const counts = (pRows ?? []).reduce((acc, r) => {
-        acc[r.session_id] = (acc[r.session_id] ?? 0) + 1;
-        return acc;
-      }, {});
-
-      return rows.map((row) => ({
-        id: row.id,
-        teamId: row.team_id,
-        title: row.title ?? "",
-        mode: row.mode ?? "solo",
-        ideaId: row.idea_id ?? null,
-        primaryAgentId: row.primary_agent_id ?? null,
-        createdByActorId: row.created_by_actor_id ?? null,
-        summary: row.summary ?? null,
-        lastMessageAt: row.last_message_at ?? null,
-        lastMessagePreview: row.last_message_preview ?? null,
-        source: row.source ?? "user",
-        cronJobId: row.cron_job_id ?? null,
-        participantCount: counts[row.id] ?? 0,
-        hasUnread: false,
-        createdAt: row.created_at ?? null,
-        updatedAt: row.updated_at ?? null,
-      }));
-    },
-
     async listAgentRuntimesForTeam(teamId) {
       const COLS =
         "id, team_id, agent_id, session_id, workspace_id, backend_type, status, backend_session_id, runtime_id, current_model, last_seen_at, created_at, updated_at";
@@ -1982,7 +1944,7 @@ export function createSupabaseBusinessRepository(options) {
       }));
     },
 
-    async listSessionsForTeamSince(teamId, updatedAfter) {
+    async listSessionsForTeamSince(teamId, updatedAfter, { limit = 50, cursor = null }: any = {}) {
       const SESSION_SYNC_COLUMNS =
         "id, team_id, title, mode, primary_agent_id, idea_id, summary, last_message_preview, last_message_at, created_by_actor_id, source, cron_job_id, created_at, updated_at";
       let q = supabase
@@ -1990,7 +1952,20 @@ export function createSupabaseBusinessRepository(options) {
         .select(SESSION_SYNC_COLUMNS)
         .eq("team_id", teamId);
       if (updatedAfter) q = q.gt("updated_at", updatedAfter);
-      const { data, error } = await q;
+      if (cursor?.updatedAt) {
+        // Keyset: strictly after (updatedAt, id). PostgREST has no row-value
+        // comparison, so express it as the equivalent OR — later timestamp, or
+        // same timestamp with a larger id.
+        q = q.or(
+          `updated_at.gt.${cursor.updatedAt},and(updated_at.eq.${cursor.updatedAt},id.gt.${cursor.id})`,
+        );
+      }
+      // Ascending and id-tiebroken so paging is deterministic: neither
+      // implementation ordered at all before, which made any cursor meaningless.
+      const { data, error } = await q
+        .order("updated_at", { ascending: true })
+        .order("id", { ascending: true })
+        .limit(limit);
       if (error) throw error;
       return data ?? [];
     },

--- a/services/fc/src/lib/supabase-repo/shared.ts
+++ b/services/fc/src/lib/supabase-repo/shared.ts
@@ -208,6 +208,14 @@ export function mapSession(row) {
     // an undefined that the client would read as "unknown origin".
     source: row?.source ?? "user",
     cronJobId: row?.cron_job_id ?? null,
+    // Display-row fields. These moved onto the list RPC in 20260802000000 when
+    // GET /v1/teams/:teamId/sessions (their previous home) was removed; a
+    // database that predates that migration simply omits them, so default
+    // rather than assume.
+    summary: row?.summary ?? null,
+    primaryAgentId: row?.primary_agent_id ?? null,
+    createdByActorId: row?.created_by_actor_id ?? null,
+    participantCount: Number(row?.participant_count ?? 0),
   };
 }
 

--- a/services/fc/test/business-api.test.ts
+++ b/services/fc/test/business-api.test.ts
@@ -45,6 +45,8 @@ test("handleBusinessApiRequest routes list sessions with bearer-scoped repositor
     args: {
       limit: 2,
       cursor: null,
+      teamId: null,
+      ideaId: null,
     },
   });
 });
@@ -781,7 +783,7 @@ test("POST /v1/sessions/:sessionId/mark-viewed forwards lastReadMessageId", asyn
   assert.deepEqual(repo.calls[0], { method: "markSessionViewed", sessionId: "session-1", lastReadMessageId: "msg-42" });
 });
 
-test("GET /v1/teams/:teamId/sessions returns full session display rows", async () => {
+test("GET /v1/teams/:teamId/sessions is gone (replaced by /v1/sessions?teamId=)", async () => {
   const repo = fakeRepo();
   const response = await handleBusinessApiRequest({
     httpMethod: "GET",
@@ -789,15 +791,41 @@ test("GET /v1/teams/:teamId/sessions returns full session display rows", async (
     headers: { Authorization: "Bearer token" },
   }, { createRepository: () => repo });
 
+  assert.equal(response.statusCode, 404);
+});
+
+test("GET /v1/sessions narrows by teamId and ideaId server-side", async () => {
+  // Narrowing must reach the repository rather than being post-filtered: once
+  // the list is paginated, filtering the returned page silently drops matches
+  // that live on later pages.
+  const repo = fakeRepo();
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/sessions",
+    queryParameters: { teamId: "team-1", ideaId: "idea-1", limit: "25" },
+    headers: { Authorization: "Bearer token" },
+  }, { createRepository: () => repo });
+
   assert.equal(response.statusCode, 200);
-  const parsed = JSON.parse(response.body);
-  assert.ok(Array.isArray(parsed.items));
-  assert.equal(parsed.items[0].id, "session-1");
-  assert.equal(parsed.items[0].participantCount, 3);
-  assert.equal(parsed.items[0].primaryAgentId, "agent-1");
-  assert.equal(parsed.items[0].createdByActorId, "actor-1");
-  assert.equal(parsed.items[0].summary, "s");
-  assert.deepEqual(repo.calls[0], { method: "listTeamSessionsFull", teamId: "team-1" });
+  assert.deepEqual(repo.calls[0], {
+    method: "listSessions",
+    args: { limit: 25, cursor: null, teamId: "team-1", ideaId: "idea-1" },
+  });
+});
+
+test("GET /v1/sessions leaves teamId/ideaId null when not supplied", async () => {
+  const repo = fakeRepo();
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/sessions",
+    headers: { Authorization: "Bearer token" },
+  }, { createRepository: () => repo });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(repo.calls[0], {
+    method: "listSessions",
+    args: { limit: 50, cursor: null, teamId: null, ideaId: null },
+  });
 });
 
 test("GET /v1/teams/:teamId/agent-runtimes returns team runtimes", async () => {
@@ -1815,7 +1843,6 @@ function fakeRepo({ sessions = [], error = null, teamWorkspaceConfigs = {}, work
     async createSession(input) { calls.push({ method: "createSession", input }); if (error) throw error; const id = input.id ?? "session-new"; const newS = { id, teamId: input.teamId, title: input.title, mode: input.mode, ideaId: null, lastMessageAt: null, lastMessagePreview: null, hasUnread: false, createdAt: "2026-05-27T03:00:00Z", updatedAt: "2026-05-27T03:00:00Z", participants: (input.participantActorIds ?? []).map(a => ({ sessionId: id, actorId: a, role: "member", joinedAt: null })) }; sessionStore.push(newS); return newS; },
     async markSessionViewed(sessionId, lastReadMessageId) { calls.push({ method: "markSessionViewed", sessionId, lastReadMessageId }); if (error) throw error; },
     async markSessionUnread(sessionId) { calls.push({ method: "markSessionUnread", sessionId }); if (error) throw error; },
-    async listTeamSessionsFull(teamId) { calls.push({ method: "listTeamSessionsFull", teamId }); if (error) throw error; return [{ id: "session-1", teamId, title: "T", mode: "solo", ideaId: null, primaryAgentId: "agent-1", createdByActorId: "actor-1", summary: "s", lastMessageAt: null, lastMessagePreview: null, participantCount: 3, hasUnread: false, createdAt: "2026-05-27T01:00:00Z", updatedAt: "2026-05-27T01:00:00Z" }]; },
     async listAgentRuntimesForTeam(teamId) { calls.push({ method: "listAgentRuntimesForTeam", teamId }); if (error) throw error; return [{ id: "rt-1", teamId, agentId: "agent-1", sessionId: "session-1", workspaceId: null, backendType: "claude_code", status: "ready", backendSessionId: "bs-1", runtimeId: "rt12abcd", currentModel: "claude-opus-4-7", lastSeenAt: "2026-05-27T01:00:00Z", createdAt: "2026-05-27T00:00:00Z", updatedAt: "2026-05-27T01:00:00Z" }]; },
     async listSessionParticipants(sessionId) { calls.push({ method: "listSessionParticipants", sessionId }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); return { items: s?.participants ?? [] }; },
     async upsertSessionParticipant(sessionId, input) { calls.push({ method: "upsertSessionParticipant", sessionId, input }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); const existing = s?.participants?.find(p => p.actorId === input.actorId); if (existing) { existing.role = input.role ?? existing.role; return existing; } const newP = { sessionId, actorId: input.actorId, role: input.role ?? "member", joinedAt: null }; if (s) s.participants.push(newP); return newP; },

--- a/services/fc/test/fixtures/v1/session-list.json
+++ b/services/fc/test/fixtures/v1/session-list.json
@@ -9,6 +9,10 @@
       "lastMessageAt": "2026-05-27T02:00:00Z",
       "lastMessagePreview": "FC facade is the next boundary.",
       "hasUnread": true,
+      "summary": null,
+      "primaryAgentId": null,
+      "createdByActorId": "actor-1",
+      "participantCount": 1,
       "createdAt": "2026-05-27T01:00:00Z",
       "updatedAt": "2026-05-27T02:00:00Z"
     },
@@ -21,6 +25,10 @@
       "lastMessageAt": "2026-05-27T00:30:00Z",
       "lastMessagePreview": "Start with OpenAPI.",
       "hasUnread": false,
+      "summary": "Kick-off notes.",
+      "primaryAgentId": "agent-1",
+      "createdByActorId": "actor-1",
+      "participantCount": 1,
       "createdAt": "2026-05-26T23:00:00Z",
       "updatedAt": "2026-05-27T00:30:00Z"
     }

--- a/services/fc/test/missing-endpoints.test.ts
+++ b/services/fc/test/missing-endpoints.test.ts
@@ -54,7 +54,57 @@ test("GET /v1/sync/sessions forwards teamId+since", async () => {
   });
   assert.equal(res.statusCode, 200);
   assert.equal(JSON.parse(res.body).items[0].id, "s1");
-  assert.deepEqual(repo.calls[0].args, ["t1", "2026-05-01T00:00:00Z"]);
+  assert.deepEqual(repo.calls[0].args, [
+    "t1",
+    "2026-05-01T00:00:00Z",
+    { limit: 50, cursor: null },
+  ]);
+});
+
+test("GET /v1/sync/sessions paginates: nextCursor set only on a full page", async () => {
+  // A short page means the walk is done — returning a cursor there would make
+  // clients loop forever on an empty tail.
+  const short = makeRepo({
+    listSessionsForTeamSince: () => [
+      { id: "s1", team_id: "t1", updated_at: "2026-05-01T00:00:00Z" },
+    ],
+  });
+  const shortRes = await request(short, {
+    method: "GET",
+    path: "/v1/sync/sessions",
+    query: { teamId: "t1", limit: "2" },
+  });
+  assert.equal(JSON.parse(shortRes.body).nextCursor, null);
+
+  const full = makeRepo({
+    listSessionsForTeamSince: () => [
+      { id: "s1", team_id: "t1", updated_at: "2026-05-01T00:00:00Z" },
+      { id: "s2", team_id: "t1", updated_at: "2026-05-02T00:00:00Z" },
+    ],
+  });
+  const fullRes = await request(full, {
+    method: "GET",
+    path: "/v1/sync/sessions",
+    query: { teamId: "t1", limit: "2" },
+  });
+  const cursor = JSON.parse(fullRes.body).nextCursor;
+  assert.ok(cursor, "a full page must hand back a cursor");
+  assert.deepEqual(JSON.parse(Buffer.from(cursor, "base64url").toString("utf8")), {
+    updatedAt: "2026-05-02T00:00:00Z",
+    id: "s2",
+  });
+
+  // And that cursor must round-trip back into the repository call.
+  const next = makeRepo({ listSessionsForTeamSince: () => [] });
+  await request(next, {
+    method: "GET",
+    path: "/v1/sync/sessions",
+    query: { teamId: "t1", limit: "2", cursor },
+  });
+  assert.deepEqual(next.calls[0].args[2], {
+    limit: 2,
+    cursor: { updatedAt: "2026-05-02T00:00:00Z", id: "s2" },
+  });
 });
 
 test("GET /v1/sync/sessions requires teamId", async () => {

--- a/services/fc/test/pg-repo-sessions.test.ts
+++ b/services/fc/test/pg-repo-sessions.test.ts
@@ -8,7 +8,8 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { eq } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
 import { makeTestDb } from "./db/pglite.js";
 import { createPgBusinessRepository } from "../src/lib/pg-repo/index.js";
 import {
@@ -65,9 +66,38 @@ test("listSessions returns canonical contract keys for actor-visible sessions", 
     "id", "teamId", "title", "mode", "ideaId",
     "lastMessageAt", "lastMessagePreview", "hasUnread",
     "source", "cronJobId",
+    // Display-row fields, previously only on GET /v1/teams/:teamId/sessions.
+    "summary", "primaryAgentId", "createdByActorId", "participantCount",
     "createdAt", "updatedAt",
   ].sort();
   assert.deepEqual(Object.keys(rows[0]).sort(), contractKeys);
+  assert.equal(rows[0].participantCount, 1, "the seeded participant must be counted");
+});
+
+test("listSessions narrows by teamId and ideaId", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const actor = await seedActor(db, team.id);
+  const repo = createPgBusinessRepository({ db, userId: actor.userId });
+
+  const withIdea = await repo.createSession({
+    teamId: team.id, title: "HasIdea", mode: "solo", participantActorIds: [actor.id],
+  });
+  await repo.createSession({
+    teamId: team.id, title: "NoIdea", mode: "solo", participantActorIds: [actor.id],
+  });
+  // Give exactly one session an idea to filter on.
+  const ideaId = randomUUID();
+  await db.execute(sql`UPDATE sessions SET idea_id = ${ideaId} WHERE id = ${withIdea.id}`);
+
+  const teamScoped = await repo.listSessions({ teamId: team.id, limit: 50, cursor: null });
+  assert.equal(teamScoped.length, 2, "both sessions belong to the team");
+
+  const ideaScoped = await repo.listSessions({ teamId: team.id, ideaId, limit: 50, cursor: null });
+  assert.deepEqual(ideaScoped.map((r: any) => r.title), ["HasIdea"]);
+
+  const otherTeam = await repo.listSessions({ teamId: randomUUID(), limit: 50, cursor: null });
+  assert.deepEqual(otherTeam, [], "a foreign teamId must not leak rows");
 });
 
 test("listSessions ordering: lastMessageAt desc nulls last, then createdAt desc, then id desc", async () => {
@@ -606,22 +636,6 @@ test("createCronSession returns sessionId", async () => {
     title: "Daily summary",
   });
   assert.ok(out.sessionId, "sessionId should be present");
-});
-
-// ── listTeamSessionsFull ──────────────────────────────────────────────────────
-
-test("listTeamSessionsFull returns sessions with participantCount", async () => {
-  const { db } = await makeTestDb();
-  const team = await seedTeam(db);
-  const actor = await seedActor(db, team.id);
-  const repo = createPgBusinessRepository({ db });
-
-  await repo.createSession({ teamId: team.id, title: "Full1", mode: "solo", participantActorIds: [actor.id] });
-  const rows = await repo.listTeamSessionsFull(team.id);
-  assert.ok(Array.isArray(rows));
-  assert.ok(rows.length >= 1);
-  const row = rows[0];
-  assert.ok(typeof row.participantCount === "number");
 });
 
 // ── listSessionsForTeamSince ──────────────────────────────────────────────────

--- a/services/supabase/migrations/20260802000000_session_list_team_and_idea_scope.sql
+++ b/services/supabase/migrations/20260802000000_session_list_team_and_idea_scope.sql
@@ -1,0 +1,189 @@
+-- Make `amux.list_current_actor_sessions` able to replace GET
+-- /v1/teams/:teamId/sessions, which is being removed.
+--
+-- Background: the team endpoint fetched EVERY session in a team, then issued a
+-- second PostgREST query filtering `session_participants` with
+-- `.in("session_id", <all ids>)`. PostgREST puts `in.(...)` in the query
+-- string, so past roughly 190-220 sessions that URL crossed the 8 KB request
+-- line limit of the gateway in front of Supabase and came back as a bare
+-- `URI too long` body — no PostgREST error code, no HTTP status — which the FC
+-- error mapper could not classify and surfaced to clients as an opaque 500.
+-- (Sentry BETLY-APP-Q, teamclaw-belayo-live-api.)
+--
+-- GET /v1/sessions is the paginated replacement, but it was missing three
+-- things the team endpoint had:
+--
+--   1. No team filter. The RPC is actor-scoped across every team the caller
+--      belongs to; callers that want one team's list had no way to say so.
+--   2. No idea filter. Expo's listSessionsForIdea pulled the whole team list
+--      and filtered client-side — which silently becomes wrong once the list
+--      is paginated, since the matching rows may not be on the first page.
+--   3. Fewer columns. summary / primary_agent_id / created_by_actor_id /
+--      participant_count only existed on the team endpoint, so iOS had to call
+--      BOTH (the team endpoint for those fields, then /v1/sessions purely to
+--      recover has_unread, which the team endpoint hardcoded to false).
+--
+-- Adding all three here collapses those two round trips into one.
+--
+-- RETURNS TABLE is part of a function's signature, so CREATE OR REPLACE cannot
+-- widen it — the function has to be dropped and recreated with its grants
+-- re-applied (same dance as 20260727000000).
+--
+-- Note on visibility: this RPC keeps `amux.is_session_participant(s.id)` and
+-- `archived_at is null`. The removed team endpoint instead relied on the
+-- `sessions_select_if_participant_or_creator` RLS policy, which is slightly
+-- wider (participant OR creator OR primary agent) and did NOT exclude archived
+-- rows. In practice createSession upserts the creator into
+-- session_participants, so the participant set already covers the creator; the
+-- real change for iOS/Expo is that archived sessions stop appearing in the
+-- list, which matches what desktop has always done.
+--
+-- Idempotent: both the old and the new signature are dropped up front so the
+-- self-host apply-migrations loop can re-run this file safely.
+
+DROP FUNCTION IF EXISTS amux.list_current_actor_sessions(
+  integer, timestamp with time zone, timestamp with time zone, uuid
+);
+DROP FUNCTION IF EXISTS amux.list_current_actor_sessions(
+  integer, timestamp with time zone, timestamp with time zone, uuid, uuid, uuid
+);
+
+CREATE FUNCTION amux.list_current_actor_sessions(
+  p_limit integer DEFAULT 50,
+  p_before_last_message_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_before_created_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_before_id uuid DEFAULT NULL::uuid,
+  p_team_id uuid DEFAULT NULL::uuid,
+  p_idea_id uuid DEFAULT NULL::uuid
+) RETURNS TABLE(
+  id uuid,
+  title text,
+  team_id uuid,
+  mode text,
+  idea_id uuid,
+  last_message_at timestamp with time zone,
+  last_message_preview text,
+  created_at timestamp with time zone,
+  updated_at timestamp with time zone,
+  has_unread boolean,
+  source text,
+  cron_job_id text,
+  summary text,
+  primary_agent_id uuid,
+  created_by_actor_id uuid,
+  participant_count integer
+)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public', 'app'
+AS $function$
+  with current_actor as (
+    select amux.current_actor_id() as actor_id
+  )
+  select
+    s.id,
+    s.title,
+    s.team_id,
+    s.mode,
+    s.idea_id,
+    s.last_message_at,
+    s.last_message_preview,
+    s.created_at,
+    s.updated_at,
+    (
+      s.last_message_at is not null
+      and s.last_message_at > coalesce(srm.last_read_at, '-infinity'::timestamptz)
+    ) as has_unread,
+    s.source,
+    s.cron_job_id,
+    s.summary,
+    s.primary_agent_id,
+    s.created_by_actor_id,
+    -- Counted here rather than by a follow-up `.in(<all session ids>)` query:
+    -- that pattern is exactly what blew past the gateway's URI limit. RLS on
+    -- session_participants lets a participant see that session's participants,
+    -- and every row reaching this point is one the caller participates in, so
+    -- the count is complete.
+    (
+      select count(*)
+      from amux.session_participants sp
+      where sp.session_id = s.id
+    )::integer as participant_count
+  from amux.sessions s
+  cross join current_actor ca
+  left join amux.session_read_markers srm
+    on srm.session_id = s.id
+   and srm.actor_id = ca.actor_id
+  where amux.is_session_participant(s.id)
+    and s.archived_at is null
+    and (p_team_id is null or s.team_id = p_team_id)
+    and (p_idea_id is null or s.idea_id = p_idea_id)
+    and (
+      p_before_id is null
+      or (
+        case
+          when p_before_last_message_at is null then
+            s.last_message_at is not null
+            or (
+              s.last_message_at is null
+              and (
+                s.created_at < p_before_created_at
+                or (s.created_at = p_before_created_at and s.id < p_before_id)
+              )
+            )
+          when s.last_message_at is null then false
+          when s.last_message_at < p_before_last_message_at then true
+          when s.last_message_at = p_before_last_message_at then
+            s.created_at < p_before_created_at
+            or (s.created_at = p_before_created_at and s.id < p_before_id)
+          else false
+        end
+      )
+    )
+  order by
+    s.last_message_at desc nulls first,
+    s.created_at desc,
+    s.id desc
+  limit greatest(1, least(coalesce(p_limit, 50), 100));
+$function$;
+
+REVOKE ALL ON FUNCTION amux.list_current_actor_sessions(
+  p_limit integer,
+  p_before_last_message_at timestamp with time zone,
+  p_before_created_at timestamp with time zone,
+  p_before_id uuid,
+  p_team_id uuid,
+  p_idea_id uuid
+) FROM PUBLIC;
+GRANT ALL ON FUNCTION amux.list_current_actor_sessions(
+  p_limit integer,
+  p_before_last_message_at timestamp with time zone,
+  p_before_created_at timestamp with time zone,
+  p_before_id uuid,
+  p_team_id uuid,
+  p_idea_id uuid
+) TO anon;
+GRANT ALL ON FUNCTION amux.list_current_actor_sessions(
+  p_limit integer,
+  p_before_last_message_at timestamp with time zone,
+  p_before_created_at timestamp with time zone,
+  p_before_id uuid,
+  p_team_id uuid,
+  p_idea_id uuid
+) TO authenticated;
+GRANT ALL ON FUNCTION amux.list_current_actor_sessions(
+  p_limit integer,
+  p_before_last_message_at timestamp with time zone,
+  p_before_created_at timestamp with time zone,
+  p_before_id uuid,
+  p_team_id uuid,
+  p_idea_id uuid
+) TO service_role;
+
+-- Supporting index for the new team-scoped path. The existing list query was
+-- actor-first (driven by is_session_participant); adding p_team_id makes
+-- (team_id, last_message_at desc) the selective prefix for a single team's
+-- list, which is what iOS and Expo now request on every session-list load.
+CREATE INDEX IF NOT EXISTS sessions_team_last_message_idx
+  ON amux.sessions (team_id, last_message_at DESC NULLS LAST)
+  WHERE archived_at IS NULL;


### PR DESCRIPTION
## Why

Sentry [BETLY-APP-Q](https://ucar-inc.sentry.io/issues/7647758705/) — the Betly iOS client gets `CloudApiException(500, /v1/teams/…/sessions)`, and `teamclaw-belayo-live-api` logs `[business-api] unclassified error: URI too long`.

**Root cause.** `listTeamSessionsFull` fetched a team's entire session list unpaginated, then counted participants with a second PostgREST query filtering `.in("session_id", <every id>)`. PostgREST serialises `in.(…)` into the query string, so past **~190–220 sessions** that URL crosses the 8 KB request-line limit of the gateway in front of Supabase.

The gateway replies with a bare `URI too long` body — no PostgREST code, no numeric status — so `mapSupabaseError` can't classify it and `normalizeError` turns it into an opaque 500. That's why the real cause was only visible in FC logs.

Only the `supabase` backend is affected; `pg-repo` uses drizzle `inArray` over the PG wire protocol, which has no URI limit.

Chasing that turned up three more unpaginated list endpoints in the same family, so this PR hardens the set and brings the clients along.

## Commits

**1. `refactor(api)` — replace `GET /v1/teams/:teamId/sessions` with `/v1/sessions?teamId`**

`/v1/sessions` gains optional `teamId` / `ideaId` narrowing plus `summary` / `primaryAgentId` / `createdByActorId` / `participantCount`, counted in SQL rather than by a follow-up id-list query. `/v1/sync/sessions` gains `limit` + `cursor` — neither backend ordered it at all, so it also gains a deterministic `(updated_at, id)` sort, without which a cursor is meaningless. The team endpoint and both `listTeamSessionsFull` implementations are deleted. iOS and Expo migrated; Expo's idea filter moves server-side, since post-filtering a paginated list drops matches on later pages.

Migration `20260802000000` drops and recreates `list_current_actor_sessions` (`RETURNS TABLE` is part of the signature, so `CREATE OR REPLACE` can't widen it), re-applies grants, adds a partial index on `(team_id, last_message_at)`. Idempotent.

**2. `fix(openapi)` — repair invalid YAML**

The `orgId` description on `POST /v1/teams/bootstrap` was a plain scalar containing `": "`, which YAML forbids. **The entire document failed to parse on `main`.** Nothing caught it because `openapi:lint` and `openapi:types` exist in `services/fc/package.json` but are not wired into CI. `redocly lint` now validates it.

**3. `feat(api)` — paginate `GET /v1/sessions/:id/messages`**

Adds `limit` (default 50, max 100) + keyset `cursor`. The query orders **descending** and applies `LIMIT`, then reverses the page — ordering ascending with a limit would cap at the *oldest* messages, the opposite of what a chat wants. Rows still come back oldest-first within the page, so timeline rendering is unchanged. `nextCursor` derives from the page's **oldest** row, since this endpoint walks backwards.

**4–6. `feat(expo|ios|desktop)` — "load older messages" in all three clients**

Each client gained a paged API method and a UI affordance above the oldest row, so the windowing in commit 3 costs no reachable history.

- **Expo** — controller tracks `olderCursor` / `isLoadingOlder`, exposes `loadOlder()`; `FlatList` gains `maintainVisibleContentPosition` so prepending doesn't shove the reader down the screen.
- **iOS** — `seedFromSupabaseMessages` keeps the newest page's cursor; `loadOlderMessages` folds older pages through the same `.historyMessage` reducer input, which already dedupes on `supabaseMessageID`.
- **Desktop** — reads its timeline from the local cache with cloud as a sync source, so older pages are written **through** that cache; history then survives a session switch and a restart rather than being re-fetched.

The affordance is a tap, not an on-appear auto-fetch: it sits at the top of a chat that scrolls to the bottom on open, so an appear trigger would fire during initial layout and page in history nobody asked for.

Found while testing: `load()` in the Expo controller fetches the newest page twice (directly, and from `connectRealtime`'s post-subscribe catch-up). The second fetch was overwriting the paging cursor, which would have discarded the user's scroll-back position on every realtime reconnect. Only the first fetch of a load generation now sets it.

## ⚠️ Betly must ship first

The **Betly Flutter client (`cn.mx5.betly`) lives in a separate repository** and still calls the removed path. Deploying this turns its current 500 into a 404. Ship the Betly change, let it roll out, then merge.

## Behaviour change

Archived sessions stop appearing in the iOS and Expo session lists. The list RPC filters `archived_at is null`; the removed endpoint relied on an RLS policy that didn't. Desktop has always behaved this way, so this reads as a bug fix — flagging it because it's user-visible.

The pg backend keeps **no** archived filter — that schema has no `archived_at` column at all, a deliberate existing choice documented in `ensureGatewaySession`.

## Verification

| Suite | Result |
|---|---|
| FC `tsc` (build config) | clean |
| FC unit tests | 1034 pass / 22 fail — **failures identical to baseline, zero new** |
| packages/app | 2557 pass (421 files), `tsc` clean |
| Expo | 342/342, `tsc` clean for touched files |
| iOS | simulator **BUILD SUCCEEDED**; AMUXCore 224 tests, 1 pre-existing `RuntimeResolverTests` failure |
| `pnpm lint` | 0 errors (52 pre-existing warnings, unchanged) |
| `redocly lint` | valid (6 pre-existing warnings) |

FC's 22 failures and the iOS one were verified against a clean `main` checkout before and after.

## Drive-by fix (separate commit)

`services/fc/node_modules` was committed as a **symlink pointing at its own absolute path**. `node_modules/` in `.gitignore` only matches directories, so a symlink by that name was never ignored. Any `git checkout -- services/fc` recreated the loop, after which npm in that package fails with ELOOP — `npm test` produced *no output at all* because tsx couldn't be resolved.

## Suggested follow-ups

- Wire `openapi:lint` into CI so the contract can't silently stop parsing again.
- iOS `fetchUnreadFlags` is now redundant (`/v1/sessions` carries `hasUnread`), but folding it in means changing `SessionRecord` and all its consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)