### PR TITLE
fix(app): 缓存的默认工作区不再顶掉本该发生的工作区创建（修 main 红灯）

### DIFF
--- a/packages/app/src/lib/teamclu/__tests__/resolve-runtime-start-workspace.test.ts
+++ b/packages/app/src/lib/teamclu/__tests__/resolve-runtime-start-workspace.test.ts
@@ -27,6 +27,7 @@ import {
   ensureCloudWorkspaceIdForAgentRuntime,
   runtimeStartWorkspaceArgs,
 } from '../resolve-runtime-start-workspace'
+import { useAgentDefaultWorkspaceStore } from '@/stores/agent-default-workspace-store'
 
 describe('resolveAgentRuntimeWorkspaceId', () => {
   it('prefers caller hint over session runtime and defaults', () => {
@@ -195,6 +196,7 @@ describe('ensureCloudWorkspaceIdForAgentRuntime', () => {
     backendMocks.listDaemonWorkspaces.mockReset()
     backendMocks.createDaemonWorkspace.mockReset()
     backendMocks.listDaemonWorkspaces.mockResolvedValue([])
+    useAgentDefaultWorkspaceStore.getState().clear()
   })
 
   it('creates a cloud workspace when lookup and path match both fail', async () => {
@@ -225,5 +227,62 @@ describe('ensureCloudWorkspaceIdForAgentRuntime', () => {
       name: 'TeamClu',
       path: '/Users/me/TeamClu',
     })
+  })
+
+  it('still creates when this agent has a cached default from a previous run', async () => {
+    // The cache answers "what did this agent last start in", which is a hint.
+    // It cannot answer "does THIS path already have a cloud workspace" — and
+    // reading it here suppressed the create, leaving the runtime bound to a
+    // workspace pointing at a different directory.
+    useAgentDefaultWorkspaceStore.getState().remember('agent-1', 'ws-from-last-run')
+    backendMocks.createDaemonWorkspace.mockResolvedValue({
+      id: 'ws-new',
+      team_id: 'team-1',
+      agent_id: 'agent-1',
+      name: 'TeamClu',
+      path: '/Users/me/TeamClu',
+      archived: false,
+      created_at: '',
+      updated_at: '',
+    })
+
+    await expect(
+      ensureCloudWorkspaceIdForAgentRuntime({
+        teamId: 'team-1',
+        agentActorId: 'agent-1',
+        localWorkspacePath: '/Users/me/TeamClu',
+        createdByMemberId: 'member-1',
+      }),
+    ).resolves.toBe('ws-new')
+
+    expect(backendMocks.createDaemonWorkspace).toHaveBeenCalledTimes(1)
+    // And the freshly created one replaces the stale cache entry.
+    expect(useAgentDefaultWorkspaceStore.getState().recall('agent-1')).toBe('ws-new')
+  })
+
+  it('does not create when the path already resolves to a live workspace', async () => {
+    backendMocks.listDaemonWorkspaces.mockResolvedValue([
+      {
+        id: 'ws-live',
+        team_id: 'team-1',
+        agent_id: 'agent-1',
+        name: 'TeamClu',
+        path: '/Users/me/TeamClu',
+        archived: false,
+        created_at: '',
+        updated_at: '',
+      },
+    ])
+
+    await expect(
+      ensureCloudWorkspaceIdForAgentRuntime({
+        teamId: 'team-1',
+        agentActorId: 'agent-1',
+        localWorkspacePath: '/Users/me/TeamClu',
+        createdByMemberId: 'member-1',
+      }),
+    ).resolves.toBe('ws-live')
+
+    expect(backendMocks.createDaemonWorkspace).not.toHaveBeenCalled()
   })
 })

--- a/packages/app/src/lib/teamclu/resolve-runtime-start-workspace.ts
+++ b/packages/app/src/lib/teamclu/resolve-runtime-start-workspace.ts
@@ -172,6 +172,15 @@ export async function resolveCloudWorkspaceIdForAgents(
 /**
  * Resolve or create the cloud workspace UUID for runtimeStart.workspaceId.
  * Never returns a filesystem path.
+ *
+ * Deliberately resolves **live only**, unlike
+ * `resolveSessionWorkspaceHintForRuntimeStart`. Here a non-empty answer is an
+ * existence claim — "this path already has a cloud workspace, don't create one"
+ * — and a remembered id from a previous run cannot support that claim. Reading
+ * the cache here suppressed `createDaemonWorkspace` for a directory that had no
+ * workspace at all, leaving the runtime bound to one whose path is somewhere
+ * else entirely. The cache exists to avoid a slow start, not to answer whether
+ * a row exists.
  */
 export async function ensureCloudWorkspaceIdForAgentRuntime(args: {
   teamId: string
@@ -183,14 +192,19 @@ export async function ensureCloudWorkspaceIdForAgentRuntime(args: {
   const agentActorId = args.agentActorId.trim()
   if (!agentActorId || !args.teamId.trim()) return ''
 
-  const fromHint = await resolveSessionWorkspaceHintForRuntimeStart({
-    teamId: args.teamId,
-    localWorkspacePath: args.localWorkspacePath,
-    sessionId: args.sessionId,
-    agentActorIds: [agentActorId],
-    localDaemonActorId: args.localWorkspacePath?.trim() ? agentActorId : null,
-  })
-  if (fromHint) return fromHint
+  const fromLive = await resolveLiveWorkspaceHint(
+    {
+      teamId: args.teamId,
+      localWorkspacePath: args.localWorkspacePath,
+      sessionId: args.sessionId,
+      localDaemonActorId: args.localWorkspacePath?.trim() ? agentActorId : null,
+    },
+    [agentActorId],
+  )
+  if (fromLive) {
+    rememberDefaultWorkspaceId([agentActorId], fromLive)
+    return fromLive
+  }
 
   const path = args.localWorkspacePath?.trim()
   if (!path) return ''
@@ -204,7 +218,11 @@ export async function ensureCloudWorkspaceIdForAgentRuntime(args: {
       name,
       path,
     })
-    return created.id?.trim() || ''
+    const id = created.id?.trim() || ''
+    // A workspace we just created is as live as it gets — seed the cache with
+    // it so the next send skips the lookup round trip.
+    if (id) rememberDefaultWorkspaceId([agentActorId], id)
+    return id
   } catch {
     return ''
   }


### PR DESCRIPTION
**main 现在是红的。** `resolve-runtime-start-workspace.test.ts` 在 `d5a9787b` 绿，
在 #921 的合并点 `4f78b1b6` 变红（单跑也红，不是顺序 flake）。

## 根因不只是测试

#921 让 `resolveSessionWorkspaceHintForRuntimeStart` 在实时链路全空时退回
`cachedDefaultWorkspaceId`。但 `ensureCloudWorkspaceIdForAgentRuntime` 把这个返回值
当**存在性判据**用：

```ts
const fromHint = await resolveSessionWorkspaceHintForRuntimeStart({ … })
if (fromHint) return fromHint          // 非空 == “云上已有工作区，不用建”
…
await getBackend().workspaces.createDaemonWorkspace({ … })
```

这两件事在 #921 之前是同一回事（hint 只可能来自后端真实返回的行），之后不是了。

**生产后果**：某个 agent 在这台机器上留着上次的缓存 id → 用户换到一个云上还没有
工作区的新目录 → 实时链路正确地一无所获 → 缓存 id 被当成「已有工作区」返回 →
`createDaemonWorkspace` 永远不会被调用，runtime 绑到一个 path 指向别处的工作区上。

这正是 #921 自己 commit message 里论证过要避免的那件事：

> 缓存若能盖过实时值，在别的设备改了默认工作区之后，这台机器会把 runtime 起到
> 错的目录，用一个慢换来一个静默的错，更糟。

那条排序规则写在 hint 函数内部（实时优先、缓存只兜底），但没覆盖到把 hint 当判据
的调用方 —— 对判据来说，「缓存有值」和「实时查到」不能等价。

## 修法

`ensureCloudWorkspaceIdForAgentRuntime` 改走 live-only 的 `resolveLiveWorkspaceHint`。
缓存兜底留在发送路径上 —— #921 的性能收益在那条路，未受影响。

顺带在创建成功后回写缓存：刚建出来的工作区就是最新鲜的实时值，下一次发送可以省掉
那次查询。

## 测试

原来那条用例之所以红，是因为前一个 `describe` 的实时命中经由
`rememberDefaultWorkspaceId` 写进了模块级 store，跨用例漏了过来。**生产上是同一条
路径**，只是那里缓存本来就跨调用存活 —— 所以这不是"测试互相污染"，是测试恰好把
生产语义暴露了出来。

把泄漏变成显式覆盖：`beforeEach` 加 `clear()`，并新增两条断言 ——

- 带着上次的缓存仍然创建，且新建的 id 覆盖掉过期缓存
- 实时查得到就不创建

## 验证

- `pnpm test:unit` — 441 文件 / **2843 passed** / 1 skipped（修前 1 failed）
- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
