### PR TITLE
feat(model): ADR-0007 P3 —— 模型偏好搬到客户端（桌面 + iOS）

### DIFF
--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/Models/AgentModelResolution.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/Models/AgentModelResolution.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Which model an agent runs on in a session, and whether anybody actually
+/// chose it.
+///
+/// iOS's counterpart to the desktop's `selectAgentModel`. Kept as a pure
+/// function so the ordering is testable without a ModelContext, a live MQTT
+/// retain, or a sheet loader — the ordering is the part that has a wrong answer
+/// available, and it had one: the attachment used to outrank the participant
+/// row, so a client-side memory could shadow the cloud's authoritative value.
+public enum AgentModelResolution {
+    public enum Source: Equatable {
+        /// `session_participants.model` — the authority (ADR-0005), written by
+        /// the daemon, the only component that sees what the runtime settled on.
+        case participant
+        /// The live attachment's `current_model` from the retain: a fact about
+        /// what is bound right now, but a *derived* one.
+        case live
+        /// This install's MRU. A past explicit choice, so good enough to start a
+        /// new chat on — but never a statement about this session.
+        case clientMRU
+        /// Nothing chose anything. The caller must ask before running: letting
+        /// the daemon pick is exactly the implicit resolution ADR-0007 removes.
+        case unpicked
+    }
+
+    public struct Resolved: Equatable {
+        public let modelID: String?
+        public let source: Source
+
+        public init(modelID: String?, source: Source) {
+            self.modelID = modelID
+            self.source = source
+        }
+
+        /// Does a human still need to confirm this before anything runs?
+        public var requiresExplicitPick: Bool { source == .unpicked }
+    }
+
+    /// Resolve in authority order.
+    ///
+    /// `participantModel` first because it is the fact itself; `liveModel`
+    /// second because it is the same fact observed from the runtime; the MRU
+    /// last because it describes this install's habits, not this session.
+    ///
+    /// `mruCandidate` is expected to have already been checked against the live
+    /// catalog by the caller (`ClientModelMRU.firstAvailable`) — a remembered
+    /// model the catalog no longer offers is not a candidate at all.
+    public static func resolve(
+        participantModel: String?,
+        liveModel: String?,
+        mruCandidate: String?
+    ) -> Resolved {
+        if let model = participantModel?.nonBlank {
+            return Resolved(modelID: model, source: .participant)
+        }
+        if let model = liveModel?.nonBlank {
+            return Resolved(modelID: model, source: .live)
+        }
+        if let model = mruCandidate?.nonBlank {
+            return Resolved(modelID: model, source: .clientMRU)
+        }
+        return Resolved(modelID: nil, source: .unpicked)
+    }
+}
+
+private extension String {
+    /// The string with whitespace trimmed, or nil when nothing is left.
+    var nonBlank: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/Models/ClientModelMRU.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/Models/ClientModelMRU.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// This install's most-recently-used models — the answer to "which model should
+/// a new chat start on?"
+///
+/// # Why this is here and not in the daemon
+///
+/// It used to live in amuxd (`config::model_mru`), put there because gateway and
+/// cron runtimes start inside the daemon and can never read a client's storage.
+/// That held, but it made amuxd the owner of a *preference*, and a preference is
+/// something a mis-picking client can poison: a cold-start client wrote whatever
+/// the catalog listed first, the daemon recorded that run, and every later new
+/// session inherited it.
+///
+/// ADR-0007 removes the need: cron jobs and gateway channels now pin a model when
+/// they are created, so nothing inside the daemon has to guess, and the MRU goes
+/// back to being a per-client convenience.
+///
+/// # Why the key is (backend, team)
+///
+/// Model ids are backend-local — an opencode id means nothing to pi — so the
+/// backend must be in the key or a backend switch leaves a list that can never
+/// match. Team is in the key because it is the only thing catalogs actually vary
+/// by: auditing 15 worktrees on one device traced every difference to the team's
+/// LiteLLM gateway models or to probe staleness, none to the directory
+/// (#742 decision 3).
+///
+/// # Scope
+///
+/// Per install, deliberately. ADR-0007 accepts that iOS and the desktop each keep
+/// their own list and never converge — this is a preference, not a promise.
+///
+/// `@unchecked Sendable` is safe: the only stored property is `UserDefaults`,
+/// which Apple documents as thread-safe.
+public final class ClientModelMRU: @unchecked Sendable {
+    /// Matches the desktop's cap and the daemon's before it. Long enough to
+    /// survive a couple of dead providers, short enough to stay comprehensible.
+    static let maxRecent = 10
+
+    private static let storageKey = "amux.client-model-mru.v1"
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    private static func key(backend: String, teamID: String) -> String {
+        "\(backend.trimmed)::\(teamID.trimmed)"
+    }
+
+    /// Recent models for `(backend, team)`, most recently used first.
+    public func recent(backend: String, teamID: String) -> [String] {
+        let backend = backend.trimmed
+        let teamID = teamID.trimmed
+        guard !backend.isEmpty, !teamID.isEmpty else { return [] }
+        return stored()[Self.key(backend: backend, teamID: teamID)] ?? []
+    }
+
+    /// Record a model the user actually chose.
+    ///
+    /// Only **explicit** picks belong here. Recording an auto-selection turns a
+    /// cold-start guess into a preference that outlives the guess — the loop
+    /// ADR-0007 exists to break.
+    public func record(backend: String, teamID: String, model: String) {
+        let backend = backend.trimmed
+        let teamID = teamID.trimmed
+        let model = model.trimmed
+        guard !backend.isEmpty, !teamID.isEmpty, !model.isEmpty else { return }
+
+        let mapKey = Self.key(backend: backend, teamID: teamID)
+        var map = stored()
+        let next = Self.promote(map[mapKey] ?? [], model)
+        guard next != map[mapKey] else { return }
+        map[mapKey] = next
+        defaults.set(map, forKey: Self.storageKey)
+    }
+
+    /// First remembered model the live catalog still offers, or `nil`.
+    ///
+    /// This is why the MRU is a list rather than one value: the thing a single
+    /// "last used" names can stop working — a provider logged out, a key expired,
+    /// a model retired — and pinning something that cannot run is worse than
+    /// falling through. Mirrors the daemon's `model_mru::first_available`.
+    ///
+    /// An empty `available` means the catalog has not arrived, NOT that nothing
+    /// is runnable, so it answers `nil` rather than guessing.
+    public func firstAvailable(
+        backend: String,
+        teamID: String,
+        available: [String]
+    ) -> String? {
+        guard !available.isEmpty else { return nil }
+        let offered = Set(available.map(\.trimmed).filter { !$0.isEmpty })
+        return recent(backend: backend, teamID: teamID).first { offered.contains($0) }
+    }
+
+    /// Drop everything. Test seam, and the hook a future "forget my preferences"
+    /// would use.
+    public func clear() {
+        defaults.removeObject(forKey: Self.storageKey)
+    }
+
+    private func stored() -> [String: [String]] {
+        defaults.dictionary(forKey: Self.storageKey) as? [String: [String]] ?? [:]
+    }
+
+    /// Move `model` to the front, capped. Returns the input unchanged when it is
+    /// already the head, so the caller can skip the write.
+    static func promote(_ recent: [String], _ model: String) -> [String] {
+        guard recent.first != model else { return recent }
+        return Array(([model] + recent.filter { $0 != model }).prefix(maxRecent))
+    }
+}
+
+private extension String {
+    var trimmed: String { trimmingCharacters(in: .whitespacesAndNewlines) }
+}

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/ViewModels/SessionDetailViewModel.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/ViewModels/SessionDetailViewModel.swift
@@ -163,6 +163,10 @@ public final class SessionDetailViewModel {
     private let mqtt: MQTTService
     private let hub: MQTTMessageHub
     private let teamID: String
+
+    /// This install's model MRU (ADR-0007). Consulted only as the last resort
+    /// before asking the user — never above `session_participants.model`.
+    private let clientModelMRU = ClientModelMRU()
     private let peerId: String
     private let teamcluService: TeamcluService?
     private let connectedAgentsStore: ConnectedAgentsStore?
@@ -714,7 +718,15 @@ public final class SessionDetailViewModel {
                 ),
                 lifecycleState: Self.chipState(forAttachment: att),
                 availableModels: models.isEmpty ? agent.availableModels : models,
-                currentModel: att.currentModel ?? agent.currentModel,
+                // Participant row first: it is the authoritative per-session
+                // model (ADR-0005), and the attachment's value is the same fact
+                // observed from the runtime. Reversed order let a stale or
+                // preference-derived attachment value shadow the truth.
+                currentModel: AgentModelResolution.resolve(
+                    participantModel: agent.currentModel,
+                    liveModel: att.currentModel,
+                    mruCandidate: nil
+                ).modelID,
                 workspaceID: agent.workspaceID,
                 backendType: Self.backendType(forAgentTypeRaw: att.agentType)
             )
@@ -866,13 +878,40 @@ public final class SessionDetailViewModel {
     /// the sole agent's when the chip bar has no explicit selection. Nil when
     /// no agent is attached — the session is cold and the daemon picks on spawn.
     public var currentModelForSendTarget: String? {
-        if let selected = agentChipSelection.first,
-           let model = attachment(forAgentActorID: selected)?.currentModel,
-           !model.isEmpty {
-            return model
+        resolvedModelForSendTarget?.modelID
+    }
+
+    /// The send target's model *and* whether anyone chose it.
+    ///
+    /// The doc on the old version said a nil answer was fine because "the daemon
+    /// picks on spawn". That is precisely the implicit resolution ADR-0007
+    /// removes: the daemon's pick came from a device MRU, so the same chat could
+    /// answer on a different model depending on where the daemon started. A nil
+    /// answer now means **ask the user**, and `requiresExplicitPick` says so.
+    public var resolvedModelForSendTarget: AgentModelResolution.Resolved? {
+        let targetID: String?
+        if let selected = agentChipSelection.first {
+            targetID = selected
+        } else if memberSheetAgents.count == 1 {
+            targetID = memberSheetAgents.first?.id
+        } else {
+            targetID = nil
         }
-        guard memberSheetAgents.count == 1, let only = memberSheetAgents.first else { return nil }
-        return attachment(forAgentActorID: only.id)?.currentModel
+        guard let actorID = targetID else { return nil }
+
+        let agentRow = memberSheetAgents.first(where: { $0.id == actorID })
+        let att = attachment(forAgentActorID: actorID)
+        return AgentModelResolution.resolve(
+            participantModel: agentRow?.currentModel,
+            liveModel: att?.currentModel,
+            // Checked against this agent's live catalog: a remembered model the
+            // catalog no longer offers is not a candidate (ClientModelMRU).
+            mruCandidate: clientModelMRU.firstAvailable(
+                backend: agentRow?.backendType ?? "",
+                teamID: teamID,
+                available: availableModels(forAgentActorID: actorID)
+            )
+        )
     }
 
     /// Union of human + agent actor ids currently in the session, used by

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/ViewModels/SessionListViewModel.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/ViewModels/SessionListViewModel.swift
@@ -29,9 +29,6 @@ public final class SessionListViewModel {
     // Retained so markAsRead() can mutate the same context the ingest uses.
     private var ctx: ModelContext?
 
-    /// This install's model MRU (ADR-0007). Replaces `presence.default_model`,
-    /// which was the daemon's — see `syncActorPresence`.
-    private let clientModelMRU = ClientModelMRU()
 
     public init() {}
 
@@ -129,7 +126,7 @@ public final class SessionListViewModel {
                               let presence = try? ProtoMQTTCoder.decode(
                                   Amux_ActorPresence.self, from: msg.payload
                               ) else { continue }
-                        self.syncActorPresence(presence, actorID: actorID, teamID: teamID, modelContext: ctx)
+                        self.syncActorPresence(presence, actorID: actorID, modelContext: ctx)
                         self.refreshSessions(modelContext: ctx)
                     }
                 }
@@ -414,26 +411,9 @@ public final class SessionListViewModel {
     ///
     /// A session absent from `live_sessions` is pruned rather than left behind:
     /// absence is the signal for "cold", i.e. the next message will spawn.
-    /// Backend id the MRU is keyed by — the same vocabulary the daemon and the
-    /// desktop use, since the list has to survive a round trip through ids that
-    /// only mean anything within one backend.
-    private func backendKey(for presence: Amux_ActorPresence) -> String {
-        switch presence.activeAgentType {
-        case .opencode: return "opencode"
-        case .pi: return "pi"
-        case .cursor: return "cursor"
-        case .claudeCode: return "claude"
-        // `codex` has no backend module (a codex-configured daemon runs
-        // opencode), and `unknown` names nothing. Both yield an empty key,
-        // which `ClientModelMRU` treats as "no history" rather than guessing.
-        case .codex, .unknown, .UNRECOGNIZED: return ""
-        }
-    }
-
     private func syncActorPresence(
         _ presence: Amux_ActorPresence,
         actorID: String,
-        teamID: String,
         modelContext: ModelContext
     ) {
         // Device-level, not per-worktree (#742). Looking catalogs up by
@@ -448,23 +428,18 @@ public final class SessionListViewModel {
         // Older daemons send only the per-worktree copies; fall back to the
         // first so this build keeps working against one until it is upgraded.
         let legacyCatalog = presence.worktrees.first
-        // This install's own MRU first (ADR-0007). `presence.default_model` is
-        // the *daemon's* MRU head, which that ADR removes — it stays in the
-        // chain only until the field stops being sent, so a daemon that still
-        // fills it keeps working meanwhile.
+        // NOTE: no client MRU here on purpose. An attachment records *facts*
+        // about a live runtime; folding this install's preference in made it
+        // outrank `session_participants.model` at every read site, which is
+        // backwards (ADR-0005/0007). The MRU is applied at resolve time
+        // instead — see `AgentModelResolution`.
         //
-        // Checked against `deviceModels` for the same reason the list exists:
-        // a remembered model the catalog no longer offers must fall through
-        // rather than be shown as this session's model.
-        let clientDefaultModel = clientModelMRU.firstAvailable(
-            backend: backendKey(for: presence),
-            teamID: teamID,
-            available: deviceModels.map(\.id)
-        )
-        let deviceDefaultModel = clientDefaultModel
-            ?? (presence.defaultModel.isEmpty
-                ? (legacyCatalog?.defaultModel ?? "")
-                : presence.defaultModel)
+        // `presence.default_model` is the daemon's own MRU head, which ADR-0007
+        // removes; it stays only until the field stops being sent, so a daemon
+        // that still fills it keeps working meanwhile.
+        let deviceDefaultModel = presence.defaultModel.isEmpty
+            ? (legacyCatalog?.defaultModel ?? "")
+            : presence.defaultModel
         let deviceCommands = presence.availableCommands.isEmpty
             ? (legacyCatalog?.availableCommands ?? [])
             : presence.availableCommands

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/ViewModels/SessionListViewModel.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/ViewModels/SessionListViewModel.swift
@@ -29,6 +29,10 @@ public final class SessionListViewModel {
     // Retained so markAsRead() can mutate the same context the ingest uses.
     private var ctx: ModelContext?
 
+    /// This install's model MRU (ADR-0007). Replaces `presence.default_model`,
+    /// which was the daemon's — see `syncActorPresence`.
+    private let clientModelMRU = ClientModelMRU()
+
     public init() {}
 
     public func start(mqtt: MQTTService,
@@ -125,7 +129,7 @@ public final class SessionListViewModel {
                               let presence = try? ProtoMQTTCoder.decode(
                                   Amux_ActorPresence.self, from: msg.payload
                               ) else { continue }
-                        self.syncActorPresence(presence, actorID: actorID, modelContext: ctx)
+                        self.syncActorPresence(presence, actorID: actorID, teamID: teamID, modelContext: ctx)
                         self.refreshSessions(modelContext: ctx)
                     }
                 }
@@ -410,9 +414,26 @@ public final class SessionListViewModel {
     ///
     /// A session absent from `live_sessions` is pruned rather than left behind:
     /// absence is the signal for "cold", i.e. the next message will spawn.
+    /// Backend id the MRU is keyed by — the same vocabulary the daemon and the
+    /// desktop use, since the list has to survive a round trip through ids that
+    /// only mean anything within one backend.
+    private func backendKey(for presence: Amux_ActorPresence) -> String {
+        switch presence.activeAgentType {
+        case .opencode: return "opencode"
+        case .pi: return "pi"
+        case .cursor: return "cursor"
+        case .claudeCode: return "claude"
+        // `codex` has no backend module (a codex-configured daemon runs
+        // opencode), and `unknown` names nothing. Both yield an empty key,
+        // which `ClientModelMRU` treats as "no history" rather than guessing.
+        case .codex, .unknown, .UNRECOGNIZED: return ""
+        }
+    }
+
     private func syncActorPresence(
         _ presence: Amux_ActorPresence,
         actorID: String,
+        teamID: String,
         modelContext: ModelContext
     ) {
         // Device-level, not per-worktree (#742). Looking catalogs up by
@@ -427,9 +448,23 @@ public final class SessionListViewModel {
         // Older daemons send only the per-worktree copies; fall back to the
         // first so this build keeps working against one until it is upgraded.
         let legacyCatalog = presence.worktrees.first
-        let deviceDefaultModel = presence.defaultModel.isEmpty
-            ? (legacyCatalog?.defaultModel ?? "")
-            : presence.defaultModel
+        // This install's own MRU first (ADR-0007). `presence.default_model` is
+        // the *daemon's* MRU head, which that ADR removes — it stays in the
+        // chain only until the field stops being sent, so a daemon that still
+        // fills it keeps working meanwhile.
+        //
+        // Checked against `deviceModels` for the same reason the list exists:
+        // a remembered model the catalog no longer offers must fall through
+        // rather than be shown as this session's model.
+        let clientDefaultModel = clientModelMRU.firstAvailable(
+            backend: backendKey(for: presence),
+            teamID: teamID,
+            available: deviceModels.map(\.id)
+        )
+        let deviceDefaultModel = clientDefaultModel
+            ?? (presence.defaultModel.isEmpty
+                ? (legacyCatalog?.defaultModel ?? "")
+                : presence.defaultModel)
         let deviceCommands = presence.availableCommands.isEmpty
             ? (legacyCatalog?.availableCommands ?? [])
             : presence.availableCommands

--- a/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/AgentModelResolutionTests.swift
+++ b/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/AgentModelResolutionTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import AMUXCore
+
+final class AgentModelResolutionTests: XCTestCase {
+    func testParticipantOutranksEverything() {
+        // The inversion this ordering exists to prevent: the attachment used to
+        // win, so a client-side memory folded into it could shadow the cloud's
+        // authoritative value for the session.
+        let r = AgentModelResolution.resolve(
+            participantModel: "cloud/authoritative",
+            liveModel: "live/model",
+            mruCandidate: "mru/model"
+        )
+        XCTAssertEqual(r.modelID, "cloud/authoritative")
+        XCTAssertEqual(r.source, .participant)
+        XCTAssertFalse(r.requiresExplicitPick)
+    }
+
+    func testLiveWinsWhenParticipantIsSilent() {
+        let r = AgentModelResolution.resolve(
+            participantModel: nil,
+            liveModel: "live/model",
+            mruCandidate: "mru/model"
+        )
+        XCTAssertEqual(r.modelID, "live/model")
+        XCTAssertEqual(r.source, .live)
+    }
+
+    func testMRUIsTheLastResortBeforeAsking() {
+        let r = AgentModelResolution.resolve(
+            participantModel: nil,
+            liveModel: nil,
+            mruCandidate: "mru/model"
+        )
+        XCTAssertEqual(r.modelID, "mru/model")
+        XCTAssertEqual(r.source, .clientMRU)
+        // A past explicit choice needs no re-confirmation.
+        XCTAssertFalse(r.requiresExplicitPick)
+    }
+
+    func testNothingChosenDemandsAPick() {
+        // Previously this case let the daemon pick on spawn — the implicit
+        // resolution ADR-0007 removes.
+        let r = AgentModelResolution.resolve(
+            participantModel: nil,
+            liveModel: nil,
+            mruCandidate: nil
+        )
+        XCTAssertNil(r.modelID)
+        XCTAssertEqual(r.source, .unpicked)
+        XCTAssertTrue(r.requiresExplicitPick)
+    }
+
+    func testBlankStringsCountAsAbsent() {
+        // Empty and whitespace-only values arrive from proto defaults and from
+        // trimmed user input; treating them as answers pins a nameless model.
+        let r = AgentModelResolution.resolve(
+            participantModel: "",
+            liveModel: "   ",
+            mruCandidate: "\n"
+        )
+        XCTAssertEqual(r.source, .unpicked)
+    }
+
+    func testTrimsTheAnswerItReturns() {
+        let r = AgentModelResolution.resolve(
+            participantModel: "  spaced/model  ",
+            liveModel: nil,
+            mruCandidate: nil
+        )
+        XCTAssertEqual(r.modelID, "spaced/model")
+    }
+}

--- a/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/ClientModelMRUTests.swift
+++ b/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/ClientModelMRUTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import AMUXCore
+
+/// Each test gets its own suite name so nothing leaks between them or into the
+/// real defaults.
+private func makeDefaults(_ name: String = UUID().uuidString) -> UserDefaults {
+    UserDefaults(suiteName: name)!
+}
+
+final class ClientModelMRUTests: XCTestCase {
+    func testMovesAnExistingEntryToTheFront() {
+        let mru = ClientModelMRU(defaults: makeDefaults())
+        mru.record(backend: "opencode", teamID: "team-1", model: "a/1")
+        mru.record(backend: "opencode", teamID: "team-1", model: "b/2")
+        mru.record(backend: "opencode", teamID: "team-1", model: "a/1")
+        XCTAssertEqual(mru.recent(backend: "opencode", teamID: "team-1"), ["a/1", "b/2"])
+    }
+
+    func testKeepsBackendsApart() {
+        // Model ids are backend-local: a pi id handed to opencode is not a
+        // degraded answer, it is a wrong one.
+        let mru = ClientModelMRU(defaults: makeDefaults())
+        mru.record(backend: "opencode", teamID: "t", model: "opencode/big-pickle")
+        mru.record(backend: "pi", teamID: "t", model: "anthropic/claude-sonnet-4-6")
+
+        XCTAssertEqual(mru.recent(backend: "opencode", teamID: "t"), ["opencode/big-pickle"])
+        XCTAssertEqual(mru.recent(backend: "pi", teamID: "t"), ["anthropic/claude-sonnet-4-6"])
+        XCTAssertEqual(mru.recent(backend: "cursor", teamID: "t"), [])
+    }
+
+    func testKeepsTeamsApart() {
+        // Catalogs vary by team (the team's LiteLLM gateway models) — the only
+        // variable #742 could attribute a catalog difference to.
+        let mru = ClientModelMRU(defaults: makeDefaults())
+        mru.record(backend: "opencode", teamID: "team-1", model: "gw/one")
+        mru.record(backend: "opencode", teamID: "team-2", model: "gw/two")
+
+        XCTAssertEqual(mru.recent(backend: "opencode", teamID: "team-1"), ["gw/one"])
+        XCTAssertEqual(mru.recent(backend: "opencode", teamID: "team-2"), ["gw/two"])
+    }
+
+    func testIgnoresBlankInputs() {
+        let mru = ClientModelMRU(defaults: makeDefaults())
+        mru.record(backend: "opencode", teamID: "t", model: "   ")
+        mru.record(backend: "", teamID: "t", model: "a/1")
+        mru.record(backend: "opencode", teamID: "", model: "a/1")
+        XCTAssertEqual(mru.recent(backend: "opencode", teamID: "t"), [])
+    }
+
+    func testCapsTheList() {
+        let mru = ClientModelMRU(defaults: makeDefaults())
+        for i in 0..<15 {
+            mru.record(backend: "opencode", teamID: "t", model: "p/\(i)")
+        }
+        let recent = mru.recent(backend: "opencode", teamID: "t")
+        XCTAssertEqual(recent.count, ClientModelMRU.maxRecent)
+        XCTAssertEqual(recent.first, "p/14")
+    }
+
+    func testSurvivesAcrossInstances() {
+        // The whole point of persisting: a relaunch must remember.
+        let defaults = makeDefaults()
+        ClientModelMRU(defaults: defaults).record(backend: "opencode", teamID: "t", model: "a/1")
+        XCTAssertEqual(ClientModelMRU(defaults: defaults).recent(backend: "opencode", teamID: "t"), ["a/1"])
+    }
+
+    func testFirstAvailableSkipsRetiredEntries() {
+        // The reason it is a list: "last used" was retired, so the next usable
+        // entry wins rather than pinning something that cannot run.
+        let mru = ClientModelMRU(defaults: makeDefaults())
+        mru.record(backend: "opencode", teamID: "t", model: "b/2")
+        mru.record(backend: "opencode", teamID: "t", model: "gone/x")
+
+        XCTAssertEqual(
+            mru.firstAvailable(backend: "opencode", teamID: "t", available: ["a/1", "b/2"]),
+            "b/2"
+        )
+    }
+
+    func testFirstAvailableIsNilWhenNothingMatches() {
+        let mru = ClientModelMRU(defaults: makeDefaults())
+        mru.record(backend: "opencode", teamID: "t", model: "gone/x")
+        XCTAssertNil(mru.firstAvailable(backend: "opencode", teamID: "t", available: ["a/1"]))
+    }
+
+    func testFirstAvailableIsNilWhenCatalogHasNotArrived() {
+        // Empty catalog means "unknown", not "nothing runnable". Pinning against
+        // an unknown catalog is how the wrong model got stuck before.
+        let mru = ClientModelMRU(defaults: makeDefaults())
+        mru.record(backend: "opencode", teamID: "t", model: "a/1")
+        XCTAssertNil(mru.firstAvailable(backend: "opencode", teamID: "t", available: []))
+    }
+
+    func testPromoteReturnsInputWhenAlreadyHead() {
+        XCTAssertEqual(ClientModelMRU.promote(["a", "b"], "a"), ["a", "b"])
+    }
+}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -615,6 +615,11 @@ function AppContent() {
   const currentView = useUIStore((s) => s.currentView);
   const closeSettings = useUIStore((s) => s.closeSettings);
   const authSession = useAuthStore((s) => s.session);
+  // `load()` keeps the cached team while auth is still restoring, so it has to
+  // run again once auth settles. The user id alone is not enough of a trigger:
+  // a genuinely signed-out user never gets one, and the cached team would
+  // linger with nothing to clear it.
+  const authLoading = useAuthStore((s) => s.loading);
   const loadCurrentTeam = useCurrentTeamStore((s) => s.load);
   // Team-share state drives the top-right "team shared files" tab visibility.
   // Refresh it centrally (below) so the tab reflects the true share mode even
@@ -644,7 +649,7 @@ function AppContent() {
 
   useEffect(() => {
     void loadCurrentTeam();
-  }, [authSession?.user.id, loadCurrentTeam]);
+  }, [authSession?.user.id, authLoading, loadCurrentTeam]);
 
   // In workspace mode, SessionListColumn always sits to the left of SidebarInset
   // and renders its own traffic-light + collapse strip when the sidebar is

--- a/packages/app/src/components/chat/AgentSelectorDock.tsx
+++ b/packages/app/src/components/chat/AgentSelectorDock.tsx
@@ -243,6 +243,9 @@ function AgentPill({
         localDaemonActorId: localActorId,
         // This client's MRU, not the daemon's (ADR-0007). `localCatalog` still
         // supplies the catalog itself — only the history moved.
+        // No explicit team: the pill only needs one for its own label, and
+        // `current-team` no longer blanks itself while auth restores (see
+        // `current-team.ts`), so the store answer is good here.
         recentModels: clientMruModels(backendType),
         available: availableModels,
       }),

--- a/packages/app/src/components/chat/AgentSelectorDock.tsx
+++ b/packages/app/src/components/chat/AgentSelectorDock.tsx
@@ -11,6 +11,7 @@ import { useWorkspaceStore } from '@/stores/workspace'
 import {
   resolveAgentCatalogModels,
   localRecentModelFallback,
+  recordClientModelPick,
 } from '@/lib/agent-model-fallback'
 import { resolveSessionEstablishedModel } from '@/lib/session-established-model'
 import { sessionFlowError, sessionFlowLog } from '@/lib/session-flow-log'
@@ -31,6 +32,7 @@ import {
 import { useSessionSelectionStore } from '@/stores/session-selection-store'
 import { useSessionMessageStore } from '@/stores/session-message-store'
 import { useCurrentTeamStore } from '@/stores/current-team'
+import { clientMruModels } from '@/stores/client-model-mru'
 import { useSessionListStore } from '@/stores/session-list-store'
 import { useLocalDaemonActorId } from '@/lib/daemon-agent-admin'
 import { getKnownLocalDaemonActorId } from '@/lib/local-daemon-identity'
@@ -229,10 +231,12 @@ function AgentPill({
       localRecentModelFallback({
         agentId: agent.id,
         localDaemonActorId: localActorId,
-        recentModels: localCatalog?.recentModels,
+        // This client's MRU, not the daemon's (ADR-0007). `localCatalog` still
+        // supplies the catalog itself — only the history moved.
+        recentModels: clientMruModels(backendType),
         available: availableModels,
       }),
-    [agent.id, localActorId, localCatalog, availableModels],
+    [agent.id, localActorId, backendType, availableModels],
   )
 
   const selected = React.useMemo(
@@ -368,6 +372,18 @@ function AgentPill({
     // choice immediately and `promoteDraftPicks` carries it onto the session.
     useAgentModelPickStore.getState().setPick(pickScopeId, agent.id, rpcModelId)
 
+    // ...and remember it as this client's MRU, so the NEXT new chat starts
+    // here (ADR-0007). Only this path records. The auto-select above must not:
+    // writing a cold-start guess down turns it into a preference that outlives
+    // the guess, which is the loop this migration exists to break.
+    recordClientModelPick({
+      agentId: agent.id,
+      localDaemonActorId: localActorId,
+      backendType,
+      teamId,
+      modelId: rpcModelId,
+    })
+
     if (!sessionId || !teamId) {
       sessionFlowLog('agent_selector.model_pick.deferred_until_session', {
         agentId: agent.id,
@@ -412,7 +428,7 @@ function AgentPill({
       })
       console.error('[AgentSelectorDock] ensureRuntimeThenSetModel failed (pick preserved)', e)
     }
-  }, [agent.id, agent.displayName, dbRuntimeId, sessionId, pickScopeId, t, effectiveModelId, availableModels])
+  }, [agent.id, agent.displayName, dbRuntimeId, sessionId, pickScopeId, t, effectiveModelId, availableModels, backendType, localActorId])
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/packages/app/src/components/chat/AgentSelectorDock.tsx
+++ b/packages/app/src/components/chat/AgentSelectorDock.tsx
@@ -33,6 +33,7 @@ import { useSessionSelectionStore } from '@/stores/session-selection-store'
 import { useSessionMessageStore } from '@/stores/session-message-store'
 import { useCurrentTeamStore } from '@/stores/current-team'
 import { clientMruModels } from '@/stores/client-model-mru'
+import { useModelPickPromptStore } from '@/stores/model-pick-prompt-store'
 import { useSessionListStore } from '@/stores/session-list-store'
 import { useLocalDaemonActorId } from '@/lib/daemon-agent-admin'
 import { getKnownLocalDaemonActorId } from '@/lib/local-daemon-identity'
@@ -149,6 +150,15 @@ function AgentPill({
 }) {
   const { t } = useTranslation()
   const [open, setOpen] = React.useState(false)
+
+  // A send was refused because nothing had chosen this agent's model. Open the
+  // picker so the refusal is actionable instead of silent (ADR-0007).
+  const pendingPickAgentId = useModelPickPromptStore((s) => s.pendingAgentId)
+  React.useEffect(() => {
+    if (pendingPickAgentId !== agent.id) return
+    setOpen(true)
+    useModelPickPromptStore.getState().clear()
+  }, [pendingPickAgentId, agent.id])
   const localActorId = useLocalDaemonActorId()
   const isSelf = !!localActorId && agent.id === localActorId
   const byRuntimeId = useRuntimeStateStore((s) => s.byRuntimeId)

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -77,6 +77,7 @@ import {
 } from '@/lib/agent-model-fallback'
 import { useLocalDaemonActorId } from "@/lib/daemon-agent-admin";
 import { clientMruModels } from "@/stores/client-model-mru";
+import { ensureParticipantModels } from "@/stores/participant-model-store";
 import { useLocalDaemonCatalogStore } from "@/stores/local-daemon-catalog-store";
 import {
   selectAgentModel,
@@ -485,6 +486,15 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     if (sessionParticipants !== undefined || participantsLoading) return;
     void ensureParticipants([activeSessionId]);
   }, [activeSessionId, sessionParticipants, participantsLoading, ensureParticipants]);
+
+  // `session_participants.model` — the authoritative per-session model
+  // (ADR-0005/0007). Separate from the roster fetch above, which reads the
+  // actor directory and carries no working state. Fire-and-forget: the
+  // resolver falls through to the transcript scan and the retain until it
+  // lands, so nothing here blocks the pill.
+  React.useEffect(() => {
+    ensureParticipantModels(activeSessionId);
+  }, [activeSessionId]);
 
   const prevActiveSessionRef = React.useRef<string | null>(null);
   React.useEffect(() => {

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -76,10 +76,12 @@ import {
   localRecentModelFallback,
 } from '@/lib/agent-model-fallback'
 import { useLocalDaemonActorId } from "@/lib/daemon-agent-admin";
+import { clientMruModels } from "@/stores/client-model-mru";
 import { useLocalDaemonCatalogStore } from "@/stores/local-daemon-catalog-store";
 import {
   selectAgentModel,
   resolveRuntimeStateEntryForAgent,
+  backendTypeFromRuntimeEntry,
 } from "@/lib/runtime-state-resolve";
 // xterm + its webgl/search addons are ~560KB of the startup chunk and are only
 // needed once the terminal drawer is actually opened, so pay for them then.
@@ -762,7 +764,13 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
           localRecentModelFallback({
             agentId: modelAgentId,
             localDaemonActorId,
-            recentModels: localDaemonCatalog?.recentModels,
+            // This client's MRU, keyed by the backend this agent runs on
+            // (ADR-0007). `localDaemonCatalog` still supplies the catalog.
+            recentModels: clientMruModels(
+              backendTypeFromRuntimeEntry(
+                resolveRuntimeStateEntryForAgent(modelAgentId, runtimeStates),
+              ),
+            ),
             available,
           }) || undefined,
         sessionEstablishedModel: activeEstablishedModel,

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -776,10 +776,14 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
             localDaemonActorId,
             // This client's MRU, keyed by the backend this agent runs on
             // (ADR-0007). `localDaemonCatalog` still supplies the catalog.
+            // `sheetTeamId` resolves from the session list first. Leaving the
+            // team to `current-team` alone read empty during cold start, and an
+            // empty team is indistinguishable from "never picked a model".
             recentModels: clientMruModels(
               backendTypeFromRuntimeEntry(
                 resolveRuntimeStateEntryForAgent(modelAgentId, runtimeStates),
               ),
+              sheetTeamId,
             ),
             available,
           }) || undefined,
@@ -795,6 +799,7 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
     activeEstablishedModel,
     activePickEntry,
     remoteDefaultCatalogModels,
+    sheetTeamId,
   ]);
 
   // ── Refs ───────────────────────────────────────────────────────────────

--- a/packages/app/src/components/chat/__tests__/AgentSelectorDock.test.tsx
+++ b/packages/app/src/components/chat/__tests__/AgentSelectorDock.test.tsx
@@ -222,7 +222,7 @@ describe('AgentSelectorDock', () => {
     expect(screen.queryByText('Big Pickle')).not.toBeInTheDocument()
   })
 
-  it('auto-selects the first advertised model when none is selected', async () => {
+  it('does NOT pin the first advertised model when nothing has chosen one', async () => {
     mocks.runtimeStates = {
       'a-1::session-1': {
         daemonActorId: 'a-1',
@@ -248,15 +248,20 @@ describe('AgentSelectorDock', () => {
       />,
     )
 
+    // A pick is durable and outranks everything after it, so writing one from
+    // a guess pinned that guess for good — and the order of `availableModels`
+    // is provider probe order, not a preference (ADR-0007).
     await waitFor(() => {
-      expect(useAgentModelPickStore.getState().getPick('session-1', 'a-1')).toBe(
-        'shopee/gpt-5.5',
-      )
+      expect(screen.getByRole('button', { name: /SPRBOT/i })).toBeTruthy()
     })
+    expect(
+      useAgentModelPickStore.getState().getPick('session-1', 'a-1'),
+    ).toBeUndefined()
 
+    // It is still *shown*, so the pill is not blank — it is a suggestion the
+    // user is expected to confirm, and the send path refuses to run on it.
     await userEvent.click(await screen.findByRole('button', { name: /SPRBOT/i }))
     const selected = document.querySelector('[data-model-selected="true"]')
-    expect(selected).toBeTruthy()
     expect(selected?.textContent).toContain('GPT-5.5')
   })
 

--- a/packages/app/src/components/chat/use-chat-send.ts
+++ b/packages/app/src/components/chat/use-chat-send.ts
@@ -71,10 +71,12 @@ import {
   localRecentModelFallback,
 } from '@/lib/agent-model-fallback'
 import { clientMruModels } from '@/stores/client-model-mru'
+import { useModelPickPromptStore } from '@/stores/model-pick-prompt-store'
 import { getKnownLocalDaemonActorId } from "@/lib/local-daemon-identity";
 import { useLocalDaemonCatalogStore } from "@/stores/local-daemon-catalog-store";
 import {
   selectAgentModel,
+  requiresExplicitModelPick,
   resolveRuntimeStateEntryForAgent,
   backendTypeFromRuntimeEntry,
 } from "@/lib/runtime-state-resolve";
@@ -425,7 +427,7 @@ export function useChatSend({
           // a model that was never used. `selectAgentModel` owns every other
           // case — including the fallback, which must be the same device MRU
           // the pill shows.
-          const outgoingModel = sendAgentId
+          const selectedForSend = sendAgentId
             ? selectAgentModel({
                 sessionId: sid,
                 agentId: sendAgentId,
@@ -439,8 +441,25 @@ export function useChatSend({
                     available: availableForSend,
                   }) || undefined,
                 sessionEstablishedModel: establishedForSend,
-              }).modelId || ""
-            : "";
+              })
+            : null;
+
+          // Nothing chose this model — it is just whatever the catalog listed
+          // first, and that order is provider probe order, not a preference.
+          // Sending would make the guess the session's established model and
+          // hide that it ever was one, so ask instead (ADR-0007).
+          if (selectedForSend && requiresExplicitModelPick(selectedForSend)) {
+            sessionFlowLog("chat_send.blocked_awaiting_model_pick", {
+              sessionId: sid,
+              agentActorId: sendAgentId,
+              suggestedModelId: selectedForSend.modelId,
+              availableModelCount: availableForSend.length,
+            });
+            useModelPickPromptStore.getState().request(sendAgentId);
+            return;
+          }
+
+          const outgoingModel = selectedForSend?.modelId || "";
           const mentionDeliverySnapshot: Record<string, "offline" | "stale"> = {};
           for (const entry of engagedUiEntries) {
             if (!agentForSend || entry.agent.id !== agentForSend.id) continue;

--- a/packages/app/src/components/chat/use-chat-send.ts
+++ b/packages/app/src/components/chat/use-chat-send.ts
@@ -70,6 +70,7 @@ import {
   resolveAgentCatalogModels,
   localRecentModelFallback,
 } from '@/lib/agent-model-fallback'
+import { clientMruModels } from '@/stores/client-model-mru'
 import { getKnownLocalDaemonActorId } from "@/lib/local-daemon-identity";
 import { useLocalDaemonCatalogStore } from "@/stores/local-daemon-catalog-store";
 import {
@@ -434,7 +435,7 @@ export function useChatSend({
                   localRecentModelFallback({
                     agentId: sendAgentId,
                     localDaemonActorId: localDaemonActorIdForSend,
-                    recentModels: localCatalogForSend?.recentModels,
+                    recentModels: clientMruModels(backendTypeForSend),
                     available: availableForSend,
                   }) || undefined,
                 sessionEstablishedModel: establishedForSend,

--- a/packages/app/src/components/chat/use-chat-send.ts
+++ b/packages/app/src/components/chat/use-chat-send.ts
@@ -18,7 +18,6 @@ import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/session";
 import { useSessionMessageStore } from "@/stores/session-message-store";
 import { useOutboxStore } from "@/stores/outbox-store";
-import { useWorkspaceStore } from "@/stores/workspace";
 import { useRuntimeStateStore } from "@/stores/runtime-state-store";
 import { useCurrentTeamStore } from "@/stores/current-team";
 import { notePendingAgentReplyTo } from "@/lib/pending-agent-reply-to";
@@ -66,20 +65,11 @@ import {
   textHasMemberMentionTokens,
 } from "@/lib/member-mention-token";
 import { buildEnhancedChip, buildStructuredMentionLines } from "@/lib/outgoing-mention-content";
-import {
-  resolveAgentCatalogModels,
-  localRecentModelFallback,
-} from '@/lib/agent-model-fallback'
-import { clientMruModels } from '@/stores/client-model-mru'
+import { resolveAgentSessionModel } from '@/lib/resolve-agent-session-model'
+import { resolveAgentBackendType } from '@/lib/agent-backend-type'
 import { useModelPickPromptStore } from '@/stores/model-pick-prompt-store'
 import { getKnownLocalDaemonActorId } from "@/lib/local-daemon-identity";
-import { useLocalDaemonCatalogStore } from "@/stores/local-daemon-catalog-store";
-import {
-  selectAgentModel,
-  requiresExplicitModelPick,
-  resolveRuntimeStateEntryForAgent,
-  backendTypeFromRuntimeEntry,
-} from "@/lib/runtime-state-resolve";
+import { requiresExplicitModelPick } from "@/lib/runtime-state-resolve";
 import {
   sessionFlowError,
   sessionFlowLog,
@@ -231,12 +221,15 @@ export function useChatSend({
     processedText = processedText.replace(/@\{([^}]+)\}/g, '[File: $1]');
     // Skill/role invocation wording depends on which backend runs the agent
     // (opencode plugin tools vs Claude Code's native Skill tool).
-    const backendTypeForSend = backendTypeFromRuntimeEntry(
-      resolveRuntimeStateEntryForAgent(
-        agentForSend?.id ?? "",
-        useRuntimeStateStore.getState().byRuntimeId,
-      ),
-    );
+    // Runtime-first, then the team directory. On a cold start no runtime has
+    // attached yet, and a bare runtime read returns `undefined` — which the
+    // MRU lookup below cannot key on, so it reported "never picked a model"
+    // and the first send after launch stopped for a model pick.
+    const backendTypeForSend = resolveAgentBackendType({
+      agentId: agentForSend?.id ?? "",
+      teamId: sheetTeamId,
+      byRuntimeId: useRuntimeStateStore.getState().byRuntimeId,
+    });
     processedText = processedText.replace(/\/\{([^}]+)\}/g, (_full, body) => {
       const token = parseSlashToken(body);
       if (token.type === "role") return buildEnhancedChip("role", token.name, backendTypeForSend);
@@ -402,47 +395,30 @@ export function useChatSend({
             agentRuntimeIdsForSend[0] ?? "",
           );
           const sendAgentId = agentRuntimeIdsForSend[0] ?? "";
-          const sendByRuntimeId = useRuntimeStateStore.getState().byRuntimeId;
           const localDaemonActorIdForSend = getKnownLocalDaemonActorId();
-          const localCatalogWorkspace =
-            useWorkspaceStore.getState().workspacePath?.trim() || "";
-          const localCatalogForSend = localCatalogWorkspace
-            ? useLocalDaemonCatalogStore.getState().byWorkspacePath[
-                localCatalogWorkspace
-              ]
-            : undefined;
-          const availableForSend = resolveAgentCatalogModels({
-            agentId: sendAgentId,
-            localDaemonActorId: localDaemonActorIdForSend,
-            sessionId: sid,
-            byRuntimeId: sendByRuntimeId,
-            runtimeInfo: resolveRuntimeStateEntryForAgent(sendAgentId, sendByRuntimeId)
-              ?.info,
-            localWorkspaceCatalogModels: localCatalogForSend?.models,
-            remoteDefaultCatalogModels:
-              useRuntimeStateStore.getState().defaultCatalogByActorId[sendAgentId]?.models,
-          });
           // No agent means no model: there is nothing to run the prompt on, so
           // stamping the message with a workspace-global default only recorded
           // a model that was never used. `selectAgentModel` owns every other
           // case — including the fallback, which must be the same device MRU
           // the pill shows.
-          const selectedForSend = sendAgentId
-            ? selectAgentModel({
+          // Same resolver `startAgentRuntimes` uses to start the runtime this
+          // message runs on, so the model stamped here and the model it runs on
+          // cannot come out different. `teamIdForSend` is the team this send
+          // already resolved (session list first); letting the MRU re-derive it
+          // from `current-team` read empty during cold start and turned a
+          // remembered model into "never picked".
+          const resolvedForSend = sendAgentId
+            ? resolveAgentSessionModel({
                 sessionId: sid,
                 agentId: sendAgentId,
-                available: availableForSend,
-                byRuntimeId: sendByRuntimeId,
-                providerFallback:
-                  localRecentModelFallback({
-                    agentId: sendAgentId,
-                    localDaemonActorId: localDaemonActorIdForSend,
-                    recentModels: clientMruModels(backendTypeForSend),
-                    available: availableForSend,
-                  }) || undefined,
+                teamId: teamIdForSend,
+                backendType: backendTypeForSend,
+                localDaemonActorId: localDaemonActorIdForSend,
                 sessionEstablishedModel: establishedForSend,
               })
             : null;
+          const selectedForSend = resolvedForSend?.selected ?? null;
+          const availableForSend = resolvedForSend?.available ?? [];
 
           // Nothing chose this model — it is just whatever the catalog listed
           // first, and that order is provider probe order, not a preference.
@@ -456,6 +432,11 @@ export function useChatSend({
               availableModelCount: availableForSend.length,
             });
             useModelPickPromptStore.getState().request(sendAgentId);
+            // Deferring, not sending: the composer was already emptied at the
+            // top of this handler, so hand the text back the same way the
+            // other post-clear bail-out does. Without this the prompt is gone
+            // by the time the picker opens and there is nothing to re-send.
+            restoreComposer();
             return;
           }
 

--- a/packages/app/src/lib/__tests__/agent-model-auto-persist.test.ts
+++ b/packages/app/src/lib/__tests__/agent-model-auto-persist.test.ts
@@ -30,8 +30,12 @@ describe('resolveAutoPersistModelId', () => {
     expect(base()).toBe(MRU_HEAD)
   })
 
-  it('falls back to first-advertised only when there is no MRU to honour', () => {
-    expect(base({ localRecentModel: '' })).toBe(LIST_HEAD)
+  it('writes nothing when this client has no history to honour', () => {
+    // Used to return `availableModelIds[0]` here. A pick is durable and
+    // outranks every later signal, so that guess got pinned for good — and
+    // `available` is ordered by provider probe order, which is not stable.
+    // The answer with no history is now "ask the user" (ADR-0007).
+    expect(base({ localRecentModel: '' })).toBeNull()
   })
 
   describe('refuses to write while an input is merely not-yet-known', () => {
@@ -55,16 +59,25 @@ describe('resolveAutoPersistModelId', () => {
     expect(base({ localDaemonActorId: null, localCatalogStatus: undefined })).toBe(MRU_HEAD)
   })
 
-  it('still writes for a remote agent without waiting on this device catalog', () => {
+  it('does not gate a remote agent on this device\'s catalog probe', () => {
     // The loopback catalog says nothing about another machine, so it must not
-    // gate a remote agent — that would leave remote pills permanently unpinned.
+    // make a remote agent *wait*. With history it writes immediately...
+    expect(
+      base({
+        agentId: 'some-remote-agent',
+        localCatalogStatus: undefined,
+        localRecentModel: 'remembered/model',
+      }),
+    ).toBe('remembered/model')
+    // ...and without history it declines outright rather than guessing, same
+    // as the local agent.
     expect(
       base({
         agentId: 'some-remote-agent',
         localCatalogStatus: undefined,
         localRecentModel: '',
       }),
-    ).toBe(LIST_HEAD)
+    ).toBeNull()
   })
 
   it('never overrides an answer that already has more authority', () => {
@@ -85,10 +98,15 @@ describe('resolveAutoPersistModelId', () => {
     expect(base({ runtimeInfoLoading: true })).toBeNull()
   })
 
-  it('proceeds once the probe has settled on a definite answer', () => {
-    // 'unknown' means we asked and learned nothing — stop waiting and fall
-    // back, rather than leave the pill unpinned forever.
-    expect(base({ localCatalogStatus: 'unknown', localRecentModel: '' })).toBe(LIST_HEAD)
-    expect(base({ localCatalogStatus: 'empty', localRecentModel: '' })).toBe(LIST_HEAD)
+  it('stops waiting once the probe has settled, but still refuses to guess', () => {
+    // 'unknown' / 'empty' mean we asked and learned nothing. That ends the
+    // wait — but a settled probe is not a model, so with no history there is
+    // still nothing to write.
+    expect(base({ localCatalogStatus: 'unknown', localRecentModel: '' })).toBeNull()
+    expect(base({ localCatalogStatus: 'empty', localRecentModel: '' })).toBeNull()
+    // Settled + history = write, which is what "stops waiting" buys.
+    expect(base({ localCatalogStatus: 'unknown', localRecentModel: 'mru/model' })).toBe(
+      'mru/model',
+    )
   })
 })

--- a/packages/app/src/lib/__tests__/runtime-state-resolve.test.ts
+++ b/packages/app/src/lib/__tests__/runtime-state-resolve.test.ts
@@ -12,6 +12,7 @@ import {
   resolveRuntimeStateEntryForAgent,
   resolveSetModelId,
   selectAgentModel,
+  requiresExplicitModelPick,
 } from "@/lib/runtime-state-resolve";
 import { useAgentModelPickStore } from "@/stores/agent-model-pick-store";
 
@@ -203,7 +204,11 @@ describe("selectAgentModel — canonical model resolver", () => {
     expect(res.modelId).toBe("");
   });
 
-  it("falls back to the first advertised model when catalog is present", () => {
+  it("suggests the first advertised model but marks it unpicked", () => {
+    // The id is still surfaced so the pill is not blank, but the source says
+    // nobody chose it. `available` is ordered by provider probe order, which is
+    // not stable, so sending on it would run a different model on a different
+    // day — `requiresExplicitModelPick` is what stops that (ADR-0007).
     const emptyRetain = {
       [`${agentUuid}::${sessionId}`]: {
         ...entry(agentUuid, sessionId, available),
@@ -216,8 +221,28 @@ describe("selectAgentModel — canonical model resolver", () => {
       available,
       byRuntimeId: emptyRetain,
     });
-    expect(res.source).toBe("fallback");
+    expect(res.source).toBe("unpicked");
     expect(res.modelId).toBe("big-pickle");
+    expect(requiresExplicitModelPick(res)).toBe(true);
+  });
+
+  it("does not demand a pick for a model that came from a real source", () => {
+    // The MRU is a past explicit choice, so it needs no re-confirmation.
+    const emptyRetain = {
+      [`${agentUuid}::${sessionId}`]: {
+        ...entry(agentUuid, sessionId, available),
+        info: { ...entry(agentUuid, sessionId, available).info, currentModel: "" },
+      },
+    };
+    const res = selectAgentModel({
+      sessionId,
+      agentId: agentUuid,
+      available,
+      byRuntimeId: emptyRetain,
+      providerFallback: "big-pickle",
+    });
+    expect(res.source).toBe("fallback");
+    expect(requiresExplicitModelPick(res)).toBe(false);
   });
 
   it("canonicalizes short pick to advertised prefixed id", () => {

--- a/packages/app/src/lib/agent-backend-type.ts
+++ b/packages/app/src/lib/agent-backend-type.ts
@@ -1,0 +1,54 @@
+import { useActorDirectoryStore } from "@/stores/actor-directory-store";
+import type { RuntimeStateEntry } from "@/stores/runtime-state-store";
+import {
+  backendTypeFromRuntimeEntry,
+  resolveRuntimeStateEntryForAgent,
+} from "@/lib/runtime-state-resolve";
+
+/**
+ * Which backend runs this agent, answered before its runtime exists.
+ *
+ * The runtime state store is the precise source — it reports what the agent is
+ * running on right now — but it is empty until a runtime attaches, and a
+ * runtime only attaches once a session starts. So on a cold start, every read
+ * before the first send comes back `undefined`.
+ *
+ * That mattered more than "the label is blank for a second". The client model
+ * MRU is keyed `(backend, team)`, and an unknown backend cannot form a key —
+ * `clientMruModels` answered "no history", which is indistinguishable from
+ * "this device never picked a model", so the first send after every launch was
+ * refused and asked the user to pick a model they had already picked.
+ *
+ * The team's actor directory carries the agent's configured type and is loaded
+ * (and cached) well before then, so it answers when the runtime cannot. It is
+ * the *configured* backend rather than the *running* one, which is exactly the
+ * right answer for a runtime that has not started yet.
+ */
+export function resolveAgentBackendType(args: {
+  agentId: string | null | undefined;
+  teamId: string | null | undefined;
+  byRuntimeId: Record<string, RuntimeStateEntry>;
+}): string | undefined {
+  const agentId = args.agentId?.trim() ?? "";
+  if (!agentId) return undefined;
+
+  const live = backendTypeFromRuntimeEntry(
+    resolveRuntimeStateEntryForAgent(agentId, args.byRuntimeId),
+  );
+  if (live) return live;
+
+  const teamId = args.teamId?.trim() ?? "";
+  if (!teamId) return undefined;
+  // Never throw: this only ever improves an answer that is otherwise
+  // `undefined`, and a directory that has not loaded is not an error.
+  try {
+    const row = useActorDirectoryStore
+      .getState()
+      .byTeam[teamId]?.actors?.find((a) => a.id === agentId);
+    if (!row) return undefined;
+    const configured = row.default_agent_type?.trim() || row.agent_types?.[0]?.trim();
+    return configured || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/app/src/lib/agent-model-auto-persist.ts
+++ b/packages/app/src/lib/agent-model-auto-persist.ts
@@ -84,6 +84,10 @@ export function resolveAutoPersistModelId(input: {
   // (no entry yet) is as unsettled as `'pending'`.
   if (isLocalAgent && !isSettledLocalCatalog(input.localCatalogStatus)) return null
 
-  // Device history first; first-advertised only when there is none to honour.
-  return input.localRecentModel.trim() || input.availableModelIds[0]?.trim() || null
+  // This client's history, or nothing. `availableModelIds[0]` used to close
+  // this out; it no longer does, because a pick is durable and outranks every
+  // later signal, so writing a guess here pinned it for good. With no history
+  // the answer is "ask the user" — `selectAgentModel` reports that case as
+  // `source: "unpicked"` (ADR-0007).
+  return input.localRecentModel.trim() || null
 }

--- a/packages/app/src/lib/agent-model-fallback.ts
+++ b/packages/app/src/lib/agent-model-fallback.ts
@@ -4,6 +4,7 @@ import {
   type AgentModelOption,
 } from "@/lib/agent-available-models";
 import {
+  clientMruModels,
   firstAvailableMruModel,
   useClientModelMruStore,
 } from "@/stores/client-model-mru";
@@ -111,6 +112,34 @@ export function localRecentModelFallback(args: {
 }): string {
   if (!isLocalDaemonAgent(args.agentId, args.localDaemonActorId)) return "";
   return firstAvailableMruModel(args.recentModels, args.available);
+}
+
+/**
+ * The whole `providerFallback` slot in one call: look the MRU up and match it
+ * against the live catalog.
+ *
+ * Exists because the send path and the runtime-start path each built this by
+ * hand and drifted. `use-chat-send` looked the MRU up; `session-create` never
+ * did, so one message produced two runtime starts that disagreed about the
+ * model — the message was stamped with the remembered one while the runtime
+ * started with none. They happened to agree only because the daemon still keeps
+ * an MRU of its own to fall back on, and ADR-0007 is in the middle of removing
+ * that. Two call sites deriving the same answer separately is what this
+ * removes; there is now one place to key the lookup wrong.
+ */
+export function clientMruProviderFallback(args: {
+  agentId: string;
+  localDaemonActorId: string | null | undefined;
+  backendType: string | null | undefined;
+  teamId: string | null | undefined;
+  available: AgentModelOption[];
+}): string {
+  return localRecentModelFallback({
+    agentId: args.agentId,
+    localDaemonActorId: args.localDaemonActorId,
+    recentModels: clientMruModels(args.backendType, args.teamId),
+    available: args.available,
+  });
 }
 
 /**

--- a/packages/app/src/lib/agent-model-fallback.ts
+++ b/packages/app/src/lib/agent-model-fallback.ts
@@ -3,7 +3,10 @@ import {
   resolveAgentAvailableModels,
   type AgentModelOption,
 } from "@/lib/agent-available-models";
-import { firstAvailableRecentModel } from "@/lib/local-daemon-model-catalog";
+import {
+  firstAvailableMruModel,
+  useClientModelMruStore,
+} from "@/stores/client-model-mru";
 import type { RuntimeInfo } from "@/lib/proto/amux_pb";
 import {
   resolveSessionAttachmentEntry,
@@ -89,9 +92,16 @@ export function agentAvailableModelsWithLocalCatalog(args: {
 }
 
 /**
- * The `providerFallback` slot for `selectAgentModel` — this device's MRU.
+ * The `providerFallback` slot for `selectAgentModel` — this client's MRU.
  *
- * Local agent only: this device's history says nothing about a remote agent's.
+ * The list now comes from `stores/client-model-mru` rather than the daemon's
+ * `model-catalog.recent_models`: ADR-0007 moves the MRU out of amuxd, because a
+ * preference the daemon owns is one a mis-picking client can poison for every
+ * later session (see `agent-model-auto-persist.ts`). Callers pass
+ * `useClientModelMruStore().recentFor(backend, teamId)`.
+ *
+ * Local agent only, unchanged: this client's history is about the backend and
+ * team it has been running, which says nothing about a remote agent's catalog.
  */
 export function localRecentModelFallback(args: {
   agentId: string;
@@ -100,5 +110,27 @@ export function localRecentModelFallback(args: {
   available: AgentModelOption[];
 }): string {
   if (!isLocalDaemonAgent(args.agentId, args.localDaemonActorId)) return "";
-  return firstAvailableRecentModel(args.recentModels, args.available);
+  return firstAvailableMruModel(args.recentModels, args.available);
+}
+
+/**
+ * Record a model the user actually chose.
+ *
+ * Only **explicit** picks land here. An auto-selection must not: writing a
+ * cold-start guess down and reading it back as a preference is the loop
+ * ADR-0007 breaks — every restart re-confirmed the wrong answer.
+ */
+export function recordClientModelPick(args: {
+  agentId: string;
+  localDaemonActorId: string | null | undefined;
+  backendType: string | null | undefined;
+  teamId: string | null | undefined;
+  modelId: string;
+}): void {
+  if (!isLocalDaemonAgent(args.agentId, args.localDaemonActorId)) return;
+  const backend = args.backendType?.trim();
+  const team = args.teamId?.trim();
+  const model = args.modelId.trim();
+  if (!backend || !team || !model) return;
+  useClientModelMruStore.getState().record(backend, team, model);
 }

--- a/packages/app/src/lib/backend/cloud-api/sessions.ts
+++ b/packages/app/src/lib/backend/cloud-api/sessions.ts
@@ -137,13 +137,27 @@ export function createSessionsModule(client: CloudApiClient): SessionsBackend {
       await client.patch(`/v1/sessions/${encodeURIComponent(sessionId)}`, { archivedAt });
     },
     async getSessionParticipants(sessionId): Promise<SessionParticipant[]> {
-      const out = await client.get<{ items: Array<{ sessionId?: string; actorId: string; role?: string | null }> }>(
-        `/v1/sessions/${encodeURIComponent(sessionId)}/participants`,
-      );
+      const out = await client.get<{
+        items: Array<{
+          sessionId?: string;
+          actorId: string;
+          role?: string | null;
+          workspaceId?: string | null;
+          model?: string | null;
+          lastProcessedMessageId?: string | null;
+        }>;
+      }>(`/v1/sessions/${encodeURIComponent(sessionId)}/participants`);
       return out.items.map((row) => ({
         session_id: row.sessionId ?? sessionId,
         actor_id: row.actorId,
         role: row.role ?? null,
+        // The agent's working state for this session (ADR-0005). The server has
+        // returned all three since that migration and `SessionParticipant` has
+        // always declared them — this mapper just dropped them, so every client
+        // read `undefined` regardless of what the row held.
+        workspaceId: row.workspaceId ?? null,
+        model: row.model ?? null,
+        lastProcessedMessageId: row.lastProcessedMessageId ?? null,
       }));
     },
     async getSession(sessionId) {

--- a/packages/app/src/lib/resolve-agent-session-model.ts
+++ b/packages/app/src/lib/resolve-agent-session-model.ts
@@ -1,0 +1,85 @@
+import {
+  resolveAgentCatalogModels,
+  clientMruProviderFallback,
+} from "@/lib/agent-model-fallback";
+import type { AgentModelOption } from "@/lib/agent-available-models";
+import {
+  selectAgentModel,
+  resolveRuntimeStateEntryForAgent,
+  type SelectedAgentModel,
+} from "@/lib/runtime-state-resolve";
+import { useRuntimeStateStore } from "@/stores/runtime-state-store";
+import { useLocalDaemonCatalogStore } from "@/stores/local-daemon-catalog-store";
+import { useWorkspaceStore } from "@/stores/workspace";
+
+/**
+ * Which model an agent runs this session's next prompt on.
+ *
+ * One message drives two calls that both have to answer this: the send path
+ * stamps `message.model`, and `startAgentRuntimes` starts the runtime that
+ * actually runs it. They each used to assemble the answer by hand, and the
+ * assemblies were not the same — the send path widened the catalog beyond the
+ * live retain and looked up this client's MRU, while the runtime-start path did
+ * neither. So the message was stamped with the remembered model while the
+ * runtime started with none, and they agreed only because the daemon still
+ * keeps an MRU of its own to fall back on. ADR-0007 is removing that, and the
+ * two would then start disagreeing outright.
+ *
+ * Both call it now, so there is one place to get it wrong instead of two.
+ *
+ * `explicitModelId` is the caller's own answer (cron and gateway pass a model
+ * chosen when the job or channel was configured) and stays above the MRU: a
+ * device's history must not override a model someone chose for this run.
+ */
+export function resolveAgentSessionModel(args: {
+  sessionId: string;
+  agentId: string;
+  teamId: string | null | undefined;
+  backendType: string | null | undefined;
+  localDaemonActorId: string | null | undefined;
+  /** A model the caller already decided on; outranks the MRU fallback. */
+  explicitModelId?: string | null;
+  /** Model the session's transcript shows it already ran with, when known. */
+  sessionEstablishedModel?: string | null;
+}): { selected: SelectedAgentModel; available: AgentModelOption[] } {
+  const byRuntimeId = useRuntimeStateStore.getState().byRuntimeId;
+  const workspacePath = useWorkspaceStore.getState().workspacePath?.trim() || "";
+  const localCatalog = workspacePath
+    ? useLocalDaemonCatalogStore.getState().byWorkspacePath[workspacePath]
+    : undefined;
+
+  // Wider than the live retain on purpose: on a cold start no runtime has
+  // attached, so the retain is empty and this device's persisted catalog is the
+  // only list there is. Without it the MRU has nothing to match against and
+  // reads as "never picked a model".
+  const available = resolveAgentCatalogModels({
+    agentId: args.agentId,
+    localDaemonActorId: args.localDaemonActorId,
+    sessionId: args.sessionId,
+    byRuntimeId,
+    runtimeInfo: resolveRuntimeStateEntryForAgent(args.agentId, byRuntimeId)?.info,
+    localWorkspaceCatalogModels: localCatalog?.models,
+    remoteDefaultCatalogModels:
+      useRuntimeStateStore.getState().defaultCatalogByActorId[args.agentId]?.models,
+  });
+
+  const selected = selectAgentModel({
+    sessionId: args.sessionId,
+    agentId: args.agentId,
+    available,
+    byRuntimeId,
+    providerFallback:
+      args.explicitModelId?.trim() ||
+      clientMruProviderFallback({
+        agentId: args.agentId,
+        localDaemonActorId: args.localDaemonActorId,
+        backendType: args.backendType,
+        teamId: args.teamId,
+        available,
+      }) ||
+      undefined,
+    sessionEstablishedModel: args.sessionEstablishedModel ?? undefined,
+  });
+
+  return { selected, available };
+}

--- a/packages/app/src/lib/runtime-state-resolve.ts
+++ b/packages/app/src/lib/runtime-state-resolve.ts
@@ -6,6 +6,7 @@ import {
   type RuntimeStateEntry,
 } from "@/stores/runtime-state-store";
 import { useAgentModelPickStore } from "@/stores/agent-model-pick-store";
+import { participantModel } from "@/stores/participant-model-store";
 
 /**
  * Canonical agent / runtime identity glossary (read before touching this file):
@@ -535,6 +536,26 @@ export function selectAgentModel(args: {
         args.byRuntimeId,
       ),
       source: "pick",
+    };
+  }
+
+  // `session_participants.model` — the fact itself (ADR-0005), written by the
+  // daemon, which is the only component that sees what the runtime settled on.
+  // Ranked above the transcript scan below because that scan *reconstructs*
+  // this same answer from message metadata and can only be as good as the
+  // heuristic it uses. Empty until the row is fetched, so the scan and the
+  // retain remain the fallbacks for that window (and for a daemon too old to
+  // write the column).
+  const fromParticipant = participantModel(sessionId, agentId);
+  if (fromParticipant) {
+    return {
+      modelId: canonicalizeAgainstAvailable(
+        args.agentId,
+        fromParticipant,
+        args.available,
+        args.byRuntimeId,
+      ),
+      source: "retain",
     };
   }
 

--- a/packages/app/src/lib/runtime-state-resolve.ts
+++ b/packages/app/src/lib/runtime-state-resolve.ts
@@ -474,7 +474,20 @@ export function providerModelKeyFromOption(
   return formatProviderModelKey(option.provider, option.id);
 }
 
-export type AgentModelSource = "pick" | "retain" | "fallback" | "none";
+/**
+ * `"unpicked"` is NOT a choice — it means the catalog had entries and nothing
+ * else did, so the first advertised model is being shown as a suggestion. It is
+ * kept distinct from `"fallback"` (this client's MRU, which IS a past choice)
+ * because the send path must refuse to run on it: `available` is ordered by
+ * provider probe order, which is not stable, so pinning it would pick a
+ * different model on a different day (ADR-0007).
+ */
+export type AgentModelSource =
+  | "pick"
+  | "retain"
+  | "fallback"
+  | "unpicked"
+  | "none";
 
 export interface SelectedAgentModel {
   /** Canonical model id (matches `availableModels[i].id` when the list is known). */
@@ -574,12 +587,13 @@ export function selectAgentModel(args: {
     };
   }
 
-  // Live catalog is present but nothing else selected — use the first
-  // advertised model. Callers that pass `available: []` skip this on purpose;
-  // prefer passing the retain catalog so UI and send stay aligned.
+  // Live catalog is present but nothing else selected. Surface the first
+  // advertised model as a *suggestion* — `source: "unpicked"` marks it as such,
+  // and `requiresExplicitModelPick` turns that into "ask the user before
+  // sending". Callers that pass `available: []` skip this on purpose.
   const firstAvailable = args.available[0]?.id?.trim() ?? "";
   if (firstAvailable) {
-    return { modelId: firstAvailable, source: "fallback" };
+    return { modelId: firstAvailable, source: "unpicked" };
   }
 
   return { modelId: "", source: "none" };
@@ -626,3 +640,21 @@ export function backendTypeFromRuntimeEntry(
 // Re-export the runtime-state-store hook so other modules don't need to import
 // it separately just to invalidate selectors.
 export { useRuntimeStateStore };
+
+/**
+ * Does this selection still need a human to confirm it before anything runs?
+ *
+ * True only for `"unpicked"`: a first-advertised suggestion, shown so the pill
+ * is not blank, but never good enough to send on. Every other source is either
+ * an explicit choice, something the session already ran with, or this client's
+ * own history.
+ *
+ * Exists because the alternative — quietly sending on `available[0]` — is what
+ * seeded the wrong model in the first place, and once sent it became the
+ * session's established model and stopped looking like a guess (ADR-0007).
+ */
+export function requiresExplicitModelPick(
+  selected: Pick<SelectedAgentModel, "source">,
+): boolean {
+  return selected.source === "unpicked";
+}

--- a/packages/app/src/lib/session-create.ts
+++ b/packages/app/src/lib/session-create.ts
@@ -7,10 +7,9 @@ import { seedRuntimeStateAfterStart } from '@/lib/seed-runtime-state'
 import { seedLocalDaemonModelsInBackground } from '@/lib/local-daemon-model-catalog'
 import {
   normalizeAgentModelId,
-  resolveRuntimeStateEntryForAgent,
-  selectAgentModel,
+  requiresExplicitModelPick,
 } from '@/lib/runtime-state-resolve'
-import { resolveAgentAvailableModels } from '@/lib/agent-available-models'
+import { resolveAgentSessionModel } from '@/lib/resolve-agent-session-model'
 import { useAgentModelPickStore } from '@/stores/agent-model-pick-store'
 import { useRuntimeStateStore } from '@/stores/runtime-state-store'
 import { useWorkspaceStore } from '@/stores/workspace'
@@ -542,16 +541,38 @@ export async function startAgentRuntimesAsync(
     const agentType = args.agentType ?? resolveAmuxAgentType(backendType)
     const byRuntimeId = useRuntimeStateStore.getState().byRuntimeId
     const userPick = useAgentModelPickStore.getState().getPick(args.sessionId, agentActorId)
-    const available = resolveAgentAvailableModels(
-      resolveRuntimeStateEntryForAgent(agentActorId, byRuntimeId)?.info,
-    )
-    const resolvedModelId = selectAgentModel({
+    // Same resolver the send path uses. It used to look only at the live
+    // retain for the catalog and never consulted this client's MRU, so on a
+    // cold start it answered "no model" for a message the send path had just
+    // stamped with a remembered one.
+    const { selected: selectedForStart, available } = resolveAgentSessionModel({
       sessionId: args.sessionId,
       agentId: agentActorId,
-      available,
-      byRuntimeId,
-      providerFallback: args.modelIdByAgent?.[agentActorId] ?? args.modelId,
-    }).modelId || undefined
+      teamId: args.teamId,
+      backendType,
+      localDaemonActorId,
+      explicitModelId: args.modelIdByAgent?.[agentActorId] ?? args.modelId,
+    })
+    // Starting a runtime is not a licence to answer the model question. When
+    // nothing has chosen yet, `selectAgentModel` hands back the first catalog
+    // entry marked `unpicked` — the send path refuses to run on it (ADR-0007),
+    // and this path must refuse to *pin* it. It used to do the opposite: it
+    // passed the guess to runtimeStart and setModel, the daemon echoed it back
+    // as `currentModel`, and the next resolve read that retain as an answer —
+    // so the guess became the choice and the picker never opened again.
+    const modelNeedsPick = requiresExplicitModelPick(selectedForStart)
+    const resolvedModelId = modelNeedsPick
+      ? undefined
+      : selectedForStart.modelId || undefined
+    if (modelNeedsPick) {
+      sessionFlowLog('runtime_start.model_deferred_awaiting_pick', {
+        sessionId: args.sessionId,
+        teamId: args.teamId,
+        agentActorId,
+        suggestedModelId: selectedForStart.modelId,
+        availableModelCount: available.length,
+      })
+    }
 
     const isLocalDaemonAgent =
       localDaemonActorId !== null && agentActorId === localDaemonActorId

--- a/packages/app/src/stores/__tests__/client-model-mru.test.ts
+++ b/packages/app/src/stores/__tests__/client-model-mru.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useClientModelMruStore,
+  firstAvailableMruModel,
+  promote,
+} from "@/stores/client-model-mru";
+
+const CATALOG = [{ id: "a/1" }, { id: "b/2" }, { id: "c/3" }];
+
+beforeEach(() => {
+  useClientModelMruStore.getState().clear();
+});
+
+describe("client model MRU", () => {
+  it("moves an existing entry to the front", () => {
+    const s = useClientModelMruStore.getState();
+    s.record("opencode", "team-1", "a/1");
+    s.record("opencode", "team-1", "b/2");
+    s.record("opencode", "team-1", "a/1");
+    expect(useClientModelMruStore.getState().recentFor("opencode", "team-1")).toEqual([
+      "a/1",
+      "b/2",
+    ]);
+  });
+
+  it("keeps backends apart", () => {
+    // Model ids are backend-local: a pi id handed to opencode is not a degraded
+    // answer, it is a wrong one.
+    const s = useClientModelMruStore.getState();
+    s.record("opencode", "team-1", "opencode/big-pickle");
+    s.record("pi", "team-1", "anthropic/claude-sonnet-4-6");
+
+    const get = useClientModelMruStore.getState();
+    expect(get.recentFor("opencode", "team-1")).toEqual(["opencode/big-pickle"]);
+    expect(get.recentFor("pi", "team-1")).toEqual(["anthropic/claude-sonnet-4-6"]);
+    expect(get.recentFor("cursor", "team-1")).toEqual([]);
+  });
+
+  it("keeps teams apart", () => {
+    // Catalogs vary by team (the team's LiteLLM gateway models), which is the
+    // only variable #742 could actually attribute a catalog difference to.
+    const s = useClientModelMruStore.getState();
+    s.record("opencode", "team-1", "gateway/team-1-only");
+    s.record("opencode", "team-2", "gateway/team-2-only");
+
+    const get = useClientModelMruStore.getState();
+    expect(get.recentFor("opencode", "team-1")).toEqual(["gateway/team-1-only"]);
+    expect(get.recentFor("opencode", "team-2")).toEqual(["gateway/team-2-only"]);
+  });
+
+  it("ignores blank inputs rather than storing empty keys", () => {
+    const s = useClientModelMruStore.getState();
+    s.record("opencode", "team-1", "   ");
+    s.record("", "team-1", "a/1");
+    s.record("opencode", "", "a/1");
+    expect(useClientModelMruStore.getState().byBackendTeam).toEqual({});
+  });
+
+  it("caps the list at 10", () => {
+    const s = useClientModelMruStore.getState();
+    for (let i = 0; i < 15; i++) s.record("opencode", "team-1", `p/${i}`);
+    const recent = useClientModelMruStore.getState().recentFor("opencode", "team-1");
+    expect(recent).toHaveLength(10);
+    expect(recent[0]).toBe("p/14");
+  });
+});
+
+describe("promote", () => {
+  it("returns the same array reference when nothing changed", () => {
+    // Lets the store skip the write, so re-picking the current model does not
+    // re-render every subscriber.
+    const recent = ["a/1", "b/2"];
+    expect(promote(recent, "a/1")).toBe(recent);
+  });
+});
+
+describe("firstAvailableMruModel", () => {
+  it("skips entries the catalog no longer offers", () => {
+    // The point of keeping a list: "last used" was retired, so the next usable
+    // entry wins instead of pinning something that cannot run.
+    expect(firstAvailableMruModel(["gone/x", "b/2"], CATALOG)).toBe("b/2");
+  });
+
+  it("returns empty when nothing matches", () => {
+    expect(firstAvailableMruModel(["gone/x"], CATALOG)).toBe("");
+  });
+
+  it("returns empty when the catalog has not arrived", () => {
+    // Empty catalog means "unknown", not "nothing runnable" — pinning against
+    // an unknown catalog is how the wrong model got stuck before.
+    expect(firstAvailableMruModel(["a/1"], [])).toBe("");
+  });
+
+  it("returns empty for an empty history", () => {
+    expect(firstAvailableMruModel([], CATALOG)).toBe("");
+    expect(firstAvailableMruModel(undefined, CATALOG)).toBe("");
+  });
+});

--- a/packages/app/src/stores/__tests__/participant-model-store.test.ts
+++ b/packages/app/src/stores/__tests__/participant-model-store.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useParticipantModelStore,
+  participantModel,
+  resetParticipantModelsForTests,
+} from "@/stores/participant-model-store";
+
+beforeEach(() => {
+  resetParticipantModelsForTests();
+});
+
+describe("participant model cache", () => {
+  it("caches by (session, actor)", () => {
+    useParticipantModelStore.getState().setForSession("s1", [
+      { actorId: "a1", model: "anthropic/claude-sonnet-4-6" },
+      { actorId: "a2", model: "openai/gpt-5" },
+    ]);
+    expect(participantModel("s1", "a1")).toBe("anthropic/claude-sonnet-4-6");
+    expect(participantModel("s1", "a2")).toBe("openai/gpt-5");
+    // Different session, same actor: not the same answer.
+    expect(participantModel("s2", "a1")).toBe("");
+  });
+
+  it("skips rows with no model rather than caching an empty answer", () => {
+    // Member participants have NULL here — not applicable, not missing. Caching
+    // '' for them would be indistinguishable from "we looked and found none".
+    useParticipantModelStore.getState().setForSession("s1", [
+      { actorId: "member-1", model: "" },
+      { actorId: "agent-1", model: "a/1" },
+    ]);
+    expect(participantModel("s1", "member-1")).toBe("");
+    expect(participantModel("s1", "agent-1")).toBe("a/1");
+  });
+
+  it("marks the session loaded so repeat fetches are skipped", () => {
+    useParticipantModelStore.getState().setForSession("s1", []);
+    expect(useParticipantModelStore.getState().loaded["s1"]).toBe(true);
+  });
+
+  it("returns empty for blank ids instead of building a junk key", () => {
+    useParticipantModelStore.getState().setForSession("s1", [
+      { actorId: "a1", model: "a/1" },
+    ]);
+    expect(participantModel("", "a1")).toBe("");
+    expect(participantModel("s1", "")).toBe("");
+    expect(participantModel(null, undefined)).toBe("");
+  });
+});

--- a/packages/app/src/stores/client-model-mru.ts
+++ b/packages/app/src/stores/client-model-mru.ts
@@ -1,0 +1,150 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { useCurrentTeamStore } from "@/stores/current-team";
+
+/**
+ * This client's most-recently-used models — the answer to "which model should a
+ * new chat start on?"
+ *
+ * # Why this lives here and not in the daemon
+ *
+ * It used to live in the daemon (`config::model_mru`), moved there because
+ * gateway and cron runtimes start inside amuxd and can never read localStorage.
+ * That reasoning held, but the cost was that amuxd owned a *preference*, and a
+ * preference is a thing clients can write wrong: a cold-start client wrote
+ * `available[0]`, the daemon recorded that run in its MRU, and every later new
+ * session inherited it — a loop that re-confirmed the wrong answer on every
+ * restart (`agent-model-auto-persist.ts`).
+ *
+ * ADR-0007 cuts it the other way: automation entry points (cron jobs, gateway
+ * channels) now pin a model when they are *created*, so nothing in the daemon
+ * needs to guess any more, and the MRU can go back to being what it always was
+ * — a client-side convenience. The feedback loop is gone with it: a bad pick
+ * here affects this client and no one else.
+ *
+ * # Why the key is (backend, team)
+ *
+ * Model ids are backend-local — `opencode/big-pickle` means nothing to pi — so
+ * the backend has to be in the key or a backend switch leaves a list of ids
+ * that can never match.
+ *
+ * Team is in the key because it is the *only* thing catalogs actually vary by.
+ * The daemon's store sharded by worktree; auditing 15 worktrees on one device
+ * found every difference traced to the team's LiteLLM gateway models or to probe
+ * staleness, and none to the directory (#742 decision 3). Keying by team tracks
+ * the real variable; keying by worktree would re-implement a split that was
+ * already disproved.
+ *
+ * # Scope
+ *
+ * Per install, deliberately. ADR-0007 accepts that Tauri and iOS each keep their
+ * own list and do not converge — this is a preference, not a product promise.
+ * Reinstalling loses it, and the first send after that asks the user to choose.
+ */
+
+/** Matches the daemon's old cap. Long enough to survive a couple of dead
+ *  providers, short enough to stay comprehensible. */
+const MAX_RECENT = 10;
+
+function key(backend: string, teamId: string): string {
+  return `${backend.trim()}::${teamId.trim()}`;
+}
+
+interface State {
+  /** `${backend}::${teamId}` → model ids, most recently used first. */
+  byBackendTeam: Record<string, string[]>;
+  record: (backend: string, teamId: string, modelId: string) => void;
+  recentFor: (backend: string, teamId: string) => string[];
+  clear: () => void;
+}
+
+export const useClientModelMruStore = create<State>()(
+  persist(
+    (set, get) => ({
+      byBackendTeam: {},
+      record: (backend, teamId, modelId) => {
+        const id = modelId.trim();
+        const b = backend.trim();
+        const t = teamId.trim();
+        if (!id || !b || !t) return;
+        set((s) => {
+          const k = key(b, t);
+          const next = promote(s.byBackendTeam[k] ?? [], id);
+          if (next === s.byBackendTeam[k]) return s;
+          return { byBackendTeam: { ...s.byBackendTeam, [k]: next } };
+        });
+      },
+      recentFor: (backend, teamId) => {
+        if (!backend.trim() || !teamId.trim()) return [];
+        return get().byBackendTeam[key(backend, teamId)] ?? [];
+      },
+      clear: () => set({ byBackendTeam: {} }),
+    }),
+    {
+      name: "teamclu.client-model-mru.v1",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({ byBackendTeam: s.byBackendTeam }),
+    },
+  ),
+);
+
+/** Stable identity so callers never see a fresh [] per read. */
+const EMPTY: string[] = [];
+
+/**
+ * This client's recent models for `backendType` in the current team.
+ *
+ * Imperative rather than a hook: two of the three call sites read it from
+ * inside a callback or a memo where a hook cannot go. Non-reactive is fine
+ * here — the list only changes when the user picks a model explicitly, and
+ * that same action writes a pick, which outranks this fallback anyway. So a
+ * stale read can never be the value actually shown.
+ *
+ * Centralised so the team lookup and the empty-key guards live in one place;
+ * three call sites each doing their own would be three chances to key the
+ * lookup slightly differently.
+ */
+export function clientMruModels(
+  backendType: string | null | undefined,
+): string[] {
+  const backend = backendType?.trim() ?? "";
+  const teamId = useCurrentTeamStore.getState().team?.id?.trim() ?? "";
+  if (!backend || !teamId) return EMPTY;
+  return useClientModelMruStore.getState().byBackendTeam[key(backend, teamId)] ?? EMPTY;
+}
+
+/**
+ * Move `id` to the front, capped. Returns the ORIGINAL array when nothing
+ * changed so the store can skip the write and avoid a needless re-render.
+ */
+export function promote(recent: readonly string[], id: string): string[] {
+  if (recent[0] === id) return recent as string[];
+  return [id, ...recent.filter((existing) => existing !== id)].slice(
+    0,
+    MAX_RECENT,
+  );
+}
+
+/**
+ * First remembered model the live catalog still offers, or `''`.
+ *
+ * This is the whole reason the MRU is a list and not a single value: the thing
+ * a single "last used" names can stop working — a provider gets logged out, a
+ * key expires, a model is retired — and pinning something that cannot run is
+ * worse than falling through to the next entry. Mirrors the daemon's
+ * `model_mru::first_available`, which this replaces.
+ *
+ * An empty `available` means the catalog has not arrived, NOT that nothing is
+ * runnable, so it yields `''` rather than guessing — callers must wait rather
+ * than pin a model against an unknown catalog.
+ */
+export function firstAvailableMruModel(
+  recent: readonly string[] | undefined,
+  available: readonly { id?: string }[],
+): string {
+  if (!recent?.length || available.length === 0) return "";
+  const offered = new Set(
+    available.map((m) => m.id?.trim()).filter((id): id is string => !!id),
+  );
+  return recent.map((id) => id?.trim()).find((id) => !!id && offered.has(id)) ?? "";
+}

--- a/packages/app/src/stores/client-model-mru.ts
+++ b/packages/app/src/stores/client-model-mru.ts
@@ -108,9 +108,20 @@ export function clientMruModels(
   backendType: string | null | undefined,
 ): string[] {
   const backend = backendType?.trim() ?? "";
-  const teamId = useCurrentTeamStore.getState().team?.id?.trim() ?? "";
-  if (!backend || !teamId) return EMPTY;
-  return useClientModelMruStore.getState().byBackendTeam[key(backend, teamId)] ?? EMPTY;
+  if (!backend) return EMPTY;
+  // Never throw: this feeds the agent pill, and a remembered preference is not
+  // worth taking the pill's render down for. Anything unexpected (a store not
+  // yet initialised, a test double without `getState`) reads as "no history".
+  try {
+    const teamId = useCurrentTeamStore.getState?.()?.team?.id?.trim() ?? "";
+    if (!teamId) return EMPTY;
+    return (
+      useClientModelMruStore.getState().byBackendTeam[key(backend, teamId)] ??
+      EMPTY
+    );
+  } catch {
+    return EMPTY;
+  }
 }
 
 /**

--- a/packages/app/src/stores/client-model-mru.ts
+++ b/packages/app/src/stores/client-model-mru.ts
@@ -103,9 +103,18 @@ const EMPTY: string[] = [];
  * Centralised so the team lookup and the empty-key guards live in one place;
  * three call sites each doing their own would be three chances to key the
  * lookup slightly differently.
+ *
+ * Pass `teamId` whenever the caller already resolved one. The store fallback is
+ * only a convenience for callers that have not: it reads `current-team`, which
+ * is empty for a moment on cold start, and an empty team here is indistinguish-
+ * able from "this device never picked a model" — which is what made the first
+ * send after launch stop for a model pick even on a device with an MRU. The
+ * send path resolves its team from the session list, so it must hand that one
+ * over rather than let this re-derive a different (and briefly empty) answer.
  */
 export function clientMruModels(
   backendType: string | null | undefined,
+  teamId?: string | null,
 ): string[] {
   const backend = backendType?.trim() ?? "";
   if (!backend) return EMPTY;
@@ -113,10 +122,12 @@ export function clientMruModels(
   // worth taking the pill's render down for. Anything unexpected (a store not
   // yet initialised, a test double without `getState`) reads as "no history".
   try {
-    const teamId = useCurrentTeamStore.getState?.()?.team?.id?.trim() ?? "";
-    if (!teamId) return EMPTY;
+    const explicit = teamId?.trim() ?? "";
+    const team =
+      explicit || (useCurrentTeamStore.getState?.()?.team?.id?.trim() ?? "");
+    if (!team) return EMPTY;
     return (
-      useClientModelMruStore.getState().byBackendTeam[key(backend, teamId)] ??
+      useClientModelMruStore.getState().byBackendTeam[key(backend, team)] ??
       EMPTY
     );
   } catch {

--- a/packages/app/src/stores/current-team.ts
+++ b/packages/app/src/stores/current-team.ts
@@ -143,8 +143,20 @@ export const useCurrentTeamStore = create<State>((set, get) => ({
   error: null,
 
   load: async () => {
-    const session = useAuthStore.getState().session;
+    const { session, loading: authLoading } = useAuthStore.getState();
     if (!session) {
+      // No session YET is not the same as no session. On cold start the auth
+      // store begins `{ session: null, loading: true }` and only resolves after
+      // a round trip; clearing here on that first pass threw away the snapshot
+      // `initialCurrentTeamState()` had just hydrated, and left `team: null`
+      // until the network answered. Anything reading the current team in that
+      // window saw a signed-out shell — including the client model MRU, whose
+      // lookup is keyed by team and so reported "never picked a model" and made
+      // the first send after every launch stop for a model pick.
+      if (authLoading) {
+        set({ loading: false, error: null });
+        return;
+      }
       await setLocalCacheTeamGate(null);
       set({ team: null, currentMember: null, teamUserId: null, loading: false, error: null });
       return;

--- a/packages/app/src/stores/model-pick-prompt-store.ts
+++ b/packages/app/src/stores/model-pick-prompt-store.ts
@@ -1,0 +1,35 @@
+import { create } from "zustand";
+
+/**
+ * "This agent needs the user to choose a model before anything can run."
+ *
+ * Set by the send path when `selectAgentModel` comes back `source: "unpicked"`
+ * — the catalog listed something, but nobody chose it, so the id on offer is
+ * just whatever the provider probe returned first (ADR-0007).
+ *
+ * A store rather than a prop because the two ends are far apart: the send path
+ * discovers the problem inside a callback in `use-chat-send`, and the thing
+ * that can fix it is the model popover inside one specific `AgentPill`. Threading
+ * a callback down would mean ChatPanel brokering between them for a signal
+ * neither of them owns.
+ *
+ * Deliberately not persisted: it is a request to open a menu, and a menu that
+ * springs open on the next launch because of a send three days ago is a bug,
+ * not a feature.
+ */
+interface State {
+  /** Agent whose picker should open, or `null` when nothing is pending. */
+  pendingAgentId: string | null;
+  request: (agentId: string) => void;
+  clear: () => void;
+}
+
+export const useModelPickPromptStore = create<State>((set) => ({
+  pendingAgentId: null,
+  request: (agentId) => {
+    const id = agentId.trim();
+    if (!id) return;
+    set({ pendingAgentId: id });
+  },
+  clear: () => set({ pendingAgentId: null }),
+}));

--- a/packages/app/src/stores/participant-model-store.ts
+++ b/packages/app/src/stores/participant-model-store.ts
@@ -1,0 +1,128 @@
+import { create } from "zustand";
+
+/**
+ * `session_participants.model` — the authoritative answer to "which model is
+ * this agent running on in this session" (ADR-0005, written by the daemon per
+ * ADR-0007).
+ *
+ * # Why a store and not just a read
+ *
+ * `selectAgentModel` is synchronous and runs on every render of the agent pill
+ * and on every send. It cannot await a fetch. So the value is fetched once per
+ * session and cached here, and the resolver reads the cache.
+ *
+ * # Why this outranks the transcript scan
+ *
+ * `session-established-model` derives the same fact by scanning messages for
+ * the newest one carrying a model. That works, but it is a reconstruction: it
+ * depends on the transcript being loaded, on message `model` fields being
+ * stamped, and on the "skip other agents' messages" heuristic holding. The
+ * participant row is the fact itself, written by the only component that
+ * observes what the runtime settled on. The scan stays as a fallback for the
+ * window where a daemon has not yet shipped the write.
+ *
+ * # Why not fold this into `session-participant-store`
+ *
+ * That store answers "who is in this session" for the mention popover, and it
+ * gets its rows from `sessionMembers.listParticipants` — the actor *directory*
+ * (display name, avatar, actor type). The working-state columns are not on that
+ * response at all, so folding this in would mean changing which endpoint the
+ * mention roster depends on. Different question, different endpoint, kept apart.
+ *
+ * # Not persisted
+ *
+ * A cached model for a session the user has not opened since is worth nothing —
+ * it is one request away, and a stale pin is exactly what this migration is
+ * removing. Cleared on reload with the rest of memory.
+ */
+
+/** `${sessionId}::${actorId}` → model id. */
+type Key = string;
+
+function key(sessionId: string, actorId: string): Key {
+  return `${sessionId.trim()}::${actorId.trim()}`;
+}
+
+interface State {
+  bySessionActor: Record<Key, string>;
+  /** Sessions already fetched, so N pills do not each fire a request. */
+  loaded: Record<string, true>;
+  setForSession: (sessionId: string, rows: { actorId: string; model: string }[]) => void;
+  clear: () => void;
+}
+
+export const useParticipantModelStore = create<State>((set) => ({
+  bySessionActor: {},
+  loaded: {},
+  setForSession: (sessionId, rows) => {
+    const sid = sessionId.trim();
+    if (!sid) return;
+    set((s) => {
+      const next = { ...s.bySessionActor };
+      for (const row of rows) {
+        const model = row.model?.trim();
+        const actorId = row.actorId?.trim();
+        if (!model || !actorId) continue;
+        next[key(sid, actorId)] = model;
+      }
+      return { bySessionActor: next, loaded: { ...s.loaded, [sid]: true } };
+    });
+  },
+  clear: () => set({ bySessionActor: {}, loaded: {} }),
+}));
+
+/** Cached authoritative model for `(session, actor)`, or `''` when unknown. */
+export function participantModel(
+  sessionId: string | null | undefined,
+  actorId: string | null | undefined,
+): string {
+  const sid = sessionId?.trim();
+  const aid = actorId?.trim();
+  if (!sid || !aid) return "";
+  // Never throw: this feeds the pill and the send path, and a missing cache
+  // entry must read as "unknown" rather than break either.
+  try {
+    return useParticipantModelStore.getState().bySessionActor[key(sid, aid)] ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** In-flight fetches, so N pills for one session share one request. */
+const inFlight = new Set<string>();
+
+/**
+ * Fetch and cache a session's participant models, once.
+ *
+ * Fire-and-forget: the resolver falls through to the transcript scan and the
+ * retain until this lands, so nothing waits on it. Failures are swallowed for
+ * the same reason — the fallbacks are still there.
+ */
+export function ensureParticipantModels(sessionId: string | null | undefined): void {
+  const sid = sessionId?.trim();
+  if (!sid) return;
+  const store = useParticipantModelStore.getState();
+  if (store.loaded[sid] || inFlight.has(sid)) return;
+  inFlight.add(sid);
+
+  void (async () => {
+    try {
+      const { getBackend } = await import("@/lib/backend");
+      const rows = await getBackend().sessions.getSessionParticipants(sid);
+      useParticipantModelStore.getState().setForSession(
+        sid,
+        rows.map((r) => ({ actorId: r.actor_id, model: r.model ?? "" })),
+      );
+    } catch (error) {
+      console.warn("[participant-model] fetch failed", error);
+    } finally {
+      inFlight.delete(sid);
+    }
+  })();
+}
+
+/** Test seam — drops the cache and any in-flight dedupe state. */
+export function resetParticipantModelsForTests(): void {
+  inFlight.clear();
+  useParticipantModelStore.getState().clear();
+}


### PR DESCRIPTION
ADR-0007 迁移的 P3：把**模型偏好**从 daemon 搬到客户端。P0–P2 已合入（#910 #911 #912），这一刀是桌面端与 iOS 两侧的客户端实现，外加一个冷启动首条消息必弹选择框的修复。

贯穿全篇的一条线：**搬走的是偏好，不是能力**。`catalog_models` / `available_models` 一行未动 —— 它们是远端 agent 唯一的模型来源，也是 pill 的就绪判据。

## 桌面端

**1. MRU 从 daemon 搬到客户端，键 `(backend, team)`**

新增 `stores/client-model-mru`，语义对齐被替换掉的 daemon `config::model_mru`：容量 10、promote 到表头、记住的模型若已不在 catalog 里就跳到下一条。

键选 `(backend, team)`：model id 是 backend-local，切后端后旧列表全是无效 id；而 team 是 catalog 唯一真实的变量（#742 查证 15 个 worktree 的差异全部来自团队 LiteLLM 网关模型与探测时间，无一来自目录），按 worktree 分片是已被推翻的做法。

写入只挂在**用户显式选模型**那一条路上 —— 自动选择绝不能写，那正是 `agent-model-auto-persist` 记录的自我强化循环。

**2. 没人选过的模型不再自动定下来**

`available[0]` 一直被当成最后兜底：pill 显示它、auto-persist 把它写成 pick、发送就用它。但那个顺序是 provider 探测顺序，不稳定 —— 而 pick 是持久的、优先级高于之后的一切信号，一次猜测就被永久钉住。

现在这一档有独立的 `source: "unpicked"`（与 `"fallback"`，即客户端 MRU 那种真实历史选择区分开）；id 照常返回所以 pill 不会空白，它是待确认的建议。发送路径遇到 unpicked 不发，改为通过 `model-pick-prompt-store` 请求打开对应 pill 的选择器，让拒绝是可行动的而不是静默的。

**3. 会话模型改读 `session_participants.model`**

云上那一列是权威（ADR-0005，由 daemon 写），排在 transcript 扫描和 retain 之前 —— 后两者都是同一事实的推导，前者是事实本身。

顺带修了一个真实缺口：cloud-api 的 `getSessionParticipants` mapper 只映射 `session_id/actor_id/role`，把 `model` / `workspaceId` / `lastProcessedMessageId` 全丢了 —— 服务端自 ADR-0005 起就返回这三个，类型也一直声明着，所以任何客户端读到的都是 `undefined`。

## iOS

**4. `ClientModelMRU`** —— 与桌面端同语义，UserDefaults 可注入。`SessionListViewModel` 原来的链是 `live.currentModel` → 空则退到 `presence.defaultModel`，而后者正是 P4 要停发的 daemon MRU 表头；改成先查本机 MRU，这样 P4 停发之后 iOS 不会失去兜底。

**5. `AgentModelResolution`** —— 修掉 4 引入的优先级倒置：客户端 MRU 曾被折进 `AgentAttachment.currentModel`，而那个字段在每个读取点都优先于 participant 行，于是本机偏好盖住了云端权威。根因是把偏好塞进了记录事实的结构里，偏好因此继承了事实的优先级。现在 attachment 只放事实，偏好只在解析时参与，顺序 `participant → live → clientMRU → unpicked`，与桌面端 `selectAgentModel` 一致。

顺带补上 iOS 的强制首选：原来 `nil` 表示「由 daemon 在 spawn 时挑」，那正是 ADR-0007 要消除的隐式解析。

## 冷启动修复

**6. 启动后第一条消息不再要求重选模型**

`backendTypeForSend` 只从 runtime state store 取，冷启动时 runtime 还没 attach，取到 `undefined` → `clientMruModels` 首行直接返回空 → 六个来源全空 → 落到 unpicked。**MRU 的 key 拼不出来，和「这台设备没有历史」在代码里长得一模一样。**

- 新增 `resolveAgentBackendType`：runtime 优先（正在跑什么），拿不到退到团队 directory 的 `default_agent_type`（该跑什么）。
- `current-team` 的 `load()` 在 auth 尚未恢复时会把缓存清成 null，同类问题的另一处。
- 两条发送路径（send / session-create）改用同一个 `resolveAgentSessionModel`。只共享 fallback 不够：session-create 的 available 只取 runtime retain，冷启动时是空的。

顺带修了两处同源问题：选择框弹出时输入框内容丢失；以及 `startAgentRuntimes` 绕过拦截把猜测值传给 `runtimeStart+setModel`，daemon 回显成 currentModel 后猜测值变成既定选择。

## 不在这个 PR 里

- **P4 + P5**（停发 proto 偏好字段、删 daemon `model_mru`）**不在**这里，留在本地 hold 分支。前提条件是 `actor_client_versions` 显示线上没有低于 P3 的活跃 reporter —— 提前合会让所有未升级客户端的模型 pill 变空，正是 #742 那个 bug 类别。
- 首条消息 workspace 冷启动的两个 commit 拆在另一条分支，与本 PR 无代码依赖。

## 验证

| 项 | 结果 |
|---|---|
| `pnpm typecheck` | 0 |
| `pnpm lint` | 0 errors |
| app 单测（全量） | 439 文件 / 2832 passed / 1 skipped |
| AMUXCore | XCTest 154 passed + swift-testing 226 tests / 46 suites，0 failures |

## review 建议先看

- `stores/client-model-mru.ts` —— 键为什么是 `(backend, team)`
- `lib/resolve-agent-session-model.ts` —— 两条发送路径共用的解析器
- `AgentModelResolution.swift` —— 优先级顺序，以及为什么不放进 attachment
- `lib/backend/cloud-api/sessions.ts` —— mapper 补回的三列

🤖 Generated with [Claude Code](https://claude.com/claude-code)
