### PR TITLE
fix(ci): unbreak the four gates keeping main red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,13 @@ jobs:
           mkdir -p apps/desktop/binaries
           touch apps/desktop/binaries/teamclaw-introspect-x86_64-unknown-linux-gnu
           touch apps/desktop/binaries/amuxd-x86_64-unknown-linux-gnu
+          # `resources` in tauri.conf.json globs binaries/{cursor,claude}-bridge/**/*.
+          # The whole binaries/ dir is gitignored, so on a fresh checkout those
+          # globs resolve to nothing and tauri-build fails the build script —
+          # before clippy ever runs. A glob needs a file, not just the directory.
+          mkdir -p apps/desktop/binaries/cursor-bridge apps/desktop/binaries/claude-bridge
+          touch apps/desktop/binaries/cursor-bridge/.keep
+          touch apps/desktop/binaries/claude-bridge/.keep
 
       - name: Check Rust formatting
         run: cargo fmt --check --manifest-path apps/desktop/Cargo.toml

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -3062,7 +3062,7 @@ pub(crate) mod tests {
     pub(crate) async fn sync_team_shared_dirs_sources_from_cloud_and_skips_missing_paths() {
         let _lock = crate::config::global_team_store::TEST_HOME_LOCK
             .lock()
-            .unwrap();
+.unwrap_or_else(|e| e.into_inner());
         let home = tempfile::tempdir().unwrap();
         // SAFETY: serialized by TEST_HOME_LOCK.
         unsafe { std::env::set_var("HOME", home.path()) };

--- a/apps/daemon/src/team_link.rs
+++ b/apps/daemon/src/team_link.rs
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn materialize_or_teardown_disabled_does_not_create_global_dir() {
-        let _lock = global_team_store::TEST_HOME_LOCK.lock().unwrap();
+        let _lock = global_team_store::TEST_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let home = tempfile::tempdir().unwrap();
         // SAFETY: serialized by TEST_HOME_LOCK.
         unsafe { std::env::set_var("HOME", home.path()) };
@@ -250,7 +250,7 @@ mod tests {
 
     #[test]
     fn app_workspaces_get_no_team_link_and_lose_a_stale_one() {
-        let _lock = global_team_store::TEST_HOME_LOCK.lock().unwrap();
+        let _lock = global_team_store::TEST_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let home = tempfile::tempdir().unwrap();
         // SAFETY: serialized by TEST_HOME_LOCK.
         unsafe { std::env::set_var("HOME", home.path()) };
@@ -279,7 +279,7 @@ mod tests {
 
     #[test]
     fn app_workspace_cleanup_never_deletes_a_real_directory() {
-        let _lock = global_team_store::TEST_HOME_LOCK.lock().unwrap();
+        let _lock = global_team_store::TEST_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let home = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("HOME", home.path()) };
 
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn prune_scaffold_team_home_removes_empty_global_copy() {
-        let _lock = global_team_store::TEST_HOME_LOCK.lock().unwrap();
+        let _lock = global_team_store::TEST_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let home = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("HOME", home.path()) };
 

--- a/apps/daemon/src/test_brand_env.rs
+++ b/apps/daemon/src/test_brand_env.rs
@@ -1,9 +1,17 @@
 //! Serialize tests that mutate brand / amuxd-home path env vars.
+//!
+//! Shares `TEST_HOME_LOCK` with the tests that mutate `HOME` rather than
+//! keeping a second mutex. Both sets drive the *same* process-global path
+//! resolution — `HOME`, `AMUXD_HOME` and the brand name all feed
+//! `global_team_dir()` / `config_dir()` — so two independent locks serialized
+//! each set against itself while leaving them free to race against each other.
+//! That race is what made `team_link` / `workspace_link` / `daemon::server`
+//! tests fail under `cargo test` but pass under `--test-threads=1`.
 
 use std::path::Path;
-use std::sync::{Mutex, MutexGuard};
+use std::sync::MutexGuard;
 
-static BRAND_ENV_LOCK: Mutex<()> = Mutex::new(());
+use crate::config::global_team_store::TEST_HOME_LOCK;
 
 pub struct BrandEnvGuard {
     _lock: MutexGuard<'static, ()>,
@@ -15,7 +23,7 @@ impl BrandEnvGuard {
     /// Set `TEAMCLAW_BRAND_SHORT_NAME` and clear `AMUXD_HOME` so path resolution
     /// is driven by brand alone.
     pub fn set(brand: &str) -> Self {
-        let lock = BRAND_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let lock = TEST_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let previous_brand = std::env::var(teamclaw_runtime_env::BRAND_SHORT_NAME_ENV).ok();
         let previous_home = std::env::var(teamclaw_runtime_env::AMUXD_HOME_ENV).ok();
         std::env::set_var(teamclaw_runtime_env::BRAND_SHORT_NAME_ENV, brand);
@@ -29,7 +37,7 @@ impl BrandEnvGuard {
 
     /// Set an explicit `AMUXD_HOME` override (brand env left unchanged).
     pub fn set_amuxd_home(home: &Path) -> Self {
-        let lock = BRAND_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let lock = TEST_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let previous_brand = std::env::var(teamclaw_runtime_env::BRAND_SHORT_NAME_ENV).ok();
         let previous_home = std::env::var(teamclaw_runtime_env::AMUXD_HOME_ENV).ok();
         std::env::set_var(teamclaw_runtime_env::AMUXD_HOME_ENV, home);

--- a/apps/daemon/tests/http_apps.rs
+++ b/apps/daemon/tests/http_apps.rs
@@ -43,6 +43,11 @@ mod team_link;
 mod team_shared_env;
 #[path = "../src/team_shared_git.rs"]
 mod team_shared_git;
+// Same reason as `claude_install` above: the modules declared here carry
+// `#[cfg(test)]` blocks that an integration-test crate compiles, and those name
+// `crate::test_brand_env` — which resolves against this root, not the bin's.
+#[path = "../src/test_brand_env.rs"]
+mod test_brand_env;
 
 use std::process::Command;
 use std::sync::Arc;

--- a/apps/daemon/tests/support/crate_modules.rs
+++ b/apps/daemon/tests/support/crate_modules.rs
@@ -35,6 +35,12 @@ mod team_link;
 mod team_shared_env;
 #[path = "../../src/team_shared_git.rs"]
 mod team_shared_git;
+// Not used by the tests in this crate directly. The modules above carry their
+// own `#[cfg(test)]` blocks, which an integration-test crate *does* compile,
+// and those name `crate::test_brand_env` — which resolves against THIS root,
+// not the bin's. Without it `cargo test -p amuxd` fails to build with E0433.
+#[path = "../../src/test_brand_env.rs"]
+mod test_brand_env;
 
 fn test_sync_dispatcher() -> sync::dispatch::SyncDispatcher {
     sync::dispatch::SyncDispatcher::new(sync::secret_store::SecretStore::new(), None)

--- a/crates/teamclaw-runtime-env/src/personal_secrets.rs
+++ b/crates/teamclaw-runtime-env/src/personal_secrets.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use tracing::warn;
 
-use crate::{brand_short_name_from_env, resolve_storage_dir_name, OFFICIAL_STORAGE_DIR};
+use crate::{brand_short_name_from_env, resolve_storage_dir_name};
 
 #[derive(Debug, Clone)]
 struct SecretStorePaths {
@@ -208,7 +208,10 @@ fn load_personal_env_for_storage_dir(storage_dir: &str) -> anyhow::Result<HashMa
 mod tests {
     use super::*;
     use aes_gcm::aead::{Aead, KeyInit};
+    // Only the tests assert against the unbranded default, so importing it at
+    // module scope left a dead import in every non-test build.
     use crate::test_util::{home_env_lock, HomeGuard};
+    use crate::OFFICIAL_STORAGE_DIR;
     use rand::RngCore;
     use std::io::Write;
     use tempfile::tempdir;

--- a/packages/app/src/lib/teamclaw/__tests__/reply-acp-permission.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/reply-acp-permission.test.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useRuntimeStateStore } from "@/stores/runtime-state-store";
 import { AgentType } from "@/lib/proto/amux_pb";
 
 const mocks = vi.hoisted(() => ({
   listParticipants: vi.fn(),
   mqttPublish: vi.fn(),
+  runtimeCommand: vi.fn(),
 }));
 
 vi.mock("@/lib/backend", () => ({
@@ -15,6 +16,15 @@ vi.mock("@/lib/backend", () => ({
 
 vi.mock("@/lib/mqtt-bridge", () => ({
   mqttPublish: mocks.mqttPublish,
+}));
+
+// ADR-0004: a command carrying a session id is dispatched over RPC, not by
+// publishing to the per-spawn `runtime/{runtimeId}/commands` topic. Stubbing
+// the RPC keeps this test on its actual subject — which attachment gets
+// addressed — instead of the transport underneath it.
+vi.mock("@/lib/teamclaw-rpc", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/teamclaw-rpc")>()),
+  runtimeCommand: (...args: unknown[]) => mocks.runtimeCommand(...args),
 }));
 
 vi.mock("@/stores/current-team", () => ({
@@ -56,6 +66,9 @@ describe("replyAcpPermission", () => {
       { id: "agent-live", actor_type: "agent" },
     ]);
     mocks.mqttPublish.mockResolvedValue(undefined);
+    // `true` = the daemon holds a live attachment for the session. Returning
+    // `false` here would make the caller throw "no live attachment".
+    mocks.runtimeCommand.mockResolvedValue(true);
   });
 
   it("addresses the attachment filed under this session, ignoring others", async () => {
@@ -84,10 +97,18 @@ describe("replyAcpPermission", () => {
     const { replyPermissionById } = await import("../reply-acp-permission");
     await replyPermissionById("perm-uuid-1", "allow");
 
-    expect(mocks.mqttPublish).toHaveBeenCalledTimes(1);
-    const topic = mocks.mqttPublish.mock.calls[0][0] as string;
-    expect(topic).toBe(
-      "amux/team-1/agent-live/runtime/live-spawn/commands",
-    );
+    expect(mocks.runtimeCommand).toHaveBeenCalledTimes(1);
+    const [call] = mocks.runtimeCommand.mock.calls[0] as [
+      { targetActorId: string; sessionId: string; envelope: { runtimeId: string } },
+    ];
+    expect(call.targetActorId).toBe("agent-live");
+    expect(call.sessionId).toBe("sess-1");
+    // The point of the test: the attachment filed under `sess-1`, not the
+    // `other-session` one that is also in the store.
+    expect(call.envelope.runtimeId).toBe("live-spawn");
+
+    // Session-addressed dispatch goes over RPC only — the legacy per-spawn
+    // topic must not also be published to, or a cold session is a silent miss.
+    expect(mocks.mqttPublish).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/lib/teamclaw/__tests__/reply-acp-permission.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/reply-acp-permission.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useRuntimeStateStore } from "@/stores/runtime-state-store";
 import { AgentType } from "@/lib/proto/amux_pb";
 


### PR DESCRIPTION
CI has failed on every recent run on `main` — `Rust Format & Clippy`,
`Daemon Unit Tests (Linux)` and `Lint, Typecheck & Test` are all red, so no PR
can go green. Four independent causes, one commit each.

### 1. `ci:` tauri-build cannot run at all

`resources` in `tauri.conf.json` globs `binaries/cursor-bridge/**/*` and
`binaries/claude-bridge/**/*`, but `apps/desktop/binaries/.gitignore` ignores
that whole directory. On a fresh checkout the globs match nothing and
tauri-build fails the `teamclaw` build script — aborting the Rust job *before
clippy runs*, so its real output never even appears.

Verified as a controlled experiment: creating only those two dirs takes
`cargo clippy --manifest-path apps/desktop/Cargo.toml -- -D warnings` from
failing to clean, with no other change.

### 2. `fix(runtime-env):` the clippy error underneath it

`OFFICIAL_STORAGE_DIR` is referenced only from a `#[cfg(test)]` block but
imported at module scope, so every non-test build carries a dead import and
`-D warnings` fails. Moved into the test module.

### 3. `fix(daemon):` `cargo test -p amuxd` fails to build

13x `error[E0433]: cannot find test_brand_env in crate`. The integration tests
pull `src/` modules into their own crate roots via `#[path]`; those modules
carry `#[cfg(test)]` blocks that an integration-test crate *does* compile, and
they name `crate::test_brand_env` — which resolves against the including
test's root, not the bin's. Only `main.rs` declared it.

Declared in both including roots, matching the precedent already documented
for `claude_install` / `cursor_install` in `http_apps.rs`.

### 4. `test(acp):` a stale assertion, worth a look

**This one changes what a test asserts, so please sanity-check the intent.**

`reply-acp-permission.test.ts` asserted the per-spawn topic
`runtime/{runtimeId}/commands`. Since ADR-0004 a command carrying a session id
goes over RPC instead, and `dispatch()` explicitly refuses to fall back ("a
failed RPC that 'falls back' becomes a silent miss"). The test therefore died
at `teamclaw-rpc not initialized`, never reaching what it was trying to prove.

I read this as the assertion being stale rather than a production regression,
on the strength of those ADR-0004 comments. It now stubs `runtimeCommand` and
asserts what the test is named for — the attachment filed under `sess-1` is
addressed, not the `other-session` one in the same store — and that the legacy
topic is not also published to. If the intended behaviour is the opposite,
this is a production bug and needs a different fix.

### Verified locally

- `cargo clippy --manifest-path apps/desktop/Cargo.toml -- -D warnings` — clean
- `cargo fmt --check --manifest-path apps/desktop/Cargo.toml` — clean
- `cargo test -p amuxd --locked --no-run` — builds, no E0433
- `cargo clippy -p teamclaw-runtime-env --all-targets -- -D warnings` — clean
- `reply-acp-permission.test.ts` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)