### PR TITLE
fix(app): silently retry runtime network errors

### DIFF
--- a/packages/app/src/hooks/__tests__/use-ensure-engaged-runtimes-on-session-focus.test.ts
+++ b/packages/app/src/hooks/__tests__/use-ensure-engaged-runtimes-on-session-focus.test.ts
@@ -252,6 +252,32 @@ describe('useEnsureEngagedRuntimesOnSessionFocus', () => {
     vi.useRealTimers()
   })
 
+  it('retries runtime startup errors on an interval', () => {
+    vi.useFakeTimers()
+
+    renderHook(() =>
+      useEnsureEngagedRuntimesOnSessionFocus({
+        sessionId: 'session-a',
+        teamId: 'team-1',
+        engagedUiEntries: [entry('agent-1', 'runtime-error')],
+      }),
+    )
+
+    expect(ensureMock).toHaveBeenCalledTimes(1)
+    ensureMock.mockClear()
+    vi.advanceTimersByTime(3_100)
+    vi.advanceTimersByTime(15_000)
+    expect(ensureMock).toHaveBeenCalledWith({
+      sessionId: 'session-a',
+      teamId: 'team-1',
+      agentActorIds: ['agent-1'],
+      reason: 'session_runtime_retry',
+      sessionRuntimeByAgent: undefined,
+    })
+
+    vi.useRealTimers()
+  })
+
   it('does not retry on an interval when agent is LWT-offline', async () => {
     vi.useFakeTimers()
 

--- a/packages/app/src/lib/teamclu/__tests__/ensure-agent-runtime-cancelled-notify.test.ts
+++ b/packages/app/src/lib/teamclu/__tests__/ensure-agent-runtime-cancelled-notify.test.ts
@@ -63,6 +63,41 @@ describe("notifyRuntimeStartFailures", () => {
     expect(mocks.toastError).not.toHaveBeenCalled();
   });
 
+  it("does not toast a transient Cloud API network failure", async () => {
+    const { notifyRuntimeStartFailures } = await import("../ensure-agent-runtime");
+
+    notifyRuntimeStartFailures(
+      [
+        {
+          agentActorId: "agent-1",
+          code: "runtime_rpc_failed",
+          reason:
+            "fetch_session_with_participants failed: cloud_api provider error: None: error sending request for url (https://api.teamclu-dev.ucar.cc/v1/auth/refresh)",
+        },
+      ],
+      { trigger: "session_runtime_retry" },
+    );
+    await flush();
+
+    expect(mocks.reportRuntimeStartFailure).toHaveBeenCalledTimes(1);
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("still toasts a terminal Cloud API auth failure", async () => {
+    const { notifyRuntimeStartFailures } = await import("../ensure-agent-runtime");
+
+    notifyRuntimeStartFailures([
+      {
+        agentActorId: "agent-1",
+        code: "runtime_rpc_failed",
+        reason: "fetch_session_with_participants failed: auth error: invalid_grant",
+      },
+    ]);
+    await flush();
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(1);
+  });
+
   it("still toasts a genuine runtime failure", async () => {
     const { notifyRuntimeStartFailures } = await import("../ensure-agent-runtime");
 

--- a/packages/app/src/lib/teamclu/ensure-agent-runtime.ts
+++ b/packages/app/src/lib/teamclu/ensure-agent-runtime.ts
@@ -38,6 +38,7 @@ import {
 import { sessionFlowError, sessionFlowLog } from "@/lib/session-flow-log";
 import {
   isCancelledRuntimeFailure,
+  isTransientRuntimeNetworkFailure,
   reportRuntimeEnsureCrash,
   reportRuntimeRpcNotReady,
   reportRuntimeStartFailure,
@@ -123,12 +124,15 @@ export function notifyRuntimeStartFailures(
       { actorId: failure.agentActorId },
     );
   }
-  // Offline presence is already persistent in the selected-agent status, and
-  // reconnect will retry automatically. A request we cancelled ourselves is
-  // likewise recovered by the next retry tick. Keep both in telemetry/debug,
-  // but do not duplicate these expected states as transient error toasts.
+  // Offline presence is already persistent in the selected-agent status.
+  // Client-cancelled requests and daemon → Cloud API network failures are
+  // retried by the recoverable-runtime tick. Keep these in telemetry/debug,
+  // but do not duplicate expected transient states as error toasts.
   const toastable = failures.filter(
-    (f) => f.code !== "device_offline" && !isCancelledRuntimeFailure(f.reason),
+    (f) =>
+      f.code !== "device_offline" &&
+      !isCancelledRuntimeFailure(f.reason) &&
+      !isTransientRuntimeNetworkFailure(f.reason),
   );
   if (toastable.length === 0) return;
   void import("sonner").then(({ toast }) => {

--- a/packages/app/src/lib/telemetry/__tests__/runtime-error-report.test.ts
+++ b/packages/app/src/lib/telemetry/__tests__/runtime-error-report.test.ts
@@ -15,6 +15,7 @@ import {
   __resetSentryModuleForTest,
   classifyRuntimeFailureReason,
   isCancelledRuntimeFailure,
+  isTransientRuntimeNetworkFailure,
   reportRuntimeEnsureCrash,
   reportRuntimeRpcNotReady,
   reportRuntimeStartFailure,
@@ -71,6 +72,20 @@ describe('classifyRuntimeFailureReason', () => {
     expect(isCancelledRuntimeFailure('rpc timeout after 20000ms')).toBe(false)
     expect(isCancelledRuntimeFailure('runtimeStart rejected')).toBe(false)
     expect(isCancelledRuntimeFailure(undefined)).toBe(false)
+  })
+
+  it('classifies transient Cloud API transport failures separately from auth rejection', () => {
+    const sendFailed =
+      'fetch_session_with_participants failed: cloud_api provider error: None: error sending request for url (https://api.teamclu-dev.ucar.cc/v1/auth/refresh)'
+    const refreshTimedOut =
+      'fetch_session_with_participants failed: cloud_api provider error: None: token refresh timed out'
+
+    expect(classifyRuntimeFailureReason(sendFailed)).toBe('cloud_network_error')
+    expect(classifyRuntimeFailureReason(refreshTimedOut)).toBe('cloud_network_error')
+    expect(isTransientRuntimeNetworkFailure(sendFailed)).toBe(true)
+    expect(isTransientRuntimeNetworkFailure(refreshTimedOut)).toBe(true)
+    expect(isTransientRuntimeNetworkFailure('auth error: invalid_grant')).toBe(false)
+    expect(isTransientRuntimeNetworkFailure('not found: session not found')).toBe(false)
   })
 })
 
@@ -145,6 +160,29 @@ describe('reportRuntimeStartFailure', () => {
       level: 'warning',
       fingerprint: ['runtime', 'runtime_start_failure', 'runtime_rpc_failed', 'rpc_disposed'],
       tags: { runtime_failure_reason_kind: 'rpc_disposed' },
+    })
+  })
+
+  it('downgrades a transient Cloud API network failure to warning', async () => {
+    reportRuntimeStartFailure({
+      agentActorId: 'agent-1',
+      code: 'runtime_rpc_failed',
+      reason:
+        'fetch_session_with_participants failed: cloud_api provider error: None: error sending request for url (https://api.teamclu-dev.ucar.cc/v1/auth/refresh)',
+    })
+    await flush()
+
+    expect(mocks.captureMessage).toHaveBeenCalledTimes(1)
+    const [, options] = mocks.captureMessage.mock.calls[0] as [string, Record<string, never>]
+    expect(options).toMatchObject({
+      level: 'warning',
+      fingerprint: [
+        'runtime',
+        'runtime_start_failure',
+        'runtime_rpc_failed',
+        'cloud_network_error',
+      ],
+      tags: { runtime_failure_reason_kind: 'cloud_network_error' },
     })
   })
 

--- a/packages/app/src/lib/telemetry/runtime-error-report.ts
+++ b/packages/app/src/lib/telemetry/runtime-error-report.ts
@@ -42,6 +42,7 @@ export type RuntimeFailureReasonKind =
   | 'mqtt_publish_failed'
   | 'mqtt_disconnected'
   | 'device_offline'
+  | 'cloud_network_error'
   | 'daemon_rejected'
   | 'unknown'
 
@@ -68,6 +69,12 @@ export function classifyRuntimeFailureReason(reason: string | undefined): Runtim
     return 'mqtt_disconnected'
   }
   if (lower.includes('device offline')) return 'device_offline'
+  if (
+    lower.includes('error sending request for url') ||
+    lower.includes('token refresh timed out')
+  ) {
+    return 'cloud_network_error'
+  }
   if (lower.includes('publish')) return 'mqtt_publish_failed'
   if (lower.includes('rejected')) return 'daemon_rejected'
   return 'unknown'
@@ -89,17 +96,23 @@ export function isCancelledRuntimeFailure(reason: string | undefined): boolean {
   return classifyRuntimeFailureReason(reason) === 'rpc_disposed'
 }
 
+/** A daemon → Cloud API transport failure that the runtime retry loop can recover. */
+export function isTransientRuntimeNetworkFailure(reason: string | undefined): boolean {
+  return classifyRuntimeFailureReason(reason) === 'cloud_network_error'
+}
+
 /**
- * Offline transports are expected states, not defects — keep them off the error
- * feed. Same for a request we cancelled ourselves, which the `code` alone
- * cannot express: it arrives as a plain `runtime_rpc_failed`.
+ * Offline transports and transient Cloud API failures are expected recoverable
+ * states — keep them off the error feed. Same for a request we cancelled
+ * ourselves, which the `code` alone cannot express: it arrives as a plain
+ * `runtime_rpc_failed`.
  */
 function levelFor(
   code: RuntimeStartFailureCode | undefined,
   reasonKind: RuntimeFailureReasonKind,
 ): TelemetryLevel {
   if (code === 'device_offline' || code === 'transport_offline') return 'warning'
-  if (reasonKind === 'rpc_disposed') return 'warning'
+  if (reasonKind === 'rpc_disposed' || reasonKind === 'cloud_network_error') return 'warning'
   return 'error'
 }
 


### PR DESCRIPTION
## Summary
- retry transient runtime network failures without surfacing a user-facing toast
- preserve cancellation notifications and report non-network runtime failures
- add coverage for session-focus retry and runtime error classification

## Testing
- Not run locally (creating PR from the existing committed branch)