### PR TITLE
chore(release): 0.4.1-beta.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amuxd"
-version = "0.4.1-beta.8"
+version = "0.4.1-beta.9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10626,7 +10626,7 @@ dependencies = [
 
 [[package]]
 name = "teamclu"
-version = "0.4.1-beta.8"
+version = "0.4.1-beta.9"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.4.1-beta.8"
+version = "0.4.1-beta.9"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclu"
-version = "0.4.1-beta.8"
+version = "0.4.1-beta.9"
 description = "TeamClu - AI Agent Desktop Platform"
 authors = ["TeamClu Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClu",
-  "version": "0.4.1-beta.8",
+  "version": "0.4.1-beta.9",
   "identifier": "com.teamclu.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclu/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclu",
-  "version": "0.4.1-beta.8",
+  "version": "0.4.1-beta.9",
   "private": true,
   "description": "TeamClu - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
Version bump only — no behaviour change. Cuts the first release that contains the [team-scoped amuxd home layout v2](https://github.com/different-ai-studio/teamclu/pull/899).

Bumps all five canonical sources: `package.json`, `apps/desktop/Cargo.toml`, `apps/desktop/tauri.conf.json`, `apps/daemon/Cargo.toml`, and `Cargo.lock` (`teamclu` + `amuxd` entries).

**Why beta.9 and not beta.8.** The repo already sat at `0.4.1-beta.8` while the last published tag was `v0.4.1-beta.1`, so beta.8 had been spent on local builds that predate the layout-v2 merge. Tagging it would give one version string to two different trees. beta.9 corresponds to exactly this code.

The bundled amuxd moves with it deliberately: the client only force-upgrades `~/.amuxd/bin/amuxd` when the bundled crate version is strictly greater than the installed one, so a release that leaves it unchanged silently keeps the old daemon.

**Verified locally** — the same gate CI runs:

```
scripts/check-desktop-version.sh          ✓ all sources match (0.4.1-beta.9)
scripts/verify-release-version-bump.sh    ✓ new version, amuxd bump enforced
cargo metadata --locked                   ✓ lockfile agrees with manifests
```

## ⚠️ This release forces a re-onboard

Layout v2 **purges v1 daemon state on boot** — everyone re-onboards once. That is deliberate: migrating would have carried forward a live `refresh_token`, plaintext channel bot tokens, and a plaintext `agents.cursor.api_key`. The desktop home (`~/.teamclu`) is untouched; personal keys survive. Worth saying out loud in the release notes.

## After merge

1. `git tag v0.4.1-beta.9 && git push origin v0.4.1-beta.9` → `release.yml` builds the official macOS desktop.
2. copilot361 ships separately: dispatch `release-oss.yml` with `brand=copilot361`, `tag=v0.4.1-beta.9`.

Note: `main` currently fails `Rust Format & Clippy` on unformatted code left by #898 (`team_skills.rs`, `setup.rs`). Unrelated to this PR and not a release blocker — `release.yml` triggers on the tag independently of CI — but it is why main is red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)