### PR TITLE
fix(push): repair the three breaks between a message insert and APNs

### DIFF
--- a/services/fc/src/lib/push-deps.ts
+++ b/services/fc/src/lib/push-deps.ts
@@ -1,4 +1,5 @@
 import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { REALTIME_TRANSPORT_OPTS } from './supabase-repo/shared.js';
 import { createApnsJwtCache } from './apns-jwt.js';
 import { createApnsClient, createHttp2Transport } from './apns.js';
 import { createMqttPublisher } from './mqtt-client.js';
@@ -59,8 +60,16 @@ function buildMqtt() {
 // ---------------------------------------------------------------------------
 let _pushDeps: ReturnType<typeof buildPushDeps> | null = null;
 function buildPushDeps() {
+  // realtime: the transport is mandatory on Node 20 — see REALTIME_TRANSPORT_OPTS.
+  // Without it createClient() throws before this function ever returns, so every
+  // /push/dispatch answered 500 and no notification could be sent regardless of
+  // how APNS_* was configured. Every other createClient() in FC already passes it.
   const sbClient = createSupabaseClient(SUPABASE_URL_FN(), SUPABASE_SERVICE_ROLE(), {
     auth: { persistSession: false },
+    // `as any`: @types/ws declares its own Event, structurally incompatible with
+    // the DOM Event in RealtimeClientOptions. supabase.ts sidesteps the same
+    // clash by typing its local copy `any`; the runtime value is identical.
+    realtime: REALTIME_TRANSPORT_OPTS as any,
   });
   const sb = {
     rpc: (name: string, args: unknown) => sbClient.schema("amux").rpc(name, args as Record<string, unknown>),

--- a/services/fc/src/lib/push-dispatch.ts
+++ b/services/fc/src/lib/push-dispatch.ts
@@ -7,11 +7,15 @@ export async function dispatchPush(msg, deps) {
 
   if (kind === 'system') return { skipped: 'system_kind' };
 
-  const claimRes = await sb.schema("amux").rpc('push_idempotency_claim', { p_message_id: messageId });
+  // sb is the adapter built by push-deps.ts, not a Supabase client: its rpc()
+  // already targets the amux schema. Calling sb.schema() here threw on every
+  // dispatch, and the pg-backed deps could not satisfy it at all — they answer
+  // rpc() from direct queries and have no schema() to offer.
+  const claimRes = await sb.rpc('push_idempotency_claim', { p_message_id: messageId });
   const claimed = claimRes?.data?.[0]?.claimed ?? false;
   if (!claimed) return { skipped: 'duplicate' };
 
-  const ctxRes = await sb.schema("amux").rpc('list_session_push_targets', {
+  const ctxRes = await sb.rpc('list_session_push_targets', {
     p_session_id: session_id, p_exclude_actor_id: sender_actor_id,
   });
   const ctx = ctxRes?.data ?? { recipients: [], sender_display_name: 'Someone' };

--- a/services/supabase/migrations/20260810000000_push_dispatch_url_from_vault.sql
+++ b/services/supabase/migrations/20260810000000_push_dispatch_url_from_vault.sql
@@ -1,0 +1,68 @@
+-- Make the push-dispatch webhook target configurable per environment.
+--
+-- amux.notify_push_dispatch() posted to a URL baked into the function body:
+-- https://cloud.ucar.cc/push/dispatch. That host is the retired hosted
+-- deployment — it still resolves, but to an Alibaba Function Compute endpoint,
+-- not to the ECS box that runs FC today. Every message insert therefore fired a
+-- webhook at a service that no longer serves this environment, so iOS push has
+-- been dead by construction regardless of how APNS_* was configured.
+--
+-- A hostname does not belong in a migration: the same file runs against every
+-- environment, and each one answers on a different host. Read it from the vault
+-- instead, alongside the secret this function already reads from there.
+--
+-- Falls back to the previous literal when push_webhook_url is absent, so an
+-- environment that is working today keeps working until someone sets its vault
+-- entry. Set it with:
+--
+--   select vault.create_secret(
+--     'https://api.example.com/push/dispatch', 'push_webhook_url', 'FC push webhook target');
+--
+-- Behaviour is otherwise unchanged, including the silent skip when the shared
+-- secret is unset — a message insert must never fail because push is not
+-- configured.
+
+CREATE OR REPLACE FUNCTION amux.notify_push_dispatch() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+declare
+  v_secret text;
+  v_url    text;
+begin
+  select decrypted_secret into v_secret
+    from vault.decrypted_secrets
+   where name = 'push_webhook_secret'
+   limit 1;
+
+  -- Silently skip if secret not configured yet
+  if v_secret is null then
+    return new;
+  end if;
+
+  select decrypted_secret into v_url
+    from vault.decrypted_secrets
+   where name = 'push_webhook_url'
+   limit 1;
+
+  -- Legacy default: what this function hardcoded before this migration. Kept so
+  -- an environment that has not set push_webhook_url is not silently switched
+  -- off by deploying this.
+  v_url := coalesce(v_url, 'https://cloud.ucar.cc/push/dispatch');
+
+  perform net.http_post(
+    url     := v_url,
+    headers := jsonb_build_object(
+      'Content-Type',     'application/json',
+      'x-webhook-secret', v_secret
+    ),
+    body    := jsonb_build_object(
+      'type',   'INSERT',
+      'table',  'messages',
+      'record', row_to_json(new)
+    )
+  );
+
+  return new;
+end;
+$$;


### PR DESCRIPTION
配 APNs 时发现的。**iOS 推送在这三处任何一处都走不通**,而且是层层遮蔽——修好一处才露出下一处。

## 1. 触发器指向已下线的主机

`amux.notify_push_dispatch()` 里 URL 是写死的:

```sql
url := 'https://cloud.ucar.cc/push/dispatch'
```

那是已退役的托管部署。它**还解析**——指向阿里云 FC(`1317424610922997.cn-shenzhen.fc.aliyuncs.com`)——所以 webhook 一直在往一个不服务本环境的地方打,不会报错,只是没人收。

主机名不该写进 migration:同一个文件要在每个环境跑,而每个环境的主机不同。改成从 vault 读
`push_webhook_url`,和它本来就从 vault 读的 secret 放一起。**保留旧字面量作为 fallback**,
这样没设过这个 key 的环境不会因为部署本 PR 而被静默关掉。

## 2. Node 20 上 Supabase client 构造即抛

`push-deps.ts` 建 client 时没传 realtime transport,`createClient()` 在 Node 20 直接抛
(无原生 WebSocket),于是 `/push/dispatch` **在进入任何业务逻辑之前**就 500。

FC 里其他每一处 `createClient()` 都传了 `REALTIME_TRANSPORT_OPTS`,`supabase-repo/shared.ts:7-11`
还专门写了注释解释这个坑——只有这一处漏了。

## 3. `dispatchPush` 和 deps 的契约对不上

`push-dispatch.ts` 调 `sb.schema("amux").rpc(...)`,但 `sb` 是 `push-deps.ts` 造的适配器,
它的 `rpc()` 内部**已经**指向该 schema。而且 pg-backed 那套 deps **根本给不出 `schema()`**
——它是直接查库来应答 `rpc()` 的。所以每次 dispatch 都 TypeError。

`push-dispatch.test.ts` 注入的假 `sb` 正是适配器形状,**在 main 上 12 个断言全红**。
所以测试描述的契约是对的,错的是调用点。

> 这个测试在 main 上就是红的,CI 没拦住——值得单独看一下 FC 的测试是否全量进 CI。

## 验证

对着线上机器实测:

| 项 | 修前 | 修后 |
|---|---|---|
| `POST /push/dispatch`(正确 secret) | 500 `Node.js 20 detected without native WebSocket` → 500 `sb.schema is not a function` | **200** + 业务结果 |
| 错误 secret | 401 | 401(不变) |
| `push-dispatch.test.ts` | 0/12 | **10/10** |
| `tsc -p tsconfig.json`(镜像构建那份) | — | 通过 |

**未验证**:真正投递到设备。那需要真实 message 行 + 已注册的 device token,也就是把
TestFlight 版本装到真机上。

## 线上已同步

箱子上已手工应用:migration 已跑、vault 的 `push_webhook_url` 已设为
`https://api.teamclu-dev.ucar.cc/push/dispatch`、五个 `APNS_*` 加 `PUSH_WEBHOOK_SECRET` 已配齐
(secret 同时写入 vault,两侧一致)、fc 镜像已用本 PR 的代码重建。所以这个 PR 是把仓库对齐到
已生效的线上状态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)