### PR TITLE
fix(fc): e2e 读取 session 时补上 teamId（修复部署验证失败）

### DIFF
--- a/services/fc/test/self-host-e2e.test.ts
+++ b/services/fc/test/self-host-e2e.test.ts
@@ -358,9 +358,12 @@ describe("Session + Messages", { skip: !E2E }, () => {
   });
 
   test("GET /v1/sessions/:id returns the session", async () => {
-    const { status, body } = await fcFetch(`/v1/sessions/${state.sessionId}`, {
-      token: state.accessToken,
-    });
+    // teamId is required on session reads: it resolves the caller's actor (one
+    // actor row per user per team) and scopes the row server-side.
+    const { status, body } = await fcFetch(
+      `/v1/sessions/${state.sessionId}?teamId=${encodeURIComponent(state.teamId)}`,
+      { token: state.accessToken },
+    );
     assert.equal(status, 200, `getSession failed: ${JSON.stringify(body)}`);
     assert.equal(body.id, state.sessionId);
     assert.equal(body.title, sessionTitle);


### PR DESCRIPTION
修复 #842 合并后 Self-Host Deploy 的失败（run [31362936471](https://github.com/different-ai-studio/teamclu/actions/runs/31362936471)）。

#842 把 `GET /v1/sessions/:id` 改成必须带 `teamId`，但漏了 `self-host-e2e.test.ts` 这个调用方，于是断言 200 拿到 400。

**部署本身是成功的** —— 容器起来了、迁移也应用了，失败的是部署后的验证步骤（11 个用例过了 10 个）。

## 为什么本地没发现

这个 suite 由 `FC_E2E=1` 门控，普通 `npm test` 会整体跳过，只有部署时才真正执行。这是这次验证的盲区。

## 验证

把本补丁应用到部署机上，跑 `deploy/self-host/smoke/run-e2e.sh`（workflow 调用的同一个脚本、同一套容器网络）：

```
# tests 11
# pass 11
# fail 0
```

此前为 10/11。验证完已把部署机工作树还原。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
