### PR TITLE
style(desktop): restore cargo fmt in team_skills.rs (unblocks CI on main and all older PRs)

### DIFF
--- a/apps/desktop/src/commands/team_skills.rs
+++ b/apps/desktop/src/commands/team_skills.rs
@@ -612,12 +612,7 @@ pub async fn team_skill_pack_and_upload(
                 "size": size,
             }))
             .send()
-            .map_err(|e| {
-                format!(
-                    "skill blob prepare failed: {}",
-                    format_reqwest_error(&e)
-                )
-            })?;
+            .map_err(|e| format!("skill blob prepare failed: {}", format_reqwest_error(&e)))?;
         if !prepare_resp.status().is_success() {
             let status = prepare_resp.status();
             let body = prepare_resp.text().unwrap_or_default();
@@ -646,9 +641,7 @@ pub async fn team_skill_pack_and_upload(
                 .header("x-upsert", "true")
                 .body(zip_bytes)
                 .send()
-                .map_err(|e| {
-                    format!("skill blob PUT failed: {}", format_reqwest_error(&e))
-                })?;
+                .map_err(|e| format!("skill blob PUT failed: {}", format_reqwest_error(&e)))?;
             if !put_resp.status().is_success() {
                 return Err(format!("skill blob PUT HTTP {}", put_resp.status()));
             }
@@ -664,12 +657,7 @@ pub async fn team_skill_pack_and_upload(
                 "size": size,
             }))
             .send()
-            .map_err(|e| {
-                format!(
-                    "skill blob complete failed: {}",
-                    format_reqwest_error(&e)
-                )
-            })?;
+            .map_err(|e| format!("skill blob complete failed: {}", format_reqwest_error(&e)))?;
         if !complete_resp.status().is_success() {
             let status = complete_resp.status();
             let body = complete_resp.text().unwrap_or_default();


### PR DESCRIPTION
`cargo fmt --check` fails on `main`, so the **Rust Format & Clippy** job is red on
main itself and on every open PR whose branch forked before #898 — regardless of
what that PR changes.

## What broke

#898 (`6f44bd49`) landed three `.map_err(|e| { format!(...) })` closures in
`apps/desktop/src/commands/team_skills.rs` written expanded, where rustfmt
collapses each onto a single line.

## Why it hits unrelated PRs

CI runs on the `pull_request` event, so `actions/checkout@v7` checks out the
**merge commit**, not the branch head. A branch that forked before #898 still has
the clean older copy of this file, but the merge pulls in main's version — and
fails. The PR that surfaced this (`refactor/amuxd-home-layout-v2`) does not touch
`team_skills.rs` at all.

main's CI has been red for three consecutive commits (`06b7b7e4`, `6f44bd49`,
`c3232e6b`) on this same job. The earliest of those was a different file
(`setup.rs`, from #895), which is already clean on main; `team_skills.rs` is the
only violation left at today's head.

## The change

`cargo fmt` output, nothing else. One file, +3/−15, **formatting only — no
behavior change.**

## Verification

Ran the job's own two commands locally against this branch:

- `cargo fmt --check --manifest-path apps/desktop/Cargo.toml` — 3 diffs before, clean after
- `cargo clippy --manifest-path apps/desktop/Cargo.toml -- -D warnings` — passes

The applied diff matches the three hunks in the CI log verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
