### PR TITLE
feat(self-host): MinIO 重来一次，这回不会拖垮部署

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -269,6 +269,23 @@ jobs:
               [ -n "$pulled" ] || { echo "litellm image pull failed after 5 attempts"; exit 1; }
             fi
 
+            # `up --pull never` fetches nothing, so any image this compose file
+            # adds must be pulled here or the whole `up` aborts with "No such
+            # image". Guarded by the service list, which only names services
+            # whose profile is active — a box that never enabled MinIO skips it.
+            if docker compose config --services | grep -qx minio; then
+              echo "=== pull minio (up --pull never will not fetch it) ==="
+              for svc in minio minio-init; do
+                pulled=""
+                for i in 1 2 3; do
+                  if docker compose pull "$svc"; then pulled=yes; break; fi
+                  echo "  $svc pull attempt $i failed; retrying in 10s"
+                  sleep 10
+                done
+                [ -n "$pulled" ] || { echo "$svc image pull failed after 3 attempts"; exit 1; }
+              done
+            fi
+
             echo "=== up ==="
             docker compose up -d --pull never --remove-orphans
 

--- a/deploy/self-host/caddy/Caddyfile
+++ b/deploy/self-host/caddy/Caddyfile
@@ -54,6 +54,18 @@
 	reverse_proxy emqx:8083
 }
 
+# Blob storage (MinIO) for team files. The daemon transfers bytes here directly
+# against a presigned URL, so this name must be the one FC signs for (ENDPOINT)
+# — SigV4 covers the Host header and a mismatch fails every upload.
+#
+# S3_DOMAIN falls back to s3.localhost (internal CA, no ACME) on a box that has
+# not enabled MinIO. It must never be empty: Caddy reads a nameless block as
+# global configuration and refuses to start.
+{$CADDY_SITE_SCHEME}{$S3_DOMAIN} {
+	{$CADDY_SITE_TLS}
+	reverse_proxy minio:9000
+}
+
 {$CADDY_SITE_SCHEME}{$STUDIO_DOMAIN} {
 	{$CADDY_SITE_TLS}
 	reverse_proxy studio:3000

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -387,6 +387,77 @@ services:
       # transparent proxy that adds no CORS headers, so Hono must own CORS
       # (see services/fc/src/app.ts). Setting it would strip CORS entirely.
 
+  # ── Blob storage for team files (knowledge, skill packages) ──
+  #
+  # OPT-IN: both services sit behind the `minio` compose profile, so a box that
+  # has not configured them does not start them at all. The first rollout made
+  # MinIO unconditional; with no credentials on that box it refused to boot
+  # (MinIO has no default root password by design), minio-init blocked on its
+  # health, and the whole `docker compose up` aborted — taking fc and caddy down
+  # with it. An optional component must never be able to veto the deploy.
+  #
+  # Enable with COMPOSE_PROFILES=minio in .env, after setting ACCESS_KEY_ID /
+  # ACCESS_KEY_SECRET / ENDPOINT / S3_DOMAIN.
+  #
+  # Team sync hands the daemon a PRESIGNED URL and the daemon transfers bytes
+  # directly — FC never proxies them. So this must be reachable from clients,
+  # not just from the compose network: SigV4 covers the Host header, so an
+  # endpoint of `minio:9000` produces signatures that fail the moment the client
+  # dials the public name. Hence MINIO_SERVER_URL and the Caddy site. Bytes
+  # still live on this box; only the door is public.
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    profiles: ["minio"]
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      # Plain `:-` defaults, deliberately. `:?` would be a better error, but
+      # compose interpolates EVERY service regardless of profile, so a required
+      # variable breaks `docker compose ps` on any box that never enabled MinIO.
+      # The profile is what keeps an unconfigured deployment safe; credentials
+      # are the operator's job when enabling it.
+      MINIO_ROOT_USER: "${ACCESS_KEY_ID:-}"
+      MINIO_ROOT_PASSWORD: "${ACCESS_KEY_SECRET:-}"
+      MINIO_SERVER_URL: "${ENDPOINT:-}"
+    volumes:
+      - minio_data:/data
+    # MinIO's own liveness endpoint. `mc ready local` (the first attempt) needs
+    # an alias nobody sets inside the container, so it could never go green.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+  # The bucket must exist before the first upload; MinIO does not create on
+  # write. One bucket holds everything, separated by key prefix:
+  #   apps/…  team-blobs/…  team-skills/…
+  # Idempotent, so it is safe on every `compose up`.
+  minio-init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    profiles: ["minio"]
+    # Start order only — NOT `condition: service_healthy`. A blocking condition
+    # is what let an unhealthy MinIO abort the entire `up` and strand fc/caddy.
+    # If MinIO is down this container just fails on its own and the bucket is
+    # missing; the deploy stays green and every other service keeps running.
+    depends_on:
+      - minio
+    environment:
+      MINIO_ROOT_USER: "${ACCESS_KEY_ID:-}"
+      MINIO_ROOT_PASSWORD: "${ACCESS_KEY_SECRET:-}"
+      BUCKET: "${BUCKET:-teamclu-team}"
+    entrypoint: >
+      /bin/sh -c "
+      for i in 1 2 3 4 5 6 7 8 9 10; do
+        mc alias set local http://minio:9000 \"$$MINIO_ROOT_USER\" \"$$MINIO_ROOT_PASSWORD\" && break;
+        echo \"minio not ready yet (attempt $$i)\"; sleep 3;
+      done &&
+      mc mb --ignore-existing local/\"$$BUCKET\" &&
+      echo 'bucket ready'
+      "
+    restart: "no"
+
   caddy:
     image: caddy:2
     restart: unless-stopped
@@ -402,6 +473,11 @@ services:
       MQTT_DOMAIN: "${MQTT_DOMAIN}"
       STUDIO_DOMAIN: "${STUDIO_DOMAIN}"
       EMQX_DASHBOARD_DOMAIN: "${EMQX_DASHBOARD_DOMAIN}"
+      # Never empty: a site block with no name is read as a global options block
+      # ("server block without any key is global configuration"), which
+      # crash-loops Caddy and takes every site down with it. `.localhost` is
+      # served by Caddy's internal CA, so the placeholder never touches ACME.
+      S3_DOMAIN: "${S3_DOMAIN:-s3.localhost}"
       ACME_EMAIL: "${ACME_EMAIL}"
       CADDY_GLOBAL_TLS: "${CADDY_GLOBAL_TLS:-}"
       CADDY_SITE_TLS: "${CADDY_SITE_TLS:-}"
@@ -494,6 +570,7 @@ services:
 
 volumes:
   emqx_data:
+  minio_data:
   caddy_data:
   caddy_config:
   postgres_backend_data:


### PR DESCRIPTION
#937 那版把 MinIO 做成了必经路径，连着两次把 self-host 打挂（复盘见 #943）。这版把三条失败模式逐个堵死。

## 三条修法

| 上次的失败 | 这次 |
|---|---|
| MinIO 无条件启动，无凭据必然 FATAL | **进 compose profile**：没有 `COMPOSE_PROFILES=minio` 就根本不启动 |
| `minio-init` 用 `depends_on: service_healthy`，MinIO 不健康 → 整个 `up` 中止 → **fc/caddy 被拆掉不重建** | `depends_on` 只保留启动顺序、**去掉阻塞条件**；MinIO 挂了就只是它自己挂，部署照样绿，`minio-init` 自带重试 |
| 健康检查写的 `mc ready local` 依赖容器里没人设过的 alias，**永远不会变绿** | 换成 MinIO 自己的 `/minio/health/live`（已在盒子上确认镜像里有 `curl`） |

## 另外两处

**Caddy 的 `S3_DOMAIN` 给了非空默认值 `s3.localhost`。** 空域名的站点块会被 Caddy 当成全局配置块并拒绝启动：

```
Error: adapting config using caddyfile: server block without any key is
global configuration, and if used, it must be first
```

这正是上次 443 无人监听的直接原因。`.localhost` 走 Caddy 内部 CA，不碰 ACME。

**环境变量用 `:-` 而不是 `:?`。** `:?` 的报错信息更好，但 compose 会对**所有**服务插值、不管 profile 是否启用——用了 `:?` 之后，没配凭据的机器连 `docker compose ps` 都会报错。profile 才是保护未配置部署的机制。

部署脚本的预拉取带了 profile 守卫（`config --services` 只列激活 profile 的服务），没启用的机器不会去拉不需要的镜像。

## 验证

三种情形都跑过：

| 情形 | 结果 |
|---|---|
| 未设凭据 `docker compose config -q` | 通过（`:?` 版本在这里就会炸） |
| 默认 `config --services` 含 minio 数 | 0 |
| `COMPOSE_PROFILES=minio` 下 | 2 |

## 切换前提（盒子上已就位）

- DNS `s3.teamclu-dev.ucar.cc` → `47.112.210.217`，直连 A 记录、未开代理 ✅
- `.env` 已写入 `ACCESS_KEY_ID` / `ACCESS_KEY_SECRET`（40 位随机）/ `ENDPOINT` / `S3_FORCE_PATH_STYLE=1` / `S3_DOMAIN` ✅
- `TEAM_BLOBS_BACKEND` **仍未设置**——合并本 PR 后先只启动 MinIO 验证，再单独翻这个开关

已确认填 `ACCESS_KEY_ID` 不会搅乱 apps 部署：`APPS_FC_ENDPOINT` / `ALIYUN_ACCOUNT_ID` 未设且 `ROLE_ARN` 为空 → `resolveFcEndpoint()` 返回 null → 仍然干净地 503。

🤖 Generated with [Claude Code](https://claude.com/claude-code)