### PR TITLE
fix(daemon): keep the actor retain populated across a reconnect

### DIFF
--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -886,6 +886,14 @@ impl DaemonServer {
                 mark_mqtt_connected(&self.mqtt_connected_flag, false);
                 return Err(());
             }
+            // That publish is presence-only, so it overwrites the retained
+            // snapshot with an empty catalog and no live sessions — measured
+            // 7346 bytes down to 19 across a daemon restart. Every reader then
+            // sees an actor holding nothing while it is in fact serving a
+            // session. Re-publishing the real snapshot is not optional on
+            // reconnect: `apply_start_runtime` takes its dedup path for an
+            // attachment that already exists, so nothing else would restore it.
+            self.publish_actor_state().await;
         } else {
             warn!("no team_id yet; skipping presence announce until onboarding completes");
         }

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -417,6 +417,11 @@ impl DaemonServer {
             // original retain (late subscribe, reconnect) still populate the
             // model picker without spawning a duplicate process.
             self.publish_runtime_state_by_id(&existing).await;
+            // Same reasoning for the actor snapshot. Reuse is the common case —
+            // every message after the first in a session lands here — and the
+            // model may have just changed above, so leaving the retain untouched
+            // would let it drift from what the attachment is actually running.
+            self.publish_actor_state().await;
             if !session_id.is_empty() {
                 if let Some(tc) = self.teamclaw.as_mut() {
                     if let Err(e) = tc.ensure_session_live_subscription(session_id).await {

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -1653,6 +1653,34 @@ mod tests {
         }
     }
 
+    /// `live_sessions` is what turns the actor retain into something a client
+    /// can key by (actor, session). If it comes back empty while attachments
+    /// exist, the retain degrades to bare presence and every reader concludes
+    /// the actor is serving nothing — the shape observed on 2026-08-04, where a
+    /// reconnect shrank the retain from 7346 bytes to 19 and the desktop store
+    /// held zero composite keys while an agent was mid-turn.
+    #[test]
+    fn live_sessions_reports_every_attachment_by_session() {
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.add_test_runtime("rt-a", "agent-1", "session-a");
+        mgr.add_test_runtime("rt-b", "agent-2", "session-b");
+
+        let live = mgr.live_sessions();
+        let mut ids: Vec<&str> = live.iter().map(|s| s.session_id.as_str()).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["session-a", "session-b"]);
+    }
+
+    /// An ambient spawn carries no session, so it has no (actor, session) key
+    /// to publish under. Emitting it anyway would put a blank session id in the
+    /// retain, which the client would file under `${actor}::` and never match.
+    #[test]
+    fn live_sessions_skips_attachments_with_no_session() {
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.add_test_runtime("rt-bare", "agent-1", "");
+        assert!(mgr.live_sessions().is_empty());
+    }
+
     /// The catalog belongs to the device, so a binding that never attached
     /// still advertises it. Before this, such a binding published an empty
     /// list and its session's pill could never leave "connecting".


### PR DESCRIPTION
Found while self-testing #711 against the live self-host box.

The publish after CONNACK is presence-only — `..Default::default()` for everything else — and it lands on **the same retained topic** as the full snapshot. So a reconnect overwrites the catalog and live-session list with nothing, and nothing puts them back: `apply_start_runtime` takes its dedup branch for an attachment that already exists, which neither marks the snapshot dirty nor republishes.

## Measured

Same actor, same topic (`amux/{team}/{actor}/state`):

| | retain | `live_sessions` | desktop composite keys |
|---|---|---|---|
| after first attach | **7346 B** | holds the session | 1 |
| after daemon restart | **19 B** | empty | **0** |
| after this fix | **7243 B**, 46 catalog models | repopulates on attach | 1 |

The desktop store matched exactly: 30 entries, all stale legacy `runtime/{id}/state` retains, **zero composite keys**, while an agent was mid-turn.

## Impact

Model name, the breathing dot, the command list and interrupt targeting all read from `${actor}::${session}`. After any daemon reconnect they stay dead until some session spawns a **new** attachment — and ordinary use reuses one, so it does not heal on its own.

## Fix

Two publishes: one after the CONNACK presence write, one on the dedup branch. The second matters beyond the reconnect case — it is the path every message after the first takes, and the model may have just changed a few lines above it.

## Tests

`live_sessions` had no test at all, despite being the field whose emptiness produces exactly this failure. Two added: one asserting every attachment is reported keyed by session, one asserting an ambient spawn with no session is skipped (it would otherwise publish a blank session id that clients file under `${actor}::` and never match).

985 daemon tests pass.

**Note on coverage:** there is no publisher-capture harness in this crate, so the seam itself — "CONNACK is followed by a full snapshot publish" — is verified live rather than by a unit test. Building that harness is worth doing but is larger than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)