### PR TITLE
fix(deploy): restart Kong after auth recreate to unblock e2e

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -266,6 +266,15 @@ jobs:
             echo "=== up ==="
             docker compose up -d --pull never --remove-orphans
 
+            # auth is recreated whenever its env changes (mailer templates, OAuth,
+            # etc.). Kong keeps stale upstream connections to the old container IP
+            # and answers /auth/v1/* with "invalid response from upstream" until
+            # restarted — which makes the post-deploy e2e suite fail on refresh.
+            echo "=== restart kong (flush stale auth upstream after compose up) ==="
+            docker compose restart kong
+            timeout 60 sh -c \
+              'until docker compose ps kong | grep -q "Up\|running"; do sleep 3; done'
+
             echo "=== wait for litellm healthy (prisma migrate runs on first boot) ==="
             timeout 300 sh -c \
               'until docker compose ps litellm | grep -q healthy; do sleep 5; done'

--- a/deploy/self-host/smoke/run-e2e.sh
+++ b/deploy/self-host/smoke/run-e2e.sh
@@ -57,6 +57,26 @@ else
   [ "$i" -lt 60 ] || echo "WARN: postgrest still not serving after 60s; running the suite anyway"
 fi
 
+# ── Wait for GoTrue through Kong ───────────────────────────────────────────
+#
+# After auth is recreated, Kong may still proxy to a dead upstream until it is
+# restarted (the deploy workflow does that, but this wait catches any residual
+# warm-up). Probe /auth/v1/health so token refresh in the first e2e suite does
+# not fail spuriously.
+echo "=== wait for gotrue via kong ==="
+i=0
+until [ "$i" -ge 30 ]; do
+  code=$(curl -s -o /dev/null -w '%{http_code}' -m 5 \
+    "http://$KONG_IP:8000/auth/v1/health" 2>/dev/null || echo "000")
+  if [ "$code" = "200" ]; then
+    echo "  gotrue ready via kong after ${i}s"
+    break
+  fi
+  i=$((i + 1))
+  sleep 1
+done
+[ "$i" -lt 30 ] || echo "WARN: gotrue health via kong still not 200 after 30s; running the suite anyway"
+
 cd "$REPO_ROOT/services/fc"
 FC_E2E=1 \
 FC_E2E_BASE_URL="http://$FC_IP:9000" \


### PR DESCRIPTION
## Summary
- Restart Kong after `docker compose up` so it picks up the new GoTrue container IP after auth env changes (mailer templates, OAuth, etc.).
- Add a GoTrue health probe in `run-e2e.sh` before the suite runs.

## Context
Self-Host Deploy for PR #761 failed at e2e with:
```
Token refresh failed: "An invalid response was received from the upstream server"
```
`templates-server` and `supabase-auth` **did** start successfully — the OTP email template change is likely already live; only the deploy gate failed.

Root cause: auth was recreated but Kong was not restarted, leaving stale upstream routes.

## Test plan
- [ ] Merge and confirm Self-Host Deploy completes green
- [ ] Request login OTP and verify email is code-only


Made with [Cursor](https://cursor.com)