### PR TITLE
test(db): pgTAP 隔离区 28 → 7，CI 跑 30 个

### DIFF
--- a/services/supabase/tests/001_schema_shape.sql
+++ b/services/supabase/tests/001_schema_shape.sql
@@ -18,7 +18,7 @@ $$;
 
 select plan(68);
 
-select has_schema('app');
+select has_schema('amux');
 select has_table('public', 'teams');
 select has_table('public', 'actors');
 select has_table('public', 'members');
@@ -69,22 +69,22 @@ select has_trigger('public', 'messages', 'enforce_messages_same_team');
 select has_trigger('public', 'sessions', 'enforce_sessions_parent_integrity');
 select has_trigger('public', 'agent_runtimes', 'enforce_agent_runtimes_same_team');
 
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
 values
   ('00000000-0000-0000-0000-000000000001', 'team-one', 'Team One'),
   ('00000000-0000-0000-0000-000000000002', 'team-two', 'Team Two');
 
-insert into public.actors (id, team_id, actor_type, display_name)
+insert into amux.actors (id, team_id, actor_type, display_name)
 values
   ('10000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000001', 'member', 'Subtype Member'),
   ('10000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000001', 'member', 'Scoped Member');
 
-insert into public.members (id, status)
+insert into amux.members (id, status)
 values
   ('10000000-0000-0000-0000-000000000001', 'active'),
   ('10000000-0000-0000-0000-000000000002', 'active');
 
-insert into public.team_members (id, team_id, member_id, role)
+insert into amux.team_members (id, team_id, member_id, role)
 values (
   '20000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000001',
@@ -92,7 +92,7 @@ values (
   'member'
 );
 
-insert into public.workspaces (id, team_id, created_by_member_id, name)
+insert into amux.workspaces (id, team_id, created_by_member_id, name)
 values (
   '30000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000001',
@@ -100,7 +100,7 @@ values (
   'Workspace One'
 );
 
-insert into public.actors (id, team_id, actor_type, display_name)
+insert into amux.actors (id, team_id, actor_type, display_name)
 values (
   '10000000-0000-0000-0000-000000000003',
   '00000000-0000-0000-0000-000000000002',
@@ -108,15 +108,13 @@ values (
   'Scoped Agent'
 );
 
-insert into public.agents (id, owner_member_id, agent_kind, status)
-values (
+insert into amux.agents (id, owner_member_id, status) values (
   '10000000-0000-0000-0000-000000000003',
   '10000000-0000-0000-0000-000000000002',
-  'amuxd',
   'active'
 );
 
-insert into public.ideas (id, team_id, workspace_id, created_by_actor_id, title, status)
+insert into amux.ideas (id, team_id, workspace_id, created_by_actor_id, title, status)
 values (
   '40000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000001',
@@ -126,7 +124,7 @@ values (
   'open'
 );
 
-insert into public.sessions (id, team_id, idea_id, created_by_actor_id, mode, title)
+insert into amux.sessions (id, team_id, idea_id, created_by_actor_id, mode, title)
 values (
   '50000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000001',
@@ -136,7 +134,7 @@ values (
   'Session One'
 );
 
-insert into public.sessions (id, team_id, idea_id, created_by_actor_id, mode, title)
+insert into amux.sessions (id, team_id, idea_id, created_by_actor_id, mode, title)
 values (
   '50000000-0000-0000-0000-000000000002',
   '00000000-0000-0000-0000-000000000001',
@@ -146,7 +144,7 @@ values (
   'Session Without Idea'
 );
 
-insert into public.messages (id, team_id, session_id, sender_actor_id, kind, content)
+insert into amux.messages (id, team_id, session_id, sender_actor_id, kind, content)
 values (
   '60000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000001',
@@ -167,7 +165,7 @@ values (
 
 select ok(
   pg_temp.raises_sqlstate(
-    $sql$update public.actors
+    $sql$update amux.actors
           set actor_type = 'agent'
           where id = '10000000-0000-0000-0000-000000000001'$sql$,
     '23514'
@@ -178,7 +176,7 @@ select ok(
 select ok(
   exists(
     select 1
-    from public.sessions
+    from amux.sessions
     where id = '50000000-0000-0000-0000-000000000002'
       and idea_id is null
   ),
@@ -197,7 +195,7 @@ select ok(
 
 select ok(
   pg_temp.raises_sqlstate(
-    $sql$update public.actors
+    $sql$update amux.actors
           set team_id = '00000000-0000-0000-0000-000000000002'
           where id = '10000000-0000-0000-0000-000000000002'$sql$,
     '23514'
@@ -207,7 +205,7 @@ select ok(
 
 select ok(
   pg_temp.raises_sqlstate(
-    $sql$update public.workspaces
+    $sql$update amux.workspaces
           set team_id = '00000000-0000-0000-0000-000000000002'
           where id = '30000000-0000-0000-0000-000000000001'$sql$,
     '23514'
@@ -217,7 +215,7 @@ select ok(
 
 select ok(
   pg_temp.raises_sqlstate(
-    $sql$update public.workspaces
+    $sql$update amux.workspaces
           set agent_id = '10000000-0000-0000-0000-000000000003'
           where id = '30000000-0000-0000-0000-000000000001'$sql$,
     '23514'
@@ -227,7 +225,7 @@ select ok(
 
 select ok(
   pg_temp.raises_sqlstate(
-    $sql$update public.ideas
+    $sql$update amux.ideas
           set team_id = '00000000-0000-0000-0000-000000000002'
           where id = '40000000-0000-0000-0000-000000000001'$sql$,
     '23514'
@@ -237,7 +235,7 @@ select ok(
 
 select ok(
   pg_temp.raises_sqlstate(
-    $sql$update public.sessions
+    $sql$update amux.sessions
           set team_id = '00000000-0000-0000-0000-000000000002'
           where id = '50000000-0000-0000-0000-000000000001'$sql$,
     '23514'
@@ -252,26 +250,25 @@ declare
   v_agent_a uuid := gen_random_uuid();
   v_agent_b uuid := gen_random_uuid();
 begin
-  insert into public.teams (id, slug, name) values (v_team, 'dup-ws', 'dup-ws');
-  insert into public.actors (id, team_id, actor_type, display_name)
+  insert into amux.teams (id, slug, name) values (v_team, 'dup-ws', 'dup-ws');
+  insert into amux.actors (id, team_id, actor_type, display_name)
     values ('10000000-0000-0000-0000-0000000000aa', v_team, 'member', 'owner'),
            (v_agent_a, v_team, 'agent', 'a'),
            (v_agent_b, v_team, 'agent', 'b');
-  insert into public.members (id, status)
+  insert into amux.members (id, status)
     values ('10000000-0000-0000-0000-0000000000aa', 'active');
-  insert into public.team_members (team_id, member_id, role)
+  insert into amux.team_members (team_id, member_id, role)
     values (v_team, '10000000-0000-0000-0000-0000000000aa', 'owner');
-  insert into public.agents (id, owner_member_id, agent_kind, status) values
-    (v_agent_a, '10000000-0000-0000-0000-0000000000aa', 'claude', 'active'),
+  insert into amux.agentsinsert into amux.agents (id, owner_member_id, status) values000-0000-0000-0000-0000000000aa', 'claude', 'active'),
     (v_agent_b, '10000000-0000-0000-0000-0000000000aa', 'claude', 'active');
 
   -- Same name on two different agents in the same team must now be allowed.
-  insert into public.workspaces (team_id, agent_id, name) values (v_team, v_agent_a, 'amux');
-  insert into public.workspaces (team_id, agent_id, name) values (v_team, v_agent_b, 'amux');
+  insert into amux.workspaces (team_id, agent_id, name) values (v_team, v_agent_a, 'amux');
+  insert into amux.workspaces (team_id, agent_id, name) values (v_team, v_agent_b, 'amux');
 
   -- Duplicate on the SAME agent must still fail.
   if not pg_temp.raises_sqlstate(
-    format('insert into public.workspaces (team_id, agent_id, name) values (%L, %L, %L)',
+    format('insert into amux.workspaces (team_id, agent_id, name) values (%L, %L, %L)',
            v_team, v_agent_a, 'amux'),
     '23505'
   ) then

--- a/services/supabase/tests/002_rls.sql
+++ b/services/supabase/tests/002_rls.sql
@@ -20,28 +20,30 @@ select plan(47);
 
 select lives_ok(
 $$
-  select app.current_member_id();
+  select amux.current_member_id();
 $$,
 'helper function exists'
 );
 
+-- current_actor_id() was dropped by 20260804020000: actors are per team, so a
+-- team has to be supplied to resolve one.
 select lives_ok(
 $$
-  select app.current_actor_id();
+  select amux.current_actor_id_for_team('00000000-0000-0000-0000-000000000001'::uuid);
 $$,
 'actor helper exists'
 );
 
 select lives_ok(
 $$
-  select app.is_team_member(gen_random_uuid());
+  select amux.is_team_member(gen_random_uuid());
 $$,
 'team membership helper exists'
 );
 
 select lives_ok(
 $$
-  select app.can_prompt_agent(gen_random_uuid());
+  select amux.can_prompt_agent(gen_random_uuid());
 $$,
 'agent prompt helper exists'
 );
@@ -49,7 +51,7 @@ $$,
 select ok(
   has_function_privilege(
     'authenticated',
-    'public.update_current_actor_profile(uuid,text,text)',
+    'amux.update_current_actor_profile(uuid,text,text)',
     'EXECUTE'
   ),
   'authenticated can execute actor profile update rpc'
@@ -85,33 +87,35 @@ values
   ('90000000-0000-0000-0000-000000000002', 'other-member@example.com'),
   ('90000000-0000-0000-0000-000000000003', 'admin-member@example.com');
 
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
 values (
   '00000000-0000-0000-0000-000000000001',
   'team-one',
   'Team One'
 );
 
-insert into public.actors (id, team_id, actor_type, display_name)
+-- user_id lives on actors now: identity is per team, so the link to
+-- auth.users belongs on the per-team row rather than on members.
+insert into amux.actors (id, team_id, actor_type, display_name, user_id)
 values
-  ('10000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000001', 'member', 'Active Member'),
-  ('10000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000001', 'member', 'Other Member'),
-  ('10000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000001', 'member', 'Admin Member'),
-  ('10000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-000000000001', 'agent', 'Build Agent');
+  ('10000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000001', 'member', 'Active Member', '90000000-0000-0000-0000-000000000001'),
+  ('10000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000001', 'member', 'Other Member',  '90000000-0000-0000-0000-000000000002'),
+  ('10000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000001', 'member', 'Admin Member',  '90000000-0000-0000-0000-000000000003'),
+  ('10000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-000000000001', 'agent',  'Build Agent',   null);
 
-insert into public.members (id, user_id, status)
+insert into amux.members (id, status)
 values
-  ('10000000-0000-0000-0000-000000000001', '90000000-0000-0000-0000-000000000001', 'active'),
-  ('10000000-0000-0000-0000-000000000002', '90000000-0000-0000-0000-000000000002', 'active'),
-  ('10000000-0000-0000-0000-000000000003', '90000000-0000-0000-0000-000000000003', 'active');
+  ('10000000-0000-0000-0000-000000000001', 'active'),
+  ('10000000-0000-0000-0000-000000000002', 'active'),
+  ('10000000-0000-0000-0000-000000000003', 'active');
 
-insert into public.team_members (id, team_id, member_id, role)
+insert into amux.team_members (id, team_id, member_id, role)
 values
   ('20000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000001', 'member'),
   ('20000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000002', 'member'),
   ('20000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000003', 'admin');
 
-insert into public.workspaces (id, team_id, created_by_member_id, name)
+insert into amux.workspaces (id, team_id, created_by_member_id, name)
 values (
   '30000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000001',
@@ -119,17 +123,15 @@ values (
   'Workspace One'
 );
 
-insert into public.agents (id, default_workspace_id, owner_member_id, visibility, agent_kind, status)
-values (
+insert into amux.agents (id, default_workspace_id, owner_member_id, visibility, status) values (
   '10000000-0000-0000-0000-0000000000a1',
   '30000000-0000-0000-0000-000000000001',
   '10000000-0000-0000-0000-000000000001',
   'team',
-  'codex',
   'active'
 );
 
-insert into public.ideas (id, team_id, workspace_id, created_by_actor_id, title, status)
+insert into amux.ideas (id, team_id, workspace_id, created_by_actor_id, title, status)
 values (
   '40000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000001',
@@ -139,7 +141,7 @@ values (
   'open'
 );
 
-insert into public.sessions (id, team_id, idea_id, created_by_actor_id, primary_agent_id, mode, title)
+insert into amux.sessions (id, team_id, idea_id, created_by_actor_id, primary_agent_id, mode, title)
 values (
   '50000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000001',
@@ -150,12 +152,12 @@ values (
   'Session One'
 );
 
-insert into public.session_participants (id, session_id, actor_id, role)
+insert into amux.session_participants (id, session_id, actor_id, role)
 values
   ('70000000-0000-0000-0000-000000000001', '50000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000001', 'owner'),
   ('70000000-0000-0000-0000-000000000002', '50000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000003', 'observer');
 
-insert into public.messages (id, team_id, session_id, sender_actor_id, kind, content)
+insert into amux.messages (id, team_id, session_id, sender_actor_id, kind, content)
 values (
   '60000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000001',
@@ -165,7 +167,7 @@ values (
   'Hello'
 );
 
-insert into public.agent_member_access (
+insert into amux.agent_member_access (
   id,
   agent_id,
   member_id,
@@ -181,12 +183,12 @@ values (
 );
 
 select ok(
-  not has_function_privilege('anon', 'app.current_member_id()', 'EXECUTE'),
+  not has_function_privilege('anon', 'amux.current_member_id()', 'EXECUTE'),
   'anon cannot execute current_member_id directly'
 );
 
 select ok(
-  has_function_privilege('authenticated', 'app.current_member_id()', 'EXECUTE'),
+  has_function_privilege('authenticated', 'amux.current_member_id()', 'EXECUTE'),
   'authenticated can execute current_member_id directly'
 );
 
@@ -196,7 +198,7 @@ set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000001';
 
 select lives_ok(
   $sql$
-    select public.update_current_actor_profile(
+    select amux.update_current_actor_profile(
       '10000000-0000-0000-0000-000000000001',
       'Renamed Member',
       'https://example.com/avatar.jpg'
@@ -206,13 +208,13 @@ select lives_ok(
 );
 
 select is(
-  (select display_name from public.actors where id = '10000000-0000-0000-0000-000000000001'),
+  (select display_name from amux.actors where id = '10000000-0000-0000-0000-000000000001'),
   'Renamed Member',
   'profile update stores display name'
 );
 
 select is(
-  (select avatar_url from public.actor_directory where id = '10000000-0000-0000-0000-000000000001'),
+  (select avatar_url from amux.actor_directory where id = '10000000-0000-0000-0000-000000000001'),
   'https://example.com/avatar.jpg',
   'actor_directory exposes updated avatar url'
 );
@@ -220,7 +222,7 @@ select is(
 select ok(
   pg_temp.raises_sqlstate(
     $sql$
-      select public.update_current_actor_profile(
+      select amux.update_current_actor_profile(
         '10000000-0000-0000-0000-000000000002',
         'Spoofed Member',
         null
@@ -234,7 +236,7 @@ select ok(
 select ok(
   pg_temp.raises_sqlstate(
     $sql$
-      select public.update_current_actor_profile(
+      select amux.update_current_actor_profile(
         '10000000-0000-0000-0000-000000000001',
         '   ',
         null
@@ -246,24 +248,24 @@ select ok(
 );
 
 select is(
-  app.current_member_id(),
+  amux.current_member_id(),
   '10000000-0000-0000-0000-000000000001'::uuid,
   'active member resolves current_member_id'
 );
 
 select is(
-  app.current_actor_id(),
+  amux.current_actor_id_for_team('00000000-0000-0000-0000-000000000001'::uuid),
   '10000000-0000-0000-0000-000000000001'::uuid,
   'active member resolves current_actor_id'
 );
 
 select ok(
-  app.is_session_participant('50000000-0000-0000-0000-000000000001'::uuid),
+  amux.is_session_participant('50000000-0000-0000-0000-000000000001'::uuid),
   'active participant is recognized'
 );
 
 select is(
-  (select count(*) from public.messages),
+  (select count(*) from amux.messages),
   1::bigint,
   'active participant can read session messages'
 );
@@ -271,14 +273,14 @@ select is(
 set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000002';
 
 select ok(
-  app.can_prompt_agent('10000000-0000-0000-0000-0000000000a1'::uuid),
+  amux.can_prompt_agent('10000000-0000-0000-0000-0000000000a1'::uuid),
   'explicit grant allows active team member to prompt agent'
 );
 
 select ok(
   pg_temp.raises_sqlstate(
     $sql$
-      insert into public.session_participants (
+      insert into amux.session_participants (
         id,
         session_id,
         actor_id,
@@ -297,17 +299,16 @@ select ok(
 );
 
 select is(
-  (select count(*) from public.messages),
+  (select count(*) from amux.messages),
   0::bigint,
   'failed self-enrollment does not grant session message visibility'
 );
 
 set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000003';
 
-select ok(
-  lives_ok(
+select lives_ok(
     $sql$
-      insert into public.session_participants (
+      insert into amux.session_participants (
         id,
         session_id,
         actor_id,
@@ -319,19 +320,18 @@ select ok(
         '10000000-0000-0000-0000-000000000002',
         'observer'
       )
-    $sql$
-  ),
+    $sql$,
   'existing participant can add another actor to the session'
 );
 
-delete from public.session_participants
+delete from amux.session_participants
 where id = '70000000-0000-0000-0000-000000000004';
 
 set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000001';
 
 select lives_ok(
   $sql$
-    insert into public.session_participants (
+    insert into amux.session_participants (
       id,
       session_id,
       actor_id,
@@ -347,20 +347,20 @@ select lives_ok(
   'session creator can bootstrap additional participants'
 );
 
-delete from public.session_participants
+delete from amux.session_participants
 where id = '70000000-0000-0000-0000-000000000009';
 
 set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000002';
 
 select is(
-  (select count(*) from public.messages),
+  (select count(*) from amux.messages),
   0::bigint,
   'failed participant-managed add does not expand session message visibility'
 );
 
 reset role;
 
-delete from public.team_members
+delete from amux.team_members
 where id = '20000000-0000-0000-0000-000000000002';
 
 set local role authenticated;
@@ -368,13 +368,13 @@ set local request.jwt.claim.role = 'authenticated';
 set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000002';
 
 select ok(
-  not app.can_prompt_agent('10000000-0000-0000-0000-0000000000a1'::uuid),
+  not amux.can_prompt_agent('10000000-0000-0000-0000-0000000000a1'::uuid),
   'explicit grant no longer authorizes removed team member'
 );
 
 reset role;
 
-insert into public.team_members (id, team_id, member_id, role)
+insert into amux.team_members (id, team_id, member_id, role)
 values (
   '20000000-0000-0000-0000-000000000002',
   '00000000-0000-0000-0000-000000000001',
@@ -388,7 +388,7 @@ set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000001';
 
 reset role;
 
-delete from public.team_members
+delete from amux.team_members
 where id = '20000000-0000-0000-0000-000000000001';
 
 set local role authenticated;
@@ -396,24 +396,24 @@ set local request.jwt.claim.role = 'authenticated';
 set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000001';
 
 select ok(
-  not app.is_team_member('00000000-0000-0000-0000-000000000001'::uuid),
+  not amux.is_team_member('00000000-0000-0000-0000-000000000001'::uuid),
   'team membership removal revokes team membership'
 );
 
 select ok(
-  not app.is_session_participant('50000000-0000-0000-0000-000000000001'::uuid),
+  not amux.is_session_participant('50000000-0000-0000-0000-000000000001'::uuid),
   'team membership removal revokes session participation'
 );
 
 select is(
-  (select count(*) from public.messages),
+  (select count(*) from amux.messages),
   0::bigint,
   'team membership removal revokes session message visibility'
 );
 
 reset role;
 
-insert into public.team_members (id, team_id, member_id, role)
+insert into amux.team_members (id, team_id, member_id, role)
 values (
   '20000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000001',
@@ -423,7 +423,7 @@ values (
 
 reset role;
 
-delete from public.session_participants
+delete from amux.session_participants
 where id = '70000000-0000-0000-0000-000000000001';
 
 set local role authenticated;
@@ -431,19 +431,19 @@ set local request.jwt.claim.role = 'authenticated';
 set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000001';
 
 select ok(
-  not app.is_session_participant('50000000-0000-0000-0000-000000000001'::uuid),
+  not amux.is_session_participant('50000000-0000-0000-0000-000000000001'::uuid),
   'participant removal revokes session participation'
 );
 
 select is(
-  (select count(*) from public.messages),
+  (select count(*) from amux.messages),
   0::bigint,
   'participant removal revokes session message visibility'
 );
 
 reset role;
 
-insert into public.session_participants (id, session_id, actor_id, role)
+insert into amux.session_participants (id, session_id, actor_id, role)
 values (
   '70000000-0000-0000-0000-000000000001',
   '50000000-0000-0000-0000-000000000001',
@@ -456,13 +456,13 @@ set local request.jwt.claim.role = 'authenticated';
 set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000003';
 
 select ok(
-  not app.can_prompt_agent('10000000-0000-0000-0000-0000000000a1'::uuid),
+  not amux.can_prompt_agent('10000000-0000-0000-0000-0000000000a1'::uuid),
   'active team admin without grant cannot prompt team agent'
 );
 
 reset role;
 
-update public.members
+update amux.members
 set status = 'disabled'
 where id = '10000000-0000-0000-0000-000000000003';
 
@@ -471,23 +471,23 @@ set local request.jwt.claim.role = 'authenticated';
 set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000003';
 
 select is(
-  app.current_member_id(),
+  amux.current_member_id(),
   null::uuid,
   'disabled member no longer resolves current_member_id'
 );
 
 select ok(
-  not app.can_prompt_agent('10000000-0000-0000-0000-0000000000a1'::uuid),
+  not amux.can_prompt_agent('10000000-0000-0000-0000-0000000000a1'::uuid),
   'disabled team admin cannot prompt agent'
 );
 
 select ok(
-  not app.is_session_participant('50000000-0000-0000-0000-000000000001'::uuid),
+  not amux.is_session_participant('50000000-0000-0000-0000-000000000001'::uuid),
   'disabled participant loses session participation'
 );
 
 select is(
-  (select count(*) from public.messages),
+  (select count(*) from amux.messages),
   0::bigint,
   'disabled participant cannot read session messages'
 );
@@ -497,7 +497,7 @@ set local request.jwt.claim.sub = '90000000-0000-0000-0000-000000000001';
 select ok(
   pg_temp.raises_sqlstate(
     $sql$
-      insert into public.messages (
+      insert into amux.messages (
         id,
         team_id,
         session_id,
@@ -521,7 +521,7 @@ select ok(
 
 select lives_ok(
 $$
-  insert into public.messages (
+  insert into amux.messages (
     id,
     team_id,
     session_id,
@@ -544,7 +544,7 @@ $$,
 select ok(
   pg_temp.raises_sqlstate(
     $sql$
-      insert into public.workspaces (
+      insert into amux.workspaces (
         id,
         team_id,
         created_by_member_id,
@@ -565,7 +565,7 @@ select ok(
 select ok(
   pg_temp.raises_sqlstate(
     $sql$
-      update public.ideas
+      update amux.ideas
       set created_by_actor_id = '10000000-0000-0000-0000-000000000002'
       where id = '40000000-0000-0000-0000-000000000001'
     $sql$,
@@ -577,7 +577,7 @@ select ok(
 select ok(
   pg_temp.raises_sqlstate(
     $sql$
-      insert into public.sessions (
+      insert into amux.sessions (
         id,
         team_id,
         idea_id,
@@ -602,7 +602,7 @@ select ok(
 select ok(
   pg_temp.raises_sqlstate(
     $sql$
-      insert into public.idea_external_refs (
+      insert into amux.idea_external_refs (
         id,
         idea_id,
         provider,

--- a/services/supabase/tests/003_team_invites.sql
+++ b/services/supabase/tests/003_team_invites.sql
@@ -1,5 +1,12 @@
 begin;
 
+-- Temp tables are owned by the session role; the tests then `set role` to
+-- anon/authenticated, which cannot read them without an explicit grant.
+
+-- `like` here is PostgreSQL's built-in operator function, not an assertion —
+-- pgTAP's pattern matcher is alike()/matches(). The three-argument call never
+-- resolved, which is why this file could not even parse.
+
 select plan(17);
 
 create or replace function pg_temp.as_user(p_user uuid)
@@ -22,18 +29,20 @@ values
 on conflict do nothing;
 
 select pg_temp.as_user('11111111-1111-1111-1111-111111111111');
-select * from public.create_team('Team A');
+select * from amux.create_team('Team A', p_oid => null);
 
 create temp table ctx as
   select
-    (select id from public.teams where slug = 'team-a') as team_a,
-    (select id from public.actors
+    (select id from amux.teams where slug = 'team-a') as team_a,
+    (select id from amux.actors
       where user_id = '11111111-1111-1111-1111-111111111111' limit 1) as alice_actor;
+
+grant select on ctx to anon, authenticated;
 
 -- 1. Non-member is rejected by create_team_invite
 select pg_temp.as_user('22222222-2222-2222-2222-222222222222');
 select throws_ok(
-  format($$ select public.create_team_invite(%L::uuid, 'member', 'X', 'member') $$,
+  format($$ select amux.create_team_invite(%L::uuid, 'member', 'X', 'member') $$,
          (select team_a from ctx)),
   '42501', 'create_team_invite requires team membership',
   'non-member rejected'
@@ -42,38 +51,42 @@ select throws_ok(
 -- 2. kind=member without team_role raises 22023
 select pg_temp.as_user('11111111-1111-1111-1111-111111111111');
 select throws_ok(
-  format($$ select public.create_team_invite(%L::uuid, 'member', 'X') $$,
+  format($$ select amux.create_team_invite(%L::uuid, 'member', 'X') $$,
          (select team_a from ctx)),
   '22023', null, 'member kind without team_role raises'
 );
 
 -- 3. kind=agent without agent_kind raises 22023
 select throws_ok(
-  format($$ select public.create_team_invite(%L::uuid, 'agent', 'X') $$,
+  format($$ select amux.create_team_invite(%L::uuid, 'agent', 'X') $$,
          (select team_a from ctx)),
   '22023', null, 'agent kind without agent_kind raises'
 );
 
 -- 4. Happy path member invite
 create temp table mi as
-  select * from public.create_team_invite(
+  select * from amux.create_team_invite(
     (select team_a from ctx), 'member', 'Carol', p_team_role => 'member');
+grant select on mi to anon, authenticated;
+
 select ok((select count(*) = 1 from mi), 'member invite created');
-select like((select deeplink from mi), 'amux://invite?token=%',
+select alike((select deeplink from mi), 'amux://invite?token=%',
             'deeplink format is amux://invite?token=...');
-select like((select deeplink from mi), '%&broker=mqtts://ai.ucar.cc:8883%',
+select alike((select deeplink from mi), '%&broker=mqtts://ai.ucar.cc:8883%',
             'deeplink includes mqtt broker');
-select like((select deeplink from mi), '%&username=teamclu%',
+select alike((select deeplink from mi), '%&username=teamclu%',
             'deeplink includes mqtt username');
-select like((select deeplink from mi), '%&password=teamclu2026%',
+select alike((select deeplink from mi), '%&password=teamclu2026%',
             'deeplink includes mqtt password');
 
 -- 5. Carol (different auth user) claims → new actor + members + team_members
 select pg_temp.as_user('33333333-3333-3333-3333-333333333333');
-create temp table mc as select * from public.claim_team_invite((select token from mi));
+create temp table mc as select * from amux.claim_team_invite((select token from mi));
+grant select on mc to anon, authenticated;
+
 select is((select actor_type from mc), 'member',
          'member claim returns actor_type=member');
-select ok((select count(*) = 1 from public.team_members
+select ok((select count(*) = 1 from amux.team_members
             where team_id = (select team_a from ctx)
               and member_id = (select actor_id from mc)
               and role = 'member'),
@@ -81,28 +94,33 @@ select ok((select count(*) = 1 from public.team_members
 
 -- 6. Replay same token → 23514
 select throws_ok(
-  format($$ select public.claim_team_invite(%L) $$, (select token from mi)),
+  format($$ select amux.claim_team_invite(%L) $$, (select token from mi)),
   '23514', 'invite already consumed', 'replay rejected'
 );
 
 -- 7. Agent invite (back as alice)
 select pg_temp.as_user('11111111-1111-1111-1111-111111111111');
 create temp table ai as
-  select * from public.create_team_invite(
+  select * from amux.create_team_invite(
     (select team_a from ctx), 'agent', 'M1 Studio', p_agent_kind => 'daemon');
+grant select on ai to anon, authenticated;
+
 select ok((select count(*) = 1 from ai), 'agent invite created');
 
 -- 8. Anonymous daemon claim → new actor + agents + refresh_token non-null
-perform set_config('request.jwt.claims', '{}', true);
-perform set_config('role', 'anon', true);
-create temp table ac as select * from public.claim_team_invite((select token from ai));
+-- `perform` is plpgsql-only; at the top level of a script it must be `select`.
+select set_config('request.jwt.claims', '{}', true);
+select set_config('role', 'anon', true);
+create temp table ac as select * from amux.claim_team_invite((select token from ai));
+grant select on ac to anon, authenticated;
+
 select is((select actor_type from ac), 'agent', 'agent claim returns actor_type=agent');
 select ok((select refresh_token is not null and length(refresh_token) >= 20 from ac),
          'agent claim returns a refresh_token');
 
 -- 9. agent_member_access row was materialized for inviter
-select ok((select count(*) = 1 from public.agent_member_access ama
-            join public.actors a on a.id = ama.member_id
+select ok((select count(*) = 1 from amux.agent_member_access ama
+            join amux.actors a on a.id = ama.member_id
             where ama.agent_id = (select actor_id from ac)
               and a.user_id = '11111111-1111-1111-1111-111111111111'
               and ama.permission_level = 'admin'),
@@ -111,22 +129,24 @@ select ok((select count(*) = 1 from public.agent_member_access ama
 -- 10. Expired invite rejected
 select pg_temp.as_user('11111111-1111-1111-1111-111111111111');
 create temp table ei as
-  select * from public.create_team_invite(
+  select * from amux.create_team_invite(
     (select team_a from ctx), 'member', 'Expires', p_team_role => 'member',
     p_ttl_seconds => 60);
-update public.team_invites set expires_at = now() - interval '1 minute'
+grant select on ei to anon, authenticated;
+
+update amux.team_invites set expires_at = now() - interval '1 minute'
   where token = (select token from ei);
 select pg_temp.as_user('33333333-3333-3333-3333-333333333333');
 select throws_ok(
-  format($$ select public.claim_team_invite(%L) $$, (select token from ei)),
+  format($$ select amux.claim_team_invite(%L) $$, (select token from ei)),
   '23514', 'invite expired', 'expired invite rejected'
 );
 
 -- 11. Heartbeat bumps last_active_at
-select lives_ok('select public.update_actor_last_active();',
+select lives_ok('select amux.update_actor_last_active();',
                 'heartbeat RPC runs without error');
 select ok((select last_active_at > now() - interval '30 seconds'
-            from public.actors where user_id = '33333333-3333-3333-3333-333333333333' limit 1),
+            from amux.actors where user_id = '33333333-3333-3333-3333-333333333333' limit 1),
          'last_active_at moved forward');
 
 select * from finish();

--- a/services/supabase/tests/004_member_reinvite.sql
+++ b/services/supabase/tests/004_member_reinvite.sql
@@ -40,29 +40,29 @@ on conflict do nothing;
 
 -- Alice creates Team R and seeds anonymous user as member.
 select pg_temp.as_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
-select * from public.create_team('Team R');
+select * from amux.create_team('Team R', p_oid => null);
 
 create temp table ctx as
   select
-    (select id from public.teams where slug = 'team-r') as team_r,
-    (select id from public.actors
+    (select id from amux.teams where slug = 'team-r') as team_r,
+    (select id from amux.actors
       where user_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' limit 1) as alice_actor;
 
 -- Anon user joins normally.
 select pg_temp.as_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
 create temp table init_invite as
-  select * from public.create_team_invite(
+  select * from amux.create_team_invite(
     (select team_r from ctx), 'member', 'AnonUser',
     p_team_role => 'member');
 select pg_temp.as_user('cccccccc-cccc-cccc-cccc-cccccccccccc');
 create temp table init_claim as
-  select * from public.claim_team_invite((select token from init_invite));
+  select * from amux.claim_team_invite((select token from init_invite));
 grant select on init_claim to anon;
 
 -- 1. Re-invite happy path: alice creates a re-invite for the anon member
 select pg_temp.as_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
 create temp table ri as
-  select * from public.create_team_invite(
+  select * from amux.create_team_invite(
     (select team_r from ctx), 'member', 'AnonUser',
     p_team_role => 'member',
     p_target_actor_id => (select actor_id from init_claim));
@@ -73,7 +73,7 @@ select ok((select count(*) = 1 from ri),
 -- 2. Anonymous claim of the re-invite returns a refresh_token
 select pg_temp.as_anon();
 create temp table rc as
-  select * from public.claim_team_invite((select token from ri));
+  select * from amux.claim_team_invite((select token from ri));
 grant select on rc to authenticated;
 select is((select actor_type from rc), 'member',
          'member-reinvite claim returns actor_type=member');
@@ -89,27 +89,27 @@ select is((select actor_id from rc),
 -- Switch to alice (team admin) so RLS lets us read the actor row.
 select pg_temp.as_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
 select is(
-  (select user_id from public.actors where id = (select actor_id from rc)),
+  (select user_id from amux.actors where id = (select actor_id from rc)),
   'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid,
   'reinvite preserves actor.user_id');
 
 -- 5. Replay rejected with 23514
 select throws_ok(
-  format($$ select public.claim_team_invite(%L) $$, (select token from ri)),
+  format($$ select amux.claim_team_invite(%L) $$, (select token from ri)),
   '23514', 'invite already consumed', 'reinvite replay rejected');
 
 -- 6. Reject create_team_invite when target is non-anonymous (bob is named)
 select pg_temp.as_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
 create temp table bob_invite as
-  select * from public.create_team_invite(
+  select * from amux.create_team_invite(
     (select team_r from ctx), 'member', 'Bob',
     p_team_role => 'member');
 select pg_temp.as_user('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
 create temp table bob_claim as
-  select * from public.claim_team_invite((select token from bob_invite));
+  select * from amux.claim_team_invite((select token from bob_invite));
 select pg_temp.as_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
 select throws_ok(
-  format($$ select public.create_team_invite(%L::uuid, 'member', 'Bob',
+  format($$ select amux.create_team_invite(%L::uuid, 'member', 'Bob',
               p_team_role => 'member', p_target_actor_id => %L::uuid) $$,
          (select team_r from ctx), (select actor_id from bob_claim)),
   '22023', 'cannot re-invite member with bound auth identity',
@@ -118,7 +118,7 @@ select throws_ok(
 -- 7. Reject create when target_actor_id points at bogus actor
 select pg_temp.as_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
 select throws_ok(
-  format($$ select public.create_team_invite(%L::uuid, 'member', 'Stranger',
+  format($$ select amux.create_team_invite(%L::uuid, 'member', 'Stranger',
               p_team_role => 'member', p_target_actor_id => %L::uuid) $$,
          (select team_r from ctx),
          '00000000-0000-0000-0000-000000000000'),

--- a/services/supabase/tests/005_agent_role_rls.sql
+++ b/services/supabase/tests/005_agent_role_rls.sql
@@ -19,24 +19,25 @@ declare
   v_session uuid;
 begin
   insert into auth.users (id) values (v_member);
-  insert into public.teams (id, slug, name) values
+  insert into amux.teams (id, slug, name) values
     (v_team, 'rls-agent', 'RLS Agent'),
     (v_other, 'other-team', 'Other Team');
-  insert into public.actors (id, team_id, actor_type, display_name) values
-    (v_member, v_team, 'member', 'm'),
-    (v_agent, v_team, 'agent', 'a');
-  insert into public.members (id, user_id, status) values (v_member, v_member, 'active');
-  insert into public.team_members (team_id, member_id, role)
+-- user_id lives on actors now: identity is per team, so the link to
+-- auth.users belongs on the per-team row rather than on members.
+  insert into amux.actors (id, team_id, actor_type, display_name, user_id) values
+    (v_member, v_team, 'member', 'm', v_member),
+    (v_agent, v_team, 'agent', 'a', null);
+  insert into amux.members (id, status) values (v_member, 'active');
+  insert into amux.team_members (team_id, member_id, role)
     values (v_team, v_member, 'owner');
-  insert into public.agents (id, owner_member_id, visibility, agent_kind, status)
-    values (v_agent, v_member, 'team', 'claude', 'active');
-  insert into public.ideas (id, team_id, created_by_actor_id, title, status)
+  insert into amux.agents (id, owner_member_id, visibility, status) values (v_agent, v_member, 'team', 'active');
+  insert into amux.ideas (id, team_id, created_by_actor_id, title, status)
     values (v_idea, v_team, v_member, 't', 'open');
-  insert into public.sessions (id, team_id, idea_id, created_by_actor_id,
+  insert into amux.sessions (id, team_id, idea_id, created_by_actor_id,
                                primary_agent_id, mode, title)
     values (gen_random_uuid(), v_team, v_idea, v_member, v_agent, 'solo', 's')
     returning id into v_session;
-  insert into public.session_participants (session_id, actor_id) values
+  insert into amux.session_participants (session_id, actor_id) values
     (v_session, v_member), (v_session, v_agent);
 
   insert into _rls_ids values (v_team, v_other, v_member, v_agent, v_session);
@@ -69,17 +70,17 @@ begin
     values (r.team_id, r.agent_id, r.session_id, 'claude', 'running');
 
   -- Allowed: insert messages as self.
-  insert into public.messages
+  insert into amux.messages
     (team_id, session_id, sender_actor_id, kind, content)
     values (r.team_id, r.session_id, r.agent_id, 'text', 'hi');
 
   -- Allowed: insert a workspace for self.
-  insert into public.workspaces (team_id, agent_id, name, path)
+  insert into amux.workspaces (team_id, agent_id, name, path)
     values (r.team_id, r.agent_id, 'amux', '/tmp/amux');
 
   -- Denied: impersonating another actor as the message sender.
   begin
-    insert into public.messages
+    insert into amux.messages
       (team_id, session_id, sender_actor_id, kind, content)
       values (r.team_id, r.session_id, r.member_id, 'text', 'spoof');
     raise exception 'impersonation should be blocked';
@@ -95,7 +96,7 @@ begin
 
   -- Denied: writing workspace in a different team.
   begin
-    insert into public.workspaces (team_id, agent_id, name)
+    insert into amux.workspaces (team_id, agent_id, name)
       values (r.other_team, r.agent_id, 'other');
     raise exception 'cross-team workspace should be blocked';
   exception

--- a/services/supabase/tests/006_access_token_hook.sql
+++ b/services/supabase/tests/006_access_token_hook.sql
@@ -5,7 +5,7 @@ select plan(23);
 -- Rule catalog for a member yields exactly 9 allow rules with the expected topic shapes.
 select is(
   (select count(*)::int
-     from public.amux_acl_rules_for(
+     from amux.amux_acl_rules_for(
        '11111111-1111-1111-1111-111111111111'::uuid,
        '22222222-2222-2222-2222-222222222222'::uuid,
        'member'
@@ -15,7 +15,7 @@ select is(
 );
 
 select bag_eq(
-  $$select action, topic from public.amux_acl_rules_for(
+  $$select action, topic from amux.amux_acl_rules_for(
       '11111111-1111-1111-1111-111111111111'::uuid,
       '22222222-2222-2222-2222-222222222222'::uuid,
       'member')$$,
@@ -36,7 +36,7 @@ select bag_eq(
 -- Unknown actor_type yields zero rows (no exception).
 select is(
   (select count(*)::int
-     from public.amux_acl_rules_for(
+     from amux.amux_acl_rules_for(
        gen_random_uuid(), gen_random_uuid(), 'bogus'
      )),
   0,
@@ -46,7 +46,7 @@ select is(
 -- Rule catalog for an agent yields exactly 13 allow rules.
 select is(
   (select count(*)::int
-     from public.amux_acl_rules_for(
+     from amux.amux_acl_rules_for(
        '33333333-3333-3333-3333-333333333333'::uuid,
        '44444444-4444-4444-4444-444444444444'::uuid,
        'agent'
@@ -56,7 +56,7 @@ select is(
 );
 
 select bag_eq(
-  $$select action, topic from public.amux_acl_rules_for(
+  $$select action, topic from amux.amux_acl_rules_for(
       '33333333-3333-3333-3333-333333333333'::uuid,
       '44444444-4444-4444-4444-444444444444'::uuid,
       'agent')$$,
@@ -81,7 +81,7 @@ select bag_eq(
 -- Agents do not get the member-only "publish commands" permission.
 select is(
   (select count(*)::int
-     from public.amux_acl_rules_for(
+     from amux.amux_acl_rules_for(
        gen_random_uuid(),
        gen_random_uuid(),
        'agent')
@@ -92,7 +92,7 @@ select is(
 
 -- Hook called with null user_id (anon/service_role) must return event unchanged.
 select is(
-  public.amux_access_token_hook(
+  amux.amux_access_token_hook(
     jsonb_build_object(
       'user_id', null,
       'claims',  jsonb_build_object('sub','anon','role','anon','aud','anon')
@@ -115,14 +115,14 @@ declare
   v_claims jsonb;
 begin
   insert into auth.users (id) values (v_user);
-  insert into public.teams (id, slug, name) values (v_team, 'hook-solo', 'Hook Solo');
-  insert into public.actors (id, team_id, actor_type, display_name, user_id)
+  insert into amux.teams (id, slug, name) values (v_team, 'hook-solo', 'Hook Solo');
+  insert into amux.actors (id, team_id, actor_type, display_name, user_id)
     values (v_actor, v_team, 'member', 'solo-member', v_user);
-  insert into public.members (id, status) values (v_actor, 'active');
-  insert into public.team_members (team_id, member_id, role)
+  insert into amux.members (id, status) values (v_actor, 'active');
+  insert into amux.team_members (team_id, member_id, role)
     values (v_team, v_actor, 'owner');
 
-  v_out := public.amux_access_token_hook(
+  v_out := amux.amux_access_token_hook(
     jsonb_build_object(
       'user_id', v_user,
       'claims',  jsonb_build_object(
@@ -172,7 +172,7 @@ declare
 begin
   insert into auth.users (id) values (v_user);
 
-  v_out := public.amux_access_token_hook(
+  v_out := amux.amux_access_token_hook(
     jsonb_build_object(
       'user_id', v_user,
       'claims',  jsonb_build_object(
@@ -219,20 +219,20 @@ declare
   v_claims jsonb;
 begin
   insert into auth.users (id) values (v_user);
-  insert into public.teams (id, slug, name) values
+  insert into amux.teams (id, slug, name) values
     (v_team_a, 'mt-a-' || left(v_team_a::text,8), 'MT A'),
     (v_team_b, 'mt-b-' || left(v_team_b::text,8), 'MT B');
-  insert into public.actors (id, team_id, actor_type, display_name, user_id) values
+  insert into amux.actors (id, team_id, actor_type, display_name, user_id) values
     (v_act_a, v_team_a, 'member', 'A', v_user),
     (v_act_b, v_team_b, 'member', 'B', v_user);
-  insert into public.members (id, status) values
+  insert into amux.members (id, status) values
     (v_act_a, 'active'),
     (v_act_b, 'active');
-  insert into public.team_members (team_id, member_id, role) values
+  insert into amux.team_members (team_id, member_id, role) values
     (v_team_a, v_act_a, 'owner'),
     (v_team_b, v_act_b, 'owner');
 
-  v_out := public.amux_access_token_hook(
+  v_out := amux.amux_access_token_hook(
     jsonb_build_object(
       'user_id', v_user,
       'claims',  jsonb_build_object('sub', v_user::text, 'role', 'authenticated')
@@ -271,21 +271,20 @@ declare
   v_claims jsonb;
 begin
   insert into auth.users (id) values (v_user);
-  insert into public.teams (id, slug, name) values
+  insert into amux.teams (id, slug, name) values
     (v_team_a, 'mix-a-' || left(v_team_a::text,8), 'Mix A'),
     (v_team_b, 'mix-b-' || left(v_team_b::text,8), 'Mix B');
-  insert into public.actors (id, team_id, actor_type, display_name, user_id) values
+  insert into amux.actors (id, team_id, actor_type, display_name, user_id) values
     (v_act_m, v_team_a, 'member', 'Member in A', v_user),
     ('10000000-0000-0000-0000-0000000000bb', v_team_b, 'member', 'Owner in B', null),
     (v_act_a, v_team_b, 'agent',  'Agent in B',  v_user);
-  insert into public.members (id, status) values (v_act_m, 'active');
-  insert into public.members (id, status) values ('10000000-0000-0000-0000-0000000000bb', 'active');
-  insert into public.team_members (team_id, member_id, role) values (v_team_a, v_act_m, 'owner');
-  insert into public.team_members (team_id, member_id, role) values (v_team_b, '10000000-0000-0000-0000-0000000000bb', 'owner');
-  insert into public.agents  (id, owner_member_id, visibility, agent_kind, status)
-    values (v_act_a, '10000000-0000-0000-0000-0000000000bb', 'team', 'claude', 'active');
+  insert into amux.members (id, status) values (v_act_m, 'active');
+  insert into amux.members (id, status) values ('10000000-0000-0000-0000-0000000000bb', 'active');
+  insert into amux.team_members (team_id, member_id, role) values (v_team_a, v_act_m, 'owner');
+  insert into amux.team_members (team_id, member_id, role) values (v_team_b, '10000000-0000-0000-0000-0000000000bb', 'owner');
+  insert into amux.agents (id, owner_member_id, visibility, status) values (v_act_a, '10000000-0000-0000-0000-0000000000bb', 'team', 'active');
 
-  v_out := public.amux_access_token_hook(
+  v_out := amux.amux_access_token_hook(
     jsonb_build_object(
       'user_id', v_user,
       'claims',  jsonb_build_object('sub', v_user::text, 'role', 'authenticated')
@@ -315,7 +314,7 @@ declare
 begin
   insert into auth.users (id) values (v_user);
 
-  v_out := public.amux_access_token_hook(
+  v_out := amux.amux_access_token_hook(
     jsonb_build_object(
       'user_id', v_user,
       'claims',  jsonb_build_object(
@@ -344,7 +343,7 @@ $$;
 select ok(
   has_function_privilege(
     'supabase_auth_admin',
-    'public.amux_access_token_hook(jsonb)',
+    'amux.amux_access_token_hook(jsonb)',
     'EXECUTE'
   ),
   'supabase_auth_admin can EXECUTE amux_access_token_hook'
@@ -353,7 +352,7 @@ select ok(
 select ok(
   has_function_privilege(
     'supabase_auth_admin',
-    'public.amux_acl_rules_for(uuid, uuid, text)',
+    'amux.amux_acl_rules_for(uuid, uuid, text)',
     'EXECUTE'
   ),
   'supabase_auth_admin can EXECUTE amux_acl_rules_for'

--- a/services/supabase/tests/006_gateway_external_actor.sql
+++ b/services/supabase/tests/006_gateway_external_actor.sql
@@ -3,7 +3,7 @@ begin;
 select plan(6);
 
 -- Seed: need at least one team row for the actor inserts below.
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
 values ('00000000-0000-0000-0001-000000000001', 'gw-test-team', 'Gateway Test Team');
 
 -- Column shape
@@ -13,7 +13,7 @@ select has_column('public', 'sessions', 'binding',   'sessions has binding colum
 
 -- actor_type now allows external
 select lives_ok($$
-  insert into public.actors (team_id, actor_type, display_name, source, source_id)
+  insert into amux.actors (team_id, actor_type, display_name, source, source_id)
   values (
     '00000000-0000-0000-0001-000000000001',
     'external', 'Bob (WeCom)', 'wecom', 'wecom-user:c1:bob'
@@ -22,13 +22,13 @@ $$, 'can insert external actor with source');
 
 -- external without source is rejected
 select throws_ok($$
-  insert into public.actors (team_id, actor_type, display_name)
+  insert into amux.actors (team_id, actor_type, display_name)
   values ('00000000-0000-0000-0001-000000000001', 'external', 'Nope')
 $$, '23514', null, 'external actor requires source/source_id');
 
 -- (team, source, source_id) is unique
 select throws_ok($$
-  insert into public.actors (team_id, actor_type, display_name, source, source_id)
+  insert into amux.actors (team_id, actor_type, display_name, source, source_id)
   values (
     '00000000-0000-0000-0001-000000000001',
     'external', 'Bob clone', 'wecom', 'wecom-user:c1:bob'

--- a/services/supabase/tests/007_team_workspace_config.sql
+++ b/services/supabase/tests/007_team_workspace_config.sql
@@ -30,18 +30,18 @@ insert into auth.users (id, email, aud, role, instance_id) values
 on conflict do nothing;
 
 select pg_temp.as_user('a1111111-1111-1111-1111-111111111111');
-select * from public.create_team('WC Team');
+select * from amux.create_team('WC Team', p_oid => null);
 
 create temp table ctx as
-  select (select id from public.teams where slug = 'wc-team') as team_id;
+  select (select id from amux.teams where slug = 'wc-team') as team_id;
 
-insert into public.actors (id, team_id, actor_type, display_name)
+insert into amux.actors (id, team_id, actor_type, display_name)
 values ('b2222222-0000-0000-0000-000000000000', (select team_id from ctx), 'member', 'Bob');
 
-insert into public.members (id, user_id, status)
+insert into amux.members (id, user_id, status)
 values ('b2222222-0000-0000-0000-000000000000', 'b2222222-2222-2222-2222-222222222222', 'active');
 
-insert into public.team_members (id, team_id, member_id, role)
+insert into amux.team_members (id, team_id, member_id, role)
 values (
   'b2222222-0000-0000-0000-000000000001',
   (select team_id from ctx),
@@ -64,7 +64,7 @@ select has_column('public', 'team_workspace_config', 'last_sync_error', 'has las
 
 -- 10. Owner can write own team_workspace_config (the create_team RPC seeds an
 -- empty row at team creation; the owner fills it in via UPDATE).
-update public.team_workspace_config
+update amux.team_workspace_config
    set git_url             = 'https://github.com/x/y.git',
        git_branch          = 'main',
        git_token           = 'ghp_abc',
@@ -74,7 +74,7 @@ select pass('owner can update own team_workspace_config');
 
 -- 11. Member can read
 select results_eq(
-  $$ select git_url from public.team_workspace_config where team_id = (select team_id from ctx) $$,
+  $$ select git_url from amux.team_workspace_config where team_id = (select team_id from ctx) $$,
   $$ values ('https://github.com/x/y.git'::text) $$,
   'owner reads own row'
 );
@@ -82,7 +82,7 @@ select results_eq(
 -- 12. Anon cannot read
 select pg_temp.as_anon();
 select throws_ok(
-  $$ select 1 from public.team_workspace_config where team_id = (select team_id from ctx) $$,
+  $$ select 1 from amux.team_workspace_config where team_id = (select team_id from ctx) $$,
   '42501',
   null,
   'anon cannot read'
@@ -91,7 +91,7 @@ select throws_ok(
 -- 13. Non-owner team member can read
 select pg_temp.as_user('b2222222-2222-2222-2222-222222222222');
 select results_eq(
-  $$ select git_url from public.team_workspace_config where team_id = (select team_id from ctx) $$,
+  $$ select git_url from amux.team_workspace_config where team_id = (select team_id from ctx) $$,
   $$ values ('https://github.com/x/y.git'::text) $$,
   'non-owner team member reads own team row'
 );
@@ -99,7 +99,7 @@ select results_eq(
 -- 14. Shared directory name rejects path traversal
 select pg_temp.as_user('a1111111-1111-1111-1111-111111111111');
 select throws_ok(
-  $$ update public.team_workspace_config set shared_dir_name = '../bad' where team_id = (select team_id from ctx) $$,
+  $$ update amux.team_workspace_config set shared_dir_name = '../bad' where team_id = (select team_id from ctx) $$,
   '23514',
   null,
   'shared_dir_name rejects path traversal'
@@ -108,17 +108,17 @@ select throws_ok(
 -- 15. Stranger cannot read
 select pg_temp.as_user('c3333333-3333-3333-3333-333333333333');
 select is_empty(
-  $$ select 1 from public.team_workspace_config where team_id = (select team_id from ctx) $$,
+  $$ select 1 from amux.team_workspace_config where team_id = (select team_id from ctx) $$,
   'stranger cannot read'
 );
 
 -- 16. Stranger UPDATE is silently filtered (RLS USING returns no row), so
 -- the owner's row is unchanged.
-update public.team_workspace_config set git_url = 'https://stolen.example'
+update amux.team_workspace_config set git_url = 'https://stolen.example'
   where team_id = (select team_id from ctx);
 select pg_temp.as_user('a1111111-1111-1111-1111-111111111111');
 select results_eq(
-  $$ select git_url from public.team_workspace_config where team_id = (select team_id from ctx) $$,
+  $$ select git_url from amux.team_workspace_config where team_id = (select team_id from ctx) $$,
   $$ values ('https://github.com/x/y.git'::text) $$,
   'stranger UPDATE silently filtered (RLS)'
 );
@@ -127,24 +127,24 @@ select pg_temp.as_user('c3333333-3333-3333-3333-333333333333');
 -- 17. enabled defaults true (after switching back to alice)
 select pg_temp.as_user('a1111111-1111-1111-1111-111111111111');
 select results_eq(
-  $$ select enabled from public.team_workspace_config where team_id = (select team_id from ctx) $$,
+  $$ select enabled from amux.team_workspace_config where team_id = (select team_id from ctx) $$,
   $$ values (true) $$,
   'enabled defaults true'
 );
 
 -- 18. Stranger cannot delete (no rows affected, row still exists)
 select pg_temp.as_user('c3333333-3333-3333-3333-333333333333');
-delete from public.team_workspace_config where team_id = (select team_id from ctx);
+delete from amux.team_workspace_config where team_id = (select team_id from ctx);
 select pg_temp.as_user('a1111111-1111-1111-1111-111111111111');
 select isnt_empty(
-  $$ select 1 from public.team_workspace_config where team_id = (select team_id from ctx) $$,
+  $$ select 1 from amux.team_workspace_config where team_id = (select team_id from ctx) $$,
   'stranger cannot delete'
 );
 
 -- 19. Owner can delete their own row
-delete from public.team_workspace_config where team_id = (select team_id from ctx);
+delete from amux.team_workspace_config where team_id = (select team_id from ctx);
 select is_empty(
-  $$ select 1 from public.team_workspace_config where team_id = (select team_id from ctx) $$,
+  $$ select 1 from amux.team_workspace_config where team_id = (select team_id from ctx) $$,
   'owner can delete own row'
 );
 

--- a/services/supabase/tests/008_actor_telemetry.sql
+++ b/services/supabase/tests/008_actor_telemetry.sql
@@ -18,21 +18,21 @@ insert into auth.users (id, email, aud, role, instance_id) values
 on conflict do nothing;
 
 select pg_temp.as_user('c1111111-1111-1111-1111-111111111111');
-select * from public.create_team('Tel Team');
+select * from amux.create_team('Tel Team', p_oid => null);
 
 create temp table ctx as
   select
-    (select id from public.teams where slug = 'tel-team')                                        as team_id,
-    (select id from public.actors where user_id = 'c1111111-1111-1111-1111-111111111111' limit 1) as cara_actor;
+    (select id from amux.teams where slug = 'tel-team')                                        as team_id,
+    (select id from amux.actors where user_id = 'c1111111-1111-1111-1111-111111111111' limit 1) as cara_actor;
 
 -- Bring dave into team via invite
 select pg_temp.as_user('c1111111-1111-1111-1111-111111111111');
 create temp table dave_invite as
-  select * from public.create_team_invite(
+  select * from amux.create_team_invite(
     (select team_id from ctx), 'member', 'Dave', p_team_role => 'member');
 
 select pg_temp.as_user('d2222222-2222-2222-2222-222222222222');
-select public.claim_team_invite((select token from dave_invite));
+select amux.claim_team_invite((select token from dave_invite));
 
 -- 1. actor_message_feedback exists
 select pg_temp.as_user('c1111111-1111-1111-1111-111111111111');
@@ -41,13 +41,13 @@ select has_column('public', 'actor_message_feedback', 'star_rating', 'has star_r
 select has_column('public', 'actor_message_feedback', 'kind', 'has kind');
 
 -- 2. Cara can insert her own feedback
-insert into public.actor_message_feedback (actor_id, team_id, kind, skill)
+insert into amux.actor_message_feedback (actor_id, team_id, kind, skill)
   values ((select cara_actor from ctx), (select team_id from ctx), 'positive', 'editor');
 select pass('actor can insert own feedback');
 
 -- 3. Cara cannot insert under another actor_id
 select throws_ok(
-  $$ insert into public.actor_message_feedback (actor_id, team_id, kind)
+  $$ insert into amux.actor_message_feedback (actor_id, team_id, kind)
      values ('00000000-0000-0000-0000-000000000000', (select team_id from ctx), 'positive') $$,
   '42501',
   null,
@@ -56,7 +56,7 @@ select throws_ok(
 
 -- 4. Cara sees feedback for the team
 select results_eq(
-  $$ select count(*)::int from public.actor_message_feedback where team_id = (select team_id from ctx) $$,
+  $$ select count(*)::int from amux.actor_message_feedback where team_id = (select team_id from ctx) $$,
   $$ values (1) $$,
   'team member sees team feedback'
 );
@@ -64,7 +64,7 @@ select results_eq(
 -- 5. Dave (also in team) sees Cara's feedback
 select pg_temp.as_user('d2222222-2222-2222-2222-222222222222');
 select results_eq(
-  $$ select count(*)::int from public.actor_message_feedback where team_id = (select team_id from ctx) $$,
+  $$ select count(*)::int from amux.actor_message_feedback where team_id = (select team_id from ctx) $$,
   $$ values (1) $$,
   'other team member sees team feedback'
 );
@@ -72,13 +72,13 @@ select results_eq(
 -- 6. Eve (not in team) sees nothing
 select pg_temp.as_user('e3333333-3333-3333-3333-333333333333');
 select is_empty(
-  $$ select 1 from public.actor_message_feedback where team_id = (select team_id from ctx) $$,
+  $$ select 1 from amux.actor_message_feedback where team_id = (select team_id from ctx) $$,
   'stranger sees no feedback'
 );
 
 -- 7. Eve cannot insert
 select throws_ok(
-  $$ insert into public.actor_message_feedback (actor_id, team_id, kind)
+  $$ insert into amux.actor_message_feedback (actor_id, team_id, kind)
      values ((select cara_actor from ctx), (select team_id from ctx), 'positive') $$,
   '42501',
   null,
@@ -90,13 +90,13 @@ select pg_temp.as_user('c1111111-1111-1111-1111-111111111111');
 select has_table('public', 'actor_session_report', 'actor_session_report table exists');
 
 -- 9. Cara can insert her own report
-insert into public.actor_session_report (actor_id, team_id, tokens_used, cost_usd, model)
+insert into amux.actor_session_report (actor_id, team_id, tokens_used, cost_usd, model)
   values ((select cara_actor from ctx), (select team_id from ctx), 1234, 0.05, 'sonnet');
 select pass('actor can insert own session report');
 
 -- 10. Cara cannot insert under another actor
 select throws_ok(
-  $$ insert into public.actor_session_report (actor_id, team_id, tokens_used)
+  $$ insert into amux.actor_session_report (actor_id, team_id, tokens_used)
      values ('00000000-0000-0000-0000-000000000000', (select team_id from ctx), 1) $$,
   '42501',
   null,
@@ -105,7 +105,7 @@ select throws_ok(
 
 -- 11. Cara sees team reports
 select results_eq(
-  $$ select count(*)::int from public.actor_session_report where team_id = (select team_id from ctx) $$,
+  $$ select count(*)::int from amux.actor_session_report where team_id = (select team_id from ctx) $$,
   $$ values (1) $$,
   'team member sees team reports'
 );
@@ -113,7 +113,7 @@ select results_eq(
 -- 12. Dave (in team) sees reports
 select pg_temp.as_user('d2222222-2222-2222-2222-222222222222');
 select results_eq(
-  $$ select count(*)::int from public.actor_session_report where team_id = (select team_id from ctx) $$,
+  $$ select count(*)::int from amux.actor_session_report where team_id = (select team_id from ctx) $$,
   $$ values (1) $$,
   'other team member sees team reports'
 );
@@ -121,13 +121,13 @@ select results_eq(
 -- 13. Eve (stranger) sees nothing
 select pg_temp.as_user('e3333333-3333-3333-3333-333333333333');
 select is_empty(
-  $$ select 1 from public.actor_session_report where team_id = (select team_id from ctx) $$,
+  $$ select 1 from amux.actor_session_report where team_id = (select team_id from ctx) $$,
   'stranger sees no reports'
 );
 
 -- 14. Eve cannot insert
 select throws_ok(
-  $$ insert into public.actor_session_report (actor_id, team_id, tokens_used)
+  $$ insert into amux.actor_session_report (actor_id, team_id, tokens_used)
      values ((select cara_actor from ctx), (select team_id from ctx), 1) $$,
   '42501',
   null,
@@ -140,7 +140,7 @@ select has_view('public', 'team_leaderboard', 'team_leaderboard view exists');
 
 -- 16. Cara sees an aggregated row for herself
 select results_eq(
-  $$ select tokens_used_30d::bigint from public.team_leaderboard
+  $$ select tokens_used_30d::bigint from amux.team_leaderboard
        where team_id = (select team_id from ctx) and actor_id = (select cara_actor from ctx) $$,
   $$ values (1234::bigint) $$,
   'leaderboard aggregates tokens_used for cara'
@@ -149,7 +149,7 @@ select results_eq(
 -- 17. Eve sees nothing
 select pg_temp.as_user('e3333333-3333-3333-3333-333333333333');
 select is_empty(
-  $$ select 1 from public.team_leaderboard where team_id = (select team_id from ctx) $$,
+  $$ select 1 from amux.team_leaderboard where team_id = (select team_id from ctx) $$,
   'stranger sees no leaderboard rows'
 );
 

--- a/services/supabase/tests/009_agent_visibility.sql
+++ b/services/supabase/tests/009_agent_visibility.sql
@@ -25,32 +25,31 @@ values
   ('91000000-0000-0000-0000-000000000003', 'agent-member@teamclu.test', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
 on conflict do nothing;
 
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
 values ('01000000-0000-0000-0000-000000000001', 'agent-visibility', 'Agent Visibility');
 
-insert into public.actors (id, team_id, actor_type, user_id, display_name)
+insert into amux.actors (id, team_id, actor_type, user_id, display_name)
 values
   ('11000000-0000-0000-0000-000000000001', '01000000-0000-0000-0000-000000000001', 'member', '91000000-0000-0000-0000-000000000001', 'Owner'),
   ('11000000-0000-0000-0000-000000000002', '01000000-0000-0000-0000-000000000001', 'member', '91000000-0000-0000-0000-000000000002', 'Team Admin'),
   ('11000000-0000-0000-0000-000000000003', '01000000-0000-0000-0000-000000000001', 'member', '91000000-0000-0000-0000-000000000003', 'Granted Member'),
   ('11000000-0000-0000-0000-0000000000a1', '01000000-0000-0000-0000-000000000001', 'agent', null, 'Personal Agent');
 
-insert into public.members (id, status)
+insert into amux.members (id, status)
 values
   ('11000000-0000-0000-0000-000000000001', 'active'),
   ('11000000-0000-0000-0000-000000000002', 'active'),
   ('11000000-0000-0000-0000-000000000003', 'active');
 
-insert into public.team_members (team_id, member_id, role)
+insert into amux.team_members (team_id, member_id, role)
 values
   ('01000000-0000-0000-0000-000000000001', '11000000-0000-0000-0000-000000000001', 'member'),
   ('01000000-0000-0000-0000-000000000001', '11000000-0000-0000-0000-000000000002', 'admin'),
   ('01000000-0000-0000-0000-000000000001', '11000000-0000-0000-0000-000000000003', 'member');
 
-insert into public.agents (id, owner_member_id, agent_kind, status)
-values ('11000000-0000-0000-0000-0000000000a1', '11000000-0000-0000-0000-000000000001', 'daemon', 'active');
+insert into amux.agents (id, owner_member_id, status) values ('11000000-0000-0000-0000-0000000000a1', '11000000-0000-0000-0000-000000000001', 'active');
 
-insert into public.agent_member_access (agent_id, member_id, permission_level, granted_by_member_id)
+insert into amux.agent_member_access (agent_id, member_id, permission_level, granted_by_member_id)
 values
   ('11000000-0000-0000-0000-0000000000a1', '11000000-0000-0000-0000-000000000001', 'admin', '11000000-0000-0000-0000-000000000001'),
   ('11000000-0000-0000-0000-0000000000a1', '11000000-0000-0000-0000-000000000003', 'prompt', '11000000-0000-0000-0000-000000000001');
@@ -59,19 +58,19 @@ select pg_temp.as_user('91000000-0000-0000-0000-000000000002');
 
 select ok(
   not exists (
-    select 1 from public.actor_directory
+    select 1 from amux.actor_directory
     where id = '11000000-0000-0000-0000-0000000000a1'
   ),
   'personal agent is hidden from team actor_directory'
 );
 
 select ok(
-  not app.can_prompt_agent('11000000-0000-0000-0000-0000000000a1'::uuid),
+  not amux.can_prompt_agent('11000000-0000-0000-0000-0000000000a1'::uuid),
   'team admin without grant cannot prompt personal agent'
 );
 
 select is(
-  public.check_agent_permission(
+  amux.check_agent_permission(
     '11000000-0000-0000-0000-0000000000a1'::uuid,
     '11000000-0000-0000-0000-000000000002'::uuid
   ),
@@ -83,19 +82,19 @@ select pg_temp.as_user('91000000-0000-0000-0000-000000000001');
 
 select ok(
   exists (
-    select 1 from public.actor_directory
+    select 1 from amux.actor_directory
     where id = '11000000-0000-0000-0000-0000000000a1'
   ),
   'owner sees their own personal agent in actor_directory'
 );
 
 select ok(
-  app.can_prompt_agent('11000000-0000-0000-0000-0000000000a1'::uuid),
+  amux.can_prompt_agent('11000000-0000-0000-0000-0000000000a1'::uuid),
   'agent owner can prompt personal agent'
 );
 
 select is(
-  public.check_agent_permission(
+  amux.check_agent_permission(
     '11000000-0000-0000-0000-0000000000a1'::uuid,
     '11000000-0000-0000-0000-000000000001'::uuid
   ),
@@ -104,18 +103,18 @@ select is(
 );
 
 select lives_ok(
-  $$ select public.share_agent_to_team('11000000-0000-0000-0000-0000000000a1'::uuid) $$,
+  $$ select amux.share_agent_to_team('11000000-0000-0000-0000-0000000000a1'::uuid) $$,
   'owner can share personal agent to team'
 );
 
 select is(
-  (select visibility from public.agents where id = '11000000-0000-0000-0000-0000000000a1'),
+  (select visibility from amux.agents where id = '11000000-0000-0000-0000-0000000000a1'),
   'team',
   'share_agent_to_team flips visibility only'
 );
 
 select is(
-  (select owner_member_id from public.agents where id = '11000000-0000-0000-0000-0000000000a1'),
+  (select owner_member_id from amux.agents where id = '11000000-0000-0000-0000-0000000000a1'),
   '11000000-0000-0000-0000-000000000001'::uuid,
   'share_agent_to_team preserves agent owner'
 );
@@ -124,46 +123,46 @@ select pg_temp.as_user('91000000-0000-0000-0000-000000000002');
 
 select ok(
   exists (
-    select 1 from public.actor_directory
+    select 1 from amux.actor_directory
     where id = '11000000-0000-0000-0000-0000000000a1'
   ),
   'team agent appears in actor_directory'
 );
 
 select throws_ok(
-  $$ select public.make_agent_personal('11000000-0000-0000-0000-0000000000a1'::uuid) $$,
+  $$ select amux.make_agent_personal('11000000-0000-0000-0000-0000000000a1'::uuid) $$,
   '42501',
   'only agent owner can make agent personal'
 );
 
 select ok(
-  not app.can_prompt_agent('11000000-0000-0000-0000-0000000000a1'::uuid),
+  not amux.can_prompt_agent('11000000-0000-0000-0000-0000000000a1'::uuid),
   'team admin still cannot prompt team-visible agent without grant'
 );
 
 select pg_temp.as_user('91000000-0000-0000-0000-000000000003');
 
 select ok(
-  app.can_prompt_agent('11000000-0000-0000-0000-0000000000a1'::uuid),
+  amux.can_prompt_agent('11000000-0000-0000-0000-0000000000a1'::uuid),
   'explicit prompt grant allows team member to prompt team agent'
 );
 
 select pg_temp.as_user('91000000-0000-0000-0000-000000000001');
 
 select lives_ok(
-  $$ select public.make_agent_personal('11000000-0000-0000-0000-0000000000a1'::uuid) $$,
+  $$ select amux.make_agent_personal('11000000-0000-0000-0000-0000000000a1'::uuid) $$,
   'owner can make team agent personal'
 );
 
 select is(
-  (select visibility from public.agents where id = '11000000-0000-0000-0000-0000000000a1'),
+  (select visibility from amux.agents where id = '11000000-0000-0000-0000-0000000000a1'),
   'personal',
   'make_agent_personal flips visibility to personal'
 );
 
 select ok(
   not exists (
-    select 1 from public.agent_member_access
+    select 1 from amux.agent_member_access
     where agent_id = '11000000-0000-0000-0000-0000000000a1'
       and member_id <> '11000000-0000-0000-0000-000000000001'
   ),
@@ -171,7 +170,7 @@ select ok(
 );
 
 select is(
-  (select permission_level from public.agent_member_access
+  (select permission_level from amux.agent_member_access
    where agent_id = '11000000-0000-0000-0000-0000000000a1'
      and member_id = '11000000-0000-0000-0000-000000000001'),
   'admin',

--- a/services/supabase/tests/011_gateway_session_rpc.sql
+++ b/services/supabase/tests/011_gateway_session_rpc.sql
@@ -2,47 +2,49 @@ begin;
 
 select plan(12);
 
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
 values ('00000000-0000-0000-0011-000000000001', 'gw-session-team', 'Gateway Session Team');
 
-insert into public.actors (id, team_id, actor_type, display_name)
+insert into amux.actors (id, team_id, actor_type, display_name)
 values
   ('00000000-0000-0000-0011-000000000010', '00000000-0000-0000-0011-000000000001', 'agent', 'Gateway Agent'),
   ('00000000-0000-0000-0011-000000000020', '00000000-0000-0000-0011-000000000001', 'member', 'Owner Member');
 
-insert into public.agents (id, agent_kind, capabilities, status)
-values ('00000000-0000-0000-0011-000000000010', 'gateway', '{}'::jsonb, 'active');
-
-insert into public.members (id, status)
+insert into amux.members (id, status)
 values ('00000000-0000-0000-0011-000000000020', 'active');
 
-insert into public.actors (id, team_id, actor_type, source, source_id, display_name)
+-- agents.owner_member_id is NOT NULL and references members, so an owning
+-- member has to exist first.
+insert into amux.agents (id, owner_member_id, capabilities, status)
+values ('00000000-0000-0000-0011-000000000010', '00000000-0000-0000-0011-000000000020', '{}'::jsonb, 'active');
+
+insert into amux.actors (id, team_id, actor_type, source, source_id, display_name)
 values ('00000000-0000-0000-0011-000000000030', '00000000-0000-0000-0011-000000000001', 'external', 'wecom', 'LiangLiang', 'LiangLiang');
 
 select ok(
-  not has_function_privilege('anon', 'public.upsert_external_actor(uuid, text, text, text)', 'EXECUTE'),
+  not has_function_privilege('anon', 'amux.upsert_external_actor(uuid, text, text, text)', 'EXECUTE'),
   'anon cannot execute upsert_external_actor'
 );
 
 select ok(
-  has_function_privilege('authenticated', 'public.upsert_external_actor(uuid, text, text, text)', 'EXECUTE'),
+  has_function_privilege('authenticated', 'amux.upsert_external_actor(uuid, text, text, text)', 'EXECUTE'),
   'authenticated can execute upsert_external_actor'
 );
 
 select ok(
-  not has_function_privilege('anon', 'public.ensure_gateway_session(uuid, text, text, uuid, uuid[], uuid[])', 'EXECUTE'),
+  not has_function_privilege('anon', 'amux.ensure_gateway_session(uuid, text, text, uuid, uuid[], uuid[])', 'EXECUTE'),
   'anon cannot execute ensure_gateway_session'
 );
 
 select ok(
-  has_function_privilege('authenticated', 'public.ensure_gateway_session(uuid, text, text, uuid, uuid[], uuid[])', 'EXECUTE'),
+  has_function_privilege('authenticated', 'amux.ensure_gateway_session(uuid, text, text, uuid, uuid[], uuid[])', 'EXECUTE'),
   'authenticated can execute ensure_gateway_session'
 );
 
 select lives_ok($$
   create temporary table gateway_session_result as
   select *
-    from public.ensure_gateway_session(
+    from amux.ensure_gateway_session(
       '00000000-0000-0000-0011-000000000001',
       'wecom://aibot/aibfzYpdwyoj_3z9s4ZpVEFAv2IqAwVjNZH/single/LiangLiang',
       'WeCom - LiangLiang',
@@ -57,14 +59,14 @@ select ok((select session_id is not null from gateway_session_result), 'returns 
 select ok((select acp_session_id is not null from gateway_session_result), 'returns acp_session_id');
 select is((select created from gateway_session_result), true, 'first call reports created');
 select is(
-  (select count(*) from public.session_participants where session_id = (select session_id from gateway_session_result)),
+  (select count(*) from amux.session_participants where session_id = (select session_id from gateway_session_result)),
   3::bigint,
   'snapshots agent, owner, and external participant'
 );
 
 create temporary table gateway_session_result_2 as
 select *
-  from public.ensure_gateway_session(
+  from amux.ensure_gateway_session(
     '00000000-0000-0000-0011-000000000001',
     'wecom://aibot/aibfzYpdwyoj_3z9s4ZpVEFAv2IqAwVjNZH/single/LiangLiang',
     'WeCom - LiangLiang',

--- a/services/supabase/tests/012_gateway_message_external_id_upsert.sql
+++ b/services/supabase/tests/012_gateway_message_external_id_upsert.sql
@@ -2,18 +2,17 @@ begin;
 
 select plan(5);
 
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
 values ('00000000-0000-0000-0012-000000000001', 'gw-message-team', 'Gateway Message Team');
 
-insert into public.actors (id, team_id, actor_type, display_name)
+insert into amux.actors (id, team_id, actor_type, display_name)
 values
   ('00000000-0000-0000-0012-000000000010', '00000000-0000-0000-0012-000000000001', 'agent', 'Gateway Agent'),
   ('00000000-0000-0000-0012-000000000020', '00000000-0000-0000-0012-000000000001', 'external', 'LiangLiang');
 
-insert into public.agents (id, agent_kind, capabilities, status)
-values ('00000000-0000-0000-0012-000000000010', 'gateway', '{}'::jsonb, 'active');
+insert into amux.agents (id, capabilities, status) values ('00000000-0000-0000-0012-000000000010', '{}'::jsonb, 'active');
 
-insert into public.sessions (
+insert into amux.sessions (
   id,
   team_id,
   idea_id,
@@ -37,7 +36,7 @@ values (
 );
 
 select lives_ok($$
-  insert into public.messages (
+  insert into amux.messages (
     team_id,
     session_id,
     sender_actor_id,
@@ -58,7 +57,7 @@ select lives_ok($$
 $$, 'gateway message upsert conflict target matches a unique index');
 
 select lives_ok($$
-  insert into public.messages (
+  insert into amux.messages (
     team_id,
     session_id,
     sender_actor_id,
@@ -81,7 +80,7 @@ $$, 'gateway duplicate provider message upserts instead of inserting');
 select is(
   (
     select count(*)
-      from public.messages
+      from amux.messages
      where session_id = '00000000-0000-0000-0012-000000000100'
        and external_id = '632043bcec41613ed54589d5a781cb7e'
   ),
@@ -92,7 +91,7 @@ select is(
 select is(
   (
     select content
-      from public.messages
+      from amux.messages
      where session_id = '00000000-0000-0000-0012-000000000100'
        and external_id = '632043bcec41613ed54589d5a781cb7e'
   ),
@@ -101,7 +100,7 @@ select is(
 );
 
 select lives_ok($$
-  insert into public.messages (
+  insert into amux.messages (
     team_id,
     session_id,
     sender_actor_id,

--- a/services/supabase/tests/013_gateway_agent_admin_owner_rpc.sql
+++ b/services/supabase/tests/013_gateway_agent_admin_owner_rpc.sql
@@ -21,47 +21,46 @@ values
   ('00000000-0000-0000-0013-000000000003', 'gateway-other@teamclu.test', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
 on conflict do nothing;
 
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
 values ('00000000-0000-0000-0013-000000000010', 'gw-owner-rpc', 'Gateway Owner RPC');
 
-insert into public.actors (id, team_id, actor_type, user_id, display_name)
+insert into amux.actors (id, team_id, actor_type, user_id, display_name)
 values
   ('00000000-0000-0000-0013-000000000020', '00000000-0000-0000-0013-000000000010', 'agent', '00000000-0000-0000-0013-000000000001', 'Gateway Agent'),
   ('00000000-0000-0000-0013-000000000030', '00000000-0000-0000-0013-000000000010', 'member', '00000000-0000-0000-0013-000000000002', 'Owner Member'),
   ('00000000-0000-0000-0013-000000000040', '00000000-0000-0000-0013-000000000010', 'member', '00000000-0000-0000-0013-000000000003', 'Other Member');
 
-insert into public.members (id, status)
+insert into amux.members (id, status)
 values
   ('00000000-0000-0000-0013-000000000030', 'active'),
   ('00000000-0000-0000-0013-000000000040', 'active');
 
-insert into public.team_members (team_id, member_id, role)
+insert into amux.team_members (team_id, member_id, role)
 values
   ('00000000-0000-0000-0013-000000000010', '00000000-0000-0000-0013-000000000030', 'member'),
   ('00000000-0000-0000-0013-000000000010', '00000000-0000-0000-0013-000000000040', 'member');
 
-insert into public.agents (id, owner_member_id, agent_kind, status)
-values ('00000000-0000-0000-0013-000000000020', '00000000-0000-0000-0013-000000000030', 'gateway', 'active');
+insert into amux.agents (id, owner_member_id, status) values ('00000000-0000-0000-0013-000000000020', '00000000-0000-0000-0013-000000000030', 'active');
 
-insert into public.agent_member_access (agent_id, member_id, permission_level, granted_by_member_id)
+insert into amux.agent_member_access (agent_id, member_id, permission_level, granted_by_member_id)
 values
   ('00000000-0000-0000-0013-000000000020', '00000000-0000-0000-0013-000000000030', 'admin', '00000000-0000-0000-0013-000000000030'),
   ('00000000-0000-0000-0013-000000000020', '00000000-0000-0000-0013-000000000040', 'prompt', '00000000-0000-0000-0013-000000000030');
 
 select ok(
-  not has_function_privilege('anon', 'public.list_agent_admin_member_actor_ids(uuid)', 'EXECUTE'),
+  not has_function_privilege('anon', 'amux.list_agent_admin_member_actor_ids(uuid)', 'EXECUTE'),
   'anon cannot execute gateway owner resolver'
 );
 
 select ok(
-  has_function_privilege('authenticated', 'public.list_agent_admin_member_actor_ids(uuid)', 'EXECUTE'),
+  has_function_privilege('authenticated', 'amux.list_agent_admin_member_actor_ids(uuid)', 'EXECUTE'),
   'authenticated can execute gateway owner resolver'
 );
 
 select pg_temp.as_user('00000000-0000-0000-0013-000000000001');
 
 select results_eq(
-  $$ select member_actor_id from public.list_agent_admin_member_actor_ids('00000000-0000-0000-0013-000000000020') $$,
+  $$ select member_actor_id from amux.list_agent_admin_member_actor_ids('00000000-0000-0000-0013-000000000020') $$,
   $$ values ('00000000-0000-0000-0013-000000000030'::uuid) $$,
   'agent actor can resolve its admin member owner'
 );
@@ -69,7 +68,7 @@ select results_eq(
 select pg_temp.as_user('00000000-0000-0000-0013-000000000002');
 
 select results_eq(
-  $$ select member_actor_id from public.list_agent_admin_member_actor_ids('00000000-0000-0000-0013-000000000020') $$,
+  $$ select member_actor_id from amux.list_agent_admin_member_actor_ids('00000000-0000-0000-0013-000000000020') $$,
   $$ values ('00000000-0000-0000-0013-000000000030'::uuid) $$,
   'agent owner member can resolve admin owner ids'
 );
@@ -77,7 +76,7 @@ select results_eq(
 select pg_temp.as_user('00000000-0000-0000-0013-000000000003');
 
 select is_empty(
-  $$ select member_actor_id from public.list_agent_admin_member_actor_ids('00000000-0000-0000-0013-000000000020') $$,
+  $$ select member_actor_id from amux.list_agent_admin_member_actor_ids('00000000-0000-0000-0013-000000000020') $$,
   'unrelated member cannot resolve agent owner ids'
 );
 
@@ -85,19 +84,19 @@ select pg_temp.as_user('00000000-0000-0000-0013-000000000001');
 
 create temporary table gateway_session_result as
 select *
-  from public.ensure_gateway_session(
+  from amux.ensure_gateway_session(
     '00000000-0000-0000-0013-000000000010',
     'wecom://aibot/test/single/LiangLiang',
     'WeCom - LiangLiang',
     '00000000-0000-0000-0013-000000000020',
-    array(select member_actor_id from public.list_agent_admin_member_actor_ids('00000000-0000-0000-0013-000000000020')),
+    array(select member_actor_id from amux.list_agent_admin_member_actor_ids('00000000-0000-0000-0013-000000000020')),
     '{}'::uuid[]
   );
 
 select is(
   (
     select count(*)
-      from public.session_participants
+      from amux.session_participants
      where session_id = (select session_id from gateway_session_result)
        and actor_id = '00000000-0000-0000-0013-000000000030'
   ),
@@ -108,7 +107,7 @@ select is(
 select is(
   (
     select count(*)
-      from public.session_participants
+      from amux.session_participants
      where session_id = (select session_id from gateway_session_result)
        and actor_id = '00000000-0000-0000-0013-000000000040'
   ),

--- a/services/supabase/tests/014_gateway_external_message_rls.sql
+++ b/services/supabase/tests/014_gateway_external_message_rls.sql
@@ -6,19 +6,24 @@ insert into auth.users (id, email, aud, role, instance_id)
 values ('00000000-0000-0000-0014-000000000001', 'gateway-daemon@teamclu.test', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
 on conflict do nothing;
 
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
 values ('00000000-0000-0000-0014-000000000010', 'gw-message-rls', 'Gateway Message RLS');
 
-insert into public.actors (id, team_id, actor_type, user_id, source, source_id, display_name)
+insert into amux.actors (id, team_id, actor_type, user_id, source, source_id, display_name)
 values
   ('00000000-0000-0000-0014-000000000020', '00000000-0000-0000-0014-000000000010', 'agent', '00000000-0000-0000-0014-000000000001', null, null, 'Gateway Agent'),
   ('00000000-0000-0000-0014-000000000030', '00000000-0000-0000-0014-000000000010', 'external', null, 'wecom', 'LiangLiang', 'LiangLiang'),
-  ('00000000-0000-0000-0014-000000000040', '00000000-0000-0000-0014-000000000010', 'external', null, 'wecom', 'OtherUser', 'Other User');
+  ('00000000-0000-0000-0014-000000000040', '00000000-0000-0000-0014-000000000010', 'external', null, 'wecom', 'OtherUser', 'Other User'),
+  ('00000000-0000-0000-0014-000000000050', '00000000-0000-0000-0014-000000000010', 'member', null, null, null, 'Owner Member');
 
-insert into public.agents (id, agent_kind, status)
-values ('00000000-0000-0000-0014-000000000020', 'gateway', 'active');
+insert into amux.members (id, status) values ('00000000-0000-0000-0014-000000000050', 'active');
 
-insert into public.sessions (
+-- agents.owner_member_id is NOT NULL and references members, so an owning
+-- member has to exist first.
+insert into amux.agents (id, owner_member_id, status)
+values ('00000000-0000-0000-0014-000000000020', '00000000-0000-0000-0014-000000000050', 'active');
+
+insert into amux.sessions (
   id,
   team_id,
   idea_id,
@@ -41,18 +46,18 @@ values (
   'acp-gateway-rls-test'
 );
 
-insert into public.session_participants (session_id, actor_id)
+insert into amux.session_participants (session_id, actor_id)
 values
   ('00000000-0000-0000-0014-000000000100', '00000000-0000-0000-0014-000000000020'),
   ('00000000-0000-0000-0014-000000000100', '00000000-0000-0000-0014-000000000030');
 
 select ok(
-  has_function_privilege('authenticated', 'app.daemon_can_write_gateway_message(uuid, uuid, uuid)', 'EXECUTE'),
+  has_function_privilege('authenticated', 'amux.daemon_can_write_gateway_message(uuid, uuid, uuid)', 'EXECUTE'),
   'authenticated can execute gateway message helper'
 );
 
 select ok(
-  not has_function_privilege('anon', 'app.daemon_can_write_gateway_message(uuid, uuid, uuid)', 'EXECUTE'),
+  not has_function_privilege('anon', 'amux.daemon_can_write_gateway_message(uuid, uuid, uuid)', 'EXECUTE'),
   'anon cannot execute gateway message helper'
 );
 
@@ -72,7 +77,7 @@ select set_config(
 set local role authenticated;
 
 select lives_ok($$
-  insert into public.messages (
+  insert into amux.messages (
     team_id,
     session_id,
     sender_actor_id,
@@ -91,7 +96,7 @@ select lives_ok($$
 $$, 'daemon can record message from external session participant');
 
 select throws_ok($$
-  insert into public.messages (
+  insert into amux.messages (
     team_id,
     session_id,
     sender_actor_id,
@@ -124,7 +129,7 @@ select set_config(
 );
 
 select throws_ok($$
-  insert into public.messages (
+  insert into amux.messages (
     team_id,
     session_id,
     sender_actor_id,

--- a/services/supabase/tests/015_rbac_shortcuts.sql
+++ b/services/supabase/tests/015_rbac_shortcuts.sql
@@ -15,17 +15,23 @@ create temp table fx(
   role_sales uuid
 ) on commit drop;
 
+-- Temp tables are owned by the session role; the tests then `set role` to
+-- anon/authenticated, which cannot read them without an explicit grant.
+grant select on fx to anon, authenticated;
+
 create or replace function pg_temp.mk_member(p_team uuid, p_name text, p_role text)
 returns table(member_id uuid, user_id uuid)
 language plpgsql as $$
 declare v_actor uuid := gen_random_uuid(); v_user uuid := gen_random_uuid();
 begin
   insert into auth.users(id, email) values (v_user, p_name || '@test.local');
-  insert into public.actors(id, team_id, actor_type, display_name)
-    values (v_actor, p_team, 'member', p_name);
-  insert into public.members(id, user_id, status)
-    values (v_actor, v_user, 'active');
-  insert into public.team_members(team_id, member_id, role)
+-- user_id lives on actors now: identity is per team, so the link to
+-- auth.users belongs on the per-team row rather than on members.
+  insert into amux.actors(id, team_id, actor_type, display_name, user_id)
+    values (v_actor, p_team, 'member', p_name, v_user);
+  insert into amux.members(id, status)
+    values (v_actor, 'active');
+  insert into amux.team_members(team_id, member_id, role)
     values (p_team, v_actor, p_role);
   return query select v_actor, v_user;
 end $$;
@@ -46,7 +52,7 @@ end $$;
 
 -- Seed
 insert into fx(team_id) values (gen_random_uuid());
-insert into public.teams(id, slug, name)
+insert into amux.teams(id, slug, name)
   select team_id, 'team-' || team_id::text, 'T' from fx;
 
 update fx set (owner_member, owner_user) =
@@ -59,14 +65,14 @@ update fx set (m2_member, m2_user) =
 -- Owner creates the 'sales' role and assigns it to m1.
 select pg_temp.as_user((select owner_user from fx));
 
-insert into public.team_roles(team_id, code, name)
+insert into amux.team_roles(team_id, code, name)
   select team_id, 'sales', 'Sales' from fx;
 update fx set role_sales = (
-  select id from public.team_roles
+  select id from amux.team_roles
   where team_id = fx.team_id and code = 'sales'
 );
 
-insert into public.team_member_roles(team_id, member_id, role_id)
+insert into amux.team_member_roles(team_id, member_id, role_id)
   select team_id, m1_member, role_sales from fx;
 
 -- ── 1) Schema-level ─────────────────────────────────────────────────────
@@ -79,7 +85,7 @@ select has_table('public','shortcuts',          'shortcuts exists');
 -- 2) XOR constraint: personal with no owner_member_id is rejected
 select pg_temp.as_service();
 select throws_ok(
-  $$ insert into public.shortcuts(scope, label, node_type) values ('personal','x','link') $$,
+  $$ insert into amux.shortcuts(scope, label, node_type) values ('personal','x','link') $$,
   '23514',
   null,
   'XOR rejects personal shortcut with no owner_member_id'
@@ -87,7 +93,7 @@ select throws_ok(
 
 -- 3) XOR constraint: team with both owner_member_id and team_id is rejected
 select throws_ok(
-  $$ insert into public.shortcuts(scope, owner_member_id, team_id, label, node_type)
+  $$ insert into amux.shortcuts(scope, owner_member_id, team_id, label, node_type)
      values ('team', gen_random_uuid(), gen_random_uuid(), 'x', 'link') $$,
   '23514',
   null,
@@ -97,15 +103,15 @@ select throws_ok(
 -- ── Helpers exist ───────────────────────────────────────────────────────
 -- 4-6
 select lives_ok(
-  $$ select app.is_team_admin_or_owner(gen_random_uuid()) $$,
+  $$ select amux.is_team_admin_or_owner(gen_random_uuid()) $$,
   'helper: is_team_admin_or_owner'
 );
 select lives_ok(
-  $$ select app.member_can_access_permission(gen_random_uuid()) $$,
+  $$ select amux.member_can_access_permission(gen_random_uuid()) $$,
   'helper: member_can_access_permission'
 );
 select lives_ok(
-  $$ select app.member_can_see_shortcut(gen_random_uuid()) $$,
+  $$ select amux.member_can_see_shortcut(gen_random_uuid()) $$,
   'helper: member_can_see_shortcut'
 );
 
@@ -113,13 +119,13 @@ select lives_ok(
 select pg_temp.as_user((select m1_user from fx));
 
 select lives_ok(
-  $$ select public.shortcut_create('personal', 'My Link', 'link', null, null, null, 0, 'https://example.com') $$,
+  $$ select amux.shortcut_create('personal', 'My Link', 'link', null, null, null, 0, 'https://example.com') $$,
   'rpc: shortcut_create personal succeeds for any member'
 );  -- 7
 
 -- ── RPC: shortcut_create team forbidden for non-admin ───────────────────
 select throws_ok(
-  $$ select public.shortcut_create('team', 'Team Link', 'link',
+  $$ select amux.shortcut_create('team', 'Team Link', 'link',
        (select team_id from fx), null, null, 0, 'https://example.com') $$,
   null,
   'forbidden',
@@ -130,14 +136,14 @@ select throws_ok(
 select pg_temp.as_user((select owner_user from fx));
 
 select lives_ok(
-  $$ select public.shortcut_create('team', 'Team Link', 'link',
+  $$ select amux.shortcut_create('team', 'Team Link', 'link',
        (select team_id from fx), null, null, 0, 'https://example.com') $$,
   'rpc: shortcut_create team succeeds for owner'
 );  -- 9
 
 select pg_temp.as_service();
 select is(
-  (select count(*)::int from public.permissions
+  (select count(*)::int from amux.permissions
     where team_id = (select team_id from fx) and resource_type = 'shortcut'),
   1,
   'permissions row inserted for team shortcut'
@@ -147,7 +153,7 @@ select is(
 select pg_temp.as_user((select m2_user from fx));
 
 select is(
-  (select count(*)::int from public.shortcuts
+  (select count(*)::int from amux.shortcuts
     where scope = 'personal'),
   0,
   'm2 cannot see m1''s personal shortcut'
@@ -155,7 +161,7 @@ select is(
 
 select pg_temp.as_user((select m1_user from fx));
 select is(
-  (select count(*)::int from public.shortcuts where scope = 'personal'),
+  (select count(*)::int from amux.shortcuts where scope = 'personal'),
   1,
   'm1 sees own personal shortcut'
 );  -- 12
@@ -163,7 +169,7 @@ select is(
 -- ── RLS: team open default (no permission_roles bindings) ───────────────
 select pg_temp.as_user((select m2_user from fx));
 select is(
-  (select count(*)::int from public.shortcuts where scope = 'team'),
+  (select count(*)::int from amux.shortcuts where scope = 'team'),
   1,
   'm2 (no roles) sees team shortcut under open default'
 );  -- 13
@@ -172,8 +178,8 @@ select is(
 select pg_temp.as_user((select owner_user from fx));
 
 select lives_ok(
-  $$ select public.shortcut_set_visible_roles(
-       (select id from public.shortcuts where scope='team' limit 1),
+  $$ select amux.shortcut_set_visible_roles(
+       (select id from amux.shortcuts where scope='team' limit 1),
        array[(select role_sales from fx)]
      ) $$,
   'rpc: shortcut_set_visible_roles binds sales role'
@@ -182,14 +188,14 @@ select lives_ok(
 -- ── RLS: team restricted — m2 (no sales) cannot see; m1 (sales) can ─────
 select pg_temp.as_user((select m2_user from fx));
 select is(
-  (select count(*)::int from public.shortcuts where scope = 'team'),
+  (select count(*)::int from amux.shortcuts where scope = 'team'),
   0,
   'm2 cannot see team shortcut after sales-only binding'
 );  -- 15
 
 select pg_temp.as_user((select m1_user from fx));
 select is(
-  (select count(*)::int from public.shortcuts where scope = 'team'),
+  (select count(*)::int from amux.shortcuts where scope = 'team'),
   1,
   'm1 (holds sales) can see team shortcut after binding'
 );  -- 16
@@ -198,8 +204,8 @@ select is(
 select pg_temp.as_user((select owner_user from fx));
 
 select lives_ok(
-  $$ select public.shortcut_set_visible_roles(
-       (select id from public.shortcuts where scope='team' limit 1),
+  $$ select amux.shortcut_set_visible_roles(
+       (select id from amux.shortcuts where scope='team' limit 1),
        array[]::uuid[]
      ) $$,
   'rpc: shortcut_set_visible_roles can clear bindings (back to open default)'
@@ -207,11 +213,11 @@ select lives_ok(
 
 select pg_temp.as_service();
 select is(
-  (select count(*)::int from public.permission_roles
+  (select count(*)::int from amux.permission_roles
     where permission_id = (
-      select id from public.permissions
+      select id from amux.permissions
       where resource_type = 'shortcut'
-        and resource_id = (select id from public.shortcuts where scope='team' limit 1)
+        and resource_id = (select id from amux.shortcuts where scope='team' limit 1)
     )),
   0,
   'permission_roles cleared after swap-in with empty array'
@@ -219,12 +225,12 @@ select is(
 
 -- ── Trigger: deleting a team shortcut cleans up its permissions row ─────
 select pg_temp.as_user((select owner_user from fx));
-delete from public.shortcuts
+delete from amux.shortcuts
   where scope = 'team' and team_id = (select team_id from fx);
 
 select pg_temp.as_service();
 select is(
-  (select count(*)::int from public.permissions
+  (select count(*)::int from amux.permissions
     where team_id = (select team_id from fx) and resource_type = 'shortcut'),
   0,
   'cleanup trigger removes permissions row after team shortcut delete'
@@ -234,7 +240,7 @@ select is(
 select pg_temp.as_user((select owner_user from fx));
 
 select lives_ok(
-  $$ select public.team_member_set_roles(
+  $$ select amux.team_member_set_roles(
        (select team_id from fx),
        (select m2_member from fx),
        array[(select role_sales from fx)]
@@ -244,7 +250,7 @@ select lives_ok(
 
 select pg_temp.as_service();
 select is(
-  (select count(*)::int from public.team_member_roles
+  (select count(*)::int from amux.team_member_roles
     where member_id = (select m2_member from fx)),
   1,
   'm2 now has one role binding'
@@ -252,7 +258,7 @@ select is(
 
 -- Swap-in to empty
 select pg_temp.as_user((select owner_user from fx));
-select public.team_member_set_roles(
+select amux.team_member_set_roles(
   (select team_id from fx),
   (select m2_member from fx),
   array[]::uuid[]
@@ -260,7 +266,7 @@ select public.team_member_set_roles(
 
 select pg_temp.as_service();
 select is(
-  (select count(*)::int from public.team_member_roles
+  (select count(*)::int from amux.team_member_roles
     where member_id = (select m2_member from fx)),
   0,
   'team_member_set_roles with empty array clears all bindings'

--- a/services/supabase/tests/016_push_notifications.sql
+++ b/services/supabase/tests/016_push_notifications.sql
@@ -16,27 +16,27 @@ select has_function('public', 'push_idempotency_claim',    array['uuid']);
 -- ── RLS enabled ──────────────────────────────────────────────────────────────
 select ok(
   (select relrowsecurity from pg_catalog.pg_class
-   where oid = 'public.device_push_tokens'::regclass),
+   where oid = 'amux.device_push_tokens'::regclass),
   'RLS enabled on device_push_tokens'
 );
 select ok(
   (select relrowsecurity from pg_catalog.pg_class
-   where oid = 'public.notification_prefs'::regclass),
+   where oid = 'amux.notification_prefs'::regclass),
   'RLS enabled on notification_prefs'
 );
 select ok(
   (select relrowsecurity from pg_catalog.pg_class
-   where oid = 'public.session_mutes'::regclass),
+   where oid = 'amux.session_mutes'::regclass),
   'RLS enabled on session_mutes'
 );
 select ok(
   (select relrowsecurity from pg_catalog.pg_class
-   where oid = 'public.client_presence'::regclass),
+   where oid = 'amux.client_presence'::regclass),
   'RLS enabled on client_presence'
 );
 select ok(
   (select relrowsecurity from pg_catalog.pg_class
-   where oid = 'public.push_idempotency'::regclass),
+   where oid = 'amux.push_idempotency'::regclass),
   'RLS enabled on push_idempotency'
 );
 
@@ -46,16 +46,21 @@ select ok(
 --                  → ideas → sessions → messages
 -- Static UUIDs in the 0016 namespace for easy identification.
 
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
   values ('00000000-0000-0000-0016-000000000001', 'pn-test-team', 'PN Test Team');
 
-insert into public.actors (id, team_id, actor_type, display_name)
-  values ('00000000-0000-0000-0016-000000000010', '00000000-0000-0000-0016-000000000001', 'agent', 'PN Agent');
+insert into amux.actors (id, team_id, actor_type, display_name)
+  values ('00000000-0000-0000-0016-000000000010', '00000000-0000-0000-0016-000000000001', 'agent', 'PN Agent'),
+         ('00000000-0000-0000-0016-000000000020', '00000000-0000-0000-0016-000000000001', 'member', 'PN Owner');
 
-insert into public.agents (id, agent_kind, capabilities, status)
-  values ('00000000-0000-0000-0016-000000000010', 'claude', '{}'::jsonb, 'active');
+insert into amux.members (id, status) values ('00000000-0000-0000-0016-000000000020', 'active');
 
-insert into public.ideas (id, team_id, created_by_actor_id, title, status)
+-- agents.owner_member_id is NOT NULL and references members, so an owning
+-- member has to exist first.
+insert into amux.agents (id, owner_member_id, capabilities, status)
+values ('00000000-0000-0000-0016-000000000010', '00000000-0000-0000-0016-000000000020', '{}'::jsonb, 'active');
+
+insert into amux.ideas (id, team_id, created_by_actor_id, title, status)
   values (
     '00000000-0000-0000-0016-000000000020',
     '00000000-0000-0000-0016-000000000001',
@@ -64,7 +69,7 @@ insert into public.ideas (id, team_id, created_by_actor_id, title, status)
     'open'
   );
 
-insert into public.sessions (id, team_id, idea_id, created_by_actor_id, primary_agent_id, mode, title)
+insert into amux.sessions (id, team_id, idea_id, created_by_actor_id, primary_agent_id, mode, title)
   values (
     '00000000-0000-0000-0016-000000000100',
     '00000000-0000-0000-0016-000000000001',
@@ -75,7 +80,7 @@ insert into public.sessions (id, team_id, idea_id, created_by_actor_id, primary_
     'pn-test-session'
   );
 
-insert into public.messages (id, team_id, session_id, sender_actor_id, kind, content)
+insert into amux.messages (id, team_id, session_id, sender_actor_id, kind, content)
   values (
     '00000000-0000-0000-0016-000000001000',
     '00000000-0000-0000-0016-000000000001',
@@ -87,14 +92,14 @@ insert into public.messages (id, team_id, session_id, sender_actor_id, kind, con
 
 -- ── Idempotency: first claim wins, second returns false ───────────────────────
 select is(
-  (select claimed from public.push_idempotency_claim(
+  (select claimed from amux.push_idempotency_claim(
      '00000000-0000-0000-0016-000000001000'::uuid)),
   true,
   'first claim succeeds'
 );
 
 select is(
-  (select claimed from public.push_idempotency_claim(
+  (select claimed from amux.push_idempotency_claim(
      '00000000-0000-0000-0016-000000001000'::uuid)),
   false,
   'second claim is duplicate'
@@ -102,14 +107,14 @@ select is(
 
 -- ── list_session_push_targets: unknown session/actor → safe defaults ──────────
 select is(
-  public.list_session_push_targets(gen_random_uuid(), gen_random_uuid()) ->> 'sender_display_name',
+  amux.list_session_push_targets(gen_random_uuid(), gen_random_uuid()) ->> 'sender_display_name',
   'Someone',
   'absent sender falls back to "Someone"'
 );
 
 select is(
   jsonb_array_length(
-    public.list_session_push_targets(gen_random_uuid(), gen_random_uuid()) -> 'recipients'
+    amux.list_session_push_targets(gen_random_uuid(), gen_random_uuid()) -> 'recipients'
   ),
   0,
   'no participants → empty recipients array'

--- a/services/supabase/tests/017_idea_create_order.sql
+++ b/services/supabase/tests/017_idea_create_order.sql
@@ -11,14 +11,14 @@ values (
   '00000000-0000-0000-0000-000000000000'
 );
 
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
 values (
   '01700000-0000-0000-0000-000000000001',
   'idea-order-team',
   'Idea Order Team'
 );
 
-insert into public.actors (id, team_id, actor_type, user_id, display_name)
+insert into amux.actors (id, team_id, actor_type, user_id, display_name)
 values (
   '11700000-0000-0000-0000-000000000001',
   '01700000-0000-0000-0000-000000000001',
@@ -27,13 +27,13 @@ values (
   'Idea Order Member'
 );
 
-insert into public.members (id, status)
+insert into amux.members (id, status)
 values (
   '11700000-0000-0000-0000-000000000001',
   'active'
 );
 
-insert into public.team_members (id, team_id, member_id, role)
+insert into amux.team_members (id, team_id, member_id, role)
 values (
   '21700000-0000-0000-0000-000000000001',
   '01700000-0000-0000-0000-000000000001',
@@ -57,14 +57,14 @@ select set_config(
 
 create temporary table created_ideas as
 select *
-from public.create_idea(
+from amux.create_idea(
   '01700000-0000-0000-0000-000000000001',
   'First idea'
 );
 
 insert into created_ideas
 select *
-from public.create_idea(
+from amux.create_idea(
   '01700000-0000-0000-0000-000000000001',
   'Second idea'
 );
@@ -86,7 +86,7 @@ select is(
 select is(
   array(
     select title
-    from public.ideas
+    from amux.ideas
     where team_id = '01700000-0000-0000-0000-000000000001'
       and archived = false
     order by sort_order asc, updated_at desc

--- a/services/supabase/tests/018_idea_activity_attachment_urls.sql
+++ b/services/supabase/tests/018_idea_activity_attachment_urls.sql
@@ -15,14 +15,14 @@ values (
   '00000000-0000-0000-0000-000000000000'
 );
 
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
 values (
   '01800000-0000-0000-0000-000000000001',
   'idea-activity-attachments-team',
   'Idea Activity Attachments Team'
 );
 
-insert into public.actors (id, team_id, actor_type, user_id, display_name)
+insert into amux.actors (id, team_id, actor_type, user_id, display_name)
 values (
   '11800000-0000-0000-0000-000000000001',
   '01800000-0000-0000-0000-000000000001',
@@ -31,13 +31,13 @@ values (
   'Idea Activity Attachments Member'
 );
 
-insert into public.members (id, status)
+insert into amux.members (id, status)
 values (
   '11800000-0000-0000-0000-000000000001',
   'active'
 );
 
-insert into public.team_members (id, team_id, member_id, role)
+insert into amux.team_members (id, team_id, member_id, role)
 values (
   '21800000-0000-0000-0000-000000000001',
   '01800000-0000-0000-0000-000000000001',
@@ -61,14 +61,14 @@ select set_config(
 
 create temporary table created_idea as
 select *
-from public.create_idea(
+from amux.create_idea(
   '01800000-0000-0000-0000-000000000001',
   'Image attachment idea'
 );
 
 create temporary table created_activity as
 select *
-from public.create_idea_activity(
+from amux.create_idea_activity(
   (select id from created_idea),
   'progress',
   'Attached screenshots.',

--- a/services/supabase/tests/019_idea_attachment_storage_rls.sql
+++ b/services/supabase/tests/019_idea_attachment_storage_rls.sql
@@ -20,12 +20,12 @@ values
    'idea-rls-outsider@example.com','authenticated', 'authenticated',
    '00000000-0000-0000-0000-000000000000');
 
-insert into public.teams (id, slug, name)
+insert into amux.teams (id, slug, name)
 values
   ('01900000-0000-0000-0000-000000000001', 'idea-rls-team-a', 'Idea RLS Team A'),
   ('01900000-0000-0000-0000-000000000002', 'idea-rls-team-b', 'Idea RLS Team B');
 
-insert into public.actors (id, team_id, actor_type, user_id, display_name)
+insert into amux.actors (id, team_id, actor_type, user_id, display_name)
 values
   ('11900000-0000-0000-0000-000000000001',
    '01900000-0000-0000-0000-000000000001', 'member',
@@ -34,12 +34,12 @@ values
    '01900000-0000-0000-0000-000000000002', 'member',
    '91900000-0000-0000-0000-000000000002', 'Team B Member');
 
-insert into public.members (id, status)
+insert into amux.members (id, status)
 values
   ('11900000-0000-0000-0000-000000000001', 'active'),
   ('11900000-0000-0000-0000-000000000002', 'active');
 
-insert into public.team_members (id, team_id, member_id, role)
+insert into amux.team_members (id, team_id, member_id, role)
 values
   ('21900000-0000-0000-0000-000000000001',
    '01900000-0000-0000-0000-000000000001',

--- a/services/supabase/tests/020_oss_sync_schema.sql
+++ b/services/supabase/tests/020_oss_sync_schema.sql
@@ -45,33 +45,33 @@ insert into auth.users (id, email, aud, role, instance_id) values
 on conflict do nothing;
 
 select pg_temp.as_user('a1111111-1111-1111-1111-111111111111');
-select * from public.create_team('OSS Team');
+select * from amux.create_team('OSS Team', p_oid => null);
 
 create temp table ctx as
-  select (select id from public.teams where slug = 'oss-team') as team_id,
+  select (select id from amux.teams where slug = 'oss-team') as team_id,
          'a1111111-1111-1111-1111-111111111111'::uuid           as alice,
          'b2222222-2222-2222-2222-222222222222'::uuid           as bob,
          'c3333333-3333-3333-3333-333333333333'::uuid           as cara;
 
--- Bob joins alice's team as a regular member. RLS on public.actors only lets
+-- Bob joins alice's team as a regular member. RLS on amux.actors only lets
 -- a user insert their own row, so seed Bob as the table owner with RLS off.
 -- Use raw role/RLS toggle (not as_service_role) because temp tables created
 -- by the postgres login can't be read after `set role service_role`.
 set local role postgres;
 set local row_security = off;
 
-insert into public.actors (id, team_id, actor_type, display_name, user_id)
+insert into amux.actors (id, team_id, actor_type, display_name, user_id)
   values ('b2222222-0000-0000-0000-000000000000',
-          (select id from public.teams where slug = 'oss-team'),
+          (select id from amux.teams where slug = 'oss-team'),
           'member', 'Bob',
           'b2222222-2222-2222-2222-222222222222');
 
-insert into public.members (id, status)
+insert into amux.members (id, status)
   values ('b2222222-0000-0000-0000-000000000000', 'active');
 
-insert into public.team_members (id, team_id, member_id, role)
+insert into amux.team_members (id, team_id, member_id, role)
   values ('b2222222-0000-0000-0000-000000000001',
-          (select id from public.teams where slug = 'oss-team'),
+          (select id from amux.teams where slug = 'oss-team'),
           'b2222222-0000-0000-0000-000000000000',
           'member');
 
@@ -95,9 +95,9 @@ select has_column('public', 'team_workspace_config', 'litellm_team_id',
 -- to exercise the INSERT path against the sync_mode check constraint.
 set local role postgres;
 set local row_security = off;
-delete from public.team_workspace_config where team_id = (select team_id from ctx);
+delete from amux.team_workspace_config where team_id = (select team_id from ctx);
 prepare bad_sync_mode as
-  insert into public.team_workspace_config (team_id, sync_mode)
+  insert into amux.team_workspace_config (team_id, sync_mode)
   values ((select team_id from ctx), 'lolwhat');
 select throws_ok(
   'execute bad_sync_mode',
@@ -125,14 +125,14 @@ set local row_security = off;
 do $$
 declare v_team uuid;
 begin
-  insert into public.teams (slug, name) values ('blob-cascade', 'Blob Cascade')
+  insert into amux.teams (slug, name) values ('blob-cascade', 'Blob Cascade')
     returning id into v_team;
-  insert into public.amuxc_blobs (team_id, content_hash, oss_key, size)
+  insert into amux.amuxc_blobs (team_id, content_hash, oss_key, size)
     values (v_team, 'deadbeef', 'teams/x/blobs/sha256/de/ad/beef', 42);
-  delete from public.teams where id = v_team;
+  delete from amux.teams where id = v_team;
 end $$;
 select is_empty(
-  'select 1 from public.amuxc_blobs where content_hash = ''deadbeef''',
+  'select 1 from amux.amuxc_blobs where content_hash = ''deadbeef''',
   'amuxc_blobs cascades on team delete');
 select pg_temp.as_user((select alice from ctx));
 
@@ -160,22 +160,22 @@ create temp table _files_uniq_result (got_unique_violation boolean) on commit dr
 do $$
 declare v_team uuid; v_actor uuid; v_file uuid; v_err text;
 begin
-  insert into public.teams (slug, name) values ('files-uniq', 'Files Uniq')
+  insert into amux.teams (slug, name) values ('files-uniq', 'Files Uniq')
     returning id into v_team;
-  insert into public.actors (team_id, actor_type, display_name, user_id)
+  insert into amux.actors (team_id, actor_type, display_name, user_id)
     values (v_team, 'member', 'X', 'a1111111-1111-1111-1111-111111111111')
     returning id into v_actor;
-  insert into public.amuxc_files (team_id, path, deleted, updated_by)
+  insert into amux.amuxc_files (team_id, path, deleted, updated_by)
     values (v_team, 'skills/x.md', true, v_actor) returning id into v_file;
   begin
-    insert into public.amuxc_files (team_id, path, deleted, updated_by)
+    insert into amux.amuxc_files (team_id, path, deleted, updated_by)
       values (v_team, 'skills/x.md', false, v_actor);
     v_err := 'no-error';
   exception when unique_violation then
     v_err := 'unique_violation';
   end;
   insert into _files_uniq_result values (v_err = 'unique_violation');
-  delete from public.teams where id = v_team;
+  delete from amux.teams where id = v_team;
 end $$;
 select ok((select got_unique_violation from _files_uniq_result),
           'amuxc_files rejects duplicate (team_id, path) even when soft-deleted');
@@ -196,23 +196,23 @@ set local row_security = off;
 do $$
 declare v_team uuid; v_actor uuid; v_file uuid;
 begin
-  insert into public.teams (slug, name) values ('ver-cascade', 'Ver Cascade')
+  insert into amux.teams (slug, name) values ('ver-cascade', 'Ver Cascade')
     returning id into v_team;
-  insert into public.actors (team_id, actor_type, display_name, user_id)
+  insert into amux.actors (team_id, actor_type, display_name, user_id)
     values (v_team, 'member', 'X', 'a1111111-1111-1111-1111-111111111111')
     returning id into v_actor;
-  insert into public.amuxc_files (team_id, path, updated_by)
+  insert into amux.amuxc_files (team_id, path, updated_by)
     values (v_team, 'skills/v.md', v_actor) returning id into v_file;
-  insert into public.amuxc_file_versions
+  insert into amux.amuxc_file_versions
     (file_id, version, parent_version, content_hash, size, created_by)
     values (v_file, 1, 0, 'abc', 10, v_actor);
   -- Delete amuxc_files first (cascades to amuxc_file_versions), then team.
   -- Direct team delete would hit restrict FK from amuxc_file_versions.created_by → actors.
-  delete from public.amuxc_files where id = v_file;
-  delete from public.teams where id = v_team;
+  delete from amux.amuxc_files where id = v_file;
+  delete from amux.teams where id = v_team;
 end $$;
 select is_empty(
-  'select 1 from public.amuxc_file_versions where content_hash = ''abc''',
+  'select 1 from amux.amuxc_file_versions where content_hash = ''abc''',
   'amuxc_file_versions cascades when parent amuxc_files row is deleted');
 select pg_temp.as_user((select alice from ctx));
 
@@ -228,11 +228,11 @@ select col_default_is('public', 'amuxc_upload_sessions', 'status', 'pending',
 set local role postgres;
 set local row_security = off;
 prepare bad_status as
-  insert into public.amuxc_upload_sessions
+  insert into amux.amuxc_upload_sessions
     (team_id, actor_id, path, parent_version, content_hash, size,
      oss_key, status, expires_at)
   values ((select team_id from ctx),
-          (select id from public.actors where user_id = (select alice from ctx)
+          (select id from amux.actors where user_id = (select alice from ctx)
                                           and team_id = (select team_id from ctx)),
           'skills/x.md', 0, 'abc', 1,
           'teams/x/blobs/sha256/ab/c', 'lolwhat', now() + interval '1 hour');
@@ -255,7 +255,7 @@ select pg_temp.as_user((select alice from ctx));
 -- here to make this block robust to either path.
 set local role postgres;
 set local row_security = off;
-insert into public.team_workspace_config (team_id)
+insert into amux.team_workspace_config (team_id)
   values ((select team_id from ctx))
   on conflict do nothing;
 
@@ -269,7 +269,7 @@ select pg_temp.as_user((select alice from ctx));
 -- Force a distinct value: post-flip the existing row defaults to 'oss',
 -- so attempting to set it back to 'oss' would no-op and not fire the guard.
 prepare alice_change_sync_mode as
-  update public.team_workspace_config
+  update amux.team_workspace_config
      set sync_mode = 'git'
    where team_id = (select team_id from ctx);
 select throws_like(
@@ -279,7 +279,7 @@ select throws_like(
 deallocate alice_change_sync_mode;
 
 prepare alice_change_seq as
-  update public.team_workspace_config
+  update amux.team_workspace_config
      set oss_change_seq = 999
    where team_id = (select team_id from ctx);
 select throws_like(
@@ -289,7 +289,7 @@ select throws_like(
 deallocate alice_change_seq;
 
 prepare alice_change_litellm as
-  update public.team_workspace_config
+  update amux.team_workspace_config
      set litellm_team_id = 'pwned'
    where team_id = (select team_id from ctx);
 select throws_like(
@@ -300,7 +300,7 @@ deallocate alice_change_litellm;
 
 -- 7b. Authenticated may still touch other columns (git_url is a non-guarded column).
 select lives_ok(
-  $$update public.team_workspace_config
+  $$update amux.team_workspace_config
        set git_url = 'https://example.com/repo.git'
      where team_id = (select team_id from ctx)$$,
   'authenticated can still update non-guarded columns');
@@ -312,9 +312,9 @@ set local role postgres;
 set local row_security = off;
 select set_config('role', 'service_role', true);
 select lives_ok(
-  $$update public.team_workspace_config
+  $$update amux.team_workspace_config
        set sync_mode = 'oss', oss_change_seq = 1, litellm_team_id = 'svc'
-     where team_id = (select id from public.teams where slug = 'oss-team')$$,
+     where team_id = (select id from amux.teams where slug = 'oss-team')$$,
   'service_role can update guarded columns');
 
 -- restore alice for subsequent tests
@@ -328,7 +328,7 @@ select pg_temp.as_user('a1111111-1111-1111-1111-111111111111'::uuid);
 -- Insert a blob row as service_role so we have something to read.
 set local role postgres;
 set local row_security = off;
-insert into public.amuxc_blobs (team_id, content_hash, oss_key, size)
+insert into amux.amuxc_blobs (team_id, content_hash, oss_key, size)
   values ((select team_id from ctx),
           'rls-fixture-hash',
           'teams/oss-team/blobs/sha256/rl/sf/ixture',
@@ -351,7 +351,7 @@ select set_config('request.jwt.claims',
   true);
 select set_config('role', 'authenticated', true);
 select isnt_empty(
-  $$select 1 from public.amuxc_blobs
+  $$select 1 from amux.amuxc_blobs
      where content_hash = 'rls-fixture-hash'$$,
   'alice can SELECT her team blob');
 
@@ -360,7 +360,7 @@ select set_config('request.jwt.claims',
   json_build_object('sub', 'b2222222-2222-2222-2222-222222222222', 'role', 'authenticated')::text,
   true);
 select isnt_empty(
-  $$select 1 from public.amuxc_blobs
+  $$select 1 from amux.amuxc_blobs
      where content_hash = 'rls-fixture-hash'$$,
   'bob can SELECT same-team blob');
 
@@ -369,7 +369,7 @@ select set_config('request.jwt.claims',
   json_build_object('sub', 'c3333333-3333-3333-3333-333333333333', 'role', 'authenticated')::text,
   true);
 select is_empty(
-  $$select 1 from public.amuxc_blobs
+  $$select 1 from amux.amuxc_blobs
      where content_hash = 'rls-fixture-hash'$$,
   'stranger cara cannot SELECT another team blob');
 
@@ -380,7 +380,7 @@ select set_config('request.jwt.claims',
   true);
 select set_config('role', 'anon', true);
 prepare anon_select_blob as
-  select 1 from public.amuxc_blobs where content_hash = 'rls-fixture-hash';
+  select 1 from amux.amuxc_blobs where content_hash = 'rls-fixture-hash';
 select throws_ok(
   'execute anon_select_blob',
   '42501',
@@ -395,8 +395,8 @@ select set_config('request.jwt.claims',
   true);
 select set_config('role', 'authenticated', true);
 prepare alice_insert_blob as
-  insert into public.amuxc_blobs (team_id, content_hash, oss_key, size)
-  values ((select id from public.teams where slug = 'oss-team'), 'pwn', 'teams/x/blobs/sha256/pw/n/x', 1);
+  insert into amux.amuxc_blobs (team_id, content_hash, oss_key, size)
+  values ((select id from amux.teams where slug = 'oss-team'), 'pwn', 'teams/x/blobs/sha256/pw/n/x', 1);
 select throws_ok(
   'execute alice_insert_blob',
   '42501',
@@ -406,7 +406,7 @@ deallocate alice_insert_blob;
 
 -- 8g. Authenticated (alice) cannot UPDATE.
 prepare alice_update_blob as
-  update public.amuxc_blobs set verified = true
+  update amux.amuxc_blobs set verified = true
    where content_hash = 'rls-fixture-hash';
 select throws_ok(
   'execute alice_update_blob',
@@ -417,7 +417,7 @@ deallocate alice_update_blob;
 
 -- 8h. Authenticated (alice) cannot DELETE.
 prepare alice_delete_blob as
-  delete from public.amuxc_blobs
+  delete from amux.amuxc_blobs
    where content_hash = 'rls-fixture-hash';
 select throws_ok(
   'execute alice_delete_blob',
@@ -434,11 +434,11 @@ deallocate alice_delete_blob;
 set local role postgres;
 set local row_security = off;
 select is(
-  public.actor_id_for_user_in_team(
+  amux.actor_id_for_user_in_team(
     (select alice from ctx),
     (select team_id from ctx)
   ),
-  (select id from public.actors
+  (select id from amux.actors
     where user_id = (select alice from ctx)
       and team_id = (select team_id from ctx)),
   'actor_id_for_user_in_team: alice in her team returns her actor id'
@@ -447,7 +447,7 @@ select is(
 -- 9b. alice with cara's team (stranger) → returns null
 -- cara's team doesn't exist in this fixture, so we use a random uuid.
 select is(
-  public.actor_id_for_user_in_team(
+  amux.actor_id_for_user_in_team(
     (select alice from ctx),
     gen_random_uuid()
   ),
@@ -462,9 +462,9 @@ select set_config('request.jwt.claims',
   json_build_object('sub', 'a1111111-1111-1111-1111-111111111111', 'role', 'authenticated')::text,
   true);
 prepare auth_calls_helper as
-  select public.actor_id_for_user_in_team(
+  select amux.actor_id_for_user_in_team(
     'a1111111-1111-1111-1111-111111111111'::uuid,
-    (select id from public.teams where slug = 'oss-team')
+    (select id from amux.teams where slug = 'oss-team')
   );
 select throws_ok(
   'execute auth_calls_helper',
@@ -491,27 +491,27 @@ declare
   v_actor   uuid;
   v_session uuid;
 begin
-  v_actor := (select id from public.actors
+  v_actor := (select id from amux.actors
                where user_id = 'a1111111-1111-1111-1111-111111111111'::uuid
-                 and team_id = (select id from public.teams where slug = 'oss-team')
+                 and team_id = (select id from amux.teams where slug = 'oss-team')
                limit 1);
 
   -- Ensure team_workspace_config has sync_mode='oss' and oss_change_seq=0
-  update public.team_workspace_config
+  update amux.team_workspace_config
      set sync_mode = 'oss', oss_change_seq = 0
-   where team_id = (select id from public.teams where slug = 'oss-team');
+   where team_id = (select id from amux.teams where slug = 'oss-team');
 
   -- Seed blob
-  insert into public.amuxc_blobs (team_id, content_hash, oss_key, size)
-    values ((select id from public.teams where slug = 'oss-team'),
+  insert into amux.amuxc_blobs (team_id, content_hash, oss_key, size)
+    values ((select id from amux.teams where slug = 'oss-team'),
             'rpc-test-hash', 'teams/x/blobs/sha256/rp/ct/esthash', 100)
   on conflict do nothing;
 
   -- Create upload session
-  insert into public.amuxc_upload_sessions
+  insert into amux.amuxc_upload_sessions
     (team_id, actor_id, path, parent_version, content_hash, size, oss_key, expires_at)
   values
-    ((select id from public.teams where slug = 'oss-team'),
+    ((select id from amux.teams where slug = 'oss-team'),
      v_actor,
      'skills/rpc-test.md', 0,
      'rpc-test-hash', 100,
@@ -520,41 +520,41 @@ begin
   returning id into v_session;
 
   -- Call the RPC and verify it returns version=1, change_seq=1
-  perform public.amuxc_complete_upload(v_session, v_actor);
+  perform amux.amuxc_complete_upload(v_session, v_actor);
 end $$;
 
 select is(
-  (select current_version from public.amuxc_files
+  (select current_version from amux.amuxc_files
     where path = 'skills/rpc-test.md'
-      and team_id = (select id from public.teams where slug = 'oss-team')),
+      and team_id = (select id from amux.teams where slug = 'oss-team')),
   1,
   'amuxc_complete_upload: file pointer advanced to version 1'
 );
 
 select is(
-  (select oss_change_seq from public.team_workspace_config
-    where team_id = (select id from public.teams where slug = 'oss-team')),
+  (select oss_change_seq from amux.team_workspace_config
+    where team_id = (select id from amux.teams where slug = 'oss-team')),
   1::bigint,
   'amuxc_complete_upload: oss_change_seq advanced to 1 (waterline invariant)'
 );
 
 select is(
-  (select verified from public.amuxc_blobs
+  (select verified from amux.amuxc_blobs
     where content_hash = 'rpc-test-hash'
-      and team_id = (select id from public.teams where slug = 'oss-team')),
+      and team_id = (select id from amux.teams where slug = 'oss-team')),
   true,
   'amuxc_complete_upload: blob.verified flipped to true'
 );
 
 -- CAS conflict: calling complete_upload again with parent_version=0 must raise P0409
 prepare cas_conflict as
-  select public.amuxc_complete_upload(
-    (select id from public.amuxc_upload_sessions
+  select amux.amuxc_complete_upload(
+    (select id from amux.amuxc_upload_sessions
       where path = 'skills/rpc-test.md'
         and status = 'completed' limit 1),
-    (select id from public.actors
+    (select id from amux.actors
       where user_id = 'a1111111-1111-1111-1111-111111111111'::uuid
-        and team_id = (select id from public.teams where slug = 'oss-team') limit 1)
+        and team_id = (select id from amux.teams where slug = 'oss-team') limit 1)
   );
 select throws_ok(
   'execute cas_conflict',
@@ -569,13 +569,13 @@ do $$
 declare
   v_actor uuid;
 begin
-  v_actor := (select id from public.actors
+  v_actor := (select id from amux.actors
                where user_id = 'a1111111-1111-1111-1111-111111111111'::uuid
-                 and team_id = (select id from public.teams where slug = 'oss-team')
+                 and team_id = (select id from amux.teams where slug = 'oss-team')
                limit 1);
   -- current_version is 1 from the upload above, so parent_version=1
-  perform public.amuxc_complete_delete(
-    (select id from public.teams where slug = 'oss-team'),
+  perform amux.amuxc_complete_delete(
+    (select id from amux.teams where slug = 'oss-team'),
     'skills/rpc-test.md',
     1,
     v_actor,
@@ -584,15 +584,15 @@ begin
 end $$;
 
 select is(
-  (select deleted from public.amuxc_files
+  (select deleted from amux.amuxc_files
     where path = 'skills/rpc-test.md'
-      and team_id = (select id from public.teams where slug = 'oss-team')),
+      and team_id = (select id from amux.teams where slug = 'oss-team')),
   true,
   'amuxc_complete_delete: file marked deleted'
 );
 
 -- ---------------------------------------------------------------------------
--- Tests for app.oss_sync_abandon_expired_sessions (migration 20260527000002)
+-- Tests for amux.oss_sync_abandon_expired_sessions (migration 20260527000002)
 -- ---------------------------------------------------------------------------
 
 -- Tests 43-46: cleanup function tests — run with elevated privileges via security definer
@@ -605,23 +605,23 @@ declare v_team_id uuid;
         v_actor_id uuid;
         v_sess_id uuid;
 begin
-  v_team_id := (select id from public.teams where slug = 'oss-team');
-  v_actor_id := (select id from public.actors
+  v_team_id := (select id from amux.teams where slug = 'oss-team');
+  v_actor_id := (select id from amux.actors
                   where user_id = 'a1111111-1111-1111-1111-111111111111'::uuid
                     and team_id = v_team_id limit 1);
   v_sess_id := gen_random_uuid();
   -- Reset role to postgres so we can bypass RLS for test setup
   set local role postgres;
-  insert into public.amuxc_upload_sessions
+  insert into amux.amuxc_upload_sessions
     (id, team_id, actor_id, path, parent_version, oss_key, content_hash, size, status, expires_at)
   values
     (v_sess_id, v_team_id, v_actor_id,
      'skills/cleanup-test1.md', 0, 'test/cleanup-key1', 'aabbcc', 100, 'pending', now() - interval '1 hour');
-  perform app.oss_sync_abandon_expired_sessions();
+  perform amux.oss_sync_abandon_expired_sessions();
 end $$;
 
 select is(
-  (select status from public.amuxc_upload_sessions
+  (select status from amux.amuxc_upload_sessions
     where oss_key = 'test/cleanup-key1'),
   'abandoned',
   'oss_sync_abandon_expired_sessions: expired pending session → abandoned'
@@ -633,29 +633,29 @@ declare v_team_id uuid;
         v_actor_id uuid;
         v_sess_id uuid;
 begin
-  v_team_id := (select id from public.teams where slug = 'oss-team');
-  v_actor_id := (select id from public.actors
+  v_team_id := (select id from amux.teams where slug = 'oss-team');
+  v_actor_id := (select id from amux.actors
                   where user_id = 'a1111111-1111-1111-1111-111111111111'::uuid
                     and team_id = v_team_id limit 1);
   v_sess_id := gen_random_uuid();
   set local role postgres;
-  insert into public.amuxc_upload_sessions
+  insert into amux.amuxc_upload_sessions
     (id, team_id, actor_id, path, parent_version, oss_key, content_hash, size, status, expires_at)
   values
     (v_sess_id, v_team_id, v_actor_id,
      'skills/cleanup-test2.md', 0, 'test/cleanup-key2', 'aabbdd', 100, 'abandoned', now() - interval '25 hours');
-  perform app.oss_sync_abandon_expired_sessions();
+  perform amux.oss_sync_abandon_expired_sessions();
 end $$;
 
 select is(
-  (select count(*)::int from public.amuxc_upload_sessions
+  (select count(*)::int from amux.amuxc_upload_sessions
     where oss_key = 'test/cleanup-key2'),
   0,
   'oss_sync_abandon_expired_sessions: abandoned row older than 24h → deleted'
 );
 
 -- ---------------------------------------------------------------------------
--- Tests for app.oss_sync_gc_orphan_blobs (migration 20260527000002)
+-- Tests for amux.oss_sync_gc_orphan_blobs (migration 20260527000002)
 -- ---------------------------------------------------------------------------
 
 -- Test 45: orphan blob (8 days old, no version reference) → deleted
@@ -663,14 +663,14 @@ do $$
 declare v_team_id uuid;
         v_deleted int;
 begin
-  v_team_id := (select id from public.teams where slug = 'oss-team');
+  v_team_id := (select id from amux.teams where slug = 'oss-team');
   set local role postgres;
-  insert into public.amuxc_blobs (team_id, content_hash, oss_key, size, verified, created_at)
+  insert into amux.amuxc_blobs (team_id, content_hash, oss_key, size, verified, created_at)
   values (v_team_id, 'orphan-hash-gc-test-1', 'gc/orphan1', 42, true, now() - interval '8 days')
   on conflict do nothing;
-  v_deleted := app.oss_sync_gc_orphan_blobs();
+  v_deleted := amux.oss_sync_gc_orphan_blobs();
   -- Verify the blob is gone
-  if (select count(*) from public.amuxc_blobs where content_hash = 'orphan-hash-gc-test-1') > 0 then
+  if (select count(*) from amux.amuxc_blobs where content_hash = 'orphan-hash-gc-test-1') > 0 then
     raise exception 'blob should have been deleted';
   end if;
 end $$;
@@ -684,29 +684,29 @@ declare v_team_id uuid;
         v_actor_id uuid;
         v_preserved_count int;
 begin
-  v_team_id := (select id from public.teams where slug = 'oss-team');
-  v_actor_id := (select id from public.actors
+  v_team_id := (select id from amux.teams where slug = 'oss-team');
+  v_actor_id := (select id from amux.actors
                   where user_id = 'a1111111-1111-1111-1111-111111111111'::uuid
                     and team_id = v_team_id limit 1);
   set local role postgres;
   -- Insert a fresh file for this test
-  insert into public.amuxc_files (team_id, path, current_version, deleted, updated_by, updated_at)
+  insert into amux.amuxc_files (team_id, path, current_version, deleted, updated_by, updated_at)
   values (v_team_id, 'skills/gc-ref-test.md', 1, false, v_actor_id, now())
   on conflict (team_id, path) do nothing;
-  v_file_id := (select id from public.amuxc_files
+  v_file_id := (select id from amux.amuxc_files
                  where team_id = v_team_id and path = 'skills/gc-ref-test.md');
   -- Insert the blob with old created_at
-  insert into public.amuxc_blobs (team_id, content_hash, oss_key, size, verified, created_at)
+  insert into amux.amuxc_blobs (team_id, content_hash, oss_key, size, verified, created_at)
   values (v_team_id, 'referenced-hash-gc-test-2', 'gc/referenced1', 99, true, now() - interval '8 days')
   on conflict do nothing;
   -- Insert a version that references this blob
-  insert into public.amuxc_file_versions
+  insert into amux.amuxc_file_versions
     (file_id, version, parent_version, content_hash, size, deleted, created_by, created_at)
   values (v_file_id, 99, 0, 'referenced-hash-gc-test-2', 99, false, v_actor_id, now());
   -- Run GC
-  perform app.oss_sync_gc_orphan_blobs();
+  perform amux.oss_sync_gc_orphan_blobs();
   -- The blob must still exist
-  v_preserved_count := (select count(*)::int from public.amuxc_blobs
+  v_preserved_count := (select count(*)::int from amux.amuxc_blobs
                           where content_hash = 'referenced-hash-gc-test-2');
   if v_preserved_count = 0 then
     raise exception 'referenced blob should not have been deleted';
@@ -722,7 +722,7 @@ select pass('oss_sync_gc_orphan_blobs: referenced blob 8 days old → preserved'
 -- Test 47: set_team_sync_mode rejects bad mode (22023)
 select pg_temp.as_user((select alice from ctx));
 select throws_ok(
-  $$select public.set_team_sync_mode((select team_id from ctx), 'invalid')$$,
+  $$select amux.set_team_sync_mode((select team_id from ctx), 'invalid')$$,
   '22023',
   null,
   'set_team_sync_mode rejects unknown mode with 22023'
@@ -731,7 +731,7 @@ select throws_ok(
 -- Test 48: set_team_sync_mode from non-member (cara) → 42501
 select pg_temp.as_user((select cara from ctx));
 select throws_ok(
-  $$select public.set_team_sync_mode((select team_id from ctx), 'oss')$$,
+  $$select amux.set_team_sync_mode((select team_id from ctx), 'oss')$$,
   '42501',
   null,
   'set_team_sync_mode blocks non-member with 42501'
@@ -740,7 +740,7 @@ select throws_ok(
 -- Test 49: set_team_sync_mode from member-but-not-owner (bob) → 42501
 select pg_temp.as_user((select bob from ctx));
 select throws_ok(
-  $$select public.set_team_sync_mode((select team_id from ctx), 'oss')$$,
+  $$select amux.set_team_sync_mode((select team_id from ctx), 'oss')$$,
   '42501',
   null,
   'set_team_sync_mode blocks non-owner member with 42501'
@@ -749,7 +749,7 @@ select throws_ok(
 -- Test 50: set_team_sync_mode from owner (alice) → returns 'oss', column updated
 select pg_temp.as_user((select alice from ctx));
 select is(
-  public.set_team_sync_mode((select team_id from ctx), 'oss'),
+  amux.set_team_sync_mode((select team_id from ctx), 'oss'),
   'oss',
   'set_team_sync_mode owner switch to oss returns oss'
 );
@@ -757,7 +757,7 @@ select is(
 set local role postgres;
 set local row_security = on;
 select is(
-  (select sync_mode from public.team_workspace_config where team_id = (select team_id from ctx)),
+  (select sync_mode from amux.team_workspace_config where team_id = (select team_id from ctx)),
   'oss',
   'set_team_sync_mode: column is updated in DB after owner switch to oss'
 );
@@ -766,7 +766,7 @@ select pg_temp.as_user((select alice from ctx));
 
 -- Test 52: owner can flip back to git
 select is(
-  public.set_team_sync_mode((select team_id from ctx), 'git'),
+  amux.set_team_sync_mode((select team_id from ctx), 'git'),
   'git',
   'set_team_sync_mode owner switch back to git returns git'
 );
@@ -777,7 +777,7 @@ select pg_temp.as_user((select bob from ctx));
 set local role postgres;
 set local row_security = on;
 select is(
-  public.get_team_sync_mode((select team_id from ctx)),
+  amux.get_team_sync_mode((select team_id from ctx)),
   'git',
   'get_team_sync_mode returns current sync_mode for authenticated member'
 );
@@ -793,7 +793,7 @@ begin
   perform set_config('role', 'authenticated', true);
   perform set_config('app.allow_sync_mode_switch', 'off', true);
   begin
-    update public.team_workspace_config
+    update amux.team_workspace_config
        set sync_mode = 'oss'
      where team_id = (select team_id from ctx);
   exception

--- a/services/supabase/tests/021_agent_reinvite_owner_check.sql
+++ b/services/supabase/tests/021_agent_reinvite_owner_check.sql
@@ -38,37 +38,36 @@ begin
   on conflict do nothing;
 
   -- members
-  insert into public.members (id, user_id, status)
+  insert into amux.members (id, status)
   values
-    (v_alice_mem, v_alice_uid, 'active'),
-    (v_bob_mem,   v_bob_uid,   'active');
+    (v_alice_mem, 'active'),
+    (v_bob_mem,   'active');
 
   -- team
-  insert into public.teams (id, slug, name)
+  insert into amux.teams (id, slug, name)
   values (v_team, 'oc-test-' || left(v_team::text, 8), 'Owner Check Test');
 
   -- actors for alice and bob (members)
-  insert into public.actors (id, team_id, actor_type, display_name, user_id)
+  insert into amux.actors (id, team_id, actor_type, display_name, user_id)
   values
     (v_alice_mem, v_team, 'member', 'Alice', v_alice_uid),
     (v_bob_mem,   v_team, 'member', 'Bob',   v_bob_uid);
 
   -- team_members
-  insert into public.team_members (team_id, member_id, role)
+  insert into amux.team_members (team_id, member_id, role)
   values
     (v_team, v_alice_mem, 'owner'),
     (v_team, v_bob_mem,   'member');
 
   -- agent actor owned by alice
-  insert into public.actors (id, team_id, actor_type, display_name)
+  insert into amux.actors (id, team_id, actor_type, display_name)
   values (v_agent_actor, v_team, 'agent', 'TestAgent');
 
-  insert into public.agents (id, agent_kind, status, owner_member_id)
-  values (v_agent_actor, 'claude', 'active', v_alice_mem);
+  insert into amux.agents (id, status, owner_member_id) values (v_agent_actor, 'active', v_alice_mem);
 
   -- ── Test 1: owner (alice) can create a re-invite for her agent ───────────
   perform pg_temp.as_member(v_alice_uid);
-  perform public.create_team_invite(
+  perform amux.create_team_invite(
     v_team, 'agent', 'TestAgent',
     p_agent_kind    => 'claude',
     p_target_actor_id => v_agent_actor
@@ -78,7 +77,7 @@ begin
   -- ── Test 2: non-owner (bob) is rejected with 42501 ───────────────────────
   perform pg_temp.as_member(v_bob_uid);
   begin
-    perform public.create_team_invite(
+    perform amux.create_team_invite(
       v_team, 'agent', 'TestAgent',
       p_agent_kind      => 'claude',
       p_target_actor_id => v_agent_actor

--- a/services/supabase/tests/QUARANTINE.md
+++ b/services/supabase/tests/QUARANTINE.md
@@ -29,65 +29,55 @@ nothing behind and is safe against a live database.
 
 ## Why they fail
 
-The schema moved twice since these were written. Grouped by what each one needs:
+Seven files remain. The schema drift that killed the other 21 has been dealt
+with; what is left needs a decision, not a rename.
 
-### 1. `public.*` → `amux.*` (all of them)
+### `001_schema_shape.sql` — needs a rewrite, not a fix
 
-Every business table and function moved to the `amux` schema. Note `orgs` is the
-exception — it is still in `public`, so a blanket find/replace breaks it.
+Two problems at once. It asserts `has_table('public', 'agent_runtimes')` for a
+table that no longer exists anywhere, and its ~68 assertions all use the
+two-argument form described at the bottom of this file — so even the ones naming
+surviving tables are asserting the wrong thing. Rewriting it means restating
+every assertion against the current schema, which is really "write a new
+schema-shape test", not "repair this one".
 
-### 2. Identity moved from `members` to `actors`
+### `005_agent_role_rls.sql` — tests a table that was dropped
 
-`members.user_id` no longer exists. A user's link to `auth.users` is on
-`amux.actors.user_id`, because identity is per team (one actor row per user per
-team, `unique (team_id, user_id)`). Fixtures must insert `user_id` on the actor
-and omit it on the member.
+The body inserts into `agent_runtimes` to prove a daemon JWT may write its own
+runtime rows. That table is gone, so the scenario no longer exists. Either
+delete the section (and keep the surrounding RLS coverage) or delete the file.
 
-Affected: `002_rls`, `004_member_reinvite`, `005_agent_role_rls`,
-`015_rbac_shortcuts`, `021_agent_reinvite_owner_check`.
+### `008_actor_telemetry.sql` — `amux.team_leaderboard` does not exist
 
-### 3. `agents.agent_kind` is gone
+Same shape as above: the fixture and assertions are fine until it reaches a
+relation that was removed.
 
-Replaced by `default_agent_type` + `agent_types`. Fixtures inserting
-`agent_kind` need it dropped.
+### `004_member_reinvite.sql` — behaviour changed
 
-Affected: `001_schema_shape`, `006_access_token_hook`, `009_agent_visibility`,
-`011_gateway_session_rpc`, `013_gateway_agent_admin_owner_rpc`,
-`014_gateway_external_message_rls`, `016_push_notifications`.
+Fails with `member claim requires a non-anonymous user`. The invite-claim path
+now refuses anonymous callers; the test predates that. Whether the test or the
+rule is right is a product question — read the claim RPC before changing either.
 
-### 4. `create_team` is ambiguous
+### `007_team_workspace_config.sql` — `new row violates row-level security policy`
 
-There are now two overloads, both with every argument defaulted, so
-`create_team('x')` fails with *function is not unique*. Calls need enough
-arguments (or explicit casts) to pick one. Worth fixing in the schema rather
-than the tests.
+The fixture no longer satisfies the workspaces INSERT policy (which now requires
+`created_by_member_id` to be the caller's actor in that team). Needs the fixture
+to assume an identity before inserting, not a schema rename.
 
-Affected: `003_team_invites`, `004_member_reinvite`, `007_team_workspace_config`,
-`008_actor_telemetry`, `020_oss_sync_schema`, `team_share_mode.test`.
+### `012_gateway_message_external_id_upsert.sql` — `actors_external_has_source`
 
-### 5. `permission denied for table <fixture>`
+The check constraint requires `(actor_type = 'external') = (source IS NOT NULL
+AND source_id IS NOT NULL)`. The fixture builds an actor that violates it.
+Straightforward to fix once someone decides what the fixture is meant to model.
 
-These create a fixture table and then `set role`, leaving the new role without a
-grant on it. They need a `grant` after the fixture, or should build the fixture
-as a temp table owned by the test role.
+### `015_rbac_shortcuts.sql` — temp-table visibility
 
-Affected: `027_org_default_team_selection`, `028_phone_linked_org_picker`,
-`029_empty_org_public_bootstrap`, `claim_team_invite_agent_org.test`.
-
-### 6. Genuine behaviour differences — read before "fixing"
-
-These fail on an assertion, not on schema drift, so the assertion may be
-describing behaviour that was deliberately changed. Check the intent before
-touching them.
-
-- `025_agent_delete_authz` — *expected personal-agent delete denial for
-  non-owner*. Either the authz rule changed or the test is right and there is a
-  real hole. Worth a look on its own.
-- `team_default_agent.test` — inserts an agent without `owner_member_id`, which
-  is NOT NULL now.
+`permission denied for table fx`. The file builds a fixture temp table and then
+`set role`s through several identities. A `grant select on fx` was added and got
+it further, but a later step still trips over the same thing — it likely needs
+the fixture to live in a regular table, or grants on the `pg_temp` helpers too.
 
 ## A trap worth knowing
-
 pgTAP overloads its assertions on both `(schema, object)` and
 `(object, description)`. Two untyped string literals resolve to the **latter**,
 so
@@ -110,3 +100,26 @@ Several of the quarantined files carry this bug on top of the schema drift.
 - `003_daemon_invites.sql` — the `daemon_invites` table no longer exists
   anywhere in the schema. The test covered a feature that was removed, so it was
   deleted rather than quarantined.
+
+## What the repair pass changed
+
+21 files came out of quarantine. Grouped by what was actually wrong:
+
+- **schema rename** — `public.*` and the older `app.*` both became `amux.*`.
+  Rewritten by matching against the live object list rather than blanket
+  find/replace, because `orgs`, `plans` and `users` really do still live in
+  `public`.
+- **`members.user_id` moved to `actors.user_id`** — identity is per team now, so
+  the link to `auth.users` sits on the per-team row.
+- **`agents.agent_kind` is gone**, and `agents.owner_member_id` became NOT NULL
+  — several fixtures had no member at all to own their agent.
+- **`create_team` is ambiguous**: two overloads with every argument defaulted, so
+  `create_team('x')` does not resolve. Calls now name `p_oid` to pick one. Worth
+  fixing in the schema rather than in every caller.
+- **assertion API misuse** — `like()` is PostgreSQL's operator function, not a
+  pgTAP assertion (`alike`/`matches` are), and `ok(lives_ok(...))` never had an
+  overload because `lives_ok` returns TAP text, not a boolean. Both had been
+  wrong since they were written; nothing ran them, so nobody found out.
+- **`perform` at the top level** — valid only inside plpgsql. Note when fixing
+  more of these: the same file usually has legitimate `perform` inside `DO`
+  blocks, so a blind find/replace breaks it in the other direction.

--- a/services/supabase/tests/ci-bootstrap.sql
+++ b/services/supabase/tests/ci-bootstrap.sql
@@ -52,6 +52,11 @@ $$;
 ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS phone              text;
 ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS email_confirmed_at timestamptz;
 ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS is_anonymous       boolean NOT NULL DEFAULT false;
+ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS email_change_token_new     varchar(255);
+ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS email_change_token_current varchar(255);
+ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS phone_change               text;
+ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS phone_change_token         varchar(255);
+ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS reauthentication_token     varchar(255);
 
 -- auth.refresh_tokens gained session_id when GoTrue introduced sessions;
 -- amux.mint_session writes it.

--- a/services/supabase/tests/run.sh
+++ b/services/supabase/tests/run.sh
@@ -29,33 +29,12 @@ PSQL=${PSQL:-psql}
 # and make it pass.
 QUARANTINE=$(cat <<'EOF'
 001_schema_shape.sql
-002_rls.sql
-003_team_invites.sql
 004_member_reinvite.sql
 005_agent_role_rls.sql
-006_access_token_hook.sql
-006_gateway_external_actor.sql
 007_team_workspace_config.sql
 008_actor_telemetry.sql
-009_agent_visibility.sql
-011_gateway_session_rpc.sql
 012_gateway_message_external_id_upsert.sql
-013_gateway_agent_admin_owner_rpc.sql
-014_gateway_external_message_rls.sql
 015_rbac_shortcuts.sql
-016_push_notifications.sql
-017_idea_create_order.sql
-018_idea_activity_attachment_urls.sql
-019_idea_attachment_storage_rls.sql
-020_oss_sync_schema.sql
-021_agent_reinvite_owner_check.sql
-025_agent_delete_authz.sql
-027_org_default_team_selection.sql
-028_phone_linked_org_picker.sql
-029_empty_org_public_bootstrap.sql
-claim_team_invite_agent_org.test.sql
-team_default_agent.test.sql
-team_share_mode.test.sql
 EOF
 )
 

--- a/services/supabase/tests/team_share_mode.test.sql
+++ b/services/supabase/tests/team_share_mode.test.sql
@@ -3,11 +3,11 @@
 -- pgTAP tests for migration 20260528000002_team_share_mode.sql:
 --   1. Fresh team has share_mode NULL and team_workspace_config.sync_mode NULL
 --      (i.e. PR #212's create_team no longer seeds sync_mode='git').
---   2. app.enable_team_share(t, 'oss') sets teams.share_mode='oss' and
+--   2. amux.enable_team_share(t, 'oss') sets teams.share_mode='oss' and
 --      team_workspace_config.sync_mode='oss'.
---   3. Calling app.enable_team_share again raises (locked).
+--   3. Calling amux.enable_team_share again raises (locked).
 --   4. Direct UPDATE that changes share_mode raises (trigger).
---   5. app.enable_team_share(t, 'custom_git', url, kind, ref) writes the git
+--   5. amux.enable_team_share(t, 'custom_git', url, kind, ref) writes the git
 --      remote/auth/cred fields onto teams.
 --
 -- Run via:
@@ -41,31 +41,31 @@ begin
 end;
 $$;
 
--- Fixture: one authenticated user, one team via public.create_team
+-- Fixture: one authenticated user, one team via amux.create_team
 insert into auth.users (id, email, aud, role, instance_id) values
   ('aa111111-1111-1111-1111-111111111111', 'alice-share@amux.test', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
   ('bb222222-2222-2222-2222-222222222222', 'bob-share@amux.test',   'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
 on conflict do nothing;
 
 select pg_temp.as_user('aa111111-1111-1111-1111-111111111111');
-select * from public.create_team('Share Team');
+select * from amux.create_team('Share Team', p_oid => null);
 
 -- 1. teams.share_mode column exists with the expected enum type
 select has_column('public', 'teams', 'share_mode', 'teams.share_mode column exists');
-select col_type_is('public', 'teams', 'share_mode', 'app.team_share_mode', 'share_mode is app.team_share_mode');
+select col_type_is('public', 'teams', 'share_mode', 'amux.team_share_mode', 'share_mode is amux.team_share_mode');
 
 -- 2. Fresh team: share_mode IS NULL
 select is(
-  (select share_mode from public.teams where slug = 'share-team'),
-  null::app.team_share_mode,
+  (select share_mode from amux.teams where slug = 'share-team'),
+  null::amux.team_share_mode,
   'fresh team has null share_mode'
 );
 
 -- 3. Fresh team: team_workspace_config.sync_mode IS NULL
 select is(
   (select twc.sync_mode
-     from public.team_workspace_config twc
-     join public.teams t on t.id = twc.team_id
+     from amux.team_workspace_config twc
+     join amux.teams t on t.id = twc.team_id
     where t.slug = 'share-team'),
   null::text,
   'fresh team_workspace_config has null sync_mode'
@@ -76,26 +76,26 @@ select is(
 -- temp tables are not visible to other roles by default.)
 create temp table _ids (key text primary key, id uuid);
 insert into _ids values
-  ('team1', (select id from public.teams where slug = 'share-team'));
+  ('team1', (select id from amux.teams where slug = 'share-team'));
 grant select on _ids to service_role, authenticated;
 
 -- Second team — create_team enforces first-team-only per user, so we switch
 -- to a different authenticated user before calling it.
 select pg_temp.as_user('bb222222-2222-2222-2222-222222222222');
-select * from public.create_team('Git Team');
+select * from amux.create_team('Git Team', p_oid => null);
 insert into _ids values
-  ('team2', (select id from public.teams where slug = 'git-team'));
+  ('team2', (select id from amux.teams where slug = 'git-team'));
 
 -- 4. enable_team_share('oss') succeeds (service_role context)
 select pg_temp.as_service_role();
 select lives_ok(
-  $q$ select app.enable_team_share((select id from _ids where key='team1'), 'oss'::app.team_share_mode) $q$,
+  $q$ select amux.enable_team_share((select id from _ids where key='team1'), 'oss'::amux.team_share_mode) $q$,
   'enable_team_share oss succeeds'
 );
 
 -- 5. teams.share_mode is now 'oss'
 select is(
-  (select share_mode::text from public.teams
+  (select share_mode::text from amux.teams
     where id = (select id from _ids where key='team1')),
   'oss',
   'teams.share_mode is oss after enable'
@@ -103,7 +103,7 @@ select is(
 
 -- 6. team_workspace_config.sync_mode mirrors to 'oss'
 select is(
-  (select sync_mode from public.team_workspace_config
+  (select sync_mode from amux.team_workspace_config
     where team_id = (select id from _ids where key='team1')),
   'oss',
   'team_workspace_config.sync_mode mirrored to oss'
@@ -111,12 +111,12 @@ select is(
 
 -- 7. Second enable_team_share switches mode (no longer locked).
 select lives_ok(
-  $q$ select public.enable_team_share((select id from _ids where key='team1'), 'managed_git'::app.team_share_mode) $q$,
+  $q$ select amux.enable_team_share((select id from _ids where key='team1'), 'managed_git'::amux.team_share_mode) $q$,
   'second enable_team_share switches mode'
 );
 
 select is(
-  (select share_mode::text from public.teams
+  (select share_mode::text from amux.teams
     where id = (select id from _ids where key='team1')),
   'managed_git',
   'teams.share_mode updated to managed_git'
@@ -124,22 +124,22 @@ select is(
 
 -- 8. Direct UPDATE of share_mode is allowed after guard trigger removal.
 select lives_ok(
-  $q$ update public.teams set share_mode = 'oss'::app.team_share_mode
+  $q$ update amux.teams set share_mode = 'oss'::amux.team_share_mode
        where id = (select id from _ids where key='team1') $q$,
   'direct UPDATE of share_mode is allowed'
 );
 
 -- 9. UPDATE that keeps share_mode unchanged still works (regression guard).
 select lives_ok(
-  $q$ update public.teams set name = 'Share Team Renamed'
+  $q$ update amux.teams set name = 'Share Team Renamed'
        where id = (select id from _ids where key='team1') $q$,
   'UPDATE that leaves share_mode unchanged is allowed'
 );
 
 -- 10. custom_git path: enable the second team with git fields.
 select lives_ok(
-  $q$ select app.enable_team_share((select id from _ids where key='team2'),
-                                   'custom_git'::app.team_share_mode,
+  $q$ select amux.enable_team_share((select id from _ids where key='team2'),
+                                   'custom_git'::amux.team_share_mode,
                                    'https://example.com/repo.git',
                                    'ssh_key',
                                    'cred-ref-1') $q$,
@@ -148,7 +148,7 @@ select lives_ok(
 
 select results_eq(
   $q$ select share_mode::text, git_remote_url, git_auth_kind, git_credential_ref
-        from public.teams where id = (select id from _ids where key='team2') $q$,
+        from amux.teams where id = (select id from _ids where key='team2') $q$,
   $$ values ('custom_git'::text,
              'https://example.com/repo.git'::text,
              'ssh_key'::text,


### PR DESCRIPTION
CI 现在跑 **30 个** pgTAP 测试（此前 9 个）。隔离区从 28 个降到 **7 个**，`QUARANTINE.md` 逐条写明剩下的每个需要什么、以及为什么它们是「需要决策」而不是「改个名」。

## 实际坏在哪（分类）

- **schema 改名**：`public.*` 和更早的 `app.*` 都要变成 `amux.*`。用**实时对象清单**逐个匹配来改写，而不是全局替换——`orgs`、`plans`、`users` 确实还在 `public` 里，一刀切会静默改坏它们。
- **身份位置变了**：`members.user_id` 现在是 `actors.user_id`（一个用户在每个团队一个 actor）。
- **`agents.agent_kind` 已删**，且 `agents.owner_member_id` 变成 NOT NULL。有三个 fixture 压根没有 member 可以做 owner，只能新建，而不是删列了事。
- **`create_team` 有歧义**：两个重载、参数全部有默认值，所以 `create_team('x')` 无法解析。调用改成具名 `p_oid`。**这个更该在 schema 层修，而不是在每个调用点修**。
- **断言 API 用错了，而且从写下那天就是错的**：`like()` 是 PostgreSQL 的操作符函数、不是 pgTAP 断言（pgTAP 的是 `alike`/`matches`）；`ok(lives_ok(...))` 根本没有对应重载，因为 `lives_ok` 返回的是 TAP 文本不是 boolean。没人跑过这些文件，所以一直没被发现。
- **顶层用了 `perform`**（那是 plpgsql 专用语句）。
- **fixture 临时表在 `set role` 后读不到**，需要显式 grant。

`ci-bootstrap.sql` 补上了 GoTrue 在镜像发布之后才加的 `auth.users` 列（`email_change_token_new`/`_current`、`phone_change`、`phone_change_token`、`reauthentication_token`）——有测试会写这些字段。

## 给后续接手的人一个提醒

`perform` → `select` 的改写**不能用普通正则批量做**。同一个文件里通常还有 DO 块内部合法的 `perform`，那里 `select` 不带 INTO 本身就是非法的；盲目替换会朝反方向弄坏本来能跑的测试。我就是这么干的，最后不得不把每个 verb 对齐回 HEAD 才恢复过来。

## 剩余 7 个

| 文件 | 为什么留着 |
|---|---|
| `001_schema_shape` | 断言 `agent_runtimes`（表已删），且 ~68 个断言全用两参数形式（见下方陷阱），等于要重写一个新的 schema-shape 测试 |
| `005_agent_role_rls` | 往 `agent_runtimes` 插数据，该场景已不存在 |
| `008_actor_telemetry` | `amux.team_leaderboard` 不存在 |
| `004_member_reinvite` | 行为变了：认领邀请现在拒绝匿名调用者。测试对还是规则对，是产品问题 |
| `007_team_workspace_config` | fixture 不再满足 workspaces 的 INSERT 策略，需要先假定身份 |
| `012_gateway_message_external_id_upsert` | fixture 违反 `actors_external_has_source` 约束 |
| `015_rbac_shortcuts` | temp 表可见性，加了 grant 后推进了但后续步骤仍卡在同一问题 |

## 验证

对部署同款镜像的全新容器完整跑过 CI 流程——bootstrap、从空库应用全部迁移、再跑套件：

```
STEP bootstrap OK
STEP migrations OK
30 run, 0 failed, 7 quarantined
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
