### PR TITLE
fix(self-host): enable Apple sign-in on GoTrue

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -115,11 +115,26 @@ OTP_EMAIL_SMTP_PASS=
 OTP_EMAIL_FROM=
 
 # ── better-auth (BACKEND_KIND=postgres only) ───────────────────────────
-# The supabase backend uses GoTrue and ignores all of these.
+# The supabase backend uses GoTrue and ignores all of these. Note APPLE_CLIENT_ID
+# here is better-auth's Services ID for the *web* flow — it is NOT the variable
+# that drives GoTrue Apple sign-in; that one is APPLE_CLIENT_IDS below.
 AUTH_BASE_URL=
 AUTH_SECRET=
 APPLE_CLIENT_ID=
 APPLE_CLIENT_SECRET=
+
+# ── Apple sign-in (GoTrue, native only) ────────────────────────────────
+# iOS obtains an id_token from the system sheet and posts it to FC
+# /v1/auth/signin-idtoken -> GoTrue /auth/v1/token?grant_type=id_token. GoTrue
+# rejects that grant with `Provider (issuer "https://appleid.apple.com") is not
+# enabled` unless the provider is on, so this defaults to enabled.
+#
+# APPLE_CLIENT_IDS is a comma-separated list of accepted `aud` values, not a
+# credential — for native Sign in with Apple the audience is the iOS bundle ID.
+# Override only when shipping under a different bundle identifier. There is no
+# secret: the grant verifies against Apple's public JWKS.
+ENABLE_APPLE_SIGNUP=true
+APPLE_CLIENT_IDS=tech.teamclaw.mobile
 
 # ── Google sign-in ─────────────────────────────────────────────────────
 # Read by BOTH auth backends: GoTrue (supabase/docker-compose.yml maps them

--- a/deploy/self-host/.env.local.example
+++ b/deploy/self-host/.env.local.example
@@ -111,6 +111,11 @@ ADDITIONAL_REDIRECT_URLS=http://127.0.0.1:*/callback,teamclaw://auth-callback
 ENABLE_GOOGLE_SIGNUP=false
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+
+# Apple sign-in — native id_token grant only, no secret. APPLE_CLIENT_IDS is the
+# comma-separated list of accepted `aud` values (the iOS bundle ID).
+ENABLE_APPLE_SIGNUP=true
+APPLE_CLIENT_IDS=tech.teamclaw.mobile
 SMTP_HOST=supabase-mail
 SMTP_PORT=2500
 SMTP_USER=fake_mail_user

--- a/deploy/self-host/README.md
+++ b/deploy/self-host/README.md
@@ -321,6 +321,28 @@ token、验签）和**终端用户浏览器**（打开 Google 授权页）。代
 桌面端按钮另受 `build.config.*.json` 的 `auth.google` 控制，默认 `false`，
 服务端跑通后再打开。
 
+##### Apple 登录（iOS 原生，和 Google 不是一条路）
+
+iOS 用系统弹窗拿到 id_token，POST 给 FC `/v1/auth/signin-idtoken`，FC 再转
+GoTrue `/auth/v1/token?grant_type=id_token`。**没有浏览器跳转，也没有
+client_secret**：这条 grant 是拿 Apple 的公开 JWKS 验签的。
+
+因此只要两个变量，且都不是机密（默认已开，`.env` 里通常不用写）：
+
+```bash
+ENABLE_APPLE_SIGNUP=true
+# 逗号分隔的 aud 白名单，就是 iOS 的 bundle id
+APPLE_CLIENT_IDS=tech.teamclaw.mobile
+```
+
+没开的现象很有迷惑性：系统弹窗先走完、看着像成功了，最后才报
+`Provider (issuer "https://appleid.apple.com") is not enabled`，容易被当成 iOS 端 bug。
+
+**`appleid.apple.com` 走直连，不走 `AUTH_EGRESS_PROXY`**（已在 `NO_PROXY` 里）。
+墙内直连 Apple 本来就通（~0.7s），而那个代理的目标白名单是给 Google 配的，
+Apple 过去会撞上 tinyproxy 的 `Filtered`，最终表现成 id_token grant 500
+`unexpected_failure` —— 和"没开 provider"是两回事，日志里要分清。
+
 #### E. 切换后端后清理缓存
 
 若之前连过线上环境，清掉浏览器/Tauri WebView 里的 MQTT 缓存，避免沿用旧 broker：

--- a/deploy/self-host/all-in-one/render-config.sh
+++ b/deploy/self-host/all-in-one/render-config.sh
@@ -92,6 +92,10 @@ GOTRUE_EXTERNAL_GOOGLE_ENABLED=${ENABLE_GOOGLE_SIGNUP:-false}
 GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
 GOTRUE_EXTERNAL_GOOGLE_SECRET=${GOOGLE_CLIENT_SECRET:-}
 GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=$PUBLIC_BASE_URL/auth/v1/callback
+# Apple: native id_token grant only, so CLIENT_ID is the accepted `aud` list
+# (the iOS bundle ID) and no secret is involved. See supabase/docker-compose.yml.
+GOTRUE_EXTERNAL_APPLE_ENABLED=${ENABLE_APPLE_SIGNUP:-true}
+GOTRUE_EXTERNAL_APPLE_CLIENT_ID=${APPLE_CLIENT_IDS:-tech.teamclaw.mobile}
 EOF_GOTRUE
 
 # ---- PostgREST (:3000) -----------------------------------------------------

--- a/deploy/self-host/supabase/docker-compose.yml
+++ b/deploy/self-host/supabase/docker-compose.yml
@@ -146,6 +146,28 @@ services:
       GOTRUE_EXTERNAL_GOOGLE_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: ${SUPABASE_PUBLIC_URL:-https://${SUPABASE_DOMAIN}}/auth/v1/callback
 
+      # Apple sign-in. Unlike Google this is a *native* flow only: iOS gets an
+      # id_token from ASAuthorizationAppleIDProvider and posts it to FC
+      # /v1/auth/signin-idtoken -> /auth/v1/token?grant_type=id_token. Without
+      # these keys GoTrue answers that grant with
+      #   Provider (issuer "https://appleid.apple.com") is not enabled
+      # and every "Sign in with Apple" tap fails after the system sheet has
+      # already succeeded — so it reads as a client bug rather than a config gap.
+      #
+      # CLIENT_ID is a comma-separated list of accepted `aud` values, not a
+      # credential. For native Sign in with Apple the audience is the app's
+      # bundle identifier (apps/ios/project.yml PRODUCT_BUNDLE_IDENTIFIER); a
+      # Services ID would only be needed for the web/redirect flow, which no
+      # client uses. Defaulted here rather than left blank because the bundle ID
+      # is public and constant — the box's .env is not in git, so anything that
+      # has to be typed there by hand is a thing that is missing in practice.
+      #
+      # No SECRET: the id_token grant verifies the token against Apple's public
+      # JWKS, so there is nothing to exchange. The client-secret JWT (which
+      # expires every 6 months) belongs to the authorize/callback flow only.
+      GOTRUE_EXTERNAL_APPLE_ENABLED: ${ENABLE_APPLE_SIGNUP:-true}
+      GOTRUE_EXTERNAL_APPLE_CLIENT_ID: ${APPLE_CLIENT_IDS:-tech.teamclaw.mobile}
+
       # Egress proxy for GoTrue's outbound HTTP. This box sits in mainland China
       # and Google is black-holed from it, while GoTrue does OIDC discovery
       # against accounts.google.com on EVERY authorize request — without a proxy
@@ -161,7 +183,14 @@ services:
       HTTPS_PROXY: ${AUTH_EGRESS_PROXY:-}
       # Keep everything inside the compose network off the proxy. Go already
       # exempts localhost and loopback, but not sibling service names.
-      NO_PROXY: localhost,127.0.0.1,::1,db,kong,rest,realtime,storage,imgproxy,meta,analytics,functions,supavisor,fc,litellm,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+      #
+      # appleid.apple.com is exempted for the opposite reason: it is directly
+      # reachable from mainland China (~0.7s), while the egress proxy above is a
+      # tinyproxy with a destination allowlist built for Google — sending Apple
+      # through it returns tinyproxy's "Filtered" page, which surfaces as a bare
+      # 500 unexpected_failure on the id_token grant. Routing Apple direct also
+      # keeps Sign in with Apple working if that proxy box ever goes away.
+      NO_PROXY: localhost,127.0.0.1,::1,db,kong,rest,realtime,storage,imgproxy,meta,analytics,functions,supavisor,fc,litellm,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,appleid.apple.com
 
       GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL}
       GOTRUE_SMTP_HOST: ${SMTP_HOST}


### PR DESCRIPTION
## 问题

iOS「通过 Apple 登录」在系统弹窗**已经走完之后**才失败：

```
auth.signInWithIdToken: Provider (issuer "https://appleid.apple.com") is not enabled
```

看起来像 iOS 端的 bug，实际全在服务端 —— 而且是两个叠在一起的问题，第一个修好才会露出第二个。

## 根因

**1. GoTrue 从来没配过 Apple provider。**

`deploy/self-host/supabase/docker-compose.yml` 里只有 `GOTRUE_EXTERNAL_GOOGLE_*`。iOS 走的是原生 id_token 链路：

```
AppleSignInHandler → FC /v1/auth/signin-idtoken → GoTrue /auth/v1/token?grant_type=id_token
```

issuer 找不到已启用的 provider，GoTrue 直接拒掉这条 grant。

**2. 开了 provider 之后，撞上出网代理。**

grant 变成裸 500，GoTrue 日志：

```
Get "https://appleid.apple.com/.well-known/openid-configuration": Filtered
```

`AUTH_EGRESS_PROXY` 是当初为 Google 加的 tinyproxy，目标白名单里没有 Apple，返回的是 tinyproxy 的 `Filtered` 页。而 Apple 在这台机器上**本来就直连得通**（实测 ~0.7s），所以把 `appleid.apple.com` 放进 `NO_PROXY` 直连，顺带也不再依赖那台代理机。

## 改动

```yaml
GOTRUE_EXTERNAL_APPLE_ENABLED: ${ENABLE_APPLE_SIGNUP:-true}
GOTRUE_EXTERNAL_APPLE_CLIENT_ID: ${APPLE_CLIENT_IDS:-tech.teamclaw.mobile}
```

- **没有 secret**。对着 GoTrue v2.188.1 源码确认过：`External.Apple.ClientID` 是可接受的 `aud` 列表，id_token grant 拿 Apple 公开 JWKS 验签，那个每 6 个月过期的 client-secret JWT 只属于 web/redirect 流程。
- **两个值都不是机密**（bundle id 是公开常量），所以直接在 compose 里给默认值，而不是留给机器上那份不进 git 的 `.env` —— 需要手工填的东西，实践中就是会缺。
- `.env.example` 里顺带澄清了已有的 better-auth `APPLE_CLIENT_ID`：那是 web 流程的 Services ID，**不是**这里驱动 GoTrue 的变量。

同步改了 `all-in-one/render-config.sh`、两份 `.env*.example`，README 补了一节。

## 验证

已在 `api.teamclaw-dev.ucar.cc` 上用构造的 Apple token 逐段验证（该机器已热修，本 PR 合并后由 git 接管）：

| 阶段 | 响应 |
|---|---|
| 修复前 | `Provider (issuer "https://appleid.apple.com") is not enabled` |
| 开启 provider 后 | 500 — `...openid-configuration: Filtered` |
| 加 `NO_PROXY` 后 | `Bad ID token` / `failed to verify signature` |

最后这个错误正是伪造 token 应有的结果：GoTrue 已经能连到 Apple、拉到 JWKS、走到验签这一步。真机 Apple 登录待复测。

`auth` 容器重启后 healthy。`deploy-env-parity.test.ts` 的 3 个失败在干净 worktree 上同样存在（`FC_SUPABASE_*` / `APP_FEATURES_*`），与本改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)