### PR TITLE
test(app): 钉住 #926 之后仍须保留的那一半——hint 路径的缓存兜底

### DIFF
--- a/packages/app/src/lib/teamclu/__tests__/resolve-runtime-start-workspace.test.ts
+++ b/packages/app/src/lib/teamclu/__tests__/resolve-runtime-start-workspace.test.ts
@@ -189,6 +189,31 @@ describe('resolveSessionWorkspaceHintForRuntimeStart', () => {
       }),
     ).resolves.toBe('ws-copilot')
   })
+
+  // The other half of the #926 contract. That change stopped
+  // ensureCloudWorkspaceIdForAgentRuntime from reading the cache, and pinned it
+  // with two tests. Nothing pins the cache fallback that must REMAIN here.
+  //
+  // It is load-bearing: an empty hint makes the daemon skip its workspace
+  // resolver entirely (runtime_lifecycle.rs runs it only when
+  // `!workspace_id.is_empty()`) and start in whatever worktree the client
+  // passed, so a new session's first send paid the backend cold start twice —
+  // the 5.5s #921 measured. Deleting the fallback as "the thing that caused the
+  // #926 bug" would silently bring that back, and no test would go red.
+  it('falls back to the remembered default when nothing is live', async () => {
+    useAgentDefaultWorkspaceStore.getState().clear()
+    useAgentDefaultWorkspaceStore.getState().remember('agent-1', 'ws-remembered')
+
+    await expect(
+      resolveSessionWorkspaceHintForRuntimeStart({
+        teamId: 'team-1',
+        localWorkspacePath: '/Users/me/brand-new-folder',
+        sessionId: 'sess-new',
+        agentActorIds: ['agent-1'],
+        localDaemonActorId: 'agent-1',
+      }),
+    ).resolves.toBe('ws-remembered')
+  })
 })
 
 describe('ensureCloudWorkspaceIdForAgentRuntime', () => {


### PR DESCRIPTION
> 这个 PR 原本是和 #926 撞车的重复修复。#926 先合了，改法一致且更完整，
> 所以实现部分全部丢弃，只保留 #926 没覆盖到的那一条测试。

## 为什么还需要这条

#926 修的是 `ensureCloudWorkspaceIdForAgentRuntime` **不许**读缓存，并配了两条测试钉住。
但没有任何测试钉住另一半：`resolveSessionWorkspaceHintForRuntimeStart` 里的缓存兜底
**必须留着**。

这条兜底是有承重作用的。空 `workspaceId` 会让 daemon 完全跳过 workspace resolver
（`runtime_lifecycle.rs` 里只在 `!workspace_id.is_empty()` 时才跑），直接用客户端传的
`worktree` 起 —— 新会话首条消息因此把后端冷启动付了两次，就是 #921 实测的那 5.5 秒。

风险很具体：这条兜底现在**看起来像是 #926 那个 bug 的元凶**。谁要是顺手把它删掉，
#921 的提速会静悄悄消失，而且没有一条测试会红。

## 实测有效性

把实现里的 `return cachedDefaultWorkspaceId(agentActorIds)` 改成 `return ''`：

```
FAIL  resolveSessionWorkspaceHintForRuntimeStart > falls back to the remembered default when nothing is live
Tests  1 failed | 13 passed (14)
```

只有这条新测试红，#926 的两条仍绿 —— 它精确地补上了另一面。

## 验证

- 只加 25 行测试，**不动任何实现**
- `pnpm typecheck` → 0
- `pnpm lint` → 0 errors
- 该测试文件 14 条全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)