### PR TITLE
fix(fc): completed 上传会话没人删，一个文件一条永久堆着

### DIFF
--- a/services/fc/src/lib/cron.ts
+++ b/services/fc/src/lib/cron.ts
@@ -32,6 +32,23 @@ export interface CronDeps {
 //     WHERE status='pending' AND expires_at < now();
 //   DELETE FROM amuxc_upload_sessions
 //     WHERE status='abandoned' AND expires_at < now() - interval '24 hours';
+//
+// ...plus `completed`, which the pg_cron original never collected. Nothing did:
+// a session that succeeded stayed in the table forever. On belayo that was
+// 15,308 rows and climbing, one per file anyone had ever synced — invisible
+// next to the abandoned-session pile until that one was cleaned up and this was
+// all that remained.
+//
+// Deleting them is safe because a completed row has exactly one job left. Both
+// complete paths look a session up BY ID (`sync-handlers.ts`, `pg-repo/oss-sync.ts`)
+// and answer 410 `session is completed` instead of 404 when a client retries a
+// `complete` that already succeeded. Nothing else reads the row: the durable
+// record of what was uploaded is `amuxc_file_versions`.
+//
+// So it is kept for a window, not deleted on the spot. A session's own TTL is
+// one hour, and the retention below is keyed off `expires_at`, so a completed
+// row survives ~25 hours past creation — orders of magnitude longer than any
+// retry, and the same rule the abandoned ones already follow.
 // ---------------------------------------------------------------------------
 export async function ossSyncAbandonExpiredSessions(
   db: Db
@@ -51,12 +68,15 @@ export async function ossSyncAbandonExpiredSessions(
     )
     .returning({ id: amuxcUploadSessions.id });
 
-  // 2. Delete abandoned sessions that expired more than 24 hours ago.
+  // 2. Delete finished sessions that expired more than 24 hours ago —
+  //    `abandoned` (gave up) and `completed` (succeeded) alike. `pending` is
+  //    deliberately absent: step 1 above is what retires those, and a pending
+  //    row that is not yet expired is a live upload.
   const deleteResult = await db
     .delete(amuxcUploadSessions)
     .where(
       and(
-        eq(amuxcUploadSessions.status, "abandoned"),
+        inArray(amuxcUploadSessions.status, ["abandoned", "completed"]),
         lt(
           amuxcUploadSessions.expiresAt,
           sql`now() - interval '24 hours'`

--- a/services/fc/test/cron.test.ts
+++ b/services/fc/test/cron.test.ts
@@ -133,6 +133,62 @@ test("ossSyncAbandonExpiredSessions: abandoned+>24h expired → deleted", async 
   assert.equal(rows[0].path, "/d.txt");
 });
 
+test("ossSyncAbandonExpiredSessions: completed sessions are collected too", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const actor = await seedActor(db, team.id);
+
+  const session = (path: string, status: string, expiredAgoMs: number) => ({
+    teamId: team.id,
+    actorId: actor.id,
+    path,
+    parentVersion: 0,
+    contentHash: `h${path}`,
+    size: 10,
+    ossKey: `k${path}`,
+    status,
+    expiresAt: ago(expiredAgoMs),
+  });
+
+  // Nothing ever deleted these, so one accumulated per file anyone ever synced.
+  await db.insert(amuxcUploadSessions).values(session("/old-done.txt", "completed", 25 * 3_600_000));
+  // Inside the retention window: a client retrying `complete` must still get
+  // 410 "session is completed" rather than 404.
+  await db.insert(amuxcUploadSessions).values(session("/fresh-done.txt", "completed", 3_600_000));
+  await db.insert(amuxcUploadSessions).values(session("/old-gone.txt", "abandoned", 25 * 3_600_000));
+
+  const result = await ossSyncAbandonExpiredSessions(db);
+  assert.equal(result.deleted, 2, "the old completed one goes with the abandoned one");
+
+  const left: any[] = await db.select().from(amuxcUploadSessions);
+  assert.deepEqual(left.map((r: any) => r.path), ["/fresh-done.txt"]);
+});
+
+test("ossSyncAbandonExpiredSessions: a live pending session is never deleted", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const actor = await seedActor(db, team.id);
+
+  // Not expired: an upload in flight. Widening step 2 to more statuses must not
+  // reach it — the client is still holding this session id.
+  await db.insert(amuxcUploadSessions).values({
+    teamId: team.id,
+    actorId: actor.id,
+    path: "/inflight.txt",
+    parentVersion: 0,
+    contentHash: "h-live",
+    size: 10,
+    ossKey: "k-live",
+    status: "pending",
+    expiresAt: fromNow(30 * 60_000),
+  });
+
+  const result = await ossSyncAbandonExpiredSessions(db);
+  assert.equal(result.abandoned, 0);
+  assert.equal(result.deleted, 0);
+  assert.equal((await db.select().from(amuxcUploadSessions)).length, 1);
+});
+
 // ---------------------------------------------------------------------------
 // ossSyncGcOrphanBlobs
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

`amuxc_upload_sessions` 表里 **15308 条 `completed` 状态的行没有任何东西清理**——每同步一个文件留一条，只增不减。之前被四万多条 `pending` 盖住了，那堆清掉才露出来。

pg_cron 原版第 2 步只删 `abandoned`，`completed` 不匹配任何条件——这不是 search_path 那个 bug 的一部分，修好 search_path 也不会动它们。

## 改动

`services/fc/src/lib/cron.ts` 第 2 步删除条件从 `status='abandoned'` 扩到 `in ('abandoned','completed')`。`pending` 刻意排除：退休 pending 是第 1 步的事，没过期的 pending 是正在传的文件。

## 为什么安全

- completed 行只剩一个用途：两条 complete 路径按 id 查一次（`sync-handlers.ts`、`pg-repo/oss-sync.ts`），让重试一次已成功的 complete 拿到 410「session is completed」而不是 404。
- 除此之外没有任何读者，真正持久的记录是 `amuxc_file_versions`；库里没有外键指向这张表（belayo 上核实过）。
- 保留窗口而非完成即删：按 `expires_at` 过期 24 小时后删，completed 行能活到创建后约 25 小时，跟 abandoned 是同一规则。

## 测试

- `ossSyncAbandonExpiredSessions: completed sessions are collected too` — 过期的 completed 与 abandoned 一起删，保留窗口内的 completed 保留
- `ossSyncAbandonExpiredSessions: a live pending session is never deleted` — 未过期的 pending 绝不被删