### PR TITLE
fix(self-host): make Google sign-in actually reach Google

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -30,12 +30,13 @@ jobs:
           BELAYO_TEST_RDS_PASSWORD: ${{ secrets.BELAYO_TEST_RDS_PASSWORD }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          AUTH_EGRESS_PROXY: ${{ secrets.AUTH_EGRESS_PROXY }}
         with:
           host: ${{ secrets.ECS_HOST }}
           username: ${{ secrets.ECS_USER }}
           key: ${{ secrets.ECS_SSH_PRIVATE_KEY }}
           command_timeout: 30m
-          envs: DEEPSEEK_API_KEY,TRUSTED_EXTERNAL_JWT_SECRET,FC_SUPABASE_URL,FC_SUPABASE_PUBLIC_URL,FC_SUPABASE_ANON_KEY,FC_SUPABASE_SERVICE_ROLE_KEY,BELAYO_TEST_RDS_PRIVATE_HOST,BELAYO_TEST_RDS_PORT,BELAYO_TEST_RDS_USER,BELAYO_TEST_RDS_PASSWORD,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET
+          envs: DEEPSEEK_API_KEY,TRUSTED_EXTERNAL_JWT_SECRET,FC_SUPABASE_URL,FC_SUPABASE_PUBLIC_URL,FC_SUPABASE_ANON_KEY,FC_SUPABASE_SERVICE_ROLE_KEY,BELAYO_TEST_RDS_PRIVATE_HOST,BELAYO_TEST_RDS_PORT,BELAYO_TEST_RDS_USER,BELAYO_TEST_RDS_PASSWORD,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,AUTH_EGRESS_PROXY
           script: |
             set -e
             cd /opt/teamclaw
@@ -219,6 +220,10 @@ jobs:
             # be able to drift away from the credential pair.
             sync_env GOOGLE_CLIENT_ID "$GOOGLE_CLIENT_ID"
             sync_env GOOGLE_CLIENT_SECRET "$GOOGLE_CLIENT_SECRET"
+            # Egress proxy for GoTrue (see supabase/docker-compose.yml). Google is
+            # unreachable from this box without it, so an empty secret must clear
+            # the key rather than leave a stale proxy in place.
+            sync_env AUTH_EGRESS_PROXY "$AUTH_EGRESS_PROXY"
             if [ -n "$GOOGLE_CLIENT_ID" ] && [ -n "$GOOGLE_CLIENT_SECRET" ]; then
               upsert_env ENABLE_GOOGLE_SIGNUP "true"
             else

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -127,6 +127,18 @@ ENABLE_GOOGLE_SIGNUP=false
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
+# Egress proxy for GoTrue's outbound HTTP, needed only where Google is not
+# directly reachable (e.g. a mainland-China host). GoTrue does OIDC discovery
+# against accounts.google.com on every authorize request, so without this the
+# request hangs until the gateway times out.
+#
+# MUST be https:// — TLS to the proxy itself. With a plaintext http:// proxy the
+# "CONNECT accounts.google.com:443" line is visible in transit and gets reset,
+# which looks like a proxy bug: the proxy reaches Google and then fails to write
+# the 200 back to the client. Leave blank where Google is reachable directly.
+#   AUTH_EGRESS_PROXY=https://user:password@proxy.example.com:3129
+AUTH_EGRESS_PROXY=
+
 # ── Phone login (optional; needs all three + SERVICE_ROLE_KEY) ─────────
 # PHONE_EMAIL_DOMAIN is half the account identity (`<phone>@<domain>`) —
 # it must match whatever partner SaaS shares this GoTrue, or phone users

--- a/deploy/self-host/README.md
+++ b/deploy/self-host/README.md
@@ -299,6 +299,23 @@ docker compose up -d --no-deps auth
 GitHub Actions secret，`self-host-deploy.yml` 会同步进 `.env` 并按两者是否都存在
 自动开关 `ENABLE_GOOGLE_SIGNUP`；删掉 secret 即关闭。
 
+**如果机器在墙内，还需要一个出网代理。** GoTrue 每次 authorize 都要拉
+`accounts.google.com` 的 OIDC discovery；拉不到就挂到网关超时（现象是 504
+`request_timeout`，很容易误判成 GoTrue 有 bug）。设 `AUTH_EGRESS_PROXY`
+（线上同样走 GitHub secret）：
+
+```bash
+AUTH_EGRESS_PROXY=https://user:password@proxy.example.com:3129
+```
+
+**必须是 `https://`，即到代理这一跳本身也加密。** 用明文 `http://` 代理时，
+`CONNECT accounts.google.com:443` 这一行在链路上是可见的，会被按关键词重置 ——
+表现为代理明明连上了 Google，却写不回那个 `200 Connection established`。
+外层 TLS 的 SNI 是代理自己的域名，不含敏感关键词，所以能过。
+
+注意这条链路上有两个"必须能到 Google"的角色，别混淆：**服务端**（GoTrue 换
+token、验签）和**终端用户浏览器**（打开 Google 授权页）。代理只解决前者。
+
 桌面端按钮另受 `build.config.*.json` 的 `auth.google` 控制，默认 `false`，
 服务端跑通后再打开。
 

--- a/deploy/self-host/supabase/docker-compose.yml
+++ b/deploy/self-host/supabase/docker-compose.yml
@@ -135,6 +135,23 @@ services:
       GOTRUE_EXTERNAL_GOOGLE_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: ${SUPABASE_PUBLIC_URL:-https://${SUPABASE_DOMAIN}}/auth/v1/callback
 
+      # Egress proxy for GoTrue's outbound HTTP. This box sits in mainland China
+      # and Google is black-holed from it, while GoTrue does OIDC discovery
+      # against accounts.google.com on EVERY authorize request — without a proxy
+      # the request stalls until Kong's 10s timeout and returns 504.
+      #
+      # The proxy URL must be https:// (TLS to the proxy itself), not http://.
+      # A plaintext "CONNECT accounts.google.com:443" is keyword-reset in transit,
+      # which fails in a thoroughly confusing way: the proxy reaches Google fine
+      # and then cannot write the 200 back. TLS hides the CONNECT line.
+      #
+      # Left empty, Go ignores these and behaves exactly as before.
+      HTTP_PROXY: ${AUTH_EGRESS_PROXY:-}
+      HTTPS_PROXY: ${AUTH_EGRESS_PROXY:-}
+      # Keep everything inside the compose network off the proxy. Go already
+      # exempts localhost and loopback, but not sibling service names.
+      NO_PROXY: localhost,127.0.0.1,::1,db,kong,rest,realtime,storage,imgproxy,meta,analytics,functions,supavisor,fc,litellm,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+
       GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL}
       GOTRUE_SMTP_HOST: ${SMTP_HOST}
       GOTRUE_SMTP_PORT: ${SMTP_PORT}

--- a/deploy/self-host/supabase/docker-compose.yml
+++ b/deploy/self-host/supabase/docker-compose.yml
@@ -121,13 +121,19 @@ services:
       # Defaults keep it off, so an .env that predates these keys still boots.
       # GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET are shared with the fc service in
       # ../docker-compose.yml — one credential pair, one .env entry each.
-      # The redirect URI here must byte-match the "Authorized redirect URI" on the
-      # Google OAuth client, and API_EXTERNAL_URL carries no path (gen-secrets.sh
-      # sets it to https://<SUPABASE_DOMAIN>), hence the explicit /auth/v1/callback.
+      # The redirect URI must byte-match the "Authorized redirect URI" on the
+      # Google OAuth client. Do NOT build it from API_EXTERNAL_URL: gen-secrets.sh
+      # sets that to the Supabase host, but it is not run on an existing box, and
+      # the live one carries the *Cloud API* host there instead — which hands
+      # Google a callback on a domain that serves no /auth/v1 at all. Derive it
+      # from the Supabase public URL, the same value FC uses to build the
+      # authorize URL (supabase-repo/auth.ts oauthAuthorizeUrl), so the two halves
+      # of the flow cannot disagree. The path is spelled out because neither
+      # variable carries one.
       GOTRUE_EXTERNAL_GOOGLE_ENABLED: ${ENABLE_GOOGLE_SIGNUP:-false}
       GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOTRUE_EXTERNAL_GOOGLE_SECRET: ${GOOGLE_CLIENT_SECRET:-}
-      GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: ${API_EXTERNAL_URL}/auth/v1/callback
+      GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: ${SUPABASE_PUBLIC_URL:-https://${SUPABASE_DOMAIN}}/auth/v1/callback
 
       GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL}
       GOTRUE_SMTP_HOST: ${SMTP_HOST}


### PR DESCRIPTION
Follow-up to #752. That PR enabled the provider correctly, but deploying it
surfaced two further blockers — both measured on the live box, not inferred.

## 1. The callback was built from the wrong host

`GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI` was derived from `API_EXTERNAL_URL`, on
the assumption that `bootstrap/gen-secrets.sh:83` had set it to the Supabase
domain. That script is deliberately **not** run by `self-host-deploy.yml` (it
would re-mint `ANON_KEY`/`SERVICE_ROLE_KEY` on every deploy), and the live box's
`.env` predates it:

```
API_EXTERNAL_URL=https://api.teamclaw-dev.ucar.cc      # the Cloud API host!
SUPABASE_PUBLIC_URL=https://supabase.teamclaw-dev.ucar.cc
```

So GoTrue was handing Google a callback on a domain that serves no `/auth/v1`
and is not registered on the OAuth client — every exchange would have failed
with `redirect_uri_mismatch`.

Now derived from `SUPABASE_PUBLIC_URL`, the same value FC uses to build the
authorize URL (`supabase-repo/auth.ts` `oauthAuthorizeUrl`), so the two halves
of the flow cannot disagree. Verified with `docker compose config` on the box
against its real `.env` — resolves to
`https://supabase.teamclaw-dev.ucar.cc/auth/v1/callback`, and the
`SUPABASE_DOMAIN` fallback branch resolves correctly too.

**Rule worth keeping:** never build a Supabase-facing URL from
`API_EXTERNAL_URL` on this box.

## 2. The box cannot reach Google at all

Not a general egress problem — measured from the box:

```
github.com             http=200  0.686s
aliyun.com             http=403  0.028s
accounts.google.com    http=000  6.00s   ← black hole
oauth2.googleapis.com  http=000  6.00s
```

GoTrue does OIDC discovery against `accounts.google.com` on **every** authorize
request, so `/auth/v1/authorize?provider=google` stalled until Kong's 10s
upstream timeout and returned `504 request_timeout`. That reads like a GoTrue
bug; it is a network black hole.

This PR adds an optional `AUTH_EGRESS_PROXY` (`HTTP_PROXY`/`HTTPS_PROXY` on the
auth service, with `NO_PROXY` covering the compose network). Empty means no
proxy, so any host that reaches Google directly is unaffected.

### The proxy URL must be `https://`, not `http://`

A plaintext `CONNECT accounts.google.com:443` carries the hostname in the clear
and is reset in transit. The failure mode is deliberately confusing — the proxy
reaches Google and only *then* fails:

```
CONNECT accounts.google.com:443 HTTP/1.1
Established connection to host "accounts.google.com" using file descriptor 6.
ERROR: handle_connection: Could not send CONNECT method greeting to client.
```

Clean control, same proxy and port, same moment:

| raw request | result |
|---|---|
| `CONNECT accounts.google.com:443` | no response at all |
| `CONNECT www.googleapis.com:443` | normal `HTTP/1.0 407 Proxy Authentication Required` |

Only `accounts.google.com` is the blocked keyword. Wrapping the hop in TLS hides
the CONNECT line; the outer SNI is the proxy's own hostname and passes.

### Proxy side (infrastructure, not in this diff)

Running on the Singapore box that already serves `ai.mx5.cn`:
stunnel terminates TLS on `:3129` with that host's existing Let's Encrypt cert
and forwards to tinyproxy on `127.0.0.1:3130`. Deliberately single-purpose —
security group restricted to the self-host box's IP alone, basic auth, `CONNECT`
limited to 443, and a host allow-list containing only the Google OAuth
endpoints. nginx was not touched; it serves live traffic. A certbot deploy hook
restarts stunnel after renewal (dry-run passes) — without it the proxy would
break weeks later when the cert rotates.

End-to-end from the self-host box through the finished chain:

```
accounts.google.com    200  0.998s   (real discovery document returned)
www.googleapis.com     200  1.028s
github.com             000          (outside the allow-list, refused)
```

## Secrets

`AUTH_EGRESS_PROXY` added to the `self-host-production` environment, alongside
the `GOOGLE_CLIENT_*` pair from #752. Clearing it turns the proxy back off.

## Still not covered

The proxy fixes the **server** half only. An end user's browser still has to
reach Google's consent page on its own, which is a separate problem for users
in mainland China and is not solvable from the server side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)