### PR TITLE
fix(expo): make the Sentry CLI resolvable so preview builds stop failing

### DIFF
--- a/apps/expo/SENTRY.md
+++ b/apps/expo/SENTRY.md
@@ -37,6 +37,18 @@ all three are already wired:
    in the **root** `package.json`. pnpm 10 blocks install scripts by default, and
    a blocked one leaves the CLI binary missing — the upload then fails at build
    time rather than at install time.
+4. `@sentry/cli` is also a **direct dependency of this app**, pinned to the exact
+   version `@sentry/react-native` asks for, even though nothing here imports it.
+
+   Sentry's Gradle integration shells out to a hardcoded
+   `<project>/node_modules/@sentry/cli/bin/sentry-cli`, which assumes npm/yarn
+   hoisting. pnpm keeps transitive dependencies out of the consumer's
+   `node_modules`, so that path did not exist and the build died with
+   `A problem occurred starting process` after having already written the bundle
+   and its source map. Declaring it directly makes pnpm symlink it into place.
+
+   If the pin ever drifts from `@sentry/react-native`'s own dependency, pnpm
+   installs two copies and the Gradle task may run the wrong one.
 
 ### The one manual step: `SENTRY_AUTH_TOKEN`
 

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -14,6 +14,7 @@
     "@bufbuild/protobuf": "^2.13.0",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@sentry/cli": "2.58.4",
     "@sentry/react-native": "~7.11.0",
     "@teamclaw/app": "workspace:*",
     "buffer": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: 2.2.0
         version: 2.2.0(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))
+      '@sentry/cli':
+        specifier: 2.58.4
+        version: 2.58.4
       '@sentry/react-native':
         specifier: ~7.11.0
         version: 7.11.0(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
@@ -11991,9 +11994,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.2': {}
 


### PR DESCRIPTION
The first `preview` build after wiring up source maps failed, 13 minutes in:

```
Execution failed for task ':app:createBundleReleaseJsAndAssets_SentryUpload_…'
> A problem occurred starting process 'command
  '/home/expo/workingdir/build/apps/expo/node_modules/@sentry/cli/bin/sentry-cli''
```

## Cause

Sentry's Gradle integration shells out to that **hardcoded** path, which assumes
npm/yarn hoisting. `@sentry/cli` is a transitive dependency of
`@sentry/react-native`, and pnpm deliberately keeps transitive dependencies out
of the consumer's `node_modules`:

```
$ ls apps/expo/node_modules/@sentry/
react-native        # ...and nothing else
```

So the path simply did not exist.

## Fix

Declare `@sentry/cli` as a direct dependency of `apps/expo`, which makes pnpm
symlink it into place. Nothing imports it — it exists so Gradle can find it, and
the comment in `SENTRY.md` says so, since an unused-looking dependency is
exactly the kind of thing a later cleanup deletes.

Pinned to the **exact** version `@sentry/react-native` depends on (`2.58.4`).
A caret here would let pnpm install a second copy and the Gradle task could then
run the wrong one.

## What was already working

The log is worth reading before assuming the whole path was broken — it had
gotten further than the failure suggests:

- `EXPO_PUBLIC_CLOUD_API_URL` and `EXPO_PUBLIC_SENTRY_DSN` loaded from the
  `preview` profile's `env`
- `SENTRY_AUTH_TOKEN` injected from the EAS secret
- `@sentry/cli postinstall: Done` — the `onlyBuiltDependencies` allowlist works
  on the builder too
- `Done writing sourcemap output`
- `Check generated source map for Debug ID: 453c2e00-…`

The bundle was built and its source map stamped. Only the upload process failed
to start.

## Verification

`tsc --noEmit` clean; 74 files / 352 tests green.

Locally `apps/expo/node_modules/@sentry/cli/bin/sentry-cli` now resolves and
runs (`sentry-cli 2.58.4`), and there is still exactly one copy in the store.

Not verified: an actual green preview build. That needs another cloud build,
which is the next step — this is the fix for a real, reproduced failure, not a
speculative one, but the end-to-end upload remains unproven until a build
completes.