### PR TITLE
fix: paginate regular and scheduled sessions independently

### DIFF
--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -472,6 +472,15 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: kind
+          in: query
+          description: >-
+            Session type to paginate. The filter is applied before LIMIT so
+            regular and scheduled sessions have independent page boundaries.
+          schema:
+            type: string
+            enum: [all, regular, cron]
+            default: all
       responses:
         "200":
           description: Current actor sessions.

--- a/packages/app/src/components/sidebar/NavRail.tsx
+++ b/packages/app/src/components/sidebar/NavRail.tsx
@@ -12,7 +12,7 @@ function refreshSessionListThrottled(): void {
   const now = Date.now()
   if (now - lastSessionListRefreshAt < 5_000) return
   lastSessionListRefreshAt = now
-  void useSessionListStore.getState().load().catch(() => {})
+  void useSessionListStore.getState().loadFirstPage(50, 'regular').catch(() => {})
 }
 import { useCronStore } from '@/stores/cron'
 import { createQuickSession, describeQuickSessionFailure } from '@/lib/create-quick-session'

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -223,7 +223,6 @@ export function SessionListColumn({
   // last_message_preview, idea_id — no extra Supabase round-trip needed.
   const listRows = useSessionListStore((s) => s.rows)
   const listLoading = useSessionListStore((s) => s.loading)
-  const listHasMore = useSessionListStore((s) => s.hasMore)
   const loadMoreSessions = useSessionListStore((s) => s.loadMore)
 
   // Activity badges: useSessionListActivityMap (legacy + v2 ACP permissions).
@@ -237,6 +236,9 @@ export function SessionListColumn({
   const cronSessionIds = useCronStore((s) => s.cronSessionIds)
   const showCronSessions = useCronStore((s) => s.showCronSessions)
   const toggleShowCronSessions = useCronStore((s) => s.toggleShowCronSessions)
+  const listHasMore = useSessionListStore((s) =>
+    showCronSessions ? s.cronHasMore : s.regularHasMore,
+  )
 
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
   const hasWorkspace = !!workspacePath
@@ -1043,12 +1045,9 @@ export function SessionListColumn({
               )}
               disabled={!sessionHeaderActionsEnabled}
               onClick={() => {
-                // When switching *into* the scheduled-sessions view, refresh the
-                // session list once so newly-created cron runs show up.
-                if (!showCronSessions) {
-                  void useSessionListStore.getState().loadFirstPage()
-                }
+                const nextKind = showCronSessions ? 'regular' : 'cron'
                 toggleShowCronSessions()
+                void useSessionListStore.getState().loadFirstPage(50, nextKind)
               }}
               title={showCronSessions ? t('sidebar.showAllSessions', 'Show all sessions') : t('sidebar.showCronSessions', 'Show scheduled sessions')}
             >

--- a/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
@@ -140,6 +140,11 @@ describe('SessionListColumn', () => {
       error: null,
       hasMore: false,
       nextCursor: null,
+      listKind: 'regular',
+      regularHasMore: false,
+      regularNextCursor: null,
+      cronHasMore: false,
+      cronNextCursor: null,
     })
   })
 
@@ -296,6 +301,19 @@ describe('SessionListColumn', () => {
     useUIStore.setState({ sidebarFilter: { kind: 'pinned' } })
     rerender(<SessionListColumn />)
     expect(screen.queryByRole('button', { name: /显示定时会话|显示全部会话/ })).not.toBeInTheDocument()
+  })
+
+  it('starts a separate cron page when opening scheduled sessions', () => {
+    useWorkspaceStore.setState({ workspacePath: '/tmp/ws' })
+    const loadFirstPage = vi
+      .spyOn(useSessionListStore.getState(), 'loadFirstPage')
+      .mockResolvedValue()
+    render(<SessionListColumn />)
+
+    fireEvent.click(screen.getByRole('button', { name: /显示定时会话|Show scheduled sessions/ }))
+
+    expect(loadFirstPage).toHaveBeenCalledWith(50, 'cron')
+    loadFirstPage.mockRestore()
   })
 
   it('shows workspace subline under session title in non-workspace filters', () => {

--- a/packages/app/src/lib/backend/cloud-api/__tests__/cloud-api.test.ts
+++ b/packages/app/src/lib/backend/cloud-api/__tests__/cloud-api.test.ts
@@ -112,7 +112,7 @@ describe("cloud api backend", () => {
     await expect(backend.auth.claimInvite("invite-token")).resolves.toMatchObject({ actorId: "actor-1" });
 
     expect(calls.map((call) => `${call.method} ${call.path}`)).toEqual([
-      "GET /v1/sessions?limit=50&teamId=team-1",
+      "GET /v1/sessions?limit=50&teamId=team-1&kind=all",
       "GET /v1/sessions/session-1/messages",
       "POST /v1/sessions/session-1/messages",
       "GET /v1/teams?limit=1",

--- a/packages/app/src/lib/backend/cloud-api/__tests__/sessions.test.ts
+++ b/packages/app/src/lib/backend/cloud-api/__tests__/sessions.test.ts
@@ -37,7 +37,7 @@ const cloudSession = {
 
 describe("sessions module", () => {
   it("listCurrentActorSessions calls /v1/sessions and maps fields", async () => {
-    const client = mockClient({ "GET /v1/sessions?limit=50&teamId=team-1": { items: [cloudSession], nextCursor: "cursor-1" } });
+    const client = mockClient({ "GET /v1/sessions?limit=50&teamId=team-1&kind=all": { items: [cloudSession], nextCursor: "cursor-1" } });
     const mod = createSessionsModule(client);
     const out = await mod.listCurrentActorSessions({ limit: 50, cursor: null, teamId: "team-1" });
     expect(out.rows[0].id).toBe("session-1");

--- a/packages/app/src/lib/backend/cloud-api/sessions.ts
+++ b/packages/app/src/lib/backend/cloud-api/sessions.ts
@@ -88,6 +88,7 @@ export function createSessionsModule(client: CloudApiClient): SessionsBackend {
       limit: number;
       cursor: SessionListCursor | null;
       teamId: string;
+      kind?: "all" | "regular" | "cron";
     }): Promise<SessionListPage> {
       // Without this an undefined teamId serializes to the literal string
       // "undefined", which sails past the server's truthiness check and reaches
@@ -97,6 +98,7 @@ export function createSessionsModule(client: CloudApiClient): SessionsBackend {
       const params = new URLSearchParams({
         limit: String(args.limit),
         teamId,
+        kind: args.kind ?? "all",
       });
       if (args.cursor) params.set("cursor", encodeCursor(args.cursor));
       const page = await client.get<Page<CloudSession>>(`/v1/sessions?${params.toString()}`);

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -202,6 +202,7 @@ export interface SessionsBackend {
     limit: number;
     cursor: SessionListCursor | null;
     teamId: string;
+    kind?: "all" | "regular" | "cron";
   }): Promise<SessionListPage>;
   markCurrentActorSessionViewed(sessionId: string, lastReadMessageId?: string | null): Promise<void>;
   createSessionShell(input: SessionCreateInput): Promise<{ sessionId: string }>;

--- a/packages/app/src/lib/reset-client-chat-state.ts
+++ b/packages/app/src/lib/reset-client-chat-state.ts
@@ -23,6 +23,11 @@ export function resetClientChatState(): void {
     error: null,
     hasMore: false,
     nextCursor: null,
+    listKind: "regular",
+    regularHasMore: false,
+    regularNextCursor: null,
+    cronHasMore: false,
+    cronNextCursor: null,
     highlightedSessionIds: [],
     // The list is team-scoped; clearing the scope alongside the rows is what
     // makes the next loadFirstPage re-fetch instead of treating the emptied

--- a/packages/app/src/stores/session-list-store.test.ts
+++ b/packages/app/src/stores/session-list-store.test.ts
@@ -66,6 +66,11 @@ describe("session-list-store", () => {
       highlightedSessionIds: [],
       hasMore: false,
       nextCursor: null,
+      listKind: "regular",
+      regularHasMore: false,
+      regularNextCursor: null,
+      cronHasMore: false,
+      cronNextCursor: null,
       serverConfirmedTeams: [],
       emptyPageKeptTeams: [],
       scopeTeamId: null,
@@ -125,6 +130,7 @@ describe("session-list-store", () => {
       limit: 50,
       cursor: null,
       teamId: "team-1",
+      kind: "regular",
     });
     expect(useSessionListStore.getState().rows[0]).toMatchObject({
       id: "session-1",
@@ -175,12 +181,49 @@ describe("session-list-store", () => {
         id: "session-2",
       },
       teamId: "team-1",
+      kind: "regular",
     });
     expect(useSessionListStore.getState().rows.map((row) => row.id)).toEqual([
       "session-1",
       "session-2",
       "session-3",
     ]);
+  });
+
+  it("keeps independent cursors for regular and cron sessions", async () => {
+    const regularCursor = "regular-page-2";
+    const cronCursor = "cron-page-2";
+    mocks.listCurrentActorSessions
+      .mockResolvedValueOnce({
+        rows: [sessionRow({ id: "regular-1" })],
+        nextCursor: regularCursor,
+      })
+      .mockResolvedValueOnce({
+        rows: [{ ...sessionRow({ id: "cron-1" }), source: "cron" }],
+        nextCursor: cronCursor,
+      })
+      .mockResolvedValueOnce({ rows: [], nextCursor: null })
+      .mockResolvedValueOnce({ rows: [], nextCursor: null });
+
+    const { useSessionListStore } = await import("./session-list-store");
+    await useSessionListStore.getState().loadFirstPage(50, "regular");
+    await useSessionListStore.getState().loadFirstPage(50, "cron");
+
+    expect(useSessionListStore.getState().rows.map((row) => row.id)).toEqual([
+      "regular-1",
+      "cron-1",
+    ]);
+
+    await useSessionListStore.getState().loadMore();
+    expect(mocks.listCurrentActorSessions).toHaveBeenLastCalledWith(
+      expect.objectContaining({ cursor: cronCursor, kind: "cron" }),
+    );
+
+    useSessionListStore.getState().setListKind("regular");
+    await useSessionListStore.getState().loadMore();
+    expect(mocks.listCurrentActorSessions).toHaveBeenLastCalledWith(
+      expect.objectContaining({ cursor: regularCursor, kind: "regular" }),
+    );
   });
 
   it("uses the backend next cursor instead of inferring hasMore from row count", async () => {

--- a/packages/app/src/stores/session-list-store.ts
+++ b/packages/app/src/stores/session-list-store.ts
@@ -187,6 +187,11 @@ interface State {
   highlightedSessionIds: string[];
   hasMore: boolean;
   nextCursor: SessionListCursor | null;
+  listKind: SessionListKind;
+  regularHasMore: boolean;
+  regularNextCursor: SessionListCursor | null;
+  cronHasMore: boolean;
+  cronNextCursor: SessionListCursor | null;
   /**
    * Teams the server has returned at least one session row for since sign-in.
    * Gates the empty-response guard in `loadFirstPage` — see the comment there.
@@ -217,8 +222,9 @@ interface State {
    */
   loadedTeamId: string | null;
   load: () => Promise<void>;
-  loadFirstPage: (limit?: number) => Promise<void>;
+  loadFirstPage: (limit?: number, kind?: SessionListKind) => Promise<void>;
   loadMore: (limit?: number) => Promise<void>;
+  setListKind: (kind: SessionListKind) => void;
   upsertRows: (rows: SessionListEntry[]) => void;
   patchRow: (sessionId: string, patch: Partial<SessionListEntry>) => void;
   /** Patch preview fields and re-sort by last_message_at. */
@@ -236,6 +242,34 @@ interface State {
   archiveSession: (sessionId: string) => Promise<boolean>;
   /** Like archiveSession but does not surface failures on the store error field. */
   archiveSessionQuiet: (sessionId: string) => Promise<boolean>;
+}
+
+export type SessionListKind = "regular" | "cron";
+
+function isKind(row: SessionListEntry, kind: SessionListKind): boolean {
+  return kind === "cron" ? row.source === "cron" : row.source !== "cron";
+}
+
+function filterToKind(rows: SessionListEntry[], kind: SessionListKind): SessionListEntry[] {
+  return rows.filter((row) => isKind(row, kind));
+}
+
+function replaceKindRows(
+  existing: SessionListEntry[],
+  incoming: SessionListEntry[],
+  kind: SessionListKind,
+): SessionListEntry[] {
+  return sortEntries([...existing.filter((row) => !isKind(row, kind)), ...incoming]);
+}
+
+function paginationPatch(
+  kind: SessionListKind,
+  nextCursor: SessionListCursor | null,
+): Partial<State> {
+  const hasMore = nextCursor != null;
+  return kind === "cron"
+    ? { cronHasMore: hasMore, cronNextCursor: nextCursor, hasMore, nextCursor }
+    : { regularHasMore: hasMore, regularNextCursor: nextCursor, hasMore, nextCursor };
 }
 
 function mergeRows(existing: SessionListEntry[], incoming: SessionListEntry[]): SessionListEntry[] {
@@ -258,11 +292,13 @@ async function loadPage(
   limit: number,
   cursor: State["nextCursor"],
   teamId: string,
+  kind: SessionListKind,
 ) {
   return getBackend().sessions.listCurrentActorSessions({
     limit,
     cursor,
     teamId,
+    kind,
   });
 }
 
@@ -318,6 +354,7 @@ function applyArchivedSessionLocalState(
 async function loadFirstPageForTeam(
   limit: number,
   teamId: string,
+  kind: SessionListKind,
   generation: number,
   set: (partial: Partial<State>) => void,
   get: () => State,
@@ -331,7 +368,15 @@ async function loadFirstPageForTeam(
   // sessions while the new page is in flight.
   const previousScope = get().scopeTeamId;
   if (previousScope !== null && previousScope !== teamId) {
-    set({ rows: [], hasMore: false, nextCursor: null });
+    set({
+      rows: [],
+      hasMore: false,
+      nextCursor: null,
+      regularHasMore: false,
+      regularNextCursor: null,
+      cronHasMore: false,
+      cronNextCursor: null,
+    });
   }
   set({ loading: true, error: null, scopeTeamId: teamId });
   markStartup("session-list:start");
@@ -345,7 +390,7 @@ async function loadFirstPageForTeam(
   // otherwise the offline paint shows sessions the server page will then
   // remove. `teamId` is the active team, so the member actor for that team is
   // the right one to narrow by.
-  const existingRows = get().rows;
+  const existingRows = filterToKind(get().rows, kind);
   const currentMemberActorId = useCurrentTeamStore.getState().currentMember?.id ?? null;
   if (isTauri() && currentMemberActorId && existingRows.length === 0) {
     // The cache is an accelerator, never a gate. A rejection here (most
@@ -359,11 +404,16 @@ async function loadFirstPageForTeam(
       ]);
       if (superseded()) return;
       const actorSessionIdSet = new Set(actorSessionIds);
-      const currentActorRows = localRows.filter((row) => actorSessionIdSet.has(row.id));
+      const currentActorRows = filterToKind(
+        localRows.filter((row) => actorSessionIdSet.has(row.id)).map(mapCacheToEntry),
+        kind,
+      );
       if (currentActorRows.length > 0) {
         set({
-          rows: filterArchivedEntries(
-            sortEntries(currentActorRows.map(mapCacheToEntry)),
+          rows: replaceKindRows(
+            get().rows,
+            filterArchivedEntries(sortEntries(currentActorRows)),
+            kind,
           ),
         });
         markStartup("session-list:local-cache");
@@ -375,7 +425,7 @@ async function loadFirstPageForTeam(
 
   let page: SessionListPage;
   try {
-    page = await loadPage(limit, null, teamId);
+    page = await loadPage(limit, null, teamId, kind);
   } catch (error) {
     if (superseded()) return;
     const message = error instanceof Error ? error.message : String(error);
@@ -386,7 +436,7 @@ async function loadFirstPageForTeam(
     return;
   }
   if (superseded()) return;
-  const rows = filterToScope(page.rows, teamId);
+  const rows = filterToKind(filterToScope(page.rows, teamId), kind);
   const nextCursor = resolveNextCursor(page);
 
   // ── Empty-response guard ───────────────────────────────────────────────
@@ -409,21 +459,28 @@ async function loadFirstPageForTeam(
   // that were archived on another device would stay in the sidebar forever.
   // Keeping them through one refresh is the hedge against a fail-closed
   // visibility gate; keeping them through every refresh is just a stale list.
-  const teamConfirmed = get().serverConfirmedTeams.includes(teamId);
-  const alreadyKeptOnce = get().emptyPageKeptTeams.includes(teamId);
-  if (rows.length === 0 && get().rows.length > 0 && !teamConfirmed && !alreadyKeptOnce) {
+  // Preserve the historical regular-session key; cron needs its own proof so
+  // one type cannot disable the empty-page safety guard for the other.
+  const confirmationKey = kind === "regular" ? teamId : `${teamId}:cron`;
+  const teamConfirmed = get().serverConfirmedTeams.includes(confirmationKey);
+  const alreadyKeptOnce = get().emptyPageKeptTeams.includes(confirmationKey);
+  const visibleKindRows = filterToKind(get().rows, kind);
+  if (rows.length === 0 && visibleKindRows.length > 0 && !teamConfirmed && !alreadyKeptOnce) {
     console.warn(
       "[session-list] server returned 0 sessions and none were confirmed before; keeping cached rows",
     );
     set({
       loading: false,
-      hasMore: false,
-      nextCursor: null,
+      ...paginationPatch(kind, null),
       // Kept rows are cache rows; narrow them to this team so a row seeded for
       // another team before the first load cannot survive here.
-      rows: filterToScope(get().rows, teamId),
+      rows: replaceKindRows(
+        get().rows,
+        filterToKind(filterToScope(get().rows, teamId), kind),
+        kind,
+      ),
       scopeTeamId: teamId,
-      emptyPageKeptTeams: [...get().emptyPageKeptTeams, teamId],
+      emptyPageKeptTeams: [...get().emptyPageKeptTeams, confirmationKey],
     });
     markStartup("session-list:loaded");
     return;
@@ -467,10 +524,9 @@ async function loadFirstPageForTeam(
   if (superseded()) return;
   forgetArchivedSessionIds(rows);
   set({
-    rows: filterArchivedEntries(sortEntries(rows)),
+    rows: replaceKindRows(get().rows, filterArchivedEntries(sortEntries(rows)), kind),
     loading: false,
-    hasMore: nextCursor != null,
-    nextCursor,
+    ...paginationPatch(kind, nextCursor),
     // Re-asserted, not assumed: resetClientChatState nulls the scope on the
     // same team switch that started this run, and its follow-up loadFirstPage
     // is swallowed by the in-flight de-dupe — so this commit is the only thing
@@ -478,11 +534,11 @@ async function loadFirstPageForTeam(
     scopeTeamId: teamId,
     loadedTeamId: teamId,
     serverConfirmedTeams:
-      rows.length > 0 && !get().serverConfirmedTeams.includes(teamId)
-        ? [...get().serverConfirmedTeams, teamId]
+      rows.length > 0 && !get().serverConfirmedTeams.includes(confirmationKey)
+        ? [...get().serverConfirmedTeams, confirmationKey]
         : get().serverConfirmedTeams,
     // A page that actually arrived supersedes the one-shot hedge above.
-    emptyPageKeptTeams: get().emptyPageKeptTeams.filter((id) => id !== teamId),
+    emptyPageKeptTeams: get().emptyPageKeptTeams.filter((id) => id !== confirmationKey),
   });
   markStartup("session-list:loaded");
 }
@@ -495,6 +551,11 @@ export const useSessionListStore = create<State>((set, get) => ({
   highlightedSessionIds: [],
   hasMore: false,
   nextCursor: null,
+  listKind: "regular",
+  regularHasMore: false,
+  regularNextCursor: null,
+  cronHasMore: false,
+  cronNextCursor: null,
   serverConfirmedTeams: [],
   emptyPageKeptTeams: [],
   scopeTeamId: null,
@@ -502,7 +563,8 @@ export const useSessionListStore = create<State>((set, get) => ({
   load: async () => {
     await get().loadFirstPage();
   },
-  loadFirstPage: async (limit = 50) => {
+  loadFirstPage: async (limit = 50, kind = get().listKind) => {
+    get().setListKind(kind);
     const session = useAuthStore.getState().session;
     if (!session) {
       set({
@@ -511,6 +573,11 @@ export const useSessionListStore = create<State>((set, get) => ({
         error: null,
         hasMore: false,
         nextCursor: null,
+        listKind: "regular",
+        regularHasMore: false,
+        regularNextCursor: null,
+        cronHasMore: false,
+        cronNextCursor: null,
         // Signing out re-arms the empty-response guard: the next account's
         // first page has proven nothing yet, in any team.
         serverConfirmedTeams: [],
@@ -536,13 +603,14 @@ export const useSessionListStore = create<State>((set, get) => ({
       return;
     }
 
-    if (firstPageInFlight && firstPageInFlightScope === teamId) {
+    const requestScope = `${teamId}:${kind}`;
+    if (firstPageInFlight && firstPageInFlightScope === requestScope) {
       return firstPageInFlight;
     }
     const generation = ++firstPageGeneration;
-    const run = loadFirstPageForTeam(limit, teamId, generation, set, get);
+    const run = loadFirstPageForTeam(limit, teamId, kind, generation, set, get);
     firstPageInFlight = run;
-    firstPageInFlightScope = teamId;
+    firstPageInFlightScope = requestScope;
     try {
       await run;
     } finally {
@@ -555,7 +623,8 @@ export const useSessionListStore = create<State>((set, get) => ({
   loadMore: async (limit = 50) => {
     const session = useAuthStore.getState().session;
     if (!session) return;
-    const cursor = get().nextCursor;
+    const kind = get().listKind;
+    const cursor = kind === "cron" ? get().cronNextCursor : get().regularNextCursor;
     if (!cursor) return;
 
     // Page 2+ must carry the same scope as page 1 — otherwise scrolling pulls
@@ -569,7 +638,7 @@ export const useSessionListStore = create<State>((set, get) => ({
     set({ loading: true, error: null });
     let page: SessionListPage;
     try {
-      page = await loadPage(limit, cursor, teamId);
+      page = await loadPage(limit, cursor, teamId, kind);
     } catch (error) {
       set({ loading: false, error: error instanceof Error ? error.message : String(error) });
       return;
@@ -580,17 +649,21 @@ export const useSessionListStore = create<State>((set, get) => ({
       set({ loading: false });
       return;
     }
-    const rows = filterToScope(page.rows, teamId);
+    const rows = filterToKind(filterToScope(page.rows, teamId), kind);
     const nextCursor = resolveNextCursor(page);
     forgetArchivedSessionIds(rows);
     const nextRows = filterArchivedEntries(mergeRows(get().rows, rows));
     set({
       rows: nextRows,
       loading: false,
-      hasMore: nextCursor != null,
-      nextCursor,
+      ...paginationPatch(kind, nextCursor),
     });
   },
+  setListKind: (kind) => set((state) => ({
+    listKind: kind,
+    hasMore: kind === "cron" ? state.cronHasMore : state.regularHasMore,
+    nextCursor: kind === "cron" ? state.cronNextCursor : state.regularNextCursor,
+  })),
   upsertRows: (rows) =>
     set((state) => ({
       rows: mergeRows(state.rows, filterToScope(rows, state.scopeTeamId)),

--- a/services/fc/src/lib/pg-repo/sessions.ts
+++ b/services/fc/src/lib/pg-repo/sessions.ts
@@ -187,11 +187,13 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
     async listSessions({
       teamId,
       ideaId,
+      kind = "all",
       limit = 50,
       cursor = null,
     }: {
       teamId?: string;
       ideaId?: string;
+      kind?: "all" | "regular" | "cron";
       limit?: number;
       cursor?: { lastMessageAt?: string | null; createdAt?: string; id?: string } | null;
     } = {}) {
@@ -223,6 +225,11 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
       // what keeps "sessions for this idea" correct once the list is paginated
       // — a client-side filter over page 1 silently misses matches on page 2.
       const ideaFilter = ideaId ? sql`sessions.idea_id = ${ideaId}` : sql`TRUE`;
+      const kindFilter = kind === "cron"
+        ? sql`sessions.source = 'cron'`
+        : kind === "regular"
+          ? sql`COALESCE(sessions.source, 'user') <> 'cron'`
+          : sql`TRUE`;
 
       let cursorFilter = sql`TRUE`;
       if (cursor) {
@@ -282,6 +289,7 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
         FROM sessions
         WHERE (${teamFilter})
           AND (${ideaFilter})
+          AND (${kindFilter})
           AND (${participantFilter})
           AND (${cursorFilter})
           -- No archived_at filter, unlike the Supabase RPC: this schema has no

--- a/services/fc/src/lib/routes/sessions.ts
+++ b/services/fc/src/lib/routes/sessions.ts
@@ -20,8 +20,27 @@ export function registerSessions(router) {
     const cursor = decodeCursor(ctx.query.get("cursor"));
     const teamId = requireString(ctx.query.get("teamId"), "teamId");
     const ideaId = ctx.query.get("ideaId") || null;
-    const items = await ctx.repository.listSessions({ limit, cursor, teamId, ideaId });
-    return { body: { items, nextCursor: nextSessionCursor(items, limit) } };
+    const kind = ctx.query.get("kind") || "all";
+    if (!["all", "regular", "cron"].includes(kind)) {
+      throw new ApiError(400, "validation_failed", "kind must be all, regular, or cron");
+    }
+    // Fetch one sentinel row so an exactly-full terminal page does not expose
+    // a dead "Load more" cursor. The sentinel is never returned to clients.
+    const fetched = await ctx.repository.listSessions({
+      limit: limit + 1,
+      cursor,
+      teamId,
+      ideaId,
+      kind,
+    });
+    const hasMore = fetched.length > limit;
+    const items = fetched.slice(0, limit);
+    return {
+      body: {
+        items,
+        nextCursor: hasMore ? nextSessionCursor(items, limit) : null,
+      },
+    };
   });
 
   router.post("/v1/sessions", async (ctx) => {

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -1178,7 +1178,7 @@ export function createSupabaseBusinessRepository(options) {
       };
     },
 
-    async listSessions({ limit = 50, cursor = null, teamId = null, ideaId = null }: any = {}) {
+    async listSessions({ limit = 50, cursor = null, teamId = null, ideaId = null, kind = "all" }: any = {}) {
       // p_team_id is what resolves the caller's actor as of 20260804020000,
       // since a user has one actor row per team. It is also load-bearing for
       // performance: only the team-scoped RPC can walk
@@ -1201,6 +1201,7 @@ export function createSupabaseBusinessRepository(options) {
         // and is what lets this replace GET /v1/teams/:teamId/sessions.
         p_team_id: teamId,
         p_idea_id: ideaId ?? null,
+        p_kind: kind,
       });
       if (error) throw error;
       return (data ?? []).map(mapSession);

--- a/services/fc/test/business-api.test.ts
+++ b/services/fc/test/business-api.test.ts
@@ -15,6 +15,7 @@ test("handleBusinessApiRequest routes list sessions with bearer-scoped repositor
     sessions: [
       session("s1", "2026-05-27T01:00:00Z"),
       session("s2", "2026-05-27T00:00:00Z"),
+      session("s3", "2026-05-26T23:00:00Z"),
     ],
   });
   const createCalls = [];
@@ -47,12 +48,32 @@ test("handleBusinessApiRequest routes list sessions with bearer-scoped repositor
   assert.deepEqual(repo.calls[0], {
     method: "listSessions",
     args: {
-      limit: 2,
+      limit: 3,
       cursor: null,
       teamId: "team-1",
       ideaId: null,
+      kind: "all",
     },
   });
+});
+
+test("GET /v1/sessions does not return a cursor for an exactly-full terminal page", async () => {
+  const repo = fakeRepo({
+    sessions: [
+      session("s1", "2026-05-27T01:00:00Z"),
+      session("s2", "2026-05-27T00:00:00Z"),
+    ],
+  });
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/sessions",
+    headers: { Authorization: "Bearer token" },
+    queryParameters: { teamId: "team-1", limit: "2", kind: "regular" },
+  }, { createRepository: () => repo });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(JSON.parse(response.body).nextCursor, null);
+  assert.equal(repo.calls[0].args.limit, 3, "one sentinel row is requested");
 });
 
 test("list sessions decodes cursor before calling repository", async () => {
@@ -968,14 +989,14 @@ test("GET /v1/sessions narrows by teamId and ideaId server-side", async () => {
   const response = await handleBusinessApiRequest({
     httpMethod: "GET",
     path: "/v1/sessions",
-    queryParameters: { teamId: "team-1", ideaId: "idea-1", limit: "25" },
+    queryParameters: { teamId: "team-1", ideaId: "idea-1", kind: "regular", limit: "25" },
     headers: { Authorization: "Bearer token" },
   }, { createRepository: () => repo });
 
   assert.equal(response.statusCode, 200);
   assert.deepEqual(repo.calls[0], {
     method: "listSessions",
-    args: { limit: 25, cursor: null, teamId: "team-1", ideaId: "idea-1" },
+    args: { limit: 26, cursor: null, teamId: "team-1", ideaId: "idea-1", kind: "regular" },
   });
 });
 
@@ -1015,8 +1036,21 @@ test("GET /v1/sessions leaves ideaId null when not supplied", async () => {
   assert.equal(response.statusCode, 200);
   assert.deepEqual(repo.calls[0], {
     method: "listSessions",
-    args: { limit: 50, cursor: null, teamId: "team-1", ideaId: null },
+    args: { limit: 51, cursor: null, teamId: "team-1", ideaId: null, kind: "all" },
   });
+});
+
+test("GET /v1/sessions rejects an unknown session kind", async () => {
+  const repo = fakeRepo();
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/sessions",
+    headers: { Authorization: "Bearer token" },
+    queryParameters: { teamId: "team-1", kind: "scheduled-ish" },
+  }, { createRepository: () => repo });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(repo.calls.length, 0);
 });
 
 

--- a/services/fc/test/pg-repo-sessions.test.ts
+++ b/services/fc/test/pg-repo-sessions.test.ts
@@ -101,6 +101,32 @@ test("listSessions narrows by teamId and ideaId", async () => {
   assert.deepEqual(otherTeam, [], "a foreign teamId must not leak rows");
 });
 
+test("listSessions filters session kind before pagination", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const actor = await seedActor(db, team.id);
+  const repo = createPgBusinessRepository({ db, userId: actor.userId });
+
+  const regular = await repo.createSession({
+    teamId: team.id, title: "Regular", mode: "solo", participantActorIds: [actor.id],
+  });
+  const cron = await repo.createSession({
+    teamId: team.id, title: "Cron", mode: "solo", participantActorIds: [actor.id],
+  });
+  await db.execute(sql`UPDATE sessions SET source = 'user' WHERE id = ${regular.id}`);
+  await db.execute(sql`UPDATE sessions SET source = 'cron' WHERE id = ${cron.id}`);
+
+  const regularRows = await repo.listSessions({
+    teamId: team.id, kind: "regular", limit: 1, cursor: null,
+  });
+  const cronRows = await repo.listSessions({
+    teamId: team.id, kind: "cron", limit: 1, cursor: null,
+  });
+
+  assert.deepEqual(regularRows.map((row: any) => row.title), ["Regular"]);
+  assert.deepEqual(cronRows.map((row: any) => row.title), ["Cron"]);
+});
+
 test("listSessions ordering: lastMessageAt desc nulls last, then createdAt desc, then id desc", async () => {
   const { db } = await makeTestDb();
   const team = await seedTeam(db);

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -63,6 +63,7 @@ test("listSessions maps current actor session rpc rows", async () => {
   const rows = await repo.listSessions({
     limit: 10,
     teamId: "team-1",
+    kind: "regular",
     cursor: { lastMessageAt: "2026-05-27T00:00:00Z", createdAt: "2026-05-26T00:00:00Z", id: "s0" },
   });
 
@@ -78,6 +79,7 @@ test("listSessions maps current actor session rpc rows", async () => {
       p_before_id: "s0",
       p_team_id: "team-1",
       p_idea_id: null,
+      p_kind: "regular",
     },
   }]);
   // The row grew after this test was written: source/cronJobId came with cron

--- a/services/supabase/migrations/20260820000000_session_list_kind_pagination.sql
+++ b/services/supabase/migrations/20260820000000_session_list_kind_pagination.sql
@@ -1,0 +1,134 @@
+-- Paginate regular and scheduled sessions independently.
+--
+-- Filtering after LIMIT made a mixed first page such as 47 cron + 3 regular
+-- render as "3 regular sessions, load more".  The type predicate belongs in
+-- the RPC, before keyset ordering and LIMIT, so each type owns its cursor.
+
+DROP FUNCTION IF EXISTS amux.list_current_actor_sessions(
+  uuid, integer, timestamp with time zone, timestamp with time zone, uuid, uuid
+);
+
+CREATE FUNCTION amux.list_current_actor_sessions(
+  p_team_id uuid,
+  p_limit integer DEFAULT 50,
+  p_before_last_message_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_before_created_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_before_id uuid DEFAULT NULL::uuid,
+  p_idea_id uuid DEFAULT NULL::uuid,
+  p_kind text DEFAULT 'all'
+) RETURNS TABLE(
+  id uuid,
+  title text,
+  team_id uuid,
+  mode text,
+  idea_id uuid,
+  last_message_at timestamp with time zone,
+  last_message_preview text,
+  created_at timestamp with time zone,
+  updated_at timestamp with time zone,
+  has_unread boolean,
+  source text,
+  cron_job_id text,
+  summary text,
+  primary_agent_id uuid,
+  created_by_actor_id uuid,
+  participant_count integer
+)
+LANGUAGE plpgsql
+STABLE
+SET search_path TO 'public', 'app'
+SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+begin
+  if p_team_id is null then
+    raise exception 'list_current_actor_sessions requires p_team_id'
+      using errcode = '22023';
+  end if;
+  if coalesce(p_kind, 'all') not in ('all', 'regular', 'cron') then
+    raise exception 'list_current_actor_sessions p_kind must be all, regular, or cron'
+      using errcode = '22023';
+  end if;
+
+  return query
+  with current_actor as (
+    select amux.current_actor_id_for_team(p_team_id) as actor_id
+  )
+  select
+    s.id,
+    s.title,
+    s.team_id,
+    s.mode,
+    s.idea_id,
+    s.last_message_at,
+    s.last_message_preview,
+    s.created_at,
+    s.updated_at,
+    (
+      s.last_message_at is not null
+      and s.last_message_at > coalesce(
+            (select srm.last_read_at
+               from amux.session_read_markers srm
+              where srm.session_id = s.id
+                and srm.actor_id = ca.actor_id),
+            '-infinity'::timestamptz)
+    ) as has_unread,
+    s.source,
+    s.cron_job_id,
+    s.summary,
+    s.primary_agent_id,
+    s.created_by_actor_id,
+    (
+      select count(*)
+      from amux.session_participants participant
+      where participant.session_id = s.id
+    )::integer as participant_count
+  from current_actor ca
+  join amux.session_participants membership
+    on membership.actor_id = ca.actor_id
+  join amux.sessions s
+    on s.id = membership.session_id
+  where s.archived_at is null
+    and s.team_id = p_team_id
+    and (p_idea_id is null or s.idea_id = p_idea_id)
+    and (
+      coalesce(p_kind, 'all') = 'all'
+      or (p_kind = 'cron' and s.source = 'cron')
+      or (p_kind = 'regular' and coalesce(s.source, 'user') <> 'cron')
+    )
+    and (
+      p_before_id is null
+      or (
+        case
+          when p_before_last_message_at is null then
+            s.last_message_at is not null
+            or (
+              s.last_message_at is null
+              and (
+                s.created_at < p_before_created_at
+                or (s.created_at = p_before_created_at and s.id < p_before_id)
+              )
+            )
+          when s.last_message_at is null then false
+          when s.last_message_at < p_before_last_message_at then true
+          when s.last_message_at = p_before_last_message_at then
+            s.created_at < p_before_created_at
+            or (s.created_at = p_before_created_at and s.id < p_before_id)
+          else false
+        end
+      )
+    )
+  order by
+    s.last_message_at desc nulls first,
+    s.created_at desc,
+    s.id desc
+  -- The HTTP facade asks for page-size + 1 to detect the terminal page.
+  limit greatest(1, least(coalesce(p_limit, 50), 101));
+end;
+$function$;
+
+REVOKE ALL ON FUNCTION amux.list_current_actor_sessions(
+  uuid, integer, timestamp with time zone, timestamp with time zone, uuid, uuid, text
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION amux.list_current_actor_sessions(
+  uuid, integer, timestamp with time zone, timestamp with time zone, uuid, uuid, text
+) TO authenticated, service_role;

--- a/services/supabase/tests/010_session_read_markers.sql
+++ b/services/supabase/tests/010_session_read_markers.sql
@@ -30,8 +30,8 @@ select has_index('amux', 'messages', 'messages_session_created_idx',
 select has_function(
   'amux',
   'list_current_actor_sessions',
-  array['uuid', 'integer', 'timestamp with time zone', 'timestamp with time zone', 'uuid', 'uuid'],
-  'list_current_actor_sessions(team, limit, keyset…, idea) exists'
+  array['uuid', 'integer', 'timestamp with time zone', 'timestamp with time zone', 'uuid', 'uuid', 'text'],
+  'list_current_actor_sessions(team, limit, keyset…, idea, kind) exists'
 );
 select has_function('amux', 'mark_current_actor_session_viewed', array['uuid', 'uuid'],
                     'mark_current_actor_session_viewed(session, message) exists');

--- a/services/supabase/tests/016_session_list_v2_rpc.sql
+++ b/services/supabase/tests/016_session_list_v2_rpc.sql
@@ -1,6 +1,6 @@
 begin;
 
-select plan(9);
+select plan(11);
 
 -- The three-argument forms are deliberate. pgTAP overloads these on
 -- (schema, object) AND (object, description), and two untyped literals resolve
@@ -17,7 +17,7 @@ select has_index('amux', 'sessions', 'sessions_team_last_message_idx',
 select has_function(
   'amux',
   'list_current_actor_sessions',
-  array['uuid', 'integer', 'timestamp with time zone', 'timestamp with time zone', 'uuid', 'uuid']
+  array['uuid', 'integer', 'timestamp with time zone', 'timestamp with time zone', 'uuid', 'uuid', 'text']
 );
 select has_function('amux', 'mark_current_actor_session_viewed', array['uuid', 'uuid']);
 
@@ -128,6 +128,10 @@ values
   ('51000000-0000-0000-0000-000000000001', '11000000-0000-0000-0000-000000000001', 'member'),
   ('51000000-0000-0000-0000-000000000004', '11000000-0000-0000-0000-000000000002', 'member');
 
+update amux.sessions
+set source = 'cron', cron_job_id = 'fixture-cron'
+where id = '51000000-0000-0000-0000-000000000003';
+
 -- team_id became NOT NULL on this table in 20260804020000 so its policies can
 -- resolve the caller per team.
 insert into amux.session_read_markers (
@@ -151,6 +155,24 @@ select is(
   (select count(*)::int from amux.list_current_actor_sessions('01000000-0000-0000-0000-000000000001', 50, null, null, null)),
   3,
   'list_current_actor_sessions returns only current actor participant sessions'
+);
+
+select is(
+  (select count(*)::int from amux.list_current_actor_sessions(
+    p_team_id => '01000000-0000-0000-0000-000000000001',
+    p_kind => 'regular'
+  )),
+  2,
+  'regular sessions are filtered before pagination'
+);
+
+select is(
+  (select count(*)::int from amux.list_current_actor_sessions(
+    p_team_id => '01000000-0000-0000-0000-000000000001',
+    p_kind => 'cron'
+  )),
+  1,
+  'cron sessions have an independent page'
 );
 
 select ok(

--- a/services/supabase/tests/030_session_list_participant_index.sql
+++ b/services/supabase/tests/030_session_list_participant_index.sql
@@ -20,9 +20,10 @@ select has_function(
     'timestamp with time zone',
     'timestamp with time zone',
     'uuid',
-    'uuid'
+    'uuid',
+    'text'
   ],
-  'session list RPC retains its six-argument contract'
+  'session list RPC exposes the session-kind filter'
 );
 
 select * from finish();


### PR DESCRIPTION
## Summary
- filter regular and cron sessions server-side before keyset pagination
- maintain independent cursors and load-more state for both session views
- use a sentinel row to avoid a dead Load more button on exact page boundaries
- add Supabase RPC migration plus frontend, PG repository, API, and pgTAP coverage

## Verification
- pnpm exec vitest run src/stores/session-list-store.test.ts src/components/sidebar/__tests__/SessionListColumn.test.tsx src/components/sidebar/__tests__/NavRail.test.tsx src/lib/backend/cloud-api/__tests__/sessions.test.ts --reporter=dot (63 passed)
- pnpm exec tsc --noEmit (packages/app)
- tsc -p services/fc/tsconfig.json --noEmit
- PG repository and Supabase repository tests passed; the combined FC run cannot import business-api.test.ts under local Node 25 because the installed better-auth expects a newer jose export