### PR TITLE
feat(db)!: 删掉 member re-invite（它的目标用户根本进不来）

### DIFF
--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -356,7 +356,12 @@ paths:
                     - string
                     - "null"
                   format: uuid
-                  description: Re-invite an existing actor instead of creating a new one.
+                  description: >-
+                    Re-invite an existing actor instead of creating a new one.
+                    Agent invites only — it rotates the daemon's credentials onto
+                    the same actor. Rejected with 22023 for `kind: member`; the
+                    member equivalent was removed because its claim side could
+                    never be reached by the person the link was for.
                 inviteEmail:
                   type:
                     - string

--- a/packages/app/src/components/sidebar/ActorDetailDialog.tsx
+++ b/packages/app/src/components/sidebar/ActorDetailDialog.tsx
@@ -67,14 +67,6 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
   const [clientVersions, setClientVersions] = React.useState<ClientVersionEntry[]>([])
   const [detailAvatarUrl, setDetailAvatarUrl] = React.useState<string | null>(null)
   const [avatarFailed, setAvatarFailed] = React.useState(false)
-  // Freshest member contact from the detail fetch — used to decide whether the
-  // member is a registered (non-anonymous) account. The libsql first-paint cache
-  // doesn't carry email/phone, so we enrich from the detail fetch when it lands.
-  const [detailContact, setDetailContact] = React.useState<{ email: string | null; phone: string | null }>({
-    email: null,
-    phone: null,
-  })
-
   // Reset the re-invite result whenever the dialog targets a different actor
   // (or is reopened) so a stale link from a previous actor never leaks through.
   React.useEffect(() => {
@@ -84,14 +76,13 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
     setRemoving(false)
   }, [actor?.id])
 
-  // Fetch the full actor detail (client versions + freshest avatar/contact) when
-  // the dialog targets an actor. Guarded so a backend hiccup never breaks render.
+  // Fetch the full actor detail (client versions + freshest avatar) when the
+  // dialog targets an actor. Guarded so a backend hiccup never breaks render.
   React.useEffect(() => {
     const id = actor?.id
     setClientVersions([])
     setDetailAvatarUrl(null)
     setAvatarFailed(false)
-    setDetailContact({ email: null, phone: null })
     if (!id) return
     let cancelled = false
     void (async () => {
@@ -100,7 +91,6 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
         if (cancelled || !entry) return
         setClientVersions(entry.client_versions ?? [])
         if (entry.avatar_url) setDetailAvatarUrl(entry.avatar_url)
-        setDetailContact({ email: entry.email ?? null, phone: entry.phone ?? null })
       } catch {
         // Detail enrichment is best-effort; keep the cached-row view.
       }
@@ -132,17 +122,6 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
       setRemoving(false)
     }
   }
-
-  // A member with a bound (non-anonymous) auth identity carries an email or
-  // phone; anonymous members carry neither. Re-invite rotates the actor onto a
-  // fresh auth user, which only makes sense for anonymous members — the server
-  // rejects it for registered members ("cannot re-invite member with bound auth
-  // identity"). Gate the button on the contact signal we already have so we
-  // never offer an action that can only fail. Use the freshest of the cached
-  // row and the detail fetch.
-  const memberHasBoundIdentity =
-    !isAgent &&
-    Boolean(displayActor.email || displayActor.phone || detailContact.email || detailContact.phone)
 
   const online = resolveActorOnlineStatus(displayActor, {
     currentMemberActorId: currentMemberId,
@@ -219,28 +198,19 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
     if (!teamId || reinviting) return
     setReinviting(true)
     try {
-      // targetActorId rotates credentials on this existing actor (re-invite)
-      // instead of minting a new one — mirrors the iOS "Re-invite" flow.
-      const row = isAgent
-        ? await getBackend().teams.createTeamInvite({
-            teamId,
-            kind: 'agent',
-            displayName: displayActor.display_name,
-            agentKind: 'daemon',
-            ttlSeconds: null,
-            targetActorId: displayActor.id,
-          })
-        : await getBackend().teams.createTeamInvite({
-            teamId,
-            kind: 'member',
-            displayName: displayActor.display_name,
-            teamRole:
-              displayActor.team_role === 'admin' || displayActor.team_role === 'owner'
-                ? displayActor.team_role
-                : 'member',
-            ttlSeconds: null,
-            targetActorId: displayActor.id,
-          })
+      // targetActorId rotates credentials on this existing agent actor instead
+      // of minting a new one. Agents only: the member equivalent was removed in
+      // 20260811110000 (the claim side could never be reached by the person it
+      // was for), and the server now rejects a member invite that names a
+      // target.
+      const row = await getBackend().teams.createTeamInvite({
+        teamId,
+        kind: 'agent',
+        displayName: displayActor.display_name,
+        agentKind: 'daemon',
+        ttlSeconds: null,
+        targetActorId: displayActor.id,
+      })
       const deeplink = row.deeplink ?? row.inviteUrl
       if (!deeplink) {
         toast.error(t('invite.failed', 'Failed to create invite: {{msg}}', { msg: 'empty response' }))
@@ -252,19 +222,7 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
       })
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
-      // Safety net for members whose bound identity isn't visible client-side
-      // (e.g. OAuth without email/phone): the server rejects re-invite with a
-      // raw English message — surface a friendly localized reason instead.
-      if (/bound auth identity/i.test(msg)) {
-        toast.error(
-          t(
-            'actors.reinvite.memberBound',
-            'This member has a registered account and can sign in again — re-invite is only for anonymous accounts.',
-          ),
-        )
-      } else {
-        toast.error(t('invite.failed', 'Failed to create invite: {{msg}}', { msg }))
-      }
+      toast.error(t('invite.failed', 'Failed to create invite: {{msg}}', { msg }))
     } finally {
       setReinviting(false)
     }
@@ -470,18 +428,14 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
             </div>
           )}
 
-          {teamId && (
+          {/* Agents only. Member re-invite was removed in 20260811110000. */}
+          {teamId && isAgent && (
             <div className="mt-8 border-t border-border-soft pt-5">
               <div className="mb-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-faint">
                 {t('actors.reinvite.title', 'Re-invite')}
               </div>
               <p className="mb-4 text-[12px] leading-5 text-muted-foreground">
-                {isAgent
-                  ? t('actors.reinvite.agentHint', 'Use this if the daemon was wiped and needs to re-pair.')
-                  : t(
-                      'actors.reinvite.memberHint',
-                      'Use this if the user signed out and lost access. Only available for anonymous accounts.',
-                    )}
+                {t('actors.reinvite.agentHint', 'Use this if the daemon was wiped and needs to re-pair.')}
               </p>
               {reinvite ? (
                 <div className="flex flex-col gap-2">
@@ -502,16 +456,6 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
                     })}
                   </p>
                 </div>
-              ) : memberHasBoundIdentity ? (
-                // Registered members can sign in again on their own — re-invite
-                // is reserved for anonymous accounts, so we explain rather than
-                // offer a button that the server would only reject.
-                <p className="text-[12px] leading-5 text-faint">
-                  {t(
-                    'actors.reinvite.memberBound',
-                    'This member has a registered account and can sign in again — re-invite is only for anonymous accounts.',
-                  )}
-                </p>
               ) : (
                 <Button
                   variant="outline"
@@ -520,9 +464,7 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
                   className="h-9 rounded-[9px] border-border-soft bg-background text-[13px]"
                 >
                   {reinviting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Link2 className="h-4 w-4" />}
-                  {isAgent
-                    ? t('actors.reinvite.agentButton', 'Regenerate invite link')
-                    : t('actors.reinvite.memberButton', 'Generate re-invite link')}
+                  {t('actors.reinvite.agentButton', 'Regenerate invite link')}
                 </Button>
               )}
             </div>

--- a/packages/app/src/components/sidebar/__tests__/ActorDetailDialog.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/ActorDetailDialog.test.tsx
@@ -209,7 +209,13 @@ describe('ActorDetailDialog', () => {
     expect(mockGetActorDirectoryEntry).toHaveBeenCalledWith('actor-1')
   })
 
-  it('hides the member re-invite button for a member with a bound identity (email)', () => {
+  // Member re-invite was removed in 20260811110000: the server rejects a member
+  // invite that names a target actor, so the dialog offers nothing here for a
+  // member — registered or anonymous.
+  it.each([
+    ['a registered member', 'matt@example.com'],
+    ['an anonymous member', undefined],
+  ])('shows no re-invite section for %s', (_label, email) => {
     render(
       <ActorDetailDialog
         actor={{
@@ -219,36 +225,15 @@ describe('ActorDetailDialog', () => {
           member_status: 'iOS',
           agent_status: null,
           last_active_at: new Date().toISOString(),
-          email: 'matt@example.com',
+          ...(email ? { email } : {}),
         }}
         teamId="team-abc"
         onOpenChange={vi.fn()}
       />,
     )
 
-    // A registered (non-anonymous) member can't be re-invited — the button is
-    // replaced by explanatory text so we never surface the raw server error.
-    expect(screen.queryByRole('button', { name: /Generate re-invite link/i })).not.toBeInTheDocument()
-    expect(screen.getByText(/This member has a registered account/i)).toBeInTheDocument()
-  })
-
-  it('shows the member re-invite button for an anonymous member (no email/phone)', () => {
-    render(
-      <ActorDetailDialog
-        actor={{
-          id: 'actor-1',
-          actor_type: 'member',
-          display_name: 'Matt-iOS',
-          member_status: 'iOS',
-          agent_status: null,
-          last_active_at: new Date().toISOString(),
-        }}
-        teamId="team-abc"
-        onOpenChange={vi.fn()}
-      />,
-    )
-
-    expect(screen.getByRole('button', { name: /Generate re-invite link/i })).toBeInTheDocument()
+    expect(screen.queryByText('Re-invite')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /re-invite link/i })).not.toBeInTheDocument()
   })
 
   it('still shows the re-invite button for an agent regardless of contact', () => {

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -3134,10 +3134,7 @@
     "reinvite": {
       "title": "Re-invite",
       "agentHint": "Use this if the daemon was wiped and needs to re-pair.",
-      "memberHint": "Use this if the user signed out and lost access. Only available for anonymous accounts.",
-      "agentButton": "Regenerate invite link",
-      "memberButton": "Generate re-invite link",
-      "memberBound": "This member has a registered account and can sign in again — re-invite is only for anonymous accounts."
+      "agentButton": "Regenerate invite link"
     }
   },
   "ideas": {

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -3134,10 +3134,7 @@
     "reinvite": {
       "title": "重新邀请",
       "agentHint": "如果 daemon 已被清空、需要重新配对，请使用此功能。",
-      "memberHint": "如果该用户已退出登录并失去访问权限，请使用此功能。仅适用于匿名账户。",
-      "agentButton": "重新生成邀请链接",
-      "memberButton": "生成重新邀请链接",
-      "memberBound": "该成员已是注册账户，可自行重新登录——重新邀请仅适用于匿名账户。"
+      "agentButton": "重新生成邀请链接"
     }
   },
   "ideas": {

--- a/services/fc/src/lib/pg-repo/teams.ts
+++ b/services/fc/src/lib/pg-repo/teams.ts
@@ -744,6 +744,15 @@ export function makeTeamsRepo(db: PgDatabase<any, any>, deps: TeamsRepoDeps = {}
         }
       }
 
+      // Member re-invite was removed in 20260811110000, and this backend never
+      // implemented it: the rebind path in auth.ts lives inside the agent claim
+      // branch. Reject it by name rather than letting it fall through to the
+      // agent-ownership check below and come back as "only the agent owner can
+      // re-invite this agent", which says nothing true about a member.
+      if (input.targetActorId && kind === "member") {
+        throw new ApiError(400, "validation_failed", "member invites cannot target an existing actor");
+      }
+
       // Owner check: only the agent owner may re-invite an existing agent actor
       if (input.targetActorId) {
         if (!userId) throw new ApiError(401, "missing_identity", "re-inviting an agent requires authentication");

--- a/services/supabase/migrations/20260811110000_remove_member_reinvite.sql
+++ b/services/supabase/migrations/20260811110000_remove_member_reinvite.sql
@@ -1,0 +1,268 @@
+-- Remove member re-invite.
+--
+-- The feature never worked as designed, and had not been able to work since
+-- 20260801010000. Its three parts disagreed:
+--
+--   * create_team_invite accepted p_target_actor_id for a member only when the
+--     target's auth user was anonymous;
+--   * claim_team_invite_legacy's member branch kept the actor on that anonymous
+--     user and minted a fresh session + refresh token FOR IT -- device recovery,
+--     handing the anonymous membership back on a new machine;
+--   * but claim_team_invite's wrapper (20260801010000) refuses anonymous and
+--     bearerless callers for every member invite, and the person on the new
+--     device is exactly that caller.
+--
+-- So the only caller who could redeem such a link was somebody already signed
+-- into a real account, who would then be handed credentials for the anonymous
+-- one -- their own account gaining nothing. Meanwhile nothing mints
+-- anonymous-bound members any more (claim_team_invite and join_public_team both
+-- refuse anonymous callers), so the targets themselves are legacy rows.
+--
+-- Rather than keep an unreachable path that reads as working code, it goes.
+-- p_target_actor_id stays on the signature and keeps working for AGENT invites:
+-- daemon credential rotation depends on it (see 021_agent_reinvite_owner_check
+-- and claim_team_invite_agent_org).
+--
+-- Both functions are reproduced from their live definitions with only the
+-- member-target blocks replaced.
+
+CREATE OR REPLACE FUNCTION amux.create_team_invite(p_team_id uuid, p_kind text, p_display_name text, p_team_role text DEFAULT NULL::text, p_agent_kind text DEFAULT NULL::text, p_ttl_seconds integer DEFAULT 604800, p_target_actor_id uuid DEFAULT NULL::uuid, p_invite_email text DEFAULT NULL::text, p_invite_phone text DEFAULT NULL::text)
+ RETURNS TABLE(token text, expires_at timestamp with time zone, deeplink text)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'amux', 'public', 'auth', 'app'
+AS $function$
+declare
+  v_caller uuid := amux.current_actor_id_for_team(p_team_id);
+  v_token  text := translate(
+                     encode(extensions.gen_random_bytes(24), 'base64'),
+                     '+/=', '-_0'
+                   );
+  v_expires timestamptz := now() + make_interval(secs => greatest(60, p_ttl_seconds));
+  v_kind    text;
+  v_role    text;
+  v_target  amux.actors%rowtype;
+  v_target_anon boolean;
+  v_email   text;
+  v_phone   text;
+begin
+  if v_caller is null then
+    raise exception 'create_team_invite requires team membership'
+      using errcode = '42501';
+  end if;
+
+  v_kind := lower(coalesce(p_kind, ''));
+  if v_kind not in ('member','agent') then
+    raise exception 'p_kind must be member or agent' using errcode = '22023';
+  end if;
+
+  v_email := nullif(lower(btrim(coalesce(p_invite_email, ''))), '');
+  v_phone := nullif(btrim(coalesce(p_invite_phone, '')), '');
+
+  if v_email is not null and v_email !~ '^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$' then
+    raise exception 'invite_email is not a valid email address' using errcode = '22023';
+  end if;
+  if v_phone is not null and amux.normalize_invite_phone(v_phone) is null then
+    raise exception 'invite_phone contains no digits' using errcode = '22023';
+  end if;
+
+  if v_kind = 'member' then
+    if p_team_role is null or btrim(p_team_role) = '' then
+      raise exception 'member invites require p_team_role' using errcode = '22023';
+    end if;
+    v_role := lower(p_team_role);
+    if v_role not in ('owner','admin','member') then
+      raise exception 'team_role must be owner/admin/member' using errcode = '22023';
+    end if;
+
+    -- Member re-invite is gone; p_target_actor_id survives for agents only.
+    if p_target_actor_id is not null then
+      raise exception 'member invites cannot target an existing actor'
+        using errcode = '22023';
+    end if;
+
+    -- Supersede an existing live invite to the same contact instead of letting
+    -- the partial unique index reject the call: an inviter re-sending an invite
+    -- means "this one is now current", and the old token stops working.
+    if v_email is not null then
+      update amux.team_invites
+         set status = 'expired', updated_at = now()
+       where team_id = p_team_id
+         and status = 'pending'
+         and lower(btrim(invite_email)) = v_email;
+    end if;
+    if v_phone is not null then
+      update amux.team_invites
+         set status = 'expired', updated_at = now()
+       where team_id = p_team_id
+         and status = 'pending'
+         and amux.normalize_invite_phone(invite_phone) = amux.normalize_invite_phone(v_phone);
+    end if;
+  else
+    if v_email is not null or v_phone is not null then
+      raise exception 'agent invites cannot carry invite_email/invite_phone'
+        using errcode = '22023';
+    end if;
+    if p_agent_kind is null or btrim(p_agent_kind) = '' then
+      raise exception 'agent invites require p_agent_kind' using errcode = '22023';
+    end if;
+    if p_target_actor_id is not null then
+      select * into v_target from amux.actors where id = p_target_actor_id;
+      if not found then
+        raise exception 'target actor not found' using errcode = '23503';
+      end if;
+      if v_target.team_id <> p_team_id then
+        raise exception 'target actor belongs to a different team'
+          using errcode = '23514';
+      end if;
+      if v_target.actor_type <> 'agent' then
+        raise exception 'target actor must be an agent' using errcode = '22023';
+      end if;
+      if not exists (
+        select 1 from amux.agents
+        where id = p_target_actor_id
+          and owner_member_id = v_caller
+      ) then
+        raise exception 'only the agent owner can re-invite this agent'
+          using errcode = '42501';
+      end if;
+    end if;
+  end if;
+
+  insert into amux.team_invites (
+    team_id, kind, display_name, team_role, agent_kind,
+    invited_by_actor_id, token, expires_at, target_actor_id,
+    invite_email, invite_phone, status
+  )
+  values (
+    p_team_id, v_kind, btrim(p_display_name), v_role, p_agent_kind,
+    v_caller, v_token, v_expires, p_target_actor_id,
+    v_email, v_phone, 'pending'
+  );
+
+  return query
+  select v_token,
+         v_expires,
+         format('amux://invite?token=%s', v_token);
+end;
+$function$;
+
+CREATE OR REPLACE FUNCTION amux.claim_team_invite_legacy(p_token text)
+ RETURNS TABLE(actor_id uuid, team_id uuid, actor_type text, display_name text, refresh_token text)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'amux', 'public', 'auth', 'extensions'
+AS $function$
+declare
+  v_invite      amux.team_invites%rowtype;
+  v_user_id     uuid;
+  v_actor       uuid;
+  v_email       text;
+  v_session     uuid;
+  v_rt          text := null;
+  v_old_user    uuid;
+  v_target_anon boolean;
+  v_team_org    uuid;   -- invite team's org (S3-FC.3)
+  v_old_org     uuid;   -- claimer's previous org (member path)
+begin
+  select * into v_invite from amux.team_invites where token = p_token for update;
+  if not found then raise exception 'invite not found' using errcode = '23503'; end if;
+  if v_invite.consumed_at is not null then raise exception 'invite already consumed' using errcode = '23514'; end if;
+  if v_invite.status = 'declined' then raise exception 'invite was declined' using errcode = '23514'; end if;
+  if v_invite.status = 'expired' then raise exception 'invite superseded' using errcode = '23514'; end if;
+  if v_invite.expires_at < now() then raise exception 'invite expired' using errcode = '23514'; end if;
+
+  -- Resolved once for both branches: members get public.users.org_id switched,
+  -- agents get the claim baked into raw_app_meta_data.
+  select oid into v_team_org from amux.teams where id = v_invite.team_id;
+
+  if v_invite.kind = 'member' then
+    if v_invite.target_actor_id is not null then
+      -- Unconsumed tokens minted before the removal still carry a target. They
+      -- are refused rather than degraded into a self-join: the token was issued
+      -- to hand back somebody else's credentials, not to add the caller.
+      raise exception 'member re-invite is no longer supported' using errcode = '22023';
+    else
+      v_user_id := auth.uid();
+      if v_user_id is null then raise exception 'member claim requires authentication' using errcode = '42501'; end if;
+      if exists (select 1 from amux.actors act where act.team_id = v_invite.team_id and act.user_id = v_user_id) then
+        raise exception 'already a member of this team' using errcode = '23505';
+      end if;
+
+      insert into amux.actors (team_id, actor_type, user_id, invited_by_actor_id, display_name, last_active_at)
+      values (v_invite.team_id, 'member', v_user_id, v_invite.invited_by_actor_id, v_invite.display_name, now())
+      returning id into v_actor;
+      insert into amux.members (id, status) values (v_actor, 'active');
+      insert into amux.team_members (team_id, member_id, role) values (v_invite.team_id, v_actor, v_invite.team_role);
+    end if;
+
+    -- S3-FC.3: strict single-org — claimer's org becomes the invite team's org.
+    if v_team_org is not null and v_user_id is not null then
+      select org_id into v_old_org from public.users where id = v_user_id;
+      if v_old_org is null then
+        insert into public.users (id, org_id, mobile) values (v_user_id, v_team_org, '');
+      else
+        update public.users set org_id = v_team_org, updated_at = now() where id = v_user_id;
+      end if;
+      -- best-effort GC of an abandoned one-person (personal) old org; never fail the claim
+      begin
+        if v_old_org is not null and v_old_org <> v_team_org
+           and not exists (select 1 from public.users where org_id = v_old_org) then
+          delete from amux.teams where oid = v_old_org;   -- cascades actors/members/sessions/...
+          delete from public.orgs where id = v_old_org;
+        end if;
+      exception when others then
+        null;  -- leave the orphan; reassignment already succeeded
+      end;
+    end if;
+  else
+    v_user_id := gen_random_uuid();
+    v_email   := format('daemon.%s@amuxd.run', v_user_id);
+    v_session := gen_random_uuid();
+    v_rt      := substring(encode(extensions.gen_random_bytes(6), 'hex'), 1, 12);
+    -- Stamp the team's org into app_metadata so daemon access tokens pass
+    -- teams_org_guard (current_org_id() reads the JWT claim first; daemon
+    -- users have no public.users fallback row).
+    insert into auth.users (id, email, email_confirmed_at, encrypted_password, confirmation_token, recovery_token,
+      email_change_token_new, email_change, raw_app_meta_data, aud, role, created_at, updated_at, instance_id)
+    values (v_user_id, v_email, now(), '', '', '', '', '',
+      case when v_team_org is not null then jsonb_build_object('org_id', v_team_org) else '{}'::jsonb end,
+      'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000');
+    insert into auth.sessions (id, user_id, aal, created_at, updated_at) values (v_session, v_user_id, 'aal1', now(), now());
+    insert into auth.refresh_tokens (token, user_id, session_id, revoked, instance_id, created_at, updated_at)
+      values (v_rt, v_user_id::text, v_session, false, '00000000-0000-0000-0000-000000000000', now(), now());
+
+    -- Also give the daemon account a public.users fallback row with the team's
+    -- org, so org resolvers that query public.users by id directly (without the
+    -- JWT app_metadata.org_id claim) can resolve org_id instead of erroring.
+    if v_team_org is not null then
+      insert into public.users (id, org_id, mobile) values (v_user_id, v_team_org, '')
+      on conflict (id) do update set org_id = excluded.org_id, updated_at = now();
+    end if;
+
+    if v_invite.target_actor_id is not null then
+      select user_id into v_old_user from amux.actors where id = v_invite.target_actor_id;
+      update amux.actors set user_id = v_user_id, invited_by_actor_id = v_invite.invited_by_actor_id,
+             last_active_at = null, updated_at = now() where id = v_invite.target_actor_id;
+      v_actor := v_invite.target_actor_id;
+      update amux.agents set owner_member_id = v_invite.invited_by_actor_id, visibility = 'team', updated_at = now() where id = v_actor;
+      if v_old_user is not null then delete from auth.users where id = v_old_user; end if;
+    else
+      insert into amux.actors (team_id, actor_type, user_id, invited_by_actor_id, display_name, last_active_at)
+      values (v_invite.team_id, 'agent', v_user_id, v_invite.invited_by_actor_id, v_invite.display_name, null)
+      returning id into v_actor;
+      insert into amux.agents (id, owner_member_id, visibility, status) values (v_actor, v_invite.invited_by_actor_id, 'team', 'active');
+    end if;
+
+    insert into amux.agent_member_access (agent_id, member_id, permission_level, granted_by_member_id)
+    values (v_actor, v_invite.invited_by_actor_id, 'admin', v_invite.invited_by_actor_id)
+    on conflict (agent_id, member_id) do update
+      set permission_level = 'admin', granted_by_member_id = excluded.granted_by_member_id, updated_at = now();
+  end if;
+
+  update amux.team_invites set consumed_at = now(), consumed_by_actor_id = v_actor,
+         status = 'accepted', updated_at = now() where id = v_invite.id;
+
+  return query select v_actor, v_invite.team_id, v_invite.kind::text, v_invite.display_name, v_rt;
+end;
+$function$;

--- a/services/supabase/tests/004_member_reinvite.sql
+++ b/services/supabase/tests/004_member_reinvite.sql
@@ -1,29 +1,21 @@
 -- services/supabase/tests/004_member_reinvite.sql
 --
--- Member re-invite: two guards that were added independently and now disagree.
+-- Member re-invite is removed (20260811110000). This file is what keeps it
+-- removed, and pins the two things that must survive alongside it.
 --
---   * create_team_invite(p_target_actor_id => …) refuses a target whose auth
---     user is NOT anonymous ('cannot re-invite member with bound auth
---     identity'), so a re-invite only ever points at an anonymous-bound member.
---   * claim_team_invite's member branch keeps the actor on its original
---     anonymous user and mints a fresh session + refresh token for THAT user --
---     device recovery: the person walks to a new device and gets their
---     anonymous member identity back.
---   * but claim_team_invite's outer wrapper (20260801010000) rejects anonymous
---     and bearerless callers before that branch runs, and the person on the new
---     device is exactly such a caller.
+-- Why it went: create_team_invite only accepted a member target whose auth user
+-- was anonymous; the claim branch then kept the actor on that anonymous user and
+-- minted a refresh token FOR IT (device recovery); but claim_team_invite's
+-- wrapper refuses anonymous and bearerless callers for every member invite, and
+-- the person on the new device is exactly that caller. The only caller who could
+-- redeem the link was someone already signed into a real account, who would be
+-- handed credentials for the anonymous one.
 --
--- The wrapper was written for the ordinary member invite ("anonymous users
--- cannot self-join a team") and catches the re-invite path as collateral. The
--- assertions below describe what the database actually enforces today, which is
--- the wrapper's version. The original file asserted the branch's version, and
--- neither the file nor the schema was updated when the other moved.
---
--- Not resolved here, because it is a product call rather than a test repair:
--- see QUARANTINE.md, "Member re-invite is unreachable by its intended caller".
+-- What must keep working: p_target_actor_id for AGENT invites (daemon credential
+-- rotation), and ordinary member invites.
 begin;
 
-select plan(10);
+select plan(6);
 
 create or replace function pg_temp.as_user(p_user uuid)
 returns void language plpgsql as $$
@@ -35,18 +27,6 @@ begin
 end;
 $$;
 
-create or replace function pg_temp.as_anon()
-returns void language plpgsql as $$
-begin
-  perform set_config('request.jwt.claims', '{}', true);
-  perform set_config('role', 'anon', true);
-end;
-$$;
-
--- Fixture users:
---   alice: team owner, real account
---   bob  : a second real account, the one that redeems the re-invite
---   anon : an anonymous-flagged Supabase user holding a member actor
 insert into auth.users (id, email, aud, role, instance_id, is_anonymous)
 values
   ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
@@ -68,107 +48,86 @@ create temp table ctx as
     (select id from amux.teams where slug = 'team-r') as team_r,
     (select id from amux.actors
       where user_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' limit 1) as alice_actor,
-    '11111111-2222-3333-4444-555555555555'::uuid as anon_actor;
+    '11111111-2222-3333-4444-555555555555'::uuid as anon_actor,
+    '11111111-2222-3333-4444-666666666666'::uuid as agent_actor;
 grant select on ctx to anon, authenticated;
 
--- Seed the anonymous member directly. Nothing in the product mints one any
--- more: claim_team_invite and join_public_team both refuse anonymous callers,
--- so an anonymous-bound member actor is a legacy row -- and legacy rows are
--- precisely what re-invite exists to rescue.
+-- A legacy anonymous-bound member: the shape re-invite used to target. Nothing
+-- mints these any more, so it has to be seeded directly.
 reset role;
 
 insert into amux.actors (id, team_id, actor_type, user_id, display_name)
 select anon_actor, team_r, 'member', 'cccccccc-cccc-cccc-cccc-cccccccccccc', 'AnonUser' from ctx;
-
-insert into amux.members (id, status)
-select anon_actor, 'active' from ctx;
-
+insert into amux.members (id, status) select anon_actor, 'active' from ctx;
 insert into amux.team_members (team_id, member_id, role)
 select team_r, anon_actor, 'member' from ctx;
 
--- 1. Alice can mint a re-invite aimed at that actor.
+-- An agent to prove the parameter still has a job.
+insert into amux.actors (id, team_id, actor_type, display_name)
+select agent_actor, team_r, 'agent', 'Daemon' from ctx;
+insert into amux.agents (id, owner_member_id, visibility, status)
+select agent_actor, alice_actor, 'team', 'active' from ctx;
+
+-- 1. A member invite may no longer name a target, however eligible it looks.
 select pg_temp.as_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
-create temp table ri as
-  select * from amux.create_team_invite(
-    (select team_r from ctx), 'member', 'AnonUser',
-    p_team_role => 'member',
-    p_target_actor_id => (select anon_actor from ctx));
-grant select on ri to anon, authenticated;
-select ok((select count(*) = 1 from ri),
-          'create_team_invite accepts target_actor_id for member kind');
-
--- 2. A bearerless caller cannot redeem it.
-select pg_temp.as_anon();
 select throws_ok(
-  format($$ select amux.claim_team_invite(%L) $$, (select token from ri)),
-  '42501', 'member claim requires a non-anonymous account',
-  'anonymous caller cannot claim a member re-invite');
+  format($$ select amux.create_team_invite(%L::uuid, 'member', 'AnonUser',
+              p_team_role => 'member', p_target_actor_id => %L::uuid) $$,
+         (select team_r from ctx), (select anon_actor from ctx)),
+  '22023', 'member invites cannot target an existing actor',
+  'member invite rejects p_target_actor_id');
 
--- 3. An anonymous *account* cannot either -- being signed in is not enough,
---    the account has to be a real one.
-select pg_temp.as_user('cccccccc-cccc-cccc-cccc-cccccccccccc');
-select throws_ok(
-  format($$ select amux.claim_team_invite(%L) $$, (select token from ri)),
-  '42501', 'member claim requires a non-anonymous account',
-  'anonymous account cannot claim a member re-invite');
-
--- 4-5. Bob (real account) redeems it and takes over the existing actor rather
---      than getting a fresh one.
-select pg_temp.as_user('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
-create temp table rc as
-  select * from amux.claim_team_invite((select token from ri));
-grant select on rc to anon, authenticated;
-
-select is((select actor_type from rc), 'member',
-         'member-reinvite claim returns actor_type=member');
-select is((select actor_id from rc), (select anon_actor from ctx),
-          'reinvite reuses the target actor_id instead of minting one');
-
--- 6. The actor stays bound to the anonymous account, and the claim hands back a
---    refresh token *for that account* -- the redeemer is meant to end up signed
---    in as the anonymous member, on a new device.
---
---    KNOWN CONTRADICTION, left asserted as-is rather than papered over: the
---    branch below is device recovery, so its natural caller is someone with no
---    account yet -- but claim_team_invite's outer guard (20260801010000) refuses
---    anonymous and bearerless callers before that branch is reached. The only
---    caller who can get through is someone already signed into a real account,
---    who is then handed credentials for the anonymous one. Whichever half is
---    wrong, they cannot both be right; see QUARANTINE.md.
-select ok((select refresh_token is not null and length(refresh_token) >= 12 from rc),
-          'reinvite claim returns a refresh token');
-
-reset role;
-select is(
-  (select user_id from amux.actors where id = (select anon_actor from ctx)),
-  'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid,
-  'reinvite leaves the actor bound to the anonymous account');
-
--- 7. Replay rejected.
-select pg_temp.as_user('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
-select throws_ok(
-  format($$ select amux.claim_team_invite(%L) $$, (select token from ri)),
-  '23514', 'invite already consumed', 'reinvite replay rejected');
-
--- 9. A member holding a real account cannot be re-invited at all: alice is the
---    owner, signed in with a real identity, so pointing a re-invite at her own
---    actor is refused. This is the guard that confines re-invite to anonymous
---    members.
-select pg_temp.as_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+-- 2. Including one aimed at a member with a real account, which used to fail
+--    with a different message ('cannot re-invite member with bound auth
+--    identity'). One rejection now covers every member target.
 select throws_ok(
   format($$ select amux.create_team_invite(%L::uuid, 'member', 'Alice',
               p_team_role => 'member', p_target_actor_id => %L::uuid) $$,
          (select team_r from ctx), (select alice_actor from ctx)),
-  '22023', 'cannot re-invite member with bound auth identity',
-  'reject re-invite for a member with a bound identity');
+  '22023', 'member invites cannot target an existing actor',
+  'the rejection does not depend on the target being anonymous');
 
--- 10. And a target that does not exist is refused before any of that.
+-- 3. Agent re-invite still works: this is daemon credential rotation.
+select lives_ok(
+  format($$ select amux.create_team_invite(%L::uuid, 'agent', 'Daemon',
+              p_agent_kind => 'daemon', p_target_actor_id => %L::uuid) $$,
+         (select team_r from ctx), (select agent_actor from ctx)),
+  'agent invite still accepts p_target_actor_id');
+
+-- 4. A token minted before the removal is refused rather than degraded into a
+--    self-join. Seeded straight into the table, since the RPC will not make one.
+reset role;
+insert into amux.team_invites (team_id, kind, token, display_name, team_role,
+                               invited_by_actor_id, target_actor_id, expires_at, status)
+select team_r, 'member', 'legacy-reinvite-token', 'AnonUser', 'member',
+       alice_actor, anon_actor, now() + interval '1 day', 'pending'
+from ctx;
+
+select pg_temp.as_user('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
 select throws_ok(
-  format($$ select amux.create_team_invite(%L::uuid, 'member', 'Stranger',
-              p_team_role => 'member', p_target_actor_id => %L::uuid) $$,
-         (select team_r from ctx), '00000000-0000-0000-0000-000000000000'),
-  '23503', 'target actor not found',
-  'reject re-invite with a bogus target_actor_id');
+  $$ select amux.claim_team_invite('legacy-reinvite-token') $$,
+  '22023', 'member re-invite is no longer supported',
+  'a pre-existing member re-invite token is refused, not honoured');
+
+-- 5-6. The ordinary member invite is untouched.
+select pg_temp.as_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+create temp table mi as
+  select * from amux.create_team_invite(
+    (select team_r from ctx), 'member', 'Bob', p_team_role => 'member');
+grant select on mi to anon, authenticated;
+
+select pg_temp.as_user('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+create temp table mc as select * from amux.claim_team_invite((select token from mi));
+grant select on mc to anon, authenticated;
+
+select is((select actor_type from mc), 'member',
+          'an ordinary member invite still claims');
+
+reset role;
+select is(
+  (select user_id from amux.actors where id = (select actor_id from mc)),
+  'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
+  'and binds the new actor to the claiming account');
 
 select * from finish();
 rollback;

--- a/services/supabase/tests/QUARANTINE.md
+++ b/services/supabase/tests/QUARANTINE.md
@@ -131,23 +131,23 @@ the file impersonates) or create and write it as the session role.
 These are product decisions, not test bugs. They are recorded here rather than
 silently encoded as "expected".
 
-### Member re-invite is unreachable by its intended caller
+### ~~Member re-invite is unreachable by its intended caller~~ → removed
 
-`004_member_reinvite.sql` asserts the behaviour the database actually enforces,
-and that behaviour is self-contradictory:
+Settled by deleting the feature: `20260811110000_remove_member_reinvite.sql`.
 
-* `create_team_invite(p_target_actor_id => …)` only accepts a target whose auth
-  user **is anonymous** ("cannot re-invite member with bound auth identity").
-* `claim_team_invite`'s member branch keeps the actor on that anonymous user and
-  mints a fresh session + refresh token **for it** — device recovery: get your
-  anonymous membership back on a new machine.
-* But the wrapper added in `20260801010000` rejects anonymous and bearerless
-  callers before that branch runs, and the person on the new device is exactly
-  such a caller.
+Its three parts disagreed. `create_team_invite(p_target_actor_id => …)` only
+accepted a target whose auth user **was anonymous**; the claim branch then kept
+the actor on that anonymous user and minted a fresh session + refresh token
+**for it** (device recovery: get your anonymous membership back on a new
+machine); but the wrapper added in `20260801010000` rejects anonymous and
+bearerless callers for every member invite, and the person on the new device is
+exactly such a caller. The only caller who could get through was somebody
+already signed into a real account, who would then be handed credentials for the
+anonymous one.
 
-The wrapper was written for the ordinary member invite ("anonymous users cannot
-self-join a team") and catches the re-invite path as collateral. The desktop
-"Re-invite" button (`ActorDetailDialog.tsx`) still ships this flow.
+`p_target_actor_id` stays on the signature and keeps working for **agent**
+invites — daemon credential rotation depends on it. `004_member_reinvite.sql`
+now guards the removal and pins that agent path.
 
 ### A disabled member keeps reading their sessions
 


### PR DESCRIPTION
> 叠在 #867 上（base = `test/pgtap-quarantine-round2`）。#867 合并后 GitHub 会自动把 base 改成 main。只看本 PR 的那一个 commit 即可。

## 为什么删

这个功能**不可能工作**，而且从 `20260801010000` 起就不可能了。三块代码对"这条链接是给谁的"意见不一致：

- `create_team_invite` 只在目标的 auth user **是匿名**时才接受 `p_target_actor_id`；
- `claim_team_invite_legacy` 的 member 分支把 actor 继续绑在那个匿名用户上，并**为它**新签一个 session + refresh token——换设备找回：人走到新机器上，把匿名成员身份拿回来；
- 但 `claim_team_invite` 的外层守卫拒绝匿名和无 bearer 的调用者，而新设备上的人**正是**这种调用者。

于是唯一能兑换成功的，是一个**已经登录真实账号**的人——然后他会拿到那个匿名账号的凭证，自己的账号什么也没得到。与此同时，现在已经没有任何路径能产出匿名绑定的成员了（`claim_team_invite` 和 `join_public_team` 都拒绝匿名调用者），所以这些目标全是历史遗留行。

### 另一个后端的旁证

FC 的 `pg-repo` **压根没实现过** member re-invite：它的 rebind 分支写在 agent claim 里，member 邀请带 target 会被下面那条 agent 所有权检查拦下，报 *"only the agent owner can re-invite this agent"*——一句关于成员完全不成立的话。同一个调用，两个后端两种行为，都不是文档写的那种。本 PR 把这条拒绝改成显式的，并和数据库用同一句措辞。

## 改了什么

| 层 | 改动 |
|---|---|
| DB | `20260811110000_remove_member_reinvite.sql`：两个函数按线上定义原样复制，只替换 member-target 那两段。创建端报 `22023 member invites cannot target an existing actor`；claim 端对**已存在的未消费旧 token** 直接拒绝，而不是降级成自助加入（那 token 本来就是用来交出别人凭证的） |
| 桌面端 | Re-invite 按钮的 member 分支、决定要不要显示它的 `memberHasBoundIdentity`、只写不读的 `detailContact` state、`bound auth identity` 错误分支，以及两个语言各 3 个文案 key |
| 契约 | OpenAPI 里 `targetActorId` 标注为 agent 专用 |

**`p_target_actor_id` 保留**，agent 邀请继续用它——daemon 凭证轮换依赖这条路，`021_agent_reinvite_owner_check`、`claim_team_invite_agent_org`、`pg-repo-claim` 都还在覆盖。

`004_member_reinvite.sql` 从"描述这个矛盾"改成"守住这次删除"。

## 验证

- pgTAP：**37 run / 0 failed**（迁移已应用）
- `pnpm typecheck` 干净、`pnpm lint` 0 error、`ActorDetailDialog.test.tsx` 10/10、FC `business-api` 119/119、FC `pg-repo-claim` 8/8
- 两处无关的红都单独确认过、不是本次引入：`DiagnosticsSection.reset` 单跑通过（已知的顺序敏感 flake）；`pg-repo-teams.test.ts` 把我的改动 stash 掉后**一模一样地红**（main 上就有，关于 team 列表字段）

## ⚠️ 一个没能核实的数字

生产库里还有多少匿名绑定的成员 actor：

```sql
select count(*) from amux.actors a join auth.users u on u.id = a.user_id
 where a.actor_type = 'member' and u.is_anonymous;
```

机器拒绝了我手上的 SSH 密码，admin MCP 也连不上。**它不改变结论**（这些用户今天同样兑换不了 re-invite），但决定了要不要给他们一条迁移路径——合并前值得看一眼。

另外提醒：本 PR 动了 `services/supabase/migrations/**`，合并到 main 会**自动部署**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
