### PR TITLE
fix(db): 邀请认领不再删除 public.orgs 的行

### DIFF
--- a/services/supabase/migrations/20260817000000_org_gc_keeps_public_orgs.sql
+++ b/services/supabase/migrations/20260817000000_org_gc_keeps_public_orgs.sql
@@ -1,0 +1,186 @@
+-- Stop the invite-claim path from deleting rows in public.orgs.
+--
+-- amux.claim_team_invite_legacy implements "strict single-org" (S3-FC.3): when a
+-- member claims an invite, their public.users.org_id is switched to the invite
+-- team's org. It then garbage-collects the org they left, if that org has no
+-- users remaining:
+--
+--     delete from amux.teams where oid = v_old_org;   -- ours
+--     delete from public.orgs  where id = v_old_org;  -- NOT ours
+--
+-- The second statement is the problem. Both public tables are explicitly
+-- foreign, per their own baseline comments:
+--
+--   public.orgs  — 'Mirror of saas-mono public.orgs (canonical tenant).
+--                   saas-mono-owned on the merged instance.'
+--   public.users — 'SUBSET mirror of saas-mono public.users … saas-mono-owned
+--                   on merge'
+--
+-- On a merged instance that ownership is not theoretical. There, public.orgs is
+-- the other product's tenant table, and 185 foreign keys point at it — 31 of
+-- them ON DELETE CASCADE (routes, route_plans, route_setters, staffs, roles,
+-- permissions, roles_users, org_units, store_areas, tasks/task_comments/
+-- task_attachments, marketing_*, wechat_accounts, certification_definitions, …).
+-- Accepting a team invite is not an operation that should be able to reach any
+-- of that. "The last user left this tenant" is a judgement only the product that
+-- owns the tenant table can make; we cannot see the rest of its data and have no
+-- business inferring abandonment from the one column we mirror.
+--
+-- Note what this does NOT change: the amux.teams deletion stays. Collecting our
+-- own teams for an org nobody is left in is squarely ours to do, and on a
+-- TeamClu-only instance (where public.orgs has just two referents, amux.teams
+-- and public.users) that was always the substantive half of the GC.
+--
+-- Two consequences worth stating plainly:
+--
+--   1. A TeamClu-only instance now accumulates user-less rows in public.orgs
+--      instead of clearing them. That is inert: every reader reaches orgs
+--      through the caller's own public.users row (list_teams_for_picker's
+--      related_orgs, bootstrap_current_org_team), so an org with no users is
+--      reachable by nobody and never appears in a picker.
+--
+--   2. On a merged instance the amux.teams deletion begins to take effect where
+--      it previously did not. The pair ran inside one BEGIN…EXCEPTION
+--      subtransaction, and there the orgs delete always raised — every org
+--      carries audit_logs rows behind a NOT DEFERRABLE no-action FK, and the
+--      orgs audit trigger writes one more on the way out — so the swallowed
+--      exception rolled the amux.teams delete back along with it. Removing the
+--      statement that always failed is what lets the statement that should
+--      always have run actually commit.
+--
+-- Carried forward from 20260812120000_agents_device_identity.sql. One statement
+-- is gone; the only other edits are two comments (this GC block's, and a stale
+-- "CHANGED:" prefix that was written relative to that migration's own diff).
+
+CREATE OR REPLACE FUNCTION amux.claim_team_invite_legacy(p_token text)
+ RETURNS TABLE(actor_id uuid, team_id uuid, actor_type text, display_name text, refresh_token text)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'amux', 'public', 'auth', 'extensions'
+AS $function$
+declare
+  v_invite      amux.team_invites%rowtype;
+  v_user_id     uuid;
+  v_actor       uuid;
+  v_email       text;
+  v_session     uuid;
+  v_rt          text := null;
+  v_old_user    uuid;
+  v_target_anon boolean;
+  v_team_org    uuid;   -- invite team's org (S3-FC.3)
+  v_old_org     uuid;   -- claimer's previous org (member path)
+begin
+  select * into v_invite from amux.team_invites where token = p_token for update;
+  if not found then raise exception 'invite not found' using errcode = '23503'; end if;
+  if v_invite.consumed_at is not null then raise exception 'invite already consumed' using errcode = '23514'; end if;
+  if v_invite.status = 'declined' then raise exception 'invite was declined' using errcode = '23514'; end if;
+  if v_invite.status = 'expired' then raise exception 'invite superseded' using errcode = '23514'; end if;
+  if v_invite.expires_at < now() then raise exception 'invite expired' using errcode = '23514'; end if;
+
+  -- Resolved once for both branches: members get public.users.org_id switched,
+  -- agents get the claim baked into raw_app_meta_data.
+  select oid into v_team_org from amux.teams where id = v_invite.team_id;
+
+  if v_invite.kind = 'member' then
+    if v_invite.target_actor_id is not null then
+      -- Unconsumed tokens minted before the removal still carry a target. They
+      -- are refused rather than degraded into a self-join: the token was issued
+      -- to hand back somebody else's credentials, not to add the caller.
+      raise exception 'member re-invite is no longer supported' using errcode = '22023';
+    else
+      v_user_id := auth.uid();
+      if v_user_id is null then raise exception 'member claim requires authentication' using errcode = '42501'; end if;
+      if exists (select 1 from amux.actors act where act.team_id = v_invite.team_id and act.user_id = v_user_id) then
+        raise exception 'already a member of this team' using errcode = '23505';
+      end if;
+
+      insert into amux.actors (team_id, actor_type, user_id, invited_by_actor_id, display_name, last_active_at)
+      values (v_invite.team_id, 'member', v_user_id, v_invite.invited_by_actor_id, v_invite.display_name, now())
+      returning id into v_actor;
+      insert into amux.members (id, status) values (v_actor, 'active');
+      insert into amux.team_members (team_id, member_id, role) values (v_invite.team_id, v_actor, v_invite.team_role);
+    end if;
+
+    -- S3-FC.3: strict single-org — claimer's org becomes the invite team's org.
+    if v_team_org is not null and v_user_id is not null then
+      select org_id into v_old_org from public.users where id = v_user_id;
+      if v_old_org is null then
+        insert into public.users (id, org_id, mobile) values (v_user_id, v_team_org, '');
+      else
+        update public.users set org_id = v_team_org, updated_at = now() where id = v_user_id;
+      end if;
+      -- best-effort GC of OUR teams under the abandoned old org; never fail the
+      -- claim. public.orgs is deliberately left alone — see the header: that row
+      -- belongs to saas-mono, and on a merged instance deleting it cascades into
+      -- another product's data.
+      begin
+        if v_old_org is not null and v_old_org <> v_team_org
+           and not exists (select 1 from public.users where org_id = v_old_org) then
+          delete from amux.teams where oid = v_old_org;   -- cascades actors/members/sessions/...
+        end if;
+      exception when others then
+        null;  -- leave the orphan; reassignment already succeeded
+      end;
+    end if;
+  else
+    v_user_id := gen_random_uuid();
+    v_email   := format('daemon.%s@amuxd.run', v_user_id);
+    v_session := gen_random_uuid();
+    v_rt      := substring(encode(extensions.gen_random_bytes(6), 'hex'), 1, 12);
+    -- Stamp the team's org into app_metadata so daemon access tokens pass
+    -- teams_org_guard (current_org_id() reads the JWT claim first; daemon
+    -- users have no public.users fallback row).
+    insert into auth.users (id, email, email_confirmed_at, encrypted_password, confirmation_token, recovery_token,
+      email_change_token_new, email_change, raw_app_meta_data, aud, role, created_at, updated_at, instance_id)
+    values (v_user_id, v_email, now(), '', '', '', '', '',
+      case when v_team_org is not null then jsonb_build_object('org_id', v_team_org) else '{}'::jsonb end,
+      'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000');
+    insert into auth.sessions (id, user_id, aal, created_at, updated_at) values (v_session, v_user_id, 'aal1', now(), now());
+    insert into auth.refresh_tokens (token, user_id, session_id, revoked, instance_id, created_at, updated_at)
+      values (v_rt, v_user_id::text, v_session, false, '00000000-0000-0000-0000-000000000000', now(), now());
+
+    -- Also give the daemon account a public.users fallback row with the team's
+    -- org, so org resolvers that query public.users by id directly (without the
+    -- JWT app_metadata.org_id claim) can resolve org_id instead of erroring.
+    if v_team_org is not null then
+      insert into public.users (id, org_id, mobile) values (v_user_id, v_team_org, '')
+      on conflict (id) do update set org_id = excluded.org_id, updated_at = now();
+    end if;
+
+    if v_invite.target_actor_id is not null then
+      select user_id into v_old_user from amux.actors where id = v_invite.target_actor_id;
+      update amux.actors set user_id = v_user_id, invited_by_actor_id = v_invite.invited_by_actor_id,
+             last_active_at = null, updated_at = now() where id = v_invite.target_actor_id;
+      v_actor := v_invite.target_actor_id;
+      -- A device-scoped agent keeps whatever visibility it has. Every credential
+      -- rotation (team switch, expired refresh token) lands here, and forcing
+      -- 'team' turned each one into a silent publish of the machine. Agents with
+      -- no device_id keep the historical behaviour.
+      update amux.agents
+         set owner_member_id = v_invite.invited_by_actor_id,
+             visibility = case when device_id is not null then visibility else 'team' end,
+             updated_at = now()
+       where id = v_actor;
+      if v_old_user is not null then delete from auth.users where id = v_old_user; end if;
+    else
+      insert into amux.actors (team_id, actor_type, user_id, invited_by_actor_id, display_name, last_active_at)
+      values (v_invite.team_id, 'agent', v_user_id, v_invite.invited_by_actor_id, v_invite.display_name, null)
+      returning id into v_actor;
+      insert into amux.agents (id, owner_member_id, visibility, status) values (v_actor, v_invite.invited_by_actor_id, 'team', 'active');
+    end if;
+
+    insert into amux.agent_member_access (agent_id, member_id, permission_level, granted_by_member_id)
+    values (v_actor, v_invite.invited_by_actor_id, 'admin', v_invite.invited_by_actor_id)
+    on conflict (agent_id, member_id) do update
+      set permission_level = 'admin', granted_by_member_id = excluded.granted_by_member_id, updated_at = now();
+  end if;
+
+  update amux.team_invites set consumed_at = now(), consumed_by_actor_id = v_actor,
+         status = 'accepted', updated_at = now() where id = v_invite.id;
+
+  return query select v_actor, v_invite.team_id, v_invite.kind::text, v_invite.display_name, v_rt;
+end;
+$function$;
+
+comment on function amux.claim_team_invite_legacy(text) is
+  'Consumes an invite token. Member claims move the claimer onto the invite team''s org (strict single-org) and collect any amux.teams left under the org they vacated. public.orgs and its rows are never deleted here — that table is saas-mono-owned.';

--- a/services/supabase/tests/031_org_gc_keeps_public_orgs.sql
+++ b/services/supabase/tests/031_org_gc_keeps_public_orgs.sql
@@ -1,0 +1,109 @@
+-- 031_org_gc_keeps_public_orgs.sql
+--
+-- amux.claim_team_invite_legacy moves a member onto the invite team's org
+-- (strict single-org) and then collects what the org they left behind still
+-- holds. 20260817000000_org_gc_keeps_public_orgs.sql narrowed that collection to
+-- our own amux.teams: public.orgs is a saas-mono-owned mirror, and on a merged
+-- instance deleting a row there cascades into another product's tables.
+--
+-- This file pins both halves at once, because the failure modes point in
+-- opposite directions: dropping the orgs delete is only safe if the teams delete
+-- still happens, and re-adding the orgs delete is exactly the regression worth
+-- catching.
+--
+-- Fixture shape: alice is the SOLE user of the old org, so switching her org
+-- empties it and the GC condition is genuinely met — a test where the old org
+-- keeps a user would pass no matter what the GC does.
+
+begin;
+
+select plan(5);
+
+create or replace function pg_temp.as_user(p_user uuid, p_org uuid default null)
+returns void language plpgsql as $$
+begin
+  perform set_config('request.jwt.claims',
+    case when p_org is null then
+      json_build_object('sub', p_user::text, 'role', 'authenticated')::text
+    else
+      json_build_object('sub', p_user::text, 'role', 'authenticated',
+                        'app_metadata', json_build_object('org_id', p_org::text))::text
+    end,
+    true);
+  perform set_config('role', 'authenticated', true);
+end;
+$$;
+
+-- ── Fixture ─────────────────────────────────────────────────────────────────
+-- Two orgs; alice alone in the old one, bob alone in the new one.
+insert into public.orgs (id, name) values
+  ('9c000000-0000-4000-8000-000000000001', 'GC Vacated Org'),
+  ('9c000000-0000-4000-8000-000000000002', 'GC Destination Org');
+
+insert into auth.users (id, email, aud, role, instance_id) values
+  ('9c000000-0000-4000-8000-0000000000a1', 'alice-orggc@amux.test', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('9c000000-0000-4000-8000-0000000000b1', 'bob-orggc@amux.test',   'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+on conflict do nothing;
+
+-- Keyed on `id`, not `auth_user_id`: claim_team_invite_legacy resolves the
+-- claimer with `where id = auth.uid()`, so a row keyed the other way would leave
+-- v_old_org null and skip the GC branch entirely.
+insert into public.users (id, org_id, mobile) values
+  ('9c000000-0000-4000-8000-0000000000a1', '9c000000-0000-4000-8000-000000000001', ''),
+  ('9c000000-0000-4000-8000-0000000000b1', '9c000000-0000-4000-8000-000000000002', '');
+
+-- Alice's team under the org she is about to vacate.
+insert into amux.teams (id, name, slug, oid) values
+  ('9c000000-0000-4000-8000-0000000000e1', 'GC Vacated Team', 'gc-vacated-team',
+   '9c000000-0000-4000-8000-000000000001');
+
+-- Bob owns a team in the destination org and invites alice into it.
+select pg_temp.as_user('9c000000-0000-4000-8000-0000000000b1',
+                       '9c000000-0000-4000-8000-000000000002');
+create temp table dest as
+  select team_id from amux.create_team('GC Destination Team',
+    p_oid => '9c000000-0000-4000-8000-000000000002');
+grant select on dest to anon, authenticated;
+
+create temp table inv as
+  select * from amux.create_team_invite(
+    (select team_id from dest), 'member', 'Alice', p_team_role => 'member');
+grant select on inv to anon, authenticated;
+
+-- ── Act: alice claims, vacating her org ─────────────────────────────────────
+select pg_temp.as_user('9c000000-0000-4000-8000-0000000000a1',
+                       '9c000000-0000-4000-8000-000000000001');
+create temp table claimed as
+  select * from amux.claim_team_invite((select token from inv));
+grant select on claimed to anon, authenticated;
+
+-- public.orgs and public.users are not readable as `authenticated` here; these
+-- are observations about what the claim did, not RLS scenarios.
+reset role;
+
+-- ── Assert ──────────────────────────────────────────────────────────────────
+select is((select actor_type from claimed), 'member',
+          'alice claimed the member invite');
+
+select is((select org_id from public.users
+            where id = '9c000000-0000-4000-8000-0000000000a1'),
+          '9c000000-0000-4000-8000-000000000002'::uuid,
+          'claimer is moved onto the invite team org');
+
+select ok(not exists (select 1 from public.users
+                       where org_id = '9c000000-0000-4000-8000-000000000001'),
+          'the old org really is empty, so the GC branch was reached');
+
+-- The regression this file exists for.
+select ok(exists (select 1 from public.orgs
+                   where id = '9c000000-0000-4000-8000-000000000001'),
+          'the vacated org row survives — public.orgs is saas-mono-owned');
+
+-- ...and the half that must keep working.
+select is((select count(*) from amux.teams
+            where oid = '9c000000-0000-4000-8000-000000000001'),
+          0::bigint,
+          'amux.teams under the vacated org are still collected');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## 问题

`amux.claim_team_invite_legacy` 实现「严格单 org」：member 认领邀请时把 `public.users.org_id` 切到邀请团队的 org，然后回收被腾空的旧 org —— 原本回收两样东西：

```sql
delete from amux.teams where oid = v_old_org;   -- 我们的
delete from public.orgs  where id  = v_old_org;  -- 不是我们的
```

第二句是问题。这两张公共表在 `20260601000000_baseline.sql` 里的注释就写明了归属：

- `public.orgs` — `'Mirror of saas-mono public.orgs (canonical tenant). saas-mono-owned on the merged instance.'`
- `public.users` — `'SUBSET mirror of saas-mono public.users … saas-mono-owned on merge'`

在合库实例上这个归属不是纸面说法。那里 `public.orgs` 是另一个产品的租户表，**185 条外键指向它，其中 31 条是 `ON DELETE CASCADE`**（`routes`、`route_plans`、`route_setters`、`staffs`、`roles`、`permissions`、`roles_users`、`org_units`、`store_areas`、`tasks`/`task_comments`/`task_attachments`、`marketing_*`、`wechat_accounts`、`certification_definitions` 等）。「接受一个团队邀请」不该够得到这些数据。「这个租户最后一个用户走了」是只有拥有该表的产品才能下的判断 —— 我们只镜像了其中一列，看不到它其余的数据，没有资格由此推断它已被废弃。

## 改动

新增 `20260817000000_org_gc_keeps_public_orgs.sql`，把函数从 `20260812120000_agents_device_identity.sql` carry forward，**功能上只少一句**（`delete from public.orgs`）。除此之外只动了两处注释：GC 那段的说明，以及一句写着 `CHANGED:` 的陈旧前缀 —— 那是相对上一个迁移自己的 diff 写的，carry forward 之后读起来是错的。已逐行 diff 确认没有第三处差异。

`amux.teams` 那句保留：回收我们自己在无人 org 下的团队本来就是我们的事，而在纯 TeamClu 实例上（`public.orgs` 只被 `amux.teams` 和 `public.users` 引用）这一直是 GC 里实质的那一半。

## 两个后果

1. **纯 TeamClu 实例**会积累无用户的 `public.orgs` 行，而不再清掉。这是惰性的：所有读取方都经由调用者自己的 `public.users` 行反查 org（`list_teams_for_picker` 的 `related_orgs`、`bootstrap_current_org_team`），没有用户的 org 谁也够不到，不会出现在团队选择器里。
2. **合库实例**上 `amux.teams` 那句会开始真正生效 —— 此前不会。两句在同一个 `BEGIN…EXCEPTION` 子事务里，而那边 orgs 的删除必定抛错（每个 org 都有 `audit_logs` 行挡在一条 NOT DEFERRABLE 的 no-action 外键后面，orgs 的审计触发器出门时还会再写一条），被吞掉的异常把 `amux.teams` 的删除一起回滚了。删掉那句必然失败的语句，才让本就该跑的那句真正提交。实测该实例上符合触发条件的只有 1 个 amux team（1 个 actor、0 session、0 message）。

## 测试

新增 `services/supabase/tests/031_org_gc_keeps_public_orgs.sql`，同时钉住两半 —— 去掉 orgs 删除只有在 teams 删除仍然发生时才是安全的，而把 orgs 删除加回来正是值得抓的回归。fixture 里 alice 是旧 org 的**唯一**用户，所以切换后旧 org 真的空了、GC 分支真的进得去（第 3 条断言专门盯这个，否则测试怎么改都绿）。

验证方式：按 `run.sh`/CI 的路子，把迁移 + 测试包在同一事务里跑完再 rollback。

| 跑法 | 结果 |
|---|---|
| 迁移 + `031` | 5/5 绿 |
| 只跑 `031`（打在改动前的函数上） | 第 4 条红 —— 证明测试抓得住回归，不是恒绿 |
| 迁移 + 全部 6 个 invite 相关 pgTAP | 全绿：`003`(16)、`004`(6)、`008`(19)、`021`(raise 风格无 TAP 输出)、`031`(5)、`claim_team_invite_agent_org`(10) |

跑完回查：函数体未变、fixture 零残留。

## 合并注意

改动落在 `services/supabase/migrations/**`，合入 main 会触发 `self-host-deploy.yml`，迁移由 `migrate` compose service 自动应用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)