### PR TITLE
fix(apps): 二级域名在 self-host 上没生效——入口漏接 + 后端选错

### DIFF
--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -23,6 +23,7 @@ import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { resolveAppsOss, getAppsS3Client } from "./lib/provisioning/apps-oss.js";
 import { makeVanityLookup } from "./lib/apps-vanity.js";
+import { createServiceRoleClient } from "./lib/supabase.js";
 import type { JWTVerifyGetKey } from "jose";
 
 // ---------------------------------------------------------------------------
@@ -111,6 +112,23 @@ function makeDeployDeps() {
   };
 }
 
+/**
+ * Vanity-host lookup, wired for whichever backend this deployment runs.
+ *
+ * Exported so the container entry (server.ts) and the FC handler below share
+ * ONE wiring. They are two separate `createApp()` calls, and the first version
+ * of this feature configured only the handler — so the self-host container,
+ * the only deployment that actually serves vanity hosts, registered neither
+ * the proxy nor the `ask` endpoint and answered a plain 404.
+ */
+export function vanityLookup() {
+  return makeVanityLookup({
+    backendKind: () => resolveBackendKind(),
+    getDb,
+    getServiceRoleClient: createServiceRoleClient,
+  });
+}
+
 export function makeAuthRepoFactory(kind: "supabase" | "postgres") {
   if (kind === "postgres") {
     return () => createPgAuthRepository();
@@ -186,9 +204,7 @@ const app = createApp({
   createRepository: makeBusinessRepoFactory(resolveBackendKind()),
   createAuthRepository: makeAuthRepoFactory(resolveBackendKind()),
   runCron: (task: string) => runCronTask(getDb(), task),
-  // Reads the control-plane database directly on both backends: the vanity
-  // host and the Caddy `ask` probe carry no bearer token to scope a repo with.
-  lookupVanityApp: makeVanityLookup(getDb),
+  lookupVanityApp: vanityLookup(),
 });
 
 const honoHandler = handle(app);

--- a/services/fc/src/lib/apps-vanity.ts
+++ b/services/fc/src/lib/apps-vanity.ts
@@ -32,7 +32,20 @@ type DbLike = any;
 
 export type LookupVanityApp = (host: string) => Promise<VanityApp | null>;
 
-export function makeVanityLookup(getDb: () => DbLike): LookupVanityApp {
+/**
+ * Of the apps sharing a slug (one per team at most), the one whose id starts
+ * with the prefix from the hostname.
+ *
+ * Two hits means two teams whose slugs AND id prefixes collide — serving either
+ * would be a coin flip between different teams' apps, so serve neither.
+ */
+export function selectByIdPrefix(rows: VanityApp[], idPrefix: string): VanityApp | null {
+  const hits = rows.filter((r) => typeof r.id === "string" && r.id.startsWith(idPrefix));
+  return hits.length === 1 ? hits[0] : null;
+}
+
+/** Postgres backend: read the control-plane tables directly. */
+export function makePgVanityLookup(getDb: () => DbLike): LookupVanityApp {
   return async (host: string) => {
     const parsed = parseAppPublicHost(host);
     if (!parsed) return null;
@@ -45,12 +58,56 @@ export function makeVanityLookup(getDb: () => DbLike): LookupVanityApp {
       })
       .from(apps)
       .where(and(eq(apps.slug, parsed.slug), sql`${apps.id}::text like ${parsed.idPrefix + "%"}`))
-      // Two rows means two teams whose slugs AND id prefixes collide. Serving
-      // either one would be a coin flip between different teams' apps, so serve
-      // neither — `limit(2)` is what makes that case visible at all.
       .limit(2);
-    if (rows.length !== 1) return null;
-    return rows[0] as VanityApp;
+    return selectByIdPrefix(rows as VanityApp[], parsed.idPrefix);
+  };
+}
+
+/**
+ * Supabase backend: PostgREST with the service-role key, which is how every
+ * other tokenless path here reads the database.
+ *
+ * Filters on slug alone and matches the id prefix in memory rather than asking
+ * PostgREST for `id like '…%'`: `id` is a uuid column, and Postgres has no
+ * `uuid ~~ text` operator — that filter fails as a query error, not as an empty
+ * result. At most one row per team shares a slug, so the list is tiny.
+ */
+export function makeSupabaseVanityLookup(getClient: () => any): LookupVanityApp {
+  return async (host: string) => {
+    const parsed = parseAppPublicHost(host);
+    if (!parsed) return null;
+    const { data, error } = await getClient()
+      .from("apps")
+      .select("id, slug, fc_endpoint, fc_status")
+      .eq("slug", parsed.slug)
+      .limit(50);
+    if (error) throw new Error(`vanity app lookup failed: ${error.message}`);
+    const rows: VanityApp[] = (data ?? []).map((r: any) => ({
+      id: r.id, slug: r.slug, fcEndpoint: r.fc_endpoint ?? null, fcStatus: r.fc_status ?? null,
+    }));
+    return selectByIdPrefix(rows, parsed.idPrefix);
+  };
+}
+
+/**
+ * The lookup this deployment can actually perform.
+ *
+ * Chosen per call rather than at wiring time so neither client is constructed
+ * on a deployment that never serves a vanity host — and `getDb()` in
+ * particular throws outright when DATABASE_URL is unset, which is the normal
+ * state of a self-host box running the supabase backend.
+ */
+export function makeVanityLookup(deps: {
+  backendKind: () => string;
+  getDb: () => DbLike;
+  getServiceRoleClient: () => any;
+}): LookupVanityApp {
+  return async (host: string) => {
+    if (!parseAppPublicHost(host)) return null;
+    const impl = deps.backendKind() === "postgres"
+      ? makePgVanityLookup(deps.getDb)
+      : makeSupabaseVanityLookup(deps.getServiceRoleClient);
+    return impl(host);
   };
 }
 

--- a/services/fc/src/server.ts
+++ b/services/fc/src/server.ts
@@ -1,7 +1,7 @@
 import { serve } from "@hono/node-server";
 import { createApp } from "./app.js";
 import { resolveBackendKind } from "./lib/backend-kind.js";
-import { makeBusinessRepoFactory, makeAuthRepoFactory } from "./index.js";
+import { makeBusinessRepoFactory, makeAuthRepoFactory, vanityLookup } from "./index.js";
 import { runCronTask } from "./lib/cron.js";
 import { getDb } from "./db/client.js";
 
@@ -11,6 +11,9 @@ const app = createApp({
   createRepository: makeBusinessRepoFactory(kind),
   createAuthRepository: makeAuthRepoFactory(kind),
   runCron: (task: string) => runCronTask(getDb(), task),
+  // This entry — not the FC handler — is what serves apps on their own
+  // hostnames, because the reverse proxy in front of it is the self-host one.
+  lookupVanityApp: vanityLookup(),
 });
 
 const parsedPort = Number(process.env.PORT);

--- a/services/fc/test/apps-vanity.test.ts
+++ b/services/fc/test/apps-vanity.test.ts
@@ -7,18 +7,25 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createApp } from "../src/app.js";
 import { appPublicUrl, appPublicLabel, parseAppPublicHost } from "../src/lib/apps-public-host.js";
-import { isServable, proxyToApp } from "../src/lib/apps-vanity.js";
+import {
+  isServable, proxyToApp, selectByIdPrefix, makeSupabaseVanityLookup, makeVanityLookup,
+} from "../src/lib/apps-vanity.js";
 
 const DOMAIN = "apps.teamclu-dev.ucar.cc";
 const APP_ID = "18e4ecad-6189-495b-a873-7fe09179a5f5";
 const env = { APPS_PUBLIC_DOMAIN: DOMAIN } as NodeJS.ProcessEnv;
 
-function withDomain<T>(fn: () => T): T {
+/** Awaits the callback before restoring: a sync `finally` would put the domain
+ *  back while the async body is still between its first and second await. */
+async function withDomain<T>(fn: () => T | Promise<T>): Promise<T> {
   const prev = process.env.APPS_PUBLIC_DOMAIN;
   process.env.APPS_PUBLIC_DOMAIN = DOMAIN;
-  try { return fn(); } finally {
+  try { return await fn(); } finally {
     if (prev === undefined) delete process.env.APPS_PUBLIC_DOMAIN;
     else process.env.APPS_PUBLIC_DOMAIN = prev;
   }
@@ -135,11 +142,109 @@ test("requests on the API's own host still reach the API", async () => {
   });
 });
 
+test("an ambiguous id prefix serves neither app", () => {
+  const rows = [
+    { id: "18e4ecad-1111", slug: "website", fcEndpoint: "https://a", fcStatus: "live" },
+    { id: "18e4ecad-2222", slug: "website", fcEndpoint: "https://b", fcStatus: "live" },
+  ];
+  assert.equal(selectByIdPrefix(rows, "18e4ecad"), null, "a coin flip between teams is not an answer");
+  assert.equal(selectByIdPrefix(rows, "18e4ecad-1"), rows[0]);
+  assert.equal(selectByIdPrefix(rows, "deadbeef"), null);
+});
+
 test("isServable requires a live status AND an endpoint", () => {
   assert.equal(isServable(null), false);
   assert.equal(isServable({ id: "1", slug: "s", fcStatus: "live", fcEndpoint: null }), false);
   assert.equal(isServable({ id: "1", slug: "s", fcStatus: "deploy_error", fcEndpoint: "https://x" }), false);
   assert.equal(isServable({ id: "1", slug: "s", fcStatus: "live", fcEndpoint: "https://x" }), true);
+});
+
+// --- both entry points ------------------------------------------------------
+
+test("every createApp() call wires the vanity lookup", () => {
+  // There are two entries: the container (server.ts) and the Alibaba FC handler
+  // (index.ts). The first version of this feature wired only the handler, so
+  // the self-host container — the ONLY deployment that serves vanity hosts —
+  // registered neither the proxy nor `ask`, and answered a bare 404 that looked
+  // exactly like a DNS or certificate problem.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  for (const entry of ["server.ts", "index.ts"]) {
+    const src = fs.readFileSync(path.join(here, "../src", entry), "utf8");
+    assert.match(
+      src,
+      /createApp\(\{[\s\S]*?lookupVanityApp[\s\S]*?\}\)/,
+      `${entry} builds an app without lookupVanityApp`,
+    );
+  }
+});
+
+// --- which database the lookup reads --------------------------------------
+
+test("the supabase lookup filters by slug and matches the id prefix in memory", async () => {
+  // NOT `id like '18e4ecad%'`: `id` is a uuid column and Postgres has no
+  // `uuid ~~ text` operator, so that filter comes back as a query ERROR rather
+  // than an empty result — a failure mode that only shows up against a real
+  // database, never against a mock that accepts any filter.
+  const calls: any[] = [];
+  const client = {
+    from(table: string) {
+      const q: any = {
+        select(cols: string) { calls.push(["select", table, cols]); return q; },
+        eq(col: string, val: string) { calls.push(["eq", col, val]); return q; },
+        like() { throw new Error("must not filter a uuid column with LIKE"); },
+        limit() {
+          return Promise.resolve({
+            data: [
+              { id: "18e4ecad-6189-495b-a873-7fe09179a5f5", slug: "website", fc_endpoint: "https://up", fc_status: "live" },
+              { id: "99999999-0000-0000-0000-000000000000", slug: "website", fc_endpoint: "https://other", fc_status: "live" },
+            ],
+            error: null,
+          });
+        },
+      };
+      return q;
+    },
+  };
+  const lookup = makeSupabaseVanityLookup(() => client);
+  const found = await withDomain(() => lookup(`website-18e4ecad.${DOMAIN}`));
+  assert.equal(found?.fcEndpoint, "https://up", "the OTHER team's app must not be served");
+  assert.deepEqual(calls.find((c) => c[0] === "eq"), ["eq", "slug", "website"]);
+});
+
+test("the supabase lookup surfaces a query error instead of reporting 'no such app'", async () => {
+  // Answering null on an error would tell Caddy the app does not exist, and a
+  // transient database blip would look exactly like a deleted app.
+  const client = { from: () => ({ select: () => ({ eq: () => ({ limit: async () => ({ data: null, error: { message: "boom" } }) }) }) }) };
+  const lookup = makeSupabaseVanityLookup(() => client);
+  await assert.rejects(
+    () => withDomain(() => lookup(`website-18e4ecad.${DOMAIN}`)),
+    /vanity app lookup failed: boom/,
+  );
+});
+
+test("the backend picks the client, and neither is built for a non-app host", async () => {
+  // getDb() throws outright when DATABASE_URL is unset — the normal state of a
+  // self-host box on the supabase backend — so choosing eagerly, or choosing
+  // wrong, takes down every request that merely passes through.
+  let dbBuilt = 0;
+  let srBuilt = 0;
+  const lookup = makeVanityLookup({
+    backendKind: () => "supabase",
+    getDb: () => { dbBuilt++; throw new Error("DATABASE_URL is not set"); },
+    getServiceRoleClient: () => {
+      srBuilt++;
+      return { from: () => ({ select: () => ({ eq: () => ({ limit: async () => ({ data: [], error: null }) }) }) }) };
+    },
+  });
+
+  await withDomain(async () => {
+    assert.equal(await lookup("api.teamclu-dev.ucar.cc"), null);
+    assert.equal(dbBuilt + srBuilt, 0, "a non-app host must not build any client");
+
+    assert.equal(await lookup(`ghost-18e4ecad.${DOMAIN}`), null);
+    assert.equal(srBuilt, 1, "supabase backend must use the service-role client");
+    assert.equal(dbBuilt, 0, "and must never touch getDb()");
+  });
 });
 
 // --- the proxy itself ------------------------------------------------------


### PR DESCRIPTION
接 #972。合并部署后**实测发现二级域名整条链路根本没生效**，两处独立缺陷：

```
$ wget -qO- "http://fc:9000/internal/caddy/ask?domain=website-18e4ecad.apps.teamclu-dev.ucar.cc"
404 {"error":{"code":"not_found","message":"Route not found"}}   ← Hono 的 not-found 信封
```

## 一、两个入口，只接了一个

`services/fc` 有两个入口，各自 `createApp()` 一次：

| 入口 | 谁在跑 |
|---|---|
| `src/server.ts` | **self-host 容器**（`node dist/server.js`） |
| `src/index.ts` | 阿里云 Function Compute 的 handler |

#972 只接了 `index.ts`。于是**唯一真正对外服务二级域名的那个部署**既没注册代理中间件也没注册 `ask`，任何请求都落到 not-found —— 而这个 404 看起来和「DNS 没生效」「证书没签下来」一模一样，极难从现象反推。

现在 `vanityLookup()` 由 `index.ts` 导出、两个入口共用，并加了一条守卫用例：扫源码，**每个 `createApp()` 调用都必须接上 `lookupVanityApp`**。

## 二、查库方式在 self-host 上必然抛错

`getDb()` 只认 `DATABASE_URL`，而这台机器：

```
BACKEND_KIND=supabase
DATABASE_URL=            ← 空
POSTGRES_HOST=db         ← 只有这些
```

实测：`getDb()` → `Error: DATABASE_URL is not set`。也就是说即便入口接对了，查询照样抛。

改成**按后端选客户端**：postgres 走 drizzle，supabase 走 service-role 客户端（它本来就带 `db: { schema: "amux" }`）。而且是**每次调用时才选**，不在装配时构造 —— `getDb()` 一构造就抛，会把每个路过的请求一起带走。

顺带一个只有真库才会暴露的坑：supabase 那条**不能**用 `id like '18e4ecad%'` 过滤 —— `id` 是 uuid 列，Postgres 没有 `uuid ~~ text` 运算符，那是**查询报错**而不是空结果，任何接受任意过滤条件的 mock 都测不出来。改成按 slug 过滤 + 在内存里比前缀（同一 slug 每团队至多一行）。查询出错时向上抛而不是当作「没有这个 app」：后者会让一次数据库抖动看起来像 app 被删了。

## 验证

- 在**线上容器里**先用 service-role 客户端把这条查询跑通了，确认返回 `website` 那一行，才动的代码
- 新增 5 条用例：两个入口的接线守卫、后端选择（含「非 app 主机名不构造任何客户端」）、uuid LIKE 的禁止、查询错误必须上抛、id 前缀歧义时两个都不服务
- 本文件 18/18 过；全量 1246 过 1136、7 红 —— 与未改动 main 一致（3 个 env-parity + 4 个 teams），本 PR 没新增
- `tsc` 干净

顺带修了测试助手自身的一个 bug：`withDomain` 用同步 `finally` 还原环境变量，异步回调还没跑完就被还原了 —— 之前几条异步用例其实是侥幸通过的。

## 合并后

机器 `.env` 已经设好 `APPS_PUBLIC_DOMAIN=apps.teamclu-dev.ucar.cc`，DNS 通配记录也已验证解析。合并部署完我会实测 `https://website-18e4ecad.apps.teamclu-dev.ucar.cc`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
