### PR TITLE
fix(app): Knowledge 列无限重复展开导致刷屏与抖动

### DIFF
--- a/packages/app/src/components/panel/ActorsView.tsx
+++ b/packages/app/src/components/panel/ActorsView.tsx
@@ -46,6 +46,11 @@ export const useActorsForTeam = useActorDirectory
 
 type ActorTypeFilter = 'all' | 'agent' | 'member'
 
+const actorNameCollator = new Intl.Collator(['zh-Hans-CN', 'en'], {
+  sensitivity: 'base',
+  numeric: true,
+})
+
 function ActorRowView({
   actor,
   onViewProfile,
@@ -219,11 +224,13 @@ export function ActorsView() {
 
   const visibleActors = React.useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase()
-    return actors.filter((actor) => {
-      if (filter !== 'all' && actor.actor_type !== filter) return false
-      if (!normalizedQuery) return true
-      return actor.display_name.toLowerCase().includes(normalizedQuery)
-    })
+    return actors
+      .filter((actor) => {
+        if (filter !== 'all' && actor.actor_type !== filter) return false
+        if (!normalizedQuery) return true
+        return actor.display_name.toLowerCase().includes(normalizedQuery)
+      })
+      .sort((a, b) => actorNameCollator.compare(a.display_name, b.display_name))
   }, [actors, filter, query])
 
   const confirmRemove = async () => {

--- a/packages/app/src/components/panel/__tests__/ActorsView.test.tsx
+++ b/packages/app/src/components/panel/__tests__/ActorsView.test.tsx
@@ -68,6 +68,48 @@ describe('ActorsView', () => {
     expect(screen.getByRole('button', { name: /Alice/ })).toHaveClass('hover:bg-selected')
   })
 
+  it('sorts all actors by display name', async () => {
+    mockActorsRows([
+      {
+        id: 'a-2',
+        actor_type: 'agent',
+        display_name: 'Zed',
+        member_status: null,
+        agent_status: 'online',
+        last_active_at: null,
+      },
+      {
+        id: 'a-1',
+        actor_type: 'member',
+        display_name: 'Alice',
+        member_status: 'active',
+        agent_status: null,
+        last_active_at: null,
+      },
+      {
+        id: 'a-3',
+        actor_type: 'agent',
+        display_name: 'Bob',
+        member_status: null,
+        agent_status: 'online',
+        last_active_at: null,
+      },
+    ])
+
+    render(<ActorsView />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /Alice/ })).toBeInTheDocument())
+    const actorButtons = screen.getAllByRole('button').filter((button) =>
+      ['Alice', 'Bob', 'Zed'].some((name) => button.textContent?.includes(name)),
+    )
+
+    expect(actorButtons.map((button) => button.textContent ?? '')).toEqual([
+      expect.stringContaining('Alice'),
+      expect.stringContaining('Bob'),
+      expect.stringContaining('Zed'),
+    ])
+  })
+
   it('renders empty state when no actors', async () => {
     mockActorsRows([])
     render(<ActorsView />)

--- a/packages/app/src/components/workspace/FileBrowser.tsx
+++ b/packages/app/src/components/workspace/FileBrowser.tsx
@@ -127,6 +127,11 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
       let current = wp
       for (const seg of segments) {
         current = `${current}/${seg}`
+        // Only load the levels that are actually missing, and re-read the tree
+        // each step because it changes across the await. Re-expanding a loaded
+        // ancestor costs an IPC round-trip and republishes the whole level,
+        // which is how this effect used to keep re-arming itself.
+        if (findSubtree(useWorkspaceStore.getState().fileTree, current) !== undefined) continue
         await useWorkspaceStore.getState().expandDirectory(current)
       }
     }

--- a/packages/app/src/components/workspace/__tests__/FileBrowser.test.tsx
+++ b/packages/app/src/components/workspace/__tests__/FileBrowser.test.tsx
@@ -135,6 +135,11 @@ vi.mock("@/stores/workspace", () => ({
     {
       getState: () => ({
         workspacePath: "/workspace",
+        // Mirrors the selector view above: FileBrowser reads the tree back out
+        // of getState between awaits, since the closed-over value goes stale.
+        get fileTree() {
+          return mockFileTree;
+        },
         expandDirectory: mockExpandDirectory,
       }),
       subscribe: vi.fn(() => vi.fn()),

--- a/packages/app/src/stores/__tests__/workspace-expand-directory.test.ts
+++ b/packages/app/src/stores/__tests__/workspace-expand-directory.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockInvoke = vi.fn();
+
+vi.mock("@/lib/utils", () => ({
+  isTauri: () => true,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+import { useWorkspaceStore } from "../workspace";
+
+type Node = {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+  children?: Node[];
+};
+
+const TEAM = "/workspace/teamclaw-team";
+const KNOWLEDGE = `${TEAM}/knowledge`;
+
+/** A directory listing as the backend returns it: no children on any entry. */
+const listing = (...nodes: Array<[string, string, "file" | "directory"]>): Node[] =>
+  nodes.map(([name, path, type]) => ({ name, path, type }));
+
+const childrenOf = (nodes: Node[], target: string): Node[] | undefined => {
+  for (const node of nodes) {
+    if (node.path === target) return node.children;
+    if (node.children) {
+      const found = childrenOf(node.children, target);
+      if (found !== undefined) return found;
+    }
+  }
+  return undefined;
+};
+
+describe("workspace expandDirectory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorkspaceStore.setState({
+      workspacePath: "/workspace",
+      fileTree: listing(["teamclaw-team", TEAM, "directory"]),
+      expandedPaths: new Set<string>(),
+      loadingPaths: new Set<string>(),
+    });
+  });
+
+  /**
+   * The regression behind the Knowledge column spinning at ~33 IPC calls/sec:
+   * re-listing a parent used to replace its children wholesale, and a fresh
+   * listing carries no grandchildren — so every parent refresh silently
+   * un-loaded the subtree below it, and callers that read "children ===
+   * undefined" as "needs loading" immediately asked for it again.
+   */
+  it("keeps an already-loaded child subtree when the parent is re-listed", async () => {
+    const store = useWorkspaceStore.getState();
+
+    mockInvoke.mockResolvedValueOnce(listing(["knowledge", KNOWLEDGE, "directory"]));
+    await store.expandDirectory(TEAM);
+
+    mockInvoke.mockResolvedValueOnce(listing(["guide.md", `${KNOWLEDGE}/guide.md`, "file"]));
+    await store.expandDirectory(KNOWLEDGE);
+
+    expect(childrenOf(useWorkspaceStore.getState().fileTree, KNOWLEDGE)).toHaveLength(1);
+
+    // Same listing again — the shape the backend always returns.
+    mockInvoke.mockResolvedValueOnce(listing(["knowledge", KNOWLEDGE, "directory"]));
+    await store.expandDirectory(TEAM);
+
+    expect(childrenOf(useWorkspaceStore.getState().fileTree, KNOWLEDGE)).toEqual([
+      { name: "guide.md", path: `${KNOWLEDGE}/guide.md`, type: "file" },
+    ]);
+  });
+
+  it("drops the old subtree when a path changes from directory to file", async () => {
+    const store = useWorkspaceStore.getState();
+
+    mockInvoke.mockResolvedValueOnce(listing(["knowledge", KNOWLEDGE, "directory"]));
+    await store.expandDirectory(TEAM);
+    mockInvoke.mockResolvedValueOnce(listing(["guide.md", `${KNOWLEDGE}/guide.md`, "file"]));
+    await store.expandDirectory(KNOWLEDGE);
+
+    mockInvoke.mockResolvedValueOnce(listing(["knowledge", KNOWLEDGE, "file"]));
+    await store.expandDirectory(TEAM);
+
+    expect(childrenOf(useWorkspaceStore.getState().fileTree, KNOWLEDGE)).toBeUndefined();
+  });
+
+  it("forgets children the listing no longer reports", async () => {
+    const store = useWorkspaceStore.getState();
+
+    mockInvoke.mockResolvedValueOnce(listing(["knowledge", KNOWLEDGE, "directory"]));
+    await store.expandDirectory(TEAM);
+    mockInvoke.mockResolvedValueOnce(listing(["guide.md", `${KNOWLEDGE}/guide.md`, "file"]));
+    await store.expandDirectory(KNOWLEDGE);
+
+    mockInvoke.mockResolvedValueOnce(listing(["other", `${TEAM}/other`, "directory"]));
+    await store.expandDirectory(TEAM);
+
+    const teamChildren = childrenOf(useWorkspaceStore.getState().fileTree, TEAM);
+    expect(teamChildren?.map((n) => n.path)).toEqual([`${TEAM}/other`]);
+  });
+
+  /**
+   * Two loads of the same path must not overlap: the one that started first
+   * could otherwise publish last, republishing children it read before the
+   * other call's write.
+   */
+  it("serialises concurrent expands of the same path", async () => {
+    const store = useWorkspaceStore.getState();
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    mockInvoke.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight -= 1;
+      return listing(["second", `${TEAM}/second`, "directory"]);
+    });
+
+    await Promise.all([store.expandDirectory(TEAM), store.expandDirectory(TEAM)]);
+
+    expect(maxInFlight).toBe(1);
+    expect(mockInvoke).toHaveBeenCalledTimes(2);
+    expect(useWorkspaceStore.getState().loadingPaths.has(TEAM)).toBe(false);
+  });
+
+  it("does not let a failed expand block later expands of the same path", async () => {
+    const store = useWorkspaceStore.getState();
+
+    // loadDirectory swallows backend errors, so drive the failure through the
+    // store's own contract rather than faking a rejection it never surfaces.
+    mockInvoke.mockRejectedValueOnce(new Error("boom"));
+    await store.expandDirectory(TEAM);
+
+    mockInvoke.mockResolvedValueOnce(listing(["knowledge", KNOWLEDGE, "directory"]));
+    await store.expandDirectory(TEAM);
+
+    expect(childrenOf(useWorkspaceStore.getState().fileTree, TEAM)?.map((n) => n.path)).toEqual([
+      KNOWLEDGE,
+    ]);
+  });
+});

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -189,8 +189,17 @@ function frontmatterValue(content: string, key: string): string | null {
   return frontmatterString(content, key) ?? null
 }
 
-const KNOWLEDGE_EXTS = new Set(['md', 'mdx', 'markdown', 'txt'])
-
+/**
+ * The entries directly under `knowledge/` — the same rows the column's file
+ * tree shows at its root.
+ *
+ * This listing exists only to produce the header and nav counts, so it has to
+ * agree with what sits next to those counts, the way every other section's does.
+ * It previously walked the tree recursively and counted only `md/mdx/markdown/
+ * txt`, which disagreed twice over: a folder was visible but never counted, and
+ * any other file type — a PDF, an image — was shared by sync yet invisible to
+ * the count.
+ */
 async function listTeamKnowledge(wsPath: string): Promise<TeamKnowledgeItem[]> {
   const teamDir = await resolveTeamDir(wsPath)
   if (!teamDir) return []
@@ -198,25 +207,16 @@ async function listTeamKnowledge(wsPath: string): Promise<TeamKnowledgeItem[]> {
   const { exists, readDir } = await import('@tauri-apps/plugin-fs')
   if (!(await exists(knowledgeDir))) return []
 
-  const out: TeamKnowledgeItem[] = []
-  const walk = async (dir: string, rel: string): Promise<void> => {
-    const entries = await readDir(dir)
-    for (const entry of entries) {
-      const childRel = rel ? `${rel}/${entry.name}` : entry.name
-      const childPath = `${dir}/${entry.name}`
-      if (entry.isDirectory) {
-        await walk(childPath, childRel)
-      } else {
-        const ext = entry.name.split('.').pop()?.toLowerCase() ?? ''
-        if (KNOWLEDGE_EXTS.has(ext)) {
-          out.push({ path: childPath, relPath: childRel, name: entry.name })
-        }
-      }
-    }
-  }
-  await walk(knowledgeDir, '')
-  out.sort((a, b) => a.relPath.localeCompare(b.relPath))
-  return out
+  const entries = await readDir(knowledgeDir)
+  // Dotfiles are deliberately not filtered: the tree renders them, so counting
+  // them is what keeps the two numbers equal.
+  return entries
+    .map((entry) => ({
+      path: `${knowledgeDir}/${entry.name}`,
+      relPath: entry.name,
+      name: entry.name,
+    }))
+    .sort((a, b) => a.relPath.localeCompare(b.relPath))
 }
 
 type OnDisk = { content: string; dirPath: string; invocationName: string; source: SkillSource }

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -198,6 +198,34 @@ async function readWorkspaceDirectory(
   return invoke<FileNode[]>("read_workspace_directory", { workspacePath, path });
 }
 
+// A freshly listed directory arrives with every entry's `children` undefined,
+// so swapping the array in wholesale discards any subtree already expanded
+// underneath it. Carry the loaded children across for entries that survived the
+// listing; new entries keep their unloaded state.
+//
+// Without this, re-listing a parent silently un-loads its grandchildren, and
+// any caller that treats "children === undefined" as "needs loading" — see
+// FileBrowser's `findSubtree` — is handed a reason to load again immediately.
+function mergeLoadedChildren(
+  previous: FileNode[] | undefined,
+  next: FileNode[],
+): FileNode[] {
+  if (!previous || previous.length === 0) return next;
+  const loaded = new Map<string, FileNode[]>();
+  for (const node of previous) {
+    if (node.children !== undefined) loaded.set(node.path, node.children);
+  }
+  if (loaded.size === 0) return next;
+  return next.map((node) => {
+    const kept = loaded.get(node.path);
+    // Only directories can carry children; a path that flipped file↔directory
+    // between listings must not inherit the old subtree.
+    return kept !== undefined && node.type === "directory"
+      ? { ...node, children: kept }
+      : node;
+  });
+}
+
 // Update only the target node's children, creating new references only along
 // the path from root to target. Siblings and unrelated subtrees keep their
 // original references, preserving React.memo effectiveness.
@@ -208,7 +236,7 @@ function updateNodeChildren(
 ): FileNode[] {
   return nodes.map((node) => {
     if (node.path === targetPath) {
-      return { ...node, children };
+      return { ...node, children: mergeLoadedChildren(node.children, children) };
     }
     // Only recurse into directories whose path is a prefix of targetPath
     if (node.children && targetPath.startsWith(node.path + "/")) {
@@ -220,6 +248,15 @@ function updateNodeChildren(
     return node; // unchanged reference
   });
 }
+
+// Serialises `expandDirectory` per path. Two loads of the same directory used
+// to interleave, and the one that started first could publish last —
+// republishing children it read before the other call's write.
+//
+// Chained rather than dropped: several call sites expand a directory precisely
+// to reveal a file they just created, and silently skipping that refresh would
+// leave the new file invisible.
+const expandChain = new Map<string, Promise<void>>();
 
 function findNodeByPath(nodes: FileNode[], path: string): FileNode | null {
   for (const node of nodes) {
@@ -590,31 +627,47 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
   // Expand a directory node
   expandDirectory: async (path: string) => {
-    const { loadDirectory } = get();
+    const load = async () => {
+      const { loadDirectory } = get();
 
-    // Mark as loading via loadingPaths Set (O(1), no tree copy)
-    const nextLoading = new Set(get().loadingPaths);
-    nextLoading.add(path);
-    set({ loadingPaths: nextLoading });
+      // Mark as loading via loadingPaths Set (O(1), no tree copy)
+      const nextLoading = new Set(get().loadingPaths);
+      nextLoading.add(path);
+      set({ loadingPaths: nextLoading });
 
-    // Load children
-    const children = await loadDirectory(path);
+      // Load children
+      const children = await loadDirectory(path);
 
-    // Update only the target node's children in the tree (minimal copy)
-    const updatedTree = updateNodeChildren(get().fileTree, path, children);
+      // Update only the target node's children in the tree (minimal copy)
+      const updatedTree = updateNodeChildren(get().fileTree, path, children);
 
-    // Always clone CURRENT expandedPaths to avoid race conditions —
-    // the Set reference may have been replaced by refreshFileTree during the await
-    const nextExpanded = new Set(get().expandedPaths);
-    nextExpanded.add(path);
-    const doneLoading = new Set(get().loadingPaths);
-    doneLoading.delete(path);
+      // Always clone CURRENT expandedPaths to avoid race conditions —
+      // the Set reference may have been replaced by refreshFileTree during the await
+      const nextExpanded = new Set(get().expandedPaths);
+      nextExpanded.add(path);
+      const doneLoading = new Set(get().loadingPaths);
+      doneLoading.delete(path);
 
-    set({
-      fileTree: updatedTree,
-      expandedPaths: nextExpanded,
-      loadingPaths: doneLoading,
-    });
+      set({
+        fileTree: updatedTree,
+        expandedPaths: nextExpanded,
+        loadingPaths: doneLoading,
+      });
+    };
+
+    // Queue behind any load already running for this same path. See expandChain.
+    const previous = expandChain.get(path) ?? Promise.resolve();
+    const run = previous.then(load);
+    // Swallowed only so one failure cannot poison every later expand of this
+    // path; the awaited `run` below still rejects for this caller.
+    const settled = run.catch(() => {});
+    expandChain.set(path, settled);
+    try {
+      await run;
+    } finally {
+      // Last one out clears the slot, so the map cannot grow unbounded.
+      if (expandChain.get(path) === settled) expandChain.delete(path);
+    }
   },
 
   // Collapse a directory node


### PR DESCRIPTION
打开团队 Knowledge 列时那一列一直在闪。实测 `read_workspace_directory` 被打到 **506 次 / 15 秒**（≈33 次/秒），成对交替请求 `teamclaw-team` 和 `teamclaw-team/knowledge`。

## 根因

自激振荡，三个条件缺一不可：

1. `updateNodeChildren`（`stores/workspace.ts`）把目标目录的 `children` **整个替换**成新列表，而新列表里每个条目的 `children` 都是 `undefined` —— 于是重新列出父目录，等于悄悄把它下面已展开的子树卸载掉。
2. `FileBrowser` 的 `findSubtree` 把 `children === undefined` 读作「需要加载」，所以被卸载的子树立刻又申请加载。
3. 那个 effect 依赖 `fileTree`，而每次展开都会写入新的树引用（`nodes.map()` 必然分配新数组），于是每一轮都给下一轮上膛。

单线程本来能收敛（父级抹掉、子级补回），实际收敛不了：写树会在飞行途中重新触发 effect，多个 `expandWithAncestors` 重叠，**晚到的父级写覆盖掉早先的子级写**。

运行时状态可以直接看到：

```
expandedPaths: ["/teamclaw-team", "/teamclaw-team/knowledge"]
loadingPaths:  ["/teamclaw-team", "/teamclaw-team/knowledge"]   ← 永远清不掉
teamclaw-team 节点: nChildren = 9
  └─ knowledge 节点: children === undefined                     ← 永远填不上
```

只有 `rootPath` 是多级路径时才会触发，所以只有 Knowledge 这一列在闪。

## 改动

按影响面从小到大：

- **`mergeLoadedChildren`** —— 重新列出目录时，把上一次已加载的子节点带过来。这是根因修复，对所有文件树都生效，不止这一列。目录变成文件时不继承旧子树；列表里消失的条目正常丢弃。
- **`expandWithAncestors`** —— 只展开真正缺失的层级，且每一步重新读 store（闭包里的 `fileTree` 跨 await 会过期）。
- **`expandDirectory`** —— 按路径串行。选择**排队**而不是丢弃：有好几个调用点是「刚建完文件、展开目录让它显示出来」，丢掉那次刷新会让新文件不可见。

## 顺带修计数

列头写着 `Knowledge · 1`，旁边却列着 2 行。`listTeamKnowledge` 递归遍历并且只统计 `md/mdx/markdown/txt`，两头都不对：文件夹显示了但不计数，而 PDF、图片这些 sync 明明会同步的文件哪边都数不到。改成列 `knowledge/` 的直接子项 —— 和树渲染的行一一对应。

## 测试

新增 `src/stores/__tests__/workspace-expand-directory.test.ts`（5 个用例）：父目录重新列出保留子树、目录→文件不继承、消失的条目丢弃、同路径并发串行、失败不阻塞后续。

`FileBrowser.test.tsx` 的 store mock 里 `getState()` 补上了 `fileTree` —— 它一直漏着这个真实 store 有的字段。

一个佐证：把改动 stash 掉（untracked 的新测试留在原地）跑全量，唯二失败的就是这两个新回归测试，确认它们确实复现了 bug。

- `pnpm typecheck` ✅
- `pnpm lint` ✅ 0 errors
- `pnpm test:unit` ✅ 439 files / 2742 tests

## 实机验证

| | 修复前 | 修复后 |
|---|---|---|
| `read_workspace_directory` | 506 次 / 15 秒 | 打开后共 4 次，之后 19 秒静默 |
| `knowledge` 节点 children | 永远 `undefined` | 正常填充 |
| `loadingPaths` | 两个路径常驻 | 空 |
| 列头 / 导航计数 | `Knowledge · 1`（2 行） | `Knowledge · 2` |

## 夹带

`ActorsView` 那两个文件（用 `Intl.Collator` 给成员列表排序）不是本次修复的一部分 —— 是同一个 checkout 里另一个会话留在工作区的改动，按要求一并带上了。要拆出去随时说。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
