### PR TITLE
fix(env): decrypt secrets written before brand rename

### DIFF
--- a/apps/daemon/src/team_shared_env.rs
+++ b/apps/daemon/src/team_shared_env.rs
@@ -116,7 +116,9 @@ fn load_team_env_from_secrets_dir_detailed(
         return Ok(TeamEnvLoadDiagnostics::default());
     }
 
-    let key = derive_key(env_secret)?;
+    // Validate the team secret shape up front; per-file decrypt uses
+    // `decrypt_secret_for_team` so pre-rename (teamclaw salt) envelopes still open.
+    derive_key(env_secret)?;
     let mut loaded = TeamEnvLoadDiagnostics::default();
     for entry in std::fs::read_dir(secrets_dir)? {
         let path = match entry {
@@ -152,7 +154,7 @@ fn load_team_env_from_secrets_dir_detailed(
                 continue;
             }
         };
-        let secret = match team_crypto::decrypt_secret(&envelope, &key) {
+        let secret = match team_crypto::decrypt_secret_for_team(&envelope, env_secret) {
             Ok(secret) => secret,
             Err(e) => {
                 warn!(path = %path.display(), "failed to decrypt team secret file: {e}");
@@ -578,6 +580,52 @@ mod tests {
             load_team_env_from_secrets_dir_detailed(&secrets_dir, &"77".repeat(32)).unwrap();
         assert_eq!(detailed.unresolved_keys, vec!["shared_token"]);
         assert!(detailed.source_paths.is_empty());
+    }
+
+    #[test]
+    fn load_team_env_decrypts_pre_rename_teamclaw_salt() {
+        use aes_gcm::aead::Aead;
+        use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+        use hkdf::Hkdf;
+        use sha2::Sha256;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let secrets_dir = tmp.path().join("teamclu").join("_secrets");
+        std::fs::create_dir_all(&secrets_dir).unwrap();
+
+        let env_secret = "99".repeat(32);
+        let ikm = hex::decode(&env_secret).unwrap();
+        let hk = Hkdf::<Sha256>::new(Some(b"teamclaw-secrets-v1"), &ikm);
+        let mut key = [0u8; 32];
+        hk.expand(b"aes-256-gcm", &mut key).unwrap();
+        let entry = SecretEntry {
+            key_id: "legacy_salt_token".to_string(),
+            key: "from-pre-rename".to_string(),
+            ..Default::default()
+        };
+        let plaintext = serde_json::to_vec(&entry).unwrap();
+        let nonce = [3u8; 12];
+        let cipher = Aes256Gcm::new_from_slice(&key).unwrap();
+        let ciphertext = cipher
+            .encrypt(Nonce::from_slice(&nonce), plaintext.as_ref())
+            .unwrap();
+        let envelope = EncryptedEnvelope {
+            v: 1,
+            nonce: BASE64.encode(nonce),
+            ciphertext: BASE64.encode(ciphertext),
+        };
+        std::fs::write(
+            secrets_dir.join("legacy_salt_token.enc.json"),
+            serde_json::to_string(&envelope).unwrap(),
+        )
+        .unwrap();
+
+        let env = load_team_env(tmp.path(), "teamclu", &env_secret).unwrap();
+        assert_eq!(
+            env.get("LEGACY_SALT_TOKEN").map(String::as_str),
+            Some("from-pre-rename")
+        );
     }
 
     #[test]

--- a/apps/desktop/src/commands/shared_secrets.rs
+++ b/apps/desktop/src/commands/shared_secrets.rs
@@ -30,7 +30,8 @@ use std::sync::Mutex;
 use tauri::{AppHandle, Emitter};
 
 use super::shared_secrets_crypto::{
-    decrypt_secret, derive_key, encrypt_secret, EncryptedEnvelope, SecretEntry, SecretMeta,
+    decrypt_secret_for_team, derive_key, encrypt_secret, EncryptedEnvelope, SecretEntry,
+    SecretMeta,
 };
 
 // ---------------------------------------------------------------------------
@@ -46,6 +47,10 @@ pub const SECRETS_DIR: &str = "_secrets";
 pub struct SharedSecretsState {
     pub secrets: Mutex<HashMap<String, SecretEntry>>,
     pub derived_key: Mutex<Option<[u8; 32]>>,
+    /// Raw team secret hex — needed so reads can fall back to the pre-rename
+    /// HKDF salt via [`decrypt_secret_for_team`]. Encrypt still uses
+    /// [`derived_key`] (current salt only).
+    pub team_secret: Mutex<Option<String>>,
     pub team_dir: Mutex<Option<PathBuf>>,
 }
 
@@ -54,6 +59,7 @@ impl Default for SharedSecretsState {
         Self {
             secrets: Mutex::new(HashMap::new()),
             derived_key: Mutex::new(None),
+            team_secret: Mutex::new(None),
             team_dir: Mutex::new(None),
         }
     }
@@ -127,6 +133,13 @@ pub fn init_shared_secrets(
         *dk = Some(key);
     }
     {
+        let mut ts = state
+            .team_secret
+            .lock()
+            .map_err(|e| format!("init_shared_secrets: lock team_secret: {e}"))?;
+        *ts = Some(team_secret.to_string());
+    }
+    {
         let mut td = state
             .team_dir
             .lock()
@@ -152,12 +165,13 @@ pub fn load_all_secrets(state: &SharedSecretsState) -> Result<(), String> {
         td.clone()
             .ok_or_else(|| "load_all_secrets: team_dir not set".to_string())?
     };
-    let derived_key = {
-        let dk = state
-            .derived_key
+    let team_secret = {
+        let ts = state
+            .team_secret
             .lock()
-            .map_err(|e| format!("load_all_secrets: lock derived_key: {e}"))?;
-        dk.ok_or_else(|| "load_all_secrets: derived_key not set".to_string())?
+            .map_err(|e| format!("load_all_secrets: lock team_secret: {e}"))?;
+        ts.clone()
+            .ok_or_else(|| "load_all_secrets: team_secret not set".to_string())?
     };
 
     let dir = team_dir.join(SECRETS_DIR);
@@ -222,7 +236,7 @@ pub fn load_all_secrets(state: &SharedSecretsState) -> Result<(), String> {
             }
         };
 
-        match decrypt_secret(&envelope, &derived_key) {
+        match decrypt_secret_for_team(&envelope, &team_secret) {
             Ok(secret) => {
                 log::info!("shared_secrets: loaded secret '{}'", secret.key_id);
                 new_map.insert(secret.key_id.clone(), secret);
@@ -357,11 +371,20 @@ fn ensure_derived_key(
         "Missing team encryption key for this workspace (not initialized). Configure it under Settings → Daemon → General, then try again.".to_string()
     })?;
     let derived_key = derive_key(&env_secret)?;
-    let mut dk = state
-        .derived_key
-        .lock()
-        .map_err(|e| format!("ensure_derived_key: lock derived_key: {e}"))?;
-    *dk = Some(derived_key);
+    {
+        let mut dk = state
+            .derived_key
+            .lock()
+            .map_err(|e| format!("ensure_derived_key: lock derived_key: {e}"))?;
+        *dk = Some(derived_key);
+    }
+    {
+        let mut ts = state
+            .team_secret
+            .lock()
+            .map_err(|e| format!("ensure_derived_key: lock team_secret: {e}"))?;
+        *ts = Some(env_secret);
+    }
     Ok(derived_key)
 }
 
@@ -585,7 +608,15 @@ pub(crate) async fn refresh_team_secrets_from_cloud(
     let Some(team_id) = team_id.map(str::trim).filter(|id| !id.is_empty()) else {
         return Ok(Vec::new());
     };
-    let derived_key = ensure_derived_key(state, workspace_path, Some(team_id))?;
+    let _derived_key = ensure_derived_key(state, workspace_path, Some(team_id))?;
+    let team_secret = {
+        let ts = state
+            .team_secret
+            .lock()
+            .map_err(|e| format!("refresh_team_secrets_from_cloud: lock team_secret: {e}"))?;
+        ts.clone()
+            .ok_or_else(|| "refresh_team_secrets_from_cloud: team_secret not set".to_string())?
+    };
     let Some(client) = fc_client_for(workspace_path, access_token, cloud_api_url) else {
         return Ok(Vec::new());
     };
@@ -624,7 +655,7 @@ pub(crate) async fn refresh_team_secrets_from_cloud(
         };
         // Undecryptable rows are skipped, not fatal: a key rotation would
         // otherwise make the whole list unreadable instead of just its stale part.
-        match decrypt_secret(&envelope, &derived_key) {
+        match decrypt_secret_for_team(&envelope, &team_secret) {
             Ok(entry) => {
                 fetched.insert(key_id.to_string(), entry);
             }
@@ -681,7 +712,7 @@ pub(crate) async fn team_listings_from_cloud(
             created_by: e.created_by.clone(),
             updated_by: e.updated_by.clone(),
             updated_at: e.updated_at.clone(),
-            // Everything here came back from `decrypt_secret`, so by construction
+            // Everything here came back from `decrypt_secret_for_team`, so by construction
             // it decrypted.
             decrypted: true,
             key_mismatch: false,

--- a/apps/desktop/src/commands/shared_secrets_crypto.rs
+++ b/apps/desktop/src/commands/shared_secrets_crypto.rs
@@ -32,6 +32,15 @@ pub fn decrypt_secret(
     team_crypto::decrypt_secret(envelope, derived_key).map_err(|e| format!("decrypt_secret: {e}"))
 }
 
+/// Decrypt under the team secret, accepting both current and pre-rename HKDF salts.
+pub fn decrypt_secret_for_team(
+    envelope: &EncryptedEnvelope,
+    team_secret: &str,
+) -> Result<SecretEntry, String> {
+    team_crypto::decrypt_secret_for_team(envelope, team_secret)
+        .map_err(|e| format!("decrypt_secret_for_team: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/teamclu-runtime-env/src/env_catalog.rs
+++ b/crates/teamclu-runtime-env/src/env_catalog.rs
@@ -198,14 +198,12 @@ fn load_team_env_metas_from_dir(secrets_dir: &Path, env_secret: &str) -> Vec<Tea
 
     // A malformed team secret (wrong length / non-hex) can't decrypt anything;
     // fall back to key-only listings for the whole directory. A secret *was*
-    // present, so mark these as a key mismatch.
-    let key = match derive_key(env_secret) {
-        Ok(key) => key,
-        Err(e) => {
-            warn!(dir = %secrets_dir.display(), "env_catalog: invalid team secret, listing keys only: {e}");
-            return load_team_env_keys_from_dir(secrets_dir, true);
-        }
-    };
+    // present, so mark these as a key mismatch. Per-file decrypt goes through
+    // `decrypt_secret_for_team` so pre-rename (teamclaw salt) envelopes still open.
+    if let Err(e) = derive_key(env_secret) {
+        warn!(dir = %secrets_dir.display(), "env_catalog: invalid team secret, listing keys only: {e}");
+        return load_team_env_keys_from_dir(secrets_dir, true);
+    }
 
     let read_dir = match std::fs::read_dir(secrets_dir) {
         Ok(read_dir) => read_dir,
@@ -246,7 +244,7 @@ fn load_team_env_metas_from_dir(secrets_dir: &Path, env_secret: &str) -> Vec<Tea
                 continue;
             }
         };
-        let secret = match team_crypto::decrypt_secret(&envelope, &key) {
+        let secret = match team_crypto::decrypt_secret_for_team(&envelope, env_secret) {
             Ok(secret) => secret,
             Err(e) => {
                 warn!(path = %path.display(), "env_catalog: failed to decrypt team secret file: {e}");

--- a/crates/teamclu-runtime-env/src/team_crypto.rs
+++ b/crates/teamclu-runtime-env/src/team_crypto.rs
@@ -31,7 +31,16 @@ use sha2::Sha256;
 // ---------------------------------------------------------------------------
 
 /// HKDF-SHA256 salt. Frozen: see module docs.
+///
+/// New envelopes are always derived with this salt via [`derive_key`].
 pub const SALT: &[u8] = b"teamclu-secrets-v1";
+
+/// Pre-rename HKDF salt (`teamclaw` → `teamclu` brand sweep).
+///
+/// The rename commit changed [`SALT`] in place, which left every existing
+/// `_secrets/*.enc.json` undecryptable. Readers must still accept envelopes
+/// derived under this salt; writers must never use it again.
+pub const LEGACY_SALT: &[u8] = b"teamclaw-secrets-v1";
 
 /// HKDF-SHA256 info. Frozen: see module docs.
 pub const INFO: &[u8] = b"aes-256-gcm";
@@ -157,12 +166,16 @@ impl From<&SecretEntry> for SecretMeta {
 /// Derive a 32-byte AES-256-GCM key from a hex-encoded 32-byte team secret
 /// using HKDF-SHA256 (RFC 5869) with [`SALT`] and [`INFO`].
 pub fn derive_key(team_secret: &str) -> Result<[u8; 32], TeamCryptoError> {
+    derive_key_with_salt(team_secret, SALT)
+}
+
+fn derive_key_with_salt(team_secret: &str, salt: &[u8]) -> Result<[u8; 32], TeamCryptoError> {
     let ikm = hex::decode(team_secret)?;
     if ikm.len() != TEAM_SECRET_BYTES {
         return Err(TeamCryptoError::SecretWrongLength { got: ikm.len() });
     }
 
-    let hk = Hkdf::<Sha256>::new(Some(SALT), &ikm);
+    let hk = Hkdf::<Sha256>::new(Some(salt), &ikm);
     let mut okm = [0u8; 32];
     hk.expand(INFO, &mut okm)
         .map_err(|_| TeamCryptoError::HkdfExpand)?;
@@ -220,6 +233,27 @@ pub fn decrypt_secret(
     Ok(serde_json::from_slice(&plaintext)?)
 }
 
+/// Decrypt a team env envelope under the team secret, accepting both the
+/// current HKDF salt and the pre-rename legacy salt.
+///
+/// Prefer this over [`derive_key`] + [`decrypt_secret`] at every read path:
+/// writers still encrypt under [`SALT`] alone, but disks (and cloud caches)
+/// still hold envelopes sealed with [`LEGACY_SALT`].
+pub fn decrypt_secret_for_team(
+    envelope: &EncryptedEnvelope,
+    team_secret: &str,
+) -> Result<SecretEntry, TeamCryptoError> {
+    let current = derive_key(team_secret)?;
+    match decrypt_secret(envelope, &current) {
+        Ok(entry) => Ok(entry),
+        Err(TeamCryptoError::Decrypt) => {
+            let legacy = derive_key_with_salt(team_secret, LEGACY_SALT)?;
+            decrypt_secret(envelope, &legacy)
+        }
+        Err(other) => Err(other),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -250,16 +284,15 @@ mod tests {
         assert_eq!(a.len(), 32);
     }
 
-    /// Pins the derived key to a literal. Any change to SALT, INFO, or the HKDF
-    /// construction breaks this — which is the point: it would silently make
-    /// every secret already on disk undecryptable.
+    /// Pins the current writer key to a literal. Legacy envelopes are covered
+    /// separately by `decrypt_secret_for_team_accepts_pre_rename_salt`.
     #[test]
     fn derive_key_matches_frozen_vector() {
         let key = derive_key(&"00".repeat(32)).unwrap();
         assert_eq!(
             hex::encode(key),
-            "d87d5fd7361bbf204cb7dc5aa0f9e4641d279bded6773423a5b6f8ffeb8f1b0e",
-            "HKDF output changed — every existing team secret would break"
+            "5c2d5a5222b3335bf85219d2867d1e415874d38ace3844a6d822e1e828f1906c",
+            "current teamclu HKDF writer output changed"
         );
     }
 
@@ -416,5 +449,40 @@ mod tests {
             !json.contains(&entry.key),
             "SecretMeta must never carry the secret value"
         );
+    }
+
+    fn encrypt_with_salt(entry: &SecretEntry, team_secret: &str, salt: &[u8]) -> EncryptedEnvelope {
+        let ikm = hex::decode(team_secret).unwrap();
+        let hk = Hkdf::<Sha256>::new(Some(salt), &ikm);
+        let mut key = [0u8; 32];
+        hk.expand(INFO, &mut key).unwrap();
+        encrypt_secret(entry, &key).unwrap()
+    }
+
+    /// Secrets written before the teamclaw→teamclu brand rename used
+    /// `teamclaw-secrets-v1` as the HKDF salt. Reading them must still work.
+    #[test]
+    fn decrypt_secret_for_team_accepts_pre_rename_salt() {
+        let entry = sample_entry();
+        let envelope = encrypt_with_salt(&entry, SECRET, b"teamclaw-secrets-v1");
+
+        // Current-salt-only decrypt must fail — that is the bug we are fixing.
+        let current_key = derive_key(SECRET).unwrap();
+        assert!(matches!(
+            decrypt_secret(&envelope, &current_key),
+            Err(TeamCryptoError::Decrypt)
+        ));
+
+        let out = decrypt_secret_for_team(&envelope, SECRET).unwrap();
+        assert_eq!(out.key_id, entry.key_id);
+        assert_eq!(out.key, entry.key);
+    }
+
+    #[test]
+    fn decrypt_secret_for_team_still_reads_current_salt() {
+        let entry = sample_entry();
+        let envelope = encrypt_with_salt(&entry, SECRET, SALT);
+        let out = decrypt_secret_for_team(&envelope, SECRET).unwrap();
+        assert_eq!(out.key, entry.key);
     }
 }


### PR DESCRIPTION
## Summary
- accept the pre-rename `teamclaw-secrets-v1` HKDF salt when reading team secret envelopes
- keep all new encryption on the current `teamclu-secrets-v1` salt
- apply compatibility reads across daemon env loading, diagnostics, and desktop local/cloud secret caches

## Test plan
- [x] `cargo test -p teamclu-runtime-env --locked`
- [x] `cargo test -p amuxd --locked team_shared_env -- --nocapture`
- [x] `cargo test --manifest-path apps/desktop/Cargo.toml --locked shared_secrets -- --nocapture`

Made with [Cursor](https://cursor.com)