### PR TITLE
fix(cloud-api): app 函数起不来——custom runtime 里没有 node，改挂官方 Nodejs20 层

### DIFF
--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -80,7 +80,13 @@ function makeDeployDeps() {
     };
   }
   const bucket = profile.bucket;
-  const fcOps = makeFcOps(getFcClient(profile), { bucket, role: process.env.ROLE_ARN });
+  const fcOps = makeFcOps(getFcClient(profile), {
+    bucket,
+    role: process.env.ROLE_ARN,
+    // Region of the function, which is also where its Node layer must come
+    // from — a layer ARN is region-scoped.
+    region: profile.region,
+  });
   const appsBaseUrl = process.env.APPS_DB_ADMIN_URL;
   const adminExec = appsBaseUrl ? getAppsAdminExecutor() : undefined;
   const s3 = getAppsS3Client(profile);

--- a/services/fc/src/lib/provisioning/fc-client.ts
+++ b/services/fc/src/lib/provisioning/fc-client.ts
@@ -65,8 +65,31 @@ export function getFcClient(profile?: AppsOssProfile): FcClientInstance {
   }) as any);
 }
 
-export interface FcOpsConfig { bucket: string; role: string | undefined; }
+export interface FcOpsConfig { bucket: string; role: string | undefined; region: string; }
 export interface EnsureFunctionArgs { ossObjectName: string; env: Record<string, string>; }
+
+/**
+ * The custom runtime image ships NO node at all — not merely one that is off
+ * PATH. `command: ["node"]` therefore failed EVERY deploy at instance start
+ * with `CAFileNotFound: the file node is not exist`, and `/bin/sh -c 'exec
+ * node …'` failed the same way with `exec: node: not found` (exit 127). The
+ * standard `nodejs20` runtime is not an escape either: it rejects a startup
+ * command outright (`customRuntimeConfig not supported for non-custom
+ * runtime`), because it is handler-based.
+ *
+ * What works is the official Node.js layer. It mounts under `/opt/nodejs20`
+ * and does NOT extend PATH (verified in a live instance: PATH is still
+ * `/usr/local/sbin:…:/bin`), so the start command must name the binary by
+ * absolute path.
+ *
+ * The version is pinned rather than floating: a layer version is immutable, so
+ * pinning is what keeps a redeploy of an untouched app from silently changing
+ * its Node runtime underneath it.
+ */
+export const NODE_BIN = "/opt/nodejs20/bin/node";
+export function nodejsLayerArn(region: string): string {
+  return `acs:fc:${region}:official:layers/Nodejs20/versions/3`;
+}
 
 function isNotFound(e: any): boolean {
   return e?.statusCode === 404 || e?.code === "FunctionNotFound" || e?.data?.Code === "FunctionNotFound";
@@ -94,13 +117,14 @@ export function makeFcOps(client: any, cfg: FcOpsConfig) {
             memorySize: 512, cpu: 0.5, timeout: 60, diskSize: 512,
             role: cfg.role,
             environmentVariables: args.env,
+            layers: [nodejsLayerArn(cfg.region)],
             customRuntimeConfig: new $fc.CustomRuntimeConfig({
               // The daemon zips the CONTENTS of the build's `.output` directory
               // (app_build.rs `zip_dir(workdir.join(".output"))`), so the server
               // entry sits at `server/index.mjs` inside the artifact — a
               // `.output/` prefix here points at a path that is never unpacked
               // and the function never boots.
-              command: ["node"], args: ["server/index.mjs"], port: 9000,
+              command: [NODE_BIN], args: ["server/index.mjs"], port: 9000,
             }),
             code: codeLocation(args.ossObjectName),
           }),
@@ -110,9 +134,18 @@ export function makeFcOps(client: any, cfg: FcOpsConfig) {
       }
     },
     async updateFunctionCode(functionName: string, args: EnsureFunctionArgs): Promise<void> {
+      // The layer and the start command are re-sent on every update, not just
+      // at create. Functions created before the Node layer existed boot with
+      // `command: ["node"]` against an image that has no node, and a code-only
+      // update leaves them broken forever — the redeploy the user reaches for
+      // would report success and change nothing about why the page 500s.
       await client.updateFunction(functionName, new $fc.UpdateFunctionRequest({
         body: new $fc.UpdateFunctionInput({
           environmentVariables: args.env,
+          layers: [nodejsLayerArn(cfg.region)],
+          customRuntimeConfig: new $fc.CustomRuntimeConfig({
+            command: [NODE_BIN], args: ["server/index.mjs"], port: 9000,
+          }),
           code: codeLocation(args.ossObjectName),
         }),
       }));

--- a/services/fc/test/provisioning/fc-client.test.ts
+++ b/services/fc/test/provisioning/fc-client.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { makeFcOps, fcEndpoint, accountIdFromRoleArn } from "../../src/lib/provisioning/fc-client.js";
+import { makeFcOps, fcEndpoint, accountIdFromRoleArn, NODE_BIN, nodejsLayerArn } from "../../src/lib/provisioning/fc-client.js";
 
 function fakeClient(overrides: Record<string, any> = {}) {
   const calls: any[] = [];
@@ -17,7 +17,7 @@ function fakeClient(overrides: Record<string, any> = {}) {
 test("ensureFunction creates when GetFunction 404s", async () => {
   const notFound = Object.assign(new Error("not found"), { statusCode: 404, code: "FunctionNotFound" });
   const { client, calls } = fakeClient({ getFunction: async () => { throw notFound; } });
-  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc" });
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
   await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
   assert.ok(calls.some((c) => c[0] === "createFunction"));
   assert.ok(!calls.some((c) => c[0] === "updateFunction"));
@@ -25,7 +25,7 @@ test("ensureFunction creates when GetFunction 404s", async () => {
 
 test("ensureFunction updates code when the function already exists", async () => {
   const { client, calls } = fakeClient();
-  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc" });
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
   await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
   assert.ok(calls.some((c) => c[0] === "updateFunction"));
   assert.ok(!calls.some((c) => c[0] === "createFunction"));
@@ -37,20 +37,52 @@ test("ensureFunction points the custom runtime at the artifact's own layout", as
   // the function silently fails to boot.
   const notFound = Object.assign(new Error("not found"), { statusCode: 404, code: "FunctionNotFound" });
   const { client, calls } = fakeClient({ getFunction: async () => { throw notFound; } });
-  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc" });
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
   await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
   const create = calls.find((c) => c[0] === "createFunction");
   const runtimeCfg = create[1].body.customRuntimeConfig;
-  assert.deepEqual(runtimeCfg.command, ["node"]);
   assert.deepEqual(runtimeCfg.args, ["server/index.mjs"]);
   assert.equal(runtimeCfg.port, 9000);
+});
+
+test("ensureFunction starts node from the layer, by absolute path", async () => {
+  // The custom runtime image has no node — a bare "node" (and even
+  // `/bin/sh -c 'exec node …'`) dies at instance start with exit 127. The
+  // official layer supplies one under /opt and does not touch PATH.
+  const notFound = Object.assign(new Error("not found"), { statusCode: 404, code: "FunctionNotFound" });
+  const { client, calls } = fakeClient({ getFunction: async () => { throw notFound; } });
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
+  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
+  const create = calls.find((c) => c[0] === "createFunction")[1].body;
+  assert.deepEqual(create.customRuntimeConfig.command, [NODE_BIN]);
+  assert.match(NODE_BIN, /^\//, "must be an absolute path, not a PATH lookup");
+  assert.deepEqual(create.layers, ["acs:fc:cn-shenzhen:official:layers/Nodejs20/versions/3"]);
+});
+
+test("nodejsLayerArn is region-scoped", () => {
+  // A layer ARN names its region; the function's region is the apps region, so
+  // borrowing another region's ARN makes CreateFunction fail on a valid config.
+  assert.equal(nodejsLayerArn("cn-hangzhou"), "acs:fc:cn-hangzhou:official:layers/Nodejs20/versions/3");
+});
+
+test("ensureFunction re-sends the layer and start command on the update path", async () => {
+  // Functions created before the layer existed boot with a command that cannot
+  // resolve. A code-only update would leave them broken through every redeploy
+  // the user tries — the update has to repair the config, not just the code.
+  const { client, calls } = fakeClient();
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
+  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
+  const upd = calls.find((c) => c[0] === "updateFunction")[2].body;
+  assert.deepEqual(upd.customRuntimeConfig.command, [NODE_BIN]);
+  assert.deepEqual(upd.customRuntimeConfig.args, ["server/index.mjs"]);
+  assert.deepEqual(upd.layers, ["acs:fc:cn-shenzhen:official:layers/Nodejs20/versions/3"]);
 });
 
 test("ensureFunction re-sends environmentVariables on the update path", async () => {
   // A redeploy rotates the app's DB password, so the env must be rewritten
   // alongside the code rather than assumed to survive.
   const { client, calls } = fakeClient();
-  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc" });
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
   await ops.ensureFunction("tc-app-1", {
     ossObjectName: "apps/1/code.zip",
     env: { PORT: "9000", DATABASE_URL: "postgres://app_x:new-pw@h/teamclu_apps" },
@@ -119,7 +151,7 @@ test("fcEndpoint composes the host from the APPS region, not the default one", (
 
 test("ensureHttpTrigger returns the public invoke URL", async () => {
   const { client } = fakeClient();
-  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc" });
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
   const url = await ops.ensureHttpTrigger("tc-app-1");
   assert.equal(url, "https://fn.example.fcapp.run");
 });
@@ -127,7 +159,7 @@ test("ensureHttpTrigger returns the public invoke URL", async () => {
 test("ensureHttpTrigger swallows 'trigger already exists' then reads the URL", async () => {
   const conflict = Object.assign(new Error("exists"), { statusCode: 409, code: "TriggerAlreadyExists" });
   const { client } = fakeClient({ createTrigger: async () => { throw conflict; } });
-  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc" });
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
   const url = await ops.ensureHttpTrigger("tc-app-1");
   assert.equal(url, "https://fn.example.fcapp.run");
 });


### PR DESCRIPTION
接 #970。那个 PR 让部署跑通了，但函数**起不来**：打开 live URL 报

```json
{"Code":"CAFileNotFound","Message":"Failed to start function instance. Error: the file node is not exist"}
```

## 根因

不是 `command[0]` 写法问题 —— **`custom.debian10` 镜像里根本没有 node 这个二进制**。在真实函数实例里逐条验过：

| 试法 | 结果 |
|---|---|
| `command: ["node"]`（原代码） | `CAFileNotFound: the file node is not exist` |
| `/bin/sh -c 'exec node …'`（让 shell 查 PATH） | `exec: node: not found`，退出码 127 |
| 标准 `nodejs20` 运行时 + 启动命令 | `InvalidArgument: customRuntimeConfig not supported for non-custom runtime`（它是 handler 型，不接受启动命令） |
| `/bin/sh -c 'ls /opt; echo $PATH'` | 镜像 PATH 是 `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`，没有任何 node |

也就是说这条路径**从第一天起就跑不起来**，只是之前部署在更早一步就 503 了，从没走到启动这步。

## 改法

挂阿里云官方的 **`Nodejs20` 层**（Node.js 20.11.0，专为 custom runtime 提供），用绝对路径启动：

```
layers:  acs:fc:<region>:official:layers/Nodejs20/versions/3
command: /opt/nodejs20/bin/node   args: server/index.mjs
```

层挂在 `/opt/nodejs20` 且**不改 PATH**（在实例里验证：挂载后 `/opt/nodejs20/bin/` 有 node/npm/npx/yarn，但 PATH 没变），所以必须写绝对路径。层版本写死不浮动 —— 层版本是不可变的，写死才能保证重新部署不会悄悄换掉一个没动过的 app 的 Node 运行时。

**更新路径也必须发 `layers` + `customRuntimeConfig`**。之前 `updateFunctionCode` 只发 env + code，那些已经建出来的坏函数会永远坏下去：用户点「重新部署」会报成功，而函数起不来的原因一点没变。这是本 PR 里最容易漏的一半。

## 验证

用**线上那个 app 的真实产物**（`teamclu-app` 桶里的 `code.zip`）建临时函数实测：

```
命令 /opt/nodejs20/bin/node + Nodejs20 层  →  HTTP 200，返回 <!doctype html> 页面
```

临时函数与触发器已删除。单测 12/12 过（新增 3 条：绝对路径、层 ARN 按区域、更新路径也发这两项），`tsc -p tsconfig.json` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
