### PR TITLE
fix(apps): app 目录只有一个位置，且移出 state/

### DIFF
--- a/apps/daemon/src/config/layout.rs
+++ b/apps/daemon/src/config/layout.rs
@@ -100,6 +100,22 @@ pub fn team_workspace_dir(team_id: &str) -> PathBuf {
     team_dir(team_id).join("workspace")
 }
 
+/// `teams/<id>/apps` — one directory per app, and the only place an app's
+/// files live.
+///
+/// A sibling of `state/`, not a child of it: an app checkout is the user's own
+/// project, not daemon bookkeeping, and it is what an agent session opens as
+/// its working directory. Nor is it under `workspace/`, which is the shared
+/// default worktree — an app owns its directory outright.
+pub fn team_apps_dir(team_id: &str) -> PathBuf {
+    team_dir(team_id).join("apps")
+}
+
+/// `teams/<active>/apps` — the app root for the team this daemon serves.
+pub fn active_apps_dir() -> PathBuf {
+    team_apps_dir(&active_team())
+}
+
 fn team_slug(team_id: &str) -> &str {
     let trimmed = team_id.trim();
     if trimmed.is_empty() {

--- a/apps/daemon/src/http/apps.rs
+++ b/apps/daemon/src/http/apps.rs
@@ -31,15 +31,61 @@ use super::auth::{require_scope, Principal};
 use super::errors::HttpError;
 use super::state::HttpState;
 
-/// The daemon's data root for per-app checkouts: `<amuxd home>/apps`.
+/// The daemon's data root for per-app checkouts: `teams/<active>/apps`.
 ///
 /// It used to say it mirrored `DaemonConfig::config_dir()` while actually
 /// re-deriving `$HOME/.amuxd` by hand — so it honoured neither `$AMUXD_HOME`
 /// nor the brand, and a white-label daemon cloned apps into the official
 /// build's home. Call the real thing.
 ///
+/// It then lived under `state/`, which is daemon bookkeeping; an app checkout
+/// is the user's own project. Existing checkouts are moved by
+/// [`migrate_legacy_apps_root`], which the daemon calls once at startup.
+///
+/// This function only computes a path. It briefly did the migration too, and a
+/// plain `cargo test` — which runs against the real `$HOME` — then renamed a
+/// developer's actual app directory as a side effect of asking where apps live.
 pub fn apps_data_root() -> PathBuf {
-    crate::config::layout::active_state_dir().join("apps")
+    crate::config::layout::active_apps_dir()
+}
+
+/// Move `state/apps` to its new home beside it, once. Called at startup.
+///
+/// A rename, so every checkout keeps its identity, its git history and its
+/// `node_modules`. Skipped when the destination already exists: merging two
+/// app roots is not a decision this function can make, and the legacy one is
+/// left untouched for recovery rather than deleted.
+///
+/// Deliberately NOT called from `apps_data_root()`: a path accessor that moves
+/// directories rewrote a developer's home during an ordinary `cargo test`.
+pub fn migrate_legacy_apps_root() {
+    let legacy = crate::config::layout::active_state_dir().join("apps");
+    migrate_legacy_apps_root_from(&legacy, &apps_data_root());
+}
+
+/// [`migrate_legacy_apps_root`] with both paths given, so the rule is testable
+/// without pointing the whole daemon at a temp home.
+fn migrate_legacy_apps_root_from(legacy: &std::path::Path, dest: &std::path::Path) {
+    if dest.exists() {
+        return;
+    }
+    if !legacy.is_dir() {
+        return;
+    }
+    if let Some(parent) = dest.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            tracing::warn!(error = %e, "apps: could not create team dir for migration");
+            return;
+        }
+    }
+    match std::fs::rename(legacy, dest) {
+        Ok(()) => {
+            tracing::info!(from = %legacy.display(), to = %dest.display(), "apps: moved app root out of state/")
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, from = %legacy.display(), "apps: could not move app root; leaving it in place")
+        }
+    }
 }
 
 /// Resolve the clone target for a seed request.
@@ -93,6 +139,35 @@ pub struct SeedAppBody {
 #[serde(rename_all = "camelCase")]
 pub struct SeedAppResponse {
     pub status: &'static str,
+    /// Where the app actually lives. Returned so the caller never has to
+    /// compute it: the desktop used to derive `~/.amuxd/apps/<id>` by hand,
+    /// which stopped matching this daemon's answer the moment the layout moved
+    /// — the agent then edited one directory while deploys built another, and
+    /// the deployed site silently stayed the seed template.
+    pub workdir: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppWorkdirResponse {
+    pub workdir: String,
+}
+
+/// `GET /v1/apps/:appId/workdir` — where this daemon keeps that app.
+///
+/// The single source of truth for the path, for callers that did not just seed
+/// (opening the app's session, revealing it in Finder). Answers for an app that
+/// has never been seeded too: the path is derived, not looked up.
+pub async fn app_workdir(
+    principal: Principal,
+    State(_state): State<HttpState>,
+    axum::extract::Path(app_id): axum::extract::Path<String>,
+) -> Result<Json<AppWorkdirResponse>, HttpError> {
+    require_scope(&principal, "workspace:read")?;
+    let path = resolve_workdir("", &app_id)?;
+    Ok(Json(AppWorkdirResponse {
+        workdir: path.to_string_lossy().into_owned(),
+    }))
 }
 
 /// `POST /v1/apps/seed` — write the starter template into the app's checkout
@@ -115,6 +190,7 @@ pub async fn seed_app(
     if let Some(parent) = workdir_path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
+    let seeded_at = workdir_path.to_string_lossy().into_owned();
 
     let app_id = body.app_id.trim().to_string();
     let app_name = if body.app_name.trim().is_empty() {
@@ -138,7 +214,10 @@ pub async fn seed_app(
     .map_err(|e| HttpError::internal(format!("seed task panicked: {e}")))?
     .map_err(|e| HttpError::internal(format!("app seed failed: {e}")))?;
 
-    Ok(Json(SeedAppResponse { status: "ready" }))
+    Ok(Json(SeedAppResponse {
+        status: "ready",
+        workdir: seeded_at,
+    }))
 }
 
 #[derive(Debug, Deserialize)]
@@ -264,6 +343,59 @@ mod tests {
         let p = resolve_workdir("", "app-xyz").unwrap();
         assert_eq!(p, apps_data_root().join("app-xyz"));
         assert!(p.ends_with("apps/app-xyz"));
+    }
+
+    #[test]
+    fn apps_live_beside_state_not_inside_it() {
+        // An app checkout is the user's own project, not daemon bookkeeping —
+        // and the desktop opens it as an agent session's working directory.
+        let root = apps_data_root();
+        assert!(root.ends_with("apps"), "got {}", root.display());
+        assert!(
+            !root.to_string_lossy().contains("/state/"),
+            "app root must not sit under state/: {}",
+            root.display()
+        );
+    }
+
+    #[test]
+    fn legacy_state_apps_root_is_moved_not_copied() {
+        // The deploy pipeline builds whatever is at the new path. Leaving the
+        // old checkouts behind would ship the seed template forever, with the
+        // user's real work sitting in a directory nothing reads.
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("state").join("apps");
+        std::fs::create_dir_all(legacy.join("app-1")).unwrap();
+        std::fs::write(legacy.join("app-1").join("index.html"), b"real work").unwrap();
+
+        let dest = tmp.path().join("apps");
+        migrate_legacy_apps_root_from(&legacy, &dest);
+
+        assert!(!legacy.exists(), "legacy root must be gone, not duplicated");
+        assert_eq!(
+            std::fs::read_to_string(dest.join("app-1").join("index.html")).unwrap(),
+            "real work",
+        );
+    }
+
+    #[test]
+    fn migration_leaves_both_alone_when_the_new_root_already_exists() {
+        // Merging two app roots is not a decision this function can make, so
+        // the legacy one stays put and stays recoverable.
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = tmp.path().join("state").join("apps");
+        std::fs::create_dir_all(legacy.join("app-1")).unwrap();
+        let dest = tmp.path().join("apps");
+        std::fs::create_dir_all(dest.join("app-2")).unwrap();
+
+        migrate_legacy_apps_root_from(&legacy, &dest);
+
+        assert!(
+            legacy.join("app-1").is_dir(),
+            "legacy must survive untouched"
+        );
+        assert!(dest.join("app-2").is_dir());
+        assert!(!dest.join("app-1").exists(), "nothing may be merged in");
     }
 
     #[test]

--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -109,6 +109,10 @@ pub fn build(state: HttpState) -> Router {
         // App build: pnpm build + zip `.output`, upload artifact to a presigned
         // OSS PUT URL. Kicked by the cloud deploy orchestration.
         .route("/v1/apps/build", post(apps::build_app))
+        // Where this daemon keeps an app. The desktop asks instead of deriving
+        // the path itself — two copies of that rule drifted apart once and the
+        // agent then edited a directory no deploy ever built.
+        .route("/v1/apps/{app_id}/workdir", get(apps::app_workdir))
         // Device-level provider config (#742). Credentials are per-machine, not
         // per-workspace, so these need no workspace id — which is what lets
         // first-run onboarding configure a model before a project is chosen.

--- a/apps/daemon/src/main.rs
+++ b/apps/daemon/src/main.rs
@@ -132,6 +132,11 @@ fn main() -> anyhow::Result<()> {
             cli::process::prepare_daemon_start();
             config::layout::purge_v1_layout();
             config::layout::ensure();
+            // App checkouts moved out of `state/` and into `teams/<id>/apps`.
+            // Done here, at boot, and never from the path accessor: the deploy
+            // pipeline builds whatever sits at the new path, so a checkout left
+            // behind would keep shipping the seed template.
+            http::apps::migrate_legacy_apps_root();
             cli::process::write_pidfile()?;
             let _pid_guard = PidfileGuard;
             // Absent config bootstraps rather than failing: a fresh install must

--- a/packages/app/src/lib/app-session.ts
+++ b/packages/app/src/lib/app-session.ts
@@ -14,21 +14,21 @@ import { useCurrentTeamStore } from '@/stores/current-team'
 import { useAuthStore } from '@/stores/auth-store'
 import { isTauri } from '@/lib/utils'
 import { resolveAppType } from '@/lib/app-types'
-import { appShortName, resolveAmuxdDirName } from '@/lib/build-config'
 import type { AppRow, AppSessionRow } from '@/lib/backend/types'
 
-/** Resolve the local daemon's per-app workdir: `~/.amuxd[-brand]/apps/<appId>`. */
+/**
+ * The local daemon's per-app workdir.
+ *
+ * Asked of the daemon rather than computed here. This used to derive
+ * `~/.amuxd[-brand]/apps/<appId>` from the home directory — a second copy of a
+ * rule the daemon also owns. When the daemon's app root moved, the two answers
+ * diverged silently: agent sessions opened one directory while `deploy` built
+ * another, so a finished site kept deploying as the untouched seed template.
+ */
 export async function appWorkdirPath(appId: string): Promise<string | null> {
   if (!isTauri()) return null
-  try {
-    const { homeDir } = await import('@tauri-apps/api/path')
-    const home = await homeDir()
-    const amuxd = resolveAmuxdDirName(appShortName)
-    return `${home}/.${amuxd}/apps/${appId}`
-  } catch (e) {
-    console.warn('[app-session] could not resolve home dir (non-fatal):', e)
-    return null
-  }
+  const { daemonAppWorkdir } = await import('@/lib/daemon-local-client')
+  return daemonAppWorkdir(appId)
 }
 
 /**

--- a/packages/app/src/lib/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon-local-client.ts
@@ -1097,6 +1097,33 @@ export async function seedDaemonApp(
  */
 export type BuildAppOutcome = "built" | "failed" | "unreachable";
 
+/**
+ * Where the local daemon keeps this app's checkout.
+ *
+ * Asked, never derived. The desktop used to compute `~/.amuxd/apps/<id>` from
+ * the home directory; when the daemon moved its app root, the two answers
+ * diverged and the agent edited a directory that no deploy ever built — the
+ * deployed site stayed the seed template with nothing reporting an error.
+ *
+ * Returns null when the daemon is unreachable or too old to answer, so callers
+ * degrade to "no local path" instead of guessing a wrong one.
+ */
+export async function daemonAppWorkdir(appId: string): Promise<string | null> {
+  try {
+    const result = await daemonFetch<{ workdir: string }>(
+      `/v1/apps/${encodeURIComponent(appId)}/workdir`,
+    )
+    if (!result.ok) {
+      console.warn('[daemon-local-client] app workdir unavailable (non-fatal):', result.error)
+      return null
+    }
+    return result.data.workdir?.trim() || null
+  } catch (err) {
+    console.warn('[daemon-local-client] app workdir unavailable:', err)
+    return null
+  }
+}
+
 export async function buildDaemonApp(
   appId: string,
   teamId: string,


### PR DESCRIPTION
## 现象

部署上线的页面永远是播种时的模板，用户在 app 里做的任何改动都不出现 —— **全程没有任何一层报错**，部署还报成功。

## 根因：桌面端和 daemon 各写各的目录

| 目录 | 谁在写 | 里面有什么 |
|---|---|---|
| `~/.amuxd/apps/<appId>` | **桌面端**（`app-session.ts` 自己算路径），agent 会话的 cwd | 用户做的真实站点 |
| `<team>/state/apps/<appId>` | **daemon**（seed + build 都在这） | 播种模板 + 构建脚手架 |

agent 和用户写的一切落在第一个目录，`deploy` 构建打包的是第二个。第一个目录里连 `package.json` 都没有（构建脚手架在另一边），所以那里根本没法构建 —— 而它恰恰是唯一被编辑的目录。

顺带解释了另一个怪象：`is_app_workspace()` 认不出桌面端那个路径，于是 app 目录里被塞了一个本不该有的 `teamclu-team` 软链。

## 修法

**一、路径只有 daemon 说了算。** 新增 `GET /v1/apps/{app_id}/workdir`，`seed` 响应也带回 `workdir`；桌面端改成**问**而不是**算**。重复计算这条规则本身就是 bug 的成因 —— 两份实现只要有一份变了，就会分叉，而且是静默分叉。

**二、app 根目录从 `<team>/state/apps` 移到 `<team>/apps`。** app checkout 是用户自己的项目，不是 daemon 的记账，而且它是 agent 会话直接打开的工作目录。`layout.rs` 里本来就写着规矩：团队的每样东西都是 `shared/` 的兄弟，不嵌进去。

已有 checkout 在**守护进程启动时**整体 rename 迁移（保留 git 历史和 `node_modules`）；目标已存在时不做合并，旧目录原地保留等人工处理。

## 一个我自己踩的坑，也写进注释了

迁移最初放在 `apps_data_root()` 里。那是个**纯路径函数**，而 daemon 的测试跑在真实 `$HOME` 上 —— 于是一次普通的 `cargo test` 真的把我机器上的 app 目录改了名。已改成只在启动时调用，并在两处注释里写明原因。

## 验证

- daemon 10 个用例过，含新增 3 条：app 根不得在 `state/` 下、旧根必须是**移动**而非复制、目标已存在时两边都不动
- `cargo check` / `clippy` 干净（只剩既有告警），改动的两个文件 `rustfmt --check` 干净
- 前端 `tsc` 干净，apps store 14 个用例过

## 本机数据已迁移

两个 app 都已合并到 `<team>/apps/<id>`（内容 + 构建脚手架），旧目录保留为 `.pre-migration-backup`，并在旧路径上留了软链，好让**当前这版**桌面端/daemon 也照常工作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
