### PR TITLE
fix(extension): auto-restore team and remote agent pill connecting

### DIFF
--- a/packages/app/src/components/auth/AuthGate.tsx
+++ b/packages/app/src/components/auth/AuthGate.tsx
@@ -27,6 +27,32 @@ interface AuthGateProps {
 
 type BootstrapState = "idle" | "checking" | "ready" | "error";
 
+function memberTeams(teams: MembershipTeam[]): MembershipTeam[] {
+  return teams.filter((team) => team.itemType !== "org" && team.isMember !== false);
+}
+
+/** True when the user must explicitly pick (multi-team, joinable public, or empty org). */
+function needsTeamPicker(teams: MembershipTeam[]): boolean {
+  const members = memberTeams(teams);
+  return (
+    members.length > 1 ||
+    teams.some((team) => team.isMember === false) ||
+    teams.some((team) => team.itemType === "org")
+  );
+}
+
+function pickAutoRestoreTarget(
+  teams: MembershipTeam[],
+  lastUsedTeamId: string | null,
+): MembershipTeam | undefined {
+  if (needsTeamPicker(teams)) return undefined;
+  const members = memberTeams(teams);
+  return (
+    (lastUsedTeamId ? members.find((team) => team.id === lastUsedTeamId) : undefined) ??
+    (members.length === 1 ? members[0] : undefined)
+  );
+}
+
 export function AuthGate({ children }: AuthGateProps) {
   const { session, loading, authFlow, hydrate, signOut } = useAuthStore();
   const [bootstrap, setBootstrap] = useState<BootstrapState>("idle");
@@ -104,16 +130,15 @@ export function AuthGate({ children }: AuthGateProps) {
   }, [session, bootstrap, teamChosen]);
 
   // iOS persists `activeTeamID` and explicitly activates it at the next
-  // bootstrap. Do the same on desktop: the refresh token returned by activate
-  // carries the selected org, so merely restoring a local cache is not enough.
+  // bootstrap. Do the same on every client (desktop + extension/web): the
+  // refresh token returned by activate carries the selected org, so merely
+  // restoring a local cache is not enough.
   useEffect(() => {
-    if (!isTauri() || !session || bootstrap !== "ready" || myTeams === null || teamChoiceResolved) {
+    if (!session || bootstrap !== "ready" || myTeams === null || teamChoiceResolved) {
       return;
     }
 
-    const target =
-      (lastUsedTeamId ? myTeams.find((team) => team.id === lastUsedTeamId) : undefined) ??
-      (myTeams.length === 1 ? myTeams[0] : undefined);
+    const target = pickAutoRestoreTarget(myTeams, lastUsedTeamId);
     if (!target) {
       setTeamChoiceResolved(true);
       return;
@@ -382,9 +407,9 @@ export function AuthGate({ children }: AuthGateProps) {
     return null;
   }
 
-  // Wait for the iOS-equivalent saved-team restoration decision before
-  // rendering the picker or desktop shell.
-  if (isTauri() && !teamChosen && !teamChoiceResolved) {
+  // Wait for the saved-team restoration decision before rendering the picker
+  // or shell (desktop and extension/web alike).
+  if (!teamChosen && !teamChoiceResolved) {
     return null;
   }
 
@@ -403,7 +428,7 @@ export function AuthGate({ children }: AuthGateProps) {
     if (myTeams === null) {
       return null; // Still loading the team list — keep the skeleton.
     }
-    if (myTeams.length >= 1) {
+    if (needsTeamPicker(myTeams)) {
       removeStartupSkeleton();
       return (
         <TeamPicker

--- a/packages/app/src/components/auth/TeamPicker.tsx
+++ b/packages/app/src/components/auth/TeamPicker.tsx
@@ -26,6 +26,9 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
   // Highlight the last-used team; on first login (no history) fall back to the
   // first team so there's always a visible pre-selection.
   const highlightId = lastUsedTeamId ?? teams.find((item) => item.itemType !== "org")?.id ?? null;
+  const memberTeamCount = teams.filter(
+    (team) => team.itemType !== "org" && team.isMember !== false,
+  ).length;
 
   // Group by org, preserving first-seen order. Teams without an org name fall
   // into a single "ungrouped" bucket.
@@ -72,7 +75,9 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
           {t("teamPicker.title", "Choose a team")}
         </h1>
         <p className="mt-1.5 text-[12.5px] leading-5 text-muted-foreground">
-          {t("teamPicker.subtitle", "You belong to multiple teams. Pick one to continue.")}
+          {memberTeamCount > 1
+            ? t("teamPicker.subtitle", "You belong to multiple teams. Pick one to continue.")
+            : t("teamPicker.subtitleSingle", "Pick a team to continue.")}
         </p>
 
         {/*

--- a/packages/app/src/components/auth/__tests__/AuthGate.test.tsx
+++ b/packages/app/src/components/auth/__tests__/AuthGate.test.tsx
@@ -302,6 +302,24 @@ describe("AuthGate", () => {
     await waitFor(() => expect(screen.getByText("App shell")).toBeInTheDocument());
   });
 
+  it("extension/web: auto-activates a sole team without showing the chooser", async () => {
+    isTauriMock.mockReturnValue(false);
+    backendMock.teams.listAllMyTeams.mockResolvedValue([
+      { id: "team-existing", name: "Acme", slug: "acme", orgId: "org-1", orgName: "Org", isMember: true },
+    ]);
+    currentTeamMock.switchToTeam.mockResolvedValueOnce(undefined);
+
+    render(
+      <AuthGate>
+        <div>App shell</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => expect(currentTeamMock.switchToTeam).toHaveBeenCalledWith("team-existing"));
+    await waitFor(() => expect(screen.getByText("App shell")).toBeInTheDocument());
+    expect(screen.queryByText(/Team picker/)).not.toBeInTheDocument();
+  });
+
   it("extension/web: keeps the shell blocked until myTeams resolves, then removes the skeleton", async () => {
     isTauriMock.mockReturnValue(false);
     currentTeamMock.team = { id: "team-cached" };

--- a/packages/app/src/lib/__tests__/agent-model-fallback.test.ts
+++ b/packages/app/src/lib/__tests__/agent-model-fallback.test.ts
@@ -85,6 +85,17 @@ describe("agentAvailableModelsWithLocalCatalog", () => {
     });
     expect(models).toEqual([]);
   });
+
+  it("falls back to MQTT default workspace catalog for a remote agent", () => {
+    const models = agentAvailableModelsWithLocalCatalog({
+      agentId: REMOTE,
+      localDaemonActorId: LOCAL,
+      runtimeInfo: undefined,
+      catalogModels: [{ id: "from/catalog", displayName: "catalog" }],
+      remoteDefaultCatalogModels: [{ id: "from/mqtt", displayName: "mqtt" }],
+    });
+    expect(models.map((m) => m.id)).toEqual(["from/mqtt"]);
+  });
 });
 
 describe("resolveAgentCatalogModels", () => {
@@ -108,6 +119,25 @@ describe("resolveAgentCatalogModels", () => {
       sessionId: null,
       byRuntimeId: {},
       runtimeInfo: runtimeInfo(["from/retain"]),
+      localWorkspaceCatalogModels: [{ id: "from/http", displayName: "http" }],
+      remoteDefaultCatalogModels: [{ id: "from/mqtt", displayName: "mqtt" }],
+    });
+    expect(models.map((m) => m.id)).toEqual(["from/mqtt"]);
+  });
+
+  it("attached remote agent falls back to default workspace catalog when retain is empty", () => {
+    const models = resolveAgentCatalogModels({
+      agentId: REMOTE,
+      localDaemonActorId: LOCAL,
+      sessionId: "session-1",
+      byRuntimeId: {
+        [`${REMOTE}::session-1`]: {
+          daemonActorId: REMOTE,
+          lastUpdated: 1,
+          info: runtimeInfo([]),
+        },
+      },
+      runtimeInfo: runtimeInfo([]),
       localWorkspaceCatalogModels: [{ id: "from/http", displayName: "http" }],
       remoteDefaultCatalogModels: [{ id: "from/mqtt", displayName: "mqtt" }],
     });

--- a/packages/app/src/lib/__tests__/session-agent-ui-state.test.ts
+++ b/packages/app/src/lib/__tests__/session-agent-ui-state.test.ts
@@ -305,6 +305,31 @@ describe('resolveSessionAgentUiState', () => {
         }),
       ).toBe('connecting')
     })
+
+    it('is ready for an online remote agent at STARTING once models are known', () => {
+      expect(
+        resolveSessionAgentUiState({
+          presenceOnline: true,
+          runtimeInfo: { state: RuntimeLifecycle.STARTING } as never,
+          availableModelCount: 1,
+          isStaleBinding: false,
+          connectingTimedOut: false,
+        }),
+      ).toBe('ready')
+    })
+
+    it('is ready for a streaming remote agent even before lifecycle flips ACTIVE', () => {
+      expect(
+        resolveSessionAgentUiState({
+          presenceOnline: true,
+          runtimeInfo: { state: RuntimeLifecycle.STARTING } as never,
+          availableModelCount: 1,
+          isStaleBinding: false,
+          connectingTimedOut: false,
+          activeStreamConfirmed: true,
+        }),
+      ).toBe('ready')
+    })
   })
 })
 

--- a/packages/app/src/lib/agent-model-fallback.ts
+++ b/packages/app/src/lib/agent-model-fallback.ts
@@ -62,6 +62,7 @@ export function resolveAgentCatalogModels(args: {
     localDaemonActorId: args.localDaemonActorId,
     runtimeInfo: args.runtimeInfo,
     catalogModels: args.localWorkspaceCatalogModels,
+    remoteDefaultCatalogModels: args.remoteDefaultCatalogModels,
   });
 }
 
@@ -77,12 +78,14 @@ export function agentAvailableModelsWithLocalCatalog(args: {
   localDaemonActorId: string | null | undefined;
   runtimeInfo: RuntimeInfo | undefined;
   catalogModels: readonly AgentModelOption[] | undefined;
+  remoteDefaultCatalogModels?: readonly AgentModelOption[] | undefined;
 }): AgentModelOption[] {
   const fromRetain = resolveAgentAvailableModels(args.runtimeInfo);
   if (fromRetain.length > 0) return fromRetain;
-  return isLocalDaemonAgent(args.agentId, args.localDaemonActorId)
-    ? dedupeAgentModelOptions(args.catalogModels)
-    : [];
+  if (isLocalDaemonAgent(args.agentId, args.localDaemonActorId)) {
+    return dedupeAgentModelOptions(args.catalogModels);
+  }
+  return dedupeAgentModelOptions(args.remoteDefaultCatalogModels);
 }
 
 /**

--- a/packages/app/src/lib/session-agent-ui-state.ts
+++ b/packages/app/src/lib/session-agent-ui-state.ts
@@ -132,6 +132,15 @@ export function resolveSessionAgentUiState(input: {
     if (!input.runtimeInfo && hasModels) {
       return 'ready'
     }
+    // Session attachment can sit at STARTING while the worktree catalog is already
+    // visible (extension draft → first send). With models to pick, "connecting"
+    // is a lie — same rule as the local loopback fast path above.
+    if (
+      hasModels &&
+      (state === RuntimeLifecycle.STARTING || input.activeStreamConfirmed === true)
+    ) {
+      return 'ready'
+    }
     if (!input.runtimeInfo || state === RuntimeLifecycle.STARTING || !hasModels) {
       return 'connecting'
     }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -3042,6 +3042,7 @@
   "teamPicker": {
     "title": "Choose a team",
     "subtitle": "You belong to multiple teams. Pick one to continue.",
+    "subtitleSingle": "Pick a team to continue.",
     "singleOrgNotice": "You can work in one organization at a time. Choosing a team here leaves the other organizations' teams inaccessible until you switch back.",
     "switching": "Switching…",
     "joining": "Joining…",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -3042,6 +3042,7 @@
   "teamPicker": {
     "title": "选择团队",
     "subtitle": "你属于多个团队，请选择要进入的一个。",
+    "subtitleSingle": "请选择一个团队继续。",
     "singleOrgNotice": "同一时间只能在一个组织内工作。选择这里的团队后，其它组织的团队将无法访问，直到你切回去。",
     "switching": "切换中…",
     "joining": "加入中…",

--- a/packages/app/src/stores/__tests__/actor-presence-store.test.ts
+++ b/packages/app/src/stores/__tests__/actor-presence-store.test.ts
@@ -17,6 +17,12 @@ vi.mock('@/lib/mqtt-bridge', () => ({
 
 beforeEach(() => {
   mockSubscribe.mockClear()
+  mockSubscribe.mockResolvedValue(undefined)
+  mockListen.mockClear()
+  mockListen.mockImplementation(async (handler: (env: { topic: string; bytes: number[] }) => void) => {
+    envelopeHandler = handler
+    return () => { envelopeHandler = null }
+  })
   envelopeHandler = null
 })
 
@@ -30,6 +36,35 @@ describe('actor-presence-store', () => {
     const { initActorPresenceStore } = await import('../actor-presence-store')
     await initActorPresenceStore('team-1')
     expect(mockSubscribe).toHaveBeenCalledWith('amux/team-1/+/state')
+  })
+
+  it('registers the envelope handler before subscribing (boot retain race)', async () => {
+    const callOrder: string[] = []
+    mockListen.mockImplementation(async (handler) => {
+      callOrder.push('listen')
+      envelopeHandler = handler
+      return () => {
+        envelopeHandler = null
+      }
+    })
+    mockSubscribe.mockImplementation(async () => {
+      callOrder.push('subscribe')
+      envelopeHandler?.({
+        topic: 'amux/team-1/actor-mac/state',
+        bytes: Array.from(
+          toBinary(
+            ActorPresenceSchema,
+            create(ActorPresenceSchema, { online: true, displayName: 'Macmini' }),
+          ),
+        ),
+      })
+    })
+
+    const { initActorPresenceStore, useActorPresenceStore } = await import('../actor-presence-store')
+    await initActorPresenceStore('team-1')
+
+    expect(callOrder).toEqual(['listen', 'subscribe'])
+    expect(useActorPresenceStore.getState().byActorId['actor-mac']?.online).toBe(true)
   })
 
   it('decodes ActorPresence retains and upserts presence by actorId', async () => {

--- a/packages/app/src/stores/__tests__/runtime-state-store.test.ts
+++ b/packages/app/src/stores/__tests__/runtime-state-store.test.ts
@@ -25,6 +25,12 @@ vi.mock('@/lib/mqtt-bridge', () => ({
 
 beforeEach(() => {
   mockSubscribe.mockClear()
+  mockSubscribe.mockResolvedValue(undefined)
+  mockListen.mockClear()
+  mockListen.mockImplementation(async (handler: (env: { topic: string; bytes: number[] }) => void) => {
+    envelopeHandler = handler
+    return () => { envelopeHandler = null }
+  })
   envelopeHandler = null
 })
 
@@ -43,6 +49,41 @@ describe('runtime-state-store', () => {
     await initRuntimeStateStore('team-1')
     expect(mockSubscribe).toHaveBeenCalledTimes(1)
     expect(mockSubscribe).toHaveBeenCalledWith('amux/team-1/+/state')
+  })
+
+  it('registers the envelope handler before subscribing (boot retain race)', async () => {
+    const callOrder: string[] = []
+    mockListen.mockImplementation(async (handler) => {
+      callOrder.push('listen')
+      envelopeHandler = handler
+      return () => {
+        envelopeHandler = null
+      }
+    })
+    mockSubscribe.mockImplementation(async () => {
+      callOrder.push('subscribe')
+      // mqtt.js can deliver retained messages before SUBACK resolves.
+      envelopeHandler?.({
+        topic: 'amux/team-1/dev-a/state',
+        bytes: Array.from(
+          toBinary(
+            ActorPresenceSchema,
+            create(ActorPresenceSchema, {
+              online: true,
+              defaultWorktree: '/tmp/default',
+              defaultWorkspaceModels: [{ id: 'shopee/gpt-5.5', displayName: 'gpt-5.5' }],
+            }),
+          ),
+        ),
+      })
+    })
+
+    const { initRuntimeStateStore, useRuntimeStateStore } = await import('../runtime-state-store')
+    await initRuntimeStateStore('team-1')
+    await flushRuntimeStateBatch()
+
+    expect(callOrder).toEqual(['listen', 'subscribe'])
+    expect(useRuntimeStateStore.getState().defaultCatalogByActorId['dev-a']?.models).toHaveLength(1)
   })
 
   it('decodes ActorPresence retained messages and upserts composite keys', async () => {

--- a/packages/app/src/stores/actor-presence-store.ts
+++ b/packages/app/src/stores/actor-presence-store.ts
@@ -53,7 +53,9 @@ let initialized = false
 
 export async function initActorPresenceStore(teamId: string): Promise<void> {
   if (initialized) return
-  await mqttSubscribe(`amux/${teamId}/+/state`)
+  const actorTopic = `amux/${teamId}/+/state`
+  // Same ordering as runtime-state-store: listen before subscribe so boot retain
+  // is not delivered before this handler is attached.
   unlisten = await listenForEnvelopes((env: IncomingEnvelope) => {
     const parsed = parseActorStateTopic(env.topic)
     if (!parsed) return
@@ -69,6 +71,7 @@ export async function initActorPresenceStore(teamId: string): Promise<void> {
       console.warn('[actor-presence] failed to decode ActorPresence', e)
     }
   })
+  await mqttSubscribe(actorTopic)
   initialized = true
 }
 

--- a/packages/app/src/stores/runtime-state-store.ts
+++ b/packages/app/src/stores/runtime-state-store.ts
@@ -365,8 +365,8 @@ export async function initRuntimeStateStore(teamId: string): Promise<void> {
     return
   }
   const actorTopic = `amux/${teamId}/+/state`
-  await mqttSubscribe(actorTopic)
-  console.info('[runtime-state] subscribed', { teamId, topic: actorTopic })
+  // Register the handler before subscribe: mqtt.js delivers retained messages
+  // as soon as the SUBACK lands, and a subscribe-then-listen race drops boot retain.
   unlisten = await listenForEnvelopes((env: IncomingEnvelope) => {
     const actor = parseActorStateTopic(env.topic)
     if (!actor || actor.teamId !== teamId) return
@@ -393,6 +393,8 @@ export async function initRuntimeStateStore(teamId: string): Promise<void> {
     })
     enqueueActorPresenceSync(actor.actorId, updates, defaultCatalog)
   })
+  await mqttSubscribe(actorTopic)
+  console.info('[runtime-state] subscribed', { teamId, topic: actorTopic })
   initialized = true
 }
 


### PR DESCRIPTION
## Summary
- Register MQTT actor-state listeners before subscribe so browser/extension clients do not drop boot retain messages (fixes draft remote agent catalog + pill stuck on Connecting).
- Treat online remote agents with a known model catalog as ready while lifecycle is STARTING or the session is actively streaming.
- Fall back to daemon-published default workspace catalog when a session attachment retain has no models yet.
- Extend saved-team auto-activation from desktop-only to extension/web; only show TeamPicker when multi-team, joinable public teams, or org buckets require an explicit choice.

## Test plan
- [ ] `pnpm test:unit` — runtime-state-store, actor-presence-store, session-agent-ui-state, agent-model-fallback, AuthGate
- [ ] Build copilot361 extension, reload Side Panel: boot should log `[session-flow] actor_state.retain.received` for SPRBOT without waiting for daemon republish
- [ ] Draft remote agent pill shows ready (not Connecting) once default catalog lands
- [ ] Extension with single team: auto-enters without TeamPicker
- [ ] Extension with multiple teams: TeamPicker still shown


Made with [Cursor](https://cursor.com)