### PR TITLE
fix(deploy): apply the two migrations the self-host list was missing

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -161,7 +161,9 @@ jobs:
                     20260801060000_phone_linked_org_team_picker.sql \
                     20260801070000_switch_phone_linked_team_identity.sql \
                     20260801080000_bootstrap_empty_org_public_team.sql \
-                    20260801090000_switch_linked_identity_without_conflict.sql
+                    20260801090000_switch_linked_identity_without_conflict.sql \
+                    20260802000000_session_list_team_and_idea_scope.sql \
+                    20260802120000_switch_active_team_no_org_id_update.sql
                   do
                     if [ "$(psql -Atc "select exists (select 1 from _selfhost.schema_migrations where filename = \$\$${migration}\$\$)")" = "t" ]; then
                       echo "skip external migration: $migration"


### PR DESCRIPTION
## Live break — please merge promptly

The self-host deploy's external-Supabase step iterates a **hardcoded list of migration filenames**, not the contents of `services/supabase/migrations/`. A migration absent from that list is silently never applied, and **the deploy still reports success**.

#706 shipped `20260802000000`, which drops and recreates `list_current_actor_sessions` with `p_team_id` / `p_idea_id`. The FC image rebuilt from the merge commit and now sends those arguments, but the function was never migrated — so PostgREST finds no matching signature and `GET /v1/sessions` fails on the self-host environment.

Verified from the deploy logs: the box is at the right commit (`HEAD is now at d20de9e0`), but only **37** migrations were processed while `main` has **39**. The two missing ones are exactly the two newest.

## This PR

Adds the two absent entries:

- `20260802000000_session_list_team_and_idea_scope.sql` (#706)
- `20260802120000_switch_active_team_no_org_id_update.sql` (#705, missed the same way)

The loop is idempotent and tracked in `_selfhost.schema_migrations`, so applying them is safe. Every parameter added to the RPC has a default, so 4-argument callers still resolve during rollout — meaning migrating first is safe in either order.

## Follow-up worth doing separately

Drive the loop from the directory listing so adding a migration cannot silently no-op. `CLAUDE.md` already *describes* it that way — "applied by the `migrate` compose service … idempotent, lexical order" — which is exactly what made this easy to miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)