### PR TITLE
fix(ci): TestFlight 不再对同一 commit 重复发布

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -15,7 +15,60 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decides whether this run should actually publish, and absorbs the debounce
+  # wait. Split out from the build so the 5-minute sleep burns Linux minutes
+  # rather than a macOS runner, and so the decision is made before anything
+  # expensive starts.
+  #
+  # Deliberately does NOT set `defaults.run.working-directory` — apps/ios only
+  # exists after checkout, and pointing the default at it is what silently
+  # killed every main-push release from 2026-08-01 onward.
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.decide.outputs.proceed }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Debounce: wait before deciding, so a burst of iOS PRs merged in quick
+      # succession collapses into a single release. Each new push cancels the
+      # in-progress run (concurrency above) and restarts this timer. Tag pushes
+      # and workflow_dispatch skip the wait.
+      - name: Debounce (batch consecutive iOS merges)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: sleep 300
+
+      # The release flow is "merge the iOS PR, then push an ios-v* tag", so both
+      # triggers fire for the same commit. `concurrency` groups on github.ref,
+      # and a tag and a branch are different refs, so neither cancels the other:
+      # two runs each ask App Store Connect for the latest build number, both get
+      # the same answer, and the loser's upload is rejected as a duplicate. That
+      # is a guaranteed red run on every normal release.
+      #
+      # Resolved by deferring to the tag: after the debounce, if this commit now
+      # carries an ios-v* tag, that tag's own run is publishing it, so this one
+      # stands down. A main push with no tag behind it still releases as before.
+      - name: Decide whether to publish
+        id: decide
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            git fetch --tags --force --quiet
+            tags=$(git tag --points-at HEAD | grep '^ios-v' || true)
+            if [ -n "$tags" ]; then
+              echo "This commit is tagged: $tags"
+              echo "Its tag run publishes it — standing down to avoid a duplicate upload."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
   build-and-upload:
+    needs: guard
+    if: needs.guard.outputs.proceed == 'true'
     runs-on: macos-26
 
     defaults:
@@ -34,20 +87,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-
-      # Debounce: wait before starting the real build so that a burst of
-      # iOS PRs merged in quick succession collapses into a single release.
-      # Each new push cancels the in-progress run (concurrency above) and
-      # restarts this timer. Tag pushes and workflow_dispatch skip the wait.
-      #
-      # Must run AFTER checkout: `defaults.run.working-directory` is apps/ios,
-      # which does not exist on the runner until the repo is checked out. As the
-      # first step it failed instantly with "No such file or directory", killing
-      # every main-push release from 2026-08-01 onward — silently, because tag
-      # pushes skip this step and so never hit it.
-      - name: Debounce (batch consecutive iOS merges)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: sleep 300
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,26 +157,46 @@ Shared: `skills/`, `.mcp/`, `knowledge/`
 
 ## Versioning & Release
 
-**Version numbers** — Desktop version must match across `package.json`, `apps/desktop/Cargo.toml`, `apps/desktop/tauri.conf.json`, and `apps/daemon/Cargo.toml` (bundled `amuxd` sidecar).
+**Version numbers** — Desktop version must match across **five** places: `package.json`,
+`apps/desktop/Cargo.toml`, `apps/desktop/tauri.conf.json`, `apps/daemon/Cargo.toml`
+(bundled `amuxd` sidecar), and **`Cargo.lock`** (the `teamclaw` and `amuxd` entries).
+
+`Cargo.lock` is not optional: CI builds the daemon with `--locked`
+(`cargo test/check/build -p amuxd --locked`), which fails outright when the lockfile
+disagrees with the manifests. Verify with `cargo metadata --locked` before tagging.
 
 **Release process:**
-1. Bump desktop version in all 4 files
+1. Bump desktop version in all 5 places above
 2. Commit, push to main
 3. `git tag v<desktop-version> && git push origin v<desktop-version>`
 4. Tag push triggers `release.yml` (macOS desktop)
 
 ## iOS TestFlight Release
 
-**Version file:** `apps/ios/project.yml` — `MARKETING_VERSION` (e.g. `1.1.5`) + `CURRENT_PROJECT_VERSION` (build number, increment by 1 each release).
+**Version file:** `apps/ios/project.yml` — `MARKETING_VERSION` (e.g. `1.2`) +
+`CURRENT_PROJECT_VERSION`.
+
+`CURRENT_PROJECT_VERSION` does NOT decide what TestFlight receives. fastlane asks
+App Store Connect for the latest build number and increments that at build time, so
+the uploaded build comes from ASC. This field governs local builds only. The two
+drift far apart — on the 1.2 release the file said 25 while ASC was already at 52,
+so the upload went out as 53. Setting it by hand cannot fix a rejected upload.
 
 **Release process:**
-1. Bump `CURRENT_PROJECT_VERSION` in `apps/ios/project.yml`
+1. Bump `MARKETING_VERSION` if the user-facing version changes; `CURRENT_PROJECT_VERSION`
+   is cosmetic (see above) but keep it moving so the checked-in value stays honest
 2. Commit and push to main
 3. `git tag ios-v<version>-<build> && git push origin ios-v<version>-<build>`
-   - Example: `git tag ios-v1.1.5-4 && git push origin ios-v1.1.5-4`
+   - Example: `git tag ios-v1.2-25 && git push origin ios-v1.2-25`
 4. Tag push triggers `.github/workflows/testflight.yml` (runs `fastlane beta` on CI)
 
 **Tag format must be `ios-v*`** — other formats (e.g. `ios-1.1.5-4`) do not trigger the workflow.
+
+`testflight.yml` also runs on pushes to `main` touching `apps/ios/**`, so the normal
+release flow (merge, then tag) fires it twice for the same commit. A `guard` job
+handles that: after the debounce it checks whether HEAD carries an `ios-v*` tag and
+stands down if so, leaving the tag's run to publish. A main push with no tag behind
+it still releases as before.
 
 ## Deployment — one environment, two deploy targets
 


### PR DESCRIPTION
## Description

修掉每次正常 iOS 发布都会产生的一条**注定失败的 run**，并订正 CLAUDE.md 里两处今天真实踩到的错误。

### 问题

发布流程是「合并 iOS PR → 打 `ios-v*` 标签」，而 `testflight.yml` 两者都监听。`concurrency` 按 `github.ref` 分组，标签和 main 是**不同的 ref**，互不取消 —— 于是两条 run 各自向 App Store Connect 查最新 build number，拿到同一个答案，后到的被拒：

```
The bundle version must be higher than the previously uploaded version: '53'
code: ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE
```

今天 1.2 发布就是这样：标签那条成功上传 build 53，main 那条 4 分钟后带着同一个 53 撞墙。**发布本身没受影响**，但每次发版都留一条红 —— 而这种噪音会训练人忽略 TestFlight 的失败。

### 改法：让 main 让位给标签，而不是放宽 concurrency

共用一个 concurrency group 看起来更简单，但方向是错的：那样**后来的 main 推送会取消正在上传的标签 run**，等于用"无害的重复"换"被打断的发布"。

改为新增一个 `guard` job：跑完 debounce 后，**仅在 main 推送路径上**检查 HEAD 是否已带 `ios-v*` 标签 —— 带了就说明该 commit 由标签那条负责发布，本条让位。没有标签跟随的 main 推送，行为完全不变。

用今天的真实 commit 离线验证过两个方向：

```
commit 4960122d（今天发布的）  → 命中 ios-v1.2-25  ⇒ proceed=false
一个无标签的 commit            → 无匹配            ⇒ proceed=true
```

顺带两个收益：5 分钟的 debounce sleep 从 macOS runner 挪到 Linux；决策发生在任何昂贵步骤之前。

`guard` 刻意**不设** `defaults.run.working-directory` —— 把它指向 checkout 之前尚不存在的 `apps/ios`，正是让 2026-08-01 起所有 main 推送发布静默失败的原因。

### CLAUDE.md 两处订正

| 原文 | 实际 |
|---|---|
| 版本号需一致的有 **4 个文件** | **5 处** —— 漏了 `Cargo.lock`（`teamclaw` + `amuxd`）。CI 用 `--locked` 构建 daemon，漏改直接失败 |
| iOS「bump `CURRENT_PROJECT_VERSION`，每次 +1」 | 该值**不决定** TestFlight 收到什么。fastlane 在构建时从 ASC 取号。今天文件里是 25、ASC 已到 52、实际上传 53。把它写成"每次 +1"暗示了一种它并不具备的控制力 |

## Related Issue

接今天的 0.4.0 / iOS 1.2 发布。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [ ] New feature / Breaking change / Refactor / Perf / Test

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**没做的验证**：工作流改动只有真正触发才能端到端验证，而触发意味着发一个 TestFlight 包。YAML 已解析校验、`guard` 的判定逻辑已用真实 commit 离线跑过两个分支，但"main 推送时确实跳过上传"这条要等下次 iOS 发布才能观察到。下次发版时留意 `guard` job 的输出即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)