### PR TITLE
fix(ios): wait for TestFlight ASC processing in CI

### DIFF
--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -108,9 +108,14 @@ platform :ios do
       },
     )
 
+    # Wait until ASC finishes processing. With skip_waiting, CI stayed green
+    # while rejected/invalid builds (e.g. build number behind an older train)
+    # never appeared in TestFlight — see the 1.2 (9) upload that never showed.
     upload_to_testflight(
       api_key: api_key,
-      skip_waiting_for_build_processing: true,
+      skip_waiting_for_build_processing: false,
+      # Default 30m is tight on cold runners; give ASC more room before failing.
+      wait_processing_timeout_duration: 60 * 60,
     )
   end
 end


### PR DESCRIPTION
## Summary
- Stop skipping ASC build processing in the `beta` lane so a rejected/invalid upload fails CI instead of looking green.
- Raise the processing wait timeout to 60 minutes for cold runners.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, TestFlight workflow runs and either publishes a build or fails visibly on ASC processing


Made with [Cursor](https://cursor.com)