### PR TITLE
fix(supabase): scope current_team_role to the active team

### DIFF
--- a/services/supabase/migrations/20260813140000_fix_current_team_role_team_scoped.sql
+++ b/services/supabase/migrations/20260813140000_fix_current_team_role_team_scoped.sql
@@ -1,0 +1,28 @@
+-- Fix amux.current_team_role for multi-team users.
+--
+-- current_team_role previously resolved the caller via amux.current_member_id(),
+-- which returns the oldest active member actor across ALL teams (no team filter).
+-- For a user who is owner of team A (older actor) and admin of team B, calls
+-- scoped to team B (set_team_default_agent, remove_team_actor, and every RLS
+-- policy behind is_team_admin_or_owner) looked up team_members with the team-A
+-- actor id → no row → role null → false 403.
+--
+-- Same class of bug as 20260731000000_fix_workspaces_insert_rls.sql.
+-- Fix: resolve via current_actor_id_for_team(target_team_id).
+
+create or replace function amux.current_team_role(target_team_id uuid)
+returns text
+language sql
+stable
+security definer
+set search_path to 'public', 'auth'
+as $$
+  select tm.role
+  from amux.team_members tm
+  where tm.team_id = target_team_id
+    and tm.member_id = amux.current_actor_id_for_team(target_team_id)
+  limit 1
+$$;
+
+revoke all on function amux.current_team_role(uuid) from public;
+grant execute on function amux.current_team_role(uuid) to authenticated;

--- a/services/supabase/tests/027_current_team_role_multi_team.sql
+++ b/services/supabase/tests/027_current_team_role_multi_team.sql
@@ -1,0 +1,83 @@
+-- 027_current_team_role_multi_team.sql
+--
+-- Multi-team user: oldest actor is owner on team A; newer actor is admin on
+-- team B. current_team_role(B) must return 'admin' (not null via the buggy
+-- current_member_id path), and set_team_default_agent(B, …) must succeed.
+--
+-- Run via:
+--   pg_prove -d "$DATABASE_URL" services/supabase/tests/027_current_team_role_multi_team.sql
+
+begin;
+
+select plan(4);
+
+create or replace function pg_temp.as_user(p_user uuid)
+returns void language plpgsql as $$
+begin
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', p_user::text, 'role', 'authenticated')::text,
+    true);
+  perform set_config('role', 'authenticated', true);
+end;
+$$;
+
+-- Auth user present on two teams
+insert into auth.users (id, email, aud, role, instance_id) values
+  ('ctr01001-0000-4000-8000-000000000001', 'ctr-multi@amux.test', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+on conflict do nothing;
+
+insert into amux.teams (id, slug, name) values
+  ('ctr02001-0000-4000-8000-00000000000a', 'ctr-team-a', 'CTR Team A'),
+  ('ctr02001-0000-4000-8000-00000000000b', 'ctr-team-b', 'CTR Team B');
+
+-- Team A actor created first (older) → would win under current_member_id()
+insert into amux.actors (id, team_id, actor_type, display_name, user_id, created_at) values
+  ('ctr03001-0000-4000-8000-00000000000a', 'ctr02001-0000-4000-8000-00000000000a', 'member', 'CTR On A', 'ctr01001-0000-4000-8000-000000000001', '2026-01-01T00:00:00Z'),
+  ('ctr03001-0000-4000-8000-00000000000b', 'ctr02001-0000-4000-8000-00000000000b', 'member', 'CTR On B', 'ctr01001-0000-4000-8000-000000000001', '2026-06-01T00:00:00Z');
+
+insert into amux.members (id, status) values
+  ('ctr03001-0000-4000-8000-00000000000a', 'active'),
+  ('ctr03001-0000-4000-8000-00000000000b', 'active');
+
+insert into amux.team_members (team_id, member_id, role) values
+  ('ctr02001-0000-4000-8000-00000000000a', 'ctr03001-0000-4000-8000-00000000000a', 'owner'),
+  ('ctr02001-0000-4000-8000-00000000000b', 'ctr03001-0000-4000-8000-00000000000b', 'admin');
+
+-- Team-visible active agent on B (valid team default)
+insert into amux.actors (id, team_id, actor_type, display_name) values
+  ('ctr04001-0000-4000-8000-00000000000b', 'ctr02001-0000-4000-8000-00000000000b', 'agent', 'CTR Agent B');
+
+insert into amux.agents (id, owner_member_id, status, visibility) values
+  ('ctr04001-0000-4000-8000-00000000000b', 'ctr03001-0000-4000-8000-00000000000b', 'active', 'team');
+
+select pg_temp.as_user('ctr01001-0000-4000-8000-000000000001');
+
+select is(
+  amux.current_member_id(),
+  'ctr03001-0000-4000-8000-00000000000a'::uuid,
+  'current_member_id still returns the oldest actor (team A)'
+);
+
+select is(
+  amux.current_team_role('ctr02001-0000-4000-8000-00000000000b'::uuid),
+  'admin',
+  'current_team_role(B) uses team-scoped actor → admin'
+);
+
+select is(
+  amux.current_team_role('ctr02001-0000-4000-8000-00000000000a'::uuid),
+  'owner',
+  'current_team_role(A) still returns owner'
+);
+
+select is(
+  amux.set_team_default_agent(
+    'ctr02001-0000-4000-8000-00000000000b'::uuid,
+    'ctr04001-0000-4000-8000-00000000000b'::uuid
+  ),
+  'ctr04001-0000-4000-8000-00000000000b'::uuid,
+  'admin on B can set_team_default_agent even when oldest actor is on A'
+);
+
+select * from finish();
+rollback;

--- a/services/supabase/tests/027_current_team_role_multi_team.sql
+++ b/services/supabase/tests/027_current_team_role_multi_team.sql
@@ -23,59 +23,59 @@ $$;
 
 -- Auth user present on two teams
 insert into auth.users (id, email, aud, role, instance_id) values
-  ('ctr01001-0000-4000-8000-000000000001', 'ctr-multi@amux.test', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+  ('c7a01001-0000-4000-8000-000000000001', 'ctr-multi@amux.test', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
 on conflict do nothing;
 
 insert into amux.teams (id, slug, name) values
-  ('ctr02001-0000-4000-8000-00000000000a', 'ctr-team-a', 'CTR Team A'),
-  ('ctr02001-0000-4000-8000-00000000000b', 'ctr-team-b', 'CTR Team B');
+  ('c7a02001-0000-4000-8000-00000000000a', 'ctr-team-a', 'CTR Team A'),
+  ('c7a02001-0000-4000-8000-00000000000b', 'ctr-team-b', 'CTR Team B');
 
 -- Team A actor created first (older) → would win under current_member_id()
 insert into amux.actors (id, team_id, actor_type, display_name, user_id, created_at) values
-  ('ctr03001-0000-4000-8000-00000000000a', 'ctr02001-0000-4000-8000-00000000000a', 'member', 'CTR On A', 'ctr01001-0000-4000-8000-000000000001', '2026-01-01T00:00:00Z'),
-  ('ctr03001-0000-4000-8000-00000000000b', 'ctr02001-0000-4000-8000-00000000000b', 'member', 'CTR On B', 'ctr01001-0000-4000-8000-000000000001', '2026-06-01T00:00:00Z');
+  ('c7a03001-0000-4000-8000-00000000000a', 'c7a02001-0000-4000-8000-00000000000a', 'member', 'CTR On A', 'c7a01001-0000-4000-8000-000000000001', '2026-01-01T00:00:00Z'),
+  ('c7a03001-0000-4000-8000-00000000000b', 'c7a02001-0000-4000-8000-00000000000b', 'member', 'CTR On B', 'c7a01001-0000-4000-8000-000000000001', '2026-06-01T00:00:00Z');
 
 insert into amux.members (id, status) values
-  ('ctr03001-0000-4000-8000-00000000000a', 'active'),
-  ('ctr03001-0000-4000-8000-00000000000b', 'active');
+  ('c7a03001-0000-4000-8000-00000000000a', 'active'),
+  ('c7a03001-0000-4000-8000-00000000000b', 'active');
 
 insert into amux.team_members (team_id, member_id, role) values
-  ('ctr02001-0000-4000-8000-00000000000a', 'ctr03001-0000-4000-8000-00000000000a', 'owner'),
-  ('ctr02001-0000-4000-8000-00000000000b', 'ctr03001-0000-4000-8000-00000000000b', 'admin');
+  ('c7a02001-0000-4000-8000-00000000000a', 'c7a03001-0000-4000-8000-00000000000a', 'owner'),
+  ('c7a02001-0000-4000-8000-00000000000b', 'c7a03001-0000-4000-8000-00000000000b', 'admin');
 
 -- Team-visible active agent on B (valid team default)
 insert into amux.actors (id, team_id, actor_type, display_name) values
-  ('ctr04001-0000-4000-8000-00000000000b', 'ctr02001-0000-4000-8000-00000000000b', 'agent', 'CTR Agent B');
+  ('c7a04001-0000-4000-8000-00000000000b', 'c7a02001-0000-4000-8000-00000000000b', 'agent', 'CTR Agent B');
 
 insert into amux.agents (id, owner_member_id, status, visibility) values
-  ('ctr04001-0000-4000-8000-00000000000b', 'ctr03001-0000-4000-8000-00000000000b', 'active', 'team');
+  ('c7a04001-0000-4000-8000-00000000000b', 'c7a03001-0000-4000-8000-00000000000b', 'active', 'team');
 
-select pg_temp.as_user('ctr01001-0000-4000-8000-000000000001');
+select pg_temp.as_user('c7a01001-0000-4000-8000-000000000001');
 
 select is(
   amux.current_member_id(),
-  'ctr03001-0000-4000-8000-00000000000a'::uuid,
+  'c7a03001-0000-4000-8000-00000000000a'::uuid,
   'current_member_id still returns the oldest actor (team A)'
 );
 
 select is(
-  amux.current_team_role('ctr02001-0000-4000-8000-00000000000b'::uuid),
+  amux.current_team_role('c7a02001-0000-4000-8000-00000000000b'::uuid),
   'admin',
   'current_team_role(B) uses team-scoped actor → admin'
 );
 
 select is(
-  amux.current_team_role('ctr02001-0000-4000-8000-00000000000a'::uuid),
+  amux.current_team_role('c7a02001-0000-4000-8000-00000000000a'::uuid),
   'owner',
   'current_team_role(A) still returns owner'
 );
 
 select is(
   amux.set_team_default_agent(
-    'ctr02001-0000-4000-8000-00000000000b'::uuid,
-    'ctr04001-0000-4000-8000-00000000000b'::uuid
+    'c7a02001-0000-4000-8000-00000000000b'::uuid,
+    'c7a04001-0000-4000-8000-00000000000b'::uuid
   ),
-  'ctr04001-0000-4000-8000-00000000000b'::uuid,
+  'c7a04001-0000-4000-8000-00000000000b'::uuid,
   'admin on B can set_team_default_agent even when oldest actor is on A'
 );
 


### PR DESCRIPTION
## Summary
- `amux.current_team_role` previously used `current_member_id()`, which returns the caller's oldest member actor across all teams.
- Multi-team users who are admin/owner on a newer team were incorrectly denied RPCs/RLS gated by this helper (e.g. `set_team_default_agent`, `remove_team_actor`, `is_team_admin_or_owner`).
- Resolve via `current_actor_id_for_team(target_team_id)` instead, matching the existing workspaces multi-team fix pattern.

## Test plan
- [ ] Apply migration (or hot-fix) on a multi-team account: oldest actor on team A as owner, newer actor on team B as admin
- [ ] On team B, set team default agent → should succeed (no 403)
- [ ] On team A, owner-only actions still work
- [ ] Single-team users unchanged
- [ ] `pg_prove` / supabase test: `services/supabase/tests/027_current_team_role_multi_team.sql`


Made with [Cursor](https://cursor.com)