### PR TITLE
Add SeaTalk Open Platform channel for @bot Q&A

### DIFF
--- a/apps/daemon/src/channels/manager.rs
+++ b/apps/daemon/src/channels/manager.rs
@@ -13,13 +13,14 @@ use tokio::sync::Mutex;
 use teamclaw_gateway::{
     AgentHandle, ChannelStore, DiscordConfig, DiscordGateway, EmailConfig, EmailGateway,
     EmailGatewayStatus, EmailProvider, FeishuConfig, FeishuGateway, FeishuGatewayStatus,
-    GatewayStatus, KookConfig, KookDmConfig, KookGateway, KookGatewayStatus, WeChatConfig,
-    WeChatGateway, WeChatGatewayStatus, WeComConfig, WeComGateway, WeComGatewayStatus,
+    GatewayStatus, KookConfig, KookDmConfig, KookGateway, KookGatewayStatus, SeaTalkConfig,
+    SeaTalkGateway, SeaTalkGatewayStatus, WeChatConfig, WeChatGateway, WeChatGatewayStatus,
+    WeComConfig, WeComGateway, WeComGatewayStatus,
 };
 
 use crate::config::{
-    DaemonConfig, DiscordChannel, EmailChannel, FeishuChannel, KookChannel, WeChatChannel,
-    WeComChannel,
+    DaemonConfig, DiscordChannel, EmailChannel, FeishuChannel, KookChannel, SeaTalkChannel,
+    WeChatChannel, WeComChannel,
 };
 
 #[derive(Default)]
@@ -30,6 +31,7 @@ struct RunningChannels {
     kook: Option<KookGateway>,
     wechat: Option<WeChatGateway>,
     email: Option<EmailGateway>,
+    seatalk: Option<SeaTalkGateway>,
 }
 
 pub struct ChannelManager {
@@ -149,6 +151,18 @@ impl ChannelManager {
             }
         }
 
+        if let Some(c) = &self.cfg.channels.seatalk {
+            if c.enabled {
+                match self.start_seatalk(c).await {
+                    Ok(g) => {
+                        println!("[ChannelManager] seatalk started");
+                        running.seatalk = Some(g);
+                    }
+                    Err(e) => eprintln!("[ChannelManager] seatalk start failed: {e}"),
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -211,7 +225,7 @@ impl ChannelManager {
                 };
                 result.map_err(|e| anyhow::anyhow!("wecom send: {e}"))
             }
-            "feishu" | "discord" | "kook" | "wechat" | "email" => {
+            "feishu" | "discord" | "kook" | "wechat" | "email" | "seatalk" => {
                 anyhow::bail!("{channel}: send not yet implemented in v2; only WeCom is wired")
             }
             other => anyhow::bail!("unknown channel: {other}"),
@@ -287,6 +301,16 @@ impl ChannelManager {
             }
             None => (false, None),
         };
+        let seatalk = match running.seatalk.as_ref() {
+            Some(g) => {
+                let status = g.get_status().await;
+                (
+                    status.status == SeaTalkGatewayStatus::Connected,
+                    status.error_message,
+                )
+            }
+            None => (false, None),
+        };
 
         vec![
             ("discord", discord.0, discord.1),
@@ -295,6 +319,7 @@ impl ChannelManager {
             ("kook", kook.0, kook.1),
             ("wechat", wechat.0, wechat.1),
             ("email", email.0, email.1),
+            ("seatalk", seatalk.0, seatalk.1),
         ]
     }
 
@@ -333,6 +358,9 @@ impl ChannelManager {
             g.shutdown().await;
         }
         if let Some(g) = running.email.take() {
+            g.shutdown().await;
+        }
+        if let Some(g) = running.seatalk.take() {
             g.shutdown().await;
         }
     }
@@ -494,6 +522,43 @@ impl ChannelManager {
             ..Default::default()
         };
         gw.set_workspace_path(&self.workspace_path).await;
+        gw.set_config(cfg).await;
+        gw.start().await.map_err(|e| anyhow::anyhow!(e))?;
+        Ok(gw)
+    }
+
+    async fn start_seatalk(&self, c: &SeaTalkChannel) -> anyhow::Result<SeaTalkGateway> {
+        let gw = SeaTalkGateway::new(
+            self.acp.clone(),
+            self.store.clone(),
+            self.team_id.clone(),
+            self.primary_agent_actor_id.clone(),
+            self.agent_owner_actor_ids.clone(),
+            self.workspace_path.clone(),
+        );
+        let cfg = SeaTalkConfig {
+            enabled: true,
+            app_id: c.app_id.clone(),
+            app_secret: c.app_secret.clone(),
+            mode: if c.mode.is_empty() {
+                "websocket".to_string()
+            } else {
+                c.mode.clone()
+            },
+            dm_policy: if c.dm_policy.is_empty() {
+                "open".to_string()
+            } else {
+                c.dm_policy.clone()
+            },
+            allow_from: c.allow_from.clone(),
+            group_policy: if c.group_policy.is_empty() {
+                "open".to_string()
+            } else {
+                c.group_policy.clone()
+            },
+            group_allow_from: c.group_allow_from.clone(),
+            ..Default::default()
+        };
         gw.set_config(cfg).await;
         gw.start().await.map_err(|e| anyhow::anyhow!(e))?;
         Ok(gw)

--- a/apps/daemon/src/cli/channel.rs
+++ b/apps/daemon/src/cli/channel.rs
@@ -58,11 +58,16 @@ fn list(cfg: &DaemonConfig) {
         "email",
         cfg.channels.email.as_ref().is_some_and(|c| c.enabled),
     );
+    line(
+        "seatalk",
+        cfg.channels.seatalk.as_ref().is_some_and(|c| c.enabled),
+    );
 }
 
 fn bind(cfg: &mut DaemonConfig, b: ChannelBindArgs) -> anyhow::Result<()> {
     use crate::config::{
-        DiscordChannel, EmailChannel, FeishuChannel, KookChannel, WeChatChannel, WeComChannel,
+        DiscordChannel, EmailChannel, FeishuChannel, KookChannel, SeaTalkChannel, WeChatChannel,
+        WeComChannel,
     };
     match b.platform {
         ChannelBindPlatform::Discord {
@@ -134,6 +139,18 @@ fn bind(cfg: &mut DaemonConfig, b: ChannelBindArgs) -> anyhow::Result<()> {
                 allowed_senders: vec![],
             });
         }
+        ChannelBindPlatform::Seatalk { app_id, app_secret } => {
+            cfg.channels.seatalk = Some(SeaTalkChannel {
+                enabled: true,
+                app_id,
+                app_secret,
+                mode: "websocket".to_string(),
+                dm_policy: "open".to_string(),
+                allow_from: vec![],
+                group_policy: "open".to_string(),
+                group_allow_from: vec![],
+            });
+        }
     }
     Ok(())
 }
@@ -158,6 +175,9 @@ fn unbind(cfg: &mut DaemonConfig, platform: &str) -> anyhow::Result<()> {
         "email" => {
             cfg.channels.email = None;
         }
+        "seatalk" => {
+            cfg.channels.seatalk = None;
+        }
         other => anyhow::bail!("unknown platform: {other}"),
     }
     Ok(())
@@ -171,6 +191,7 @@ fn test_channel(cfg: &DaemonConfig, platform: &str) -> anyhow::Result<()> {
         "kook" => cfg.channels.kook.is_some(),
         "wechat" => cfg.channels.wechat.is_some(),
         "email" => cfg.channels.email.is_some(),
+        "seatalk" => cfg.channels.seatalk.is_some(),
         other => anyhow::bail!("unknown platform: {other}"),
     };
     println!(

--- a/apps/daemon/src/cli/mod.rs
+++ b/apps/daemon/src/cli/mod.rs
@@ -333,6 +333,13 @@ pub enum ChannelBindPlatform {
         #[arg(long)]
         smtp_pass: String,
     },
+    /// Bind a SeaTalk Open Platform bot.
+    Seatalk {
+        #[arg(long)]
+        app_id: String,
+        #[arg(long)]
+        app_secret: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/apps/daemon/src/config/daemon_config.rs
+++ b/apps/daemon/src/config/daemon_config.rs
@@ -352,6 +352,8 @@ pub struct ChannelsConfig {
     pub wechat: Option<WeChatChannel>,
     #[serde(default)]
     pub email: Option<EmailChannel>,
+    #[serde(default)]
+    pub seatalk: Option<SeaTalkChannel>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -440,6 +442,38 @@ pub struct WeChatChannel {
     pub enabled: bool,
     pub ilink_account: String,
     pub ilink_token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SeaTalkChannel {
+    pub enabled: bool,
+    pub app_id: String,
+    pub app_secret: String,
+    /// `websocket` (default) or `webhook`
+    #[serde(default = "default_seatalk_mode")]
+    pub mode: String,
+    /// `open` | `allowlist`
+    #[serde(default = "default_seatalk_dm_policy")]
+    pub dm_policy: String,
+    #[serde(default)]
+    pub allow_from: Vec<String>,
+    /// `disabled` | `allowlist` | `open`
+    #[serde(default = "default_seatalk_group_policy")]
+    pub group_policy: String,
+    #[serde(default)]
+    pub group_allow_from: Vec<String>,
+}
+
+fn default_seatalk_mode() -> String {
+    "websocket".to_string()
+}
+
+fn default_seatalk_dm_policy() -> String {
+    "open".to_string()
+}
+
+fn default_seatalk_group_policy() -> String {
+    "open".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -17,7 +17,7 @@ mod workspace_resolver;
 pub use daemon_config::{
     ActorConfig, AgentBackendConfig, AgentsConfig, ClaudeAgentConfig, CursorAgentConfig,
     DaemonConfig, DiscordChannel, EmailChannel, FeishuChannel, HttpConfig, KookChannel, MqttConfig,
-    TeamShareConfig, TransportKind, WeChatChannel, WeComChannel, BOOTSTRAP_ACTOR_NAME,
+    SeaTalkChannel, TeamShareConfig, TransportKind, WeChatChannel, WeComChannel, BOOTSTRAP_ACTOR_NAME,
 };
 // Constructed only by the test suite (runtime_resolution / server tests).
 #[cfg(test)]

--- a/apps/daemon/src/daemon/server/channels.rs
+++ b/apps/daemon/src/daemon/server/channels.rs
@@ -235,6 +235,7 @@ impl DaemonServer {
                 "kook" => cfg.kook.as_ref().map(|c| c.enabled).unwrap_or(false),
                 "wechat" => cfg.wechat.as_ref().map(|c| c.enabled).unwrap_or(false),
                 "email" => cfg.email.as_ref().map(|c| c.enabled).unwrap_or(false),
+                "seatalk" => cfg.seatalk.as_ref().map(|c| c.enabled).unwrap_or(false),
                 _ => false,
             }
         };
@@ -248,6 +249,7 @@ impl DaemonServer {
                 ("kook", false, None),
                 ("wechat", false, None),
                 ("email", false, None),
+                ("seatalk", false, None),
             ],
         };
 
@@ -391,6 +393,11 @@ impl DaemonServer {
                     let v: crate::config::EmailChannel = serde_json::from_str(config_json)
                         .map_err(|e| format!("parse email: {e}"))?;
                     self.config.channels.email = Some(v);
+                }
+                "seatalk" => {
+                    let v: crate::config::SeaTalkChannel = serde_json::from_str(config_json)
+                        .map_err(|e| format!("parse seatalk: {e}"))?;
+                    self.config.channels.seatalk = Some(v);
                 }
                 other => {
                     return Err(format!("unknown platform '{other}'"));

--- a/apps/desktop/src/commands/gateway/mod.rs
+++ b/apps/desktop/src/commands/gateway/mod.rs
@@ -136,7 +136,7 @@ pub async fn list_wecom_bots_status() -> Result<Vec<WeComBotStatus>, String> {
 pub fn load_channel_config(platform: String) -> Result<Option<serde_json::Value>, String> {
     if !matches!(
         platform.as_str(),
-        "discord" | "wecom" | "feishu" | "kook" | "wechat" | "email"
+        "discord" | "wecom" | "feishu" | "kook" | "wechat" | "email" | "seatalk"
     ) {
         return Err(format!("unknown platform: {platform}"));
     }
@@ -198,6 +198,16 @@ pub async fn reload_channels() -> Result<(), String> {
             .map_err(|e| format!("write failed: {e}"))?;
         Ok(())
     }
+}
+
+/// Probe SeaTalk App ID / App Secret against the Open Platform token API.
+/// Does not require amuxd — useful before saving/starting the gateway.
+#[tauri::command]
+pub async fn test_seatalk_credentials(
+    app_id: String,
+    app_secret: String,
+) -> Result<String, String> {
+    SeaTalkGateway::test_credentials(&app_id, &app_secret).await
 }
 
 /// Persist a per-session model preference for gateway-backed chats.

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -410,6 +410,7 @@ pub fn run() {
             commands::gateway::load_channel_config,
             commands::gateway::save_channel_config,
             commands::gateway::reload_channels,
+            commands::gateway::test_seatalk_credentials,
             commands::gateway::qr::start_wechat_qr_login,
             commands::gateway::qr::poll_wechat_qr_status,
             commands::gateway::qr::start_wecom_qr_auth,

--- a/build.config.dev.json
+++ b/build.config.dev.json
@@ -17,7 +17,8 @@
       "email": true,
       "kook": true,
       "wecom": true,
-      "wechat": true
+      "wechat": true,
+      "seatalk": true
     },
     "auth": {
       "google": true,

--- a/build.config.example.json
+++ b/build.config.example.json
@@ -26,7 +26,8 @@
       "email": true,
       "kook": true,
       "wecom": true,
-      "wechat": true
+      "wechat": true,
+      "seatalk": true
     },
     "auth": {
       "google": false,

--- a/build.config.production.json
+++ b/build.config.production.json
@@ -16,7 +16,8 @@
       "email": true,
       "kook": true,
       "wecom": true,
-      "wechat": true
+      "wechat": true,
+      "seatalk": true
     },
     "auth": {
       "google": true

--- a/crates/teamclaw-gateway/src/binding.rs
+++ b/crates/teamclaw-gateway/src/binding.rs
@@ -34,6 +34,18 @@ pub fn wechat_dm(ilink_account: &str, from_user_id: &str) -> String {
 pub fn email_thread(account_key: &str, thread_key: &str) -> String {
     format!("email://{account_key}/thread/{thread_key}")
 }
+pub fn seatalk_group(app_id: &str, group_id: &str) -> String {
+    format!("seatalk://{app_id}/group/{group_id}")
+}
+pub fn seatalk_group_thread(app_id: &str, group_id: &str, thread_id: &str) -> String {
+    format!("seatalk://{app_id}/group/{group_id}/thread/{thread_id}")
+}
+pub fn seatalk_dm(app_id: &str, employee_code: &str) -> String {
+    format!("seatalk://{app_id}/single/{employee_code}")
+}
+pub fn seatalk_dm_thread(app_id: &str, employee_code: &str, thread_id: &str) -> String {
+    format!("seatalk://{app_id}/single/{employee_code}/thread/{thread_id}")
+}
 
 pub fn urn_wecom_user(corp_id: &str, userid: &str) -> String {
     format!("wecom-user:{corp_id}:{userid}")
@@ -55,6 +67,9 @@ pub fn urn_wechat_user(ilink_account: &str, from_user_id: &str) -> String {
 }
 pub fn urn_email_user(addr: &str) -> String {
     format!("email-user:{}", addr.to_lowercase())
+}
+pub fn urn_seatalk_user(app_id: &str, employee_code: &str) -> String {
+    format!("seatalk-user:{app_id}:{employee_code}")
 }
 
 #[cfg(test)]

--- a/crates/teamclaw-gateway/src/config.rs
+++ b/crates/teamclaw-gateway/src/config.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::email_config::EmailConfig;
 use crate::feishu_config::FeishuConfig;
 use crate::kook_config::KookConfig;
+use crate::seatalk_config::SeaTalkConfig;
 use crate::wechat_config::WeChatConfig;
 use crate::wecom_config::WeComConfig;
 
@@ -16,6 +17,7 @@ pub struct ChannelsConfig {
     pub kook: Option<KookConfig>,
     pub wechat: Option<WeChatConfig>,
     pub wecom: Option<WeComConfig>,
+    pub seatalk: Option<SeaTalkConfig>,
 }
 
 /// Discord channel configuration (mirrors OpenClaw structure)

--- a/crates/teamclaw-gateway/src/lib.rs
+++ b/crates/teamclaw-gateway/src/lib.rs
@@ -22,6 +22,8 @@ pub mod i18n;
 pub mod kook;
 pub mod kook_config;
 pub mod pending_question;
+pub mod seatalk;
+pub mod seatalk_config;
 pub mod session;
 pub mod session_queue;
 pub mod wechat;
@@ -42,6 +44,8 @@ pub use pending_question::{
     extract_question_marker, format_question_message, handle_question_event, parse_question_event,
     ForwardedQuestion, PendingQuestionStore, QuestionContext,
 };
+pub use seatalk::SeaTalkGateway;
+pub use seatalk_config::*;
 pub use session::SessionMapping;
 pub use wechat::WeChatGateway;
 pub use wechat_config::*;

--- a/crates/teamclaw-gateway/src/seatalk.rs
+++ b/crates/teamclaw-gateway/src/seatalk.rs
@@ -1,0 +1,1130 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use serde_json::json;
+use tokio::sync::{oneshot, RwLock};
+use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
+
+use crate::seatalk_config::{SeaTalkConfig, SeaTalkGatewayStatus, SeaTalkGatewayStatusResponse};
+use crate::{
+    AgentHandle, ChannelStore, FilterResult, ProcessedMessageTracker, MAX_PROCESSED_MESSAGES,
+};
+
+const SEATALK_API_BASE: &str = "https://openapi.seatalk.io";
+const SEATALK_WS_URL: &str = "wss://ws-openapi.haiserve.com/ws/bot";
+const TOKEN_REFRESH_MARGIN_SECS: u64 = 600;
+const TEXT_CHUNK_LIMIT: usize = 4000;
+const INITIAL_BACKOFF_MS: u64 = 1_000;
+const MAX_BACKOFF_MS: u64 = 30_000;
+const DEFAULT_PING_INTERVAL_MS: u64 = 15_000;
+const STALE_TIMEOUT_MS: u64 = 75_000;
+
+#[derive(Debug, Clone)]
+struct SeaTalkTokenInfo {
+    token: String,
+    expire_at: u64,
+}
+
+struct SeaTalkClient {
+    app_id: String,
+    app_secret: String,
+    http: reqwest::Client,
+    token: RwLock<Option<SeaTalkTokenInfo>>,
+}
+
+impl SeaTalkClient {
+    fn new(app_id: String, app_secret: String) -> Self {
+        Self {
+            app_id,
+            app_secret,
+            http: crate::http_client_secs(10),
+            token: RwLock::new(None),
+        }
+    }
+
+    async fn get_access_token(&self) -> Result<String, String> {
+        {
+            let guard = self.token.read().await;
+            if let Some(info) = guard.as_ref() {
+                let now = chrono::Utc::now().timestamp() as u64;
+                if info.expire_at.saturating_sub(now) > TOKEN_REFRESH_MARGIN_SECS {
+                    return Ok(info.token.clone());
+                }
+            }
+        }
+        self.refresh_token().await.map(|t| t.token)
+    }
+
+    async fn refresh_token(&self) -> Result<SeaTalkTokenInfo, String> {
+        let resp = self
+            .http
+            .post(format!("{SEATALK_API_BASE}/auth/app_access_token"))
+            .json(&json!({
+                "app_id": self.app_id,
+                "app_secret": self.app_secret,
+            }))
+            .send()
+            .await
+            .map_err(|e| format!("token request failed: {e}"))?;
+
+        let data: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("token parse failed: {e}"))?;
+
+        let code = data["code"].as_i64().unwrap_or(-1);
+        if code != 0 {
+            return Err(format!(
+                "SeaTalk token error: code={code} message={}",
+                data["message"].as_str().unwrap_or("unknown")
+            ));
+        }
+
+        let token = data["app_access_token"]
+            .as_str()
+            .ok_or_else(|| "token response missing app_access_token".to_string())?
+            .to_string();
+        let expire_at = data["expire"]
+            .as_u64()
+            .ok_or_else(|| "token response missing expire".to_string())?;
+
+        let info = SeaTalkTokenInfo { token, expire_at };
+        *self.token.write().await = Some(info.clone());
+        Ok(info)
+    }
+
+    async fn api_call(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        retry: bool,
+    ) -> Result<serde_json::Value, String> {
+        let token = self.get_access_token().await?;
+        let url = format!("{SEATALK_API_BASE}{path}");
+        let mut req = self
+            .http
+            .request(method.clone(), &url)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json");
+        if let Some(ref b) = body {
+            req = req.json(b);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("SeaTalk API request failed: {e}"))?;
+        let data: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("SeaTalk API parse failed: {e}"))?;
+
+        let code = data["code"].as_i64().unwrap_or(-1);
+        if code == 100 && retry {
+            self.refresh_token().await?;
+            return Box::pin(self.api_call(method, path, body.clone(), false)).await;
+        }
+        if code != 0 {
+            return Err(format!(
+                "SeaTalk API error: code={code} message={}",
+                data["message"].as_str().unwrap_or("unknown")
+            ));
+        }
+        Ok(data)
+    }
+
+    async fn send_group_text(
+        &self,
+        group_id: &str,
+        text: &str,
+        thread_id: Option<&str>,
+    ) -> Result<(), String> {
+        for chunk in chunk_text(text, TEXT_CHUNK_LIMIT) {
+            let mut message = json!({
+                "tag": "text",
+                "text": { "format": 1, "content": chunk }
+            });
+            if let Some(tid) = thread_id {
+                message["thread_id"] = json!(tid);
+            }
+            self.api_call(
+                reqwest::Method::POST,
+                "/messaging/v2/group_chat",
+                Some(json!({
+                    "group_id": group_id,
+                    "message": message,
+                })),
+                true,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn send_single_text(
+        &self,
+        employee_code: &str,
+        text: &str,
+        thread_id: Option<&str>,
+    ) -> Result<(), String> {
+        for chunk in chunk_text(text, TEXT_CHUNK_LIMIT) {
+            let mut message = json!({
+                "tag": "text",
+                "text": { "format": 1, "content": chunk }
+            });
+            if let Some(tid) = thread_id {
+                message["thread_id"] = json!(tid);
+            }
+            self.api_call(
+                reqwest::Method::POST,
+                "/messaging/v2/single_chat",
+                Some(json!({
+                    "employee_code": employee_code,
+                    "message": message,
+                })),
+                true,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn set_group_typing(&self, group_id: &str, thread_id: Option<&str>) -> Result<(), String> {
+        let mut body = json!({ "group_id": group_id });
+        if let Some(tid) = thread_id {
+            body["thread_id"] = json!(tid);
+        }
+        let _ = self
+            .api_call(
+                reqwest::Method::POST,
+                "/messaging/v2/group_chat_typing",
+                Some(body),
+                true,
+            )
+            .await;
+        Ok(())
+    }
+
+    async fn set_single_typing(
+        &self,
+        employee_code: &str,
+        thread_id: Option<&str>,
+    ) -> Result<(), String> {
+        let mut body = json!({ "employee_code": employee_code });
+        if let Some(tid) = thread_id {
+            body["thread_id"] = json!(tid);
+        }
+        let _ = self
+            .api_call(
+                reqwest::Method::POST,
+                "/messaging/v2/single_chat_typing",
+                Some(body),
+                true,
+            )
+            .await;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct WsEnvelope {
+    cmd: String,
+    header: Option<serde_json::Value>,
+    data: Option<serde_json::Value>,
+    code: Option<i64>,
+    message: Option<String>,
+}
+
+#[derive(Clone)]
+struct HandlerContext {
+    app_id: String,
+    config: Arc<RwLock<SeaTalkConfig>>,
+    agent: Arc<dyn AgentHandle>,
+    store: Arc<dyn ChannelStore>,
+    team_id: String,
+    primary_agent_actor_id: String,
+    agent_owner_actor_ids: Vec<String>,
+    #[allow(dead_code)]
+    workspace_path: String,
+    client: Arc<SeaTalkClient>,
+    processed_events: Arc<RwLock<ProcessedMessageTracker>>,
+}
+
+pub struct SeaTalkGateway {
+    config: Arc<RwLock<SeaTalkConfig>>,
+    pub agent: Arc<dyn AgentHandle>,
+    pub store: Arc<dyn ChannelStore>,
+    pub team_id: String,
+    pub primary_agent_actor_id: String,
+    pub agent_owner_actor_ids: Vec<String>,
+    workspace_path: String,
+    shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
+    status: Arc<RwLock<SeaTalkGatewayStatusResponse>>,
+    is_running: Arc<RwLock<bool>>,
+    processed_events: Arc<RwLock<ProcessedMessageTracker>>,
+}
+
+impl SeaTalkGateway {
+    pub fn new(
+        agent: Arc<dyn AgentHandle>,
+        store: Arc<dyn ChannelStore>,
+        team_id: String,
+        primary_agent_actor_id: String,
+        agent_owner_actor_ids: Vec<String>,
+        workspace_path: String,
+    ) -> Self {
+        Self {
+            config: Arc::new(RwLock::new(SeaTalkConfig::default())),
+            agent,
+            store,
+            team_id,
+            primary_agent_actor_id,
+            agent_owner_actor_ids,
+            workspace_path,
+            shutdown_tx: Arc::new(RwLock::new(None)),
+            status: Arc::new(RwLock::new(SeaTalkGatewayStatusResponse::default())),
+            is_running: Arc::new(RwLock::new(false)),
+            processed_events: Arc::new(RwLock::new(ProcessedMessageTracker::new(
+                MAX_PROCESSED_MESSAGES,
+            ))),
+        }
+    }
+
+    pub async fn set_config(&self, config: SeaTalkConfig) {
+        *self.config.write().await = config;
+    }
+
+    pub async fn get_status(&self) -> SeaTalkGatewayStatusResponse {
+        self.status.read().await.clone()
+    }
+
+    /// Probe SeaTalk Open Platform credentials by requesting an app access token.
+    pub async fn test_credentials(app_id: &str, app_secret: &str) -> Result<String, String> {
+        if app_id.trim().is_empty() || app_secret.trim().is_empty() {
+            return Err("App ID and App Secret are required".to_string());
+        }
+        let client = SeaTalkClient::new(app_id.trim().to_string(), app_secret.trim().to_string());
+        let _token = client.refresh_token().await?;
+        Ok("Credentials valid".to_string())
+    }
+
+    pub async fn start(&self) -> Result<(), String> {
+        {
+            let running = self.is_running.read().await;
+            if *running {
+                return Err("SeaTalk gateway is already running".to_string());
+            }
+        }
+
+        let config = self.config.read().await.clone();
+        if config.app_id.is_empty() || config.app_secret.is_empty() {
+            return Err("SeaTalk app_id and app_secret are required".to_string());
+        }
+
+        {
+            let mut status = self.status.write().await;
+            status.status = SeaTalkGatewayStatus::Connecting;
+            status.error_message = None;
+            status.app_id = Some(config.app_id.clone());
+        }
+
+        *self.is_running.write().await = true;
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        *self.shutdown_tx.write().await = Some(shutdown_tx);
+
+        let gateway = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = gateway.run_gateway_loop(shutdown_rx).await {
+                eprintln!("[SeaTalk] Gateway error: {e}");
+                let mut status = gateway.status.write().await;
+                status.status = SeaTalkGatewayStatus::Error;
+                status.error_message = Some(e);
+            }
+            *gateway.is_running.write().await = false;
+        });
+
+        Ok(())
+    }
+
+    pub async fn shutdown(self) {
+        if let Some(tx) = self.shutdown_tx.write().await.take() {
+            let _ = tx.send(());
+        }
+        let mut status = self.status.write().await;
+        status.status = SeaTalkGatewayStatus::Disconnected;
+    }
+
+    async fn run_gateway_loop(&self, mut shutdown_rx: oneshot::Receiver<()>) -> Result<(), String> {
+        let config = self.config.read().await.clone();
+        let client = Arc::new(SeaTalkClient::new(
+            config.app_id.clone(),
+            config.app_secret.clone(),
+        ));
+
+        let ctx = HandlerContext {
+            app_id: config.app_id.clone(),
+            config: Arc::clone(&self.config),
+            agent: Arc::clone(&self.agent),
+            store: Arc::clone(&self.store),
+            team_id: self.team_id.clone(),
+            primary_agent_actor_id: self.primary_agent_actor_id.clone(),
+            agent_owner_actor_ids: self.agent_owner_actor_ids.clone(),
+            workspace_path: self.workspace_path.clone(),
+            client,
+            processed_events: Arc::clone(&self.processed_events),
+        };
+
+        let mode = config.mode.clone();
+        if mode == "webhook" {
+            return self.run_webhook_server(ctx, shutdown_rx).await;
+        }
+
+        let mut backoff = INITIAL_BACKOFF_MS;
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => {
+                    println!("[SeaTalk] Gateway shutting down");
+                    return Ok(());
+                }
+                result = self.connect_websocket(&ctx) => {
+                    match result {
+                        Ok(()) => {
+                            backoff = INITIAL_BACKOFF_MS;
+                        }
+                        Err(e) => {
+                            eprintln!("[SeaTalk] WebSocket disconnected: {e}");
+                            let mut status = self.status.write().await;
+                            status.status = SeaTalkGatewayStatus::Connecting;
+                            status.error_message = Some(e);
+                        }
+                    }
+                }
+            }
+
+            tokio::select! {
+                _ = &mut shutdown_rx => return Ok(()),
+                _ = tokio::time::sleep(Duration::from_millis(backoff)) => {}
+            }
+            backoff = (backoff * 2).min(MAX_BACKOFF_MS);
+        }
+    }
+
+    async fn connect_websocket(&self, ctx: &HandlerContext) -> Result<(), String> {
+        let (ws_stream, _) = connect_async(SEATALK_WS_URL)
+            .await
+            .map_err(|e| format!("WebSocket connect failed: {e}"))?;
+        let (mut write, mut read) = ws_stream.split();
+
+        let cfg = ctx.config.read().await.clone();
+        let register = json!({
+            "cmd": "register",
+            "header": {
+                "rid": uuid::Uuid::new_v4().to_string(),
+                "app_id": cfg.app_id,
+                "app_secret": cfg.app_secret,
+            }
+        });
+        write
+            .send(WsMessage::Text(register.to_string().into()))
+            .await
+            .map_err(|e| format!("register send failed: {e}"))?;
+
+        let mut token = String::new();
+        let mut registered = false;
+        let mut ping_ms = DEFAULT_PING_INTERVAL_MS;
+        let mut stale_ms = STALE_TIMEOUT_MS;
+        let mut last_activity = Instant::now();
+
+        loop {
+            if last_activity.elapsed() > Duration::from_millis(stale_ms) {
+                return Err("WebSocket stale timeout".to_string());
+            }
+
+            tokio::select! {
+                msg = read.next() => {
+                    let Some(msg) = msg else {
+                        return Err("WebSocket closed".to_string());
+                    };
+                    last_activity = Instant::now();
+                    let msg = msg.map_err(|e| format!("WebSocket read error: {e}"))?;
+                    if !msg.is_text() {
+                        continue;
+                    }
+                    let env: WsEnvelope = serde_json::from_str(msg.to_text().unwrap_or(""))
+                        .map_err(|e| format!("invalid ws json: {e}"))?;
+
+                    if !registered {
+                        if env.cmd != "register" {
+                            if env.cmd == "kick" {
+                                return Err(format!("connection kicked: {}", env.message.unwrap_or_default()));
+                            }
+                            // SeaTalk may send non-register frames before the
+                            // register ack; ignore them (official SDK treats
+                            // unexpected frames more strictly, but "ok" replies
+                            // without a code field are common enough that we
+                            // keep waiting for the register response).
+                            continue;
+                        }
+                        // Missing `code` means success — match SeaTalk/OpenClaw:
+                        // `(env.code ?? 0) !== 0`.
+                        let code = env.code.unwrap_or(0);
+                        let reg_token = env
+                            .header
+                            .as_ref()
+                            .and_then(|h| h["token"].as_str())
+                            .map(str::to_string);
+                        if code != 0 || reg_token.is_none() {
+                            return Err(format!(
+                                "register rejected: code={code} {} (token={})",
+                                env.message.unwrap_or_default(),
+                                if reg_token.is_some() { "present" } else { "missing" }
+                            ));
+                        }
+                        token = reg_token.unwrap();
+                        registered = true;
+                        let settings = env.data.clone().unwrap_or_default();
+                        if let Some(interval) = settings["heartbeat_interval"].as_u64() {
+                            if interval > 0 {
+                                ping_ms = interval * 1000;
+                            }
+                        }
+                        stale_ms = stale_ms.max(ping_ms * 2);
+                        let mut status = self.status.write().await;
+                        status.status = SeaTalkGatewayStatus::Connected;
+                        status.error_message = None;
+                        println!("[SeaTalk] WebSocket registered (ping={ping_ms}ms)");
+                        continue;
+                    }
+
+                    match env.cmd.as_str() {
+                        "event" => {
+                            let callback_id = env.header.as_ref().and_then(|h| h["callback_id"].as_str()).map(str::to_string);
+                            if let Some(data) = env.data.clone() {
+                                let preview = data.to_string();
+                                let preview = if preview.len() > 500 {
+                                    format!("{}…", &preview[..500])
+                                } else {
+                                    preview
+                                };
+                                println!(
+                                    "[SeaTalk] ws event received callback_id={} data={}",
+                                    callback_id.as_deref().unwrap_or("-"),
+                                    preview
+                                );
+                                let ctx_clone = ctx.clone();
+                                tokio::spawn(async move {
+                                    if let Err(e) = handle_callback_event(&ctx_clone, &data).await {
+                                        eprintln!("[SeaTalk] event handler failed: {e}");
+                                    }
+                                });
+                            } else {
+                                eprintln!("[SeaTalk] ws event missing data (callback_id={:?})", callback_id);
+                            }
+                            if let Some(cid) = callback_id {
+                                let ack = json!({
+                                    "cmd": "ack",
+                                    "header": {
+                                        "rid": uuid::Uuid::new_v4().to_string(),
+                                        "token": token,
+                                        "callback_id": cid,
+                                    }
+                                });
+                                let _ = write.send(WsMessage::Text(ack.to_string().into())).await;
+                            }
+                        }
+                        "pong" => {}
+                        "kick" => {
+                            return Err(format!("connection kicked: {}", env.message.unwrap_or_default()));
+                        }
+                        other => {
+                            println!("[SeaTalk] ws cmd={other} code={:?} msg={:?}", env.code, env.message);
+                        }
+                    }
+                }
+                _ = tokio::time::sleep(Duration::from_millis(ping_ms)) => {
+                    if registered {
+                        let ping = json!({
+                            "cmd": "ping",
+                            "header": {
+                                "rid": uuid::Uuid::new_v4().to_string(),
+                                "token": token,
+                            }
+                        });
+                        write
+                            .send(WsMessage::Text(ping.to_string().into()))
+                            .await
+                            .map_err(|e| format!("ping send failed: {e}"))?;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn run_webhook_server(
+        &self,
+        _ctx: HandlerContext,
+        _shutdown_rx: oneshot::Receiver<()>,
+    ) -> Result<(), String> {
+        Err("SeaTalk webhook mode is not implemented yet; use websocket mode".to_string())
+    }
+}
+
+async fn handle_callback_event(ctx: &HandlerContext, event: &serde_json::Value) -> Result<(), String> {
+    let event_id = event["event_id"].as_str().unwrap_or("").to_string();
+    let event_type = event["event_type"].as_str().unwrap_or("").to_string();
+    if event_id.is_empty() {
+        eprintln!(
+            "[SeaTalk] dropping event without event_id type={} keys={:?}",
+            event_type,
+            event.as_object().map(|o| o.keys().cloned().collect::<Vec<_>>())
+        );
+        return Ok(());
+    }
+    {
+        let mut tracker = ctx.processed_events.write().await;
+        if tracker.is_duplicate(&event_id) {
+            println!("[SeaTalk] duplicate event_id={event_id}, skip");
+            return Ok(());
+        }
+    }
+
+    println!("[SeaTalk] handle event_id={event_id} type={event_type}");
+    match event_type.as_str() {
+        "message_from_bot_subscriber" => handle_dm_event(ctx, event).await,
+        "new_mentioned_message_received_from_group_chat" | "new_message_received_from_thread" => {
+            handle_group_event(ctx, event).await
+        }
+        "bot_added_to_group_chat" | "bot_removed_from_group_chat" | "new_bot_subscriber" => {
+            println!("[SeaTalk] lifecycle event type={event_type} (ignored)");
+            Ok(())
+        }
+        other => {
+            println!("[SeaTalk] unhandled event_type={other}");
+            Ok(())
+        }
+    }
+}
+
+async fn handle_dm_event(ctx: &HandlerContext, event: &serde_json::Value) -> Result<(), String> {
+    let payload = &event["event"];
+    let employee_code = sender_identity(payload);
+    let email = payload["email"].as_str();
+    let message = &payload["message"];
+
+    if employee_code.is_empty() {
+        eprintln!("[SeaTalk] dm event missing sender identity: {payload}");
+        return Ok(());
+    }
+
+    let cfg = ctx.config.read().await.clone();
+    if !check_dm_allowed(&cfg, &employee_code, email) {
+        println!("[SeaTalk] dm blocked by policy for {employee_code}");
+        return Ok(());
+    }
+
+    let text = extract_message_text(message);
+    if text.is_empty() {
+        println!("[SeaTalk] dm empty text from {employee_code}, ignore");
+        return Ok(());
+    }
+
+    let thread_id = optional_id(message["thread_id"].as_str());
+    let message_id = message["message_id"].as_str().unwrap_or("").to_string();
+    let binding = if cfg.dm_thread_session {
+        if let Some(tid) = thread_id {
+            crate::binding::seatalk_dm_thread(&ctx.app_id, &employee_code, tid)
+        } else {
+            crate::binding::seatalk_dm(&ctx.app_id, &employee_code)
+        }
+    } else {
+        crate::binding::seatalk_dm(&ctx.app_id, &employee_code)
+    };
+
+    let sender_display = email
+        .map(str::to_string)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| employee_code.clone());
+
+    process_inbound(
+        ctx,
+        &binding,
+        &format!("SeaTalk DM: {sender_display}"),
+        &sender_display,
+        &employee_code,
+        email,
+        true,
+        &text,
+        &message_id,
+        &employee_code,
+        None,
+        thread_id,
+    )
+    .await
+}
+
+async fn handle_group_event(ctx: &HandlerContext, event: &serde_json::Value) -> Result<(), String> {
+    let payload = &event["event"];
+    // Mention events use event.group_id; some lifecycle payloads nest it.
+    let group_id = payload["group_id"]
+        .as_str()
+        .or_else(|| payload["group"]["group_id"].as_str())
+        .unwrap_or("");
+    let message = &payload["message"];
+
+    if group_id.is_empty() {
+        eprintln!("[SeaTalk] group event missing group_id: {payload}");
+        return Ok(());
+    }
+
+    let sender = &message["sender"];
+    let employee_code = sender_identity(sender);
+    let email = sender["email"].as_str();
+
+    if employee_code.is_empty() {
+        eprintln!("[SeaTalk] group event missing sender identity in {group_id}: {sender}");
+        return Ok(());
+    }
+
+    let cfg = ctx.config.read().await.clone();
+    match check_group_allowed(&cfg, group_id, &employee_code, email) {
+        FilterResult::Allow => {}
+        FilterResult::Ignore => {
+            println!("[SeaTalk] group policy disabled, ignore group={group_id}");
+            return Ok(());
+        }
+        FilterResult::ChannelNotConfigured => {
+            println!("[SeaTalk] group {group_id} not in allowlist, ignore");
+            return Ok(());
+        }
+        FilterResult::UserNotAllowed => {
+            let _ = ctx
+                .client
+                .send_group_text(
+                    group_id,
+                    "Sorry, you are not authorized to use this bot.",
+                    optional_id(message["thread_id"].as_str()),
+                )
+                .await;
+            return Ok(());
+        }
+    }
+
+    let text = extract_message_text(message);
+    let text = if text.is_empty() {
+        // Bare @Bot with no question — still acknowledge so users know we're live.
+        "你好，请直接说明需要我帮你做什么。".to_string()
+    } else {
+        text
+    };
+
+    let thread_id = optional_id(message["thread_id"].as_str());
+    let message_id = message["message_id"].as_str().unwrap_or("").to_string();
+    let binding = if cfg.group_thread_session {
+        if let Some(tid) = thread_id {
+            crate::binding::seatalk_group_thread(&ctx.app_id, group_id, tid)
+        } else {
+            crate::binding::seatalk_group(&ctx.app_id, group_id)
+        }
+    } else {
+        crate::binding::seatalk_group(&ctx.app_id, group_id)
+    };
+
+    let sender_display = email
+        .map(str::to_string)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| employee_code.clone());
+
+    println!(
+        "[SeaTalk] group mention group={group_id} from={sender_display} text_len={} thread={:?}",
+        text.len(),
+        thread_id
+    );
+
+    process_inbound(
+        ctx,
+        &binding,
+        &format!("SeaTalk group: {group_id}"),
+        &sender_display,
+        &employee_code,
+        email,
+        false,
+        &text,
+        &message_id,
+        &employee_code,
+        Some(group_id),
+        thread_id,
+    )
+    .await
+}
+
+/// Prefer employee_code; fall back to seatalk_id when SeaTalk omits the former.
+fn sender_identity(sender: &serde_json::Value) -> String {
+    sender["employee_code"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .or_else(|| sender["seatalk_id"].as_str().filter(|s| !s.is_empty()))
+        .unwrap_or("")
+        .to_string()
+}
+
+fn optional_id(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|s| !s.is_empty())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn process_inbound(
+    ctx: &HandlerContext,
+    binding: &str,
+    session_title: &str,
+    sender_display: &str,
+    employee_code: &str,
+    _email: Option<&str>,
+    is_dm: bool,
+    text: &str,
+    message_id: &str,
+    reply_target: &str,
+    group_id: Option<&str>,
+    thread_id: Option<&str>,
+) -> Result<(), String> {
+    let urn = crate::binding::urn_seatalk_user(&ctx.app_id, employee_code);
+    let external_actor_id = ctx
+        .store
+        .ensure_external_actor(&ctx.team_id, "seatalk", &urn, sender_display)
+        .await
+        .map_err(|e| format!("ensure_external_actor: {e}"))?;
+
+    println!(
+        "[SeaTalk] ensure_session binding={binding} title={session_title} actor={external_actor_id}"
+    );
+    let outcome = ctx
+        .store
+        .ensure_session(
+            &ctx.team_id,
+            binding,
+            session_title,
+            &ctx.primary_agent_actor_id,
+            &ctx.agent_owner_actor_ids,
+            std::slice::from_ref(&external_actor_id),
+        )
+        .await
+        .map_err(|e| format!("ensure_session: {e}"))?;
+
+    let _ = ctx
+        .store
+        .add_participant(&outcome.session_id, &external_actor_id)
+        .await;
+
+    let lower = text.to_lowercase();
+    let is_session_slash =
+        lower == "/stop" || lower == "/reset" || lower == "/model" || lower.starts_with("/model ");
+
+    if is_session_slash {
+        let reply_text =
+            crate::commands::dispatch_session_slash_cmd(&ctx.agent, &lower, &outcome.acp_session_id)
+                .await;
+        return send_reply(
+            ctx,
+            is_dm,
+            reply_target,
+            group_id,
+            thread_id,
+            &reply_text,
+        )
+        .await;
+    }
+
+    let _ = ctx
+        .store
+        .record_message(
+            &outcome.session_id,
+            &external_actor_id,
+            text,
+            Some(message_id),
+        )
+        .await;
+
+    if is_dm {
+        let _ = ctx
+            .client
+            .set_single_typing(reply_target, thread_id)
+            .await;
+    } else if let Some(gid) = group_id {
+        let _ = ctx.client.set_group_typing(gid, thread_id).await;
+    }
+
+    println!(
+        "[SeaTalk] send_prompt session={} acp={} from={sender_display}",
+        outcome.session_id, outcome.acp_session_id
+    );
+    let reply = match ctx
+        .agent
+        .send_prompt(&outcome.acp_session_id, sender_display, text)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            let detail = e.to_string();
+            let err = format!("send_prompt: {detail}");
+            eprintln!("[SeaTalk] {err}");
+            let user_msg = if detail.contains("Invalid User API Key") || detail.contains("API Key")
+            {
+                "Agent 未就绪：本地 API Key 无效，请在 TeamClaw 设置里更新模型/Provider 凭证后重试。"
+                    .to_string()
+            } else {
+                format!("抱歉，处理失败：{detail}")
+            };
+            let _ = send_reply(ctx, is_dm, reply_target, group_id, thread_id, &user_msg).await;
+            return Err(err);
+        }
+    };
+
+    let _ = ctx
+        .store
+        .record_agent_reply(
+            &outcome.session_id,
+            &ctx.primary_agent_actor_id,
+            &reply.reply_text,
+            None,
+        )
+        .await;
+
+    println!(
+        "[SeaTalk] reply ready chars={} dm={is_dm} target={reply_target} group={:?}",
+        reply.reply_text.len(),
+        group_id
+    );
+    send_reply(
+        ctx,
+        is_dm,
+        reply_target,
+        group_id,
+        thread_id,
+        &reply.reply_text,
+    )
+    .await
+}
+
+async fn send_reply(
+    ctx: &HandlerContext,
+    is_dm: bool,
+    reply_target: &str,
+    group_id: Option<&str>,
+    thread_id: Option<&str>,
+    text: &str,
+) -> Result<(), String> {
+    if is_dm {
+        ctx.client
+            .send_single_text(reply_target, text, thread_id)
+            .await
+    } else if let Some(gid) = group_id {
+        ctx.client.send_group_text(gid, text, thread_id).await
+    } else {
+        Ok(())
+    }
+}
+
+fn extract_message_text(message: &serde_json::Value) -> String {
+    let tag = message["tag"].as_str().unwrap_or("");
+    match tag {
+        "text" => {
+            let raw = message["text"]["plain_text"]
+                .as_str()
+                .or_else(|| message["text"]["content"].as_str())
+                .unwrap_or("");
+            strip_leading_mentions(raw)
+        }
+        _ => String::new(),
+    }
+}
+
+/// Remove leading `@BotName` / `@all` tokens that SeaTalk includes in plain_text
+/// for group mention events, so the agent sees the user's question only.
+fn strip_leading_mentions(text: &str) -> String {
+    let mut rest = text.trim_start();
+    loop {
+        let Some(stripped) = rest.strip_prefix('@') else {
+            break;
+        };
+        let end = stripped
+            .find(|c: char| c.is_whitespace())
+            .unwrap_or(stripped.len());
+        if end == 0 {
+            break;
+        }
+        rest = stripped[end..].trim_start();
+    }
+    rest.trim().to_string()
+}
+
+fn check_dm_allowed(cfg: &SeaTalkConfig, employee_code: &str, email: Option<&str>) -> bool {
+    match cfg.dm_policy.as_str() {
+        "open" => cfg.allow_from.iter().any(|e| e.trim() == "*")
+            || cfg.allow_from.is_empty(),
+        _ => is_sender_allowed(employee_code, email, &cfg.allow_from),
+    }
+}
+
+fn check_group_allowed(
+    cfg: &SeaTalkConfig,
+    group_id: &str,
+    employee_code: &str,
+    email: Option<&str>,
+) -> FilterResult {
+    if cfg.group_policy == "disabled" {
+        return FilterResult::Ignore;
+    }
+
+    let group_ok = match cfg.group_policy.as_str() {
+        "open" => true,
+        "allowlist" => {
+            if cfg.group_allow_from.is_empty() {
+                true
+            } else {
+                cfg.group_allow_from.iter().any(|g| g == group_id || g == "*")
+            }
+        }
+        _ => false,
+    };
+
+    if !group_ok {
+        return FilterResult::ChannelNotConfigured;
+    }
+
+    if let Some(group_cfg) = cfg.groups.get(group_id) {
+        if !group_cfg.allow {
+            return FilterResult::ChannelNotConfigured;
+        }
+        if !group_cfg.users.is_empty()
+            && !is_sender_allowed(employee_code, email, &group_cfg.users)
+        {
+            return FilterResult::UserNotAllowed;
+        }
+    }
+
+    if !cfg.group_sender_allow_from.is_empty()
+        && !is_sender_allowed(employee_code, email, &cfg.group_sender_allow_from)
+    {
+        return FilterResult::UserNotAllowed;
+    }
+
+    FilterResult::Allow
+}
+
+fn is_sender_allowed(employee_code: &str, email: Option<&str>, allow_from: &[String]) -> bool {
+    allow_from.iter().any(|entry| {
+        let e = entry.trim();
+        e == "*" || e == employee_code || email.is_some_and(|mail| e.eq_ignore_ascii_case(mail))
+    })
+}
+
+fn chunk_text(text: &str, limit: usize) -> Vec<String> {
+    if text.len() <= limit {
+        return vec![text.to_string()];
+    }
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < text.len() {
+        let end = (start + limit).min(text.len());
+        let split_at = if end == text.len() {
+            end
+        } else {
+            text[start..end]
+                .rfind('\n')
+                .map(|i| start + i + 1)
+                .unwrap_or(end)
+        };
+        chunks.push(text[start..split_at].to_string());
+        start = split_at;
+    }
+    chunks
+}
+
+impl Clone for SeaTalkGateway {
+    fn clone(&self) -> Self {
+        Self {
+            config: Arc::clone(&self.config),
+            agent: Arc::clone(&self.agent),
+            store: Arc::clone(&self.store),
+            team_id: self.team_id.clone(),
+            primary_agent_actor_id: self.primary_agent_actor_id.clone(),
+            agent_owner_actor_ids: self.agent_owner_actor_ids.clone(),
+            workspace_path: self.workspace_path.clone(),
+            shutdown_tx: Arc::clone(&self.shutdown_tx),
+            status: Arc::clone(&self.status),
+            is_running: Arc::clone(&self.is_running),
+            processed_events: Arc::clone(&self.processed_events),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::seatalk_config::SeaTalkConfig;
+
+    #[test]
+    fn strips_leading_bot_mentions() {
+        assert_eq!(
+            strip_leading_mentions("@TeamClaw 帮我查一下状态"),
+            "帮我查一下状态"
+        );
+        assert_eq!(
+            strip_leading_mentions("@TeamClaw @all please summarize"),
+            "please summarize"
+        );
+        assert_eq!(strip_leading_mentions("no mention here"), "no mention here");
+        assert_eq!(strip_leading_mentions("@only"), "");
+    }
+
+    #[test]
+    fn default_config_allows_group_mentions() {
+        let cfg = SeaTalkConfig::default();
+        assert_eq!(cfg.mode, "websocket");
+        assert_eq!(cfg.group_policy, "open");
+        assert_eq!(
+            check_group_allowed(&cfg, "g1", "e1", Some("a@b.com")),
+            FilterResult::Allow
+        );
+        assert!(check_dm_allowed(&cfg, "e1", Some("a@b.com")));
+    }
+
+    #[test]
+    fn extract_text_prefers_plain_text() {
+        let message = json!({
+            "tag": "text",
+            "text": {
+                "plain_text": "@Bot hello world",
+                "content": "ignored"
+            }
+        });
+        assert_eq!(extract_message_text(&message), "hello world");
+    }
+
+    #[test]
+    fn sender_identity_falls_back_to_seatalk_id() {
+        assert_eq!(
+            sender_identity(&json!({"employee_code": "e1", "seatalk_id": "s1"})),
+            "e1"
+        );
+        assert_eq!(sender_identity(&json!({"seatalk_id": "s1"})), "s1");
+        assert_eq!(sender_identity(&json!({})), "");
+    }
+
+    #[test]
+    fn register_success_when_code_omitted() {
+        // SeaTalk often replies `{ cmd, message: "ok", header: { token } }`
+        // without a numeric `code`. Missing code must be treated as 0.
+        let raw = r#"{"cmd":"register","message":"ok","header":{"token":"t1","sid":"s1"},"data":{"heartbeat_interval":15}}"#;
+        let env: WsEnvelope = serde_json::from_str(raw).unwrap();
+        assert_eq!(env.cmd, "register");
+        assert_eq!(env.code.unwrap_or(0), 0);
+        assert_eq!(
+            env.header.as_ref().and_then(|h| h["token"].as_str()),
+            Some("t1")
+        );
+    }
+}

--- a/crates/teamclaw-gateway/src/seatalk_config.rs
+++ b/crates/teamclaw-gateway/src/seatalk_config.rs
@@ -1,0 +1,155 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// SeaTalk channel configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SeaTalkConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// SeaTalk Open Platform App ID
+    #[serde(default)]
+    pub app_id: String,
+
+    /// SeaTalk Open Platform App Secret
+    #[serde(default)]
+    pub app_secret: String,
+
+    /// Gateway mode: `websocket` (default) or `webhook`
+    #[serde(default = "default_mode")]
+    pub mode: String,
+
+    /// Signing secret for webhook mode event verification
+    #[serde(default)]
+    pub signing_secret: String,
+
+    /// HTTP port for webhook mode
+    #[serde(default = "default_webhook_port")]
+    pub webhook_port: u16,
+
+    /// HTTP path for webhook mode
+    #[serde(default = "default_webhook_path")]
+    pub webhook_path: String,
+
+    /// DM access policy: `open` | `allowlist`
+    #[serde(default = "default_dm_policy")]
+    pub dm_policy: String,
+
+    /// Allowed DM senders (employee codes or emails). Use `*` for open policy.
+    #[serde(default)]
+    pub allow_from: Vec<String>,
+
+    /// Group access policy: `disabled` | `allowlist` | `open`
+    ///
+    /// Default `open` so @bot mentions work after the bot is added to a group.
+    #[serde(default = "default_group_policy")]
+    pub group_policy: String,
+
+    /// Allowed group IDs when `groupPolicy = allowlist`
+    #[serde(default)]
+    pub group_allow_from: Vec<String>,
+
+    /// Optional per-group sender allowlist (employee codes or emails)
+    #[serde(default)]
+    pub group_sender_allow_from: Vec<String>,
+
+    /// Route each group thread to its own agent session
+    #[serde(default = "default_true")]
+    pub group_thread_session: bool,
+
+    /// Route each DM thread to its own agent session
+    #[serde(default = "default_true")]
+    pub dm_thread_session: bool,
+
+    /// Per-group overrides (group_id -> config)
+    #[serde(default)]
+    pub groups: HashMap<String, SeaTalkGroupConfig>,
+}
+
+impl Default for SeaTalkConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            app_id: String::new(),
+            app_secret: String::new(),
+            mode: default_mode(),
+            signing_secret: String::new(),
+            webhook_port: default_webhook_port(),
+            webhook_path: default_webhook_path(),
+            dm_policy: default_dm_policy(),
+            allow_from: Vec::new(),
+            group_policy: default_group_policy(),
+            group_allow_from: Vec::new(),
+            group_sender_allow_from: Vec::new(),
+            group_thread_session: true,
+            dm_thread_session: true,
+            groups: HashMap::new(),
+        }
+    }
+}
+
+/// Per-group configuration
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SeaTalkGroupConfig {
+    #[serde(default)]
+    pub allow: bool,
+
+    #[serde(default)]
+    pub users: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SeaTalkGatewayStatus {
+    #[default]
+    Disconnected,
+    Connecting,
+    Connected,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SeaTalkGatewayStatusResponse {
+    pub status: SeaTalkGatewayStatus,
+    pub error_message: Option<String>,
+    pub app_id: Option<String>,
+}
+
+impl Default for SeaTalkGatewayStatusResponse {
+    fn default() -> Self {
+        Self {
+            status: SeaTalkGatewayStatus::Disconnected,
+            error_message: None,
+            app_id: None,
+        }
+    }
+}
+
+fn default_mode() -> String {
+    "websocket".to_string()
+}
+
+fn default_webhook_port() -> u16 {
+    8080
+}
+
+fn default_webhook_path() -> String {
+    "/callback".to_string()
+}
+
+fn default_dm_policy() -> String {
+    // Open by default so 1:1 chats work without an allowlist UI pass.
+    "open".to_string()
+}
+
+fn default_group_policy() -> String {
+    // Open by default so @bot in any group the bot joins is answered.
+    "open".to_string()
+}
+
+fn default_true() -> bool {
+    true
+}

--- a/packages/app/src/components/settings/ChannelsSection.tsx
+++ b/packages/app/src/components/settings/ChannelsSection.tsx
@@ -10,6 +10,7 @@ import { EmailChannel } from './channels/Email'
 import { KookChannel } from './channels/Kook'
 import { WeComChannel } from './channels/Wecom'
 import { WeChatChannel } from './channels/Wechat'
+import { SeaTalkChannel } from './channels/Seatalk'
 import { useFeatures } from '@/lib/remote-features'
 
 // Main Channels Section Component
@@ -67,6 +68,7 @@ export function ChannelsSection() {
       {channelsConfig.kook && <KookChannel />}
       {channelsConfig.wecom && <WeComChannel />}
       {channelsConfig.wechat && <WeChatChannel />}
+      {channelsConfig.seatalk && <SeaTalkChannel />}
     </div>
   )
 }

--- a/packages/app/src/components/settings/channels/Seatalk.tsx
+++ b/packages/app/src/components/settings/channels/Seatalk.tsx
@@ -1,0 +1,240 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Key, Shield, Loader2, ExternalLink, Bot, Sparkles } from 'lucide-react'
+import { openExternalUrl } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  useChannelsStore,
+  type SeaTalkConfig,
+  defaultSeaTalkConfig,
+} from '@/stores/channels'
+import { GatewayStatusCard } from './GatewayStatusCard'
+import { TestCredentialsButton } from './TestCredentialsButton'
+import { useChannelConfig } from '@/hooks/useChannelConfig'
+
+function SeaTalkIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M12 2C6.48 2 2 6.03 2 11c0 2.9 1.46 5.48 3.74 7.1L5 22l3.64-1.86C9.68 20.71 10.81 21 12 21c5.52 0 10-4.03 10-9S17.52 2 12 2zm0 16c-.95 0-1.87-.22-2.7-.63l-.3-.15-2.2 1.12.42-2.41-.2-.31C5.9 14.4 5 12.78 5 11c0-3.87 3.58-7 7-7s7 3.13 7 7-3.58 7-7 7z" />
+    </svg>
+  )
+}
+
+export function SeaTalkChannel() {
+  const { t } = useTranslation()
+  const {
+    seatalk,
+    seatalkIsLoading,
+    seatalkGatewayStatus,
+    seatalkHasChanges,
+    seatalkIsTesting,
+    seatalkTestResult,
+    saveSeaTalkConfig,
+    startSeaTalkGateway,
+    stopSeaTalkGateway,
+    refreshSeaTalkStatus,
+    testSeaTalkCredentials,
+    clearSeaTalkTestResult,
+    setSeaTalkHasChanges,
+    toggleSeaTalkEnabled,
+  } = useChannelsStore()
+
+  const [expanded, setExpanded] = React.useState(false)
+
+  const {
+    localConfig,
+    updateLocalConfig,
+    isConnecting,
+    isRunning,
+    handleSave,
+    handleRestart,
+  } = useChannelConfig<SeaTalkConfig>({
+    storeConfig: seatalk,
+    defaultConfig: defaultSeaTalkConfig,
+    gatewayStatus: seatalkGatewayStatus,
+    isLoading: seatalkIsLoading,
+    hasChanges: seatalkHasChanges,
+    setHasChanges: setSeaTalkHasChanges,
+    saveConfig: saveSeaTalkConfig,
+    startGateway: startSeaTalkGateway,
+    stopGateway: stopSeaTalkGateway,
+    refreshStatus: refreshSeaTalkStatus,
+  })
+
+  const handleTestCredentials = async () => {
+    if (!localConfig.appId || !localConfig.appSecret) return
+    await testSeaTalkCredentials(localConfig.appId, localConfig.appSecret)
+  }
+
+  if (!seatalk) return null
+
+  return (
+    <GatewayStatusCard
+      icon={
+        <div className="rounded-md p-1.5 bg-sky-100 dark:bg-sky-900/50">
+          <SeaTalkIcon className="h-4 w-4 text-sky-600 dark:text-sky-400" />
+        </div>
+      }
+      title={t('settings.channels.seatalk.gateway', 'SeaTalk Gateway')}
+      status={seatalkGatewayStatus.status}
+      statusDetail={
+        seatalkGatewayStatus.appId ? (
+          <p className="text-xs text-muted-foreground">App: {seatalkGatewayStatus.appId}</p>
+        ) : undefined
+      }
+      errorMessage={seatalkGatewayStatus.errorMessage}
+      expanded={expanded}
+      onToggleExpanded={() => setExpanded(!expanded)}
+      enabled={localConfig.enabled}
+      onToggleEnabled={(enabled) => {
+        updateLocalConfig({ enabled })
+        toggleSeaTalkEnabled(enabled, { ...localConfig, enabled })
+      }}
+      isLoading={seatalkIsLoading}
+      isConnecting={isConnecting}
+      isRunning={isRunning}
+      hasChanges={seatalkHasChanges}
+      onStart={startSeaTalkGateway}
+      onStop={stopSeaTalkGateway}
+      onRestart={handleRestart}
+      startDisabled={!localConfig.appId || !localConfig.appSecret}
+    >
+      {!localConfig.appId && (
+        <div className="p-4 rounded-lg bg-gradient-to-br from-sky-50 to-blue-50 dark:from-sky-950/30 dark:to-blue-950/30 border border-sky-200 dark:border-sky-800">
+          <div className="flex items-start gap-4">
+            <Bot className="h-8 w-8 text-sky-600 dark:text-sky-400 flex-shrink-0" />
+            <div className="flex-1 space-y-2">
+              <h4 className="font-semibold text-sky-900 dark:text-sky-100">
+                {t('settings.channels.seatalk.setupTitle', 'Set up SeaTalk Bot')}
+              </h4>
+              <p className="text-[13px] text-sky-700 dark:text-sky-300">
+                {t(
+                  'settings.channels.seatalk.setupDesc',
+                  'Create a Bot App on SeaTalk Open Platform, enable WebSocket event delivery, then paste App ID and App Secret below.',
+                )}
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-2"
+                onClick={() => openExternalUrl('https://open.seatalk.io/')}
+              >
+                <ExternalLink className="h-4 w-4" />
+                {t('settings.channels.seatalk.openPlatform', 'Open SeaTalk Open Platform')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <label className="text-[13px] font-medium flex items-center gap-2">
+          <Key className="h-4 w-4 text-muted-foreground" />
+          {t('settings.channels.seatalk.appCredentials', 'App Credentials')}
+        </label>
+        <div className="space-y-2">
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">{t('settings.channels.seatalk.appId', 'App ID')}</label>
+            <Input
+              value={localConfig.appId}
+              onChange={(e) => updateLocalConfig({ appId: e.target.value })}
+              placeholder="your_app_id"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">{t('settings.channels.seatalk.appSecret', 'App Secret')}</label>
+            <div className="flex gap-2">
+              <div className="relative flex-1">
+                <Input
+                  type="password"
+                  value={localConfig.appSecret}
+                  onChange={(e) => updateLocalConfig({ appSecret: e.target.value })}
+                  placeholder={t('settings.channels.seatalk.appSecretPlaceholder', 'Your app secret')}
+                  className="pr-10"
+                />
+                <Shield className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              </div>
+              <TestCredentialsButton
+                onTest={handleTestCredentials}
+                isTesting={seatalkIsTesting}
+                testResult={seatalkTestResult}
+                onClearResult={clearSeaTalkTestResult}
+                disabled={!localConfig.appId || !localConfig.appSecret}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-[13px] font-medium">
+          {t('settings.channels.seatalk.groupPolicy', 'Group @bot policy')}
+        </label>
+        <select
+          className="w-full h-9 rounded-md border border-border bg-paper px-3 text-[13px]"
+          value={localConfig.groupPolicy}
+          onChange={(e) => updateLocalConfig({ groupPolicy: e.target.value })}
+        >
+          <option value="open">
+            {t('settings.channels.seatalk.groupPolicyOpen', 'Open — answer @bot in any group')}
+          </option>
+          <option value="allowlist">
+            {t('settings.channels.seatalk.groupPolicyAllowlist', 'Allowlist — only listed group IDs')}
+          </option>
+          <option value="disabled">
+            {t('settings.channels.seatalk.groupPolicyDisabled', 'Disabled — ignore group mentions')}
+          </option>
+        </select>
+        {localConfig.groupPolicy === 'allowlist' && (
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">
+              {t('settings.channels.seatalk.groupAllowFrom', 'Allowed group IDs (one per line)')}
+            </label>
+            <textarea
+              className="w-full min-h-[72px] rounded-md border border-border bg-paper px-3 py-2 text-[12px] font-mono"
+              value={(localConfig.groupAllowFrom ?? []).join('\n')}
+              onChange={(e) =>
+                updateLocalConfig({
+                  groupAllowFrom: e.target.value
+                    .split('\n')
+                    .map((s) => s.trim())
+                    .filter(Boolean),
+                })
+              }
+              placeholder="group_id_1&#10;group_id_2"
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="p-3 rounded-lg bg-muted/40 text-[13px] space-y-1">
+        <p className="font-medium">{t('settings.channels.seatalk.portalChecklist', 'SeaTalk portal checklist')}</p>
+        <ul className="list-disc list-inside text-muted-foreground space-y-1">
+          <li>{t('settings.channels.seatalk.checkBotOnline', 'Set Bot status to Online')}</li>
+          <li>{t('settings.channels.seatalk.checkWebSocket', 'Event delivery: WebSocket mode')}</li>
+          <li>{t('settings.channels.seatalk.checkMentionEvent', 'Subscribe: new_mentioned_message_received_from_group_chat')}</li>
+          <li>{t('settings.channels.seatalk.checkDmEvent', 'Subscribe: message_from_bot_subscriber (for DMs)')}</li>
+          <li>{t('settings.channels.seatalk.checkSendGroup', 'Permission: Send Message to Group Chat (required to reply)')}</li>
+          <li>{t('settings.channels.seatalk.checkSendDm', 'Permission: Send Message to Bot User (for DMs)')}</li>
+          <li>{t('settings.channels.seatalk.checkAddToGroup', 'Add the bot to your target group')}</li>
+          <li>{t('settings.channels.seatalk.checkStartGateway', 'Start the gateway below, then Re-verify WebSocket in the portal')}</li>
+        </ul>
+      </div>
+
+      <Button className="w-full gap-2" onClick={handleSave} disabled={seatalkIsLoading}>
+        {seatalkIsLoading ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t('settings.channels.saving', 'Saving...')}
+          </>
+        ) : (
+          <>
+            <Sparkles className="h-4 w-4" />
+            {t('settings.channels.saveChanges', 'Save Changes')}
+          </>
+        )}
+      </Button>
+    </GatewayStatusCard>
+  )
+}

--- a/packages/app/src/lib/amuxd-channels.ts
+++ b/packages/app/src/lib/amuxd-channels.ts
@@ -6,7 +6,8 @@ export type ChannelPlatform =
   | "feishu"
   | "kook"
   | "wechat"
-  | "email";
+  | "email"
+  | "seatalk";
 
 export interface ChannelStatus {
   platform: ChannelPlatform;
@@ -92,6 +93,19 @@ function toDaemonConfig(platform: ChannelPlatform, config: ChannelConfig): Chann
         app_id: String(config.appId ?? ""),
         app_secret: String(config.appSecret ?? ""),
       };
+    case "seatalk":
+      return {
+        enabled: Boolean(config.enabled),
+        app_id: String(config.appId ?? ""),
+        app_secret: String(config.appSecret ?? ""),
+        mode: String(config.mode ?? "websocket"),
+        dm_policy: String(config.dmPolicy ?? "open"),
+        allow_from: Array.isArray(config.allowFrom) ? config.allowFrom : [],
+        group_policy: String(config.groupPolicy ?? "open"),
+        group_allow_from: Array.isArray(config.groupAllowFrom)
+          ? config.groupAllowFrom
+          : [],
+      };
     case "kook":
       return {
         enabled: Boolean(config.enabled),
@@ -165,6 +179,19 @@ function fromDaemonConfig(platform: ChannelPlatform, config: ChannelConfig): Cha
         enabled: Boolean(config.enabled),
         appId: String(config.app_id ?? ""),
         appSecret: String(config.app_secret ?? ""),
+      };
+    case "seatalk":
+      return {
+        enabled: Boolean(config.enabled),
+        appId: String(config.app_id ?? ""),
+        appSecret: String(config.app_secret ?? ""),
+        mode: String(config.mode ?? "websocket"),
+        dmPolicy: String(config.dm_policy ?? "open"),
+        allowFrom: Array.isArray(config.allow_from) ? config.allow_from : [],
+        groupPolicy: String(config.group_policy ?? "open"),
+        groupAllowFrom: Array.isArray(config.group_allow_from)
+          ? config.group_allow_from
+          : [],
       };
     case "kook":
       return {

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -22,6 +22,7 @@ export interface ChannelsFeatureConfig {
   kook: boolean
   wecom: boolean
   wechat: boolean
+  seatalk: boolean
 }
 
 export interface TeamModelOption {
@@ -131,6 +132,7 @@ const allChannelsEnabled: ChannelsFeatureConfig = {
   kook: true,
   wecom: true,
   wechat: true,
+  seatalk: true,
 }
 
 /**
@@ -140,7 +142,7 @@ export function resolveChannelsConfig(channels: boolean | ChannelsFeatureConfig)
   if (typeof channels === 'boolean') {
     return channels
       ? { ...allChannelsEnabled }
-      : { discord: false, feishu: false, email: false, kook: false, wecom: false, wechat: false }
+      : { discord: false, feishu: false, email: false, kook: false, wecom: false, wechat: false, seatalk: false }
   }
   return channels
 }

--- a/packages/app/src/lib/remote-features.ts
+++ b/packages/app/src/lib/remote-features.ts
@@ -177,6 +177,7 @@ function normalizeChannels(value: boolean | ChannelsFeatureConfig | undefined): 
       kook: value,
       wecom: value,
       wechat: value,
+      seatalk: value,
     };
   }
   return value;
@@ -218,6 +219,7 @@ function resolveFrom(patches: RemoteFeaturePatch[]): ResolvedFeatures {
       kook: merged.channels?.kook ?? channels.kook,
       wecom: merged.channels?.wecom ?? channels.wecom,
       wechat: merged.channels?.wechat ?? channels.wechat,
+      seatalk: merged.channels?.seatalk ?? channels.seatalk,
     },
     teamShareBrowser: merged.teamShareBrowser ?? base.teamShareBrowser ?? false,
     apps: merged.apps ?? base.apps ?? false,

--- a/packages/app/src/stores/channels-store.ts
+++ b/packages/app/src/stores/channels-store.ts
@@ -6,12 +6,14 @@ import type {
   KookConfig,
   WeComConfig,
   WeChatConfig,
+  SeaTalkConfig,
   GatewayStatusResponse,
   FeishuGatewayStatusResponse,
   EmailGatewayStatusResponse,
   KookGatewayStatusResponse,
   WeComGatewayStatusResponse,
   WeChatGatewayStatusResponse,
+  SeaTalkGatewayStatusResponse,
   ChannelsState,
 } from './channels-types'
 import {
@@ -21,6 +23,7 @@ import {
   defaultEmailConfig,
   defaultWeComConfig,
   defaultWeChatConfig,
+  defaultSeaTalkConfig,
 } from './channels-types'
 import { createDiscordActions } from './channels/discord'
 import { createFeishuActions } from './channels/feishu'
@@ -28,6 +31,7 @@ import { createEmailActions } from './channels/email'
 import { createKookActions } from './channels/kook'
 import { createWecomActions } from './channels/wecom'
 import { createWechatActions } from './channels/wechat'
+import { createSeaTalkActions } from './channels/seatalk'
 import {
   listChannels,
   loadChannelConfig,
@@ -89,6 +93,15 @@ function wecomStatus(list: AmuxdChannelStatus[]): WeComGatewayStatusResponse {
 
 function wechatStatus(list: AmuxdChannelStatus[]): WeChatGatewayStatusResponse {
   const entry = list.find((c) => c.platform === 'wechat')
+  if (!entry) return { status: 'disconnected' }
+  if (entry.lastError) return { status: 'error', errorMessage: entry.lastError }
+  if (entry.connected) return { status: 'connected' }
+  if (entry.enabled) return { status: 'connecting' }
+  return { status: 'disconnected' }
+}
+
+function seatalkStatus(list: AmuxdChannelStatus[]): SeaTalkGatewayStatusResponse {
+  const entry = list.find((c) => c.platform === 'seatalk')
   if (!entry) return { status: 'disconnected' }
   if (entry.lastError) return { status: 'error', errorMessage: entry.lastError }
   if (entry.connected) return { status: 'connected' }
@@ -159,6 +172,14 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
   emailTestResult: null,
   gmailAuthUrl: null,
 
+  // SeaTalk initial state
+  seatalk: null,
+  seatalkIsLoading: false,
+  seatalkGatewayStatus: { status: 'disconnected' },
+  seatalkHasChanges: false,
+  seatalkIsTesting: false,
+  seatalkTestResult: null,
+
   // Compose all channel actions
   ...createDiscordActions(set),
   ...createFeishuActions(set),
@@ -166,6 +187,7 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
   ...createKookActions(set),
   ...createWecomActions(set),
   ...createWechatActions(set),
+  ...createSeaTalkActions(set),
 
   // ========== Shared gateway logic ==========
 
@@ -183,6 +205,7 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
         kookConfig,
         wecomConfig,
         wechatConfig,
+        seatalkConfig,
       ] = await Promise.all([
         listChannels(),
         loadChannelConfig<DiscordConfig>('discord'),
@@ -191,6 +214,7 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
         loadChannelConfig<KookConfig>('kook'),
         loadChannelConfig<WeComConfig>('wecom'),
         loadChannelConfig<WeChatConfig>('wechat'),
+        loadChannelConfig<SeaTalkConfig>('seatalk'),
       ])
       set({
         discord: { ...defaultDiscordConfig, ...discordConfig },
@@ -205,6 +229,8 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
         wecomGatewayStatus: wecomStatus(list),
         wechat: { ...defaultWeChatConfig, ...wechatConfig },
         wechatGatewayStatus: wechatStatus(list),
+        seatalk: { ...defaultSeaTalkConfig, ...seatalkConfig },
+        seatalkGatewayStatus: seatalkStatus(list),
         error: null,
         isLoading: false,
         hasChanges: false,
@@ -212,6 +238,7 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
         emailHasChanges: false,
         wecomHasChanges: false,
         wechatHasChanges: false,
+        seatalkHasChanges: false,
       })
     } catch (error) {
       set({
@@ -268,6 +295,12 @@ export const useChannelsStore = create<ChannelsState>((set) => ({
       wechatHasChanges: false,
       wechatIsTesting: false,
       wechatTestResult: null,
+      seatalk: null,
+      seatalkIsLoading: false,
+      seatalkGatewayStatus: { status: 'disconnected' },
+      seatalkHasChanges: false,
+      seatalkIsTesting: false,
+      seatalkTestResult: null,
     })
   },
 

--- a/packages/app/src/stores/channels-types.ts
+++ b/packages/app/src/stores/channels-types.ts
@@ -67,6 +67,29 @@ export interface FeishuGatewayStatusResponse {
   appId?: string
 }
 
+// SeaTalk configuration
+export interface SeaTalkConfig {
+  enabled: boolean
+  appId: string
+  appSecret: string
+  /** `websocket` (default) or `webhook` */
+  mode: string
+  /** `open` | `allowlist` */
+  dmPolicy: string
+  allowFrom: string[]
+  /** `disabled` | `allowlist` | `open` — default `open` for @bot */
+  groupPolicy: string
+  groupAllowFrom: string[]
+}
+
+export type SeaTalkGatewayStatus = 'disconnected' | 'connecting' | 'connected' | 'error'
+
+export interface SeaTalkGatewayStatusResponse {
+  status: SeaTalkGatewayStatus
+  errorMessage?: string
+  appId?: string
+}
+
 // Email provider type
 export type EmailProvider = 'gmail' | 'custom'
 
@@ -217,6 +240,7 @@ export interface ChannelsConfig {
   kook?: KookConfig
   wecom?: WeComConfig
   wechat?: WeChatConfig
+  seatalk?: SeaTalkConfig
 }
 
 // Gateway status response
@@ -261,6 +285,17 @@ export const defaultFeishuConfig: FeishuConfig = {
   appId: '',
   appSecret: '',
   chats: {},
+}
+
+export const defaultSeaTalkConfig: SeaTalkConfig = {
+  enabled: false,
+  appId: '',
+  appSecret: '',
+  mode: 'websocket',
+  dmPolicy: 'open',
+  allowFrom: [],
+  groupPolicy: 'open',
+  groupAllowFrom: [],
 }
 
 export const defaultKookDmConfig: KookDmConfig = {
@@ -351,6 +386,14 @@ export interface ChannelsState {
   wechatIsTesting: boolean
   wechatTestResult: { success: boolean; message: string } | null
 
+  // SeaTalk state
+  seatalk: SeaTalkConfig | null
+  seatalkIsLoading: boolean
+  seatalkGatewayStatus: SeaTalkGatewayStatusResponse
+  seatalkHasChanges: boolean
+  seatalkIsTesting: boolean
+  seatalkTestResult: { success: boolean; message: string } | null
+
   // Actions
   loadConfig: () => Promise<void>
   saveDiscordConfig: (config: DiscordConfig) => Promise<void>
@@ -417,6 +460,16 @@ export interface ChannelsState {
   clearWechatTestResult: () => void
   setWechatHasChanges: (hasChanges: boolean) => void
 
+  // SeaTalk actions
+  loadSeaTalkConfig: () => Promise<void>
+  saveSeaTalkConfig: (config: SeaTalkConfig) => Promise<void>
+  startSeaTalkGateway: () => Promise<void>
+  stopSeaTalkGateway: () => Promise<void>
+  refreshSeaTalkStatus: () => Promise<void>
+  testSeaTalkCredentials: (appId: string, appSecret: string) => Promise<boolean>
+  clearSeaTalkTestResult: () => void
+  setSeaTalkHasChanges: (hasChanges: boolean) => void
+
   // Toggle enabled and persist immediately
   toggleDiscordEnabled: (enabled: boolean, config: DiscordConfig) => Promise<void>
   toggleFeishuEnabled: (enabled: boolean, config: FeishuConfig) => Promise<void>
@@ -424,6 +477,7 @@ export interface ChannelsState {
   toggleKookEnabled: (enabled: boolean, config: KookConfig) => Promise<void>
   toggleWecomEnabled: (enabled: boolean, config: WeComConfig) => Promise<void>
   toggleWechatEnabled: (enabled: boolean, config: WeChatConfig) => Promise<void>
+  toggleSeaTalkEnabled: (enabled: boolean, config: SeaTalkConfig) => Promise<void>
 
   // Auto-start enabled gateways
   autoStartEnabledGateways: () => Promise<void>

--- a/packages/app/src/stores/channels.ts
+++ b/packages/app/src/stores/channels.ts
@@ -41,6 +41,9 @@ export type {
   WeChatConfig,
   WeChatGatewayStatus,
   WeChatGatewayStatusResponse,
+  SeaTalkConfig,
+  SeaTalkGatewayStatus,
+  SeaTalkGatewayStatusResponse,
   ChannelsConfig,
   GatewayStatusResponse,
   ChannelsState,
@@ -56,4 +59,5 @@ export {
   defaultKookDmConfig,
   defaultKookConfig,
   defaultEmailConfig,
+  defaultSeaTalkConfig,
 } from './channels-types'

--- a/packages/app/src/stores/channels/seatalk.ts
+++ b/packages/app/src/stores/channels/seatalk.ts
@@ -1,0 +1,190 @@
+import { invoke } from '@tauri-apps/api/core'
+import type {
+  SeaTalkConfig,
+  SeaTalkGatewayStatusResponse,
+  ChannelsState,
+} from '../channels-types'
+import { defaultSeaTalkConfig } from '../channels-types'
+import {
+  listChannels,
+  loadChannelConfig,
+  saveChannelConfig,
+  reloadChannels,
+  AmuxdUnreachableError,
+} from '@/lib/amuxd-channels'
+
+type ChannelsSet = (fn: ((state: ChannelsState) => Partial<ChannelsState>) | Partial<ChannelsState>) => void
+
+function statusFor(list: Awaited<ReturnType<typeof listChannels>>): SeaTalkGatewayStatusResponse {
+  const entry = list.find((c) => c.platform === 'seatalk')
+  if (!entry) return { status: 'disconnected' }
+  if (entry.lastError) return { status: 'error', errorMessage: entry.lastError }
+  if (entry.connected) return { status: 'connected' }
+  if (entry.enabled) return { status: 'connecting' }
+  return { status: 'disconnected' }
+}
+
+function describe(e: unknown): string {
+  if (e instanceof AmuxdUnreachableError) return 'amuxd not running. Start amuxd and try again.'
+  return e instanceof Error ? e.message : String(e)
+}
+
+export function createSeaTalkActions(set: ChannelsSet) {
+  return {
+    loadSeaTalkConfig: async () => {
+      set({ seatalkIsLoading: true, error: null })
+      try {
+        const [list, storedConfig] = await Promise.all([
+          listChannels(),
+          loadChannelConfig<SeaTalkConfig>('seatalk'),
+        ])
+        set({
+          seatalk: { ...defaultSeaTalkConfig, ...storedConfig },
+          seatalkGatewayStatus: statusFor(list),
+          seatalkIsLoading: false,
+          seatalkHasChanges: false,
+        })
+      } catch (error) {
+        set({
+          error: describe(error),
+          seatalkIsLoading: false,
+        })
+      }
+    },
+
+    saveSeaTalkConfig: async (config: SeaTalkConfig) => {
+      set({ seatalkIsLoading: true, error: null })
+      try {
+        await saveChannelConfig('seatalk', config)
+        await reloadChannels()
+        set({
+          seatalk: config,
+          seatalkIsLoading: false,
+        })
+      } catch (error) {
+        set({
+          error: describe(error),
+          seatalkIsLoading: false,
+        })
+        throw error
+      }
+    },
+
+    startSeaTalkGateway: async () => {
+      set({ seatalkIsLoading: true, error: null })
+      try {
+        let cfg: SeaTalkConfig = defaultSeaTalkConfig
+        set((state) => {
+          cfg = state.seatalk ?? defaultSeaTalkConfig
+          return {}
+        })
+        const enabled = { ...cfg, enabled: true }
+        await saveChannelConfig('seatalk', enabled)
+        await reloadChannels()
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        const list = await listChannels()
+        set({
+          seatalk: enabled,
+          seatalkGatewayStatus: statusFor(list),
+          seatalkIsLoading: false,
+          seatalkHasChanges: false,
+        })
+      } catch (error) {
+        const errorMessage = describe(error)
+        set({
+          error: errorMessage,
+          seatalkIsLoading: false,
+          seatalkGatewayStatus: {
+            status: 'error',
+            errorMessage,
+          },
+        })
+        throw error
+      }
+    },
+
+    stopSeaTalkGateway: async () => {
+      set({ seatalkIsLoading: true, error: null })
+      try {
+        let cfg: SeaTalkConfig = defaultSeaTalkConfig
+        set((state) => {
+          cfg = state.seatalk ?? defaultSeaTalkConfig
+          return {}
+        })
+        const disabled = { ...cfg, enabled: false }
+        await saveChannelConfig('seatalk', disabled)
+        await reloadChannels()
+        set({
+          seatalk: disabled,
+          seatalkGatewayStatus: { status: 'disconnected' },
+          seatalkIsLoading: false,
+        })
+      } catch (error) {
+        set({
+          error: describe(error),
+          seatalkIsLoading: false,
+        })
+        throw error
+      }
+    },
+
+    refreshSeaTalkStatus: async () => {
+      try {
+        const list = await listChannels()
+        set({ seatalkGatewayStatus: statusFor(list) })
+      } catch (error) {
+        console.error('Failed to refresh SeaTalk gateway status:', error)
+      }
+    },
+
+    testSeaTalkCredentials: async (appId: string, appSecret: string) => {
+      set({ seatalkIsTesting: true, seatalkTestResult: null, error: null })
+      try {
+        const message = await invoke<string>('test_seatalk_credentials', {
+          appId,
+          appSecret,
+        })
+        set({
+          seatalkIsTesting: false,
+          seatalkTestResult: { success: true, message },
+        })
+        return true
+      } catch (error) {
+        const message = describe(error)
+        set({
+          seatalkIsTesting: false,
+          seatalkTestResult: { success: false, message },
+        })
+        return false
+      }
+    },
+
+    clearSeaTalkTestResult: () => set({ seatalkTestResult: null }),
+    setSeaTalkHasChanges: (hasChanges: boolean) => set({ seatalkHasChanges: hasChanges }),
+
+    toggleSeaTalkEnabled: async (enabled: boolean, config: SeaTalkConfig) => {
+      const updatedConfig = { ...config, enabled }
+      try {
+        await saveChannelConfig('seatalk', updatedConfig)
+        await reloadChannels()
+        set({ seatalk: updatedConfig, seatalkHasChanges: false })
+        if (enabled) {
+          set({ seatalkIsLoading: true })
+          await new Promise((resolve) => setTimeout(resolve, 1000))
+          try {
+            const list = await listChannels()
+            set({ seatalkGatewayStatus: statusFor(list), seatalkIsLoading: false })
+          } catch (error) {
+            console.error('[SeaTalk] Status check after toggle failed:', error)
+            set({ seatalkIsLoading: false, error: describe(error) })
+          }
+        } else {
+          set({ seatalkGatewayStatus: { status: 'disconnected' } })
+        }
+      } catch (error) {
+        console.error('[SeaTalk] Toggle enabled failed:', error)
+        set({ error: describe(error) })
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Add a SeaTalk gateway (WebSocket mode) that receives group `@bot` mentions and DMs, routes them into TeamClaw agent sessions, and replies via the SeaTalk messaging API.
- Wire SeaTalk through amuxd channel config/CLI, desktop settings UI, build-feature flags, and a real App ID/Secret credential probe.
- Harden register parsing (missing `code` means success), strip leading `@mentions`, surface agent/send failures back to chat when possible, and document required portal permissions.

## Test plan
- [ ] Settings → Channels → SeaTalk: paste App ID/Secret, click Test → Credentials valid
- [ ] Save + Start gateway → status Connected; SeaTalk portal WebSocket Re-verify succeeds
- [ ] Portal has permissions: Send Message to Group Chat (+ Send Message to Bot User for DMs), Bot Online, event `new_mentioned_message_received_from_group_chat` subscribed
- [ ] Add bot to a group, `@Bot 你好` → agent reply appears in the group
- [ ] Confirm `amuxd.managed.log` shows `ws event received` → `reply ready` without `app permission denied`
- [ ] `cargo test -p teamclaw-gateway seatalk::tests`


Made with [Cursor](https://cursor.com)