### PR TITLE
fix(daemon): persist gateway user messages and fail closed on permission stalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9550,6 +9550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12039,6 +12045,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -39,7 +39,7 @@ dirs = "6"
 # Utilities
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 anyhow = "1"
 thiserror = "2"

--- a/apps/daemon/src/backend/cloud_api/messages.rs
+++ b/apps/daemon/src/backend/cloud_api/messages.rs
@@ -57,6 +57,59 @@ pub(super) struct InsertMessageRequest<'a> {
     pub(super) created_at: Option<&'a str>,
 }
 
+/// Namespace for deterministic gateway message UUIDs derived from channel-
+/// native ids (SeaTalk/WeCom/Feishu/…). `messages.id` is a UUID column — using
+/// the raw channel id as the PK makes inserts fail and leaves agent-only
+/// history in the UI.
+const GATEWAY_MSG_NS: uuid::Uuid = uuid::Uuid::from_bytes([
+    0x74, 0x65, 0x61, 0x6d, // "team"
+    0x63, 0x6c, 0x61, 0x77, // "claw"
+    0x67, 0x77, 0x6d, 0x73, // "gwms"
+    0x67, 0x69, 0x64, 0x01, // "gid\x01"
+]);
+
+/// Build a UUID primary key (+ optional metadata) for a gateway-originated
+/// message. Channel-native ids are never used as the PK; they are stored under
+/// `metadata.external_message_id` and folded into a deterministic UUID v5 so
+/// retries stay idempotent.
+pub(super) fn gateway_message_id_and_metadata(
+    session_id: &str,
+    external_message_id: Option<&str>,
+    extra_metadata: Option<Value>,
+) -> (String, Option<Value>) {
+    let mut metadata = match extra_metadata {
+        Some(Value::Object(map)) => Value::Object(map),
+        Some(other) => serde_json::json!({ "extra": other }),
+        None => Value::Object(serde_json::Map::new()),
+    };
+
+    let id = match external_message_id.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(external) => {
+            if let Some(obj) = metadata.as_object_mut() {
+                obj.insert(
+                    "external_message_id".to_string(),
+                    Value::String(external.to_string()),
+                );
+            }
+            // Prefer the raw value when it is already a UUID (keeps older
+            // callers that passed UUIDs stable). Otherwise derive v5.
+            if let Ok(parsed) = uuid::Uuid::parse_str(external) {
+                parsed.to_string()
+            } else {
+                let name = format!("gateway:{session_id}:{external}");
+                uuid::Uuid::new_v5(&GATEWAY_MSG_NS, name.as_bytes()).to_string()
+            }
+        }
+        None => uuid::Uuid::new_v4().to_string(),
+    };
+
+    let metadata = match &metadata {
+        Value::Object(map) if map.is_empty() => None,
+        other => Some(other.clone()),
+    };
+    (id, metadata)
+}
+
 impl CloudApiBackend {
     pub(super) async fn messages_after_cursor_impl(
         &self,
@@ -85,9 +138,8 @@ impl CloudApiBackend {
         content: &str,
         external_message_id: Option<&str>,
     ) -> BackendResult<String> {
-        let id = external_message_id
-            .map(str::to_string)
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let (id, metadata) =
+            gateway_message_id_and_metadata(session_id, external_message_id, None);
         let message: CloudMessage = self
             .post(
                 &format!("/v1/sessions/{session_id}/messages"),
@@ -97,7 +149,7 @@ impl CloudApiBackend {
                     sender_actor_id,
                     content,
                     kind: "text",
-                    metadata: None,
+                    metadata,
                     turn_id: None,
                     reply_to_message_id: None,
                     model: None,
@@ -116,9 +168,8 @@ impl CloudApiBackend {
         content: &str,
         external_message_id: Option<&str>,
     ) -> BackendResult<String> {
-        let id = external_message_id
-            .map(str::to_string)
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let (id, metadata) =
+            gateway_message_id_and_metadata(session_id, external_message_id, None);
         let message: CloudMessage = self
             .post(
                 &format!("/v1/sessions/{session_id}/messages"),
@@ -128,7 +179,7 @@ impl CloudApiBackend {
                     sender_actor_id,
                     content,
                     kind: "agent_reply",
-                    metadata: None,
+                    metadata,
                     turn_id: None,
                     reply_to_message_id: None,
                     model: None,
@@ -148,10 +199,11 @@ impl CloudApiBackend {
         external_message_id: Option<&str>,
         attachments: Value,
     ) -> BackendResult<String> {
-        let id = external_message_id
-            .map(str::to_string)
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-        let metadata = serde_json::json!({ "attachments": attachments });
+        let (id, metadata) = gateway_message_id_and_metadata(
+            session_id,
+            external_message_id,
+            Some(serde_json::json!({ "attachments": attachments })),
+        );
         let message: CloudMessage = self
             .post(
                 &format!("/v1/sessions/{session_id}/messages"),
@@ -161,7 +213,7 @@ impl CloudApiBackend {
                     sender_actor_id,
                     content,
                     kind: "text",
-                    metadata: Some(metadata),
+                    metadata,
                     turn_id: None,
                     reply_to_message_id: None,
                     model: None,
@@ -310,5 +362,56 @@ mod tests {
         let items = vec![make_msg("a"), make_msg("b")];
         let out = CloudApiBackend::cursor_filter(items, Some("z"));
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn gateway_id_without_external_is_random_uuid() {
+        let (id, meta) = gateway_message_id_and_metadata("sess-1", None, None);
+        assert!(uuid::Uuid::parse_str(&id).is_ok());
+        assert!(meta.is_none());
+        let (id2, _) = gateway_message_id_and_metadata("sess-1", None, None);
+        assert_ne!(id, id2);
+    }
+
+    #[test]
+    fn gateway_id_with_native_channel_id_is_uuid_v5_and_stores_external() {
+        let native = "u7oirumAclCbrRQB-RCYnjzhvXNAhNTUFJTM6fDCaFsK-Jplxk2X23T2";
+        let (id, meta) = gateway_message_id_and_metadata("sess-1", Some(native), None);
+        assert!(uuid::Uuid::parse_str(&id).is_ok());
+        assert_ne!(id, native);
+        assert_eq!(
+            meta.as_ref().and_then(|m| m["external_message_id"].as_str()),
+            Some(native)
+        );
+        // Deterministic for idempotency.
+        let (id2, _) = gateway_message_id_and_metadata("sess-1", Some(native), None);
+        assert_eq!(id, id2);
+        // Different session ⇒ different id.
+        let (id3, _) = gateway_message_id_and_metadata("sess-2", Some(native), None);
+        assert_ne!(id, id3);
+    }
+
+    #[test]
+    fn gateway_id_preserves_uuid_external_ids() {
+        let external = "550e8400-e29b-41d4-a716-446655440000";
+        let (id, meta) = gateway_message_id_and_metadata("sess-1", Some(external), None);
+        assert_eq!(id, external);
+        assert_eq!(
+            meta.as_ref().and_then(|m| m["external_message_id"].as_str()),
+            Some(external)
+        );
+    }
+
+    #[test]
+    fn gateway_id_merges_attachments_metadata() {
+        let (id, meta) = gateway_message_id_and_metadata(
+            "sess-1",
+            Some("native-msg-1"),
+            Some(serde_json::json!({ "attachments": [{"filename": "a.png"}] })),
+        );
+        assert!(uuid::Uuid::parse_str(&id).is_ok());
+        let meta = meta.expect("metadata");
+        assert_eq!(meta["external_message_id"], "native-msg-1");
+        assert_eq!(meta["attachments"][0]["filename"], "a.png");
     }
 }

--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -32,6 +32,10 @@ use teamclaw_gateway::{
 /// hundreds of them is unreadable — the newest are the ones anyone switches
 /// back to.
 const GATEWAY_SESSION_LIST_LIMIT: u32 = 20;
+/// Bound how long a channel/gateway turn may wait for Active→Idle. Long enough
+/// for real tool use; short enough that a wedged permission/provider wait does
+/// not look like a permanently stuck SeaTalk/WeCom bot.
+const GATEWAY_TURN_TIMEOUT_SECS: u64 = 120;
 
 use crate::backend::Backend;
 use crate::proto::amux;
@@ -750,7 +754,8 @@ impl AmuxdAgentHandle {
         let mut last_update = std::time::Instant::now();
         let mut sent_update = String::new();
 
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5 * 60);
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_secs(GATEWAY_TURN_TIMEOUT_SECS);
         // On a turn-level timeout, salvage any reply text the agent already
         // produced instead of failing the whole turn (issue #555): OpenCode can
         // finish and persist its final assistant text while the ACP adapter

--- a/apps/daemon/src/runtime/opencode_http/events.rs
+++ b/apps/daemon/src/runtime/opencode_http/events.rs
@@ -330,15 +330,34 @@ async fn handle_permission_asked(
 
     if permission.is_full_access() {
         // Full-access sessions (gateway conversations, cron jobs) have no human
-        // to ask — auto-allow rather than wait forever.
+        // to ask — auto-allow rather than wait forever. If the auto-reply
+        // itself fails, abort the turn so channel clients are not stuck for
+        // the full gateway timeout with nobody able to approve.
         info!(session_id, permission_id = %permission_id, "auto-allow full-access permission");
-        if let Ok(client) = shared.serve.ensure().await {
-            if let Err(e) = client
+        let respond_ok = match shared.serve.ensure().await {
+            Ok(client) => client
                 .permission_respond(&directory, session_id, &permission_id, "once")
                 .await
-            {
-                warn!(session_id, error = %e, "gateway permission auto-reply failed");
+                .map_err(|e| {
+                    warn!(session_id, error = %e, "gateway permission auto-reply failed");
+                    e
+                })
+                .is_ok(),
+            Err(e) => {
+                warn!(session_id, error = %e, "gateway permission auto-reply: serve unavailable");
+                false
             }
+        };
+        if !respond_ok {
+            super::abort_turn_with_error(
+                shared,
+                session_id,
+                "permission auto-allow failed".into(),
+                format!(
+                    "full-access session could not auto-approve permission {permission_id}; aborting turn"
+                ),
+            )
+            .await;
         }
         return;
     }
@@ -509,11 +528,33 @@ async fn handle_question_asked(shared: &Arc<Shared>, session_id: &str, props: &s
         }
     };
     if let Some(directory) = full_access {
+        // Same fail-closed path as permissions: unanswered questions park the
+        // stuck-turn watchdog, so a failed reject must end the turn.
         info!(session_id, request_id, "auto-reject full-access question");
-        if let Ok(client) = shared.serve.ensure().await {
-            if let Err(e) = client.question_reject(&directory, request_id).await {
-                warn!(session_id, error = %e, "full-access question auto-reject failed");
+        let reject_ok = match shared.serve.ensure().await {
+            Ok(client) => client
+                .question_reject(&directory, request_id)
+                .await
+                .map_err(|e| {
+                    warn!(session_id, error = %e, "full-access question auto-reject failed");
+                    e
+                })
+                .is_ok(),
+            Err(e) => {
+                warn!(session_id, error = %e, "full-access question auto-reject: serve unavailable");
+                false
             }
+        };
+        if !reject_ok {
+            super::abort_turn_with_error(
+                shared,
+                session_id,
+                "question auto-reject failed".into(),
+                format!(
+                    "full-access session could not auto-reject question {request_id}; aborting turn"
+                ),
+            )
+            .await;
         }
         return;
     }

--- a/crates/teamclaw-gateway/src/agent.rs
+++ b/crates/teamclaw-gateway/src/agent.rs
@@ -228,7 +228,7 @@ pub enum AgentError {
     Create(String),
     #[error("agent send failed: {0}")]
     Send(String),
-    #[error("agent turn timed out")]
+    #[error("agent turn timed out waiting for a reply — please retry")]
     Timeout,
     #[error("not found: {0}")]
     NotFound(String),


### PR DESCRIPTION
## Summary
- Map channel-native gateway message ids to UUID primary keys (v5 when non-UUID) and store the original under `metadata.external_message_id`, so SeaTalk/WeCom/Feishu user turns actually persist instead of failing the UUID column insert.
- When full-access auto-allow / question auto-reject fails, abort the turn (Error + Idle) instead of leaving the channel turn wedged with nobody to approve.
- Shorten the gateway turn wait from 5 minutes to 120s and clarify the timeout error text for channel replies.

## Test plan
- [ ] `cargo test --manifest-path apps/daemon/Cargo.toml gateway_id`
- [ ] SeaTalk (or WeCom) @bot: confirm the TeamClaw session shows both the inbound user message and the agent reply
- [ ] Force a permission auto-allow failure path (or observe logs): turn should end with an error rather than hanging until timeout
- [ ] Confirm a stuck turn surfaces a retryable timeout within ~2 minutes when no reply is produced


Made with [Cursor](https://cursor.com)