### PR TITLE
perf(daemon): stop the local probe from re-authenticating every 20s

### DIFF
--- a/apps/daemon/src/sync/dispatch.rs
+++ b/apps/daemon/src/sync/dispatch.rs
@@ -389,6 +389,14 @@ mod tests {
     }
     #[tokio::test]
     async fn auto_sync_disabled_skips_without_backend() {
+        // AMUXD_HOME is process-wide. Without this lock the set/restore races
+        // every other test that reads it, and the loser sees somebody else's
+        // temp dir — which is how this test started failing intermittently on
+        // CI while passing alone. Same lock the HOME-mutating tests in
+        // team_link.rs take, for the same reason.
+        let _lock = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
         let config_path = tmp.path().join("daemon.toml");
         let mut cfg = crate::config::DaemonConfig::bootstrap();
@@ -400,7 +408,14 @@ mod tests {
 
         let (d, _backend) = dispatcher_with_mock(&tmp);
         let st = d
-            .sync_team("t", "/tmp/ws", SyncOptions { force: false, ..Default::default() })
+            .sync_team(
+                "t",
+                "/tmp/ws",
+                SyncOptions {
+                    force: false,
+                    ..Default::default()
+                },
+            )
             .await;
         assert!(st.skipped);
         assert!(st.last_error.is_none());
@@ -414,6 +429,11 @@ mod tests {
 
     #[tokio::test]
     async fn auto_sync_disabled_skip_preserves_cached_status() {
+        // Same process-wide AMUXD_HOME as the sibling test above — they raced
+        // each other directly.
+        let _lock = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
         let config_path = tmp.path().join("daemon.toml");
         let mut cfg = crate::config::DaemonConfig::bootstrap();
@@ -441,7 +461,14 @@ mod tests {
         cfg.save(&config_path).unwrap();
 
         let st = d
-            .sync_team("t", "/tmp/ws", SyncOptions { force: false, ..Default::default() })
+            .sync_team(
+                "t",
+                "/tmp/ws",
+                SyncOptions {
+                    force: false,
+                    ..Default::default()
+                },
+            )
             .await;
         assert!(st.skipped);
         assert!(st.last_error.is_some());

--- a/packages/app/src/hooks/use-local-daemon-http-status.ts
+++ b/packages/app/src/hooks/use-local-daemon-http-status.ts
@@ -8,9 +8,56 @@ import { useDaemonMqttConnected } from '@/stores/daemon-mqtt-status'
 
 export type LocalDaemonHttpStatus = 'idle' | 'checking' | 'online' | 'offline'
 
+/**
+ * Shared probe state. One timer for the whole app, ref-counted by mounts —
+ * mirroring `daemon-mqtt-status`, which already worked this way.
+ *
+ * Per-mount intervals meant N copies of the same probe against one local
+ * daemon, all landing at slightly different times, and `requestDaemonProbe()`
+ * fanned out to every one of them at once.
+ */
+let sharedStatus: LocalDaemonHttpStatus = 'idle'
+const statusListeners = new Set<(s: LocalDaemonHttpStatus) => void>()
+let probeSubscribers = 0
+let probeTimer: ReturnType<typeof setInterval> | null = null
+let unsubscribeProbeSignal: (() => void) | null = null
+let probeInFlight: Promise<void> | null = null
+
+function setSharedStatus(next: LocalDaemonHttpStatus) {
+  if (sharedStatus === next) return
+  sharedStatus = next
+  statusListeners.forEach((fn) => fn(next))
+}
+
+function runSharedProbe(): Promise<void> {
+  // Coalesce: a poll tick landing on top of a requestDaemonProbe() must not
+  // produce two concurrent probes.
+  probeInFlight ??= probeDaemonHttp()
+    .then((probe) => setSharedStatus(probe.ok ? 'online' : 'offline'))
+    .finally(() => {
+      probeInFlight = null
+    })
+  return probeInFlight
+}
+
+function startSharedProbe() {
+  setSharedStatus('checking')
+  void runSharedProbe()
+  probeTimer = setInterval(() => void runSharedProbe(), QUICK_CHAT_DAEMON_PROBE_INTERVAL_MS)
+  unsubscribeProbeSignal = onDaemonProbeRequested(() => void runSharedProbe())
+}
+
+function stopSharedProbe() {
+  if (probeTimer) clearInterval(probeTimer)
+  probeTimer = null
+  unsubscribeProbeSignal?.()
+  unsubscribeProbeSignal = null
+  setSharedStatus('idle')
+}
+
 export function useLocalDaemonHttpStatus(enabled = true): LocalDaemonHttpStatus {
   const daemonReady = useDaemonOnboardingStore((s) => s.status === 'ready')
-  const [status, setStatus] = React.useState<LocalDaemonHttpStatus>('idle')
+  const [status, setStatus] = React.useState<LocalDaemonHttpStatus>(sharedStatus)
 
   React.useEffect(() => {
     if (!enabled || !daemonReady) {
@@ -18,23 +65,15 @@ export function useLocalDaemonHttpStatus(enabled = true): LocalDaemonHttpStatus 
       return
     }
 
-    let cancelled = false
-    const runProbe = async () => {
-      const probe = await probeDaemonHttp()
-      if (cancelled) return
-      setStatus(probe.ok ? 'online' : 'offline')
-    }
+    setStatus(sharedStatus)
+    statusListeners.add(setStatus)
+    probeSubscribers += 1
+    if (probeSubscribers === 1) startSharedProbe()
 
-    setStatus('checking')
-    void runProbe()
-    const interval = setInterval(() => void runProbe(), QUICK_CHAT_DAEMON_PROBE_INTERVAL_MS)
-    // Let Retry / network-online force an immediate re-probe instead of waiting
-    // out the poll interval.
-    const unsubscribe = onDaemonProbeRequested(() => void runProbe())
     return () => {
-      cancelled = true
-      clearInterval(interval)
-      unsubscribe()
+      statusListeners.delete(setStatus)
+      probeSubscribers -= 1
+      if (probeSubscribers === 0) stopSharedProbe()
     }
   }, [daemonReady, enabled])
 

--- a/packages/app/src/lib/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon-local-client.ts
@@ -167,10 +167,21 @@ export async function probeDaemonHttp(): Promise<DaemonHttpProbe> {
     return { ok: false, reason: 'not_running' }
   }
 
-  // 2) Token valid? — exchange the root token for a scoped session token.
-  invalidateDaemonConnection()
-  _connection = null
-  const conn = await _fetchConnection()
+  // 2) Token valid? — through the cache, deliberately.
+  //
+  // This used to invalidate the cached session and force a fresh
+  // `/v1/auth/exchange` on every probe. Three pollers run this on a 20s tick,
+  // and each one also wiped the connection every other caller shares — so the
+  // cache was never warm and the exchange count scaled with probes, not with
+  // token lifetime (measured on the box: ~33 `/v1/auth/exchange` per minute for
+  // a token that lives an hour).
+  //
+  // `getConnection` already answers the question this step is asking. It drops
+  // the cache when the daemon rebinds to a new port, refreshes 5 minutes before
+  // expiry, and coalesces concurrent callers — so a non-null result means the
+  // root token exchanged successfully at some point within the token's life,
+  // and null means it cannot be exchanged now.
+  const conn = await getConnection()
   if (!conn) return { ok: false, reason: 'token_invalid' }
 
   return { ok: true, baseUrl: conn.baseUrl }


### PR DESCRIPTION
Measured on the self-host box, against a local daemon holding a **one-hour** token:

```
GET  /v1/info            92 / min
POST /v1/auth/exchange   33 / min
GET  /v1/healthz         33 / min
```

## Two causes

**`probeDaemonHttp` bypassed the connection cache and destroyed it.**

```ts
invalidateDaemonConnection()          // wipes the cache every other caller shares
_connection = null
const conn = await _fetchConnection() // direct, not through getConnection
```

So the token-exchange rate tracked *probe frequency* rather than *token lifetime*, and every other consumer of `getConnection()` found a cold cache right after each probe and had to re-exchange too.

`getConnection()` already answers the question this step is asking — it drops the cache when the daemon rebinds to a new loopback port, refreshes five minutes before expiry, and coalesces concurrent callers. A non-null result means the root token exchanged successfully within the token's life; null means it cannot be exchanged now, which is exactly the `token_invalid` signal the probe reports.

The other five `invalidateDaemonConnection()` call sites were checked individually and all stay: 401-rejected retry, network-error retry, and explicit daemon restart.

**`useLocalDaemonHttpStatus` created an interval per mount.** N mounted consumers meant N copies of the same probe against one local daemon, and `requestDaemonProbe()` fanned out to every one of them simultaneously. Now a ref-counted shared timer — the shape `daemon-mqtt-status` already used — plus in-flight coalescing so a poll tick landing on a manual re-probe does not produce two concurrent probes.

## Verification

`pnpm typecheck` clean, `eslint` clean on both files, frontend vitest **2735 / 2736** — the single failure (`provider.test > hasBackendConfig`) reproduces with these changes stashed and is unrelated.

Behaviour is unchanged: the probe still distinguishes `not_running` (healthz unreachable) from `token_invalid` (exchange fails), and still re-probes immediately on Retry / network-online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)