### PR TITLE
fix(self-host): accept both bundle ids for Apple sign-in

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -133,8 +133,15 @@ APPLE_CLIENT_SECRET=
 # credential — for native Sign in with Apple the audience is the iOS bundle ID.
 # Override only when shipping under a different bundle identifier. There is no
 # secret: the grant verifies against Apple's public JWKS.
+#
+# Both bundle ids are listed because the teamclaw → teamclu rebrand moved the
+# app to com.teamclu.mobile, and a build already on someone's phone still sends
+# tech.teamclaw.mobile as its audience. Apple's user identifier is stable per
+# developer team, so listing both carries those accounts across; replacing the
+# old value instead would lock every not-yet-updated install out of sign-in.
+# Drop tech.teamclaw.mobile once that install base is gone.
 ENABLE_APPLE_SIGNUP=true
-APPLE_CLIENT_IDS=tech.teamclaw.mobile
+APPLE_CLIENT_IDS=tech.teamclaw.mobile,com.teamclu.mobile
 
 # ── Google sign-in ─────────────────────────────────────────────────────
 # Read by BOTH auth backends: GoTrue (supabase/docker-compose.yml maps them

--- a/deploy/self-host/.env.local.example
+++ b/deploy/self-host/.env.local.example
@@ -115,7 +115,7 @@ GOOGLE_CLIENT_SECRET=
 # Apple sign-in — native id_token grant only, no secret. APPLE_CLIENT_IDS is the
 # comma-separated list of accepted `aud` values (the iOS bundle ID).
 ENABLE_APPLE_SIGNUP=true
-APPLE_CLIENT_IDS=tech.teamclaw.mobile
+APPLE_CLIENT_IDS=tech.teamclaw.mobile,com.teamclu.mobile
 SMTP_HOST=supabase-mail
 SMTP_PORT=2500
 SMTP_USER=fake_mail_user

--- a/deploy/self-host/README.md
+++ b/deploy/self-host/README.md
@@ -332,7 +332,7 @@ client_secret**：这条 grant 是拿 Apple 的公开 JWKS 验签的。
 ```bash
 ENABLE_APPLE_SIGNUP=true
 # 逗号分隔的 aud 白名单，就是 iOS 的 bundle id
-APPLE_CLIENT_IDS=tech.teamclaw.mobile
+APPLE_CLIENT_IDS=tech.teamclaw.mobile,com.teamclu.mobile
 ```
 
 没开的现象很有迷惑性：系统弹窗先走完、看着像成功了，最后才报

--- a/deploy/self-host/all-in-one/render-config.sh
+++ b/deploy/self-host/all-in-one/render-config.sh
@@ -95,7 +95,7 @@ GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=$PUBLIC_BASE_URL/auth/v1/callback
 # Apple: native id_token grant only, so CLIENT_ID is the accepted `aud` list
 # (the iOS bundle ID) and no secret is involved. See supabase/docker-compose.yml.
 GOTRUE_EXTERNAL_APPLE_ENABLED=${ENABLE_APPLE_SIGNUP:-true}
-GOTRUE_EXTERNAL_APPLE_CLIENT_ID=${APPLE_CLIENT_IDS:-tech.teamclaw.mobile}
+GOTRUE_EXTERNAL_APPLE_CLIENT_ID=${APPLE_CLIENT_IDS:-tech.teamclaw.mobile,com.teamclu.mobile}
 EOF_GOTRUE
 
 # ---- PostgREST (:3000) -----------------------------------------------------

--- a/deploy/self-host/supabase/docker-compose.yml
+++ b/deploy/self-host/supabase/docker-compose.yml
@@ -166,7 +166,7 @@ services:
       # JWKS, so there is nothing to exchange. The client-secret JWT (which
       # expires every 6 months) belongs to the authorize/callback flow only.
       GOTRUE_EXTERNAL_APPLE_ENABLED: ${ENABLE_APPLE_SIGNUP:-true}
-      GOTRUE_EXTERNAL_APPLE_CLIENT_ID: ${APPLE_CLIENT_IDS:-tech.teamclaw.mobile}
+      GOTRUE_EXTERNAL_APPLE_CLIENT_ID: ${APPLE_CLIENT_IDS:-tech.teamclaw.mobile,com.teamclu.mobile}
 
       # Egress proxy for GoTrue's outbound HTTP. This box sits in mainland China
       # and Google is black-holed from it, while GoTrue does OIDC discovery


### PR DESCRIPTION
#826 landed `APPLE_CLIENT_IDS=tech.teamclaw.mobile` while the rebrand (#827) was in flight. Merging the two left the old bundle id as the only accepted `aud`, and the rebrand has since moved the app to `com.teamclu.mobile`.

```diff
-APPLE_CLIENT_IDS=tech.teamclaw.mobile
+APPLE_CLIENT_IDS=tech.teamclaw.mobile,com.teamclu.mobile
```

**Appending rather than replacing is the whole point.** Apple's user identifier is stable per developer team, so listing both carries existing accounts across the bundle-id change. Swapping the value would lock every not-yet-updated install out of sign-in, with no way back in. The variable is already documented in `.env.example` as a comma-separated list of accepted audiences.

Five sites, all defaults/examples: `.env.example`, `.env.local.example`, `README.md`, `all-in-one/render-config.sh`, `supabase/docker-compose.yml`.

Drop `tech.teamclaw.mobile` once that install base is gone.

⚠️ The **live** value is in the ECS box's `.env` and still has to be updated there by hand — this PR only fixes the checked-in defaults. See `docs/plans/2026-08-09-teamclu-rebrand-cutover.md`.

Note that `self-host-deploy` is currently dispatch-only (safety catch from #827), so merging this does not redeploy anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)