### PR TITLE
fix(app): permission and answer survive RPC transport blips

### DIFF
--- a/packages/app/src/lib/teamclaw/__tests__/runtime-command-dispatch.test.ts
+++ b/packages/app/src/lib/teamclaw/__tests__/runtime-command-dispatch.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createRuntimeCommandSender } from "@/lib/teamclaw/runtime-command";
+import {
+  createRuntimeCommandSender,
+  runtimeCommandsTopic,
+} from "@/lib/teamclaw/runtime-command";
 
 function makeSender(overrides: {
   rpc?: (input: { targetActorId: string; sessionId: string }) => Promise<boolean>;
@@ -19,6 +22,21 @@ function makeSender(overrides: {
 }
 
 const CANCEL = { targetActorId: "agent-a", runtimeId: "rt-abcd", sessionId: "session-1" };
+const PERMISSION = {
+  targetActorId: "agent-a",
+  runtimeId: "rt-abcd",
+  sessionId: "session-1",
+  requestId: "perm-1",
+  granted: true,
+  optionId: "once",
+};
+const ANSWER = {
+  targetActorId: "agent-a",
+  runtimeId: "rt-abcd",
+  sessionId: "session-1",
+  requestId: "q-1",
+  answers: [["yes"]],
+};
 
 describe("runtime command dispatch", () => {
   it("addresses the session over rpc when one is available", async () => {
@@ -44,7 +62,7 @@ describe("runtime command dispatch", () => {
     expect(publish).not.toHaveBeenCalled();
   });
 
-  it("does not fall back to the legacy topic when the rpc channel itself is down", async () => {
+  it("does not fall back to the legacy topic when cancel rpc is down", async () => {
     // Legacy fallback published cancel with session UUID as the topic
     // segment; the daemon looked that up as a spawn key and dropped it
     // silently — stop looked like a no-op (cross-actor interrupt on the
@@ -67,5 +85,54 @@ describe("runtime command dispatch", () => {
 
     expect(rpc).not.toHaveBeenCalled();
     expect(publish).toHaveBeenCalledTimes(1);
+  });
+
+  // Issue #783: permission / answer share dispatch with cancel. A transport
+  // blip must not leave the agent stuck waiting on an approval the user
+  // already clicked — deliver via spawn-keyed MQTT after one RPC retry.
+  it("delivers permission response via spawn topic when rpc transport fails", async () => {
+    const rpc = vi.fn(async () => {
+      throw new Error("teamclaw-rpc not initialized");
+    });
+    const { sender, publish } = makeSender({ rpc });
+
+    await sender.sendPermissionResponse(PERMISSION);
+
+    expect(rpc.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0]?.[0]).toBe(
+      runtimeCommandsTopic("team-1", "agent-a", "rt-abcd"),
+    );
+  });
+
+  it("delivers answer-question via spawn topic when rpc transport fails", async () => {
+    const rpc = vi.fn(async () => {
+      throw new Error("broker disconnected");
+    });
+    const { sender, publish } = makeSender({ rpc });
+
+    await sender.sendAnswerQuestion(ANSWER);
+
+    expect(rpc.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0]?.[0]).toBe(
+      runtimeCommandsTopic("team-1", "agent-a", "rt-abcd"),
+    );
+  });
+
+  it("does not mqtt-fallback permission when the session is cold", async () => {
+    const { sender, publish } = makeSender({ rpc: async () => false });
+
+    await expect(sender.sendPermissionResponse(PERMISSION)).rejects.toThrow(
+      /no live attachment/,
+    );
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it("does not mqtt-fallback answer-question when the session is cold", async () => {
+    const { sender, publish } = makeSender({ rpc: async () => false });
+
+    await expect(sender.sendAnswerQuestion(ANSWER)).rejects.toThrow(/no live attachment/);
+    expect(publish).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/lib/teamclaw/answer-question.ts
+++ b/packages/app/src/lib/teamclaw/answer-question.ts
@@ -50,8 +50,8 @@ export async function answerAcpQuestion(args: {
   const peerId = `teamclaw-desktop-${(senderActorId || "anon").slice(0, 8)}`;
   const sender = createRuntimeCommandSender({
     mqtt: { publish: mqttPublish },
-    // Session-addressed dispatch with a delivery receipt; falls back to the
-    // per-spawn topic when no session id reaches here.
+    // Session-addressed RPC; on transport failure the sender retries once
+    // then publishes to the spawn-keyed commands topic (issue #783).
     rpc: ({ targetActorId, sessionId: sid, envelope }) =>
       runtimeCommand({ targetActorId, sessionId: sid, envelope }),
     teamId,

--- a/packages/app/src/lib/teamclaw/reply-acp-permission.ts
+++ b/packages/app/src/lib/teamclaw/reply-acp-permission.ts
@@ -87,8 +87,8 @@ export async function replyAcpPermission(args: {
   const peerId = `teamclaw-desktop-${(senderActorId || "anon").slice(0, 8)}`;
   const sender = createRuntimeCommandSender({
     mqtt: { publish: mqttPublish },
-    // Session-addressed dispatch with a delivery receipt; falls back to the
-    // per-spawn topic when no session id reaches here.
+    // Session-addressed RPC; on transport failure the sender retries once
+    // then publishes to the spawn-keyed commands topic (issue #783).
     rpc: ({ targetActorId, sessionId: sid, envelope }) =>
       runtimeCommand({ targetActorId, sessionId: sid, envelope }),
     teamId,

--- a/packages/app/src/lib/teamclaw/runtime-command.ts
+++ b/packages/app/src/lib/teamclaw/runtime-command.ts
@@ -131,7 +131,9 @@ export function createRuntimeCommandSender(
         acpCommand,
       });
 
-      await dispatch(deps, teamId, targetActorId, runtimeId, input.sessionId, envelope);
+      await dispatch(deps, teamId, targetActorId, runtimeId, input.sessionId, envelope, {
+        onRpcTransportFailure: "mqtt-fallback",
+      });
     },
 
     async sendAnswerQuestion(input) {
@@ -161,7 +163,9 @@ export function createRuntimeCommandSender(
         acpCommand,
       });
 
-      await dispatch(deps, teamId, targetActorId, runtimeId, input.sessionId, envelope);
+      await dispatch(deps, teamId, targetActorId, runtimeId, input.sessionId, envelope, {
+        onRpcTransportFailure: "mqtt-fallback",
+      });
     },
 
     async sendCancel(input) {
@@ -186,18 +190,32 @@ export function createRuntimeCommandSender(
         acpCommand,
       });
 
-      await dispatch(deps, teamId, targetActorId, runtimeId, input.sessionId, envelope);
+      await dispatch(deps, teamId, targetActorId, runtimeId, input.sessionId, envelope, {
+        onRpcTransportFailure: "throw",
+      });
     },
   };
 }
+
+type DispatchOptions = {
+  /**
+   * When the RPC *channel* throws (not initialized, broker down), cancel
+   * stays loud (`throw`) so a stop never looks like a silent no-op.
+   * Permission / answer-question retry once then publish on the spawn-keyed
+   * MQTT topic — a stuck approval is worse than a best-effort delivery
+   * (issue #783). Cold-session (`dispatched === false`) always throws.
+   */
+  onRpcTransportFailure: "throw" | "mqtt-fallback";
+};
 
 /**
  * Send by (actor, session) when both a session id and an RPC dispatcher are
  * available; otherwise fall back to the per-spawn commands topic.
  *
- * When RPC is attempted, failures are not silently re-routed to the legacy
- * topic — that topic has no delivery receipt and after ADR-0004 often
- * addresses by session UUID while the daemon map is still spawn-keyed.
+ * Cold-session answers (`dispatched === false`) never fall back — that is
+ * how cancel learned the session was dead. Transport errors are per-command:
+ * cancel throws; permission / answer may MQTT-fallback with the spawn
+ * `runtimeId` (never the session UUID as a topic segment).
  */
 async function dispatch(
   deps: RuntimeCommandSenderDeps,
@@ -206,21 +224,45 @@ async function dispatch(
   runtimeId: string,
   sessionId: string | undefined,
   envelope: RuntimeCommandEnvelope,
+  options: DispatchOptions,
 ): Promise<void> {
   const session = sessionId?.trim() ?? "";
   if (deps.rpc && session) {
-    // No silent legacy fallback: publishing to runtime/{sessionId}/commands
-    // after ADR-0004 addresses by session while the daemon map is still
-    // spawn-keyed, so a failed RPC that "falls back" becomes a silent miss.
-    const dispatched = await deps.rpc({ targetActorId, sessionId: session, envelope });
-    if (!dispatched) {
-      // The daemon answered and holds nothing for this session — it is cold.
-      // Surfacing this is the entire point of moving onto a channel with a
-      // reply path; the old topic swallowed it.
-      throw new Error(`no live attachment for session ${session}`);
+    const maxAttempts = options.onRpcTransportFailure === "mqtt-fallback" ? 2 : 1;
+    let lastTransportError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const dispatched = await deps.rpc({ targetActorId, sessionId: session, envelope });
+        if (!dispatched) {
+          // The daemon answered and holds nothing for this session — it is cold.
+          // Surfacing this is the entire point of moving onto a channel with a
+          // reply path; the old topic swallowed it.
+          throw new Error(`no live attachment for session ${session}`);
+        }
+        return;
+      } catch (error) {
+        if (error instanceof Error && /no live attachment/.test(error.message)) {
+          throw error;
+        }
+        lastTransportError = error;
+      }
     }
-    return;
+    if (options.onRpcTransportFailure === "mqtt-fallback") {
+      await publishSpawnCommands(deps, teamId, targetActorId, runtimeId, envelope);
+      return;
+    }
+    throw lastTransportError;
   }
+  await publishSpawnCommands(deps, teamId, targetActorId, runtimeId, envelope);
+}
+
+async function publishSpawnCommands(
+  deps: RuntimeCommandSenderDeps,
+  teamId: string,
+  targetActorId: string,
+  runtimeId: string,
+  envelope: RuntimeCommandEnvelope,
+): Promise<void> {
   await deps.mqtt.publish(
     runtimeCommandsTopic(teamId, targetActorId, runtimeId),
     toBinary(RuntimeCommandEnvelopeSchema, envelope),


### PR DESCRIPTION
## Summary
- Split runtime-command `dispatch` policy: cancel still throws when the RPC channel is down (#775); permission / answer-question retry once then publish on the spawn-keyed MQTT topic.
- Cold-session answers (`dispatched === false`) never fall back for any command — that loud failure stays.
- Regression tests lock both the cancel no-fallback and the permission/answer transport-fallback paths.

Fixes #783

## Test plan
- [x] `pnpm exec vitest run src/lib/teamclaw/__tests__/runtime-command-dispatch.test.ts src/lib/__tests__/interrupt-agent.test.ts` (in `packages/app`)
- [ ] Manual: grant permission while MQTT/RPC briefly unavailable — agent should proceed (or recover after retry)
- [ ] Manual: stop button with RPC down still surfaces an error (no silent MQTT miss)


Made with [Cursor](https://cursor.com)