### PR TITLE
fix(chat): stop an empty participant cache from silencing a session

### DIFF
--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -636,7 +636,10 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
       return true;
     };
 
-    if (sessionParticipants !== undefined) {
+    // Same rule as resolve-session-mention-ids: an empty roster means the cache
+    // has not answered yet, so fall through to the cloud read below instead of
+    // concluding this session has no agent to engage.
+    if (sessionParticipants !== undefined && sessionParticipants.length > 0) {
       engageFromRoster(sessionParticipants);
       return;
     }

--- a/packages/app/src/components/chat/SessionActorSheet.tsx
+++ b/packages/app/src/components/chat/SessionActorSheet.tsx
@@ -27,6 +27,7 @@ import { useActorPresenceStore } from '@/stores/actor-presence-store'
 import { RuntimeLifecycle, AgentStatus, type RuntimeInfo } from '@/lib/proto/amux_pb'
 import { resolveAmuxAgentType } from '@/lib/amux-agent-type'
 import { useSessionParticipantStore } from '@/stores/session-participant-store'
+import { isAgentActorType } from '@/lib/actor-type'
 import { actorAvatarColor } from '@/lib/actor-color'
 import {
   loadAgentWorkspaceLookups,
@@ -450,6 +451,21 @@ export function SessionActorPanel({ sessionId, teamId }: SessionActorPanelProps)
     ) {
       setRows(actorRows)
       setCandidateActors(candidates)
+      // The roster this sheet just resolved is the same roster the mention
+      // popover, the composer's auto-engage and the session list read out of
+      // the participant store. Keeping it local is what let the sheet list an
+      // agent nobody else could see. Detail (statuses, agent types, presence)
+      // stays here; membership does not.
+      if (!sessionId) return
+      useSessionParticipantStore.getState().setParticipants(
+        sessionId,
+        actorRows.map((row) => ({
+          actorId: row.id,
+          displayName: row.display_name?.trim() || row.id,
+          avatarUrl: null,
+          isAgent: isAgentActorType(row.actor_type),
+        })),
+      )
     }
 
     void (async () => {

--- a/packages/app/src/lib/__tests__/resolve-session-mention-ids.test.ts
+++ b/packages/app/src/lib/__tests__/resolve-session-mention-ids.test.ts
@@ -95,6 +95,23 @@ describe("resolveSessionMentionActorIds", () => {
     expect(ids).toEqual(["agent-1"]);
   });
 
+  it("falls back to the backend when the cached roster is empty", async () => {
+    // A cron-created session has no local participant rows until something
+    // syncs them, and nothing does that on open. Reading the empty array as
+    // "no agent here" is what made those sessions silent: the message went out
+    // with no mention_actor_ids and nobody answered.
+    mocks.participantStoreState.participantsBySession = { "session-1": [] };
+    mocks.listParticipants.mockResolvedValue([
+      { id: "member-1", actor_type: "member", display_name: "Alice" },
+      { id: "agent-1", actor_type: "agent", display_name: "Bot" },
+    ]);
+
+    const ids = await resolveSessionMentionActorIds("session-1", [], []);
+
+    expect(ids).toEqual(["agent-1"]);
+    expect(mocks.listParticipants).toHaveBeenCalledWith("session-1");
+  });
+
   it("ignores stale solo cache while roster refresh is in flight", async () => {
     mocks.participantStoreState.participantsBySession = {
       "session-1": [

--- a/packages/app/src/lib/cache-sync.ts
+++ b/packages/app/src/lib/cache-sync.ts
@@ -77,6 +77,16 @@ export async function syncTableForSession<TSupabaseRow, TCacheRow>(args: {
   mapRow: (r: TSupabaseRow) => TCacheRow;
   upsertBatch: (rows: TCacheRow[]) => Promise<void>;
   full?: boolean;
+  /**
+   * Full sync only: hand over every row the server still has, so the caller can
+   * drop local rows it no longer does. A delta sync keyed on `updated_at` can
+   * never observe a hard DELETE, so without this a removed row lives forever in
+   * the cache.
+   *
+   * Deliberately not called when the pull failed (the early return above) — a
+   * network error must never be read as "the server has nothing".
+   */
+  reconcileFull?: (rows: TCacheRow[]) => Promise<void>;
 }): Promise<{ count: number }> {
   const wmKey = `${args.watermarkKey}:${args.sessionId}`;
   const watermark = args.full
@@ -104,6 +114,11 @@ export async function syncTableForSession<TSupabaseRow, TCacheRow>(args: {
     if (maxUpdated) {
       await cache.setWatermark(wmKey, args.teamId, maxUpdated);
     }
+  }
+  // Outside the `rows.length > 0` guard on purpose: a session whose every row
+  // was removed returns nothing, and that is exactly when reconciling matters.
+  if (args.full && args.reconcileFull) {
+    await args.reconcileFull(rows);
   }
   return { count: rows.length };
 }

--- a/packages/app/src/lib/resolve-session-mention-ids.ts
+++ b/packages/app/src/lib/resolve-session-mention-ids.ts
@@ -18,7 +18,10 @@ async function resolveSoleAgentIdIfSoloSession(sessionId: string): Promise<strin
   const store = useSessionParticipantStore.getState();
   const cached = store.participantsBySession[sessionId];
   const loading = store.loadingBySession[sessionId] ?? false;
-  if (cached !== undefined && !loading) {
+  // An empty roster is "not loaded yet", not "nobody is here" — falling through
+  // to the cloud read below is what keeps a cron-created session answerable.
+  // Trusting the empty array here is what sent messages with no target.
+  if (cached !== undefined && cached.length > 0 && !loading) {
     return soleAgentIdFromRoster(cached);
   }
 

--- a/packages/app/src/lib/sync/__tests__/session-participant-sync.test.ts
+++ b/packages/app/src/lib/sync/__tests__/session-participant-sync.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isTauri: vi.fn(() => true),
+  listSessionParticipantsForSync: vi.fn(),
+  loadSessionParticipants: vi.fn(),
+  upsertSessionParticipantsBatch: vi.fn(async () => {}),
+  softDeleteSessionParticipant: vi.fn(async () => {}),
+  getWatermark: vi.fn(async () => null as string | null),
+  setWatermark: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/utils", () => ({ isTauri: mocks.isTauri }));
+
+vi.mock("@/lib/backend", () => ({
+  getBackend: () => ({
+    sync: { listSessionParticipantsForSync: mocks.listSessionParticipantsForSync },
+  }),
+}));
+
+vi.mock("@/lib/local-cache", () => ({
+  loadSessionParticipants: mocks.loadSessionParticipants,
+  upsertSessionParticipantsBatch: mocks.upsertSessionParticipantsBatch,
+  softDeleteSessionParticipant: mocks.softDeleteSessionParticipant,
+  getWatermark: mocks.getWatermark,
+  setWatermark: mocks.setWatermark,
+}));
+
+import { syncParticipantsForSession } from "@/lib/sync/session-participant-sync";
+
+function serverRow(id: string, actorId: string) {
+  return {
+    id,
+    session_id: "session-1",
+    actor_id: actorId,
+    joined_at: null,
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+  };
+}
+
+function cachedRow(id: string, actorId: string) {
+  return {
+    id,
+    sessionId: "session-1",
+    actorId,
+    joinedAt: null,
+    createdAt: "2026-08-01T00:00:00Z",
+    updatedAt: "2026-08-01T00:00:00Z",
+    deletedAt: null,
+    syncedAt: "2026-08-01T00:00:00Z",
+  };
+}
+
+describe("syncParticipantsForSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isTauri.mockReturnValue(true);
+    mocks.getWatermark.mockResolvedValue(null);
+    mocks.loadSessionParticipants.mockResolvedValue([]);
+  });
+
+  it("drops local rows the server no longer has on a full sync", async () => {
+    // Removal is a hard DELETE server-side, so the row just stops appearing.
+    // Without reconciliation the removed actor lived on in the cache and came
+    // back the next time the session was opened.
+    mocks.listSessionParticipantsForSync.mockResolvedValue([serverRow("p1", "agent-1")]);
+    mocks.loadSessionParticipants.mockResolvedValue([
+      cachedRow("p1", "agent-1"),
+      cachedRow("p2", "member-removed"),
+    ]);
+
+    await syncParticipantsForSession("session-1", "team-1", { full: true });
+
+    expect(mocks.softDeleteSessionParticipant).toHaveBeenCalledTimes(1);
+    expect(mocks.softDeleteSessionParticipant.mock.calls[0][0]).toBe("p2");
+  });
+
+  it("reconciles even when the server returns nobody", async () => {
+    mocks.listSessionParticipantsForSync.mockResolvedValue([]);
+    mocks.loadSessionParticipants.mockResolvedValue([cachedRow("p1", "agent-1")]);
+
+    await syncParticipantsForSession("session-1", "team-1", { full: true });
+
+    expect(mocks.softDeleteSessionParticipant).toHaveBeenCalledTimes(1);
+    expect(mocks.softDeleteSessionParticipant.mock.calls[0][0]).toBe("p1");
+  });
+
+  it("leaves the cache alone on a delta sync", async () => {
+    // A delta pull only carries rows touched since the watermark; the rows it
+    // omits are not gone, they are merely unchanged.
+    mocks.getWatermark.mockResolvedValue("2026-08-01T00:00:00Z");
+    mocks.listSessionParticipantsForSync.mockResolvedValue([]);
+    mocks.loadSessionParticipants.mockResolvedValue([cachedRow("p1", "agent-1")]);
+
+    await syncParticipantsForSession("session-1", "team-1");
+
+    expect(mocks.softDeleteSessionParticipant).not.toHaveBeenCalled();
+  });
+
+  it("never reconciles when the pull failed", async () => {
+    // A network error must not be read as "the server has nobody" — that would
+    // empty the roster of every session the user opened while offline.
+    mocks.listSessionParticipantsForSync.mockRejectedValue(new Error("offline"));
+    mocks.loadSessionParticipants.mockResolvedValue([cachedRow("p1", "agent-1")]);
+
+    const count = await syncParticipantsForSession("session-1", "team-1", { full: true });
+
+    expect(count).toBe(0);
+    expect(mocks.softDeleteSessionParticipant).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/lib/sync/session-participant-sync.ts
+++ b/packages/app/src/lib/sync/session-participant-sync.ts
@@ -50,6 +50,26 @@ export async function syncParticipantsForSession(
     mapRow,
     upsertBatch: cache.upsertSessionParticipantsBatch,
     full: opts?.full,
+    // Removing a participant is a hard DELETE server-side
+    // (supabase-repo `removeSessionParticipant`), so the row simply stops
+    // appearing — a delta sync has nothing to carry and even a full sync used
+    // to only upsert what survived. The removed actor stayed in the cache and
+    // came back the next time the session was opened. A full sync is the one
+    // moment we hold the server's complete answer, so make it authoritative.
+    //
+    // MQTT `participant.removed` already routes through `refreshSession`, which
+    // syncs with `full: true` — so this also propagates removals made on
+    // another device.
+    reconcileFull: async (rows) => {
+      const stillPresent = new Set(rows.map((row) => row.id));
+      const local = await cache.loadSessionParticipants(sessionId);
+      const gone = local.filter((row) => !stillPresent.has(row.id));
+      if (gone.length === 0) return;
+      const deletedAt = new Date().toISOString();
+      await Promise.all(
+        gone.map((row) => cache.softDeleteSessionParticipant(row.id, deletedAt)),
+      );
+    },
   });
   return count;
 }

--- a/packages/app/src/stores/session-participant-store.test.ts
+++ b/packages/app/src/stores/session-participant-store.test.ts
@@ -110,7 +110,41 @@ describe("session-participant-store", () => {
     ]);
   });
 
-  it("retries empty cache on extension/web", async () => {
+  it("falls back to the cloud when the desktop local cache has no rows", async () => {
+    // A cron-created session is never synced into libsql just by being opened,
+    // so its local roster is empty while the cloud has the agent. Treating that
+    // empty read as the answer is what left the agent unmentionable and left
+    // messages with no target.
+    mockListParticipants.mockResolvedValue([
+      {
+        id: "daemon-1",
+        actor_type: "agent",
+        display_name: "MACPRO",
+        avatar_url: null,
+      },
+    ]);
+
+    await useSessionParticipantStore.getState().ensureParticipants(["cron-session"]);
+
+    expect(mockListParticipants).toHaveBeenCalledWith("cron-session");
+    expect(useSessionParticipantStore.getState().participantsBySession["cron-session"]).toEqual([
+      {
+        actorId: "daemon-1",
+        displayName: "MACPRO",
+        avatarUrl: null,
+        isAgent: true,
+      },
+    ]);
+  });
+
+  it("prefers the local cache and never calls the cloud when it has rows", async () => {
+    await useSessionParticipantStore.getState().ensureParticipants(["s1"]);
+
+    expect(mockListParticipants).not.toHaveBeenCalled();
+    expect(useSessionParticipantStore.getState().participantsBySession.s1).toHaveLength(2);
+  });
+
+  it("retries an empty roster on the next ensure", async () => {
     mockIsTauri.mockReturnValue(false);
     useSessionParticipantStore.setState({
       participantsBySession: { s1: [] },

--- a/packages/app/src/stores/session-participant-store.test.ts
+++ b/packages/app/src/stores/session-participant-store.test.ts
@@ -173,6 +173,45 @@ describe("session-participant-store", () => {
     ]);
   });
 
+  it("setParticipants publishes a roster resolved elsewhere and clears loading", async () => {
+    useSessionParticipantStore.setState({
+      participantsBySession: {},
+      loadingBySession: { s2: true },
+      errorBySession: { s2: "stale error" },
+    });
+
+    useSessionParticipantStore.getState().setParticipants("s2", [
+      { actorId: "agent-1", displayName: "MACPRO", avatarUrl: null, isAgent: true },
+    ]);
+
+    const state = useSessionParticipantStore.getState();
+    expect(state.participantsBySession.s2).toEqual([
+      { actorId: "agent-1", displayName: "MACPRO", avatarUrl: null, isAgent: true },
+    ]);
+    expect(state.loadingBySession.s2).toBe(false);
+    expect(state.errorBySession.s2).toBeNull();
+  });
+
+  it("setParticipants keeps an avatar the caller does not carry", async () => {
+    // The sheet's Row shape has no avatar_url; publishing from it must not blank
+    // an avatar this store already resolved from the actor cache.
+    useSessionParticipantStore.setState({
+      participantsBySession: {
+        s2: [{ actorId: "a1", displayName: "Alice", avatarUrl: "https://img/a1.png", isAgent: false }],
+      },
+      loadingBySession: {},
+      errorBySession: {},
+    });
+
+    useSessionParticipantStore.getState().setParticipants("s2", [
+      { actorId: "a1", displayName: "Alice", avatarUrl: null, isAgent: false },
+    ]);
+
+    expect(useSessionParticipantStore.getState().participantsBySession.s2[0].avatarUrl).toBe(
+      "https://img/a1.png",
+    );
+  });
+
   it("clears loading on invalidate while keeping cached roster", async () => {
     await useSessionParticipantStore.getState().ensureParticipants(["s1"]);
     useSessionParticipantStore.setState({

--- a/packages/app/src/stores/session-participant-store.ts
+++ b/packages/app/src/stores/session-participant-store.ts
@@ -28,6 +28,15 @@ type State = {
     options?: { force?: boolean },
   ) => Promise<void>;
   refreshSession: (sessionId: string, teamId?: string | null) => Promise<void>;
+  /**
+   * Publish a roster resolved elsewhere. The participants sheet loads its own
+   * rich rows (statuses, agent types, presence) in one round-trip and used to
+   * keep them entirely to itself — which is how it could list an agent that the
+   * mention popover, reading this store, did not know existed. Whoever learns
+   * the roster tells the store, so there is one answer to "who is in this
+   * session" even though the detail fetch stays where it is.
+   */
+  setParticipants: (sessionId: string, participants: SessionParticipantInfo[]) => void;
   invalidateSessions: (sessionIds: string[]) => void;
 };
 
@@ -183,6 +192,27 @@ export const useSessionParticipantStore = create<State>((set, get) => ({
         },
       }));
     }
+  },
+  setParticipants: (sessionId, participants) => {
+    if (!sessionId) return;
+    set((state) => {
+      // Callers that resolve a roster without avatars (the sheet's Row shape
+      // carries none) must not blank an avatar this store already knows.
+      const known = new Map(
+        (state.participantsBySession[sessionId] ?? []).map((p) => [p.actorId, p] as const),
+      );
+      return {
+        participantsBySession: {
+          ...state.participantsBySession,
+          [sessionId]: participants.map((p) => ({
+            ...p,
+            avatarUrl: p.avatarUrl ?? known.get(p.actorId)?.avatarUrl ?? null,
+          })),
+        },
+        loadingBySession: { ...state.loadingBySession, [sessionId]: false },
+        errorBySession: { ...state.errorBySession, [sessionId]: null },
+      };
+    });
   },
   invalidateSessions: (sessionIds) => {
     const ids = Array.from(new Set(sessionIds)).filter(Boolean);

--- a/packages/app/src/stores/session-participant-store.ts
+++ b/packages/app/src/stores/session-participant-store.ts
@@ -67,11 +67,30 @@ async function loadParticipantInfoFromLocalCache(
     .filter((p): p is SessionParticipantInfo => p !== null);
 }
 
+/**
+ * The local cache is an accelerator, never the truth.
+ *
+ * Nothing fills it when a session is merely opened — `syncParticipantsForSession`
+ * runs on a forced refresh, on the actor sheet's add/remove, on MQTT
+ * participant events and on a cache rebuild, and nowhere else. A session
+ * created server-side (cron) therefore has an empty local roster, and every
+ * consumer that treated that empty array as authoritative concluded "no
+ * participants": the sole-agent routing in `resolve-session-mention-ids` sent
+ * the message with no target (the agent never answered), the composer never
+ * engaged the agent pill, and the mention popover had nothing to offer — while
+ * the participants sheet, which reads the cloud directly, listed the agent the
+ * whole time.
+ *
+ * So an empty local read means "unknown", and we ask the cloud. A cloud answer
+ * of zero participants is the only empty this store will publish.
+ */
 async function loadParticipantInfo(sessionId: string): Promise<SessionParticipantInfo[]> {
   if (!isTauri()) {
     return loadParticipantInfoFromCloud(sessionId);
   }
-  return loadParticipantInfoFromLocalCache(sessionId);
+  const local = await loadParticipantInfoFromLocalCache(sessionId);
+  if (local.length > 0) return local;
+  return loadParticipantInfoFromCloud(sessionId);
 }
 
 export const useSessionParticipantStore = create<State>((set, get) => ({
@@ -86,8 +105,11 @@ export const useSessionParticipantStore = create<State>((set, get) => ({
       const cached = get().participantsBySession[sessionId]
       if (force) return true
       if (cached === undefined) return true
-      // Extension/web: retry empty cache (legacy loadSessionParticipants stub).
-      if (!isTauri() && cached.length === 0) return true
+      // Retry an empty roster on every platform, not just extension/web. A
+      // session always has at least its creator, so empty means something went
+      // wrong (a cloud read that transiently returned nothing) rather than a
+      // real answer — the retry costs nothing in practice and self-heals.
+      if (cached.length === 0) return true
       return false
     });
     if (missing.length === 0) return;


### PR DESCRIPTION
## 现象（用户报的）

1. 定时任务开的 session，发消息**不响应**
2. 打开右侧 participants 面板**能看到** agent，但**无法 @**
3. 随便加入一个其他人，就能 @ 到 local agent 了
4. 把刚加的那个人删掉，再打开 session，**它可能还在**

## 根因 A：桌面端名单只读本地缓存，而打开会话时没人填这个缓存

`session-participant-store.ts` 的桌面分支只读 libsql 本地缓存，从不查云端。而本地缓存**只由 `syncParticipantsForSession` 填充**，它的调用点是：强制刷新（`App.tsx:2511`）、面板增删（`SessionActorSheet.tsx:526`）、MQTT participant 事件（`App.tsx:1542`）、缓存重建 —— **「打开会话」不在其中**。

定时任务的 session 是服务端建的（`createCronSession` 确实写了参与者：主 agent + 该 agent 的管理员），客户端从没同步过 → 本地 0 行。

然后三个消费方把空数组当成权威的「没有参与者」：

| 位置 | 后果 |
|---|---|
| `resolve-session-mention-ids.ts:21` | 独 agent 路由返回空 → 消息不带 `mention_actor_ids` 发出 → **没人应**（现象 1） |
| `ChatPanel.tsx:639` | 不自动挂 agent pill |
| `MentionPopover` → `ensureParticipants` | 空缓存重试只对 extension/web 生效 → 桌面端 @ 列表空（现象 2） |

而 `SessionActorSheet` 绕开缓存直接打云端 → **看得到却 @ 不到**。加人时会调 `syncParticipantsForSession` 把缓存填上 → 这就是现象 3。

## 根因 B：删除参与者根本没有传播路径（现象 4）

- 服务端是**硬删**（`supabase-repo.ts` `removeSessionParticipant` 直接 `.delete()`）
- 客户端同步**只 upsert**，`mapRow` 还把 `deletedAt: null` 写死
- 增量同步靠 `updated_at > watermark`，物理删除的行永远不会再出现

本地那行于是永久留存，重开就「诈尸」。

## 改动

**A2 —— 缓存降级为加速器**：本地空读回落云端，只有云端亲口说 0 才发布空名单。`ensureParticipants` 的空名单重试同时对所有平台生效（会话至少有创建者，真空基本不可能，这条实际不触发，但瞬时空值能自愈）。

**A3 —— 让两处已有的云端兜底真的跑得到**：`resolve-session-mention-ids` 和 `ChatPanel` 都卡在 `!== undefined` 上，空数组满足这个条件。

**B1 —— full 同步变成权威**：`syncTableForSession` 新增 `reconcileFull` 钩子（**仅 full 调用，拉取失败时绝不调用** —— 否则一次网络错误就会清空整个名单），participant sync 用它 soft-delete 掉服务端已经没有的本地行。MQTT `participant.removed` 本来就走 `refreshSession(full: true)`，所以别的设备上的删除也能传播。

**顺带**：`SessionActorSheet` 解析出名单后 `setParticipants` 推给 store（`applySnapshot` 是它唯一的汇聚点）。**成员身份单一来源，明细各取所需** —— 面板继续自己取状态/agent 类型/在线状态。`setParticipants` 不会用 null 覆盖已知头像（面板的 Row 没有 `avatar_url`）。

## 验证

单测 9 条新增：桌面空缓存回落云端、本地有行时不打云端、mention 解析空名单回落、发布名单清 loading/error、不覆盖已知头像，以及同步的四种情况（删掉服务端没有的行 / 服务端返回空也要 reconcile / 增量同步不动缓存 / 拉取失败绝不 reconcile）。

**全量 425 文件 / 2581 测试通过**，`pnpm typecheck` 干净，`pnpm lint` 0 errors。

**真机验证**（本地 `pnpm tauri:dev`，连自建环境 `api.teamclaw-dev.ucar.cc`，团队 Curious Cougar）：

- 该团队在本地 libsql 缓存里**一个会话、一条参与者行都没有**（缓存是 belayo 时代的遗留）
- 但运行中的 app 在会话列表上显示「**2 participants**」，而这个徽标正是从 `participantsBySession` 渲染的（`SessionListColumn.tsx:612`）
- 改动前，桌面端只会读到空缓存、把 `[]` 存进 store，徽标不会出现 —— **这 2 个参与者只可能来自新增的云端回落**
- 打开其中一个会话，头部显示 `You, H96Y63G035 · 2 participants · Only one agent in this session`，独 agent 状态正确识别

另外实测：该 dev 缓存里有 **76 个 cron 会话本地参与者为 0**，而服务端每个 cron 会话都是 2 个参与者 —— 这就是本 issue 的量级。

🤖 Generated with [Claude Code](https://claude.com/claude-code)