### PR TITLE
feat(introspect): manage_participants —— agent 能把人拉进当前会话

### DIFF
--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -5,6 +5,7 @@ mod cron;
 mod env_vars;
 mod knowledge;
 mod mcp;
+mod participants;
 mod roles;
 mod send;
 mod session;
@@ -340,6 +341,33 @@ fn tool_definitions() -> Value {
             }
         },
         {
+            "name": "manage_participants",
+            "description": "Read the roster of a TeamClu session, and pull people into it or take them out. Requires the desktop app to be running and the user to be signed in. When session_id is omitted, acts on the current TeamClu session (TEAMCLU_SESSION_ID env or workspace .teamclu/active-session-id). Actions: 'list' (the full roster, people and agents), 'list_candidates' (people who can be added, excluding those already present), 'add', 'remove'. add/remove handle HUMAN MEMBERS ONLY — agents are joined from the app's session member sheet, which also starts their runtime; asking for one here is refused rather than half-done. Adding someone makes the session, including its history, visible to them, so the target is never guessed: pass actor_id, or a name that matches exactly one person. A name matching none or several comes back as the candidate list instead of a write.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["list", "list_candidates", "add", "remove"],
+                        "description": "What to do with the roster."
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Cloud session UUID. Optional — omit to act on the current TeamClu session."
+                    },
+                    "actor_id": {
+                        "type": "string",
+                        "description": "Actor UUID to add or remove. Use this when you have the id from 'list' or 'list_candidates'."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Display name to add or remove, as an alternative to actor_id. Must match exactly one actor in the team; otherwise the candidate list is returned and nothing is written."
+                    }
+                },
+                "required": ["action"]
+            }
+        },
+        {
             "name": "archive_session",
             "description": "Archive a TeamClu cloud session (soft-hide from the active session list). Requires the desktop app to be running and the user to be signed in. When session_id is omitted, archives the current TeamClu session (TEAMCLU_SESSION_ID env or workspace .teamclu/active-session-id).",
             "inputSchema": {
@@ -525,6 +553,15 @@ async fn handle_request(req: &Value, workspace: &str, api_port: u16) -> Option<V
                     }
                     Err(e) => tool_err(&e),
                 },
+                "manage_participants" => {
+                    match participants::handle(workspace, api_port, &arguments).await {
+                        Ok(v) => {
+                            let text = serde_json::to_string_pretty(&v).unwrap_or_default();
+                            tool_ok(&text)
+                        }
+                        Err(e) => tool_err(&e),
+                    }
+                }
                 "archive_session" => {
                     match session::archive(workspace, api_port, &arguments).await {
                         Ok(v) => {

--- a/apps/desktop/crates/teamclu-introspect/src/participants.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/participants.rs
@@ -1,0 +1,147 @@
+//! `manage_participants` — read and change a session's roster from inside it.
+//!
+//! A thin client over the desktop loopback API, which owns the Cloud API call:
+//! only the app has the signed-in user's bearer (so RLS decides what is
+//! allowed) and the desktop's current team (so candidates come from the team
+//! the user is actually looking at). This binary's job is argument shaping and
+//! the session-id default.
+//!
+//! Adding a participant is visible to another human — the session shows up in
+//! their list, history included — so the target is never guessed: pass
+//! `actor_id`, or a `name` that matches exactly one actor. Zero or several
+//! matches come back as the candidate list, not as a write.
+//!
+//! `add` / `remove` cover human members only. Joining an agent is a longer
+//! story — workspace, backend, runtime — and doing half of it here would leave
+//! a mute agent in the roster, so the desktop refuses those and points at the
+//! member sheet instead.
+
+use serde_json::{json, Value};
+
+const ACTIONS: [&str; 4] = ["list", "list_candidates", "add", "remove"];
+
+fn str_arg(arguments: &Value, key: &str) -> Option<String> {
+    arguments
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+pub async fn handle(workspace: &str, api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let action = str_arg(arguments, "action").unwrap_or_default();
+    if !ACTIONS.contains(&action.as_str()) {
+        return Err(format!(
+            "action must be one of: {}. Got: {}",
+            ACTIONS.join(", "),
+            if action.is_empty() {
+                "(missing)"
+            } else {
+                &action
+            }
+        ));
+    }
+
+    let session_id = crate::session::resolve_session_id(workspace, arguments)?;
+    let mut body = json!({ "action": action, "session_id": session_id });
+
+    if action == "add" || action == "remove" {
+        match (str_arg(arguments, "actor_id"), str_arg(arguments, "name")) {
+            (Some(_), Some(_)) => {
+                return Err("pass actor_id or name, not both".to_string());
+            }
+            (None, None) => {
+                return Err(format!(
+                    "{action} needs actor_id or name — run action \"list_candidates\" first to see who can be added"
+                ));
+            }
+            (Some(id), None) => body["actor_id"] = json!(id),
+            (None, Some(name)) => body["name"] = json!(name),
+        }
+    }
+
+    post(api_port, &body).await
+}
+
+async fn post(api_port: u16, body: &Value) -> Result<Value, String> {
+    let url = format!("http://127.0.0.1:{api_port}/session-participants");
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}. Is the TeamClu app running?"))?;
+
+    if !resp.status().is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("API error: {text}"));
+    }
+
+    resp.json::<Value>()
+        .await
+        .map_err(|e| format!("Failed to parse response: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UUID: &str = "a1ca8f06-94ee-4fb5-bdfb-194a5606062f";
+
+    fn args(v: Value) -> Value {
+        v
+    }
+
+    #[tokio::test]
+    async fn unknown_action_is_rejected_before_anything_else() {
+        // Checked first on purpose: a typo'd action must not resolve a session
+        // id (which can fail for its own reasons) or reach the app.
+        let err = handle("/tmp", 1, &args(json!({"action": "invite"})))
+            .await
+            .unwrap_err();
+        assert!(err.contains("action must be one of"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn add_without_a_target_names_the_way_out() {
+        let err = handle(
+            "/tmp",
+            1,
+            &args(json!({"action": "add", "session_id": UUID})),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("actor_id or name"), "{err}");
+        assert!(err.contains("list_candidates"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn add_refuses_both_target_forms() {
+        let err = handle(
+            "/tmp",
+            1,
+            &args(json!({
+                "action": "add", "session_id": UUID,
+                "actor_id": UUID, "name": "海港"
+            })),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("not both"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn list_needs_no_target() {
+        // Reaches the loopback call (port 1 refuses) rather than failing on
+        // arguments — proving `list` does not require actor_id/name.
+        let err = handle(
+            "/tmp",
+            1,
+            &args(json!({"action": "list", "session_id": UUID})),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("Request failed"), "{err}");
+    }
+}

--- a/apps/desktop/crates/teamclu-introspect/src/session.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/session.rs
@@ -47,7 +47,7 @@ fn resolve_scheme(arguments: &Value) -> Result<String, String> {
     Ok(scheme)
 }
 
-fn resolve_session_id(workspace: &str, arguments: &Value) -> Result<String, String> {
+pub(crate) fn resolve_session_id(workspace: &str, arguments: &Value) -> Result<String, String> {
     if let Some(id) = arguments
         .get("session_id")
         .and_then(|v| v.as_str())

--- a/apps/desktop/src/commands/introspect_api.rs
+++ b/apps/desktop/src/commands/introspect_api.rs
@@ -13,6 +13,7 @@
 //   POST /mcp-get           — fetch merged workspace MCP map (daemon)
 //   POST /mcp-put           — replace workspace MCP map (daemon)
 //   POST /session-archive   — archive a cloud session (PATCH archivedAt)
+//   POST /session-participants — list/add/remove a session's participants
 //   POST /session-export    — export session messages as opencode-compatible JSON
 //
 // Uses raw TCP + manual HTTP parsing to stay minimal (no axum state needed).
@@ -108,6 +109,9 @@ pub async fn start_introspect_api(app: AppHandle) -> anyhow::Result<()> {
                 ("POST", "/mcp-put") => handle_mcp_put(&app_clone, body_bytes).await,
                 ("POST", "/session-archive") => {
                     handle_session_archive(&app_clone, body_bytes).await
+                }
+                ("POST", "/session-participants") => {
+                    handle_session_participants(&app_clone, body_bytes).await
                 }
                 _ => Err(format!("Not found: {} {}", method, path)),
             };
@@ -717,39 +721,7 @@ async fn handle_session_archive(app: &AppHandle, body: &[u8]) -> Result<String, 
         .map(|s| s.to_string())
         .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
 
-    let body_token = v
-        .get("accessToken")
-        .or_else(|| v.get("access_token"))
-        .and_then(|x| x.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string());
-    let body_url = v
-        .get("cloudApiUrl")
-        .or_else(|| v.get("cloud_api_url"))
-        .and_then(|x| x.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(|s| s.trim_end_matches('/').to_string());
-
-    let (access_token, cloud_api_url) = match (body_token, body_url) {
-        (Some(token), Some(url)) => (token, url),
-        (Some(token), None) => {
-            let url = super::oss_sync::get_fc_endpoint("");
-            (token, url)
-        }
-        (None, url_opt) => {
-            let bridge = app.state::<super::introspect_auth::IntrospectAuthState>();
-            let (token, bridged_url) = bridge.get().ok_or_else(|| {
-                "Not signed in: open TeamClu and sign in so archive_session can call the Cloud API."
-                    .to_string()
-            })?;
-            (token, url_opt.unwrap_or(bridged_url))
-        }
-    };
-
-    let endpoint = super::oss_sync::resolve_runtime_fc_endpoint(&cloud_api_url)?;
-    let fc = super::oss_sync::fc_client::FcClient::new(endpoint, access_token);
+    let fc = introspect_fc_client(app, &v, "archive_session").await?;
     let path = format!("/v1/sessions/{}", session_id);
     let patch = serde_json::json!({ "archivedAt": archived_at });
     fc.patch_json(&path, &patch)
@@ -779,6 +751,316 @@ async fn handle_session_archive(app: &AppHandle, body: &[u8]) -> Result<String, 
 /// Find the position of `\r\n\r\n` in `data`, returning the index of the first `\r`.
 fn find_double_crlf(data: &[u8]) -> Option<usize> {
     data.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+/// Cloud API client for an introspect tool call, on behalf of the signed-in user.
+///
+/// Body-supplied credentials win: the caller may be pointed at a different
+/// server than this desktop is. Otherwise the in-memory bridge the frontend
+/// pushes on sign-in — nothing is read from disk, and nothing here escalates
+/// past what the user themselves may do (RLS still decides).
+async fn introspect_fc_client(
+    app: &AppHandle,
+    v: &serde_json::Value,
+    tool: &str,
+) -> Result<super::oss_sync::fc_client::FcClient, String> {
+    let body_token = v
+        .get("accessToken")
+        .or_else(|| v.get("access_token"))
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let body_url = v
+        .get("cloudApiUrl")
+        .or_else(|| v.get("cloud_api_url"))
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.trim_end_matches('/').to_string());
+
+    let (access_token, cloud_api_url) = match (body_token, body_url) {
+        (Some(token), Some(url)) => (token, url),
+        (Some(token), None) => {
+            let url = super::oss_sync::get_fc_endpoint("");
+            (token, url)
+        }
+        (None, url_opt) => {
+            let bridge = app.state::<super::introspect_auth::IntrospectAuthState>();
+            let (token, bridged_url) = bridge.get().ok_or_else(|| {
+                format!("Not signed in: open TeamClu and sign in so {tool} can call the Cloud API.")
+            })?;
+            (token, url_opt.unwrap_or(bridged_url))
+        }
+    };
+
+    let endpoint = super::oss_sync::resolve_runtime_fc_endpoint(&cloud_api_url)?;
+    Ok(super::oss_sync::fc_client::FcClient::new(
+        endpoint,
+        access_token,
+    ))
+}
+
+fn str_body_field(v: &serde_json::Value, snake: &str, camel: &str) -> Option<String> {
+    v.get(snake)
+        .or_else(|| v.get(camel))
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// One roster row, flattened for an agent to read.
+fn participant_brief(row: &serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "actor_id": row.get("actorId").and_then(|x| x.as_str()).unwrap_or_default(),
+        "name": row.get("displayName").and_then(|x| x.as_str()),
+        "actor_type": row.get("actorType").and_then(|x| x.as_str()),
+        "role": row.get("role").and_then(|x| x.as_str()),
+    })
+}
+
+fn actor_brief(row: &serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "actor_id": row.get("id").and_then(|x| x.as_str()).unwrap_or_default(),
+        "name": row.get("displayName").and_then(|x| x.as_str()),
+        "actor_type": row.get("kind").and_then(|x| x.as_str()),
+    })
+}
+
+/// Actors that can take part in a session at all — the filter the desktop's own
+/// member sheet applies before showing candidates.
+fn actor_is_participant_kind(row: &serde_json::Value) -> bool {
+    matches!(
+        row.get("kind").and_then(|x| x.as_str()),
+        Some("member") | Some("agent")
+    )
+}
+
+/// Actors this tool will add or remove: human members only.
+///
+/// Agents are deliberately out of scope. Adding one is only half of what the
+/// app's member sheet does — it goes on to resolve the agent's workspace, pick
+/// its backend and start a runtime (`SessionActorSheet.tsx`). Writing the
+/// participant row alone leaves the agent in the roster and mute, which reads
+/// as a broken agent rather than an unfinished step.
+fn actor_is_human_member(row: &serde_json::Value) -> bool {
+    row.get("kind").and_then(|x| x.as_str()) == Some("member")
+}
+
+/// Fail unless `actor_id` is a human member. Checked BEFORE any write, so a
+/// refusal never leaves a half-added agent behind.
+async fn ensure_human_member(
+    fc: &super::oss_sync::fc_client::FcClient,
+    actor_id: &str,
+    verb: &str,
+) -> Result<(), String> {
+    let actor = fc
+        .get_json(&format!("/v1/actors/{}", urlencoding::encode(actor_id)))
+        .await
+        .map_err(|e| format!("Cloud API actor lookup failed: {e}"))?;
+    if actor_is_human_member(&actor) {
+        return Ok(());
+    }
+    let kind = actor
+        .get("kind")
+        .and_then(|x| x.as_str())
+        .unwrap_or("unknown");
+    let name = actor
+        .get("displayName")
+        .and_then(|x| x.as_str())
+        .unwrap_or(actor_id);
+    Err(format!(
+        "{name} is a {kind}, not a human member — this tool only {verb}s people. Agents are added from the app's session member sheet, which also starts their runtime."
+    ))
+}
+
+fn items_of(v: &serde_json::Value) -> Vec<serde_json::Value> {
+    v.get("items")
+        .and_then(|x| x.as_array())
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// The team the desktop is currently in — kept by the team-switch flow.
+///
+/// Not derived from the session: `GET /v1/sessions/{id}` is itself team-scoped
+/// (teamId is a required query param), so there is no team-free way to ask
+/// which team a session belongs to.
+async fn introspect_current_team(app: &AppHandle) -> Result<String, String> {
+    let cache = app.state::<crate::local_cache::commands::LocalCacheState>();
+    let team = cache.current_team_id.read().await.clone();
+    team.filter(|t| !t.is_empty())
+        .ok_or_else(|| "No current team: open TeamClu and select a team first.".to_string())
+}
+
+/// Resolve the `actor_id` / `name` argument to exactly one actor id.
+///
+/// A name is only accepted when it identifies one actor. Adding the wrong
+/// person hands them the session and its history — an effect no fuzzy match is
+/// worth — so zero or several matches come back as the candidate list and
+/// nothing is written.
+async fn resolve_participant_actor_id(
+    app: &AppHandle,
+    fc: &super::oss_sync::fc_client::FcClient,
+    v: &serde_json::Value,
+) -> Result<String, String> {
+    if let Some(id) = str_body_field(v, "actor_id", "actorId") {
+        return Ok(id);
+    }
+    let name = str_body_field(v, "name", "displayName")
+        .ok_or("Missing field: actor_id or name is required")?;
+    let team_id = introspect_current_team(app).await?;
+    let listing = fc
+        .get_json(&format!(
+            "/v1/teams/{}/actors?limit=500",
+            urlencoding::encode(&team_id)
+        ))
+        .await
+        .map_err(|e| format!("Cloud API actor list failed: {e}"))?;
+
+    let wanted = name.to_lowercase();
+    let addable: Vec<serde_json::Value> = items_of(&listing)
+        .into_iter()
+        .filter(actor_is_participant_kind)
+        .collect();
+    let matches: Vec<&serde_json::Value> = addable
+        .iter()
+        .filter(|a| {
+            a.get("displayName")
+                .and_then(|x| x.as_str())
+                .map(|n| n.trim().to_lowercase() == wanted)
+                .unwrap_or(false)
+        })
+        .collect();
+
+    match matches.len() {
+        1 => Ok(matches[0]
+            .get("id")
+            .and_then(|x| x.as_str())
+            .unwrap_or_default()
+            .to_string()),
+        0 => Err(format!(
+            "No actor named {:?} in this team. Candidates: {}",
+            name,
+            serde_json::Value::Array(addable.iter().map(actor_brief).collect())
+        )),
+        n => Err(format!(
+            "{:?} matches {} actors — pass actor_id instead. Matches: {}",
+            name,
+            n,
+            serde_json::Value::Array(matches.iter().map(|a| actor_brief(a)).collect())
+        )),
+    }
+}
+
+/// `manage_participants` — read or change a session's roster.
+///
+/// Every call runs with the signed-in user's bearer, so RLS is what decides
+/// whether an agent may pull someone in; this handler never escalates.
+async fn handle_session_participants(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?;
+
+    let action = str_body_field(&v, "action", "action").ok_or("Missing field: action")?;
+    let session_id =
+        str_body_field(&v, "session_id", "sessionId").ok_or("Missing field: session_id")?;
+    let fc = introspect_fc_client(app, &v, "manage_participants").await?;
+    let roster_path = format!(
+        "/v1/sessions/{}/participants",
+        urlencoding::encode(&session_id)
+    );
+
+    match action.as_str() {
+        "list" => {
+            let out = fc
+                .get_json(&roster_path)
+                .await
+                .map_err(|e| format!("Cloud API participant list failed: {e}"))?;
+            Ok(serde_json::json!({
+                "action": "list",
+                "session_id": session_id,
+                "participants": items_of(&out).iter().map(participant_brief).collect::<Vec<_>>(),
+            })
+            .to_string())
+        }
+        "list_candidates" => {
+            let team_id = introspect_current_team(app).await?;
+            let present = fc
+                .get_json(&roster_path)
+                .await
+                .map_err(|e| format!("Cloud API participant list failed: {e}"))?;
+            let present_ids: std::collections::HashSet<String> = items_of(&present)
+                .iter()
+                .filter_map(|r| {
+                    r.get("actorId")
+                        .and_then(|x| x.as_str())
+                        .map(str::to_string)
+                })
+                .collect();
+            let listing = fc
+                .get_json(&format!(
+                    "/v1/teams/{}/actors?limit=500",
+                    urlencoding::encode(&team_id)
+                ))
+                .await
+                .map_err(|e| format!("Cloud API actor list failed: {e}"))?;
+            let candidates: Vec<serde_json::Value> = items_of(&listing)
+                .iter()
+                .filter(|a| actor_is_human_member(a))
+                .filter(|a| {
+                    !a.get("id")
+                        .and_then(|x| x.as_str())
+                        .map(|id| present_ids.contains(id))
+                        .unwrap_or(false)
+                })
+                .map(actor_brief)
+                .collect();
+            Ok(serde_json::json!({
+                "action": "list_candidates",
+                "session_id": session_id,
+                "team_id": team_id,
+                "candidates": candidates,
+            })
+            .to_string())
+        }
+        "add" => {
+            let actor_id = resolve_participant_actor_id(app, &fc, &v).await?;
+            ensure_human_member(&fc, &actor_id, "add").await?;
+            fc.post_json(
+                &roster_path,
+                &serde_json::json!({ "actorId": actor_id, "role": "member" }),
+            )
+            .await
+            .map_err(|e| format!("Cloud API add participant failed: {e}"))?;
+            Ok(serde_json::json!({
+                "ok": true, "action": "add",
+                "session_id": session_id, "actor_id": actor_id,
+            })
+            .to_string())
+        }
+        "remove" => {
+            let actor_id = resolve_participant_actor_id(app, &fc, &v).await?;
+            // Same restriction as `add`, deliberately: a tool that can drop an
+            // agent it cannot put back is a trap, not a capability.
+            ensure_human_member(&fc, &actor_id, "remove").await?;
+            fc.delete_json(&format!(
+                "{}/{}",
+                roster_path,
+                urlencoding::encode(&actor_id)
+            ))
+            .await
+            .map_err(|e| format!("Cloud API remove participant failed: {e}"))?;
+            Ok(serde_json::json!({
+                "ok": true, "action": "remove",
+                "session_id": session_id, "actor_id": actor_id,
+            })
+            .to_string())
+        }
+        other => Err(format!(
+            "Unknown action: {other} (expected list, list_candidates, add or remove)"
+        )),
+    }
 }
 
 async fn write_response(


### PR DESCRIPTION
给 `teamclu-introspect` 加一个 `manage_participants` 工具：agent 能读当前会话的名单，并把人拉进来 / 请出去。

## 工具形状

| action | 行为 |
|---|---|
| `list` | 完整名单（人 + agent 都列，看得见但动不了） |
| `list_candidates` | 还能拉谁进来（只列人，已在场的自动排除） |
| `add` / `remove` | **只处理 human member** |

"当前 session" 沿用 `session.rs::resolve_session_id` 的既有解析链：参数 → `TEAMCLU_SESSION_ID` → `<workspace>/.teamclu/active-session-id`，跟 `get_session_deeplink` / `archive_session` 一致。

## 服务端零改动

用的就是桌面端"添加成员"面板同一批接口，没有新增任何 endpoint：

- `GET  /v1/sessions/:id/participants`
- `POST /v1/sessions/:id/participants` `{actorId, role:"member"}`
- `DELETE /v1/sessions/:id/participants/:actorId`
- `GET  /v1/teams/:teamId/actors?limit=500`

## 三个刻意的决定

**1. 名字不猜。** 拉错人的后果是对方立刻看到整段会话历史，社交上不可撤销。所以 `name` 只接受**唯一精确匹配**；0 个或多个匹配时返回候选名单、不写入。有 id 就直接传 `actor_id`。

**2. agent 一律拒绝，而且在写入之前拒绝。** 桌面端加 agent 是一整套动作——解析 workspace、挑 backend、拉起 runtime（`SessionActorSheet.tsx`）——只写 participant 行会留下一个**进了名单却不说话的 agent**，看起来像 agent 坏了而不是流程没做完。`remove` 同样限制：一个能踢出去却加不回来的工具是陷阱不是能力。

**3. 不提权。** Cloud API 调用走已登录用户的 bearer（introspect auth bridge），RLS 决定能不能拉；候选人来自桌面端**当前团队**（`LocalCacheState.current_team_id`），不是从 session 反推——`GET /v1/sessions/{id}` 本身就要求 teamId，没有"不带团队问这个 session 属于哪个团队"的路。

## 顺带

`handle_session_archive` 里那段 35 行凭据解析抽成了 `introspect_fc_client`，两个 handler 共用，行为不变（包括 body 凭据优先于 auth bridge 的既有语义）。

## 验证

- `cargo test -p teamclu-introspect`：39 passed（含新增 4 个参数校验测试）
- `pnpm rust:check` / `pnpm rust:clippy`：干净，新符号零告警
- rustfmt 对改动的文件 clean（这两个 crate 整体本来就不 fmt-clean，未触碰其它文件）

## 一个已知的、非本 PR 引入的问题

加人有两条路径，通知能力不同：

- **daemon RPC**（`session_manager.rs:handle_add_participant`）会 publish `presence.joined` + 给相关 actor 发 membership refresh
- **Cloud API POST**（桌面端"添加成员"面板走的，本 PR 也是）——客户端**能**处理 `session_participant.created` 之类的 MQTT 事件并刷新名单（`MqttLiveWiring.tsx:741`），但 FC 在 POST 时到底发不发这个事件**尚未验证**

也就是说本工具与 UI 按钮行为完全一致；若存在"对方要等下次同步才看到"的问题，那是两者共有的产品问题，可以单独跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
