### PR TITLE
build(release): define the official build in this repo, and enable Google

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,42 +53,27 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Write production build config from secret
-        env:
-          BUILD_CONFIG_PRODUCTION: ${{ secrets.BUILD_CONFIG_PRODUCTION }}
-        run: |
-          if [ -n "$BUILD_CONFIG_PRODUCTION" ]; then
-            echo "$BUILD_CONFIG_PRODUCTION" > build.config.json
-            echo "✅ Production build config written (replaces repo default)"
-          else
-            echo "⚠️ No BUILD_CONFIG_PRODUCTION secret set, using defaults"
-          fi
-
-      - name: Fetch branding assets (private repo)
-        env:
-          BRANDING_REPO: ${{ vars.BRANDING_REPO }}
-          BRANDING_REPO_PAT: ${{ secrets.BRANDING_REPO_PAT }}
-          BRANDING_CONFIG_FILE: ${{ vars.BRANDING_CONFIG_FILE }}
+      - name: Materialise the official build config
         shell: bash
         run: |
-          if [ -z "$BRANDING_REPO" ] || [ -z "$BRANDING_REPO_PAT" ]; then
-            echo "ℹ️ No branding repo configured (BRANDING_REPO / BRANDING_REPO_PAT) — non-branded build"
-            exit 0
-          fi
-          git clone --depth 1 "https://x-access-token:${BRANDING_REPO_PAT}@github.com/${BRANDING_REPO}.git" .branding-src
-          if [ -d .branding-src/branding ]; then
-            mkdir -p ./branding
-            cp -R .branding-src/branding/. ./branding/
-            echo "✅ Branding assets placed under ./branding"
-          fi
-          cfg="${BRANDING_CONFIG_FILE:-build.config.copilot361.json}"
-          if [ -f ".branding-src/${cfg}" ]; then
-            cp ".branding-src/${cfg}" build.config.json
-            echo "✅ Branding build config applied: ${cfg} (overrides BUILD_CONFIG_PRODUCTION)"
-          else
-            echo "⚠️ Branding config ${cfg} not found in branding repo; keeping existing build.config.json"
-          fi
-          rm -rf .branding-src
+          # This workflow builds ONE brand: official. Its config lives in this
+          # repo. betly and copilot361 live in the private branding repo and are
+          # published by release-oss.yml — nothing here reaches for them.
+          #
+          # Previously the base came from a BUILD_CONFIG_PRODUCTION secret and was
+          # then overwritten by a file from the branding repo, chosen by the
+          # BRANDING_CONFIG_FILE variable. That variable is set to
+          # build.config.copilot361.json, which does not exist in that repo, so the
+          # override silently no-opped — and would have silently repointed the
+          # official build at copilot361's backend the day anyone added it.
+          #
+          # Copy rather than lean on the BUILD_ENV=production merge alone: build.rs
+          # and vite both merge build.config.production.json ON TOP of this file, so
+          # making the two identical turns the merge into a no-op and anything that
+          # reads build.config.json directly sees the same values.
+          cp build.config.production.json build.config.json
+          echo "Official build config:"
+          cat build.config.json
 
       - name: Verify Tauri signing key
         env:
@@ -322,43 +307,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Write production build config from secret
-        env:
-          BUILD_CONFIG_PRODUCTION: ${{ secrets.BUILD_CONFIG_PRODUCTION }}
+      - name: Materialise the official build config
         shell: bash
         run: |
-          if [ -n "$BUILD_CONFIG_PRODUCTION" ]; then
-            echo "$BUILD_CONFIG_PRODUCTION" > build.config.json
-            echo "✅ Production build config written (replaces repo default)"
-          else
-            echo "⚠️ No BUILD_CONFIG_PRODUCTION secret set, using defaults"
-          fi
-
-      - name: Fetch branding assets (private repo)
-        env:
-          BRANDING_REPO: ${{ vars.BRANDING_REPO }}
-          BRANDING_REPO_PAT: ${{ secrets.BRANDING_REPO_PAT }}
-          BRANDING_CONFIG_FILE: ${{ vars.BRANDING_CONFIG_FILE }}
-        shell: bash
-        run: |
-          if [ -z "$BRANDING_REPO" ] || [ -z "$BRANDING_REPO_PAT" ]; then
-            echo "ℹ️ No branding repo configured (BRANDING_REPO / BRANDING_REPO_PAT) — non-branded build"
-            exit 0
-          fi
-          git clone --depth 1 "https://x-access-token:${BRANDING_REPO_PAT}@github.com/${BRANDING_REPO}.git" .branding-src
-          if [ -d .branding-src/branding ]; then
-            mkdir -p ./branding
-            cp -R .branding-src/branding/. ./branding/
-            echo "✅ Branding assets placed under ./branding"
-          fi
-          cfg="${BRANDING_CONFIG_FILE:-build.config.copilot361.json}"
-          if [ -f ".branding-src/${cfg}" ]; then
-            cp ".branding-src/${cfg}" build.config.json
-            echo "✅ Branding build config applied: ${cfg} (overrides BUILD_CONFIG_PRODUCTION)"
-          else
-            echo "⚠️ Branding config ${cfg} not found in branding repo; keeping existing build.config.json"
-          fi
-          rm -rf .branding-src
+          # Same as the macOS job above — see the comment there for why the
+          # BUILD_CONFIG_PRODUCTION secret and the branding-repo override are gone.
+          cp build.config.production.json build.config.json
+          echo "Official build config:"
+          cat build.config.json
 
       - name: Verify Tauri signing key
         env:

--- a/build.config.production.json
+++ b/build.config.production.json
@@ -17,6 +17,9 @@
       "kook": true,
       "wecom": true,
       "wechat": true
+    },
+    "auth": {
+      "google": true
     }
   },
   "defaults": {


### PR DESCRIPTION
Three brands from here on:

| brand | config source | published by |
|---|---|---|
| **official** | this repo — `build.config.production.json` | `release.yml` (tag `v*`) |
| betly | private branding repo `brands/betly/` | `release-oss.yml` |
| copilot361 | private branding repo `brands/copilot361/` | `release-oss.yml` |

`release.yml` builds only the first, so it no longer reaches for the branding
repo at all.

## What it did before

1. Wrote `build.config.json` from a `BUILD_CONFIG_PRODUCTION` secret.
2. Cloned the private branding repo and let a file from it **overwrite** that
   config, chosen by the `BRANDING_CONFIG_FILE` variable.

That variable is set to `build.config.copilot361.json` — **a path that does not
exist in that repo** (its root holds only `README.md`, `branding/`, `brands/`).
So every official release silently took the `⚠️ config not found, keeping
existing` branch. Harmless today, but it would have silently repointed the
official build at copilot361's backend the day anyone added that file. Both
layers are gone.

## Correction worth stating

`build.config.production.json` was **already being read** — `build.rs:81` and
`vite.config.ts:50` both deep-merge `build.config.<BUILD_ENV>.json`, and this
workflow sets `BUILD_ENV: production`, so it layered on top of the secret. This
PR makes the base identical to that layer, which turns the merge into a no-op
instead of a partial override of an invisible base.

A consequence: enabling `features.auth.google` needed no workflow change at all.
The workflow change is about removing the hidden layer underneath it.

## What dropping the secret could have broken

The secret's contents are not readable, so every key
`build.config.production.json` does *not* define had to be checked individually:

| missing key | outcome |
|---|---|
| `app.updater.endpoints` / `pubkey` | **safe** — `tauri.conf.json` carries both, and `updater.rs`'s `DEFAULT_PUBKEY` is the same 1D087DF9 key with `DEFAULT_REPO_OWNER/NAME` pointing at this repo, so the unset `option_env!` resolves identically |
| `app.logo` | unset → `resolveLogoPlan` returns null → icon regeneration skipped, repo default icon set used, no `./branding` required |
| `app.palette` | unset → `resolveBrandTheme` returns null for absent/`default`, no `theme.json` required |
| `localAgent` | unset → `build-config.ts:232` defaults to `opencode` |
| `features.auth`, `features.teamShareBrowser` | covered by `FALLBACK_BUILD_CONFIG` |

`app.shortName` stays `teamclaw`, which is in `OFFICIAL_BRAND_SHORT_NAMES`, so
the official on-disk (`.teamclaw`) and localStorage namespace is preserved — a
rename there would have orphaned every existing install's data.

## Merged config, verified

Reproducing the real `deepMerge` chain (fallback → base → BUILD_ENV layer):

```
cloudApiUrl : https://api.teamclaw-dev.ucar.cc
mqttWsUrl   : wss://mqtt.teamclaw-dev.ucar.cc/mqtt
app         : {'name': 'TeamClaw', 'shortName': 'teamclaw'}
auth        : {'google': True, 'wechat': False, 'phone': False, 'password': False, 'webSSO': False}
updater     : True
idempotent  : True
```

`cloudApiUrl` is the self-host box, where Google sign-in was verified end-to-end
(#752, #753) — 302 to `accounts.google.com` in 0.1s, loopback receives the code.

## Not touched

- **betly / copilot361** — betly's backend still answers
  `Unsupported provider: provider is not enabled`, so enabling Google there
  would ship a button that cannot work. Its `app.name` is also `TeamClaw`, which
  makes it easy to mistake for the official brand; it is not.
- **`release-extension.yml`** — same secret + override pattern, different
  artifact. Out of scope here, but it carries the identical latent hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)