### PR TITLE
fix(daemon): route manage cloud access through daemon

### DIFF
--- a/apps/daemon/src/backend/mock.rs
+++ b/apps/daemon/src/backend/mock.rs
@@ -147,6 +147,10 @@ pub struct MockState {
     /// Per-team `team_share_config` overrides. Missing entries fall back to
     /// `ShareModeConfig::default()` (i.e. team-share disabled).
     pub team_share_configs: HashMap<String, ShareModeConfig>,
+    /// Per-team registry rows returned by `team_skills`.
+    pub team_skills: HashMap<String, Vec<super::TeamSkillRow>>,
+    /// `(team_id, slug, version)` writes made by `record_team_skill_install`.
+    pub team_skill_installs: Vec<(String, String, i64)>,
     /// Per-agent `get_agent_defaults` overrides. Missing entries fall back to
     /// `AgentDefaults::default()` (all `None`).
     pub agent_defaults: HashMap<String, AgentDefaults>,
@@ -234,6 +238,38 @@ impl Backend for MockBackend {
             .get(team_id)
             .cloned()
             .unwrap_or_default())
+    }
+
+    async fn team_skills(&self, team_id: &str) -> BackendResult<Vec<super::TeamSkillRow>> {
+        Ok(self
+            .state
+            .lock()
+            .unwrap()
+            .team_skills
+            .get(team_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    async fn record_team_skill_install(
+        &self,
+        team_id: &str,
+        slug: &str,
+        version: i64,
+    ) -> BackendResult<()> {
+        let mut state = self.state.lock().unwrap();
+        state
+            .team_skill_installs
+            .push((team_id.to_string(), slug.to_string(), version));
+        if let Some(row) = state
+            .team_skills
+            .get_mut(team_id)
+            .and_then(|rows| rows.iter_mut().find(|row| row.slug == slug))
+        {
+            row.installed = true;
+            row.installed_version = Some(version);
+        }
+        Ok(())
     }
 
     async fn get_effective_default_agent(&self, _team_id: &str) -> BackendResult<Option<String>> {

--- a/apps/daemon/src/backend/mod.rs
+++ b/apps/daemon/src/backend/mod.rs
@@ -107,7 +107,7 @@ pub struct TeamEnvSecretRow {
 /// needs the metadata too: the frontmatter rewrite that makes a skill legible
 /// to an agent (`when_to_use`, `when_not_to_use`, owner) is fed from these
 /// fields, and the install list carries only versions.
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TeamSkillRow {
     pub slug: String,

--- a/apps/daemon/src/cli/manage.rs
+++ b/apps/daemon/src/cli/manage.rs
@@ -6,27 +6,113 @@
 use std::path::{Path, PathBuf};
 
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, Password, Select};
-use serde::Deserialize;
+use serde::{de::DeserializeOwned, Deserialize};
 
+use crate::backend::TeamSkillRow;
 use crate::config::{
-    encode_workspace_path, workspace_path::listable_local_workspace, AgentBackendConfig,
-    DaemonConfig, OpenCodeCompatStore, ProviderAuthRequest, ProviderModelConfig,
-    WorkspaceControlStore,
+    encode_workspace_path, AgentBackendConfig, DaemonConfig, OpenCodeCompatStore,
+    ProviderAuthRequest, ProviderModelConfig, WorkspaceControlStore,
 };
-use crate::daemon::backend_from_provider_config;
-use crate::provider_config::ProviderConfig;
 use crate::sync::oss::state::LocalSyncState;
 use crate::sync::secret_store::{mask_secret, validate_team_secret, SecretStore, TeamSecrets};
 
 /// One cloud-registered workspace that exists on this machine (same filter as
 /// `GET /v1/workspaces`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 struct RegisteredWorkspace {
     path: PathBuf,
     display_name: String,
     is_default: bool,
     #[allow(dead_code)]
     workspace_id: String,
+}
+
+/// Small loopback client for the running daemon's management surface.
+/// Cloud credentials stay owned by that process; this CLI only holds a
+/// short-lived local session token.
+struct ManageDaemonClient {
+    client: reqwest::Client,
+    base: String,
+    session_token: String,
+}
+
+impl ManageDaemonClient {
+    async fn connect() -> anyhow::Result<Self> {
+        let port_path = DaemonConfig::http_port_path();
+        let token_path = DaemonConfig::http_token_path();
+        let port = std::fs::read_to_string(&port_path)
+            .map_err(|e| {
+                anyhow::anyhow!("read {} ({e}). Is the daemon running?", port_path.display())
+            })?
+            .trim()
+            .to_string();
+        let root_token = std::fs::read_to_string(&token_path)
+            .map_err(|e| anyhow::anyhow!("read {} ({e})", token_path.display()))?
+            .trim()
+            .to_string();
+        if port.is_empty() || root_token.is_empty() {
+            anyhow::bail!("daemon HTTP control files are empty; restart amuxd");
+        }
+
+        let client = reqwest::Client::new();
+        let base = format!("http://127.0.0.1:{port}");
+        let exchange: serde_json::Value = client
+            .post(format!("{base}/v1/auth/exchange"))
+            .bearer_auth(&root_token)
+            .json(&serde_json::json!({
+                "scopes": ["workspace:read", "workspace:write"],
+                "ttl_seconds": 300,
+                "label": "manage-cli",
+            }))
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("connect to running daemon: {e}"))?
+            .error_for_status()
+            .map_err(|e| anyhow::anyhow!("authenticate to running daemon: {e}"))?
+            .json()
+            .await?;
+        let session_token = exchange["token"]
+            .as_str()
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("daemon auth response missing token"))?
+            .to_string();
+
+        Ok(Self {
+            client,
+            base,
+            session_token,
+        })
+    }
+
+    async fn json<T: DeserializeOwned>(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+    ) -> anyhow::Result<T> {
+        let mut request = self
+            .client
+            .request(method, format!("{}{}", self.base, path))
+            .bearer_auth(&self.session_token);
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("daemon request {path}: {e}"))?;
+        let status = response.status();
+        let bytes = response.bytes().await?;
+        if !status.is_success() {
+            let detail = serde_json::from_slice::<serde_json::Value>(&bytes)
+                .ok()
+                .and_then(|body| body["detail"].as_str().map(str::to_owned))
+                .unwrap_or_else(|| String::from_utf8_lossy(&bytes).into_owned());
+            anyhow::bail!("daemon request {path} returned {status}: {detail}");
+        }
+        serde_json::from_slice(&bytes)
+            .map_err(|e| anyhow::anyhow!("decode daemon response {path}: {e}"))
+    }
 }
 
 pub fn run() -> anyhow::Result<()> {
@@ -41,6 +127,7 @@ pub fn run() -> anyhow::Result<()> {
                 "Agent runtime (install & default)",
                 "LLM provider",
                 "Team share secrets",
+                "Team skills",
                 "Sync status / trigger",
                 "Quit",
             ])
@@ -52,7 +139,8 @@ pub fn run() -> anyhow::Result<()> {
             1 => agent_runtime_menu(&theme)?,
             2 => llm_menu(&theme)?,
             3 => team_secrets_menu(&theme)?,
-            4 => sync_menu(&theme)?,
+            4 => team_skills_menu(&theme)?,
+            5 => sync_menu(&theme)?,
             _ => break,
         }
     }
@@ -559,6 +647,182 @@ fn team_secrets_menu(theme: &ColorfulTheme) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Manage the skills assigned to this daemon's own agent actor.
+///
+/// Unlike the Desktop UI, a headless daemon never selects another actor: its
+/// Cloud API credential is the hosted agent identity, so all installs land on
+/// this machine and are materialised under its daemon-owned cloud cache.
+fn team_skills_menu(theme: &ColorfulTheme) -> anyhow::Result<()> {
+    loop {
+        let (team_id, skills) = fetch_team_skills()?;
+        println!("Team: {team_id}");
+        if skills.is_empty() {
+            println!("  No skills have been published to this team's registry.");
+        } else {
+            println!("  Registry skills (for this daemon):");
+            for skill in &skills {
+                let installed = match skill.installed_version {
+                    Some(version) if version == skill.latest_version => {
+                        format!("installed v{version}")
+                    }
+                    Some(version) => format!(
+                        "installed v{version}; update available v{}",
+                        skill.latest_version
+                    ),
+                    None => "not installed".to_string(),
+                };
+                println!(
+                    "  - {} (latest v{}; {installed})",
+                    skill.slug, skill.latest_version
+                );
+            }
+        }
+
+        let choice = Select::with_theme(theme)
+            .with_prompt("Team skills")
+            .items(&[
+                "Refresh registry",
+                "Install a skill on this daemon",
+                "Sync installed skills now",
+                "Back",
+            ])
+            .default(0)
+            .interact()?;
+
+        match choice {
+            0 => continue,
+            1 => install_team_skill_interactive(theme, &team_id, &skills)?,
+            2 => sync_team_skills_now(&team_id)?,
+            _ => break,
+        }
+    }
+    Ok(())
+}
+
+fn install_team_skill_interactive(
+    theme: &ColorfulTheme,
+    team_id: &str,
+    skills: &[TeamSkillRow],
+) -> anyhow::Result<()> {
+    let available: Vec<&TeamSkillRow> = skills.iter().filter(|skill| !skill.installed).collect();
+    if available.is_empty() {
+        println!("All published team skills are already assigned to this daemon.");
+        return Ok(());
+    }
+    let labels: Vec<String> = available
+        .iter()
+        .map(|skill| {
+            let summary = skill.summary.trim();
+            if summary.is_empty() {
+                format!("{} (v{})", skill.slug, skill.latest_version)
+            } else {
+                format!("{} (v{}) — {summary}", skill.slug, skill.latest_version)
+            }
+        })
+        .collect();
+    let idx = Select::with_theme(theme)
+        .with_prompt("Install on this daemon")
+        .items(&labels)
+        .interact()?;
+    let skill = available[idx];
+    let version = skill.latest_version.max(1);
+    if !Confirm::with_theme(theme)
+        .with_prompt(format!(
+            "Assign {} v{version} to this daemon and download it now?",
+            skill.slug
+        ))
+        .default(true)
+        .interact()?
+    {
+        return Ok(());
+    }
+
+    let outcome = install_and_sync_team_skill(team_id, &skill.slug, version)?;
+    println!("✓ {} is assigned to this daemon.", skill.slug);
+    print_team_skill_sync_outcome(outcome);
+    Ok(())
+}
+
+fn sync_team_skills_now(team_id: &str) -> anyhow::Result<()> {
+    let outcome = reconcile_team_skills(team_id)?;
+    print_team_skill_sync_outcome(outcome);
+    Ok(())
+}
+
+fn print_team_skill_sync_outcome(outcome: crate::runtime::team_skills::TeamSkillReconcileOutcome) {
+    if outcome.changed() {
+        println!(
+            "✓ Team skills synced: installed {}, removed {}.",
+            outcome.installed, outcome.removed
+        );
+        println!("  New agent sessions will discover the updated skill set.");
+    } else {
+        println!("✓ Team skills are already current.");
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HttpTeamSkillsResponse {
+    team_id: String,
+    skills: Vec<TeamSkillRow>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HttpTeamSkillReconcileResponse {
+    team_id: String,
+    #[serde(flatten)]
+    outcome: crate::runtime::team_skills::TeamSkillReconcileOutcome,
+}
+
+fn fetch_team_skills() -> anyhow::Result<(String, Vec<TeamSkillRow>)> {
+    tokio::runtime::Runtime::new()?.block_on(async {
+        let daemon = ManageDaemonClient::connect().await?;
+        let response: HttpTeamSkillsResponse = daemon
+            .json(reqwest::Method::GET, "/v1/team/skills", None)
+            .await?;
+        Ok((response.team_id, response.skills))
+    })
+}
+
+fn install_and_sync_team_skill(
+    team_id: &str,
+    slug: &str,
+    version: i64,
+) -> anyhow::Result<crate::runtime::team_skills::TeamSkillReconcileOutcome> {
+    tokio::runtime::Runtime::new()?.block_on(async {
+        let daemon = ManageDaemonClient::connect().await?;
+        let path = format!("/v1/team/skills/{slug}/install");
+        let response: HttpTeamSkillReconcileResponse = daemon
+            .json(
+                reqwest::Method::PUT,
+                &path,
+                Some(serde_json::json!({ "version": version })),
+            )
+            .await?;
+        if response.team_id != team_id {
+            anyhow::bail!("daemon is bound to a different team");
+        }
+        Ok(response.outcome)
+    })
+}
+
+fn reconcile_team_skills(
+    team_id: &str,
+) -> anyhow::Result<crate::runtime::team_skills::TeamSkillReconcileOutcome> {
+    tokio::runtime::Runtime::new()?.block_on(async {
+        let daemon = ManageDaemonClient::connect().await?;
+        let response: HttpTeamSkillReconcileResponse = daemon
+            .json(reqwest::Method::POST, "/v1/team/skills/reconcile", None)
+            .await?;
+        if response.team_id != team_id {
+            anyhow::bail!("daemon is bound to a different team");
+        }
+        Ok(response.outcome)
+    })
+}
+
 fn sync_menu(theme: &ColorfulTheme) -> anyhow::Result<()> {
     let config_path = DaemonConfig::default_path();
     // team_share is serde-skipped on DaemonConfig; a raw load would always
@@ -578,10 +842,8 @@ fn sync_menu(theme: &ColorfulTheme) -> anyhow::Result<()> {
         println!("  Use manual sync below or `amuxd config set team_share.auto_sync true`.");
     }
 
-    if let Ok(rt) = tokio::runtime::Runtime::new() {
-        if let Ok(mode) = rt.block_on(fetch_cloud_share_mode(&team_id)) {
-            println!("Cloud share-mode: {mode}");
-        }
+    if let Ok(mode) = fetch_share_mode(&team_id) {
+        println!("Cloud share-mode: {mode}");
     }
 
     let toggle_label = if auto_sync {
@@ -687,21 +949,27 @@ fn trigger_manual_sync(theme: &ColorfulTheme, team_id: &str) -> anyhow::Result<(
     Ok(())
 }
 
-async fn fetch_cloud_share_mode(team_id: &str) -> anyhow::Result<String> {
-    let backend_path =
-        ProviderConfig::default_path().map_err(|e| anyhow::anyhow!("backend config path: {e}"))?;
-    let provider_config = ProviderConfig::load_from_path(&backend_path)
-        .map_err(|e| anyhow::anyhow!("load {}: {e}", backend_path.display()))?;
-    let backend = backend_from_provider_config(provider_config)
-        .map_err(|e| anyhow::anyhow!("cloud backend: {e}"))?;
-    let share = backend
-        .team_share_config(team_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-    Ok(share
-        .mode
-        .filter(|m| !m.trim().is_empty())
-        .unwrap_or_else(|| "(unset)".to_string()))
+fn fetch_share_mode(team_id: &str) -> anyhow::Result<String> {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Response {
+        team_id: String,
+        mode: Option<String>,
+    }
+
+    tokio::runtime::Runtime::new()?.block_on(async {
+        let daemon = ManageDaemonClient::connect().await?;
+        let response: Response = daemon
+            .json(reqwest::Method::GET, "/v1/team/share-mode", None)
+            .await?;
+        if response.team_id != team_id {
+            anyhow::bail!("daemon is bound to a different team");
+        }
+        Ok(response
+            .mode
+            .filter(|mode| !mode.trim().is_empty())
+            .unwrap_or_else(|| "(unset)".to_string()))
+    })
 }
 
 fn pick_workspace(theme: &ColorfulTheme) -> anyhow::Result<PathBuf> {
@@ -776,42 +1044,16 @@ fn fetch_registered_workspaces() -> anyhow::Result<Vec<RegisteredWorkspace>> {
 }
 
 async fn fetch_registered_workspaces_async() -> anyhow::Result<Vec<RegisteredWorkspace>> {
-    let backend_path =
-        ProviderConfig::default_path().map_err(|e| anyhow::anyhow!("backend config path: {e}"))?;
-    let provider_config = ProviderConfig::load_from_path(&backend_path)
-        .map_err(|e| anyhow::anyhow!("load {}: {e}", backend_path.display()))?;
-    let backend = backend_from_provider_config(provider_config)
-        .map_err(|e| anyhow::anyhow!("cloud backend: {e}"))?;
-
-    let team_id = backend.team_id().to_string();
-    let actor_id = backend.actor_id().to_string();
-    if team_id.trim().is_empty() {
-        anyhow::bail!("no team_id in backend.toml");
+    #[derive(Deserialize)]
+    struct Response {
+        workspaces: Vec<RegisteredWorkspace>,
     }
 
-    let default_id = backend
-        .get_agent_defaults(&actor_id)
-        .await
-        .ok()
-        .and_then(|d| d.default_workspace_id);
-
-    let rows = backend
-        .get_workspaces_by_agent(&team_id, &actor_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("get workspaces: {e}"))?;
-
-    let mut out = Vec::new();
-    for row in rows {
-        let Some((path, display_name)) = listable_local_workspace(&row) else {
-            continue;
-        };
-        out.push(RegisteredWorkspace {
-            path: PathBuf::from(path),
-            display_name,
-            is_default: default_id.as_deref() == Some(row.id.as_str()),
-            workspace_id: row.id,
-        });
-    }
+    let daemon = ManageDaemonClient::connect().await?;
+    let mut out = daemon
+        .json::<Response>(reqwest::Method::GET, "/v1/workspaces", None)
+        .await?
+        .workspaces;
     out.sort_by(|a, b| {
         b.is_default
             .cmp(&a.is_default)
@@ -953,57 +1195,19 @@ fn trigger_sync_via_http(
     team_id: &str,
     force_sync: bool,
 ) -> anyhow::Result<HttpSyncStatus> {
-    let port_path = DaemonConfig::http_port_path();
-    let token_path = DaemonConfig::http_token_path();
-    let port = std::fs::read_to_string(&port_path)
-        .map_err(|e| anyhow::anyhow!("read {} ({e}). Is the daemon running?", port_path.display()))?
-        .trim()
-        .to_string();
-    let root_token = std::fs::read_to_string(&token_path)
-        .map_err(|e| anyhow::anyhow!("read {} ({e})", token_path.display()))?
-        .trim()
-        .to_string();
-
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
-        let client = reqwest::Client::new();
-        let base = format!("http://127.0.0.1:{port}");
-
-        #[derive(serde::Serialize)]
-        #[serde(rename_all = "camelCase")]
-        struct ExchangeBody<'a> {
-            scopes: &'a [&'a str],
-            label: &'a str,
-        }
-
-        let exchange: serde_json::Value = client
-            .post(format!("{base}/v1/auth/exchange"))
-            .header("authorization", format!("Bearer {root_token}"))
-            .json(&ExchangeBody {
-                scopes: &["workspace:read", "workspace:write"],
-                label: "manage-cli",
-            })
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
-        let session_token = exchange["token"]
-            .as_str()
-            .ok_or_else(|| anyhow::anyhow!("exchange response missing token"))?;
-
+        let daemon = ManageDaemonClient::connect().await?;
         let workspace_path = workspace.to_string_lossy().to_string();
-        let sync: HttpSyncStatus = client
-            .post(format!("{base}/v1/team/sync"))
-            .header("authorization", format!("Bearer {session_token}"))
-            .json(&serde_json::json!({
-                "workspacePath": workspace_path,
-                "forceSync": force_sync,
-            }))
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
+        let sync: HttpSyncStatus = daemon
+            .json(
+                reqwest::Method::POST,
+                "/v1/team/sync",
+                Some(serde_json::json!({
+                    "workspacePath": workspace_path,
+                    "forceSync": force_sync,
+                })),
+            )
             .await?;
 
         // Ignore unused field in struct when API returns extra keys.

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -970,6 +970,9 @@ impl DaemonServer {
         // Escapes the HTTP-setup block so the prewarm notifier can be installed
         // once the sock command channel exists (below).
         let mut supervisor_for_prewarm: Option<Arc<crate::runtime::RuntimeSupervisor>> = None;
+        let team_skill_reconciler = Arc::new(
+            crate::runtime::team_skills::TeamSkillReconciler::new(self.backend.clone()),
+        );
         let _http_handle = {
             let mut meta = crate::http::server::metadata(self.actor_id.clone(), "amuxd");
             // Expose configured backends so the model-catalog endpoint can
@@ -1050,6 +1053,7 @@ impl DaemonServer {
                 })),
                 Some(local_rpc_tx),
                 Some(local_live_ingest_tx),
+                Some(team_skill_reconciler.clone()),
             )
             .await
             {
@@ -1374,8 +1378,8 @@ impl DaemonServer {
             .filter(|id| !id.is_empty())
             .map(str::to_owned)
         {
-            use crate::runtime::team_skills::{apply_team_skill_outcome, TeamSkillReconciler};
-            let reconciler = Arc::new(TeamSkillReconciler::new(self.backend.clone()));
+            use crate::runtime::team_skills::apply_team_skill_outcome;
+            let reconciler = team_skill_reconciler.clone();
             let backend = Some(self.backend.clone());
             let refresh = self.refresh_coordinator.clone();
             tokio::spawn(async move {

--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -212,6 +212,16 @@ pub fn build(state: HttpState) -> Router {
         // Daemon-owned team sync: desktop triggers sync + reads status over loopback.
         .route("/v1/team/sync", post(team_sync::sync_now))
         .route("/v1/team/sync/status", get(team_sync::sync_status))
+        .route("/v1/team/share-mode", get(team_sync::get_share_mode))
+        .route("/v1/team/skills", get(team_sync::list_team_skills))
+        .route(
+            "/v1/team/skills/reconcile",
+            post(team_sync::reconcile_team_skills),
+        )
+        .route(
+            "/v1/team/skills/:slug/install",
+            put(team_sync::install_team_skill),
+        )
         // Pull team MCP / team env from Cloud API into the daemon cache now
         // (desktop calls this after a successful env-secret write/delete).
         .route(

--- a/apps/daemon/src/http/server.rs
+++ b/apps/daemon/src/http/server.rs
@@ -82,6 +82,7 @@ pub async fn spawn(
     onboarding: Option<Arc<dyn crate::http::setup::OnboardingService>>,
     local_rpc_tx: Option<crate::http::state::LocalRpcTx>,
     local_live_ingest_tx: Option<crate::http::state::LocalLiveIngestTx>,
+    team_skills: Option<Arc<crate::runtime::team_skills::TeamSkillReconciler>>,
 ) -> anyhow::Result<HttpHandle> {
     // Resolve token + port files (defaults live in DaemonConfig::config_dir).
     let token_path = http
@@ -127,9 +128,9 @@ pub async fn spawn(
         .map(|b| Arc::new(crate::runtime::managed_llm::ManagedLlmResolver::new(b)));
     // Same shape for team MCP / team env: desktop posts after a Cloud API write
     // so the daemon cache converges immediately instead of waiting for the tick.
-    let team_cloud = backend.clone().map(|b| {
-        Arc::new(crate::runtime::team_cloud_config::TeamCloudConfigResolver::new(b))
-    });
+    let team_cloud = backend
+        .clone()
+        .map(|b| Arc::new(crate::runtime::team_cloud_config::TeamCloudConfigResolver::new(b)));
 
     let state = HttpState::new(
         http,
@@ -147,6 +148,7 @@ pub async fn spawn(
     .with_live_tee(live_tee)
     .with_managed_llm(managed_llm)
     .with_team_cloud(team_cloud)
+    .with_team_skills(team_skills)
     .with_local_rpc(local_rpc_tx)
     .with_local_live_ingest(local_live_ingest_tx);
 
@@ -258,6 +260,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -287,6 +290,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -341,6 +345,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -542,6 +547,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -616,6 +622,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -703,6 +710,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -802,6 +810,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -911,6 +920,7 @@ mod tests {
             None,
             Some(rpc_tx),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -969,6 +979,129 @@ mod tests {
         let decoded = crate::proto::teamclu::RpcResponse::decode(bytes.as_ref()).unwrap();
         assert!(decoded.success);
         assert_eq!(decoded.request_id, "req-42");
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn team_management_routes_use_the_daemon_backend() {
+        let home = tempfile::tempdir().unwrap();
+        let team_id = "team-manage-http-route-test";
+
+        let backend = Arc::new(crate::backend::mock::MockBackend::with_identity(
+            team_id,
+            "agent-manage",
+        ));
+        {
+            let mut state = backend.state();
+            state.team_share_configs.insert(
+                team_id.to_string(),
+                crate::backend::ShareModeConfig {
+                    mode: Some("oss".to_string()),
+                },
+            );
+            state.team_skills.insert(
+                team_id.to_string(),
+                vec![crate::backend::TeamSkillRow {
+                    slug: "managed-skill".to_string(),
+                    summary: "Managed through daemon HTTP".to_string(),
+                    category: "test".to_string(),
+                    when_to_use: String::new(),
+                    when_not_to_use: String::new(),
+                    requires: None,
+                    owner_actor_id: None,
+                    latest_version: 2,
+                    installed: false,
+                    installed_version: None,
+                }],
+            );
+        }
+        let backend_dyn: Arc<dyn Backend> = backend.clone();
+        let reconciler = Arc::new(crate::runtime::team_skills::TeamSkillReconciler::new(
+            backend_dyn.clone(),
+        ));
+
+        let token_path = home.path().join("http-token");
+        let cfg = HttpConfig {
+            bind: "127.0.0.1:0".into(),
+            token_file: Some(token_path.clone()),
+            port_file: Some(home.path().join("http-port")),
+            ..HttpConfig::default()
+        };
+        let runtime = crate::http::runtime_adapter::StubRuntimeAdapter::new(32);
+        let handle = spawn(
+            cfg,
+            metadata("agent-manage".into(), "test"),
+            runtime,
+            None,
+            None,
+            None,
+            test_dispatcher(),
+            None,
+            Some(backend_dyn),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(reconciler),
+        )
+        .await
+        .unwrap();
+        let base = format!("http://{}", handle.local_addr);
+        let root = std::fs::read_to_string(&token_path).unwrap();
+        let client = reqwest::Client::new();
+        let exchanged: serde_json::Value = client
+            .post(format!("{base}/v1/auth/exchange"))
+            .bearer_auth(root.trim())
+            .json(&serde_json::json!({
+                "scopes": ["workspace:read", "workspace:write"]
+            }))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let token = exchanged["token"].as_str().unwrap();
+
+        let share: serde_json::Value = client
+            .get(format!("{base}/v1/team/share-mode"))
+            .bearer_auth(token)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(share["teamId"], team_id);
+        assert_eq!(share["mode"], "oss");
+
+        let skills: serde_json::Value = client
+            .get(format!("{base}/v1/team/skills"))
+            .bearer_auth(token)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(skills["teamId"], team_id);
+        assert_eq!(skills["skills"][0]["slug"], "managed-skill");
+
+        let response = client
+            .put(format!("{base}/v1/team/skills/managed-skill/install"))
+            .bearer_auth(token)
+            .json(&serde_json::json!({ "version": 2 }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status().as_u16(), 200);
+        assert_eq!(
+            backend.state().team_skill_installs,
+            vec![(team_id.to_string(), "managed-skill".to_string(), 2)]
+        );
+
         handle.shutdown().await;
     }
 }

--- a/apps/daemon/src/http/state.rs
+++ b/apps/daemon/src/http/state.rs
@@ -151,6 +151,10 @@ pub struct HttpState {
     /// tick so a post-write `POST /v1/team/cloud-config/reconcile` and the
     /// periodic poll share one TTL/`last_fetch`. `None` in focused tests.
     pub team_cloud: Option<Arc<crate::runtime::team_cloud_config::TeamCloudConfigResolver>>,
+    /// Materialises the skills assigned to this daemon's agent. The loopback
+    /// management API and the periodic task share this instance so both use
+    /// the daemon-owned backend/token state and the same reconcile cadence.
+    pub team_skills: Option<Arc<crate::runtime::team_skills::TeamSkillReconciler>>,
     /// `daemon.toml` path backing `/v1/config/*`. `None` in focused tests —
     /// those routes then return 503.
     pub config_path: Option<std::path::PathBuf>,
@@ -209,6 +213,7 @@ impl HttpState {
             live_tee: None,
             managed_llm: None,
             team_cloud: None,
+            team_skills: None,
             config_path: None,
             channel_reload_tx: None,
             onboarding: None,
@@ -254,6 +259,15 @@ impl HttpState {
         team_cloud: Option<Arc<crate::runtime::team_cloud_config::TeamCloudConfigResolver>>,
     ) -> Self {
         self.team_cloud = team_cloud;
+        self
+    }
+
+    /// Attach the shared team-skill reconciler.
+    pub fn with_team_skills(
+        mut self,
+        team_skills: Option<Arc<crate::runtime::team_skills::TeamSkillReconciler>>,
+    ) -> Self {
+        self.team_skills = team_skills;
         self
     }
 

--- a/apps/daemon/src/http/team_sync.rs
+++ b/apps/daemon/src/http/team_sync.rs
@@ -286,6 +286,139 @@ pub async fn uninstall_team_mcp(
 }
 
 // ---------------------------------------------------------------------------
+// Daemon-owned team skill management
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamSkillsResponse {
+    pub team_id: String,
+    pub skills: Vec<crate::backend::TeamSkillRow>,
+}
+
+/// `GET /v1/team/skills` — list registry skills decorated for this daemon's
+/// own agent actor. The handler deliberately uses the daemon's shared backend;
+/// a local management client must never create a second refresh-token owner.
+pub async fn list_team_skills(
+    principal: Principal,
+    State(state): State<HttpState>,
+) -> Result<Json<TeamSkillsResponse>, HttpError> {
+    require_scope(&principal, "workspace:read")?;
+    let (backend, team_id) = daemon_backend_and_team(&state)?;
+    let skills = backend
+        .team_skills(&team_id)
+        .await
+        .map_err(|e| HttpError::internal(e.to_string()))?;
+    Ok(Json(TeamSkillsResponse { team_id, skills }))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallTeamSkillRequest {
+    pub version: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamSkillReconcileResponse {
+    pub team_id: String,
+    #[serde(flatten)]
+    pub outcome: crate::runtime::team_skills::TeamSkillReconcileOutcome,
+}
+
+/// `PUT /v1/team/skills/:slug/install` — assign a published skill to this
+/// daemon actor and materialise the resulting desired set immediately.
+pub async fn install_team_skill(
+    principal: Principal,
+    State(state): State<HttpState>,
+    Path(slug): Path<String>,
+    Json(body): Json<InstallTeamSkillRequest>,
+) -> Result<Json<TeamSkillReconcileResponse>, HttpError> {
+    require_scope(&principal, "workspace:write")?;
+    if slug.trim().is_empty() {
+        return Err(HttpError::validation("skill slug must not be empty"));
+    }
+    if body.version < 1 {
+        return Err(HttpError::validation("skill version must be at least 1"));
+    }
+    let (backend, team_id) = daemon_backend_and_team(&state)?;
+    backend
+        .record_team_skill_install(&team_id, &slug, body.version)
+        .await
+        .map_err(|e| HttpError::internal(e.to_string()))?;
+    reconcile_team_skills_for_state(&state, team_id).await
+}
+
+/// `POST /v1/team/skills/reconcile` — force the same reconciler used by the
+/// daemon's periodic task to run now.
+pub async fn reconcile_team_skills(
+    principal: Principal,
+    State(state): State<HttpState>,
+) -> Result<Json<TeamSkillReconcileResponse>, HttpError> {
+    require_scope(&principal, "workspace:write")?;
+    let (_, team_id) = daemon_backend_and_team(&state)?;
+    reconcile_team_skills_for_state(&state, team_id).await
+}
+
+async fn reconcile_team_skills_for_state(
+    state: &HttpState,
+    team_id: String,
+) -> Result<Json<TeamSkillReconcileResponse>, HttpError> {
+    let reconciler = state
+        .team_skills
+        .as_ref()
+        .ok_or_else(|| HttpError::runtime_unavailable("team skill reconciler is not available"))?;
+    let outcome = reconciler.reconcile_now(&team_id).await;
+    crate::runtime::team_skills::apply_team_skill_outcome(
+        &team_id,
+        outcome,
+        state.backend.as_ref(),
+        state.runtime_refresh.as_ref(),
+    )
+    .await;
+    Ok(Json(TeamSkillReconcileResponse { team_id, outcome }))
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamShareModeResponse {
+    pub team_id: String,
+    pub mode: Option<String>,
+}
+
+/// `GET /v1/team/share-mode` — authoritative cloud share mode through the
+/// daemon-owned backend/token state.
+pub async fn get_share_mode(
+    principal: Principal,
+    State(state): State<HttpState>,
+) -> Result<Json<TeamShareModeResponse>, HttpError> {
+    require_scope(&principal, "workspace:read")?;
+    let (backend, team_id) = daemon_backend_and_team(&state)?;
+    let config = backend
+        .team_share_config(&team_id)
+        .await
+        .map_err(|e| HttpError::internal(e.to_string()))?;
+    Ok(Json(TeamShareModeResponse {
+        team_id,
+        mode: config.mode,
+    }))
+}
+
+fn daemon_backend_and_team(
+    state: &HttpState,
+) -> Result<(&std::sync::Arc<dyn crate::backend::Backend>, String), HttpError> {
+    let backend = state
+        .backend
+        .as_ref()
+        .ok_or_else(|| HttpError::runtime_unavailable("cloud backend unavailable"))?;
+    let team_id = backend.team_id().trim().to_string();
+    if team_id.is_empty() {
+        return Err(HttpError::validation("daemon is not onboarded to a team"));
+    }
+    Ok((backend, team_id))
+}
+
+// ---------------------------------------------------------------------------
 // Task 11: secrets delivery
 // ---------------------------------------------------------------------------
 

--- a/apps/daemon/src/runtime/team_skills.rs
+++ b/apps/daemon/src/runtime/team_skills.rs
@@ -67,7 +67,7 @@ pub fn team_cloud_skills_dir(team_id: &str) -> PathBuf {
     global_team_cloud_dir(team_id).join("skills")
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct TeamSkillReconcileOutcome {
     pub installed: usize,
     pub removed: usize,
@@ -83,6 +83,7 @@ pub struct TeamSkillReconciler {
     backend: Arc<dyn Backend>,
     http: reqwest::Client,
     last_fetch: AsyncMutex<HashMap<String, Instant>>,
+    reconcile_lock: AsyncMutex<()>,
 }
 
 impl TeamSkillReconciler {
@@ -91,6 +92,7 @@ impl TeamSkillReconciler {
             backend,
             http: reqwest::Client::new(),
             last_fetch: AsyncMutex::new(HashMap::new()),
+            reconcile_lock: AsyncMutex::new(()),
         }
     }
 
@@ -107,6 +109,7 @@ impl TeamSkillReconciler {
     /// Reconcile regardless of the TTL. Used on startup and by the MQTT nudge,
     /// which only exists to pull the next tick forward.
     pub async fn reconcile_now(&self, team_id: &str) -> TeamSkillReconcileOutcome {
+        let _guard = self.reconcile_lock.lock().await;
         let rows = match self.backend.team_skills(team_id).await {
             Ok(rows) => rows,
             Err(e) => {

--- a/apps/daemon/tests/http_apps.rs
+++ b/apps/daemon/tests/http_apps.rs
@@ -104,6 +104,7 @@ async fn test_app_inner(backend: Option<Arc<dyn Backend>>) -> (TestApp, tempfile
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");

--- a/apps/daemon/tests/http_default_workspace.rs
+++ b/apps/daemon/tests/http_default_workspace.rs
@@ -61,6 +61,7 @@ async fn test_app(backend: Arc<dyn Backend>, scopes: &[&str]) -> (TestApp, tempf
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");

--- a/apps/daemon/tests/http_sessions_runtime.rs
+++ b/apps/daemon/tests/http_sessions_runtime.rs
@@ -186,6 +186,7 @@ async fn test_app_with_runtime_adapter() -> TestApp {
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");

--- a/apps/daemon/tests/http_workspace_provider_auth.rs
+++ b/apps/daemon/tests/http_workspace_provider_auth.rs
@@ -60,6 +60,7 @@ async fn test_app_with_workspace_store(
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");


### PR DESCRIPTION
## Description

- route every Cloud-backed `amuxd manage` operation through the running daemon's loopback HTTP API instead of constructing a second `CloudApiBackend`
- add daemon-owned endpoints for team share mode and team skill list/install/reconcile, while reusing the existing workspace and team sync endpoints
- share one team-skill reconciler between the periodic task and manual management requests, with serialization to avoid concurrent filesystem reconciliation
- extend the mock backend and HTTP coverage to prove management requests use the daemon's backend/token owner

This keeps refresh-token rotation inside the daemon process and removes the cross-process token race that could invalidate a headless agent. Local-only manage operations keep their existing behavior. No FC, database, or Cloud API contract changes are included.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Validation:

- `pnpm daemon:build`
- `pnpm daemon:test` (all test targets passed; one environment-dependent opencode test remains ignored as designed)
- `git diff origin/main...HEAD --check`
