### PR TITLE
fix(app): suppress offline agent runtime toast

### DIFF
--- a/packages/app/src/lib/teamclu/__tests__/ensure-agent-runtime-cancelled-notify.test.ts
+++ b/packages/app/src/lib/teamclu/__tests__/ensure-agent-runtime-cancelled-notify.test.ts
@@ -48,6 +48,21 @@ describe("notifyRuntimeStartFailures", () => {
     expect(mocks.toastError).not.toHaveBeenCalled();
   });
 
+  it("does not toast when an agent device is offline", async () => {
+    const { notifyRuntimeStartFailures } = await import("../ensure-agent-runtime");
+
+    notifyRuntimeStartFailures(
+      [{ agentActorId: "remote-agent-1", code: "device_offline", reason: "device offline" }],
+      { trigger: "session_runtime_retry" },
+    );
+    await flush();
+
+    // The persistent agent status already shows offline. Keep the failure in
+    // telemetry for diagnosis without duplicating it as a transient toast.
+    expect(mocks.reportRuntimeStartFailure).toHaveBeenCalledTimes(1);
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
   it("still toasts a genuine runtime failure", async () => {
     const { notifyRuntimeStartFailures } = await import("../ensure-agent-runtime");
 
@@ -65,10 +80,11 @@ describe("notifyRuntimeStartFailures", () => {
     notifyRuntimeStartFailures([
       { agentActorId: "agent-1", code: "runtime_rpc_failed", reason: "rpc disposed" },
       { agentActorId: "agent-2", code: "runtime_rpc_failed", reason: "runtimeStart rejected" },
+      { agentActorId: "agent-3", code: "device_offline", reason: "device offline" },
     ]);
     await flush();
 
-    expect(mocks.reportRuntimeStartFailure).toHaveBeenCalledTimes(2);
+    expect(mocks.reportRuntimeStartFailure).toHaveBeenCalledTimes(3);
     expect(mocks.toastError).toHaveBeenCalledTimes(1);
     const [, options] = mocks.toastError.mock.calls[0] as [string, { id: string }];
     expect(options.id).toBe("runtime-start-failed-agent-2");

--- a/packages/app/src/lib/teamclu/ensure-agent-runtime.ts
+++ b/packages/app/src/lib/teamclu/ensure-agent-runtime.ts
@@ -123,10 +123,13 @@ export function notifyRuntimeStartFailures(
       { actorId: failure.agentActorId },
     );
   }
-  // A request we cancelled ourselves is not a user-facing failure: the retry
-  // tick that follows re-attempts it. It still reaches Sentry (as a warning)
-  // and the debug log above, just not the user.
-  const toastable = failures.filter((f) => !isCancelledRuntimeFailure(f.reason));
+  // Offline presence is already persistent in the selected-agent status, and
+  // reconnect will retry automatically. A request we cancelled ourselves is
+  // likewise recovered by the next retry tick. Keep both in telemetry/debug,
+  // but do not duplicate these expected states as transient error toasts.
+  const toastable = failures.filter(
+    (f) => f.code !== "device_offline" && !isCancelledRuntimeFailure(f.reason),
+  );
   if (toastable.length === 0) return;
   void import("sonner").then(({ toast }) => {
     for (const failure of toastable) {


### PR DESCRIPTION
## Description

- stop showing an error toast when an agent device presence is offline
- keep the persistent agent offline status, telemetry reporting, debug logging, and automatic reconnect retry
- continue showing toasts for actionable runtime startup failures

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A — removes the redundant offline toast while retaining the existing persistent offline status.

## Additional Notes

Validation:
- 16 focused Vitest tests passed
- `pnpm typecheck` passed
- ESLint passed for the changed files