### PR TITLE
fix(amuxd): skills refresh + team MCP on the daemon agent

### DIFF
--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -535,6 +535,39 @@ impl CloudApiBackend {
     pub(super) fn cloud_url(&self, path: &str) -> String {
         cloud_url(&self.cfg, path)
     }
+
+    /// DELETE with the response body discarded. Mirrors `put_no_content` for
+    /// idempotent removals whose only interesting outcome is success.
+    pub(super) async fn delete_no_content(&self, path: &str) -> BackendResult<()> {
+        for is_retry in [false, true] {
+            let token = self.access_token().await?;
+            let resp = self
+                .http
+                .delete(self.cloud_url(path))
+                .bearer_auth(token)
+                .header("x-request-id", request_id())
+                .send()
+                .await
+                .map_err(network_error)?;
+            if resp.status().is_success() {
+                return Ok(());
+            }
+            let status = resp.status();
+            let bytes = resp.bytes().await.map_err(network_error)?;
+            let envelope = serde_json::from_slice::<client::CloudErrorEnvelope>(&bytes).ok();
+            match client::decode_error(status, envelope) {
+                BackendError::Auth(_) if !is_retry => {
+                    tracing::debug!(
+                        path,
+                        "cloud_api: 401 unauthorized, invalidating cached access token and retrying once"
+                    );
+                    self.invalidate_access_token_cache();
+                }
+                err => return Err(err),
+            }
+        }
+        unreachable!("cloud_api delete retry loop exhausted")
+    }
 }
 
 /// One participant row for (session, actor). The participant owns this agent's
@@ -673,6 +706,20 @@ impl Backend for CloudApiBackend {
             Err(BackendError::NotFound(_)) => Ok(serde_json::json!({ "mcpServers": {} })),
             Err(e) => Err(e),
         }
+    }
+
+    async fn install_team_mcp(&self, team_id: &str, name: &str) -> BackendResult<()> {
+        // No `actorId`: the endpoint records against the caller, and the
+        // daemon's caller is the hosted agent actor itself — the same contract
+        // `record_team_skill_install` relies on. Installing on the human's actor
+        // would never reach this daemon's merged MCP view (see team-mcp design).
+        let path = format!("/v1/teams/{team_id}/mcp-servers/{name}/install");
+        self.put_no_content(&path, &serde_json::json!({})).await
+    }
+
+    async fn uninstall_team_mcp(&self, team_id: &str, name: &str) -> BackendResult<()> {
+        let path = format!("/v1/teams/{team_id}/mcp-servers/{name}/install");
+        self.delete_no_content(&path).await
     }
 
     async fn team_env_secrets(&self, team_id: &str) -> BackendResult<Vec<TeamEnvSecretRow>> {

--- a/apps/daemon/src/backend/deferred.rs
+++ b/apps/daemon/src/backend/deferred.rs
@@ -27,7 +27,7 @@ use super::records::{
 };
 use super::{
     AgentDefaults, Backend, BackendError, BackendResult, BootstrapMqttOverride, CloudAuthSnapshot,
-    ManagedLlmConfig, ShareModeConfig, TeamSkillDownload, TeamSkillRow,
+    ManagedLlmConfig, ShareModeConfig, TeamEnvSecretRow, TeamSkillDownload, TeamSkillRow,
 };
 
 /// Error returned by every business call before onboarding completes.
@@ -158,6 +158,22 @@ impl Backend for DeferredBackend {
 
     async fn managed_llm_config(&self, team_id: &str) -> BackendResult<ManagedLlmConfig> {
         self.inner()?.managed_llm_config(team_id).await
+    }
+
+    async fn team_mcp_config(&self, team_id: &str) -> BackendResult<serde_json::Value> {
+        self.inner()?.team_mcp_config(team_id).await
+    }
+
+    async fn install_team_mcp(&self, team_id: &str, name: &str) -> BackendResult<()> {
+        self.inner()?.install_team_mcp(team_id, name).await
+    }
+
+    async fn uninstall_team_mcp(&self, team_id: &str, name: &str) -> BackendResult<()> {
+        self.inner()?.uninstall_team_mcp(team_id, name).await
+    }
+
+    async fn team_env_secrets(&self, team_id: &str) -> BackendResult<Vec<TeamEnvSecretRow>> {
+        self.inner()?.team_env_secrets(team_id).await
     }
 
     // Every method a caller needs has to be forwarded explicitly — a trait

--- a/apps/daemon/src/backend/mod.rs
+++ b/apps/daemon/src/backend/mod.rs
@@ -257,6 +257,29 @@ pub trait Backend: Send + Sync {
         Ok(serde_json::json!({ "mcpServers": {} }))
     }
 
+    /// Install a team MCP server for the calling actor
+    /// (`PUT /v1/teams/:id/mcp-servers/:name/install`).
+    ///
+    /// Installing means "run this command on this machine", and the daemon *is*
+    /// the actor that spawns/probes it — so the daemon installs for its own
+    /// agent actor, never on a human's behalf. Default errors: a backend that
+    /// has not wired this up must not let an install silently no-op, because
+    /// the merged MCP view would then never contain the server and the UI would
+    /// keep reporting zero tools.
+    async fn install_team_mcp(&self, _team_id: &str, _name: &str) -> BackendResult<()> {
+        Err(BackendError::NotFound(
+            "team MCP install unavailable on this backend".to_string(),
+        ))
+    }
+
+    /// Uninstall a team MCP server for the calling actor
+    /// (`DELETE /v1/teams/:id/mcp-servers/:name/install`).
+    async fn uninstall_team_mcp(&self, _team_id: &str, _name: &str) -> BackendResult<()> {
+        Err(BackendError::NotFound(
+            "team MCP uninstall unavailable on this backend".to_string(),
+        ))
+    }
+
     /// Fetch the team's env secrets (`GET /v1/teams/:id/env-secrets`).
     ///
     /// Ciphertext only — the envelope is opaque here and stays that way until

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -999,7 +999,7 @@ impl DaemonServer {
             // bind (see below), and the watcher poll loop reads the registry live.
             let refresh_watch_registry =
                 crate::runtime::refresh::refresh_watch::start_refresh_watchers(
-                    runtime_supervisor.refresh_coordinator(),
+                    runtime_supervisor.clone(),
                     Vec::new(),
                     dirs::home_dir(),
                 );

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -1139,10 +1139,7 @@ impl DaemonServer {
                     registry
                         .upsert_workspace(
                             crate::runtime::refresh::refresh_watch::WatchedWorkspace {
-                                workspace_id:
-                                    crate::runtime::refresh::refresh_watch::workspace_runtime_id(
-                                        Path::new(&workspace.path),
-                                    ),
+                                workspace_id: workspace.workspace_id,
                                 workspace_path: PathBuf::from(&workspace.path),
                             },
                         )

--- a/apps/daemon/src/daemon/server/peers_workspaces.rs
+++ b/apps/daemon/src/daemon/server/peers_workspaces.rs
@@ -321,9 +321,7 @@ impl DaemonServer {
         if let Some(registry) = self.refresh_watch_registry.as_ref() {
             registry
                 .upsert_workspace(crate::runtime::refresh::refresh_watch::WatchedWorkspace {
-                    workspace_id: crate::runtime::refresh::refresh_watch::workspace_runtime_id(
-                        &canonical,
-                    ),
+                    workspace_id: remote.id.clone(),
                     workspace_path: canonical.clone(),
                 })
                 .await;

--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -203,6 +203,12 @@ pub fn build(state: HttpState) -> Router {
             "/v1/team/cloud-config/reconcile",
             post(team_sync::reconcile_cloud_config),
         )
+        // Install/uninstall a team MCP server for the daemon's own agent actor
+        // (not the desktop user), then re-fetch the team MCP cache immediately.
+        .route(
+            "/v1/team/mcp-servers/:name/install",
+            put(team_sync::install_team_mcp).delete(team_sync::uninstall_team_mcp),
+        )
         .route(
             "/v1/team/secrets",
             post(team_sync::set_secrets).get(team_sync::get_secrets),

--- a/apps/daemon/src/http/team_sync.rs
+++ b/apps/daemon/src/http/team_sync.rs
@@ -6,7 +6,7 @@
 //! status. The daemon is single-team, so the team_id is resolved from
 //! `daemon.toml` (teamclu.json carries no team_id) — same lookup as
 //! `/v1/team/link`.
-use axum::extract::{Query, State};
+use axum::extract::{Path, Query, State};
 use axum::Json;
 use serde::{Deserialize, Serialize};
 
@@ -150,6 +150,87 @@ pub async fn reconcile_cloud_config(
         team_id,
         mcp_changed: outcome.mcp_changed,
         env_changed: outcome.env_changed,
+    }))
+}
+
+/// Re-fetch the team MCP/env cache immediately and fan out refresh signals.
+/// Shared by the reconcile route and the team MCP install/uninstall routes so a
+/// write surfaces without waiting out the 300s background tick.
+async fn reconcile_team_cloud_after_write(
+    state: &HttpState,
+    team_id: &str,
+) -> Result<crate::runtime::team_cloud_config::TeamCloudReconcileOutcome, HttpError> {
+    let Some(resolver) = state.team_cloud.as_ref() else {
+        return Err(HttpError::runtime_unavailable(
+            "team cloud config resolver is not available",
+        ));
+    };
+    let outcome = resolver.reconcile_now(team_id).await;
+    crate::runtime::team_cloud_config::apply_team_cloud_outcome(
+        team_id,
+        outcome,
+        state.backend.as_ref(),
+        state.runtime_refresh.as_ref(),
+    )
+    .await;
+    Ok(outcome)
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamMcpInstallResponse {
+    pub team_id: String,
+    pub mcp_changed: bool,
+}
+
+/// `PUT /v1/team/mcp-servers/:name/install`
+///
+/// Installs a team MCP server for the daemon's own agent actor — never the
+/// desktop user. The daemon is what spawns and probes the server, so the install
+/// must land on the daemon's actor for the merged MCP view (and therefore the
+/// tool probe) to pick it up. Then the team MCP cache is re-fetched immediately.
+pub async fn install_team_mcp(
+    principal: Principal,
+    State(state): State<HttpState>,
+    Path(name): Path<String>,
+) -> Result<Json<TeamMcpInstallResponse>, HttpError> {
+    require_scope(&principal, "workspace:write")?;
+    let team_id = team_id_for_workspace("")?;
+    let backend = state
+        .backend
+        .as_ref()
+        .ok_or_else(|| HttpError::runtime_unavailable("cloud backend unavailable"))?;
+    backend
+        .install_team_mcp(&team_id, &name)
+        .await
+        .map_err(|e| HttpError::internal(e.to_string()))?;
+    let outcome = reconcile_team_cloud_after_write(&state, &team_id).await?;
+    Ok(Json(TeamMcpInstallResponse {
+        team_id,
+        mcp_changed: outcome.mcp_changed,
+    }))
+}
+
+/// `DELETE /v1/team/mcp-servers/:name/install`
+pub async fn uninstall_team_mcp(
+    principal: Principal,
+    State(state): State<HttpState>,
+    Path(name): Path<String>,
+) -> Result<Json<TeamMcpInstallResponse>, HttpError> {
+    require_scope(&principal, "workspace:write")?;
+    let team_id = team_id_for_workspace("")?;
+    let backend = state
+        .backend
+        .as_ref()
+        .ok_or_else(|| HttpError::runtime_unavailable("cloud backend unavailable"))?;
+    backend
+        .uninstall_team_mcp(&team_id, &name)
+        .await
+        .map_err(|e| HttpError::internal(e.to_string()))?;
+    let outcome = reconcile_team_cloud_after_write(&state, &team_id).await?;
+    Ok(Json(TeamMcpInstallResponse {
+        team_id,
+        mcp_changed: outcome.mcp_changed,
     }))
 }
 

--- a/apps/daemon/src/http/workspaces.rs
+++ b/apps/daemon/src/http/workspaces.rs
@@ -113,6 +113,15 @@ async fn record_skills_refresh_change(
             error = %error,
             "failed to record skills refresh change after workspace mutation"
         );
+        return;
+    }
+
+    // OpenCode discovers skills when `opencode serve` starts, not when an
+    // individual session is attached. Keep existing sessions on their current
+    // generation, but drain it so the next session starts a fresh host and sees
+    // the skill mutation without requiring an explicit Apply first.
+    if let Some(supervisor) = state.runtime_supervisor.as_ref() {
+        supervisor.request_workspace_host_refresh(workspace_id);
     }
 }
 

--- a/apps/daemon/src/http/workspaces.rs
+++ b/apps/daemon/src/http/workspaces.rs
@@ -90,6 +90,64 @@ async fn workspace_path_or_404(workspace_id: &str) -> Result<std::path::PathBuf,
     Ok(wpath)
 }
 
+fn paths_refer_to_same_workspace(left: &StdPath, right: &StdPath) -> bool {
+    if left == right {
+        return true;
+    }
+    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
+/// Convert the path-encoded id used by workspace-control HTTP routes into the
+/// cloud UUID used by runtime isolation and the OpenCode host pool.
+async fn resolve_runtime_workspace_id(
+    state: &HttpState,
+    route_workspace_id: &str,
+    workspace_path: &StdPath,
+) -> String {
+    // A watcher may already have recorded a pending change under the canonical
+    // UUID. Prefer that local mapping and avoid a cloud round trip on Apply.
+    if let Some(refresh) = state.runtime_refresh.as_ref() {
+        if let Some(workspace_id) = refresh.workspace_id_for_path(workspace_path).await {
+            return workspace_id;
+        }
+    }
+
+    let Some(backend) = state.backend.as_ref() else {
+        return route_workspace_id.to_owned();
+    };
+    let team_id = backend.team_id();
+    if team_id.trim().is_empty() {
+        return route_workspace_id.to_owned();
+    }
+    match backend
+        .get_workspaces_by_agent(team_id, backend.actor_id())
+        .await
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .find(|row| {
+                !row.archived
+                    && row.path.as_deref().is_some_and(|path| {
+                        paths_refer_to_same_workspace(StdPath::new(path), workspace_path)
+                    })
+            })
+            .map(|row| row.id)
+            .unwrap_or_else(|| route_workspace_id.to_owned()),
+        Err(error) => {
+            tracing::warn!(
+                route_workspace_id,
+                workspace_path = %workspace_path.display(),
+                error = %error,
+                "failed to resolve runtime workspace UUID; using route identity"
+            );
+            route_workspace_id.to_owned()
+        }
+    }
+}
+
 async fn record_skills_refresh_change(
     state: &HttpState,
     workspace_id: &str,
@@ -98,9 +156,11 @@ async fn record_skills_refresh_change(
     let Some(refresh) = state.runtime_refresh.as_ref() else {
         return;
     };
+    let runtime_workspace_id =
+        resolve_runtime_workspace_id(state, workspace_id, workspace_path).await;
     if let Err(error) = refresh
         .record_change(
-            workspace_id,
+            &runtime_workspace_id,
             workspace_path,
             RefreshChangeKind::Skills,
             RefreshSource::UiMutation,
@@ -108,7 +168,7 @@ async fn record_skills_refresh_change(
         .await
     {
         tracing::warn!(
-            workspace_id = %workspace_id,
+            workspace_id = %runtime_workspace_id,
             workspace_path = %workspace_path.display(),
             error = %error,
             "failed to record skills refresh change after workspace mutation"
@@ -121,7 +181,7 @@ async fn record_skills_refresh_change(
     // generation, but drain it so the next session starts a fresh host and sees
     // the skill mutation without requiring an explicit Apply first.
     if let Some(supervisor) = state.runtime_supervisor.as_ref() {
-        supervisor.request_workspace_host_refresh(workspace_id);
+        supervisor.request_workspace_host_refresh(&runtime_workspace_id);
     }
 }
 
@@ -131,16 +191,18 @@ async fn reload_runtime_after_provider_auth(
     workspace_id: &str,
     workspace_path: &std::path::Path,
 ) -> ApplyOutcome {
+    let runtime_workspace_id =
+        resolve_runtime_workspace_id(state, workspace_id, workspace_path).await;
     if let Some(supervisor) = state.runtime_supervisor.as_ref() {
         match supervisor
             // Explicit provider-auth reload path: always refresh the hosts.
-            .reload_workspace(workspace_id, workspace_path, true)
+            .reload_workspace(&runtime_workspace_id, workspace_path, true)
             .await
         {
             Ok(outcome) => return outcome,
             Err(e) => {
                 tracing::warn!(
-                    workspace_id = %workspace_id,
+                    workspace_id = %runtime_workspace_id,
                     error = %e,
                     "runtime reload after provider auth failed"
                 );
@@ -1157,6 +1219,8 @@ pub async fn record_pending_runtime_changes(
 ) -> Result<Json<PendingRuntimeChangesResponse>, HttpError> {
     require_scope(&principal, "workspace:write")?;
     let workspace_path = decode_workspace_path(&workspace_id).map_err(map_control_err)?;
+    let runtime_workspace_id =
+        resolve_runtime_workspace_id(&state, &workspace_id, &workspace_path).await;
     let kinds = crate::runtime::refresh::parse_refresh_change_kinds(&body.change_kinds);
     if kinds.is_empty() {
         return Err(HttpError::validation(
@@ -1174,7 +1238,7 @@ pub async fn record_pending_runtime_changes(
     for kind in kinds {
         refresh
             .record_change(
-                &workspace_id,
+                &runtime_workspace_id,
                 &workspace_path,
                 kind,
                 RefreshSource::UiMutation,
@@ -1195,11 +1259,13 @@ pub async fn reload_runtime(
 ) -> Result<Json<ApplyResponse>, HttpError> {
     require_scope(&principal, "workspace:write")?;
     let workspace_path = decode_workspace_path(&workspace_id).map_err(map_control_err)?;
+    let runtime_workspace_id =
+        resolve_runtime_workspace_id(&state, &workspace_id, &workspace_path).await;
 
     if let Some(supervisor) = state.runtime_supervisor.as_ref() {
         let outcome = supervisor
             // Explicit user-triggered apply: refresh provider hosts too.
-            .apply_refresh(&workspace_id, &workspace_path, true)
+            .apply_refresh(&runtime_workspace_id, &workspace_path, true)
             .await
             .map_err(map_control_err)?;
         return Ok(apply_ok(outcome));
@@ -1207,7 +1273,11 @@ pub async fn reload_runtime(
 
     let store = resolve_store(&state)?;
     let attempt = if let Some(refresh) = state.runtime_refresh.as_ref() {
-        Some(refresh.mark_applying(&workspace_id, &workspace_path).await)
+        Some(
+            refresh
+                .mark_applying(&runtime_workspace_id, &workspace_path)
+                .await,
+        )
     } else {
         None
     };
@@ -1216,14 +1286,19 @@ pub async fn reload_runtime(
         Err(err) => {
             if let (Some(refresh), Some(attempt)) = (state.runtime_refresh.as_ref(), attempt) {
                 refresh
-                    .mark_apply_failed(&workspace_id, &workspace_path, attempt, err.to_string())
+                    .mark_apply_failed(
+                        &runtime_workspace_id,
+                        &workspace_path,
+                        attempt,
+                        err.to_string(),
+                    )
                     .await;
             }
             return Err(map_control_err(err));
         }
     };
     if let (Some(refresh), Some(attempt)) = (state.runtime_refresh.as_ref(), attempt) {
-        refresh.clear_applied(&workspace_id, attempt).await;
+        refresh.clear_applied(&runtime_workspace_id, attempt).await;
     }
     Ok(apply_ok(outcome))
 }

--- a/apps/daemon/src/http/workspaces.rs
+++ b/apps/daemon/src/http/workspaces.rs
@@ -177,11 +177,13 @@ async fn record_skills_refresh_change(
     }
 
     // OpenCode discovers skills when `opencode serve` starts, not when an
-    // individual session is attached. Keep existing sessions on their current
-    // generation, but drain it so the next session starts a fresh host and sees
-    // the skill mutation without requiring an explicit Apply first.
+    // individual session is attached. Preserve active turns, detach resumable
+    // idle sessions, then drain the generation so the next session starts a
+    // fresh host and sees the mutation without requiring an explicit Apply.
     if let Some(supervisor) = state.runtime_supervisor.as_ref() {
-        supervisor.request_workspace_host_refresh(&runtime_workspace_id);
+        supervisor
+            .request_workspace_host_refresh(&runtime_workspace_id, workspace_path)
+            .await;
     }
 }
 
@@ -335,7 +337,9 @@ async fn reconcile_team_provider(state: &HttpState, workspace_id: &str) {
     let after = std::fs::read(config_path).ok();
     if before != after {
         if let Some(supervisor) = state.runtime_supervisor.as_ref() {
-            supervisor.request_workspace_host_refresh(workspace_id);
+            supervisor
+                .request_workspace_host_refresh(workspace_id, &wpath)
+                .await;
         }
     }
 }

--- a/apps/daemon/src/runtime/manager/workspace_query.rs
+++ b/apps/daemon/src/runtime/manager/workspace_query.rs
@@ -90,4 +90,89 @@ impl RuntimeManager {
         }
         stopped
     }
+
+    /// Detach workspace runtimes that are safe to resume after a pooled host
+    /// refresh.
+    ///
+    /// A pooled OpenCode generation cannot exit while an attached runtime owns
+    /// one of its route leases. Keeping every idle attachment across repeated
+    /// config refreshes therefore accumulates draining generations until the
+    /// global host cap is exhausted. Idle runtimes can be reconstructed from
+    /// their persisted backend session on the next message, so release those
+    /// leases before rolling the host. Active and checked-out turns remain on
+    /// their current generation and are never interrupted.
+    pub async fn stop_idle_runtimes_for_workspace(
+        &mut self,
+        workspace_path: &str,
+        workspace_id: &str,
+    ) -> usize {
+        let ids: Vec<String> = self
+            .agents
+            .iter()
+            .filter(|(_, handle)| {
+                Self::workspace_runtime_matches(handle, workspace_path, workspace_id)
+                    && handle.status == amux::AgentStatus::Idle
+                    && handle.event_rx.is_some()
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+        let mut stopped = 0usize;
+        for id in ids {
+            if self.stop_runtime(&id).await.is_some() {
+                stopped += 1;
+            }
+        }
+        stopped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn refresh_cleanup_stops_only_safe_idle_workspace_runtimes() {
+        let mut manager = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        manager.add_test_workspace_runtime(
+            "idle-target",
+            "/tmp/target",
+            "ws-target",
+            amux::AgentStatus::Idle,
+        );
+        manager.add_test_workspace_runtime(
+            "active-target",
+            "/tmp/target",
+            "ws-target",
+            amux::AgentStatus::Active,
+        );
+        manager.add_test_workspace_runtime(
+            "checked-out-target",
+            "/tmp/target",
+            "ws-target",
+            amux::AgentStatus::Idle,
+        );
+        manager
+            .get_handle_mut("checked-out-target")
+            .unwrap()
+            .event_rx = None;
+        manager.add_test_workspace_runtime(
+            "idle-other",
+            "/tmp/other",
+            "ws-other",
+            amux::AgentStatus::Idle,
+        );
+
+        assert_eq!(
+            manager
+                .stop_idle_runtimes_for_workspace("/tmp/target", "ws-target")
+                .await,
+            1
+        );
+
+        let ids = manager.agent_ids();
+        assert!(!ids.iter().any(|id| id == "idle-target"));
+        assert!(ids.iter().any(|id| id == "active-target"));
+        assert!(ids.iter().any(|id| id == "checked-out-target"));
+        assert!(ids.iter().any(|id| id == "idle-other"));
+    }
 }

--- a/apps/daemon/src/runtime/refresh.rs
+++ b/apps/daemon/src/runtime/refresh.rs
@@ -302,6 +302,45 @@ impl RuntimeRefreshCoordinator {
             .cloned()
     }
 
+    /// Resolve a refresh identity by its filesystem path. HTTP workspace
+    /// control routes use a base64url path as `:id`, while runtime isolation
+    /// uses the cloud workspace UUID. The watcher records the UUID; status and
+    /// Apply callers therefore need this path bridge to address the same state.
+    pub async fn workspace_id_for_path(&self, workspace_path: &Path) -> Option<String> {
+        let workspace_path = workspace_path.to_string_lossy();
+        let path_identity = refresh_watch::workspace_runtime_id(Path::new(workspace_path.as_ref()));
+        self.inner
+            .read()
+            .await
+            .workspaces
+            .values()
+            .filter(|state| state.workspace_path == workspace_path)
+            .max_by_key(|state| state.workspace_id != path_identity)
+            .map(|state| state.workspace_id.clone())
+    }
+
+    pub async fn runtime_refresh_dto_for_path(
+        &self,
+        workspace_id: &str,
+        workspace_path: &Path,
+    ) -> RuntimeRefreshDto {
+        let workspace_path = workspace_path.to_string_lossy();
+        let path_identity = refresh_watch::workspace_runtime_id(Path::new(workspace_path.as_ref()));
+        let guard = self.inner.read().await;
+        if workspace_id != path_identity {
+            if let Some(state) = guard.workspaces.get(workspace_id) {
+                return state.to_dto();
+            }
+        }
+        guard
+            .workspaces
+            .values()
+            .filter(|state| state.workspace_path == workspace_path)
+            .max_by_key(|state| state.workspace_id != path_identity)
+            .map(WorkspaceRefreshState::to_dto)
+            .unwrap_or_else(RuntimeRefreshDto::clean)
+    }
+
     pub async fn pending_workspace_states(&self) -> Vec<WorkspaceRefreshState> {
         self.inner
             .read()
@@ -557,6 +596,41 @@ mod tests {
         assert_eq!(state.strongest_impact, RefreshImpact::IdleRestart);
         assert!(state.change_kinds.contains(&RefreshChangeKind::Skills));
         assert!(state.change_kinds.contains(&RefreshChangeKind::Mcp));
+    }
+
+    #[tokio::test]
+    async fn path_lookup_bridges_http_route_id_to_runtime_workspace_id() {
+        let coordinator = RuntimeRefreshCoordinator::new();
+        let path = Path::new("/tmp/teamclu-runtime-id-bridge");
+        coordinator
+            .record_change(
+                "cloud-workspace-uuid",
+                path,
+                RefreshChangeKind::Skills,
+                RefreshSource::FilesystemWatch,
+            )
+            .await
+            .unwrap();
+        let path_identity = refresh_watch::workspace_runtime_id(path);
+        coordinator
+            .record_change(
+                &path_identity,
+                path,
+                RefreshChangeKind::OpencodeJson,
+                RefreshSource::UiMutation,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            coordinator.workspace_id_for_path(path).await.as_deref(),
+            Some("cloud-workspace-uuid")
+        );
+        let dto = coordinator
+            .runtime_refresh_dto_for_path(&path_identity, path)
+            .await;
+        assert_eq!(dto.status, "pending");
+        assert_eq!(dto.change_kinds, vec!["skills"]);
     }
 
     #[tokio::test]

--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -46,6 +46,30 @@ fn is_meta_skills_path(path: &Path, workspace: &Path) -> bool {
     path.starts_with(&brand) || (legacy != brand && path.starts_with(&legacy))
 }
 
+/// Return both the workspace-visible team path and its physical target.
+///
+/// On macOS, FSEvents reports mutations made through a symlink using the
+/// canonical target path, and watching the symlink itself does not reliably
+/// follow writes below that target. Keep both spellings so edits performed by
+/// an agent inside `teamclu-team/skills` are attributed to the workspace that
+/// owns the link.
+fn team_link_child_paths(workspace: &Path, child: &str) -> Vec<PathBuf> {
+    let visible = workspace.join(TEAM_LINK_NAME).join(child);
+    let mut paths = vec![visible.clone()];
+    if let Ok(canonical) = std::fs::canonicalize(&visible) {
+        if canonical != visible {
+            paths.push(canonical);
+        }
+    }
+    paths
+}
+
+fn is_team_skills_path(path: &Path, workspace: &Path) -> bool {
+    team_link_child_paths(workspace, "skills")
+        .iter()
+        .any(|root| path.starts_with(root))
+}
+
 /// How often the watch loop reconciles OS watches against the registry absent an
 /// explicit change signal. This performs only cheap `is_dir()` checks on the
 /// handful of `watch_roots` — never a recursive tree walk — so it stays
@@ -179,7 +203,7 @@ pub fn classify_change_path(
             || path.starts_with(workspace.workspace_path.join(".opencode/skills"))
             || path.starts_with(workspace.workspace_path.join(".claude/skills"))
             || path.starts_with(workspace.workspace_path.join(".agents/skills"))
-            || path.starts_with(workspace.workspace_path.join(TEAM_LINK_NAME).join("skills"))
+            || is_team_skills_path(path, &workspace.workspace_path)
             || is_global_skill_path
         {
             Some(RefreshChangeKind::Skills)
@@ -252,11 +276,12 @@ fn watch_roots(workspaces: &[WatchedWorkspace], home: Option<&Path>) -> Vec<Watc
             path: workspace.workspace_path.join(".agents/skills"),
             recursive: true,
         });
-        let team_skills = workspace.workspace_path.join(TEAM_LINK_NAME).join("skills");
-        roots.push(WatchRoot {
-            path: team_skills,
-            recursive: true,
-        });
+        for team_skills in team_link_child_paths(&workspace.workspace_path, "skills") {
+            roots.push(WatchRoot {
+                path: team_skills,
+                recursive: true,
+            });
+        }
         roots.push(WatchRoot {
             path: workspace
                 .workspace_path
@@ -594,6 +619,36 @@ mod tests {
                 kind
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_team_skill_target_is_watched_and_classified() {
+        let root = tempfile::tempdir().unwrap();
+        let workspace = root.path().join("workspace");
+        let shared_team = root.path().join("shared/teamclu-team");
+        let shared_skills = shared_team.join("skills");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::create_dir_all(shared_skills.join("multiply-add")).unwrap();
+        std::os::unix::fs::symlink(&shared_team, workspace.join(TEAM_LINK_NAME)).unwrap();
+
+        let workspaces = vec![WatchedWorkspace {
+            workspace_id: "ws-symlink".to_string(),
+            workspace_path: workspace.clone(),
+        }];
+        let canonical_skills = std::fs::canonicalize(&shared_skills).unwrap();
+        let roots = watch_roots(&workspaces, None);
+        assert!(roots.iter().any(|root| root.path == canonical_skills));
+
+        let changed_file = canonical_skills.join("multiply-add/SKILL.md");
+        assert_eq!(
+            classify_change_path(&changed_file, &workspaces, None),
+            vec![ClassifiedChange {
+                workspace_id: "ws-symlink".to_string(),
+                workspace_path: workspace,
+                kind: RefreshChangeKind::Skills,
+            }]
+        );
     }
 
     #[tokio::test]

--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -356,7 +356,9 @@ async fn record_classified_changes(
         // on-disk skill content.
         if change.kind == RefreshChangeKind::Skills {
             if let Some(supervisor) = supervisor {
-                supervisor.request_workspace_host_refresh(&change.workspace_id);
+                supervisor
+                    .request_workspace_host_refresh(&change.workspace_id, &change.workspace_path)
+                    .await;
             }
         }
     }

--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -292,6 +292,7 @@ fn watch_roots(workspaces: &[WatchedWorkspace], home: Option<&Path>) -> Vec<Watc
 
 async fn record_classified_changes(
     refresh: &RuntimeRefreshCoordinator,
+    supervisor: Option<&RuntimeSupervisor>,
     debounce: &mut RefreshDebounce,
     workspaces: &[WatchedWorkspace],
     home: Option<&Path>,
@@ -321,6 +322,17 @@ async fn record_classified_changes(
                 error = %error,
                 "failed to record filesystem refresh change"
             );
+            continue;
+        }
+
+        // OpenCode caches its discovered skill catalog for the lifetime of the
+        // serve process. Draining the workspace generation preserves existing
+        // sessions while guaranteeing that the next session discovers the new
+        // on-disk skill content.
+        if change.kind == RefreshChangeKind::Skills {
+            if let Some(supervisor) = supervisor {
+                supervisor.request_workspace_host_refresh(&change.workspace_id);
+            }
         }
     }
 }
@@ -405,10 +417,11 @@ fn is_relevant_event(kind: &EventKind) -> bool {
 }
 
 pub fn start_refresh_watchers(
-    refresh: Arc<RuntimeRefreshCoordinator>,
+    supervisor: Arc<RuntimeSupervisor>,
     workspaces: Vec<WatchedWorkspace>,
     home: Option<PathBuf>,
 ) -> Arc<RefreshWatchRegistry> {
+    let refresh = supervisor.refresh_coordinator();
     let registry = RefreshWatchRegistry::new(workspaces);
     let watch_registry = Arc::clone(&registry);
     tokio::spawn(async move {
@@ -466,6 +479,7 @@ pub fn start_refresh_watchers(
                     let workspaces = watch_registry.snapshot().await;
                     record_classified_changes(
                         &refresh,
+                        Some(&supervisor),
                         &mut debounce,
                         &workspaces,
                         home.as_deref(),
@@ -498,6 +512,8 @@ pub fn suppress_for_workspace_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::execution_context::{IsolationDomainKey, ProcessEnvRevision};
+    use crate::runtime::opencode_http::host_pool::HostLifecycle;
     use crate::runtime::RuntimeManager;
     use tokio::sync::Mutex as AsyncMutex;
 
@@ -588,9 +604,19 @@ mod tests {
         let now = Instant::now();
         let path = Path::new("/tmp/ws-1/.teamclu/skills/demo-skill/SKILL.md");
 
-        record_classified_changes(&coordinator, &mut debounce, &workspaces, None, path, now).await;
         record_classified_changes(
             &coordinator,
+            None,
+            &mut debounce,
+            &workspaces,
+            None,
+            path,
+            now,
+        )
+        .await;
+        record_classified_changes(
+            &coordinator,
+            None,
             &mut debounce,
             &workspaces,
             None,
@@ -600,6 +626,7 @@ mod tests {
         .await;
         record_classified_changes(
             &coordinator,
+            None,
             &mut debounce,
             &workspaces,
             None,
@@ -630,6 +657,7 @@ mod tests {
 
         record_classified_changes(
             &supervisor.refresh_coordinator(),
+            None,
             &mut debounce,
             &workspaces,
             None,
@@ -644,6 +672,64 @@ mod tests {
             .unwrap();
         assert_eq!(status.refresh.status, "pending");
         assert_eq!(status.refresh.change_kinds, vec!["skills".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn skill_change_drains_current_host_and_next_session_gets_fresh_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = workspace_runtime_id(dir.path());
+        let domain = IsolationDomainKey::Workspace(workspace_id.clone());
+        let revision = ProcessEnvRevision::from_bindings(&HashMap::new());
+        let pool = crate::runtime::test_support::test_host_pool();
+        let old = pool
+            .acquire(
+                domain.clone(),
+                revision.clone(),
+                HashMap::new(),
+                Instant::now() + Duration::from_secs(1),
+            )
+            .await
+            .unwrap();
+        let old_generation_id = old.generation.generation_id.clone();
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            pool.clone(),
+        );
+        let workspaces = vec![WatchedWorkspace {
+            workspace_id: workspace_id.clone(),
+            workspace_path: dir.path().to_path_buf(),
+        }];
+        let mut debounce = RefreshDebounce::new(Duration::from_millis(250));
+
+        record_classified_changes(
+            &supervisor.refresh_coordinator(),
+            Some(&supervisor),
+            &mut debounce,
+            &workspaces,
+            None,
+            &dir.path().join(".teamclu/skills/demo-skill/SKILL.md"),
+            Instant::now(),
+        )
+        .await;
+
+        // Invalidation requests a rolling replacement; the old host stays
+        // ready until the next acquire actually publishes that replacement.
+        assert_eq!(old.generation.lifecycle(), HostLifecycle::Ready);
+        let fresh = pool
+            .acquire(
+                domain,
+                revision,
+                HashMap::new(),
+                Instant::now() + Duration::from_secs(1),
+            )
+            .await
+            .unwrap();
+        assert_ne!(fresh.generation.generation_id, old_generation_id);
+        assert_eq!(fresh.generation.lifecycle(), HostLifecycle::Ready);
+        assert_eq!(old.generation.lifecycle(), HostLifecycle::Draining);
     }
 
     #[tokio::test]
@@ -671,6 +757,7 @@ mod tests {
 
         record_classified_changes(
             &coordinator,
+            None,
             &mut debounce,
             &workspaces,
             None,
@@ -710,6 +797,7 @@ mod tests {
         std::fs::write(&opencode, content).unwrap();
         record_classified_changes(
             &leaky,
+            None,
             &mut debounce,
             &workspaces,
             None,
@@ -734,6 +822,7 @@ mod tests {
         std::fs::write(&opencode, content).unwrap();
         record_classified_changes(
             &covered,
+            None,
             &mut debounce,
             &workspaces,
             None,

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -809,14 +809,34 @@ impl RuntimeSupervisor {
         })
     }
 
-    pub fn request_workspace_host_refresh(&self, workspace_id: &str) -> bool {
-        self.host_pool.as_ref().is_some_and(|pool| {
-            pool.invalidate_domain(
-                &crate::runtime::execution_context::IsolationDomainKey::Workspace(
-                    workspace_id.to_string(),
-                ),
-            )
-        })
+    pub async fn request_workspace_host_refresh(
+        &self,
+        workspace_id: &str,
+        workspace_path: &Path,
+    ) -> usize {
+        let Some(pool) = self.host_pool.as_ref() else {
+            return 0;
+        };
+        let stopped = self
+            .agents
+            .lock()
+            .await
+            .stop_idle_runtimes_for_workspace(&workspace_path.to_string_lossy(), workspace_id)
+            .await;
+        pool.invalidate_domain(
+            &crate::runtime::execution_context::IsolationDomainKey::Workspace(
+                workspace_id.to_string(),
+            ),
+        );
+        if stopped > 0 {
+            info!(
+                workspace_id,
+                workspace = %workspace_path.display(),
+                stopped,
+                "detached idle workspace runtimes before pooled host refresh"
+            );
+        }
+        stopped
     }
 
     pub fn request_all_workspace_host_refreshes(&self) -> usize {
@@ -1353,9 +1373,11 @@ impl RuntimeSupervisor {
         let workspace_path_str = workspace_path.to_string_lossy();
         let stopped = if self.host_pool.is_some() {
             if evict_provider_hosts {
-                self.request_workspace_host_refresh(workspace_id);
+                self.request_workspace_host_refresh(workspace_id, workspace_path)
+                    .await
+            } else {
+                0
             }
-            0
         } else {
             let mut manager = self.agents.lock().await;
             let stopped = manager
@@ -1655,7 +1677,9 @@ mod tests {
         )));
         let supervisor = RuntimeSupervisor::new_with_host_pool(manager, pool.clone());
 
-        assert!(supervisor.request_workspace_host_refresh("ws-a"));
+        supervisor
+            .request_workspace_host_refresh("ws-a", Path::new("/tmp/ws-a"))
+            .await;
         let replacement_a = pool
             .acquire(
                 IsolationDomainKey::Workspace("ws-a".into()),
@@ -1758,6 +1782,63 @@ mod tests {
         let ids = manager.agent_ids();
         assert!(ids.iter().any(|id| id == "rt-a"));
         assert!(ids.iter().any(|id| id == "rt-b"));
+    }
+
+    #[tokio::test]
+    async fn pooled_refresh_detaches_idle_route_before_starting_replacement() {
+        let (pool, factory) = service_pool();
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_id = "ws-idle";
+        let workspace_path = workspace.path().to_string_lossy().into_owned();
+        let (revision, lease) = seed_domain(&pool, workspace_id, "before").await;
+        let old_generation = Arc::clone(&lease.generation);
+        let (generation, route_lease) = lease.into_route_parts();
+        let manager = Arc::new(AsyncMutex::new(RuntimeManager::new(
+            RuntimeManager::default_launch_configs(),
+            None,
+        )));
+        {
+            let mut manager = manager.lock().await;
+            manager.add_test_workspace_runtime(
+                "rt-idle",
+                &workspace_path,
+                workspace_id,
+                amux::AgentStatus::Idle,
+            );
+            let handle = manager.get_handle_mut("rt-idle").unwrap();
+            handle.host_generation_id = generation.generation_id.clone();
+            handle.route_lease = Some(route_lease);
+        }
+        let supervisor = RuntimeSupervisor::new_with_host_pool(manager.clone(), pool.clone());
+
+        let outcome = supervisor
+            .reload_workspace(workspace_id, workspace.path(), true)
+            .await
+            .unwrap();
+        assert!(matches!(outcome, ApplyOutcome::RestartRequired));
+        assert!(manager.lock().await.agent_ids().is_empty());
+
+        let replacement = pool
+            .acquire(
+                IsolationDomainKey::Workspace(workspace_id.into()),
+                revision,
+                HashMap::from([("SENTINEL".into(), "before".into())]),
+                std::time::Instant::now() + std::time::Duration::from_secs(1),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(
+            replacement.generation.generation_id,
+            old_generation.generation_id
+        );
+        assert_eq!(factory.starts.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            pool.stats_for(&IsolationDomainKey::Workspace(workspace_id.into()))
+                .draining_generations,
+            0,
+            "the detached idle route must not leave a draining generation"
+        );
     }
 
     #[tokio::test]

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -962,7 +962,10 @@ impl RuntimeSupervisor {
             ready: backend_ready,
             backend,
             current_model,
-            refresh: self.refresh.runtime_refresh_dto(workspace_id).await,
+            refresh: self
+                .refresh
+                .runtime_refresh_dto_for_path(workspace_id, workspace_path)
+                .await,
         })
     }
 
@@ -1129,7 +1132,10 @@ impl RuntimeSupervisor {
             })
             .unwrap_or(0);
 
-        let refresh = self.refresh.runtime_refresh_dto(workspace_id).await;
+        let refresh = self
+            .refresh
+            .runtime_refresh_dto_for_path(workspace_id, workspace_path)
+            .await;
         let mut blockers: Vec<EnvActivationBlocker> = Vec::new();
 
         if !store.blob_readable {

--- a/apps/daemon/src/runtime/team_cloud_config.rs
+++ b/apps/daemon/src/runtime/team_cloud_config.rs
@@ -135,8 +135,7 @@ pub async fn apply_team_cloud_outcome(
             continue;
         };
         let workspace_path = PathBuf::from(&path);
-        let workspace_id =
-            crate::runtime::refresh::refresh_watch::workspace_runtime_id(&workspace_path);
+        let workspace_id = row.id;
         if outcome.env_changed {
             record_refresh(
                 refresh,

--- a/apps/daemon/src/runtime/team_skills.rs
+++ b/apps/daemon/src/runtime/team_skills.rs
@@ -330,8 +330,7 @@ pub async fn apply_team_skill_outcome(
             continue;
         };
         let workspace_path = PathBuf::from(&path);
-        let workspace_id =
-            crate::runtime::refresh::refresh_watch::workspace_runtime_id(&workspace_path);
+        let workspace_id = row.id;
         if let Err(error) = refresh
             .record_change(
                 &workspace_id,

--- a/docs/architecture/team-skills-registry.md
+++ b/docs/architecture/team-skills-registry.md
@@ -312,7 +312,7 @@ MQTT 通道是现成的（`crates/teamclu-types/src/mqtt.rs` 的 `actor_notify()
 
 1. team agent 本来就只能在 daemon 做（§8.1）——管理员的机器上不跑那个 agent。
 2. `runtime/team_cloud_config.rs` 已经把「后台 reconcile + 文件缓存 + 失败不缩水 + 离线可用」这套模式跑通了，skills 是第三个 `reconcile_*`，不是新范式。
-3. **`runtime/refresh_watch.rs` 已经 recursive watch `~/.agents/skills` 并归类成 `RefreshChangeKind::Skills`。** 落盘后当前会话记 pending，**不** idle auto-apply；需显式 Apply / reload 才刷新当前会话。新 session attach 会重新发现磁盘上的 skills，所以远程/无 UI 也不会永远卡在旧目录。
+3. **`runtime/refresh_watch.rs` 已经 recursive watch `~/.agents/skills` 并归类成 `RefreshChangeKind::Skills`。** 落盘后当前会话记 pending，**不** idle auto-apply；需显式 Apply / reload 才刷新当前会话。同时该 workspace 的 OpenCode host 会请求滚动替换：已有 session 继续使用旧 generation，下一次新 session attach 使用新 generation 并重新发现磁盘上的 skills，所以远程/无 UI 也不会永远卡在旧目录。
 
 **代价（本方案唯一的大账）：安装管线要抽成共享 crate。** zip 防穿越解压、frontmatter 回写、lockfile、`permission.skill` 写入现在全在 `apps/desktop/src/commands/{clawhub,team_skills}.rs`，daemon 够不着。`crates/teamclu-types/src/skill_frontmatter.rs` 是这条路的先例。工作量比本设计里所有 UI 加起来都大，排期时不要按「加个定时器」估。
 

--- a/packages/app/src/lib/__tests__/daemon-mcp-tools.test.ts
+++ b/packages/app/src/lib/__tests__/daemon-mcp-tools.test.ts
@@ -10,13 +10,19 @@ vi.mock('@tauri-apps/api/core', () => ({
   }),
 }))
 
-import { getDaemonMcpTools, invalidateDaemonConnection } from '../daemon-local-client'
+import {
+  getDaemonMcpTools,
+  installDaemonTeamMcp,
+  reconcileDaemonTeamCloudConfig,
+  uninstallDaemonTeamMcp,
+  invalidateDaemonConnection,
+} from '../daemon-local-client'
 
 beforeEach(() => {
   invalidateDaemonConnection()
   vi.stubGlobal(
     'fetch',
-    vi.fn(async (url: string) => {
+    vi.fn(async (url: string, init?: RequestInit) => {
       const u = String(url)
       if (u.endsWith('/v1/auth/exchange')) {
         return {
@@ -41,7 +47,21 @@ beforeEach(() => {
           }),
         } as unknown as Response
       }
-      throw new Error(`unexpected fetch ${u}`)
+      if (u.includes('/v1/team/mcp-servers/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ teamId: 'team-x', mcpChanged: true }),
+        } as unknown as Response
+      }
+      if (u.endsWith('/v1/team/cloud-config/reconcile')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ teamId: 'team-x', mcpChanged: true, envChanged: false }),
+        } as unknown as Response
+      }
+      throw new Error(`unexpected fetch ${u} ${init?.method ?? ''}`)
     }),
   )
 })
@@ -60,6 +80,35 @@ describe('getDaemonMcpTools', () => {
   it('appends refresh query when requested', async () => {
     await getDaemonMcpTools('ws-id', { refresh: true })
     const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls
-    expect(calls.some((c) => String(c[0]).includes('/mcp/tools?refresh=1'))).toBe(true)
+    expect(calls.some((c) => String(c[0]).includes('/mcp/tools?refresh=true'))).toBe(true)
+  })
+})
+
+describe('team MCP install/uninstall', () => {
+  it('installs for the daemon actor via PUT', async () => {
+    const result = await installDaemonTeamMcp('weather')
+    expect(result).toEqual({ teamId: 'team-x', mcpChanged: true })
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls
+    const call = calls.find((c) => String(c[0]).includes('/v1/team/mcp-servers/weather/install'))
+    expect(call).toBeTruthy()
+    expect((call?.[1] as RequestInit)?.method).toBe('PUT')
+  })
+
+  it('uninstalls for the daemon actor via DELETE', async () => {
+    const result = await uninstallDaemonTeamMcp('weather')
+    expect(result).toEqual({ teamId: 'team-x', mcpChanged: true })
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls
+    const call = calls.find((c) => String(c[0]).includes('/v1/team/mcp-servers/weather/install'))
+    expect(call).toBeTruthy()
+    expect((call?.[1] as RequestInit)?.method).toBe('DELETE')
+  })
+
+  it('reconciles the daemon team cloud cache after catalog writes', async () => {
+    const result = await reconcileDaemonTeamCloudConfig()
+    expect(result).toEqual({ teamId: 'team-x', mcpChanged: true, envChanged: false })
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls
+    const call = calls.find((c) => String(c[0]).endsWith('/v1/team/cloud-config/reconcile'))
+    expect(call).toBeTruthy()
+    expect((call?.[1] as RequestInit)?.method).toBe('POST')
   })
 })

--- a/packages/app/src/lib/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon-local-client.ts
@@ -1115,11 +1115,51 @@ export async function getDaemonMcpTools(
   workspaceId: string,
   options?: { refresh?: boolean },
 ): Promise<Record<string, DaemonMcpServerProbeResult>> {
-  const query = options?.refresh ? '?refresh=1' : ''
+  const query = options?.refresh ? '?refresh=true' : ''
   const data = await daemonFetchData<{ servers: Record<string, DaemonMcpServerProbeResult> }>(
     `/v1/workspaces/${workspaceId}/mcp/tools${query}`,
   )
   return data.servers
+}
+
+export interface DaemonTeamMcpInstallOutcome {
+  teamId: string
+  mcpChanged: boolean
+}
+
+export interface DaemonTeamCloudReconcileOutcome {
+  teamId: string
+  mcpChanged: boolean
+  envChanged: boolean
+}
+
+/** Re-fetch the daemon actor's team MCP/env cache immediately. */
+export async function reconcileDaemonTeamCloudConfig(): Promise<DaemonTeamCloudReconcileOutcome> {
+  return daemonFetchData<DaemonTeamCloudReconcileOutcome>(
+    '/v1/team/cloud-config/reconcile',
+    { method: 'POST', body: JSON.stringify({}) },
+  )
+}
+
+/**
+ * Install a team MCP server for the daemon's own agent actor (not the desktop
+ * user). The daemon is what spawns and probes the server, so the install must
+ * land on the daemon's actor for the merged MCP view to contain it. The daemon
+ * then re-fetches its team MCP cache before returning.
+ */
+export async function installDaemonTeamMcp(name: string): Promise<DaemonTeamMcpInstallOutcome> {
+  return daemonFetchData<DaemonTeamMcpInstallOutcome>(
+    `/v1/team/mcp-servers/${encodeURIComponent(name)}/install`,
+    { method: 'PUT', body: JSON.stringify({}) },
+  )
+}
+
+/** Uninstall a team MCP server for the daemon's own agent actor. */
+export async function uninstallDaemonTeamMcp(name: string): Promise<DaemonTeamMcpInstallOutcome> {
+  return daemonFetchData<DaemonTeamMcpInstallOutcome>(
+    `/v1/team/mcp-servers/${encodeURIComponent(name)}/install`,
+    { method: 'DELETE' },
+  )
 }
 
 // ─── Runtime ──────────────────────────────────────────────────────────────────

--- a/packages/app/src/stores/__tests__/team-share-mcp-merge.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-mcp-merge.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest'
+import type { TeamMcpServer } from '@/lib/backend/cloud-api/team-mcp'
+import { mergeTeamMcpCatalogAndDaemon } from '../team-share-browser'
+
+const catalogEntry = (installed: boolean): TeamMcpServer => ({
+  id: 'server-1',
+  teamId: 'team-1',
+  name: 'weather',
+  description: null,
+  transport: 'stdio',
+  command: 'weather-mcp',
+  args: [],
+  url: null,
+  env: {},
+  headers: {},
+  createdBy: 'human-actor',
+  updatedBy: 'human-actor',
+  createdAt: '2026-08-14T00:00:00Z',
+  updatedAt: '2026-08-14T00:00:00Z',
+  installed,
+})
+
+describe('mergeTeamMcpCatalogAndDaemon', () => {
+  test('ignores an installation belonging to the desktop user actor', () => {
+    const [item] = mergeTeamMcpCatalogAndDaemon([catalogEntry(true)], {})
+    expect(item.installed).toBe(false)
+  })
+
+  test('marks a server installed only when it is live in the daemon team config', () => {
+    const [item] = mergeTeamMcpCatalogAndDaemon([catalogEntry(false)], {
+      weather: { source: 'team', type: 'local', command: ['weather-mcp'] },
+    })
+    expect(item.installed).toBe(true)
+    expect(item.config.command).toEqual(['weather-mcp'])
+  })
+})

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -93,7 +93,9 @@ import {
   deleteDaemonSkill,
   getDaemonMcp,
   getDaemonMcpTools,
-  materializeDaemonTeamMcp,
+  installDaemonTeamMcp,
+  reconcileDaemonTeamCloudConfig,
+  uninstallDaemonTeamMcp,
   type DaemonMcpServerConfig,
   type DaemonMcpServerProbeResult,
 } from '@/lib/daemon-local-client'
@@ -160,7 +162,7 @@ export interface TeamMcpItem {
    * read-only, since there is no catalog row to edit.
    */
   catalog: TeamMcpServer | null
-  /** Whether *you* have installed it. Uninstalled servers do not run. */
+  /** Whether this machine's daemon actor has installed it. Uninstalled servers do not run. */
   installed: boolean
 }
 
@@ -294,25 +296,6 @@ function workspacePath(): string | null {
 
 function currentTeamId(): string | null {
   return useCurrentTeamStore.getState().team?.id ?? null
-}
-
-/**
- * Nudge the daemon to re-fold team MCP into `opencode.json` after a catalog or
- * install change, so the user sees their action take effect now rather than on
- * the next reconcile tick.
- *
- * Best-effort: the daemon converges on its own schedule regardless, so a
- * failure here is a latency problem, not a correctness one, and must not turn a
- * successful cloud write into a visible error.
- */
-async function materializeTeamMcp(): Promise<void> {
-  const wsPath = workspacePath()
-  if (!wsPath) return
-  try {
-    await materializeDaemonTeamMcp(encodeWorkspaceId(wsPath))
-  } catch {
-    // Intentionally swallowed — see above.
-  }
 }
 
 function frontmatterValue(content: string, key: string): string | null {
@@ -565,19 +548,11 @@ async function listTeamSkills(
  * the daemon side with no catalog row; it stays read-only and is reported as
  * installed, because for those the two concepts never separated.
  */
-async function listTeamMcp(wsPath: string, teamId: string | null): Promise<TeamMcpItem[]> {
-  const wid = encodeWorkspaceId(wsPath)
-  const daemonConfig = await getDaemonMcp(wid).catch(() => ({}) as Record<string, DaemonMcpServerConfig>)
+export function mergeTeamMcpCatalogAndDaemon(
+  catalog: TeamMcpServer[],
+  daemonConfig: Record<string, DaemonMcpServerConfig>,
+): TeamMcpItem[] {
   const daemonTeamEntries = Object.entries(daemonConfig).filter(([, cfg]) => cfg.source === 'team')
-
-  let catalog: TeamMcpServer[] = []
-  if (teamId) {
-    catalog = await getBackend()
-      .teamMcp.listTeamMcpServers(teamId)
-      // A catalog fetch failure must not blank the servers already running —
-      // fall back to the daemon's view rather than showing an empty team.
-      .catch(() => [])
-  }
   const catalogByName = new Map(catalog.map((c) => [c.name, c]))
 
   const items = new Map<string, TeamMcpItem>()
@@ -590,7 +565,10 @@ async function listTeamMcp(wsPath: string, teamId: string | null): Promise<TeamM
       tools: [],
       error: null,
       catalog: entry,
-      installed: entry.installed,
+      // The catalog is fetched with the desktop user's token, while install
+      // mutations target the daemon actor. Only the daemon's live merged config
+      // can answer whether this machine will actually run the server.
+      installed: false,
     })
   }
 
@@ -610,6 +588,21 @@ async function listTeamMcp(wsPath: string, teamId: string | null): Promise<TeamM
   }
 
   return [...items.values()].sort((a, b) => a.name.localeCompare(b.name))
+}
+
+async function listTeamMcp(wsPath: string, teamId: string | null): Promise<TeamMcpItem[]> {
+  const wid = encodeWorkspaceId(wsPath)
+  const daemonConfig = await getDaemonMcp(wid).catch(() => ({}) as Record<string, DaemonMcpServerConfig>)
+
+  let catalog: TeamMcpServer[] = []
+  if (teamId) {
+    catalog = await getBackend()
+      .teamMcp.listTeamMcpServers(teamId)
+      // A catalog fetch failure must not blank the servers already running —
+      // fall back to the daemon's view rather than showing an empty team.
+      .catch(() => [])
+  }
+  return mergeTeamMcpCatalogAndDaemon(catalog, daemonConfig)
 }
 
 /** Raised by the Rust installer instead of overwriting a locally edited pack. */
@@ -858,21 +851,18 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
   },
 
   installMcp: async (name) => {
-    const teamId = currentTeamId()
-    if (!teamId) throw new Error('no current team')
-    await getBackend().teamMcp.installTeamMcpServer(teamId, name)
-    // The daemon mirrors the cloud on a TTL tick; nudge the workspace so the
-    // server appears without waiting it out.
-    await materializeTeamMcp()
-    await get().loadSection('mcp', { force: true })
+    // Install for the daemon's own agent actor, not the desktop user. The
+    // daemon is what spawns and probes the server, so an install on the human's
+    // actor would never reach the merged MCP view and the row would keep
+    // reporting zero tools. The daemon re-fetches its team MCP cache before it
+    // returns, so a plain reload sees the server (and its probed tools).
+    await installDaemonTeamMcp(name)
+    await get().loadSection('mcp', { force: true, withTools: true })
   },
 
   uninstallMcp: async (name) => {
-    const teamId = currentTeamId()
-    if (!teamId) throw new Error('no current team')
-    await getBackend().teamMcp.uninstallTeamMcpServer(teamId, name)
-    await materializeTeamMcp()
-    await get().loadSection('mcp', { force: true })
+    await uninstallDaemonTeamMcp(name)
+    await get().loadSection('mcp', { force: true, withTools: true })
   },
 
   createMcp: async (input) => {
@@ -888,17 +878,17 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     const teamId = currentTeamId()
     if (!teamId) throw new Error('no current team')
     await getBackend().teamMcp.updateTeamMcpServer(teamId, name, patch)
-    await materializeTeamMcp()
-    await get().loadSection('mcp', { force: true })
+    await reconcileDaemonTeamCloudConfig()
+    await get().loadSection('mcp', { force: true, withTools: true })
   },
 
   deleteMcp: async (name) => {
     const teamId = currentTeamId()
     if (!teamId) throw new Error('no current team')
     await getBackend().teamMcp.deleteTeamMcpServer(teamId, name)
-    await materializeTeamMcp()
+    await reconcileDaemonTeamCloudConfig()
     closeTeamShareTabs((t) => t === encodeTeamShareTarget({ kind: 'mcp', name }))
-    await get().loadSection('mcp', { force: true })
+    await get().loadSection('mcp', { force: true, withTools: true })
   },
 
   sharePersonalSkill: async (slug, input) => {

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -1940,12 +1940,32 @@ export function createSupabaseBusinessRepository(options) {
     // --- Directory resolution (frontend supabase delegate parity) ---
 
     async resolveCallerActorForTeam(teamId) {
-      // Resolve the bearer caller's member actor in this team (not any member).
+      // Resolve the bearer caller's actor in this team, member OR agent. The
+      // daemon authenticates as an "agent" actor (its machine-bound identity),
+      // and team MCP / team skills / team env must resolve that actor so the
+      // daemon can install/read them — `resolveCurrentMemberActor` below is
+      // member-only and is reserved for the human member directory.
       const { data: userData, error: userErr } = await supabase.auth.getUser();
       if (userErr) throw userErr;
       const userId = userData?.user?.id;
       if (!userId) return null;
-      return this.resolveCurrentMemberActor(teamId, userId);
+      return this.resolveCurrentActor(teamId, userId);
+    },
+
+    // The caller's single actor in this team regardless of `actor_type`.
+    // `actors_team_user_idx` guarantees at most one actor per (team, user), so
+    // this is unambiguous: a human resolves to their member actor, a daemon
+    // resolves to its agent actor.
+    async resolveCurrentActor(teamId, userId) {
+      const { data, error } = await supabase
+        .from("actors")
+        .select("id")
+        .eq("team_id", teamId)
+        .eq("user_id", userId)
+        .limit(1)
+        .maybeSingle();
+      if (error) throw error;
+      return data ? { id: data.id } : null;
     },
 
     async resolveCurrentMemberActor(teamId, userId) {


### PR DESCRIPTION
## Skills / runtime refresh (amuxd)

- fix(amuxd): refresh skills for new sessions
- fix(amuxd): watch canonical team skill paths
- fix(amuxd): unify refresh workspace identity
- fix(amuxd): reclaim idle runtimes before host refresh

## Team MCP install onto the daemon agent actor

Team MCP servers rendered "0 tools" because the install landed on the
desktop user's actor while the daemon (an "agent" actor) is the one that
spawns and probes them — and two bugs hid that:

- `DeferredBackend` never forwarded `team_mcp_config` / `team_env_secrets`,
  so the daemon's team MCP reconcile always saw an empty cache.
- fc's `resolveCallerActorForTeam` only resolved "member" actors, rejecting
  the daemon's "agent" actor with "not a member of this team".

Changes:

- frontend: install/uninstall/reconcile team MCP through the daemon (its own
  agent actor) and reload tools; `refresh=1 -> refresh=true`.
- daemon: `Backend` install/uninstall_team_mcp + `CloudApiBackend` impl +
  `DeferredBackend` forwarding + `PUT|DELETE /v1/team/mcp-servers/:name/install`.
- fc: `resolveCallerActorForTeam` resolves any actor type (member or agent).

## Deployment

- fc (cloud) auto-deploys on merge (touches `services/fc/**`).
- daemon + frontend need a local rebuild/restart.
