### PR TITLE
feat(deploy): CI-driven amuxd deploy to ECS via GHCR

### DIFF
--- a/.github/workflows/daemon-deploy.yml
+++ b/.github/workflows/daemon-deploy.yml
@@ -1,0 +1,185 @@
+name: Daemon Deploy
+
+# Build amuxd in GitHub Actions, push to GHCR, and roll the daemon profile on
+# the self-host ECS box. The server never runs `cargo build` — it only pulls
+# the prebuilt image and recreates the amuxd service.
+#
+# First-time bootstrap (once per ECS box):
+#   1. Ensure at least one team + human member exist.
+#   2. SSH to ECS and mint a daemon invite:
+#        cd /opt/teamclaw/deploy/self-host && ./amuxd/mint-invite.sh <TEAM_ID>
+#   3. Store the token in GitHub secret AMUXD_JOIN_TOKEN (or upsert into .env).
+#   4. Trigger this workflow. Identity persists in the amuxd_state volume; later
+#      deploys skip the join token even if the secret is removed.
+#
+# Agent capability is optional:
+#   - presence-only (default): leave OPENCODE_API_KEY unset.
+#   - full agent sessions: set OPENCODE_BASE_URL + OPENCODE_API_KEY + OPENCODE_MODEL
+#     (LiteLLM on the same box: http://litellm:4000/v1 + a virtual key).
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - 'apps/daemon/**'
+      - 'crates/**'
+      - 'deploy/self-host/amuxd/**'
+      - 'deploy/self-host/docker-compose.yml'
+      - 'deploy/self-host/smoke/amuxd-smoke.sh'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/daemon-deploy.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: daemon-deploy
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: teamclaw-amuxd
+  DEPLOY_REF: ${{ github.event_name == 'push' && 'main' || github.ref_name }}
+
+jobs:
+  build:
+    name: Build & push image
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=self-host
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/self-host/amuxd/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # ECS pulls without credentials when the package is public. The first push
+      # creates the package; this step opens read access for docker pull on the
+      # box. Falls back to GHCR_PULL_TOKEN when the API call is denied.
+      - name: Ensure GHCR package is public
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method PATCH \
+            "/orgs/${{ github.repository_owner }}/packages/container/${{ env.IMAGE_NAME }}/visibility" \
+            -f visibility=public
+
+  deploy:
+    name: Deploy to ECS
+    needs: build
+    runs-on: ubuntu-latest
+    environment: self-host-production
+    env:
+      AMUXD_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+    steps:
+      - name: Deploy amuxd on ECS
+        uses: appleboy/ssh-action@v1.2.5
+        env:
+          AMUXD_IMAGE: ${{ env.AMUXD_IMAGE }}
+          DEPLOY_REF: ${{ env.DEPLOY_REF }}
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN || secrets.UPDATER_GITHUB_TOKEN }}
+          GHCR_PULL_USER: ${{ secrets.GHCR_PULL_USER }}
+          AMUXD_JOIN_TOKEN: ${{ secrets.AMUXD_JOIN_TOKEN }}
+          OPENCODE_BASE_URL: ${{ secrets.OPENCODE_BASE_URL }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          OPENCODE_MODEL: ${{ secrets.OPENCODE_MODEL }}
+          OPENCODE_PROVIDER_ID: ${{ secrets.OPENCODE_PROVIDER_ID }}
+          OPENCODE_PROVIDER_NAME: ${{ secrets.OPENCODE_PROVIDER_NAME }}
+        with:
+          host: ${{ secrets.ECS_HOST }}
+          username: ${{ secrets.ECS_USER }}
+          key: ${{ secrets.ECS_SSH_PRIVATE_KEY }}
+          command_timeout: 15m
+          envs: AMUXD_IMAGE,DEPLOY_REF,GHCR_PULL_TOKEN,GHCR_PULL_USER,AMUXD_JOIN_TOKEN,OPENCODE_BASE_URL,OPENCODE_API_KEY,OPENCODE_MODEL,OPENCODE_PROVIDER_ID,OPENCODE_PROVIDER_NAME
+          script: |
+            set -e
+            cd /opt/teamclaw
+
+            echo "=== git pull (${DEPLOY_REF}) ==="
+            git config http.lowSpeedLimit 1000
+            git config http.lowSpeedTime 20
+            fetched=""
+            for i in 1 2 3 4 5 6 7 8; do
+              if git fetch origin "$DEPLOY_REF"; then fetched=yes; echo "  fetch ok (attempt $i)"; break; fi
+              echo "  fetch attempt $i failed; retrying in 10s"
+              sleep 10
+            done
+            [ -n "$fetched" ] || { echo "git fetch failed after 8 attempts"; exit 1; }
+            git reset --hard "origin/$DEPLOY_REF"
+
+            cd deploy/self-host
+
+            upsert_env() {
+              [ -n "$2" ] || { echo "  skip $1 (empty)"; return 0; }
+              if grep -q "^$1=" .env; then
+                awk -v k="$1" -v v="$2" 'BEGIN{FS=OFS="="} $1==k{print k"="v; next}{print}' .env > .env.tmp && mv .env.tmp .env
+              else
+                printf '%s=%s\n' "$1" "$2" >> .env
+              fi
+              echo "  set $1"
+            }
+
+            echo "=== pull amuxd image from GHCR ==="
+            pull_user="${GHCR_PULL_USER:-${{ github.repository_owner }}}"
+            if [ -n "${GHCR_PULL_TOKEN:-}" ]; then
+              echo "$GHCR_PULL_TOKEN" | docker login ghcr.io -u "$pull_user" --password-stdin
+            else
+              echo "  skip ghcr login (public package pull)"
+            fi
+
+            echo "=== sync daemon env ==="
+            upsert_env AMUXD_IMAGE "$AMUXD_IMAGE"
+            upsert_env AMUXD_JOIN_TOKEN "$AMUXD_JOIN_TOKEN"
+            upsert_env OPENCODE_BASE_URL "$OPENCODE_BASE_URL"
+            upsert_env OPENCODE_API_KEY "$OPENCODE_API_KEY"
+            upsert_env OPENCODE_MODEL "$OPENCODE_MODEL"
+            upsert_env OPENCODE_PROVIDER_ID "$OPENCODE_PROVIDER_ID"
+            upsert_env OPENCODE_PROVIDER_NAME "$OPENCODE_PROVIDER_NAME"
+
+            echo "=== ensure fc + emqx healthy ==="
+            docker compose up -d fc emqx
+            timeout 180 sh -c \
+              'until docker compose ps fc | grep -q healthy; do sleep 5; done'
+            timeout 180 sh -c \
+              'until docker compose ps emqx | grep -q healthy; do sleep 5; done'
+
+            echo "=== pull + recreate amuxd ==="
+            docker compose pull amuxd
+            docker compose --profile daemon up -d --pull never --remove-orphans amuxd
+
+            echo "=== amuxd smoke ==="
+            sh smoke/amuxd-smoke.sh
+
+            echo "=== daemon deploy complete ==="

--- a/.github/workflows/daemon-deploy.yml
+++ b/.github/workflows/daemon-deploy.yml
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: self-host-production
     env:
-      AMUXD_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+      AMUXD_IMAGE: ghcr.io/${{ github.repository_owner }}/teamclaw-amuxd:${{ github.sha }}
     steps:
       - name: Deploy amuxd on ECS
         uses: appleboy/ssh-action@v1.2.5

--- a/.github/workflows/daemon-deploy.yml
+++ b/.github/workflows/daemon-deploy.yml
@@ -1,8 +1,7 @@
 name: Daemon Deploy
 
-# Build amuxd in GitHub Actions, push to GHCR, and roll the daemon profile on
-# the self-host ECS box. The server never runs `cargo build` — it only pulls
-# the prebuilt image and recreates the amuxd service.
+# Build amuxd in GitHub Actions, push to GHCR, stream the image to ECS over SSH,
+# and roll the daemon profile. The server never runs `cargo build`.
 #
 # First-time bootstrap (once per ECS box):
 #   1. Ensure at least one team + human member exist.
@@ -84,33 +83,47 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # ECS pulls without credentials when the package is public. The first push
-      # creates the package; this step opens read access for docker pull on the
-      # box. Falls back to GHCR_PULL_TOKEN when the API call is denied.
-      - name: Ensure GHCR package is public
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api --method PATCH \
-            "/orgs/${{ github.repository_owner }}/packages/container/${{ env.IMAGE_NAME }}/visibility" \
-            -f visibility=public
-
   deploy:
     name: Deploy to ECS
     needs: build
     runs-on: ubuntu-latest
     environment: self-host-production
     env:
-      AMUXD_IMAGE: ghcr.io/${{ github.repository_owner }}/teamclaw-amuxd:${{ github.sha }}
+      AMUXD_IMAGE: ghcr.io/${{ github.repository_owner }}/teamclaw-amuxd:self-host
     steps:
+      - name: Prepare SSH key
+        env:
+          ECS_SSH_PRIVATE_KEY: ${{ secrets.ECS_SSH_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$ECS_SSH_PRIVATE_KEY" > ~/.ssh/ecs_key
+          chmod 600 ~/.ssh/ecs_key
+
+      - name: Set up Docker CLI
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stream image to ECS
+        env:
+          ECS_HOST: ${{ secrets.ECS_HOST }}
+          ECS_USER: ${{ secrets.ECS_USER }}
+        run: |
+          docker pull "$AMUXD_IMAGE"
+          docker save "$AMUXD_IMAGE" | gzip -1 | \
+            ssh -i ~/.ssh/ecs_key -o StrictHostKeyChecking=no "$ECS_USER@$ECS_HOST" \
+              "gunzip | docker load"
+
       - name: Deploy amuxd on ECS
         uses: appleboy/ssh-action@v1.2.5
         env:
           AMUXD_IMAGE: ${{ env.AMUXD_IMAGE }}
           DEPLOY_REF: ${{ env.DEPLOY_REF }}
-          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN || secrets.UPDATER_GITHUB_TOKEN }}
-          GHCR_PULL_USER: ${{ secrets.GHCR_PULL_USER }}
           AMUXD_JOIN_TOKEN: ${{ secrets.AMUXD_JOIN_TOKEN }}
           OPENCODE_BASE_URL: ${{ secrets.OPENCODE_BASE_URL }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
@@ -122,7 +135,7 @@ jobs:
           username: ${{ secrets.ECS_USER }}
           key: ${{ secrets.ECS_SSH_PRIVATE_KEY }}
           command_timeout: 15m
-          envs: AMUXD_IMAGE,DEPLOY_REF,GHCR_PULL_TOKEN,GHCR_PULL_USER,AMUXD_JOIN_TOKEN,OPENCODE_BASE_URL,OPENCODE_API_KEY,OPENCODE_MODEL,OPENCODE_PROVIDER_ID,OPENCODE_PROVIDER_NAME
+          envs: AMUXD_IMAGE,DEPLOY_REF,AMUXD_JOIN_TOKEN,OPENCODE_BASE_URL,OPENCODE_API_KEY,OPENCODE_MODEL,OPENCODE_PROVIDER_ID,OPENCODE_PROVIDER_NAME
           script: |
             set -e
             cd /opt/teamclaw
@@ -151,15 +164,7 @@ jobs:
               echo "  set $1"
             }
 
-            echo "=== pull amuxd image from GHCR ==="
-            pull_user="${GHCR_PULL_USER:-${{ github.repository_owner }}}"
-            if [ -n "${GHCR_PULL_TOKEN:-}" ]; then
-              echo "$GHCR_PULL_TOKEN" | docker login ghcr.io -u "$pull_user" --password-stdin
-            else
-              echo "  skip ghcr login (public package pull)"
-            fi
-
-            echo "=== sync daemon env ==="
+            echo "=== sync daemon env (presence-only when OPENCODE_* secrets empty) ==="
             upsert_env AMUXD_IMAGE "$AMUXD_IMAGE"
             upsert_env AMUXD_JOIN_TOKEN "$AMUXD_JOIN_TOKEN"
             upsert_env OPENCODE_BASE_URL "$OPENCODE_BASE_URL"
@@ -175,8 +180,7 @@ jobs:
             timeout 180 sh -c \
               'until docker compose ps emqx | grep -q healthy; do sleep 5; done'
 
-            echo "=== pull + recreate amuxd ==="
-            docker compose pull amuxd
+            echo "=== recreate amuxd (image streamed from CI) ==="
             docker compose --profile daemon up -d --pull never --remove-orphans amuxd
 
             echo "=== amuxd smoke ==="

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -194,6 +194,9 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 
 # ── TeamClaw daemon (optional; docker compose --profile daemon) ─────────
+# Prebuilt image tag for CI/ECS deploy (daemon-deploy.yml). Leave blank for
+# local `docker compose build amuxd` (defaults to teamclaw-amuxd:self-host).
+AMUXD_IMAGE=
 # Daemon team-join invite token. Leave blank in the template. After a team
 # exists, mint one with ./amuxd/mint-invite.sh and paste the token here, then:
 #   docker compose --profile daemon up -d --build amuxd

--- a/deploy/self-host/amuxd/bootstrap-presence-only.sh
+++ b/deploy/self-host/amuxd/bootstrap-presence-only.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# One-shot bootstrap for presence-only amuxd on the self-host ECS box.
+#
+# - Mints a daemon invite when AMUXD_JOIN_TOKEN is empty and no identity exists
+# - Writes AMUXD_JOIN_TOKEN (+ optional AMUXD_TEAM_ID) into deploy/self-host/.env
+# - Clears OPENCODE_* so the daemon stays presence-only
+#
+# Usage (on ECS, from deploy/self-host/):
+#   ./amuxd/bootstrap-presence-only.sh [TEAM_ID]
+#
+# After this, trigger the Daemon Deploy workflow (or pull the GHCR image manually).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+[ -f .env ] || { echo "bootstrap: $ROOT/.env not found"; exit 1; }
+
+TEAM_ID="${1:-${TEAM_ID:-}}"
+STATE_VOLUME="${COMPOSE_PROJECT_NAME:-teamclaw-self-host}_amuxd_state"
+
+upsert_env() {
+  local key="$1" value="$2"
+  if grep -q "^${key}=" .env; then
+    awk -v k="$key" -v v="$value" 'BEGIN{FS=OFS="="} $1==k{print k"="v; next}{print}' .env > .env.tmp && mv .env.tmp .env
+  else
+    printf '%s=%s\n' "$key" "$value" >> .env
+  fi
+  echo "  set $key"
+}
+
+clear_env() {
+  local key="$1"
+  if grep -q "^${key}=" .env; then
+    grep -v "^${key}=" .env > .env.tmp && mv .env.tmp .env
+    echo "  cleared $key"
+  fi
+}
+
+has_identity() {
+  docker volume inspect "$STATE_VOLUME" >/dev/null 2>&1 \
+    && docker run --rm -v "${STATE_VOLUME}:/state" alpine:3.20 \
+         test -f /state/.amuxd/backend.toml
+}
+
+echo "=== presence-only bootstrap ==="
+
+if has_identity; then
+  echo "  existing amuxd identity in volume $STATE_VOLUME — skip invite mint"
+else
+  token_line="$(./amuxd/mint-invite.sh ${TEAM_ID:+"$TEAM_ID"})"
+  token="$(printf '%s\n' "$token_line" | sed -n 's/^AMUXD_JOIN_TOKEN=//p')"
+  [ -n "$token" ] || { echo "bootstrap: mint-invite did not return a token"; exit 1; }
+  upsert_env AMUXD_JOIN_TOKEN "$token"
+fi
+
+if [ -n "$TEAM_ID" ]; then
+  upsert_env AMUXD_TEAM_ID "$TEAM_ID"
+fi
+
+for key in OPENCODE_BASE_URL OPENCODE_API_KEY OPENCODE_MODEL; do
+  clear_env "$key"
+done
+
+echo "=== done ==="
+echo "Next: trigger .github/workflows/daemon-deploy.yml (or docker compose pull/up amuxd)."

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -408,7 +408,9 @@ services:
     build:
       context: ../..
       dockerfile: deploy/self-host/amuxd/Dockerfile
-    image: teamclaw-amuxd:self-host
+    # Local dev: `docker compose build amuxd` → teamclaw-amuxd:self-host.
+    # CI/ECS: daemon-deploy.yml sets AMUXD_IMAGE to a GHCR tag and pulls it.
+    image: ${AMUXD_IMAGE:-teamclaw-amuxd:self-host}
     restart: unless-stopped
     profiles: ["daemon"]
     depends_on:

--- a/deploy/self-host/smoke/amuxd-smoke.sh
+++ b/deploy/self-host/smoke/amuxd-smoke.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+# Smoke-test the self-host amuxd daemon after deploy.
+#
+# Usage (from deploy/self-host/):
+#   sh smoke/amuxd-smoke.sh
+#
+# Checks:
+#   1. amuxd container is Up
+#   2. recent logs show a successful start (no invite/bootstrap fatals)
+#   3. /v1/healthz responds when the HTTP port file is present
+set -eu
+
+SH_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SH_DIR"
+
+[ -f .env ] || { echo "FAIL: $SH_DIR/.env not found"; exit 1; }
+
+fails=0
+ok()  { echo "  PASS  $1"; }
+bad() { echo "  FAIL  $1"; fails=$((fails + 1)); }
+
+echo "1. amuxd container running"
+if docker compose ps amuxd 2>/dev/null | grep -qE 'Up|running'; then
+  ok "container Up"
+else
+  bad "container not Up"
+  docker compose ps amuxd || true
+fi
+
+echo "2. recent logs (no bootstrap fatals)"
+logs="$(docker compose logs --tail=80 amuxd 2>&1 || true)"
+printf '%s\n' "$logs" | tail -20
+case "$logs" in
+  *"no persisted identity and AMUXD_JOIN_TOKEN is empty"*)
+    bad "missing AMUXD_JOIN_TOKEN on first boot"
+    ;;
+  *"OPENCODE_MODEL must be set when OPENCODE_API_KEY is set"*)
+    bad "OPENCODE_MODEL missing while OPENCODE_API_KEY is set"
+    ;;
+  *"OPENCODE_BASE_URL must be set when OPENCODE_API_KEY is set"*)
+    bad "OPENCODE_BASE_URL missing while OPENCODE_API_KEY is set"
+    ;;
+esac
+case "$logs" in
+  *"starting daemon"*|*"amuxd: starting daemon"*)
+    ok "daemon start line present"
+    ;;
+  *)
+    bad "no daemon start line in recent logs"
+    ;;
+esac
+
+echo "3. HTTP health probe"
+port="$(docker compose exec -T amuxd sh -c 'cat /state/.amuxd/amuxd.http.port 2>/dev/null || true' | tr -d '[:space:]' || true)"
+if [ -n "$port" ]; then
+  if docker compose exec -T amuxd sh -c "wget -qO- http://127.0.0.1:${port}/v1/healthz >/dev/null 2>&1 || curl -sf http://127.0.0.1:${port}/v1/healthz >/dev/null"; then
+    ok "/v1/healthz on port ${port}"
+  else
+    bad "/v1/healthz failed on port ${port}"
+  fi
+else
+  echo "  SKIP  HTTP port file not written yet (daemon may still be booting)"
+fi
+
+if [ "$fails" -gt 0 ]; then
+  echo "amuxd-smoke: FAIL ($fails check(s))"
+  exit 1
+fi
+
+echo "amuxd-smoke: PASS"

--- a/deploy/self-host/smoke/amuxd-smoke.sh
+++ b/deploy/self-host/smoke/amuxd-smoke.sh
@@ -35,7 +35,18 @@ else
 fi
 
 echo "2. recent logs (no bootstrap fatals)"
-logs="$(docker compose logs --tail=80 amuxd 2>&1 || true)"
+deadline=$(( $(date +%s) + 120 ))
+logs=""
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  logs="$(docker compose logs --tail=80 amuxd 2>&1 || true)"
+  case "$logs" in
+    *"no persisted identity and AMUXD_JOIN_TOKEN is empty"*) break ;;
+    *"OPENCODE_MODEL must be set when OPENCODE_API_KEY is set"*) break ;;
+    *"OPENCODE_BASE_URL must be set when OPENCODE_API_KEY is set"*) break ;;
+    *"starting daemon"*|*"amuxd: starting daemon"*) break ;;
+  esac
+  sleep 5
+done
 printf '%s\n' "$logs" | tail -20
 case "$logs" in
   *"no persisted identity and AMUXD_JOIN_TOKEN is empty"*)

--- a/deploy/self-host/smoke/amuxd-smoke.sh
+++ b/deploy/self-host/smoke/amuxd-smoke.sh
@@ -20,6 +20,13 @@ ok()  { echo "  PASS  $1"; }
 bad() { echo "  FAIL  $1"; fails=$((fails + 1)); }
 
 echo "1. amuxd container running"
+deadline=$(( $(date +%s) + 120 ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if docker compose ps amuxd 2>/dev/null | grep -qE 'Up|running'; then
+    break
+  fi
+  sleep 3
+done
 if docker compose ps amuxd 2>/dev/null | grep -qE 'Up|running'; then
   ok "container Up"
 else


### PR DESCRIPTION
## Summary

- Add `daemon-deploy.yml`: build `amuxd` in GitHub Actions, push to `ghcr.io/different-ai-studio/teamclaw-amuxd:self-host`, stream the image to the self-host ECS box over SSH, and roll the `daemon` compose profile — ECS never runs `cargo build`.
- Support prebuilt images via `AMUXD_IMAGE` in `docker-compose.yml`; local dev still uses `docker compose build amuxd`.
- Add presence-only bootstrap helper (`deploy/self-host/amuxd/bootstrap-presence-only.sh`) and post-deploy smoke (`deploy/self-host/smoke/amuxd-smoke.sh`).

Presence-only is the default: leave `OPENCODE_*` secrets unset. Full agent sessions can be enabled later via GitHub environment secrets.

**Already verified on ECS (47.112.210.217):** daemon joined team *Bright Owl*, MQTT connected, `/v1/healthz` OK.

## Test plan

- [x] Manual `workflow_dispatch` on `feat/daemon-ecs-deploy` — build + image stream + `compose --profile daemon up` succeeded
- [x] `sh deploy/self-host/smoke/amuxd-smoke.sh` on ECS — PASS
- [ ] After merge: confirm push to `main` touching `apps/daemon/**` triggers `Daemon Deploy`
- [ ] Optional: delete `AMUXD_JOIN_TOKEN` secret (identity persists in `amuxd_state` volume)


Made with [Cursor](https://cursor.com)