### PR TITLE
feat(apps): 部署的 app 挂上自己的二级域名，证书按需签发

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -153,6 +153,18 @@ APPS_ACCESS_KEY_SECRET=
 APPS_OSS_BUCKET=
 APPS_REGION=
 APPS_OSS_ENDPOINT=
+# Parent domain for per-app vanity hostnames: an app is reachable at
+# <slug>-<id8>.<this>, proxied by Caddy to its Function Compute trigger (whose
+# own hostname carries a random suffix and is not guessable).
+#
+# Needs a WILDCARD A record for *.<this> pointing at this box. Give it its own
+# label (apps.<base domain>) rather than the base domain itself — a wildcard on
+# the base would swallow api/supabase/mqtt/s3/studio/emqx.
+#
+# Certificates are issued on demand, per hostname, on first request; Caddy asks
+# FC (/internal/caddy/ask) before each one, so unknown names never reach ACME.
+# Blank = feature off: apps keep their raw .fcapp.run URL.
+APPS_PUBLIC_DOMAIN=
 
 # ── iOS push (optional; all five needed together) ──────────────────────
 APNS_PRIVATE_KEY_P8=

--- a/deploy/self-host/caddy/Caddyfile
+++ b/deploy/self-host/caddy/Caddyfile
@@ -5,6 +5,17 @@
 	# Force RSA certs — ECDSA with Let's Encrypt YE1 chain causes
 	# ERR_SSL_VERSION_OR_CIPHER_MISMATCH on some clients (incl. CN networks).
 	key_type rsa2048
+
+	# Deployed apps get a certificate on first request rather than from a fixed
+	# list — there is no list, apps come and go. `ask` is what keeps that from
+	# being an open cert-minting endpoint: FC answers 404 for any hostname that
+	# is not a deployed app, and Caddy then declines the handshake instead of
+	# going to Let's Encrypt. Without it, anyone pointing a name at this box
+	# could burn the rate limit, which counts per REGISTERED domain and is
+	# therefore shared with api/supabase/mqtt/s3 on the same name.
+	on_demand_tls {
+		ask http://fc:9000/internal/caddy/ask
+	}
 }
 
 # CADDY_SITE_SCHEME is "http://" when CADDY_TLS_MODE=off (gen-secrets.sh), empty
@@ -74,4 +85,26 @@
 {$CADDY_SITE_SCHEME}{$EMQX_DASHBOARD_DOMAIN} {
 	{$CADDY_SITE_TLS}
 	reverse_proxy emqx:18083
+}
+
+# Deployed apps: <slug>-<id8>.{$APPS_DOMAIN}
+#
+# The wildcard sits one level DOWN, on its own `apps.` label, and never on the
+# bare base domain: `*.teamclu-dev.ucar.cc` would swallow api/supabase/mqtt/s3/
+# studio/emqx and hand every typo'd hostname to on-demand TLS.
+#
+# Everything goes to FC rather than straight to Function Compute because the
+# trigger hostname carries a random suffix (tc-app-<id>-<random>.fcapp.run) and
+# cannot be derived from the request — FC looks the app up by Host and streams
+# the response through. That also means an app's routes survive a Caddy restart
+# with no reconciliation: there is nothing per-app in this file.
+#
+# APPS_DOMAIN falls back to apps.localhost (internal CA, no ACME) on a box that
+# has not set one, for the same reason S3_DOMAIN does: a nameless block is read
+# as global configuration and Caddy refuses to start.
+{$CADDY_SITE_SCHEME}*.{$APPS_DOMAIN} {
+	tls {
+		on_demand
+	}
+	reverse_proxy fc:9000
 }

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -327,6 +327,11 @@ services:
       # Defaults to https://oss-<APPS_REGION>.aliyuncs.com; override only for a
       # VPC/internal OSS endpoint.
       APPS_OSS_ENDPOINT: "${APPS_OSS_ENDPOINT:-}"
+      # Parent domain for per-app vanity hostnames
+      # (<slug>-<id8>.<this>). Blank = feature off: apps keep their raw
+      # Function Compute trigger URL and Caddy never asks about a certificate.
+      # Requires a wildcard A record for *.<this> pointing at this box.
+      APPS_PUBLIC_DOMAIN: "${APPS_PUBLIC_DOMAIN:-}"
       # Optional partner-integration features, all off unless set here. This
       # `environment:` map is an explicit allowlist — a var absent from it never
       # reaches the container, no matter what the box's .env says.
@@ -496,6 +501,9 @@ services:
       # crash-loops Caddy and takes every site down with it. `.localhost` is
       # served by Caddy's internal CA, so the placeholder never touches ACME.
       S3_DOMAIN: "${S3_DOMAIN:-s3.localhost}"
+      # Parent of every deployed app's hostname. Same never-empty rule as
+      # S3_DOMAIN above — `*.` with nothing after it is a nameless block.
+      APPS_DOMAIN: "${APPS_PUBLIC_DOMAIN:-apps.localhost}"
       ACME_EMAIL: "${ACME_EMAIL}"
       CADDY_GLOBAL_TLS: "${CADDY_GLOBAL_TLS:-}"
       CADDY_SITE_TLS: "${CADDY_SITE_TLS:-}"

--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -5255,7 +5255,17 @@ components:
             - type: "null"
         fcEndpoint:
           type: [string, "null"]
-          description: Public URL of the deployed app; set once `fcStatus` is `live`.
+          description: >-
+            Function Compute trigger URL of the deployed app; set once
+            `fcStatus` is `live`. Its hostname carries a random suffix, so it
+            cannot be derived from the app — prefer `publicUrl` when present.
+        publicUrl:
+          type: [string, "null"]
+          description: >-
+            Vanity URL (`https://<slug>-<first 8 of id>.<apps domain>`) served
+            by the deployment's own reverse proxy. Derived, never stored, and
+            null when the deployment has no apps domain configured — then
+            `fcEndpoint` is the only address the app has.
         fcFunctionName: { type: [string, "null"] }
         fcRegion: { type: [string, "null"] }
         createdAt: { type: string, format: date-time }

--- a/packages/app/src/components/sidebar/AppsListColumn.tsx
+++ b/packages/app/src/components/sidebar/AppsListColumn.tsx
@@ -107,23 +107,28 @@ function AppItemRow({ app, onClick, onRename }: RowProps) {
     if (path) await revealInFinder(path)
   }, [app.id])
 
+  // The address we hand the user is the vanity one when this deployment has an
+  // apps domain — `publicUrl` is null otherwise, and the raw Function Compute
+  // trigger URL (random suffix and all) remains the only way in.
+  const shareUrl = app.publicUrl ?? app.fcEndpoint
+
   const handleOpenUrl = React.useCallback(async (e: React.SyntheticEvent) => {
     e.stopPropagation()
-    if (!app.fcEndpoint) return
+    if (!shareUrl) return
     const { open } = await import('@tauri-apps/plugin-shell')
-    await open(app.fcEndpoint)
-  }, [app.fcEndpoint])
+    await open(shareUrl)
+  }, [shareUrl])
 
   const handleCopyUrl = React.useCallback(async (e: React.SyntheticEvent) => {
     e.stopPropagation()
-    if (!app.fcEndpoint) return
+    if (!shareUrl) return
     try {
-      await navigator.clipboard.writeText(app.fcEndpoint)
+      await navigator.clipboard.writeText(shareUrl)
     } catch {
       const { toast } = await import('sonner')
       toast.error(t('apps.urlCopyFailed', '复制失败'))
     }
-  }, [app.fcEndpoint, t])
+  }, [shareUrl, t])
 
   return (
     <div className="group relative flex items-stretch">

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -924,6 +924,9 @@ export interface AppRow {
   provisionStatus: string;
   fcStatus: string | null;
   fcEndpoint: string | null;
+  /** Vanity URL (`<slug>-<id8>.<apps domain>`), or null on a deployment that
+   *  has no apps domain — then `fcEndpoint` is the only address there is. */
+  publicUrl: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -84,6 +84,10 @@ resources:
         APPS_OSS_BUCKET: ${env('APPS_OSS_BUCKET', '')}
         APPS_REGION: ${env('APPS_REGION', '')}
         APPS_OSS_ENDPOINT: ${env('APPS_OSS_ENDPOINT', '')}
+        # Parent domain for per-app vanity hostnames. Only self-host has the
+        # reverse proxy that terminates them, so this is normally blank here —
+        # declared so the two targets stay in step (deploy-env-parity.test.ts).
+        APPS_PUBLIC_DOMAIN: ${env('APPS_PUBLIC_DOMAIN', '')}
         PUSH_WEBHOOK_SECRET: ${env('PUSH_WEBHOOK_SECRET')}
         CRON_TRIGGER_SECRET: ${env('CRON_TRIGGER_SECRET', '')}
         # Raw-TCP address for clients whose MQTT stack can't do WebSocket (iOS

--- a/services/fc/src/app.ts
+++ b/services/fc/src/app.ts
@@ -8,11 +8,15 @@ import { isRateLimited, resolveClientIp } from "./lib/rate-limit.js";
 import { handleSyncRequest } from "./lib/legacy-sync.js";
 import { resolveBackendKind } from "./lib/backend-kind.js";
 import * as admin from "./lib/admin-handlers.js";
+import { isServable, proxyToApp, type LookupVanityApp } from "./lib/apps-vanity.js";
+import { parseAppPublicHost } from "./lib/apps-public-host.js";
 
 export type AppDeps = {
   createRepository: (args: { accessToken: string }) => unknown;
   createAuthRepository: () => unknown;
   runCron?: (task: string) => Promise<unknown>;
+  /** Resolves a vanity app host to its row; injected so tests need no database. */
+  lookupVanityApp?: LookupVanityApp;
 };
 
 function sendLegacy(_c: any, r: { statusCode: number; headers?: Record<string, string>; body: string }) {
@@ -24,6 +28,42 @@ function sendLegacy(_c: any, r: { statusCode: number; headers?: Record<string, s
 
 export function createApp(deps: AppDeps): Hono {
   const app = new Hono();
+
+  // --- Deployed apps on their own hostnames -------------------------------
+  //
+  // Registered FIRST, ahead of CORS and the rate limiter, because these
+  // requests are not Cloud API traffic at all: the response belongs to the
+  // user's app, and adding our CORS headers or counting a page load against an
+  // API budget would both be wrong.
+  //
+  // Caddy sends every `*.<APPS_PUBLIC_DOMAIN>` request here (it cannot know an
+  // app's Function Compute URL — the trigger hostname carries a random suffix),
+  // and asks this same service whether a hostname deserves a certificate.
+  if (deps.lookupVanityApp) {
+    const lookup = deps.lookupVanityApp;
+
+    // Caddy's on-demand TLS gate. Answer 200 only for a hostname that really
+    // maps to an app; anything else must 404 so Caddy declines the handshake
+    // instead of requesting a certificate for it.
+    app.get("/internal/caddy/ask", async (c) => {
+      const domain = c.req.query("domain") ?? "";
+      if (!parseAppPublicHost(domain)) return c.text("not an app host", 404);
+      const found = await lookup(domain);
+      return found ? c.text("ok", 200) : c.text("no such app", 404);
+    });
+
+    app.use("*", async (c, next) => {
+      const host = c.req.header("host");
+      if (!parseAppPublicHost(host)) return next();
+      const target = await lookup(host!);
+      // A hostname whose app exists but has never deployed is a real app with
+      // nothing to serve yet — say so, rather than proxying to null.
+      if (!isServable(target)) {
+        return c.text(target ? "app is not deployed yet" : "no such app", 404);
+      }
+      return proxyToApp(c.req.raw, target.fcEndpoint);
+    });
+  }
 
   // CORS — two modes depending on deployment:
   //

--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -22,6 +22,7 @@ import { startDeploy as startDeployImpl, finalizeDeploy as finalizeDeployImpl } 
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { resolveAppsOss, getAppsS3Client } from "./lib/provisioning/apps-oss.js";
+import { makeVanityLookup } from "./lib/apps-vanity.js";
 import type { JWTVerifyGetKey } from "jose";
 
 // ---------------------------------------------------------------------------
@@ -185,6 +186,9 @@ const app = createApp({
   createRepository: makeBusinessRepoFactory(resolveBackendKind()),
   createAuthRepository: makeAuthRepoFactory(resolveBackendKind()),
   runCron: (task: string) => runCronTask(getDb(), task),
+  // Reads the control-plane database directly on both backends: the vanity
+  // host and the Caddy `ask` probe carry no bearer token to scope a repo with.
+  lookupVanityApp: makeVanityLookup(getDb),
 });
 
 const honoHandler = handle(app);

--- a/services/fc/src/lib/apps-public-host.ts
+++ b/services/fc/src/lib/apps-public-host.ts
@@ -1,0 +1,62 @@
+/**
+ * Vanity hostnames for deployed apps: `<slug>-<id8>.<APPS_PUBLIC_DOMAIN>`.
+ *
+ * Why the id suffix rather than the bare slug: `apps_team_slug_uniq` makes a
+ * slug unique WITHIN a team, not globally, so two teams can both own `website`
+ * — and a hostname has no team in it. Eight hex characters of the app's uuid
+ * make the label unique without making it unreadable.
+ *
+ * Why one label and not a nested one: the wildcard certificate/route covers
+ * exactly one level under the domain. `a.b.<domain>` would not match
+ * `*.<domain>`, so a label containing a dot is rejected rather than served
+ * with a certificate that cannot exist.
+ */
+type Env = NodeJS.ProcessEnv;
+
+/** Blank disables vanity hostnames entirely — the app keeps its FC trigger URL. */
+export const appsPublicDomain = (env: Env = process.env) => env.APPS_PUBLIC_DOMAIN?.trim() || "";
+
+export const ID_PREFIX_LEN = 8;
+
+export function appPublicLabel(slug: string, appId: string): string {
+  return `${slug}-${appId.slice(0, ID_PREFIX_LEN)}`;
+}
+
+/** Public URL for an app, or null when this deployment has no apps domain. */
+export function appPublicUrl(
+  slug: string | null | undefined,
+  appId: string | null | undefined,
+  env: Env = process.env,
+): string | null {
+  const domain = appsPublicDomain(env);
+  if (!domain || !slug || !appId) return null;
+  return `https://${appPublicLabel(slug, appId)}.${domain}`;
+}
+
+/**
+ * Split a request's Host back into the parts that identify an app, or null
+ * when the host is not a vanity app host at all (the Cloud API's own domain,
+ * an IP, the container name — all of which must fall through to the API).
+ */
+export function parseAppPublicHost(
+  host: string | null | undefined,
+  env: Env = process.env,
+): { slug: string; idPrefix: string } | null {
+  const domain = appsPublicDomain(env);
+  if (!domain || !host) return null;
+  // Host carries the port on non-443 listeners; the label never does.
+  const name = host.split(":")[0].trim().toLowerCase();
+  const suffix = `.${domain.toLowerCase()}`;
+  if (!name.endsWith(suffix)) return null;
+  const label = name.slice(0, -suffix.length);
+  // Exactly one level: `*.<domain>` matches `x.<domain>`, never `x.y.<domain>`.
+  if (!label || label.includes(".")) return null;
+  const cut = label.lastIndexOf("-");
+  if (cut <= 0) return null;
+  const slug = label.slice(0, cut);
+  const idPrefix = label.slice(cut + 1);
+  // uuid text is lowercase hex; anything else cannot be an app id prefix and
+  // must not reach the database as a LIKE pattern.
+  if (!new RegExp(`^[0-9a-f]{${ID_PREFIX_LEN}}$`).test(idPrefix)) return null;
+  return { slug, idPrefix };
+}

--- a/services/fc/src/lib/apps-vanity.ts
+++ b/services/fc/src/lib/apps-vanity.ts
@@ -1,0 +1,113 @@
+import { and, eq, sql } from "drizzle-orm";
+import { apps } from "../db/schema/index.js";
+import { parseAppPublicHost } from "./apps-public-host.js";
+
+/**
+ * Serving deployed apps on `<slug>-<id8>.<APPS_PUBLIC_DOMAIN>`.
+ *
+ * Two halves, both driven by the request's Host:
+ *
+ *   * `ask`   — Caddy asks before completing a TLS handshake for a hostname it
+ *               has no certificate for. Answering 404 for unknown names is the
+ *               only thing standing between on-demand issuance and an open
+ *               cert-minting endpoint: anyone can point a request at this box,
+ *               and Let's Encrypt's rate limit is per REGISTERED domain, shared
+ *               with api/supabase/mqtt on the same name.
+ *   * `proxy` — forward the request to that app's Function Compute trigger.
+ *
+ * The lookup deliberately does NOT go through the request-scoped repository:
+ * both halves are unauthenticated by nature (a browser hitting a public page,
+ * and Caddy itself), so there is no bearer token to scope RLS with. It reads
+ * the control-plane database directly, like the cron and push paths do.
+ */
+export interface VanityApp {
+  id: string;
+  slug: string;
+  fcEndpoint: string | null;
+  fcStatus: string | null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DbLike = any;
+
+export type LookupVanityApp = (host: string) => Promise<VanityApp | null>;
+
+export function makeVanityLookup(getDb: () => DbLike): LookupVanityApp {
+  return async (host: string) => {
+    const parsed = parseAppPublicHost(host);
+    if (!parsed) return null;
+    const rows = await getDb()
+      .select({
+        id: apps.id,
+        slug: apps.slug,
+        fcEndpoint: apps.fcEndpoint,
+        fcStatus: apps.fcStatus,
+      })
+      .from(apps)
+      .where(and(eq(apps.slug, parsed.slug), sql`${apps.id}::text like ${parsed.idPrefix + "%"}`))
+      // Two rows means two teams whose slugs AND id prefixes collide. Serving
+      // either one would be a coin flip between different teams' apps, so serve
+      // neither — `limit(2)` is what makes that case visible at all.
+      .limit(2);
+    if (rows.length !== 1) return null;
+    return rows[0] as VanityApp;
+  };
+}
+
+/** A deployed app is servable only once it has a live endpoint to serve from. */
+export function isServable(app: VanityApp | null): app is VanityApp & { fcEndpoint: string } {
+  return !!app && app.fcStatus === "live" && !!app.fcEndpoint;
+}
+
+// Hop-by-hop headers are connection-scoped: forwarding them corrupts the next
+// hop's framing (RFC 9110 §7.6.1). `host` is dropped separately because fetch
+// derives it from the upstream URL — and FC routes on it, so passing the
+// client's Host through would reach the wrong function or none at all.
+const HOP_BY_HOP = [
+  "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+  "te", "trailer", "transfer-encoding", "upgrade",
+];
+
+function strip(headers: Headers): Headers {
+  const out = new Headers(headers);
+  for (const h of HOP_BY_HOP) out.delete(h);
+  return out;
+}
+
+/**
+ * Proxy one request to the app's FC trigger, streaming both ways.
+ *
+ * Response headers pass through untouched apart from hop-by-hop ones: the app
+ * owns its own content-type, caching and CORS, and second-guessing them here
+ * is how a proxy starts breaking the very apps it serves.
+ */
+export async function proxyToApp(
+  request: Request,
+  endpoint: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  const incoming = new URL(request.url);
+  const upstream = new URL(endpoint);
+  upstream.pathname = incoming.pathname;
+  upstream.search = incoming.search;
+
+  const headers = strip(request.headers);
+  headers.delete("host");
+  headers.set("x-forwarded-host", incoming.host);
+  headers.set("x-forwarded-proto", incoming.protocol.replace(":", ""));
+
+  const hasBody = request.method !== "GET" && request.method !== "HEAD";
+  const res = await fetchImpl(upstream, {
+    method: request.method,
+    headers,
+    body: hasBody ? request.body : undefined,
+    // Node's fetch refuses a streamed body without it, and buffering instead
+    // would hold whole uploads in the API's memory.
+    ...(hasBody ? { duplex: "half" } : {}),
+    // A 302 belongs to the app; following it here would silently rewrite the
+    // app's own navigation into a response from a different URL.
+    redirect: "manual",
+  } as RequestInit);
+
+  return new Response(res.body, { status: res.status, headers: strip(res.headers) });
+}

--- a/services/fc/src/lib/pg-repo/apps.ts
+++ b/services/fc/src/lib/pg-repo/apps.ts
@@ -12,6 +12,7 @@ import { requireActorForTeam, resolveActorForTeam } from "./authz.js";
 import { isLegalStatusTransition } from "./app-status.js";
 import { isLegalFcTransition } from "../provisioning/app-fc-status.js";
 import { appOssObjectName, deployUnavailable } from "../provisioning/app-deploy.js";
+import { appPublicUrl } from "../apps-public-host.js";
 import { ApiError } from "../http-utils.js";
 
 type AppsCtx = { userId?: string };
@@ -31,7 +32,7 @@ function slugify(name: string): string {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const iso = (v: any): string | null => (v ? new Date(v).toISOString() : null);
 
-// Shared mapper — exposes EXACTLY the 12 canonical app fields. Reused by
+// Shared mapper — exposes EXACTLY the canonical app fields. Reused by
 // listApps/updateApp in the next task.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function mapApp(r: any) {
@@ -46,6 +47,9 @@ function mapApp(r: any) {
     provisionStatus: r.provisionStatus,
     fcStatus: r.fcStatus ?? null,
     fcEndpoint: r.fcEndpoint ?? null,
+    // Derived from slug + id, never stored — see the same field in
+    // supabase-repo/shared.ts. Null when this deployment has no apps domain.
+    publicUrl: appPublicUrl(r.slug, r.id),
     fcFunctionName: r.fcFunctionName ?? null,
     fcRegion: r.fcRegion ?? null,
     createdAt: iso(r.createdAt)!,

--- a/services/fc/src/lib/supabase-repo/shared.ts
+++ b/services/fc/src/lib/supabase-repo/shared.ts
@@ -3,6 +3,7 @@
 import WebSocket from "ws";
 
 import { ApiError } from "../http-utils.js";
+import { appPublicUrl } from "../apps-public-host.js";
 
 // FC runtime is Node 20 which lacks native WebSocket. supabase-js v2.45+ tries
 // to construct a RealtimeClient at createClient() time and throws without a
@@ -113,7 +114,7 @@ export function slugify(name: string): string {
 
 export const appIso = (v: any): string | null => (v ? new Date(v).toISOString() : null);
 
-// Exposes EXACTLY the 12 canonical app fields. Reads snake_case DB columns
+// Exposes EXACTLY the canonical app fields. Reads snake_case DB columns
 // (PostgREST returns the table's native column names).
 export function mapApp(r: any) {
   return {
@@ -127,6 +128,10 @@ export function mapApp(r: any) {
     provisionStatus: r.provision_status,
     fcStatus: r.fc_status ?? null,
     fcEndpoint: r.fc_endpoint ?? null,
+    // Derived, never stored: the vanity host is a pure function of slug + id,
+    // and a deployment without an apps domain has none. Storing it would let a
+    // renamed app keep a hostname that no longer routes.
+    publicUrl: appPublicUrl(r.slug, r.id),
     fcFunctionName: r.fc_function_name ?? null,
     fcRegion: r.fc_region ?? null,
     createdAt: appIso(r.created_at)!,

--- a/services/fc/test/apps-vanity.test.ts
+++ b/services/fc/test/apps-vanity.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Deployed apps are served on `<slug>-<id8>.<APPS_PUBLIC_DOMAIN>`, which makes
+ * the request's Host a routing key AND a certificate request. Both halves are
+ * reachable by anyone on the internet, so the parsing below is a security
+ * boundary, not a convenience: a host that parses is a host Caddy will go ask
+ * Let's Encrypt about.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../src/app.js";
+import { appPublicUrl, appPublicLabel, parseAppPublicHost } from "../src/lib/apps-public-host.js";
+import { isServable, proxyToApp } from "../src/lib/apps-vanity.js";
+
+const DOMAIN = "apps.teamclu-dev.ucar.cc";
+const APP_ID = "18e4ecad-6189-495b-a873-7fe09179a5f5";
+const env = { APPS_PUBLIC_DOMAIN: DOMAIN } as NodeJS.ProcessEnv;
+
+function withDomain<T>(fn: () => T): T {
+  const prev = process.env.APPS_PUBLIC_DOMAIN;
+  process.env.APPS_PUBLIC_DOMAIN = DOMAIN;
+  try { return fn(); } finally {
+    if (prev === undefined) delete process.env.APPS_PUBLIC_DOMAIN;
+    else process.env.APPS_PUBLIC_DOMAIN = prev;
+  }
+}
+
+function deps(lookup?: any) {
+  return {
+    createRepository: () => ({}),
+    createAuthRepository: () => ({}),
+    ...(lookup ? { lookupVanityApp: lookup } : {}),
+  } as any;
+}
+
+// --- hostname shape --------------------------------------------------------
+
+test("the label carries an id suffix because slugs are only unique per team", () => {
+  // apps_team_slug_uniq is (team_id, slug): two teams can both own `website`,
+  // and a hostname has no team in it.
+  assert.equal(appPublicLabel("website", APP_ID), "website-18e4ecad");
+  assert.equal(appPublicUrl("website", APP_ID, env), `https://website-18e4ecad.${DOMAIN}`);
+});
+
+test("no apps domain means no public URL at all", () => {
+  assert.equal(appPublicUrl("website", APP_ID, {} as NodeJS.ProcessEnv), null);
+  assert.equal(parseAppPublicHost(`website-18e4ecad.${DOMAIN}`, {} as NodeJS.ProcessEnv), null);
+});
+
+test("parses a vanity host into slug + id prefix, port and case included", () => {
+  assert.deepEqual(parseAppPublicHost(`website-18e4ecad.${DOMAIN}`, env), {
+    slug: "website", idPrefix: "18e4ecad",
+  });
+  assert.deepEqual(parseAppPublicHost(`WebSite-18E4ECAD.${DOMAIN}:8443`, env), {
+    slug: "website", idPrefix: "18e4ecad",
+  });
+  // Slugs may contain dashes; only the LAST one separates the id.
+  assert.deepEqual(parseAppPublicHost(`my-cool-site-18e4ecad.${DOMAIN}`, env), {
+    slug: "my-cool-site", idPrefix: "18e4ecad",
+  });
+});
+
+test("refuses everything that is not exactly one label under the apps domain", () => {
+  const bad = [
+    "api.teamclu-dev.ucar.cc",             // the Cloud API's own name
+    DOMAIN,                                 // the bare apps domain
+    `deep.website-18e4ecad.${DOMAIN}`,      // two levels: no wildcard covers it
+    `website.${DOMAIN}`,                    // no id suffix
+    `website-.${DOMAIN}`,                   // empty id
+    `website-zzzzzzzz.${DOMAIN}`,           // not hex — cannot be a uuid prefix
+    `website-18e4eca.${DOMAIN}`,            // 7 chars
+    `-18e4ecad.${DOMAIN}`,                  // empty slug
+    `website-18e4ecad.evil.com`,            // someone else's domain
+    "",
+  ];
+  for (const host of bad) {
+    assert.equal(parseAppPublicHost(host, env), null, `should refuse ${host || "<empty>"}`);
+  }
+});
+
+// --- Caddy's on-demand TLS gate -------------------------------------------
+
+test("ask says no for hosts that are not apps, without touching the database", async () => {
+  let called = 0;
+  const app = createApp(deps(async () => { called++; return null; }));
+  await withDomain(async () => {
+    const res = await app.request("/internal/caddy/ask?domain=evil.example.com");
+    assert.equal(res.status, 404);
+  });
+  assert.equal(called, 0, "a non-app hostname must be rejected on shape alone");
+});
+
+test("ask says no for a well-formed host with no app behind it", async () => {
+  const app = createApp(deps(async () => null));
+  await withDomain(async () => {
+    const res = await app.request(`/internal/caddy/ask?domain=ghost-18e4ecad.${DOMAIN}`);
+    assert.equal(res.status, 404);
+  });
+});
+
+test("ask says yes for a real app, even before it has ever deployed", async () => {
+  // The certificate is for the hostname, not for the deployment: refusing here
+  // would leave a just-created app unable to get one until its first deploy.
+  const app = createApp(deps(async () => ({
+    id: APP_ID, slug: "website", fcEndpoint: null, fcStatus: null,
+  })));
+  await withDomain(async () => {
+    const res = await app.request(`/internal/caddy/ask?domain=website-18e4ecad.${DOMAIN}`);
+    assert.equal(res.status, 200);
+  });
+});
+
+// --- serving ---------------------------------------------------------------
+
+test("a vanity host with nothing deployed behind it 404s instead of proxying to null", async () => {
+  const app = createApp(deps(async () => ({
+    id: APP_ID, slug: "website", fcEndpoint: null, fcStatus: "awaiting_build",
+  })));
+  await withDomain(async () => {
+    const res = await app.request("/", { headers: { host: `website-18e4ecad.${DOMAIN}` } });
+    assert.equal(res.status, 404);
+    assert.match(await res.text(), /not deployed/);
+  });
+});
+
+test("requests on the API's own host still reach the API", async () => {
+  // The middleware runs on every request; only Host decides. Getting this wrong
+  // would take the whole Cloud API down.
+  const app = createApp(deps(async () => { throw new Error("must not be consulted"); }));
+  await withDomain(async () => {
+    const res = await app.request("/v1/nope-nope", {
+      headers: { host: "api.teamclu-dev.ucar.cc", authorization: "Bearer abc" },
+    });
+    assert.equal(res.status, 404);
+    assert.equal((await res.json() as any).error.code, "not_found");
+  });
+});
+
+test("isServable requires a live status AND an endpoint", () => {
+  assert.equal(isServable(null), false);
+  assert.equal(isServable({ id: "1", slug: "s", fcStatus: "live", fcEndpoint: null }), false);
+  assert.equal(isServable({ id: "1", slug: "s", fcStatus: "deploy_error", fcEndpoint: "https://x" }), false);
+  assert.equal(isServable({ id: "1", slug: "s", fcStatus: "live", fcEndpoint: "https://x" }), true);
+});
+
+// --- the proxy itself ------------------------------------------------------
+
+test("proxy keeps path and query, and sends the UPSTREAM host", async () => {
+  // Function Compute routes on Host. Forwarding the client's Host reaches no
+  // function at all, which is the failure this asserts against.
+  let seen: any = null;
+  const fake = (async (url: any, init: any) => {
+    seen = { url: String(url), headers: new Headers(init.headers) };
+    return new Response("ok", { status: 200 });
+  }) as unknown as typeof fetch;
+
+  const req = new Request(`https://website-18e4ecad.${DOMAIN}/blog/post?id=7`, {
+    headers: { host: `website-18e4ecad.${DOMAIN}`, "x-test": "1", connection: "keep-alive" },
+  });
+  await proxyToApp(req, "https://tc-app-x-abc123.cn-shenzhen.fcapp.run", fake);
+
+  assert.equal(seen.url, "https://tc-app-x-abc123.cn-shenzhen.fcapp.run/blog/post?id=7");
+  assert.equal(seen.headers.get("host"), null, "client Host must not be forwarded");
+  assert.equal(seen.headers.get("connection"), null, "hop-by-hop headers must be dropped");
+  assert.equal(seen.headers.get("x-test"), "1", "everything else passes through");
+  assert.equal(seen.headers.get("x-forwarded-host"), `website-18e4ecad.${DOMAIN}`);
+});
+
+test("proxy passes the app's own status and headers back untouched", async () => {
+  const fake = (async () => new Response("<!doctype html>", {
+    status: 201,
+    headers: { "content-type": "text/html", "access-control-allow-origin": "*", "transfer-encoding": "chunked" },
+  })) as unknown as typeof fetch;
+
+  const res = await proxyToApp(new Request(`https://website-18e4ecad.${DOMAIN}/`), "https://up.example", fake);
+  assert.equal(res.status, 201);
+  assert.equal(res.headers.get("content-type"), "text/html");
+  // The app owns its CORS; rewriting it here would break the app it serves.
+  assert.equal(res.headers.get("access-control-allow-origin"), "*");
+  assert.equal(res.headers.get("transfer-encoding"), null, "hop-by-hop must not survive");
+  assert.equal(await res.text(), "<!doctype html>");
+});
+
+test("proxy does not follow the app's redirects on its behalf", async () => {
+  let init: any = null;
+  const fake = (async (_u: any, i: any) => { init = i; return new Response(null, { status: 302, headers: { location: "/login" } }); }) as unknown as typeof fetch;
+  const res = await proxyToApp(new Request(`https://website-18e4ecad.${DOMAIN}/`), "https://up.example", fake);
+  assert.equal(init.redirect, "manual");
+  assert.equal(res.status, 302);
+  assert.equal(res.headers.get("location"), "/login");
+});

--- a/services/fc/test/pg-repo-apps.test.ts
+++ b/services/fc/test/pg-repo-apps.test.ts
@@ -52,7 +52,7 @@ test("createApp inserts a workspace + app and returns canonical fields", async (
 
   assert.deepEqual(Object.keys(app).sort(), [
     "createdAt", "fcStatus", "fcEndpoint", "fcFunctionName", "fcRegion",
-    "id", "name", "provisionStatus",
+    "id", "name", "provisionStatus", "publicUrl",
     "slug", "teamId", "type", "updatedAt", "visibility", "workspaceId",
   ].sort());
   assert.equal(app.teamId, team.id);

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -1906,15 +1906,17 @@ const APP_ROW = {
   updated_at: "2026-06-13T00:00:00Z",
 };
 
-test("apps: mapApp exposes exactly the 13 canonical keys", async () => {
+test("apps: mapApp exposes exactly the canonical keys", async () => {
   const repo = appsRepo(appsSupabase({ seed: { apps: [APP_ROW] } }));
   const items = await repo.listApps({ teamId: "team-1", limit: 100 });
   assert.equal(items.length, 1);
   assert.deepEqual(Object.keys(items[0]).sort(), [
     "createdAt", "fcStatus", "fcEndpoint", "fcFunctionName", "fcRegion",
-    "id", "name", "provisionStatus",
+    "id", "name", "provisionStatus", "publicUrl",
     "slug", "teamId", "type", "updatedAt", "visibility", "workspaceId",
   ].sort());
+  // Null unless the deployment sets an apps domain — this suite sets none.
+  assert.equal(items[0].publicUrl, null);
   assert.equal(items[0].teamId, "team-1");
   assert.equal(items[0].workspaceId, "ws-1");
   assert.equal(items[0].provisionStatus, "pending");


### PR DESCRIPTION
部署完的 app 现在只有一个 `.fcapp.run` 地址，主机名带随机后缀（`tc-app-<id>-bikksipbel.cn-shenzhen.fcapp.run`），既不好记也推导不出来。这个 PR 让每个 app 有自己的二级域名，证书自动签。

## 域名形状

```
https://<slug>-<id 前 8 位>.<APPS_PUBLIC_DOMAIN>
例：https://website-18e4ecad.apps.teamclu-dev.ucar.cc
```

带 id 后缀是因为 `apps_team_slug_uniq` 是 `(team_id, slug)` —— slug 只在团队内唯一，而主机名里没有团队，两个团队都可以有 `website`。

通配符放在单独的 `apps.` 这一级，**不放在基础域名上**：`*.teamclu-dev.ucar.cc` 会把 api / supabase / mqtt / s3 / studio / emqx 全吞掉，还会让每个打错的主机名都去申请证书。

## 证书：on-demand TLS + ask 端点

Caddy 在握手时遇到没有证书的主机名，先问 `GET /internal/caddy/ask?domain=…`；FC 确认这是个真实存在的 app 才回 200。

**ask 不是可选项**：任何人都能把自己的域名解析到这台机器，而 Let's Encrypt 的限额按**注册域名**算（`ucar.cc`），跟 api/supabase/mqtt 共用。没有 ask，这就是一个开放的证书签发入口。ask 先按形状拒（连数据库都不查），再查库确认。

## 路由：为什么走 Cloud API 而不是往 Caddy 塞配置

FC 触发器主机名带随机后缀，**无法从请求推导出上游**，必须查库。两条路：

- 部署时通过 Caddy admin API 推路由 —— 官方镜像跑的是 `caddy run --config /etc/caddy/Caddyfile`，**推进去的路由重启即失**（autosave 被 `--config` 顶掉），于是还得写一套开机对账逻辑，外加把无鉴权的 admin API 暴露到 compose 网络上（同网段任何容器都能改反代）。
- **本 PR**：Caddy 只有一段静态配置，`*.<APPS_DOMAIN>` 全丢给 `fc:9000`，FC 按 Host 查 `fc_endpoint` 流式转发。Caddyfile 里没有任何 per-app 内容，重启天然自愈，将来做私有 app 鉴权也有地方挂。

代价是 app 流量多一跳内网转发（同一台机器）。真到扛不住那天再换推路由，**URL 方案和 DNS 都不用动**。

转发按代理该有的样子做：剥 hop-by-hop 头、Host 用上游的（FC 按 Host 路由，透传客户端 Host 会谁也找不到）、不替 app 跟随重定向、响应头原样返回（CORS 是 app 自己的事，改它就是在拆自己服务的 app）。中间件注册在 CORS 和限流**之前** —— 这些请求根本不是 Cloud API 流量。

## `publicUrl`

派生字段，**不落库**：存下来的话 app 改名后会留着一个不再路由的主机名。`APPS_PUBLIC_DOMAIN` 留空即整个功能关闭，`publicUrl` 为 null，app 保持原来的 `.fcapp.run`（阿里云那个部署目标就是这样）。桌面端「打开/复制部署地址」优先用 `publicUrl`。

## 验证

- Caddyfile 用 `caddy validate` 在 **acme / internal / off 三种 TLS 模式**下全部 `Valid configuration`（在线上那台机器的 caddy 容器里跑的）
- FC 新增 13 条用例全过：主机名解析（含端口、大小写、多段 slug、非法 id、嵌套标签、别人的域名）、ask 的三种答案、未部署的 app 不代理到 null、**API 自己的域名照常进 API**、代理的头处理与重定向
- 全量 1241 用例 1131 过、7 红 —— 这 7 个在未改动的 main 上一模一样地红（3 个 env-parity + 4 个 teams），本 PR 没新增
- `tsc` 干净（FC 与 packages/app 两边）；前端 30 条相关用例过；eslint 干净

## 合并后还要做的

1. 机器 `.env` 里设 `APPS_PUBLIC_DOMAIN=apps.teamclu-dev.ucar.cc`（DNS 通配记录已经加好并验证解析）
2. 已经部署过的 app 第一次访问新域名时会现签证书，有几秒握手延迟，属正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)
