### PR TITLE
fix(daemon): Idle 只写云端最终 agent_reply

### DIFF
--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -636,10 +636,13 @@ fn absorb_emitted(
     let mut flushed = false;
     for m in emitted {
         if matches!(m.kind, crate::proto::teamclu::MessageKind::AgentReply) {
-            // Tool-only turns emit an empty AgentReply at turn end purely to
-            // anchor the turn for clients; it carries no text and must not
-            // add a blank segment.
-            if !m.content.is_empty() {
+            // Empty anchors and English status notices (no_final_reply /
+            // interrupt instruction) must not become WeCom/channel reply text.
+            if !m.content.is_empty()
+                && !crate::runtime::turn_aggregator::TurnAggregator::is_agent_facing_status_notice(
+                    &m.content,
+                )
+            {
                 segments.push(m.content);
             }
             live.clear();
@@ -1483,8 +1486,8 @@ mod tests {
         assert_eq!(compose_reply(&segments, ""), "first\n\nsecond\n\nthird");
     }
 
-    /// Tool-only turns emit an empty `AgentReply` at turn end to anchor the
-    /// turn for clients; it must not become a blank segment.
+    /// Tool-only turns emit a `no_final_reply` AgentReply at Idle for cloud /
+    /// catchup; channel absorb must still yield no user-visible segment.
     #[test]
     fn tool_only_turn_yields_empty_reply() {
         let segments = segments_from(&[tool_use("Bash"), turn_end()]);

--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -437,11 +437,14 @@ impl DaemonServer {
                     .cloned()
                     .unwrap_or_default();
                 for msg in emitted {
-                    let persist =
-                        crate::runtime::turn_aggregator::TurnAggregator::cloud_persistent(&msg);
-                    if !persist {
+                    // Thinking / tool rows stay ACP-only. AgentReply always
+                    // lands on live + local TOML; cloud insert only for the
+                    // turn-final slice (Idle / interrupted).
+                    if msg.kind != crate::proto::teamclu::MessageKind::AgentReply {
                         continue;
                     }
+                    let persist =
+                        crate::runtime::turn_aggregator::TurnAggregator::cloud_persistent(&msg);
                     let kind = msg.kind;
                     let content = msg.content;
                     let metadata_json = msg.metadata_json;
@@ -470,7 +473,7 @@ impl DaemonServer {
                     // may have returned Err and skipped persist_runtime_cursor.
                     // Only advance when cloud insert succeeded — otherwise
                     // catchup would skip an unanswered @mention with no row.
-                    if interrupted && cloud_ok && !reply_to_message_id.is_empty() {
+                    if interrupted && persist && cloud_ok && !reply_to_message_id.is_empty() {
                         self.persist_runtime_cursor(agent_id, &reply_to_message_id)
                             .await;
                     }

--- a/apps/daemon/src/runtime/turn_aggregator.rs
+++ b/apps/daemon/src/runtime/turn_aggregator.rs
@@ -2,7 +2,14 @@
 //! discrete "logical messages" (thinking blocks, tool calls/results, agent
 //! replies). The daemon runs one of these per agent_id and feeds every
 //! `AcpEvent` into it; emitted messages get persisted (TOML, plus the cloud
-//! backend for AGENT_REPLY) and broadcast on session/live.
+//! backend for **turn-final** AGENT_REPLY) and broadcast on session/live.
+//!
+//! ## Cloud vs live
+//!
+//! Mid-turn `AgentReply` slices (flushed before each `ToolUse`) are live/TOML
+//! only. Cloud `messages` receives at most one non-empty `AgentReply` per turn
+//! — the Active→Idle flush (including interrupted turns). OpenCode / Cursor /
+//! Claude Code / Pi all map run completion onto that Idle boundary.
 //!
 //! ## metadata_json shapes
 //!
@@ -32,6 +39,20 @@ Do not continue, resume, or retry the interrupted work unless the user \
 explicitly asks again.";
 
 const INTERRUPTED_REPLY_METADATA_JSON: &str = r#"{"turn_status":"interrupted"}"#;
+
+/// Durable AGENT_REPLY body when a turn ends at Idle with no final prose
+/// (tool-only, or all narration was mid-flushed before the last ToolUse).
+///
+/// English so agent context / catchup understand completion. Frontends hide
+/// this notice when `metadata.turn_status == "no_final_reply"` and render a
+/// localized status strip.
+pub const NO_FINAL_REPLY_AGENT_CONTENT: &str = "\
+[Turn completed with no final reply] The agent finished this turn after tool \
+use without producing a final written answer. Treat the turn as successfully \
+completed. Do not invent a summary, continue the interrupted narration, or \
+re-run the tools unless the user explicitly asks.";
+
+const NO_FINAL_REPLY_METADATA_JSON: &str = r#"{"turn_status":"no_final_reply"}"#;
 
 fn is_turn_abort_error(err: &amux::AcpError) -> bool {
     let message = err.message.to_ascii_lowercase();
@@ -112,6 +133,10 @@ pub struct EmittedMessage {
     /// is no active turn (shouldn't happen for agent emissions but
     /// renderers must tolerate it).
     pub turn_id: String,
+    /// When true, this `AgentReply` is the turn-final slice (Active→Idle,
+    /// including interrupted) and may be written to the cloud backend.
+    /// Mid-turn ToolUse flushes keep this false (live + local TOML only).
+    pub cloud_persist: bool,
 }
 
 #[derive(Debug, Default)]
@@ -156,13 +181,14 @@ impl TurnAggregator {
                 self.ensure_turn_started();
                 self.turn_had_activity = true;
                 self.flush_thinking_into(&mut out);
-                self.flush_reply_into(&mut out);
+                self.flush_reply_into(&mut out, false);
                 let metadata = tool_use_metadata(tu);
                 out.push(EmittedMessage {
                     kind: MessageKind::AgentToolCall,
                     content: tu.tool_name.clone(),
                     metadata_json: metadata,
                     turn_id: self.current_turn_id.clone().unwrap_or_default(),
+                    cloud_persist: false,
                 });
             }
             Some(amux::acp_event::Event::ToolResult(tr)) => {
@@ -174,6 +200,7 @@ impl TurnAggregator {
                     content: tr.summary.clone(),
                     metadata_json: metadata,
                     turn_id: self.current_turn_id.clone().unwrap_or_default(),
+                    cloud_persist: false,
                 });
             }
             Some(amux::acp_event::Event::Error(err)) => {
@@ -220,20 +247,25 @@ impl TurnAggregator {
                             content,
                             metadata_json: INTERRUPTED_REPLY_METADATA_JSON.to_string(),
                             turn_id: self.current_turn_id.clone().unwrap_or_default(),
+                            cloud_persist: true,
                         });
                         self.turn_had_reply = true;
                     } else {
-                        self.flush_reply_into(&mut out);
-                        // Tool-only turns never accumulate reply text. Emit an
-                        // empty AgentReply so clients get message.created and
-                        // can anchor the turn in the main timeline.
-                        if !self.turn_had_reply && self.turn_had_activity {
+                        // Non-empty Idle prose → one cloud-final AgentReply.
+                        // Empty Idle (tool-only, or mid-turn flushes already
+                        // drained the buffer) → durable no_final_reply notice
+                        // so catchup sees an agent row and UI can localize.
+                        let had_final_prose = !self.reply_buf.trim().is_empty();
+                        self.flush_reply_into(&mut out, true);
+                        if !had_final_prose && self.turn_had_activity {
                             out.push(EmittedMessage {
                                 kind: MessageKind::AgentReply,
-                                content: String::new(),
-                                metadata_json: String::new(),
+                                content: NO_FINAL_REPLY_AGENT_CONTENT.to_string(),
+                                metadata_json: NO_FINAL_REPLY_METADATA_JSON.to_string(),
                                 turn_id: self.current_turn_id.clone().unwrap_or_default(),
+                                cloud_persist: true,
                             });
+                            self.turn_had_reply = true;
                         }
                     }
                     self.turn_had_activity = false;
@@ -263,27 +295,31 @@ impl TurnAggregator {
                 content: std::mem::take(&mut self.thinking_buf),
                 metadata_json: String::new(),
                 turn_id: self.current_turn_id.clone().unwrap_or_default(),
+                cloud_persist: false,
             });
         }
     }
 
-    fn flush_reply_into(&mut self, out: &mut Vec<EmittedMessage>) {
+    fn flush_reply_into(&mut self, out: &mut Vec<EmittedMessage>, cloud_persist: bool) {
         if !self.reply_buf.is_empty() {
             out.push(EmittedMessage {
                 kind: MessageKind::AgentReply,
                 content: std::mem::take(&mut self.reply_buf),
                 metadata_json: String::new(),
                 turn_id: self.current_turn_id.clone().unwrap_or_default(),
+                cloud_persist,
             });
             self.turn_had_reply = true;
         }
     }
 
     /// True if this emitted message should be persisted to the cloud backend.
-    /// We only persist `AgentReply` (per design — the cloud backend is the
-    /// durable canonical conversation log, not an audit trail).
+    /// Only non-empty **turn-final** `AgentReply` rows (Active→Idle /
+    /// interrupted). Mid-turn ToolUse flushes stay live + local TOML.
     pub fn cloud_persistent(msg: &EmittedMessage) -> bool {
-        matches!(msg.kind, MessageKind::AgentReply) && !msg.content.trim().is_empty()
+        matches!(msg.kind, MessageKind::AgentReply)
+            && msg.cloud_persist
+            && !msg.content.trim().is_empty()
     }
 
     /// Current per-turn correlation id, or `None` between turns. Read by the
@@ -415,6 +451,8 @@ mod tests {
         assert_eq!(emitted[0].content, "Let me think...");
         assert_eq!(emitted[1].kind, MessageKind::AgentReply);
         assert_eq!(emitted[1].content, "The answer is 579.");
+        assert!(emitted[1].cloud_persist);
+        assert!(TurnAggregator::cloud_persistent(&emitted[1]));
     }
 
     #[test]
@@ -427,6 +465,8 @@ mod tests {
         assert_eq!(emitted.len(), 3);
         assert_eq!(emitted[0].kind, MessageKind::AgentThinking);
         assert_eq!(emitted[1].kind, MessageKind::AgentReply);
+        assert!(!emitted[1].cloud_persist);
+        assert!(!TurnAggregator::cloud_persistent(&emitted[1]));
         assert_eq!(emitted[2].kind, MessageKind::AgentToolCall);
         assert!(emitted[2].content.contains("Read"));
         assert!(emitted[2].metadata_json.contains("\"tool_id\":\"t1\""));
@@ -458,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    fn tool_only_turn_emits_empty_agent_reply_at_idle() {
+    fn tool_only_turn_emits_no_final_reply_notice_at_idle() {
         let mut agg = TurnAggregator::new();
         agg.ingest(&status_change(
             amux::AgentStatus::Idle,
@@ -474,12 +514,17 @@ mod tests {
         ));
         assert_eq!(emitted.len(), 1);
         assert_eq!(emitted[0].kind, MessageKind::AgentReply);
-        assert!(emitted[0].content.is_empty());
+        assert_eq!(emitted[0].content, NO_FINAL_REPLY_AGENT_CONTENT);
+        assert!(emitted[0]
+            .metadata_json
+            .contains("\"turn_status\":\"no_final_reply\""));
+        assert!(emitted[0].cloud_persist);
         assert!(!emitted[0].turn_id.is_empty());
+        assert!(TurnAggregator::cloud_persistent(&emitted[0]));
     }
 
     #[test]
-    fn empty_agent_reply_is_not_cloud_persistent() {
+    fn empty_prose_idle_is_cloud_persistent_via_no_final_reply_notice() {
         let mut agg = TurnAggregator::new();
         agg.ingest(&status_change(
             amux::AgentStatus::Idle,
@@ -495,8 +540,7 @@ mod tests {
         ));
         assert_eq!(emitted.len(), 1);
         assert_eq!(emitted[0].kind, MessageKind::AgentReply);
-        assert!(emitted[0].content.is_empty());
-        assert!(!TurnAggregator::cloud_persistent(&emitted[0]));
+        assert!(TurnAggregator::cloud_persistent(&emitted[0]));
     }
 
     #[test]
@@ -575,6 +619,7 @@ mod tests {
         let r1 = agg.ingest(&tool_use("t1", "Read", "{}"));
         assert_eq!(r1.len(), 2); // reply flush + tool call
         assert_eq!(r1[0].kind, MessageKind::AgentReply);
+        assert!(!r1[0].cloud_persist);
         assert_eq!(r1[1].kind, MessageKind::AgentToolCall);
 
         let r2 = agg.ingest(&tool_result("t1", true, "done"));
@@ -586,12 +631,69 @@ mod tests {
         assert_eq!(r3.len(), 2);
         assert_eq!(r3[0].kind, MessageKind::AgentReply);
         assert_eq!(r3[0].content, "then ");
+        assert!(!r3[0].cloud_persist);
+        assert!(!TurnAggregator::cloud_persistent(&r3[0]));
         assert_eq!(r3[1].kind, MessageKind::AgentToolCall);
 
         let r4 = agg.ingest(&status_change(
             amux::AgentStatus::Active,
             amux::AgentStatus::Idle,
         ));
-        assert!(r4.is_empty()); // nothing buffered after the second tool
+        assert_eq!(r4.len(), 1);
+        assert_eq!(r4[0].kind, MessageKind::AgentReply);
+        assert_eq!(r4[0].content, NO_FINAL_REPLY_AGENT_CONTENT);
+        assert!(r4[0].cloud_persist);
+        assert!(TurnAggregator::cloud_persistent(&r4[0]));
+    }
+
+    #[test]
+    fn only_idle_final_reply_is_cloud_persistent() {
+        let mut agg = TurnAggregator::new();
+        agg.ingest(&status_change(
+            amux::AgentStatus::Idle,
+            amux::AgentStatus::Active,
+        ));
+        agg.ingest(&output_chunk("mid "));
+        let mid = agg.ingest(&tool_use("t1", "Bash", "pwd"));
+        assert_eq!(mid[0].kind, MessageKind::AgentReply);
+        assert_eq!(mid[0].content, "mid ");
+        assert!(!mid[0].cloud_persist);
+        assert!(!TurnAggregator::cloud_persistent(&mid[0]));
+
+        agg.ingest(&tool_result("t1", true, "/tmp"));
+        agg.ingest(&output_chunk("final answer"));
+        let idle = agg.ingest(&status_change(
+            amux::AgentStatus::Active,
+            amux::AgentStatus::Idle,
+        ));
+        assert_eq!(idle.len(), 1);
+        assert_eq!(idle[0].kind, MessageKind::AgentReply);
+        assert_eq!(idle[0].content, "final answer");
+        assert!(idle[0].cloud_persist);
+        assert!(TurnAggregator::cloud_persistent(&idle[0]));
+    }
+
+    #[test]
+    fn mid_flush_then_idle_without_prose_emits_no_final_reply_notice() {
+        let mut agg = TurnAggregator::new();
+        agg.ingest(&status_change(
+            amux::AgentStatus::Idle,
+            amux::AgentStatus::Active,
+        ));
+        agg.ingest(&output_chunk("mid "));
+        let mid = agg.ingest(&tool_use("t1", "Bash", "pwd"));
+        assert!(!TurnAggregator::cloud_persistent(&mid[0]));
+        agg.ingest(&tool_result("t1", true, "/tmp"));
+
+        let idle = agg.ingest(&status_change(
+            amux::AgentStatus::Active,
+            amux::AgentStatus::Idle,
+        ));
+        assert_eq!(idle.len(), 1);
+        assert_eq!(idle[0].content, NO_FINAL_REPLY_AGENT_CONTENT);
+        assert!(idle[0]
+            .metadata_json
+            .contains("\"turn_status\":\"no_final_reply\""));
+        assert!(TurnAggregator::cloud_persistent(&idle[0]));
     }
 }

--- a/apps/daemon/src/runtime/turn_aggregator.rs
+++ b/apps/daemon/src/runtime/turn_aggregator.rs
@@ -41,16 +41,16 @@ explicitly asks again.";
 const INTERRUPTED_REPLY_METADATA_JSON: &str = r#"{"turn_status":"interrupted"}"#;
 
 /// Durable AGENT_REPLY body when a turn ends at Idle with no final prose
-/// (tool-only, or all narration was mid-flushed before the last ToolUse).
+/// (tool-only, thinking-only, or all narration was mid-flushed before Idle).
 ///
 /// English so agent context / catchup understand completion. Frontends hide
 /// this notice when `metadata.turn_status == "no_final_reply"` and render a
 /// localized status strip.
 pub const NO_FINAL_REPLY_AGENT_CONTENT: &str = "\
-[Turn completed with no final reply] The agent finished this turn after tool \
-use without producing a final written answer. Treat the turn as successfully \
-completed. Do not invent a summary, continue the interrupted narration, or \
-re-run the tools unless the user explicitly asks.";
+[Turn completed with no final reply] The agent finished this turn without \
+producing a final written answer. Treat the turn as successfully completed. \
+Do not invent a summary, continue earlier narration, or re-run work unless \
+the user explicitly asks.";
 
 const NO_FINAL_REPLY_METADATA_JSON: &str = r#"{"turn_status":"no_final_reply"}"#;
 

--- a/apps/daemon/src/runtime/turn_aggregator.rs
+++ b/apps/daemon/src/runtime/turn_aggregator.rs
@@ -322,6 +322,15 @@ impl TurnAggregator {
             && !msg.content.trim().is_empty()
     }
 
+    /// English status notices (interrupt / no_final_reply) meant for agent
+    /// context and catchup — channel UIs must not treat them as user-visible
+    /// reply text.
+    pub fn is_agent_facing_status_notice(content: &str) -> bool {
+        let trimmed = content.trim_start();
+        trimmed.starts_with("[Turn interrupted by user]")
+            || trimmed.starts_with("[Turn completed with no final reply]")
+    }
+
     /// Current per-turn correlation id, or `None` between turns. Read by the
     /// publish path so outgoing `Envelope`s carry `turn_id`, letting clients
     /// dedupe `output isComplete=true` events by `(runtime_id, turn_id)`

--- a/apps/daemon/src/runtime/turn_aggregator.rs
+++ b/apps/daemon/src/runtime/turn_aggregator.rs
@@ -18,8 +18,11 @@
 //! - AgentThinking: `""` (no metadata)
 //! - AgentToolCall: `{"tool_id": str, "tool_name": str, "description": str}`
 //! - AgentToolResult: `{"tool_id": str, "success": bool}`
-//! - AgentReply: `""` normally; interrupted turns use
-//!   `{"turn_status":"interrupted"}` with non-empty agent-facing content
+//! - AgentReply: `""` normally; special turn endings use non-empty
+//!   agent-facing English content plus:
+//!   - `{"turn_status":"interrupted"}` — user abort
+//!   - `{"turn_status":"no_final_reply"}` — Idle with no final prose
+//!     (frontends hide the English notice and render a localized strip)
 //!
 //! Always emit all keys for a kind (use empty strings/false rather than
 //! omitting). New keys may be added; existing keys must not be removed

--- a/apps/daemon/src/teamclu/session_manager.rs
+++ b/apps/daemon/src/teamclu/session_manager.rs
@@ -1266,7 +1266,7 @@ impl SessionManager {
             warn!(?e, session_id, "persist_message failed");
         }
 
-        // 3. Backend (final replies only — see TurnAggregator::cloud_persistent).
+        // 3. Backend (turn-final AgentReply only — see TurnAggregator::cloud_persistent).
         // Await the insert: catchup after restart reads cloud messages, so a
         // fire-and-forget write can race with daemon shutdown and leave an
         // @mention unanswered (re-prompt after interrupt).

--- a/packages/app/src/components/chat/ChatMessage.tsx
+++ b/packages/app/src/components/chat/ChatMessage.tsx
@@ -102,6 +102,7 @@ export const ChatMessage = React.memo(function ChatMessage({
   const { t } = useTranslation();
   const isUser = message.role === "user";
   const isInterruptedTurn = !isUser && message.turnStatus === "interrupted";
+  const isNoFinalReplyTurn = !isUser && message.turnStatus === "no_final_reply";
   const [copied, setCopied] = React.useState(false);
   const [hydratedProcessParts, setHydratedProcessParts] = React.useState<
     MessagePart[] | null
@@ -626,6 +627,31 @@ export const ChatMessage = React.memo(function ChatMessage({
             {t(
               "chat.interrupt.agentReplyBodyKept",
               "You interrupted this reply. Generated content is kept.",
+            )}
+          </p>
+        </div>
+      ) : null}
+
+      {/* Daemon no_final_reply AGENT_REPLY — tool-complete without prose */}
+      {isNoFinalReplyTurn ? (
+        <div
+          className="mt-1 flex max-w-[520px] flex-wrap items-baseline gap-x-2 gap-y-1 pl-1 text-[12.5px] leading-[1.5] text-ink-2"
+          data-testid="no-final-reply"
+        >
+          <span
+            className="inline-block h-1.5 w-1.5 shrink-0 translate-y-[-1px] rounded-[1px] bg-muted-foreground/70"
+            aria-hidden
+          />
+          <span className="font-semibold">
+            {t("chat.noFinalReply.finishedTitle", "Turn finished")}
+          </span>
+          <span className="font-mono text-[11px] text-faint">
+            · {t("chat.noFinalReply.statusLabel", "no final reply")}
+          </span>
+          <p className="mt-0.5 w-full text-[12.5px] leading-[1.55] text-muted-foreground">
+            {t(
+              "chat.noFinalReply.description",
+              "Tools completed. No additional written reply was produced.",
             )}
           </p>
         </div>

--- a/packages/app/src/components/chat/ChatMessage.tsx
+++ b/packages/app/src/components/chat/ChatMessage.tsx
@@ -651,7 +651,7 @@ export const ChatMessage = React.memo(function ChatMessage({
           <p className="mt-0.5 w-full text-[12.5px] leading-[1.55] text-muted-foreground">
             {t(
               "chat.noFinalReply.description",
-              "Tools completed. No additional written reply was produced.",
+              "No additional written reply was produced.",
             )}
           </p>
         </div>

--- a/packages/app/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -334,7 +334,7 @@ describe('ChatMessage', () => {
     expect(text).toContain('Turn finished');
     expect(text).toContain('no final reply');
     expect(text).toContain(
-      'Tools completed. No additional written reply was produced.',
+      'No additional written reply was produced.',
     );
     expect(text).not.toContain('Turn completed with no final reply');
   });

--- a/packages/app/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -293,6 +293,52 @@ describe('ChatMessage', () => {
     ).toBe(true);
   });
 
+  it('renders no_final_reply agent status strip', () => {
+    const message = makeMessage({
+      id: 'msg-nfr-1',
+      role: 'assistant',
+      content: '',
+      parts: [
+        {
+          id: 'tool-part-1',
+          type: 'tool-call',
+          toolCallId: 't1',
+          toolCall: {
+            id: 't1',
+            name: 'bash',
+            status: 'completed',
+            arguments: {},
+            startTime: new Date(),
+          },
+        },
+      ],
+      toolCalls: [
+        {
+          id: 't1',
+          name: 'bash',
+          status: 'completed',
+          arguments: {},
+          startTime: new Date(),
+        },
+      ],
+      isStreaming: false,
+      senderActorId: 'actor-1',
+      turnStatus: 'no_final_reply',
+    });
+
+    const { container } = render(<ChatMessage message={message} />);
+    const text = container.textContent || '';
+    const strip = container.querySelector('[data-testid="no-final-reply"]');
+
+    expect(strip).toBeTruthy();
+    expect(text).toContain('Turn finished');
+    expect(text).toContain('no final reply');
+    expect(text).toContain(
+      'Tools completed. No additional written reply was produced.',
+    );
+    expect(text).not.toContain('Turn completed with no final reply');
+  });
+
   it('does not render hidden synthetic messages', () => {
     const message = makeMessage({
       id: 'msg-hidden',

--- a/packages/app/src/components/settings/ClawHubMarketplace.tsx
+++ b/packages/app/src/components/settings/ClawHubMarketplace.tsx
@@ -89,9 +89,11 @@ export const ClawHubMarketplace = React.memo(function ClawHubMarketplace({
 
   const searchTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const hasLoadedExploreRef = React.useRef(false)
+  const installedLoadGenRef = React.useRef(0)
 
   const loadInstalled = React.useCallback(async () => {
     if (!workspacePath) return
+    const loadGen = ++installedLoadGenRef.current
     const allSlugs = new Set<string>()
 
     const [, fsModule, pathModule] = await Promise.all([
@@ -101,6 +103,8 @@ export const ClawHubMarketplace = React.memo(function ClawHubMarketplace({
       import("@tauri-apps/plugin-fs").catch(() => null),
       import("@tauri-apps/api/path").catch(() => null),
     ])
+
+    if (loadGen !== installedLoadGenRef.current) return
 
     if (fsModule && pathModule) {
       try {
@@ -127,6 +131,7 @@ export const ClawHubMarketplace = React.memo(function ClawHubMarketplace({
       }
     }
 
+    if (loadGen !== installedLoadGenRef.current) return
     setInstalledSlugs(allSlugs)
   }, [workspacePath])
 
@@ -188,6 +193,11 @@ export const ClawHubMarketplace = React.memo(function ClawHubMarketplace({
     if (!hasLoadedExploreRef.current) {
       hasLoadedExploreRef.current = true
       loadExplore()
+    }
+    return () => {
+      // Invalidate in-flight installed scans so unmount cannot setState
+      // after the jsdom window is torn down (vitest teardown race).
+      installedLoadGenRef.current += 1
     }
   }, [loadInstalled, loadExplore])
 

--- a/packages/app/src/lib/__tests__/agent-reply-transcript.test.ts
+++ b/packages/app/src/lib/__tests__/agent-reply-transcript.test.ts
@@ -32,7 +32,7 @@ describe("agent reply transcript", () => {
         senderActorId: "a1",
         kind: MessageKind.AGENT_REPLY,
         content:
-          "[Turn completed with no final reply] The agent finished this turn after tool use without producing a final written answer.",
+          "[Turn completed with no final reply] The agent finished this turn without producing a final written answer.",
         metadataJson: JSON.stringify({ turn_status: "no_final_reply" }),
       }),
     ];

--- a/packages/app/src/lib/__tests__/agent-reply-transcript.test.ts
+++ b/packages/app/src/lib/__tests__/agent-reply-transcript.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   deriveAgentReplyContent,
+  isAgentFacingStatusNotice,
   joinTextPartsFromParts,
   splitAssistantProcessAndFinalParts,
   stripPriorTranscriptTextPrefix,
 } from "@/lib/agent-reply-transcript";
+import { create as createMessage } from "@bufbuild/protobuf";
+import { MessageKind, MessageSchema } from "@/lib/proto/teamclu_pb";
 
 describe("agent reply transcript", () => {
   it("joins multiple text parts for derived content", () => {
@@ -14,6 +17,28 @@ describe("agent reply transcript", () => {
       { type: "text", text: "Final?" },
     ];
     expect(joinTextPartsFromParts(parts)).toBe("Intro.\n\nFinal?");
+  });
+
+  it("ignores no_final_reply agent-facing notice when deriving content", () => {
+    expect(
+      isAgentFacingStatusNotice(
+        "[Turn completed with no final reply] The agent finished this turn",
+      ),
+    ).toBe(true);
+    const pending = [
+      createMessage(MessageSchema, {
+        messageId: "nfr-1",
+        sessionId: "s1",
+        senderActorId: "a1",
+        kind: MessageKind.AGENT_REPLY,
+        content:
+          "[Turn completed with no final reply] The agent finished this turn after tool use without producing a final written answer.",
+        metadataJson: JSON.stringify({ turn_status: "no_final_reply" }),
+      }),
+    ];
+    expect(deriveAgentReplyContent([{ type: "tool-call", toolCall: { id: "t1" } }], pending)).toBe(
+      "",
+    );
   });
 
   it("derives content from parts for ef30ac98 sandwich tools", () => {

--- a/packages/app/src/lib/__tests__/v2-message-adapter.test.ts
+++ b/packages/app/src/lib/__tests__/v2-message-adapter.test.ts
@@ -782,6 +782,24 @@ describe("adaptTeamcluMessages", () => {
     expect(result?.[0]?.parts ?? []).toEqual([]);
   });
 
+  it("maps no_final_reply AGENT_REPLY metadata to turnStatus and hides agent-facing body", () => {
+    const result = adaptTeamcluMessages([
+      tmsg({
+        kind: MessageKind.AGENT_REPLY,
+        content:
+          "[Turn completed with no final reply] The agent finished this turn after tool use without producing a final written answer.",
+        turnId: "t-nfr",
+        metadataJson: JSON.stringify({ turn_status: "no_final_reply" }),
+        replyToMessageId: "user-tools",
+      }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.turnStatus).toBe("no_final_reply");
+    expect(result?.[0]?.content).toBe("");
+    expect(result?.[0]?.replyToMessageId).toBe("user-tools");
+    expect(result?.[0]?.parts ?? []).toEqual([]);
+  });
+
   it("keeps generated prose on interrupted AGENT_REPLY and sets turnStatus", () => {
     const prose = "暮色从城市的边缘慢慢漫上来……";
     const result = adaptTeamcluMessages([

--- a/packages/app/src/lib/__tests__/v2-message-adapter.test.ts
+++ b/packages/app/src/lib/__tests__/v2-message-adapter.test.ts
@@ -787,7 +787,7 @@ describe("adaptTeamcluMessages", () => {
       tmsg({
         kind: MessageKind.AGENT_REPLY,
         content:
-          "[Turn completed with no final reply] The agent finished this turn after tool use without producing a final written answer.",
+          "[Turn completed with no final reply] The agent finished this turn without producing a final written answer.",
         turnId: "t-nfr",
         metadataJson: JSON.stringify({ turn_status: "no_final_reply" }),
         replyToMessageId: "user-tools",

--- a/packages/app/src/lib/agent-reply-transcript.ts
+++ b/packages/app/src/lib/agent-reply-transcript.ts
@@ -14,6 +14,24 @@ export type TranscriptPart = {
 };
 
 /**
+ * Daemon English status notices stored on AGENT_REPLY for agent context /
+ * catchup. Live merge and UI display must treat them as empty prose.
+ */
+export function isAgentFacingStatusNotice(content: string): boolean {
+  const trimmed = content.trimStart();
+  return (
+    trimmed.startsWith("[Turn interrupted by user]") ||
+    trimmed.startsWith("[Turn completed with no final reply]")
+  );
+}
+
+function pendingReplyProse(message: TeamcluMessage): string {
+  const text = message.content?.trim() ?? "";
+  if (!text || isAgentFacingStatusNotice(text)) return "";
+  return text;
+}
+
+/**
  * Todo-list tools carry no answer content and agents routinely emit one *after*
  * the substantive reply to mark the work done. They must not anchor the
  * process/final boundary, or that trailing call buries the real answer inside
@@ -151,11 +169,12 @@ export function deriveAgentReplyContent(
   const textParts = parts.filter(
     (part) => part.type === "text" && Boolean((part.text || part.content)?.trim()),
   );
-  const daemonFinal = pending[pending.length - 1]?.content?.trim() ?? "";
+  const lastPending = pending[pending.length - 1];
+  const daemonFinal = lastPending ? pendingReplyProse(lastPending) : "";
 
   if (textParts.length === 0) {
     const joinedPending = pending
-      .map((message) => message.content?.trim())
+      .map((message) => pendingReplyProse(message))
       .filter(Boolean)
       .filter((text, index, all) => index === 0 || text !== all[index - 1])
       .join("\n\n");

--- a/packages/app/src/lib/live-agent-stream.ts
+++ b/packages/app/src/lib/live-agent-stream.ts
@@ -5,7 +5,7 @@ import { MessageKind, MessageSchema } from "@/lib/proto/teamclu_pb";
 import type { AgentStreamEntry } from "@/stores/v2-streaming-store";
 import type { ToolCallContentBlock } from "@/components/chat/tool-calls/tool-call-content";
 import { parseToolContentBlocks } from "@/components/chat/tool-calls/tool-call-content";
-import { deriveAgentReplyContent } from "@/lib/agent-reply-transcript";
+import { deriveAgentReplyContent, isAgentFacingStatusNotice } from "@/lib/agent-reply-transcript";
 import { agentReplyTextsEquivalent } from "@/lib/agent-reply-text";
 import { getFlushedTurn } from "@/lib/flushed-turn-registry";
 import { isStreamInterruptible } from "@/stores/v2-streaming-store";
@@ -58,7 +58,7 @@ export function joinDistinctPendingReplyChunks(pending: TeamcluMessage[]): strin
   const chunks: string[] = [];
   for (const message of pending) {
     const text = message.content?.trim();
-    if (!text) continue;
+    if (!text || isAgentFacingStatusNotice(text)) continue;
     const previous = chunks[chunks.length - 1];
     if (!previous) {
       chunks.push(text);

--- a/packages/app/src/lib/v2-message-adapter.ts
+++ b/packages/app/src/lib/v2-message-adapter.ts
@@ -54,20 +54,25 @@ export function adaptTeamcluMessageToSdk(m: TeamcluMessage): SdkMessage {
   const replyTo = m.replyToMessageId?.trim() || undefined;
   const turnId = m.turnId?.trim() || undefined;
   const interrupted = isInterruptedReply(m);
+  const noFinalReply = isNoFinalReply(m);
   const displayContent = displayContentForReply(m);
   return {
     id: m.messageId,
     sessionId: m.sessionId,
     senderActorId: m.senderActorId,
     role: kindToRole(m.kind),
-    // Keep generated prose; only hide the English agent-facing interrupt notice.
+    // Keep generated prose; only hide English agent-facing status notices.
     content: displayContent,
     mentionActorIds,
     mentionDeliverySnapshot,
     modelID: m.model || undefined,
     replyToMessageId: replyTo,
     turnId,
-    turnStatus: interrupted ? "interrupted" : undefined,
+    turnStatus: interrupted
+      ? "interrupted"
+      : noFinalReply
+        ? "no_final_reply"
+        : undefined,
     parts: displayContent
       ? [
           {
@@ -95,22 +100,35 @@ function isInterruptedReply(m: TeamcluMessage): boolean {
   return parseMetadata(m).turn_status === "interrupted";
 }
 
+function isNoFinalReply(m: TeamcluMessage): boolean {
+  if (parseMetadata(m).turn_status === "no_final_reply") return true;
+  return isAgentFacingNoFinalReplyNotice(m.content ?? "");
+}
+
 /** Daemon English instruction when there was no prose to keep. */
 function isAgentFacingInterruptNotice(content: string): boolean {
   return content.trimStart().startsWith("[Turn interrupted by user]");
 }
 
-/** User-visible body for an AGENT_REPLY (hide interrupt instruction only). */
+function isAgentFacingNoFinalReplyNotice(content: string): boolean {
+  return content.trimStart().startsWith("[Turn completed with no final reply]");
+}
+
+/** User-visible body for an AGENT_REPLY (hide agent-facing status notices). */
 function displayContentForReply(m: TeamcluMessage): string {
   const raw = m.content ?? "";
-  if (isInterruptedReply(m) && isAgentFacingInterruptNotice(raw)) return "";
+  if (isAgentFacingInterruptNotice(raw) || isAgentFacingNoFinalReplyNotice(raw)) {
+    return "";
+  }
   return raw;
 }
 
 function turnStatusFromReplies(
   replies: TeamcluMessage[],
-): "interrupted" | undefined {
-  return replies.some(isInterruptedReply) ? "interrupted" : undefined;
+): "interrupted" | "no_final_reply" | undefined {
+  if (replies.some(isInterruptedReply)) return "interrupted";
+  if (replies.some(isNoFinalReply)) return "no_final_reply";
+  return undefined;
 }
 
 function parseDisplayMentionActorIds(m: TeamcluMessage): string[] {

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -691,7 +691,7 @@
     "noFinalReply": {
       "finishedTitle": "Turn finished",
       "statusLabel": "no final reply",
-      "description": "Tools completed. No additional written reply was produced."
+      "description": "No additional written reply was produced."
     },
     "acpDebug": {
       "title": "ACP stream debug",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -688,6 +688,11 @@
       "interruptedStatusLabel": "interrupted",
       "agentReplyBodyKept": "You interrupted this reply. Generated content is kept."
     },
+    "noFinalReply": {
+      "finishedTitle": "Turn finished",
+      "statusLabel": "no final reply",
+      "description": "Tools completed. No additional written reply was produced."
+    },
     "acpDebug": {
       "title": "ACP stream debug",
       "lineCount": "{{count}} line",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -691,7 +691,7 @@
     "noFinalReply": {
       "finishedTitle": "本轮已结束",
       "statusLabel": "no final reply",
-      "description": "工具调用已完成，没有额外的文字回复。"
+      "description": "没有额外的文字回复。"
     },
     "acpDebug": {
       "title": "ACP 流调试",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -688,6 +688,11 @@
       "interruptedStatusLabel": "中断",
       "agentReplyBodyKept": "你已打断本次回复。已生成的内容会保留。"
     },
+    "noFinalReply": {
+      "finishedTitle": "本轮已结束",
+      "statusLabel": "no final reply",
+      "description": "工具调用已完成，没有额外的文字回复。"
+    },
     "acpDebug": {
       "title": "ACP 流调试",
       "lineCount": "{{count}} 条",

--- a/packages/app/src/stores/mqtt-reconnect.test.ts
+++ b/packages/app/src/stores/mqtt-reconnect.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   useMqttReconnectStore,
   isMqttAuthFailure,
@@ -8,10 +8,56 @@ import {
   resetMqttReconnectRecovery,
   __resetMqttReconnectForTests,
   __markAuthRecoveryForTests,
+  BROWSER_RECONNECT_GRACE_MS,
 } from './mqtt-reconnect'
 
 vi.mock('@/lib/auth/session-store', () => ({
   refreshSession: vi.fn().mockResolvedValue(undefined),
+}))
+
+/**
+ * Hoisted mocks for the browser ensureWired path.
+ *
+ * `vi.doMock` + `vi.resetModules()` + dynamic `import()` is flaky on CI: the
+ * real `@/lib/mqtt-browser-bridge` sometimes wins the race, `stateHandler`
+ * stays null, and `waitFor(bridge subscribed)` times out. Hoisted `vi.mock`
+ * is applied before any import, so the dynamic import in `ensureWired` always
+ * hits the stub.
+ */
+const browserBridgeHandlers = vi.hoisted(() => {
+  const handlers: {
+    stateHandler: ((state: 'connecting' | 'connected' | 'disconnected') => void) | null
+    errorHandler: ((message: string) => void) | null
+  } = {
+    stateHandler: null,
+    errorHandler: null,
+  }
+  return handlers
+})
+
+vi.mock('@/lib/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/utils')>()
+  return {
+    ...actual,
+    isTauri: () => false,
+  }
+})
+
+vi.mock('@/lib/mqtt-browser-bridge', () => ({
+  subscribeBrowserMqttState: (
+    h: (s: 'connecting' | 'connected' | 'disconnected') => void,
+  ) => {
+    browserBridgeHandlers.stateHandler = h
+    return () => {
+      browserBridgeHandlers.stateHandler = null
+    }
+  },
+  subscribeBrowserMqttError: (h: (msg: string) => void) => {
+    browserBridgeHandlers.errorHandler = h
+    return () => {
+      browserBridgeHandlers.errorHandler = null
+    }
+  },
 }))
 
 describe('useMqttReconnectStore', () => {
@@ -163,103 +209,65 @@ describe('resetMqttReconnectRecovery', () => {
 })
 
 /**
- * Poll until `check()` holds, instead of sleeping a fixed amount and hoping.
- *
- * `ensureWired()` reaches the bridge through a dynamic `import()`, so the
- * subscription lands an unpredictable number of microtasks later. This suite
- * used to wait a flat 20ms for that, which is plenty on a dev laptop and not
- * always enough on a CI runner — `stateHandler` was still null, and calling it
- * threw `stateHandler is not a function`. That single gamble was behind every
- * red CI run on main over the last 25 builds.
- *
+ * Poll until `check()` holds. `ensureWired()` reaches the bridge through
+ * dynamic imports, so the subscription lands a few microtasks later.
  * Must only be used on real timers.
  */
 async function waitFor(check: () => boolean, label: string, timeoutMs = 2000): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     if (check()) return
+    await Promise.resolve()
     await new Promise((r) => setTimeout(r, 5))
   }
   throw new Error(`waitFor(${label}): condition still false after ${timeoutMs}ms`)
 }
 
 describe('useMqttReconnectStore — ensureWired browser path', () => {
-  let stateHandler: ((state: 'connecting' | 'connected' | 'disconnected') => void) | null = null
-  let errorHandler: ((message: string) => void) | null = null
-
   beforeEach(async () => {
-    stateHandler = null
-    errorHandler = null
-
-    // Mock isTauri() => false (jsdom is already non-Tauri, but make it explicit)
-    vi.doMock('@/lib/utils', () => ({
-      isTauri: () => false,
-      cn: (...args: string[]) => args.join(' '),
-    }))
-
-    // Mock the browser bridge to capture subscriptions
-    vi.doMock('@/lib/mqtt-browser-bridge', () => ({
-      subscribeBrowserMqttState: (h: (s: 'connecting' | 'connected' | 'disconnected') => void) => {
-        stateHandler = h
-        return () => { stateHandler = null }
-      },
-      subscribeBrowserMqttError: (h: (msg: string) => void) => {
-        errorHandler = h
-        return () => { errorHandler = null }
-      },
-    }))
-
-    // Reset store state and _wired flag so ensureWired runs fresh each test
+    browserBridgeHandlers.stateHandler = null
+    browserBridgeHandlers.errorHandler = null
+    __resetMqttReconnectForTests()
     useMqttReconnectStore.setState({ nonce: 0, lastError: null, connected: null, _wired: false })
-
-    // Clear module cache so dynamic imports pick up the new mocks
-    vi.resetModules()
-  })
-
-  afterEach(() => {
-    vi.doUnmock('@/lib/utils')
-    vi.doUnmock('@/lib/mqtt-browser-bridge')
+    const { refreshSession } = await import('@/lib/auth/session-store')
+    vi.mocked(refreshSession).mockClear()
   })
 
   it('ensureWired in browser path subscribes to state and error from bridge', async () => {
-    // Re-import fresh module to pick up mocks
-    const { useMqttReconnectStore: store } = await import('./mqtt-reconnect')
-    store.setState({ _wired: false, connected: null, lastError: null })
-    store.getState().ensureWired()
+    useMqttReconnectStore.getState().ensureWired()
 
-    await waitFor(() => stateHandler !== null && errorHandler !== null, 'bridge subscribed')
+    await waitFor(
+      () =>
+        browserBridgeHandlers.stateHandler !== null &&
+        browserBridgeHandlers.errorHandler !== null,
+      'bridge subscribed',
+    )
 
+    const { stateHandler, errorHandler } = browserBridgeHandlers
     expect(stateHandler).not.toBeNull()
     expect(errorHandler).not.toBeNull()
 
-    // 'disconnected' state -> connected=false
     stateHandler!('disconnected')
-    expect(store.getState().connected).toBe(false)
+    expect(useMqttReconnectStore.getState().connected).toBe(false)
 
-    // 'connected' state -> connected=true
     stateHandler!('connected')
-    expect(store.getState().connected).toBe(true)
+    expect(useMqttReconnectStore.getState().connected).toBe(true)
 
-    // 'connecting' state -> connected=null
     stateHandler!('connecting')
-    expect(store.getState().connected).toBeNull()
+    expect(useMqttReconnectStore.getState().connected).toBeNull()
 
-    // error -> lastError set
     errorHandler!('broker auth failure')
-    expect(store.getState().lastError).toBe('broker auth failure')
+    expect(useMqttReconnectStore.getState().lastError).toBe('broker auth failure')
   })
 
   it('refreshes credentials and bumps reconnect when a browser MQTT disconnect outlasts the grace window', async () => {
     const { refreshSession } = await import('@/lib/auth/session-store')
-    vi.mocked(refreshSession).mockClear()
-    const { useMqttReconnectStore: store, BROWSER_RECONNECT_GRACE_MS } = await import('./mqtt-reconnect')
-    store.setState({ _wired: false, connected: null, lastError: null, nonce: 0 })
-    store.getState().ensureWired()
-    await waitFor(() => stateHandler !== null, 'bridge subscribed')
+    useMqttReconnectStore.getState().ensureWired()
+    await waitFor(() => browserBridgeHandlers.stateHandler !== null, 'bridge subscribed')
 
     vi.useFakeTimers()
     try {
-      stateHandler!('disconnected')
+      browserBridgeHandlers.stateHandler!('disconnected')
       // Inside the grace window mqtt.js auto-reconnect owns recovery.
       await vi.advanceTimersByTimeAsync(BROWSER_RECONNECT_GRACE_MS - 1000)
       expect(refreshSession).not.toHaveBeenCalled()
@@ -271,22 +279,19 @@ describe('useMqttReconnectStore — ensureWired browser path', () => {
     await waitFor(() => vi.mocked(refreshSession).mock.calls.length > 0, 'refreshSession called')
 
     expect(refreshSession).toHaveBeenCalledOnce()
-    expect(store.getState().nonce).toBe(1)
+    expect(useMqttReconnectStore.getState().nonce).toBe(1)
   })
 
   it('does not refresh credentials when auto-reconnect restores within the grace window', async () => {
     const { refreshSession } = await import('@/lib/auth/session-store')
-    vi.mocked(refreshSession).mockClear()
-    const { useMqttReconnectStore: store, BROWSER_RECONNECT_GRACE_MS } = await import('./mqtt-reconnect')
-    store.setState({ _wired: false, connected: null, lastError: null, nonce: 0 })
-    store.getState().ensureWired()
-    await waitFor(() => stateHandler !== null, 'bridge subscribed')
+    useMqttReconnectStore.getState().ensureWired()
+    await waitFor(() => browserBridgeHandlers.stateHandler !== null, 'bridge subscribed')
 
     vi.useFakeTimers()
     try {
-      stateHandler!('disconnected')
+      browserBridgeHandlers.stateHandler!('disconnected')
       await vi.advanceTimersByTimeAsync(3000)
-      stateHandler!('connected')
+      browserBridgeHandlers.stateHandler!('connected')
       await vi.advanceTimersByTimeAsync(BROWSER_RECONNECT_GRACE_MS * 2)
     } finally {
       vi.useRealTimers()
@@ -296,23 +301,22 @@ describe('useMqttReconnectStore — ensureWired browser path', () => {
     await new Promise((r) => setTimeout(r, 20))
 
     expect(refreshSession).not.toHaveBeenCalled()
-    expect(store.getState().nonce).toBe(0)
+    expect(useMqttReconnectStore.getState().nonce).toBe(0)
   })
 
   it('refreshes credentials and bumps reconnect on browser MQTT auth failure', async () => {
     const { refreshSession } = await import('@/lib/auth/session-store')
-    vi.mocked(refreshSession).mockClear()
-    const { useMqttReconnectStore: store } = await import('./mqtt-reconnect')
-    store.setState({ _wired: false, connected: null, lastError: null, nonce: 0 })
-    store.getState().ensureWired()
+    useMqttReconnectStore.getState().ensureWired()
 
-    await waitFor(() => errorHandler !== null, 'bridge subscribed')
-    errorHandler!('Connection refused: bad_username_or_password')
-    expect(store.getState().lastError).toBe('Connection refused: bad_username_or_password')
+    await waitFor(() => browserBridgeHandlers.errorHandler !== null, 'bridge subscribed')
+    browserBridgeHandlers.errorHandler!('Connection refused: bad_username_or_password')
+    expect(useMqttReconnectStore.getState().lastError).toBe(
+      'Connection refused: bad_username_or_password',
+    )
     await waitFor(() => vi.mocked(refreshSession).mock.calls.length > 0, 'refreshSession called')
 
     expect(refreshSession).toHaveBeenCalledOnce()
-    expect(store.getState().nonce).toBe(1)
-    expect(store.getState().lastError).toBeNull()
+    expect(useMqttReconnectStore.getState().nonce).toBe(1)
+    expect(useMqttReconnectStore.getState().lastError).toBeNull()
   })
 })

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -178,7 +178,7 @@ export interface Message {
   /** ACP turn correlation id when available (debug / grouping). */
   turnId?: string | null;
   /** Daemon AGENT_REPLY metadata.turn_status — e.g. user abort. */
-  turnStatus?: "interrupted" | null;
+  turnStatus?: "interrupted" | "no_final_reply" | null;
   /** Historical turn: process parts omitted until user expands collapsible. */
   processDeferred?: boolean;
   /** Lightweight process summary while {@link processDeferred} is true. */


### PR DESCRIPTION
## Summary
- Daemon 仅在 Active→Idle（含 interrupted）将非空最终 `AgentReply` 写入云端；ToolUse 前的中间切片只走 MQTT + 本地 TOML
- Idle 无最终正文时写入 `turn_status: no_final_reply` 英文 notice，保证 catchup 仍能看到 agent 行、避免重启后误重跑 @mention
- 桌面端隐藏英文 notice，按多语言渲染「本轮已结束」状态条（对齐 interrupted 样式）

## Test plan
- [ ] 重启 amuxd 后：多 tool 轮次（中间有叙述 + 有最终总结）→ 云端仅 1 条最终正文
- [ ] 多 tool 轮次结束无最终文字 → 云端 1 条 `no_final_reply`；UI 显示「本轮已结束 / Turn finished」，不展示英文 notice
- [ ] 用户打断 → 仍为 interrupted 状态条
- [ ] `cargo test -p amuxd turn_aggregator`
- [ ] `vitest`：`v2-message-adapter` / `ChatMessage` / `agent-reply-transcript`


Made with [Cursor](https://cursor.com)