### PR TITLE
fix(pi): 消掉 MCP 冷启动开销，并挡住会话切换毁掉正在跑的 turn

### DIFF
--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -32,6 +32,7 @@
  */
 
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 
 // Loose ExtensionAPI typing: keeps this file dependency-free (the real types
@@ -152,6 +153,18 @@ class McpBridge {
       for (const p of this.pending.values()) p.reject(err);
       this.pending.clear();
     });
+  }
+
+  /** Kill the child and fail anything still in flight. Used when a server's
+   *  command changed or it was removed from the config. */
+  dispose(): void {
+    for (const p of this.pending.values()) p.reject(new Error("MCP bridge disposed"));
+    this.pending.clear();
+    try {
+      this.child.kill();
+    } catch {
+      // Already gone: nothing to do.
+    }
   }
 
   private onData(chunk: string): void {
@@ -276,8 +289,340 @@ function resolveEnv(env: Record<string, unknown> | undefined): Record<string, st
   return out;
 }
 
-/** Spawn one stdio MCP server and register each of its tools as a pi tool that
- *  proxies `tools/call`. Best-effort: a failed server never breaks the others. */
+/**
+ * Process-wide MCP bridge registry.
+ *
+ * # Why this is global rather than per-extension-instance
+ *
+ * pi runs this extension's entry point again for every new session, on the SAME
+ * process. Each run used to spawn a fresh child for every configured server and
+ * leave the previous ones running: a live process tree showed one `pi` with two
+ * complete sets of MCP children, and a third session would have added a third.
+ *
+ * The cost was the whole of the "first message is slow" complaint. Measured on
+ * this machine, `new_session` scaled linearly with the number of npx-based
+ * servers — ~4s each, serially:
+ *
+ *   0 npx servers →   ~50ms
+ *   1 npx server  →  ~4100ms
+ *   3 npx servers → ~11000ms
+ *
+ * Keyed on `globalThis` rather than a module-level `const` because a re-import
+ * would give the module fresh state, and re-import is exactly the case this has
+ * to survive.
+ */
+type McpTool = { name: string; description?: string; inputSchema?: unknown };
+
+type BridgeEntry = {
+  /** Resolves once the child has completed the MCP handshake. Held as a
+   *  promise, not a value, because a cache hit registers tools before the
+   *  child is even spawned. */
+  ready: Promise<McpBridge>;
+  /** The command that produced this bridge; a change means respawn. */
+  signature: string;
+  tools: McpTool[];
+  /** `tools` came from the on-disk cache and no live `tools/list` has
+   *  confirmed it yet. */
+  provisional: boolean;
+};
+
+const BRIDGE_REGISTRY: Map<string, BridgeEntry> = ((globalThis as any).__teamcluMcpBridges ??=
+  new Map());
+
+function bridgeSignature(cmd: string[], env?: Record<string, string>): string {
+  return JSON.stringify([cmd, env ?? {}]);
+}
+
+// ---------------------------------------------------------------------------
+// tools/list cache
+// ---------------------------------------------------------------------------
+
+/**
+ * Why this cache exists.
+ *
+ * pi cannot start a session until the extension's entry point returns, and the
+ * entry point cannot register a server's tools until `tools/list` answers —
+ * which means spawning the child and completing the MCP handshake first. Timed
+ * inside pi on this machine, that is where the cold first message goes:
+ *
+ *   pi boot -> extension loaded    1.05s
+ *   remote-tools bridge            0.03s
+ *   teamclu-introspect bridge      0.03s
+ *   playwright bridge              1.94s
+ *   chrome-control bridge          2.14s
+ *   autoui bridge                  4.25s   <- the whole wait is this one
+ *   entry done                     5.33s
+ *
+ * The tool list is the only part the entry point actually needs, and it barely
+ * changes between runs. Cached on disk it registers instantly and the child is
+ * spawned in the background, taking the slowest server off the critical path.
+ * A tool call that arrives before its child is ready simply awaits `ready`.
+ */
+const TOOL_CACHE_DIR = process.env.TEAMCLU_MCP_TOOL_CACHE_DIR;
+
+/** Stable per-signature filename. FNV-1a: no crypto import, and collisions only
+ *  cost a cache miss because the stored signature is compared on read. */
+function cacheKey(signature: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < signature.length; i++) {
+    h ^= signature.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
+}
+
+function cachePath(label: string, signature: string): string | null {
+  if (!TOOL_CACHE_DIR) return null;
+  const safe = label.replace(/[^A-Za-z0-9._-]/g, "_");
+  return `${TOOL_CACHE_DIR}/${safe}.${cacheKey(signature)}.json`;
+}
+
+function readToolCache(label: string, signature: string): McpTool[] | null {
+  const p = cachePath(label, signature);
+  if (!p) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(p, "utf8"));
+    // The signature is stored as well as hashed: a hash collision, or a stale
+    // file from an older command, must miss rather than register wrong tools.
+    if (parsed?.signature !== signature) return null;
+    const tools = parsed?.tools;
+    if (!Array.isArray(tools) || tools.length === 0) return null;
+    return tools.filter((t: any) => t && typeof t.name === "string");
+  } catch {
+    return null;
+  }
+}
+
+function writeToolCache(label: string, signature: string, tools: McpTool[]): void {
+  const p = cachePath(label, signature);
+  if (!p || tools.length === 0) return;
+  try {
+    fs.writeFileSync(p, JSON.stringify({ signature, tools }));
+  } catch (e) {
+    console.error(`[teamclu] MCP tool cache write failed (${label}): ${e}`);
+  }
+}
+
+/** Spawn the child and complete the MCP handshake. */
+async function handshake(
+  cmd: string[],
+  env?: Record<string, string>,
+): Promise<{ bridge: McpBridge; tools: McpTool[] }> {
+  const bridge = new McpBridge(cmd, env);
+  try {
+    await bridge.request("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "teamclu-pi-extension", version: "1.0.0" },
+    });
+    bridge.notify("notifications/initialized");
+    const listed = await bridge.request("tools/list");
+    return { bridge, tools: listed?.tools ?? [] };
+  } catch (e) {
+    bridge.dispose(); // never leak a child whose handshake failed
+    throw e;
+  }
+}
+
+/**
+ * Get a bridge entry for `label`, spawning only when there is not already one
+ * with the same command. A changed command tears the old child down first —
+ * that is what makes an MCP config edit take effect without restarting pi.
+ *
+ * Returns as soon as a tool list is known: from the live registry, from the
+ * on-disk cache (child spawning in the background), or — only on the very
+ * first run for a given command — from a full handshake.
+ */
+async function ensureBridge(
+  label: string,
+  cmd: string[],
+  env?: Record<string, string>,
+): Promise<BridgeEntry> {
+  const signature = bridgeSignature(cmd, env);
+  const existing = BRIDGE_REGISTRY.get(label);
+  if (existing) {
+    if (existing.signature === signature) return existing;
+    disposeEntry(existing);
+    BRIDGE_REGISTRY.delete(label);
+  }
+
+  const cached = readToolCache(label, signature);
+  if (cached) {
+    const pending = handshake(cmd, env);
+    const entry: BridgeEntry = {
+      ready: pending.then((r) => r.bridge),
+      signature,
+      tools: cached,
+      provisional: true,
+    };
+    BRIDGE_REGISTRY.set(label, entry);
+    // Derived chain, so `entry.ready` keeps its own rejection for awaiting
+    // tool calls instead of being swallowed here.
+    void pending.then(
+      ({ tools }) => {
+        entry.tools = tools;
+        entry.provisional = false;
+        writeToolCache(label, signature, tools);
+      },
+      (e) => {
+        // Drop the entry so the next session retries rather than inheriting a
+        // bridge that will never answer.
+        if (BRIDGE_REGISTRY.get(label) === entry) BRIDGE_REGISTRY.delete(label);
+        console.error(`[teamclu] MCP bridge failed after cached start (${label}): ${e}`);
+      },
+    );
+    return entry;
+  }
+
+  const { bridge, tools } = await handshake(cmd, env);
+  writeToolCache(label, signature, tools);
+  const entry: BridgeEntry = {
+    ready: Promise.resolve(bridge),
+    signature,
+    tools,
+    provisional: false,
+  };
+  BRIDGE_REGISTRY.set(label, entry);
+  return entry;
+}
+
+function disposeEntry(entry: BridgeEntry): void {
+  // The child may still be starting; dispose when it lands either way.
+  void entry.ready.then(
+    (b) => b.dispose(),
+    () => {},
+  );
+}
+
+/** Tear down bridges whose server is no longer configured. */
+function disposeRemovedBridges(configured: Set<string>): void {
+  for (const [label, entry] of [...BRIDGE_REGISTRY]) {
+    if (configured.has(label)) continue;
+    disposeEntry(entry);
+    BRIDGE_REGISTRY.delete(label);
+  }
+}
+
+type McpServerSpec = { command: string[]; environment?: Record<string, unknown> };
+
+/**
+ * Read the workspace MCP config the same way amuxd does when it builds
+ * `TEAMCLU_MCP_SERVERS` (`mcp_servers_from_value` in `pi_rpc/mod.rs`): skip the
+ * daemon's own remote-tools entry, skip `type: "remote"` and `enabled: false`,
+ * and require a non-empty string `command` array.
+ *
+ * Kept deliberately in sync with the Rust side — the env payload is a snapshot
+ * of this file at spawn, so a watcher re-reading it must apply the same rules
+ * or a reload would bridge servers the initial pass rejected.
+ *
+ * Returns `null` when the file cannot be read or parsed, which the caller must
+ * treat as "no information" rather than "no servers". Editors save atomically
+ * (write temp, rename), so a read can land mid-write; answering `{}` there
+ * would tear down every working bridge over a transient half-written file, and
+ * nothing would bring them back until the next edit.
+ */
+function readMcpServers(configPath: string): Record<string, McpServerSpec> | null {
+  let root: any;
+  try {
+    root = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  } catch {
+    return null;
+  }
+  // Valid JSON with no `mcp` section genuinely means "no servers".
+  const mcp = root?.mcp;
+  if (!mcp || typeof mcp !== "object") return {};
+  const out: Record<string, McpServerSpec> = {};
+  for (const [name, raw] of Object.entries(mcp)) {
+    if (name === "amuxd-remote-tools") continue;
+    const spec = raw as any;
+    if (!spec || typeof spec !== "object") continue;
+    if (spec.type === "remote") continue;
+    if (spec.enabled === false) continue;
+    const cmd = spec.command;
+    if (!Array.isArray(cmd) || cmd.length === 0 || !cmd.every((c: unknown) => typeof c === "string")) {
+      continue;
+    }
+    out[name] = { command: cmd as string[], environment: spec.environment };
+  }
+  return out;
+}
+
+/** Bring the live bridges in line with `servers`: drop what is gone, spawn what
+ *  is new, leave unchanged ones alone (the registry decides by signature). */
+async function reconcileBridges(
+  pi: ExtensionAPI,
+  ownTools: Set<string>,
+  servers: Record<string, McpServerSpec>,
+): Promise<void> {
+  const names = Object.keys(servers);
+  // "remote-tools" is bridged from its own env contract, not from this file.
+  disposeRemovedBridges(new Set([...names, "remote-tools"]));
+  await Promise.all(
+    names.map((name) =>
+      bridgeMcpServer(pi, ownTools, name, servers[name].command, resolveEnv(servers[name].environment)),
+    ),
+  );
+}
+
+/**
+ * The extension instance a config reload should register new tools on.
+ *
+ * `pi.registerTool` binds to the instance that is passed to the entry point,
+ * and the entry point runs again per session — so the watcher, which outlives
+ * any one session, cannot capture a `pi` and keep it. It reads the newest one
+ * from here instead, which the entry point refreshes on every run.
+ */
+const WATCH_STATE: { target: { pi: ExtensionAPI; ownTools: Set<string> } | null; started: boolean } =
+  ((globalThis as any).__teamcluMcpWatchState ??= { target: null, started: false });
+
+/**
+ * Watch the workspace MCP config and re-bridge on edit.
+ *
+ * Without this an MCP config change only lands when the pi process itself is
+ * replaced, because `TEAMCLU_MCP_SERVERS` is read once at spawn. Watching the
+ * *directory* rather than the file is deliberate: editors write config atomically
+ * (write temp + rename), which detaches an `fs.watch` bound to the old inode and
+ * silently stops delivering events.
+ *
+ * Idempotent and process-wide: the entry point calls it every session, and only
+ * the first call installs anything.
+ */
+function ensureMcpConfigWatcher(): void {
+  if (WATCH_STATE.started) return;
+  const configPath = process.env.TEAMCLU_MCP_CONFIG_PATH;
+  if (!configPath) return;
+  const dir = path.dirname(configPath);
+  const base = path.basename(configPath);
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    fs.watch(dir, (_event, filename) => {
+      // A rename fires for the temp file too; only the real name matters.
+      if (filename && filename !== base) return;
+      if (timer) clearTimeout(timer);
+      // One save can fire several events (truncate, write, rename).
+      timer = setTimeout(() => {
+        timer = null;
+        const target = WATCH_STATE.target;
+        if (!target) return;
+        const servers = readMcpServers(configPath);
+        if (!servers) {
+          console.error(`[teamclu] MCP config unreadable; keeping current bridges: ${configPath}`);
+          return;
+        }
+        void reconcileBridges(target.pi, target.ownTools, servers).catch((e) =>
+          console.error(`[teamclu] MCP config reload failed: ${e}`),
+        );
+      }, 250);
+    });
+    WATCH_STATE.started = true;
+  } catch (e) {
+    // No watch ⇒ config changes need a pi restart, as before. Not fatal.
+    console.error(`[teamclu] MCP config watch unavailable (${configPath}): ${e}`);
+  }
+}
+
+/** Reuse (or spawn) one stdio MCP server and register its tools on `pi`.
+ *  Best-effort: a failed server never breaks the others. */
 async function bridgeMcpServer(
   pi: ExtensionAPI,
   ownTools: Set<string>,
@@ -286,18 +631,8 @@ async function bridgeMcpServer(
   env?: Record<string, string>,
 ): Promise<void> {
   try {
-    const bridge = new McpBridge(cmd, env);
-    await bridge.request("initialize", {
-      protocolVersion: "2024-11-05",
-      capabilities: {},
-      clientInfo: { name: "teamclu-pi-extension", version: "1.0.0" },
-    });
-    bridge.notify("notifications/initialized");
-
-    const listed = await bridge.request("tools/list");
-    const tools: Array<{ name: string; description?: string; inputSchema?: unknown }> =
-      listed?.tools ?? [];
-    for (const tool of tools) {
+    const entry = await ensureBridge(label, cmd, env);
+    for (const tool of entry.tools) {
       ownTools.add(tool.name);
       pi.registerTool({
         name: tool.name,
@@ -307,6 +642,9 @@ async function bridgeMcpServer(
         // JSON Schema objects at runtime, so pass it through directly.
         parameters: tool.inputSchema ?? { type: "object", properties: {} },
         async execute(_toolCallId, params) {
+          // On a cached start the child may still be handshaking; this is the
+          // only place that waits for it, and only when a tool is actually used.
+          const bridge = await entry.ready;
           const result = await bridge.request("tools/call", {
             name: tool.name,
             arguments: params ?? {},
@@ -382,6 +720,14 @@ export default async function (pi: ExtensionAPI) {
   // 2) The workspace's other MCP servers (from opencode.json `mcp`), bridged so
   //    pi gets the same tools opencode loads natively. Payload:
   //    { "<name>": { "command": [...], "environment": {...} }, ... }
+  // Point the config watcher at this session's instance BEFORE bridging, and
+  // unconditionally — including when nothing is configured yet. Doing it inside
+  // the "has servers" branch below would mean a workspace that starts with no
+  // MCP servers never gets a watcher, so adding the first one would still need
+  // a pi restart, which is the case this exists to remove.
+  WATCH_STATE.target = { pi, ownTools };
+  ensureMcpConfigWatcher();
+
   const serversRaw = process.env.TEAMCLU_MCP_SERVERS;
   if (serversRaw) {
     let servers: Record<string, { command?: unknown; environment?: Record<string, unknown> }>;
@@ -391,10 +737,18 @@ export default async function (pi: ExtensionAPI) {
       console.error(`[teamclu] invalid TEAMCLU_MCP_SERVERS: ${e}`);
       servers = {};
     }
+    const valid: Record<string, McpServerSpec> = {};
     for (const [name, spec] of Object.entries(servers)) {
       const cmd = spec?.command;
-      if (!Array.isArray(cmd) || cmd.length === 0 || cmd.some((c) => typeof c !== "string")) continue;
-      await bridgeMcpServer(pi, ownTools, name, cmd as string[], resolveEnv(spec.environment));
+      if (Array.isArray(cmd) && cmd.length > 0 && cmd.every((c) => typeof c === "string")) {
+        valid[name] = { command: cmd as string[], environment: spec.environment };
+      }
     }
+    // Drops servers that are no longer configured before adding the rest (so an
+    // edit that replaces one server with another does not leave both running),
+    // then spawns in parallel. Only the FIRST session in this process pays a
+    // spawn at all — later ones reuse the registry — but that first one used to
+    // pay for every server end to end, ~4s each for the npx-based ones.
+    await reconcileBridges(pi, ownTools, valid);
   }
 }

--- a/apps/daemon/src/runtime/pi_rpc/events.rs
+++ b/apps/daemon/src/runtime/pi_rpc/events.rs
@@ -95,6 +95,13 @@ async fn handle_event(
         "agent_start" => {
             if let Some(route) = shared.routes.lock().get_mut(&session_id) {
                 route.translate.reset_turn();
+                // A prompt sent while pi was busy is queued as `followUp`, so
+                // it starts its own run after the current one ends — and that
+                // first `agent_end` already cleared `turn_active`. Without
+                // re-arming here the queued run would finish with `close_turn`
+                // bailing on `!turn_active`, leaving the caller without the
+                // Active→Idle for a reply it did receive.
+                route.turn_active = true;
             }
         }
         // A pi agent run can contain multiple turns: each tool-use cycle ends

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -264,8 +264,14 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
         .filter(|p| !p.is_empty())
         .map(str::to_string);
 
+    // Attaching replaces whatever session this child holds, so it is subject to
+    // the same guard as a prompt-driven switch. This is the path a restart's
+    // resume sweep takes, and resuming stored sessions one after another is how
+    // a live turn got aborted out from under its sender.
+    let _switching = proc.switch_lock.lock().await;
     let session_path = match resume_path {
         Some(path) => {
+            guard_switch(&proc, &path).await.map_err(|e| e.to_string())?;
             let switch = proc
                 .client
                 .request(serde_json::json!({"type": "switch_session", "sessionPath": path}))
@@ -291,7 +297,12 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
                 }
             }
         }
-        None => new_session_path(&proc.client).await?,
+        // `new_session` replaces the held session too, so it needs the same
+        // guard — a fresh chat must not abort a turn already running here.
+        None => {
+            guard_switch(&proc, "<new>").await.map_err(|e| e.to_string())?;
+            new_session_path(&proc.client).await?
+        }
     };
 
     // Model catalog + initial model.
@@ -414,6 +425,67 @@ async fn emit_frame(
 /// Ensure `session_id` is the process's active pi session (switch if another
 /// runtime session on the same worktree prompted in between, or after a
 /// respawn).
+/// Is this pi child mid-turn right now?
+///
+/// Asked of pi rather than tracked locally: `Route::turn_active` is this
+/// daemon's own bookkeeping and can disagree with the child (a turn started
+/// through another path, a reply that landed between our reads). `get_state`
+/// is the child's own answer.
+///
+/// A failed or malformed probe reports "busy". Refusing to switch costs a
+/// retry; switching into a live turn destroys it (see `guard_switch`).
+async fn pi_is_busy(proc: &process::PiProcess) -> bool {
+    match proc
+        .client
+        .request(serde_json::json!({"type": "get_state"}))
+        .await
+    {
+        Ok(state) => {
+            let streaming = state
+                .pointer("/data/isStreaming")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            let compacting = state
+                .pointer("/data/isCompacting")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            streaming || compacting
+        }
+        Err(e) => {
+            warn!(error = %e, "pi get_state failed; treating the child as busy");
+            true
+        }
+    }
+}
+
+/// Refuse to switch a pi child that is mid-turn.
+///
+/// pi's RPC channel carries one session at a time, and `switch_session` does
+/// not park the outgoing session — `teardownCurrent` calls `session.abort()`
+/// and disposes it, then re-subscribes to the new one. The aborted turn's
+/// `agent_end` is therefore never emitted, so nothing closes the TeamClu turn
+/// and the sender waits on a reply that no longer exists. Observed exactly
+/// that: four sessions sharing one worktree, a resume of the others while one
+/// was mid-turn, and a chat stuck on "replying" for good.
+///
+/// So a switch is only safe when the child is idle. Callers surface the error
+/// rather than waiting, because the turn holding the child may run for minutes
+/// and the caller (a prompt, a resume sweep) has its own retry.
+async fn guard_switch(proc: &process::PiProcess, target: &str) -> crate::error::Result<()> {
+    if pi_is_busy(proc).await {
+        let holder = proc.active_acp_session.lock().clone().unwrap_or_default();
+        warn!(
+            target_session = target,
+            holding_session = holder,
+            "pi switch refused: child is mid-turn"
+        );
+        return Err(crate::error::AmuxError::Agent(format!(
+            "pi is mid-turn on another session ({holder}); retry when it settles"
+        )));
+    }
+    Ok(())
+}
+
 async fn ensure_active(
     shared: &Arc<Shared>,
     session_id: &str,
@@ -421,13 +493,21 @@ async fn ensure_active(
     session_path: &str,
 ) -> crate::error::Result<Arc<process::PiProcess>> {
     let proc = shared.pool.ensure(shared, worktree)?;
+    // The whole check-then-switch runs under the lock: two prompts for
+    // different sessions could otherwise both see an idle child and both
+    // switch, and the second one would abort the turn the first just started.
+    let _switching = proc.switch_lock.lock().await;
     let is_active = proc.active_acp_session.lock().as_deref() == Some(session_id);
     if !is_active {
+        guard_switch(&proc, session_id).await?;
         proc.client
             .request(serde_json::json!({"type": "switch_session", "sessionPath": session_path}))
             .await?;
         *proc.active_acp_session.lock() = Some(session_id.to_string());
     }
+    // Released before handing the process back: the guard borrows `proc`, and
+    // the switch it protects is already done.
+    drop(_switching);
     Ok(proc)
 }
 
@@ -474,7 +554,25 @@ async fn do_prompt(
     let result = match ensure_active(shared, session_id, &worktree, &session_path).await {
         Ok(proc) => {
             proc.client
-                .request(serde_json::json!({"type": "prompt", "message": message}))
+                .request(serde_json::json!({
+                    "type": "prompt",
+                    "message": message,
+                    // pi refuses a bare prompt while a turn is running:
+                    // "Agent is already processing. Specify streamingBehavior
+                    // ('steer' or 'followUp') to queue the message." Sending
+                    // one anyway is how a message typed mid-reply was lost.
+                    //
+                    // `followUp` runs it after the current turn; `steer` folds
+                    // it into the running one. followUp matches what TeamClu
+                    // already promises elsewhere — a message is its own turn
+                    // with its own reply, and the client's own queue holds
+                    // messages until the stream ends rather than redirecting it.
+                    //
+                    // Always sent, not only when busy: pi reads the field only
+                    // on the streaming branch, so an idle prompt is unaffected
+                    // and no extra `get_state` round trip is needed to decide.
+                    "streamingBehavior": "followUp"
+                }))
                 .await
         }
         Err(e) => Err(e),

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -218,6 +218,20 @@ impl PiProcessPool {
         if let Some(servers) = self.mcp_servers.lock().clone() {
             cmd.env("TEAMCLU_MCP_SERVERS", servers);
         }
+        // Same file `mcp_servers_from_opencode_json` read to build the payload
+        // above. The extension watches it so an edit re-bridges in place; the
+        // env payload alone only ever reflects spawn time, and a config change
+        // otherwise needs the whole pi process to be replaced to take effect.
+        cmd.env(
+            "TEAMCLU_MCP_CONFIG_PATH",
+            std::path::Path::new(worktree).join("opencode.json"),
+        );
+        let tool_cache = mcp_tool_cache_dir();
+        if let Err(e) = std::fs::create_dir_all(&tool_cache) {
+            warn!(path = %tool_cache.display(), error = %e, "pi MCP tool cache dir unavailable");
+        } else {
+            cmd.env("TEAMCLU_MCP_TOOL_CACHE_DIR", &tool_cache);
+        }
         cmd.env(
             "PATH",
             crate::runtime::opencode_http::enriched_spawn_path(
@@ -343,6 +357,15 @@ fn amuxd_pi_dir() -> PathBuf {
 
 pub(crate) fn extension_path() -> PathBuf {
     amuxd_pi_dir().join("extensions").join("teamclu.ts")
+}
+
+/// Where the extension caches each MCP server's `tools/list` result
+/// (`TEAMCLU_MCP_TOOL_CACHE_DIR`). Bridging a server takes seconds — measured
+/// 4.2s for the slowest one here — and pi cannot start a session until the
+/// extension has registered its tools. With a cached list the tools register
+/// at once and the child is spawned in the background instead.
+fn mcp_tool_cache_dir() -> PathBuf {
+    amuxd_pi_dir().join("mcp-tools")
 }
 
 /// Write the embedded extension to its on-disk path (only when its content

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -21,6 +21,11 @@ pub(crate) struct PiProcess {
     /// The acp session id currently active in this process (pi is
     /// one-active-session; prompts for another session switch first).
     pub(crate) active_acp_session: parking_lot::Mutex<Option<String>>,
+    /// Held across "ask pi whether it is busy, then switch it". Those are two
+    /// round trips, and without the lock a second caller can pass the busy
+    /// check with the answer the first one already invalidated — which is the
+    /// exact race the check exists to close.
+    pub(crate) switch_lock: tokio::sync::Mutex<()>,
     child: parking_lot::Mutex<tokio::process::Child>,
     /// Fingerprint of the env this child was spawned with (binary + team
     /// provider + MCP servers + extra env). A prewarmed child is spawned before
@@ -283,6 +288,7 @@ impl PiProcessPool {
         let proc = Arc::new(PiProcess {
             client: client.clone(),
             active_acp_session: parking_lot::Mutex::new(None),
+            switch_lock: tokio::sync::Mutex::new(()),
             child: parking_lot::Mutex::new(child),
             env_fingerprint: self.env_fingerprint(),
         });


### PR DESCRIPTION
两件事，都只碰 `apps/daemon/` 的 pi runtime。

## 1. MCP 桥接从冷启动关键路径上移除

pi 的扩展入口**每建一个会话就重跑一次**，每次都为所有配置的 MCP server 新起一批子进程，且不回收上一批——进程树上曾同时挂着两整套。

进程内实测（`process.uptime()`，相对 pi 自身启动）：

| 阶段 | 耗时 |
|---|---|
| pi 自身启动 → 扩展加载 | 1.05s |
| playwright 桥 | 1.94s |
| chrome-control 桥 | 2.14s |
| **autoui 桥** | **4.25s** ← 长杆 |
| entry 完成 | **5.33s** |

三处改动：

- **桥接注册表**挂在 `globalThis`，按 `(命令, env)` 签名复用；签名变了才重起，配置里删掉的 server 会被拆掉。
- **`tools/list` 落盘缓存**。入口必须等工具注册完才返回，而 pi 要等入口返回才能开会话——所以每个 server 的握手都在关键路径上。缓存命中时工具立即注册、子进程后台握手，工具调用若早于握手完成则在调用点等待。
- **监听配置文件**，编辑后就地重新桥接，不再需要重启 pi。监听目录而非文件（编辑器原子保存会让绑在旧 inode 上的 watch 失效）、250ms 去抖、解析失败保持现状不拆桥。

| | 改前 | 改后 |
|---|---|---|
| 同进程内建会话 | 10–12s | 25–395ms |
| 冷启动桥接 | 3.72s | 26ms |
| MCP 配置改动生效 | 要重启 pi | 就地重新桥接 |

## 2. 切会话前先确认 pi 空闲

pi 的 RPC 通道一次只绑一个 session，**事件流里不带任何 session 标识**（0.81.1 实跑抓包 + 0.84.2 源码双证：`agent_start`/`turn_start`/`agent_settled` 顶层只有 `type`）。daemon 却是照 opencode 的形状写的——池按 worktree 分、routes 按 session id 索引、`active_acp_session` 单槽当寻址依据，于是同目录多会话变成了假的多路复用。

代价不是「事件归错人」，是 `switch_session` 会**直接毁掉正在跑的那轮**：

```js
// pi 的 teardownCurrent
await this.session.abort();
this.session.dispose();
```

同时 rebind 掉订阅，所以那轮的 `agent_end` 永远发不出来——发起方永久停在「正在回复」，而回复本身也没了。实际踩到过：四个会话共用一个目录，重启后 resume 逐个把 pi 切走，正在跑的那个就此消失。

`Route::turn_active` 一直存在，但从来只是 turn 生命周期记账，不是切换闸门。现在三个切换入口（`ensure_active`、`attach` 的 resume 与 new_session 分支）前先问 pi 自己：`get_state` 的 `isStreaming` / `isCompacting`。问 pi 而不是查本地账本，因为本地记录可能与子进程不一致；**探测失败一律判忙**——拒绝切换只让调用方重试，切进活跃 turn 则是把它毁掉。

`switch_lock` 把「查忙 → 切换」串行化：两次 RPC 之间有窗口，两个 prompt 可能都看到 idle、都切。

**同会话追发**改带 `streamingBehavior=followUp`。pi 对正在流式的会话收到裸 prompt 会 throw `Agent is already processing`，消息直接丢失。followUp 让它成为独立的下一轮，与客户端既有队列语义一致。排队那轮开跑时在 `agent_start` 重新置位 `turn_active`，否则它结束时 `close_turn` 会提前返回、调用方收不到 Active→Idle。

## 测试

- `cargo test -p amuxd --locked`：1159 + 842 全绿
- 实测 followUp：`sleep 45` 占住进程期间追发一条，两个 prompt 的答案在同一条回复里返回（`SLEEP-DONE排队成功`），`already processing` 计数 0
- 实测 MCP：`autoui` 置 `enabled:false` → 桥被拆（pi 进程不变）；置回 → 新 pid 起来；写入半截坏 JSON → 五个桥原样保留

## 已知未覆盖

`isStreaming` 只覆盖「模型正在生成」，**不覆盖「工具正在执行」**。工具执行期间的切换仍会发生，我构造的重叠窗口恰好落在那里所以守卫没触发（那次两个会话都正常完成）。纯生成阶段的切换未能实测拦截，只有代码路径推断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)