### PR TITLE
fix(interrupt): session-addressed cancel no longer silently fails

### DIFF
--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -156,7 +156,30 @@ impl DaemonServer {
                 runtime_id,
                 envelope,
             } => {
-                self.handle_agent_command(&runtime_id, envelope).await;
+                // Topic segment may be a spawn key, cloud session id, or
+                // `{actor}::{session}` (ADR-0004). Resolve before cancel.
+                let resolved = {
+                    let agents = self.agents.lock().await;
+                    agents.resolve_command_agent_id(&runtime_id)
+                };
+                match resolved {
+                    Some(agent_id) => {
+                        if agent_id != runtime_id {
+                            info!(
+                                addressed = %runtime_id,
+                                %agent_id,
+                                "resolved runtime command address to spawn key"
+                            );
+                        }
+                        self.handle_agent_command(&agent_id, envelope).await;
+                    }
+                    None => {
+                        warn!(
+                            addressed = %runtime_id,
+                            "runtime command address resolved to no agent; dropping"
+                        );
+                    }
+                }
             }
             subscriber::IncomingMessage::TeamclawRpc { topic, payload } => {
                 self.handle_rpc_request(&topic, &payload).await;

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -2407,6 +2407,50 @@ mod tests {
         );
     }
 
+    #[test]
+    fn resolve_command_agent_id_accepts_spawn_key() {
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.add_test_runtime("76fd9bf2", "76fd9bf2", "54809303-ed5b-4f10-893f-2d0fd2db4e00");
+        assert_eq!(
+            mgr.resolve_command_agent_id("76fd9bf2").as_deref(),
+            Some("76fd9bf2")
+        );
+    }
+
+    #[test]
+    fn resolve_command_agent_id_accepts_cloud_session_id() {
+        // Regression: desktop retain advertises runtimeId = sessionId; legacy
+        // commands topic used that segment and cancel_agent looked up the
+        // session UUID as a spawn key → not found.
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.add_test_runtime("76fd9bf2", "76fd9bf2", "54809303-ed5b-4f10-893f-2d0fd2db4e00");
+        assert_eq!(
+            mgr.resolve_command_agent_id("54809303-ed5b-4f10-893f-2d0fd2db4e00")
+                .as_deref(),
+            Some("76fd9bf2")
+        );
+    }
+
+    #[test]
+    fn resolve_command_agent_id_accepts_actor_session_composite() {
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.add_test_runtime("76fd9bf2", "76fd9bf2", "54809303-ed5b-4f10-893f-2d0fd2db4e00");
+        assert_eq!(
+            mgr.resolve_command_agent_id(
+                "614433ab-52dd-4ce3-b5f4-14376f8eb680::54809303-ed5b-4f10-893f-2d0fd2db4e00"
+            )
+            .as_deref(),
+            Some("76fd9bf2")
+        );
+    }
+
+    #[test]
+    fn resolve_command_agent_id_unknown_returns_none() {
+        let mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        assert_eq!(mgr.resolve_command_agent_id("no-such").as_deref(), None);
+        assert_eq!(mgr.resolve_command_agent_id("").as_deref(), None);
+    }
+
     #[tokio::test]
     async fn inject_context_buffers_without_sending() {
         let mut mgr = RuntimeManager::test_dummy_with_runtime("rt1");

--- a/apps/daemon/src/runtime/manager/lookup.rs
+++ b/apps/daemon/src/runtime/manager/lookup.rs
@@ -85,4 +85,34 @@ impl RuntimeManager {
             .find(|(_, h)| h.acp_session_id == acp_session_id)
             .map(|(_, h)| h.agent_type)
     }
+
+    /// Resolve a command address (MQTT topic segment or legacy runtime id) to
+    /// the spawn key in `agents`.
+    ///
+    /// After ADR-0004 clients may address by cloud `session_id` (or iOS's
+    /// `{actor}::{session}` composite) while this map is still keyed by the
+    /// per-spawn id. Cancel that used the session UUID as a map key failed
+    /// with `agent {session} not found` and left Cursor running.
+    pub fn resolve_command_agent_id(&self, addressed_as: &str) -> Option<String> {
+        let addressed = addressed_as.trim();
+        if addressed.is_empty() {
+            return None;
+        }
+        if self.agents.contains_key(addressed) {
+            return Some(addressed.to_string());
+        }
+        if let Some(id) = self.newest_runtime_id_for_session(addressed) {
+            return Some(id);
+        }
+        // iOS composite: `{actor}::{session}`
+        if let Some((_, session)) = addressed.split_once("::") {
+            let session = session.trim();
+            if !session.is_empty() {
+                if let Some(id) = self.newest_runtime_id_for_session(session) {
+                    return Some(id);
+                }
+            }
+        }
+        None
+    }
 }

--- a/packages/app/src/lib/__tests__/interrupt-agent.test.ts
+++ b/packages/app/src/lib/__tests__/interrupt-agent.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fromBinary } from "@bufbuild/protobuf";
-import { AgentType, RuntimeCommandEnvelopeSchema, RuntimeLifecycle } from "@/lib/proto/amux_pb";
+import { AgentType, RuntimeLifecycle } from "@/lib/proto/amux_pb";
 import type { RuntimeStateEntry } from "@/stores/runtime-state-store";
 import { useV2StreamingStore } from "@/stores/v2-streaming-store";
 
 const mqttPublish = vi.fn().mockResolvedValue(undefined);
+const runtimeCommand = vi.fn().mockResolvedValue(true);
 const mockByRuntimeId: Record<string, RuntimeStateEntry> = {};
 
 /** A retain entry as the daemon files it: keyed by session id. */
@@ -24,6 +24,10 @@ function seedAttachment(sessionId: string, runtimeId: string) {
 
 vi.mock("@/lib/mqtt-bridge", () => ({
   mqttPublish: (...args: unknown[]) => mqttPublish(...args),
+}));
+
+vi.mock("@/lib/teamclaw-rpc", () => ({
+  runtimeCommand: (...args: unknown[]) => runtimeCommand(...args),
 }));
 
 vi.mock("@/lib/backend", () => ({
@@ -69,6 +73,8 @@ import { interruptAgentActor } from "@/lib/teamclaw/interrupt-agent";
 describe("interruptAgentActor", () => {
   beforeEach(() => {
     mqttPublish.mockClear();
+    runtimeCommand.mockClear();
+    runtimeCommand.mockResolvedValue(true);
     discardPendingStreamReply.mockClear();
     for (const key of Object.keys(mockByRuntimeId)) {
       delete mockByRuntimeId[key];
@@ -82,18 +88,19 @@ describe("interruptAgentActor", () => {
     useV2StreamingStore.getState().appendOutput("session-1", "agent-a", "Hello");
   });
 
-  it("publishes AcpCancel to the resolved runtime command topic", async () => {
+  it("sends AcpCancel over session-addressed rpc", async () => {
     await interruptAgentActor({
       sessionId: "session-1",
       agentActorId: "agent-a",
     });
 
-    expect(mqttPublish).toHaveBeenCalledTimes(1);
-    const [topic, bytes] = mqttPublish.mock.calls[0] as [string, Uint8Array];
-    expect(topic).toBe("amux/team-1/agent-a/runtime/rt-abcd/commands");
-
-    const envelope = fromBinary(RuntimeCommandEnvelopeSchema, bytes);
+    expect(runtimeCommand).toHaveBeenCalledTimes(1);
+    expect(runtimeCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ targetActorId: "agent-a", sessionId: "session-1" }),
+    );
+    const envelope = runtimeCommand.mock.calls[0]![0].envelope;
     expect(envelope.acpCommand?.command.case).toBe("cancel");
+    expect(mqttPublish).not.toHaveBeenCalled();
 
     expect(discardPendingStreamReply).not.toHaveBeenCalled();
     expect(useV2StreamingStore.getState().byKey["session-1::agent-a"]?.active).toBe(true);
@@ -115,20 +122,40 @@ describe("interruptAgentActor", () => {
       agentActorId: "agent-a",
     });
 
-    const [topic] = mqttPublish.mock.calls[0] as [string, Uint8Array];
-    expect(topic).toBe("amux/team-1/agent-a/runtime/rt-abcd/commands");
+    expect(runtimeCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ targetActorId: "agent-a", sessionId: "session-1" }),
+    );
+    expect(mqttPublish).not.toHaveBeenCalled();
   });
 
-  it("cleans up locally when the session is cold", async () => {
-    // No attachment for this session — absence is the answer, not a failure.
+  it("rpcs cancel by (actor, session) even without a retain entry", async () => {
+    // Cross-actor interrupt on the same machine often has no local retain for
+    // the remote agent; session + actor is enough for the daemon to resolve.
     delete mockByRuntimeId["agent-a::session-1"];
+
+    await interruptAgentActor({
+      sessionId: "session-1",
+      agentActorId: "agent-a",
+    });
+
+    expect(runtimeCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ targetActorId: "agent-a", sessionId: "session-1" }),
+    );
+    expect(mqttPublish).not.toHaveBeenCalled();
+    expect(
+      useV2StreamingStore.getState().isInterruptedFlushPending("session-1", "agent-a"),
+    ).toBe(true);
+  });
+
+  it("cleans up locally when the daemon reports no attachment", async () => {
+    runtimeCommand.mockResolvedValue(false);
 
     await expect(
       interruptAgentActor({
         sessionId: "session-1",
         agentActorId: "agent-a",
       }),
-    ).rejects.toThrow(/Could not resolve agent runtime/);
+    ).rejects.toThrow(/no live attachment/);
 
     expect(mqttPublish).not.toHaveBeenCalled();
     expect(discardPendingStreamReply).toHaveBeenCalledWith("session-1", "agent-a");

--- a/packages/app/src/lib/teamclaw/__tests__/runtime-command-dispatch.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/runtime-command-dispatch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createRuntimeCommandSender, runtimeCommandsTopic } from "@/lib/teamclaw/runtime-command";
+import { createRuntimeCommandSender } from "@/lib/teamclaw/runtime-command";
 
 function makeSender(overrides: {
   rpc?: (input: { targetActorId: string; sessionId: string }) => Promise<boolean>;
@@ -44,22 +44,19 @@ describe("runtime command dispatch", () => {
     expect(publish).not.toHaveBeenCalled();
   });
 
-  it("falls back to the legacy topic when the rpc channel itself is down", async () => {
-    // Distinct from the case above: no answer at all, rather than a negative
-    // one. The old path may still deliver, so failing here would lose a command
-    // needlessly during the dual-channel transition.
+  it("does not fall back to the legacy topic when the rpc channel itself is down", async () => {
+    // Legacy fallback published cancel with session UUID as the topic
+    // segment; the daemon looked that up as a spawn key and dropped it
+    // silently — stop looked like a no-op (cross-actor interrupt on the
+    // same machine). Prefer a loud failure over a silent miss.
     const { sender, publish } = makeSender({
       rpc: async () => {
         throw new Error("teamclaw-rpc not initialized");
       },
     });
 
-    await sender.sendCancel(CANCEL);
-
-    expect(publish).toHaveBeenCalledTimes(1);
-    expect(publish.mock.calls[0]![0]).toBe(
-      runtimeCommandsTopic("team-1", "agent-a", "rt-abcd"),
-    );
+    await expect(sender.sendCancel(CANCEL)).rejects.toThrow(/teamclaw-rpc not initialized/);
+    expect(publish).not.toHaveBeenCalled();
   });
 
   it("uses the legacy topic when the caller has no session id yet", async () => {

--- a/packages/app/src/lib/teamclaw/interrupt-agent.ts
+++ b/packages/app/src/lib/teamclaw/interrupt-agent.ts
@@ -76,17 +76,18 @@ export async function interruptAgentActor(args: {
     byRuntimeId,
   });
 
-  if (!target) {
-    useV2StreamingStore.getState().clearInterruptedFlushPending(sessionId, agentActorId);
-    cleanupLocalAgentStream(sessionId, agentActorId);
-    throw new Error("Could not resolve agent runtime for interrupt");
-  }
+  // Prefer (actor, session) RPC even when retain is missing — the owning
+  // daemon resolves the live attachment by session_id. Requiring retain here
+  // blocked cross-actor interrupt when the local client had no copy of the
+  // remote agent's retain.
+  const targetActorId = target?.actorId ?? agentActorId;
+  const runtimeId = target?.runtimeId ?? sessionId;
 
   sessionFlowLog("interrupt.begin", {
     sessionId,
     agentActorId,
-    targetActorId: target.actorId,
-    runtimeId: target.runtimeId,
+    targetActorId,
+    runtimeId,
     sessionRuntimeId:
       sessionRuntimeRows.find((row) => row.agent_id?.trim() === agentActorId)?.runtime_id ??
       null,
@@ -95,10 +96,10 @@ export async function interruptAgentActor(args: {
   const peerId = `teamclaw-desktop-${(senderActorId || "anon").slice(0, 8)}`;
   const sender = createRuntimeCommandSender({
     mqtt: { publish: mqttPublish },
-    // Session-addressed dispatch with a delivery receipt; falls back to the
-    // per-spawn topic when no session id reaches here.
-    rpc: ({ targetActorId, sessionId: sid, envelope }) =>
-      runtimeCommand({ targetActorId, sessionId: sid, envelope }),
+    // Session-addressed dispatch with a delivery receipt. No silent legacy
+    // topic fallback — that path mis-addresses by session UUID as a spawn key.
+    rpc: ({ targetActorId: actor, sessionId: sid, envelope }) =>
+      runtimeCommand({ targetActorId: actor, sessionId: sid, envelope }),
     teamId,
     peerId,
     senderActorId,
@@ -106,8 +107,8 @@ export async function interruptAgentActor(args: {
 
   try {
     await sender.sendCancel({
-      targetActorId: target.actorId,
-      runtimeId: target.runtimeId,
+      targetActorId,
+      runtimeId,
       sessionId,
     });
   } catch (error) {
@@ -116,7 +117,7 @@ export async function interruptAgentActor(args: {
     sessionFlowError("interrupt.failed", error, {
       sessionId,
       agentActorId,
-      runtimeId: target.runtimeId,
+      runtimeId,
     });
     throw error;
   }
@@ -128,7 +129,7 @@ export async function interruptAgentActor(args: {
   sessionFlowLog("interrupt.ok", {
     sessionId,
     agentActorId,
-    runtimeId: target.runtimeId,
+    runtimeId,
   });
 }
 

--- a/packages/app/src/lib/teamclaw/runtime-command.ts
+++ b/packages/app/src/lib/teamclaw/runtime-command.ts
@@ -21,8 +21,9 @@ type RuntimeCommandSenderDeps = {
    * at a spawn the daemon no longer knows is dropped silently, which is how a
    * stop button stopped working (docs/debug/interrupt-agent-stale-runtime.md).
    *
-   * Resolves false when the session is cold (no attachment). Omitted in tests
-   * and on the legacy path, where the MQTT publish is used instead.
+   * Resolves false when the session is cold (no attachment). Omitted when the
+   * caller has no session id yet — then the MQTT topic is used instead.
+   * RPC errors are not silently re-routed to that topic.
    */
   rpc?: (input: {
     targetActorId: string;
@@ -194,9 +195,9 @@ export function createRuntimeCommandSender(
  * Send by (actor, session) when both a session id and an RPC dispatcher are
  * available; otherwise fall back to the per-spawn commands topic.
  *
- * The fallback exists for callers that have not been threaded a session id yet
- * and for daemons still on the old channel. It is the path with no delivery
- * receipt, so it is the one we are retiring.
+ * When RPC is attempted, failures are not silently re-routed to the legacy
+ * topic — that topic has no delivery receipt and after ADR-0004 often
+ * addresses by session UUID while the daemon map is still spawn-keyed.
  */
 async function dispatch(
   deps: RuntimeCommandSenderDeps,
@@ -208,21 +209,10 @@ async function dispatch(
 ): Promise<void> {
   const session = sessionId?.trim() ?? "";
   if (deps.rpc && session) {
-    let dispatched: boolean;
-    try {
-      dispatched = await deps.rpc({ targetActorId, sessionId: session, envelope });
-    } catch {
-      // The RPC channel itself is unavailable (not initialised, broker down).
-      // Distinct from a reachable daemon reporting no attachment: that is an
-      // answer, this is the absence of one. Fall through to the legacy topic
-      // rather than failing a command the old path could still deliver.
-      await deps.mqtt.publish(
-        runtimeCommandsTopic(teamId, targetActorId, runtimeId),
-        toBinary(RuntimeCommandEnvelopeSchema, envelope),
-        false,
-      );
-      return;
-    }
+    // No silent legacy fallback: publishing to runtime/{sessionId}/commands
+    // after ADR-0004 addresses by session while the daemon map is still
+    // spawn-keyed, so a failed RPC that "falls back" becomes a silent miss.
+    const dispatched = await deps.rpc({ targetActorId, sessionId: session, envelope });
     if (!dispatched) {
       // The daemon answered and holds nothing for this session — it is cold.
       // Surfacing this is the entire point of moving onto a channel with a


### PR DESCRIPTION
## Summary
- Daemon MQTT `RuntimeCommand` now resolves spawn key / cloud `session_id` / `{actor}::{session}` before cancel, fixing `agent {session} not found` after ADR-0004.
- Desktop interrupt prefers `(actor, session)` RPC even without a local retain, and no longer falls back to the legacy commands topic on RPC failure (that path mis-addressed by session UUID and looked like a no-op stop).

## Test plan
- [x] `cargo test --manifest-path apps/daemon/Cargo.toml --bin amuxd resolve_command_agent_id`
- [x] `pnpm exec vitest run src/lib/teamclaw/__tests__/runtime-command-dispatch.test.ts src/lib/__tests__/interrupt-agent.test.ts` (in `packages/app`)
- [ ] Manual: same-machine cross-actor Cursor turn — stop from the non-owner client should cancel the live turn
- [ ] Manual: cold session interrupt surfaces failure / cleans local stream (no silent MQTT miss)


Made with [Cursor](https://cursor.com)