### PR TITLE
fix(release): sign bridge sidecars for notarization

### DIFF
--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -273,6 +273,10 @@ jobs:
           echo "All parallel tasks completed"
           ls -lh apps/desktop/binaries/
 
+      - name: Sign nested Mach-O in bundled sidecars (notarization)
+        shell: bash
+        run: ./scripts/sign-macos-bundle-binaries.sh apps/desktop/binaries
+
       - name: Finalize tauri.conf.json (version from tag + frontend prebuilt + OSS updater endpoint)
         env:
           TAG: ${{ inputs.tag }}
@@ -534,6 +538,13 @@ jobs:
           cargo build --release --locked --manifest-path apps/daemon/Cargo.toml -p amuxd
           cp "$TARGET_DIR/release/amuxd.exe" apps/desktop/binaries/amuxd-x86_64-pc-windows-msvc.exe
           echo "amuxd sidecar ready"
+
+      - name: Bundle agent bridge sidecars
+        shell: bash
+        run: |
+          node scripts/ensure-agent-bridge-bundles.js
+          test -f apps/desktop/binaries/cursor-bridge/src/main.mjs
+          test -d apps/desktop/binaries/cursor-bridge/node_modules/@cursor/sdk
 
       - name: Finalize tauri.conf.json (version from tag + frontend prebuilt + OSS updater endpoint)
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,10 @@ jobs:
           ls -lh apps/desktop/binaries/
           ls -lh packages/app/dist/ | head -5
 
+      - name: Sign nested Mach-O in bundled sidecars (notarization)
+        shell: bash
+        run: ./scripts/sign-macos-bundle-binaries.sh apps/desktop/binaries
+
       # Skip beforeBuildCommand since frontend is already built above,
       # and substitute __OSS_BASE_URL__ in updater endpoints (drop if OSS not configured).
       - name: Finalize tauri.conf.json for build

--- a/scripts/ensure-agent-bridge-bundles.js
+++ b/scripts/ensure-agent-bridge-bundles.js
@@ -31,10 +31,12 @@ function bridgeFingerprint(srcDir) {
 }
 
 function npmCi(srcDir, env) {
+  const isWindows = process.platform === "win32";
   const result = spawnSync("npm", ["ci", "--omit=dev"], {
     cwd: srcDir,
     stdio: "inherit",
     env,
+    shell: isWindows,
   });
   if (result.status !== 0) {
     throw new Error(`npm ci failed in ${srcDir}`);

--- a/scripts/sign-macos-bundle-binaries.sh
+++ b/scripts/sign-macos-bundle-binaries.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Deep-sign Mach-O binaries under apps/desktop/binaries/ before Tauri bundles them.
+# Bridge sidecars ship ripgrep/sharp/native addons that fail Apple notarization if
+# unsigned. No-op when APPLE_SIGNING_IDENTITY is unset (ad-hoc local builds).
+set -euo pipefail
+
+ROOT="${1:-apps/desktop/binaries}"
+IDENT="${APPLE_SIGNING_IDENTITY:-}"
+
+if [[ ! -d "$ROOT" ]]; then
+  echo "sign-macos-bundle-binaries: skip — $ROOT not found"
+  exit 0
+fi
+
+if [[ -z "$IDENT" ]]; then
+  echo "sign-macos-bundle-binaries: skip — APPLE_SIGNING_IDENTITY unset"
+  exit 0
+fi
+
+count=0
+while IFS= read -r -d '' f; do
+  echo "Signing $f"
+  codesign --force --options runtime --timestamp --sign "$IDENT" "$f"
+  count=$((count + 1))
+done < <(
+  find "$ROOT" -type f -print0 | while IFS= read -r -d '' candidate; do
+    if file -b "$candidate" | grep -q 'Mach-O'; then
+      printf '%s\0' "$candidate"
+    fi
+  done
+)
+
+echo "sign-macos-bundle-binaries: signed $count file(s) under $ROOT"


### PR DESCRIPTION
## Summary

Fix copilot361 OSS release CI failures from #766 bridge bundling:
- Sign nested Mach-O under `apps/desktop/binaries/` before Tauri notarization
- Run `npm ci` with `shell: true` on Windows in `ensure-agent-bridge-bundles.js`
- Pre-bundle bridges on Windows job (same as macOS) for clearer failures

## Test plan

- [ ] Re-run `release-oss.yml` for copilot361 `v0.3.1-beta.25`

Made with [Cursor](https://cursor.com)