### PR TITLE
fix: New Chat team-share exit, setModel RPC, permission poll noise

### DIFF
--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -777,7 +777,11 @@ impl DaemonServer {
         // `{actor}::{session}` composite (ADR-0004). Resolve before touching
         // the handle — `agents` is still keyed by the per-spawn id, which no
         // topic broadcasts any more, so clients cannot address by it.
-        let resolve_actor = request.requester_actor_id.trim();
+        //
+        // Use this daemon's actor id, not `request.requester_actor_id` (the
+        // signed-in member). The RPC is already routed to `amux/{team}/{actor}/rpc/req`
+        // for this agent; owner checks must match the attachment's owner.
+        let resolve_actor = self.actor_id.as_str();
         let resolved = {
             let agents = self.agents.lock().await;
             agents.resolve_command_agent_id(&addressed, resolve_actor)
@@ -925,7 +929,10 @@ impl DaemonServer {
         // id, or `{actor}::{session}` composite (ADR-0004). Without this the
         // raw map lookup in `send_set_model` fails for every client, because
         // the per-spawn key is no longer published anywhere.
-        let resolve_actor = request.requester_actor_id.trim();
+        //
+        // Match `handle_runtime_command_rpc`: resolve as this daemon's agent,
+        // not the human member in `request.requester_actor_id`.
+        let resolve_actor = self.actor_id.as_str();
         let resolved = {
             let agents = self.agents.lock().await;
             agents.resolve_command_agent_id(&addressed, resolve_actor)

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -2523,6 +2523,20 @@ mod tests {
         );
     }
 
+    /// Desktop setModel/runtimeStop: client sends bare cloud session_id; the RPC
+    /// handler resolves with this daemon's actor id (not the signed-in member).
+    #[test]
+    fn resolve_command_agent_id_accepts_bare_session_for_daemon_actor() {
+        let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        mgr.add_test_runtime("session_S");
+        mgr.get_handle_mut("session_S").unwrap().owner_actor_id = "actor-A".into();
+
+        assert_eq!(
+            mgr.resolve_command_agent_id("session_S", "actor-A").as_deref(),
+            Some("session_S")
+        );
+    }
+
     /// The client-facing address and the map key are the same value now, so
     /// set-model needs no lookup. Before the rekey this call failed with
     /// "agent {session} not found" for every client, because the map was keyed

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -977,20 +977,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
 
   // SSE connection is managed by SSEProvider in App.tsx (persists across mode switches)
 
-  // Poll for pending permissions as fallback
-  const pollPermissions = useSessionStore((s) => s.pollPermissions);
-  const hasRunningTools = React.useMemo(() =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (activeMessages ?? []).some((m: any) => m.toolCalls?.some((tc: any) => tc.status === "calling" || tc.status === "waiting")),
-    [activeMessages],
-  );
-  React.useEffect(() => {
-    if (!activeSessionId) return;
-    if (!isStreaming && !hasRunningTools) return;
-    const interval = setInterval(pollPermissions, 2000);
-    return () => clearInterval(interval);
-  }, [isStreaming, hasRunningTools, activeSessionId, pollPermissions]);
-
+  // v2: pending permissions arrive on the ACP/MQTT stream — no HTTP poll fallback.
 
   // ── Session loading ───────────────────────────────────────────────────
   const prevWorkspaceRef = React.useRef<string | null>(null);

--- a/packages/app/src/stores/__tests__/ui-enter-actor-draft.test.ts
+++ b/packages/app/src/stores/__tests__/ui-enter-actor-draft.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useUIStore } from '../ui'
+
+describe('enterActorDraft sidebar handling', () => {
+  beforeEach(() => {
+    useUIStore.setState({
+      currentView: 'chat',
+      sidebarFilter: { kind: 'teamShare', section: 'skills' },
+      draftPreselectedActor: null,
+    } as Partial<ReturnType<typeof useUIStore.getState>>)
+  })
+
+  it('resets teamShare sidebar filter so the chat pane replaces TeamShareDetailPane', () => {
+    useUIStore.getState().enterActorDraft({
+      id: 'agent-1',
+      displayName: 'MACPRO',
+      kind: 'agent',
+    })
+
+    expect(useUIStore.getState().sidebarFilter).toEqual({ kind: 'all' })
+    expect(useUIStore.getState().draftPreselectedActor).toEqual({
+      id: 'agent-1',
+      displayName: 'MACPRO',
+      kind: 'agent',
+    })
+  })
+})

--- a/packages/app/src/stores/ui.ts
+++ b/packages/app/src/stores/ui.ts
@@ -369,6 +369,7 @@ export const useUIStore = create<UIState>((set, get) => ({
       currentView: 'chat',
       settingsInitialSection: null,
       daemonGeneralPrompt: null,
+      sidebarFilter: { kind: 'all' },
     })
     // Mirror startNewChat's clear-out so the chat view shows an empty
     // canvas with the preselected actor as the implicit recipient. We


### PR DESCRIPTION
## Summary
- Reset `sidebarFilter` in `enterActorDraft` so New Chat exits Skills/MCP/Env/Knowledge team-share panels and returns to the draft chat view.
- Fix daemon `setModel` and `runtimeStop` RPC handlers to resolve runtime addresses with the target daemon's actor id instead of the signed-in member id, which caused `unknown runtime address` on every model switch.
- Remove the obsolete `pollPermissions` 2s polling loop in `ChatPanel`; v2 permissions arrive on the ACP/MQTT stream and the store stub was only emitting console warnings during agent replies.

## Test plan
- [x] `pnpm test:unit packages/app/src/stores/__tests__/ui-enter-actor-draft.test.ts`
- [x] `cargo test -p amuxd resolve_command_agent_id`
- [x] `pnpm rust:check`
- [ ] New Chat from Skills/MCP/Env/Knowledge panel closes team-share view and shows draft chat
- [ ] Select or send with a model — console shows `runtime_start.set_model.ok`, no `unknown runtime address`
- [ ] Agent reply — no `[session-store stub] pollPermissions` warnings in console


Made with [Cursor](https://cursor.com)