### PR TITLE
fix(self-host): amuxd 身份守卫跟上 layout v2，别再重复 claim 邀请

### DIFF
--- a/deploy/self-host/amuxd/entrypoint.sh
+++ b/deploy/self-host/amuxd/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Entrypoint for the self-host amuxd daemon.
 #
-# On first start (no backend.toml yet) it claims a team invite using
+# On first start (no persisted identity yet) it claims a team invite using
 # $AMUXD_JOIN_TOKEN, persisting identity under $HOME/.amuxd. Subsequent
 # starts reuse the persisted identity and skip the claim.
 set -eu
@@ -12,7 +12,30 @@ mkdir -p "$STATE_DIR"
 CLOUD_API_URL="${TEAMCLU_CLOUD_API_URL:-http://fc:9000}"
 export TEAMCLU_CLOUD_API_URL="$CLOUD_API_URL"
 
-if [ ! -f "$STATE_DIR/backend.toml" ]; then
+# Has this daemon already been claimed?
+#
+# The credentials live at `teams/<team_id>/state/backend.toml` (see
+# `provider_config.rs`), so the team id is part of the path and this cannot be a
+# fixed filename. Home-layout v2 moved the file there; the guard used to check
+# `$STATE_DIR/backend.toml`, the v1 location, which nothing writes any more.
+# A stale guard does not fail loudly — it re-runs `amuxd init` on *every* start,
+# and since an invite is single-use, the second start onwards dies with
+# "invite already consumed" and the container crash-loops.
+#
+# `_unclaimed` is excluded on purpose: it is where an unclaimed daemon's writes
+# land, so its presence is not evidence of a claim.
+has_identity() {
+  for f in "$STATE_DIR"/teams/*/state/backend.toml; do
+    [ -f "$f" ] || continue
+    case "$f" in
+      "$STATE_DIR"/teams/_unclaimed/*) continue ;;
+    esac
+    return 0
+  done
+  return 1
+}
+
+if ! has_identity; then
   if [ -z "${AMUXD_JOIN_TOKEN:-}" ]; then
     echo "amuxd: no persisted identity and AMUXD_JOIN_TOKEN is empty." >&2
     echo "amuxd: mint a daemon invite (deploy/self-host/amuxd/mint-invite.sh)," >&2
@@ -22,6 +45,13 @@ if [ ! -f "$STATE_DIR/backend.toml" ]; then
   echo "amuxd: claiming team invite against $CLOUD_API_URL ..."
   amuxd init "amux://invite?token=${AMUXD_JOIN_TOKEN}&cloud_api_url=${CLOUD_API_URL}"
   echo "amuxd: invite claimed; identity persisted under $STATE_DIR"
+  # A claim that reports success but leaves no credentials would otherwise be
+  # discovered one restart later, as a crash loop against a spent invite.
+  if ! has_identity; then
+    echo "amuxd: claim reported success but no backend.toml was written under" >&2
+    echo "amuxd: $STATE_DIR/teams/<team_id>/state/ — refusing to start." >&2
+    exit 1
+  fi
 else
   echo "amuxd: existing identity found in $STATE_DIR; skipping invite claim"
 fi


### PR DESCRIPTION
线上 self-host 的 amuxd **已经崩溃循环 4 天**（8/13 至今，17+ 次重启）：

```
amuxd: claiming team invite against http://fc:9000 ...
Error: cloud api claim failed (400 Bad Request): {"error":{"code":"validation_failed",
  "message":"invite already consumed"}}
```

## 根因不是邀请码

entrypoint 的守卫查 `$HOME/.amuxd/backend.toml` —— 那是 **v1** 的位置。home layout v2 把凭据挪到了 `teams/<team_id>/state/backend.toml`（`apps/daemon/src/provider_config.rs:43`）：团队 id 成了路径的一部分，所以它**不可能**再是一个固定文件名。

守卫过时不会响亮地失败，而是**每次启动都重跑 `amuxd init`**。邀请是一次性的，于是从第二次启动起必然撞上 "invite already consumed" → `exit 1` → 崩溃循环。

**换个新邀请码只能买到一次启动。** 这是这个 PR 存在的理由。

## 时间线

| 时间 | 事件 |
|---|---|
| 8/6 02:43 | daemon 成功 claim，加入团队 Bright Owl |
| 8/13 13:05 | layout v2 落地，`purge_v1_layout()` 按设计抹掉 v1 身份 → 变回未认领 |
| 8/13 起 | 守卫找不到 v1 路径的文件 → 重新 claim → 撞已消费邀请 → 循环至今 |

掉身份本身**是设计行为**，`purge_v1_layout()` 的注释写得很清楚：

> A daemon that had already onboarded comes up unclaimed afterwards and the user re-onboards; that is the cutover, and it is visible rather than silent.

问题在于守卫没跟着一起改，把"需要重新 onboard 一次"变成了"每次启动都试图重新 onboard"。

## 改了什么

守卫改成 glob `teams/*/state/backend.toml`。**`_unclaimed` 被显式排除**——未认领 daemon 的写入也落在那个目录（`layout.rs` 的 `UNCLAIMED_TEAM` 就是干这个的），它的存在不构成"已认领"的证据。

另外在 claim 成功之后立刻复查一次。claim 报成功却没写下凭据的话，原本要等到下一次重启、以"撞上已消费邀请"的形式才暴露——正是本次这个故障模式。

## 验证

守卫函数对五种状态目录形状逐个跑过：

| 状态 | 判定 |
|---|---|
| 全新安装（`teams/` 空） | unclaimed ✅ |
| **线上当前状态**（只有 `_unclaimed` + 残留 workspace） | unclaimed ✅ |
| claim 成功后（v2 路径） | claimed ✅ |
| 只有 `_unclaimed` 下有 `backend.toml` | unclaimed ✅ |
| v1 老路径遗留文件 | unclaimed ✅ |

`sh -n` 通过；`shellcheck -s sh` 对本次改动零告警（仅报既有第 74 行的 SC2016，那是 JSON 字面键 `$schema`，本就不该展开）。

entrypoint 是 bind-mount 进容器的（`./amuxd/entrypoint.sh:/entrypoint.sh:ro`），合并后 `git pull` + 重启即可生效，**不需要重建镜像**。

## 合并后还要做的（不在本 PR 内）

邀请确实已被消费且已于 8/13 过期，需要用 `deploy/self-host/amuxd/mint-invite.sh` 发一个新的并重新 onboard。届时 8/6 那次 claim 留下的孤儿 agent actor 会一并清掉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)