### PR TITLE
fix(daemon): keep vendored OpenSSL off the Windows build

### DIFF
--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -86,12 +86,19 @@ hkdf = "0.12"
 sha2 = "0.10"
 hex = "0.4"
 urlencoding = "2"
-# Mac → Linux cross-compile (cargo-zigbuild): teamclaw-gateway pulls native-tls/openssl-sys;
-# vendored builds OpenSSL from source so no Linux sysroot/pkg-config is needed on the host.
-openssl = { version = "0.10", features = ["vendored"] }
-
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+# Mac → Linux cross-compile (cargo-zigbuild): teamclaw-gateway pulls native-tls/openssl-sys;
+# vendored builds OpenSSL from source so no Linux sysroot/pkg-config is needed on the host.
+#
+# Unix-only on purpose. As a plain dependency this also reached the Windows
+# build, where native-tls uses schannel and nothing else wants openssl-sys — so
+# the only thing it accomplished was making the runner compile OpenSSL from
+# source, which needs perl/NASM and fails there:
+#   cargo:warning=configuring OpenSSL build: 'perl' reported failure with exit code: 2
+# That killed build-windows in release-oss, and publish-manifest requires it, so
+# the 2026-08-03 nightly published nothing for either brand.
+openssl = { version = "0.10", features = ["vendored"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }


### PR DESCRIPTION
## 现象

昨晚 `2026-08-03T17:45Z` 的两个 release-oss 运行（copilot361 + betly）**都失败**，卡在 `build-windows` 的 "Build amuxd sidecar"：

```
cargo:warning=configuring OpenSSL build: 'perl' reported failure with exit code: 2
cargo:warning=openssl-src: failed to build OpenSSL from source
##[error]Process completed with exit code 101
```

`publish-manifest` 的条件是 `needs.build-windows.result == 'success'`（release-oss.yml:745），所以 macOS 全绿也没用 —— 安装包和 latest.json 一个都没上传，两个 brand 昨晚都等于没发。

## 根因

`84eadbb4`（feat(daemon): add interactive `amuxd manage`）往 `apps/daemon/Cargo.toml` 加了

```toml
openssl = { version = "0.10", features = ["vendored"] }
```

意图是给 Mac → Linux 交叉编译（cargo-zigbuild）用，免掉 Linux sysroot / pkg-config。但写成普通依赖就等于**所有 target**，包括 Windows —— 那边 native-tls 走 schannel，本来不需要 openssl。

```
$ cargo tree --manifest-path apps/daemon/Cargo.toml --target x86_64-pc-windows-msvc -i openssl-sys
openssl-sys v0.9.114
└── openssl v0.10.78
    └── amuxd v0.3.1-beta.18
```

唯一把 openssl-sys 拽进 Windows 依赖图的就是这一行。于是 runner 从源码编 OpenSSL，缺 perl/NASM，退出码 101。

## 改动

把它挪进 `[target.'cfg(unix)'.dependencies]`，并把上面这段原委写进注释，免得下次又被当成普通依赖挪回去。

## 验证

`cargo tree -i openssl-sys`，两个 target：

- `x86_64-pc-windows-msvc` → **nothing to print**（openssl-sys 已不在图里）
- `x86_64-unknown-linux-gnu` → **不变**，amuxd 和 native-tls 两条路径都还在，交叉编译那个用途不受影响

Cargo.lock 不需要改：依赖集合完全一致，只是 target 门变了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)