### PR TITLE
fix(self-host): 修好 MinIO 上线时的部署失败

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -269,6 +269,21 @@ jobs:
               [ -n "$pulled" ] || { echo "litellm image pull failed after 5 attempts"; exit 1; }
             fi
 
+            echo "=== pull minio (same reason as litellm) ==="
+            # `up --pull never` fetches nothing, so every image this compose
+            # file adds has to be pulled here or the whole `up` aborts with
+            # "No such image" — which is exactly how the MinIO rollout failed
+            # its first deploy.
+            for svc in minio minio-init; do
+              pulled=""
+              for i in 1 2 3; do
+                if docker compose pull "$svc"; then pulled=yes; break; fi
+                echo "  $svc pull attempt $i failed; retrying in 10s"
+                sleep 10
+              done
+              [ -n "$pulled" ] || { echo "$svc image pull failed after 3 attempts"; exit 1; }
+            done
+
             echo "=== up ==="
             docker compose up -d --pull never --remove-orphans
 

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -399,7 +399,7 @@ services:
   # Inactive until FC is switched over with TEAM_BLOBS_BACKEND=s3 — the service
   # can be deployed first and the cutover made separately.
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:
@@ -421,7 +421,7 @@ services:
   #   apps/…  team-blobs/…  team-skills/…
   # Idempotent, so it is safe on every `compose up`.
   minio-init:
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
#937 合并后自动部署红了：

```
Error response from daemon: No such image: minio/minio:RELEASE.2025-04-22T22-12-26Z
```

两个原因，都出在我这边：

1. **镜像 tag 是凭印象写的，压根不存在。** 换成 Docker Hub 上真实存在的 `minio RELEASE.2025-09-07T16-13-09Z` / `mc RELEASE.2025-08-13T08-35-41Z`。
2. **更要紧的**：部署走的是 `docker compose up -d --pull never`，它什么都不拉。litellm 之所以能用，是因为脚本里专门为它写了预拉取。**任何新加进这个 compose 的镜像都必须同样预拉**，否则整个 `up` 直接中止——tag 写对了也一样会挂。

所以这里补的是预拉取（带重试，和 litellm 同一形状），tag 修正只是顺带。

## 线上未受影响

失败发生在拉镜像阶段，`fc` 容器没有被替换：

- `GET /healthz` → 200
- FC 日志里 `/sync/manifest` 全程 200，最近一次 06:55

## 验证

- `docker compose config -q` 通过
- workflow YAML 解析通过
- tag 是查 Docker Hub tags API 拿到的，不是再猜一次

🤖 Generated with [Claude Code](https://claude.com/claude-code)