### PR TITLE
perf(db): sessions 可见性谓词改为集合运算（列表 RPC 8.6×）

### DIFF
--- a/services/supabase/migrations/20260810050000_sessions_visibility_predicate.sql
+++ b/services/supabase/migrations/20260810050000_sessions_visibility_predicate.sql
@@ -1,0 +1,81 @@
+-- Rewrite the sessions SELECT policy so it stops calling a SECURITY DEFINER
+-- function four times per row.
+--
+-- The policy read:
+--
+--     is_team_member(team_id)                                       -- call #1
+--     AND ( created_by_actor_id = current_actor_id_for_team(team_id) -- #2
+--        OR primary_agent_id   = current_actor_id_for_team(team_id) -- #3
+--        OR is_session_participant(id) )                            -- #4
+--
+-- Every one of those is SECURITY DEFINER, so none can be inlined and all four
+-- run per candidate row. Scanning the sessions of the heaviest user in the
+-- database (1,162 visible of 2,066) measured 58.8 ms; the predicate below
+-- measured 4.1 ms on the same identity and returned the same rows — 14x, and
+-- the plan changes from a per-row filter into a materialised actor set plus a
+-- bitmap index scan.
+--
+-- TWO SIMPLIFICATIONS, BOTH RESTING ON EXISTING SCHEMA INVARIANTS
+--
+-- 1. `is_team_member(team_id)` is redundant. Each branch names an actor, and
+--    enforce_core_team_integrity pins sessions.created_by_actor_id and
+--    sessions.primary_agent_id to the session's team (as it does for
+--    participants). So "that actor is mine" already implies "I have an actor in
+--    this team" — precisely what is_team_member checked. Verified over the whole
+--    database: 0 sessions whose created_by_actor_id is in another team, 0 whose
+--    primary_agent_id is.
+--
+-- 2. `= current_actor_id_for_team(team_id)` becomes `IN (<my actors>)`. With
+--    unique (team_id, user_id) on actors plus the same-team pinning above, "is
+--    my actor in that team" and "is one of my actors" select the same rows. The
+--    set form is what matters: it takes no per-row argument, so the planner
+--    evaluates it once per query instead of calling a function per row.
+--
+-- `is_session_participant(id)` stays as it is. It is still SECURITY DEFINER and
+-- therefore still per-row; removing that costs a rework of the
+-- sessions/session_participants policy recursion, which is deliberately not
+-- attempted here (see 20260810040000's header for why the obvious version
+-- widens visibility).
+--
+-- Idempotent: safe for the self-host apply-migrations loop to re-run.
+
+-- ---------------------------------------------------------------------------
+-- 1. The caller's actors, as a set the planner can hoist
+-- ---------------------------------------------------------------------------
+-- SECURITY DEFINER because it reads amux.actors, whose own SELECT policy calls
+-- is_team_member — going through RLS here would reintroduce the per-row cost
+-- this migration exists to remove.
+--
+-- Returns SETOF rather than uuid[] so callers write `IN (SELECT ...)`, the form
+-- the planner turns into a single hashed evaluation. `= ANY ((SELECT f()))`
+-- does NOT work: PostgreSQL reads the parenthesised SELECT as a sub-SELECT
+-- rather than an array and fails with "operator does not exist: uuid = uuid[]".
+--
+-- A function of this name existed until 20260810010000, which dropped it along
+-- with the un-scoped session list it fed. This one serves a different purpose
+-- and is not tied to that shim.
+
+DROP FUNCTION IF EXISTS amux.current_actor_ids();
+CREATE FUNCTION amux.current_actor_ids() RETURNS SETOF uuid
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO 'public', 'auth'
+    AS $$
+  select id from amux.actors where user_id = auth.uid()
+$$;
+
+REVOKE ALL ON FUNCTION amux.current_actor_ids() FROM PUBLIC;
+GRANT ALL ON FUNCTION amux.current_actor_ids() TO authenticated;
+GRANT ALL ON FUNCTION amux.current_actor_ids() TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. The policy
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS sessions_select_if_participant_or_creator ON amux.sessions;
+CREATE POLICY sessions_select_if_participant_or_creator ON amux.sessions
+  FOR SELECT TO authenticated
+  USING (
+    created_by_actor_id IN (SELECT amux.current_actor_ids())
+    OR primary_agent_id IN (SELECT amux.current_actor_ids())
+    OR amux.is_session_participant(id)
+  );


### PR DESCRIPTION
方案 A：把 sessions 的 SELECT 策略从「每行四次 SECURITY DEFINER 调用」改成「每查询一次的集合运算」。

## 改了什么

```sql
-- 之前：四个 DEFINER 调用，每个候选行都跑一遍
is_team_member(team_id)
AND ( created_by_actor_id = current_actor_id_for_team(team_id)
   OR primary_agent_id   = current_actor_id_for_team(team_id)
   OR is_session_participant(id) )

-- 之后
created_by_actor_id IN (SELECT amux.current_actor_ids())
OR primary_agent_id IN (SELECT amux.current_actor_ids())
OR amux.is_session_participant(id)
```

两处简化，依据都是 schema 已经强制的不变量：

1. **`is_team_member(team_id)` 是冗余的**。三个分支各自指名一个 actor，而 `enforce_core_team_integrity` 把 `created_by_actor_id` 和 `primary_agent_id` 钉在 session 所属团队里——所以「这个 actor 是我的」已经蕴含「我在这个团队有 actor」，正是它要检查的东西。
2. **`= current_actor_id_for_team(team_id)` 换成 `IN (<我的 actor 集合>)`**。有 `unique(team_id,user_id)` 加上同样的同队约束，两者选出相同的行；而集合形式不带每行参数，planner 会物化成一次哈希，不再是每行一次函数调用。

`is_session_participant(id)` 保持不动——它仍是 SECURITY DEFINER、仍然逐行。要去掉需要重构 sessions / session_participants 的策略递归，`20260810040000` 的文件头已经说明那不是一个安全的改写（会放宽可见性）。

## 性能（生产库，事务内测量后回滚）

| 指标 | 之前 | 之后 | |
|---|---|---|---|
| **session 列表 RPC，20 次调用** | **2,848 ms** | **330 ms** | **8.6×** |
| `count(*) sessions` | 57.2 ms | 27.4 ms | 2.1× |
| `count(*) session_participants` | 67.8 ms | 38.3 ms | 1.8× |
| `count(*) messages` | 79.6 ms | 80.0 ms | 持平（未改其策略）|

`session_participants` 也变快，是因为它的策略内部通过 `EXISTS (SELECT 1 FROM sessions …)` 走 sessions 的 RLS。

## 等价性（同一份生产数据）

- **不变量成立**：`created_by_actor_id` 跨团队 0 行、`primary_agent_id` 跨团队 0 行、participant 跨团队 0 行
- **可见性零变化**：`messages` / `sessions` / `session_participants` 的可见行数，改动前后对**库里全部 155 个用户**逐一比对完全一致——不是抽样

## 备注

`amux.current_actor_ids()` 在 `20260810010000` 里被删过（当时是给已废弃的 un-scoped session 列表用的）。这次重新引入，用途不同，迁移注释里写明了这一点。另外它必须写成 `IN (SELECT …)` 而不是 `= ANY((SELECT …))`——后者会被解析成子查询形式并报 `operator does not exist: uuid = uuid[]`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
