### PR TITLE
fix(daemon): stabilize OpenCode serve env fingerprint across attaches

### DIFF
--- a/apps/daemon/src/runtime/env_assembly.rs
+++ b/apps/daemon/src/runtime/env_assembly.rs
@@ -21,6 +21,14 @@ pub fn assemble_spawn_runtime_env(
     cloud_token_file: Option<&str>,
     managed_llm: &ManagedLlmState,
 ) -> anyhow::Result<SpawnRuntimeEnv> {
+    // Cold ManagedLlm cache often yields Unknown and omits TEAMCLAW_TEAM_PROVIDER;
+    // reconstruct Enabled from on-disk provider.team so the spawn fingerprint
+    // matches a later successful cloud resolve with the same gateway data.
+    let disk_team = teamclaw_runtime_env::read_disk_team_provider(workspace_root);
+    let managed_llm = teamclaw_runtime_env::stabilize_managed_llm_for_spawn(
+        managed_llm,
+        disk_team.as_ref(),
+    );
     let team_env = team_shared_env::load_team_env_for_workspace_detailed(workspace_root, team_id);
     let mut bundle = teamclaw_runtime_env::assemble_runtime_env(
         workspace_root,
@@ -30,7 +38,7 @@ pub fn assemble_spawn_runtime_env(
             display_name: display_name.to_string(),
             cloud_token_file: cloud_token_file.map(str::to_string),
         },
-        managed_llm,
+        &managed_llm,
     )?;
     let personal_store = teamclaw_runtime_env::diagnose_personal_env_store();
     let personal_location = (!personal_store.secrets_dir.is_empty()).then(|| {
@@ -59,30 +67,11 @@ pub fn assemble_spawn_runtime_env(
     // this `TEAMCLAW_TEAM_PROVIDER` env and register the provider themselves.
     // The secret is NOT embedded — the payload references `${tc_api_key}`, the
     // same env-interpolated key opencode uses, which is already in `extra_env`.
-    if let ManagedLlmState::Enabled(provider) = managed_llm {
-        let models: Vec<serde_json::Value> = provider
-            .models
-            .iter()
-            .filter(|m| !m.id.is_empty())
-            .map(|m| {
-                serde_json::json!({
-                    "id": m.id,
-                    "name": if m.name.is_empty() { &m.id } else { &m.name },
-                })
-            })
-            .collect();
-        let name = if provider.name.is_empty() {
-            "Team"
-        } else {
-            &provider.name
-        };
-        let payload = serde_json::json!({
-            "name": name,
-            "baseUrl": provider.base_url,
-            "apiKeyEnv": "tc_api_key",
-            "models": models,
-        });
-        extra_env.insert("TEAMCLAW_TEAM_PROVIDER".to_string(), payload.to_string());
+    if let ManagedLlmState::Enabled(provider) = &managed_llm {
+        extra_env.insert(
+            "TEAMCLAW_TEAM_PROVIDER".to_string(),
+            teamclaw_runtime_env::team_provider_env_payload(provider),
+        );
     }
     Ok(SpawnRuntimeEnv {
         extra_env,
@@ -155,6 +144,74 @@ mod tests {
                 .map(String::as_str),
             Some("expected-team-value"),
             "the uppercase alias is what many ACP agents consume"
+        );
+    }
+
+    #[test]
+    fn unknown_managed_llm_with_disk_provider_matches_enabled_fingerprint() {
+        use teamclaw_runtime_env::{ManagedLlmModel, ManagedLlmProvider};
+
+        let workspace = tempfile::tempdir().unwrap();
+        std::fs::write(
+            workspace.path().join("opencode.json"),
+            serde_json::json!({
+                "provider": {
+                    "team": {
+                        "name": "Team",
+                        "options": {
+                            "baseURL": "https://gateway.example/v1",
+                            "apiKey": "${tc_api_key}"
+                        },
+                        "models": {
+                            "gpt-4": { "name": "GPT-4" }
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let enabled = ManagedLlmState::Enabled(ManagedLlmProvider {
+            name: "Team".to_string(),
+            base_url: "https://gateway.example/v1".to_string(),
+            models: vec![ManagedLlmModel {
+                id: "gpt-4".to_string(),
+                name: "GPT-4".to_string(),
+            }],
+        });
+
+        let from_unknown = assemble_spawn_runtime_env(
+            workspace.path(),
+            None,
+            "actor-fp",
+            "FP Agent",
+            None,
+            &ManagedLlmState::Unknown,
+        )
+        .unwrap();
+        let from_enabled = assemble_spawn_runtime_env(
+            workspace.path(),
+            None,
+            "actor-fp",
+            "FP Agent",
+            None,
+            &enabled,
+        )
+        .unwrap();
+
+        assert!(
+            from_unknown.extra_env.contains_key("TEAMCLAW_TEAM_PROVIDER"),
+            "Unknown + disk provider.team must still inject TEAMCLAW_TEAM_PROVIDER"
+        );
+        assert_eq!(
+            from_unknown.extra_env.get("TEAMCLAW_TEAM_PROVIDER"),
+            from_enabled.extra_env.get("TEAMCLAW_TEAM_PROVIDER")
+        );
+        assert_eq!(
+            teamclaw_runtime_env::resolved_env::fingerprint_bindings(&from_unknown.extra_env),
+            teamclaw_runtime_env::resolved_env::fingerprint_bindings(&from_enabled.extra_env),
+            "spawn fingerprints must match across Unknown→Enabled when disk already has provider.team"
         );
     }
 }

--- a/apps/daemon/src/runtime/opencode_http/env_snapshot_policy.rs
+++ b/apps/daemon/src/runtime/opencode_http/env_snapshot_policy.rs
@@ -1,0 +1,126 @@
+//! Pure policy for global OpenCode serve env-snapshot conflicts.
+//!
+//! The host is device-wide: only one env fingerprint can be active at a time.
+//! When a new attach resolves a different fingerprint, we must decide whether
+//! to restart (nobody using the host), hard-fail (another workspace owns it),
+//! or tolerate (same-workspace fingerprint jitter from cold cache / TTL).
+
+/// Decision for an incoming workspace env fingerprint vs the running host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EnvSnapshotDecision {
+    /// Fingerprints already match, or serve is not running — proceed normally.
+    Continue,
+    /// Fingerprint changed and no routes hold the host — safe to restart.
+    RestartAllowed,
+    /// Fingerprint changed, but every active route belongs to this workspace.
+    /// Keep the running env; queue the new snapshot for a later idle restart.
+    TolerateSameWorkspace,
+    /// Fingerprint changed and at least one other workspace still holds a route.
+    ConflictOtherWorkspace,
+}
+
+/// Decide how to handle an env fingerprint mismatch (or match) at attach time.
+///
+/// `active_route_directories` are the canonical `Route.directory` values for
+/// sessions currently registered on the global host.
+pub(crate) fn decide_env_snapshot_conflict(
+    incoming_fingerprint: &str,
+    active_fingerprint: Option<&str>,
+    serve_running: bool,
+    active_route_directories: &[String],
+    attaching_workspace: &str,
+) -> EnvSnapshotDecision {
+    if !serve_running || active_fingerprint == Some(incoming_fingerprint) {
+        return EnvSnapshotDecision::Continue;
+    }
+
+    if active_route_directories.is_empty() {
+        return EnvSnapshotDecision::RestartAllowed;
+    }
+
+    let only_same_workspace = active_route_directories
+        .iter()
+        .all(|directory| directory == attaching_workspace);
+    if only_same_workspace {
+        EnvSnapshotDecision::TolerateSameWorkspace
+    } else {
+        EnvSnapshotDecision::ConflictOtherWorkspace
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn continue_when_fingerprints_match() {
+        assert_eq!(
+            decide_env_snapshot_conflict(
+                "fp-a",
+                Some("fp-a"),
+                true,
+                &["/ws-a".to_string()],
+                "/ws-a",
+            ),
+            EnvSnapshotDecision::Continue
+        );
+    }
+
+    #[test]
+    fn restart_allowed_when_fingerprint_changed_and_routes_empty() {
+        assert_eq!(
+            decide_env_snapshot_conflict("fp-b", Some("fp-a"), true, &[], "/ws-a"),
+            EnvSnapshotDecision::RestartAllowed
+        );
+    }
+
+    #[test]
+    fn tolerate_when_fingerprint_changed_and_only_same_workspace_routes() {
+        assert_eq!(
+            decide_env_snapshot_conflict(
+                "fp-b",
+                Some("fp-a"),
+                true,
+                &["/ws-a".to_string(), "/ws-a".to_string()],
+                "/ws-a",
+            ),
+            EnvSnapshotDecision::TolerateSameWorkspace
+        );
+    }
+
+    #[test]
+    fn conflict_when_fingerprint_changed_and_other_workspace_holds_route() {
+        assert_eq!(
+            decide_env_snapshot_conflict(
+                "fp-b",
+                Some("fp-a"),
+                true,
+                &["/ws-a".to_string(), "/ws-b".to_string()],
+                "/ws-a",
+            ),
+            EnvSnapshotDecision::ConflictOtherWorkspace
+        );
+    }
+
+    #[test]
+    fn continue_when_serve_not_running_even_if_fingerprints_differ() {
+        assert_eq!(
+            decide_env_snapshot_conflict("fp-b", Some("fp-a"), false, &[], "/ws-a"),
+            EnvSnapshotDecision::Continue
+        );
+    }
+
+    #[test]
+    fn conflict_when_only_other_workspace_holds_route() {
+        assert_eq!(
+            decide_env_snapshot_conflict(
+                "fp-b",
+                Some("fp-a"),
+                true,
+                &["/ws-b".to_string()],
+                "/ws-a",
+            ),
+            EnvSnapshotDecision::ConflictOtherWorkspace
+        );
+    }
+}

--- a/apps/daemon/src/runtime/opencode_http/mod.rs
+++ b/apps/daemon/src/runtime/opencode_http/mod.rs
@@ -20,6 +20,7 @@ use crate::runtime::permission_policy::PermissionPolicy;
 
 pub mod client;
 mod envelope;
+mod env_snapshot_policy;
 mod events;
 pub mod supervisor;
 pub mod translate;
@@ -27,6 +28,7 @@ pub mod translate;
 pub use envelope::*;
 
 use client::{PromptBody, PromptPart};
+use env_snapshot_policy::{decide_env_snapshot_conflict, EnvSnapshotDecision};
 use supervisor::ServeSupervisor;
 use translate::TranslateState;
 
@@ -360,6 +362,25 @@ fn canonical_dir(worktree: &str) -> String {
         .unwrap_or_else(|_| worktree.to_string())
 }
 
+fn active_route_directories(shared: &Shared) -> Vec<String> {
+    shared
+        .routes
+        .lock()
+        .values()
+        .map(|route| route.directory.clone())
+        .collect()
+}
+
+fn decide_serve_env_switch(shared: &Shared, workspace: &str, incoming: &str) -> EnvSnapshotDecision {
+    decide_env_snapshot_conflict(
+        incoming,
+        shared.serve.active_env_fingerprint().as_deref(),
+        shared.serve.is_running(),
+        &active_route_directories(shared),
+        workspace,
+    )
+}
+
 // ---------------------------------------------------------------------------
 // OpencodeHost
 // ---------------------------------------------------------------------------
@@ -456,12 +477,25 @@ impl OpencodeHost {
         self.shared
             .serve
             .record_requested_env_fingerprint(&workspace, &incoming);
-        if self.shared.serve.env_snapshot_requires_restart(&incoming) {
-            warn!(
-                workspace,
-                "opencode serve prewarm skipped: another workspace snapshot is already active"
-            );
-            return;
+        match decide_serve_env_switch(&self.shared, &workspace, &incoming) {
+            EnvSnapshotDecision::Continue => {}
+            EnvSnapshotDecision::RestartAllowed => {
+                self.shared.serve.shutdown();
+            }
+            EnvSnapshotDecision::TolerateSameWorkspace => {
+                info!(
+                    workspace,
+                    "opencode serve prewarm tolerating same-workspace env fingerprint drift"
+                );
+            }
+            EnvSnapshotDecision::ConflictOtherWorkspace => {
+                self.shared.serve.mark_snapshot_conflict(&workspace);
+                warn!(
+                    workspace,
+                    "opencode serve prewarm skipped: another workspace snapshot is already active"
+                );
+                return;
+            }
         }
         self.shared
             .serve
@@ -474,21 +508,24 @@ impl OpencodeHost {
         // our initial state check and snapshot install. Verify what the child
         // actually inherited and repair that race before declaring prewarm
         // successful.
-        if self.shared.serve.active_env_fingerprint().as_deref() != Some(&incoming) {
-            if !self.shared.routes.lock().is_empty() {
+        match decide_serve_env_switch(&self.shared, &workspace, &incoming) {
+            EnvSnapshotDecision::Continue | EnvSnapshotDecision::TolerateSameWorkspace => {}
+            EnvSnapshotDecision::RestartAllowed => {
+                self.shared.serve.shutdown();
+                self.shared
+                    .serve
+                    .install_env_snapshot(&workspace, extra_env);
+                if let Err(e) = self.shared.serve.ensure().await {
+                    warn!(error = %e, "opencode serve prewarm race recovery failed");
+                    return;
+                }
+            }
+            EnvSnapshotDecision::ConflictOtherWorkspace => {
                 self.shared.serve.mark_snapshot_conflict(&workspace);
                 warn!(
                     workspace,
                     "opencode serve prewarm raced with an active snapshot"
                 );
-                return;
-            }
-            self.shared.serve.shutdown();
-            self.shared
-                .serve
-                .install_env_snapshot(&workspace, extra_env);
-            if let Err(e) = self.shared.serve.ensure().await {
-                warn!(error = %e, "opencode serve prewarm race recovery failed");
                 return;
             }
         }
@@ -550,32 +587,44 @@ impl OpencodeHost {
         self.shared
             .serve
             .record_requested_env_fingerprint(&workspace, &incoming);
-        if self.shared.serve.env_snapshot_requires_restart(&incoming) {
-            if !self.shared.routes.lock().is_empty() {
+        match decide_serve_env_switch(&self.shared, &workspace, &incoming) {
+            EnvSnapshotDecision::Continue => {}
+            EnvSnapshotDecision::RestartAllowed => {
+                self.shared.serve.shutdown();
+            }
+            EnvSnapshotDecision::TolerateSameWorkspace => {
+                info!(
+                    workspace,
+                    "tolerating same-workspace env fingerprint drift; keeping active serve env"
+                );
+            }
+            EnvSnapshotDecision::ConflictOtherWorkspace => {
                 self.shared.serve.mark_snapshot_conflict(&workspace);
                 return Err(crate::error::AmuxError::Agent(format!(
                     "env_snapshot_conflict: workspace {workspace} resolved a different environment while the global opencode host has active sessions"
                 )));
             }
-            self.shared.serve.shutdown();
         }
         let _ = force_env_override; // preserved in the backend interface during transition
         self.shared
             .serve
             .install_env_snapshot(&workspace, extra_env.clone());
         self.shared.serve.ensure().await?;
-        if self.shared.serve.active_env_fingerprint().as_deref() != Some(&incoming) {
-            if !self.shared.routes.lock().is_empty() {
+        match decide_serve_env_switch(&self.shared, &workspace, &incoming) {
+            EnvSnapshotDecision::Continue | EnvSnapshotDecision::TolerateSameWorkspace => {}
+            EnvSnapshotDecision::RestartAllowed => {
+                self.shared.serve.shutdown();
+                self.shared
+                    .serve
+                    .install_env_snapshot(&workspace, extra_env);
+                self.shared.serve.ensure().await?;
+            }
+            EnvSnapshotDecision::ConflictOtherWorkspace => {
                 self.shared.serve.mark_snapshot_conflict(&workspace);
                 return Err(crate::error::AmuxError::Agent(format!(
                     "env_snapshot_conflict: workspace {workspace} lost an environment activation race"
                 )));
             }
-            self.shared.serve.shutdown();
-            self.shared
-                .serve
-                .install_env_snapshot(&workspace, extra_env);
-            self.shared.serve.ensure().await?;
         }
         let cmd_tx = self.command_sender();
         let startup = attach(

--- a/crates/teamclaw-runtime-env/src/lib.rs
+++ b/crates/teamclaw-runtime-env/src/lib.rs
@@ -37,7 +37,10 @@ pub use resolved_env::{
     resolve_runtime_env, EnvOverride, EnvOverrideKind, EnvProvenance, EnvScope, EnvSource,
     ResolvedEnvSnapshot, UnresolvedEnv, UnresolvedReason,
 };
-pub use team_provider::{ManagedLlmModel, ManagedLlmProvider, ManagedLlmState};
+pub use team_provider::{
+    managed_llm_provider_from_disk_team, read_disk_team_provider, stabilize_managed_llm_for_spawn,
+    team_provider_env_payload, ManagedLlmModel, ManagedLlmProvider, ManagedLlmState,
+};
 pub use team_provider_sync::{
     sync_team_provider_on_disk, SecretResolveScope, TeamProviderSyncResult,
 };

--- a/crates/teamclaw-runtime-env/src/team_provider.rs
+++ b/crates/teamclaw-runtime-env/src/team_provider.rs
@@ -165,6 +165,104 @@ pub fn mutate_team_provider(
     Ok(changed)
 }
 
+/// Read `provider.team` from workspace `opencode.json`, if present.
+pub fn read_disk_team_provider(workspace: &Path) -> Option<serde_json::Value> {
+    let content = OpencodeConfigStore::load_raw(workspace).ok().flatten()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    json.get("provider")
+        .and_then(|provider| provider.get("team"))
+        .filter(|team| team.is_object())
+        .cloned()
+}
+
+/// Reconstruct a [`ManagedLlmProvider`] from an on-disk `provider.team` object.
+pub fn managed_llm_provider_from_disk_team(
+    team: &serde_json::Value,
+) -> Option<ManagedLlmProvider> {
+    let base_url = team
+        .get("options")
+        .and_then(|options| options.get("baseURL"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())?
+        .to_string();
+    let name = team
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Team")
+        .to_string();
+    let models = team
+        .get("models")
+        .and_then(|v| v.as_object())
+        .map(|map| {
+            let mut models: Vec<ManagedLlmModel> = map
+                .iter()
+                .map(|(id, entry)| ManagedLlmModel {
+                    id: id.clone(),
+                    name: entry
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(id)
+                        .to_string(),
+                })
+                .collect();
+            models.sort_by(|left, right| left.id.cmp(&right.id));
+            models
+        })
+        .unwrap_or_default();
+    Some(ManagedLlmProvider {
+        name,
+        base_url,
+        models,
+    })
+}
+
+/// Stabilize managed-LLM state before spawn env fingerprinting.
+///
+/// Cold cloud fetches / empty TTL caches often yield [`ManagedLlmState::Unknown`],
+/// which omits `TEAMCLAW_TEAM_PROVIDER` from the spawn env. A later successful
+/// fetch then injects the key and flips the global OpenCode host fingerprint.
+/// When disk already has `provider.team`, reconstruct `Enabled` from it so the
+/// first attach matches a subsequent confirmed cloud answer with the same data.
+pub fn stabilize_managed_llm_for_spawn(
+    state: &ManagedLlmState,
+    disk_team_provider: Option<&serde_json::Value>,
+) -> ManagedLlmState {
+    if !matches!(state, ManagedLlmState::Unknown) {
+        return state.clone();
+    }
+    match disk_team_provider.and_then(managed_llm_provider_from_disk_team) {
+        Some(provider) => ManagedLlmState::Enabled(provider),
+        None => ManagedLlmState::Unknown,
+    }
+}
+
+/// JSON payload for the `TEAMCLAW_TEAM_PROVIDER` spawn env (no secret embedded).
+pub fn team_provider_env_payload(provider: &ManagedLlmProvider) -> String {
+    let models: Vec<serde_json::Value> = provider
+        .models
+        .iter()
+        .filter(|m| !m.id.is_empty())
+        .map(|m| {
+            serde_json::json!({
+                "id": m.id,
+                "name": if m.name.is_empty() { &m.id } else { &m.name },
+            })
+        })
+        .collect();
+    let name = if provider.name.is_empty() {
+        "Team"
+    } else {
+        &provider.name
+    };
+    serde_json::json!({
+        "name": name,
+        "baseUrl": provider.base_url,
+        "apiKeyEnv": "tc_api_key",
+        "models": models,
+    })
+    .to_string()
+}
+
 /// Reconcile `provider.team` in opencode.json against the cloud-sourced managed LLM.
 ///
 /// Returns whether the on-disk config was rewritten. External callers should prefer
@@ -306,5 +404,66 @@ mod tests {
         let dir = TempDir::new().unwrap();
         write_teamclaw_json(dir.path(), Some("custom-team"));
         assert_eq!(resolve_shared_dir_name(dir.path()), "custom-team");
+    }
+
+    #[test]
+    fn stabilize_leaves_enabled_and_disabled_unchanged() {
+        let enabled = ManagedLlmState::Enabled(sample_provider());
+        assert!(matches!(
+            stabilize_managed_llm_for_spawn(&enabled, None),
+            ManagedLlmState::Enabled(_)
+        ));
+        assert!(matches!(
+            stabilize_managed_llm_for_spawn(&ManagedLlmState::Disabled, None),
+            ManagedLlmState::Disabled
+        ));
+    }
+
+    #[test]
+    fn stabilize_unknown_without_disk_stays_unknown() {
+        assert!(matches!(
+            stabilize_managed_llm_for_spawn(&ManagedLlmState::Unknown, None),
+            ManagedLlmState::Unknown
+        ));
+    }
+
+    #[test]
+    fn stabilize_unknown_with_disk_team_becomes_enabled() {
+        let disk = serde_json::json!({
+            "name": "Team",
+            "options": { "baseURL": "https://gateway.example/v1", "apiKey": "${tc_api_key}" },
+            "models": {
+                "gpt-4": { "name": "GPT-4" }
+            }
+        });
+        match stabilize_managed_llm_for_spawn(&ManagedLlmState::Unknown, Some(&disk)) {
+            ManagedLlmState::Enabled(provider) => {
+                assert_eq!(provider.base_url, "https://gateway.example/v1");
+                assert_eq!(provider.models.len(), 1);
+                assert_eq!(provider.models[0].id, "gpt-4");
+            }
+            other => panic!("expected Enabled from disk, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stabilize_unknown_disk_payload_matches_enabled_env_payload() {
+        let provider = sample_provider();
+        let disk = serde_json::json!({
+            "name": provider.name,
+            "options": { "baseURL": provider.base_url, "apiKey": "${tc_api_key}" },
+            "models": {
+                "gpt-4": { "name": "GPT-4" }
+            }
+        });
+        let stabilized =
+            stabilize_managed_llm_for_spawn(&ManagedLlmState::Unknown, Some(&disk));
+        let ManagedLlmState::Enabled(from_disk) = stabilized else {
+            panic!("expected Enabled");
+        };
+        assert_eq!(
+            team_provider_env_payload(&from_disk),
+            team_provider_env_payload(&provider)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Stabilize `TEAMCLAW_TEAM_PROVIDER` spawn env when managed LLM cloud state is still `Unknown` by reconstructing from on-disk `provider.team`.
- Add an explicit OpenCode serve env-snapshot conflict policy (continue / restart / tolerate same workspace / block other workspace).
- Reduces false `pending` / fingerprint mismatch in personal-env activation when vars are already usable.

## Test plan
- [ ] Cold-start amuxd, open a workspace with existing `provider.team` — first attach fingerprint matches a later confirmed cloud fetch
- [ ] Two workspaces with different env fingerprints: second attach reports other-workspace conflict (not silent pending)
- [ ] Same workspace fingerprint jitter: tolerate / queue without blocking activation
- [ ] `rg -i shopee` on the PR diff returns no matches


Made with [Cursor](https://cursor.com)