### PR TITLE
test(e2e): make the V2 smoke suite able to drive a built app at all

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1164,13 +1164,22 @@ function App() {
   useTrayMenuLocaleSync()
   useAppMenuOpenSettings()
 
-  // ── Initialize tauri-plugin-mcp event listeners (dev only) ──
+  // ── Initialize tauri-plugin-mcp event listeners (dev + E2E builds) ──
+  // The plugin's `execute_js` works by emitting an `execute-js` event and
+  // waiting for `execute-js-response`; these listeners are what answers it.
+  // Without them every executeJs call from the test harness times out, so an
+  // E2E build needs them even though vite built it in production mode.
   useEffect(() => {
-    if (!isTauri() || import.meta.env.PROD) return;
-    // Dynamic import — module only exists in Tauri dev; externalized in prod builds
+    if (!isTauri()) return;
+    if (import.meta.env.PROD && !E2E_BUILD) return;
+    // Deliberately NOT `/* @vite-ignore */`: that leaves the specifier
+    // unanalyzed, so neither the stub alias nor the E2E bundling below can
+    // apply and the webview is handed a bare specifier it cannot resolve.
+    // Normal builds alias this to a no-op stub; an E2E build bundles the real
+    // package.
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    import(/* @vite-ignore */ 'tauri-plugin-mcp').then((mod: { setupPluginListeners?: () => void }) => {
+    import('tauri-plugin-mcp').then((mod: { setupPluginListeners?: () => void }) => {
       mod.setupPluginListeners?.();
       console.log('[App] tauri-plugin-mcp listeners initialized');
     }).catch(() => {});
@@ -1273,7 +1282,10 @@ function App() {
 
   // First-run welcome — the very first screen, shown before dependency setup.
   // Dismissing it (Get started) is what unblocks the dependency initialization.
-  const [welcomeAck, setWelcomeAck] = useState(() => !isTauri() || hasSeenWelcome());
+  // E2E: the harness drives the chat UI directly, so the first-run welcome is
+  // just a screen it can never get past — it seeds state rather than clicking
+  // through onboarding.
+  const [welcomeAck, setWelcomeAck] = useState(() => E2E_BUILD || !isTauri() || hasSeenWelcome());
   const showWelcome = isTauri() && !welcomeAck;
 
   // Welcome / dependency-setup are immediately-interactive first-run screens — if

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -36,6 +36,7 @@ import { getSkillDirectories, loadAllSkills } from "@/lib/git/skill-loader";
 import { appStoragePrefix, DEFAULT_WORKSPACE_PATH, TEAM_REPO_DIR } from "@/lib/build-config";
 import { WORKSPACE_STORAGE_KEY } from "@/stores/workspace";
 import { markStartup } from "@/lib/startup-perf";
+import { E2E_BUILD } from "@/lib/e2e/v2-control-active";
 
 export const SKILLS_CHANGED_EVENT = "skills-files-changed";
 
@@ -746,7 +747,10 @@ export function useSetupGuide(workspaceReady: boolean) {
 
     const decision = setupDecisionRef.current;
 
-    if (decision === "skip") {
+    // E2E builds never show the dependency guide: a CI machine legitimately
+    // lacks the optional runtimes, and the guide would render over the chat UI
+    // the harness is there to exercise.
+    if (E2E_BUILD || decision === "skip") {
       depsResultRef.current = { checked: true, hasRequiredMissing: false };
       return;
     }

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -20,6 +20,7 @@ import { initJwtBridge } from './lib/jwt-bridge'
 import { installConsoleCapture } from './lib/console-capture'
 import { markStartup } from './lib/startup-perf'
 import { removeStartupSkeleton } from './lib/utils'
+import { E2E_BUILD } from './lib/e2e/v2-control-active'
 
 markStartup('main:start')
 
@@ -134,9 +135,25 @@ createRoot(document.getElementById('root')!).render(
       ) : (
         <>
           <SidePanelHostGateOverlay />
-          <AuthGate>
+          {/*
+            An E2E build mounts App without AuthGate. The harness never signs
+            in — it drives the app over the MCP socket and seeds sessions,
+            actors and messages straight into the stores — so there is no
+            session for the gate to pass. Inside AuthGate, App simply never
+            mounts at the login screen, and it takes the tauri-plugin-mcp
+            listeners and the `window.__TEAMCLU_V2_E2E__` control surface down
+            with it, leaving the harness with nothing to talk to.
+
+            `E2E_BUILD` is a build-time constant: a normal build folds this to
+            the AuthGate branch and the bundler drops the other one.
+          */}
+          {E2E_BUILD ? (
             <App />
-          </AuthGate>
+          ) : (
+            <AuthGate>
+              <App />
+            </AuthGate>
+          )}
         </>
       )}
     </ErrorBoundary>

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -7,7 +7,14 @@ import tailwindcss from '@tailwindcss/vite'
 import { visualizer } from 'rollup-plugin-visualizer'
 
 const tauriPluginMcpPath = path.resolve(__dirname, '../../.tauri-plugin-mcp')
-const useTauriPluginMcpStub = !existsSync(path.join(tauriPluginMcpPath, 'package.json'))
+// An E2E build is driven through the plugin's socket, so it needs the real
+// package bundled in: the stub's `setupPluginListeners` is a no-op, and an
+// externalized bare specifier does not resolve inside the webview — either way
+// `execute_js` gets no answer and the whole harness times out. The npm
+// dependency provides the same listeners as the linked dev checkout.
+const isTauriMcpE2EBuild = process.env.VITE_TEAMCLU_E2E === 'true'
+const useTauriPluginMcpStub =
+  !isTauriMcpE2EBuild && !existsSync(path.join(tauriPluginMcpPath, 'package.json'))
 
 // --- Build config: read build.config.json + optional environment/local overrides ---
 function readJSON(filePath: string): Record<string, unknown> | null {
@@ -203,8 +210,9 @@ export default defineConfig({
     sourcemap: !!process.env.TAURI_DEBUG,
     // Chunk splitting strategy (Vite 8 / Rolldown requires manualChunks as a function)
     rollupOptions: {
-      // tauri-plugin-mcp is dev-only (linked from .tauri-plugin-mcp/, gitignored)
-      external: ['tauri-plugin-mcp'],
+      // tauri-plugin-mcp is dev-only (linked from .tauri-plugin-mcp/, gitignored).
+      // An E2E build is the exception — see isTauriMcpE2EBuild above.
+      external: isTauriMcpE2EBuild ? [] : ['tauri-plugin-mcp'],
       output: {
         manualChunks(id) {
           const groups: Record<string, string[]> = {

--- a/tests/_utils/tauri-mcp-test-utils.ts
+++ b/tests/_utils/tauri-mcp-test-utils.ts
@@ -38,6 +38,27 @@ const TEAMCLU_APP_PATH =
 const TAURI_MCP_SOCKET =
   process.env.TAURI_MCP_SOCKET || '/tmp/tauri-mcp.sock';
 
+/**
+ * The plugin authenticates every request. When no token is configured it
+ * generates a random one (`PluginConfig` in tauri-plugin-mcp-local/src/lib.rs)
+ * and writes it to a `<socket>.token` sidecar, 0600, for clients to discover —
+ * the plugin's own TypeScript MCP server does exactly this on connect.
+ *
+ * Read it per call rather than once at module load: the token is minted when
+ * the app starts, which is *after* this module is imported.
+ */
+function readAuthToken(): string | null {
+  try {
+    const token = readFileSync(`${TAURI_MCP_SOCKET}.token`, 'utf8').trim();
+    return token.length > 0 ? token : null;
+  } catch {
+    // No sidecar — the app is either not up yet or was built with
+    // `insecure_no_auth`. Send the request unauthenticated and let the plugin
+    // decide; an auth-enabled plugin answers with a clear auth error.
+    return null;
+  }
+}
+
 let _processId: string | null = null;
 let _osPid: number | null = null;
 let _appProcess: ChildProcess | null = null;
@@ -72,7 +93,13 @@ function socketCall(command: string, payload: Record<string, unknown> = {}): Pro
     }
 
     client.on('connect', () => {
-      const msg = JSON.stringify({ command, payload }) + '\n';
+      const authToken = readAuthToken();
+      // `authToken`, not `auth_token`: SocketRequest is `rename_all = "camelCase"`.
+      // A snake_case key is silently ignored by serde and the request is then
+      // rejected as unauthenticated.
+      const msg = JSON.stringify(
+        authToken ? { command, payload, authToken } : { command, payload },
+      ) + '\n';
       client.write(msg);
     });
 


### PR DESCRIPTION
`pnpm test:smoke` has never run against a built binary — not in CI, not locally. **Five independent breaks** stood between the harness and the app, each hidden behind the one before it.

## The chain

1. **The harness never authenticated.** tauri-plugin-mcp turns auth on by default: with no token configured it mints a random one and writes it to a `<socket>.token` sidecar for clients to discover. The harness predates that and sent nothing, so every call came back `invalid or missing auth token` — surfacing as "tauri-mcp socket not ready".

2. **The token field is `authToken`.** `SocketRequest` is `rename_all = "camelCase"`, so a snake_case key is silently dropped by serde and the request is *then* rejected as unauthenticated.

3. **`/* @vite-ignore */`** on the plugin import left the specifier unanalyzed, so neither the stub alias nor `external` could apply — the webview got a bare specifier it cannot resolve.

4. **Listeners gated on `!import.meta.env.PROD`.** `tauri build --debug` builds the *frontend* in production mode, so `setupPluginListeners()` never ran. Those listeners are what answers `execute_js` (it emits `execute-js` and awaits `execute-js-response`), so every `executeJs` timed out. Only `pnpm tauri:dev` — the socket-*reuse* path — ever worked.

5. **`<App/>` mounts inside `<AuthGate>`.** At the login screen it never mounts, taking the plugin listeners and `window.__TEAMCLU_V2_E2E__` down with it. Confirmed by screenshotting the running app: it sat on "Choose setup". The harness signs in nowhere — it seeds stores directly — so an E2E build now mounts App without the gate, and skips the first-run welcome and dependency guide that render over the chat UI it exists to exercise.

## Blast radius

Everything on the app side is behind `E2E_BUILD` (`VITE_TEAMCLU_E2E`), a build-time constant. Verified against a real `vite build` rather than by reading the code:

| | normal build | E2E build |
|---|---|---|
| `__TEAMCLU_V2_E2E__` | 0 | present |
| `execute-js-response` (listeners) | 0 | present |
| `AuthGate` | present | bypassed |

## Where it lands

**1 of 6 tests passes, up from 6 that could not start.** The app now renders the real chat UI from seeded state — sessions, streaming text, participants.

The other 5 fail on assertions that drifted from the current UI, which is what you would expect from tests that have never once run:
- the streaming bubble does not render after `emitAgentDelta` (`StreamingAgentBubble` takes its early `return null`)
- session isolation in PR-02
- a markdown case where `79. text` renders as a list item, so `textContent` has no `79.`

Those are a follow-up, as is the CI job. One CI fact worth recording for whoever builds it: the job must set `TEAMCLU_APP_PATH=target/debug/teamclu`, because `scripts/rust-build-env.js:105` deliberately does **not** override `CARGO_TARGET_DIR` under `GITHUB_ACTIONS` while the harness defaults to `.cargo-target/…` — exactly the path in today's CI error.

## Verification

`pnpm typecheck` clean · `pnpm lint` 0 errors · app suite 426 files / 2725 tests pass · smoke run against a real `tauri build --debug` binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)