### PR TITLE
fix(app): re-check a team skill for local edits right after saving

### DIFF
--- a/packages/app/src/components/teamshare/SkillDetail.tsx
+++ b/packages/app/src/components/teamshare/SkillDetail.tsx
@@ -945,12 +945,19 @@ export function SkillDetail({ slug }: { slug: string }) {
       })
       if (saved === null) throw new Error('daemon rejected the update')
       await loadSection('skills', { force: true })
+      // Re-check the pack against its baseline right away. Saving is what makes
+      // a team pack differ from the version it was installed at, and "differs"
+      // is the state the conflict bar renders — which is where the only entry
+      // to publishing a new version lives. Leaving it to the next reconcile
+      // tick meant the author saved, saw nothing change, found no way to share
+      // the edit, and waited up to ten minutes to be told there was one.
+      await reconcileSkills().catch(() => {})
     } catch (e) {
       toast.error(t('teamShare.saveFailed', 'Save failed: {{msg}}', { msg: e instanceof Error ? e.message : String(e) }))
     } finally {
       setSaving(false)
     }
-  }, [item, workspacePath, saving, content, loadSection, t])
+  }, [item, workspacePath, saving, content, loadSection, reconcileSkills, t])
 
   const runInstall = React.useCallback(async () => {
     if (!item || busy) return


### PR DESCRIPTION
改一个已安装的团队 skill、按保存,界面上看不出任何变化——版本没动(**这是对的**,保存只写盘、从不碰注册表),但也没有任何地方能把这次修改分享出去。

原因:发新版的入口在**冲突条**里,而冲突条渲染的是"盘上内容和安装时的基线不一致"这个状态,该状态由对账计算。`handleSave` 只调了 `loadSection`,没有重新判脏,所以要等下一个 10 分钟周期才会出现。

保存之后立刻跑一次 `reconcileSkills()` 就够了:

```
改内容 → Save → 写盘 → 立即重新判脏 → 冲突条出现
                                      ↓
                    [发布为 v2] / [另存为个人] / [丢弃本地]
```

对账失败被吞掉是有意的:字节已经落盘,一次成功的保存不该因为对账(比如离线)失败而被报成失败,下一个 tick 会看到同样的改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)