### PR TITLE
fix(expo): unblock sign-in end to end, and put Android on Sentry

### DIFF
--- a/apps/expo/SENTRY.md
+++ b/apps/expo/SENTRY.md
@@ -1,0 +1,56 @@
+# Expo app — error reporting
+
+Sentry project: [`ucar-inc/teamclu-expo`](https://ucar-inc.sentry.io/projects/teamclu-expo/).
+One React Native project covers both Android and iOS.
+
+> The slug really is `teamclu-expo`, not `teamclaw-expo`. If it is ever renamed,
+> update `organization`/`project` in the `@sentry/react-native` plugin entry in
+> `app.json` — the DSN keeps working, but source map upload breaks.
+
+## What reports, and when
+
+| Build | Reports? |
+|---|---|
+| `expo start` (dev client) | No — set `EXPO_PUBLIC_SENTRY_DEBUG=1` to force it on |
+| `preview` / `production` EAS build | Yes |
+
+Dev is off by default because hot reload turns half-finished code into real
+events: a missing import throws at module scope on every save, and that noise
+lands in the same project as production traffic.
+
+Errors only — `tracesSampleRate: 0`. Tracing costs battery and quota and we have
+no latency question worth paying for yet.
+
+## Source maps
+
+A production bundle is minified, so without source maps every stack frame reads
+as `index.android.bundle:1:284915`. Three pieces make symbolication work, and
+all three are already wired:
+
+1. `metro.config.js` builds from `getSentryExpoConfig`, whose serializer stamps
+   a **debug ID** into both the bundle and its map. That ID is what matches a
+   crash to the right map — not the release name, which is why upgrading the
+   Metro config mattered more than it looks.
+2. The `@sentry/react-native` config plugin in `app.json` writes
+   `sentry.properties` with the org and project, so the upload knows where to go.
+3. `@sentry/cli` is allowed to run its postinstall via `onlyBuiltDependencies`
+   in the **root** `package.json`. pnpm 10 blocks install scripts by default, and
+   a blocked one leaves the CLI binary missing — the upload then fails at build
+   time rather than at install time.
+
+### The one manual step: `SENTRY_AUTH_TOKEN`
+
+Uploading needs a token, which is **not** in this repo and must not be. It is
+also not the same thing as `EXPO_TOKEN`.
+
+1. Create an **organization auth token** at
+   Settings → Auth Tokens (scope: `project:releases`).
+2. Give it to EAS as a secret, so cloud builds can upload:
+
+   ```sh
+   eas env:create --name SENTRY_AUTH_TOKEN --value <token> --visibility secret \
+     --environment preview --environment production
+   ```
+
+Until that exists, builds still succeed and errors still report — only the
+stack traces stay minified.

--- a/apps/expo/SENTRY.md
+++ b/apps/expo/SENTRY.md
@@ -45,12 +45,16 @@ also not the same thing as `EXPO_TOKEN`.
 
 1. Create an **organization auth token** at
    Settings → Auth Tokens (scope: `project:releases`).
-2. Give it to EAS as a secret, so cloud builds can upload:
+2. Give it to EAS as a secret, so cloud builds can upload. Run from
+   `apps/expo/`. There is no global `eas` and the repo does not depend on
+   `eas-cli`, so invoke it through `npx`:
 
    ```sh
-   eas env:create --name SENTRY_AUTH_TOKEN --value <token> --visibility secret \
-     --environment preview --environment production
+   npx eas-cli@latest env:set --name SENTRY_AUTH_TOKEN --value <token> \
+     --visibility secret --environment preview --environment production
    ```
+
+   Use `env:set`, not `env:create` — the latter is deprecated as of eas-cli 21.
 
 Until that exists, builds still succeed and errors still report — only the
 stack traces stay minified.

--- a/apps/expo/app.json
+++ b/apps/expo/app.json
@@ -21,7 +21,13 @@
       "expo-web-browser",
       "expo-router",
       "expo-sqlite",
-      "@sentry/react-native"
+      [
+        "@sentry/react-native",
+        {
+          "organization": "ucar-inc",
+          "project": "teamclu-expo"
+        }
+      ]
     ],
     "ios": {
       "bundleIdentifier": "com.bertrand319.teamclawexpo"

--- a/apps/expo/app.json
+++ b/apps/expo/app.json
@@ -20,7 +20,8 @@
       "expo-audio",
       "expo-web-browser",
       "expo-router",
-      "expo-sqlite"
+      "expo-sqlite",
+      "@sentry/react-native"
     ],
     "ios": {
       "bundleIdentifier": "com.bertrand319.teamclawexpo"

--- a/apps/expo/app/_layout.tsx
+++ b/apps/expo/app/_layout.tsx
@@ -20,6 +20,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 import { ToastHost, showToast } from "../src/ui/Toast";
 import { createConfiguredInviteApi, parseInviteToken } from "../src/features/onboarding/invite-api";
+import { isOAuthCallbackUrl } from "../src/features/onboarding/onboarding-oauth";
 import { createOnboardingController } from "../src/features/onboarding/onboarding-store";
 import type {
   OnboardingRoute,
@@ -145,6 +146,17 @@ function OnboardingProvider({ children }: { children: ReactNode }) {
   // user is signed in.
   useEffect(() => {
     const handleUrl = (url: string | null | undefined) => {
+      // The OAuth redirect is a deep link, so this listener — not
+      // `openAuthSessionAsync`'s return value — is what reliably carries a
+      // Google/Apple sign-in back to us on Android. Completing it here is
+      // idempotent; the controller spends each callback once.
+      if (isOAuthCallbackUrl(url)) {
+        void controller.completeOAuthFromUrl(url!).catch(() => {
+          // Rendered from controller state by the auth screen.
+        });
+        return;
+      }
+
       const token = parseInviteToken(url);
       if (!token) return;
       void savePendingInviteToken(token).then(() => {

--- a/apps/expo/app/_layout.tsx
+++ b/apps/expo/app/_layout.tsx
@@ -1,5 +1,11 @@
 import "../src/lib/polyfills";
 
+import { initSentry, wrapRoot } from "../src/lib/telemetry/sentry";
+
+// Before any other module runs, so an error thrown while the tree is still
+// being built is still reported.
+initSentry();
+
 import Constants from "expo-constants";
 import * as Linking from "expo-linking";
 import * as Notifications from "expo-notifications";
@@ -404,7 +410,7 @@ function OnboardingProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export default function RootLayout() {
+function RootLayout() {
   return (
     <GestureHandlerRootView style={styles.root}>
       <StatusBar {...appStatusBarProps} />
@@ -419,6 +425,8 @@ export default function RootLayout() {
     </GestureHandlerRootView>
   );
 }
+
+export default wrapRoot(RootLayout);
 
 const styles = StyleSheet.create({
   root: {

--- a/apps/expo/app/auth-callback.tsx
+++ b/apps/expo/app/auth-callback.tsx
@@ -7,32 +7,51 @@ import { colors, spacing, typography } from "../src/ui/theme";
 /**
  * Landing route for the `teamclaw://auth-callback` deep link.
  *
- * The OAuth flow itself is completed by `openAuthSessionAsync`, which resolves
- * with the callback URL and hands it to `signInWithOAuth`. But the redirect is
- * also a real deep link into the app, so expo-router receives
- * `/auth-callback` as a navigation target — and with no file to match it, the
- * user landed on "Unmatched Route — Page could not be found" *after a
- * successful sign-in*.
+ * The OS routes this URL two places at once: to `Linking`, where the root
+ * layout hands it to `completeOAuthFromUrl` to actually exchange the code, and
+ * to expo-router, which treats `/auth-callback` as a navigation target. With
+ * no file to match it the user landed on "Unmatched Route — Page could not be
+ * found" *after a successful sign-in*, which is why this screen exists.
  *
- * So this screen deliberately does no auth work: completing the callback a
- * second time would re-spend a one-time PKCE code. It only holds the user
- * still while the session settles, then forwards to wherever onboarding says
- * they belong.
+ * It deliberately does no auth work of its own — the exchange is already
+ * running, and spending the one-time PKCE code twice would fail the second
+ * time. It just holds the user still until onboarding knows where they belong.
  *
  * iOS handles the same URL in `AMUXApp.swift` (`case "auth-callback"`), which
- * likewise just forwards it rather than treating it as a screen.
+ * likewise forwards it rather than treating it as a screen.
  */
 export default function AuthCallbackRoute() {
   const { state } = useOnboarding();
-  const href = routeToHref(state.route);
 
+  // Redirecting on `route` alone sent the user to `/welcome` for the whole
+  // exchange — a successful Google sign-in looked like being dumped back on
+  // the first screen. `needsAuth` is simply what the state machine says until
+  // a session exists, so wait it out.
+  if (state.isBusy) {
+    return <Progress />;
+  }
+
+  if (state.route === "needsAuth") {
+    // Signing in didn't produce a session. Go back to the form, which renders
+    // `errorMessage` — the welcome screen shows nothing, so a real failure
+    // there is indistinguishable from "nothing happened".
+    return <Redirect href="/auth" />;
+  }
+
+  const href = routeToHref(state.route);
   if (href) {
     return <Redirect href={href} />;
   }
 
-  // `loading` / `failed` have no href. Bootstrap is mid-flight right after a
-  // sign-in, so this is the expected state for a moment — show progress rather
-  // than a dead end, and let the redirect fire once the route resolves.
+  // `failed` has no href; `/` renders it with retry + sign out.
+  if (state.route === "failed") {
+    return <Redirect href="/" />;
+  }
+
+  return <Progress />;
+}
+
+function Progress() {
   return (
     <View style={styles.screen}>
       <ActivityIndicator color={colors.coral} size="small" />

--- a/apps/expo/app/auth-callback.tsx
+++ b/apps/expo/app/auth-callback.tsx
@@ -1,0 +1,57 @@
+import { Redirect } from "expo-router";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+
+import { useOnboarding, routeToHref } from "./_layout";
+import { colors, spacing, typography } from "../src/ui/theme";
+
+/**
+ * Landing route for the `teamclaw://auth-callback` deep link.
+ *
+ * The OAuth flow itself is completed by `openAuthSessionAsync`, which resolves
+ * with the callback URL and hands it to `signInWithOAuth`. But the redirect is
+ * also a real deep link into the app, so expo-router receives
+ * `/auth-callback` as a navigation target — and with no file to match it, the
+ * user landed on "Unmatched Route — Page could not be found" *after a
+ * successful sign-in*.
+ *
+ * So this screen deliberately does no auth work: completing the callback a
+ * second time would re-spend a one-time PKCE code. It only holds the user
+ * still while the session settles, then forwards to wherever onboarding says
+ * they belong.
+ *
+ * iOS handles the same URL in `AMUXApp.swift` (`case "auth-callback"`), which
+ * likewise just forwards it rather than treating it as a screen.
+ */
+export default function AuthCallbackRoute() {
+  const { state } = useOnboarding();
+  const href = routeToHref(state.route);
+
+  if (href) {
+    return <Redirect href={href} />;
+  }
+
+  // `loading` / `failed` have no href. Bootstrap is mid-flight right after a
+  // sign-in, so this is the expected state for a moment — show progress rather
+  // than a dead end, and let the redirect fire once the route resolves.
+  return (
+    <View style={styles.screen}>
+      <ActivityIndicator color={colors.coral} size="small" />
+      <Text style={styles.title}>Finishing sign-in</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    alignItems: "center",
+    backgroundColor: colors.background,
+    flex: 1,
+    gap: spacing.md,
+    justifyContent: "center",
+    padding: spacing.xxl,
+  },
+  title: {
+    color: colors.foreground,
+    ...typography.sectionTitle,
+  },
+});

--- a/apps/expo/app/auth.tsx
+++ b/apps/expo/app/auth.tsx
@@ -43,6 +43,7 @@ export default function AuthRoute() {
           openAuthSession: WebBrowser.openAuthSessionAsync,
         })
       }
+      onSignInWithPassword={controller.signInWithPassword}
       onVerifyOtp={controller.verifyOtp}
     />
   );

--- a/apps/expo/app/create-team.tsx
+++ b/apps/expo/app/create-team.tsx
@@ -18,6 +18,7 @@ export default function CreateTeamRoute() {
       isAnonymous={state.isAnonymous}
       isBusy={state.isBusy}
       onCreateTeam={controller.createTeam}
+      onSignOut={controller.signOut}
     />
   );
 }

--- a/apps/expo/app/index.tsx
+++ b/apps/expo/app/index.tsx
@@ -1,5 +1,11 @@
 import { Redirect } from "expo-router";
-import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 
 import { useOnboarding, routeToHref } from "./_layout";
 import { PrimaryButton } from "../src/ui/button";
@@ -7,7 +13,7 @@ import { AppCard } from "../src/ui/card";
 import { colors, spacing, typography } from "../src/ui/theme";
 
 export default function IndexRoute() {
-  const { retryBootstrap, state } = useOnboarding();
+  const { controller, retryBootstrap, state } = useOnboarding();
   const href = routeToHref(state.route);
 
   if (href) {
@@ -29,6 +35,31 @@ export default function IndexRoute() {
               void retryBootstrap().catch(() => {});
             }}
           />
+
+          {/*
+            Retry alone is a trap. Bootstrap reports every failure the same way,
+            including an expired or otherwise rejected session — and that class
+            of failure never recovers by retrying, so the screen becomes a
+            permanent dead end that survives even killing the app, because the
+            bad session is in storage. Signing out clears it.
+
+            iOS shows both buttons here for the same reason
+            (`onboardingError.retryButton` + `onboardingError.signOutButton`).
+          */}
+          <Pressable
+            accessibilityRole="button"
+            disabled={state.isBusy}
+            onPress={() => {
+              void controller.signOut().catch(() => {});
+            }}
+            style={({ pressed }) => [
+              styles.signOut,
+              pressed && !state.isBusy ? styles.signOutPressed : null,
+            ]}
+            testID="onboardingError.signOutButton"
+          >
+            <Text style={styles.signOutLabel}>Sign out and start over</Text>
+          </Pressable>
         </AppCard>
       </View>
     );
@@ -70,6 +101,18 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     padding: spacing.xxl,
+  },
+  signOut: {
+    alignItems: "center",
+    paddingVertical: spacing.sm,
+  },
+  signOutLabel: {
+    color: colors.danger,
+    ...typography.body,
+    fontWeight: "600",
+  },
+  signOutPressed: {
+    opacity: 0.6,
   },
   title: {
     color: colors.foreground,

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -12,10 +12,18 @@
       }
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_CLOUD_API_URL": "https://api.teamclaw-dev.ucar.cc",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://3d62272a2572c722fbf4da76ef3ea30e@o60909.ingest.us.sentry.io/4511878837960704"
+      }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_CLOUD_API_URL": "https://api.teamclaw-dev.ucar.cc",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://3d62272a2572c722fbf4da76ef3ea30e@o60909.ingest.us.sentry.io/4511878837960704"
+      }
     }
   },
   "submit": {

--- a/apps/expo/metro.config.js
+++ b/apps/expo/metro.config.js
@@ -12,13 +12,18 @@
 // before Metro's resolver consults it. We need `resolveRequest` to
 // intercept every `react` / `react-native` request and force it back to
 // apps/expo's copy regardless of which dep graph asked.
-const { getDefaultConfig } = require("expo/metro-config");
+// `getSentryExpoConfig` is `getDefaultConfig` plus the Sentry serializer, which
+// stamps a debug ID into the bundle and its source map. Without it the uploaded
+// map cannot be matched to the bundle that produced a crash, so production
+// stack traces stay minified. Everything below still applies unchanged — it
+// returns the same shape.
+const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 const path = require("path");
 
 const projectRoot = __dirname;
 const workspaceRoot = path.resolve(projectRoot, "../..");
 
-const config = getDefaultConfig(projectRoot);
+const config = getSentryExpoConfig(projectRoot);
 
 config.watchFolders = [workspaceRoot];
 

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -14,6 +14,7 @@
     "@bufbuild/protobuf": "^2.13.0",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@sentry/react-native": "~7.11.0",
     "@teamclaw/app": "workspace:*",
     "buffer": "^6.0.3",
     "expo": "~57.0.11",

--- a/apps/expo/src/features/onboarding/onboarding-oauth.ts
+++ b/apps/expo/src/features/onboarding/onboarding-oauth.ts
@@ -18,6 +18,23 @@ export type OAuthProvider = "apple" | "google";
  */
 export const OAUTH_REDIRECT_URL = "teamclaw://auth-callback";
 
+/**
+ * True for the URL GoTrue redirects to once a provider has signed the user in.
+ *
+ * That redirect is a real Android deep link, so the OS delivers it to the app
+ * as an intent — `Linking` sees it whether or not `openAuthSessionAsync`
+ * resolves with it. Completing the sign-in therefore has to be driven from the
+ * URL itself; see `completeOAuthFromUrl`.
+ *
+ * Tolerates the double- and triple-slash spellings because `Linking.createURL`
+ * has emitted both, and a trailing slash because some browsers add one.
+ */
+export function isOAuthCallbackUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  const withoutParams = url.split(/[?#]/)[0] ?? "";
+  return /^teamclaw:\/{2,3}auth-callback\/?$/i.test(withoutParams);
+}
+
 export type OAuthCallback =
   | { type: "code"; code: string }
   | { type: "tokens"; accessToken: string; refreshToken: string };

--- a/apps/expo/src/features/onboarding/onboarding-store.ts
+++ b/apps/expo/src/features/onboarding/onboarding-store.ts
@@ -173,6 +173,47 @@ export function createOnboardingController(api: OnboardingApi) {
     }
   };
 
+  /**
+   * Callback URLs already spent, so the one-time PKCE code is exchanged exactly
+   * once no matter which channel delivers it. Both can fire for a single
+   * sign-in: `openAuthSessionAsync` may resolve with the URL, *and* the OS
+   * delivers the same URL to `Linking` because the redirect is a deep link.
+   */
+  const consumedOAuthCallbacks = new Set<string>();
+
+  /**
+   * Exchange an OAuth callback URL for a session, then bootstrap.
+   *
+   * This is the path that actually carries Google sign-in on Android: the
+   * redirect is a deep link, so the OS routes it to the app and the custom tab
+   * merely closes — `openAuthSessionAsync` reports `dismiss`, indistinguishable
+   * from the user backing out. Driving the exchange off the URL instead means
+   * the browser result no longer has to be trusted to carry it.
+   *
+   * Returns false when the callback was already consumed.
+   */
+  const completeOAuthFromUrl = async (
+    url: string,
+    existingToken?: number,
+  ): Promise<boolean> => {
+    if (consumedOAuthCallbacks.has(url)) return false;
+    consumedOAuthCallbacks.add(url);
+
+    const token = existingToken ?? beginOperation();
+    dispatchIfCurrent(token, { type: "beginBusy" });
+
+    try {
+      await api.completeOAuthCallback(url);
+      await bootstrap(token);
+      return true;
+    } catch (error) {
+      if (!(error instanceof BootstrapFailureError)) {
+        finishWithError(token, toErrorMessage(error));
+      }
+      throw (error instanceof BootstrapFailureError ? error.cause : error);
+    }
+  };
+
   const runOAuthBrowserFlow = async (
     token: number,
     authUrl: string,
@@ -184,6 +225,10 @@ export function createOnboardingController(api: OnboardingApi) {
   ): Promise<boolean> => {
     const result = await openAuthSession(authUrl, redirectTo);
     if (!shouldCompleteOAuthResult(result)) {
+      // Not necessarily a cancel — on Android a *successful* redirect also
+      // lands here, because the OS consumed the deep link. If the URL already
+      // arrived via `Linking`, that completion owns the operation token now,
+      // so leave its busy state alone rather than clearing it out from under.
       if (isActiveOperation(token)) {
         setState({
           ...state,
@@ -193,8 +238,7 @@ export function createOnboardingController(api: OnboardingApi) {
       }
       return false;
     }
-    await api.completeOAuthCallback(result.url!);
-    return true;
+    return completeOAuthFromUrl(result.url!, token);
   };
 
   const signInWithOAuth = async (
@@ -215,14 +259,9 @@ export function createOnboardingController(api: OnboardingApi) {
 
     try {
       const authUrl = await api.createOAuthSignInUrl(provider, redirectTo);
-      const completed = await runOAuthBrowserFlow(
-        token,
-        authUrl,
-        redirectTo,
-        openAuthSession,
-      );
-      if (!completed) return;
-      await bootstrap(token);
+      // Bootstraps internally on success — the deep-link path has to bootstrap
+      // too, so it lives inside `completeOAuthFromUrl` rather than out here.
+      await runOAuthBrowserFlow(token, authUrl, redirectTo, openAuthSession);
     } catch (error) {
       if (!(error instanceof BootstrapFailureError)) {
         finishWithError(token, toErrorMessage(error));
@@ -249,14 +288,7 @@ export function createOnboardingController(api: OnboardingApi) {
 
     try {
       const authUrl = await api.createOAuthLinkUrl(provider, redirectTo);
-      const completed = await runOAuthBrowserFlow(
-        token,
-        authUrl,
-        redirectTo,
-        openAuthSession,
-      );
-      if (!completed) return;
-      await bootstrap(token);
+      await runOAuthBrowserFlow(token, authUrl, redirectTo, openAuthSession);
     } catch (error) {
       if (!(error instanceof BootstrapFailureError)) {
         finishWithError(token, toErrorMessage(error));
@@ -312,6 +344,7 @@ export function createOnboardingController(api: OnboardingApi) {
     verifyOtp,
     signInWithPassword,
     signInWithOAuth,
+    completeOAuthFromUrl,
     linkIdentityWithOAuth,
     resetPendingEmail,
     createTeam,

--- a/apps/expo/src/features/onboarding/onboarding-store.ts
+++ b/apps/expo/src/features/onboarding/onboarding-store.ts
@@ -153,6 +153,26 @@ export function createOnboardingController(api: OnboardingApi) {
     }
   };
 
+  /**
+   * Email + password sign-in. Unlike the OTP flow there is no pending-email
+   * step: one call either produces a session or fails, so it goes straight to
+   * bootstrap.
+   */
+  const signInWithPassword = async (email: string, password: string) => {
+    const operationToken = beginOperation();
+    dispatchIfCurrent(operationToken, { type: "beginBusy" });
+
+    try {
+      await api.signInWithPassword(email.trim(), password);
+      await bootstrap(operationToken);
+    } catch (error) {
+      if (!(error instanceof BootstrapFailureError)) {
+        finishWithError(operationToken, toErrorMessage(error));
+      }
+      throw (error instanceof BootstrapFailureError ? error.cause : error);
+    }
+  };
+
   const runOAuthBrowserFlow = async (
     token: number,
     authUrl: string,
@@ -290,6 +310,7 @@ export function createOnboardingController(api: OnboardingApi) {
     signInAnonymously,
     requestOtp,
     verifyOtp,
+    signInWithPassword,
     signInWithOAuth,
     linkIdentityWithOAuth,
     resetPendingEmail,

--- a/apps/expo/src/features/onboarding/screens/AuthScreen.tsx
+++ b/apps/expo/src/features/onboarding/screens/AuthScreen.tsx
@@ -14,7 +14,7 @@ import {
   View,
 } from "react-native";
 
-import { colors, spacing, typography } from "../../../ui/theme";
+import { colors, radii, shadows, spacing, typography } from "../../../ui/theme";
 import { OTP_CODE_LENGTH, sanitizeOtpInput } from "../auth-otp";
 
 type AuthScreenProps = {
@@ -24,19 +24,28 @@ type AuthScreenProps = {
   onBack: () => void;
   onRequestOtp: (email: string) => Promise<void>;
   onVerifyOtp: (token: string) => Promise<void>;
+  onSignInWithPassword: (email: string, password: string) => Promise<void>;
   onResetPendingEmail: () => void;
   onSignInWithApple?: () => Promise<void> | void;
   onSignInWithGoogle?: () => Promise<void> | void;
 };
+
+/** iOS `LoginView.LoginMethod`, minus `phone` — not implemented here yet. */
+type LoginMethod = "email" | "password";
 
 function isValidEmail(value: string) {
   return /\S+@\S+\.\S+/.test(value);
 }
 
 /**
- * 1:1 port of `apps/ios/AMUXApp/LoginView.swift`. Email-OTP first, then
- * "Sign in with Apple" / "Sign in with Google" rails below an "or" divider.
- * Guest / private-workspace lives on the ChooseAuthScreen — same as iOS.
+ * Port of `apps/ios/AMUXApp/LoginView.swift`: a segmented method picker over
+ * email-OTP and email+password, then "Sign in with Apple" / "Sign in with
+ * Google" rails below an "or" divider. Guest / private-workspace lives on the
+ * ChooseAuthScreen — same as iOS.
+ *
+ * iOS also offers a `phone` method with a multi-account picker sheet; that is
+ * deliberately not ported yet, so the picker here shows two tabs rather than
+ * three.
  */
 export function AuthScreen({
   errorMessage,
@@ -45,12 +54,15 @@ export function AuthScreen({
   onBack,
   onRequestOtp,
   onVerifyOtp,
+  onSignInWithPassword,
   onResetPendingEmail,
   onSignInWithApple,
   onSignInWithGoogle,
 }: AuthScreenProps) {
   const [email, setEmail] = useState(pendingEmail ?? "");
+  const [password, setPassword] = useState("");
   const [code, setCode] = useState("");
+  const [method, setMethod] = useState<LoginMethod>("email");
 
   useEffect(() => {
     if (pendingEmail) setEmail(pendingEmail);
@@ -63,6 +75,14 @@ export function AuthScreen({
     if (!isValidEmail(next)) return;
     try {
       await onRequestOtp(next);
+    } catch {}
+  };
+
+  const submitPassword = async () => {
+    const next = email.trim().toLowerCase();
+    if (!isValidEmail(next) || password.length === 0) return;
+    try {
+      await onSignInWithPassword(next, password);
     } catch {}
   };
 
@@ -97,7 +117,17 @@ export function AuthScreen({
 
   const canSubmit = isCodeStep
     ? code.length === OTP_CODE_LENGTH
-    : email.trim().length > 0;
+    : method === "password"
+      ? email.trim().length > 0 && password.length > 0
+      : email.trim().length > 0;
+
+  // Mirrors iOS `headerSubtitle`: the copy tracks the selected method, so the
+  // screen never promises a code when the user picked password.
+  const subtitle = isCodeStep
+    ? "Check your inbox for a 6-digit code."
+    : method === "password"
+      ? "Use your email and password to sign in."
+      : "We'll email you a 6-digit code.";
 
   return (
     <KeyboardAvoidingView
@@ -122,12 +152,25 @@ export function AuthScreen({
           <Text style={styles.title}>
             {isCodeStep ? "Enter the code" : "Sign in"}
           </Text>
-          <Text style={styles.subtitle}>
-            {isCodeStep
-              ? "Check your inbox for a 6-digit code."
-              : "We'll email you a 6-digit code."}
-          </Text>
+          <Text style={styles.subtitle}>{subtitle}</Text>
         </View>
+
+        {!isCodeStep ? (
+          <View style={styles.methodPicker} testID="login.methodPicker">
+            <MethodTab
+              disabled={isBusy}
+              label="Email"
+              onPress={() => setMethod("email")}
+              selected={method === "email"}
+            />
+            <MethodTab
+              disabled={isBusy}
+              label="Password"
+              onPress={() => setMethod("password")}
+              selected={method === "password"}
+            />
+          </View>
+        ) : null}
 
         {isCodeStep ? (
           <View style={styles.section}>
@@ -188,17 +231,43 @@ export function AuthScreen({
                 placeholderTextColor={colors.slate}
                 selectionColor={colors.cinnabar}
                 style={styles.fieldText}
-                textContentType="emailAddress"
+                testID="login.emailField"
+                textContentType={method === "password" ? "username" : "emailAddress"}
                 value={email}
               />
             </View>
 
+            {method === "password" ? (
+              <View style={styles.authField}>
+                <TextInput
+                  accessibilityLabel="Password"
+                  autoCapitalize="none"
+                  autoComplete="current-password"
+                  autoCorrect={false}
+                  editable={!isBusy}
+                  onChangeText={setPassword}
+                  onSubmitEditing={() => {
+                    void submitPassword();
+                  }}
+                  placeholder="Password"
+                  placeholderTextColor={colors.slate}
+                  returnKeyType="go"
+                  secureTextEntry
+                  selectionColor={colors.cinnabar}
+                  style={styles.fieldText}
+                  testID="login.passwordField"
+                  textContentType="password"
+                  value={password}
+                />
+              </View>
+            ) : null}
+
             <PrimaryButton
               busy={isBusy}
               enabled={canSubmit}
-              label="Send code"
+              label={method === "password" ? "Sign in" : "Send code"}
               onPress={() => {
-                void sendCode();
+                void (method === "password" ? submitPassword() : sendCode());
               }}
             />
           </View>
@@ -230,6 +299,42 @@ export function AuthScreen({
         </View>
       </ScrollView>
     </KeyboardAvoidingView>
+  );
+}
+
+/** One segment of the method picker — RN has no built-in segmented control. */
+function MethodTab({
+  disabled,
+  label,
+  onPress,
+  selected,
+}: {
+  disabled: boolean;
+  label: string;
+  onPress: () => void;
+  selected: boolean;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ disabled, selected }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.methodTab,
+        selected ? styles.methodTabSelected : null,
+        pressed && !disabled ? styles.pressed : null,
+      ]}
+    >
+      <Text
+        style={[
+          styles.methodTabLabel,
+          selected ? styles.methodTabLabelSelected : null,
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
   );
 }
 
@@ -424,6 +529,34 @@ const styles = StyleSheet.create({
   screen: {
     backgroundColor: colors.mist,
     flex: 1,
+  },
+  // Stands in for iOS's `.pickerStyle(.segmented)` — a recessed track with a
+  // raised selected segment. React Native ships no segmented control.
+  methodPicker: {
+    backgroundColor: colors.pebble,
+    borderRadius: radii.button + 2,
+    flexDirection: "row",
+    gap: 2,
+    padding: 2,
+  },
+  methodTab: {
+    alignItems: "center",
+    borderRadius: radii.button,
+    flex: 1,
+    paddingVertical: 7,
+  },
+  methodTabLabel: {
+    color: colors.basalt,
+    ...typography.body,
+    fontWeight: "500",
+  },
+  methodTabLabelSelected: {
+    color: colors.onyx,
+    fontWeight: "600",
+  },
+  methodTabSelected: {
+    backgroundColor: colors.paper,
+    ...shadows.card,
   },
   section: {
     gap: 12,

--- a/apps/expo/src/features/onboarding/screens/ChooseAuthScreen.tsx
+++ b/apps/expo/src/features/onboarding/screens/ChooseAuthScreen.tsx
@@ -259,7 +259,6 @@ const styles = StyleSheet.create({
   header: {
     gap: spacing.sm,
     paddingHorizontal: spacing.xl,
-    paddingTop: spacing.xxxl + spacing.lg,
   },
   iconWrap: {
     alignItems: "center",
@@ -309,6 +308,10 @@ const styles = StyleSheet.create({
   screen: {
     backgroundColor: colors.mist,
     flex: 1,
+    // Centre header + actions + error as one block. The header used to carry a
+    // fixed `paddingTop` that pinned everything near the top; that offset now
+    // fights the centring, so it is gone.
+    justifyContent: "center",
   },
   sheet: {
     backgroundColor: colors.mist,

--- a/apps/expo/src/features/onboarding/screens/CreateTeamScreen.tsx
+++ b/apps/expo/src/features/onboarding/screens/CreateTeamScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import {
   KeyboardAvoidingView,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -18,6 +19,7 @@ type CreateTeamScreenProps = {
   isAnonymous: boolean;
   isBusy: boolean;
   onCreateTeam: (name: string) => Promise<void>;
+  onSignOut: () => Promise<void>;
 };
 
 export function CreateTeamScreen({
@@ -25,6 +27,7 @@ export function CreateTeamScreen({
   isAnonymous,
   isBusy,
   onCreateTeam,
+  onSignOut,
 }: CreateTeamScreenProps) {
   const [teamName, setTeamName] = useState("");
   const [localError, setLocalError] = useState<string | null>(null);
@@ -98,6 +101,27 @@ export function CreateTeamScreen({
               : "Your account is ready. This step creates the first shared space for your team."}
           </Text>
         </AppCard>
+
+        {/*
+          The only way out. Being signed in with no team routes straight back
+          here, so without this the screen is a dead end — you cannot even
+          switch accounts. iOS offers the same escape from its onboarding error
+          state (`Button("Sign Out", role: .destructive)`).
+        */}
+        <Pressable
+          accessibilityRole="button"
+          disabled={isBusy}
+          onPress={() => {
+            void onSignOut();
+          }}
+          style={({ pressed }) => [
+            styles.signOut,
+            pressed && !isBusy ? styles.signOutPressed : null,
+          ]}
+          testID="createTeam.signOutButton"
+        >
+          <Text style={styles.signOutLabel}>Sign out</Text>
+        </Pressable>
       </ScrollView>
     </KeyboardAvoidingView>
   );
@@ -136,6 +160,18 @@ const styles = StyleSheet.create({
   screen: {
     backgroundColor: colors.background,
     flex: 1,
+  },
+  signOut: {
+    alignItems: "center",
+    paddingVertical: spacing.sm,
+  },
+  signOutLabel: {
+    color: colors.danger,
+    ...typography.body,
+    fontWeight: "600",
+  },
+  signOutPressed: {
+    opacity: 0.6,
   },
   title: {
     color: colors.foreground,

--- a/apps/expo/src/lib/auth/cloud-auth.ts
+++ b/apps/expo/src/lib/auth/cloud-auth.ts
@@ -159,6 +159,10 @@ export type CloudAuthClient = {
       email: string;
       options?: { shouldCreateUser?: boolean };
     }) => Promise<void>;
+    signInWithPassword: (input: {
+      email: string;
+      password: string;
+    }) => Promise<{ data: unknown; error: { message: string } | null }>;
     verifyOtp: (input: {
       email: string;
       token: string;
@@ -276,6 +280,33 @@ export const cloudAuth: CloudAuthClient = {
         method: "POST",
         body: { email, options: { shouldCreateUser: options?.shouldCreateUser ?? true } },
       });
+    },
+
+    /**
+     * Email + password sign-in, matching iOS
+     * `CloudAPIAppOnboardingStore.signIn(email:password:)`.
+     *
+     * Returns the error rather than throwing, like `verifyOtp` — a wrong
+     * password is an ordinary outcome the form has to render, not an exception.
+     */
+    async signInWithPassword({ email, password }) {
+      await store().start();
+      try {
+        const body = await authRequest<GoTrueSessionBody>("/v1/auth/signin-password", {
+          method: "POST",
+          body: { email, password },
+        });
+        if (!body.access_token || !body.refresh_token) {
+          return { data: null, error: { message: "Sign-in did not return a session." } };
+        }
+        await storeGoTrue(body);
+        return { data: body, error: null };
+      } catch (error) {
+        return {
+          data: null,
+          error: { message: error instanceof Error ? error.message : "Sign-in failed" },
+        };
+      }
     },
 
     async verifyOtp({ email, token, type }) {

--- a/apps/expo/src/lib/auth/cloud-auth.ts
+++ b/apps/expo/src/lib/auth/cloud-auth.ts
@@ -34,6 +34,17 @@ type GoTrueSessionBody = {
   user?: GoTrueUser;
 };
 
+/**
+ * `/v1/auth/refresh` alone is mapped by FC rather than forwarded raw, so it
+ * answers in camelCase and carries no user. Every other `/v1/auth/*` endpoint
+ * returns a `GoTrueSessionBody`.
+ */
+type RefreshedSessionBody = {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number;
+};
+
 type SupabaseShapedSession = {
   access_token: string;
   refresh_token: string;
@@ -225,11 +236,32 @@ export const cloudAuth: CloudAuthClient = {
     async setRefreshSession(refreshToken) {
       await store().start();
       try {
-        const body = await authRequest<GoTrueSessionBody>("/v1/auth/refresh", {
+        // `/v1/auth/refresh` is the one auth endpoint that does NOT forward a
+        // raw GoTrue body: FC maps it to camelCase
+        // (`{ accessToken, refreshToken, expiresAt }` — see
+        // `supabase-repo/auth.ts` and the repository contract test). Feeding it
+        // to `storeGoTrue`, which reads `access_token` / `refresh_token`, found
+        // neither and threw "Authentication response did not include a
+        // session." — killing bootstrap for every user who has a team, since
+        // `loadBootstrap` calls this right after team activation.
+        const body = await authRequest<RefreshedSessionBody>("/v1/auth/refresh", {
           method: "POST",
           body: { refreshToken },
         });
-        await storeGoTrue(body);
+        if (!body.accessToken || !body.refreshToken) {
+          throw new Error("Authentication response did not include a session.");
+        }
+        const previous = store().current();
+        await store().setSession({
+          accessToken: body.accessToken,
+          refreshToken: body.refreshToken,
+          expiresAt: body.expiresAt ?? nowSeconds() + 3600,
+          // The refresh response carries no user, so identity fields come from
+          // the session being replaced — this swaps tokens, not accounts.
+          isAnonymous: previous?.isAnonymous ?? false,
+          email: previous?.email ?? null,
+          userId: previous?.userId ?? null,
+        });
         return { data: {}, error: null };
       } catch (error) {
         return { data: null, error: { message: error instanceof Error ? error.message : "setRefreshSession failed" } };

--- a/apps/expo/src/lib/supabase/onboarding-api.ts
+++ b/apps/expo/src/lib/supabase/onboarding-api.ts
@@ -72,6 +72,11 @@ export function createOnboardingApi(client: CloudAuthClient) {
       if (error) throw new Error(error.message);
     },
 
+    async signInWithPassword(email: string, password: string) {
+      const { error } = await client.auth.signInWithPassword({ email, password });
+      if (error) throw new Error(error.message);
+    },
+
     async createOAuthSignInUrl(provider: OAuthProvider, redirectTo: string) {
       return client.auth.oauthAuthorize(provider, redirectTo);
     },

--- a/apps/expo/src/lib/telemetry/sentry.ts
+++ b/apps/expo/src/lib/telemetry/sentry.ts
@@ -56,6 +56,16 @@ export function initSentry(): void {
   });
 
   Sentry.setTag("platform.os", Platform.OS);
+
+  if (DEBUG_REPORTING) {
+    // Proves the pipeline without waiting for a real crash: DSN reachable,
+    // transport working, events landing in the right project. Only ever fires
+    // when someone opts in, so it cannot pollute production.
+    //
+    // Message text is fixed — per the grouping rule, a version or timestamp
+    // in here would fingerprint every launch as a separate issue.
+    Sentry.captureMessage("expo sentry pipeline check", "info");
+  }
 }
 
 /**

--- a/apps/expo/src/lib/telemetry/sentry.ts
+++ b/apps/expo/src/lib/telemetry/sentry.ts
@@ -1,0 +1,69 @@
+import Constants from "expo-constants";
+import { Platform } from "react-native";
+
+/**
+ * Sentry bootstrap for the Expo app.
+ *
+ * This surface ran unmonitored while every other client reported: the Ideas
+ * list crashed on render, OAuth sign-in dropped users back on the welcome
+ * screen, and `/v1/auth/refresh` broke startup for anyone with a team — none
+ * of it visible until someone drove the app by hand.
+ *
+ * Grouping rule, same as `packages/app/src/lib/telemetry/capture.ts`: never
+ * interpolate ids, durations, or raw reasons into a message. Sentry
+ * fingerprints on message text, so an embedded UUID shatters one problem into
+ * dozens of issues. Ids belong in tags/extra.
+ */
+
+/**
+ * Public by design — the DSN ships inside every client bundle and only grants
+ * the ability to submit events. It is read from the environment anyway so the
+ * value is not duplicated across `.env`, `eas.json`, and the source tree.
+ */
+const DSN = process.env.EXPO_PUBLIC_SENTRY_DSN ?? "";
+
+/**
+ * Report from a dev build too. Off by default: hot reload turns half-finished
+ * code into real events (a missing import throws at module scope on every
+ * save), and that noise lands in the same project as production traffic.
+ *
+ * Set it to verify the pipeline end-to-end without waiting on an EAS build.
+ */
+const DEBUG_REPORTING = process.env.EXPO_PUBLIC_SENTRY_DEBUG === "1";
+
+let started = false;
+
+export function initSentry(): void {
+  // Without a DSN the SDK still installs global handlers and queues events it
+  // can never send, so skip entirely. Contributors without the var configured
+  // get an app that behaves identically, minus reporting.
+  if (started || !DSN) return;
+  started = true;
+
+  const Sentry = require("@sentry/react-native") as typeof import("@sentry/react-native");
+
+  Sentry.init({
+    dsn: DSN,
+    enabled: !__DEV__ || DEBUG_REPORTING,
+    environment: __DEV__ ? "development" : "production",
+    // Matches the desktop `teamclaw-web@<version>` convention so releases line
+    // up across projects.
+    release: `teamclaw-expo@${Constants.expoConfig?.version ?? "0.0.0"}`,
+    // Errors only for now. Tracing on mobile costs battery and quota, and we
+    // have no latency question worth paying for yet.
+    tracesSampleRate: 0,
+    sendDefaultPii: false,
+  });
+
+  Sentry.setTag("platform.os", Platform.OS);
+}
+
+/**
+ * Wraps the root component for native crash + navigation instrumentation.
+ * A no-op when Sentry never started, so the tree is unchanged in dev.
+ */
+export function wrapRoot<T>(component: T): T {
+  if (!started) return component;
+  const Sentry = require("@sentry/react-native") as typeof import("@sentry/react-native");
+  return Sentry.wrap(component as never) as T;
+}

--- a/apps/expo/src/test/cloud-auth-refresh.test.ts
+++ b/apps/expo/src/test/cloud-auth-refresh.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The real module falls through to a `window`-backed web shim under the node
+// test environment. Nothing here is testing persistence, only the wire shape.
+vi.mock("@react-native-async-storage/async-storage", () => {
+  const memory = new Map<string, string>();
+  return {
+    default: {
+      getItem: async (key: string) => memory.get(key) ?? null,
+      setItem: async (key: string, value: string) => void memory.set(key, value),
+      removeItem: async (key: string) => void memory.delete(key),
+    },
+  };
+});
+
+/**
+ * `/v1/auth/refresh` is the one `/v1/auth/*` endpoint FC maps instead of
+ * forwarding a raw GoTrue body, so it answers in camelCase. Reading it as
+ * snake_case made `setRefreshSession` throw "Authentication response did not
+ * include a session." — and because `loadBootstrap` calls it immediately after
+ * team activation, that broke startup for every user who had a team, with no
+ * way out of the error screen.
+ *
+ * These pin the shape so the two sides cannot drift apart again silently.
+ */
+
+const CAMEL_CASE_REFRESH_RESPONSE = {
+  accessToken: "new-access-token",
+  refreshToken: "new-refresh-token",
+  expiresAt: 1893456000,
+};
+
+function mockFetchOnce(body: unknown, ok = true) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 401,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+}
+
+describe("setRefreshSession", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("EXPO_PUBLIC_CLOUD_API_URL", "https://api.example.test");
+  });
+
+  it("accepts the camelCase body FC actually returns", async () => {
+    vi.stubGlobal("fetch", mockFetchOnce(CAMEL_CASE_REFRESH_RESPONSE));
+    const { cloudAuth } = await import("../lib/auth/cloud-auth");
+
+    const result = await cloudAuth.auth.setRefreshSession("old-refresh-token");
+
+    expect(result.error).toBeNull();
+    const { data } = await cloudAuth.auth.getSession();
+    expect(data.session?.access_token).toBe("new-access-token");
+    expect(data.session?.refresh_token).toBe("new-refresh-token");
+  });
+
+  it("sends the token under the key the route reads", async () => {
+    const fetchMock = mockFetchOnce(CAMEL_CASE_REFRESH_RESPONSE);
+    vi.stubGlobal("fetch", fetchMock);
+    const { cloudAuth } = await import("../lib/auth/cloud-auth");
+
+    await cloudAuth.auth.setRefreshSession("old-refresh-token");
+
+    // FC: `const { refreshToken } = ctx.json` — snake_case here would 400.
+    const [url, init] = fetchMock.mock.calls.at(-1) as [string, { body: string }];
+    expect(url).toContain("/v1/auth/refresh");
+    expect(JSON.parse(init.body)).toEqual({ refreshToken: "old-refresh-token" });
+  });
+
+  it("reports a body with no tokens as an error rather than storing a blank session", async () => {
+    vi.stubGlobal("fetch", mockFetchOnce({}));
+    const { cloudAuth } = await import("../lib/auth/cloud-auth");
+
+    const result = await cloudAuth.auth.setRefreshSession("old-refresh-token");
+
+    expect(result.error?.message).toMatch(/did not include a session/i);
+  });
+});

--- a/apps/expo/src/test/onboarding-oauth.test.ts
+++ b/apps/expo/src/test/onboarding-oauth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   OAUTH_REDIRECT_URL,
+  isOAuthCallbackUrl,
   parseOAuthCallbackUrl,
   shouldCompleteOAuthResult,
 } from "../features/onboarding/onboarding-oauth";
@@ -51,6 +52,22 @@ describe("onboarding oauth helpers", () => {
         "teamclaw://auth-callback?error=access_denied&error_description=Nope",
       ),
     ).toThrow("Nope");
+  });
+
+  it("recognises the callback deep link the OS hands to Linking", () => {
+    // The root layout routes matching URLs to `completeOAuthFromUrl`; anything
+    // it fails to recognise means the sign-in never completes on Android.
+    expect(isOAuthCallbackUrl(`${OAUTH_REDIRECT_URL}?code=abc123`)).toBe(true);
+    expect(isOAuthCallbackUrl(OAUTH_REDIRECT_URL)).toBe(true);
+    expect(isOAuthCallbackUrl("teamclaw://auth-callback/?code=abc")).toBe(true);
+    expect(isOAuthCallbackUrl("teamclaw:///auth-callback?code=abc")).toBe(true);
+    expect(isOAuthCallbackUrl("teamclaw://auth-callback#access_token=a")).toBe(true);
+
+    // Invite links share the scheme and must keep reaching the invite handler.
+    expect(isOAuthCallbackUrl("teamclaw://invite/token123")).toBe(false);
+    expect(isOAuthCallbackUrl("https://example.com/auth-callback")).toBe(false);
+    expect(isOAuthCallbackUrl(null)).toBe(false);
+    expect(isOAuthCallbackUrl(undefined)).toBe(false);
   });
 
   it("only completes successful browser auth sessions with a callback url", () => {

--- a/apps/expo/src/test/onboarding-store.test.ts
+++ b/apps/expo/src/test/onboarding-store.test.ts
@@ -51,6 +51,7 @@ function createApiMock(overrides: Partial<OnboardingApi> = {}): OnboardingApi {
       pendingEmail: email,
     })),
     verifyOTP: vi.fn().mockResolvedValue({}),
+    signInWithPassword: vi.fn().mockResolvedValue(undefined),
     createOAuthSignInUrl: vi.fn().mockResolvedValue("https://auth.example.com/oauth"),
     createOAuthLinkUrl: vi.fn().mockResolvedValue("https://auth.example.com/link"),
     completeOAuthCallback: vi.fn().mockResolvedValue({}),
@@ -193,6 +194,49 @@ describe("createOnboardingController", () => {
     expect(controller.getState()).toMatchObject<Partial<OnboardingState>>({
       route: "createTeam",
       pendingEmailOTPEmail: null,
+    });
+  });
+
+  it("signInWithPassword signs in and bootstraps without a pending-email step", async () => {
+    const { createOnboardingController } = await loadController();
+    const api = createApiMock({
+      getCurrentSession: vi
+        .fn()
+        .mockResolvedValue({ user: { id: "user-1", is_anonymous: false } }),
+    });
+    const controller = createOnboardingController(api);
+
+    // Unlike the OTP flow there is no requestOtp first: one call is the whole
+    // sign-in, so it must reach bootstrap on its own.
+    await controller.signInWithPassword("  Person@Example.com  ", "hunter2");
+
+    expect(api.signInWithPassword).toHaveBeenCalledWith(
+      "Person@Example.com",
+      "hunter2",
+    );
+    expect(api.loadBootstrap).toHaveBeenCalledTimes(1);
+    expect(controller.getState()).toMatchObject<Partial<OnboardingState>>({
+      route: "createTeam",
+    });
+  });
+
+  it("signInWithPassword surfaces a rejected credential as an error, not a crash", async () => {
+    const { createOnboardingController } = await loadController();
+    const api = createApiMock({
+      signInWithPassword: vi
+        .fn()
+        .mockRejectedValue(new Error("Invalid login credentials")),
+    });
+    const controller = createOnboardingController(api);
+
+    await expect(
+      controller.signInWithPassword("person@example.com", "wrong"),
+    ).rejects.toThrow("Invalid login credentials");
+
+    expect(api.loadBootstrap).not.toHaveBeenCalled();
+    expect(controller.getState()).toMatchObject<Partial<OnboardingState>>({
+      errorMessage: "Invalid login credentials",
+      isBusy: false,
     });
   });
 

--- a/apps/expo/src/test/onboarding-store.test.ts
+++ b/apps/expo/src/test/onboarding-store.test.ts
@@ -304,6 +304,86 @@ describe("createOnboardingController", () => {
     });
   });
 
+  /**
+   * On Android the OAuth redirect is a deep link, so the OS hands the callback
+   * URL to the app and the custom tab merely closes — `openAuthSessionAsync`
+   * reports `dismiss`, exactly as if the user had backed out. Sign-in therefore
+   * has to survive being carried entirely by the deep link.
+   */
+  it("signs in from the callback deep link even when the browser reports a dismiss", async () => {
+    const { createOnboardingController } = await loadController();
+    const api = createApiMock({
+      getCurrentSession: vi
+        .fn()
+        .mockResolvedValue({ user: { id: "user-1", is_anonymous: false } }),
+      loadBootstrap: vi.fn().mockResolvedValue({
+        isAnonymous: false,
+        team: { id: "team-1", name: "Team Claw", slug: "team-claw", role: "owner" },
+        memberActorId: "member-1",
+      } satisfies BootstrapResult),
+    });
+    const controller = createOnboardingController(api);
+
+    await controller.signInWithOAuth("google", {
+      redirectTo: "teamclaw://auth-callback",
+      openAuthSession: vi.fn().mockResolvedValue({ type: "dismiss" }),
+    });
+    expect(api.completeOAuthCallback).not.toHaveBeenCalled();
+
+    await controller.completeOAuthFromUrl("teamclaw://auth-callback?code=abc");
+
+    expect(api.completeOAuthCallback).toHaveBeenCalledWith(
+      "teamclaw://auth-callback?code=abc",
+    );
+    expect(controller.getState()).toMatchObject<Partial<OnboardingState>>({
+      route: "ready",
+      currentMemberActorId: "member-1",
+      isBusy: false,
+    });
+  });
+
+  it("spends a callback url once even when both channels deliver it", async () => {
+    const { createOnboardingController } = await loadController();
+    const api = createApiMock({
+      getCurrentSession: vi
+        .fn()
+        .mockResolvedValue({ user: { id: "user-1", is_anonymous: false } }),
+    });
+    const controller = createOnboardingController(api);
+    const url = "teamclaw://auth-callback?code=abc";
+
+    // The browser result path wins the race...
+    await controller.signInWithOAuth("google", {
+      redirectTo: "teamclaw://auth-callback",
+      openAuthSession: vi.fn().mockResolvedValue({ type: "success", url }),
+    });
+    // ...then the OS delivers the same URL to the Linking listener.
+    const second = await controller.completeOAuthFromUrl(url);
+
+    expect(second).toBe(false);
+    // A PKCE code is single-use: exchanging twice fails the second time.
+    expect(api.completeOAuthCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a failed callback exchange instead of returning silently", async () => {
+    const { createOnboardingController } = await loadController();
+    const api = createApiMock({
+      completeOAuthCallback: vi
+        .fn()
+        .mockRejectedValue(new Error("invalid or expired code")),
+    });
+    const controller = createOnboardingController(api);
+
+    await expect(
+      controller.completeOAuthFromUrl("teamclaw://auth-callback?code=stale"),
+    ).rejects.toThrow("invalid or expired code");
+
+    expect(controller.getState()).toMatchObject<Partial<OnboardingState>>({
+      isBusy: false,
+      errorMessage: "invalid or expired code",
+    });
+  });
+
   it("linkIdentityWithOAuth links an identity, completes callback, and bootstraps", async () => {
     const { createOnboardingController } = await loadController();
     const api = createApiMock({

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
   "pnpm": {
     "overrides": {
       "@codemirror/state": "6.7.0"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@sentry/cli"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: 2.2.0
         version: 2.2.0(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))
+      '@sentry/react-native':
+        specifier: ~7.11.0
+        version: 7.11.0(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       '@teamclaw/app':
         specifier: workspace:*
         version: link:../../packages/app
@@ -3662,12 +3665,92 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@sentry-internal/browser-utils@10.37.0':
+    resolution: {integrity: sha512-rqdESYaVio9Ktz55lhUhtBsBUCF3wvvJuWia5YqoHDd+egyIfwWxITTAa0TSEyZl7283A4WNHNl0hyeEMblmfA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.37.0':
+    resolution: {integrity: sha512-P0PVlfrDvfvCYg2KPIS7YUG/4i6ZPf8z1MicXx09C9Cz9W9UhSBh/nii13eBdDtLav2BFMKhvaFMcghXHX03Hw==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.37.0':
+    resolution: {integrity: sha512-PyIYSbjLs+L5essYV0MyIsh4n5xfv2eV7l0nhUoPJv9Bak3kattQY3tholOj0EP3SgKgb+8HSZnmazgF++Hbog==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.37.0':
+    resolution: {integrity: sha512-snuk12ZaDerxesSnetNIwKoth/51R0y/h3eXD/bGtXp+hnSkeXN5HanI/RJl297llRjn4zJYRShW9Nx86Ay0Dw==}
+    engines: {node: '>=18'}
+
+  '@sentry/babel-plugin-component-annotate@4.8.0':
+    resolution: {integrity: sha512-cy/9Eipkv23MsEJ4IuB4dNlVwS9UqOzI3Eu+QPake5BVFgPYCX0uP0Tr3Z43Ime6Rb+BiDnWC51AJK9i9afHYw==}
+    engines: {node: '>= 14'}
+
   '@sentry/browser-utils@10.63.0':
     resolution: {integrity: sha512-DhUGNN+CH8fzAs6qAsueKPU70qShyTX3NxLhIP+l5DbGXDSXpYXBT6s8ubZus0/LhxpLvI0iSyNIDvZRD/gZaA==}
     engines: {node: '>=18'}
 
+  '@sentry/browser@10.37.0':
+    resolution: {integrity: sha512-kheqJNqGZP5TSBCPv4Vienv1sfZwXKHQDYR+xrdHHYdZqwWuZMJJW/cLO9XjYAe+B9NnJ4UwJOoY4fPvU+HQ1Q==}
+    engines: {node: '>=18'}
+
   '@sentry/browser@10.63.0':
     resolution: {integrity: sha512-0mi56YOkwgyjdLOcN5cB1//EcYzEOt3NZ2GLygE92B3zAAwVM1WgbmibZCXToKFClH7z1uH3VWVfBffmkwIMYw==}
+    engines: {node: '>=18'}
+
+  '@sentry/cli-darwin@2.58.4':
+    resolution: {integrity: sha512-kbTD+P4X8O+nsNwPxCywtj3q22ecyRHWff98rdcmtRrvwz8CKi/T4Jxn/fnn2i4VEchy08OWBuZAqaA5Kh2hRQ==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.4':
+    resolution: {integrity: sha512-0g0KwsOozkLtzN8/0+oMZoOuQ0o7W6O+hx+ydVU1bktaMGKEJLMAWxOQNjsh1TcBbNIXVOKM/I8l0ROhaAb8Ig==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.4':
+    resolution: {integrity: sha512-rdQ8beTwnN48hv7iV7e7ZKucPec5NJkRdrrycMJMZlzGBPi56LqnclgsHySJ6Kfq506A2MNuQnKGaf/sBC9REA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.4':
+    resolution: {integrity: sha512-NseoIQAFtkziHyjZNPTu1Gm1opeQHt7Wm1LbLrGWVIRvUOzlslO9/8i6wETUZ6TjlQxBVRgd3Q0lRBG2A8rFYA==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.4':
+    resolution: {integrity: sha512-d3Arz+OO/wJYTqCYlSN3Ktm+W8rynQ/IMtSZLK8nu0ryh5mJOh+9XlXY6oDXw4YlsM8qCRrNquR8iEI1Y/IH+Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.4':
+    resolution: {integrity: sha512-bqYrF43+jXdDBh0f8HIJU3tbvlOFtGyRjHB8AoRuMQv9TEDUfENZyCelhdjA+KwDKYl48R1Yasb4EHNzsoO83w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.4':
+    resolution: {integrity: sha512-3triFD6jyvhVcXOmGyttf+deKZcC1tURdhnmDUIBkiDPJKGT/N5xa4qAtHJlAB/h8L9jgYih9bvJnvvFVM7yug==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.4':
+    resolution: {integrity: sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.4':
+    resolution: {integrity: sha512-ArDrpuS8JtDYEvwGleVE+FgR+qHaOp77IgdGSacz6SZy6Lv90uX0Nu4UrHCQJz8/xwIcNxSqnN22lq0dH4IqTg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/core@10.37.0':
+    resolution: {integrity: sha512-hkRz7S4gkKLgPf+p3XgVjVm7tAfvcEPZxeACCC6jmoeKhGkzN44nXwLiqqshJ25RMcSrhfFvJa/FlBg6zupz7g==}
     engines: {node: '>=18'}
 
   '@sentry/core@10.63.0':
@@ -3677,6 +3760,23 @@ packages:
   '@sentry/feedback@10.63.0':
     resolution: {integrity: sha512-If/+72xFg9ylz4twUo3U9gUpZ+Ys+T/3Y09WH7r2gGhWEOF9bp+ta94+Pg7Lb0M2nVD7waz4OxIvB49GEvtLDA==}
     engines: {node: '>=18'}
+
+  '@sentry/react-native@7.11.0':
+    resolution: {integrity: sha512-OiDaLCAGpRN18YG/o7IIwLhU0Xpb0tYKQ5QxkGHiwb+L3VHn+MqGCGfITYNdhqr06HHMvu9Lysm+UJxaNmGaJg==}
+    hasBin: true
+    peerDependencies:
+      expo: '>=49.0.0'
+      react: '>=17.0.0'
+      react-native: '>=0.65.0'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
+  '@sentry/react@10.37.0':
+    resolution: {integrity: sha512-XLnXJOHgsCeVAVBbO+9AuGlZWnCxLQHLOmKxpIr8wjE3g7dHibtug6cv8JLx78O4dd7aoCqv2TTyyKY9FLJ2EQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
 
   '@sentry/react@10.63.0':
     resolution: {integrity: sha512-+/Y0dd4EMqyqYBJ1D3bAYYuG+ccIx5+IFcbTZ9p+XWnW6nNIVjy5zttVftYo6xOmtTQbzRuPT/vO4dqDHKKmfw==}
@@ -3690,6 +3790,10 @@ packages:
 
   '@sentry/replay@10.63.0':
     resolution: {integrity: sha512-u4fDaLbd4QmJbU0qGzV5g2B2hjw5utdeZzpTrmq565AS5o6mfaZdCz30zF9R2Unkn0g9SJr90piTN2RMwvDrkw==}
+    engines: {node: '>=18'}
+
+  '@sentry/types@10.37.0':
+    resolution: {integrity: sha512-umpnUKRC0AAbJrADg6SlFtqN2yzf7NHciCF9lkHau+ax2PIZ/NDmoG4RQujFVflVaVoD60Ly2t+CcPnYIWMPlw==}
     engines: {node: '>=18'}
 
   '@shikijs/core@4.3.1':
@@ -4367,6 +4471,10 @@ packages:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -5903,6 +6011,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -6755,6 +6867,15 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -7044,6 +7165,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -7785,6 +7909,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -8110,6 +8237,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -8127,6 +8257,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -12001,9 +12134,37 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@sentry-internal/browser-utils@10.37.0':
+    dependencies:
+      '@sentry/core': 10.37.0
+
+  '@sentry-internal/feedback@10.37.0':
+    dependencies:
+      '@sentry/core': 10.37.0
+
+  '@sentry-internal/replay-canvas@10.37.0':
+    dependencies:
+      '@sentry-internal/replay': 10.37.0
+      '@sentry/core': 10.37.0
+
+  '@sentry-internal/replay@10.37.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.37.0
+      '@sentry/core': 10.37.0
+
+  '@sentry/babel-plugin-component-annotate@4.8.0': {}
+
   '@sentry/browser-utils@10.63.0':
     dependencies:
       '@sentry/core': 10.63.0
+
+  '@sentry/browser@10.37.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.37.0
+      '@sentry-internal/feedback': 10.37.0
+      '@sentry-internal/replay': 10.37.0
+      '@sentry-internal/replay-canvas': 10.37.0
+      '@sentry/core': 10.37.0
 
   '@sentry/browser@10.63.0':
     dependencies:
@@ -12013,11 +12174,79 @@ snapshots:
       '@sentry/replay': 10.63.0
       '@sentry/replay-canvas': 10.63.0
 
+  '@sentry/cli-darwin@2.58.4':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.4':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.4':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.4':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.4':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.4':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.4':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.4':
+    optional: true
+
+  '@sentry/cli@2.58.4':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.4
+      '@sentry/cli-linux-arm': 2.58.4
+      '@sentry/cli-linux-arm64': 2.58.4
+      '@sentry/cli-linux-i686': 2.58.4
+      '@sentry/cli-linux-x64': 2.58.4
+      '@sentry/cli-win32-arm64': 2.58.4
+      '@sentry/cli-win32-i686': 2.58.4
+      '@sentry/cli-win32-x64': 2.58.4
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/core@10.37.0': {}
+
   '@sentry/core@10.63.0': {}
 
   '@sentry/feedback@10.63.0':
     dependencies:
       '@sentry/core': 10.63.0
+
+  '@sentry/react-native@7.11.0(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@sentry/babel-plugin-component-annotate': 4.8.0
+      '@sentry/browser': 10.37.0
+      '@sentry/cli': 2.58.4
+      '@sentry/core': 10.37.0
+      '@sentry/react': 10.37.0(react@19.2.3)
+      '@sentry/types': 10.37.0
+      react: 19.2.3
+      react-native: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
+    optionalDependencies:
+      expo: 57.0.11(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@57.0.8)(expo-router@57.0.11)(react-dom@19.2.8(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/react@10.37.0(react@19.2.3)':
+    dependencies:
+      '@sentry/browser': 10.37.0
+      '@sentry/core': 10.37.0
+      react: 19.2.3
 
   '@sentry/react@10.63.0(react@19.2.8)':
     dependencies:
@@ -12034,6 +12263,10 @@ snapshots:
     dependencies:
       '@sentry/browser-utils': 10.63.0
       '@sentry/core': 10.63.0
+
+  '@sentry/types@10.37.0':
+    dependencies:
+      '@sentry/core': 10.37.0
 
   '@shikijs/core@4.3.1':
     dependencies:
@@ -12711,6 +12944,12 @@ snapshots:
   acorn@8.16.0: {}
 
   acorn@8.17.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -14440,6 +14679,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -15534,6 +15780,10 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -15828,6 +16078,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 
@@ -16801,6 +17053,8 @@ snapshots:
     dependencies:
       tldts: 7.4.5
 
+  tr46@0.0.3: {}
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -17080,6 +17334,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.1: {}
 
   whatwg-fetch@3.6.20: {}
@@ -17095,6 +17351,11 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
Eleven commits from driving the Expo app by hand on a real device. Each fix
came from an actual dead end, and the last group exists so the next one shows
up in a dashboard instead of over my shoulder.

## Sign-in was broken in two independent ways

**`/v1/auth/refresh` was read as snake_case.** It is the one `/v1/auth/*`
endpoint FC maps rather than forwarding a raw GoTrue body, so it answers
`{accessToken, refreshToken, expiresAt}`. `setRefreshSession` piped it through
`storeGoTrue`, which reads `access_token`, found nothing, and threw
`Authentication response did not include a session.` `loadBootstrap` calls it
right after team activation — so this fired for **every user with a team, on
every launch**, and because it landed in bootstrap's generic error state,
killing and reopening the app hit it again. The store's own `refresh()` already
had this right; only that one call site had drifted.

**Google sign-in never exchanged its code.** The redirect
`teamclaw://auth-callback` is a real Android deep link, so the OS delivers it to
the app and the custom tab merely closes — `openAuthSessionAsync` resolves
`dismiss`, indistinguishable from the user backing out. That was treated as a
cancel: busy cleared, no error, no exchange, no session. Meanwhile expo-router
took the same URL as a navigation to `/auth-callback`, which redirected on
`route` alone — still `needsAuth` without a session, i.e. `/welcome`. So a
successful Google login rendered as *"dumped back on the first screen"*, and the
error had no screen to appear on. (Before `/auth-callback` existed, this same
path produced the "Unmatched Route" report.)

The exchange now runs off the URL via the Linking listener that reliably
receives it; the browser result is just one of two channels that may deliver it,
and each callback is spent exactly once since a PKCE code is single-use.

## Android had no error reporting at all

Every other client reports — `packages/app`, `apps/desktop`, `apps/ios`. Expo
did not, which is why none of the above ever appeared in Sentry.

Uses `@sentry/react-native`, not the native Android SDK: the business logic is
all JS, and a native-only SDK would have caught none of these. Errors only
(`tracesSampleRate: 0`); dev builds stay silent by default because hot reload
turns half-finished code into real events.

Source maps are wired end to end — `getSentryExpoConfig` stamps the debug ID
that matches a crash to its map, the config plugin writes `sentry.properties`,
and `@sentry/cli` is unblocked in `onlyBuiltDependencies` (pnpm 10 blocks
install scripts by default, and a missing CLI binary fails at *build* time, not
install time). `SENTRY_AUTH_TOKEN` is deliberately absent — it is a real
credential and belongs in an EAS secret. `apps/expo/SENTRY.md` covers that.

`eas.json` also gains `EXPO_PUBLIC_CLOUD_API_URL` for preview/production.
`EXPO_PUBLIC_*` is inlined at bundle time and those profiles bundle on EAS
servers, which never see a local `.env` — the same mechanism behind the
`EXPO_PUBLIC_CLOUD_API_URL is required` crash in an installed APK. It would have
swallowed the DSN too.

## Also here

- Vertical centering on the choose-auth screen.
- Email+password sign-in alongside OTP and Google, closer to iOS.
- Sign-out escapes from the create-team and failed-bootstrap dead ends, both of
  which survived killing the app because the bad session was in storage.

## Verification

`tsc --noEmit` clean; 74 files / 351 tests green.

The two sign-in fixes have tests that were mutation-checked — reverting either
one turns them red, and the refresh test reproduces the exact production error
string. Sentry's serializer was verified by building a real production bundle
and confirming `debugId` and `sentry-dbid-` are stamped with matching UUIDs,
rather than trusting that the config edit took.

Not verified: on-device confirmation of the Google flow. The final link — that
`openAuthSessionAsync` reports `dismiss` — is inferred from the deep link
demonstrably reaching expo-router while no session was created, not directly
observed (no adb on this machine). The flow no longer depends on that return
value either way, and a failure now surfaces on the auth screen instead of a
silent bounce.