### PR TITLE
style(desktop): restore cargo fmt on main

### DIFF
--- a/apps/desktop/src/commands/introspect_api.rs
+++ b/apps/desktop/src/commands/introspect_api.rs
@@ -768,9 +768,7 @@ async fn handle_session_archive(app: &AppHandle, body: &[u8]) -> Result<String, 
     )
     .await
     {
-        eprintln!(
-            "[IntrospectAPI] local cache soft-delete after archive failed: {e}"
-        );
+        eprintln!("[IntrospectAPI] local cache soft-delete after archive failed: {e}");
     }
 
     let payload = serde_json::json!({


### PR DESCRIPTION
main 现在 `cargo fmt --check` 是红的,所以**每个针对 main 开的 PR 都会在 "Rust Format & Clippy" 这个 job 上挂**。

来自 #840,一个 `eprintln!` 被折成了三行而 rustfmt 要求单行:

```rust
-        eprintln!(
-            "[IntrospectAPI] local cache soft-delete after archive failed: {e}"
-        );
+        eprintln!("[IntrospectAPI] local cache soft-delete after archive failed: {e}");
```

纯 `cargo fmt` 产物,没有手改。

## 顺带确认了 clippy

fmt 是那个 job 的第一步,它一挂 clippy 就不会跑,所以在此之前没人知道 clippy 是什么状态。我单独验过:`cargo clippy --manifest-path apps/desktop/Cargo.toml -- -D warnings` **exit 0、零 error**。

有一个坑值得记一下:在全新 checkout 上跑 clippy 会先炸,报的是 `build.rs` panic —— 因为 `apps/desktop/binaries/` 下的 sidecar 二进制在 `.gitignore` 里,新 worktree 没有。那不是 lint 结论,别当成真问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)