### PR TITLE
fix(expo): stop the bootstrap loop stuck on "Opening TeamClaw"

### DIFF
--- a/apps/expo/src/lib/auth/cloud-auth.ts
+++ b/apps/expo/src/lib/auth/cloud-auth.ts
@@ -252,16 +252,24 @@ export const cloudAuth: CloudAuthClient = {
           throw new Error("Authentication response did not include a session.");
         }
         const previous = store().current();
-        await store().setSession({
-          accessToken: body.accessToken,
-          refreshToken: body.refreshToken,
-          expiresAt: body.expiresAt ?? nowSeconds() + 3600,
-          // The refresh response carries no user, so identity fields come from
-          // the session being replaced — this swaps tokens, not accounts.
-          isAnonymous: previous?.isAnonymous ?? false,
-          email: previous?.email ?? null,
-          userId: previous?.userId ?? null,
-        });
+        await store().setSession(
+          {
+            accessToken: body.accessToken,
+            refreshToken: body.refreshToken,
+            expiresAt: body.expiresAt ?? nowSeconds() + 3600,
+            // The refresh response carries no user, so identity fields come
+            // from the session being replaced — this swaps tokens, not
+            // accounts.
+            isAnonymous: previous?.isAnonymous ?? false,
+            email: previous?.email ?? null,
+            userId: previous?.userId ?? null,
+          },
+          // Silent because `loadBootstrap` calls this mid-bootstrap: notifying
+          // re-enters `bootstrap()`, which invalidates the in-flight run and
+          // loops forever on "Opening TeamClaw". Nobody needs waking — the
+          // access token is always read live through `accessToken()`.
+          { silent: true },
+        );
         return { data: {}, error: null };
       } catch (error) {
         return { data: null, error: { message: error instanceof Error ? error.message : "setRefreshSession failed" } };

--- a/apps/expo/src/lib/auth/session-store.ts
+++ b/apps/expo/src/lib/auth/session-store.ts
@@ -111,10 +111,22 @@ export function createSessionStore(options: SessionStoreOptions) {
       return session;
     },
 
-    async setSession(next: StoredSession): Promise<void> {
+    /**
+     * `silent` stores the session without waking subscribers.
+     *
+     * Subscribers exist to react to *who is signed in* changing — the app's
+     * listener re-runs `bootstrap()`. A token swap for the same user is not
+     * that, and announcing it is actively harmful when the swap happens
+     * *inside* bootstrap: team activation calls `setRefreshSession`, so the
+     * notify re-entered `bootstrap`, whose `beginOperation()` invalidated the
+     * in-flight run's token and made its `bootstrapResolved` a no-op. That
+     * loops forever, leaving the app on "Opening TeamClaw" and hammering
+     * `/v1/teams` + activate + refresh on every pass.
+     */
+    async setSession(next: StoredSession, options?: { silent?: boolean }): Promise<void> {
       session = next;
       await persist();
-      notify();
+      if (!options?.silent) notify();
     },
 
     clear: clearSession,

--- a/apps/expo/src/test/cloud-auth-refresh.test.ts
+++ b/apps/expo/src/test/cloud-auth-refresh.test.ts
@@ -70,6 +70,30 @@ describe("setRefreshSession", () => {
     expect(JSON.parse(init.body)).toEqual({ refreshToken: "old-refresh-token" });
   });
 
+  /**
+   * `loadBootstrap` calls this in the middle of a bootstrap, right after team
+   * activation. The app's `onAuthStateChange` listener re-runs `bootstrap()`,
+   * so notifying here re-entered bootstrap, and the new run's
+   * `beginOperation()` invalidated the in-flight one — whose `bootstrapResolved`
+   * then dropped on the floor. The result was an infinite loop stuck on
+   * "Opening TeamClaw", hammering /v1/teams + activate + refresh each pass.
+   *
+   * Swapping tokens is not an auth-state change: same user, new claims.
+   */
+  it("does not wake auth-state subscribers, which would re-enter bootstrap", async () => {
+    vi.stubGlobal("fetch", mockFetchOnce(CAMEL_CASE_REFRESH_RESPONSE));
+    const { cloudAuth } = await import("../lib/auth/cloud-auth");
+    const onAuthStateChange = vi.fn();
+    cloudAuth.auth.onAuthStateChange(onAuthStateChange);
+
+    await cloudAuth.auth.setRefreshSession("old-refresh-token");
+
+    expect(onAuthStateChange).not.toHaveBeenCalled();
+    // ...and the swap still took effect.
+    const { data } = await cloudAuth.auth.getSession();
+    expect(data.session?.access_token).toBe("new-access-token");
+  });
+
   it("reports a body with no tokens as an error rather than storing a blank session", async () => {
     vi.stubGlobal("fetch", mockFetchOnce({}));
     const { cloudAuth } = await import("../lib/auth/cloud-auth");


### PR DESCRIPTION
Regression from #816, found on device within minutes of installing the build.
The app never leaves the `loading` screen.

## What happens

Reading `/v1/auth/refresh` as camelCase turned `setRefreshSession` from
something that **always threw** into something that succeeds. Succeeding means
it now reaches `store().setSession()` — which notifies subscribers.

The app's `onAuthStateChange` listener re-runs `bootstrap()`. But
`loadBootstrap` calls `setRefreshSession` *during* bootstrap, right after team
activation. So:

```
bootstrap → loadBootstrap → activate → setRefreshSession → setSession → notify
    → onAuthStateChange → bootstrap  (beginOperation() invalidates the token
                                      of the run still in flight)
    → that run's `bootstrapResolved` is dropped by `dispatchIfCurrent`
    → repeat forever
```

No terminal route is ever reached, so `app/index.tsx` renders "Opening
TeamClaw" indefinitely while re-requesting `/v1/teams`, activate, and refresh
on every pass.

It hits **exactly the users the camelCase fix was meant to unblock** — only a
user with a team reaches the activation call. Before #816 the same path threw,
which is why the loop did not exist: it errored out to the failure screen
instead.

## The fix

Subscribers exist to react to *who is signed in* changing; the listener's whole
job is to re-route on sign-in and sign-out. Swapping tokens for the same user
is not that — team activation returns new claims, not a new account — so the
refresh stores silently.

Nothing needs waking: the access token is always read live through
`accessToken()`, so the MQTT password and every bearer bridge already pick up
the new value on next read.

`silent` is opt-in per call rather than the default, so ordinary sign-in and
sign-out keep notifying.

## Verification

`tsc --noEmit` clean; 74 files / 352 tests green, run against this branch on
top of current `main` rather than the branch it was authored on.

The new test was mutation-checked — restoring the unconditional `notify()`
turns it red, and only it.

Not covered: no test asserts the *loop* itself, only the notify that caused it.
Reproducing the loop would mean driving the layout's effect wiring, which the
suite does not currently model.