### PR TITLE
feat(daemon): serve team MCP from one file every runtime reads

### DIFF
--- a/apps/daemon/src/config/team_mcp.rs
+++ b/apps/daemon/src/config/team_mcp.rs
@@ -49,12 +49,12 @@ struct TeamMcpFile {
 }
 
 #[derive(Debug, Deserialize)]
-struct CursorMcpServer {
-    command: Option<String>,
-    args: Option<Vec<String>>,
-    env: Option<HashMap<String, String>>,
-    url: Option<String>,
-    headers: Option<HashMap<String, String>>,
+pub(crate) struct CursorMcpServer {
+    pub command: Option<String>,
+    pub args: Option<Vec<String>>,
+    pub env: Option<HashMap<String, String>>,
+    pub url: Option<String>,
+    pub headers: Option<HashMap<String, String>>,
 }
 
 fn io_err(e: std::io::Error) -> WorkspaceControlError {
@@ -69,7 +69,7 @@ fn is_inherent(name: &str) -> bool {
     INHERENT_MCP_NAMES.contains(&name)
 }
 
-fn onboarded_team_id() -> Option<String> {
+pub(crate) fn onboarded_team_id() -> Option<String> {
     super::DaemonConfig::load(&super::DaemonConfig::default_path())
         .ok()
         .and_then(|cfg| {
@@ -104,7 +104,7 @@ fn team_mcp_dirs(workspace: &Path) -> Vec<PathBuf> {
     }
 }
 
-fn convert_cursor_server(server: &CursorMcpServer) -> McpServerConfig {
+pub(crate) fn convert_cursor_server(server: &CursorMcpServer) -> McpServerConfig {
     if server.url.is_some() {
         McpServerConfig {
             server_type: "remote".to_owned(),
@@ -145,10 +145,39 @@ fn convert_cursor_server(server: &CursorMcpServer) -> McpServerConfig {
 /// [`team_mcp_dirs`] for the ordering and why.
 pub fn scan_team_mcp(workspace: &Path) -> HashMap<String, McpServerConfig> {
     let mut team_servers = HashMap::new();
+    // Legacy first so it can never shadow the cloud file — see `team_mcp_dirs`.
     for mcp_dir in team_mcp_dirs(workspace) {
         scan_team_mcp_dir_into(&mcp_dir, &mut team_servers);
     }
+    if let Some(team_id) = onboarded_team_id() {
+        read_cloud_mcp_file_into(
+            &crate::runtime::team_cloud_config::team_cloud_mcp_file(&team_id),
+            &mut team_servers,
+        );
+    }
     team_servers
+}
+
+/// Read the cloud file, which is already in opencode's `mcp` shape.
+///
+/// Kept separate from the legacy scan because the two speak different formats:
+/// the synced `.mcp/*.json` files are Cursor's `mcpServers`, this one is what
+/// every runtime consumes directly.
+fn read_cloud_mcp_file_into(path: &Path, out: &mut HashMap<String, McpServerConfig>) {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return;
+    };
+    let Some(map) = json.get("mcp").and_then(|v| v.as_object()) else {
+        return;
+    };
+    for (name, raw) in map {
+        if let Ok(cfg) = serde_json::from_value::<McpServerConfig>(raw.clone()) {
+            out.insert(name.clone(), cfg);
+        }
+    }
 }
 
 fn scan_team_mcp_dir_into(mcp_dir: &Path, out: &mut HashMap<String, McpServerConfig>) {
@@ -275,70 +304,83 @@ pub fn filter_put_body(
         .collect()
 }
 
-/// Result of materializing team MCP entries into `opencode.json`.
+/// Result of reconciling a workspace's `opencode.json` against the team set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MaterializeTeamMcpOutcome {
+pub struct PruneTeamMcpOutcome {
     /// Whether `opencode.json` was rewritten.
     pub changed: bool,
-    /// Team MCP servers newly inserted (existing workspace/inherent entries are untouched).
-    pub added_count: usize,
+    /// Leftover team copies removed.
+    pub removed_count: usize,
 }
 
-/// Add team-only MCP entries into `opencode.json` for agent runtimes (workspace wins).
-pub fn materialize_team_mcp_for_runtime(
-    workspace: &Path,
-) -> Result<MaterializeTeamMcpOutcome, WorkspaceControlError> {
-    materialize_team_mcp_entries(workspace, &scan_team_mcp(workspace))
-}
-
-/// The applying half, taking the team map explicitly.
+/// Remove team MCP entries an older build copied into `opencode.json`.
 ///
-/// Split from [`materialize_team_mcp_for_runtime`] so it can be tested without a
-/// daemon config dir: resolving *where* team MCP comes from now goes through the
-/// cloud cache under `~/.amuxd`, which a unit test has no business creating.
-pub fn materialize_team_mcp_entries(
+/// Team servers used to be *materialised* into every workspace's config so the
+/// runtimes could see them. They are now read straight from
+/// `~/.amuxd/teams/<id>/cloud/mcp.json` by all four, which makes those copies
+/// worse than redundant: a workspace entry outranks the team's, so a leftover
+/// copy silently pins that server at whatever the team shipped the day it was
+/// written, and no team update can ever reach the machine again.
+///
+/// Only byte-identical copies go. An entry that differs from the team's is a
+/// deliberate local override — the one thing the workspace layer exists for —
+/// and outranking the team is exactly what it should keep doing.
+pub fn prune_materialised_team_mcp(
+    workspace: &Path,
+) -> Result<PruneTeamMcpOutcome, WorkspaceControlError> {
+    prune_materialised_team_mcp_entries(workspace, &scan_team_mcp(workspace))
+}
+
+/// The applying half, taking the team map explicitly so it is testable without
+/// a daemon config dir.
+pub fn prune_materialised_team_mcp_entries(
     workspace: &Path,
     team: &HashMap<String, McpServerConfig>,
-) -> Result<MaterializeTeamMcpOutcome, WorkspaceControlError> {
+) -> Result<PruneTeamMcpOutcome, WorkspaceControlError> {
     if team.is_empty() {
-        return Ok(MaterializeTeamMcpOutcome {
+        return Ok(PruneTeamMcpOutcome {
             changed: false,
-            added_count: 0,
+            removed_count: 0,
         });
     }
 
-    let mut added_count = 0usize;
+    let mut removed_count = 0usize;
     let changed =
         teamclu_runtime_env::opencode_config::OpencodeConfigStore::apply(workspace, |json| {
-            let obj = json.as_object_mut().ok_or_else(|| {
-                OpencodeConfigError::Parse("opencode.json root is not an object".into())
-            })?;
-            if obj.get("$schema").is_none() && obj.is_empty() {
-                obj.insert(
-                    "$schema".to_string(),
-                    serde_json::json!("https://opencode.ai/config.json"),
-                );
-            }
-            let mcp = obj.entry("mcp").or_insert_with(|| serde_json::json!({}));
-            let mcp_obj = mcp
-                .as_object_mut()
-                .ok_or_else(|| OpencodeConfigError::Parse("mcp is not an object".into()))?;
+            let Some(obj) = json.as_object_mut() else {
+                return Ok(false);
+            };
+            let Some(mcp_obj) = obj.get_mut("mcp").and_then(|m| m.as_object_mut()) else {
+                return Ok(false);
+            };
 
-            for (name, cfg) in team {
-                if !mcp_obj.contains_key(name) {
-                    let value = serde_json::to_value(cfg)
-                        .map_err(|e| OpencodeConfigError::Parse(e.to_string()))?;
-                    mcp_obj.insert(name.clone(), value);
-                    added_count += 1;
-                }
+            let stale: Vec<String> = mcp_obj
+                .iter()
+                .filter(|(name, raw)| {
+                    if is_inherent(name) {
+                        return false;
+                    }
+                    let Some(team_cfg) = team.get(name.as_str()) else {
+                        return false;
+                    };
+                    serde_json::from_value::<McpServerConfig>((*raw).clone())
+                        .map(|local| configs_equal(&local, team_cfg))
+                        .unwrap_or(false)
+                })
+                .map(|(name, _)| name.clone())
+                .collect();
+
+            for name in &stale {
+                mcp_obj.remove(name);
+                removed_count += 1;
             }
-            Ok(added_count > 0)
+            Ok(removed_count > 0)
         })
         .map_err(|e| WorkspaceControlError::Io(e.to_string()))?;
 
-    Ok(MaterializeTeamMcpOutcome {
+    Ok(PruneTeamMcpOutcome {
         changed,
-        added_count,
+        removed_count,
     })
 }
 
@@ -508,27 +550,61 @@ mod tests {
     }
 
     #[test]
-    fn materialize_adds_team_only_entries_without_overwriting_workspace() {
+    fn pruning_drops_a_leftover_team_copy_but_keeps_a_real_override() {
+        // The migration. An older build copied every team server into this file;
+        // the runtimes now read the team's own file, so a copy that still
+        // matches is dead weight that would outrank the source forever. A copy
+        // the user changed is the local override the workspace layer is for.
         let ws = tempfile::tempdir().unwrap();
         std::fs::write(
             ws.path().join("opencode.json"),
-            r#"{"mcp":{"shared":{"type":"local","enabled":true,"command":["npx","local"]}}}"#,
+            r#"{"mcp":{
+                "copied":{"type":"local","enabled":true,"command":["npx","team"]},
+                "overridden":{"type":"local","enabled":true,"command":["npx","mine"]},
+                "mine-only":{"type":"local","enabled":true,"command":["npx","solo"]}
+            }}"#,
         )
         .unwrap();
 
         let mut team = HashMap::new();
-        team.insert("team-a".to_owned(), local_cfg(&["npx", "a"]));
-        team.insert("shared".to_owned(), local_cfg(&["npx", "team"]));
+        team.insert("copied".to_owned(), local_cfg(&["npx", "team"]));
+        team.insert("overridden".to_owned(), local_cfg(&["npx", "team"]));
 
-        let outcome = materialize_team_mcp_entries(ws.path(), &team).unwrap();
+        let outcome = prune_materialised_team_mcp_entries(ws.path(), &team).unwrap();
         assert!(outcome.changed);
-        assert_eq!(outcome.added_count, 1);
+        assert_eq!(outcome.removed_count, 1);
 
         let persisted = read_persisted_mcp(ws.path()).unwrap();
-        assert_eq!(
-            persisted.get("shared").unwrap().command,
-            vec!["npx", "local"]
+        assert!(
+            !persisted.contains_key("copied"),
+            "an unmodified copy of the team entry is removed"
         );
-        assert_eq!(persisted.get("team-a").unwrap().command, vec!["npx", "a"]);
+        assert_eq!(
+            persisted.get("overridden").unwrap().command,
+            vec!["npx", "mine"],
+            "a changed entry is a deliberate override and stays"
+        );
+        assert_eq!(
+            persisted.get("mine-only").unwrap().command,
+            vec!["npx", "solo"],
+            "a server the team never had is untouched"
+        );
+    }
+
+    #[test]
+    fn pruning_leaves_an_inherent_server_alone_even_if_the_team_ships_one() {
+        let ws = tempfile::tempdir().unwrap();
+        std::fs::write(
+            ws.path().join("opencode.json"),
+            r#"{"mcp":{"playwright":{"type":"local","enabled":true,"command":["npx","pw"]}}}"#,
+        )
+        .unwrap();
+        let mut team = HashMap::new();
+        team.insert("playwright".to_owned(), local_cfg(&["npx", "pw"]));
+
+        let outcome = prune_materialised_team_mcp_entries(ws.path(), &team).unwrap();
+
+        assert!(!outcome.changed);
+        assert!(read_persisted_mcp(ws.path()).unwrap().contains_key("playwright"));
     }
 }

--- a/apps/daemon/src/config/workspace_control.rs
+++ b/apps/daemon/src/config/workspace_control.rs
@@ -808,7 +808,9 @@ impl WorkspaceControlStore for OpenCodeCompatStore {
         let mut cfg = Self::read_opencode_json(&wpath)?;
         cfg.mcp = workspace_only;
         Self::write_opencode_json(&wpath, &cfg)?;
-        super::team_mcp::materialize_team_mcp_for_runtime(&wpath)?;
+        // Drop any team copy an older build left in this file; the runtimes read
+        // the team's own file now, and a leftover copy would outrank it forever.
+        super::team_mcp::prune_materialised_team_mcp(&wpath)?;
         // OpenCode re-reads mcp on next session start; a running session
         // needs a restart to pick up server changes.
         Ok(ApplyOutcome::RestartRequired)

--- a/apps/daemon/src/http/workspaces.rs
+++ b/apps/daemon/src/http/workspaces.rs
@@ -807,7 +807,7 @@ pub async fn get_mcp(
     require_scope(&principal, "workspace:read")?;
     let wpath = workspace_path_or_404(&workspace_id).await?;
     crate::runtime::supervisor::ensure_inherent_mcp(&wpath).map_err(map_control_err)?;
-    crate::config::team_mcp::materialize_team_mcp_for_runtime(&wpath).map_err(map_control_err)?;
+    crate::config::team_mcp::prune_materialised_team_mcp(&wpath).map_err(map_control_err)?;
     let store = resolve_store(&state)?;
     let servers = store.get_mcp(&workspace_id).map_err(map_control_err)?;
     Ok(Json(servers))
@@ -850,7 +850,7 @@ pub async fn get_mcp_tools(
     require_scope(&principal, "workspace:read")?;
     let wpath = workspace_path_or_404(&workspace_id).await?;
     crate::runtime::supervisor::ensure_inherent_mcp(&wpath).map_err(map_control_err)?;
-    crate::config::team_mcp::materialize_team_mcp_for_runtime(&wpath).map_err(map_control_err)?;
+    crate::config::team_mcp::prune_materialised_team_mcp(&wpath).map_err(map_control_err)?;
     let store = resolve_store(&state)?;
     let servers = store.get_mcp(&workspace_id).map_err(map_control_err)?;
     let response =
@@ -866,10 +866,14 @@ pub struct MaterializeTeamMcpResponse {
 
 /// `POST /v1/workspaces/:id/mcp/materialize-team`
 ///
-/// Materialize team-shared MCP definitions from `teamclu-team/.mcp/*.json`
-/// into this workspace's `opencode.json`. Only amuxd writes the file (atomic +
-/// process-local lock). Desktop/git join flows call this instead of touching
-/// `opencode.json` directly.
+/// No longer materialises anything: every runtime reads team MCP from
+/// `~/.amuxd/teams/<id>/cloud/mcp.json` directly. The route stays, and now does
+/// the inverse — clearing team copies an older build wrote into this
+/// workspace's `opencode.json`, where they would outrank the team's own file
+/// and freeze those servers at the version that was copied.
+///
+/// Kept rather than removed so a desktop that still calls it keeps working; it
+/// reports what it removed under the old field name.
 pub async fn materialize_team_mcp(
     principal: Principal,
     Path(workspace_id): Path<String>,
@@ -877,11 +881,11 @@ pub async fn materialize_team_mcp(
     require_scope(&principal, "workspace:write")?;
     let wpath = workspace_path_or_404(&workspace_id).await?;
     crate::runtime::supervisor::ensure_inherent_mcp(&wpath).map_err(map_control_err)?;
-    let outcome = crate::config::team_mcp::materialize_team_mcp_for_runtime(&wpath)
-        .map_err(map_control_err)?;
+    let outcome =
+        crate::config::team_mcp::prune_materialised_team_mcp(&wpath).map_err(map_control_err)?;
     Ok(Json(MaterializeTeamMcpResponse {
         changed: outcome.changed,
-        added_count: outcome.added_count,
+        added_count: outcome.removed_count,
     }))
 }
 

--- a/apps/daemon/src/runtime/opencode_http/supervisor.rs
+++ b/apps/daemon/src/runtime/opencode_http/supervisor.rs
@@ -323,6 +323,21 @@ impl ServeSupervisor {
             ),
         );
         cmd.env("OPENCODE_SERVER_PASSWORD", &self.password);
+        // Team MCP reaches opencode as an extra config file rather than by
+        // being copied into the user's `<worktree>/opencode.json`.
+        //
+        // `OPENCODE_CONFIG` *merges* with the normal config chain instead of
+        // replacing it, and the workspace file wins a name collision — verified
+        // against opencode 1.18.5 with `opencode debug config`. That is exactly
+        // the precedence the merged view already documented (workspace beats
+        // team), so pointing at the file gets it for free and stops the daemon
+        // writing team entries into a file the user edits and commits.
+        if let Some(team_id) = crate::config::team_mcp::onboarded_team_id() {
+            let path = crate::runtime::team_cloud_config::team_cloud_mcp_file(&team_id);
+            if path.is_file() {
+                cmd.env("OPENCODE_CONFIG", &path);
+            }
+        }
         for (k, v) in &spawn_env {
             if std::env::var_os(k).is_none() {
                 cmd.env(k, v);

--- a/apps/daemon/src/runtime/sidecar/mcp.rs
+++ b/apps/daemon/src/runtime/sidecar/mcp.rs
@@ -1,12 +1,16 @@
 //! Workspace MCP manifest → `@cursor/sdk` `AgentOptions.mcpServers`.
 //!
-//! Two sources, merged (remote-tools wins on a name clash):
+//! Three sources, merged in this order (later wins a name clash):
 //!
-//! 1. `mcp_config_path` — the host-level `remote-tools-host.json` written by
+//! 1. `~/.amuxd/teams/<id>/cloud/mcp.json` — the team registry's servers, in
+//!    opencode's own `mcp` shape. The same file `opencode serve` is pointed at
+//!    with `OPENCODE_CONFIG`, so all four runtimes read one source and nothing
+//!    is copied into the user's workspace config to get there.
+//! 2. `<worktree>/opencode.json` `mcp` map — the user's own servers and local
+//!    overrides of team ones.
+//! 3. `mcp_config_path` — the host-level `remote-tools-host.json` written by
 //!    `remote_tools::mcp_config`, shape `{"mcpServers": {name: {command, args}}}`.
-//! 2. `<worktree>/opencode.json` `mcp` map — the MCP SSOT (team + inherent +
-//!    user servers all merge into it), same source pi bridges through its
-//!    extension.
+//!    Daemon-owned, so it wins outright.
 //!
 //! The SDK wants `Record<string, McpServerConfig>` (`options.d.ts:235`) where a
 //! stdio entry is `{type:"stdio", command: string, args: string[], env}` — note
@@ -123,9 +127,27 @@ fn read_json(path: &Path) -> Option<Value> {
 /// Assemble every MCP server a cursor session should see. Missing or malformed
 /// files contribute nothing rather than failing the attach.
 pub fn assemble(worktree: &str, mcp_config_path: Option<&Path>) -> McpServers {
-    let mut out = read_json(&Path::new(worktree).join("opencode.json"))
+    // Team servers first, so a same-named workspace entry overwrites them
+    // below. That is the same precedence `opencode serve` applies to the file
+    // we hand it via `OPENCODE_CONFIG`, and the same one the merged view has
+    // always documented: a local override beats the team's copy, because a
+    // server definition carries machine-specific paths and ports that only the
+    // person at that machine can be right about.
+    //
+    // Read straight from the cloud file rather than from whatever a
+    // materialise step last copied into the workspace: one source, no step in
+    // between that can drift or be overwritten.
+    let mut out = crate::config::team_mcp::onboarded_team_id()
+        .map(|id| crate::runtime::team_cloud_config::team_cloud_mcp_file(&id))
+        .and_then(|p| read_json(&p))
         .map(|v| servers_from_opencode_value(&v))
         .unwrap_or_default();
+    for (name, cfg) in read_json(&Path::new(worktree).join("opencode.json"))
+        .map(|v| servers_from_opencode_value(&v))
+        .unwrap_or_default()
+    {
+        out.insert(name, cfg);
+    }
     // remote-tools is daemon-owned; it wins over a same-named workspace entry.
     if let Some(extra) = mcp_config_path
         .and_then(read_json)

--- a/apps/daemon/src/runtime/team_cloud_config.rs
+++ b/apps/daemon/src/runtime/team_cloud_config.rs
@@ -57,7 +57,7 @@ const TEAM_CLOUD_TTL: Duration = Duration::from_secs(60);
 /// Name of the single team-MCP cache file. One file rather than one per server
 /// so a fetch lands atomically: a partial rename sequence must never be able to
 /// present half a team's servers as the whole set.
-const MCP_CACHE_FILE: &str = "team.json";
+const MCP_CACHE_FILE: &str = "mcp.json";
 
 pub struct TeamCloudConfigResolver {
     backend: Arc<dyn Backend>,
@@ -183,6 +183,17 @@ async fn record_refresh(
     }
 }
 
+/// The single team-MCP file every runtime reads.
+///
+/// Written in opencode's own config shape (`{"mcp": {...}}`) rather than the
+/// server's Cursor shape, because that is what lets one file serve all four
+/// runtimes: `opencode serve` is pointed at it with `OPENCODE_CONFIG` and
+/// merges it itself, and the sidecar runtimes (claude / cursor / pi) already
+/// know how to read an opencode `mcp` map.
+pub fn team_cloud_mcp_file(team_id: &str) -> PathBuf {
+    global_team_cloud_dir(team_id).join(MCP_CACHE_FILE)
+}
+
 pub fn team_cloud_mcp_dir(team_id: &str) -> PathBuf {
     global_team_cloud_dir(team_id).join(".mcp")
 }
@@ -278,7 +289,28 @@ impl TeamCloudConfigResolver {
             return None;
         }
 
-        let path = team_cloud_mcp_dir(team_id).join(MCP_CACHE_FILE);
+        // Convert on the way in, not on the way out. Every reader then sees
+        // opencode's shape and nobody has to know the registry speaks Cursor's.
+        let servers: std::collections::HashMap<String, serde_json::Value> = config
+            .get("mcpServers")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(name, raw)| {
+                        let parsed: crate::config::team_mcp::CursorMcpServer =
+                            serde_json::from_value(raw.clone()).ok()?;
+                        let converted = crate::config::team_mcp::convert_cursor_server(&parsed);
+                        Some((name.clone(), serde_json::to_value(converted).ok()?))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let config = serde_json::json!({
+            "$schema": "https://opencode.ai/config.json",
+            "mcp": servers,
+        });
+
+        let path = team_cloud_mcp_file(team_id);
         let body = match serde_json::to_string_pretty(&config) {
             Ok(s) => s,
             Err(e) => {

--- a/apps/daemon/tests/http_workspace_provider_auth.rs
+++ b/apps/daemon/tests/http_workspace_provider_auth.rs
@@ -275,7 +275,11 @@ async fn post_provider_oauth_authorize_503_without_settings_service() {
 }
 
 #[tokio::test]
-async fn post_materialize_team_mcp_writes_team_servers_into_opencode_json() {
+async fn post_materialize_team_mcp_clears_copies_an_older_build_left_behind() {
+    // The route no longer materialises: every runtime reads the team's own file
+    // now. What it does instead is undo the old behaviour, because a leftover
+    // copy in this file outranks the team's and would freeze that server at
+    // whatever was copied.
     let (app, dir) = test_app_with_workspace_store(None).await;
     let wid = ws_id(dir.path());
 
@@ -294,6 +298,17 @@ async fn post_materialize_team_mcp_writes_team_servers_into_opencode_json() {
     )
     .expect("write team mcp");
 
+    // What the old materialise would have written, plus a server of the user's
+    // own that must survive.
+    std::fs::write(
+        dir.path().join("opencode.json"),
+        r#"{"mcp":{
+  "team-db":{"type":"local","enabled":true,"command":["npx","-y","team-db-mcp"]},
+  "mine":{"type":"local","enabled":true,"command":["npx","mine"]}
+}}"#,
+    )
+    .expect("write opencode.json");
+
     let body: Value = app
         .client
         .post(format!(
@@ -311,9 +326,16 @@ async fn post_materialize_team_mcp_writes_team_servers_into_opencode_json() {
         .expect("json");
 
     assert_eq!(body["changed"], true);
-    assert_eq!(body["added_count"], 1);
+    assert_eq!(body["added_count"], 1, "reports what it removed");
 
     let opencode = std::fs::read_to_string(dir.path().join("opencode.json")).expect("opencode");
     let parsed: Value = serde_json::from_str(&opencode).expect("parse opencode");
-    assert!(parsed["mcp"]["team-db"].is_object());
+    assert!(
+        parsed["mcp"]["team-db"].is_null(),
+        "the leftover team copy is gone"
+    );
+    assert!(
+        parsed["mcp"]["mine"].is_object(),
+        "the user's own server is untouched"
+    );
 }


### PR DESCRIPTION
团队 MCP 原来是**复制**进每个 workspace 的 `opencode.json` 才能被 agent 看到。这等于在注册表和 agent 之间塞了一个可变、用户可编辑、通常还会被提交进仓库的文件;而且它只对 opencode 有效——纯粹因为那恰好是 opencode 自己的配置文件。

现在只有一份文件:`~/.amuxd/teams/<id>/cloud/mcp.json`,四个 runtime 全部直读。

## 各 runtime 怎么拿到

| runtime | 方式 |
|---|---|
| opencode | spawn 时 `OPENCODE_CONFIG` 指过去 |
| claude / cursor / pi | `sidecar::mcp::assemble()` 直接读 |

`OPENCODE_CONFIG` 的行为是**实测**的(opencode 1.18.5,用 `opencode debug config` 验的),两条关键性质:

1. **合并而非替换** —— 用户 `~/.config/opencode` 里的 plugin 等配置照常生效
2. **workspace 同名条目优先** —— 正是既有的 `workspace > team` 规则,不用我们再实现一遍

sidecar 那三个的合并顺序对齐同一规则:先 team,再 worktree `opencode.json` 覆盖,最后 daemon 自有的 remote-tools 覆盖。

## 形状转换挪到写入侧

注册表给的是 Cursor 的 `mcpServers`,文件落盘时就转成 opencode 的 `mcp`。转一次,四个读者都只认一种方言,没人需要知道服务端说的是另一种。

## materialise 反转成迁移清理

老版本留在用户 `opencode.json` 里的 team 副本,在新模型下**不只是冗余**:workspace 层优先级更高,每个残留副本都会把那个服务器**永久钉死**在复制当天的版本,团队之后的更新再也到不了这台机器。

`prune_materialised_team_mcp` 只删**和团队定义逐字段相同**的条目;用户改过的保留——那是本地覆盖,压过团队正是它该做的。inherent 服务器(playwright 等)永不删。

`POST .../mcp/materialize-team` 路由保留,现在执行的是这个清理,所以老版本桌面端调它依然做的是对的事。

## 已知限制

`OPENCODE_CONFIG` 是**进程级**的,而 daemon 每台设备只跑一个全局 `opencode serve`,所以只能指向当前 onboarded team 的那份。这和现在"daemon 绑定单个团队"的模型一致;若将来一台机器要同时服务多个团队的 workspace,需要另想办法。

## 验证

- `cargo test -p amuxd`:**1073 passed / 0 failed**
- 新增两个测试钉住迁移判据:未改过的副本被删、改过的保留、团队没有的不动;inherent 不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)