### PR TITLE
feat(fc): 团队文件 blob 支持 S3 后端（self-host 用 MinIO，belayo 用 OSS）

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -50,6 +50,11 @@ SUPABASE_DOMAIN=supabase.example.com
 MQTT_DOMAIN=mqtt.example.com
 STUDIO_DOMAIN=studio.example.com
 EMQX_DASHBOARD_DOMAIN=emqx.example.com
+# Blob storage (MinIO) for team files — knowledge documents and skill packages.
+# Leave blank to keep storing them in Supabase Storage. To cut over, point this
+# name at the box, set the four S3_* / ACCESS_KEY_* values below, and set
+# TEAM_BLOBS_BACKEND=s3.
+S3_DOMAIN=
 
 # The ONE broker address: FC's own inbox publisher dials it AND
 # GET /v1/config/bootstrap hands it to clients. Use the public hostname — an
@@ -83,13 +88,37 @@ CRON_TRIGGER_SECRET=
 # DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
 POSTGRES_BACKEND_PASSWORD=postgres
 
-# ── object storage (external Alibaba OSS; leave blank to disable) ──────
+# ── object storage ────────────────────────────────────────────────────
+#
+# Two consumers, same credentials:
+#   1. team files (knowledge, skill packages) — only when TEAM_BLOBS_BACKEND=s3
+#   2. app bundles for the Apps module — always S3, never Supabase
+#
+# Self-host default is the bundled MinIO (bytes stay on this box). Point these
+# at Alibaba OSS instead if you would rather not run it.
+#
+# MinIO (recommended for self-host):
+#   TEAM_BLOBS_BACKEND=s3
+#   ACCESS_KEY_ID / ACCESS_KEY_SECRET = the MinIO root credentials (any value;
+#     the minio service reads these too, so they must be set before first start)
+#   ENDPOINT=https://<S3_DOMAIN>   ← the public name, NOT http://minio:9000:
+#     the daemon transfers bytes directly against a presigned URL, and SigV4
+#     covers the Host header
+#   S3_FORCE_PATH_STYLE=1
+#
+# Alibaba OSS:
+#   ENDPOINT=https://oss-<region>.aliyuncs.com, S3_FORCE_PATH_STYLE blank
+TEAM_BLOBS_BACKEND=
+S3_FORCE_PATH_STYLE=
 ACCESS_KEY_ID=
 ACCESS_KEY_SECRET=
 ROLE_ARN=
 BUCKET=teamclu-team
 REGION=cn-shenzhen
 ENDPOINT=https://oss-cn-shenzhen.aliyuncs.com
+# Buckets for team files. Created automatically by the minio-init service.
+TEAM_BLOBS_STORAGE_BUCKET=team-blobs
+SKILLS_STORAGE_BUCKET=team-skills
 
 # ── Apps module (per-app git repo + FC function + Postgres schema) ─────
 # All optional. Without CODEUP_*, creating an app fails at the repo step;

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -99,6 +99,7 @@ POSTGRES_BACKEND_PASSWORD=postgres
 #
 # MinIO (recommended for self-host):
 #   TEAM_BLOBS_BACKEND=s3
+#   BUCKET = the one bucket everything lives in (minio-init creates it)
 #   ACCESS_KEY_ID / ACCESS_KEY_SECRET = the MinIO root credentials (any value;
 #     the minio service reads these too, so they must be set before first start)
 #   ENDPOINT=https://<S3_DOMAIN>   ← the public name, NOT http://minio:9000:
@@ -116,7 +117,10 @@ ROLE_ARN=
 BUCKET=teamclu-team
 REGION=cn-shenzhen
 ENDPOINT=https://oss-cn-shenzhen.aliyuncs.com
-# Buckets for team files. Created automatically by the minio-init service.
+# On the supabase backend these are bucket names. On s3 they are key PREFIXES
+# inside the single BUCKET above — app bundles (apps/…), knowledge documents
+# (team-blobs/…) and skill packages (team-skills/…) share one bucket, so there
+# is one bucket to provision and one policy to reason about.
 TEAM_BLOBS_STORAGE_BUCKET=team-blobs
 SKILLS_STORAGE_BUCKET=team-skills
 

--- a/deploy/self-host/caddy/Caddyfile
+++ b/deploy/self-host/caddy/Caddyfile
@@ -54,6 +54,21 @@
 	reverse_proxy emqx:8083
 }
 
+# Blob storage (MinIO) for team files. The daemon transfers bytes here directly
+# against a presigned URL, so this name must be the one FC signs for (ENDPOINT)
+# — SigV4 covers the Host header and a mismatch fails every upload.
+#
+# S3_DOMAIN is blank until the box cuts over, and an empty site name makes Caddy
+# skip the block instead of requesting a certificate for "".
+{$CADDY_SITE_SCHEME}{$S3_DOMAIN} {
+	{$CADDY_SITE_TLS}
+
+	# No request_body limit: blobs are whole files, and Caddy's default is
+	# unlimited — stating it here only to make the intent explicit if that
+	# default ever changes.
+	reverse_proxy minio:9000
+}
+
 {$CADDY_SITE_SCHEME}{$STUDIO_DOMAIN} {
 	{$CADDY_SITE_TLS}
 	reverse_proxy studio:3000

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -242,6 +242,8 @@ services:
       # Private Supabase Storage buckets holding client-encrypted blobs: team
       # file-sync bodies and skill packages. This map is an allowlist, so a var
       # missing here never reaches the container regardless of the box's .env.
+      # Supabase bucket names, and — on TEAM_BLOBS_BACKEND=s3 — the key prefixes
+      # inside the single shared BUCKET.
       TEAM_BLOBS_STORAGE_BUCKET: "${TEAM_BLOBS_STORAGE_BUCKET:-team-blobs}"
       SKILLS_STORAGE_BUCKET: "${SKILLS_STORAGE_BUCKET:-team-skills}"
       # The ONE broker address: FC's own inbox publisher dials it AND
@@ -414,7 +416,9 @@ services:
       retries: 12
       start_period: 20s
 
-  # Buckets must exist before the first upload; MinIO does not create on write.
+  # The bucket must exist before the first upload; MinIO does not create on
+  # write. One bucket holds everything, separated by key prefix:
+  #   apps/…  team-blobs/…  team-skills/…
   # Idempotent, so it is safe on every `compose up`.
   minio-init:
     image: minio/mc:RELEASE.2025-04-16T18-13-26Z
@@ -424,14 +428,12 @@ services:
     environment:
       MINIO_ROOT_USER: "${ACCESS_KEY_ID:-teamclu}"
       MINIO_ROOT_PASSWORD: "${ACCESS_KEY_SECRET:-}"
-      TEAM_BLOBS_STORAGE_BUCKET: "${TEAM_BLOBS_STORAGE_BUCKET:-team-blobs}"
-      SKILLS_STORAGE_BUCKET: "${SKILLS_STORAGE_BUCKET:-team-skills}"
+      BUCKET: "${BUCKET:-teamclu-team}"
     entrypoint: >
       /bin/sh -c "
       mc alias set local http://minio:9000 \"$$MINIO_ROOT_USER\" \"$$MINIO_ROOT_PASSWORD\" &&
-      mc mb --ignore-existing local/\"$$TEAM_BLOBS_STORAGE_BUCKET\" &&
-      mc mb --ignore-existing local/\"$$SKILLS_STORAGE_BUCKET\" &&
-      echo 'buckets ready'
+      mc mb --ignore-existing local/\"$$BUCKET\" &&
+      echo 'bucket ready'
       "
     restart: "no"
 

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -284,6 +284,13 @@ services:
       BUCKET: "${BUCKET:-teamclu-team}"
       REGION: "${REGION:-cn-shenzhen}"
       ENDPOINT: "${ENDPOINT:-}"
+      # Blob backend for team files (knowledge, skill packages). Unset — or
+      # anything but "s3" — keeps the historical Supabase Storage path, so
+      # deploying this file changes nothing until the box opts in.
+      TEAM_BLOBS_BACKEND: "${TEAM_BLOBS_BACKEND:-}"
+      # MinIO addresses buckets by path; virtual-host style would need per-bucket
+      # DNS. Alibaba OSS works either way, so this stays blank there.
+      S3_FORCE_PATH_STYLE: "${S3_FORCE_PATH_STYLE:-}"
       # Apps module. These were declared in services/fc/s.yaml but never in this
       # allowlist, so the container saw none of them: creating an app failed at
       # the managed-git repo step (CODEUP_*), and "deploy" 503'd with an opaque
@@ -378,6 +385,56 @@ services:
       # transparent proxy that adds no CORS headers, so Hono must own CORS
       # (see services/fc/src/app.ts). Setting it would strip CORS entirely.
 
+  # ── Blob storage for team files (knowledge, skills packages) ──
+  #
+  # Team sync hands the daemon a PRESIGNED URL and the daemon transfers bytes
+  # directly — FC never proxies them. So this has to be reachable from clients,
+  # not just from the compose network: SigV4 covers the Host header, so an
+  # endpoint of `minio:9000` produces signatures that fail the moment the client
+  # dials the public name. That is what MINIO_SERVER_URL and the Caddy site are
+  # for. Bytes still live on this box; only the door is public.
+  #
+  # Inactive until FC is switched over with TEAM_BLOBS_BACKEND=s3 — the service
+  # can be deployed first and the cutover made separately.
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: "${ACCESS_KEY_ID:-teamclu}"
+      MINIO_ROOT_PASSWORD: "${ACCESS_KEY_SECRET:-}"
+      # The public origin MinIO signs and validates against.
+      MINIO_SERVER_URL: "${ENDPOINT:-}"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+  # Buckets must exist before the first upload; MinIO does not create on write.
+  # Idempotent, so it is safe on every `compose up`.
+  minio-init:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: "${ACCESS_KEY_ID:-teamclu}"
+      MINIO_ROOT_PASSWORD: "${ACCESS_KEY_SECRET:-}"
+      TEAM_BLOBS_STORAGE_BUCKET: "${TEAM_BLOBS_STORAGE_BUCKET:-team-blobs}"
+      SKILLS_STORAGE_BUCKET: "${SKILLS_STORAGE_BUCKET:-team-skills}"
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 \"$$MINIO_ROOT_USER\" \"$$MINIO_ROOT_PASSWORD\" &&
+      mc mb --ignore-existing local/\"$$TEAM_BLOBS_STORAGE_BUCKET\" &&
+      mc mb --ignore-existing local/\"$$SKILLS_STORAGE_BUCKET\" &&
+      echo 'buckets ready'
+      "
+    restart: "no"
+
   caddy:
     image: caddy:2
     restart: unless-stopped
@@ -393,6 +450,9 @@ services:
       MQTT_DOMAIN: "${MQTT_DOMAIN}"
       STUDIO_DOMAIN: "${STUDIO_DOMAIN}"
       EMQX_DASHBOARD_DOMAIN: "${EMQX_DASHBOARD_DOMAIN}"
+      # Blank until the MinIO cutover: an empty site name makes Caddy skip that
+      # block rather than request a certificate for "".
+      S3_DOMAIN: "${S3_DOMAIN:-}"
       ACME_EMAIL: "${ACME_EMAIL}"
       CADDY_GLOBAL_TLS: "${CADDY_GLOBAL_TLS:-}"
       CADDY_SITE_TLS: "${CADDY_SITE_TLS:-}"
@@ -485,6 +545,7 @@ services:
 
 volumes:
   emqx_data:
+  minio_data:
   caddy_data:
   caddy_config:
   postgres_backend_data:

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -84,10 +84,12 @@ resources:
         SUPABASE_PUBLIC_URL: ${env('SUPABASE_PUBLIC_URL', '')}
         SUPABASE_SERVICE_ROLE_KEY: ${env('SUPABASE_SERVICE_ROLE_KEY')}
         SUPABASE_ANON_KEY: ${env('SUPABASE_ANON_KEY')}
-        # Private buckets holding client-encrypted blobs: team file-sync bodies
-        # and skill packages. On TEAM_BLOBS_BACKEND=s3 these are OSS buckets and
-        # must be SEPARATE from the app-bundle BUCKET above — different
-        # lifecycle and access policies. Both have working defaults,
+        # Client-encrypted blobs: team file-sync bodies and skill packages.
+        # These name Supabase buckets on the supabase backend; on
+        # TEAM_BLOBS_BACKEND=s3 they are key PREFIXES inside the single BUCKET
+        # above, which also holds app bundles under `apps/`. The prefix is what
+        # keeps knowledge blobs and skill packages apart — their object paths are
+        # otherwise byte-identical. Both have working defaults,
         # but `s deploy` overwrites the whole environment map — an undeclared
         # var simply never arrives, so declare them even when unset.
         TEAM_BLOBS_STORAGE_BUCKET: ${env('TEAM_BLOBS_STORAGE_BUCKET', 'team-blobs')}

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -44,6 +44,13 @@ resources:
         BUCKET: ${env('BUCKET')}
         REGION: ${env('REGION', 'cn-shenzhen')}
         ENDPOINT: ${env('ENDPOINT', 'https://oss-cn-shenzhen.aliyuncs.com')}
+        # Where team file bodies live. `s3` puts them in OSS alongside app
+        # bundles (this target's choice); blank keeps the historical Supabase
+        # Storage path. Self-host sets the same var to `s3` and points it at its
+        # own MinIO — one code path, two backends, chosen per deployment.
+        TEAM_BLOBS_BACKEND: ${env('TEAM_BLOBS_BACKEND', 's3')}
+        # OSS addresses buckets virtual-host style; only MinIO needs path style.
+        S3_FORCE_PATH_STYLE: ${env('S3_FORCE_PATH_STYLE', '')}
         LITELLM_URL: ${env('LITELLM_URL', 'https://ai.ucar.cc')}
         LITELLM_MASTER_KEY: ${env('LITELLM_MASTER_KEY', '')}
         # Blank = no cap, matching the compose default. Keep the two targets in
@@ -77,8 +84,10 @@ resources:
         SUPABASE_PUBLIC_URL: ${env('SUPABASE_PUBLIC_URL', '')}
         SUPABASE_SERVICE_ROLE_KEY: ${env('SUPABASE_SERVICE_ROLE_KEY')}
         SUPABASE_ANON_KEY: ${env('SUPABASE_ANON_KEY')}
-        # Private Supabase Storage buckets holding client-encrypted blobs:
-        # team file-sync bodies and skill packages. Both have working defaults,
+        # Private buckets holding client-encrypted blobs: team file-sync bodies
+        # and skill packages. On TEAM_BLOBS_BACKEND=s3 these are OSS buckets and
+        # must be SEPARATE from the app-bundle BUCKET above — different
+        # lifecycle and access policies. Both have working defaults,
         # but `s deploy` overwrites the whole environment map — an undeclared
         # var simply never arrives, so declare them even when unset.
         TEAM_BLOBS_STORAGE_BUCKET: ${env('TEAM_BLOBS_STORAGE_BUCKET', 'team-blobs')}

--- a/services/fc/src/lib/skills-storage.ts
+++ b/services/fc/src/lib/skills-storage.ts
@@ -1,9 +1,10 @@
-import { SKILLS_BUCKET, supabaseBlobStorage } from "./team-blob-storage.js";
+import { SKILLS_BUCKET, blobStorageFor } from "./team-blob-storage.js";
 
 // ---------------------------------------------------------------------------
 // Supabase Storage helpers for team skill package blobs.
 //
-// Package bodies (zips) live in a private Supabase Storage bucket, keyed by the
+// Package bodies (zips) live in a private bucket on whichever blob backend the
+// deployment runs (see team-blob-storage.ts), keyed by the
 // same content-addressed path amuxc_blobs already tracks
 // (teams/<teamId>/blobs/sha256/<aa>/<bb>/<hash>). amuxc_blobs stays the
 // dedup/bookkeeping table; oss_key just holds this bucket's object path now.
@@ -14,7 +15,15 @@ import { SKILLS_BUCKET, supabaseBlobStorage } from "./team-blob-storage.js";
 
 export { SKILLS_BUCKET };
 
-const storage = supabaseBlobStorage(SKILLS_BUCKET);
+// Resolved lazily: `blobStorageFor` reads env, and a module-level call would
+// freeze the choice at import time — before the process env is fully set up in
+// some test and serverless entrypoints.
+const storage = {
+  createUploadUrl: (p: string) => blobStorageFor(SKILLS_BUCKET).createUploadUrl(p),
+  createDownloadUrl: (p: string, e?: number) =>
+    blobStorageFor(SKILLS_BUCKET).createDownloadUrl(p, e),
+  stat: (p: string) => blobStorageFor(SKILLS_BUCKET).stat(p),
+};
 
 export function createSkillUploadUrl(objectPath: string): Promise<string> {
   return storage.createUploadUrl(objectPath);

--- a/services/fc/src/lib/team-blob-storage.ts
+++ b/services/fc/src/lib/team-blob-storage.ts
@@ -1,12 +1,33 @@
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { createServiceRoleClient } from "./supabase.js";
+import { getS3Client } from "./oss.js";
 
 // ---------------------------------------------------------------------------
-// Supabase Storage helpers for team blobs.
+// Blob storage for team files.
 //
 // Both team sync (knowledge documents) and the skills registry store immutable,
 // content-addressed, client-encrypted blobs. They share this signing layer and
 // differ only in which private bucket they land in — one place to change when
 // the storage backend moves again.
+//
+// Two backends, picked by `TEAM_BLOBS_BACKEND`:
+//
+//   supabase (default) — Supabase Storage, the historical home.
+//   s3                 — any S3-compatible store: MinIO on self-host, Alibaba
+//                        OSS on the Aliyun FC target. Same protocol both ways,
+//                        which is the point: file bytes stop riding on the
+//                        Postgres-adjacent stack that also serves auth and the
+//                        control plane.
+//
+// The switch is an explicit env var rather than "S3 creds are present": the
+// Aliyun target already sets `ACCESS_KEY_ID` for app-bundle uploads, and
+// inferring from that would silently relocate every team's blobs the day
+// someone configured app deploys.
 //
 // Object paths keep the historical `teams/<teamId>/blobs/sha256/<aa>/<bb>/<hash>`
 // shape, and `amuxc_blobs.oss_key` keeps its name: the column is just "where the
@@ -98,10 +119,78 @@ export function supabaseBlobStorage(bucket: () => string): BlobStorage {
   };
 }
 
+/**
+ * A `BlobStorage` backed by one private S3-compatible bucket.
+ *
+ * Presigned URLs are handed to the daemon, which PUTs/GETs them **directly** —
+ * FC never sees the bytes. So `ENDPOINT` must be the host the client can reach,
+ * not an in-cluster address: SigV4 covers the Host header, so signing for
+ * `minio:9000` and dialing `s3.example.com` fails the signature, and signing
+ * for a host the client cannot resolve fails the transfer. This is why the
+ * self-host MinIO sits behind Caddy on its own domain.
+ */
+export function s3BlobStorage(bucket: () => string): BlobStorage {
+  return {
+    async createUploadUrl(objectPath) {
+      // `as any`: two @aws-sdk major versions coexist in the tree, so the
+      // presigner's `Client` and this `S3Client` have separate declarations of
+      // a private field. Same cast `index.ts` uses for app-bundle uploads.
+      return getSignedUrl(
+        getS3Client() as any,
+        new PutObjectCommand({ Bucket: bucket(), Key: objectPath }),
+        { expiresIn: 900 },
+      );
+    },
+
+    async createDownloadUrl(objectPath, expiresIn = 900) {
+      return getSignedUrl(
+        getS3Client() as any,
+        new GetObjectCommand({ Bucket: bucket(), Key: objectPath }),
+        { expiresIn },
+      );
+    },
+
+    async stat(objectPath) {
+      try {
+        const head = await getS3Client().send(
+          new HeadObjectCommand({ Bucket: bucket(), Key: objectPath }),
+        );
+        return { size: head.ContentLength ?? 0 };
+      } catch (e) {
+        if (isMissingObject(e)) return null;
+        throw e;
+      }
+    },
+  };
+}
+
+/**
+ * Whether an S3 error means "no such object" rather than a real failure.
+ *
+ * A missing object is the normal needs-upload answer. Everything else (bad
+ * creds, network, bucket gone) must propagate: treating those as "absent" would
+ * report every blob as missing and re-upload the entire team.
+ */
+export function isMissingObject(e: unknown): boolean {
+  const status = (e as { $metadata?: { httpStatusCode?: number } })?.$metadata?.httpStatusCode;
+  const name = (e as { name?: string })?.name;
+  return status === 404 || name === "NotFound" || name === "NoSuchKey";
+}
+
+/** Which backend `getTeamBlobStorage` / the skills store resolve to. */
+export function blobBackendKind(): "s3" | "supabase" {
+  return process.env.TEAM_BLOBS_BACKEND?.trim() === "s3" ? "s3" : "supabase";
+}
+
+/** A blob store for `bucket`, on whichever backend this deployment runs. */
+export function blobStorageFor(bucket: () => string): BlobStorage {
+  return blobBackendKind() === "s3" ? s3BlobStorage(bucket) : supabaseBlobStorage(bucket);
+}
+
 let cachedTeamBlobStorage: BlobStorage | undefined;
 
 /** Default blob store for team file sync. */
 export function getTeamBlobStorage(): BlobStorage {
-  cachedTeamBlobStorage ??= supabaseBlobStorage(TEAM_BLOBS_BUCKET);
+  cachedTeamBlobStorage ??= blobStorageFor(TEAM_BLOBS_BUCKET);
   return cachedTeamBlobStorage;
 }

--- a/services/fc/src/lib/team-blob-storage.ts
+++ b/services/fc/src/lib/team-blob-storage.ts
@@ -5,7 +5,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { createServiceRoleClient } from "./supabase.js";
-import { getS3Client } from "./oss.js";
+import { getS3Client, OSS_BUCKET } from "./oss.js";
 
 // ---------------------------------------------------------------------------
 // Blob storage for team files.
@@ -14,6 +14,23 @@ import { getS3Client } from "./oss.js";
 // content-addressed, client-encrypted blobs. They share this signing layer and
 // differ only in which private bucket they land in — one place to change when
 // the storage backend moves again.
+//
+// On S3 everything shares ONE bucket (`BUCKET`) and is separated by key prefix,
+// so a deployment needs exactly one bucket to provision and one policy to
+// reason about:
+//
+//   apps/<appId>/code.zip                       app bundles (already distinct)
+//   team-blobs/teams/<teamId>/blobs/sha256/...  knowledge documents
+//   team-skills/teams/<teamId>/blobs/sha256/... skill packages
+//
+// The prefix matters for the last two: their object paths are byte-identical
+// (both content-addressed the same way), so without it a skill package and a
+// knowledge blob would be the same object — harmless while both exist, fatal
+// the moment one side's GC deletes it out from under the other.
+//
+// `TEAM_BLOBS_STORAGE_BUCKET` / `SKILLS_STORAGE_BUCKET` name the Supabase
+// bucket on the supabase backend and the key prefix on the s3 one. One setting,
+// one meaning per backend: "where this kind of blob lives".
 //
 // Two backends, picked by `TEAM_BLOBS_BACKEND`:
 //
@@ -128,8 +145,16 @@ export function supabaseBlobStorage(bucket: () => string): BlobStorage {
  * `minio:9000` and dialing `s3.example.com` fails the signature, and signing
  * for a host the client cannot resolve fails the transfer. This is why the
  * self-host MinIO sits behind Caddy on its own domain.
+ *
+ * `prefix` is what keeps the shared bucket's tenants apart; see the module
+ * header. Passing an empty one is legitimate (app bundles carry their own
+ * `apps/` prefix already).
  */
-export function s3BlobStorage(bucket: () => string): BlobStorage {
+export function s3BlobStorage(bucket: () => string, prefix: () => string): BlobStorage {
+  const key = (objectPath: string) => {
+    const p = prefix().replace(/^\/+|\/+$/g, "");
+    return p ? `${p}/${objectPath}` : objectPath;
+  };
   return {
     async createUploadUrl(objectPath) {
       // `as any`: two @aws-sdk major versions coexist in the tree, so the
@@ -137,7 +162,7 @@ export function s3BlobStorage(bucket: () => string): BlobStorage {
       // a private field. Same cast `index.ts` uses for app-bundle uploads.
       return getSignedUrl(
         getS3Client() as any,
-        new PutObjectCommand({ Bucket: bucket(), Key: objectPath }),
+        new PutObjectCommand({ Bucket: bucket(), Key: key(objectPath) }),
         { expiresIn: 900 },
       );
     },
@@ -145,7 +170,7 @@ export function s3BlobStorage(bucket: () => string): BlobStorage {
     async createDownloadUrl(objectPath, expiresIn = 900) {
       return getSignedUrl(
         getS3Client() as any,
-        new GetObjectCommand({ Bucket: bucket(), Key: objectPath }),
+        new GetObjectCommand({ Bucket: bucket(), Key: key(objectPath) }),
         { expiresIn },
       );
     },
@@ -153,7 +178,7 @@ export function s3BlobStorage(bucket: () => string): BlobStorage {
     async stat(objectPath) {
       try {
         const head = await getS3Client().send(
-          new HeadObjectCommand({ Bucket: bucket(), Key: objectPath }),
+          new HeadObjectCommand({ Bucket: bucket(), Key: key(objectPath) }),
         );
         return { size: head.ContentLength ?? 0 };
       } catch (e) {
@@ -182,9 +207,16 @@ export function blobBackendKind(): "s3" | "supabase" {
   return process.env.TEAM_BLOBS_BACKEND?.trim() === "s3" ? "s3" : "supabase";
 }
 
-/** A blob store for `bucket`, on whichever backend this deployment runs. */
-export function blobStorageFor(bucket: () => string): BlobStorage {
-  return blobBackendKind() === "s3" ? s3BlobStorage(bucket) : supabaseBlobStorage(bucket);
+/**
+ * A blob store for one kind of blob, on whichever backend this deployment runs.
+ *
+ * `name` is the Supabase bucket on the supabase backend, and the key prefix
+ * inside the single shared `BUCKET` on the s3 one.
+ */
+export function blobStorageFor(name: () => string): BlobStorage {
+  return blobBackendKind() === "s3"
+    ? s3BlobStorage(OSS_BUCKET, name)
+    : supabaseBlobStorage(name);
 }
 
 let cachedTeamBlobStorage: BlobStorage | undefined;

--- a/services/fc/test/team-blob-storage.test.ts
+++ b/services/fc/test/team-blob-storage.test.ts
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { blobBackendKind, isMissingObject } from "../src/lib/team-blob-storage.js";
+
+function withEnv(value: string | undefined, fn: () => void) {
+  const prev = process.env.TEAM_BLOBS_BACKEND;
+  if (value === undefined) delete process.env.TEAM_BLOBS_BACKEND;
+  else process.env.TEAM_BLOBS_BACKEND = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.TEAM_BLOBS_BACKEND;
+    else process.env.TEAM_BLOBS_BACKEND = prev;
+  }
+}
+
+test("blob backend defaults to supabase", () => {
+  // Existing deployments must not relocate their blobs by upgrading.
+  withEnv(undefined, () => assert.equal(blobBackendKind(), "supabase"));
+  withEnv("", () => assert.equal(blobBackendKind(), "supabase"));
+});
+
+test("blob backend switches only on an explicit s3 opt-in", () => {
+  withEnv("s3", () => assert.equal(blobBackendKind(), "s3"));
+  withEnv(" s3 ", () => assert.equal(blobBackendKind(), "s3"));
+  // Anything else is not a silent fallthrough to s3 — a typo must keep the
+  // deployment where its bytes already are.
+  withEnv("minio", () => assert.equal(blobBackendKind(), "supabase"));
+  withEnv("S3", () => assert.equal(blobBackendKind(), "supabase"));
+});
+
+test("a missing object is classified apart from a real failure", () => {
+  // "Missing" is the normal needs-upload answer. Swallowing other failures
+  // would report every blob as absent and re-upload the whole team.
+  assert.equal(isMissingObject({ $metadata: { httpStatusCode: 404 } }), true);
+  assert.equal(isMissingObject({ name: "NotFound" }), true);
+  assert.equal(isMissingObject({ name: "NoSuchKey" }), true);
+
+  assert.equal(isMissingObject({ name: "AccessDenied", $metadata: { httpStatusCode: 403 } }), false);
+  assert.equal(isMissingObject({ $metadata: { httpStatusCode: 500 } }), false);
+  assert.equal(isMissingObject(new Error("socket hang up")), false);
+  assert.equal(isMissingObject(undefined), false);
+});

--- a/services/fc/test/team-blob-storage.test.ts
+++ b/services/fc/test/team-blob-storage.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { blobBackendKind, isMissingObject } from "../src/lib/team-blob-storage.js";
+import { blobBackendKind, isMissingObject, s3BlobStorage } from "../src/lib/team-blob-storage.js";
 
 function withEnv(value: string | undefined, fn: () => void) {
   const prev = process.env.TEAM_BLOBS_BACKEND;
@@ -41,4 +41,36 @@ test("a missing object is classified apart from a real failure", () => {
   assert.equal(isMissingObject({ $metadata: { httpStatusCode: 500 } }), false);
   assert.equal(isMissingObject(new Error("socket hang up")), false);
   assert.equal(isMissingObject(undefined), false);
+});
+
+test("the shared bucket is partitioned by key prefix", async () => {
+  // Knowledge blobs and skill packages are content-addressed the same way, so
+  // their object paths are byte-identical. Without the prefix they would be the
+  // same object in a shared bucket, and one side's GC would delete the other's.
+  const seen: string[] = [];
+  const original = process.env.ACCESS_KEY_ID;
+  process.env.ACCESS_KEY_ID = "k";
+  process.env.ACCESS_KEY_SECRET = "s";
+  process.env.ENDPOINT = "https://s3.example.com";
+
+  const objectPath = "teams/t1/blobs/sha256/aa/bb/hash";
+  for (const prefix of ["team-blobs", "team-skills", "", "/team-blobs/"]) {
+    const url = await s3BlobStorage(
+      () => "shared",
+      () => prefix,
+    ).createUploadUrl(objectPath);
+    // Path-style puts the bucket in the path, virtual-host style in the
+    // hostname. Normalize so this test pins the prefix, not the addressing mode
+    // (MinIO needs path-style, OSS does not — both must partition the same).
+    seen.push(new URL(url).pathname.replace(/^\/shared/, ""));
+  }
+  if (original === undefined) delete process.env.ACCESS_KEY_ID;
+  else process.env.ACCESS_KEY_ID = original;
+
+  assert.equal(seen[0], `/team-blobs/${objectPath}`);
+  assert.equal(seen[1], `/team-skills/${objectPath}`);
+  // No prefix is legitimate: app bundles carry their own `apps/` already.
+  assert.equal(seen[2], `/${objectPath}`);
+  // Stray slashes must not produce `//` or a leading empty segment.
+  assert.equal(seen[3], seen[0]);
 });


### PR DESCRIPTION
让团队文件的字节从 Supabase Storage 挪走：**self-host 用本机 MinIO，belayo 用阿里云 OSS**。

## 为什么

Knowledge 文档和技能包的字节此前一律走 Supabase Storage——和 auth、控制面同一套栈，文件流量压上去顶不住。而同一个 FC 里其实**已经有第二套存储**（app bundle 走 S3），所以现状是两套栈并存。统一到 S3 协议之后反而更简单：一个接口、两种后端、按部署选。

## 代码改了什么

`services/fc/src/lib/team-blob-storage.ts` 新增 `s3BlobStorage`，实现现成的 `BlobStorage` 三个方法（`createUploadUrl` / `createDownloadUrl` / `stat`）。S3 客户端复用已有的 `getS3Client()`，没有新依赖。team 同步与技能包两处都改走 `blobStorageFor(bucket)`，桶各自独立。

**选择是显式 env（`TEAM_BLOBS_BACKEND`），不是"有 AK 就切"**：阿里云那侧本来就为 app 部署配了 `ACCESS_KEY_ID`，按存在与否推断，会在某人配好 app 部署的那天悄悄把所有团队的 blob 搬家。默认值保持 `supabase`。

## 一个必须记住的约束

同步不是"客户端 → FC → 存储"，而是 FC 只发预签名 URL、**daemon 直传**：

```
amuxd → FC /sync/upload/prepare → presignedPut
amuxd → PUT <presignedPut>       ← 直连存储，FC 不经手字节
```

SigV4 把 Host 算进签名，所以 `ENDPOINT` 必须是**客户端能到达的那个名字**——不能是 `minio:9000`（签名不匹配），也不能是客户端解析不了的名字（传输失败）。这就是 MinIO 要挂在 Caddy 上并配 `MINIO_SERVER_URL` 的原因。

**"内网"指的是数据落在本机，不是端口不对外。**

## 部署侧

**self-host**（`docker-compose.yml` / `Caddyfile` / `.env.example`）：

- 新增 `minio` + `minio-init`（幂等建桶，MinIO 不会在写入时自动建）+ `minio_data` 卷
- Caddy 新增 `S3_DOMAIN` 站点；**域名留空时 Caddy 会跳过该块**，不会去给 `""` 申请证书——所以合并本 PR 不会改变现有部署
- FC 新增 `TEAM_BLOBS_BACKEND`、`S3_FORCE_PATH_STYLE`

**belayo**（`s.yaml`）：`TEAM_BLOBS_BACKEND` 默认 `s3`，AK/BUCKET/ENDPOINT 它本来就有。按 CLAUDE.md 的规矩，新变量两个目标都声明了。

### 单桶 + 前缀分区

S3 侧**只用一个桶**（`BUCKET`），用 key 前缀分区——一个部署只需开一个桶、只需想清楚一份策略：

```
apps/<appId>/code.zip                        应用包（本来就是这个前缀）
team-blobs/teams/<teamId>/blobs/sha256/...   Knowledge 文档
team-skills/teams/<teamId>/blobs/sha256/...  技能包
```

前缀对后两者是**必须的**，不是整洁问题：它们的 object path 完全一样（同一套内容寻址），共用一个桶而不加前缀就会变成同一个对象——两边都在时无害，但任何一侧的 GC 删掉它，另一侧就凭空少了一个 blob。

`TEAM_BLOBS_STORAGE_BUCKET` / `SKILLS_STORAGE_BUCKET` 被复用为前缀名：在 supabase 后端它们是桶名，在 s3 后端是前缀。一个配置项，每种后端一个含义，不新增变量。

## 合并是安全的：分两步走

`TEAM_BLOBS_BACKEND` 默认空 → FC 继续用 Supabase Storage，`S3_DOMAIN` 默认空 → Caddy 不加站点。所以：

1. **合并本 PR** —— 基础设施就位（MinIO 起来、桶建好），行为零变化
2. **切换**（另行操作，改 `.env` 即可）：加 DNS `s3.<域名>` → 设 `ACCESS_KEY_ID/SECRET`（MinIO root 凭据）、`ENDPOINT=https://s3.<域名>`、`S3_FORCE_PATH_STYLE=1`、`TEAM_BLOBS_BACKEND=s3` → `docker compose up -d`

## 存量数据

切换后旧 blob 的 `stat()` 返回 null → `requiresUpload=true` → 客户端重新上传，本地还有文件就自愈。**不做迁移**（已确认）。想避免重传的话，切换前跑一次 `mc mirror` 也行。

## 验证

| 检查 | 结果 |
|---|---|
| `services/fc` `pnpm build` | 通过 |
| 新增单测 | 3 passed（后端选择的默认值与显式 opt-in、`stat` 的 404 分类） |
| `docker compose config -q` | 通过 |
| `s.yaml` YAML 解析 | 通过 |

`stat` 那条测试值得一看：**只有"对象不存在"才返回 null，凭据/网络/桶不存在都要往外抛**——把后者也吞成"不存在"，会让每个 blob 都报缺失，触发整个团队重传。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

