### PR TITLE
feat(skills): team skill package blobs → Supabase Storage

### DIFF
--- a/apps/desktop/src/commands/team_skills.rs
+++ b/apps/desktop/src/commands/team_skills.rs
@@ -439,6 +439,7 @@ pub async fn team_skill_pack_and_upload(
                 })?;
             let put_resp = client
                 .put(&put_url)
+                .header("x-upsert", "true")
                 .body(zip_bytes)
                 .send()
                 .map_err(|e| format!("skill blob PUT failed: {}", e))?;

--- a/docs/architecture/team-skills-registry.md
+++ b/docs/architecture/team-skills-registry.md
@@ -39,7 +39,7 @@
 桌面端                      FC /v1                     存储
 ─────────────────────────────────────────────────────────────
 浏览市场      ──────────>  GET  /teams/:id/skills   ──> Postgres 元数据
-发布 skill    ──────────>  POST /teams/:id/skills   ──> zip → OSS (amuxc_blobs)
+发布 skill    ──────────>  POST /teams/:id/skills   ──> zip → Supabase Storage (amuxc_blobs)
 安装          ──────────>  GET  .../download        ──> 签名 URL
                            PUT  .../install         ──> Postgres 安装记录
                     │
@@ -49,7 +49,7 @@
 三条约束：
 
 1. **客户端不直连 Supabase。** `cloud_api` 是唯一客户端后端，`packages/app/src/lib/backend/__tests__/no-supabase-import.test.ts` 是守卫。表建在 Supabase Postgres，访问一律走 FC `/v1`。
-2. **包体不进 Supabase Storage。** 复用 `amuxc_blobs` + OSS，避免第二套存储运维面。
+2. **包体走 Supabase Storage，不进 OSS。**（2026-08-06 反转此前决定：注册表刚合并、生产环境尚无真实 skill 包，改动是干净切换而非数据迁移。）私有 bucket `team-skills`，签名 URL 由 FC 的 service-role 客户端签发（`services/fc/src/lib/skills-storage.ts`）。`amuxc_blobs` 仍是内容哈希去重/记账表，`oss_key` 列复用为 Supabase Storage 的 object path（该表也被 `amuxc_files` 等无关的 OSS 同步功能共用，那部分继续走 OSS，不受影响）。
 3. **只有 registry 是发行面。** `teamclaw-team/skills/` 最终退出团队同步（时机见待定 #1），否则两套管线传同一批内容、版本语义作废。
 
 ## 4. 数据模型
@@ -140,7 +140,7 @@
 | POST | `/v1/teams/:id/skills` | 发布新 skill（两步上传：prepare 拿签名 URL → complete 提交元数据） |
 | POST | `/v1/teams/:id/skills/:slug/versions` | 发新版本 |
 | PATCH | `/v1/teams/:id/skills/:slug` | 改元数据 / 转交 owner / 标记 deprecated |
-| GET | `/v1/teams/:id/skills/:slug/versions/:v/download` | 返回 OSS 签名 URL |
+| GET | `/v1/teams/:id/skills/:slug/versions/:v/download` | 返回 Supabase Storage 签名 URL |
 | PUT | `/v1/teams/:id/skills/:slug/install` | 记录安装（`actorId` + version + scope） |
 | DELETE | `/v1/teams/:id/skills/:slug/install` | 记录卸载 |
 
@@ -152,7 +152,7 @@
 - 目标是 **`visibility='team'` 的 agent actor** → 要求团队 owner，或该 agent 的 `owner_member_id`。沿用 `pg-repo/agents.ts` 里 visibility 切换那套 owner-gated 判断，不新造一套
 - 目标是**别人的 member actor** → 拒绝。管理员不能替成员做安装决定
 
-**别忘了 FC 的两个部署目标**：新增环境变量要同时进 `services/fc/s.yaml` 和 `deploy/self-host/docker-compose.yml` 的 `environment:` 白名单，缺一个就在某一边静默丢失。本设计预计不新增 env（OSS 凭据已有）。
+**别忘了 FC 的两个部署目标**：新增环境变量要同时进 `services/fc/s.yaml` 和 `deploy/self-host/docker-compose.yml` 的 `environment:` 白名单，缺一个就在某一边静默丢失。本设计不新增 env（复用两边已有的 `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`）。
 
 ## 6. 发布门：6 个必填字段
 

--- a/services/fc/src/lib/pg-repo/team-skills.ts
+++ b/services/fc/src/lib/pg-repo/team-skills.ts
@@ -592,9 +592,9 @@ export function makeTeamSkillsRepo(db: DbLike, ctx: TeamSkillsCtx) {
 
     /**
      * Ensure an amuxc_blobs placeholder exists for a skill package. The route
-     * layer then HEADs OSS and returns a presigned PUT when needed. Keeps
-     * skill packages on the same content-addressed store as sync without
-     * creating an amuxc_files path entry.
+     * layer then asks Supabase Storage for a signed PUT when the blob isn't
+     * verified yet. Keeps skill packages on the same content-addressed store
+     * as sync without creating an amuxc_files path entry.
      */
     async prepareTeamSkillBlob(teamId: string, body: any = {}) {
       const userId = requireUser();
@@ -612,7 +612,12 @@ export function makeTeamSkillsRepo(db: DbLike, ctx: TeamSkillsCtx) {
       await (db.insert(amuxcBlobs) as any)
         .values({ teamId, contentHash: hash, ossKey, size, verified: false })
         .onConflictDoNothing();
-      return { contentHash: hash, size, ossKey };
+      const [row] = await db
+        .select({ ossKey: amuxcBlobs.ossKey, size: amuxcBlobs.size, verified: amuxcBlobs.verified })
+        .from(amuxcBlobs)
+        .where(and(eq(amuxcBlobs.teamId, teamId), eq(amuxcBlobs.contentHash, hash)))
+        .limit(1);
+      return { contentHash: hash, size: row.size ?? size, ossKey: row.ossKey, verified: row.verified };
     },
 
     /** Mark a skill package blob verified after the client PUTs to OSS. */

--- a/services/fc/src/lib/routes/team-skills.ts
+++ b/services/fc/src/lib/routes/team-skills.ts
@@ -55,43 +55,17 @@ export function registerTeamSkills(router) {
       ctx.params.teamId,
       ctx.json ?? {},
     );
-    const { getS3Client, OSS_BUCKET } = await import("../oss.js");
-    const { HeadObjectCommand, PutObjectCommand } = await import("@aws-sdk/client-s3");
-    const { getSignedUrl } = await import("@aws-sdk/s3-request-presigner");
-    const s3 = getS3Client();
-    const bucket = OSS_BUCKET();
-    let requiresUpload = true;
     let presignedPut: string | null = null;
-    try {
-      const head = await s3.send(
-        new HeadObjectCommand({ Bucket: bucket, Key: prepared.ossKey }),
-      );
-      if (head.ContentLength === prepared.size) {
-        requiresUpload = false;
-      }
-    } catch (e: any) {
-      if (
-        e.$metadata?.httpStatusCode !== 404 &&
-        e.name !== "NotFound" &&
-        e.Code !== "NoSuchKey"
-      ) {
-        console.error("[skill-blobs/prepare] HEAD OSS error:", e.message);
-      }
-    }
-    if (requiresUpload) {
-      const putCmd = new PutObjectCommand({
-        Bucket: bucket,
-        Key: prepared.ossKey,
-        ContentLength: prepared.size,
-      });
-      presignedPut = await getSignedUrl(s3 as any, putCmd, { expiresIn: 900 });
+    if (!prepared.verified) {
+      const { createSkillUploadUrl } = await import("../skills-storage.js");
+      presignedPut = await createSkillUploadUrl(prepared.ossKey);
     }
     return {
       body: {
         contentHash: prepared.contentHash,
         size: prepared.size,
         ossKey: prepared.ossKey,
-        requiresUpload,
+        requiresUpload: !prepared.verified,
         presignedPut,
       },
     };
@@ -100,26 +74,16 @@ export function registerTeamSkills(router) {
   router.post("/v1/teams/:teamId/skill-blobs/complete", async (ctx) => {
     const body = ctx.json ?? {};
     const contentHash = String(body.contentHash ?? "").trim().toLowerCase();
-    // Re-resolve placeholder so we know expected size before HEAD.
+    // Re-resolve placeholder so we know expected size before checking storage.
     const prepared = await ctx.repository.prepareTeamSkillBlob(ctx.params.teamId, body);
-    const { getS3Client, OSS_BUCKET } = await import("../oss.js");
-    const { HeadObjectCommand } = await import("@aws-sdk/client-s3");
-    const s3 = getS3Client();
-    const bucket = OSS_BUCKET();
-    try {
-      const head = await s3.send(
-        new HeadObjectCommand({ Bucket: bucket, Key: prepared.ossKey }),
+    const { statSkillObject } = await import("../skills-storage.js");
+    const stat = await statSkillObject(prepared.ossKey);
+    if (!stat || stat.size !== prepared.size) {
+      throw new ApiError(
+        422,
+        "blob_missing",
+        `Blob missing or size mismatch: expected ${prepared.size}, got ${stat?.size ?? "none"}`,
       );
-      if (head.ContentLength !== prepared.size) {
-        throw new ApiError(
-          422,
-          "blob_missing",
-          `Blob size mismatch: expected ${prepared.size}, got ${head.ContentLength}`,
-        );
-      }
-    } catch (e: any) {
-      if (e instanceof ApiError) throw e;
-      throw new ApiError(422, "blob_missing", `Blob missing or unreachable: ${e.message}`);
     }
     const done = await ctx.repository.completeTeamSkillBlob(ctx.params.teamId, {
       contentHash,
@@ -162,9 +126,8 @@ export function registerTeamSkills(router) {
       ctx.params.slug,
       version,
     );
-    const { getS3Client, OSS_BUCKET } = await import("../oss.js");
-    const { signedDownloadUrl } = await import("../sync-handlers.js");
-    const url = await signedDownloadUrl(getS3Client(), OSS_BUCKET(), blob.ossKey);
+    const { createSkillDownloadUrl } = await import("../skills-storage.js");
+    const url = await createSkillDownloadUrl(blob.ossKey);
     return { body: { url, contentHash: blob.contentHash, size: blob.size } };
   });
 

--- a/services/fc/src/lib/skills-storage.ts
+++ b/services/fc/src/lib/skills-storage.ts
@@ -1,0 +1,53 @@
+import { createServiceRoleClient } from "./supabase.js";
+
+// ---------------------------------------------------------------------------
+// Supabase Storage helpers for team skill package blobs.
+//
+// Package bodies (zips) live in a private Supabase Storage bucket, keyed by
+// the same content-addressed path amuxc_blobs already tracks
+// (teams/<teamId>/blobs/sha256/<aa>/<bb>/<hash>). amuxc_blobs stays the
+// dedup/bookkeeping table; oss_key just holds this bucket's object path now.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_BUCKET = "team-skills";
+
+export const SKILLS_BUCKET = () => process.env.SKILLS_STORAGE_BUCKET || DEFAULT_BUCKET;
+
+function splitPath(objectPath: string): { dir: string; name: string } {
+  const slash = objectPath.lastIndexOf("/");
+  return { dir: objectPath.slice(0, slash), name: objectPath.slice(slash + 1) };
+}
+
+export async function createSkillUploadUrl(objectPath: string): Promise<string> {
+  const { data, error } = await createServiceRoleClient()
+    .storage.from(SKILLS_BUCKET())
+    .createSignedUploadUrl(objectPath, { upsert: true });
+  if (error || !data) {
+    throw new Error(`failed to create signed upload url: ${error?.message ?? "unknown error"}`);
+  }
+  return data.signedUrl;
+}
+
+export async function statSkillObject(objectPath: string): Promise<{ size: number } | null> {
+  const { dir, name } = splitPath(objectPath);
+  const { data, error } = await createServiceRoleClient()
+    .storage.from(SKILLS_BUCKET())
+    .list(dir, { search: name, limit: 1 });
+  if (error || !data) return null;
+  const entry = data.find((f: any) => f.name === name);
+  if (!entry) return null;
+  return { size: entry.metadata?.size ?? 0 };
+}
+
+export async function createSkillDownloadUrl(
+  objectPath: string,
+  expiresIn = 900,
+): Promise<string> {
+  const { data, error } = await createServiceRoleClient()
+    .storage.from(SKILLS_BUCKET())
+    .createSignedUrl(objectPath, expiresIn);
+  if (error || !data) {
+    throw new Error(`failed to create signed download url: ${error?.message ?? "unknown error"}`);
+  }
+  return data.signedUrl;
+}

--- a/services/fc/test/team-skills.test.ts
+++ b/services/fc/test/team-skills.test.ts
@@ -209,8 +209,8 @@ test("POST skill-blobs/prepare is routed to the repository", async () => {
   const repo = fakeRepo({
     prepareTeamSkillBlob: async (...args: unknown[]) => {
       seen.push(args);
-      // Fail before the route HEADs OSS so the test stays offline-safe.
-      throw new ApiError(400, "validation_failed", "skip-oss-for-test");
+      // Fail before the route reaches Supabase Storage so the test stays offline-safe.
+      throw new ApiError(400, "validation_failed", "skip-storage-for-test");
     },
   });
   const res = await request(
@@ -224,4 +224,27 @@ test("POST skill-blobs/prepare is routed to the repository", async () => {
   assert.equal(res.statusCode, 400);
   assert.equal(seen.length, 1);
   assert.deepEqual(seen[0], ["team-1", { contentHash: "a".repeat(64), size: 12 }]);
+});
+
+test("POST skill-blobs/prepare skips the upload URL when the blob is already verified", async () => {
+  const repo = fakeRepo({
+    prepareTeamSkillBlob: async () => ({
+      contentHash: "a".repeat(64),
+      size: 12,
+      ossKey: "teams/team-1/blobs/sha256/aa/aa/" + "a".repeat(64),
+      verified: true,
+    }),
+  });
+  const res = await request(
+    {
+      httpMethod: "POST",
+      path: "/v1/teams/team-1/skill-blobs/prepare",
+      body: JSON.stringify({ contentHash: "a".repeat(64), size: 12 }),
+    },
+    repo,
+  );
+  assert.equal(res.statusCode, 200);
+  const body = JSON.parse(res.body);
+  assert.equal(body.requiresUpload, false);
+  assert.equal(body.presignedPut, null);
 });

--- a/services/supabase/migrations/20260806010000_team_skills_storage_bucket.sql
+++ b/services/supabase/migrations/20260806010000_team_skills_storage_bucket.sql
@@ -1,0 +1,9 @@
+-- Team skill package blobs move from Alibaba OSS to Supabase Storage.
+-- See docs/architecture/team-skills-registry.md — amuxc_blobs stays the
+-- dedup/bookkeeping table; oss_key now holds this bucket's object path for
+-- skill rows. Private bucket: all access goes through signed URLs minted by
+-- FC's service-role client (services/fc/src/lib/skills-storage.ts), so no
+-- authenticated/anon RLS policies are added — the default deny applies.
+insert into storage.buckets (id, name, public)
+values ('team-skills', 'team-skills', false)
+on conflict (id) do nothing;


### PR DESCRIPTION
## Summary
- Switches team-skills-registry package blob storage from Alibaba OSS (S3 presigned URLs) to a private Supabase Storage bucket (`team-skills`), reversing the constraint recorded in `docs/architecture/team-skills-registry.md` §3 that explicitly avoided a second storage backend.
- Reasoning: no team has uploaded a real skill package yet (feature just merged in #771), so this is a clean cutover rather than a data migration — no back-compat branching needed.
- `amuxc_blobs` stays the shared content-hash dedup/bookkeeping table (also used by the unrelated `amuxc_files` OSS-sync feature, untouched here); its `oss_key` column now holds the Supabase Storage object path for skill rows.
- Desktop client (`team_skills.rs`) needed only a one-line change (`x-upsert` header on the upload PUT) — it already talks to whatever presigned URL FC hands back, regardless of backend.
- New migration creates the private `team-skills` bucket; no new env vars (reuses `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` already wired in both `s.yaml` and `docker-compose.yml`).

## Test plan
- [x] `services/fc`: `npm run build` (tsc -p tsconfig.json, the actual Docker build check) passes
- [x] `services/fc`: `npm test` — full suite passes (11/11 in `team-skills.test.ts`, including 2 new/updated blob tests; unrelated pre-existing skips in `sync-flow.test.ts` require a local Supabase instance)
- [ ] `pnpm rust:check` — running in a cold worktree cache at time of PR, will confirm separately
- [ ] Manual: publish + download a skill via the desktop app against a deployed self-host box, confirm the object lands in the `team-skills` Supabase Storage bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)