### PR TITLE
fix: session list perf and messaging after agent_runtimes drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,4 +186,4 @@ test-results/
 playwright-report/
 screenshots/
 tmp/
-
+log/

--- a/packages/app/src/__tests__/open-session-deeplink.test.ts
+++ b/packages/app/src/__tests__/open-session-deeplink.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   enterTeam: vi.fn(),
   switchToSession: vi.fn(),
   load: vi.fn(),
+  upsertRows: vi.fn(),
   session: { user: { id: 'user-1', is_anonymous: false } } as
     | { user: { id: string; is_anonymous?: boolean } }
     | null,
@@ -44,7 +45,7 @@ vi.mock('@/stores/ui', () => ({
 
 vi.mock('@/stores/session-list-store', () => ({
   useSessionListStore: {
-    getState: () => ({ load: mocks.load }),
+    getState: () => ({ load: mocks.load, upsertRows: mocks.upsertRows }),
   },
 }))
 
@@ -66,7 +67,17 @@ describe('openSessionFromDeeplink', () => {
     localStorage.clear()
     mocks.session = { user: { id: 'user-1', is_anonymous: false } }
     mocks.teamId = TEAM_A
-    mocks.joinSession.mockResolvedValue({ team_id: TEAM_A })
+    mocks.joinSession.mockResolvedValue({
+      id: UUID,
+      team_id: TEAM_A,
+      title: 'Linked session',
+      mode: 'collab',
+      idea_id: null,
+      last_message_at: '2026-08-01T00:00:00.000Z',
+      last_message_preview: 'Earlier message',
+      created_at: '2026-07-01T00:00:00.000Z',
+      updated_at: '2026-08-01T00:00:00.000Z',
+    })
     mocks.enterTeam.mockResolvedValue(undefined)
     mocks.switchToSession.mockResolvedValue(undefined)
     mocks.load.mockResolvedValue(undefined)
@@ -90,15 +101,46 @@ describe('openSessionFromDeeplink', () => {
     expect(readPendingSessionDeeplink()).toBeNull()
   })
 
+  it('keeps a joined session visible when it falls outside the refreshed first page', async () => {
+    const ok = await openSessionFromDeeplink(UUID)
+
+    expect(ok).toBe(true)
+    expect(mocks.upsertRows).toHaveBeenCalledTimes(2)
+    expect(mocks.upsertRows).toHaveBeenLastCalledWith([expect.objectContaining({
+      id: UUID,
+      team_id: TEAM_A,
+      title: 'Linked session',
+      last_message_preview: 'Earlier message',
+    })])
+    expect(mocks.upsertRows.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.switchToSession.mock.invocationCallOrder[0])
+    expect(mocks.upsertRows.mock.invocationCallOrder[1])
+      .toBeGreaterThan(mocks.load.mock.invocationCallOrder[0])
+  })
+
   it('defers navigation across team switches', async () => {
-    mocks.joinSession.mockResolvedValue({ team_id: TEAM_B })
+    mocks.joinSession.mockResolvedValue({
+      id: UUID,
+      team_id: TEAM_B,
+      title: 'Other team session',
+      mode: 'collab',
+      idea_id: null,
+      last_message_at: null,
+      last_message_preview: null,
+      created_at: null,
+      updated_at: null,
+    })
     mocks.teamId = TEAM_A
 
     const ok = await openSessionFromDeeplink(UUID)
     expect(ok).toBe(true)
     expect(mocks.enterTeam).toHaveBeenCalledWith(TEAM_B)
     expect(mocks.switchToSession).not.toHaveBeenCalled()
-    expect(readPendingSessionDeeplink()).toEqual({ sessionId: UUID, teamId: TEAM_B })
+    expect(readPendingSessionDeeplink()).toEqual(expect.objectContaining({
+      sessionId: UUID,
+      teamId: TEAM_B,
+      sessionRow: expect.objectContaining({ id: UUID, team_id: TEAM_B }),
+    }))
   })
 })
 
@@ -113,10 +155,24 @@ describe('completePendingSessionDeeplink', () => {
   })
 
   it('opens the stashed session once the target team is active', async () => {
-    stashPendingSessionDeeplink(UUID, TEAM_B)
+    stashPendingSessionDeeplink(UUID, TEAM_B, {
+      id: UUID,
+      team_id: TEAM_B,
+      title: 'Other team session',
+      last_message_at: null,
+      last_message_preview: null,
+      mode: 'collab',
+      idea_id: null,
+      has_unread: false,
+      source: null,
+      cron_job_id: null,
+      created_at: null,
+      updated_at: null,
+    })
     const ok = await completePendingSessionDeeplink()
     expect(ok).toBe(true)
     expect(mocks.switchToSession).toHaveBeenCalledWith(UUID)
+    expect(mocks.upsertRows).toHaveBeenCalledTimes(2)
     expect(readPendingSessionDeeplink()).toBeNull()
   })
 

--- a/packages/app/src/lib/open-session-deeplink.ts
+++ b/packages/app/src/lib/open-session-deeplink.ts
@@ -1,8 +1,9 @@
 import { getBackend } from '@/lib/backend'
+import type { SessionDetailRow } from '@/lib/backend/types'
 import { CloudApiError } from '@/lib/backend/cloud-api/http'
 import { useAuthStore } from '@/stores/auth-store'
 import { useCurrentTeamStore } from '@/stores/current-team'
-import { useSessionListStore } from '@/stores/session-list-store'
+import { type SessionListEntry, useSessionListStore } from '@/stores/session-list-store'
 import { useUIStore } from '@/stores/ui'
 import i18n from '@/lib/i18n'
 import { toast } from 'sonner'
@@ -12,6 +13,12 @@ const PENDING_SESSION_DEEPLINK_KEY = 'teamclaw.pendingSessionDeeplink'
 export type PendingSessionDeeplink = {
   sessionId: string
   teamId: string | null
+  /**
+   * `listCurrentActorSessions` is paginated. Keep the row returned by the
+   * successful join so a linked older session remains renderable even when it
+   * does not land in the first page after a team switch.
+   */
+  sessionRow?: SessionListEntry
 }
 
 function readPendingRaw(): PendingSessionDeeplink | null {
@@ -23,6 +30,7 @@ function readPendingRaw(): PendingSessionDeeplink | null {
     return {
       sessionId: parsed.sessionId,
       teamId: parsed.teamId ?? null,
+      sessionRow: parsed.sessionRow,
     }
   } catch {
     return null
@@ -36,8 +44,9 @@ export function readPendingSessionDeeplink(): PendingSessionDeeplink | null {
 export function stashPendingSessionDeeplink(
   sessionId: string,
   teamId: string | null = null,
+  sessionRow?: SessionListEntry,
 ): void {
-  const payload: PendingSessionDeeplink = { sessionId, teamId }
+  const payload: PendingSessionDeeplink = { sessionId, teamId, sessionRow }
   try {
     localStorage.setItem(PENDING_SESSION_DEEPLINK_KEY, JSON.stringify(payload))
   } catch {
@@ -59,9 +68,38 @@ function isAuthedRealUser(): boolean {
   return Boolean(session && !session.user?.is_anonymous)
 }
 
-async function navigateToSession(sessionId: string): Promise<void> {
+function sessionDetailToListEntry(session: SessionDetailRow): SessionListEntry {
+  const mode = session.mode === 'solo' || session.mode === 'control'
+    ? session.mode
+    : 'collab'
+  return {
+    id: session.id,
+    title: session.title,
+    team_id: session.team_id,
+    last_message_at: session.last_message_at,
+    last_message_preview: session.last_message_preview,
+    mode,
+    idea_id: session.idea_id,
+    has_unread: false,
+    source: session.source ?? null,
+    cron_job_id: session.cron_job_id ?? null,
+    created_at: session.created_at,
+    updated_at: session.updated_at,
+  }
+}
+
+async function navigateToSession(
+  sessionId: string,
+  sessionRow?: SessionListEntry,
+): Promise<void> {
+  // A linked session may be older than the first page (50 rows) returned by
+  // listCurrentActorSessions. Seed it before selecting so the chat header and
+  // desktop message sync can resolve its team, then re-apply it after the
+  // paginated reconcile which replaces the list rows.
+  if (sessionRow) useSessionListStore.getState().upsertRows([sessionRow])
   await useUIStore.getState().switchToSession(sessionId)
   await useSessionListStore.getState().load()
+  if (sessionRow) useSessionListStore.getState().upsertRows([sessionRow])
   clearPendingSessionDeeplink()
 }
 
@@ -91,15 +129,16 @@ export async function openSessionFromDeeplink(sessionId: string): Promise<boolea
   try {
     const session = await getBackend().sessions.joinSession(sessionId)
     const teamId = session.team_id ?? null
+    const sessionRow = sessionDetailToListEntry(session)
     const currentTeamId = useCurrentTeamStore.getState().team?.id ?? null
 
     if (teamId && teamId !== currentTeamId) {
-      stashPendingSessionDeeplink(sessionId, teamId)
+      stashPendingSessionDeeplink(sessionId, teamId, sessionRow)
       await useCurrentTeamStore.getState().enterTeam(teamId)
       return true
     }
 
-    await navigateToSession(sessionId)
+    await navigateToSession(sessionId, sessionRow)
     return true
   } catch (err) {
     clearPendingSessionDeeplink()
@@ -120,7 +159,7 @@ export async function completePendingSessionDeeplink(): Promise<boolean> {
   if (pending.teamId && pending.teamId !== currentTeamId) return false
 
   try {
-    await navigateToSession(pending.sessionId)
+    await navigateToSession(pending.sessionId, pending.sessionRow)
     return true
   } catch (err) {
     clearPendingSessionDeeplink()

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -70,6 +70,8 @@ test("listSessions maps current actor session rpc rows", async () => {
       p_before_last_message_at: "2026-05-27T00:00:00Z",
       p_before_created_at: "2026-05-26T00:00:00Z",
       p_before_id: "s0",
+      p_team_id: null,
+      p_idea_id: null,
     },
   }]);
   assert.deepEqual(rows, [{
@@ -81,6 +83,12 @@ test("listSessions maps current actor session rpc rows", async () => {
     lastMessageAt: "2026-05-27T01:00:00Z",
     lastMessagePreview: "hello",
     hasUnread: true,
+    source: "user",
+    cronJobId: null,
+    summary: null,
+    primaryAgentId: null,
+    createdByActorId: null,
+    participantCount: 0,
     createdAt: "2026-05-26T01:00:00Z",
     updatedAt: "2026-05-27T01:00:00Z",
   }]);

--- a/services/supabase/migrations/20260804000000_optimize_current_actor_session_list.sql
+++ b/services/supabase/migrations/20260804000000_optimize_current_actor_session_list.sql
@@ -1,0 +1,106 @@
+-- Drive the session list from the current actor's participant rows instead of
+-- scanning every session and evaluating is_session_participant() per row.
+--
+-- On teams with a large history this endpoint is the desktop's first request.
+-- `limit` is applied only after visibility, unread state, participant counts,
+-- and ordering are computed, so a 50-row page previously timed out for actors
+-- participating in thousands of sessions.
+
+CREATE INDEX IF NOT EXISTS session_participants_actor_session_idx
+  ON amux.session_participants (actor_id, session_id);
+
+CREATE OR REPLACE FUNCTION amux.list_current_actor_sessions(
+  p_limit integer DEFAULT 50,
+  p_before_last_message_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_before_created_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_before_id uuid DEFAULT NULL::uuid,
+  p_team_id uuid DEFAULT NULL::uuid,
+  p_idea_id uuid DEFAULT NULL::uuid
+) RETURNS TABLE(
+  id uuid,
+  title text,
+  team_id uuid,
+  mode text,
+  idea_id uuid,
+  last_message_at timestamp with time zone,
+  last_message_preview text,
+  created_at timestamp with time zone,
+  updated_at timestamp with time zone,
+  has_unread boolean,
+  source text,
+  cron_job_id text,
+  summary text,
+  primary_agent_id uuid,
+  created_by_actor_id uuid,
+  participant_count integer
+)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public', 'app'
+AS $function$
+  with current_actor as (
+    select amux.current_actor_id() as actor_id
+  )
+  select
+    s.id,
+    s.title,
+    s.team_id,
+    s.mode,
+    s.idea_id,
+    s.last_message_at,
+    s.last_message_preview,
+    s.created_at,
+    s.updated_at,
+    (
+      s.last_message_at is not null
+      and s.last_message_at > coalesce(srm.last_read_at, '-infinity'::timestamptz)
+    ) as has_unread,
+    s.source,
+    s.cron_job_id,
+    s.summary,
+    s.primary_agent_id,
+    s.created_by_actor_id,
+    (
+      select count(*)
+      from amux.session_participants participant
+      where participant.session_id = s.id
+    )::integer as participant_count
+  from current_actor ca
+  join amux.session_participants membership
+    on membership.actor_id = ca.actor_id
+  join amux.sessions s
+    on s.id = membership.session_id
+  left join amux.session_read_markers srm
+    on srm.session_id = s.id
+   and srm.actor_id = ca.actor_id
+  where s.archived_at is null
+    and (p_team_id is null or s.team_id = p_team_id)
+    and (p_idea_id is null or s.idea_id = p_idea_id)
+    and (
+      p_before_id is null
+      or (
+        case
+          when p_before_last_message_at is null then
+            s.last_message_at is not null
+            or (
+              s.last_message_at is null
+              and (
+                s.created_at < p_before_created_at
+                or (s.created_at = p_before_created_at and s.id < p_before_id)
+              )
+            )
+          when s.last_message_at is null then false
+          when s.last_message_at < p_before_last_message_at then true
+          when s.last_message_at = p_before_last_message_at then
+            s.created_at < p_before_created_at
+            or (s.created_at = p_before_created_at and s.id < p_before_id)
+          else false
+        end
+      )
+    )
+  order by
+    s.last_message_at desc nulls first,
+    s.created_at desc,
+    s.id desc
+  limit greatest(1, least(coalesce(p_limit, 50), 100));
+$function$;

--- a/services/supabase/migrations/20260804010000_fix_functions_after_drop_agent_runtimes.sql
+++ b/services/supabase/migrations/20260804010000_fix_functions_after_drop_agent_runtimes.sql
@@ -1,0 +1,180 @@
+-- 20260803010000 dropped amux.agent_runtimes but left trigger helpers pointing at
+-- it. Any UPDATE sessions (including bump_session_last_message after INSERT
+-- messages) hit enforce_parent_integrity → 42P01.
+--
+-- Rewrite the two integrity functions without agent_runtimes references.
+-- Workspace bindings now live on session_participants.workspace_id (ADR-0005).
+
+create or replace function amux.enforce_core_team_integrity()
+returns trigger
+language plpgsql
+as $function$
+begin
+  if tg_table_name = 'team_members' then
+    perform amux.require_same_team(
+      new.team_id,
+      amux.actor_team_id(new.member_id),
+      'team_members.member_id'
+    );
+  elsif tg_table_name = 'workspaces' then
+    perform amux.require_same_team(
+      new.team_id,
+      amux.actor_team_id(new.created_by_member_id),
+      'workspaces.created_by_member_id'
+    );
+    perform amux.require_same_team(
+      new.team_id,
+      amux.actor_team_id(new.agent_id),
+      'workspaces.agent_id'
+    );
+  elsif tg_table_name = 'agents' then
+    perform amux.require_same_team(
+      amux.actor_team_id(new.id),
+      amux.table_team_id('amux.workspaces'::regclass, new.default_workspace_id),
+      'agents.default_workspace_id'
+    );
+  elsif tg_table_name = 'agent_member_access' then
+    perform amux.require_same_team(
+      amux.actor_team_id(new.agent_id),
+      amux.actor_team_id(new.member_id),
+      'agent_member_access.member_id'
+    );
+    perform amux.require_same_team(
+      amux.actor_team_id(new.agent_id),
+      amux.actor_team_id(new.granted_by_member_id),
+      'agent_member_access.granted_by_member_id'
+    );
+  elsif tg_table_name = 'ideas' then
+    perform amux.require_same_team(
+      new.team_id,
+      amux.table_team_id('amux.workspaces'::regclass, new.workspace_id),
+      'ideas.workspace_id'
+    );
+    perform amux.require_same_team(
+      new.team_id,
+      amux.table_team_id('amux.ideas'::regclass, new.parent_idea_id),
+      'ideas.parent_idea_id'
+    );
+    perform amux.require_same_team(
+      new.team_id,
+      amux.actor_team_id(new.created_by_actor_id),
+      'ideas.created_by_actor_id'
+    );
+  elsif tg_table_name = 'idea_external_refs' then
+    perform amux.require_same_team(
+      amux.table_team_id('amux.ideas'::regclass, new.idea_id),
+      amux.actor_team_id(new.linked_by_actor_id),
+      'idea_external_refs.linked_by_actor_id'
+    );
+  elsif tg_table_name = 'sessions' then
+    perform amux.require_same_team(
+      new.team_id,
+      amux.table_team_id('amux.ideas'::regclass, new.idea_id),
+      'sessions.idea_id'
+    );
+    perform amux.require_same_team(
+      new.team_id,
+      amux.actor_team_id(new.created_by_actor_id),
+      'sessions.created_by_actor_id'
+    );
+    perform amux.require_same_team(
+      new.team_id,
+      amux.actor_team_id(new.primary_agent_id),
+      'sessions.primary_agent_id'
+    );
+  elsif tg_table_name = 'session_participants' then
+    perform amux.require_same_team(
+      amux.table_team_id('amux.sessions'::regclass, new.session_id),
+      amux.actor_team_id(new.actor_id),
+      'session_participants.actor_id'
+    );
+  elsif tg_table_name = 'messages' then
+    perform amux.require_same_team(
+      new.team_id,
+      amux.table_team_id('amux.sessions'::regclass, new.session_id),
+      'messages.session_id'
+    );
+    perform amux.require_same_team(
+      new.team_id,
+      amux.actor_team_id(new.sender_actor_id),
+      'messages.sender_actor_id'
+    );
+    perform amux.require_same_team(
+      new.team_id,
+      amux.table_team_id('amux.messages'::regclass, new.reply_to_message_id),
+      'messages.reply_to_message_id'
+    );
+  else
+    raise exception 'amux.enforce_core_team_integrity is not defined for table %', tg_table_name;
+  end if;
+
+  return new;
+end;
+$function$;
+
+create or replace function amux.enforce_parent_integrity()
+returns trigger
+language plpgsql
+as $function$
+begin
+  if tg_table_name = 'actors' then
+    if new.actor_type is distinct from old.actor_type then
+      if exists (select 1 from amux.members where id = new.id) and new.actor_type <> 'member' then
+        raise exception 'actors.actor_type cannot diverge from members.id'
+          using errcode = '23514';
+      end if;
+
+      if exists (select 1 from amux.agents where id = new.id) and new.actor_type <> 'agent' then
+        raise exception 'actors.actor_type cannot diverge from agents.id'
+          using errcode = '23514';
+      end if;
+    end if;
+
+    if new.team_id is distinct from old.team_id then
+      if exists (select 1 from amux.members where id = new.id)
+        or exists (select 1 from amux.agents where id = new.id)
+        or exists (select 1 from amux.team_members where member_id = new.id)
+        or exists (select 1 from amux.workspaces where created_by_member_id = new.id or agent_id = new.id)
+        or exists (select 1 from amux.agent_member_access where member_id = new.id or granted_by_member_id = new.id or agent_id = new.id)
+        or exists (select 1 from amux.ideas where created_by_actor_id = new.id)
+        or exists (select 1 from amux.idea_external_refs where linked_by_actor_id = new.id)
+        or exists (select 1 from amux.sessions where created_by_actor_id = new.id or primary_agent_id = new.id)
+        or exists (select 1 from amux.session_participants where actor_id = new.id)
+        or exists (select 1 from amux.messages where sender_actor_id = new.id) then
+        perform amux.reject_team_reassignment('actors.team_id');
+      end if;
+    end if;
+  elsif tg_table_name = 'workspaces' then
+    if new.team_id is distinct from old.team_id
+      and (
+        exists (select 1 from amux.agents where default_workspace_id = new.id)
+        or old.agent_id is not null
+        or exists (select 1 from amux.ideas where workspace_id = new.id)
+        or exists (select 1 from amux.session_participants where workspace_id = new.id)
+      ) then
+      perform amux.reject_team_reassignment('workspaces.team_id');
+    end if;
+  elsif tg_table_name = 'ideas' then
+    if new.team_id is distinct from old.team_id
+      and (
+        exists (select 1 from amux.ideas where parent_idea_id = new.id)
+        or exists (select 1 from amux.idea_external_refs where idea_id = new.id)
+        or exists (select 1 from amux.sessions where idea_id = new.id)
+      ) then
+      perform amux.reject_team_reassignment('ideas.team_id');
+    end if;
+  elsif tg_table_name = 'sessions' then
+    if new.team_id is distinct from old.team_id
+      and (
+        exists (select 1 from amux.session_participants where session_id = new.id)
+        or exists (select 1 from amux.messages where session_id = new.id)
+      ) then
+      perform amux.reject_team_reassignment('sessions.team_id');
+    end if;
+  else
+    raise exception 'amux.enforce_parent_integrity is not defined for table %', tg_table_name;
+  end if;
+
+  return new;
+end;
+$function$;

--- a/services/supabase/tests/030_session_list_participant_index.sql
+++ b/services/supabase/tests/030_session_list_participant_index.sql
@@ -1,0 +1,27 @@
+begin;
+
+select plan(2);
+
+select has_index(
+  'amux',
+  'session_participants',
+  'session_participants_actor_session_idx',
+  'session list can start from an actor participant lookup'
+);
+
+select has_function(
+  'amux',
+  'list_current_actor_sessions',
+  array[
+    'integer',
+    'timestamp with time zone',
+    'timestamp with time zone',
+    'uuid',
+    'uuid',
+    'uuid'
+  ],
+  'session list RPC retains its six-argument contract'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

- **perf:** Add `20260804000000_optimize_current_actor_session_list` migration with pgTAP coverage to optimize the current-actor session list RPC.
- **fix:** Add `20260804010000_fix_functions_after_drop_agent_runtimes` migration to remove stale `agent_runtimes` references from integrity trigger functions (fixes message INSERT 42P01 after #711).
- **fix:** Preserve joined session rows across paginated list reloads when opening session deeplinks (`open-session-deeplink.ts`).

## Test plan

- [ ] Apply both Supabase migrations on a DB that already ran `20260803010000_drop_agent_runtimes`
- [ ] Verify message INSERT / session UPDATE no longer hits `relation "amux.agent_runtimes" does not exist`
- [ ] Open a session deeplink for a session outside the first paginated page; confirm it stays visible after team switch
- [ ] Run pgTAP test `030_session_list_participant_index.sql`
- [ ] Run `pnpm test:unit` for `open-session-deeplink.test.ts`


Made with [Cursor](https://cursor.com)