### PR TITLE
fix(chat): restore OS file drop onto the composer as attachments

### DIFF
--- a/packages/app/src/components/workspace/FileTree.tsx
+++ b/packages/app/src/components/workspace/FileTree.tsx
@@ -4,6 +4,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronRight, File } from "lucide-react";
 
 import { toast } from 'sonner';
+import { isChatInputDropTarget, isPointOverElement } from '@/lib/chat-file-drop';
 import { copyToClipboard, isTauri } from '@/lib/utils';
 import { GitStatus } from "@/lib/git/service";
 import { useWorkspaceStore, type FileNode } from "@/stores/workspace";
@@ -1127,6 +1128,22 @@ export function FileTree({
           }
           const paths = event.payload.paths;
           if (!paths || paths.length === 0) return;
+
+          // OS drops on the chat composer attach as pending files (PromptInput
+          // listens to the same tauri://drag-drop event). Do not copy into the
+          // workspace in that case — previously every external drop was treated
+          // as a file-tree import, so drag-to-input silently stopped working.
+          const dropPos = event.payload.position;
+          const chatInput = document.querySelector('[data-testid="chat-input-area"]');
+          // Prefer geometry over elementFromPoint — during native DnD the
+          // hit-test under the cursor can miss the composer chrome.
+          if (
+            isPointOverElement(dropPos, chatInput) ||
+            isChatInputDropTarget(document.elementFromPoint(dropPos.x, dropPos.y))
+          ) {
+            setDragOverPath(null);
+            return;
+          }
 
           const targetDir = dragOverPathRef.current || workspacePath;
 

--- a/packages/app/src/lib/__tests__/chat-file-drop.test.ts
+++ b/packages/app/src/lib/__tests__/chat-file-drop.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { isChatInputDropTarget, isPointOverElement } from '@/lib/chat-file-drop'
+
+describe('isChatInputDropTarget', () => {
+  it('returns false for null / unrelated elements', () => {
+    expect(isChatInputDropTarget(null)).toBe(false)
+    expect(isChatInputDropTarget(document.createElement('div'))).toBe(false)
+  })
+
+  it('returns true when the element is inside chat-input-area', () => {
+    const root = document.createElement('div')
+    root.setAttribute('data-testid', 'chat-input-area')
+    const child = document.createElement('textarea')
+    root.appendChild(child)
+    document.body.appendChild(root)
+    try {
+      expect(isChatInputDropTarget(child)).toBe(true)
+      expect(isChatInputDropTarget(root)).toBe(true)
+    } finally {
+      root.remove()
+    }
+  })
+})
+
+describe('isPointOverElement', () => {
+  it('returns false when element is missing', () => {
+    expect(isPointOverElement({ x: 10, y: 10 }, null)).toBe(false)
+  })
+
+  it('returns true when the point lies inside the element box', () => {
+    const el = document.createElement('div')
+    el.getBoundingClientRect = () =>
+      ({
+        left: 100,
+        top: 200,
+        right: 150,
+        bottom: 240,
+        width: 50,
+        height: 40,
+        x: 100,
+        y: 200,
+        toJSON: () => ({}),
+      }) as DOMRect
+    expect(isPointOverElement({ x: 120, y: 220 }, el)).toBe(true)
+    expect(isPointOverElement({ x: 10, y: 10 }, el)).toBe(false)
+  })
+})

--- a/packages/app/src/lib/chat-file-drop.ts
+++ b/packages/app/src/lib/chat-file-drop.ts
@@ -1,0 +1,18 @@
+/** True when an OS/Tauri drop should attach to chat instead of copying into the workspace. */
+export function isChatInputDropTarget(el: Element | null | undefined): boolean {
+  return Boolean(el?.closest('[data-testid="chat-input-area"]'))
+}
+
+export function isPointOverElement(
+  position: { x: number; y: number },
+  el: Element | null | undefined,
+): boolean {
+  if (!el) return false
+  const rect = el.getBoundingClientRect()
+  return (
+    position.x >= rect.left &&
+    position.x <= rect.right &&
+    position.y >= rect.top &&
+    position.y <= rect.bottom
+  )
+}

--- a/packages/app/src/packages/ai/__tests__/prompt-input.test.tsx
+++ b/packages/app/src/packages/ai/__tests__/prompt-input.test.tsx
@@ -93,3 +93,26 @@ describe('usePromptInputContext', () => {
     }).toThrow('PromptInput components must be used within <PromptInput />')
   })
 })
+
+describe('PromptInput HTML5 file drop', () => {
+  it('forwards dropped File objects to onFilesChange', async () => {
+    const { fireEvent } = await import('@testing-library/react')
+    const { PromptInput } = await import('@/packages/ai/prompt-input')
+    const onFilesChange = vi.fn()
+    const { container } = render(
+      React.createElement(PromptInput, { onFilesChange, multiple: true },
+        React.createElement('div', null, 'child'),
+      ),
+    )
+    const form = container.querySelector('form')
+    expect(form).not.toBeNull()
+    const file = new File(['hello'], 'note.txt', { type: 'text/plain' })
+    fireEvent.drop(form!, {
+      dataTransfer: {
+        files: [file],
+        getData: () => '',
+      },
+    })
+    expect(onFilesChange).toHaveBeenCalledWith([file])
+  })
+})

--- a/packages/app/src/packages/ai/prompt-input.tsx
+++ b/packages/app/src/packages/ai/prompt-input.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
 
 import { appShortName } from "@/lib/build-config"
-import { cn } from "@/lib/utils"
+import { isPointOverElement } from "@/lib/chat-file-drop"
+import { cn, isTauri } from "@/lib/utils"
 import { encodeMemberMentionToken, parseMemberMentionsFromText } from "@/lib/member-mention-token"
 import { EditableWithFileChips } from "./editable-with-file-chips"
 
@@ -179,6 +180,16 @@ export function PromptInput({
   }
 
   const formRef = React.useRef<HTMLFormElement>(null)
+  const onFilesChangeRef = React.useRef(onFilesChange)
+  const multipleRef = React.useRef(multiple)
+  React.useEffect(() => { onFilesChangeRef.current = onFilesChange }, [onFilesChange])
+  React.useEffect(() => { multipleRef.current = multiple }, [multiple])
+
+  const dropHitTarget = React.useCallback(() => {
+    // Prefer the full chat input chrome so drops on padding still attach,
+    // matching FileTree's skip-copy check via data-testid="chat-input-area".
+    return formRef.current?.closest('[data-testid="chat-input-area"]') ?? formRef.current
+  }, [])
 
   // Listen for teamclaw:filedrop custom events dispatched when Tauri intercepts
   // an internal file-tree drag that lands outside the tree (e.g. on this input).
@@ -186,15 +197,91 @@ export function PromptInput({
     if (!onFilePathsDrop) return
     const handler = (e: Event) => {
       const { path, position } = (e as CustomEvent).detail as { path: string; position: { x: number; y: number } }
-      const rect = formRef.current?.getBoundingClientRect()
-      if (!rect) return
-      if (position.x >= rect.left && position.x <= rect.right && position.y >= rect.top && position.y <= rect.bottom) {
-        onFilePathsDrop([path])
-      }
+      if (!isPointOverElement(position, dropHitTarget())) return
+      onFilePathsDrop([path])
     }
     window.addEventListener('teamclaw:filedrop', handler)
     return () => window.removeEventListener('teamclaw:filedrop', handler)
-  }, [onFilePathsDrop])
+  }, [onFilePathsDrop, dropHitTarget])
+
+  // Tauri with dragDropEnabled steals HTML5 dataTransfer.files. Attach OS drops
+  // that land on the chat input via the native tauri://drag-drop event instead.
+  React.useEffect(() => {
+    if (!onFilesChange || !isTauri()) return
+    let cancelled = false
+    const unlisteners: Array<() => void> = []
+
+    void import('@tauri-apps/api/event').then(async ({ listen }) => {
+      if (cancelled) return
+
+      unlisteners.push(
+        await listen<{ paths: string[]; position: { x: number; y: number } }>(
+          'tauri://drag-over',
+          (event) => {
+            setIsDragging(isPointOverElement(event.payload.position, dropHitTarget()))
+          },
+        ),
+      )
+      if (cancelled) {
+        unlisteners.forEach((fn) => fn())
+        return
+      }
+
+      unlisteners.push(
+        await listen('tauri://drag-leave', () => {
+          setIsDragging(false)
+        }),
+      )
+      if (cancelled) {
+        unlisteners.forEach((fn) => fn())
+        return
+      }
+
+      unlisteners.push(
+        await listen<{ paths: string[]; position: { x: number; y: number } }>(
+          'tauri://drag-drop',
+          async (event) => {
+            setIsDragging(false)
+            const { paths, position } = event.payload
+            if (!paths?.length) return
+            if (!isPointOverElement(position, dropHitTarget())) return
+
+            const { readDesktopPathsAsFiles } = await import('@/lib/read-desktop-files')
+            const { files, oversize, failed } = await readDesktopPathsAsFiles(paths)
+            if (oversize.length > 0 || failed.length > 0) {
+              const { toast } = await import('sonner')
+              if (oversize.length > 0) {
+                toast.error(
+                  oversize.length === 1
+                    ? `"${oversize[0]}" exceeds the 20MB limit`
+                    : `${oversize.length} files exceed the 20MB limit`,
+                )
+              }
+              if (failed.length > 0) {
+                toast.error(
+                  failed.length === 1
+                    ? `Could not read "${failed[0]}"`
+                    : `Could not read ${failed.length} files`,
+                )
+              }
+            }
+            if (files.length === 0) return
+
+            const filesToAdd = multipleRef.current ? files : [files[0]]
+            setFiles((prev) =>
+              multipleRef.current ? [...prev, ...filesToAdd] : filesToAdd,
+            )
+            onFilesChangeRef.current?.(filesToAdd)
+          },
+        ),
+      )
+    })
+
+    return () => {
+      cancelled = true
+      unlisteners.forEach((fn) => fn())
+    }
+  }, [onFilesChange, dropHitTarget])
 
   const handleDrop = (event: React.DragEvent) => {
     event.preventDefault()


### PR DESCRIPTION
## Summary
- Desktop Tauri drops no longer always copy into the workspace file tree; drops over the chat input attach as pending files again.
- `PromptInput` handles `tauri://drag-drop` when the drop lands on the composer (HTML5 `dataTransfer.files` is empty with `dragDropEnabled`).
- Adds shared hit-test helpers and unit coverage for drop routing / HTML5 file forwarding.

## Test plan
- [ ] `pnpm --filter @teamclaw/app exec vitest run src/lib/__tests__/chat-file-drop.test.ts src/packages/ai/__tests__/prompt-input.test.tsx`
- [ ] In `pnpm tauri:dev`, drag an image from Finder onto the chat composer → pending attachment preview appears
- [ ] Drag a non-image file onto the composer → pending file chip appears
- [ ] Drag a file onto the file tree → still copies into the workspace (not attached to chat)
- [ ] Drag a workspace file-tree item onto the composer → still inserts `@{path}` mention


Made with [Cursor](https://cursor.com)