### PR TITLE
feat(picker): 同名团队补上创建者/成员数/创建时间

### DIFF
--- a/packages/app/src/components/auth/TeamPicker.tsx
+++ b/packages/app/src/components/auth/TeamPicker.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertCircle, ChevronRight, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { formatDate } from "@/lib/date-format";
 import type { MembershipTeam } from "@/lib/backend";
 import { getBackend } from "@/lib/backend";
 import { useCurrentTeamStore } from "@/stores/current-team";
@@ -39,6 +40,44 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
     const bucket = groups.get(key);
     if (bucket) bucket.push(team);
     else groups.set(key, [team]);
+  }
+
+  /**
+   * Names repeated inside one org group. A team is named after its org and the
+   * name is not unique, so an org where several people onboarded ends up with
+   * several teams reading identically — without this the rows are two
+   * indistinguishable buttons.
+   *
+   * Scoped per group rather than across the whole list on purpose: two teams
+   * with the same name in DIFFERENT orgs are already told apart by the org
+   * heading above them, so annotating those would be noise.
+   */
+  const ambiguousNamesByGroup = new Map<string, Set<string>>();
+  for (const [orgName, orgTeams] of groups) {
+    const counts = new Map<string, number>();
+    for (const team of orgTeams) {
+      if (team.itemType === "org") continue;
+      counts.set(team.name, (counts.get(team.name) ?? 0) + 1);
+    }
+    const dupes = new Set<string>();
+    for (const [name, n] of counts) if (n > 1) dupes.add(name);
+    ambiguousNamesByGroup.set(orgName, dupes);
+  }
+
+  /**
+   * The line shown under an ambiguous name: owner, size, age. Each part is
+   * dropped when the backend did not supply it, so an older server (or the
+   * Postgres backend, which has no org model) degrades to a shorter line rather
+   * than rendering "undefined".
+   */
+  function disambiguation(team: MembershipTeam): string | null {
+    const parts: string[] = [];
+    if (team.ownerName) parts.push(team.ownerName);
+    if (typeof team.memberCount === "number") {
+      parts.push(t("teamPicker.memberCount", { count: team.memberCount }));
+    }
+    if (team.createdAt) parts.push(formatDate(team.createdAt));
+    return parts.length > 0 ? parts.join(" · ") : null;
   }
 
   async function choose(team: MembershipTeam) {
@@ -118,6 +157,10 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
                   const isLastUsed = team.id === lastUsedTeamId;
                   const switching = busyId === team.id;
                   const joinable = team.isMember === false;
+                  const detail =
+                    !emptyOrg && ambiguousNamesByGroup.get(orgName)?.has(team.name)
+                      ? disambiguation(team)
+                      : null;
                   return (
                     <button
                       key={team.id}
@@ -129,20 +172,27 @@ export function TeamPicker({ teams, lastUsedTeamId, onDone }: TeamPickerProps) {
                         active ? "border-coral" : "border-border",
                       )}
                     >
-                      <span className="flex min-w-0 items-center gap-2">
-                        <span className="min-w-0 truncate text-[13px] font-medium text-foreground">
-                          {emptyOrg
-                            ? t("teamPicker.initializeOrg", "Initialize {{org}}", { org: team.name })
-                            : team.name}
-                        </span>
-                        {!emptyOrg && isLastUsed && (
-                          <span className="shrink-0 rounded-full bg-selected px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                            {t("teamPicker.lastUsed", "Last used")}
+                      <span className="flex min-w-0 flex-col gap-0.5">
+                        <span className="flex min-w-0 items-center gap-2">
+                          <span className="min-w-0 truncate text-[13px] font-medium text-foreground">
+                            {emptyOrg
+                              ? t("teamPicker.initializeOrg", "Initialize {{org}}", { org: team.name })
+                              : team.name}
                           </span>
-                        )}
-                        {joinable && !emptyOrg && (
-                          <span className="shrink-0 rounded-full border border-border px-1.5 py-0.5 text-[10px] font-medium text-faint">
-                            {t("teamPicker.public", "Public")}
+                          {!emptyOrg && isLastUsed && (
+                            <span className="shrink-0 rounded-full bg-selected px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                              {t("teamPicker.lastUsed", "Last used")}
+                            </span>
+                          )}
+                          {joinable && !emptyOrg && (
+                            <span className="shrink-0 rounded-full border border-border px-1.5 py-0.5 text-[10px] font-medium text-faint">
+                              {t("teamPicker.public", "Public")}
+                            </span>
+                          )}
+                        </span>
+                        {detail && (
+                          <span className="min-w-0 truncate text-[11.5px] leading-4 text-faint">
+                            {detail}
                           </span>
                         )}
                       </span>

--- a/packages/app/src/components/auth/__tests__/TeamPicker.test.tsx
+++ b/packages/app/src/components/auth/__tests__/TeamPicker.test.tsx
@@ -75,4 +75,60 @@ describe("TeamPicker", () => {
     await vi.waitFor(() => expect(switchToTeam).toHaveBeenCalledWith("created-team"));
   });
 
+  /*
+   * Teams are named after their org and the name is not unique, so an org where
+   * several people onboarded shows several identical rows. These cover the
+   * annotation that tells them apart — and, just as importantly, that it stays
+   * out of the way when the name is already unambiguous.
+   *
+   * The date part is deliberately not asserted: formatDate is locale-driven, and
+   * pinning its exact output would make this a test of Intl.
+   */
+  const sameName = [
+    { id: "t1", name: "香蕉攀岩", slug: "team", orgId: "o1", orgName: "香蕉攀岩",
+      ownerName: "周金亮", memberCount: 68, createdAt: "2026-06-16T12:53:21Z" },
+    { id: "t4", name: "香蕉攀岩", slug: "team-4", orgId: "o1", orgName: "香蕉攀岩",
+      ownerName: "蜕变", memberCount: 24, createdAt: "2026-08-07T07:59:58Z" },
+  ];
+
+  it("annotates same-named teams with owner and size", () => {
+    render(<TeamPicker teams={sameName} onDone={() => {}} />);
+    expect(screen.getByText(/周金亮 · 68 人/)).toBeInTheDocument();
+    expect(screen.getByText(/蜕变 · 24 人/)).toBeInTheDocument();
+  });
+
+  it("leaves uniquely named teams unannotated", () => {
+    const distinct = [
+      { id: "t1", name: "Alpha", slug: "alpha", orgId: "o1", orgName: "Org One",
+        ownerName: "周金亮", memberCount: 68, createdAt: "2026-06-16T12:53:21Z" },
+      { id: "t3", name: "Gamma", slug: "gamma", orgId: "o1", orgName: "Org One",
+        ownerName: "蜕变", memberCount: 24, createdAt: "2026-08-07T07:59:58Z" },
+    ];
+    render(<TeamPicker teams={distinct} onDone={() => {}} />);
+    expect(screen.queryByText(/周金亮/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/蜕变/)).not.toBeInTheDocument();
+  });
+
+  // The org heading already separates these, so annotating them would be noise.
+  it("leaves same-named teams in different orgs unannotated", () => {
+    const crossOrg = [
+      { ...sameName[0], orgId: "o1", orgName: "Org One" },
+      { ...sameName[1], orgId: "o2", orgName: "Org Two" },
+    ];
+    render(<TeamPicker teams={crossOrg} onDone={() => {}} />);
+    expect(screen.queryByText(/周金亮/)).not.toBeInTheDocument();
+  });
+
+  // The Postgres backend supplies no owner, and an older server supplies none of
+  // the three. Either way the row must not render "undefined".
+  it("drops the parts the backend did not supply", () => {
+    const partial = [
+      { id: "t1", name: "香蕉攀岩", slug: "team", orgId: "o1", orgName: "香蕉攀岩", memberCount: 68 },
+      { id: "t4", name: "香蕉攀岩", slug: "team-4", orgId: "o1", orgName: "香蕉攀岩" },
+    ];
+    render(<TeamPicker teams={partial} onDone={() => {}} />);
+    expect(screen.getByText("68 人")).toBeInTheDocument();
+    expect(screen.queryByText(/undefined|NaN/)).not.toBeInTheDocument();
+  });
+
 });

--- a/packages/app/src/lib/backend/cloud-api/teams.ts
+++ b/packages/app/src/lib/backend/cloud-api/teams.ts
@@ -19,6 +19,9 @@ type CloudMembershipTeam = {
   isMember?: boolean;
   itemType?: "team" | "org";
   teamId?: string | null;
+  createdAt?: string | null;
+  memberCount?: number | null;
+  ownerName?: string | null;
 };
 
 type CloudInvite = {
@@ -118,6 +121,9 @@ export function createTeamsModule(client: CloudApiClient): TeamsBackend {
         isMember: r.isMember !== false,
         itemType: r.itemType ?? "team",
         teamId: r.teamId ?? r.id,
+        createdAt: r.createdAt ?? null,
+        memberCount: r.memberCount ?? null,
+        ownerName: r.ownerName ?? null,
       }));
     },
     async listDiscoverableTeams() {

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -403,6 +403,18 @@ export interface MembershipTeam {
   itemType?: "team" | "org";
   /** Null for an empty-org picker row; otherwise the same value as `id`. */
   teamId?: string | null;
+  /*
+   * The next three exist because a team's name is not unique. Every team an org
+   * creates is named after the org, so a picker can legitimately show several
+   * rows with identical text; these are what a human recognises them apart by.
+   * All null on an empty-org row, which has no team behind it.
+   */
+  /** ISO timestamp the team was created. */
+  createdAt?: string | null;
+  /** Number of member actors (agents excluded). */
+  memberCount?: number | null;
+  /** Display name of the team's owner. */
+  ownerName?: string | null;
 }
 
 export interface TeamInviteResult {

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -2966,7 +2966,10 @@
     "ungrouped": "Other",
     "lastUsed": "Last used",
     "initializeOrg": "Initialize {{org}}",
-    "initializing": "Initializing…"
+    "initializing": "Initializing…",
+    "memberCount": "{{count}} members",
+    "memberCount_one": "{{count}} member",
+    "memberCount_other": "{{count}} members"
   },
   "actors": {
     "allTitle": "All actors",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -2966,7 +2966,10 @@
     "ungrouped": "其它",
     "lastUsed": "最后使用",
     "initializeOrg": "初始化 {{org}}",
-    "initializing": "初始化中…"
+    "initializing": "初始化中…",
+    "memberCount": "{{count}} 人",
+    "memberCount_one": "{{count}} 人",
+    "memberCount_other": "{{count}} 人"
   },
   "actors": {
     "allTitle": "所有成员",

--- a/services/fc/src/lib/pg-repo/teams.ts
+++ b/services/fc/src/lib/pg-repo/teams.ts
@@ -257,7 +257,7 @@ export function makeTeamsRepo(db: PgDatabase<any, any>, deps: TeamsRepoDeps = {}
 
       // (a) Teams the caller is already an actor in.
       const mineRows = await db
-        .select({ id: teams.id, name: teams.name, slug: teams.slug, oid: teams.oid, visibility: teams.visibility })
+        .select({ id: teams.id, name: teams.name, slug: teams.slug, oid: teams.oid, visibility: teams.visibility, createdAt: teams.createdAt })
         .from(teams)
         .innerJoin(actors, eq(actors.teamId, teams.id))
         .where(eq(actors.userId, userId))
@@ -265,24 +265,55 @@ export function makeTeamsRepo(db: PgDatabase<any, any>, deps: TeamsRepoDeps = {}
 
       // Dedup by team id (a user could theoretically have >1 actor per team).
       const seen = new Set<string>();
-      const out: Array<{ id: string; name: string; slug: string | null; orgId: string | null; orgName: null; visibility: string; isMember: boolean }> = [];
+      const out: Array<{ id: string; name: string; slug: string | null; orgId: string | null; orgName: null; visibility: string; isMember: boolean; createdAt: string | null; memberCount: number | null; ownerName: string | null }> = [];
       for (const r of mineRows) {
         if (seen.has(r.id)) continue;
         seen.add(r.id);
-        out.push({ id: r.id, name: r.name, slug: r.slug ?? null, orgId: r.oid ?? null, orgName: null, visibility: r.visibility ?? "private", isMember: true });
+        out.push({ id: r.id, name: r.name, slug: r.slug ?? null, orgId: r.oid ?? null, orgName: null, visibility: r.visibility ?? "private", isMember: true, createdAt: iso(r.createdAt), memberCount: null, ownerName: null });
       }
 
       // (b) PUBLIC teams in the shared DEFAULT_ORG the caller can join.
       if (defaultOrgId) {
         const publicRows = await db
-          .select({ id: teams.id, name: teams.name, slug: teams.slug, oid: teams.oid })
+          .select({ id: teams.id, name: teams.name, slug: teams.slug, oid: teams.oid, createdAt: teams.createdAt })
           .from(teams)
           .where(and(eq(teams.oid, defaultOrgId), eq(teams.visibility, "public")))
           .orderBy(asc(teams.createdAt));
         for (const r of publicRows) {
           if (seen.has(r.id)) continue;
           seen.add(r.id);
-          out.push({ id: r.id, name: r.name, slug: r.slug ?? null, orgId: r.oid ?? null, orgName: null, visibility: "public", isMember: false });
+          out.push({ id: r.id, name: r.name, slug: r.slug ?? null, orgId: r.oid ?? null, orgName: null, visibility: "public", isMember: false, createdAt: iso(r.createdAt), memberCount: null, ownerName: null });
+        }
+      }
+
+      // Member count + owner, for the client to disambiguate same-named teams.
+      // Two batched queries rather than per-row lookups: the picker can list
+      // every team a user belongs to, and this runs on every login.
+      const ids = out.map((t) => t.id);
+      if (ids.length > 0) {
+        const counts = await db
+          .select({ teamId: actors.teamId, n: sql<number>`count(*)::int` })
+          .from(actors)
+          .where(and(inArray(actors.teamId, ids), eq(actors.actorType, "member")))
+          .groupBy(actors.teamId);
+        const countByTeam = new Map(counts.map((c) => [c.teamId, Number(c.n)]));
+
+        const owners = await db
+          .select({ teamId: teamMembers.teamId, displayName: actors.displayName, createdAt: actors.createdAt, actorId: actors.id })
+          .from(teamMembers)
+          .innerJoin(actors, eq(actors.id, teamMembers.memberId))
+          .where(and(inArray(teamMembers.teamId, ids), eq(teamMembers.role, "owner")))
+          .orderBy(asc(actors.createdAt), asc(actors.id));
+        // First row wins per team — same "oldest owner actor" tiebreak the
+        // supabase RPC applies, so both backends name the same person.
+        const ownerByTeam = new Map<string, string | null>();
+        for (const o of owners) {
+          if (!ownerByTeam.has(o.teamId)) ownerByTeam.set(o.teamId, o.displayName ?? null);
+        }
+
+        for (const t of out) {
+          t.memberCount = countByTeam.get(t.id) ?? 0;
+          t.ownerName = ownerByTeam.get(t.id) ?? null;
         }
       }
       return out;

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -474,6 +474,11 @@ export function createSupabaseBusinessRepository(options) {
         isMember: r.is_member !== false,
         itemType: r.item_type === "org" ? "org" : "team",
         teamId: r.team_id ?? null,
+        // Disambiguation for teams that share a name (an org's teams are all
+        // named after the org). Null on an empty-org row, which has no team.
+        createdAt: r.created_at ?? null,
+        memberCount: typeof r.member_count === "number" ? r.member_count : null,
+        ownerName: r.owner_name ?? null,
       }));
     },
 

--- a/services/fc/test/pg-repo-teams.test.ts
+++ b/services/fc/test/pg-repo-teams.test.ts
@@ -317,7 +317,15 @@ test("listAllMyTeams lists all teams the caller has an actor in", async () => {
   const rows = await repo.listAllMyTeams();
   const ids = rows.map((r: any) => r.id).sort();
   assert.deepEqual(ids, [t1, t2.id].sort());
-  assert.deepEqual(Object.keys(rows[0]).sort(), ["id", "name", "orgId", "orgName", "slug"]);
+  // Shape parity with supabase-repo.listAllMyTeams — the client maps both
+  // backends through one type, so a key that exists on only one is a bug.
+  // This list had fallen behind twice over: `visibility`/`isMember` were added
+  // without it, and then createdAt/memberCount/ownerName for picker
+  // disambiguation.
+  assert.deepEqual(Object.keys(rows[0]).sort(), [
+    "createdAt", "id", "isMember", "memberCount", "name",
+    "orgId", "orgName", "ownerName", "slug", "visibility",
+  ]);
   assert.equal(rows[0].orgId, null);
   assert.equal(rows[0].orgName, null);
 });

--- a/services/supabase/migrations/20260817010000_picker_disambiguation_fields.sql
+++ b/services/supabase/migrations/20260817010000_picker_disambiguation_fields.sql
@@ -1,0 +1,144 @@
+-- Give the team picker enough to tell same-named teams apart.
+--
+-- bootstrap_current_org_team names the team it creates after the org, and it
+-- deliberately never joins an org's existing team (pgTAP 027 asserts exactly
+-- that: 'bootstrap does not silently join an existing org team'). create_team
+-- then uniquifies the SLUG in a loop and leaves the NAME alone — amux.teams has
+-- a unique index on slug and none on name. So every additional person who
+-- onboards into an org mints another team carrying the org's name, and the
+-- picker renders them as identical rows.
+--
+-- This is not hypothetical: one org on a live deployment has four teams all
+-- called the same thing, created by four different people over two months, with
+-- 68 / 2 / 1 / 24 actors respectively. A member of two of them sees two
+-- indistinguishable buttons and no way to tell which is the one with their 484
+-- sessions in it.
+--
+-- The slug does not rescue the display either. It is built from
+-- lower(regexp_replace(name, '[^a-zA-Z0-9]+', '-')), so an all-CJK name reduces
+-- to an empty string and falls back to the literal 'team' — every Chinese-named
+-- team on the deployment therefore shares one global `team-N` sequence and the
+-- slug carries no information about which team it is.
+--
+-- So return the three things a human actually recognises a team by: when it was
+-- made, who owns it, and how many people are in it. The picker shows them only
+-- for rows whose name is ambiguous, so the ordinary single-team case is
+-- unchanged.
+--
+-- Nothing about team creation changes here — this migration only widens a
+-- read-only listing. Whether an org should be able to accumulate same-named
+-- teams at all is a separate question from whether the picker can survive it.
+--
+-- The return type grows, so this is DROP + CREATE rather than CREATE OR REPLACE,
+-- which means the grants have to be restored explicitly (a recreated function
+-- keeps only the default EXECUTE-to-PUBLIC).
+--
+-- Body is otherwise carried forward verbatim from
+-- 20260807040000_picker_lists_own_teams_without_org_row.sql.
+
+drop function if exists amux.list_teams_for_picker(uuid, boolean);
+
+create function amux.list_teams_for_picker(
+  p_default_org_id uuid default null,
+  p_include_empty_orgs boolean default false
+)
+returns table(team_id uuid, team_name text, team_slug text, org_id uuid, org_name text,
+              visibility text, is_member boolean, item_type text,
+              created_at timestamptz, member_count integer, owner_name text)
+language sql
+stable security definer
+set search_path to 'amux', 'public', 'auth'
+as $function$
+  with current_identity as (
+    select u.id, nullif(btrim(u.mobile), '') as mobile
+      from public.users u
+     where u.id = auth.uid()
+     limit 1
+  ), related_users as (
+    -- Retain the caller even when a legacy record has no phone, then expand
+    -- only through the shared phone when it is available.
+    select auth.uid() as id
+     where auth.uid() is not null
+    union
+    select u.id
+      from public.users u
+      join current_identity c on c.mobile is not null and u.mobile = c.mobile
+  ), related_orgs as (
+    select distinct u.org_id
+      from public.users u
+      join related_users ru on ru.id = u.id
+     where u.org_id is not null
+  ), member_teams as (
+    -- No org filter: an actor in the team is the membership.
+    select t.id, t.name, t.slug, t.oid, t.visibility, true as is_member, 'team'::text as item_type,
+           t.created_at
+      from amux.teams t
+     where exists (
+         select 1
+           from amux.actors a
+           join related_users ru on ru.id = a.user_id
+          where a.team_id = t.id
+       )
+  ), public_teams as (
+    select t.id, t.name, t.slug, t.oid, t.visibility, false as is_member, 'team'::text as item_type,
+           t.created_at
+      from amux.teams t
+     where t.oid in (select org_id from related_orgs)
+       and t.visibility = 'public'
+       and not exists (
+         select 1
+           from amux.actors a
+           join related_users ru on ru.id = a.user_id
+          where a.team_id = t.id
+       )
+  ), empty_orgs as (
+    select null::uuid as id, null::text as name, null::text as slug, o.id as oid,
+           'private'::text as visibility, true as is_member, 'org'::text as item_type,
+           null::timestamptz as created_at
+      from public.orgs o
+      join related_orgs ro on ro.org_id = o.id
+     where p_include_empty_orgs
+       and not exists (select 1 from amux.teams t where t.oid = o.id)
+  )
+  select * from (
+    select t.id as team_id, t.name as team_name, t.slug as team_slug, t.oid as org_id,
+           o.name as org_name, t.visibility, t.is_member, t.item_type,
+           t.created_at,
+           -- Counted here rather than client-side: the picker runs before the
+           -- caller has switched into the team, so a per-team member listing
+           -- would be blocked by RLS for exactly the rows worth disambiguating.
+           -- This function is SECURITY DEFINER, so the count is accurate even
+           -- for a public team the caller has not joined.
+           (select count(*)::int
+              from amux.actors a
+             where a.team_id = t.id and a.actor_type = 'member') as member_count,
+           (select a.display_name
+              from amux.team_members tm
+              join amux.actors a on a.id = tm.member_id
+             where tm.team_id = t.id and tm.role = 'owner'
+             order by a.created_at asc, a.id asc
+             limit 1) as owner_name
+      from (
+        select * from member_teams
+        union all
+        select * from public_teams
+      ) t
+      join public.orgs o on o.id = t.oid
+    union all
+    select e.id, e.name, e.slug, e.oid, o.name, e.visibility, e.is_member, e.item_type,
+           e.created_at, null::int, null::text
+      from empty_orgs e
+      join public.orgs o on o.id = e.oid
+  ) picker_items
+  -- created_at/team_id only break ties the previous ORDER BY left open, so no
+  -- pair that was already ordered moves. Same-named teams used to come back in
+  -- whatever order the plan produced, which made the picker reshuffle between
+  -- loads — the one thing worse than two identical buttons is two identical
+  -- buttons that swap places.
+  order by org_name nulls last, item_type, team_name, created_at nulls last, team_id;
+$function$;
+
+grant execute on function amux.list_teams_for_picker(uuid, boolean) to authenticated, service_role;
+
+comment on function amux.list_teams_for_picker(uuid, boolean) is
+  'Cross-org team picker source: teams the caller holds an actor in, plus public teams in their orgs they could join. Also returns created_at / member_count / owner_name so the client can disambiguate teams that share a name (an org''s teams are all named after the org).';

--- a/services/supabase/tests/032_picker_disambiguation_fields.sql
+++ b/services/supabase/tests/032_picker_disambiguation_fields.sql
@@ -1,0 +1,127 @@
+-- 032_picker_disambiguation_fields.sql
+--
+-- 20260817010000_picker_disambiguation_fields.sql widened
+-- amux.list_teams_for_picker with created_at / member_count / owner_name, so a
+-- client can tell apart the same-named teams an org accumulates (every team is
+-- named after its org, and create_team uniquifies only the slug).
+--
+-- The fixture builds exactly that shape: one org, two teams with the SAME name,
+-- different owners and different sizes. A test with distinct names would pass
+-- against the old function too.
+
+begin;
+
+select plan(8);
+
+create or replace function pg_temp.as_user(p_user uuid, p_org uuid default null)
+returns void language plpgsql as $$
+begin
+  perform set_config('request.jwt.claims',
+    case when p_org is null then
+      json_build_object('sub', p_user::text, 'role', 'authenticated')::text
+    else
+      json_build_object('sub', p_user::text, 'role', 'authenticated',
+                        'app_metadata', json_build_object('org_id', p_org::text))::text
+    end,
+    true);
+  perform set_config('role', 'authenticated', true);
+end;
+$$;
+
+-- ── Fixture ─────────────────────────────────────────────────────────────────
+insert into public.orgs (id, name) values
+  ('9d000000-0000-4000-8000-000000000001', 'Dup Name Org');
+
+insert into auth.users (id, email, aud, role, instance_id) values
+  ('9d000000-0000-4000-8000-0000000000a1', 'ann-dup@amux.test',  'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('9d000000-0000-4000-8000-0000000000b1', 'bo-dup@amux.test',   'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('9d000000-0000-4000-8000-0000000000c1', 'cy-dup@amux.test',   'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('9d000000-0000-4000-8000-0000000000d1', 'dee-dup@amux.test',  'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+on conflict do nothing;
+
+insert into public.users (id, org_id, mobile) values
+  ('9d000000-0000-4000-8000-0000000000a1', '9d000000-0000-4000-8000-000000000001', ''),
+  ('9d000000-0000-4000-8000-0000000000b1', '9d000000-0000-4000-8000-000000000001', ''),
+  ('9d000000-0000-4000-8000-0000000000c1', '9d000000-0000-4000-8000-000000000001', '');
+
+-- Ann's team, then Bo's team — both named after the org, exactly what bootstrap
+-- produces for two people onboarding into one org.
+select pg_temp.as_user('9d000000-0000-4000-8000-0000000000a1',
+                       '9d000000-0000-4000-8000-000000000001');
+create temp table ann as
+  select team_id from amux.create_team('Dup Name Org',
+    p_oid => '9d000000-0000-4000-8000-000000000001', p_display_name => 'Ann');
+grant select on ann to anon, authenticated;
+
+select pg_temp.as_user('9d000000-0000-4000-8000-0000000000b1',
+                       '9d000000-0000-4000-8000-000000000001');
+create temp table bo as
+  select team_id from amux.create_team('Dup Name Org',
+    p_oid => '9d000000-0000-4000-8000-000000000001', p_display_name => 'Bo');
+grant select on bo to anon, authenticated;
+
+-- Give Ann's team a second member so the two rows differ in size, and so
+-- member_count is proven to count more than the owner.
+reset role;
+insert into amux.actors (team_id, actor_type, user_id, display_name)
+values ((select team_id from ann), 'member', '9d000000-0000-4000-8000-0000000000c1', 'Cy');
+-- An agent in the same team: member_count must not count it.
+insert into amux.actors (team_id, actor_type, display_name)
+values ((select team_id from ann), 'agent', 'Some Daemon');
+
+-- ── Act: Ann opens the picker ───────────────────────────────────────────────
+select pg_temp.as_user('9d000000-0000-4000-8000-0000000000a1',
+                       '9d000000-0000-4000-8000-000000000001');
+create temp table picked as
+  select * from amux.list_teams_for_picker(null, false);
+reset role;
+grant select on picked to anon, authenticated;
+
+-- ── Assert ──────────────────────────────────────────────────────────────────
+select is((select count(*) from picked where item_type = 'team'), 1::bigint,
+          'Ann sees only her own team (Bo''s is private and not hers)');
+
+select is((select count(distinct team_name) from picked where item_type = 'team'), 1::bigint,
+          'the fixture really did produce same-named teams');
+
+select is((select member_count from picked where team_id = (select team_id from ann)),
+          2,
+          'member_count counts members (owner + Cy) and excludes the agent');
+
+select is((select owner_name from picked where team_id = (select team_id from ann)),
+          'Ann',
+          'owner_name is the team owner''s display name');
+
+select ok((select created_at from picked where team_id = (select team_id from ann)) is not null,
+          'created_at is populated');
+
+-- Bo's team is invisible to Ann above, so widen to a caller who is in both:
+-- the point is that the two rows carry DIFFERENT disambiguation values.
+-- Dee joins Ann's team in the same breath, so the two rows end up 3 vs 2.
+-- Without this both land on 2 and the assertion below cannot fail for the right
+-- reason.
+reset role;
+insert into amux.actors (team_id, actor_type, user_id, display_name)
+values ((select team_id from bo), 'member', '9d000000-0000-4000-8000-0000000000a1', 'Ann'),
+       ((select team_id from ann), 'member', '9d000000-0000-4000-8000-0000000000d1', 'Dee');
+
+select pg_temp.as_user('9d000000-0000-4000-8000-0000000000a1',
+                       '9d000000-0000-4000-8000-000000000001');
+-- `both` is a reserved word (trim(both …)), hence the suffix.
+create temp table both_teams as
+  select * from amux.list_teams_for_picker(null, false);
+reset role;
+grant select on both_teams to anon, authenticated;
+
+select is((select count(*) from both_teams where item_type = 'team'), 2::bigint,
+          'Ann now sees both same-named teams');
+
+select is((select count(distinct owner_name) from both_teams where item_type = 'team'), 2::bigint,
+          'the two same-named rows carry different owners');
+
+select isnt((select member_count from both_teams where team_id = (select team_id from ann)),
+            (select member_count from both_teams where team_id = (select team_id from bo)),
+            'the two same-named rows carry different member counts');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## 问题

一个 org 里每多一个第一次登录的人，团队选择器就多一个**同名**条目：

1. `bootstrap_current_org_team` 用 org 的名字命名它创建的团队；
2. 它刻意从不加入该 org 已有的团队 —— pgTAP `027_org_default_team_selection.sql` 就断言了 `'bootstrap does not silently join an existing org team'`；
3. `create_team` 随后只对 **slug** 跑去重循环，**name 一个字都不改**。`amux.teams` 上有 `teams_slug_key`，没有 name 的唯一索引。

线上确实堆出来了 —— 某个 org 下 4 个团队全叫一个名字，两个月里由 4 个不同的人创建：

| slug | 创建 | 创建者 | 可见性 | actors | sessions |
|---|---|---|---|---|---|
| `team` | 6/16 | A | private | 68 | 484 |
| `team-2` | 6/16 | B | private | 2 | 1 |
| `team-3` | 8/03 | C | private | 1 | 0 |
| `team-4` | 8/07 | D | public | 24 | 19 |

同时属于其中两个的人，看到的是两个完全一样的按钮 —— 今天渲染出来的唯一差别只有「最后使用」徽标 —— 没有任何办法知道哪个装着自己那 484 条会话。

**slug 也救不了显示。** 它由 `lower(regexp_replace(name, '[^a-zA-Z0-9]+', '-'))` 生成，纯中文名整串被替换掉、trim 完是空串，于是回退到字面量 `'team'`。线上所有中文名团队因此共用同一条全局 `team-N` 序列（实测 10 个团队、6 个不同 org），slug 完全不携带信息。

## 改动

让 `list_teams_for_picker` 返回人真正用来辨认一个团队的三样东西：**什么时候建的、谁的、多少人**。选择器**只在名字有歧义时**显示这一行，单团队的常见情况原样不变。

```
香蕉攀岩                  [最后使用]
周金亮 · 68 人 · 2026年6月16日
──────────────────────────────
香蕉攀岩
蜕变 · 24 人 · 2026年8月7日
```

几个实现上的判断：

- **`member_count` 在服务端算**，不是客户端。选择器运行在用户切进团队**之前**，逐团队拉成员列表恰好会被 RLS 挡在最该消歧的那些行上。该 RPC 是 `SECURITY DEFINER`，所以连没加入的公开团队也数得准。
- **同名判定按 org 分组**，不是全列表。跨 org 的同名已经被 org 标题分开了，再加副行是噪音。
- **顺带把排序补成确定的**（`created_at, team_id` 兜底）。同名团队此前按计划返回什么顺序就是什么顺序，选择器会在两次加载之间自己换位置 —— 比两个一样的按钮更糟的是两个会互换位置的一样的按钮。只加兜底键，原本已确定的顺序不会变。
- 副行按字段缺失逐个降级，老服务端或 Postgres 后端不会渲染出 `undefined`。
- 返回类型变了，所以是 `DROP` + `CREATE` 而不是 `CREATE OR REPLACE` —— grant 因此手工补回（重建的函数只保留默认的 EXECUTE-to-PUBLIC）。

**团队创建本身没有任何改动**，这里只加宽一个只读列表。

## 顺手修好的一条陈旧测试

`pg-repo-teams.test.ts` 断言返回对象的**精确键集**，期望 5 个键 —— 但代码在 `visibility`/`isMember` 加进来时就已经返回 7 个了，这条 shape-parity 测试一直红着没人管。我加字段正好要求把它更新成真实键集，现在它重新有意义了。

## 验证

| | |
|---|---|
| app 单测 | 445 文件 / 2880 用例全绿（含新增 4 条 TeamPicker 用例 + 两个 i18n 守卫） |
| typecheck / lint | 干净 / 0 error（53 个 warning 全在未触碰的文件里） |
| pgTAP `032`（新增） | 8/8 绿；打在**未迁移**的函数上直接 `column "member_count" does not exist` —— 抓得住回归 |
| pgTAP `027` / `028` / `029` | 带迁移全绿 |
| FC 测试 | 145 红 vs 基线 147 红，**新增 0 条**，修好 1 条（那批红是缺本地 Supabase 的环境问题，且 FC 测试未进 CI） |

pgTAP 的 fixture 刻意造两个**同名**团队、不同 owner、不同人数 —— 名字不同的 fixture 在旧函数上也会绿。

## 合并注意 & 未覆盖的部分

- 改动落在 `services/supabase/migrations/**`，合入 main 会触发 `self-host-deploy.yml`。
- **这只治了显示。根因没动**：org 里第二个人 onboard 仍然会再造一个同名团队；中文名的 slug 仍然塌成 `team-N`。两者都值得单独排。

🤖 Generated with [Claude Code](https://claude.com/claude-code)