### PR TITLE
fix(fc): session 查询性能——执行计划悬崖、teamId 作用域、消息与 sync 分页

### DIFF
--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -1010,7 +1010,14 @@ impl Backend for CloudApiBackend {
             #[serde(default)]
             participants: Vec<CloudParticipant>,
         }
-        let s: CloudSession = self.get(&format!("/v1/sessions/{session_id}")).await?;
+        // teamId is required on session reads: it is what resolves the caller's
+        // actor (one actor row per user per team) and scopes the row server-side.
+        let s: CloudSession = self
+            .get(&format!(
+                "/v1/sessions/{session_id}?teamId={}",
+                self.cfg.team_id
+            ))
+            .await?;
         let session_id_str = s.id.clone();
         let session = BackendSessionRow {
             id: s.id,

--- a/apps/expo/src/features/sessions/cloud-api.ts
+++ b/apps/expo/src/features/sessions/cloud-api.ts
@@ -175,7 +175,9 @@ export function createCloudSessionsApi(options: CreateCloudSessionsApiOptions) {
     fetchImpl: options.fetchImpl,
   });
 
-  return {
+  // Bound to a name so methods can call siblings (listMessages delegates to
+  // listMessagesPage) without `this` — callers destructure this object.
+  const api = {
     async listSessions(teamId: string, currentActorId?: string): Promise<SessionSummary[]> {
       // currentActorId is derived server-side from the bearer; kept for
       // signature parity with the legacy Supabase implementation.
@@ -205,12 +207,12 @@ export function createCloudSessionsApi(options: CreateCloudSessionsApiOptions) {
     },
 
     async getSession(teamId: string, sessionId: string): Promise<SessionSummary | null> {
-      // The session lookup is keyed by id alone; teamId is retained for
-      // signature parity.
-      void teamId;
+      // teamId is required on session reads — it resolves the caller's actor
+      // (one actor row per user per team) and scopes the lookup, so an id from
+      // another team is a 404 rather than an RLS-filtered empty row.
       try {
         const row = await client.get<CloudSessionFull>(
-          `/v1/sessions/${encodeURIComponent(sessionId)}`,
+          `/v1/sessions/${encodeURIComponent(sessionId)}?teamId=${encodeURIComponent(teamId)}`,
         );
         return mapSession(row);
       } catch (error) {
@@ -219,12 +221,34 @@ export function createCloudSessionsApi(options: CreateCloudSessionsApiOptions) {
       }
     },
 
-    async listMessages(teamId: string, sessionId: string): Promise<SessionMessage[]> {
+    // One page of history, newest-last, walking BACKWARD: no cursor gives the
+    // tail of the conversation and `nextCursor` reaches older pages. The server
+    // caps the page (it used to return the whole history, which took 6.1s /
+    // 3.7MB at 6k messages and 500'd past ~40k).
+    async listMessagesPage(
+      teamId: string,
+      sessionId: string,
+      opts: { limit?: number; cursor?: string | null } = {},
+    ): Promise<{ items: SessionMessage[]; nextCursor: string | null }> {
       void teamId;
-      const response = await client.get<{ items?: CloudMessage[] }>(
-        `/v1/sessions/${encodeURIComponent(sessionId)}/messages`,
+      const params = new URLSearchParams();
+      if (opts.limit != null) params.set("limit", String(opts.limit));
+      if (opts.cursor) params.set("cursor", opts.cursor);
+      const query = params.toString();
+      const response = await client.get<{ items?: CloudMessage[]; nextCursor?: string | null }>(
+        `/v1/sessions/${encodeURIComponent(sessionId)}/messages${query ? `?${query}` : ""}`,
       );
-      return (response.items ?? []).map(mapMessage);
+      return {
+        items: (response.items ?? []).map(mapMessage),
+        nextCursor: response.nextCursor ?? null,
+      };
+    },
+
+    // Convenience wrapper for callers that only want the current viewport.
+    // Deliberately NOT `this.listMessagesPage` — the api object gets picked
+    // apart into `deps.api`, so a `this` reference would break on the way.
+    async listMessages(teamId: string, sessionId: string): Promise<SessionMessage[]> {
+      return (await api.listMessagesPage(teamId, sessionId)).items;
     },
 
     async insertOutgoingMessage(input: OutgoingMessageInput): Promise<void> {
@@ -383,4 +407,6 @@ export function createCloudSessionsApi(options: CreateCloudSessionsApiOptions) {
       }
     },
   };
+
+  return api;
 }

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/CloudAPI/CloudAPIRepositories.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/CloudAPI/CloudAPIRepositories.swift
@@ -243,9 +243,26 @@ public actor CloudAPIMessagesRepository: MessagesRepository {
         self.client = client
     }
 
+    private static func enc(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+    }
+
+    /// The newest page of the session. Omitting a cursor no longer means "the
+    /// whole history" — the server caps the page and reports `nextCursor` for
+    /// older ones. Use `listPage` to walk back through them.
     public func listForSession(sessionID: String) async throws -> [MessageRecord] {
-        let page: CloudPage<CloudMessage> = try await client.get("/v1/sessions/\(sessionID)/messages")
-        return page.items.map { row in
+        try await listPage(sessionID: sessionID, limit: nil, cursor: nil).messages
+    }
+
+    public func listPage(sessionID: String, limit: Int?, cursor: String?) async throws -> MessagePage {
+        var query: [String] = []
+        if let limit { query.append("limit=\(limit)") }
+        if let cursor, !cursor.isEmpty { query.append("cursor=\(Self.enc(cursor))") }
+        let suffix = query.isEmpty ? "" : "?\(query.joined(separator: "&"))"
+        let page: CloudPage<CloudMessage> = try await client.get(
+            "/v1/sessions/\(sessionID)/messages\(suffix)"
+        )
+        let messages = page.items.map { row in
             MessageRecord(
                 id: row.id,
                 teamID: row.teamId,
@@ -262,6 +279,7 @@ public actor CloudAPIMessagesRepository: MessagesRepository {
                 sequence: 0
             )
         }
+        return MessagePage(messages: messages, nextCursor: page.nextCursor)
     }
 
     public func insert(_ input: MessageInsertInput) async throws {

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/Sessions/SessionListRepositories.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/Sessions/SessionListRepositories.swift
@@ -127,8 +127,27 @@ public struct MessageInsertInput: Equatable, Sendable {
     }
 }
 
+/// One page of history, walking backward from the newest message.
+///
+/// `messages` is oldest-first (transcript order); `nextCursor` reaches the page
+/// immediately OLDER than this one and is nil at the start of the session.
+public struct MessagePage: Sendable {
+    public let messages: [MessageRecord]
+    public let nextCursor: String?
+
+    public init(messages: [MessageRecord], nextCursor: String?) {
+        self.messages = messages
+        self.nextCursor = nextCursor
+    }
+}
+
 public protocol MessagesRepository: Sendable {
     func listForSession(sessionID: String) async throws -> [MessageRecord]
+    /// Paginated history. `GET /v1/sessions/:id/messages` used to return a
+    /// session's entire history in one response — 6k messages measured
+    /// 6.1s / 3.7MB and 40k exceeded the server's statement timeout — so it now
+    /// serves the newest page and pages backward from there.
+    func listPage(sessionID: String, limit: Int?, cursor: String?) async throws -> MessagePage
     func insert(_ input: MessageInsertInput) async throws
     /// Rewrites a persisted message's content. FC enforces sender-only
     /// semantics, so callers only offer this for the current actor's own
@@ -137,6 +156,16 @@ public protocol MessagesRepository: Sendable {
     /// Permanently removes a persisted message (FC returns 204).
     /// Same sender-only contract as `patch`.
     func delete(messageID: String) async throws
+}
+
+public extension MessagesRepository {
+    /// Default for repositories that have nothing to page (in-memory fakes,
+    /// tests): serve everything as a single, final page.
+    func listPage(sessionID: String, limit: Int? = nil, cursor: String? = nil) async throws -> MessagePage {
+        _ = limit
+        _ = cursor
+        return MessagePage(messages: try await listForSession(sessionID: sessionID), nextCursor: nil)
+    }
 }
 
 

--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -3818,6 +3818,20 @@ paths:
         - name: since
           in: query
           schema: { type: string, format: date-time }
+        - name: limit
+          in: query
+          description: Page size. Rows are ordered by (updated_at, id) ascending.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: cursor
+          in: query
+          description: >-
+            Opaque keyset cursor from a previous response's `nextCursor`. Omit
+            to start at the beginning.
+          schema: { type: string }
       responses:
         "200":
           description: Actor directory rows
@@ -3825,11 +3839,16 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [items]
+                required: [items, nextCursor]
                 properties:
                   items:
                     type: array
                     items: { type: object }
+                  nextCursor:
+                    description: Null on the last page.
+                    type:
+                      - string
+                      - "null"
         "400":
           $ref: "#/components/responses/Error"
   /v1/sync/ideas:
@@ -3845,6 +3864,20 @@ paths:
         - name: since
           in: query
           schema: { type: string, format: date-time }
+        - name: limit
+          in: query
+          description: Page size. Rows are ordered by (updated_at, id) ascending.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: cursor
+          in: query
+          description: >-
+            Opaque keyset cursor from a previous response's `nextCursor`. Omit
+            to start at the beginning.
+          schema: { type: string }
       responses:
         "200":
           description: Idea rows
@@ -3852,11 +3885,16 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [items]
+                required: [items, nextCursor]
                 properties:
                   items:
                     type: array
                     items: { type: object }
+                  nextCursor:
+                    description: Null on the last page.
+                    type:
+                      - string
+                      - "null"
         "400":
           $ref: "#/components/responses/Error"
   /v1/sync/session-participants:
@@ -3872,6 +3910,20 @@ paths:
         - name: since
           in: query
           schema: { type: string, format: date-time }
+        - name: limit
+          in: query
+          description: Page size. Rows are ordered by (updated_at, id) ascending.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: cursor
+          in: query
+          description: >-
+            Opaque keyset cursor from a previous response's `nextCursor`. Omit
+            to start at the beginning.
+          schema: { type: string }
       responses:
         "200":
           description: Session participant rows
@@ -3879,11 +3931,16 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [items]
+                required: [items, nextCursor]
                 properties:
                   items:
                     type: array
                     items: { type: object }
+                  nextCursor:
+                    description: Null on the last page.
+                    type:
+                      - string
+                      - "null"
         "400":
           $ref: "#/components/responses/Error"
   /v1/sync/sessions:
@@ -3945,6 +4002,20 @@ paths:
         - name: since
           in: query
           schema: { type: string, format: date-time }
+        - name: limit
+          in: query
+          description: Page size. Rows are ordered by (updated_at, id) ascending.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: cursor
+          in: query
+          description: >-
+            Opaque keyset cursor from a previous response's `nextCursor`. Omit
+            to start at the beginning.
+          schema: { type: string }
       responses:
         "200":
           description: Message sync rows
@@ -3952,11 +4023,16 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [items]
+                required: [items, nextCursor]
                 properties:
                   items:
                     type: array
                     items: { type: object }
+                  nextCursor:
+                    description: Null on the last page.
+                    type:
+                      - string
+                      - "null"
         "400":
           $ref: "#/components/responses/Error"
   /v1/sessions/display-rows:

--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -439,12 +439,18 @@ paths:
       summary: List sessions
       description: |
         Sessions the calling actor participates in, newest activity first,
-        excluding archived ones. Optionally narrowed to one team and/or one
+        excluding archived ones. Scoped to one team, optionally narrowed to one
         idea.
 
         This replaced `GET /v1/teams/{teamId}/sessions`, which returned a
         team's whole session list unpaginated. Callers that want every session
         in a team pass `teamId` and follow `nextCursor` to exhaustion.
+
+        `teamId` is **required**. It identifies the caller's actor (one actor
+        row per user per team) and it is the only thing that lets the query use
+        an index — the un-scoped listing it replaced walked every participant
+        row the caller had and sorted, which measured 4.5s at 6k sessions and
+        timed out into a 500 past ~13k. Omitting it returns 400.
       tags: [Sessions]
       parameters:
         - name: limit
@@ -460,7 +466,8 @@ paths:
             type: string
         - name: teamId
           in: query
-          description: Narrow to a single team.
+          required: true
+          description: The team to list sessions for.
           schema:
             type: string
             format: uuid
@@ -523,9 +530,20 @@ paths:
     get:
       operationId: getSession
       summary: Get session with participants
+      description: |
+        `teamId` is **required**: it scopes the read to a team the caller has an
+        actor in, so a session id from another team is a 404 at the query level
+        rather than relying on RLS alone to hide the row.
       tags: [Sessions]
       parameters:
         - $ref: "#/components/parameters/SessionId"
+        - name: teamId
+          in: query
+          required: true
+          description: The team the session belongs to.
+          schema:
+            type: string
+            format: uuid
       responses:
         "200":
           description: Session with participants.
@@ -1002,11 +1020,32 @@ paths:
     get:
       operationId: listMessages
       summary: List messages
+      description: |
+        One page of a session's history, walking **backward** from the newest
+        message: the default page is the tail of the conversation, and
+        `nextCursor` reaches further into the past. Messages inside a page are
+        ordered oldest-first, so a client can render them in order.
+
+        This endpoint was previously unbounded — it returned the entire history
+        and always reported `nextCursor: null`. A session with 6k messages
+        measured 6.1s / 3.7MB, 20k took 22.9s, and 40k exceeded the database
+        statement timeout and failed with a 500.
       tags: [Messages]
       parameters:
         - $ref: "#/components/parameters/SessionId"
+        - name: limit
+          in: query
+          description: Messages per page, counted back from the newest.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 200
         - name: cursor
           in: query
+          description: >-
+            From a previous response's `nextCursor`. Returns the page of
+            messages immediately OLDER than that page.
           schema:
             type: string
       responses:

--- a/packages/app/src/components/SessionHistoryLoader.tsx
+++ b/packages/app/src/components/SessionHistoryLoader.tsx
@@ -154,7 +154,7 @@ export function SessionHistoryLoader() {
 
         let historyRows;
         try {
-          historyRows = await getBackend().messages.listMessages(currentSessionId);
+          historyRows = (await getBackend().messages.listMessages(currentSessionId)).rows;
         } catch (error) {
           console.warn(
             "[history] load failed:",
@@ -204,7 +204,7 @@ export function SessionHistoryLoader() {
       // ── Non-Tauri web: full backend pull ──────────────────────────
       let historyRows;
       try {
-        historyRows = await getBackend().messages.listMessages(currentSessionId);
+        historyRows = (await getBackend().messages.listMessages(currentSessionId)).rows;
       } catch (error) {
         console.warn("[history] load failed:", error instanceof Error ? error.message : error);
         if (!cancelled) {

--- a/packages/app/src/components/chat/use-chat-send.ts
+++ b/packages/app/src/components/chat/use-chat-send.ts
@@ -28,7 +28,6 @@ import { useSessionListStore } from "@/stores/session-list-store";
 import { useEngagedAgentStore } from "@/stores/engaged-agent-store";
 import { useAgentModelPickStore } from "@/stores/agent-model-pick-store";
 import { useUIStore } from "@/stores/ui";
-import { getBackend } from "@/lib/backend";
 import { expandPageLinkTokensInText } from "@/lib/expand-page-link-tokens";
 import { create as createMessage } from "@bufbuild/protobuf";
 import {
@@ -206,15 +205,12 @@ export function useChatSend({
       useSessionListStore.getState().rows.find(r => r.id === sid)?.team_id ?? null;
     let teamIdForSend: string | null = teamIdFromSessionList;
 
-    const teamIdPromise = resolveSendTeamId({
-      sessionId: sid,
-      teamIdFromSessionList,
-      fetchSessionTeamId: (sessionId) => {
-        sessionFlowLog("send.resolve_team_from_backend.begin", { sessionId });
-        return getBackend().sessions.getSessionTeamId(sessionId);
-      },
-      currentTeamId: () => useCurrentTeamStore.getState().team?.id ?? null,
-    });
+    const teamIdPromise = Promise.resolve(
+      resolveSendTeamId({
+        teamIdFromSessionList,
+        currentTeamId: () => useCurrentTeamStore.getState().team?.id ?? null,
+      }),
+    );
 
     const syncMentions = trySyncMentionActorIds(memberIds, agentIds, text);
     const mentionsPromise: Promise<string[]> = syncMentions

--- a/packages/app/src/lib/__tests__/cron-session-messages.test.ts
+++ b/packages/app/src/lib/__tests__/cron-session-messages.test.ts
@@ -4,7 +4,6 @@ import { useSessionMessageStore } from "@/stores/session-message-store";
 
 const mocks = vi.hoisted(() => ({
   listMessages: vi.fn(),
-  getSessionTeamId: vi.fn(),
   listSessionDisplayRows: vi.fn(),
   reloadAndSwitchTo: vi.fn(),
 }));
@@ -13,7 +12,6 @@ vi.mock("@/lib/backend", () => ({
   getBackend: () => ({
     messages: { listMessages: mocks.listMessages },
     sessions: {
-      getSessionTeamId: mocks.getSessionTeamId,
       listSessionDisplayRows: mocks.listSessionDisplayRows,
     },
   }),
@@ -47,7 +45,9 @@ beforeEach(() => {
 
 describe("hydrateCronSessionMessages", () => {
   it("maps cloud rows into the message store", async () => {
-    mocks.listMessages.mockResolvedValueOnce([
+    mocks.listMessages.mockResolvedValueOnce({
+      nextCursor: null,
+      rows: [
       {
         id: "m1",
         team_id: "t1",
@@ -62,7 +62,8 @@ describe("hydrateCronSessionMessages", () => {
         created_at: "2026-06-01T07:00:00.000Z",
         updated_at: "2026-06-01T07:00:00.000Z",
       },
-    ]);
+      ],
+    });
 
     const count = await hydrateCronSessionMessages("s1");
     expect(count).toBe(1);
@@ -73,7 +74,7 @@ describe("hydrateCronSessionMessages", () => {
   });
 
   it("falls back to run summary when cloud has no messages", async () => {
-    mocks.listMessages.mockResolvedValueOnce([]);
+    mocks.listMessages.mockResolvedValueOnce({ rows: [], nextCursor: null });
 
     const count = await hydrateCronSessionMessages("s1", {
       fallbackSummary: "北极熊笑话",
@@ -90,7 +91,6 @@ describe("hydrateCronSessionMessages", () => {
 describe("ensureCronSessionVisible", () => {
   beforeEach(() => {
     useSessionListStore.setState({ rows: [] });
-    mocks.getSessionTeamId.mockResolvedValue("team-1");
     mocks.listSessionDisplayRows.mockResolvedValue([{ id: "s-cron", title: "Cron: Test" }]);
   });
 

--- a/packages/app/src/lib/__tests__/send-path-resolve.test.ts
+++ b/packages/app/src/lib/__tests__/send-path-resolve.test.ts
@@ -44,39 +44,35 @@ describe("trySyncMentionActorIds", () => {
 });
 
 describe("resolveSendTeamId", () => {
-  it("uses the session-list row without hitting the backend", async () => {
-    const fetchSessionTeamId = vi.fn();
-    await expect(
+  it("uses the session-list row when it has one", () => {
+    expect(
       resolveSendTeamId({
-        sessionId: "s1",
         teamIdFromSessionList: "team-row",
-        fetchSessionTeamId,
         currentTeamId: () => "team-selected",
       }),
-    ).resolves.toBe("team-row");
-    expect(fetchSessionTeamId).not.toHaveBeenCalled();
+    ).toBe("team-row");
   });
 
-  it("prefers the session's own team over the selected team", async () => {
-    await expect(
+  // The by-id backend lookup that used to sit between these two is gone:
+  // session reads are team-scoped, and a composer only exists inside the team
+  // you are looking at, so the current team is the right answer when the list
+  // row has not loaded yet. It also keeps a round-trip off the send path.
+  it("falls back to the selected team when the list row is missing", () => {
+    expect(
       resolveSendTeamId({
-        sessionId: "s1",
         teamIdFromSessionList: null,
-        fetchSessionTeamId: async () => "team-of-session",
         currentTeamId: () => "team-selected",
       }),
-    ).resolves.toBe("team-of-session");
+    ).toBe("team-selected");
   });
 
-  it("falls back to the selected team only when the backend has none", async () => {
-    await expect(
+  it("returns null when neither is known", () => {
+    expect(
       resolveSendTeamId({
-        sessionId: "s1",
         teamIdFromSessionList: null,
-        fetchSessionTeamId: async () => null,
-        currentTeamId: () => "team-selected",
+        currentTeamId: () => null,
       }),
-    ).resolves.toBe("team-selected");
+    ).toBeNull();
   });
 });
 

--- a/packages/app/src/lib/backend/cloud-api/__tests__/cloud-api.test.ts
+++ b/packages/app/src/lib/backend/cloud-api/__tests__/cloud-api.test.ts
@@ -96,9 +96,9 @@ describe("cloud api backend", () => {
     await expect(backend.sessions.listCurrentActorSessions({ limit: 50, cursor: null, teamId: "team-1" })).resolves.toMatchObject({
       rows: [{ id: "session-1", team_id: "team-1", has_unread: true }],
     });
-    await expect(backend.messages.listMessages("session-1")).resolves.toMatchObject([
-      { id: "message-1", team_id: "team-1", sender_actor_id: "actor-1" },
-    ]);
+    await expect(backend.messages.listMessages("session-1")).resolves.toMatchObject({
+      rows: [{ id: "message-1", team_id: "team-1", sender_actor_id: "actor-1" }],
+    });
     await expect(backend.messages.insertOutgoingMessage({
       id: "message-2",
       teamId: "team-1",

--- a/packages/app/src/lib/backend/cloud-api/__tests__/messages.test.ts
+++ b/packages/app/src/lib/backend/cloud-api/__tests__/messages.test.ts
@@ -46,9 +46,23 @@ describe("messages module", () => {
     const client = mockClient({ "GET /v1/sessions/session-1/messages": { items: [cloudMessage], nextCursor: null } });
     const mod = createMessagesModule(client);
     const out = await mod.listMessages("session-1");
-    expect(out[0].id).toBe("message-1");
-    expect(out[0].team_id).toBe("team-1");
-    expect(out[0].sender_actor_id).toBe("actor-1");
+    expect(out.rows[0].id).toBe("message-1");
+    expect(out.rows[0].team_id).toBe("team-1");
+    expect(out.rows[0].sender_actor_id).toBe("actor-1");
+    expect(out.nextCursor).toBeNull();
+  });
+
+  it("listMessages forwards limit and cursor, and returns nextCursor", async () => {
+    const client = mockClient({
+      "GET /v1/sessions/session-1/messages?limit=2&cursor=abc": {
+        items: [cloudMessage],
+        nextCursor: "older-page",
+      },
+    });
+    const mod = createMessagesModule(client);
+    const out = await mod.listMessages("session-1", { limit: 2, cursor: "abc" });
+    expect(out.rows).toHaveLength(1);
+    expect(out.nextCursor).toBe("older-page");
   });
 
   it("insertOutgoingMessage calls POST and returns mapped message", async () => {

--- a/packages/app/src/lib/backend/cloud-api/__tests__/sync-paging.test.ts
+++ b/packages/app/src/lib/backend/cloud-api/__tests__/sync-paging.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CloudApiClient } from "../http";
+import { fetchAllSyncPages } from "../sync-paging";
+import { createSyncModule } from "../sync";
+import { createSessionsModule } from "../sessions";
+import { createMessagesModule } from "../messages";
+
+/**
+ * A client that serves a scripted list of pages in order and records the paths
+ * it was asked for.
+ */
+function pagingClient(pages: Array<{ items: unknown[]; nextCursor: string | null }>) {
+  const paths: string[] = [];
+  let next = 0;
+  return {
+    paths,
+    client: {
+      async get(path: string) {
+        paths.push(path);
+        const page = pages[next] ?? { items: [], nextCursor: null };
+        next += 1;
+        return page as never;
+      },
+      async post() { throw new Error("unexpected post"); },
+      async patch() { throw new Error("unexpected patch"); },
+      async put() { throw new Error("unexpected put"); },
+      async delete() { throw new Error("unexpected delete"); },
+      async postRaw() { throw new Error("not impl"); },
+      async getRaw() { throw new Error("not impl"); },
+    } as unknown as CloudApiClient,
+  };
+}
+
+describe("fetchAllSyncPages", () => {
+  it("follows nextCursor to exhaustion and concatenates every page", async () => {
+    const { client, paths } = pagingClient([
+      { items: [{ id: "a" }, { id: "b" }], nextCursor: "cur-1" },
+      { items: [{ id: "c" }], nextCursor: "cur-2" },
+      { items: [{ id: "d" }], nextCursor: null },
+    ]);
+
+    const rows = await fetchAllSyncPages<{ id: string }>(client, "/v1/sync/ideas", {
+      teamId: "team-1",
+      since: null,
+    });
+
+    expect(rows.map((r) => r.id)).toEqual(["a", "b", "c", "d"]);
+    expect(paths).toHaveLength(3);
+    // The first request carries no cursor; each later one carries the previous
+    // page's, so no row is skipped or repeated across the boundary.
+    expect(paths[0]).not.toContain("cursor=");
+    expect(paths[1]).toContain("cursor=cur-1");
+    expect(paths[2]).toContain("cursor=cur-2");
+  });
+
+  it("stops when a page reports no cursor, even if it is full", async () => {
+    const { client, paths } = pagingClient([{ items: [{ id: "only" }], nextCursor: null }]);
+
+    const rows = await fetchAllSyncPages<{ id: string }>(client, "/v1/sync/ideas", { teamId: "t" });
+
+    expect(rows).toHaveLength(1);
+    expect(paths).toHaveLength(1);
+  });
+
+  it("omits empty params but always sends a limit", async () => {
+    const { client, paths } = pagingClient([{ items: [], nextCursor: null }]);
+
+    await fetchAllSyncPages(client, "/v1/sync/messages", { sessionId: "s-1", since: null });
+
+    expect(paths[0]).toContain("sessionId=s-1");
+    expect(paths[0]).not.toContain("since=");
+    expect(paths[0]).toContain("limit=");
+  });
+
+  it("warns and stops rather than looping forever on an endless cursor", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Every page reports another cursor.
+    const endless = Array.from({ length: 1200 }, () => ({
+      items: [{ id: "x" }],
+      nextCursor: "always",
+    }));
+    const { client, paths } = pagingClient(endless);
+
+    const rows = await fetchAllSyncPages<{ id: string }>(client, "/v1/sync/ideas", { teamId: "t" });
+
+    expect(paths.length).toBe(1000);
+    expect(rows).toHaveLength(1000);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("incomplete"));
+    warn.mockRestore();
+  });
+});
+
+// Regression: every sync reader must page. listSessionsForTeamSince in
+// particular hit a live server that already paginated at 50 while this client
+// read only the first response, so large deltas were silently truncated.
+describe("sync readers page to exhaustion", () => {
+  const twoPages = () =>
+    pagingClient([
+      { items: [{ id: "1" }], nextCursor: "c1" },
+      { items: [{ id: "2" }], nextCursor: null },
+    ]);
+
+  it("listSessionsForTeamSince", async () => {
+    const { client } = twoPages();
+    const rows = await createSessionsModule(client).listSessionsForTeamSince("team-1", null);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("listMessagesForSessionSince", async () => {
+    const { client } = twoPages();
+    const rows = await createMessagesModule(client).listMessagesForSessionSince("session-1", null);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("listActorDirectoryForSync", async () => {
+    const { client } = twoPages();
+    const rows = await createSyncModule(client).listActorDirectoryForSync("team-1", null);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("listIdeasForSync", async () => {
+    const { client } = twoPages();
+    const rows = await createSyncModule(client).listIdeasForSync("team-1", null);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("listSessionParticipantsForSync", async () => {
+    const { client } = twoPages();
+    const rows = await createSyncModule(client).listSessionParticipantsForSync("session-1", null);
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/packages/app/src/lib/backend/cloud-api/messages.ts
+++ b/packages/app/src/lib/backend/cloud-api/messages.ts
@@ -5,6 +5,7 @@ import type {
   OutgoingMessageInput,
 } from "../types";
 import type { CloudApiClient } from "./http";
+import { fetchAllSyncPages } from "./sync-paging";
 
 type CloudMessage = {
   id: string;
@@ -80,13 +81,13 @@ export function createMessagesModule(client: CloudApiClient): MessagesBackend {
     async updateMessageContent(messageId: string, content: string): Promise<void> {
       await client.patch<CloudMessage>(`/v1/messages/${encodeURIComponent(messageId)}`, { content });
     },
+    // Pages to exhaustion — the route is keyset-paginated now, and a delta sync
+    // that stopped at the first page would leave the local cache behind.
     async listMessagesForSessionSince(sessionId, updatedAfter) {
-      const params = new URLSearchParams({ sessionId });
-      if (updatedAfter) params.set("since", updatedAfter);
-      const out = await client.get<{ items: import("../types").MessageSyncRow[] }>(
-        `/v1/sync/messages?${params.toString()}`,
-      );
-      return out.items ?? [];
+      return fetchAllSyncPages<import("../types").MessageSyncRow>(client, "/v1/sync/messages", {
+        sessionId,
+        since: updatedAfter ?? null,
+      });
     },
   };
 }

--- a/packages/app/src/lib/backend/cloud-api/messages.ts
+++ b/packages/app/src/lib/backend/cloud-api/messages.ts
@@ -1,4 +1,9 @@
-import type { MessageHistoryRow, MessagesBackend, OutgoingMessageInput } from "../types";
+import type {
+  MessageHistoryPage,
+  MessageHistoryRow,
+  MessagesBackend,
+  OutgoingMessageInput,
+} from "../types";
 import type { CloudApiClient } from "./http";
 
 type CloudMessage = {
@@ -37,11 +42,21 @@ function mapMessage(row: CloudMessage): MessageHistoryRow {
 
 export function createMessagesModule(client: CloudApiClient): MessagesBackend {
   return {
-    async listMessages(sessionId: string): Promise<MessageHistoryRow[]> {
+    // Paginated backward from the newest message: no `cursor` yields the tail of
+    // the history, and `nextCursor` walks into older pages. The server caps the
+    // page, so omitting `limit` is not "give me everything" any more.
+    async listMessages(
+      sessionId: string,
+      opts: { limit?: number; cursor?: string | null } = {},
+    ): Promise<MessageHistoryPage> {
+      const params = new URLSearchParams();
+      if (opts.limit != null) params.set("limit", String(opts.limit));
+      if (opts.cursor) params.set("cursor", opts.cursor);
+      const query = params.toString();
       const page = await client.get<Page<CloudMessage>>(
-        `/v1/sessions/${encodeURIComponent(sessionId)}/messages`,
+        `/v1/sessions/${encodeURIComponent(sessionId)}/messages${query ? `?${query}` : ""}`,
       );
-      return page.items.map(mapMessage);
+      return { rows: page.items.map(mapMessage), nextCursor: page.nextCursor ?? null };
     },
     async insertOutgoingMessage(input: OutgoingMessageInput): Promise<MessageHistoryRow> {
       const message = await client.post<CloudMessage>(

--- a/packages/app/src/lib/backend/cloud-api/sessions.ts
+++ b/packages/app/src/lib/backend/cloud-api/sessions.ts
@@ -162,15 +162,6 @@ export function createSessionsModule(client: CloudApiClient): SessionsBackend {
       );
       return mapSessionDetail(out);
     },
-    async getSessionTeamId(sessionId) {
-      try {
-        const out = await client.get<{ teamId?: string | null }>(`/v1/sessions/${encodeURIComponent(sessionId)}`);
-        return out.teamId ?? null;
-      } catch (e) {
-        if (e instanceof CloudApiError && e.status === 404) return null;
-        throw e;
-      }
-    },
     // Pages to exhaustion. This route was already paginated server-side
     // (default 50) while this client read only `items` off the first response,
     // so any team with more than 50 changes since the last watermark lost the

--- a/packages/app/src/lib/backend/cloud-api/sessions.ts
+++ b/packages/app/src/lib/backend/cloud-api/sessions.ts
@@ -9,6 +9,7 @@ import type {
   SessionsBackend,
 } from "../types";
 import { CloudApiError, type CloudApiClient } from "./http";
+import { fetchAllSyncPages } from "./sync-paging";
 
 type CloudSession = {
   id: string;
@@ -170,11 +171,15 @@ export function createSessionsModule(client: CloudApiClient): SessionsBackend {
         throw e;
       }
     },
+    // Pages to exhaustion. This route was already paginated server-side
+    // (default 50) while this client read only `items` off the first response,
+    // so any team with more than 50 changes since the last watermark lost the
+    // remainder on every sync.
     async listSessionsForTeamSince(teamId, updatedAfter): Promise<SessionSyncRow[]> {
-      const params = new URLSearchParams({ teamId });
-      if (updatedAfter) params.set("since", updatedAfter);
-      const out = await client.get<{ items: SessionSyncRow[] }>(`/v1/sync/sessions?${params.toString()}`);
-      return out.items ?? [];
+      return fetchAllSyncPages<SessionSyncRow>(client, "/v1/sync/sessions", {
+        teamId,
+        since: updatedAfter ?? null,
+      });
     },
     async listSessionDisplayRows(teamId, sessionIds): Promise<SessionDisplayRow[]> {
       if (sessionIds.length === 0) return [];

--- a/packages/app/src/lib/backend/cloud-api/sync-paging.ts
+++ b/packages/app/src/lib/backend/cloud-api/sync-paging.ts
@@ -1,0 +1,61 @@
+import type { CloudApiClient } from "./http";
+
+/**
+ * Walks a paginated `/v1/sync/*` endpoint to exhaustion.
+ *
+ * The sync endpoints are keyset-paginated on (updated_at, id) and report
+ * `nextCursor`. A caller that reads only the first page silently drops every
+ * change past it — which is exactly what `listSessionsForTeamSince` did: the
+ * server had paginated that route (default 50) while this client took
+ * `out.items` and returned, so a team with more than 50 changes since the last
+ * watermark lost the remainder on every sync.
+ *
+ * Sync callers want "everything changed since X" as one list, so paging belongs
+ * here rather than in each caller: the delta-sync code stays a single call and
+ * cannot forget the cursor.
+ */
+
+/** Server-side maximum for `parseLimit`; a larger value is rejected as a 400. */
+const SYNC_PAGE_SIZE = 100;
+
+/**
+ * Backstop against a server that keeps handing back a cursor. At the page size
+ * above this is 100k rows — far past any real delta, so hitting it means
+ * something is wrong, and it is logged rather than silently truncated.
+ */
+const MAX_PAGES = 1000;
+
+export async function fetchAllSyncPages<T>(
+  client: CloudApiClient,
+  path: string,
+  params: Record<string, string | null | undefined>,
+): Promise<T[]> {
+  const all: T[] = [];
+  let cursor: string | null = null;
+  let pages = 0;
+
+  do {
+    const search = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== null && value !== undefined && value !== "") search.set(key, value);
+    }
+    search.set("limit", String(SYNC_PAGE_SIZE));
+    if (cursor) search.set("cursor", cursor);
+
+    const out = await client.get<{ items?: T[]; nextCursor?: string | null }>(
+      `${path}?${search.toString()}`,
+    );
+    all.push(...(out.items ?? []));
+    cursor = out.nextCursor ?? null;
+    pages += 1;
+  } while (cursor && pages < MAX_PAGES);
+
+  if (cursor) {
+    console.warn(
+      `[sync] ${path} still had a cursor after ${MAX_PAGES} pages (${all.length} rows); ` +
+        "stopping short — this delta is incomplete.",
+    );
+  }
+
+  return all;
+}

--- a/packages/app/src/lib/backend/cloud-api/sync.ts
+++ b/packages/app/src/lib/backend/cloud-api/sync.ts
@@ -5,33 +5,29 @@ import type {
   SyncBackend,
 } from "../types";
 import type { CloudApiClient } from "./http";
-
-function buildQuery(params: Record<string, string | null | undefined>): string {
-  const search = new URLSearchParams();
-  for (const [k, v] of Object.entries(params)) {
-    if (v !== null && v !== undefined && v !== "") search.set(k, v);
-  }
-  return search.toString();
-}
+import { fetchAllSyncPages } from "./sync-paging";
 
 export function createSyncModule(client: CloudApiClient): SyncBackend {
   return {
+    // Each of these pages to exhaustion — the endpoints are keyset-paginated and
+    // reading only the first page would silently drop the rest of the delta.
     async listActorDirectoryForSync(teamId, updatedAfter) {
-      const qs = buildQuery({ teamId, since: updatedAfter ?? null });
-      const out = await client.get<{ items: ActorDirectorySyncRow[] }>(`/v1/sync/actor-directory?${qs}`);
-      return out.items;
+      return fetchAllSyncPages<ActorDirectorySyncRow>(client, "/v1/sync/actor-directory", {
+        teamId,
+        since: updatedAfter ?? null,
+      });
     },
     async listIdeasForSync(teamId, updatedAfter) {
-      const qs = buildQuery({ teamId, since: updatedAfter ?? null });
-      const out = await client.get<{ items: IdeaSyncRow[] }>(`/v1/sync/ideas?${qs}`);
-      return out.items;
+      return fetchAllSyncPages<IdeaSyncRow>(client, "/v1/sync/ideas", {
+        teamId,
+        since: updatedAfter ?? null,
+      });
     },
     async listSessionParticipantsForSync(sessionId, updatedAfter) {
-      const qs = buildQuery({ sessionId, since: updatedAfter ?? null });
-      const out = await client.get<{ items: SessionParticipantSyncRow[] }>(
-        `/v1/sync/session-participants?${qs}`,
-      );
-      return out.items;
+      return fetchAllSyncPages<SessionParticipantSyncRow>(client, "/v1/sync/session-participants", {
+        sessionId,
+        since: updatedAfter ?? null,
+      });
     },
   };
 }

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -272,9 +272,25 @@ export interface MessageSyncRow {
   updated_at: string;
 }
 
+/**
+ * One page of history, walking backward from the newest message.
+ *
+ * `rows` is oldest-first (what the transcript renders); `nextCursor` reaches the
+ * page immediately OLDER than this one, and is null once the session's start is
+ * reached. GET /v1/sessions/:id/messages used to return the entire history in
+ * one response — 6k messages measured 6.1s / 3.7MB and 40k timed out into a 500.
+ */
+export interface MessageHistoryPage {
+  rows: MessageHistoryRow[];
+  nextCursor: string | null;
+}
+
 export interface MessagesBackend {
   insertOutgoingMessage(input: OutgoingMessageInput): Promise<MessageHistoryRow>;
-  listMessages(sessionId: string): Promise<MessageHistoryRow[]>;
+  listMessages(
+    sessionId: string,
+    opts?: { limit?: number; cursor?: string | null },
+  ): Promise<MessageHistoryPage>;
   updateMessageContent(messageId: string, content: string): Promise<void>;
   listMessagesForSessionSince(sessionId: string, updatedAfter?: string | null): Promise<MessageSyncRow[]>;
 }

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -199,11 +199,10 @@ export interface SessionsBackend {
    * the app at all without a current team (AuthGate.tsx, `bootstrap ===
    * "ready"`).
    *
-   * The query param is still optional on the wire, and deliberately so: FC
-   * redeploys on merge while desktop and iOS ship on tags, so already-released
-   * builds keep working through a deprecated un-scoped fallback
-   * (list_current_actor_sessions_all_teams). Requiring it in this type is what
-   * keeps NEW code off that path.
+   * It is required on the wire too, as of the drop of the un-scoped fallback
+   * (list_current_actor_sessions_all_teams): without a team the query cannot
+   * use an index and degraded linearly with the caller's history — 4.5s at 6k
+   * sessions, a statement-timeout 500 past ~13k. Omitting it is now a 400.
    */
   listCurrentActorSessions(args: {
     limit: number;
@@ -218,7 +217,6 @@ export interface SessionsBackend {
   getSessionParticipants(sessionId: string): Promise<SessionParticipant[]>;
   getSession(sessionId: string): Promise<SessionDetailRow | null>;
   joinSession(sessionId: string): Promise<SessionDetailRow>;
-  getSessionTeamId(sessionId: string): Promise<string | null>;
   listSessionsForTeamSince(teamId: string, updatedAfter: string): Promise<SessionSyncRow[]>;
   listSessionDisplayRows(teamId: string, sessionIds: string[]): Promise<SessionDisplayRow[]>;
 }

--- a/packages/app/src/lib/cron-session-messages.ts
+++ b/packages/app/src/lib/cron-session-messages.ts
@@ -21,25 +21,31 @@ import { useCurrentTeamStore } from "@/stores/current-team";
  * creates one — the list otherwise only picks the row up on its own poll.
  */
 export async function ensureCronSessionVisible(sessionId: string): Promise<void> {
-  // Fetch session's team from cloud (always do this to verify access)
-  const teamId = await getBackend().sessions.getSessionTeamId(sessionId);
+  // A cron session belongs to the team you are in. This used to look the team
+  // up from the session id and then `enterTeam` into whatever came back, which
+  // meant a cron surface could yank you into another team's session; a run
+  // history should only ever show its own team's runs. Scoping to the current
+  // team makes a foreign session id simply "not found".
+  const teamId = useCurrentTeamStore.getState().team?.id ?? null;
   if (!teamId) {
     throw new Error(
       i18n.t("settings.cron.sessionNotFound", { id: sessionId.slice(0, 8) }),
     );
   }
 
-  // Switch teams if needed
-  const activeTeamId = useCurrentTeamStore.getState().team?.id ?? null;
-  if (activeTeamId !== teamId) {
-    await useCurrentTeamStore.getState().enterTeam(teamId);
-  }
-
   // Skip upsert if already in list (may have been added by a previous call)
   if (useSessionListStore.getState().rows.some((row) => row.id === sessionId)) return;
 
-  // Fetch display row for title, then upsert into list store
+  // One team-scoped request doing double duty: it fetches the title AND proves
+  // the session is ours — display-rows is filtered by team, so a session from
+  // another team comes back empty. (This replaced a getSessionTeamId call that
+  // ran ahead of it purely to "verify access", so this is one request fewer.)
   const [displayRow] = await getBackend().sessions.listSessionDisplayRows(teamId, [sessionId]);
+  if (!displayRow) {
+    throw new Error(
+      i18n.t("settings.cron.sessionNotFound", { id: sessionId.slice(0, 8) }),
+    );
+  }
   useSessionListStore.getState().upsertRows([
     {
       id: sessionId,
@@ -147,7 +153,7 @@ export async function hydrateCronSessionMessages(
 
   if (opts?.syncCache !== false && isTauri() && rows.length > 0) {
     try {
-      const teamId = await getBackend().sessions.getSessionTeamId(sessionId);
+      const teamId = useCurrentTeamStore.getState().team?.id ?? null;
       if (teamId) {
         await syncMessagesForSession(sessionId, teamId, { full: true });
         const { loadMessagesForSession } = await import("@/lib/local-cache");

--- a/packages/app/src/lib/cron-session-messages.ts
+++ b/packages/app/src/lib/cron-session-messages.ts
@@ -123,7 +123,7 @@ export async function hydrateCronSessionMessages(
 ): Promise<number> {
   let rows: MessageHistoryRow[] = [];
   try {
-    rows = await getBackend().messages.listMessages(sessionId);
+    rows = (await getBackend().messages.listMessages(sessionId)).rows;
   } catch (error) {
     console.warn(
       "[cron-session] cloud listMessages failed:",

--- a/packages/app/src/lib/send-path-resolve.ts
+++ b/packages/app/src/lib/send-path-resolve.ts
@@ -25,18 +25,21 @@ export function trySyncMentionActorIds(
  * (capped, lazily-loaded) list would otherwise be sent under the wrong team and
  * the Cloud insert would fail.
  */
-export async function resolveSendTeamId(args: {
-  sessionId: string;
+/**
+ * The team to send into: the session's own row if the list has it, else the
+ * team you are currently in.
+ *
+ * There used to be a middle step that asked the backend to resolve a team from
+ * a bare session id. It is gone on purpose — session reads are team-scoped now,
+ * and a composer is always inside the team you are looking at, so the current
+ * team is the right answer whenever the list row has not loaded yet. Removing
+ * it also drops a network round-trip from the send path.
+ */
+export function resolveSendTeamId(args: {
   teamIdFromSessionList: string | null;
-  fetchSessionTeamId: (sessionId: string) => Promise<string | null>;
   currentTeamId: () => string | null;
-}): Promise<string | null> {
-  if (args.teamIdFromSessionList) return args.teamIdFromSessionList;
-  if (args.sessionId) {
-    const fromBackend = await args.fetchSessionTeamId(args.sessionId);
-    if (fromBackend) return fromBackend;
-  }
-  return args.currentTeamId();
+}): string | null {
+  return args.teamIdFromSessionList ?? args.currentTeamId();
 }
 
 /**

--- a/packages/app/src/stores/session-messages.ts
+++ b/packages/app/src/stores/session-messages.ts
@@ -107,11 +107,13 @@ export function createMessageActions(set: SessionSet, get: SessionGet) {
     const authSession = useAuthStore.getState().session;
     if (!authSession) throw new Error("No authenticated user session");
 
-    let teamId =
-      useSessionListStore.getState().rows.find((row) => row.id === sessionId)?.team_id ?? null;
-    if (!teamId) {
-      teamId = await getBackend().sessions.getSessionTeamId(sessionId);
-    }
+    // The session's own row if the list has it, else the team we are in — a
+    // composer only ever exists inside the current team. (This used to resolve
+    // the team from a bare session id, which session reads no longer support.)
+    const teamId =
+      useSessionListStore.getState().rows.find((row) => row.id === sessionId)?.team_id ??
+      useCurrentTeamStore.getState().team?.id ??
+      null;
     if (!teamId) throw new Error(`No team_id found for session ${sessionId}`);
 
     const currentTeam = useCurrentTeamStore.getState().team;

--- a/services/fc/src/lib/pg-repo/actors.ts
+++ b/services/fc/src/lib/pg-repo/actors.ts
@@ -16,10 +16,11 @@
  *   all team-visible agents (matching Supabase default behavior).
  */
 
-import { and, desc, eq, inArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, or, sql } from "drizzle-orm";
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { actors, agents, members, teamMembers, teams, actorDirectory, actorClientVersions } from "../../db/schema/index.js";
 import { resolveActorForTeam, requireActorForTeam } from "./authz.js";
+import { DEFAULT_LIST_LIMIT } from "../routing-utils.js";
 import { ApiError } from "../http-utils.js";
 
 const iso = (d: Date | string | null | undefined): string | null =>
@@ -341,10 +342,25 @@ export function makeActorsRepo(db: DbLike, ctx: ActorsCtx = {}) {
      * No visibility filter applied — matches the permissive Supabase behavior
      * used by the sync service which already runs with elevated privileges.
      */
-    async listActorDirectoryForSync(teamId: string, updatedAfter: string | null) {
+    // Keyset-paginated on (updated_at, id). Unbounded before: a team with 10k
+    // actors returned 3.1MB in a single response.
+    async listActorDirectoryForSync(
+      teamId: string,
+      updatedAfter: string | null,
+      { limit = DEFAULT_LIST_LIMIT, cursor = null }: {
+        limit?: number;
+        cursor?: { updatedAt?: string | null; id?: string | null } | null;
+      } = {},
+    ) {
       const conditions = [eq(actorDirectory.teamId, teamId)];
       if (updatedAfter) {
         conditions.push(sql`${actorDirectory.updatedAt} > ${updatedAfter}::timestamptz`);
+      }
+      if (cursor?.updatedAt) {
+        const at = cursor.updatedAt;
+        conditions.push(
+          sql`(${actorDirectory.updatedAt} > ${at}::timestamptz OR (${actorDirectory.updatedAt} = ${at}::timestamptz AND ${actorDirectory.id} > ${cursor.id ?? null}))`,
+        );
       }
       const rows = await db
         .select({
@@ -359,7 +375,9 @@ export function makeActorsRepo(db: DbLike, ctx: ActorsCtx = {}) {
           updatedAt: actorDirectory.updatedAt,
         })
         .from(actorDirectory)
-        .where(and(...conditions));
+        .where(and(...conditions))
+        .orderBy(asc(actorDirectory.updatedAt), asc(actorDirectory.id))
+        .limit(limit);
       return rows.map((r: any) => ({
         id: r.id,
         team_id: r.teamId,

--- a/services/fc/src/lib/pg-repo/ideas.ts
+++ b/services/fc/src/lib/pg-repo/ideas.ts
@@ -20,9 +20,15 @@
  *  - kind          ← idea_activities.activityType (schema column rename)
  */
 
-import { and, asc, desc, eq, gt, inArray, lt } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, lt, sql } from "drizzle-orm";
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { ideas, ideaActivities } from "../../db/schema/index.js";
+import { DEFAULT_LIST_LIMIT } from "../routing-utils.js";
+
+type SyncPageOpts = {
+  limit?: number;
+  cursor?: { updatedAt?: string | null; id?: string | null } | null;
+};
 import { ApiError } from "../http-utils.js";
 import { requireActorForTeam } from "./authz.js";
 
@@ -229,13 +235,27 @@ export function makeIdeasRepo(db: DbLike, ctx: IdeasCtx = {}) {
     // ── Sync ──────────────────────────────────────────────────────────────
     // Snake_case wire shape — consumed directly by the client's lib/sync/idea-sync.ts
     // (no client mapper). Matches supabase-repo's listIdeasForSync SELECT columns.
-    async listIdeasForSync(teamId: string, updatedAfter: string | null) {
-      const rows = updatedAfter
-        ? await db
-            .select()
-            .from(ideas)
-            .where(and(eq(ideas.teamId, teamId), gt(ideas.updatedAt, new Date(updatedAfter))))
-        : await db.select().from(ideas).where(eq(ideas.teamId, teamId));
+    // Keyset-paginated on (updated_at, id) like every other *ForSync reader —
+    // see applySyncKeyset in supabase-repo for why the tiebreak matters.
+    async listIdeasForSync(
+      teamId: string,
+      updatedAfter: string | null,
+      { limit = DEFAULT_LIST_LIMIT, cursor = null }: SyncPageOpts = {},
+    ) {
+      const conditions = [eq(ideas.teamId, teamId)];
+      if (updatedAfter) conditions.push(gt(ideas.updatedAt, new Date(updatedAfter)));
+      if (cursor?.updatedAt) {
+        const at = new Date(cursor.updatedAt);
+        conditions.push(
+          sql`(${ideas.updatedAt} > ${at} OR (${ideas.updatedAt} = ${at} AND ${ideas.id} > ${cursor.id ?? null}))`,
+        );
+      }
+      const rows = await db
+        .select()
+        .from(ideas)
+        .where(and(...conditions))
+        .orderBy(asc(ideas.updatedAt), asc(ideas.id))
+        .limit(limit);
       return rows.map((r: any) => ({
         id: r.id,
         team_id: r.teamId,

--- a/services/fc/src/lib/pg-repo/messages.ts
+++ b/services/fc/src/lib/pg-repo/messages.ts
@@ -8,10 +8,11 @@
  *   consistent error.code of either "23505" or "conflict".
  */
 
-import { and, asc, eq, gt } from "drizzle-orm";
+import { and, asc, desc, eq, gt, lt, or, sql } from "drizzle-orm";
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { messages } from "../../db/schema/index.js";
 import { ApiError } from "../http-utils.js";
+import { DEFAULT_MESSAGE_LIST_LIMIT } from "../routing-utils.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DbLike = PgDatabase<any, any>;
@@ -80,13 +81,32 @@ function isPkViolation(err: any): boolean {
 export function makeMessagesRepo(db: DbLike, deps?: MessagesRepoDeps) {
   return {
     // ── listMessages ──────────────────────────────────────────────────────────
-    async listMessages(sessionId: string) {
+    // Mirrors supabase-repo: fetch the NEWEST `limit` rows (so the limit cuts
+    // the old end of the history), then reverse so the page reads oldest-first.
+    // `cursor` walks backward into older messages.
+    async listMessages(
+      sessionId: string,
+      { limit = DEFAULT_MESSAGE_LIST_LIMIT, cursor = null }: {
+        limit?: number;
+        cursor?: { createdAt?: string | null; id?: string | null } | null;
+      } = {},
+    ) {
+      const keyset = cursor?.createdAt
+        ? or(
+            lt(messages.createdAt, new Date(cursor.createdAt)),
+            and(
+              eq(messages.createdAt, new Date(cursor.createdAt)),
+              lt(messages.id, sql`${cursor.id ?? null}`),
+            ),
+          )
+        : undefined;
       const rows = await db
         .select()
         .from(messages)
-        .where(eq(messages.sessionId, sessionId))
-        .orderBy(asc(messages.createdAt), asc(messages.id));
-      return rows.map(mapMessage);
+        .where(keyset ? and(eq(messages.sessionId, sessionId), keyset) : eq(messages.sessionId, sessionId))
+        .orderBy(desc(messages.createdAt), desc(messages.id))
+        .limit(limit);
+      return rows.map(mapMessage).reverse();
     },
 
     // ── insertMessage ─────────────────────────────────────────────────────────

--- a/services/fc/src/lib/pg-repo/messages.ts
+++ b/services/fc/src/lib/pg-repo/messages.ts
@@ -12,7 +12,7 @@ import { and, asc, desc, eq, gt, lt, or, sql } from "drizzle-orm";
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { messages } from "../../db/schema/index.js";
 import { ApiError } from "../http-utils.js";
-import { DEFAULT_MESSAGE_LIST_LIMIT } from "../routing-utils.js";
+import { DEFAULT_LIST_LIMIT, DEFAULT_MESSAGE_LIST_LIMIT } from "../routing-utils.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DbLike = PgDatabase<any, any>;
@@ -187,18 +187,30 @@ export function makeMessagesRepo(db: DbLike, deps?: MessagesRepoDeps) {
     },
 
     // ── listMessagesForSessionSince ───────────────────────────────────────────
-    async listMessagesForSessionSince(sessionId: string, updatedAfter: string | null) {
-      const rows = updatedAfter
-        ? await db
-            .select()
-            .from(messages)
-            .where(
-              and(
-                eq(messages.sessionId, sessionId),
-                gt(messages.updatedAt, new Date(updatedAfter)),
-              ),
-            )
-        : await db.select().from(messages).where(eq(messages.sessionId, sessionId));
+    // Keyset-paginated on (updated_at, id). This was unbounded, so a first sync
+    // of a long-running session pulled its entire history in one response.
+    async listMessagesForSessionSince(
+      sessionId: string,
+      updatedAfter: string | null,
+      { limit = DEFAULT_LIST_LIMIT, cursor = null }: {
+        limit?: number;
+        cursor?: { updatedAt?: string | null; id?: string | null } | null;
+      } = {},
+    ) {
+      const conditions = [eq(messages.sessionId, sessionId)];
+      if (updatedAfter) conditions.push(gt(messages.updatedAt, new Date(updatedAfter)));
+      if (cursor?.updatedAt) {
+        const at = new Date(cursor.updatedAt);
+        conditions.push(
+          sql`(${messages.updatedAt} > ${at} OR (${messages.updatedAt} = ${at} AND ${messages.id} > ${cursor.id ?? null}))`,
+        );
+      }
+      const rows = await db
+        .select()
+        .from(messages)
+        .where(and(...conditions))
+        .orderBy(asc(messages.updatedAt), asc(messages.id))
+        .limit(limit);
       return rows.map(mapMessageSyncRow);
     },
   };

--- a/services/fc/src/lib/pg-repo/sessions.ts
+++ b/services/fc/src/lib/pg-repo/sessions.ts
@@ -33,6 +33,7 @@ import {
 } from "../../db/schema/index.js";
 import { ApiError } from "../http-utils.js";
 import { requireActorForTeam, resolveActorForTeam } from "./authz.js";
+import { DEFAULT_LIST_LIMIT } from "../routing-utils.js";
 
 const iso = (d: Date | string | null | undefined): string | null =>
   d ? new Date(d).toISOString() : null;
@@ -797,7 +798,7 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
     async listSessionsForTeamSince(
       teamId: string,
       updatedAfter: string | null,
-      { limit = 50, cursor = null }: { limit?: number; cursor?: { updatedAt?: string | null; id?: string } | null } = {},
+      { limit = DEFAULT_LIST_LIMIT, cursor = null }: { limit?: number; cursor?: { updatedAt?: string | null; id?: string } | null } = {},
     ) {
       const conditions = [eq(sessions.teamId, teamId)];
       if (updatedAfter) conditions.push(gt(sessions.updatedAt, new Date(updatedAfter)));
@@ -907,18 +908,31 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
     },
 
     // ── listSessionParticipantsForSync ────────────────────────────────────────
-    async listSessionParticipantsForSync(sessionId: string, updatedAfter: string | null) {
-      const rows = updatedAfter
-        ? await db
-            .select()
-            .from(sessionParticipants)
-            .where(
-              and(
-                eq(sessionParticipants.sessionId, sessionId),
-                gt(sessionParticipants.updatedAt, new Date(updatedAfter)),
-              ),
-            )
-        : await db.select().from(sessionParticipants).where(eq(sessionParticipants.sessionId, sessionId));
+    // Keyset-paginated on (updated_at, id), like the other *ForSync readers.
+    async listSessionParticipantsForSync(
+      sessionId: string,
+      updatedAfter: string | null,
+      { limit = DEFAULT_LIST_LIMIT, cursor = null }: {
+        limit?: number;
+        cursor?: { updatedAt?: string | null; id?: string | null } | null;
+      } = {},
+    ) {
+      const conditions = [eq(sessionParticipants.sessionId, sessionId)];
+      if (updatedAfter) {
+        conditions.push(gt(sessionParticipants.updatedAt, new Date(updatedAfter)));
+      }
+      if (cursor?.updatedAt) {
+        const at = new Date(cursor.updatedAt);
+        conditions.push(
+          sql`(${sessionParticipants.updatedAt} > ${at} OR (${sessionParticipants.updatedAt} = ${at} AND ${sessionParticipants.id} > ${cursor.id ?? null}))`,
+        );
+      }
+      const rows = await db
+        .select()
+        .from(sessionParticipants)
+        .where(and(...conditions))
+        .orderBy(asc(sessionParticipants.updatedAt), asc(sessionParticipants.id))
+        .limit(limit);
       return rows.map(mapSessionParticipantSyncRow);
     },
   };

--- a/services/fc/src/lib/pg-repo/sessions.ts
+++ b/services/fc/src/lib/pg-repo/sessions.ts
@@ -191,6 +191,13 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
       limit?: number;
       cursor?: { lastMessageAt?: string | null; createdAt?: string; id?: string } | null;
     } = {}) {
+      // teamId is required, matching GET /v1/sessions and the supabase-repo
+      // path: a team is what identifies the caller's actor, and on the supabase
+      // side it is also the only thing that keeps the query on an index.
+      if (!teamId) {
+        throw new ApiError(400, "validation_failed", "teamId is required");
+      }
+
       // Resolve the caller's actor ids from the authenticated user.
       const actorIds = ctx.userId ? await resolveActorIdsForUser(ctx.userId) : [];
       if (actorIds.length === 0) {
@@ -305,8 +312,15 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
     },
 
     // ── getSession ────────────────────────────────────────────────────────────
-    async getSession(sessionId: string) {
-      const [r] = await db.select().from(sessions).where(eq(sessions.id, sessionId)).limit(1);
+    // `teamId` is required by GET /v1/sessions/:sessionId and optional here, so
+    // the internal callers that already own the row can keep calling it with an
+    // id alone. Mirrors the supabase-repo signature.
+    async getSession(sessionId: string, { teamId }: { teamId?: string | null } = {}) {
+      const [r] = await db
+        .select()
+        .from(sessions)
+        .where(teamId ? and(eq(sessions.id, sessionId), eq(sessions.teamId, teamId)) : eq(sessions.id, sessionId))
+        .limit(1);
       if (!r) return null;
       const parts = await db
         .select()

--- a/services/fc/src/lib/routes/messages.ts
+++ b/services/fc/src/lib/routes/messages.ts
@@ -1,10 +1,26 @@
 import { ApiError } from "../http-utils.js";
-import { requireString } from "../routing-utils.js";
+import {
+  requireString,
+  parseMessageLimit,
+  decodeMessageCursor,
+  nextMessageCursor,
+} from "../routing-utils.js";
 
 export function registerMessages(router) {
+  // Paginated backward from the newest message. `nextCursor` was hardcoded to
+  // null here while the repository fetched the entire history unbounded, so a
+  // long-running session degraded until it timed out — see the limits in
+  // routing-utils. Omitting `limit` now yields the most recent
+  // DEFAULT_MESSAGE_LIST_LIMIT messages (oldest-first within the page) plus a
+  // cursor for the page before it.
   router.get("/v1/sessions/:sessionId/messages", async (ctx) => {
-    const items = await ctx.repository.listMessages(decodeURIComponent(ctx.params.sessionId));
-    return { body: { items, nextCursor: null } };
+    const limit = parseMessageLimit(ctx.query.get("limit"));
+    const cursor = decodeMessageCursor(ctx.query.get("cursor"));
+    const items = await ctx.repository.listMessages(
+      decodeURIComponent(ctx.params.sessionId),
+      { limit, cursor },
+    );
+    return { body: { items, nextCursor: nextMessageCursor(items, limit) } };
   });
 
   router.post("/v1/sessions/:sessionId/messages", async (ctx) => {

--- a/services/fc/src/lib/routes/sessions.ts
+++ b/services/fc/src/lib/routes/sessions.ts
@@ -6,16 +6,19 @@ export function registerSessions(router) {
   // correct under pagination. They are what replaced the removed
   // GET /v1/teams/:teamId/sessions — see 20260802000000.
   //
-  // teamId is required of CURRENT clients: since 20260804020000 the caller's
-  // actor is resolved per team (one actor row per user per team), so a team is
-  // what identifies who is asking. It stays optional on the wire because FC
-  // redeploys on merge while desktop and iOS ship on tags — a released build
-  // that omits it falls back to the deprecated un-scoped list rather than
-  // losing its session list. See the repository for that fallback.
+  // teamId is REQUIRED. Since 20260804020000 the caller's actor is resolved per
+  // team (one actor row per user per team), so a team is what identifies who is
+  // asking — and it is also the only thing that lets this query use
+  // `sessions_team_active_last_message_idx`. The un-scoped fallback that used to
+  // serve callers omitting it was O(N) in the caller's session count: measured
+  // on 47.112.210.217, 6k sessions took 4.5s and anything past ~13k blew the
+  // `authenticated` role's 8s statement_timeout and came back as a 500. A
+  // released build that omits teamId now gets an honest 400 instead of a list
+  // that degrades into timeouts as its history grows.
   router.get("/v1/sessions", async (ctx) => {
     const limit = parseLimit(ctx.query.get("limit"));
     const cursor = decodeCursor(ctx.query.get("cursor"));
-    const teamId = ctx.query.get("teamId") || null;
+    const teamId = requireString(ctx.query.get("teamId"), "teamId");
     const ideaId = ctx.query.get("ideaId") || null;
     const items = await ctx.repository.listSessions({ limit, cursor, teamId, ideaId });
     return { body: { items, nextCursor: nextSessionCursor(items, limit) } };
@@ -52,9 +55,14 @@ export function registerSessions(router) {
     return { body: out };
   });
 
+  // teamId is required here for the same reason as on the list: it is what
+  // scopes a read to a team the caller has an actor in. Passing it also turns a
+  // cross-team id into a 404 at the query level rather than relying on RLS
+  // alone to hide the row.
   router.get("/v1/sessions/:sessionId", async (ctx) => {
     const sessionId = decodeURIComponent(ctx.params.sessionId);
-    const out = await ctx.repository.getSession(sessionId);
+    const teamId = requireString(ctx.query.get("teamId"), "teamId");
+    const out = await ctx.repository.getSession(sessionId, { teamId });
     if (!out) throw new ApiError(404, "not_found", "session not found");
     return { body: out };
   });

--- a/services/fc/src/lib/routes/sync.ts
+++ b/services/fc/src/lib/routes/sync.ts
@@ -1,40 +1,58 @@
 import { ApiError } from "../http-utils.js";
 import { parseLimit, decodeSyncCursor, nextSyncCursor } from "../routing-utils.js";
 
+/**
+ * Incremental sync readers.
+ *
+ * Every route here is paginated on (updated_at, id) and reports `nextCursor`.
+ * They used to return every changed row in a single response, which made a
+ * first-time sync of a large team unbounded — 10k actors measured 3.1MB / 4.4s
+ * on /v1/sync/actor-directory, and /v1/sync/messages had the same shape over a
+ * session's whole history.
+ *
+ * Consequence for callers: a client that ignores `nextCursor` now sees only the
+ * first page, so every consumer MUST page to exhaustion. That is the same
+ * contract /v1/sync/sessions already had.
+ */
 export function registerSync(router) {
+  // Reads the shared `limit`/`cursor` pair off a request.
+  const page = (ctx) => ({
+    limit: parseLimit(ctx.query.get("limit")),
+    cursor: decodeSyncCursor(ctx.query.get("cursor")),
+  });
+
   router.get("/v1/sync/actor-directory", async (ctx) => {
     const teamId = ctx.query.get("teamId");
     if (!teamId) throw new ApiError(400, "validation_failed", "teamId is required");
     const since = ctx.query.get("since") || null;
-    const items = await ctx.repository.listActorDirectoryForSync(teamId, since);
-    return { body: { items } };
+    const { limit, cursor } = page(ctx);
+    const items = await ctx.repository.listActorDirectoryForSync(teamId, since, { limit, cursor });
+    return { body: { items, nextCursor: nextSyncCursor(items, limit) } };
   });
 
   router.get("/v1/sync/ideas", async (ctx) => {
     const teamId = ctx.query.get("teamId");
     if (!teamId) throw new ApiError(400, "validation_failed", "teamId is required");
     const since = ctx.query.get("since") || null;
-    const items = await ctx.repository.listIdeasForSync(teamId, since);
-    return { body: { items } };
+    const { limit, cursor } = page(ctx);
+    const items = await ctx.repository.listIdeasForSync(teamId, since, { limit, cursor });
+    return { body: { items, nextCursor: nextSyncCursor(items, limit) } };
   });
 
   router.get("/v1/sync/session-participants", async (ctx) => {
     const sessionId = ctx.query.get("sessionId");
     if (!sessionId) throw new ApiError(400, "validation_failed", "sessionId is required");
     const since = ctx.query.get("since") || null;
-    const items = await ctx.repository.listSessionParticipantsForSync(sessionId, since);
-    return { body: { items } };
+    const { limit, cursor } = page(ctx);
+    const items = await ctx.repository.listSessionParticipantsForSync(sessionId, since, { limit, cursor });
+    return { body: { items, nextCursor: nextSyncCursor(items, limit) } };
   });
 
-  // Paginated: a first-time sync of a large team used to return every session
-  // row in one response. `limit`/`cursor` are optional — omitting the cursor
-  // starts at the beginning, and `nextCursor` is null on the last page.
   router.get("/v1/sync/sessions", async (ctx) => {
     const teamId = ctx.query.get("teamId");
     if (!teamId) throw new ApiError(400, "validation_failed", "teamId is required");
     const since = ctx.query.get("since") || null;
-    const limit = parseLimit(ctx.query.get("limit"));
-    const cursor = decodeSyncCursor(ctx.query.get("cursor"));
+    const { limit, cursor } = page(ctx);
     const items = await ctx.repository.listSessionsForTeamSince(teamId, since, { limit, cursor });
     return { body: { items, nextCursor: nextSyncCursor(items, limit) } };
   });
@@ -43,7 +61,8 @@ export function registerSync(router) {
     const sessionId = ctx.query.get("sessionId");
     if (!sessionId) throw new ApiError(400, "validation_failed", "sessionId is required");
     const since = ctx.query.get("since") || null;
-    const items = await ctx.repository.listMessagesForSessionSince(sessionId, since);
-    return { body: { items } };
+    const { limit, cursor } = page(ctx);
+    const items = await ctx.repository.listMessagesForSessionSince(sessionId, since, { limit, cursor });
+    return { body: { items, nextCursor: nextSyncCursor(items, limit) } };
   });
 }

--- a/services/fc/src/lib/routing-utils.ts
+++ b/services/fc/src/lib/routing-utils.ts
@@ -62,6 +62,57 @@ export function nextSyncCursor(items, limit) {
   });
 }
 
+// Message history has its own limits because its page is a chat viewport, not a
+// list row: 200 is roughly what a client renders on open, where 50 would force
+// an immediate second round-trip. Before this existed the endpoint had no limit
+// at all and returned the whole history — 6k messages measured 6.1s / 3.7MB, 20k
+// took 22.9s, and 40k exceeded the 8s statement_timeout and 500'd.
+export const DEFAULT_MESSAGE_LIST_LIMIT = 200;
+export const MAX_MESSAGE_LIST_LIMIT = 500;
+
+// A message page walks BACKWARD from the newest message, because that is what a
+// chat opens on: the first page is the tail of the history, and `nextCursor`
+// reaches further into the past. Items inside a page stay oldest-first so
+// clients can keep rendering them in order.
+export function decodeMessageCursor(value) {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    if (!parsed || typeof parsed !== "object") throw new Error("not an object");
+    return {
+      createdAt: optionalStringOrNull(parsed.createdAt, "cursor.createdAt"),
+      id: optionalStringOrNull(parsed.id, "cursor.id"),
+    };
+  } catch (cause) {
+    throw new ApiError(400, "validation_failed", "Invalid cursor", { cause });
+  }
+}
+
+// The cursor points at the OLDEST row on the page (items[0]) — that is the
+// boundary the next, older page continues from.
+export function nextMessageCursor(items, limit) {
+  if (!Array.isArray(items) || items.length < limit) return null;
+  const oldest = items[0];
+  if (!oldest) return null;
+  return encodeCursor({
+    createdAt: oldest.createdAt ?? oldest.created_at ?? null,
+    id: oldest.id,
+  });
+}
+
+export function parseMessageLimit(value) {
+  if (value === null || value === undefined || value === "") return DEFAULT_MESSAGE_LIST_LIMIT;
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_MESSAGE_LIST_LIMIT) {
+    throw new ApiError(
+      400,
+      "validation_failed",
+      `limit must be an integer from 1 to ${MAX_MESSAGE_LIST_LIMIT}`,
+    );
+  }
+  return limit;
+}
+
 export function parseLimit(value) {
   if (value === null || value === undefined || value === "") return DEFAULT_LIST_LIMIT;
   const limit = Number(value);

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { createClient as defaultCreateClient } from "@supabase/supabase-js";
 import { verifyTrustedExternalJwt } from "./trusted-external-jwt.js";
 import { ApiError } from "./http-utils.js";
+import { DEFAULT_MESSAGE_LIST_LIMIT } from "./routing-utils.js";
 
 /**
  * Device ids that are not identities. Clients emit these when they cannot read
@@ -1105,14 +1106,20 @@ export function createSupabaseBusinessRepository(options) {
     },
 
     async getTeamDirectory(teamId) {
+      // Column names here are PostgREST aliases, not a rename: `actor_directory`
+      // exposes the discriminator as `actor_type` and `team_members` keys the
+      // actor as `member_id`. Selecting the mapper-side names directly (`kind`,
+      // `actor_id`) made this endpoint a guaranteed 500 — "column
+      // actor_directory.kind does not exist" — at any team size. Aliasing keeps
+      // mapActor/mapTeamMember and the response shape untouched.
       const [actorsRes, membersRes] = await Promise.all([
         supabase
           .from("actor_directory")
-          .select("id, team_id, kind, display_name, avatar_url, metadata")
+          .select("id, team_id, kind:actor_type, display_name, avatar_url")
           .eq("team_id", teamId),
         supabase
           .from("team_members")
-          .select("actor_id, team_id, role, joined_at")
+          .select("actor_id:member_id, team_id, role, joined_at")
           .eq("team_id", teamId),
       ]);
       if (actorsRes.error) throw actorsRes.error;
@@ -1125,15 +1132,18 @@ export function createSupabaseBusinessRepository(options) {
 
     async listSessions({ limit = 50, cursor = null, teamId = null, ideaId = null }: any = {}) {
       // p_team_id is what resolves the caller's actor as of 20260804020000,
-      // since a user has one actor row per team. Callers that predate that
-      // change send no teamId; they get the deprecated un-scoped RPC, which
-      // reproduces the old every-team list on the corrected identity (all of
-      // the caller's actors, not the oldest one). Delete this branch — and the
-      // function behind it — once no released client omits teamId.
-      const rpcName = teamId
-        ? "list_current_actor_sessions"
-        : "list_current_actor_sessions_all_teams";
-      const { data, error } = await supabase.rpc(rpcName, {
+      // since a user has one actor row per team. It is also load-bearing for
+      // performance: only the team-scoped RPC can walk
+      // `sessions_team_active_last_message_idx` and stop at `limit`. The
+      // un-scoped `list_current_actor_sessions_all_teams` fallback that used to
+      // serve callers without a teamId joined every participant row the caller
+      // had, RLS-checked each one, then sorted — O(N), 4.5s at 6k sessions and a
+      // statement_timeout 500 past ~13k. It is gone; the route rejects a missing
+      // teamId with a 400 before reaching here.
+      if (!teamId) {
+        throw new ApiError(400, "validation_failed", "teamId is required");
+      }
+      const { data, error } = await supabase.rpc("list_current_actor_sessions", {
         p_limit: limit,
         p_before_last_message_at: cursor?.lastMessageAt ?? null,
         p_before_created_at: cursor?.createdAt ?? null,
@@ -1141,23 +1151,36 @@ export function createSupabaseBusinessRepository(options) {
         // Narrowing happens inside the RPC (20260802000000). Doing it there
         // rather than post-filtering keeps the result correct under pagination
         // and is what lets this replace GET /v1/teams/:teamId/sessions.
-        ...(teamId ? { p_team_id: teamId } : {}),
+        p_team_id: teamId,
         p_idea_id: ideaId ?? null,
       });
       if (error) throw error;
       return (data ?? []).map(mapSession);
     },
 
-    async listMessages(sessionId) {
-      const query = supabase
+    // Newest-first on the way out of Postgres so `limit` truncates the OLD end
+    // of the history, then reversed so the page itself reads oldest-first — the
+    // order every client already renders in. Fetching ascending and slicing
+    // would keep the wrong end.
+    async listMessages(sessionId, { limit = DEFAULT_MESSAGE_LIST_LIMIT, cursor = null }: any = {}) {
+      let query = supabase
         .from("messages")
         .select(MESSAGE_COLUMNS)
         .eq("session_id", sessionId);
+      if (cursor?.createdAt) {
+        // Keyset: strictly before (createdAt, id). PostgREST has no row-value
+        // comparison, so express it as the equivalent OR — earlier timestamp, or
+        // same timestamp with a smaller id.
+        query = query.or(
+          `created_at.lt.${cursor.createdAt},and(created_at.eq.${cursor.createdAt},id.lt.${cursor.id})`,
+        );
+      }
       const { data, error } = await query
-        .order("created_at", { ascending: true })
-        .order("id", { ascending: true });
+        .order("created_at", { ascending: false })
+        .order("id", { ascending: false })
+        .limit(limit);
       if (error) throw error;
-      return (data ?? []).map(mapMessage);
+      return (data ?? []).map(mapMessage).reverse();
     },
 
     async insertMessage(sessionId, input) {
@@ -2056,12 +2079,17 @@ export function createSupabaseBusinessRepository(options) {
 
     // --- Sessions CRUD (single-session ops; list uses listSessions above) ---
 
-    async getSession(sessionId) {
-      const { data, error } = await supabase
+    async getSession(sessionId, { teamId = null }: any = {}) {
+      // `teamId` is supplied by GET /v1/sessions/:sessionId, where it is
+      // required. It stays optional on this method because the internal callers
+      // below (joinSession, createSession) already know the row is theirs and
+      // have no team in hand at that point.
+      let query = supabase
         .from("sessions")
         .select(SESSION_FULL_COLUMNS)
-        .eq("id", sessionId)
-        .maybeSingle();
+        .eq("id", sessionId);
+      if (teamId) query = query.eq("team_id", teamId);
+      const { data, error } = await query.maybeSingle();
       if (error) throw error;
       return data ? mapSessionFull(data) : null;
     },

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { createClient as defaultCreateClient } from "@supabase/supabase-js";
 import { verifyTrustedExternalJwt } from "./trusted-external-jwt.js";
 import { ApiError } from "./http-utils.js";
-import { DEFAULT_MESSAGE_LIST_LIMIT } from "./routing-utils.js";
+import { DEFAULT_LIST_LIMIT, DEFAULT_MESSAGE_LIST_LIMIT } from "./routing-utils.js";
 
 /**
  * Device ids that are not identities. Clients emit these when they cannot read
@@ -169,6 +169,32 @@ function guardedFetch(input: any, init?: any) {
  * `workspace_id` is NULL for member participants (not applicable, not missing),
  * so the equality filter already selects agent rows only.
  */
+/**
+ * Shared tail of every `*ForSync` reader: keyset on (updated_at, id), ascending,
+ * bounded by `limit`.
+ *
+ * All of them walk FORWARD — the sync contract is "everything changed since X",
+ * and `updated_at` is the only column that moves monotonically as rows are
+ * touched. Ordering is ascending and id-tiebroken so a cursor is meaningful:
+ * without the `id` tiebreak, rows sharing an `updated_at` could be skipped or
+ * repeated across a page boundary.
+ *
+ * PostgREST has no row-value comparison, so `(updated_at, id) > (u, i)` has to
+ * be spelled out as the equivalent OR.
+ */
+function applySyncKeyset(query, cursor, limit) {
+  let q = query;
+  if (cursor?.updatedAt) {
+    q = q.or(
+      `updated_at.gt.${cursor.updatedAt},and(updated_at.eq.${cursor.updatedAt},id.gt.${cursor.id})`,
+    );
+  }
+  return q
+    .order("updated_at", { ascending: true })
+    .order("id", { ascending: true })
+    .limit(limit);
+}
+
 async function archiveSessionsForWorkspace(supabase, workspaceId) {
   const { data: participants, error: rtError } = await supabase
     .from("session_participants")
@@ -1910,7 +1936,15 @@ export function createSupabaseBusinessRepository(options) {
 
     // --- Sync (incremental) ---
 
-    async listActorDirectoryForSync(teamId, updatedAfter) {
+    // Every *ForSync reader below walks FORWARD through (updated_at, id) — the
+    // sync contract is "everything changed since X", and updated_at is the only
+    // column that moves monotonically as rows are touched. They were unbounded:
+    // a first-time sync of a large team returned every row in one response
+    // (10k actors measured 3.1MB / 4.4s). `limit`/`cursor` are optional on the
+    // wire; a caller that ignores nextCursor now gets a truncated first page
+    // rather than a response that grows without limit, so clients MUST page to
+    // exhaustion — see applySyncKeyset for the shared shape.
+    async listActorDirectoryForSync(teamId, updatedAfter, { limit = DEFAULT_LIST_LIMIT, cursor = null }: any = {}) {
       let q = supabase
         .from("actor_directory")
         .select(
@@ -1918,12 +1952,12 @@ export function createSupabaseBusinessRepository(options) {
         )
         .eq("team_id", teamId);
       if (updatedAfter) q = q.gt("updated_at", updatedAfter);
-      const { data, error } = await q;
+      const { data, error } = await applySyncKeyset(q, cursor, limit);
       if (error) throw error;
       return data ?? [];
     },
 
-    async listIdeasForSync(teamId, updatedAfter) {
+    async listIdeasForSync(teamId, updatedAfter, { limit = DEFAULT_LIST_LIMIT, cursor = null }: any = {}) {
       let q = supabase
         .from("ideas")
         .select(
@@ -1931,18 +1965,18 @@ export function createSupabaseBusinessRepository(options) {
         )
         .eq("team_id", teamId);
       if (updatedAfter) q = q.gt("updated_at", updatedAfter);
-      const { data, error } = await q;
+      const { data, error } = await applySyncKeyset(q, cursor, limit);
       if (error) throw error;
       return data ?? [];
     },
 
-    async listSessionParticipantsForSync(sessionId, updatedAfter) {
+    async listSessionParticipantsForSync(sessionId, updatedAfter, { limit = DEFAULT_LIST_LIMIT, cursor = null }: any = {}) {
       let q = supabase
         .from("session_participants")
         .select("id, session_id, actor_id, joined_at, created_at, updated_at")
         .eq("session_id", sessionId);
       if (updatedAfter) q = q.gt("updated_at", updatedAfter);
-      const { data, error } = await q;
+      const { data, error } = await applySyncKeyset(q, cursor, limit);
       if (error) throw error;
       return data ?? [];
     },
@@ -1976,7 +2010,7 @@ export function createSupabaseBusinessRepository(options) {
     // existing default/pinned workspace config) ---
 
 
-    async listSessionsForTeamSince(teamId, updatedAfter, { limit = 50, cursor = null }: any = {}) {
+    async listSessionsForTeamSince(teamId, updatedAfter, { limit = DEFAULT_LIST_LIMIT, cursor = null }: any = {}) {
       const SESSION_SYNC_COLUMNS =
         "id, team_id, title, mode, primary_agent_id, idea_id, summary, last_message_preview, last_message_at, created_by_actor_id, source, cron_job_id, created_at, updated_at";
       let q = supabase
@@ -1984,25 +2018,12 @@ export function createSupabaseBusinessRepository(options) {
         .select(SESSION_SYNC_COLUMNS)
         .eq("team_id", teamId);
       if (updatedAfter) q = q.gt("updated_at", updatedAfter);
-      if (cursor?.updatedAt) {
-        // Keyset: strictly after (updatedAt, id). PostgREST has no row-value
-        // comparison, so express it as the equivalent OR — later timestamp, or
-        // same timestamp with a larger id.
-        q = q.or(
-          `updated_at.gt.${cursor.updatedAt},and(updated_at.eq.${cursor.updatedAt},id.gt.${cursor.id})`,
-        );
-      }
-      // Ascending and id-tiebroken so paging is deterministic: neither
-      // implementation ordered at all before, which made any cursor meaningless.
-      const { data, error } = await q
-        .order("updated_at", { ascending: true })
-        .order("id", { ascending: true })
-        .limit(limit);
+      const { data, error } = await applySyncKeyset(q, cursor, limit);
       if (error) throw error;
       return data ?? [];
     },
 
-    async listMessagesForSessionSince(sessionId, updatedAfter) {
+    async listMessagesForSessionSince(sessionId, updatedAfter, { limit = DEFAULT_LIST_LIMIT, cursor = null }: any = {}) {
       const MESSAGE_SYNC_COLUMNS =
         "id, team_id, session_id, turn_id, sender_actor_id, reply_to_message_id, kind, content, metadata, model, created_at, updated_at";
       let q = supabase
@@ -2010,7 +2031,7 @@ export function createSupabaseBusinessRepository(options) {
         .select(MESSAGE_SYNC_COLUMNS)
         .eq("session_id", sessionId);
       if (updatedAfter) q = q.gt("updated_at", updatedAfter);
-      const { data, error } = await q;
+      const { data, error } = await applySyncKeyset(q, cursor, limit);
       if (error) throw error;
       return data ?? [];
     },

--- a/services/fc/test/business-api.test.ts
+++ b/services/fc/test/business-api.test.ts
@@ -159,6 +159,71 @@ test("GET messages rejects a limit past the maximum", async () => {
   assert.equal(repo.calls.length, 0);
 });
 
+// ── /v1/sync/* pagination ────────────────────────────────────────────────────
+// These were unbounded: a first-time sync of a large team returned every
+// changed row in one response (10k actors measured 3.1MB / 4.4s). They are now
+// keyset-paginated on (updated_at, id), so callers must follow nextCursor.
+
+const SYNC_ROUTES = [
+  { path: "/v1/sync/actor-directory", query: { teamId: "team-1" }, method: "listActorDirectoryForSync" },
+  { path: "/v1/sync/ideas", query: { teamId: "team-1" }, method: "listIdeasForSync" },
+  { path: "/v1/sync/session-participants", query: { sessionId: "session-1" }, method: "listSessionParticipantsForSync" },
+  { path: "/v1/sync/sessions", query: { teamId: "team-1" }, method: "listSessionsForTeamSince" },
+  { path: "/v1/sync/messages", query: { sessionId: "session-1" }, method: "listMessagesForSessionSince" },
+];
+
+for (const route of SYNC_ROUTES) {
+  test(`GET ${route.path} forwards limit and cursor`, async () => {
+    const repo = fakeRepo({ syncRows: [] });
+    const cursor = Buffer.from(
+      JSON.stringify({ updatedAt: "2026-05-27T00:00:00Z", id: "row-7" }), "utf8",
+    ).toString("base64url");
+
+    const response = await handleBusinessApiRequest({
+      httpMethod: "GET",
+      path: route.path,
+      headers: { Authorization: "Bearer token" },
+      queryParameters: { ...route.query, limit: "10", cursor },
+    }, { createRepository: () => repo });
+
+    assert.equal(response.statusCode, 200);
+    const call = repo.calls[0];
+    assert.equal(call.method, route.method);
+    assert.equal(call.limit, 10);
+    assert.deepEqual(call.cursor, { updatedAt: "2026-05-27T00:00:00Z", id: "row-7" });
+  });
+
+  test(`GET ${route.path} reports a cursor on a full page and null on a short one`, async () => {
+    // A page that fills `limit` may have more behind it.
+    const full = fakeRepo({
+      syncRows: [
+        { id: "r1", updated_at: "2026-05-27T00:00:01Z" },
+        { id: "r2", updated_at: "2026-05-27T00:00:02Z" },
+      ],
+    });
+    const fullResponse = await handleBusinessApiRequest({
+      httpMethod: "GET",
+      path: route.path,
+      headers: { Authorization: "Bearer token" },
+      queryParameters: { ...route.query, limit: "2" },
+    }, { createRepository: () => full });
+    const fullBody = JSON.parse(fullResponse.body);
+    assert.ok(fullBody.nextCursor, "a full page must carry a cursor");
+    const decoded = JSON.parse(Buffer.from(fullBody.nextCursor, "base64url").toString("utf8"));
+    // The cursor is the LAST row — sync walks forward through (updated_at, id).
+    assert.deepEqual(decoded, { updatedAt: "2026-05-27T00:00:02Z", id: "r2" });
+
+    const short = fakeRepo({ syncRows: [{ id: "r1", updated_at: "2026-05-27T00:00:01Z" }] });
+    const shortResponse = await handleBusinessApiRequest({
+      httpMethod: "GET",
+      path: route.path,
+      headers: { Authorization: "Bearer token" },
+      queryParameters: { ...route.query, limit: "2" },
+    }, { createRepository: () => short });
+    assert.equal(JSON.parse(shortResponse.body).nextCursor, null);
+  });
+}
+
 test("insert message enforces narrow idempotency contract", async () => {
   const repo = fakeRepo();
 
@@ -1832,9 +1897,10 @@ test("GET /v1/teams/:teamId/leaderboard defaults to week period", async () => {
 
 
 
-function fakeRepo({ sessions = [], error = null, teamWorkspaceConfigs = {}, workspaces = [], ideas = null, messages = [] } = {}) {
+function fakeRepo({ sessions = [], error = null, teamWorkspaceConfigs = {}, workspaces = [], ideas = null, messages = [], syncRows = [] } = {}) {
   const calls = [];
   const messageStore = messages.slice();
+  const syncStore = syncRows.slice();
   const configs = { ...teamWorkspaceConfigs };
   const workspaceStore = workspaces.length > 0 ? workspaces.slice() : [
     { id: "workspace-1", teamId: "team-1", name: "Alpha", slug: null, archived: false, metadata: null, createdAt: "2026-05-01T00:00:00Z", updatedAt: "2026-05-01T00:00:00Z" },
@@ -1865,6 +1931,11 @@ function fakeRepo({ sessions = [], error = null, teamWorkspaceConfigs = {}, work
     async getSessionByAcp(acpSessionId) { calls.push({ method: "getSessionByAcp", acpSessionId }); if (error) throw error; return gatewayBindings[acpSessionId] ?? null; },
     async ensureGatewaySession(input) { calls.push({ method: "ensureGatewaySession", input }); if (error) throw error; const b = input.binding; if (gatewayBindings[b]) return { ...gatewayBindings[b], created: false }; const r = { sessionId: "gw-" + b, gatewaySessionId: b, created: true }; gatewayBindings[b] = r; return r; },
     async createCronSession(input) { calls.push({ method: "createCronSession", input }); if (error) throw error; return { sessionId: "cron-" + input.title }; },
+    async listActorDirectoryForSync(teamId, since, opts = {}) { calls.push({ method: "listActorDirectoryForSync", teamId, since, limit: opts?.limit ?? null, cursor: opts?.cursor ?? null }); return syncStore.slice(0, opts?.limit ?? syncStore.length); },
+    async listIdeasForSync(teamId, since, opts = {}) { calls.push({ method: "listIdeasForSync", teamId, since, limit: opts?.limit ?? null, cursor: opts?.cursor ?? null }); return syncStore.slice(0, opts?.limit ?? syncStore.length); },
+    async listSessionParticipantsForSync(sessionId, since, opts = {}) { calls.push({ method: "listSessionParticipantsForSync", sessionId, since, limit: opts?.limit ?? null, cursor: opts?.cursor ?? null }); return syncStore.slice(0, opts?.limit ?? syncStore.length); },
+    async listSessionsForTeamSince(teamId, since, opts = {}) { calls.push({ method: "listSessionsForTeamSince", teamId, since, limit: opts?.limit ?? null, cursor: opts?.cursor ?? null }); return syncStore.slice(0, opts?.limit ?? syncStore.length); },
+    async listMessagesForSessionSince(sessionId, since, opts = {}) { calls.push({ method: "listMessagesForSessionSince", sessionId, since, limit: opts?.limit ?? null, cursor: opts?.cursor ?? null }); return syncStore.slice(0, opts?.limit ?? syncStore.length); },
     async listMessages(sessionId, opts = {}) { calls.push({ method: "listMessages", sessionId, limit: opts?.limit ?? null, cursor: opts?.cursor ?? null }); if (error) throw error; return messageStore.slice(0, opts?.limit ?? messageStore.length); },
     async insertMessage(sessionId, input) { calls.push({ method: "insertMessage", sessionId, input }); if (error) throw error; return { id: input.id, teamId: input.teamId, sessionId, turnId: null, senderActorId: input.senderActorId, replyToMessageId: null, kind: input.kind ?? "text", content: input.content, metadata: input.metadata ?? null, model: null, createdAt: "2026-05-27T01:00:00Z", updatedAt: null }; },
     async patchMessage(messageId, patch) { calls.push({ method: "patchMessage", messageId, patch }); if (error) throw error; return { id: messageId, teamId: "team-1", sessionId: "session-1", turnId: null, senderActorId: "actor-1", replyToMessageId: null, kind: "text", content: patch.content ?? "hello", metadata: patch.metadata ?? null, model: null, createdAt: "2026-05-27T01:00:00Z", updatedAt: "2026-05-27T02:00:00Z" }; },

--- a/services/fc/test/business-api.test.ts
+++ b/services/fc/test/business-api.test.ts
@@ -5,6 +5,10 @@ import {
   encodeCursor,
   handleBusinessApiRequest,
 } from "../src/lib/business-api.js";
+import {
+  DEFAULT_MESSAGE_LIST_LIMIT,
+  MAX_MESSAGE_LIST_LIMIT,
+} from "../src/lib/routing-utils.js";
 
 test("handleBusinessApiRequest routes list sessions with bearer-scoped repository", async () => {
   const repo = fakeRepo({
@@ -72,6 +76,87 @@ test("list sessions decodes cursor before calling repository", async () => {
     createdAt: "2026-05-26T01:00:00Z",
     id: "s1",
   });
+});
+
+// ── GET /v1/sessions/:id/messages pagination ─────────────────────────────────
+// This endpoint had no limit and returned `nextCursor: null` unconditionally, so
+// a long session shipped its entire history every time — 6k messages measured
+// 6.1s / 3.7MB, and 40k exceeded the 8s statement_timeout as a 500.
+
+test("GET messages defaults to the newest page and reports a cursor", async () => {
+  const rows = Array.from({ length: DEFAULT_MESSAGE_LIST_LIMIT }, (_, i) => ({
+    id: `m${i}`, createdAt: `2026-05-27T00:00:${String(i % 60).padStart(2, "0")}Z`,
+  }));
+  const repo = fakeRepo({ messages: rows });
+
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/sessions/session-1/messages",
+    headers: { Authorization: "Bearer token" },
+  }, { createRepository: () => repo });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(repo.calls[0], {
+    method: "listMessages",
+    sessionId: "session-1",
+    limit: DEFAULT_MESSAGE_LIST_LIMIT,
+    cursor: null,
+  });
+  // A full page means there may be older messages, so the cursor must point at
+  // the OLDEST row on the page — items[0], since a page reads oldest-first.
+  const body = JSON.parse(response.body);
+  assert.ok(body.nextCursor, "a full page must carry a cursor");
+  const decoded = JSON.parse(Buffer.from(body.nextCursor, "base64url").toString("utf8"));
+  assert.equal(decoded.id, "m0");
+});
+
+test("GET messages omits the cursor on a short (final) page", async () => {
+  const repo = fakeRepo({ messages: [{ id: "only", createdAt: "2026-05-27T00:00:00Z" }] });
+
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/sessions/session-1/messages",
+    headers: { Authorization: "Bearer token" },
+  }, { createRepository: () => repo });
+
+  assert.equal(JSON.parse(response.body).nextCursor, null);
+});
+
+test("GET messages forwards limit and cursor to the repository", async () => {
+  const repo = fakeRepo({ messages: [] });
+  const cursor = Buffer.from(
+    JSON.stringify({ createdAt: "2026-05-27T00:00:00Z", id: "m-42" }), "utf8",
+  ).toString("base64url");
+
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/sessions/session-1/messages",
+    headers: { Authorization: "Bearer token" },
+    queryParameters: { limit: "10", cursor },
+  }, { createRepository: () => repo });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(repo.calls[0], {
+    method: "listMessages",
+    sessionId: "session-1",
+    limit: 10,
+    cursor: { createdAt: "2026-05-27T00:00:00Z", id: "m-42" },
+  });
+});
+
+test("GET messages rejects a limit past the maximum", async () => {
+  const repo = fakeRepo({ messages: [] });
+
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/sessions/session-1/messages",
+    headers: { Authorization: "Bearer token" },
+    queryParameters: { limit: String(MAX_MESSAGE_LIST_LIMIT + 1) },
+  }, { createRepository: () => repo });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(JSON.parse(response.body).error.code, "validation_failed");
+  assert.equal(repo.calls.length, 0);
 });
 
 test("insert message enforces narrow idempotency contract", async () => {
@@ -699,13 +784,27 @@ test("GET /v1/sessions/:sessionId returns session with participants", async () =
     httpMethod: "GET",
     path: "/v1/sessions/session-1",
     headers: { Authorization: "Bearer token" },
+    queryParameters: { teamId: "team-1" },
   }, { createRepository: () => repo });
 
   assert.equal(response.statusCode, 200);
   const body = JSON.parse(response.body);
   assert.equal(body.id, "session-1");
   assert.ok(Array.isArray(body.participants));
-  assert.deepEqual(repo.calls[0], { method: "getSession", sessionId: "session-1" });
+  assert.deepEqual(repo.calls[0], { method: "getSession", sessionId: "session-1", teamId: "team-1" });
+});
+
+test("GET /v1/sessions/:sessionId requires teamId", async () => {
+  const repo = fakeRepo();
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/sessions/session-1",
+    headers: { Authorization: "Bearer token" },
+  }, { createRepository: () => repo });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(JSON.parse(response.body).error.code, "validation_failed");
+  assert.equal(repo.calls.length, 0, "must not reach the repository without a team");
 });
 
 test("GET /v1/sessions/:sessionId returns 404 for missing session", async () => {
@@ -713,6 +812,7 @@ test("GET /v1/sessions/:sessionId returns 404 for missing session", async () => 
     httpMethod: "GET",
     path: "/v1/sessions/session-missing",
     headers: { Authorization: "Bearer token" },
+    queryParameters: { teamId: "team-1" },
   }, { createRepository: () => fakeRepo({ sessions: [] }) });
 
   assert.equal(response.statusCode, 404);
@@ -819,7 +919,13 @@ test("GET /v1/sessions narrows by teamId and ideaId server-side", async () => {
 // FC redeploys on merge, clients ship on tags. The repository routes a
 // team-less call to the deprecated un-scoped RPC — see
 // 20260804020000_per_team_actor_scope.sql.
-test("GET /v1/sessions still serves a client that sends no teamId", async () => {
+// Was "still serves a client that sends no teamId". The un-scoped fallback it
+// covered is gone: without a team the query cannot use
+// sessions_team_active_last_message_idx, so it degraded linearly with the
+// caller's history (4.5s at 6k sessions, statement_timeout 500 past ~13k).
+// A caller that omits teamId now gets a 400 instead of a list that silently
+// rots as it grows.
+test("GET /v1/sessions rejects a client that sends no teamId", async () => {
   const repo = fakeRepo();
   const response = await handleBusinessApiRequest({
     httpMethod: "GET",
@@ -827,11 +933,9 @@ test("GET /v1/sessions still serves a client that sends no teamId", async () => 
     headers: { Authorization: "Bearer token" },
   }, { createRepository: () => repo });
 
-  assert.equal(response.statusCode, 200);
-  assert.deepEqual(repo.calls[0], {
-    method: "listSessions",
-    args: { limit: 50, cursor: null, teamId: null, ideaId: null },
-  });
+  assert.equal(response.statusCode, 400);
+  assert.equal(JSON.parse(response.body).error.code, "validation_failed");
+  assert.equal(repo.calls.length, 0, "must not reach the repository without a team");
 });
 
 test("GET /v1/sessions leaves ideaId null when not supplied", async () => {
@@ -1728,8 +1832,9 @@ test("GET /v1/teams/:teamId/leaderboard defaults to week period", async () => {
 
 
 
-function fakeRepo({ sessions = [], error = null, teamWorkspaceConfigs = {}, workspaces = [], ideas = null } = {}) {
+function fakeRepo({ sessions = [], error = null, teamWorkspaceConfigs = {}, workspaces = [], ideas = null, messages = [] } = {}) {
   const calls = [];
+  const messageStore = messages.slice();
   const configs = { ...teamWorkspaceConfigs };
   const workspaceStore = workspaces.length > 0 ? workspaces.slice() : [
     { id: "workspace-1", teamId: "team-1", name: "Alpha", slug: null, archived: false, metadata: null, createdAt: "2026-05-01T00:00:00Z", updatedAt: "2026-05-01T00:00:00Z" },
@@ -1748,7 +1853,7 @@ function fakeRepo({ sessions = [], error = null, teamWorkspaceConfigs = {}, work
     async createTeam(input) { calls.push({ method: "createTeam", input }); if (error) throw error; return { id: "team-1", name: input.name, slug: input.slug ?? null, createdAt: null }; },
     async getTeam(teamId) { calls.push({ method: "getTeam", teamId }); if (error) throw error; return { id: teamId, name: "Team", slug: null, createdAt: null }; },
     async listSessions(args) { calls.push({ method: "listSessions", args }); if (error) throw error; return sessions.length > 0 ? sessions : sessionStore; },
-    async getSession(sessionId) { calls.push({ method: "getSession", sessionId }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; return store.find(s => s.id === sessionId) ?? null; },
+    async getSession(sessionId, opts = {}) { calls.push({ method: "getSession", sessionId, teamId: opts?.teamId ?? null }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; return store.find(s => s.id === sessionId) ?? null; },
     async patchSession(sessionId, patch) { calls.push({ method: "patchSession", sessionId, patch }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); if (!s) return null; if (patch.title !== undefined) s.title = patch.title; return s; },
     async createSession(input) { calls.push({ method: "createSession", input }); if (error) throw error; const id = input.id ?? "session-new"; const newS = { id, teamId: input.teamId, title: input.title, mode: input.mode, ideaId: null, lastMessageAt: null, lastMessagePreview: null, hasUnread: false, createdAt: "2026-05-27T03:00:00Z", updatedAt: "2026-05-27T03:00:00Z", participants: (input.participantActorIds ?? []).map(a => ({ sessionId: id, actorId: a, role: "member", joinedAt: null })) }; sessionStore.push(newS); return newS; },
     async markSessionViewed(sessionId, lastReadMessageId) { calls.push({ method: "markSessionViewed", sessionId, lastReadMessageId }); if (error) throw error; },
@@ -1760,7 +1865,7 @@ function fakeRepo({ sessions = [], error = null, teamWorkspaceConfigs = {}, work
     async getSessionByAcp(acpSessionId) { calls.push({ method: "getSessionByAcp", acpSessionId }); if (error) throw error; return gatewayBindings[acpSessionId] ?? null; },
     async ensureGatewaySession(input) { calls.push({ method: "ensureGatewaySession", input }); if (error) throw error; const b = input.binding; if (gatewayBindings[b]) return { ...gatewayBindings[b], created: false }; const r = { sessionId: "gw-" + b, gatewaySessionId: b, created: true }; gatewayBindings[b] = r; return r; },
     async createCronSession(input) { calls.push({ method: "createCronSession", input }); if (error) throw error; return { sessionId: "cron-" + input.title }; },
-    async listMessages(sessionId) { calls.push({ method: "listMessages", sessionId }); if (error) throw error; return []; },
+    async listMessages(sessionId, opts = {}) { calls.push({ method: "listMessages", sessionId, limit: opts?.limit ?? null, cursor: opts?.cursor ?? null }); if (error) throw error; return messageStore.slice(0, opts?.limit ?? messageStore.length); },
     async insertMessage(sessionId, input) { calls.push({ method: "insertMessage", sessionId, input }); if (error) throw error; return { id: input.id, teamId: input.teamId, sessionId, turnId: null, senderActorId: input.senderActorId, replyToMessageId: null, kind: input.kind ?? "text", content: input.content, metadata: input.metadata ?? null, model: null, createdAt: "2026-05-27T01:00:00Z", updatedAt: null }; },
     async patchMessage(messageId, patch) { calls.push({ method: "patchMessage", messageId, patch }); if (error) throw error; return { id: messageId, teamId: "team-1", sessionId: "session-1", turnId: null, senderActorId: "actor-1", replyToMessageId: null, kind: "text", content: patch.content ?? "hello", metadata: patch.metadata ?? null, model: null, createdAt: "2026-05-27T01:00:00Z", updatedAt: "2026-05-27T02:00:00Z" }; },
     async deleteMessage(messageId) { calls.push({ method: "deleteMessage", messageId }); if (error) throw error; },

--- a/services/fc/test/missing-endpoints.test.ts
+++ b/services/fc/test/missing-endpoints.test.ts
@@ -127,7 +127,13 @@ test("GET /v1/sync/messages forwards sessionId+since", async () => {
     query: { sessionId: "s1" },
   });
   assert.equal(res.statusCode, 200);
-  assert.deepEqual(repo.calls[0].args, ["s1", null]);
+  // Third arg is the page options the route now always supplies; the endpoint
+  // is keyset-paginated rather than returning a session's whole history.
+  const [sessionId, since, page] = repo.calls[0].args;
+  assert.equal(sessionId, "s1");
+  assert.equal(since, null);
+  assert.equal(typeof page.limit, "number");
+  assert.equal(page.cursor, null);
 });
 
 test("GET /v1/sync/messages requires sessionId", async () => {

--- a/services/fc/test/pg-business-factory-authz.test.ts
+++ b/services/fc/test/pg-business-factory-authz.test.ts
@@ -128,7 +128,7 @@ test("createShortcut: client-supplied FOREIGN ownerActorId is rejected (cannot f
   assert.equal(row.ownerMemberId, me.id, "owner must be the caller's resolved actor");
 });
 
-test("listSessions: works from ctx.userId with neither teamId nor actorId supplied", async () => {
+test("listSessions: resolves the actor from ctx.userId, given a teamId", async () => {
   const { db } = await makeTestDb();
   const team = await seedTeam(db);
   const me = await seedActor(db, team.id, "user-me");
@@ -136,9 +136,24 @@ test("listSessions: works from ctx.userId with neither teamId nor actorId suppli
   await writer.createSession({ teamId: team.id, title: "S1", mode: "solo", participantActorIds: [me.id] });
 
   const repo = createPgBusinessRepository({ db, userId: "user-me" });
-  const rows = await repo.listSessions({ limit: 50, cursor: null });
+  const rows = await repo.listSessions({ limit: 50, cursor: null, teamId: team.id });
   assert.ok(rows.length >= 1, "should list the user's participating sessions");
   assert.ok(rows.every((r: any) => r.teamId === team.id));
+});
+
+// teamId is required on both repositories, mirroring GET /v1/sessions. The
+// un-scoped listing it replaced could not use an index and degraded linearly
+// with the caller's session count.
+test("listSessions: rejects a call with no teamId", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  await seedActor(db, team.id, "user-me");
+
+  const repo = createPgBusinessRepository({ db, userId: "user-me" });
+  await assert.rejects(
+    () => repo.listSessions({ limit: 50, cursor: null }),
+    (err: any) => err?.statusCode === 400 && err?.code === "validation_failed",
+  );
 });
 
 test("listSessions: returns [] (fail closed) when there is no identity", async () => {
@@ -149,7 +164,7 @@ test("listSessions: returns [] (fail closed) when there is no identity", async (
   await writer.createSession({ teamId: team.id, title: "Hidden", mode: "solo", participantActorIds: [me.id] });
 
   const repo = createPgBusinessRepository({ db }); // no userId
-  const rows = await repo.listSessions({ limit: 50, cursor: null });
+  const rows = await repo.listSessions({ limit: 50, cursor: null, teamId: team.id });
   assert.deepEqual(rows, [], "no identity → no sessions");
 });
 

--- a/services/fc/test/pg-repo-messages.test.ts
+++ b/services/fc/test/pg-repo-messages.test.ts
@@ -311,3 +311,107 @@ test("insertMessage succeeds even when dispatchPush throws", async () => {
   const allMsgs = await repo.listMessages(session.id);
   assert.ok(allMsgs.some((m: any) => m.id === msg.id), "message should be in DB");
 });
+
+// ── listMessages pagination ───────────────────────────────────────────────────
+//
+// The endpoint used to fetch a session's whole history with no LIMIT and a
+// hardcoded `nextCursor: null`. Measured against the self-host box, 6k messages
+// took 6.1s / 3.7MB, 20k took 22.9s, and 40k blew the 8s statement_timeout and
+// returned a 500. A page is now the NEWEST `limit` messages, oldest-first, with
+// a cursor that walks backward into older ones.
+
+test("listMessages returns the NEWEST page, oldest-first within the page", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const actor = await seedActor(db, team.id);
+  const repo = createPgBusinessRepository({ db });
+  const session = await seedSession(repo, team.id, actor.id);
+
+  for (let i = 1; i <= 10; i++) {
+    await repo.insertMessage(session.id, {
+      teamId: team.id,
+      kind: "text",
+      content: `m${i}`,
+      senderActorId: actor.id,
+      createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+    });
+  }
+
+  const page = await repo.listMessages(session.id, { limit: 4 });
+  assert.deepEqual(
+    page.map((m: any) => m.content),
+    ["m7", "m8", "m9", "m10"],
+    "a page is the tail of the history, still in ascending order",
+  );
+});
+
+test("listMessages cursor walks backward through older messages without gaps", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const actor = await seedActor(db, team.id);
+  const repo = createPgBusinessRepository({ db });
+  const session = await seedSession(repo, team.id, actor.id);
+
+  for (let i = 1; i <= 9; i++) {
+    await repo.insertMessage(session.id, {
+      teamId: team.id,
+      kind: "text",
+      content: `m${i}`,
+      senderActorId: actor.id,
+      createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+    });
+  }
+
+  const seen: string[] = [];
+  let cursor: any = null;
+  for (let page = 0; page < 5; page++) {
+    const rows = await repo.listMessages(session.id, { limit: 4, cursor });
+    if (rows.length === 0) break;
+    seen.unshift(...rows.map((m: any) => m.content));
+    if (rows.length < 4) break;
+    cursor = { createdAt: rows[0].createdAt, id: rows[0].id };
+  }
+
+  assert.deepEqual(
+    seen,
+    ["m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m9"],
+    "walking the cursor must reassemble the full history exactly once",
+  );
+});
+
+test("listMessages cursor breaks ties on id when createdAt collides", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const actor = await seedActor(db, team.id);
+  const repo = createPgBusinessRepository({ db });
+  const session = await seedSession(repo, team.id, actor.id);
+
+  // Same timestamp on every row: only the id tiebreak keeps paging moving.
+  const sameInstant = new Date(Date.UTC(2026, 0, 1, 12, 0, 0)).toISOString();
+  for (let i = 1; i <= 6; i++) {
+    await repo.insertMessage(session.id, {
+      teamId: team.id,
+      kind: "text",
+      content: `same${i}`,
+      senderActorId: actor.id,
+      createdAt: sameInstant,
+    });
+  }
+
+  const first = await repo.listMessages(session.id, { limit: 3 });
+  assert.equal(first.length, 3);
+  const second = await repo.listMessages(session.id, {
+    limit: 3,
+    cursor: { createdAt: first[0].createdAt, id: first[0].id },
+  });
+
+  const firstIds = first.map((m: any) => m.id);
+  const secondIds = second.map((m: any) => m.id);
+  assert.equal(second.length, 3, "the second page must not stall on a tie");
+  assert.equal(
+    firstIds.filter((id: string) => secondIds.includes(id)).length,
+    0,
+    "pages must not overlap",
+  );
+  assert.equal(new Set([...firstIds, ...secondIds]).size, 6, "all rows seen exactly once");
+});

--- a/services/fc/test/pg-repo-sessions.test.ts
+++ b/services/fc/test/pg-repo-sessions.test.ts
@@ -52,13 +52,14 @@ test("listSessions returns canonical contract keys for actor-visible sessions", 
   const { db } = await makeTestDb();
   const team = await seedTeam(db);
   const actor = await seedActor(db, team.id);
-  // Identity flows through ctx.userId — the route supplies neither teamId nor actorId.
+  // Identity flows through ctx.userId; teamId is a required narrowing filter,
+  // and actorId is still never supplied by the route.
   const repo = createPgBusinessRepository({ db, userId: actor.userId });
 
   await repo.createSession({ teamId: team.id, title: "Alpha", mode: "solo", participantActorIds: [actor.id] });
   await repo.createSession({ teamId: team.id, title: "Beta", mode: "solo", participantActorIds: [actor.id] });
 
-  const rows = await repo.listSessions({ limit: 50, cursor: null });
+  const rows = await repo.listSessions({ teamId: team.id, limit: 50, cursor: null });
   assert.ok(Array.isArray(rows), "listSessions should return an array");
   assert.ok(rows.length >= 2, "should see 2 sessions");
 
@@ -111,7 +112,7 @@ test("listSessions ordering: lastMessageAt desc nulls last, then createdAt desc,
   await new Promise((r) => setTimeout(r, 5)); // tiny delay to ensure createdAt ordering
   await repo.createSession({ teamId: team.id, title: "Second", mode: "solo", participantActorIds: [actor.id] });
 
-  const rows = await repo.listSessions({ limit: 50, cursor: null });
+  const rows = await repo.listSessions({ teamId: team.id, limit: 50, cursor: null });
   assert.ok(rows.length >= 2);
 
   // Verify ordering: null lastMessageAt rows sorted by createdAt desc
@@ -159,10 +160,11 @@ test("listSessions cursor continues through rows with the same lastMessageAt", a
     .set({ lastMessageAt: sharedLastMessageAt, createdAt: new Date("2026-05-27T09:59:00.000Z") })
     .where(eq(sessions.id, newest.id));
 
-  const firstPage = await repo.listSessions({ limit: 1, cursor: null });
+  const firstPage = await repo.listSessions({ teamId: team.id, limit: 1, cursor: null });
   assert.deepEqual(firstPage.map((row: any) => row.title), ["Newest"]);
 
   const secondPage = await repo.listSessions({
+    teamId: team.id,
     limit: 2,
     cursor: {
       lastMessageAt: firstPage[0].lastMessageAt,
@@ -189,8 +191,8 @@ test("listSessions team-scopes: a user only sees sessions where their actor part
   // Each user's list is resolved purely from their own ctx.userId.
   const repoA = createPgBusinessRepository({ db, userId: actorA.userId });
   const repoB = createPgBusinessRepository({ db, userId: actorB.userId });
-  const rowsA = await repoA.listSessions({ limit: 50, cursor: null });
-  const rowsB = await repoB.listSessions({ limit: 50, cursor: null });
+  const rowsA = await repoA.listSessions({ teamId: teamA.id, limit: 50, cursor: null });
+  const rowsB = await repoB.listSessions({ teamId: teamB.id, limit: 50, cursor: null });
 
   assert.ok(rowsA.every((r: any) => r.teamId === teamA.id), "userA should only see teamA sessions");
   assert.ok(rowsB.every((r: any) => r.teamId === teamB.id), "userB should only see teamB sessions");
@@ -364,7 +366,7 @@ test("hasUnread is false after markSessionViewed", async () => {
   const s = await repo.createSession({ teamId: team.id, title: "UnreadTest", mode: "solo", participantActorIds: [actor.id] });
   await repo.markSessionViewed(s.id);
 
-  const rows = await repo.listSessions({ limit: 50, cursor: null });
+  const rows = await repo.listSessions({ teamId: team.id, limit: 50, cursor: null });
   const found = rows.find((r: any) => r.id === s.id);
   assert.ok(found);
   assert.equal(found.hasUnread, false);

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -6,6 +6,7 @@ import {
   createSupabaseAuthRepository,
   publishableKeyFromEnv,
 } from "../src/lib/supabase-repo.js";
+import { DEFAULT_MESSAGE_LIST_LIMIT } from "../src/lib/routing-utils.js";
 
 test("createSupabaseBusinessRepository creates caller-scoped Supabase client", async () => {
   const calls = [];
@@ -244,18 +245,20 @@ test("repository throws upstream errors without hiding Supabase error codes", as
 
 // Released clients that predate 20260804020000 send no teamId. They must keep
 // getting a list rather than an error, via the deprecated un-scoped RPC.
-test("listSessions falls back to the un-scoped rpc when no teamId is given", async () => {
+// The un-scoped rpc this used to assert on is dropped in
+// 20260810010000_drop_unscoped_session_list.sql. Without a team the query has no
+// index to walk, so it scanned every participant row the caller had and sorted:
+// 4.5s at 6k sessions, statement_timeout 500 past ~13k. Reject instead of
+// reaching for a query that cannot scale.
+test("listSessions refuses to run without a teamId", async () => {
   const rpcCalls: any[] = [];
-  const repo = createRepo(fakeSupabase({
-    rpcCalls,
-    rpcData: { list_current_actor_sessions_all_teams: [] },
-  }));
+  const repo = createRepo(fakeSupabase({ rpcCalls, rpcData: {} }));
 
-  await repo.listSessions({ limit: 10 });
-
-  assert.equal(rpcCalls.length, 1);
-  assert.equal(rpcCalls[0].name, "list_current_actor_sessions_all_teams");
-  assert.ok(!("p_team_id" in rpcCalls[0].args), "un-scoped rpc takes no p_team_id");
+  await assert.rejects(
+    () => repo.listSessions({ limit: 10 }),
+    (err: any) => err?.statusCode === 400 && err?.code === "validation_failed",
+  );
+  assert.equal(rpcCalls.length, 0, "must not issue an un-scoped rpc");
 });
 
 test("createSupabaseAuthRepository refreshAccessToken calls Supabase auth endpoint", async () => {
@@ -336,6 +339,77 @@ function fakeSupabaseForShareMode(rpcData, rpcCalls = []) {
     auth: OWNER_AUTH.auth,
   });
 }
+
+// ── listMessages pagination ──────────────────────────────────────────────────
+// The query fetches NEWEST-first so `limit` truncates the old end of a long
+// history, then reverses so the page reads oldest-first. Fetching ascending and
+// slicing would keep the wrong end of a 6k-message session.
+
+function msgRow(id: string, createdAt: string) {
+  return {
+    id,
+    team_id: "team-1",
+    session_id: "session-1",
+    kind: "text",
+    content: id,
+    created_at: createdAt,
+  };
+}
+
+test("listMessages fetches the newest page descending and returns it oldest-first", async () => {
+  const tableCalls: any[] = [];
+  const repo = createRepo(fakeSupabase({
+    tableCalls,
+    // What Postgres would hand back for ORDER BY created_at DESC.
+    tableData: {
+      messages: [
+        msgRow("m3", "2026-05-27T00:00:03Z"),
+        msgRow("m2", "2026-05-27T00:00:02Z"),
+        msgRow("m1", "2026-05-27T00:00:01Z"),
+      ],
+    },
+  }));
+
+  const rows = await repo.listMessages("session-1", { limit: 3 });
+
+  assert.deepEqual(rows.map((r: any) => r.id), ["m1", "m2", "m3"], "page reads oldest-first");
+  const orders = tableCalls.filter((c) => c.op === "order");
+  assert.deepEqual(
+    orders.map((o) => [o.column, o.options.ascending]),
+    [["created_at", false], ["id", false]],
+    "must sort descending so the limit cuts the OLD end",
+  );
+  assert.ok(tableCalls.some((c) => c.op === "limit" && c.count === 3), "limit must reach the query");
+});
+
+test("listMessages applies a default limit when the caller gives none", async () => {
+  const tableCalls: any[] = [];
+  const repo = createRepo(fakeSupabase({ tableCalls, tableData: { messages: [] } }));
+
+  await repo.listMessages("session-1");
+
+  assert.ok(
+    tableCalls.some((c) => c.op === "limit" && c.count === DEFAULT_MESSAGE_LIST_LIMIT),
+    "an omitted limit must not mean 'the entire history'",
+  );
+});
+
+test("listMessages cursor asks for strictly older rows, tiebroken on id", async () => {
+  const tableCalls: any[] = [];
+  const repo = createRepo(fakeSupabase({ tableCalls, tableData: { messages: [] } }));
+
+  await repo.listMessages("session-1", {
+    limit: 2,
+    cursor: { createdAt: "2026-05-27T00:00:02Z", id: "m-9" },
+  });
+
+  const or = tableCalls.find((c) => c.op === "or");
+  assert.equal(
+    or?.expr,
+    "created_at.lt.2026-05-27T00:00:02Z,and(created_at.eq.2026-05-27T00:00:02Z,id.lt.m-9)",
+    "PostgREST has no row-value comparison, so the keyset is an explicit OR",
+  );
+});
 
 test("createTeam routes to create_team with the caller's JWT org as fallback", async () => {
   const rpcCalls = [];
@@ -1203,6 +1277,10 @@ function createSelectableQuery(table, calls, data, error) {
     },
     in(column, values) {
       calls.push({ table, op: "in", column, values });
+      return query;
+    },
+    or(expr) {
+      calls.push({ table, op: "or", expr });
       return query;
     },
     single() {

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -411,6 +411,57 @@ test("listMessages cursor asks for strictly older rows, tiebroken on id", async 
   );
 });
 
+// ── *ForSync keyset ──────────────────────────────────────────────────────────
+// All the sync readers share applySyncKeyset: forward through (updated_at, id),
+// ascending, bounded. They were unbounded before.
+
+test("sync readers order ascending on (updated_at, id) and bound the page", async () => {
+  const readers: Array<[string, (repo: any) => Promise<unknown>]> = [
+    ["actor_directory", (r) => r.listActorDirectoryForSync("team-1", null, { limit: 7 })],
+    ["ideas", (r) => r.listIdeasForSync("team-1", null, { limit: 7 })],
+    ["session_participants", (r) => r.listSessionParticipantsForSync("session-1", null, { limit: 7 })],
+    ["sessions", (r) => r.listSessionsForTeamSince("team-1", null, { limit: 7 })],
+    ["messages", (r) => r.listMessagesForSessionSince("session-1", null, { limit: 7 })],
+  ];
+
+  for (const [table, run] of readers) {
+    const tableCalls: any[] = [];
+    await run(createRepo(fakeSupabase({ tableCalls, tableData: { [table]: [] } })));
+
+    const orders = tableCalls.filter((c) => c.op === "order");
+    assert.deepEqual(
+      orders.map((o) => [o.column, o.options.ascending]),
+      [["updated_at", true], ["id", true]],
+      `${table}: sync must walk forward, id-tiebroken`,
+    );
+    assert.ok(
+      tableCalls.some((c) => c.op === "limit" && c.count === 7),
+      `${table}: limit must reach the query`,
+    );
+  }
+});
+
+test("sync readers express the keyset as a PostgREST OR", async () => {
+  const tableCalls: any[] = [];
+  const repo = createRepo(fakeSupabase({ tableCalls, tableData: { ideas: [] } }));
+
+  await repo.listIdeasForSync("team-1", "2026-05-01T00:00:00Z", {
+    limit: 50,
+    cursor: { updatedAt: "2026-05-27T00:00:02Z", id: "row-7" },
+  });
+
+  const or = tableCalls.find((c) => c.op === "or");
+  assert.equal(
+    or?.expr,
+    "updated_at.gt.2026-05-27T00:00:02Z,and(updated_at.eq.2026-05-27T00:00:02Z,id.gt.row-7)",
+  );
+  // `since` and the cursor are independent filters and must both survive.
+  assert.ok(
+    tableCalls.some((c) => c.op === "gt" && c.column === "updated_at"),
+    "the `since` watermark must not be dropped when a cursor is present",
+  );
+});
+
 test("createTeam routes to create_team with the caller's JWT org as fallback", async () => {
   const rpcCalls = [];
   const prev = process.env.DEFAULT_ORG_ID;
@@ -1281,6 +1332,10 @@ function createSelectableQuery(table, calls, data, error) {
     },
     or(expr) {
       calls.push({ table, op: "or", expr });
+      return query;
+    },
+    gt(column, value) {
+      calls.push({ table, op: "gt", column, value });
       return query;
     },
     single() {

--- a/services/supabase/migrations/20260810010000_drop_unscoped_session_list.sql
+++ b/services/supabase/migrations/20260810010000_drop_unscoped_session_list.sql
@@ -1,0 +1,39 @@
+-- Retire the un-scoped session list.
+--
+-- 20260804020000 added amux.list_current_actor_sessions_all_teams as an
+-- explicitly deprecated-on-arrival shim: FC redeploys on merge while desktop and
+-- iOS ship on tags, so released builds that listed sessions without a teamId
+-- needed something to call. Its own header said to delete it — and the function,
+-- amux.current_actor_ids(), and the FC fallback — once no released client omits
+-- teamId. GET /v1/sessions now rejects a missing teamId with a 400 and
+-- supabase-repo no longer has the branch, so nothing calls either function.
+--
+-- Deleting it is not just tidying. Without a team there is no way to reach
+-- sessions_team_active_last_message_idx, so the shim joined every participant
+-- row the caller had, evaluated the sessions RLS policy on each, and only then
+-- sorted and applied the limit. Measured on the self-host box (47.112.210.217)
+-- against a seeded fixture:
+--
+--     caller's sessions   GET /v1/sessions (no teamId)
+--     1,500               1.56 s
+--     3,000               2.52 s
+--     6,000               4.52 s
+--     12,000              7.22 s
+--     25,000              HTTP 500  (authenticated statement_timeout = 8s)
+--     120,000             HTTP 500
+--
+-- The team-scoped RPC served the same first page in 90-200 ms at 120,000.
+--
+-- Leaving the function in place would let any future caller reintroduce that
+-- curve silently. Dropping it turns the mistake into "function not found".
+--
+-- Idempotent: safe for the self-host apply-migrations loop to re-run.
+
+DROP FUNCTION IF EXISTS amux.list_current_actor_sessions_all_teams(
+  integer, timestamp with time zone, timestamp with time zone, uuid, uuid
+);
+
+-- Only ever existed to feed the shim above; no policy or function references it
+-- (verified by grep across services/ and by this DROP, which fails rather than
+-- cascading if something still depends on it).
+DROP FUNCTION IF EXISTS amux.current_actor_ids();

--- a/services/supabase/migrations/20260810020000_sync_keyset_indexes.sql
+++ b/services/supabase/migrations/20260810020000_sync_keyset_indexes.sql
@@ -1,0 +1,43 @@
+-- Indexes for the incremental-sync readers.
+--
+-- Every /v1/sync/* endpoint pages on (updated_at, id) ascending, filtered by its
+-- owning key (team or session). Without a matching index the keyset buys
+-- nothing: Postgres still reads every candidate row, applies the per-row RLS
+-- predicate, and top-N sorts. Measured on the self-host box against 120k
+-- sessions, `GET /v1/sync/sessions?limit=50` took 2.3s for a 50-row page:
+--
+--     Limit  (actual time=2304.409..2304.415 rows=50)
+--       ->  Sort  (Sort Key: updated_at, id)  Sort Method: top-N heapsort
+--             ->  Seq Scan on sessions  (actual rows=120004)
+--                   Filter: (team_id = ... AND amux.is_team_member(team_id)
+--                            AND (... OR amux.is_session_participant(id)))
+--
+-- With these, the scan walks the index in sort order and stops once the page is
+-- full, so RLS runs on a page's worth of rows instead of the whole table.
+--
+-- Plain CREATE INDEX (not CONCURRENTLY): these tables are small on every
+-- deployment today, and the self-host apply-migrations loop runs each file in a
+-- transaction, where CONCURRENTLY is not allowed.
+--
+-- Idempotent: safe for the self-host apply-migrations loop to re-run.
+
+-- GET /v1/sync/sessions
+CREATE INDEX IF NOT EXISTS sessions_team_updated_idx
+  ON amux.sessions (team_id, updated_at, id);
+
+-- GET /v1/sync/messages
+CREATE INDEX IF NOT EXISTS messages_session_updated_idx
+  ON amux.messages (session_id, updated_at, id);
+
+-- GET /v1/sync/session-participants
+CREATE INDEX IF NOT EXISTS session_participants_session_updated_idx
+  ON amux.session_participants (session_id, updated_at, id);
+
+-- GET /v1/sync/ideas
+CREATE INDEX IF NOT EXISTS ideas_team_updated_idx
+  ON amux.ideas (team_id, updated_at, id);
+
+-- GET /v1/sync/actor-directory. The endpoint reads the actor_directory view,
+-- whose driving table is amux.actors filtered by team.
+CREATE INDEX IF NOT EXISTS actors_team_updated_idx
+  ON amux.actors (team_id, updated_at, id);

--- a/services/supabase/migrations/20260810030000_session_list_force_custom_plan.sql
+++ b/services/supabase/migrations/20260810030000_session_list_force_custom_plan.sql
@@ -1,0 +1,44 @@
+-- Stop the session list from falling off a generic-plan cliff.
+--
+-- amux.list_current_actor_sessions is plpgsql, so its query plan is cached by
+-- the SPI plan cache. PostgreSQL builds a custom plan for the first 5
+-- executions, then compares the average custom cost against a generic plan and
+-- switches if the generic one looks no worse. Here it always looks better and
+-- always is worse. Measured on the self-host box (47.112.210.217), same
+-- connection, same call, nothing else changing:
+--
+--     team sessions   executions 1-5   executions 6+
+--     20,000          10 ms            1,310-1,416 ms
+--     120,000         29-58 ms         9,913 ms  -> HTTP 500
+--
+-- The generic plan is wrong because it cannot see the parameters. With
+-- p_before_* and p_idea_id unknown it estimates the sessions scan at rows=1, so
+-- sorting looks free and it abandons the ordered index:
+--
+--     custom :  Index Scan using sessions_team_active_last_message_idx
+--               (walks in ORDER BY order, stops at p_limit)
+--     generic:  Index Scan using idx_sessions_team_id   (rows=1 estimated)
+--                 -> 120,004 rows materialised, RLS evaluated on each
+--                 -> Sort -> Limit
+--
+-- Since the `authenticated` role carries statement_timeout = 8s, the 120k case
+-- does not merely get slow, it fails. And because PostgREST pools connections,
+-- a backend is poisoned only after ITS 5th session-list call — which is why the
+-- endpoint failed intermittently and looked like a load problem rather than a
+-- planning one.
+--
+-- force_custom_plan is the right setting rather than a workaround: this
+-- function's selectivity genuinely depends on its arguments (first page vs deep
+-- cursor, idea-filtered vs not), which is precisely the case the mode exists
+-- for. Re-planning costs ~1 ms against an execution that should be ~10-50 ms.
+--
+-- Idempotent: safe for the self-host apply-migrations loop to re-run.
+
+ALTER FUNCTION amux.list_current_actor_sessions(
+  p_team_id uuid,
+  p_limit integer,
+  p_before_last_message_at timestamp with time zone,
+  p_before_created_at timestamp with time zone,
+  p_before_id uuid,
+  p_idea_id uuid
+) SET plan_cache_mode = 'force_custom_plan';


### PR DESCRIPTION
## 背景

`GET /v1/sessions` 在会话量大时会 500。在 self-host 上造数据实测（12 万 session / 单团队 1 万 actor / 单会话 4 万条消息）后，定位到彼此独立的四个问题，都在这个 PR 里修掉。

## 1. session 列表的执行计划悬崖（主因）

`amux.list_current_actor_sessions` 是 plpgsql，计划走 SPI 缓存：前 5 次 custom plan，第 6 次起切 generic plan。通用计划看不见 `p_before_*` / `p_idea_id`，把 sessions 扫描估成 `rows=1`，于是丢掉有序索引 `sessions_team_active_last_message_idx`，改用无序的 `idx_sessions_team_id` 全量物化再排序。

同一连接、同一调用、12 万 session：

| | 修复前 | 修复后 |
|---|---|---|
| 第 1–5 次 | 17–21 ms | 17–21 ms |
| 第 6 次起 | **9,701 / 9,384 / 9,057 ms** | **18.5 / 19.0 / 18.6 ms** |

`authenticated` 角色带 `statement_timeout=8s`，所以第 6 次起直接 500。又因为 PostgREST 有连接池，是「某条连接跑满 5 次才废」，表现成时好时坏，看起来像负载问题而不是规划问题。

修法是 `plan_cache_mode = 'force_custom_plan'`。这个函数的选择性本来就取决于参数（首页 vs 深翻、有无 idea 过滤），正是该模式的适用场景；重新规划约 1 ms。

端到端：翻页此前在第 15 页 500（最慢一页 8.04 s），现在 **150 页 / 15,000 行**零重复零乱序，最慢一页 0.33 s，含穿过 12,000 行的 NULLS FIRST 区段。

## 2. 读 session 强制 teamId

不带 team 就用不上索引，只能扫遍调用者的全部参与记录再排序：

| 调用者的 session 数 | 1,500 | 3,000 | 6,000 | 12,000 | 25,000 |
|---|---|---|---|---|---|
| `GET /v1/sessions`（无 teamId） | 1.56 s | 2.52 s | 4.52 s | 7.22 s | **500** |

团队维度的同一首页在 12 万量级是 90–200 ms。`list_current_actor_sessions_all_teams` 和 `current_actor_ids()` 一并删除——它们在 20260804020000 里就标注了「等没有客户端不带 teamId 就删」，留着只会让这条曲线被新调用方悄悄带回来。

客户端相应地不再「由 sessionId 反查 teamId」：cron 运行历史原来会查出 teamId 再 `enterTeam` 切过去，也就是说打开一条运行记录可能把你拽进别的团队；现在按当前团队作用域，外来 id 视为不存在。

## 3. 消息接口分页

`GET /v1/sessions/:id/messages` 此前没有 LIMIT，且 `nextCursor` 恒为 null：

| 消息数 | 2,000 | 6,000 | 20,000 | 40,000 |
|---|---|---|---|---|
| | 1.4 s / 1.2 MB | 6.1 s / 3.7 MB | 22.9 s / 12.5 MB | **500** |

现在默认返回最新 200 条（上限 500），页内仍是旧→新，游标向更早翻。实现上是**降序取再反转**——这样 limit 砍掉的是历史的旧端而非新端。

RLS 是主要放大器：同一条 12k 行查询，`postgres` 角色 18.5 ms、`authenticated` 2,654 ms（143×），因为 `session_id` 明明是常量，`is_session_participant(session_id)` 仍逐行求值。

## 4. sync 接口分页 + 一个正在丢数据的 bug

actor-directory / ideas / session-participants / messages 四个接口完全无界（1 万 actor 实测 3.1 MB / 4.4 s），现在与 `/v1/sync/sessions` 共用同一套 `(updated_at, id)` keyset，并补齐索引——没有索引 keyset 等于白做：`/v1/sync/sessions?limit=50` 取 50 行要 2.3 s，因为要全表扫 12 万行、逐行跑 RLS、再 top-N 排序。

**顺带修掉一个既有的线上数据丢失**：`/v1/sync/sessions` 服务端早已分页（默认 50），但 desktop 客户端只读第一页的 `items` 就返回，任何团队只要自上次水位线以来变更超过 50 条，每次同步都静默丢掉剩下的。客户端现在统一在 API 层翻页到底（`fetchAllSyncPages`），上层 delta-sync 代码一行没动。

## 附带修复

`GET /v1/teams/:teamId/directory` **在任何数据量下恒 500**：`getTeamDirectory` 选了不存在的列——`actor_directory.kind`（实际是 `actor_type`）和 `team_members.actor_id`（实际是 `member_id`）。用 PostgREST 别名修，mapper 和响应结构不变。已在真实网关上对比验证：旧写法仍报 `column actor_directory.kind does not exist`，新写法正常返回。

## 影响面

- **破坏性**：`GET /v1/sessions` 与 `GET /v1/sessions/:id` 不带 teamId 变 400。当前 desktop / iOS / Expo 本就都带；daemon 的单会话读已补上。旧版本客户端会拿到明确的 400，而不是一份随历史增长而逐渐超时的列表。
- **行为变化**：消息接口默认只返回最新一页，客户端需翻页取更早历史（三端均已支持）。
- 五个迁移随自动部署生效，均幂等。`force_custom_plan` 那条为验证修复已在 self-host 库执行过，部署时重放，线上与本分支一致。

## 验证

- FC：`tsc -p tsconfig.json`（镜像构建用的配置）通过；全量测试相对未改动树**零新增失败**
- 新增测试中较关键的两条跑在 pglite 真库上：游标翻页能不重不漏地拼回完整历史；`created_at` 完全相同时靠 id 破平不会卡住
- 前端 **424 文件 / 2703 测试**通过，typecheck 干净，lint 0 error
- iOS AMUXCore 全绿；expo typecheck 通过；daemon `cargo check --locked` 通过；OpenAPI lint 通过
- self-host 上造的数据已全部清除，计数回到基线

## 未处理

`/v1/sync/messages` 之外，desktop 的 Tauri 主路径走的是 sync 而非 `/v1/sessions/:id/messages`，所以第 3 项对桌面端大会话的收益来自第 4 项。RLS 逐行求值 `is_session_participant` 的开销（143×）没有动，属于更大的改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
