### PR TITLE
fix(ci): release-oss 的 amuxd-linux 不再走 apt 装 protoc + 全 job 加超时兜底

### DIFF
--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -70,6 +70,10 @@ jobs:
           - target: x86_64-apple-darwin
             runner: macos-latest
     runs-on: ${{ matrix.runner }}
+    # Backstop: a hung step must not squat the 360-minute default and
+    # starve publish-manifest. Healthy peak over the last 6 releases was
+    # 33.0 min.
+    timeout-minutes: 90
     # Job-level, not step-level: these used to sit only on the tauri-action step,
     # so the amuxd and teamclu-introspect sidecar builds (and the Cargo.lock
     # sync) compiled with no sccache at all — despite sharing most of their
@@ -426,6 +430,10 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    # Backstop: a hung step must not squat the 360-minute default and
+    # starve publish-manifest. Healthy peak over the last 6 releases was
+    # 42.2 min.
+    timeout-minutes: 90
     # See build-macos: hoisted off the tauri-action step so the amuxd (~495s) and
     # introspect (~87s) sidecar builds get sccache too.
     env:
@@ -690,6 +698,10 @@ jobs:
 
   build-amuxd-linux:
     runs-on: ubuntu-latest
+    # Backstop: a hung step must not squat the 360-minute default and
+    # starve publish-manifest. Healthy peak over the last 6 releases was
+    # 10.2 min.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -709,11 +721,25 @@ jobs:
           oss-endpoint-default: ${{ env.OSS_ENDPOINT_DEFAULT }}
           cdn-base-default: ${{ env.CDN_BASE_DEFAULT }}
 
-      - name: Install Rust target + protoc
-        run: |
-          rustup target add ${{ matrix.target }}
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+      # NOT `apt-get install protobuf-compiler`. The ubuntu runner's
+      # /etc/apt/apt-mirrors.txt puts the Azure-internal mirror first and the
+      # public archive.ubuntu.com second; when the Azure mirror goes bad every
+      # request is Ign:'d, apt falls back to the public archive over HTTPS, and
+      # that fetch hangs with no timeout that ever fires. It hit 5 of the 8
+      # amuxd-linux jobs across the 2026-08-18 and 2026-08-19 nightlies, each
+      # time squatting until cancelled. publish-manifest tolerates a failed
+      # amuxd job (see its `if:`) but still `needs:` it, so the cost is a
+      # release delayed by up to the 360-minute job default and a manifest
+      # shipped one amuxd binary short. arduino/setup-protoc pulls a pinned
+      # protoc from GitHub Releases and never touches an Ubuntu mirror -- the
+      # same action ci.yml's daemon-windows job already builds amuxd with.
+      - name: Install protoc (for prost_build)
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -775,6 +801,9 @@ jobs:
     # artifacts get rendered; any missing platform is simply omitted.
     if: always() && needs.build-macos.result == 'success' && needs.build-windows.result == 'success'
     runs-on: ubuntu-latest
+    # Backstop against a hung step burning the 360-minute job default.
+    # Healthy peak over the last 6 releases was 0.5 min.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## 问题

`build-amuxd-linux` 的 `Install Rust target + protoc` 步骤在 8/18、8/19 两晚的 **8 个 job 里挂死了 5 个**，每次都要人工取消。8/16、8/17 零发生，是最近才开始的退化。

## 根因：不是 protoc，是 apt 的镜像回退

对照同一批次成功与卡死的 job，唯一差别在 apt 走哪个源：

| | 成功的 job | 卡死的 job |
|---|---|---|
| `Ign:` 行数 | **0** | **25**（每条 azure 请求全被忽略） |
| 实际源 | `file:/etc/apt/apt-mirrors.txt` → Azure 内网镜像 | 回退到公网 `https://archive.ubuntu.com` |
| 结果 | `Fetched 11.4 MB in 2s (6723 kB/s)` | 卡在 `Get:5 … noble-security InRelease`，**永久静默** |

ubuntu runner 的 `/etc/apt/apt-mirrors.txt` 把 Azure 内网镜像排第一、公网兜底。Azure 镜像一失效，apt 回退到公网 HTTPS，而这个连接挂住之后 **apt 的超时从未触发**。两次卡死的最后一行日志逐字相同。

## 改动

**1. 删掉 apt，改用 `arduino/setup-protoc@v3`**

从 GitHub Releases 拉固定版本 protoc，完全不碰 Ubuntu 镜像 —— 是消除故障模式而非缓解。

不是新引入的依赖：`ci.yml` 的 `daemon-windows` job **已经**在用同一个 action 构建**同一个 crate**（`cargo build -p amuxd`），所以 protoc 版本满足 `teamclu-proto` 的 prost-build 是已验证的事实。

**2. 四个 job 都补上 `timeout-minutes`**

此前全文件一个都没有，默认即 GitHub 的 360 分钟上限，所以卡死的 job 会霸占 runner 六小时。`publish-manifest` 虽然容忍 amuxd 失败（见其 `if:`），但仍 `needs:` 它，于是整个发版被拖住。

阈值按最近 6 次发版的健康峰值留足 2 倍以上余量：

| job | 健康峰值 | 设定 |
|---|---|---|
| build-macos | 33.0 min | 90 |
| build-windows | 42.2 min | 90 |
| build-amuxd-linux | 10.2 min | 30 |
| publish-manifest | 0.5 min | 20 |

## 影响范围

只动 `.github/workflows/release-oss.yml`，不改任何构建逻辑或产物。

## 验证

- YAML 解析通过，四个 job 的 `timeout-minutes` 与步骤结构均已核对
- `build-amuxd-linux` 步骤顺序正确：protoc → rustup target → Rust cache → build
- 工作流改动无法本地执行，真正的验证要等下次发版（或手动触发一次 release-oss）

## 遗留

betly 的 `v0.4.1-beta.17` 因为这个问题少发了一个 Linux x86_64 的 amuxd 独立二进制（桌面端三个安装包 + `latest.json` 都已正常发布）。本 PR 合并后重发一次版即可补齐。

🤖 Generated with [Claude Code](https://claude.com/claude-code)