### PR TITLE
fix(self-host): finish reverting the compose project prefix

### DIFF
--- a/deploy/self-host/README.md
+++ b/deploy/self-host/README.md
@@ -95,7 +95,7 @@ Podman 用户 **`不要`** 直接跑裸 `docker compose up -d`，容易遇到：
 **Podman Machine 内存（MQTT 必需）：** 默认 `2GiB` 不够跑完整 Supabase + EMQX。桌面端 MQTT 报 `connection closed by peer` 时，先查 EMQX 是否被 OOM 杀：
 
 ```bash
-podman inspect teamclu-self-host_emqx_1 --format '{{.State.OOMKilled}}'   # true = 内存不足
+podman inspect teamclaw-self-host_emqx_1 --format '{{.State.OOMKilled}}'   # true = 内存不足
 podman machine stop
 podman machine set --memory 8192 --cpus 4
 podman machine start
@@ -182,7 +182,7 @@ cd ../../services/fc && sh ../../deploy/self-host/smoke/run-e2e.sh
 ```bash
 cd deploy/self-host
 docker compose restart fc
-# Podman：podman restart teamclu-self-host_fc_1
+# Podman：podman restart teamclaw-self-host_fc_1
 ```
 
 #### B. Desktop（Tauri）——推荐直连 FC
@@ -419,8 +419,8 @@ cd deploy/self-host
 若修改过 `CADDY_TLS_MODE`，还需清 Caddy 持久化配置（否则会沿用旧 autosave）：
 
 ```bash
-docker compose stop caddy   # 或 podman stop teamclu-self-host_caddy_1
-docker volume rm teamclu-self-host_caddy_config   # 保留 caddy_data 可留证书
+docker compose stop caddy   # 或 podman stop teamclaw-self-host_caddy_1
+docker volume rm teamclaw-self-host_caddy_config   # 保留 caddy_data 可留证书
 ./bootstrap/gen-secrets.sh
 ./bootstrap/up.sh
 ```
@@ -457,7 +457,7 @@ docker volume rm teamclu-self-host_caddy_config   # 保留 caddy_data 可留证�
 | Docker Desktop | Caddy `80`/`443`；EMQX `1883` |
 | Podman rootless | Caddy `8080`→80、`8443`→443；FC `9000`；EMQX `1883` |
 
-其余服务仅在 `teamclu-self-host_default` 内部网络通信。
+其余服务仅在 `teamclaw-self-host_default` 内部网络通信。
 
 ---
 
@@ -632,7 +632,7 @@ To re-join a different team, remove the persisted identity first:
 
 ```bash
 docker compose --profile daemon down
-docker volume rm teamclu-self-host_amuxd_state
+docker volume rm teamclaw-self-host_amuxd_state
 # then set a fresh AMUXD_JOIN_TOKEN and bring it back up
 ```
 
@@ -641,7 +641,7 @@ docker volume rm teamclu-self-host_amuxd_state
 ## TLS modes
 
 `CADDY_TLS_MODE` 控制 Caddy 行为。修改后 **必须** 重新跑 `./bootstrap/gen-secrets.sh`，
-必要时清 `teamclu-self-host_caddy_config` volume，再 `./bootstrap/up.sh`。
+必要时清 `teamclaw-self-host_caddy_config` volume，再 `./bootstrap/up.sh`。
 
 | Mode | Value | Effect |
 |---|---|---|
@@ -787,9 +787,9 @@ rm -f .env .env.bak
 | `supabase-auth` / `supabase-analytics` password failed | `down -v` **不会**删 bind mount `supabase/volumes/db/data`，旧 Postgres 密码仍在 | `./bootstrap/reset-data.sh`（脚本会 `rm -rf supabase/volumes/db/data`） |
 | `supabase-db` password 错误 | 旧数据卷用了空密码初始化 | `docker compose down -v` 后重来（**清数据**） |
 | migrate / fc 一直 Created | 上游 healthcheck 未过 | `podman logs supabase-db`；确认 `POSTGRES_PASSWORD` |
-| 桌面 MQTT **Disconnected** / `connection closed by peer` | EMQX 被 OOM 杀（Podman VM 默认 2GiB） | `podman inspect teamclu-self-host_emqx_1 --format '{{.State.OOMKilled}}'`；`podman machine set --memory 8192` 后重建 emqx（见 §运行时 Podman 内存） |
+| 桌面 MQTT **Disconnected** / `connection closed by peer` | EMQX 被 OOM 杀（Podman VM 默认 2GiB） | `podman inspect teamclaw-self-host_emqx_1 --format '{{.State.OOMKilled}}'`；`podman machine set --memory 8192` 后重建 emqx（见 §运行时 Podman 内存） |
 | Team Shared Enable → `PGRST301` / `wrong key type` | 前端连 `127.0.0.1:9000` 但 Rust 仍烘焙 `build.config.json` 的远程 API | 确认 `packages/app/.env.local` 含 `VITE_CLOUD_API_URL=http://127.0.0.1:9000`；**退出** 桌面后重跑 `pnpm tauri:dev`；Settings → General 里 Server 应显示 `127.0.0.1:9000` |
-| `emqx` 重启次数极高 / health `starting` | 同上，或 healthcheck 在启动期失败 | 增大 Podman 内存；`podman logs teamclu-self-host_emqx_1` 查 `high_system_memory_usage` |
+| `emqx` 重启次数极高 / health `starting` | 同上，或 healthcheck 在启动期失败 | 增大 Podman 内存；`podman logs teamclaw-self-host_emqx_1` 查 `high_system_memory_usage` |
 
 ---
 

--- a/deploy/self-host/amuxd/bootstrap-presence-only.sh
+++ b/deploy/self-host/amuxd/bootstrap-presence-only.sh
@@ -16,7 +16,7 @@ cd "$ROOT"
 [ -f .env ] || { echo "bootstrap: $ROOT/.env not found"; exit 1; }
 
 TEAM_ID="${1:-${TEAM_ID:-}}"
-STATE_VOLUME="${COMPOSE_PROJECT_NAME:-teamclu-self-host}_amuxd_state"
+STATE_VOLUME="${COMPOSE_PROJECT_NAME:-teamclaw-self-host}_amuxd_state"
 
 upsert_env() {
   local key="$1" value="$2"

--- a/deploy/self-host/bootstrap/check.sh
+++ b/deploy/self-host/bootstrap/check.sh
@@ -123,7 +123,7 @@ check_running_healthy() {
 }
 
 check_migrate() {
-  local name="teamclu-self-host_migrate_1"
+  local name="teamclaw-self-host_migrate_1"
   if ! container_exists "$name"; then
     fail "migrate — container missing ($name)"
     return
@@ -199,9 +199,9 @@ check_running_healthy supabase-auth "auth (gotrue)"
 check_running_healthy supabase-kong "kong (supabase API gateway)"
 check_running_healthy supabase-storage "storage"
 check_migrate
-check_running_healthy teamclu-self-host_emqx_1 "emqx (MQTT)"
-check_running_healthy teamclu-self-host_fc_1 "fc (Cloud API)"
-check_running_healthy teamclu-self-host_caddy_1 "caddy (reverse proxy)"
+check_running_healthy teamclaw-self-host_emqx_1 "emqx (MQTT)"
+check_running_healthy teamclaw-self-host_fc_1 "fc (Cloud API)"
+check_running_healthy teamclaw-self-host_caddy_1 "caddy (reverse proxy)"
 
 echo ""
 echo "[HTTP probes]"
@@ -211,18 +211,18 @@ CADDY_URL="http://127.0.0.1:${CADDY_HTTP_PORT}/healthz"
 if curl_health "$FC_URL" | grep -q '"ok"[[:space:]]*:[[:space:]]*true'; then
   ok "FC direct — $FC_URL → {\"ok\":true}"
 else
-  st="$(container_status teamclu-self-host_fc_1 2>/dev/null || echo missing)"
+  st="$(container_status teamclaw-self-host_fc_1 2>/dev/null || echo missing)"
   if [ "$st" = "created" ] || [ "$st" = "missing" ]; then
     fail "FC direct — $FC_URL unreachable (fc not running)"
   else
-    fail "FC direct — $FC_URL failed — run: $RUNTIME logs teamclu-self-host_fc_1 --tail 40"
+    fail "FC direct — $FC_URL failed — run: $RUNTIME logs teamclaw-self-host_fc_1 --tail 40"
   fi
 fi
 
 if curl_health "$CADDY_URL" -H "Host: ${FC_DOMAIN}" | grep -q '"ok"[[:space:]]*:[[:space:]]*true'; then
   ok "Caddy proxy — $CADDY_URL (Host: $FC_DOMAIN) → {\"ok\":true}"
 else
-  cst="$(container_status teamclu-self-host_caddy_1 2>/dev/null || echo missing)"
+  cst="$(container_status teamclaw-self-host_caddy_1 2>/dev/null || echo missing)"
   if [ "$cst" = "created" ] || [ "$cst" = "missing" ]; then
     warn "Caddy proxy — skipped (caddy not running); Desktop can use FC direct :9000"
   else
@@ -240,7 +240,7 @@ if [ "$TRY_START" = true ] && [ "$FAIL" -gt 0 ]; then
   echo ""
   echo "[--try-start] recreating fc + caddy (--no-deps)..."
   for svc in fc caddy; do
-    "$RUNTIME" rm -f "teamclu-self-host_${svc}_1" 2>/dev/null || true
+    "$RUNTIME" rm -f "teamclaw-self-host_${svc}_1" 2>/dev/null || true
     "${RUN[@]}" up -d --no-deps "$svc" 2>&1 || true
   done
   sleep 2
@@ -280,7 +280,7 @@ for issue in "${ISSUES[@]}"; do
       echo "  • Caddy stuck Created: ${RUN[*]} up -d --no-deps caddy"
       ;;
     *migrate*Created*)
-      echo "  • Migrate not run: ${RUN[*]} up -d migrate && $RUNTIME logs -f teamclu-self-host_migrate_1"
+      echo "  • Migrate not run: ${RUN[*]} up -d migrate && $RUNTIME logs -f teamclaw-self-host_migrate_1"
       ;;
   esac
 done

--- a/deploy/self-host/bootstrap/reset-data.sh
+++ b/deploy/self-host/bootstrap/reset-data.sh
@@ -43,8 +43,8 @@ read -r -p "Type 'yes' to continue: " confirm
 echo "==> compose down (release bind mounts)"
 "${RUN[@]}" down --remove-orphans 2>/dev/null || true
 if [ "$RUNTIME" = podman ]; then
-  podman pod rm -f pod_teamclu-self-host 2>/dev/null || true
-  podman rm -f $(podman ps -aq --filter label=com.docker.compose.project=teamclu-self-host) 2>/dev/null || true
+  podman pod rm -f pod_teamclaw-self-host 2>/dev/null || true
+  podman rm -f $(podman ps -aq --filter label=com.docker.compose.project=teamclaw-self-host) 2>/dev/null || true
 fi
 
 wipe_bind_mounts
@@ -52,8 +52,8 @@ wipe_bind_mounts
 echo "==> compose down -v (named volumes)"
 "${RUN[@]}" down -v --remove-orphans 2>/dev/null || true
 if [ "$RUNTIME" = podman ]; then
-  podman pod rm -f pod_teamclu-self-host 2>/dev/null || true
-  podman rm -f $(podman ps -aq --filter label=com.docker.compose.project=teamclu-self-host) 2>/dev/null || true
+  podman pod rm -f pod_teamclaw-self-host 2>/dev/null || true
+  podman rm -f $(podman ps -aq --filter label=com.docker.compose.project=teamclaw-self-host) 2>/dev/null || true
 fi
 
 echo "==> gen-secrets + up"

--- a/deploy/self-host/bootstrap/up-app.sh
+++ b/deploy/self-host/bootstrap/up-app.sh
@@ -22,7 +22,7 @@ else
   RUN=( docker compose "${COMPOSE[@]}" )
 fi
 
-MIGRATE=teamclu-self-host_migrate_1
+MIGRATE=teamclaw-self-host_migrate_1
 status="$("$RUNTIME" inspect "$MIGRATE" --format '{{.State.Status}}' 2>/dev/null || echo missing)"
 code="$("$RUNTIME" inspect "$MIGRATE" --format '{{.State.ExitCode}}' 2>/dev/null || echo "?")"
 if [ "$status" != "exited" ] || [ "$code" != "0" ]; then
@@ -32,7 +32,7 @@ fi
 
 for svc in fc caddy; do
   echo "up-app: recreate $svc (--no-deps)"
-  "$RUNTIME" rm -f "teamclu-self-host_${svc}_1" 2>/dev/null || true
+  "$RUNTIME" rm -f "teamclaw-self-host_${svc}_1" 2>/dev/null || true
   "${RUN[@]}" up -d --no-deps --build "$svc"
 done
 

--- a/deploy/self-host/bootstrap/up.sh
+++ b/deploy/self-host/bootstrap/up.sh
@@ -36,15 +36,15 @@ else
 fi
 
 fc_container() {
-  echo "teamclu-self-host_fc_1"
+  echo "teamclaw-self-host_fc_1"
 }
 
 caddy_container() {
-  echo "teamclu-self-host_caddy_1"
+  echo "teamclaw-self-host_caddy_1"
 }
 
 migrate_container() {
-  echo "teamclu-self-host_migrate_1"
+  echo "teamclaw-self-host_migrate_1"
 }
 
 wait_fc() {
@@ -134,7 +134,7 @@ compose_services_except() {
 }
 
 recreate_no_deps() { # $1=service name
-  local svc="$1" cname="teamclu-self-host_${svc}_1"
+  local svc="$1" cname="teamclaw-self-host_${svc}_1"
   echo "up: recreate $svc (--no-deps, clears stale podman dependency edges)"
   "$RUNTIME" rm -f "$cname" 2>/dev/null || true
   "${RUN[@]}" up -d --no-deps --build "$svc"
@@ -143,8 +143,8 @@ recreate_no_deps() { # $1=service name
 if use_podman_compose; then
   echo "==> compose down (clean stale podman dependency graph)"
   "${RUN[@]}" down --remove-orphans 2>/dev/null || true
-  podman pod rm -f pod_teamclu-self-host 2>/dev/null || true
-  podman rm -f $(podman ps -aq --filter label=com.docker.compose.project=teamclu-self-host) 2>/dev/null || true
+  podman pod rm -f pod_teamclaw-self-host 2>/dev/null || true
+  podman rm -f $(podman ps -aq --filter label=com.docker.compose.project=teamclaw-self-host) 2>/dev/null || true
 
   echo "==> compose up (base stack, excluding fc/caddy/litellm — may take several minutes on first boot)"
   # litellm is held back until litellm-init has created the _litellm database;
@@ -180,10 +180,10 @@ wait_exit_ok "$MIGRATE" 300
 
 if use_podman_compose; then
   echo "==> create _litellm database"
-  "$RUNTIME" start teamclu-self-host_litellm-init_1 2>/dev/null \
+  "$RUNTIME" start teamclaw-self-host_litellm-init_1 2>/dev/null \
     || "${RUN[@]}" up -d --no-deps litellm-init 2>/dev/null \
     || true
-  wait_exit_ok teamclu-self-host_litellm-init_1 120
+  wait_exit_ok teamclaw-self-host_litellm-init_1 120
   recreate_no_deps litellm
 fi
 

--- a/deploy/self-host/emqx/emqx.conf
+++ b/deploy/self-host/emqx/emqx.conf
@@ -4,6 +4,14 @@
 
 node {
   name = "emqx@127.0.0.1"
+  # Erlang distribution cookie, NOT a container or network name — it only has to
+  # stay stable, and it is deliberately left on the rebranded value the running
+  # node already booted with. Changing it is hazardous in a way the name-shaped
+  # strings elsewhere in this directory are not: `docker compose up -d` does not
+  # restart a container just because a bind-mounted file changed, so the node
+  # keeps the old cookie while `emqx ctl` — the healthcheck — reads the new one
+  # from this file, fails Erlang distribution auth, and the container goes
+  # unhealthy until someone restarts it by hand.
   cookie = "teamclu-self-host"
   # required by EMQX 5.x; mounting our own emqx.conf over the image default drops it
   data_dir = "/opt/emqx/data"

--- a/deploy/self-host/smoke/image-upload.sh
+++ b/deploy/self-host/smoke/image-upload.sh
@@ -13,7 +13,7 @@ set -eu
 
 cd "$(dirname "$0")/.."
 ENV_FILE="${ENV_FILE:-.env}"
-PROJECT="${COMPOSE_PROJECT:-teamclu-self-host}"
+PROJECT="${COMPOSE_PROJECT:-teamclaw-self-host}"
 NET="${PROJECT}_default"
 BUCKET="${BUCKET:-smoke-images}"
 OBJECT="${OBJECT:-test.png}"

--- a/services/fc/test/self-host-e2e.test.ts
+++ b/services/fc/test/self-host-e2e.test.ts
@@ -38,7 +38,7 @@ function containerIp(name: string): string {
 }
 
 const FC_BASE = (
-  process.env.FC_E2E_BASE_URL ?? `http://${containerIp("teamclu-self-host-fc-1")}:9000`
+  process.env.FC_E2E_BASE_URL ?? `http://${containerIp("teamclaw-self-host-fc-1")}:9000`
 ).replace(/\/$/, "");
 
 const KONG_BASE = (
@@ -135,7 +135,7 @@ async function goFetch(
 function isDaemonRunning(): boolean {
   try {
     const out = execSync(
-      'docker inspect teamclu-self-host-amuxd-1 --format "{{.State.Running}}"',
+      'docker inspect teamclaw-self-host-amuxd-1 --format "{{.State.Running}}"',
       { stdio: ["pipe", "pipe", "pipe"] }
     )
       .toString()


### PR DESCRIPTION
接 #830。部署跑到最后的 e2e 挂了:

```
docker: Error response from daemon: failed to set up container networking:
network teamclu-self-host_default not found
```

#830 改回了 `docker-compose.yml` 的 `name:`,但漏了**另外 9 个文件**——它们各自硬编码了这个
project name 派生出来的容器名 / 卷名 / 网络名。compose 的 project name 是这三者的前缀,所以
必须全部一致。

这次全仓扫了一遍,不是只修报错点名的那个:

- `bootstrap/{check,up,up-app,reset-data}.sh`
- `amuxd/bootstrap-presence-only.sh`
- `smoke/image-upload.sh`
- `services/fc/test/self-host-e2e.test.ts`
- `README.md`

## 一处刻意不改

`emqx.conf` 的 `cookie` 字面量一样,但**不能跟着改**——它是 Erlang distribution cookie,
不是 compose 派生的名字,只要求稳定。

改它是有实际危险的:`docker compose up -d` **不会**因为 bind-mount 的文件内容变了就重启容器,
于是运行中的 node 还持有旧 cookie,而 `emqx ctl`(healthcheck 用的)从文件里读到新 cookie,
distribution 认证失败 → 容器变 unhealthy,直到有人手工重启。保持现值,加注释说明。

## 验证

在箱子上实测修好的脚本:

```
upload HTTP 200
download 200:image/png:70
PASS: image uploaded and round-tripped byte-for-byte
```

网络名也核对过,实际就是 `teamclaw-self-host_default`。

## 合并后

再 `workflow_dispatch` 跑一次 self-host-deploy。上一次(run 31311463912)前面所有阶段——
`git pull` / `docker compose build fc` / `up -d` / FC 健康检查——**都过了**,只挂在 e2e 的
Storage 一条(11 个测试 9 过 1 挂),所以这个修完应该就全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)