### PR TITLE
feat(auth): support Google sign-in in the Chrome extension

### DIFF
--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_appName__",
   "version": "0.1.0",
   "description": "__MSG_extensionDescription__",
-  "permissions": ["sidePanel", "scripting", "activeTab", "tabs", "storage"],
+  "permissions": ["sidePanel", "scripting", "activeTab", "tabs", "storage", "identity"],
   "host_permissions": ["http://*/*", "https://*/*"],
   "background": { "service_worker": "background.js", "type": "module" },
   "action": { "default_title": "__MSG_appName__" },

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -307,7 +307,7 @@ MAILER_URLPATHS_EMAIL_CHANGE=/auth/v1/verify
 # Chrome extension (chrome.identity.launchWebAuthFlow, see
 # packages/app/src/lib/auth/extension-oauth.ts) additionally needs its synthetic
 # redirect listed, one entry per extension id:
-#   https://<extension-id>.chromiumapp.org/
+#   https://nlmkpmokfbboonocdnngddbfpdedkfee.chromiumapp.org/
 # The id is per Web Store item, so each brand that ships the extension with
 # Google sign-in needs its own entry. Read it from chrome://extensions, or from
 # the brand's CHROME_EXTENSION_ID release secret. An unpacked dev build gets a
@@ -315,7 +315,7 @@ MAILER_URLPATHS_EMAIL_CHANGE=/auth/v1/verify
 # matching after a reinstall — pin the key rather than re-editing this list.
 # Prefer exact ids over a https://*.chromiumapp.org/ wildcard: the wildcard lets
 # any extension complete a sign-in flow against this GoTrue.
-ADDITIONAL_REDIRECT_URLS=http://127.0.0.1:*/callback,teamclu://auth-callback
+ADDITIONAL_REDIRECT_URLS=http://127.0.0.1:*/callback,teamclu://auth-callback,https://nlmkpmokfbboonocdnngddbfpdedkfee.chromiumapp.org/
 # SMTP — placeholder values so GoTrue (auth) starts; it will not actually
 # deliver mail until you point these at a real SMTP server. Do NOT blank these:
 # GoTrue parses SMTP_PORT as an integer and fails to start on an empty value.

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -303,6 +303,18 @@ MAILER_URLPATHS_EMAIL_CHANGE=/auth/v1/verify
 #   teamclu://auth-callback     iOS ASWebAuthenticationSession + Expo
 # The globs stop at "." and "/", so the port wildcard above matches but does
 # not leak into other paths.
+#
+# Chrome extension (chrome.identity.launchWebAuthFlow, see
+# packages/app/src/lib/auth/extension-oauth.ts) additionally needs its synthetic
+# redirect listed, one entry per extension id:
+#   https://<extension-id>.chromiumapp.org/
+# The id is per Web Store item, so each brand that ships the extension with
+# Google sign-in needs its own entry. Read it from chrome://extensions, or from
+# the brand's CHROME_EXTENSION_ID release secret. An unpacked dev build gets a
+# random id unless manifest.json pins a "key", so a dev id listed here stops
+# matching after a reinstall — pin the key rather than re-editing this list.
+# Prefer exact ids over a https://*.chromiumapp.org/ wildcard: the wildcard lets
+# any extension complete a sign-in flow against this GoTrue.
 ADDITIONAL_REDIRECT_URLS=http://127.0.0.1:*/callback,teamclu://auth-callback
 # SMTP — placeholder values so GoTrue (auth) starts; it will not actually
 # deliver mail until you point these at a real SMTP server. Do NOT blank these:

--- a/deploy/self-host/.env.local.example
+++ b/deploy/self-host/.env.local.example
@@ -103,7 +103,9 @@ MAILER_URLPATHS_CONFIRMATION=/auth/v1/verify
 MAILER_URLPATHS_INVITE=/auth/v1/verify
 MAILER_URLPATHS_RECOVERY=/auth/v1/verify
 MAILER_URLPATHS_EMAIL_CHANGE=/auth/v1/verify
-ADDITIONAL_REDIRECT_URLS=http://127.0.0.1:*/callback,teamclu://auth-callback
+# The chromiumapp.org entry is the Chrome extension's synthetic OAuth redirect
+# (chrome.identity.launchWebAuthFlow); see .env.example for the full note.
+ADDITIONAL_REDIRECT_URLS=http://127.0.0.1:*/callback,teamclu://auth-callback,https://nlmkpmokfbboonocdnngddbfpdedkfee.chromiumapp.org/
 
 # Google sign-in — off unless both values are filled. The OAuth client must be
 # a "Web application" client with https://<SUPABASE_DOMAIN>/auth/v1/callback as

--- a/packages/app/src/components/auth/LoginScreen.tsx
+++ b/packages/app/src/components/auth/LoginScreen.tsx
@@ -9,6 +9,7 @@ import { useAppVersion } from "@/lib/version";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { isTauri } from "@/lib/utils";
+import { capabilities } from "@/lib/platform";
 import { GoogleIcon, WechatIcon } from "./oauth-icons";
 import { WebSsoOverlay } from "./WebSsoOverlay";
 import type { OAuthProvider } from "@/lib/auth";
@@ -19,7 +20,11 @@ export function OAuthButtons() {
   // Read through useFeatures, not the build config: the Cloud API delivers
   // these at startup and they can land after first paint.
   const auth = useFeatures().auth;
-  const showGoogle = isTauri() && auth.google;
+  // Google runs wherever a redirect can be captured — desktop via the native
+  // loopback listener, the extension via chrome.identity. WeChat and web SSO
+  // stay desktop-only: web SSO needs a native webview, and WeChat's redirect
+  // domain is registered against the desktop flow.
+  const showGoogle = capabilities.oauthSignIn && auth.google;
   const showWechat = isTauri() && auth.wechat;
   const showWebSso = isTauri() && auth.webSSO;
   if (!showGoogle && !showWechat && !showWebSso) return null;

--- a/packages/app/src/components/auth/__tests__/OAuthButtons.test.tsx
+++ b/packages/app/src/components/auth/__tests__/OAuthButtons.test.tsx
@@ -44,6 +44,31 @@ describe("OAuthButtons", () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it("renders Google in the extension, where chrome.identity can capture the redirect", () => {
+    isTauriMock.mockReturnValue(false);
+    (globalThis as { chrome?: unknown }).chrome = { runtime: { id: "abcdefghijklmnop" } };
+    try {
+      render(<OAuthButtons />);
+      expect(screen.getByText("使用 Google 登录")).toBeTruthy();
+    } finally {
+      delete (globalThis as { chrome?: unknown }).chrome;
+    }
+  });
+
+  it("keeps WeChat and 快捷登录 desktop-only in the extension", () => {
+    isTauriMock.mockReturnValue(false);
+    (globalThis as { chrome?: unknown }).chrome = { runtime: { id: "abcdefghijklmnop" } };
+    try {
+      render(<OAuthButtons />);
+      // Both need native pieces the extension has no equivalent of: a webview
+      // for 快捷登录, a registered redirect domain for WeChat.
+      expect(screen.queryByText("使用微信登录")).toBeNull();
+      expect(screen.queryByText("快捷登录")).toBeNull();
+    } finally {
+      delete (globalThis as { chrome?: unknown }).chrome;
+    }
+  });
+
   it("shows a cancel control instead of provider buttons while OAuth is pending", () => {
     isTauriMock.mockReturnValue(true);
     const cancelOAuth = vi.fn();

--- a/packages/app/src/lib/auth/extension-oauth.test.ts
+++ b/packages/app/src/lib/auth/extension-oauth.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./oauth-pkce", () => ({
+  generatePkce: vi.fn().mockResolvedValue({ verifier: "VER", challenge: "CHA" }),
+}));
+
+import { cancelExtensionOAuth, runExtensionOAuth } from "./extension-oauth";
+
+const REDIRECT = "https://abcdefghijklmnop.chromiumapp.org/";
+
+function fakeClient() {
+  return {
+    oauthAuthorizeUrl: vi.fn().mockReturnValue("https://auth.example/url"),
+    exchangeOAuthCode: vi.fn().mockResolvedValue({ access_token: "at", user: { id: "u1" } }),
+  } as any;
+}
+
+/** Install a chrome.identity double. `flow` drives the launchWebAuthFlow callback. */
+function installChrome(flow: (cb: (responseUrl?: string) => void) => void, lastError?: { message?: string }) {
+  const launchWebAuthFlow = vi.fn((_details: unknown, cb: (responseUrl?: string) => void) => {
+    // lastError is only readable from inside the callback, matching Chrome.
+    (globalThis as any).chrome.runtime.lastError = lastError;
+    flow(cb);
+    (globalThis as any).chrome.runtime.lastError = undefined;
+  });
+  (globalThis as any).chrome = {
+    identity: { getRedirectURL: vi.fn().mockReturnValue(REDIRECT), launchWebAuthFlow },
+    runtime: { id: "abcdefghijklmnop", lastError: undefined },
+  };
+  return launchWebAuthFlow;
+}
+
+beforeEach(() => {
+  delete (globalThis as any).chrome;
+});
+
+afterEach(() => {
+  delete (globalThis as any).chrome;
+});
+
+describe("runExtensionOAuth", () => {
+  it("authorizes with the chrome redirect, then exchanges the code", async () => {
+    const launch = installChrome(cb => cb(`${REDIRECT}?code=CODE`));
+    const client = fakeClient();
+
+    const session = await runExtensionOAuth(client, "google");
+
+    expect(client.oauthAuthorizeUrl).toHaveBeenCalledWith("google", REDIRECT, "CHA");
+    expect(launch).toHaveBeenCalledWith(
+      { url: "https://auth.example/url", interactive: true },
+      expect.any(Function),
+    );
+    expect(client.exchangeOAuthCode).toHaveBeenCalledWith("CODE", "VER");
+    expect(session.access_token).toBe("at");
+  });
+
+  it("fails cleanly when the identity permission is absent", async () => {
+    (globalThis as any).chrome = { runtime: { id: "x" } };
+    await expect(runExtensionOAuth(fakeClient(), "google")).rejects.toThrow(/identity permission/i);
+  });
+
+  it("maps a dismissed auth window to oauth_cancelled", async () => {
+    installChrome(cb => cb(undefined), { message: "The user did not approve access." });
+    await expect(runExtensionOAuth(fakeClient(), "google")).rejects.toMatchObject({
+      code: "oauth_cancelled",
+    });
+  });
+
+  it("treats an empty response url as a cancel", async () => {
+    installChrome(cb => cb(undefined));
+    await expect(runExtensionOAuth(fakeClient(), "google")).rejects.toMatchObject({
+      code: "oauth_cancelled",
+    });
+  });
+
+  it("keeps a genuine provider failure distinguishable from a cancel", async () => {
+    installChrome(cb => cb(undefined), { message: "Authorization page could not be loaded." });
+    await expect(runExtensionOAuth(fakeClient(), "google")).rejects.toMatchObject({
+      code: "oauth_failed",
+    });
+  });
+
+  it("surfaces an error carried on the redirect url", async () => {
+    installChrome(cb => cb(`${REDIRECT}?error=access_denied&error_description=Nope`));
+    await expect(runExtensionOAuth(fakeClient(), "google")).rejects.toThrow(/nope/i);
+  });
+
+  it("rejects when the redirect carries neither code nor error", async () => {
+    installChrome(cb => cb(REDIRECT));
+    await expect(runExtensionOAuth(fakeClient(), "google")).rejects.toMatchObject({
+      code: "oauth_failed",
+    });
+  });
+
+  it("does not exchange a code once cancelled", async () => {
+    // Never invokes the callback: the flow stays pending until cancelled, which
+    // is what a user staring at an abandoned Chrome window actually hits.
+    installChrome(() => {});
+    const client = fakeClient();
+
+    const pending = runExtensionOAuth(client, "google");
+    await Promise.resolve();
+    cancelExtensionOAuth();
+
+    await expect(pending).rejects.toMatchObject({ code: "oauth_cancelled" });
+    expect(client.exchangeOAuthCode).not.toHaveBeenCalled();
+  });
+
+  it("cancel is a no-op when no flow is in flight", () => {
+    expect(() => cancelExtensionOAuth()).not.toThrow();
+  });
+});

--- a/packages/app/src/lib/auth/extension-oauth.ts
+++ b/packages/app/src/lib/auth/extension-oauth.ts
@@ -1,0 +1,136 @@
+// Chrome MV3 OAuth orchestration: chrome.identity.launchWebAuthFlow + PKCE
+// exchange. The desktop twin of this file (desktop-oauth.ts) captures the
+// redirect with a native loopback listener; an extension has no such thing, so
+// Chrome's own auth window stands in and hands back the final redirect URL.
+//
+// Everything below the redirect capture is identical to desktop: same FC PKCE
+// endpoints (`/v1/auth/oauth/:provider/authorize` + `/exchange`), same verifier
+// handling. Only the transport differs.
+//
+// The redirect lands on `https://<extension-id>.chromiumapp.org/`, which Chrome
+// synthesises and never actually loads. GoTrue still validates it against
+// GOTRUE_URI_ALLOW_LIST (deploy: ADDITIONAL_REDIRECT_URLS), so a new extension
+// id needs an entry there or the provider round-trip fails with a redirect
+// mismatch — see deploy/self-host/.env.example.
+
+import type { AuthClient } from "./auth-client";
+import type { OAuthProvider } from "./desktop-oauth";
+import { generatePkce } from "./oauth-pkce";
+import { AuthError, type Session } from "./types";
+
+/**
+ * Structural shape of the slice of `chrome.identity` we use. Declared here
+ * rather than pulled from @types/chrome because packages/app builds for desktop
+ * and web too, where that global does not exist.
+ */
+interface ChromeIdentityLike {
+  getRedirectURL(path?: string): string;
+  launchWebAuthFlow(
+    details: { url: string; interactive: boolean },
+    callback: (responseUrl?: string) => void,
+  ): void;
+}
+
+interface ChromeRuntimeLike {
+  lastError?: { message?: string };
+}
+
+function readChrome(): { identity?: ChromeIdentityLike; runtime?: ChromeRuntimeLike } | undefined {
+  if (typeof globalThis === "undefined") return undefined;
+  return (globalThis as { chrome?: { identity?: ChromeIdentityLike; runtime?: ChromeRuntimeLike } }).chrome;
+}
+
+/**
+ * Chrome reports a closed auth window as a generic lastError rather than a
+ * dedicated code, so match on the phrasing it actually uses. Anything we cannot
+ * confidently read as a cancel stays a real failure — mislabelling a broken
+ * provider as "cancelled" would swallow the error message the user needs.
+ */
+function isCancelMessage(message: string): boolean {
+  const m = message.toLowerCase();
+  return (
+    m.includes("did not approve") ||
+    m.includes("canceled") ||
+    m.includes("cancelled") ||
+    m.includes("closed by the user")
+  );
+}
+
+function friendlyError(message: string): AuthError {
+  if (isCancelMessage(message)) {
+    return new AuthError("Sign-in was cancelled.", 0, "oauth_cancelled");
+  }
+  return new AuthError(message || "OAuth sign-in failed.", 0, "oauth_failed");
+}
+
+let activeCancel: (() => void) | null = null;
+
+function launchWebAuthFlow(identity: ChromeIdentityLike, url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    identity.launchWebAuthFlow({ url, interactive: true }, responseUrl => {
+      const lastError = readChrome()?.runtime?.lastError;
+      if (lastError) {
+        reject(friendlyError(lastError.message ?? ""));
+        return;
+      }
+      // Chrome also yields an empty responseUrl when the window is dismissed
+      // without an error being set.
+      if (!responseUrl) {
+        reject(new AuthError("Sign-in was cancelled.", 0, "oauth_cancelled"));
+        return;
+      }
+      resolve(responseUrl);
+    });
+  });
+}
+
+export async function runExtensionOAuth(
+  authClient: AuthClient,
+  provider: OAuthProvider,
+): Promise<Session> {
+  const identity = readChrome()?.identity;
+  if (!identity) {
+    throw new AuthError(
+      "Sign-in is unavailable: the extension is missing the identity permission.",
+      0,
+      "oauth_failed",
+    );
+  }
+
+  const pkce = await generatePkce();
+  const redirect = identity.getRedirectURL();
+  const authorizeUrl = authClient.oauthAuthorizeUrl(provider, redirect, pkce.challenge);
+
+  // launchWebAuthFlow has no abort API, so an explicit cancel races the flow
+  // instead of aborting it. Chrome's window may linger until the user closes
+  // it; the orphaned promise is ignored either way. This exists so the sign-in
+  // controls re-enable immediately rather than staying disabled behind a window
+  // the user has already given up on.
+  const cancellation = new Promise<never>((_, reject) => {
+    activeCancel = () => reject(new AuthError("Sign-in was cancelled.", 0, "oauth_cancelled"));
+  });
+
+  let responseUrl: string;
+  try {
+    responseUrl = await Promise.race([launchWebAuthFlow(identity, authorizeUrl), cancellation]);
+  } finally {
+    activeCancel = null;
+  }
+
+  const params = new URL(responseUrl).searchParams;
+  const failure = params.get("error");
+  if (failure) throw friendlyError(params.get("error_description") || failure);
+
+  const code = params.get("code");
+  if (!code) throw new AuthError("OAuth sign-in failed.", 0, "oauth_failed");
+
+  return authClient.exchangeOAuthCode(code, pkce.verifier);
+}
+
+/**
+ * Abort an in-flight extension OAuth attempt so the caller's promise rejects
+ * with `oauth_cancelled` and the UI can recover. No-op when nothing is pending.
+ */
+export function cancelExtensionOAuth(): void {
+  activeCancel?.();
+}

--- a/packages/app/src/lib/auth/index.ts
+++ b/packages/app/src/lib/auth/index.ts
@@ -19,4 +19,5 @@ export {
 } from "./session-store";
 export { createAuthClient, type AuthClient, type PhoneLoginResult, type PhoneUser } from "./auth-client";
 export { runDesktopOAuth, cancelDesktopOAuth, type OAuthProvider } from "./desktop-oauth";
+export { runExtensionOAuth, cancelExtensionOAuth } from "./extension-oauth";
 export { generatePkce, type PkcePair } from "./oauth-pkce";

--- a/packages/app/src/lib/backend/cloud-api/auth.ts
+++ b/packages/app/src/lib/backend/cloud-api/auth.ts
@@ -1,11 +1,13 @@
 import type { AuthBackend, AuthClaimResult, AuthSession, PendingInvite, Unsubscribe } from "../types";
 import { BackendError } from "../errors";
 import type { CloudApiClient } from "./http";
+import { isChromeExtension } from "@/lib/platform";
 import {
   adoptRefreshToken,
   createAuthClient,
   getSession as getStoreSession,
   runDesktopOAuth,
+  runExtensionOAuth,
   subscribe as subscribeStore,
   type AuthClient,
   type OAuthProvider,
@@ -79,7 +81,10 @@ export function createAuthModule(
       return mapSession(next);
     },
     async signInWithOAuth(provider: OAuthProvider): Promise<AuthSession | null> {
-      const next = await runDesktopOAuth(authClient, provider);
+      // Same PKCE endpoints either way — only the redirect capture differs, so
+      // the runner is picked by platform rather than branching inside it.
+      const run = isChromeExtension() ? runExtensionOAuth : runDesktopOAuth;
+      const next = await run(authClient, provider);
       return mapSession(next);
     },
     async signOut(): Promise<void> {

--- a/packages/app/src/lib/platform.ts
+++ b/packages/app/src/lib/platform.ts
@@ -32,4 +32,13 @@ export const capabilities = {
   get pageCapture() {
     return getAppPlatform() === 'extension'
   },
+  /**
+   * Provider OAuth (Google / WeChat) can capture its redirect. Desktop uses a
+   * native loopback listener, the extension uses chrome.identity; plain web has
+   * neither, so it stays on email OTP.
+   */
+  get oauthSignIn() {
+    const platform = getAppPlatform()
+    return platform === 'desktop' || platform === 'extension'
+  },
 } as const

--- a/packages/app/src/stores/auth-store.ts
+++ b/packages/app/src/stores/auth-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { cancelDesktopOAuth, type OAuthProvider } from "@/lib/auth";
+import { cancelDesktopOAuth, cancelExtensionOAuth, type OAuthProvider } from "@/lib/auth";
+import { isChromeExtension } from "@/lib/platform";
 import type { PhoneUser } from "@/lib/auth/auth-client";
 import { cancelWebSso as libCancelWebSso, runWebSso } from "@/lib/auth/web-sso";
 import {
@@ -371,8 +372,14 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
   cancelOAuth: () => {
     if (!get().oauthPending) return;
-    // Fire-and-forget: the loopback abort makes the in-flight signInWithOAuth
-    // promise reject with oauth_cancelled, whose catch block resets the state.
+    // Fire-and-forget: the abort makes the in-flight signInWithOAuth promise
+    // reject with oauth_cancelled, whose catch block resets the state. The
+    // extension has no abort API, so cancelExtensionOAuth races the flow rather
+    // than stopping it — Chrome's auth window may outlive this call.
+    if (isChromeExtension()) {
+      cancelExtensionOAuth();
+      return;
+    }
     void cancelDesktopOAuth();
   },
   signInWithWebSso: async () => {


### PR DESCRIPTION
Google sign-in worked on desktop only. In the extension side panel the login screen offered nothing but email OTP.

## Why it didn't work

Five independent blockers, not one:

| # | Blocker | Where |
|---|---|---|
| 1 | Every provider button gated on `isTauri()`, so the extension rendered no OAuth options at all | `LoginScreen.tsx:22-25` |
| 2 | `signInWithOAuth` always called `runDesktopOAuth`, which invokes the Tauri command `oauth_loopback_start` and throws outside Tauri | `cloud-api/auth.ts:82` |
| 3 | No way to capture the OAuth redirect without a loopback server | — |
| 4 | `identity` permission absent | `apps/extension/manifest.json` |
| 5 | GoTrue rejects the extension's redirect until it is allowlisted | deploy config |

## What this changes

`runExtensionOAuth` mirrors `runDesktopOAuth` exactly below the redirect capture — same FC endpoints, same verifier handling — swapping the native loopback listener for `chrome.identity.launchWebAuthFlow`. The runner is selected by platform rather than branched inside, and the `isTauri()` gate becomes a `capabilities.oauthSignIn` check, following the *"prefer these over scattered isTauri() checks"* note already in `platform.ts`.

**The server needed no code change.** `/v1/auth/oauth/:provider/authorize` and `/exchange` are transport-agnostic PKCE; FC does not validate `redirect` (GoTrue does); and the URI registered with Google is GoTrue's own `/auth/v1/callback`, which is invariant across clients — so **Google Cloud Console needs no change**. Confirmed FC returns a real `302` (`hono-adapter.ts:88`), so `launchWebAuthFlow` follows FC → GoTrue → Google → back to the chromiumapp.org redirect.

### Cancellation

`launchWebAuthFlow` has no abort API, so `cancelExtensionOAuth` races the flow rather than stopping it. Chrome's window may outlive the cancel, but the sign-in controls re-enable immediately instead of staying dead behind a window the user has already abandoned — matching desktop's intent.

Cancel detection matches on Chrome's `lastError` phrasing, and anything unrecognised stays `oauth_failed`. Mislabelling a broken provider page as "cancelled" would swallow the error message the user needs, so the ambiguity is resolved toward showing the error.

### Deliberately left desktop-only

WeChat (its redirect domain is registered against the desktop flow) and web SSO (needs a native webview). Only the `self-host` profile has `auth.google` enabled, so no feature-profile changes are included.

## Verification

- 9 new runner tests, 2 new UI-gate tests
- 129 auth tests, 153 tests across `platform.ts` consumers — all green
- `pnpm lint` and `pnpm typecheck` clean

## Deployment — merging this does NOT finish the job

Each extension id needs its redirect in `ADDITIONAL_REDIRECT_URLS`:

```
https://nlmkpmokfbboonocdnngddbfpdedkfee.chromiumapp.org/
```

Added to both env templates here, but the box deploys from its **own** `.env`, so **this must still be applied on the server by hand** followed by a GoTrue recreate (a plain `restart` will not pick up a changed compose env).

The failure mode if skipped is silent and confusing rather than loud: GoTrue rewrites an unlisted redirect back to `SITE_URL`, so the code never reaches the extension and sign-in just bounces.

Two related notes in `.env.example`:

- **Exact ids beat a `https://*.chromiumapp.org/` wildcard** — the wildcard lets any Chrome extension complete a sign-in flow against this GoTrue.
- **An unpacked dev build gets a random id** each reinstall unless `manifest.json` pins a `key`, so a dev id added to the list silently stops matching. Pinning the key needs the Web Store item's private key, so it is not done here.

## Heads-up

This touches `deploy/self-host/.env.example`, which is in Self-Host Deploy's trigger paths, so merging fires a deploy. The content is inert documentation and the deploy will not apply the allowlist.

## Pre-existing, not fixed here

`pnpm --filter @teamclu/extension typecheck` fails on `content-handler.test.ts` and `link-hover-zone.test.ts`. Unrelated to this change and not caught by CI, which runs only `pnpm typecheck` (app) and `typecheck:expo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)