### PR TITLE
feat(ui): simplify welcome page and sidebar contacts nav

### DIFF
--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -2213,7 +2213,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
             onHeightChange={handleInputHeightChange}
             bottomOffsetPx={terminalBottomOffset}
           />
-        ) : (
+        ) : activeSessionId || draftPreselectedActor ? (
           <>
             {activeSessionId ? (
               <div className="shrink-0 px-3 pt-2">
@@ -2265,7 +2265,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
             planSlotHidden={hasComposerPlanData && !showInlineTodo}
           />
           </>
-        )
+        ) : null
       ) : null}
 
       {terminalOpen && workspacePath && (

--- a/packages/app/src/components/sidebar/ActorsSection.tsx
+++ b/packages/app/src/components/sidebar/ActorsSection.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, ChevronRight, Plus, Users } from 'lucide-react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import { toast } from 'sonner'
 import { getBackend } from '@/lib/backend'
 import { formatActorRemoveError } from '@/lib/actor-remove-error'
 import { useActorsForTeam, type ActorRow as ActorRowData } from '@/components/panel/ActorsView'
-import { InviteActorDialog } from '@/components/sidebar/InviteActorDialog'
 import { ActorRow } from '@/components/sidebar/ActorRow'
 import { getLocalDaemonAgent } from '@/lib/daemon-agent-admin'
 import { ActorDetailDialog } from '@/components/sidebar/ActorDetailDialog'
@@ -22,7 +21,6 @@ import {
 import { useUIStore } from '@/stores/ui'
 import { useMemberPreferencesStore } from '@/stores/member-preferences-store'
 import { useActorPresenceStore } from '@/stores/actor-presence-store'
-import { cn } from '@/lib/utils'
 import { getRecentContactActors } from '@/components/sidebar/sidebar-list-helpers'
 
 export function ActorsSection() {
@@ -34,7 +32,6 @@ export function ActorsSection() {
   const { actors, loading, refetch, teamId } = useActorsForTeam()
   const defaultAgentId = useMemberPreferencesStore((s) => s.defaultAgentId)
   const ensureDefaultAgentLoaded = useMemberPreferencesStore((s) => s.ensureLoaded)
-  const [inviteOpen, setInviteOpen] = React.useState(false)
   const [detailFor, setDetailFor] = React.useState<ActorRowData | null>(null)
   const [removeFor, setRemoveFor] = React.useState<ActorRowData | null>(null)
   const [removing, setRemoving] = React.useState(false)
@@ -118,29 +115,7 @@ export function ActorsSection() {
             </span>
           )}
         </button>
-        <button
-          type="button"
-          onClick={(e) => { e.stopPropagation(); setFilter({ kind: 'actors' }) }}
-          className={cn(
-            'rounded-md p-0.5 text-faint hover:bg-selected/60 hover:text-foreground',
-            filter.kind === 'actors' && 'bg-selected text-foreground',
-          )}
-          title={t('actors.viewAll', 'View all actors')}
-          aria-label={t('actors.viewAll', 'View all actors')}
-        >
-          <Users className="h-[11px] w-[11px]" />
-        </button>
-        <button
-          type="button"
-          onClick={(e) => { e.stopPropagation(); setInviteOpen(true) }}
-          className="rounded-md p-0.5 text-faint hover:bg-selected/60 hover:text-foreground"
-          title={t('invite.title', 'Invite to team')}
-          aria-label={t('invite.title', 'Invite to team')}
-        >
-          <Plus className="h-[11px] w-[11px]" />
-        </button>
       </div>
-      <InviteActorDialog open={inviteOpen} onOpenChange={setInviteOpen} />
       <ActorDetailDialog
         actor={detailFor}
         teamId={teamId}

--- a/packages/app/src/components/sidebar/ContactsNavEntry.tsx
+++ b/packages/app/src/components/sidebar/ContactsNavEntry.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Plus, Users } from 'lucide-react'
+import { useUIStore } from '@/stores/ui'
+import { InviteActorDialog } from '@/components/sidebar/InviteActorDialog'
+import { cn } from '@/lib/utils'
+
+export function ContactsNavEntry() {
+  const { t } = useTranslation()
+  const filter = useUIStore((s) => s.sidebarFilter)
+  const setFilter = useUIStore((s) => s.setSidebarFilter)
+  const [inviteOpen, setInviteOpen] = React.useState(false)
+
+  const active = filter.kind === 'actors'
+  const inviteLabel = t('invite.title', 'Invite to team')
+
+  return (
+    <>
+      <div
+        className={cn(
+          'flex w-full items-center gap-2.5 rounded-lg px-[9px] py-[7px] transition-[background-color,box-shadow,color] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
+          active
+            ? 'bg-paper shadow-[0_1px_2px_rgba(28,27,25,0.04)] ring-1 ring-black/[0.05]'
+            : 'hover:bg-black/[0.04]',
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => setFilter({ kind: 'actors' })}
+          className={cn(
+            'flex min-w-0 flex-1 items-center gap-2.5 text-left text-[13px] transition-colors duration-150',
+            active ? 'font-semibold text-foreground' : 'font-normal text-ink-2',
+          )}
+        >
+          <Users
+            className={cn('h-[15px] w-[15px] shrink-0', active ? 'text-foreground' : 'text-muted-foreground')}
+          />
+          <span className="min-w-0 flex-1 truncate">{t('sidebar.contacts', 'Contacts')}</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => setInviteOpen(true)}
+          title={inviteLabel}
+          aria-label={inviteLabel}
+          className="inline-flex h-[18px] min-w-[18px] shrink-0 items-center justify-center rounded-full text-muted-foreground transition-[background-color,color] duration-150 hover:bg-black/[0.04] hover:text-foreground"
+        >
+          <Plus className="h-3.5 w-3.5" strokeWidth={2.5} />
+        </button>
+      </div>
+      <InviteActorDialog open={inviteOpen} onOpenChange={setInviteOpen} />
+    </>
+  )
+}

--- a/packages/app/src/components/sidebar/NavRail.tsx
+++ b/packages/app/src/components/sidebar/NavRail.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Inbox, Lightbulb, Keyboard, Pin, AppWindow } from 'lucide-react'
+import { Inbox, Lightbulb, Keyboard, AppWindow } from 'lucide-react'
 import { useUIStore } from '@/stores/ui'
 import { useSessionListStore } from '@/stores/session-list-store'
 
-// Clicking 会话/已置顶 doubles as a "something looks stale" fallback: refetch
+// Clicking 会话 doubles as a "something looks stale" fallback: refetch
 // the first page of sessions (cloud + local hydrate). Throttled so rapid
 // tab-switching doesn't hammer the Cloud API.
 let lastSessionListRefreshAt = 0
@@ -18,6 +18,7 @@ import { useCronStore } from '@/stores/cron'
 import { createQuickSession, describeQuickSessionFailure } from '@/lib/create-quick-session'
 import { useQuickChatReadiness } from '@/hooks/use-quick-chat-readiness'
 import { ActorsSection } from '@/components/sidebar/ActorsSection'
+import { ContactsNavEntry } from '@/components/sidebar/ContactsNavEntry'
 import { TeamShareNavSection } from '@/components/sidebar/TeamShareNavSection'
 import { NewChatSplitButton } from '@/components/sidebar/NewChatSplitButton'
 import { buildConfig } from '@/lib/build-config'
@@ -72,7 +73,6 @@ export function NavRail() {
   const filter = useUIStore((s) => s.sidebarFilter)
   const setFilter = useUIStore((s) => s.setSidebarFilter)
   const listRows = useSessionListStore((s) => s.rows)
-  const pinnedSessionIds = useSessionListStore((s) => s.pinnedSessionIds)
   const cronSessionIds = useCronStore((s) => s.cronSessionIds)
   const showCronSessions = useCronStore((s) => s.showCronSessions)
   const setShowCronSessions = useCronStore((s) => s.setShowCronSessions)
@@ -83,13 +83,6 @@ export function NavRail() {
     () => listRows.filter((r) => !isScheduledSession(r, cronSessionIds)).length,
     [listRows, cronSessionIds],
   )
-
-  const pinnedCount = React.useMemo(() => {
-    const visibleIds = new Set(
-      listRows.filter((r) => !isScheduledSession(r, cronSessionIds)).map((r) => r.id),
-    )
-    return pinnedSessionIds.filter((id) => visibleIds.has(id)).length
-  }, [listRows, pinnedSessionIds, cronSessionIds])
 
   const handleQuickNewChat = React.useCallback(() => {
     if (quickChatState.kind !== 'ready' || creating) return
@@ -155,16 +148,7 @@ export function NavRail() {
             refreshSessionListThrottled()
           }}
         />
-        <TopEntry
-          label={t('sidebar.pinned', 'Pinned')}
-          icon={Pin}
-          active={filter.kind === 'pinned'}
-          badge={pinnedCount}
-          onClick={() => {
-            setFilter({ kind: 'pinned' })
-            refreshSessionListThrottled()
-          }}
-        />
+        <ContactsNavEntry />
         {!embedMode ? (
           <TopEntry
             label={t('sidebar.ideas', 'Ideas')}

--- a/packages/app/src/components/sidebar/NewChatSplitButton.tsx
+++ b/packages/app/src/components/sidebar/NewChatSplitButton.tsx
@@ -63,9 +63,7 @@ export function NewChatSplitButton({
           >
             {creating ? (
               <Loader2 className="h-[14px] w-[14px] shrink-0 animate-spin" />
-            ) : (
-              <Plus className="h-[14px] w-[14px] shrink-0" strokeWidth={2.5} />
-            )}
+            ) : null}
             <span className="min-w-0 flex-1 truncate">{t('chat.newChat', 'New Chat')}</span>
             <span className="ml-auto shrink-0 font-mono text-[10.5px] font-medium tracking-tight text-white/70">
               ⌘N

--- a/packages/app/src/components/sidebar/__tests__/ContactsNavEntry.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/ContactsNavEntry.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ContactsNavEntry } from '../ContactsNavEntry'
+import { useUIStore } from '@/stores/ui'
+
+vi.mock('@/components/sidebar/InviteActorDialog', () => ({
+  InviteActorDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="invite-dialog" /> : null,
+}))
+
+describe('ContactsNavEntry', () => {
+  beforeEach(() => {
+    useUIStore.setState({ sidebarFilter: { kind: 'all' } })
+  })
+
+  it('main area sets filter to actors', () => {
+    render(<ContactsNavEntry />)
+    fireEvent.click(screen.getByRole('button', { name: /联系人|Contacts/ }))
+    expect(useUIStore.getState().sidebarFilter).toEqual({ kind: 'actors' })
+  })
+
+  it('invite button opens invite dialog without changing filter', () => {
+    render(<ContactsNavEntry />)
+    fireEvent.click(screen.getByRole('button', { name: /邀请加入团队|Invite to team/ }))
+    expect(screen.getByTestId('invite-dialog')).toBeInTheDocument()
+    expect(useUIStore.getState().sidebarFilter).toEqual({ kind: 'all' })
+  })
+})

--- a/packages/app/src/components/sidebar/__tests__/NavRail.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/NavRail.test.tsx
@@ -22,6 +22,9 @@ const mkListRow = (id: string, title: string) => ({
 vi.mock('@/components/sidebar/ActorsSection', () => ({
   ActorsSection: () => <div data-testid="actors-section" />,
 }))
+vi.mock('@/components/sidebar/ContactsNavEntry', () => ({
+  ContactsNavEntry: () => <div data-testid="contacts-nav-entry" />,
+}))
 vi.mock('@/components/sidebar/NewChatSplitButton', () => ({
   NewChatSplitButton: () => <div data-testid="new-chat-split" />,
 }))
@@ -63,12 +66,6 @@ describe('NavRail', () => {
     expect(useCronStore.getState().showCronSessions).toBe(false)
   })
 
-  it('clicking Pinned sets filter to { kind: "pinned" }', () => {
-    render(<NavRail />)
-    fireEvent.click(screen.getByRole('button', { name: /已置顶/ }))
-    expect(useUIStore.getState().sidebarFilter).toEqual({ kind: 'pinned' })
-  })
-
   it('clicking Shortcuts sets filter to { kind: "shortcuts" }', () => {
     render(<NavRail />)
     fireEvent.click(screen.getByRole('button', { name: /快捷方式/ }))
@@ -89,18 +86,9 @@ describe('NavRail', () => {
     expect(screen.getByText('3')).toBeInTheDocument()
   })
 
-  it('shows pinned count badge in Pinned row', () => {
-    useSessionListStore.setState({
-      rows: [mkListRow('s1', 'A'), mkListRow('s2', 'B')],
-      pinnedSessionIds: ['s1'],
-    })
+  it('renders ContactsNavEntry, ActorsSection, and an Ideas filter entry', () => {
     render(<NavRail />)
-    const pinnedButton = screen.getByRole('button', { name: /Pinned|已置顶/ })
-    expect(pinnedButton).toHaveTextContent('1')
-  })
-
-  it('renders ActorsSection and an Ideas filter entry', () => {
-    render(<NavRail />)
+    expect(screen.getByTestId('contacts-nav-entry')).toBeInTheDocument()
     expect(screen.getByTestId('actors-section')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Ideas|想法/ })).toBeInTheDocument()
   })

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -799,6 +799,7 @@
     "scheduledSessions": "Scheduled sessions",
     "searchWithShortcut": "Search (⌘K)",
     "pinned": "Pinned",
+    "contacts": "Contacts",
     "ideasSection": "Top Ideas",
     "actorsSection": "Recents",
     "participantCount": "{{count}} participants",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -3043,7 +3043,6 @@
     "empty": "No actors in this team yet",
     "noRecentContacts": "No recent contacts",
     "error": "Failed to load actors",
-    "viewAll": "View all actors",
     "filterType": "Filter by type",
     "typeFilterLabel": "Type",
     "searchPlaceholder": "Search actors",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -3043,7 +3043,6 @@
     "empty": "团队暂无成员",
     "noRecentContacts": "暂无最近联系",
     "error": "加载成员失败",
-    "viewAll": "查看全部成员",
     "filterType": "按类型筛选",
     "typeFilterLabel": "类型",
     "searchPlaceholder": "搜索成员",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -799,6 +799,7 @@
     "scheduledSessions": "定时会话",
     "searchWithShortcut": "搜索 (⌘K)",
     "pinned": "已置顶",
+    "contacts": "联系人",
     "ideasSection": "热门想法",
     "actorsSection": "最近联系",
     "participantCount": "{{count}} 位",


### PR DESCRIPTION
## Summary
- Remove the composer on the local-agent welcome page; users start chats via New Chat / ⌘N instead.
- Replace the sidebar Pinned filter with a split Contacts row (view all members + invite), aligned with the Sessions count badge slot.
- Simplify Recents header (drop inline contact/invite icons) and remove the + icon from the New Chat primary button.

## Test plan
- [x] `vitest run src/components/sidebar/__tests__/ContactsNavEntry.test.tsx`
- [x] `vitest run src/components/sidebar/__tests__/NavRail.test.tsx`
- [x] `vitest run src/components/sidebar/__tests__/NewChatSplitButton.test.tsx`
- [ ] Manual: welcome page shows no bottom input; New Chat / resume links still work
- [ ] Manual: Contacts row opens members view on main click and invite dialog on +
- [ ] Manual: + aligns with Sessions count badge on the right edge


Made with [Cursor](https://cursor.com)