### PR TITLE
fix(cron): make "Run Now" actually run — reply, model, streaming, prompt

### DIFF
--- a/apps/daemon/src/daemon/collab_runtime_ensure.rs
+++ b/apps/daemon/src/daemon/collab_runtime_ensure.rs
@@ -102,7 +102,7 @@ impl DaemonServer {
             );
 
             // opencode.json suppress is inside assemble (after managed-LLM await).
-            let runtime_env = match self
+            let mut runtime_env = match self
                 .assemble_spawn_runtime_env_for_worktree(&stored.worktree, &stored.workspace_id)
                 .await
             {
@@ -118,6 +118,13 @@ impl DaemonServer {
                     crate::runtime::SpawnRuntimeEnv::default()
                 }
             };
+
+            // Both branches above produce a desktop-shaped env, which for a
+            // gateway/cron runtime means it comes back as "ask".
+            crate::runtime::restore_gateway_shape_for_resume(
+                &mut runtime_env,
+                &stored.workspace_id,
+            );
 
             let resume_res = self
                 .agents

--- a/apps/daemon/src/daemon/mod.rs
+++ b/apps/daemon/src/daemon/mod.rs
@@ -3,7 +3,7 @@ mod prompt_await;
 mod runtime_cursor;
 mod runtime_resolution;
 pub(crate) mod server;
-mod session_events;
+pub(crate) mod session_events;
 mod session_resume;
 
 pub use server::{backend_from_provider_config, DaemonServer};

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -238,6 +238,14 @@ pub struct DaemonServer {
     cron_turn_done_tx: mpsc::Sender<cron::CronTurnDone>,
     /// Receiver half, `take()`n by whichever run loop (MQTT or NATS) is active.
     cron_turn_done_rx: Option<mpsc::Receiver<cron::CronTurnDone>>,
+    /// Sender for the ACP events of an in-flight cron turn. The turn task owns
+    /// the agent's event channel, so nothing else can publish them to
+    /// `session/live`; the loop drains this and does it (see
+    /// `publish_cron_turn_event`). Bounded and `try_send`-only — the UI must
+    /// never be able to stall a model turn.
+    cron_turn_event_tx: mpsc::Sender<cron::CronTurnEvent>,
+    /// Receiver half, `take()`n by whichever run loop is active.
+    cron_turn_event_rx: Option<mpsc::Receiver<cron::CronTurnEvent>>,
 }
 
 /// Single control command parsed off `amuxd.sock`. Variants correspond to the
@@ -746,6 +754,11 @@ impl DaemonServer {
         // Bounded queue of completed cron turns handed back to the run loop for
         // persistence + sock reply (see `cron_turn_done_tx`).
         let (cron_turn_done_tx, cron_turn_done_rx) = mpsc::channel(64);
+        // Streaming events of in-flight cron turns. Deeper than the done queue
+        // because a single turn emits one frame per delta; overflow drops
+        // frames (the UI catches up on the next one) instead of applying
+        // backpressure to the turn.
+        let (cron_turn_event_tx, cron_turn_event_rx) = mpsc::channel(1024);
 
         Ok(Self {
             config,
@@ -788,6 +801,8 @@ impl DaemonServer {
             rpc_client,
             cron_turn_done_tx,
             cron_turn_done_rx: Some(cron_turn_done_rx),
+            cron_turn_event_tx,
+            cron_turn_event_rx: Some(cron_turn_event_rx),
         })
     }
 
@@ -1383,6 +1398,10 @@ impl DaemonServer {
             .cron_turn_done_rx
             .take()
             .expect("cron_turn_done_rx already taken (MQTT run loop entered twice)");
+        let mut cron_event_rx = self
+            .cron_turn_event_rx
+            .take()
+            .expect("cron_turn_event_rx already taken (MQTT run loop entered twice)");
 
         'outer: loop {
             // ── 0. Self-heal team_id from daemon.toml ──
@@ -1779,6 +1798,14 @@ impl DaemonServer {
                             self.finalize_cron_turn(done).await;
                         }
                     }
+                    ev = cron_event_rx.recv() => {
+                        // An in-flight cron turn emitted an ACP event; publish it
+                        // so the desktop streams the run instead of sitting still
+                        // until the finished reply lands.
+                        if let Some(ev) = ev {
+                            self.publish_cron_turn_event(ev).await;
+                        }
+                    }
                     poll_result = self.mqtt.eventloop.poll() => {
                         match poll_result {
                             Ok(Event::Incoming(Packet::ConnAck(_))) => {
@@ -1952,6 +1979,10 @@ impl DaemonServer {
             .cron_turn_done_rx
             .take()
             .expect("cron_turn_done_rx already taken (NATS run loop entered twice)");
+        let mut cron_event_rx = self
+            .cron_turn_event_rx
+            .take()
+            .expect("cron_turn_event_rx already taken (NATS run loop entered twice)");
 
         'outer: loop {
             // 1. Fresh backend access_token; same retry cadence as MQTT path.
@@ -2209,6 +2240,13 @@ impl DaemonServer {
                         // matching arm in the MQTT loop.
                         if let Some(done) = done {
                             self.finalize_cron_turn(done).await;
+                        }
+                    }
+                    ev = cron_event_rx.recv() => {
+                        // Streaming events of an in-flight cron turn. See the
+                        // matching arm in the MQTT loop.
+                        if let Some(ev) = ev {
+                            self.publish_cron_turn_event(ev).await;
                         }
                     }
                     frame = inbound.recv() => {
@@ -3384,6 +3422,7 @@ pub(crate) mod tests {
             backend.clone(),
         ));
         let (cron_turn_done_tx, cron_turn_done_rx) = mpsc::channel(64);
+        let (cron_turn_event_tx, cron_turn_event_rx) = mpsc::channel(1024);
         TestServer {
             server: DaemonServer {
                 config,
@@ -3430,6 +3469,8 @@ pub(crate) mod tests {
                 ))),
                 cron_turn_done_tx,
                 cron_turn_done_rx: Some(cron_turn_done_rx),
+                cron_turn_event_tx,
+                cron_turn_event_rx: Some(cron_turn_event_rx),
             },
             _tmp: tmp,
         }

--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -544,11 +544,13 @@ impl DaemonServer {
     /// shows no mention, and every catchup re-queues it as silent context
     /// instead of seeing an answered turn.
     ///
-    /// Skips session/live publish so the daemon does not re-route the prompt
-    /// back into the ACP runtime (cron already calls `send_prompt_raw`), and
-    /// burns the message id in the ingestion dedup gate so a catchup replay
-    /// racing the in-flight cron turn cannot fire a second prompt off the
-    /// now-present mention.
+    /// Burns the message id in the ingestion dedup gate first, then publishes
+    /// on `session/live` like any other message. The burn is what makes the
+    /// publish safe: cron drives this turn itself, and without it the loopback
+    /// copy would prompt the runtime a second time — which is why this used to
+    /// skip the publish entirely. Skipping it left the desktop to *pull* the
+    /// prompt, and "Run Now" navigates in before the row is queryable, so the
+    /// thread opened showing the agent talking to nobody.
     pub(crate) async fn persist_cron_user_prompt(
         &mut self,
         team_id: &str,
@@ -594,10 +596,16 @@ impl DaemonServer {
             }
         }
 
-        // Cron drives this turn itself; claim the id so neither the live
-        // ingest nor a catchup replay prompts the runtime a second time.
+        // Claim the id BEFORE publishing: the loopback copy comes back fast,
+        // and the gate has to already be closed when it does.
         if let Some(tc) = self.teamclaw.as_mut() {
             tc.should_process_message(session_id, &message_id);
+        }
+
+        if let Some(tc) = self.teamclaw.as_ref() {
+            if let Err(e) = tc.publish_live_message(session_id, &proto_msg).await {
+                warn!(?e, session_id, "cron: publish user prompt to live failed");
+            }
         }
 
         info!(

--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -224,11 +224,24 @@ impl DaemonServer {
             (sb_sid, acp_sid)
         };
 
+        // The model the runtime actually settled on — not `parsed.model_override`,
+        // which the daemon drops when the job's pinned pair is no longer in the
+        // workspace catalog. A desktop-typed message carries the sender's model
+        // the same way; without it "Run Now" navigates into a session whose only
+        // message has no model, and the desktop spawns its own runtime on the
+        // device MRU instead of the model the job asked for.
+        let run_model = {
+            let mgr = self.agents.lock().await;
+            mgr.agent_id_by_acp_session(&acp_sid)
+                .and_then(|runtime_id| mgr.current_model(&runtime_id).cloned())
+                .unwrap_or_default()
+        };
+
         // Cron drives the ACP turn directly (bypassing session/live routing),
         // so the job prompt never lands in Cloud the way a desktop-typed
         // message would. Persist it before the turn so "view session" shows
         // both sides of the exchange.
-        self.persist_cron_user_prompt(&team_id, &remote_session_id, parsed.message)
+        self.persist_cron_user_prompt(&team_id, &remote_session_id, parsed.message, &run_model)
             .await;
 
         Ok((
@@ -468,6 +481,7 @@ impl DaemonServer {
         team_id: &str,
         session_id: &str,
         prompt: &str,
+        model: &str,
     ) {
         if self.teamclaw.is_none() {
             warn!(
@@ -497,6 +511,7 @@ impl DaemonServer {
             content: prompt.to_string(),
             created_at: now.timestamp(),
             metadata_json: metadata_json.clone(),
+            model: model.to_string(),
             ..Default::default()
         };
 
@@ -524,6 +539,7 @@ impl DaemonServer {
         let team_id = team_id.to_string();
         let session = session_id.to_string();
         let content = prompt.to_string();
+        let model = model.to_string();
         tokio::spawn(async move {
             if let Err(e) = backend
                 .insert_message(
@@ -534,7 +550,7 @@ impl DaemonServer {
                     "text",
                     &content,
                     &metadata_json,
-                    "",
+                    &model,
                     "",
                     "",
                     0,
@@ -860,7 +876,7 @@ mod tests {
 
         test_server
             .server
-            .persist_cron_user_prompt("team-test", "session-1", "check approvals")
+            .persist_cron_user_prompt("team-test", "session-1", "check approvals", "")
             .await;
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -893,7 +909,7 @@ mod tests {
 
         test_server
             .server
-            .persist_cron_user_prompt("team-test", "session-1", "check approvals")
+            .persist_cron_user_prompt("team-test", "session-1", "check approvals", "")
             .await;
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -904,6 +920,38 @@ mod tests {
                 &snap.messages_inserted[0].metadata_json
             ),
             vec!["agent-actor".to_string()],
+        );
+    }
+
+    /// "Run Now" navigates into the session while it holds nothing but this
+    /// prompt. If the prompt carries no model, the desktop cannot tell what the
+    /// job is running on and spawns its own runtime on the device MRU — the
+    /// composer pill then names a model the job never asked for.
+    #[tokio::test]
+    async fn persist_cron_user_prompt_carries_the_run_model() {
+        use crate::backend::mock::MockBackend;
+        use crate::backend::Backend;
+        use std::sync::Arc;
+
+        let mock = MockBackend::with_identity("team-test", "agent-actor");
+        let backend: Arc<dyn Backend> = Arc::new(mock.clone());
+        let mut test_server = test_server_with_cloud_api(backend);
+
+        test_server
+            .server
+            .persist_cron_user_prompt(
+                "team-test",
+                "session-1",
+                "check approvals",
+                "anthropic/claude-haiku-4-5-20251001",
+            )
+            .await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        assert_eq!(
+            mock.state().messages_inserted[0].model,
+            "anthropic/claude-haiku-4-5-20251001",
         );
     }
 
@@ -922,7 +970,7 @@ mod tests {
 
         test_server
             .server
-            .persist_cron_user_prompt("team-test", "session-1", "check approvals")
+            .persist_cron_user_prompt("team-test", "session-1", "check approvals", "")
             .await;
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;

--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -451,21 +451,31 @@ impl DaemonServer {
 
     /// Persist the cron job prompt as a `text` message on the cloud session.
     ///
+    /// The prompt is written the way a human @-mentioning this daemon's agent
+    /// would be — `metadata.mention_actor_ids = [self.actor_id]` — because the
+    /// sender is a human admin member, and an un-mentioned inbound message is
+    /// treated as drive-by chatter everywhere else in the system: the chat UI
+    /// shows no mention, and every catchup re-queues it as silent context
+    /// instead of seeing an answered turn.
+    ///
     /// Skips session/live publish so the daemon does not re-route the prompt
-    /// back into the ACP runtime (cron already calls `send_prompt_raw`).
+    /// back into the ACP runtime (cron already calls `send_prompt_raw`), and
+    /// burns the message id in the ingestion dedup gate so a catchup replay
+    /// racing the in-flight cron turn cannot fire a second prompt off the
+    /// now-present mention.
     pub(crate) async fn persist_cron_user_prompt(
-        &self,
+        &mut self,
         team_id: &str,
         session_id: &str,
         prompt: &str,
     ) {
-        let Some(tc) = self.teamclaw.as_ref() else {
+        if self.teamclaw.is_none() {
             warn!(
                 session_id,
                 "cron: SessionManager unavailable; user prompt not persisted"
             );
             return;
-        };
+        }
 
         let sender_actor_id = self
             .backend
@@ -477,6 +487,8 @@ impl DaemonServer {
 
         let message_id = uuid::Uuid::new_v4().to_string();
         let now = chrono::Utc::now();
+        let metadata_json =
+            serde_json::json!({ "mention_actor_ids": [self.actor_id.clone()] }).to_string();
         let proto_msg = crate::proto::teamclaw::Message {
             message_id: message_id.clone(),
             session_id: session_id.to_string(),
@@ -484,17 +496,27 @@ impl DaemonServer {
             kind: crate::proto::teamclaw::MessageKind::Text as i32,
             content: prompt.to_string(),
             created_at: now.timestamp(),
+            metadata_json: metadata_json.clone(),
             ..Default::default()
         };
 
-        if let Err(e) = tc.persist_message(session_id, &proto_msg).await {
-            warn!(?e, session_id, "cron: persist user prompt to TOML failed");
+        if let Some(tc) = self.teamclaw.as_ref() {
+            if let Err(e) = tc.persist_message(session_id, &proto_msg).await {
+                warn!(?e, session_id, "cron: persist user prompt to TOML failed");
+            }
+        }
+
+        // Cron drives this turn itself; claim the id so neither the live
+        // ingest nor a catchup replay prompts the runtime a second time.
+        if let Some(tc) = self.teamclaw.as_mut() {
+            tc.should_process_message(session_id, &message_id);
         }
 
         info!(
             session_id,
             bytes = prompt.len(),
             sender_actor_id = %sender_actor_id,
+            mention_actor_id = %self.actor_id,
             "cron: persisted user prompt to session TOML and cloud"
         );
 
@@ -511,7 +533,7 @@ impl DaemonServer {
                     &sender_actor_id,
                     "text",
                     &content,
-                    "",
+                    &metadata_json,
                     "",
                     "",
                     "",
@@ -834,7 +856,7 @@ mod tests {
                 .insert("agent-actor".to_string(), vec!["human-admin".to_string()]);
         }
         let backend: Arc<dyn Backend> = Arc::new(mock.clone());
-        let test_server = test_server_with_cloud_api(backend);
+        let mut test_server = test_server_with_cloud_api(backend);
 
         test_server
             .server
@@ -849,5 +871,72 @@ mod tests {
         assert_eq!(snap.messages_inserted[0].content, "check approvals");
         assert_eq!(snap.messages_inserted[0].sender_actor_id, "human-admin");
         assert_eq!(snap.messages_inserted[0].session_id, "session-1");
+    }
+
+    /// The prompt must land as an @mention of this daemon's agent, otherwise
+    /// the chat UI shows an un-addressed message and catchup treats it as
+    /// drive-by chatter rather than an answered turn.
+    #[tokio::test]
+    async fn persist_cron_user_prompt_mentions_the_daemon_agent() {
+        use crate::backend::mock::MockBackend;
+        use crate::backend::Backend;
+        use std::sync::Arc;
+
+        let mock = MockBackend::with_identity("team-test", "agent-actor");
+        {
+            let mut st = mock.state();
+            st.admin_member_actor_ids
+                .insert("agent-actor".to_string(), vec!["human-admin".to_string()]);
+        }
+        let backend: Arc<dyn Backend> = Arc::new(mock.clone());
+        let mut test_server = test_server_with_cloud_api(backend);
+
+        test_server
+            .server
+            .persist_cron_user_prompt("team-test", "session-1", "check approvals")
+            .await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let snap = mock.state();
+        assert_eq!(
+            crate::daemon::session_events::parse_mention_actor_ids(
+                &snap.messages_inserted[0].metadata_json
+            ),
+            vec!["agent-actor".to_string()],
+        );
+    }
+
+    /// Cron drives its own turn, so the prompt id must already be spent in the
+    /// ingestion dedup gate — a catchup replay racing the in-flight turn would
+    /// otherwise see the fresh mention and fire a duplicate prompt.
+    #[tokio::test]
+    async fn persist_cron_user_prompt_claims_the_message_id_for_dedup() {
+        use crate::backend::mock::MockBackend;
+        use crate::backend::Backend;
+        use std::sync::Arc;
+
+        let mock = MockBackend::with_identity("team-test", "agent-actor");
+        let backend: Arc<dyn Backend> = Arc::new(mock.clone());
+        let mut test_server = test_server_with_cloud_api(backend);
+
+        test_server
+            .server
+            .persist_cron_user_prompt("team-test", "session-1", "check approvals")
+            .await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let message_id = mock.state().messages_inserted[0].id.clone();
+        let already_seen = !test_server
+            .server
+            .teamclaw
+            .as_mut()
+            .expect("test server has a SessionManager")
+            .should_process_message("session-1", &message_id);
+        assert!(
+            already_seen,
+            "cron prompt id should be spent so re-ingestion is a no-op"
+        );
     }
 }

--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -35,6 +35,21 @@ pub(crate) struct CronTurnDone {
     pub(crate) reply_tx: oneshot::Sender<String>,
 }
 
+/// One ACP event of a cron-driven turn, sent from the turn task to the active
+/// run loop so it can reach `session/live`.
+///
+/// The turn task owns the agent's event channel for the whole turn, so
+/// `poll_events` — and with it `forward_agent_event` — never sees these frames.
+/// Publishing is what `forward_agent_event` would have done; it has to happen
+/// on the loop because it needs `&self.teamclaw`, which is not `Send`.
+pub(crate) struct CronTurnEvent {
+    /// Runtime key (8-char), not the actor id.
+    pub(crate) agent_id: String,
+    /// Set only for subagent sessions, matching `forward_agent_event`.
+    pub(crate) child_acp_session_id: Option<String>,
+    pub(crate) event: crate::proto::amux::AcpEvent,
+}
+
 /// Caches the `(cloud_session_id, acp_session_id)` pair for each cron logical
 /// `session_key`.
 ///
@@ -280,8 +295,10 @@ impl DaemonServer {
         // itself for the whole turn duration.
         let agents = self.agents.clone();
         let done_tx = self.cron_turn_done_tx.clone();
+        let event_tx = self.cron_turn_event_tx.clone();
         tokio::spawn(async move {
-            let turn_result = Self::drive_cron_turn(&agents, &acp_sid, &message, timeout).await;
+            let turn_result =
+                Self::drive_cron_turn(&agents, &acp_sid, &message, timeout, event_tx).await;
             let _ = done_tx
                 .send(CronTurnDone {
                     turn_result,
@@ -370,6 +387,62 @@ impl DaemonServer {
         };
 
         let _ = reply_tx.send(result.to_string());
+    }
+
+    /// Publish one event of a cron-driven turn to `session/live`.
+    ///
+    /// This is `forward_agent_event`'s publish tail and deliberately nothing
+    /// else: the turn task has already fed the event to the aggregator, and
+    /// ingesting it a second time here would emit the reply twice. Without it
+    /// a cron session sat frozen — "Run Now" navigates you into the thread and
+    /// nothing moves until the whole answer appears at once.
+    pub(super) async fn publish_cron_turn_event(&mut self, ev: CronTurnEvent) {
+        use crate::proto::amux;
+
+        let CronTurnEvent {
+            agent_id,
+            child_acp_session_id,
+            mut event,
+        } = ev;
+
+        // Same stamping rule as `forward_agent_event`: only agent-reply events
+        // are model-attributable.
+        if matches!(
+            event.event,
+            Some(amux::acp_event::Event::Output(_)) | Some(amux::acp_event::Event::Thinking(_))
+        ) {
+            if let Some(model) = self.agents.lock().await.current_model(&agent_id).cloned() {
+                event.model = model;
+            }
+        }
+
+        let (seq, turn_id) = {
+            let mut agents = self.agents.lock().await;
+            let seq = agents
+                .get_handle_mut(&agent_id)
+                .map(|h| h.next_sequence())
+                .unwrap_or(0);
+            let turn_id = agents
+                .aggregator(&agent_id)
+                .and_then(|a| a.current_turn_id())
+                .unwrap_or("")
+                .to_string();
+            (seq, turn_id)
+        };
+
+        let envelope = amux::Envelope {
+            runtime_id: agent_id.clone(),
+            actor_id: self.config.actor.id.clone(),
+            source_peer_id: String::new(),
+            timestamp: chrono::Utc::now().timestamp(),
+            sequence: seq,
+            turn_id,
+            acp_session_id: child_acp_session_id.unwrap_or_default(),
+            payload: Some(amux::envelope::Payload::AcpEvent(event)),
+        };
+        self.history.append(&agent_id, &envelope);
+        self.publish_envelope_to_sessions(&agent_id, &envelope)
+            .await;
     }
 
     /// Cron cloud session title, matching what the desktop expects: `Cron: <job
@@ -623,6 +696,7 @@ impl DaemonServer {
         acp_sid: &str,
         prompt: &str,
         timeout: Duration,
+        event_tx: tokio::sync::mpsc::Sender<CronTurnEvent>,
     ) -> anyhow::Result<crate::runtime::turn_aggregator::EmittedMessage> {
         // 1. Per-agent turn lock (held for the whole turn) under a brief
         //    manager lock.
@@ -672,6 +746,23 @@ impl DaemonServer {
                 Ok(None) => break Err(anyhow::anyhow!("ACP event channel closed before reply")),
                 Err(_) => break Err(anyhow::anyhow!("ACP turn timed out")),
             };
+
+            // Hand the loop a copy for `session/live` before consuming it, so
+            // the desktop renders the turn as it happens. Best-effort: a full
+            // channel drops frames rather than stalling the model turn behind
+            // the UI, and the finalized reply lands regardless.
+            let forwarded = CronTurnEvent {
+                agent_id: agent_id.clone(),
+                child_acp_session_id: Some(event.acp_session_id.clone())
+                    .filter(|sid| !sid.is_empty() && sid != acp_sid),
+                event: event.event.clone(),
+            };
+            if event_tx.try_send(forwarded).is_err() {
+                tracing::debug!(
+                    agent_id = %agent_id,
+                    "cron: live event channel full; dropping one streaming frame"
+                );
+            }
 
             if let Some(crate::proto::amux::acp_event::Event::Error(err)) = &event.event.event {
                 let details = if err.details.is_empty() {

--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -578,13 +578,31 @@ impl DaemonServer {
         let Some(keep) = keep else {
             return ids;
         };
-        let superseded: Vec<String> = ids.into_iter().filter(|id| id != &keep).collect();
-        warn!(
-            session_id = %session_id,
-            keep = %keep,
-            superseded = ?superseded,
-            "coalesce_session_runtimes: stopping duplicate live runtimes before fanout"
-        );
+        // Same carve-out as `apply_start_runtime`: a runtime that is mid-turn
+        // keeps running. It is still dropped from the routing set, so the
+        // prompt goes to `keep` alone — but stopping it here would kill an
+        // in-flight cron/gateway answer just because a message arrived.
+        let (in_flight, superseded): (Vec<String>, Vec<String>) = {
+            let agents = self.agents.lock().await;
+            ids.into_iter()
+                .filter(|id| id != &keep)
+                .partition(|id| agents.turn_in_flight(id))
+        };
+        if !in_flight.is_empty() {
+            info!(
+                session_id = %session_id,
+                in_flight = ?in_flight,
+                "coalesce_session_runtimes: left mid-turn runtimes running rather than stopping them"
+            );
+        }
+        if !superseded.is_empty() {
+            warn!(
+                session_id = %session_id,
+                keep = %keep,
+                superseded = ?superseded,
+                "coalesce_session_runtimes: stopping duplicate live runtimes before fanout"
+            );
+        }
         for rid in &superseded {
             self.agents.lock().await.stop_runtime(rid).await;
             self.remote_tool_turn_contexts

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -260,32 +260,50 @@ impl DaemonServer {
         // and only a single runtime remains to answer. Also protects against
         // misbehaving clients that fire RuntimeStart twice (picker + inline
         // mention race on the desktop client pre-4210aad8).
-        let (existing_runtime, superseded): (Option<String>, Vec<String>) = if session_id.is_empty()
-        {
-            (None, Vec::new())
-        } else {
-            let agents = self.agents.lock().await;
-            let mut reuse: Option<String> = None;
-            let mut stale: Vec<String> = Vec::new();
-            for rid in agents.runtime_ids_for_session(session_id) {
-                match agents.get_handle(&rid) {
-                    Some(h)
-                        if reuse.is_none()
-                            && h.agent_type == agent_type
-                            && same_runtime_workspace(
-                                &h.worktree,
-                                &h.workspace_id,
-                                &resolved_worktree,
-                                &ws_id,
-                            ) =>
-                    {
-                        reuse = Some(rid);
+        // One runtime is spared that collapse: whichever is mid-turn. Cron's
+        // "Run Now" navigates the desktop straight into the run's session, and
+        // the RuntimeStart that follows arrives while the cron runtime is still
+        // answering — in a different workspace, so it never matches the reuse
+        // key. Superseding it there stopped the runtime mid-answer, and the run
+        // ended as a prompt with no reply. A busy runtime is left running to
+        // finish; it is not routed to (it is not `reuse`), and the next
+        // routing-time `coalesce_session_runtimes` reaps it once it is idle.
+        let (existing_runtime, superseded, in_flight): (Option<String>, Vec<String>, Vec<String>) =
+            if session_id.is_empty() {
+                (None, Vec::new(), Vec::new())
+            } else {
+                let agents = self.agents.lock().await;
+                let mut reuse: Option<String> = None;
+                let mut stale: Vec<String> = Vec::new();
+                let mut busy: Vec<String> = Vec::new();
+                for rid in agents.runtime_ids_for_session(session_id) {
+                    match agents.get_handle(&rid) {
+                        Some(h)
+                            if reuse.is_none()
+                                && h.agent_type == agent_type
+                                && same_runtime_workspace(
+                                    &h.worktree,
+                                    &h.workspace_id,
+                                    &resolved_worktree,
+                                    &ws_id,
+                                ) =>
+                        {
+                            reuse = Some(rid);
+                        }
+                        _ if agents.turn_in_flight(&rid) => busy.push(rid),
+                        _ => stale.push(rid),
                     }
-                    _ => stale.push(rid),
                 }
-            }
-            (reuse, stale)
-        };
+                (reuse, stale, busy)
+            };
+
+        if !in_flight.is_empty() {
+            info!(
+                session_id,
+                in_flight = ?in_flight,
+                "apply_start_runtime: left mid-turn runtimes running rather than superseding them"
+            );
+        }
 
         if !superseded.is_empty() {
             for rid in &superseded {

--- a/apps/daemon/src/runtime/cursor_sdk/permission.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/permission.rs
@@ -82,29 +82,103 @@ fn params_from_input(tool_input: &Value) -> HashMap<String, String> {
     }
 }
 
-/// Route a hook request to the session running in `worktree`. A worktree can
-/// host more than one runtime session, but only the one mid-turn can be making
-/// a tool call, so an active turn is the discriminator.
-fn route_for_worktree(shared: &Arc<Shared>, worktree: &str) -> Option<RouteSnapshot> {
+/// Fields a Cursor hook request might carry an agent/conversation id under.
+/// The SDK's `preToolUse` payload is forwarded verbatim, so if any of these
+/// name a live cursor agent we can route exactly instead of guessing.
+const AGENT_ID_FIELDS: &[&str] = &[
+    "agentId",
+    "agent_id",
+    "conversationId",
+    "conversation_id",
+    "threadId",
+    "thread_id",
+    "sessionId",
+    "session_id",
+];
+
+fn agent_id_from_request(request: &Value) -> Option<String> {
+    let obj = request.as_object()?;
+    AGENT_ID_FIELDS.iter().find_map(|key| {
+        obj.get(*key)
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    })
+}
+
+/// Pick the route a hook request belongs to.
+///
+/// Resolution order:
+///
+///  1. **An id in the request that names a live cursor agent.** Exact, and the
+///     only branch that is not a guess. The SDK documents `preToolUse` as
+///     carrying `tool_name` + `tool_input` + `cwd`, so this often misses — it
+///     costs one map lookup and is worth it when it hits.
+///  2. **The worktree's mid-turn routes** — a tool call comes from a turn.
+///  3. **The strictest policy among those.** A worktree can host more than one
+///     live session, and since a mid-turn runtime is no longer superseded
+///     (a cron run and a desktop session now stay live side by side) more than
+///     one can be answering at once. The two ways of guessing wrong are not
+///     symmetric: asking about a call that would have been allowed is noise,
+///     while auto-allowing a call that should have been shown to a human grants
+///     a permission the user never gave. So ambiguity resolves toward asking.
+fn route_for_request(
+    shared: &Arc<Shared>,
+    worktree: &str,
+    request: &Value,
+) -> Option<RouteSnapshot> {
     let routes = shared.routes.lock();
-    let mut candidates: Vec<&String> = routes
-        .iter()
-        .filter(|(_, r)| r.worktree == worktree)
-        .map(|(id, _)| id)
-        .collect();
-    candidates.sort();
-    let chosen = candidates
-        .iter()
-        .find(|id| routes.get(**id).is_some_and(|r| r.turn_active))
-        .or_else(|| candidates.first())?;
-    let route = routes.get(*chosen)?;
-    Some(RouteSnapshot {
-        session_id: (*chosen).clone(),
+
+    let snapshot = |session_id: &String, route: &super::Route| RouteSnapshot {
+        session_id: session_id.clone(),
         event_tx: route.event_tx.clone(),
         full_access: route.permission.is_full_access(),
         requester: route.turn_requester.clone(),
         reply_to: route.turn_reply_to.clone(),
-    })
+    };
+
+    if let Some(id) = agent_id_from_request(request) {
+        if let Some((session_id, route)) = routes
+            .iter()
+            .find(|(session_id, route)| route.agent_id == id || session_id.as_str() == id)
+        {
+            return Some(snapshot(session_id, route));
+        }
+    }
+
+    let mut candidates: Vec<(&String, &super::Route)> = routes
+        .iter()
+        .filter(|(_, r)| r.worktree == worktree)
+        .collect();
+    if candidates.is_empty() {
+        return None;
+    }
+    // Sorted so the tie-break below is deterministic rather than hash order.
+    candidates.sort_by(|a, b| a.0.cmp(b.0));
+
+    let active: Vec<(&String, &super::Route)> = candidates
+        .iter()
+        .filter(|(_, r)| r.turn_active)
+        .cloned()
+        .collect();
+    let pool = if active.is_empty() {
+        candidates
+    } else {
+        active
+    };
+
+    if pool.len() > 1 {
+        warn!(
+            worktree,
+            routes = pool.len(),
+            "cursor permission: worktree hosts several candidate sessions; using the strictest policy"
+        );
+    }
+    let (session_id, route) = pool
+        .iter()
+        .min_by_key(|(_, r)| u8::from(r.permission.is_full_access()))?;
+    Some(snapshot(session_id, route))
 }
 
 struct RouteSnapshot {
@@ -135,7 +209,7 @@ pub async fn handle(payload: &Value) -> Value {
         .map(canonical_dir)
         .unwrap_or_default();
 
-    let Some(route) = route_for_worktree(&shared, &worktree) else {
+    let Some(route) = route_for_request(&shared, &worktree, request) else {
         warn!(
             worktree,
             tool_name, "cursor permission: no session for worktree; allowing"
@@ -365,6 +439,145 @@ mod tests {
             "worktree": "/tmp/does-not-need-to-exist",
             "request": { "tool_name": tool, "tool_input": { "command": "rm -rf /" } }
         })
+    }
+
+    /// `register_route` with control over the fields the router discriminates on.
+    fn register_route_as(
+        session_id: &str,
+        agent_id: &str,
+        worktree: &str,
+        permission: crate::runtime::permission_policy::PermissionPolicy,
+        turn_active: bool,
+    ) -> tokio::sync::mpsc::Receiver<AcpEventFrame> {
+        let (event_tx, event_rx) = tokio::sync::mpsc::channel(8);
+        super::super::shared().routes.lock().insert(
+            session_id.to_string(),
+            super::super::Route {
+                event_tx,
+                permission,
+                worktree: worktree.to_string(),
+                agent_id: agent_id.to_string(),
+                turn_active,
+                turn_reply_to: None,
+                turn_requester: None,
+                translate: Default::default(),
+                model: "cursor/composer-2.5".into(),
+            },
+        );
+        event_rx
+    }
+
+    /// A cron run and a desktop session can now be live in the same worktree at
+    /// once — a mid-turn runtime is no longer superseded — and the hook carries
+    /// no session identity. Guessing the full-access one would hand out a
+    /// permission the user never granted, so ambiguity must resolve to asking.
+    #[tokio::test]
+    async fn two_live_sessions_in_one_worktree_resolve_to_the_strictest() {
+        use crate::runtime::permission_policy::PermissionPolicy;
+        let worktree = "/tmp/cursor-perm-ambiguous";
+        // "a-cron" sorts first, so the old id-order pick would have taken the
+        // full-access route and silently allowed.
+        let _cron = register_route_as(
+            "cursor:a-cron",
+            "a-cron",
+            worktree,
+            PermissionPolicy::Full,
+            true,
+        );
+        let mut desktop_rx = register_route_as(
+            "cursor:b-desktop",
+            "b-desktop",
+            worktree,
+            PermissionPolicy::Ask,
+            true,
+        );
+
+        let shared = super::super::shared();
+        let chosen = route_for_request(&shared, worktree, &json!({ "tool_name": "shell" }))
+            .expect("a route is found");
+        assert_eq!(chosen.session_id, "cursor:b-desktop");
+        assert!(!chosen.full_access);
+        assert!(desktop_rx.try_recv().is_err(), "nothing emitted yet");
+    }
+
+    /// An id in the request beats the worktree guess entirely.
+    #[tokio::test]
+    async fn an_agent_id_in_the_request_routes_exactly() {
+        use crate::runtime::permission_policy::PermissionPolicy;
+        let worktree = "/tmp/cursor-perm-exact";
+        let _cron = register_route_as(
+            "cursor:exact-cron",
+            "exact-cron",
+            worktree,
+            PermissionPolicy::Full,
+            true,
+        );
+        let _desktop = register_route_as(
+            "cursor:exact-desktop",
+            "exact-desktop",
+            worktree,
+            PermissionPolicy::Ask,
+            true,
+        );
+
+        let shared = super::super::shared();
+        let chosen = route_for_request(
+            &shared,
+            worktree,
+            &json!({ "tool_name": "shell", "conversationId": "exact-cron" }),
+        )
+        .expect("a route is found");
+        assert_eq!(chosen.session_id, "cursor:exact-cron");
+        assert!(
+            chosen.full_access,
+            "an exact id must win over the strict fallback"
+        );
+    }
+
+    /// Only one session mid-turn: it is the answer regardless of policy, and an
+    /// idle sibling must not drag the pick toward "ask".
+    #[tokio::test]
+    async fn a_single_mid_turn_session_wins_over_idle_siblings() {
+        use crate::runtime::permission_policy::PermissionPolicy;
+        let worktree = "/tmp/cursor-perm-single-active";
+        let _idle = register_route_as(
+            "cursor:a-idle",
+            "a-idle",
+            worktree,
+            PermissionPolicy::Ask,
+            false,
+        );
+        let _busy = register_route_as(
+            "cursor:z-busy",
+            "z-busy",
+            worktree,
+            PermissionPolicy::Full,
+            true,
+        );
+
+        let shared = super::super::shared();
+        let chosen = route_for_request(&shared, worktree, &json!({ "tool_name": "shell" }))
+            .expect("a route is found");
+        assert_eq!(chosen.session_id, "cursor:z-busy");
+        assert!(chosen.full_access);
+    }
+
+    #[test]
+    fn agent_id_is_read_from_any_known_field() {
+        assert_eq!(
+            agent_id_from_request(&json!({ "agentId": "a1" })).as_deref(),
+            Some("a1")
+        );
+        assert_eq!(
+            agent_id_from_request(&json!({ "thread_id": " t2 " })).as_deref(),
+            Some("t2")
+        );
+        assert_eq!(agent_id_from_request(&json!({ "agentId": "" })), None);
+        assert_eq!(
+            agent_id_from_request(&json!({ "tool_name": "shell" })),
+            None
+        );
+        assert_eq!(agent_id_from_request(&json!("scalar")), None);
     }
 
     #[tokio::test]

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -1120,6 +1120,20 @@ impl RuntimeManager {
         self.agents.get(agent_id)
     }
 
+    /// Whether this runtime is driving a turn right now.
+    ///
+    /// The unattended drive paths (cron's `drive_cron_turn`, the gateway's
+    /// `AmuxdAgentHandle::send_prompt`) hold the handle's `turn_lock` for the
+    /// whole turn, so a failed `try_lock` means "an answer is in flight".
+    /// Runtime bookkeeping consults this before stopping anything: a stopped
+    /// runtime takes its unfinished turn with it, and the caller that asked
+    /// for the answer just never gets one.
+    pub fn turn_in_flight(&self, runtime_id: &str) -> bool {
+        self.get_handle(runtime_id)
+            .map(|h| h.turn_lock.try_lock().is_err())
+            .unwrap_or(false)
+    }
+
     /// Find an existing live runtime matching the (session_id, agent_type,
     /// workspace_id) key. Used by `apply_start_runtime` to dedupe duplicate
     /// `RuntimeStart` RPCs from misbehaving clients into a single spawn.
@@ -2518,6 +2532,30 @@ mod tests {
         assert_eq!(
             mgr.resolve_permission_runtime_key("cd073767").as_deref(),
             Some("cd073767")
+        );
+    }
+
+    /// The signal `apply_start_runtime` / `coalesce_session_runtimes` use to
+    /// decide a runtime must not be stopped. Cron holds this lock for the whole
+    /// turn; without the check, the RuntimeStart that follows "Run Now"'s jump
+    /// into the session stopped the runtime mid-answer.
+    #[tokio::test]
+    async fn turn_in_flight_tracks_the_handles_turn_lock() {
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.add_test_runtime("rt1", "agent_A", "session_S");
+        assert!(!mgr.turn_in_flight("rt1"), "idle runtime is not mid-turn");
+        assert!(
+            !mgr.turn_in_flight("missing"),
+            "unknown runtime is not busy"
+        );
+
+        let turn_lock = mgr.get_handle("rt1").unwrap().turn_lock.clone();
+        let guard = turn_lock.lock().await;
+        assert!(mgr.turn_in_flight("rt1"), "a held turn_lock reads as busy");
+        drop(guard);
+        assert!(
+            !mgr.turn_in_flight("rt1"),
+            "released turn_lock reads as idle"
         );
     }
 

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -36,6 +36,30 @@ impl AgentLaunchConfig {
     }
 }
 
+/// Prefix `create_gateway_session_with_model` stamps onto the `workspace_id`
+/// of every gateway/cron runtime (`gateway:<binding>`). It is the only marker
+/// of "this runtime is unattended" that survives to disk, so the resume path
+/// reads it back to restore full access — see [`is_gateway_workspace_id`].
+pub const GATEWAY_WORKSPACE_ID_PREFIX: &str = "gateway:";
+
+/// Whether a stored `workspace_id` belongs to a gateway/cron runtime.
+pub fn is_gateway_workspace_id(workspace_id: &str) -> bool {
+    workspace_id.starts_with(GATEWAY_WORKSPACE_ID_PREFIX)
+}
+
+/// Restore the unattended shape onto an env assembled for a *resume*.
+///
+/// The env builders produce a desktop-shaped runtime (`is_gateway: false`,
+/// which [`SpawnRuntimeEnv::permission_policy`] reads as "ask"). Resuming is
+/// not a policy change, but `attach()` replaces the session's route with
+/// whatever it is handed — so without this a resumed gateway/cron session
+/// quietly starts asking for approvals nobody is there to answer.
+pub fn restore_gateway_shape_for_resume(env: &mut SpawnRuntimeEnv, workspace_id: &str) {
+    if is_gateway_workspace_id(workspace_id) {
+        env.is_gateway = true;
+    }
+}
+
 /// Environment bundle passed when spawning an ACP-backed agent runtime.
 #[derive(Debug, Clone, Default)]
 pub struct SpawnRuntimeEnv {
@@ -1512,7 +1536,7 @@ impl RuntimeManager {
             }
         };
 
-        let workspace_id = format!("gateway:{binding}");
+        let workspace_id = format!("{GATEWAY_WORKSPACE_ID_PREFIX}{binding}");
         let agent_id = self
             .start_runtime_with_model(
                 agent_type,
@@ -2533,6 +2557,36 @@ mod tests {
             mgr.resolve_permission_runtime_key("cd073767").as_deref(),
             Some("cd073767")
         );
+    }
+
+    /// A resumed cron/gateway runtime must come back with the policy it ran
+    /// under. The env builders always say "desktop", so without the restore a
+    /// resume silently downgrades the session to approval prompts.
+    #[test]
+    fn resume_restores_full_access_for_gateway_runtimes() {
+        let mut env = SpawnRuntimeEnv::default();
+        restore_gateway_shape_for_resume(&mut env, "gateway:cron://cron/job-1/run-1");
+        assert!(env.is_gateway);
+        assert_eq!(env.permission_policy(), PermissionPolicy::Full);
+
+        // A desktop workspace id is untouched: those runtimes have a human
+        // watching, and approvals are the point.
+        let mut env = SpawnRuntimeEnv::default();
+        restore_gateway_shape_for_resume(&mut env, "e78b4c4c-95a3-48bf-9c6f-8eee385cd0d2");
+        assert!(!env.is_gateway);
+        assert_eq!(env.permission_policy(), PermissionPolicy::Ask);
+    }
+
+    /// An explicit policy still wins — a cron job that opted back into "ask"
+    /// keeps asking even though the restore marks it as a gateway runtime.
+    #[test]
+    fn restore_does_not_override_an_explicit_permission() {
+        let mut env = SpawnRuntimeEnv {
+            permission: Some(PermissionPolicy::Ask),
+            ..Default::default()
+        };
+        restore_gateway_shape_for_resume(&mut env, "gateway:cron://cron/job-1/run-1");
+        assert_eq!(env.permission_policy(), PermissionPolicy::Ask);
     }
 
     /// The signal `apply_start_runtime` / `coalesce_session_runtimes` use to

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -28,7 +28,10 @@ pub use handle::{InjectedContextItem, PendingMessage, RuntimeHandle};
 pub use instruction_delivery::{
     resolve_instruction_delivery, skips_buffered_inject, InstructionDelivery,
 };
-pub use manager::{AgentLaunchConfig, CheckedOutTurn, RuntimeManager, SpawnRuntimeEnv};
+pub use manager::{
+    restore_gateway_shape_for_resume, AgentLaunchConfig, CheckedOutTurn, RuntimeManager,
+    SpawnRuntimeEnv,
+};
 pub use permission_policy::PermissionPolicy;
 // Kept importable for external callers/tests even though in-crate code now
 // goes through `AgentBackend`.

--- a/apps/daemon/src/runtime/opencode_http/events.rs
+++ b/apps/daemon/src/runtime/opencode_http/events.rs
@@ -291,7 +291,7 @@ async fn handle_permission_asked(
     // Register a lightweight child route (parent event_tx + directory) so the
     // ask reaches the desktop while reply still targets this session_id.
     if !shared.routes.lock().contains_key(session_id) {
-        if let Some(parent_id) = resolve_parent_session_id(shared, session_id).await {
+        if let Some(parent_id) = resolve_routed_ancestor_session_id(shared, session_id).await {
             if !shared.ensure_child_route(session_id, &parent_id) {
                 warn!(
                     session_id,
@@ -301,7 +301,14 @@ async fn handle_permission_asked(
                 return;
             }
         } else {
-            warn!(session_id, "permission.asked for unrouted session");
+            // Nothing to reply on and nobody to ask: opencode keeps waiting on
+            // this permission, so the turn stalls until its timeout. Say so —
+            // the bare "unrouted session" line read like a harmless skip.
+            warn!(
+                session_id,
+                permission_id = %permission_id,
+                "permission.asked: no routed ancestor session; dropping (the turn will stall on it)"
+            );
             return;
         }
     }
@@ -386,6 +393,34 @@ fn maybe_register_subagent_route(
 
 /// Look up `Session.parentID` for an unrouted child via `GET /session/{id}`
 /// across known worktree directories.
+/// Walk up from `child_id` to the nearest ancestor that has a live route.
+///
+/// `resolve_parent_session_id` climbs exactly one level, which is all a
+/// `task` subagent needs. A subagent that spawns its own subagent is one level
+/// deeper: its parent is itself unrouted, `ensure_child_route` refuses to
+/// adopt it, and the permission ask is dropped — the turn then waits on an
+/// approval that was never shown to anyone. Climbing until a routed ancestor
+/// appears keeps those asks reachable.
+const MAX_SUBAGENT_PARENT_DEPTH: usize = 8;
+
+async fn resolve_routed_ancestor_session_id(
+    shared: &Arc<Shared>,
+    child_id: &str,
+) -> Option<String> {
+    let mut current = child_id.to_string();
+    for _ in 0..MAX_SUBAGENT_PARENT_DEPTH {
+        let parent = resolve_parent_session_id(shared, &current).await?;
+        if shared.routes.lock().contains_key(&parent) {
+            return Some(parent);
+        }
+        if parent == current {
+            return None;
+        }
+        current = parent;
+    }
+    None
+}
+
 async fn resolve_parent_session_id(shared: &Arc<Shared>, child_id: &str) -> Option<String> {
     {
         let routes = shared.routes.lock();

--- a/apps/daemon/src/teamclaw/session_manager.rs
+++ b/apps/daemon/src/teamclaw/session_manager.rs
@@ -1298,7 +1298,10 @@ impl SessionManager {
         true
     }
 
-    #[allow(dead_code)]
+    /// Publish an already-persisted message on `session/{id}/live`.
+    ///
+    /// Mentions ride along from the message's own metadata, so a subscriber
+    /// sees the same envelope it would have for a desktop-sent message.
     pub async fn publish_live_message(
         &self,
         session_id: &str,
@@ -1306,7 +1309,9 @@ impl SessionManager {
     ) -> crate::error::Result<()> {
         let envelope = teamclaw::SessionMessageEnvelope {
             message: Some(message.clone()),
-            mention_actor_ids: vec![],
+            mention_actor_ids: crate::daemon::session_events::parse_mention_actor_ids(
+                &message.metadata_json,
+            ),
         };
         self.live_publisher
             .publish_message(session_id, &message.sender_actor_id, &envelope)

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -612,11 +612,22 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
         useCurrentTeamStore.getState().team?.id ??
         null;
       if (!teamId) return;
+      // Start on the model this session has already been running, not on
+      // whatever the device MRU offers. Opening a cron session used to spawn a
+      // second runtime on the daemon's default model, and since the pill
+      // reports the live runtime, a job pinned to Haiku read as "Big Pickle" —
+      // and the next message really would have run on it.
+      const established =
+        resolveSessionEstablishedModel(
+          useSessionMessageStore.getState().messages[activeSessionId],
+          agentActorId,
+        )?.trim() || undefined;
       void import("@/lib/teamclaw/ensure-agent-runtime").then(({ ensureAgentRuntimesForSession }) => {
         void ensureAgentRuntimesForSession({
           sessionId: activeSessionId,
           teamId,
           agentActorIds: [agentActorId],
+          modelId: established,
           reason: "session_auto_engage",
         });
       });

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -62,6 +62,32 @@ async function detectNewRunSession(
 }
 
 /**
+ * Record the job's model as this session's pick, for the local daemon agent.
+ *
+ * The pick is the top of `selectAgentModel`'s order, so the composer pill names
+ * the model the run is actually on, and the RuntimeStart the desktop fires on
+ * arrival starts its runtime there too. Everything cheaper was too late: the
+ * transcript is the other source of the session's model, and on arrival it
+ * holds one message the desktop has not fetched yet.
+ *
+ * Best-effort — a job with no pinned model, or an unresolvable daemon actor,
+ * simply leaves the existing resolution order alone.
+ */
+async function pinJobModelToSession(sessionId: string, jobId: string): Promise<void> {
+  try {
+    const model = useCronStore.getState().jobs.find((j) => j.id === jobId)?.payload.model?.trim()
+    if (!model) return
+    const { getLocalDaemonActorId } = await import('@/lib/daemon-agent-admin')
+    const agentActorId = (await getLocalDaemonActorId())?.trim()
+    if (!agentActorId) return
+    const { useAgentModelPickStore } = await import('@/stores/agent-model-pick-store')
+    useAgentModelPickStore.getState().setPick(sessionId, agentActorId, model)
+  } catch {
+    // Non-fatal: the pill falls back to the transcript / retain order.
+  }
+}
+
+/**
  * Fire-and-forget: keep polling this run after we've already navigated to its
  * session, and if it ends in failure/timeout, seed a fallback message into the
  * session so opening it later (e.g. from the plain session list, not the run
@@ -442,6 +468,12 @@ export const useCronStore = create<CronState>((set, get) => ({
           // Non-fatal: the session still exists and will show up once the
           // list store's next reload picks it up.
         }
+        // Pin the job's model onto the session before navigating. We land in a
+        // session whose only message is a prompt the desktop has not fetched
+        // yet, so nothing else can tell the composer — or the runtime the
+        // desktop is about to start — which model this run is on; both fell
+        // back to the device MRU and named a model the job never chose.
+        await pinJobModelToSession(sessionId, jobId)
         // Keep watching after we navigate away — if the run ends in failure,
         // seed an explanatory message into the session (see fn doc above).
         void watchRunOutcomeAndSeedFailureMessage(jobId, sessionId, activeScope, selectedWorkspacePath)


### PR DESCRIPTION
"Run Now" produced a session with a prompt and no reply. Chasing that turned up five separate defects on the path between the cron scheduler and the chat pane, plus two in the permission plumbing around it.

## The one that started it

Run Now navigates the desktop into the run's session. The `RuntimeStart` that follows comes from the desktop's own workspace, never matches the cron runtime's reuse key, and `apply_start_runtime` superseded — stopped — the cron runtime 1.4s into its turn:

```
06:45:36.585  cron: prepared cloud session (eager)    session=2167e801…
06:45:36.699  opencode session attached               agent=0a3c6060
06:45:36.765  cron: persisted user prompt
06:45:38.166  apply_start_runtime  workspace="Copilot 361"  session=2167e801…
06:45:38.166  agent stopped        agent_id=0a3c6060
06:45:38.166  WARN closing an in-flight turn: its runtime went away mid-turn
06:45:38.351  WARN route_session_message: empty mention_actor_ids; message will be silent-queued
```

Scheduled runs were fine — nobody navigates into those.

Whichever runtime is mid-turn is now spared. The unattended drive paths hold the handle's `turn_lock` for the whole turn, so `try_lock` is an exact "answer in flight" signal. A busy runtime is still dropped from the routing set (no duplicate replies) and reaped by the next `coalesce` once idle.

## The rest

- **The prompt didn't @mention anyone.** It is sent as a human admin member but carried no `mention_actor_ids`, so the chat showed an un-addressed message and every catchup re-queued it as drive-by chatter. Now stamped, with the message id burned in the ingestion dedup gate so a catchup racing the in-flight turn can't fire a second prompt off the new mention.
- **The model was the device MRU, not the job's.** Run Now lands in a session holding one message the desktop hasn't fetched, so nothing named a model. A job pinned to Haiku ran its own runtime on Haiku while the desktop's ran on MiniMax — and the composer pill, which reports the live runtime, said MiniMax. Three places agree now: the prompt carries the model its runtime settled on, `runJob` pins it as the session's pick before navigating, and solo auto-engage passes the session's established model to `RuntimeStart`.
- **Nothing streamed.** `drive_cron_turn` owns the agent's event channel for the whole turn, so `forward_agent_event` never saw a frame — the thread sat still, then the entire answer appeared at once. The turn task now hands each event to the run loop, which publishes it. Publishing has to happen there (`&self.teamclaw` is not `Send`), and it is deliberately only `forward_agent_event`'s publish tail: the aggregator already ingested the event on the turn task. Bounded, `try_send`-only, so a slow UI can never backpressure a model turn.
- **The prompt vanished.** It was persisted but never published on `session/live`, so the desktop could only *pull* it — and Run Now navigates in before the row is queryable. Now published like any other message; the dedup burn above is what makes that safe.

## Permission plumbing

- **A resume silently downgraded full access to "ask".** `resume_stored_collab_runtimes` rebuilds the spawn env through the desktop builders, which always report `is_gateway: false`, and `attach()` *replaces* the session's route. The stored `gateway:<binding>` workspace id is the one marker of "unattended" that survives to disk; read it back. An explicit policy (a job that opted back into asking) still wins.
- **Deep subagent permission asks were dropped.** A `task` subagent that spawns its own subagent is two levels down; its parent is itself unrouted, so the ask was discarded and opencode waited on an approval nobody ever saw. Now climbs to the nearest routed ancestor. *Not reproduced in the wild — the log line that revealed it fired once and I could not make it fire again.*
- **Cursor's hook guessed its way into full access.** Its `preToolUse` payload carries no session identity, so the daemon matched by worktree and took the first mid-turn route in id order. That was safe while a worktree hosted one live session; it no longer does, because of the fix at the top. Routing is now: an id in the request that names a live cursor agent → the worktree's mid-turn routes → the **strictest** policy among them. Guessing wrong is not symmetric — asking about a call that would have been allowed is noise, auto-allowing one that should have been asked grants a permission nobody gave.

## Verification

Driven through the real UI (tauri-mcp), against the rebuilt sidecar:

| | before | after |
|---|---|---|
| run status | `failed` — `ACP event channel closed before reply` | `success` |
| cron runtime model | `claude-haiku-4-5` | `claude-haiku-4-5` |
| desktop runtime model | `MiniMax-M2.5` ✗ | `claude-haiku-4-5` ✓ |
| streaming frames reaching the client | 0 | 38 (`statusChange`, 30×`output`, `toolUse`, `toolResult`) |
| prompt on screen mid-turn | absent | `mac-mini  run test and replay who you are?` |

The model check is a controlled one: the job was pinned to Haiku while the device MRU was MiniMax, so "both agree" can't be a coincidence — an earlier run where they matched turned out to be exactly that.

One AgentReply per run throughout, and no `mention matched; sending prompt` for the cron prompt's own id — the loopback copy is dropped as intended.

995 daemon tests, 2589 frontend tests, `cargo clippy` clean, `tsc --noEmit` clean, rustfmt clean on the touched files (per-file, not `cargo fmt` — that crate isn't fmt-clean).

## Not fixed here

The chat header reads `New Chat` instead of `Cron: <job>`. It isn't a display bug: `GET /v1/sessions/:id` 404s because cron sessions never add the person who triggered them as a participant, so `ensureCronSessionVisible` throws on its first line and the row never enters the list. Messages still render only because live events bypass RLS. The fix wants `joinSession` (the SECURITY DEFINER RPC that exists for exactly this), and is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)