### PR TITLE
fix(fc): archive workspace sessions via session_participants

### DIFF
--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -130,17 +130,29 @@ function guardedFetch(input: any, init?: any) {
   return fetch(input, init);
 }
 
-/** Archive sessions bound to a workspace via agent_runtimes.workspace_id. */
+/**
+ * Archive sessions bound to a workspace via session_participants.workspace_id.
+ *
+ * This used to read `agent_runtimes`, which 20260803010000 dropped once
+ * 20260803000000 moved an agent's per-session working state onto
+ * `session_participants` — its natural (session, actor) key. The read was left
+ * behind, so every `PATCH /v1/workspaces/:id` with `archived: true` threw
+ * `relation "amux.agent_runtimes" does not exist` AFTER the workspace row had
+ * already been updated: the caller got a 500, the workspace was archived
+ * anyway, and its sessions never were. A retry hit the same wall.
+ *
+ * `workspace_id` is NULL for member participants (not applicable, not missing),
+ * so the equality filter already selects agent rows only.
+ */
 async function archiveSessionsForWorkspace(supabase, workspaceId) {
-  const { data: runtimes, error: rtError } = await supabase
-    .from("agent_runtimes")
+  const { data: participants, error: rtError } = await supabase
+    .from("session_participants")
     .select("session_id")
-    .eq("workspace_id", workspaceId)
-    .not("session_id", "is", null);
+    .eq("workspace_id", workspaceId);
   if (rtError) throw rtError;
 
   const sessionIds = [...new Set(
-    (runtimes ?? [])
+    (participants ?? [])
       .map((row) => row.session_id)
       .filter((id) => typeof id === "string" && id.length > 0),
   )];

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -1047,6 +1047,18 @@ function createUpdatableQuery(table, calls, data, error) {
       eqValue = value;
       return query;
     },
+    // `in` / `is` / awaiting the builder are what a filtered bulk UPDATE needs
+    // (archiveSessionsForWorkspace does `.in("id", chunk).is("archived_at", null)`
+    // with no `.select()`). Without them that call resolved to undefined and the
+    // path was untestable — which is how it kept reading a dropped table.
+    in(column, values) {
+      calls.push({ table, op: "update.in", column, values });
+      return query;
+    },
+    is(column, value) {
+      calls.push({ table, op: "update.is", column, value });
+      return query;
+    },
     select(columns) {
       calls.push({ table, op: "update.select", columns });
       return {
@@ -1054,7 +1066,14 @@ function createUpdatableQuery(table, calls, data, error) {
           calls.push({ table, op: "update.maybeSingle" });
           return { data: eqValue ? { id: eqValue } : data[0] ?? null, error };
         },
+        async single() {
+          calls.push({ table, op: "update.single" });
+          return { data: data[0] ?? (eqValue ? { id: eqValue } : null), error };
+        },
       };
+    },
+    then(resolve, reject) {
+      return Promise.resolve({ data: null, error }).then(resolve, reject);
     },
   };
   return query;
@@ -1092,6 +1111,61 @@ function createSelectableQuery(table, calls, data, error) {
   };
   return query;
 }
+
+test("patchWorkspace archives linked sessions via session_participants, not the dropped agent_runtimes", async () => {
+  const tableCalls = [];
+  const repo = createRepo(fakeSupabase({
+    tableCalls,
+    tableData: {
+      workspaces: [{ id: "ws-1", team_id: "team-1", name: "Repo", path: "/repo", archived: true }],
+      session_participants: [
+        { session_id: "session-1" },
+        { session_id: "session-2" },
+        // Same agent re-attached: the id set must be deduped before the update.
+        { session_id: "session-1" },
+      ],
+    },
+  }));
+
+  await repo.patchWorkspace("ws-1", { archived: true });
+
+  const source = tableCalls.find((c) => c.op === "select" && c.table !== "workspaces");
+  assert.equal(
+    source?.table,
+    "session_participants",
+    "workspace_id moved to session_participants in 20260803000000; agent_runtimes was dropped by 20260803010000",
+  );
+  assert.ok(
+    tableCalls.every((c) => c.table !== "agent_runtimes"),
+    "must not touch the dropped agent_runtimes table",
+  );
+  assert.deepEqual(
+    tableCalls.find((c) => c.table === "session_participants" && c.op === "eq"),
+    { table: "session_participants", op: "eq", column: "workspace_id", value: "ws-1" },
+  );
+
+  const sessionUpdate = tableCalls.find((c) => c.table === "sessions" && c.op === "update.in");
+  assert.deepEqual(sessionUpdate?.values, ["session-1", "session-2"], "deduped session ids");
+  assert.ok(
+    tableCalls.some((c) => c.table === "sessions" && c.op === "update.is" && c.column === "archived_at"),
+    "archive must stay idempotent by skipping already-archived rows",
+  );
+});
+
+test("patchWorkspace without archived:true never touches sessions", async () => {
+  const tableCalls = [];
+  const repo = createRepo(fakeSupabase({
+    tableCalls,
+    tableData: { workspaces: [{ id: "ws-1", team_id: "team-1", name: "Renamed", path: "/repo" }] },
+  }));
+
+  await repo.patchWorkspace("ws-1", { name: "Renamed" });
+
+  assert.ok(
+    tableCalls.every((c) => c.table !== "sessions" && c.table !== "session_participants"),
+    "a rename must not cascade into session archival",
+  );
+});
 
 // --- Actor directory ---
 


### PR DESCRIPTION
## 现象

自建机器（47.112.210.217）上，`657de72e` 的迁移落库之后，fc 一直在报：

```
[business-api] unclassified error: relation "amux.agent_runtimes" does not exist
```

从 `2026-08-03T15:37Z` 到现在共 **29 次**，最近一批在今天 03:24–03:27。

## 根因

`20260803000000_participant_owns_agent_session_state.sql` 把 agent 的每会话工作状态（workspace / model / 读取位点）挪到了 `session_participants`，`20260803010000_drop_agent_runtimes.sql` 随后删掉了 `agent_runtimes`。但 `archiveSessionsForWorkspace`（`services/fc/src/lib/supabase-repo.ts:133`）还在读那张已删的表。

调用链：`PATCH /v1/workspaces/:id` 带 `archived: true` → `patchWorkspace`（同文件 1215-1217）→ 抛错。

**失败方式比单纯 500 更糟**：`patchWorkspace` 先更新 workspaces 行，之后才归档关联 session。所以调用方拿到 500，工作区其实已经归档，而它的 session 一个都没归档；重试撞同一张已删的表。

## 改动

数据源换成 `session_participants`。`workspace_id` 对成员参与者是 NULL（"不适用"而非"缺失"），所以等值过滤天然只命中 agent 行。去重、`chunkedIn` 分片、`.is("archived_at", null)` 幂等这些都原样保留。

## 测试

测试假客户端的 update builder **没有 `in` / `is`，也不可 await** —— 而这条路径是「带过滤的批量 UPDATE 且没有 `.select()`」，在假客户端里会 resolve 成 undefined，等于根本断言不了。这正是这处过期读能在迁移中幸存下来的原因。补上 `in` / `is` / `then` / `single`，然后覆盖两个方向：

- `archived: true` → 走 `session_participants`，session id 去重，仍然带 `.is("archived_at", null)`
- 纯重命名 → 完全不碰 sessions / session_participants

## 给 reviewer 的两点

1. `services/fc/test/` 在 main 上**本来就有 5 条失败**（listSessions、bootstrapTeam ×2、getWorkspaceConfig ×2），本 PR 不改变它们：70 → 72 通过。
2. 之所以没人发现，是因为 CI 的 `pnpm test:unit` 只跑 `packages/app` —— **`services/fc/test/` 没有任何 CI 覆盖**。这个洞值得单独处理。

另外 `pg-repo`（postgres backend）的 `patchWorkspace` 压根不归档关联 session，是两个 backend 之间既有的行为差异，不在本 PR 范围内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)