### PR TITLE
Add manage_mcp tool to teamclaw-introspect sidecar

### DIFF
--- a/apps/desktop/crates/teamclaw-introspect/src/capabilities.rs
+++ b/apps/desktop/crates/teamclaw-introspect/src/capabilities.rs
@@ -22,6 +22,10 @@ pub fn is_channel_bound_pub(name: &str, channels: &Value) -> bool {
             non_empty_str(ch.get("appId").or_else(|| ch.get("app_id")))
                 && non_empty_str(ch.get("appSecret").or_else(|| ch.get("app_secret")))
         }
+        "seatalk" => {
+            non_empty_str(ch.get("appId").or_else(|| ch.get("app_id")))
+                && non_empty_str(ch.get("appSecret").or_else(|| ch.get("app_secret")))
+        }
         "kook" => non_empty_str(ch.get("token")),
         "wechat" => non_empty_str(ch.get("botToken").or_else(|| ch.get("bot_token"))),
         _ => false,
@@ -57,7 +61,7 @@ fn build_overview(workspace: &str) -> Result<Value, String> {
     let config = crate::config::read_teamclaw_config(workspace)?;
 
     let channels_val = config.get("channels").cloned().unwrap_or(json!({}));
-    let channel_names = ["wecom", "discord", "email", "feishu", "kook", "wechat"];
+    let channel_names = ["wecom", "discord", "email", "feishu", "kook", "wechat", "seatalk"];
     let mut bound = Vec::new();
     let mut unbound = Vec::new();
     for name in channel_names {

--- a/apps/desktop/crates/teamclaw-introspect/src/channels.rs
+++ b/apps/desktop/crates/teamclaw-introspect/src/channels.rs
@@ -6,6 +6,7 @@ const SENSITIVE: &[(&str, &[&str])] = &[
     ("wecom", &["secret", "encodingAesKey"]),
     ("discord", &["token"]),
     ("feishu", &["appSecret"]),
+    ("seatalk", &["appSecret"]),
     ("email", &["gmailClientSecret", "password"]),
     ("kook", &["token"]),
     ("wechat", &["botToken"]),
@@ -60,7 +61,7 @@ fn get_channels(workspace: &str, channel: Option<&str>) -> Result<Value, String>
             "config": redact(name, ch_cfg),
         }))
     } else {
-        let all_channels = ["wecom", "discord", "feishu", "email", "kook", "wechat"];
+        let all_channels = ["wecom", "discord", "feishu", "email", "kook", "wechat", "seatalk"];
         let result: serde_json::Map<String, Value> = all_channels
             .iter()
             .map(|name| {

--- a/apps/desktop/crates/teamclaw-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclaw-introspect/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod cron;
 mod env_vars;
 mod knowledge;
+mod mcp;
 mod roles;
 mod send;
 mod session;
@@ -90,7 +91,7 @@ fn tool_definitions() -> Value {
                     "channel": {
                         "type": "string",
                         "description": "The channel to send through, or 'all' to broadcast to all configured channels.",
-                        "enum": ["all", "wecom", "discord", "email", "feishu", "kook", "wechat"]
+                        "enum": ["all", "wecom", "discord", "email", "feishu", "kook", "wechat", "seatalk"]
                     },
                     "message": {
                         "type": "string",
@@ -281,12 +282,65 @@ fn tool_definitions() -> Value {
                     },
                     "channel": {
                         "type": "string",
-                        "enum": ["wecom", "discord", "feishu", "email", "kook", "wechat"],
+                        "enum": ["wecom", "discord", "feishu", "email", "kook", "wechat", "seatalk"],
                         "description": "Target channel. Required for set; optional for get (omit to get all channels)."
                     },
                     "config": {
                         "type": "object",
                         "description": "Channel config fields to set. Required for set. Fields vary by channel:\n- wecom: botId, secret, encodingAesKey, ownerId\n- discord: token, dm, guilds\n- feishu: appId, appSecret, chats\n- email: provider, gmailEmail, gmailClientId, gmailClientSecret (or imapServer, smtpServer, username, password for custom)\n- kook: token, dm, guilds\n- wechat: botToken, accountId, baseUrl"
+                    }
+                },
+                "required": ["action"]
+            }
+        },
+        {
+            "name": "manage_mcp",
+            "description": "Manage MCP servers for this workspace: list configured servers, get one by name, add/update a local (stdio) or remote (HTTP) server, enable/disable, or remove a custom server. Built-in servers (teamclaw-introspect, playwright, chrome-control, autoui) cannot be deleted; team-shared servers under teamclaw-team/.mcp cannot be edited or deleted here. Env/header secret values are redacted on list/get. Changes require an agent runtime restart to take effect.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["list", "get", "add", "update", "remove", "enable", "disable"],
+                        "description": "The action to perform."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "MCP server name. Required for get/add/update/remove/enable/disable."
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["local", "remote"],
+                        "description": "Server kind. Required for add; optional for update."
+                    },
+                    "command": {
+                        "description": "Local stdio command as an argv array, or a whitespace-separated string (e.g. 'npx -y @modelcontextprotocol/server-filesystem /tmp'). Required for add when type=local.",
+                        "anyOf": [
+                            { "type": "string" },
+                            { "type": "array", "items": { "type": "string" } }
+                        ]
+                    },
+                    "environment": {
+                        "type": "object",
+                        "description": "Environment variables for local servers (string values).",
+                        "additionalProperties": { "type": "string" }
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "Base URL for remote HTTP MCP servers. Required for add when type=remote."
+                    },
+                    "headers": {
+                        "type": "object",
+                        "description": "HTTP headers for remote servers (string values).",
+                        "additionalProperties": { "type": "string" }
+                    },
+                    "enabled": {
+                        "type": "boolean",
+                        "description": "Whether the server is enabled (default true on add)."
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Optional timeout in milliseconds."
                     }
                 },
                 "required": ["action"]
@@ -464,6 +518,13 @@ async fn handle_request(req: &Value, workspace: &str, api_port: u16) -> Option<V
                         Err(e) => tool_err(&e),
                     }
                 }
+                "manage_mcp" => match mcp::handle(workspace, api_port, &arguments).await {
+                    Ok(v) => {
+                        let text = serde_json::to_string_pretty(&v).unwrap_or_default();
+                        tool_ok(&text)
+                    }
+                    Err(e) => tool_err(&e),
+                },
                 "get_session_deeplink" => match session::handle(workspace, &arguments) {
                     Ok(v) => {
                         let text = serde_json::to_string_pretty(&v).unwrap_or_default();

--- a/apps/desktop/crates/teamclaw-introspect/src/mcp.rs
+++ b/apps/desktop/crates/teamclaw-introspect/src/mcp.rs
@@ -1,0 +1,519 @@
+use serde_json::{json, Map, Value};
+
+/// MCP names TeamClaw auto-injects — cannot be deleted via this tool.
+const INHERENT_MCP_NAMES: &[&str] = &[
+    "playwright",
+    "chrome-control",
+    "autoui",
+    "teamclaw-introspect",
+];
+
+pub async fn handle(workspace: &str, api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let action = arguments
+        .get("action")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: action")?;
+
+    match action {
+        "list" => list_servers(workspace, api_port).await,
+        "get" => {
+            let name = require_name(arguments)?;
+            get_server(workspace, api_port, name).await
+        }
+        "add" => add_server(workspace, api_port, arguments).await,
+        "update" => update_server(workspace, api_port, arguments).await,
+        "remove" | "delete" => {
+            let name = require_name(arguments)?;
+            remove_server(workspace, api_port, name).await
+        }
+        "enable" => set_enabled(workspace, api_port, require_name(arguments)?, true).await,
+        "disable" => set_enabled(workspace, api_port, require_name(arguments)?, false).await,
+        unknown => Err(format!(
+            "Unknown action: '{unknown}'. Valid actions: list, get, add, update, remove, enable, disable"
+        )),
+    }
+}
+
+fn require_name(arguments: &Value) -> Result<&str, String> {
+    arguments
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "Missing field: name".to_string())
+}
+
+fn is_inherent(name: &str) -> bool {
+    INHERENT_MCP_NAMES.contains(&name)
+}
+
+async fn fetch_servers(workspace: &str, api_port: u16) -> Result<Map<String, Value>, String> {
+    let resp = post_api(api_port, "/mcp-get", &json!({ "workspace": workspace })).await?;
+    resp.as_object()
+        .cloned()
+        .ok_or_else(|| "MCP get response is not an object".to_string())
+}
+
+async fn put_servers(
+    workspace: &str,
+    api_port: u16,
+    servers: &Map<String, Value>,
+) -> Result<Value, String> {
+    post_api(
+        api_port,
+        "/mcp-put",
+        &json!({
+            "workspace": workspace,
+            "servers": Value::Object(servers.clone()),
+        }),
+    )
+    .await
+}
+
+async fn list_servers(workspace: &str, api_port: u16) -> Result<Value, String> {
+    let servers = fetch_servers(workspace, api_port).await?;
+    let mut out = Map::new();
+    for (name, cfg) in servers {
+        out.insert(name, redact_server(&cfg));
+    }
+    Ok(json!({
+        "servers": out,
+        "note": "Secret environment/header values are redacted. Mutations require an agent runtime restart to take effect."
+    }))
+}
+
+async fn get_server(workspace: &str, api_port: u16, name: &str) -> Result<Value, String> {
+    let servers = fetch_servers(workspace, api_port).await?;
+    let cfg = servers
+        .get(name)
+        .ok_or_else(|| format!("MCP server '{name}' not found"))?;
+    Ok(json!({
+        "name": name,
+        "config": redact_server(cfg),
+    }))
+}
+
+async fn add_server(workspace: &str, api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let name = require_name(arguments)?;
+    if is_inherent(name) {
+        return Err(format!(
+            "'{name}' is a built-in TeamClaw MCP server and cannot be re-added. Use enable/disable or update instead."
+        ));
+    }
+
+    let mut servers = fetch_servers(workspace, api_port).await?;
+    if let Some(existing) = servers.get(name) {
+        if source_of(existing) == Some("team") {
+            return Err(format!(
+                "'{name}' is a team-shared MCP server (managed under teamclaw-team/.mcp). Cannot overwrite from here."
+            ));
+        }
+        return Err(format!(
+            "MCP server '{name}' already exists. Use action=update to modify it."
+        ));
+    }
+
+    let config = build_config(arguments, None)?;
+    servers.insert(name.to_string(), config);
+    let outcome = put_servers(workspace, api_port, &servers).await?;
+    Ok(json!({
+        "ok": true,
+        "action": "add",
+        "name": name,
+        "outcome": outcome.get("outcome").cloned().unwrap_or(json!("restart_required")),
+        "note": "Restart the agent runtime for the new MCP server to become available."
+    }))
+}
+
+async fn update_server(workspace: &str, api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let name = require_name(arguments)?;
+    let mut servers = fetch_servers(workspace, api_port).await?;
+    let existing = servers
+        .get(name)
+        .cloned()
+        .ok_or_else(|| format!("MCP server '{name}' not found"))?;
+
+    if source_of(&existing) == Some("team") {
+        return Err(format!(
+            "'{name}' is a team-shared MCP server (managed under teamclaw-team/.mcp). Edit the team file and sync instead."
+        ));
+    }
+
+    let config = if is_inherent(name) {
+        patch_inherent(&existing, arguments)?
+    } else {
+        build_config(arguments, Some(&existing))?
+    };
+    servers.insert(name.to_string(), config);
+    let outcome = put_servers(workspace, api_port, &servers).await?;
+    Ok(json!({
+        "ok": true,
+        "action": "update",
+        "name": name,
+        "outcome": outcome.get("outcome").cloned().unwrap_or(json!("restart_required")),
+        "note": "Restart the agent runtime for MCP changes to take effect."
+    }))
+}
+
+async fn remove_server(workspace: &str, api_port: u16, name: &str) -> Result<Value, String> {
+    if is_inherent(name) {
+        return Err(format!(
+            "'{name}' is a built-in TeamClaw MCP server and cannot be deleted. Use disable instead."
+        ));
+    }
+
+    let mut servers = fetch_servers(workspace, api_port).await?;
+    let existing = servers
+        .get(name)
+        .ok_or_else(|| format!("MCP server '{name}' not found"))?;
+    if source_of(existing) == Some("team") {
+        return Err(format!(
+            "'{name}' is a team-shared MCP server and cannot be deleted from the workspace. Remove it from teamclaw-team/.mcp instead."
+        ));
+    }
+
+    servers.remove(name);
+    let outcome = put_servers(workspace, api_port, &servers).await?;
+    Ok(json!({
+        "ok": true,
+        "action": "remove",
+        "name": name,
+        "outcome": outcome.get("outcome").cloned().unwrap_or(json!("restart_required")),
+        "note": "Restart the agent runtime for MCP changes to take effect."
+    }))
+}
+
+async fn set_enabled(
+    workspace: &str,
+    api_port: u16,
+    name: &str,
+    enabled: bool,
+) -> Result<Value, String> {
+    let mut servers = fetch_servers(workspace, api_port).await?;
+    let mut existing = servers
+        .get(name)
+        .cloned()
+        .ok_or_else(|| format!("MCP server '{name}' not found"))?;
+
+    if source_of(&existing) == Some("team") {
+        return Err(format!(
+            "'{name}' is a team-shared MCP server (managed under teamclaw-team/.mcp). Enable/disable it there."
+        ));
+    }
+
+    if let Some(obj) = existing.as_object_mut() {
+        obj.insert("enabled".to_string(), json!(enabled));
+        // Drop API-only provenance before PUT.
+        obj.remove("source");
+    }
+    servers.insert(name.to_string(), existing);
+    let outcome = put_servers(workspace, api_port, &servers).await?;
+    Ok(json!({
+        "ok": true,
+        "action": if enabled { "enable" } else { "disable" },
+        "name": name,
+        "enabled": enabled,
+        "outcome": outcome.get("outcome").cloned().unwrap_or(json!("restart_required")),
+        "note": "Restart the agent runtime for MCP changes to take effect."
+    }))
+}
+
+fn source_of(cfg: &Value) -> Option<&str> {
+    cfg.get("source").and_then(|v| v.as_str())
+}
+
+/// Build a full config for add, or merge onto existing for update.
+fn build_config(arguments: &Value, existing: Option<&Value>) -> Result<Value, String> {
+    let server_type = arguments
+        .get("type")
+        .and_then(|v| v.as_str())
+        .or_else(|| existing.and_then(|e| e.get("type")).and_then(|v| v.as_str()))
+        .unwrap_or("local");
+
+    if server_type != "local" && server_type != "remote" {
+        return Err(format!(
+            "Invalid type '{server_type}'. Valid types: local, remote"
+        ));
+    }
+
+    let enabled = arguments
+        .get("enabled")
+        .and_then(|v| v.as_bool())
+        .or_else(|| existing.and_then(|e| e.get("enabled")).and_then(|v| v.as_bool()))
+        .unwrap_or(true);
+
+    let mut cfg = json!({
+        "type": server_type,
+        "enabled": enabled,
+    });
+
+    if server_type == "local" {
+        let command = parse_command(arguments.get("command"))
+            .or_else(|| {
+                existing
+                    .and_then(|e| e.get("command"))
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                            .collect::<Vec<_>>()
+                    })
+            })
+            .ok_or("Missing field: command (required for type=local)")?;
+        if command.is_empty() {
+            return Err("command must not be empty".to_string());
+        }
+        cfg["command"] = json!(command);
+
+        if let Some(env) = arguments.get("environment") {
+            if !env.is_object() {
+                return Err("environment must be a JSON object of string values".to_string());
+            }
+            cfg["environment"] = env.clone();
+        } else if let Some(env) = existing.and_then(|e| e.get("environment")) {
+            if env.as_object().map(|o| !o.is_empty()).unwrap_or(false) {
+                cfg["environment"] = env.clone();
+            }
+        }
+    } else {
+        let url = arguments
+            .get("url")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .or_else(|| {
+                existing
+                    .and_then(|e| e.get("url"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            })
+            .ok_or("Missing field: url (required for type=remote)")?;
+        cfg["url"] = json!(url);
+
+        if let Some(headers) = arguments.get("headers") {
+            if !headers.is_object() {
+                return Err("headers must be a JSON object of string values".to_string());
+            }
+            cfg["headers"] = headers.clone();
+        } else if let Some(headers) = existing.and_then(|e| e.get("headers")) {
+            if headers.as_object().map(|o| !o.is_empty()).unwrap_or(false) {
+                cfg["headers"] = headers.clone();
+            }
+        }
+    }
+
+    if let Some(timeout) = arguments
+        .get("timeout")
+        .and_then(|v| v.as_u64())
+        .or_else(|| existing.and_then(|e| e.get("timeout")).and_then(|v| v.as_u64()))
+    {
+        cfg["timeout"] = json!(timeout);
+    }
+
+    Ok(cfg)
+}
+
+/// Inherent servers: only `enabled` and `environment` may be patched.
+fn patch_inherent(existing: &Value, arguments: &Value) -> Result<Value, String> {
+    if arguments.get("type").is_some()
+        || arguments.get("command").is_some()
+        || arguments.get("url").is_some()
+        || arguments.get("headers").is_some()
+    {
+        return Err(
+            "Built-in MCP servers only support updating enabled and environment. Use enable/disable for on/off."
+                .to_string(),
+        );
+    }
+
+    let mut cfg = existing.clone();
+    let obj = cfg
+        .as_object_mut()
+        .ok_or("existing config is not an object")?;
+    obj.remove("source");
+
+    if let Some(enabled) = arguments.get("enabled").and_then(|v| v.as_bool()) {
+        obj.insert("enabled".to_string(), json!(enabled));
+    }
+    if let Some(env) = arguments.get("environment") {
+        if !env.is_object() {
+            return Err("environment must be a JSON object of string values".to_string());
+        }
+        if env.as_object().map(|o| o.is_empty()).unwrap_or(true) {
+            obj.remove("environment");
+        } else {
+            obj.insert("environment".to_string(), env.clone());
+        }
+    }
+    Ok(cfg)
+}
+
+fn parse_command(value: Option<&Value>) -> Option<Vec<String>> {
+    let value = value?;
+    if let Some(arr) = value.as_array() {
+        let parts: Vec<String> = arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+        return if parts.is_empty() { None } else { Some(parts) };
+    }
+    if let Some(s) = value.as_str() {
+        let parts: Vec<String> = s.split_whitespace().map(|p| p.to_string()).collect();
+        return if parts.is_empty() { None } else { Some(parts) };
+    }
+    None
+}
+
+fn redact_server(cfg: &Value) -> Value {
+    let mut out = cfg.clone();
+    let Some(obj) = out.as_object_mut() else {
+        return out;
+    };
+    if let Some(env) = obj.get_mut("environment").and_then(|v| v.as_object_mut()) {
+        for (_k, v) in env.iter_mut() {
+            if v.as_str().map(|s| !s.is_empty()).unwrap_or(false) {
+                *v = json!("[set]");
+            }
+        }
+    }
+    if let Some(headers) = obj.get_mut("headers").and_then(|v| v.as_object_mut()) {
+        for (_k, v) in headers.iter_mut() {
+            if v.as_str().map(|s| !s.is_empty()).unwrap_or(false) {
+                *v = json!("[set]");
+            }
+        }
+    }
+    out
+}
+
+async fn post_api(api_port: u16, path: &str, body: &Value) -> Result<Value, String> {
+    let url = format!("http://127.0.0.1:{api_port}{path}");
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}. Is the TeamClaw app running?"))?;
+
+    if !resp.status().is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("API error: {text}"));
+    }
+
+    resp.json::<Value>()
+        .await
+        .map_err(|e| format!("Failed to parse response: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_command_string_and_array() {
+        assert_eq!(
+            parse_command(Some(&json!("npx -y @modelcontextprotocol/server-filesystem /tmp"))),
+            Some(vec![
+                "npx".into(),
+                "-y".into(),
+                "@modelcontextprotocol/server-filesystem".into(),
+                "/tmp".into()
+            ])
+        );
+        assert_eq!(
+            parse_command(Some(&json!(["node", "server.js"]))),
+            Some(vec!["node".into(), "server.js".into()])
+        );
+        assert_eq!(parse_command(Some(&json!(""))), None);
+    }
+
+    #[test]
+    fn build_config_local_requires_command() {
+        let err = build_config(&json!({ "type": "local" }), None).unwrap_err();
+        assert!(err.contains("command"));
+    }
+
+    #[test]
+    fn build_config_remote_requires_url() {
+        let err = build_config(&json!({ "type": "remote" }), None).unwrap_err();
+        assert!(err.contains("url"));
+    }
+
+    #[test]
+    fn build_config_local_ok() {
+        let cfg = build_config(
+            &json!({
+                "type": "local",
+                "command": ["npx", "-y", "foo"],
+                "environment": { "TOKEN": "secret" }
+            }),
+            None,
+        )
+        .unwrap();
+        assert_eq!(cfg["type"], "local");
+        assert_eq!(cfg["enabled"], true);
+        assert_eq!(cfg["command"][0], "npx");
+        assert_eq!(cfg["environment"]["TOKEN"], "secret");
+    }
+
+    #[test]
+    fn redact_hides_secrets() {
+        let redacted = redact_server(&json!({
+            "type": "local",
+            "command": ["npx"],
+            "environment": { "API_KEY": "super-secret" },
+            "headers": { "Authorization": "Bearer x" }
+        }));
+        assert_eq!(redacted["environment"]["API_KEY"], "[set]");
+        assert_eq!(redacted["headers"]["Authorization"], "[set]");
+        assert_eq!(redacted["command"][0], "npx");
+    }
+
+    #[test]
+    fn patch_inherent_rejects_command_change() {
+        let existing = json!({
+            "type": "local",
+            "enabled": true,
+            "command": ["npx", "playwright"],
+            "source": "inherent"
+        });
+        let err = patch_inherent(&existing, &json!({ "command": ["evil"] })).unwrap_err();
+        assert!(err.contains("Built-in"));
+    }
+
+    #[test]
+    fn patch_inherent_allows_enabled() {
+        let existing = json!({
+            "type": "local",
+            "enabled": false,
+            "command": ["npx", "playwright"],
+            "source": "inherent"
+        });
+        let patched = patch_inherent(&existing, &json!({ "enabled": true })).unwrap();
+        assert_eq!(patched["enabled"], true);
+        assert!(patched.get("source").is_none());
+    }
+
+    #[tokio::test]
+    async fn unknown_action_errors() {
+        let err = handle(".", 13144, &json!({ "action": "nope" }))
+            .await
+            .unwrap_err();
+        assert!(err.contains("Unknown action"));
+    }
+
+    #[tokio::test]
+    async fn remove_inherent_rejected_without_network() {
+        // Validation runs before API calls for inherent names.
+        let err = handle(
+            ".",
+            13144,
+            &json!({ "action": "remove", "name": "teamclaw-introspect" }),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("built-in"));
+    }
+}

--- a/apps/desktop/crates/teamclaw-introspect/src/send.rs
+++ b/apps/desktop/crates/teamclaw-introspect/src/send.rs
@@ -58,7 +58,7 @@ async fn send_broadcast(
     let config = crate::config::read_teamclaw_config(workspace)?;
     let channels_val = config.get("channels").cloned().unwrap_or(json!({}));
 
-    let channel_names = ["wecom", "discord", "feishu", "kook", "wechat"];
+    let channel_names = ["wecom", "discord", "feishu", "kook", "wechat", "seatalk"];
     let mut results = serde_json::Map::new();
     let mut sent_count = 0usize;
     let mut failed_count = 0usize;

--- a/apps/desktop/src/commands/daemon_http.rs
+++ b/apps/desktop/src/commands/daemon_http.rs
@@ -225,14 +225,10 @@ pub struct MaterializeTeamMcpResponse {
     pub added_count: usize,
 }
 
-/// Ask the local daemon to materialize team MCP definitions into `opencode.json`.
-///
-/// Best-effort from team-git join: returns `Err` when the daemon HTTP listener
-/// is unavailable; callers should log and continue (materialization also happens
-/// lazily on `GET /v1/workspaces/:id/mcp`).
-pub async fn materialize_team_mcp_via_daemon(
-    workspace_path: &str,
-) -> Result<MaterializeTeamMcpResponse, String> {
+async fn exchange_daemon_workspace_token(
+    scopes: &[&str],
+    ttl_seconds: u64,
+) -> Result<(String, String), String> {
     let (base, root_token) =
         daemon_http_base().ok_or_else(|| "daemon http port/token files not present".to_string())?;
     let client = reqwest::Client::new();
@@ -240,8 +236,8 @@ pub async fn materialize_team_mcp_via_daemon(
         .post(format!("{base}/v1/auth/exchange"))
         .header("Authorization", format!("Bearer {root_token}"))
         .json(&serde_json::json!({
-            "scopes": ["workspace:write"],
-            "ttl_seconds": 300,
+            "scopes": scopes,
+            "ttl_seconds": ttl_seconds,
         }))
         .send()
         .await
@@ -251,11 +247,25 @@ pub async fn materialize_team_mcp_via_daemon(
         .json()
         .await
         .map_err(|e| format!("auth exchange decode: {e}"))?;
+    Ok((base, exchange.token))
+}
+
+/// Ask the local daemon to materialize team MCP definitions into `opencode.json`.
+///
+/// Best-effort from team-git join: returns `Err` when the daemon HTTP listener
+/// is unavailable; callers should log and continue (materialization also happens
+/// lazily on `GET /v1/workspaces/:id/mcp`).
+pub async fn materialize_team_mcp_via_daemon(
+    workspace_path: &str,
+) -> Result<MaterializeTeamMcpResponse, String> {
+    let (base, token) =
+        exchange_daemon_workspace_token(&["workspace:write"], 300).await?;
 
     let ws_id = encode_workspace_id(workspace_path);
+    let client = reqwest::Client::new();
     client
         .post(format!("{base}/v1/workspaces/{ws_id}/mcp/materialize-team"))
-        .header("Authorization", format!("Bearer {}", exchange.token))
+        .header("Authorization", format!("Bearer {token}"))
         .send()
         .await
         .map_err(|e| format!("materialize-team request: {e}"))?
@@ -264,6 +274,48 @@ pub async fn materialize_team_mcp_via_daemon(
         .json()
         .await
         .map_err(|e| format!("materialize-team decode: {e}"))
+}
+
+/// `GET /v1/workspaces/:id/mcp` — merged MCP map for the workspace.
+pub async fn get_mcp_via_daemon(workspace_path: &str) -> Result<serde_json::Value, String> {
+    let (base, token) =
+        exchange_daemon_workspace_token(&["workspace:read", "workspace:write"], 300).await?;
+    let ws_id = encode_workspace_id(workspace_path);
+    let client = reqwest::Client::new();
+    client
+        .get(format!("{base}/v1/workspaces/{ws_id}/mcp"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| format!("mcp get request: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("mcp get: {e}"))?
+        .json()
+        .await
+        .map_err(|e| format!("mcp get decode: {e}"))
+}
+
+/// `PUT /v1/workspaces/:id/mcp` — replace workspace MCP map. Returns `{ outcome }`.
+pub async fn put_mcp_via_daemon(
+    workspace_path: &str,
+    servers: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let (base, token) =
+        exchange_daemon_workspace_token(&["workspace:read", "workspace:write"], 300).await?;
+    let ws_id = encode_workspace_id(workspace_path);
+    let client = reqwest::Client::new();
+    client
+        .put(format!("{base}/v1/workspaces/{ws_id}/mcp"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(servers)
+        .send()
+        .await
+        .map_err(|e| format!("mcp put request: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("mcp put: {e}"))?
+        .json()
+        .await
+        .map_err(|e| format!("mcp put decode: {e}"))
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/desktop/src/commands/introspect_api.rs
+++ b/apps/desktop/src/commands/introspect_api.rs
@@ -10,6 +10,8 @@
 //   POST /knowledge-delete  — delete a memory entry
 //   POST /env-var-set       — create or update an env var (`scope`: personal | team)
 //   POST /env-var-delete    — delete an env var (`scope`: personal | team)
+//   POST /mcp-get           — fetch merged workspace MCP map (daemon)
+//   POST /mcp-put           — replace workspace MCP map (daemon)
 //   POST /session-export    — export session messages as opencode-compatible JSON
 //
 // Uses raw TCP + manual HTTP parsing to stay minimal (no axum state needed).
@@ -101,6 +103,8 @@ pub async fn start_introspect_api(app: AppHandle) -> anyhow::Result<()> {
                 ("POST", "/env-var-delete") => handle_env_var_delete(&app_clone, body_bytes).await,
                 ("POST", "/session-export") => handle_session_export(&app_clone, body_bytes).await,
                 ("POST", "/channel-set") => handle_channel_set(&app_clone, body_bytes).await,
+                ("POST", "/mcp-get") => handle_mcp_get(&app_clone, body_bytes).await,
+                ("POST", "/mcp-put") => handle_mcp_put(&app_clone, body_bytes).await,
                 ("POST", "/git-credential-get") => {
                     handle_git_credential_get(&app_clone, body_bytes).await
                 }
@@ -562,7 +566,7 @@ async fn handle_channel_set(app: &AppHandle, body: &[u8]) -> Result<String, Stri
         .ok_or("Missing field: channel")?;
     let patch = v.get("config").ok_or("Missing field: config")?;
 
-    let valid_channels = ["wecom", "discord", "feishu", "email", "kook", "wechat"];
+    let valid_channels = ["wecom", "discord", "feishu", "email", "kook", "wechat", "seatalk"];
     if !valid_channels.contains(&channel) {
         return Err(format!(
             "Unknown channel: '{}'. Valid: {}",
@@ -608,6 +612,52 @@ async fn handle_channel_set(app: &AppHandle, body: &[u8]) -> Result<String, Stri
     super::env_vars::write_teamclaw_json(&workspace, &json)?;
 
     Ok(format!(r#"{{"ok":true,"channel":"{}"}}"#, channel))
+}
+
+fn resolve_workspace_path(app: &AppHandle, body: &serde_json::Value) -> Result<String, String> {
+    if let Some(ws) = body
+        .get("workspace")
+        .or_else(|| body.get("workspace_path"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return Ok(ws.to_string());
+    }
+    let registry = app.state::<super::window::WindowRegistry>();
+    registry
+        .current_workspace
+        .lock()
+        .ok()
+        .and_then(|cw| cw.clone())
+        .ok_or_else(|| "No workspace path set. Please select a workspace first.".to_string())
+}
+
+/// Body: `{ "workspace"?: string }`. Returns the merged MCP server map from amuxd.
+async fn handle_mcp_get(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value = if body.is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?
+    };
+    let workspace = resolve_workspace_path(app, &v)?;
+    let servers = super::daemon_http::get_mcp_via_daemon(&workspace).await?;
+    serde_json::to_string(&servers).map_err(|e| format!("Serialization error: {e}"))
+}
+
+/// Body: `{ "workspace"?: string, "servers": { ... } }`. Replaces workspace MCP map.
+async fn handle_mcp_put(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?;
+    let workspace = resolve_workspace_path(app, &v)?;
+    let servers = v
+        .get("servers")
+        .ok_or("Missing field: servers")?;
+    if !servers.is_object() {
+        return Err("servers must be a JSON object".to_string());
+    }
+    let result = super::daemon_http::put_mcp_via_daemon(&workspace, servers).await?;
+    serde_json::to_string(&result).map_err(|e| format!("Serialization error: {e}"))
 }
 
 /// Fetch a stored Git credential by ref. Body: `{"workspace_path": "...", "credential_ref": "..."}`.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "tauri": "node scripts/tauri-cli.js",
     "tauri:dev": "node scripts/update-tauri-config.js && node scripts/tauri-cli.js dev",
     "tauri:dev:daemon": "node scripts/update-tauri-config.js && node scripts/tauri-cli.js dev --force-amuxd",
+    "tauri:dev:introspect": "node scripts/update-tauri-config.js && node scripts/tauri-cli.js dev --force-introspect",
     "tauri:build": "node scripts/update-tauri-config.js && node scripts/tauri-cli.js build",
     "tauri:build:debug": "node scripts/update-tauri-config.js && node scripts/tauri-cli.js build --debug",
     "tauri:deeplink:clean": "node scripts/deeplink-dev.mjs clean",

--- a/scripts/ensure-introspect-sidecar.js
+++ b/scripts/ensure-introspect-sidecar.js
@@ -4,18 +4,70 @@
 const { spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
+const { installSidecarAtomic } = require("./lib/install-sidecar-atomic");
+
+const VERSION_PROBE_TIMEOUT_MS = 5_000;
+
+function readCargoPackageVersion(manifestPath) {
+  const raw = fs.readFileSync(manifestPath, "utf8");
+  const match = raw.match(/^\s*version\s*=\s*"([^"]+)"/m);
+  return match ? match[1] : null;
+}
+
+function parseVersionFromOutput(output) {
+  const match = String(output ?? "").match(/\b(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/);
+  return match ? match[1] : null;
+}
 
 /**
- * Build and install teamclaw-introspect into apps/desktop/binaries/ if missing.
- * Must run before main cargo/tauri build: build.rs panics when the file is absent (unless CI is set).
- * @param {NodeJS.ProcessEnv} env - Use the same env as cargo (e.g. CARGO_TARGET_DIR from createRustBuildEnv)
- * @param {{ logPrefix?: string }} [opts]
+ * Probe `--version` with a hard timeout. A corrupted / in-place-overwritten
+ * Mach-O on macOS can hang forever in UE without this.
+ */
+function readExecutableVersion(executable, env) {
+  if (!fs.existsSync(executable)) {
+    return null;
+  }
+  const result = spawnSync(executable, ["--version"], {
+    encoding: "utf8",
+    env,
+    timeout: VERSION_PROBE_TIMEOUT_MS,
+    killSignal: "SIGKILL",
+  });
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+  return parseVersionFromOutput(`${result.stdout}\n${result.stderr}`);
+}
+
+function shouldRebuildSidecar({ exists, expectedVersion, existingVersion }) {
+  if (!exists) {
+    return true;
+  }
+  if (!expectedVersion || !existingVersion) {
+    return true;
+  }
+  return expectedVersion !== existingVersion;
+}
+
+/**
+ * Build and install teamclaw-introspect into apps/desktop/binaries/ if missing,
+ * version-stale, or forced.
+ *
+ * Must run before main cargo/tauri build: build.rs panics when the file is
+ * absent (unless CI is set).
+ *
+ * @param {NodeJS.ProcessEnv} env - Use the same env as cargo (e.g. CARGO_TARGET_DIR)
+ * @param {{ logPrefix?: string, force?: boolean }} [opts]
  */
 function ensureTeamclawIntrospectSidecar(env, opts) {
   if (env.CI) {
     return;
   }
   const logPrefix = opts?.logPrefix ?? "[rust-cli]";
+  const force =
+    opts?.force === true ||
+    env.TEAMCLAW_FORCE_INTROSPECT_SIDECAR === "1" ||
+    env.TEAMCLAW_FORCE_INTROSPECT_SIDECAR === "true";
   const tauriDir = path.resolve(__dirname, "..", "apps/desktop");
   const target =
     env.TARGET ||
@@ -27,31 +79,69 @@ function ensureTeamclawIntrospectSidecar(env, opts) {
   if (!target) {
     return;
   }
-  const dest = path.join(tauriDir, "binaries", `teamclaw-introspect-${target}`);
-  if (fs.existsSync(dest)) {
+  const binName =
+    process.platform === "win32" ? "teamclaw-introspect.exe" : "teamclaw-introspect";
+  const destName =
+    process.platform === "win32"
+      ? `teamclaw-introspect-${target}.exe`
+      : `teamclaw-introspect-${target}`;
+  const dest = path.join(tauriDir, "binaries", destName);
+  const packageManifestPath = path.join(
+    tauriDir,
+    "crates",
+    "teamclaw-introspect",
+    "Cargo.toml",
+  );
+  const workspaceManifestPath = path.join(tauriDir, "Cargo.toml");
+  if (!fs.existsSync(packageManifestPath) || !fs.existsSync(workspaceManifestPath)) {
     return;
   }
-  const manifestPath = path.join(tauriDir, "crates", "teamclaw-introspect", "Cargo.toml");
-  if (!fs.existsSync(manifestPath)) {
+  const expectedVersion = readCargoPackageVersion(packageManifestPath);
+  const exists = fs.existsSync(dest);
+  // Force must skip the probe: a corrupted dest can hang even with a timeout.
+  const existingVersion = force ? null : readExecutableVersion(dest, env);
+  if (
+    !force &&
+    !shouldRebuildSidecar({ exists, expectedVersion, existingVersion })
+  ) {
     return;
+  }
+  if (force) {
+    console.log(`${logPrefix} Forcing teamclaw-introspect sidecar rebuild...`);
+  } else if (exists) {
+    console.log(
+      `${logPrefix} Rebuilding teamclaw-introspect sidecar (${existingVersion ?? "unknown"} -> ${expectedVersion ?? "unknown"})...`,
+    );
   }
   console.log(`${logPrefix} Building teamclaw-introspect sidecar...`);
   const targetDir = env.CARGO_TARGET_DIR || path.join(tauriDir, "target");
   const result = spawnSync(
     "cargo",
-    ["build", "--manifest-path", manifestPath, "--target-dir", targetDir],
+    [
+      "build",
+      "--manifest-path",
+      workspaceManifestPath,
+      "-p",
+      "teamclaw-introspect",
+      "--target-dir",
+      targetDir,
+    ],
     { stdio: "inherit", env },
   );
   if (result.status !== 0) {
     console.error(`${logPrefix} Failed to build teamclaw-introspect`);
     process.exit(1);
   }
-  const profile = "debug";
-  const binName = process.platform === "win32" ? "teamclaw-introspect.exe" : "teamclaw-introspect";
-  const built = path.join(targetDir, profile, binName);
-  const { installSidecarAtomic } = require("./lib/install-sidecar-atomic");
+  const built = path.join(targetDir, "debug", binName);
   installSidecarAtomic(built, dest);
   console.log(`${logPrefix} Installed ${dest}`);
 }
 
-module.exports = { ensureTeamclawIntrospectSidecar };
+module.exports = {
+  ensureTeamclawIntrospectSidecar,
+  parseVersionFromOutput,
+  readCargoPackageVersion,
+  readExecutableVersion,
+  shouldRebuildSidecar,
+  VERSION_PROBE_TIMEOUT_MS,
+};

--- a/scripts/tauri-cli.js
+++ b/scripts/tauri-cli.js
@@ -24,12 +24,16 @@ const bridgeTarget = extractTargetFromArgv(args);
  *   pnpm tauri:dev -- --skip-setup
  *   pnpm tauri:dev -- --skip-daemon-onboarding
  *   pnpm tauri:dev -- --force-amuxd
+ *   pnpm tauri:dev -- --force-introspect
  *   pnpm tauri:dev:daemon
+ *   pnpm tauri:dev:introspect
  *
  * Aliases: --skip-onboarding → --skip-daemon-onboarding
  *          --rebuild-daemon / --rebuild-amuxd → --force-amuxd
+ *          --rebuild-introspect → --force-introspect
  * Env fallbacks: TEAMCLAW_SKIP_SETUP=1, TEAMCLAW_SKIP_DAEMON_ONBOARDING=1,
- *                TEAMCLAW_FORCE_AMUXD_SIDECAR=1
+ *                TEAMCLAW_FORCE_AMUXD_SIDECAR=1,
+ *                TEAMCLAW_FORCE_INTROSPECT_SIDECAR=1
  */
 function applyDevSkipFlags(argv, env) {
   if (argv[0] !== "dev") {
@@ -44,6 +48,9 @@ function applyDevSkipFlags(argv, env) {
   let forceAmuxd =
     env.TEAMCLAW_FORCE_AMUXD_SIDECAR === "1" ||
     env.TEAMCLAW_FORCE_AMUXD_SIDECAR === "true";
+  let forceIntrospect =
+    env.TEAMCLAW_FORCE_INTROSPECT_SIDECAR === "1" ||
+    env.TEAMCLAW_FORCE_INTROSPECT_SIDECAR === "true";
 
   const filtered = [];
   for (const arg of argv) {
@@ -63,6 +70,10 @@ function applyDevSkipFlags(argv, env) {
       forceAmuxd = true;
       continue;
     }
+    if (arg === "--force-introspect" || arg === "--rebuild-introspect") {
+      forceIntrospect = true;
+      continue;
+    }
     filtered.push(arg);
   }
 
@@ -75,10 +86,13 @@ function applyDevSkipFlags(argv, env) {
   if (forceAmuxd) {
     env.TEAMCLAW_FORCE_AMUXD_SIDECAR = "1";
   }
+  if (forceIntrospect) {
+    env.TEAMCLAW_FORCE_INTROSPECT_SIDECAR = "1";
+  }
 
-  if (skipSetup || skipDaemonOnboarding || forceAmuxd) {
+  if (skipSetup || skipDaemonOnboarding || forceAmuxd || forceIntrospect) {
     console.log(
-      `[tauri-cli] dev flags: setup_skip=${skipSetup}, daemon_onboarding_skip=${skipDaemonOnboarding}, force_amuxd=${forceAmuxd}`,
+      `[tauri-cli] dev flags: setup_skip=${skipSetup}, daemon_onboarding_skip=${skipDaemonOnboarding}, force_amuxd=${forceAmuxd}, force_introspect=${forceIntrospect}`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Add a `manage_mcp` introspect tool so agents can list/get/add/update/remove/enable/disable workspace MCP servers (local stdio + remote HTTP), with secret redaction on read and guards against deleting built-in or team-shared servers.
- Bridge introspect ↔ amuxd via new `/mcp-get` and `/mcp-put` desktop API handlers that call daemon workspace MCP endpoints.
- Improve sidecar rebuild flow (`tauri:dev:introspect` / `--force-introspect`) so introspect binary changes are picked up during desktop development.

## Test plan
- [ ] `pnpm tauri:dev:introspect` (or `tauri:dev --force-introspect`) rebuilds and runs the new sidecar
- [ ] From an agent with teamclaw-introspect: `manage_mcp` action=`list` returns the merged MCP map with secrets redacted
- [ ] `manage_mcp` action=`add` with a local stdio server, then `get`/`enable`/`disable`, then `remove`
- [ ] Built-in servers (`teamclaw-introspect`, `playwright`, etc.) cannot be deleted
- [ ] Team-shared MCP under `teamclaw-team/.mcp` cannot be edited/deleted via this tool
- [ ] After add/update, restart agent runtime and confirm the new MCP is available


Made with [Cursor](https://cursor.com)