### PR TITLE
docs(cutover): APNs 那段一直是错的，改成今天核实过的事实

### DIFF
--- a/docs/plans/2026-08-09-teamclu-rebrand-cutover.md
+++ b/docs/plans/2026-08-09-teamclu-rebrand-cutover.md
@@ -95,7 +95,7 @@ Caddy 把证书存成 `0700 root:root`，而 emqx 容器跑在 uid 1000 下，�
 |---|---|---|
 | `ADDITIONAL_REDIRECT_URLS` | 同时包含 `teamclu://auth-callback` **和** `teamclaw://auth-callback` | 桌面深链 scheme 变了；旧版客户端仍回调旧 scheme，两个都留着，等存量清空再删 |
 | `APPLE_CLIENT_IDS` | **追加** `com.teamclu.mobile`（逗号分隔，不要替换） | Apple 的用户 `sub` 按开发者 team 稳定，追加就能延续身份；直接替换会让旧 App 无法登录 |
-| `APNS_TOPIC` | `com.teamclu.mobile` | 注意：旧 App 的 topic 仍是 `tech.teamclaw.mobile`，切了之后旧装机收不到推送 |
+| `APNS_TOPIC` | `com.teamclu.mobile` | **不是改名，是新增**：切换那会儿这台机器根本没配过 APNs，旧装机当时也收不到推送，所以切换不损失任何东西。整套 APNs 变量现已配齐，见下 |
 | `BUCKET` | `teamclu-team`（自建 compose 默认值已改） | OSS bucket 要先建出来，否则新团队开通共享盘直接失败 |
 
 #### 已核实（2026-08-10）：Apple 相关的值不在 `.env` 里
@@ -110,10 +110,31 @@ compose 里的默认值。也就是说改仓库里那个默认值就等于改线
 GOTRUE_EXTERNAL_APPLE_CLIENT_ID = tech.teamclaw.mobile,com.teamclu.mobile
 GOTRUE_EXTERNAL_APPLE_ENABLED   = true
 ADDITIONAL_REDIRECT_URLS        = http://127.0.0.1:*/callback,teamclaw://auth-callback,teamclu://auth-callback
-APNS_TOPIC                      = com.teamclu.mobile
 ```
 
 排查这类问题时以容器里的 env 为准，不要以 `.env` 为准。
+
+（这份清单原先还列了一行 `APNS_TOPIC`，是抄错了容器：compose 的 `auth` 服务下没有任何
+`APNS_*`，`docker compose exec -T auth printenv APNS_TOPIC` 是空的。APNs 变量只发给 `fc`。）
+
+#### iOS 推送：切换时是空的，现在已配齐（2026-08-16 核实）
+
+`services/fc/src/lib/push-deps.ts` 的 `buildApns()` **无条件**构造 APNs 客户端，不做"是否已配置"
+的判断——签名 key 是空字符串时，每次推送都在 APNs 那边失败。所以下面这些必须凑齐，
+只设 `APNS_TOPIC` 等于没配。`deploy/self-host/.env.example` 那句 "all five needed together"
+说的就是这个；compose 的 `fc.environment` 里这六个都写成 `${VAR:-}`，`.env` 不给就是空串。
+
+| 变量 | 从哪来 |
+|---|---|
+| `APNS_PRIVATE_KEY_P8` | 开发者门户的 APNs Auth Key（`.p8` 全文）。**token-based key 是 team 级的，跨 bundle id 通用，不用为改名新建** |
+| `APNS_KEY_ID` | 同一把 key 的 Key ID（文件名 `AuthKey_<KEYID>.p8` 里那段） |
+| `APNS_TEAM_ID` | `43G5A6G9QV`（同 `apps/ios/project.yml` 的 `DEVELOPMENT_TEAM`） |
+| `APNS_TOPIC` | 新 bundle id `com.teamclu.mobile` |
+| `APNS_ENV` | `production`——`AMUXApp/AMUX.entitlements` 是 `aps-environment: production`。留空也默认 production |
+| `PUSH_WEBHOOK_SECRET` | 推送 webhook 的鉴权共享密钥 |
+
+**2026-08-16 复核：六个在 `.env` 里都有值，`docker compose exec -T fc printenv <VAR>` 六个也都非空。**
+所以下面 Apple 一节第 4 步「新建或重新映射 APNs key」不用再做了。复核只看键是否为空，不要把值贴出来。
 
 ### Google OAuth 回调地址（控制台，无 API）
 
@@ -174,7 +195,8 @@ sed -i '' 's|mqtt\.teamclaw-dev\.ucar\.cc|mqtt.teamclu-dev.ucar.cc|' ~/.amuxd/da
 1. 开发者门户建 App ID `com.teamclu.mobile`（+ `.uitests`）
 2. `fastlane match` 重新签发描述文件（`Matchfile` / `Appfile` / `Fastfile` 代码里已改）
 3. ASC 建新 App 记录，重新配 TestFlight 测试组
-4. 新建或重新映射 APNs key
+4. ~~新建或重新映射 APNs key~~ —— 不需要。token-based APNs Auth Key 是 team 级的，跨 bundle id
+   通用；自建机上六个 `APNS_*` / `PUSH_WEBHOOK_SECRET` 已配齐（2026-08-16 核实），见上文
 5. 旧记录 `tech.teamclaw.mobile` 保留但不再发版；已装用户不会自动迁移，需要引导重装
 
 ### Sentry


### PR DESCRIPTION
改名切换清单里关于 iOS 推送的那段一直是错的，而且错的方向在这一周里翻了个面。这个 PR 把它改成今天核实过的事实。

## 原文错在哪

清单第 98 行写着：

> `APNS_TOPIC` → `com.teamclu.mobile`｜注意：旧 App 的 topic 仍是 `tech.teamclaw.mobile`，切了之后旧装机收不到推送

这句从来没成立过。改名切换那会儿这台机器一个 `APNS_*` 都没配，旧装机当时本来就收不到推送 —— 切换不损失任何东西。这条假警告会让人在切换时凭空犹豫。

## 现在反过来了

2026-08-16 复核：六个变量（五个 `APNS_*` 加 `PUSH_WEBHOOK_SECRET`）在 `.env` 和 `fc` 容器里**都已有值**。所以这一节重写成两件事都记下来：当时为什么不用担心，以及现在已经配齐了。

同时列出每个变量的来源，并说明为什么必须凑齐 —— `services/fc/src/lib/push-deps.ts` 的 `buildApns()` 无条件构造 APNs 客户端，不做"是否已配置"判断：

```ts
function buildApns() {
  const jwt = createApnsJwtCache({
    privateKeyP8: APNS_PRIVATE_KEY_P8(),   // 空串也照样构造
    keyId: APNS_KEY_ID(),
    teamId: APNS_TEAM_ID(),
  });
  return createApnsClient({ jwt, topic: APNS_TOPIC(), ... });
}
```

签名 key 是空字符串时，每次推送都在 APNs 那边失败 —— 只设 topic 等于没配。`deploy/self-host/.env.example` 那句 "all five needed together" 说的就是这个。

## 顺带修的两处

- **Apple 一节第 4 步「新建或重新映射 APNs key」划掉。** token-based APNs Auth Key 是 team 级的，跨 bundle id 通用，改名不需要新建 —— 何况已经配好了。原文这一步会让人白跑一趟开发者门户。
- **「已核实（2026-08-10）」那段的 `auth` 容器 env 清单里混进了一行 `APNS_TOPIC`，是抄错了容器。** compose 的 `auth` 服务下没有任何 `APNS_*`，实测 `docker compose exec -T auth printenv APNS_TOPIC` 也是空的。APNs 变量只发给 `fc`。这行留着会把下一个排查的人带偏。

## 核实方式

| 断言 | 怎么验的 |
|---|---|
| `buildApns()` 无条件构造 | `services/fc/src/lib/push-deps.ts:35-46` |
| "all five needed together" | `deploy/self-host/.env.example:109` |
| 六个变量走 `fc` 的 compose allowlist | `deploy/self-host/docker-compose.yml:352-358`，全是 `${VAR:-}` |
| `auth` 没有 `APNS_*` | compose `auth:` 段无匹配 + 线上 `printenv` 为空 |
| `APNS_TEAM_ID` = `43G5A6G9QV` | `apps/ios/project.yml:41` 的 `DEVELOPMENT_TEAM` |
| `APNS_ENV` = `production` | `apps/ios/AMUXApp/AMUX.entitlements` 的 `aps-environment` |
| 线上六个都非空 | `docker compose exec -T fc printenv <VAR>`，只看空/非空，没取值 |

纯文档改动，无代码路径变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
