### PR TITLE
test(daemon): pool_tests 的 wait_until 别再忙等——它在跟自己等的子进程抢 CPU

### DIFF
--- a/apps/daemon/src/runtime/opencode_http/mod.rs
+++ b/apps/daemon/src/runtime/opencode_http/mod.rs
@@ -1920,10 +1920,25 @@ mod pool_tests {
         }
     }
 
+    /// Poll `condition` until it holds, then return; fail if it never does.
+    ///
+    /// This used to spin on `yield_now()` against a 1s budget, and both halves
+    /// of that hurt. The spin burns a core for the whole wait, and what these
+    /// tests wait on is a real child process starting — so a dozen of them
+    /// running at once starve the very spawns they are waiting for. The full
+    /// `cargo test -p amuxd` run (1261 tests in parallel, on a machine also
+    /// building the desktop app) randomly failed one of these three, while the
+    /// same tests passed serially, and passed in parallel once the machine was
+    /// idle. Sleeping between polls hands the CPU back to the thing being
+    /// waited on.
+    ///
+    /// 10s is slack for a loaded machine, not license to hang: a command loop
+    /// that never reaches the state still fails, just later. Every wait here
+    /// is satisfied in microseconds when nothing else is competing.
     async fn wait_until(mut condition: impl FnMut() -> bool) {
-        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
             while !condition() {
-                tokio::task::yield_now().await;
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
             }
         })
         .await


### PR DESCRIPTION
`cargo test -p amuxd` 跑全量（1261 个测试并行）时，`runtime::opencode_http::pool_tests` 里这三个会随机红一到三个：

- `permission_commands_resolve_only_the_sender_generation`
- `question_commands_answer_only_the_sender_generation`
- `prompt_and_cancel_commands_do_not_mutate_duplicate_route_on_other_generation`

都是 `command loop did not reach the expected state: Elapsed(())`。

## 原因

`wait_until` 是纯忙等，没有任何 sleep：

```rust
tokio::time::timeout(Duration::from_secs(1), async {
    while !condition() {
        tokio::task::yield_now().await;
    }
})
```

十来个用例并行时，每个都在自己的 current-thread runtime 上把一个核烧满。而它们等的恰恰是**一个真实子进程起来**（`install_blocking_fake_serve` 铺的那个 `/bin/sh` 脚本要 `printf` 出 marker 文件）——等待方在跟被等方抢 CPU。1 秒的预算在这种情况下不够。

改成每 2ms 睡一次再查，预算 1s → 10s。断言一点没弱：命令循环真到不了那个状态照样红，只是晚一点才红。机器不忙的时候这些 wait 都是**微秒级**满足的。

## 排除过的假设

一开始怀疑是 macOS 上的进程验活开销——`cmdline_of` 在没有 `/proc` 的系统上会 fork `ps`，`group_has_managed_member` 还会先 fork 一个 `pgrep`，而 `reap_verified_group` 用 `thread::sleep(50ms)` 步进轮询，内层 deadline 正好 300ms，跟当时量到的读数对得上。

给这两个函数加探针实测：**这三个用例一次都没调用过它们**。所以那条路不在这里的路径上，假设否掉了。

（`cmdline_of` 在 macOS 上 fork `ps` 是真的，但我没有任何测量说明它在生产里有多贵，不在这个 PR 的范围内。）

## 验证到什么程度

| 跑法 | 结果 |
|---|---|
| 改后 `cargo test -p amuxd --locked` 全量 ×3 | 全绿 |
| 改后 pool_tests 默认并行 ×2 | 全绿 |
| 改后 `--test-threads=1` ×6 | 全绿 |
| **回退改动**、当前（空闲）机器全量 ×4 | **也全绿** |

**before/after 的复现对比没做出来。** 最初的红是在 tauri dev 正在编译、amuxd 和 agent 都在跑的高负载下出现的（当时实测到单次 wait 花掉 300ms 和 4.4s，对着 1s 的预算）；机器闲下来之后旧代码同样跑不红。手动造满核忙循环也没顶上去。

所以这个改动的依据是代码事实——忙等确实在抢它自己等的那个 CPU，1 秒预算确实只剩几十毫秒余量——而不是一次成功的 before/after。CI 上这三个本来就是绿的，所以 CI 也证明不了什么。

`cargo clippy -p amuxd --all-targets` 没有因此产生新告警。改动只碰 `#[cfg(test)]` 里的一个测试辅助函数，不影响生产代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
