### PR TITLE
fix(daemon): cancel resolve keeps actor so multi-agent sessions stop the right runtime

### DIFF
--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -153,14 +153,21 @@ impl DaemonServer {
         use prost::Message as ProstMessage;
         match msg {
             subscriber::IncomingMessage::RuntimeCommand {
+                actor_id,
                 runtime_id,
                 envelope,
             } => {
                 // Topic segment may be a spawn key, cloud session id, or
                 // `{actor}::{session}` (ADR-0004). Resolve before cancel.
+                // Prefer envelope.actor_id (target agent); fall back to topic.
+                let resolve_actor = if !envelope.actor_id.trim().is_empty() {
+                    envelope.actor_id.trim()
+                } else {
+                    actor_id.trim()
+                };
                 let resolved = {
                     let agents = self.agents.lock().await;
-                    agents.resolve_command_agent_id(&runtime_id)
+                    agents.resolve_command_agent_id(&runtime_id, resolve_actor)
                 };
                 match resolved {
                     Some(agent_id) => {
@@ -444,10 +451,15 @@ impl DaemonServer {
             };
         };
 
+        let resolve_actor = if !envelope.actor_id.trim().is_empty() {
+            envelope.actor_id.trim().to_string()
+        } else {
+            self.actor_id.clone()
+        };
         let agent_id = {
             let agents = self.agents.lock().await;
             agents
-                .attachment_for_session(&session_id)
+                .attachment_for_session_actor(&session_id, &resolve_actor)
                 .map(|h| h.agent_id.clone())
         };
 

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -638,6 +638,17 @@ impl DaemonServer {
             }
         };
 
+        // Belt-and-suspenders: env snapshot usually stamps owner_actor_id, but
+        // gateway / bare spawns may omit it. Command resolve keys on this field.
+        {
+            let mut agents = self.agents.lock().await;
+            if let Some(h) = agents.get_handle_mut(&new_id) {
+                if h.owner_actor_id.is_empty() {
+                    h.owner_actor_id = self.actor_id.clone();
+                }
+            }
+        }
+
         if !session_id.is_empty() {
             if let Err(e) = teamclaw_runtime_env::write_active_session_id(
                 Path::new(&resolved_worktree),

--- a/apps/daemon/src/mqtt/subscriber.rs
+++ b/apps/daemon/src/mqtt/subscriber.rs
@@ -8,6 +8,8 @@ use crate::proto::amux;
 pub enum IncomingMessage {
     // Decoded from amux/{team}/{actor}/runtime/+/commands.
     RuntimeCommand {
+        /// Target agent actor from the topic (`parts[2]`).
+        actor_id: String,
         runtime_id: String,
         envelope: amux::RuntimeCommandEnvelope,
     },
@@ -82,10 +84,12 @@ pub fn parse_frame(frame: &IncomingFrame) -> Option<IncomingMessage> {
         // amux / {team} / {actor} / runtime / {runtime_id} / commands
         // = 6 segments
         if parts.len() == 6 && parts[3] == "runtime" {
+            let actor_id = parts[2].to_string();
             let runtime_id = parts[4].to_string();
             match amux::RuntimeCommandEnvelope::decode(payload.as_slice()) {
                 Ok(envelope) => {
                     return Some(IncomingMessage::RuntimeCommand {
+                        actor_id,
                         runtime_id,
                         envelope,
                     });
@@ -118,7 +122,12 @@ mod tests {
         );
         let msg = parse_incoming(&p).expect("should parse");
         match msg {
-            IncomingMessage::RuntimeCommand { runtime_id, .. } => {
+            IncomingMessage::RuntimeCommand {
+                actor_id,
+                runtime_id,
+                ..
+            } => {
+                assert_eq!(actor_id, "actor-a");
                 assert_eq!(runtime_id, "rt1");
             }
             _ => panic!("wrong variant"),

--- a/apps/daemon/src/runtime/handle.rs
+++ b/apps/daemon/src/runtime/handle.rs
@@ -26,6 +26,11 @@ pub struct RuntimeHandle {
     pub agent_id: String,
     pub acp_session_id: String,
     pub session_id: String,
+    /// Cloud agent actor UUID that owns this attachment (daemon routing
+    /// identity). Distinct from `agent_id`, which is the 8-char spawn key.
+    /// Used to resolve session-addressed commands when multiple attachments
+    /// share a session_id (ADR-0004 `(actor, session)`).
+    pub owner_actor_id: String,
     pub agent_type: amux::AgentType,
     pub worktree: String,
     pub workspace_id: String,
@@ -118,6 +123,7 @@ impl RuntimeHandle {
             agent_id,
             acp_session_id: String::new(),
             session_id: String::new(),
+            owner_actor_id: String::new(),
             agent_type,
             worktree,
             workspace_id,
@@ -148,6 +154,22 @@ impl RuntimeHandle {
             env_snapshot: None,
             env_team_id: None,
             remote_tools_mcp_refresh_pending: false,
+        }
+    }
+
+    /// Copy cloud actor id from the resolved env snapshot when present.
+    pub fn stamp_owner_actor_from_env(&mut self) {
+        if !self.owner_actor_id.is_empty() {
+            return;
+        }
+        if let Some(actor) = self
+            .env_snapshot
+            .as_ref()
+            .and_then(|snap| snap.bindings.get("actor_id"))
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+        {
+            self.owner_actor_id = actor.to_string();
         }
     }
 
@@ -372,6 +394,7 @@ impl RuntimeHandle {
             agent_id: String::new(),
             acp_session_id: String::new(),
             session_id: String::new(),
+            owner_actor_id: String::new(),
             agent_type: crate::proto::amux::AgentType::ClaudeCode,
             worktree: String::new(),
             workspace_id: String::new(),

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -655,6 +655,7 @@ impl RuntimeManager {
             .map(|snapshot| snapshot.fingerprint.clone());
         handle.env_snapshot = resolved_env;
         handle.env_team_id = env_team_id;
+        handle.stamp_owner_actor_from_env();
         handle.session_id = remote_session_id.unwrap_or_default().to_string();
         // No static fallback: models come only from the live serve catalog
         // captured at attach time. Empty until the runtime advertises them.
@@ -799,6 +800,7 @@ impl RuntimeManager {
             .map(|snapshot| snapshot.fingerprint.clone());
         handle.env_snapshot = resolved_env;
         handle.env_team_id = env_team_id;
+        handle.stamp_owner_actor_from_env();
         handle.session_id = remote_session_id.unwrap_or_default().to_string();
         handle.is_gateway = is_gateway;
 
@@ -1351,11 +1353,31 @@ impl RuntimeManager {
     /// lets commands be addressed by (actor, session) rather than by a spawn id
     /// that goes stale the moment it is written down (ADR-0004).
     pub fn attachment_for_session(&self, session_id: &str) -> Option<&RuntimeHandle> {
+        self.attachment_for_session_actor(session_id, "")
+    }
+
+    /// Session attachment lookup scoped to a cloud actor when `actor_id` is set.
+    /// Among matches, prefer the newest `started_at` (same rule as command
+    /// resolve) so a leaked mid-turn sibling is not picked at random.
+    pub fn attachment_for_session_actor(
+        &self,
+        session_id: &str,
+        actor_id: &str,
+    ) -> Option<&RuntimeHandle> {
         let session_id = session_id.trim();
         if session_id.is_empty() {
             return None;
         }
-        self.agents.values().find(|h| h.session_id == session_id)
+        let actor_id = actor_id.trim();
+        self.agents
+            .values()
+            .filter(|h| {
+                h.session_id == session_id
+                    && (actor_id.is_empty()
+                        || h.owner_actor_id.is_empty()
+                        || h.owner_actor_id == actor_id)
+            })
+            .max_by_key(|h| h.started_at)
     }
 
     /// The sessions this daemon currently holds an attachment for.
@@ -2412,7 +2434,7 @@ mod tests {
         let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
         mgr.add_test_runtime("76fd9bf2", "76fd9bf2", "54809303-ed5b-4f10-893f-2d0fd2db4e00");
         assert_eq!(
-            mgr.resolve_command_agent_id("76fd9bf2").as_deref(),
+            mgr.resolve_command_agent_id("76fd9bf2", "").as_deref(),
             Some("76fd9bf2")
         );
     }
@@ -2425,7 +2447,7 @@ mod tests {
         let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
         mgr.add_test_runtime("76fd9bf2", "76fd9bf2", "54809303-ed5b-4f10-893f-2d0fd2db4e00");
         assert_eq!(
-            mgr.resolve_command_agent_id("54809303-ed5b-4f10-893f-2d0fd2db4e00")
+            mgr.resolve_command_agent_id("54809303-ed5b-4f10-893f-2d0fd2db4e00", "")
                 .as_deref(),
             Some("76fd9bf2")
         );
@@ -2435,9 +2457,12 @@ mod tests {
     fn resolve_command_agent_id_accepts_actor_session_composite() {
         let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
         mgr.add_test_runtime("76fd9bf2", "76fd9bf2", "54809303-ed5b-4f10-893f-2d0fd2db4e00");
+        mgr.get_handle_mut("76fd9bf2").unwrap().owner_actor_id =
+            "614433ab-52dd-4ce3-b5f4-14376f8eb680".into();
         assert_eq!(
             mgr.resolve_command_agent_id(
-                "614433ab-52dd-4ce3-b5f4-14376f8eb680::54809303-ed5b-4f10-893f-2d0fd2db4e00"
+                "614433ab-52dd-4ce3-b5f4-14376f8eb680::54809303-ed5b-4f10-893f-2d0fd2db4e00",
+                "614433ab-52dd-4ce3-b5f4-14376f8eb680",
             )
             .as_deref(),
             Some("76fd9bf2")
@@ -2447,8 +2472,42 @@ mod tests {
     #[test]
     fn resolve_command_agent_id_unknown_returns_none() {
         let mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
-        assert_eq!(mgr.resolve_command_agent_id("no-such").as_deref(), None);
-        assert_eq!(mgr.resolve_command_agent_id("").as_deref(), None);
+        assert_eq!(mgr.resolve_command_agent_id("no-such", "").as_deref(), None);
+        assert_eq!(mgr.resolve_command_agent_id("", "").as_deref(), None);
+    }
+
+    #[test]
+    fn resolve_command_agent_id_prefers_matching_actor_when_session_has_two() {
+        // Issue #780: same session, two owners — cancel for A must not hit B
+        // just because B started later.
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.add_test_runtime("rt-a", "rt-a", "session_S");
+        mgr.add_test_runtime("rt-b", "rt-b", "session_S");
+        mgr.get_handle_mut("rt-a").unwrap().owner_actor_id = "actor-A".into();
+        mgr.get_handle_mut("rt-a").unwrap().started_at = 100;
+        mgr.get_handle_mut("rt-b").unwrap().owner_actor_id = "actor-B".into();
+        mgr.get_handle_mut("rt-b").unwrap().started_at = 200;
+
+        assert_eq!(
+            mgr.resolve_command_agent_id("session_S", "actor-A")
+                .as_deref(),
+            Some("rt-a")
+        );
+        assert_eq!(
+            mgr.resolve_command_agent_id("actor-A::session_S", "actor-A")
+                .as_deref(),
+            Some("rt-a")
+        );
+        assert_eq!(
+            mgr.resolve_command_agent_id("actor-A::session_S", "actor-B")
+                .as_deref(),
+            None
+        );
+        assert_eq!(
+            mgr.resolve_command_agent_id("session_S", "actor-B")
+                .as_deref(),
+            Some("rt-b")
+        );
     }
 
     #[tokio::test]

--- a/apps/daemon/src/runtime/manager/lookup.rs
+++ b/apps/daemon/src/runtime/manager/lookup.rs
@@ -9,7 +9,19 @@
 
 use crate::proto::amux;
 
+use super::super::handle::RuntimeHandle;
 use super::RuntimeManager;
+
+fn owner_matches(handle: &RuntimeHandle, actor_id: &str) -> bool {
+    if actor_id.is_empty() {
+        return true;
+    }
+    // Legacy / unstamped handles: do not fail closed on missing owner.
+    if handle.owner_actor_id.is_empty() {
+        return true;
+    }
+    handle.owner_actor_id == actor_id
+}
 
 impl RuntimeManager {
     /// Return all runtime IDs whose handle has `session_id == session_id`.
@@ -25,9 +37,19 @@ impl RuntimeManager {
     /// the greatest `started_at`. Defense-in-depth when multiple runtimes
     /// leaked despite the one-runtime-per-session invariant.
     pub fn newest_runtime_id_for_session(&self, session_id: &str) -> Option<String> {
+        self.newest_runtime_id_for_session_actor(session_id, "")
+    }
+
+    /// Like [`Self::newest_runtime_id_for_session`], but when `actor_id` is
+    /// non-empty prefer attachments owned by that cloud actor (ADR-0004).
+    pub fn newest_runtime_id_for_session_actor(
+        &self,
+        session_id: &str,
+        actor_id: &str,
+    ) -> Option<String> {
         self.agents
             .iter()
-            .filter(|(_, h)| h.session_id == session_id)
+            .filter(|(_, h)| h.session_id == session_id && owner_matches(h, actor_id))
             .max_by_key(|(_, h)| h.started_at)
             .map(|(id, _)| id.clone())
     }
@@ -93,7 +115,15 @@ impl RuntimeManager {
     /// `{actor}::{session}` composite) while this map is still keyed by the
     /// per-spawn id. Cancel that used the session UUID as a map key failed
     /// with `agent {session} not found` and left Cursor running.
-    pub fn resolve_command_agent_id(&self, addressed_as: &str) -> Option<String> {
+    ///
+    /// `actor_id` is the cloud agent actor from the envelope (and/or MQTT
+    /// topic). When non-empty, session fallbacks prefer that owner's
+    /// attachment so a multi-agent session cannot cancel the newest sibling.
+    pub fn resolve_command_agent_id(
+        &self,
+        addressed_as: &str,
+        actor_id: &str,
+    ) -> Option<String> {
         let addressed = addressed_as.trim();
         if addressed.is_empty() {
             return None;
@@ -101,18 +131,28 @@ impl RuntimeManager {
         if self.agents.contains_key(addressed) {
             return Some(addressed.to_string());
         }
-        if let Some(id) = self.newest_runtime_id_for_session(addressed) {
-            return Some(id);
-        }
-        // iOS composite: `{actor}::{session}`
-        if let Some((_, session)) = addressed.split_once("::") {
+
+        let actor_id = actor_id.trim();
+
+        // iOS composite: `{actor}::{session}` — keep the left side for filter
+        // / validation instead of discarding it.
+        if let Some((left, session)) = addressed.split_once("::") {
+            let left = left.trim();
             let session = session.trim();
-            if !session.is_empty() {
-                if let Some(id) = self.newest_runtime_id_for_session(session) {
-                    return Some(id);
-                }
+            if session.is_empty() {
+                return None;
             }
+            if !actor_id.is_empty() && !left.is_empty() && left != actor_id {
+                return None;
+            }
+            let filter_actor = if !actor_id.is_empty() {
+                actor_id
+            } else {
+                left
+            };
+            return self.newest_runtime_id_for_session_actor(session, filter_actor);
         }
-        None
+
+        self.newest_runtime_id_for_session_actor(addressed, actor_id)
     }
 }


### PR DESCRIPTION
## Summary
- Stamp `owner_actor_id` on attachments (env bindings + daemon actor fallback) so session-addressed commands can filter by cloud actor, not just newest `started_at`.
- `resolve_command_agent_id` / MQTT topic parse / RPC `attachment_for_session_actor` now use that actor; iOS `{actor}::{session}` validates the left half instead of discarding it.
- Adds a same-session two-owner regression test so cancel for A cannot hit newer B.

Fixes #780

## Test plan
- [x] `cargo test --manifest-path apps/daemon/Cargo.toml --bin amuxd resolve_command_agent_id`
- [x] `cargo test --manifest-path apps/daemon/Cargo.toml --bin amuxd parse_runtime_commands` (via built test binary)
- [ ] Manual: same-session two agents on one daemon — stop A leaves B running
- [ ] Manual: iOS composite `{actor}::{session}` cancel still resolves


Made with [Cursor](https://cursor.com)