### PR TITLE
chore(daemon): 团队网盘的 skills/ 不再是技能根

### DIFF
--- a/apps/daemon/src/config/roles_skills.rs
+++ b/apps/daemon/src/config/roles_skills.rs
@@ -402,14 +402,19 @@ fn collect_team_skill_paths(workspace_path: &Path) -> Vec<PathBuf> {
         push(extra);
     }
 
-    if let Some(team_id) = team_id.as_deref() {
-        let default_team_skills =
-            super::global_team_store::resolve_team_dir(workspace_path, team_id).join("skills");
-        push(default_team_skills);
-    } else {
-        let default_team_skills = workspace_path.join(TEAM_LINK_NAME).join("skills");
-        push(default_team_skills);
-    }
+    // The team-share drive's own `skills/` used to be a root here. It no longer
+    // has a writer: `skills/` is in the OSS sync's RETIRED_PREFIXES (it moved to
+    // the skills registry), so nothing has landed there since that migration.
+    //
+    // Dropping it is a real behaviour change on machines that synced skills
+    // *before* the migration — the retirement stopped the syncing but never
+    // deleted anything, so those files are still on disk and were still being
+    // scanned. They stop reaching agents now, which is the point: a pack the
+    // registry has since superseded is exactly the "quietly running a version
+    // the team retired" case the registry exists to end.
+    //
+    // Config-declared `/skills/paths` entries pointing into the team drive are
+    // untouched — those are somebody's explicit choice, not a default.
 
     paths
 }
@@ -1153,14 +1158,26 @@ mod tests {
         assert_eq!(state.metrics.roles_count, 0);
     }
 
+    /// Bundle naming for a team root. Declared via `opencode.json` rather than
+    /// the team drive's own `skills/`, which is no longer a root — see
+    /// `collect_team_skill_paths`.
     #[test]
-    fn scan_finds_nested_team_share_bundle_skills() {
+    fn scan_finds_nested_team_bundle_skills() {
         let dir = tempfile::tempdir().unwrap();
         let ws = dir.path();
 
-        let bundle_dir = ws
-            .join(TEAM_LINK_NAME)
-            .join("skills/superpowers/brainstorming");
+        let team_root = ws.join("team-skills");
+        std::fs::create_dir_all(&team_root).unwrap();
+        std::fs::write(
+            ws.join("opencode.json"),
+            format!(
+                r#"{{"skills":{{"paths":["{}"]}}}}"#,
+                team_root.to_string_lossy()
+            ),
+        )
+        .unwrap();
+
+        let bundle_dir = team_root.join("superpowers/brainstorming");
         std::fs::create_dir_all(&bundle_dir).unwrap();
         std::fs::write(
             bundle_dir.join("SKILL.md"),
@@ -1181,8 +1198,15 @@ mod tests {
         assert_eq!(team_skill.source.as_deref(), Some("team"));
     }
 
+    /// The team drive's `skills/` is deliberately NOT a root any more.
+    ///
+    /// `skills/` is in the OSS sync's RETIRED_PREFIXES — it moved to the skills
+    /// registry — but that retirement only stopped the syncing; it never deleted
+    /// what earlier syncs had already written. Those leftovers kept reaching
+    /// agents through this root, which is how a member ends up running a version
+    /// the team retired.
     #[test]
-    fn scan_finds_team_share_skills_without_config_paths() {
+    fn team_share_leftovers_are_no_longer_scanned() {
         let dir = tempfile::tempdir().unwrap();
         let ws = dir.path();
 
@@ -1195,12 +1219,10 @@ mod tests {
         .unwrap();
 
         let state = scan_roles_skills_state(ws).unwrap();
-        let team_skill = state
-            .skills
-            .iter()
-            .find(|skill| skill.filename == "shared-skill")
-            .expect("team share skill");
-        assert_eq!(team_skill.source.as_deref(), Some("team"));
+        assert!(
+            !state.skills.iter().any(|s| s.filename == "shared-skill"),
+            "a leftover under the team drive must not reach agents any more"
+        );
     }
 
     #[test]

--- a/apps/daemon/src/runtime/claude_skills.rs
+++ b/apps/daemon/src/runtime/claude_skills.rs
@@ -178,7 +178,39 @@ fn io_err(e: std::io::Error) -> WorkspaceControlError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::global_team_store::TEAM_LINK_NAME;
+    use crate::config::global_team_store::TEST_HOME_LOCK;
+
+    /// A workspace whose only team skill root is one it declares itself.
+    ///
+    /// Two things this has to nail down. The team drive's own `skills/` stopped
+    /// being a root (see `collect_team_skill_paths`), so the fixture declares
+    /// one through `opencode.json` instead. And `team_skill_roots` probes
+    /// `$HOME/.agents/skills`, which on a developer machine is a real directory
+    /// full of real packs — without redirecting HOME these tests symlink whatever
+    /// the person running them happens to have installed, and pass or fail by
+    /// machine. The lock is the daemon-wide one every HOME-mutating test shares.
+    fn workspace_with_team_root() -> (
+        std::sync::MutexGuard<'static, ()>,
+        tempfile::TempDir,
+        tempfile::TempDir,
+        PathBuf,
+    ) {
+        let lock = TEST_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", home.path());
+        let ws = tempfile::tempdir().unwrap();
+        let team_skills = ws.path().join("team-skills");
+        std::fs::create_dir_all(&team_skills).unwrap();
+        std::fs::write(
+            ws.path().join("opencode.json"),
+            format!(
+                r#"{{"skills":{{"paths":["{}"]}}}}"#,
+                team_skills.to_string_lossy()
+            ),
+        )
+        .unwrap();
+        (lock, home, ws, team_skills)
+    }
 
     fn write_skill(dir: &Path, slug: &str) {
         let skill_dir = dir.join(slug);
@@ -192,9 +224,7 @@ mod tests {
 
     #[test]
     fn symlinks_team_skills_into_claude_dir() {
-        let ws = tempfile::tempdir().unwrap();
-        let team_skills = ws.path().join(TEAM_LINK_NAME).join("skills");
-        std::fs::create_dir_all(&team_skills).unwrap();
+        let (_lock, _home, ws, team_skills) = workspace_with_team_root();
         write_skill(&team_skills, "team-skill");
 
         ensure_claude_team_skills(ws.path()).unwrap();
@@ -206,9 +236,7 @@ mod tests {
 
     #[test]
     fn local_skill_wins_over_team_with_same_slug() {
-        let ws = tempfile::tempdir().unwrap();
-        let team_skills = ws.path().join(TEAM_LINK_NAME).join("skills");
-        std::fs::create_dir_all(&team_skills).unwrap();
+        let (_lock, _home, ws, team_skills) = workspace_with_team_root();
         write_skill(&team_skills, "shared-name");
 
         let local = ws.path().join(".claude/skills/shared-name");
@@ -224,9 +252,7 @@ mod tests {
 
     #[test]
     fn removes_stale_team_symlinks() {
-        let ws = tempfile::tempdir().unwrap();
-        let team_skills = ws.path().join(TEAM_LINK_NAME).join("skills");
-        std::fs::create_dir_all(&team_skills).unwrap();
+        let (_lock, _home, ws, team_skills) = workspace_with_team_root();
         write_skill(&team_skills, "keep-me");
 
         ensure_claude_team_skills(ws.path()).unwrap();


### PR DESCRIPTION
`skills/` 早就进了 OSS 同步的 `RETIRED_PREFIXES`（`path_validator.rs:28`）—— 它搬去了技能 registry，所以那次迁移之后**再没有任何东西往 `teamclu-team/skills` 写过**。但它一直还留在 `collect_team_skill_paths` 的默认根里。

## 这不只是删一行死代码

那次退休**只停了同步，从没删过任何文件** —— 注释原话是「scanner 不再推送、pull 循环跳过」。所以在迁移之前同步过技能的机器上，老包还原样躺在磁盘上，而且照旧被扫描、照旧软链进 `.claude/skills`、照旧进 agent。

也就是说：**一个已经被 registry 取代的版本，在那些机器上还在被执行** —— 正是 registry 和自动跟随要终结的那种情况。

⚠️ **反过来说，这是一个真实的行为变化**：那些机器上的这些技能会无声消失。如果某个团队有技能一直没迁到 registry，它就直接不工作了。提交机上没有残留（扫过），但没法确认所有成员机器。评审时值得判断一下要不要配一条迁移提示。

## 保留的部分

- 配置里显式声明的 `/skills/paths` 不受影响 —— 那是有人主动的选择，不是默认。
- `remap_team_skill_path` 保留，它服务的正是那些声明路径（把指向团队网盘的相对路径映射到解析后的全局团队目录）。

## 顺带修掉三个测试的机器依赖

`claude_skills` 的 fixture 原本建在 `teamclu-team/skills` 下，而 `team_skill_roots` 会探 `$HOME/.agents/skills` —— **开发机上那是个装着真包的真目录**。团队根一去掉，桥接就把跑测试的人自己装的技能链进临时工作区，断言随机挂（本地实测就是这么发现的）。

更糟的是 `local_skill_wins_over_team_with_same_slug`：它会因为「压根没有团队根了」而通过，属于**因错误的理由变绿**。

现在三个 fixture 统一改用 `opencode.json` 声明的根，并按 daemon 既有约定重定向 `HOME`（共用 `TEST_HOME_LOCK`，理由见 `test_brand_env.rs` 顶部注释：两把独立的锁只会让各自那组串行、却仍然彼此竞争）。

## 验证

- `pnpm daemon:test` 全量**连跑两遍**，0 失败
- `roles_skills` 17 个用例全过（含两个改写后的）
- `rustfmt --check` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)