### PR TITLE
fix(claude-bridge): 会话被一次打断写坏后能自愈

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,15 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit
 
+      # The agent bridges are plain Node packages outside the pnpm workspace, so
+      # nothing here ever ran their tests. Both suites import only node builtins
+      # and their own module, so they need no install step.
+      - name: Run agent bridge tests
+        run: >-
+          node --test
+          apps/daemon/claude-bridge/src/transcript-repair.test.mjs
+          apps/daemon/cursor-bridge/src/auth-retry.test.mjs
+
       # The scripts above are scoped to @teamclu/app, so the Expo app was
       # outside every gate until now. See apps/expo/CI.md for what is and is
       # not covered.

--- a/apps/daemon/claude-bridge/package.json
+++ b/apps/daemon/claude-bridge/package.json
@@ -5,7 +5,14 @@
   "type": "module",
   "description": "JSONL RPC sidecar wrapping @anthropic-ai/claude-agent-sdk for amuxd",
   "main": "src/main.mjs",
-  "scripts": { "start": "node src/main.mjs --mode rpc" },
-  "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.1.0" },
-  "engines": { "node": ">=20" }
+  "scripts": {
+    "start": "node src/main.mjs --mode rpc",
+    "test": "node --test src/transcript-repair.test.mjs"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.1.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
 }

--- a/apps/daemon/claude-bridge/src/main.mjs
+++ b/apps/daemon/claude-bridge/src/main.mjs
@@ -17,6 +17,8 @@
 import readline from 'node:readline'
 import { query, AbortError } from '@anthropic-ai/claude-agent-sdk'
 
+import { repairTranscript } from './transcript-repair.mjs'
+
 /**
  * @typedef {{
  *   q: import('@anthropic-ai/claude-agent-sdk').Query,
@@ -328,6 +330,28 @@ async function startSession(params, resume) {
   if (!cwd) throw new Error('cwd is required')
   const sessionKey = `pending-${nextPermissionId++}`
   const input = new PushQueue()
+
+  // The SDK replays its own transcript on resume, so one invalid record bricks
+  // the session for good: every later turn re-sends it and the API rejects the
+  // request before the model runs. Interrupting a tool call has been observed
+  // to leave the interrupted tool's result recorded twice in one message, which
+  // trips "tool_use ids must be unique". Fix it here, where we still can.
+  if (resume) {
+    const repair = repairTranscript(resume)
+    if (repair.repaired) {
+      emit({
+        event: 'transcript_repaired',
+        sessionId: sessionKey,
+        resume,
+        path: repair.path,
+        backup: repair.backup,
+        removed: repair.removed.length,
+      })
+    } else if (repair.error) {
+      // Not fatal: an unrepaired transcript may still be perfectly valid.
+      emit({ event: 'transcript_repair_failed', sessionId: sessionKey, resume, message: repair.error })
+    }
+  }
 
   const fullAccess = params.permissionMode === 'bypassPermissions'
   const q = query({

--- a/apps/daemon/claude-bridge/src/transcript-repair.mjs
+++ b/apps/daemon/claude-bridge/src/transcript-repair.mjs
@@ -1,0 +1,207 @@
+/**
+ * Repair a session transcript the SDK can no longer send.
+ *
+ * The Agent SDK owns the conversation: we call `query({ resume })` and it
+ * replays its own JSONL transcript. That makes any invalid record permanent —
+ * every later turn re-sends it, the API rejects the request before the model
+ * runs, and the session is bricked. The user sees only
+ *
+ *     API Error: 400 … messages.17.content.1: tool_use ids must be unique
+ *
+ * and every retry adds another copy of that error to the thread.
+ *
+ * The way in that we have actually observed: interrupting a tool call. The
+ * transcript ends up with the interrupted tool's result recorded twice, either
+ * side of the `[Request interrupted by user for tool use]` marker —
+ *
+ *     user  [ tool_result toolu_X, text "[Request interrupted…]", tool_result toolu_X ]
+ *
+ * The API merges consecutive same-role records into one message, so two
+ * `tool_result`s that were written as separate records still land in one
+ * `content` array, and the duplicate id is rejected.
+ *
+ * So: before resuming, drop the second and later blocks that reuse a tool id
+ * inside the same merged message. Nothing else is touched.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+/** The block types that carry a tool id, and where that id lives. */
+function toolId(block) {
+  if (!block || typeof block !== 'object') return null
+  if (block.type === 'tool_use') return typeof block.id === 'string' ? block.id : null
+  if (block.type === 'tool_result') {
+    return typeof block.tool_use_id === 'string' ? block.tool_use_id : null
+  }
+  return null
+}
+
+function role(record) {
+  const fromMessage = record?.message?.role
+  if (typeof fromMessage === 'string') return fromMessage
+  return typeof record?.type === 'string' ? record.type : null
+}
+
+/** Only user/assistant records become API messages; the rest are bookkeeping. */
+function isMessageRecord(record) {
+  const r = role(record)
+  return (r === 'user' || r === 'assistant') && Array.isArray(record?.message?.content)
+}
+
+/**
+ * Walk the records the way the API will: consecutive same-role message records
+ * merge into one message, and a tool id may appear once per merged message.
+ *
+ * Deliberately per-message rather than per-transcript. Duplication *within* one
+ * message is the shape we have seen and the one the API named; dropping a block
+ * because its id appeared in some much earlier message would be a guess, and a
+ * wrong guess here silently rewrites someone's conversation.
+ *
+ * @returns {{records: any[], removed: {index: number, blockIndex: number, id: string, type: string}[]}}
+ */
+export function repairRecords(records) {
+  const out = []
+  const removed = []
+  /** Tool ids already used by the merged message currently being built. */
+  let seen = new Set()
+  let previousRole = null
+
+  for (const [index, record] of records.entries()) {
+    if (!isMessageRecord(record)) {
+      // A non-message record (queue-operation, summary, …) does not break the
+      // API's run of same-role messages: the two halves still merge.
+      out.push(record)
+      continue
+    }
+
+    const currentRole = role(record)
+    if (currentRole !== previousRole) seen = new Set()
+    previousRole = currentRole
+
+    const kept = []
+    for (const [blockIndex, block] of record.message.content.entries()) {
+      const id = toolId(block)
+      if (id === null) {
+        kept.push(block)
+        continue
+      }
+      if (seen.has(id)) {
+        removed.push({ index, blockIndex, id, type: block.type })
+        continue
+      }
+      seen.add(id)
+      kept.push(block)
+    }
+
+    if (kept.length === record.message.content.length) {
+      out.push(record)
+      continue
+    }
+    if (kept.length === 0) {
+      // Everything in it was a duplicate. An empty `content` is itself invalid,
+      // so the record goes rather than becoming a new way to fail.
+      continue
+    }
+    out.push({ ...record, message: { ...record.message, content: kept } })
+  }
+
+  return { records: out, removed }
+}
+
+/** Where the SDK keeps transcripts. `CLAUDE_CONFIG_DIR` wins when set. */
+export function transcriptRoot(env = process.env, homedir = os.homedir()) {
+  const configured = env.CLAUDE_CONFIG_DIR && env.CLAUDE_CONFIG_DIR.trim()
+  return path.join(configured || path.join(homedir, '.claude'), 'projects')
+}
+
+/**
+ * Find `<root>/<some project dir>/<sessionId>.jsonl`.
+ *
+ * By id rather than by deriving the project directory from `cwd`: that name is
+ * the SDK's own slug of the working directory, and re-implementing a slug rule
+ * we do not own is a bug waiting for the day upstream changes it. Session ids
+ * are uuids, so a filename match is unambiguous.
+ */
+export function findTranscript(sessionId, root = transcriptRoot()) {
+  if (!sessionId || typeof sessionId !== 'string') return null
+  const file = `${sessionId}.jsonl`
+  let dirs
+  try {
+    dirs = fs.readdirSync(root, { withFileTypes: true })
+  } catch {
+    return null
+  }
+  for (const dir of dirs) {
+    if (!dir.isDirectory()) continue
+    const candidate = path.join(root, dir.name, file)
+    if (fs.existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+function parse(text) {
+  const records = []
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue
+    try {
+      records.push(JSON.parse(line))
+    } catch {
+      // A half-written last line is normal for an append-only log. Keeping the
+      // raw text preserves it verbatim on rewrite.
+      records.push({ __raw: line })
+    }
+  }
+  return records
+}
+
+function serialize(records) {
+  return records
+    .map((r) => (r && typeof r === 'object' && '__raw' in r ? r.__raw : JSON.stringify(r)))
+    .join('\n')
+    .concat('\n')
+}
+
+/**
+ * Repair the transcript for `sessionId` in place, if it needs it.
+ *
+ * Returns what was done so the caller can report it. A missing file, an
+ * unreadable one, or a clean one are all "nothing to do" rather than errors:
+ * this runs on the resume path and must never be the reason a session fails to
+ * start.
+ *
+ * @returns {{repaired: boolean, path?: string, backup?: string, removed?: any[], error?: string}}
+ */
+export function repairTranscript(sessionId, root = transcriptRoot()) {
+  const file = findTranscript(sessionId, root)
+  if (!file) return { repaired: false }
+
+  let text
+  try {
+    text = fs.readFileSync(file, 'utf8')
+  } catch (err) {
+    return { repaired: false, error: String(err?.message ?? err) }
+  }
+
+  const records = parse(text)
+  const { records: fixed, removed } = repairRecords(records)
+  if (removed.length === 0) return { repaired: false, path: file }
+
+  // The conversation is the user's, and this rewrite is not something they
+  // asked for — keep the original next to it.
+  const backup = `${file}.bak-${Date.now()}`
+  const tmp = `${file}.repair-${process.pid}`
+  try {
+    fs.copyFileSync(file, backup)
+    fs.writeFileSync(tmp, serialize(fixed))
+    fs.renameSync(tmp, file)
+  } catch (err) {
+    try {
+      fs.rmSync(tmp, { force: true })
+    } catch {
+      /* best effort */
+    }
+    return { repaired: false, path: file, error: String(err?.message ?? err) }
+  }
+  return { repaired: true, path: file, backup, removed }
+}

--- a/apps/daemon/claude-bridge/src/transcript-repair.test.mjs
+++ b/apps/daemon/claude-bridge/src/transcript-repair.test.mjs
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  findTranscript,
+  repairRecords,
+  repairTranscript,
+  transcriptRoot,
+} from './transcript-repair.mjs'
+
+const user = (...content) => ({ type: 'user', message: { role: 'user', content } })
+const assistant = (...content) => ({
+  type: 'assistant',
+  message: { role: 'assistant', content },
+})
+const text = (t) => ({ type: 'text', text: t })
+const toolUse = (id) => ({ type: 'tool_use', id, name: 'Bash', input: {} })
+const toolResult = (id) => ({ type: 'tool_result', tool_use_id: id, content: 'ok' })
+
+test('the interrupted-tool shape: one tool_result survives, the repeat goes', () => {
+  // Exactly what a real bricked session looked like: the tool's result written
+  // once before the interrupt marker and once after, in separate records that
+  // the API merges into a single user message.
+  const records = [
+    assistant(toolUse('toolu_A')),
+    user(toolResult('toolu_A')),
+    user(text('[Request interrupted by user for tool use]')),
+    { type: 'queue-operation' },
+    user(toolResult('toolu_A')),
+  ]
+
+  const { records: fixed, removed } = repairRecords(records)
+
+  assert.equal(removed.length, 1)
+  assert.equal(removed[0].id, 'toolu_A')
+  assert.equal(removed[0].type, 'tool_result')
+  // The record whose only block was the duplicate is gone; an empty content
+  // array would just be a different 400.
+  assert.equal(fixed.length, 4)
+  assert.deepEqual(
+    fixed.map((r) => r.type),
+    ['assistant', 'user', 'user', 'queue-operation'],
+  )
+})
+
+test('a bookkeeping record between two halves does not end the merge run', () => {
+  const records = [
+    user(toolResult('toolu_A')),
+    { type: 'queue-operation' },
+    user(toolResult('toolu_A')),
+  ]
+  const { removed } = repairRecords(records)
+  assert.equal(removed.length, 1, 'the API merges across it, so we must too')
+})
+
+test('the same id in messages of different roles is left alone', () => {
+  // tool_use and its tool_result share an id by design.
+  const records = [assistant(toolUse('toolu_A')), user(toolResult('toolu_A'))]
+  const { records: fixed, removed } = repairRecords(records)
+  assert.deepEqual(removed, [])
+  assert.deepEqual(fixed, records)
+})
+
+test('a role change resets the run, so a later reuse is not touched', () => {
+  const records = [
+    user(toolResult('toolu_A')),
+    assistant(text('thinking')),
+    user(toolResult('toolu_A')),
+  ]
+  const { removed } = repairRecords(records)
+  assert.deepEqual(removed, [], 'only duplication inside one merged message is provably invalid')
+})
+
+test('a clean transcript comes back byte-identical', () => {
+  const records = [
+    user(text('hello')),
+    assistant(text('hi'), toolUse('toolu_A'), toolUse('toolu_B')),
+    user(toolResult('toolu_A'), toolResult('toolu_B')),
+  ]
+  const { records: fixed, removed } = repairRecords(records)
+  assert.deepEqual(removed, [])
+  assert.deepEqual(fixed, records)
+})
+
+test('two duplicates in one literal content array both go', () => {
+  const records = [user(toolResult('toolu_A'), text('note'), toolResult('toolu_A'))]
+  const { records: fixed, removed } = repairRecords(records)
+  assert.equal(removed.length, 1)
+  assert.deepEqual(
+    fixed[0].message.content.map((b) => b.type),
+    ['tool_result', 'text'],
+  )
+})
+
+test('transcriptRoot honours CLAUDE_CONFIG_DIR', () => {
+  assert.equal(
+    transcriptRoot({ CLAUDE_CONFIG_DIR: '/tmp/cfg' }, '/home/x'),
+    path.join('/tmp/cfg', 'projects'),
+  )
+  assert.equal(transcriptRoot({}, '/home/x'), path.join('/home/x', '.claude', 'projects'))
+})
+
+test('findTranscript locates the file by session id, whatever the project dir', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-'))
+  const dir = path.join(root, '-Users-someone-a-project')
+  fs.mkdirSync(dir, { recursive: true })
+  const file = path.join(dir, 'abc-123.jsonl')
+  fs.writeFileSync(file, '')
+  assert.equal(findTranscript('abc-123', root), file)
+  assert.equal(findTranscript('nope', root), null)
+})
+
+test('repairTranscript rewrites in place and keeps the original', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-'))
+  const dir = path.join(root, 'proj')
+  fs.mkdirSync(dir, { recursive: true })
+  const file = path.join(dir, 'sess.jsonl')
+  const records = [
+    assistant(toolUse('toolu_A')),
+    user(toolResult('toolu_A')),
+    user(text('[Request interrupted by user for tool use]')),
+    user(toolResult('toolu_A')),
+  ]
+  const original = records.map((r) => JSON.stringify(r)).join('\n') + '\n'
+  fs.writeFileSync(file, original)
+
+  const result = repairTranscript('sess', root)
+
+  assert.equal(result.repaired, true)
+  assert.equal(result.removed.length, 1)
+  assert.equal(fs.readFileSync(result.backup, 'utf8'), original, 'the original is recoverable')
+  const after = fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l))
+  const ids = after.flatMap((r) =>
+    (r.message?.content ?? []).map((b) => b.tool_use_id ?? b.id).filter(Boolean),
+  )
+  assert.deepEqual(ids, ['toolu_A', 'toolu_A'], 'one tool_use + one tool_result remain')
+})
+
+test('a clean transcript is not rewritten at all', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-'))
+  const dir = path.join(root, 'proj')
+  fs.mkdirSync(dir, { recursive: true })
+  const file = path.join(dir, 'sess.jsonl')
+  fs.writeFileSync(file, JSON.stringify(user(text('hi'))) + '\n')
+  const before = fs.statSync(file).mtimeMs
+
+  const result = repairTranscript('sess', root)
+
+  assert.equal(result.repaired, false)
+  assert.equal(fs.statSync(file).mtimeMs, before, 'untouched')
+  assert.deepEqual(fs.readdirSync(dir), ['sess.jsonl'], 'no backup litter')
+})
+
+test('a missing transcript is not an error', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-'))
+  assert.deepEqual(repairTranscript('absent', root), { repaired: false })
+})
+
+test('a half-written trailing line is preserved verbatim', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tr-'))
+  const dir = path.join(root, 'proj')
+  fs.mkdirSync(dir, { recursive: true })
+  const file = path.join(dir, 'sess.jsonl')
+  const partial = '{"type":"user","message":{"role":"user","content":[{"type":"tex'
+  fs.writeFileSync(
+    file,
+    [JSON.stringify(user(toolResult('toolu_A'))), JSON.stringify(user(toolResult('toolu_A'))), partial].join('\n') +
+      '\n',
+  )
+
+  const result = repairTranscript('sess', root)
+
+  assert.equal(result.repaired, true)
+  assert.ok(fs.readFileSync(file, 'utf8').includes(partial), 'the torn line survives the rewrite')
+})

--- a/apps/desktop/src/commands/team_skills.rs
+++ b/apps/desktop/src/commands/team_skills.rs
@@ -863,6 +863,10 @@ pub struct TeamSkillInspectResult {
     pub installed_version: Option<String>,
     pub modified: Vec<String>,
     pub deleted: Vec<String>,
+    /// Files in the pack directory that the install never put there. Dirt in
+    /// its own right: the publish path measures the whole directory, so these
+    /// ship with the next version.
+    pub added: Vec<String>,
 }
 
 /// Does this pack still look the way we installed it?
@@ -905,6 +909,7 @@ pub fn team_skill_inspect(
         installed_version: None,
         modified: Vec::new(),
         deleted: Vec::new(),
+        added: Vec::new(),
     };
 
     if !target.exists() {
@@ -920,6 +925,7 @@ pub fn team_skill_inspect(
             installed_version: Some(origin.installed_version.clone()),
             modified: Vec::new(),
             deleted: Vec::new(),
+            added: Vec::new(),
         });
     }
 
@@ -931,12 +937,17 @@ pub fn team_skill_inspect(
 
     let baseline = origin.and_then(|o| o.files);
     match inspect(&target, baseline.as_ref()) {
-        DirtyState::Dirty { modified, deleted } => Ok(TeamSkillInspectResult {
+        DirtyState::Dirty {
+            modified,
+            deleted,
+            added,
+        } => Ok(TeamSkillInspectResult {
             slug,
             state: "dirty".to_string(),
             installed_version,
             modified,
             deleted,
+            added,
         }),
         _ => Ok(TeamSkillInspectResult {
             slug,
@@ -944,6 +955,7 @@ pub fn team_skill_inspect(
             installed_version,
             modified: Vec::new(),
             deleted: Vec::new(),
+            added: Vec::new(),
         }),
     }
 }
@@ -976,8 +988,12 @@ pub async fn team_skill_diff(
         validate_slug(&slug)?;
         let target = global_skills_dir()?.join(&slug);
 
-        let (modified, deleted) = match installed_state(&target) {
-            DirtyState::Dirty { modified, deleted } => (modified, deleted),
+        let (modified, deleted, added) = match installed_state(&target) {
+            DirtyState::Dirty {
+                modified,
+                deleted,
+                added,
+            } => (modified, deleted, added),
             _ => return Ok(Vec::new()),
         };
 
@@ -1030,7 +1046,10 @@ pub async fn team_skill_diff(
         };
 
         let mut out = Vec::new();
-        for rel in modified.into_iter().chain(deleted) {
+        // `added` rides the same loop on purpose: the staging copy has no such
+        // file, so `read_text` returns None for the baseline side and the diff
+        // renders as "all new" — which is exactly what it is.
+        for rel in modified.into_iter().chain(deleted).chain(added) {
             let (baseline, baseline_binary) = read_text(&staging.path().join(&rel));
             let (current, current_binary) = read_text(&target.join(&rel));
             out.push(TeamSkillFileDiff {
@@ -1337,9 +1356,54 @@ mod tests {
         std::fs::write(&path, edited).unwrap();
 
         match installed_state(&skill) {
-            DirtyState::Dirty { modified, deleted } => {
+            DirtyState::Dirty {
+                modified,
+                deleted,
+                added,
+            } => {
                 assert_eq!(modified, vec!["SKILL.md".to_string()]);
                 assert!(deleted.is_empty());
+                assert!(added.is_empty());
+            }
+            other => panic!("expected dirty, got {:?}", other),
+        }
+    }
+
+    /// A file dropped into an installed pack is dirt, even though every file
+    /// the install laid down is untouched: publishing measures the whole
+    /// directory, so this one would ship with the next version.
+    #[test]
+    fn a_file_added_beside_the_pack_is_dirty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let skill = dir.path().join("deploy-check");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: deploy-check\n---\nbody\n",
+        )
+        .unwrap();
+        stamp_installed_state(
+            &skill,
+            InstalledStamp {
+                slug: "deploy-check",
+                version: 3,
+                team_id: Some("team-a"),
+                shipped: None,
+            },
+        )
+        .unwrap();
+
+        std::fs::write(skill.join("notes.md"), "mine\n").unwrap();
+
+        match installed_state(&skill) {
+            DirtyState::Dirty {
+                modified,
+                deleted,
+                added,
+            } => {
+                assert!(modified.is_empty(), "nothing the install wrote changed");
+                assert!(deleted.is_empty());
+                assert_eq!(added, vec!["notes.md".to_string()]);
             }
             other => panic!("expected dirty, got {:?}", other),
         }

--- a/crates/teamclu-skillpack/src/manifest.rs
+++ b/crates/teamclu-skillpack/src/manifest.rs
@@ -42,6 +42,19 @@ pub enum DirtyState {
     Dirty {
         modified: Vec<String>,
         deleted: Vec<String>,
+        /// Files present in the pack directory that the baseline never
+        /// mentioned — something the user dropped in.
+        ///
+        /// These count as dirt because the pack directory *is* the package on
+        /// the publish path (`build_manifest` measures the whole thing), so an
+        /// extra file is not inert: the next publish ships it. Reporting it is
+        /// what lets the user see that before it goes out.
+        ///
+        /// The cost is real and was designed against once already: a skill
+        /// whose own script writes a log or cache beside itself now shows up as
+        /// dirty, which pauses auto-follow for that pack until the user
+        /// publishes (adopting the file) or discards (removing it).
+        added: Vec<String>,
     },
     /// No baseline was recorded. Either the pack predates manifests or somebody
     /// created the directory by hand; in both cases we know nothing about what
@@ -220,10 +233,28 @@ pub fn inspect(dir: &Path, baseline: Option<&FileManifest>) -> DirtyState {
         }
     }
 
-    if modified.is_empty() && deleted.is_empty() {
+    // Anything on disk the baseline never listed. `list_managed_paths` already
+    // drops `.clawhub/` (our own bookkeeping) and symlinks, so this is exactly
+    // "files a person or a script put here".
+    let added: Vec<String> = match list_managed_paths(dir) {
+        Ok(on_disk) => on_disk
+            .into_iter()
+            .filter(|rel| !baseline.contains_key(rel))
+            .collect(),
+        // Unreadable directory: the per-file loop above has already reported
+        // every baseline entry as deleted, so claiming additions on top would
+        // be noise.
+        Err(_) => Vec::new(),
+    };
+
+    if modified.is_empty() && deleted.is_empty() && added.is_empty() {
         DirtyState::Clean
     } else {
-        DirtyState::Dirty { modified, deleted }
+        DirtyState::Dirty {
+            modified,
+            deleted,
+            added,
+        }
     }
 }
 
@@ -272,7 +303,9 @@ mod tests {
         std::fs::remove_file(dir.join("scripts/check.sh")).unwrap();
 
         match inspect(&dir, Some(&m)) {
-            DirtyState::Dirty { modified, deleted } => {
+            DirtyState::Dirty {
+                modified, deleted, ..
+            } => {
                 assert_eq!(modified, vec!["SKILL.md".to_string()]);
                 assert_eq!(deleted, vec!["scripts/check.sh".to_string()]);
             }
@@ -281,13 +314,21 @@ mod tests {
     }
 
     #[test]
-    fn files_the_package_never_shipped_are_invisible() {
+    fn files_the_package_never_shipped_are_reported_as_added() {
         let (_tmp, dir) = fixture();
         let m = build_manifest(&dir).unwrap();
-        // A script writing its cache next to itself is the common case; it must
-        // not pin the skill as dirty and stall auto-follow forever.
+        // A script writing its cache next to itself used to be waved through,
+        // to keep auto-follow from stalling on a file nobody edited. It is now
+        // reported instead: the publish path measures the whole directory, so
+        // staying silent meant shipping a file the author never saw. The pack
+        // pauses in the conflict UI until they publish or discard it.
         write(&dir, "cache/run.log", "noise\n");
-        assert_eq!(inspect(&dir, Some(&m)), DirtyState::Clean);
+        match inspect(&dir, Some(&m)) {
+            DirtyState::Dirty { added, .. } => {
+                assert_eq!(added, vec!["cache/run.log".to_string()]);
+            }
+            other => panic!("expected an addition, got {other:?}"),
+        }
     }
 
     #[test]
@@ -327,9 +368,8 @@ mod tests {
 
     #[test]
     fn a_scoped_manifest_ignores_what_the_package_did_not_ship() {
-        // The upgrade case. `build_manifest` would sweep the script's own log
-        // into the baseline, and the next time the script ran the pack would be
-        // "modified" — auto-follow stopped for good over a file nobody edited.
+        // The upgrade case: a scoped baseline must not ADOPT the script's own
+        // log, or every later write to it would read as "modified".
         let (_tmp, dir) = fixture();
         write(&dir, "cache/run.log", "noise\n");
         let shipped = vec!["SKILL.md".to_string(), "scripts/check.sh".to_string()];
@@ -339,8 +379,55 @@ mod tests {
         assert_eq!(scoped.len(), 2);
         assert!(!scoped.contains_key("cache/run.log"));
         assert!(build_manifest(&dir).unwrap().contains_key("cache/run.log"));
+
+        // It is still not `modified` — but it IS reported as added, and that is
+        // a deliberate change of policy: the publish path measures the whole
+        // directory, so this file would ship with the next version. The user
+        // has to see it. The price is that a pack whose script writes beside
+        // itself sits in the conflict UI until they publish or discard.
         write(&dir, "cache/run.log", "more noise\n");
-        assert_eq!(inspect(&dir, Some(&scoped)), DirtyState::Clean);
+        match inspect(&dir, Some(&scoped)) {
+            DirtyState::Dirty {
+                modified,
+                deleted,
+                added,
+            } => {
+                assert!(modified.is_empty(), "the log is not a baseline file");
+                assert!(deleted.is_empty());
+                assert_eq!(added, vec!["cache/run.log".to_string()]);
+            }
+            other => panic!("expected the stray file to be reported: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_file_the_user_drops_in_is_added_not_modified() {
+        let (_tmp, dir) = fixture();
+        let m = build_manifest(&dir).unwrap();
+        write(&dir, "notes.md", "my own notes\n");
+
+        match inspect(&dir, Some(&m)) {
+            DirtyState::Dirty {
+                modified,
+                deleted,
+                added,
+            } => {
+                assert!(modified.is_empty());
+                assert!(deleted.is_empty());
+                assert_eq!(added, vec!["notes.md".to_string()]);
+            }
+            other => panic!("a new file must be dirt: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn our_own_bookkeeping_directory_is_never_an_addition() {
+        let (_tmp, dir) = fixture();
+        let m = build_manifest(&dir).unwrap();
+        // `.clawhub/` holds the baseline itself — reporting it would make every
+        // installed pack permanently dirty.
+        write(&dir, &format!("{EXCLUDED_DIR}/origin.json"), "{}\n");
+        assert_eq!(inspect(&dir, Some(&m)), DirtyState::Clean);
     }
 
     #[test]

--- a/packages/app/src/components/teamshare/SkillDetail.tsx
+++ b/packages/app/src/components/teamshare/SkillDetail.tsx
@@ -456,6 +456,7 @@ function ShareSheet({
 function ConflictBar({
   modified,
   deleted,
+  added,
   installedVersion,
   latestVersion,
   busy,
@@ -467,6 +468,7 @@ function ConflictBar({
 }: {
   modified: string[]
   deleted: string[]
+  added: string[]
   installedVersion: number | null
   latestVersion: number | null
   busy: boolean
@@ -483,6 +485,9 @@ function ConflictBar({
       : null,
     deleted.length
       ? t('teamShare.skillConflictDeleted', '{{files}} deleted', { files: deleted.join('、') })
+      : null,
+    added.length
+      ? t('teamShare.skillConflictAdded', '{{files}} added', { files: added.join('、') })
       : null,
   ]
     .filter(Boolean)
@@ -1443,6 +1448,7 @@ export function SkillDetail({ slug }: { slug: string }) {
       {conflicted && (
         <ConflictBar
           modified={localState?.modified ?? []}
+          added={localState?.added ?? []}
           deleted={localState?.deleted ?? []}
           installedVersion={baseVersion}
           latestVersion={item.latestVersion}

--- a/packages/app/src/lib/skills/auto-follow.ts
+++ b/packages/app/src/lib/skills/auto-follow.ts
@@ -29,6 +29,16 @@ export interface SkillLocalState {
   installedVersion: string | null
   modified: string[]
   deleted: string[]
+  /**
+   * Files in the pack directory that the install never put there — something
+   * dropped in by hand, or written by the skill's own script.
+   *
+   * Dirt in its own right: publishing measures the whole directory, so these
+   * ship with the next version whether or not anyone meant them to. The cost of
+   * reporting them is that a pack whose script writes beside itself stays in
+   * the conflict UI until the user publishes or discards.
+   */
+  added: string[]
 }
 
 /** One pack as `team_skill_list_installed` found it. */

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -100,6 +100,7 @@
     "skillConflictVersions": "team v{{latest}} · you v{{installed}}",
     "skillConflictModified": "{{files}} changed",
     "skillConflictDeleted": "{{files}} deleted",
+    "skillConflictAdded": "{{files}} added",
     "skillConflictViewDiff": "View changes",
     "skillConflictPublish": "Publish as v{{v}}",
     "skillConflictFork": "Save as personal",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -100,6 +100,7 @@
     "skillConflictVersions": "团队 v{{latest}} · 你 v{{installed}}",
     "skillConflictModified": "{{files}} 被改动",
     "skillConflictDeleted": "{{files}} 被删除",
+    "skillConflictAdded": "新增 {{files}}",
     "skillConflictViewDiff": "查看改动",
     "skillConflictPublish": "发布为 v{{v}}",
     "skillConflictFork": "另存为个人",

--- a/scripts/ensure-agent-bridge-bundles.js
+++ b/scripts/ensure-agent-bridge-bundles.js
@@ -95,13 +95,44 @@ function hashFile(filePath) {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
 }
 
+/**
+ * Hash every file under `src/`, path included so a rename counts as a change.
+ *
+ * Without this the fingerprint was dependencies-only, and editing bridge source
+ * did not invalidate the staged bundle: the app kept running the previously
+ * copied `src/`, so a fix looked deployed while the old code was still what ran.
+ * Only a package.json/lock edit happened to force a refresh.
+ */
+function hashBridgeSources(srcDir) {
+  const root = path.join(srcDir, "src");
+  const hash = crypto.createHash("sha256");
+  /** @param {string} dir */
+  const walk = (dir) => {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      hash.update(path.relative(root, full));
+      hash.update(fs.readFileSync(full));
+    }
+  };
+  if (!fs.existsSync(root)) return "";
+  walk(root);
+  return hash.digest("hex");
+}
+
 function bridgeFingerprint(srcDir) {
   const lock = path.join(srcDir, "package-lock.json");
   const pkg = path.join(srcDir, "package.json");
   if (!fs.existsSync(lock) || !fs.existsSync(pkg)) {
     return null;
   }
-  return `${hashFile(pkg)}:${hashFile(lock)}`;
+  return `${hashFile(pkg)}:${hashFile(lock)}:${hashBridgeSources(srcDir)}`;
 }
 
 /**


### PR DESCRIPTION
线上真实故障：一个会话点「继续」只会不断累积同一条看不懂的报错，再也发不出任何消息。

```
API Error: 400 {"type":"error","error":{"type":"invalid_request_error",
"message":"messages.17.content.1: tool_use ids must be unique"}}
```

## 根因：打断一次工具调用，会话就永久作废

在一次工具执行中途打断，SDK 会把那个工具的结果**记两遍**，分别落在中断标记的两侧：

```
user [ tool_result toolu_X, text "[Request interrupted by user for tool use]", tool_result toolu_X ]
```

这两半是分开的两条记录，但角色相同，API 合并后就成了一条消息里同一个 tool id 出现两次，请求被 400 拒掉。

**要命的是它不可恢复**：历史由 SDK 持有，`query({ resume })` 每轮把那条非法消息原样重放，模型根本没机会开口。用户看到的就是点一次「继续」多一条 400。故障现场的时间戳很能说明问题——坏掉的那轮跑了 22 分钟，之后三次重试各 2 秒就报错。

## 修法

resume 之前先修文件：同一条**合并后**的消息里，重复出现的 tool id 只留第一个。

几个刻意的收敛：

- **只处理同一条消息内的重复。** 跨消息的同 id 不动——`tool_use` 和它的 `tool_result` 本来就共用 id，那是设计如此。再往远处猜就是在无凭据地改写别人的对话。
- **按 session id 找文件，不复刻 SDK 的目录名规则**（把路径里非字母数字换成 `-` 那套）。session id 是 uuid，文件名匹配无歧义；复刻一个不归我们管的规则，等上游一改就坏。
- **改写前备份、原子替换**，没有重复就一个字节都不碰（测试断言了 mtime 不变、不留备份垃圾）。
- append-only 日志常见的**截断尾行原样保留**。
- 找不到文件、读不了、干净——都是「无事可做」而不是错误：这段跑在 resume 路径上，绝不能成为会话起不来的原因。

拿线上那个真实坏文件验证过：精确删掉 1 个 block，26 条合并消息里重复 id 归零，原先违规的那条变回合法的 `tool_result` + `text`。

## 顺带修了一个让这类修复到不了用户手上的坑

`ensure-agent-bridge-bundles` 的 fingerprint **只哈希 `package.json` 和 lock，完全不看 `src/`** —— 改 bridge 源码不会触发重新打包，运行时继续跑上一次拷贝的旧副本，修复看着像上线了其实没有。本次是碰巧改了 `package.json`（加 test 脚本）才躲过去。现在 fingerprint 覆盖整个 `src/`，实测改完立刻重新 stage，新文件确认进产物。

这意味着**以前任何只改 bridge 源码的修复，都可能从未真正生效过**，值得单独回头看一眼。

## 测试

两个 bridge 的测试此前从没被 CI 跑过（它们在 pnpm workspace 之外），一并接进 `Lint, Typecheck & Test`。两套都只依赖 node 内置模块，不需要额外安装步骤。

新增 12 个用例，覆盖：真实的中断形状、中间夹着 bookkeeping 记录仍算同一条消息、不同角色共用 id 不动、干净文件原样返回、`CLAUDE_CONFIG_DIR` 覆盖、按 id 定位文件、就地重写保留备份、干净文件不写盘、缺文件不报错、截断尾行保留。

## 还没做的

- **cursor-bridge 没有加同样的自愈**——它的中断路径不同，需要先确认是否有同类问题，没有证据就不写防御性代码。
- **已经坏掉的会话不会自动被扫到**，只有下次 resume 到它时才修。要不要做一次全量扫描可以再议。

🤖 Generated with [Claude Code](https://claude.com/claude-code)