### PR TITLE
docs(expo): make .env.example match what the app actually reads

### DIFF
--- a/apps/expo/.env.example
+++ b/apps/expo/.env.example
@@ -1,4 +1,11 @@
-EXPO_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
-# Optional: defaults to mqtts://ai.ucar.cc:8883 for the native MQTT bridge.
+# Required. `cloud_api` is the only client backend, and the app throws on the
+# first render without this — see `cloudApiBaseUrl` in src/lib/cloud-api/client.ts.
+EXPO_PUBLIC_CLOUD_API_URL=https://api.teamclaw-dev.ucar.cc
+
+# Optional, and normally left empty.
+#
+# The broker address is NOT bundled: `resolveMqttUrl` fetches it from
+# `GET /v1/config/bootstrap` and caches it, so a broker that moves does not need
+# an app release. Set this only to pin a specific broker for local development —
+# it overrides the fetch entirely.
 EXPO_PUBLIC_MQTT_URL=

--- a/apps/expo/README.md
+++ b/apps/expo/README.md
@@ -65,13 +65,16 @@ should be made in the `app/` directory.
 
 Create `apps/expo/.env` from `.env.example` and provide:
 
-- `EXPO_PUBLIC_SUPABASE_URL`
-- `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
-- `EXPO_PUBLIC_MQTT_URL` only when pinning a broker for local development
+- `EXPO_PUBLIC_CLOUD_API_URL` — **required**
+- `EXPO_PUBLIC_MQTT_URL` — optional, only when pinning a broker for local
+  development
 
-These values are required for the Expo app to start correctly. If either one is
-missing, the current app bootstrap fails instead of falling back to a limited
-onboarding shell.
+`EXPO_PUBLIC_CLOUD_API_URL` is the one that must be set. Without it the app
+throws on its first render (`EXPO_PUBLIC_CLOUD_API_URL is required (cloud_api is
+the only backend)`) rather than falling back to a limited onboarding shell.
+
+`EXPO_PUBLIC_*` values are inlined at bundle time, so **restart Metro after
+editing `.env`** — an already-running dev server keeps serving the old values.
 
 The MQTT broker address is **not** bundled: `resolveMqttUrl` fetches it from
 `GET /v1/config/bootstrap` (server-side `MQTT_PUBLIC_TCP_BROKER_URL` /


### PR DESCRIPTION
Following `.env.example` produced an app that crashed on its first render:

```
Render Error
EXPO_PUBLIC_CLOUD_API_URL is required (cloud_api is the only backend).
  at cloudApiBaseUrl (src/lib/cloud-api/client.ts:28)
```

The example documented `EXPO_PUBLIC_SUPABASE_URL` and
`EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY` — **neither appears anywhere in the
app's source**, left over from before the move to a cloud-API-only backend.
Meanwhile the one variable that is genuinely required,
`EXPO_PUBLIC_CLOUD_API_URL`, was not mentioned at all. `README.md` listed the
same two dead variables.

### Verified in both directions

```
.env.example declares : ['EXPO_PUBLIC_CLOUD_API_URL', 'EXPO_PUBLIC_MQTT_URL']
source actually reads : ['EXPO_PUBLIC_CLOUD_API_URL', 'EXPO_PUBLIC_MQTT_URL']
declared but unused   : none
used but undeclared   : none
```

(`EXPO_PUBLIC_BACKEND_KIND` appears only inside a test's `vi.stubEnv`, never in
app code, so it is deliberately not listed.)

### Also corrected

- **`EXPO_PUBLIC_MQTT_URL` guidance.** It is optional and normally empty —
  `resolveMqttUrl` fetches the broker from `GET /v1/config/bootstrap` so a
  broker that moves needs no app release, and setting this overrides that fetch
  entirely. The old comment implied a bundled default host
  (`mqtts://ai.ucar.cc:8883`), which is not how the code works.
- **Added the detail that costs an afternoon otherwise**: `EXPO_PUBLIC_*` is
  inlined at bundle time, so Metro has to be restarted after editing `.env`.
  Editing the file and reloading the app changes nothing.

### Why this went unnoticed

Same shape as the metro pin and the OAuth redirect: the app could not be
launched by anyone (Metro would not start until #809), so config drift had no
way of surfacing. This was hit the first time the app actually booted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)