### PR TITLE
fix(extension): always allow side panel on chrome://extensions

### DIFF
--- a/packages/app/src/lib/__tests__/side-panel-host-allowlist.test.ts
+++ b/packages/app/src/lib/__tests__/side-panel-host-allowlist.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  isChromeExtensionsPageUrl,
   isHostnameAllowedByPatterns,
   isUrlAllowedBySidePanelPatterns,
   parseSidePanelDomainPatterns,
@@ -47,13 +48,31 @@ describe('isUrlAllowedBySidePanelPatterns', () => {
     expect(isUrlAllowedBySidePanelPatterns('http://localhost:3000/', patterns)).toBe(true)
   })
 
-  it('rejects non-http and non-matching hosts', () => {
-    expect(isUrlAllowedBySidePanelPatterns('chrome://extensions', patterns)).toBe(false)
+  it('always allows chrome://extensions regardless of patterns', () => {
+    expect(isUrlAllowedBySidePanelPatterns('chrome://extensions', patterns)).toBe(true)
+    expect(isUrlAllowedBySidePanelPatterns('chrome://extensions/', patterns)).toBe(true)
+    expect(
+      isUrlAllowedBySidePanelPatterns('chrome://extensions/?id=abcdefghijklmnop', patterns),
+    ).toBe(true)
+  })
+
+  it('rejects other non-http and non-matching hosts', () => {
+    expect(isUrlAllowedBySidePanelPatterns('chrome://settings', patterns)).toBe(false)
     expect(isUrlAllowedBySidePanelPatterns('https://evil.com', patterns)).toBe(false)
     expect(isUrlAllowedBySidePanelPatterns(undefined, patterns)).toBe(false)
   })
 
   it('allows any url when ungated', () => {
     expect(isUrlAllowedBySidePanelPatterns('https://evil.com', [])).toBe(true)
+  })
+})
+
+describe('isChromeExtensionsPageUrl', () => {
+  it('matches chrome extension management URLs only', () => {
+    expect(isChromeExtensionsPageUrl('chrome://extensions')).toBe(true)
+    expect(isChromeExtensionsPageUrl('chrome://extensions/')).toBe(true)
+    expect(isChromeExtensionsPageUrl('chrome://extensions/?id=abc')).toBe(true)
+    expect(isChromeExtensionsPageUrl('chrome://settings')).toBe(false)
+    expect(isChromeExtensionsPageUrl('https://extensions.example.com')).toBe(false)
   })
 })

--- a/packages/app/src/lib/side-panel-host-allowlist.ts
+++ b/packages/app/src/lib/side-panel-host-allowlist.ts
@@ -29,6 +29,16 @@ export function isSidePanelHostGateEnabled(
   return patterns.length > 0
 }
 
+/** Always allow the extension management page so users can configure domains. */
+export function isChromeExtensionsPageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'chrome:' && parsed.hostname === 'extensions'
+  } catch {
+    return false
+  }
+}
+
 /**
  * Match hostname against allowlist patterns.
  * `*.example.com` also allows the apex `example.com`.
@@ -59,6 +69,7 @@ export function isUrlAllowedBySidePanelPatterns(
 ): boolean {
   if (patterns.length === 0) return true
   if (!url) return false
+  if (isChromeExtensionsPageUrl(url)) return true
   try {
     const parsed = new URL(url)
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false


### PR DESCRIPTION
## Summary
- 配置了 `extensions.domains` 域名白名单时，side panel 原先只放行 `http/https`，`chrome://extensions` 会被 host gate 遮罩挡住
- 新增 `isChromeExtensionsPageUrl`，在 `isUrlAllowedBySidePanelPatterns` 中始终放行扩展管理页（含 `/?id=...` 等子路径），方便用户在该页打开插件设置

## Test plan
- [x] `pnpm exec vitest run packages/app/src/lib/__tests__/side-panel-host-allowlist.test.ts`
- [ ] 打包带域名白名单的 extension，在 `chrome://extensions` 打开 side panel，确认无遮罩
- [ ] 切换到未配置域名（如 `https://evil.com`），确认遮罩仍正常出现


Made with [Cursor](https://cursor.com)