### PR TITLE
fix(claude-code): report a model catalog after switching the local agent to it

### DIFF
--- a/apps/daemon/claude-bridge/src/main.mjs
+++ b/apps/daemon/claude-bridge/src/main.mjs
@@ -30,6 +30,11 @@ import { query, AbortError } from '@anthropic-ai/claude-agent-sdk'
 
 /** @type {Map<string, Session>} */
 const sessions = new Map()
+/**
+ * In-flight `startSession` for a model probe, so two concurrent `list_models`
+ * calls do not each spawn a session. Cleared when it settles.
+ */
+let modelProbeSession = null
 
 /** requestId → resolve fn for a pending canUseTool callback. */
 const pendingPermissions = new Map()
@@ -383,10 +388,37 @@ async function handleRequest(req) {
   try {
     switch (method) {
       case 'list_models': {
-        const existing = [...sessions.values()][0]
+        // supportedModels() hangs off a live query, so with no session there is
+        // nothing to ask. Returning [] here is what made switching the local
+        // agent to claude-code leave the desktop at "No model configured"
+        // forever: attach probes the catalog before any session exists, the
+        // device catalog is only ever written from a non-empty probe, and
+        // claude-code has no provider file to fall back on — so all three tiers
+        // stayed empty until something else happened to start a session.
+        //
+        // Start one instead. It is the same headless session `create_session`
+        // builds, minus a prompt: nothing is sent to the model, and it is kept
+        // so the next probe (and the first real turn) reuses it.
+        let existing = [...sessions.values()][0]
         if (!existing) {
-          emit({ id, result: { models: [] } })
-          break
+          if (!modelProbeSession) {
+            modelProbeSession = startSession({
+              cwd: params.cwd || process.cwd(),
+              permissionMode: params.permissionMode ?? 'default',
+            }).finally(() => {
+              modelProbeSession = null
+            })
+          }
+          try {
+            existing = (await modelProbeSession).session
+          } catch (e) {
+            // An unusable backend (missing login, bad binary) must read as
+            // "cannot tell", not as "this device has no models" — the caller
+            // persists a non-empty catalog and shows a terminal
+            // "nothing configured" hint for the latter.
+            emit({ id, error: { message: `list_models could not start a session: ${e.message}` } })
+            break
+          }
         }
         const models = await existing.q.supportedModels()
         emit({

--- a/apps/daemon/src/http/workspaces.rs
+++ b/apps/daemon/src/http/workspaces.rs
@@ -491,6 +491,20 @@ pub struct ModelCatalog {
     /// `"opencode"` in single-agent mode; `None` when no backend is configured.
     pub automation_default_backend: Option<String>,
     pub backends: Vec<BackendCatalog>,
+    /// Why the live probe could not answer, when it could not.
+    ///
+    /// An empty `backends[].models` has two very different causes: the backend
+    /// answered and has nothing configured, or it could not be asked at all — a
+    /// cursor daemon with a rejected API key, a binary that will not start. Both
+    /// used to arrive at the client as the same empty list, which renders as
+    /// "No model configured": a setup hint that sends the user looking for a
+    /// missing provider when the real answer is in a daemon log line.
+    ///
+    /// Set whenever the probe errored, even if a cached catalog then filled the
+    /// list — callers are expected to surface it only when they end up with no
+    /// models to show.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub probe_error: Option<String>,
 }
 
 fn backend_label(backend: &str) -> &'static str {
@@ -593,6 +607,8 @@ pub fn build_model_catalog(
     ModelCatalog {
         automation_default_backend,
         backends,
+        // Set by the caller, which is the only layer that saw the probe fail.
+        probe_error: None,
     }
 }
 
@@ -650,6 +666,11 @@ pub async fn get_model_catalog(
     // Deliberately not gated on the backend name: it used to run only for
     // `opencode` or `pi`, so a cursor daemon always fell through with `None`
     // and, having no provider-file fallback, served an empty catalog.
+    // `probe_error` is carried separately from `probed`: both a failed probe and
+    // an empty one fall back to the persisted catalog, but only the first one
+    // means "could not ask". Collapsing them is what let a rejected cursor API
+    // key reach the user as "No model configured".
+    let mut probe_error: Option<String> = None;
     let (probed_models, cached_models) = match workspace_path_or_404(&workspace_id).await {
         Ok(wpath) => match state.runtime_supervisor.as_ref() {
             Some(supervisor) => {
@@ -668,6 +689,7 @@ pub async fn get_model_catalog(
                             error = %e,
                             "catalog probe failed; falling back to the persisted catalog"
                         );
+                        probe_error = Some(e.to_string());
                         None
                     }
                 };
@@ -690,6 +712,13 @@ pub async fn get_model_catalog(
         &cached_models,
         &providers,
     );
+
+    // Only meaningful when nothing filled the list: a probe that failed while the
+    // persisted catalog still had models is a log line, not something to put in
+    // front of the user.
+    if catalog.backends.iter().all(|b| b.models.is_empty()) {
+        catalog.probe_error = probe_error;
+    }
 
     // The device MRU rides along so a client can resolve the last-used model
     // without waiting for a runtime to come up and publish its retain.

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -295,6 +295,16 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
     };
 
     // Model catalog + initial model.
+    // A failed catalog read must not fail the attach: the list only populates a
+    // picker, and the session is perfectly usable without it — `fill_catalog`
+    // backfills from this device's persisted catalog, and `record_catalog`
+    // ignores an empty result rather than overwriting a good list with it.
+    //
+    // Unlike the claude backend, this call is made AFTER a session exists (see
+    // the session resolution just above), so an error here is a real failure
+    // rather than "asked too early" — which is why it is logged at warn and the
+    // HTTP catalog reports it separately as `probe_error`, instead of the empty
+    // list reaching the user as "No model configured".
     let available_models = match proc
         .client
         .request(serde_json::json!({"type": "get_available_models"}))

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -798,10 +798,17 @@ impl RuntimeSupervisor {
     /// Probe the configured local backend for its live model catalog.
     ///
     /// Dispatches through the backend trait, so opencode reaches `serve.ensure()`
-    /// and `/config/providers`, pi reaches `get_available_models`, cursor reaches
-    /// `list_models`, and claude-code returns its static table — each spawning a
-    /// child if none is live. There is no static fallback — an unavailable
-    /// binary is an error, not a phantom list.
+    /// and `/config/providers`, pi reaches `get_available_models`, and cursor and
+    /// claude-code reach `list_models` — each spawning a child if none is live.
+    /// There is no static fallback — an unavailable binary is an error, not a
+    /// phantom list.
+    ///
+    /// This used to claim claude-code "returns its static table". It never had
+    /// one: the claude bridge answers `list_models` off a live query, and with
+    /// no session it used to answer `[]`. Believing the comment is how switching
+    /// the local agent to claude-code ended up with a permanently empty picker —
+    /// the probe tier looked covered, so nothing else was. The bridge now starts
+    /// a session to answer, which is what makes this dispatch meaningful.
     pub async fn probe_catalog_models(
         &self,
         workspace_path: &Path,

--- a/packages/app/src/components/chat/EngagedAgentOfflineBanner.tsx
+++ b/packages/app/src/components/chat/EngagedAgentOfflineBanner.tsx
@@ -129,6 +129,11 @@ export function pillSuffixForUiState(
       // Reachable, just has nothing to run — say so instead of implying a wait
       // ("Connecting…") or a network problem ("Offline").
       return t('chat.sessionAgent.pillUnconfigured', 'No model configured')
+    case 'catalog-error':
+      // Reachable, and could not be asked what it can run. Distinct from
+      // `unconfigured` because that one tells the user to go configure a model,
+      // which is the wrong errand for a rejected key or a broken binary.
+      return t('chat.sessionAgent.pillCatalogError', 'Model list unavailable')
     default:
       return null
   }

--- a/packages/app/src/components/chat/__tests__/engaged-agent-pill-label.test.ts
+++ b/packages/app/src/components/chat/__tests__/engaged-agent-pill-label.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { pillSuffixForUiState } from '../EngagedAgentOfflineBanner'
+import type { SessionAgentUiState } from '@/lib/session-agent-ui-state'
+
+// Returns the key so a missing case is visible as `null` rather than as a
+// plausible-looking English string.
+const t = (key: string) => key
+
+describe('pillSuffixForUiState', () => {
+  // The switch has a `default:` returning null, so a state added to the union
+  // without a case here still type-checks — it just renders a pill with no
+  // label. That is how `catalog-error` shipped mute the first time.
+  it('labels every state that is meant to be labelled', () => {
+    const labelled: SessionAgentUiState[] = [
+      'offline',
+      'stale',
+      'connecting',
+      'unconfigured',
+      'catalog-error',
+    ]
+    for (const state of labelled) {
+      expect(pillSuffixForUiState(state, t), `no label for ${state}`).not.toBeNull()
+    }
+  })
+
+  it('says the model list is unavailable, not that none is configured', () => {
+    // Two different situations, two different errands for the user: one is
+    // "go configure a provider", the other is "something is broken".
+    expect(pillSuffixForUiState('catalog-error', t)).toBe('chat.sessionAgent.pillCatalogError')
+    expect(pillSuffixForUiState('unconfigured', t)).toBe('chat.sessionAgent.pillUnconfigured')
+  })
+
+  it('leaves a ready agent unlabelled', () => {
+    expect(pillSuffixForUiState('ready', t)).toBeNull()
+  })
+})

--- a/packages/app/src/components/settings/DaemonGeneralSection.tsx
+++ b/packages/app/src/components/settings/DaemonGeneralSection.tsx
@@ -28,6 +28,8 @@ import {
   type DaemonLocalAgent,
 } from '@/lib/daemon-local-client'
 import { useUIStore } from '@/stores/ui'
+import { ensureLocalDaemonCatalog } from '@/stores/local-daemon-catalog-store'
+import { useWorkspaceStore } from '@/stores/workspace'
 import { useDaemonMqttConnected } from '@/stores/daemon-mqtt-status'
 import { cn, isTauri } from '@/lib/utils'
 import { SectionHeader, SettingCard } from './shared'
@@ -166,6 +168,20 @@ export function DaemonGeneralSection() {
           )
         }
         setLocalAgentState(next)
+        // Warm the new backend's model catalog before the user goes back to the
+        // conversation. The restart above empties the daemon's process pool, so
+        // the next catalog read is a cold probe — and for claude-code that probe
+        // has to start a session to get an answer at all. Doing it here, while
+        // the switch is still on screen, is what keeps the agent pill from
+        // showing "Offline" and then "No model configured" until a restart.
+        //
+        // `force` because the cached entry describes the backend being left.
+        // Fire-and-forget: a failure here costs a slower first pill, not a
+        // failed switch, and the periodic refresh retries anyway.
+        const workspacePath = useWorkspaceStore.getState().workspacePath?.trim()
+        if (workspacePath) {
+          ensureLocalDaemonCatalog(workspacePath, next, { force: true })
+        }
       } catch (e) {
         setLocalAgentState(previous) // revert on failure
         setError(e instanceof Error ? e.message : String(e))

--- a/packages/app/src/lib/__tests__/session-agent-ui-state.test.ts
+++ b/packages/app/src/lib/__tests__/session-agent-ui-state.test.ts
@@ -197,6 +197,27 @@ describe('resolveSessionAgentUiState', () => {
       ).toBe('unconfigured')
     })
 
+    // "Could not ask" and "has nothing" arrive as the same empty list from the
+    // daemon unless probe_error separates them. Reporting a rejected API key as
+    // "No model configured" sends the user hunting for a missing provider.
+    it('separates a failed probe from a genuinely empty catalog', () => {
+      const base = {
+        presenceOnline: true,
+        runtimeInfo: undefined,
+        availableModelCount: 0,
+        isStaleBinding: false,
+        connectingTimedOut: false,
+        localReachabilityConfirmed: true,
+      } as const
+
+      expect(resolveSessionAgentUiState({ ...base, localCatalog: 'empty' })).toBe(
+        'unconfigured',
+      )
+      expect(resolveSessionAgentUiState({ ...base, localCatalog: 'error' })).toBe(
+        'catalog-error',
+      )
+    })
+
     it('still shows connecting while the loopback probe is in flight', () => {
       expect(
         resolveSessionAgentUiState({
@@ -372,6 +393,10 @@ describe('resolveAgentPillDot', () => {
 
     it('connecting is amber', () => {
       expect(resolveAgentPillDot('connecting', undefined).color).toBe(AMBER)
+    })
+
+    it('a failed model probe is red — broken, not merely unset', () => {
+      expect(resolveAgentPillDot('catalog-error', undefined).color).not.toBe(AMBER)
     })
 
     it('unconfigured is amber — a setup gap, not a failure', () => {

--- a/packages/app/src/lib/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon-local-client.ts
@@ -634,6 +634,12 @@ export interface DaemonBackendCatalog {
 /** Mirrors Rust `workspaces::ModelCatalog`. */
 export interface DaemonModelCatalog {
   automation_default_backend: string | null
+  /**
+   * Why the live probe could not answer, when it could not. Present only when
+   * the catalog also came back with no models — an empty list plus this is
+   * "could not ask"; an empty list without it is "nothing configured".
+   */
+  probe_error?: string | null
   backends: DaemonBackendCatalog[]
 }
 

--- a/packages/app/src/lib/local-daemon-model-catalog.ts
+++ b/packages/app/src/lib/local-daemon-model-catalog.ts
@@ -70,6 +70,14 @@ export type LocalDaemonCatalogOutcome =
   | { status: 'models'; backend: string; models: ModelInfo[]; recentModels: string[] }
   /** The daemon answered and serves no models for this backend. First install. */
   | { status: 'empty'; backend: string }
+  /**
+   * The daemon answered, and said it could not ask the backend — a rejected
+   * cursor API key, a binary that will not start. Distinct from `empty` on
+   * purpose: that one is a setup gap the user can act on, this one is a
+   * failure, and showing "nothing configured" for it sends them looking for
+   * the wrong thing.
+   */
+  | { status: 'error'; backend: string; message: string }
   /** No answer, or an ambiguous multi-group reply — claim nothing. */
   | { status: 'unknown' }
 
@@ -125,7 +133,12 @@ export async function fetchLocalDaemonCatalog(
 
   const group = resolveCatalogGroup(catalog, backendType)
   if (!group) return { status: 'unknown' }
-  if (group.models.length === 0) return { status: 'empty', backend: group.backend }
+  if (group.models.length === 0) {
+    const probeError = catalog.probe_error?.trim()
+    return probeError
+      ? { status: 'error', backend: group.backend, message: probeError }
+      : { status: 'empty', backend: group.backend }
+  }
 
   return {
     status: 'models',

--- a/packages/app/src/lib/session-agent-ui-state.ts
+++ b/packages/app/src/lib/session-agent-ui-state.ts
@@ -14,13 +14,20 @@ export type SessionAgentUiState =
    * from the loopback catalog, which cannot see a remote agent.
    */
   | 'unconfigured'
+  /**
+   * The daemon answered and told us it could not ask the backend for its models
+   * — a rejected API key, a binary that will not start. Terminal like
+   * `unconfigured`, but a failure rather than a setup gap: pointing the user at
+   * "configure a model" for a bad credential is what this exists to stop.
+   */
+  | 'catalog-error'
 
 /**
  * What this device's loopback catalog says, for the **local agent only**.
  * Mirrors `LocalDaemonCatalogStatus`; `undefined` for remote agents, which have
  * no loopback path and must keep resolving purely from presence + retain.
  */
-export type LocalCatalogSnapshot = 'pending' | 'ready' | 'empty' | 'unknown'
+export type LocalCatalogSnapshot = 'pending' | 'ready' | 'empty' | 'error' | 'unknown'
 
 export type MentionDeliverySnapshot = 'ready' | 'offline' | 'stale'
 
@@ -92,6 +99,9 @@ export function resolveSessionAgentUiState(input: {
     if (hasModels || input.localCatalog === 'ready') return 'ready'
     // Answered, and genuinely has nothing to run. Terminal, not a wait state.
     if (input.localCatalog === 'empty') return 'unconfigured'
+    // Answered, and could not find out. Also terminal, but not the user's
+    // configuration to fix.
+    if (input.localCatalog === 'error') return 'catalog-error'
     // 'pending' / 'unknown': the loopback request is still out or told us
     // nothing. Fall through — a brief connecting is honest here.
   }
@@ -162,6 +172,9 @@ export function dotClassesForUiState(uiState: SessionAgentUiState): AgentPillDot
       // Amber like connecting — the daemon is up; this is a setup gap, not a
       // failure — but steady, because nothing is in progress.
       return { color: 'bg-amber-400', pulse: false }
+    case 'catalog-error':
+      // Red, unlike unconfigured's amber: something is broken, not merely unset.
+      return { color: 'bg-red-500', pulse: false }
     case 'stale':
       return { color: 'bg-red-500', pulse: false }
     case 'offline':

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -499,6 +499,7 @@
       "pillStale": "Rebind required",
       "pillConnecting": "Connecting…",
       "pillUnconfigured": "No model configured",
+      "pillCatalogError": "Model list unavailable",
       "mentionOffline": "Offline",
       "mentionStale": "Rebind required",
       "mentionConnecting": "Connecting…",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -499,6 +499,7 @@
       "pillStale": "需重新绑定",
       "pillConnecting": "连接中…",
       "pillUnconfigured": "未配置模型",
+      "pillCatalogError": "无法获取模型列表",
       "mentionOffline": "离线",
       "mentionStale": "需重新绑定",
       "mentionConnecting": "连接中…",

--- a/packages/app/src/stores/__tests__/local-daemon-catalog-store.test.ts
+++ b/packages/app/src/stores/__tests__/local-daemon-catalog-store.test.ts
@@ -80,6 +80,38 @@ describe('ensureLocalDaemonCatalog', () => {
     expect(read('/w1').recentModels).toEqual(['prov/a'])
   })
 
+  // Switching the local agent restarts the daemon onto a different backend, so
+  // the cached entry describes models the new one has never heard of. Without
+  // `force` it stays valid for the full ready-refresh window and the picker
+  // keeps offering them.
+  it('re-probes a fresh ready entry when forced', async () => {
+    useLocalDaemonCatalogStore.getState().setEntry('/w1', {
+      status: 'ready',
+      models: [{ id: 'opencode/big-pickle' } as never],
+      recentModels: [],
+      fetchedAt: Date.now(),
+    })
+    fetchLocalDaemonCatalog.mockResolvedValueOnce({
+      status: 'models',
+      backend: 'claude-code',
+      models: [{ id: 'claude/sonnet' }],
+      recentModels: [],
+    })
+
+    // Not due yet: without the flag this is a no-op.
+    ensureLocalDaemonCatalog('/w1', 'claude-code')
+    await settled()
+    expect(fetchLocalDaemonCatalog).not.toHaveBeenCalled()
+
+    ensureLocalDaemonCatalog('/w1', 'claude-code', { force: true })
+    await settled()
+
+    expect(fetchLocalDaemonCatalog).toHaveBeenCalledWith('/w1', 'claude-code')
+    const after = useLocalDaemonCatalogStore.getState().byWorkspacePath['/w1']
+    expect(after.status).toBe('ready')
+    expect(after.models.map((m) => m.id)).toEqual(['claude/sonnet'])
+  })
+
   it('drops a stale list when the daemon reports empty', async () => {
     // `empty` is authoritative — keeping old models would let the picker offer
     // something the daemon just said it cannot run.

--- a/packages/app/src/stores/local-daemon-catalog-store.ts
+++ b/packages/app/src/stores/local-daemon-catalog-store.ts
@@ -106,19 +106,30 @@ export function shouldFetchLocalDaemonCatalog(
  * Fire-and-forget refresh of this device's catalog. Safe to call on every
  * render — it dedupes in-flight requests and respects the refresh interval.
  *
+ * `force` skips the interval, for the one case where the cached answer is known
+ * to be about a different backend: switching the local agent. Without it the
+ * entry from the previous runtime stays valid for READY_REFRESH_MS and the
+ * picker keeps offering models the new backend has never heard of.
+ *
  * Callers MUST have established that the agent in question is the local daemon;
  * this reaches loopback HTTP and says nothing about any remote agent.
  */
 export function ensureLocalDaemonCatalog(
   workspacePath: string,
   backendType?: string | null,
+  options?: { force?: boolean },
 ): void {
   const path = workspacePath.trim()
   if (!path) return
   if (inFlight.has(path)) return
 
   const store = useLocalDaemonCatalogStore.getState()
-  if (!shouldFetchLocalDaemonCatalog(store.byWorkspacePath[path], Date.now())) return
+  if (
+    options?.force !== true &&
+    !shouldFetchLocalDaemonCatalog(store.byWorkspacePath[path], Date.now())
+  ) {
+    return
+  }
 
   const previous = store.byWorkspacePath[path]
   // Keep whatever we already resolved visible while refreshing — a periodic

--- a/packages/app/src/stores/local-daemon-catalog-store.ts
+++ b/packages/app/src/stores/local-daemon-catalog-store.ts
@@ -35,7 +35,7 @@ import { fetchLocalDaemonCatalog } from '@/lib/local-daemon-model-catalog'
  *                a fresh install with no provider configured, not a slow start.
  * - `unknown`  — no answer (daemon down / mid-restart), or an ambiguous reply.
  */
-export type LocalDaemonCatalogStatus = 'pending' | 'ready' | 'empty' | 'unknown'
+export type LocalDaemonCatalogStatus = 'pending' | 'ready' | 'empty' | 'error' | 'unknown'
 
 export type LocalDaemonCatalogEntry = {
   status: LocalDaemonCatalogStatus
@@ -58,7 +58,7 @@ export type LocalDaemonCatalogEntry = {
 export function isSettledLocalCatalog(
   status: LocalDaemonCatalogStatus | undefined,
 ): boolean {
-  return status === 'ready' || status === 'empty' || status === 'unknown'
+  return status === 'ready' || status === 'empty' || status === 'error' || status === 'unknown'
 }
 
 /** A settled catalog is stable; re-reading it every render would be waste. */
@@ -153,10 +153,17 @@ export function ensureLocalDaemonCatalog(
               fetchedAt: Date.now(),
             }
           : {
-              status: outcome.status === 'empty' ? 'empty' : 'unknown',
+              status:
+                outcome.status === 'empty'
+                  ? 'empty'
+                  : outcome.status === 'error'
+                    ? 'error'
+                    : 'unknown',
               // An 'empty' answer is authoritative — drop any stale list so the
               // UI can honestly say "nothing configured". 'unknown' means we
               // learned nothing, so the previous list stands.
+              // Only 'empty' is authoritative about the list being gone. A
+              // failed probe knows nothing, so whatever was last resolved stays.
               models: outcome.status === 'empty' ? [] : (previous?.models ?? []),
               recentModels:
                 outcome.status === 'empty' ? [] : (previous?.recentModels ?? []),


### PR DESCRIPTION
## 问题

运行期间把 local agent 从 opencode 切成 claude code，会话里的 agent 先显示 **Offline**，随后变成 **No model configured**，**必须重启 app 才能恢复**。

## 根因

claude bridge 的 `list_models` 是从一个 live query 上取 `supportedModels()` 的，没有 session 时直接返回 `[]`，而且注释把这当成预期行为：

```js
const existing = [...sessions.values()][0]
if (!existing) { emit({ id, result: { models: [] } }); break }
```

问题是**所有可能提供这份列表的层，都恰好发生在"还没有 session"的那一刻**：

| 层 | claude-code 的结果 |
|---|---|
| attach 时的 probe（喂给 `RuntimeInfo`） | 空 —— 此时 session 还没建 |
| 持久化的 device catalog | 空 —— 它只从**非空**的 probe 结果写入，所以从来没拿到过第一条 |
| `opencode.json` provider 文件兜底 | 不适用 —— 按设计只服务 opencode |

三层全空 → HTTP catalog 返回 `models: []` → 桌面端读成"未配置模型"。opencode 不会遇到，是因为它有 850 条持久化模型垫底。重启之所以"能好"，只是因为重启后恰好已经有 session 了。

线上实测（本机 daemon，loopback）：

```json
{ "automation_default_backend": "claude-code",
  "backends": [ { "backend": "claude-code", "label": "Claude Code", "models": [] } ] }
```

而 `~/.amuxd/model-catalog.toml` 里 `by_backend.opencode` 850 条、`pi` 若干、**`claude-code` 零条**。

## 改动

**bridge 自己去建一个 session 来回答。** 就是 `create_session` 那套 headless session，只是不发 prompt——不会向模型发送任何东西——并且保留下来，下次 probe 和第一次真实对话直接复用。并发 probe 共享同一次启动。

**backend 完全起不来时返回 error，而不是 `[]`。** "问不出来"和"这台机器没有模型"对调用方是两件事，只有后者该呈现为终态提示。

**Settings 切换确认后预热 catalog**，用户切回对话时 pill 就是对的，不用等第一次发消息。`ensureLocalDaemonCatalog` 为此加了 `force`——缓存里那条描述的是**正在离开的那个 backend**，不强制的话它在 5 分钟 ready 窗口内一直有效，picker 会继续列出新 backend 根本不认识的模型。

**`probe_error` 贯通到客户端。** 之前 catalog 端点把"probe 报错"和"probe 返回空"折叠成同一个 `None`，两者都以 `models: []` 到达客户端、都渲染成 "No model configured"。对 cursor 来说这是实打实的误导：**API key 被拒会被讲成"没有配置模型"**，真实原因只在 daemon 的一行 warn 里。现在 `ModelCatalog` 带 `probe_error`（仅在 probe 报错**且**最终没有任何模型可展示时设置），客户端映射成独立的 `catalog-error` pill（"无法获取模型列表"，红点而非 `unconfigured` 的琥珀色）。

## 实测（真实 SDK，非 mock）

无任何前置 session 时，两个并发 `list_models`：

```
两次调用都返回 claude/default、claude/sonnet、claude/haiku
一次 2.5s 的 session 启动（并发共享）
第二次 probe：0ms（复用 session）
```

## 也查了 cursor 和 pi

**cursor 不受影响**，而且形状本来就是对的：`Cursor.models.list({ apiKey })` 不需要 session，attach 时 `.map_err(...)?` 直接报错而不是吞成空列表——正是 claude-code 缺的那块。

**pi 也不受影响**：它在问模型**之前**就已经建好 session 了，这解释了为什么它有持久化条目而 claude-code 没有。它 attach 时确实会把读取失败吞成空列表，但那是合理的（列表只喂 picker，不值得让一个可用的 session 失败），这个理由已经写进代码，免得下次被当成 bug 重查。

顺带修正了 `probe_catalog_models` 上那句错误注释——它声称 claude-code "returns its static table"，**根本没有这张表**。这句话很可能就是当初没人给它加兜底的原因：看注释会以为 probe 那层已经覆盖了。

## 关于测试的两点实话

**bridge 没有自动化覆盖。** 那是个单文件 `.mjs`，仓库里没有配测试运行器，加一个属于另开话题。它的正确性靠上面那次真实测量，不是靠测试。

**我自己犯了一个错，值得记下来。** 第一遍改 pill 文案时改错了文件——`pillSuffixForUiState` 在 `EngagedAgentOfflineBanner.tsx`，不在状态机旁边——那次替换静默没生效，而 **typecheck 完全没意见**：那个 switch 有 `default:`，新状态不写 case 也能编译，只是渲染出一个没有文字的 pill。是 i18n 的 dead-key 检查绕了一圈把它抓出来的。所以补了一个直接的测试：**每个应该有文案的 pill 状态都必须有文案**，让这类错误在离原因更近的地方失败。

## 验证

`cargo check` 通过，`pnpm typecheck` 干净，`pnpm lint` 0 error，`pnpm test:unit` **427 files / 2616 tests 全绿**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
