### PR TITLE
chore(ios): marketing 版本 1.1.5 → 1.2

### DIFF
--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -39,7 +39,7 @@ targets:
         CODE_SIGN_ENTITLEMENTS: AMUXApp/AMUX.entitlements
         PRODUCT_BUNDLE_IDENTIFIER: tech.teamclaw.mobile
         DEVELOPMENT_TEAM: 43G5A6G9QV
-        MARKETING_VERSION: "1.1.5"
+        MARKETING_VERSION: "1.2"
         CURRENT_PROJECT_VERSION: 25
         SWIFT_VERSION: "6.0"
 


### PR DESCRIPTION
## Description

iOS marketing 版本 `1.1.5` → **`1.2`**。

`apps/ios/project.yml` 是唯一来源 —— `Info.plist` 里是 `$(MARKETING_VERSION)` 变量，改这一处就够。

**build number 保持 25**，不需要重置：#823 之后 fastlane 在构建时向 App Store Connect 查最新 build number 再 +1，实际上传的值来自 ASC 而非本文件；而且新的 marketing 版本在 ASC 里本就开启独立的 build 序列。

发布标签相应变成 **`ios-v1.2-25`**。

## Related Issue

接 #823（TestFlight build number 修复 + build 25）。同期发布桌面端 #822（0.4.0）。

## Type of Change

- [ ] Bug fix / New feature / Breaking change / Docs / Refactor / Perf / Test

发版用的版本号变更。

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

合并后打标签才会触发 TestFlight：

```
git tag ios-v1.2-25 && git push origin ios-v1.2-25
```

标签格式必须是 `ios-v*`。仓库里目前一个 `ios-v*` 标签都没有，这会是 `testflight.yml` 第一次被标签触发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)