### PR TITLE
fix(daemon): reconcile team env cloud cache after writes

### DIFF
--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -1317,6 +1317,11 @@ impl DaemonServer {
         // A background tick rather than a fetch on the read path: both readers
         // are synchronous and sit on the runtime spawn path, and agents have to
         // start while offline. See `runtime::team_cloud_config`.
+        //
+        // Desktop also triggers an immediate reconcile via
+        // `POST /v1/team/cloud-config/reconcile` after a Cloud API write; that
+        // path shares the same fan-out so a cache update surfaces "runtime
+        // needs restart" without waiting for this tick.
         if let Some(team_id) = self
             .config
             .team_id
@@ -1325,23 +1330,27 @@ impl DaemonServer {
             .filter(|id| !id.is_empty())
             .map(str::to_owned)
         {
-            use crate::runtime::team_cloud_config::log_team_cloud_outcome;
+            use crate::runtime::team_cloud_config::apply_team_cloud_outcome;
             let resolver = Arc::new(
                 crate::runtime::team_cloud_config::TeamCloudConfigResolver::new(
                     self.backend.clone(),
                 ),
             );
+            let backend = Some(self.backend.clone());
+            let refresh = self.refresh_coordinator.clone();
             tokio::spawn(async move {
                 // Once up front so a freshly started daemon converges without
                 // waiting out the first tick, then on the TTL cadence.
                 let outcome = resolver.reconcile_now(&team_id).await;
-                log_team_cloud_outcome(&team_id, outcome);
+                apply_team_cloud_outcome(&team_id, outcome, backend.as_ref(), refresh.as_ref())
+                    .await;
                 let mut tick = tokio::time::interval(Duration::from_secs(300));
                 tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 loop {
                     tick.tick().await;
                     let outcome = resolver.reconcile(&team_id).await;
-                    log_team_cloud_outcome(&team_id, outcome);
+                    apply_team_cloud_outcome(&team_id, outcome, backend.as_ref(), refresh.as_ref())
+                        .await;
                 }
             });
         }

--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -185,6 +185,12 @@ pub fn build(state: HttpState) -> Router {
         // Daemon-owned team sync: desktop triggers sync + reads status over loopback.
         .route("/v1/team/sync", post(team_sync::sync_now))
         .route("/v1/team/sync/status", get(team_sync::sync_status))
+        // Pull team MCP / team env from Cloud API into the daemon cache now
+        // (desktop calls this after a successful env-secret write/delete).
+        .route(
+            "/v1/team/cloud-config/reconcile",
+            post(team_sync::reconcile_cloud_config),
+        )
         .route(
             "/v1/team/secrets",
             post(team_sync::set_secrets).get(team_sync::get_secrets),

--- a/apps/daemon/src/http/server.rs
+++ b/apps/daemon/src/http/server.rs
@@ -125,6 +125,11 @@ pub async fn spawn(
     let managed_llm = backend
         .clone()
         .map(|b| Arc::new(crate::runtime::managed_llm::ManagedLlmResolver::new(b)));
+    // Same shape for team MCP / team env: desktop posts after a Cloud API write
+    // so the daemon cache converges immediately instead of waiting for the tick.
+    let team_cloud = backend.clone().map(|b| {
+        Arc::new(crate::runtime::team_cloud_config::TeamCloudConfigResolver::new(b))
+    });
 
     let state = HttpState::new(
         http,
@@ -141,6 +146,7 @@ pub async fn spawn(
     .with_config_admin(config_path, channel_reload_tx, onboarding)
     .with_live_tee(live_tee)
     .with_managed_llm(managed_llm)
+    .with_team_cloud(team_cloud)
     .with_local_rpc(local_rpc_tx)
     .with_local_live_ingest(local_live_ingest_tx);
 

--- a/apps/daemon/src/http/state.rs
+++ b/apps/daemon/src/http/state.rs
@@ -140,6 +140,11 @@ pub struct HttpState {
     /// member on a plain refresh rather than only at the next runtime spawn.
     /// `None` in focused tests — the reconcile is then skipped.
     pub managed_llm: Option<Arc<crate::runtime::managed_llm::ManagedLlmResolver>>,
+    /// Mirrors team MCP / team env from the Cloud API onto the daemon-owned
+    /// cache under `~/.amuxd/teams/<id>/cloud/`. Shared with the background
+    /// tick so a post-write `POST /v1/team/cloud-config/reconcile` and the
+    /// periodic poll share one TTL/`last_fetch`. `None` in focused tests.
+    pub team_cloud: Option<Arc<crate::runtime::team_cloud_config::TeamCloudConfigResolver>>,
     /// `daemon.toml` path backing `/v1/config/*`. `None` in focused tests —
     /// those routes then return 503.
     pub config_path: Option<std::path::PathBuf>,
@@ -197,6 +202,7 @@ impl HttpState {
             backend: None,
             live_tee: None,
             managed_llm: None,
+            team_cloud: None,
             config_path: None,
             channel_reload_tx: None,
             onboarding: None,
@@ -233,6 +239,15 @@ impl HttpState {
         managed_llm: Option<Arc<crate::runtime::managed_llm::ManagedLlmResolver>>,
     ) -> Self {
         self.managed_llm = managed_llm;
+        self
+    }
+
+    /// Attach the shared team-cloud (MCP/env) cache resolver.
+    pub fn with_team_cloud(
+        mut self,
+        team_cloud: Option<Arc<crate::runtime::team_cloud_config::TeamCloudConfigResolver>>,
+    ) -> Self {
+        self.team_cloud = team_cloud;
         self
     }
 

--- a/apps/daemon/src/http/team_sync.rs
+++ b/apps/daemon/src/http/team_sync.rs
@@ -101,6 +101,66 @@ pub async fn sync_status(
     Ok(Json(state.sync_dispatcher.status(&q.team_id).await))
 }
 
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconcileCloudConfigRequest {
+    /// Optional override; when omitted the daemon's onboarded team is used.
+    #[serde(default)]
+    pub team_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconcileCloudConfigResponse {
+    pub team_id: String,
+    pub mcp_changed: bool,
+    pub env_changed: bool,
+}
+
+/// `POST /v1/team/cloud-config/reconcile` — pull team MCP / team env from the
+/// Cloud API into the daemon-owned cache immediately, then fan-out refresh
+/// signals so the UI can prompt for a runtime restart.
+///
+/// Desktop calls this after a successful team env write/delete. Without it the
+/// background tick (300s) is the only converge path, and the cloud cache sits
+/// outside every `refresh_watch` root so no EnvVars change would ever surface.
+pub async fn reconcile_cloud_config(
+    principal: Principal,
+    State(state): State<HttpState>,
+    Json(body): Json<ReconcileCloudConfigRequest>,
+) -> Result<Json<ReconcileCloudConfigResponse>, HttpError> {
+    require_scope(&principal, "workspace:write")?;
+    let team_id = body
+        .team_id
+        .and_then(|id| {
+            let trimmed = id.trim().to_string();
+            (!trimmed.is_empty()).then_some(trimmed)
+        })
+        .map(Ok)
+        .unwrap_or_else(|| team_id_for_workspace(""))?;
+
+    let Some(resolver) = state.team_cloud.as_ref() else {
+        return Err(HttpError::runtime_unavailable(
+            "team cloud config resolver is not available",
+        ));
+    };
+
+    let outcome = resolver.reconcile_now(&team_id).await;
+    crate::runtime::team_cloud_config::apply_team_cloud_outcome(
+        &team_id,
+        outcome,
+        state.backend.as_ref(),
+        state.runtime_refresh.as_ref(),
+    )
+    .await;
+
+    Ok(Json(ReconcileCloudConfigResponse {
+        team_id,
+        mcp_changed: outcome.mcp_changed,
+        env_changed: outcome.env_changed,
+    }))
+}
+
 // ---------------------------------------------------------------------------
 // Task 11: secrets delivery
 // ---------------------------------------------------------------------------

--- a/apps/daemon/src/runtime/team_cloud_config.rs
+++ b/apps/daemon/src/runtime/team_cloud_config.rs
@@ -78,21 +78,8 @@ impl TeamCloudReconcileOutcome {
     }
 }
 
-/// Report what a reconcile changed.
-///
-/// **Known gap, deliberately left for the PR that makes it reachable.** When the
-/// cache changes, affected workspaces should also get a
-/// `RefreshChangeKind::{Mcp, EnvVars}` recorded so the UI surfaces "runtime
-/// needs restart" — that is what `refresh_watch` does today for the on-disk
-/// `.mcp/` and `_secrets/` directories, and the cloud cache is outside every
-/// watched root (it is a daemon-private sibling of the synced team dir, by
-/// design). The signal cannot ride the watcher; it has to come from here.
-///
-/// It is not wired yet because `RefreshCoordinator::record_change` is
-/// per-workspace while this resolver is per-team, so it needs a fan-out over the
-/// team's workspaces — and until clients start writing team MCP/env, every
-/// reconcile is a no-op, which would make that fan-out untestable dead code.
-/// Wire it alongside the first write path.
+/// Log a reconcile outcome (no fan-out). Prefer [`apply_team_cloud_outcome`]
+/// whenever a refresh coordinator is available.
 pub fn log_team_cloud_outcome(team_id: &str, outcome: TeamCloudReconcileOutcome) {
     if outcome.changed() {
         tracing::info!(
@@ -100,6 +87,98 @@ pub fn log_team_cloud_outcome(team_id: &str, outcome: TeamCloudReconcileOutcome)
             mcp_changed = outcome.mcp_changed,
             env_changed = outcome.env_changed,
             "team cloud config cache updated"
+        );
+    }
+}
+
+/// Log + fan-out `RefreshChangeKind::{Mcp, EnvVars}` to every local workspace
+/// of `team_id`.
+///
+/// The cloud cache lives under `~/.amuxd/teams/<id>/cloud/`, a sibling of the
+/// synced team dir and outside every `refresh_watch` root — so a cache update
+/// never produces a filesystem watch event. The signal has to come from here:
+/// `record_change` is per-workspace while the resolver is per-team.
+pub async fn apply_team_cloud_outcome(
+    team_id: &str,
+    outcome: TeamCloudReconcileOutcome,
+    backend: Option<&Arc<dyn Backend>>,
+    refresh: Option<&Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>>,
+) {
+    log_team_cloud_outcome(team_id, outcome);
+    if !outcome.changed() {
+        return;
+    }
+    let Some(refresh) = refresh else {
+        return;
+    };
+    let Some(backend) = backend else {
+        return;
+    };
+
+    let rows = match backend
+        .get_workspaces_by_agent(team_id, backend.actor_id())
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(
+                team_id,
+                error = %e,
+                "team cloud cache changed but workspace list failed; skipping refresh fan-out"
+            );
+            return;
+        }
+    };
+
+    for row in rows {
+        let Some((path, _)) = crate::config::workspace_path::listable_local_workspace(&row) else {
+            continue;
+        };
+        let workspace_path = PathBuf::from(&path);
+        let workspace_id =
+            crate::runtime::refresh::refresh_watch::workspace_runtime_id(&workspace_path);
+        if outcome.env_changed {
+            record_refresh(
+                refresh,
+                &workspace_id,
+                &workspace_path,
+                crate::runtime::refresh::RefreshChangeKind::EnvVars,
+            )
+            .await;
+        }
+        if outcome.mcp_changed {
+            record_refresh(
+                refresh,
+                &workspace_id,
+                &workspace_path,
+                crate::runtime::refresh::RefreshChangeKind::Mcp,
+            )
+            .await;
+        }
+    }
+}
+
+async fn record_refresh(
+    refresh: &crate::runtime::refresh::RuntimeRefreshCoordinator,
+    workspace_id: &str,
+    workspace_path: &Path,
+    kind: crate::runtime::refresh::RefreshChangeKind,
+) {
+    if let Err(error) = refresh
+        .record_change(
+            workspace_id,
+            workspace_path,
+            kind,
+            crate::runtime::refresh::RefreshSource::UiMutation,
+        )
+        .await
+    {
+        tracing::warn!(
+            workspace_id,
+            workspace_path = %workspace_path.display(),
+            ?kind,
+            error = %error,
+            "failed to record refresh change after team cloud reconcile"
         );
     }
 }

--- a/apps/desktop/src/commands/diagnostics.rs
+++ b/apps/desktop/src/commands/diagnostics.rs
@@ -197,15 +197,12 @@ fn gather_team_env_diagnostics(workspace_path: &str, team_id: Option<&str>) -> T
     };
     let target_accessible = std::fs::metadata(&link).is_ok();
 
-    let secrets_dir = link.join(super::shared_secrets::SECRETS_DIR);
-    let secrets_dir_exists = secrets_dir.exists();
-    let secret_file_count = std::fs::read_dir(&secrets_dir)
-        .map(|rd| {
-            rd.flatten()
-                .filter(|e| e.file_name().to_string_lossy().ends_with(".enc.json"))
-                .count()
-        })
-        .unwrap_or(0);
+    let (cloud_secrets_dir, secrets_dir_exists, secret_file_count) =
+        super::env_vars::team_cloud_secrets_diag(team_id_trimmed.as_deref());
+
+    let legacy_secrets_dir = link.join(super::shared_secrets::SECRETS_DIR);
+    let legacy_secrets_dir_exists = legacy_secrets_dir.exists();
+    let legacy_secret_file_count = super::env_vars::count_enc_json_files(&legacy_secrets_dir);
 
     let secret_configured = teamclaw_runtime_env::env_catalog::resolve_team_env_secret(
         ws,
@@ -223,6 +220,9 @@ fn gather_team_env_diagnostics(workspace_path: &str, team_id: Option<&str>) -> T
         target_accessible,
         secrets_dir_exists,
         secret_file_count,
+        cloud_secrets_dir,
+        legacy_secrets_dir_exists,
+        legacy_secret_file_count,
         secret_configured,
     }
 }

--- a/apps/desktop/src/commands/env_vars.rs
+++ b/apps/desktop/src/commands/env_vars.rs
@@ -527,10 +527,18 @@ pub struct TeamEnvDiagnostics {
     pub link_target: Option<String>,
     /// The path is accessible following the link (a dangling symlink is false).
     pub target_accessible: bool,
-    /// A `_secrets/` directory exists under the team dir.
+    /// Daemon cloud cache dir exists:
+    /// `~/.amuxd/teams/<teamId>/cloud/_secrets`.
     pub secrets_dir_exists: bool,
-    /// Count of `*.enc.json` secret files present under `_secrets/`.
+    /// Count of `*.enc.json` files in the daemon cloud cache (authoritative
+    /// after the Cloud API migration).
     pub secret_file_count: usize,
+    /// Absolute path of the cloud `_secrets` cache (empty when team id missing).
+    pub cloud_secrets_dir: String,
+    /// Legacy workspace `teamclaw-team/_secrets` still present from the
+    /// git/OSS era. Informational only — cloud cache wins at runtime.
+    pub legacy_secrets_dir_exists: bool,
+    pub legacy_secret_file_count: usize,
     /// A local team secret is resolvable, so shared writes can be encrypted and
     /// existing secrets decrypted.
     pub secret_configured: bool,
@@ -568,15 +576,12 @@ pub async fn team_env_diagnostics(
     // `metadata` follows symlinks: a dangling link yields Err → not accessible.
     let target_accessible = std::fs::metadata(&link).is_ok();
 
-    let secrets_dir = link.join(super::shared_secrets::SECRETS_DIR);
-    let secrets_dir_exists = secrets_dir.exists();
-    let secret_file_count = std::fs::read_dir(&secrets_dir)
-        .map(|rd| {
-            rd.flatten()
-                .filter(|e| e.file_name().to_string_lossy().ends_with(".enc.json"))
-                .count()
-        })
-        .unwrap_or(0);
+    let (cloud_secrets_dir, secrets_dir_exists, secret_file_count) =
+        team_cloud_secrets_diag(team_id_trimmed.as_deref());
+
+    let legacy_secrets_dir = link.join(super::shared_secrets::SECRETS_DIR);
+    let legacy_secrets_dir_exists = legacy_secrets_dir.exists();
+    let legacy_secret_file_count = count_enc_json_files(&legacy_secrets_dir);
 
     let secret_configured = teamclaw_runtime_env::env_catalog::resolve_team_env_secret(
         ws,
@@ -594,8 +599,36 @@ pub async fn team_env_diagnostics(
         target_accessible,
         secrets_dir_exists,
         secret_file_count,
+        cloud_secrets_dir,
+        legacy_secrets_dir_exists,
+        legacy_secret_file_count,
         secret_configured,
     })
+}
+
+/// `~/.amuxd/teams/<teamId>/cloud/_secrets` presence + `*.enc.json` count.
+pub(crate) fn team_cloud_secrets_diag(team_id: Option<&str>) -> (String, bool, usize) {
+    let Some(team_id) = team_id.map(str::trim).filter(|s| !s.is_empty()) else {
+        return (String::new(), false, 0);
+    };
+    let dir = super::amuxd_home_dir()
+        .join("teams")
+        .join(team_id)
+        .join("cloud")
+        .join(super::shared_secrets::SECRETS_DIR);
+    let exists = dir.exists();
+    let count = count_enc_json_files(&dir);
+    (dir.display().to_string(), exists, count)
+}
+
+pub(crate) fn count_enc_json_files(dir: &Path) -> usize {
+    std::fs::read_dir(dir)
+        .map(|rd| {
+            rd.flatten()
+                .filter(|e| e.file_name().to_string_lossy().ends_with(".enc.json"))
+                .count()
+        })
+        .unwrap_or(0)
 }
 
 /// Diagnostics for the personal env-var store + workspace index alignment.

--- a/apps/desktop/src/commands/shared_secrets.rs
+++ b/apps/desktop/src/commands/shared_secrets.rs
@@ -483,6 +483,10 @@ pub(crate) async fn set_secret_for_workspace(
     }
 
     app_handle.emit("secrets-changed", ()).ok();
+    // Best-effort: kick the daemon cache so the new value is injectable without
+    // waiting for the 300s background tick. A failure here must not undo the
+    // durable Cloud API write — the tick will catch up.
+    notify_daemon_team_cloud_reconcile(&team_id).await;
     log::info!("shared_secrets: set secret '{}'", key_id);
     Ok(())
 }
@@ -549,8 +553,17 @@ pub(crate) async fn delete_secret_for_workspace(
     }
 
     app_handle.emit("secrets-changed", ()).ok();
+    notify_daemon_team_cloud_reconcile(&team_id).await;
     log::info!("shared_secrets: deleted secret '{}'", key_id);
     Ok(())
+}
+
+async fn notify_daemon_team_cloud_reconcile(team_id: &str) {
+    if let Err(e) = super::team_sync_proxy::daemon_team_cloud_reconcile(team_id).await {
+        log::warn!(
+            "shared_secrets: daemon cloud-config reconcile failed (will retry on tick): {e}"
+        );
+    }
 }
 
 /// Pull team env from the Cloud API and merge it over whatever the legacy

--- a/apps/desktop/src/commands/team_sync_proxy.rs
+++ b/apps/desktop/src/commands/team_sync_proxy.rs
@@ -186,6 +186,20 @@ pub async fn daemon_team_sync(
     .await
 }
 
+/// `POST /v1/team/cloud-config/reconcile` — pull team MCP/env into the daemon
+/// cache now. Called after a successful Cloud API env-secret write/delete so
+/// the agent runtime does not wait up to 5 minutes for the background tick.
+pub async fn daemon_team_cloud_reconcile(team_id: &str) -> Result<(), String> {
+    daemon_request_unit(
+        reqwest::Method::POST,
+        "/v1/team/cloud-config/reconcile",
+        "",
+        &["workspace:write"],
+        Some(&serde_json::json!({ "teamId": team_id })),
+    )
+    .await
+}
+
 /// Stable daemon problem+json code when the global team dir is not a git repo.
 pub const TEAM_SHARED_DIR_NOT_GIT_CODE: &str = "team_shared_dir_not_git";
 

--- a/packages/app/src/components/settings/EnvVarsSection.tsx
+++ b/packages/app/src/components/settings/EnvVarsSection.tsx
@@ -527,8 +527,12 @@ interface TeamEnvDiagnostics {
   linkIsSymlink: boolean
   linkTarget: string | null
   targetAccessible: boolean
+  /** Daemon cloud cache `~/.amuxd/teams/<id>/cloud/_secrets`. */
   secretsDirExists: boolean
   secretFileCount: number
+  cloudSecretsDir?: string
+  legacySecretsDirExists?: boolean
+  legacySecretFileCount?: number
   secretConfigured: boolean
 }
 
@@ -633,14 +637,21 @@ function TeamEnvDiagnosticsCard({
                     : undefined
                 }
               />
-              {/* Encrypted files present */}
+              {/* Encrypted files in daemon cloud cache */}
               <DiagRow
-                ok={diag.secretFileCount > 0}
-                label={t('settings.envVars.diag.files', '加密文件')}
-                value={t('settings.envVars.diag.filesCount', '{{count}} 个 (_secrets/*.enc.json)', { count: diag.secretFileCount })}
+                ok={diag.secretsDirExists}
+                label={t('settings.envVars.diag.files', '云端缓存')}
+                value={t(
+                  'settings.envVars.diag.filesCount',
+                  '{{count}} 个 (cloud/_secrets/*.enc.json)',
+                  { count: diag.secretFileCount },
+                )}
                 hint={
-                  diag.secretFileCount === 0
-                    ? t('settings.envVars.diag.filesMissing', '团队目录下没有加密的团队变量文件，可能尚未从远端同步下来（daemon 未拉取），或团队还没有人设置过团队变量。')
+                  !diag.secretsDirExists
+                    ? t(
+                        'settings.envVars.diag.filesMissing',
+                        'daemon 尚未拉取团队 env 云缓存（写完后应立即 reconcile；否则最长约 5 分钟）。若团队还没有人设置过变量，首次写入后也会创建该目录。',
+                      )
                     : undefined
                 }
               />
@@ -651,7 +662,7 @@ function TeamEnvDiagnosticsCard({
                   {t('settings.envVars.diag.otherTitle', '其他可能的异常原因')}
                 </p>
                 <ul className="list-disc pl-4 text-xs text-muted-foreground space-y-0.5">
-                  <li>{t('settings.envVars.diag.other1', 'daemon 未运行或未完成一次同步，加密文件还没拉取到本机。')}</li>
+                  <li>{t('settings.envVars.diag.other1', 'daemon 未运行，或写完后未能触发 cloud-config reconcile，缓存尚未更新。')}</li>
                   <li>{t('settings.envVars.diag.other2', '本机团队密钥与加密时用的密钥不一致（成员看到「未解密」标记）。')}</li>
                   <li>{t('settings.envVars.diag.other3', '团队变量只在新建 Agent 会话时注入，改动后需要重启会话才生效。')}</li>
                   <li>{t('settings.envVars.diag.other4', '变量名不合法（团队变量仅支持小写字母、数字、下划线，最长 64 字符）。')}</li>

--- a/packages/app/src/lib/diagnostic-report.ts
+++ b/packages/app/src/lib/diagnostic-report.ts
@@ -104,8 +104,12 @@ export interface TeamEnvDiagnostics {
   linkIsSymlink: boolean
   linkTarget: string | null
   targetAccessible: boolean
+  /** Daemon cloud cache `~/.amuxd/teams/<id>/cloud/_secrets`. */
   secretsDirExists: boolean
   secretFileCount: number
+  cloudSecretsDir?: string
+  legacySecretsDirExists?: boolean
+  legacySecretFileCount?: number
   secretConfigured: boolean
 }
 
@@ -865,11 +869,21 @@ function buildTeamEnvCheck(teamEnv: TeamEnvDiagnostics | null, teamId: string | 
       hintSection: 'envVars',
     }
   }
+  if (!teamEnv.secretsDirExists) {
+    return {
+      id: 'team_env',
+      title: '团队环境同步',
+      status: 'warn',
+      message: 'daemon 尚未拉取团队 env 云缓存',
+      hint: '确认 daemon 在跑；写入团队变量后会立即 reconcile，否则最长约 5 分钟',
+      hintSection: 'envVars',
+    }
+  }
   return {
     id: 'team_env',
     title: '团队环境同步',
     status: 'ok',
-    message: '团队目录与密钥配置正常',
+    message: `团队目录与密钥配置正常（云缓存 ${teamEnv.secretFileCount} 个）`,
   }
 }
 


### PR DESCRIPTION
## Summary
- Close [#801](https://github.com/different-ai-studio/teamclaw/issues/801): after a team env write/delete, desktop best-effort calls new `POST /v1/team/cloud-config/reconcile` so the daemon cache updates immediately instead of waiting up to 5 minutes.
- When reconcile changes the cloud cache, fan out `RefreshChangeKind::{EnvVars,Mcp}` to local workspaces so the UI can prompt for a runtime restart (cloud cache is outside `refresh_watch` roots).
- Point `team_env_diagnostics` / settings / diagnostic report at `~/.amuxd/teams/<id>/cloud/_secrets` instead of the always-empty workspace `_secrets` directory.

## Test plan
- [ ] Write a team env var in Settings → confirm daemon `cloud/_secrets` updates without waiting for the 300s tick
- [ ] Confirm a runtime refresh / “needs restart” signal appears for an active workspace after the write
- [ ] Delete a team env var → cache and refresh behave the same
- [ ] Open team env diagnostics with a healthy cloud team → “云端缓存” is green when the cache dir exists
- [ ] `cargo check` desktop + daemon; unit tests for diagnostic-report / EnvVarsSection still pass


Made with [Cursor](https://cursor.com)