### PR TITLE
fix(ci): restore main to green — cargo fmt and two i18n keys

### DIFF
--- a/apps/desktop/src/commands/shared_secrets.rs
+++ b/apps/desktop/src/commands/shared_secrets.rs
@@ -30,8 +30,7 @@ use std::sync::Mutex;
 use tauri::{AppHandle, Emitter};
 
 use super::shared_secrets_crypto::{
-    decrypt_secret_for_team, derive_key, encrypt_secret, EncryptedEnvelope, SecretEntry,
-    SecretMeta,
+    decrypt_secret_for_team, derive_key, encrypt_secret, EncryptedEnvelope, SecretEntry, SecretMeta,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1277,6 +1277,8 @@
       "refreshing": "Refreshing...",
       "custom": "Custom",
       "modelsAvailable": "{{count}} model(s) available",
+      "modelsLoading": "Loading models...",
+      "modelsUnavailable": "Models could not be loaded",
       "notConnected": "Not connected",
       "removeCustomTooltip": "Remove custom provider",
       "editCustomTooltip": "Edit custom provider",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1277,6 +1277,8 @@
       "refreshing": "刷新中...",
       "custom": "自定义",
       "modelsAvailable": "{{count}} 个模型可用",
+      "modelsLoading": "正在加载模型...",
+      "modelsUnavailable": "模型加载失败",
       "notConnected": "未连接",
       "removeCustomTooltip": "移除自定义提供商",
       "editCustomTooltip": "编辑自定义提供商",


### PR DESCRIPTION
main has been red for three commits (`6397d32f`, `68e7b7cb`, `e6e12b89`), on two jobs, for two unrelated reasons. Every PR opened against it inherits both.

Neither was caught before merge because both arrived through PRs whose own CI was already red for the same reason — the signal was there, it just looked like the noise everyone was already stepping over.

## Rust Format & Clippy

`#882` landed an import in `shared_secrets.rs` that rustfmt rewraps onto one line:

```
Diff in apps/desktop/src/commands/shared_secrets.rs:30:
-    decrypt_secret_for_team, derive_key, encrypt_secret, EncryptedEnvelope, SecretEntry,
-    SecretMeta,
+    decrypt_secret_for_team, derive_key, encrypt_secret, EncryptedEnvelope, SecretEntry, SecretMeta,
```

`cargo fmt --manifest-path apps/desktop/Cargo.toml` touches only that file — no collateral reformatting.

## Lint, Typecheck & Test

`#877` added `settings.llm.modelsLoading` and `settings.llm.modelsUnavailable` in `LLMSection.tsx` without adding either to the locale files. That fails two guards at once: the `i18n-parity` runtime-missing-key check and `locale.test.ts`'s static-reference check.

Worth noting *why* this was invisible outside CI: both call sites pass fallback text —

```tsx
t('settings.llm.modelsLoading', 'Loading models...')
t('settings.llm.modelsUnavailable', 'Models could not be loaded')
```

— so the UI rendered correctly the whole time. It only ever surfaced as a red gate, which is exactly what those guards are for.

The English strings are the call sites' own fallbacks, so **nothing user-visible changes**; the Chinese ones are new. Locale files were edited as text rather than parse-and-dump, so key order and formatting are untouched.

## Verification

The full CI-gated set, locally:

| | |
|---|---|
| `pnpm lint` | 0 errors |
| `pnpm typecheck` | clean |
| app unit | 2743 passed |
| expo | 93 files / 572 tests |
| extension | 11 files / 38 tests |
| `pnpm test:scripts` | 90 passed |
| `cargo fmt --check` | clean |
| `cargo clippy -- -D warnings` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)