### PR TITLE
chore: 个人 SDLC 覆盖文件挪到仓库根目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,7 +125,7 @@ docs/superpowers/
 
 # Internal planning documents
 docs/superpowers/*
-docs/SDLC.md
+SDLC.md
 docs/prototypes/
 docs/design/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@ This file is the source-of-truth for the **web / desktop** visual language
 (`packages/app/`). For the **iOS client** (`apps/ios/`) the source-of-truth is
 `apps/ios/DESIGN.md` (the Hai 灰 / wabi-sabi system) — don't apply the rules
 below to iOS work. For repo conventions (architecture, commands, release
-process) see `CLAUDE.md`. If `docs/SDLC.md` exists in this checkout, read it
-before starting changes; it is a local, git-ignored SDLC override for this
-workspace.
+process) see `CLAUDE.md`. If `SDLC.md` exists at the repo root of this
+checkout, read it before starting changes; it is a local, git-ignored SDLC
+override for this workspace.
 
 The web/desktop design direction is **"Editorial Calm"** — paper-feel
 neutrals, brand coral used only as small accents, Chinese-first typography,
@@ -19,8 +19,8 @@ The local prototype copy lives in `/tmp/design-OLWqff/` when fetched.
 
 > **Git note:** Work on a task-scoped branch, never on `main`, and never push
 > to `main` directly. See `CLAUDE.md` → Git Workflow for the full rule. If
-> `docs/SDLC.md` exists in this checkout, it may add personal worktree /
-> preview-integration conventions on top.
+> `SDLC.md` exists at the repo root of this checkout, it may add personal
+> worktree / preview-integration conventions on top.
 >
 > **PR rule:** Do **not** push the branch or run `gh pr create` on your own
 > initiative. Until the user explicitly says "open the PR" / "ship it" /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ Pull Request:
    back.
 3. Do not merge or push to `main` directly, even for small fixes.
 
-If `docs/SDLC.md` exists in this checkout, read it before starting any change.
+If `SDLC.md` exists at the repo root of this checkout, read it before starting
+any change.
 It is a local, git-ignored SDLC override that can layer additional personal
 workflow (e.g. worktree + preview-integration conventions) on top of the rules
 above. It is intentionally not checked in, so it only affects the workspace that


### PR DESCRIPTION
把个人 SDLC 覆盖文件的位置从 `docs/SDLC.md` 挪到仓库根目录的 `SDLC.md`。

## 改了什么

```
.gitignore:128   docs/SDLC.md → SDLC.md
CLAUDE.md:26     If `SDLC.md` exists at the repo root of this checkout, ...
AGENTS.md:7      同上
AGENTS.md:22     同上（Git note 那个 blockquote 里）
```

四处一起改，`grep -rn "docs/SDLC.md"` 已确认没有指向旧路径的死引用残留。

## 为什么挪

`SDLC.md` 和 `CLAUDE.md`、`AGENTS.md` 是同一类东西——agent 进来先读的规矩，不是 `docs/` 里的参考资料。放在一起，新来的人（和新来的 agent）一眼能看出这三个是一组。

## 对其他人的影响

**没有行为变化。** 这个文件依旧是 git-ignored 的：谁的 checkout 里有它，谁的 agent 就按它执行；没有的 checkout 完全走默认流程，和现在一模一样。仓库里从来没有、以后也不会有这个文件的内容。

所以这个 PR 的全部内容就是一行忽略规则改名 + 三处文档引用跟着改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
