### PR TITLE
chore(release): copilot361 v0.3.1-beta.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "amuxd"
-version = "0.3.1-beta.22"
+version = "0.3.1-beta.23"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10742,7 +10742,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaw"
-version = "0.3.1-beta.22"
+version = "0.3.1-beta.23"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.3.1-beta.22"
+version = "0.3.1-beta.23"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaw"
-version = "0.3.1-beta.22"
+version = "0.3.1-beta.23"
 description = "TeamClaw - AI Agent Desktop Platform"
 authors = ["TeamClaw Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClaw",
-  "version": "0.3.1-beta.22",
+  "version": "0.3.1-beta.23",
   "identifier": "com.teamclaw.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclaw/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclaw",
-  "version": "0.3.1-beta.22",
+  "version": "0.3.1-beta.23",
   "private": true,
   "description": "TeamClaw - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
## Summary

Bump desktop/amuxd version to **0.3.1-beta.23** for a copilot361 OSS release.

Includes latest main (PR #759 cursor-bridge auth retry, env transition, OTP email fixes).

## Test plan

- [ ] Merge to main
- [ ] Dispatch `release-oss.yml` with brand `copilot361`, tag `v0.3.1-beta.23`
- [ ] Verify OSS manifest + installers updated

Made with [Cursor](https://cursor.com)