### PR TITLE
fix(expo): send the OAuth redirect GoTrue actually allows

### DIFF
--- a/apps/expo/app/(app)/upgrade-account.tsx
+++ b/apps/expo/app/(app)/upgrade-account.tsx
@@ -1,5 +1,4 @@
 import { Ionicons } from "@expo/vector-icons";
-import * as Linking from "expo-linking";
 import { useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 import { useState } from "react";
@@ -21,7 +20,10 @@ import {
   OTP_CODE_LENGTH,
   sanitizeOtpInput,
 } from "../../src/features/onboarding/auth-otp";
-import type { OAuthProvider } from "../../src/features/onboarding/onboarding-oauth";
+import {
+  OAUTH_REDIRECT_URL,
+  type OAuthProvider,
+} from "../../src/features/onboarding/onboarding-oauth";
 import { Hairline } from "../../src/ui/atoms/Hairline";
 import { showToast } from "../../src/ui/Toast";
 import { colors, hai, radii, spacing, typography } from "../../src/ui/theme";
@@ -102,7 +104,7 @@ export default function UpgradeAccountRoute() {
     setError(null);
     try {
       await controller.linkIdentityWithOAuth(provider, {
-        redirectTo: Linking.createURL("auth/callback"),
+        redirectTo: OAUTH_REDIRECT_URL,
         openAuthSession: WebBrowser.openAuthSessionAsync,
       });
       showToast("success", "Account connected.");

--- a/apps/expo/app/auth.tsx
+++ b/apps/expo/app/auth.tsx
@@ -1,7 +1,7 @@
-import * as Linking from "expo-linking";
 import { Redirect, useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 
+import { OAUTH_REDIRECT_URL } from "../src/features/onboarding/onboarding-oauth";
 import { AuthScreen } from "../src/features/onboarding/screens/AuthScreen";
 
 import { routeToHref, useOnboarding } from "./_layout";
@@ -33,13 +33,13 @@ export default function AuthRoute() {
       onResetPendingEmail={controller.resetPendingEmail}
       onSignInWithApple={() =>
         controller.signInWithOAuth("apple", {
-          redirectTo: Linking.createURL("auth/callback"),
+          redirectTo: OAUTH_REDIRECT_URL,
           openAuthSession: WebBrowser.openAuthSessionAsync,
         })
       }
       onSignInWithGoogle={() =>
         controller.signInWithOAuth("google", {
-          redirectTo: Linking.createURL("auth/callback"),
+          redirectTo: OAUTH_REDIRECT_URL,
           openAuthSession: WebBrowser.openAuthSessionAsync,
         })
       }

--- a/apps/expo/src/features/onboarding/onboarding-oauth.ts
+++ b/apps/expo/src/features/onboarding/onboarding-oauth.ts
@@ -1,5 +1,23 @@
 export type OAuthProvider = "apple" | "google";
 
+/**
+ * Where GoTrue sends the browser back after an external provider signs the user
+ * in. Must appear **verbatim** in `GOTRUE_URI_ALLOW_LIST`; anything else is
+ * rejected and the browser falls back to `SITE_URL`, so the app never sees a
+ * callback and the sign-in silently dies.
+ *
+ * Deliberately a literal rather than `Linking.createURL("auth-callback")`:
+ * `createURL` varies by runtime (`exp://…/--/…` under Expo Go) and has shipped
+ * both `scheme://path` and `scheme:///path` forms, neither of which the allow
+ * list would match. The app bundles a custom native module
+ * (`plugins/withTeamClawMqtt`) so it never runs under Expo Go anyway — the
+ * scheme is always `teamclaw`.
+ *
+ * Keep in sync with iOS `CloudAPIAppOnboardingStore.oauthAuthorizeURL`, which
+ * uses this same string.
+ */
+export const OAUTH_REDIRECT_URL = "teamclaw://auth-callback";
+
 export type OAuthCallback =
   | { type: "code"; code: string }
   | { type: "tokens"; accessToken: string; refreshToken: string };

--- a/apps/expo/src/test/onboarding-api.test.ts
+++ b/apps/expo/src/test/onboarding-api.test.ts
@@ -111,9 +111,9 @@ describe("createOnboardingApi (cloud-only)", () => {
     const api = createOnboardingApi(client);
 
     await expect(
-      api.createOAuthSignInUrl("google", "teamclaw://auth/callback"),
+      api.createOAuthSignInUrl("google", "teamclaw://auth-callback"),
     ).resolves.toBe("https://fc.example.com/v1/auth/oauth/google/authorize?...");
-    expect(oauthAuthorize).toHaveBeenCalledWith("google", "teamclaw://auth/callback");
+    expect(oauthAuthorize).toHaveBeenCalledWith("google", "teamclaw://auth-callback");
   });
 
   it("completeOAuthCallback exchanges a PKCE code", async () => {
@@ -122,7 +122,7 @@ describe("createOnboardingApi (cloud-only)", () => {
     const client = makeClient({ auth: { exchangeOAuthCode } });
     const api = createOnboardingApi(client);
 
-    await api.completeOAuthCallback("teamclaw://auth/callback?code=abc");
+    await api.completeOAuthCallback("teamclaw://auth-callback?code=abc");
     expect(exchangeOAuthCode).toHaveBeenCalledWith("abc");
   });
 
@@ -133,7 +133,7 @@ describe("createOnboardingApi (cloud-only)", () => {
     const api = createOnboardingApi(client);
 
     await api.completeOAuthCallback(
-      "teamclaw://auth/callback#access_token=access&refresh_token=refresh",
+      "teamclaw://auth-callback#access_token=access&refresh_token=refresh",
     );
     expect(setSession).toHaveBeenCalledWith({
       access_token: "access",

--- a/apps/expo/src/test/onboarding-oauth.test.ts
+++ b/apps/expo/src/test/onboarding-oauth.test.ts
@@ -1,13 +1,33 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  OAUTH_REDIRECT_URL,
   parseOAuthCallbackUrl,
   shouldCompleteOAuthResult,
 } from "../features/onboarding/onboarding-oauth";
 
 describe("onboarding oauth helpers", () => {
+  it("pins the redirect to the URL GoTrue actually allows", () => {
+    // Server-side `GOTRUE_URI_ALLOW_LIST` contains exactly
+    // `teamclaw://auth-callback`, and iOS sends the same string. This app used
+    // to send `teamclaw://auth/callback` (a slash, from
+    // `Linking.createURL("auth/callback")`), which GoTrue rejected — it then
+    // redirected to SITE_URL instead, so the browser never returned to the app
+    // and every Google/Apple sign-in died silently with no error anywhere.
+    //
+    // Changing this string requires changing the server allow list too.
+    expect(OAUTH_REDIRECT_URL).toBe("teamclaw://auth-callback");
+  });
+
+  it("parses a callback landing on the pinned redirect", () => {
+    expect(parseOAuthCallbackUrl(`${OAUTH_REDIRECT_URL}?code=abc123`)).toEqual({
+      type: "code",
+      code: "abc123",
+    });
+  });
+
   it("extracts an auth code from the OAuth callback query", () => {
-    expect(parseOAuthCallbackUrl("teamclaw://auth/callback?code=abc123")).toEqual({
+    expect(parseOAuthCallbackUrl("teamclaw://auth-callback?code=abc123")).toEqual({
       type: "code",
       code: "abc123",
     });
@@ -16,7 +36,7 @@ describe("onboarding oauth helpers", () => {
   it("extracts implicit access and refresh tokens from the callback fragment", () => {
     expect(
       parseOAuthCallbackUrl(
-        "teamclaw://auth/callback#access_token=access&refresh_token=refresh",
+        "teamclaw://auth-callback#access_token=access&refresh_token=refresh",
       ),
     ).toEqual({
       type: "tokens",
@@ -28,7 +48,7 @@ describe("onboarding oauth helpers", () => {
   it("turns OAuth error callbacks into readable errors", () => {
     expect(() =>
       parseOAuthCallbackUrl(
-        "teamclaw://auth/callback?error=access_denied&error_description=Nope",
+        "teamclaw://auth-callback?error=access_denied&error_description=Nope",
       ),
     ).toThrow("Nope");
   });
@@ -37,7 +57,7 @@ describe("onboarding oauth helpers", () => {
     expect(
       shouldCompleteOAuthResult({
         type: "success",
-        url: "teamclaw://auth/callback",
+        url: "teamclaw://auth-callback",
       }),
     ).toBe(true);
     expect(shouldCompleteOAuthResult({ type: "cancel" })).toBe(false);

--- a/apps/expo/src/test/onboarding-store.test.ts
+++ b/apps/expo/src/test/onboarding-store.test.ts
@@ -215,24 +215,24 @@ describe("createOnboardingController", () => {
     });
     const openAuthSession = vi
       .fn()
-      .mockResolvedValue({ type: "success", url: "teamclaw://auth/callback?code=abc" });
+      .mockResolvedValue({ type: "success", url: "teamclaw://auth-callback?code=abc" });
     const controller = createOnboardingController(api);
 
     await controller.signInWithOAuth("google", {
-      redirectTo: "teamclaw://auth/callback",
+      redirectTo: "teamclaw://auth-callback",
       openAuthSession,
     });
 
     expect(api.createOAuthSignInUrl).toHaveBeenCalledWith(
       "google",
-      "teamclaw://auth/callback",
+      "teamclaw://auth-callback",
     );
     expect(openAuthSession).toHaveBeenCalledWith(
       "https://auth.example.com/oauth",
-      "teamclaw://auth/callback",
+      "teamclaw://auth-callback",
     );
     expect(api.completeOAuthCallback).toHaveBeenCalledWith(
-      "teamclaw://auth/callback?code=abc",
+      "teamclaw://auth-callback?code=abc",
     );
     expect(controller.getState()).toMatchObject<Partial<OnboardingState>>({
       route: "ready",
@@ -248,7 +248,7 @@ describe("createOnboardingController", () => {
     const controller = createOnboardingController(api);
 
     await controller.signInWithOAuth("apple", {
-      redirectTo: "teamclaw://auth/callback",
+      redirectTo: "teamclaw://auth-callback",
       openAuthSession,
     });
 
@@ -279,24 +279,24 @@ describe("createOnboardingController", () => {
     });
     const openAuthSession = vi
       .fn()
-      .mockResolvedValue({ type: "success", url: "teamclaw://auth/callback?code=abc" });
+      .mockResolvedValue({ type: "success", url: "teamclaw://auth-callback?code=abc" });
     const controller = createOnboardingController(api);
 
     await controller.linkIdentityWithOAuth("apple", {
-      redirectTo: "teamclaw://auth/callback",
+      redirectTo: "teamclaw://auth-callback",
       openAuthSession,
     });
 
     expect(api.createOAuthLinkUrl).toHaveBeenCalledWith(
       "apple",
-      "teamclaw://auth/callback",
+      "teamclaw://auth-callback",
     );
     expect(openAuthSession).toHaveBeenCalledWith(
       "https://auth.example.com/link",
-      "teamclaw://auth/callback",
+      "teamclaw://auth-callback",
     );
     expect(api.completeOAuthCallback).toHaveBeenCalledWith(
-      "teamclaw://auth/callback?code=abc",
+      "teamclaw://auth-callback?code=abc",
     );
     expect(controller.getState()).toMatchObject<Partial<OnboardingState>>({
       route: "ready",


### PR DESCRIPTION
Google (and Apple) sign-in died silently in the Expo app: the browser opened,
the user completed consent, and nothing came back.

```
server GOTRUE_URI_ALLOW_LIST:  teamclaw://auth-callback     ← hyphen
expo sent:                     teamclaw://auth/callback     ← slash
iOS sends:                     teamclaw://auth-callback     ← matches, so iOS works
```

A redirect that is not on the allow list is **not an error** — GoTrue quietly
falls back to `SITE_URL`. So the browser lands on the API host,
`openAuthSessionAsync` never sees the app's scheme, and the flow ends with no
error surfaced anywhere. Nothing in the client or the server logs says
"rejected", which is why this looked like broken plumbing rather than a
one-character mismatch.

Pinned as a shared `OAUTH_REDIRECT_URL` matching iOS, used at all three call
sites (sign-in ×2, identity linking ×1).

A literal, not `Linking.createURL("auth-callback")`: `createURL` varies by
runtime (`exp://…/--/…` under Expo Go) and has shipped both `scheme://path` and
`scheme:///path` forms, none of which the allow list matches. The app bundles a
custom native module (`plugins/withTeamClawMqtt`) so it never runs under Expo
Go — the scheme is always `teamclaw`.

### Why the tests did not catch it

The fixtures used the wrong URL too. They passed either way
(`parseOAuthCallbackUrl` only reads query/fragment), so they documented the
broken value while proving nothing about it. They now use the real one, and a
new test pins the constant to the allow-list string so it cannot drift back.

### Verified

- Server side needs no change: GoTrue logs show a **successful** Google login
  at 05:59Z today with `referer: teamclaw://auth-callback` (from iOS), so the
  provider config and egress are fine.
- 342 tests pass; `tsc` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)