### PR TITLE
fix(fc): write skill package blobs with the service-role client

### DIFF
--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -350,20 +350,21 @@ export function createSupabaseBusinessRepository(options) {
     return provisioning;
   }
 
-  async function shareModeServiceRpc(rpcName, args) {
-    let admin;
-    if (createServiceRoleClientOpt) {
-      admin = createServiceRoleClientOpt();
-    } else {
-      const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
-      if (!serviceKey) {
-        throw new Error(
-          "SUPABASE_SERVICE_ROLE_KEY is not configured on FC; cannot change team share mode",
-        );
-      }
-      const { createServiceRoleClient } = await import("./supabase.js");
-      admin = createServiceRoleClient();
+  // Escalation hatch for the handful of writes the caller's own token cannot
+  // make. `what` is spliced into the misconfiguration error so a missing key
+  // says which operation it broke.
+  async function serviceRoleClient(what) {
+    if (createServiceRoleClientOpt) return createServiceRoleClientOpt();
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+    if (!serviceKey) {
+      throw new Error(`SUPABASE_SERVICE_ROLE_KEY is not configured on FC; cannot ${what}`);
     }
+    const { createServiceRoleClient } = await import("./supabase.js");
+    return createServiceRoleClient();
+  }
+
+  async function shareModeServiceRpc(rpcName, args) {
+    const admin = await serviceRoleClient("change team share mode");
     const { data, error } = await admin.rpc(rpcName, args);
     if (error) {
       const code = error?.code || "";
@@ -3191,7 +3192,16 @@ export function createSupabaseBusinessRepository(options) {
         throw new ApiError(400, "validation_failed", "size must be a non-negative number");
       }
       const ossKey = `teams/${teamId}/blobs/sha256/${contentHash.slice(0, 2)}/${contentHash.slice(2, 4)}/${contentHash}`;
-      const { error } = await supabase.from("amuxc_blobs").upsert(
+      // amuxc_blobs predates the skills registry: it is the OSS-sync blob
+      // ledger, where `authenticated` holds SELECT only and every write is
+      // service_role's (20260527000002_oss_sync_schema.sql). Writing it with
+      // the caller's token returns `42501 permission denied for table
+      // amuxc_blobs`. Escalate rather than grant the client INSERT/UPDATE —
+      // `verified` is the flag OSS sync trusts, and a member who can set it
+      // by hand can point a team at a blob that was never uploaded.
+      // Membership was checked above, and teamId comes from the route path.
+      const admin = await serviceRoleClient("register a skill package blob");
+      const { error } = await admin.from("amuxc_blobs").upsert(
         {
           team_id: teamId,
           content_hash: contentHash,
@@ -3222,7 +3232,11 @@ export function createSupabaseBusinessRepository(options) {
       if (!data) {
         throw new ApiError(404, "not_found", "blob placeholder not found — call prepare first");
       }
-      const { error: uErr } = await supabase
+      // The lookup above stays on the caller's token so RLS keeps proving the
+      // blob belongs to a team they are in; only the write escalates, for the
+      // same reason as prepare.
+      const admin = await serviceRoleClient("mark a skill package blob verified");
+      const { error: uErr } = await admin
         .from("amuxc_blobs")
         .update({ verified: true })
         .eq("team_id", teamId)

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -1049,6 +1049,75 @@ test("getWorkspaceConfig returns nulls when both rows absent", async () => {
 
 
 
+// amuxc_blobs is the OSS-sync blob ledger, not a skills table: `authenticated`
+// holds SELECT and nothing else, and every write belongs to service_role
+// (20260527000002_oss_sync_schema.sql). The skills registry reuses it for
+// package bookkeeping, so publishing through the caller's own token died with
+// `403 permission denied for table amuxc_blobs` on self-host. Escalating beats
+// granting the client INSERT/UPDATE — `verified` is the flag OSS sync trusts.
+const BLOB_CALLER_AUTH = {
+  auth: {
+    async getUser() {
+      return { data: { user: { id: "user-1" } }, error: null };
+    },
+  },
+};
+
+test("prepareTeamSkillBlob writes amuxc_blobs with the service-role client", async () => {
+  const callerCalls: any[] = [];
+  const adminCalls: any[] = [];
+  const caller = fakeSupabase({
+    ...BLOB_CALLER_AUTH,
+    tableCalls: callerCalls,
+    tableData: { actors: [{ id: "actor-1" }] },
+  });
+  const admin = fakeSupabase({ tableCalls: adminCalls });
+  const repo = createRepo(caller, { createServiceRoleClient: () => admin });
+
+  const hash = "a".repeat(64);
+  const out = await repo.prepareTeamSkillBlob("team-1", { contentHash: hash, size: 42 });
+
+  assert.equal(out.ossKey, `teams/team-1/blobs/sha256/aa/aa/${hash}`);
+  const write = adminCalls.find((c) => c.table === "amuxc_blobs" && c.op === "upsert");
+  assert.ok(write, "the placeholder row must be upserted with the service-role client");
+  assert.equal(write.row.verified, false);
+  assert.equal(
+    callerCalls.some((c) => c.table === "amuxc_blobs"),
+    false,
+    "a caller-token write to amuxc_blobs is 42501 permission denied",
+  );
+});
+
+test("completeTeamSkillBlob checks as the caller and flips verified as service_role", async () => {
+  const callerCalls: any[] = [];
+  const adminCalls: any[] = [];
+  const hash = "b".repeat(64);
+  const caller = fakeSupabase({
+    ...BLOB_CALLER_AUTH,
+    tableCalls: callerCalls,
+    tableData: {
+      actors: [{ id: "actor-1" }],
+      amuxc_blobs: [{ oss_key: `teams/team-1/blobs/sha256/bb/bb/${hash}`, size: 42 }],
+    },
+  });
+  const admin = fakeSupabase({ tableCalls: adminCalls });
+  const repo = createRepo(caller, { createServiceRoleClient: () => admin });
+
+  const out = await repo.completeTeamSkillBlob("team-1", { contentHash: hash });
+
+  assert.equal(out.size, 42);
+  // The existence check stays on the caller's token so RLS keeps proving the
+  // blob belongs to a team they are actually in.
+  assert.ok(callerCalls.some((c) => c.table === "amuxc_blobs" && c.op === "select"));
+  const update = adminCalls.find((c) => c.table === "amuxc_blobs" && c.op === "update");
+  assert.ok(update, "verified must be flipped with the service-role client");
+  assert.equal(update.row.verified, true);
+  assert.equal(
+    callerCalls.some((c) => c.table === "amuxc_blobs" && c.op === "update"),
+    false,
+  );
+});
+
 function fakeSupabase({
   rpcCalls = [],
   tableCalls = [],
@@ -1138,6 +1207,13 @@ function createTableQuery(table: any, calls: any, data: any, error: any, hooks: 
             },
           };
         },
+        // A bare `await client.from(t).upsert(...)` has to surface the error the
+        // same way insert() does. Without this the builder resolves to itself,
+        // the destructured `error` is undefined, and a failing upsert reads as
+        // a success in tests.
+        then(resolve, reject) {
+          return Promise.resolve({ data: resolvedData, error }).then(resolve, reject);
+        },
       };
     },
     update(row) {
@@ -1193,9 +1269,13 @@ function createSelectableQuery(table, calls, data, error) {
       calls.push({ table, op: "order", column, options });
       return query;
     },
+    // Returns the builder, not a promise: `.limit(1).maybeSingle()` is how the
+    // member-actor lookup reads, and a promise has no maybeSingle. Awaiting the
+    // builder still resolves `{ data, error }` via then(), so direct-await
+    // callers are unaffected.
     limit(count) {
       calls.push({ table, op: "limit", count });
-      return Promise.resolve({ data, error });
+      return query;
     },
     eq(column, value) {
       calls.push({ table, op: "eq", column, value });


### PR DESCRIPTION
## Problem

Sharing a skill to a team fails on the self-host env with:

```
skill blob prepare HTTP 403 forbidden: permission denied for table amuxc_blobs
```

`amux.amuxc_blobs` is the **OSS-sync blob ledger**, not a skills table. Since `20260527000002_oss_sync_schema.sql` its contract has been "team members SELECT, all writes are service_role". Verified on the live box:

| grantee | privileges |
|---|---|
| `authenticated` | `SELECT` |
| `service_role` | `SELECT, INSERT, UPDATE, DELETE, …` |

The team skills registry reuses that table for package bookkeeping, and `20260806000000_team_skills_registry.sql` granted the three *new* tables to `authenticated` but never touched `amuxc_blobs`. So `prepareTeamSkillBlob` upserts the placeholder row through the **caller's** bearer token → Postgres `42501` → PostgREST `403` → surfaced verbatim by `apps/desktop/src/commands/team_skills.rs:420`.

Only the supabase backend is affected (self-host runs `BACKEND_KIND=supabase`). `pg-repo` connects as `postgres`, which has `BYPASSRLS` and full grants.

Reproduced against the live DB, both directions, in rolled-back transactions:

```
set local role authenticated; insert into amux.amuxc_blobs …
  → ERROR: permission denied for table amuxc_blobs

set local role service_role;  insert into amux.amuxc_blobs …
  → INSERT 0 1
```

## Fix

`prepareTeamSkillBlob`'s upsert and `completeTeamSkillBlob`'s `verified` flip now go through the service-role client. `completeTeamSkillBlob`'s existence check stays on the caller's token so RLS keeps proving the blob belongs to a team they are in.

### Why escalate rather than grant the client INSERT/UPDATE

`verified` is the flag OSS sync trusts, and the table is shared with the unrelated file-sync path. A member who can set it by hand can point a team at a blob that was never uploaded. Membership is already checked before both writes and `teamId` comes from the route path, so escalating is the narrower change — and it matches the design doc, which already has FC signing the upload URL with service role.

Also folds the inline service-role client construction in `shareModeServiceRpc` into a shared helper, so a missing key names whichever operation needed it.

## Test-fake fixes

Three bugs in `test/supabase-repo.test.ts` blocked coverage of this path:

- a bare `await client.from(t).upsert(…)` resolved to the *builder*, so the destructured `error` was always `undefined` — **a failing upsert read as a success in every test using that helper**
- `.limit()` returned a promise, so `.limit(1).maybeSingle()` (how the member-actor lookup reads) threw

## Verification

- `npm run build` (the tsconfig that gates the deploy image) — clean
- Full FC suite — exit 0; `supabase-repo.test.ts` 81/81
- The new regression test **fails** with the source line reverted, so it isn't vacuous
- `npm run typecheck` reports 9 errors — byte-identical before and after this change, all pre-existing

⚠️ Merging auto-deploys: `services/fc/**` triggers `self-host-deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)