### PR TITLE
fix(ci): run the frontend job on lts/*, not the Node 20 that lacks node:sqlite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # `lts/*`, matching every other workflow in this repo — so CI validates on
+      # the same Node the release jobs build with, rather than a version nothing
+      # ships on. The old '20' pin was the outlier, and it broke the Expo suite:
+      # its cache tests drive a real SQLite through `node:sqlite`
+      # (src/test/helpers/memory-db.ts), a built-in that does not exist before
+      # Node 22.5 and is behind --experimental-sqlite until 23.4, so four suites
+      # died at import with "No such built-in module: node:sqlite".
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: lts/*
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.10

--- a/apps/expo/CI.md
+++ b/apps/expo/CI.md
@@ -27,6 +27,23 @@ Google and Apple sign-in (`teamclu://auth/callback` against the allow-listed
 `teamclu://auth-callback`) lived here undetected, with test fixtures that
 asserted the *broken* value.
 
+## The suite needs Node ≥ 24
+
+`src/test/helpers/memory-db.ts` runs the cache tests against a real database
+via `node:sqlite`, so the schema, constraints and ordering under test are
+SQLite's own rather than a fake's. That built-in does not exist before Node
+22.5 and stays behind `--experimental-sqlite` until 23.4.
+
+The `Lint, Typecheck & Test` job was pinned to Node 20 while every other
+workflow used `lts/*`. The moment these tests landed, four suites — `session-cache`,
+`session-detail-cache`, `streaming-snapshot`, `team-cache` — failed at *import*
+with `No such built-in module: node:sqlite`, reddening CI on main for three
+commits. A suite that fails to load takes its whole file down, so the failure
+read as four broken features rather than one missing runtime.
+
+CI is now on `lts/*` and the root `engines.node` says `>=24.0.0`, so a dev on an
+older Node gets a warning at install rather than that error at test time.
+
 ## Two fixes worth keeping a record of
 
 ### `<WebView>` — every prop was `never`

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "packageManager": "pnpm@10.33.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
main has been red for three commits. One missing runtime, not four broken features.

## What broke

`apps/expo/src/test/helpers/memory-db.ts` drives the cache tests against a real database through **`node:sqlite`**, so the schema, constraints and ordering under test are SQLite's own rather than a fake's. That built-in does not exist before Node 22.5, and sits behind `--experimental-sqlite` until 23.4.

The `Lint, Typecheck & Test` job was pinned to **Node 20** — the only such pin in the repo; the other seven workflow steps all use `lts/*`. The moment those tests landed (`d77f920c`), four suites failed at *import*:

```
FAIL src/test/session-cache.test.ts
FAIL src/test/session-detail-cache.test.ts
FAIL src/test/streaming-snapshot.test.ts
FAIL src/test/team-cache.test.ts
Error: No such built-in module: node:sqlite
```

A suite that fails to load takes its whole file down, so this read as four broken features instead of one runtime that was too old.

## The fix

- **`node-version: lts/*`** — CI now validates on the same Node the release jobs build with, instead of a version nothing ships on. The pin was the outlier.
- **`engines.node: ">=24.0.0"`** — the honest floor for the suite, so a dev on an older Node gets a warning at install rather than that error at test time.
- A note in `apps/expo/CI.md`, which is where this repo already keeps its CI-coverage decisions.

**`services/fc` is untouched.** Its container builds from its own `services/fc/package.json` + lockfile against `node:20-slim`, with no `engines` field and no dependency on the root workspace — the root floor does not reach it.

## Verification

Every step of the job, run locally on Node 26: ESLint 0 errors · `pnpm typecheck` clean · app suite 426 files / 2725 tests · `pnpm typecheck:expo` clean · **`pnpm test:expo` 93/93 suites, 572 tests** · `pnpm test:scripts` 90/90.

That 572 is against CI's previous 530 — **42 tests that had never once executed.**

One thing I could not check locally: `lts/*` resolves to Node 24 on the runners, and my machine is on 26. `node:sqlite` is unflagged from 23.4 onward so 24 should be fine, but this PR's own CI run is the real proof — worth a look at the Expo step before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)