### PR TITLE
fix(skills): 脏检测不再靠 mtime 下结论

### DIFF
--- a/crates/teamclu-skillpack/src/manifest.rs
+++ b/crates/teamclu-skillpack/src/manifest.rs
@@ -17,14 +17,33 @@ use std::path::{Path, PathBuf};
 /// manifest, so including it would make the file describe itself.
 pub const EXCLUDED_DIR: &str = ".clawhub";
 
+/// Files up to this size are hashed on every inspection; larger ones keep the
+/// size+mtime pre-filter.
+///
+/// A skill pack is prose and scripts. Hashing a whole team's installed set
+/// measured 45ms for 13 packs / 116KB, against an inspection that runs on a
+/// 10-minute reconcile and when the panel opens — the fast path was protecting
+/// a cost that does not exist, at the price of a verdict that can be wrong.
+///
+/// The threshold exists because nothing *stops* someone shipping a model or a
+/// binary inside a pack, and re-reading that every tick would be a real cost.
+/// Such a file keeps the old, weaker check: the uncertainty is confined to
+/// files that should not be in a skill pack to begin with.
+pub const ALWAYS_HASH_MAX_BYTES: u64 = 5 * 1024 * 1024;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ManagedFile {
     pub sha256: String,
     pub size: u64,
-    /// Pre-filter only, never a verdict. mtime survives neither a copy nor a
-    /// clock change, so it may only ever be used to skip work — a match means
-    /// "don't bother reading the file", a mismatch means "read it and decide".
+    /// Pre-filter, and only for files past [`ALWAYS_HASH_MAX_BYTES`].
+    ///
+    /// mtime survives neither a copy nor a clock change, so pairing it with
+    /// size was never a sound verdict: `cp -p` and a restore from backup both
+    /// put back the original mtime, and an edit that keeps the byte count then
+    /// reads as clean. Everything small enough to hash cheaply is now hashed,
+    /// which is what the "never a verdict" rule always implied. This stays for
+    /// the files where reading the bytes every tick would be the wrong trade.
     #[serde(default)]
     pub mtime_ms: u64,
     /// Tracked separately because `chmod +x` is a real edit that moves ctime,
@@ -221,7 +240,12 @@ pub fn inspect(dir: &Path, baseline: Option<&FileManifest>) -> DirtyState {
             modified.push(rel.clone());
             continue;
         }
-        if meta.len() == want.size && mtime_ms(&meta) == want.mtime_ms {
+        // Same size AND same mtime is only allowed to mean "clean" for a file
+        // too big to hash on every pass. See ALWAYS_HASH_MAX_BYTES.
+        if want.size > ALWAYS_HASH_MAX_BYTES
+            && meta.len() == want.size
+            && mtime_ms(&meta) == want.mtime_ms
+        {
             continue;
         }
         match file_sha256(&full) {
@@ -261,6 +285,14 @@ pub fn inspect(dir: &Path, baseline: Option<&FileManifest>) -> DirtyState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Set a file's mtime to an exact millisecond, so a test can reproduce the
+    /// "same size, same mtime" state on purpose.
+    fn set_mtime_ms(path: &Path, ms: u64) {
+        let when = std::time::UNIX_EPOCH + std::time::Duration::from_millis(ms);
+        let file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_modified(when).unwrap();
+    }
 
     fn write(dir: &Path, rel: &str, body: &str) {
         let path = dir.join(rel);
@@ -340,12 +372,60 @@ mod tests {
         let swapped = original.replace("body", "b0dy");
         assert_eq!(swapped.len(), original.len());
         std::fs::write(&path, swapped).unwrap();
-        // Equal length: only the hash can tell these apart. If mtime happens to
-        // land in the same millisecond the fast path would wave it through, so
-        // force the comparison the way a later reconcile tick would see it.
-        let mut baseline = m.clone();
-        baseline.get_mut("SKILL.md").unwrap().mtime_ms = 0;
-        assert!(inspect(&dir, Some(&baseline)).is_dirty());
+        // Equal length: only the hash can tell these apart. No longer any need
+        // to defeat a fast path first — a file this size is always hashed.
+        assert!(inspect(&dir, Some(&m)).is_dirty());
+    }
+
+    /// The blind spot the size+mtime pre-filter used to have, in the shape that
+    /// actually produces it: an edit that keeps both the byte count and the
+    /// original mtime. `cp -p`, a restore from backup and rsync's `-t` all do
+    /// exactly this.
+    #[test]
+    fn an_edit_that_restores_size_and_mtime_is_still_caught() {
+        let (_tmp, dir) = fixture();
+        let m = build_manifest(&dir).unwrap();
+        let path = dir.join("SKILL.md");
+        let original = std::fs::read_to_string(&path).unwrap();
+        let swapped = original.replace("body", "b0dy");
+        assert_eq!(swapped.len(), original.len());
+        std::fs::write(&path, &swapped).unwrap();
+
+        // Put the recorded mtime back, so size AND mtime both match the
+        // baseline — the exact state the old fast path waved through.
+        let baseline_mtime = m.get("SKILL.md").unwrap().mtime_ms;
+        set_mtime_ms(&path, baseline_mtime);
+        let meta = std::fs::metadata(&path).unwrap();
+        assert_eq!(meta.len(), m.get("SKILL.md").unwrap().size);
+        assert_eq!(mtime_ms(&meta), baseline_mtime);
+
+        assert!(
+            inspect(&dir, Some(&m)).is_dirty(),
+            "content changed; matching size and mtime must not be taken as clean"
+        );
+    }
+
+    /// The exception, stated as a test so it cannot rot into an accident: past
+    /// the threshold the old pre-filter still applies, because re-reading a
+    /// file that big on every tick is the wrong trade.
+    #[test]
+    fn a_file_past_the_threshold_keeps_the_pre_filter() {
+        let (_tmp, dir) = fixture();
+        let path = dir.join("big.bin");
+        let size = (ALWAYS_HASH_MAX_BYTES + 1) as usize;
+        std::fs::write(&path, vec![b'a'; size]).unwrap();
+        let m = build_manifest(&dir).unwrap();
+
+        // Same length, different bytes, original mtime restored.
+        let baseline_mtime = m.get("big.bin").unwrap().mtime_ms;
+        std::fs::write(&path, vec![b'b'; size]).unwrap();
+        set_mtime_ms(&path, baseline_mtime);
+
+        assert_eq!(
+            inspect(&dir, Some(&m)),
+            DirtyState::Clean,
+            "the documented cost of keeping the fast path for large files"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
`size + mtime` 都没变就跳过哈希 —— 这个快筛实际上是在**用 mtime 下判据**，而同一个文件里 `mtime_ms` 的字段注释早就写着：

> *「Pre-filter only, never a verdict. mtime 既扛不住复制也扛不住时钟变化，所以它只能用来跳过工作。」*

实现和它自己声明的原则是矛盾的。

## 漏判的具体形状

改动**保持字节数不变**、且 **mtime 被恢复成原值**。`cp -p`、从备份还原、`rsync -t` 都正好干这件事 —— 实测确认 `cp -p` 保住 mtime、只有 ctime 变：

```
a: mtime=1787052498 ctime=1787052498     ← 原文件
b: mtime=1787052498 ctime=1787052499     ← cp -p 的副本
```

这种情况下包已经被改过，检测却报干净，**自动跟随会直接覆盖掉用户的改动** —— 而冲突保护存在的全部理由就是不让这件事发生。

## 修法：小文件一律算哈希

快筛保护的开销并不存在。实测本机全量哈希 **13 个包 / 31 个文件 / 116KB = 45 毫秒**（含进程启动），而 `inspect` 的触发频率是 10 分钟一轮的对账，加上打开技能面板时。

为什么不是「把 ctime 也加进快筛」：那只是把判据从两个字段扩到三个，矛盾还在，只是更难撞上；而且 ctime 在 Windows 上没有对应概念，得再加一条平台分支。去掉快筛才是让实现回到注释所声明的原则。

## 保留 5MB 阈值

没有任何机制阻止别人往技能包里塞模型或二进制，那种文件每轮重读是真的贵。超过 `ALWAYS_HASH_MAX_BYTES` 的仍走老的 `size+mtime` 快筛 —— **不确定性被限制在本来就不该出现在技能包里的东西上**。

这条例外单独写了测试（`a_file_past_the_threshold_keeps_the_pre_filter`），免得日后退化成一个没人记得的意外。

## 验证

- **新回归测试确实在守行为**：把修复回退掉重跑，`an_edit_that_restores_size_and_mtime_is_still_caught` 变红；改回来变绿。不然它可能只是碰巧通过。
- `same_size_content_still_counts_as_modified` 顺手简化了 —— 它原本要手动把 `mtime_ms` 改成 0 才能绕开快筛，现在不需要了。
- skillpack 33 个用例、desktop lib 196 个、daemon 全量 0 失败；`rustfmt --check` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)