### PR TITLE
fix(daemon): managed_llm 测试改用共用的 TEST_HOME_LOCK

### DIFF
--- a/apps/daemon/src/runtime/managed_llm.rs
+++ b/apps/daemon/src/runtime/managed_llm.rs
@@ -161,30 +161,7 @@ mod tests {
     use super::*;
     use crate::backend::mock::MockBackend;
     use crate::backend::{ManagedLlmConfig, ManagedLlmModelInfo};
-
-    static AMUXD_HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    struct AmuxdHomeGuard(Option<String>);
-
-    impl AmuxdHomeGuard {
-        fn set(path: &std::path::Path) -> Self {
-            let previous = std::env::var(teamclu_runtime_env::AMUXD_HOME_ENV).ok();
-            // SAFETY: test-only and protected by AMUXD_HOME_LOCK.
-            unsafe { std::env::set_var(teamclu_runtime_env::AMUXD_HOME_ENV, path) };
-            Self(previous)
-        }
-    }
-
-    impl Drop for AmuxdHomeGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(value) => unsafe {
-                    std::env::set_var(teamclu_runtime_env::AMUXD_HOME_ENV, value)
-                },
-                None => unsafe { std::env::remove_var(teamclu_runtime_env::AMUXD_HOME_ENV) },
-            }
-        }
-    }
+    use crate::test_brand_env::BrandEnvGuard;
 
     fn config_with_models(models: &[&str]) -> ManagedLlmConfig {
         ManagedLlmConfig {
@@ -201,23 +178,25 @@ mod tests {
         }
     }
 
-    fn isolated_global_config() -> (
-        std::sync::MutexGuard<'static, ()>,
-        tempfile::TempDir,
-        AmuxdHomeGuard,
-    ) {
-        let lock = AMUXD_HOME_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+    /// An isolated amuxd home for the tests that write the global team config.
+    ///
+    /// `BrandEnvGuard` deliberately, rather than a mutex local to this module:
+    /// it carries the daemon-wide `TEST_HOME_LOCK`, and `HOME`, `AMUXD_HOME`
+    /// and the brand name all feed the SAME process-global path resolution. A
+    /// second lock only serialized this module against itself while leaving it
+    /// free to race `runtime::env_assembly` — which is exactly what turned main
+    /// red after #948: both suites drive `<amuxd home>/teams/<active>/state/
+    /// opencode.json`, so whoever set AMUXD_HOME last won.
+    fn isolated_global_config() -> (tempfile::TempDir, BrandEnvGuard) {
         let dir = tempfile::TempDir::new().unwrap();
-        let home = AmuxdHomeGuard::set(dir.path());
+        let home = BrandEnvGuard::set_amuxd_home(dir.path());
         std::fs::write(
             dir.path().join("daemon.toml"),
             "active_team = \"team-test\"\n",
         )
         .unwrap();
         std::fs::create_dir_all(dir.path().join("teams/team-test/state")).unwrap();
-        (lock, dir, home)
+        (dir, home)
     }
 
     fn team_model_ids() -> Vec<String> {
@@ -239,7 +218,7 @@ mod tests {
     /// env. Reconciling has to replace the list on disk, not union into it.
     #[tokio::test]
     async fn reconcile_replaces_the_team_model_list_from_cloud() {
-        let (_lock, _global, _home) = isolated_global_config();
+        let (_global, _home) = isolated_global_config();
         let mock = MockBackend::with_identity("team-x", "actor-x");
         mock.state()
             .managed_llm_configs
@@ -307,7 +286,7 @@ mod tests {
     /// `${tc_api_key}` placeholder (wake / refresh regression).
     #[tokio::test]
     async fn reconcile_preserves_resolved_team_api_key() {
-        let (_lock, _global, _home) = isolated_global_config();
+        let (_global, _home) = isolated_global_config();
         let resolved_key = "sk-tc-actor-x";
         std::fs::write(
             teamclu_runtime_env::opencode_config::global_opencode_config_path(),
@@ -341,7 +320,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_resolves_tc_api_key_placeholder() {
-        let (_lock, _global, _home) = isolated_global_config();
+        let (_global, _home) = isolated_global_config();
         std::fs::write(
             teamclu_runtime_env::opencode_config::global_opencode_config_path(),
             serde_json::to_string_pretty(&serde_json::json!({
@@ -370,7 +349,7 @@ mod tests {
     /// A cloud blip must not strip a working `provider.team`.
     #[tokio::test]
     async fn unknown_state_leaves_disk_untouched() {
-        let (_lock, _global, _home) = isolated_global_config();
+        let (_global, _home) = isolated_global_config();
         std::fs::write(
             teamclu_runtime_env::opencode_config::global_opencode_config_path(),
             serde_json::to_string_pretty(&serde_json::json!({


### PR DESCRIPTION
修 main 现在的红灯 —— #948 合进去之后 `Daemon Unit Tests (Linux)` 仍然失败，但换了两个测试：

```
runtime::env_assembly::tests::worktree_uses_parent_team_env_and_materializes_its_own_opencode_config
runtime::managed_llm::tests::reconcile_preserves_resolved_team_api_key
```

## 根因：两把锁守同一个环境变量

两组测试都在驱动 `<amuxd home>/teams/<active>/state/opencode.json`，但各自持有**不同的锁**：

| 测试 | 锁 |
|---|---|
| `runtime::env_assembly` | daemon 全局的 `TEST_HOME_LOCK`（经 `BrandEnvGuard`，#948 引入）|
| `runtime::managed_llm` | 本模块私有的 `AMUXD_HOME_LOCK` |

两把锁守着同一个进程级 `AMUXD_HOME`，谁最后设置谁说了算，于是两边随机读到对方的临时目录。

这正是 `test_brand_env.rs` 顶部注释写过的情形 —— *「两个独立的锁只让各自那组串行，却仍然彼此竞争」*。#948 之前 `env_assembly` 压根不加锁、直接读真实 home，所以从没撞上；把隔离修好之后才第一次真正相撞。**是我在 #948 里没顺着那条注释检查还有谁在抢 `AMUXD_HOME`，PR 的 CI 侥幸绿了，合进 main 就翻车了。**

修法是删掉第二把锁：`isolated_global_config()` 改用同一个 `BrandEnvGuard`，净删 21 行。

## 验证

- 目标两组测试（`runtime::env_assembly` + `runtime::managed_llm`）连跑 **5 遍全绿**
- 全量套件在本机会随机挂 `cursor_sdk::permission::ask_policy_surfaces_a_request_and_honours_a_denial` 或 `opencode_http::pool_tests::*`。这是**既有的负载敏感 flake**，不是本改动引入的：它们都卡在 1 秒超时的 `wait_until`，而在同样负载下**干净的 main 4 次里挂了 3 次**（机器空闲时 3 次全绿）。我这台机器刚连跑了十几轮 Rust 测试。
- `rustfmt --check` 干净

## 顺带记一笔

那两个 flake 的等待预算（`tokio::time::timeout(1s)` + `yield_now()` 轮询）在并行套件里偏紧，值得单独调一调，但不在本 PR 范围内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)