### PR TITLE
chore(release): bump to v0.4.1-beta.7 for copilot361 OSS release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amuxd"
-version = "0.4.1-beta.6"
+version = "0.4.1-beta.7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10625,7 +10625,7 @@ dependencies = [
 
 [[package]]
 name = "teamclu"
-version = "0.4.1-beta.6"
+version = "0.4.1-beta.7"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.4.1-beta.6"
+version = "0.4.1-beta.7"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclu"
-version = "0.4.1-beta.6"
+version = "0.4.1-beta.7"
 description = "TeamClu - AI Agent Desktop Platform"
 authors = ["TeamClu Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClu",
-  "version": "0.4.1-beta.6",
+  "version": "0.4.1-beta.7",
   "identifier": "com.teamclu.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclu/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclu",
-  "version": "0.4.1-beta.6",
+  "version": "0.4.1-beta.7",
   "private": true,
   "description": "TeamClu - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
只改版本号，为 copilot361 的 OSS 发布做准备。

五处规范来源加上 `Cargo.lock` 里 `teamclu` 与 `amuxd` 两条，全部对齐 `0.4.1-beta.7`。lockfile 不是可选项——CI 用 `--locked` 构建 daemon，和清单不一致会直接失败。

包含自 v0.4.1-beta.6 以来合入 main 的内容（#884 e2e 清理、#885 CI 修复）。

**不包含** PR #886 的团队 skill 自动跟随，那个还没合。

合入后手动 dispatch：

```
gh workflow run release-oss.yml -f brand=copilot361 -f tag=v0.4.1-beta.7
```

验证：
- `scripts/verify-release-version-bump.sh 0.4.1-beta.7` ✅ 五处一致、版本号严格递增
- `cargo metadata --locked` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)