### PR TITLE
fix(expo): exclude reanimated and worklets from autolinking

### DIFF
--- a/apps/expo/react-native.config.js
+++ b/apps/expo/react-native.config.js
@@ -8,5 +8,31 @@ module.exports = {
         },
       },
     },
+    // `react-native-reanimated@4.3.1` reaches us only transitively, through
+    // `react-native-drawer-layout` (a react-navigation dependency). Nothing in
+    // this app imports it and no drawer navigator is mounted, but autolinking
+    // still hands its podspec to CocoaPods — and that podspec hard-asserts a
+    // React Native version (`peerDependencies: "0.81 - 0.85"`) that 0.86.0 does
+    // not satisfy. The assertion aborts `pod install`, so the native build
+    // could not run at all.
+    //
+    // Excluding it from autolinking skips the podspec. If a drawer navigator or
+    // any direct reanimated use ever lands here, remove this and upgrade
+    // reanimated to a release that supports the pinned React Native instead.
+    'react-native-reanimated': {
+      platforms: {
+        ios: null,
+        android: null,
+      },
+    },
+    // Reanimated's companion package, pulled in by the same transitive path and
+    // failing the same way — its podspec asserts a React Native version too.
+    // Excluding reanimated alone just moves the error here.
+    'react-native-worklets': {
+      platforms: {
+        ios: null,
+        android: null,
+      },
+    },
   },
 };


### PR DESCRIPTION
The Expo app could not be built natively **at all** — `pod install` aborted
before producing an xcworkspace, on any machine:

```
[!] Invalid `RNReanimated.podspec` file: [Reanimated] Your installed version of
    React Native is not compatible with installed version of Reanimated.
```

`react-native-reanimated@4.3.1` declares `react-native: "0.81 - 0.85"`; the app
is on 0.86.0. Nobody chose it — it arrives transitively via
`react-native-drawer-layout` (a react-navigation package). Nothing imports it
and no drawer navigator is mounted, but autolinking still hands its podspec to
CocoaPods, and the podspec asserts the version and aborts.

Excluding it just moves the failure to `react-native-worklets@0.8.3`, its
companion, which fails identically. Both are excluded; `android: null` too,
since Gradle autolinking reads the same config and would hit the same wall.

### Verified

`pod install` gets past both podspecs and proceeds to install the React pods.

> Full verification stopped short of a launched app for an unrelated reason: a
> CocoaPods cache entry for `hermes-engine` was left corrupt by a killed run
> (`Errno::ENOENT … .lock`). Clearing `~/Library/Caches/CocoaPods/Pods/External/hermes-engine`
> is the fix; it is environmental, not something this PR causes.

### Worth knowing before someone tests on a device

The native MQTT path will still fail to connect, for a **separate** reason.
`expo-mqtt.ts` prefers the native module (`withTeamClawMqtt`: HiveMQ on
Android, CocoaMQTT on iOS) and `parseNativeUrl` maps a `wss://` URL with no
explicit port to **8883**. That port is closed on the server — verified three
ways (`/dev/tcp`, `nc -z`, `openssl s_client` → `errno=61`, connection
refused). Open on `mqtt.teamclaw-dev.ucar.cc` are 443 (WSS, valid cert) and
1883 (plaintext).

So today only the JS/WebSocket fallback actually connects. Either expose 8883,
or make `parseNativeUrl` keep WebSocket semantics for `wss://`. Not fixed here
— it is a server/config decision, not an autolinking one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)