### PR TITLE
perf(chat): improve session switch and reply-to scroll

### DIFF
--- a/apps/daemon/src/runtime/opencode_http/mod.rs
+++ b/apps/daemon/src/runtime/opencode_http/mod.rs
@@ -2006,6 +2006,60 @@ mod turn_activity_tests {
         assert_eq!(frame.turn_reply_to_message_id.as_deref(), Some("reply-1"));
     }
 
+    /// Reproduces mid-turn follow-up: `do_prompt` has no busy gate, so a second
+    /// prompt while `turn_active` re-emits Idle→Active and clears
+    /// `tools_in_flight` (turn 1 tools still running upstream).
+    #[tokio::test]
+    async fn second_prompt_while_turn_active_reopens_turn_and_clears_tools() {
+        let shared = Arc::new(Shared::new());
+        let (tx, mut rx) = mpsc::channel(8);
+        {
+            let mut routes = shared.routes.lock();
+            let mut route = test_route("/ws");
+            route.event_tx = tx.clone();
+            route.turn_active = true;
+            route.turn_seq = 1;
+            route.tools_in_flight.insert("tool-turn1".to_string());
+            routes.insert("ses_repro".to_string(), route);
+        }
+
+        // Mirror the synchronous head of `do_prompt` (lines 1046–1074).
+        let (event_tx, turn_seq) = {
+            let mut routes = shared.routes.lock();
+            let route = routes.get_mut("ses_repro").expect("route");
+            route.turn_active = true;
+            route.turn_seq += 1;
+            route.tools_in_flight.clear();
+            (route.event_tx.clone(), route.turn_seq)
+        };
+        emit_frame(
+            &event_tx,
+            "ses_repro",
+            translate::status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
+            None,
+        )
+        .await;
+
+        let frame = rx.try_recv().expect("second prompt emits Idle→Active");
+        assert_eq!(frame.acp_session_id, "ses_repro");
+        match frame.event.event {
+            Some(amux::acp_event::Event::StatusChange(sc)) => {
+                assert_eq!(sc.old_status, amux::AgentStatus::Idle as i32);
+                assert_eq!(sc.new_status, amux::AgentStatus::Active as i32);
+            }
+            other => panic!("expected StatusChange, got {other:?}"),
+        }
+
+        let routes = shared.routes.lock();
+        let route = routes.get("ses_repro").expect("route");
+        assert!(route.turn_active);
+        assert_eq!(turn_seq, 2);
+        assert!(
+            route.tools_in_flight.is_empty(),
+            "second prompt clears in-flight tool tracking for turn 1"
+        );
+    }
+
     #[tokio::test]
     async fn an_idle_route_emits_nothing_when_dropped() {
         let (tx, mut rx) = mpsc::channel(4);

--- a/docs/plans/2026-08-09-session-switch-perf-requirements.md
+++ b/docs/plans/2026-08-09-session-switch-perf-requirements.md
@@ -1,0 +1,160 @@
+# 会话切换性能 + 聊天体验需求说明
+
+> **状态：** 需求归档（原 PR #832 放弃，由新 agent 在最新 `main` 上重新实现）  
+> **范围：** Web / Desktop 聊天面板（`packages/app/`）  
+> **背景：** 长会话、多 tool call 的历史消息在切换会话时卡顿；另有 reply-to 跳转时 header 错位。
+
+本文只描述**要解决的问题、预期行为与验收标准**，不包含具体代码方案或实现细节。
+
+---
+
+## 1. 问题背景
+
+### 1.1 会话切换卡顿
+
+切换到一个消息较多的会话时，用户能感知明显延迟。调查结论（现象层，非实现约束）：
+
+- 每次切换都会对整段 proto 消息做完整的 v2 → SDK 适配（CPU 密集），且稳态下同一套数据可能被适配两次。
+- 会话 fade 动画期间，旧会话与新会话的消息列表可能并行走两套适配路径。
+- 已完成的历史 agent turn 若包含大量 tool call / thinking，会在列表 mount 时一次性渲染全部 Process 卡片，加重切换成本。
+
+### 1.2 Reply-to 跳转 header 错位
+
+点击 reply-to 引用跳转到目标消息时，若使用页面级滚动，sticky 聊天 header 与目标消息的对齐会出错（目标被 header 遮住或位置偏移）。
+
+---
+
+## 2. 需求 A — 稳态会话切换：避免重复适配
+
+### 目标
+
+当用户已在查看的会话与 store 中的 active 会话一致时（无 fade 过渡），消息列表不应再做第二次全量 v2 适配。
+
+### 预期行为
+
+| 场景 | 预期 |
+|------|------|
+| 稳态：展示中的 sessionId === activeSessionId | 消息列表复用已适配好的 SDK 消息，不重复跑适配器 |
+| Fade 过渡：展示中的 sessionId 滞后于 activeSessionId | 允许旧会话与新会话各走一条适配路径（过渡是短暂的） |
+| 同一会话内新消息到达 | 正常随 store 更新；稳态下仍只适配一次 |
+
+### 非目标
+
+- 不改变 fade 动画本身的时长或交互。
+- 不在此需求内解决「切换时 App 层全量 reload 无缓存 skip」（若仍存在，可另开任务）。
+
+### 验收
+
+- [ ] 在长会话 A ↔ B 来回切换时，稳态阶段 DevTools Performance 中适配相关 CPU 峰值明显低于改前（或同等消息量下主观切换更跟手）。
+- [ ] Fade 期间旧会话内容仍能正常淡出，新会话淡入后内容正确。
+- [ ] 流式中的 active 会话消息仍实时更新，无 stale 或丢消息。
+
+---
+
+## 3. 需求 B — 历史 Process 懒加载（展开时才 hydrate）
+
+### 目标
+
+**已完成**的历史 agent turn，默认不在列表 mount 时渲染完整 thinking + tool call 过程；用户展开「处理过程」后再加载并展示。
+
+### 适用范围
+
+**应 defer（懒加载）：**
+
+- Turn 已结束（有最终 reply 文本，或 tool 均已 completed，等价的「不会再变」判定）。
+- 该 turn 的 process 部分（thinking、tool-call 等）与最终正文可以分离展示。
+
+**不应 defer：**
+
+- 正在流式输出或 turn 尚未完成的 message。
+- 整个 bubble 只有 process、没有可单独展示的最终正文（tool-only turn 等）— 这类应继续完整渲染，避免空白气泡。
+- Session 导出、需要完整 transcript 的路径 — 必须拿到 full process，不能走 UI 懒加载路径。
+
+### 预期行为
+
+| 场景 | 预期 |
+|------|------|
+| 历史已完成 turn，默认收起 | 列表只渲染最终正文 + process 摘要（如 tool 数量）；不 mount 完整 ToolCall 卡片 |
+| 用户点击展开「处理过程」 | 显示 loading，hydrate 后展示完整 thinking / tool calls；同 message 再次展开应命中缓存 |
+| 活跃 / 流式 turn | 与改前一致，process 实时可见，不 defer |
+| Session 导出 | 导出结果包含完整 thinking + tools，与改前 export 语义一致 |
+
+### 数据 / 契约层（概念）
+
+适配后的 SDK message 需要能表达：
+
+- 该条是否 defer 了 process（布尔或等价语义）。
+- defer 状态下 process 的轻量摘要（如 tool 数量、是否有 thinking），供 collapsible 标题使用。
+- 展开 hydrate 时定位原始 turn 所需的引用（session + turn + sender 等），hydrate 输入为 store 中的 proto 消息。
+
+### 非目标
+
+- 不改变 Process collapsible 的视觉设计规范（仍遵循 AGENTS.md Editorial Calm）。
+- 不改变 streaming 架构（streaming 阶段仍只读 streamingContent，完成后读 message.parts）。
+
+### 验收
+
+- [ ] 含 20+ tool call 的历史会话：切换进入后首屏 mount 明显快于改前；默认收起时不渲染 tool 卡片 DOM。
+- [ ] 展开某条历史 process：tool / thinking 内容与改前 full adapt 一致。
+- [ ] 流式 turn：进行中仍能看到 process 更新；完成后行为符合上表。
+- [ ] Session 导出 JSON：仍含完整 tool/thinking parts。
+- [ ] 单元测试覆盖：defer 判定、forceFull 路径、hydrate 结果与 full adapt 一致。
+
+---
+
+## 4. 需求 C — Reply-to 跳转：仅在消息列表容器内滚动
+
+### 目标
+
+从 reply-to 引用跳转到目标消息时，滚动应限制在聊天消息列表容器内，不影响外层 layout，sticky header 保持正确对齐。
+
+### 预期行为
+
+| 场景 | 预期 |
+|------|------|
+| 点击 reply-to 引用 | 目标 message 滚动到消息列表可视区域内，不被 sticky header 遮挡 |
+| 目标在虚拟列表未渲染窗口外 | 先扩展/定位虚拟列表可见窗口，再滚到目标 |
+| 跳转后 | 可选：短暂高亮目标 message（若产品已有 flash 行为则保持） |
+
+### 非目标
+
+- 不改变 reply-to 引用的 UI 样式。
+- 不使用 `scrollIntoView` 直接滚整个页面/外层容器（已知会导致 header 错位）。
+
+### 验收
+
+- [ ] 线程较长、header sticky 时：点击 reply-to，目标消息完整出现在 header 下方。
+- [ ] 目标在列表很靠上/靠下/未初始渲染时均能正确跳转。
+- [ ] 单元测试覆盖：容器内 scroll 计算、message 元素查找逻辑（不依赖真实 DOM layout）。
+
+---
+
+## 5. 测试与回归清单
+
+实现完成后至少验证：
+
+| 类别 | 检查项 |
+|------|--------|
+| 自动化 | `pnpm typecheck`；v2 适配器相关 vitest；reply-to scroll 相关 vitest |
+| 手动 — 切换 | 长会话 A/B 快速切换；fade 过渡无闪屏、无错会话内容 |
+| 手动 — process | 历史 turn 默认收起 → 展开 hydrate；流式 turn 不受影响 |
+| 手动 — reply-to | 跨多屏高度跳转；header 不挡目标 |
+| 手动 — 导出 | 含 tool 的会话导出后 parts 完整 |
+
+---
+
+## 6. 明确不在本需求内
+
+- TeamClu 重命名 / DNS / CI canary 等基础设施改动（随 `main` 已有方案即可）。
+- OSS e2e `skills` → `knowledge` 目录 mkdir 修正（若 `main` 仍有遗漏，单独小 PR）。
+- 150ms fade 人为延迟的移除或缩短（可另开 perf 任务）。
+- App 层 session 切换时的全量 reload 缓存策略（可另开任务）。
+- 未读 badge、列表分页、participants 缓存失效等 AGENTS.md Out-of-scope 项。
+
+---
+
+## 7. 实现提示（非方案）
+
+- 在最新 `main` 上开新分支；命名与 proto/API 以当前 **TeamClu** 为准（`teamclu_pb`、`adaptTeamcluMessages` 等）。
+- 三个需求可拆成独立 commit/PR，但 B 与 A 都_touch_ v2 适配器与 ChatPanel，合并时注意冲突。
+- 优先保证 **流式 active turn** 与 **export full path** 零回归，再优化历史 turn 路径。

--- a/packages/app/src/components/MqttLiveWiring.tsx
+++ b/packages/app/src/components/MqttLiveWiring.tsx
@@ -48,7 +48,7 @@ import { bufferStreamDelta, flushStreamDeltasFor, flushAllStreamDeltas } from "@
 import { recordLatencyProbe } from "@/lib/latency-probe";
 import { bumpLiveDuplicateDropped } from "@/lib/live-dedup-stats";
 import { cloneStreamEntrySnapshot, patchPersistedToolResult, patchPersistedToolUse, resolveStreamEntryForPersist, syncStreamingToolOutputsFromLocalCache } from "@/lib/streaming-persist";
-import { clearFlushedTurn, getFlushedTurn } from "@/lib/flushed-turn-registry";
+import { getFlushedTurn } from "@/lib/flushed-turn-registry";
 import { logInterruptMsgDiag, summarizeFlushDecision, summarizePendingReplies, summarizeStreamEntry } from "@/lib/interrupt-msg-diag";
 import { logExtMsgDiag, summarizeProtoForExtDiag, summarizeProtosForExtDiag } from "@/lib/extension-msg-diag";
 import { logStreamToolDiag } from "@/lib/stream-tool-diag";
@@ -58,7 +58,7 @@ import { acquireRuntimeStateStore, useRuntimeStateStore } from "@/stores/runtime
 import { findStaleLiveStreams, STALE_STREAM_SWEEP_MS } from "@/lib/stale-stream-recovery";
 import { acquireActorPresenceStore } from "@/stores/actor-presence-store";
 import { MessageKind, type Message as TeamcluMessage } from "@/lib/proto/teamclu_pb";
-import { agentStreamKey, isAgentActiveStatus, isTerminalAgentStatus, isToolOnlyTurnAnchor, mergePendingAgentReplies, normalizeToolResultEvent, normalizeToolUseEvent, registerDiscardPendingStreamReply, rememberLiveEventId, streamEntryHasVisibleContent } from "@/lib/live-agent-stream";
+import { agentStreamKey, isAgentActiveStatus, isTerminalAgentStatus, isToolOnlyTurnAnchor, mergePendingAgentReplies, normalizeToolResultEvent, normalizeToolUseEvent, registerDiscardPendingStreamReply, rememberLiveEventId, shouldPatchFlushedToolEvent, streamEntryHasVisibleContent } from "@/lib/live-agent-stream";
 import { mapAcpPlanEntries, syncPlanFromTodoTool, syncPlanFromTodoToolResult } from "@/lib/sync-plan-from-todowrite";
 import { useWorkspaceStore } from "@/stores/workspace";
 import { useLocalStatsStore } from "@/stores/local-stats";
@@ -1151,11 +1151,7 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
               const tu = normalizeToolUseEvent(event.value);
               const liveEntry =
                 useV2StreamingStore.getState().byKey[agentStreamKey(sid, actorId)];
-              // After idle flush, late toolUse must not reopen the live dock.
-              if (
-                getFlushedTurn(sid, actorId) &&
-                (!liveEntry || !isStreamInterruptible(liveEntry))
-              ) {
+              if (shouldPatchFlushedToolEvent(sid, actorId, tu.toolId, liveEntry)) {
                 logStreamToolDiag("mqtt.toolUse.skipAfterFlush", {
                   sessionId: sid,
                   actorId,
@@ -1207,6 +1203,8 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
               }
             } else if (event?.case === "toolResult") {
               const tr = normalizeToolResultEvent(event.value);
+              const liveEntry =
+                useV2StreamingStore.getState().byKey[agentStreamKey(sid, actorId)];
               logStreamToolDiag("mqtt.toolResult", {
                 sessionId: sid,
                 actorId,
@@ -1214,33 +1212,43 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
                 toolId: tr.toolId,
                 success: tr.success,
               });
-              useV2StreamingStore.getState().completeToolUse(sid, actorId, {
-                toolId: tr.toolId,
-                success: tr.success,
-                summary: tr.summary,
-                content: tr.content,
-                rawOutput: tr.rawOutput,
-              });
-              // Late toolResult after idle: patch the message-area parts_json
-              // (OpenCode-style reconcile on the persisted turn).
-              void patchPersistedToolResult({
-                sessionId: sid,
-                actorId,
-                toolId: tr.toolId,
-                success: tr.success,
-                summary: tr.summary,
-                content: tr.content,
-                rawOutput: tr.rawOutput,
-              });
+              if (shouldPatchFlushedToolEvent(sid, actorId, tr.toolId, liveEntry)) {
+                void patchPersistedToolResult({
+                  sessionId: sid,
+                  actorId,
+                  toolId: tr.toolId,
+                  success: tr.success,
+                  summary: tr.summary,
+                  content: tr.content,
+                  rawOutput: tr.rawOutput,
+                });
+              } else {
+                useV2StreamingStore.getState().completeToolUse(sid, actorId, {
+                  toolId: tr.toolId,
+                  success: tr.success,
+                  summary: tr.summary,
+                  content: tr.content,
+                  rawOutput: tr.rawOutput,
+                });
+                void patchPersistedToolResult({
+                  sessionId: sid,
+                  actorId,
+                  toolId: tr.toolId,
+                  success: tr.success,
+                  summary: tr.summary,
+                  content: tr.content,
+                  rawOutput: tr.rawOutput,
+                });
+                void syncStreamingToolOutputsFromLocalCache(sid, actorId);
+                window.setTimeout(() => {
+                  void syncStreamingToolOutputsFromLocalCache(sid, actorId);
+                }, 500);
+              }
               syncPlanFromTodoToolResult(sid, actorId, {
                 toolId: tr.toolId,
                 success: tr.success,
                 summary: tr.summary,
               });
-              void syncStreamingToolOutputsFromLocalCache(sid, actorId);
-              window.setTimeout(() => {
-                void syncStreamingToolOutputsFromLocalCache(sid, actorId);
-              }, 500);
             } else if (event?.case === "statusChange") {
               const sc = event.value as { oldStatus?: number; newStatus?: number };
               logStreamToolDiag("mqtt.statusChange", {
@@ -1269,7 +1277,6 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
                   ),
                 });
                 clearTerminalFlushPending(agentStreamKey(sid, actorId));
-                clearFlushedTurn(sid, actorId);
                 useV2StreamingStore.getState().beginPlanningPlaceholder(sid, actorId);
               } else if (isTerminalAgentStatus(sc.newStatus)) {
                 const streamKey = agentStreamKey(sid, actorId);
@@ -1591,6 +1598,7 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
         clearTerminalAwaitTimeout(streamKey);
       }
       terminalFlushPendingRef.current = {};
+      followUpActiveRef.current = {};
       interruptedStreamFlushRef.current = {};
       interruptedFlushSupersededRef.current = {};
       interruptedFlushSupersededStreamIdRef.current = {};

--- a/packages/app/src/components/MqttLiveWiring.tsx
+++ b/packages/app/src/components/MqttLiveWiring.tsx
@@ -47,7 +47,7 @@ import { removePendingAgentReplyTo, resolvePendingAgentReplyTo } from "@/lib/pen
 import { bufferStreamDelta, flushStreamDeltasFor, flushAllStreamDeltas } from "@/lib/stream-delta-buffer";
 import { recordLatencyProbe } from "@/lib/latency-probe";
 import { bumpLiveDuplicateDropped } from "@/lib/live-dedup-stats";
-import { cloneStreamEntrySnapshot, patchPersistedToolResult, resolveStreamEntryForPersist, syncStreamingToolOutputsFromLocalCache } from "@/lib/streaming-persist";
+import { cloneStreamEntrySnapshot, patchPersistedToolResult, patchPersistedToolUse, resolveStreamEntryForPersist, syncStreamingToolOutputsFromLocalCache } from "@/lib/streaming-persist";
 import { clearFlushedTurn, getFlushedTurn } from "@/lib/flushed-turn-registry";
 import { logInterruptMsgDiag, summarizeFlushDecision, summarizePendingReplies, summarizeStreamEntry } from "@/lib/interrupt-msg-diag";
 import { logExtMsgDiag, summarizeProtoForExtDiag, summarizeProtosForExtDiag } from "@/lib/extension-msg-diag";
@@ -103,6 +103,8 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
   const pendingStreamRepliesRef = useRef<Record<string, TeamcluMessage[]>>({});
   /** Set on terminal statusChange; late message.created triggers flush. */
   const terminalFlushPendingRef = useRef<Record<string, boolean>>({});
+  /** Set on follow-up ACTIVE (mid-turn user message); reopen turn2 dock after flush. */
+  const followUpActiveRef = useRef<Record<string, boolean>>({});
   /** Timeout while waiting for daemon AGENT_REPLY after terminal (no interrupt-*). */
   const terminalAwaitTimeoutRef = useRef<Record<string, ReturnType<typeof setTimeout>>>(
     {},
@@ -124,6 +126,18 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
   function clearTerminalFlushPending(streamKey: string) {
     clearTerminalAwaitTimeout(streamKey);
     delete terminalFlushPendingRef.current[streamKey];
+  }
+
+  function clearFollowUpActive(streamKey: string) {
+    delete followUpActiveRef.current[streamKey];
+  }
+
+  function ensureFollowUpLiveStream(sessionId: string, actorId: string) {
+    const streamKey = agentStreamKey(sessionId, actorId);
+    if (!followUpActiveRef.current[streamKey]) return;
+    const liveEntry = useV2StreamingStore.getState().byKey[streamKey];
+    if (liveEntry && isStreamInterruptible(liveEntry)) return;
+    useV2StreamingStore.getState().beginPlanningPlaceholder(sessionId, actorId);
   }
 
   function scheduleTerminalDaemonReplyTimeout(
@@ -394,6 +408,7 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
       useV2StreamingStore
         .getState()
         .clearInterruptedFlushPending(sessionId, actorId);
+      ensureFollowUpLiveStream(sessionId, actorId);
       // A late interrupted AGENT_REPLY may have parked while this flush was
       // in-flight — drain it now so scheme-A UI is not stuck until next Active.
       if (
@@ -1146,6 +1161,19 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
                   actorId,
                   toolId: tu.toolId,
                 });
+                void patchPersistedToolUse({
+                  sessionId: sid,
+                  actorId,
+                  toolId: tu.toolId,
+                  toolName: tu.toolName,
+                  description: tu.description,
+                  params: tu.params,
+                  toolKind: tu.toolKind,
+                  content: tu.content,
+                  locations: tu.locations,
+                  acpStatus: tu.acpStatus,
+                  rawInput: tu.rawInput,
+                });
               } else {
                 useV2StreamingStore.getState().pushToolUse(sid, actorId, {
                   toolId: tu.toolId,
@@ -1223,6 +1251,8 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
                 newStatus: sc.newStatus,
               });
               if (isAgentActiveStatus(sc.newStatus)) {
+                const streamKey = agentStreamKey(sid, actorId);
+                followUpActiveRef.current[streamKey] = true;
                 const flushed = flushTurnAgentReply(
                   sid,
                   actorId,
@@ -1243,6 +1273,7 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
                 useV2StreamingStore.getState().beginPlanningPlaceholder(sid, actorId);
               } else if (isTerminalAgentStatus(sc.newStatus)) {
                 const streamKey = agentStreamKey(sid, actorId);
+                clearFollowUpActive(streamKey);
                 terminalFlushPendingRef.current[streamKey] = true;
                 const flushed = flushTurnAgentReply(
                   sid,

--- a/packages/app/src/components/chat/AgentProcessCollapsible.tsx
+++ b/packages/app/src/components/chat/AgentProcessCollapsible.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Loader2 } from "lucide-react";
 import {
   Collapsible,
   CollapsibleContent,
@@ -13,15 +13,27 @@ export function AgentProcessCollapsible({
   children,
   summary,
   defaultOpen = false,
+  loading = false,
+  onOpenChange,
   className,
 }: {
   children: React.ReactNode;
   summary?: string;
   defaultOpen?: boolean;
+  loading?: boolean;
+  onOpenChange?: (open: boolean) => void;
   className?: string;
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = React.useState(defaultOpen);
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      onOpenChange?.(next);
+    },
+    [onOpenChange],
+  );
 
   return (
     <div
@@ -29,7 +41,7 @@ export function AgentProcessCollapsible({
       data-testid="agent-process-collapsible"
       data-open={open ? "true" : "false"}
     >
-      <Collapsible open={open} onOpenChange={setOpen}>
+      <Collapsible open={open} onOpenChange={handleOpenChange}>
         <CollapsibleTrigger asChild>
           <button
             type="button"
@@ -48,13 +60,17 @@ export function AgentProcessCollapsible({
                 </span>
               </>
             ) : null}
-            <ChevronRight
-              className={cn(
-                "h-3 w-3 shrink-0 text-faint opacity-0 transition-[opacity,transform] duration-200 group-hover/process:opacity-100",
-                open && "rotate-90",
-              )}
-              aria-hidden
-            />
+            {loading ? (
+              <Loader2 className="h-3 w-3 shrink-0 animate-spin text-faint" aria-hidden />
+            ) : (
+              <ChevronRight
+                className={cn(
+                  "h-3 w-3 shrink-0 text-faint opacity-0 transition-[opacity,transform] duration-200 group-hover/process:opacity-100",
+                  open && "rotate-90",
+                )}
+                aria-hidden
+              />
+            )}
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>

--- a/packages/app/src/components/chat/AgentReplyQuote.tsx
+++ b/packages/app/src/components/chat/AgentReplyQuote.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from "react-i18next";
 import { CornerDownRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+export { jumpToMessageById } from "@/lib/chat-scroll-to-message";
+
 /** Soft-strip quote (style B): faint pad + author + inline AGENT pills + body. */
 export function AgentReplyQuote({
   authorName,
@@ -107,21 +109,4 @@ export function parseReplyQuoteContent(
 /** @deprecated Prefer parseReplyQuoteContent — kept for call sites that only need text. */
 export function formatReplyQuoteSnippet(content: string, maxLen = 80): string {
   return parseReplyQuoteContent(content, maxLen).body;
-}
-
-export function jumpToMessageById(messageId: string): boolean {
-  const id = messageId.trim();
-  if (!id) return false;
-  const el = document.querySelector(
-    `[data-testid="chat-message"][data-message-id="${CSS.escape(id)}"]`,
-  ) as HTMLElement | null;
-  if (!el) return false;
-  el.scrollIntoView({ behavior: "smooth", block: "center" });
-  el.classList.remove("agent-reply-quote-flash");
-  void el.offsetWidth;
-  el.classList.add("agent-reply-quote-flash");
-  window.setTimeout(() => {
-    el.classList.remove("agent-reply-quote-flash");
-  }, 1100);
-  return true;
 }

--- a/packages/app/src/components/chat/ChatMessage.tsx
+++ b/packages/app/src/components/chat/ChatMessage.tsx
@@ -28,12 +28,54 @@ import { MessageFeedback } from "./MessageFeedback";
 import { MessageStarRating } from "./MessageStarRating";
 import { RetrievedChunksCard } from "./RetrievedChunksCard";
 import { splitAssistantProcessAndFinalParts } from "@/lib/agent-reply-transcript";
+import { hydrateDeferredProcessParts } from "@/lib/lazy-process-parts";
+import type { MessagePart } from "@/stores/session-types";
+import { useSessionMessageStore } from "@/stores/session-message-store";
 import {
   AgentReplyQuote,
   jumpToMessageById,
 } from "./AgentReplyQuote";
 import { useActorDisplayName } from "@/hooks/useActorDisplayName";
 import { useCurrentTeamStore } from "@/stores/current-team";
+
+function formatProcessMetaSummary(meta: {
+  toolCount: number;
+  hasThinking: boolean;
+}): string | undefined {
+  const bits: string[] = [];
+  if (meta.hasThinking) bits.push("Thinking");
+  if (meta.toolCount > 0) bits.push(`${meta.toolCount} tool`);
+  return bits.join(" · ") || undefined;
+}
+
+function renderAgentProcessPart(part: MessagePart, basePath?: string) {
+  if (part.type === "reasoning") {
+    const reasoningText = part.text || part.content || "";
+    if (!reasoningText) return null;
+    return (
+      <ThinkingBlock
+        key={part.id}
+        content={reasoningText}
+        isOpen={false}
+      />
+    );
+  }
+  if (part.type === "tool-call" && part.toolCall) {
+    return <ToolCallCard key={part.id} toolCall={part.toolCall} />;
+  }
+  if (part.type === "text") {
+    const partText = part.text || part.content || "";
+    if (!partText) return null;
+    return (
+      <Message key={part.id} from="assistant" basePath={basePath}>
+        <MessageContent>
+          <MessageResponse>{partText}</MessageResponse>
+        </MessageContent>
+      </Message>
+    );
+  }
+  return null;
+}
 
 /** Renders a single message with all its parts. Memoized to avoid re-renders when siblings change. */
 export const ChatMessage = React.memo(function ChatMessage({
@@ -61,6 +103,10 @@ export const ChatMessage = React.memo(function ChatMessage({
   const isUser = message.role === "user";
   const isInterruptedTurn = !isUser && message.turnStatus === "interrupted";
   const [copied, setCopied] = React.useState(false);
+  const [hydratedProcessParts, setHydratedProcessParts] = React.useState<
+    MessagePart[] | null
+  >(null);
+  const [processHydrating, setProcessHydrating] = React.useState(false);
   const replyAuthorResolved = useActorDisplayName(replyToMessage?.senderActorId);
   const myActorId = useCurrentTeamStore((s) => s.currentMember?.id);
   const replyAuthorName = React.useMemo(() => {
@@ -117,6 +163,29 @@ export const ChatMessage = React.memo(function ChatMessage({
   const textContent = isThisMessageStreaming
     ? (isChildSessionStreaming ? (childStreamingState?.text || "") : streamingContent)
     : (latestMessage.content || "");
+
+  const isDeferredProcess =
+    !latestMessage.isStreaming && Boolean(latestMessage.processDeferred);
+
+  React.useEffect(() => {
+    setHydratedProcessParts(null);
+    setProcessHydrating(false);
+  }, [latestMessage.id, latestMessage.processDeferred]);
+
+  const handleProcessOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (!open || !isDeferredProcess || hydratedProcessParts) return;
+      setProcessHydrating(true);
+      void Promise.resolve().then(() => {
+        const protos =
+          useSessionMessageStore.getState().messages[latestMessage.sessionId];
+        const parts = hydrateDeferredProcessParts(protos, latestMessage);
+        setHydratedProcessParts(parts);
+        setProcessHydrating(false);
+      });
+    },
+    [hydratedProcessParts, isDeferredProcess, latestMessage],
+  );
 
   // Extract reasoning/thinking content from parts — memoized to avoid
   // re-filtering on every render during streaming.
@@ -292,8 +361,22 @@ export const ChatMessage = React.memo(function ChatMessage({
         />
       ) : null}
 
+      {/* Deferred historical process — hydrate on expand */}
+      {!isUser && isDeferredProcess && latestMessage.processMeta ? (
+        <div className="mb-0.5 pl-1">
+          <AgentProcessCollapsible
+            summary={formatProcessMetaSummary(latestMessage.processMeta)}
+            loading={processHydrating}
+            onOpenChange={handleProcessOpenChange}
+          >
+            {hydratedProcessParts?.map((part) => renderAgentProcessPart(part, basePath))}
+          </AgentProcessCollapsible>
+        </div>
+      ) : null}
+
       {/* Reasoning / tools — collapsed「处理过程」above final text when not streaming */}
       {!isUser &&
+        !isDeferredProcess &&
         !latestMessage.isStreaming &&
         !shouldRenderOrderedAssistantParts &&
         (hasReasoning || (hasToolCalls && !hasOrderedToolParts)) && (
@@ -392,7 +475,7 @@ export const ChatMessage = React.memo(function ChatMessage({
       )}
 
       {/* Assistant message - either dynamic UI or text */}
-      {!isUser && shouldRenderOrderedAssistantParts && (
+      {!isUser && shouldRenderOrderedAssistantParts && !isDeferredProcess && (
         <div className="mt-2 space-y-1">
           {orderedProcessParts.length > 0 && !latestMessage.isStreaming ? (
             <AgentProcessCollapsible summary={orderedProcessSummary}>

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -18,6 +18,7 @@ import { useTeamModeStore } from "@/stores/team-mode";
 import { useCurrentTeamStore } from "@/stores/current-team";
 import { TEAMCLU_DIR, CONFIG_FILE_NAME, TEAM_REPO_DIR } from "@/lib/build-config";
 import { adaptTeamcluMessages } from "@/lib/v2-message-adapter";
+import { clearDeferredProcessCache } from "@/lib/lazy-process-parts";
 import { logInterruptMsgDiag } from "@/lib/interrupt-msg-diag";
 import { logExtMsgDiag } from "@/lib/extension-msg-diag";
 import { isChromeExtension } from "@/lib/platform";
@@ -789,20 +790,25 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     activeSessionId ? s.messages?.[activeSessionId] : undefined
   );
   const activeMessages = React.useMemo(
-    () => adaptTeamcluMessages(activeMessagesRaw),
+    () => adaptTeamcluMessages(activeMessagesRaw, { deferProcess: true }),
     [activeMessagesRaw],
   );
   /** Shown messages lag store during fade so old session can fade out before swap */
   const [displaySessionId, setDisplaySessionId] = React.useState<string | null>(activeSessionId);
   const [sessionFadeOpacity, setSessionFadeOpacity] = React.useState(1);
+  const sessionsInSync = displaySessionId === activeSessionId;
 
   const displayMessagesRaw = useSessionMessageStore((s) =>
-    displaySessionId ? s.messages?.[displaySessionId] : undefined,
+    !sessionsInSync && displaySessionId ? s.messages?.[displaySessionId] : undefined,
   );
-  const displayMessages = React.useMemo(
-    () => adaptTeamcluMessages(displayMessagesRaw),
-    [displayMessagesRaw],
+  const displayOnlyMessages = React.useMemo(
+    () =>
+      sessionsInSync
+        ? undefined
+        : adaptTeamcluMessages(displayMessagesRaw, { deferProcess: true }),
+    [sessionsInSync, displayMessagesRaw],
   );
+  const displayMessages = sessionsInSync ? activeMessages : displayOnlyMessages;
 
   const activeStreamingAgents = React.useMemo(() => {
     const seen = new Set<string>();
@@ -845,6 +851,9 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     }
     setSessionFadeOpacity(0);
     const t = window.setTimeout(() => {
+      if (displaySessionId) {
+        clearDeferredProcessCache(displaySessionId);
+      }
       setDisplaySessionId(activeSessionId);
       requestAnimationFrame(() => {
         requestAnimationFrame(() => setSessionFadeOpacity(1));

--- a/packages/app/src/components/chat/MessageList.tsx
+++ b/packages/app/src/components/chat/MessageList.tsx
@@ -11,6 +11,13 @@ import { useV2StreamingStore } from "@/stores/v2-streaming-store";
 import { Button } from "@/components/ui/button";
 import { ChatMessage } from "./ChatMessage";
 import { useChatStickToBottom } from "@/hooks/use-chat-stick-to-bottom";
+import {
+  CHAT_SCROLL_TO_MESSAGE_EVENT,
+  findChatMessageElement,
+  flashChatMessage,
+  scrollChatMessageIntoView,
+  type ChatScrollToMessageDetail,
+} from "@/lib/chat-scroll-to-message";
 import { DEFAULT_INPUT_AREA_HEIGHT, SAFE_BOTTOM_SPACING } from "./layout-constants";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -210,6 +217,7 @@ const MessageListInner = React.forwardRef<MessageListHandle, MessageListProps>(
     const scrollRef = React.useRef<HTMLDivElement>(null);
     const messageAreaRef = React.useRef<HTMLDivElement>(null);
     const prevStreamingRef = React.useRef(false);
+    const pendingScrollMessageIdRef = React.useRef<string | null>(null);
 
     const {
       scrollToBottom,
@@ -219,7 +227,18 @@ const MessageListInner = React.forwardRef<MessageListHandle, MessageListProps>(
       onScroll,
       enableAutoFollow,
       pauseAutoFollowIfReading,
+      stopAutoFollow,
     } = useChatStickToBottom(scrollRef);
+
+    const fulfillPendingScroll = React.useCallback(() => {
+      const messageId = pendingScrollMessageIdRef.current;
+      if (!messageId) return;
+      const el = findChatMessageElement(messageId);
+      if (!el) return;
+      scrollChatMessageIntoView(el);
+      flashChatMessage(el);
+      pendingScrollMessageIdRef.current = null;
+    }, []);
 
     /**
      * Called from ChatPanel right after optimistic append.
@@ -296,6 +315,65 @@ const MessageListInner = React.forwardRef<MessageListHandle, MessageListProps>(
 
       return () => cancelAnimationFrame(raf);
     }, [useVirtualMessages, messageAreaWidth, messageVirtualizer]);
+
+    React.useEffect(() => {
+      const onScrollRequest = (event: Event) => {
+        const messageId = (event as CustomEvent<ChatScrollToMessageDetail>).detail
+          ?.messageId;
+        if (!messageId) return;
+
+        stopAutoFollow();
+        pendingScrollMessageIdRef.current = messageId;
+
+        const idx = messages.findIndex((message) => message.id === messageId);
+        if (idx < 0) {
+          pendingScrollMessageIdRef.current = null;
+          return;
+        }
+
+        const firstRenderedIndex = Math.max(0, messages.length - visibleMessageCount);
+        if (idx < firstRenderedIndex) {
+          setVisibleMessageCount(messages.length - idx);
+          return;
+        }
+
+        if (useVirtualMessages) {
+          const renderedIndex = renderedMessages.findIndex(
+            (message) => message.id === messageId,
+          );
+          if (renderedIndex >= 0) {
+            messageVirtualizer.scrollToIndex(renderedIndex, {
+              align: "start",
+              behavior: "smooth",
+            });
+          }
+        }
+
+        requestAnimationFrame(() => {
+          requestAnimationFrame(fulfillPendingScroll);
+        });
+      };
+
+      window.addEventListener(CHAT_SCROLL_TO_MESSAGE_EVENT, onScrollRequest);
+      return () => {
+        window.removeEventListener(CHAT_SCROLL_TO_MESSAGE_EVENT, onScrollRequest);
+      };
+    }, [
+      fulfillPendingScroll,
+      messageVirtualizer,
+      messages,
+      renderedMessages,
+      stopAutoFollow,
+      useVirtualMessages,
+      visibleMessageCount,
+    ]);
+
+    React.useEffect(() => {
+      if (!pendingScrollMessageIdRef.current) return;
+      requestAnimationFrame(() => {
+        requestAnimationFrame(fulfillPendingScroll);
+      });
+    }, [fulfillPendingScroll, renderedMessages, visibleMessageCount]);
 
     // ── Scroll management (stick-to-bottom + ResizeObserver) ─────────────
 

--- a/packages/app/src/hooks/use-chat-stick-to-bottom.ts
+++ b/packages/app/src/hooks/use-chat-stick-to-bottom.ts
@@ -144,6 +144,10 @@ export function useChatStickToBottom(
     isAtBottomRef.current = true;
   }, []);
 
+  const stopAutoFollow = React.useCallback(() => {
+    isAtBottomRef.current = false;
+  }, []);
+
   return {
     scrollToBottom,
     scrollToBottomIfAtBottom,
@@ -152,5 +156,6 @@ export function useChatStickToBottom(
     onScroll,
     enableAutoFollow,
     pauseAutoFollowIfReading,
+    stopAutoFollow,
   };
 }

--- a/packages/app/src/lib/__tests__/chat-scroll-to-message.test.ts
+++ b/packages/app/src/lib/__tests__/chat-scroll-to-message.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  CHAT_SCROLL_TO_MESSAGE_EVENT,
+  findChatMessageElement,
+  flashChatMessage,
+  jumpToMessageById,
+  requestChatScrollToMessage,
+  scrollChatMessageIntoView,
+} from "@/lib/chat-scroll-to-message";
+
+describe("chat-scroll-to-message", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("findChatMessageElement returns the matching row", () => {
+    document.body.innerHTML = `
+      <div data-chat-messages>
+        <div data-testid="chat-message" data-message-id="m1">one</div>
+        <div data-testid="chat-message" data-message-id="m2">two</div>
+      </div>
+    `;
+    expect(findChatMessageElement("m2")?.textContent).toBe("two");
+    expect(findChatMessageElement("missing")).toBeNull();
+  });
+
+  it("scrollChatMessageIntoView scrolls the message list container", () => {
+    const container = document.createElement("div");
+    container.setAttribute("data-chat-messages", "");
+    Object.defineProperty(container, "clientHeight", { value: 400 });
+    Object.defineProperty(container, "scrollHeight", { value: 1000 });
+    container.scrollTop = 0;
+    container.scrollTo = vi.fn();
+
+    const message = document.createElement("div");
+    message.getBoundingClientRect = () =>
+      ({
+        top: 500,
+        bottom: 560,
+        height: 60,
+      }) as DOMRect;
+    container.getBoundingClientRect = () =>
+      ({
+        top: 100,
+        bottom: 500,
+      }) as DOMRect;
+    container.appendChild(message);
+
+    const scrolled = scrollChatMessageIntoView(message, { behavior: "instant" });
+    expect(scrolled).toBe(true);
+    expect(container.scrollTo).toHaveBeenCalled();
+  });
+
+  it("requestChatScrollToMessage dispatches a window event", () => {
+    const handler = vi.fn();
+    window.addEventListener(CHAT_SCROLL_TO_MESSAGE_EVENT, handler);
+    requestChatScrollToMessage("target-id");
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(
+      (handler.mock.calls[0][0] as CustomEvent<{ messageId: string }>).detail.messageId,
+    ).toBe("target-id");
+    window.removeEventListener(CHAT_SCROLL_TO_MESSAGE_EVENT, handler);
+  });
+
+  it("jumpToMessageById scrolls immediately when the row is mounted", () => {
+    document.body.innerHTML = `
+      <div data-chat-messages style="height: 200px; overflow: auto;">
+        <div data-testid="chat-message" data-message-id="m1" style="height: 40px;">one</div>
+      </div>
+    `;
+    const el = findChatMessageElement("m1")!;
+    const container = el.closest("[data-chat-messages]") as HTMLElement;
+    container.scrollTo = vi.fn();
+
+    expect(jumpToMessageById("m1")).toBe(true);
+    expect(container.scrollTo).toHaveBeenCalled();
+    expect(el.classList.contains("agent-reply-quote-flash")).toBe(true);
+  });
+
+  it("jumpToMessageById requests scroll when the row is not mounted yet", () => {
+    const handler = vi.fn();
+    window.addEventListener(CHAT_SCROLL_TO_MESSAGE_EVENT, handler);
+    expect(jumpToMessageById("missing-id")).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    window.removeEventListener(CHAT_SCROLL_TO_MESSAGE_EVENT, handler);
+  });
+
+  it("flashChatMessage toggles the highlight class", () => {
+    vi.useFakeTimers();
+    const el = document.createElement("div");
+    flashChatMessage(el);
+    expect(el.classList.contains("agent-reply-quote-flash")).toBe(true);
+    vi.advanceTimersByTime(1100);
+    expect(el.classList.contains("agent-reply-quote-flash")).toBe(false);
+    vi.useRealTimers();
+  });
+});

--- a/packages/app/src/lib/__tests__/lazy-process-parts.test.ts
+++ b/packages/app/src/lib/__tests__/lazy-process-parts.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import { MessageSchema, MessageKind } from "@/lib/proto/teamclu_pb";
+import {
+  clearDeferredProcessCache,
+  hydrateDeferredProcessParts,
+} from "@/lib/lazy-process-parts";
+import { adaptTeamcluMessages } from "@/lib/v2-message-adapter";
+
+function tmsg(o: {
+  kind?: MessageKind;
+  content?: string;
+  metadataJson?: string;
+  turnId?: string;
+  t?: number;
+}) {
+  return create(MessageSchema, {
+    messageId: `msg-${o.t ?? 0}`,
+    sessionId: "s1",
+    senderActorId: "actor-a",
+    kind: o.kind ?? MessageKind.AGENT_REPLY,
+    content: o.content ?? "",
+    metadataJson: o.metadataJson ?? "",
+    model: "",
+    turnId: o.turnId ?? "turn-1",
+    replyToMessageId: "",
+    createdAt: BigInt(o.t ?? 0),
+  });
+}
+
+describe("lazy-process-parts", () => {
+  beforeEach(() => {
+    clearDeferredProcessCache();
+  });
+
+  it("hydrates deferred process parts from proto rows", () => {
+    const toolId = "tool-1";
+    const protos = [
+      tmsg({
+        kind: MessageKind.AGENT_TOOL_CALL,
+        content: "",
+        metadataJson: JSON.stringify({ tool_id: toolId, tool_name: "read", description: "file" }),
+        t: 1,
+      }),
+      tmsg({
+        kind: MessageKind.AGENT_TOOL_RESULT,
+        content: "done",
+        metadataJson: JSON.stringify({ tool_id: toolId, success: true }),
+        t: 2,
+      }),
+      tmsg({
+        kind: MessageKind.AGENT_REPLY,
+        content: "Answer.",
+        t: 3,
+      }),
+    ];
+
+    const deferred = adaptTeamcluMessages(protos, { deferProcess: true })!;
+    const message = deferred[0];
+    expect(message.processDeferred).toBe(true);
+
+    const parts = hydrateDeferredProcessParts(protos, message);
+    expect(parts.some((p) => p.type === "tool-call")).toBe(true);
+
+    const cached = hydrateDeferredProcessParts(protos, message);
+    expect(cached).toBe(parts);
+  });
+
+  it("clearDeferredProcessCache drops entries for one session", () => {
+    const protos = [
+      tmsg({
+        kind: MessageKind.AGENT_TOOL_CALL,
+        content: "",
+        metadataJson: JSON.stringify({ tool_id: "t1", tool_name: "bash", description: "ls" }),
+        t: 1,
+      }),
+      tmsg({
+        kind: MessageKind.AGENT_TOOL_RESULT,
+        content: "ok",
+        metadataJson: JSON.stringify({ tool_id: "t1", success: true }),
+        t: 2,
+      }),
+      tmsg({
+        kind: MessageKind.AGENT_REPLY,
+        content: "Done.",
+        t: 3,
+      }),
+    ];
+
+    const deferred = adaptTeamcluMessages(protos, { deferProcess: true })!;
+    hydrateDeferredProcessParts(protos, deferred[0]);
+    clearDeferredProcessCache("s1");
+
+    const again = hydrateDeferredProcessParts(protos, deferred[0]);
+    expect(again.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/lib/__tests__/live-agent-stream.test.ts
+++ b/packages/app/src/lib/__tests__/live-agent-stream.test.ts
@@ -14,8 +14,14 @@ import {
   streamTranscriptHasText,
   streamTranscriptRevision,
   streamEntryHasVisibleContent,
+  shouldPatchFlushedToolEvent,
 } from "@/lib/live-agent-stream";
 import type { AgentStreamEntry } from "@/stores/v2-streaming-store";
+import {
+  registerFlushedTurn,
+  resetFlushedTurnRegistryForTests,
+} from "@/lib/flushed-turn-registry";
+import { useV2StreamingStore } from "@/stores/v2-streaming-store";
 
 describe("live agent stream event helpers", () => {
   it("normalizes execute tool uses preserving wire name when absent", () => {
@@ -304,5 +310,56 @@ describe("live agent stream event helpers", () => {
     expect(Number(anchor.createdAt)).toBe(
       Math.floor(new Date("2026-06-08T07:38:00.000Z").getTime() / 1000),
     );
+  });
+});
+
+describe("shouldPatchFlushedToolEvent", () => {
+  beforeEach(() => {
+    resetFlushedTurnRegistryForTests();
+    useV2StreamingStore.setState({
+      byKey: {},
+      archived: [],
+      revisionBySession: {},
+      interruptedFlushPending: {},
+    });
+  });
+
+  it("patches when the live stream is inactive after flush", () => {
+    registerFlushedTurn("s1", "a1", {
+      messageId: "m1",
+      streamId: "stream-1",
+      turnId: "turn-1",
+    });
+    expect(shouldPatchFlushedToolEvent("s1", "a1", "tool-late", undefined)).toBe(true);
+  });
+
+  it("patches orphan tools from a prior turn while follow-up dock is open", () => {
+    registerFlushedTurn("s1", "a1", {
+      messageId: "m1",
+      streamId: "stream-1",
+      turnId: "turn-1",
+    });
+    useV2StreamingStore.getState().beginPlanningPlaceholder("s1", "a1");
+    const live = useV2StreamingStore.getState().byKey["s1::a1"] as AgentStreamEntry;
+    expect(live.streamId).not.toBe("stream-1");
+    expect(shouldPatchFlushedToolEvent("s1", "a1", "turn1-tool", live)).toBe(true);
+  });
+
+  it("keeps current-turn tools on the live stream", () => {
+    registerFlushedTurn("s1", "a1", {
+      messageId: "m1",
+      streamId: "stream-1",
+      turnId: "turn-1",
+    });
+    useV2StreamingStore.getState().beginPlanningPlaceholder("s1", "a1");
+    useV2StreamingStore.getState().pushToolUse("s1", "a1", {
+      toolId: "turn2-tool",
+      toolName: "grep",
+      description: "search",
+      params: {},
+      toolKind: "search",
+    });
+    const live = useV2StreamingStore.getState().byKey["s1::a1"] as AgentStreamEntry;
+    expect(shouldPatchFlushedToolEvent("s1", "a1", "turn2-tool", live)).toBe(false);
   });
 });

--- a/packages/app/src/lib/__tests__/mid-turn-followup-repro.test.ts
+++ b/packages/app/src/lib/__tests__/mid-turn-followup-repro.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Repro tests for the mid-turn follow-up bug: a second user message while
+ * opencode is still processing can drop the Composer live panel and skip
+ * late toolUse events.
+ *
+ * Run against a live daemon:
+ *   REPRO_MID_TURN_LIVE=1 pnpm --filter @teamclu/app exec vitest run src/lib/__tests__/mid-turn-followup-repro.test.ts
+ * or:
+ *   scripts/repro-mid-turn-followup.sh [--session-id <uuid>]
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { create, toBinary } from "@bufbuild/protobuf";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  LiveEventEnvelopeSchema,
+  SessionMessageEnvelopeSchema,
+  MessageSchema,
+  MessageKind,
+} from "@/lib/proto/teamclu_pb";
+import { AgentStatus } from "@/lib/proto/amux_pb";
+import { decodeLiveEvent } from "@/lib/teamclu-events";
+import {
+  clearFlushedTurn,
+  getFlushedTurn,
+  registerFlushedTurn,
+  resetFlushedTurnRegistryForTests,
+} from "@/lib/flushed-turn-registry";
+import {
+  isStreamInterruptible,
+  useV2StreamingStore,
+} from "@/stores/v2-streaming-store";
+import { useSessionMessageStore } from "@/stores/session-message-store";
+
+const LIVE = process.env.REPRO_MID_TURN_LIVE === "1";
+const AMUXD_DIR = path.join(os.homedir(), ".amuxd");
+
+function resetStreamingStore() {
+  useV2StreamingStore.setState({
+    byKey: {},
+    archived: [],
+    revisionBySession: {},
+    interruptedFlushPending: {},
+    persistedPlansBySession: {},
+  });
+}
+
+function readAmuxdHttpBase(): string {
+  const port = fs.readFileSync(path.join(AMUXD_DIR, "amuxd.http.port"), "utf8").trim();
+  return `http://127.0.0.1:${port}`;
+}
+
+function readAmuxdRootToken(): string {
+  return fs.readFileSync(path.join(AMUXD_DIR, "amuxd.http.token"), "utf8").trim();
+}
+
+async function exchangeScopedToken(scopes: string[]): Promise<string> {
+  const res = await fetch(`${readAmuxdHttpBase()}/v1/auth/exchange`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${readAmuxdRootToken()}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ scopes }),
+  });
+  if (!res.ok) {
+    throw new Error(`auth exchange failed (${res.status}): ${await res.text()}`);
+  }
+  const body = (await res.json()) as { token?: string };
+  if (!body.token) throw new Error("auth exchange returned no token");
+  return body.token;
+}
+
+async function fetchDaemonInfo(token: string): Promise<{ actor_id: string; mqtt_connected: boolean }> {
+  const res = await fetch(`${readAmuxdHttpBase()}/v1/info`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`info failed (${res.status})`);
+  return res.json() as Promise<{ actor_id: string; mqtt_connected: boolean }>;
+}
+
+function defaultSessionId(): string {
+  const fromEnv = process.env.REPRO_SESSION_ID?.trim();
+  if (fromEnv) return fromEnv;
+  const activePath = path.join(
+    os.homedir(),
+    ".amuxd/teams/68c9c97a-7393-494f-9b82-59364e7179ba/workspace/.teamclu/active-session-id",
+  );
+  if (fs.existsSync(activePath)) {
+    const id = fs.readFileSync(activePath, "utf8").trim();
+    if (id) return id;
+  }
+  throw new Error("Set REPRO_SESSION_ID or open a session in TeamClu first");
+}
+
+function buildMessageCreatedEnvelope(args: {
+  sessionId: string;
+  senderActorId: string;
+  daemonActorId: string;
+  content: string;
+  messageId?: string;
+}): Uint8Array {
+  const messageId = args.messageId ?? randomUUID();
+  const nowSec = BigInt(Math.floor(Date.now() / 1000));
+  const message = create(MessageSchema, {
+    messageId,
+    sessionId: args.sessionId,
+    senderActorId: args.senderActorId,
+    kind: MessageKind.TEXT,
+    content: args.content,
+    createdAt: nowSec,
+  });
+  const sessionMsg = create(SessionMessageEnvelopeSchema, {
+    message,
+    mentionActorIds: [args.daemonActorId],
+  });
+  const live = create(LiveEventEnvelopeSchema, {
+    eventId: randomUUID(),
+    eventType: "message.created",
+    sessionId: args.sessionId,
+    actorId: args.senderActorId,
+    sentAt: nowSec,
+    body: toBinary(SessionMessageEnvelopeSchema, sessionMsg),
+  });
+  return toBinary(LiveEventEnvelopeSchema, live);
+}
+
+async function ingestMessage(token: string, sessionId: string, bytes: Uint8Array): Promise<void> {
+  const res = await fetch(
+    `${readAmuxdHttpBase()}/v1/session-live/ingest?session_id=${encodeURIComponent(sessionId)}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/x-protobuf",
+      },
+      body: bytes as unknown as BodyInit,
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`live ingest failed (${res.status}): ${await res.text()}`);
+  }
+}
+
+type LiveEventRecord = {
+  at: number;
+  topic: string;
+  eventType: string;
+  oldStatus?: AgentStatus;
+  newStatus?: AgentStatus;
+  toolName?: string;
+  outputSnippet?: string;
+};
+
+function summarizeAcpEvent(decoded: ReturnType<typeof decodeLiveEvent>): Partial<LiveEventRecord> {
+  if (!decoded?.acpEvent) return {};
+  const ev = decoded.acpEvent.event;
+  if (ev?.case === "statusChange") {
+    return { oldStatus: ev.value.oldStatus, newStatus: ev.value.newStatus };
+  }
+  if (ev?.case === "toolUse") {
+    const tu = ev.value as { toolName?: string; toolId?: string };
+    return { toolName: tu.toolName ?? tu.toolId ?? "tool" };
+  }
+  if (ev?.case === "output") {
+    const text = (ev.value as { text?: string }).text ?? "";
+    return { outputSnippet: text.slice(0, 80) };
+  }
+  return {};
+}
+
+describe("mid-turn follow-up repro (client store simulation)", () => {
+  beforeEach(() => {
+    resetFlushedTurnRegistryForTests();
+    resetStreamingStore();
+  });
+
+  it("terminal flush with inactive live stream gates late toolUse (matches mqtt.toolUse.skipAfterFlush)", () => {
+    const sessionId = "s1";
+    const actorId = "agent-1";
+    const store = useV2StreamingStore.getState();
+
+    store.beginPlanningPlaceholder(sessionId, actorId);
+    store.appendOutput(sessionId, actorId, "Turn 1 output");
+    store.pushToolUse(sessionId, actorId, {
+      toolId: "tool-1",
+      toolName: "grep",
+      description: "search",
+      params: {},
+      toolKind: "search",
+    });
+
+    const beforeFlush = useV2StreamingStore.getState().byKey[`${sessionId}::${actorId}`];
+    expect(isStreamInterruptible(beforeFlush)).toBe(true);
+    expect(beforeFlush.toolCalls).toHaveLength(1);
+
+    registerFlushedTurn(sessionId, actorId, {
+      messageId: "msg-flushed",
+      streamId: beforeFlush.streamId,
+      turnId: "turn-1",
+    });
+    store.finishSessionActor(sessionId, actorId);
+
+    const liveEntry = useV2StreamingStore.getState().byKey[`${sessionId}::${actorId}`];
+    expect(liveEntry?.active ?? false).toBe(false);
+
+    const wouldSkipLateToolUse = Boolean(
+      getFlushedTurn(sessionId, actorId) &&
+        (!liveEntry || !isStreamInterruptible(liveEntry)),
+    );
+    expect(wouldSkipLateToolUse).toBe(true);
+  });
+
+  it("second ACTIVE after flush clears registry but beginPlanning skips when turn1 still has content", () => {
+    const sessionId = "s1";
+    const actorId = "agent-1";
+    const store = useV2StreamingStore.getState();
+
+    store.beginPlanningPlaceholder(sessionId, actorId);
+    store.appendOutput(sessionId, actorId, "In-flight text");
+
+    clearFlushedTurn(sessionId, actorId);
+    store.beginPlanningPlaceholder(sessionId, actorId);
+
+    const entry = useV2StreamingStore.getState().byKey[`${sessionId}::${actorId}`];
+    expect(entry.outputText).toBe("In-flight text");
+    expect(isStreamInterruptible(entry)).toBe(true);
+  });
+
+  it("race: terminal flush after second ACTIVE hides live panel and drops late toolUse", async () => {
+    const sessionId = "s1";
+    const actorId = "agent-1";
+    const store = useV2StreamingStore.getState();
+
+    store.beginPlanningPlaceholder(sessionId, actorId);
+    store.appendOutput(sessionId, actorId, "Step 1");
+    store.pushToolUse(sessionId, actorId, {
+      toolId: "tool-1",
+      toolName: "grep",
+      description: "search",
+      params: {},
+      toolKind: "search",
+    });
+
+    const turn1 = useV2StreamingStore.getState().byKey[`${sessionId}::${actorId}`];
+
+    clearFlushedTurn(sessionId, actorId);
+    store.beginPlanningPlaceholder(sessionId, actorId);
+
+    const reply = create(MessageSchema, {
+      messageId: "msg-flushed",
+      sessionId,
+      senderActorId: actorId,
+      kind: MessageKind.AGENT_REPLY,
+      content: "Step 1",
+      turnId: "turn-1",
+      createdAt: BigInt(100),
+    });
+    Object.assign(reply, {
+      partsJson: JSON.stringify([
+        { id: "p1", type: "text", text: "Step 1", content: "Step 1" },
+      ]),
+    });
+    useSessionMessageStore.getState().replaceTurnAgentRepliesInStore(sessionId, reply);
+    registerFlushedTurn(sessionId, actorId, {
+      messageId: "msg-flushed",
+      streamId: turn1.streamId,
+      turnId: "turn-1",
+    });
+    store.finishSessionActor(sessionId, actorId);
+
+    const liveAfter = useV2StreamingStore.getState().byKey[`${sessionId}::${actorId}`];
+    expect(liveAfter?.active ?? false).toBe(false);
+
+    const { patchPersistedToolUse } = await import("@/lib/streaming-persist");
+    const patched = await patchPersistedToolUse({
+      sessionId,
+      actorId,
+      toolId: "tool-late",
+      toolName: "grep",
+      description: "late search",
+      params: { pattern: "foo" },
+      toolKind: "search",
+    });
+    expect(patched).toBe(true);
+
+    const stored = useSessionMessageStore.getState().messages[sessionId]?.[0] as {
+      partsJson?: string;
+    };
+    const parts = JSON.parse(stored.partsJson ?? "[]");
+    expect(parts.some((p: { toolCall?: { id?: string } }) => p.toolCall?.id === "tool-late")).toBe(
+      true,
+    );
+  });
+
+  it("follow-up beginPlanning after flush reopens empty active dock", () => {
+    const sessionId = "s1";
+    const actorId = "agent-1";
+    const store = useV2StreamingStore.getState();
+
+    store.beginPlanningPlaceholder(sessionId, actorId);
+    store.appendOutput(sessionId, actorId, "Turn 1 still running");
+    store.beginPlanningPlaceholder(sessionId, actorId);
+
+    const midTurn = useV2StreamingStore.getState().byKey[`${sessionId}::${actorId}`];
+    expect(midTurn.outputText).toBe("Turn 1 still running");
+
+    store.finishSessionActor(sessionId, actorId);
+    store.beginPlanningPlaceholder(sessionId, actorId);
+
+    const entry = useV2StreamingStore.getState().byKey[`${sessionId}::${actorId}`];
+    expect(entry?.active).toBe(true);
+    expect(entry.outputText).toBe("");
+  });
+});
+
+const liveDescribe = LIVE ? describe : describe.skip;
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+liveDescribe("mid-turn follow-up repro (live daemon)", () => {
+  it(
+    "double prompt while turn active emits repeated Idle→Active and can lose post-flush toolUse",
+    async () => {
+      const token = await exchangeScopedToken([
+        "sessions:read",
+        "sessions:write",
+        "events:read",
+      ]);
+      const info = await fetchDaemonInfo(token);
+      expect(info.mqtt_connected).toBe(true);
+
+      const sessionId = defaultSessionId();
+      const daemonActorId = info.actor_id;
+      const userActorId = "repro-user-" + randomUUID().slice(0, 8);
+
+      const msg1 = buildMessageCreatedEnvelope({
+        sessionId,
+        senderActorId: userActorId,
+        daemonActorId,
+        content:
+          "请用 grep 或 bash 工具列出当前 workspace 根目录下的文件（必须调用工具），然后简短总结。",
+      });
+      const msg2 = buildMessageCreatedEnvelope({
+        sessionId,
+        senderActorId: userActorId,
+        daemonActorId,
+        content: "补充：完成后也检查一下 package.json 是否存在（继续用工具）。",
+      });
+
+      const events: LiveEventRecord[] = [];
+      const url = `${readAmuxdHttpBase()}/v1/live/events?access_token=${encodeURIComponent(token)}`;
+      const controller = new AbortController();
+
+      const sseTask = (async () => {
+        try {
+          const res = await fetch(url, { signal: controller.signal });
+          if (!res.ok || !res.body) throw new Error(`live/events failed (${res.status})`);
+          const reader = res.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            let idx = buffer.indexOf("\n\n");
+            while (idx >= 0) {
+              const chunk = buffer.slice(0, idx);
+              buffer = buffer.slice(idx + 2);
+              const dataLine = chunk.split("\n").find((line) => line.startsWith("data: "));
+              if (dataLine) {
+                try {
+                  const frame = JSON.parse(dataLine.slice(6)) as { topic?: string; b64?: string };
+                  if (!frame.b64) continue;
+                  const payload = Uint8Array.from(atob(frame.b64), (c) => c.charCodeAt(0));
+                  const decoded = decodeLiveEvent(payload);
+                  const sid =
+                    decoded?.envelope.sessionId ??
+                    (frame.topic?.match(/session\/([^/]+)\/live/)?.[1] ?? "");
+                  if (sid && sid !== sessionId) continue;
+                  events.push({
+                    at: Date.now(),
+                    topic: frame.topic ?? "",
+                    eventType: decoded?.envelope.eventType ?? "unknown",
+                    ...summarizeAcpEvent(decoded),
+                  });
+                } catch {
+                  // ignore
+                }
+              }
+              idx = buffer.indexOf("\n\n");
+            }
+          }
+        } catch (err) {
+          if (!isAbortError(err)) throw err;
+        }
+      })();
+
+      await ingestMessage(token, sessionId, msg1);
+
+      const waitUntil = async (predicate: () => boolean, timeoutMs: number) => {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+          if (predicate()) return true;
+          await new Promise((r) => setTimeout(r, 150));
+        }
+        return false;
+      };
+
+      await waitUntil(
+        () =>
+          events.some(
+            (e) =>
+              e.eventType === "acp.event" &&
+              e.oldStatus === AgentStatus.IDLE &&
+              e.newStatus === AgentStatus.ACTIVE,
+          ),
+        30_000,
+      );
+
+      await waitUntil(() => events.some((e) => e.toolName || e.outputSnippet), 20_000);
+
+      await ingestMessage(token, sessionId, msg2);
+
+      await waitUntil(
+        () =>
+          events.filter(
+            (e) =>
+              e.eventType === "acp.event" &&
+              e.oldStatus === AgentStatus.IDLE &&
+              e.newStatus === AgentStatus.ACTIVE,
+          ).length >= 2,
+        15_000,
+      );
+
+      await new Promise((r) => setTimeout(r, 3_000));
+      controller.abort();
+      await sseTask;
+
+      const idleToActive = events.filter(
+        (e) =>
+          e.eventType === "acp.event" &&
+          e.oldStatus === AgentStatus.IDLE &&
+          e.newStatus === AgentStatus.ACTIVE,
+      );
+      const activeToIdle = events.filter(
+        (e) =>
+          e.eventType === "acp.event" &&
+          e.oldStatus === AgentStatus.ACTIVE &&
+          e.newStatus === AgentStatus.IDLE,
+      );
+      const toolUses = events.filter((e) => e.toolName);
+      const outputs = events.filter((e) => e.outputSnippet);
+
+      console.log("[repro] session", sessionId);
+      console.log("[repro] Idle→Active count", idleToActive.length);
+      console.log("[repro] Active→Idle count", activeToIdle.length);
+      console.log("[repro] toolUse events", toolUses.length, toolUses.map((t) => t.toolName));
+      console.log("[repro] output events", outputs.length);
+
+      if (idleToActive.length >= 2) {
+        const secondActiveAt = idleToActive[1]?.at ?? 0;
+        const toolUsesAfterSecondActive = toolUses.filter((t) => t.at >= secondActiveAt);
+        console.log(
+          "[repro] toolUse after 2nd Idle→Active",
+          toolUsesAfterSecondActive.length,
+        );
+      } else {
+        console.warn(
+          "[repro] only one Idle→Active — runtime may not have been mid-turn; retry while agent is busy",
+        );
+      }
+
+      expect(events.length).toBeGreaterThan(0);
+    },
+    60_000,
+  );
+});

--- a/packages/app/src/lib/__tests__/mid-turn-followup-repro.test.ts
+++ b/packages/app/src/lib/__tests__/mid-turn-followup-repro.test.ts
@@ -28,6 +28,7 @@ import {
   registerFlushedTurn,
   resetFlushedTurnRegistryForTests,
 } from "@/lib/flushed-turn-registry";
+import { shouldPatchFlushedToolEvent } from "@/lib/live-agent-stream";
 import {
   isStreamInterruptible,
   useV2StreamingStore,
@@ -206,9 +207,11 @@ describe("mid-turn follow-up repro (client store simulation)", () => {
     const liveEntry = useV2StreamingStore.getState().byKey[`${sessionId}::${actorId}`];
     expect(liveEntry?.active ?? false).toBe(false);
 
-    const wouldSkipLateToolUse = Boolean(
-      getFlushedTurn(sessionId, actorId) &&
-        (!liveEntry || !isStreamInterruptible(liveEntry)),
+    const wouldSkipLateToolUse = shouldPatchFlushedToolEvent(
+      sessionId,
+      actorId,
+      "tool-late",
+      liveEntry,
     );
     expect(wouldSkipLateToolUse).toBe(true);
   });

--- a/packages/app/src/lib/__tests__/mid-turn-followup-repro.test.ts
+++ b/packages/app/src/lib/__tests__/mid-turn-followup-repro.test.ts
@@ -24,7 +24,6 @@ import { AgentStatus } from "@/lib/proto/amux_pb";
 import { decodeLiveEvent } from "@/lib/teamclu-events";
 import {
   clearFlushedTurn,
-  getFlushedTurn,
   registerFlushedTurn,
   resetFlushedTurnRegistryForTests,
 } from "@/lib/flushed-turn-registry";

--- a/packages/app/src/lib/__tests__/streaming-persist.test.ts
+++ b/packages/app/src/lib/__tests__/streaming-persist.test.ts
@@ -359,4 +359,53 @@ describe("persistStreamingPartsForReply", () => {
     expect(parts[0].toolCall.result).toContain("User aborted");
     expect(useV2StreamingStore.getState().byKey["s1::actor-a"]).toBeUndefined();
   });
+
+  it("patches a flushed message when a late toolUse arrives after idle flush", async () => {
+    const { registerFlushedTurn, resetFlushedTurnRegistryForTests } = await import(
+      "@/lib/flushed-turn-registry"
+    );
+    const { patchPersistedToolUse } = await import("@/lib/streaming-persist");
+    resetFlushedTurnRegistryForTests();
+
+    const reply = create(MessageSchema, {
+      messageId: "reply-1",
+      sessionId: "s1",
+      senderActorId: "actor-a",
+      kind: MessageKind.AGENT_REPLY,
+      content: "partial",
+      turnId: "turn-1",
+      createdAt: BigInt(100),
+    });
+    Object.assign(reply, {
+      partsJson: JSON.stringify([
+        { id: "p1", type: "text", text: "partial", content: "partial" },
+      ]),
+    });
+    useSessionMessageStore.getState().replaceTurnAgentRepliesInStore("s1", reply);
+    registerFlushedTurn("s1", "actor-a", {
+      messageId: "reply-1",
+      streamId: "stream-1",
+      turnId: "turn-1",
+    });
+
+    const patched = await patchPersistedToolUse({
+      sessionId: "s1",
+      actorId: "actor-a",
+      toolId: "grep-tool",
+      toolName: "grep",
+      description: "search files",
+      params: { pattern: "version" },
+      toolKind: "search",
+    });
+    expect(patched).toBe(true);
+
+    const stored = useSessionMessageStore.getState().messages.s1?.[0] as {
+      partsJson?: string;
+    };
+    const parts = JSON.parse(stored.partsJson ?? "[]");
+    expect(parts).toHaveLength(2);
+    expect(parts[1].type).toBe("tool-call");
+    expect(parts[1].toolCall.id).toBe("grep-tool");
+    expect(parts[1].toolCall.status).toBe("calling");
+  });
 });

--- a/packages/app/src/lib/__tests__/v2-message-adapter.test.ts
+++ b/packages/app/src/lib/__tests__/v2-message-adapter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { create } from "@bufbuild/protobuf";
 import { MessageSchema, MessageKind } from "@/lib/proto/teamclu_pb";
 import { adaptTeamcluMessages } from "@/lib/v2-message-adapter";
+import { hydrateDeferredProcessParts } from "@/lib/lazy-process-parts";
 
 // Simple counter for stable IDs in tests (avoids crypto.randomUUID dependency)
 let _idCounter = 0;
@@ -798,5 +799,112 @@ describe("adaptTeamcluMessages", () => {
     expect(result?.[0]?.parts?.some((p) => p.type === "text" && p.text === prose)).toBe(
       true,
     );
+  });
+
+  it("defers completed turn process parts when final reply text exists", () => {
+    const toolId = "tool-defer";
+    const turnId = "t-defer";
+    const msgs = [
+      tmsg({
+        kind: MessageKind.AGENT_THINKING,
+        content: "Planning…",
+        turnId,
+        t: 1,
+      }),
+      tmsg({
+        kind: MessageKind.AGENT_TOOL_CALL,
+        content: "",
+        metadataJson: JSON.stringify({ tool_id: toolId, tool_name: "read", description: "open file" }),
+        turnId,
+        t: 2,
+      }),
+      tmsg({
+        kind: MessageKind.AGENT_TOOL_RESULT,
+        content: "ok",
+        metadataJson: JSON.stringify({ tool_id: toolId, success: true }),
+        turnId,
+        t: 3,
+      }),
+      tmsg({
+        kind: MessageKind.AGENT_REPLY,
+        content: "Final answer.",
+        turnId,
+        t: 4,
+      }),
+    ];
+
+    const result = adaptTeamcluMessages(msgs, { deferProcess: true })!;
+    expect(result).toHaveLength(1);
+    expect(result[0].processDeferred).toBe(true);
+    expect(result[0].processMeta).toEqual({ toolCount: 1, hasThinking: true });
+    expect(result[0].content).toBe("Final answer.");
+    expect(result[0].toolCalls).toEqual([]);
+    expect(result[0].parts.some((p) => p.type === "tool-call")).toBe(false);
+    expect(result[0].parts.some((p) => p.type === "reasoning")).toBe(false);
+  });
+
+  it("forceFull adapt matches hydrated deferred process parts", () => {
+    const toolId = "tool-hydrate";
+    const turnId = "t-hydrate";
+    const msgs = [
+      tmsg({
+        kind: MessageKind.AGENT_TOOL_CALL,
+        content: "",
+        metadataJson: JSON.stringify({ tool_id: toolId, tool_name: "bash", description: "ls" }),
+        turnId,
+        t: 1,
+      }),
+      tmsg({
+        kind: MessageKind.AGENT_TOOL_RESULT,
+        content: "a.txt",
+        metadataJson: JSON.stringify({ tool_id: toolId, success: true }),
+        turnId,
+        t: 2,
+      }),
+      tmsg({
+        kind: MessageKind.AGENT_REPLY,
+        content: "Here are the files.",
+        turnId,
+        t: 3,
+      }),
+    ];
+
+    const deferred = adaptTeamcluMessages(msgs, { deferProcess: true })!;
+    const full = adaptTeamcluMessages(msgs, { forceFull: true })!;
+
+    expect(deferred[0].processDeferred).toBe(true);
+    expect(full[0].processDeferred).toBeUndefined();
+    expect(full[0].toolCalls).toHaveLength(1);
+
+    const hydrated = hydrateDeferredProcessParts(msgs, deferred[0]);
+    const fullToolParts = full[0].parts.filter((p) => p.type === "tool-call");
+    const hydratedToolParts = hydrated.filter((p) => p.type === "tool-call");
+    expect(hydratedToolParts).toHaveLength(fullToolParts.length);
+    expect(hydratedToolParts[0]?.toolCall?.name).toBe("bash");
+  });
+
+  it("does not defer tool-only turns without separate final text", () => {
+    const toolId = "tool-only";
+    const turnId = "t-tool-only";
+    const msgs = [
+      tmsg({
+        kind: MessageKind.AGENT_TOOL_CALL,
+        content: "",
+        metadataJson: JSON.stringify({ tool_id: toolId, tool_name: "bash", description: "pwd" }),
+        turnId,
+        t: 1,
+      }),
+      tmsg({
+        kind: MessageKind.AGENT_TOOL_RESULT,
+        content: "/home/user",
+        metadataJson: JSON.stringify({ tool_id: toolId, success: true }),
+        turnId,
+        t: 2,
+      }),
+    ];
+
+    const result = adaptTeamcluMessages(msgs)!;
+    expect(result[0].processDeferred).toBeUndefined();
+    expect(result[0].toolCalls).toHaveLength(1);
   });
 });

--- a/packages/app/src/lib/chat-scroll-to-message.ts
+++ b/packages/app/src/lib/chat-scroll-to-message.ts
@@ -1,0 +1,101 @@
+/** Scroll a chat message into view without disturbing outer sticky headers. */
+
+export const CHAT_SCROLL_TO_MESSAGE_EVENT = "teamclaw:chat-scroll-to-message";
+
+export type ChatScrollToMessageDetail = {
+  messageId: string;
+};
+
+/** Extra offset so the target clears the sticky chat header inside the list. */
+const SCROLL_TOP_INSET_PX = 12;
+
+export function findChatMessageElement(messageId: string): HTMLElement | null {
+  const id = messageId.trim();
+  if (!id) return null;
+  return document.querySelector(
+    `[data-testid="chat-message"][data-message-id="${CSS.escape(id)}"]`,
+  ) as HTMLElement | null;
+}
+
+export function scrollChatMessageIntoView(
+  messageEl: HTMLElement,
+  options?: {
+    behavior?: ScrollBehavior;
+    block?: "center" | "start" | "nearest";
+  },
+): boolean {
+  const container = messageEl.closest("[data-chat-messages]") as HTMLElement | null;
+  const behavior = options?.behavior ?? "smooth";
+  const block = options?.block ?? "start";
+
+  if (!container) {
+    messageEl.scrollIntoView({ behavior, block });
+    return false;
+  }
+
+  const containerRect = container.getBoundingClientRect();
+  const messageRect = messageEl.getBoundingClientRect();
+  const relativeTop = messageRect.top - containerRect.top + container.scrollTop;
+
+  let targetScrollTop: number;
+  switch (block) {
+    case "center":
+      targetScrollTop =
+        relativeTop - (container.clientHeight - messageRect.height) / 2;
+      break;
+    case "nearest":
+      if (
+        messageRect.top >= containerRect.top &&
+        messageRect.bottom <= containerRect.bottom
+      ) {
+        return true;
+      }
+      targetScrollTop = relativeTop - SCROLL_TOP_INSET_PX;
+      break;
+    case "start":
+    default:
+      targetScrollTop = relativeTop - SCROLL_TOP_INSET_PX;
+      break;
+  }
+
+  const maxScroll = Math.max(0, container.scrollHeight - container.clientHeight);
+  container.scrollTo({
+    top: Math.max(0, Math.min(targetScrollTop, maxScroll)),
+    behavior,
+  });
+  return true;
+}
+
+export function flashChatMessage(messageEl: HTMLElement): void {
+  messageEl.classList.remove("agent-reply-quote-flash");
+  void messageEl.offsetWidth;
+  messageEl.classList.add("agent-reply-quote-flash");
+  window.setTimeout(() => {
+    messageEl.classList.remove("agent-reply-quote-flash");
+  }, 1100);
+}
+
+export function requestChatScrollToMessage(messageId: string): void {
+  const id = messageId.trim();
+  if (!id) return;
+  window.dispatchEvent(
+    new CustomEvent<ChatScrollToMessageDetail>(CHAT_SCROLL_TO_MESSAGE_EVENT, {
+      detail: { messageId: id },
+    }),
+  );
+}
+
+export function jumpToMessageById(messageId: string): boolean {
+  const id = messageId.trim();
+  if (!id) return false;
+
+  const el = findChatMessageElement(id);
+  if (el) {
+    scrollChatMessageIntoView(el);
+    flashChatMessage(el);
+    return true;
+  }
+
+  requestChatScrollToMessage(id);
+  return true;
+}

--- a/packages/app/src/lib/lazy-process-parts.ts
+++ b/packages/app/src/lib/lazy-process-parts.ts
@@ -1,0 +1,51 @@
+import { splitAssistantProcessAndFinalParts } from "@/lib/agent-reply-transcript";
+import type { Message as TeamcluMessage } from "@/lib/proto/teamclu_pb";
+import type { Message as SdkMessage, MessagePart } from "@/stores/session-types";
+import { buildFullTurnSdkMessageFromGroup } from "@/lib/v2-message-adapter";
+
+const deferredProcessCache = new Map<string, MessagePart[]>();
+
+function renderableParts(parts: MessagePart[]): MessagePart[] {
+  return parts.filter(
+    (p) =>
+      (p.type === "reasoning" && Boolean(p.text || p.content)) ||
+      (p.type === "text" && Boolean(p.text || p.content)) ||
+      (p.type === "tool-call" && Boolean(p.toolCall)),
+  );
+}
+
+/** Hydrate collapsed process parts for a deferred historical turn (cached per message). */
+export function hydrateDeferredProcessParts(
+  protos: TeamcluMessage[] | undefined,
+  message: Pick<SdkMessage, "id" | "lazyProcessRef">,
+): MessagePart[] {
+  const ref = message.lazyProcessRef;
+  if (!protos?.length || !ref) return [];
+
+  const cacheKey = `${ref.sessionId}:${message.id}`;
+  const cached = deferredProcessCache.get(cacheKey);
+  if (cached) return cached;
+
+  const group = protos.filter(
+    (p) => p.turnId === ref.turnId && p.senderActorId === ref.senderActorId,
+  );
+  if (group.length === 0) return [];
+
+  const full = buildFullTurnSdkMessageFromGroup(group);
+  const { processParts } = splitAssistantProcessAndFinalParts(
+    renderableParts(full.parts),
+  );
+  deferredProcessCache.set(cacheKey, processParts);
+  return processParts;
+}
+
+export function clearDeferredProcessCache(sessionId?: string): void {
+  if (!sessionId) {
+    deferredProcessCache.clear();
+    return;
+  }
+  const prefix = `${sessionId}:`;
+  for (const key of deferredProcessCache.keys()) {
+    if (key.startsWith(prefix)) deferredProcessCache.delete(key);
+  }
+}

--- a/packages/app/src/lib/live-agent-stream.ts
+++ b/packages/app/src/lib/live-agent-stream.ts
@@ -7,6 +7,8 @@ import type { ToolCallContentBlock } from "@/components/chat/tool-calls/tool-cal
 import { parseToolContentBlocks } from "@/components/chat/tool-calls/tool-call-content";
 import { deriveAgentReplyContent } from "@/lib/agent-reply-transcript";
 import { agentReplyTextsEquivalent } from "@/lib/agent-reply-text";
+import { getFlushedTurn } from "@/lib/flushed-turn-registry";
+import { isStreamInterruptible } from "@/stores/v2-streaming-store";
 
 export {
   deriveAgentReplyContent,
@@ -308,4 +310,31 @@ export function isTerminalAgentStatus(status: AgentStatus | number | undefined):
 /** Daemon emits `statusChange` with `newStatus=ACTIVE` when a prompt turn starts. */
 export function isAgentActiveStatus(status: AgentStatus | number | undefined): boolean {
   return status === AgentStatus.ACTIVE;
+}
+
+/**
+ * Route a late toolUse/toolResult to the flushed AGENT_REPLY instead of the
+ * live dock. Keeps the flushed-turn registry across follow-up ACTIVE so turn-1
+ * orphans still patch persist while turn-2 tools stay on the live stream.
+ */
+export function shouldPatchFlushedToolEvent(
+  sessionId: string,
+  actorId: string,
+  toolId: string,
+  liveEntry: AgentStreamEntry | undefined,
+): boolean {
+  const flushed = getFlushedTurn(sessionId, actorId);
+  if (!flushed) return false;
+  const trimmedToolId = toolId.trim();
+  if (!trimmedToolId) return false;
+
+  if (!liveEntry || !isStreamInterruptible(liveEntry)) {
+    return true;
+  }
+
+  if (liveEntry.streamId !== flushed.streamId) {
+    return !liveEntry.toolCalls.some((tc) => tc.id === trimmedToolId);
+  }
+
+  return false;
 }

--- a/packages/app/src/lib/session-export/index.ts
+++ b/packages/app/src/lib/session-export/index.ts
@@ -23,7 +23,7 @@ export function exportSessionFromRows(
   } = opts;
 
   const protos = messageRowsToProto(rows);
-  const sdkMessages = adaptTeamcluMessages(protos) ?? [];
+  const sdkMessages = adaptTeamcluMessages(protos, { forceFull: true }) ?? [];
 
   let messages = sdkMessages
     .filter((msg) => includeSystem || msg.role !== "system")

--- a/packages/app/src/lib/streaming-persist.ts
+++ b/packages/app/src/lib/streaming-persist.ts
@@ -21,6 +21,8 @@ import { snapshotSubagentEntry } from "@/lib/subagent-snapshot";
 import { extractTaskChildBinding, isTaskToolCall } from "@/lib/teamclu/subagent-acp-binding";
 import { useSessionMessageStore } from "@/stores/session-message-store";
 import { getFlushedTurn } from "@/lib/flushed-turn-registry";
+import { toolUseArguments } from "@/stores/v2-stream-parts";
+import type { ToolCallContentBlock } from "@/components/chat/tool-calls/tool-call-content";
 
 /** Snapshot live transcript parts — the only canonical source for parts_json. */
 export function snapshotTranscriptParts(
@@ -257,6 +259,84 @@ function withPatchedToolResult(
     return { ...part, toolCall };
   });
   return matched ? next : null;
+}
+
+/**
+ * Append a late toolUse onto the already-flushed AGENT_REPLY in the message
+ * store. Returns true when a new tool-call part was added.
+ */
+export async function patchPersistedToolUse(args: {
+  sessionId: string;
+  actorId: string;
+  toolId: string;
+  toolName: string;
+  description: string;
+  params: Record<string, string>;
+  toolKind?: string;
+  content?: ToolCallContentBlock[];
+  locations?: Array<{ path: string; line?: number }>;
+  acpStatus?: string;
+  rawInput?: unknown;
+}): Promise<boolean> {
+  const flushed = getFlushedTurn(args.sessionId, args.actorId);
+  if (!flushed) return false;
+
+  const toolId = args.toolId.trim();
+  if (!toolId) return false;
+
+  const messages = useSessionMessageStore.getState().messages[args.sessionId] ?? [];
+  const message = messages.find((m) => m.messageId === flushed.messageId);
+  if (!message) return false;
+
+  const parts = parsePartsJson(messagePartsJson(message));
+  if (parts.some((part) => part.type === "tool-call" && part.toolCall?.id === toolId)) {
+    return false;
+  }
+
+  const newToolCall: ToolCall = {
+    id: toolId,
+    name: args.toolName || "unknown",
+    toolKind: args.toolKind || undefined,
+    acpStatus: args.acpStatus,
+    content: args.content,
+    locations: args.locations,
+    rawInput: args.rawInput,
+    status: "calling",
+    arguments: toolUseArguments(args.params, args.description),
+    startTime: new Date(),
+  };
+  const nextParts: MessagePart[] = [
+    ...parts,
+    {
+      id: `stream:tool:${toolId}`,
+      type: "tool-call",
+      toolCallId: toolId,
+      toolCall: newToolCall,
+    },
+  ];
+
+  const partsJson = JSON.stringify(nextParts);
+  let enrichedPartsJson = partsJson;
+  try {
+    enrichedPartsJson = await setMessageParts(
+      flushed.messageId,
+      partsJson,
+      useWorkspaceStore.getState().workspacePath,
+    );
+  } catch (e) {
+    console.warn("[streaming-persist] late toolUse parts_json write failed:", e);
+  }
+
+  const updated = Object.assign(
+    Object.create(Object.getPrototypeOf(message)),
+    message,
+    { partsJson: enrichedPartsJson },
+  ) as TeamcluMessage;
+
+  useSessionMessageStore
+    .getState()
+    .replaceTurnAgentRepliesInStore(args.sessionId, updated);
+  return true;
 }
 
 /**

--- a/packages/app/src/lib/v2-message-adapter.ts
+++ b/packages/app/src/lib/v2-message-adapter.ts
@@ -8,6 +8,7 @@
 // tool_result row, one or more agent_reply rows — all sharing a
 // turn_id) renders as a single coherent agent bubble.
 
+import { splitAssistantProcessAndFinalParts } from "@/lib/agent-reply-transcript";
 import type { Message as TeamcluMessage } from "@/lib/proto/teamclu_pb";
 import { MessageKind } from "@/lib/proto/teamclu_pb";
 import type {
@@ -311,7 +312,7 @@ function firstNonEmptyReplyToMessageId(group: TeamcluMessage[]): string | undefi
  * messages into one SdkMessage. Thinking → reasoning part. Tool calls →
  * toolCalls[] matched with results by metadata.tool_id. Replies →
  * concatenated content. */
-function buildTurnSdkMessage(group: TeamcluMessage[]): SdkMessage {
+export function buildFullTurnSdkMessageFromGroup(group: TeamcluMessage[]): SdkMessage {
   const thinking = group.filter((m) => m.kind === MessageKind.AGENT_THINKING);
   const toolCallProtos = group.filter((m) => m.kind === MessageKind.AGENT_TOOL_CALL);
   const toolResultProtos = group.filter((m) => m.kind === MessageKind.AGENT_TOOL_RESULT);
@@ -552,7 +553,196 @@ function buildTurnSdkMessage(group: TeamcluMessage[]): SdkMessage {
   };
 }
 
-function groupByTurn(msgs: TeamcluMessage[]): SdkMessage[] {
+function countTurnProcessMeta(group: TeamcluMessage[]): {
+  toolCount: number;
+  hasThinking: boolean;
+} {
+  const toolCount = group.filter((m) => m.kind === MessageKind.AGENT_TOOL_CALL).length;
+  const hasThinking = group.some(
+    (m) => m.kind === MessageKind.AGENT_THINKING && (m.content ?? "").trim().length > 0,
+  );
+  return { toolCount, hasThinking };
+}
+
+function isTurnCompleteForProcessDefer(group: TeamcluMessage[]): boolean {
+  const replies = group.filter((m) => m.kind === MessageKind.AGENT_REPLY);
+  if (replies.some((r) => partsJson(r).trim())) return true;
+
+  const toolCalls = group.filter((m) => m.kind === MessageKind.AGENT_TOOL_CALL);
+  if (toolCalls.length === 0) return true;
+
+  const results = group.filter((m) => m.kind === MessageKind.AGENT_TOOL_RESULT);
+  if (results.length >= toolCalls.length) return true;
+
+  for (const tc of toolCalls) {
+    const md = parseMetadata(tc);
+    const status = String(md.status ?? "").toLowerCase();
+    if (status === "pending" || status === "in_progress" || status === "in progress") {
+      return false;
+    }
+  }
+
+  return replies.some((r) => displayContentForReply(r).trim().length > 0);
+}
+
+function shouldDeferProcessParts(group: TeamcluMessage[]): boolean {
+  const meta = countTurnProcessMeta(group);
+  if (meta.toolCount === 0 && !meta.hasThinking) return false;
+  if (!isTurnCompleteForProcessDefer(group)) return false;
+
+  const finalParts = extractFinalTextPartsForDeferredTurn(group);
+  const hasFinalText = finalParts.some((p) => (p.text || p.content || "").trim());
+  if (!hasFinalText) return false;
+
+  return true;
+}
+
+function extractFinalTextPartsForDeferredTurn(group: TeamcluMessage[]): MessagePart[] {
+  const replies = group.filter((m) => m.kind === MessageKind.AGENT_REPLY);
+  const uniqueReplies: TeamcluMessage[] = [];
+  const uniqueReplyIds = new Set<string>();
+  const replyIndexByKey = new Map<string, number>();
+  for (const reply of replies) {
+    const key = `${reply.content}\u0000${reply.model}`;
+    const existingIndex = replyIndexByKey.get(key);
+    if (existingIndex !== undefined) {
+      const existing = uniqueReplies[existingIndex];
+      if (!partsJson(existing) && partsJson(reply)) {
+        uniqueReplyIds.delete(existing.messageId);
+        uniqueReplies[existingIndex] = reply;
+        uniqueReplyIds.add(reply.messageId);
+      }
+      continue;
+    }
+    replyIndexByKey.set(key, uniqueReplies.length);
+    uniqueReplies.push(reply);
+    uniqueReplyIds.add(reply.messageId);
+  }
+
+  const repliesWithParts = uniqueReplies.filter((reply) => partsJson(reply).trim());
+  const mergedPersistedParts =
+    repliesWithParts.length > 1
+      ? mergeTurnPartsFromReplies(repliesWithParts)
+      : repliesWithParts.length === 1
+        ? parsePartsJson(partsJson(repliesWithParts[0]!))
+        : [];
+
+  if (mergedPersistedParts.length > 0) {
+    const renderable = mergedPersistedParts.filter(
+      (p) =>
+        (p.type === "reasoning" && Boolean(p.text || p.content)) ||
+        (p.type === "text" && Boolean(p.text || p.content)) ||
+        (p.type === "tool-call" && Boolean(p.toolCall)),
+    );
+    const { finalTextParts } = splitAssistantProcessAndFinalParts(renderable);
+    if (finalTextParts.length > 0) return finalTextParts;
+  }
+
+  const replyText = uniqueReplies
+    .map((r) => displayContentForReply(r))
+    .filter((text) => text.trim().length > 0)
+    .join("\n\n");
+  const groupId =
+    uniqueReplies.find((r) => displayContentForReply(r).trim())?.messageId ??
+    uniqueReplies[0]?.messageId ??
+    group[0].messageId;
+
+  if (!replyText.trim()) return [];
+  return [
+    {
+      id: `${groupId}-final`,
+      type: "text",
+      text: replyText,
+      content: replyText,
+    },
+  ];
+}
+
+function buildDeferredProcessTurnSdkMessage(group: TeamcluMessage[]): SdkMessage {
+  const replies = group.filter((m) => m.kind === MessageKind.AGENT_REPLY);
+  const uniqueReplies: TeamcluMessage[] = [];
+  const replyIndexByKey = new Map<string, number>();
+  for (const reply of replies) {
+    const key = `${reply.content}\u0000${reply.model}`;
+    const existingIndex = replyIndexByKey.get(key);
+    if (existingIndex !== undefined) {
+      const existing = uniqueReplies[existingIndex];
+      if (!partsJson(existing) && partsJson(reply)) {
+        uniqueReplies[existingIndex] = reply;
+      }
+      continue;
+    }
+    replyIndexByKey.set(key, uniqueReplies.length);
+    uniqueReplies.push(reply);
+  }
+
+  const turnStatus = turnStatusFromReplies(uniqueReplies);
+  const finalParts = extractFinalTextPartsForDeferredTurn(group);
+  const finalText = finalParts
+    .map((p) => p.text || p.content || "")
+    .filter(Boolean)
+    .join("\n\n");
+  const groupId =
+    uniqueReplies.find((r) => displayContentForReply(r).trim())?.messageId ??
+    uniqueReplies[0]?.messageId ??
+    group[0].messageId;
+  const modelID =
+    uniqueReplies[uniqueReplies.length - 1]?.model ||
+    group.find((m) => m.model)?.model ||
+    undefined;
+  const turnId = group[0]?.turnId?.trim() || undefined;
+  const processMeta = countTurnProcessMeta(group);
+
+  return {
+    id: groupId,
+    sessionId: group[0].sessionId,
+    senderActorId: group[0].senderActorId,
+    role: "assistant",
+    content: finalText,
+    modelID,
+    parts: finalParts,
+    toolCalls: [],
+    replyToMessageId: firstNonEmptyReplyToMessageId(group),
+    turnId,
+    turnStatus,
+    timestamp: new Date(Number(group[0].createdAt) * 1000),
+    processDeferred: true,
+    processMeta,
+    lazyProcessRef: turnId
+      ? {
+          sessionId: group[0].sessionId,
+          turnId,
+          senderActorId: group[0].senderActorId,
+        }
+      : undefined,
+  };
+}
+
+type BuildTurnSdkMessageOptions = {
+  /** Omit process parts for completed historical turns (chat list). */
+  deferProcess?: boolean;
+  /** Always build full process (export). Overrides deferProcess. */
+  forceFull?: boolean;
+};
+
+function buildTurnSdkMessage(
+  group: TeamcluMessage[],
+  opts?: BuildTurnSdkMessageOptions,
+): SdkMessage {
+  if (
+    !opts?.forceFull &&
+    opts?.deferProcess &&
+    shouldDeferProcessParts(group)
+  ) {
+    return buildDeferredProcessTurnSdkMessage(group);
+  }
+  return buildFullTurnSdkMessageFromGroup(group);
+}
+
+function groupByTurn(
+  msgs: TeamcluMessage[],
+  opts?: BuildTurnSdkMessageOptions,
+): SdkMessage[] {
   const out: SdkMessage[] = [];
   let i = 0;
   while (i < msgs.length) {
@@ -574,17 +764,18 @@ function groupByTurn(msgs: TeamcluMessage[]): SdkMessage[] {
       group.push(msgs[i]);
       i++;
     }
-    out.push(buildTurnSdkMessage(group));
+    out.push(buildTurnSdkMessage(group, opts));
   }
   return out;
 }
 
+export type AdaptTeamcluMessagesOptions = BuildTurnSdkMessageOptions;
+
 export function adaptTeamcluMessages(
   msgs: TeamcluMessage[] | undefined,
+  opts?: AdaptTeamcluMessagesOptions,
 ): SdkMessage[] | undefined {
   if (!msgs) return undefined;
-  // Sort defensively — caller should already merge in createdAt order,
-  // but local cache + supabase merge can interleave at the same epoch.
   const sorted = [...msgs].sort(compareTeamcluMessages);
-  return groupByTurn(sorted);
+  return groupByTurn(sorted, opts);
 }

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -179,6 +179,16 @@ export interface Message {
   turnId?: string | null;
   /** Daemon AGENT_REPLY metadata.turn_status — e.g. user abort. */
   turnStatus?: "interrupted" | null;
+  /** Historical turn: process parts omitted until user expands collapsible. */
+  processDeferred?: boolean;
+  /** Lightweight process summary while {@link processDeferred} is true. */
+  processMeta?: { toolCount: number; hasThinking: boolean };
+  /** Locates proto rows for on-demand process hydration. */
+  lazyProcessRef?: {
+    sessionId: string;
+    turnId: string;
+    senderActorId: string;
+  };
 }
 
 export interface PlanEntry {

--- a/scripts/repro-mid-turn-followup.sh
+++ b/scripts/repro-mid-turn-followup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Reproduce mid-turn follow-up race against a running local amuxd.
+#
+# Usage:
+#   scripts/repro-mid-turn-followup.sh [--session-id <uuid>]
+#
+# Requires ~/.amuxd/amuxd.http.{port,token} and an engaged opencode runtime
+# for the target session (TeamClu desktop open on that session works).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SESSION_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --session-id)
+      SESSION_ID="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "$SESSION_ID" ]]; then
+  export REPRO_SESSION_ID="$SESSION_ID"
+fi
+
+export REPRO_MID_TURN_LIVE=1
+
+echo "==> Client-side simulation (always)"
+pnpm --filter @teamclu/app exec vitest run src/lib/__tests__/mid-turn-followup-repro.test.ts -t "client store simulation"
+
+echo ""
+echo "==> Live daemon repro (needs mid-turn runtime on session ${REPRO_SESSION_ID:-active-session-id})"
+pnpm --filter @teamclu/app exec vitest run src/lib/__tests__/mid-turn-followup-repro.test.ts -t "live daemon"
+
+echo ""
+echo "==> Daemon unit: double prompt clears tools_in_flight (cargo test)"
+cargo test -p amuxd second_prompt_while_turn_active -- --nocapture


### PR DESCRIPTION
## Summary

- **A — Steady-state session switch:** reuse `activeMessages` when `displaySessionId === activeSessionId`; only adapt the fading-out session during the 150ms fade transition.
- **B — Historical process lazy load:** completed agent turns adapt with `deferProcess: true` (final text + summary only); expand hydrates thinking/tool parts from proto with cache; export uses `forceFull: true`.
- **C — Reply-to scroll:** container-local scrolling via `[data-chat-messages]`; MessageList expands visible window / virtualizer when target is off-screen.

## Test plan

- [x] `pnpm typecheck`
- [x] `vitest`: v2-message-adapter, chat-scroll-to-message, lazy-process-parts (39 tests)
- [ ] Manual: long session A↔B switch — no duplicate adapt spike in steady state
- [ ] Manual: history turn with 20+ tools — default collapsed, expand shows full process
- [ ] Manual: streaming turn — process still live; export JSON still has full parts
- [ ] Manual: reply-to jump with sticky header — target visible below header


Made with [Cursor](https://cursor.com)