### PR TITLE
fix(fc): reuse existing workspaces on supabase upsert

### DIFF
--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -195,6 +195,36 @@ function applySyncKeyset(query, cursor, limit) {
     .limit(limit);
 }
 
+function normalizeWorkspacePath(path: string | null | undefined): string | null {
+  if (path == null) return null;
+  const trimmed = path.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/\/+$/, "") || trimmed;
+}
+
+async function findUniqueWorkspaceName(
+  supabase,
+  teamId: string,
+  agentId: string | null | undefined,
+  baseName: string,
+): Promise<string> {
+  let candidate = baseName;
+  let suffix = 2;
+  while (true) {
+    let query = supabase
+      .from("workspaces")
+      .select("id")
+      .eq("team_id", teamId)
+      .eq("name", candidate);
+    query = agentId ? query.eq("agent_id", agentId) : query.is("agent_id", null);
+    const { data, error } = await query.limit(1);
+    if (error) throw error;
+    if (!data?.length) return candidate;
+    candidate = `${baseName} (${suffix})`;
+    suffix += 1;
+  }
+}
+
 async function archiveSessionsForWorkspace(supabase, workspaceId) {
   const { data: participants, error: rtError } = await supabase
     .from("session_participants")
@@ -1281,15 +1311,65 @@ export function createSupabaseBusinessRepository(options) {
       if (!resolved?.id) throw new ApiError(403, "forbidden", "not a member of this team");
       const createdByMemberId = resolved.id;
 
-      const row = {
-        id: input.id,
+      // Dedup key: explicit `id` always wins. Otherwise reuse by (team, path)
+      // or by (team, agent, name) — the table's unique constraint is
+      // (team_id, agent_id, name), and onConflict:"id" alone mints a fresh
+      // UUID that collides with that constraint when re-adding an existing /
+      // archived workspace. Mirrors pg-repo/workspaces.ts.
+      let targetId = input.id ?? null;
+      const normalizedPath = normalizeWorkspacePath(input.path ?? input.slug ?? null);
+      let resolvedName = input.name;
+
+      if (!targetId && normalizedPath) {
+        const { data: byPath, error: pathErr } = await supabase
+          .from("workspaces")
+          .select("id")
+          .eq("team_id", input.teamId)
+          .in("path", [normalizedPath, `${normalizedPath}/`])
+          .limit(1);
+        if (pathErr) throw pathErr;
+        if (byPath?.[0]?.id) targetId = byPath[0].id;
+      }
+
+      if (!targetId) {
+        let byNameQuery = supabase
+          .from("workspaces")
+          .select("id, path, archived")
+          .eq("team_id", input.teamId)
+          .eq("name", resolvedName);
+        byNameQuery = input.agentId
+          ? byNameQuery.eq("agent_id", input.agentId)
+          : byNameQuery.is("agent_id", null);
+        const { data: byNameRows, error: nameErr } = await byNameQuery.limit(1);
+        if (nameErr) throw nameErr;
+        const existingByName = byNameRows?.[0];
+        if (existingByName) {
+          const existingPath = normalizeWorkspacePath(existingByName.path);
+          if (normalizedPath && existingPath === normalizedPath) {
+            targetId = existingByName.id;
+          } else if (existingByName.archived) {
+            targetId = existingByName.id;
+          } else {
+            resolvedName = await findUniqueWorkspaceName(
+              supabase,
+              input.teamId,
+              input.agentId,
+              resolvedName,
+            );
+          }
+        }
+      }
+
+      const row: Record<string, unknown> = {
         team_id: input.teamId,
-        name: input.name,
-        path: input.path ?? input.slug ?? null,
+        name: resolvedName,
+        path: normalizedPath,
         agent_id: input.agentId ?? null,
         created_by_member_id: createdByMemberId,
         archived: input.archived ?? false,
       };
+      if (targetId) row.id = targetId;
+
       const { data, error } = await supabase
         .from("workspaces")
         .upsert(row, { onConflict: "id" })

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -1774,12 +1774,28 @@ function appsAuth(userId = "user-app-1") {
 
 // Stateful supabase double for apps tests. `seed` provides rows keyed by table.
 // `actorRow` is what the actors lookup (resolveCurrentMemberActor) returns.
+// Select filters (eq / is / in) are applied so workspace upsert dedup lookups
+// can find seeded rows the same way PostgREST would.
 function appsSupabase({ seed = {}, actorRow = { id: "actor-app-1" }, calls = [] }: any = {}) {
   const state: any = { apps: [...(seed.apps ?? [])], workspaces: [...(seed.workspaces ?? [])], sessions: [...(seed.sessions ?? [])] };
   return {
     auth: appsAuth(),
     from(table: string) {
-      const ctx: any = { table, op: null, filters: {} };
+      const ctx: any = { table, op: null, filters: {}, isFilters: {}, inFilters: {}, limitCount: null };
+      const matchRows = () => {
+        let rows = [...(state[table] ?? [])];
+        for (const [col, val] of Object.entries(ctx.filters)) {
+          rows = rows.filter((r) => r[col as string] === val);
+        }
+        for (const [col, val] of Object.entries(ctx.isFilters)) {
+          rows = rows.filter((r) => (val === null ? r[col as string] == null : r[col as string] === val));
+        }
+        for (const [col, vals] of Object.entries(ctx.inFilters)) {
+          rows = rows.filter((r) => (vals as any[]).includes(r[col as string]));
+        }
+        if (typeof ctx.limitCount === "number") rows = rows.slice(0, ctx.limitCount);
+        return rows;
+      };
       const builder: any = {
         select(columns: string) {
           calls.push({ table, op: ctx.op ? `${ctx.op}.select` : "select", columns });
@@ -1804,8 +1820,11 @@ function appsSupabase({ seed = {}, actorRow = { id: "actor-app-1" }, calls = [] 
           ctx.op = "upsert";
           calls.push({ table, op: "upsert", row, options });
           const upserted = { ...row, id: row.id ?? `${table}-id-1` };
-          state[table] = [upserted];
-          ctx.inserted = upserted;
+          if (!state[table]) state[table] = [];
+          const idx = state[table].findIndex((r: any) => r.id === upserted.id);
+          if (idx >= 0) state[table][idx] = { ...state[table][idx], ...upserted };
+          else state[table].push(upserted);
+          ctx.inserted = state[table].find((r: any) => r.id === upserted.id);
           return builder;
         },
         eq(column: string, value: any) {
@@ -1813,36 +1832,58 @@ function appsSupabase({ seed = {}, actorRow = { id: "actor-app-1" }, calls = [] 
           calls.push({ table, op: `${ctx.op ?? "select"}.eq`, column, value });
           return builder;
         },
+        is(column: string, value: any) {
+          ctx.isFilters[column] = value;
+          calls.push({ table, op: `${ctx.op ?? "select"}.is`, column, value });
+          return builder;
+        },
+        in(column: string, values: any[]) {
+          ctx.inFilters[column] = values;
+          calls.push({ table, op: `${ctx.op ?? "select"}.in`, column, values });
+          return builder;
+        },
         order() { return builder; },
         // Chainable like supabase-js: limit() returns the (thenable) builder so
         // a trailing .maybeSingle()/.single() still works; awaiting it yields the
-        // table rows (used by listApps).
-        limit() { return builder; },
+        // table rows (used by listApps / workspace dedup lookups).
+        limit(count: number) {
+          ctx.limitCount = count;
+          return builder;
+        },
         single() {
           if (ctx.op === "insert" || ctx.op === "upsert") return Promise.resolve({ data: ctx.inserted, error: null });
           if (ctx.op === "update") {
-            const base = state[table]?.[0] ?? {};
+            const matched = matchRows();
+            const base = matched[0] ?? state[table]?.[0] ?? {};
             const merged = { ...base, ...ctx.update };
-            state[table] = [merged];
+            if (base?.id) {
+              const idx = state[table].findIndex((r: any) => r.id === base.id);
+              if (idx >= 0) state[table][idx] = merged;
+              else state[table] = [merged];
+            } else {
+              state[table] = [merged];
+            }
             return Promise.resolve({ data: merged, error: null });
           }
           // plain select: actors lookup returns the actor row
           if (table === "actors") return Promise.resolve({ data: actorRow, error: null });
-          return Promise.resolve({ data: state[table]?.[0] ?? null, error: null });
+          return Promise.resolve({ data: matchRows()[0] ?? null, error: null });
         },
         maybeSingle() {
           if (table === "actors") return Promise.resolve({ data: actorRow, error: null });
           if (ctx.op === "update") {
-            const base = state[table]?.[0];
+            const matched = matchRows();
+            const base = matched[0];
             if (!base) return Promise.resolve({ data: null, error: null });
             const merged = { ...base, ...ctx.update };
-            state[table] = [merged];
+            const idx = state[table].findIndex((r: any) => r.id === base.id);
+            if (idx >= 0) state[table][idx] = merged;
             return Promise.resolve({ data: merged, error: null });
           }
-          return Promise.resolve({ data: state[table]?.[0] ?? null, error: null });
+          return Promise.resolve({ data: matchRows()[0] ?? null, error: null });
         },
         then(resolve: any, reject: any) {
-          return Promise.resolve({ data: state[table] ?? [], error: null }).then(resolve, reject);
+          return Promise.resolve({ data: matchRows(), error: null }).then(resolve, reject);
         },
       };
       return builder;
@@ -2113,7 +2154,7 @@ test("apps: listAppSessions returns the session-summary shape", async () => {
   const repo = appsRepo(appsSupabase({
     seed: {
       sessions: [{
-        id: "sess-1", team_id: "team-1", title: "Chat", mode: "collab",
+        id: "sess-1", team_id: "team-1", app_id: "app-1", title: "Chat", mode: "collab",
         last_message_at: "2026-06-13T01:00:00Z",
         created_at: "2026-06-13T00:00:00Z", updated_at: "2026-06-13T00:30:00Z",
       }],
@@ -2211,6 +2252,98 @@ test("upsertWorkspace returns 403 when the caller is not a member of the team", 
     () => repo.upsertWorkspace({ teamId: "team-b", name: "Nope", path: "/tmp/x" }),
     (err: any) => err?.statusCode === 403,
   );
+});
+
+test("upsertWorkspace without id reuses existing row by (teamId, path)", async () => {
+  // Regression: re-adding an already-synced workspace used to hit
+  // workspaces_team_id_agent_id_name_key because upsert only deduped on id.
+  const calls: any[] = [];
+  const repo = appsRepo(appsSupabase({
+    calls,
+    seed: {
+      workspaces: [{
+        id: "ws-existing",
+        team_id: "team-b",
+        name: "Alpha",
+        path: "/tmp/alpha",
+        agent_id: "agent-1",
+        archived: false,
+      }],
+    },
+  }));
+
+  const out = await repo.upsertWorkspace({
+    teamId: "team-b",
+    name: "Alpha Renamed",
+    path: "/tmp/alpha/",
+    agentId: "agent-1",
+  });
+
+  const upsert = calls.find((c) => c.table === "workspaces" && c.op === "upsert");
+  assert.equal(upsert?.row.id, "ws-existing");
+  assert.equal(upsert?.row.path, "/tmp/alpha", "trailing slash is normalized");
+  assert.equal(upsert?.row.name, "Alpha Renamed");
+  assert.equal(out.id, "ws-existing");
+});
+
+test("upsertWorkspace reuses archived row with the same name instead of inserting", async () => {
+  const calls: any[] = [];
+  const repo = appsRepo(appsSupabase({
+    calls,
+    seed: {
+      workspaces: [{
+        id: "ws-archived",
+        team_id: "team-b",
+        name: "legacy",
+        path: "/tmp/legacy",
+        agent_id: "agent-1",
+        archived: true,
+      }],
+    },
+  }));
+
+  const out = await repo.upsertWorkspace({
+    teamId: "team-b",
+    name: "legacy",
+    path: "/tmp/legacy-new",
+    agentId: "agent-1",
+    archived: false,
+  });
+
+  const upsert = calls.find((c) => c.table === "workspaces" && c.op === "upsert");
+  assert.equal(upsert?.row.id, "ws-archived");
+  assert.equal(upsert?.row.archived, false);
+  assert.equal(upsert?.row.path, "/tmp/legacy-new");
+  assert.equal(out.id, "ws-archived");
+});
+
+test("upsertWorkspace disambiguates name when same agent already has that name at another path", async () => {
+  const calls: any[] = [];
+  const repo = appsRepo(appsSupabase({
+    calls,
+    seed: {
+      workspaces: [{
+        id: "ws-active",
+        team_id: "team-b",
+        name: "teamclu",
+        path: "/Users/me/code/teamclu",
+        agent_id: "agent-1",
+        archived: false,
+      }],
+    },
+  }));
+
+  const out = await repo.upsertWorkspace({
+    teamId: "team-b",
+    name: "teamclu",
+    path: "/Users/me/other/teamclu",
+    agentId: "agent-1",
+  });
+
+  const upsert = calls.find((c) => c.table === "workspaces" && c.op === "upsert");
+  assert.equal(upsert?.row.name, "teamclu (2)");
+  assert.notEqual(upsert?.row.id, "ws-active");
+  assert.equal(out.name, "teamclu (2)");
 });
 
 test("createSession is server-authoritative for created_by (ignores client createdByActorId)", async () => {


### PR DESCRIPTION
## Summary
- Port pg-repo workspace dedup/reuse into the live supabase `upsertWorkspace` path so re-adding an existing or archived workspace no longer hits `workspaces_team_id_agent_id_name_key`.
- Normalize trailing-slash paths, reuse by `(team, path)` / archived `(team, agent, name)`, and disambiguate active name collisions across different directories.
- Add supabase-repo regression coverage for path reuse, archived restore, and name disambiguation.

## Test plan
- [x] `node --import tsx --test test/supabase-repo.test.ts` (89 pass)
- [ ] Re-add an already-synced workspace in the desktop app — should update, not 500
- [ ] Re-add a sidebar-archived workspace with the same name — should restore the archived row
- [ ] Add a second directory that shares a folder name with an active workspace — should land as `name (2)`


Made with [Cursor](https://cursor.com)