### PR TITLE
revert(self-host): 撤掉 MinIO 服务与 Caddy 站点，止住部署连环失败

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -269,21 +269,6 @@ jobs:
               [ -n "$pulled" ] || { echo "litellm image pull failed after 5 attempts"; exit 1; }
             fi
 
-            echo "=== pull minio (same reason as litellm) ==="
-            # `up --pull never` fetches nothing, so every image this compose
-            # file adds has to be pulled here or the whole `up` aborts with
-            # "No such image" — which is exactly how the MinIO rollout failed
-            # its first deploy.
-            for svc in minio minio-init; do
-              pulled=""
-              for i in 1 2 3; do
-                if docker compose pull "$svc"; then pulled=yes; break; fi
-                echo "  $svc pull attempt $i failed; retrying in 10s"
-                sleep 10
-              done
-              [ -n "$pulled" ] || { echo "$svc image pull failed after 3 attempts"; exit 1; }
-            done
-
             echo "=== up ==="
             docker compose up -d --pull never --remove-orphans
 

--- a/deploy/self-host/caddy/Caddyfile
+++ b/deploy/self-host/caddy/Caddyfile
@@ -54,21 +54,6 @@
 	reverse_proxy emqx:8083
 }
 
-# Blob storage (MinIO) for team files. The daemon transfers bytes here directly
-# against a presigned URL, so this name must be the one FC signs for (ENDPOINT)
-# — SigV4 covers the Host header and a mismatch fails every upload.
-#
-# S3_DOMAIN is blank until the box cuts over, and an empty site name makes Caddy
-# skip the block instead of requesting a certificate for "".
-{$CADDY_SITE_SCHEME}{$S3_DOMAIN} {
-	{$CADDY_SITE_TLS}
-
-	# No request_body limit: blobs are whole files, and Caddy's default is
-	# unlimited — stating it here only to make the intent explicit if that
-	# default ever changes.
-	reverse_proxy minio:9000
-}
-
 {$CADDY_SITE_SCHEME}{$STUDIO_DOMAIN} {
 	{$CADDY_SITE_TLS}
 	reverse_proxy studio:3000

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -387,56 +387,6 @@ services:
       # transparent proxy that adds no CORS headers, so Hono must own CORS
       # (see services/fc/src/app.ts). Setting it would strip CORS entirely.
 
-  # ── Blob storage for team files (knowledge, skills packages) ──
-  #
-  # Team sync hands the daemon a PRESIGNED URL and the daemon transfers bytes
-  # directly — FC never proxies them. So this has to be reachable from clients,
-  # not just from the compose network: SigV4 covers the Host header, so an
-  # endpoint of `minio:9000` produces signatures that fail the moment the client
-  # dials the public name. That is what MINIO_SERVER_URL and the Caddy site are
-  # for. Bytes still live on this box; only the door is public.
-  #
-  # Inactive until FC is switched over with TEAM_BLOBS_BACKEND=s3 — the service
-  # can be deployed first and the cutover made separately.
-  minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
-    restart: unless-stopped
-    command: server /data --console-address ":9001"
-    environment:
-      MINIO_ROOT_USER: "${ACCESS_KEY_ID:-teamclu}"
-      MINIO_ROOT_PASSWORD: "${ACCESS_KEY_SECRET:-}"
-      # The public origin MinIO signs and validates against.
-      MINIO_SERVER_URL: "${ENDPOINT:-}"
-    volumes:
-      - minio_data:/data
-    healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
-      interval: 10s
-      timeout: 5s
-      retries: 12
-      start_period: 20s
-
-  # The bucket must exist before the first upload; MinIO does not create on
-  # write. One bucket holds everything, separated by key prefix:
-  #   apps/…  team-blobs/…  team-skills/…
-  # Idempotent, so it is safe on every `compose up`.
-  minio-init:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
-    depends_on:
-      minio:
-        condition: service_healthy
-    environment:
-      MINIO_ROOT_USER: "${ACCESS_KEY_ID:-teamclu}"
-      MINIO_ROOT_PASSWORD: "${ACCESS_KEY_SECRET:-}"
-      BUCKET: "${BUCKET:-teamclu-team}"
-    entrypoint: >
-      /bin/sh -c "
-      mc alias set local http://minio:9000 \"$$MINIO_ROOT_USER\" \"$$MINIO_ROOT_PASSWORD\" &&
-      mc mb --ignore-existing local/\"$$BUCKET\" &&
-      echo 'bucket ready'
-      "
-    restart: "no"
-
   caddy:
     image: caddy:2
     restart: unless-stopped
@@ -452,9 +402,6 @@ services:
       MQTT_DOMAIN: "${MQTT_DOMAIN}"
       STUDIO_DOMAIN: "${STUDIO_DOMAIN}"
       EMQX_DASHBOARD_DOMAIN: "${EMQX_DASHBOARD_DOMAIN}"
-      # Blank until the MinIO cutover: an empty site name makes Caddy skip that
-      # block rather than request a certificate for "".
-      S3_DOMAIN: "${S3_DOMAIN:-}"
       ACME_EMAIL: "${ACME_EMAIL}"
       CADDY_GLOBAL_TLS: "${CADDY_GLOBAL_TLS:-}"
       CADDY_SITE_TLS: "${CADDY_SITE_TLS:-}"
@@ -547,7 +494,6 @@ services:
 
 volumes:
   emqx_data:
-  minio_data:
   caddy_data:
   caddy_config:
   postgres_backend_data:


### PR DESCRIPTION
## 紧急：main 当前状态会打挂 self-host

从 07:36 起，self-host 被打挂两次、部署连红三次（`93674373` / `28feac88` / `25a56f7f`），根因都在 #937 我加的两处：

1. **`minio` 是硬依赖，但它必然启动失败。** 盒子上 `ACCESS_KEY_SECRET` 为空，MinIO 缺 `MINIO_ROOT_PASSWORD` 时拒绝启动；`minio-init` 又 `depends_on` 它 healthy → 整个 `up` 中止 → **`fc`/`caddy` 被拆掉却没重建**，外部 20 分钟不可达。
2. **Caddy 站点块的空域名判断是错的。** 我以为"`S3_DOMAIN` 为空就会跳过该块"，实际空 key 的块被 Caddy 当成全局配置块：

   ```
   Error: adapting config using caddyfile: server block without any key is
   global configuration, and if used, it must be first
   ```

   Caddy 崩溃循环 → 443 无人监听。

两条是同一个错误判断：**把一个尚未配置的可选组件做成了必经路径。**

> 另外：盒子上的 `caddy/Caddyfile` 我曾手工改过以恢复服务，随后被 `git pull` 覆盖回坏版本。Caddy 只因为没再重启过才幸存——**现在任何一次 caddy 重启都会让线上再挂**。这是本 PR 需要尽快合的原因。

## 撤掉什么、保留什么

**撤掉**（回到已知可用状态）：`minio` / `minio-init` 服务、`minio_data` 卷、Caddy 的 S3 站点块、workflow 里的 minio 预拉取。

**保留**：FC 侧的 S3 blob 后端代码。`TEAM_BLOBS_BACKEND` 默认 `supabase`，不启用就完全惰性，留着不影响任何人，且已有单测覆盖。

## 重新引入时的硬性前提

否则同样的事会再发生一次：

- MinIO 放进 **compose profile**（照现有 `cron` 的做法），没显式启用就根本不参与 `up`
- Caddy 站点块要么给**非空默认名**（`.localhost` 走内部 CA，不会去 ACME），要么等切换时才加进仓库
- 切换前先把 `ACCESS_KEY_ID/SECRET`、`ENDPOINT`、DNS 全部就位——`s3.teamclu-dev.ucar.cc` 目前在权威 NS 上仍查不到

## 验证

- `docker compose config -q` 通过
- workflow YAML 解析通过
- 线上已手工恢复：`/healthz` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)