### PR TITLE
fix(daemon): 一条改名残留的 MCP 配置能把整个 pi runtime 打死

### DIFF
--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -149,6 +149,9 @@ class McpBridge {
   private nextId = 1;
   private pending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();
   private buffer = "";
+  /** First fatal error seen (spawn failure or child exit). Once set, every
+   *  request fails immediately instead of writing to a dead pipe. */
+  private failure: Error | null = null;
 
   constructor(cmd: string[], env?: Record<string, string>) {
     this.child = spawn(cmd[0], cmd.slice(1), {
@@ -157,18 +160,34 @@ class McpBridge {
     });
     this.child.stdout!.setEncoding("utf8");
     this.child.stdout!.on("data", (chunk: string) => this.onData(chunk));
-    this.child.on("exit", () => {
-      const err = new Error("remote-tools MCP server exited");
-      for (const p of this.pending.values()) p.reject(err);
-      this.pending.clear();
+    // A ChildProcess "error" event with NO listener is an uncaught exception in
+    // node — it takes the whole pi process down, before `host_ready` and before
+    // any response. That is how one stale entry in the workspace MCP config (a
+    // renamed binary, an absolute path from another machine) turned every
+    // session in that workspace into "pi exited before responding". Bridging is
+    // best-effort by design (`bridgeMcpServer` catches and carries on); this
+    // listener is what lets that catch ever run.
+    this.child.on("error", (e: unknown) => {
+      this.fail(e instanceof Error ? e : new Error(String(e)));
     });
+    this.child.on("exit", (code, signal) => {
+      this.fail(
+        new Error(`MCP server "${cmd[0]}" exited (code=${code ?? "null"} signal=${signal ?? "null"})`),
+      );
+    });
+  }
+
+  /** Record the first fatal error and fail everything in flight. */
+  private fail(err: Error): void {
+    if (!this.failure) this.failure = err;
+    for (const p of this.pending.values()) p.reject(err);
+    this.pending.clear();
   }
 
   /** Kill the child and fail anything still in flight. Used when a server's
    *  command changed or it was removed from the config. */
   dispose(): void {
-    for (const p of this.pending.values()) p.reject(new Error("MCP bridge disposed"));
-    this.pending.clear();
+    this.fail(new Error("MCP bridge disposed"));
     try {
       this.child.kill();
     } catch {
@@ -198,6 +217,7 @@ class McpBridge {
   }
 
   request(method: string, params?: unknown, timeoutMs = 60_000): Promise<any> {
+    if (this.failure) return Promise.reject(this.failure);
     const id = this.nextId++;
     const payload = JSON.stringify({ jsonrpc: "2.0", id, method, params: params ?? {} });
     return new Promise((resolve, reject) => {
@@ -215,12 +235,25 @@ class McpBridge {
           reject(e);
         },
       });
-      this.child.stdin!.write(payload + "\n");
+      try {
+        this.child.stdin!.write(payload + "\n");
+      } catch (e) {
+        // Dead pipe (child already gone): reject rather than throw out of the
+        // executor, so the caller sees a normal bridge failure.
+        this.pending.delete(id);
+        clearTimeout(timer);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
     });
   }
 
   notify(method: string, params?: unknown): void {
-    this.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params: params ?? {} }) + "\n");
+    if (this.failure) return;
+    try {
+      this.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params: params ?? {} }) + "\n");
+    } catch {
+      // Same as `request`: a dead bridge is not a fatal condition.
+    }
   }
 }
 

--- a/apps/daemon/src/config/roles_skills.rs
+++ b/apps/daemon/src/config/roles_skills.rs
@@ -1143,10 +1143,21 @@ pub fn delete_role(
 
 #[cfg(test)]
 mod tests {
+    // EVERY test here takes a `BrandEnvGuard`, including the ones that never
+    // change the brand. The workspace meta dir is named after the *process*
+    // brand (`workspace_meta_read_roots` + `brand_short_name_from_env`), which
+    // is a process-global env var, and the white-label tests below flip it to
+    // `copilot361` under `TEST_HOME_LOCK`. A test that only reads those paths
+    // and does not take the lock therefore has the directory renamed out from
+    // under it mid-run: `upsert_skill` writes `.teamclu/skills/<slug>` and the
+    // `delete_skill` that follows looks in `.copilot361/skills/` and reports
+    // NotFound. That is a real CI failure, not a hypothetical. Pinning the
+    // official brand takes the same lock and makes the name deterministic.
     use super::*;
 
     #[test]
     fn scan_empty_workspace_returns_empty_state() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         let dir = tempfile::tempdir().unwrap();
         let state = scan_roles_skills_state(dir.path()).unwrap();
         assert!(state.roles.is_empty());
@@ -1163,6 +1174,7 @@ mod tests {
     /// `collect_team_skill_paths`.
     #[test]
     fn scan_finds_nested_team_bundle_skills() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         let dir = tempfile::tempdir().unwrap();
         let ws = dir.path();
 
@@ -1207,6 +1219,7 @@ mod tests {
     /// the team retired.
     #[test]
     fn team_share_leftovers_are_no_longer_scanned() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         let dir = tempfile::tempdir().unwrap();
         let ws = dir.path();
 
@@ -1227,6 +1240,7 @@ mod tests {
 
     #[test]
     fn scan_finds_role_and_skill() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         let dir = tempfile::tempdir().unwrap();
         let ws = dir.path();
 
@@ -1257,6 +1271,7 @@ mod tests {
 
     #[test]
     fn upsert_and_delete_skill_round_trip() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         let ws = tempfile::tempdir().unwrap();
         let req = UpsertSkillRequest {
             content: "# Demo\n\nBody".to_owned(),
@@ -1291,6 +1306,7 @@ mod tests {
 
     #[test]
     fn the_team_pack_root_outranks_a_personal_copy() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         // A member with a same-named skill of their own must not decide what the
         // team's procedure is. Only the workspace's own meta dir and
         // `.claude/skills` sit above the pack root.
@@ -1317,6 +1333,7 @@ mod tests {
 
     #[test]
     fn a_duplicated_slug_resolves_by_root_rank_not_by_scan_order() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         // `.claude/skills` (rank 1) outranks `.agents/skills` (3), which
         // outranks `.opencode/skills` (11) — regardless of the order the specs
         // happen to be listed in. Ordering used to be derived from the source
@@ -1341,6 +1358,7 @@ mod tests {
 
     #[test]
     fn only_the_brand_meta_dir_gets_the_local_builtin_clawhub_labels() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         // `builtin` and `clawhub` are read out of the workspace's own inherent
         // list and lockfile, so they describe the brand meta directory and
         // nothing else. This used to be applied to every root whose parent name
@@ -1384,6 +1402,7 @@ mod tests {
 
     #[test]
     fn upsert_reports_the_directory_it_wrote_even_when_a_higher_source_shadows_the_slug() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         // The share-then-edit case, which used to 404 with "not found after
         // write".
         //
@@ -1451,6 +1470,7 @@ mod tests {
 
     #[test]
     fn upsert_skill_rejects_dir_path_outside_workspace_and_home() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         let ws = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
         let req = UpsertSkillRequest {
@@ -1467,6 +1487,7 @@ mod tests {
 
     #[test]
     fn upsert_skill_rejects_traversal_in_filename() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         let ws = tempfile::tempdir().unwrap();
         let req = UpsertSkillRequest {
             content: "# Evil".to_owned(),
@@ -1481,6 +1502,7 @@ mod tests {
 
     #[test]
     fn delete_skill_rejects_traversal_slug() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         let ws = tempfile::tempdir().unwrap();
         let err = delete_skill(ws.path(), "../../../etc", None).unwrap_err();
         assert!(matches!(err, WorkspaceControlError::InvalidInput(_)));
@@ -1488,6 +1510,7 @@ mod tests {
 
     #[test]
     fn delete_role_rejects_file_path_outside_role_roots() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         let ws = tempfile::tempdir().unwrap();
         // A victim directory that lives under the workspace but NOT under a
         // managed role root. delete_role must refuse to remove it.
@@ -1501,6 +1524,7 @@ mod tests {
 
     #[test]
     fn delete_role_removes_managed_role_dir_via_file_path() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         let ws = tempfile::tempdir().unwrap();
         let role_dir = ws.path().join(".teamclu/roles/reviewer");
         std::fs::create_dir_all(&role_dir).unwrap();

--- a/apps/daemon/src/main.rs
+++ b/apps/daemon/src/main.rs
@@ -109,7 +109,19 @@ fn main() -> anyhow::Result<()> {
                             // Without its own directive the gateway crate matches
                             // nothing and every warn! it emits — inbound attachment
                             // failures included — is discarded before it reaches a file.
-                            .add_directive("teamclu_gateway=info".parse().unwrap()),
+                            .add_directive("teamclu_gateway=info".parse().unwrap())
+                            // Child-process output is emitted under its own target
+                            // (`warn!(target: "pi_rpc", ...)`), which matches none
+                            // of the directives above — and `from_default_env`
+                            // defaults to ERROR, so every one of these lines was
+                            // dropped in a packaged build. They are the ONLY record
+                            // of why a runtime child died: a pi host that fails to
+                            // boot writes its stack to stderr and nothing at all to
+                            // stdout.
+                            .add_directive("pi_rpc=info".parse().unwrap())
+                            .add_directive("opencode_serve=info".parse().unwrap())
+                            .add_directive("cursor_bridge=info".parse().unwrap())
+                            .add_directive("claude_bridge=info".parse().unwrap()),
                     )
                     .with(
                         tracing_subscriber::fmt::layer()

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -228,6 +228,24 @@ fn remote_tools_cmd_from_mcp_config(path: &Path) -> Option<String> {
 /// Excluded: disabled servers, non-`local` (remote/url) servers the stdio bridge
 /// can't spawn, and `amuxd-remote-tools` (already bridged via
 /// `TEAMCLU_REMOTE_TOOLS_CMD`).
+/// The `command[0]` of an MCP server entry when it names a path that does not
+/// exist on this machine.
+///
+/// Only *paths* are checked. A bare name (`npx`, `uvx`, `node`) is resolved by
+/// the OS through the child's enriched PATH, which this process cannot
+/// faithfully reproduce, so second-guessing it here would drop servers that
+/// work fine.
+fn missing_command_path(command: &[serde_json::Value]) -> Option<String> {
+    let first = command.first()?.as_str()?;
+    if !first.contains(std::path::MAIN_SEPARATOR) {
+        return None;
+    }
+    if Path::new(first).exists() {
+        return None;
+    }
+    Some(first.to_string())
+}
+
 fn mcp_servers_from_value(root: &serde_json::Value) -> Option<String> {
     let mcp = root.get("mcp")?.as_object()?;
     let mut out = serde_json::Map::new();
@@ -250,6 +268,19 @@ fn mcp_servers_from_value(root: &serde_json::Value) -> Option<String> {
             Some(c) if !c.is_empty() && c.iter().all(|a| a.is_string()) => c.clone(),
             _ => continue,
         };
+        if let Some(missing) = missing_command_path(&command) {
+            // A path that is not there cannot become a working bridge, and a
+            // whole workspace was once taken down by one of these: a leftover
+            // `teamclaw-introspect` entry from before the rename, pointing into
+            // an app bundle that no longer has that binary. Drop it here rather
+            // than hand pi a server it can only fail to spawn.
+            warn!(
+                server = %name,
+                path = %missing,
+                "MCP server command not found on this machine; not bridging it into pi"
+            );
+            continue;
+        }
         let mut entry = serde_json::Map::new();
         entry.insert("command".to_string(), serde_json::Value::Array(command));
         if let Some(env) = obj.get("environment").and_then(|v| v.as_object()) {
@@ -332,6 +363,21 @@ struct AttachArgs {
     force_env_override: bool,
 }
 
+/// Append the child's stderr tail to an establish failure.
+///
+/// A pi child that dies during startup answers nothing and prints nothing to
+/// stdout — the reason is on stderr and only there. Reporting the bare
+/// "process exited before responding" cost two people half a day each: the
+/// actual cause (an MCP bridge whose binary had been renamed) was one line
+/// away the whole time.
+fn with_stderr_tail(proc: &Arc<PiProcess>, error: String) -> String {
+    let tail = proc.stderr_tail();
+    if tail.trim().is_empty() {
+        return error;
+    }
+    format!("{error}\n--- pi stderr (last lines) ---\n{tail}")
+}
+
 /// The session a child established for us, mode-independently.
 struct EstablishedSession {
     acp_session_id: String,
@@ -372,12 +418,13 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
     let established = match proc.mode {
         PiSessionMode::Host => {
             host_establish_session(shared, &proc, resume_path, args.forbid_new_session_fallback)
-                .await?
+                .await
         }
         PiSessionMode::LegacyRpc => {
-            legacy_establish_session(&proc, resume_path, args.forbid_new_session_fallback).await?
+            legacy_establish_session(&proc, resume_path, args.forbid_new_session_fallback).await
         }
-    };
+    }
+    .map_err(|e| with_stderr_tail(&proc, e))?;
     let acp_session_id = established.acp_session_id.clone();
 
     // Model catalog + initial model.
@@ -1450,7 +1497,13 @@ impl AgentBackend for PiRpcBackend {
             remote_tools_cmd: None,
             mcp_servers: mcp_servers_from_opencode_json(&worktree),
         };
-        let proc = self.shared.pool.ensure_with_env(&self.shared, &key, env)?;
+        // `ensure_for_catalog`, never `ensure_with_env`: this env is missing
+        // fields the attach env has, so its fingerprint can never match and
+        // `ensure` would kill the session's child to spawn a probe one.
+        let proc = self
+            .shared
+            .pool
+            .ensure_for_catalog(&self.shared, &key, env)?;
         let resp = proc
             .client
             .request(serde_json::json!({"type": "get_available_models"}))
@@ -1624,5 +1677,40 @@ mod tests {
             result.is_err(),
             "expected spawn attempt to fail, got {result:?}"
         );
+    }
+
+    #[test]
+    fn dead_command_paths_are_not_bridged_into_pi() {
+        // A path that is not on this machine cannot become a working bridge —
+        // and one of them (a `teamclaw-introspect` entry left behind by the
+        // rename) took every pi session in a workspace down. Bare names are
+        // left alone: the child resolves those through its enriched PATH.
+        let root = serde_json::json!({
+            "mcp": {
+                "gone": {"type": "local", "enabled": true,
+                         "command": ["/no/such/path/teamclaw-introspect", "--workspace", "/w"]},
+                "bare": {"type": "local", "enabled": true,
+                         "command": ["npx", "-y", "@scope/server"]},
+            }
+        });
+        let payload = mcp_servers_from_value(&root).expect("bare server survives");
+        let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert!(parsed.get("gone").is_none(), "dead path must be dropped");
+        assert!(parsed.get("bare").is_some(), "bare name must be kept");
+    }
+
+    #[test]
+    fn missing_command_path_only_judges_paths() {
+        let here = std::env::current_exe()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            missing_command_path(&[serde_json::json!("/no/such/path/x")]).as_deref(),
+            Some("/no/such/path/x")
+        );
+        assert_eq!(missing_command_path(&[serde_json::json!(here)]), None);
+        assert_eq!(missing_command_path(&[serde_json::json!("npx")]), None);
+        assert_eq!(missing_command_path(&[]), None);
     }
 }

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -91,6 +91,13 @@ pub(crate) struct PiProcess {
     /// pass the busy check with the answer the first one already invalidated.
     pub(crate) switch_lock: tokio::sync::Mutex<()>,
     child: parking_lot::Mutex<tokio::process::Child>,
+    /// Last few stderr lines from this child, for error reporting.
+    ///
+    /// When a child dies during startup its stdout carries nothing at all —
+    /// node prints the reason (a bad extension, a bridge that could not spawn)
+    /// to stderr and exits. Without this the daemon could only report "process
+    /// exited before responding", which names the symptom and nothing else.
+    stderr_tail: Arc<parking_lot::Mutex<std::collections::VecDeque<String>>>,
     /// Fingerprint of what this child was spawned with (binary + mode + env).
     /// `ensure` respawns when it no longer matches the wanted spawn.
     env_fingerprint: String,
@@ -101,7 +108,18 @@ pub(crate) struct PiProcess {
     retired: std::sync::atomic::AtomicBool,
 }
 
+/// How many stderr lines to keep per child. Enough to carry a node stack trace
+/// without turning an error message into a log dump.
+const STDERR_TAIL_LINES: usize = 12;
+
 impl PiProcess {
+    /// The child's last stderr lines, newest last, as one string. Empty when it
+    /// said nothing.
+    pub(crate) fn stderr_tail(&self) -> String {
+        let tail = self.stderr_tail.lock();
+        tail.iter().cloned().collect::<Vec<_>>().join("\n")
+    }
+
     pub(crate) fn is_alive(&self) -> bool {
         matches!(self.child.lock().try_wait(), Ok(None))
     }
@@ -273,6 +291,33 @@ impl PiProcessPool {
         Ok(proc)
     }
 
+    /// Ensure a live child for a *catalog probe*, without ever replacing one.
+    ///
+    /// `model_catalog_for_context` builds its [`SpawnEnv`] from a trait method
+    /// that carries neither `force_env_override` nor the remote-tools command,
+    /// so a probe's env is a strictly poorer copy of the attach env for the
+    /// same key and the two fingerprints can never match. Routed through
+    /// [`Self::ensure`], every catalog publish therefore killed the child the
+    /// session had just attached to — and a probe landing while an attach was
+    /// mid-`new_session` surfaced as "pi new_session: process exited before
+    /// responding".
+    ///
+    /// A probe only needs *a* live child to ask for the model list, and the
+    /// catalog is host-level in both modes, so reusing whatever is already
+    /// running costs nothing. Only a cold key spawns, and the probe's env is
+    /// deliberately not recorded for the key: the next attach owns that.
+    pub(crate) fn ensure_for_catalog(
+        &self,
+        shared: &Arc<Shared>,
+        key: &PoolKey,
+        env: SpawnEnv,
+    ) -> crate::error::Result<Arc<PiProcess>> {
+        if let Some(p) = self.get(key) {
+            return Ok(p);
+        }
+        self.ensure_with_env(shared, key, env)
+    }
+
     /// Resolve what to spawn: binary + host/legacy mode. Read fresh per spawn
     /// so a config flip (`[agents.pi] session_host`) or a pi upgrade takes
     /// effect on the next respawn without a daemon restart.
@@ -429,10 +474,21 @@ impl PiProcessPool {
             .stdout
             .take()
             .ok_or_else(|| crate::error::AmuxError::Agent("pi stdout unavailable".into()))?;
+        let stderr_tail = Arc::new(parking_lot::Mutex::new(
+            std::collections::VecDeque::<String>::with_capacity(STDERR_TAIL_LINES),
+        ));
         if let Some(stderr) = child.stderr.take() {
+            let tail = Arc::clone(&stderr_tail);
             tokio::spawn(async move {
                 let mut lines = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = lines.next_line().await {
+                    {
+                        let mut tail = tail.lock();
+                        if tail.len() == STDERR_TAIL_LINES {
+                            tail.pop_front();
+                        }
+                        tail.push_back(line.clone());
+                    }
                     warn!(target: "pi_rpc", "{line}");
                 }
             });
@@ -449,6 +505,7 @@ impl PiProcessPool {
             child: parking_lot::Mutex::new(child),
             env_fingerprint: fingerprint,
             retired: std::sync::atomic::AtomicBool::new(false),
+            stderr_tail,
         });
         events::spawn_reader(
             Arc::clone(shared),
@@ -906,5 +963,134 @@ mod tests {
         assert_eq!(worktree_hash("/a/b"), worktree_hash("/a/b"));
         assert_ne!(worktree_hash("/a/b"), worktree_hash("/a/c"));
         assert_eq!(worktree_hash("/a/b").len(), 16);
+    }
+
+    /// A catalog probe and an attach land on the same [`PoolKey`] with
+    /// fingerprints that can never match: `model_catalog_for_context`
+    /// implements a trait method carrying neither `force_env_override` nor the
+    /// remote-tools command, while an attach passes the assembled spawn env
+    /// through, whose `force_env_override` is unconditionally true
+    /// (`runtime/env_assembly.rs`). This asserts the divergence rather than
+    /// wishing it away — it is why the probe must not go through `ensure`.
+    #[test]
+    fn probe_and_attach_fingerprints_diverge_by_construction() {
+        let pool = PiProcessPool::new();
+        let launch = ResolvedLaunch {
+            binary: "pi".into(),
+            mode: LaunchMode::LegacyRpc,
+        };
+        let extra_env = HashMap::from([("BASE_URL".to_string(), "https://gw".to_string())]);
+        let attach = SpawnEnv {
+            extra_env: extra_env.clone(),
+            force_env_override: true,
+            remote_tools_cmd: Some(r#"["amuxd","remote-tools-mcp"]"#.to_string()),
+            mcp_servers: None,
+        };
+        let probe = SpawnEnv {
+            extra_env,
+            force_env_override: false,
+            remote_tools_cmd: None,
+            mcp_servers: None,
+        };
+        assert_ne!(
+            pool.spawn_fingerprint(&attach, &launch),
+            pool.spawn_fingerprint(&probe, &launch),
+        );
+    }
+
+    /// The regression: a catalog probe on a key an attached session already
+    /// owns must reuse that child, never replace it. Before
+    /// [`PiProcessPool::ensure_for_catalog`] the probe went through `ensure`,
+    /// whose fingerprint check killed the session's child — and a probe landing
+    /// while an attach was mid-`new_session` reported "pi new_session: process
+    /// exited before responding".
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn catalog_probe_reuses_the_attached_session_child() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Hermetic home: spawning materializes the extension and the
+        // per-worktree permissions file under `cache/`.
+        let home = tempfile::tempdir().unwrap();
+        let _env = crate::test_brand_env::BrandEnvGuard::set_amuxd_home(home.path());
+
+        // Stand-in for pi: stays alive, answers nothing. Enough to own a pool
+        // slot and to have a request in flight when it would be killed.
+        let bin_dir = tempfile::tempdir().unwrap();
+        let fake_pi = bin_dir.path().join("fake-pi");
+        std::fs::write(
+            &fake_pi,
+            "#!/bin/sh\necho 'fake-pi startup noise' >&2\ncat > /dev/null\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_pi, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let worktree = tempfile::tempdir().unwrap();
+        let shared = super::Shared::new();
+        shared.pool.set_binary_hint(&fake_pi.to_string_lossy());
+        let key = PoolKey {
+            domain: IsolationDomainKey::Workspace("ws-1".into()),
+            env_revision: ProcessEnvRevision::from_bindings(&HashMap::new()),
+            worktree: worktree.path().to_string_lossy().into_owned(),
+        };
+
+        // 1. attach: assembled env => force_env_override = true.
+        let attached = shared
+            .pool
+            .ensure_with_env(
+                &shared,
+                &key,
+                SpawnEnv {
+                    force_env_override: true,
+                    ..Default::default()
+                },
+            )
+            .expect("attach spawn");
+        assert!(attached.is_alive(), "attach child is up");
+
+        // 2. a command in flight on it, exactly as `new_session` is mid-attach.
+        let client = attached.client.clone();
+        let in_flight = tokio::spawn(async move {
+            client
+                .request(serde_json::json!({"type":"new_session"}))
+                .await
+        });
+        // Poll rather than sleep a fixed span: spawning a shell and getting its
+        // first stderr line back takes longer than any constant is safe to
+        // assume on a loaded machine.
+        for _ in 0..100 {
+            if !attached.stderr_tail().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            attached.stderr_tail().contains("fake-pi startup noise"),
+            "stderr is captured for error reporting, got {:?}",
+            attached.stderr_tail()
+        );
+
+        // 3. the catalog probe: same key, poorer env.
+        let probed = shared
+            .pool
+            .ensure_for_catalog(&shared, &key, SpawnEnv::default())
+            .expect("probe");
+
+        assert!(
+            Arc::ptr_eq(&attached, &probed),
+            "the probe must reuse the attached session's child"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            attached.is_alive(),
+            "the session's child survived the probe"
+        );
+        assert!(
+            !in_flight.is_finished(),
+            "the session's in-flight command was not killed"
+        );
+
+        in_flight.abort();
+        shared.pool.kill_all();
     }
 }

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -17,6 +17,10 @@ use tracing::{info, warn};
 const INTROSPECT_API_PORT: u16 = 13144;
 const TEAM_SKILLS_PATH: &str = "teamclu-team/skills";
 const REMOTE_TOOLS_MCP_SERVER_NAME: &str = "amuxd-remote-tools";
+
+/// Inherent MCP servers that older builds wrote into workspace configs under a
+/// name this build no longer maintains. Removed on sight — see the call site.
+const LEGACY_MCP_NAMES: &[&str] = &["teamclaw-introspect"];
 const INSTRUCTION_PLUGIN_TEMPLATE: &str = include_str!(
     "../../../../packages/app/src/lib/opencode/templates/teamclu-instruction-plugin.mjs.txt"
 );
@@ -159,6 +163,24 @@ fn mutate_inherent_mcp(
     for name in device_names {
         mcp_obj.remove(&name);
         changed = true;
+    }
+
+    // Renamed inherent servers. The 2026-08-09 teamclaw→teamclu rename changed
+    // the sidecar's binary name; the entries already written into every
+    // workspace kept the old name AND an absolute path into the app bundle, and
+    // nothing owned them afterwards: `is_device_scoped` does not list them and
+    // the introspect self-heal below matches the new name only. Under opencode
+    // a dead server is merely ignored, so they sat there until someone switched
+    // to pi — where the extension's bridge spawn took the whole runtime down.
+    for name in LEGACY_MCP_NAMES {
+        if mcp_obj.remove(*name).is_some() {
+            info!(
+                workspace = %workspace_path.display(),
+                server = name,
+                "dropping renamed inherent MCP entry from workspace config"
+            );
+            changed = true;
+        }
     }
 
     ensure_extended_inherent_config(workspace_path, config, &mut changed)?;
@@ -2442,5 +2464,39 @@ mod tests {
                 .unwrap_or(false)
         }));
         assert!(crate::runtime::instruction_plugin_installed(dir.path()));
+    }
+
+    #[test]
+    fn prepare_workspace_drops_renamed_inherent_mcp_entry() {
+        // A workspace written before the 2026-08-09 teamclaw→teamclu rename
+        // carries `teamclaw-introspect` with an absolute path into an app
+        // bundle that no longer ships that binary. Nothing owned the old name
+        // afterwards, and under pi the extension's bridge spawn took the whole
+        // runtime down with it, so every session in the workspace failed with
+        // "process exited before responding".
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("opencode.json"),
+            r#"{"mcp":{"teamclaw-introspect":{"type":"local","enabled":true,
+                 "command":["/Applications/Old.app/Contents/MacOS/teamclaw-introspect"]},
+                 "user-server":{"type":"local","enabled":true,"command":["npx","-y","x"]}}}"#,
+        )
+        .unwrap();
+
+        prepare_workspace(dir.path()).unwrap();
+
+        let cfg: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("opencode.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(
+            cfg["mcp"].get("teamclaw-introspect").is_none(),
+            "the renamed inherent entry must be dropped"
+        );
+        assert!(
+            cfg["mcp"].get("user-server").is_some(),
+            "a user's own server must survive the migration"
+        );
     }
 }


### PR DESCRIPTION
## 现象

切到 pi 后，新建会话能看到模型，一发消息就永远"连接中"。前端日志只有一句没有信息量的：

```
start_runtime failed: agent error: pi new_session: process exited before responding
```

## 根因链（已复现验证）

1. 8/9 改名 teamclaw→teamclu（a7d65c3b）改了 sidecar 二进制名 → `teamclu-introspect`
2. 但**已经写进各 workspace `opencode.json` 的 `teamclaw-introspect` 条目没有任何迁移**——它带的是绝对路径
   `/Applications/<App>.app/Contents/MacOS/teamclaw-introspect`。`is_device_scoped` 不认这个名字，
   introspect 的自愈逻辑只匹配新名字，于是它成了谁都不负责的孤儿条目
3. pi 扩展桥接它时 `spawn()` 拿到 ENOENT，而 `ChildProcess` 没有挂 `"error"` 监听 ——
   node 未捕获的 emitter 事件在 0.5s 内把**整个 pi 进程**带走，stdout 一个字节都没有
4. opencode 下死条目只是被忽略，所以潜伏了十几天，直到有人切 pi 才爆

真因唯一的记录（stderr 上那段 ENOENT 栈）又恰好被日志过滤器丢掉了，见修复 4。

## 五处修复

| # | 改动 |
|---|---|
| 1 | `McpBridge` 补 `error`/`exit` 监听并记录首个致命错误；`request` 快速失败，`notify` 与 stdin 写入包 try/catch。桥接失败降级为"这个 server 不可用"——`bridgeMcpServer` 本来就 catch 并继续，只是永远没机会跑 |
| 2 | daemon 不再把死配置喂给 pi：`command[0]` 是路径且不存在的 local server 直接跳过并 warn。**只判断路径**，裸名字（`npx`/`uvx`/`node`）交给子进程的 PATH 解析 |
| 3 | `mutate_inherent_mcp` 删除 workspace 配置里的 `teamclaw-introspect`，补上改名漏掉的迁移；用户自己的 server 不受影响 |
| 4 | 子进程输出用的是自定义 target（`pi_rpc` / `opencode_serve` / `cursor_bridge` / `claude_bridge`），不匹配任何 directive，而 `from_default_env` 的默认档是 **ERROR** —— 打包版里这些行全被丢掉，而它们是子进程死因的唯一记录。补上 directive，并把 stderr 尾巴（最后 12 行）附到 attach 失败的错误里 |
| 5 | `model_catalog_for_context` 实现的 trait 方法不带 `force_env_override` / `remote_tools_cmd`，它的 `SpawnEnv` 必然比 attach 的贫瘠，fingerprint 永远对不上，于是 `ensure()` 每次都 kill 重开——探针撞进 attach 的 `new_session` 窗口就报出同一句错误。新增 `ensure_for_catalog`：有活的就复用，只有冷 key 才拉起，且不覆盖该 key 的 env |

## 验证

真实 pi 0.84.2 + node 26 驱动 `assets/pi-host/host.mjs`，配上那条确切的死路径：

```
# 修复前
[err] Error: spawn /Applications/Copilot 361.app/Contents/MacOS/teamclaw-introspect ENOENT
[err]       throw er; // Unhandled 'error' event
[!] child exited with code 1 after 0.5s          # stdout 全空

# 修复后
[err] [teamclu] MCP bridge unavailable (teamclaw-introspect): Error: spawn … ENOENT
[out] {"type":"host_ready","protocol":1,"piVersion":"0.84.2"}
[out] {"id":"1","type":"response","command":"new_session","success":true,…}
```

正向路径同样验过：接一个能工作的 stdio MCP server，`initialize` / `notifications/initialized` / `tools/list`
全部走通并写进 tool cache——`request` / `notify` 的改动没伤到 happy path。

- 新增 5 个回归测试，其中 `catalog_probe_reuses_the_attached_session_child` 在修复前是红的
- `cargo test -p amuxd --locked` 全绿（1280 单测 + 各集成套件）
- clippy 对新符号零告警；rustfmt 对改动的四个 Rust 文件 clean（该 crate 整体本来就不 fmt-clean，未触碰其它文件）

## 范围说明

这是**止血**。结构性重构——统一 MCP 解析器、device 层降级为开关表、workspace 配置改名 `<brand>.json`——
另开了 #1019 跟踪，含阶段拆分与三个已知的坑。

## 给现在被卡住的人

不用等发版：删掉 workspace `opencode.json` 里的 `teamclaw-introspect` 再重启 amuxd 即可。

```bash
jq 'del(.mcp["teamclaw-introspect"])' opencode.json > /tmp/o.json && mv /tmp/o.json opencode.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
