### PR TITLE
fix(release): install @cursor/sdk native binary for the bundle target

### DIFF
--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -230,13 +230,20 @@ jobs:
           ) > /tmp/amuxd.log 2>&1 &
           PID_AMUXD=$!
 
+          # Pass --target so npm installs @cursor/sdk's optional native binary for
+          # the *bundle* arch, not the runner (macos-latest is always arm64; see #778).
           (
             set -e
-            echo "Bundling agent bridge sidecars..."
-            node scripts/ensure-agent-bridge-bundles.js
+            echo "Bundling agent bridge sidecars for ${{ matrix.target }}..."
+            case "${{ matrix.target }}" in
+              aarch64-apple-darwin) SDK_NATIVE="@cursor/sdk-darwin-arm64" ;;
+              x86_64-apple-darwin) SDK_NATIVE="@cursor/sdk-darwin-x64" ;;
+              *) echo "unsupported matrix target: ${{ matrix.target }}" >&2; exit 1 ;;
+            esac
+            node scripts/ensure-agent-bridge-bundles.js --target "${{ matrix.target }}"
             test -f apps/desktop/binaries/cursor-bridge/src/main.mjs
-            test -d apps/desktop/binaries/cursor-bridge/node_modules/@cursor/sdk
-            echo "agent bridge bundles ready"
+            test -d "apps/desktop/binaries/cursor-bridge/node_modules/${SDK_NATIVE}"
+            echo "agent bridge bundles ready (${SDK_NATIVE})"
           ) > /tmp/bridge-bundles.log 2>&1 &
           PID_BRIDGES=$!
 
@@ -542,9 +549,11 @@ jobs:
       - name: Bundle agent bridge sidecars
         shell: bash
         run: |
-          node scripts/ensure-agent-bridge-bundles.js
+          # Windows runners are already x64; still pass --target and assert the
+          # native package so a wrong optionalDependency cannot slip through (#778).
+          node scripts/ensure-agent-bridge-bundles.js --target x86_64-pc-windows-msvc
           test -f apps/desktop/binaries/cursor-bridge/src/main.mjs
-          test -d apps/desktop/binaries/cursor-bridge/node_modules/@cursor/sdk
+          test -d apps/desktop/binaries/cursor-bridge/node_modules/@cursor/sdk-win32-x64
 
       - name: Finalize tauri.conf.json (version from tag + frontend prebuilt + OSS updater endpoint)
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,13 +192,20 @@ jobs:
           PID_AMUXD=$!
 
           # 2c) Bundle cursor/claude bridge sidecars for Tauri resources (background)
+          # Pass --target so npm installs @cursor/sdk's optional native binary for
+          # the *bundle* arch, not the runner (macos-latest is always arm64; see #778).
           (
             set -e
-            echo "Bundling agent bridge sidecars..."
-            node scripts/ensure-agent-bridge-bundles.js
+            echo "Bundling agent bridge sidecars for ${{ matrix.target }}..."
+            case "${{ matrix.target }}" in
+              aarch64-apple-darwin) SDK_NATIVE="@cursor/sdk-darwin-arm64" ;;
+              x86_64-apple-darwin) SDK_NATIVE="@cursor/sdk-darwin-x64" ;;
+              *) echo "unsupported matrix target: ${{ matrix.target }}" >&2; exit 1 ;;
+            esac
+            node scripts/ensure-agent-bridge-bundles.js --target "${{ matrix.target }}"
             test -f apps/desktop/binaries/cursor-bridge/src/main.mjs
-            test -d apps/desktop/binaries/cursor-bridge/node_modules/@cursor/sdk
-            echo "agent bridge bundles ready"
+            test -d "apps/desktop/binaries/cursor-bridge/node_modules/${SDK_NATIVE}"
+            echo "agent bridge bundles ready (${SDK_NATIVE})"
           ) > /tmp/bridge-bundles.log 2>&1 &
           PID_BRIDGES=$!
 
@@ -423,6 +430,15 @@ jobs:
           cargo build --release --locked --manifest-path apps/daemon/Cargo.toml -p amuxd
           cp "$TARGET_DIR/release/amuxd.exe" apps/desktop/binaries/amuxd-x86_64-pc-windows-msvc.exe
           echo "amuxd sidecar ready"
+
+      - name: Bundle agent bridge sidecars
+        shell: bash
+        run: |
+          # Assert the native package so a wrong optionalDependency cannot slip
+          # through (see #778).
+          node scripts/ensure-agent-bridge-bundles.js --target x86_64-pc-windows-msvc
+          test -f apps/desktop/binaries/cursor-bridge/src/main.mjs
+          test -d apps/desktop/binaries/cursor-bridge/node_modules/@cursor/sdk-win32-x64
 
       # Skip beforeBuildCommand since frontend is already built above
       - name: Finalize tauri.conf.json for build

--- a/scripts/ensure-agent-bridge-bundles.js
+++ b/scripts/ensure-agent-bridge-bundles.js
@@ -10,12 +10,86 @@ const BRIDGES = [
   {
     name: "cursor-bridge",
     src: path.join("apps", "daemon", "cursor-bridge"),
+    // Optional native package installed via @cursor/sdk optionalDependencies.
+    nativePackage: (npmPlatform) =>
+      npmPlatform ? `@cursor/sdk-${npmPlatform.os}-${npmPlatform.cpu}` : null,
   },
   {
     name: "claude-bridge",
     src: path.join("apps", "daemon", "claude-bridge"),
   },
 ];
+
+/** @typedef {{ os: string, cpu: string }} NpmPlatform */
+
+/**
+ * Map a Rust target triple to npm's `--os` / `--cpu` filters (npm ≥ 10).
+ * @param {string} target
+ * @returns {NpmPlatform}
+ */
+function rustTargetToNpmPlatform(target) {
+  const table = {
+    "aarch64-apple-darwin": { os: "darwin", cpu: "arm64" },
+    "x86_64-apple-darwin": { os: "darwin", cpu: "x64" },
+    "aarch64-unknown-linux-gnu": { os: "linux", cpu: "arm64" },
+    "x86_64-unknown-linux-gnu": { os: "linux", cpu: "x64" },
+    "x86_64-pc-windows-msvc": { os: "win32", cpu: "x64" },
+    "x86_64-pc-windows-gnu": { os: "win32", cpu: "x64" },
+  };
+  const mapped = table[target];
+  if (!mapped) {
+    throw new Error(
+      `unsupported rust target for bridge npm platform: ${target}`,
+    );
+  }
+  return mapped;
+}
+
+/**
+ * Host platform as npm `--os` / `--cpu` values.
+ * @returns {NpmPlatform}
+ */
+function hostNpmPlatform() {
+  const os =
+    process.platform === "win32"
+      ? "win32"
+      : process.platform === "darwin"
+        ? "darwin"
+        : process.platform === "linux"
+          ? "linux"
+          : null;
+  const cpu =
+    process.arch === "arm64"
+      ? "arm64"
+      : process.arch === "x64"
+        ? "x64"
+        : null;
+  if (!os || !cpu) {
+    throw new Error(
+      `unsupported host platform for bridge npm install: ${process.platform}/${process.arch}`,
+    );
+  }
+  return { os, cpu };
+}
+
+/**
+ * @param {string | null | undefined} target Rust target triple, or null for host
+ * @returns {NpmPlatform}
+ */
+function resolveNpmPlatform(target) {
+  if (target) {
+    return rustTargetToNpmPlatform(target);
+  }
+  return hostNpmPlatform();
+}
+
+/**
+ * @param {NpmPlatform} npmPlatform
+ * @returns {string}
+ */
+function npmPlatformKey(npmPlatform) {
+  return `${npmPlatform.os}-${npmPlatform.cpu}`;
+}
 
 function hashFile(filePath) {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
@@ -30,9 +104,35 @@ function bridgeFingerprint(srcDir) {
   return `${hashFile(pkg)}:${hashFile(lock)}`;
 }
 
-function npmCi(srcDir, env) {
+/**
+ * Stamp includes npm platform so cross-target builds (arm64 CI building
+ * x86_64-apple-darwin) cannot reuse a wrong-arch node_modules tree.
+ * @param {string | null} contentFingerprint
+ * @param {NpmPlatform} npmPlatform
+ * @returns {string | null}
+ */
+function bundleStamp(contentFingerprint, npmPlatform) {
+  if (!contentFingerprint) return null;
+  return `${contentFingerprint}:${npmPlatformKey(npmPlatform)}`;
+}
+
+/**
+ * @param {string} srcDir
+ * @param {NodeJS.ProcessEnv} env
+ * @param {NpmPlatform} npmPlatform
+ */
+function npmCi(srcDir, env, npmPlatform) {
   const isWindows = process.platform === "win32";
-  const result = spawnSync("npm", ["ci", "--omit=dev"], {
+  // --os / --cpu force optionalDependencies for the *bundle* target, not the
+  // runner. Without this, macos-latest (arm64) installs only darwin-arm64
+  // when packaging x86_64-apple-darwin (see #778).
+  const args = [
+    "ci",
+    "--omit=dev",
+    `--os=${npmPlatform.os}`,
+    `--cpu=${npmPlatform.cpu}`,
+  ];
+  const result = spawnSync("npm", args, {
     cwd: srcDir,
     stdio: "inherit",
     env,
@@ -82,9 +182,66 @@ function shouldRebuildBundle({ destDir, fingerprint, force }) {
 }
 
 /**
+ * @param {string} destDir
+ * @param {string | null | undefined} nativePackage
+ */
+function assertNativePackage(destDir, nativePackage) {
+  if (!nativePackage) return;
+  const dir = path.join(destDir, "node_modules", nativePackage);
+  if (!fs.existsSync(dir)) {
+    throw new Error(
+      `bridge bundle missing native package ${nativePackage} under ${destDir}`,
+    );
+  }
+}
+
+/**
+ * Parse CLI flags for the standalone entrypoint.
+ * @param {string[]} argv
+ * @returns {{ force: boolean, target: string | null }}
+ */
+function parseCliArgs(argv) {
+  let force = false;
+  let target = null;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--force") {
+      force = true;
+      continue;
+    }
+    if (arg === "--target") {
+      target = argv[++i] ?? null;
+      continue;
+    }
+    if (arg.startsWith("--target=")) {
+      target = arg.slice("--target=".length) || null;
+    }
+  }
+  return { force, target };
+}
+
+/**
+ * Extract `--target <triple>` / `--target=<triple>` from a tauri argv list.
+ * @param {string[]} argv
+ * @returns {string | null}
+ */
+function extractTargetFromArgv(argv) {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--target") {
+      return argv[i + 1] ?? null;
+    }
+    if (arg.startsWith("--target=")) {
+      return arg.slice("--target=".length) || null;
+    }
+  }
+  return null;
+}
+
+/**
  * Install cursor/claude bridge trees into apps/desktop/binaries/ for Tauri bundling.
  * @param {NodeJS.ProcessEnv} env
- * @param {{ logPrefix?: string, force?: boolean }} [opts]
+ * @param {{ logPrefix?: string, force?: boolean, target?: string | null }} [opts]
  */
 function ensureAgentBridgeBundles(env, opts) {
   const logPrefix = opts?.logPrefix ?? "[bridge-bundle]";
@@ -92,8 +249,19 @@ function ensureAgentBridgeBundles(env, opts) {
     opts?.force === true ||
     env.TEAMCLAW_FORCE_BRIDGE_BUNDLES === "1" ||
     env.TEAMCLAW_FORCE_BRIDGE_BUNDLES === "true";
+  const target =
+    opts?.target ||
+    env.TEAMCLAW_BRIDGE_TARGET ||
+    env.TARGET ||
+    null;
+  const npmPlatform = resolveNpmPlatform(target);
   const repoRoot = path.resolve(__dirname, "..");
   const destRoot = path.join(repoRoot, "apps", "desktop", "binaries");
+
+  console.log(
+    `${logPrefix} npm platform ${npmPlatformKey(npmPlatform)}` +
+      (target ? ` (target ${target})` : " (host)"),
+  );
 
   for (const bridge of BRIDGES) {
     const srcDir = path.join(repoRoot, bridge.src);
@@ -102,14 +270,20 @@ function ensureAgentBridgeBundles(env, opts) {
       console.warn(`${logPrefix} skip ${bridge.name}: missing ${srcDir}`);
       continue;
     }
-    const fingerprint = bridgeFingerprint(srcDir);
+    const contentFingerprint = bridgeFingerprint(srcDir);
+    const fingerprint = bundleStamp(contentFingerprint, npmPlatform);
     if (!shouldRebuildBundle({ destDir, fingerprint, force })) {
       continue;
     }
     console.log(`${logPrefix} preparing ${bridge.name} bundle...`);
-    npmCi(srcDir, env);
+    npmCi(srcDir, env, npmPlatform);
     pruneBridgeNodeModules(srcDir);
     copyBridgeTree(srcDir, destDir);
+    const nativePackage =
+      typeof bridge.nativePackage === "function"
+        ? bridge.nativePackage(npmPlatform)
+        : null;
+    assertNativePackage(destDir, nativePackage);
     if (fingerprint) {
       writeStamp(destDir, fingerprint);
     }
@@ -120,13 +294,22 @@ function ensureAgentBridgeBundles(env, opts) {
 module.exports = {
   BRIDGES,
   bridgeFingerprint,
+  bundleStamp,
   ensureAgentBridgeBundles,
+  extractTargetFromArgv,
+  hostNpmPlatform,
+  npmPlatformKey,
+  parseCliArgs,
+  resolveNpmPlatform,
+  rustTargetToNpmPlatform,
   shouldRebuildBundle,
 };
 
 if (require.main === module) {
+  const { force, target } = parseCliArgs(process.argv.slice(2));
   ensureAgentBridgeBundles(process.env, {
     logPrefix: "[ensure-agent-bridge-bundles]",
-    force: process.argv.includes("--force"),
+    force,
+    target,
   });
 }

--- a/scripts/lib/ensure-agent-bridge-bundles.test.js
+++ b/scripts/lib/ensure-agent-bridge-bundles.test.js
@@ -6,6 +6,11 @@ const { test } = require("node:test");
 
 const {
   bridgeFingerprint,
+  bundleStamp,
+  extractTargetFromArgv,
+  parseCliArgs,
+  resolveNpmPlatform,
+  rustTargetToNpmPlatform,
   shouldRebuildBundle,
 } = require("../ensure-agent-bridge-bundles");
 
@@ -45,4 +50,58 @@ test("bridgeFingerprint tracks package + lock", () => {
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("rustTargetToNpmPlatform maps release matrix triples", () => {
+  assert.deepEqual(rustTargetToNpmPlatform("aarch64-apple-darwin"), {
+    os: "darwin",
+    cpu: "arm64",
+  });
+  assert.deepEqual(rustTargetToNpmPlatform("x86_64-apple-darwin"), {
+    os: "darwin",
+    cpu: "x64",
+  });
+  assert.deepEqual(rustTargetToNpmPlatform("x86_64-pc-windows-msvc"), {
+    os: "win32",
+    cpu: "x64",
+  });
+  assert.throws(() => rustTargetToNpmPlatform("wasm32-unknown-unknown"), /unsupported/);
+});
+
+test("bundleStamp includes npm platform so cross-target rebuilds", () => {
+  const arm = bundleStamp("abc", { os: "darwin", cpu: "arm64" });
+  const x64 = bundleStamp("abc", { os: "darwin", cpu: "x64" });
+  assert.equal(arm, "abc:darwin-arm64");
+  assert.equal(x64, "abc:darwin-x64");
+  assert.notEqual(arm, x64);
+});
+
+test("resolveNpmPlatform uses host when target omitted", () => {
+  const host = resolveNpmPlatform(null);
+  assert.ok(host.os);
+  assert.ok(host.cpu);
+  assert.deepEqual(resolveNpmPlatform("x86_64-apple-darwin"), {
+    os: "darwin",
+    cpu: "x64",
+  });
+});
+
+test("parseCliArgs and extractTargetFromArgv", () => {
+  assert.deepEqual(parseCliArgs(["--force", "--target", "x86_64-apple-darwin"]), {
+    force: true,
+    target: "x86_64-apple-darwin",
+  });
+  assert.deepEqual(parseCliArgs(["--target=aarch64-apple-darwin"]), {
+    force: false,
+    target: "aarch64-apple-darwin",
+  });
+  assert.equal(
+    extractTargetFromArgv(["build", "--target", "x86_64-apple-darwin"]),
+    "x86_64-apple-darwin",
+  );
+  assert.equal(
+    extractTargetFromArgv(["build", "--target=aarch64-apple-darwin", "--debug"]),
+    "aarch64-apple-darwin",
+  );
+  assert.equal(extractTargetFromArgv(["dev"]), null);
 });

--- a/scripts/tauri-cli.js
+++ b/scripts/tauri-cli.js
@@ -6,12 +6,16 @@ const path = require("path");
 const { createRustBuildEnv } = require("./rust-build-env");
 const { ensureTeamclawIntrospectSidecar } = require("./ensure-introspect-sidecar");
 const { ensureAmuxdSidecar } = require("./ensure-amuxd-sidecar");
-const { ensureAgentBridgeBundles } = require("./ensure-agent-bridge-bundles");
+const {
+  ensureAgentBridgeBundles,
+  extractTargetFromArgv,
+} = require("./ensure-agent-bridge-bundles");
 const { platform } = process;
 
 let args = process.argv.slice(2);
 const isWindows = platform === "win32";
 const sub = args[0];
+const bridgeTarget = extractTargetFromArgv(args);
 
 /**
  * Strip desktop-dev-only flags and expose them via env before sidecars / tauri run.
@@ -106,7 +110,10 @@ const env = createRustBuildEnv(process.env, __dirname);
 args = applyDevSkipFlags(args, env);
 ensureTeamclawIntrospectSidecar(env, { logPrefix: "[tauri-cli]" });
 ensureAmuxdSidecar(env, { logPrefix: "[tauri-cli]" });
-ensureAgentBridgeBundles(env, { logPrefix: "[tauri-cli]" });
+ensureAgentBridgeBundles(env, {
+  logPrefix: "[tauri-cli]",
+  target: bridgeTarget,
+});
 
 const desktopDir = path.resolve(__dirname, "..", "apps", "desktop");
 const child = spawn("pnpm", ["exec", "tauri", ...args], {


### PR DESCRIPTION
## Summary
- Fixes #778: macOS Intel DMGs no longer ship only the arm64 `@cursor/sdk` native binary.
- `ensure-agent-bridge-bundles` now takes a Rust `--target`, runs `npm ci --os/--cpu` for that arch, and stamps the platform into the bundle fingerprint.
- Release CI asserts `@cursor/sdk-darwin-arm64` / `darwin-x64` / `win32-x64` (and fills in the missing Windows bridge step on `release.yml`).

## Test plan
- [x] `node --test scripts/lib/ensure-agent-bridge-bundles.test.js`
- [x] Manual: `npm ci --omit=dev --os=darwin --cpu=x64` on arm64 installs `@cursor/sdk-darwin-x64` only
- [ ] Trigger / inspect a dual-arch macOS release build and confirm each artifact has the matching `@cursor/sdk-darwin-*` package
- [ ] Confirm Windows release job bundles `@cursor/sdk-win32-x64`


Made with [Cursor](https://cursor.com)