### PR TITLE
feat: scope team LLM providers by active team

### DIFF
--- a/apps/daemon/src/config/workspace_control.rs
+++ b/apps/daemon/src/config/workspace_control.rs
@@ -506,8 +506,8 @@ impl OpenCodeCompatStore {
         serde_json::from_str(&content).map_err(|e| WorkspaceControlError::Parse(e.to_string()))
     }
 
-    /// The daemon-owned global config (`~/.amuxd/opencode.json`), which is where
-    /// user-configured providers now live (#742). Missing file reads as empty.
+    /// The daemon-owned active-team config (`~/.amuxd/teams/<team>/state/opencode.json`),
+    /// which is where user-configured providers now live (#742). Missing file reads as empty.
     fn read_global_opencode_json() -> Result<OpencodeJson, WorkspaceControlError> {
         let value = teamclu_runtime_env::opencode_config::OpencodeConfigStore::load_global()
             .map_err(|e| WorkspaceControlError::Parse(e.to_string()))?;
@@ -530,7 +530,7 @@ impl OpenCodeCompatStore {
         Ok(merged)
     }
 
-    /// Write one provider entry into the global config, leaving every other key
+    /// Write one provider entry into the active-team config, leaving every other key
     /// in that file untouched.
     fn put_global_provider(
         provider_id: &str,
@@ -559,7 +559,7 @@ impl OpenCodeCompatStore {
         .map_err(|e| WorkspaceControlError::Io(e.to_string()))
     }
 
-    /// Remove a provider entry from the global config. Returns without error
+    /// Remove a provider entry from the active-team config. Returns without error
     /// when the file or the entry is absent.
     fn remove_global_provider(provider_id: &str) -> Result<(), WorkspaceControlError> {
         teamclu_runtime_env::opencode_config::OpencodeConfigStore::apply_global(|cfg| {
@@ -778,7 +778,7 @@ impl WorkspaceControlStore for OpenCodeCompatStore {
         let _lock = self.write_lock.lock().unwrap();
         // Seed from the merged view so a pre-#742 workspace entry is carried
         // forward (base URL, model list) rather than silently reset when the
-        // user re-saves it into the global config.
+        // user re-saves it into the active-team config.
         let seed = Self::merged_provider_entries(&wpath)?
             .get(provider_id)
             .cloned();
@@ -1119,10 +1119,10 @@ mod tests {
         OpenCodeCompatStore::new()
     }
 
-    /// Point the device-level global config (#742) at a throwaway home.
+    /// Point the active-team config (#742) at a throwaway home.
     ///
     /// Without this, provider tests read and write the developer's real
-    /// `~/.amuxd/opencode.json` — they would leak into each other and their
+    /// active team's `state/opencode.json` — they would leak into each other and their
     /// results would depend on whatever that machine happens to have
     /// configured. The inner guard holds `TEST_HOME_LOCK`, so these tests also
     /// serialize against every other test that moves `HOME` / `AMUXD_HOME` /
@@ -1390,7 +1390,10 @@ mod tests {
             !dir.path().join("opencode.json").exists(),
             "provider auth must not create a workspace opencode.json"
         );
-        let global = std::fs::read_to_string(home.path().join("opencode.json")).unwrap();
+        let global = std::fs::read_to_string(
+            teamclu_runtime_env::opencode_config::global_opencode_config_path(),
+        )
+        .unwrap();
         assert!(global.contains("sk-secret"));
     }
 

--- a/apps/daemon/src/daemon/runtime_env.rs
+++ b/apps/daemon/src/daemon/runtime_env.rs
@@ -323,8 +323,7 @@ mod execution_context_tests {
         ));
         std::fs::create_dir_all(&scratch).unwrap();
         let backend = Arc::new(MockBackend::default());
-        backend.state().get_workspaces_by_team_error =
-            Some("workspace backend unavailable".into());
+        backend.state().get_workspaces_by_team_error = Some("workspace backend unavailable".into());
         let assembler = assembler(backend, "team-a", "actor-a");
 
         let result = assembler
@@ -648,8 +647,7 @@ impl DaemonServer {
     /// workspace: `(workspace_id, worktree_path, extra_env, force_env_override)`.
     ///
     /// Reusing `assemble_spawn_runtime_env_for_worktree` here is deliberate: it
-    /// (a) syncs `provider.team` into each workspace's `opencode.json` (via
-    /// `sync_team_provider_on_disk`) so the prewarmed host advertises the team
+    /// (a) syncs `provider.team` into the active team's `opencode.json` so the prewarmed host advertises the team
     /// model list, (b) warms the `managed_llm_cache` so the first real session
     /// skips the cloud round-trip, and (c) yields the exact `extra_env` the first
     /// `attach_session` will use, so the prewarmed host's `env_fingerprint`
@@ -769,7 +767,7 @@ impl DaemonServer {
             .map(|p| p.to_string_lossy().into_owned());
 
         // Suppress immediately before sync disk writes (inherent MCP, then
-        // provider.team + secret resolve via sync_team_provider_on_disk). Callers
+        // global provider.team sync + workspace secret resolve). Callers
         // must not rely on a suppress issued before the awaits above.
         self.suppress_internal_opencode_writes(worktree);
         crate::runtime::supervisor::materialize_inherent_mcp_for_spawn(Path::new(worktree))

--- a/apps/daemon/src/http/workspaces.rs
+++ b/apps/daemon/src/http/workspaces.rs
@@ -285,11 +285,11 @@ pub async fn get_providers(
 ) -> Result<Json<Vec<ProviderInfo>>, HttpError> {
     require_scope(&principal, "workspace:read")?;
     let store = resolve_store(&state)?;
-    // `provider.team` is synced from the team's cloud LLM config via
-    // `sync_team_provider_on_disk` before this handler reads straight off disk.
+    // The active team's `provider.team` is synced from the team's cloud LLM
+    // config before this handler reads the merged workspace/global provider view.
     // Without that step, an admin's model-list change would only reach this member
     // at their next runtime spawn — app restarts included.
-    reconcile_team_provider(&state, &workspace_id).await;
+    reconcile_team_provider(&state).await;
     let mut providers = store
         .get_providers(&workspace_id)
         .map_err(map_control_err)?;
@@ -309,13 +309,13 @@ pub async fn get_providers(
     Ok(Json(providers))
 }
 
-/// Re-materialize `provider.team` via [`teamclu_runtime_env::sync_team_provider_on_disk`], best-effort.
+/// Re-materialize the active team's `provider.team`, best-effort.
 ///
 /// Silently no-ops when the daemon has no managed-LLM resolver (focused tests),
 /// no cloud backend, no team, or an unresolvable workspace path — in each case
 /// there is nothing authoritative to reconcile against, and the caller should
 /// still serve whatever is on disk rather than fail the read.
-async fn reconcile_team_provider(state: &HttpState, workspace_id: &str) {
+async fn reconcile_team_provider(state: &HttpState) {
     let Some(managed_llm) = state.managed_llm.as_ref() else {
         return;
     };
@@ -326,20 +326,13 @@ async fn reconcile_team_provider(state: &HttpState, workspace_id: &str) {
     if team_id.trim().is_empty() {
         return;
     }
-    let Ok(wpath) = workspace_path_or_404(workspace_id).await else {
-        return;
-    };
-    let config_path = wpath.join("opencode.json");
+    let config_path = teamclu_runtime_env::opencode_config::global_opencode_config_path();
     let before = std::fs::read(&config_path).ok();
-    managed_llm
-        .reconcile_workspace(&wpath, team_id.trim())
-        .await;
+    managed_llm.reconcile_global(team_id.trim()).await;
     let after = std::fs::read(config_path).ok();
     if before != after {
         if let Some(supervisor) = state.runtime_supervisor.as_ref() {
-            supervisor
-                .request_workspace_host_refresh(workspace_id, &wpath)
-                .await;
+            supervisor.request_all_workspace_host_refreshes();
         }
     }
 }

--- a/apps/daemon/src/runtime/env_assembly.rs
+++ b/apps/daemon/src/runtime/env_assembly.rs
@@ -6,11 +6,12 @@ use crate::team_shared_env;
 
 use super::SpawnRuntimeEnv;
 
-/// Assemble personal + team + system env, materialize `provider.team`, and resolve
-/// `${KEY}` placeholders in `opencode.json` before attaching an ACP host.
+/// Assemble personal + team + system env, materialize the active-team
+/// `provider.team`, and resolve workspace `${KEY}` placeholders before attaching
+/// an ACP host.
 ///
 /// `managed_llm` is the team's shared LLM as resolved from the cloud API (base
-/// URL + model list). It is written to `opencode.json`'s `provider.team` inside
+/// URL + model list). It is written to amuxd's global `opencode.json` inside
 /// [`teamclu_runtime_env::assemble_runtime_env`]; the secret (`tc_api_key`) is
 /// derived locally from `actor_id`, never sourced from the cloud config.
 pub fn assemble_spawn_runtime_env(
@@ -47,7 +48,7 @@ pub fn assemble_spawn_runtime_env_for_execution(
     // Cold ManagedLlm cache often yields Unknown and omits TEAMCLU_TEAM_PROVIDER;
     // reconstruct Enabled from on-disk provider.team so the spawn fingerprint
     // matches a later successful cloud resolve with the same gateway data.
-    let disk_team = teamclu_runtime_env::read_disk_team_provider(workspace_root);
+    let disk_team = teamclu_runtime_env::read_global_team_provider();
     let managed_llm =
         teamclu_runtime_env::stabilize_managed_llm_for_spawn(managed_llm, disk_team.as_ref());
     let team_env = team_shared_env::load_team_env_for_workspace_detailed(workspace_root, team_id);
@@ -83,7 +84,7 @@ pub fn assemble_spawn_runtime_env_for_execution(
         }));
     let mut extra_env = bundle.extra_env;
     // Backend-neutral team-provider handoff. opencode consumes the team gateway
-    // via `provider.team` in opencode.json (written by `ensure_team_provider`);
+    // via `provider.team` in the active team's opencode.json;
     // other local runtimes (pi, …) that can't read opencode.json instead read
     // this `TEAMCLU_TEAM_PROVIDER` env and register the provider themselves.
     // The secret is NOT embedded — the payload references `${tc_api_key}`, the

--- a/apps/daemon/src/runtime/managed_llm.rs
+++ b/apps/daemon/src/runtime/managed_llm.rs
@@ -2,11 +2,10 @@
 //! the HTTP provider snapshot.
 //!
 //! Team `provider.team` rows are materialized through
-//! [`teamclu_runtime_env::sync_team_provider_on_disk`]:
+//! [`teamclu_runtime_env::sync_global_team_provider`]:
 //! - **Spawn** — [`teamclu_runtime_env::assemble_runtime_env`] with
 //!   [`teamclu_runtime_env::SecretResolveScope::FullConfig`]
-//! - **Provider reads** — [`ManagedLlmResolver::reconcile_workspace`] with
-//!   [`teamclu_runtime_env::SecretResolveScope::ProviderApiKeysOnly`]
+//! - **Provider reads** — [`ManagedLlmResolver::reconcile_global`]
 //!
 //! Before reconcile existed, `provider.team` was written only at spawn time, so an
 //! admin's model-list change never reached a member until the next runtime spawn
@@ -18,7 +17,6 @@
 //! most one request per team per [`MANAGED_LLM_TTL`].
 
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -120,26 +118,20 @@ impl ManagedLlmResolver {
         }
     }
 
-    /// Re-materialize `provider.team` via [`teamclu_runtime_env::sync_team_provider_on_disk`].
+    /// Re-materialize the active team's `provider.team`.
     ///
     /// Safe to call on every provider read: the cloud fetch is TTL-throttled and
-    /// [`sync_team_provider_on_disk`] only writes when the entry actually differs,
+    /// [`sync_global_team_provider`] only writes when the entry actually differs,
     /// so a steady state performs no writes and does not churn the refresh watcher.
     /// A `Unknown` resolution (no fresh cloud answer) leaves the file untouched.
-    pub async fn reconcile_workspace(&self, workspace: &Path, team_id: &str) {
+    pub async fn reconcile_global(&self, team_id: &str) {
         let state = self.resolve(team_id).await;
         let secrets = teamclu_runtime_env::secrets_for_team_provider(self.backend.actor_id());
-        if let Err(e) = teamclu_runtime_env::sync_team_provider_on_disk(
-            workspace,
-            &state,
-            &secrets,
-            teamclu_runtime_env::SecretResolveScope::ProviderApiKeysOnly,
-        ) {
+        if let Err(e) = teamclu_runtime_env::sync_global_team_provider(&state, &secrets) {
             tracing::warn!(
                 team_id,
-                workspace = %workspace.display(),
                 error = %e,
-                "team provider sync failed during managed LLM reconcile"
+                "global team provider sync failed during managed LLM reconcile"
             );
         }
     }
@@ -170,6 +162,30 @@ mod tests {
     use crate::backend::mock::MockBackend;
     use crate::backend::{ManagedLlmConfig, ManagedLlmModelInfo};
 
+    static AMUXD_HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct AmuxdHomeGuard(Option<String>);
+
+    impl AmuxdHomeGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let previous = std::env::var(teamclu_runtime_env::AMUXD_HOME_ENV).ok();
+            // SAFETY: test-only and protected by AMUXD_HOME_LOCK.
+            unsafe { std::env::set_var(teamclu_runtime_env::AMUXD_HOME_ENV, path) };
+            Self(previous)
+        }
+    }
+
+    impl Drop for AmuxdHomeGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(value) => unsafe {
+                    std::env::set_var(teamclu_runtime_env::AMUXD_HOME_ENV, value)
+                },
+                None => unsafe { std::env::remove_var(teamclu_runtime_env::AMUXD_HOME_ENV) },
+            }
+        }
+    }
+
     fn config_with_models(models: &[&str]) -> ManagedLlmConfig {
         ManagedLlmConfig {
             enabled: true,
@@ -185,8 +201,30 @@ mod tests {
         }
     }
 
-    fn team_model_ids(workspace: &Path) -> Vec<String> {
-        let raw = std::fs::read_to_string(workspace.join("opencode.json")).unwrap();
+    fn isolated_global_config() -> (
+        std::sync::MutexGuard<'static, ()>,
+        tempfile::TempDir,
+        AmuxdHomeGuard,
+    ) {
+        let lock = AMUXD_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = tempfile::TempDir::new().unwrap();
+        let home = AmuxdHomeGuard::set(dir.path());
+        std::fs::write(
+            dir.path().join("daemon.toml"),
+            "active_team = \"team-test\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(dir.path().join("teams/team-test/state")).unwrap();
+        (lock, dir, home)
+    }
+
+    fn team_model_ids() -> Vec<String> {
+        let raw = std::fs::read_to_string(
+            teamclu_runtime_env::opencode_config::global_opencode_config_path(),
+        )
+        .unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
         let mut ids: Vec<String> = json["provider"]["team"]["models"]
             .as_object()
@@ -201,7 +239,7 @@ mod tests {
     /// env. Reconciling has to replace the list on disk, not union into it.
     #[tokio::test]
     async fn reconcile_replaces_the_team_model_list_from_cloud() {
-        let workspace = tempfile::TempDir::new().unwrap();
+        let (_lock, _global, _home) = isolated_global_config();
         let mock = MockBackend::with_identity("team-x", "actor-x");
         mock.state()
             .managed_llm_configs
@@ -209,13 +247,8 @@ mod tests {
         let backend: Arc<dyn Backend> = Arc::new(mock.clone());
         let resolver = ManagedLlmResolver::new(backend);
 
-        resolver
-            .reconcile_workspace(workspace.path(), "team-x")
-            .await;
-        assert_eq!(
-            team_model_ids(workspace.path()),
-            vec!["model-a".to_string()]
-        );
+        resolver.reconcile_global("team-x").await;
+        assert_eq!(team_model_ids(), vec!["model-a".to_string()]);
 
         // Admin swaps the team onto a new set. The TTL cache would otherwise
         // hold the old answer, so drop it the way a 60s expiry would.
@@ -225,11 +258,9 @@ mod tests {
         );
         resolver.cache.lock().await.clear();
 
-        resolver
-            .reconcile_workspace(workspace.path(), "team-x")
-            .await;
+        resolver.reconcile_global("team-x").await;
         assert_eq!(
-            team_model_ids(workspace.path()),
+            team_model_ids(),
             vec!["model-b".to_string(), "model-c".to_string()],
             "the dropped model must not survive the reconcile"
         );
@@ -260,8 +291,11 @@ mod tests {
         }
     }
 
-    fn team_api_key(workspace: &Path) -> String {
-        let raw = std::fs::read_to_string(workspace.join("opencode.json")).unwrap();
+    fn team_api_key() -> String {
+        let raw = std::fs::read_to_string(
+            teamclu_runtime_env::opencode_config::global_opencode_config_path(),
+        )
+        .unwrap();
         let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
         json["provider"]["team"]["options"]["apiKey"]
             .as_str()
@@ -273,10 +307,10 @@ mod tests {
     /// `${tc_api_key}` placeholder (wake / refresh regression).
     #[tokio::test]
     async fn reconcile_preserves_resolved_team_api_key() {
-        let workspace = tempfile::TempDir::new().unwrap();
+        let (_lock, _global, _home) = isolated_global_config();
         let resolved_key = "sk-tc-actor-x";
         std::fs::write(
-            workspace.path().join("opencode.json"),
+            teamclu_runtime_env::opencode_config::global_opencode_config_path(),
             serde_json::to_string_pretty(&serde_json::json!({
                 "provider": {
                     "team": {
@@ -301,17 +335,15 @@ mod tests {
         let backend: Arc<dyn Backend> = Arc::new(mock);
         let resolver = ManagedLlmResolver::new(backend);
 
-        resolver
-            .reconcile_workspace(workspace.path(), "team-x")
-            .await;
-        assert_eq!(team_api_key(workspace.path()), resolved_key);
+        resolver.reconcile_global("team-x").await;
+        assert_eq!(team_api_key(), resolved_key);
     }
 
     #[tokio::test]
     async fn reconcile_resolves_tc_api_key_placeholder() {
-        let workspace = tempfile::TempDir::new().unwrap();
+        let (_lock, _global, _home) = isolated_global_config();
         std::fs::write(
-            workspace.path().join("opencode.json"),
+            teamclu_runtime_env::opencode_config::global_opencode_config_path(),
             serde_json::to_string_pretty(&serde_json::json!({
                 "provider": {
                     "team": {
@@ -331,18 +363,16 @@ mod tests {
         let backend: Arc<dyn Backend> = Arc::new(mock);
         let resolver = ManagedLlmResolver::new(backend);
 
-        resolver
-            .reconcile_workspace(workspace.path(), "team-x")
-            .await;
-        assert_eq!(team_api_key(workspace.path()), "sk-tc-actor-x");
+        resolver.reconcile_global("team-x").await;
+        assert_eq!(team_api_key(), "sk-tc-actor-x");
     }
 
     /// A cloud blip must not strip a working `provider.team`.
     #[tokio::test]
     async fn unknown_state_leaves_disk_untouched() {
-        let workspace = tempfile::TempDir::new().unwrap();
+        let (_lock, _global, _home) = isolated_global_config();
         std::fs::write(
-            workspace.path().join("opencode.json"),
+            teamclu_runtime_env::opencode_config::global_opencode_config_path(),
             serde_json::to_string_pretty(&serde_json::json!({
                 "provider": { "team": { "models": { "model-a": { "name": "Model A" } } } }
             }))
@@ -351,18 +381,10 @@ mod tests {
         .unwrap();
 
         // MockBackend with no seeded config resolves to Disabled, not Unknown,
-        // so drive the untouched path through `sync_team_provider_on_disk` directly.
-        teamclu_runtime_env::sync_team_provider_on_disk(
-            workspace.path(),
-            &ManagedLlmState::Unknown,
-            &HashMap::new(),
-            teamclu_runtime_env::SecretResolveScope::ProviderApiKeysOnly,
-        )
-        .unwrap();
+        // so drive the untouched global path through the sync helper directly.
+        teamclu_runtime_env::sync_global_team_provider(&ManagedLlmState::Unknown, &HashMap::new())
+            .unwrap();
 
-        assert_eq!(
-            team_model_ids(workspace.path()),
-            vec!["model-a".to_string()]
-        );
+        assert_eq!(team_model_ids(), vec!["model-a".to_string()]);
     }
 }

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -237,7 +237,7 @@ pub fn materialize_opencode_for_prepare(
 ///
 /// Cloud `provider.team` materialization and secret resolution run in
 /// [`teamclu_runtime_env::assemble_runtime_env`] via
-/// [`teamclu_runtime_env::sync_team_provider_on_disk`].
+/// [`teamclu_runtime_env::sync_global_team_provider`].
 pub fn materialize_inherent_mcp_for_spawn(
     workspace_path: &Path,
 ) -> Result<(), WorkspaceControlError> {

--- a/crates/teamclu-runtime-env/src/lib.rs
+++ b/crates/teamclu-runtime-env/src/lib.rs
@@ -42,13 +42,16 @@ pub use resolved_env::{
     ResolvedEnvSnapshot, UnresolvedEnv, UnresolvedReason,
 };
 pub use team_provider::{
-    managed_llm_provider_from_disk_team, read_disk_team_provider, stabilize_managed_llm_for_spawn,
-    team_provider_env_payload, ManagedLlmModel, ManagedLlmProvider, ManagedLlmState,
+    managed_llm_provider_from_disk_team, read_global_team_provider,
+    stabilize_managed_llm_for_spawn, team_provider_env_payload, ManagedLlmModel,
+    ManagedLlmProvider, ManagedLlmState,
 };
 pub use team_provider_sync::{
-    sync_team_provider_on_disk, SecretResolveScope, TeamProviderSyncResult,
+    resolve_workspace_runtime_config, sync_global_team_provider, SecretResolveScope,
+    TeamProviderSyncResult,
 };
 
+pub use amuxd_layout::{active_team as active_amuxd_team, team_state_dir as amuxd_team_state_dir};
 pub use storage_namespace::{
     amuxd_home_for_brand, amuxd_home_from_env, brand_home_dir, brand_short_name_from_env,
     is_official_brand, resolve_amuxd_dir_name, resolve_storage_dir_name,
@@ -99,9 +102,9 @@ pub fn assemble_runtime_env(
 
     let personal = personal_secrets::load_personal_env()?;
     let resolved_env = resolved_env::resolve_runtime_env(personal, team_env, system);
-    let sync = sync_team_provider_on_disk(
+    sync_global_team_provider(managed_llm, &resolved_env.bindings)?;
+    let sync = resolve_workspace_runtime_config(
         workspace,
-        managed_llm,
         &resolved_env.bindings,
         SecretResolveScope::FullConfig,
     )?;
@@ -119,6 +122,14 @@ mod tests {
 
     #[test]
     fn assemble_runtime_env_materializes_team_provider_on_spawn() {
+        let _lock = crate::test_util::home_env_lock();
+        let global_dir = tempfile::tempdir().unwrap();
+        let _amuxd_home = crate::test_util::AmuxdHomeGuard::set(global_dir.path());
+        std::fs::write(
+            global_dir.path().join("daemon.toml"),
+            "active_team = \"team-test\"\n",
+        )
+        .unwrap();
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("opencode.json"), "{}").unwrap();
 
@@ -148,9 +159,16 @@ mod tests {
             Some("sk-tc-spawn-actor")
         );
 
-        let raw = std::fs::read_to_string(dir.path().join("opencode.json")).unwrap();
+        let raw = std::fs::read_to_string(
+            global_dir
+                .path()
+                .join("teams/team-test/state/opencode.json"),
+        )
+        .unwrap();
         assert!(raw.contains("sk-tc-spawn-actor"));
         assert!(raw.contains("model-a"));
-        assert!(bundle.opencode_json_original.is_some());
+        let workspace_raw = std::fs::read_to_string(dir.path().join("opencode.json")).unwrap();
+        assert!(!workspace_raw.contains("\"team\""));
+        assert!(bundle.opencode_json_original.is_none());
     }
 }

--- a/crates/teamclu-runtime-env/src/opencode_config.rs
+++ b/crates/teamclu-runtime-env/src/opencode_config.rs
@@ -28,8 +28,8 @@ pub fn opencode_config_path(workspace: &Path) -> PathBuf {
     workspace.join(OPENCODE_JSON)
 }
 
-/// The daemon-owned global opencode config (`~/.amuxd/opencode.json`, or the
-/// white-label equivalent).
+/// The daemon-owned config for the active team
+/// (`~/.amuxd/teams/<team>/state/opencode.json`, or the white-label equivalent).
 ///
 /// This file is amuxd's alone — it is injected into opencode via
 /// `OPENCODE_CONFIG`, which loads it as an *additional* global-scope config
@@ -39,7 +39,28 @@ pub fn opencode_config_path(workspace: &Path) -> PathBuf {
 /// `recover_leading_object` path exists because config files here have been
 /// corrupted by partial writes before.
 pub fn global_opencode_config_path() -> PathBuf {
+    let home = crate::amuxd_home_from_env();
+    crate::amuxd_layout::team_state_dir(&home, &crate::amuxd_layout::active_team(&home))
+        .join(OPENCODE_JSON)
+}
+
+/// Pre-team-layout location, used only to adopt an existing device config on
+/// the first write after upgrading.
+fn legacy_global_opencode_config_path() -> PathBuf {
     crate::amuxd_home_from_env().join(OPENCODE_JSON)
+}
+
+fn migrate_legacy_global_config() -> Result<(), OpencodeConfigError> {
+    let target = global_opencode_config_path();
+    let legacy = legacy_global_opencode_config_path();
+    if target.exists() || !legacy.is_file() {
+        return Ok(());
+    }
+    let parent = target
+        .parent()
+        .ok_or_else(|| OpencodeConfigError::Io("team config path has no parent".to_string()))?;
+    std::fs::create_dir_all(parent).map_err(map_io_err)?;
+    std::fs::rename(&legacy, &target).map_err(map_io_err)
 }
 
 /// Relative overlay path for the given brand (`{meta}/opencode.runtime.json`).
@@ -72,7 +93,13 @@ impl OpencodeConfigStore {
 
     /// [`load`] against the daemon-owned global config.
     pub fn load_global() -> Result<Value, OpencodeConfigError> {
-        Self::load_at(&global_opencode_config_path())
+        let path = global_opencode_config_path();
+        if path.exists() {
+            return Self::load_at(&path);
+        }
+        // Read compatibility is deliberately non-mutating; the next global
+        // write atomically adopts this file into the active team's state dir.
+        Self::load_at(&legacy_global_opencode_config_path())
     }
 
     /// Load an explicit config path. Missing file reads as an empty object.
@@ -111,6 +138,7 @@ impl OpencodeConfigStore {
     where
         F: FnOnce(&mut Value) -> Result<bool, OpencodeConfigError>,
     {
+        migrate_legacy_global_config()?;
         Self::apply_at(&global_opencode_config_path(), mutator)
     }
 
@@ -135,6 +163,7 @@ impl OpencodeConfigStore {
 
     /// [`write_value`] against the daemon-owned global config.
     pub fn write_value_global(value: &Value) -> Result<(), OpencodeConfigError> {
+        migrate_legacy_global_config()?;
         Self::write_value_locked_at(&global_opencode_config_path(), value)
     }
 
@@ -220,6 +249,49 @@ fn map_io_err(e: std::io::Error) -> OpencodeConfigError {
 mod tests {
     use super::*;
     use std::fs;
+
+    fn isolate_global_config() -> (
+        std::sync::MutexGuard<'static, ()>,
+        tempfile::TempDir,
+        crate::test_util::AmuxdHomeGuard,
+    ) {
+        let lock = crate::test_util::home_env_lock();
+        let home = tempfile::tempdir().unwrap();
+        let guard = crate::test_util::AmuxdHomeGuard::set(home.path());
+        fs::write(
+            home.path().join("daemon.toml"),
+            "active_team = \"team-a\"\n",
+        )
+        .unwrap();
+        (lock, home, guard)
+    }
+
+    #[test]
+    fn global_config_is_scoped_to_active_team_state() {
+        let (_lock, home, _guard) = isolate_global_config();
+        assert_eq!(
+            global_opencode_config_path(),
+            home.path().join("teams/team-a/state/opencode.json")
+        );
+    }
+
+    #[test]
+    fn applying_global_config_adopts_legacy_root_file() {
+        let (_lock, home, _guard) = isolate_global_config();
+        let legacy = home.path().join(OPENCODE_JSON);
+        fs::write(&legacy, r#"{ "provider": { "mine": {} } }"#).unwrap();
+
+        OpencodeConfigStore::apply_global(|config| {
+            config["provider"]["team"] = serde_json::json!({});
+            Ok(true)
+        })
+        .unwrap();
+
+        assert!(!legacy.exists());
+        let migrated = fs::read_to_string(global_opencode_config_path()).unwrap();
+        assert!(migrated.contains("\"mine\""));
+        assert!(migrated.contains("\"team\""));
+    }
 
     #[test]
     fn apply_persists_mutated_object_once() {

--- a/crates/teamclu-runtime-env/src/team_provider.rs
+++ b/crates/teamclu-runtime-env/src/team_provider.rs
@@ -14,7 +14,8 @@ pub struct ManagedLlmModel {
 }
 
 /// The team's managed (shared) LLM provider, sourced from the cloud API rather
-/// than a disk file. Materialized into `opencode.json`'s `provider.team` entry.
+/// than a disk file. Materialized into amuxd's global `opencode.json` as
+/// `provider.team`.
 #[derive(Debug, Clone)]
 pub struct ManagedLlmProvider {
     pub name: String,
@@ -114,7 +115,7 @@ pub fn mutate_team_provider(
             } else {
                 &provider.name
             };
-            // Keep a resolved `sk-tc-*` key across reconciles. `ensure_team_provider`
+            // Keep a resolved `sk-tc-*` key across reconciles. `ensure_global_team_provider`
             // runs on every provider read (including after wake); always writing the
             // `${tc_api_key}` placeholder would clobber spawn-time resolution and
             // break LiteLLM auth for a live opencode serve instance.
@@ -165,10 +166,9 @@ pub fn mutate_team_provider(
     Ok(changed)
 }
 
-/// Read `provider.team` from workspace `opencode.json`, if present.
-pub fn read_disk_team_provider(workspace: &Path) -> Option<serde_json::Value> {
-    let content = OpencodeConfigStore::load_raw(workspace).ok().flatten()?;
-    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+/// Read `provider.team` from amuxd's active-team OpenCode config, if present.
+pub fn read_global_team_provider() -> Option<serde_json::Value> {
+    let json = OpencodeConfigStore::load_global().ok()?;
     json.get("provider")
         .and_then(|provider| provider.get("team"))
         .filter(|team| team.is_object())
@@ -218,8 +218,8 @@ pub fn managed_llm_provider_from_disk_team(team: &serde_json::Value) -> Option<M
 ///
 /// Cold cloud fetches / empty TTL caches often yield [`ManagedLlmState::Unknown`],
 /// which omits `TEAMCLU_TEAM_PROVIDER` from the spawn env. A later successful
-/// fetch then injects the key and flips the global OpenCode host fingerprint.
-/// When disk already has `provider.team`, reconstruct `Enabled` from it so the
+/// fetch then injects the key and flips the OpenCode host fingerprint.
+/// When the active-team config already has `provider.team`, reconstruct `Enabled` from it so the
 /// first attach matches a subsequent confirmed cloud answer with the same data.
 pub fn stabilize_managed_llm_for_spawn(
     state: &ManagedLlmState,
@@ -261,17 +261,48 @@ pub fn team_provider_env_payload(provider: &ManagedLlmProvider) -> String {
     .to_string()
 }
 
-/// Reconcile `provider.team` in opencode.json against the cloud-sourced managed LLM.
+/// Reconcile `provider.team` in the active-team OpenCode config against the
+/// cloud-sourced managed LLM.
 ///
 /// Returns whether the on-disk config was rewritten. External callers should prefer
-/// [`crate::team_provider_sync::sync_team_provider_on_disk`] so materialization and secret resolution
+/// [`crate::team_provider_sync::sync_global_team_provider`] so materialization and secret resolution
 /// stay aligned across spawn and reconcile paths.
-pub fn ensure_team_provider(workspace: &Path, state: &ManagedLlmState) -> anyhow::Result<bool> {
+pub fn ensure_global_team_provider(state: &ManagedLlmState) -> anyhow::Result<bool> {
     if matches!(state, ManagedLlmState::Unknown) {
         return Ok(false);
     }
-    OpencodeConfigStore::apply(workspace, |config| {
+    OpencodeConfigStore::apply_global(|config| {
         mutate_team_provider(config, state).map_err(map_mutate_err)
+    })
+    .map_err(map_store_err)
+}
+
+/// Remove the legacy workspace-local copy of TeamClu's reserved `provider.team`.
+///
+/// The entry used to live in every `<workspace>/opencode.json`. Keeping one
+/// around would make a disabled global provider silently fall back to stale
+/// workspace models, so every spawn clears it during the global-config
+/// migration. Other workspace providers are left untouched.
+pub fn remove_legacy_workspace_team_provider(workspace: &Path) -> anyhow::Result<bool> {
+    OpencodeConfigStore::apply(workspace, |config| {
+        let Some(root) = config.as_object_mut() else {
+            return Err(crate::opencode_config::OpencodeConfigError::Parse(
+                "opencode.json root is not an object".to_string(),
+            ));
+        };
+        let Some(providers) = root
+            .get_mut("provider")
+            .and_then(|value| value.as_object_mut())
+        else {
+            return Ok(false);
+        };
+        if providers.remove("team").is_none() {
+            return Ok(false);
+        }
+        if providers.is_empty() {
+            root.remove("provider");
+        }
+        Ok(true)
     })
     .map_err(map_store_err)
 }
@@ -303,22 +334,44 @@ mod tests {
         }
     }
 
-    #[test]
-    fn ensure_team_provider_adds_team_when_enabled() {
+    fn global_config_dir() -> (
+        std::sync::MutexGuard<'static, ()>,
+        TempDir,
+        crate::test_util::AmuxdHomeGuard,
+    ) {
+        let lock = crate::test_util::home_env_lock();
         let dir = TempDir::new().unwrap();
-        ensure_team_provider(dir.path(), &ManagedLlmState::Enabled(sample_provider())).unwrap();
+        let home = crate::test_util::AmuxdHomeGuard::set(dir.path());
+        fs::write(
+            dir.path().join("daemon.toml"),
+            "active_team = \"team-test\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("teams/team-test/state")).unwrap();
+        (lock, dir, home)
+    }
+
+    fn global_config_path(home: &TempDir) -> std::path::PathBuf {
+        home.path()
+            .join("teams/team-test/state")
+            .join(crate::opencode_config::OPENCODE_JSON)
+    }
+
+    #[test]
+    fn ensure_global_team_provider_adds_team_when_enabled() {
+        let (_lock, dir, _home) = global_config_dir();
+        ensure_global_team_provider(&ManagedLlmState::Enabled(sample_provider())).unwrap();
         let parsed: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(dir.path().join("opencode.json")).unwrap())
-                .unwrap();
+            serde_json::from_str(&fs::read_to_string(global_config_path(&dir)).unwrap()).unwrap();
         assert!(parsed["provider"]["team"].is_object());
     }
 
     #[test]
-    fn ensure_team_provider_preserves_resolved_api_key() {
-        let dir = TempDir::new().unwrap();
+    fn ensure_global_team_provider_preserves_resolved_api_key() {
+        let (_lock, dir, _home) = global_config_dir();
         let resolved_key = "sk-tc-actor-123";
         fs::write(
-            dir.path().join("opencode.json"),
+            global_config_path(&dir),
             serde_json::json!({
                 "provider": {
                     "team": {
@@ -333,10 +386,9 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        ensure_team_provider(dir.path(), &ManagedLlmState::Enabled(sample_provider())).unwrap();
+        ensure_global_team_provider(&ManagedLlmState::Enabled(sample_provider())).unwrap();
         let parsed: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(dir.path().join("opencode.json")).unwrap())
-                .unwrap();
+            serde_json::from_str(&fs::read_to_string(global_config_path(&dir)).unwrap()).unwrap();
         assert_eq!(
             parsed["provider"]["team"]["options"]["apiKey"].as_str(),
             Some(resolved_key),
@@ -345,10 +397,10 @@ mod tests {
     }
 
     #[test]
-    fn ensure_team_provider_overwrites_existing_team_when_enabled() {
-        let dir = TempDir::new().unwrap();
+    fn ensure_global_team_provider_overwrites_existing_team_when_enabled() {
+        let (_lock, dir, _home) = global_config_dir();
         fs::write(
-            dir.path().join("opencode.json"),
+            global_config_path(&dir),
             serde_json::json!({
                 "provider": {
                     "team": { "options": { "baseURL": "https://old.example" } }
@@ -357,10 +409,9 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        ensure_team_provider(dir.path(), &ManagedLlmState::Enabled(sample_provider())).unwrap();
+        ensure_global_team_provider(&ManagedLlmState::Enabled(sample_provider())).unwrap();
         let parsed: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(dir.path().join("opencode.json")).unwrap())
-                .unwrap();
+            serde_json::from_str(&fs::read_to_string(global_config_path(&dir)).unwrap()).unwrap();
         assert_eq!(
             parsed["provider"]["team"]["options"]["baseURL"],
             "https://gateway.example/v1"
@@ -368,32 +419,30 @@ mod tests {
     }
 
     #[test]
-    fn ensure_team_provider_removes_stale_team_when_disabled() {
-        let dir = TempDir::new().unwrap();
+    fn ensure_global_team_provider_removes_stale_team_when_disabled() {
+        let (_lock, dir, _home) = global_config_dir();
         fs::write(
-            dir.path().join("opencode.json"),
+            global_config_path(&dir),
             serde_json::json!({ "provider": { "team": {} } }).to_string(),
         )
         .unwrap();
-        ensure_team_provider(dir.path(), &ManagedLlmState::Disabled).unwrap();
+        ensure_global_team_provider(&ManagedLlmState::Disabled).unwrap();
         let parsed: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(dir.path().join("opencode.json")).unwrap())
-                .unwrap();
+            serde_json::from_str(&fs::read_to_string(global_config_path(&dir)).unwrap()).unwrap();
         assert!(parsed.get("provider").is_none());
     }
 
     #[test]
-    fn ensure_team_provider_unknown_leaves_config_untouched() {
-        let dir = TempDir::new().unwrap();
+    fn ensure_global_team_provider_unknown_leaves_config_untouched() {
+        let (_lock, dir, _home) = global_config_dir();
         fs::write(
-            dir.path().join("opencode.json"),
+            global_config_path(&dir),
             serde_json::json!({ "provider": { "team": { "keep": true } } }).to_string(),
         )
         .unwrap();
-        ensure_team_provider(dir.path(), &ManagedLlmState::Unknown).unwrap();
+        ensure_global_team_provider(&ManagedLlmState::Unknown).unwrap();
         let parsed: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(dir.path().join("opencode.json")).unwrap())
-                .unwrap();
+            serde_json::from_str(&fs::read_to_string(global_config_path(&dir)).unwrap()).unwrap();
         assert_eq!(parsed["provider"]["team"]["keep"], true);
     }
 

--- a/crates/teamclu-runtime-env/src/team_provider_sync.rs
+++ b/crates/teamclu-runtime-env/src/team_provider_sync.rs
@@ -29,18 +29,45 @@ pub struct TeamProviderSyncResult {
     pub provider_section_changed: bool,
 }
 
-/// Materialize `provider.team` from `managed_llm`, then resolve apiKey placeholders.
-///
-/// This is the single entry point both spawn (PR2) and reconcile should use so the
-/// two paths cannot drift again.
-pub fn sync_team_provider_on_disk(
-    workspace: &Path,
+/// Materialize `provider.team` from `managed_llm` into amuxd's active-team OpenCode
+/// config. Workspace config remains reserved
+/// for workspace-owned MCP and project settings.
+pub fn sync_global_team_provider(
     managed_llm: &ManagedLlmState,
+    secrets: &HashMap<String, String>,
+) -> anyhow::Result<bool> {
+    let changed = team_provider::ensure_global_team_provider(managed_llm)?;
+    let Some(api_key) = secrets.get("tc_api_key") else {
+        return Ok(changed);
+    };
+    let resolved = crate::opencode_config::OpencodeConfigStore::apply_global(|config| {
+        let Some(key) = config
+            .get_mut("provider")
+            .and_then(|providers| providers.get_mut("team"))
+            .and_then(|team| team.get_mut("options"))
+            .and_then(|options| options.get_mut("apiKey"))
+            .and_then(|key| key.as_str().map(str::to_owned))
+        else {
+            return Ok(false);
+        };
+        let next = key.replace("${tc_api_key}", api_key);
+        if next == key {
+            return Ok(false);
+        }
+        config["provider"]["team"]["options"]["apiKey"] = serde_json::Value::String(next);
+        Ok(true)
+    })?;
+    Ok(changed || resolved)
+}
+
+/// Resolve workspace-owned secrets and install the runtime overlay. Team LLM
+/// materialization is intentionally absent: it belongs to the active-team config.
+pub fn resolve_workspace_runtime_config(
+    workspace: &Path,
     secrets: &HashMap<String, String>,
     scope: SecretResolveScope,
 ) -> anyhow::Result<TeamProviderSyncResult> {
-    let provider_section_changed = team_provider::ensure_team_provider(workspace, managed_llm)?;
-
+    team_provider::remove_legacy_workspace_team_provider(workspace)?;
     let opencode_json_original = match scope {
         SecretResolveScope::FullConfig => {
             mcp_resolve::resolve_config_secret_refs(workspace, secrets)?
@@ -50,10 +77,9 @@ pub fn sync_team_provider_on_disk(
             None
         }
     };
-
     Ok(TeamProviderSyncResult {
         opencode_json_original,
-        provider_section_changed,
+        provider_section_changed: false,
     })
 }
 
@@ -80,10 +106,30 @@ mod tests {
         fs::read_to_string(path.join("opencode.json")).unwrap()
     }
 
+    fn global_config_dir() -> (
+        std::sync::MutexGuard<'static, ()>,
+        TempDir,
+        crate::test_util::AmuxdHomeGuard,
+    ) {
+        let lock = crate::test_util::home_env_lock();
+        let dir = TempDir::new().unwrap();
+        let home = crate::test_util::AmuxdHomeGuard::set(dir.path());
+        fs::write(
+            dir.path().join("daemon.toml"),
+            "active_team = \"team-test\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("teams/team-test/state")).unwrap();
+        (lock, dir, home)
+    }
+
+    fn global_config_path(home: &TempDir) -> std::path::PathBuf {
+        home.path().join("teams/team-test/state/opencode.json")
+    }
+
     #[test]
     fn provider_only_scope_resolves_team_api_key_leaves_mcp_placeholder() {
-        let _lock = crate::test_util::home_env_lock();
-        std::env::remove_var(crate::BRAND_SHORT_NAME_ENV);
+        let (_lock, global_dir, _home) = global_config_dir();
         let dir = TempDir::new().unwrap();
         fs::write(
             dir.path().join("opencode.json"),
@@ -104,16 +150,18 @@ mod tests {
         .unwrap();
 
         let secrets = secrets_for_team_provider("actor-123");
-        sync_team_provider_on_disk(
+        sync_global_team_provider(&ManagedLlmState::Enabled(sample_provider()), &secrets).unwrap();
+        resolve_workspace_runtime_config(
             dir.path(),
-            &ManagedLlmState::Enabled(sample_provider()),
             &secrets,
             SecretResolveScope::ProviderApiKeysOnly,
         )
         .unwrap();
 
         let on_disk = read_opencode(dir.path());
-        assert!(on_disk.contains("sk-tc-actor-123"));
+        let global = fs::read_to_string(global_config_path(&global_dir)).unwrap();
+        assert!(global.contains("sk-tc-actor-123"));
+        assert!(!on_disk.contains("provider.team"));
         assert!(
             on_disk.contains("${GITHUB_TOKEN}"),
             "reconcile scope must not resolve MCP placeholders"
@@ -126,10 +174,10 @@ mod tests {
 
     #[test]
     fn sync_preserves_resolved_api_key_on_reconcile() {
-        let dir = TempDir::new().unwrap();
+        let (_lock, dir, _home) = global_config_dir();
         let resolved = "sk-tc-actor-xyz";
         fs::write(
-            dir.path().join("opencode.json"),
+            global_config_path(&dir),
             serde_json::json!({
                 "provider": {
                     "team": {
@@ -145,15 +193,14 @@ mod tests {
         )
         .unwrap();
 
-        sync_team_provider_on_disk(
-            dir.path(),
+        sync_global_team_provider(
             &ManagedLlmState::Enabled(sample_provider()),
             &secrets_for_team_provider("actor-xyz"),
-            SecretResolveScope::ProviderApiKeysOnly,
         )
         .unwrap();
 
-        let parsed: serde_json::Value = serde_json::from_str(&read_opencode(dir.path())).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(global_config_path(&dir)).unwrap()).unwrap();
         assert_eq!(
             parsed["provider"]["team"]["options"]["apiKey"].as_str(),
             Some(resolved)
@@ -162,30 +209,17 @@ mod tests {
 
     #[test]
     fn spawn_and_reconcile_scopes_agree_on_team_provider_api_key() {
-        let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("opencode.json"), r#"{}"#).unwrap();
+        let (_lock, dir, _home) = global_config_dir();
 
         let secrets = secrets_for_team_provider("shared-actor");
         let managed = ManagedLlmState::Enabled(sample_provider());
 
-        sync_team_provider_on_disk(
-            dir.path(),
-            &managed,
-            &secrets,
-            SecretResolveScope::ProviderApiKeysOnly,
-        )
-        .unwrap();
-        let reconcile_disk = read_opencode(dir.path());
+        sync_global_team_provider(&managed, &secrets).unwrap();
+        let reconcile_disk = fs::read_to_string(global_config_path(&dir)).unwrap();
 
-        fs::write(dir.path().join("opencode.json"), r#"{}"#).unwrap();
-        sync_team_provider_on_disk(
-            dir.path(),
-            &managed,
-            &secrets,
-            SecretResolveScope::FullConfig,
-        )
-        .unwrap();
-        let spawn_disk = read_opencode(dir.path());
+        fs::write(global_config_path(&dir), r#"{}"#).unwrap();
+        sync_global_team_provider(&managed, &secrets).unwrap();
+        let spawn_disk = fs::read_to_string(global_config_path(&dir)).unwrap();
 
         let reconcile_json: serde_json::Value = serde_json::from_str(&reconcile_disk).unwrap();
         let spawn_json: serde_json::Value = serde_json::from_str(&spawn_disk).unwrap();
@@ -201,8 +235,7 @@ mod tests {
 
     #[test]
     fn full_config_scope_materializes_team_provider_and_resolves_secrets() {
-        let _lock = crate::test_util::home_env_lock();
-        std::env::remove_var(crate::BRAND_SHORT_NAME_ENV);
+        let (_lock, global_dir, _home) = global_config_dir();
         let dir = TempDir::new().unwrap();
         fs::write(
             dir.path().join("opencode.json"),
@@ -221,21 +254,18 @@ mod tests {
         secrets.insert("tc_api_key".to_string(), "sk-tc-spawn-actor".to_string());
         secrets.insert("API_TOKEN".to_string(), "ghp_spawn".to_string());
 
-        sync_team_provider_on_disk(
-            dir.path(),
-            &ManagedLlmState::Enabled(sample_provider()),
-            &secrets,
-            SecretResolveScope::FullConfig,
-        )
-        .unwrap();
+        sync_global_team_provider(&ManagedLlmState::Enabled(sample_provider()), &secrets).unwrap();
+        resolve_workspace_runtime_config(dir.path(), &secrets, SecretResolveScope::FullConfig)
+            .unwrap();
 
         let on_disk = read_opencode(dir.path());
-        assert!(on_disk.contains("sk-tc-spawn-actor"));
+        let global = fs::read_to_string(global_config_path(&global_dir)).unwrap();
+        assert!(global.contains("sk-tc-spawn-actor"));
         assert!(on_disk.contains("ghp_spawn"));
-        assert!(!on_disk.contains("${tc_api_key}"));
+        assert!(!global.contains("${tc_api_key}"));
         assert!(!on_disk.contains("${API_TOKEN}"));
         assert!(dir.path().join(".teamclu/opencode.runtime.json").exists());
-        let parsed: serde_json::Value = serde_json::from_str(&on_disk).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&global).unwrap();
         assert_eq!(
             parsed["provider"]["team"]["models"]["model-a"]["name"].as_str(),
             Some("Model A")

--- a/crates/teamclu-runtime-env/src/test_util.rs
+++ b/crates/teamclu-runtime-env/src/test_util.rs
@@ -12,6 +12,30 @@ pub struct HomeGuard {
     previous: Option<String>,
 }
 
+pub struct AmuxdHomeGuard {
+    previous: Option<String>,
+}
+
+impl AmuxdHomeGuard {
+    pub fn set(home: &Path) -> Self {
+        let previous = env::var(crate::AMUXD_HOME_ENV).ok();
+        // SAFETY: test-only; guarded by HOME_ENV_LOCK.
+        unsafe {
+            env::set_var(crate::AMUXD_HOME_ENV, home);
+        }
+        Self { previous }
+    }
+}
+
+impl Drop for AmuxdHomeGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => unsafe { env::set_var(crate::AMUXD_HOME_ENV, value) },
+            None => unsafe { env::remove_var(crate::AMUXD_HOME_ENV) },
+        }
+    }
+}
+
 impl HomeGuard {
     pub fn set(home: &Path) -> Self {
         let previous = env::var("HOME").ok();

--- a/docs/architecture/amuxd-home-layout-v2.md
+++ b/docs/architecture/amuxd-home-layout-v2.md
@@ -110,6 +110,7 @@ daemon.toml  device-id  teams/  run/  logs/  cache/
             ├── secret.key             # 本团队主密钥，0600
             ├── secrets.enc            # 团队密钥 + channels 凭证
             ├── cloud-token            # 0600，注入为 TC_ACCESS_TOKEN_FILE
+            ├── opencode.json          # 当前团队的 OpenCode provider 配置，注入为 OPENCODE_CONFIG
             ├── members.toml           # 成员 / pending invite 缓存
             ├── runtimes.toml          # 本机 runtime 索引（§4.4）
             ├── cursor-permissions.json

--- a/packages/app/src/components/onboarding/SetupStep.tsx
+++ b/packages/app/src/components/onboarding/SetupStep.tsx
@@ -129,7 +129,7 @@ function DependencyRow({ req, installing }: { req: RequirementStatus; installing
  *
  * - `developer` sees both runtimes with their install state and the optional
  *   git row (missing git is surfaced but never blocks).
- * - `guided` gets pi preselected and no dependency detail at all; if a runtime
+ * - `guided` gets OpenCode preselected and no dependency detail at all; if a runtime
  *   is already installed we offer to reuse it rather than download another.
  *
  * amuxd installs silently in both, since there is no meaningful choice to make
@@ -140,7 +140,7 @@ export function SetupStep({ role, onDone }: { role: OnboardingRole; onDone: () =
   const { requirements, agentRuntimes, installing, errors, loaded, listRequirements, listAgentRuntimes, install } =
     useSetupStore()
   const setRuntime = useOnboardingStore((s) => s.setRuntime)
-  const [selected, setSelected] = React.useState<DaemonLocalAgent>('pi')
+  const [selected, setSelected] = React.useState<DaemonLocalAgent>('opencode')
 
   React.useEffect(() => {
     void listAgentRuntimes()
@@ -158,20 +158,20 @@ export function SetupStep({ role, onDone }: { role: OnboardingRole; onDone: () =
     [agentRuntimes],
   )
 
-  // Guided is always pi, installed if absent.
+  // Guided is always OpenCode, installed if absent.
   //
   // It used to adopt whichever runtime happened to be on the machine ("a working
   // install beats a fresh download"), which made the outcome depend on the
-  // machine's history: anyone who had ever installed OpenCode silently got
-  // OpenCode. The guided path promises no choices, so it has to land somewhere
-  // predictable — and pi is the one this app installs and drives end to end.
+  // machine's history: anyone who had ever installed Pi silently got Pi. The
+  // guided path promises no choices, so it has to land somewhere predictable —
+  // and OpenCode is the one this app installs and drives end to end.
   React.useEffect(() => {
     if (role !== 'guided') return
-    setSelected('pi')
+    setSelected('opencode')
     // Mirror into the store right away rather than waiting for Continue — the
     // next step branches on this value, and leaving it stale until the last
     // moment is one more window for the two to disagree.
-    setRuntime('pi')
+    setRuntime('opencode')
   }, [role, setRuntime])
 
   const amuxd = requirements.find((r) => r.id === 'amuxd')
@@ -183,17 +183,17 @@ export function SetupStep({ role, onDone }: { role: OnboardingRole; onDone: () =
     void install('amuxd', { minDurationMs: AMUXD_AUTO_INSTALL_MIN_MS })
   }, [loaded, amuxdMissing, install])
 
-  // Same treatment for pi on the guided path: promising "no choices" and then
+  // Same treatment for OpenCode on the guided path: promising "no choices" and then
   // stopping at a runtime the user has to install by hand is the same dead end
   // twice over — they were never offered the choice that would have avoided it.
-  const pi = agentRuntimes.find((r) => r.id === 'pi')
-  const piMissing = role === 'guided' && !!pi && !usable(pi)
-  const piTriggered = React.useRef(false)
+  const opencode = agentRuntimes.find((r) => r.id === 'opencode')
+  const opencodeMissing = role === 'guided' && !!opencode && !usable(opencode)
+  const opencodeTriggered = React.useRef(false)
   React.useEffect(() => {
-    if (!piMissing || piTriggered.current) return
-    piTriggered.current = true
-    void install('pi')
-  }, [piMissing, install])
+    if (!opencodeMissing || opencodeTriggered.current) return
+    opencodeTriggered.current = true
+    void install('opencode')
+  }, [opencodeMissing, install])
 
   const selectedRuntime = agentRuntimes.find((r) => r.id === selected)
   const runtimeReady = usable(selectedRuntime)
@@ -207,7 +207,7 @@ export function SetupStep({ role, onDone }: { role: OnboardingRole; onDone: () =
    * other moving part, so the whole window reads as hung. Anything that greys
    * the button out while the machine is still working spins.
    */
-  const busy = !!installing || amuxdMissing || piMissing || (!runtimeReady && visibleRuntimes.length > 0)
+  const busy = !!installing || amuxdMissing || opencodeMissing || (!runtimeReady && visibleRuntimes.length > 0)
 
   const pick = (id: DaemonLocalAgent) => {
     setSelected(id)
@@ -270,13 +270,13 @@ export function SetupStep({ role, onDone }: { role: OnboardingRole; onDone: () =
           </div>
         ) : (
           selectedRuntime && (
-            // `|| piMissing` covers the gap between "we know it is missing" and
+            // `|| opencodeMissing` covers the gap between "we know it is missing" and
             // "the install effect has fired": without it the row sits on a red
             // "not found" for a beat, which reads as a failure rather than as
             // the work this screen just promised.
             <DependencyRow
               req={selectedRuntime}
-              installing={installing === selectedRuntime.id || piMissing}
+              installing={installing === selectedRuntime.id || opencodeMissing}
             />
           )
         )}

--- a/packages/app/src/components/onboarding/__tests__/SetupStep.test.tsx
+++ b/packages/app/src/components/onboarding/__tests__/SetupStep.test.tsx
@@ -61,31 +61,31 @@ describe('SetupStep', () => {
 
   // The guided path promises no choices, so it has to land somewhere
   // predictable. Adopting whatever was already installed made the outcome depend
-  // on the machine's history: anyone who had ever installed OpenCode got it.
-  it('always lands on pi for the guided path, even with another runtime installed', async () => {
+  // on the machine's history: anyone who had ever installed Pi got it.
+  it('always lands on OpenCode for the guided path, even with another runtime installed', async () => {
     seed({
       agentRuntimes: [
         req('opencode', { title: 'OpenCode' }),
-        req('pi', { title: 'Pi', present: false, version: null }),
+        req('pi', { title: 'Pi' }),
       ],
     })
     render(<SetupStep role="guided" onDone={() => {}} />)
-    await vi.waitFor(() => expect(useOnboardingStore.getState().runtime).toBe('pi'))
+    await vi.waitFor(() => expect(useOnboardingStore.getState().runtime).toBe('opencode'))
   })
 
-  // Landing on pi and then stopping at "install it yourself" would be the same
+  // Landing on OpenCode and then stopping at "install it yourself" would be the same
   // dead end the guided path exists to avoid.
-  it('installs pi itself when the guided path finds it missing', async () => {
+  it('installs OpenCode itself when the guided path finds it missing', async () => {
     const install = vi.fn(async () => {})
     seed({
       agentRuntimes: [
-        req('opencode', { title: 'OpenCode' }),
-        req('pi', { title: 'Pi', present: false, version: null }),
+        req('opencode', { title: 'OpenCode', present: false, version: null }),
+        req('pi', { title: 'Pi' }),
       ],
       install,
     })
     render(<SetupStep role="guided" onDone={() => {}} />)
-    await vi.waitFor(() => expect(install).toHaveBeenCalledWith('pi'))
+    await vi.waitFor(() => expect(install).toHaveBeenCalledWith('opencode'))
   })
 
   // Nothing on the guided screen is user-initiated, so a failed auto-install has
@@ -93,10 +93,10 @@ describe('SetupStep', () => {
   it('surfaces a runtime install failure on the guided path', () => {
     seed({
       agentRuntimes: [req('opencode', { title: 'OpenCode' }), req('pi', { title: 'Pi' })],
-      errors: { pi: 'pi install boom' },
+      errors: { opencode: 'opencode install boom' },
     })
     render(<SetupStep role="guided" onDone={() => {}} />)
-    expect(screen.getByText('pi install boom')).toBeInTheDocument()
+    expect(screen.getByText('opencode install boom')).toBeInTheDocument()
   })
 
   it('blocks continuing until amuxd is present', () => {


### PR DESCRIPTION
## Summary
- Default onboarding agent type to OpenCode.
- Materialize provider.team in the active team state instead of workspace configs.
- Store active-team OpenCode config at teams/<teamId>/state/opencode.json and adopt the legacy root config on first write.

## Verification
- pnpm rust:check
- cargo test -p teamclu-runtime-env
- cargo test --manifest-path apps/daemon/Cargo.toml runtime::managed_llm