### PR TITLE
chore(ios): 修复 TestFlight build number 取值，并 bump 到 25

### DIFF
--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -37,8 +37,16 @@ platform :ios do
       profile_name: profile_name,
     )
 
+    # GITHUB_RUN_NUMBER resets per-repo, so it collides with build numbers
+    # already uploaded to App Store Connect from the old teamclaw-next CI.
+    # Ask ASC for the actual latest build number instead.
+    next_build_number = latest_testflight_build_number(
+      api_key: api_key,
+      app_identifier: "tech.teamclaw.mobile",
+    ) + 1
+
     increment_build_number(
-      build_number: ENV["GITHUB_RUN_NUMBER"],
+      build_number: next_build_number.to_s,
       xcodeproj: "AMUX.xcodeproj",
     )
 

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -40,7 +40,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: tech.teamclaw.mobile
         DEVELOPMENT_TEAM: 43G5A6G9QV
         MARKETING_VERSION: "1.1.5"
-        CURRENT_PROJECT_VERSION: 24
+        CURRENT_PROJECT_VERSION: 25
         SWIFT_VERSION: "6.0"
 
   AMUXUITests:


### PR DESCRIPTION
## Description

发 iOS TestFlight 前的必要修复 + 版本号递增。

### ⚠️ 先修一个会导致上传被拒的问题

`Fastfile` 用 `ENV["GITHUB_RUN_NUMBER"]` 当 build number：

```ruby
increment_build_number(
  build_number: ENV["GITHUB_RUN_NUMBER"],
  ...
)
```

`GITHUB_RUN_NUMBER` 是**按仓库计数的工作流序号**，和 App Store Connect 上已有的 build number 序列毫无关系。旧的 teamclaw-next CI 已经往同一个 app（`tech.teamclaw.mobile`）传过若干 build，两个序列会撞 —— ASC 要求同一版本下 build number 严格递增，撞了就**直接拒绝上传**。

改成向 ASC 查询当前最新 build number 再 +1：

```ruby
next_build_number = latest_testflight_build_number(
  api_key: api_key,
  app_identifier: "tech.teamclaw.mobile",
) + 1
```

这个修复此前停在 `fix/ios-testflight-build-number` 分支上、一直没提 PR（落后 main 109 个 commit）。这里 cherry-pick 过来，只动 `Fastfile` 一个文件。

### CURRENT_PROJECT_VERSION 24 → 25

顺带说明它现在的作用变了：修复之后，上传用的 build number 来自 ASC，fastlane 在构建时写进 xcodeproj。所以 `project.yml` 这个字段**管的是本地构建**，不再是 TestFlight 看到的值 —— 保持递增是为了让仓库里的数字不至于失真。

`MARKETING_VERSION` 保持 `1.1.5`：iOS 有自己的版本线，与同期发布的桌面端 0.4.0 无关。

## Related Issue

配合 #822（桌面端 0.4.0）。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / Breaking change / Docs / Refactor / Perf / Test

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

合并后打标签才会真正发布：

```
git tag ios-v1.1.5-25 && git push origin ios-v1.1.5-25
```

**标签格式必须是 `ios-v*`**，`ios-1.1.5-25` 这类不会触发 `testflight.yml`。

顺带一提：仓库里目前**一个 `ios-v*` 标签都没有**（`git tag -l "ios-v*"` 为空），所以这会是该工作流的第一次标签触发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)