### PR TITLE
feat(extension): support invite-only team onboarding

### DIFF
--- a/packages/app/src/components/auth/AuthGate.tsx
+++ b/packages/app/src/components/auth/AuthGate.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useAuthStore } from "@/stores/auth-store";
+import { useAuthStore, type AuthClaimResult } from "@/stores/auth-store";
 import { useCurrentTeamStore, readCachedCurrentTeam } from "@/stores/current-team";
 import { getBackend } from "@/lib/backend";
 import { isTauri, removeStartupSkeleton } from "@/lib/utils";
@@ -133,6 +133,11 @@ export function AuthGate({ children }: AuthGateProps) {
   const [lastUsedTeamId, setLastUsedTeamId] = useState<string | null>(null);
   const extensionRequiresInvitation =
     isChromeExtension() && !extensionTeamOnboarding.autoCreateTeam;
+  // Team discovery must not race a link invite claim. The claim enters the
+  // invited team and clears the token asynchronously; keeping the promise in
+  // a ref lets the bootstrap effect await the exact in-flight operation even
+  // when React re-runs effects in StrictMode.
+  const inviteClaimPromise = useRef<Promise<AuthClaimResult | null> | null>(null);
 
   useEffect(() => {
     if (isTauri()) void listSetup();
@@ -240,11 +245,20 @@ export function AuthGate({ children }: AuthGateProps) {
     if (!pendingInviteToken) return;
     if (inviteClaimAttempted.current === pendingInviteToken) return;
     inviteClaimAttempted.current = pendingInviteToken;
-    void useAuthStore.getState().claimPendingInvite().then((result) => {
-      // A claimed invite is an explicit team choice; don't immediately reopen
-      // the general picker after its active-team switch completes.
-      if (result) setTeamChosen(true);
-    });
+    const claimPromise = useAuthStore.getState().claimPendingInvite();
+    inviteClaimPromise.current = claimPromise;
+    void claimPromise
+      .then((result) => {
+        // A claimed invite is an explicit team choice; don't immediately reopen
+        // the general picker after its active-team switch completes.
+        if (result) setTeamChosen(true);
+      })
+      .catch((error) => {
+        console.warn("[AuthGate] pending invite claim failed", error);
+      })
+      .finally(() => {
+        if (inviteClaimPromise.current === claimPromise) inviteClaimPromise.current = null;
+      });
   }, [session, pendingInviteToken]);
 
   // Separate from the token replay above: these invites were addressed to the
@@ -304,6 +318,22 @@ export function AuthGate({ children }: AuthGateProps) {
       let teamAssignmentRequired = false;
       let bootErr: unknown = null;
       try {
+        const pendingClaim = pendingInviteToken ? inviteClaimPromise.current : null;
+        if (pendingClaim) {
+          const claimed = await pendingClaim;
+          if (claimed) {
+            // The claim already entered the invited team. Mark bootstrap ready
+            // explicitly so a concurrently started team-list request cannot
+            // overwrite the successful onboarding with `no_team`.
+            setMyTeams([]);
+            setTeamChosen(true);
+            setBootstrapError(null);
+            setRetrying(false);
+            markStartup("team-bootstrap:end");
+            setBootstrap("ready");
+            return;
+          }
+        }
         const allTeams = await getBackend().teams.listAllMyTeams({ includeEmptyOrgs: true });
         markStartup("team-list:end");
         // This build policy is extension-only. Public joinable teams and empty

--- a/packages/app/src/components/auth/AuthGate.tsx
+++ b/packages/app/src/components/auth/AuthGate.tsx
@@ -25,6 +25,9 @@ import { TeamPicker } from "./TeamPicker";
 import { PendingInvitesDialog } from "@/components/auth/PendingInvitesDialog";
 import { GuestTeamDiscovery } from "@/components/auth/GuestTeamDiscovery";
 import { getDesktopDeviceIdOrNull } from "@/lib/backend/cloud-api/device-id";
+import { isChromeExtension } from "@/lib/platform";
+import { extensionTeamOnboarding } from "@/lib/build-config";
+import { ExtensionNoTeamScreen } from "./ExtensionNoTeamScreen";
 import type { MembershipTeam } from "@/lib/backend";
 
 /** A one-option "choice" is noise: single-locale builds skip the language step
@@ -35,7 +38,7 @@ interface AuthGateProps {
   children: React.ReactNode;
 }
 
-type BootstrapState = "idle" | "checking" | "ready" | "error";
+type BootstrapState = "idle" | "checking" | "ready" | "no_team" | "error";
 
 function memberTeams(teams: MembershipTeam[]): MembershipTeam[] {
   return teams.filter((team) => team.itemType !== "org" && team.isMember !== false);
@@ -69,6 +72,7 @@ export function AuthGate({ children }: AuthGateProps) {
   const [bootstrapError, setBootstrapError] = useState<string | null>(null);
   const [bootstrapNonce, setBootstrapNonce] = useState(0);
   const [retrying, setRetrying] = useState(false);
+  const [checkingNoTeamInvites, setCheckingNoTeamInvites] = useState(false);
   const [authHydrated, setAuthHydrated] = useState(false);
   const bootstrappedUserId = useRef<string | null>(null);
   const savedTeamRestoreUserId = useRef<string | null>(null);
@@ -127,6 +131,8 @@ export function AuthGate({ children }: AuthGateProps) {
   // before team-bootstrap can overwrite the cache, so the picker can badge it
   // "Last used". Null on a genuinely-first login (no history).
   const [lastUsedTeamId, setLastUsedTeamId] = useState<string | null>(null);
+  const extensionRequiresInvitation =
+    isChromeExtension() && !extensionTeamOnboarding.autoCreateTeam;
 
   useEffect(() => {
     if (isTauri()) void listSetup();
@@ -248,8 +254,12 @@ export function AuthGate({ children }: AuthGateProps) {
   useEffect(() => {
     if (!session || session.user?.isAnonymous) return;
     if (pendingInviteToken) return;
+    // The invite-only extension path performs this lookup as part of the
+    // blocking team resolution below. Existing-team users still refresh once
+    // bootstrap reaches ready so their normal in-app dialog keeps working.
+    if (extensionRequiresInvitation && bootstrap !== "ready") return;
     void useAuthStore.getState().refreshPendingInvites();
-  }, [session, pendingInviteToken]);
+  }, [session, pendingInviteToken, bootstrap, extensionRequiresInvitation]);
 
   // After auth, resolve the full team chooser before entering a team. Only an
   // empty result may create a team; it uses the dedicated atomic bootstrap RPC.
@@ -291,11 +301,19 @@ export function AuthGate({ children }: AuthGateProps) {
 
     void (async () => {
       let teamSet = false;
+      let teamAssignmentRequired = false;
       let bootErr: unknown = null;
       try {
         const allTeams = await getBackend().teams.listAllMyTeams({ includeEmptyOrgs: true });
         markStartup("team-list:end");
-        if (allTeams.length > 0) {
+        // This build policy is extension-only. Public joinable teams and empty
+        // org rows are not memberships and must not accidentally bypass the
+        // invite-only gate or offer a hidden team-creation path.
+        if (extensionRequiresInvitation && memberTeams(allTeams).length === 0) {
+          setMyTeams([]);
+          await useAuthStore.getState().refreshPendingInvites();
+          teamAssignmentRequired = true;
+        } else if (allTeams.length > 0) {
           // Do not auto-select the first row: the chooser makes the org then
           // team decision explicit, including public teams that need joining.
           setMyTeams(allTeams);
@@ -357,6 +375,9 @@ export function AuthGate({ children }: AuthGateProps) {
       if (teamSet) {
         setBootstrapError(null);
         setBootstrap("ready");
+      } else if (teamAssignmentRequired) {
+        setBootstrapError(null);
+        setBootstrap("no_team");
       } else {
         // No current team means the app can't continue — daemon onboarding,
         // sessions and the actor directory are all team-scoped. Surface the
@@ -366,7 +387,7 @@ export function AuthGate({ children }: AuthGateProps) {
         setBootstrap("error");
       }
     })();
-  }, [loading, session, bootstrapNonce, pendingInviteToken]);
+  }, [loading, session, bootstrapNonce, pendingInviteToken, extensionRequiresInvitation, signOut]);
 
   const retryBootstrap = () => {
     // Re-arm the per-user ref guard and bump the nonce so the bootstrap effect
@@ -375,6 +396,21 @@ export function AuthGate({ children }: AuthGateProps) {
     bootstrappedUserId.current = null;
     setRetrying(true);
     setBootstrapNonce((n) => n + 1);
+  };
+
+  const retryNoTeamInvites = () => {
+    if (checkingNoTeamInvites) return;
+    setCheckingNoTeamInvites(true);
+    void useAuthStore.getState().refreshPendingInvites().finally(() => {
+      setCheckingNoTeamInvites(false);
+    });
+  };
+
+  const finishPendingInvite = () => {
+    setTeamChosen(true);
+    setTeamChoiceResolved(true);
+    setBootstrapError(null);
+    setBootstrap("ready");
   };
 
   // Each gate below either (a) is a pure-loading state — return null so the
@@ -466,6 +502,21 @@ export function AuthGate({ children }: AuthGateProps) {
         onRetry={retryBootstrap}
         onSignOut={() => void signOut()}
       />
+    );
+  }
+
+  if (bootstrap === "no_team") {
+    removeStartupSkeleton();
+    return (
+      <>
+        <ExtensionNoTeamScreen
+          messages={extensionTeamOnboarding.noTeamMessage}
+          checking={checkingNoTeamInvites}
+          onRetry={retryNoTeamInvites}
+          onSignOut={() => void signOut()}
+        />
+        <PendingInvitesDialog onAccepted={finishPendingInvite} />
+      </>
     );
   }
 

--- a/packages/app/src/components/auth/ExtensionNoTeamScreen.tsx
+++ b/packages/app/src/components/auth/ExtensionNoTeamScreen.tsx
@@ -1,0 +1,74 @@
+import { Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+
+function configuredMessage(
+  messages: Record<string, string>,
+  language: string | undefined,
+): string | null {
+  const locale = language?.trim() || 'zh-CN'
+  const base = locale.split('-')[0]
+  const candidates = [locale, base, base === 'zh' ? 'zh-CN' : null, 'zh-CN', 'en']
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    const message = messages[candidate]?.trim()
+    if (message) return message
+  }
+  return null
+}
+
+export function ExtensionNoTeamScreen({
+  messages,
+  checking,
+  onRetry,
+  onSignOut,
+}: {
+  messages: Record<string, string>
+  checking: boolean
+  onRetry: () => void
+  onSignOut: () => void
+}) {
+  const { t, i18n } = useTranslation()
+  const message = configuredMessage(messages, i18n?.resolvedLanguage ?? i18n?.language)
+    ?? t(
+      'auth.extensionNoTeam.message',
+      '当前账号尚未加入任何团队，请联系管理员向你的登录邮箱发送团队邀请。',
+    )
+
+  return (
+    <div className="flex h-screen items-center justify-center bg-background px-6">
+      <div className="w-full max-w-[440px] rounded-[16px] border border-border bg-paper p-6 shadow-sm">
+        <h1 className="text-[16px] font-semibold text-foreground">
+          {t('auth.extensionNoTeam.title', '暂未加入团队')}
+        </h1>
+        <p className="mt-1.5 whitespace-pre-wrap text-[12.5px] leading-5 text-muted-foreground">
+          {message}
+        </p>
+        <div className="mt-5 flex flex-col gap-4">
+          <Button
+            className="h-10 w-full rounded-[10px] bg-coral text-coral-foreground hover:opacity-90"
+            disabled={checking}
+            onClick={onRetry}
+          >
+            {checking ? (
+              <span className="flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t('auth.extensionNoTeam.checking', '正在检查…')}
+              </span>
+            ) : (
+              t('auth.extensionNoTeam.retry', '重新检查邀请')
+            )}
+          </Button>
+          <button
+            type="button"
+            onClick={onSignOut}
+            disabled={checking}
+            className="text-[12px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+          >
+            {t('auth.teamBootstrapError.signOut', '退出登录并使用其他账号')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/components/auth/LoginScreen.tsx
+++ b/packages/app/src/components/auth/LoginScreen.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "@/stores/auth-store";
-import { appDisplayName } from "@/lib/build-config";
+import { appDisplayName, extensionTeamOnboarding } from "@/lib/build-config";
 import { useFeatures } from "@/lib/remote-features";
 import { hasBackendConfig } from "@/lib/backend";
 import { getEffectiveServerConfigSync } from "@/lib/server-config";
@@ -9,7 +9,7 @@ import { useAppVersion } from "@/lib/version";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { isTauri } from "@/lib/utils";
-import { capabilities } from "@/lib/platform";
+import { capabilities, isChromeExtension } from "@/lib/platform";
 import { GoogleIcon, WechatIcon } from "./oauth-icons";
 import { WebSsoOverlay } from "./WebSsoOverlay";
 import type { OAuthProvider } from "@/lib/auth";
@@ -151,6 +151,7 @@ export function LoginScreen({ embedded = false, onBack }: LoginScreenProps) {
   const passwordEnabled = auth.password;
   const appVersion = useAppVersion();
   const cloudApiUrl = getEffectiveServerConfigSync().cloudApiUrl;
+  const showAnonymousTrial = !isChromeExtension() || extensionTeamOnboarding.autoCreateTeam;
   const onSendEmail = async (e: React.FormEvent) => {
     e.preventDefault();
     await sendOtp(email);
@@ -424,16 +425,18 @@ export function LoginScreen({ embedded = false, onBack }: LoginScreenProps) {
               ? method === "password" ? t("auth.signingIn", "Signing in…") : t("auth.sending", "Sending…")
               : method === "password" ? t("auth.signIn", "Sign in") : t("auth.sendCode", "Send code")}
           </Button>
-          <button
-            type="button"
-            onClick={() => void onQuickTrial()}
-            disabled={serverConfigRequired || loading}
-            className="block w-full text-center text-[12px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
-          >
-            {loading
-              ? t("auth.onboarding.startingTrial", "Preparing…")
-              : t("auth.onboarding.quickTrial", "Try anonymously")}
-          </button>
+          {showAnonymousTrial && (
+            <button
+              type="button"
+              onClick={() => void onQuickTrial()}
+              disabled={serverConfigRequired || loading}
+              className="block w-full text-center text-[12px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+            >
+              {loading
+                ? t("auth.onboarding.startingTrial", "Preparing…")
+                : t("auth.onboarding.quickTrial", "Try anonymously")}
+            </button>
+          )}
           <OAuthButtons />
         </form>
       )}

--- a/packages/app/src/components/auth/PendingInvitesDialog.tsx
+++ b/packages/app/src/components/auth/PendingInvitesDialog.tsx
@@ -21,7 +21,7 @@ import { useAuthStore } from '@/stores/auth-store'
  * The token path (an invite link the user opened) does not come through here —
  * opening the link IS the choice, and AuthGate claims it directly.
  */
-export function PendingInvitesDialog() {
+export function PendingInvitesDialog({ onAccepted }: { onAccepted?: () => void } = {}) {
   const { t } = useTranslation()
   const invites = useAuthStore((s) => s.pendingInvites)
   const [busyId, setBusyId] = React.useState<string | null>(null)
@@ -40,6 +40,7 @@ export function PendingInvitesDialog() {
       toast.error(t('pendingInvite.acceptFailed', 'Failed to join team: {{msg}}', { msg: msg ?? '' }))
       return
     }
+    onAccepted?.()
     toast.success(t('pendingInvite.accepted', 'Joined the team'))
   }
 

--- a/packages/app/src/components/auth/__tests__/AuthGate.test.tsx
+++ b/packages/app/src/components/auth/__tests__/AuthGate.test.tsx
@@ -435,6 +435,34 @@ describe("AuthGate", () => {
     expect(screen.queryByText("App shell")).not.toBeInTheDocument();
   });
 
+  it("waits for a pending invite claim before resolving the team gate", async () => {
+    isTauriMock.mockReturnValue(false);
+    extensionPolicyMock.isExtension = true;
+    extensionPolicyMock.autoCreateTeam = false;
+    authState.pendingInviteToken = "invite-token";
+
+    let resolveClaim: (result: { teamId: string }) => void = () => {};
+    const claimPromise = new Promise<{ teamId: string }>((resolve) => {
+      resolveClaim = resolve;
+    });
+    authState.claimPendingInvite.mockReturnValue(claimPromise);
+
+    render(
+      <AuthGate>
+        <div>App shell</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => expect(authState.claimPendingInvite).toHaveBeenCalled());
+    expect(backendMock.teams.listAllMyTeams).not.toHaveBeenCalled();
+
+    resolveClaim({ teamId: "team-invited" });
+
+    await waitFor(() => expect(screen.getByText("App shell")).toBeInTheDocument());
+    expect(screen.queryByText("暂未加入团队")).not.toBeInTheDocument();
+    expect(backendMock.teams.bootstrapTeam).not.toHaveBeenCalled();
+  });
+
   it("extension: shows contact-matched invitations before entering a team", async () => {
     isTauriMock.mockReturnValue(false);
     extensionPolicyMock.isExtension = true;

--- a/packages/app/src/components/auth/__tests__/AuthGate.test.tsx
+++ b/packages/app/src/components/auth/__tests__/AuthGate.test.tsx
@@ -1,10 +1,15 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { setLocalCacheTeamGateMock, removeStartupSkeletonMock, isTauriMock } = vi.hoisted(() => ({
+const { setLocalCacheTeamGateMock, removeStartupSkeletonMock, isTauriMock, extensionPolicyMock } = vi.hoisted(() => ({
   setLocalCacheTeamGateMock: vi.fn().mockResolvedValue(undefined),
   removeStartupSkeletonMock: vi.fn(),
   isTauriMock: vi.fn(() => true),
+  extensionPolicyMock: {
+    isExtension: false,
+    autoCreateTeam: true,
+    noTeamMessage: { 'zh-CN': '请联系管理员邀请你加入团队。' } as Record<string, string>,
+  },
 }));
 
 const { deviceIdMock } = vi.hoisted(() => ({ deviceIdMock: { value: "device-1" as string | null } }));
@@ -25,6 +30,9 @@ const { authState, currentTeamMock, backendMock } = vi.hoisted(() => ({
     // dialog stays closed and these tests only exercise the gate itself.
     pendingInvites: [] as unknown[],
     refreshPendingInvites: vi.fn(),
+    acceptPendingInvite: vi.fn(),
+    declinePendingInvite: vi.fn(),
+    signOut: vi.fn(),
   },
   currentTeamMock: {
     reloadAndSwitchTo: vi.fn(),
@@ -76,6 +84,14 @@ vi.mock("@/lib/utils", () => ({
   cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(" "),
   isTauri: () => isTauriMock(),
   removeStartupSkeleton: () => removeStartupSkeletonMock(),
+}));
+
+vi.mock("@/lib/platform", () => ({
+  isChromeExtension: () => extensionPolicyMock.isExtension,
+}));
+
+vi.mock("@/lib/build-config", () => ({
+  extensionTeamOnboarding: extensionPolicyMock,
 }));
 
 vi.mock("@/stores/setup", () => ({
@@ -145,6 +161,13 @@ beforeEach(() => {
   authState.loading = false;
   authState.authFlow = "idle";
   authState.hydrate.mockReset();
+  authState.pendingInviteToken = null;
+  authState.pendingInvites = [];
+  authState.refreshPendingInvites.mockReset();
+  authState.refreshPendingInvites.mockResolvedValue(undefined);
+  authState.acceptPendingInvite.mockReset();
+  authState.declinePendingInvite.mockReset();
+  authState.signOut.mockReset();
   backendMock.teams.listCurrentUserTeams.mockReset();
   backendMock.teams.listAllMyTeams.mockReset();
   backendMock.teams.listDiscoverableTeams.mockReset();
@@ -161,6 +184,8 @@ beforeEach(() => {
   setLocalCacheTeamGateMock.mockClear();
   removeStartupSkeletonMock.mockClear();
   isTauriMock.mockReturnValue(true);
+  extensionPolicyMock.isExtension = false;
+  extensionPolicyMock.autoCreateTeam = true;
 });
 
 describe("AuthGate", () => {
@@ -389,6 +414,124 @@ describe("AuthGate", () => {
     await waitFor(() => expect(currentTeamMock.switchToTeam).toHaveBeenCalledWith("team-existing"));
     await waitFor(() => expect(screen.getByText("App shell")).toBeInTheDocument());
     expect(screen.queryByText(/Team picker/)).not.toBeInTheDocument();
+  });
+
+  it("extension: blocks a teamless user without auto-creating a team", async () => {
+    isTauriMock.mockReturnValue(false);
+    extensionPolicyMock.isExtension = true;
+    extensionPolicyMock.autoCreateTeam = false;
+    backendMock.teams.listAllMyTeams.mockResolvedValue([]);
+
+    render(
+      <AuthGate>
+        <div>App shell</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => expect(screen.getByText("暂未加入团队")).toBeInTheDocument());
+    expect(screen.getByText("请联系管理员邀请你加入团队。")).toBeInTheDocument();
+    expect(authState.refreshPendingInvites).toHaveBeenCalled();
+    expect(backendMock.teams.bootstrapTeam).not.toHaveBeenCalled();
+    expect(screen.queryByText("App shell")).not.toBeInTheDocument();
+  });
+
+  it("extension: shows contact-matched invitations before entering a team", async () => {
+    isTauriMock.mockReturnValue(false);
+    extensionPolicyMock.isExtension = true;
+    extensionPolicyMock.autoCreateTeam = false;
+    authState.pendingInvites = [{
+      inviteId: "invite-1",
+      teamId: "team-invited",
+      teamName: "研发协作组",
+      teamRole: "member",
+      displayName: "New member",
+      invitedByDisplayName: "Alice",
+      inviteEmail: "new@example.com",
+      invitePhone: null,
+      expiresAt: null,
+      matchedVia: "email",
+    }];
+
+    render(
+      <AuthGate>
+        <div>App shell</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => expect(screen.getByText("你有团队邀请")).toBeInTheDocument());
+    expect(screen.getByText("研发协作组")).toBeInTheDocument();
+    expect(backendMock.teams.bootstrapTeam).not.toHaveBeenCalled();
+  });
+
+  it("extension: enters the invited team after the user accepts", async () => {
+    isTauriMock.mockReturnValue(false);
+    extensionPolicyMock.isExtension = true;
+    extensionPolicyMock.autoCreateTeam = false;
+    authState.pendingInvites = [{
+      inviteId: "invite-1",
+      teamId: "team-invited",
+      teamName: "研发协作组",
+      teamRole: "member",
+      displayName: "New member",
+      invitedByDisplayName: "Alice",
+      inviteEmail: "new@example.com",
+      invitePhone: null,
+      expiresAt: null,
+      matchedVia: "email",
+    }];
+    authState.acceptPendingInvite.mockResolvedValue({
+      actorId: "actor-1",
+      teamId: "team-invited",
+      actorType: "member",
+      displayName: "New member",
+      refreshToken: null,
+    });
+
+    render(
+      <AuthGate>
+        <div>App shell</div>
+      </AuthGate>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "接受邀请" }));
+
+    await waitFor(() => expect(screen.getByText("App shell")).toBeInTheDocument());
+    expect(authState.acceptPendingInvite).toHaveBeenCalledWith("invite-1");
+  });
+
+  it("extension: does not treat public teams or empty org rows as memberships", async () => {
+    isTauriMock.mockReturnValue(false);
+    extensionPolicyMock.isExtension = true;
+    extensionPolicyMock.autoCreateTeam = false;
+    backendMock.teams.listAllMyTeams.mockResolvedValue([
+      { id: "public-team", name: "Public", itemType: "team", isMember: false },
+      { id: "empty-org", name: "Empty org", itemType: "org", isMember: false },
+    ]);
+
+    render(
+      <AuthGate>
+        <div>App shell</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => expect(screen.getByText("暂未加入团队")).toBeInTheDocument());
+    expect(screen.queryByText(/Team picker/)).not.toBeInTheDocument();
+    expect(backendMock.teams.bootstrapTeam).not.toHaveBeenCalled();
+  });
+
+  it("plain web: ignores the extension-only policy and keeps automatic creation", async () => {
+    isTauriMock.mockReturnValue(false);
+    extensionPolicyMock.isExtension = false;
+    extensionPolicyMock.autoCreateTeam = false;
+    backendMock.teams.listAllMyTeams.mockResolvedValue([]);
+
+    render(
+      <AuthGate>
+        <div>App shell</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => expect(backendMock.teams.bootstrapTeam).toHaveBeenCalled());
   });
 
   it("extension/web: keeps the shell blocked until myTeams resolves, then removes the skeleton", async () => {

--- a/packages/app/src/components/auth/__tests__/LoginScreen.test.tsx
+++ b/packages/app/src/components/auth/__tests__/LoginScreen.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { authState, backendConfig } = vi.hoisted(() => ({
+const { authState, backendConfig, extensionPolicy } = vi.hoisted(() => ({
   authState: {
     loading: false,
     errorMessage: null as string | null,
@@ -13,6 +13,10 @@ const { authState, backendConfig } = vi.hoisted(() => ({
   },
   backendConfig: {
     hasConfig: true,
+  },
+  extensionPolicy: {
+    isExtension: false,
+    autoCreateTeam: true,
   },
 }));
 
@@ -37,6 +41,12 @@ vi.mock("@/lib/version", () => ({
 vi.mock("@/lib/build-config", () => ({
   buildConfig: { app: { name: "TeamClu" } },
   appDisplayName: "TeamClu",
+  extensionTeamOnboarding: extensionPolicy,
+}));
+
+vi.mock("@/lib/platform", () => ({
+  isChromeExtension: () => extensionPolicy.isExtension,
+  capabilities: { oauthSignIn: false },
 }));
 
 import { LoginScreen } from "../LoginScreen";
@@ -50,6 +60,8 @@ beforeEach(() => {
   authState.resetOtp.mockReset();
   authState.signInAnonymously.mockReset();
   backendConfig.hasConfig = true;
+  extensionPolicy.isExtension = false;
+  extensionPolicy.autoCreateTeam = true;
 });
 
 describe("LoginScreen", () => {
@@ -69,6 +81,24 @@ describe("LoginScreen", () => {
     render(<LoginScreen />);
     fireEvent.click(screen.getByRole("button", { name: /try anonymously/i }));
     await waitFor(() => expect(authState.signInAnonymously).toHaveBeenCalledTimes(1));
+  });
+
+  it("hides anonymous trial only in extension builds that disable automatic team creation", () => {
+    extensionPolicy.isExtension = true;
+    extensionPolicy.autoCreateTeam = false;
+
+    render(<LoginScreen />);
+
+    expect(screen.queryByRole("button", { name: /try anonymously/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps anonymous trial visible in plain web even when the extension policy disables it", () => {
+    extensionPolicy.isExtension = false;
+    extensionPolicy.autoCreateTeam = false;
+
+    render(<LoginScreen />);
+
+    expect(screen.getByRole("button", { name: /try anonymously/i })).toBeInTheDocument();
   });
 
   it("shows error message when signInAnonymously fails", () => {

--- a/packages/app/src/lib/build-config.ts
+++ b/packages/app/src/lib/build-config.ts
@@ -6,12 +6,14 @@ import {
   parseExtensionPackConfig,
   type ExtensionPackConfig,
   type ExtensionSettingsBake,
+  type ExtensionTeamOnboardingBake,
 } from './extension-settings-bake'
 
 export type {
   ExtensionSettingsBake,
   ExtensionLinkHoverBake,
   ExtensionPackConfig,
+  ExtensionTeamOnboardingBake,
 } from './extension-settings-bake'
 
 
@@ -116,7 +118,8 @@ export interface BuildConfig {
    * Chrome extension pack options (`solo`, side-panel `domains`, `settings`).
    * Sole source for extension packaging — no SOLO/DOMAINS CLI overrides.
    */
-  extensions?: Partial<ExtensionPackConfig> & {
+  extensions?: Omit<Partial<ExtensionPackConfig>, 'settings' | 'teamOnboarding'> & {
+    teamOnboarding?: Partial<ExtensionTeamOnboardingBake>
     settings?: Partial<ExtensionSettingsBake> & {
       linkHover?: Partial<ExtensionSettingsBake['linkHover']>
     }
@@ -281,11 +284,16 @@ export const TEAM_SYNCED_EVENT = `${appStoragePrefix}-team-synced`
 
 /** Baked Chrome-extension pack config (`extensions` in build.config*.json). */
 export const extensionPack: ExtensionPackConfig = parseExtensionPackConfig(
-  buildConfig.extensions ?? DEFAULT_EXTENSION_PACK_CONFIG,
+  typeof __TEAMCLU_EXTENSION_PACK__ !== 'undefined'
+    ? __TEAMCLU_EXTENSION_PACK__
+    : buildConfig.extensions ?? DEFAULT_EXTENSION_PACK_CONFIG,
 )
 
 /** Baked Chrome-extension settings (`extensions.settings`). */
 export const extensionSettings: ExtensionSettingsBake = extensionPack.settings
+
+/** Extension-only policy for assigning a team after sign-in. */
+export const extensionTeamOnboarding: ExtensionTeamOnboardingBake = extensionPack.teamOnboarding
 
 /** When true, the extension side-panel hides the settings gear button. */
 export const hideExtensionSettingsButton: boolean = extensionSettings.hideButton === true

--- a/packages/app/src/lib/extension-settings-bake.test.ts
+++ b/packages/app/src/lib/extension-settings-bake.test.ts
@@ -47,6 +47,41 @@ describe('parseExtensionPackConfig', () => {
         hideButton: true,
         linkHover: { domains: [], urlPatterns: [] },
       },
+      teamOnboarding: {
+        autoCreateTeam: true,
+        noTeamMessage: {},
+      },
+    })
+  })
+
+  it('parses the extension-only team onboarding policy', () => {
+    expect(
+      parseExtensionPackConfig({
+        teamOnboarding: {
+          autoCreateTeam: false,
+          noTeamMessage: {
+            'zh-CN': ' 请联系管理员邀请你加入团队。 ',
+            en: ' Ask an administrator for an invite. ',
+            empty: '   ',
+            invalid: 42,
+          },
+        },
+      }),
+    ).toMatchObject({
+      teamOnboarding: {
+        autoCreateTeam: false,
+        noTeamMessage: {
+          'zh-CN': '请联系管理员邀请你加入团队。',
+          en: 'Ask an administrator for an invite.',
+        },
+      },
+    })
+  })
+
+  it('keeps automatic team creation enabled when the policy is omitted', () => {
+    expect(parseExtensionPackConfig(undefined).teamOnboarding).toEqual({
+      autoCreateTeam: true,
+      noTeamMessage: {},
     })
   })
 })

--- a/packages/app/src/lib/extension-settings-bake.ts
+++ b/packages/app/src/lib/extension-settings-bake.ts
@@ -12,11 +12,21 @@ export interface ExtensionSettingsBake {
   linkHover: ExtensionLinkHoverBake
 }
 
+export interface ExtensionTeamOnboardingBake {
+  /** Preserve the legacy extension behavior when true. False makes team
+   * assignment invite-only for users who do not already belong to a team. */
+  autoCreateTeam: boolean
+  /** Build-specific copy for the extension's signed-in, teamless gate. */
+  noTeamMessage: Record<string, string>
+}
+
 export interface ExtensionPackConfig {
   /** Solo-agent UI (hide permission control + model on mention pills; force narrow layout). */
   solo: boolean
   /** Side-panel host allowlist (`*.example.com` or `example.com`). Empty = ungated. */
   domains: string[]
+  /** Extension-only policy for the post-login team assignment flow. */
+  teamOnboarding: ExtensionTeamOnboardingBake
   settings: ExtensionSettingsBake
 }
 
@@ -28,10 +38,27 @@ export const DEFAULT_EXTENSION_SETTINGS_BAKE: ExtensionSettingsBake = {
 export const DEFAULT_EXTENSION_PACK_CONFIG: ExtensionPackConfig = {
   solo: false,
   domains: [],
+  teamOnboarding: {
+    autoCreateTeam: true,
+    noTeamMessage: {},
+  },
   settings: {
     hideButton: false,
     linkHover: { domains: [], urlPatterns: [] },
   },
+}
+
+function asLocalizedStrings(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const out: Record<string, string> = {}
+  for (const [locale, message] of Object.entries(raw)) {
+    if (typeof message !== 'string') continue
+    const normalizedLocale = locale.trim()
+    const normalizedMessage = message.trim()
+    if (!normalizedLocale || !normalizedMessage) continue
+    out[normalizedLocale] = normalizedMessage
+  }
+  return out
 }
 
 function asStringList(raw: unknown): string[] {
@@ -94,6 +121,10 @@ export function parseExtensionPackConfig(raw: unknown): ExtensionPackConfig {
     return {
       solo: false,
       domains: [],
+      teamOnboarding: {
+        autoCreateTeam: DEFAULT_EXTENSION_PACK_CONFIG.teamOnboarding.autoCreateTeam,
+        noTeamMessage: {},
+      },
       settings: parseExtensionSettingsBake(undefined),
     }
   }
@@ -101,8 +132,14 @@ export function parseExtensionPackConfig(raw: unknown): ExtensionPackConfig {
   const row = raw as {
     solo?: unknown
     domains?: unknown
+    teamOnboarding?: unknown
     settings?: unknown
   }
+
+  const teamOnboardingRaw =
+    row.teamOnboarding && typeof row.teamOnboarding === 'object'
+      ? (row.teamOnboarding as { autoCreateTeam?: unknown; noTeamMessage?: unknown })
+      : null
 
   const domains: string[] = []
   const seen = new Set<string>()
@@ -116,6 +153,10 @@ export function parseExtensionPackConfig(raw: unknown): ExtensionPackConfig {
   return {
     solo: row.solo === true,
     domains,
+    teamOnboarding: {
+      autoCreateTeam: teamOnboardingRaw?.autoCreateTeam !== false,
+      noTeamMessage: asLocalizedStrings(teamOnboardingRaw?.noTeamMessage),
+    },
     settings: parseExtensionSettingsBake(row.settings),
   }
 }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -292,6 +292,12 @@
       "retrying": "Retrying…",
       "signOut": "Sign out and use another account"
     },
+    "extensionNoTeam": {
+      "title": "No team yet",
+      "message": "Your account has not joined a team yet. Ask an administrator to invite your sign-in email.",
+      "retry": "Check invitations again",
+      "checking": "Checking…"
+    },
     "signIn": "Sign in",
     "willEmailCode": "We'll email you a 6-digit code.",
     "email": "Email",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -292,6 +292,12 @@
       "retrying": "正在重试…",
       "signOut": "退出登录，换个账号"
     },
+    "extensionNoTeam": {
+      "title": "暂未加入团队",
+      "message": "当前账号尚未加入任何团队，请联系管理员向你的登录邮箱发送团队邀请。",
+      "retry": "重新检查邀请",
+      "checking": "正在检查…"
+    },
     "signIn": "登录",
     "willEmailCode": "我们将向你的邮箱发送 6 位验证码。",
     "email": "邮箱",

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -25,6 +25,8 @@ interface ImportMeta {
 }
 
 declare const __BUILD_CONFIG__: import('./lib/build-config').BuildConfig | undefined
+/** Fully normalized extension pack, including the `extension` branding alias. */
+declare const __TEAMCLU_EXTENSION_PACK__: unknown | undefined
 /** Baked `extensions.settings` from build.config*.json (Vite + extension content-script). */
 declare const __TEAMCLU_EXTENSION_SETTINGS__: unknown | undefined
 

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -61,7 +61,8 @@ const buildConfig = deepMerge(baseConfig || {}, envConfig)
 // and `extensions.settings` (repo configs) reach the app identically.
 const { resolveExtensionPack } = nodeRequire(
   path.join(rootDir, 'scripts/lib/extension-config.js'),
-) as { resolveExtensionPack: (buildConfig: unknown) => { settings: unknown } }
+) as { resolveExtensionPack: (buildConfig: unknown) => { settings: unknown; [key: string]: unknown } }
+const resolvedExtensionPack = resolveExtensionPack(buildConfig)
 
 const { resolveBrandTheme, generateBrandThemeCss, extractRootTokenNames } =
   nodeRequire(path.join(rootDir, 'scripts/lib/brand-theme.js')) as {
@@ -152,7 +153,8 @@ export default defineConfig({
   },
   define: {
     __BUILD_CONFIG__: JSON.stringify(buildConfig),
-    __TEAMCLU_EXTENSION_SETTINGS__: JSON.stringify(resolveExtensionPack(buildConfig).settings),
+    __TEAMCLU_EXTENSION_PACK__: JSON.stringify(resolvedExtensionPack),
+    __TEAMCLU_EXTENSION_SETTINGS__: JSON.stringify(resolvedExtensionPack.settings),
     // Inject build config defaults into import.meta.env so they work without .env files
     'import.meta.env.VITE_LOCALE': JSON.stringify((buildConfig as any).defaults?.locale ?? ''),
     'import.meta.env.PACKAGE_VERSION': JSON.stringify(

--- a/scripts/lib/extension-config.js
+++ b/scripts/lib/extension-config.js
@@ -26,6 +26,19 @@ function asStringList(raw) {
   return out
 }
 
+function asLocalizedStrings(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const out = {}
+  for (const [locale, message] of Object.entries(raw)) {
+    if (typeof message !== 'string') continue
+    const normalizedLocale = locale.trim()
+    const normalizedMessage = message.trim()
+    if (!normalizedLocale || !normalizedMessage) continue
+    out[normalizedLocale] = normalizedMessage
+  }
+  return out
+}
+
 /**
  * Normalize a domain entry for the side-panel host gate.
  * Accepts either `*.shopee.io` or a Chrome match pattern `https://*.shopee.io/*`.
@@ -70,10 +83,18 @@ function parseExtensionsConfig(raw) {
     settingsRaw.linkHover && typeof settingsRaw.linkHover === 'object'
       ? settingsRaw.linkHover
       : {}
+  const teamOnboardingRaw =
+    row.teamOnboarding && typeof row.teamOnboarding === 'object'
+      ? row.teamOnboarding
+      : {}
 
   return {
     solo: row.solo === true,
     domains,
+    teamOnboarding: {
+      autoCreateTeam: teamOnboardingRaw.autoCreateTeam !== false,
+      noTeamMessage: asLocalizedStrings(teamOnboardingRaw.noTeamMessage),
+    },
     settings: {
       hideButton: settingsRaw.hideButton === true,
       linkHover: {
@@ -106,6 +127,22 @@ function resolveExtensionPack(buildConfig) {
       ...asStringList(alias.hosts),
     ],
     solo: canonical.solo === true || alias.solo === true,
+    teamOnboarding: {
+      ...(alias.teamOnboarding && typeof alias.teamOnboarding === 'object'
+        ? alias.teamOnboarding
+        : {}),
+      ...(canonical.teamOnboarding && typeof canonical.teamOnboarding === 'object'
+        ? canonical.teamOnboarding
+        : {}),
+      noTeamMessage: {
+        ...(alias.teamOnboarding?.noTeamMessage && typeof alias.teamOnboarding.noTeamMessage === 'object'
+          ? alias.teamOnboarding.noTeamMessage
+          : {}),
+        ...(canonical.teamOnboarding?.noTeamMessage && typeof canonical.teamOnboarding.noTeamMessage === 'object'
+          ? canonical.teamOnboarding.noTeamMessage
+          : {}),
+      },
+    },
     settings: {
       ...(alias.settings && typeof alias.settings === 'object' ? alias.settings : {}),
       ...(canonical.settings && typeof canonical.settings === 'object' ? canonical.settings : {}),

--- a/scripts/lib/extension-config.test.js
+++ b/scripts/lib/extension-config.test.js
@@ -44,6 +44,10 @@ test("resolveExtensionPack yields no domains when neither block is present", () 
   const pack = resolveExtensionPack({ app: { name: "TeamClu" } });
   assert.deepStrictEqual(pack.domains, []);
   assert.strictEqual(pack.solo, false);
+  assert.deepStrictEqual(pack.teamOnboarding, {
+    autoCreateTeam: true,
+    noTeamMessage: {},
+  });
 });
 
 test("resolveExtensionPack tolerates a missing or non-object config", () => {
@@ -65,6 +69,51 @@ test("resolveExtensionPack lets the canonical block win on settings", () => {
   });
   assert.strictEqual(pack.settings.hideButton, false);
   assert.deepStrictEqual(pack.settings.linkHover.domains, ["a.com"]);
+});
+
+test("resolveExtensionPack parses the team onboarding policy", () => {
+  const pack = resolveExtensionPack({
+    extensions: {
+      teamOnboarding: {
+        autoCreateTeam: false,
+        noTeamMessage: {
+          "zh-CN": " 请联系管理员邀请你加入团队。 ",
+          en: "Ask an administrator for an invite.",
+          invalid: 42,
+        },
+      },
+    },
+  });
+  assert.deepStrictEqual(pack.teamOnboarding, {
+    autoCreateTeam: false,
+    noTeamMessage: {
+      "zh-CN": "请联系管理员邀请你加入团队。",
+      en: "Ask an administrator for an invite.",
+    },
+  });
+});
+
+test("resolveExtensionPack accepts the branding alias and lets canonical fields win", () => {
+  const pack = resolveExtensionPack({
+    extension: {
+      teamOnboarding: {
+        autoCreateTeam: false,
+        noTeamMessage: { en: "Alias message" },
+      },
+    },
+    extensions: {
+      teamOnboarding: {
+        noTeamMessage: { "zh-CN": "主配置文案" },
+      },
+    },
+  });
+  assert.deepStrictEqual(pack.teamOnboarding, {
+    autoCreateTeam: false,
+    noTeamMessage: {
+      en: "Alias message",
+      "zh-CN": "主配置文案",
+    },
+  });
 });
 
 test("parseExtensionsConfig still accepts a bare domains row", () => {


### PR DESCRIPTION
## Summary
- add extension build policy for disabling automatic team creation
- hide anonymous trial entry when invite-only onboarding is enabled
- show pending invite selection or configured no-team guidance after login
- keep desktop and web onboarding behavior unchanged

## Validation
- app auth/config tests
- extension config tests
- TypeScript typecheck
- ESLint
- web production build

## Notes
- local build config changes and the HTML flow prototype are intentionally excluded