### PR TITLE
fix(deploy): use caddy:2 for auth templates-server on ECS

### DIFF
--- a/deploy/self-host/supabase/docker-compose.yml
+++ b/deploy/self-host/supabase/docker-compose.yml
@@ -71,7 +71,8 @@ services:
 
   templates-server:
     container_name: supabase-auth-templates
-    image: caddy:2-alpine
+    # Match the caddy:2 image already present on ECS (deploy uses --pull never).
+    image: caddy:2
     restart: unless-stopped
     command: ["caddy", "file-server", "-r", "/templates", "--listen", ":80"]
     volumes:


### PR DESCRIPTION
## Summary
- Switch `templates-server` from `caddy:2-alpine` to `caddy:2`, which is already present on the ECS box.
- Unblocks the failed Self-Host Deploy from PR #758 so OTP-only auth email templates can roll out.

## Context
Deploy run [#31004838839](https://github.com/different-ai-studio/teamclaw/actions/runs/31004838839) failed with:
```
Error response from daemon: No such image: caddy:2-alpine
```
because `docker compose up -d --pull never` does not fetch new images.

## Test plan
- [ ] Merge and confirm Self-Host Deploy succeeds
- [ ] Verify `supabase-auth-templates` container is running on ECS
- [ ] Request login OTP and confirm email contains only the 6-digit code


Made with [Cursor](https://cursor.com)