### PR TITLE
fix(cron): 修好 #978 遗留的陈旧测试，main 现在是红的

### DIFF
--- a/apps/desktop/src/commands/cron/amuxd_client.rs
+++ b/apps/desktop/src/commands/cron/amuxd_client.rs
@@ -693,13 +693,20 @@ mod tests {
         assert!(err.contains("no team_id"), "got: {err}");
     }
 
+    // Pins the envelope against the daemon's `channel-send` handler, whose
+    // contract is {cmd, channel, target, message} with no reply_token. This
+    // test kept asserting the old `mcp-send` shape after the impl moved off it,
+    // which is how a red main reached #984.
     #[tokio::test]
-    async fn channel_send_uses_mcp_send_with_overrides() {
+    async fn channel_send_uses_the_tokenless_channel_send_command() {
         let sock_path = mock_server(|req| {
-            assert_eq!(req["cmd"].as_str(), Some("mcp-send"));
-            assert_eq!(req["channel_override"].as_str(), Some("wecom"));
-            assert_eq!(req["target_override"].as_str(), Some("user:alice"));
+            assert_eq!(req["cmd"].as_str(), Some("channel-send"));
+            assert_eq!(req["channel"].as_str(), Some("wecom"));
+            assert_eq!(req["target"].as_str(), Some("user:alice"));
             assert_eq!(req["message"].as_str(), Some("hello"));
+            // The whole reason this is a separate command: a cron announcement
+            // has no chat behind it, so it cannot carry mcp-send's reply token.
+            assert!(req.get("reply_token").is_none());
             serde_json::json!({ "ok": true, "result": {} }).to_string()
         })
         .await;


### PR DESCRIPTION
## main 现在是红的

`Rust Format & Clippy` 在 main 上失败（run 32240814838）：

```
commands::cron::amuxd_client::tests::channel_send_uses_mcp_send_with_overrides
assertion `left == right` failed
  left: Some("channel-send")
 right: Some("mcp-send")
```

## 根因

**#978**（`c0fcd054`「gateway 内核重做 + 网关/企微/设置一串修复」）把 `channel_send_at` 的信封从 `mcp-send` 换成了 daemon 专设的 `channel-send`，实现里留了注释说明原因：

> `channel-send`, not `mcp-send`: this is the app announcing a run, not an agent replying to anyone. The old envelope borrowed the agent path with a placeholder binding, and stopped working the day that path started requiring a real reply token — silently, because delivery is best-effort.

但配套测试没跟着改，三处断言全部陈旧：

| 字段 | 测试断言 | 实现实际发送 |
|---|---|---|
| `cmd` | `mcp-send` | `channel-send` |
| `channel_override` | `wecom` | → `channel` |
| `target_override` | `user:alice` | → `target` |

**之所以没人发现**：今早 09:02–09:03 连着合了 4 个 PR，main 上的 CI run 被 concurrency 依次取消（那几个 run 的 conclusion 都是空的），只有最后一个 `42961c2b` 跑完并报红。

## 改动

对齐三处断言。测试名 `channel_send_uses_mcp_send_with_overrides` 本身已名不副实，改成 `channel_send_uses_the_tokenless_channel_send_command`。

另加一条 `reply_token` 缺席的断言 —— 那正是 daemon 分设这个命令的理由，daemon 侧的 `cron_delivery_needs_no_reply_token` 断言的是同一件事，两边现在对齐了。

契约已对着 daemon 侧核实（`server.rs:2745` 的 `channel-send` 分支 + `channels.rs` 的同形状测试），确认是**实现对、测试陈旧**，不是把 bug 固化进测试。

## 验证

- `cargo test -p teamclu --lib` → **196 passed / 0 failed**（CI 里红的正是这个目标）
- `cargo fmt --check --manifest-path apps/desktop/Cargo.toml` → 干净

## 说明

main 上还有一盏红灯 `Database Tests (pgTAP)`，与本 PR 无关（它在 `43a88bad` 上是绿的，`42961c2b` 上才红），本 PR 不处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)