### PR TITLE
fix(invites): 凭据轮换不再换掉数字员工的账号

### DIFF
--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -70,6 +70,10 @@ jobs:
           - target: x86_64-apple-darwin
             runner: macos-latest
     runs-on: ${{ matrix.runner }}
+    # Backstop: a hung step must not squat the 360-minute default and
+    # starve publish-manifest. Healthy peak over the last 6 releases was
+    # 33.0 min.
+    timeout-minutes: 90
     # Job-level, not step-level: these used to sit only on the tauri-action step,
     # so the amuxd and teamclu-introspect sidecar builds (and the Cargo.lock
     # sync) compiled with no sccache at all — despite sharing most of their
@@ -426,6 +430,10 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    # Backstop: a hung step must not squat the 360-minute default and
+    # starve publish-manifest. Healthy peak over the last 6 releases was
+    # 42.2 min.
+    timeout-minutes: 90
     # See build-macos: hoisted off the tauri-action step so the amuxd (~495s) and
     # introspect (~87s) sidecar builds get sccache too.
     env:
@@ -690,6 +698,10 @@ jobs:
 
   build-amuxd-linux:
     runs-on: ubuntu-latest
+    # Backstop: a hung step must not squat the 360-minute default and
+    # starve publish-manifest. Healthy peak over the last 6 releases was
+    # 10.2 min.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -709,11 +721,25 @@ jobs:
           oss-endpoint-default: ${{ env.OSS_ENDPOINT_DEFAULT }}
           cdn-base-default: ${{ env.CDN_BASE_DEFAULT }}
 
-      - name: Install Rust target + protoc
-        run: |
-          rustup target add ${{ matrix.target }}
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+      # NOT `apt-get install protobuf-compiler`. The ubuntu runner's
+      # /etc/apt/apt-mirrors.txt puts the Azure-internal mirror first and the
+      # public archive.ubuntu.com second; when the Azure mirror goes bad every
+      # request is Ign:'d, apt falls back to the public archive over HTTPS, and
+      # that fetch hangs with no timeout that ever fires. It hit 5 of the 8
+      # amuxd-linux jobs across the 2026-08-18 and 2026-08-19 nightlies, each
+      # time squatting until cancelled. publish-manifest tolerates a failed
+      # amuxd job (see its `if:`) but still `needs:` it, so the cost is a
+      # release delayed by up to the 360-minute job default and a manifest
+      # shipped one amuxd binary short. arduino/setup-protoc pulls a pinned
+      # protoc from GitHub Releases and never touches an Ubuntu mirror -- the
+      # same action ci.yml's daemon-windows job already builds amuxd with.
+      - name: Install protoc (for prost_build)
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -775,6 +801,9 @@ jobs:
     # artifacts get rendered; any missing platform is simply omitted.
     if: always() && needs.build-macos.result == 'success' && needs.build-windows.result == 'success'
     runs-on: ubuntu-latest
+    # Backstop against a hung step burning the 360-minute job default.
+    # Healthy peak over the last 6 releases was 0.5 min.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 

--- a/services/fc/src/lib/pg-repo/auth.ts
+++ b/services/fc/src/lib/pg-repo/auth.ts
@@ -512,33 +512,76 @@ export function createPgAuthRepository(
       }
 
       if (kind === "agent") {
-        // Create a daemon Better-Auth user via internalAdapter.createUser
-        // (same surface used by mintSession for createSession)
         const ctx2 = await (auth as any).$context;
-        const daemonEmail = `daemon.${randomUUID()}@amuxd.run`;
-        const daemonUser = await ctx2.internalAdapter.createUser({
-          email: daemonEmail,
-          name: invite.displayName,
-          emailVerified: false,
-        });
-        if (!daemonUser?.id) throw new Error("failed to create daemon Better-Auth user");
 
-        const minted = await mintSession(daemonUser.id, auth);
+        // Which account do these credentials belong to? A rebind
+        // (invite.targetActorId) keeps the one the agent actor already has:
+        // rotation is supposed to replace the *credential*, not the identity,
+        // and everything durable is keyed on that user id (public.users and its
+        // admin_type, user_metadata, grants). Anything else provisions one.
+        // Resolved before any write — the SQL twin is
+        // 20260819000000_claim_invite_keeps_daemon_user.sql.
+        let oldDaemonUserId: string | null = null;
+        let reusedUserId: string | null = null;
+        if (invite.targetActorId) {
+          const [old] = await db
+            .select({ userId: actors.userId })
+            .from(actors)
+            .where(eq(actors.id, invite.targetActorId))
+            .limit(1);
+          oldDaemonUserId = old?.userId ?? null;
+          if (oldDaemonUserId) {
+            // Conditional on the row still being there: actors.userId can point
+            // at an account an older rotation already deleted, and that one
+            // cannot be reused.
+            const [existing] = await db
+              .select({ id: user.id })
+              .from(user)
+              .where(eq(user.id, oldDaemonUserId))
+              .limit(1);
+            reusedUserId = existing?.id ?? null;
+          }
+        }
+
+        let daemonUserId: string;
+        if (reusedUserId) {
+          daemonUserId = reusedUserId;
+          // Revoke what the previous device still holds. Deleting the account
+          // used to do this as a side effect; reuse has to say it.
+          try {
+            await ctx2.internalAdapter.deleteSessions(daemonUserId);
+          } catch { /* best-effort */ }
+        } else {
+          // Create a daemon Better-Auth user via internalAdapter.createUser
+          // (same surface used by mintSession for createSession)
+          const daemonEmail = `daemon.${randomUUID()}@amuxd.run`;
+          const daemonUser = await ctx2.internalAdapter.createUser({
+            email: daemonEmail,
+            name: invite.displayName,
+            emailVerified: false,
+          });
+          if (!daemonUser?.id) throw new Error("failed to create daemon Better-Auth user");
+          daemonUserId = daemonUser.id;
+        }
+
+        const minted = await mintSession(daemonUserId, auth);
 
         // Compensation helper: if the DB transaction fails, clean up the orphaned
         // Better-Auth user + session so no zombie credentials are left behind.
+        // Only for an account this call created — a reused one predates the
+        // claim and must outlive a failed one.
         async function compensate() {
+          if (reusedUserId) return;
           try {
-            await ctx2.internalAdapter.deleteSessions(daemonUser.id);
+            await ctx2.internalAdapter.deleteSessions(daemonUserId);
           } catch { /* best-effort */ }
           try {
             if (typeof ctx2.internalAdapter.deleteUser === "function") {
-              await ctx2.internalAdapter.deleteUser(daemonUser.id);
+              await ctx2.internalAdapter.deleteUser(daemonUserId);
             }
           } catch { /* best-effort */ }
         }
 
-        let oldDaemonUserId: string | null = null;
         let result!: { actorId: string; teamId: string; actorType: "agent"; displayName: string; refreshToken: string | null };
         try {
           result = await (db as any).transaction(async (tx: any) => {
@@ -546,11 +589,8 @@ export function createPgAuthRepository(
 
           if (invite.targetActorId) {
             // Rebind path: reuse the existing actor + agent rows, just update them.
-            const [old] = await tx.select({ userId: actors.userId }).from(actors).where(eq(actors.id, invite.targetActorId)).limit(1);
-            oldDaemonUserId = old?.userId ?? null;
-
             await (tx.update(actors) as any)
-              .set({ userId: daemonUser.id, invitedByActorId: invite.invitedByActorId, lastActiveAt: null, updatedAt: new Date() })
+              .set({ userId: daemonUserId, invitedByActorId: invite.invitedByActorId, lastActiveAt: null, updatedAt: new Date() })
               .where(eq(actors.id, invite.targetActorId));
 
             await (tx.update(agents) as any)
@@ -568,7 +608,7 @@ export function createPgAuthRepository(
               teamId: invite.teamId,
               actorType: "agent",
               displayName: invite.displayName,
-              userId: daemonUser.id,
+              userId: daemonUserId,
               invitedByActorId: invite.invitedByActorId,
             }).returning();
 
@@ -611,7 +651,9 @@ export function createPgAuthRepository(
         // Best-effort cleanup of the previous daemon user the agent was bound to.
         // Done AFTER commit and OUTSIDE the drizzle tx: pglite is single-connection, so a
         // Better-Auth adapter query issued inside the open tx would deadlock. Idempotent.
-        if (oldDaemonUserId && oldDaemonUserId !== daemonUser.id) {
+        // A reused account fails this guard, which is the point: it IS the
+        // account the agent is now bound to.
+        if (oldDaemonUserId && oldDaemonUserId !== daemonUserId) {
           try { await ctx2.internalAdapter.deleteSessions(oldDaemonUserId); } catch { /* ignore */ }
           try {
             if (typeof ctx2.internalAdapter.deleteUser === "function") {

--- a/services/fc/test/pg-repo-claim.test.ts
+++ b/services/fc/test/pg-repo-claim.test.ts
@@ -300,13 +300,15 @@ test("claimInvite agent with targetActorId: rebinds existing agent, no new agent
   assert.equal(after.ownerMemberId, inviterActorId, "ownerMemberId unchanged");
 });
 
-test("claimInvite agent with targetActorId: rotates actor.userId off the old daemon user", async () => {
+test("claimInvite agent with targetActorId: provisions an account when the actor's old one is gone", async () => {
   const { repo, db } = await setup();
   const { teamId, inviterActorId } = await createTeamAndInviter(db);
   const { agents: agentsTable } = await import("../src/db/schema/index.js");
 
-  // Existing agent already bound to a (stale) daemon user — exercises the
-  // old-user cleanup branch in the rebind path.
+  // The actor points at a user id that is not in the user table (an account an
+  // older rotation already deleted). Reuse is conditional on the row actually
+  // being there, so this claim has to provision a fresh one and collect the
+  // dangling id — the other half of the rebind path.
   const oldUserId = `old-daemon-${randomBytes(4).toString("hex")}`;
   const [agActor] = await db.insert(actors).values({
     teamId,
@@ -340,6 +342,52 @@ test("claimInvite agent with targetActorId: rotates actor.userId off the old dae
   const [after] = await db.select().from(actors).where(eq(actors.id, agActor.id)).limit(1);
   assert.ok(after.userId, "actor has a userId after rebind");
   assert.notEqual(after.userId, oldUserId, "actor.userId rotated off the old daemon user");
+});
+
+test("claimInvite agent with targetActorId: keeps the account the agent already has", async () => {
+  // Rotation replaces the credential, not the identity. The previous body
+  // minted a new account on every rebind and deleted the old one, which reset
+  // everything keyed on that user id (public.users.admin_type above all) —
+  // see 20260819000000_claim_invite_keeps_daemon_user.sql for the SQL twin.
+  const { repo, db } = await setup();
+  const { teamId, inviterActorId } = await createTeamAndInviter(db);
+  const { user } = await import("../src/db/schema/auth.js");
+
+  // First claim mints the daemon account.
+  const firstToken = await createInvite(db, {
+    teamId,
+    invitedByActorId: inviterActorId,
+    kind: "agent",
+    displayName: "Badge Bot",
+  });
+  const first = await repo.claimInvite(firstToken, {});
+  const [bound] = await db.select().from(actors).where(eq(actors.id, first.actorId)).limit(1);
+  const daemonUserId = bound.userId!;
+  assert.ok(daemonUserId, "first claim bound the actor to a daemon account");
+
+  // Rotate: re-invite the same agent actor.
+  const rebindToken = randomBytes(24).toString("base64url");
+  await db.insert(teamInvites).values({
+    teamId,
+    token: rebindToken,
+    kind: "agent",
+    agentKind: "daemon",
+    displayName: "Badge Bot",
+    invitedByActorId: inviterActorId,
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    targetActorId: first.actorId,
+  });
+  const second = await repo.claimInvite(rebindToken, {});
+
+  assert.equal(second.actorId, first.actorId, "rebinds the same agent actor");
+  const [after] = await db.select().from(actors).where(eq(actors.id, first.actorId)).limit(1);
+  assert.equal(after.userId, daemonUserId, "actor keeps the account it already had");
+
+  const [stillThere] = await db.select().from(user).where(eq(user.id, daemonUserId)).limit(1);
+  assert.ok(stillThere, "the account row survives the rotation");
+
+  assert.ok(second.refreshToken, "rotation still returns a refresh token");
+  assert.notEqual(second.refreshToken, first.refreshToken, "the credential itself is replaced");
 });
 
 test("claimInvite: expired invite throws not_found/expired", async () => {

--- a/services/supabase/migrations/20260819000000_claim_invite_keeps_daemon_user.sql
+++ b/services/supabase/migrations/20260819000000_claim_invite_keeps_daemon_user.sql
@@ -1,0 +1,217 @@
+-- Stop credential rotation from replacing the agent's account.
+--
+-- The agent branch of amux.claim_team_invite_legacy opened with
+--
+--     v_user_id := gen_random_uuid();
+--
+-- before it had even looked at p_token's target_actor_id. A rebind claim — the
+-- "重新生成邀请" button on an existing agent, i.e. every credential rotation:
+-- re-onboarding a machine, switching teams, a refresh_token that expired —
+-- therefore always minted a *new* auth.users row, pointed the actor at it, and
+-- deleted the row the actor used to have. The deletion was only cleaning up the
+-- user the same call had just orphaned.
+--
+-- Nothing needed a new account. auth.sessions/auth.refresh_tokens are per
+-- session, not per user: minting a fresh credential for the account that
+-- already exists is one INSERT, and it is what the pg-repo twin's
+-- mintSession(userId) does. What the rotate-and-delete costs instead is every
+-- durable fact keyed on the daemon's user id:
+--
+--   * public.users — a SUBSET mirror of saas-mono's table on the merged
+--     instance. The claim seeds `(id, org_id, mobile)` and nothing else, so a
+--     new row lands with admin_type at its DEFAULT 1 (普通用户). Any grant an
+--     operator made to the digital employee's account is silently back to zero
+--     after the next rotation, and only service_role can re-apply it
+--     (prevent_admin_type_change).
+--   * anything else saas-mono keys by user id — user_metadata rows (the
+--     `team_claw_device_binding` the device-header lane resolves), roles_users,
+--     audit trails.
+--
+-- The agent actor is stable across rotations by design — that is the entire
+-- point of target_actor_id. Its account now is too.
+--
+-- Behaviour that deliberately does NOT change:
+--
+--   * The previous credential still dies. Deleting the user used to revoke it
+--     implicitly; the reuse path deletes that account's sessions and refresh
+--     tokens explicitly instead, so an old daemon holding the previous
+--     refresh_token is cut off exactly as before.
+--   * A first claim (no target_actor_id) still creates the account, and a
+--     rebind whose actor points at a user that no longer exists still creates
+--     one — reuse is conditional on the row actually being there, which is also
+--     what keeps this safe to deploy over data the old function already
+--     rotated.
+--   * raw_app_meta_data's org_id is refreshed on reuse, so a rebind onto a team
+--     in another org updates the claim teams_org_guard reads.
+--
+-- Carried forward from 20260817000000_org_gc_keeps_public_orgs.sql. The member
+-- branch is untouched; the agent branch is reordered so the account decision
+-- happens before the account is created.
+
+CREATE OR REPLACE FUNCTION amux.claim_team_invite_legacy(p_token text)
+ RETURNS TABLE(actor_id uuid, team_id uuid, actor_type text, display_name text, refresh_token text)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'amux', 'public', 'auth', 'extensions'
+AS $function$
+declare
+  v_invite      amux.team_invites%rowtype;
+  v_user_id     uuid;
+  v_actor       uuid;
+  v_email       text;
+  v_session     uuid;
+  v_rt          text := null;
+  v_old_user    uuid;
+  v_target_anon boolean;
+  v_team_org    uuid;   -- invite team's org (S3-FC.3)
+  v_old_org     uuid;   -- claimer's previous org (member path)
+begin
+  select * into v_invite from amux.team_invites where token = p_token for update;
+  if not found then raise exception 'invite not found' using errcode = '23503'; end if;
+  if v_invite.consumed_at is not null then raise exception 'invite already consumed' using errcode = '23514'; end if;
+  if v_invite.status = 'declined' then raise exception 'invite was declined' using errcode = '23514'; end if;
+  if v_invite.status = 'expired' then raise exception 'invite superseded' using errcode = '23514'; end if;
+  if v_invite.expires_at < now() then raise exception 'invite expired' using errcode = '23514'; end if;
+
+  -- Resolved once for both branches: members get public.users.org_id switched,
+  -- agents get the claim baked into raw_app_meta_data.
+  select oid into v_team_org from amux.teams where id = v_invite.team_id;
+
+  if v_invite.kind = 'member' then
+    if v_invite.target_actor_id is not null then
+      -- Unconsumed tokens minted before the removal still carry a target. They
+      -- are refused rather than degraded into a self-join: the token was issued
+      -- to hand back somebody else's credentials, not to add the caller.
+      raise exception 'member re-invite is no longer supported' using errcode = '22023';
+    else
+      v_user_id := auth.uid();
+      if v_user_id is null then raise exception 'member claim requires authentication' using errcode = '42501'; end if;
+      if exists (select 1 from amux.actors act where act.team_id = v_invite.team_id and act.user_id = v_user_id) then
+        raise exception 'already a member of this team' using errcode = '23505';
+      end if;
+
+      insert into amux.actors (team_id, actor_type, user_id, invited_by_actor_id, display_name, last_active_at)
+      values (v_invite.team_id, 'member', v_user_id, v_invite.invited_by_actor_id, v_invite.display_name, now())
+      returning id into v_actor;
+      insert into amux.members (id, status) values (v_actor, 'active');
+      insert into amux.team_members (team_id, member_id, role) values (v_invite.team_id, v_actor, v_invite.team_role);
+    end if;
+
+    -- S3-FC.3: strict single-org — claimer's org becomes the invite team's org.
+    if v_team_org is not null and v_user_id is not null then
+      select org_id into v_old_org from public.users where id = v_user_id;
+      if v_old_org is null then
+        insert into public.users (id, org_id, mobile) values (v_user_id, v_team_org, '');
+      else
+        update public.users set org_id = v_team_org, updated_at = now() where id = v_user_id;
+      end if;
+      -- best-effort GC of OUR teams under the abandoned old org; never fail the
+      -- claim. public.orgs is deliberately left alone — see 20260817000000: that
+      -- row belongs to saas-mono, and on a merged instance deleting it cascades
+      -- into another product's data.
+      begin
+        if v_old_org is not null and v_old_org <> v_team_org
+           and not exists (select 1 from public.users where org_id = v_old_org) then
+          delete from amux.teams where oid = v_old_org;   -- cascades actors/members/sessions/...
+        end if;
+      exception when others then
+        null;  -- leave the orphan; reassignment already succeeded
+      end;
+    end if;
+  else
+    -- Which account do these credentials belong to? A rebind reuses the one the
+    -- agent actor already has; everything else mints one. Resolved BEFORE any
+    -- write, which is the whole change — the old body created an account first
+    -- and discovered the answer afterwards.
+    if v_invite.target_actor_id is not null then
+      select user_id into v_old_user from amux.actors where id = v_invite.target_actor_id;
+      if v_old_user is not null and exists (select 1 from auth.users u where u.id = v_old_user) then
+        v_user_id := v_old_user;
+      end if;
+    end if;
+
+    v_session := gen_random_uuid();
+    v_rt      := substring(encode(extensions.gen_random_bytes(6), 'hex'), 1, 12);
+
+    if v_user_id is null then
+      v_user_id := gen_random_uuid();
+      v_email   := format('daemon.%s@amuxd.run', v_user_id);
+      -- Stamp the team's org into app_metadata so daemon access tokens pass
+      -- teams_org_guard (current_org_id() reads the JWT claim first; daemon
+      -- users have no public.users fallback row).
+      insert into auth.users (id, email, email_confirmed_at, encrypted_password, confirmation_token, recovery_token,
+        email_change_token_new, email_change, raw_app_meta_data, aud, role, created_at, updated_at, instance_id)
+      values (v_user_id, v_email, now(), '', '', '', '', '',
+        case when v_team_org is not null then jsonb_build_object('org_id', v_team_org) else '{}'::jsonb end,
+        'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000');
+    else
+      -- Reuse. Refresh the org claim (a rebind can land the agent under a team
+      -- in another org), then revoke what the previous device still holds —
+      -- deleting the account used to do that as a side effect.
+      update auth.users
+         set raw_app_meta_data = case
+               when v_team_org is null then coalesce(raw_app_meta_data, '{}'::jsonb)
+               else coalesce(raw_app_meta_data, '{}'::jsonb) || jsonb_build_object('org_id', v_team_org)
+             end,
+             updated_at = now()
+       where id = v_user_id;
+      delete from auth.refresh_tokens where user_id = v_user_id::text;
+      delete from auth.sessions where user_id = v_user_id;
+    end if;
+
+    insert into auth.sessions (id, user_id, aal, created_at, updated_at) values (v_session, v_user_id, 'aal1', now(), now());
+    insert into auth.refresh_tokens (token, user_id, session_id, revoked, instance_id, created_at, updated_at)
+      values (v_rt, v_user_id::text, v_session, false, '00000000-0000-0000-0000-000000000000', now(), now());
+
+    -- Also give the daemon account a public.users fallback row with the team's
+    -- org, so org resolvers that query public.users by id directly (without the
+    -- JWT app_metadata.org_id claim) can resolve org_id instead of erroring.
+    -- On reuse this is the row whose other columns — admin_type above all — are
+    -- what the rotation used to throw away.
+    if v_team_org is not null then
+      insert into public.users (id, org_id, mobile) values (v_user_id, v_team_org, '')
+      on conflict (id) do update set org_id = excluded.org_id, updated_at = now();
+    end if;
+
+    if v_invite.target_actor_id is not null then
+      update amux.actors set user_id = v_user_id, invited_by_actor_id = v_invite.invited_by_actor_id,
+             last_active_at = null, updated_at = now() where id = v_invite.target_actor_id;
+      v_actor := v_invite.target_actor_id;
+      -- A device-scoped agent keeps whatever visibility it has. Every credential
+      -- rotation (team switch, expired refresh token) lands here, and forcing
+      -- 'team' turned each one into a silent publish of the machine. Agents with
+      -- no device_id keep the historical behaviour.
+      update amux.agents
+         set owner_member_id = v_invite.invited_by_actor_id,
+             visibility = case when device_id is not null then visibility else 'team' end,
+             updated_at = now()
+       where id = v_actor;
+      -- Only an account we could NOT reuse is collected: the actor pointed at a
+      -- user id that is no longer in auth.users, so the row this claim replaced
+      -- it with leaves nothing behind. When v_old_user IS the account in use,
+      -- this is a no-op — that is the fix.
+      if v_old_user is not null and v_old_user <> v_user_id then
+        delete from auth.users where id = v_old_user;
+      end if;
+    else
+      insert into amux.actors (team_id, actor_type, user_id, invited_by_actor_id, display_name, last_active_at)
+      values (v_invite.team_id, 'agent', v_user_id, v_invite.invited_by_actor_id, v_invite.display_name, null)
+      returning id into v_actor;
+      insert into amux.agents (id, owner_member_id, visibility, status) values (v_actor, v_invite.invited_by_actor_id, 'team', 'active');
+    end if;
+
+    insert into amux.agent_member_access (agent_id, member_id, permission_level, granted_by_member_id)
+    values (v_actor, v_invite.invited_by_actor_id, 'admin', v_invite.invited_by_actor_id)
+    on conflict (agent_id, member_id) do update
+      set permission_level = 'admin', granted_by_member_id = excluded.granted_by_member_id, updated_at = now();
+  end if;
+
+  update amux.team_invites set consumed_at = now(), consumed_by_actor_id = v_actor,
+         status = 'accepted', updated_at = now() where id = v_invite.id;
+
+  return query select v_actor, v_invite.team_id, v_invite.kind::text, v_invite.display_name, v_rt;
+end;
+$function$;
+
+comment on function amux.claim_team_invite_legacy(text) is
+  'Consumes an invite token. Member claims move the claimer onto the invite team''s org (strict single-org) and collect any amux.teams left under the org they vacated; public.orgs and its rows are never deleted here — that table is saas-mono-owned. Agent claims that name a target_actor_id rotate the credential in place: the agent keeps the auth.users account it already had, so anything keyed on that user id (public.users.admin_type, user_metadata, grants) survives the rotation.';

--- a/services/supabase/tests/034_claim_invite_keeps_daemon_user.sql
+++ b/services/supabase/tests/034_claim_invite_keeps_daemon_user.sql
@@ -1,0 +1,130 @@
+-- 034_claim_invite_keeps_daemon_user.sql
+--
+-- A rebind claim (create_team_invite with p_target_actor_id — the "重新生成邀请"
+-- path, i.e. every credential rotation) must replace the agent's *credential*,
+-- not its account. Before 20260819000000 the agent branch opened with
+-- `v_user_id := gen_random_uuid()` and deleted the account the actor had been
+-- bound to, which reset every durable fact keyed on that user id — public.users
+-- lands back at admin_type DEFAULT 1, and any grant an operator made to the
+-- digital employee's account was silently gone.
+--
+-- The fixture grants admin_type = 2 between the two claims because that is the
+-- property that has to survive; asserting only "same uuid" would pass on a
+-- function that kept the id and dropped the row.
+--
+-- The other half is revocation: deleting the account used to kill the previous
+-- refresh token as a side effect, so reuse has to do it explicitly or a retired
+-- device keeps a working credential.
+
+begin;
+
+select plan(6);
+
+create or replace function pg_temp.as_user(p_user uuid, p_org uuid default null)
+returns void language plpgsql as $$
+begin
+  perform set_config('request.jwt.claims',
+    case when p_org is null then
+      json_build_object('sub', p_user::text, 'role', 'authenticated')::text
+    else
+      json_build_object('sub', p_user::text, 'role', 'authenticated',
+                        'app_metadata', json_build_object('org_id', p_org::text))::text
+    end,
+    true);
+  perform set_config('role', 'authenticated', true);
+end;
+$$;
+
+-- ── Fixture: an org, its owner, and a team ──────────────────────────────────
+insert into public.orgs (id, name) values
+  ('9e000000-0000-4000-8000-000000000001', 'Daemon Reuse Org');
+
+insert into auth.users (id, email, aud, role, instance_id) values
+  ('9e000000-0000-4000-8000-0000000000a1', 'owner-daemonreuse@amux.test',
+   'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000')
+on conflict do nothing;
+
+insert into public.users (id, org_id, mobile) values
+  ('9e000000-0000-4000-8000-0000000000a1', '9e000000-0000-4000-8000-000000000001', '');
+
+select pg_temp.as_user('9e000000-0000-4000-8000-0000000000a1',
+                       '9e000000-0000-4000-8000-000000000001');
+
+create temp table team as
+  select team_id from amux.create_team('Daemon Reuse Team',
+    p_oid => '9e000000-0000-4000-8000-000000000001');
+grant select on team to anon, authenticated;
+
+-- ── First claim: the agent gets its account ─────────────────────────────────
+create temp table inv1 as
+  select * from amux.create_team_invite((select team_id from team), 'agent', 'Badge Bot',
+    p_agent_kind => 'daemon');
+grant select on inv1 to anon, authenticated;
+
+create temp table claim1 as
+  select * from amux.claim_team_invite((select token from inv1));
+grant select on claim1 to anon, authenticated;
+
+reset role;
+
+create temp table before as
+  select a.user_id, (select refresh_token from claim1) as rt
+    from amux.actors a
+   where a.id = (select actor_id from claim1);
+
+-- What an operator does once, by hand, on the account the digital employee
+-- authenticates as. On a merged instance this is what makes the bot's calls
+-- pass the backend's admin check.
+update public.users set admin_type = 2 where id = (select user_id from before);
+
+-- ── Rotate: re-invite the same agent actor ──────────────────────────────────
+select pg_temp.as_user('9e000000-0000-4000-8000-0000000000a1',
+                       '9e000000-0000-4000-8000-000000000001');
+
+create temp table inv2 as
+  select * from amux.create_team_invite((select team_id from team), 'agent', 'Badge Bot',
+    p_agent_kind      => 'daemon',
+    p_target_actor_id => (select actor_id from claim1));
+grant select on inv2 to anon, authenticated;
+
+create temp table claim2 as
+  select * from amux.claim_team_invite((select token from inv2));
+grant select on claim2 to anon, authenticated;
+
+reset role;
+
+-- ── Assert ──────────────────────────────────────────────────────────────────
+select is((select actor_id from claim2), (select actor_id from claim1),
+          'the rebind lands on the same agent actor');
+
+select is((select user_id from amux.actors where id = (select actor_id from claim2)),
+          (select user_id from before),
+          'the actor keeps the account it already had');
+
+select ok(exists (select 1 from auth.users where id = (select user_id from before)),
+          'that account still exists — the rotation did not delete it');
+
+-- The regression this file exists for. Keyed on the account the agent
+-- authenticates as *after* the rotation, not on the id it had before: the old
+-- body left the previous public.users row behind (nothing cascades from
+-- auth.users into it — public.users.id is a plain PK), so asserting on the old
+-- id passes either way. What actually broke is that the identity the daemon
+-- now presents is a different row, and that row is a fresh DEFAULT 1.
+select is((select admin_type from public.users
+            where id = (select user_id from amux.actors
+                         where id = (select actor_id from claim2))),
+          2::smallint,
+          'the account the agent now authenticates as still carries the grant');
+
+-- ...and the revocation the deletion used to provide for free.
+select ok(exists (select 1 from auth.refresh_tokens
+                   where token = (select refresh_token from claim2)
+                     and user_id = (select user_id from before)::text),
+          'the claim returns a fresh, usable refresh token for that account');
+
+select ok(not exists (select 1 from auth.refresh_tokens
+                       where token = (select rt from before)),
+          'the previous device''s refresh token is revoked');
+
+select * from finish();
+rollback;

--- a/services/supabase/tests/claim_team_invite_agent_org.test.sql
+++ b/services/supabase/tests/claim_team_invite_agent_org.test.sql
@@ -116,7 +116,13 @@ select pg_temp.as_user((select user_id from daemon1));
 select ok(exists (select 1 from amux.teams where id = (select team from ctx)),
           'daemon JWT without org claim resolves its org from the public.users fallback');
 
--- ── 4. Rebind (target_actor_id) rotates to a new user that keeps the claim ──
+-- ── 4. Rebind (target_actor_id) keeps the account, refreshes the claim ──────
+-- This used to assert the opposite: the agent branch minted a new auth user on
+-- every rotation and deleted the old one. 20260819000000 stopped that — a
+-- rotation replaces the credential, and everything keyed on the daemon's user
+-- id (public.users.admin_type, user_metadata, grants) has to survive it. The
+-- org stamp is refreshed on the account rather than baked into a new one, which
+-- is what the following assertion now covers.
 select pg_temp.as_user('aa110000-0000-4000-8000-000000000001');
 create temp table ri as
   select * from amux.create_team_invite(
@@ -136,8 +142,8 @@ create temp table daemon2 as
   select a.user_id from amux.actors a where a.id = (select actor_id from rc);
 grant select on daemon2 to anon, authenticated;
 
-select isnt((select user_id from daemon2), (select user_id from daemon1),
-            'rebind rotates the actor onto a new daemon auth user');
+select is((select user_id from daemon2), (select user_id from daemon1),
+          'rebind leaves the actor on the daemon auth user it already had');
 -- auth.users is not readable by anon; these are observations about what the
 -- claim minted, not RLS scenarios, so make them as the session role.
 reset role;


### PR DESCRIPTION
## Description

agent 邀请的 claim 分支第一行就是 `v_user_id := gen_random_uuid()`——还没看
`target_actor_id` 就先建了一个新 auth 用户。等它走到 rebind 分支时账号已经建好，
只能把 actor 指过去、再 `delete from auth.users` 删掉旧的。**那句删除不是撤销语义，
是在收拾它自己刚制造出来的孤儿。**

rebind 就是每一次凭据轮换：重新 onboard 一台机器、换团队、refresh token 过期后
点"重新生成邀请"。于是数字员工的账号每轮换一次就换一个 id，所有按 daemon user id
存的东西跟着归零：

- `public.users` 重新插一行 → `admin_type` 回到 `DEFAULT 1`（普通用户），运维手配的
  授权静默失效，而且只有 service_role 能再配一次（`prevent_admin_type_change`）；
- 合并实例上 saas-mono 按 user id 存的 `user_metadata`、`roles_users`、审计同理。

而新账号根本不需要：`auth.sessions` / `auth.refresh_tokens` 是按**会话**发的，不是按
用户，给已有账号插一条就够了——pg 后端的孪生实现 `mintSession(userId)` 本来就是
这么做的。agent actor 本身跨轮换是稳定的（这正是 `target_actor_id` 的意义），它的
账号现在也一样。

### 改法

- `20260819000000_claim_invite_keeps_daemon_user.sql`：agent 分支重排，**先决定账号
  再建账号**。rebind 且账号仍存在 → 复用；否则新建（首次 claim，以及 actor 指向的
  账号已被以前的轮换删掉的情况）。
- `services/fc/src/lib/pg-repo/auth.ts`：pg-repo 孪生实现同样处理，免得切
  `BACKEND_KIND=postgres` 时 bug 复活。

### 刻意保持不变

- **旧凭据照样作废**：复用路径显式删该账号的 session + refresh_token；原来是靠删
  用户顺带做掉的，退役的机器不能继续拿着能用的 refresh token。
- 复用时刷新 `raw_app_meta_data.org_id`（rebind 可能落到另一个 org 的团队）。
- 首次 claim 的行为、member 分支，一行没动。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## 验证

pgTAP `034_claim_invite_keeps_daemon_user.sql` 在线上 schema 上跑过（事务内替换函数 +
回滚，未落库）：

| 断言 | 旧函数 | 新函数 |
|---|---|---|
| rebind 落在同一个 agent actor | ✓ | ✓ |
| actor 保住原账号 | ✗ | ✓ |
| 该账号没被删 | ✗ | ✓ |
| **它现在认证用的账号仍带着 admin_type=2** | ✗ (have 1 / want 2) | ✓ |
| 返回的 refresh token 可用 | ✗ | ✓ |
| 上一台设备的 refresh token 已作废 | ✓ | ✓ |

- 全量 42 个 pgTAP 文件带补丁重跑：只剩一条本来就红的 buckets 断言（线上 storage
  状态，与本次无关）。
- `services/fc` claim 用例 9/9。
- `claim_team_invite_agent_org.test.sql` 里写死旧行为的那条断言 `isnt` → `is`，并写清
  为什么反过来。

## Additional Notes

排查时容易踩的一个坑，写在这里：删 `auth.users` **不会**连带删 `public.users`
（`public.users.id` 是普通主键，`auth_user_id` 才是关联列）。历史轮换因此在
`public.users` 留下了一批孤儿行——按**旧** user id 查 `admin_type` 会看到还是 2，
像是没掉；真正掉的是机器人**当前**认证用的那个新行。定位要按 `amux.actors.user_id`
反查。

**部署**：self-host 走 push main 自动迁移；**belayo（`teamclaw-api.ucar.cc`）的迁移是
手工的**，`deploy-aliyun-fc.sh` 默认不跑迁移。合并后需要单独在 belayo 上执行，否则
那套环境行为不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
