### PR TITLE
chore(release): copilot361 v0.4.1-beta.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amuxd"
-version = "0.4.1-beta.5"
+version = "0.4.1-beta.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10625,7 +10625,7 @@ dependencies = [
 
 [[package]]
 name = "teamclu"
-version = "0.4.1-beta.5"
+version = "0.4.1-beta.6"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.4.1-beta.5"
+version = "0.4.1-beta.6"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclu"
-version = "0.4.1-beta.5"
+version = "0.4.1-beta.6"
 description = "TeamClu - AI Agent Desktop Platform"
 authors = ["TeamClu Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClu",
-  "version": "0.4.1-beta.5",
+  "version": "0.4.1-beta.6",
   "identifier": "com.teamclu.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclu/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclu",
-  "version": "0.4.1-beta.5",
+  "version": "0.4.1-beta.6",
   "private": true,
   "description": "TeamClu - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
## Summary

Bump desktop/amuxd version to **0.4.1-beta.6** for copilot361 OSS release.

## Test plan

- [ ] Merge to main
- [ ] Dispatch `release-oss.yml` with brand `copilot361`, tag `v0.4.1-beta.6`

Made with [Cursor](https://cursor.com)