### PR TITLE
feat(daemon): 把 settle 后的模型写进 session_participants.model

### DIFF
--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -1130,6 +1130,23 @@ impl Backend for CloudApiBackend {
         .await
     }
 
+    async fn update_participant_model(
+        &self,
+        session_id: &str,
+        actor_id: &str,
+        model: &str,
+    ) -> BackendResult<()> {
+        #[derive(serde::Serialize)]
+        struct Body<'a> {
+            model: &'a str,
+        }
+        self.patch_no_content(
+            &format!("/v1/sessions/{session_id}/participants/{actor_id}/model"),
+            &Body { model },
+        )
+        .await
+    }
+
     async fn rpc_upsert_external_actor(
         &self,
         team_id: &str,

--- a/apps/daemon/src/backend/deferred.rs
+++ b/apps/daemon/src/backend/deferred.rs
@@ -319,6 +319,17 @@ impl Backend for DeferredBackend {
             .await
     }
 
+    async fn update_participant_model(
+        &self,
+        session_id: &str,
+        actor_id: &str,
+        model: &str,
+    ) -> BackendResult<()> {
+        self.inner()?
+            .update_participant_model(session_id, actor_id, model)
+            .await
+    }
+
     async fn rpc_upsert_external_actor(
         &self,
         team_id: &str,

--- a/apps/daemon/src/backend/mock.rs
+++ b/apps/daemon/src/backend/mock.rs
@@ -107,6 +107,8 @@ pub struct MockState {
     pub gateway_messages_inserted: Vec<RecordedGatewayMessage>,
     pub external_actors_upserted: Vec<RecordedExternalActor>,
     pub runtime_cursors_updated: Vec<(String, String)>,
+    /// `("{session}:{actor}", model)` pairs passed to `update_participant_model`.
+    pub participant_models_updated: Vec<(String, String)>,
     pub attachments_uploaded: Vec<RecordedAttachment>,
     pub gateway_sessions_ensured: Vec<RecordedGatewayEnsure>,
     /// `(binding, session_id)` pairs passed to `rpc_attach_gateway_session`.
@@ -418,6 +420,20 @@ impl Backend for MockBackend {
             format!("{session_id}:{actor_id}"),
             last_processed_message_id.to_string(),
         ));
+        Ok(())
+    }
+
+    async fn update_participant_model(
+        &self,
+        session_id: &str,
+        actor_id: &str,
+        model: &str,
+    ) -> BackendResult<()> {
+        self.state
+            .lock()
+            .unwrap()
+            .participant_models_updated
+            .push((format!("{session_id}:{actor_id}"), model.to_string()));
         Ok(())
     }
 

--- a/apps/daemon/src/backend/mod.rs
+++ b/apps/daemon/src/backend/mod.rs
@@ -453,6 +453,19 @@ pub trait Backend: Send + Sync {
         last_processed_message_id: &str,
     ) -> BackendResult<()>;
 
+    /// Persist the model this agent runs on for this session — same participant
+    /// row and same (session, actor) addressing as the cursor above.
+    ///
+    /// The daemon is the only writer: it is the only component that observes
+    /// which model a runtime actually settled on, and the only one present for
+    /// gateway and cron sessions, where no client is (ADR-0007).
+    async fn update_participant_model(
+        &self,
+        session_id: &str,
+        actor_id: &str,
+        model: &str,
+    ) -> BackendResult<()>;
+
     /// Upsert an `actors` row of type `external` keyed on
     /// `(team_id, source, source_id)`. Returns the actor's UUID.
     async fn rpc_upsert_external_actor(

--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -109,6 +109,14 @@ pub struct AmuxdAgentHandle {
     /// runtime starts on the user-chosen model. In-memory only — cleared
     /// across daemon restarts (same caveat as `logical_to_acp`).
     pub model_override: Arc<Mutex<HashMap<String, (String, String)>>>,
+    /// Gateway-wide model (`channels.model` in team.toml), pre-split into the
+    /// `(provider, model)` shape `model_override` uses.
+    ///
+    /// Consulted when a chat has not set its own with `/model`. Without it the
+    /// spawn went out unpinned and the model came from the device MRU — exactly
+    /// the implicit resolution ADR-0007 removes. `None` keeps the unpinned
+    /// behaviour for a team that has not set one.
+    pub gateway_model: Option<(String, String)>,
     /// Backend client used to look up `sessions.binding` from the
     /// SQL-minted `acp_session_id` when lazy-spawning a runtime. The
     /// binding is required to write the per-session MCP config file
@@ -466,9 +474,15 @@ impl AmuxdAgentHandle {
         //   - ClaudeCode: maps short names (sonnet→claude-sonnet-4-6), drops provider
         //   - OpenCode (and similar provider/model backends): rejoins as
         //     "provider/model"
+        // Chat's own `/model` first, then the gateway-wide setting. Falling
+        // through to `None` means an unpinned spawn, which used to resolve
+        // against the device MRU — the implicit behaviour ADR-0007 removes.
         let model_arg: Option<(String, String)> = {
             let overrides = self.model_override.lock().await;
-            overrides.get(session).cloned()
+            overrides
+                .get(session)
+                .cloned()
+                .or_else(|| self.gateway_model.clone())
         };
         let (workspace_dir, agent_type) = self.resolve_spawn_target(session, &binding).await;
         let spawn_env = self.assemble_spawn_env(workspace_dir.as_deref()).await;
@@ -1384,6 +1398,8 @@ mod tests {
             logical_to_acp: Arc::new(Mutex::new(HashMap::new())),
             team_id: "team-test".to_string(),
             model_override: Arc::new(Mutex::new(HashMap::new())),
+            // Unset, so these tests keep exercising the unpinned spawn.
+            gateway_model: None,
             backend: backend.clone(),
             default_agent_type: None,
             default_workspace_dir: None,

--- a/apps/daemon/src/config/daemon_config.rs
+++ b/apps/daemon/src/config/daemon_config.rs
@@ -388,6 +388,23 @@ fn default_claude_binary() -> String {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ChannelsConfig {
+    /// Model every gateway session starts on, as a `provider/model` ref.
+    ///
+    /// Gateway-level rather than per-platform: the platforms differ in how a
+    /// message arrives, not in what should answer it, and a per-platform field
+    /// would be seven settings to keep in sync for one decision.
+    ///
+    /// Before this existed a gateway session started **unpinned** — the backend
+    /// picked, and attach-time resolution fell back to the device MRU, so the
+    /// same chat answered on a different model depending on which directory the
+    /// daemon happened to spawn in. ADR-0007 removes that MRU, so the choice has
+    /// to be stated somewhere; this is where.
+    ///
+    /// `None` keeps the old unpinned behaviour, which is what an existing
+    /// team.toml deserializes to — the setting is additive, not a hard cutover.
+    /// A chat's own `/model` still wins for that session.
+    #[serde(default)]
+    pub model: Option<String>,
     #[serde(default)]
     pub discord: Option<DiscordChannel>,
     #[serde(default)]

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -248,6 +248,13 @@ pub(crate) enum SockCommand {
         platform: String,
         config_json: String,
     },
+    /// Replace `daemon_config.channels.model` — the model every gateway session
+    /// starts on when the chat has not set its own with `/model` — persist to
+    /// team.toml, and reload the channel manager. An empty string clears it,
+    /// restoring the unpinned spawn. One-way (no reply).
+    GatewayModelSave {
+        model: String,
+    },
     /// Proactive send request from the `amuxd mcp-server` bridge running
     /// as a child of an ACP agent. `payload` is the raw JSON envelope the
     /// bridge wrote to the sock; the daemon parses out binding + channel
@@ -1773,6 +1780,9 @@ impl DaemonServer {
                             Some(SockCommand::ChannelSave { platform, config_json }) => {
                                 self.save_channel_config(&platform, &config_json).await;
                             }
+                            Some(SockCommand::GatewayModelSave { model }) => {
+                                self.save_gateway_model(&model).await;
+                            }
                             Some(SockCommand::McpSend { payload, reply_tx }) => {
                                 let resp = match self.handle_mcp_send(&payload).await {
                                     Ok(v) => serde_json::json!({ "ok": true, "result": v }),
@@ -2224,6 +2234,9 @@ impl DaemonServer {
                             }
                             Some(SockCommand::ChannelSave { platform, config_json }) => {
                                 self.save_channel_config(&platform, &config_json).await;
+                            }
+                            Some(SockCommand::GatewayModelSave { model }) => {
+                                self.save_gateway_model(&model).await;
                             }
                             Some(SockCommand::McpSend { payload, reply_tx }) => {
                                 let resp = match self.handle_mcp_send(&payload).await {
@@ -2934,6 +2947,20 @@ where
                         .send(SockCommand::ChannelSave {
                             platform: platform.trim().to_string(),
                             config_json: config_json.trim().to_string(),
+                        })
+                        .await;
+                }
+                "gateway-model" => {
+                    // Wire format: line 1 = "gateway-model", line 2 = the
+                    // `provider/model` ref (empty line clears the setting).
+                    let mut model = String::new();
+                    if reader.read_line(&mut model).await.is_err() {
+                        warn!("amuxd.sock: gateway-model missing model");
+                        return;
+                    }
+                    let _ = tx
+                        .send(SockCommand::GatewayModelSave {
+                            model: model.trim().to_string(),
                         })
                         .await;
                 }

--- a/apps/daemon/src/daemon/server/channels.rs
+++ b/apps/daemon/src/daemon/server/channels.rs
@@ -149,6 +149,7 @@ impl DaemonServer {
             logical_to_acp: Arc::new(AsyncMutex::new(HashMap::new())),
             team_id: team_id.clone(),
             model_override: Arc::new(AsyncMutex::new(HashMap::new())),
+            gateway_model: split_gateway_model(self.config.channels.model.as_deref()),
             backend: self.backend.clone(),
             default_agent_type,
             default_workspace_dir,
@@ -431,6 +432,34 @@ impl DaemonServer {
         self.reload_channels().await;
     }
 
+    /// Persist the gateway-wide model (`channels.model`) and reload channels so
+    /// the next spawn picks it up.
+    ///
+    /// An empty string clears the setting rather than storing `""` — that is
+    /// how the UI expresses "back to unpinned", and an empty ref would spawn on
+    /// a nameless model.
+    pub(crate) async fn save_gateway_model(&mut self, model: &str) {
+        let trimmed = model.trim();
+        self.config.channels.model = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+
+        // Same destination as the per-platform sections: team-scoped team.toml,
+        // never daemon.toml.
+        if let Err(e) = crate::config::team_config::persist_from(&self.config) {
+            error!("gateway-model: failed to persist team.toml: {e:?}");
+            return;
+        }
+
+        info!(
+            model = trimmed,
+            "gateway-model: persisted, reloading channel manager"
+        );
+        self.reload_channels().await;
+    }
+
     /// Tear down any running channels. Idempotent — safe to call when
     /// `channel_mgr` is `None`.
     pub(crate) async fn shutdown_channels(&mut self) {
@@ -498,6 +527,71 @@ fn placeholder_target_reason(target: &str) -> Option<&'static str> {
         return Some("unresolved 'current' placeholder");
     }
     None
+}
+
+/// Split `channels.model` into the `(provider, model)` pair the spawn path
+/// wants, mirroring how `/model` stores a chat's own choice.
+///
+/// Splits on the **first** slash only: `resolve_initial_model` rejoins with a
+/// single `/`, so an id whose model segment contains slashes must keep them on
+/// the model side to survive the round trip.
+///
+/// A ref with no slash yields an empty provider, which `resolve_initial_model`
+/// already treats as "pass the model through unchanged".
+fn split_gateway_model(raw: Option<&str>) -> Option<(String, String)> {
+    let raw = raw?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    Some(match raw.split_once('/') {
+        Some((provider, model)) if !model.trim().is_empty() => {
+            (provider.trim().to_string(), model.trim().to_string())
+        }
+        // "provider/" is a half-written setting, not a model — treat the whole
+        // thing as a bare model id rather than spawning on an empty name.
+        _ => (String::new(), raw.trim_end_matches('/').to_string()),
+    })
+}
+
+#[cfg(test)]
+mod gateway_model_tests {
+    use super::split_gateway_model;
+
+    #[test]
+    fn splits_provider_and_model_on_the_first_slash() {
+        assert_eq!(
+            split_gateway_model(Some("anthropic/claude-sonnet-4-6")),
+            Some(("anthropic".into(), "claude-sonnet-4-6".into()))
+        );
+        // Model segments can carry slashes; only the first one is the provider
+        // boundary, or `resolve_initial_model` would rejoin a different id.
+        assert_eq!(
+            split_gateway_model(Some("openrouter/meta/llama-4")),
+            Some(("openrouter".into(), "meta/llama-4".into()))
+        );
+    }
+
+    #[test]
+    fn unset_stays_unset_so_the_old_unpinned_spawn_is_preserved() {
+        assert_eq!(split_gateway_model(None), None);
+        assert_eq!(split_gateway_model(Some("")), None);
+        assert_eq!(split_gateway_model(Some("   ")), None);
+    }
+
+    #[test]
+    fn a_bare_model_id_gets_an_empty_provider() {
+        // `resolve_initial_model` passes the model through untouched when the
+        // provider is empty, which is what a claude-style short name needs.
+        assert_eq!(
+            split_gateway_model(Some("claude-sonnet-4-6")),
+            Some((String::new(), "claude-sonnet-4-6".into()))
+        );
+        // Half-written "provider/" must not spawn on an empty model name.
+        assert_eq!(
+            split_gateway_model(Some("anthropic/")),
+            Some((String::new(), "anthropic".into()))
+        );
+    }
 }
 
 #[cfg(test)]

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -485,7 +485,16 @@ impl RuntimeManager {
     /// already been dropped from `agents` falls back to the daemon default,
     /// which is the backend it would have been running on.
     pub fn set_current_model(&mut self, agent_id: &str, model_id: &str) {
+        // Whether this is a real change, decided *before* `set_model` overwrites
+        // it. Attach-time resolution re-applies the same value on every runtime
+        // start, so without this the cloud write below would fire once per
+        // spawn with nothing new to say.
+        let changed = self.agent_state.model(agent_id).map(String::as_str) != Some(model_id);
+
         self.agent_state.set_model(agent_id, model_id);
+        if changed {
+            self.persist_participant_model(agent_id, model_id);
+        }
         let backend = self.backend_id_for_runtime(agent_id);
         // Catalogs differ per worktree (68–72 models for the same opencode on
         // one device), so the choice is attributed to the directory it was made
@@ -502,6 +511,70 @@ impl RuntimeManager {
                 warn!(error = %e, "model MRU save failed");
             }
         }
+    }
+
+    /// Mirror a settled model onto `session_participants.model` (ADR-0005),
+    /// which is the authoritative answer to "what model does this session run
+    /// on" and the one every client reads (ADR-0007).
+    ///
+    /// Fire-and-forget on purpose. The cursor write in `messaging.rs` can await
+    /// its backend call because it already sits in an async handler; this is a
+    /// sync method reached from six call sites, several of them on the runtime
+    /// start path. Blocking any of them on a cloud round trip to persist a
+    /// display value would trade a correct field for a slower spawn.
+    ///
+    /// Skipped when there is no backend (tests, offline daemon) or when the
+    /// attachment carries no session / actor to address the row by —
+    /// `owner_actor_id` is stamped by the env snapshot and back-filled in
+    /// `runtime_lifecycle`, so it is briefly empty on a cold attach.
+    fn persist_participant_model(&self, runtime_id: &str, model_id: &str) {
+        let Some(backend) = self.backend.clone() else {
+            return;
+        };
+        let Some((session_id, actor_id, model)) =
+            self.participant_model_write(runtime_id, model_id)
+        else {
+            return;
+        };
+
+        tokio::spawn(async move {
+            if let Err(e) = backend
+                .update_participant_model(&session_id, &actor_id, &model)
+                .await
+            {
+                // A stale display value is not worth failing anything over; the
+                // next model change re-attempts it.
+                warn!(?e, session_id, "update_participant_model failed");
+            }
+        });
+    }
+
+    /// The `(session, actor, model)` a participant-model write would target, or
+    /// `None` when this runtime cannot address a row.
+    ///
+    /// Split out from the spawn above so the decision is testable without
+    /// waiting on a detached task — the addressing is the part that has a
+    /// wrong answer available (see `owner_actor_id` vs `agent_id`), the spawn
+    /// is glue.
+    fn participant_model_write(
+        &self,
+        runtime_id: &str,
+        model_id: &str,
+    ) -> Option<(String, String, String)> {
+        let handle = self.agents.get(runtime_id)?;
+        let session_id = handle.session_id.trim();
+        // The cloud row is keyed by the *actor*, not by `agent_id` — that one is
+        // the 8-char spawn key and means nothing to Supabase.
+        let actor_id = handle.owner_actor_id.trim();
+        let model = model_id.trim();
+        if session_id.is_empty() || actor_id.is_empty() || model.is_empty() {
+            return None;
+        }
+        Some((
+            session_id.to_string(),
+            actor_id.to_string(),
+            model.to_string(),
+        ))
     }
 
     /// Ask the backend what model it actually ran this runtime's session on,
@@ -1987,6 +2060,40 @@ mod tests {
         mgr.record_catalog("/w1", &[catalog_model("a/x")]);
         mgr.record_catalog("/w1", &[]);
         assert_eq!(mgr.catalog_for_worktree("/w1").len(), 1);
+    }
+
+    /// The cloud row is keyed by the actor, not by the spawn key. `agent_id` is
+    /// an 8-char spawn key that means nothing to Supabase, so addressing the
+    /// participant row with it would write to a row that does not exist —
+    /// silently, since the PATCH matches zero rows and still returns 204.
+    #[test]
+    fn participant_model_write_addresses_the_actor_not_the_spawn_key() {
+        let mut mgr = RuntimeManager::test_dummy_with_runtime("session_S");
+        mgr.get_handle_mut("session_S").unwrap().owner_actor_id = "actor-A".into();
+
+        let (session_id, actor_id, model) = mgr
+            .participant_model_write("session_S", "anthropic/claude-sonnet-4-6")
+            .expect("addressable");
+        assert_eq!(session_id, "session_S");
+        assert_eq!(actor_id, "actor-A");
+        assert_eq!(model, "anthropic/claude-sonnet-4-6");
+    }
+
+    /// `owner_actor_id` is stamped by the env snapshot and back-filled in
+    /// `runtime_lifecycle`, so a cold attach can reach here with it still empty.
+    /// Writing then would address `/participants//model`.
+    #[test]
+    fn participant_model_write_skips_what_it_cannot_address() {
+        let mut mgr = RuntimeManager::test_dummy_with_runtime("session_S");
+        // owner_actor_id still empty — the cold-attach window.
+        assert_eq!(mgr.participant_model_write("session_S", "a/b"), None);
+
+        mgr.get_handle_mut("session_S").unwrap().owner_actor_id = "actor-A".into();
+        assert_eq!(mgr.participant_model_write("session_S", "   "), None);
+        assert_eq!(mgr.participant_model_write("no-such-runtime", "a/b"), None);
+
+        mgr.get_handle_mut("session_S").unwrap().session_id = String::new();
+        assert_eq!(mgr.participant_model_write("session_S", "a/b"), None);
     }
 
     #[test]

--- a/apps/desktop/src/commands/gateway/mod.rs
+++ b/apps/desktop/src/commands/gateway/mod.rs
@@ -183,6 +183,53 @@ pub async fn save_channel_config(platform: String, config_json: String) -> Resul
     }
 }
 
+/// Read `channels.model` — the model every gateway session starts on when the
+/// chat has not set its own with `/model` (ADR-0007).
+///
+/// Reads team.toml directly, like `load_channel_config`: it is plain structure
+/// with no credential in it, so there is nothing for the daemon to decrypt.
+/// `None` means unset, which is the pre-ADR-0007 unpinned behaviour.
+#[tauri::command]
+pub fn load_gateway_model() -> Result<Option<String>, String> {
+    let Some(path) = team_config_path() else {
+        return Ok(None);
+    };
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let content =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let parsed: toml::Value =
+        toml::from_str(&content).map_err(|e| format!("parse {}: {e}", path.display()))?;
+
+    Ok(parsed
+        .get("channels")
+        .and_then(|channels| channels.get("model"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.trim().is_empty()))
+}
+
+/// Set `channels.model`. An empty string clears it, restoring the unpinned
+/// spawn. Goes through amuxd rather than writing team.toml directly so the
+/// channel manager reloads and the next spawn actually uses it.
+#[tauri::command]
+pub async fn save_gateway_model(model: String) -> Result<(), String> {
+    #[cfg(windows)]
+    return Err(amuxd_unavailable());
+    #[cfg(unix)]
+    {
+        let mut s =
+            UnixStream::connect(sock_path()).map_err(|e| format!("amuxd not reachable: {e}"))?;
+        // Two newline-terminated tokens, matching the sock's line framing.
+        let payload = format!("gateway-model\n{}\n", model.trim().replace('\n', " "));
+        s.write_all(payload.as_bytes())
+            .map_err(|e| format!("write failed: {e}"))?;
+        Ok(())
+    }
+}
+
 /// Tell amuxd to re-read `daemon.toml` and restart all channels. Cheap;
 /// useful when the daemon-managed config file was edited out-of-band.
 #[tauri::command]

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -402,6 +402,8 @@ pub fn run() {
             commands::gateway::list_wecom_bots_status,
             commands::gateway::load_channel_config,
             commands::gateway::save_channel_config,
+            commands::gateway::load_gateway_model,
+            commands::gateway::save_gateway_model,
             commands::gateway::reload_channels,
             commands::gateway::test_seatalk_credentials,
             commands::gateway::qr::start_wechat_qr_login,

--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -757,6 +757,53 @@ paths:
           description: OK
         "401":
           $ref: "#/components/responses/Error"
+  /v1/sessions/{sessionId}/participants/{actorId}/model:
+    patch:
+      operationId: updateParticipantModel
+      summary: Update the model this agent uses in this session
+      description: |
+        Which model an agent runs on for one session, addressed by (session,
+        actor) — the participant row's own key (ADR-0005).
+
+        The column has existed since the ADR-0005 migration but had no writer:
+        it was backfilled once from `agent_runtimes.current_model` and then
+        drifted, while both the glossary and that ADR described it as
+        authoritative. This endpoint is that missing writer.
+
+        The daemon is the only caller. It is the sole component that observes
+        which model a runtime actually settled on, and it is the only one
+        present for gateway and cron sessions, where no client is (ADR-0007).
+      tags: [Sessions]
+      parameters:
+        - $ref: "#/components/parameters/SessionId"
+        - name: actorId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [model]
+              properties:
+                model:
+                  type: string
+                  description: |
+                    Backend-local model id, usually `provider/model`. Not
+                    nullable: every entry point pins a model at creation time,
+                    so there is no state to clear it back to (ADR-0007).
+                  example: anthropic/claude-sonnet-4-6
+      responses:
+        "204":
+          description: OK
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
   /v1/sessions/by-acp/{acpSessionId}:
     get:
       operationId: getSessionByAcp
@@ -5969,6 +6016,25 @@ components:
             - string
             - "null"
           format: date-time
+        # An agent participant's working state for this session (ADR-0005).
+        # `listSessionParticipants` has returned these three since that
+        # migration; the schema simply had not caught up. NULL on member rows —
+        # not applicable rather than missing.
+        workspaceId:
+          type:
+            - string
+            - "null"
+          format: uuid
+        model:
+          type:
+            - string
+            - "null"
+          description: Written by PATCH …/participants/{actorId}/model.
+        lastProcessedMessageId:
+          type:
+            - string
+            - "null"
+          format: uuid
     SessionParticipantList:
       type: object
       required: [items]

--- a/packages/app/src/components/settings/ChannelsSection.tsx
+++ b/packages/app/src/components/settings/ChannelsSection.tsx
@@ -11,6 +11,7 @@ import { KookChannel } from './channels/Kook'
 import { WeComChannel } from './channels/Wecom'
 import { WeChatChannel } from './channels/Wechat'
 import { SeaTalkChannel } from './channels/Seatalk'
+import { GatewayModelCard } from './channels/GatewayModel'
 import { useFeatures } from '@/lib/remote-features'
 
 // Main Channels Section Component
@@ -60,6 +61,9 @@ export function ChannelsSection() {
           </div>
         </SettingCard>
       )}
+
+      {/* Applies to every channel below, so it sits above them. */}
+      <GatewayModelCard />
 
       {/* Channel Components */}
       {channelsConfig.discord && <DiscordChannel />}

--- a/packages/app/src/components/settings/channels/GatewayModel.tsx
+++ b/packages/app/src/components/settings/channels/GatewayModel.tsx
@@ -1,0 +1,183 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Box, ChevronDown, Loader2 } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { ModelPickerCommand } from '@/components/model/ModelPickerCommand'
+import { SettingCard } from './shared'
+import { cn } from '@/lib/utils'
+import { loadGatewayModel, saveGatewayModel } from '@/lib/amuxd-channels'
+import { loadCronDialogModels, type CronModelGroup } from '@/lib/cron-workspace-models'
+import { useCurrentTeamStore } from '@/stores/current-team'
+
+/**
+ * The model every gateway session starts on when the chat has not set its own
+ * with `/model`.
+ *
+ * # Why this is one setting and not seven
+ *
+ * The seven platforms differ in how a message arrives, not in what should
+ * answer it. Seven fields would be seven places to keep in sync for one
+ * decision, and nothing in the product distinguishes "the model that answers
+ * WeCom" from "the model that answers Feishu".
+ *
+ * # Why it exists at all
+ *
+ * A gateway session used to spawn **unpinned**: the backend picked, and
+ * attach-time resolution fell back to the device MRU, so the same chat could
+ * answer on a different model depending on which directory the daemon happened
+ * to start in. ADR-0007 deletes that MRU, so the choice has to be stated —
+ * this is where it is stated.
+ *
+ * Leaving it unset keeps the old unpinned behaviour rather than blocking the
+ * gateway, so an existing install does not break on upgrade.
+ */
+export function GatewayModelCard() {
+  const { t } = useTranslation()
+  const teamId = useCurrentTeamStore((s) => s.team?.id ?? null)
+
+  const [model, setModel] = React.useState<string | null>(null)
+  const [groups, setGroups] = React.useState<CronModelGroup[]>([])
+  const [hint, setHint] = React.useState<string | null>(null)
+  const [menuOpen, setMenuOpen] = React.useState(false)
+  const [saving, setSaving] = React.useState(false)
+
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const current = await loadGatewayModel()
+        if (!cancelled) setModel(current)
+      } catch {
+        // Daemon down — the picker still renders, it just cannot say what is set.
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // The gateway runs in the daemon's default workspace, which is what the
+  // 'global' cron scope already resolves — reuse it rather than re-deriving.
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      const { groups: loaded, hint: loadedHint } = await loadCronDialogModels({
+        activeScope: 'global',
+        teamId,
+        selectedWorkspacePath: null,
+        messages: {
+          workspaceNoPath: '',
+          globalNoTeam: t('settings.channels.modelsNoTeam', 'Join a team to load models.'),
+          globalNoDefault: t(
+            'settings.channels.modelsNoDefault',
+            'Set a default workspace in Daemon settings.',
+          ),
+          globalNoDefaultPath: t(
+            'settings.channels.modelsNoDefaultPath',
+            'Default workspace has no local path on this daemon.',
+          ),
+          daemonUnavailable: t(
+            'settings.channels.modelsDaemonUnavailable',
+            'Daemon is not ready. Wait for the app to finish starting, then try again.',
+          ),
+          noConfiguredModels: t(
+            'settings.channels.modelsNoConfigured',
+            'No configured models. Add a provider in LLM settings.',
+          ),
+          loadFailed: t('settings.channels.modelsLoadFailed', 'Failed to load models.'),
+        },
+      })
+      if (cancelled) return
+      setGroups(loaded)
+      setHint(loadedHint)
+    })().catch(() => {
+      if (!cancelled) setHint(t('settings.channels.modelsLoadFailed', 'Failed to load models.'))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [teamId, t])
+
+  const pickerModels = React.useMemo(
+    () =>
+      groups.flatMap((group) =>
+        group.models.map((m) => ({
+          id: m.ref,
+          displayName: m.name,
+          providerName: m.providerName,
+        })),
+      ),
+    [groups],
+  )
+
+  const apply = async (next: string) => {
+    setMenuOpen(false)
+    setSaving(true)
+    // Optimistic: the daemon write is one-way (no reply on the sock), so there
+    // is no ack to wait for. A failed save surfaces on the next mount.
+    setModel(next || null)
+    try {
+      await saveGatewayModel(next)
+    } catch (error) {
+      console.error('[GatewayModel] save failed', error)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <SettingCard>
+      <div className="flex items-start gap-3">
+        <Box className="mt-0.5 h-5 w-5 shrink-0 text-indigo-500" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <p className="font-medium">
+            {t('settings.channels.gatewayModel', 'Gateway model')}
+          </p>
+          <p className="mt-0.5 text-[13px] text-muted-foreground">
+            {t(
+              'settings.channels.gatewayModelDescription',
+              'Every channel starts its sessions on this model. A chat can still switch with /model.',
+            )}
+          </p>
+
+          <div className="mt-2 flex items-center gap-2">
+            <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className={cn(
+                    'flex h-8 w-fit max-w-[min(100%,20rem)] items-center gap-1.5 rounded-md border border-border/70 px-2 font-mono text-xs',
+                    'hover:bg-muted/60 focus:outline-none data-[state=open]:bg-muted/60',
+                    !model && 'italic font-sans text-muted-foreground',
+                  )}
+                >
+                  <span className="truncate">
+                    {model ||
+                      t('settings.channels.gatewayModelUnset', 'Let the backend choose')}
+                  </span>
+                  <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="start" sideOffset={6} className="w-[20rem] p-0">
+                <ModelPickerCommand
+                  models={pickerModels}
+                  selectedId={model ?? ''}
+                  onSelect={(id) => void apply(id)}
+                  emptyState={
+                    <div className="px-2 py-6 text-center text-[13px] text-muted-foreground">
+                      {hint ??
+                        t('settings.channels.noModels', 'No models advertised.')}
+                    </div>
+                  }
+                />
+              </PopoverContent>
+            </Popover>
+            {saving && (
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+            )}
+          </div>
+        </div>
+      </div>
+    </SettingCard>
+  )
+}

--- a/packages/app/src/components/settings/cron/CronJobDialog.tsx
+++ b/packages/app/src/components/settings/cron/CronJobDialog.tsx
@@ -55,7 +55,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
-import { CommandItem } from '@/components/ui/command'
 import { ModelPickerCommand } from '@/components/model/ModelPickerCommand'
 import { useRuntimeStateStore } from '@/stores/runtime-state-store'
 import { ToggleSwitch } from '../shared'
@@ -269,6 +268,14 @@ export function CronJobDialog({
       setError(t('settings.cron.requiredCron', 'Cron expression is required'))
       return
     }
+    // Every automation entry point pins a model at creation time (ADR-0007).
+    // The old "use default model" path resolved at run time against the device
+    // MRU, so the same job ran on whatever model this device happened to have
+    // used last — and on a different device, a different model.
+    if (!form.model.trim()) {
+      setError(t('settings.cron.requiredModel', 'Model is required'))
+      return
+    }
     if (form.deliveryEnabled) {
       const entry = getRegistryEntry(form.deliveryChannel)
       if (entry) {
@@ -393,7 +400,7 @@ export function CronJobDialog({
                           title={
                             form.model
                               ? t('settings.cron.modelSelected', `Using: ${form.model}`)
-                              : t('settings.cron.modelOverrideHint', 'Select a model or use workspace default.')
+                              : t('settings.cron.modelRequiredHint', 'Pick the model this job runs on.')
                           }
                           className={cn(
                             'flex h-7 min-h-7 w-fit max-w-[min(100%,18rem)] shrink items-center justify-start gap-1 rounded-md px-1.5 py-0 font-mono text-xs',
@@ -402,7 +409,7 @@ export function CronJobDialog({
                           )}
                         >
                           <span className="truncate">
-                            {form.model || t('settings.cron.useDefaultModel', 'Use default model')}
+                            {form.model || t('settings.cron.selectModel', 'Select a model')}
                           </span>
                           <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
                         </button>
@@ -428,21 +435,11 @@ export function CronJobDialog({
                             update({ model: id, backend: backendByRef.get(id) ?? '' })
                             setModelMenuOpen(false)
                           }}
-                          leadingItems={
-                            <CommandItem
-                              value="__default__ use default model"
-                              data-model-selected={!form.model ? 'true' : undefined}
-                              onSelect={() => {
-                                update({ model: '', backend: '' })
-                                setModelMenuOpen(false)
-                              }}
-                              className="text-xs py-1.5"
-                            >
-                              <span className="text-muted-foreground italic">
-                                {t('settings.cron.useDefaultModel', 'Use default model')}
-                              </span>
-                            </CommandItem>
-                          }
+                          // No "use default model" entry any more: a job with no
+                          // model resolved at run time against the device MRU,
+                          // so the same job ran on a different model depending
+                          // on which device and which directory picked it up
+                          // (ADR-0007). The choice is made here or nowhere.
                           emptyState={
                             modelHint ? (
                               <div className="px-2 py-4 text-center text-[12.5px] text-muted-foreground">

--- a/packages/app/src/components/settings/cron/__tests__/CronJobDialog.test.tsx
+++ b/packages/app/src/components/settings/cron/__tests__/CronJobDialog.test.tsx
@@ -100,4 +100,15 @@ describe('CronJobDialog', () => {
     expect(queryByText('Timeout (seconds)')).toBeNull()
     expect(queryByText(/Auto-aborts if exceeded/)).toBeNull()
   })
+
+  // Every automation entry point pins a model at creation time (ADR-0007).
+  // "Use default model" resolved at run time against the device MRU, so the
+  // same job ran on whatever model that device last happened to use.
+  it('offers no "use default model" escape hatch', () => {
+    const { queryByText } = render(
+      <CronJobDialog open onOpenChange={vi.fn()} />
+    )
+    expect(queryByText('Use default model')).toBeNull()
+    expect(queryByText('Select a model')).not.toBeNull()
+  })
 })

--- a/packages/app/src/lib/__tests__/cron-model-backfill.test.ts
+++ b/packages/app/src/lib/__tests__/cron-model-backfill.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { planCronModelBackfill } from '@/lib/cron-model-backfill'
+
+const CATALOG = [{ id: 'anthropic/claude-sonnet-4-6' }, { id: 'openai/gpt-5' }]
+
+describe('planCronModelBackfill', () => {
+  it('pins the MRU head onto jobs that have no model', () => {
+    const plan = planCronModelBackfill({
+      jobs: [
+        { id: 'a', payload: {} },
+        { id: 'b', payload: { model: '  ' } },
+      ],
+      recentModels: ['openai/gpt-5', 'anthropic/claude-sonnet-4-6'],
+      available: CATALOG,
+    })
+    expect(plan.updates).toEqual([
+      { id: 'a', model: 'openai/gpt-5' },
+      { id: 'b', model: 'openai/gpt-5' },
+    ])
+    expect(plan.complete).toBe(true)
+  })
+
+  it('leaves jobs that already pinned a model alone', () => {
+    const plan = planCronModelBackfill({
+      jobs: [{ id: 'a', payload: { model: 'openai/gpt-5' } }],
+      recentModels: ['anthropic/claude-sonnet-4-6'],
+      available: CATALOG,
+    })
+    expect(plan.updates).toEqual([])
+    expect(plan.complete).toBe(true)
+  })
+
+  it('skips an MRU entry the catalog no longer offers', () => {
+    // A wrong pin is permanent and silent; a missing pin is fixable. So a
+    // remembered model that is no longer served is treated as no answer.
+    const plan = planCronModelBackfill({
+      jobs: [{ id: 'a', payload: {} }],
+      recentModels: ['retired/model'],
+      available: CATALOG,
+    })
+    expect(plan.updates).toEqual([])
+    expect(plan.complete).toBe(false)
+  })
+
+  it('is inconclusive when the catalog has not arrived', () => {
+    // Daemon down or still starting. Must not be recorded as done — the next
+    // launch may still be able to answer, and after P5 nothing can.
+    const plan = planCronModelBackfill({
+      jobs: [{ id: 'a', payload: {} }],
+      recentModels: ['openai/gpt-5'],
+      available: [],
+    })
+    expect(plan.updates).toEqual([])
+    expect(plan.complete).toBe(false)
+  })
+
+  it('is inconclusive when this device has no MRU at all', () => {
+    const plan = planCronModelBackfill({
+      jobs: [{ id: 'a', payload: {} }],
+      recentModels: [],
+      available: CATALOG,
+    })
+    expect(plan.updates).toEqual([])
+    expect(plan.complete).toBe(false)
+  })
+
+  it('is conclusively done when nothing needs a model, even with no MRU', () => {
+    const plan = planCronModelBackfill({
+      jobs: [{ id: 'a', payload: { model: 'openai/gpt-5' } }],
+      recentModels: undefined,
+      available: [],
+    })
+    expect(plan.complete).toBe(true)
+  })
+})

--- a/packages/app/src/lib/amuxd-channels.ts
+++ b/packages/app/src/lib/amuxd-channels.ts
@@ -56,6 +56,33 @@ export async function saveChannelConfig(
   }
 }
 
+/**
+ * The model every gateway session starts on when the chat has not set its own
+ * with `/model` (ADR-0007). `null` = unset, which leaves the spawn unpinned and
+ * lets the backend pick — the behaviour this setting exists to replace.
+ *
+ * Gateway-level rather than per-platform: the platforms differ in how a message
+ * arrives, not in what should answer it.
+ */
+export async function loadGatewayModel(): Promise<string | null> {
+  try {
+    return await invoke<string | null>("load_gateway_model");
+  } catch (e) {
+    if (isUnreachableError(e)) throw new AmuxdUnreachableError();
+    throw e;
+  }
+}
+
+/** Empty string clears it, restoring the unpinned spawn. */
+export async function saveGatewayModel(model: string): Promise<void> {
+  try {
+    await invoke("save_gateway_model", { model });
+  } catch (e) {
+    if (isUnreachableError(e)) throw new AmuxdUnreachableError();
+    throw e;
+  }
+}
+
 export async function reloadChannels(): Promise<void> {
   try {
     await invoke("reload_channels");

--- a/packages/app/src/lib/cron-model-backfill.ts
+++ b/packages/app/src/lib/cron-model-backfill.ts
@@ -1,0 +1,71 @@
+import { firstAvailableRecentModel } from '@/lib/local-daemon-model-catalog'
+
+/**
+ * One-time backfill of `payload.model` on cron jobs saved before the field was
+ * required (ADR-0007, migration plan P2).
+ *
+ * # Why this has a deadline
+ *
+ * A job with no model used to resolve at run time against the device MRU
+ * (`config::model_mru`). That MRU is deleted in P5, so these jobs have exactly
+ * one window in which the intended answer is still knowable — between the field
+ * becoming required and the MRU going away. After P5 the only remaining option
+ * is to fail the run and make the user pick.
+ *
+ * # Why it refuses more often than it acts
+ *
+ * The value written here becomes the job's permanent pinned model, so writing a
+ * wrong one is worse than writing none: the job keeps running either way, but a
+ * wrong pin is silent and a missing pin is fixable. Every input therefore has to
+ * be positively known — an MRU entry that the live catalog no longer offers is
+ * treated as no answer at all, exactly as `model_mru::first_available` does.
+ */
+
+/** Minimal shape needed to decide; matches `CronJob` structurally. */
+export interface BackfillCandidate {
+  id: string
+  payload: { model?: string }
+}
+
+export interface CronModelBackfillPlan {
+  /** Jobs to rewrite, with the model each should be pinned to. */
+  updates: { id: string; model: string }[]
+  /**
+   * Whether the run is conclusive — i.e. every job that needed a model got one.
+   * `false` means the caller must NOT mark the backfill done: the catalog or the
+   * MRU was unavailable, and a later launch may still be able to answer.
+   */
+  complete: boolean
+}
+
+/**
+ * Decide which jobs to backfill and to what.
+ *
+ * `recentModels` is this device's MRU newest-first (from the loopback catalog's
+ * `recent_models`); `available` is the live catalog for the same workspace. A
+ * remembered model the catalog no longer serves is skipped rather than pinned.
+ */
+export function planCronModelBackfill(args: {
+  jobs: readonly BackfillCandidate[]
+  recentModels: string[] | undefined
+  available: readonly { id?: string }[]
+}): CronModelBackfillPlan {
+  const needing = args.jobs.filter((job) => !job.payload.model?.trim())
+  if (needing.length === 0) {
+    // Nothing to do is a conclusive answer: the backfill is done for good.
+    return { updates: [], complete: true }
+  }
+
+  const model = firstAvailableRecentModel(args.recentModels, args.available)
+  if (!model) {
+    // Either the daemon never answered (catalog empty) or nothing the MRU
+    // remembers is still on offer. Both mean "ask again next launch" — not
+    // "these jobs have no model".
+    return { updates: [], complete: false }
+  }
+
+  return {
+    updates: needing.map((job) => ({ id: job.id, model })),
+    complete: true,
+  }
+}

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1694,6 +1694,16 @@
       "liveState": "Live state"
     },
     "channels": {
+      "gatewayModel": "Gateway model",
+      "gatewayModelDescription": "Every channel starts its sessions on this model. A chat can still switch with /model.",
+      "gatewayModelUnset": "Let the backend choose",
+      "modelsNoTeam": "Join a team to load models.",
+      "modelsNoDefault": "Set a default workspace in Daemon settings.",
+      "modelsNoDefaultPath": "Default workspace has no local path on this daemon.",
+      "modelsDaemonUnavailable": "Daemon is not ready. Wait for the app to finish starting, then try again.",
+      "modelsNoConfigured": "No configured models. Add a provider in LLM settings.",
+      "modelsLoadFailed": "Failed to load models.",
+      "noModels": "No models advertised.",
       "seatalk": {
         "gateway": "SeaTalk Gateway",
         "setupTitle": "Set up SeaTalk Bot",
@@ -2696,7 +2706,7 @@
       "fullAccessOffDesc": "Ask for approval. The run waits until someone answers, or times out.",
       "viewConversation": "View Conversation",
       "execution": "Execution",
-      "modelOverrideHint": "Select a model or use workspace default.",
+      "modelRequiredHint": "Pick the model this job runs on.",
       "scopeGlobal": "Global tasks",
       "scopeGlobalHint": "Runs in the Daemon default workspace, independent of the active window.",
       "scopeWorkspace": "Workspace tasks",
@@ -2714,7 +2724,8 @@
       "modelSelected": "Using: {{model}}",
       "noModels": "No models configured. Please configure providers in LLM Settings first.",
       "lastHeartbeat": "Last heartbeat",
-      "useDefaultModel": "Use default model",
+      "selectModel": "Select a model",
+      "requiredModel": "Model is required",
       "sessionNotFound": "Session not found or access denied (sessionId: {{id}}...)",
       "runFailedFallback": "This run failed: {{error}}"
     },

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1694,6 +1694,16 @@
       "liveState": "实时状态"
     },
     "channels": {
+      "gatewayModel": "网关模型",
+      "gatewayModelDescription": "所有渠道都用这个模型起会话。单个会话仍可以用 /model 切换。",
+      "gatewayModelUnset": "由后端自行选择",
+      "modelsNoTeam": "先加入团队才能加载模型。",
+      "modelsNoDefault": "先在 Daemon 设置里指定默认工作区。",
+      "modelsNoDefaultPath": "默认工作区在这台 daemon 上没有本地路径。",
+      "modelsDaemonUnavailable": "Daemon 还没就绪，等应用启动完成后重试。",
+      "modelsNoConfigured": "没有已配置的模型，请先在 LLM 设置里添加 provider。",
+      "modelsLoadFailed": "加载模型失败。",
+      "noModels": "没有可用模型。",
       "seatalk": {
         "gateway": "SeaTalk 网关",
         "setupTitle": "配置 SeaTalk 机器人",
@@ -2696,7 +2706,7 @@
       "fullAccessOffDesc": "需要人工审批。任务会一直等待，直到有人处理或超时。",
       "viewConversation": "查看对话",
       "execution": "执行",
-      "modelOverrideHint": "选择一个模型，或使用工作区默认模型。",
+      "modelRequiredHint": "选择这个任务运行时用的模型。",
       "scopeGlobal": "全局任务",
       "scopeGlobalHint": "运行在 Daemon 默认工作区，不依赖当前打开的窗口。",
       "scopeWorkspace": "工作区任务",
@@ -2714,7 +2724,8 @@
       "modelSelected": "使用：{{model}}",
       "noModels": "未配置模型。请先在 LLM 设置中配置提供商。",
       "lastHeartbeat": "最后心跳",
-      "useDefaultModel": "使用默认模型",
+      "selectModel": "选择模型",
+      "requiredModel": "必须选择模型",
       "sessionNotFound": "对话不存在或无访问权限 (sessionId: {{id}}...)",
       "runFailedFallback": "本次运行失败：{{error}}"
     },

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -22,6 +22,13 @@ function cronInvokeArgs(scope: CronScope, selectedWorkspacePath: string | null) 
 // (via `cron-prepare-session`) and stamps `session_id` into the run record
 // within a second or two of clicking — well before the ACP turn completes —
 // so it surfaces in `cron_get_runs` almost immediately.
+/**
+ * Latch for the one-time model backfill (ADR-0007 P2). Set only after a
+ * conclusive pass, so an offline daemon does not consume the single window in
+ * which the device MRU can still supply the answer.
+ */
+const CRON_MODEL_BACKFILL_KEY = 'teamclu.cron.model-backfill.v1'
+
 const RUN_JOB_SESSION_POLL_INTERVAL_MS = 1000
 // Even with eager creation, a run whose prepare is queued behind another
 // in-flight cron turn (the daemon serializes turns) can take longer. Keep the
@@ -249,6 +256,11 @@ interface CronState {
   setScope: (scope: CronScope) => Promise<void>
   setSelectedWorkspacePath: (workspacePath: string | null) => Promise<void>
   loadJobs: () => Promise<void>
+  /**
+   * One-time pass that pins a model onto jobs saved before the field was
+   * required. Latches only on a conclusive run — see `lib/cron-model-backfill`.
+   */
+  backfillMissingModels: () => Promise<void>
   addJob: (request: CreateCronJobRequest) => Promise<CronJob>
   updateJob: (request: UpdateCronJobRequest) => Promise<CronJob>
   removeJob: (jobId: string) => Promise<void>
@@ -288,9 +300,52 @@ export const useCronStore = create<CronState>((set, get) => ({
       await invoke('cron_init', cronInvokeArgs(get().activeScope, get().selectedWorkspacePath))
       set({ isInitialized: true })
       await get().loadJobs()
+      void get().backfillMissingModels()
     } catch (error) {
       console.error('[Cron] Init failed:', error)
       set({ error: error instanceof Error ? error.message : String(error) })
+    }
+  },
+
+  backfillMissingModels: async () => {
+    if (localStorage.getItem(CRON_MODEL_BACKFILL_KEY) === 'done') return
+
+    const workspacePath = get().selectedWorkspacePath?.trim()
+    if (!workspacePath) return
+
+    try {
+      const { fetchLocalDaemonCatalog } = await import('@/lib/local-daemon-model-catalog')
+      const { planCronModelBackfill } = await import('@/lib/cron-model-backfill')
+
+      const outcome = await fetchLocalDaemonCatalog(workspacePath)
+      const plan = planCronModelBackfill({
+        jobs: get().jobs,
+        recentModels: outcome.status === 'models' ? outcome.recentModels : [],
+        available: outcome.status === 'models' ? outcome.models : [],
+      })
+
+      for (const { id, model } of plan.updates) {
+        const job = get().jobs.find((j) => j.id === id)
+        if (!job) continue
+        await get().updateJob({
+          id: job.id,
+          name: job.name,
+          description: job.description,
+          enabled: job.enabled,
+          schedule: job.schedule,
+          payload: { ...job.payload, model },
+          delivery: job.delivery ?? null,
+          deleteAfterRun: job.deleteAfterRun,
+        })
+      }
+
+      // Only latch when the run was conclusive. An unreachable daemon must not
+      // burn the one window in which the MRU can still answer (it is deleted in
+      // P5 — see lib/cron-model-backfill.ts).
+      if (plan.complete) localStorage.setItem(CRON_MODEL_BACKFILL_KEY, 'done')
+    } catch (error) {
+      // A migration convenience must never break cron init.
+      console.warn('[Cron] model backfill skipped:', error)
     }
   },
 

--- a/services/fc/src/lib/pg-repo/sessions.ts
+++ b/services/fc/src/lib/pg-repo/sessions.ts
@@ -869,6 +869,31 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
         );
     },
 
+    // ── updateParticipantModel ────────────────────────────────────────────────
+    /**
+     * Which model this agent runs on in this session. Same key as the cursor
+     * above, and same reason it belongs here rather than on a runtime row.
+     *
+     * Added late: the ADR-0005 migration created the column and backfilled it
+     * from `agent_runtimes.current_model`, but no writer was ever wired up, so
+     * it sat frozen while the glossary called it authoritative.
+     */
+    async updateParticipantModel(
+      sessionId: string,
+      actorId: string,
+      { model }: { model: string },
+    ) {
+      await (db as any)
+        .update(sessionParticipants)
+        .set({ model, updatedAt: new Date() })
+        .where(
+          and(
+            eq(sessionParticipants.sessionId, sessionId),
+            eq(sessionParticipants.actorId, actorId),
+          ),
+        );
+    },
+
     // ── upsertSessionParticipant ──────────────────────────────────────────────
     async upsertSessionParticipant(
       sessionId: string,

--- a/services/fc/src/lib/repository-contract.ts
+++ b/services/fc/src/lib/repository-contract.ts
@@ -223,6 +223,26 @@ export function runBusinessRepositoryContract({ test, assert, createRepository }
     );
   });
 
+  test("repository contract: updateParticipantModel succeeds", async () => {
+    const repo = createRepository();
+    await repo.updateParticipantModel("session-1", "actor-1", {
+      model: "anthropic/claude-sonnet-4-6",
+    });
+  });
+
+  test("repository contract: updateParticipantModel round-trips through the participant row", async () => {
+    // The point of the whole endpoint: `session_participants.model` was
+    // backfilled once by the ADR-0005 migration and then had no writer, so it
+    // read as authoritative while drifting. Asserting the read-back here is
+    // what keeps a future refactor from quietly disconnecting it again.
+    const repo = createRepository();
+    await repo.updateParticipantModel("session-1", "actor-1", { model: "openai/gpt-5" });
+    const out = await repo.listSessionParticipants("session-1");
+    const row = out.items.find((p) => p.actorId === "actor-1");
+    assert.ok(row, "actor-1 should still be a participant");
+    assert.equal(row.model, "openai/gpt-5");
+  });
+
   test("repository contract: removeSessionParticipant succeeds", async () => {
     const repo = createRepository();
     await repo.removeSessionParticipant("session-1", "actor-1");

--- a/services/fc/src/lib/routes/sessions.ts
+++ b/services/fc/src/lib/routes/sessions.ts
@@ -138,6 +138,28 @@ export function registerSessions(router) {
     return { statusCode: 204, body: null };
   });
 
+  // Which model this agent runs on in this session — same (session, actor)
+  // addressing as the cursor above (ADR-0005).
+  //
+  // This column shipped with the ADR-0005 migration and was backfilled once,
+  // but no writer was ever wired up, so it froze while both the ADR and the
+  // glossary described it as authoritative. The daemon is the only caller:
+  // it is the only component that sees which model a runtime settled on, and
+  // the only one present for gateway and cron sessions (ADR-0007).
+  //
+  // `model` is required rather than nullable — every entry point pins a model
+  // at creation time, so there is no unpinned state to clear back to.
+  router.patch("/v1/sessions/:sessionId/participants/:actorId/model", async (ctx) => {
+    const body = ctx.json ?? {};
+    const model = requireString(body.model, "model");
+    await ctx.repository.updateParticipantModel(
+      decodeURIComponent(ctx.params.sessionId),
+      decodeURIComponent(ctx.params.actorId),
+      { model },
+    );
+    return { statusCode: 204, body: null };
+  });
+
   router.delete("/v1/sessions/:sessionId/participants/:actorId", async (ctx) => {
     const sessionId = decodeURIComponent(ctx.params.sessionId);
     const actorId = decodeURIComponent(ctx.params.actorId);

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -2522,6 +2522,23 @@ export function createSupabaseBusinessRepository(options) {
       if (error) throw error;
     },
 
+    /**
+     * Which model this agent runs on in this session.
+     *
+     * The column landed with the ADR-0005 migration alongside `workspace_id`
+     * and the cursor, but only those two got writers: `model` was backfilled
+     * from `agent_runtimes.current_model` and then never touched again, so
+     * every reader trusting the ADR got a frozen value. This is that writer.
+     */
+    async updateParticipantModel(sessionId, actorId, { model }) {
+      const { error } = await supabase
+        .from("session_participants")
+        .update({ model, updated_at: new Date().toISOString() })
+        .eq("session_id", sessionId)
+        .eq("actor_id", actorId);
+      if (error) throw error;
+    },
+
     async removeSessionParticipant(sessionId, actorId) {
       const { error } = await supabase
         .from("session_participants")

--- a/services/fc/test/business-api.test.ts
+++ b/services/fc/test/business-api.test.ts
@@ -1059,6 +1059,39 @@ test("POST /v1/sessions/:sessionId/participants returns 400 without actorId", as
   assert.equal(JSON.parse(response.body).error.code, "validation_failed");
 });
 
+test("PATCH /v1/sessions/:sessionId/participants/:actorId/model updates the model", async () => {
+  const repo = fakeRepo();
+  const response = await handleBusinessApiRequest({
+    httpMethod: "PATCH",
+    path: "/v1/sessions/session-1/participants/actor-1/model",
+    headers: { Authorization: "Bearer token" },
+    body: JSON.stringify({ model: "anthropic/claude-sonnet-4-6" }),
+  }, { createRepository: () => repo });
+
+  assert.equal(response.statusCode, 204);
+  assert.deepEqual(repo.calls[0], {
+    method: "updateParticipantModel",
+    sessionId: "session-1",
+    actorId: "actor-1",
+    input: { model: "anthropic/claude-sonnet-4-6" },
+  });
+});
+
+test("PATCH /v1/sessions/:sessionId/participants/:actorId/model returns 400 without model", async () => {
+  // Not nullable on purpose: every entry point pins a model at creation time,
+  // so an empty body is a caller bug, not a request to clear (ADR-0007).
+  const repo = fakeRepo();
+  const response = await handleBusinessApiRequest({
+    httpMethod: "PATCH",
+    path: "/v1/sessions/session-1/participants/actor-1/model",
+    headers: { Authorization: "Bearer token" },
+    body: JSON.stringify({}),
+  }, { createRepository: () => repo });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(repo.calls.length, 0);
+});
+
 test("DELETE /v1/sessions/:sessionId/participants/:actorId removes participant", async () => {
   const repo = fakeRepo();
   const response = await handleBusinessApiRequest({
@@ -1927,6 +1960,7 @@ function fakeRepo({ sessions = [], error = null, teamWorkspaceConfigs = {}, work
     async listAgentRuntimesForTeam(teamId) { calls.push({ method: "listAgentRuntimesForTeam", teamId }); if (error) throw error; return [{ id: "rt-1", teamId, agentId: "agent-1", sessionId: "session-1", workspaceId: null, backendType: "claude_code", status: "ready", backendSessionId: "bs-1", runtimeId: "rt12abcd", currentModel: "claude-opus-4-7", lastSeenAt: "2026-05-27T01:00:00Z", createdAt: "2026-05-27T00:00:00Z", updatedAt: "2026-05-27T01:00:00Z" }]; },
     async listSessionParticipants(sessionId) { calls.push({ method: "listSessionParticipants", sessionId }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); return { items: s?.participants ?? [] }; },
     async upsertSessionParticipant(sessionId, input) { calls.push({ method: "upsertSessionParticipant", sessionId, input }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); const existing = s?.participants?.find(p => p.actorId === input.actorId); if (existing) { existing.role = input.role ?? existing.role; return existing; } const newP = { sessionId, actorId: input.actorId, role: input.role ?? "member", joinedAt: null }; if (s) s.participants.push(newP); return newP; },
+    async updateParticipantModel(sessionId, actorId, input) { calls.push({ method: "updateParticipantModel", sessionId, actorId, input }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); const p = s?.participants?.find(p => p.actorId === actorId); if (p) p.model = input.model; },
     async removeSessionParticipant(sessionId, actorId) { calls.push({ method: "removeSessionParticipant", sessionId, actorId }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); if (s?.participants) s.participants = s.participants.filter(p => p.actorId !== actorId); },
     async getSessionByAcp(acpSessionId) { calls.push({ method: "getSessionByAcp", acpSessionId }); if (error) throw error; return gatewayBindings[acpSessionId] ?? null; },
     async ensureGatewaySession(input) { calls.push({ method: "ensureGatewaySession", input }); if (error) throw error; const b = input.binding; if (gatewayBindings[b]) return { ...gatewayBindings[b], created: false }; const r = { sessionId: "gw-" + b, gatewaySessionId: b, created: true }; gatewayBindings[b] = r; return r; },

--- a/services/fc/test/repository-contract.test.ts
+++ b/services/fc/test/repository-contract.test.ts
@@ -223,6 +223,11 @@ function contractRepo() {
       if (s) s.participants.push(newP);
       return newP;
     },
+    async updateParticipantModel(sessionId, actorId, { model }) {
+      const s = sessionStore.find(s => s.id === sessionId);
+      const p = s?.participants?.find(p => p.actorId === actorId);
+      if (p) p.model = model;
+    },
     async removeSessionParticipant(sessionId, actorId) {
       const s = sessionStore.find(s => s.id === sessionId);
       if (s?.participants) s.participants = s.participants.filter(p => p.actorId !== actorId);


### PR DESCRIPTION
> **叠在 #910 上**（base 是 `task/fc-participant-model`）。#910 建端点，本 PR 调它。合并顺序不能反 —— 先合本 PR 的话 daemon 会打到一个 404。

迁移计划的 **P1 第 1 项**（`docs/plans/2026-08-13-amuxd-model-preference-removal.md`）。

## 改动

daemon 成为 `session_participants.model` 的唯一写入者 —— 它是唯一能观察到 runtime 最终 settle 在哪个模型上的角色，也是 gateway / cron 会话里唯一在场的（ADR-0007）。

写入点选 `RuntimeManager::set_current_model`，而不是六个调用点各写一遍：那里本来就是设备 MRU 的单一写入点，六条路全部汇入 —— desktop picker、gateway `/model`、cron、attach 时的解析、HTTP adapter、`model_apply`。

`Backend` trait 加 `update_participant_model`，三个实现（`cloud_api` / `deferred` / `mock`）跟既有的 `update_session_cursor` 一一对应。

## 三个值得看的决定

**① 值未变则跳过。** attach 时的解析每次 runtime 起都会重新应用同一个值，不短路的话每次 spawn 都白打一次云请求。判断必须放在 `agent_state.set_model` 覆盖之前，否则永远读到"已相同"。

**② 云行按 `owner_actor_id` 定位，不是 `agent_id`。** 后者是 8 字符 spawn key（`handle.rs` 的注释明写 "Distinct from `agent_id`, which is the 8-char spawn key"），Supabase 不认识它。用错的失败模式很阴险：PATCH 匹配零行，**照样返回 204**，写入静默丢失。专门加了一条测试钉住这个。

`owner_actor_id` 由 env snapshot 打戳、`runtime_lifecycle` 兜底回填，所以冷 attach 有一个短暂的空窗口 —— 空则跳过，不写 `/participants//model`。

**③ fire-and-forget。** `messaging.rs` 的 cursor 写入能 `await` 是因为它本来就在 async handler 里；这里是同步方法、六个调用点、其中几个在 runtime 启动路径上。为持久化一个展示值去阻塞 spawn 不划算。失败只 warn，下次模型变更自然重试。

寻址决策抽成 `participant_model_write` 作为可测试接缝 —— 避免为断言游离任务而引入时序 flake，测的是真正会出错的那部分（寻址），spawn 只剩胶水。

## 验证

- `cargo test -p amuxd --locked`：**1078 passed / 1 failed**
  - 唯一失败是 `apply_start_runtime_stamps_workspace_id_on_resolve_fail_worktree_fallback`，原因是本机没装 `opencode` 二进制（`spawn opencode serve: No such file or directory`）。**已 stash 取基线复现，与本 PR 无关。**
- `cargo clippy -p amuxd --locked`：**exit 0**
- 新增 2 条测试：寻址用 actor 而非 spawn key、无法寻址时跳过（空 `owner_actor_id` / 空 session / 空 model / 未知 runtime）
- 格式：只对改动文件跑了 `rustfmt --check`，我的改动区零差异。报出的差异全在 `cloud_api/messages.rs`（未触碰，既有漂移），故意不动 —— 该 crate 本来就不是 fmt-clean，bare `cargo fmt` 会重排约 51 个无关文件。

## P1 第 2 项的实际状态（未完成，如实记录）

计划里 P1 还有一项「gateway `/model` 从内存 override 改为落库」。查证后情况比计划描述的好一些但没全好：

- `channels/agent_handle.rs::set_model` 确实只写内存 `model_override`
- 但 `daemon/server/messaging.rs:813` 在下一个 turn 真正应用时会调 `set_current_model` —— 所以**生效的模型现在会落库**

**剩余缺口**：设了 `/model` 但一次消息都没发就重启 daemon，那次选择会丢。要不要专门为这个窗口在 `/model` 时直接落库，是个独立的小决定，没有包含在本 PR 里。

## 部署

只动 `apps/daemon/**`，不触发 self-host 部署。daemon 随桌面版本一起发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
