### PR TITLE
fix(lint): drop two dead bindings left by the pill attachment refactor

### DIFF
--- a/packages/app/src/hooks/use-engaged-agent-ui-states.ts
+++ b/packages/app/src/hooks/use-engaged-agent-ui-states.ts
@@ -141,7 +141,8 @@ function computeProvisionalState(
   localCatalog: LocalDaemonCatalogEntry | undefined,
   now: number,
 ): SessionAgentUiState {
-  const dbRuntimeId = agentToRuntimeId.get(agent.id)
+  // The session's own runtime id is resolved inside resolveProvisionalRuntimeEntry
+  // now; reading it again here has been dead since that lookup moved.
   const entry = resolveProvisionalRuntimeEntry(agent, agentToRuntimeId, byRuntimeId)
   const runtimeInfo = entry?.info
   const retainModelCount = resolveAgentAvailableModels(runtimeInfo).length

--- a/packages/app/src/stores/__tests__/runtime-state-store.test.ts
+++ b/packages/app/src/stores/__tests__/runtime-state-store.test.ts
@@ -3,7 +3,6 @@ import { create, toBinary } from '@bufbuild/protobuf'
 import {
   ActorPresenceSchema,
   LiveSessionSchema,
-  ModelInfoSchema,
   RuntimeInfoSchema,
   AgentStatus,
   AgentType,


### PR DESCRIPTION
main 的 CI 从 #739 起就是红的：eslint 报两个 error，job 因此失败，于是**每个开着的 PR 都继承了一次与自己无关的红**——这也是三个 dependabot PR 看起来"全都坏了"的原因之一。

两处都是重构后的遗留，不是疏忽：

- `use-engaged-agent-ui-states.ts` 里的 `dbRuntimeId`：session runtime 的查找搬进 `resolveProvisionalRuntimeEntry` 之后，这一行就没人再读了。
- `runtime-state-store.test.ts` 里的 `ModelInfoSchema`：整个文件只在 import 里出现一次。

无行为变更，改前改后都是 427 files / 2626 tests 全过。目的只是把 main 自己的信号拿回来——让 PR 上的红重新代表这个 PR 本身。

🤖 Generated with [Claude Code](https://claude.com/claude-code)