### PR TITLE
feat(settings): align OpenCode LLM Model list with session catalog

### DIFF
--- a/docs/superpowers/plans/2026-08-11-opencode-settings-model-catalog.md
+++ b/docs/superpowers/plans/2026-08-11-opencode-settings-model-catalog.md
@@ -1,0 +1,538 @@
+# OpenCode Settings Model Catalog Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Settings → LLM Model list models from the same loopback `model-catalog` as the session picker (OpenCode `/config/providers`), while keeping `/providers` for connection management only.
+
+**Architecture:** Add a pure helper that groups catalog `provider/model` refs by provider. `OpenCodeLLMSection` reads `useLocalDaemonCatalogStore` (via `ensureLocalDaemonCatalog(..., 'opencode')`) for model lists and expandability; `useProviderStore` stays authoritative for Connect / Disconnect / OAuth / custom CRUD. Catalog-only providers (e.g. free `opencode`) are merged into the visible provider list so they can expand without being `configured`.
+
+**Tech Stack:** React 19, TypeScript, Zustand, Vitest, Testing Library; daemon loopback `GET /v1/workspaces/:id/model-catalog` (unchanged).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-11-opencode-settings-model-catalog-design.md`
+- Direction A: Settings shows the full session-equivalent model list; connection management retained.
+- Model authority for Settings OpenCode section: loopback `model-catalog` / `local-daemon-catalog-store` — **not** MQTT retain, **not** `configuredProviders`.
+- Connection authority: `GET /providers` / `useProviderStore.providers[].configured` unchanged.
+- No daemon `/providers` contract changes.
+- Team Shared LLM pane out of scope; session picker logic out of scope.
+- Work on branch `feat/opencode-settings-model-catalog`; never push to `main`; commit per task; do not open a PR unless asked.
+- Prefer TDD: failing test → implement → pass → commit.
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `packages/app/src/lib/group-catalog-models-by-provider.ts` | Pure: group `{ id, displayName }[]` → per-provider model lists |
+| `packages/app/src/lib/__tests__/group-catalog-models-by-provider.test.ts` | Unit tests for the helper |
+| `packages/app/src/components/settings/LLMSection.tsx` | Wire OpenCode settings UI to catalog + expand rules + force refetch |
+| `packages/app/src/components/settings/__tests__/LLMSection.test.tsx` | Component tests for catalog-backed listing / expand / refetch |
+
+---
+
+### Task 1: `groupCatalogModelsByProvider` helper (TDD)
+
+**Files:**
+- Create: `packages/app/src/lib/group-catalog-models-by-provider.ts`
+- Create: `packages/app/src/lib/__tests__/group-catalog-models-by-provider.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export type CatalogModelOption = { id: string; name: string }
+  export type CatalogProviderGroup = {
+    providerId: string
+    models: CatalogModelOption[]
+  }
+
+  /** Group `provider/model` catalog entries. Preserves input order; dedupes by full id. */
+  export function groupCatalogModelsByProvider(
+    models: ReadonlyArray<{ id: string; displayName?: string | null }>,
+  ): CatalogProviderGroup[]
+
+  /** Models for one provider id (case-sensitive match on the prefix before `/`). */
+  export function catalogModelsForProvider(
+    models: ReadonlyArray<{ id: string; displayName?: string | null }>,
+    providerId: string,
+  ): CatalogModelOption[]
+  ```
+- Consumes: nothing from other tasks.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  catalogModelsForProvider,
+  groupCatalogModelsByProvider,
+} from '../group-catalog-models-by-provider'
+
+describe('groupCatalogModelsByProvider', () => {
+  it('groups by provider prefix and keeps full refs + display names', () => {
+    const groups = groupCatalogModelsByProvider([
+      { id: 'opencode/qwen3.6-plus-free', displayName: 'OpenCode Zen/Qwen3.6 Plus Free' },
+      { id: 'anthropic/claude-sonnet-4', displayName: 'Claude Sonnet 4' },
+      { id: 'opencode/gpt-5-nano', displayName: 'OpenCode Zen/GPT-5 Nano' },
+    ])
+    expect(groups).toEqual([
+      {
+        providerId: 'opencode',
+        models: [
+          { id: 'opencode/qwen3.6-plus-free', name: 'OpenCode Zen/Qwen3.6 Plus Free' },
+          { id: 'opencode/gpt-5-nano', name: 'OpenCode Zen/GPT-5 Nano' },
+        ],
+      },
+      {
+        providerId: 'anthropic',
+        models: [{ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' }],
+      },
+    ])
+  })
+
+  it('dedupes by full id and falls back name to id', () => {
+    const groups = groupCatalogModelsByProvider([
+      { id: 'opencode/a', displayName: 'A' },
+      { id: 'opencode/a', displayName: 'A duplicate' },
+      { id: 'opencode/b', displayName: '  ' },
+      { id: '', displayName: 'skip' },
+      { id: 'nopath', displayName: 'No slash' },
+    ])
+    expect(groups).toEqual([
+      {
+        providerId: 'opencode',
+        models: [
+          { id: 'opencode/a', name: 'A' },
+          { id: 'opencode/b', name: 'opencode/b' },
+        ],
+      },
+      {
+        providerId: 'nopath',
+        models: [{ id: 'nopath', name: 'No slash' }],
+      },
+    ])
+  })
+
+  it('catalogModelsForProvider returns only that provider', () => {
+    const models = catalogModelsForProvider(
+      [
+        { id: 'opencode/a', displayName: 'A' },
+        { id: 'openai/b', displayName: 'B' },
+      ],
+      'opencode',
+    )
+    expect(models).toEqual([{ id: 'opencode/a', name: 'A' }])
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm exec vitest run packages/app/src/lib/__tests__/group-catalog-models-by-provider.test.ts`
+Expected: FAIL (module not found / export missing)
+
+- [ ] **Step 3: Implement the helper**
+
+```ts
+// packages/app/src/lib/group-catalog-models-by-provider.ts
+
+export type CatalogModelOption = { id: string; name: string }
+
+export type CatalogProviderGroup = {
+  providerId: string
+  models: CatalogModelOption[]
+}
+
+function splitProviderModel(id: string): { providerId: string; modelId: string } | null {
+  const trimmed = id.trim()
+  if (!trimmed) return null
+  const slash = trimmed.indexOf('/')
+  if (slash <= 0) return { providerId: trimmed, modelId: trimmed }
+  return {
+    providerId: trimmed.slice(0, slash),
+    modelId: trimmed.slice(slash + 1),
+  }
+}
+
+export function groupCatalogModelsByProvider(
+  models: ReadonlyArray<{ id: string; displayName?: string | null }>,
+): CatalogProviderGroup[] {
+  const groups: CatalogProviderGroup[] = []
+  const byProvider = new Map<string, CatalogProviderGroup>()
+  const seen = new Set<string>()
+
+  for (const model of models) {
+    const id = model.id?.trim()
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    const parts = splitProviderModel(id)
+    if (!parts) continue
+    const name = model.displayName?.trim() || id
+    let group = byProvider.get(parts.providerId)
+    if (!group) {
+      group = { providerId: parts.providerId, models: [] }
+      byProvider.set(parts.providerId, group)
+      groups.push(group)
+    }
+    group.models.push({ id, name })
+  }
+
+  return groups
+}
+
+export function catalogModelsForProvider(
+  models: ReadonlyArray<{ id: string; displayName?: string | null }>,
+  providerId: string,
+): CatalogModelOption[] {
+  return groupCatalogModelsByProvider(models).find((g) => g.providerId === providerId)?.models ?? []
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm exec vitest run packages/app/src/lib/__tests__/group-catalog-models-by-provider.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/lib/group-catalog-models-by-provider.ts \
+  packages/app/src/lib/__tests__/group-catalog-models-by-provider.test.ts
+git commit -m "$(cat <<'EOF'
+feat(app): add catalog model grouping helper for settings LLM
+
+Group OpenCode model-catalog refs by provider so Settings can share
+the same provider/model ids and display names as the session picker.
+EOF
+)"
+```
+
+---
+
+### Task 2: Wire `OpenCodeLLMSection` to local daemon model-catalog
+
+**Files:**
+- Modify: `packages/app/src/components/settings/LLMSection.tsx`
+- Modify: `packages/app/src/components/settings/__tests__/LLMSection.test.tsx`
+
+**Interfaces:**
+- Consumes: `groupCatalogModelsByProvider`, `catalogModelsForProvider` from Task 1; `ensureLocalDaemonCatalog`, `useLocalDaemonCatalogStore` from `packages/app/src/stores/local-daemon-catalog-store.ts` (existing `force?: boolean`).
+- Produces: Settings model lists derived from catalog; catalog-only providers appear in the list; expand works when catalog has models even if `configured === false`.
+
+- [ ] **Step 1: Extend `LLMSection.test.tsx` mocks and add failing cases**
+
+Add hoisted catalog mock + mock module (alongside existing provider mocks):
+
+```ts
+// inside vi.hoisted return + mocks object:
+const catalogState = {
+  byWorkspacePath: {} as Record<
+    string,
+    { status: string; models: Array<{ id: string; displayName: string }>; recentModels: string[]; fetchedAt: number }
+  >,
+}
+const ensureLocalDaemonCatalog = vi.fn()
+
+// vi.mock:
+vi.mock('@/stores/local-daemon-catalog-store', () => ({
+  useLocalDaemonCatalogStore: vi.fn((sel: (s: any) => any) => sel(mocks.catalogState)),
+  ensureLocalDaemonCatalog: mocks.ensureLocalDaemonCatalog,
+}))
+```
+
+In `beforeEach`, reset:
+
+```ts
+mocks.catalogState.byWorkspacePath = {}
+mocks.ensureLocalDaemonCatalog.mockReset()
+```
+
+Add tests:
+
+```ts
+it('seeds the local model-catalog on mount for the current workspace', async () => {
+  render(<LLMSection />)
+  await waitFor(() => {
+    expect(mocks.ensureLocalDaemonCatalog).toHaveBeenCalledWith('/test', 'opencode')
+  })
+})
+
+it('lists catalog models for an unconnected provider and allows expand', async () => {
+  mocks.providerState.providers = [{ id: 'opencode', name: 'OpenCode', configured: false }]
+  mocks.catalogState.byWorkspacePath['/test'] = {
+    status: 'ready',
+    models: [
+      { id: 'opencode/qwen3.6-plus-free', displayName: 'OpenCode Zen/Qwen3.6 Plus Free' },
+    ],
+    recentModels: [],
+    fetchedAt: Date.now(),
+  }
+
+  render(<LLMSection />)
+
+  expect(screen.getByText(/1 model/i)).toBeTruthy()
+  // Click the card row (provider name), not Connect — should expand, not only open connect dialog
+  fireEvent.click(screen.getByText('OpenCode'))
+  expect(await screen.findByText('OpenCode Zen/Qwen3.6 Plus Free')).toBeTruthy()
+  expect(screen.getByText('opencode/qwen3.6-plus-free')).toBeTruthy()
+})
+
+it('uses catalog display names for a connected provider (not configuredProviders bare ids)', async () => {
+  mocks.providerState.providers = [{ id: 'anthropic', name: 'Anthropic', configured: true }]
+  mocks.providerState.configuredProviders = [
+    { id: 'anthropic', name: 'Anthropic', models: [{ id: 'claude-sonnet-4', name: 'claude-sonnet-4' }] },
+  ]
+  mocks.catalogState.byWorkspacePath['/test'] = {
+    status: 'ready',
+    models: [
+      { id: 'anthropic/claude-sonnet-4', displayName: 'Claude Sonnet 4' },
+    ],
+    recentModels: [],
+    fetchedAt: Date.now(),
+  }
+
+  render(<LLMSection />)
+  fireEvent.click(screen.getByText('Anthropic'))
+  expect(await screen.findByText('Claude Sonnet 4')).toBeTruthy()
+  expect(screen.getByText('anthropic/claude-sonnet-4')).toBeTruthy()
+  expect(screen.queryByText('claude-sonnet-4')).toBeNull()
+})
+
+it('merges catalog-only providers into the list when /providers omitted them', async () => {
+  mocks.providerState.providers = []
+  mocks.catalogState.byWorkspacePath['/test'] = {
+    status: 'ready',
+    models: [{ id: 'opencode/gpt-5-nano', displayName: 'GPT-5 Nano' }],
+    recentModels: [],
+    fetchedAt: Date.now(),
+  }
+
+  render(<LLMSection />)
+  expect(screen.getByText('opencode')).toBeTruthy()
+  expect(screen.queryByText('No providers available')).toBeNull()
+})
+```
+
+- [ ] **Step 2: Run the new tests — expect FAIL**
+
+Run: `pnpm exec vitest run packages/app/src/components/settings/__tests__/LLMSection.test.tsx`
+Expected: FAIL on catalog seeding / expand / displayName / merge cases
+
+- [ ] **Step 3: Implement wiring in `OpenCodeLLMSection`**
+
+Concrete edits in `packages/app/src/components/settings/LLMSection.tsx`:
+
+1. Imports:
+
+```ts
+import {
+  catalogModelsForProvider,
+  groupCatalogModelsByProvider,
+} from '@/lib/group-catalog-models-by-provider'
+import {
+  ensureLocalDaemonCatalog,
+  useLocalDaemonCatalogStore,
+} from '@/stores/local-daemon-catalog-store'
+```
+
+2. Subscribe to catalog for `workspacePath`:
+
+```ts
+const catalogEntry = useLocalDaemonCatalogStore((s) =>
+  workspacePath ? s.byWorkspacePath[workspacePath] : undefined,
+)
+const catalogModels = catalogEntry?.models ?? []
+```
+
+3. On mount / workspace change, seed catalog (keep existing provider refresh):
+
+```ts
+React.useEffect(() => {
+  void refreshAllProviders()
+  if (workspacePath) {
+    refreshCustomProviderIds(workspacePath)
+    ensureLocalDaemonCatalog(workspacePath, 'opencode')
+  }
+}, [refreshAllProviders, refreshCustomProviderIds, workspacePath])
+```
+
+4. Replace `getProviderModels` to use catalog:
+
+```ts
+const getProviderModels = (providerId: string) =>
+  catalogModelsForProvider(catalogModels, providerId)
+```
+
+5. Merge catalog-only providers into the visible list (inside the existing `useMemo` that builds `visibleProviders`, or a preceding memo). For each group from `groupCatalogModelsByProvider(catalogModels)`, if no provider row exists and id !== `TEAM_SHARED_PROVIDER_ID`, append `{ id, name: id, configured: false }` (prefer a nicer name if `providers` later gains one). Treat providers that have catalog models like “visible” even when not mainstream — put them in `connected` if configured, else in `mainstream` when they have models so free OpenCode is not buried behind “Show more”.
+
+6. Expand / click behavior:
+
+```ts
+const canExpandProvider = (providerId: string, configured: boolean) =>
+  configured || catalogModelsForProvider(catalogModels, providerId).length > 0
+
+const handleProviderClick = (providerId: string, configured: boolean, providerName: string) => {
+  if (canExpandProvider(providerId, configured)) {
+    setSelectedProviderId(selectedProviderId === providerId ? null : providerId)
+    return
+  }
+  handleConnectClick(providerId, providerName)
+}
+```
+
+7. In the card render loop:
+   - `const models = getProviderModels(p.id)` for both connected and catalog-backed unconnected
+   - Subtitle: if `models.length > 0`, show models-available count; else if connected show 0 models; else “Not connected”
+   - Show chevron when `canExpandProvider(...)`
+   - Expanded block: `canExpandProvider && isExpanded && models.length > 0` (not `isConnected && ...`)
+   - Keep Connect button for `!isConnected`; Connected badge only when `isConnected`
+
+Stop using `configuredProviders` for the OpenCode model list UI (the store subscription can remain unused or be removed from this component if nothing else needs it — remove the unused selector to avoid lint noise).
+
+- [ ] **Step 4: Re-run LLMSection tests**
+
+Run: `pnpm exec vitest run packages/app/src/components/settings/__tests__/LLMSection.test.tsx`
+Expected: PASS (including pre-existing OAuth / custom provider tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/components/settings/LLMSection.tsx \
+  packages/app/src/components/settings/__tests__/LLMSection.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(settings): show OpenCode LLM models from model-catalog
+
+Settings LLM Model expands the same loopback catalog the session
+picker uses, including free/unconnected providers, while Connect
+still goes through /providers.
+EOF
+)"
+```
+
+---
+
+### Task 3: Force catalog refetch after auth / refresh actions
+
+**Files:**
+- Modify: `packages/app/src/components/settings/LLMSection.tsx`
+- Modify: `packages/app/src/components/settings/__tests__/LLMSection.test.tsx`
+
+**Interfaces:**
+- Consumes: `ensureLocalDaemonCatalog(path, 'opencode', { force: true })`
+- Produces: After Connect success, Disconnect success, custom add/edit/remove success, and the section Refresh button, catalog is force-refetched so new models appear without waiting for the 5-minute ready TTL.
+
+- [ ] **Step 1: Write failing test for refresh + connect paths**
+
+```ts
+it('force-refetches model-catalog when the refresh control is used', async () => {
+  mocks.providerState.providers = [{ id: 'openai', name: 'OpenAI', configured: true }]
+  render(<LLMSection />)
+  mocks.ensureLocalDaemonCatalog.mockClear()
+
+  fireEvent.click(screen.getByRole('button', { name: /refresh/i }))
+  await waitFor(() => {
+    expect(mocks.ensureLocalDaemonCatalog).toHaveBeenCalledWith('/test', 'opencode', {
+      force: true,
+    })
+  })
+})
+```
+
+If the Refresh control’s accessible name differs, match the existing button label in `LLMSection.tsx` (search for `handleRefreshProviders` / refresh icon button `title` / `aria-label`).
+
+Also add (or fold into an existing connect success path if one exists): after `connectProvider` resolves true and dialog closes, expect `ensureLocalDaemonCatalog('/test', 'opencode', { force: true })`. Mirror for disconnect if a simple path is testable with current mocks.
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `pnpm exec vitest run packages/app/src/components/settings/__tests__/LLMSection.test.tsx -t 'force-refetches'`
+Expected: FAIL (force not called)
+
+- [ ] **Step 3: Implement force refetch**
+
+Add a small helper inside the component:
+
+```ts
+const refreshModelCatalog = React.useCallback(() => {
+  if (!workspacePath) return
+  ensureLocalDaemonCatalog(workspacePath, 'opencode', { force: true })
+}, [workspacePath])
+```
+
+Call it from:
+- `handleRefreshProviders` after `refreshAllProviders` / custom ids refresh
+- Successful `connectProvider` / OAuth complete paths (wherever `refreshAllProviders` is already awaited after success)
+- Successful `disconnectProvider`
+- Successful custom provider add / update / remove
+
+Do **not** pass `{ force: true }` on the initial mount effect (TTL-friendly first load is fine).
+
+- [ ] **Step 4: Re-run LLMSection tests**
+
+Run: `pnpm exec vitest run packages/app/src/components/settings/__tests__/LLMSection.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/components/settings/LLMSection.tsx \
+  packages/app/src/components/settings/__tests__/LLMSection.test.tsx
+git commit -m "$(cat <<'EOF'
+fix(settings): refresh model-catalog after LLM provider auth changes
+
+Force-refetch the loopback catalog after connect/disconnect/custom
+edits and the refresh control so Settings stays aligned with chat.
+EOF
+)"
+```
+
+---
+
+### Task 4: Spec status + smoke verification
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-11-opencode-settings-model-catalog-design.md` (Status line only)
+
+- [ ] **Step 1: Run focused verification**
+
+```bash
+pnpm exec vitest run \
+  packages/app/src/lib/__tests__/group-catalog-models-by-provider.test.ts \
+  packages/app/src/components/settings/__tests__/LLMSection.test.tsx
+```
+
+Expected: all PASS
+
+- [ ] **Step 2: Update spec status**
+
+Change `Status: Draft (awaiting review)` → `Status: Implemented`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -f docs/superpowers/specs/2026-08-11-opencode-settings-model-catalog-design.md
+git commit -m "$(cat <<'EOF'
+docs: mark OpenCode settings model-catalog design implemented
+EOF
+)"
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|---|---|
+| Settings models from `model-catalog` / local-daemon-catalog-store | Task 2 |
+| Keep `/providers` for connection only | Task 2 (no daemon change) |
+| Same `provider/model` ids + displayNames | Task 1 + 2 |
+| Unconnected catalog providers expandable (free OpenCode) | Task 2 |
+| Force refetch after auth / refresh | Task 3 |
+| Helper unit tests + LLMSection tests | Task 1–3 |
+| Team Shared LLM pane untouched | (no task) |
+| Session picker untouched | (no task) |
+
+## Self-review notes
+
+- No placeholders / TBD left in tasks.
+- `ensureLocalDaemonCatalog` already supports `{ force: true }` — no store API change required.
+- Catalog-only provider merge is required; otherwise free `opencode` never appears if `/providers` omits it.
+- `configuredProviders` remains in the provider store for cron/other callers; Settings OpenCode UI stops reading it for models.

--- a/docs/superpowers/specs/2026-08-11-opencode-settings-model-catalog-design.md
+++ b/docs/superpowers/specs/2026-08-11-opencode-settings-model-catalog-design.md
@@ -1,7 +1,7 @@
 # OpenCode Settings Model Catalog Alignment — Design
 
 Date: 2026-08-11
-Status: Draft (awaiting review)
+Status: Implemented
 
 ## Goal
 

--- a/docs/superpowers/specs/2026-08-11-opencode-settings-model-catalog-design.md
+++ b/docs/superpowers/specs/2026-08-11-opencode-settings-model-catalog-design.md
@@ -1,0 +1,143 @@
+# OpenCode Settings Model Catalog Alignment — Design
+
+Date: 2026-08-11
+Status: Draft (awaiting review)
+
+## Goal
+
+Make **Settings → LLM Model** show the same selectable models as the **session
+model picker** when the local runtime is OpenCode: same source, same
+`provider/model` ids, same display names.
+
+Provider **connection management** (Connect / Disconnect / OAuth / custom
+providers) stays on the existing `/providers` path.
+
+## Problem
+
+Today the two UIs use different catalogs:
+
+| Surface | Source | Filter |
+|---|---|---|
+| Settings → LLM Model | daemon `GET /providers` (`opencode.json` + OpenCode `GET /provider` connected set) | Only `authenticated` providers expand models |
+| Session picker | OpenCode `GET /config/providers` → `RuntimeInfo.availableModels` / loopback `model-catalog` | Full runtime catalog |
+
+Result: settings misses built-in / free OpenCode models, uses bare model ids,
+and can disagree with chat even for connected providers.
+
+## Decisions (locked)
+
+- **Direction A:** Settings shows the full session-equivalent model list;
+  connection management is retained, not removed.
+- **Authoritative model source for Settings:** local loopback
+  `GET /v1/workspaces/:id/model-catalog` (OpenCode group), via the existing
+  `local-daemon-catalog-store` / `ensureLocalDaemonCatalog` path — **not** MQTT
+  retain, **not** `configuredProviders` from `/providers`.
+- **Connection source unchanged:** `GET /v1/workspaces/:id/providers` +
+  `useProviderStore.providers[].configured`.
+- **No daemon contract change** to `/providers`. Reuse `model-catalog` as the
+  single model list already used by draft/local session UI.
+- **Team Shared LLM pane** (LiteLLM admin UI) is out of scope.
+- **Session picker logic** is out of scope (already correct for this goal).
+
+## Data flow
+
+```
+OpenCode serve GET /config/providers
+        │
+        ▼
+daemon GET /v1/workspaces/:id/model-catalog
+        │
+        ├── Session draft / local agent pill  (existing)
+        └── Settings → LLM Model              (this change)
+
+daemon GET /v1/workspaces/:id/providers
+        └── Settings provider cards (connected / connect / disconnect)
+```
+
+Settings consumes **both**: catalog for models, providers for auth state.
+
+## Frontend design
+
+### Helper
+
+Add a pure helper (e.g. `groupCatalogModelsByProvider` under
+`packages/app/src/lib/`):
+
+- **Input:** `ModelInfo[]` (or `{ id, displayName }[]`) where `id` is
+  `provider/model`.
+- **Output:** `Map` or array of `{ providerId, models: [{ id: fullRef, name: displayName }] }`.
+- Preserve daemon order; dedupe by full ref; ignore blank ids.
+
+### `OpenCodeLLMSection`
+
+1. On mount / workspace change: call
+   `ensureLocalDaemonCatalog(workspacePath, 'opencode')` (same store the chat
+   draft path uses).
+2. Derive per-provider model lists from the catalog entry for the current
+   workspace, **not** from `configuredProviders`.
+3. Keep using `useProviderStore` for provider rows, connect/disconnect, OAuth,
+   and custom provider CRUD.
+4. After successful connect / disconnect / custom add-edit-remove: refresh
+   providers **and** force a catalog refetch (bypass the ready TTL so the new
+   models appear immediately).
+
+### UI rules
+
+| Provider state | Model list | Card chrome |
+|---|---|---|
+| `configured === true` | From catalog for that provider id | Connected + expand chevron |
+| Catalog has models, not configured (e.g. free `opencode` Zen) | From catalog; expandable | No forced Connect; show available count; Connect still offered if auth methods exist |
+| Not configured and catalog empty for that id | Empty | Connect only |
+| Catalog `pending` | Empty / loading subtitle | Unchanged cards |
+| Catalog `empty` / `error` / `unknown` | Empty; optional muted hint | Connection UI still works |
+
+Expanded row shows **displayName** primary and full `provider/model` id as
+secondary (mono / muted), matching session identity.
+
+`TEAM_SHARED_PROVIDER_ID` remains a pinned card outside this list (existing
+behavior); its models continue to come from team config / materialization, not
+this change’s primary path. If the catalog already includes `team/...` models,
+showing them under the team card when expanded is allowed as long as membership
+still treats cloud/daemon team config as authoritative for connect state.
+
+### Store notes
+
+- Prefer reading `useLocalDaemonCatalogStore` over duplicating fetch logic in
+  `useProviderStore`.
+- `configuredProviders` / `refreshConfiguredProviders` may remain for cron and
+  other callers in this change; Settings OpenCode section stops treating them
+  as the model authority. A follow-up may retire the settings dependency
+  entirely — not required here.
+
+## Testing
+
+- Unit: `groupCatalogModelsByProvider` — grouping, dedupe, empty input, ids
+  without `/`.
+- Unit / component: when catalog contains `opencode/foo` and provider
+  `opencode` is not `configured`, the OpenCode card still lists the model.
+- Unit / component: connected provider uses catalog `displayName`, not bare
+  model id from `/providers`.
+- After connect success mock: catalog refetch is triggered (spy on
+  `ensureLocalDaemonCatalog` / store force path).
+
+No new daemon integration tests unless a missing catalog field blocks the UI
+(unexpected).
+
+## Risks
+
+- Settings requires a reachable local daemon for the model list — same as the
+  draft session path; acceptable.
+- Brief mismatch vs an already-attached session’s MQTT retain is possible;
+  Settings intentionally follows loopback catalog (draft parity). Attached
+  chat remains retain-first.
+- Forcing catalog refetch on every auth change may hit OpenCode
+  `/config/providers` more often; cost is small and matches user expectation
+  after Connect.
+
+## Out of scope
+
+- Changing session `resolveAgentCatalogModels` / retain precedence.
+- Rewriting `/providers` to return full `/config/providers`.
+- Team LiteLLM admin model multi-select UX.
+- Non-OpenCode settings sections (if any) beyond the shared helper reuse.
+`)

--- a/docs/superpowers/specs/2026-08-11-opencode-settings-model-catalog-design.md
+++ b/docs/superpowers/specs/2026-08-11-opencode-settings-model-catalog-design.md
@@ -140,4 +140,3 @@ No new daemon integration tests unless a missing catalog field blocks the UI
 - Rewriting `/providers` to return full `/config/providers`.
 - Team LiteLLM admin model multi-select UX.
 - Non-OpenCode settings sections (if any) beyond the shared helper reuse.
-`)

--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -112,6 +112,10 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
     () => catalogEntry?.models ?? [],
     [catalogEntry?.models],
   )
+  const catalogIsLoading =
+    !catalogEntry || catalogEntry.status === 'pending' || catalogEntry.fetchedAt === 0
+  const catalogLoadFailed =
+    catalogEntry?.status === 'error' || catalogEntry?.status === 'unknown'
 
   // Dialog state for connecting a provider
   const [connectDialogOpen, setConnectDialogOpen] = React.useState(false)
@@ -320,14 +324,15 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
       setSelectedProviderId(selectedProviderId === providerId ? null : providerId)
       return
     }
+    if (configured) return
     handleConnectClick(providerId, providerName)
   }
 
   const getProviderModels = (providerId: string) =>
     catalogModelsForProvider(catalogModels, providerId)
 
-  const canExpandProvider = (providerId: string, configured: boolean) =>
-    configured || catalogModelsForProvider(catalogModels, providerId).length > 0
+  const canExpandProvider = (providerId: string, _configured: boolean) =>
+    catalogModelsForProvider(catalogModels, providerId).length > 0
 
   const [isRefreshing, setIsRefreshing] = React.useState(false)
 
@@ -661,9 +666,13 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
                         )}
                       </div>
                       <p className="text-xs text-muted-foreground">
-                        {models.length > 0 || isConnected
-                          ? t('settings.llm.modelsAvailable', { count: models.length, defaultValue: `${models.length} model${models.length !== 1 ? 's' : ''} available` })
-                          : t('settings.llm.notConnected', 'Not connected')}
+                        {catalogIsLoading
+                          ? t('settings.llm.modelsLoading', 'Loading models...')
+                          : catalogLoadFailed
+                            ? t('settings.llm.modelsUnavailable', 'Models could not be loaded')
+                            : models.length > 0 || isConnected
+                              ? t('settings.llm.modelsAvailable', { count: models.length, defaultValue: `${models.length} model${models.length !== 1 ? 's' : ''} available` })
+                              : t('settings.llm.notConnected', 'Not connected')}
                       </p>
                     </div>
                   </div>

--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -23,6 +23,14 @@ import { useProviderStore } from '@/stores/provider'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useTeamModeStore } from '@/stores/team-mode'
 import { TEAM_SHARED_PROVIDER_ID } from '@/lib/team-provider'
+import {
+  catalogModelsForProvider,
+  groupCatalogModelsByProvider,
+} from '@/lib/group-catalog-models-by-provider'
+import {
+  ensureLocalDaemonCatalog,
+  useLocalDaemonCatalogStore,
+} from '@/stores/local-daemon-catalog-store'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -82,7 +90,6 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
   const devUnlocked = useTeamModeStore((s) => s.devUnlocked)
   const providers = useProviderStore((s) => s.providers)
   const providersLoading = useProviderStore((s) => s.providersLoading)
-  const configuredProviders = useProviderStore((s) => s.configuredProviders)
   const refreshProviders = useProviderStore((s) => s.refreshProviders)
   const refreshConfiguredProviders = useProviderStore((s) => s.refreshConfiguredProviders)
   const authMethods = useProviderStore((s) => s.authMethods)
@@ -98,6 +105,13 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
   const removeCustomProvider = useProviderStore((s) => s.removeCustomProvider)
   const disconnectProvider = useProviderStore((s) => s.disconnectProvider)
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
+  const catalogEntry = useLocalDaemonCatalogStore((s) =>
+    workspacePath ? s.byWorkspacePath[workspacePath] : undefined,
+  )
+  const catalogModels = React.useMemo(
+    () => catalogEntry?.models ?? [],
+    [catalogEntry?.models],
+  )
 
   // Dialog state for connecting a provider
   const [connectDialogOpen, setConnectDialogOpen] = React.useState(false)
@@ -149,15 +163,31 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
     const connected: typeof providers = []
     const mainstream: typeof providers = []
     const others: typeof providers = []
+    const mergedProviders = [...providers]
+    const knownProviderIds = new Set(providers.map((provider) => provider.id))
 
-    for (const p of providers) {
+    for (const group of groupCatalogModelsByProvider(catalogModels)) {
+      if (
+        group.providerId !== TEAM_SHARED_PROVIDER_ID &&
+        !knownProviderIds.has(group.providerId)
+      ) {
+        mergedProviders.push({
+          id: group.providerId,
+          name: group.providerId,
+          configured: false,
+        })
+      }
+    }
+
+    for (const p of mergedProviders) {
       // The team-shared provider is rendered as its own pinned card below.
       if (p.id === TEAM_SHARED_PROVIDER_ID) continue
       if (p.configured) {
         connected.push(p)
       } else if (
         customProviderIds.includes(p.id) ||
-        MAINSTREAM_PROVIDER_IDS.has(p.id.toLowerCase())
+        MAINSTREAM_PROVIDER_IDS.has(p.id.toLowerCase()) ||
+        catalogModelsForProvider(catalogModels, p.id).length > 0
       ) {
         mainstream.push(p)
       } else {
@@ -171,7 +201,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
         : [...connected, ...mainstream],
       hiddenCount: others.length,
     }
-  }, [providers, showAllProviders, customProviderIds])
+  }, [providers, showAllProviders, customProviderIds, catalogModels])
 
   const refreshAllProviders = React.useCallback(async () => {
     await Promise.all([refreshProviders(), refreshConfiguredProviders(), refreshAuthMethods()])
@@ -181,6 +211,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
     void refreshAllProviders()
     if (workspacePath) {
       refreshCustomProviderIds(workspacePath)
+      ensureLocalDaemonCatalog(workspacePath, 'opencode')
     }
   }, [refreshAllProviders, refreshCustomProviderIds, workspacePath])
 
@@ -277,17 +308,18 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
   }
 
   const handleProviderClick = (providerId: string, configured: boolean, providerName: string) => {
-    if (configured) {
+    if (canExpandProvider(providerId, configured)) {
       setSelectedProviderId(selectedProviderId === providerId ? null : providerId)
-    } else {
-      handleConnectClick(providerId, providerName)
+      return
     }
+    handleConnectClick(providerId, providerName)
   }
 
-  const getProviderModels = (providerId: string) => {
-    const cp = configuredProviders.find((p) => p.id === providerId)
-    return cp?.models || []
-  }
+  const getProviderModels = (providerId: string) =>
+    catalogModelsForProvider(catalogModels, providerId)
+
+  const canExpandProvider = (providerId: string, configured: boolean) =>
+    configured || catalogModelsForProvider(catalogModels, providerId).length > 0
 
   const [isRefreshing, setIsRefreshing] = React.useState(false)
 
@@ -585,7 +617,8 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
           {visibleProviders.map((p) => {
             const isConnected = p.configured
             const isExpanded = selectedProviderId === p.id
-            const models = isConnected ? getProviderModels(p.id) : []
+            const models = getProviderModels(p.id)
+            const canExpand = canExpandProvider(p.id, isConnected)
 
             return (
               <SettingCard key={p.id} className={cn(
@@ -615,7 +648,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
                         )}
                       </div>
                       <p className="text-xs text-muted-foreground">
-                        {isConnected
+                        {models.length > 0 || isConnected
                           ? t('settings.llm.modelsAvailable', { count: models.length, defaultValue: `${models.length} model${models.length !== 1 ? 's' : ''} available` })
                           : t('settings.llm.notConnected', 'Not connected')}
                       </p>
@@ -696,7 +729,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
                         {t('settings.llm.connect', 'Connect')}
                       </Button>
                     )}
-                    {isConnected && (
+                    {canExpand && (
                       <ChevronRight className={cn(
                         "h-4 w-4 text-muted-foreground transition-transform",
                         isExpanded && "rotate-90"
@@ -705,8 +738,8 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
                   </div>
                 </div>
 
-                {/* Expanded model list for connected provider */}
-                {isConnected && isExpanded && models.length > 0 && (
+                {/* Expanded model list for catalog-backed provider */}
+                {canExpand && isExpanded && models.length > 0 && (
                   <div className="mt-4 pt-4 border-t space-y-1.5">
                     <p className="text-xs font-medium text-muted-foreground mb-2">{t('settings.llm.availableModels', 'Available Models')}</p>
                     {models.map((m) => (
@@ -734,7 +767,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
             </button>
           )}
 
-          {providers.length === 0 && !providersLoading && (
+          {visibleProviders.length === 0 && !providersLoading && (
             <SettingCard>
               <div className="text-center py-6 text-muted-foreground">
                 <Plug className="h-8 w-8 mx-auto mb-2 opacity-50" />

--- a/packages/app/src/components/settings/LLMSection.tsx
+++ b/packages/app/src/components/settings/LLMSection.tsx
@@ -207,6 +207,11 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
     await Promise.all([refreshProviders(), refreshConfiguredProviders(), refreshAuthMethods()])
   }, [refreshProviders, refreshConfiguredProviders, refreshAuthMethods])
 
+  const refreshModelCatalog = React.useCallback(() => {
+    if (!workspacePath) return
+    ensureLocalDaemonCatalog(workspacePath, 'opencode', { force: true })
+  }, [workspacePath])
+
   React.useEffect(() => {
     void refreshAllProviders()
     if (workspacePath) {
@@ -241,6 +246,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
       setConnectDialogOpen(false)
       setApiKeyInput('')
       await refreshAllProviders()
+      refreshModelCatalog()
     }
     setIsConnecting(false)
   }
@@ -272,6 +278,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
           setOAuthMethodType(null)
           setOAuthCodeInput('')
           void refreshAllProviders()
+          refreshModelCatalog()
         }
       })
     }
@@ -291,6 +298,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
         setOAuthMethodType(null)
         setOAuthCodeInput('')
         await refreshAllProviders()
+        refreshModelCatalog()
       }
     } finally {
       setIsConnecting(false)
@@ -329,6 +337,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
     if (workspacePath) {
       await refreshCustomProviderIds(workspacePath)
     }
+    refreshModelCatalog()
     setIsRefreshing(false)
   }
 
@@ -442,6 +451,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
           setCustomModels([{ modelId: '', modelName: '', contextLimit: '', outputLimit: '' }])
           await refreshAllProviders()
           await refreshCustomProviderIds(workspacePath)
+          refreshModelCatalog()
         }
       } else {
         // Add new provider
@@ -456,6 +466,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
           setCustomModels([{ modelId: '', modelName: '', contextLimit: '', outputLimit: '' }])
           await refreshAllProviders()
           await refreshCustomProviderIds(workspacePath)
+          refreshModelCatalog()
         }
       }
     } finally {
@@ -488,6 +499,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
         setDeletingProviderId(null)
         await refreshAllProviders()
         await refreshCustomProviderIds(workspacePath)
+        refreshModelCatalog()
       }
     } finally {
       setIsDeleting(false)
@@ -503,6 +515,7 @@ export const OpenCodeLLMSection = React.memo(function OpenCodeLLMSection() {
       if (success) {
         setDisconnectingProviderId(null)
         setDisconnectingProviderName('')
+        refreshModelCatalog()
       }
     } finally {
       setIsDisconnecting(false)

--- a/packages/app/src/components/settings/__tests__/LLMSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/LLMSection.test.tsx
@@ -30,10 +30,19 @@ const mocks = vi.hoisted(() => {
     setWorkspace: vi.fn(),
   }
   const teamModeState = { teamModeType: null as string | null, teamModelConfig: null as null | { model: string; modelName: string; baseUrl: string }, devUnlocked: false, teamModelOptions: [] as Array<{ id: string; name: string }>, switchTeamModel: vi.fn() }
+  const catalogState = {
+    byWorkspacePath: {} as Record<
+      string,
+      { status: string; models: Array<{ id: string; displayName: string }>; recentModels: string[]; fetchedAt: number }
+    >,
+  }
+  const ensureLocalDaemonCatalog = vi.fn()
   return {
     providerState,
     workspaceState,
     teamModeState,
+    catalogState,
+    ensureLocalDaemonCatalog,
     shellOpen: vi.fn(),
     dialogOpen: vi.fn(),
   }
@@ -61,6 +70,10 @@ vi.mock('@/stores/team-mode', () => ({
     return sel(mocks.teamModeState)
   }),
 }))
+vi.mock('@/stores/local-daemon-catalog-store', () => ({
+  useLocalDaemonCatalogStore: vi.fn((sel: (s: any) => any) => sel(mocks.catalogState)),
+  ensureLocalDaemonCatalog: mocks.ensureLocalDaemonCatalog,
+}))
 vi.mock('@/lib/team-permissions', () => ({
   useTeamPermissions: () => ({ role: 'owner', isOwner: true, canManageTeam: true, canEditFiles: true }),
 }))
@@ -84,6 +97,8 @@ describe('LLMSection', () => {
     mocks.providerState.configuredProviders = []
     mocks.providerState.customProviderIds = []
     mocks.providerState.authMethods = {}
+    mocks.catalogState.byWorkspacePath = {}
+    mocks.ensureLocalDaemonCatalog.mockReset()
     mocks.workspaceState.workspacePath = '/test'
     mocks.workspaceState.openCodeReady = true
     mocks.workspaceState.daemonHttpReady = true
@@ -116,6 +131,67 @@ describe('LLMSection', () => {
       expect(mocks.providerState.refreshConfiguredProviders).toHaveBeenCalled()
       expect(mocks.providerState.refreshAuthMethods).toHaveBeenCalled()
     })
+  })
+
+  it('seeds the local model-catalog on mount for the current workspace', async () => {
+    render(<LLMSection />)
+    await waitFor(() => {
+      expect(mocks.ensureLocalDaemonCatalog).toHaveBeenCalledWith('/test', 'opencode')
+    })
+  })
+
+  it('lists catalog models for an unconnected provider and allows expand', async () => {
+    mocks.providerState.providers = [{ id: 'opencode', name: 'OpenCode', configured: false }]
+    mocks.catalogState.byWorkspacePath['/test'] = {
+      status: 'ready',
+      models: [
+        { id: 'opencode/qwen3.6-plus-free', displayName: 'OpenCode Zen/Qwen3.6 Plus Free' },
+      ],
+      recentModels: [],
+      fetchedAt: Date.now(),
+    }
+
+    render(<LLMSection />)
+
+    expect(screen.getByText(/1 model/i)).toBeTruthy()
+    fireEvent.click(screen.getByText('OpenCode'))
+    expect(await screen.findByText('OpenCode Zen/Qwen3.6 Plus Free')).toBeTruthy()
+    expect(screen.getByText('opencode/qwen3.6-plus-free')).toBeTruthy()
+  })
+
+  it('uses catalog display names for a connected provider (not configuredProviders bare ids)', async () => {
+    mocks.providerState.providers = [{ id: 'anthropic', name: 'Anthropic', configured: true }]
+    mocks.providerState.configuredProviders = [
+      { id: 'anthropic', name: 'Anthropic', models: [{ id: 'claude-sonnet-4', name: 'claude-sonnet-4' }] },
+    ]
+    mocks.catalogState.byWorkspacePath['/test'] = {
+      status: 'ready',
+      models: [
+        { id: 'anthropic/claude-sonnet-4', displayName: 'Claude Sonnet 4' },
+      ],
+      recentModels: [],
+      fetchedAt: Date.now(),
+    }
+
+    render(<LLMSection />)
+    fireEvent.click(screen.getByText('Anthropic'))
+    expect(await screen.findByText('Claude Sonnet 4')).toBeTruthy()
+    expect(screen.getByText('anthropic/claude-sonnet-4')).toBeTruthy()
+    expect(screen.queryByText('claude-sonnet-4')).toBeNull()
+  })
+
+  it('merges catalog-only providers into the list when /providers omitted them', async () => {
+    mocks.providerState.providers = []
+    mocks.catalogState.byWorkspacePath['/test'] = {
+      status: 'ready',
+      models: [{ id: 'opencode/gpt-5-nano', displayName: 'GPT-5 Nano' }],
+      recentModels: [],
+      fetchedAt: Date.now(),
+    }
+
+    render(<LLMSection />)
+    expect(screen.getByText('opencode')).toBeTruthy()
+    expect(screen.queryByText('No providers available')).toBeNull()
   })
 
   it('shows no providers message when empty', () => {

--- a/packages/app/src/components/settings/__tests__/LLMSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/LLMSection.test.tsx
@@ -140,6 +140,52 @@ describe('LLMSection', () => {
     })
   })
 
+  it('force-refetches model-catalog when the refresh control is used', async () => {
+    mocks.providerState.providers = [{ id: 'openai', name: 'OpenAI', configured: true }]
+    render(<LLMSection />)
+    mocks.ensureLocalDaemonCatalog.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }))
+    await waitFor(() => {
+      expect(mocks.ensureLocalDaemonCatalog).toHaveBeenCalledWith('/test', 'opencode', {
+        force: true,
+      })
+    })
+  })
+
+  it('force-refetches model-catalog after connecting a provider', async () => {
+    mocks.providerState.providers = [{ id: 'openai', name: 'OpenAI', configured: false }]
+    mocks.providerState.connectProvider.mockResolvedValueOnce(true)
+    render(<LLMSection />)
+    mocks.ensureLocalDaemonCatalog.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+    fireEvent.change(screen.getByPlaceholderText('sk-...'), { target: { value: 'sk-test' } })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Connect' }).at(-1)!)
+
+    await waitFor(() => {
+      expect(mocks.ensureLocalDaemonCatalog).toHaveBeenCalledWith('/test', 'opencode', {
+        force: true,
+      })
+    })
+  })
+
+  it('force-refetches model-catalog after disconnecting a provider', async () => {
+    mocks.providerState.providers = [{ id: 'openai', name: 'OpenAI', configured: true }]
+    mocks.providerState.disconnectProvider.mockResolvedValueOnce(true)
+    render(<LLMSection />)
+    mocks.ensureLocalDaemonCatalog.mockClear()
+
+    fireEvent.click(screen.getByTitle('Disconnect provider'))
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }))
+
+    await waitFor(() => {
+      expect(mocks.ensureLocalDaemonCatalog).toHaveBeenCalledWith('/test', 'opencode', {
+        force: true,
+      })
+    })
+  })
+
   it('lists catalog models for an unconnected provider and allows expand', async () => {
     mocks.providerState.providers = [{ id: 'opencode', name: 'OpenCode', configured: false }]
     mocks.catalogState.byWorkspacePath['/test'] = {

--- a/packages/app/src/components/settings/__tests__/LLMSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/LLMSection.test.tsx
@@ -186,6 +186,73 @@ describe('LLMSection', () => {
     })
   })
 
+  it('force-refetches model-catalog after adding a custom provider', async () => {
+    mocks.providerState.addCustomProvider.mockResolvedValueOnce('custom-openai')
+    render(<LLMSection />)
+    mocks.ensureLocalDaemonCatalog.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Custom' }))
+    fireEvent.change(screen.getByPlaceholderText('e.g. My OpenAI Proxy'), {
+      target: { value: 'Custom OpenAI' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('e.g. https://api.openai.com/v1'), {
+      target: { value: 'https://api.example.test/v1' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('sk-...'), {
+      target: { value: 'sk-test' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('e.g. gpt-4o'), {
+      target: { value: 'custom-model' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add Provider' }))
+
+    await waitFor(() => {
+      expect(mocks.ensureLocalDaemonCatalog).toHaveBeenCalledWith('/test', 'opencode', {
+        force: true,
+      })
+    })
+  })
+
+  it('force-refetches model-catalog after updating a custom provider', async () => {
+    mocks.providerState.providers = [{ id: 'custom-openai', name: 'Custom OpenAI', configured: true }]
+    mocks.providerState.customProviderIds = ['custom-openai']
+    mocks.providerState.getCustomProvider.mockResolvedValueOnce({
+      name: 'Custom OpenAI',
+      baseURL: 'https://api.example.test/v1',
+      models: [{ modelId: 'custom-model', modelName: 'Custom Model' }],
+    })
+    mocks.providerState.updateCustomProvider.mockResolvedValueOnce(true)
+    render(<LLMSection />)
+    mocks.ensureLocalDaemonCatalog.mockClear()
+
+    fireEvent.click(screen.getByTitle('Edit custom provider'))
+    expect(await screen.findByDisplayValue('Custom OpenAI')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Update Provider' }))
+
+    await waitFor(() => {
+      expect(mocks.ensureLocalDaemonCatalog).toHaveBeenCalledWith('/test', 'opencode', {
+        force: true,
+      })
+    })
+  })
+
+  it('force-refetches model-catalog after removing a custom provider', async () => {
+    mocks.providerState.providers = [{ id: 'custom-openai', name: 'Custom OpenAI', configured: true }]
+    mocks.providerState.customProviderIds = ['custom-openai']
+    mocks.providerState.removeCustomProvider.mockResolvedValueOnce(true)
+    render(<LLMSection />)
+    mocks.ensureLocalDaemonCatalog.mockClear()
+
+    fireEvent.click(screen.getByTitle('Remove custom provider'))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => {
+      expect(mocks.ensureLocalDaemonCatalog).toHaveBeenCalledWith('/test', 'opencode', {
+        force: true,
+      })
+    })
+  })
+
   it('lists catalog models for an unconnected provider and allows expand', async () => {
     mocks.providerState.providers = [{ id: 'opencode', name: 'OpenCode', configured: false }]
     mocks.catalogState.byWorkspacePath['/test'] = {

--- a/packages/app/src/components/settings/__tests__/LLMSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/LLMSection.test.tsx
@@ -293,6 +293,47 @@ describe('LLMSection', () => {
     expect(screen.queryByText('claude-sonnet-4')).toBeNull()
   })
 
+  it.each([
+    ['pending', 0],
+    ['ready', 0],
+  ])('shows a loading subtitle for an unsettled %s catalog', (status, fetchedAt) => {
+    mocks.providerState.providers = [{ id: 'openai', name: 'OpenAI', configured: true }]
+    mocks.catalogState.byWorkspacePath['/test'] = {
+      status,
+      models: [],
+      recentModels: [],
+      fetchedAt,
+    }
+
+    const { container } = render(<LLMSection />)
+
+    expect(screen.getByText('Loading models...')).toBeTruthy()
+    expect(screen.queryByText(/0 models available/i)).toBeNull()
+    expect(container.querySelector('svg.lucide-chevron-right')).toBeNull()
+  })
+
+  it.each(['error', 'unknown'])(
+    'shows an unavailable hint and no expansion control for a %s catalog',
+    (status) => {
+      mocks.providerState.providers = [{ id: 'openai', name: 'OpenAI', configured: true }]
+      mocks.catalogState.byWorkspacePath['/test'] = {
+        status,
+        models: [],
+        recentModels: [],
+        fetchedAt: Date.now(),
+      }
+
+      const { container } = render(<LLMSection />)
+
+      expect(screen.getByText('Models could not be loaded')).toBeTruthy()
+      expect(screen.queryByText(/0 models available/i)).toBeNull()
+      expect(container.querySelector('svg.lucide-chevron-right')).toBeNull()
+
+      fireEvent.click(screen.getByText('OpenAI'))
+      expect(screen.queryByText('Connect OpenAI')).toBeNull()
+    },
+  )
+
   it('merges catalog-only providers into the list when /providers omitted them', async () => {
     mocks.providerState.providers = []
     mocks.catalogState.byWorkspacePath['/test'] = {

--- a/packages/app/src/lib/__tests__/group-catalog-models-by-provider.test.ts
+++ b/packages/app/src/lib/__tests__/group-catalog-models-by-provider.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  catalogModelsForProvider,
+  groupCatalogModelsByProvider,
+} from '../group-catalog-models-by-provider'
+
+describe('groupCatalogModelsByProvider', () => {
+  it('groups by provider prefix and keeps full refs + display names', () => {
+    const groups = groupCatalogModelsByProvider([
+      { id: 'opencode/qwen3.6-plus-free', displayName: 'OpenCode Zen/Qwen3.6 Plus Free' },
+      { id: 'anthropic/claude-sonnet-4', displayName: 'Claude Sonnet 4' },
+      { id: 'opencode/gpt-5-nano', displayName: 'OpenCode Zen/GPT-5 Nano' },
+    ])
+    expect(groups).toEqual([
+      {
+        providerId: 'opencode',
+        models: [
+          { id: 'opencode/qwen3.6-plus-free', name: 'OpenCode Zen/Qwen3.6 Plus Free' },
+          { id: 'opencode/gpt-5-nano', name: 'OpenCode Zen/GPT-5 Nano' },
+        ],
+      },
+      {
+        providerId: 'anthropic',
+        models: [{ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' }],
+      },
+    ])
+  })
+
+  it('dedupes by full id and falls back name to id', () => {
+    const groups = groupCatalogModelsByProvider([
+      { id: 'opencode/a', displayName: 'A' },
+      { id: 'opencode/a', displayName: 'A duplicate' },
+      { id: 'opencode/b', displayName: '  ' },
+      { id: '', displayName: 'skip' },
+      { id: 'nopath', displayName: 'No slash' },
+    ])
+    expect(groups).toEqual([
+      {
+        providerId: 'opencode',
+        models: [
+          { id: 'opencode/a', name: 'A' },
+          { id: 'opencode/b', name: 'opencode/b' },
+        ],
+      },
+      {
+        providerId: 'nopath',
+        models: [{ id: 'nopath', name: 'No slash' }],
+      },
+    ])
+  })
+
+  it('catalogModelsForProvider returns only that provider', () => {
+    const models = catalogModelsForProvider(
+      [
+        { id: 'opencode/a', displayName: 'A' },
+        { id: 'openai/b', displayName: 'B' },
+      ],
+      'opencode',
+    )
+    expect(models).toEqual([{ id: 'opencode/a', name: 'A' }])
+  })
+})

--- a/packages/app/src/lib/group-catalog-models-by-provider.ts
+++ b/packages/app/src/lib/group-catalog-models-by-provider.ts
@@ -1,0 +1,50 @@
+export type CatalogModelOption = { id: string; name: string }
+
+export type CatalogProviderGroup = {
+  providerId: string
+  models: CatalogModelOption[]
+}
+
+function splitProviderModel(id: string): { providerId: string; modelId: string } | null {
+  const trimmed = id.trim()
+  if (!trimmed) return null
+  const slash = trimmed.indexOf('/')
+  if (slash <= 0) return { providerId: trimmed, modelId: trimmed }
+  return {
+    providerId: trimmed.slice(0, slash),
+    modelId: trimmed.slice(slash + 1),
+  }
+}
+
+export function groupCatalogModelsByProvider(
+  models: ReadonlyArray<{ id: string; displayName?: string | null }>,
+): CatalogProviderGroup[] {
+  const groups: CatalogProviderGroup[] = []
+  const byProvider = new Map<string, CatalogProviderGroup>()
+  const seen = new Set<string>()
+
+  for (const model of models) {
+    const id = model.id?.trim()
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    const parts = splitProviderModel(id)
+    if (!parts) continue
+    const name = model.displayName?.trim() || id
+    let group = byProvider.get(parts.providerId)
+    if (!group) {
+      group = { providerId: parts.providerId, models: [] }
+      byProvider.set(parts.providerId, group)
+      groups.push(group)
+    }
+    group.models.push({ id, name })
+  }
+
+  return groups
+}
+
+export function catalogModelsForProvider(
+  models: ReadonlyArray<{ id: string; displayName?: string | null }>,
+  providerId: string,
+): CatalogModelOption[] {
+  return groupCatalogModelsByProvider(models).find((g) => g.providerId === providerId)?.models ?? []
+}

--- a/packages/app/src/stores/__tests__/local-daemon-catalog-store.test.ts
+++ b/packages/app/src/stores/__tests__/local-daemon-catalog-store.test.ts
@@ -173,6 +173,42 @@ describe('ensureLocalDaemonCatalog', () => {
     expect(fetchLocalDaemonCatalog).toHaveBeenCalledTimes(1)
   })
 
+  it('runs a forced follow-up probe after an in-flight request settles', async () => {
+    let resolveFirst!: (value: {
+      status: 'models'
+      backend: string
+      models: Array<{ id: string }>
+      recentModels: string[]
+    }) => void
+    fetchLocalDaemonCatalog
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveFirst = resolve
+      }))
+      .mockResolvedValueOnce({
+        status: 'models',
+        backend: 'claude-code',
+        models: [{ id: 'claude/sonnet' }],
+        recentModels: [],
+      })
+
+    ensureLocalDaemonCatalog('/w1', 'opencode')
+    ensureLocalDaemonCatalog('/w1', 'claude-code', { force: true })
+
+    expect(fetchLocalDaemonCatalog).toHaveBeenCalledTimes(1)
+    resolveFirst({
+      status: 'models',
+      backend: 'opencode',
+      models: [{ id: 'opencode/big-pickle' }],
+      recentModels: [],
+    })
+    await settled()
+    await settled()
+
+    expect(fetchLocalDaemonCatalog).toHaveBeenCalledTimes(2)
+    expect(fetchLocalDaemonCatalog).toHaveBeenLastCalledWith('/w1', 'claude-code')
+    expect(read('/w1').models.map((model) => model.id)).toEqual(['claude/sonnet'])
+  })
+
   it('survives a throwing probe without breaking the pill it feeds', async () => {
     fetchLocalDaemonCatalog.mockRejectedValueOnce(new Error('daemon exploded'))
     ensureLocalDaemonCatalog('/w1')

--- a/packages/app/src/stores/local-daemon-catalog-store.ts
+++ b/packages/app/src/stores/local-daemon-catalog-store.ts
@@ -89,6 +89,8 @@ export const useLocalDaemonCatalogStore = createZustand<LocalDaemonCatalogState>
 
 /** In-flight fetches, so N pills for one workspace share one request. */
 const inFlight = new Map<string, Promise<void>>()
+/** Latest forced refresh requested while a probe for the workspace is active. */
+const forcedFollowUps = new Map<string, { backendType?: string | null }>()
 
 function refreshDueAt(entry: LocalDaemonCatalogEntry): number {
   return entry.fetchedAt + (entry.status === 'ready' ? READY_REFRESH_MS : RETRY_REFRESH_MS)
@@ -123,7 +125,12 @@ export function ensureLocalDaemonCatalog(
 ): void {
   const path = workspacePath.trim()
   if (!path) return
-  if (inFlight.has(path)) return
+  if (inFlight.has(path)) {
+    if (options?.force === true) {
+      forcedFollowUps.set(path, { backendType })
+    }
+    return
+  }
 
   const store = useLocalDaemonCatalogStore.getState()
   if (
@@ -182,6 +189,11 @@ export function ensureLocalDaemonCatalog(
       })
     } finally {
       inFlight.delete(path)
+      const followUp = forcedFollowUps.get(path)
+      if (followUp) {
+        forcedFollowUps.delete(path)
+        ensureLocalDaemonCatalog(path, followUp.backendType, { force: true })
+      }
     }
   })()
 
@@ -191,5 +203,6 @@ export function ensureLocalDaemonCatalog(
 /** Test seam — drops cached entries and any in-flight dedupe state. */
 export function resetLocalDaemonCatalogForTests(): void {
   inFlight.clear()
+  forcedFollowUps.clear()
   useLocalDaemonCatalogStore.getState().clear()
 }


### PR DESCRIPTION
## Summary
- Settings → LLM Model now lists models from the same loopback `model-catalog` as the session picker (`provider/model` ids + OpenCode display names), including free/unconnected catalog providers.
- Provider Connect / Disconnect / OAuth / custom CRUD still go through `/providers`; connection management is unchanged.
- After auth changes and Refresh, force-refetch the catalog (and queue force when a probe is already in flight). Unsettled/error catalog states show loading/unavailable hints instead of a false “0 models available”.

## Test plan
- [ ] Open Settings → LLM Model with OpenCode runtime; expand providers and confirm models match the session model picker (ids + names).
- [ ] Confirm free/OpenCode Zen models appear even when that provider is not “Connected”.
- [ ] Connect a provider (API key and/or OAuth); list updates without waiting for the 5-minute TTL.
- [ ] Disconnect / add-edit-remove custom provider; catalog refreshes.
- [ ] With daemon mid-restart or catalog pending/error, connected rows show loading/unavailable — not a dead “0 models” expand.
- [ ] `cd packages/app && pnpm exec vitest run src/lib/__tests__/group-catalog-models-by-provider.test.ts src/components/settings/__tests__/LLMSection.test.tsx src/stores/__tests__/local-daemon-catalog-store.test.ts`


Made with [Cursor](https://cursor.com)