### PR TITLE
fix(app): keep turn-2 toolUse on live dock instead of prior reply

### DIFF
--- a/packages/app/src/lib/__tests__/live-agent-stream.test.ts
+++ b/packages/app/src/lib/__tests__/live-agent-stream.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
 import { AgentStatus } from "@/lib/proto/amux_pb";
-import type { Message as TeamcluMessage } from "@/lib/proto/teamclu_pb";
+import {
+  MessageKind,
+  MessageSchema,
+  type Message as TeamcluMessage,
+} from "@/lib/proto/teamclu_pb";
 import {
   buildInterruptedStreamAnchor,
   isAgentActiveStatus,
@@ -22,6 +27,7 @@ import {
   resetFlushedTurnRegistryForTests,
 } from "@/lib/flushed-turn-registry";
 import { useV2StreamingStore } from "@/stores/v2-streaming-store";
+import { useSessionMessageStore } from "@/stores/session-message-store";
 
 describe("live agent stream event helpers", () => {
   it("normalizes execute tool uses preserving wire name when absent", () => {
@@ -322,6 +328,7 @@ describe("shouldPatchFlushedToolEvent", () => {
       revisionBySession: {},
       interruptedFlushPending: {},
     });
+    useSessionMessageStore.setState({ messages: {} });
   });
 
   it("patches when the live stream is inactive after flush", () => {
@@ -333,7 +340,27 @@ describe("shouldPatchFlushedToolEvent", () => {
     expect(shouldPatchFlushedToolEvent("s1", "a1", "tool-late", undefined)).toBe(true);
   });
 
-  it("patches orphan tools from a prior turn while follow-up dock is open", () => {
+  it("patches orphan tools already on the flushed reply while follow-up dock is open", () => {
+    const reply = create(MessageSchema, {
+      messageId: "m1",
+      sessionId: "s1",
+      senderActorId: "a1",
+      kind: MessageKind.AGENT_REPLY,
+      content: "done",
+      turnId: "turn-1",
+      createdAt: BigInt(100),
+    });
+    Object.assign(reply, {
+      partsJson: JSON.stringify([
+        {
+          id: "stream:tool:turn1-tool",
+          type: "tool-call",
+          toolCallId: "turn1-tool",
+          toolCall: { id: "turn1-tool", name: "grep", status: "calling" },
+        },
+      ]),
+    });
+    useSessionMessageStore.getState().replaceTurnAgentRepliesInStore("s1", reply);
     registerFlushedTurn("s1", "a1", {
       messageId: "m1",
       streamId: "stream-1",
@@ -343,6 +370,35 @@ describe("shouldPatchFlushedToolEvent", () => {
     const live = useV2StreamingStore.getState().byKey["s1::a1"] as AgentStreamEntry;
     expect(live.streamId).not.toBe("stream-1");
     expect(shouldPatchFlushedToolEvent("s1", "a1", "turn1-tool", live)).toBe(true);
+  });
+
+  it("keeps the first turn-2 toolUse on the live stream (not turn-1 parts)", () => {
+    const reply = create(MessageSchema, {
+      messageId: "m1",
+      sessionId: "s1",
+      senderActorId: "a1",
+      kind: MessageKind.AGENT_REPLY,
+      content: "turn 1 reply",
+      turnId: "turn-1",
+      createdAt: BigInt(100),
+    });
+    Object.assign(reply, {
+      partsJson: JSON.stringify([
+        { id: "p1", type: "text", text: "turn 1 reply", content: "turn 1 reply" },
+      ]),
+    });
+    useSessionMessageStore.getState().replaceTurnAgentRepliesInStore("s1", reply);
+    registerFlushedTurn("s1", "a1", {
+      messageId: "m1",
+      streamId: "stream-1",
+      turnId: "turn-1",
+    });
+    useV2StreamingStore.getState().beginPlanningPlaceholder("s1", "a1");
+    const live = useV2StreamingStore.getState().byKey["s1::a1"] as AgentStreamEntry;
+    expect(live.streamId).not.toBe("stream-1");
+    expect(live.toolCalls).toHaveLength(0);
+    // Regression: brand-new tool ids must not patch the prior flushed reply.
+    expect(shouldPatchFlushedToolEvent("s1", "a1", "turn2-tool", live)).toBe(false);
   });
 
   it("keeps current-turn tools on the live stream", () => {

--- a/packages/app/src/lib/live-agent-stream.ts
+++ b/packages/app/src/lib/live-agent-stream.ts
@@ -9,6 +9,7 @@ import { deriveAgentReplyContent, isAgentFacingStatusNotice } from "@/lib/agent-
 import { agentReplyTextsEquivalent } from "@/lib/agent-reply-text";
 import { getFlushedTurn } from "@/lib/flushed-turn-registry";
 import { isStreamInterruptible } from "@/stores/v2-streaming-store";
+import { useSessionMessageStore } from "@/stores/session-message-store";
 
 export {
   deriveAgentReplyContent,
@@ -312,10 +313,43 @@ export function isAgentActiveStatus(status: AgentStatus | number | undefined): b
   return status === AgentStatus.ACTIVE;
 }
 
+/** True when the flushed AGENT_REPLY already carries this tool id in parts_json. */
+function flushedMessageHasTool(
+  sessionId: string,
+  messageId: string,
+  toolId: string,
+): boolean {
+  const messages = useSessionMessageStore.getState().messages[sessionId] ?? [];
+  const message = messages.find((m) => m.messageId === messageId);
+  if (!message) return false;
+  const raw = (message as { partsJson?: string | null }).partsJson ?? "";
+  if (!raw.trim()) return false;
+  try {
+    const parts = JSON.parse(raw) as Array<{
+      type?: string;
+      toolCall?: { id?: string };
+      toolCallId?: string;
+    }>;
+    if (!Array.isArray(parts)) return false;
+    return parts.some(
+      (part) =>
+        part.type === "tool-call" &&
+        (part.toolCall?.id === toolId || part.toolCallId === toolId),
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Route a late toolUse/toolResult to the flushed AGENT_REPLY instead of the
  * live dock. Keeps the flushed-turn registry across follow-up ACTIVE so turn-1
  * orphans still patch persist while turn-2 tools stay on the live stream.
+ *
+ * When a new turn already owns an interruptible live dock (different streamId),
+ * only patch tools that already belong to the flushed message. Brand-new tool
+ * ids are current-turn work and must stay on the live stream — otherwise the
+ * first turn-2 toolUse is mis-attributed to turn-1's Process block.
  */
 export function shouldPatchFlushedToolEvent(
   sessionId: string,
@@ -333,7 +367,12 @@ export function shouldPatchFlushedToolEvent(
   }
 
   if (liveEntry.streamId !== flushed.streamId) {
-    return !liveEntry.toolCalls.some((tc) => tc.id === trimmedToolId);
+    // Already on the live dock → keep updating there (toolResult etc.).
+    if (liveEntry.toolCalls.some((tc) => tc.id === trimmedToolId)) {
+      return false;
+    }
+    // Only orphan updates for tools already persisted on the flushed reply.
+    return flushedMessageHasTool(sessionId, flushed.messageId, trimmedToolId);
   }
 
   return false;


### PR DESCRIPTION
## Summary
- Fix `shouldPatchFlushedToolEvent` so brand-new turn-2 tool ids stay on the live Composer dock instead of patching into the previous flushed AGENT_REPLY.
- Only patch the flushed reply when the live dock is inactive, or when the tool id already exists on that reply (true orphan updates).
- Add regression coverage for the first turn-2 `toolUse` mis-routing case that folded the prior reply into Process.

## Test plan
- [x] `pnpm --filter @teamclu/app exec vitest run src/lib/__tests__/live-agent-stream.test.ts`
- [x] `pnpm --filter @teamclu/app exec vitest run src/lib/__tests__/mid-turn-followup-repro.test.ts`
- [x] `pnpm --filter @teamclu/app exec vitest run src/lib/__tests__/streaming-persist.test.ts`
- [ ] Manual: new session → first agent reply completes → second user message with tools → tools appear on turn-2 live dock / Process, not on turn-1


Made with [Cursor](https://cursor.com)