### PR TITLE
fix(build): drop `baseUrl`, which TypeScript 7 removed

### DIFF
--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -25,7 +25,9 @@
     "noUncheckedSideEffectImports": true,
 
     /* Paths */
-    "baseUrl": ".",
+    /* No `baseUrl`: TypeScript 7 removed it, and it was redundant here anyway —
+       `paths` below is already relative, which is resolved against this file's
+       own directory. */
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
main 现在建不出前端,发布因此发不出任何东西。

#477 把 TypeScript 从 6.0.3 升到 7.0.2,而 TS 7 直接移除了 `baseUrl`:

```
tsconfig.json(28,5): error TS5102: Option 'baseUrl' has been removed.
```

`tsc -b` 挂 → `pnpm build` 挂 → 发布工作流里每个桌面构建 job 都停在 "Build frontend"。`publish-manifest` 的条件是 macOS 和 Windows 都成功,所以 copilot361 v0.4.1-beta.7 那次 run(31580366252)**一个包都没发出去**。CI 的 lint 和 typecheck 两个 job 也是同一个原因红的。

## 为什么删掉是安全的

这个选项本来就是冗余的:

```json
"baseUrl": ".",
"paths": { "@/*": ["./src/*"] }
```

`paths` 里已经是相对路径 `./src/*`,而相对路径本来就按 tsconfig 所在目录解析——正是 `baseUrl: "."` 在说的事。删掉不改变任何解析行为。

## 验证

用 **TypeScript 7.0.2 本体**(不是仓库里 pin 的 6.x)对 `packages/app` 跑了一遍 `tsc --noEmit`:**exit 0,零错误**。所以 TS 7 这个大版本里没有别的破坏性变更压在这第一个错误后面——这是选"删一行"而不是"revert #477"时唯一真正的风险,已排除。

全仓库带 `baseUrl` 的 tsconfig 只有这一个;`packages/app/tsconfig.json` 没有 project references,`tsc -b` 只建它自己。

🤖 Generated with [Claude Code](https://claude.com/claude-code)