### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amuxd"
-version = "0.3.1-beta.27"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10625,7 +10625,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaw"
-version = "0.3.1-beta.27"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.3.1-beta.27"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaw"
-version = "0.3.1-beta.27"
+version = "0.4.0"
 description = "TeamClaw - AI Agent Desktop Platform"
 authors = ["TeamClaw Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClaw",
-  "version": "0.3.1-beta.27",
+  "version": "0.4.0",
   "identifier": "com.teamclaw.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclaw/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclaw",
-  "version": "0.3.1-beta.27",
+  "version": "0.4.0",
   "private": true,
   "description": "TeamClaw - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
## Description

版本号 `0.3.1-beta.27` → **`0.4.0`**，转正式版线（上一个稳定版是 `v0.2.27`，中间的 `0.3.1-beta.*` 都是预发布）。

⚠️ **版本号有 5 处要一致，不是 CLAUDE.md 写的 4 处**：

| 文件 | 说明 |
|---|---|
| `package.json` | |
| `apps/desktop/Cargo.toml` | |
| `apps/desktop/tauri.conf.json` | |
| `apps/daemon/Cargo.toml` | 随桌面端打包的 amuxd sidecar |
| **`Cargo.lock`** | `teamclaw` + `amuxd` 两条记录 —— **CLAUDE.md 没提** |

`Cargo.lock` 不是可选项：CI 的 daemon 三个 job 全部带 `--locked`（`cargo test/check/build -p amuxd --locked`），锁文件与 manifest 对不上会直接失败。已用 `cargo metadata --locked` 验证一致。

## Related Issue

N/A

## Type of Change

- [ ] Bug fix / New feature / Breaking change / Docs / Refactor / Perf / Test

发版用的版本号变更。

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

合并后需要打标签才会真正发布：

```
git tag v0.4.0 && git push origin v0.4.0
```

标签推送触发 `release.yml`（macOS 桌面端）。注意该工作流是**无条件 `prerelease: false`** 的 —— 打上 `v0.4.0` 就会发成正式 release，不是预发布。

🤖 Generated with [Claude Code](https://claude.com/claude-code)