### PR TITLE
fix(desktop): resolve bundled claude-bridge under Resources/binaries

### DIFF
--- a/apps/daemon/src/runtime/sidecar/bridge_path.rs
+++ b/apps/daemon/src/runtime/sidecar/bridge_path.rs
@@ -32,28 +32,45 @@ fn push_candidate(out: &mut Vec<PathBuf>, path: PathBuf) {
     }
 }
 
-/// Candidate locations for a bundled bridge main script, most-specific first.
-pub fn bundled_bridge_candidates(relative: &str) -> Vec<PathBuf> {
+/// Candidate locations for a bundled bridge main script next to `exe_dir`
+/// (typically `…/Contents/MacOS`), most-specific first.
+///
+/// Tauri ships `resources: ["binaries/claude-bridge/**/*"]` as
+/// `Contents/Resources/binaries/claude-bridge/…` — the `binaries/` prefix is
+/// preserved. Looking only under `Resources/<bridge>/` misses the release
+/// layout and falls through to the CI `CARGO_MANIFEST_DIR` path.
+pub fn bundled_bridge_candidates_from(exe_dir: &Path, relative: &str) -> Vec<PathBuf> {
     let mut out = Vec::new();
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            push_candidate(&mut out, dir.join(relative));
-            if let Some(parent) = dir.parent() {
-                push_candidate(&mut out, parent.join("Resources").join(relative));
-                if let Some(bridge_dir) = relative.split('/').next().filter(|s| !s.is_empty()) {
-                    push_candidate(
-                        &mut out,
-                        parent
-                            .join("share")
-                            .join("teamclu")
-                            .join(bridge_dir)
-                            .join(relative.split('/').skip(1).collect::<Vec<_>>().join("/")),
-                    );
-                }
-            }
+    push_candidate(&mut out, exe_dir.join(relative));
+    if let Some(parent) = exe_dir.parent() {
+        push_candidate(&mut out, parent.join("Resources").join(relative));
+        push_candidate(
+            &mut out,
+            parent.join("Resources").join("binaries").join(relative),
+        );
+        if let Some(bridge_dir) = relative.split('/').next().filter(|s| !s.is_empty()) {
+            push_candidate(
+                &mut out,
+                parent
+                    .join("share")
+                    .join("teamclu")
+                    .join(bridge_dir)
+                    .join(relative.split('/').skip(1).collect::<Vec<_>>().join("/")),
+            );
         }
     }
     out
+}
+
+/// Candidate locations for a bundled bridge main script, most-specific first.
+pub fn bundled_bridge_candidates(relative: &str) -> Vec<PathBuf> {
+    match std::env::current_exe() {
+        Ok(exe) => exe
+            .parent()
+            .map(|dir| bundled_bridge_candidates_from(dir, relative))
+            .unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
 }
 
 pub fn resolve_bridge_main(relative: &str, env_key: &str) -> PathBuf {
@@ -109,11 +126,33 @@ mod tests {
 
     #[test]
     fn bundled_candidates_include_resources_layout() {
-        let cands = bundled_bridge_candidates(CURSOR_BRIDGE_REL);
-        assert!(!cands.is_empty());
+        let cands = bundled_bridge_candidates_from(
+            Path::new("/Applications/App.app/Contents/MacOS"),
+            CURSOR_BRIDGE_REL,
+        );
         assert!(cands.iter().any(|p| p
             .to_string_lossy()
-            .contains("Resources/cursor-bridge/src/main.mjs")));
+            .ends_with("Contents/Resources/cursor-bridge/src/main.mjs")));
+    }
+
+    #[test]
+    fn bundled_candidates_include_tauri_resources_binaries_layout() {
+        // Regression: Copilot 361 release bundles bridges under
+        // Resources/binaries/<bridge>/ (tauri resource path prefix). Missing
+        // this candidate made amuxd spawn the CI checkout path
+        // (/Users/runner/work/…) and every list_models probe die with
+        // "bridge exited before responding".
+        let cands = bundled_bridge_candidates_from(
+            Path::new("/Applications/Copilot 361.app/Contents/MacOS"),
+            CLAUDE_BRIDGE_REL,
+        );
+        assert!(
+            cands.iter().any(|p| {
+                p.to_string_lossy()
+                    .ends_with("Contents/Resources/binaries/claude-bridge/src/main.mjs")
+            }),
+            "candidates={cands:?}"
+        );
     }
 
     #[test]

--- a/apps/desktop/src/commands/amuxd_supervisor.rs
+++ b/apps/desktop/src/commands/amuxd_supervisor.rs
@@ -135,25 +135,33 @@ fn bundled_introspect_path() -> Option<PathBuf> {
     locate_bundled_sidecar("teamclu-introspect")
 }
 
-fn locate_bundled_bridge_main(bridge_name: &str) -> Option<PathBuf> {
+/// Candidate paths for a bridge `src/main.mjs`, most-specific first.
+///
+/// Tauri packs `resources: ["binaries/<bridge>/**/*"]` as
+/// `Contents/Resources/binaries/<bridge>/…`. Omitting that layout left
+/// `TEAMCLU_*_BRIDGE_MAIN` unset in release, and amuxd fell back to the CI
+/// `CARGO_MANIFEST_DIR` path (`/Users/runner/work/…`).
+fn bundled_bridge_main_candidates(
+    bridge_name: &str,
+    exe_dir: &Path,
+    manifest_dir: &Path,
+) -> Vec<PathBuf> {
     let rel = format!("{bridge_name}/src/main.mjs");
-    let dev = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("binaries")
-        .join(&rel);
-    if dev.is_file() {
-        return Some(dev);
-    }
+    vec![
+        manifest_dir.join("binaries").join(&rel),
+        exe_dir.join(&rel),
+        exe_dir.join("../Resources").join(&rel),
+        exe_dir.join("../Resources/binaries").join(&rel),
+    ]
+}
+
+fn locate_bundled_bridge_main(bridge_name: &str) -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
     let dir = exe.parent()?;
-    let sibling = dir.join(&rel);
-    if sibling.is_file() {
-        return Some(sibling);
-    }
-    let resources = dir.join("../Resources").join(&rel);
-    if resources.is_file() {
-        return Some(resources);
-    }
-    None
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    bundled_bridge_main_candidates(bridge_name, dir, manifest)
+        .into_iter()
+        .find(|p| p.is_file())
 }
 
 fn amuxd_dir() -> PathBuf {
@@ -796,4 +804,23 @@ pub async fn daemon_supervisor_status<R: Runtime>(
     app: AppHandle<R>,
 ) -> Result<DaemonSupervisorStatus, String> {
     Ok(AmuxdSupervisor::status(&app).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bridge_candidates_include_tauri_resources_binaries_layout() {
+        let exe_dir = Path::new("/Applications/Copilot 361.app/Contents/MacOS");
+        let manifest = Path::new("/tmp/does-not-exist-manifest");
+        let cands = bundled_bridge_main_candidates("claude-bridge", exe_dir, manifest);
+        assert!(
+            cands.iter().any(|p| {
+                p.to_string_lossy()
+                    .contains("Resources/binaries/claude-bridge/src/main.mjs")
+            }),
+            "candidates={cands:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Copilot 361 (`local_agent = claude-code`) showed **Model list unavailable** because amuxd spawned `claude-bridge` from the CI checkout path (`/Users/runner/work/...`) instead of the app bundle.
- Tauri packs bridges as `Contents/Resources/binaries/<bridge>/…`; the desktop supervisor and amuxd only looked under `Resources/<bridge>/`, so `TEAMCLU_CLAUDE_BRIDGE_MAIN` was never set.
- Teach both resolvers about the `Resources/binaries/` layout and add regression tests.

## Test plan
- [x] `cargo test --manifest-path apps/daemon/Cargo.toml bundled_candidates_include_tauri`
- [x] `cargo test --manifest-path apps/desktop/Cargo.toml --lib bridge_candidates_include_tauri`
- [x] On a Copilot 361 install: after pointing bridge at the bundled path, `GET /v1/workspaces/.../model-catalog` returns claude models with `probe_error: null`
- [ ] Install a build that includes this fix and confirm Copilot 361 model pill leaves "Model list unavailable" without a `daemon.toml` workaround


Made with [Cursor](https://cursor.com)