### PR TITLE
fix(release): drop bridge .bin symlinks for notarization

### DIFF
--- a/scripts/ensure-agent-bridge-bundles.js
+++ b/scripts/ensure-agent-bridge-bundles.js
@@ -43,6 +43,14 @@ function npmCi(srcDir, env) {
   }
 }
 
+/** npm's .bin symlinks are not used at runtime (amuxd runs node src/main.mjs). */
+function pruneBridgeNodeModules(srcDir) {
+  const binDir = path.join(srcDir, "node_modules", ".bin");
+  if (fs.existsSync(binDir)) {
+    fs.rmSync(binDir, { recursive: true, force: true });
+  }
+}
+
 function copyBridgeTree(srcDir, destDir) {
   fs.rmSync(destDir, { recursive: true, force: true });
   fs.mkdirSync(destDir, { recursive: true });
@@ -100,6 +108,7 @@ function ensureAgentBridgeBundles(env, opts) {
     }
     console.log(`${logPrefix} preparing ${bridge.name} bundle...`);
     npmCi(srcDir, env);
+    pruneBridgeNodeModules(srcDir);
     copyBridgeTree(srcDir, destDir);
     if (fingerprint) {
       writeStamp(destDir, fingerprint);

--- a/scripts/sign-macos-bundle-binaries.sh
+++ b/scripts/sign-macos-bundle-binaries.sh
@@ -23,7 +23,7 @@ while IFS= read -r -d '' f; do
   codesign --force --options runtime --timestamp --sign "$IDENT" "$f"
   count=$((count + 1))
 done < <(
-  find "$ROOT" -type f -print0 | while IFS= read -r -d '' candidate; do
+  find -L "$ROOT" -type f -print0 | while IFS= read -r -d '' candidate; do
     if file -b "$candidate" | grep -q 'Mach-O'; then
       printf '%s\0' "$candidate"
     fi


### PR DESCRIPTION
Fix macOS notarization Invalid on cursor-bridge node_modules/.bin/rg.

Made with [Cursor](https://cursor.com)