### PR TITLE
test(daemon): env_assembly 测试跟上 #941 的全局团队配置布局

### DIFF
--- a/apps/daemon/src/runtime/env_assembly.rs
+++ b/apps/daemon/src/runtime/env_assembly.rs
@@ -124,8 +124,44 @@ pub fn assemble_spawn_runtime_env_for_execution(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_brand_env::BrandEnvGuard;
     use teamclu_runtime_env::team_crypto::{self, SecretEntry};
     use teamclu_runtime_env::{ManagedLlmModel, ManagedLlmProvider};
+
+    /// An isolated amuxd home with an active team.
+    ///
+    /// Every test that assembles a spawn environment needs this: assembly calls
+    /// `ensure_global_team_provider`, which WRITES the team provider into
+    /// `<amuxd home>/teams/<active team>/state/opencode.json`. Without the
+    /// override that path is the developer's real `~/.amuxd` — running this
+    /// suite locally overwrote the machine's actual gateway URL and model list
+    /// with these fixtures, then read them back on the next run, which is why
+    /// the same test failed differently on a developer box than on CI.
+    ///
+    /// `BrandEnvGuard` (not a private mutex) because it holds the daemon-wide
+    /// `TEST_HOME_LOCK`: `HOME`, `AMUXD_HOME` and the brand name all feed the
+    /// same process-global path resolution, so a second lock would serialize
+    /// these tests against each other while still racing `team_link` and
+    /// friends. Drop order matters — the guard restores the env before the
+    /// TempDir it points at is removed.
+    fn amuxd_home_with_active_team() -> (tempfile::TempDir, BrandEnvGuard) {
+        let home = tempfile::tempdir().unwrap();
+        let guard = BrandEnvGuard::set_amuxd_home(home.path());
+        std::fs::write(
+            home.path().join("daemon.toml"),
+            "active_team = \"team-test\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(home.path().join("teams/team-test/state")).unwrap();
+        (home, guard)
+    }
+
+    /// Where the active team's `opencode.json` lives — resolved the same way
+    /// the production writer resolves it, so the test cannot drift from the
+    /// layout by hand-joining a path.
+    fn global_team_config() -> std::path::PathBuf {
+        teamclu_runtime_env::opencode_config::global_opencode_config_path()
+    }
 
     /// Covers the production boundary, rather than merely testing the secret
     /// reader: an encrypted team value must be present in the environment that
@@ -133,6 +169,7 @@ mod tests {
     /// personal environment cannot mask a regression in this test.
     #[test]
     fn encrypted_team_secret_is_injected_into_spawn_environment() {
+        let (_home, _home_guard) = amuxd_home_with_active_team();
         let workspace = tempfile::tempdir().unwrap();
         let team_secret = "6a".repeat(32);
         let config_dir = workspace.path().join(".teamclu");
@@ -187,6 +224,7 @@ mod tests {
 
     #[test]
     fn worktree_uses_parent_team_env_and_materializes_its_own_opencode_config() {
+        let (_home, _home_guard) = amuxd_home_with_active_team();
         let workspace = tempfile::tempdir().unwrap();
         let worktree = workspace.path().join(".worktrees/cron-j1-r1");
         std::fs::create_dir_all(&worktree).unwrap();
@@ -257,20 +295,35 @@ mod tests {
                 .map(String::as_str),
             Some("from-parent")
         );
+        // The worktree config carries the workspace's own `${KEY}` placeholders,
+        // resolved from the PARENT workspace's team env.
         let materialized = std::fs::read_to_string(worktree.join("opencode.json")).unwrap();
-        assert!(materialized.contains("cron-model"));
         assert!(materialized.contains("from-parent"));
         assert!(
             !workspace.path().join("opencode.json").exists(),
-            "provider/config materialization belongs in the execution worktree"
+            "placeholder resolution belongs in the execution worktree"
+        );
+        // The team provider is NOT part of that file any more: since #941 it is
+        // scoped to the active team and written once, globally.
+        let global = std::fs::read_to_string(global_team_config()).unwrap();
+        assert!(
+            global.contains("cron-model"),
+            "the managed provider belongs in the active team's global opencode.json"
+        );
+        assert!(
+            !materialized.contains("cron-model"),
+            "and must not be duplicated into the worktree config"
         );
     }
 
     #[test]
     fn unknown_managed_llm_with_disk_provider_matches_enabled_fingerprint() {
+        let (_home, _home_guard) = amuxd_home_with_active_team();
         let workspace = tempfile::tempdir().unwrap();
+        // The "disk provider" a cold cache falls back to is the active team's
+        // global config (`read_global_team_provider`), not the workspace's.
         std::fs::write(
-            workspace.path().join("opencode.json"),
+            global_team_config(),
             serde_json::json!({
                 "provider": {
                     "team": {
@@ -319,7 +372,7 @@ mod tests {
 
         assert!(
             from_unknown.extra_env.contains_key("TEAMCLU_TEAM_PROVIDER"),
-            "Unknown + disk provider.team must still inject TEAMCLU_TEAM_PROVIDER"
+            "Unknown + global provider.team must still inject TEAMCLU_TEAM_PROVIDER"
         );
         assert_eq!(
             from_unknown.extra_env.get("TEAMCLU_TEAM_PROVIDER"),


### PR DESCRIPTION
修 main 上 `Daemon Unit Tests (Linux)` 的红灯 —— 从 #941 合入起一直红着，之后每个 PR 的 CI 都带着这条。

## 不是回退，是漏改的测试

#941 **故意**把团队 provider 配置从「每个工作区一份」改成「全局、按活跃团队隔离」：

| 之前 | 之后 |
|---|---|
| `read_disk_team_provider(workspace)` | `read_global_team_provider()` |
| `ensure_team_provider(workspace, state)` | `ensure_global_team_provider(state)` |

同一个提交里的文档注释就写着 *"It is written to amuxd's global `opencode.json`"*，`crates/teamclu-runtime-env` 自己的测试也都跟着改到新路径了（还专门加了 `AmuxdHomeGuard` / `home_env_lock`）。只有 `apps/daemon/src/runtime/env_assembly.rs` 这几个没跟上，两个失败断言都在断言旧行为：

- provider.team 的 fixture 写进工作区的 `opencode.json`，而读取方已改看全局 → CI 上 `TEAMCLU_TEAM_PROVIDER` 根本没注入
- worktree 的 `opencode.json` 里已经不再有 provider，模型现在写在全局配置里 → `contains("cron-model")` 失败

所以本 PR **只动测试，不动产品代码**。

## 顺带修掉一个更难受的问题

这些测试没有隔离 `AMUXD_HOME`，而组装 spawn 环境会调用 `ensure_global_team_provider` **写盘**。也就是说在开发机上跑一次 `pnpm daemon:test`，就会用 fixture 覆盖掉 `~/.amuxd` 里真实的团队网关地址和模型列表（我自己的就被覆盖了：`ai.ucar.cc` + `default/max/pro` 变成了 `gateway.example` + `gpt-4`），下次再跑又把它读回来。

这正是同一个测试在本地和 CI 上报错不一样的原因 —— 本地读到真实配置比对失败，CI 上没有那个文件所以注入失败。

隔离用的是 daemon 自己的 `BrandEnvGuard` 而不是新造一把锁：`HOME`、`AMUXD_HOME` 和 brand 都喂给同一套进程级路径解析，第二把锁只会让这几个测试彼此串行、却仍然和 `team_link` 那批互相竞争（`test_brand_env.rs` 顶部的注释记着这个教训）。路径也不再手拼，直接调 `global_opencode_config_path()`，跟生产写入方用同一个解析。

## 验证

- `pnpm daemon:test` 全量：842 passed / 0 failed（改动前：2 failed）
- 目标测试单独跑：3 passed
- `rustfmt --check` 干净（按仓库惯例没对整个 daemon 跑 `cargo fmt`，那会重排一批无关文件）

## 遗留（本 PR 不处理）

还有别的 daemon 测试会写真实的 `~/.amuxd`：把 `AMUXD_HOME` 指到临时目录跑全量，我的真实配置就毫发无损，但 `config::workspace_link` 有个测试会挂 —— 它用基于 `HOME` 的 `temp_home()`，被外层的 `AMUXD_HOME` 抢了优先级。所以「让 `pnpm daemon:test` 默认用临时 home」这个更彻底的做法需要先让 `temp_home()` 一并接管 `AMUXD_HOME`，值得单独一个 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)