### PR TITLE
fix: three production Sentry issues from 2026-08-03

### DIFF
--- a/apps/extension/build.mjs
+++ b/apps/extension/build.mjs
@@ -85,6 +85,23 @@ if (!backend.cloudApiUrl) {
   process.exit(1)
 }
 
+// mqttWsUrl gets the same treatment, for the same reason one step removed. It
+// used to be a console warning that let the build through, and what shipped was
+// a package whose API talked to the brand's cluster while realtime kept the
+// TeamClaw broker baked into .env.web. That package does not fail loudly — it
+// signs in fine and then every session reports `runtime_start_failure:
+// transport_offline`, because the broker it reaches has no idea who the user is.
+// A build error names the missing field; the runtime symptom does not.
+if (!backend.mqttWsUrl) {
+  console.error(
+    '[extension] build.config.json declares no mqttWsUrl — refusing to build a package\n' +
+      '            whose realtime transport would fall back to the TeamClaw broker while\n' +
+      '            its API points elsewhere. Add "mqttWsUrl" (top level, or under the\n' +
+      '            "extensions" block) to the brand config and re-run.',
+  )
+  process.exit(1)
+}
+
 const esbuildAliasWithAllowlist = {
   ...esbuildAlias,
   '@teamclaw/side-panel-host-allowlist': resolve(appDir, 'src/lib/side-panel-host-allowlist.ts'),
@@ -109,7 +126,7 @@ const backendEnv =
     ? {}
     : {
         VITE_CLOUD_API_URL: backend.cloudApiUrl,
-        ...(backend.mqttWsUrl ? { VITE_MQTT_WS_URL: backend.mqttWsUrl } : {}),
+        VITE_MQTT_WS_URL: backend.mqttWsUrl,
       }
 console.log(
   '[extension] web build ->',
@@ -121,13 +138,7 @@ if (process.env.EXT_ENV === 'test') {
   console.log('[extension] backend -> .env.web.test (EXT_ENV=test)')
 } else {
   console.log('[extension] backend -> cloudApiUrl:', backend.cloudApiUrl)
-  // Without a brand-declared endpoint the side panel keeps whatever .env.web
-  // pins, which points at the TeamClaw broker — realtime then talks to the
-  // wrong cluster while the API talks to the right one.
-  console.log(
-    '[extension] backend -> mqttWsUrl:',
-    backend.mqttWsUrl ?? '(none in build config — falling back to .env.web)',
-  )
+  console.log('[extension] backend -> mqttWsUrl:', backend.mqttWsUrl)
 }
 execSync(`pnpm ${webBuildScript}`, {
   cwd: appDir,

--- a/build.config.dev.json
+++ b/build.config.dev.json
@@ -1,5 +1,6 @@
 {
   "cloudApiUrl": "https://api.teamclaw-dev.ucar.cc",
+  "mqttWsUrl": "wss://mqtt.teamclaw-dev.ucar.cc/mqtt",
   "team": {
     "lockLlmConfig": false
   },

--- a/build.config.production.json
+++ b/build.config.production.json
@@ -1,5 +1,6 @@
 {
   "cloudApiUrl": "https://api.teamclaw-dev.ucar.cc",
+  "mqttWsUrl": "wss://mqtt.teamclaw-dev.ucar.cc/mqtt",
   "team": {
     "lockLlmConfig": false
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -70,7 +70,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-web-links": "^0.12.0",
-    "@xterm/addon-webgl": "^0.19.0",
+    "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/app/src/components/terminal/XtermInstance.tsx
+++ b/packages/app/src/components/terminal/XtermInstance.tsx
@@ -83,6 +83,11 @@ export function XtermInstance({ tabId, active }: Props) {
     searchRef.current = search;
 
     // WebGL renderer — falls back to canvas/DOM if context creation fails or is lost.
+    //
+    // addon-webgl is pinned to ^0.18.0 on purpose: 0.19.0 reads
+    // `terminal._core._store._isDisposed` on teardown, and that `_store` only
+    // exists in the xterm 6.x core. Against @xterm/xterm 5.5.0 the read throws
+    // and takes the whole cleanup below with it. Bump both or neither.
     try {
       const addon = new WebglAddon();
       addon.onContextLoss(() => {
@@ -192,7 +197,14 @@ export function XtermInstance({ tabId, active }: Props) {
       onDataDisposer?.dispose();
       onResizeDisposer?.dispose();
       oscDisposer?.dispose();
-      webglAddon?.dispose();
+      // Disposing the addon swaps xterm back to its DOM renderer, and that swap
+      // is xterm's code, not ours. When it threw, it took `term.dispose()` and
+      // the ref cleanup below with it and leaked the terminal on every unmount.
+      try {
+        webglAddon?.dispose();
+      } catch (err) {
+        console.warn("[terminal] WebGL addon teardown failed", err);
+      }
       term.dispose();
       termRef.current = null;
       fitRef.current = null;

--- a/packages/app/src/stores/__tests__/acp-debug-store.test.ts
+++ b/packages/app/src/stores/__tests__/acp-debug-store.test.ts
@@ -1,9 +1,19 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { isAcpDebugPanelVisible, useAcpDebugStore } from '../acp-debug-store'
+import {
+  ACP_DEBUG_MAX_LINES,
+  isAcpDebugPanelVisible,
+  useAcpDebugStore,
+} from '../acp-debug-store'
+
+/** Let the queued append flush; the store coalesces on a microtask. */
+const flush = () => Promise.resolve()
+
+const line = (topic: string) => ({ topic, eventCase: 'test' })
 
 describe('acp-debug-store', () => {
   beforeEach(() => {
     localStorage.clear()
+    useAcpDebugStore.getState().clear()
     useAcpDebugStore.setState({ enabled: false, lines: [] })
   })
 
@@ -20,5 +30,55 @@ describe('acp-debug-store', () => {
     useAcpDebugStore.getState().setEnabled(false)
     expect(useAcpDebugStore.getState().enabled).toBe(false)
     expect(localStorage.getItem('teamclaw-acp-stream-debug')).toBe('false')
+  })
+
+  it('drops appends while disabled', async () => {
+    useAcpDebugStore.getState().append(line('amux/t/a/session/s/live'))
+    await flush()
+    expect(useAcpDebugStore.getState().lines).toHaveLength(0)
+  })
+
+  // Regression (Sentry TEAMCLAW-REACT-85): a set() per line meant a synchronous
+  // React render per live event, and a streaming reply overran React's nested
+  // update limit. A burst has to land as one store update, not N.
+  it('coalesces a burst of appends into a single store update', async () => {
+    useAcpDebugStore.setState({ enabled: true })
+    let notifications = 0
+    const unsubscribe = useAcpDebugStore.subscribe(() => {
+      notifications += 1
+    })
+
+    for (let i = 0; i < 60; i += 1) {
+      useAcpDebugStore.getState().append(line(`topic/${i}`))
+    }
+    expect(useAcpDebugStore.getState().lines).toHaveLength(0)
+
+    await flush()
+    unsubscribe()
+
+    expect(useAcpDebugStore.getState().lines).toHaveLength(60)
+    expect(notifications).toBe(1)
+  })
+
+  it('keeps the ring buffer capped when a burst overflows it', async () => {
+    useAcpDebugStore.setState({ enabled: true })
+    for (let i = 0; i < ACP_DEBUG_MAX_LINES + 25; i += 1) {
+      useAcpDebugStore.getState().append(line(`topic/${i}`))
+    }
+    await flush()
+
+    const { lines } = useAcpDebugStore.getState()
+    expect(lines).toHaveLength(ACP_DEBUG_MAX_LINES)
+    // The oldest 25 were dropped, so the window starts at 25.
+    expect(lines[0]?.topic).toBe('topic/25')
+    expect(lines[lines.length - 1]?.topic).toBe(`topic/${ACP_DEBUG_MAX_LINES + 24}`)
+  })
+
+  it('clear() discards lines that are queued but not yet flushed', async () => {
+    useAcpDebugStore.setState({ enabled: true })
+    useAcpDebugStore.getState().append(line('topic/queued'))
+    useAcpDebugStore.getState().clear()
+    await flush()
+    expect(useAcpDebugStore.getState().lines).toHaveLength(0)
   })
 })

--- a/packages/app/src/stores/acp-debug-store.ts
+++ b/packages/app/src/stores/acp-debug-store.ts
@@ -62,6 +62,41 @@ interface State {
   setEnabled: (enabled: boolean) => void;
 }
 
+/**
+ * Appends are driven straight off the MQTT/SSE firehose — one per live event,
+ * which during a stream means one per delta chunk. A `set()` per line is a
+ * synchronous React render per line, and a burst (a streaming reply, or the
+ * retained-message flood on reconnect) walks React past its nested-update limit
+ * and throws "Maximum update depth exceeded".
+ *
+ * So coalesce: queue the lines and flush them in a single `set` on the next
+ * microtask, mirroring `enqueueRuntimeStateUpdate` in the runtime-state store.
+ * The disk log stays per-line — it is async I/O and never touches React.
+ */
+let pendingLines: AcpDebugLine[] = [];
+let flushScheduled = false;
+
+function flushPendingLines(): void {
+  flushScheduled = false;
+  const queued = pendingLines;
+  pendingLines = [];
+  if (queued.length === 0) return;
+  useAcpDebugStore.setState((state) => {
+    const next = [...state.lines, ...queued];
+    if (next.length > ACP_DEBUG_MAX_LINES) {
+      next.splice(0, next.length - ACP_DEBUG_MAX_LINES);
+    }
+    return { lines: next };
+  });
+}
+
+function enqueueLine(line: AcpDebugLine): void {
+  pendingLines.push(line);
+  if (flushScheduled) return;
+  flushScheduled = true;
+  queueMicrotask(flushPendingLines);
+}
+
 export const useAcpDebugStore = create<State>((set, get) => ({
   lines: [],
   enabled: readAcpDebugEnabled(),
@@ -82,16 +117,13 @@ export const useAcpDebugStore = create<State>((set, get) => ({
           ? { envelope: input.envelopeMeta, acp: serializeAcpPayload(input.acpEvent) }
           : serializeAcpPayload(input.acpEvent)),
     };
-    set((state) => {
-      const next = [...state.lines, line];
-      if (next.length > ACP_DEBUG_MAX_LINES) {
-        next.splice(0, next.length - ACP_DEBUG_MAX_LINES);
-      }
-      return { lines: next };
-    });
+    enqueueLine(line);
     void appendAcpDebugLineToFile(line);
   },
-  clear: () => set({ lines: [] }),
+  clear: () => {
+    pendingLines = [];
+    set({ lines: [] });
+  },
   setEnabled: (enabled) => {
     try {
       localStorage.setItem(ACP_DEBUG_ENABLED_KEY, String(enabled));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,8 +300,8 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
       '@xterm/addon-webgl':
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^0.18.0
+        version: 0.18.0(@xterm/xterm@5.5.0)
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
@@ -4453,8 +4453,10 @@ packages:
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
-  '@xterm/addon-webgl@0.19.0':
-    resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
+  '@xterm/addon-webgl@0.18.0':
+    resolution: {integrity: sha512-xCnfMBTI+/HKPdRnSOHaJDRqEpq2Ugy8LEj9GiY4J3zJObo3joylIFaMvzBwbYRg8zLtkO0KQaStCeSfoaI2/w==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
 
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
@@ -12220,7 +12222,7 @@ snapshots:
   '@react-native/codegen@0.85.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       hermes-parser: 0.33.3
       invariant: 2.2.4
       nullthrows: 1.1.1
@@ -13200,7 +13202,9 @@ snapshots:
 
   '@xterm/addon-web-links@0.12.0': {}
 
-  '@xterm/addon-webgl@0.19.0': {}
+  '@xterm/addon-webgl@0.18.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
 
   '@xterm/xterm@5.5.0': {}
 

--- a/scripts/lib/extension-config.test.js
+++ b/scripts/lib/extension-config.test.js
@@ -222,3 +222,16 @@ test("build.config.example.json documents both backend fields", () => {
   assert.ok(backend.cloudApiUrl, "example config must declare cloudApiUrl");
   assert.ok(backend.mqttWsUrl, "example config must declare mqttWsUrl");
 });
+
+// apps/extension/build.mjs now exits non-zero when either field is missing, so
+// a config that omits one is not a degraded build — it is no build at all. The
+// omission is invisible in review (the extension build is a separate workflow),
+// which is how packages shipped with realtime pointed at the wrong broker.
+for (const name of ["build.config.dev.json", "build.config.production.json"]) {
+  test(`${name} declares both backend fields the extension build requires`, () => {
+    const cfg = JSON.parse(fs.readFileSync(path.join(repoRoot, name), "utf8"));
+    const backend = resolveExtensionBackend(cfg);
+    assert.ok(backend.cloudApiUrl, `${name} must declare cloudApiUrl`);
+    assert.ok(backend.mqttWsUrl, `${name} must declare mqttWsUrl`);
+  });
+}


### PR DESCRIPTION
Triage of everything unresolved that fired on 2026-08-03. Half the issues were
`environment=development` noise from a single dev box; these are the three that
came from real users.

## TEAMCLAW-REACT-6J — 14 users, 24 events, since 6/30

`TypeError: undefined is not an object (evaluating 'this._terminal._core._store._isDisposed')`

Not a double-dispose, as it first looked — a version mismatch.
`@xterm/addon-webgl@0.19.0` reads `terminal._core._store._isDisposed` in the
disposable it registers during `activate()`, and that `_store` only exists in
the xterm 6.x core. `@xterm/xterm@5.5.0` still uses `_disposables` + its own
`_isDisposed`; `_store` appears zero times in the whole package. So the read
throws on every WebGL teardown. addon-webgl 0.19.0 declares no
`peerDependencies` at all, which is how it got installed against a 5.x core.

Worse than the crash itself: the throw originated at `webglAddon?.dispose()` in
`XtermInstance`'s cleanup, so `term.dispose()` and the three ref resets below it
never ran. Every terminal unmount leaked its terminal.

- Pin `@xterm/addon-webgl` to `^0.18.0` (peer `@xterm/xterm: ^5.0.0`; verified
  the installed build has no `_store` access, only `_core._createRenderer` /
  `_core._renderService`, both present in 5.5.0).
- Isolate the addon teardown so xterm's renderer swap can't abort the rest of
  the cleanup again.
- Comment at the load site so the two packages get bumped together or not at all.

## TEAMCLAW-REACT-85 — 2 users, 6 events

`Error: Maximum update depth exceeded`, reported from
`runtime-state-store` → `useAcpDebugStore.append`.

The store did one `set()` per appended line, and appends come straight off the
live event firehose: one per delta chunk during a streaming reply, plus the
retained-message flood on reconnect. One `set` is one synchronous React render,
and a burst walks React past its nested-update limit.

Coalesce appends onto a microtask and flush them as a single update — the same
shape as `enqueueRuntimeStateUpdate` a few files over, which exists for exactly
this reason. The disk log stays per-line; it is async I/O and never touches
React. `clear()` now drops queued-but-unflushed lines too.

Note this addresses the trigger in the reported stack. It is not a proof that
no other path can produce a max-update-depth error.

## TEAMCLAW-REACT-7S — 10 users, 41 events

`runtime_start_failure: transport_offline`, all from the copilot361 extension
side panel.

A brand config with no `mqttWsUrl` only produced a console warning and the build
went through, so the package shipped with its API on the brand's cluster and
realtime still on the TeamClaw broker baked into `.env.web`. That package does
not fail loudly — it signs in fine, then reports `transport_offline` on every
session, because the broker it reaches has no idea who the user is.

- Fail the extension build on a missing `mqttWsUrl`, the way a missing
  `cloudApiUrl` already does since #731.
- Declare the field in `build.config.dev.json` and
  `build.config.production.json`, which were both missing it (only the example
  config had it).
- Extend the guardrail test to cover both shipped configs.

**Still outstanding:** the already-published copilot361 package stays broken
until `mqttWsUrl` is added to its brand config in the enterprise-branding repo
and it is rebuilt. This PR only stops the next one from shipping that way.

## Verification

- `pnpm test:unit` — 425 files, 2586 tests, all passing
- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (52 pre-existing warnings, none in changed files)
- `node --test scripts/lib/extension-config.test.js` — 22/22
- Simulated backend resolution across `BUILD_ENV` unset / `dev` / `production` to
  confirm the new build gate blocks no in-repo build

🤖 Generated with [Claude Code](https://claude.com/claude-code)