### PR TITLE
ci(ios): let CI mint the match profile for a new bundle id

### DIFF
--- a/.github/workflows/ios-match.yml
+++ b/.github/workflows/ios-match.yml
@@ -1,0 +1,68 @@
+name: iOS Signing (match)
+
+# Manual only, and deliberately so. This is the one workflow that WRITES to the
+# shared match certificates repo and creates provisioning profiles at Apple —
+# never give it a push or schedule trigger.
+#
+# Why it exists: match encrypts different-ai-studio/match-certificates with a
+# passphrase that lives in the MATCH_PASSWORD secret and nowhere else, so
+# generating a profile from a laptop means someone has to know that passphrase
+# and clear Apple 2FA. CI already holds the passphrase, the git credentials, and
+# an App Store Connect API key (which needs no 2FA), so it can do it unattended.
+#
+# Run this once per new bundle id. The teamclaw → teamclu rebrand moved the app
+# to com.teamclu.mobile, which has no profile yet — until this has run, the
+# TestFlight workflow's `match(readonly: true)` finds nothing and the release
+# fails at signing.
+#
+# Prerequisite: the App ID must already exist in the developer portal, with
+# Sign In with Apple and Push Notifications enabled (they mirror
+# apps/ios/AMUXApp/AMUX.entitlements). match does NOT create App IDs — it exits
+# with "Could not find App with App Identifier".
+on:
+  workflow_dispatch:
+    inputs:
+      app_identifier:
+        description: "Bundle id to generate an App Store profile for"
+        required: true
+        default: "com.teamclu.mobile"
+
+concurrency:
+  # Two runs would race pushing to the certificates repo; the loser's commit is
+  # rejected and its generated profile is lost. Queue instead of cancelling —
+  # a cancelled run can leave a profile created at Apple but never stored.
+  group: ios-match
+  cancel-in-progress: false
+
+jobs:
+  match:
+    runs-on: macos-26
+
+    defaults:
+      run:
+        working-directory: apps/ios
+
+    env:
+      TEAM_ID: ${{ secrets.TEAM_ID }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+          working-directory: apps/ios
+
+      # No Xcode select, no xcodegen: match neither builds nor reads the
+      # project, so this run is minutes rather than the full release build.
+      - name: Generate the App Store profile and store it
+        env:
+          APP_IDENTIFIER: ${{ inputs.app_identifier }}
+        run: bundle exec fastlane bootstrap_certs app_identifier:"$APP_IDENTIFIER"

--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -8,6 +8,52 @@ platform :ios do
     match(type: "appstore", readonly: true)
   end
 
+  desc "Create the App Store profile for a bundle id match has never seen, and push it back to the certificates repo"
+  lane :bootstrap_certs do |options|
+    # The only lane that WRITES to the shared certificates repo — everything
+    # else runs match readonly. Invoked exclusively by ios-match.yml, which is
+    # manual-dispatch only.
+    #
+    # It exists because the repo's encryption passphrase lives in the
+    # MATCH_PASSWORD secret and nowhere else, so generating a profile locally
+    # means knowing that passphrase and clearing Apple 2FA. CI has the
+    # passphrase and an ASC API key, so it can do it unattended.
+    setup_ci
+
+    # Duplicated from `beta` rather than extracted: that lane is the live
+    # release path and is only exercised by a real TestFlight upload.
+    key_content = ENV["ASC_KEY_CONTENT"].to_s
+    api_key = app_store_connect_api_key(
+      key_id: ENV["ASC_KEY_ID"],
+      issuer_id: ENV["ASC_ISSUER_ID"],
+      key_content: key_content,
+      is_key_content_base64: !key_content.include?("BEGIN PRIVATE KEY"),
+    )
+
+    # readonly: false, but NOT `force` and never `nuke`. match reuses the
+    # distribution certificate already in the repo and only adds the missing
+    # provisioning profile; it signs a new certificate solely when the repo has
+    # none. Apple caps distribution certificates per team, and revoking one
+    # invalidates every profile built against it.
+    match_options = { type: "appstore", readonly: false, api_key: api_key }
+
+    # Only override the Matchfile when the caller actually named a bundle id —
+    # handing match an empty app_identifier is worse than omitting the key.
+    app_identifier = options[:app_identifier].to_s
+    match_options[:app_identifier] = app_identifier unless app_identifier.empty?
+
+    match(match_options)
+
+    # `beta` looks the profile up by exactly this env var, so print it: a green
+    # run that produced a name `beta` cannot resolve is still a broken release.
+    # Guarded rather than clever — match has already pushed by this point, and
+    # a raise here would report a successful run as a failure.
+    if (resolved = match_options[:app_identifier])
+      UI.success("Profile stored — beta resolves it as " \
+                 "#{ENV["sigh_#{resolved}_appstore_profile-name"].inspect}")
+    end
+  end
+
   desc "Build and upload to TestFlight"
   lane :beta do
     manual_signing = !ENV["IOS_DISTRIBUTION_CERT_P12"].to_s.empty?


### PR DESCRIPTION
## 为什么

改名把 App 移到了 `com.teamclu.mobile`,这个 bundle id 还没有描述文件。TestFlight 流程里的 `match(readonly: true)` 取不到东西,发版会卡在签名。

在本机生成又卡在两件事上:match 加密证书仓库的口令**只存在于 `MATCH_PASSWORD` secret 里**,而且要过 Apple 2FA。CI 手上口令、git 凭据、免 2FA 的 ASC API key 全都有,让它代跑最省事——全程没人需要知道口令。

## 改了什么

**`.github/workflows/ios-match.yml`**(新增)——只有 `workflow_dispatch` 触发器,带一个 `app_identifier` 输入(默认 `com.teamclu.mobile`)。不 select Xcode、不跑 xcodegen:match 既不编译也不读工程。

**`apps/ios/fastlane/Fastfile`** —— 新增 `bootstrap_certs` lane。

## 三个刻意的取舍

**`readonly: false`,但绝不带 `force`、绝不 `nuke`。** match 复用仓库里已有的 `6HMM363B6V` 证书,只补缺失的 profile;只有仓库里一张证书都没有时才会去 Apple 签新的。吊销发布证书会让所有基于它构建的 profile 全部失效,而 Apple 对每个 team 的发布证书数量有上限。

**`concurrency` 排队而非取消。** 两个 run 同时往证书仓库推,输的那个 commit 被拒,但 profile 已经在 Apple 那边建出来了,就成了孤儿。

**没有复用 `beta` 的 API key 代码,抄了一遍。** `beta` 是活的发版路径,只有真实上传 TestFlight 才能验证;为消掉 7 行重复去动它不划算。注释里写明了原因。

lane 结尾会打印 profile name——`beta` 是靠 `ENV["sigh_com.teamclu.mobile_appstore_profile-name"]` 取的(`Fastfile:64`),跑绿了但名字对不上,发版照样挂。这行做了 guard:match 这时已经推完,一个日志语句抛异常把成功的 run 报成失败不值得。

## 验证

- `ruby -c apps/ios/fastlane/Fastfile` → Syntax OK
- YAML 解析确认触发器只有 `workflow_dispatch`
- `bundle exec fastlane lanes` 能列出 `sync_certs` / `bootstrap_certs` / `beta`,说明运行时也加载得动

未实际 dispatch——前置条件还没齐(见下)。

## 合并后要做的

1. 开发者门户 App ID `com.teamclu.mobile` 勾上 Sign In with Apple + Push Notifications(对应 `AMUXApp/AMUX.entitlements` 两个 key)
2. ASC 建 App 记录。match 不创建 App ID,找不到直接报 `Could not find App with App Identifier` 退出
3. 齐了之后去 Actions 手动 dispatch 这个 workflow

⚠️ **别动 `MATCH_PASSWORD` secret。** 它是目前唯一能解开证书仓库的东西——本地钥匙串副本已经没了。仓库历史里那三条 `password lost with archived teamclaw-next` 就是上次踩这个坑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)