### PR TITLE
fix(brand): a build with its own app.scheme speaks only that scheme

### DIFF
--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -135,6 +135,23 @@ fn main() {
     println!("cargo:rustc-env=TEAMCLU_DIR={}", teamclu_dir);
     println!("cargo:rustc-env=CONFIG_FILE_NAME={}", config_file_name);
 
+    // Deep-link scheme (`app.scheme`). Not derivable from short_name: betly's
+    // short name is "teamclaw" while it ships on the default "teamclu" scheme.
+    // Stamped onto amuxd so the teamclu-introspect sidecar's export_session_link
+    // hands out a link this build actually registers with the OS.
+    let app_scheme = config["app"]["scheme"].as_str().unwrap_or("teamclu");
+    assert!(
+        !app_scheme.is_empty()
+            && app_scheme.starts_with(|c: char| c.is_ascii_lowercase())
+            && app_scheme.chars().all(|c| c.is_ascii_lowercase()
+                || c.is_ascii_digit()
+                || matches!(c, '+' | '.' | '-')),
+        "app.scheme must start with a lowercase letter, then [a-z0-9+.-], got: '{}'",
+        app_scheme
+    );
+    println!("cargo:rustc-env=APP_SCHEME={}", app_scheme);
+    println!("cargo:warning=Using APP_SCHEME={}", app_scheme);
+
     // Export updater config from build.config.json (comma-separated for runtime fallback)
     let updater_endpoints = resolve_updater_endpoints(&config);
     if !updater_endpoints.is_empty() {

--- a/apps/desktop/src/commands/amuxd_supervisor.rs
+++ b/apps/desktop/src/commands/amuxd_supervisor.rs
@@ -31,6 +31,9 @@ const CURSOR_BRIDGE_MAIN_ENV: &str = "TEAMCLU_CURSOR_BRIDGE_MAIN";
 const CLAUDE_BRIDGE_MAIN_ENV: &str = "TEAMCLU_CLAUDE_BRIDGE_MAIN";
 const BRAND_SHORT_NAME_ENV: &str = teamclu_runtime_env::BRAND_SHORT_NAME_ENV;
 const AMUXD_HOME_ENV: &str = teamclu_runtime_env::AMUXD_HOME_ENV;
+/// Read by the teamclu-introspect sidecar (`export_session_link`), which amuxd
+/// registers as an MCP server and therefore inherits this from.
+const APP_SCHEME_ENV: &str = "TEAMCLU_APP_SCHEME";
 const LAUNCHD_LABEL: &str = "cc.ucar.amuxd";
 
 struct SupervisorInner {
@@ -612,6 +615,7 @@ impl AmuxdSupervisor {
         let amuxd_home = amuxd_dir();
         cmd.env(BRAND_SHORT_NAME_ENV, super::APP_SHORT_NAME);
         cmd.env(AMUXD_HOME_ENV, &amuxd_home);
+        cmd.env(APP_SCHEME_ENV, super::APP_SCHEME);
         if let Some(introspect) = bundled_introspect_path() {
             cmd.env(INTROSPECT_ENV, introspect);
         }

--- a/apps/desktop/src/commands/mod.rs
+++ b/apps/desktop/src/commands/mod.rs
@@ -53,6 +53,10 @@ use crate::process_util::CommandNoWindow;
 
 /// The short application name, injected at compile time via `build.rs`.
 pub const APP_SHORT_NAME: &str = env!("APP_SHORT_NAME");
+/// Deep-link scheme for this build (`app.scheme`, default `teamclu`).
+/// Independent of `APP_SHORT_NAME` — betly is short name `teamclaw` on scheme
+/// `teamclu`, copilot361 is `copilot361` on both.
+pub const APP_SCHEME: &str = env!("APP_SCHEME");
 /// Workspace metadata directory (`.teamclu` for official builds).
 pub const TEAMCLU_DIR: &str = env!("TEAMCLU_DIR");
 /// Subfolder inside workspace where the team repo is cloned / symlinked.

--- a/packages/app/src/__tests__/App.test.tsx
+++ b/packages/app/src/__tests__/App.test.tsx
@@ -97,6 +97,7 @@ vi.mock('@/lib/build-config', () => ({
   appShortName: 'teamclu',
   appStoragePrefix: 'teamclu',
   appScheme: 'teamclu',
+  deeplinkSchemes: ['teamclu', 'teamclaw', 'amux'],
   TEAM_REPO_DIR: 'teamclu-team',
   buildConfig: {
     app: { name: 'TeamClu' },

--- a/packages/app/src/__tests__/invite-deeplink.test.ts
+++ b/packages/app/src/__tests__/invite-deeplink.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { parseInviteDeeplink, parseInviteTokenInput } from '@/lib/invite-deeplink'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { buildInviteDeeplink, parseInviteDeeplink, parseInviteTokenInput } from '@/lib/invite-deeplink'
 
 describe('parseInviteDeeplink', () => {
   it('extracts the token from teamclu://invite?token=…', () => {
@@ -38,5 +38,49 @@ describe('parseInviteDeeplink', () => {
 
   it('rejects non-invite urls for pasted onboarding input', () => {
     expect(parseInviteTokenInput('https://example.com/invite?token=nope')).toBeNull()
+  })
+})
+
+describe('buildInviteDeeplink', () => {
+  it('builds the link on the build scheme, not the backend amux:// one', () => {
+    expect(buildInviteDeeplink('TOK/EN+1')).toBe('teamclu://invite?token=TOK%2FEN%2B1')
+  })
+})
+
+describe('a build with its own app.scheme', () => {
+  afterEach(() => {
+    vi.doUnmock('@/lib/build-config')
+    vi.resetModules()
+  })
+
+  async function loadForScheme(scheme: string) {
+    vi.resetModules()
+    vi.doMock('@/lib/build-config', async () => {
+      const actual =
+        await vi.importActual<typeof import('@/lib/build-config')>('@/lib/build-config')
+      return { ...actual, appScheme: scheme, deeplinkSchemes: actual.resolveDeeplinkSchemes(scheme) }
+    })
+    return import('@/lib/invite-deeplink')
+  }
+
+  it('takes copilot361:// and nothing else', async () => {
+    // The OS only ever hands this build copilot361:// links; a teamclu:// or
+    // amux:// one would open the official app, so accepting it here just made a
+    // dead link look supported.
+    const { parseInviteDeeplink: parse } = await loadForScheme('copilot361')
+    expect(parse('copilot361://invite?token=OK')).toBe('OK')
+    expect(parse('teamclu://invite?token=NO')).toBeNull()
+    expect(parse('teamclaw://invite?token=NO')).toBeNull()
+    expect(parse('amux://invite?token=NO')).toBeNull()
+  })
+
+  it('hands out invite links on its own scheme', async () => {
+    const { buildInviteDeeplink: build } = await loadForScheme('copilot361')
+    expect(build('TOK')).toBe('copilot361://invite?token=TOK')
+  })
+
+  it('still takes a bare pasted token', async () => {
+    const { parseInviteTokenInput: parseInput } = await loadForScheme('copilot361')
+    expect(parseInput('  bare_token_123  ')).toBe('bare_token_123')
   })
 })

--- a/packages/app/src/__tests__/session-deeplink.test.ts
+++ b/packages/app/src/__tests__/session-deeplink.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { parseSessionDeeplink, buildSessionDeeplink } from '@/lib/session-deeplink'
 
 const UUID = 'a1ca8f06-94ee-4fb5-bdfb-194a5606062f'
@@ -33,5 +33,30 @@ describe('parseSessionDeeplink', () => {
 describe('buildSessionDeeplink', () => {
   it('builds teamclu://session/<uuid> using the build scheme', () => {
     expect(buildSessionDeeplink(UUID)).toBe(`teamclu://session/${UUID}`)
+  })
+})
+
+describe('a build with its own app.scheme', () => {
+  afterEach(() => {
+    vi.doUnmock('@/lib/build-config')
+    vi.resetModules()
+  })
+
+  it('takes copilot361:// and nothing else', async () => {
+    vi.resetModules()
+    vi.doMock('@/lib/build-config', async () => {
+      const actual =
+        await vi.importActual<typeof import('@/lib/build-config')>('@/lib/build-config')
+      return {
+        ...actual,
+        appScheme: 'copilot361',
+        deeplinkSchemes: actual.resolveDeeplinkSchemes('copilot361'),
+      }
+    })
+    const mod = await import('@/lib/session-deeplink')
+    expect(mod.parseSessionDeeplink(`copilot361://session/${UUID}`)).toBe(UUID)
+    expect(mod.parseSessionDeeplink(`teamclu://session/${UUID}`)).toBeNull()
+    expect(mod.parseSessionDeeplink(`amux://session/${UUID}`)).toBeNull()
+    expect(mod.buildSessionDeeplink(UUID)).toBe(`copilot361://session/${UUID}`)
   })
 })

--- a/packages/app/src/components/auth/__tests__/DesktopOnboarding.test.tsx
+++ b/packages/app/src/components/auth/__tests__/DesktopOnboarding.test.tsx
@@ -53,6 +53,7 @@ vi.mock("@/lib/version", () => ({
 vi.mock("@/lib/build-config", () => ({
   buildConfig: { app: { name: "TeamClu" } },
   appScheme: 'teamclu',
+  deeplinkSchemes: ['teamclu', 'teamclaw', 'amux'],
 }));
 
 import { DesktopOnboarding } from "../DesktopOnboarding";

--- a/packages/app/src/components/sidebar/ActorDetailDialog.tsx
+++ b/packages/app/src/components/sidebar/ActorDetailDialog.tsx
@@ -23,6 +23,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { getBackend } from '@/lib/backend'
+import { buildInviteDeeplink } from '@/lib/invite-deeplink'
 import { formatActorRemoveError } from '@/lib/actor-remove-error'
 import type { ClientVersionEntry } from '@/lib/backend/types'
 import { actorAvatarColor } from '@/lib/actor-color'
@@ -211,13 +212,14 @@ export function ActorDetailDialog({ actor, teamId, onOpenChange, onRemoved }: Pr
         ttlSeconds: null,
         targetActorId: displayActor.id,
       })
-      const deeplink = row.deeplink ?? row.inviteUrl
-      if (!deeplink) {
+      if (!row.token) {
         toast.error(t('invite.failed', 'Failed to create invite: {{msg}}', { msg: 'empty response' }))
         return
       }
       setReinvite({
-        deeplink,
+        // Not row.deeplink: that carries the backend's `amux://` scheme, which
+        // no build registers with the OS.
+        deeplink: buildInviteDeeplink(row.token),
         expiresAt: row.expiresAt ?? new Date(Date.now() + 604800 * 1000).toISOString(),
       })
     } catch (e) {

--- a/packages/app/src/components/sidebar/InviteActorDialog.tsx
+++ b/packages/app/src/components/sidebar/InviteActorDialog.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { UpgradeToOrgDialog } from '@/components/auth/UpgradeToOrgDialog'
 import { getBackend } from '@/lib/backend'
+import { buildInviteDeeplink } from '@/lib/invite-deeplink'
 import { cn } from '@/lib/utils'
 import { useCurrentTeamStore } from '@/stores/current-team'
 
@@ -95,15 +96,16 @@ export function InviteActorDialog({ open, onOpenChange, teamId }: InviteActorDia
             ttlSeconds: null,
             targetActorId: null,
           })
-      const deeplink = row.deeplink ?? row.inviteUrl
-      if (!deeplink) {
+      if (!row.token) {
         toast.error(t('invite.failed', 'Failed to create invite: {{msg}}', { msg: 'empty response' }))
         return
       }
       setInvite({
         token: row.token,
         expiresAt: row.expiresAt ?? new Date(Date.now() + 604800 * 1000).toISOString(),
-        deeplink,
+        // Not row.deeplink: that carries the backend's `amux://` scheme, which
+        // no build registers with the OS.
+        deeplink: buildInviteDeeplink(row.token),
       })
     } catch (e) {
       // Default-org teams are solo-only: inviting members requires upgrading the

--- a/packages/app/src/lib/__tests__/build-config.test.ts
+++ b/packages/app/src/lib/__tests__/build-config.test.ts
@@ -4,6 +4,7 @@ import {
   appDisplayName,
   FALLBACK_BUILD_CONFIG,
   resolveAmuxdDirName,
+  resolveDeeplinkSchemes,
 } from "@/lib/build-config";
 
 describe("build-config auth.webSSO", () => {
@@ -28,5 +29,20 @@ describe("resolveAmuxdDirName", () => {
     expect(resolveAmuxdDirName("teamclu")).toBe("amuxd");
     expect(resolveAmuxdDirName("teamcludev")).toBe("amuxd");
     expect(resolveAmuxdDirName("copilot361")).toBe("amuxd-copilot361");
+  });
+});
+
+describe("resolveDeeplinkSchemes", () => {
+  it("keeps the legacy schemes for builds on the default scheme", () => {
+    // betly ships without app.scheme, so it lands here too and keeps accepting
+    // the amux:// links its backend hands out.
+    expect(resolveDeeplinkSchemes(undefined)).toEqual(["teamclu", "teamclaw", "amux"]);
+    expect(resolveDeeplinkSchemes("teamclu")).toEqual(["teamclu", "teamclaw", "amux"]);
+  });
+
+  it("restricts a build with its own scheme to that scheme alone", () => {
+    // copilot361 registers only copilot361:// with the OS — a teamclu:// link
+    // would open the official app, never this build.
+    expect(resolveDeeplinkSchemes("copilot361")).toEqual(["copilot361"]);
   });
 });

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -221,7 +221,30 @@ export const appStoragePrefix: string = resolveStorageDirName(appShortName)
 /** The product name to show users. Prefer this over `buildConfig.app.name` in
  *  any UI string — `app.name` is the bundle identity and may differ. */
 export const appDisplayName: string = buildConfig.app.displayName ?? buildConfig.app.name
-export const appScheme: string = buildConfig.app.scheme ?? 'teamclu'
+/** Deep-link scheme used when a build does not declare `app.scheme`. */
+export const DEFAULT_APP_SCHEME = 'teamclu'
+export const appScheme: string = buildConfig.app.scheme ?? DEFAULT_APP_SCHEME
+
+/**
+ * Schemes this build accepts on an inbound deeplink.
+ *
+ * A build that declares its own `app.scheme` speaks only that scheme.
+ * `scripts/lib/branding.js` rewrites tauri.conf's deep-link list to exactly
+ * `[app.scheme]`, so the OS never hands a `teamclu://` link to that build in the
+ * first place — accepting them here only made a pasted official link look
+ * supported. copilot361 (scheme `copilot361`) is such a build.
+ *
+ * Builds with no explicit scheme keep the legacy list: `teamclaw://` from before
+ * the rename, and `amux://`, which is still what the `create_team_invite` RPC
+ * emits. That covers the official builds and the betly brand, which ships on the
+ * default `teamclu` scheme.
+ */
+export function resolveDeeplinkSchemes(scheme: string | undefined): string[] {
+  const own = scheme ?? DEFAULT_APP_SCHEME
+  return own === DEFAULT_APP_SCHEME ? [own, 'teamclaw', 'amux'] : [own]
+}
+
+export const deeplinkSchemes: readonly string[] = resolveDeeplinkSchemes(buildConfig.app.scheme)
 /**
  * Local agent runtime for this build. Defaults to opencode.
  *

--- a/packages/app/src/lib/invite-deeplink.ts
+++ b/packages/app/src/lib/invite-deeplink.ts
@@ -1,15 +1,23 @@
 import { getBackend } from '@/lib/backend'
-import { appScheme } from '@/lib/build-config'
+import { appScheme, deeplinkSchemes } from '@/lib/build-config'
 
-// `create_team_invite` RPC returns deeplinks with the `amux://` scheme (shared
-// with iOS). The desktop app accepts the build's configured scheme as well as
-// `teamclu://`, the pre-rebrand `teamclaw://`, and `amux://` for back-compat.
-//
-// `teamclaw:` is a historical fact, not a brand string: invite links already
-// handed out carry it, and a white-label build (whose appScheme is its own) has
-// no other way to accept an official link.
-const INVITE_SCHEMES = new Set([`${appScheme}:`, 'teamclu:', 'teamclaw:', 'amux:'])
+// Which schemes count as an invite link is a build-level decision — see
+// `resolveDeeplinkSchemes`. A build on the default scheme also takes the
+// pre-rebrand `teamclaw://` and the `amux://` the RPC emits; a build with its
+// own scheme (copilot361) takes only that one.
+const INVITE_SCHEMES = new Set(deeplinkSchemes.map((s) => `${s}:`))
 const INVITE_HOST = 'invite'
+
+/**
+ * The invite link to hand out, always on this build's own scheme.
+ *
+ * Built from the token rather than passed through from the backend: the
+ * `create_team_invite` RPC still returns `amux://invite?token=…`, a scheme no
+ * build registers with the OS, and the pg-repo backend returns no link at all.
+ */
+export function buildInviteDeeplink(token: string): string {
+  return `${appScheme}://${INVITE_HOST}?token=${encodeURIComponent(token)}`
+}
 
 export function parseInviteDeeplink(raw: string): string | null {
   try {

--- a/packages/app/src/lib/session-deeplink.ts
+++ b/packages/app/src/lib/session-deeplink.ts
@@ -1,12 +1,11 @@
-import { appScheme } from '@/lib/build-config'
+import { appScheme, deeplinkSchemes } from '@/lib/build-config'
 
-// The desktop app accepts the build's configured scheme as well as `teamclu://`,
-// the pre-rebrand `teamclaw://`, and `amux://` for back-compat (shared with iOS).
-//
-// `teamclaw:` is a historical fact, not a brand string: session links already
-// shared with teammates carry it, and a white-label build (whose appScheme is
-// its own) has no other way to accept an official link.
-const SESSION_SCHEMES = new Set([`${appScheme}:`, 'teamclu:', 'teamclaw:', 'amux:'])
+// Which schemes count as a session link is a build-level decision — see
+// `resolveDeeplinkSchemes`. A build on the default scheme also takes the
+// pre-rebrand `teamclaw://` and `amux://` (shared with iOS), so links already
+// shared with teammates keep working; a build with its own scheme (copilot361)
+// takes only that one.
+const SESSION_SCHEMES = new Set(deeplinkSchemes.map((s) => `${s}:`))
 const SESSION_HOST = 'session'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i


### PR DESCRIPTION
copilot361 deeplinks should be `copilot361://` only — no `teamclu://` compat.

## The rule

Derived from the brand config rather than a hardcoded brand check: **a build that declares its own `app.scheme` accepts that scheme and nothing else.**

- **copilot361** — `brands/copilot361/build.config.json` sets `"scheme": "copilot361"` → strict. `teamclu://invite?token=…` and `amux://session/<uuid>` now parse to null.
- **betly / official** — declare no scheme, so they ship on the default `teamclu` and keep the `teamclaw://` + `amux://` back-compat untouched.

This matches what the OS already does: `scripts/lib/branding.js` rewrites tauri.conf's deep-link list to exactly `[app.scheme]`, so a `teamclu://` link never reaches a copilot361 build. Accepting it in the parser only made a pasted official link *look* supported.

Pasting a bare invite token still works on every build.

## Two leaks where the build handed out links it can't open

- **Invite dialogs** displayed the backend's `deeplink` verbatim, and `create_team_invite` still returns `amux://invite?token=…` — a scheme *no* build registers with the OS. Both dialogs now build from `row.token` via `buildInviteDeeplink()`. Side effect: this fixes the pg-repo backend, which returns `deeplink: null` and made the dialog fail with "empty response".
- **`export_session_link`** (the `teamclu-introspect` MCP tool) reads `TEAMCLU_APP_SCHEME`, which nothing in the repo ever set — so the agent handed out `teamclu://session/<uuid>` on copilot361. `apps/desktop/build.rs` now bakes `APP_SCHEME` from the brand config and the amuxd supervisor stamps it onto the daemon, which the sidecar inherits.

## Left alone deliberately

The daemon's `apps/daemon/src/onboarding/invite_url.rs` parser. It's a brand-shared binary with no reliable way to know its brand's scheme (betly is short name `teamclaw` on scheme `teamclu`), it already accepts any custom scheme, and it only ever sees URLs the desktop built.

## Verification

`pnpm typecheck` clean · app suite 426 files / 2725 tests pass · `pnpm lint` 0 errors · `cargo clippy -- -D warnings` exit 0 · `cargo fmt --check` clean.

New tests cover both arms of `resolveDeeplinkSchemes` and a simulated copilot361 build (accepts only its own scheme, emits only its own scheme, still takes a bare token). Two existing test files mock `@/lib/build-config` wholesale and needed the new export added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)