### PR TITLE
chore(release): copilot361 v0.3.1-beta.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "amuxd"
-version = "0.3.1-beta.24"
+version = "0.3.1-beta.25"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10742,7 +10742,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaw"
-version = "0.3.1-beta.24"
+version = "0.3.1-beta.25"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.3.1-beta.24"
+version = "0.3.1-beta.25"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaw"
-version = "0.3.1-beta.24"
+version = "0.3.1-beta.25"
 description = "TeamClaw - AI Agent Desktop Platform"
 authors = ["TeamClaw Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClaw",
-  "version": "0.3.1-beta.24",
+  "version": "0.3.1-beta.25",
   "identifier": "com.teamclaw.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclaw/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclaw",
-  "version": "0.3.1-beta.24",
+  "version": "0.3.1-beta.25",
   "private": true,
   "description": "TeamClaw - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
## Summary

Bump desktop/amuxd version to **0.3.1-beta.25** for copilot361 OSS release.

Includes #766 (white-label amuxd/workspace meta isolation) and #767 (ECS amuxd deploy).

## Test plan

- [ ] Merge to main
- [ ] Dispatch `release-oss.yml` with brand `copilot361`, tag `v0.3.1-beta.25`

Made with [Cursor](https://cursor.com)