### PR TITLE
fix(ios): unbreak the session list build on an optional lastEventTime

### DIFF
--- a/apps/ios/Packages/AMUXUI/Sources/AMUXUI/SessionList/SessionListHelpers.swift
+++ b/apps/ios/Packages/AMUXUI/Sources/AMUXUI/SessionList/SessionListHelpers.swift
@@ -297,19 +297,20 @@ struct SessionListContent: View {
 
     /// The `Runtime` snapshot serving this session.
     ///
-    /// Resolves by session id first: `ActorPresence.live_sessions` is keyed
-    /// that way, and exactly one attachment serves a session at a time. The
-    /// `cached.runtimeId` bridge below is the old path — a spawn id that went
-    /// stale the moment it was written down, which is what made a cancel land
-    /// on a dead runtime (docs/debug/interrupt-agent-stale-runtime.md).
+    /// Resolves by session id: `ActorPresence.live_sessions` is keyed that way,
+    /// and exactly one attachment serves a session at a time. The old path went
+    /// through a spawn id that went stale the moment it was written down, which
+    /// is what made a cancel land on a dead runtime
+    /// (docs/debug/interrupt-agent-stale-runtime.md).
     private func liveRuntime(for session: Session) -> Runtime? {
         // Rows are keyed (actor, session); a session whose agents live on two
         // machines has one row per machine. The list row shows one, so take the
-        // most recently active.
+        // most recently active. A row that has never reported an event sorts
+        // last rather than crashing the comparison.
         let suffix = "::\(session.sessionId)"
         return viewModel.runtimes
             .filter { $0.runtimeId.hasSuffix(suffix) }
-            .max(by: { $0.lastEventTime < $1.lastEventTime })
+            .max(by: { ($0.lastEventTime ?? .distantPast) < ($1.lastEventTime ?? .distantPast) })
     }
 
     /// Prefers the live runtime's workspace: it comes from the attachment the


### PR DESCRIPTION
`liveRuntime(for:)` compared `lastEventTime` directly, but it is `Date?` — a row that has never reported an event has none. Swift rejects the comparison, so **AMUXUI stopped compiling**. This shipped in #711 and is on `main` right now.

```
SessionListHelpers.swift:312:27: error: value of optional type 'Date?'
  must be unwrapped to a value of type 'Date'
```

Fixed the way `RuntimeResolver.swift:49` already does it — a row that has never reported an event sorts last rather than crashing the comparison.

## Why nothing caught it

- CI has **no iOS build job**. All four checks on #711 passed.
- `pnpm ios:test:core` covers AMUXCore only, which still compiled fine — the break is in AMUXUI.
- Locally the build had been wedging at `CreateBuildDescription` on a corrupt DerivedData, so it never got far enough to report an error either. Clearing `apps/ios/build` is what finally surfaced it.

Worth considering separately: an `xcodebuild build` job in CI would close this gap.

## Verification

- `pnpm ios:build` → `** BUILD SUCCEEDED **`
- `pnpm ios:test:core` → 227 tests in 46 suites passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)