### PR TITLE
fix(expo): expo-localization 版本号写错一个世代（Android 启动即崩）+ .env.example 补齐

### DIFF
--- a/apps/expo/.env.example
+++ b/apps/expo/.env.example
@@ -11,3 +11,25 @@ EXPO_PUBLIC_CLOUD_API_URL=https://api.teamclu-dev.ucar.cc
 # an app release. Set this only to pin a specific broker for local development —
 # it overrides the fetch entirely.
 EXPO_PUBLIC_MQTT_URL=
+
+# Error reporting. Public by design — the DSN ships inside the client bundle,
+# so this is the real value rather than a placeholder.
+EXPO_PUBLIC_SENTRY_DSN=https://3d62272a2572c722fbf4da76ef3ea30e@o60909.ingest.us.sentry.io/4511878837960704
+
+# Verbose Sentry logging. 1 while debugging the reporter itself, otherwise 0.
+EXPO_PUBLIC_SENTRY_DEBUG=0
+
+# Only for `eas build` / publishing. Personal token — NEVER commit a real one.
+# Leave blank for local `expo prebuild` + gradle builds, which need no auth.
+EXPO_TOKEN=
+
+# A NOTE ON STALE COPIES
+#
+# EAS builds ignore `.env` entirely; their values come from the `env` block of
+# each profile in eas.json. So a `.env` copied from this file long ago and never
+# refreshed breaks only LOCAL builds — cloud builds keep passing and nothing
+# looks wrong. That is how a pre-rename `.env` naming `api.teamclaw-dev.ucar.cc`
+# survived here: the record was deleted on purpose during the teamclaw → teamclu
+# rename, so the Android build compiled, installed, and failed only when someone
+# tapped sign-in. If something works on EAS but not locally, re-diff against
+# this file first.

--- a/apps/expo/README.md
+++ b/apps/expo/README.md
@@ -63,11 +63,23 @@ should be made in the `app/` directory.
 
 ## Environment
 
-Create `apps/expo/.env` from `.env.example` and provide:
+```sh
+cp apps/expo/.env.example apps/expo/.env
+```
 
-- `EXPO_PUBLIC_CLOUD_API_URL` — **required**
+- `EXPO_PUBLIC_CLOUD_API_URL` — **required**; the template already carries the
+  right value
 - `EXPO_PUBLIC_MQTT_URL` — optional, only when pinning a broker for local
   development
+- `EXPO_TOKEN` — only for `eas build` / publishing; leave blank otherwise
+
+EAS builds ignore `.env` entirely — their values come from the `env` block of
+each profile in `eas.json`. Keep the two in step: a `.env` that has drifted
+breaks only LOCAL builds, so cloud builds keep passing and nobody notices. That
+is exactly how a `.env` left over from before the teamclaw → teamclu rename
+survived — it still named `api.teamclaw-dev.ucar.cc`, a host whose DNS record
+was deliberately deleted, so the local Android build compiled, installed, and
+failed only when someone tapped sign-in.
 
 `EXPO_PUBLIC_CLOUD_API_URL` is the one that must be set. Without it the app
 throws on its first render (`EXPO_PUBLIC_CLOUD_API_URL is required (cloud_api is

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -30,7 +30,7 @@
     "expo-image-picker": "^57.0.8",
     "expo-linear-gradient": "~57.0.1",
     "expo-linking": "~57.0.5",
-    "expo-localization": "~17.0.7",
+    "expo-localization": "~57.0.1",
     "expo-notifications": "~57.0.9",
     "expo-router": "~57.0.11",
     "expo-sqlite": "~57.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ~57.0.5
         version: 57.0.5(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)
       expo-localization:
-        specifier: ~17.0.7
-        version: 17.0.9(expo@57.0.11)(react@19.2.8)
+        specifier: ~57.0.1
+        version: 57.0.1(expo@57.0.11)(react@19.2.8)
       expo-notifications:
         specifier: ~57.0.9
         version: 57.0.9(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
@@ -5611,8 +5611,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  expo-localization@17.0.9:
-    resolution: {integrity: sha512-k5eYHr7iLMob3M8cHH6bgDrDRmqnZG8xKGLhpx8ST+LsFXmSgYpJ/t0VwWm0gz64C/K669XhObdG3D6QwCGqhw==}
+  expo-localization@57.0.1:
+    resolution: {integrity: sha512-8Ffl4UTbOsQeGT0v5fxMbyPHyPMPnhSPDFQJa8p9rjJrthFoAtNi+fL6Ssmrvf1/7dmPq1mVY52MEt0TMEfgjA==}
     peerDependencies:
       expo: '*'
       react: '*'
@@ -14170,7 +14170,7 @@ snapshots:
       - expo
       - supports-color
 
-  expo-localization@17.0.9(expo@57.0.11)(react@19.2.8):
+  expo-localization@57.0.1(expo@57.0.11)(react@19.2.8):
     dependencies:
       expo: 57.0.11(0c436e1b63bc6325df63addf536c0852)
       react: 19.2.8


### PR DESCRIPTION
两个 commit：一个修真 bug，一个补文档。可以分开看。

---

# 1. `expo-localization` 版本号写错一个世代 → Android 启动即崩

## 症状

从 main 打的 Android release 包，**装上后一启动就退**，进程活不过 3 秒。

```
FATAL EXCEPTION: pool-3-thread-1
java.lang.NoSuchMethodError: No direct method <init>(Lkotlin/reflect/KClass;)V
  in class Lexpo/modules/kotlin/types/ReturnType;
    at expo.modules.localization.LocalizationModule.definition(LocalizationModule.kt:204)
    at expo.modules.kotlin.ModuleRegistry.register(ModuleRegistry.kt:29)
    at expo.modules.kotlin.AppContext.<init>(AppContext.kt:131)
```

崩在原生模块注册阶段，所以任何界面都来不及画。

## 原因

`apps/expo/package.json` 里写的是 `~17.0.7`。`17.0.x` 是 `expo-localization` 早年的独立版本线；Expo SDK 57 对应的是 `~57.0.1`。装出来的 `17.0.9` 照着**另一个版本的 `expo-modules-core`** 编译，它要调的 `ReturnType(KClass)` 构造函数在包里这份 core 上不存在。

`npx expo install --check` 也单独把它标了出来 —— 其余包都只是小版本落后（`57.0.9` vs `57.0.13` 之类），只有它差了一整代：

```
expo-localization@17.0.9 - expected version: ~57.0.1
```

这个依赖是随「跟随系统语言支持中英双语」那次改动进来的，版本号从一开始就是错的。iOS 侧没暴露，是因为原生模块的绑定方式不同。

## 验证

**moto g35 5G / Android 15 / arm64-v8a** 真机：

| | |
|---|---|
| 改之前 | 装上即崩，`FATAL EXCEPTION` × 1，进程秒退 |
| 改之后 | 启动正常，进程稳定存活，`FATAL` 0 次，JS VM 正常起来 |

构建方式：`expo prebuild -p android` + `gradlew assembleRelease`（本地 release 包，不带 dev-client 外壳）。

---

# 2. `.env.example` 补齐 + 写明陈旧 `.env` 的陷阱

这部分是排查上面那个崩溃时连带发现的，**独立于崩溃本身**。

修完崩溃之后，同一个包又出现「点 Google 登录说地址无法访问」。原因是本地 `.env` 里还是改名前的 `api.teamclaw-dev.ucar.cc` —— 那条 DNS 在 teamclaw → teamclu 改名时被**有意删除**，现在彻底不解析。

关键在于这个陷阱的形状：

- 模板 `.env.example` **本来就存在，地址也一直是对的**，README 也早就指向它
- 但**已经存在的 `.env` 不会因为模板更新而更新** —— 一份改名前建的个人文件就这么活了下来
- 而 **EAS 构建完全不读 `.env`**（值来自 `eas.json` 各 profile 的 `env` 块），所以漂移**只坏本地构建**，云构建一路绿灯，没人会注意到
- 本地 Android 包因此编译通过、安装成功，**只在点登录时才炸**

所以加两样：

**模板补齐缺的三个变量。** 原来只有 `CLOUD_API_URL` 和 `MQTT_URL`，而一份能跑的 `.env` 有五个 —— 照它复制出来的人拿不到 Sentry，也没有 `EXPO_TOKEN` 的位置。补上（token 留空；DSN 用真实值，它本来就打进客户端包里）。**纯追加，原有内容一字未动。**

**模板和 README 里写明上面那条判据**：「EAS 上好使、本地不好使，先回来对这个文件」。

`EXPO_PUBLIC_BACKEND_KIND` 刻意不写进模板：它只在 `src/test/cloud-api-provider.test.ts` 里被 stub，运行时无人读取（`cloud_api` 早已是唯一后端），列出来只会让人以为还能切后端。

---

## 顺带一提，本 PR 没动的

`expo install --check` 还报了 `@sentry/react-native@8.23.0`（应为 `~7.11.0`）和 `react@19.2.8`（应为 `19.2.3`）超前 —— 来自最近合的 dependabot #958 / #955。**dependabot 不认识 Expo 的版本约束**，只看 npm semver。这次崩溃跟它们无关，但建议给 `apps/expo/` 下的 Expo 生态包加 dependabot ignore，否则同类问题会反复出现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
