### PR TITLE
fix(app): 修复暗色模式退出指引 UI

### DIFF
--- a/packages/app/src/components/CloseToTrayDialog.tsx
+++ b/packages/app/src/components/CloseToTrayDialog.tsx
@@ -167,14 +167,16 @@ function ChoiceCard(props: {
       className={cn(
         'grid grid-cols-[18px_1fr] gap-2.5 rounded-[10px] border px-3 py-2.5 text-left transition-colors',
         props.selected
-          ? 'border-[color:rgba(232,90,74,0.45)] bg-[#fff8f6]'
-          : 'border-border bg-background hover:border-[color:rgba(26,26,20,0.16)]',
+          ? 'border-coral/45 bg-coral-soft/25'
+          : 'border-border bg-background hover:border-foreground/16',
       )}
     >
       <span
         className={cn(
           'mt-0.5 h-[14px] w-[14px] rounded-full border',
-          props.selected ? 'border-coral bg-coral shadow-[inset_0_0_0_3px_#fff]' : 'border-border',
+          props.selected
+            ? 'border-coral bg-coral shadow-[inset_0_0_0_3px_var(--paper)]'
+            : 'border-border',
         )}
         aria-hidden
       />

--- a/packages/app/src/components/chat/ComposerStack.tsx
+++ b/packages/app/src/components/chat/ComposerStack.tsx
@@ -159,7 +159,7 @@ function ComposerAgentStrip({
       <div
         className={cn(
           "box-border flex min-h-9 w-full items-center gap-1 px-2 py-[7px] pr-3.5",
-          enlarged && "bg-[#fdf0ed]",
+          enlarged && "bg-coral-soft/20",
         )}
       >
         {canExpand ? (

--- a/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
+++ b/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
@@ -21,11 +21,11 @@ export function SkillToolCard({ toolCall }: { toolCall: ToolCall }) {
       className="overflow-hidden rounded-[14px] border border-[#e7edf4] bg-[#fbfcfe] dark:border-border dark:bg-card"
     >
       <div className="flex items-center gap-[10px] px-3 py-[10px]">
-        <span className="text-[12px] text-[#8a7a63]">⚡</span>
+        <span className="text-[12px] text-ink-2">⚡</span>
         <span className="text-[13px] font-bold text-[#334155] dark:text-foreground">
           {skillName}
         </span>
-        <span className="rounded-full border border-[#e8dfd1] bg-[#f7f4ed] px-2 py-0.5 text-[11px] text-[#8a7a63]">
+        <span className="rounded-full border border-coral/25 bg-coral-soft/30 px-2 py-0.5 text-[11px] text-ink-2">
           {t("chat.toolCall.skill.title", "Skill")}
         </span>
         <div className="ml-auto">


### PR DESCRIPTION
## 变更
- 修复退出应用指引在暗色模式下选中项浅色背景导致文字不可读的问题
- 将单选圆点和相关高亮背景改为主题 token
- 扫描并修复 Composer 与 Skill tool card 中同类浅色硬编码

## 验证
- `pnpm --filter @teamclu/app exec vitest run src/components/__tests__/CloseToTrayDialog.test.tsx --maxWorkers=1`
- `pnpm --filter @teamclu/app typecheck`
- `git diff --check`
