### PR TITLE
chore(deploy): clear the WITHHELD migration now that belayo is on it

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -162,13 +162,11 @@ jobs:
                   # live one.
                   NEVER="20260601000000_baseline.sql"
                   #
-                  # WITHHELD: correct for this database, but not yet.
-                  #   20260804020000_per_team_actor_scope.sql — drops the old
-                  #   list_current_actor_sessions signatures. The FC in front of
-                  #   THIS database deploys separately and by hand
-                  #   (services/fc/deploy-aliyun-fc.sh), so apply it in the same
-                  #   change that redeploys that FC, not before.
-                  WITHHELD="20260804020000_per_team_actor_scope.sql"
+                  # WITHHELD: correct for this database, but not yet. Empty
+                  # right now — 20260804020000 sat here until its FC was
+                  # redeployed, and both landed on 2026-08-04. Anything added
+                  # back must say why, and who clears it.
+                  WITHHELD=""
 
                   for migration in $(ls /migrations/*.sql | xargs -n1 basename | sort)
                   do


### PR DESCRIPTION
注释清理，无行为变更。

`20260804020000_per_team_actor_scope.sql` 之前被 `WITHHELD` 挡在外部数据库（belayo）之外，理由是那个库前面的 FC 是手工部署的、和迁移不同步。**两件事今天都做完了**：

- `20260803010000_drop_agent_runtimes.sql`（那边一直缺）和 `20260804020000` 已直接应用到 belayo live，两条都记进了 `_selfhost.schema_migrations`；
- `teamclaw-belayo-live-api` 已从 `main` 的合并提交重新部署（`services/fc` 与 `origin/main` 逐字一致）。

所以 `WITHHELD` 现在是空的，注释里写明了它为什么空、以及再往里加东西时要说清楚是谁来清。账本已经记录了这两个文件，扫描循环本来就会跳过它们——这次改动只是不让注释继续声称一个已经不存在的暂缓。

### 顺带记录一下 drop 前做的验证

`amux.agent_runtimes` 有 624 行，DROP 不可逆，所以先证明它安全：

- **写**：最后一次成功写入 `12:58`，而重写了 `enforce_core_team_integrity` 的 `20260804010000` 是 `13:09` 应用的——说明还有旧代码在写，且从那一刻起已经失败了 8 小时。drop 前后都是失败，不构成回归。
- **读**：跨 5 分钟连续 6 次采样 `pg_stat_user_tables`，扫描计数纹丝不动，`last_idx_scan` 的时间戳正是我自己那条 count 查询。没有活跃读者。

完整备份（建表语句 + 624 行）已存到执行者机器的 `~/belayo-agent_runtimes-backup-20260804.sql`，**没有放进仓库**——那是生产数据。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
