### PR TITLE
fix(claude): stabilize skills flow and add diagnostics

### DIFF
--- a/apps/daemon/claude-bridge/src/main.mjs
+++ b/apps/daemon/claude-bridge/src/main.mjs
@@ -146,12 +146,20 @@ function makeCanUseTool(sessionKey) {
     })
 }
 
-function handleAssistantMessage(sessionKey, message) {
+function handleAssistantMessage(sessionKey, session, message) {
+  // Top-level text/thinking already streamed through stream_event deltas
+  // (includePartialMessages); re-emitting the completed block would duplicate
+  // it. Subagent messages (parent_tool_use_id set) never stream, keep whole.
+  const topLevel = message.parent_tool_use_id == null
   for (const block of message.message?.content ?? []) {
     if (block.type === 'text' && block.text) {
-      emit({ event: 'assistant_delta', sessionId: sessionKey, text: block.text })
+      if (!(topLevel && session.streamedText)) {
+        emit({ event: 'assistant_delta', sessionId: sessionKey, text: block.text })
+      }
     } else if (block.type === 'thinking' && block.thinking) {
-      emit({ event: 'thinking_delta', sessionId: sessionKey, text: block.thinking })
+      if (!(topLevel && session.streamedThinking)) {
+        emit({ event: 'thinking_delta', sessionId: sessionKey, text: block.thinking })
+      }
     } else if (block.type === 'tool_use') {
       emit({
         event: 'tool_start',
@@ -161,6 +169,25 @@ function handleAssistantMessage(sessionKey, message) {
         args: paramsToObject(block.input),
       })
     }
+  }
+  if (topLevel) {
+    session.streamedText = false
+    session.streamedThinking = false
+  }
+}
+
+/** Token-level streaming (includePartialMessages). Top-level content only. */
+function handleStreamEvent(sessionKey, session, message) {
+  if (message.parent_tool_use_id != null) return
+  const ev = message.event
+  if (ev?.type !== 'content_block_delta') return
+  const delta = ev.delta
+  if (delta?.type === 'text_delta' && delta.text) {
+    session.streamedText = true
+    emit({ event: 'assistant_delta', sessionId: sessionKey, text: delta.text })
+  } else if (delta?.type === 'thinking_delta' && delta.thinking) {
+    session.streamedThinking = true
+    emit({ event: 'thinking_delta', sessionId: sessionKey, text: delta.thinking })
   }
 }
 
@@ -188,15 +215,22 @@ async function pumpSession(sessionKey, session) {
           if (message.subtype === 'init') {
             session.sessionId = message.session_id
             session.model = message.model ?? session.model
+            void emitSlashCommands(sessionKey, session.q, message.slash_commands ?? [])
           }
           break
         case 'assistant':
-          handleAssistantMessage(sessionKey, message)
+          if (!session.priming) handleAssistantMessage(sessionKey, session, message)
+          break
+        case 'stream_event':
+          if (!session.priming) handleStreamEvent(sessionKey, session, message)
           break
         case 'user':
-          handleUserMessage(sessionKey, message)
+          if (!session.priming) handleUserMessage(sessionKey, message)
           break
         case 'result': {
+          // Errors surface even for the invisible priming turn — if that turn
+          // failed (auth, model access), every later turn will fail the same
+          // way and hiding it would leave the user staring at silence.
           if (message.subtype !== 'success') {
             emit({
               event: 'run_error',
@@ -208,14 +242,27 @@ async function pumpSession(sessionKey, session) {
           // authoritative reading, unlike whatever we last asked for.
           const used = Object.keys(message.modelUsage ?? {})
           if (used.length > 0) session.model = used[used.length - 1]
+          const wasPriming = session.priming
+          session.priming = false
           session.turnActive = false
-          emit({
-            event: 'turn_end',
-            sessionId: sessionKey,
-            status: message.subtype,
-            model: session.model,
-            costUsd: message.total_cost_usd,
-          })
+          session.streamedText = false
+          session.streamedThinking = false
+          if (!wasPriming) {
+            emit({
+              event: 'turn_end',
+              sessionId: sessionKey,
+              status: message.subtype,
+              model: session.model,
+              costUsd: message.total_cost_usd,
+            })
+          }
+          // A send that arrived mid-turn was queued; its turn begins only now,
+          // so its turn_start cannot be closed by the previous turn's result.
+          if (session.pendingTurnStarts > 0) {
+            session.pendingTurnStarts -= 1
+            session.turnActive = true
+            emit({ event: 'turn_start', sessionId: sessionKey })
+          }
           break
         }
         default:
@@ -226,6 +273,8 @@ async function pumpSession(sessionKey, session) {
     if (!(err instanceof AbortError)) {
       emit({ event: 'run_error', sessionId: sessionKey, message: String(err?.message ?? err) })
     }
+    session.priming = false
+    session.pendingTurnStarts = 0
     session.turnActive = false
     emit({ event: 'turn_end', sessionId: sessionKey, status: 'error' })
   } finally {
@@ -240,6 +289,33 @@ async function pumpSession(sessionKey, session) {
 function mcpServersOption(mcpServers) {
   if (!mcpServers || typeof mcpServers !== 'object' || Array.isArray(mcpServers)) return {}
   return Object.keys(mcpServers).length > 0 ? { mcpServers } : {}
+}
+
+async function emitSlashCommands(sessionKey, q, fallbackNames = []) {
+  try {
+    const cmds = await q.supportedCommands()
+    if (cmds.length > 0) {
+      emit({
+        event: 'slash_commands',
+        sessionId: sessionKey,
+        commands: cmds.map((c) => ({
+          name: c.name,
+          description: c.description ?? '',
+          inputHint: c.argumentHint ?? '',
+        })),
+      })
+      return
+    }
+  } catch {
+    // Fall back to init-time names when supportedCommands is unavailable.
+  }
+  if (fallbackNames.length > 0) {
+    emit({
+      event: 'slash_commands',
+      sessionId: sessionKey,
+      commands: fallbackNames.map((name) => ({ name, description: '', inputHint: '' })),
+    })
+  }
 }
 
 async function startSession(params, resume) {
@@ -257,29 +333,42 @@ async function startSession(params, resume) {
       ...(resume ? { resume } : {}),
       ...mcpServersOption(params.mcpServers),
       permissionMode: params.permissionMode ?? 'default',
-      // bypassPermissions never consults canUseTool; wiring it anyway would be
-      // dead code that hides which mode is actually in force.
+      // "project" loads <cwd>/.claude/settings.json and .claude/skills/ without
+      // pulling in ~/.claude/* (user scope would bypass canUseTool via personal
+      // permissions.allow rules and flood sessions with personal skills).
+      settingSources: ['project'],
+      // Skills the user explicitly invokes must not stall on an approval
+      // popover; the tools a skill then runs are still gated individually.
+      allowedTools: ['Skill'],
+      // Token-level deltas (stream_event) instead of whole assistant blocks.
+      includePartialMessages: true,
       ...(fullAccess ? {} : { canUseTool: makeCanUseTool(sessionKey) }),
     },
   })
 
+  // The SDK emits system/init (whose session id we persist for resume) only
+  // once a first turn runs. With no initial prompt we prime it with a
+  // throwaway nudge turn whose events are all suppressed — without that flag
+  // the model's answer to the nudge would render as a reply to the user's
+  // real first message, which arrives later via `send`.
+  const priming = !params.initialPrompt
   const session = {
     q,
     input,
     cwd,
     sessionId: resume ?? '',
     model: params.model ?? '',
-    turnActive: false,
+    turnActive: true,
+    priming,
+    pendingTurnStarts: 0,
+    streamedText: false,
+    streamedThinking: false,
   }
   sessions.set(sessionKey, session)
   void pumpSession(sessionKey, session)
 
-  // The SDK emits system/init only once it has spun up; the session id it
-  // carries is what we persist for resume. Nudge it with an empty turn only if
-  // the caller gave no initial prompt — otherwise the prompt itself starts it.
   input.push(userMessage(params.initialPrompt || 'Ready.', session.sessionId))
-  session.turnActive = true
-  emit({ event: 'turn_start', sessionId: sessionKey })
+  if (!priming) emit({ event: 'turn_start', sessionId: sessionKey })
 
   const deadline = Date.now() + 60_000
   while (!session.sessionId && Date.now() < deadline) {
@@ -329,8 +418,15 @@ async function handleRequest(req) {
           await session.q.setModel(params.model)
           session.model = params.model
         }
-        session.turnActive = true
-        emit({ event: 'turn_start', sessionId: params.sessionKey })
+        if (session.turnActive) {
+          // A turn is still running (possibly the invisible priming turn).
+          // Emitting turn_start now would let that turn's result close the
+          // new turn before it produced anything; defer to its `result`.
+          session.pendingTurnStarts += 1
+        } else {
+          session.turnActive = true
+          emit({ event: 'turn_start', sessionId: params.sessionKey })
+        }
         session.input.push(userMessage(params.text, session.sessionId))
         emit({ id, result: { ok: true } })
         break

--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -30,7 +30,7 @@ pub use provider_auth::{
     ProviderAuthMethodType, ProviderAuthMethodsResponse,
 };
 pub use roles_skills::{
-    scan_roles_skills_state, ManagedSkillDto, RoleRecordDto, RoleSkillLinkDto,
+    scan_roles_skills_state, team_skill_roots, ManagedSkillDto, RoleRecordDto, RoleSkillLinkDto,
     RolesSkillsMetricsDto, RolesSkillsStateDto,
 };
 pub use session_store::{SessionStore, StoredSession};

--- a/apps/daemon/src/config/roles_skills.rs
+++ b/apps/daemon/src/config/roles_skills.rs
@@ -304,6 +304,11 @@ fn remap_team_skill_path(workspace_path: &Path, path: PathBuf, team_id: &str) ->
     path
 }
 
+/// Team skill directory roots for a workspace (config paths + default team share).
+pub fn team_skill_roots(workspace_path: &Path) -> Vec<PathBuf> {
+    collect_team_skill_paths(workspace_path)
+}
+
 fn collect_team_skill_paths(workspace_path: &Path) -> Vec<PathBuf> {
     let mut paths: Vec<PathBuf> = Vec::new();
     let mut seen = HashSet::new();

--- a/apps/daemon/src/runtime/claude_agent/events.rs
+++ b/apps/daemon/src/runtime/claude_agent/events.rs
@@ -79,6 +79,58 @@ fn acp_session_for(shared: &Arc<Shared>, session_key: &str) -> Option<String> {
     shared.session_keys.lock().get(session_key).cloned()
 }
 
+async fn emit_slash_commands(shared: &Arc<Shared>, session_id: &str, event: &serde_json::Value) {
+    let commands: Vec<amux::AcpAvailableCommand> = event
+        .get("commands")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| {
+                    let name = c.get("name").and_then(|v| v.as_str())?;
+                    if name.is_empty() {
+                        return None;
+                    }
+                    Some(amux::AcpAvailableCommand {
+                        name: name.to_string(),
+                        description: c
+                            .get("description")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                        input_hint: c
+                            .get("inputHint")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    if commands.is_empty() {
+        return;
+    }
+
+    let event_tx = {
+        let routes = shared.routes.lock();
+        let Some(route) = routes.get(session_id) else {
+            return;
+        };
+        route.event_tx.clone()
+    };
+
+    let ev = amux::AcpEvent {
+        event: Some(amux::acp_event::Event::AvailableCommands(
+            amux::AcpAvailableCommands { commands },
+        )),
+        model: String::new(),
+    };
+    crate::runtime::agent_trace::log_acp_event(session_id, &ev);
+    let _ = event_tx
+        .send(AcpEventFrame::new(session_id.to_string(), ev))
+        .await;
+}
+
 async fn handle_event(shared: &Arc<Shared>, event: &serde_json::Value) {
     let event_name = event.get("event").and_then(|v| v.as_str()).unwrap_or("");
     let session_key = event
@@ -98,6 +150,11 @@ async fn handle_event(shared: &Arc<Shared>, event: &serde_json::Value) {
 
     if event_name == "permission_request" {
         permission::handle_request(shared, &session_id, session_key, event).await;
+        return;
+    }
+
+    if event_name == "slash_commands" {
+        emit_slash_commands(shared, &session_id, event).await;
         return;
     }
 

--- a/apps/daemon/src/runtime/claude_agent/mod.rs
+++ b/apps/daemon/src/runtime/claude_agent/mod.rs
@@ -286,9 +286,11 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
             permission: args.permission,
             worktree: worktree.clone(),
             session_key,
-            // startSession sends the opening turn itself, so the session is
-            // already mid-turn by the time we get here.
-            turn_active: true,
+            // startSession opens a visible turn only when it carried an
+            // initial prompt. With an empty prompt the bridge runs a hidden
+            // priming turn (to obtain the SDK session id) and suppresses all
+            // of its events, so no turn is active from our point of view.
+            turn_active: !args.initial_prompt.is_empty(),
             turn_reply_to: None,
             turn_requester: None,
             model: model.clone(),

--- a/apps/daemon/src/runtime/claude_agent/translate.rs
+++ b/apps/daemon/src/runtime/claude_agent/translate.rs
@@ -221,7 +221,7 @@ mod tests {
     #[test]
     fn unknown_and_lifecycle_events_translate_to_nothing() {
         // turn_start / turn_end drive route state, not the event stream.
-        for name in ["turn_start", "turn_end", "permission_request", "bogus"] {
+        for name in ["turn_start", "turn_end", "permission_request", "slash_commands", "bogus"] {
             assert!(
                 translate_event(&json!({"event": name})).is_empty(),
                 "{name} should not translate"

--- a/apps/daemon/src/runtime/claude_skills.rs
+++ b/apps/daemon/src/runtime/claude_skills.rs
@@ -1,0 +1,252 @@
+//! Bridge team-shared skills into `<workspace>/.claude/skills/` for Claude Code.
+//!
+//! OpenCode reads `teamclaw-team/skills` via `opencode.json`; the Claude Agent SDK
+//! only discovers skills under `.claude/skills/` (with `settingSources` including
+//! `project`). We materialize per-skill symlinks so team skills are visible without
+//! touching the team-share layout.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use crate::config::team_skill_roots;
+use crate::config::workspace_control::WorkspaceControlError;
+
+const CLAUDE_SKILLS_DIR: &str = ".claude/skills";
+
+/// Ensure team skills are symlinked into `.claude/skills/`, without overwriting
+/// workspace-local entries. Idempotent; safe to call on every `prepare_workspace`.
+pub fn ensure_claude_team_skills(workspace_path: &Path) -> Result<(), WorkspaceControlError> {
+    let claude_skills = workspace_path.join(CLAUDE_SKILLS_DIR);
+    std::fs::create_dir_all(&claude_skills).map_err(io_err)?;
+
+    let team_roots = team_skill_roots(workspace_path);
+    if team_roots.is_empty() {
+        prune_stale_team_symlinks(&claude_skills, &team_roots, &HashSet::new())?;
+        return Ok(());
+    }
+
+    let desired = collect_desired_team_skills(&team_roots);
+    let desired_slugs: HashSet<String> = desired.keys().cloned().collect();
+
+    for (slug, target) in &desired {
+        let link = claude_skills.join(slug);
+        if link.exists() {
+            if link.is_dir() && !is_symlink(&link) {
+                // Workspace-local skill wins over team.
+                continue;
+            }
+            if is_symlink(&link) {
+                if symlink_points_to(&link, target) {
+                    continue;
+                }
+                if is_team_managed_symlink(&link, &team_roots) {
+                    std::fs::remove_file(&link).map_err(io_err)?;
+                } else {
+                    // User-owned symlink — do not overwrite.
+                    continue;
+                }
+            } else if link.is_file() {
+                continue;
+            }
+        }
+        create_dir_symlink(target, &link)?;
+    }
+
+    prune_stale_team_symlinks(&claude_skills, &team_roots, &desired_slugs)?;
+    Ok(())
+}
+
+fn collect_desired_team_skills(team_roots: &[PathBuf]) -> HashMap<String, PathBuf> {
+    let mut desired = HashMap::new();
+    for root in team_roots {
+        let Ok(entries) = std::fs::read_dir(root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if !path.join("SKILL.md").is_file() {
+                continue;
+            }
+            let Some(slug) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            desired.entry(slug.to_string()).or_insert(path);
+        }
+    }
+    desired
+}
+
+fn prune_stale_team_symlinks(
+    claude_skills: &Path,
+    team_roots: &[PathBuf],
+    desired_slugs: &HashSet<String>,
+) -> Result<(), WorkspaceControlError> {
+    let Ok(entries) = std::fs::read_dir(claude_skills) else {
+        return Ok(());
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !is_symlink(&path) {
+            continue;
+        }
+        let Some(slug) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if desired_slugs.contains(slug) {
+            continue;
+        }
+        if is_team_managed_symlink(&path, team_roots) {
+            std::fs::remove_file(&path).map_err(io_err)?;
+        }
+    }
+    Ok(())
+}
+
+fn is_symlink(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+fn resolve_symlink_target(link: &Path) -> Option<PathBuf> {
+    let dest = std::fs::read_link(link).ok()?;
+    let resolved = if dest.is_absolute() {
+        dest
+    } else {
+        link.parent()?.join(dest)
+    };
+    Some(std::fs::canonicalize(&resolved).unwrap_or(resolved))
+}
+
+fn symlink_points_to(link: &Path, target: &Path) -> bool {
+    let Some(resolved) = resolve_symlink_target(link) else {
+        return false;
+    };
+    let Ok(canonical_target) = std::fs::canonicalize(target) else {
+        return false;
+    };
+    resolved == canonical_target
+}
+
+fn is_team_managed_symlink(link: &Path, team_roots: &[PathBuf]) -> bool {
+    if !is_symlink(link) {
+        return false;
+    }
+    let Some(resolved) = resolve_symlink_target(link) else {
+        // Broken symlink — only prune when we can't resolve; treat as managed
+        // if the link target string references a team root path component.
+        let Ok(dest) = std::fs::read_link(link) else {
+            return false;
+        };
+        let dest_str = dest.to_string_lossy();
+        return team_roots.iter().any(|root| {
+            let root_str = root.to_string_lossy();
+            dest_str.contains(root_str.as_ref())
+        });
+    };
+    team_roots.iter().any(|root| {
+        let root_canon = std::fs::canonicalize(root).unwrap_or_else(|_| root.clone());
+        resolved.starts_with(&root_canon)
+    })
+}
+
+fn create_dir_symlink(target: &Path, link: &Path) -> Result<(), WorkspaceControlError> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(target, link).map_err(io_err)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(target, link).map_err(io_err)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (target, link);
+        Err(WorkspaceControlError::Io(
+            "symlinks are not supported on this platform".into(),
+        ))
+    }
+}
+
+fn io_err(e: std::io::Error) -> WorkspaceControlError {
+    WorkspaceControlError::Io(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::global_team_store::TEAM_LINK_NAME;
+
+    fn write_skill(dir: &Path, slug: &str) {
+        let skill_dir = dir.join(slug);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), format!("---\nname: {slug}\n---\n")).unwrap();
+    }
+
+    #[test]
+    fn symlinks_team_skills_into_claude_dir() {
+        let ws = tempfile::tempdir().unwrap();
+        let team_skills = ws.path().join(TEAM_LINK_NAME).join("skills");
+        std::fs::create_dir_all(&team_skills).unwrap();
+        write_skill(&team_skills, "team-skill");
+
+        ensure_claude_team_skills(ws.path()).unwrap();
+
+        let link = ws.path().join(".claude/skills/team-skill");
+        assert!(is_symlink(&link));
+        assert!(link.join("SKILL.md").is_file());
+    }
+
+    #[test]
+    fn local_skill_wins_over_team_with_same_slug() {
+        let ws = tempfile::tempdir().unwrap();
+        let team_skills = ws.path().join(TEAM_LINK_NAME).join("skills");
+        std::fs::create_dir_all(&team_skills).unwrap();
+        write_skill(&team_skills, "shared-name");
+
+        let local = ws.path().join(".claude/skills/shared-name");
+        std::fs::create_dir_all(&local).unwrap();
+        std::fs::write(local.join("SKILL.md"), "local wins").unwrap();
+
+        ensure_claude_team_skills(ws.path()).unwrap();
+
+        let content = std::fs::read_to_string(local.join("SKILL.md")).unwrap();
+        assert_eq!(content, "local wins");
+        assert!(!is_symlink(&local));
+    }
+
+    #[test]
+    fn removes_stale_team_symlinks() {
+        let ws = tempfile::tempdir().unwrap();
+        let team_skills = ws.path().join(TEAM_LINK_NAME).join("skills");
+        std::fs::create_dir_all(&team_skills).unwrap();
+        write_skill(&team_skills, "keep-me");
+
+        ensure_claude_team_skills(ws.path()).unwrap();
+
+        // Simulate a removed team skill by deleting source and re-running prepare.
+        std::fs::remove_dir_all(team_skills.join("keep-me")).unwrap();
+        ensure_claude_team_skills(ws.path()).unwrap();
+
+        assert!(!ws.path().join(".claude/skills/keep-me").exists());
+    }
+
+    #[test]
+    fn first_team_root_wins_for_duplicate_slug() {
+        let ws = tempfile::tempdir().unwrap();
+        let root_a = ws.path().join("skills-a");
+        let root_b = ws.path().join("skills-b");
+        std::fs::create_dir_all(&root_a).unwrap();
+        std::fs::create_dir_all(&root_b).unwrap();
+        write_skill(&root_a, "dup");
+        write_skill(&root_b, "dup");
+        std::fs::write(root_a.join("dup/SKILL.md"), "from-a").unwrap();
+        std::fs::write(root_b.join("dup/SKILL.md"), "from-b").unwrap();
+
+        let desired = collect_desired_team_skills(&[root_a.clone(), root_b]);
+        assert_eq!(desired.get("dup").unwrap(), &root_a.join("dup"));
+    }
+}

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -1,5 +1,6 @@
 pub mod acp_event_frame;
 pub mod backend;
+mod claude_skills;
 pub mod claude_agent;
 pub mod cursor_sdk;
 pub mod opencode_http;

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -666,6 +666,7 @@ pub fn prepare_workspace(workspace_path: &Path) -> Result<(), WorkspaceControlEr
     materialize_opencode_for_prepare(workspace_path)?;
     ensure_inherent_skills_in_dir(&workspace_path.join(".teamclaw/skills"))?;
     ensure_inherent_skills_in_dir(&workspace_path.join(".opencode/skills"))?;
+    crate::runtime::claude_skills::ensure_claude_team_skills(workspace_path)?;
 
     if let Ok(Some(result)) =
         teamclaw_runtime_env::opencode_db::maybe_migrate_legacy_opencode_db(workspace_path)

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -104,7 +104,7 @@ import {
   parseMemberMentionsFromText,
   textHasMemberMentionTokens,
 } from "@/lib/member-mention-token";
-import { buildStructuredMentionLines } from "@/lib/outgoing-mention-content";
+import { buildEnhancedChip, buildStructuredMentionLines } from "@/lib/outgoing-mention-content";
 import {
   agentAvailableModelsWithLocalCatalog,
   localRecentModelFallback,
@@ -117,6 +117,7 @@ import { useLocalDaemonCatalogStore } from "@/stores/local-daemon-catalog-store"
 import {
   selectAgentModel,
   resolveRuntimeStateEntryForAgent,
+  backendTypeFromRuntimeEntry,
 } from "@/lib/runtime-state-resolve";
 import {
   sessionFlowError,
@@ -135,18 +136,6 @@ function parseSlashToken(body: string): { type: "role" | "skill" | "command"; na
   if (body.startsWith("skill:")) return { type: "skill", name: body.slice("skill:".length) };
   if (body.startsWith("command:")) return { type: "command", name: body.slice("command:".length) };
   return { type: "skill", name: body };
-}
-
-function buildEnhancedChip(
-  type: "role" | "skill",
-  name: string,
-): string {
-  const label = type === "role" ? "Role" : "Skill";
-  const toolCall =
-    type === "role"
-      ? `role_load({ name: "${name}" })`
-      : `skill({ name: "${name}" })`;
-  return `[${label}: ${name}|instruction:You must call ${toolCall} before any other action.]`;
 }
 
 // ─── Main component ────────────────────────────────────────────────────────
@@ -1199,14 +1188,22 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     processedText = expandPageLinkTokensInText(processedText);
     processedText = expandSessionAttachmentTokensInText(processedText);
     processedText = processedText.replace(/@\{([^}]+)\}/g, '[File: $1]');
+    // Skill/role invocation wording depends on which backend runs the agent
+    // (opencode plugin tools vs Claude Code's native Skill tool).
+    const backendTypeForSend = backendTypeFromRuntimeEntry(
+      resolveRuntimeStateEntryForAgent(
+        agentForSend?.id ?? "",
+        useRuntimeStateStore.getState().byRuntimeId,
+      ),
+    );
     processedText = processedText.replace(/\/\{([^}]+)\}/g, (_full, body) => {
       const token = parseSlashToken(body);
-      if (token.type === "role") return buildEnhancedChip("role", token.name);
+      if (token.type === "role") return buildEnhancedChip("role", token.name, backendTypeForSend);
       if (token.type === "command") return `[Command: ${token.name}]`;
-      return buildEnhancedChip("skill", token.name);
+      return buildEnhancedChip("skill", token.name, backendTypeForSend);
     });
     processedText = processedText.replace(/\/<([a-z0-9]+(?:-[a-z0-9]+)*)>/g, (_full, roleName) =>
-      buildEnhancedChip("role", roleName),
+      buildEnhancedChip("role", roleName, backendTypeForSend),
     );
     processedText = processedText.replace(/\/\[([^\]]+)\]/g, '[Command: $1]');
 

--- a/packages/app/src/components/chat/CommandPopover.tsx
+++ b/packages/app/src/components/chat/CommandPopover.tsx
@@ -70,6 +70,17 @@ function summarizeRuntimeStates(
   )
 }
 
+function dedupeSkillEntries(skills: SkillEntry[]): SkillEntry[] {
+  const seen = new Map<string, SkillEntry>()
+  for (const skill of skills) {
+    const key = skill.invocationName || skill.name
+    if (!seen.has(key)) {
+      seen.set(key, skill)
+    }
+  }
+  return Array.from(seen.values())
+}
+
 async function scanAvailableSkills(workspacePath: string): Promise<SkillEntry[]> {
   const state = await loadRolesSkillsWorkspaceState(workspacePath)
   return state.skills
@@ -274,11 +285,15 @@ export function CommandPopover({
 
           const runtimeSkills: SkillEntry[] = []
           const runtimeCommands: Command[] = []
+          const runtimeSkillKeys = new Set<string>()
 
           for (const cmd of cmds) {
             const matchedSkill = skillByInvocation.get(cmd.name) ?? skillByFilename.get(cmd.name)
             if (matchedSkill) {
               if (deniedSkillNames.has(matchedSkill.name)) continue
+              const dedupeKey = matchedSkill.invocationName || matchedSkill.name
+              if (runtimeSkillKeys.has(dedupeKey)) continue
+              runtimeSkillKeys.add(dedupeKey)
               console.info('[CommandPopover] classified daemon command as known skill', {
                 commandName: cmd.name,
                 skillName: matchedSkill.name,
@@ -314,7 +329,7 @@ export function CommandPopover({
           
           setCommands(runtimeCommands)
           setRoles(loadedRoles)
-          setSkills([...runtimeSkills, ...uniqueFrontendSkills])
+          setSkills(dedupeSkillEntries([...runtimeSkills, ...uniqueFrontendSkills]))
           console.info('[CommandPopover] picker state set', {
             activeSessionId,
             runtimeSkillCount: runtimeSkills.length,

--- a/packages/app/src/components/chat/__tests__/CommandPopover.test.tsx
+++ b/packages/app/src/components/chat/__tests__/CommandPopover.test.tsx
@@ -212,4 +212,52 @@ describe('CommandPopover', () => {
       }),
     )
   })
+
+  it('dedupes duplicate scanned skills that share the same invocation name', async () => {
+    mocks.loadRolesSkillsWorkspaceState.mockResolvedValue({
+      roles: [],
+      skills: [
+        {
+          filename: 'accounting-error-investigator',
+          name: 'accounting-error-investigator',
+          invocationName: 'accounting-error-investigator',
+          description: 'Investigate accounting errors',
+          content: '---\nname: accounting-error-investigator\n---\n',
+          source: 'team',
+          dirPath: '/workspace/demo/teamclaw-team/skills',
+          linkedRoles: [],
+          isRoleSkill: false,
+        },
+        {
+          filename: 'accounting-error-investigator',
+          name: 'accounting-error-investigator',
+          invocationName: 'accounting-error-investigator',
+          description: 'Investigate accounting errors',
+          content: '---\nname: accounting-error-investigator\n---\n',
+          source: 'claude',
+          dirPath: '/workspace/demo/.claude/skills',
+          linkedRoles: [],
+          isRoleSkill: false,
+        },
+      ],
+      roleUsageBySkill: {},
+      skillNamesByRole: {},
+      metrics: { rolesCount: 0, skillsCount: 2, linkedSkillsCount: 0, unlinkedSkillsCount: 2 },
+    })
+
+    render(
+      <CommandPopover
+        open={true}
+        activeSessionId={null}
+        onOpenChange={vi.fn()}
+        searchQuery=""
+        onSelect={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('chat.commandPopover.skills:1')).toBeInTheDocument()
+    })
+    expect(screen.getAllByText('accounting-error-investigator')).toHaveLength(1)
+  })
 })

--- a/packages/app/src/components/settings/SkillsDiagnosticsDialog.tsx
+++ b/packages/app/src/components/settings/SkillsDiagnosticsDialog.tsx
@@ -1,0 +1,227 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  AlertCircle,
+  Check,
+  Copy,
+  Loader2,
+  Stethoscope,
+  TriangleAlert,
+  XCircle,
+} from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import {
+  formatSkillsDiagnosticsReport,
+  runSkillsDiagnostics,
+  type SkillDiagnosticCheck,
+  type SkillDiagnosticStatus,
+  type SkillsDiagnosticsReport,
+} from '@/lib/skill-diagnostics'
+
+function statusIcon(status: SkillDiagnosticStatus) {
+  switch (status) {
+    case 'ok':
+      return <Check className="h-4 w-4 shrink-0 text-emerald-500" />
+    case 'warn':
+      return <TriangleAlert className="h-4 w-4 shrink-0 text-amber-500" />
+    case 'fail':
+      return <XCircle className="h-4 w-4 shrink-0 text-red-500" />
+  }
+}
+
+function DiagRow({ check }: { check: SkillDiagnosticCheck }) {
+  return (
+    <div className="flex items-start gap-2 py-1.5">
+      {statusIcon(check.status)}
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2">
+          <span className="text-[13px] font-medium text-foreground">{check.label}</span>
+          {check.detail ? (
+            <span className="break-all font-mono text-xs text-muted-foreground">{check.detail}</span>
+          ) : null}
+        </div>
+        {check.hint ? (
+          <p className="mt-0.5 text-xs text-amber-700 dark:text-amber-300">{check.hint}</p>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function summaryLabel(status: SkillDiagnosticStatus, t: (key: string, fallback: string) => string): string {
+  switch (status) {
+    case 'ok':
+      return t('settings.skills.diag.summaryOk', 'All checks passed')
+    case 'warn':
+      return t('settings.skills.diag.summaryWarn', 'Issues found — review hints below')
+    case 'fail':
+      return t('settings.skills.diag.summaryFail', 'Blocking issues found')
+  }
+}
+
+export interface SkillsDiagnosticsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspacePath: string | null
+}
+
+export function SkillsDiagnosticsDialog({
+  open,
+  onOpenChange,
+  workspacePath,
+}: SkillsDiagnosticsDialogProps) {
+  const { t } = useTranslation()
+  const [report, setReport] = React.useState<SkillsDiagnosticsReport | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+  const [isRunning, setIsRunning] = React.useState(false)
+  const [copied, setCopied] = React.useState(false)
+
+  const runDiagnostics = React.useCallback(async () => {
+    if (!workspacePath) return
+    setIsRunning(true)
+    setError(null)
+    try {
+      const next = await runSkillsDiagnostics(workspacePath)
+      setReport(next)
+    } catch (err) {
+      setReport(null)
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setIsRunning(false)
+    }
+  }, [workspacePath])
+
+  React.useEffect(() => {
+    if (!open || !workspacePath) return
+    void runDiagnostics()
+  }, [open, workspacePath, runDiagnostics])
+
+  const handleCopy = React.useCallback(async () => {
+    if (!report) return
+    try {
+      await navigator.clipboard.writeText(formatSkillsDiagnosticsReport(report))
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      setCopied(false)
+    }
+  }, [report])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[min(85vh,760px)] w-[min(720px,92vw)] flex-col overflow-hidden p-0">
+        <DialogHeader className="shrink-0 border-b px-6 py-4">
+          <DialogTitle className="flex items-center gap-2">
+            <Stethoscope className="h-4 w-4 text-blue-500" />
+            {t('settings.skills.diag.title', 'Skills diagnostics')}
+          </DialogTitle>
+          <DialogDescription>
+            {t(
+              'settings.skills.diag.description',
+              'Checks skill directories, daemon inventory, team paths, and runtime refresh state.',
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex-1 space-y-4 overflow-y-auto px-6 py-4">
+          {!workspacePath ? (
+            <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
+              <AlertCircle className="h-4 w-4" />
+              {t('settings.skills.selectWorkspace', 'Please select a workspace directory first')}
+            </div>
+          ) : isRunning && !report ? (
+            <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t('settings.skills.diag.running', 'Running diagnostics…')}
+            </div>
+          ) : error ? (
+            <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-[13px] text-destructive">
+              {error}
+            </div>
+          ) : report ? (
+            <>
+              <div
+                className={cn(
+                  'rounded-lg border px-3 py-2 text-[13px]',
+                  report.summary === 'ok' && 'border-emerald-200 bg-emerald-50/70 dark:border-emerald-900 dark:bg-emerald-950/20',
+                  report.summary === 'warn' && 'border-amber-200 bg-amber-50/70 dark:border-amber-900 dark:bg-amber-950/20',
+                  report.summary === 'fail' && 'border-red-200 bg-red-50/70 dark:border-red-900 dark:bg-red-950/20',
+                )}
+              >
+                <p className="font-medium">{summaryLabel(report.summary, t)}</p>
+                <p className="mt-1 font-mono text-xs text-muted-foreground">
+                  {t('settings.skills.diag.counts', 'Daemon {{daemon}} · FS {{fs}} · Merged {{merged}}', {
+                    daemon: report.daemonSkillCount ?? 'n/a',
+                    fs: report.fsSkillCount,
+                    merged: report.mergedSkillCount,
+                  })}
+                </p>
+              </div>
+
+              <div className="divide-y divide-border/60 rounded-lg border border-border/60 px-3">
+                {report.checks.map((check) => (
+                  <DiagRow key={check.id} check={check} />
+                ))}
+              </div>
+
+              {report.directories.some((dir) => dir.brokenDirs.length > 0) ? (
+                <div className="rounded-lg border border-amber-200/70 bg-amber-50/50 px-3 py-2 dark:border-amber-900/50 dark:bg-amber-950/20">
+                  <p className="text-[13px] font-medium text-foreground">
+                    {t('settings.skills.diag.brokenTitle', 'Folders missing SKILL.md')}
+                  </p>
+                  <ul className="mt-1 space-y-1 text-xs text-muted-foreground">
+                    {report.directories
+                      .filter((dir) => dir.brokenDirs.length > 0)
+                      .map((dir) => (
+                        <li key={dir.path}>
+                          <span className="font-mono">{dir.label}</span>: {dir.brokenDirs.join(', ')}
+                        </li>
+                      ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              <div className="text-xs text-muted-foreground">
+                <p>{t('settings.skills.diag.tipsTitle', 'Common fixes')}</p>
+                <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                  <li>{t('settings.skills.diag.tipRefresh', 'Click Refresh to reload the skills list from disk.')}</li>
+                  <li>{t('settings.skills.diag.tipRestart', 'Restart OpenCode after adding or editing skills.')}</li>
+                  <li>{t('settings.skills.diag.tipPaths', 'Verify teamclaw.json / opencode.json skills.paths point to existing directories.')}</li>
+                  <li>{t('settings.skills.diag.tipDaemon', 'Ensure amuxd is running if daemon inventory is missing.')}</li>
+                </ul>
+              </div>
+            </>
+          ) : null}
+        </div>
+
+        <DialogFooter className="shrink-0 border-t px-6 py-4">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.close', 'Close')}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => void handleCopy()}
+            disabled={!report}
+            className="gap-2"
+          >
+            <Copy className="h-4 w-4" />
+            {copied ? t('settings.skills.diag.copied', 'Copied') : t('settings.skills.diag.copy', 'Copy report')}
+          </Button>
+          <Button onClick={() => void runDiagnostics()} disabled={!workspacePath || isRunning} className="gap-2">
+            {isRunning ? <Loader2 className="h-4 w-4 animate-spin" /> : <Stethoscope className="h-4 w-4" />}
+            {t('settings.skills.diag.rerun', 'Run again')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/settings/SkillsSection.tsx
+++ b/packages/app/src/components/settings/SkillsSection.tsx
@@ -26,6 +26,7 @@ import {
   Store,
   Users,
   Package,
+  Stethoscope,
 } from 'lucide-react'
 import { invoke } from '@tauri-apps/api/core'
 import { SKILLS_CHANGED_EVENT } from '@/hooks/useAppInit'
@@ -64,6 +65,7 @@ import { resolveSkillPermission } from '@/lib/opencode/config'
 import type { SkillSource } from '@/lib/git/types'
 import { INHERENT_SKILL_NAMES } from '@/lib/git/types'
 import { SkillsMarketplace } from './SkillsMarketplace'
+import { SkillsDiagnosticsDialog } from './SkillsDiagnosticsDialog'
 
 
 interface Skill {
@@ -145,6 +147,7 @@ export const SkillsSection = React.memo(function SkillsSection({
   const [exitingSkillKeys, setExitingSkillKeys] = React.useState<Set<string>>(new Set())
   const [marketplaceRefreshSignal, setMarketplaceRefreshSignal] = React.useState(0)
   const [marketplaceSource, setMarketplaceSource] = React.useState<'clawhub' | 'skillssh'>('clawhub')
+  const [diagnosticsOpen, setDiagnosticsOpen] = React.useState(false)
   const installedTabRef = React.useRef<HTMLButtonElement>(null)
   const marketplaceTabRef = React.useRef<HTMLButtonElement>(null)
 
@@ -681,6 +684,15 @@ ${skillContent.trim()}`
                   <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
                   {t('settings.llm.refresh', 'Refresh')}
                 </Button>
+                <Button
+                  onClick={() => setDiagnosticsOpen(true)}
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                >
+                  <Stethoscope className="h-4 w-4" />
+                  {t('settings.skills.diag.button', 'Diagnose')}
+                </Button>
                 <Button onClick={openCreateDialog} size="sm" className="gap-2">
                   <Plus className="h-4 w-4" />
                   {t('settings.skills.addSkill', 'Add Skill')}
@@ -806,6 +818,15 @@ ${skillContent.trim()}`
                 <Button onClick={loadSkills} variant="outline" size="sm" className="h-8 gap-2" disabled={isLoading}>
                   <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
                   {t('settings.llm.refresh', 'Refresh')}
+                </Button>
+                <Button
+                  onClick={() => setDiagnosticsOpen(true)}
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-2"
+                >
+                  <Stethoscope className="h-4 w-4" />
+                  {t('settings.skills.diag.button', 'Diagnose')}
                 </Button>
                 <Button onClick={openCreateDialog} size="sm" className="h-8 gap-2">
                   <Plus className="h-4 w-4" />
@@ -1493,6 +1514,12 @@ ${skillContent.trim()}`
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <SkillsDiagnosticsDialog
+        open={diagnosticsOpen}
+        onOpenChange={setDiagnosticsOpen}
+        workspacePath={workspacePath}
+      />
 
       {/* Delete Confirmation Dialog */}
       <Dialog

--- a/packages/app/src/components/settings/__tests__/SkillsSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/SkillsSection.test.tsx
@@ -73,6 +73,10 @@ vi.mock('../SkillsMarketplace', () => ({
     )
   },
 }))
+vi.mock('../SkillsDiagnosticsDialog', () => ({
+  SkillsDiagnosticsDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="skills-diagnostics-dialog">Diagnostics open</div> : null,
+}))
 import { SkillsSection } from '../SkillsSection'
 
 describe('SkillsSection', () => {
@@ -190,6 +194,16 @@ describe('SkillsSection', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Add Skill' }))
 
     expect(await screen.findByText('Create New Skill')).toBeTruthy()
+  })
+
+  it('opens skills diagnostics from Diagnose button', async () => {
+    workspaceState.workspacePath = '/workspace/project'
+
+    render(<SkillsSection />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Diagnose' }))
+
+    expect(await screen.findByTestId('skills-diagnostics-dialog')).toBeTruthy()
   })
 
   it('keeps ZIP import install location selectable', async () => {

--- a/packages/app/src/lib/__tests__/outgoing-mention-content.test.ts
+++ b/packages/app/src/lib/__tests__/outgoing-mention-content.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildEnhancedChip,
   buildHumanMentionChip,
   buildStructuredMentionLines,
   hasStructuredMentionLines,
@@ -26,6 +27,27 @@ describe("outgoing-mention-content", () => {
     ).toBe(
       "[Mentioned: Haigang Ye|instruction: 这条信息还提及了人类 Haigang Ye]",
     );
+  });
+
+  it("builds opencode skill/role chips with plugin tool calls", () => {
+    expect(buildEnhancedChip("skill", "issue-normalizer")).toBe(
+      '[Skill: issue-normalizer|instruction:You must call skill({ name: "issue-normalizer" }) before any other action.]',
+    );
+    expect(buildEnhancedChip("skill", "issue-normalizer", "opencode")).toBe(
+      '[Skill: issue-normalizer|instruction:You must call skill({ name: "issue-normalizer" }) before any other action.]',
+    );
+    expect(buildEnhancedChip("role", "reviewer", "opencode")).toBe(
+      '[Role: reviewer|instruction:You must call role_load({ name: "reviewer" }) before any other action.]',
+    );
+  });
+
+  it("builds claude-code skill chips around the native Skill tool", () => {
+    const chip = buildEnhancedChip("skill", "issue-normalizer", "claude-code");
+    expect(chip).toBe(
+      '[Skill: issue-normalizer|instruction:You must run the "issue-normalizer" skill (via your Skill tool) before any other action.]',
+    );
+    // The wrapper shape must stay parseable by UserMessageWithMentions.
+    expect(chip).toMatch(/^\[Skill: issue-normalizer\|instruction:[^\]]+\]$/);
   });
 
   it("detects structured agent mention lines", () => {

--- a/packages/app/src/lib/__tests__/skill-diagnostics.test.ts
+++ b/packages/app/src/lib/__tests__/skill-diagnostics.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { runSkillsDiagnostics, formatSkillsDiagnosticsReport } from '../skill-diagnostics'
+
+const mockExists = vi.fn(async () => true)
+const mockReadDir = vi.fn(async () => [])
+const mockLoadAllSkills = vi.fn(async () => ({ skills: [], overrides: [] }))
+const mockGetSkillDirectories = vi.fn(async () => ['/workspace/.teamclaw/skills'])
+const mockLoadRolesSkillsWorkspaceStateFromFs = vi.fn(async () => ({
+  roles: [],
+  skills: [],
+  roleUsageBySkill: {},
+  skillNamesByRole: {},
+  metrics: {
+    rolesCount: 0,
+    skillsCount: 0,
+    linkedSkillsCount: 0,
+    unlinkedSkillsCount: 0,
+  },
+}))
+const mockGetDaemonRolesSkillsState = vi.fn(async () => null)
+const mockGetDaemonRuntime = vi.fn(async () => null)
+const mockCollectTeamSkillPaths = vi.fn(async () => [])
+const mockGlobalTeamShareDir = vi.fn(async () => null)
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  exists: (...args: unknown[]) => mockExists(...args),
+  readDir: (...args: unknown[]) => mockReadDir(...args),
+}))
+
+vi.mock('@/lib/git/skill-loader', () => ({
+  loadAllSkills: (...args: unknown[]) => mockLoadAllSkills(...args),
+  getSkillDirectories: (...args: unknown[]) => mockGetSkillDirectories(...args),
+  getSourceDirHint: (source: string) => source,
+}))
+
+vi.mock('@/lib/roles/loader', () => ({
+  loadRolesSkillsWorkspaceStateFromFs: (...args: unknown[]) =>
+    mockLoadRolesSkillsWorkspaceStateFromFs(...args),
+}))
+
+vi.mock('@/lib/daemon-local-client', () => ({
+  encodeWorkspaceId: (path: string) => path,
+  getDaemonRolesSkillsState: (...args: unknown[]) => mockGetDaemonRolesSkillsState(...args),
+  getDaemonRuntime: (...args: unknown[]) => mockGetDaemonRuntime(...args),
+}))
+
+vi.mock('@/lib/team-skill-paths', () => ({
+  collectTeamSkillPaths: (...args: unknown[]) => mockCollectTeamSkillPaths(...args),
+  globalTeamShareDir: (...args: unknown[]) => mockGlobalTeamShareDir(...args),
+  TEAM_SHARE_LINK_DIR: 'teamclaw-team',
+}))
+
+vi.mock('@/lib/utils', () => ({
+  isTauri: () => true,
+}))
+
+describe('runSkillsDiagnostics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExists.mockResolvedValue(true)
+    mockReadDir.mockResolvedValue([])
+    mockLoadAllSkills.mockResolvedValue({ skills: [], overrides: [] })
+    mockGetSkillDirectories.mockResolvedValue(['/workspace/.teamclaw/skills'])
+    mockLoadRolesSkillsWorkspaceStateFromFs.mockResolvedValue({
+      roles: [],
+      skills: [],
+      roleUsageBySkill: {},
+      skillNamesByRole: {},
+      metrics: {
+        rolesCount: 0,
+        skillsCount: 0,
+        linkedSkillsCount: 0,
+        unlinkedSkillsCount: 0,
+      },
+    })
+    mockGetDaemonRolesSkillsState.mockResolvedValue({
+      roles: [],
+      skills: [{ filename: 'alpha' }],
+      roleUsageBySkill: {},
+      skillNamesByRole: {},
+      metrics: {
+        rolesCount: 0,
+        skillsCount: 1,
+        linkedSkillsCount: 0,
+        unlinkedSkillsCount: 1,
+      },
+    })
+    mockGetDaemonRuntime.mockResolvedValue({
+      workspace_id: 'workspace',
+      ready: true,
+      backend: 'cloud_api',
+      current_model: null,
+      refresh: {
+        status: 'pending',
+        change_kinds: ['skills'],
+        recommended_action: 'apply_changes',
+        auto_apply_blocked_by_active_runtime: false,
+        last_detected_at: null,
+        last_error: null,
+      },
+    })
+    mockCollectTeamSkillPaths.mockResolvedValue([])
+    mockGlobalTeamShareDir.mockResolvedValue(null)
+  })
+
+  it('returns fail when workspace path is empty', async () => {
+    const report = await runSkillsDiagnostics('')
+    expect(report.summary).toBe('fail')
+    expect(report.checks.some((check) => check.id === 'workspace')).toBe(true)
+  })
+
+  it('warns when daemon inventory differs from filesystem merge', async () => {
+    mockLoadAllSkills.mockResolvedValue({
+      skills: [{ filename: 'beta' } as never, { filename: 'gamma' } as never],
+      overrides: [],
+    })
+    mockLoadRolesSkillsWorkspaceStateFromFs.mockResolvedValue({
+      roles: [],
+      skills: [{ filename: 'beta' } as never, { filename: 'gamma' } as never],
+      roleUsageBySkill: {},
+      skillNamesByRole: {},
+      metrics: {
+        rolesCount: 0,
+        skillsCount: 2,
+        linkedSkillsCount: 0,
+        unlinkedSkillsCount: 2,
+      },
+    })
+
+    const report = await runSkillsDiagnostics('/workspace')
+    expect(report.checks.some((check) => check.id === 'count-mismatch')).toBe(true)
+    expect(report.summary).not.toBe('ok')
+  })
+
+  it('flags broken skill folders missing SKILL.md', async () => {
+    mockReadDir.mockImplementation(async (path: string) => {
+      if (path.endsWith('/.teamclaw/skills')) {
+        return [
+          { name: 'broken-skill', isDirectory: true },
+          { name: 'good-skill', isDirectory: true },
+        ]
+      }
+      return []
+    })
+    mockExists.mockImplementation(async (path: string) => {
+      if (path.endsWith('/good-skill/SKILL.md')) return true
+      if (path.endsWith('/broken-skill/SKILL.md')) return false
+      return true
+    })
+
+    const report = await runSkillsDiagnostics('/workspace')
+    expect(report.directories[0]?.brokenDirs).toContain('broken-skill')
+    expect(report.checks.some((check) => check.id.startsWith('dir-broken:'))).toBe(true)
+  })
+})
+
+describe('formatSkillsDiagnosticsReport', () => {
+  it('includes summary and checks in plain text', () => {
+    const text = formatSkillsDiagnosticsReport({
+      generatedAt: '2026-08-04T08:00:00.000Z',
+      workspacePath: '/workspace',
+      summary: 'warn',
+      checks: [{
+        id: 'daemon',
+        label: 'Daemon scan',
+        status: 'warn',
+        hint: 'offline',
+      }],
+      directories: [],
+      daemonSkillCount: null,
+      fsSkillCount: 0,
+      mergedSkillCount: 0,
+      overrides: [],
+    })
+
+    expect(text).toContain('Summary: warn')
+    expect(text).toContain('[warn] Daemon scan')
+    expect(text).toContain('hint: offline')
+  })
+})

--- a/packages/app/src/lib/outgoing-mention-content.ts
+++ b/packages/app/src/lib/outgoing-mention-content.ts
@@ -12,6 +12,29 @@ export function buildHumanMentionChip(
   return `[Mentioned: ${name}|instruction: ${hint}]`;
 }
 
+/**
+ * Skill / role invocation chip. The hidden instruction must name a tool the
+ * target backend actually has: `skill()` / `role_load()` are opencode plugin
+ * tools, while Claude Code loads skills through its native Skill tool —
+ * telling Claude to call a nonexistent `skill()` makes it answer
+ * conversationally first and only reach for the skill later.
+ */
+export function buildEnhancedChip(
+  type: "role" | "skill",
+  name: string,
+  backendType?: string,
+): string {
+  const label = type === "role" ? "Role" : "Skill";
+  if (type === "skill" && backendType === "claude-code") {
+    return `[Skill: ${name}|instruction:You must run the "${name}" skill (via your Skill tool) before any other action.]`;
+  }
+  const toolCall =
+    type === "role"
+      ? `role_load({ name: "${name}" })`
+      : `skill({ name: "${name}" })`;
+  return `[${label}: ${name}|instruction:You must call ${toolCall} before any other action.]`;
+}
+
 /** Agent mention stays as a structured prefix line. */
 export function buildStructuredMentionLines(
   agent: Pick<AttachedAgent, "displayName"> | null,

--- a/packages/app/src/lib/roles/__tests__/loader.test.ts
+++ b/packages/app/src/lib/roles/__tests__/loader.test.ts
@@ -282,6 +282,57 @@ Body
     expect(state.metrics.skillsCount).toBe(2)
   })
 
+  it("dedupes the same team skill seen via team share and .claude symlink", async () => {
+    const workspace = "/workspace"
+    mockIsTauri.mockReturnValue(true)
+    mockGetDaemonRolesSkillsState.mockResolvedValue({
+      roles: [],
+      skills: [
+        {
+          filename: "accounting-error-investigator",
+          name: "accounting-error-investigator",
+          invocationName: "accounting-error-investigator",
+          content: "---\nname: accounting-error-investigator\n---\n",
+          description: "Investigate accounting errors",
+          source: "team",
+          dirPath: `${workspace}/teamclaw-team/skills`,
+          linkedRoles: [],
+          isRoleSkill: false,
+        },
+      ],
+      roleUsageBySkill: {},
+      skillNamesByRole: {},
+      metrics: {
+        rolesCount: 0,
+        skillsCount: 1,
+        linkedSkillsCount: 0,
+        unlinkedSkillsCount: 1,
+      },
+    })
+    mockLoadAllSkills.mockResolvedValue({
+      skills: [
+        {
+          filename: "accounting-error-investigator",
+          name: "accounting-error-investigator",
+          invocationName: "accounting-error-investigator",
+          content: "---\nname: accounting-error-investigator\n---\n",
+          source: "claude",
+          dirPath: `${workspace}/.claude/skills`,
+        },
+      ],
+      overrides: [],
+    })
+    mockExists.mockResolvedValue(false)
+    mockReadDir.mockResolvedValue([])
+
+    const state = await loadRolesSkillsWorkspaceState(workspace)
+
+    expect(state.skills).toHaveLength(1)
+    expect(state.skills[0].filename).toBe("accounting-error-investigator")
+    expect(state.skills[0].source).toBe("claude")
+    expect(state.skills[0].dirPath).toBe(`${workspace}/.claude/skills`)
+  })
+
   it("ignores non-role directories under the roles root", async () => {
     const workspace = "/workspace"
     mockExists.mockImplementation(async (path: string) => {

--- a/packages/app/src/lib/roles/loader.ts
+++ b/packages/app/src/lib/roles/loader.ts
@@ -280,7 +280,7 @@ export async function loadAllRoles(workspacePath: string | null): Promise<RoleRe
   return state.roles
 }
 
-async function loadRolesSkillsWorkspaceStateFromFs(
+export async function loadRolesSkillsWorkspaceStateFromFs(
   workspacePath: string,
 ): Promise<RolesSkillsWorkspaceState> {
   const [roles, { skills: normalSkills }, roleManagedSkills] = await Promise.all([
@@ -304,8 +304,7 @@ async function loadRolesSkillsWorkspaceStateFromFs(
   const managedSkillsByKey = new Map<string, ManagedSkillRecord>()
 
   for (const skill of normalSkills) {
-    const key = `${skill.dirPath ?? ""}:${skill.filename}`
-    managedSkillsByKey.set(key, {
+    managedSkillsByKey.set(skill.filename, {
       filename: skill.filename,
       name: skill.name,
       invocationName: skill.invocationName,
@@ -336,6 +335,38 @@ async function loadRolesSkillsWorkspaceStateFromFs(
 
 function skillRecordKey(skill: Pick<ManagedSkillRecord, "dirPath" | "filename">): string {
   return `${skill.dirPath}:${skill.filename}`
+}
+
+const SKILL_SOURCE_PRIORITY: Record<SkillSource, number> = {
+  local: 0,
+  claude: 1,
+  clawhub: 2,
+  shared: 3,
+  team: 4,
+  builtin: 5,
+  plugin: 6,
+  "global-teamclaw": 7,
+  "global-claude": 8,
+  "global-agent": 9,
+  personal: 10,
+}
+
+/** Same filename from team share + `.claude/skills` symlink must collapse to one row. */
+function dedupeSkillsByFilename(skills: ManagedSkillRecord[]): ManagedSkillRecord[] {
+  const seen = new Map<string, ManagedSkillRecord>()
+  for (const skill of skills) {
+    const existing = seen.get(skill.filename)
+    if (!existing) {
+      seen.set(skill.filename, skill)
+      continue
+    }
+    const existingPriority = SKILL_SOURCE_PRIORITY[existing.source ?? "team"] ?? 99
+    const nextPriority = SKILL_SOURCE_PRIORITY[skill.source ?? "team"] ?? 99
+    if (nextPriority < existingPriority) {
+      seen.set(skill.filename, skill)
+    }
+  }
+  return Array.from(seen.values())
 }
 
 function buildRolesSkillsWorkspaceState(
@@ -397,7 +428,7 @@ function mergeRolesSkillsStates(
     }
   }
 
-  const skills = Array.from(skillsByKey.values()).sort((a, b) => {
+  const skills = dedupeSkillsByFilename(Array.from(skillsByKey.values())).sort((a, b) => {
     if (a.isRoleSkill !== b.isRoleSkill) return a.isRoleSkill ? 1 : -1
     return a.filename.localeCompare(b.filename)
   })

--- a/packages/app/src/lib/skill-diagnostics.ts
+++ b/packages/app/src/lib/skill-diagnostics.ts
@@ -1,0 +1,401 @@
+import { exists, readDir } from '@tauri-apps/plugin-fs'
+import { loadAllSkills, getSkillDirectories } from '@/lib/git/skill-loader'
+import type { SkillSource } from '@/lib/git/types'
+import { loadRolesSkillsWorkspaceStateFromFs } from '@/lib/roles/loader'
+import {
+  encodeWorkspaceId,
+  getDaemonRolesSkillsState,
+  getDaemonRuntime,
+} from '@/lib/daemon-local-client'
+import { collectTeamSkillPaths, globalTeamShareDir, TEAM_SHARE_LINK_DIR } from '@/lib/team-skill-paths'
+import { TEAMCLAW_DIR } from '@/lib/build-config'
+import { isTauri } from '@/lib/utils'
+
+export type SkillDiagnosticStatus = 'ok' | 'warn' | 'fail'
+
+export interface SkillDiagnosticCheck {
+  id: string
+  label: string
+  status: SkillDiagnosticStatus
+  detail?: string
+  hint?: string
+}
+
+export interface SkillDirectoryScan {
+  path: string
+  label: string
+  exists: boolean
+  readable: boolean
+  skillCount: number
+  brokenDirs: string[]
+  error?: string
+}
+
+export interface SkillsDiagnosticsReport {
+  generatedAt: string
+  workspacePath: string
+  summary: SkillDiagnosticStatus
+  checks: SkillDiagnosticCheck[]
+  directories: SkillDirectoryScan[]
+  daemonSkillCount: number | null
+  fsSkillCount: number
+  mergedSkillCount: number
+  overrides: Array<{ name: string; winner: SkillSource; loser: SkillSource }>
+}
+
+const DIRECTORY_LABELS: Record<string, string> = {
+  workspace: `${TEAMCLAW_DIR}/skills`,
+  claude: '.claude/skills',
+  agents: '.agents/skills',
+  globalTeamclaw: '~/.config/teamclaw/skills',
+  globalClaude: '~/.claude/skills',
+  globalAgents: '~/.agents/skills',
+}
+
+function worstStatus(current: SkillDiagnosticStatus, next: SkillDiagnosticStatus): SkillDiagnosticStatus {
+  if (current === 'fail' || next === 'fail') return 'fail'
+  if (current === 'warn' || next === 'warn') return 'warn'
+  return 'ok'
+}
+
+function summarizeChecks(checks: SkillDiagnosticCheck[]): SkillDiagnosticStatus {
+  return checks.reduce<SkillDiagnosticStatus>(
+    (acc, check) => worstStatus(acc, check.status),
+    'ok',
+  )
+}
+
+function labelForDirectory(path: string, workspacePath: string): string {
+  const normalized = path.replace(/\\/g, '/')
+  const workspace = workspacePath.replace(/\\/g, '/')
+  if (normalized.includes(`/${TEAMCLAW_DIR}/skills`)) return DIRECTORY_LABELS.workspace
+  if (normalized.includes('/.claude/skills')) {
+    return normalized.startsWith(workspace) ? DIRECTORY_LABELS.claude : DIRECTORY_LABELS.globalClaude
+  }
+  if (normalized.includes('/.agents/skills')) {
+    return normalized.startsWith(workspace) ? DIRECTORY_LABELS.agents : DIRECTORY_LABELS.globalAgents
+  }
+  if (normalized.includes('/.config/teamclaw/skills')) return DIRECTORY_LABELS.globalTeamclaw
+  if (normalized.includes(`/${TEAM_SHARE_LINK_DIR}/skills`)) return `${TEAM_SHARE_LINK_DIR}/skills`
+  if (normalized.includes('/roles/skills')) return `${TEAMCLAW_DIR}/roles/skills`
+  return path
+}
+
+async function scanSkillDirectory(path: string, label: string): Promise<SkillDirectoryScan> {
+  const scan: SkillDirectoryScan = {
+    path,
+    label,
+    exists: false,
+    readable: false,
+    skillCount: 0,
+    brokenDirs: [],
+  }
+
+  try {
+    if (!(await exists(path))) {
+      return scan
+    }
+    scan.exists = true
+
+    const entries = await readDir(path)
+    scan.readable = true
+
+    for (const entry of entries) {
+      if (!entry.isDirectory || !entry.name) continue
+      const entryPath = `${path}/${entry.name}`
+      const skillMdPath = `${entryPath}/SKILL.md`
+      if (await exists(skillMdPath)) {
+        scan.skillCount += 1
+        continue
+      }
+
+      let nestedSkillFound = false
+      try {
+        const nestedEntries = await readDir(entryPath)
+        for (const nested of nestedEntries) {
+          if (!nested.isDirectory || !nested.name) continue
+          const nestedSkillMd = `${entryPath}/${nested.name}/SKILL.md`
+          if (await exists(nestedSkillMd)) {
+            scan.skillCount += 1
+            nestedSkillFound = true
+          }
+        }
+      } catch {
+        // ignore nested read errors
+      }
+
+      if (!nestedSkillFound) {
+        scan.brokenDirs.push(entry.name)
+      }
+    }
+  } catch (err) {
+    scan.error = err instanceof Error ? err.message : String(err)
+  }
+
+  return scan
+}
+
+export async function runSkillsDiagnostics(workspacePath: string): Promise<SkillsDiagnosticsReport> {
+  const checks: SkillDiagnosticCheck[] = []
+  const directories: SkillDirectoryScan[] = []
+
+  if (!workspacePath.trim()) {
+    return {
+      generatedAt: new Date().toISOString(),
+      workspacePath,
+      summary: 'fail',
+      checks: [{
+        id: 'workspace',
+        label: 'Workspace',
+        status: 'fail',
+        hint: 'Select a workspace directory before running diagnostics.',
+      }],
+      directories: [],
+      daemonSkillCount: null,
+      fsSkillCount: 0,
+      mergedSkillCount: 0,
+      overrides: [],
+    }
+  }
+
+  const workspaceExists = await exists(workspacePath)
+  checks.push({
+    id: 'workspace',
+    label: 'Workspace directory',
+    status: workspaceExists ? 'ok' : 'fail',
+    detail: workspacePath,
+    hint: workspaceExists ? undefined : 'The workspace path does not exist on disk.',
+  })
+
+  let daemonSkillCount: number | null = null
+  let runtimeRefreshPending = false
+  let runtimeRefreshError: string | null = null
+  let runtimeSkillsPending = false
+
+  if (isTauri()) {
+    try {
+      const wid = encodeWorkspaceId(workspacePath)
+      const [daemonState, runtime] = await Promise.all([
+        getDaemonRolesSkillsState(wid),
+        getDaemonRuntime(wid),
+      ])
+
+      if (daemonState) {
+        daemonSkillCount = daemonState.skills.length
+        checks.push({
+          id: 'daemon',
+          label: 'Daemon scan',
+          status: 'ok',
+          detail: `${daemonSkillCount} skill(s)`,
+        })
+      } else {
+        checks.push({
+          id: 'daemon',
+          label: 'Daemon scan',
+          status: 'warn',
+          hint: 'amuxd did not return a skills inventory. The UI falls back to a local filesystem scan.',
+        })
+      }
+
+      const refresh = runtime?.refresh
+      runtimeRefreshPending = refresh?.status === 'pending' || refresh?.status === 'failed'
+      runtimeSkillsPending = refresh?.change_kinds.includes('skills') ?? false
+      runtimeRefreshError = refresh?.last_error ?? null
+
+      if (refresh?.status === 'failed') {
+        checks.push({
+          id: 'runtime-refresh',
+          label: 'Runtime refresh',
+          status: 'fail',
+          detail: runtimeRefreshError ?? refresh.status,
+          hint: 'Runtime refresh failed. Restart OpenCode from this page or Diagnostics.',
+        })
+      } else if (runtimeSkillsPending) {
+        checks.push({
+          id: 'runtime-refresh',
+          label: 'Runtime refresh',
+          status: 'warn',
+          detail: 'Skills changes pending',
+          hint: 'New or updated skills were detected but the runtime has not reloaded yet.',
+        })
+      } else if (runtimeRefreshPending) {
+        checks.push({
+          id: 'runtime-refresh',
+          label: 'Runtime refresh',
+          status: 'warn',
+          detail: refresh?.change_kinds.join(', ') || 'pending',
+          hint: 'Workspace runtime changes are pending reload.',
+        })
+      } else {
+        checks.push({
+          id: 'runtime-refresh',
+          label: 'Runtime refresh',
+          status: 'ok',
+          detail: 'Up to date',
+        })
+      }
+    } catch (err) {
+      checks.push({
+        id: 'daemon',
+        label: 'Daemon scan',
+        status: 'warn',
+        detail: err instanceof Error ? err.message : String(err),
+        hint: 'Ensure amuxd is running. Skills may still load from the local filesystem.',
+      })
+    }
+  } else {
+    checks.push({
+      id: 'daemon',
+      label: 'Daemon scan',
+      status: 'warn',
+      detail: 'Not available in browser mode',
+    })
+  }
+
+  const teamLinkPath = `${workspacePath}/${TEAM_SHARE_LINK_DIR}`
+  const teamLinkExists = await exists(teamLinkPath)
+  const globalTeamDir = await globalTeamShareDir()
+  checks.push({
+    id: 'team-share',
+    label: 'Team share directory',
+    status: teamLinkExists || !!globalTeamDir ? 'ok' : 'warn',
+    detail: teamLinkExists
+      ? teamLinkPath
+      : globalTeamDir ?? 'Not linked',
+    hint: !teamLinkExists && globalTeamDir
+      ? `Workspace symlink missing; global team dir is ${globalTeamDir}`
+      : !teamLinkExists
+        ? 'No team share link found. Team skills from teamclaw-team/ will not appear.'
+        : undefined,
+  })
+
+  const configuredPaths = await collectTeamSkillPaths(workspacePath)
+  for (const configPath of configuredPaths) {
+    const pathExists = await exists(configPath)
+    checks.push({
+      id: `config-path:${configPath}`,
+      label: 'Configured skill path',
+      status: pathExists ? 'ok' : 'fail',
+      detail: configPath,
+      hint: pathExists ? undefined : 'Path from teamclaw.json / opencode.json does not exist or is inaccessible.',
+    })
+  }
+
+  const skillDirs = await getSkillDirectories(workspacePath)
+  for (const dirPath of skillDirs) {
+    const label = labelForDirectory(dirPath, workspacePath)
+    const scan = await scanSkillDirectory(dirPath, label)
+    directories.push(scan)
+
+    if (scan.error) {
+      checks.push({
+        id: `dir-error:${dirPath}`,
+        label: label,
+        status: 'fail',
+        detail: dirPath,
+        hint: scan.error,
+      })
+    } else if (scan.brokenDirs.length > 0) {
+      checks.push({
+        id: `dir-broken:${dirPath}`,
+        label: label,
+        status: 'warn',
+        detail: `${scan.brokenDirs.length} folder(s) missing SKILL.md`,
+        hint: scan.brokenDirs.slice(0, 5).join(', '),
+      })
+    } else if (scan.exists && scan.skillCount === 0) {
+      checks.push({
+        id: `dir-empty:${dirPath}`,
+        label: label,
+        status: 'ok',
+        detail: 'Empty directory',
+      })
+    } else if (scan.exists) {
+      checks.push({
+        id: `dir-ok:${dirPath}`,
+        label: label,
+        status: 'ok',
+        detail: `${scan.skillCount} skill(s)`,
+      })
+    }
+  }
+
+  const { skills: fsSkills, overrides } = await loadAllSkills(workspacePath)
+  const fsState = await loadRolesSkillsWorkspaceStateFromFs(workspacePath)
+  const fsSkillCount = fsSkills.length
+  const mergedSkillCount = fsState.skills.length
+
+  checks.push({
+    id: 'fs-scan',
+    label: 'Filesystem scan',
+    status: fsSkillCount > 0 ? 'ok' : 'warn',
+    detail: `${fsSkillCount} skill(s)`,
+    hint: fsSkillCount === 0 ? 'No skills were found in any configured directory.' : undefined,
+  })
+
+  if (daemonSkillCount !== null && daemonSkillCount !== mergedSkillCount) {
+    checks.push({
+      id: 'count-mismatch',
+      label: 'Daemon vs filesystem',
+      status: 'warn',
+      detail: `daemon ${daemonSkillCount}, filesystem ${mergedSkillCount}`,
+      hint: 'Inventory counts differ. Try Refresh, then restart OpenCode if skills still look wrong.',
+    })
+  }
+
+  if (overrides.length > 0) {
+    checks.push({
+      id: 'overrides',
+      label: 'Name collisions',
+      status: 'warn',
+      detail: `${overrides.length} duplicate name(s) resolved by priority`,
+      hint: overrides.slice(0, 3).map((o) => `${o.name}: ${o.winner} over ${o.loser}`).join('; '),
+    })
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    workspacePath,
+    summary: summarizeChecks(checks),
+    checks,
+    directories,
+    daemonSkillCount,
+    fsSkillCount,
+    mergedSkillCount,
+    overrides,
+  }
+}
+
+export function formatSkillsDiagnosticsReport(report: SkillsDiagnosticsReport): string {
+  const lines = [
+    `Skills diagnostics — ${report.generatedAt}`,
+    `Workspace: ${report.workspacePath}`,
+    `Summary: ${report.summary}`,
+    `Daemon: ${report.daemonSkillCount ?? 'n/a'} | FS: ${report.fsSkillCount} | Merged: ${report.mergedSkillCount}`,
+    '',
+    'Checks:',
+  ]
+
+  for (const check of report.checks) {
+    lines.push(`[${check.status}] ${check.label}${check.detail ? `: ${check.detail}` : ''}`)
+    if (check.hint) lines.push(`  hint: ${check.hint}`)
+  }
+
+  if (report.directories.length > 0) {
+    lines.push('', 'Directories:')
+    for (const dir of report.directories) {
+      lines.push(`- ${dir.label} (${dir.path})`)
+      lines.push(`  exists=${dir.exists} skills=${dir.skillCount} broken=${dir.brokenDirs.join(', ') || 'none'}`)
+      if (dir.error) lines.push(`  error: ${dir.error}`)
+    }
+  }
+
+  if (report.overrides.length > 0) {
+    lines.push('', 'Overrides:')
+    for (const override of report.overrides) {
+      lines.push(`- ${override.name}: ${override.winner} > ${override.loser}`)
+    }
+  }
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Summary

- **Claude Code runtime**: suppress the hidden `"Ready."` priming turn that caused the first user message to receive a bogus greeting before skill invocation; serialize `turn_start`/`turn_end` so queued sends don't cross turns; enable token-level streaming via `includePartialMessages`; pre-allow the native `Skill` tool so user-selected skills don't stall on permission prompts.
- **Team skills for Claude Code**: materialize team-share skills into `.claude/skills/` via symlinks (`claude_skills.rs`), load project-scoped settings in the bridge, and forward slash commands to the UI as `AvailableCommands`.
- **Frontend**: add a Skills Diagnostics dialog (settings → Diagnose) for inspecting skill discovery paths; dedupe team/claude duplicate skill rows in the loader and command picker; emit runtime-aware skill chips (`Skill` tool for claude-code, `skill()` for opencode).

## Test plan

- [x] `cargo test --manifest-path apps/daemon/Cargo.toml claude`
- [x] `pnpm vitest run src/lib/__tests__/outgoing-mention-content.test.ts src/components/chat/__tests__/UserMessageWithMentions.test.tsx`
- [x] `pnpm typecheck`
- [ ] Restart daemon, start a **claude code** runtime session, send a message with a skill chip — no "I'm ready to help" preamble; reply streams token-by-token; skill runs without a Skill-tool permission popover
- [ ] Settings → Skills → **Diagnose** — verify team/claude skill paths and counts look correct
- [ ] Command picker (`/`) — same skill should not appear twice when symlinked from team share


Made with [Cursor](https://cursor.com)