### PR TITLE
fix(fc): 定时任务从建函数起就没跑通过一次——drizzle 裸表名撞上 amux schema

### DIFF
--- a/services/fc/src/db/client.ts
+++ b/services/fc/src/db/client.ts
@@ -11,6 +11,41 @@ function makeDb(sql: ReturnType<typeof postgres>) {
   return drizzle(sql, { schema });
 }
 
+/**
+ * Where this connection looks for unqualified table names.
+ *
+ * Every table in `src/db/schema/` is declared with a bare `pgTable("name")`, so
+ * the SQL drizzle emits is unqualified and resolution is entirely up to
+ * `search_path`. The tables themselves live in `amux` — `move_teamclu_to_amux`
+ * relocated them out of `public` — while the role we connect as carries the
+ * stock Supabase default (`"$user", public, auth, extensions`). Nothing put
+ * `amux` on that list, so every drizzle query against a relocated table failed
+ * with `relation "…" does not exist`.
+ *
+ * That was not theoretical: it is why both FC timer tasks (`oss-abandon-sessions`
+ * every 15 minutes, `oss-gc-blobs` daily) had failed on every single run since
+ * the function was created, so expired upload sessions were never abandoned and
+ * orphan blobs were never collected.
+ *
+ * `amux` is PREPENDED to the stock list rather than replacing it: `public` still
+ * holds tables this schema also names (`members`, `permissions`), `auth` and
+ * `extensions` are where Supabase keeps GoTrue's tables and pgcrypto. A
+ * narrower path would trade one set of missing relations for another.
+ *
+ * Deliberately NOT an env var. It would have to be declared on both deploy
+ * targets, and the FC one rewrites its whole environment map on every deploy —
+ * so a path configured only in one machine's env file would vanish on the next
+ * unrelated deploy and take the cron tasks down again, silently, exactly the way
+ * they were already down. Where the tables live is a property of the migrations,
+ * which are in git; this belongs in git with them.
+ */
+const SEARCH_PATH = "amux, public, auth, extensions";
+
+/** Exported so the ordering above can be pinned by a test rather than by hope. */
+export function resolveSearchPath(): string {
+  return SEARCH_PATH;
+}
+
 // Module-level singleton. Serverless-safe defaults: small pool, short idle,
 // prepare:false (proxy-compatible). Tune via env. Production: front with
 // Alibaba RDS Proxy / PolarDB Proxy; this code only needs DATABASE_URL.
@@ -23,6 +58,9 @@ export function getDb(): Db {
     idle_timeout: Number(process.env.PG_IDLE_TIMEOUT ?? "20"),
     connect_timeout: Number(process.env.PG_CONNECT_TIMEOUT ?? "10"),
     prepare: false,
+    // Sent in the startup packet, so it is set before the first query rather
+    // than by a `SET` that a pooled connection could hand back without.
+    connection: { search_path: resolveSearchPath() },
   });
   _db = makeDb(_client);
   return _db;

--- a/services/fc/src/lib/cron.ts
+++ b/services/fc/src/lib/cron.ts
@@ -7,7 +7,7 @@
  *   oss_sync_gc_orphan_blobs()           →  ossSyncGcOrphanBlobs()
  */
 
-import { and, eq, lt, sql, notExists } from "drizzle-orm";
+import { and, eq, inArray, lt, sql, notExists } from "drizzle-orm";
 import type { Db } from "../db/client.js";
 import {
   amuxcUploadSessions,
@@ -20,6 +20,8 @@ import { getTeamBlobStorage, type BlobStorage } from "./team-blob-storage.js";
 /** What the cron tasks need injected; everything defaults to the real thing. */
 export interface CronDeps {
   storage?: BlobStorage;
+  /** Blobs collected per GC run — see `GC_BATCH_LIMIT`. Tests use small ones. */
+  limit?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -99,34 +101,87 @@ export async function ossSyncAbandonExpiredSessions(
 // run — but it does mean a deployment whose objects sit under a key layout the
 // current storage config no longer produces will report happy deletes while the
 // real bytes stay put. Those need a one-off sweep by prefix, not this task.
+//
+// The sweep is CAPPED, because adding object deletes changed what one run costs.
+// Deleting rows was a single statement whose size did not matter; deleting bytes
+// is one network round trip per blob, and the FC function this runs in has a
+// 30-second timeout (`s.yaml`). The first run after this ships would have found
+// 45,610 orphans on belayo — the DELETE would commit and the function would then
+// be killed a few hundred keys into the loop, leaking the rest with no row left
+// to name them. A capped run drains over several days instead, and says so.
 // ---------------------------------------------------------------------------
+
+/** Blobs collected per run. ~30ms/delete against OSS leaves room in 30s. */
+const GC_BATCH_LIMIT = 500;
+
+/** `created_at` older than 7 days and no file version pointing at the hash. */
+function orphanBlobPredicate(db: Db) {
+  return and(
+    lt(amuxcBlobs.createdAt, sql`now() - interval '7 days'`),
+    notExists(
+      db
+        .select({ one: sql`1` })
+        .from(amuxcFileVersions)
+        .innerJoin(amuxcFiles, eq(amuxcFiles.id, amuxcFileVersions.fileId))
+        .where(
+          and(
+            eq(amuxcFiles.teamId, amuxcBlobs.teamId),
+            eq(amuxcFileVersions.contentHash, amuxcBlobs.contentHash)
+          )
+        )
+    )
+  );
+}
+
 export async function ossSyncGcOrphanBlobs(
   db: Db,
   deps: CronDeps = {}
-): Promise<{ deleted: number; objectsDeleted: number; objectsFailed: number }> {
+): Promise<{
+  deleted: number;
+  objectsDeleted: number;
+  objectsFailed: number;
+  capped: number;
+}> {
+  const limit = deps.limit ?? GC_BATCH_LIMIT;
+
+  // Postgres DELETE takes no LIMIT, so pick the batch first. `oss_key` is
+  // derived from (team_id, content_hash) — the primary key — so it identifies a
+  // row exactly.
+  const batch = await db
+    .select({ ossKey: amuxcBlobs.ossKey })
+    .from(amuxcBlobs)
+    .where(orphanBlobPredicate(db))
+    .limit(limit);
+
+  if (batch.length === 0) {
+    return { deleted: 0, objectsDeleted: 0, objectsFailed: 0, capped: 0 };
+  }
+
+  // The predicate is re-checked here, not just used to build the list: between
+  // the select and the delete a blob can acquire a file version, and collecting
+  // one that just became live would delete bytes somebody now references.
   const deleteResult = await db
     .delete(amuxcBlobs)
     .where(
       and(
-        lt(amuxcBlobs.createdAt, sql`now() - interval '7 days'`),
-        notExists(
-          db
-            .select({ one: sql`1` })
-            .from(amuxcFileVersions)
-            .innerJoin(amuxcFiles, eq(amuxcFiles.id, amuxcFileVersions.fileId))
-            .where(
-              and(
-                eq(amuxcFiles.teamId, amuxcBlobs.teamId),
-                eq(amuxcFileVersions.contentHash, amuxcBlobs.contentHash)
-              )
-            )
-        )
+        inArray(amuxcBlobs.ossKey, batch.map((b) => b.ossKey)),
+        orphanBlobPredicate(db)
       )
     )
     .returning({ teamId: amuxcBlobs.teamId, ossKey: amuxcBlobs.ossKey });
 
+  // Hitting the cap is normal while a backlog drains, but it must be visible:
+  // a run that silently stops at 500 reads exactly like a run that finished.
+  // 0/1 rather than a boolean because `runCronTask` reports a map of numbers.
+  const capped = batch.length === limit ? 1 : 0;
+  if (capped) {
+    console.warn(
+      `[cron/oss-gc-blobs] hit the ${limit}-blob cap; more orphans remain for the next run`
+    );
+  }
+
   if (deleteResult.length === 0) {
-    return { deleted: 0, objectsDeleted: 0, objectsFailed: 0 };
+    return { deleted: 0, objectsDeleted: 0, objectsFailed: 0, capped };
   }
 
   // Resolved only once there is something to delete: building the real store
@@ -152,7 +207,7 @@ export async function ossSyncGcOrphanBlobs(
     }
   }
 
-  return { deleted: deleteResult.length, objectsDeleted, objectsFailed };
+  return { deleted: deleteResult.length, objectsDeleted, objectsFailed, capped };
 }
 
 // ---------------------------------------------------------------------------

--- a/services/fc/src/lib/cron.ts
+++ b/services/fc/src/lib/cron.ts
@@ -15,6 +15,12 @@ import {
   amuxcFileVersions,
   amuxcFiles,
 } from "../db/schema/oss-sync.js";
+import { getTeamBlobStorage, type BlobStorage } from "./team-blob-storage.js";
+
+/** What the cron tasks need injected; everything defaults to the real thing. */
+export interface CronDeps {
+  storage?: BlobStorage;
+}
 
 // ---------------------------------------------------------------------------
 // ossSyncAbandonExpiredSessions
@@ -71,10 +77,33 @@ export async function ossSyncAbandonExpiredSessions(
 //         JOIN amuxc_files f ON f.id = v.file_id
 //         WHERE f.team_id = b.team_id AND v.content_hash = b.content_hash
 //       );
+//
+// ...and then deletes the bytes. The pg_cron original could only reach the
+// registry, so "garbage collection" meant forgetting where the garbage was:
+// every collected blob left its object behind with nothing left pointing at it.
+//
+// Order is deliberate. The row goes first, the object second:
+//
+//   * row deleted, object delete fails  → a leaked object. Exactly the old
+//     behaviour, and the next `prepare` for that hash simply re-uploads.
+//   * object deleted, row survives      → `prepare` would see a `verified` row,
+//     tell the client to skip the upload, and `complete` would then 422 on a
+//     blob that is not there. That one is a broken client, not just waste.
+//
+// A failure to delete an object is counted and logged, never thrown: one
+// unhappy key must not abandon the rest of the sweep.
+//
+// `objectsDeleted` counts delete calls that came back clean, which is not quite
+// the same as bytes reclaimed: deleting an absent key succeeds too. It has to
+// work that way — a collector must be able to finish after a half-done previous
+// run — but it does mean a deployment whose objects sit under a key layout the
+// current storage config no longer produces will report happy deletes while the
+// real bytes stay put. Those need a one-off sweep by prefix, not this task.
 // ---------------------------------------------------------------------------
 export async function ossSyncGcOrphanBlobs(
-  db: Db
-): Promise<{ deleted: number }> {
+  db: Db,
+  deps: CronDeps = {}
+): Promise<{ deleted: number; objectsDeleted: number; objectsFailed: number }> {
   const deleteResult = await db
     .delete(amuxcBlobs)
     .where(
@@ -94,9 +123,36 @@ export async function ossSyncGcOrphanBlobs(
         )
       )
     )
-    .returning({ teamId: amuxcBlobs.teamId });
+    .returning({ teamId: amuxcBlobs.teamId, ossKey: amuxcBlobs.ossKey });
 
-  return { deleted: deleteResult.length };
+  if (deleteResult.length === 0) {
+    return { deleted: 0, objectsDeleted: 0, objectsFailed: 0 };
+  }
+
+  // Resolved only once there is something to delete: building the real store
+  // reads env a caller with nothing to collect should not have to provide.
+  const storage = deps.storage ?? getTeamBlobStorage();
+
+  let objectsDeleted = 0;
+  let objectsFailed = 0;
+  for (const { teamId, ossKey } of deleteResult) {
+    try {
+      await storage.remove(ossKey);
+      objectsDeleted++;
+    } catch (e) {
+      objectsFailed++;
+      // The row is already gone, so this line is the only remaining record of
+      // which bytes leaked. Carry the team id with it.
+      console.error(
+        "[cron/oss-gc-blobs] failed to delete object:",
+        teamId,
+        ossKey,
+        e,
+      );
+    }
+  }
+
+  return { deleted: deleteResult.length, objectsDeleted, objectsFailed };
 }
 
 // ---------------------------------------------------------------------------
@@ -106,7 +162,8 @@ export type CronTask = "oss-abandon-sessions" | "oss-gc-blobs";
 
 export async function runCronTask(
   db: Db,
-  task: string
+  task: string,
+  deps: CronDeps = {}
 ): Promise<{ task: string; result: Record<string, number> }> {
   switch (task) {
     case "oss-abandon-sessions": {
@@ -114,7 +171,7 @@ export async function runCronTask(
       return { task, result };
     }
     case "oss-gc-blobs": {
-      const result = await ossSyncGcOrphanBlobs(db);
+      const result = await ossSyncGcOrphanBlobs(db, deps);
       return { task, result };
     }
     default:

--- a/services/fc/src/lib/team-blob-storage.ts
+++ b/services/fc/src/lib/team-blob-storage.ts
@@ -1,4 +1,5 @@
 import {
+  DeleteObjectCommand,
   GetObjectCommand,
   HeadObjectCommand,
   PutObjectCommand,
@@ -84,6 +85,12 @@ export interface BlobStorage {
   createDownloadUrl(objectPath: string, expiresIn?: number): Promise<string>;
   /** `null` when the object does not exist. */
   stat(objectPath: string): Promise<{ size: number } | null>;
+  /**
+   * Remove the bytes. Idempotent: an object that is already gone is a success,
+   * because the only caller is a collector and "not there" is the outcome it
+   * wanted. Real failures (credentials, network, bucket gone) still throw.
+   */
+  remove(objectPath: string): Promise<void>;
 }
 
 export const TEAM_BLOBS_BUCKET = () => process.env.TEAM_BLOBS_STORAGE_BUCKET || "team-blobs";
@@ -132,6 +139,17 @@ export function supabaseBlobStorage(bucket: () => string): BlobStorage {
       const entry = data.find((f: { name: string }) => f.name === name);
       if (!entry) return null;
       return { size: (entry as { metadata?: { size?: number } }).metadata?.size ?? 0 };
+    },
+
+    async remove(objectPath) {
+      const { error } = await createServiceRoleClient()
+        .storage.from(bucket())
+        .remove([objectPath]);
+      // `remove` reports a missing key in `data[].error` rather than here, and
+      // we do not care either way — see the interface note on idempotence.
+      if (error) {
+        throw new Error(`failed to delete blob: ${error.message}`);
+      }
     },
   };
 }
@@ -183,6 +201,19 @@ export function s3BlobStorage(bucket: () => string, prefix: () => string): BlobS
         return { size: head.ContentLength ?? 0 };
       } catch (e) {
         if (isMissingObject(e)) return null;
+        throw e;
+      }
+    },
+
+    async remove(objectPath) {
+      try {
+        await getS3Client().send(
+          new DeleteObjectCommand({ Bucket: bucket(), Key: key(objectPath) }),
+        );
+      } catch (e) {
+        // S3 answers 204 for an absent key, but MinIO and OSS are not always so
+        // agreeable — swallow the same "no such object" shapes `stat` knows.
+        if (isMissingObject(e)) return;
         throw e;
       }
     },

--- a/services/fc/test/cron.test.ts
+++ b/services/fc/test/cron.test.ts
@@ -269,7 +269,53 @@ test("ossSyncGcOrphanBlobs: nothing to collect → storage is never touched", as
   // No storage injected at all: with zero orphans the real store must never be
   // constructed, or a deployment with no blob config would fail the sweep.
   const result = await ossSyncGcOrphanBlobs(db);
-  assert.deepEqual(result, { deleted: 0, objectsDeleted: 0, objectsFailed: 0 });
+  assert.deepEqual(result, {
+    deleted: 0,
+    objectsDeleted: 0,
+    objectsFailed: 0,
+    capped: 0,
+  });
+});
+
+test("ossSyncGcOrphanBlobs: a run is capped, and the backlog survives it", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+
+  const keys = ["k1", "k2", "k3", "k4", "k5"];
+  for (const k of keys) {
+    await db.insert(amuxcBlobs).values({
+      teamId: team.id,
+      contentHash: `${k}-hash`,
+      ossKey: k,
+      size: 100,
+      verified: true,
+      createdAt: ago(8 * 24 * 3_600_000),
+    });
+  }
+
+  // Unbounded, this run would issue one network round trip per orphan inside a
+  // 30-second function. It stops at the cap instead.
+  const objects = new Set(keys);
+  const first = await ossSyncGcOrphanBlobs(db, {
+    storage: makeMockStorage(objects),
+    limit: 2,
+  });
+  assert.equal(first.deleted, 2);
+  assert.equal(first.objectsDeleted, 2);
+  assert.equal(first.capped, 1, "hitting the cap must be reported, not silent");
+  assert.equal(objects.size, 3, "the rest of the backlog is still there");
+  assert.equal((await db.select().from(amuxcBlobs)).length, 3);
+
+  // Draining continues on the next run, and the last one is not capped.
+  await ossSyncGcOrphanBlobs(db, { storage: makeMockStorage(objects), limit: 2 });
+  const last = await ossSyncGcOrphanBlobs(db, {
+    storage: makeMockStorage(objects),
+    limit: 2,
+  });
+  assert.equal(last.deleted, 1);
+  assert.equal(last.capped, 0, "a run that did not fill the batch is not capped");
+  assert.equal(objects.size, 0);
+  assert.equal((await db.select().from(amuxcBlobs)).length, 0);
 });
 
 // ---------------------------------------------------------------------------

--- a/services/fc/test/cron.test.ts
+++ b/services/fc/test/cron.test.ts
@@ -17,6 +17,7 @@ import {
   amuxcFiles,
 } from "../src/db/schema/oss-sync.js";
 import { teams, actors, members, teamMembers, teamWorkspaceConfig } from "../src/db/schema/index.js";
+import type { BlobStorage } from "../src/lib/team-blob-storage.js";
 import { handler } from "../src/index.js";
 
 // ---------------------------------------------------------------------------
@@ -136,6 +137,22 @@ test("ossSyncAbandonExpiredSessions: abandoned+>24h expired → deleted", async 
 // ossSyncGcOrphanBlobs
 // ---------------------------------------------------------------------------
 
+/**
+ * In-memory `BlobStorage`. `failOn` makes one key's delete blow up, which is
+ * how the sweep's "keep going, count it" behaviour gets asserted.
+ */
+function makeMockStorage(objects: Set<string>, failOn?: string): BlobStorage {
+  return {
+    async createUploadUrl(p) { return `https://storage.test/up/${p}`; },
+    async createDownloadUrl(p) { return `https://storage.test/down/${p}`; },
+    async stat(p) { return objects.has(p) ? { size: 100 } : null; },
+    async remove(p) {
+      if (p === failOn) throw new Error("storage exploded");
+      objects.delete(p);
+    },
+  };
+}
+
 test("ossSyncGcOrphanBlobs: orphan blob >7d → deleted; referenced blob → kept", async () => {
   const { db } = await makeTestDb();
   const team = await seedTeam(db);
@@ -193,12 +210,66 @@ test("ossSyncGcOrphanBlobs: orphan blob >7d → deleted; referenced blob → kep
     createdBy: actor.id,
   });
 
-  const result = await ossSyncGcOrphanBlobs(db);
+  const objects = new Set(["orphan-key", "recent-orphan-key", "ref-key"]);
+  const result = await ossSyncGcOrphanBlobs(db, {
+    storage: makeMockStorage(objects),
+  });
   assert.equal(result.deleted, 1, "only the old orphan should be deleted");
 
   const remaining: any[] = await db.select().from(amuxcBlobs);
   const hashes = remaining.map((r: any) => r.contentHash).sort();
   assert.deepEqual(hashes, ["recent-orphan-hash", "ref-hash"]);
+
+  // The bytes go too — collecting the row and leaving the object behind is
+  // what made the old GC a no-op for storage.
+  assert.equal(result.objectsDeleted, 1);
+  assert.equal(result.objectsFailed, 0);
+  assert.deepEqual(
+    [...objects].sort(),
+    ["recent-orphan-key", "ref-key"],
+    "only the collected blob's object should be gone",
+  );
+});
+
+test("ossSyncGcOrphanBlobs: a failed object delete is counted, not thrown", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+
+  for (const hash of ["a", "b"]) {
+    await db.insert(amuxcBlobs).values({
+      teamId: team.id,
+      contentHash: `${hash}-hash`,
+      ossKey: `${hash}-key`,
+      size: 100,
+      verified: true,
+      createdAt: ago(8 * 24 * 3_600_000),
+    });
+  }
+
+  const objects = new Set(["a-key", "b-key"]);
+  const result = await ossSyncGcOrphanBlobs(db, {
+    storage: makeMockStorage(objects, "a-key"),
+  });
+
+  // One key blew up; the sweep still finished the other one.
+  assert.equal(result.deleted, 2);
+  assert.equal(result.objectsDeleted, 1);
+  assert.equal(result.objectsFailed, 1);
+  assert.deepEqual([...objects], ["a-key"], "the failed key's object survives");
+
+  // Rows are gone either way. A leaked object is the acceptable failure mode;
+  // a surviving row pointing at deleted bytes is not.
+  assert.equal((await db.select().from(amuxcBlobs)).length, 0);
+});
+
+test("ossSyncGcOrphanBlobs: nothing to collect → storage is never touched", async () => {
+  const { db } = await makeTestDb();
+  await seedTeam(db);
+
+  // No storage injected at all: with zero orphans the real store must never be
+  // constructed, or a deployment with no blob config would fail the sweep.
+  const result = await ossSyncGcOrphanBlobs(db);
+  assert.deepEqual(result, { deleted: 0, objectsDeleted: 0, objectsFailed: 0 });
 });
 
 // ---------------------------------------------------------------------------

--- a/services/fc/test/db-search-path.test.ts
+++ b/services/fc/test/db-search-path.test.ts
@@ -1,0 +1,42 @@
+/**
+ * db-search-path.test.ts — pins the schema resolution order for every drizzle
+ * query.
+ *
+ * Every table in `src/db/schema/` is declared with a bare `pgTable("name")`, so
+ * the emitted SQL is unqualified and `search_path` alone decides what it finds.
+ * The tables live in `amux`; the connecting role's stock default does not list
+ * it. When that was the whole story, both FC timer tasks failed on every run
+ * with `relation "amuxc_upload_sessions" does not exist` — for months, silently,
+ * because nothing else on the deployment uses this client.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveSearchPath } from "../src/db/client.js";
+
+const schemas = () => resolveSearchPath().split(",").map((s) => s.trim());
+
+test("amux is searched first — that is the whole point", () => {
+  assert.equal(schemas()[0], "amux");
+});
+
+test("the stock Supabase schemas are kept, not replaced", () => {
+  // `public` still holds tables this schema also names (members, permissions);
+  // `auth` and `extensions` are GoTrue's tables and pgcrypto. Dropping any of
+  // them would trade one set of missing relations for another.
+  for (const schema of ["public", "auth", "extensions"]) {
+    assert.ok(schemas().includes(schema), `${schema} must stay on the path`);
+  }
+});
+
+test("no env var can move it", () => {
+  // The FC deploy target rewrites its whole environment map, so a search_path
+  // that lived in env would disappear on an unrelated deploy and put the cron
+  // tasks back on the floor. It stays in git next to the migrations that decide
+  // where the tables actually are.
+  process.env.PG_SEARCH_PATH = "somewhere_else";
+  try {
+    assert.equal(schemas()[0], "amux");
+  } finally {
+    delete process.env.PG_SEARCH_PATH;
+  }
+});

--- a/services/fc/test/sync-handlers-pg.test.ts
+++ b/services/fc/test/sync-handlers-pg.test.ts
@@ -75,6 +75,9 @@ function makeMockStorage(state: MockStorageState): BlobStorage {
       const size = state.objects.get(objectPath);
       return size === undefined ? null : { size };
     },
+    async remove(objectPath) {
+      state.objects.delete(objectPath);
+    },
   };
 }
 


### PR DESCRIPTION
查 belayo 日志时发现的：两个 FC 定时任务 **自 2026-06 建函数起 100% 失败**，一次都没成功过，每次 4 次重试全挂。SLS 日志能回溯到的最早一条是 06-21（再往前超出保留期），函数是 06-15 建的。

```
oss-abandon-sessions  每 15 分钟   PostgresError: relation "amuxc_upload_sessions" does not exist
oss-gc-blobs          每天 04:17   PostgresError: relation "amuxc_blobs" does not exist
```

## 根因不是缺表，是 search_path

- `to_regclass('amuxc_upload_sessions')` → NULL；`to_regclass('amux.amuxc_upload_sessions')` → 有。表在 `amux` 里（`move_teamclu_to_amux` 搬的）。
- `src/db/schema/` 里**一个 `pgSchema` 都没有**，全是裸的 `pgTable("name")`，`getDb()` 也没设 search_path。
- 连接角色带的是 Supabase 默认的 `"$user", public, auth, extensions` —— 没人把 `amux` 放上去。

所以整个 drizzle 层都假设表在 search_path 上。两个线上环境都跑 `BACKEND_KIND=supabase`，业务请求走 PostgREST（它自己配了 amux），**只有 cron 这条直连 DB 的路径暴露出来**，而它没人看，于是错了两个月没人发现。

self-host 上看不到这个错不是因为它没问题：compose 里 `cron` 是 `profiles: ["cron"]` 选择性启用，box 上没跑这个容器，同一个 bug 潜伏着。

## 改法

**1. `db/client.ts`** — 在启动包里把 `amux` **前置**成 `amux, public, auth, extensions`。

不是替换：`public` 还有这份 schema 同名的 `members`/`permissions`，`auth`/`extensions` 是 GoTrue 的表和 pgcrypto，换成 `amux,public` 只会拿一批缺失的关系换另一批。

**刻意没做成 env var**：FC 那个 target 每次部署重写整张环境变量表，只配在某台机器 env 文件里的值会在下一次无关部署时消失，把 cron 再次悄悄打回原形——跟 `APP_FEATURES_JSON` 在 s.yaml 注释里写的是同一个坑。表在哪是迁移决定的，迁移在 git 里，这个也该在。

**2. GC 的另一半：它只删注册表行，从来不删对象。**

`services/fc/src/` 里没有任何 `deleteObject` 调用，所以"垃圾回收"实际是把垃圾在哪的线索删了——收掉的 blob 留下一个再没有任何东西指向它的对象。belayo 现在 45,610 行孤儿，对应 1014 MB 这样的对象。

`BlobStorage` 补 `remove()`（s3 走 `DeleteObjectCommand`，supabase 走 `.remove()`，两边都把"对象本来就不在"当成功），GC 先删行再删对象：

- 删了行、删对象失败 → 漏一个对象，**就是今天的行为**，下次 `prepare` 会重传
- 删了对象、行还在 → `prepare` 看到 `verified` 行让客户端跳过上传，`complete` 就 422

前者只是浪费，后者是坏掉的客户端，所以顺序不能反。单个对象删失败只计数加日志，不中断整轮清扫。

## 验证

拿真 belayo 库跑了只读版本（没改数据）：`set search_path to amux, public, auth, extensions` 之后，cron 那三条裸表名语句全部解析成功——

```
abandon-step1 would mark    46023
abandon-step2 would delete      0
gc would collect            45610
```

单测新增 5 个（3 个钉 search_path 顺序、2 个钉对象删除与失败计数），受影响的 4 个文件 35/35 绿。

全量 `npm test` 是 1259 个 / 7 红，但 **main 上是同样的 7 个**（`FC_SUPABASE_URL`、`TRUSTED_EXTERNAL_JWT_SECRET`、`CODEUP_*` 的部署环境变量对账，加 4 个 pg-repo teams 用例），跟本 PR 无关。`npm run typecheck` 同理，两边都是 28 个错且没有一个在改动的文件里。

## 已知没覆盖的

`objectsDeleted` 数的是"删除调用成功"，不等于真的释放了字节——删一个不存在的 key 也算成功（必须如此，否则上一轮半途而废后这一轮跑不完）。

belayo 的对象键布局变过三代：`≤08-07` 写 OSS 裸路径、`08-07~08-17` 在 Supabase Storage、`≥08-17`（#937）才是 `team-blobs/` 前缀。新 GC 按当前前缀删，只够得着最后那 381 个；前面 60,821 个（1.65 GiB）和桶里 139 个已不存在团队的前缀（11.8 GiB）都要靠按前缀的一次性脚本，不在这个 PR 里。这一点写在代码注释里了。

> ⚠️ 这个 PR 动 `services/fc/**`，合进 main 会触发 self-host 自动部署。belayo 是手工部署，需要另外发一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
