### PR TITLE
fix(apps): 部署的页面变成下载、跨域预检被拒

### DIFF
--- a/services/fc/src/lib/apps-vanity.ts
+++ b/services/fc/src/lib/apps-vanity.ts
@@ -132,6 +132,27 @@ function strip(headers: Headers): Headers {
 }
 
 /**
+ * Function Compute stamps a bare `Content-Disposition: attachment` on every
+ * response served through its default `*.fcapp.run` hostname, so that nobody
+ * uses that hostname as a website: the browser downloads the page instead of
+ * rendering it. It arrives on the upstream response, not from the app — this
+ * was verified against the trigger URL directly, which carries it too.
+ *
+ * We are serving the app on its own hostname through our own proxy, so the
+ * measure no longer applies and passing it through would make every deployed
+ * page a download prompt.
+ *
+ * Only the BARE value is dropped. An app's own download (`attachment;
+ * filename="report.csv"`) carries parameters, is deliberate, and is left alone.
+ */
+function stripForcedDownload(headers: Headers): Headers {
+  if (headers.get("content-disposition")?.trim().toLowerCase() === "attachment") {
+    headers.delete("content-disposition");
+  }
+  return headers;
+}
+
+/**
  * Proxy one request to the app's FC trigger, streaming both ways.
  *
  * Response headers pass through untouched apart from hop-by-hop ones: the app
@@ -166,5 +187,5 @@ export async function proxyToApp(
     redirect: "manual",
   } as RequestInit);
 
-  return new Response(res.body, { status: res.status, headers: strip(res.headers) });
+  return new Response(res.body, { status: res.status, headers: stripForcedDownload(strip(res.headers)) });
 }

--- a/services/fc/src/lib/provisioning/fc-client.ts
+++ b/services/fc/src/lib/provisioning/fc-client.ts
@@ -151,14 +151,29 @@ export function makeFcOps(client: any, cfg: FcOpsConfig) {
       }));
     },
     async ensureHttpTrigger(functionName: string): Promise<string> {
+      // A method missing from this list is refused by the trigger with a 403
+      // that never reaches the app. The original four left OPTIONS out, which
+      // fails every CORS preflight a browser sends, and HEAD out, which is what
+      // link previews and health checks use.
+      const triggerConfig = JSON.stringify({
+        authType: "anonymous",
+        methods: ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"],
+      });
       try {
         await client.createTrigger(functionName, new $fc.CreateTriggerRequest({
           body: new $fc.CreateTriggerInput({
-            triggerName: "http", triggerType: "http",
-            triggerConfig: JSON.stringify({ authType: "anonymous", methods: ["GET", "POST", "PUT", "DELETE"] }),
+            triggerName: "http", triggerType: "http", triggerConfig,
           }),
         }));
-      } catch (e) { if (!isAlreadyExists(e)) throw e; }
+      } catch (e) {
+        if (!isAlreadyExists(e)) throw e;
+        // Triggers created earlier keep whatever method list they were made
+        // with — creating is a no-op for them, so repair it explicitly rather
+        // than leaving already-deployed apps refusing OPTIONS forever.
+        await client.updateTrigger(functionName, "http", new $fc.UpdateTriggerRequest({
+          body: new $fc.UpdateTriggerInput({ triggerConfig }),
+        }));
+      }
       const t = await client.getTrigger(functionName, "http");
       const url = t?.body?.httpTrigger?.urlInternet;
       if (!url) throw new Error("http trigger has no urlInternet");

--- a/services/fc/test/apps-vanity.test.ts
+++ b/services/fc/test/apps-vanity.test.ts
@@ -285,6 +285,30 @@ test("proxy passes the app's own status and headers back untouched", async () =>
   assert.equal(await res.text(), "<!doctype html>");
 });
 
+test("proxy drops the forced-download header FC stamps on its default domain", async () => {
+  // Verified against the live trigger URL: `content-disposition: attachment`
+  // (bare, no filename) rides on the UPSTREAM response, so passing it through
+  // turned every deployed page into a download prompt in the browser.
+  const fake = (async () => new Response("<!doctype html>", {
+    status: 200,
+    headers: { "content-type": "text/html; charset=utf-8", "content-disposition": "attachment" },
+  })) as unknown as typeof fetch;
+  const res = await proxyToApp(new Request("https://website-18e4ecad.example/"), "https://up.example", fake);
+  assert.equal(res.headers.get("content-disposition"), null);
+  assert.equal(res.headers.get("content-type"), "text/html; charset=utf-8");
+});
+
+test("proxy keeps a download the app actually asked for", async () => {
+  // A real download names its file. Dropping that would break every export
+  // button in every deployed app.
+  const fake = (async () => new Response("a,b\n1,2", {
+    status: 200,
+    headers: { "content-type": "text/csv", "content-disposition": 'attachment; filename="report.csv"' },
+  })) as unknown as typeof fetch;
+  const res = await proxyToApp(new Request("https://website-18e4ecad.example/export"), "https://up.example", fake);
+  assert.equal(res.headers.get("content-disposition"), 'attachment; filename="report.csv"');
+});
+
 test("proxy does not follow the app's redirects on its behalf", async () => {
   let init: any = null;
   const fake = (async (_u: any, i: any) => { init = i; return new Response(null, { status: 302, headers: { location: "/login" } }); }) as unknown as typeof fetch;

--- a/services/fc/test/provisioning/fc-client.test.ts
+++ b/services/fc/test/provisioning/fc-client.test.ts
@@ -9,6 +9,7 @@ function fakeClient(overrides: Record<string, any> = {}) {
     async createFunction(req: any) { calls.push(["createFunction", req]); return { body: {} }; },
     async updateFunction(name: string, req: any) { calls.push(["updateFunction", name, req]); return { body: {} }; },
     async createTrigger(name: string, req: any) { calls.push(["createTrigger", name, req]); return { body: {} }; },
+    async updateTrigger(name: string, trig: string, req: any) { calls.push(["updateTrigger", name, trig, req]); return { body: {} }; },
     async getTrigger(name: string, trig: string) { calls.push(["getTrigger", name, trig]); return { body: { httpTrigger: { urlInternet: "https://fn.example.fcapp.run" } } }; },
   };
   return { client: { ...base, ...overrides }, calls };
@@ -154,6 +155,31 @@ test("ensureHttpTrigger returns the public invoke URL", async () => {
   const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
   const url = await ops.ensureHttpTrigger("tc-app-1");
   assert.equal(url, "https://fn.example.fcapp.run");
+});
+
+test("ensureHttpTrigger allows the methods a browser actually sends", async () => {
+  // The trigger refuses anything outside this list with a 403 the app never
+  // sees. Leaving OPTIONS out fails every CORS preflight; leaving HEAD out
+  // breaks link previews and health checks.
+  const { client, calls } = fakeClient();
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
+  await ops.ensureHttpTrigger("tc-app-1");
+  const cfg = JSON.parse(calls.find((c) => c[0] === "createTrigger")[2].body.triggerConfig);
+  for (const m of ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"]) {
+    assert.ok(cfg.methods.includes(m), `${m} must be allowed`);
+  }
+});
+
+test("ensureHttpTrigger repairs an existing trigger's method list", async () => {
+  // Triggers made before OPTIONS was allowed keep refusing it: createTrigger is
+  // a no-op for them, so a redeploy has to update the config explicitly.
+  const conflict = Object.assign(new Error("exists"), { statusCode: 409, code: "TriggerAlreadyExists" });
+  const { client, calls } = fakeClient({ createTrigger: async () => { throw conflict; } });
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
+  await ops.ensureHttpTrigger("tc-app-1");
+  const upd = calls.find((c) => c[0] === "updateTrigger");
+  assert.ok(upd, "an existing trigger must be updated, not silently left alone");
+  assert.ok(JSON.parse(upd[3].body.triggerConfig).methods.includes("OPTIONS"));
 });
 
 test("ensureHttpTrigger swallows 'trigger already exists' then reads the URL", async () => {


### PR DESCRIPTION
二级域名已经通了（#975 之后 `https://website-18e4ecad.apps.teamclu-dev.ucar.cc` 返回 `HTTP/2 200`、证书有效、`via: 1.1 Caddy`），但打开是**下载 HTML 而不是渲染**。抓头定位到两个独立问题。

## 一、强制下载是阿里云加的，不是我们

```
$ curl -sD- https://website-18e4ecad.apps.teamclu-dev.ucar.cc/      ← 经我们的域名
content-disposition: attachment
content-type: text/html; charset=utf-8

$ curl -sD- https://tc-app-b-a-feaf-ksunxrqtfd.cn-shenzhen.fcapp.run/   ← 直连触发器
Content-Disposition: attachment          ← 上游就带着
```

这是 Function Compute 对**默认域名**的反滥用措施：默认域名没有备案，经它返回的内容一律强制下载、不给浏览器渲染。我们已经用自己的域名 + 自己的代理在服务，这个措施不再适用，但代理按「响应头原样返回」的原则把它透传了下来。

**只丢弃裸的 `attachment`**。app 自己的下载会带参数（`attachment; filename="report.csv"`），那是有意的，原样保留 —— 一刀切会把每个 app 的导出按钮都弄坏。

## 二、HTTP 触发器把 HEAD 和 OPTIONS 挡在门外

```
$ curl -I https://…/          → 403 FCCommonError
```

触发器建的时候只放了 `GET/POST/PUT/DELETE`。不在列表里的方法会被触发器用 403 直接拒掉，**请求根本到不了 app**：

- **OPTIONS 被拒 = 任何跨域预检都失败**，app 一旦要调外部 API 就废了
- HEAD 被拒 = 链接预览、健康检查、很多抓取工具拿不到页面

补齐 `HEAD/OPTIONS/PATCH`，并且在触发器已存在时**显式 `updateTrigger`** —— `createTrigger` 对已有触发器是空操作，不更新的话已经部署过的 app 会永远拒绝 OPTIONS（和 #971 里「更新路径不修配置」是同一类错误）。

## 验证

两条都在**真实函数**上验过，不是推理：

```
before: {"methods":["GET","POST","PUT","DELETE"],...}
updateTrigger: OK
after:  {"methods":["GET","POST","PUT","DELETE","HEAD","OPTIONS","PATCH"],...}

HEAD: 200   OPTIONS: 200   GET: 200      ← 配置传播约几秒后
```

单测 34/34 过（新增 4 条：裸 attachment 必须丢、带 filename 的必须留、方法列表必须含 OPTIONS/HEAD、已存在的触发器必须被更新），`tsc` 干净。

## 合并后

部署完我会再 curl 一次二级域名，确认 `content-disposition` 消失、浏览器能正常渲染。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
