### PR TITLE
fix(app): scope stream recovery by session

### DIFF
--- a/packages/app/src/lib/__tests__/stale-stream-recovery.test.ts
+++ b/packages/app/src/lib/__tests__/stale-stream-recovery.test.ts
@@ -4,7 +4,10 @@ import {
   findStaleLiveStreams,
   STREAM_SILENCE_RECOVERY_MS,
 } from "@/lib/stale-stream-recovery";
-import type { RuntimeStateEntry } from "@/stores/runtime-state-store";
+import {
+  attachmentKey,
+  type RuntimeStateEntry,
+} from "@/stores/runtime-state-store";
 import type { AgentStreamEntry } from "@/stores/v2-streaming-store";
 
 const NOW = 1_800_000_000_000;
@@ -32,12 +35,13 @@ const stream = (
 const runtime = (
   status: AgentStatus,
   lastUpdated: number,
+  sessionId = "s1",
 ): Record<string, RuntimeStateEntry> => ({
-  [AGENT]: {
+  [attachmentKey(AGENT, sessionId)]: {
     daemonActorId: AGENT,
     lastUpdated,
     info: {
-      runtimeId: "abcd1234",
+      runtimeId: sessionId,
       agentType: 0,
       status,
       availableModels: [],
@@ -78,6 +82,32 @@ describe("findStaleLiveStreams — runtime retain reconciliation", () => {
     expect(
       find({ k: stream({ active: false }) }, runtime(AgentStatus.IDLE, NOW)),
     ).toEqual([]);
+  });
+
+  it("ignores a newer terminal retain from another session", () => {
+    expect(
+      find(
+        { k: stream() },
+        {
+          ...runtime(AgentStatus.ACTIVE, NOW - 500, "s1"),
+          ...runtime(AgentStatus.IDLE, NOW - 100, "s2"),
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  it("uses the current session terminal retain when another session is newer", () => {
+    expect(
+      find(
+        { k: stream() },
+        {
+          ...runtime(AgentStatus.IDLE, NOW - 500, "s1"),
+          ...runtime(AgentStatus.ACTIVE, NOW - 100, "s2"),
+        },
+      ),
+    ).toEqual([
+      { sessionId: "s1", actorId: AGENT, reason: "runtime-terminal" },
+    ]);
   });
 });
 

--- a/packages/app/src/lib/stale-stream-recovery.ts
+++ b/packages/app/src/lib/stale-stream-recovery.ts
@@ -1,7 +1,9 @@
 import { AgentStatus } from "@/lib/proto/amux_pb";
 import { isTerminalAgentStatus } from "@/lib/live-agent-stream";
-import { resolveRuntimeStateEntryForAgent } from "@/lib/runtime-state-resolve";
-import type { RuntimeStateEntry } from "@/stores/runtime-state-store";
+import {
+  resolveSessionAttachmentEntry,
+  type RuntimeStateEntry,
+} from "@/stores/runtime-state-store";
 import type { AgentStreamEntry } from "@/stores/v2-streaming-store";
 
 /**
@@ -44,14 +46,15 @@ export function findStaleLiveStreams(args: {
 
   for (const entry of Object.values(args.byKey)) {
     if (!entry.active) continue;
-    const runtime = resolveRuntimeStateEntryForAgent(
+    const runtime = resolveSessionAttachmentEntry(
       entry.actorId,
+      entry.sessionId,
       args.byRuntimeId,
     );
 
-    // `runtime/{id}/state` is a retained topic, so the broker republishes it on
-    // reconnect. A terminal status stamped after the last stream event is proof
-    // that the turn finished and we missed the event.
+    // Actor state is retained and can be replayed on reconnect. Only the
+    // current session's attachment can prove this live turn ended; sibling
+    // sessions for the same actor are unrelated.
     if (
       runtime &&
       isTerminalAgentStatus(runtime.info.status) &&


### PR DESCRIPTION
## Summary
- scope stale stream recovery to the active agent-session attachment
- prevent retained terminal state from sibling sessions from hiding the live output panel
- add multi-session regression coverage

## Test plan
- [x] pnpm --filter @teamclaw/app test:unit (427 files, 2637 tests)
- [x] pnpm --filter @teamclaw/app typecheck