### PR TITLE
fix(desktop): scope workspaceIdHint to local daemon agent only

### DIFF
--- a/packages/app/src/lib/__tests__/session-create.test.ts
+++ b/packages/app/src/lib/__tests__/session-create.test.ts
@@ -459,7 +459,8 @@ describe('startAgentRuntimesAsync', () => {
     )
   })
 
-  it('prefers workspaceIdHint from send/outbox over backend lookups', async () => {
+  it('prefers workspaceIdHint from send/outbox for the local daemon agent', async () => {
+    daemonAdminMocks.getLocalDaemonActorId.mockResolvedValue('agent-10')
     mockTables({
       participants: [{ agent_id: 'agent-10', workspace_id: 'ws-session' }],
       actors: [{ id: 'agent-10', agent_types: [], default_agent_type: null, default_workspace_id: 'ws-default' }],
@@ -477,6 +478,79 @@ describe('startAgentRuntimesAsync', () => {
       expect.objectContaining({
         targetActorId: 'agent-10',
         workspaceId: 'ws-from-send',
+        worktree: '',
+      }),
+    )
+  })
+
+  it('ignores workspaceIdHint for remote agents and uses per-agent lookup', async () => {
+    daemonAdminMocks.getLocalDaemonActorId.mockResolvedValue('local-agent')
+    mockTables({
+      participants: [{ agent_id: 'remote-agent', workspace_id: 'ws-session' }],
+      actors: [
+        {
+          id: 'remote-agent',
+          agent_types: ['opencode'],
+          default_agent_type: 'opencode',
+          default_workspace_id: 'ws-remote-default',
+        },
+      ],
+    })
+
+    const { startAgentRuntimesAsync } = await import('../session-create')
+    await startAgentRuntimesAsync({
+      sessionId: 'sess-1',
+      teamId: 'team-1',
+      agentActorIds: ['remote-agent'],
+      workspaceIdHint: 'ws-from-desktop-local',
+    })
+
+    expect(mockRuntimeStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetActorId: 'remote-agent',
+        workspaceId: 'ws-session',
+        worktree: '',
+      }),
+    )
+  })
+
+  it('applies workspaceIdHint only to the local daemon in a mixed batch', async () => {
+    daemonAdminMocks.getLocalDaemonActorId.mockResolvedValue('local-agent')
+    mockTables({
+      participants: [
+        { agent_id: 'local-agent', workspace_id: 'ws-local-participant' },
+        { agent_id: 'remote-agent', workspace_id: 'ws-remote-participant' },
+      ],
+      actors: [
+        { id: 'local-agent', agent_types: ['opencode'], default_agent_type: 'opencode' },
+        {
+          id: 'remote-agent',
+          agent_types: ['opencode'],
+          default_agent_type: 'opencode',
+          default_workspace_id: 'ws-remote-default',
+        },
+      ],
+    })
+
+    const { startAgentRuntimesAsync } = await import('../session-create')
+    await startAgentRuntimesAsync({
+      sessionId: 'sess-1',
+      teamId: 'team-1',
+      agentActorIds: ['local-agent', 'remote-agent'],
+      workspaceIdHint: 'ws-from-desktop-local',
+    })
+
+    expect(mockRuntimeStart).toHaveBeenCalledTimes(2)
+    expect(mockRuntimeStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetActorId: 'local-agent',
+        workspaceId: 'ws-from-desktop-local',
+      }),
+    )
+    expect(mockRuntimeStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetActorId: 'remote-agent',
+        workspaceId: 'ws-remote-participant',
         worktree: '',
       }),
     )

--- a/packages/app/src/lib/session-create.ts
+++ b/packages/app/src/lib/session-create.ts
@@ -340,7 +340,11 @@ export interface StartAgentRuntimesArgs {
   /** Applied to every agent when `modelIdByAgent` has no entry for that id. */
   modelId?: string
   modelIdByAgent?: Record<string, string>
-  /** Explicit cloud workspace UUID from send/outbox — highest lookup priority. */
+  /**
+   * Explicit cloud workspace UUID from send/outbox — highest lookup priority
+   * for the **local daemon agent only**. Remote agents ignore this and use
+   * their own participant/default/owned workspace lookup.
+   */
   workspaceIdHint?: string | null
   rpcTimeoutMs?: number
   /** Suppress workspace-layer toasts; caller surfaces failures. */
@@ -553,12 +557,13 @@ export async function startAgentRuntimesAsync(
       localDaemonActorId !== null && agentActorId === localDaemonActorId
 
     const baseLookup = workspaceLookups.get(agentActorId) ?? {}
+    const callerHint =
+      isLocalDaemonAgent ? args.workspaceIdHint?.trim() || undefined : undefined
     const workspaceLookup = {
       ...baseLookup,
-      ...(args.workspaceIdHint?.trim() ? { callerWorkspaceId: args.workspaceIdHint } : {}),
+      ...(callerHint ? { callerWorkspaceId: callerHint } : {}),
     }
     let workspaceId = ''
-    const callerHint = args.workspaceIdHint?.trim()
     const sessionWorkspaceId = baseLookup.sessionWorkspaceId?.trim()
     if (callerHint) {
       workspaceId = resolveAgentRuntimeWorkspaceId(workspaceLookup)


### PR DESCRIPTION
## Summary
- Restrict `workspaceIdHint` in `startAgentRuntimesAsync` to the local daemon agent (`isLocalDaemonAgent`)
- Remote agents now resolve workspace via their own participant/default/owned lookup instead of inheriting the Desktop caller's Mac workspace UUID
- Add unit tests for remote-agent ignore, local-agent apply, and mixed local+remote batches

## Problem
When Desktop @-mentioned a remote agent (e.g. Linux SDEBOT), outbox/ensure resolved one shared `workspaceIdHint` from the caller's local path and passed it to every agent. The remote daemon then resolved that cloud UUID to a Mac filesystem path and failed to spawn.

## Test plan
- [x] `pnpm exec vitest run src/lib/__tests__/session-create.test.ts` (packages/app)
- [ ] Desktop @ remote agent — runtimeStart uses remote agent's workspace, not local Mac UUID
- [ ] Desktop @ local agent — still uses current workspace / workspaceIdHint
- [ ] Mixed @ local + remote in one message — each agent gets the correct workspace


Made with [Cursor](https://cursor.com)