### PR TITLE
feat(self-host): serve MQTT over TLS on 8883

### DIFF
--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -28,11 +28,10 @@ services:
     # only fronts the WebSocket listener (8083) on 443. Without this mapping the
     # broker is reachable only on the internal docker network (emqx:1883), so
     # external clients get "Connection refused (os error 61)".
-    # NOTE: the ECS security group must also allow inbound TCP 1883.
-    # Only the plaintext TCP listener (1883) is configured in emqx.conf; there
-    # is no SSL listener (8883), so we do not publish it.
+    # NOTE: the ECS security group must also allow inbound TCP 1883 and 8883.
     ports:
       - "1883:1883"   # MQTT (plaintext, listeners.tcp.default)
+      - "8883:8883"   # MQTT over TLS (listeners.ssl.default) — mobile native clients
     environment:
       # EMQX expects the HMAC secret base64-encoded (secret_base64_encoded=true).
       EMQX_JWT_SECRET: "${EMQX_JWT_SECRET}"
@@ -46,6 +45,11 @@ services:
     volumes:
       - ./emqx/emqx.conf:/opt/emqx/etc/emqx.conf:ro
       - emqx_data:/opt/emqx/data
+      # Read-only view of Caddy's ACME storage so the 8883 listener can reuse
+      # the Let's Encrypt cert Caddy already obtains for MQTT_DOMAIN, instead of
+      # running a second ACME client for the same name. EMQX reads it once at
+      # listener start — see the renewal warning in emqx/emqx.conf.
+      - caddy_data:/caddy-certs:ro
     healthcheck:
       test: ["CMD", "/opt/emqx/bin/emqx", "ctl", "status"]
       interval: 10s

--- a/deploy/self-host/emqx/emqx.conf
+++ b/deploy/self-host/emqx/emqx.conf
@@ -18,11 +18,35 @@ listeners.ws.default {
   websocket.mqtt_path = "/mqtt"
 }
 
-# Image defaults still enable SSL/WSS (8883/8084). Disable them — self-host uses
-# plaintext 1883 internally and Caddy-terminated WSS in production; on a 2GiB
-# Podman VM the extra listeners push EMQX into OOM (connection closed by peer).
+# MQTT over TLS, for the mobile apps' native MQTT clients (HiveMQ on Android,
+# CocoaMQTT on iOS). They speak raw MQTT, not WebSocket, so Caddy's WSS on 443
+# does not serve them — `parseNativeUrl` in apps/expo maps a `wss://` broker URL
+# to port 8883.
+#
+# This was previously disabled with the note "on a 2GiB Podman VM the extra
+# listeners push EMQX into OOM". That constraint no longer holds: the box now
+# has 7.1GiB and EMQX sits at ~340MiB (<5%), with no OOM kills and no restarts.
+#
+# ⚠️ THE CERTIFICATE IS CADDY'S, AND EMQX ONLY READS IT AT LISTENER START.
+#
+# Reusing Caddy's Let's Encrypt cert avoids running a second ACME client, but
+# Caddy renews roughly every 60 days and EMQX keeps serving the copy it loaded
+# at boot. A renewed cert therefore does NOT reach this listener until EMQX is
+# restarted — after which 8883 starts presenting an EXPIRED certificate while
+# 443/WSS stays perfectly healthy. Native clients fail TLS verification; nothing
+# alerts; Caddy's own view of the cert looks fine, so the obvious place to look
+# is the wrong one.
+#
+# Restarting EMQX periodically is what keeps this listener working. That is a
+# deliberate operational choice made when this was enabled, not an oversight.
 listeners.ssl.default {
-  enable = false
+  enable = true
+  bind = "0.0.0.0:8883"
+  ssl_options {
+    # `caddy_data` is mounted read-only at /caddy-certs (see docker-compose.yml).
+    certfile = "/caddy-certs/caddy/certificates/acme-v02.api.letsencrypt.org-directory/mqtt.teamclaw-dev.ucar.cc/mqtt.teamclaw-dev.ucar.cc.crt"
+    keyfile = "/caddy-certs/caddy/certificates/acme-v02.api.letsencrypt.org-directory/mqtt.teamclaw-dev.ucar.cc/mqtt.teamclaw-dev.ucar.cc.key"
+  }
 }
 
 listeners.wss.default {


### PR DESCRIPTION
The mobile apps' native MQTT clients (HiveMQ on Android, CocoaMQTT on iOS)
speak raw MQTT, not WebSocket, so Caddy's WSS on 443 does not serve them —
`parseNativeUrl` in `apps/expo` maps a `wss://` broker URL with no explicit
port to **8883**. That port was refused, verified three ways (`nc -z`,
`/dev/tcp`, `openssl s_client` → `errno=61`), so on a device only the
JS/WebSocket fallback could connect.

Two things were missing, not one:

- `listeners.ssl.default` was `enable = false` in `emqx.conf`
- 8883 was `EXPOSE`d by the image but never published to the host

### Reusing Caddy's certificate

`caddy_data` is mounted read-only at `/caddy-certs`, so the listener uses the
Let's Encrypt cert Caddy already obtains for `MQTT_DOMAIN`. No second ACME
client for the same name.

### Why the listener had been disabled, and why that no longer applies

The old comment read *"on a 2GiB Podman VM the extra listeners push EMQX into
OOM"*. Measured on the box today: **7.1GiB total**, EMQX at **~340MiB (<5%)**,
`OOMKilled: false`, `RestartCount: 0`. The constraint is gone.

### ⚠️ This adds a renewal dependency, deliberately

EMQX reads the certificate **only when the listener starts**; Caddy renews
roughly every 60 days. A renewed cert does not reach this listener until EMQX
restarts — after which:

- 8883 serves an **expired** certificate
- 443/WSS stays perfectly healthy
- native clients fail TLS verification
- nothing alerts, and Caddy's own view of the cert looks fine

so the obvious place to look is the wrong one. **Periodically restarting EMQX
is what keeps this listener working** — that is the agreed operational answer
here, not an oversight, and the failure mode is written into `emqx.conf` so
whoever hits it does not have to rediscover it.

### Two things this PR cannot do

1. **The ECS security group must allow inbound TCP 8883.** Until it does,
   external clients still get connection-refused — which looks identical to
   this change not having deployed. The compose comment now names both ports.
2. Deploying restarts EMQX, which **briefly drops every live MQTT connection**
   (desktop apps, daemons). Short, but not zero.

`docker-compose.podman.yml` is an override with no emqx `ports`/`volumes` of
its own, so it inherits this from the base file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)