### PR TITLE
fix(amuxd): clear stale team MCP cache on uninstall

### DIFF
--- a/apps/daemon/src/config/team_mcp.rs
+++ b/apps/daemon/src/config/team_mcp.rs
@@ -3,8 +3,9 @@
 //!
 //! The file format is unchanged (Cursor `mcpServers`) because the server hands
 //! back exactly that shape — see `docs/architecture/team-mcp-and-env-cloud.md`.
-//! The synced `teamclu-team/.mcp/` directory is no longer synced, but is still
-//! read for machines that already have it; the cloud copy always wins.
+//! The synced `teamclu-team/.mcp/` directory is no longer synced and is only a
+//! fallback before the daemon has a valid cloud cache. Once that cache exists,
+//! it is authoritative — including when it is empty after an uninstall.
 //!
 //! Merged at read time with workspace `opencode.json` entries. On name
 //! collision the workspace layer wins (user local override).
@@ -83,11 +84,9 @@ pub(crate) fn onboarded_team_id() -> Option<String> {
 
 /// Directories holding team MCP definitions, **least** preferred first.
 ///
-/// The cloud cache is last so it wins on a name collision. The legacy synced
-/// `teamclu-team/.mcp/` is still read rather than dropped: `.mcp/` is no longer
-/// synced, so those files can only exist on a machine that already had them —
-/// reading them keeps a pre-migration checkout working, and the ordering means
-/// they can never shadow what the member actually installed.
+/// The legacy synced `teamclu-team/.mcp/` is used only when there is no valid
+/// cloud cache yet. That preserves pre-migration offline checkouts without
+/// allowing a stale legacy file to resurrect a server that this actor removed.
 fn team_mcp_dirs(workspace: &Path) -> Vec<PathBuf> {
     let team_id = onboarded_team_id();
     let legacy = match &team_id {
@@ -141,38 +140,45 @@ pub(crate) fn convert_cursor_server(server: &CursorMcpServer) -> McpServerConfig
 
 /// Scan every team MCP source for `*.json` in Cursor `mcpServers` format.
 ///
-/// Later directories override earlier ones on a name collision — see
-/// [`team_mcp_dirs`] for the ordering and why.
+/// A valid cloud cache is authoritative. Only when it is absent or malformed do
+/// we fall back to the legacy directories for pre-migration offline support.
 pub fn scan_team_mcp(workspace: &Path) -> HashMap<String, McpServerConfig> {
+    if let Some(team_id) = onboarded_team_id() {
+        let mut cloud_servers = HashMap::new();
+        if read_cloud_mcp_file_into(
+            &crate::runtime::team_cloud_config::team_cloud_mcp_file(&team_id),
+            &mut cloud_servers,
+        ) {
+            return cloud_servers;
+        }
+    }
+
     let mut team_servers = HashMap::new();
-    // Legacy first so it can never shadow the cloud file — see `team_mcp_dirs`.
     for mcp_dir in team_mcp_dirs(workspace) {
         scan_team_mcp_dir_into(&mcp_dir, &mut team_servers);
-    }
-    if let Some(team_id) = onboarded_team_id() {
-        read_cloud_mcp_file_into(
-            &crate::runtime::team_cloud_config::team_cloud_mcp_file(&team_id),
-            &mut team_servers,
-        );
     }
     team_servers
 }
 
 /// Read the cloud file in Cursor `{ "mcpServers": … }` shape.
-fn read_cloud_mcp_file_into(path: &Path, out: &mut HashMap<String, McpServerConfig>) {
+/// Returns `true` only when the cache has a valid MCP map, including an empty
+/// one. In that case it replaces rather than augments `out` so a legacy server
+/// cannot survive a successful uninstall.
+fn read_cloud_mcp_file_into(path: &Path, out: &mut HashMap<String, McpServerConfig>) -> bool {
     let Ok(content) = std::fs::read_to_string(path) else {
-        return;
+        return false;
     };
     let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
-        return;
+        return false;
     };
     let Some(map) = json
         .get("mcpServers")
         .and_then(|v| v.as_object())
         .or_else(|| json.get("mcp").and_then(|v| v.as_object()))
     else {
-        return;
+        return false;
     };
+    out.clear();
     for (name, raw) in map {
         if let Ok(parsed) = serde_json::from_value::<CursorMcpServer>(raw.clone()) {
             out.insert(name.clone(), convert_cursor_server(&parsed));
@@ -180,6 +186,7 @@ fn read_cloud_mcp_file_into(path: &Path, out: &mut HashMap<String, McpServerConf
             out.insert(name.clone(), cfg);
         }
     }
+    true
 }
 
 fn scan_team_mcp_dir_into(mcp_dir: &Path, out: &mut HashMap<String, McpServerConfig>) {
@@ -437,6 +444,26 @@ mod tests {
         assert_eq!(merged.get("shared").unwrap().command, vec!["fresh"]);
         // ...but it does not erase entries the cloud never mentioned.
         assert_eq!(merged.get("legacy-only").unwrap().command, vec!["keep"]);
+    }
+
+    #[test]
+    fn an_empty_cloud_cache_removes_legacy_team_servers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("legacy");
+        let cloud = tmp.path().join("mcp.json");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(
+            legacy.join("stale.json"),
+            r#"{"mcpServers":{"stale":{"command":"npx","args":["stale-mcp"]}}}"#,
+        )
+        .unwrap();
+        std::fs::write(&cloud, r#"{"mcpServers":{}}"#).unwrap();
+
+        let mut merged = HashMap::new();
+        scan_team_mcp_dir_into(&legacy, &mut merged);
+        read_cloud_mcp_file_into(&cloud, &mut merged);
+
+        assert!(merged.is_empty());
     }
 
     #[test]

--- a/apps/daemon/src/runtime/team_cloud_config.rs
+++ b/apps/daemon/src/runtime/team_cloud_config.rs
@@ -24,14 +24,11 @@
 //!
 //! # The cache never shrinks on failure
 //!
-//! A fetch error leaves the previous cache **exactly as it was**. This is the
-//! whole offline story, and it also closes a subtler trap: if the team MCP map
-//! were allowed to go empty while entries were still materialized into a
-//! workspace's `opencode.json`, `classify_source` would reclassify every one of
-//! them as `Workspace`, the UI would offer them for editing, and
-//! `filter_put_body` would persist them as workspace-owned — a permanent local
-//! fork that survives the network coming back. Keeping stale-but-correct data
-//! is strictly better than briefly correct-looking emptiness.
+//! A fetch error leaves the previous cache **exactly as it was**. A successful
+//! fetch returning an empty `mcpServers` map is different: it is authoritative
+//! evidence that this actor has no installed team MCP servers and must clear
+//! the cache. Otherwise an uninstall would report success while the daemon
+//! continued running the stale server.
 //!
 //! Note the in-memory TTL cache used by [`crate::runtime::managed_llm`] is not
 //! sufficient here: it is process-local and empty after every daemon restart.
@@ -256,26 +253,6 @@ fn team_mcp_write_lock(team_id: &str) -> Arc<SyncMutex<()>> {
     )
 }
 
-fn cloud_mcp_file_has_servers(path: &Path) -> bool {
-    let Ok(body) = std::fs::read_to_string(path) else {
-        return false;
-    };
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) else {
-        return false;
-    };
-    let cursor = json
-        .get("mcpServers")
-        .and_then(|v| v.as_object())
-        .map(|o| !o.is_empty())
-        .unwrap_or(false);
-    let legacy = json
-        .get("mcp")
-        .and_then(|v| v.as_object())
-        .map(|o| !o.is_empty())
-        .unwrap_or(false);
-    cursor || legacy
-}
-
 /// Write the Cursor SSOT and refresh the OpenCode-only generated adapter.
 pub fn replace_team_mcp_cache(
     team_id: &str,
@@ -431,10 +408,6 @@ impl TeamCloudConfigResolver {
             .get("mcpServers")
             .cloned()
             .unwrap_or(serde_json::json!({}));
-        let incoming_empty = servers.as_object().map(|o| o.is_empty()).unwrap_or(true);
-        if incoming_empty && cloud_mcp_file_has_servers(&team_cloud_mcp_file(team_id)) {
-            return Some(false);
-        }
 
         match replace_team_mcp_cache(team_id, &servers) {
             Ok(changed) => Some(changed),
@@ -600,5 +573,28 @@ mod tests {
                 .collect();
             assert_eq!(cursor_names, generated_names);
         }
+    }
+
+    #[tokio::test]
+    async fn reconcile_mcp_clears_a_populated_cache_when_the_cloud_returns_no_servers() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_amuxd_home(home.path());
+        let team_id = "empty-mcp-team";
+        replace_team_mcp_cache(
+            team_id,
+            &serde_json::json!({
+                "stale": { "command": "npx", "args": ["stale-mcp"] }
+            }),
+        )
+        .unwrap();
+
+        let resolver =
+            TeamCloudConfigResolver::new(Arc::new(crate::backend::mock::MockBackend::new()));
+
+        assert_eq!(resolver.reconcile_mcp(team_id).await, Some(true));
+        let cache: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(team_cloud_mcp_file(team_id)).unwrap())
+                .unwrap();
+        assert_eq!(cache, serde_json::json!({ "mcpServers": {} }));
     }
 }


### PR DESCRIPTION
## Summary
- Clear the daemon MCP cache when the Cloud API confirms no installed servers remain.
- Treat a valid Cloud MCP cache as authoritative, preventing legacy .mcp files from resurrecting an uninstalled server.
- Add regressions for both stale-cache paths.

## Test Plan
- cargo test -p amuxd reconcile_mcp_clears_a_populated_cache_when_the_cloud_returns_no_servers
- cargo test -p amuxd an_empty_cloud_cache_removes_legacy_team_servers