### PR TITLE
fix(deploy): let an empty FC_SUPABASE_* secret point fc back at the bundled Supabase

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -69,14 +69,32 @@ jobs:
               fi
               echo "  set $1"
             }
+            # The FC_SUPABASE_* overrides select an EXTERNAL Supabase for fc.
+            # Unlike the values above, an empty secret here must clear the .env
+            # line rather than leave the previous one standing: otherwise
+            # deleting the secret cannot ever point fc back at the bundled
+            # Supabase (docker-compose defaults SUPABASE_URL to http://kong:8000
+            # only when FC_SUPABASE_URL is unset).
+            sync_env() { # $1=key $2=value — empty value deletes the key
+              if [ -z "$2" ]; then
+                if grep -q "^$1=" .env; then
+                  grep -v "^$1=" .env > .env.tmp && mv .env.tmp .env
+                  echo "  cleared $1 (secret empty)"
+                else
+                  echo "  skip $1 (empty, absent)"
+                fi
+                return 0
+              fi
+              upsert_env "$1" "$2"
+            }
             # Self-host runs against its bundled Supabase data plane. Set this
             # explicitly so a stale server .env cannot select the postgres mode.
             upsert_env BACKEND_KIND "supabase"
             upsert_env TRUSTED_EXTERNAL_JWT_SECRET "$TRUSTED_EXTERNAL_JWT_SECRET"
-            upsert_env FC_SUPABASE_URL "$FC_SUPABASE_URL"
-            upsert_env FC_SUPABASE_PUBLIC_URL "$FC_SUPABASE_PUBLIC_URL"
-            upsert_env FC_SUPABASE_ANON_KEY "$FC_SUPABASE_ANON_KEY"
-            upsert_env FC_SUPABASE_SERVICE_ROLE_KEY "$FC_SUPABASE_SERVICE_ROLE_KEY"
+            sync_env FC_SUPABASE_URL "$FC_SUPABASE_URL"
+            sync_env FC_SUPABASE_PUBLIC_URL "$FC_SUPABASE_PUBLIC_URL"
+            sync_env FC_SUPABASE_ANON_KEY "$FC_SUPABASE_ANON_KEY"
+            sync_env FC_SUPABASE_SERVICE_ROLE_KEY "$FC_SUPABASE_SERVICE_ROLE_KEY"
 
             if [ -n "$FC_SUPABASE_URL" ]; then
               echo "=== migrate external Supabase schema ==="


### PR DESCRIPTION
## 背景

`upsert_env` 对空值一律 skip —— 对大多数 key 这是对的（防止漏配的 secret 把机器上的好值抹掉）。但 `FC_SUPABASE_*` 这四个是**选择外部 Supabase** 的开关，而 compose 只有在 `FC_SUPABASE_URL` 未设置时才回落到自带网关：

```yaml
SUPABASE_URL: "${FC_SUPABASE_URL:-http://kong:8000}"
```

于是删掉 GitHub secret 也回不去本机数据面 —— 机器 `.env` 里那行会一直留着，成了单向门。这次就是手工 `sed -i '/^FC_SUPABASE_/d' .env` 才切回来的。

## 改动

新增 `sync_env`：空值时把该 key 从 `.env` 删掉，非空时照旧走 `upsert_env`。四个 `FC_SUPABASE_*` 改用它，其它 key 不变。

外部迁移块和外部 RPC smoke 本来就由 `[ -n "$FC_SUPABASE_URL" ]` 守着，所以清空后自动跳过，本地 `run-e2e.sh` 路径恢复。

## 验证

- YAML 解析通过；把 `script` 抽出来 `sh -n` 语法通过。
- `sync_env` 的清除 / 跳过 / 写入三种行为单独跑过用例验证。
- 线上已按这个语义手工切回：fc `SUPABASE_URL=http://kong:8000`，`smoke/run-e2e.sh` 11 tests / 10 passed / 0 failed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)