### PR TITLE
perf(app): 消掉新会话首条消息的重复 pi 冷启动

### DIFF
--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -851,6 +851,8 @@ impl DaemonServer {
         }
 
         let initial_model_override = runtime_start_initial_model_override(start);
+
+
         let outcome = self
             .apply_start_runtime(
                 at,

--- a/packages/app/src/lib/teamclu-rpc.ts
+++ b/packages/app/src/lib/teamclu-rpc.ts
@@ -475,6 +475,7 @@ export interface RuntimeStartArgs {
 }
 
 export async function runtimeStart(args: RuntimeStartArgs): Promise<RuntimeStartResult> {
+
   const response = await sendRequest((req) => {
     const start = create(RuntimeStartRequestSchema, {
       workspaceId: args.workspaceId,

--- a/packages/app/src/lib/teamclu/resolve-runtime-start-workspace.ts
+++ b/packages/app/src/lib/teamclu/resolve-runtime-start-workspace.ts
@@ -1,5 +1,9 @@
 import { getBackend } from '@/lib/backend'
 import { workspacePathsMatch } from '@/stores/session-utils'
+import {
+  cachedDefaultWorkspaceId,
+  rememberDefaultWorkspaceId,
+} from '@/stores/agent-default-workspace-store'
 
 /** Inputs for picking the cloud workspace id sent in runtimeStart. */
 export type AgentWorkspaceLookup = {
@@ -220,6 +224,31 @@ export async function resolveSessionWorkspaceHintForRuntimeStart(args: {
   localDaemonActorId?: string | null
 }): Promise<string> {
   const agentActorIds = [...new Set((args.agentActorIds ?? []).map((id) => id.trim()).filter(Boolean))]
+  const live = await resolveLiveWorkspaceHint(args, agentActorIds)
+  if (live) {
+    // Live value wins and refreshes the cache. This is server-owned config, so
+    // the cache must never get ahead of it (see the store's ordering note).
+    rememberDefaultWorkspaceId(agentActorIds, live)
+    return live
+  }
+  // Nothing live. An empty hint makes the daemon skip its workspace resolver
+  // and start in whatever worktree the client passed — measured cost is a full
+  // backend cold start in the wrong directory, superseded seconds later when
+  // the real id lands. A remembered default from a previous run is a far better
+  // guess than none.
+  return cachedDefaultWorkspaceId(agentActorIds)
+}
+
+/** The original chain: session binding → local path → per-agent lookups. */
+async function resolveLiveWorkspaceHint(
+  args: {
+    teamId: string
+    localWorkspacePath?: string | null
+    sessionId?: string
+    localDaemonActorId?: string | null
+  },
+  agentActorIds: string[],
+): Promise<string> {
 
   const localPath = args.localWorkspacePath?.trim()
   const localDaemonActorId = args.localDaemonActorId?.trim()

--- a/packages/app/src/services/__tests__/outbox-sender.test.ts
+++ b/packages/app/src/services/__tests__/outbox-sender.test.ts
@@ -394,6 +394,40 @@ describe('outbox sender', () => {
     expect(resolveSessionWorkspaceHintForRuntimeStart).toHaveBeenCalled()
   })
 
+  it('local fast path carries a workspace id rather than an empty one', async () => {
+    // It used to hardcode `workspaceId: ''`. The daemon skips its workspace
+    // resolver for an empty id and starts in whatever `worktree` says, so the
+    // slow path landing on a different directory ~0.8s later superseded this
+    // runtime and respawned the backend — a 5.5s cold start paid twice on a
+    // first message, by the very path that exists to be fast.
+    mocks.isTauri.mockReturnValue(true)
+    mocks.getLocalDaemonActorId.mockResolvedValue('agent-local')
+    mocks.runtimeStart.mockResolvedValue({})
+
+    const { useOutboxStore } = await import('@/stores/outbox-store')
+    const { startOutboxSender } = await import('../outbox-sender')
+
+    await useOutboxStore.getState().enqueue({
+      messageId: 'msg-ws-hint',
+      teamId: 'team-1',
+      sessionId: 'session-1',
+      senderActorId: 'member-1',
+      content: '@Local hi',
+      model: 'opencode/qwen',
+      mentionActorIds: ['agent-local'],
+      attachmentUrls: [],
+      workspaceIdHint: 'ws-from-enqueue',
+    })
+    startOutboxSender()
+
+    await vi.waitFor(() => {
+      expect(mocks.runtimeStart).toHaveBeenCalled()
+    })
+    expect(mocks.runtimeStart).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: 'ws-from-enqueue' }),
+    )
+  })
+
   it('local-only mentions: runtimeStart → ingest → MQTT → Cloud; Cloud failure still delivers', async () => {
     const order: string[] = []
     mocks.isTauri.mockReturnValue(true)
@@ -441,6 +475,8 @@ describe('outbox sender', () => {
         targetActorId: 'agent-local',
         sessionId: 'session-1',
         worktree: '/tmp/workspace',
+        // No enqueue hint and a cold cache in this fixture, so still empty —
+        // the fast path degrades to the old behaviour rather than guessing.
         workspaceId: '',
         modelId: 'opencode/qwen',
       }),

--- a/packages/app/src/services/outbox-sender.ts
+++ b/packages/app/src/services/outbox-sender.ts
@@ -125,16 +125,36 @@ async function ensureLocalRuntimeForFastPath(
     // Keep OPENCODE — matches daemon default when config is unavailable.
   }
   const worktree = useWorkspaceStore.getState().workspacePath?.trim() ?? "";
+
+  // Carry a workspace id. This used to send `""`, and the daemon skips its
+  // workspace resolver entirely for an empty one — it starts in whatever
+  // `worktree` says instead. The slow path that follows ~0.8s later DOES
+  // resolve, and when it lands on a different directory the runtime this call
+  // just started is superseded and the backend respawns. Measured on a first
+  // message: `~/TeamClu` here, `~/TeamClu Dev` there, and a 5.5s cold start
+  // paid twice. A path that exists to be fast was costing an extra one.
+  //
+  // Both sources are synchronous, so the fast path stays fast: the enqueue-time
+  // hint is what the slow path already resolved for this very message, and the
+  // cache is this client's last known default for the agent. Still empty means
+  // a cold cache on a first-ever run — same behaviour as before, no regression.
+  const { cachedDefaultWorkspaceId } = await import(
+    "@/stores/agent-default-workspace-store"
+  );
+  const workspaceId =
+    entry.workspaceIdHint?.trim() || cachedDefaultWorkspaceId([localDaemonActorId]);
+
   sessionFlowLog("outbox_sender.local_runtime_start.begin", {
     messageId: entry.messageId,
     sessionId: entry.sessionId,
     teamId: entry.teamId,
     localDaemonActorId,
     worktree: worktree || null,
+    workspaceId: workspaceId || null,
   });
   await runtimeStart({
     targetActorId: localDaemonActorId,
-    workspaceId: "",
+    workspaceId,
     worktree,
     sessionId: entry.sessionId,
     agentType,

--- a/packages/app/src/stores/__tests__/agent-default-workspace-store.test.ts
+++ b/packages/app/src/stores/__tests__/agent-default-workspace-store.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useAgentDefaultWorkspaceStore,
+  cachedDefaultWorkspaceId,
+  rememberDefaultWorkspaceId,
+} from "@/stores/agent-default-workspace-store";
+
+beforeEach(() => {
+  useAgentDefaultWorkspaceStore.getState().clear();
+});
+
+describe("agent default workspace cache", () => {
+  it("remembers a live-resolved id per agent", () => {
+    rememberDefaultWorkspaceId(["agent-a"], "ws-1");
+    rememberDefaultWorkspaceId(["agent-b"], "ws-2");
+    expect(cachedDefaultWorkspaceId(["agent-a"])).toBe("ws-1");
+    expect(cachedDefaultWorkspaceId(["agent-b"])).toBe("ws-2");
+    expect(cachedDefaultWorkspaceId(["agent-unknown"])).toBe("");
+  });
+
+  it("returns the first agent that has a cached id", () => {
+    rememberDefaultWorkspaceId(["agent-b"], "ws-2");
+    expect(cachedDefaultWorkspaceId(["agent-a", "agent-b"])).toBe("ws-2");
+  });
+
+  it("is overwritten by a newer live value", () => {
+    // The whole ordering rule: this is server-owned config, so a later live
+    // answer replaces the cache. If it did not, changing the default workspace
+    // on another device would keep starting runtimes in the old directory.
+    rememberDefaultWorkspaceId(["agent-a"], "ws-old");
+    rememberDefaultWorkspaceId(["agent-a"], "ws-new");
+    expect(cachedDefaultWorkspaceId(["agent-a"])).toBe("ws-new");
+  });
+
+  it("ignores blank writes rather than caching an empty answer", () => {
+    rememberDefaultWorkspaceId(["agent-a"], "ws-1");
+    rememberDefaultWorkspaceId(["agent-a"], "   ");
+    rememberDefaultWorkspaceId([""], "ws-2");
+    expect(cachedDefaultWorkspaceId(["agent-a"])).toBe("ws-1");
+  });
+
+  it("survives across store instances (persisted)", () => {
+    rememberDefaultWorkspaceId(["agent-a"], "ws-1");
+    expect(localStorage.getItem("teamclu.agent-default-workspace.v1")).toBeTruthy();
+  });
+
+  it("returns empty for an empty agent list", () => {
+    expect(cachedDefaultWorkspaceId([])).toBe("");
+  });
+});

--- a/packages/app/src/stores/agent-default-workspace-store.ts
+++ b/packages/app/src/stores/agent-default-workspace-store.ts
@@ -1,0 +1,105 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+/**
+ * Last known `agents.default_workspace_id` per agent, cached on this client.
+ *
+ * # Why
+ *
+ * `runtimeStart.workspaceId` is resolved through a chain that ends at the actor
+ * directory, which loads asynchronously. On a **new session's first send** the
+ * two earlier links are structurally empty — there is no prior runtime for a
+ * session that did not exist a second ago — so if the directory has not landed
+ * yet the whole chain yields `''`.
+ *
+ * An empty `workspaceId` is not harmless. The daemon skips its workspace
+ * resolver entirely for it (`runtime_lifecycle.rs`: the resolver only runs when
+ * `!workspace_id.is_empty()`) and starts in whatever worktree the client passed.
+ * Measured on this machine: the first start went to `~/TeamClu`, and 6.6s later
+ * the resolved id arrived pointing at `~/TeamClu Dev`, which superseded the
+ * runtime and respawned the backend — `pi env changed; respawning`. The 5.5s
+ * cold start was paid twice, which is what makes a first message feel slow.
+ *
+ * # The ordering rule
+ *
+ * **The live value always wins.** This is server-owned config, not a client
+ * preference: someone can change the default workspace in Daemon settings or on
+ * another device. The cache is consulted only when the live chain has nothing,
+ * and is overwritten whenever the live chain produces an answer. Letting it
+ * outrank the live value would trade a slow start for a start in the wrong
+ * directory — a worse failure, and a silent one.
+ *
+ * # What it does not fix
+ *
+ * The very first run on a fresh install still has a cold cache and still takes
+ * the slow path. This removes the repeat, not the first occurrence.
+ */
+
+interface State {
+  /** agent actor id → last known cloud workspace UUID. */
+  byAgentId: Record<string, string>;
+  remember: (agentActorId: string, workspaceId: string) => void;
+  recall: (agentActorId: string) => string;
+  clear: () => void;
+}
+
+export const useAgentDefaultWorkspaceStore = create<State>()(
+  persist(
+    (set, get) => ({
+      byAgentId: {},
+      remember: (agentActorId, workspaceId) => {
+        const agent = agentActorId.trim();
+        const ws = workspaceId.trim();
+        if (!agent || !ws) return;
+        set((s) =>
+          s.byAgentId[agent] === ws
+            ? s
+            : { byAgentId: { ...s.byAgentId, [agent]: ws } },
+        );
+      },
+      recall: (agentActorId) => get().byAgentId[agentActorId.trim()] ?? "",
+      clear: () => set({ byAgentId: {} }),
+    }),
+    {
+      name: "teamclu.agent-default-workspace.v1",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({ byAgentId: s.byAgentId }),
+    },
+  ),
+);
+
+/**
+ * Cached default for the first of `agentActorIds` that has one, or `''`.
+ *
+ * Never throws: this sits on the send path, and a missing cache entry must read
+ * as "no cached answer" rather than break the send it is meant to speed up.
+ */
+export function cachedDefaultWorkspaceId(
+  agentActorIds: readonly string[],
+): string {
+  try {
+    const store = useAgentDefaultWorkspaceStore.getState();
+    for (const id of agentActorIds) {
+      const hit = store.recall(id ?? "");
+      if (hit) return hit;
+    }
+  } catch {
+    /* fall through */
+  }
+  return "";
+}
+
+/** Record a live-resolved workspace id for every agent it applies to. */
+export function rememberDefaultWorkspaceId(
+  agentActorIds: readonly string[],
+  workspaceId: string,
+): void {
+  const ws = workspaceId.trim();
+  if (!ws) return;
+  try {
+    const { remember } = useAgentDefaultWorkspaceStore.getState();
+    for (const id of agentActorIds) remember(id ?? "", ws);
+  } catch {
+    /* a cache write must never break a send */
+  }
+}


### PR DESCRIPTION
## 问题

实测一次新会话首条消息 6.67 秒，其中 5.46 秒（82%）是 pi 进程冷启动 —— 而且这次冷启动是白花的，同一条消息付了两次。

链条：

1. `resolveAgentRuntimeWorkspaceId` 按 caller → 本会话历史 → agent 默认 → agent 拥有 四级取值。新会话第一次发送时，本会话历史结构性为空，agent 默认来自异步加载的 actor 目录、此刻常常还没到，于是 `workspaceId=''` 发了出去。
2. `outbox-sender.ts` 的 `ensureLocalRuntimeForFastPath` 里 workspaceId 干脆是硬编码的空字符串。
3. daemon 侧 `runtime_lifecycle.rs:175` 只在 `!workspace_id.is_empty()` 时才走 workspace resolver，空的就直接用客户端传的 worktree。

daemon 侧临时埋点 + 前端调用栈实测：

```
10:27:46.488  outbox-sender.ts:95   workspaceId=""         worktree=~/TeamClu
10:27:47.302  session-create.ts:428 workspaceId=a9c9bba4   → 解析出 ~/TeamClu Dev
              → worktree 不同 → superseded + pi env changed; respawning
```

这条路径叫 fast path，实际让首条消息多慢一次冷启动。也解释了预热为何没帮上：预热打在 `~/TeamClu Dev`（正确目标），而这次起在了 `~/TeamClu`。

## 修法

**`perf(app)`：按 agent 缓存最后一次实时解析出的 default workspace id**，实时链路全空时用它兜底。

优先级刻意写死：实时值永远优先，且命中即回写缓存。这是服务端拥有的配置，不是客户端偏好 —— 缓存若能盖过实时值，在别的设备改了默认工作区之后，这台机器会把 runtime 起到错的目录，用一个慢换来一个静默的错，更糟。

**`fix(outbox)`：本地快速路径带上 workspace**。用 `entry.workspaceIdHint`（入队时就捕获的、正是慢路径会解析出的那个），退化到本机缓存的 agent 默认 workspace。两者都是同步的，fast path 仍然快。两者都空时保持原行为（全新安装第一次），不猜。

## 范围

不解决全新安装的第一次（缓存是冷的），消除的是此后每一次的重复。

既有测试 `'local-only mentions'` 断言过 `workspaceId: ''`，把旧行为钉住了 —— 更新为「无 hint + 冷缓存时才为空」，并新增一条钉住有 hint 时必须带上。

## 验证

- `vitest run outbox-sender.test.ts agent-default-workspace-store.test.ts` — 18 passed
- `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
