### PR TITLE
fix(app): retain MCP tool counts across refresh

### DIFF
--- a/packages/app/src/components/sidebar/TeamShareNavSection.tsx
+++ b/packages/app/src/components/sidebar/TeamShareNavSection.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { Sparkles, Plug, Box, Bookmark } from 'lucide-react'
 import { useUIStore } from '@/stores/ui'
 import { useTeamShareBrowserStore, type TeamShareSection } from '@/stores/team-share-browser'
+import { useCurrentTeamStore } from '@/stores/current-team'
+import { useWorkspaceStore } from '@/stores/workspace'
 import { cn } from '@/lib/utils'
 
 interface SectionDef {
@@ -74,6 +76,8 @@ export function TeamShareNavSection() {
   const { t } = useTranslation()
   const filter = useUIStore((s) => s.sidebarFilter)
   const setFilter = useUIStore((s) => s.setSidebarFilter)
+  const currentTeamId = useCurrentTeamStore((s) => s.team?.id ?? null)
+  const workspacePath = useWorkspaceStore((s) => s.workspacePath)
 
   const loadSection = useTeamShareBrowserStore((s) => s.loadSection)
   const loadCounts = useTeamShareBrowserStore((s) => s.loadCounts)
@@ -96,8 +100,9 @@ export function TeamShareNavSection() {
   }
 
   React.useEffect(() => {
+    if (!currentTeamId || !workspacePath) return
     void loadCounts()
-  }, [loadCounts])
+  }, [currentTeamId, workspacePath, loadCounts])
 
   const handleSelect = React.useCallback(
     (section: TeamShareSection) => {

--- a/packages/app/src/components/sidebar/__tests__/TeamShareNavSection.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/TeamShareNavSection.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import React from 'react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, fallback: string) => fallback }),
+}))
+
+const teamState = vi.hoisted(() => ({ id: null as string | null }))
+vi.mock('@/stores/current-team', () => ({
+  useCurrentTeamStore: (selector: (state: { team: { id: string } | null }) => unknown) =>
+    selector({ team: teamState.id ? { id: teamState.id } : null }),
+}))
+
+const workspaceState = vi.hoisted(() => ({ path: '/workspace' as string | null }))
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: (selector: (state: { workspacePath: string | null }) => unknown) =>
+    selector({ workspacePath: workspaceState.path }),
+}))
+
+const { loadCounts, loadSection, setSidebarFilter } = vi.hoisted(() => ({
+  loadCounts: vi.fn(),
+  loadSection: vi.fn(),
+  setSidebarFilter: vi.fn(),
+}))
+vi.mock('@/stores/team-share-browser', () => ({
+  useTeamShareBrowserStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      loadCounts,
+      loadSection,
+      skills: { items: [] },
+      mcp: { items: [] },
+      envCount: 0,
+      knowledge: { items: [] },
+      skillLocalState: {},
+    }),
+}))
+vi.mock('@/stores/ui', () => ({
+  useUIStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ sidebarFilter: { kind: 'sessions' }, setSidebarFilter }),
+}))
+
+import { TeamShareNavSection } from '../TeamShareNavSection'
+
+describe('TeamShareNavSection', () => {
+  it('loads counts after the current team becomes available', async () => {
+    teamState.id = null
+    loadCounts.mockReset()
+
+    const view = render(<TeamShareNavSection />)
+    expect(loadCounts).not.toHaveBeenCalled()
+
+    teamState.id = 'team-1'
+    view.rerender(<TeamShareNavSection />)
+
+    await waitFor(() => expect(loadCounts).toHaveBeenCalledTimes(1))
+  })
+})

--- a/packages/app/src/stores/__tests__/team-share-mcp-rows.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-mcp-rows.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { TeamMcpServer } from '@/lib/backend/types'
 import type { DaemonMcpServerConfig, DaemonMcpServerProbeResult } from '@/lib/daemon-local-client'
-import { applyMcpProbes, planMcpItems } from '../team-share-browser'
+import { applyMcpProbes, mergeTeamMcpCatalogAndDaemon, planMcpItems } from '../team-share-browser'
 
 const catalogEntry = (installed: boolean): TeamMcpServer => ({
   name: 'memory',
@@ -87,6 +87,24 @@ describe('applyMcpProbes', () => {
 
     expect(applyMcpProbes(rows, { memory: readyProbe })[0]).toMatchObject({
       id: 'memory',
+      probeStatus: 'ready',
+      tools: ['remember'],
+    })
+  })
+})
+
+describe('mergeTeamMcpCatalogAndDaemon', () => {
+  it('retains the prior probe while the same MCP rows are reloaded', () => {
+    const previous = applyMcpProbes(planMcpItems([catalogEntry(true)], {}), {
+      memory: {
+        probe_status: 'ready',
+        tools: ['remember'],
+        error: null,
+        probed_at: '2026-08-16T00:00:00Z',
+      },
+    })
+
+    expect(mergeTeamMcpCatalogAndDaemon([catalogEntry(true)], {}, previous)[0]).toMatchObject({
       probeStatus: 'ready',
       tools: ['remember'],
     })

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -543,8 +543,28 @@ async function listTeamSkills(
 export function mergeTeamMcpCatalogAndDaemon(
   catalog: TeamMcpServer[],
   daemonConfig: Record<string, DaemonMcpServerConfig>,
+  previousItems: TeamMcpItem[] = [],
 ): TeamMcpItem[] {
-  return planMcpItems(catalog, daemonConfig)
+  return preserveMcpProbes(planMcpItems(catalog, daemonConfig), previousItems)
+}
+
+/**
+ * Catalog/config refresh creates fresh rows, while probing is asynchronous.
+ * Keep the last known probe for a surviving row so switching sections does not
+ * briefly repaint it as "0 tools" before the daemon's cached probe returns.
+ */
+export function preserveMcpProbes(items: TeamMcpItem[], previousItems: TeamMcpItem[]): TeamMcpItem[] {
+  const previousById = new Map(previousItems.map((item) => [item.id, item]))
+  return items.map((item) => {
+    const previous = previousById.get(item.id)
+    if (!previous) return item
+    return {
+      ...item,
+      probeStatus: previous.probeStatus,
+      tools: previous.tools,
+      error: previous.error,
+    }
+  })
 }
 
 /**
@@ -624,7 +644,11 @@ export function applyMcpProbes(
   })
 }
 
-async function listTeamMcp(wsPath: string, teamId: string | null): Promise<TeamMcpItem[]> {
+async function listTeamMcp(
+  wsPath: string,
+  teamId: string | null,
+  previousItems: TeamMcpItem[] = [],
+): Promise<TeamMcpItem[]> {
   const wid = encodeWorkspaceId(wsPath)
   const daemonConfig = await getDaemonMcp(wid).catch(() => ({}) as Record<string, DaemonMcpServerConfig>)
 
@@ -636,7 +660,7 @@ async function listTeamMcp(wsPath: string, teamId: string | null): Promise<TeamM
       // fall back to the daemon's view rather than showing an empty team.
       .catch(() => [])
   }
-  return mergeTeamMcpCatalogAndDaemon(catalog, daemonConfig)
+  return mergeTeamMcpCatalogAndDaemon(catalog, daemonConfig, previousItems)
 }
 
 /** Raised by the Rust installer instead of overwriting a locally edited pack. */
@@ -1422,7 +1446,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
         const items = wsPath ? await listTeamKnowledge(wsPath) : []
         set({ knowledgeRoot: root, knowledge: { items, loading: false, loaded: true, error: null } })
       } else if (section === 'mcp') {
-        const items = wsPath ? await listTeamMcp(wsPath, currentTeamId()) : []
+        const items = wsPath ? await listTeamMcp(wsPath, currentTeamId(), get().mcp.items) : []
         set({ mcp: { items, loading: false, loaded: true, error: null } })
         if (opts?.withTools) await get().loadMcpTools()
       }


### PR DESCRIPTION
## Summary
- Reload team-share navigation counts after the active team and workspace are ready.
- Preserve MCP probe results while the catalog is refreshed, avoiding transient 0-tool rows.
- Add regression coverage for both behaviors.

## Test Plan
- pnpm --filter @teamclu/app exec vitest run src/components/sidebar/__tests__/TeamShareNavSection.test.tsx src/stores/__tests__/team-share-mcp-rows.test.ts src/lib/__tests__/daemon-mcp-tools.test.ts --maxWorkers=1
- pnpm --filter @teamclu/app typecheck