### PR TITLE
fix(mqtt): harden reconnect subscription recovery

### DIFF
--- a/apps/desktop/src/commands/mqtt_bus.rs
+++ b/apps/desktop/src/commands/mqtt_bus.rs
@@ -35,18 +35,19 @@ pub async fn mqtt_connect(
         use_tls,
     };
     let client = MqttClient::connect(cfg).map_err(|e| e.to_string())?;
-    let generation = bus.bump_generation();
-    // Reset to false until the event loop observes a CONNACK. Without this,
-    // a stale `true` from a previous session could leak into the UI between
-    // `mqtt_connect` returning and the broker's CONNACK arriving.
-    bus.set_connected(false);
-    let previous_client = {
-        let mut client_guard = bus.client.lock().await;
-        client_guard.replace(client)
+    let (generation, previous_client) = {
+        let _client_guard = bus.client_gate.write().await;
+        let _event_guard = bus.event_gate.write().await;
+        let generation = bus.bump_generation();
+        let previous_client = bus.client.lock().await.replace(client);
+        bus.subscribed.lock().await.clear();
+        (generation, previous_client)
     };
-    bus.subscribed.lock().await.clear();
     if let Some(previous_client) = previous_client {
-        let _ = previous_client.client.disconnect().await;
+        // The retired event loop may already have stopped draining its bounded
+        // channel. Never wait for capacity on a client that no longer owns the
+        // generation.
+        let _ = previous_client.client.try_disconnect();
     }
 
     let bus_arc = (*bus).clone();
@@ -59,28 +60,38 @@ pub async fn mqtt_connect(
 
 #[tauri::command]
 pub async fn mqtt_subscribe(bus: State<'_, MqttBus>, topic: String) -> Result<(), String> {
-    let client_guard = bus.client.lock().await;
-    let client = client_guard.as_ref().ok_or("mqtt not connected")?;
-    client
+    let _client_guard = bus.client_gate.read().await;
+    let client = bus
         .client
+        .lock()
+        .await
+        .as_ref()
+        .ok_or("mqtt not connected")?
+        .client
+        .clone();
+    client
         .subscribe(&topic, QoS::AtLeastOnce)
         .await
         .map_err(|e| e.to_string())?;
-    drop(client_guard);
     bus.subscribed.lock().await.insert(topic);
     Ok(())
 }
 
 #[tauri::command]
 pub async fn mqtt_unsubscribe(bus: State<'_, MqttBus>, topic: String) -> Result<(), String> {
-    let client_guard = bus.client.lock().await;
-    let client = client_guard.as_ref().ok_or("mqtt not connected")?;
-    client
+    let _client_guard = bus.client_gate.read().await;
+    let client = bus
         .client
+        .lock()
+        .await
+        .as_ref()
+        .ok_or("mqtt not connected")?
+        .client
+        .clone();
+    client
         .unsubscribe(&topic)
         .await
         .map_err(|e| e.to_string())?;
-    drop(client_guard);
     bus.subscribed.lock().await.remove(&topic);
     Ok(())
 }
@@ -92,10 +103,19 @@ pub async fn mqtt_publish(
     bytes: Vec<u8>,
     retain: bool,
 ) -> Result<(), String> {
+    let _client_guard = bus.client_gate.read().await;
+    let generation = bus.ready_generation().ok_or("mqtt not ready")?;
     let client_guard = bus.client.lock().await;
-    let client = client_guard.as_ref().ok_or("mqtt not connected")?;
-    client
+    if bus.ready_generation() != Some(generation) {
+        return Err("mqtt not ready".to_string());
+    }
+    let client = client_guard
+        .as_ref()
+        .ok_or("mqtt not connected")?
         .client
+        .clone();
+    drop(client_guard);
+    client
         .publish(&topic, QoS::AtLeastOnce, retain, bytes)
         .await
         .map_err(|e| e.to_string())?;

--- a/apps/desktop/src/mqtt/client.rs
+++ b/apps/desktop/src/mqtt/client.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use rumqttc::{
-    AsyncClient, ConnectReturnCode, Event, EventLoop, LastWill, MqttOptions, Packet, QoS,
-    SubscribeFilter, Transport,
+    AsyncClient, ConnectReturnCode, Event, EventLoop, LastWill, MqttOptions, Outgoing, Packet, QoS,
+    Request, SubAck, Subscribe, SubscribeFilter, SubscribeReasonCode, Transport,
 };
 use serde::Serialize;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use teamclu_transport::MqttBroker;
@@ -96,34 +97,126 @@ fn build_mqtt_options(cfg: &ClientConfig, clean_session: bool) -> MqttOptions {
     opts
 }
 
-/// Replay the subscriptions the UI has registered on the current MQTT client.
-///
-/// A successful CONNACK only proves the transport is back. The broker may have
-/// discarded the previous persistent session, so relying on `session_present`
-/// can leave the desktop connected but unable to receive RPC responses. MQTT
-/// subscriptions are idempotent, therefore replaying them after every CONNACK
-/// is both safe and the smallest reliable recovery path.
-async fn resubscribe_tracked_topics(bus: &super::MqttBusInner) -> Result<usize, String> {
-    // Keep the same lock order as mqtt_subscribe/mqtt_unsubscribe so a user
-    // unsubscribe cannot race with this replay and be accidentally restored.
-    let client_guard = bus.client.lock().await;
-    let client = client_guard.as_ref().ok_or("mqtt client unavailable")?;
-    let mut topics: Vec<String> = bus.subscribed.lock().await.iter().cloned().collect();
-    topics.sort_unstable();
-    if topics.is_empty() {
-        return Ok(0);
+#[derive(Debug)]
+struct PendingRecovery {
+    packet_id: Option<u16>,
+    filters: Vec<SubscribeFilter>,
+    session_present: bool,
+}
+
+#[derive(Debug, Default)]
+struct SubscriptionRecovery {
+    /// Requests retained by rumqttc across a disconnect. They must not run
+    /// before the response subscriptions have been restored.
+    deferred: VecDeque<Request>,
+    pending: Option<PendingRecovery>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RecoveryResult {
+    NotRecoveryAck,
+    Restored {
+        subscription_count: usize,
+        session_present: bool,
+        deferred_count: usize,
+    },
+    Failed(String),
+}
+
+impl SubscriptionRecovery {
+    /// Places the recovery SUBSCRIBE directly at the front of rumqttc's
+    /// event-loop queue. Using `AsyncClient::subscribe_many().await` here can
+    /// deadlock because this same task is the only consumer of its bounded
+    /// request channel. Moving the existing pending requests aside also keeps
+    /// stale RPC publishes from overtaking the recovery subscription.
+    fn prepare(
+        &mut self,
+        event_loop_pending: &mut VecDeque<Request>,
+        topics: Vec<String>,
+        session_present: bool,
+    ) -> usize {
+        self.pending = None;
+        self.deferred.append(event_loop_pending);
+
+        if topics.is_empty() {
+            event_loop_pending.append(&mut self.deferred);
+            return 0;
+        }
+
+        let filters: Vec<SubscribeFilter> = topics
+            .into_iter()
+            .map(|path| SubscribeFilter::new(path, QoS::AtLeastOnce))
+            .collect();
+        let subscribe = Subscribe::new_many(filters.clone());
+        let subscription_count = subscribe.filters.len();
+        event_loop_pending.push_back(Request::Subscribe(subscribe));
+        self.pending = Some(PendingRecovery {
+            packet_id: None,
+            filters,
+            session_present,
+        });
+        subscription_count
     }
 
-    let count = topics.len();
-    let filters = topics
-        .into_iter()
-        .map(|path| SubscribeFilter::new(path, QoS::AtLeastOnce));
-    client
-        .client
-        .subscribe_many(filters)
-        .await
-        .map_err(|error| error.to_string())?;
-    Ok(count)
+    fn observe_outgoing(&mut self, outgoing: &Outgoing, event_loop_pending: &VecDeque<Request>) {
+        if let (Some(pending), Outgoing::Subscribe(packet_id)) = (&mut self.pending, outgoing) {
+            let recovery_request_is_still_queued = event_loop_pending.iter().any(|request| {
+                matches!(request, Request::Subscribe(subscribe) if subscribe.filters == pending.filters)
+            });
+            if pending.packet_id.is_none() && !recovery_request_is_still_queued {
+                pending.packet_id = Some(*packet_id);
+            }
+        }
+    }
+
+    fn finish(
+        &mut self,
+        event_loop_pending: &mut VecDeque<Request>,
+        ack: &SubAck,
+    ) -> RecoveryResult {
+        let Some(pending) = self.pending.as_ref() else {
+            return RecoveryResult::NotRecoveryAck;
+        };
+        if pending.packet_id != Some(ack.pkid) {
+            return RecoveryResult::NotRecoveryAck;
+        }
+
+        let pending = self.pending.take().expect("pending recovery checked above");
+        if ack.return_codes.len() != pending.filters.len() {
+            return RecoveryResult::Failed(format!(
+                "broker returned {} SUBACK result(s) for {} subscription(s)",
+                ack.return_codes.len(),
+                pending.filters.len()
+            ));
+        }
+        if ack.return_codes.contains(&SubscribeReasonCode::Failure) {
+            return RecoveryResult::Failed(
+                "broker rejected one or more restored subscriptions".to_string(),
+            );
+        }
+
+        let deferred_count = self.deferred.len();
+        event_loop_pending.append(&mut self.deferred);
+        RecoveryResult::Restored {
+            subscription_count: pending.filters.len(),
+            session_present: pending.session_present,
+            deferred_count,
+        }
+    }
+
+    fn connection_lost(&mut self, event_loop_pending: &mut VecDeque<Request>) {
+        // The recovery SUBSCRIBE itself is not retained by rumqttc's clean-up
+        // path. Keep the deferred application requests and retry a fresh
+        // recovery SUBSCRIBE after the next successful CONNACK.
+        let Some(pending) = self.pending.take() else {
+            return;
+        };
+        if let Some(index) = event_loop_pending.iter().position(|request| {
+            matches!(request, Request::Subscribe(subscribe) if subscribe.filters == pending.filters)
+        }) {
+            event_loop_pending.remove(index);
+        }
+    }
 }
 
 /// One-shot broker reachability probe. Does not touch the shared [`MqttBus`].
@@ -222,36 +315,143 @@ mod tests {
         assert_eq!(broker.port, 443);
     }
 
-    #[tokio::test]
-    async fn connack_replay_enqueues_every_tracked_subscription() {
-        let options = MqttOptions::new("desktop-resubscribe-test", "127.0.0.1", 1883);
-        let (client, event_loop) = AsyncClient::new(options, 8);
-        let bus = super::super::MqttBusInner::new();
-        *bus.client.lock().await = Some(MqttClient {
-            client,
-            event_loop: Arc::new(Mutex::new(event_loop)),
-            client_id: "desktop-resubscribe-test".to_string(),
-        });
-        bus.subscribed.lock().await.extend([
-            "amux/team/+/rpc/res".to_string(),
-            "amux/team/session/+/live".to_string(),
-        ]);
-
-        assert_eq!(resubscribe_tracked_topics(&bus).await, Ok(2));
-    }
-
-    #[tokio::test]
-    async fn connack_replay_fails_when_the_current_client_is_missing() {
-        let bus = super::super::MqttBusInner::new();
-        bus.subscribed
-            .lock()
-            .await
-            .insert("amux/team/+/rpc/res".to_string());
+    #[test]
+    fn recovery_subscribe_precedes_a_full_deferred_queue() {
+        let mut event_loop_pending = (0..64)
+            .map(|index| {
+                Request::Publish(rumqttc::Publish::new(
+                    format!("rpc/{index}"),
+                    QoS::AtLeastOnce,
+                    vec![index as u8],
+                ))
+            })
+            .collect::<VecDeque<_>>();
+        let mut recovery = SubscriptionRecovery::default();
 
         assert_eq!(
-            resubscribe_tracked_topics(&bus).await,
-            Err("mqtt client unavailable".to_string())
+            recovery.prepare(
+                &mut event_loop_pending,
+                vec!["rpc/response".to_string(), "session/live".to_string()],
+                false,
+            ),
+            2
         );
+        assert_eq!(event_loop_pending.len(), 1);
+        assert!(matches!(
+            event_loop_pending.front(),
+            Some(Request::Subscribe(subscribe)) if subscribe.filters.len() == 2
+        ));
+        assert_eq!(recovery.deferred.len(), 64);
+    }
+
+    #[test]
+    fn successful_suback_restores_deferred_requests_in_order() {
+        let first = Request::Publish(rumqttc::Publish::new(
+            "rpc/first",
+            QoS::AtLeastOnce,
+            vec![1],
+        ));
+        let second = Request::Publish(rumqttc::Publish::new(
+            "rpc/second",
+            QoS::AtLeastOnce,
+            vec![2],
+        ));
+        let mut event_loop_pending = VecDeque::from([first.clone(), second.clone()]);
+        let mut recovery = SubscriptionRecovery::default();
+        recovery.prepare(
+            &mut event_loop_pending,
+            vec!["rpc/response".to_string()],
+            true,
+        );
+        event_loop_pending.clear();
+        recovery.observe_outgoing(&Outgoing::Subscribe(7), &event_loop_pending);
+
+        assert_eq!(
+            recovery.finish(
+                &mut event_loop_pending,
+                &SubAck::new(7, vec![SubscribeReasonCode::Success(QoS::AtLeastOnce)],),
+            ),
+            RecoveryResult::Restored {
+                subscription_count: 1,
+                session_present: true,
+                deferred_count: 2,
+            }
+        );
+        assert_eq!(event_loop_pending, VecDeque::from([first, second]));
+    }
+
+    #[test]
+    fn failed_or_unrelated_suback_never_releases_deferred_publish() {
+        let mut event_loop_pending = VecDeque::from([Request::Publish(rumqttc::Publish::new(
+            "rpc/request",
+            QoS::AtLeastOnce,
+            vec![1],
+        ))]);
+        let mut recovery = SubscriptionRecovery::default();
+        recovery.prepare(
+            &mut event_loop_pending,
+            vec!["rpc/response".to_string()],
+            false,
+        );
+        event_loop_pending.clear();
+        recovery.observe_outgoing(&Outgoing::Subscribe(11), &event_loop_pending);
+
+        assert_eq!(
+            recovery.finish(
+                &mut event_loop_pending,
+                &SubAck::new(12, vec![SubscribeReasonCode::Success(QoS::AtLeastOnce)],),
+            ),
+            RecoveryResult::NotRecoveryAck
+        );
+        assert_eq!(recovery.deferred.len(), 1);
+        assert_eq!(
+            recovery.finish(
+                &mut event_loop_pending,
+                &SubAck::new(11, vec![SubscribeReasonCode::Failure]),
+            ),
+            RecoveryResult::Failed(
+                "broker rejected one or more restored subscriptions".to_string()
+            )
+        );
+        assert!(event_loop_pending.is_empty());
+        assert_eq!(recovery.deferred.len(), 1);
+
+        recovery.prepare(
+            &mut event_loop_pending,
+            vec!["rpc/response".to_string()],
+            false,
+        );
+        event_loop_pending.clear();
+        recovery.observe_outgoing(&Outgoing::Subscribe(13), &event_loop_pending);
+        assert!(matches!(
+            recovery.finish(
+                &mut event_loop_pending,
+                &SubAck::new(13, vec![SubscribeReasonCode::Success(QoS::AtLeastOnce)],),
+            ),
+            RecoveryResult::Restored {
+                deferred_count: 1,
+                ..
+            }
+        ));
+        assert_eq!(event_loop_pending.len(), 1);
+    }
+
+    #[test]
+    fn stale_outgoing_subscribe_does_not_capture_recovery_packet_id() {
+        let mut event_loop_pending = VecDeque::new();
+        let mut recovery = SubscriptionRecovery::default();
+        recovery.prepare(
+            &mut event_loop_pending,
+            vec!["rpc/response".to_string()],
+            false,
+        );
+
+        recovery.observe_outgoing(&Outgoing::Subscribe(4), &event_loop_pending);
+        assert_eq!(recovery.pending.as_ref().unwrap().packet_id, None);
+
+        event_loop_pending.pop_front();
+        recovery.observe_outgoing(&Outgoing::Subscribe(5), &event_loop_pending);
+        assert_eq!(recovery.pending.as_ref().unwrap().packet_id, Some(5));
     }
 }
 
@@ -292,6 +492,7 @@ pub async fn run_event_loop(bus: Arc<super::MqttBusInner>, app: tauri::AppHandle
     }
 
     let mut backoff_secs: u64 = 1;
+    let mut recovery = SubscriptionRecovery::default();
     loop {
         if bus.current_generation() != generation {
             return;
@@ -304,10 +505,12 @@ pub async fn run_event_loop(bus: Arc<super::MqttBusInner>, app: tauri::AppHandle
             return;
         }
         let Some(event_loop) = event_loop_arc else {
+            let event_guard = bus.event_gate.read().await;
             if bus.current_generation() != generation {
                 return;
             }
-            bus.set_connected(false);
+            bus.set_connected_for_generation(generation, false);
+            drop(event_guard);
             tokio::time::sleep(Duration::from_secs(1)).await;
             continue;
         };
@@ -316,57 +519,114 @@ pub async fn run_event_loop(bus: Arc<super::MqttBusInner>, app: tauri::AppHandle
         if bus.current_generation() != generation {
             return;
         }
+        // Keep explicit `mqtt_connect` from retiring this generation between
+        // the ownership check and its state/UI side effects.
+        let event_guard = bus.event_gate.read().await;
+        if bus.current_generation() != generation {
+            return;
+        }
         match poll_result {
             Ok(Event::Incoming(Packet::ConnAck(ack))) => {
                 if ack.code == ConnectReturnCode::Success {
-                    // `poll()` holds the event-loop mutex. Release it before
-                    // queueing SUBSCRIBE so the next poll can send the packet.
-                    drop(event_loop);
-                    backoff_secs = 1;
-                    match resubscribe_tracked_topics(&bus).await {
-                        Ok(subscription_count) => {
-                            bus.set_connected(true);
-                            tracing::info!(
-                                session_present = ack.session_present,
-                                subscription_count,
-                                "mqtt CONNACK: success; subscriptions restored"
-                            );
-                            let _ = app.emit("mqtt:connected", true);
+                    let mut topics: Vec<String> =
+                        bus.subscribed.lock().await.iter().cloned().collect();
+                    if bus.current_generation() != generation {
+                        return;
+                    }
+                    topics.sort_unstable();
+                    let subscription_count =
+                        recovery.prepare(&mut event_loop.pending, topics, ack.session_present);
+                    if subscription_count == 0 {
+                        backoff_secs = 1;
+                        if !bus.set_connected_for_generation(generation, true) {
+                            return;
                         }
-                        Err(error) => {
-                            bus.set_connected(false);
-                            let msg = format!("mqtt subscription restore failed: {error}");
-                            tracing::warn!(session_present = ack.session_present, "{msg}");
-                            let _ = app.emit("mqtt:connected", false);
-                            let _ = app.emit("mqtt:error", msg.as_str());
-                        }
+                        tracing::info!(
+                            session_present = ack.session_present,
+                            "mqtt CONNACK: success; no subscriptions to restore"
+                        );
+                        let _ = app.emit("mqtt:connected", true);
+                    } else {
+                        tracing::info!(
+                            session_present = ack.session_present,
+                            subscription_count,
+                            "mqtt CONNACK: success; waiting for subscription restore SUBACK"
+                        );
                     }
                 } else {
                     // The broker accepted the TCP/TLS socket but refused the MQTT
                     // session (e.g. bad credentials). Surface the reason instead of
                     // flashing "connected" and letting the socket-close error below
                     // silently flip us back to red with no explanation.
-                    bus.set_connected(false);
+                    recovery.connection_lost(&mut event_loop.pending);
+                    bus.set_connected_for_generation(generation, false);
                     let msg = format!("broker refused connection: {:?}", ack.code);
                     tracing::warn!("mqtt {msg}");
                     let _ = app.emit("mqtt:connected", false);
                     let _ = app.emit("mqtt:error", msg.as_str());
                 }
             }
+            Ok(Event::Incoming(Packet::SubAck(ack))) => {
+                match recovery.finish(&mut event_loop.pending, &ack) {
+                    RecoveryResult::NotRecoveryAck => {}
+                    RecoveryResult::Restored {
+                        subscription_count,
+                        session_present,
+                        deferred_count,
+                    } => {
+                        backoff_secs = 1;
+                        if !bus.set_connected_for_generation(generation, true) {
+                            return;
+                        }
+                        tracing::info!(
+                            session_present,
+                            subscription_count,
+                            deferred_count,
+                            "mqtt subscriptions restored and connection ready"
+                        );
+                        let _ = app.emit("mqtt:connected", true);
+                    }
+                    RecoveryResult::Failed(error) => {
+                        bus.set_connected_for_generation(generation, false);
+                        // Never release already-accepted QoS requests when a
+                        // restore is rejected. Disconnect first, retain them,
+                        // and retry the restore on the next CONNACK.
+                        event_loop
+                            .pending
+                            .push_front(Request::Disconnect(rumqttc::Disconnect));
+                        let msg = format!("mqtt subscription restore failed: {error}");
+                        tracing::warn!("{msg}");
+                        let _ = app.emit("mqtt:connected", false);
+                        let _ = app.emit("mqtt:error", msg.as_str());
+                    }
+                }
+            }
             Ok(Event::Incoming(Packet::Disconnect)) => {
-                bus.set_connected(false);
+                recovery.connection_lost(&mut event_loop.pending);
+                bus.set_connected_for_generation(generation, false);
                 tracing::warn!("mqtt broker sent DISCONNECT");
                 let _ = app.emit("mqtt:connected", false);
             }
             Ok(Event::Incoming(Packet::Publish(p))) => {
-                backoff_secs = 1;
+                if bus.is_connected() {
+                    backoff_secs = 1;
+                }
                 let _ = env_tx.send((p.topic.clone(), p.payload.to_vec()));
             }
+            Ok(Event::Outgoing(outgoing)) => {
+                if bus.is_connected() {
+                    backoff_secs = 1;
+                }
+                recovery.observe_outgoing(&outgoing, &event_loop.pending);
+            }
             Ok(_) => {
-                backoff_secs = 1;
+                if bus.is_connected() {
+                    backoff_secs = 1;
+                }
             }
             Err(e) => {
-                bus.set_connected(false);
+                recovery.connection_lost(&mut event_loop.pending);
+                bus.set_connected_for_generation(generation, false);
                 let msg = e.to_string();
                 let _ = app.emit("mqtt:connected", false);
                 // Surface the connection failure (auth rejection, refused socket,
@@ -374,6 +634,7 @@ pub async fn run_event_loop(bus: Arc<super::MqttBusInner>, app: tauri::AppHandle
                 let _ = app.emit("mqtt:error", msg.as_str());
                 tracing::warn!("mqtt event loop error: {msg}, retry in {backoff_secs}s");
                 drop(event_loop);
+                drop(event_guard);
                 tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
                 backoff_secs = (backoff_secs * 2).min(60);
             }

--- a/apps/desktop/src/mqtt/mod.rs
+++ b/apps/desktop/src/mqtt/mod.rs
@@ -5,23 +5,24 @@ pub mod topics;
 pub use client::{ClientConfig, MqttClient};
 
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 pub struct MqttBusInner {
     pub client: Mutex<Option<MqttClient>>,
     pub subscribed: Mutex<HashSet<String>>,
-    /// True only after the event loop has observed a CONNACK and not yet seen
-    /// a network/disconnect error. The `client` handle being `Some(_)` only
-    /// proves the wrapper struct exists — it can outlive a broken TCP/TLS
-    /// connection, which is why we need this separate flag for honest UI
-    /// status.
-    pub connected: AtomicBool,
-    /// Monotonic token for the currently-owned MQTT connection. Reconnects
-    /// replace the client and spawn a new event loop; older event loops exit
-    /// when their captured generation no longer matches this value.
-    pub generation: AtomicU64,
+    /// Packs the current generation and its readiness bit into one atomic.
+    /// Keeping them together prevents an obsolete event loop from marking a
+    /// newer connection ready between a generation check and a separate store.
+    connection_state: AtomicU64,
+    /// Linearizes explicit client replacement with outbound enqueue.
+    pub(crate) client_gate: RwLock<()>,
+    /// Linearizes generation changes with event-loop state/UI side effects.
+    /// This is deliberately separate from `client_gate`: a writer waiting for
+    /// an in-flight bounded-channel enqueue must not stop the event loop that
+    /// drains that channel.
+    pub(crate) event_gate: RwLock<()>,
 }
 
 impl MqttBusInner {
@@ -29,32 +30,151 @@ impl MqttBusInner {
         Self {
             client: Mutex::new(None),
             subscribed: Mutex::new(HashSet::new()),
-            connected: AtomicBool::new(false),
-            generation: AtomicU64::new(0),
+            connection_state: AtomicU64::new(0),
+            client_gate: RwLock::new(()),
+            event_gate: RwLock::new(()),
         }
     }
 
     pub fn is_connected(&self) -> bool {
-        self.connected.load(Ordering::Acquire)
+        self.connection_state.load(Ordering::Acquire) & 1 == 1
     }
 
-    pub fn set_connected(&self, value: bool) {
-        self.connected.store(value, Ordering::Release);
+    pub fn ready_generation(&self) -> Option<u64> {
+        let state = self.connection_state.load(Ordering::Acquire);
+        (state & 1 == 1).then_some(state >> 1)
     }
 
     pub fn current_generation(&self) -> u64 {
-        self.generation.load(Ordering::Acquire)
+        self.connection_state.load(Ordering::Acquire) >> 1
     }
 
     pub fn bump_generation(&self) -> u64 {
-        self.generation.fetch_add(1, Ordering::AcqRel) + 1
+        loop {
+            let state = self.connection_state.load(Ordering::Acquire);
+            let generation = (state >> 1) + 1;
+            let next = generation << 1;
+            if self
+                .connection_state
+                .compare_exchange_weak(state, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return generation;
+            }
+        }
+    }
+
+    /// Updates readiness only if `generation` still owns the connection.
+    pub fn set_connected_for_generation(&self, generation: u64, value: bool) -> bool {
+        let next = generation << 1 | u64::from(value);
+        loop {
+            let state = self.connection_state.load(Ordering::Acquire);
+            if state >> 1 != generation {
+                return false;
+            }
+            if state == next {
+                return true;
+            }
+            if self
+                .connection_state
+                .compare_exchange_weak(state, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return true;
+            }
+        }
     }
 
     pub async fn force_reconnect(&self) {
-        self.set_connected(false);
-        if let Some(client) = self.client.lock().await.as_ref() {
-            let _ = client.client.disconnect().await;
+        let (generation, client) = {
+            let _client_guard = self.client_gate.write().await;
+            let _event_guard = self.event_gate.write().await;
+            let generation = self.current_generation();
+            self.set_connected_for_generation(generation, false);
+            let client = self
+                .client
+                .lock()
+                .await
+                .as_ref()
+                .map(|client| client.client.clone());
+            (generation, client)
+        };
+        if let Some(client) = client {
+            // Wait for the active event loop to make bounded-channel capacity,
+            // but cancel the enqueue if an explicit connect retires this
+            // generation while we wait. No gate is held here, so the event
+            // loop remains free to drain requests.
+            tokio::select! {
+                _ = client.disconnect() => {}
+                _ = async {
+                    while self.current_generation() == generation {
+                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    }
+                } => {}
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MqttBusInner, MqttClient};
+    use rumqttc::{AsyncClient, MqttOptions, QoS};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::Mutex;
+
+    #[test]
+    fn obsolete_generation_cannot_change_new_connection_readiness() {
+        let bus = MqttBusInner::new();
+        let first = bus.bump_generation();
+        assert!(bus.set_connected_for_generation(first, true));
+        assert!(bus.is_connected());
+
+        let second = bus.bump_generation();
+        assert!(!bus.is_connected());
+        assert!(!bus.set_connected_for_generation(first, true));
+        assert!(!bus.set_connected_for_generation(first, false));
+        assert_eq!(bus.current_generation(), second);
+        assert_eq!(bus.ready_generation(), None);
+
+        assert!(bus.set_connected_for_generation(second, true));
+        assert_eq!(bus.ready_generation(), Some(second));
+    }
+
+    #[tokio::test]
+    async fn force_reconnect_stops_waiting_on_a_retired_full_queue() {
+        let bus = Arc::new(MqttBusInner::new());
+        let generation = bus.bump_generation();
+        assert!(bus.set_connected_for_generation(generation, true));
+
+        let options = MqttOptions::new("force-reconnect-test", "127.0.0.1", 1883);
+        let (client, event_loop) = AsyncClient::new(options, 1);
+        client
+            .try_publish("queue/full", QoS::AtLeastOnce, false, vec![1])
+            .unwrap();
+        *bus.client.lock().await = Some(MqttClient {
+            client,
+            event_loop: Arc::new(Mutex::new(event_loop)),
+            client_id: "force-reconnect-test".to_string(),
+        });
+
+        let reconnect = tokio::spawn({
+            let bus = bus.clone();
+            async move { bus.force_reconnect().await }
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!reconnect.is_finished());
+
+        {
+            let _client_guard = bus.client_gate.write().await;
+            let _event_guard = bus.event_gate.write().await;
+            bus.bump_generation();
+        }
+        tokio::time::timeout(Duration::from_secs(1), reconnect)
+            .await
+            .expect("retiring the generation should cancel the blocked disconnect")
+            .unwrap();
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #962 after correctness review. This hardens desktop MQTT recovery against bounded-channel deadlocks, stale generation races, pending publish ordering, and premature readiness.

## Changes

- restore tracked subscriptions directly ahead of retained requests
- wait for matching successful SUBACK before reporting ready
- preserve deferred QoS requests across failed recovery
- isolate client replacement and event generation races
- make explicit/forced reconnect safe with full request queues
- apply exponential backoff to repeated subscription rejection

## Validation

- 10 targeted MQTT unit tests passed
- pnpm rust:clippy passed with -D warnings
- git diff --check passed

## Review

A separate subagent performed multiple correctness review rounds and found no remaining issues in the final workspace.