### PR TITLE
fix: agent 跑到别的 app 目录里——workdir 路由用错捕获语法，静默 404

### DIFF
--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -112,7 +112,11 @@ pub fn build(state: HttpState) -> Router {
         // Where this daemon keeps an app. The desktop asks instead of deriving
         // the path itself — two copies of that rule drifted apart once and the
         // agent then edited a directory no deploy ever built.
-        .route("/v1/apps/{app_id}/workdir", get(apps::app_workdir))
+        // `:app_id`, not `{app_id}`: this is axum 0.7 (matchit 0.7), where the
+        // brace form is a LITERAL segment. Written that way, the route only
+        // matched the path `/v1/apps/%7Bapp_id%7D/workdir` and answered 404 for
+        // every real app — which is exactly what it did, from the day it landed.
+        .route("/v1/apps/:app_id/workdir", get(apps::app_workdir))
         // Device-level provider config (#742). Credentials are per-machine, not
         // per-workspace, so these need no workspace id — which is what lets
         // first-run onboarding configure a model before a project is chosen.
@@ -352,4 +356,31 @@ async fn info_handler(State(state): State<HttpState>) -> Json<InfoBody> {
             .mqtt_connected
             .load(std::sync::atomic::Ordering::Relaxed),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    /// Every capture in this router must use axum 0.7's `:name` form.
+    ///
+    /// matchit 0.7 treats `{name}` as a LITERAL path segment, so a route
+    /// written that way compiles, registers, and then 404s for every real
+    /// value. One route shipped like that — `/v1/apps/{app_id}/workdir` — and
+    /// nothing failed loudly: the desktop asks the daemon where an app's files
+    /// live, got 404 every single time, and each caller quietly fell back to
+    /// ambient state, so the agent ran in whichever app happened to be open
+    /// before. Guard the syntax itself; there is no other symptom to test for.
+    #[test]
+    fn routes_use_axum_capture_syntax() {
+        let offenders: Vec<&str> = include_str!("routes.rs")
+            .lines()
+            .filter(|line| line.contains(".route(\""))
+            .filter(|line| line.split('"').nth(1).is_some_and(|p| p.contains('{')))
+            .collect();
+        assert!(
+            offenders.is_empty(),
+            "these routes use the `{{name}}` capture form, which matchit 0.7 \
+             matches literally (use `:name`):\n{}",
+            offenders.join("\n")
+        );
+    }
 }

--- a/apps/daemon/src/sync/app_templates.rs
+++ b/apps/daemon/src/sync/app_templates.rs
@@ -206,4 +206,28 @@ mod tests {
             "lockfile copied byte-for-byte"
         );
     }
+
+    #[test]
+    fn the_dev_server_finds_the_site_in_both_layouts() {
+        // `server.mjs` runs from two places: in the artifact it is
+        // `.output/server/index.mjs` with the site at `../public`, and under
+        // `pnpm dev` it runs in place at the app root with the site at
+        // `./public`. It used to resolve `../public` unconditionally, which at
+        // the app root points OUTSIDE the app — at the directory holding every
+        // app — so `pnpm dev` served a path that does not exist and answered
+        // 404 to everything, in every static site app. Nothing reported it: an
+        // empty preview reads as "I have not written the page yet".
+        for t in [AppType::StaticWeb, AppType::Slides] {
+            let tmp = seed(t);
+            let server = std::fs::read_to_string(tmp.path().join("server.mjs")).unwrap();
+            assert!(
+                !server.contains("new URL('../public/', import.meta.url)"),
+                "{t:?}: server.mjs resolves ../public unconditionally, which breaks `pnpm dev`"
+            );
+            assert!(
+                server.contains("existsSync"),
+                "{t:?}: server.mjs must pick its root by looking for the site"
+            );
+        }
+    }
 }

--- a/packages/app/src/lib/teamclu/resolve-runtime-start-workspace.ts
+++ b/packages/app/src/lib/teamclu/resolve-runtime-start-workspace.ts
@@ -257,6 +257,49 @@ export async function resolveSessionWorkspaceHintForRuntimeStart(args: {
   return cachedDefaultWorkspaceId(agentActorIds)
 }
 
+/**
+ * This session's own workspace binding for the local daemon, read from the
+ * local cache alone — no Cloud API, no daemon IPC.
+ *
+ * The synchronous send path cannot await {@link resolveSessionWorkspaceHintForRuntimeStart}:
+ * that one starts with a Cloud round trip, and paying it before the runtime
+ * starts is the 7–8s of dead air the fast path exists to avoid. But its only
+ * synchronous alternative — `cachedDefaultWorkspaceId` — is a *device*-level
+ * default for the agent, with no session in it: send the first message in a
+ * freshly created app and the runtime started in whichever app was open
+ * before, so the agent read and wrote another app's files while the new app
+ * deployed as the untouched seed template.
+ *
+ * The binding this reads is written when the session is bound to its app
+ * (`bindAppWorkspace`), so it is already on disk by the time the user can
+ * type. A session with no cached row yields null and the caller falls back —
+ * cold cache behaves exactly as before.
+ */
+export async function cachedSessionWorkspaceForLocalDaemon(args: {
+  teamId: string
+  sessionId: string
+  localDaemonActorId: string
+}): Promise<{ workspaceId: string; workspacePath: string } | null> {
+  const teamId = args.teamId.trim()
+  const sessionId = args.sessionId.trim()
+  const agentId = args.localDaemonActorId.trim()
+  if (!teamId || !sessionId || !agentId) return null
+  try {
+    const { useCurrentTeamStore } = await import('@/stores/current-team')
+    const viewerMemberId = useCurrentTeamStore.getState().currentMember?.id?.trim() ?? ''
+    if (!viewerMemberId) return null
+    const { loadSessionWorkspacesForTeam } = await import('@/lib/local-cache')
+    const rows = await loadSessionWorkspacesForTeam(teamId, viewerMemberId)
+    const row = rows.find((r) => r.sessionId === sessionId && r.agentId === agentId)
+    const workspaceId = row?.workspaceId?.trim() ?? ''
+    const workspacePath = row?.workspacePath?.trim() ?? ''
+    if (!workspaceId && !workspacePath) return null
+    return { workspaceId, workspacePath }
+  } catch {
+    return null
+  }
+}
+
 /** The original chain: session binding → local path → per-agent lookups. */
 async function resolveLiveWorkspaceHint(
   args: {

--- a/packages/app/src/services/__tests__/outbox-sender.test.ts
+++ b/packages/app/src/services/__tests__/outbox-sender.test.ts
@@ -17,6 +17,9 @@ const mocks = vi.hoisted(() => ({
   ingestSessionLiveLocally: vi.fn(async () => undefined),
   runtimeStart: vi.fn(async () => ({})),
   getDaemonLocalAgent: vi.fn(async () => 'opencode' as const),
+  cachedSessionWorkspaceForLocalDaemon: vi.fn(
+    async () => null as { workspaceId: string; workspacePath: string } | null,
+  ),
 }))
 
 vi.mock('@/lib/mqtt-bridge', () => ({
@@ -79,6 +82,8 @@ vi.mock('@/lib/teamclu/ensure-agent-runtime', () => ({
 
 vi.mock('@/lib/teamclu/resolve-runtime-start-workspace', () => ({
   resolveSessionWorkspaceHintForRuntimeStart: vi.fn().mockResolvedValue(''),
+  cachedSessionWorkspaceForLocalDaemon: (...args: unknown[]) =>
+    mocks.cachedSessionWorkspaceForLocalDaemon(...args),
 }))
 
 vi.mock('@/stores/workspace', () => ({
@@ -107,6 +112,7 @@ describe('outbox sender', () => {
     mocks.ingestSessionLiveLocally.mockResolvedValue(undefined)
     mocks.runtimeStart.mockResolvedValue({})
     mocks.getDaemonLocalAgent.mockResolvedValue('opencode')
+    mocks.cachedSessionWorkspaceForLocalDaemon.mockResolvedValue(null)
   })
 
   afterEach(async () => {
@@ -425,6 +431,46 @@ describe('outbox sender', () => {
     })
     expect(mocks.runtimeStart).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceId: 'ws-from-enqueue' }),
+    )
+  })
+
+  it("local fast path runs in the session's own workspace, not the agent's device default", async () => {
+    // The device default belongs to the agent, not to one session. Sending the
+    // first message in a just-created app started the runtime in whichever app
+    // was open before it, so the agent edited that app's files and the new one
+    // deployed as the untouched seed template.
+    mocks.isTauri.mockReturnValue(true)
+    mocks.getLocalDaemonActorId.mockResolvedValue('agent-local')
+    mocks.runtimeStart.mockResolvedValue({})
+    mocks.cachedSessionWorkspaceForLocalDaemon.mockResolvedValue({
+      workspaceId: 'ws-this-session',
+      workspacePath: '/apps/this-session',
+    })
+
+    const { useOutboxStore } = await import('@/stores/outbox-store')
+    const { startOutboxSender } = await import('../outbox-sender')
+
+    await useOutboxStore.getState().enqueue({
+      messageId: 'msg-session-ws',
+      teamId: 'team-1',
+      sessionId: 'session-1',
+      senderActorId: 'member-1',
+      content: '@Local hi',
+      model: 'opencode/qwen',
+      mentionActorIds: ['agent-local'],
+      attachmentUrls: [],
+    })
+    startOutboxSender()
+
+    await vi.waitFor(() => {
+      expect(mocks.runtimeStart).toHaveBeenCalled()
+    })
+    expect(mocks.runtimeStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'ws-this-session',
+        // Not '/tmp/workspace' — the folder the desktop happens to have open.
+        worktree: '/apps/this-session',
+      }),
     )
   })
 

--- a/packages/app/src/services/outbox-sender.ts
+++ b/packages/app/src/services/outbox-sender.ts
@@ -124,8 +124,6 @@ async function ensureLocalRuntimeForFastPath(
   } catch {
     // Keep OPENCODE — matches daemon default when config is unavailable.
   }
-  const worktree = useWorkspaceStore.getState().workspacePath?.trim() ?? "";
-
   // Carry a workspace id. This used to send `""`, and the daemon skips its
   // workspace resolver entirely for an empty one — it starts in whatever
   // `worktree` says instead. The slow path that follows ~0.8s later DOES
@@ -134,15 +132,34 @@ async function ensureLocalRuntimeForFastPath(
   // message: `~/TeamClu` here, `~/TeamClu Dev` there, and a 5.5s cold start
   // paid twice. A path that exists to be fast was costing an extra one.
   //
-  // Both sources are synchronous, so the fast path stays fast: the enqueue-time
-  // hint is what the slow path already resolved for this very message, and the
-  // cache is this client's last known default for the agent. Still empty means
-  // a cold cache on a first-ever run — same behaviour as before, no regression.
-  const { cachedDefaultWorkspaceId } = await import(
-    "@/stores/agent-default-workspace-store"
-  );
+  // Order matters, and both of the cheap sources it used to have are
+  // session-blind: the enqueue hint is per-message, but `cachedDefaultWorkspaceId`
+  // is this device's default for the AGENT, shared by every session it runs.
+  // Sending the first message in a brand-new app therefore started the runtime
+  // in the app that happened to be open before, and the agent read and edited
+  // that app's files while the new one deployed as the untouched template.
+  // The session's own binding goes in between — local cache only, so the fast
+  // path stays local, and null on a cold cache falls through to the old answer.
+  const [{ cachedDefaultWorkspaceId }, { cachedSessionWorkspaceForLocalDaemon }] =
+    await Promise.all([
+      import("@/stores/agent-default-workspace-store"),
+      import("@/lib/teamclu/resolve-runtime-start-workspace"),
+    ]);
+  const bound = await cachedSessionWorkspaceForLocalDaemon({
+    teamId: entry.teamId,
+    sessionId: entry.sessionId,
+    localDaemonActorId,
+  });
   const workspaceId =
-    entry.workspaceIdHint?.trim() || cachedDefaultWorkspaceId([localDaemonActorId]);
+    entry.workspaceIdHint?.trim() ||
+    bound?.workspaceId ||
+    cachedDefaultWorkspaceId([localDaemonActorId]);
+  // Same reasoning for the worktree: the workspace store is whichever folder
+  // the desktop has open, which is not necessarily the one this session runs
+  // in. It is only the daemon's fallback for an id it cannot resolve, but when
+  // that fallback fires it decides the directory outright.
+  const worktree =
+    bound?.workspacePath || (useWorkspaceStore.getState().workspacePath?.trim() ?? "");
 
   sessionFlowLog("outbox_sender.local_runtime_start.begin", {
     messageId: entry.messageId,

--- a/packages/app/src/stores/apps-store.ts
+++ b/packages/app/src/stores/apps-store.ts
@@ -39,11 +39,6 @@ async function toastError(title: string, description?: string): Promise<void> {
   toast.error(title, description ? { description } : undefined);
 }
 
-async function toastSuccess(title: string, description?: string): Promise<void> {
-  const { toast } = await import("sonner");
-  toast.success(title, description ? { description } : undefined);
-}
-
 /**
  * Write a terminal provision status back to the cloud API and patch the matching
  * row in the store. Non-fatal: a failed writeback must never reject the caller
@@ -179,12 +174,13 @@ export const useAppsStore = create<AppsState>((set, get) => ({
       }
 
       // 3. Cloud: point the function at the uploaded code, get the live endpoint.
+      // No success toast. It showed `fcEndpoint` — the raw FC function URL —
+      // which is not the address the product hands out (that is the app's
+      // vanity domain, and the row already carries it into the UI). A popup
+      // naming the wrong host on every deploy is worse than no popup: the
+      // merged row flips the row to live on its own.
       const finalized = await getBackend().apps.finalizeDeploy(appId);
       mergeRow(set, finalized);
-      await toastSuccess(
-        "部署成功",
-        finalized.fcEndpoint ? finalized.fcEndpoint : undefined,
-      );
     } catch (e) {
       const reason = e instanceof Error ? e.message : String(e);
       // The cloud already marks its own failures; this covers the ones it

--- a/templates/slides/server.mjs
+++ b/templates/slides/server.mjs
@@ -2,14 +2,24 @@
 //
 // The build copies this to `.output/server/index.mjs` and the site to
 // `.output/public/`, which is the artifact shape Alibaba FC runs:
-// `node server/index.mjs`, listening on $PORT. Resolving `../public` relative
-// to this file works both there and when running it straight from the repo.
+// `node server/index.mjs`, listening on $PORT.
 import { createServer } from 'node:http'
 import { readFile, stat } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import { join, extname, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const ROOT = resolve(fileURLToPath(new URL('../public/', import.meta.url)))
+// One file, two layouts. In the artifact this sits at `.output/server/` and the
+// site is `../public`. But `pnpm dev` runs it in place, at the app root, where
+// the site is `./public` and `../public` points OUTSIDE the app entirely — at
+// the directory that holds every app. It resolved `../public` unconditionally,
+// so `pnpm dev` served a path that does not exist and answered 404 to every
+// request, for every app. Pick the layout by looking for the site, not by
+// assuming which copy is running.
+const HERE = fileURLToPath(new URL('.', import.meta.url))
+const ROOT = existsSync(resolve(HERE, 'public'))
+  ? resolve(HERE, 'public')
+  : resolve(HERE, '../public')
 const PORT = Number(process.env.PORT || 9000)
 
 const TYPES = {

--- a/templates/static-web/server.mjs
+++ b/templates/static-web/server.mjs
@@ -2,14 +2,24 @@
 //
 // The build copies this to `.output/server/index.mjs` and the site to
 // `.output/public/`, which is the artifact shape Alibaba FC runs:
-// `node server/index.mjs`, listening on $PORT. Resolving `../public` relative
-// to this file works both there and when running it straight from the repo.
+// `node server/index.mjs`, listening on $PORT.
 import { createServer } from 'node:http'
 import { readFile, stat } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import { join, extname, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const ROOT = resolve(fileURLToPath(new URL('../public/', import.meta.url)))
+// One file, two layouts. In the artifact this sits at `.output/server/` and the
+// site is `../public`. But `pnpm dev` runs it in place, at the app root, where
+// the site is `./public` and `../public` points OUTSIDE the app entirely — at
+// the directory that holds every app. It resolved `../public` unconditionally,
+// so `pnpm dev` served a path that does not exist and answered 404 to every
+// request, for every app. Pick the layout by looking for the site, not by
+// assuming which copy is running.
+const HERE = fileURLToPath(new URL('.', import.meta.url))
+const ROOT = existsSync(resolve(HERE, 'public'))
+  ? resolve(HERE, 'public')
+  : resolve(HERE, '../public')
 const PORT = Number(process.env.PORT || 9000)
 
 const TYPES = {


### PR DESCRIPTION
新建一个 app、在里面让 agent 干活，agent 会跑到**上一个打开过的 app** 的目录里——读它的文件、改它的文件，而新 app 部署上线的还是没动过的模板。

真实发生过一次：在 test-wuxing 的会话里让 agent 做打飞机游戏，27KB 的 `game.html` 写进了衡信会计那个 app 的 `public/`（会话历史里另一个 app 的 id 出现 117 次，自己的只有 2 次）。

## 根因：一条路由用错了捕获语法，静默 404 了一辈子

`apps/daemon/src/http/routes.rs`

```rust
.route("/v1/apps/{app_id}/workdir", get(apps::app_workdir))
```

daemon 用的是 **axum 0.7.9 / matchit 0.7.3**，捕获语法是 `:name`，花括号在这个版本里是**字面量路径段**。所以这条路由只匹配 `/v1/apps/%7Bapp_id%7D/workdir`，真实 app id 一律落到 axum 的 fallback 404——从它上线那天起，对每一个 app、每一次调用都是 404（当天日志：test-wuxing 10 次、test-wuxing2 4 次，无一例外）。

链条这样断掉：

```
appWorkdirPath() 拿到 404
  → bindAppWorkspace() 在 if (!appWorkdir) 处提前 return
  → session→workspace 的本地绑定一行都没写
  → 所有解析器都查不到
  → 回退到桌面当前打开的目录 / agent 的设备默认 workspace ＝ 上一个打开过的 app
```

全仓库只有这一条路由用花括号，另外 9 条都是 `:id`。没有任何响亮的失败：编译过、注册成功、然后静默 404。

## 四个提交

**1. `fix(apps)`：部署成功不再弹 toast** — 它把 `fcEndpoint`（FC 函数的原始 URL）当地址给用户看，而产品对外给的是 app 的二级域名。失败提示保留。

**2. `fix(chat)`：发消息的快路径按会话挑 workspace** — `outbox-sender` 的本地快路径只有两个同步来源：entry 上的 hint（发送路径一直传 null）和 `cachedDefaultWorkspaceId`，后者是 agent 在本机的**设备级**默认值，跟会话无关。中间插了一层只读本地缓存的 `cachedSessionWorkspaceForLocalDaemon`——慢路径早就把会话绑定排第一，但它以一次云端往返开头，快路径等不起。缓存空了就落回原答案，冷启动行为不变。

**3. `fix(daemon)`：`{app_id}` → `:app_id`** — 上面那条。加了守卫测试遍历 `routes.rs` 里所有 `.route("...")` 字面量，出现花括号就红。

**4. `fix(apps)`：模板的 `pnpm dev` 服务的是 app 外面的目录** — `server.mjs` 要在两个位置跑，它一直无条件解析 `../public`：

```
dev  (node server.mjs)      ROOT = .../teams/<team>/apps/public   [不存在]
prod (.output/server/index) ROOT = .../<app>/.output/public       [存在]
```

每个静态网页 / 幻灯片 app 的 `pnpm dev` 都在服务一个不存在的目录，所有请求 404。改成按布局找站点。这个 bug 上一轮真的把 agent 绕过去了——它自己发现 `pnpm dev` 不对，改跑了构建产物。

## 验证

真机跑通（重编 sidecar + 重启 daemon 后）：

- 路由从 `404 content-length:0`（axum fallback）变成 `401 missing bearer token`（裸 curl 无 token，证明路由匹配上了）
- tauri-mcp 读实况：文件面板根目录 = 新 app 自己的目录；agent 自报 cwd 正确；游戏写进了正确的 `public/`；`本地运行预览` 起在 `:9200`，curl 200
- 模板两种布局都实测过：dev 拿到 `<app>/public`，产物拿到 `<app>/.output/public`

`pnpm typecheck` 0，`pnpm lint` 0 error，`pnpm test:unit` **452 文件 / 2924 用例全绿**，`cargo test -p amuxd --locked` 1258 passed / 3 failed——那 3 个是 `runtime::opencode_http::pool_tests` 里 1 秒超时的时序用例，**在干净的 origin/main 上同样红**（拿 detached worktree 复现过，且每次红的条数还会变），与本 PR 无关。

## 注意

- 模板改动只对**新建的** app 生效，已有 checkout 里那份 `server.mjs` 是拷贝
- daemon 的模板是 `build.rs` 打进二进制的，要重编 sidecar 才生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)
