### PR TITLE
ci: bring the Expo app into CI, and fix what that surfaced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit
 
+      # `test:unit` is scoped to @teamclaw/app, so the Expo app's suite ran
+      # nowhere until now. Typecheck is deliberately NOT gated for it yet — it
+      # has 14 pre-existing errors, itemised with root causes in apps/expo/CI.md.
+      - name: Run Expo unit tests
+        run: pnpm test:expo
+
       - name: Run script tests
         run: pnpm test:scripts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,12 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit
 
-      # `test:unit` is scoped to @teamclaw/app, so the Expo app's suite ran
-      # nowhere until now. Typecheck is deliberately NOT gated for it yet — it
-      # has 14 pre-existing errors, itemised with root causes in apps/expo/CI.md.
+      # The scripts above are scoped to @teamclaw/app, so the Expo app was
+      # outside every gate until now. See apps/expo/CI.md for what is and is
+      # not covered.
+      - name: Run Expo TypeScript check
+        run: pnpm typecheck:expo
+
       - name: Run Expo unit tests
         run: pnpm test:expo
 

--- a/apps/expo/CI.md
+++ b/apps/expo/CI.md
@@ -1,0 +1,48 @@
+# Expo app — CI coverage
+
+## What CI runs
+
+`pnpm test:expo` (the vitest suite, 342 tests) runs in the `Lint, Typecheck &
+Test` job. Nothing else.
+
+## What CI does not run, and why
+
+**Typecheck is not gated.** `npx tsc --noEmit` in `apps/expo` currently reports
+14 errors, all pre-existing. Turning the gate on means fixing these first:
+
+| Count | File | Error |
+|---|---|---|
+| 9 | `src/features/shortcuts/ShortcutWebScreen.tsx` | every `<WebView>` prop: `not assignable to type 'never'` |
+| 4 | `app/(app)/(tabs)/_layout.tsx` | tab `tabBarIcon`: `ColorValue` vs `string` |
+| 1 | `src/ui/SwipeableRow.tsx` | `Swipeable` is not exported by `react-native-gesture-handler` |
+
+Root causes, so nobody has to re-derive them:
+
+- **WebView (9).** `react-native-webview` exports
+  `React.FunctionComponent<IOSWebViewProps & AndroidWebViewProps &
+  WindowsWebViewProps>`. Props that differ across those three platforms
+  intersect to `never`, so *every* prop fails. Setting
+  `compilerOptions.moduleSuffixes` to resolve `.ios`/`.native` declarations —
+  the usual fix — was tried and **made it worse** (15 errors: it broke
+  `src/ui/button.tsx` too). The remaining options are upgrading
+  `react-native-webview` past its React 19 support gap, or a narrow documented
+  cast at the call site.
+- **SwipeableRow (1).** `react-native-gesture-handler@3.0.0` removed the legacy
+  `Swipeable`. `ReanimatedSwipeable` exists at
+  `react-native-gesture-handler/ReanimatedSwipeable`. This one is cheap: the
+  local `renderRightActions` takes no arguments, so it needs only an import
+  change, not a signature migration.
+- **Tab icons (4).** Widen the local `TabIconProps.color` from `string` to
+  `ColorValue`.
+
+**Lint is not gated** either — the app has no ESLint config of its own, and the
+root `pnpm lint` is scoped to `@teamclaw/app`.
+
+## Why this matters
+
+Everything here was invisible until 2026-08. The root `lint` / `typecheck` /
+`test:unit` scripts are all `--filter @teamclaw/app`, so this app's suite had
+never run in CI at all. The OAuth redirect bug that broke every Google and
+Apple sign-in (`teamclaw://auth/callback` vs the allow-listed
+`teamclaw://auth-callback`) sat here undetected, with test fixtures that
+asserted the *broken* value.

--- a/apps/expo/CI.md
+++ b/apps/expo/CI.md
@@ -7,14 +7,15 @@ Test` job. Nothing else.
 
 ## What CI does not run, and why
 
-**Typecheck is not gated.** `npx tsc --noEmit` in `apps/expo` currently reports
-14 errors, all pre-existing. Turning the gate on means fixing these first:
+**Typecheck is not gated.** `npx tsc --noEmit` in `apps/expo` reports 10
+pre-existing errors. Turning the gate on means fixing these first:
 
 | Count | File | Error |
 |---|---|---|
 | 9 | `src/features/shortcuts/ShortcutWebScreen.tsx` | every `<WebView>` prop: `not assignable to type 'never'` |
-| 4 | `app/(app)/(tabs)/_layout.tsx` | tab `tabBarIcon`: `ColorValue` vs `string` |
 | 1 | `src/ui/SwipeableRow.tsx` | `Swipeable` is not exported by `react-native-gesture-handler` |
+
+> ⚠️ **The `SwipeableRow` one is a live crash, not a type nit.** See below.
 
 Root causes, so nobody has to re-derive them:
 
@@ -27,13 +28,27 @@ Root causes, so nobody has to re-derive them:
   `src/ui/button.tsx` too). The remaining options are upgrading
   `react-native-webview` past its React 19 support gap, or a narrow documented
   cast at the call site.
-- **SwipeableRow (1).** `react-native-gesture-handler@3.0.0` removed the legacy
-  `Swipeable`. `ReanimatedSwipeable` exists at
-  `react-native-gesture-handler/ReanimatedSwipeable`. This one is cheap: the
-  local `renderRightActions` takes no arguments, so it needs only an import
-  change, not a signature migration.
-- **Tab icons (4).** Widen the local `TabIconProps.color` from `string` to
-  `ColorValue`.
+- **SwipeableRow (1) — this is a production crash.**
+  `react-native-gesture-handler@3.0.0` removed `Swipeable` from its exports
+  **at runtime**, not just from its types. So
+  `import { Swipeable } from "react-native-gesture-handler"` binds `undefined`,
+  and `<Swipeable>` throws *Element type is invalid* the moment it renders.
+
+  `IdeasListScreen` renders `<SwipeableRow enabled={!selectionMode &&
+  !!onArchiveBatch} trailingActions={[{ label: "Archive", … }]}>`, and
+  `SwipeableRow` only short-circuits to a plain `<View>` when it is disabled or
+  has no actions — so with archiving available, **the Ideas list crashes**. No
+  test covers `SwipeableRow` or `IdeasListScreen`, which is why the suite is
+  green anyway.
+
+  The obvious replacement, `ReanimatedSwipeable` (at
+  `react-native-gesture-handler/ReanimatedSwipeable`), is **not** a drop-in:
+  `react-native-reanimated` is not a dependency, is not in `node_modules`, and
+  `babel.config.js` has no reanimated plugin — all three are required. So the
+  choice is either adopting reanimated (a native dependency, needs a device
+  build to verify) or reimplementing the swipe on RNGH's `Gesture` /
+  `GestureDetector` with RN `Animated`. Either way it needs on-device
+  verification, not just a green `tsc`.
 
 **Lint is not gated** either — the app has no ESLint config of its own, and the
 root `pnpm lint` is scoped to `@teamclaw/app`.

--- a/apps/expo/CI.md
+++ b/apps/expo/CI.md
@@ -2,61 +2,74 @@
 
 ## What CI runs
 
-`pnpm test:expo` (the vitest suite, 342 tests) runs in the `Lint, Typecheck &
-Test` job. Nothing else.
+In the `Lint, Typecheck & Test` job:
 
-## What CI does not run, and why
+- `pnpm typecheck:expo` — `tsc --noEmit`, currently clean
+- `pnpm test:expo` — the vitest suite
 
-**Typecheck is not gated.** `npx tsc --noEmit` in `apps/expo` reports 9
-remaining errors, all in one file. Turning the gate on means fixing these:
+## What CI does not run
 
-| Count | File | Error |
-|---|---|---|
-| 9 | `src/features/shortcuts/ShortcutWebScreen.tsx` | every `<WebView>` prop: `not assignable to type 'never'` |
+**Lint.** The app has no ESLint config of its own, and the root `pnpm lint` is
+scoped to `@teamclaw/app`.
 
-Root cause, so nobody has to re-derive it:
+**Anything requiring a device or a native build.** Nothing here exercises
+gestures, navigation, or the native modules — see the caveat on `SwipeableRow`
+below.
 
-- **WebView (9).** `react-native-webview` exports
-  `React.FunctionComponent<IOSWebViewProps & AndroidWebViewProps &
-  WindowsWebViewProps>`. Props that differ across those three platforms
-  intersect to `never`, so *every* prop fails. Setting
-  `compilerOptions.moduleSuffixes` to resolve `.ios`/`.native` declarations —
-  the usual fix — was tried and **made it worse** (15 errors: it broke
-  `src/ui/button.tsx` too). The remaining options are upgrading
-  `react-native-webview` past its React 19 support gap, or a narrow documented
-  cast at the call site.
-## Fixed here (kept as a record)
+## Why this exists
 
-`SwipeableRow` used to import `Swipeable` from `react-native-gesture-handler`,
-which **Gesture Handler 3 removed at runtime**, not just from its types — so
-the import bound `undefined` and `<Swipeable>` threw *Element type is invalid*
-on render. `IdeasListScreen` reaches it whenever archiving is available, so the
-Ideas list crashed. Nothing caught it: no test covered `SwipeableRow` or
-`IdeasListScreen`, and the app was outside CI entirely.
+Until 2026-08 the root `lint` / `typecheck` / `test:unit` scripts were *all*
+`--filter @teamclaw/app`, so this app was in the workspace but outside every
+gate — its tests had never run in CI, and `tsc` had drifted to 14 errors.
 
-It is now built on the v3 pan API (`usePanGesture` + `GestureDetector`) with
-React Native's own `Animated`, so it needs no `react-native-reanimated` — that
-package is absent from `package.json`, from `node_modules`, and from
-`babel.config.js`, so `ReanimatedSwipeable` was never a drop-in replacement.
-
-Two things worth knowing if you touch it:
-
-- The snap decision lives in `src/ui/swipeable-row-rest.ts`, deliberately free
-  of React and `@expo/vector-icons`. Importing the component from a test drags
-  in the icon set, which does not resolve under vitest's node environment — and
-  a test file that fails to *load* takes unrelated suites down with it.
-- **The gesture feel is unverified.** The rest-position rules are unit-tested,
-  but thresholds, scroll arbitration (`activeOffsetX` / `failOffsetY`) and the
-  spring need a device.
-
-**Lint is not gated** either — the app has no ESLint config of its own, and the
-root `pnpm lint` is scoped to `@teamclaw/app`.
-
-## Why this matters
-
-Everything here was invisible until 2026-08. The root `lint` / `typecheck` /
-`test:unit` scripts are all `--filter @teamclaw/app`, so this app's suite had
-never run in CI at all. The OAuth redirect bug that broke every Google and
-Apple sign-in (`teamclaw://auth/callback` vs the allow-listed
-`teamclaw://auth-callback`) sat here undetected, with test fixtures that
+That gap was not theoretical. The OAuth redirect bug that silently broke every
+Google and Apple sign-in (`teamclaw://auth/callback` against the allow-listed
+`teamclaw://auth-callback`) lived here undetected, with test fixtures that
 asserted the *broken* value.
+
+## Two fixes worth keeping a record of
+
+### `<WebView>` — every prop was `never`
+
+`react-native-webview@14`'s `types` field points at its **package-root**
+`index.d.ts`, not the correct one at `lib/index.d.ts`. The root file declares:
+
+```ts
+declare class WebView<P = undefined> extends Component<WebViewProps & P>
+```
+
+so the default instantiation has props of `WebViewProps & undefined` — that is,
+`never` — and *every* prop fails to typecheck, along with the ref type. This is
+an upstream declaration bug, not a platform-types problem.
+
+`ShortcutWebScreen` supplies the parameter explicitly (`WebView<object>`,
+restoring `WebViewProps & object`). Drop that once the package fixes its root
+declaration or repoints `types` at `lib/`.
+
+> Setting `compilerOptions.moduleSuffixes` to resolve `.ios`/`.native`
+> declarations looks like the fix for this and **is not** — it was tried and
+> made things worse (15 errors; it also broke `src/ui/button.tsx`).
+
+### `SwipeableRow` — the Ideas list crashed
+
+It imported `Swipeable` from `react-native-gesture-handler`, which Gesture
+Handler 3 removed **at runtime**, not just from its types. The binding was
+`undefined`, so `<Swipeable>` threw *Element type is invalid* on render, and
+`IdeasListScreen` reaches it whenever archiving is available.
+
+It is now built on the v3 pan API (`usePanGesture` + `GestureDetector`, both
+re-exported from the package root via `export * from './v3'`) driving React
+Native's own `Animated`. Deliberately not `ReanimatedSwipeable`, which needs
+`react-native-reanimated` — absent from `package.json`, from `node_modules`,
+and from `babel.config.js`.
+
+Two things to know before touching it:
+
+- The snap decision lives in `src/ui/swipeable-row-rest.ts`, kept free of React
+  and `@expo/vector-icons` so it can be unit-tested. Importing the component
+  from a test drags in the icon set, which does not resolve under vitest's node
+  environment — and a test file that fails to *load* takes unrelated suites
+  down with it.
+- **The gesture feel is unverified.** The rest-position rules have tests, but
+  thresholds, scroll arbitration (`activeOffsetX` / `failOffsetY`) and the
+  spring need a device.

--- a/apps/expo/CI.md
+++ b/apps/expo/CI.md
@@ -7,17 +7,14 @@ Test` job. Nothing else.
 
 ## What CI does not run, and why
 
-**Typecheck is not gated.** `npx tsc --noEmit` in `apps/expo` reports 10
-pre-existing errors. Turning the gate on means fixing these first:
+**Typecheck is not gated.** `npx tsc --noEmit` in `apps/expo` reports 9
+remaining errors, all in one file. Turning the gate on means fixing these:
 
 | Count | File | Error |
 |---|---|---|
 | 9 | `src/features/shortcuts/ShortcutWebScreen.tsx` | every `<WebView>` prop: `not assignable to type 'never'` |
-| 1 | `src/ui/SwipeableRow.tsx` | `Swipeable` is not exported by `react-native-gesture-handler` |
 
-> ⚠️ **The `SwipeableRow` one is a live crash, not a type nit.** See below.
-
-Root causes, so nobody has to re-derive them:
+Root cause, so nobody has to re-derive it:
 
 - **WebView (9).** `react-native-webview` exports
   `React.FunctionComponent<IOSWebViewProps & AndroidWebViewProps &
@@ -28,27 +25,29 @@ Root causes, so nobody has to re-derive them:
   `src/ui/button.tsx` too). The remaining options are upgrading
   `react-native-webview` past its React 19 support gap, or a narrow documented
   cast at the call site.
-- **SwipeableRow (1) — this is a production crash.**
-  `react-native-gesture-handler@3.0.0` removed `Swipeable` from its exports
-  **at runtime**, not just from its types. So
-  `import { Swipeable } from "react-native-gesture-handler"` binds `undefined`,
-  and `<Swipeable>` throws *Element type is invalid* the moment it renders.
+## Fixed here (kept as a record)
 
-  `IdeasListScreen` renders `<SwipeableRow enabled={!selectionMode &&
-  !!onArchiveBatch} trailingActions={[{ label: "Archive", … }]}>`, and
-  `SwipeableRow` only short-circuits to a plain `<View>` when it is disabled or
-  has no actions — so with archiving available, **the Ideas list crashes**. No
-  test covers `SwipeableRow` or `IdeasListScreen`, which is why the suite is
-  green anyway.
+`SwipeableRow` used to import `Swipeable` from `react-native-gesture-handler`,
+which **Gesture Handler 3 removed at runtime**, not just from its types — so
+the import bound `undefined` and `<Swipeable>` threw *Element type is invalid*
+on render. `IdeasListScreen` reaches it whenever archiving is available, so the
+Ideas list crashed. Nothing caught it: no test covered `SwipeableRow` or
+`IdeasListScreen`, and the app was outside CI entirely.
 
-  The obvious replacement, `ReanimatedSwipeable` (at
-  `react-native-gesture-handler/ReanimatedSwipeable`), is **not** a drop-in:
-  `react-native-reanimated` is not a dependency, is not in `node_modules`, and
-  `babel.config.js` has no reanimated plugin — all three are required. So the
-  choice is either adopting reanimated (a native dependency, needs a device
-  build to verify) or reimplementing the swipe on RNGH's `Gesture` /
-  `GestureDetector` with RN `Animated`. Either way it needs on-device
-  verification, not just a green `tsc`.
+It is now built on the v3 pan API (`usePanGesture` + `GestureDetector`) with
+React Native's own `Animated`, so it needs no `react-native-reanimated` — that
+package is absent from `package.json`, from `node_modules`, and from
+`babel.config.js`, so `ReanimatedSwipeable` was never a drop-in replacement.
+
+Two things worth knowing if you touch it:
+
+- The snap decision lives in `src/ui/swipeable-row-rest.ts`, deliberately free
+  of React and `@expo/vector-icons`. Importing the component from a test drags
+  in the icon set, which does not resolve under vitest's node environment — and
+  a test file that fails to *load* takes unrelated suites down with it.
+- **The gesture feel is unverified.** The rest-position rules are unit-tested,
+  but thresholds, scroll arbitration (`activeOffsetX` / `failOffsetY`) and the
+  spring need a device.
 
 **Lint is not gated** either — the app has no ESLint config of its own, and the
 root `pnpm lint` is scoped to `@teamclaw/app`.

--- a/apps/expo/app/(app)/(tabs)/_layout.tsx
+++ b/apps/expo/app/(app)/(tabs)/_layout.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Tabs } from "expo-router";
 import { useEffect, useState } from "react";
-import { StyleSheet } from "react-native";
+import { StyleSheet, type ColorValue } from "react-native";
 
 import {
   getUnreadSessionCount,
@@ -10,7 +10,9 @@ import {
 import { colors, typography } from "../../../src/ui/theme";
 
 type TabIconProps = {
-  color: string;
+  // `ColorValue`, not `string`: this is what expo-router hands `tabBarIcon`,
+  // and a `string` parameter makes the callback unassignable to the prop.
+  color: ColorValue;
   focused: boolean;
   size: number;
 };

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -7,7 +7,8 @@
     "dev": "expo start",
     "ios": "expo run:ios",
     "android": "expo run:android",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.13.0",

--- a/apps/expo/src/features/shortcuts/ShortcutWebScreen.tsx
+++ b/apps/expo/src/features/shortcuts/ShortcutWebScreen.tsx
@@ -15,6 +15,22 @@ import { WebView, type WebViewNavigation } from "react-native-webview";
 
 import { colors, spacing, typography } from "../../ui/theme";
 
+/**
+ * `react-native-webview@14`'s `types` field points at its package-root
+ * `index.d.ts`, which declares
+ *
+ *     declare class WebView<P = undefined> extends Component<WebViewProps & P>
+ *
+ * so the default instantiation gives props of `WebViewProps & undefined` —
+ * i.e. `never`, which makes *every* prop fail to typecheck. (The correct
+ * declaration exists at `lib/index.d.ts`; `types` just does not point there.)
+ *
+ * Supplying the parameter explicitly restores `WebViewProps & object` =
+ * `WebViewProps`. Drop this alias once the package ships a fixed root
+ * declaration, or once `types` points at `lib/`.
+ */
+type Web = WebView<object>;
+
 export type ShortcutWebScreenProps = {
   url: string;
   title: string;
@@ -22,7 +38,7 @@ export type ShortcutWebScreenProps = {
 };
 
 export function ShortcutWebScreen({ url, title, onClose }: ShortcutWebScreenProps) {
-  const webviewRef = useRef<WebView>(null);
+  const webviewRef = useRef<Web>(null);
   const insets = useSafeAreaInsets();
   const [nav, setNav] = useState<WebViewNavigation>({
     canGoBack: false,
@@ -103,7 +119,7 @@ export function ShortcutWebScreen({ url, title, onClose }: ShortcutWebScreenProp
         ) : null}
       </View>
 
-      <WebView
+      <WebView<object>
         ref={webviewRef}
         source={{ uri: url }}
         onNavigationStateChange={setNav}

--- a/apps/expo/src/test/swipeable-row.test.ts
+++ b/apps/expo/src/test/swipeable-row.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSwipeRest } from "../ui/swipeable-row-rest";
+
+const WIDTH = 100;
+
+/** A release with no meaningful velocity, so distance alone decides. */
+function released(restOffset: number, translation: number) {
+  return resolveSwipeRest({
+    restOffset,
+    translation,
+    velocity: 0,
+    actionsWidth: WIDTH,
+  });
+}
+
+describe("resolveSwipeRest", () => {
+  it("stays shut for a drag that does not clear half the strip", () => {
+    expect(released(0, -10)).toBe(0);
+    expect(released(0, -49)).toBe(0);
+  });
+
+  it("opens once the drag clears half the strip", () => {
+    expect(released(0, -51)).toBe(-WIDTH);
+    expect(released(0, -WIDTH)).toBe(-WIDTH);
+  });
+
+  it("closes an open row once it is dragged back past half", () => {
+    // Starting open (-100) and dragging right by 60 leaves it at -40.
+    expect(released(-WIDTH, 60)).toBe(0);
+    // Still past halfway, so it snaps back open.
+    expect(released(-WIDTH, 40)).toBe(-WIDTH);
+  });
+
+  it("opens on a fast left flick even when barely dragged", () => {
+    expect(
+      resolveSwipeRest({
+        restOffset: 0,
+        translation: -5,
+        velocity: -900,
+        actionsWidth: WIDTH,
+      }),
+    ).toBe(-WIDTH);
+  });
+
+  it("closes on a fast right flick even from fully open", () => {
+    expect(
+      resolveSwipeRest({
+        restOffset: -WIDTH,
+        translation: -0,
+        velocity: 900,
+        actionsWidth: WIDTH,
+      }),
+    ).toBe(0);
+  });
+
+  it("never opens before the action strip has been measured", () => {
+    // `onLayout` has not fired yet: opening to -0 would strand the row with no
+    // buttons visible under it.
+    expect(
+      resolveSwipeRest({
+        restOffset: 0,
+        translation: -400,
+        velocity: -2000,
+        actionsWidth: 0,
+      }),
+    ).toBe(0);
+  });
+
+  it("clamps to the two rest positions and nothing in between", () => {
+    const outcomes = new Set(
+      [-200, -120, -80, -60, -40, -20, 0, 20, 80].map((t) => released(0, t)),
+    );
+    expect([...outcomes].sort((a, b) => a - b)).toEqual([-WIDTH, 0]);
+  });
+});

--- a/apps/expo/src/ui/SwipeableRow.tsx
+++ b/apps/expo/src/ui/SwipeableRow.tsx
@@ -1,8 +1,16 @@
 import { Ionicons } from "@expo/vector-icons";
-import type { ReactNode } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
-import { Swipeable } from "react-native-gesture-handler";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import {
+  Animated,
+  type LayoutChangeEvent,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { GestureDetector, usePanGesture } from "react-native-gesture-handler";
 
+import { resolveSwipeRest } from "./swipeable-row-rest";
 import { colors, spacing, typography } from "./theme";
 
 export type SwipeableRowAction = {
@@ -18,70 +26,155 @@ export type SwipeableRowAction = {
 
 export type SwipeableRowProps = {
   children: ReactNode;
-  /** Trailing-edge actions (revealed by swiping left-to-right out from the right edge). */
+  /** Trailing-edge actions (revealed by swiping the row leftwards). */
   trailingActions?: SwipeableRowAction[];
   /** Whether the row should react to swipes. Default true. */
   enabled?: boolean;
 };
 
+
 /**
- * Thin wrapper over `react-native-gesture-handler` Swipeable that produces
- * the same "swipe row to reveal action buttons" interaction iOS gets for
- * free via `.swipeActions`. Keeps the row visual untouched — actions are
- * styled with Hai tokens.
+ * "Swipe row to reveal action buttons" — the interaction iOS gets for free from
+ * `.swipeActions`. Keeps the row visual untouched; actions use Hai tokens.
  *
- * Requires `GestureHandlerRootView` to be mounted at the app root.
+ * Built on the Gesture Handler v3 pan API plus React Native's own `Animated`.
+ * It deliberately does **not** use `ReanimatedSwipeable`, which would drag in
+ * `react-native-reanimated` — a native dependency this app does not have, and
+ * which would also need a babel plugin. `runOnJS` keeps the callbacks on the JS
+ * thread, which is where `Animated.Value.setValue` has to run anyway.
+ *
+ * (This replaces an import of `Swipeable`, which Gesture Handler 3 removed. That
+ * import resolved to `undefined`, so every row with actions threw
+ * "Element type is invalid" on render.)
+ *
+ * Requires `GestureHandlerRootView` at the app root — mounted in `app/_layout`.
  */
 export function SwipeableRow({
   children,
   trailingActions = [],
   enabled = true,
 }: SwipeableRowProps) {
-  if (!enabled || trailingActions.length === 0) {
+  const translateX = useRef(new Animated.Value(0)).current;
+  /** Where the row rests between gestures: 0 shut, -actionsWidth open. */
+  const restOffset = useRef(0);
+  /**
+   * Last values seen by `onUpdate`. `onFinalize` is typed with the *base* pan
+   * payload, which carries no translation or velocity — and it is the only
+   * callback guaranteed to fire, including when the gesture is cancelled
+   * mid-drag. Stashing them here is what lets the row settle from every exit
+   * path rather than only a clean release.
+   */
+  const lastTranslation = useRef(0);
+  const lastVelocity = useRef(0);
+  const [actionsWidth, setActionsWidth] = useState(0);
+
+  const active = enabled && trailingActions.length > 0;
+
+  const settle = useCallback(
+    (to: number) => {
+      restOffset.current = to;
+      Animated.spring(translateX, {
+        toValue: to,
+        useNativeDriver: true,
+        bounciness: 0,
+        speed: 20,
+      }).start();
+    },
+    [translateX],
+  );
+
+  const close = useCallback(() => settle(0), [settle]);
+
+  // A row that stops being swipeable (selection mode, actions removed) must not
+  // stay parked open — it would leave buttons stranded under a row that can no
+  // longer be dragged shut.
+  useEffect(() => {
+    if (!active && restOffset.current !== 0) close();
+  }, [active, close]);
+
+  const pan = usePanGesture({
+    enabled: active && actionsWidth > 0,
+    runOnJS: true,
+    // Only claim the gesture once it is clearly horizontal, and bail as soon as
+    // it looks vertical — otherwise the row steals the list's scroll.
+    activeOffsetX: [-12, 12],
+    failOffsetY: [-10, 10],
+    onBegin: () => {
+      lastTranslation.current = 0;
+      lastVelocity.current = 0;
+    },
+    onUpdate: (event) => {
+      lastTranslation.current = event.translationX;
+      lastVelocity.current = event.velocityX;
+      const next = restOffset.current + event.translationX;
+      // Rubber-banding is not worth it here: clamping to the strip keeps the
+      // buttons from ever being over- or under-revealed.
+      translateX.setValue(Math.max(-actionsWidth, Math.min(0, next)));
+    },
+    onFinalize: () => {
+      settle(
+        resolveSwipeRest({
+          restOffset: restOffset.current,
+          translation: lastTranslation.current,
+          velocity: lastVelocity.current,
+          actionsWidth,
+        }),
+      );
+    },
+  });
+
+  const onActionsLayout = (event: LayoutChangeEvent) => {
+    const width = Math.round(event.nativeEvent.layout.width);
+    if (width !== actionsWidth) setActionsWidth(width);
+  };
+
+  if (!active) {
     return <View>{children}</View>;
   }
 
-  const renderRightActions = () => (
-    <View style={styles.actionGroup}>
-      {trailingActions.map((action) => (
-        <Pressable
-          accessibilityLabel={action.label}
-          accessibilityRole="button"
-          key={action.label}
-          onPress={action.onPress}
-          style={({ pressed }) => [
-            styles.action,
-            action.destructive ? styles.actionDestructive : styles.actionNeutral,
-            pressed ? styles.actionPressed : null,
-          ]}
-        >
-          <Ionicons
-            color={action.destructive ? colors.paper : colors.basalt}
-            name={action.iconName}
-            size={20}
-          />
-          <Text
-            style={[
-              styles.actionLabel,
-              action.destructive ? styles.actionLabelDestructive : null,
+  return (
+    <View style={styles.container}>
+      <View onLayout={onActionsLayout} style={styles.actionGroup}>
+        {trailingActions.map((action) => (
+          <Pressable
+            accessibilityLabel={action.label}
+            accessibilityRole="button"
+            key={action.label}
+            onPress={() => {
+              // Shut the row first so it is not left open over a list that has
+              // just changed underneath it (archiving removes this very row).
+              close();
+              action.onPress();
+            }}
+            style={({ pressed }) => [
+              styles.action,
+              action.destructive ? styles.actionDestructive : styles.actionNeutral,
+              pressed ? styles.actionPressed : null,
             ]}
           >
-            {action.label}
-          </Text>
-        </Pressable>
-      ))}
-    </View>
-  );
+            <Ionicons
+              color={action.destructive ? colors.paper : colors.basalt}
+              name={action.iconName}
+              size={20}
+            />
+            <Text
+              style={[
+                styles.actionLabel,
+                action.destructive ? styles.actionLabelDestructive : null,
+              ]}
+            >
+              {action.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
 
-  return (
-    <Swipeable
-      friction={2}
-      overshootRight={false}
-      renderRightActions={renderRightActions}
-      rightThreshold={32}
-    >
-      {children}
-    </Swipeable>
+      <GestureDetector gesture={pan}>
+        <Animated.View style={{ transform: [{ translateX }] }}>
+          {children}
+        </Animated.View>
+      </GestureDetector>
+    </View>
   );
 }
 
@@ -96,7 +189,11 @@ const styles = StyleSheet.create({
     backgroundColor: colors.cinnabar,
   },
   actionGroup: {
+    bottom: 0,
     flexDirection: "row",
+    position: "absolute",
+    right: 0,
+    top: 0,
   },
   actionLabel: {
     color: colors.basalt,
@@ -112,6 +209,9 @@ const styles = StyleSheet.create({
   },
   actionPressed: {
     opacity: 0.7,
+  },
+  container: {
+    overflow: "hidden",
   },
 });
 

--- a/apps/expo/src/ui/swipeable-row-rest.ts
+++ b/apps/expo/src/ui/swipeable-row-rest.ts
@@ -1,0 +1,43 @@
+/**
+ * Rest-position logic for `SwipeableRow`, kept free of React and of
+ * `@expo/vector-icons` so it can be unit-tested. Importing the component itself
+ * from a test pulls in the icon set, which does not resolve under vitest's node
+ * environment.
+ */
+
+/** Past this fraction of the action strip, release snaps open instead of shut. */
+export const OPEN_RATIO = 0.5;
+/** A fast enough flick decides the direction regardless of distance (points/second). */
+export const FLICK_VELOCITY = 500;
+
+export type SwipeRestInput = {
+  /** Offset the row was resting at when the gesture began. */
+  restOffset: number;
+  /** Horizontal travel of the gesture (negative = leftwards). */
+  translation: number;
+  /** Horizontal velocity at release (negative = leftwards), points/second. */
+  velocity: number;
+  /** Width of the revealed action strip. */
+  actionsWidth: number;
+};
+
+/**
+ * Where the row should come to rest when the finger leaves: `0` (shut) or
+ * `-actionsWidth` (open). Never anything in between.
+ */
+export function resolveSwipeRest({
+  restOffset,
+  translation,
+  velocity,
+  actionsWidth,
+}: SwipeRestInput): number {
+  // Nothing measured yet — opening would strand the row over an empty strip.
+  if (actionsWidth <= 0) return 0;
+  // Flicks are checked before distance, so a decisive flick back to the right
+  // closes even from fully open, and a decisive left flick opens from barely
+  // moved.
+  if (velocity < -FLICK_VELOCITY) return -actionsWidth;
+  if (velocity > FLICK_VELOCITY) return 0;
+  const travelled = restOffset + translation;
+  return travelled < -actionsWidth * OPEN_RATIO ? -actionsWidth : 0;
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:all": "pnpm test:unit && pnpm expo:test",
     "test:unit": "pnpm --filter @teamclaw/app test:unit",
     "test:expo": "pnpm --filter @teamclaw/expo test",
+    "typecheck:expo": "pnpm --filter @teamclaw/expo typecheck",
     "test:scripts": "node --test scripts/lib/*.test.js",
     "test:smoke": "vitest run --config vitest.config.v2-e2e.ts tests/v2-e2e/pr",
     "test:e2e": "pnpm test:e2e:v2:pr",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test": "pnpm test:unit",
     "test:all": "pnpm test:unit && pnpm expo:test",
     "test:unit": "pnpm --filter @teamclaw/app test:unit",
+    "test:expo": "pnpm --filter @teamclaw/expo test",
     "test:scripts": "node --test scripts/lib/*.test.js",
     "test:smoke": "vitest run --config vitest.config.v2-e2e.ts tests/v2-e2e/pr",
     "test:e2e": "pnpm test:e2e:v2:pr",


### PR DESCRIPTION
The root `lint` / `typecheck` / `test:unit` scripts are all
`--filter @teamclaw/app`, so the Expo app sat in the workspace but outside
every gate — its tests had never run in CI, and `tsc` had drifted to 14 errors.

Four commits: wire it into CI, then clear everything that turned up.

| Commit | What |
|---|---|
| `ci:` | `test:expo` root script + CI step |
| `fix(expo): type tab icons` | `TabIconProps.color` → `ColorValue` (4 errors) |
| `fix(expo): unbreak the Ideas list` | **a live crash** — see below (1 error) |
| `fix(expo): instantiate WebView's type param` | upstream declaration bug (9 errors), then gate typecheck |

Result: `tsc --noEmit` clean (14 → 0) and both typecheck and tests now gate.

### The Ideas list was crashing

`SwipeableRow` imported `Swipeable` from `react-native-gesture-handler`, which
Gesture Handler 3 removed **at runtime**, not just from its types. The binding
was `undefined`, so `<Swipeable>` threw *Element type is invalid* on render —
and `IdeasListScreen` reaches it whenever archiving is available.

Rebuilt on the v3 pan API (`usePanGesture` + `GestureDetector`, re-exported
from the package root via `export * from './v3'`) driving React Native's own
`Animated`. Deliberately **not** `ReanimatedSwipeable`, which needs
`react-native-reanimated` — absent from package.json, node_modules and
babel.config.js, and incompatible with this React Native anyway (see #806).

Public props unchanged, so `IdeasListScreen` needed no edit.

### The WebView errors were an upstream bug, not platform-props conflict

`react-native-webview@14`'s `types` field points at its **package-root**
`index.d.ts` rather than the correct `lib/index.d.ts`. The root file declares

```ts
declare class WebView<P = undefined> extends Component<WebViewProps & P>
```

so the default instantiation gives props of `WebViewProps & undefined` — i.e.
`never`, which is why all nine errors read "not assignable to type 'never'",
one per prop. Supplying the parameter explicitly (`WebView<object>`) restores
`WebViewProps & object`. No cast, no tsconfig override, no dependency change.

> `moduleSuffixes` looks like the fix here and is not — it was tried and made
> things worse (15 errors). `apps/expo/CI.md` records that so nobody repeats it.

### Caveat worth reviewing

**The swipe gesture's feel is unverified.** The rest-position rules are
unit-tested (7 new tests), but thresholds, scroll arbitration
(`activeOffsetX` / `failOffsetY`) and the spring need a device. Native builds
were blocked by #806; even with that, the app cannot reach MQTT on a device
until port 8883 is resolved (see #806's description).

### Verified

`pnpm typecheck:expo` clean · `pnpm test:expo` 74 files / 347 tests · main
app's `pnpm typecheck` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)