### PR TITLE
fix(self-host): unbreak the deploy after the rename, and follow the new hosts

### DIFF
--- a/.github/workflows/daemon-deploy.yml
+++ b/.github/workflows/daemon-deploy.yml
@@ -6,7 +6,7 @@ name: Daemon Deploy
 # First-time bootstrap (once per ECS box):
 #   1. Ensure at least one team + human member exist.
 #   2. SSH to ECS and mint a daemon invite:
-#        cd /opt/teamclu/deploy/self-host && ./amuxd/mint-invite.sh <TEAM_ID>
+#        cd /opt/teamclaw/deploy/self-host && ./amuxd/mint-invite.sh <TEAM_ID>
 #   3. Store the token in GitHub secret AMUXD_JOIN_TOKEN (or upsert into .env).
 #   4. Trigger this workflow. Identity persists in the amuxd_state volume; later
 #      deploys skip the join token even if the secret is removed.
@@ -46,7 +46,7 @@ permissions:
   contents: read
   packages: write
 
-# Shared with self-host-deploy.yml so both never reset /opt/teamclu at once.
+# Shared with self-host-deploy.yml so both never reset /opt/teamclaw at once.
 # cancel-in-progress is false at the ECS gate (deploy job); build may still
 # cancel newer superseding builds via its own group below.
 env:
@@ -156,7 +156,7 @@ jobs:
           envs: AMUXD_IMAGE,DEPLOY_REF,AMUXD_JOIN_TOKEN,OPENCODE_BASE_URL,OPENCODE_API_KEY,OPENCODE_MODEL,OPENCODE_PROVIDER_ID,OPENCODE_PROVIDER_NAME
           script: |
             set -e
-            cd /opt/teamclu
+            cd /opt/teamclaw
 
             echo "=== git pull (${DEPLOY_REF}) ==="
             git config http.lowSpeedLimit 1000

--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -20,7 +20,7 @@ on:
   #     - 'services/fc/**'
   #     - 'services/supabase/migrations/**'
 
-# Shared with daemon-deploy.yml deploy job — both reset /opt/teamclu on the
+# Shared with daemon-deploy.yml deploy job — both reset /opt/teamclaw on the
 # same ECS box. Never cancel mid compose build / up.
 concurrency:
   group: selfhost-ecs
@@ -56,7 +56,7 @@ jobs:
           envs: DEEPSEEK_API_KEY,TRUSTED_EXTERNAL_JWT_SECRET,FC_SUPABASE_URL,FC_SUPABASE_PUBLIC_URL,FC_SUPABASE_ANON_KEY,FC_SUPABASE_SERVICE_ROLE_KEY,BELAYO_TEST_RDS_PRIVATE_HOST,BELAYO_TEST_RDS_PORT,BELAYO_TEST_RDS_USER,BELAYO_TEST_RDS_PASSWORD,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,AUTH_EGRESS_PROXY
           script: |
             set -e
-            cd /opt/teamclu
+            cd /opt/teamclaw
 
             echo "=== git pull ==="
             # This ECS box reaches github.com over https unreliably: a bare fetch
@@ -306,7 +306,7 @@ jobs:
               'until docker compose ps caddy | grep -q "Up\|running"; do sleep 3; done'
 
             echo "=== litellm smoke ==="
-            sh /opt/teamclu/deploy/self-host/smoke/litellm-smoke.sh
+            sh /opt/teamclaw/deploy/self-host/smoke/litellm-smoke.sh
 
             echo "=== e2e verification ==="
             if [ -n "$FC_SUPABASE_URL" ]; then
@@ -319,9 +319,9 @@ jobs:
                 "$FC_SUPABASE_URL/rest/v1/rpc/list_teams_for_picker" >/dev/null
               echo "external Supabase RPC smoke: OK"
             else
-              cd /opt/teamclu/services/fc
+              cd /opt/teamclaw/services/fc
               npm ci --prefer-offline --silent
-              sh /opt/teamclu/deploy/self-host/smoke/run-e2e.sh
+              sh /opt/teamclaw/deploy/self-host/smoke/run-e2e.sh
             fi
 
             echo "=== deploy complete ==="

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -33,6 +33,18 @@ CADDY_SITE_SCHEME=
 DOCKER_SOCKET_LOCATION=/var/run/docker.sock
 
 # ── public domains (used by Caddy + client-facing URLs) ────────────────
+# Single-valued. Every client-facing URL is built by interpolating these
+# (SITE_URL, API_EXTERNAL_URL, SUPABASE_PUBLIC_URL, MQTT_BROKER_URL,
+# GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI), so a list here produces malformed URLs.
+#
+# Renaming one is a hard cutover, not a redirect: Caddy stops answering for the
+# old name, and any client with it compiled in loses the backend for good — the
+# iOS app bakes its host into services.default.json, which only a new App Store
+# build can change. Change these only alongside a client release.
+#
+# SUPABASE_PUBLIC_URL / API_EXTERNAL_URL / SITE_URL / MQTT_PUBLIC_BROKER_URL are
+# stored separately further down and do NOT follow a change here — update them
+# in the same edit or GoTrue keeps redirecting to the old host.
 FC_DOMAIN=api.example.com
 SUPABASE_DOMAIN=supabase.example.com
 MQTT_DOMAIN=mqtt.example.com
@@ -86,7 +98,7 @@ ENDPOINT=https://oss-cn-shenzhen.aliyuncs.com
 CODEUP_ORG_ID=
 CODEUP_PAT=
 CODEUP_BOT_USERNAME=teamclu
-# Same RDS instance as the control plane, DIFFERENT database (teamclu_apps).
+# Same RDS instance as the control plane, DIFFERENT database (teamclaw_apps).
 APPS_DB_ADMIN_URL=
 # Account-scoped FC 3.0 data-plane host — NOT the OSS ENDPOINT above. Either
 # set APPS_FC_ENDPOINT directly, or ALIYUN_ACCOUNT_ID to have it composed as

--- a/deploy/self-host/README.md
+++ b/deploy/self-host/README.md
@@ -829,7 +829,7 @@ All variables live in `.env` (copied from `.env.example`).
 | `REGION` | no | OSS region (default: `cn-shenzhen`) |
 | `ENDPOINT` | no | OSS endpoint URL |
 | `CODEUP_ORG_ID` / `CODEUP_PAT` / `CODEUP_BOT_USERNAME` | for apps | Managed-git org + PAT used to create each app's repo. Missing → `POST /v1/apps` fails at the repo step |
-| `APPS_DB_ADMIN_URL` | for apps | Admin connection to the shared `teamclu_apps` database (same RDS instance, different database). Missing → app deploy returns 503 `deploy_unavailable` |
+| `APPS_DB_ADMIN_URL` | for apps | Admin connection to the shared `teamclaw_apps` database (same RDS instance, different database). Missing → app deploy returns 503 `deploy_unavailable` |
 | `APPS_FC_ENDPOINT` / `ALIYUN_ACCOUNT_ID` | for apps | Account-scoped FC 3.0 data-plane host (`<accountId>.<region>.fc.aliyuncs.com`). Not the OSS `ENDPOINT`; set one of the two |
 | `LITELLM_URL` | no | 留空即用内置网关（compose 默认 `http://litellm:4000`）。仅在改用**外部**网关时才设置 |
 | `LITELLM_MASTER_KEY` | auto | `gen-secrets.sh` 生成（`sk-` 前缀）；LiteLLM 管理凭证,同时交给 FC |

--- a/deploy/self-host/docker-compose.podman.yml
+++ b/deploy/self-host/docker-compose.podman.yml
@@ -11,7 +11,9 @@
 #   podman-compose --in-pod false -f docker-compose.yml -f docker-compose.podman.yml up -d
 # or: ./bootstrap/up.sh
 
-name: teamclu-self-host
+# Must stay byte-identical to docker-compose.yml's `name:` — see the comment
+# there for why the rebrand does not touch it.
+name: teamclaw-self-host
 
 services:
   vector:

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -1,4 +1,10 @@
-name: teamclu-self-host
+# NOT renamed with the teamclaw → teamclu rebrand, deliberately. The compose
+# project name prefixes every container and every volume on the one live ECS
+# box (teamclaw-self-host_db-config, …). Changing it does not rename anything:
+# compose would treat this as a brand-new project and bring up 19 containers on
+# fresh empty volumes, stranding the database, Caddy's issued certificates and
+# EMQX's state in an orphaned project.
+name: teamclaw-self-host
 
 include:
   - path: ./supabase/docker-compose.yml
@@ -42,6 +48,18 @@ services:
       # EMQX's native env override (Compose interpolates ${EMQX_JWT_SECRET} at
       # parse time) so the authenticator is created with the real key.
       EMQX_AUTHENTICATION__1__SECRET: "${EMQX_JWT_SECRET}"
+      # The 8883 listener reads Caddy's ACME storage, where certificates are
+      # filed under the hostname they were issued for. Derive the path from
+      # MQTT_DOMAIN rather than hardcoding it in emqx.conf, so renaming the host
+      # moves the listener to the new certificate in the same step instead of
+      # leaving it pointed at a file that no longer exists — EMQX fails the
+      # listener outright when the certfile is missing, taking MQTTS down.
+      #
+      # Uses the bare MQTT_DOMAIN (never the legacy-joined form above): this is
+      # a filesystem path, and Caddy files a multi-host site under its first
+      # hostname only.
+      EMQX_LISTENERS__SSL__DEFAULT__SSL_OPTIONS__CERTFILE: "/caddy-certs/caddy/certificates/acme-v02.api.letsencrypt.org-directory/${MQTT_DOMAIN}/${MQTT_DOMAIN}.crt"
+      EMQX_LISTENERS__SSL__DEFAULT__SSL_OPTIONS__KEYFILE: "/caddy-certs/caddy/certificates/acme-v02.api.letsencrypt.org-directory/${MQTT_DOMAIN}/${MQTT_DOMAIN}.key"
     volumes:
       - ./emqx/emqx.conf:/opt/emqx/etc/emqx.conf:ro
       - emqx_data:/opt/emqx/data
@@ -114,7 +132,7 @@ services:
           echo "litellm-init: created _litellm"
         fi
 
-  # Creates the teamclu_apps database — the shared home for per-app Postgres
+  # Creates the teamclaw_apps database — the shared home for per-app Postgres
   # schemas (one schema + one scoped login role per "数据操作" app), kept apart
   # from the control-plane database. Same one-shot pattern and reasoning as
   # litellm-init above: an already-deployed stack would never run a
@@ -141,11 +159,14 @@ services:
       - -c
       - |
         set -e
-        if [ "$$(psql -tAc "SELECT 1 FROM pg_database WHERE datname='teamclu_apps'")" = "1" ]; then
-          echo "apps-db-init: teamclu_apps already exists"
+        # Name not renamed with the rebrand: the database already exists on the
+        # live box as teamclaw_apps. Renaming it here would leave that one in
+        # place and create a second, empty one alongside it.
+        if [ "$$(psql -tAc "SELECT 1 FROM pg_database WHERE datname='teamclaw_apps'")" = "1" ]; then
+          echo "apps-db-init: teamclaw_apps already exists"
         else
-          psql -c 'CREATE DATABASE "teamclu_apps"'
-          echo "apps-db-init: created teamclu_apps"
+          psql -c 'CREATE DATABASE "teamclaw_apps"'
+          echo "apps-db-init: created teamclaw_apps"
         fi
 
   # AI gateway. FC provisions per-team budgets and virtual keys against the admin
@@ -271,7 +292,7 @@ services:
       CODEUP_ORG_ID: "${CODEUP_ORG_ID:-}"
       CODEUP_PAT: "${CODEUP_PAT:-}"
       CODEUP_BOT_USERNAME: "${CODEUP_BOT_USERNAME:-teamclu}"
-      # Admin connection to the shared per-app database (teamclu_apps) — same
+      # Admin connection to the shared per-app database (teamclaw_apps) — same
       # RDS instance as the control plane, different database. Blank disables
       # app deploys (they return 503 rather than half-provisioning).
       APPS_DB_ADMIN_URL: "${APPS_DB_ADMIN_URL:-}"
@@ -364,6 +385,9 @@ services:
       - "${CADDY_HTTP_PORT:-80}:80"
       - "${CADDY_HTTPS_PORT:-443}:443"
     environment:
+      # One hostname per site. Caddy only requests a certificate for names that
+      # appear in its config, so these have to be the names clients actually
+      # dial — pointing DNS at the box is not enough on its own.
       FC_DOMAIN: "${FC_DOMAIN}"
       SUPABASE_DOMAIN: "${SUPABASE_DOMAIN}"
       MQTT_DOMAIN: "${MQTT_DOMAIN}"

--- a/deploy/self-host/emqx/emqx.conf
+++ b/deploy/self-host/emqx/emqx.conf
@@ -44,6 +44,22 @@ listeners.ssl.default {
   bind = "0.0.0.0:8883"
   ssl_options {
     # `caddy_data` is mounted read-only at /caddy-certs (see docker-compose.yml).
+    #
+    # Both paths are OVERRIDDEN at runtime by
+    # EMQX_LISTENERS__SSL__DEFAULT__SSL_OPTIONS__{CERTFILE,KEYFILE} in
+    # docker-compose.yml, which builds them from ${MQTT_DOMAIN} so a renamed
+    # host moves the listener to the new certificate in the same step. The
+    # values here are only the fallback for running EMQX with this file alone.
+    #
+    # KNOWN BROKEN as of 2026-08-09, and not caused by the path: Caddy stores
+    # certificates 0700 root:root, while this container runs as uid 1000, so
+    # EMQX cannot read either file. The listener binds and then drops every
+    # connection at handshake with no peer certificate. Verified by reading the
+    # files as uid 1000 — the pre-rename path failed identically, so this is not
+    # a regression from the rename. Nothing depends on 8883 today: clients get
+    # mqtt://…:1883 from /v1/config/bootstrap and iOS ships mqttUseTls false,
+    # which is why it went unnoticed. Fixing it needs the certificate copied
+    # somewhere readable, not a path change.
     certfile = "/caddy-certs/caddy/certificates/acme-v02.api.letsencrypt.org-directory/mqtt.teamclu-dev.ucar.cc/mqtt.teamclu-dev.ucar.cc.crt"
     keyfile = "/caddy-certs/caddy/certificates/acme-v02.api.letsencrypt.org-directory/mqtt.teamclu-dev.ucar.cc/mqtt.teamclu-dev.ucar.cc.key"
   }

--- a/deploy/self-host/smoke/run-e2e.sh
+++ b/deploy/self-host/smoke/run-e2e.sh
@@ -9,12 +9,12 @@ set -eu
 
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 
-FC_IP=$(docker inspect teamclu-self-host-fc-1 \
+FC_IP=$(docker inspect teamclaw-self-host-fc-1 \
   --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 2>/dev/null || echo "")
 KONG_IP=$(docker inspect supabase-kong \
   --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 2>/dev/null || echo "")
 
-[ -n "$FC_IP" ]   || { echo "FAIL: teamclu-self-host-fc-1 not running"; exit 1; }
+[ -n "$FC_IP" ]   || { echo "FAIL: teamclaw-self-host-fc-1 not running"; exit 1; }
 [ -n "$KONG_IP" ] || { echo "FAIL: supabase-kong not running"; exit 1; }
 
 # ── Wait for PostgREST's schema cache ──────────────────────────────────────

--- a/docs/plans/2026-08-09-teamclu-rebrand-cutover.md
+++ b/docs/plans/2026-08-09-teamclu-rebrand-cutover.md
@@ -12,6 +12,16 @@
 `~/.teamclaw` → `~/.teamclu` 有迁移兜底，DNS 和 GitHub 没有。旧名字一停，那批用户就永久断更、
 永久连不上后端，且没有任何补救手段。
 
+### 例外：`*.teamclaw-dev.ucar.cc` 已经决定不保留（2026-08-09）
+
+五条 `*.teamclaw-dev.ucar.cc` 记录在 DNS 切换时被**删除**而不是保留为别名，且经确认这是有意的
+决定，不是失误。后果照上面那条规则：**所有存量装机——桌面端、iOS、betly、copilot361——从此
+连不上后端，只能引导重装新版本**，没有服务端补救手段。
+
+这条例外只适用于 `-dev` 那五个主机名。GitHub 仓库重定向、`teamclaw.ucar.cc`（betly 更新清单）、
+`teamclaw-api.ucar.cc`（belayo 后端）**仍然适用原规则**——它们服务的是自动更新链路，断了连
+"重装新版本"这条路都没有。
+
 ## 合并前必须就位
 
 | 项 | 现状 | 要做什么 |
@@ -33,6 +43,27 @@
 | `supabase` / `studio` / `emqx.teamclaw-dev.ucar.cc` | `…teamclu-dev…` | 网关 / 控制台 |
 | `teamclaw.ucar.cc` | `teamclu.ucar.cc` | **betly 的更新清单地址**（`release-oss.yml` 的 `CDN_BASE_DEFAULT`）。新主机不存在就发布 betly，等于把 betly 的 `latest.json` 指向 404 |
 | `teamclaw-api.ucar.cc` | `teamclu-api.ucar.cc` | belayo 后端，betly 的 `cloudApiUrl` |
+
+#### 已完成（2026-08-09）
+
+五个 `-dev` 新主机名已解析到 `47.112.210.217`，箱子 `.env` 已切、Caddy 已签发全部五张
+Let's Encrypt 证书，`https://api.teamclu-dev.ucar.cc/healthz` 返回 `{"ok":true}`。
+
+要点：**Caddy 只给自己配置里出现的名字签证书**，DNS 指过来它不会自动去签——`.env` 不改，
+新主机名就是 TLS 握手直接 `tlsv1 alert internal error`。
+
+`.env` 里要改的不止 `*_DOMAIN` 五个。`SUPABASE_PUBLIC_URL` / `API_EXTERNAL_URL` /
+`SITE_URL` / `MQTT_PUBLIC_BROKER_URL` 是**单独存的值**，不会跟着 `*_DOMAIN` 走；漏了它们，
+GoTrue 会继续往旧主机发重定向。备份在箱子上的 `.env.bak.pre-teamclu-dns`。
+
+#### 遗留：EMQX 8883 的 MQTTS 是坏的（先于这次改名）
+
+Caddy 把证书存成 `0700 root:root`，而 emqx 容器跑在 uid 1000 下，读不到——listener 能 bind，
+但每个连接都在握手阶段被丢弃、不发证书。用 uid 1000 读**改名前**那份证书同样是
+`Permission denied`，所以不是这次切换造成的。
+
+目前没有使用者：`/v1/config/bootstrap` 下发的是 `mqtt://…:1883`，iOS 也是
+`mqttUseTls: false`，所以一直没人察觉。要修得把证书复制到 emqx 读得到的地方，改路径没用。
 
 ### 自建机（ECS `47.112.210.217`）的 `.env`
 
@@ -111,6 +142,21 @@ scheme，但操作系统层面的 URL 路由不认——这个靠代码补不回
 
 若要避免这一点，需要把 `app.scheme` 扩展成支持数组（让 copilot 同时注册
 `copilot361` 和 `teamclaw`）。目前没有做。
+
+## 箱子上已经存在的东西（改名扫到了，已改回）
+
+这些不是品牌字符串，是**那台 ECS 上已经存在什么**。改名把它们一起改了，任何一条都足以让
+一次部署看起来像把环境清空了：
+
+| 位置 | 恢复成 | 改了会怎样 |
+|---|---|---|
+| `docker-compose.yml` / `docker-compose.podman.yml` 的 `name:` | `teamclaw-self-host` | 容器和卷全都带这个前缀。改名不会重命名任何东西——compose 当成全新项目，19 个容器起在全新空卷上，数据库、Caddy 已签的证书、EMQX 状态全部搁浅在孤儿项目里 |
+| `smoke/run-e2e.sh` 的容器名 | `teamclaw-self-host-fc-1` | 跟着 `name:` 走，必须一致 |
+| `apps-db-init` 的库名 | `teamclaw_apps` | 库已经在线上；改名只会在旁边再建一个空的 |
+| 两个 deploy workflow 的 `cd` 路径 | `/opt/teamclaw` | 箱子上就叫这个，`/opt/teamclu` 不存在，部署第一步就失败 |
+| `emqx.conf` 的 certfile/keyfile | 见上，改由 `${MQTT_DOMAIN}` 派生 | Caddy 手上只有旧名字的证书，路径写成新名字 = 8883 listener 起不来，MQTTS 全断 |
+
+想真的改成 `teamclu-*`，得先在箱子上迁移卷和数据库、再改这里，不能只改仓库。
 
 ## 刻意没有改名的东西
 

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -56,7 +56,7 @@ resources:
         CODEUP_ORG_ID: ${env('CODEUP_ORG_ID', '')}
         CODEUP_PAT: ${env('CODEUP_PAT', '')}
         CODEUP_BOT_USERNAME: ${env('CODEUP_BOT_USERNAME', 'teamclu')}
-        # Admin connection to the shared per-app Postgres DB (teamclu_apps),
+        # Admin connection to the shared per-app Postgres DB (teamclaw_apps),
         # same RDS instance as the control plane but a DIFFERENT database. Used
         # only by apps provisioning (CREATE SCHEMA / CREATE ROLE). Never sent
         # to clients.


### PR DESCRIPTION
## 1. 改名扫到了"箱子上已经存在什么"

这些不是品牌字符串,是那台 ECS 上的既有事实。**任何一条不改回,下次部署都会像把环境清空。**

| 位置 | 改回 | 不改的后果 |
|---|---|---|
| compose `name:` | `teamclaw-self-host` | 所有容器/卷都是这前缀。改名不会重命名任何东西——compose 当成新项目,19 个容器起在**全新空卷**上,数据库、Caddy 已签证书、EMQX 状态全部搁浅在孤儿项目里 |
| `apps-db-init` 库名 | `teamclaw_apps` | 库已在线上(查过 `pg_database`),改名只会在旁边再建个空的 |
| `run-e2e.sh` 容器名 | `teamclaw-self-host-fc-1` | 跟 `name:` 走,必须一致 |
| 两个 workflow 的 `cd` | `/opt/teamclaw` | 箱子上只有这个,`/opt/teamclu` 不存在,部署第一步就失败 |

每处都加了注释说明为什么不能动。真想改成 `teamclu-*`,得先在箱子上迁移卷和数据库,不能只改仓库。

## 2. EMQX 证书路径改为派生

`emqx.conf` 之前硬编码主机名,改名后指向一个不存在的文件。现在由 compose 的
`EMQX_LISTENERS__SSL__DEFAULT__SSL_OPTIONS__{CERTFILE,KEYFILE}` 从 `${MQTT_DOMAIN}` 派生,
换主机名时 listener 跟着走到新证书。

### 顺带查出:8883 的 MQTTS 本来就是坏的

Caddy 把证书存成 `0700 root:root`,而容器跑在 uid 1000 下,新旧证书**都读不到**。listener 能 bind,
但每个连接都在握手阶段被丢弃、不发证书。

用 uid 1000 读**改名前**那份证书同样是 `Permission denied`,所以确认不是这次改动造成的。
没有使用者所以一直没暴露:`/v1/config/bootstrap` 下发 `mqtt://…:1883`,iOS 也是 `mqttUseTls: false`。
结论写进了 `emqx.conf`。修它要把证书复制到 emqx 读得到的地方,改路径没用——本 PR 不含修复。

## 3. 文档

`.env.example` 补了两条容易踩的:改域名是**硬切换不是重定向**;`SUPABASE_PUBLIC_URL` /
`API_EXTERNAL_URL` / `SITE_URL` / `MQTT_PUBLIC_BROKER_URL` 是单独存的值,**不跟着 `*_DOMAIN` 走**,
漏改 GoTrue 会继续往旧主机发重定向。

cutover 文档记下:五条 `*.teamclaw-dev.ucar.cc` 被**删除**而非保留为别名,这是有意决定。
后果是所有存量装机(桌面端 / iOS / betly / copilot361)从此连不上后端,只能引导重装,无服务端补救。
**该例外仅限这五个** —— GitHub 仓库重定向、`teamclaw.ucar.cc`(betly 更新清单)、
`teamclaw-api.ucar.cc`(belayo 后端)仍适用"永久保留"原规则:它们承载自动更新链路,断了连
"重装新版本"这条路都没有。

## 线上状态

本 PR 合并前,线上已按此手工切换完毕:

- 箱子 `.env` 九个键已切到 `teamclu-dev`(备份 `.env.bak.pre-teamclu-dns`)
- Caddy 重启后 30 秒签发全部五张 Let's Encrypt 证书
- `https://api.teamclu-dev.ucar.cc/healthz` → `{"ok":true}`,supabase/studio/emqx/mqtt 均握手正常

所以这个 PR 是**把仓库对齐到已经生效的线上状态**,不是引入新变更。

## 验证

- `docker compose config` 用箱子上真实 `.env`:exit 0,渲染出 `name: teamclaw-self-host`,EMQX 指向 `${MQTT_DOMAIN}` 的证书
- compose YAML 解析通过
- 五个新主机名的 TLS 与 HTTP 逐个实测

## 合并后

push 触发器仍是注释掉的状态(`37e16aa1` 那个 safety catch)。恢复触发器本身不会触发部署,
需要手动 `workflow_dispatch` 跑一次 self-host-deploy 验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)