### PR TITLE
feat(introspect): add archive_session MCP tool

### DIFF
--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -362,6 +362,23 @@ fn tool_definitions() -> Value {
                     }
                 }
             }
+        },
+        {
+            "name": "archive_session",
+            "description": "Archive a TeamClu cloud session (soft-hide from the active session list). Requires the desktop app to be running and the user to be signed in. When session_id is omitted, archives the current TeamClu session (TEAMCLU_SESSION_ID env or workspace .teamclu/active-session-id).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Cloud session UUID to archive. Optional — omit to archive the current TeamClu session."
+                    },
+                    "archived_at": {
+                        "type": "string",
+                        "description": "Optional ISO-8601 timestamp for archivedAt. Defaults to now."
+                    }
+                }
+            }
         }
     ])
 }
@@ -532,6 +549,15 @@ async fn handle_request(req: &Value, workspace: &str, api_port: u16) -> Option<V
                     }
                     Err(e) => tool_err(&e),
                 },
+                "archive_session" => {
+                    match session::archive(workspace, api_port, &arguments).await {
+                        Ok(v) => {
+                            let text = serde_json::to_string_pretty(&v).unwrap_or_default();
+                            tool_ok(&text)
+                        }
+                        Err(e) => tool_err(&e),
+                    }
+                }
                 unknown => tool_err(&format!("Unknown tool: {unknown}")),
             };
 

--- a/apps/desktop/crates/teamclu-introspect/src/session.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/session.rs
@@ -93,6 +93,39 @@ pub fn handle(workspace: &str, arguments: &Value) -> Result<Value, String> {
     }))
 }
 
+/// Archive a cloud session via the desktop introspect API → Cloud API PATCH.
+pub async fn archive(workspace: &str, api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let session_id = resolve_session_id(workspace, arguments)?;
+    let mut body = json!({ "session_id": session_id });
+    if let Some(at) = arguments
+        .get("archived_at")
+        .or_else(|| arguments.get("archivedAt"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        body["archivedAt"] = json!(at);
+    }
+
+    let url = format!("http://127.0.0.1:{api_port}/session-archive");
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}. Is the TeamClu app running?"))?;
+
+    if !resp.status().is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("API error: {text}"));
+    }
+
+    resp.json::<Value>()
+        .await
+        .map_err(|e| format!("Failed to parse response: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -163,5 +196,13 @@ mod tests {
             Some(v) => std::env::set_var(TEAMCLU_SESSION_ID_ENV, v),
             None => std::env::remove_var(TEAMCLU_SESSION_ID_ENV),
         }
+    }
+
+    #[tokio::test]
+    async fn archive_rejects_invalid_uuid_without_network() {
+        let err = archive("/ws", 13144, &json!({ "session_id": "not-a-uuid" }))
+            .await
+            .unwrap_err();
+        assert!(err.contains("Invalid session_id"));
     }
 }

--- a/apps/desktop/src/commands/introspect_api.rs
+++ b/apps/desktop/src/commands/introspect_api.rs
@@ -12,6 +12,7 @@
 //   POST /env-var-delete    — delete an env var (`scope`: personal | team)
 //   POST /mcp-get           — fetch merged workspace MCP map (daemon)
 //   POST /mcp-put           — replace workspace MCP map (daemon)
+//   POST /session-archive   — archive a cloud session (PATCH archivedAt)
 //   POST /session-export    — export session messages as opencode-compatible JSON
 //
 // Uses raw TCP + manual HTTP parsing to stay minimal (no axum state needed).
@@ -105,6 +106,9 @@ pub async fn start_introspect_api(app: AppHandle) -> anyhow::Result<()> {
                 ("POST", "/channel-set") => handle_channel_set(&app_clone, body_bytes).await,
                 ("POST", "/mcp-get") => handle_mcp_get(&app_clone, body_bytes).await,
                 ("POST", "/mcp-put") => handle_mcp_put(&app_clone, body_bytes).await,
+                ("POST", "/session-archive") => {
+                    handle_session_archive(&app_clone, body_bytes).await
+                }
                 ("POST", "/git-credential-get") => {
                     handle_git_credential_get(&app_clone, body_bytes).await
                 }
@@ -688,6 +692,93 @@ async fn handle_mcp_put(app: &AppHandle, body: &[u8]) -> Result<String, String> 
     }
     let result = super::daemon_http::put_mcp_via_daemon(&workspace, servers).await?;
     serde_json::to_string(&result).map_err(|e| format!("Serialization error: {e}"))
+}
+
+/// Archive a cloud session via `PATCH /v1/sessions/:id` with `{ archivedAt }`.
+///
+/// Body: `{ "session_id": "...", "archivedAt"?: ISO, "accessToken"?: "...", "cloudApiUrl"?: "..." }`.
+/// Credentials fall back to the in-memory introspect auth bridge (pushed by the
+/// frontend on sign-in / token refresh).
+async fn handle_session_archive(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?;
+
+    let session_id = v
+        .get("session_id")
+        .or_else(|| v.get("sessionId"))
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or("Missing field: session_id")?;
+
+    let archived_at = v
+        .get("archivedAt")
+        .or_else(|| v.get("archived_at"))
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+
+    let body_token = v
+        .get("accessToken")
+        .or_else(|| v.get("access_token"))
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let body_url = v
+        .get("cloudApiUrl")
+        .or_else(|| v.get("cloud_api_url"))
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.trim_end_matches('/').to_string());
+
+    let (access_token, cloud_api_url) = match (body_token, body_url) {
+        (Some(token), Some(url)) => (token, url),
+        (Some(token), None) => {
+            let url = super::oss_sync::get_fc_endpoint("");
+            (token, url)
+        }
+        (None, url_opt) => {
+            let bridge = app.state::<super::introspect_auth::IntrospectAuthState>();
+            let (token, bridged_url) = bridge.get().ok_or_else(|| {
+                "Not signed in: open TeamClu and sign in so archive_session can call the Cloud API."
+                    .to_string()
+            })?;
+            (token, url_opt.unwrap_or(bridged_url))
+        }
+    };
+
+    let endpoint = super::oss_sync::resolve_runtime_fc_endpoint(&cloud_api_url)?;
+    let fc = super::oss_sync::fc_client::FcClient::new(endpoint, access_token);
+    let path = format!("/v1/sessions/{}", session_id);
+    let patch = serde_json::json!({ "archivedAt": archived_at });
+    fc.patch_json(&path, &patch)
+        .await
+        .map_err(|e| format!("Cloud API archive failed: {e}"))?;
+
+    // Best-effort local cache cleanup so the desktop list doesn't resurrect the row.
+    let cache = app.state::<crate::local_cache::commands::LocalCacheState>();
+    if let Err(e) = crate::local_cache::commands::soft_delete_session_best_effort(
+        &cache,
+        session_id,
+        &archived_at,
+    )
+    .await
+    {
+        eprintln!(
+            "[IntrospectAPI] local cache soft-delete after archive failed: {e}"
+        );
+    }
+
+    let payload = serde_json::json!({
+        "ok": true,
+        "session_id": session_id,
+        "archivedAt": archived_at,
+    });
+    serde_json::to_string(&payload).map_err(|e| format!("Serialization error: {e}"))
 }
 
 /// Fetch a stored Git credential by ref. Body: `{"workspace_path": "...", "credential_ref": "..."}`.

--- a/apps/desktop/src/commands/introspect_auth.rs
+++ b/apps/desktop/src/commands/introspect_auth.rs
@@ -1,0 +1,72 @@
+//! Short-lived Cloud API credentials for the introspect loopback API.
+//!
+//! Design-2 keeps the user JWT in the renderer. Background MCP tools (e.g.
+//! `archive_session`) still need a bearer to call `PATCH /v1/sessions/:id`, so
+//! the frontend pushes a fresh token into this in-memory bridge on auth
+//! changes. Nothing is written to disk.
+
+use std::sync::Mutex;
+
+use tauri::State;
+
+#[derive(Default)]
+pub struct IntrospectAuthState {
+    inner: Mutex<IntrospectAuthSnapshot>,
+}
+
+#[derive(Default, Clone)]
+struct IntrospectAuthSnapshot {
+    access_token: Option<String>,
+    cloud_api_url: Option<String>,
+}
+
+impl IntrospectAuthState {
+    pub fn set(&self, access_token: Option<String>, cloud_api_url: Option<String>) {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.access_token = access_token
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty());
+        guard.cloud_api_url = cloud_api_url
+            .map(|u| u.trim().trim_end_matches('/').to_string())
+            .filter(|u| !u.is_empty());
+    }
+
+    pub fn clear(&self) {
+        self.set(None, None);
+    }
+
+    pub fn get(&self) -> Option<(String, String)> {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        match (&guard.access_token, &guard.cloud_api_url) {
+            (Some(token), Some(url)) => Some((token.clone(), url.clone())),
+            _ => None,
+        }
+    }
+}
+
+/// Push the signed-in user's Cloud API credentials for introspect MCP tools.
+#[tauri::command]
+pub fn set_introspect_auth(
+    state: State<'_, IntrospectAuthState>,
+    access_token: Option<String>,
+    cloud_api_url: Option<String>,
+) -> Result<(), String> {
+    if access_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .is_none()
+    {
+        state.clear();
+        return Ok(());
+    }
+    state.set(access_token, cloud_api_url);
+    Ok(())
+}
+
+/// Drop credentials (sign-out).
+#[tauri::command]
+pub fn clear_introspect_auth(state: State<'_, IntrospectAuthState>) -> Result<(), String> {
+    state.clear();
+    Ok(())
+}

--- a/apps/desktop/src/commands/mod.rs
+++ b/apps/desktop/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod filewatcher;
 pub mod gateway;
 pub mod git;
 pub mod introspect_api;
+pub mod introspect_auth;
 pub mod knowledge;
 pub mod local_secret_store;
 pub mod local_stats;

--- a/apps/desktop/src/commands/oss_sync/fc_client.rs
+++ b/apps/desktop/src/commands/oss_sync/fc_client.rs
@@ -167,6 +167,21 @@ impl FcClient {
         map_fc_response(resp).await
     }
 
+    /// Generic PATCH helper. Returns raw JSON value on 2xx (empty body → null).
+    pub async fn patch_json(&self, path: &str, body: &Value) -> Result<Value, SyncError> {
+        let url = format!("{}{}", self.base_url, path);
+        let resp = self
+            .client
+            .patch(&url)
+            .header("Authorization", format!("Bearer {}", self.jwt))
+            .header("Content-Type", "application/json")
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| SyncError::Network(e.to_string()))?;
+        map_fc_response(resp).await
+    }
+
     /// Internal POST helper with JWT injection and error mapping.
     async fn post<T: serde::de::DeserializeOwned>(
         &self,

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -351,6 +351,7 @@ pub fn run() {
         })
         .manage(commands::window_chrome::MainWindowState::default())
         .manage(commands::shared_secrets::SharedSecretsState::default())
+        .manage(commands::introspect_auth::IntrospectAuthState::default())
         .manage(commands::oauth_loopback::OAuthLoopbackState::default())
         .manage::<crate::mqtt::MqttBus>(std::sync::Arc::new(crate::mqtt::MqttBusInner::new()))
         .manage(std::sync::Arc::new(crate::terminal::Registry::new()))
@@ -363,6 +364,8 @@ pub fn run() {
             commands::daemon_http::get_daemon_team_id,
             commands::daemon_http::list_local_daemon_workspaces,
             commands::daemon_http::register_daemon_workspace,
+            commands::introspect_auth::set_introspect_auth,
+            commands::introspect_auth::clear_introspect_auth,
             commands::show_in_folder,
             commands::acp_debug_log::acp_debug_append_log,
             commands::acp_debug_log::acp_debug_log_directory,

--- a/apps/desktop/src/local_cache/commands.rs
+++ b/apps/desktop/src/local_cache/commands.rs
@@ -220,6 +220,17 @@ pub async fn local_cache_session_soft_delete(
     db.session_soft_delete(&id, &deleted_at).await
 }
 
+/// Soft-delete without the current-team gate — used by introspect after a
+/// successful Cloud API archive. Missing rows are fine (store update is a no-op).
+pub async fn soft_delete_session_best_effort(
+    state: &LocalCacheState,
+    id: &str,
+    deleted_at: &str,
+) -> Result<(), String> {
+    let db = get_db(state).await?;
+    db.session_soft_delete(id, deleted_at).await
+}
+
 // ─── session_workspace commands ───────────────────────────────────────────
 
 #[tauri::command]

--- a/packages/app/src/lib/introspect-auth-bridge.ts
+++ b/packages/app/src/lib/introspect-auth-bridge.ts
@@ -1,0 +1,45 @@
+/**
+ * Push the signed-in user's Cloud API credentials into the desktop Rust
+ * introspect auth bridge so MCP tools (e.g. archive_session) can call /v1.
+ *
+ * No-op outside Tauri. Failures are swallowed — archive will surface a clear
+ * "not signed in" error if the bridge is empty.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { getFreshAccessToken } from "@/lib/auth/session-store";
+import { getEffectiveServerConfigSync } from "@/lib/server-config";
+import { isTauri } from "@/lib/utils";
+
+export async function syncIntrospectAuthBridge(
+  session: { accessToken?: string | null } | null | undefined,
+): Promise<void> {
+  if (!isTauri()) return;
+  try {
+    if (!session?.accessToken) {
+      await invoke("clear_introspect_auth");
+      return;
+    }
+    const accessToken = await getFreshAccessToken().catch(() => session.accessToken);
+    if (!accessToken) {
+      await invoke("clear_introspect_auth");
+      return;
+    }
+    const cloudApiUrl = getEffectiveServerConfigSync().cloudApiUrl;
+    await invoke("set_introspect_auth", {
+      accessToken,
+      cloudApiUrl: cloudApiUrl ?? null,
+    });
+  } catch (error) {
+    console.warn("[introspect-auth] sync failed:", error);
+  }
+}
+
+export async function clearIntrospectAuthBridge(): Promise<void> {
+  if (!isTauri()) return;
+  try {
+    await invoke("clear_introspect_auth");
+  } catch (error) {
+    console.warn("[introspect-auth] clear failed:", error);
+  }
+}

--- a/packages/app/src/stores/auth-store.ts
+++ b/packages/app/src/stores/auth-store.ts
@@ -11,6 +11,10 @@ import type { AuthClaimResult, AuthSession, PendingInvite } from "@/lib/backend"
 import { accessTokenMatchesBackend } from "@/lib/auth/auth-client";
 import { CloudApiError } from "@/lib/backend/cloud-api/http";
 import { clearBootstrapAppliedFields, fetchAndApplyBootstrap } from "@/lib/bootstrap";
+import {
+  clearIntrospectAuthBridge,
+  syncIntrospectAuthBridge,
+} from "@/lib/introspect-auth-bridge";
 import { clearSessionFeatures } from "@/lib/remote-features";
 import { getEffectiveServerConfig } from "@/lib/server-config";
 import { markStartup } from "@/lib/startup-perf";
@@ -218,6 +222,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     if (session) {
       void fetchAndApplyBootstrap({ accessToken: session.accessToken });
     }
+    void syncIntrospectAuthBridge(session);
     // StrictMode double-invokes the effect that calls hydrate, and this
     // subscription outlives it. Drop the previous one first so a cold start
     // doesn't accumulate listeners that each re-run bootstrap on every auth
@@ -228,6 +233,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       if (session) {
         void fetchAndApplyBootstrap({ accessToken: session.accessToken });
       }
+      void syncIntrospectAuthBridge(session);
     });
   },
   sendOtp: async (email) => {
@@ -582,6 +588,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   signOut: async () => {
     await getBackend().auth.signOut();
     set({ session: null, authFlow: "idle", otpEmail: null, otpPhone: null, phoneMultiUsers: [], pendingPhoneOTPToken: "", upgradeEmail: null, pendingInvites: [] });
+    void clearIntrospectAuthBridge();
     // Reset the current team so the NEXT (e.g. anonymous) login doesn't inherit
     // the previous user's team. Without this the current-team store kept the old
     // team (its RLS-lag guard preserves it while the new user's team list is


### PR DESCRIPTION
## Summary
- Add `archive_session` to `teamclu-introspect` so agents can archive cloud sessions (defaults to the current session when `session_id` is omitted).
- Desktop loopback `POST /session-archive` calls Cloud API `PATCH /v1/sessions/:id` with `{ archivedAt }`, then best-effort soft-deletes the local cache row.
- Sync a short-lived user JWT into an in-memory introspect auth bridge on sign-in / token refresh (cleared on sign-out), so the MCP path does not need the agent to pass tokens.

## Test plan
- [ ] `cargo test -p teamclu-introspect --manifest-path apps/desktop/Cargo.toml`
- [ ] `pnpm tauri:dev -- --force-introspect`, sign in, restart an agent session
- [ ] Call `archive_session` with an explicit `session_id` and confirm the session leaves the active list
- [ ] Call `archive_session` with no `session_id` inside an active session and confirm it archives the current one
- [ ] Sign out and confirm `archive_session` fails with a signed-in / auth bridge error


Made with [Cursor](https://cursor.com)