### PR TITLE
fix(cloud-api): self-host 上 app 部署不再借用 MinIO 凭证

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -135,9 +135,24 @@ CODEUP_BOT_USERNAME=teamclu
 APPS_DB_ADMIN_URL=
 # Account-scoped FC 3.0 data-plane host — NOT the OSS ENDPOINT above. Either
 # set APPS_FC_ENDPOINT directly, or ALIYUN_ACCOUNT_ID to have it composed as
-# <accountId>.<REGION>.fc.aliyuncs.com.
+# <accountId>.<APPS_REGION>.fc.aliyuncs.com.
 APPS_FC_ENDPOINT=
 ALIYUN_ACCOUNT_ID=
+# Where the built app artifact (apps/<appId>/code.zip) is staged. Leave blank
+# ONLY if ACCESS_KEY_ID/BUCKET/ENDPOINT above are already a real Alibaba OSS
+# profile. On a MinIO box they are not: the daemon would presign the upload
+# into the box's own bucket, which Function Compute cannot read code from, and
+# the MinIO key does not authenticate against the FC API either. Set all four
+# together (ENDPOINT defaults to https://oss-<APPS_REGION>.aliyuncs.com).
+#
+# APPS_REGION is the region of BOTH the function and this bucket — FC can only
+# load code from a bucket in its own region. The bucket must also be readable
+# by ROLE_ARN, the RAM role the function assumes.
+APPS_ACCESS_KEY_ID=
+APPS_ACCESS_KEY_SECRET=
+APPS_OSS_BUCKET=
+APPS_REGION=
+APPS_OSS_ENDPOINT=
 
 # ── iOS push (optional; all five needed together) ──────────────────────
 APNS_PRIVATE_KEY_P8=

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -310,6 +310,23 @@ services:
       # Set APPS_FC_ENDPOINT, or ALIYUN_ACCOUNT_ID to have it composed.
       APPS_FC_ENDPOINT: "${APPS_FC_ENDPOINT:-}"
       ALIYUN_ACCOUNT_ID: "${ALIYUN_ACCOUNT_ID:-}"
+      # Where the app code artifact (apps/<appId>/code.zip) is staged, and with
+      # which credentials. Separate from ACCESS_KEY_ID/BUCKET/ENDPOINT above
+      # because on this target those are MinIO's: the daemon would presign into
+      # a box-local bucket that Function Compute cannot read, and the same key
+      # would fail to authenticate against the FC API at all. Set all three to
+      # a real Alibaba OSS profile to enable app deploys here; leave them blank
+      # and deploy answers 503 naming the empty one.
+      APPS_ACCESS_KEY_ID: "${APPS_ACCESS_KEY_ID:-}"
+      APPS_ACCESS_KEY_SECRET: "${APPS_ACCESS_KEY_SECRET:-}"
+      APPS_OSS_BUCKET: "${APPS_OSS_BUCKET:-}"
+      # Region of BOTH the function and its code bucket — FC can only load code
+      # from a bucket in its own region. Defaults to REGION, which is wrong here
+      # (it labels the MinIO client), so set it alongside the profile above.
+      APPS_REGION: "${APPS_REGION:-}"
+      # Defaults to https://oss-<APPS_REGION>.aliyuncs.com; override only for a
+      # VPC/internal OSS endpoint.
+      APPS_OSS_ENDPOINT: "${APPS_OSS_ENDPOINT:-}"
       # Optional partner-integration features, all off unless set here. This
       # `environment:` map is an explicit allowlist — a var absent from it never
       # reaches the container, no matter what the box's .env says.

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -73,6 +73,17 @@ resources:
         # the OSS ENDPOINT above. Set one of the two.
         APPS_FC_ENDPOINT: ${env('APPS_FC_ENDPOINT', '')}
         ALIYUN_ACCOUNT_ID: ${env('ALIYUN_ACCOUNT_ID', '')}
+        # Optional dedicated OSS profile for app code artifacts. On THIS target
+        # everything already lives in one Alibaba account, so leaving these
+        # blank keeps using ACCESS_KEY_ID / BUCKET / REGION / ENDPOINT above —
+        # app deploys need no new configuration here. Self-host sets them
+        # because its default S3 config is a box-local MinIO that Function
+        # Compute cannot read code from.
+        APPS_ACCESS_KEY_ID: ${env('APPS_ACCESS_KEY_ID', '')}
+        APPS_ACCESS_KEY_SECRET: ${env('APPS_ACCESS_KEY_SECRET', '')}
+        APPS_OSS_BUCKET: ${env('APPS_OSS_BUCKET', '')}
+        APPS_REGION: ${env('APPS_REGION', '')}
+        APPS_OSS_ENDPOINT: ${env('APPS_OSS_ENDPOINT', '')}
         PUSH_WEBHOOK_SECRET: ${env('PUSH_WEBHOOK_SECRET')}
         CRON_TRIGGER_SECRET: ${env('CRON_TRIGGER_SECRET', '')}
         # Raw-TCP address for clients whose MQTT stack can't do WebSocket (iOS

--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -21,7 +21,7 @@ import { getFcClient, makeFcOps, resolveFcEndpoint } from "./lib/provisioning/fc
 import { startDeploy as startDeployImpl, finalizeDeploy as finalizeDeployImpl } from "./lib/provisioning/app-deploy.js";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { getS3Client, OSS_BUCKET } from "./lib/oss.js";
+import { resolveAppsOss, getAppsS3Client } from "./lib/provisioning/apps-oss.js";
 import type { JWTVerifyGetKey } from "jose";
 
 // ---------------------------------------------------------------------------
@@ -52,30 +52,48 @@ export function syncGetQueryToBody(event: any) {
 }
 
 // Deploy provisioning deps (FC function + optionally a Postgres schema).
-// Returns {} when FC is unconfigured so deployApp/finalizeDeploy surface 503
-// rather than crashing at import. APPS_FC_ENDPOINT/ALIYUN_ACCOUNT_ID counts as
-// "configured": without it every FC call fails deep inside the SDK.
+// Returns a bare `deployUnavailableReason` when FC is unconfigured so
+// deployApp/finalizeDeploy surface a 503 that NAMES the missing variable rather
+// than crashing at import — or, as before, answering with an opaque
+// "deploy provisioning not configured" that costs an SSH session to decode.
+//
+// Two things must be configured, and they are not the same thing:
+//   * the artifact profile (apps-oss.ts) — which OSS bucket and credentials the
+//     code zip is staged under. NOT automatically the deployment's default S3
+//     config, which on self-host is a box-local MinIO that FC cannot read.
+//   * APPS_FC_ENDPOINT / ALIYUN_ACCOUNT_ID / ROLE_ARN — without one of them
+//     every FC call fails deep inside the SDK.
 //
 // The apps database is a SEPARATE, softer requirement — only `data_app` needs
 // it. Static apps deploy fine without APPS_DB_ADMIN_URL; asking for one is what
 // raises the error, not merely having the module loaded.
 function makeDeployDeps() {
-  if (!process.env.ACCESS_KEY_ID) return {};
+  const resolved = resolveAppsOss();
+  if (resolved.error) return { deployUnavailableReason: resolved.error };
+  const profile = resolved.profile;
   // Same resolution the client uses, so "configured" here and "usable" there
   // cannot drift — including the ROLE_ARN fallback.
-  if (!resolveFcEndpoint()) return {};
-  const bucket = OSS_BUCKET();
-  const fcOps = makeFcOps(getFcClient(), { bucket, role: process.env.ROLE_ARN });
+  if (!resolveFcEndpoint()) {
+    return {
+      deployUnavailableReason:
+        "FC endpoint is not configured: set APPS_FC_ENDPOINT, ALIYUN_ACCOUNT_ID, or a ROLE_ARN to derive it from",
+    };
+  }
+  const bucket = profile.bucket;
+  const fcOps = makeFcOps(getFcClient(profile), { bucket, role: process.env.ROLE_ARN });
   const appsBaseUrl = process.env.APPS_DB_ADMIN_URL;
   const adminExec = appsBaseUrl ? getAppsAdminExecutor() : undefined;
-  const s3 = getS3Client();
+  const s3 = getAppsS3Client(profile);
   // 30 min: the daemon runs `pnpm install && pnpm build` between minting this
   // URL and using it, and a cold install on a modest laptop outlasts 15.
   const mintUploadUrl = (ossObjectName: string) =>
     getSignedUrl(s3 as any, new PutObjectCommand({ Bucket: bucket, Key: ossObjectName }), { expiresIn: 1800 });
   return {
+    // The caller's `region` is ignored: `fc_region` must record where the
+    // function actually went, which is the apps region, not the deployment's
+    // default REGION.
     startDeploy: (a: { appId: string; region: string }) =>
-      startDeployImpl({ mintUploadUrl }, a),
+      startDeployImpl({ mintUploadUrl }, { ...a, region: profile.region }),
     finalizeDeploy: (a: {
       appId: string;
       slug: string;

--- a/services/fc/src/lib/oss.ts
+++ b/services/fc/src/lib/oss.ts
@@ -2,15 +2,22 @@ import { S3Client } from "@aws-sdk/client-s3";
 
 // ---------------------------------------------------------------------------
 // OSS / S3-compatible environment helpers
+//
+// Each reader takes the environment as an argument (defaulting to process.env)
+// so the apps profile in provisioning/apps-oss.ts can resolve its fallbacks
+// against an injected environment without duplicating these defaults — a
+// duplicated default is how a bucket name drifts between two code paths.
 // ---------------------------------------------------------------------------
-export const ACCESS_KEY_ID = () => process.env.ACCESS_KEY_ID;
-export const ACCESS_KEY_SECRET = () => process.env.ACCESS_KEY_SECRET;
-export const OSS_BUCKET = () => process.env.BUCKET || "teamclu-sync";
-export const OSS_REGION = () => process.env.REGION || "cn-hangzhou";
-export const OSS_ENDPOINT = () =>
-  process.env.ENDPOINT || "https://oss-cn-hangzhou.aliyuncs.com";
-export const OSS_FORCE_PATH_STYLE = () => {
-  const raw = process.env.S3_FORCE_PATH_STYLE;
+type Env = NodeJS.ProcessEnv;
+
+export const ACCESS_KEY_ID = (env: Env = process.env) => env.ACCESS_KEY_ID;
+export const ACCESS_KEY_SECRET = (env: Env = process.env) => env.ACCESS_KEY_SECRET;
+export const OSS_BUCKET = (env: Env = process.env) => env.BUCKET || "teamclu-sync";
+export const OSS_REGION = (env: Env = process.env) => env.REGION || "cn-hangzhou";
+export const OSS_ENDPOINT = (env: Env = process.env) =>
+  env.ENDPOINT || "https://oss-cn-hangzhou.aliyuncs.com";
+export const OSS_FORCE_PATH_STYLE = (env: Env = process.env) => {
+  const raw = env.S3_FORCE_PATH_STYLE;
   return raw === "1" || raw === "true";
 };
 

--- a/services/fc/src/lib/pg-repo/apps.ts
+++ b/services/fc/src/lib/pg-repo/apps.ts
@@ -11,7 +11,7 @@ import { apps, workspaces, sessions } from "../../db/schema/index.js";
 import { requireActorForTeam, resolveActorForTeam } from "./authz.js";
 import { isLegalStatusTransition } from "./app-status.js";
 import { isLegalFcTransition } from "../provisioning/app-fc-status.js";
-import { appOssObjectName } from "../provisioning/app-deploy.js";
+import { appOssObjectName, deployUnavailable } from "../provisioning/app-deploy.js";
 import { ApiError } from "../http-utils.js";
 
 type AppsCtx = { userId?: string };
@@ -63,6 +63,12 @@ export type AppsRepoDeps = {
     fcFunctionName: string;
     ossObjectName: string;
   }) => Promise<{ fcEndpoint: string }>;
+  /**
+   * Why deploy provisioning is unavailable, when it is. Named variables beat
+   * the bare "not configured" this replaced: that message reached the user as a
+   * toast and told nobody which of five environment variables was empty.
+   */
+  deployUnavailableReason?: string;
 };
 
 export function makeAppsRepo(db: DbLike, ctx: AppsCtx = {}, deps: AppsRepoDeps = {}) {
@@ -215,7 +221,7 @@ export function makeAppsRepo(db: DbLike, ctx: AppsCtx = {}, deps: AppsRepoDeps =
       if (existing.provisionStatus !== "ready") {
         throw new ApiError(409, "app_not_ready", "app must be seeded (provision_status=ready) before deploy");
       }
-      if (!deps.startDeploy) throw new ApiError(503, "deploy_unavailable", "deploy provisioning not configured");
+      if (!deps.startDeploy) throw deployUnavailable(deps.deployUnavailableReason);
       try {
         const r = await deps.startDeploy({ appId, region: process.env.REGION || "cn-hangzhou" });
         const [row] = await db.update(apps).set({
@@ -243,7 +249,7 @@ export function makeAppsRepo(db: DbLike, ctx: AppsCtx = {}, deps: AppsRepoDeps =
       if (!isLegalFcTransition(existing.fcStatus, "deploying")) {
         throw new ApiError(409, "invalid_deploy_state", `cannot finalize from fc_status ${existing.fcStatus}`);
       }
-      if (!deps.finalizeDeploy) throw new ApiError(503, "deploy_unavailable", "deploy provisioning not configured");
+      if (!deps.finalizeDeploy) throw deployUnavailable(deps.deployUnavailableReason);
       await db.update(apps).set({ fcStatus: "deploying", updatedAt: new Date() }).where(eq(apps.id, appId));
       try {
         const r = await deps.finalizeDeploy({

--- a/services/fc/src/lib/provisioning/app-deploy.ts
+++ b/services/fc/src/lib/provisioning/app-deploy.ts
@@ -1,8 +1,26 @@
 import { randomBytes } from "node:crypto";
 import { ensureAppSchema } from "./app-postgres.js";
+import { ApiError } from "../http-utils.js";
 
 export function appFunctionName(appId: string): string { return `tc-app-${appId}`; }
 export function appOssObjectName(appId: string): string { return `apps/${appId}/code.zip`; }
+
+/**
+ * 503 for a deploy attempt on a deployment that cannot provision.
+ *
+ * `reason` comes from makeDeployDeps and names the empty variable. Without it
+ * this answered a bare "deploy provisioning not configured", which is what the
+ * user saw in a toast and what got written into `apps.provision_error` — true,
+ * and useless for finding out which of APPS_ACCESS_KEY_ID / APPS_OSS_BUCKET /
+ * APPS_FC_ENDPOINT was the empty one.
+ */
+export function deployUnavailable(reason?: string): ApiError {
+  return new ApiError(
+    503,
+    "deploy_unavailable",
+    reason ? `deploy provisioning not configured: ${reason}` : "deploy provisioning not configured",
+  );
+}
 
 // --- Deploy is two calls with a daemon build in between:
 //

--- a/services/fc/src/lib/provisioning/apps-oss.ts
+++ b/services/fc/src/lib/provisioning/apps-oss.ts
@@ -1,0 +1,128 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import {
+  ACCESS_KEY_ID,
+  ACCESS_KEY_SECRET,
+  OSS_BUCKET,
+  OSS_ENDPOINT,
+  OSS_FORCE_PATH_STYLE,
+  OSS_REGION,
+} from "../oss.js";
+
+/**
+ * Where an app's built code artifact (`apps/<appId>/code.zip`) is staged, and
+ * with which credentials — for BOTH the presigned upload the daemon PUTs to
+ * and the OSS object Function Compute reads the code from.
+ *
+ * Why this is not simply the deployment's default S3 config: on self-host the
+ * default one is MinIO (`ACCESS_KEY_ID`/`ACCESS_KEY_SECRET` are the MinIO root
+ * credentials, `ENDPOINT` is `https://s3.<host>`, `S3_FORCE_PATH_STYLE=1`).
+ * Alibaba Function Compute cannot read code out of a box-local MinIO bucket, so
+ * a self-host deployment that wants app deploys needs a SECOND, real Alibaba
+ * OSS profile alongside the MinIO one. On the Alibaba FC target both are the
+ * same account and no new configuration is needed at all.
+ */
+export interface AppsOssProfile {
+  bucket: string;
+  region: string;
+  endpoint: string;
+  accessKeyId: string;
+  accessKeySecret: string;
+  /** Only MinIO needs path-style addressing; Alibaba OSS is virtual-host. */
+  forcePathStyle: boolean;
+}
+
+export type AppsOssResolution =
+  | { profile: AppsOssProfile; error?: undefined }
+  | { profile?: undefined; error: string };
+
+type Env = NodeJS.ProcessEnv;
+
+const trimmed = (v: string | undefined) => v?.trim() || "";
+
+/**
+ * Region for the app's function AND its code bucket. Function Compute can only
+ * load code from an OSS bucket in its OWN region, so one knob covers both — two
+ * would let them drift into a deploy that fails inside the FC API.
+ */
+export function appsRegion(env: Env = process.env): string {
+  return trimmed(env.APPS_REGION) || OSS_REGION(env);
+}
+
+/**
+ * Resolve the apps artifact profile, or explain what is missing.
+ *
+ * Returning the reason rather than a bare null is deliberate: the failure this
+ * replaces surfaced to the user as `deploy provisioning not configured`, which
+ * named no variable and cost an SSH session to diagnose.
+ */
+export function resolveAppsOss(env: Env = process.env): AppsOssResolution {
+  const dedicatedKey = trimmed(env.APPS_ACCESS_KEY_ID);
+
+  // --- Dedicated profile: apps live in a different account than the default
+  // S3 config (the self-host shape). Nothing is inherited from ENDPOINT /
+  // S3_FORCE_PATH_STYLE — inheriting them is precisely how app code would get
+  // presigned into MinIO with an Alibaba key and 403 on upload.
+  if (dedicatedKey) {
+    const secret = trimmed(env.APPS_ACCESS_KEY_SECRET);
+    if (!secret) {
+      return { error: "APPS_ACCESS_KEY_ID is set but APPS_ACCESS_KEY_SECRET is empty" };
+    }
+    const bucket = trimmed(env.APPS_OSS_BUCKET);
+    if (!bucket) {
+      return {
+        error:
+          "APPS_ACCESS_KEY_ID is set but APPS_OSS_BUCKET is empty — app code cannot fall back to BUCKET, which belongs to the default (possibly MinIO) endpoint",
+      };
+    }
+    const region = appsRegion(env);
+    return {
+      profile: {
+        bucket,
+        region,
+        endpoint: trimmed(env.APPS_OSS_ENDPOINT) || `https://oss-${region}.aliyuncs.com`,
+        accessKeyId: dedicatedKey,
+        accessKeySecret: secret,
+        forcePathStyle: false,
+      },
+    };
+  }
+
+  // --- Shared profile: one account for everything (the Alibaba FC target).
+  const accessKeyId = ACCESS_KEY_ID(env);
+  const accessKeySecret = ACCESS_KEY_SECRET(env);
+  if (!accessKeyId || !accessKeySecret) {
+    return { error: "ACCESS_KEY_ID / ACCESS_KEY_SECRET are not set" };
+  }
+  // A bucket override alone is fine (same account, separate bucket for app
+  // code); a REGION override alone is not, because ENDPOINT still points at the
+  // old region and FC would be handed a cross-region code location.
+  if (trimmed(env.APPS_REGION) && trimmed(env.APPS_REGION) !== OSS_REGION(env)) {
+    return {
+      error:
+        `APPS_REGION (${trimmed(env.APPS_REGION)}) differs from REGION (${OSS_REGION(env)}) without a dedicated apps profile — also set APPS_ACCESS_KEY_ID / APPS_ACCESS_KEY_SECRET / APPS_OSS_BUCKET`,
+    };
+  }
+  return {
+    profile: {
+      bucket: trimmed(env.APPS_OSS_BUCKET) || OSS_BUCKET(env),
+      region: OSS_REGION(env),
+      endpoint: OSS_ENDPOINT(env),
+      accessKeyId,
+      accessKeySecret,
+      forcePathStyle: OSS_FORCE_PATH_STYLE(env),
+    },
+  };
+}
+
+/** S3 client for the app-artifact bucket — never the default team-blobs one. */
+export function getAppsS3Client(profile: AppsOssProfile): S3Client {
+  return new S3Client({
+    region: profile.region,
+    endpoint: profile.endpoint,
+    credentials: {
+      accessKeyId: profile.accessKeyId,
+      secretAccessKey: profile.accessKeySecret,
+    },
+    forcePathStyle: profile.forcePathStyle,
+  });
+}

--- a/services/fc/src/lib/provisioning/fc-client.ts
+++ b/services/fc/src/lib/provisioning/fc-client.ts
@@ -1,9 +1,13 @@
 import FcClient, * as $fc from "@alicloud/fc20230330";
 import { Config } from "@alicloud/openapi-client";
+import { appsRegion, type AppsOssProfile } from "./apps-oss.js";
 
 type FcClientInstance = InstanceType<typeof FcClient.default>;
 
-const REGION = () => process.env.REGION || "cn-hangzhou";
+// The function's region, which is the apps region — NOT necessarily the
+// deployment's default `REGION`. On self-host that one labels a MinIO client
+// and has nothing to do with where the app function runs.
+const REGION = () => appsRegion();
 
 /** Pull the account id out of a RAM role ARN: `acs:ram::<accountId>:role/<name>`. */
 export function accountIdFromRoleArn(arn: string | undefined): string | null {
@@ -45,12 +49,18 @@ export function fcEndpoint(): string {
   return endpoint;
 }
 
-export function getFcClient(): FcClientInstance {
+/**
+ * `profile` carries the Alibaba credentials the app artifacts live under. It is
+ * optional only so tests and any legacy caller keep working; production passes
+ * the resolved profile, because on a deployment whose default `ACCESS_KEY_ID`
+ * is MinIO's, those credentials do not authenticate against the FC API at all.
+ */
+export function getFcClient(profile?: AppsOssProfile): FcClientInstance {
   const endpoint = fcEndpoint();
   return new FcClient.default(new Config({
-    accessKeyId: process.env.ACCESS_KEY_ID,
-    accessKeySecret: process.env.ACCESS_KEY_SECRET,
-    regionId: REGION(),
+    accessKeyId: profile?.accessKeyId ?? process.env.ACCESS_KEY_ID,
+    accessKeySecret: profile?.accessKeySecret ?? process.env.ACCESS_KEY_SECRET,
+    regionId: profile?.region ?? REGION(),
     endpoint,
   }) as any);
 }

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -39,7 +39,7 @@ import {
   readEnvelope as readTeamEnvEnvelope,
 } from "./pg-repo/team-env-secrets.js";
 import { isLegalFcTransition } from "./provisioning/app-fc-status.js";
-import { appOssObjectName } from "./provisioning/app-deploy.js";
+import { appOssObjectName, deployUnavailable } from "./provisioning/app-deploy.js";
 import { normalizeAgentTypes } from "./agent-types.js";
 import { isListableAgentStatus, LISTABLE_AGENT_STATUS_OR_FILTER } from "./agent-status.js";
 import { computeRange, getLiteLlmSql, queryTeamUsage } from "./litellm-usage.js";
@@ -280,6 +280,9 @@ export function createSupabaseBusinessRepository(options) {
     fetchLiteLlmModels: fetchLiteLlmModelsOpt,
     startDeploy,
     finalizeDeploy,
+    // Set when the two above are absent: names the environment variable that
+    // made deploy provisioning unavailable (see makeDeployDeps in index.ts).
+    deployUnavailableReason,
     // Injectable for tests; defaults to querying the LiteLLM RDS directly.
     queryLiteLlmUsage = (litellmTeamId, range) => queryTeamUsage(getLiteLlmSql(), litellmTeamId, range),
     // Injectable for tests; defaults to the shared LiteLLM HTTP client.
@@ -3000,7 +3003,7 @@ export function createSupabaseBusinessRepository(options) {
       if (existing.provision_status !== "ready") {
         throw new ApiError(409, "app_not_ready", "app must be seeded (provision_status=ready) before deploy");
       }
-      if (!startDeploy) throw new ApiError(503, "deploy_unavailable", "deploy provisioning not configured");
+      if (!startDeploy) throw deployUnavailable(deployUnavailableReason);
       try {
         const r = await startDeploy({ appId, region: process.env.REGION || "cn-hangzhou" });
         // Persist only fc_function_name / fc_region / fc_status. The app's own
@@ -3050,7 +3053,7 @@ export function createSupabaseBusinessRepository(options) {
       if (!isLegalFcTransition(existing.fc_status, "deploying")) {
         throw new ApiError(409, "invalid_deploy_state", `cannot finalize from fc_status ${existing.fc_status}`);
       }
-      if (!finalizeDeploy) throw new ApiError(503, "deploy_unavailable", "deploy provisioning not configured");
+      if (!finalizeDeploy) throw deployUnavailable(deployUnavailableReason);
       // Mark deploying (RLS-gated UPDATE).
       await supabase.from("apps").update({ fc_status: "deploying", updated_at: new Date().toISOString() }).eq("id", appId);
       try {

--- a/services/fc/test/provisioning/apps-oss.test.ts
+++ b/services/fc/test/provisioning/apps-oss.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The apps artifact profile decides where `apps/<appId>/code.zip` is presigned
+ * to and which credentials sign it. Getting it wrong is invisible until a real
+ * deploy: the upload 403s, or Function Compute reports a code location it
+ * cannot read. These tests pin the two shapes apart — one Alibaba account for
+ * everything (the FC target), and a self-host box whose default S3 config is a
+ * local MinIO that must never be borrowed for app code.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveAppsOss, appsRegion } from "../../src/lib/provisioning/apps-oss.js";
+
+/** The Alibaba FC target: one account, no APPS_* overrides. */
+const SHARED_ENV = {
+  ACCESS_KEY_ID: "LTAI-shared",
+  ACCESS_KEY_SECRET: "shared-secret",
+  BUCKET: "teamclu-sync",
+  REGION: "cn-shenzhen",
+  ENDPOINT: "https://oss-cn-shenzhen.aliyuncs.com",
+} as NodeJS.ProcessEnv;
+
+/** The self-host box as it actually stands: ACCESS_KEY_* are MinIO's. */
+const SELF_HOST_ENV = {
+  ACCESS_KEY_ID: "minioadmin",
+  ACCESS_KEY_SECRET: "minio-secret",
+  BUCKET: "teamclu-team",
+  REGION: "cn-shenzhen",
+  ENDPOINT: "https://s3.teamclu-dev.ucar.cc",
+  S3_FORCE_PATH_STYLE: "1",
+} as NodeJS.ProcessEnv;
+
+test("no APPS_* overrides keeps the deployment's own S3 config", () => {
+  const r = resolveAppsOss(SHARED_ENV);
+  assert.equal(r.error, undefined);
+  assert.deepEqual(r.profile, {
+    bucket: "teamclu-sync",
+    region: "cn-shenzhen",
+    endpoint: "https://oss-cn-shenzhen.aliyuncs.com",
+    accessKeyId: "LTAI-shared",
+    accessKeySecret: "shared-secret",
+    forcePathStyle: false,
+  });
+});
+
+test("a bucket override alone stays on the shared account", () => {
+  // Legitimate on the FC target: same credentials, app code in its own bucket.
+  const r = resolveAppsOss({ ...SHARED_ENV, APPS_OSS_BUCKET: "teamclu-apps" });
+  assert.equal(r.profile?.bucket, "teamclu-apps");
+  assert.equal(r.profile?.accessKeyId, "LTAI-shared");
+});
+
+test("a dedicated profile does not inherit the MinIO endpoint or path style", () => {
+  // The whole point: self-host's ENDPOINT/S3_FORCE_PATH_STYLE describe MinIO.
+  // Inheriting either would presign app code into the box's own bucket, which
+  // Function Compute cannot read.
+  const r = resolveAppsOss({
+    ...SELF_HOST_ENV,
+    APPS_ACCESS_KEY_ID: "LTAI-apps",
+    APPS_ACCESS_KEY_SECRET: "apps-secret",
+    APPS_OSS_BUCKET: "teamclu-apps",
+    APPS_REGION: "cn-hangzhou",
+  });
+  assert.equal(r.error, undefined);
+  assert.deepEqual(r.profile, {
+    bucket: "teamclu-apps",
+    region: "cn-hangzhou",
+    endpoint: "https://oss-cn-hangzhou.aliyuncs.com",
+    accessKeyId: "LTAI-apps",
+    accessKeySecret: "apps-secret",
+    forcePathStyle: false,
+  });
+});
+
+test("a dedicated profile can point at an explicit (e.g. VPC) OSS endpoint", () => {
+  const r = resolveAppsOss({
+    ...SELF_HOST_ENV,
+    APPS_ACCESS_KEY_ID: "LTAI-apps",
+    APPS_ACCESS_KEY_SECRET: "apps-secret",
+    APPS_OSS_BUCKET: "teamclu-apps",
+    APPS_REGION: "cn-hangzhou",
+    APPS_OSS_ENDPOINT: "https://oss-cn-hangzhou-internal.aliyuncs.com",
+  });
+  assert.equal(r.profile?.endpoint, "https://oss-cn-hangzhou-internal.aliyuncs.com");
+});
+
+test("dedicated credentials without a bucket are refused, by name", () => {
+  // Falling back to BUCKET here would sign an Alibaba request for the MinIO
+  // bucket name and fail at upload time with NoSuchBucket.
+  const r = resolveAppsOss({
+    ...SELF_HOST_ENV,
+    APPS_ACCESS_KEY_ID: "LTAI-apps",
+    APPS_ACCESS_KEY_SECRET: "apps-secret",
+  });
+  assert.equal(r.profile, undefined);
+  assert.match(r.error!, /APPS_OSS_BUCKET/);
+});
+
+test("a dedicated key without its secret is refused, by name", () => {
+  const r = resolveAppsOss({
+    ...SELF_HOST_ENV,
+    APPS_ACCESS_KEY_ID: "LTAI-apps",
+    APPS_OSS_BUCKET: "teamclu-apps",
+  });
+  assert.equal(r.profile, undefined);
+  assert.match(r.error!, /APPS_ACCESS_KEY_SECRET/);
+});
+
+test("a region override with no dedicated profile is refused", () => {
+  // ENDPOINT still names the old region, so FC would get a cross-region code
+  // location — a failure that surfaces inside the FC API, far from the cause.
+  const r = resolveAppsOss({ ...SHARED_ENV, APPS_REGION: "cn-hangzhou" });
+  assert.equal(r.profile, undefined);
+  assert.match(r.error!, /APPS_REGION/);
+});
+
+test("no credentials at all is a named failure, not a crash", () => {
+  const r = resolveAppsOss({ BUCKET: "b" } as NodeJS.ProcessEnv);
+  assert.equal(r.profile, undefined);
+  assert.match(r.error!, /ACCESS_KEY_ID/);
+});
+
+test("appsRegion prefers APPS_REGION and falls back to REGION", () => {
+  assert.equal(appsRegion({ REGION: "cn-shenzhen" } as NodeJS.ProcessEnv), "cn-shenzhen");
+  assert.equal(
+    appsRegion({ REGION: "cn-shenzhen", APPS_REGION: "cn-hangzhou" } as NodeJS.ProcessEnv),
+    "cn-hangzhou",
+  );
+  assert.equal(appsRegion({} as NodeJS.ProcessEnv), "cn-hangzhou");
+});

--- a/services/fc/test/provisioning/fc-client.test.ts
+++ b/services/fc/test/provisioning/fc-client.test.ts
@@ -98,6 +98,25 @@ test("fcEndpoint resolves explicit host, then account id, then ROLE_ARN", () => 
   }
 });
 
+test("fcEndpoint composes the host from the APPS region, not the default one", () => {
+  // On self-host REGION labels the MinIO client; the function lives wherever
+  // its code bucket is. Composing the host from REGION would aim every FC call
+  // at a region that holds no function at all.
+  const prev = { region: process.env.REGION, apps: process.env.APPS_REGION, account: process.env.ALIYUN_ACCOUNT_ID, endpoint: process.env.APPS_FC_ENDPOINT };
+  delete process.env.APPS_FC_ENDPOINT;
+  process.env.ALIYUN_ACCOUNT_ID = "1234567890123456";
+  process.env.REGION = "cn-shenzhen";
+  try {
+    assert.equal(fcEndpoint(), "1234567890123456.cn-shenzhen.fc.aliyuncs.com");
+    process.env.APPS_REGION = "cn-hangzhou";
+    assert.equal(fcEndpoint(), "1234567890123456.cn-hangzhou.fc.aliyuncs.com");
+  } finally {
+    for (const [k, v] of [["REGION", prev.region], ["APPS_REGION", prev.apps], ["ALIYUN_ACCOUNT_ID", prev.account], ["APPS_FC_ENDPOINT", prev.endpoint]] as const) {
+      if (v === undefined) delete process.env[k]; else process.env[k] = v;
+    }
+  }
+});
+
 test("ensureHttpTrigger returns the public invoke URL", async () => {
   const { client } = fakeClient();
   const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc" });

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -2031,6 +2031,23 @@ test("apps: deployApp rejects 503 when startDeploy dep missing", async () => {
   );
 });
 
+test("apps: the 503 names the missing configuration when one is given", async () => {
+  // Without this the user's toast — and apps.provision_error — read only
+  // "deploy provisioning not configured", which named none of the five
+  // variables that can cause it and took an SSH session to decode.
+  const repo = appsRepo(
+    appsSupabase({ seed: { apps: [{ ...APP_ROW, provision_status: "ready" }] } }),
+    { deployUnavailableReason: "APPS_ACCESS_KEY_ID is set but APPS_OSS_BUCKET is empty" },
+  );
+  await assert.rejects(
+    () => repo.deployApp("app-1"),
+    (err: any) =>
+      err?.code === "deploy_unavailable" &&
+      err?.statusCode === 503 &&
+      /APPS_OSS_BUCKET/.test(err?.message ?? ""),
+  );
+});
+
 test("apps: deployApp on ready app returns awaiting_build + ossObjectName", async () => {
   const repo = appsRepo(
     appsSupabase({ seed: { apps: [{ ...APP_ROW, provision_status: "ready" }] } }),


### PR DESCRIPTION
## 问题

self-host 上点「部署」必失败。线上那条记录写得很清楚：

```
name             | website        (static_web)
provision_status | ready
provision_error  | deploy provisioning not configured
fc_status        | deploy_error
```

链路断在第一次云端调用：`makeDeployDeps()` 在 `resolveFcEndpoint()` 返回 null 时返回空 deps，repo 抛 503，桌面端把它回写成 `deploy_error`。本地压根没开始构建。

但根因不是「少配了几个变量」。apps 模块的运行时按设计就是**每个 app 一个阿里云 FC 函数 + OSS 交接代码**（`docs/specs/2026-06-14-apps-module-phase2-design.md`），而 app 产物一直复用**部署自身的默认 S3 配置**（`ACCESS_KEY_ID` / `BUCKET` / `ENDPOINT`）。在阿里云那个部署目标上这没问题 —— 同一个账号。self-host 上这套配置指向机器本地的 MinIO：

* 预签名 PUT 会把 `code.zip` 传进本机桶，函数计算读不到；
* 同一把 key 拿去调 FC API 根本认证不了。

## 改动

新增 `services/fc/src/lib/provisioning/apps-oss.ts`：app 代码产物有了独立的 OSS profile。规则是**要么全共享、要么全独立**，不做逐字段兜底 —— 一旦设了 `APPS_ACCESS_KEY_ID`，桶/区域/endpoint 全部走 `APPS_*`，绝不从 `ENDPOINT` / `S3_FORCE_PATH_STYLE` 继承。逐字段兜底恰恰是「拿阿里云 key 去签 MinIO 地址」和「拿 MinIO 桶名去签阿里云请求」这两种只能等真部署才炸的配法。

**没设 `APPS_*` 时行为与之前逐字节一致，阿里云那个部署目标零改动、零新配置。**

配套：

* `getFcClient()` 用同一 profile 的凭证和区域（之前 FC API 拿的是默认 `ACCESS_KEY_ID`）；`fc_region` 也记成真实落地区域。
* `APPS_REGION` 一个旋钮同时管函数和它的代码桶 —— FC 只能从同区域的桶加载代码，拆成两个旋钮迟早漂移。
* 503 现在点名是哪个变量空着。之前那句 `deploy provisioning not configured` 既进 toast 又进 `apps.provision_error`，五个变量里是哪个空着完全看不出来 —— 这次就是靠 SSH 上机器查出来的。supabase / pg 两条 repo 路径都改了。
* 五个新变量在 compose / `s.yaml` / `.env.example` 三处都声明（`deploy-env-parity.test.ts` 强制这一点）。

## 验证

不是推理，是在真账号（`1457752404144823`）上用**本 PR 的代码路径**跑通的：

```
resolveAppsOss()  → bucket=teamclu-app region=cn-shenzhen
                    endpoint=https://oss-cn-shenzhen.aliyuncs.com（由 region 推导）
预签名 PUT        → teamclu-app.oss-cn-shenzhen.aliyuncs.com   ← 虚拟主机风格，对
上传探针产物      → 200 OK
CreateFunction    → OK，FC 成功从该 OSS 对象读到代码
清理              → 函数已删、对象已删
```

顺带确认 **`ROLE_ARN` 不需要**：在不设角色的情况下建函数成功，FC 是用调用方凭证拉代码对象的，角色只管函数运行时身份。

单测：`tsc -p tsconfig.json` 干净；FC 全量 1225 用例 1115 过、7 红 —— 这 7 个在**未改动的 main 上一模一样地红**（3 个 env-parity 是 `FC_SUPABASE_*` / `APP_FEATURES_*` / `TRUSTED_EXTERNAL_JWT_SECRET` 没进 `.env.example`，4 个 teams 相关），本 PR 没新增任何一个，也没顺手动它们。

## 合并后

* 机器上的 `.env` 已经配好（`APPS_ACCESS_KEY_ID/SECRET`、`APPS_OSS_BUCKET=teamclu-app`、`APPS_REGION=cn-shenzhen`、`ALIYUN_ACCOUNT_ID`），原文件备份为 `.env.bak.20260818-apps`。本 PR 触发 self-host 自动部署，容器重建即生效。
* **`数据操作`(data_app) 仍然不通**，与本 PR 无关：`APPS_DB_ADMIN_URL` 的 host 会被写进函数的 `DATABASE_URL`，而 `teamclaw_apps` 只在 compose 网络里（`db:5432`），公网的 FC 函数连不到。该变量保持留空 —— 留空时报错明确，不会半途 provision 出一个连不上库的函数。`静态网页` / `演示材料` 不受影响。
* 机器上现在用的是**主账号 AK**，建议后续换成只有该桶 + FC 权限的 RAM 子用户。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
