### PR TITLE
fix(chat): 「继续 ×N」弹层不再列出定时任务会话

### DIFF
--- a/packages/app/src/components/chat/SessionContinueBanner.tsx
+++ b/packages/app/src/components/chat/SessionContinueBanner.tsx
@@ -4,7 +4,9 @@ import { MessageSquare, ChevronRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { getBackend } from '@/lib/backend'
 import { useSessionListStore, type SessionListEntry } from '@/stores/session-list-store'
+import { useCronStore } from '@/stores/cron'
 import { useUIStore } from '@/stores/ui'
+import { isScheduledSession } from '@/lib/session-origin'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 
 interface Props {
@@ -31,6 +33,7 @@ export function SessionContinueBanner({
 }: Props) {
   const { t } = useTranslation()
   const allRows = useSessionListStore((s) => s.rows)
+  const cronSessionIds = useCronStore((s) => s.cronSessionIds)
   const [matchingIds, setMatchingIds] = React.useState<Set<string> | null>(null)
   const [popoverOpen, setPopoverOpen] = React.useState(false)
 
@@ -53,7 +56,14 @@ export function SessionContinueBanner({
 
   if (!matchingIds || matchingIds.size === 0) return null
 
-  const matching: SessionListEntry[] = allRows.filter((r) => matchingIds.has(r.id))
+  // Scheduled runs are their own surface: NavRail, SessionListColumn and
+  // SessionList all split them out via this same predicate. Continuing a
+  // cron run by hand is not what this affordance is for, and a busy job
+  // buries every real conversation. Filtered before .length is read, so
+  // the trigger count and the popover list agree.
+  const matching: SessionListEntry[] = allRows.filter(
+    (r) => matchingIds.has(r.id) && !isScheduledSession(r, cronSessionIds),
+  )
   if (matching.length === 0) return null
 
   const top5 = matching.slice(0, 5)

--- a/packages/app/src/components/chat/__tests__/SessionContinueBanner.test.tsx
+++ b/packages/app/src/components/chat/__tests__/SessionContinueBanner.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { SessionContinueBanner } from '@/components/chat/SessionContinueBanner'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: string, vars?: Record<string, unknown>) => {
+      let out = defaultValue ?? _key
+      for (const [k, v] of Object.entries(vars ?? {})) out = out.replace(`{{${k}}}`, String(v))
+      return out
+    },
+  }),
+}))
+
+// Radix's popover keeps its content unmounted until opened and portals it out of
+// the tree; this test is about which rows survive the filter, so render both
+// halves inline instead.
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+const listSessionIdsForActor = vi.fn()
+vi.mock('@/lib/backend', () => ({
+  getBackend: () => ({ sessionMembers: { listSessionIdsForActor } }),
+}))
+
+let rows: any[] = []
+vi.mock('@/stores/session-list-store', () => ({
+  useSessionListStore: (sel: (s: any) => unknown) => sel({ rows }),
+}))
+
+let cronSessionIds = new Set<string>()
+vi.mock('@/stores/cron', () => ({
+  useCronStore: (sel: (s: any) => unknown) => sel({ cronSessionIds }),
+}))
+
+vi.mock('@/stores/ui', () => ({
+  useUIStore: { getState: () => ({ switchToSession: vi.fn() }) },
+}))
+
+function row(id: string, title: string, source: string | null) {
+  return {
+    id,
+    title,
+    team_id: 't1',
+    last_message_at: null,
+    last_message_preview: null,
+    mode: 'solo',
+    idea_id: null,
+    has_unread: false,
+    source,
+    cron_job_id: source === 'cron' ? 'job-1' : null,
+    created_at: null,
+    updated_at: null,
+  }
+}
+
+function renderBanner() {
+  return render(<SessionContinueBanner actorId="actor-1" actorName="MACPRO" variant="inline" />)
+}
+
+describe('SessionContinueBanner', () => {
+  it('hides scheduled sessions and counts only what it lists', async () => {
+    cronSessionIds = new Set()
+    rows = [row('s1', 'Real chat', 'user'), row('c1', 'Cron: test', 'cron'), row('c2', 'Cron: test', 'cron')]
+    listSessionIdsForActor.mockResolvedValue(['s1', 'c1', 'c2'])
+
+    renderBanner()
+
+    expect(await screen.findByText('Real chat')).toBeInTheDocument()
+    expect(screen.queryByText('Cron: test')).not.toBeInTheDocument()
+    // The trigger count is derived from the same filtered array, so a popover
+    // showing one row must never advertise three.
+    expect(screen.getByText('继续 ×1')).toBeInTheDocument()
+  })
+
+  it('also hides a just-created cron session whose row has not synced source yet', async () => {
+    // `source` arrives from the server; until it does, the device-local overlay
+    // is the only signal, which is why the shared predicate checks both.
+    cronSessionIds = new Set(['c1'])
+    rows = [row('s1', 'Real chat', 'user'), row('c1', 'Cron: test', null)]
+    listSessionIdsForActor.mockResolvedValue(['s1', 'c1'])
+
+    renderBanner()
+
+    expect(await screen.findByText('Real chat')).toBeInTheDocument()
+    expect(screen.queryByText('Cron: test')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when every match is scheduled', async () => {
+    cronSessionIds = new Set()
+    rows = [row('c1', 'Cron: test', 'cron')]
+    listSessionIdsForActor.mockResolvedValue(['c1'])
+
+    const { container } = renderBanner()
+
+    await waitFor(() => expect(listSessionIdsForActor).toHaveBeenCalled())
+    expect(container).toBeEmptyDOMElement()
+  })
+})


### PR DESCRIPTION
## 问题

空状态里的「继续 ×N」弹层把定时任务跑出来的会话也当成可续聊的对话列了出来。一个跑得勤的 job 能把真正的对话全部挤掉 —— 用户截图里 5 条全是 `Cron: test`，计数还写着 ×50。

## 根因：不是漏写过滤，是漏接已有的共用判据

`packages/app/src/lib/session-origin.ts` 里早就有 `isScheduledSession(row, cronSessionIds)`，NavRail、SessionListColumn、SessionList 三处都接了。`SessionContinueBanner` 是**第四个界面，从来没接进来**。

该文件的注释正好警告过这类漂移：

> the surfaces that split the list into "chat" vs "scheduled" — NavRail's counts, SessionListColumn, SessionList — drifted apart once already

这次是第二次。

## 改动

接入同一个判据，+12 行：

```tsx
const matching: SessionListEntry[] = allRows.filter(
  (r) => matchingIds.has(r.id) && !isScheduledSession(r, cronSessionIds),
)
```

两个刻意的选择：

**1. 判据用 `source === 'cron'` 而不是 `cron_job_id`。** 查过 `supabase-repo.ts` 和 `pg-repo/sessions.ts` 两条建会话路径：`source: \"cron\"` 是无条件写入的，而 `cron_job_id` 在 session_key 里取不到 job id 时会是 `null` —— 用后者会漏掉一部分。共用判据还额外兜住「刚建好、`source` 还没从服务端同步下来」的设备本地 overlay。

**2. 过滤放在 `.length` 被读之前。** 否则会出现「继续 ×50」点开只有 3 条。计数和列表现在始终一致。

## 验证

新增 `SessionContinueBanner.test.tsx` —— 该组件此前零测试（唯一渲染它的 `LocalAgentWelcomeEmptyState.test.tsx` 直接把它 mock 成 `null`）。3 个用例：

- 过滤掉 cron 会话，且触发器计数只算列出来的
- `source` 尚未同步、只有本地 overlay 标记时同样挡住
- 全部匹配都是定时任务时整个组件不渲染

**把修复撤掉后三个用例全红、装回后全绿**，确认钉住的是真行为而非空跑。

其余：`pnpm typecheck` 通过，eslint 无输出，相关既有测试 16 文件 / 93 用例全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)