### PR TITLE
fix(auth): stop a dead invite token white-screening the app on launch

### DIFF
--- a/packages/app/src/components/auth/AuthGate.tsx
+++ b/packages/app/src/components/auth/AuthGate.tsx
@@ -159,9 +159,17 @@ export function AuthGate({ children }: AuthGateProps) {
   // in claim_team_invite), so the onboarding stashes the token and routes the
   // user through sign-in; this completes the join afterward.
   const pendingInviteToken = useAuthStore((s) => s.pendingInviteToken);
+  // Which token this mount has already run a claim for. Team bootstrap defers
+  // to a pending claim (below), so without this a claim that fails and leaves
+  // the token in place would block bootstrap forever and the gate would render
+  // nothing. Attempted-once is the condition to stop waiting on — not
+  // claimed-successfully.
+  const inviteClaimAttempted = useRef<string | null>(null);
   useEffect(() => {
     if (!session || session.user?.is_anonymous) return;
     if (!pendingInviteToken) return;
+    if (inviteClaimAttempted.current === pendingInviteToken) return;
+    inviteClaimAttempted.current = pendingInviteToken;
     void useAuthStore.getState().claimPendingInvite().then((result) => {
       // A claimed invite is an explicit team choice; don't immediately reopen
       // the general picker after its active-team switch completes.
@@ -202,8 +210,11 @@ export function AuthGate({ children }: AuthGateProps) {
       return;
     }
     // An invite claim has precedence over normal discovery. claimPendingInvite
-    // enters the invited team and clears this token on success.
-    if (pendingInviteToken) return;
+    // enters the invited team and clears this token on success. Only wait while
+    // the claim is still unattempted: a failed claim keeps its token for a
+    // later retry, and waiting on that pinned `bootstrap` at "idle" — every
+    // gate below then rendered null, i.e. a white screen with no way out.
+    if (pendingInviteToken && inviteClaimAttempted.current !== pendingInviteToken) return;
     // Browser runtime (Chrome extension / web build) is a real cloud client:
     // it still needs a current team for MQTT + team-scoped reads, so it must
     // run the same team-bootstrap as desktop. The bootstrap path below is

--- a/packages/app/src/stores/auth-store.test.ts
+++ b/packages/app/src/stores/auth-store.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/lib/auth/web-sso", () => ({
 }));
 
 import { runWebSso, cancelWebSso } from "@/lib/auth/web-sso";
+import { CloudApiError } from "@/lib/backend/cloud-api/http";
 
 const authMock = {
   getSession: vi.fn(),
@@ -311,6 +312,33 @@ describe("auth-store", () => {
     expect(result).toBeNull();
     expect(authMock.claimInvite).not.toHaveBeenCalled();
     expect(useAuthStore.getState().pendingInviteToken).toBe("tok-2");
+  });
+
+  it("claimPendingInvite drops a token the server permanently rejects", async () => {
+    // 400 validation_failed is what `claim_team_invite` raising 'invite already
+    // consumed' / 'invite expired' / 'already a member of this team' becomes.
+    // Keeping such a token made AuthGate skip team bootstrap on every launch.
+    authMock.claimInvite.mockRejectedValueOnce(
+      new CloudApiError(400, "validation_failed", "invite already consumed", null),
+    );
+    useAuthStore.setState({ session: storeSessionLike("real-5"), pendingInviteToken: "tok-5" });
+
+    const result = await useAuthStore.getState().claimPendingInvite();
+
+    expect(result).toBeNull();
+    expect(useAuthStore.getState().pendingInviteToken).toBeNull();
+    expect(useAuthStore.getState().loading).toBe(false);
+    expect(useAuthStore.getState().authFlow).toBe("idle");
+  });
+
+  it("claimPendingInvite keeps the token when the failure is transient", async () => {
+    authMock.claimInvite.mockRejectedValueOnce(new Error("network down"));
+    useAuthStore.setState({ session: storeSessionLike("real-6"), pendingInviteToken: "tok-6" });
+
+    const result = await useAuthStore.getState().claimPendingInvite();
+
+    expect(result).toBeNull();
+    expect(useAuthStore.getState().pendingInviteToken).toBe("tok-6");
   });
 
   it("claimPendingInvite claims and enters the team for a real session", async () => {

--- a/packages/app/src/stores/auth-store.ts
+++ b/packages/app/src/stores/auth-store.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/backend";
 import type { AuthClaimResult, AuthSession, PendingInvite } from "@/lib/backend";
 import { accessTokenMatchesBackend } from "@/lib/auth/auth-client";
+import { CloudApiError } from "@/lib/backend/cloud-api/http";
 import { clearBootstrapAppliedFields, fetchAndApplyBootstrap } from "@/lib/bootstrap";
 import { getEffectiveServerConfig } from "@/lib/server-config";
 import { markStartup } from "@/lib/startup-perf";
@@ -109,11 +110,24 @@ function storeSession(session: AuthSession | null): StoreAuthSession | null {
   };
 }
 
-async function claimInviteToken(token: string): Promise<AuthClaimResult | { errorMessage: string }> {
+// A claim that can never succeed, no matter how many times it is replayed:
+// `claim_team_invite` raises for a consumed token, an expired one, and for a
+// user who is already a member of the team — the FC repo maps those to 400
+// (validation_failed) / 404 (invite invalid) / 409 (already claimed).
+// Distinguishing them from a transient failure (offline, 5xx, expired bearer)
+// is what lets `claimPendingInvite` drop a dead token instead of retrying it on
+// every launch forever.
+function isPermanentClaimFailure(error: unknown): boolean {
+  return error instanceof CloudApiError && (error.status === 400 || error.status === 404 || error.status === 409);
+}
+
+type ClaimFailure = { errorMessage: string; permanent: boolean };
+
+async function claimInviteToken(token: string): Promise<AuthClaimResult | ClaimFailure> {
   try {
     return await getBackend().auth.claimInvite(token);
   } catch (error) {
-    return { errorMessage: errorMessageFor(error) };
+    return { errorMessage: errorMessageFor(error), permanent: isPermanentClaimFailure(error) };
   }
 }
 
@@ -418,6 +432,15 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     set({ loading: true, authFlow: "invite", errorMessage: null });
     const result = await claimInviteToken(token);
     if ("errorMessage" in result) {
+      // Drop a token the server will never accept. Keeping it stranded the
+      // account: AuthGate skips team bootstrap while a token is pending, so a
+      // dead token left `bootstrap` at "idle" and the gate rendered nothing —
+      // a white screen on every launch, after the startup skeleton had already
+      // been torn down for the claim splash. Transient failures still retry.
+      if (result.permanent) {
+        persistPendingInviteToken(null);
+        set({ pendingInviteToken: null });
+      }
       set({ loading: false, authFlow: "idle", errorMessage: result.errorMessage });
       return null;
     }


### PR DESCRIPTION
## 现象

登录界面白屏，控制台一个 `HTTP 400 /v1/invites/claim`。发生在**已经加入过团队**的用户身上，只是更新后重开应用。每次重开都复现，没有出口。

## 成因

1. 邀请 token 持久化在 `localStorage["teamclaw.pendingInviteToken"]`，每次启动重放一次 claim（`AuthGate.tsx:162`）。
2. `claimPendingInvite` **只在成功时清 token**（"留给瞬时失败重试"）。但 `amux.claim_team_invite` 对已用过的 token 抛 `invite already consumed`（或 `invite expired` / `already a member of this team`），`supabase-repo/auth.ts:114` 把这类消息落到兜底分支 → **400**。这个 400 永远不会变成 200，token 也就永远清不掉。
3. `AuthGate.tsx:206`：只要 `pendingInviteToken` 还在，就**整个跳过 team bootstrap** → `bootstrap` 永远停在 `"idle"`。
4. claim 期间命中 `isTauri() && loading && authFlow === "invite"` 分支（`AuthGate.tsx:318`），它 `removeStartupSkeleton()` 并渲染 `DesktopOnboarding`；claim 失败后 `loading` 转 false，往下走到 `if (bootstrap !== "ready") return null` —— 骨架屏已拆、`#root` 为空 → **白屏**。

## 改动

两处，缺一个都还有洞：

- `auth-store.ts`：区分永久失败（400 / 404 / 409）与瞬时失败（离线、5xx、bearer 过期）。永久失败清 token；瞬时失败保留重试。
- `AuthGate.tsx`：bootstrap 的等待条件从「claim 成功」改为「claim 已尝试」（新增 `inviteClaimAttempted` ref），瞬时失败也不会再饿死 bootstrap。

## 验证

- `packages/app` 单测 37 passed，含新增两条：400 清 token / 网络错误保留 token。
- `pnpm typecheck` 干净；`pnpm lint` 0 errors。

## 后续（不在本 PR）

服务端幂等：同一用户重复 claim 直接返回已有 actor/team 而不是抛异常。那个能不发版就救到存量用户 —— 本 PR 的客户端修复要等发版才生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)