### PR TITLE
fix(deps): @codemirror/view 收敛成一份，修好被打断的发版

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -38,7 +38,7 @@
     "@codemirror/search": "^6.7.1",
     "@codemirror/state": "^6.7.0",
     "@codemirror/theme-one-dark": "^6.1.3",
-    "@codemirror/view": "^6.43.6",
+    "@codemirror/view": "^6.43.8",
     "@json-render/core": "^0.19.0",
     "@json-render/react": "^0.19.0",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       '@codemirror/view':
-        specifier: ^6.43.6
-        version: 6.43.6
+        specifier: ^6.43.8
+        version: 6.43.8
       '@json-render/core':
         specifier: ^0.19.0
         version: 0.19.0(zod@4.4.3)
@@ -955,9 +955,6 @@ packages:
 
   '@codemirror/theme-one-dark@6.1.3':
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
-
-  '@codemirror/view@6.43.6':
-    resolution: {integrity: sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==}
 
   '@codemirror/view@6.43.8':
     resolution: {integrity: sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==}
@@ -9189,14 +9186,14 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.0
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
 
   '@codemirror/commands@6.10.3':
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.0
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
 
   '@codemirror/lang-css@6.3.1':
@@ -9214,7 +9211,7 @@ snapshots:
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.0
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
       '@lezer/html': 1.3.13
@@ -9225,7 +9222,7 @@ snapshots:
       '@codemirror/language': 6.12.4
       '@codemirror/lint': 6.9.5
       '@codemirror/state': 6.7.0
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
 
@@ -9240,7 +9237,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.0
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/markdown': 1.6.3
 
@@ -9271,7 +9268,7 @@ snapshots:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.0
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/xml': 1.0.6
 
@@ -9288,7 +9285,7 @@ snapshots:
   '@codemirror/language@6.12.4':
     dependencies:
       '@codemirror/state': 6.7.0
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -9297,7 +9294,7 @@ snapshots:
   '@codemirror/lint@6.9.5':
     dependencies:
       '@codemirror/state': 6.7.0
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       crelt: 1.0.7
 
   '@codemirror/search@6.7.1':
@@ -9314,15 +9311,8 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/state': 6.7.0
-      '@codemirror/view': 6.43.6
+      '@codemirror/view': 6.43.8
       '@lezer/highlight': 1.2.3
-
-  '@codemirror/view@6.43.6':
-    dependencies:
-      '@codemirror/state': 6.7.0
-      crelt: 1.0.7
-      style-mod: 4.1.3
-      w3c-keyname: 2.2.8
 
   '@codemirror/view@6.43.8':
     dependencies:


### PR DESCRIPTION
**main 从 8/18 22:36 起就是红的，昨晚的定时发版因此没发出任何东西。**

## 昨晚发生了什么

| 时间（北京） | 事件 |
|---|---|
| 8/18 22:36 | #956（Dependabot：`@codemirror/search` 6.6.0 → 6.7.1）合入，**CI 当场变红** |
| 8/19 00:17 | 定时发版触发，版本推到 `v0.4.1-beta.17`，派发 copilot361 / betly 两个构建 |
| 00:20 | 两个品牌的 **macOS + Windows 全部失败**，`publish-manifest` 跳过 —— **什么都没发出去** |

那个 17 秒就"成功"的 `Nightly OSS Release` 只是调度器（推版本号 + 派发），它绿不代表发版成功。真正干活的两个 run 都是 `failure`。

## 根因

`@codemirror/search@6.7.1` 依赖 `@codemirror/view: 6.43.8`，而 app 自己的解析锁在 `6.43.6` —— lockfile 里于是同时存在两份：

```
'@codemirror/view@6.43.6
'@codemirror/view@6.43.8
```

两个副本的 `KeyBinding` 是**不同的类型**。`CodeEditor.tsx` / `MarkdownEditor.tsx` 把 `searchKeymap`（来自 6.43.8）和自己 import 的 keymap（6.43.6）放进同一个数组，`tsc` 报 TS2322 / TS2345，`tsc -b && vite build` 挂掉，整条桌面打包链跟着断。

## 修法

app 声明的 `^6.43.6` **本来就涵盖 6.43.8** —— 只是 lockfile 里的解析早已钉死，而 Dependabot 那次只改了 `search` 一条。把 spec 抬到 `^6.43.8`，两边落在同一份上。

**为什么不用 `pnpm dedupe`**：它确实能收敛，但会顺手合并整个 monorepo 里所有重复依赖，lockfile 动 **2100 行**（−1907/+193）。为修一个发版问题引入那么大的面，既难评审又容易带出新问题。本 PR 只动 **34 行**，diff 全部是「`6.43.6` → `6.43.8`」加删掉那份重复条目。

## 验证

特意跑了**发版实际用的那条命令**，而不只是 CI 的 typecheck：

- `packages/app` 的 `tsc -b && vite build` —— ✅ 通过（就是昨晚挂掉的那条）
- `pnpm typecheck` —— 0 错误
- 前端单测 —— 446 文件 / 2885 用例全绿
- `pnpm lint` —— 0 error

## 合并之后

今晚的定时发版才会正常。建议合并后手动触发一次 `nightly-release-oss` 补上今天的构建，不用等到 00:17。

另外 `chore(release): nightly beta v0.4.1-beta.17` 这个版本号**已经推到 main 了但从未发布成功** —— 今晚会再推一个 beta.18，beta.17 会成为一个空洞的版本号，值得确认这对更新器有没有影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)