### PR TITLE
chore(release): v0.3.1-beta.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "amuxd"
-version = "0.3.1-beta.21"
+version = "0.3.1-beta.22"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10742,7 +10742,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaw"
-version = "0.3.1-beta.21"
+version = "0.3.1-beta.22"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.3.1-beta.21"
+version = "0.3.1-beta.22"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaw"
-version = "0.3.1-beta.21"
+version = "0.3.1-beta.22"
 description = "TeamClaw - AI Agent Desktop Platform"
 authors = ["TeamClaw Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClaw",
-  "version": "0.3.1-beta.21",
+  "version": "0.3.1-beta.22",
   "identifier": "com.teamclaw.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclaw/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclaw",
-  "version": "0.3.1-beta.21",
+  "version": "0.3.1-beta.22",
   "private": true,
   "description": "TeamClaw - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
Version bump so the official desktop build can be tagged. First official build
carrying Google sign-in (#752, #753, #755) and the restyled OAuth callback page
(#754).

Bumps the four canonical sources plus the two workspace entries in `Cargo.lock`:

```
package.json          0.3.1-beta.21 → 0.3.1-beta.22
apps/desktop/Cargo.toml
apps/desktop/tauri.conf.json
apps/daemon/Cargo.toml
Cargo.lock            (teamclaw + amuxd entries only)
```

## Why not reuse 0.3.1-beta.21

The nightly job bumped the repo to `0.3.1-beta.21` without pushing a matching
tag, and betly's OSS channel already publishes an artifact under that version.
Tagging it would put two differently-configured builds behind one version
number — and would defeat the very thing the release gate exists to protect:
the client only force-upgrades `~/.amuxd/bin/amuxd` when the bundled crate
version is strictly greater than the installed one, so anyone already on
`0.3.1-beta.21` would keep their old daemon.

## Verification

`scripts/verify-release-version-bump.sh v0.3.1-beta.22 v0.3.1-beta.22` — the
same script the release gate runs — passes locally:

```
✓ All desktop version sources match (0.3.1-beta.22)
✓ Release version 0.3.1-beta.22 is new (not previously released);
  bundled amuxd bump enforced.
```

Once merged, pushing `v0.3.1-beta.22` triggers `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)