### PR TITLE
fix(mqtt): harden reconnect recovery and durable queues

### DIFF
--- a/apps/daemon/src/backend/cloud_api/messages.rs
+++ b/apps/daemon/src/backend/cloud_api/messages.rs
@@ -138,8 +138,7 @@ impl CloudApiBackend {
         content: &str,
         external_message_id: Option<&str>,
     ) -> BackendResult<String> {
-        let (id, metadata) =
-            gateway_message_id_and_metadata(session_id, external_message_id, None);
+        let (id, metadata) = gateway_message_id_and_metadata(session_id, external_message_id, None);
         let message: CloudMessage = self
             .post(
                 &format!("/v1/sessions/{session_id}/messages"),
@@ -168,8 +167,7 @@ impl CloudApiBackend {
         content: &str,
         external_message_id: Option<&str>,
     ) -> BackendResult<String> {
-        let (id, metadata) =
-            gateway_message_id_and_metadata(session_id, external_message_id, None);
+        let (id, metadata) = gateway_message_id_and_metadata(session_id, external_message_id, None);
         let message: CloudMessage = self
             .post(
                 &format!("/v1/sessions/{session_id}/messages"),
@@ -385,7 +383,8 @@ mod tests {
         assert!(uuid::Uuid::parse_str(&id).is_ok());
         assert_ne!(id, native);
         assert_eq!(
-            meta.as_ref().and_then(|m| m["external_message_id"].as_str()),
+            meta.as_ref()
+                .and_then(|m| m["external_message_id"].as_str()),
             Some(native)
         );
         // Deterministic for idempotency.
@@ -402,7 +401,8 @@ mod tests {
         let (id, meta) = gateway_message_id_and_metadata("sess-1", Some(external), None);
         assert_eq!(id, external);
         assert_eq!(
-            meta.as_ref().and_then(|m| m["external_message_id"].as_str()),
+            meta.as_ref()
+                .and_then(|m| m["external_message_id"].as_str()),
             Some(external)
         );
     }

--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -3085,6 +3085,10 @@ mod tests {
         );
 
         // Next refresh succeeds and clears the latch.
+        // Clear the shared failure cooldown to model re-onboarding/fresh
+        // credentials; ordinary callers must continue respecting the cooldown
+        // after a terminal refresh rejection.
+        backend.invalidate_cached_credential();
         assert_eq!(backend.access_token().await.unwrap(), "access-token");
         assert_eq!(
             backend.cloud_auth_health(),

--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -104,6 +104,7 @@ impl From<ShareModeResponse> for ShareModeConfig {
 /// Access token must be refreshed this long before its `expires_at` so an
 /// in-flight request never races the expiry boundary.
 const ACCESS_TOKEN_LEEWAY: Duration = Duration::from_secs(60);
+const REFRESH_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Mutable token state shared across all clones of a `CloudApiBackend`.
 ///
@@ -249,7 +250,22 @@ impl CloudApiBackend {
 
         // Slow path: serialize refreshes so concurrent callers don't each submit
         // the (about-to-rotate) refresh token in parallel.
-        let _guard = self.refresh_lock.lock().await;
+        // A waiter must not sit behind a wedged refresh forever. The request
+        // itself has a timeout too, but this bound protects callers when the
+        // coordinator is contended during wake/reconnect bursts.
+        let _guard =
+            match tokio::time::timeout(REFRESH_LOCK_TIMEOUT, self.refresh_lock.lock()).await {
+                Ok(guard) => guard,
+                Err(_) => {
+                    let error = BackendError::Provider {
+                        provider: "cloud_api",
+                        code: Some("refresh_coordinator_busy".to_string()),
+                        message: "token refresh coordinator is busy".to_string(),
+                    };
+                    self.remember_refresh_failure(&error, Duration::from_secs(2));
+                    return Err(error);
+                }
+            };
 
         // Re-check: another task may have refreshed while we waited on the gate.
         if let Some(token) = self.cached_access_token() {
@@ -293,11 +309,7 @@ impl CloudApiBackend {
             Ok(Ok(resp)) => resp,
             Ok(Err(error)) => {
                 let error = network_error(error);
-                self.token
-                    .lock()
-                    .expect("token state poisoned")
-                    .refresh_failure =
-                    Some((Instant::now() + Duration::from_secs(5), error.to_string()));
+                self.remember_refresh_failure(&error, Duration::from_secs(5));
                 return Err(error);
             }
             Err(_) => {
@@ -306,11 +318,7 @@ impl CloudApiBackend {
                     code: None,
                     message: "token refresh timed out".to_string(),
                 };
-                self.token
-                    .lock()
-                    .expect("token state poisoned")
-                    .refresh_failure =
-                    Some((Instant::now() + Duration::from_secs(5), error.to_string()));
+                self.remember_refresh_failure(&error, Duration::from_secs(5));
                 return Err(error);
             }
         };
@@ -330,14 +338,18 @@ impl CloudApiBackend {
             } else {
                 Duration::from_secs(5)
             };
-            self.token
-                .lock()
-                .expect("token state poisoned")
-                .refresh_failure = Some((Instant::now() + cooldown, error.to_string()));
+            self.remember_refresh_failure(&error, cooldown);
             return Err(error);
         }
 
-        let body: TokenResponse = resp.json().await.map_err(network_error)?;
+        let body: TokenResponse = match resp.json().await {
+            Ok(body) => body,
+            Err(error) => {
+                let error = network_error(error);
+                self.remember_refresh_failure(&error, Duration::from_secs(5));
+                return Err(error);
+            }
+        };
 
         // Capture the rotated refresh token. Supabase revokes the prior token
         // after the reuse interval, so we must keep (and persist) the new one.
@@ -383,6 +395,13 @@ impl CloudApiBackend {
             }
             _ => None,
         }
+    }
+
+    fn remember_refresh_failure(&self, error: &BackendError, cooldown: Duration) {
+        self.token
+            .lock()
+            .expect("token state poisoned")
+            .refresh_failure = Some((Instant::now() + cooldown, error.to_string()));
     }
 
     /// Best-effort write of a rotated refresh token back to `backend.toml`.
@@ -1874,6 +1893,38 @@ mod tests {
         assert_eq!(
             refreshes, 1,
             "access token should be cached, not re-fetched"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_refresh_failures_share_one_cloud_attempt() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        let backend = CloudApiBackend::new(config(&server));
+
+        let mut calls = Vec::new();
+        for _ in 0..16 {
+            let backend = backend.clone();
+            calls.push(tokio::spawn(async move { backend.access_token().await }));
+        }
+        for call in calls {
+            assert!(call.await.unwrap().is_err());
+        }
+
+        let refreshes = server
+            .received_requests()
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|request| request.url.path() == "/v1/auth/refresh")
+            .count();
+        assert_eq!(
+            refreshes, 1,
+            "one failed refresh must fan out to all waiters"
         );
     }
 

--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Shared cloud-auth health flag, cloned across every `CloudApiBackend` clone so
 /// the HTTP layer observes the same state as the refresh path. Set when a token
@@ -118,6 +118,9 @@ struct TokenState {
     /// JWT expiry as epoch seconds (wall clock). Must not use `Instant` — macOS
     /// suspends the monotonic clock during sleep while JWT expiry is wall-clock.
     expires_at_epoch: Option<i64>,
+    /// Shared transient refresh failure cooldown. Waiters receive the same
+    /// failure instead of serially retrying the same black-holed request.
+    refresh_failure: Option<(Instant, String)>,
 }
 
 #[derive(Clone)]
@@ -228,6 +231,7 @@ impl CloudApiBackend {
                 refresh_token,
                 access_token: None,
                 expires_at_epoch: None,
+                refresh_failure: None,
             })),
             refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
             persist_path,
@@ -252,6 +256,23 @@ impl CloudApiBackend {
             return Ok(token);
         }
 
+        // A failed refresh is shared across all waiters for a short wall-clock
+        // cooldown. Without this guard, every waiter acquires the mutex in
+        // turn and submits the same dead refresh token or black-holed request.
+        {
+            let mut state = self.token.lock().expect("token state poisoned");
+            if let Some((until, message)) = state.refresh_failure.as_ref() {
+                if *until > Instant::now() {
+                    return Err(BackendError::Provider {
+                        provider: "cloud_api",
+                        code: None,
+                        message: message.clone(),
+                    });
+                }
+                state.refresh_failure = None;
+            }
+        }
+
         let refresh_token = {
             let state = self.token.lock().expect("token state poisoned");
             state.refresh_token.clone()
@@ -268,14 +289,31 @@ impl CloudApiBackend {
                 refresh_token: &refresh_token,
             })
             .send();
-        let resp = tokio::time::timeout(Duration::from_secs(30), send_fut)
-            .await
-            .map_err(|_| BackendError::Provider {
-                provider: "cloud_api",
-                code: None,
-                message: "token refresh timed out".to_string(),
-            })?
-            .map_err(network_error)?;
+        let resp = match tokio::time::timeout(Duration::from_secs(30), send_fut).await {
+            Ok(Ok(resp)) => resp,
+            Ok(Err(error)) => {
+                let error = network_error(error);
+                self.token
+                    .lock()
+                    .expect("token state poisoned")
+                    .refresh_failure =
+                    Some((Instant::now() + Duration::from_secs(5), error.to_string()));
+                return Err(error);
+            }
+            Err(_) => {
+                let error = BackendError::Provider {
+                    provider: "cloud_api",
+                    code: None,
+                    message: "token refresh timed out".to_string(),
+                };
+                self.token
+                    .lock()
+                    .expect("token state poisoned")
+                    .refresh_failure =
+                    Some((Instant::now() + Duration::from_secs(5), error.to_string()));
+                return Err(error);
+            }
+        };
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -286,7 +324,17 @@ impl CloudApiBackend {
             if is_terminal_refresh_status(status) {
                 self.auth_health.mark_terminal();
             }
-            return Err(BackendError::Auth(refresh_failure_message(&text)));
+            let error = BackendError::Auth(refresh_failure_message(&text));
+            let cooldown = if is_terminal_refresh_status(status) {
+                Duration::from_secs(10)
+            } else {
+                Duration::from_secs(5)
+            };
+            self.token
+                .lock()
+                .expect("token state poisoned")
+                .refresh_failure = Some((Instant::now() + cooldown, error.to_string()));
+            return Err(error);
         }
 
         let body: TokenResponse = resp.json().await.map_err(network_error)?;
@@ -304,6 +352,7 @@ impl CloudApiBackend {
             let mut state = self.token.lock().expect("token state poisoned");
             state.access_token = Some(body.access_token.clone());
             state.expires_at_epoch = body.expires_at;
+            state.refresh_failure = None;
             if let Some(ref new_rt) = rotated {
                 state.refresh_token = new_rt.clone();
             }
@@ -394,6 +443,7 @@ impl CloudApiBackend {
         let mut state = self.token.lock().expect("token state poisoned");
         state.access_token = None;
         state.expires_at_epoch = None;
+        state.refresh_failure = None;
     }
 
     pub(super) async fn get<T>(&self, path: &str) -> BackendResult<T>

--- a/apps/daemon/src/config/device_mcp.rs
+++ b/apps/daemon/src/config/device_mcp.rs
@@ -67,7 +67,9 @@ fn read_raw() -> serde_json::Map<String, serde_json::Value> {
         .unwrap_or_default()
 }
 
-fn write_raw(root: &serde_json::Map<String, serde_json::Value>) -> Result<(), WorkspaceControlError> {
+fn write_raw(
+    root: &serde_json::Map<String, serde_json::Value>,
+) -> Result<(), WorkspaceControlError> {
     let path = device_mcp_file();
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| WorkspaceControlError::Io(e.to_string()))?;

--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod daemon_config;
+pub mod device_mcp;
 pub mod edit;
 pub mod global_team_store;
 pub mod layout;
@@ -9,7 +10,6 @@ pub mod provider_auth;
 mod roles_skills;
 mod session_store;
 pub mod team_config;
-pub mod device_mcp;
 pub mod team_mcp;
 pub mod workspace_control;
 mod workspace_instructions;
@@ -24,8 +24,8 @@ pub use daemon_config::{
     WeChatChannel, WeComChannel, BOOTSTRAP_ACTOR_NAME,
 };
 pub use member_store::{MemberStore, PendingInvite, StoredMember};
-pub use model_resolution::first_available;
 pub use model_catalog::DeviceModelCatalog;
+pub use model_resolution::first_available;
 pub use provider_auth::{
     builtin_provider_auth_methods, merge_live_provider_auth_methods, ProviderAuthMethod,
     ProviderAuthMethodType, ProviderAuthMethodsResponse,

--- a/apps/daemon/src/config/team_mcp.rs
+++ b/apps/daemon/src/config/team_mcp.rs
@@ -308,7 +308,10 @@ pub fn load_merged_mcp(
 pub fn split_put_body(
     workspace: &Path,
     body: HashMap<String, McpServerConfig>,
-) -> (HashMap<String, McpServerConfig>, HashMap<String, McpServerConfig>) {
+) -> (
+    HashMap<String, McpServerConfig>,
+    HashMap<String, McpServerConfig>,
+) {
     let mut device = HashMap::new();
     let mut workspace_owned = HashMap::new();
     for (name, cfg) in filter_put_body(workspace, body) {

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -3454,6 +3454,10 @@ pub(crate) mod tests {
     pub(crate) struct TestServer {
         pub(crate) server: DaemonServer,
         _tmp: TempDir,
+        // Keep the event loop alive for the AsyncClient-backed publisher used
+        // by these unit-test fixtures. Dropping it closes rumqttc's request
+        // channel, making otherwise local subscribe/publish calls fail.
+        _mqtt_eventloop: rumqttc::EventLoop,
     }
 
     #[derive(Clone, Default)]
@@ -3756,6 +3760,7 @@ pub(crate) mod tests {
                 cron_turn_event_rx: Some(cron_turn_event_rx),
             },
             _tmp: tmp,
+            _mqtt_eventloop: mqtt.eventloop,
         }
     }
 

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -862,14 +862,14 @@ impl DaemonServer {
         mqtt_supervisor: &MqttSupervisor,
         generation: u64,
         worker_generation: u64,
-    ) -> Result<(), ()> {
+    ) -> Result<(), String> {
         let current = || mqtt_supervisor.is_generation_current(generation, worker_generation);
         if !current() {
             warn!(
                 context,
                 generation, worker_generation, "discarding stale MQTT restore attempt"
             );
-            return Err(());
+            return Err("stale MQTT generation".to_string());
         }
         if subscribe {
             let runtime_topic = self.topics.runtime_commands_wildcard();
@@ -887,10 +887,10 @@ impl DaemonServer {
                     "subscribe_all failed after CONNACK, reconnecting"
                 );
                 mark_mqtt_connected(&self.mqtt_connected_flag, false);
-                return Err(());
+                return Err(format!("MQTT runtime subscription failed: {e}"));
             }
             if !current() {
-                return Err(());
+                return Err("stale MQTT generation after runtime subscription".to_string());
             }
             if let Some(tc) = &mut self.teamclu {
                 if let Err(e) = tc.subscribe_all().await {
@@ -900,12 +900,12 @@ impl DaemonServer {
                         "teamclu subscribe failed after CONNACK, reconnecting"
                     );
                     mark_mqtt_connected(&self.mqtt_connected_flag, false);
-                    return Err(());
+                    return Err(format!("teamclu subscription failed: {e}"));
                 }
             }
         }
         if !current() {
-            return Err(());
+            return Err("stale MQTT generation before state restore".to_string());
         }
         if self.config.team_id.is_some() {
             let publisher = Publisher::new_from_handle(self.publisher_handle.clone(), &self.topics);
@@ -927,10 +927,10 @@ impl DaemonServer {
                     "publish_actor_presence failed after CONNACK, reconnecting"
                 );
                 mark_mqtt_connected(&self.mqtt_connected_flag, false);
-                return Err(());
+                return Err(format!("MQTT actor presence publish failed: {e}"));
             }
             if !current() {
-                return Err(());
+                return Err("stale MQTT generation after actor presence".to_string());
             }
             // That publish is presence-only, so it overwrites the retained
             // snapshot with an empty catalog and no live sessions — measured
@@ -939,17 +939,43 @@ impl DaemonServer {
             // session. Re-publishing the real snapshot is not optional on
             // reconnect: `apply_start_runtime` takes its dedup path for an
             // attachment that already exists, so nothing else would restore it.
-            self.publish_actor_state().await;
+            if let Err(error) = self.publish_actor_state().await {
+                warn!(%error, "failed to publish actor state after MQTT reconnect");
+                mark_mqtt_connected(&self.mqtt_connected_flag, false);
+                let reason = if matches!(
+                    &error,
+                    teamclu_transport::PublisherError::Unavailable(message)
+                        if message.starts_with("could not persist MQTT publish")
+                ) {
+                    format!("durable_store:actor_state_publish_failed: {error}")
+                } else {
+                    format!("MQTT actor state publish failed: {error}")
+                };
+                return Err(reason);
+            }
             if !current() {
-                return Err(());
+                return Err("stale MQTT generation after actor state".to_string());
             }
         } else {
             warn!("no team_id yet; skipping presence announce until onboarding completes");
+            if let Err(error) = self.publish_actor_state().await {
+                warn!(%error, "failed to publish actor state before onboarding");
+                mark_mqtt_connected(&self.mqtt_connected_flag, false);
+                let reason = if matches!(
+                    &error,
+                    teamclu_transport::PublisherError::Unavailable(message)
+                        if message.starts_with("could not persist MQTT publish")
+                ) {
+                    format!("durable_store:actor_state_publish_failed: {error}")
+                } else {
+                    format!("MQTT actor state publish failed: {error}")
+                };
+                return Err(reason);
+            }
         }
         if !current() {
-            return Err(());
+            return Err("stale MQTT generation before readiness".to_string());
         }
-        self.publish_all_agent_states().await;
         Ok(())
     }
 
@@ -1745,7 +1771,7 @@ impl DaemonServer {
                     event = mqtt_supervisor.events.recv() => match event {
                         Some(MqttSupervisorEvent::TransportConnected { generation, worker_generation }) => {
                             info!(generation, "MQTT first generation transport connected; restoring subscriptions and daemon state");
-                            let restored = tokio::time::timeout(
+                            let restore_reason = match tokio::time::timeout(
                                 Duration::from_secs(15),
                                     self.mqtt_resubscribe_after_connack(
                                         "initial",
@@ -1756,12 +1782,26 @@ impl DaemonServer {
                                     ),
                             )
                             .await
-                            .is_ok_and(|result| result.is_ok());
-                            if restored && mqtt_supervisor.mark_generation_ready(generation, worker_generation).await {
+                            {
+                                Ok(Ok(())) => None,
+                                Ok(Err(reason)) => Some(reason),
+                                Err(_) => Some("MQTT state restore timed out".to_string()),
+                            };
+                            if restore_reason.is_none()
+                                && mqtt_supervisor
+                                    .mark_generation_ready(generation, worker_generation)
+                                    .await
+                            {
                                 break;
                             }
                             mqtt_supervisor
-                                .request_rebuild("initial MQTT subscription/state restore failed")
+                                .request_rebuild_for_generation(
+                                    generation,
+                                    worker_generation,
+                                    restore_reason.as_deref().unwrap_or(
+                                        "initial MQTT subscription/state restore failed",
+                                    ),
+                                )
                                 .await;
                         }
                         Some(MqttSupervisorEvent::Terminated) | None => {
@@ -1967,7 +2007,7 @@ impl DaemonServer {
                             }
                             Some(MqttSupervisorEvent::SubscriptionsReady { generation, worker_generation }) => {
                                 info!(generation, "MQTT subscriptions ready; restoring daemon state");
-                                let restored = tokio::time::timeout(
+                                let restore_reason = match tokio::time::timeout(
                                     Duration::from_secs(15),
                                     self.mqtt_resubscribe_after_connack(
                                         "auto-reconnect",
@@ -1978,13 +2018,27 @@ impl DaemonServer {
                                     ),
                                 )
                                 .await
-                                .is_ok_and(|result| result.is_ok());
-                                if restored && mqtt_supervisor.mark_generation_ready(generation, worker_generation).await {
+                                {
+                                    Ok(Ok(())) => None,
+                                    Ok(Err(reason)) => Some(reason),
+                                    Err(_) => Some("MQTT state restore timed out".to_string()),
+                                };
+                                if restore_reason.is_none()
+                                    && mqtt_supervisor
+                                        .mark_generation_ready(generation, worker_generation)
+                                        .await
+                                {
                                     info!(generation, "MQTT generation readiness acknowledged");
                                 } else {
                                     warn!(generation, "MQTT state restore failed; requesting generation rebuild");
                                     mqtt_supervisor
-                                        .request_rebuild("MQTT subscription/state restore failed")
+                                        .request_rebuild_for_generation(
+                                            generation,
+                                            worker_generation,
+                                            restore_reason
+                                                .as_deref()
+                                                .unwrap_or("MQTT subscription/state restore failed"),
+                                        )
                                         .await;
                                 }
                             }
@@ -2038,7 +2092,7 @@ impl DaemonServer {
                             // `apply_start_runtime` and so were invisible in the
                             // retain until an unrelated reconnect.
                             if actor_state_dirty {
-                                self.publish_actor_state().await;
+                                let _ = self.publish_actor_state().await;
                             }
                             for (agent_id, acp_event) in coalesce_text_events(agent_events) {
                                 self.forward_agent_event(&agent_id, acp_event).await;

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -1,4 +1,3 @@
-use rumqttc::{Event, Packet};
 use std::collections::HashMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -43,6 +42,7 @@ pub(crate) mod runtime_env;
 // cache) lives in `server/cron.rs` as a child module so it can reach the
 // server's private fields directly.
 mod channels;
+mod command_executor;
 mod cron;
 mod messaging;
 mod peers_workspaces;
@@ -50,7 +50,11 @@ mod remote_tools;
 mod rpc;
 mod runtime_lifecycle;
 use crate::history::EventHistory;
-use crate::mqtt::{publisher::Publisher, subscriber, MqttClient};
+#[cfg(test)]
+use crate::mqtt::MqttClient;
+use crate::mqtt::{
+    publisher::Publisher, subscriber, MqttPublisher, MqttSupervisor, MqttSupervisorEvent,
+};
 use crate::proto::amux;
 use crate::provider_config::ProviderConfig;
 use crate::runtime::acp_event_frame::AcpEventFrame;
@@ -78,21 +82,6 @@ fn mark_mqtt_connected(flag: &Option<Arc<std::sync::atomic::AtomicBool>>, connec
     if let Some(flag) = flag {
         flag.store(connected, std::sync::atomic::Ordering::Relaxed);
     }
-}
-
-/// After this long with `mqtt_connected == false`, tear down the rumqttc
-/// client and rebuild via the outer loop (fresh JWT + new TCP/WSS session).
-/// Backend/EMQX restarts can leave rumqttc auto-reconnect retrying with a
-/// stale password indefinitely; a full rebuild matches what process restart
-/// does. Three keepalive periods (30s each) gives the broker time to come
-/// back before we escalate.
-const MQTT_DISCONNECT_REBUILD: Duration = Duration::from_secs(90);
-
-fn mqtt_disconnect_rebuild_due(
-    disconnected_since: Option<std::time::Instant>,
-    threshold: Duration,
-) -> bool {
-    disconnected_since.is_some_and(|since| since.elapsed() >= threshold)
 }
 
 pub(crate) use crate::config::workspace_path::is_linkable_workspace_path;
@@ -136,13 +125,15 @@ pub struct DaemonServer {
     /// `channel-reload` (over `amuxd.sock`) can re-read the latest config
     /// without callers having to thread the path through every helper.
     config_path: PathBuf,
-    mqtt: MqttClient,
+    /// Receiver consumed exactly once by the MQTT supervisor. The publisher
+    /// proxy itself is shared with every business module and survives all
+    /// connection generations.
+    mqtt_command_rx: Option<mpsc::Receiver<crate::mqtt::MqttCommand>>,
     /// Set when running on the NATS transport (`config.transport.kind = "nats"`).
-    /// Mutually exclusive with the MQTT event loop in `mqtt`. On the MQTT path
-    /// this stays `None` and `mqtt` is the live backend.
+    /// Mutually exclusive with the MQTT supervisor.
     nats: Option<crate::nats::NatsBackend>,
-    /// Unified publisher handle. Set to `mqtt.client` on the MQTT path and
-    /// to `nats.client` on the NATS path during connect. All publishing
+    /// Unified publisher handle. On MQTT it is the generation-independent
+    /// supervisor proxy; on NATS it is the active NATS client. All publishing
     /// downstream (Publisher::new_from_handle, teamclu, channels) reads
     /// this so the same handler code works for both backends.
     publisher_handle: Arc<dyn MessagePublisher>,
@@ -587,23 +578,6 @@ fn hydrate_identity_from_backend(
     Ok(())
 }
 
-/// Best-effort first access token. Failure must not block startup — `run()`
-/// retries indefinitely before each MQTT connect.
-async fn initial_access_token(backend: &Arc<dyn Backend>) -> String {
-    match backend.auth_token().await {
-        Ok(token) => token,
-        Err(e) => {
-            warn!(
-                error = %e,
-                "initial Cloud API token fetch failed; HTTP/local control plane will start \
-                 and MQTT/collab will retry in the main loop (re-run `amuxd init` if the refresh \
-                 token is invalid)"
-            );
-            String::new()
-        }
-    }
-}
-
 impl DaemonServer {
     pub async fn new(
         mut config: DaemonConfig,
@@ -649,22 +623,12 @@ impl DaemonServer {
         }
         let actor_id = backend.actor_id().to_string();
 
-        // Best-effort token — `run()`'s outer loop retries before MQTT connect.
-        let token = initial_access_token(&backend).await;
-
         // Authoritative: resolve the MQTT broker from /v1/config/bootstrap.
         // When bootstrap is unreachable or answers without an `mqtt` block, keep
         // the last-known address already in daemon.toml (invite `?broker=` or a
         // previously persisted bootstrap value) and continue in degraded mode
         // (HTTP/local APIs stay up).
         apply_bootstrap_overrides(&backend, &mut config, config_path).await?;
-
-        let mqtt = if config.mqtt.broker_url.trim().is_empty() {
-            warn!("deferring MQTT client until broker URL is configured");
-            MqttClient::new_placeholder(&config)?
-        } else {
-            MqttClient::new(&config, &actor_id, &token)?
-        };
 
         let mut launch_configs = RuntimeManager::default_launch_configs();
         if let Some(claude) = config.agents.claude_code.as_ref() {
@@ -742,8 +706,10 @@ impl DaemonServer {
             Some(backend.clone()),
         )));
 
-        let publisher_handle: Arc<dyn MessagePublisher> = Arc::new(mqtt.client.clone());
-        let topics = mqtt.topics.clone();
+        let (mqtt_publisher, mqtt_command_rx) = MqttPublisher::channel();
+        let publisher_handle: Arc<dyn MessagePublisher> = mqtt_publisher;
+        let topics =
+            crate::mqtt::Topics::new(config.team_id.as_deref().unwrap_or_default(), &actor_id);
 
         // Local fast-path broadcast (SSE tee). Capacity sized for bursts of
         // coalesced deltas; a lagging subscriber skips events, which the MQTT
@@ -784,7 +750,7 @@ impl DaemonServer {
         Ok(Self {
             config,
             config_path: config_path.to_path_buf(),
-            mqtt,
+            mqtt_command_rx: Some(mqtt_command_rx),
             nats: None,
             publisher_handle,
             topics,
@@ -878,26 +844,39 @@ impl DaemonServer {
     /// Re-subscribe team topics and re-announce presence after MQTT CONNACK.
     /// Returns `Err(())` when the caller should break to the outer reconnect
     /// loop (same semantics as the first-connect path).
-    async fn mqtt_resubscribe_after_connack(&mut self, context: &str) -> Result<(), ()> {
-        mark_mqtt_connected(&self.mqtt_connected_flag, true);
-        if let Err(e) = self.mqtt.subscribe_all().await {
-            warn!(
-                context,
-                error = %e,
-                "subscribe_all failed after CONNACK, reconnecting"
-            );
-            mark_mqtt_connected(&self.mqtt_connected_flag, false);
-            return Err(());
-        }
-        if let Some(tc) = &mut self.teamclu {
-            if let Err(e) = tc.subscribe_all().await {
+    async fn mqtt_resubscribe_after_connack(
+        &mut self,
+        context: &str,
+        subscribe: bool,
+    ) -> Result<(), ()> {
+        if subscribe {
+            let runtime_topic = self.topics.runtime_commands_wildcard();
+            if let Err(e) = self
+                .publisher_handle
+                .subscribe(
+                    &runtime_topic,
+                    teamclu_transport::DeliveryGuarantee::AtLeastOnce,
+                )
+                .await
+            {
                 warn!(
                     context,
                     error = %e,
-                    "teamclu subscribe failed after CONNACK, reconnecting"
+                    "subscribe_all failed after CONNACK, reconnecting"
                 );
                 mark_mqtt_connected(&self.mqtt_connected_flag, false);
                 return Err(());
+            }
+            if let Some(tc) = &mut self.teamclu {
+                if let Err(e) = tc.subscribe_all().await {
+                    warn!(
+                        context,
+                        error = %e,
+                        "teamclu subscribe failed after CONNACK, reconnecting"
+                    );
+                    mark_mqtt_connected(&self.mqtt_connected_flag, false);
+                    return Err(());
+                }
             }
         }
         if self.config.team_id.is_some() {
@@ -1669,39 +1648,12 @@ impl DaemonServer {
                 continue 'outer;
             }
 
-            // ── 2. Rebuild MqttClient ──
-            let credential_mode =
-                if self.config.mqtt.username.is_some() && self.config.mqtt.password.is_some() {
-                    "configured"
-                } else {
-                    "backend_token"
-                };
-            info!(
-                actor_id = %self.actor_id,
-                broker   = %self.config.mqtt.broker_url,
-                credential_mode,
-                "MQTT connecting"
-            );
-            self.mqtt = match MqttClient::new(&self.config, &self.actor_id, &token) {
-                Ok(c) => c,
-                Err(e) => {
-                    warn!("MqttClient build failed: {e}, retrying in 5s");
-                    tokio::select! {
-                        _ = tokio::time::sleep(Duration::from_secs(5)) => {}
-                        _ = &mut shutdown => {
-                            info!("shutdown signal received while rebuilding MQTT client");
-                            let _ = std::fs::remove_file(&sock_path);
-                            return Ok(());
-                        }
-                    }
-                    continue 'outer;
-                }
-            };
-
-            // ── 3. Rebuild teamclu with new AsyncClient ──
+            // ── 2. Start the generation-independent MQTT supervisor ──
+            // The supervisor owns every AsyncClient/EventLoop generation. The
+            // publisher proxy held by SessionManager and all channel modules is
+            // intentionally left untouched across reconnects.
             if let Some(team_id) = self.config.team_id.clone() {
-                self.publisher_handle = Arc::new(self.mqtt.client.clone());
-                self.topics = self.mqtt.topics.clone();
+                self.topics = crate::mqtt::Topics::new(&team_id, &self.config.actor.id);
                 self.refresh_rpc_client_publisher();
                 self.teamclu = match crate::teamclu::SessionManager::new(
                     self.publisher_handle.clone(),
@@ -1721,54 +1673,60 @@ impl DaemonServer {
                 };
             }
 
-            // ── 4. Wait for CONNACK ──
-            mark_mqtt_connected(&self.mqtt_connected_flag, false);
+            let command_rx = self
+                .mqtt_command_rx
+                .take()
+                .expect("MQTT command receiver already taken");
+            let mut mqtt_supervisor = MqttSupervisor::spawn(
+                self.config.clone(),
+                self.actor_id.clone(),
+                token,
+                self.backend.clone(),
+                command_rx,
+                self.mqtt_connected_flag
+                    .clone()
+                    .expect("MQTT connected flag must be installed before run"),
+            );
+
+            // ── 3. Wait for the first generation to become ready ──
             loop {
-                match self.mqtt.eventloop.poll().await {
-                    Ok(Event::Incoming(Packet::ConnAck(_))) => {
-                        info!("MQTT CONNACK received");
-                        mark_mqtt_connected(&self.mqtt_connected_flag, true);
-                        break;
+                tokio::select! {
+                    _ = &mut shutdown => {
+                        mqtt_supervisor.shutdown().await;
+                        self.shutdown_for_exit().await;
+                        let _ = std::fs::remove_file(&sock_path);
+                        return Ok(());
                     }
-                    Ok(_) => {}
-                    Err(rumqttc::ConnectionError::ConnectionRefused(code)) => {
-                        warn!(
-                            reason = ?code,
-                            "MQTT connection refused during connect, refreshing token"
-                        );
-                        self.backend.invalidate_cached_credential();
-                        tokio::select! {
-                            _ = tokio::time::sleep(Duration::from_secs(3)) => {}
-                            _ = &mut shutdown => {
-                                info!("shutdown signal received while awaiting MQTT CONNACK");
-                                let _ = std::fs::remove_file(&sock_path);
-                                return Ok(());
+                    event = mqtt_supervisor.events.recv() => match event {
+                        Some(MqttSupervisorEvent::TransportConnected { generation }) => {
+                            info!(generation, "MQTT first generation transport connected; restoring subscriptions and daemon state");
+                            let restored = tokio::time::timeout(
+                                Duration::from_secs(15),
+                                self.mqtt_resubscribe_after_connack("initial", true),
+                            )
+                            .await
+                            .is_ok_and(|result| result.is_ok());
+                            if restored && mqtt_supervisor.mark_generation_ready(generation).await {
+                                break;
                             }
+                            mqtt_supervisor
+                                .request_rebuild("initial MQTT subscription/state restore failed")
+                                .await;
                         }
-                        continue 'outer;
-                    }
-                    Err(e) => {
-                        warn!("MQTT connect error: {e}, retrying...");
-                        tokio::select! {
-                            _ = tokio::time::sleep(Duration::from_secs(3)) => {}
-                            _ = &mut shutdown => {
-                                info!("shutdown signal received while awaiting MQTT CONNACK");
-                                let _ = std::fs::remove_file(&sock_path);
-                                return Ok(());
-                            }
+                        Some(MqttSupervisorEvent::Terminated) | None => {
+                            self.shutdown_for_exit().await;
+                            let _ = std::fs::remove_file(&sock_path);
+                            return Ok(());
                         }
+                        Some(MqttSupervisorEvent::SubscriptionsReady { .. })
+                        | Some(MqttSupervisorEvent::GenerationReady { .. })
+                        | Some(MqttSupervisorEvent::Disconnected { .. })
+                        | Some(MqttSupervisorEvent::Rebuilt { .. }) => {}
                     }
                 }
             }
 
-            // ── 5. Subscribe and announce ──
-            if self
-                .mqtt_resubscribe_after_connack("initial")
-                .await
-                .is_err()
-            {
-                continue 'outer;
-            }
+            // ── 4. Subscribe and announce ──
             info!(actor_id = %self.config.actor.id, "MQTT connected, listening for commands");
 
             if first_connect {
@@ -1782,45 +1740,15 @@ impl DaemonServer {
                 first_connect = false;
             }
 
-            // ── 6. Proactive reconnect timer ──
-            //
-            // Compute when to break the inner loop so we can fetch a fresh
-            // access_token and re-CONNECT before the current JWT expires.
-            // EMQX silently rejects PUB/SUB on a connection whose JWT exp
-            // has passed (it doesn't always disconnect), so waiting for a
-            // reactive ConnectionRefused leaves stale-ACL windows where
-            // the daemon thinks everything's fine but messages are dropped.
-            // Fire 5 min before the cached expiry; conservative 50 min
-            // fallback if expiry isn't cached yet.
-            let proactive_reconnect_in =
-                proactive_reconnect_delay(self.backend.cached_credential_expiry_epoch());
-            info!(
-                reconnect_in_secs = proactive_reconnect_in.as_secs(),
-                "scheduled proactive MQTT reconnect before token expiry"
-            );
-            let proactive_sleep = tokio::time::sleep(proactive_reconnect_in);
-            tokio::pin!(proactive_sleep);
-
-            // Track how long we've been disconnected so rumqttc auto-reconnect
-            // cannot wedge the daemon after a backend/EMQX restart.
-            let mut disconnected_since: Option<std::time::Instant> = None;
-
-            // ── 7. Event loop ──
-            //
-            // We must NEVER preempt `eventloop.poll()` with a timeout. rumqttc's
-            // poll() drives TLS handshake / TCP reconnect / packet IO inside one
-            // future; if we drop the future mid-flight (which timeout() does),
-            // the in-progress connection state is dropped, the underlying socket
-            // is closed (broker sees `ssl_closed`), and the next poll() starts a
-            // fresh reconnect — leading to a self-takeover loop where the
-            // daemon opens 4-5 sockets per ~50 ms timeout cycle and broker
-            // discards them. Use `tokio::select!` instead so the agent-event
-            // pump runs alongside poll() without cancelling it.
+            // ── 5. Business/control loop ──
+            // MQTT polling and connection recovery are now owned by the
+            // supervisor. This loop dispatches only decoded frames and local
+            // control commands, so a business await cannot freeze MQTT IO.
             loop {
                 tokio::select! {
-                    biased;
                     _ = &mut shutdown => {
                         info!("shutdown signal received, draining channels");
+                        mqtt_supervisor.shutdown().await;
                         self.shutdown_for_exit().await;
                         let _ = std::fs::remove_file(&sock_path);
                         return Ok(());
@@ -1829,6 +1757,7 @@ impl DaemonServer {
                         match sock_cmd {
                             Some(SockCommand::Shutdown) => {
                                 info!("shutdown control command received, draining channels");
+                                mqtt_supervisor.shutdown().await;
                                 self.shutdown_for_exit().await;
                                 let _ = std::fs::remove_file(&sock_path);
                                 return Ok(());
@@ -1980,100 +1909,58 @@ impl DaemonServer {
                             self.publish_cron_turn_event(ev).await;
                         }
                     }
-                    poll_result = self.mqtt.eventloop.poll() => {
-                        match poll_result {
-                            Ok(Event::Incoming(Packet::ConnAck(_))) => {
-                                // Network blip — rumqttc reconnected automatically.
-                                info!("MQTT reconnected (network blip), re-publishing state");
-                                disconnected_since = None;
-                                if self
-                                    .mqtt_resubscribe_after_connack("auto-reconnect")
-                                    .await
-                                    .is_err()
-                                {
-                                    self.backend.invalidate_cached_credential();
-                                    break;
+                    event = mqtt_supervisor.events.recv() => {
+                        match event {
+                            Some(MqttSupervisorEvent::TransportConnected { generation }) => {
+                                info!(generation, "MQTT generation transport connected; worker is restoring subscriptions");
+                            }
+                            Some(MqttSupervisorEvent::SubscriptionsReady { generation }) => {
+                                info!(generation, "MQTT subscriptions ready; restoring daemon state");
+                                let restored = tokio::time::timeout(
+                                    Duration::from_secs(15),
+                                    self.mqtt_resubscribe_after_connack("auto-reconnect", false),
+                                )
+                                .await
+                                .is_ok_and(|result| result.is_ok());
+                                if restored && mqtt_supervisor.mark_generation_ready(generation).await {
+                                    info!(generation, "MQTT generation readiness acknowledged");
+                                } else {
+                                    warn!(generation, "MQTT state restore failed; requesting generation rebuild");
+                                    mqtt_supervisor
+                                        .request_rebuild("MQTT subscription/state restore failed")
+                                        .await;
                                 }
                             }
-                            Ok(Event::Incoming(Packet::Publish(publish))) => {
-                                if let Some(msg) = subscriber::parse_incoming(&publish) {
-                                    self.handle_incoming(msg).await;
-                                }
+                            Some(MqttSupervisorEvent::GenerationReady { generation }) => {
+                                info!(generation, "MQTT generation ready for business traffic");
                             }
-                            // EMQX rejected connection (JWT expired).
-                            Err(rumqttc::ConnectionError::ConnectionRefused(code)) => {
-                                mark_mqtt_connected(&self.mqtt_connected_flag, false);
-                                warn!(reason = ?code, "MQTT connection refused (token expired), reconnecting");
-                                self.backend.invalidate_cached_credential();
-                                break; // outer loop gets fresh token
+                            Some(MqttSupervisorEvent::Disconnected { generation, reason }) => {
+                                warn!(generation, %reason, "MQTT generation disconnected; recovery is owned by supervisor");
                             }
-                            Err(e) => {
-                                mark_mqtt_connected(&self.mqtt_connected_flag, false);
-                                warn!("MQTT transient error: {e}, will retry (rumqttc auto-reconnects)");
-                                tokio::time::sleep(Duration::from_secs(5)).await;
+                            Some(MqttSupervisorEvent::Rebuilt { generation, reason }) => {
+                                info!(generation, %reason, "MQTT generation rebuilt");
                             }
-                            Ok(_) => {} // other events (Outgoing(...), PingResp, etc.)
+                            Some(MqttSupervisorEvent::Terminated) | None => {
+                                self.shutdown_for_exit().await;
+                                let _ = std::fs::remove_file(&sock_path);
+                                return Ok(());
+                            }
                         }
                     }
-                    _ = &mut proactive_sleep => {
-                        info!(
-                            expiry = ?self.backend.cached_credential_expiry_epoch(),
-                            "JWT nearing expiry, proactively reconnecting MQTT before broker silently denies ACL"
-                        );
-                        mark_mqtt_connected(&self.mqtt_connected_flag, false);
-                        self.backend.invalidate_cached_credential();
-                        // Queue a graceful DISCONNECT so the broker sees an
-                        // intentional close (no LWT blip) before we drop the
-                        // eventloop. The drain loop below gives rumqttc a
-                        // bounded chance to write the packet.
-                        let _ = self.mqtt.client.disconnect().await;
-                        for _ in 0..3 {
-                            match tokio::time::timeout(
-                                Duration::from_millis(50),
-                                self.mqtt.eventloop.poll(),
-                            ).await {
-                                Ok(Err(_)) | Err(_) => break,
-                                Ok(Ok(_)) => {}
-                            }
+                    inbound = mqtt_supervisor.inbound.recv() => {
+                        if let Some(envelope) = inbound {
+                            command_executor::DaemonCommandExecutor::new(&mut self)
+                                .execute_mqtt(envelope, &mqtt_supervisor)
+                                .await;
                         }
-                        break; // outer loop fetches fresh token + reconnects
                     }
                     _ = tokio::time::sleep(Duration::from_millis(50)) => {
-                        // FIX 8: gate the pump on the shared MQTT-connected flag.
-                        // On a proactive reconnect / ConnectionRefused the old
-                        // AsyncClient (and its queued QoS1 deltas) is dropped
-                        // wholesale on rebuild, so publishing while the link is
-                        // known-down silently loses live deltas. Rather than
-                        // build a full outbox, we simply HOLD: skip draining
-                        // `poll_events()` (events stay buffered in the
-                        // RuntimeManager) until CONNACK re-sets the flag, so the
-                        // deltas are forwarded intact after reconnect. `false`
-                        // when the flag cell is absent (test/degraded) → treat as
-                        // connected so behavior is unchanged there.
                         let mqtt_up = self
                             .mqtt_connected_flag
                             .as_ref()
                             .map(|f| f.load(std::sync::atomic::Ordering::Relaxed))
                             .unwrap_or(true);
-                        if !mqtt_up {
-                            if disconnected_since.is_none() {
-                                disconnected_since = Some(std::time::Instant::now());
-                            } else if mqtt_disconnect_rebuild_due(
-                                disconnected_since,
-                                MQTT_DISCONNECT_REBUILD,
-                            ) {
-                                warn!(
-                                    threshold_secs = MQTT_DISCONNECT_REBUILD.as_secs(),
-                                    "MQTT disconnected too long, forcing full reconnect with fresh credentials"
-                                );
-                                self.backend.invalidate_cached_credential();
-                                break;
-                            }
-                        } else {
-                            disconnected_since = None;
-                        }
                         if mqtt_up {
-                            // Drain queued runtime events without preempting poll().
                             let (agent_events, evicted_runtime_ids, actor_state_dirty): (
                                 Vec<_>,
                                 Vec<String>,
@@ -3664,25 +3551,6 @@ pub(crate) mod tests {
         assert!(flag.load(std::sync::atomic::Ordering::Relaxed));
     }
 
-    #[test]
-    fn mqtt_disconnect_rebuild_due_after_threshold() {
-        use std::time::{Duration, Instant};
-
-        let since = Instant::now() - Duration::from_secs(91);
-        assert!(super::mqtt_disconnect_rebuild_due(
-            Some(since),
-            Duration::from_secs(90)
-        ));
-        assert!(!super::mqtt_disconnect_rebuild_due(
-            Some(Instant::now()),
-            Duration::from_secs(90)
-        ));
-        assert!(!super::mqtt_disconnect_rebuild_due(
-            None,
-            Duration::from_secs(90)
-        ));
-    }
-
     pub(crate) fn test_mqtt(actor_id: &str) -> MqttClient {
         let mut opts = MqttOptions::new("daemon-server-test", "localhost", 1883);
         opts.set_clean_session(true);
@@ -3726,7 +3594,7 @@ pub(crate) mod tests {
             server: DaemonServer {
                 config,
                 config_path: tmp.path().join("daemon.toml"),
-                mqtt,
+                mqtt_command_rx: None,
                 nats: None,
                 publisher_handle: publisher_handle.clone(),
                 topics,

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -175,6 +175,10 @@ pub struct DaemonServer {
     refresh_coordinator: Option<Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>>,
     /// Shared flag written by the MQTT event loop and read by `/v1/info`.
     mqtt_connected_flag: Option<Arc<std::sync::atomic::AtomicBool>>,
+    /// Recovery signal receiver is installed into the supervisor exactly once.
+    mqtt_recovery_rx: Option<mpsc::Receiver<crate::mqtt::MqttRecoveryRequest>>,
+    mqtt_recovery_handle: crate::mqtt::MqttRecoveryHandle,
+    mqtt_snapshot: crate::mqtt::MqttSnapshotHandle,
     /// Resolves the team's cloud-sourced managed (shared) LLM on a short TTL.
     /// Shared with the HTTP layer (`GET /v1/workspaces/:id/providers`) so a
     /// provider read can re-materialize `provider.team` off the same throttled
@@ -707,6 +711,10 @@ impl DaemonServer {
         )));
 
         let (mqtt_publisher, mqtt_command_rx) = MqttPublisher::channel();
+        let (mqtt_recovery_handle, mqtt_recovery_rx) = crate::mqtt::MqttRecoveryHandle::channel();
+        let mqtt_snapshot = Arc::new(parking_lot::RwLock::new(
+            crate::mqtt::MqttSnapshot::default(),
+        ));
         let publisher_handle: Arc<dyn MessagePublisher> = mqtt_publisher;
         let topics =
             crate::mqtt::Topics::new(config.team_id.as_deref().unwrap_or_default(), &actor_id);
@@ -751,6 +759,9 @@ impl DaemonServer {
             config,
             config_path: config_path.to_path_buf(),
             mqtt_command_rx: Some(mqtt_command_rx),
+            mqtt_recovery_rx: Some(mqtt_recovery_rx),
+            mqtt_recovery_handle,
+            mqtt_snapshot,
             nats: None,
             publisher_handle,
             topics,
@@ -848,7 +859,18 @@ impl DaemonServer {
         &mut self,
         context: &str,
         subscribe: bool,
+        mqtt_supervisor: &MqttSupervisor,
+        generation: u64,
+        worker_generation: u64,
     ) -> Result<(), ()> {
+        let current = || mqtt_supervisor.is_generation_current(generation, worker_generation);
+        if !current() {
+            warn!(
+                context,
+                generation, worker_generation, "discarding stale MQTT restore attempt"
+            );
+            return Err(());
+        }
         if subscribe {
             let runtime_topic = self.topics.runtime_commands_wildcard();
             if let Err(e) = self
@@ -867,6 +889,9 @@ impl DaemonServer {
                 mark_mqtt_connected(&self.mqtt_connected_flag, false);
                 return Err(());
             }
+            if !current() {
+                return Err(());
+            }
             if let Some(tc) = &mut self.teamclu {
                 if let Err(e) = tc.subscribe_all().await {
                     warn!(
@@ -878,6 +903,9 @@ impl DaemonServer {
                     return Err(());
                 }
             }
+        }
+        if !current() {
+            return Err(());
         }
         if self.config.team_id.is_some() {
             let publisher = Publisher::new_from_handle(self.publisher_handle.clone(), &self.topics);
@@ -901,6 +929,9 @@ impl DaemonServer {
                 mark_mqtt_connected(&self.mqtt_connected_flag, false);
                 return Err(());
             }
+            if !current() {
+                return Err(());
+            }
             // That publish is presence-only, so it overwrites the retained
             // snapshot with an empty catalog and no live sessions — measured
             // 7346 bytes down to 19 across a daemon restart. Every reader then
@@ -909,8 +940,14 @@ impl DaemonServer {
             // reconnect: `apply_start_runtime` takes its dedup path for an
             // attachment that already exists, so nothing else would restore it.
             self.publish_actor_state().await;
+            if !current() {
+                return Err(());
+            }
         } else {
             warn!("no team_id yet; skipping presence announce until onboarding completes");
+        }
+        if !current() {
+            return Err(());
         }
         self.publish_all_agent_states().await;
         Ok(())
@@ -991,6 +1028,8 @@ impl DaemonServer {
             meta.configured_agent_types = supported_agent_type_names(&self.config);
             meta.agent_types_advertise = agent_types_advertise.clone();
             meta.mqtt_connected = mqtt_connected_flag.clone();
+            meta.mqtt_recovery = Some(self.mqtt_recovery_handle.clone());
+            meta.mqtt_snapshot = self.mqtt_snapshot.clone();
             // The HTTP workspace runtime endpoints share this supervisor's
             // refresh coordinator for status + apply-intent semantics.
             let execution_context_assembler = Arc::new(self.execution_context_assembler());
@@ -1677,15 +1716,21 @@ impl DaemonServer {
                 .mqtt_command_rx
                 .take()
                 .expect("MQTT command receiver already taken");
+            let recovery_rx = self
+                .mqtt_recovery_rx
+                .take()
+                .expect("MQTT recovery receiver already taken");
             let mut mqtt_supervisor = MqttSupervisor::spawn(
                 self.config.clone(),
                 self.actor_id.clone(),
                 token,
                 self.backend.clone(),
                 command_rx,
+                recovery_rx,
                 self.mqtt_connected_flag
                     .clone()
                     .expect("MQTT connected flag must be installed before run"),
+                self.mqtt_snapshot.clone(),
             );
 
             // ── 3. Wait for the first generation to become ready ──
@@ -1698,15 +1743,21 @@ impl DaemonServer {
                         return Ok(());
                     }
                     event = mqtt_supervisor.events.recv() => match event {
-                        Some(MqttSupervisorEvent::TransportConnected { generation }) => {
+                        Some(MqttSupervisorEvent::TransportConnected { generation, worker_generation }) => {
                             info!(generation, "MQTT first generation transport connected; restoring subscriptions and daemon state");
                             let restored = tokio::time::timeout(
                                 Duration::from_secs(15),
-                                self.mqtt_resubscribe_after_connack("initial", true),
+                                    self.mqtt_resubscribe_after_connack(
+                                        "initial",
+                                        true,
+                                        &mqtt_supervisor,
+                                        generation,
+                                        worker_generation,
+                                    ),
                             )
                             .await
                             .is_ok_and(|result| result.is_ok());
-                            if restored && mqtt_supervisor.mark_generation_ready(generation).await {
+                            if restored && mqtt_supervisor.mark_generation_ready(generation, worker_generation).await {
                                 break;
                             }
                             mqtt_supervisor
@@ -1911,18 +1962,24 @@ impl DaemonServer {
                     }
                     event = mqtt_supervisor.events.recv() => {
                         match event {
-                            Some(MqttSupervisorEvent::TransportConnected { generation }) => {
+                            Some(MqttSupervisorEvent::TransportConnected { generation, worker_generation }) => {
                                 info!(generation, "MQTT generation transport connected; worker is restoring subscriptions");
                             }
-                            Some(MqttSupervisorEvent::SubscriptionsReady { generation }) => {
+                            Some(MqttSupervisorEvent::SubscriptionsReady { generation, worker_generation }) => {
                                 info!(generation, "MQTT subscriptions ready; restoring daemon state");
                                 let restored = tokio::time::timeout(
                                     Duration::from_secs(15),
-                                    self.mqtt_resubscribe_after_connack("auto-reconnect", false),
+                                    self.mqtt_resubscribe_after_connack(
+                                        "auto-reconnect",
+                                        false,
+                                        &mqtt_supervisor,
+                                        generation,
+                                        worker_generation,
+                                    ),
                                 )
                                 .await
                                 .is_ok_and(|result| result.is_ok());
-                                if restored && mqtt_supervisor.mark_generation_ready(generation).await {
+                                if restored && mqtt_supervisor.mark_generation_ready(generation, worker_generation).await {
                                     info!(generation, "MQTT generation readiness acknowledged");
                                 } else {
                                     warn!(generation, "MQTT state restore failed; requesting generation rebuild");
@@ -1931,13 +1988,13 @@ impl DaemonServer {
                                         .await;
                                 }
                             }
-                            Some(MqttSupervisorEvent::GenerationReady { generation }) => {
+                            Some(MqttSupervisorEvent::GenerationReady { generation, .. }) => {
                                 info!(generation, "MQTT generation ready for business traffic");
                             }
-                            Some(MqttSupervisorEvent::Disconnected { generation, reason }) => {
+                            Some(MqttSupervisorEvent::Disconnected { generation, reason, .. }) => {
                                 warn!(generation, %reason, "MQTT generation disconnected; recovery is owned by supervisor");
                             }
-                            Some(MqttSupervisorEvent::Rebuilt { generation, reason }) => {
+                            Some(MqttSupervisorEvent::Rebuilt { generation, reason, .. }) => {
                                 info!(generation, %reason, "MQTT generation rebuilt");
                             }
                             Some(MqttSupervisorEvent::Terminated) | None => {
@@ -3619,6 +3676,11 @@ pub(crate) mod tests {
                 refresh_watch_registry: None,
                 refresh_coordinator: None,
                 mqtt_connected_flag: None,
+                mqtt_recovery_rx: None,
+                mqtt_recovery_handle: crate::mqtt::MqttRecoveryHandle::channel().0,
+                mqtt_snapshot: Arc::new(parking_lot::RwLock::new(
+                    crate::mqtt::MqttSnapshot::default(),
+                )),
                 managed_llm: Arc::new(crate::runtime::managed_llm::ManagedLlmResolver::new(
                     backend,
                 )),
@@ -3922,7 +3984,8 @@ pub(crate) mod tests {
         assert_eq!(err.error_code, "ENV_ASSEMBLE_FAILED");
         assert_eq!(err.failed_stage, "env_setup");
         assert!(
-            err.error_message.contains("workspace identity resolution failed"),
+            err.error_message
+                .contains("workspace identity resolution failed"),
             "unexpected error message: {}",
             err.error_message
         );

--- a/apps/daemon/src/daemon/server/command_executor.rs
+++ b/apps/daemon/src/daemon/server/command_executor.rs
@@ -1,0 +1,63 @@
+//! Serialized business command boundary for transport-originated work.
+//!
+//! The MQTT worker never enters this module. It only persists an inbound frame
+//! and forwards an envelope. Keeping the executor as a small owner-facing
+//! adapter makes the transport boundary explicit while preserving the daemon's
+//! existing single-owner ordering for `DaemonServer` state.
+
+use std::time::{Duration, Instant};
+
+use tracing::{error, warn};
+
+use crate::mqtt::{MqttInbound, MqttInboundDisposition, MqttSupervisor};
+
+use super::DaemonServer;
+
+pub(crate) struct DaemonCommandExecutor<'a> {
+    server: &'a mut DaemonServer,
+}
+
+impl<'a> DaemonCommandExecutor<'a> {
+    pub(crate) fn new(server: &'a mut DaemonServer) -> Self {
+        Self { server }
+    }
+
+    /// Execute one durable MQTT envelope while retaining the daemon's
+    /// single-owner ordering. The transport worker remains free to poll and
+    /// reconnect while this future is running.
+    pub(crate) async fn execute_mqtt(
+        &mut self,
+        envelope: MqttInbound,
+        supervisor: &MqttSupervisor,
+    ) {
+        let started = Instant::now();
+        let id = envelope.id;
+        if let Some(message) = crate::mqtt::subscriber::parse_frame(&envelope.frame) {
+            // Do not cancel a side-effecting handler at an arbitrary wall-clock
+            // boundary. Its HTTP/RPC clients own their cancellation and retry
+            // semantics; cancelling here could replay a partially applied command.
+            self.server.handle_incoming(message).await;
+        }
+
+        let duration = started.elapsed();
+        if duration >= Duration::from_secs(10) {
+            error!(
+                command_id = id,
+                source = "mqtt",
+                duration_ms = duration.as_millis() as u64,
+                "MQTT business command exceeded 10s"
+            );
+        } else if duration >= Duration::from_secs(5) {
+            warn!(
+                command_id = id,
+                source = "mqtt",
+                duration_ms = duration.as_millis() as u64,
+                "MQTT business command exceeded 5s"
+            );
+        }
+
+        supervisor
+            .dispose_inbound(id, MqttInboundDisposition::Ack)
+            .await;
+    }
+}

--- a/apps/daemon/src/daemon/server/command_executor.rs
+++ b/apps/daemon/src/daemon/server/command_executor.rs
@@ -7,6 +7,7 @@
 
 use std::time::{Duration, Instant};
 
+use prost::Message;
 use tracing::{error, warn};
 
 use crate::mqtt::{MqttInbound, MqttInboundDisposition, MqttSupervisor};
@@ -15,6 +16,15 @@ use super::DaemonServer;
 
 pub(crate) struct DaemonCommandExecutor<'a> {
     server: &'a mut DaemonServer,
+}
+
+/// Result of the business side of a durable inbound message. The transport
+/// layer owns the durable ACK, so handlers must not ACK MQTT frames directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HandlerOutcome {
+    Success,
+    Retryable { reason: String },
+    Permanent { reason: String },
 }
 
 impl<'a> DaemonCommandExecutor<'a> {
@@ -29,15 +39,23 @@ impl<'a> DaemonCommandExecutor<'a> {
         &mut self,
         envelope: MqttInbound,
         supervisor: &MqttSupervisor,
-    ) {
+    ) -> HandlerOutcome {
         let started = Instant::now();
         let id = envelope.id;
-        if let Some(message) = crate::mqtt::subscriber::parse_frame(&envelope.frame) {
-            // Do not cancel a side-effecting handler at an arbitrary wall-clock
-            // boundary. Its HTTP/RPC clients own their cancellation and retry
-            // semantics; cancelling here could replay a partially applied command.
-            self.server.handle_incoming(message).await;
-        }
+        let outcome = if let Some(message) = crate::mqtt::subscriber::parse_frame(&envelope.frame) {
+            if let Err(reason) = validate_inbound_message(&message) {
+                HandlerOutcome::Permanent { reason }
+            } else {
+                // Do not cancel a side-effecting handler at an arbitrary wall-clock
+                // boundary. Its HTTP/RPC clients own their cancellation and retry
+                // semantics; cancelling here could replay a partially applied command.
+                self.server.handle_incoming(message).await
+            }
+        } else {
+            HandlerOutcome::Permanent {
+                reason: "unsupported or malformed MQTT inbound frame".to_string(),
+            }
+        };
 
         let duration = started.elapsed();
         if duration >= Duration::from_secs(10) {
@@ -56,8 +74,43 @@ impl<'a> DaemonCommandExecutor<'a> {
             );
         }
 
-        supervisor
-            .dispose_inbound(id, MqttInboundDisposition::Ack)
-            .await;
+        let disposition = match &outcome {
+            HandlerOutcome::Success => MqttInboundDisposition::Ack,
+            HandlerOutcome::Retryable { .. } => MqttInboundDisposition::Retry,
+            HandlerOutcome::Permanent { reason } => MqttInboundDisposition::DeadLetter {
+                reason: reason.clone(),
+            },
+        };
+        supervisor.dispose_inbound(id, disposition).await;
+        outcome
+    }
+}
+
+fn validate_inbound_message(
+    message: &crate::mqtt::subscriber::IncomingMessage,
+) -> Result<(), String> {
+    use crate::mqtt::subscriber::IncomingMessage;
+    match message {
+        IncomingMessage::RuntimeCommand { .. } => Ok(()),
+        IncomingMessage::TeamcluRpc { payload, .. } => {
+            crate::proto::teamclu::RpcRequest::decode(payload.as_slice())
+                .map(|_| ())
+                .map_err(|error| format!("invalid RpcRequest: {error}"))
+        }
+        IncomingMessage::TeamcluRpcResponse { payload, .. } => {
+            crate::proto::teamclu::RpcResponse::decode(payload.as_slice())
+                .map(|_| ())
+                .map_err(|error| format!("invalid RpcResponse: {error}"))
+        }
+        IncomingMessage::TeamcluSessionLive { payload, .. } => {
+            crate::proto::teamclu::LiveEventEnvelope::decode(payload.as_slice())
+                .map(|_| ())
+                .map_err(|error| format!("invalid LiveEventEnvelope: {error}"))
+        }
+        IncomingMessage::TeamcluNotify { payload, .. } => {
+            crate::proto::teamclu::Notify::decode(payload.as_slice())
+                .map(|_| ())
+                .map_err(|error| format!("invalid Notify: {error}"))
+        }
     }
 }

--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -100,12 +100,7 @@ impl DaemonServer {
             }
         };
 
-        let (
-            active_agent_type,
-            catalog_models,
-            live_sessions,
-            actor_available_commands,
-        ) = {
+        let (active_agent_type, catalog_models, live_sessions, actor_available_commands) = {
             let agents = self.agents.lock().await;
             (
                 agents.default_agent_type() as i32,

--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use crate::runtime::acp_event_frame::AcpEventFrame;
+use teamclu_transport::PublisherError;
 
 /// One-way latency probe (dev-only). When the daemon is started with
 /// AMUX_LATENCY_PROBE=1, outgoing ACP envelopes carry a `probe:<ms>` marker in
@@ -43,12 +44,12 @@ impl DaemonServer {
     /// `runtime/{id}/state` retains are no longer published — clients read
     /// `{actor}/state` only (ADR-0004 phase 7, iOS out of scope).
     pub(crate) async fn publish_runtime_state_by_id(&self, _agent_id: &str) {
-        self.publish_actor_state().await;
+        let _ = self.publish_actor_state().await;
     }
 
     /// Re-publish the actor snapshot on startup / MQTT reconnect.
     pub(crate) async fn publish_all_agent_states(&self) {
-        self.publish_actor_state().await;
+        let _ = self.publish_actor_state().await;
     }
 
     /// Publish the whole actor snapshot on the one retained topic this actor
@@ -64,7 +65,7 @@ impl DaemonServer {
     /// `apply_start_runtime` (which is why they never got a spawn-time retain),
     /// but they do live in `RuntimeManager.agents`, so they appear here as soon
     /// as this fires on attach.
-    pub(crate) async fn publish_actor_state(&self) {
+    pub(crate) async fn publish_actor_state(&self) -> Result<(), PublisherError> {
         let (default_workspace_id, default_worktree) =
             self.resolve_default_workspace_for_publish().await;
 
@@ -140,7 +141,7 @@ impl DaemonServer {
         };
 
         let publisher = Publisher::new_from_handle(self.publisher_handle.clone(), &self.topics);
-        let _ = publisher.publish_actor_presence(&state).await;
+        publisher.publish_actor_presence(&state).await
     }
 
     /// Returns the single collab session_id this runtime should publish
@@ -289,7 +290,7 @@ impl DaemonServer {
                 session.status = amux::AgentStatus::Error as i32;
                 let _ = self.sessions.save(&self.sessions_path);
             }
-            self.publish_actor_state().await;
+            let _ = self.publish_actor_state().await;
         }
 
         // Handle internal RawJson events (session_title, tool_title_update)

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -51,9 +51,13 @@ impl DaemonServer {
             "publishing RpcResponse"
         );
         if let Err(e) = self
-            .mqtt
-            .client
-            .publish(res_topic, rumqttc::QoS::AtLeastOnce, false, bytes)
+            .publisher_handle
+            .publish(
+                &res_topic,
+                bytes,
+                false,
+                teamclu_transport::DeliveryGuarantee::AtLeastOnce,
+            )
             .await
         {
             warn!("failed to publish RpcResponse: {}", e);

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -153,7 +153,10 @@ impl DaemonServer {
             .to_string()
     }
 
-    pub(crate) async fn handle_incoming(&mut self, msg: subscriber::IncomingMessage) {
+    pub(crate) async fn handle_incoming(
+        &mut self,
+        msg: subscriber::IncomingMessage,
+    ) -> super::command_executor::HandlerOutcome {
         use prost::Message as ProstMessage;
         match msg {
             subscriber::IncomingMessage::RuntimeCommand {
@@ -260,7 +263,9 @@ impl DaemonServer {
                                         err = %e,
                                         "SessionMessageEnvelope decode failed"
                                     );
-                                    return;
+                                    return super::command_executor::HandlerOutcome::Permanent {
+                                        reason: format!("invalid SessionMessageEnvelope: {e}"),
+                                    };
                                 }
                             };
                             let Some(msg) = env.message.as_ref() else {
@@ -272,7 +277,9 @@ impl DaemonServer {
                                     daemon_team_id = %daemon_team_id,
                                     "SessionMessageEnvelope without inner message; dropping"
                                 );
-                                return;
+                                return super::command_executor::HandlerOutcome::Permanent {
+                                    reason: "SessionMessageEnvelope has no message".to_string(),
+                                };
                             };
                             // Dedup is enforced centrally in
                             // `route_session_message_to_runtimes` (the single
@@ -295,7 +302,7 @@ impl DaemonServer {
                             {
                                 if let Some(tc) = &mut self.teamclu {
                                     if !tc.should_process_idea_event(&session_id, &event) {
-                                        return;
+                                        return super::command_executor::HandlerOutcome::Success;
                                     }
                                 }
                                 if let Some(tc) = &self.teamclu {
@@ -331,6 +338,10 @@ impl DaemonServer {
                         }
                         _ => {}
                     }
+                } else {
+                    return super::command_executor::HandlerOutcome::Permanent {
+                        reason: "invalid LiveEventEnvelope".to_string(),
+                    };
                 }
             }
             subscriber::IncomingMessage::TeamcluNotify { actor_id, payload } => {
@@ -357,6 +368,9 @@ impl DaemonServer {
                                                 session_id = %n.refresh_hint,
                                                 "failed to ingest cloud session after membership.refresh notify"
                                             );
+                                            return super::command_executor::HandlerOutcome::Retryable {
+                                                reason: format!("failed to ingest membership refresh: {err}"),
+                                            };
                                         }
                                     }
                                 }
@@ -367,16 +381,23 @@ impl DaemonServer {
                                         session_id = %n.refresh_hint,
                                         "failed to fetch cloud session after membership.refresh notify"
                                     );
+                                    return super::command_executor::HandlerOutcome::Retryable {
+                                        reason: format!("membership refresh fetch failed: {err}"),
+                                    };
                                 }
                             }
                         }
                     }
                     Err(err) => {
                         warn!(?err, "failed to decode actor notify payload as Notify");
+                        return super::command_executor::HandlerOutcome::Permanent {
+                            reason: format!("invalid Notify: {err}"),
+                        };
                     }
                 }
             }
         }
+        super::command_executor::HandlerOutcome::Success
     }
 
     /// Derive the caller's MemberRole via a cloud `agent_member_access`

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -425,7 +425,7 @@ impl DaemonServer {
             // Re-publish retained RuntimeInfo so clients that missed the
             // original retain (late subscribe, reconnect) still populate the
             // model picker without spawning a duplicate process.
-            self.publish_actor_state().await;
+            let _ = self.publish_actor_state().await;
             if !session_id.is_empty() {
                 if let Some(tc) = self.teamclu.as_mut() {
                     if let Err(e) = tc.ensure_session_live_subscription(session_id).await {
@@ -700,7 +700,7 @@ impl DaemonServer {
         let _ = self.sessions.save(&self.sessions_path);
 
         // ACTIVE — refresh the actor snapshot so clients see the attachment.
-        self.publish_actor_state().await;
+        let _ = self.publish_actor_state().await;
 
         // Replay any messages the runtime missed before it was spawned.
         // Uses Option B (event loop hook is not needed here because
@@ -801,7 +801,7 @@ impl DaemonServer {
         }
         // Detach: the session drops out of `live_sessions`, so clients render
         // it cold. Absence is the signal — there is no "stopped" entry.
-        self.publish_actor_state().await;
+        let _ = self.publish_actor_state().await;
     }
 
     pub(crate) async fn handle_start_runtime(
@@ -925,7 +925,7 @@ impl DaemonServer {
         // `agent_runtimes.current_model` this used to do is gone: the model
         // lives on the participant row and the actor snapshot (ADR-0004/0005).
         if success {
-            self.publish_actor_state().await;
+            let _ = self.publish_actor_state().await;
         }
 
         RpcResponse {

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -820,7 +820,6 @@ impl DaemonServer {
 
         let initial_model_override = runtime_start_initial_model_override(start);
 
-
         let outcome = self
             .apply_start_runtime(
                 at,

--- a/apps/daemon/src/device_id.rs
+++ b/apps/daemon/src/device_id.rs
@@ -47,7 +47,13 @@ const DEVICE_ID_ENV: &str = "AMUXD_DEVICE_ID";
 pub fn daemon_device_id() -> String {
     static CACHED: OnceLock<String> = OnceLock::new();
     CACHED
-        .get_or_init(|| resolve(std::env::var(DEVICE_ID_ENV).ok(), device_id_path(), machine_id()))
+        .get_or_init(|| {
+            resolve(
+                std::env::var(DEVICE_ID_ENV).ok(),
+                device_id_path(),
+                machine_id(),
+            )
+        })
         .clone()
 }
 
@@ -318,7 +324,10 @@ mod tests {
         let id = resolve(None, Some(path.clone()), Some(("linux", "raw".to_string())));
 
         assert_eq!(id, "legacy-random-id");
-        assert_eq!(std::fs::read_to_string(&path).unwrap(), "legacy-random-id\n");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "legacy-random-id\n"
+        );
     }
 
     /// The point of the change: losing the file recomputes the same id.
@@ -334,7 +343,10 @@ mod tests {
         std::fs::remove_file(&path).unwrap();
         let second = resolve(None, Some(path.clone()), machine());
 
-        assert_eq!(first, second, "a deleted cache must not rotate the identity");
+        assert_eq!(
+            first, second,
+            "a deleted cache must not rotate the identity"
+        );
     }
 
     /// Without a machine identity the daemon still has to work; it just loses
@@ -375,7 +387,10 @@ mod tests {
             return;
         };
         assert!(!platform.is_empty());
-        assert!(!raw.trim().is_empty(), "a blank raw id would hash to a constant");
+        assert!(
+            !raw.trim().is_empty(),
+            "a blank raw id would hash to a constant"
+        );
         let (_, again) = machine_id().expect("machine identity must not disappear between calls");
         assert_eq!(raw, again, "machine identity must be stable across calls");
     }

--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -372,14 +372,7 @@ async fn mqtt_recover(
     principal: super::auth::Principal,
     Json(body): Json<MqttRecoverBody>,
 ) -> Result<Json<crate::mqtt::MqttRecoveryAccepted>, super::errors::HttpError> {
-    if !peer.ip().is_loopback()
-        || !state
-            .config
-            .bind
-            .parse::<SocketAddr>()
-            .map(|addr| addr.ip().is_loopback())
-            .unwrap_or(false)
-    {
+    if !recovery_listener_allows(peer, &state.config.bind) {
         return Err(super::errors::HttpError::forbidden(
             "MQTT recovery is available only on the daemon loopback listener",
         ));
@@ -403,8 +396,50 @@ async fn mqtt_recover(
     Ok(Json(response))
 }
 
+fn recovery_listener_allows(peer: SocketAddr, bind: &str) -> bool {
+    peer.ip().is_loopback()
+        && bind
+            .parse::<SocketAddr>()
+            .map(|addr| addr.ip().is_loopback())
+            .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn mqtt_recovery_requires_loopback_peer_and_listener() {
+        assert!(recovery_listener_allows(
+            "127.0.0.1:40000".parse().unwrap(),
+            "127.0.0.1:0"
+        ));
+        assert!(recovery_listener_allows(
+            "[::1]:40000".parse().unwrap(),
+            "[::1]:0"
+        ));
+        assert!(!recovery_listener_allows(
+            "192.168.1.10:40000".parse().unwrap(),
+            "127.0.0.1:0"
+        ));
+        assert!(!recovery_listener_allows(
+            "127.0.0.1:40000".parse().unwrap(),
+            "0.0.0.0:0"
+        ));
+        assert!(!recovery_listener_allows(
+            "127.0.0.1:40000".parse().unwrap(),
+            "not-an-address"
+        ));
+    }
+
+    #[test]
+    fn mqtt_recovery_reasons_are_strictly_allowlisted() {
+        assert!(MqttRecoveryReason::parse("long_visibility_resume").is_some());
+        assert!(MqttRecoveryReason::parse("user_requested").is_some());
+        assert!(MqttRecoveryReason::parse("force_credential_refresh").is_none());
+        assert!(MqttRecoveryReason::parse("").is_none());
+    }
+
     /// Every capture in this router must use axum 0.7's `:name` form.
     ///
     /// matchit 0.7 treats `{name}` as a LITERAL path segment, so a route

--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -4,12 +4,13 @@
 //! `/v1/auth/*`, `/v1/sessions/*`, `/v1/sessions/:id/stream`, etc.
 
 use axum::{
-    extract::State,
+    extract::{ConnectInfo, State},
     middleware,
     response::Html,
     routing::{delete, get, post, put, MethodRouter},
     Json, Router,
 };
+use std::net::SocketAddr;
 
 use super::apps;
 use super::auth;
@@ -25,12 +26,14 @@ use super::state::HttpState;
 use super::team;
 use super::team_sync;
 use super::workspaces;
+use crate::mqtt::MqttRecoveryReason;
 
 pub fn build(state: HttpState) -> Router {
     let body_cap = state.config.max_body_bytes;
     Router::new()
         .route("/v1/healthz", healthz_route())
         .route("/v1/info", info_route())
+        .route("/v1/mqtt/recover", post(mqtt_recover))
         // Embedded protocol console. Static zero-dependency HTML inlined into
         // the binary; it drives this same daemon's /v1/sessions API over fetch
         // + SSE and shows every event frame for debugging. Auth is carried by
@@ -321,6 +324,7 @@ struct InfoBody {
     agent_types_advertise: crate::http::state::AgentTypesAdvertise,
     /// Whether the daemon's MQTT connection is currently established.
     mqtt_connected: bool,
+    mqtt: crate::mqtt::MqttSnapshot,
 }
 
 #[derive(serde::Serialize)]
@@ -341,6 +345,7 @@ async fn info_handler(State(state): State<HttpState>) -> Json<InfoBody> {
         .map(|h| CloudAuthInfo {
             status: if h.terminal_failure { "expired" } else { "ok" },
         });
+    let mqtt = state.meta.mqtt_snapshot.read().clone();
     Json(InfoBody {
         version: state.meta.version,
         started_at: state.meta.started_at,
@@ -351,11 +356,51 @@ async fn info_handler(State(state): State<HttpState>) -> Json<InfoBody> {
         cloud_auth,
         configured_agent_types: state.meta.configured_agent_types.clone(),
         agent_types_advertise: state.meta.agent_types_advertise.lock().clone(),
-        mqtt_connected: state
-            .meta
-            .mqtt_connected
-            .load(std::sync::atomic::Ordering::Relaxed),
+        mqtt_connected: mqtt.connected,
+        mqtt,
     })
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct MqttRecoverBody {
+    reason: String,
+}
+
+async fn mqtt_recover(
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    State(state): State<HttpState>,
+    principal: super::auth::Principal,
+    Json(body): Json<MqttRecoverBody>,
+) -> Result<Json<crate::mqtt::MqttRecoveryAccepted>, super::errors::HttpError> {
+    if !peer.ip().is_loopback()
+        || !state
+            .config
+            .bind
+            .parse::<SocketAddr>()
+            .map(|addr| addr.ip().is_loopback())
+            .unwrap_or(false)
+    {
+        return Err(super::errors::HttpError::forbidden(
+            "MQTT recovery is available only on the daemon loopback listener",
+        ));
+    }
+    super::auth::require_scope(&principal, "admin")?;
+    let reason = MqttRecoveryReason::parse(body.reason.trim())
+        .ok_or_else(|| super::errors::HttpError::validation("unknown MQTT recovery reason"))?;
+    let handle = state.meta.mqtt_recovery.as_ref().ok_or_else(|| {
+        super::errors::HttpError::runtime_unavailable("MQTT recovery supervisor is unavailable")
+    })?;
+    let response = handle.request(reason).await.map_err(|error| match error {
+        crate::mqtt::MqttRecoveryError::Unavailable => {
+            super::errors::HttpError::runtime_unavailable(
+                "MQTT recovery signal is busy or unavailable",
+            )
+        }
+        crate::mqtt::MqttRecoveryError::Timeout => super::errors::HttpError::runtime_unavailable(
+            "MQTT recovery supervisor did not acknowledge the signal",
+        ),
+    })?;
+    Ok(Json(response))
 }
 
 #[cfg(test)]

--- a/apps/daemon/src/http/server.rs
+++ b/apps/daemon/src/http/server.rs
@@ -160,10 +160,13 @@ pub async fn spawn(
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let join = tokio::spawn(async move {
-        let server =
-            axum::serve(listener, app.into_make_service()).with_graceful_shutdown(async move {
-                let _ = shutdown_rx.await;
-            });
+        let server = axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(async move {
+            let _ = shutdown_rx.await;
+        });
         if let Err(e) = server.await {
             tracing::error!("http listener exited with error: {e}");
         } else {
@@ -208,6 +211,10 @@ pub fn metadata(actor_id: String, backend_kind: impl Into<String>) -> DaemonMeta
         configured_agent_types: Vec::new(),
         agent_types_advertise: Default::default(),
         mqtt_connected: Default::default(),
+        mqtt_recovery: None,
+        mqtt_snapshot: std::sync::Arc::new(parking_lot::RwLock::new(
+            crate::mqtt::MqttSnapshot::default(),
+        )),
     }
 }
 

--- a/apps/daemon/src/http/state.rs
+++ b/apps/daemon/src/http/state.rs
@@ -5,7 +5,7 @@
 //! that need fine-grained pieces extract from this struct rather than
 //! introducing parallel statics.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use tokio::sync::{mpsc, oneshot};
@@ -92,6 +92,11 @@ pub struct DaemonMetadata {
     /// Whether the daemon's MQTT connection is currently established.
     /// Updated by the MQTT event loop; surfaced via `/v1/info`.
     pub mqtt_connected: Arc<AtomicBool>,
+    /// Generation-independent MQTT recovery signal exposed only to the local
+    /// daemon HTTP adapter. The receiver is attached when the supervisor starts.
+    pub mqtt_recovery: Option<crate::mqtt::MqttRecoveryHandle>,
+    /// A single coherent MQTT status snapshot for `/v1/info`.
+    pub mqtt_snapshot: crate::mqtt::MqttSnapshotHandle,
 }
 
 /// Outcome of the cloud `agents.agent_types` advertise. Surfaced via

--- a/apps/daemon/src/mqtt/client.rs
+++ b/apps/daemon/src/mqtt/client.rs
@@ -84,6 +84,10 @@ impl MqttClient {
         opts.set_credentials(username, password);
         opts.set_keep_alive(Duration::from_secs(30));
         opts.set_clean_session(true);
+        // The worker persists inbound frames before acknowledging them. This
+        // prevents a slow/full durable inbox from turning QoS1 delivery into
+        // an in-memory-only handoff.
+        opts.set_manual_acks(true);
         // ACP live events can carry full LLM chunks and tool-call payloads.
         // Match the desktop client so daemon-originated session/live publishes
         // do not trip rumqttc's 10 KiB default packet cap.

--- a/apps/daemon/src/mqtt/durable_queue.rs
+++ b/apps/daemon/src/mqtt/durable_queue.rs
@@ -366,6 +366,7 @@ fn for_each_log_line(
     let mut line = Vec::new();
     let mut line_start = 0_usize;
     let mut line_no = 1_usize;
+    let mut offset = 0_usize;
 
     loop {
         let buffer = reader.fill_buf()?;
@@ -400,6 +401,7 @@ fn for_each_log_line(
         let content_len = newline.unwrap_or(take);
         line.extend_from_slice(&buffer[..content_len]);
         reader.consume(take);
+        offset = offset.saturating_add(take);
 
         if has_newline {
             let text = String::from_utf8(std::mem::take(&mut line)).map_err(|error| {
@@ -415,7 +417,7 @@ fn for_each_log_line(
                 text,
                 is_final,
             })?;
-            line_start = line_start.saturating_add(take);
+            line_start = offset;
             line_no += 1;
         }
     }
@@ -1033,6 +1035,34 @@ mod tests {
             Err(error) => error,
         };
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn torn_tail_truncation_preserves_records_spanning_reader_buffers() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = LogRecord::Put {
+            id: 1,
+            item: DurableInbound {
+                topic: "amux/team/actor/notify".into(),
+                payload: vec![7; 10_000],
+                retained: false,
+                message_id: Some("large-record".into()),
+            },
+        };
+        let first_line = format!("{}\n", serde_json::to_string(&first).unwrap());
+        let mut contents = first_line.as_bytes().to_vec();
+        contents.extend_from_slice(b"{\"Put\":{\"id\":2,\"item\":");
+        std::fs::write(dir.path().join("inbox.log"), contents).unwrap();
+
+        let reopened = DurableMqttStore::open_at(dir.path()).unwrap();
+        assert_eq!(reopened.inbound_len(), 1);
+        assert_eq!(reopened.inbound(1).unwrap().payload.len(), 10_000);
+        assert_eq!(
+            std::fs::metadata(dir.path().join("inbox.log"))
+                .unwrap()
+                .len(),
+            first_line.len() as u64
+        );
     }
 
     #[test]

--- a/apps/daemon/src/mqtt/durable_queue.rs
+++ b/apps/daemon/src/mqtt/durable_queue.rs
@@ -4,7 +4,7 @@
 //! can therefore be rebuilt without losing messages that were accepted by the
 //! daemon but had not reached the broker (or the business executor) yet.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -13,10 +13,21 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use teamclu_transport::{DeliveryGuarantee, IncomingFrame};
 
 const COMPACT_AFTER_OPS: usize = 128;
+const MAX_DURABLE_LOG_LINE_BYTES: usize = 8 * 1024 * 1024;
+const DEAD_LETTER_MAX_ENTRIES: usize = 1024;
+const DEAD_LETTER_MAX_BYTES: usize = 16 * 1024 * 1024;
+const DEAD_LETTER_MAX_REASON_BYTES: usize = 4 * 1024;
 
 struct DurableDedup {
     path: PathBuf,
-    keys: std::collections::HashSet<String>,
+    keys: HashSet<String>,
+    ops_since_compact: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum DedupRecord {
+    Insert { key: String },
+    Remove { key: String },
 }
 
 impl DurableDedup {
@@ -24,36 +35,50 @@ impl DurableDedup {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let mut keys = std::collections::HashSet::new();
+        let mut keys = HashSet::new();
         if path.is_file() {
-            let file = File::open(&path)?;
-            let mut lines = BufReader::new(file).lines().peekable();
-            let mut line_no = 0;
-            while let Some(line) = lines.next() {
-                line_no += 1;
-                let line = line?;
+            for_each_log_line(&path, |line| {
                 if line.trim().is_empty() {
-                    continue;
+                    return Ok(());
                 }
-                match serde_json::from_str::<String>(&line) {
-                    Ok(key) => {
+                match serde_json::from_str::<DedupRecord>(line.trim()) {
+                    Ok(DedupRecord::Insert { key }) => {
                         keys.insert(key);
                     }
-                    Err(error) if lines.peek().is_none() => {
-                        tracing::warn!(path = %path.display(), %error, "ignoring torn final MQTT dedup record");
+                    Ok(DedupRecord::Remove { key }) => {
+                        keys.remove(&key);
                     }
-                    Err(error) => {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!(
-                                "malformed durable MQTT dedup record at line {line_no}: {error}"
-                            ),
-                        ));
-                    }
+                    Err(record_error) => match serde_json::from_str::<String>(line.trim()) {
+                        // Older builds wrote the key directly. Keep those
+                        // records readable while the next compaction upgrades
+                        // the file to the insert/remove format.
+                        Ok(key) => {
+                            keys.insert(key);
+                        }
+                        Err(legacy_error) if line.is_final => {
+                            let error = format!("{record_error}; {legacy_error}");
+                            truncate_torn_tail(&path, line.start)?;
+                            tracing::warn!(path = %path.display(), %error, "ignoring torn final MQTT dedup record");
+                        }
+                        Err(legacy_error) => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!(
+                                    "malformed durable MQTT dedup record at line {}: {record_error}; {legacy_error}",
+                                    line.line_no
+                                ),
+                            ));
+                        }
+                    },
                 }
-            }
+                Ok(())
+            })?;
         }
-        Ok(Self { path, keys })
+        Ok(Self {
+            path,
+            keys,
+            ops_since_compact: 0,
+        })
     }
 
     fn contains(&self, key: &str) -> bool {
@@ -64,8 +89,39 @@ impl DurableDedup {
         if self.keys.contains(&key) {
             return Ok(());
         }
-        let encoded = serde_json::to_vec(&key)
+        self.append_record(&DedupRecord::Insert { key: key.clone() })?;
+        self.keys.insert(key);
+        self.compact_if_needed()
+    }
+
+    fn remove(&mut self, key: &str) -> io::Result<()> {
+        if !self.keys.contains(key) {
+            return Ok(());
+        }
+        self.append_record(&DedupRecord::Remove {
+            key: key.to_string(),
+        })?;
+        self.keys.remove(key);
+        self.compact_if_needed()
+    }
+
+    fn reconcile(&mut self, pending_keys: HashSet<String>) -> io::Result<()> {
+        if self.keys == pending_keys {
+            return Ok(());
+        }
+        self.keys = pending_keys;
+        self.compact()
+    }
+
+    fn append_record(&mut self, record: &DedupRecord) -> io::Result<()> {
+        let encoded = serde_json::to_vec(record)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        if encoded.len() > MAX_DURABLE_LOG_LINE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("durable MQTT dedup record exceeds {MAX_DURABLE_LOG_LINE_BYTES} bytes"),
+            ));
+        }
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -73,8 +129,40 @@ impl DurableDedup {
         file.write_all(&encoded)?;
         file.write_all(b"\n")?;
         file.sync_data()?;
-        self.keys.insert(key);
+        self.ops_since_compact += 1;
         Ok(())
+    }
+
+    fn compact_if_needed(&mut self) -> io::Result<()> {
+        if self.ops_since_compact < COMPACT_AFTER_OPS
+            || self.ops_since_compact < self.keys.len().max(1)
+        {
+            return Ok(());
+        }
+        self.compact()
+    }
+
+    fn compact(&mut self) -> io::Result<()> {
+        let temp_path = self.path.with_extension("log.tmp");
+        let result = (|| {
+            let mut file = File::create(&temp_path)?;
+            for key in &self.keys {
+                let encoded = serde_json::to_vec(&DedupRecord::Insert { key: key.clone() })
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+                file.write_all(&encoded)?;
+                file.write_all(b"\n")?;
+            }
+            file.sync_all()?;
+            std::fs::rename(&temp_path, &self.path)?;
+            sync_parent_directory(self.path.parent())?;
+            Ok::<(), io::Error>(())
+        })();
+        if result.is_ok() {
+            self.ops_since_compact = 0;
+        } else {
+            let _ = std::fs::remove_file(&temp_path);
+        }
+        result
     }
 }
 
@@ -82,6 +170,7 @@ impl DurableDedup {
 enum LogRecord<T> {
     Put { id: u64, item: T },
     Ack { id: u64 },
+    Watermark { next_id: u64 },
 }
 
 /// A durable FIFO-ish queue. Ordering is recovered by the monotonically
@@ -105,40 +194,35 @@ where
         let mut entries = BTreeMap::new();
         let mut next_id = 1_u64;
         if path.is_file() {
-            let file = File::open(&path)?;
-            let reader = BufReader::new(file);
-            let mut lines = reader.lines().peekable();
-            let mut line_no = 0;
-            while let Some(line) = lines.next() {
-                line_no += 1;
-                let line = line?;
+            for_each_log_line(&path, |line| {
                 if line.trim().is_empty() {
-                    continue;
+                    return Ok(());
                 }
-                let record = match serde_json::from_str::<LogRecord<T>>(&line) {
+                let record = match serde_json::from_str::<LogRecord<T>>(line.trim()) {
                     Ok(record) => record,
+                    Err(error) if line.is_final => {
+                        truncate_torn_tail(&path, line.start)?;
+                        tracing::warn!(
+                            path = %path.display(),
+                            line = line.line_no,
+                            %error,
+                            "ignoring torn final durable MQTT queue record"
+                        );
+                        return Ok(());
+                    }
                     Err(error) => {
                         // A process can be killed while appending the final
                         // line. Only that torn tail is recoverable. A
                         // malformed record with later records means the log
                         // is damaged in the middle and must not silently drop
                         // a durable message.
-                        if lines.peek().is_some() {
-                            return Err(io::Error::new(
-                                io::ErrorKind::InvalidData,
-                                format!(
-                                    "malformed durable queue record at line {}: {}",
-                                    line_no, error
-                                ),
-                            ));
-                        }
-                        tracing::warn!(
-                            path = %path.display(),
-                            line = line_no,
-                            %error,
-                            "ignoring torn final durable MQTT queue record"
-                        );
-                        continue;
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "malformed durable queue record at line {}: {}",
+                                line.line_no, error
+                            ),
+                        ));
                     }
                 };
                 match record {
@@ -149,8 +233,14 @@ where
                     LogRecord::Ack { id } => {
                         entries.remove(&id);
                     }
+                    LogRecord::Watermark {
+                        next_id: high_water_mark,
+                    } => {
+                        next_id = next_id.max(high_water_mark);
+                    }
                 }
-            }
+                Ok(())
+            })?;
         }
 
         Ok(Self {
@@ -164,6 +254,12 @@ where
     fn append_record(&mut self, record: &LogRecord<T>) -> io::Result<()> {
         let encoded = serde_json::to_vec(record)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        if encoded.len() > MAX_DURABLE_LOG_LINE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("durable MQTT queue record exceeds {MAX_DURABLE_LOG_LINE_BYTES} bytes"),
+            ));
+        }
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -220,6 +316,13 @@ where
         let temp_path = self.path.with_extension("log.tmp");
         let result = (|| {
             let mut file = File::create(&temp_path)?;
+            let watermark = LogRecord::<T>::Watermark {
+                next_id: self.next_id,
+            };
+            let encoded = serde_json::to_vec(&watermark)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+            file.write_all(&encoded)?;
+            file.write_all(b"\n")?;
             for (&id, item) in &self.entries {
                 let record = LogRecord::Put { id, item };
                 let encoded = serde_json::to_vec(&record)
@@ -229,6 +332,7 @@ where
             }
             file.sync_all()?;
             std::fs::rename(&temp_path, &self.path)?;
+            sync_parent_directory(self.path.parent())?;
             Ok::<(), io::Error>(())
         })();
         if result.is_ok() {
@@ -238,6 +342,103 @@ where
         }
         result
     }
+}
+
+struct LogLine {
+    line_no: usize,
+    start: usize,
+    text: String,
+    is_final: bool,
+}
+
+impl LogLine {
+    fn trim(&self) -> &str {
+        self.text.trim()
+    }
+}
+
+fn for_each_log_line(
+    path: &Path,
+    mut callback: impl FnMut(&LogLine) -> io::Result<()>,
+) -> io::Result<()> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut line = Vec::new();
+    let mut line_start = 0_usize;
+    let mut line_no = 1_usize;
+
+    loop {
+        let buffer = reader.fill_buf()?;
+        if buffer.is_empty() {
+            if line.is_empty() {
+                break;
+            }
+            let text = String::from_utf8(std::mem::take(&mut line)).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid UTF-8 in durable log line {line_no}: {error}"),
+                )
+            })?;
+            callback(&LogLine {
+                line_no,
+                start: line_start,
+                text,
+                is_final: true,
+            })?;
+            break;
+        }
+
+        let newline = buffer.iter().position(|byte| *byte == b'\n');
+        let take = newline.map_or(buffer.len(), |position| position + 1);
+        if line.len().saturating_add(take) > MAX_DURABLE_LOG_LINE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("durable log line {line_no} exceeds {MAX_DURABLE_LOG_LINE_BYTES} bytes"),
+            ));
+        }
+        let has_newline = newline.is_some();
+        let content_len = newline.unwrap_or(take);
+        line.extend_from_slice(&buffer[..content_len]);
+        reader.consume(take);
+
+        if has_newline {
+            let text = String::from_utf8(std::mem::take(&mut line)).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid UTF-8 in durable log line {line_no}: {error}"),
+                )
+            })?;
+            let is_final = reader.fill_buf()?.is_empty();
+            callback(&LogLine {
+                line_no,
+                start: line_start,
+                text,
+                is_final,
+            })?;
+            line_start = line_start.saturating_add(take);
+            line_no += 1;
+        }
+    }
+    Ok(())
+}
+
+fn truncate_torn_tail(path: &Path, offset: usize) -> io::Result<()> {
+    let file = OpenOptions::new().write(true).open(path)?;
+    file.set_len(offset as u64)?;
+    file.sync_data()
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(parent: Option<&Path>) -> io::Result<()> {
+    let Some(parent) = parent else {
+        return Ok(());
+    };
+    File::open(parent)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_parent: Option<&Path>) -> io::Result<()> {
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -309,11 +510,53 @@ impl DurableMqttStore {
     pub(crate) fn open_at(dir: impl AsRef<Path>) -> io::Result<Self> {
         let dir = dir.as_ref();
         std::fs::create_dir_all(dir)?;
+        let inbox: DurableQueue<DurableInbound> = DurableQueue::open(dir.join("inbox.log"))?;
+        let outbox: DurableQueue<DurablePublish> = DurableQueue::open(dir.join("outbox.log"))?;
+        let dead_letter: DurableQueue<DurableDeadLetter> =
+            DurableQueue::open(dir.join("dead-letter.log"))?;
+
+        // A crash can leave the dead-letter Put durable while its inbox ACK is
+        // still missing. Reconcile that terminal transition on reopen before
+        // replaying the inbox, otherwise a poison message is executed again.
+        let orphaned_inbox_ids = inbox
+            .values()
+            .filter(|(_, inbound)| {
+                dead_letter
+                    .values()
+                    .any(|(_, item)| same_inbound(inbound, &item.inbound))
+            })
+            .map(|(id, _)| id)
+            .collect::<Vec<_>>();
+        let mut inbox = inbox;
+        for id in orphaned_inbox_ids {
+            inbox.ack(id)?;
+        }
+        let mut inbound_dedup = DurableDedup::open(dir.join("inbox-dedup.log"))?;
+
+        // Rebuild the dedup index from pending inbox entries as well as its
+        // append-only log. This closes the crash window between the inbox Put
+        // record and the dedup record: a redelivery after that window must not
+        // create a second durable item.
+        let pending_keys = inbox
+            .values()
+            .filter_map(|(_, item)| {
+                item.message_id
+                    .as_ref()
+                    .map(|message_id| format!("{}:{message_id}", item.topic))
+            })
+            .collect();
+        // Deduplication is needed for messages that are still inside the
+        // inbox. Keeping acknowledged ids forever turns this index into an
+        // unbounded history and eventually becomes a disk/memory outage.
+        // Reconcile from the inbox on every reopen so a crash between inbox
+        // ACK and dedup removal also self-heals.
+        inbound_dedup.reconcile(pending_keys)?;
+
         Ok(Self {
-            inbox: DurableQueue::open(dir.join("inbox.log"))?,
-            outbox: DurableQueue::open(dir.join("outbox.log"))?,
-            dead_letter: DurableQueue::open(dir.join("dead-letter.log"))?,
-            inbound_dedup: DurableDedup::open(dir.join("inbox-dedup.log"))?,
+            inbox,
+            outbox,
+            dead_letter,
+            inbound_dedup,
         })
     }
 
@@ -331,6 +574,13 @@ impl DurableMqttStore {
         {
             return Ok(None);
         }
+        if message_id.as_deref().is_some_and(|message_id| {
+            self.inbox.values().any(|(_, inbound)| {
+                inbound.topic == frame.topic && inbound.message_id.as_deref() == Some(message_id)
+            })
+        }) {
+            return Ok(None);
+        }
         let id = self.inbox.put(DurableInbound {
             topic: frame.topic,
             payload: frame.payload,
@@ -344,7 +594,16 @@ impl DurableMqttStore {
     }
 
     pub(crate) fn ack_inbound(&mut self, id: u64) -> io::Result<()> {
-        self.inbox.ack(id)
+        let dedup_key = self.inbox.get(id).and_then(|item| {
+            item.message_id
+                .as_ref()
+                .map(|message_id| format!("{}:{message_id}", item.topic))
+        });
+        self.inbox.ack(id)?;
+        if let Some(key) = dedup_key {
+            self.inbound_dedup.remove(&key)?;
+        }
+        Ok(())
     }
 
     /// Persist a terminally rejected inbound before removing it from the
@@ -354,9 +613,55 @@ impl DurableMqttStore {
         let Some(inbound) = self.inbox.get(id).cloned() else {
             return Ok(());
         };
+        if self
+            .dead_letter
+            .values()
+            .any(|(_, item)| same_inbound(&inbound, &item.inbound))
+        {
+            self.inbox.ack(id)?;
+            if let Some(message_id) = inbound.message_id.as_ref() {
+                self.inbound_dedup
+                    .remove(&format!("{}:{message_id}", inbound.topic))?;
+            }
+            return Ok(());
+        }
+        let dead_letter = DurableDeadLetter {
+            inbound,
+            reason: truncate_reason(reason),
+        };
+        let incoming_bytes = dead_letter_bytes(&dead_letter);
+        if incoming_bytes > DEAD_LETTER_MAX_BYTES {
+            tracing::warn!(
+                id,
+                incoming_bytes,
+                max_bytes = DEAD_LETTER_MAX_BYTES,
+                "dropping oversized MQTT dead-letter item after durable inbox admission"
+            );
+            return self.ack_inbound(id);
+        }
+        while self.dead_letter.len() >= DEAD_LETTER_MAX_ENTRIES
+            || self.dead_letter_bytes().saturating_add(incoming_bytes) > DEAD_LETTER_MAX_BYTES
+        {
+            let Some((oldest_id, _)) = self.dead_letter.values().next() else {
+                break;
+            };
+            self.dead_letter.ack(oldest_id)?;
+            tracing::warn!(
+                oldest_id,
+                max_entries = DEAD_LETTER_MAX_ENTRIES,
+                max_bytes = DEAD_LETTER_MAX_BYTES,
+                "evicted oldest MQTT dead-letter item"
+            );
+        }
+        self.dead_letter.put(dead_letter)?;
+        self.ack_inbound(id)
+    }
+
+    fn dead_letter_bytes(&self) -> usize {
         self.dead_letter
-            .put(DurableDeadLetter { inbound, reason })?;
-        self.inbox.ack(id)
+            .values()
+            .map(|(_, item)| dead_letter_bytes(item))
+            .sum()
     }
 
     pub(crate) fn inbound(&self, id: u64) -> Option<&DurableInbound> {
@@ -378,7 +683,13 @@ impl DurableMqttStore {
         self.inbox.values()
     }
 
-    pub(crate) fn enqueue_publish(&mut self, publish: DurablePublish) -> io::Result<u64> {
+    pub(crate) fn enqueue_publish(&mut self, mut publish: DurablePublish) -> io::Result<u64> {
+        // The local queue id is an ordering cursor, not an event identity. A
+        // UUID survives generation rebuilds and process restarts, so an
+        // at-least-once consumer can deduplicate a replayed publish.
+        if publish.event_id.is_none() {
+            publish.event_id = Some(uuid::Uuid::new_v4().to_string());
+        }
         self.outbox.put(publish)
     }
 
@@ -409,6 +720,33 @@ impl DurableMqttStore {
     fn dead_letter_len(&self) -> usize {
         self.dead_letter.len()
     }
+}
+
+fn same_inbound(left: &DurableInbound, right: &DurableInbound) -> bool {
+    left.topic == right.topic
+        && left.payload == right.payload
+        && left.retained == right.retained
+        && left.message_id == right.message_id
+}
+
+fn dead_letter_bytes(item: &DurableDeadLetter) -> usize {
+    item.inbound.topic.len()
+        + item.inbound.payload.len()
+        + item.reason.len()
+        + item.inbound.message_id.as_ref().map_or(0, String::len)
+}
+
+fn truncate_reason(mut reason: String) -> String {
+    if reason.len() <= DEAD_LETTER_MAX_REASON_BYTES {
+        return reason;
+    }
+    let mut end = DEAD_LETTER_MAX_REASON_BYTES.saturating_sub(3);
+    while !reason.is_char_boundary(end) {
+        end = end.saturating_sub(1);
+    }
+    reason.truncate(end);
+    reason.push_str("...");
+    reason
 }
 
 #[cfg(test)]
@@ -460,6 +798,205 @@ mod tests {
     }
 
     #[test]
+    fn replay_preserves_fifo_ids_and_outbox_event_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
+        let first = store
+            .enqueue_inbound(
+                IncomingFrame {
+                    topic: "amux/team/actor/notify".into(),
+                    payload: vec![1],
+                    retained: false,
+                },
+                Some("in-1".into()),
+            )
+            .unwrap()
+            .unwrap();
+        let second = store
+            .enqueue_inbound(
+                IncomingFrame {
+                    topic: "amux/team/actor/notify".into(),
+                    payload: vec![2],
+                    retained: false,
+                },
+                Some("in-2".into()),
+            )
+            .unwrap()
+            .unwrap();
+        let third = store
+            .enqueue_inbound(
+                IncomingFrame {
+                    topic: "amux/team/actor/notify".into(),
+                    payload: vec![3],
+                    retained: false,
+                },
+                Some("in-3".into()),
+            )
+            .unwrap()
+            .unwrap();
+        store.ack_inbound(second).unwrap();
+
+        let outbox_id = store
+            .enqueue_publish(DurablePublish {
+                topic: "amux/team/actor/state".into(),
+                payload: vec![7],
+                retain: true,
+                delivery: StoredDelivery::AtLeastOnce,
+                event_id: None,
+            })
+            .unwrap();
+        let event_id = store.outbox(outbox_id).unwrap().event_id.clone();
+        assert!(event_id.is_some());
+
+        let reopened = DurableMqttStore::open_at(dir.path()).unwrap();
+        assert_eq!(
+            reopened
+                .pending_inbound()
+                .map(|(id, _)| id)
+                .collect::<Vec<_>>(),
+            vec![first, third]
+        );
+        assert_eq!(reopened.outbox(outbox_id).unwrap().event_id, event_id);
+    }
+
+    #[test]
+    fn pending_inbox_rebuilds_dedup_after_put_before_dedup_crash_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = LogRecord::Put {
+            id: 1,
+            item: DurableInbound {
+                topic: "amux/team/actor/notify".into(),
+                payload: vec![8],
+                retained: false,
+                message_id: Some("crash-window-1".into()),
+            },
+        };
+        std::fs::write(
+            dir.path().join("inbox.log"),
+            format!("{}\n", serde_json::to_string(&inbox).unwrap()),
+        )
+        .unwrap();
+
+        let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
+        let duplicate = store
+            .enqueue_inbound(
+                IncomingFrame {
+                    topic: "amux/team/actor/notify".into(),
+                    payload: vec![8],
+                    retained: false,
+                },
+                Some("crash-window-1".into()),
+            )
+            .unwrap();
+        assert_eq!(duplicate, None);
+        assert_eq!(store.inbound_len(), 1);
+    }
+
+    #[test]
+    fn ack_compacts_log_without_changing_recovered_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
+        let mut ids = Vec::new();
+        for value in 0..130u8 {
+            ids.push(
+                store
+                    .enqueue_inbound(
+                        IncomingFrame {
+                            topic: "amux/team/actor/notify".into(),
+                            payload: vec![value],
+                            retained: false,
+                        },
+                        Some(format!("compact-{value}")),
+                    )
+                    .unwrap()
+                    .unwrap(),
+            );
+        }
+        for id in ids {
+            store.ack_inbound(id).unwrap();
+        }
+
+        let log_len = std::fs::metadata(dir.path().join("inbox.log"))
+            .unwrap()
+            .len();
+        assert!(log_len < 256, "ACK compaction did not shrink the log");
+        assert_eq!(
+            DurableMqttStore::open_at(dir.path()).unwrap().inbound_len(),
+            0
+        );
+    }
+
+    #[test]
+    fn queue_compaction_preserves_high_water_mark_for_late_acks() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
+        let mut last_id = 0;
+        for value in 0..64u8 {
+            let id = store
+                .enqueue_inbound(
+                    IncomingFrame {
+                        topic: "amux/team/actor/notify".into(),
+                        payload: vec![value],
+                        retained: false,
+                    },
+                    Some(format!("watermark-{value}")),
+                )
+                .unwrap()
+                .unwrap();
+            last_id = id;
+            store.ack_inbound(id).unwrap();
+        }
+
+        let mut reopened = DurableMqttStore::open_at(dir.path()).unwrap();
+        let new_id = reopened
+            .enqueue_inbound(
+                IncomingFrame {
+                    topic: "amux/team/actor/notify".into(),
+                    payload: vec![99],
+                    retained: false,
+                },
+                Some("watermark-new".into()),
+            )
+            .unwrap()
+            .unwrap();
+        assert!(new_id > last_id);
+        // An ACK from the old generation must not be able to target this item.
+        reopened.ack_inbound(last_id).unwrap();
+        assert!(reopened.inbound(new_id).is_some());
+    }
+
+    #[test]
+    fn acknowledged_inbound_ids_do_not_grow_the_dedup_log_forever() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
+        for value in 0..128u16 {
+            let id = store
+                .enqueue_inbound(
+                    IncomingFrame {
+                        topic: "amux/team/actor/notify".into(),
+                        payload: value.to_le_bytes().to_vec(),
+                        retained: false,
+                    },
+                    Some(format!("dedup-compact-{value}")),
+                )
+                .unwrap()
+                .unwrap();
+            store.ack_inbound(id).unwrap();
+        }
+
+        let dedup_path = dir.path().join("inbox-dedup.log");
+        assert!(
+            std::fs::metadata(&dedup_path).unwrap().len() < 256,
+            "acknowledged dedup ids must be compacted"
+        );
+        assert_eq!(store.inbound_len(), 0);
+        assert_eq!(
+            DurableMqttStore::open_at(dir.path()).unwrap().inbound_len(),
+            0
+        );
+    }
+
+    #[test]
     fn delivery_round_trips_without_using_transport_types_on_disk() {
         for value in [
             DeliveryGuarantee::AtMostOnce,
@@ -475,7 +1012,20 @@ mod tests {
     fn only_a_torn_final_record_is_ignored_during_recovery() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("inbox.log"), b"not-json\n").unwrap();
-        assert!(DurableMqttStore::open_at(dir.path()).is_ok());
+        let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
+        let id = store
+            .enqueue_inbound(
+                IncomingFrame {
+                    topic: "amux/team/actor/notify".into(),
+                    payload: vec![1],
+                    retained: false,
+                },
+                Some("after-torn-tail".into()),
+            )
+            .unwrap()
+            .unwrap();
+        let reopened = DurableMqttStore::open_at(dir.path()).unwrap();
+        assert!(reopened.inbound(id).is_some());
 
         std::fs::write(dir.path().join("inbox.log"), b"not-json\n{}\n").unwrap();
         let error = match DurableMqttStore::open_at(dir.path()) {
@@ -532,12 +1082,54 @@ mod tests {
     }
 
     #[test]
+    fn dead_letter_retention_is_bounded() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
+        for value in 0..=DEAD_LETTER_MAX_ENTRIES {
+            let id = store
+                .enqueue_inbound(
+                    IncomingFrame {
+                        topic: "amux/team/actor/notify".into(),
+                        payload: value.to_le_bytes().to_vec(),
+                        retained: false,
+                    },
+                    Some(format!("dead-letter-{value}")),
+                )
+                .unwrap()
+                .unwrap();
+            store
+                .dead_letter_inbound(id, "poison message".repeat(2_000))
+                .unwrap();
+        }
+
+        assert_eq!(store.dead_letter_len(), DEAD_LETTER_MAX_ENTRIES);
+        assert!(
+            std::fs::metadata(dir.path().join("dead-letter.log"))
+                .unwrap()
+                .len()
+                <= (DEAD_LETTER_MAX_BYTES as u64 * 2),
+            "dead-letter log must remain bounded between compactions"
+        );
+    }
+
+    #[test]
     fn dedup_torn_tail_is_recoverable_but_middle_corruption_is_not() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("inbox-dedup.log");
         std::fs::write(&path, b"\"ok\"\n\"torn").unwrap();
-        let store = DurableMqttStore::open_at(dir.path()).unwrap();
+        let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
         assert!(store.inbound_len() == 0);
+        store
+            .enqueue_inbound(
+                IncomingFrame {
+                    topic: "amux/team/actor/notify".into(),
+                    payload: vec![2],
+                    retained: false,
+                },
+                Some("after-dedup-tail".into()),
+            )
+            .unwrap();
+        assert!(!std::fs::read_to_string(&path).unwrap().contains("torn"));
 
         std::fs::write(&path, b"\"ok\"\nnot-json\n\"later\"\n").unwrap();
         let error = match DurableMqttStore::open_at(dir.path()) {
@@ -545,5 +1137,47 @@ mod tests {
             Err(error) => error,
         };
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn reopen_reconciles_a_dead_letter_put_without_its_inbox_ack() {
+        let dir = tempfile::tempdir().unwrap();
+        let inbound = DurableInbound {
+            topic: "amux/team/actor/notify".into(),
+            payload: vec![3],
+            retained: false,
+            message_id: Some("poison-crash-1".into()),
+        };
+        std::fs::write(
+            dir.path().join("inbox.log"),
+            format!(
+                "{}\n",
+                serde_json::to_string(&LogRecord::Put {
+                    id: 1,
+                    item: inbound.clone(),
+                })
+                .unwrap()
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("dead-letter.log"),
+            format!(
+                "{}\n",
+                serde_json::to_string(&LogRecord::Put {
+                    id: 1,
+                    item: DurableDeadLetter {
+                        inbound,
+                        reason: "poison".into(),
+                    },
+                })
+                .unwrap()
+            ),
+        )
+        .unwrap();
+
+        let store = DurableMqttStore::open_at(dir.path()).unwrap();
+        assert_eq!(store.inbound_len(), 0);
+        assert_eq!(store.dead_letter_len(), 1);
     }
 }

--- a/apps/daemon/src/mqtt/durable_queue.rs
+++ b/apps/daemon/src/mqtt/durable_queue.rs
@@ -14,6 +14,70 @@ use teamclu_transport::{DeliveryGuarantee, IncomingFrame};
 
 const COMPACT_AFTER_OPS: usize = 128;
 
+struct DurableDedup {
+    path: PathBuf,
+    keys: std::collections::HashSet<String>,
+}
+
+impl DurableDedup {
+    fn open(path: PathBuf) -> io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut keys = std::collections::HashSet::new();
+        if path.is_file() {
+            let file = File::open(&path)?;
+            let mut lines = BufReader::new(file).lines().peekable();
+            let mut line_no = 0;
+            while let Some(line) = lines.next() {
+                line_no += 1;
+                let line = line?;
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<String>(&line) {
+                    Ok(key) => {
+                        keys.insert(key);
+                    }
+                    Err(error) if lines.peek().is_none() => {
+                        tracing::warn!(path = %path.display(), %error, "ignoring torn final MQTT dedup record");
+                    }
+                    Err(error) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "malformed durable MQTT dedup record at line {line_no}: {error}"
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(Self { path, keys })
+    }
+
+    fn contains(&self, key: &str) -> bool {
+        self.keys.contains(key)
+    }
+
+    fn insert(&mut self, key: String) -> io::Result<()> {
+        if self.keys.contains(&key) {
+            return Ok(());
+        }
+        let encoded = serde_json::to_vec(&key)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        file.write_all(&encoded)?;
+        file.write_all(b"\n")?;
+        file.sync_data()?;
+        self.keys.insert(key);
+        Ok(())
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 enum LogRecord<T> {
     Put { id: u64, item: T },
@@ -181,6 +245,8 @@ pub(crate) struct DurableInbound {
     pub(crate) topic: String,
     pub(crate) payload: Vec<u8>,
     pub(crate) retained: bool,
+    #[serde(default)]
+    pub(crate) message_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -189,6 +255,16 @@ pub(crate) struct DurablePublish {
     pub(crate) payload: Vec<u8>,
     pub(crate) retain: bool,
     pub(crate) delivery: StoredDelivery,
+    /// Optional protocol event id retained for diagnostics and downstream
+    /// idempotency. The payload remains the source of truth for old records.
+    #[serde(default)]
+    pub(crate) event_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct DurableDeadLetter {
+    pub(crate) inbound: DurableInbound,
+    pub(crate) reason: String,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -221,6 +297,8 @@ impl From<StoredDelivery> for DeliveryGuarantee {
 pub(crate) struct DurableMqttStore {
     inbox: DurableQueue<DurableInbound>,
     outbox: DurableQueue<DurablePublish>,
+    dead_letter: DurableQueue<DurableDeadLetter>,
+    inbound_dedup: DurableDedup,
 }
 
 impl DurableMqttStore {
@@ -234,18 +312,50 @@ impl DurableMqttStore {
         Ok(Self {
             inbox: DurableQueue::open(dir.join("inbox.log"))?,
             outbox: DurableQueue::open(dir.join("outbox.log"))?,
+            dead_letter: DurableQueue::open(dir.join("dead-letter.log"))?,
+            inbound_dedup: DurableDedup::open(dir.join("inbox-dedup.log"))?,
         })
     }
 
-    pub(crate) fn enqueue_inbound(&mut self, frame: IncomingFrame) -> io::Result<u64> {
-        self.inbox.put(DurableInbound {
+    pub(crate) fn enqueue_inbound(
+        &mut self,
+        frame: IncomingFrame,
+        message_id: Option<String>,
+    ) -> io::Result<Option<u64>> {
+        let dedup_key = message_id
+            .as_ref()
+            .map(|id| format!("{}:{id}", frame.topic));
+        if dedup_key
+            .as_deref()
+            .is_some_and(|key| self.inbound_dedup.contains(key))
+        {
+            return Ok(None);
+        }
+        let id = self.inbox.put(DurableInbound {
             topic: frame.topic,
             payload: frame.payload,
             retained: frame.retained,
-        })
+            message_id,
+        })?;
+        if let Some(key) = dedup_key {
+            self.inbound_dedup.insert(key)?;
+        }
+        Ok(Some(id))
     }
 
     pub(crate) fn ack_inbound(&mut self, id: u64) -> io::Result<()> {
+        self.inbox.ack(id)
+    }
+
+    /// Persist a terminally rejected inbound before removing it from the
+    /// retryable inbox. This keeps malformed or unauthorized messages
+    /// inspectable without allowing one poison message to block recovery.
+    pub(crate) fn dead_letter_inbound(&mut self, id: u64, reason: String) -> io::Result<()> {
+        let Some(inbound) = self.inbox.get(id).cloned() else {
+            return Ok(());
+        };
+        self.dead_letter
+            .put(DurableDeadLetter { inbound, reason })?;
         self.inbox.ack(id)
     }
 
@@ -294,6 +404,11 @@ impl DurableMqttStore {
     pub(crate) fn pending_outbox(&self) -> impl Iterator<Item = (u64, &DurablePublish)> {
         self.outbox.values()
     }
+
+    #[cfg(test)]
+    fn dead_letter_len(&self) -> usize {
+        self.dead_letter.len()
+    }
 }
 
 #[cfg(test)]
@@ -312,13 +427,17 @@ mod tests {
         let outbound_id;
         {
             let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
-            inbound_id = store.enqueue_inbound(frame.clone()).unwrap();
+            inbound_id = store
+                .enqueue_inbound(frame.clone(), Some("message-1".to_string()))
+                .unwrap()
+                .unwrap();
             outbound_id = store
                 .enqueue_publish(DurablePublish {
                     topic: "amux/team/actor/state".into(),
                     payload: vec![4, 5],
                     retain: true,
                     delivery: StoredDelivery::AtLeastOnce,
+                    event_id: Some("event-1".into()),
                 })
                 .unwrap();
         }
@@ -361,6 +480,68 @@ mod tests {
         std::fs::write(dir.path().join("inbox.log"), b"not-json\n{}\n").unwrap();
         let error = match DurableMqttStore::open_at(dir.path()) {
             Ok(_) => panic!("middle durable queue corruption must be reported"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn stable_redelivery_is_deduplicated_but_unidentified_messages_are_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let frame = IncomingFrame {
+            topic: "amux/team/actor/notify".into(),
+            payload: vec![1],
+            retained: false,
+        };
+        let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
+        assert!(store
+            .enqueue_inbound(frame.clone(), Some("m-1".into()))
+            .unwrap()
+            .is_some());
+        assert!(store
+            .enqueue_inbound(frame.clone(), Some("m-1".into()))
+            .unwrap()
+            .is_none());
+        assert!(store.enqueue_inbound(frame, None).unwrap().is_some());
+        assert_eq!(store.inbound_len(), 2);
+    }
+
+    #[test]
+    fn permanent_inbound_failure_is_durable_before_inbox_ack() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
+        let id = store
+            .enqueue_inbound(
+                IncomingFrame {
+                    topic: "amux/team/actor/notify".into(),
+                    payload: vec![9],
+                    retained: false,
+                },
+                Some("poison-1".into()),
+            )
+            .unwrap()
+            .unwrap();
+        store
+            .dead_letter_inbound(id, "invalid payload".into())
+            .unwrap();
+        assert_eq!(store.inbound_len(), 0);
+        assert_eq!(store.dead_letter_len(), 1);
+        let reopened = DurableMqttStore::open_at(dir.path()).unwrap();
+        assert_eq!(reopened.inbound_len(), 0);
+        assert_eq!(reopened.dead_letter_len(), 1);
+    }
+
+    #[test]
+    fn dedup_torn_tail_is_recoverable_but_middle_corruption_is_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("inbox-dedup.log");
+        std::fs::write(&path, b"\"ok\"\n\"torn").unwrap();
+        let store = DurableMqttStore::open_at(dir.path()).unwrap();
+        assert!(store.inbound_len() == 0);
+
+        std::fs::write(&path, b"\"ok\"\nnot-json\n\"later\"\n").unwrap();
+        let error = match DurableMqttStore::open_at(dir.path()) {
+            Ok(_) => panic!("middle dedup corruption must be reported"),
             Err(error) => error,
         };
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);

--- a/apps/daemon/src/mqtt/durable_queue.rs
+++ b/apps/daemon/src/mqtt/durable_queue.rs
@@ -1,0 +1,368 @@
+//! Small append-only durable queues used by the MQTT supervisor.
+//!
+//! The queue is deliberately independent of the MQTT generation.  A worker
+//! can therefore be rebuilt without losing messages that were accepted by the
+//! daemon but had not reached the broker (or the business executor) yet.
+
+use std::collections::BTreeMap;
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use teamclu_transport::{DeliveryGuarantee, IncomingFrame};
+
+const COMPACT_AFTER_OPS: usize = 128;
+
+#[derive(Debug, Serialize, Deserialize)]
+enum LogRecord<T> {
+    Put { id: u64, item: T },
+    Ack { id: u64 },
+}
+
+/// A durable FIFO-ish queue. Ordering is recovered by the monotonically
+/// increasing id, while the BTreeMap also gives us cheap idempotent ACKs.
+struct DurableQueue<T> {
+    path: PathBuf,
+    entries: BTreeMap<u64, T>,
+    next_id: u64,
+    ops_since_compact: usize,
+}
+
+impl<T> DurableQueue<T>
+where
+    T: DeserializeOwned + Serialize,
+{
+    fn open(path: PathBuf) -> io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut entries = BTreeMap::new();
+        let mut next_id = 1_u64;
+        if path.is_file() {
+            let file = File::open(&path)?;
+            let reader = BufReader::new(file);
+            let mut lines = reader.lines().peekable();
+            let mut line_no = 0;
+            while let Some(line) = lines.next() {
+                line_no += 1;
+                let line = line?;
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let record = match serde_json::from_str::<LogRecord<T>>(&line) {
+                    Ok(record) => record,
+                    Err(error) => {
+                        // A process can be killed while appending the final
+                        // line. Only that torn tail is recoverable. A
+                        // malformed record with later records means the log
+                        // is damaged in the middle and must not silently drop
+                        // a durable message.
+                        if lines.peek().is_some() {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!(
+                                    "malformed durable queue record at line {}: {}",
+                                    line_no, error
+                                ),
+                            ));
+                        }
+                        tracing::warn!(
+                            path = %path.display(),
+                            line = line_no,
+                            %error,
+                            "ignoring torn final durable MQTT queue record"
+                        );
+                        continue;
+                    }
+                };
+                match record {
+                    LogRecord::Put { id, item } => {
+                        next_id = next_id.max(id.saturating_add(1));
+                        entries.insert(id, item);
+                    }
+                    LogRecord::Ack { id } => {
+                        entries.remove(&id);
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            path,
+            entries,
+            next_id,
+            ops_since_compact: 0,
+        })
+    }
+
+    fn append_record(&mut self, record: &LogRecord<T>) -> io::Result<()> {
+        let encoded = serde_json::to_vec(record)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        file.write_all(&encoded)?;
+        file.write_all(b"\n")?;
+        file.sync_data()?;
+        self.ops_since_compact += 1;
+        Ok(())
+    }
+
+    fn put(&mut self, item: T) -> io::Result<u64> {
+        let id = self.next_id;
+        let record = LogRecord::Put { id, item };
+        self.append_record(&record)?;
+        if let LogRecord::Put { id, item } = record {
+            self.entries.insert(id, item);
+        }
+        self.next_id = id.saturating_add(1);
+        Ok(id)
+    }
+
+    fn ack(&mut self, id: u64) -> io::Result<()> {
+        if !self.entries.contains_key(&id) {
+            return Ok(());
+        }
+        self.append_record(&LogRecord::Ack { id })?;
+        self.entries.remove(&id);
+        self.compact_if_needed()
+    }
+
+    fn get(&self, id: u64) -> Option<&T> {
+        self.entries.get(&id)
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn values(&self) -> impl Iterator<Item = (u64, &T)> {
+        self.entries.iter().map(|(&id, item)| (id, item))
+    }
+
+    fn compact_if_needed(&mut self) -> io::Result<()> {
+        if self.ops_since_compact < COMPACT_AFTER_OPS
+            || self.ops_since_compact < self.entries.len().max(1)
+        {
+            return Ok(());
+        }
+        self.compact()
+    }
+
+    fn compact(&mut self) -> io::Result<()> {
+        let temp_path = self.path.with_extension("log.tmp");
+        let result = (|| {
+            let mut file = File::create(&temp_path)?;
+            for (&id, item) in &self.entries {
+                let record = LogRecord::Put { id, item };
+                let encoded = serde_json::to_vec(&record)
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+                file.write_all(&encoded)?;
+                file.write_all(b"\n")?;
+            }
+            file.sync_all()?;
+            std::fs::rename(&temp_path, &self.path)?;
+            Ok::<(), io::Error>(())
+        })();
+        if result.is_ok() {
+            self.ops_since_compact = 0;
+        } else {
+            let _ = std::fs::remove_file(&temp_path);
+        }
+        result
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct DurableInbound {
+    pub(crate) topic: String,
+    pub(crate) payload: Vec<u8>,
+    pub(crate) retained: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct DurablePublish {
+    pub(crate) topic: String,
+    pub(crate) payload: Vec<u8>,
+    pub(crate) retain: bool,
+    pub(crate) delivery: StoredDelivery,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub(crate) enum StoredDelivery {
+    AtMostOnce,
+    AtLeastOnce,
+    ExactlyOnce,
+}
+
+impl From<DeliveryGuarantee> for StoredDelivery {
+    fn from(value: DeliveryGuarantee) -> Self {
+        match value {
+            DeliveryGuarantee::AtMostOnce => Self::AtMostOnce,
+            DeliveryGuarantee::AtLeastOnce => Self::AtLeastOnce,
+            DeliveryGuarantee::ExactlyOnce => Self::ExactlyOnce,
+        }
+    }
+}
+
+impl From<StoredDelivery> for DeliveryGuarantee {
+    fn from(value: StoredDelivery) -> Self {
+        match value {
+            StoredDelivery::AtMostOnce => Self::AtMostOnce,
+            StoredDelivery::AtLeastOnce => Self::AtLeastOnce,
+            StoredDelivery::ExactlyOnce => Self::ExactlyOnce,
+        }
+    }
+}
+
+pub(crate) struct DurableMqttStore {
+    inbox: DurableQueue<DurableInbound>,
+    outbox: DurableQueue<DurablePublish>,
+}
+
+impl DurableMqttStore {
+    pub(crate) fn open_default() -> io::Result<Self> {
+        Self::open_at(crate::config::layout::active_state_dir().join("mqtt"))
+    }
+
+    pub(crate) fn open_at(dir: impl AsRef<Path>) -> io::Result<Self> {
+        let dir = dir.as_ref();
+        std::fs::create_dir_all(dir)?;
+        Ok(Self {
+            inbox: DurableQueue::open(dir.join("inbox.log"))?,
+            outbox: DurableQueue::open(dir.join("outbox.log"))?,
+        })
+    }
+
+    pub(crate) fn enqueue_inbound(&mut self, frame: IncomingFrame) -> io::Result<u64> {
+        self.inbox.put(DurableInbound {
+            topic: frame.topic,
+            payload: frame.payload,
+            retained: frame.retained,
+        })
+    }
+
+    pub(crate) fn ack_inbound(&mut self, id: u64) -> io::Result<()> {
+        self.inbox.ack(id)
+    }
+
+    pub(crate) fn inbound(&self, id: u64) -> Option<&DurableInbound> {
+        self.inbox.get(id)
+    }
+
+    pub(crate) fn inbound_len(&self) -> usize {
+        self.inbox.len()
+    }
+
+    pub(crate) fn inbox_bytes(&self) -> usize {
+        self.inbox
+            .values()
+            .map(|(_, item)| item.topic.len() + item.payload.len())
+            .sum()
+    }
+
+    pub(crate) fn pending_inbound(&self) -> impl Iterator<Item = (u64, &DurableInbound)> {
+        self.inbox.values()
+    }
+
+    pub(crate) fn enqueue_publish(&mut self, publish: DurablePublish) -> io::Result<u64> {
+        self.outbox.put(publish)
+    }
+
+    pub(crate) fn ack_publish(&mut self, id: u64) -> io::Result<()> {
+        self.outbox.ack(id)
+    }
+
+    pub(crate) fn outbox_len(&self) -> usize {
+        self.outbox.len()
+    }
+
+    pub(crate) fn outbox(&self, id: u64) -> Option<&DurablePublish> {
+        self.outbox.get(id)
+    }
+
+    pub(crate) fn outbox_bytes(&self) -> usize {
+        self.outbox
+            .values()
+            .map(|(_, item)| item.topic.len() + item.payload.len())
+            .sum()
+    }
+
+    pub(crate) fn pending_outbox(&self) -> impl Iterator<Item = (u64, &DurablePublish)> {
+        self.outbox.values()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queue_replays_unacked_inbox_and_outbox_after_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let frame = IncomingFrame {
+            topic: "amux/team/actor/notify".into(),
+            payload: vec![1, 2, 3],
+            retained: false,
+        };
+        let inbound_id;
+        let outbound_id;
+        {
+            let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
+            inbound_id = store.enqueue_inbound(frame.clone()).unwrap();
+            outbound_id = store
+                .enqueue_publish(DurablePublish {
+                    topic: "amux/team/actor/state".into(),
+                    payload: vec![4, 5],
+                    retain: true,
+                    delivery: StoredDelivery::AtLeastOnce,
+                })
+                .unwrap();
+        }
+
+        let mut store = DurableMqttStore::open_at(dir.path()).unwrap();
+        let stored = store.inbound(inbound_id).unwrap();
+        assert_eq!(
+            IncomingFrame {
+                topic: stored.topic.clone(),
+                payload: stored.payload.clone(),
+                retained: stored.retained,
+            },
+            frame
+        );
+        assert_eq!(store.outbox_len(), 1);
+        store.ack_inbound(inbound_id).unwrap();
+        store.ack_publish(outbound_id).unwrap();
+        assert_eq!(store.inbound_len(), 0);
+        assert_eq!(store.outbox_len(), 0);
+    }
+
+    #[test]
+    fn delivery_round_trips_without_using_transport_types_on_disk() {
+        for value in [
+            DeliveryGuarantee::AtMostOnce,
+            DeliveryGuarantee::AtLeastOnce,
+            DeliveryGuarantee::ExactlyOnce,
+        ] {
+            let stored = StoredDelivery::from(value.clone());
+            assert_eq!(DeliveryGuarantee::from(stored), value);
+        }
+    }
+
+    #[test]
+    fn only_a_torn_final_record_is_ignored_during_recovery() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("inbox.log"), b"not-json\n").unwrap();
+        assert!(DurableMqttStore::open_at(dir.path()).is_ok());
+
+        std::fs::write(dir.path().join("inbox.log"), b"not-json\n{}\n").unwrap();
+        let error = match DurableMqttStore::open_at(dir.path()) {
+            Ok(_) => panic!("middle durable queue corruption must be reported"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/apps/daemon/src/mqtt/mod.rs
+++ b/apps/daemon/src/mqtt/mod.rs
@@ -8,7 +8,8 @@ mod topics;
 pub use client::client_danger;
 pub use client::MqttClient;
 pub use supervisor::{
-    MqttCommand, MqttInbound, MqttInboundDisposition, MqttPublisher, MqttSupervisor,
-    MqttSupervisorEvent,
+    MqttCommand, MqttInbound, MqttInboundDisposition, MqttPublisher, MqttRecoveryAccepted,
+    MqttRecoveryError, MqttRecoveryHandle, MqttRecoveryReason, MqttRecoveryRequest, MqttSnapshot,
+    MqttSnapshotHandle, MqttSupervisor, MqttSupervisorEvent,
 };
 pub use topics::Topics;

--- a/apps/daemon/src/mqtt/mod.rs
+++ b/apps/daemon/src/mqtt/mod.rs
@@ -1,8 +1,14 @@
 mod client;
+mod durable_queue;
 pub mod publisher;
 pub mod subscriber;
+pub mod supervisor;
 mod topics;
 
 pub use client::client_danger;
 pub use client::MqttClient;
+pub use supervisor::{
+    MqttCommand, MqttInbound, MqttInboundDisposition, MqttPublisher, MqttSupervisor,
+    MqttSupervisorEvent,
+};
 pub use topics::Topics;

--- a/apps/daemon/src/mqtt/subscriber.rs
+++ b/apps/daemon/src/mqtt/subscriber.rs
@@ -102,6 +102,50 @@ pub fn parse_frame(frame: &IncomingFrame) -> Option<IncomingMessage> {
     None
 }
 
+/// Extract the protocol-level id used to deduplicate MQTT redeliveries. A
+/// local durable queue id is intentionally not used here: it changes every
+/// time the broker redelivers the same packet.
+pub fn stable_message_id(frame: &IncomingFrame) -> Option<String> {
+    if frame.topic.ends_with("/rpc/req") {
+        return teamclu_proto::teamclu::RpcRequest::decode(frame.payload.as_slice())
+            .ok()
+            .map(|request| request.request_id)
+            .filter(|id| !id.is_empty());
+    }
+    if frame.topic.contains("/session/") && frame.topic.ends_with("/live") {
+        if let Ok(envelope) =
+            teamclu_proto::teamclu::LiveEventEnvelope::decode(frame.payload.as_slice())
+        {
+            if !envelope.event_id.is_empty() {
+                return Some(envelope.event_id);
+            }
+            if let Ok(message) =
+                teamclu_proto::teamclu::SessionMessageEnvelope::decode(envelope.body.as_slice())
+            {
+                return message
+                    .message
+                    .map(|message| message.message_id)
+                    .filter(|id| !id.is_empty());
+            }
+        }
+        return None;
+    }
+    if frame.topic.ends_with("/notify") {
+        return teamclu_proto::teamclu::SessionMessageEnvelope::decode(frame.payload.as_slice())
+            .ok()
+            .and_then(|envelope| envelope.message)
+            .map(|message| message.message_id)
+            .filter(|id| !id.is_empty());
+    }
+    if frame.topic.contains("/runtime/") && frame.topic.ends_with("/commands") {
+        return amux::RuntimeCommandEnvelope::decode(frame.payload.as_slice())
+            .ok()
+            .map(|envelope| envelope.command_id)
+            .filter(|id| !id.is_empty());
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/daemon/src/mqtt/supervisor.rs
+++ b/apps/daemon/src/mqtt/supervisor.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
     Arc,
 };
 use std::time::{Duration, Instant};
@@ -41,6 +41,183 @@ const CONTROL_CAPACITY: usize = 32;
 const WORKER_COMMAND_CAPACITY: usize = 2048;
 const WORKER_DISPOSITION_CAPACITY: usize = 2048;
 const WORKER_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+const RECOVERY_SIGNAL_TIMEOUT: Duration = Duration::from_secs(2);
+const WAKE_GAP_THRESHOLD: Duration = Duration::from_secs(120);
+const INBOUND_RETRY_MAX: Duration = Duration::from_secs(30);
+
+/// The one snapshot published to `/v1/info`. Keeping the fields together
+/// prevents the UI from observing `connected=true` with a stale recovery phase.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MqttSnapshot {
+    pub snapshot_version: u64,
+    pub connected: bool,
+    pub phase: String,
+    pub worker_generation: Option<u64>,
+    pub connection_attempt: Option<u64>,
+    pub ready_generation: Option<u64>,
+    pub last_error_code: Option<String>,
+    pub last_error_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_recovery_reason: Option<String>,
+    pub next_retry_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_ready_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+pub type MqttSnapshotHandle = Arc<parking_lot::RwLock<MqttSnapshot>>;
+
+impl Default for MqttSnapshot {
+    fn default() -> Self {
+        Self {
+            snapshot_version: 0,
+            connected: false,
+            phase: "Starting".to_string(),
+            worker_generation: None,
+            connection_attempt: None,
+            ready_generation: None,
+            last_error_code: None,
+            last_error_at: None,
+            last_recovery_reason: None,
+            next_retry_at: None,
+            last_ready_at: None,
+        }
+    }
+}
+
+fn snapshot_update(snapshot: &MqttSnapshotHandle, update: impl FnOnce(&mut MqttSnapshot)) {
+    let mut current = snapshot.write();
+    update(&mut current);
+    current.snapshot_version = current.snapshot_version.wrapping_add(1);
+}
+
+fn mqtt_error_code(reason: &str) -> &'static str {
+    let reason = reason.to_ascii_lowercase();
+    if reason.contains("dns") || reason.contains("resolve") {
+        "dns_failure"
+    } else if reason.contains("tls") || reason.contains("certificate") {
+        "tls_failure"
+    } else if reason.contains("not authorized")
+        || reason.contains("bad username")
+        || reason.contains("authentication")
+    {
+        "broker_auth_rejected"
+    } else if reason.contains("timeout") || reason.contains("timed out") {
+        "network_timeout"
+    } else if reason.contains("502") || reason.contains("503") {
+        "broker_unavailable"
+    } else if reason.contains("closed") || reason.contains("eof") {
+        "connection_closed"
+    } else {
+        "transport_failure"
+    }
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MqttRecoveryReason {
+    Startup,
+    VisibilityResume,
+    LongVisibilityResume,
+    NetworkOnline,
+    UserRequested,
+    Watchdog,
+    CredentialRejected,
+}
+
+impl MqttRecoveryReason {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "startup" => Some(Self::Startup),
+            "visibility_resume" => Some(Self::VisibilityResume),
+            "long_visibility_resume" => Some(Self::LongVisibilityResume),
+            "network_online" => Some(Self::NetworkOnline),
+            "user_requested" => Some(Self::UserRequested),
+            "watchdog" => Some(Self::Watchdog),
+            "credential_rejected" => Some(Self::CredentialRejected),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Startup => "startup",
+            Self::VisibilityResume => "visibility_resume",
+            Self::LongVisibilityResume => "long_visibility_resume",
+            Self::NetworkOnline => "network_online",
+            Self::UserRequested => "user_requested",
+            Self::Watchdog => "watchdog",
+            Self::CredentialRejected => "credential_rejected",
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MqttRecoveryOutcome {
+    Recovering,
+    AlreadyHealthy,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MqttRecoveryAccepted {
+    pub accepted: bool,
+    pub outcome: MqttRecoveryOutcome,
+    pub request_id: String,
+    pub worker_generation: Option<u64>,
+}
+
+#[derive(Debug)]
+pub enum MqttRecoveryError {
+    Unavailable,
+    Timeout,
+}
+
+pub struct MqttRecoveryRequest {
+    pub reason: MqttRecoveryReason,
+    pub request_id: String,
+    pub reply: oneshot::Sender<MqttRecoveryAccepted>,
+}
+
+/// A bounded, try-send-only recovery signal. The HTTP layer can be started
+/// before the supervisor, so the receiver is attached later by `spawn`.
+#[derive(Debug, Clone)]
+pub struct MqttRecoveryHandle {
+    tx: mpsc::Sender<MqttRecoveryRequest>,
+    next_request_id: Arc<AtomicU64>,
+}
+
+impl MqttRecoveryHandle {
+    pub fn channel() -> (Self, mpsc::Receiver<MqttRecoveryRequest>) {
+        let (tx, rx) = mpsc::channel(1);
+        (
+            Self {
+                tx,
+                next_request_id: Arc::new(AtomicU64::new(1)),
+            },
+            rx,
+        )
+    }
+
+    pub async fn request(
+        &self,
+        reason: MqttRecoveryReason,
+    ) -> Result<MqttRecoveryAccepted, MqttRecoveryError> {
+        let request_id = format!(
+            "mqtt-recovery-{}",
+            self.next_request_id.fetch_add(1, Ordering::Relaxed)
+        );
+        let (reply, response) = oneshot::channel();
+        self.tx
+            .try_send(MqttRecoveryRequest {
+                reason,
+                request_id,
+                reply,
+            })
+            .map_err(|_| MqttRecoveryError::Unavailable)?;
+        tokio::time::timeout(RECOVERY_SIGNAL_TIMEOUT, response)
+            .await
+            .map_err(|_| MqttRecoveryError::Timeout)?
+            .map_err(|_| MqttRecoveryError::Unavailable)
+    }
+}
 
 /// Commands accepted by the stable publisher proxy.
 pub enum MqttCommand {
@@ -71,10 +248,11 @@ pub struct MqttInbound {
     pub frame: IncomingFrame,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum MqttInboundDisposition {
     Ack,
     Retry,
+    DeadLetter { reason: String },
 }
 
 /// A generation-independent publisher handle. It is intentionally the only
@@ -163,23 +341,28 @@ pub enum MqttSupervisorEvent {
     /// daemon state are not ready yet.
     TransportConnected {
         generation: u64,
+        worker_generation: u64,
     },
     /// The worker restored every subscription known before this generation
     /// was rebuilt and received all corresponding SUBACK packets.
     SubscriptionsReady {
         generation: u64,
+        worker_generation: u64,
     },
     /// The daemon command executor has completed subscriptions and state
     /// restoration for this generation.
     GenerationReady {
         generation: u64,
+        worker_generation: u64,
     },
     Disconnected {
         generation: u64,
+        worker_generation: u64,
         reason: String,
     },
     Rebuilt {
         generation: u64,
+        worker_generation: u64,
         reason: String,
     },
     Terminated,
@@ -194,11 +377,13 @@ pub struct MqttSupervisor {
     join: Option<tokio::task::JoinHandle<()>>,
     watchdog_shutdown: Option<oneshot::Sender<()>>,
     watchdog_join: Option<tokio::task::JoinHandle<()>>,
+    snapshot: MqttSnapshotHandle,
 }
 
 enum MqttControl {
     GenerationReady {
         generation: u64,
+        worker_generation: u64,
         reply: oneshot::Sender<bool>,
     },
     Rebuild {
@@ -209,6 +394,7 @@ enum MqttControl {
 enum WorkerControl {
     GenerationReady {
         generation: u64,
+        worker_generation: u64,
         reply: oneshot::Sender<bool>,
     },
 }
@@ -258,11 +444,14 @@ fn generation_is_current(active: u64, incoming: u64) -> bool {
 
 fn is_current_ready_generation(
     worker_present: bool,
+    active_worker_generation: u64,
     active_generation: u64,
     transport_connected_generation: Option<u64>,
     ready_generation: u64,
+    ready_worker_generation: u64,
 ) -> bool {
     worker_present
+        && active_worker_generation == ready_worker_generation
         && transport_connected_generation == Some(ready_generation)
         && generation_is_current(active_generation, ready_generation)
 }
@@ -274,6 +463,10 @@ fn restart_delay(failure_count: u32) -> Duration {
         .checked_mul(multiplier)
         .unwrap_or(REBUILD_RETRY_MAX)
         .min(REBUILD_RETRY_MAX)
+}
+
+fn inbound_retry_delay(attempt: u32) -> Duration {
+    Duration::from_secs(1_u64 << attempt.saturating_sub(1).min(4)).min(INBOUND_RETRY_MAX)
 }
 
 fn schedule_restart_at(next_restart: &mut Instant, restart_failures: &mut u32, now: Instant) {
@@ -306,7 +499,9 @@ impl MqttSupervisor {
         initial_token: String,
         backend: Arc<dyn Backend>,
         command_rx: mpsc::Receiver<MqttCommand>,
+        recovery_rx: mpsc::Receiver<MqttRecoveryRequest>,
         connected: Arc<AtomicBool>,
+        snapshot: MqttSnapshotHandle,
     ) -> Self {
         let (events_tx, events) = mpsc::channel(128);
         let (inbound_tx, inbound) = mpsc::channel(INBOUND_CAPACITY);
@@ -321,6 +516,7 @@ impl MqttSupervisor {
         let watchdog_join = tokio::spawn(async move {
             mqtt_watchdog(watchdog_heartbeat, watchdog_control, watchdog_shutdown_rx).await;
         });
+        let supervisor_snapshot = snapshot.clone();
         let join = tokio::spawn(async move {
             run_supervisor(
                 config,
@@ -333,8 +529,10 @@ impl MqttSupervisor {
                 inbound_tx,
                 inbound_disposition_rx,
                 control_rx,
+                recovery_rx,
                 connected,
                 heartbeat,
+                supervisor_snapshot,
             )
             .await;
         });
@@ -348,6 +546,7 @@ impl MqttSupervisor {
             join: Some(join),
             watchdog_shutdown: Some(watchdog_shutdown_tx),
             watchdog_join: Some(watchdog_join),
+            snapshot,
         }
     }
 
@@ -366,11 +565,15 @@ impl MqttSupervisor {
         }
     }
 
-    pub async fn mark_generation_ready(&self, generation: u64) -> bool {
+    pub async fn mark_generation_ready(&self, generation: u64, worker_generation: u64) -> bool {
         let (reply, result) = oneshot::channel();
         if self
             .control_tx
-            .send(MqttControl::GenerationReady { generation, reply })
+            .send(MqttControl::GenerationReady {
+                generation,
+                worker_generation,
+                reply,
+            })
             .await
             .is_err()
         {
@@ -399,6 +602,16 @@ impl MqttSupervisor {
             warn!(id, %error, "MQTT supervisor closed before durable inbound disposition");
         }
     }
+
+    /// Check the generation fence without waiting on the supervisor loop. This
+    /// is used by the daemon-owned state restore future, which may be awaiting
+    /// cloud/storage work while a recovery signal rebuilds the worker.
+    pub fn is_generation_current(&self, generation: u64, worker_generation: u64) -> bool {
+        let snapshot = self.snapshot.read();
+        snapshot.worker_generation == Some(worker_generation)
+            && snapshot.connection_attempt == Some(generation)
+            && matches!(snapshot.phase.as_str(), "TransportConnected" | "Restoring")
+    }
 }
 
 struct WorkerHandle {
@@ -420,8 +633,10 @@ async fn run_supervisor(
     inbound_tx: mpsc::Sender<MqttInbound>,
     mut inbound_disposition_rx: mpsc::Receiver<(u64, MqttInboundDisposition)>,
     mut control_rx: mpsc::Receiver<MqttControl>,
+    mut recovery_rx: mpsc::Receiver<MqttRecoveryRequest>,
     connected: Arc<AtomicBool>,
     heartbeat: Arc<MqttHeartbeat>,
+    snapshot: MqttSnapshotHandle,
 ) {
     let (worker_events_tx, mut worker_events_rx) = mpsc::channel(128);
     let mut worker = Some(spawn_worker(
@@ -429,6 +644,7 @@ async fn run_supervisor(
         actor_id.clone(),
         initial_token,
         backend.clone(),
+        0,
         0,
         BTreeMap::new(),
         worker_events_tx.clone(),
@@ -440,11 +656,20 @@ async fn run_supervisor(
     let mut pending_commands = VecDeque::<MqttCommand>::new();
     let mut pending_dispositions = VecDeque::<(u64, MqttInboundDisposition)>::new();
     let mut generation = 0_u64;
+    let mut worker_generation = 0_u64;
     let mut transport_connected_generation = None::<u64>;
     let mut restart_reason = None::<String>;
     let mut next_restart = Instant::now();
     let mut restart_failures = 0_u32;
     let mut shutting_down = false;
+    let mut ready_connection_generation = None::<u64>;
+    let mut last_observed_ms = MqttHeartbeat::now_ms();
+
+    snapshot_update(&snapshot, |current| {
+        current.phase = "Connecting".to_string();
+        current.worker_generation = Some(worker_generation);
+        current.ready_generation = None;
+    });
 
     loop {
         if let Some(active) = worker.as_ref() {
@@ -486,6 +711,11 @@ async fn run_supervisor(
             let reason = restart_reason
                 .take()
                 .unwrap_or_else(|| "MQTT worker exited".to_string());
+            snapshot_update(&snapshot, |current| {
+                current.phase = "AuthRecovering".to_string();
+                current.connected = false;
+                current.ready_generation = None;
+            });
             let token = match tokio::time::timeout(Duration::from_secs(10), backend.auth_token())
                 .await
             {
@@ -493,15 +723,36 @@ async fn run_supervisor(
                 Ok(Err(error)) => {
                     warn!(%error, "could not obtain MQTT credential while starting a new worker");
                     schedule_restart(&mut next_restart, &mut restart_failures);
+                    snapshot_update(&snapshot, |current| {
+                        current.phase = "Backoff".to_string();
+                        current.last_error_code = Some("cloud_auth_failure".to_string());
+                        current.next_retry_at = Some(
+                            chrono::Utc::now()
+                                + chrono::Duration::seconds(
+                                    restart_delay(restart_failures).as_secs() as i64,
+                                ),
+                        );
+                    });
                     continue;
                 }
                 Err(_) => {
                     warn!("timed out obtaining MQTT credential while starting a new worker");
                     schedule_restart(&mut next_restart, &mut restart_failures);
+                    snapshot_update(&snapshot, |current| {
+                        current.phase = "Backoff".to_string();
+                        current.last_error_code = Some("cloud_auth_timeout".to_string());
+                        current.next_retry_at = Some(
+                            chrono::Utc::now()
+                                + chrono::Duration::seconds(
+                                    restart_delay(restart_failures).as_secs() as i64,
+                                ),
+                        );
+                    });
                     continue;
                 }
             };
             connected.store(false, Ordering::Relaxed);
+            worker_generation = worker_generation.wrapping_add(1);
             let rebuilt_generation = generation;
             worker = Some(spawn_worker(
                 config.clone(),
@@ -509,15 +760,23 @@ async fn run_supervisor(
                 token,
                 backend.clone(),
                 generation,
+                worker_generation,
                 subscriptions.clone(),
                 worker_events_tx.clone(),
                 inbound_tx.clone(),
                 connected.clone(),
                 heartbeat.clone(),
             ));
+            snapshot_update(&snapshot, |current| {
+                current.phase = "Connecting".to_string();
+                current.worker_generation = Some(worker_generation);
+                current.connected = false;
+                current.ready_generation = None;
+            });
             let _ = events_tx
                 .send(MqttSupervisorEvent::Rebuilt {
                     generation: rebuilt_generation,
+                    worker_generation,
                     reason,
                 })
                 .await;
@@ -561,17 +820,20 @@ async fn run_supervisor(
             }
             control = control_rx.recv() => {
                 match control {
-                    Some(MqttControl::GenerationReady { generation: ready_generation, reply }) => {
+                    Some(MqttControl::GenerationReady { generation: ready_generation, worker_generation: ready_worker, reply }) => {
                         let accepted = is_current_ready_generation(
                             worker.is_some(),
+                            worker_generation,
                             generation,
                             transport_connected_generation,
                             ready_generation,
+                            ready_worker,
                         );
                         if accepted {
                             if let Some(active) = worker.as_ref() {
                                 let readiness = WorkerControl::GenerationReady {
                                     generation: ready_generation,
+                                    worker_generation: ready_worker,
                                     reply,
                                 };
                                 match active.control_tx.try_send(readiness) {
@@ -589,13 +851,24 @@ async fn run_supervisor(
                         }
                     }
                     Some(MqttControl::Rebuild { reason }) => {
-                        restart_reason = Some(reason);
+                        let first_request = restart_reason.is_none();
+                        restart_reason.get_or_insert(reason);
                         if worker.is_some() {
                             stop_worker(&mut worker, &heartbeat).await;
                             transport_connected_generation = None;
                             connected.store(false, Ordering::Relaxed);
+                            ready_connection_generation = None;
+                            if first_request {
+                                schedule_restart(&mut next_restart, &mut restart_failures);
+                            }
+                        } else if first_request {
+                            // A rebuild signal arriving while credential/backoff
+                            // recovery is already in progress only wakes the
+                            // existing retry. It must not count as another
+                            // worker failure or reset the exponential backoff
+                            // repeatedly.
+                            next_restart = Instant::now();
                         }
-                        schedule_restart(&mut next_restart, &mut restart_failures);
                     }
                     None => {
                         shutting_down = true;
@@ -603,36 +876,106 @@ async fn run_supervisor(
                     }
                 }
             }
+            request = recovery_rx.recv() => {
+                if let Some(request) = request {
+                    let current_generation = (worker.is_some()).then_some(worker_generation);
+                    let healthy = worker.is_some()
+                        && ready_connection_generation == Some(generation)
+                        && connected.load(Ordering::Relaxed);
+                    if healthy {
+                        let _ = request.reply.send(MqttRecoveryAccepted {
+                            accepted: true,
+                            outcome: MqttRecoveryOutcome::AlreadyHealthy,
+                            request_id: request.request_id,
+                            worker_generation: current_generation,
+                        });
+                    } else {
+                        let reason = format!("{} recovery", request.reason.as_str());
+                        snapshot_update(&snapshot, |current| {
+                            current.phase = "Recovering".to_string();
+                            current.last_recovery_reason = Some(request.reason.as_str().to_string());
+                            current.connected = false;
+                            current.ready_generation = None;
+                        });
+                        ready_connection_generation = None;
+                        let _ = request.reply.send(MqttRecoveryAccepted {
+                            accepted: true,
+                            outcome: MqttRecoveryOutcome::Recovering,
+                            request_id: request.request_id,
+                            worker_generation: current_generation,
+                        });
+                        if worker.is_some() {
+                            stop_worker(&mut worker, &heartbeat).await;
+                            transport_connected_generation = None;
+                            connected.store(false, Ordering::Relaxed);
+                        }
+                        restart_reason.get_or_insert(reason);
+                        next_restart = Instant::now();
+                    }
+                } else {
+                    shutting_down = true;
+                    break;
+                }
+            }
             event = worker_events_rx.recv() => {
                 match event {
                     Some(WorkerEvent::Supervisor(event)) => {
                         match &event {
-                            MqttSupervisorEvent::TransportConnected { generation: current } => {
+                            MqttSupervisorEvent::TransportConnected { generation: current, .. } => {
                                 generation = *current;
                                 transport_connected_generation = Some(*current);
+                                snapshot_update(&snapshot, |current_snapshot| {
+                                    current_snapshot.phase = "TransportConnected".to_string();
+                                    current_snapshot.worker_generation = Some(worker_generation);
+                                    current_snapshot.connection_attempt = Some(current_snapshot.connection_attempt.unwrap_or(0).saturating_add(1));
+                                    current_snapshot.connected = false;
+                                    current_snapshot.ready_generation = None;
+                                });
                             }
-                            MqttSupervisorEvent::Disconnected { .. } => {
+                            MqttSupervisorEvent::Disconnected { reason, .. } => {
                                 transport_connected_generation = None;
                                 connected.store(false, Ordering::Relaxed);
+                                ready_connection_generation = None;
+                                snapshot_update(&snapshot, |current| {
+                                    current.phase = "Recovering".to_string();
+                                    current.connected = false;
+                                    current.ready_generation = None;
+                                    current.last_error_code = Some(mqtt_error_code(reason).to_string());
+                                    current.last_error_at = Some(chrono::Utc::now());
+                                });
                             }
-                            MqttSupervisorEvent::GenerationReady { generation: ready_generation } => {
+                            MqttSupervisorEvent::GenerationReady { generation: ready_gen, worker_generation: ready_worker } => {
                                 if is_current_ready_generation(
                                     worker.is_some(),
+                                    worker_generation,
                                     generation,
                                     transport_connected_generation,
-                                    *ready_generation,
+                                    *ready_gen,
+                                    *ready_worker,
                                 ) {
                                     restart_failures = 0;
+                                    ready_connection_generation = Some(*ready_gen);
+                                    snapshot_update(&snapshot, |current| {
+                                        current.phase = "Ready".to_string();
+                                        current.connected = true;
+                                        current.ready_generation = Some(*ready_worker);
+                                        current.last_ready_at = Some(chrono::Utc::now());
+                                        current.next_retry_at = None;
+                                    });
                                 } else {
                                     debug!(
-                                        generation = *ready_generation,
+                                        generation = *ready_gen,
                                         active_generation = generation,
                                         "ignored stale MQTT generation readiness for restart backoff"
                                     );
                                 }
                             }
+                            MqttSupervisorEvent::SubscriptionsReady { .. } => {
+                                snapshot_update(&snapshot, |current| {
+                                    current.phase = "Restoring".to_string();
+                                });
+                            }
                             MqttSupervisorEvent::Rebuilt { .. }
-                            | MqttSupervisorEvent::SubscriptionsReady { .. }
                             | MqttSupervisorEvent::Terminated => {}
                         }
                         let _ = events_tx.send(event).await;
@@ -640,14 +983,23 @@ async fn run_supervisor(
                     Some(WorkerEvent::Exited { reason }) => {
                         if !shutting_down {
                             warn!(%reason, "MQTT worker exited; supervisor will create a new generation");
-                            restart_reason = Some(reason);
+                            restart_reason = Some(reason.clone());
                             transport_connected_generation = None;
                             connected.store(false, Ordering::Relaxed);
+                            ready_connection_generation = None;
                             let had_worker = worker.is_some();
                             stop_worker(&mut worker, &heartbeat).await;
                             if had_worker {
                                 schedule_restart(&mut next_restart, &mut restart_failures);
                             }
+                            snapshot_update(&snapshot, |current| {
+                                current.phase = "Backoff".to_string();
+                                current.connected = false;
+                                current.ready_generation = None;
+                                current.last_error_code = Some(mqtt_error_code(&reason).to_string());
+                                current.last_error_at = Some(chrono::Utc::now());
+                                current.next_retry_at = Some(chrono::Utc::now() + chrono::Duration::seconds(restart_delay(restart_failures).as_secs() as i64));
+                            });
                         }
                     }
                     None => {
@@ -659,9 +1011,28 @@ async fn run_supervisor(
             }
             _ = &mut tick => {}
         }
+
+        let now_ms = MqttHeartbeat::now_ms();
+        if now_ms.saturating_sub(last_observed_ms) >= WAKE_GAP_THRESHOLD.as_millis() as u64 {
+            last_observed_ms = now_ms;
+            if worker.is_some() && !connected.load(Ordering::Relaxed) {
+                restart_reason.get_or_insert("daemon wake gap recovery".to_string());
+                next_restart = Instant::now();
+            }
+            snapshot_update(&snapshot, |current| {
+                current.last_recovery_reason = Some("daemon_wake_gap".to_string());
+            });
+        } else {
+            last_observed_ms = now_ms;
+        }
     }
 
     connected.store(false, Ordering::Relaxed);
+    snapshot_update(&snapshot, |current| {
+        current.phase = "Stopped".to_string();
+        current.connected = false;
+        current.ready_generation = None;
+    });
     stop_worker(&mut worker, &heartbeat).await;
     while let Some(command) = pending_commands.pop_front() {
         fail_command(command, "MQTT supervisor is shutting down");
@@ -675,6 +1046,7 @@ fn spawn_worker(
     initial_token: String,
     backend: Arc<dyn Backend>,
     generation_seed: u64,
+    worker_generation: u64,
     initial_subscriptions: BTreeMap<String, QoS>,
     events_tx: mpsc::Sender<WorkerEvent>,
     inbound_tx: mpsc::Sender<MqttInbound>,
@@ -700,6 +1072,7 @@ fn spawn_worker(
             connected,
             heartbeat,
             generation_seed,
+            worker_generation,
             initial_subscriptions,
         };
         worker.run().await;
@@ -756,6 +1129,7 @@ struct MqttWorker {
     connected: Arc<AtomicBool>,
     heartbeat: Arc<MqttHeartbeat>,
     generation_seed: u64,
+    worker_generation: u64,
     initial_subscriptions: BTreeMap<String, QoS>,
 }
 
@@ -796,6 +1170,8 @@ impl MqttWorker {
         let mut subscribe_waiting_for_write = VecDeque::<PendingSubscribe>::new();
         let mut subscribe_inflight = HashMap::<u16, PendingSubscribe>::new();
         let mut inbound_staging = load_pending_inbound(&store);
+        let mut inbound_retry_attempts = HashMap::<u64, u32>::new();
+        let mut inbound_retry_deadlines = HashMap::<u64, Instant>::new();
         let mut forced_rebuild = None::<String>;
         let mut auto_restore_subscriptions = false;
         let mut subscriptions_ready_announced = false;
@@ -803,6 +1179,11 @@ impl MqttWorker {
 
         loop {
             self.heartbeat.touch();
+            self.flush_due_inbound_retries(
+                &mut store,
+                &mut inbound_staging,
+                &mut inbound_retry_deadlines,
+            );
             self.flush_inbound(&mut inbound_staging);
 
             if connected && generation_ready {
@@ -838,13 +1219,16 @@ impl MqttWorker {
                     }
                     control = self.control_rx.recv() => {
                         match control {
-                            Some(WorkerControl::GenerationReady { generation: ready_generation, reply }) => {
-                                let accepted = generation_is_current(generation, ready_generation) && connected;
+                            Some(WorkerControl::GenerationReady { generation: ready_generation, worker_generation: ready_worker_generation, reply }) => {
+                                let accepted = generation_is_current(generation, ready_generation)
+                                    && self.worker_generation == ready_worker_generation
+                                    && connected;
                                 if accepted {
                                     generation_ready = true;
                                     self.connected.store(true, Ordering::Relaxed);
                                     let _ = self.events_tx.send(WorkerEvent::Supervisor(MqttSupervisorEvent::GenerationReady {
                                         generation: ready_generation,
+                                        worker_generation: ready_worker_generation,
                                     })).await;
                                     info!(generation = ready_generation, "MQTT generation is fully ready");
                                 } else {
@@ -864,7 +1248,8 @@ impl MqttWorker {
                                 id,
                                 disposition,
                                 &mut store,
-                                &mut inbound_staging,
+                                &mut inbound_retry_attempts,
+                                &mut inbound_retry_deadlines,
                             );
                         }
                     }
@@ -909,7 +1294,10 @@ impl MqttWorker {
                                     self.backend.cached_credential_expiry_epoch(),
                                 );
                                 info!(generation, subscriptions = subscriptions.len(), previous_poll_errors, "MQTT transport connected; waiting for subscription and state restore");
-                                let _ = self.events_tx.send(WorkerEvent::Supervisor(MqttSupervisorEvent::TransportConnected { generation })).await;
+                                let _ = self.events_tx.send(WorkerEvent::Supervisor(MqttSupervisorEvent::TransportConnected {
+                                    generation,
+                                    worker_generation: self.worker_generation,
+                                })).await;
                                 if !auto_restore_subscriptions {
                                     self.announce_subscriptions_ready(
                                         generation,
@@ -938,14 +1326,23 @@ impl MqttWorker {
                                             "durable MQTT inbox is full; withholding broker ACK until business ACK"
                                         );
                                     } else {
-                                        match store.enqueue_inbound(frame.clone()) {
-                                            Ok(id) => {
+                                        let message_id = subscriber::stable_message_id(&frame);
+                                        match store.enqueue_inbound(frame.clone(), message_id) {
+                                            Ok(Some(id)) => {
                                                 inbound_staging.push_back(MqttInbound { id, frame });
                                                 // manual_acks is enabled in MqttClient. The
                                                 // broker ACK is emitted only after the local
                                                 // durable inbox append has synced.
                                                 if let Err(error) = active.client.try_ack(&publish) {
                                                     warn!(%error, "failed to ACK durably stored MQTT inbound");
+                                                }
+                                            }
+                                            Ok(None) => {
+                                                // The durable dedup key was already accepted. It
+                                                // is safe to ACK this broker redelivery without
+                                                // scheduling a second business execution.
+                                                if let Err(error) = active.client.try_ack(&publish) {
+                                                    warn!(%error, "failed to ACK deduplicated MQTT inbound");
                                                 }
                                             }
                                             Err(error) => {
@@ -1039,6 +1436,7 @@ impl MqttWorker {
                                     self.connected.store(false, Ordering::Relaxed);
                                     let _ = self.events_tx.send(WorkerEvent::Supervisor(MqttSupervisorEvent::Disconnected {
                                         generation,
+                                        worker_generation: self.worker_generation,
                                         reason: reason.clone(),
                                     })).await;
                                 }
@@ -1111,9 +1509,9 @@ impl MqttWorker {
                     }
                     control = self.control_rx.recv() => {
                         match control {
-                            Some(WorkerControl::GenerationReady { generation: ready_generation, reply }) => {
+                            Some(WorkerControl::GenerationReady { generation: ready_generation, worker_generation: ready_worker_generation, reply }) => {
                                 let accepted = false;
-                                warn!(generation = ready_generation, active_generation = generation, "ignored MQTT generation readiness while transport is offline");
+                                warn!(generation = ready_generation, worker_generation = ready_worker_generation, active_generation = generation, "ignored MQTT generation readiness while transport is offline");
                                 let _ = reply.send(accepted);
                             }
                             None => {
@@ -1128,7 +1526,8 @@ impl MqttWorker {
                                 id,
                                 disposition,
                                 &mut store,
-                                &mut inbound_staging,
+                                &mut inbound_retry_attempts,
+                                &mut inbound_retry_deadlines,
                             );
                         }
                     }
@@ -1242,6 +1641,11 @@ impl MqttWorker {
                     return true;
                 }
                 let publish = DurablePublish {
+                    event_id: subscriber::stable_message_id(&IncomingFrame {
+                        topic: topic.clone(),
+                        payload: payload.clone(),
+                        retained: false,
+                    }),
                     topic,
                     payload,
                     retain,
@@ -1324,32 +1728,73 @@ impl MqttWorker {
         id: u64,
         disposition: MqttInboundDisposition,
         store: &mut DurableMqttStore,
-        staging: &mut VecDeque<MqttInbound>,
+        retry_attempts: &mut HashMap<u64, u32>,
+        retry_deadlines: &mut HashMap<u64, Instant>,
     ) {
         match disposition {
             MqttInboundDisposition::Ack => {
+                retry_attempts.remove(&id);
+                retry_deadlines.remove(&id);
                 if let Err(error) = store.ack_inbound(id) {
                     warn!(%error, id, "failed to ACK durable MQTT inbox item");
                 }
             }
             MqttInboundDisposition::Retry => {
-                if let Some(item) = store.inbound(id) {
-                    let frame = IncomingFrame {
-                        topic: item.topic.clone(),
-                        payload: item.payload.clone(),
-                        retained: item.retained,
-                    };
-                    if staging.len() < INBOUND_STAGING_CAPACITY {
-                        staging.push_back(MqttInbound { id, frame });
-                    } else {
-                        warn!(
-                            capacity = INBOUND_STAGING_CAPACITY,
-                            id,
-                            "MQTT inbound staging is full; durable item will replay after restart"
-                        );
-                    }
+                let attempt = retry_attempts.entry(id).or_insert(0);
+                *attempt = attempt.saturating_add(1);
+                let delay = inbound_retry_delay(*attempt);
+                retry_deadlines
+                    .entry(id)
+                    .or_insert_with(|| Instant::now() + delay.min(INBOUND_RETRY_MAX));
+                debug!(
+                    id,
+                    retry_attempt = *attempt,
+                    delay_ms = delay.as_millis() as u64,
+                    "scheduled durable MQTT inbound retry"
+                );
+            }
+            MqttInboundDisposition::DeadLetter { reason } => {
+                retry_attempts.remove(&id);
+                retry_deadlines.remove(&id);
+                if let Err(error) = store.dead_letter_inbound(id, reason) {
+                    warn!(%error, id, "failed to move durable MQTT inbox item to dead letter");
                 }
             }
+        }
+    }
+
+    fn flush_due_inbound_retries(
+        &self,
+        store: &DurableMqttStore,
+        staging: &mut VecDeque<MqttInbound>,
+        retry_deadlines: &mut HashMap<u64, Instant>,
+    ) {
+        let now = Instant::now();
+        let due = retry_deadlines
+            .iter()
+            .filter_map(|(&id, &deadline)| (deadline <= now).then_some(id))
+            .collect::<Vec<_>>();
+        for id in due {
+            retry_deadlines.remove(&id);
+            let Some(item) = store.inbound(id) else {
+                continue;
+            };
+            if staging.len() >= INBOUND_STAGING_CAPACITY {
+                warn!(
+                    capacity = INBOUND_STAGING_CAPACITY,
+                    id, "MQTT inbound staging is full; durable item will replay after restart"
+                );
+                retry_deadlines.insert(id, now + INBOUND_RETRY_MAX);
+                continue;
+            }
+            staging.push_back(MqttInbound {
+                id,
+                frame: IncomingFrame {
+                    topic: item.topic.clone(),
+                    payload: item.payload.clone(),
+                    retained: item.retained,
+                },
+            });
         }
     }
 
@@ -1382,7 +1827,10 @@ impl MqttWorker {
         let _ = self
             .events_tx
             .send(WorkerEvent::Supervisor(
-                MqttSupervisorEvent::SubscriptionsReady { generation },
+                MqttSupervisorEvent::SubscriptionsReady {
+                    generation,
+                    worker_generation: self.worker_generation,
+                },
             ))
             .await;
         info!(
@@ -1545,10 +1993,10 @@ mod tests {
         assert!(generation_is_current(7, 7));
         assert!(!generation_is_current(7, 6));
         assert!(!generation_is_current(7, 8));
-        assert!(is_current_ready_generation(true, 7, Some(7), 7));
-        assert!(!is_current_ready_generation(true, 7, Some(7), 6));
-        assert!(!is_current_ready_generation(true, 7, None, 7));
-        assert!(!is_current_ready_generation(false, 7, Some(7), 7));
+        assert!(is_current_ready_generation(true, 7, 7, Some(7), 7, 7));
+        assert!(!is_current_ready_generation(true, 7, 7, Some(7), 6, 7));
+        assert!(!is_current_ready_generation(true, 7, 7, None, 7, 7));
+        assert!(!is_current_ready_generation(false, 7, 7, Some(7), 7, 7));
     }
 
     #[test]
@@ -1635,6 +2083,41 @@ mod tests {
         let near_expiry = crate::backend::epoch_secs_now() + 60;
         assert!(proactive_reconnect_deadline(Some(near_expiry)).is_none());
         assert!(proactive_reconnect_deadline(None).is_some());
+    }
+
+    #[test]
+    fn inbound_retry_backoff_is_bounded_and_monotonic() {
+        assert_eq!(inbound_retry_delay(1), Duration::from_secs(1));
+        assert_eq!(inbound_retry_delay(2), Duration::from_secs(2));
+        assert_eq!(inbound_retry_delay(3), Duration::from_secs(4));
+        assert_eq!(inbound_retry_delay(5), Duration::from_secs(16));
+        assert_eq!(inbound_retry_delay(6), Duration::from_secs(30));
+        assert_eq!(inbound_retry_delay(100), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn recovery_signal_channel_keeps_only_one_pending_request() {
+        let (handle, mut receiver) = MqttRecoveryHandle::channel();
+        let (reply, _response) = oneshot::channel();
+        handle
+            .tx
+            .try_send(MqttRecoveryRequest {
+                reason: MqttRecoveryReason::NetworkOnline,
+                request_id: "one".into(),
+                reply,
+            })
+            .expect("first recovery signal should fit");
+        let (reply, _response) = oneshot::channel();
+        assert!(handle
+            .tx
+            .try_send(MqttRecoveryRequest {
+                reason: MqttRecoveryReason::VisibilityResume,
+                request_id: "two".into(),
+                reply,
+            })
+            .is_err());
+        let first = receiver.try_recv().expect("pending signal");
+        assert_eq!(first.request_id, "one");
     }
 
     #[tokio::test]

--- a/apps/daemon/src/mqtt/supervisor.rs
+++ b/apps/daemon/src/mqtt/supervisor.rs
@@ -466,7 +466,8 @@ fn restart_delay(failure_count: u32) -> Duration {
 }
 
 fn inbound_retry_delay(attempt: u32) -> Duration {
-    Duration::from_secs(1_u64 << attempt.saturating_sub(1).min(4)).min(INBOUND_RETRY_MAX)
+    let exponent = attempt.saturating_sub(1).min(5);
+    Duration::from_secs(1_u64 << exponent).min(INBOUND_RETRY_MAX)
 }
 
 fn schedule_restart_at(next_restart: &mut Instant, restart_failures: &mut u32, now: Instant) {
@@ -490,6 +491,10 @@ fn watchdog_rebuild_request_allowed(
         return false;
     }
     rebuild_requested_at.is_none()
+}
+
+fn wake_gap_requires_recovery(last_observed_ms: u64, now_ms: u64) -> bool {
+    now_ms.saturating_sub(last_observed_ms) >= WAKE_GAP_THRESHOLD.as_millis() as u64
 }
 
 impl MqttSupervisor {
@@ -664,6 +669,10 @@ async fn run_supervisor(
     let mut shutting_down = false;
     let mut ready_connection_generation = None::<u64>;
     let mut last_observed_ms = MqttHeartbeat::now_ms();
+    // A recovery signal is an edge, not a command to repeatedly tear down the
+    // worker. Keep the state in the supervisor so focus/online/watchdog/wake
+    // signals all converge on one active recovery attempt.
+    let mut recovery_in_progress = false;
 
     snapshot_update(&snapshot, |current| {
         current.phase = "Connecting".to_string();
@@ -772,6 +781,7 @@ async fn run_supervisor(
                 current.worker_generation = Some(worker_generation);
                 current.connected = false;
                 current.ready_generation = None;
+                current.next_retry_at = None;
             });
             let _ = events_tx
                 .send(MqttSupervisorEvent::Rebuilt {
@@ -891,12 +901,17 @@ async fn run_supervisor(
                         });
                     } else {
                         let reason = format!("{} recovery", request.reason.as_str());
+                        let already_recovering = recovery_in_progress;
                         snapshot_update(&snapshot, |current| {
-                            current.phase = "Recovering".to_string();
+                            if !already_recovering {
+                                current.phase = "Recovering".to_string();
+                            }
                             current.last_recovery_reason = Some(request.reason.as_str().to_string());
                             current.connected = false;
                             current.ready_generation = None;
+                            current.next_retry_at = None;
                         });
+                        recovery_in_progress = true;
                         ready_connection_generation = None;
                         let _ = request.reply.send(MqttRecoveryAccepted {
                             accepted: true,
@@ -904,13 +919,19 @@ async fn run_supervisor(
                             request_id: request.request_id,
                             worker_generation: current_generation,
                         });
-                        if worker.is_some() {
+                        // Once a recovery is active, later signals only update
+                        // the reason above. Repeated teardown here was the
+                        // source of rebuild storms after a laptop wake or a
+                        // flapping VPN.
+                        if !already_recovering && worker.is_some() {
                             stop_worker(&mut worker, &heartbeat).await;
                             transport_connected_generation = None;
                             connected.store(false, Ordering::Relaxed);
                         }
                         restart_reason.get_or_insert(reason);
-                        next_restart = Instant::now();
+                        if !already_recovering {
+                            next_restart = Instant::now();
+                        }
                     }
                 } else {
                     shutting_down = true;
@@ -954,6 +975,7 @@ async fn run_supervisor(
                                     *ready_worker,
                                 ) {
                                     restart_failures = 0;
+                                    recovery_in_progress = false;
                                     ready_connection_generation = Some(*ready_gen);
                                     snapshot_update(&snapshot, |current| {
                                         current.phase = "Ready".to_string();
@@ -1013,15 +1035,30 @@ async fn run_supervisor(
         }
 
         let now_ms = MqttHeartbeat::now_ms();
-        if now_ms.saturating_sub(last_observed_ms) >= WAKE_GAP_THRESHOLD.as_millis() as u64 {
+        if wake_gap_requires_recovery(last_observed_ms, now_ms) {
             last_observed_ms = now_ms;
-            if worker.is_some() && !connected.load(Ordering::Relaxed) {
+            if !shutting_down && !recovery_in_progress {
+                recovery_in_progress = true;
+                snapshot_update(&snapshot, |current| {
+                    current.phase = "Recovering".to_string();
+                    current.connected = false;
+                    current.ready_generation = None;
+                    current.last_recovery_reason = Some("daemon_wake_gap".to_string());
+                    current.next_retry_at = None;
+                });
+                ready_connection_generation = None;
                 restart_reason.get_or_insert("daemon wake gap recovery".to_string());
+                // A wall-clock gap means the old socket may have survived in
+                // a half-closed state. Stop that generation even if its last
+                // snapshot said Ready, then let the normal credential/backoff
+                // path create exactly one replacement worker.
+                if worker.is_some() {
+                    stop_worker(&mut worker, &heartbeat).await;
+                    transport_connected_generation = None;
+                    connected.store(false, Ordering::Relaxed);
+                }
                 next_restart = Instant::now();
             }
-            snapshot_update(&snapshot, |current| {
-                current.last_recovery_reason = Some("daemon_wake_gap".to_string());
-            });
         } else {
             last_observed_ms = now_ms;
         }
@@ -2076,6 +2113,19 @@ mod tests {
         assert!(!watchdog_rebuild_request_allowed(false, &mut requested_at));
         assert!(requested_at.is_none());
         assert!(watchdog_rebuild_request_allowed(true, &mut requested_at));
+    }
+
+    #[test]
+    fn wall_clock_wake_gap_is_only_triggered_once_per_observation() {
+        let threshold = WAKE_GAP_THRESHOLD.as_millis() as u64;
+        assert!(!wake_gap_requires_recovery(1_000, 1_000 + threshold - 1));
+        assert!(wake_gap_requires_recovery(1_000, 1_000 + threshold));
+
+        // The supervisor advances its observation timestamp after handling the
+        // gap. A second pass at the same wall-clock value must not create a
+        // second recovery edge.
+        let observed = 1_000 + threshold;
+        assert!(!wake_gap_requires_recovery(observed, observed));
     }
 
     #[test]

--- a/apps/daemon/src/mqtt/supervisor.rs
+++ b/apps/daemon/src/mqtt/supervisor.rs
@@ -1,0 +1,1691 @@
+//! MQTT connection supervision.
+//!
+//! The important ownership rule in this module is that `EventLoop` and
+//! `AsyncClient` never escape the worker task.  Business code only sees the
+//! stable `MqttPublisher` proxy, so a reconnect cannot leave a
+//! `SessionManager` or `LivePublisher` holding a dead client generation.
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::{Duration, Instant};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rumqttc::{Event, Outgoing, Packet, QoS};
+use teamclu_transport::{DeliveryGuarantee, IncomingFrame, MessagePublisher, PublisherError};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, error, info, warn};
+
+use crate::backend::{proactive_reconnect_delay, Backend};
+use crate::config::DaemonConfig;
+use crate::mqtt::subscriber;
+use crate::mqtt::MqttClient;
+
+use super::durable_queue::{DurableMqttStore, DurablePublish, StoredDelivery};
+
+const COMMAND_CAPACITY: usize = 2048;
+const INBOUND_CAPACITY: usize = 2048;
+const INBOUND_STAGING_CAPACITY: usize = 4096;
+const DURABLE_QUEUE_CAPACITY: usize = 4096;
+const DURABLE_QUEUE_MAX_BYTES: usize = 64 * 1024 * 1024;
+const RECOVERY_DEADLINE: Duration = Duration::from_secs(30);
+const REBUILD_RETRY: Duration = Duration::from_secs(5);
+const REBUILD_RETRY_MAX: Duration = Duration::from_secs(30);
+const SUPERVISOR_TICK: Duration = Duration::from_secs(1);
+const WORKER_STALL_WARN: Duration = Duration::from_secs(5);
+const POLL_PENDING_WARN: Duration = Duration::from_secs(45);
+const POLL_PENDING_REBUILD: Duration = Duration::from_secs(75);
+const CONTROL_CAPACITY: usize = 32;
+const WORKER_COMMAND_CAPACITY: usize = 2048;
+const WORKER_DISPOSITION_CAPACITY: usize = 2048;
+const WORKER_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Commands accepted by the stable publisher proxy.
+pub enum MqttCommand {
+    Publish {
+        topic: String,
+        payload: Vec<u8>,
+        retain: bool,
+        delivery: DeliveryGuarantee,
+        reply: oneshot::Sender<Result<(), PublisherError>>,
+    },
+    Subscribe {
+        topic: String,
+        delivery: DeliveryGuarantee,
+        reply: oneshot::Sender<Result<(), PublisherError>>,
+    },
+    Unsubscribe {
+        topic: String,
+        reply: oneshot::Sender<Result<(), PublisherError>>,
+    },
+}
+
+/// A message has already been durably written when it reaches the business
+/// loop. The MQTT ACK is intentionally sent at that point, not after a slow
+/// handler finishes; the local inbox ACK below is the replay boundary.
+#[derive(Debug)]
+pub struct MqttInbound {
+    pub id: u64,
+    pub frame: IncomingFrame,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MqttInboundDisposition {
+    Ack,
+    Retry,
+}
+
+/// A generation-independent publisher handle. It is intentionally the only
+/// MQTT object retained by the rest of the daemon.
+#[derive(Clone)]
+pub struct MqttPublisher {
+    tx: mpsc::Sender<MqttCommand>,
+}
+
+impl MqttPublisher {
+    pub fn channel() -> (Arc<Self>, mpsc::Receiver<MqttCommand>) {
+        let (tx, rx) = mpsc::channel(COMMAND_CAPACITY);
+        (Arc::new(Self { tx }), rx)
+    }
+
+    async fn send(
+        &self,
+        command: MqttCommand,
+        reply: oneshot::Receiver<Result<(), PublisherError>>,
+    ) -> Result<(), PublisherError> {
+        self.tx.send(command).await.map_err(|_| {
+            PublisherError::Unavailable("MQTT supervisor is shutting down".to_string())
+        })?;
+        reply.await.map_err(|_| {
+            PublisherError::Unavailable("MQTT worker dropped the command".to_string())
+        })?
+    }
+}
+
+#[async_trait::async_trait]
+impl MessagePublisher for MqttPublisher {
+    async fn publish(
+        &self,
+        topic: &str,
+        payload: Vec<u8>,
+        retain: bool,
+        delivery: DeliveryGuarantee,
+    ) -> Result<(), PublisherError> {
+        let (reply, rx) = oneshot::channel();
+        self.send(
+            MqttCommand::Publish {
+                topic: topic.to_string(),
+                payload,
+                retain,
+                delivery,
+                reply,
+            },
+            rx,
+        )
+        .await
+    }
+
+    async fn subscribe(
+        &self,
+        topic: &str,
+        delivery: DeliveryGuarantee,
+    ) -> Result<(), PublisherError> {
+        let (reply, rx) = oneshot::channel();
+        self.send(
+            MqttCommand::Subscribe {
+                topic: topic.to_string(),
+                delivery,
+                reply,
+            },
+            rx,
+        )
+        .await
+    }
+
+    async fn unsubscribe(&self, topic: &str) -> Result<(), PublisherError> {
+        let (reply, rx) = oneshot::channel();
+        self.send(
+            MqttCommand::Unsubscribe {
+                topic: topic.to_string(),
+                reply,
+            },
+            rx,
+        )
+        .await
+    }
+}
+
+#[derive(Debug)]
+pub enum MqttSupervisorEvent {
+    /// The broker accepted the MQTT connection. Subscriptions and retained
+    /// daemon state are not ready yet.
+    TransportConnected {
+        generation: u64,
+    },
+    /// The worker restored every subscription known before this generation
+    /// was rebuilt and received all corresponding SUBACK packets.
+    SubscriptionsReady {
+        generation: u64,
+    },
+    /// The daemon command executor has completed subscriptions and state
+    /// restoration for this generation.
+    GenerationReady {
+        generation: u64,
+    },
+    Disconnected {
+        generation: u64,
+        reason: String,
+    },
+    Rebuilt {
+        generation: u64,
+        reason: String,
+    },
+    Terminated,
+}
+
+pub struct MqttSupervisor {
+    pub events: mpsc::Receiver<MqttSupervisorEvent>,
+    pub inbound: mpsc::Receiver<MqttInbound>,
+    inbound_disposition_tx: mpsc::Sender<(u64, MqttInboundDisposition)>,
+    control_tx: mpsc::Sender<MqttControl>,
+    shutdown: Option<oneshot::Sender<()>>,
+    join: Option<tokio::task::JoinHandle<()>>,
+    watchdog_shutdown: Option<oneshot::Sender<()>>,
+    watchdog_join: Option<tokio::task::JoinHandle<()>>,
+}
+
+enum MqttControl {
+    GenerationReady {
+        generation: u64,
+        reply: oneshot::Sender<bool>,
+    },
+    Rebuild {
+        reason: String,
+    },
+}
+
+enum WorkerControl {
+    GenerationReady {
+        generation: u64,
+        reply: oneshot::Sender<bool>,
+    },
+}
+
+enum WorkerEvent {
+    Supervisor(MqttSupervisorEvent),
+    Exited { reason: String },
+}
+
+#[derive(Default)]
+struct MqttHeartbeat {
+    last_progress_ms: std::sync::atomic::AtomicU64,
+    poll_pending_since_ms: std::sync::atomic::AtomicU64,
+}
+
+impl MqttHeartbeat {
+    fn now_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+
+    fn touch(&self) {
+        self.last_progress_ms
+            .store(Self::now_ms(), Ordering::Relaxed);
+    }
+
+    fn begin_poll(&self) {
+        let now = Self::now_ms();
+        let _ = self.poll_pending_since_ms.compare_exchange(
+            0,
+            now,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        );
+    }
+
+    fn end_poll(&self) {
+        self.poll_pending_since_ms.store(0, Ordering::Relaxed);
+    }
+}
+
+fn generation_is_current(active: u64, incoming: u64) -> bool {
+    active == incoming
+}
+
+fn is_current_ready_generation(
+    worker_present: bool,
+    active_generation: u64,
+    transport_connected_generation: Option<u64>,
+    ready_generation: u64,
+) -> bool {
+    worker_present
+        && transport_connected_generation == Some(ready_generation)
+        && generation_is_current(active_generation, ready_generation)
+}
+
+fn restart_delay(failure_count: u32) -> Duration {
+    let shift = failure_count.saturating_sub(1).min(3);
+    let multiplier = 1_u32 << shift;
+    REBUILD_RETRY
+        .checked_mul(multiplier)
+        .unwrap_or(REBUILD_RETRY_MAX)
+        .min(REBUILD_RETRY_MAX)
+}
+
+fn schedule_restart_at(next_restart: &mut Instant, restart_failures: &mut u32, now: Instant) {
+    *restart_failures = restart_failures.saturating_add(1);
+    let retry_at = now + restart_delay(*restart_failures);
+    if *next_restart < retry_at {
+        *next_restart = retry_at;
+    }
+}
+
+fn schedule_restart(next_restart: &mut Instant, restart_failures: &mut u32) {
+    schedule_restart_at(next_restart, restart_failures, Instant::now());
+}
+
+fn watchdog_rebuild_request_allowed(
+    rebuild_due: bool,
+    rebuild_requested_at: &mut Option<Instant>,
+) -> bool {
+    if !rebuild_due {
+        *rebuild_requested_at = None;
+        return false;
+    }
+    rebuild_requested_at.is_none()
+}
+
+impl MqttSupervisor {
+    pub fn spawn(
+        config: DaemonConfig,
+        actor_id: String,
+        initial_token: String,
+        backend: Arc<dyn Backend>,
+        command_rx: mpsc::Receiver<MqttCommand>,
+        connected: Arc<AtomicBool>,
+    ) -> Self {
+        let (events_tx, events) = mpsc::channel(128);
+        let (inbound_tx, inbound) = mpsc::channel(INBOUND_CAPACITY);
+        let (inbound_disposition_tx, inbound_disposition_rx) = mpsc::channel(INBOUND_CAPACITY);
+        let (control_tx, control_rx) = mpsc::channel(CONTROL_CAPACITY);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let heartbeat = Arc::new(MqttHeartbeat::default());
+        heartbeat.touch();
+        let (watchdog_shutdown_tx, watchdog_shutdown_rx) = oneshot::channel();
+        let watchdog_heartbeat = heartbeat.clone();
+        let watchdog_control = control_tx.clone();
+        let watchdog_join = tokio::spawn(async move {
+            mqtt_watchdog(watchdog_heartbeat, watchdog_control, watchdog_shutdown_rx).await;
+        });
+        let join = tokio::spawn(async move {
+            run_supervisor(
+                config,
+                actor_id,
+                initial_token,
+                backend,
+                command_rx,
+                shutdown_rx,
+                events_tx,
+                inbound_tx,
+                inbound_disposition_rx,
+                control_rx,
+                connected,
+                heartbeat,
+            )
+            .await;
+        });
+
+        Self {
+            events,
+            inbound,
+            inbound_disposition_tx,
+            control_tx,
+            shutdown: Some(shutdown_tx),
+            join: Some(join),
+            watchdog_shutdown: Some(watchdog_shutdown_tx),
+            watchdog_join: Some(watchdog_join),
+        }
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(tx) = self.watchdog_shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(join) = self.join.take() {
+            let _ = join.await;
+        }
+        if let Some(join) = self.watchdog_join.take() {
+            let _ = join.await;
+        }
+    }
+
+    pub async fn mark_generation_ready(&self, generation: u64) -> bool {
+        let (reply, result) = oneshot::channel();
+        if self
+            .control_tx
+            .send(MqttControl::GenerationReady { generation, reply })
+            .await
+            .is_err()
+        {
+            return false;
+        }
+        result.await.unwrap_or(false)
+    }
+
+    pub async fn request_rebuild(&self, reason: impl Into<String>) {
+        if self
+            .control_tx
+            .send(MqttControl::Rebuild {
+                reason: reason.into(),
+            })
+            .await
+            .is_err()
+        {
+            warn!("MQTT supervisor closed before rebuild request could be delivered");
+        }
+    }
+
+    /// Mark a durable inbound message handled, or ask the worker to replay it
+    /// after a transient business failure/timeout.
+    pub async fn dispose_inbound(&self, id: u64, disposition: MqttInboundDisposition) {
+        if let Err(error) = self.inbound_disposition_tx.send((id, disposition)).await {
+            warn!(id, %error, "MQTT supervisor closed before durable inbound disposition");
+        }
+    }
+}
+
+struct WorkerHandle {
+    command_tx: mpsc::Sender<MqttCommand>,
+    disposition_tx: mpsc::Sender<(u64, MqttInboundDisposition)>,
+    control_tx: mpsc::Sender<WorkerControl>,
+    stop_tx: Option<oneshot::Sender<()>>,
+    join: tokio::task::JoinHandle<()>,
+}
+
+async fn run_supervisor(
+    config: DaemonConfig,
+    actor_id: String,
+    initial_token: String,
+    backend: Arc<dyn Backend>,
+    mut command_rx: mpsc::Receiver<MqttCommand>,
+    mut shutdown_rx: oneshot::Receiver<()>,
+    events_tx: mpsc::Sender<MqttSupervisorEvent>,
+    inbound_tx: mpsc::Sender<MqttInbound>,
+    mut inbound_disposition_rx: mpsc::Receiver<(u64, MqttInboundDisposition)>,
+    mut control_rx: mpsc::Receiver<MqttControl>,
+    connected: Arc<AtomicBool>,
+    heartbeat: Arc<MqttHeartbeat>,
+) {
+    let (worker_events_tx, mut worker_events_rx) = mpsc::channel(128);
+    let mut worker = Some(spawn_worker(
+        config.clone(),
+        actor_id.clone(),
+        initial_token,
+        backend.clone(),
+        0,
+        BTreeMap::new(),
+        worker_events_tx.clone(),
+        inbound_tx.clone(),
+        connected.clone(),
+        heartbeat.clone(),
+    ));
+    let mut subscriptions = BTreeMap::<String, QoS>::new();
+    let mut pending_commands = VecDeque::<MqttCommand>::new();
+    let mut pending_dispositions = VecDeque::<(u64, MqttInboundDisposition)>::new();
+    let mut generation = 0_u64;
+    let mut transport_connected_generation = None::<u64>;
+    let mut restart_reason = None::<String>;
+    let mut next_restart = Instant::now();
+    let mut restart_failures = 0_u32;
+    let mut shutting_down = false;
+
+    loop {
+        if let Some(active) = worker.as_ref() {
+            while let Some(command) = pending_commands.pop_front() {
+                match active.command_tx.try_send(command) {
+                    Ok(()) => {}
+                    Err(mpsc::error::TrySendError::Full(command)) => {
+                        pending_commands.push_front(command);
+                        break;
+                    }
+                    Err(mpsc::error::TrySendError::Closed(command)) => {
+                        pending_commands.push_front(command);
+                        restart_reason.get_or_insert_with(|| {
+                            "MQTT worker command channel closed".to_string()
+                        });
+                        break;
+                    }
+                }
+            }
+            while let Some(disposition) = pending_dispositions.pop_front() {
+                match active.disposition_tx.try_send(disposition) {
+                    Ok(()) => {}
+                    Err(mpsc::error::TrySendError::Full(disposition)) => {
+                        pending_dispositions.push_front(disposition);
+                        break;
+                    }
+                    Err(mpsc::error::TrySendError::Closed(disposition)) => {
+                        pending_dispositions.push_front(disposition);
+                        restart_reason.get_or_insert_with(|| {
+                            "MQTT worker disposition channel closed".to_string()
+                        });
+                        break;
+                    }
+                }
+            }
+        }
+
+        if worker.is_none() && !shutting_down && Instant::now() >= next_restart {
+            let reason = restart_reason
+                .take()
+                .unwrap_or_else(|| "MQTT worker exited".to_string());
+            let token = match tokio::time::timeout(Duration::from_secs(10), backend.auth_token())
+                .await
+            {
+                Ok(Ok(token)) => token,
+                Ok(Err(error)) => {
+                    warn!(%error, "could not obtain MQTT credential while starting a new worker");
+                    schedule_restart(&mut next_restart, &mut restart_failures);
+                    continue;
+                }
+                Err(_) => {
+                    warn!("timed out obtaining MQTT credential while starting a new worker");
+                    schedule_restart(&mut next_restart, &mut restart_failures);
+                    continue;
+                }
+            };
+            connected.store(false, Ordering::Relaxed);
+            let rebuilt_generation = generation;
+            worker = Some(spawn_worker(
+                config.clone(),
+                actor_id.clone(),
+                token,
+                backend.clone(),
+                generation,
+                subscriptions.clone(),
+                worker_events_tx.clone(),
+                inbound_tx.clone(),
+                connected.clone(),
+                heartbeat.clone(),
+            ));
+            let _ = events_tx
+                .send(MqttSupervisorEvent::Rebuilt {
+                    generation: rebuilt_generation,
+                    reason,
+                })
+                .await;
+        }
+
+        let tick = tokio::time::sleep(SUPERVISOR_TICK);
+        tokio::pin!(tick);
+        tokio::select! {
+            _ = &mut shutdown_rx => {
+                shutting_down = true;
+                break;
+            }
+            command = command_rx.recv() => {
+                let Some(command) = command else {
+                    shutting_down = true;
+                    break;
+                };
+                if pending_commands.len() >= WORKER_COMMAND_CAPACITY {
+                    fail_command(command, "MQTT worker command queue is full");
+                } else {
+                    match &command {
+                        MqttCommand::Subscribe { topic, delivery, .. } => {
+                            subscriptions.insert(topic.clone(), delivery.clone().into());
+                        }
+                        MqttCommand::Unsubscribe { topic, .. } => {
+                            subscriptions.remove(topic);
+                        }
+                        MqttCommand::Publish { .. } => {}
+                    }
+                    pending_commands.push_back(command);
+                }
+            }
+            disposition = inbound_disposition_rx.recv() => {
+                if let Some(disposition) = disposition {
+                    if pending_dispositions.len() >= WORKER_DISPOSITION_CAPACITY {
+                        warn!("MQTT inbound disposition queue is full; durable item will replay after restart");
+                    } else {
+                        pending_dispositions.push_back(disposition);
+                    }
+                }
+            }
+            control = control_rx.recv() => {
+                match control {
+                    Some(MqttControl::GenerationReady { generation: ready_generation, reply }) => {
+                        let accepted = is_current_ready_generation(
+                            worker.is_some(),
+                            generation,
+                            transport_connected_generation,
+                            ready_generation,
+                        );
+                        if accepted {
+                            if let Some(active) = worker.as_ref() {
+                                let readiness = WorkerControl::GenerationReady {
+                                    generation: ready_generation,
+                                    reply,
+                                };
+                                match active.control_tx.try_send(readiness) {
+                                    Ok(()) => {}
+                                    Err(mpsc::error::TrySendError::Full(WorkerControl::GenerationReady { reply, .. }))
+                                    | Err(mpsc::error::TrySendError::Closed(WorkerControl::GenerationReady { reply, .. })) => {
+                                        let _ = reply.send(false);
+                                        warn!(generation = ready_generation, "failed to forward MQTT generation readiness");
+                                    }
+                                }
+                            }
+                        } else {
+                            let _ = reply.send(false);
+                            warn!(generation = ready_generation, active_generation = generation, "ignored stale MQTT generation readiness");
+                        }
+                    }
+                    Some(MqttControl::Rebuild { reason }) => {
+                        restart_reason = Some(reason);
+                        if worker.is_some() {
+                            stop_worker(&mut worker, &heartbeat).await;
+                            transport_connected_generation = None;
+                            connected.store(false, Ordering::Relaxed);
+                        }
+                        schedule_restart(&mut next_restart, &mut restart_failures);
+                    }
+                    None => {
+                        shutting_down = true;
+                        break;
+                    }
+                }
+            }
+            event = worker_events_rx.recv() => {
+                match event {
+                    Some(WorkerEvent::Supervisor(event)) => {
+                        match &event {
+                            MqttSupervisorEvent::TransportConnected { generation: current } => {
+                                generation = *current;
+                                transport_connected_generation = Some(*current);
+                            }
+                            MqttSupervisorEvent::Disconnected { .. } => {
+                                transport_connected_generation = None;
+                                connected.store(false, Ordering::Relaxed);
+                            }
+                            MqttSupervisorEvent::GenerationReady { generation: ready_generation } => {
+                                if is_current_ready_generation(
+                                    worker.is_some(),
+                                    generation,
+                                    transport_connected_generation,
+                                    *ready_generation,
+                                ) {
+                                    restart_failures = 0;
+                                } else {
+                                    debug!(
+                                        generation = *ready_generation,
+                                        active_generation = generation,
+                                        "ignored stale MQTT generation readiness for restart backoff"
+                                    );
+                                }
+                            }
+                            MqttSupervisorEvent::Rebuilt { .. }
+                            | MqttSupervisorEvent::SubscriptionsReady { .. }
+                            | MqttSupervisorEvent::Terminated => {}
+                        }
+                        let _ = events_tx.send(event).await;
+                    }
+                    Some(WorkerEvent::Exited { reason }) => {
+                        if !shutting_down {
+                            warn!(%reason, "MQTT worker exited; supervisor will create a new generation");
+                            restart_reason = Some(reason);
+                            transport_connected_generation = None;
+                            connected.store(false, Ordering::Relaxed);
+                            let had_worker = worker.is_some();
+                            stop_worker(&mut worker, &heartbeat).await;
+                            if had_worker {
+                                schedule_restart(&mut next_restart, &mut restart_failures);
+                            }
+                        }
+                    }
+                    None => {
+                        restart_reason = Some("MQTT worker event channel closed".to_string());
+                        stop_worker(&mut worker, &heartbeat).await;
+                        schedule_restart(&mut next_restart, &mut restart_failures);
+                    }
+                }
+            }
+            _ = &mut tick => {}
+        }
+    }
+
+    connected.store(false, Ordering::Relaxed);
+    stop_worker(&mut worker, &heartbeat).await;
+    while let Some(command) = pending_commands.pop_front() {
+        fail_command(command, "MQTT supervisor is shutting down");
+    }
+    let _ = events_tx.send(MqttSupervisorEvent::Terminated).await;
+}
+
+fn spawn_worker(
+    config: DaemonConfig,
+    actor_id: String,
+    initial_token: String,
+    backend: Arc<dyn Backend>,
+    generation_seed: u64,
+    initial_subscriptions: BTreeMap<String, QoS>,
+    events_tx: mpsc::Sender<WorkerEvent>,
+    inbound_tx: mpsc::Sender<MqttInbound>,
+    connected: Arc<AtomicBool>,
+    heartbeat: Arc<MqttHeartbeat>,
+) -> WorkerHandle {
+    let (command_tx, command_rx) = mpsc::channel(WORKER_COMMAND_CAPACITY);
+    let (disposition_tx, disposition_rx) = mpsc::channel(WORKER_DISPOSITION_CAPACITY);
+    let (control_tx, control_rx) = mpsc::channel(CONTROL_CAPACITY);
+    let (stop_tx, stop_rx) = oneshot::channel();
+    let join = tokio::spawn(async move {
+        let worker = MqttWorker {
+            config,
+            actor_id,
+            initial_token,
+            backend,
+            command_rx,
+            stop_rx,
+            events_tx,
+            inbound_tx,
+            inbound_disposition_rx: disposition_rx,
+            control_rx,
+            connected,
+            heartbeat,
+            generation_seed,
+            initial_subscriptions,
+        };
+        worker.run().await;
+    });
+    WorkerHandle {
+        command_tx,
+        disposition_tx,
+        control_tx,
+        stop_tx: Some(stop_tx),
+        join,
+    }
+}
+
+async fn stop_worker(worker: &mut Option<WorkerHandle>, heartbeat: &MqttHeartbeat) {
+    heartbeat.end_poll();
+    let Some(mut active) = worker.take() else {
+        return;
+    };
+    if let Some(stop_tx) = active.stop_tx.take() {
+        let _ = stop_tx.send(());
+    }
+    if tokio::time::timeout(WORKER_STOP_TIMEOUT, &mut active.join)
+        .await
+        .is_err()
+    {
+        warn!("MQTT worker did not stop within the grace period; aborting its task");
+        active.join.abort();
+        let _ = active.join.await;
+    }
+}
+
+fn fail_command(command: MqttCommand, reason: &str) {
+    let error = PublisherError::Unavailable(reason.to_string());
+    match command {
+        MqttCommand::Publish { reply, .. }
+        | MqttCommand::Subscribe { reply, .. }
+        | MqttCommand::Unsubscribe { reply, .. } => {
+            let _ = reply.send(Err(error));
+        }
+    }
+}
+
+struct MqttWorker {
+    config: DaemonConfig,
+    actor_id: String,
+    initial_token: String,
+    backend: Arc<dyn Backend>,
+    command_rx: mpsc::Receiver<MqttCommand>,
+    stop_rx: oneshot::Receiver<()>,
+    events_tx: mpsc::Sender<WorkerEvent>,
+    inbound_tx: mpsc::Sender<MqttInbound>,
+    inbound_disposition_rx: mpsc::Receiver<(u64, MqttInboundDisposition)>,
+    control_rx: mpsc::Receiver<WorkerControl>,
+    connected: Arc<AtomicBool>,
+    heartbeat: Arc<MqttHeartbeat>,
+    generation_seed: u64,
+    initial_subscriptions: BTreeMap<String, QoS>,
+}
+
+impl MqttWorker {
+    async fn run(mut self) {
+        let mut store = match DurableMqttStore::open_default() {
+            Ok(store) => store,
+            Err(error) => {
+                error!(%error, "failed to open durable MQTT inbox/outbox");
+                self.connected.store(false, Ordering::Relaxed);
+                let _ = self
+                    .events_tx
+                    .send(WorkerEvent::Exited {
+                        reason: "durable MQTT store could not be opened".to_string(),
+                    })
+                    .await;
+                return;
+            }
+        };
+        let mut client = match MqttClient::new(&self.config, &self.actor_id, &self.initial_token) {
+            Ok(client) => Some(client),
+            Err(error) => {
+                error!(%error, "failed to build initial MQTT client");
+                None
+            }
+        };
+        let mut generation = self.generation_seed;
+        let mut poll_error_count = 0_u64;
+        let mut connected = false;
+        let mut generation_ready = false;
+        let mut recovery_started = None;
+        let mut next_proactive_reconnect =
+            proactive_reconnect_deadline(self.backend.cached_credential_expiry_epoch());
+        let mut subscriptions = self.initial_subscriptions.clone();
+        let mut pending = load_pending_publishes(&store);
+        let mut publish_waiting_for_write = VecDeque::<u64>::new();
+        let mut publish_inflight = HashMap::<u16, u64>::new();
+        let mut subscribe_waiting_for_write = VecDeque::<PendingSubscribe>::new();
+        let mut subscribe_inflight = HashMap::<u16, PendingSubscribe>::new();
+        let mut inbound_staging = load_pending_inbound(&store);
+        let mut forced_rebuild = None::<String>;
+        let mut auto_restore_subscriptions = false;
+        let mut subscriptions_ready_announced = false;
+        let mut exit_reason = "MQTT worker stopped".to_string();
+
+        loop {
+            self.heartbeat.touch();
+            self.flush_inbound(&mut inbound_staging);
+
+            if connected && generation_ready {
+                self.flush_pending(&mut client, &mut pending, &mut publish_waiting_for_write);
+            }
+
+            let tick = tokio::time::sleep(SUPERVISOR_TICK);
+            tokio::pin!(tick);
+
+            if let Some(active) = client.as_mut() {
+                // Keep driving the event loop even when the durable inbox is
+                // full. Backpressure must stop accepting/ACKing business
+                // messages, not MQTT keepalive traffic.
+                self.heartbeat.begin_poll();
+                tokio::select! {
+                    _ = &mut self.stop_rx => {
+                        exit_reason = "MQTT worker stop requested".to_string();
+                        break;
+                    }
+                    command = self.command_rx.recv() => {
+                        if !self.accept_command(
+                            command,
+                            connected,
+                            Some(active.client.clone()),
+                            &mut subscriptions,
+                            &mut pending,
+                            &mut store,
+                            &mut subscribe_waiting_for_write,
+                        ) {
+                            exit_reason = "MQTT worker command channel closed".to_string();
+                            break;
+                        }
+                    }
+                    control = self.control_rx.recv() => {
+                        match control {
+                            Some(WorkerControl::GenerationReady { generation: ready_generation, reply }) => {
+                                let accepted = generation_is_current(generation, ready_generation) && connected;
+                                if accepted {
+                                    generation_ready = true;
+                                    self.connected.store(true, Ordering::Relaxed);
+                                    let _ = self.events_tx.send(WorkerEvent::Supervisor(MqttSupervisorEvent::GenerationReady {
+                                        generation: ready_generation,
+                                    })).await;
+                                    info!(generation = ready_generation, "MQTT generation is fully ready");
+                                } else {
+                                    warn!(generation = ready_generation, active_generation = generation, connected, "ignored stale MQTT generation readiness");
+                                }
+                                let _ = reply.send(accepted);
+                            }
+                            None => {
+                                exit_reason = "MQTT worker control channel closed".to_string();
+                                break;
+                            }
+                        }
+                    }
+                    disposition = self.inbound_disposition_rx.recv() => {
+                        if let Some((id, disposition)) = disposition {
+                            self.handle_inbound_disposition(
+                                id,
+                                disposition,
+                                &mut store,
+                                &mut inbound_staging,
+                            );
+                        }
+                    }
+                    poll_result = active.eventloop.poll() => {
+                        match poll_result {
+                            Ok(Event::Incoming(Packet::ConnAck(_))) => {
+                                let previous_poll_errors = poll_error_count;
+                                poll_error_count = 0;
+                                self.requeue_publish_attempts(
+                                    &mut pending,
+                                    &mut publish_waiting_for_write,
+                                    &mut publish_inflight,
+                                    &store,
+                                );
+                                self.fail_pending_subscriptions(
+                                    &mut subscribe_waiting_for_write,
+                                    &mut subscribe_inflight,
+                                    "MQTT connection generation changed",
+                                );
+                                generation = generation.wrapping_add(1);
+                                connected = true;
+                                generation_ready = false;
+                                recovery_started = None;
+                                self.connected.store(false, Ordering::Relaxed);
+                                self.heartbeat.end_poll();
+                                auto_restore_subscriptions = !subscriptions.is_empty();
+                                subscriptions_ready_announced = !auto_restore_subscriptions;
+                                if auto_restore_subscriptions {
+                                    for (topic, qos) in &subscriptions {
+                                        if let Err(error) = active.client.try_subscribe(topic.clone(), *qos) {
+                                            warn!(%error, topic, generation, "failed to queue MQTT subscription restore");
+                                            forced_rebuild = Some("subscription restore queue rejected".to_string());
+                                        } else {
+                                            subscribe_waiting_for_write.push_back(PendingSubscribe {
+                                                topic: topic.clone(),
+                                                reply: None,
+                                            });
+                                        }
+                                    }
+                                }
+                                next_proactive_reconnect = proactive_reconnect_deadline(
+                                    self.backend.cached_credential_expiry_epoch(),
+                                );
+                                info!(generation, subscriptions = subscriptions.len(), previous_poll_errors, "MQTT transport connected; waiting for subscription and state restore");
+                                let _ = self.events_tx.send(WorkerEvent::Supervisor(MqttSupervisorEvent::TransportConnected { generation })).await;
+                                if !auto_restore_subscriptions {
+                                    self.announce_subscriptions_ready(
+                                        generation,
+                                        &mut subscriptions_ready_announced,
+                                    ).await;
+                                }
+                            }
+                            Ok(Event::Incoming(Packet::Publish(publish))) => {
+                                self.heartbeat.end_poll();
+                                if subscriber::parse_incoming(&publish).is_some() {
+                                    let frame = IncomingFrame {
+                                        topic: publish.topic.clone(),
+                                        payload: publish.payload.to_vec(),
+                                        retained: publish.retain,
+                                    };
+                                    if durable_inbox_blocked(&store)
+                                        || store
+                                            .inbox_bytes()
+                                            .saturating_add(frame.topic.len())
+                                            .saturating_add(frame.payload.len())
+                                            > DURABLE_QUEUE_MAX_BYTES
+                                    {
+                                        warn!(
+                                            capacity = DURABLE_QUEUE_CAPACITY,
+                                            max_bytes = DURABLE_QUEUE_MAX_BYTES,
+                                            "durable MQTT inbox is full; withholding broker ACK until business ACK"
+                                        );
+                                    } else {
+                                        match store.enqueue_inbound(frame.clone()) {
+                                            Ok(id) => {
+                                                inbound_staging.push_back(MqttInbound { id, frame });
+                                                // manual_acks is enabled in MqttClient. The
+                                                // broker ACK is emitted only after the local
+                                                // durable inbox append has synced.
+                                                if let Err(error) = active.client.try_ack(&publish) {
+                                                    warn!(%error, "failed to ACK durably stored MQTT inbound");
+                                                }
+                                            }
+                                            Err(error) => {
+                                                error!(%error, "failed to append MQTT inbound to durable inbox");
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            Ok(Event::Incoming(Packet::PubAck(ack))) => {
+                                self.heartbeat.end_poll();
+                                if let Some(id) = publish_inflight.remove(&ack.pkid) {
+                                    self.ack_publish(id, &mut store);
+                                }
+                            }
+                            Ok(Event::Incoming(Packet::PubComp(comp))) => {
+                                self.heartbeat.end_poll();
+                                if let Some(id) = publish_inflight.remove(&comp.pkid) {
+                                    self.ack_publish(id, &mut store);
+                                }
+                            }
+                            Ok(Event::Incoming(Packet::SubAck(ack))) => {
+                                self.heartbeat.end_poll();
+                                if let Some(request) = subscribe_inflight.remove(&ack.pkid) {
+                                    let success = !ack.return_codes.iter().any(|code| matches!(code, rumqttc::SubscribeReasonCode::Failure));
+                                    let result = if success {
+                                        Ok(())
+                                    } else {
+                                        Err(PublisherError::Unavailable(format!("MQTT broker rejected subscription for {}", request.topic)))
+                                    };
+                                    if let Some(reply) = request.reply {
+                                        let _ = reply.send(result);
+                                    }
+                                    if success
+                                        && auto_restore_subscriptions
+                                        && subscribe_waiting_for_write.is_empty()
+                                        && subscribe_inflight.is_empty()
+                                    {
+                                        self.announce_subscriptions_ready(
+                                            generation,
+                                            &mut subscriptions_ready_announced,
+                                        ).await;
+                                    } else if !success && auto_restore_subscriptions {
+                                        forced_rebuild = Some(format!(
+                                            "broker rejected restored subscription {}",
+                                            request.topic
+                                        ));
+                                    }
+                                } else {
+                                    debug!(pkid = ack.pkid, "received MQTT SUBACK without a tracked request");
+                                }
+                            }
+                            Ok(Event::Outgoing(Outgoing::Publish(pkid))) => {
+                                self.heartbeat.end_poll();
+                                if let Some(id) = publish_waiting_for_write.pop_front() {
+                                    if pkid == 0 {
+                                        self.ack_publish(id, &mut store);
+                                    } else {
+                                        publish_inflight.insert(pkid, id);
+                                    }
+                                }
+                            }
+                            Ok(Event::Outgoing(Outgoing::Subscribe(pkid))) => {
+                                self.heartbeat.end_poll();
+                                if let Some(request) = subscribe_waiting_for_write.pop_front() {
+                                    subscribe_inflight.insert(pkid, request);
+                                }
+                            }
+                            Err(error) => {
+                                poll_error_count = poll_error_count.saturating_add(1);
+                                self.heartbeat.end_poll();
+                                self.requeue_publish_attempts(
+                                    &mut pending,
+                                    &mut publish_waiting_for_write,
+                                    &mut publish_inflight,
+                                    &store,
+                                );
+                                let reason = error.to_string();
+                                if let rumqttc::ConnectionError::ConnectionRefused(code) = &error {
+                                    use rumqttc::mqttbytes::v4::ConnectReturnCode;
+                                    if matches!(code, ConnectReturnCode::BadUserNamePassword | ConnectReturnCode::NotAuthorized) {
+                                        self.backend.invalidate_cached_credential();
+                                        warn!(?code, "MQTT authentication rejected; invalidating cached credential");
+                                    } else {
+                                        warn!(?code, "MQTT connection refused for a non-auth reason");
+                                    }
+                                }
+                                if connected {
+                                    connected = false;
+                                    generation_ready = false;
+                                    self.connected.store(false, Ordering::Relaxed);
+                                    let _ = self.events_tx.send(WorkerEvent::Supervisor(MqttSupervisorEvent::Disconnected {
+                                        generation,
+                                        reason: reason.clone(),
+                                    })).await;
+                                }
+                                recovery_started.get_or_insert_with(Instant::now);
+                                warn!(
+                                    generation,
+                                    poll_error_count,
+                                    recovery_elapsed_ms = recovery_started
+                                        .map(|started| started.elapsed().as_millis() as u64)
+                                        .unwrap_or_default(),
+                                    %reason,
+                                    "MQTT transport error; rumqttc automatic recovery remains active"
+                                );
+                            }
+                            Ok(_) => {
+                                // Includes PingResp and other protocol-level
+                                // traffic. They are poll progress even when
+                                // they do not change business state.
+                                self.heartbeat.end_poll();
+                            }
+                        }
+                    }
+                    _ = &mut tick => {
+                        self.heartbeat.touch();
+                        let recovery_expired = recovery_started
+                            .is_some_and(|started| started.elapsed() >= RECOVERY_DEADLINE);
+                        let proactive_due = next_proactive_reconnect
+                            .is_some_and(|deadline| Instant::now() >= deadline);
+                        if forced_rebuild.is_some() || recovery_expired || proactive_due {
+                            let forced = forced_rebuild.take();
+                            let reason = forced.clone().unwrap_or_else(|| {
+                                if recovery_expired {
+                                    "recovery deadline exceeded".to_string()
+                                } else {
+                                    "proactive credential refresh".to_string()
+                                }
+                            });
+                            self.connected.store(false, Ordering::Relaxed);
+                            connected = false;
+                            generation_ready = false;
+                            self.fail_pending_subscriptions(
+                                &mut subscribe_waiting_for_write,
+                                &mut subscribe_inflight,
+                                &reason,
+                            );
+                            exit_reason = reason;
+                            break;
+                        }
+                    }
+                }
+            } else {
+                tokio::select! {
+                    _ = &mut self.stop_rx => {
+                        exit_reason = "MQTT worker stop requested".to_string();
+                        break;
+                    }
+                    command = self.command_rx.recv() => {
+                        if !self.accept_command(
+                            command,
+                            false,
+                            None,
+                            &mut subscriptions,
+                            &mut pending,
+                            &mut store,
+                            &mut subscribe_waiting_for_write,
+                        ) {
+                            exit_reason = "MQTT worker command channel closed".to_string();
+                            break;
+                        }
+                    }
+                    control = self.control_rx.recv() => {
+                        match control {
+                            Some(WorkerControl::GenerationReady { generation: ready_generation, reply }) => {
+                                let accepted = false;
+                                warn!(generation = ready_generation, active_generation = generation, "ignored MQTT generation readiness while transport is offline");
+                                let _ = reply.send(accepted);
+                            }
+                            None => {
+                                exit_reason = "MQTT worker control channel closed".to_string();
+                                break;
+                            }
+                        }
+                    }
+                    disposition = self.inbound_disposition_rx.recv() => {
+                        if let Some((id, disposition)) = disposition {
+                            self.handle_inbound_disposition(
+                                id,
+                                disposition,
+                                &mut store,
+                                &mut inbound_staging,
+                            );
+                        }
+                    }
+                    _ = &mut tick => {
+                        let reason = forced_rebuild
+                            .take()
+                            .unwrap_or_else(|| "client construction failed".to_string());
+                        self.fail_pending_subscriptions(
+                            &mut subscribe_waiting_for_write,
+                            &mut subscribe_inflight,
+                            &reason,
+                        );
+                        exit_reason = reason;
+                        break;
+                    }
+                }
+            }
+        }
+
+        self.heartbeat.end_poll();
+        self.connected.store(false, Ordering::Relaxed);
+        let reason = exit_reason;
+        while let Some(publish) = pending.pop_front() {
+            self.fail_pending_publish(publish, &reason);
+        }
+        // A subscription request must never wait forever when the worker is
+        // shutting down before a SUBACK arrives.
+        self.fail_pending_subscriptions(
+            &mut subscribe_waiting_for_write,
+            &mut subscribe_inflight,
+            &reason,
+        );
+        self.fail_queued_commands(&reason);
+        let _ = self.events_tx.send(WorkerEvent::Exited { reason }).await;
+    }
+
+    fn accept_command(
+        &self,
+        command: Option<MqttCommand>,
+        connected: bool,
+        mqtt_client: Option<rumqttc::AsyncClient>,
+        subscriptions: &mut BTreeMap<String, QoS>,
+        pending: &mut VecDeque<PendingPublish>,
+        store: &mut DurableMqttStore,
+        subscribe_waiting_for_write: &mut VecDeque<PendingSubscribe>,
+    ) -> bool {
+        let Some(command) = command else {
+            return false;
+        };
+
+        match command {
+            MqttCommand::Subscribe {
+                topic,
+                delivery,
+                reply,
+            } => {
+                let qos: QoS = delivery.clone().into();
+                subscriptions.insert(topic.clone(), qos);
+                let result = if connected {
+                    let result = mqtt_client
+                        .expect("connected MQTT command must have a client")
+                        .try_subscribe(topic.clone(), qos)
+                        .map_err(PublisherError::from);
+                    if result.is_ok() {
+                        subscribe_waiting_for_write.push_back(PendingSubscribe {
+                            topic,
+                            reply: Some(reply),
+                        });
+                        return true;
+                    }
+                    result
+                } else {
+                    Ok(())
+                };
+                let _ = reply.send(result);
+            }
+            MqttCommand::Unsubscribe { topic, reply } => {
+                subscriptions.remove(&topic);
+                let result = if connected {
+                    mqtt_client
+                        .expect("connected MQTT command must have a client")
+                        .try_unsubscribe(topic)
+                        .map_err(PublisherError::from)
+                } else {
+                    Ok(())
+                };
+                let _ = reply.send(result);
+            }
+            MqttCommand::Publish {
+                topic,
+                payload,
+                retain,
+                delivery,
+                reply,
+            } => {
+                if store.outbox_len() >= DURABLE_QUEUE_CAPACITY
+                    || store
+                        .outbox_bytes()
+                        .saturating_add(payload.len())
+                        .saturating_add(topic.len())
+                        > DURABLE_QUEUE_MAX_BYTES
+                {
+                    let _ = reply.send(Err(PublisherError::Unavailable(
+                        "MQTT durable outbox is full".to_string(),
+                    )));
+                    warn!(
+                        capacity = DURABLE_QUEUE_CAPACITY,
+                        max_bytes = DURABLE_QUEUE_MAX_BYTES,
+                        "MQTT durable outbox is full"
+                    );
+                    return true;
+                }
+                let publish = DurablePublish {
+                    topic,
+                    payload,
+                    retain,
+                    delivery: StoredDelivery::from(delivery),
+                };
+                match store.enqueue_publish(publish.clone()) {
+                    Ok(id) => {
+                        // `publish()` success means the message is durable and
+                        // accepted by the supervisor. Broker ACK handling may
+                        // happen later, including after a generation rebuild.
+                        let _ = reply.send(Ok(()));
+                        pending.push_back(PendingPublish {
+                            id,
+                            publish,
+                            reply: None,
+                        });
+                    }
+                    Err(error) => {
+                        let _ = reply.send(Err(PublisherError::Unavailable(format!(
+                            "could not persist MQTT publish: {error}"
+                        ))));
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    fn flush_pending(
+        &self,
+        client: &mut Option<MqttClient>,
+        pending: &mut VecDeque<PendingPublish>,
+        waiting_for_write: &mut VecDeque<u64>,
+    ) {
+        let Some(client) = client.as_ref().map(|client| client.client.clone()) else {
+            return;
+        };
+        // Keep this bounded per loop so a publish burst cannot starve poll().
+        for _ in 0..64 {
+            let Some(pending_publish) = pending.pop_front() else {
+                break;
+            };
+            if let Err(error) = client.try_publish(
+                pending_publish.publish.topic.clone(),
+                DeliveryGuarantee::from(pending_publish.publish.delivery).into(),
+                pending_publish.publish.retain,
+                pending_publish.publish.payload.clone(),
+            ) {
+                pending.push_front(pending_publish);
+                debug!(%error, "MQTT client queue rejected durable outbox item; retrying");
+                break;
+            }
+            waiting_for_write.push_back(pending_publish.id);
+        }
+    }
+
+    fn requeue_publish_attempts(
+        &self,
+        pending: &mut VecDeque<PendingPublish>,
+        waiting_for_write: &mut VecDeque<u64>,
+        inflight: &mut HashMap<u16, u64>,
+        store: &DurableMqttStore,
+    ) {
+        let mut ids = waiting_for_write.drain(..).collect::<Vec<_>>();
+        ids.extend(inflight.drain().map(|(_, id)| id));
+        ids.sort_unstable();
+        for id in ids.into_iter().rev() {
+            if let Some(publish) = store.outbox(id).cloned() {
+                pending.push_front(PendingPublish {
+                    id,
+                    publish,
+                    reply: None,
+                });
+            }
+        }
+    }
+
+    fn handle_inbound_disposition(
+        &self,
+        id: u64,
+        disposition: MqttInboundDisposition,
+        store: &mut DurableMqttStore,
+        staging: &mut VecDeque<MqttInbound>,
+    ) {
+        match disposition {
+            MqttInboundDisposition::Ack => {
+                if let Err(error) = store.ack_inbound(id) {
+                    warn!(%error, id, "failed to ACK durable MQTT inbox item");
+                }
+            }
+            MqttInboundDisposition::Retry => {
+                if let Some(item) = store.inbound(id) {
+                    let frame = IncomingFrame {
+                        topic: item.topic.clone(),
+                        payload: item.payload.clone(),
+                        retained: item.retained,
+                    };
+                    if staging.len() < INBOUND_STAGING_CAPACITY {
+                        staging.push_back(MqttInbound { id, frame });
+                    } else {
+                        warn!(
+                            capacity = INBOUND_STAGING_CAPACITY,
+                            id,
+                            "MQTT inbound staging is full; durable item will replay after restart"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn ack_publish(&self, id: u64, store: &mut DurableMqttStore) {
+        if let Err(error) = store.ack_publish(id) {
+            // Keep the item in the log if the ACK record could not be synced;
+            // replaying once is safer than silently losing a publish.
+            warn!(%error, id, "failed to ACK durable MQTT outbox item");
+        }
+    }
+
+    fn flush_inbound(&self, staging: &mut VecDeque<MqttInbound>) {
+        while let Some(frame) = staging.pop_front() {
+            match self.inbound_tx.try_send(frame) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(frame)) => {
+                    staging.push_front(frame);
+                    break;
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => break,
+            }
+        }
+    }
+
+    async fn announce_subscriptions_ready(&self, generation: u64, announced: &mut bool) {
+        if *announced {
+            return;
+        }
+        *announced = true;
+        let _ = self
+            .events_tx
+            .send(WorkerEvent::Supervisor(
+                MqttSupervisorEvent::SubscriptionsReady { generation },
+            ))
+            .await;
+        info!(
+            generation,
+            "MQTT subscriptions restored and SUBACKs received"
+        );
+    }
+
+    fn fail_command(&self, command: MqttCommand, reason: &str) {
+        let error = PublisherError::Unavailable(reason.to_string());
+        match command {
+            MqttCommand::Publish { reply, .. }
+            | MqttCommand::Subscribe { reply, .. }
+            | MqttCommand::Unsubscribe { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+        }
+    }
+
+    fn fail_pending_publish(&self, publish: PendingPublish, reason: &str) {
+        if let Some(reply) = publish.reply {
+            let _ = reply.send(Err(PublisherError::Unavailable(reason.to_string())));
+        }
+    }
+
+    fn fail_pending_subscriptions(
+        &self,
+        waiting_for_write: &mut VecDeque<PendingSubscribe>,
+        inflight: &mut HashMap<u16, PendingSubscribe>,
+        reason: &str,
+    ) {
+        for request in waiting_for_write
+            .drain(..)
+            .chain(inflight.drain().map(|(_, request)| request))
+        {
+            if let Some(reply) = request.reply {
+                let _ = reply.send(Err(PublisherError::Unavailable(format!(
+                    "MQTT subscription interrupted: {reason}"
+                ))));
+            }
+        }
+    }
+
+    fn fail_queued_commands(&mut self, reason: &str) {
+        while let Ok(command) = self.command_rx.try_recv() {
+            self.fail_command(command, reason);
+        }
+    }
+}
+
+struct PendingPublish {
+    id: u64,
+    publish: DurablePublish,
+    /// New publishes are acknowledged when durably accepted, so this is only
+    /// populated by future callers that choose broker-ACK completion.
+    reply: Option<oneshot::Sender<Result<(), PublisherError>>>,
+}
+
+struct PendingSubscribe {
+    topic: String,
+    reply: Option<oneshot::Sender<Result<(), PublisherError>>>,
+}
+
+async fn mqtt_watchdog(
+    heartbeat: Arc<MqttHeartbeat>,
+    control_tx: mpsc::Sender<MqttControl>,
+    mut shutdown: oneshot::Receiver<()>,
+) {
+    let mut interval = tokio::time::interval(SUPERVISOR_TICK);
+    let mut last_stall_warning = None::<Instant>;
+    let mut rebuild_requested_at = None::<Instant>;
+    loop {
+        tokio::select! {
+            _ = &mut shutdown => break,
+            _ = interval.tick() => {
+                let now = MqttHeartbeat::now_ms();
+                let progress_age = now.saturating_sub(heartbeat.last_progress_ms.load(Ordering::Relaxed));
+                if progress_age >= WORKER_STALL_WARN.as_millis() as u64
+                    && last_stall_warning.map_or(true, |at| at.elapsed() >= WORKER_STALL_WARN)
+                {
+                    warn!(age_ms = progress_age, "MQTT worker heartbeat is delayed; this is a task-liveness warning, not an idle-connection failure");
+                    last_stall_warning = Some(Instant::now());
+                }
+
+                let pending_since = heartbeat.poll_pending_since_ms.load(Ordering::Relaxed);
+                let pending_age = now.saturating_sub(pending_since);
+                if pending_since != 0 && pending_age >= POLL_PENDING_WARN.as_millis() as u64 {
+                    debug!(age_ms = pending_age, "MQTT eventloop poll is pending; an idle connection is expected to have no MQTT events");
+                }
+                let (rebuild_due, reason, age_ms) = if pending_since != 0
+                    && pending_age >= POLL_PENDING_REBUILD.as_millis() as u64
+                {
+                    (
+                        true,
+                        "eventloop poll pending beyond watchdog bound",
+                        pending_age,
+                    )
+                } else if progress_age >= POLL_PENDING_REBUILD.as_millis() as u64 {
+                    (
+                        true,
+                        "MQTT worker heartbeat stalled beyond watchdog bound",
+                        progress_age,
+                    )
+                } else {
+                    (false, "", 0)
+                };
+                if watchdog_rebuild_request_allowed(rebuild_due, &mut rebuild_requested_at) {
+                    warn!(age_ms, %reason, "MQTT worker exceeded the watchdog recovery bound; requesting controlled generation rebuild");
+                    if control_tx.send(MqttControl::Rebuild {
+                        reason: reason.to_string(),
+                    }).await.is_ok() {
+                        rebuild_requested_at = Some(Instant::now());
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn load_pending_publishes(store: &DurableMqttStore) -> VecDeque<PendingPublish> {
+    store
+        .pending_outbox()
+        .map(|(id, publish)| PendingPublish {
+            id,
+            publish: publish.clone(),
+            reply: None,
+        })
+        .collect()
+}
+
+fn durable_inbox_blocked(store: &DurableMqttStore) -> bool {
+    store.inbound_len() >= DURABLE_QUEUE_CAPACITY || store.inbox_bytes() >= DURABLE_QUEUE_MAX_BYTES
+}
+
+fn proactive_reconnect_deadline(expires_at_epoch: Option<i64>) -> Option<Instant> {
+    let delay = proactive_reconnect_delay(expires_at_epoch);
+    (!delay.is_zero()).then(|| Instant::now() + delay)
+}
+
+fn load_pending_inbound(store: &DurableMqttStore) -> VecDeque<MqttInbound> {
+    store
+        .pending_inbound()
+        .map(|(id, item)| MqttInbound {
+            id,
+            frame: IncomingFrame {
+                topic: item.topic.clone(),
+                payload: item.payload.clone(),
+                retained: item.retained,
+            },
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_generation_is_rejected_by_the_readiness_fence() {
+        assert!(generation_is_current(7, 7));
+        assert!(!generation_is_current(7, 6));
+        assert!(!generation_is_current(7, 8));
+        assert!(is_current_ready_generation(true, 7, Some(7), 7));
+        assert!(!is_current_ready_generation(true, 7, Some(7), 6));
+        assert!(!is_current_ready_generation(true, 7, None, 7));
+        assert!(!is_current_ready_generation(false, 7, Some(7), 7));
+    }
+
+    #[test]
+    fn heartbeat_tracks_poll_pending_separately_from_task_progress() {
+        let heartbeat = MqttHeartbeat::default();
+        heartbeat.touch();
+        assert_eq!(heartbeat.poll_pending_since_ms.load(Ordering::Relaxed), 0);
+        heartbeat.begin_poll();
+        assert!(heartbeat.poll_pending_since_ms.load(Ordering::Relaxed) > 0);
+        heartbeat.touch();
+        assert!(heartbeat.last_progress_ms.load(Ordering::Relaxed) > 0);
+        heartbeat.end_poll();
+        assert_eq!(heartbeat.poll_pending_since_ms.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn restart_backoff_is_capped_after_repeated_worker_failures() {
+        assert_eq!(restart_delay(1), Duration::from_secs(5));
+        assert_eq!(restart_delay(2), Duration::from_secs(10));
+        assert_eq!(restart_delay(3), Duration::from_secs(20));
+        assert_eq!(restart_delay(4), Duration::from_secs(30));
+        assert_eq!(restart_delay(20), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn restart_deadline_never_moves_earlier_than_retry_window() {
+        let now = Instant::now();
+        let mut next_restart = now + Duration::from_secs(20);
+        let mut restart_failures = 0;
+
+        schedule_restart_at(&mut next_restart, &mut restart_failures, now);
+
+        assert_eq!(restart_failures, 1);
+        assert_eq!(next_restart, now + Duration::from_secs(20));
+    }
+
+    #[test]
+    fn repeated_restart_requests_use_monotonic_exponential_backoff() {
+        let now = Instant::now();
+        let mut next_restart = now;
+        let mut restart_failures = 0;
+
+        schedule_restart_at(&mut next_restart, &mut restart_failures, now);
+        assert_eq!(next_restart, now + Duration::from_secs(5));
+
+        schedule_restart_at(
+            &mut next_restart,
+            &mut restart_failures,
+            now + Duration::from_millis(1),
+        );
+        assert!(next_restart >= now + Duration::from_secs(10));
+
+        schedule_restart_at(
+            &mut next_restart,
+            &mut restart_failures,
+            now + Duration::from_millis(2),
+        );
+        assert!(next_restart >= now + Duration::from_secs(20));
+
+        schedule_restart_at(
+            &mut next_restart,
+            &mut restart_failures,
+            now + Duration::from_millis(3),
+        );
+        assert!(next_restart >= now + Duration::from_secs(30));
+        assert_eq!(restart_failures, 4);
+    }
+
+    #[test]
+    fn watchdog_rebuild_gate_rearms_after_recovery() {
+        let mut requested_at = None;
+
+        assert!(watchdog_rebuild_request_allowed(true, &mut requested_at));
+        requested_at = Some(Instant::now());
+        assert!(!watchdog_rebuild_request_allowed(true, &mut requested_at));
+
+        assert!(!watchdog_rebuild_request_allowed(false, &mut requested_at));
+        assert!(requested_at.is_none());
+        assert!(watchdog_rebuild_request_allowed(true, &mut requested_at));
+    }
+
+    #[test]
+    fn proactive_refresh_window_does_not_trigger_a_rebuild_loop() {
+        let near_expiry = crate::backend::epoch_secs_now() + 60;
+        assert!(proactive_reconnect_deadline(Some(near_expiry)).is_none());
+        assert!(proactive_reconnect_deadline(None).is_some());
+    }
+
+    #[tokio::test]
+    async fn stable_publisher_routes_commands_without_exposing_client_generation() {
+        let (publisher, mut commands) = MqttPublisher::channel();
+        let task = tokio::spawn(async move {
+            publisher
+                .publish(
+                    "amux/team/actor/state",
+                    vec![1, 2, 3],
+                    true,
+                    DeliveryGuarantee::AtLeastOnce,
+                )
+                .await
+        });
+
+        let command = commands.recv().await.expect("publish command");
+        match command {
+            MqttCommand::Publish {
+                topic,
+                payload,
+                retain,
+                delivery,
+                reply,
+            } => {
+                assert_eq!(topic, "amux/team/actor/state");
+                assert_eq!(payload, vec![1, 2, 3]);
+                assert!(retain);
+                assert_eq!(delivery, DeliveryGuarantee::AtLeastOnce);
+                reply.send(Ok(())).expect("reply receiver is alive");
+            }
+            _ => panic!("unexpected command"),
+        }
+
+        assert!(task.await.expect("publisher task").is_ok());
+    }
+
+    #[tokio::test]
+    async fn stable_publisher_reports_supervisor_shutdown() {
+        let (publisher, commands) = MqttPublisher::channel();
+        drop(commands);
+
+        let result = publisher
+            .publish(
+                "amux/team/actor/state",
+                vec![],
+                false,
+                DeliveryGuarantee::AtMostOnce,
+            )
+            .await;
+
+        assert!(matches!(result, Err(PublisherError::Unavailable(_))));
+    }
+}

--- a/apps/daemon/src/mqtt/supervisor.rs
+++ b/apps/daemon/src/mqtt/supervisor.rs
@@ -44,6 +44,8 @@ const WORKER_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 const RECOVERY_SIGNAL_TIMEOUT: Duration = Duration::from_secs(2);
 const WAKE_GAP_THRESHOLD: Duration = Duration::from_secs(120);
 const INBOUND_RETRY_MAX: Duration = Duration::from_secs(30);
+const SUPERVISOR_EVENT_SEND_TIMEOUT: Duration = Duration::from_secs(2);
+const DURABLE_STORE_FAILURE_PREFIX: &str = "durable_store:";
 
 /// The one snapshot published to `/v1/info`. Keeping the fields together
 /// prevents the UI from observing `connected=true` with a stale recovery phase.
@@ -110,6 +112,18 @@ fn mqtt_error_code(reason: &str) -> &'static str {
     }
 }
 
+fn should_persist_publish(delivery: &DeliveryGuarantee) -> bool {
+    !matches!(delivery, DeliveryGuarantee::AtMostOnce)
+}
+
+fn is_durable_store_failure(reason: &str) -> bool {
+    reason.starts_with(DURABLE_STORE_FAILURE_PREFIX)
+}
+
+fn recovery_may_retry_storage(reason: MqttRecoveryReason) -> bool {
+    matches!(reason, MqttRecoveryReason::UserRequested)
+}
+
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MqttRecoveryReason {
@@ -174,14 +188,18 @@ pub struct MqttRecoveryRequest {
     pub reason: MqttRecoveryReason,
     pub request_id: String,
     pub reply: oneshot::Sender<MqttRecoveryAccepted>,
+    coalescing: Arc<AtomicBool>,
 }
 
-/// A bounded, try-send-only recovery signal. The HTTP layer can be started
-/// before the supervisor, so the receiver is attached later by `spawn`.
+/// A bounded recovery signal with sender-side coalescing. The HTTP layer can be
+/// started before the supervisor, so the receiver is attached later by
+/// `spawn`. Concurrent focus/online/wake signals share one recovery edge and
+/// do not turn a healthy request queue into a spurious HTTP 503.
 #[derive(Debug, Clone)]
 pub struct MqttRecoveryHandle {
     tx: mpsc::Sender<MqttRecoveryRequest>,
     next_request_id: Arc<AtomicU64>,
+    coalescing: Arc<AtomicBool>,
 }
 
 impl MqttRecoveryHandle {
@@ -191,6 +209,7 @@ impl MqttRecoveryHandle {
             Self {
                 tx,
                 next_request_id: Arc::new(AtomicU64::new(1)),
+                coalescing: Arc::new(AtomicBool::new(false)),
             },
             rx,
         )
@@ -204,18 +223,45 @@ impl MqttRecoveryHandle {
             "mqtt-recovery-{}",
             self.next_request_id.fetch_add(1, Ordering::Relaxed)
         );
+        if self.coalescing.swap(true, Ordering::AcqRel) {
+            return Ok(MqttRecoveryAccepted {
+                accepted: true,
+                outcome: MqttRecoveryOutcome::Recovering,
+                request_id,
+                worker_generation: None,
+            });
+        }
         let (reply, response) = oneshot::channel();
-        self.tx
+        if self
+            .tx
             .try_send(MqttRecoveryRequest {
                 reason,
                 request_id,
                 reply,
+                coalescing: self.coalescing.clone(),
             })
-            .map_err(|_| MqttRecoveryError::Unavailable)?;
-        tokio::time::timeout(RECOVERY_SIGNAL_TIMEOUT, response)
+            .is_err()
+        {
+            self.coalescing.store(false, Ordering::Release);
+            return Err(MqttRecoveryError::Unavailable);
+        }
+        let result = tokio::time::timeout(RECOVERY_SIGNAL_TIMEOUT, response)
             .await
-            .map_err(|_| MqttRecoveryError::Timeout)?
-            .map_err(|_| MqttRecoveryError::Unavailable)
+            .map_err(|_| MqttRecoveryError::Timeout)
+            .and_then(|result| result.map_err(|_| MqttRecoveryError::Unavailable));
+        match &result {
+            Ok(accepted) if matches!(accepted.outcome, MqttRecoveryOutcome::AlreadyHealthy) => {
+                self.coalescing.store(false, Ordering::Release);
+            }
+            Ok(accepted) if !accepted.accepted => {
+                self.coalescing.store(false, Ordering::Release);
+            }
+            Err(_) => {
+                self.coalescing.store(false, Ordering::Release);
+            }
+            _ => {}
+        }
+        result
     }
 }
 
@@ -388,6 +434,10 @@ enum MqttControl {
     },
     Rebuild {
         reason: String,
+        /// Optional generation fence for rebuild requests originating from
+        /// daemon-owned restore work. An old restore future must not tear down
+        /// a newer worker that has already taken its place.
+        fence: Option<(u64, u64)>,
     },
 }
 
@@ -401,7 +451,10 @@ enum WorkerControl {
 
 enum WorkerEvent {
     Supervisor(MqttSupervisorEvent),
-    Exited { reason: String },
+    Exited {
+        worker_generation: u64,
+        reason: String,
+    },
 }
 
 #[derive(Default)]
@@ -456,6 +509,19 @@ fn is_current_ready_generation(
         && generation_is_current(active_generation, ready_generation)
 }
 
+fn rebuild_fence_matches_generation(
+    worker_present: bool,
+    active_generation: u64,
+    active_worker_generation: u64,
+    fence: Option<(u64, u64)>,
+) -> bool {
+    fence.map_or(true, |(expected_generation, expected_worker_generation)| {
+        worker_present
+            && active_generation == expected_generation
+            && active_worker_generation == expected_worker_generation
+    })
+}
+
 fn restart_delay(failure_count: u32) -> Duration {
     let shift = failure_count.saturating_sub(1).min(3);
     let multiplier = 1_u32 << shift;
@@ -497,6 +563,71 @@ fn wake_gap_requires_recovery(last_observed_ms: u64, now_ms: u64) -> bool {
     now_ms.saturating_sub(last_observed_ms) >= WAKE_GAP_THRESHOLD.as_millis() as u64
 }
 
+fn worker_event_matches_generation(
+    active_worker_generation: u64,
+    event: &MqttSupervisorEvent,
+) -> bool {
+    match event {
+        MqttSupervisorEvent::TransportConnected {
+            worker_generation, ..
+        }
+        | MqttSupervisorEvent::SubscriptionsReady {
+            worker_generation, ..
+        }
+        | MqttSupervisorEvent::GenerationReady {
+            worker_generation, ..
+        }
+        | MqttSupervisorEvent::Disconnected {
+            worker_generation, ..
+        }
+        | MqttSupervisorEvent::Rebuilt {
+            worker_generation, ..
+        } => *worker_generation == active_worker_generation,
+        MqttSupervisorEvent::Terminated => true,
+    }
+}
+
+fn worker_exit_matches_generation(
+    active_worker_generation: u64,
+    exited_worker_generation: u64,
+) -> bool {
+    active_worker_generation == exited_worker_generation
+}
+
+fn supervisor_event_is_critical(event: &MqttSupervisorEvent) -> bool {
+    matches!(
+        event,
+        MqttSupervisorEvent::TransportConnected { .. }
+            | MqttSupervisorEvent::SubscriptionsReady { .. }
+            | MqttSupervisorEvent::GenerationReady { .. }
+            | MqttSupervisorEvent::Terminated
+    )
+}
+
+async fn emit_supervisor_event(
+    events_tx: &mpsc::Sender<MqttSupervisorEvent>,
+    event: MqttSupervisorEvent,
+) {
+    match events_tx.try_send(event) {
+        Ok(()) => {}
+        Err(mpsc::error::TrySendError::Closed(_)) => {}
+        Err(mpsc::error::TrySendError::Full(event)) => {
+            if supervisor_event_is_critical(&event) {
+                if tokio::time::timeout(SUPERVISOR_EVENT_SEND_TIMEOUT, events_tx.send(event))
+                    .await
+                    .is_err()
+                {
+                    warn!(
+                        "MQTT supervisor event receiver remained full; critical event was dropped"
+                    );
+                }
+            } else {
+                debug!("MQTT supervisor event receiver is full; dropping an informational event");
+            }
+        }
+    }
+}
+
 impl MqttSupervisor {
     pub fn spawn(
         config: DaemonConfig,
@@ -508,7 +639,7 @@ impl MqttSupervisor {
         connected: Arc<AtomicBool>,
         snapshot: MqttSnapshotHandle,
     ) -> Self {
-        let (events_tx, events) = mpsc::channel(128);
+        let (events_tx, events) = mpsc::channel(1024);
         let (inbound_tx, inbound) = mpsc::channel(INBOUND_CAPACITY);
         let (inbound_disposition_tx, inbound_disposition_rx) = mpsc::channel(INBOUND_CAPACITY);
         let (control_tx, control_rx) = mpsc::channel(CONTROL_CAPACITY);
@@ -588,10 +719,29 @@ impl MqttSupervisor {
     }
 
     pub async fn request_rebuild(&self, reason: impl Into<String>) {
+        self.request_rebuild_with_fence(None, reason).await;
+    }
+
+    pub async fn request_rebuild_for_generation(
+        &self,
+        generation: u64,
+        worker_generation: u64,
+        reason: impl Into<String>,
+    ) {
+        self.request_rebuild_with_fence(Some((generation, worker_generation)), reason)
+            .await;
+    }
+
+    async fn request_rebuild_with_fence(
+        &self,
+        fence: Option<(u64, u64)>,
+        reason: impl Into<String>,
+    ) {
         if self
             .control_tx
             .send(MqttControl::Rebuild {
                 reason: reason.into(),
+                fence,
             })
             .await
             .is_err()
@@ -669,10 +819,14 @@ async fn run_supervisor(
     let mut shutting_down = false;
     let mut ready_connection_generation = None::<u64>;
     let mut last_observed_ms = MqttHeartbeat::now_ms();
+    let mut credential_attempt = 0_u64;
+    let mut recovery_signal_count = 0_u64;
+    let mut storage_blocked = false;
     // A recovery signal is an edge, not a command to repeatedly tear down the
     // worker. Keep the state in the supervisor so focus/online/watchdog/wake
     // signals all converge on one active recovery attempt.
     let mut recovery_in_progress = false;
+    let mut recovery_coalescing = None::<Arc<AtomicBool>>;
 
     snapshot_update(&snapshot, |current| {
         current.phase = "Connecting".to_string();
@@ -716,50 +870,72 @@ async fn run_supervisor(
             }
         }
 
-        if worker.is_none() && !shutting_down && Instant::now() >= next_restart {
+        if worker.is_none() && !storage_blocked && !shutting_down && Instant::now() >= next_restart
+        {
             let reason = restart_reason
                 .take()
                 .unwrap_or_else(|| "MQTT worker exited".to_string());
+            credential_attempt = credential_attempt.saturating_add(1);
+            let credential_started = Instant::now();
+            info!(
+                worker_generation = worker_generation.saturating_add(1),
+                credential_attempt,
+                %reason,
+                "starting MQTT credential attempt"
+            );
             snapshot_update(&snapshot, |current| {
                 current.phase = "AuthRecovering".to_string();
                 current.connected = false;
                 current.ready_generation = None;
             });
-            let token = match tokio::time::timeout(Duration::from_secs(10), backend.auth_token())
-                .await
-            {
-                Ok(Ok(token)) => token,
-                Ok(Err(error)) => {
-                    warn!(%error, "could not obtain MQTT credential while starting a new worker");
-                    schedule_restart(&mut next_restart, &mut restart_failures);
-                    snapshot_update(&snapshot, |current| {
-                        current.phase = "Backoff".to_string();
-                        current.last_error_code = Some("cloud_auth_failure".to_string());
-                        current.next_retry_at = Some(
-                            chrono::Utc::now()
-                                + chrono::Duration::seconds(
-                                    restart_delay(restart_failures).as_secs() as i64,
-                                ),
+            let token =
+                match tokio::time::timeout(Duration::from_secs(10), backend.auth_token()).await {
+                    Ok(Ok(token)) => token,
+                    Ok(Err(error)) => {
+                        warn!(
+                            %error,
+                            credential_attempt,
+                            duration_ms = credential_started.elapsed().as_millis() as u64,
+                            "could not obtain MQTT credential while starting a new worker"
                         );
-                    });
-                    continue;
-                }
-                Err(_) => {
-                    warn!("timed out obtaining MQTT credential while starting a new worker");
-                    schedule_restart(&mut next_restart, &mut restart_failures);
-                    snapshot_update(&snapshot, |current| {
-                        current.phase = "Backoff".to_string();
-                        current.last_error_code = Some("cloud_auth_timeout".to_string());
-                        current.next_retry_at = Some(
-                            chrono::Utc::now()
-                                + chrono::Duration::seconds(
-                                    restart_delay(restart_failures).as_secs() as i64,
-                                ),
+                        schedule_restart(&mut next_restart, &mut restart_failures);
+                        snapshot_update(&snapshot, |current| {
+                            current.phase = "Backoff".to_string();
+                            current.last_error_code = Some("cloud_auth_failure".to_string());
+                            current.next_retry_at = Some(
+                                chrono::Utc::now()
+                                    + chrono::Duration::seconds(
+                                        restart_delay(restart_failures).as_secs() as i64,
+                                    ),
+                            );
+                        });
+                        continue;
+                    }
+                    Err(_) => {
+                        warn!(
+                            credential_attempt,
+                            duration_ms = credential_started.elapsed().as_millis() as u64,
+                            "timed out obtaining MQTT credential while starting a new worker"
                         );
-                    });
-                    continue;
-                }
-            };
+                        schedule_restart(&mut next_restart, &mut restart_failures);
+                        snapshot_update(&snapshot, |current| {
+                            current.phase = "Backoff".to_string();
+                            current.last_error_code = Some("cloud_auth_timeout".to_string());
+                            current.next_retry_at = Some(
+                                chrono::Utc::now()
+                                    + chrono::Duration::seconds(
+                                        restart_delay(restart_failures).as_secs() as i64,
+                                    ),
+                            );
+                        });
+                        continue;
+                    }
+                };
+            info!(
+                credential_attempt,
+                duration_ms = credential_started.elapsed().as_millis() as u64,
+                "MQTT credential attempt succeeded"
+            );
             connected.store(false, Ordering::Relaxed);
             worker_generation = worker_generation.wrapping_add(1);
             let rebuilt_generation = generation;
@@ -783,13 +959,15 @@ async fn run_supervisor(
                 current.ready_generation = None;
                 current.next_retry_at = None;
             });
-            let _ = events_tx
-                .send(MqttSupervisorEvent::Rebuilt {
+            emit_supervisor_event(
+                &events_tx,
+                MqttSupervisorEvent::Rebuilt {
                     generation: rebuilt_generation,
                     worker_generation,
                     reason,
-                })
-                .await;
+                },
+            )
+            .await;
         }
 
         let tick = tokio::time::sleep(SUPERVISOR_TICK);
@@ -860,7 +1038,47 @@ async fn run_supervisor(
                             warn!(generation = ready_generation, active_generation = generation, "ignored stale MQTT generation readiness");
                         }
                     }
-                    Some(MqttControl::Rebuild { reason }) => {
+                    Some(MqttControl::Rebuild { reason, fence }) => {
+                        if !rebuild_fence_matches_generation(
+                            worker.is_some(),
+                            generation,
+                            worker_generation,
+                            fence,
+                        ) {
+                            let (expected_generation, expected_worker_generation) =
+                                fence.expect("fence must be present when the match failed");
+                            warn!(
+                                generation,
+                                worker_generation,
+                                expected_generation,
+                                expected_worker_generation,
+                                %reason,
+                                "ignoring stale fenced MQTT rebuild request"
+                            );
+                            continue;
+                        }
+                        if is_durable_store_failure(&reason) {
+                            storage_blocked = true;
+                            restart_reason = None;
+                            recovery_in_progress = false;
+                            if let Some(coalescing) = recovery_coalescing.take() {
+                                coalescing.store(false, Ordering::Release);
+                            }
+                            transport_connected_generation = None;
+                            connected.store(false, Ordering::Relaxed);
+                            ready_connection_generation = None;
+                            stop_worker(&mut worker, &heartbeat).await;
+                            snapshot_update(&snapshot, |current| {
+                                current.phase = "StorageError".to_string();
+                                current.connected = false;
+                                current.ready_generation = None;
+                                current.last_error_code = Some("durable_store_corrupt".to_string());
+                                current.last_error_at = Some(chrono::Utc::now());
+                                current.next_retry_at = None;
+                            });
+                            error!(%reason, "MQTT durable store failure fenced the active generation; automatic rebuilds are paused");
+                            continue;
+                        }
                         let first_request = restart_reason.is_none();
                         restart_reason.get_or_insert(reason);
                         if worker.is_some() {
@@ -888,11 +1106,18 @@ async fn run_supervisor(
             }
             request = recovery_rx.recv() => {
                 if let Some(request) = request {
+                    recovery_signal_count = recovery_signal_count.saturating_add(1);
                     let current_generation = (worker.is_some()).then_some(worker_generation);
                     let healthy = worker.is_some()
                         && ready_connection_generation == Some(generation)
                         && connected.load(Ordering::Relaxed);
                     if healthy {
+                        info!(
+                            recovery_signal_count,
+                            worker_generation = ?current_generation,
+                            reason = %request.reason.as_str(),
+                            "ignored MQTT recovery signal because generation is healthy"
+                        );
                         let _ = request.reply.send(MqttRecoveryAccepted {
                             accepted: true,
                             outcome: MqttRecoveryOutcome::AlreadyHealthy,
@@ -900,8 +1125,24 @@ async fn run_supervisor(
                             worker_generation: current_generation,
                         });
                     } else {
+                        if storage_blocked && !recovery_may_retry_storage(request.reason) {
+                            let _ = request.reply.send(MqttRecoveryAccepted {
+                                accepted: false,
+                                outcome: MqttRecoveryOutcome::Recovering,
+                                request_id: request.request_id,
+                                worker_generation: current_generation,
+                            });
+                            continue;
+                        }
                         let reason = format!("{} recovery", request.reason.as_str());
                         let already_recovering = recovery_in_progress;
+                        info!(
+                            recovery_signal_count,
+                            worker_generation = ?current_generation,
+                            reason = %request.reason.as_str(),
+                            coalesced = already_recovering,
+                            "accepted MQTT recovery signal"
+                        );
                         snapshot_update(&snapshot, |current| {
                             if !already_recovering {
                                 current.phase = "Recovering".to_string();
@@ -912,6 +1153,14 @@ async fn run_supervisor(
                             current.next_retry_at = None;
                         });
                         recovery_in_progress = true;
+                        // Only an explicit user request may retry a durable
+                        // store that was classified as broken. Automatic
+                        // wake/network signals must not turn a disk failure
+                        // into a rebuild loop.
+                        if recovery_may_retry_storage(request.reason) {
+                            storage_blocked = false;
+                        }
+                        recovery_coalescing = Some(request.coalescing.clone());
                         ready_connection_generation = None;
                         let _ = request.reply.send(MqttRecoveryAccepted {
                             accepted: true,
@@ -941,6 +1190,13 @@ async fn run_supervisor(
             event = worker_events_rx.recv() => {
                 match event {
                     Some(WorkerEvent::Supervisor(event)) => {
+                        if !worker_event_matches_generation(worker_generation, &event) {
+                            warn!(
+                                active_worker_generation = worker_generation,
+                                "discarding stale MQTT worker event"
+                            );
+                            continue;
+                        }
                         match &event {
                             MqttSupervisorEvent::TransportConnected { generation: current, .. } => {
                                 generation = *current;
@@ -976,6 +1232,9 @@ async fn run_supervisor(
                                 ) {
                                     restart_failures = 0;
                                     recovery_in_progress = false;
+                                    if let Some(coalescing) = recovery_coalescing.take() {
+                                        coalescing.store(false, Ordering::Release);
+                                    }
                                     ready_connection_generation = Some(*ready_gen);
                                     snapshot_update(&snapshot, |current| {
                                         current.phase = "Ready".to_string();
@@ -1000,9 +1259,46 @@ async fn run_supervisor(
                             MqttSupervisorEvent::Rebuilt { .. }
                             | MqttSupervisorEvent::Terminated => {}
                         }
-                        let _ = events_tx.send(event).await;
+                        emit_supervisor_event(&events_tx, event).await;
                     }
-                    Some(WorkerEvent::Exited { reason }) => {
+                    Some(WorkerEvent::Exited {
+                        worker_generation: exited_worker_generation,
+                        reason,
+                    }) => {
+                        if !worker_exit_matches_generation(worker_generation, exited_worker_generation) {
+                            warn!(
+                                active_worker_generation = worker_generation,
+                                exited_worker_generation,
+                                "discarding stale MQTT worker exit event"
+                            );
+                            continue;
+                        }
+                        if is_durable_store_failure(&reason) {
+                            storage_blocked = true;
+                            restart_reason = None;
+                            recovery_in_progress = false;
+                            if let Some(coalescing) = recovery_coalescing.take() {
+                                coalescing.store(false, Ordering::Release);
+                            }
+                            transport_connected_generation = None;
+                            connected.store(false, Ordering::Relaxed);
+                            ready_connection_generation = None;
+                            stop_worker(&mut worker, &heartbeat).await;
+                            snapshot_update(&snapshot, |current| {
+                                current.phase = "StorageError".to_string();
+                                current.connected = false;
+                                current.ready_generation = None;
+                                current.last_error_code = Some("durable_store_corrupt".to_string());
+                                current.last_error_at = Some(chrono::Utc::now());
+                                current.next_retry_at = None;
+                            });
+                            error!(%reason, "MQTT durable store is unavailable; automatic rebuilds are paused");
+                            continue;
+                        }
+                        if storage_blocked {
+                            debug!(%reason, "ignoring MQTT worker exit while durable store recovery is blocked");
+                            continue;
+                        }
                         if !shutting_down {
                             warn!(%reason, "MQTT worker exited; supervisor will create a new generation");
                             restart_reason = Some(reason.clone());
@@ -1074,7 +1370,7 @@ async fn run_supervisor(
     while let Some(command) = pending_commands.pop_front() {
         fail_command(command, "MQTT supervisor is shutting down");
     }
-    let _ = events_tx.send(MqttSupervisorEvent::Terminated).await;
+    emit_supervisor_event(&events_tx, MqttSupervisorEvent::Terminated).await;
 }
 
 fn spawn_worker(
@@ -1180,7 +1476,8 @@ impl MqttWorker {
                 let _ = self
                     .events_tx
                     .send(WorkerEvent::Exited {
-                        reason: "durable MQTT store could not be opened".to_string(),
+                        worker_generation: self.worker_generation,
+                        reason: format!("{DURABLE_STORE_FAILURE_PREFIX}open_failed"),
                     })
                     .await;
                 return;
@@ -1281,13 +1578,16 @@ impl MqttWorker {
                     }
                     disposition = self.inbound_disposition_rx.recv() => {
                         if let Some((id, disposition)) = disposition {
-                            self.handle_inbound_disposition(
+                            if let Err(reason) = self.handle_inbound_disposition(
                                 id,
                                 disposition,
                                 &mut store,
                                 &mut inbound_retry_attempts,
                                 &mut inbound_retry_deadlines,
-                            );
+                            ) {
+                                exit_reason = reason;
+                                break;
+                            }
                         }
                     }
                     poll_result = active.eventloop.poll() => {
@@ -1384,6 +1684,13 @@ impl MqttWorker {
                                             }
                                             Err(error) => {
                                                 error!(%error, "failed to append MQTT inbound to durable inbox");
+                                                // The inbox Put may already be durable while the
+                                                // dedup record failed. Reopen the store in a fresh
+                                                // worker so startup can rebuild dedup from that
+                                                // pending inbox item before accepting a redelivery.
+                                                forced_rebuild = Some(format!(
+                                                    "{DURABLE_STORE_FAILURE_PREFIX}inbound_persistence_failed: {error}"
+                                                ));
                                             }
                                         }
                                     }
@@ -1559,13 +1866,16 @@ impl MqttWorker {
                     }
                     disposition = self.inbound_disposition_rx.recv() => {
                         if let Some((id, disposition)) = disposition {
-                            self.handle_inbound_disposition(
+                            if let Err(reason) = self.handle_inbound_disposition(
                                 id,
                                 disposition,
                                 &mut store,
                                 &mut inbound_retry_attempts,
                                 &mut inbound_retry_deadlines,
-                            );
+                            ) {
+                                exit_reason = reason;
+                                break;
+                            }
                         }
                     }
                     _ = &mut tick => {
@@ -1598,7 +1908,13 @@ impl MqttWorker {
             &reason,
         );
         self.fail_queued_commands(&reason);
-        let _ = self.events_tx.send(WorkerEvent::Exited { reason }).await;
+        let _ = self
+            .events_tx
+            .send(WorkerEvent::Exited {
+                worker_generation: self.worker_generation,
+                reason,
+            })
+            .await;
     }
 
     fn accept_command(
@@ -1660,6 +1976,26 @@ impl MqttWorker {
                 delivery,
                 reply,
             } => {
+                // QoS0 is explicitly transient. Sending it through the
+                // durable outbox would turn a best-effort stream delta into a
+                // replayable message after a worker restart, violating the
+                // AtMostOnce contract. It is accepted only while a transport
+                // is connected; a full rumqttc queue is reported to the
+                // caller instead of being persisted for later replay.
+                if !should_persist_publish(&delivery) {
+                    let result = if connected {
+                        mqtt_client
+                            .expect("connected MQTT command must have a client")
+                            .try_publish(topic, delivery.into(), retain, payload)
+                            .map_err(PublisherError::from)
+                    } else {
+                        Err(PublisherError::Unavailable(
+                            "MQTT transport is offline; transient publish was dropped".to_string(),
+                        ))
+                    };
+                    let _ = reply.send(result);
+                    return true;
+                }
                 if store.outbox_len() >= DURABLE_QUEUE_CAPACITY
                     || store
                         .outbox_bytes()
@@ -1767,13 +2103,14 @@ impl MqttWorker {
         store: &mut DurableMqttStore,
         retry_attempts: &mut HashMap<u64, u32>,
         retry_deadlines: &mut HashMap<u64, Instant>,
-    ) {
+    ) -> Result<(), String> {
         match disposition {
             MqttInboundDisposition::Ack => {
                 retry_attempts.remove(&id);
                 retry_deadlines.remove(&id);
                 if let Err(error) = store.ack_inbound(id) {
-                    warn!(%error, id, "failed to ACK durable MQTT inbox item");
+                    error!(%error, id, "failed to ACK durable MQTT inbox item");
+                    return Err(format!("{DURABLE_STORE_FAILURE_PREFIX}inbox_ack_failed"));
                 }
             }
             MqttInboundDisposition::Retry => {
@@ -1794,10 +2131,12 @@ impl MqttWorker {
                 retry_attempts.remove(&id);
                 retry_deadlines.remove(&id);
                 if let Err(error) = store.dead_letter_inbound(id, reason) {
-                    warn!(%error, id, "failed to move durable MQTT inbox item to dead letter");
+                    error!(%error, id, "failed to move durable MQTT inbox item to dead letter");
+                    return Err(format!("{DURABLE_STORE_FAILURE_PREFIX}dead_letter_failed"));
                 }
             }
         }
+        Ok(())
     }
 
     fn flush_due_inbound_retries(
@@ -1976,9 +2315,14 @@ async fn mqtt_watchdog(
                 };
                 if watchdog_rebuild_request_allowed(rebuild_due, &mut rebuild_requested_at) {
                     warn!(age_ms, %reason, "MQTT worker exceeded the watchdog recovery bound; requesting controlled generation rebuild");
-                    if control_tx.send(MqttControl::Rebuild {
-                        reason: reason.to_string(),
-                    }).await.is_ok() {
+                    if control_tx
+                        .send(MqttControl::Rebuild {
+                            reason: reason.to_string(),
+                            fence: None,
+                        })
+                        .await
+                        .is_ok()
+                    {
                         rebuild_requested_at = Some(Instant::now());
                     }
                 }
@@ -2034,6 +2378,71 @@ mod tests {
         assert!(!is_current_ready_generation(true, 7, 7, Some(7), 6, 7));
         assert!(!is_current_ready_generation(true, 7, 7, None, 7, 7));
         assert!(!is_current_ready_generation(false, 7, 7, Some(7), 7, 7));
+    }
+
+    #[test]
+    fn fenced_rebuild_requests_cannot_target_a_new_worker() {
+        assert!(rebuild_fence_matches_generation(true, 11, 4, Some((11, 4))));
+        assert!(!rebuild_fence_matches_generation(
+            true,
+            12,
+            5,
+            Some((11, 4))
+        ));
+        assert!(!rebuild_fence_matches_generation(
+            false,
+            11,
+            4,
+            Some((11, 4))
+        ));
+        assert!(rebuild_fence_matches_generation(false, 99, 99, None));
+    }
+
+    #[test]
+    fn only_reliable_publish_guarantees_enter_the_durable_outbox() {
+        assert!(!should_persist_publish(&DeliveryGuarantee::AtMostOnce));
+        assert!(should_persist_publish(&DeliveryGuarantee::AtLeastOnce));
+        assert!(should_persist_publish(&DeliveryGuarantee::ExactlyOnce));
+    }
+
+    #[test]
+    fn permanent_durable_store_failure_is_distinct_from_transport_failure() {
+        assert!(is_durable_store_failure("durable_store:open_failed"));
+        assert!(is_durable_store_failure(
+            "durable_store:inbound_persistence_failed"
+        ));
+        assert!(!is_durable_store_failure("MQTT connection closed"));
+        assert!(recovery_may_retry_storage(
+            MqttRecoveryReason::UserRequested
+        ));
+        assert!(!recovery_may_retry_storage(
+            MqttRecoveryReason::NetworkOnline
+        ));
+        assert!(!recovery_may_retry_storage(
+            MqttRecoveryReason::VisibilityResume
+        ));
+    }
+
+    #[test]
+    fn stale_worker_events_cannot_reopen_a_previous_generation() {
+        assert!(worker_event_matches_generation(
+            8,
+            &MqttSupervisorEvent::TransportConnected {
+                generation: 3,
+                worker_generation: 8,
+            }
+        ));
+        assert!(!worker_event_matches_generation(
+            8,
+            &MqttSupervisorEvent::SubscriptionsReady {
+                generation: 2,
+                worker_generation: 7,
+            }
+        ));
+        assert!(worker_event_matches_generation(
+            8,
+            &MqttSupervisorEvent::Terminated
+        ));
     }
 
     #[test]
@@ -2155,6 +2564,7 @@ mod tests {
                 reason: MqttRecoveryReason::NetworkOnline,
                 request_id: "one".into(),
                 reply,
+                coalescing: handle.coalescing.clone(),
             })
             .expect("first recovery signal should fit");
         let (reply, _response) = oneshot::channel();
@@ -2164,10 +2574,52 @@ mod tests {
                 reason: MqttRecoveryReason::VisibilityResume,
                 request_id: "two".into(),
                 reply,
+                coalescing: handle.coalescing.clone(),
             })
             .is_err());
         let first = receiver.try_recv().expect("pending signal");
         assert_eq!(first.request_id, "one");
+    }
+
+    #[tokio::test]
+    async fn concurrent_recovery_requests_are_accepted_by_one_recovery_edge() {
+        let (handle, mut receiver) = MqttRecoveryHandle::channel();
+        let first_handle = handle.clone();
+        let first = tokio::spawn(async move {
+            first_handle
+                .request(MqttRecoveryReason::NetworkOnline)
+                .await
+                .unwrap()
+        });
+
+        let request = receiver.recv().await.expect("first recovery request");
+        let second = handle
+            .request(MqttRecoveryReason::VisibilityResume)
+            .await
+            .unwrap();
+        assert!(second.accepted);
+        assert!(matches!(second.outcome, MqttRecoveryOutcome::Recovering));
+        assert!(receiver.try_recv().is_err());
+
+        request
+            .reply
+            .send(MqttRecoveryAccepted {
+                accepted: true,
+                outcome: MqttRecoveryOutcome::Recovering,
+                request_id: request.request_id,
+                worker_generation: None,
+            })
+            .unwrap();
+        assert!(matches!(
+            first.await.unwrap().outcome,
+            MqttRecoveryOutcome::Recovering
+        ));
+    }
+
+    #[test]
+    fn stale_worker_exit_events_are_rejected_by_generation() {
+        assert!(!worker_exit_matches_generation(2, 1));
+        assert!(worker_exit_matches_generation(2, 2));
     }
 
     #[tokio::test]

--- a/apps/daemon/src/mqtt/supervisor.rs
+++ b/apps/daemon/src/mqtt/supervisor.rs
@@ -44,7 +44,6 @@ const WORKER_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 const RECOVERY_SIGNAL_TIMEOUT: Duration = Duration::from_secs(2);
 const WAKE_GAP_THRESHOLD: Duration = Duration::from_secs(120);
 const INBOUND_RETRY_MAX: Duration = Duration::from_secs(30);
-const SUPERVISOR_EVENT_SEND_TIMEOUT: Duration = Duration::from_secs(2);
 const DURABLE_STORE_FAILURE_PREFIX: &str = "durable_store:";
 
 /// The one snapshot published to `/v1/info`. Keeping the fields together
@@ -415,7 +414,7 @@ pub enum MqttSupervisorEvent {
 }
 
 pub struct MqttSupervisor {
-    pub events: mpsc::Receiver<MqttSupervisorEvent>,
+    pub events: mpsc::UnboundedReceiver<MqttSupervisorEvent>,
     pub inbound: mpsc::Receiver<MqttInbound>,
     inbound_disposition_tx: mpsc::Sender<(u64, MqttInboundDisposition)>,
     control_tx: mpsc::Sender<MqttControl>,
@@ -594,37 +593,12 @@ fn worker_exit_matches_generation(
     active_worker_generation == exited_worker_generation
 }
 
-fn supervisor_event_is_critical(event: &MqttSupervisorEvent) -> bool {
-    matches!(
-        event,
-        MqttSupervisorEvent::TransportConnected { .. }
-            | MqttSupervisorEvent::SubscriptionsReady { .. }
-            | MqttSupervisorEvent::GenerationReady { .. }
-            | MqttSupervisorEvent::Terminated
-    )
-}
-
-async fn emit_supervisor_event(
-    events_tx: &mpsc::Sender<MqttSupervisorEvent>,
+fn emit_supervisor_event(
+    events_tx: &mpsc::UnboundedSender<MqttSupervisorEvent>,
     event: MqttSupervisorEvent,
 ) {
-    match events_tx.try_send(event) {
-        Ok(()) => {}
-        Err(mpsc::error::TrySendError::Closed(_)) => {}
-        Err(mpsc::error::TrySendError::Full(event)) => {
-            if supervisor_event_is_critical(&event) {
-                if tokio::time::timeout(SUPERVISOR_EVENT_SEND_TIMEOUT, events_tx.send(event))
-                    .await
-                    .is_err()
-                {
-                    warn!(
-                        "MQTT supervisor event receiver remained full; critical event was dropped"
-                    );
-                }
-            } else {
-                debug!("MQTT supervisor event receiver is full; dropping an informational event");
-            }
-        }
+    if events_tx.send(event).is_err() {
+        debug!("MQTT supervisor event receiver is closed");
     }
 }
 
@@ -639,7 +613,11 @@ impl MqttSupervisor {
         connected: Arc<AtomicBool>,
         snapshot: MqttSnapshotHandle,
     ) -> Self {
-        let (events_tx, events) = mpsc::channel(1024);
+        // Lifecycle events are low-volume and must never be dropped: losing
+        // SubscriptionsReady would leave the daemon permanently below the
+        // generation readiness fence. This channel is separate from the
+        // bounded command/inbound data paths.
+        let (events_tx, events) = mpsc::unbounded_channel();
         let (inbound_tx, inbound) = mpsc::channel(INBOUND_CAPACITY);
         let (inbound_disposition_tx, inbound_disposition_rx) = mpsc::channel(INBOUND_CAPACITY);
         let (control_tx, control_rx) = mpsc::channel(CONTROL_CAPACITY);
@@ -784,7 +762,7 @@ async fn run_supervisor(
     backend: Arc<dyn Backend>,
     mut command_rx: mpsc::Receiver<MqttCommand>,
     mut shutdown_rx: oneshot::Receiver<()>,
-    events_tx: mpsc::Sender<MqttSupervisorEvent>,
+    events_tx: mpsc::UnboundedSender<MqttSupervisorEvent>,
     inbound_tx: mpsc::Sender<MqttInbound>,
     mut inbound_disposition_rx: mpsc::Receiver<(u64, MqttInboundDisposition)>,
     mut control_rx: mpsc::Receiver<MqttControl>,
@@ -966,8 +944,7 @@ async fn run_supervisor(
                     worker_generation,
                     reason,
                 },
-            )
-            .await;
+            );
         }
 
         let tick = tokio::time::sleep(SUPERVISOR_TICK);
@@ -1259,7 +1236,7 @@ async fn run_supervisor(
                             MqttSupervisorEvent::Rebuilt { .. }
                             | MqttSupervisorEvent::Terminated => {}
                         }
-                        emit_supervisor_event(&events_tx, event).await;
+                        emit_supervisor_event(&events_tx, event);
                     }
                     Some(WorkerEvent::Exited {
                         worker_generation: exited_worker_generation,
@@ -1370,7 +1347,7 @@ async fn run_supervisor(
     while let Some(command) = pending_commands.pop_front() {
         fail_command(command, "MQTT supervisor is shutting down");
     }
-    emit_supervisor_event(&events_tx, MqttSupervisorEvent::Terminated).await;
+    emit_supervisor_event(&events_tx, MqttSupervisorEvent::Terminated);
 }
 
 fn spawn_worker(

--- a/apps/daemon/src/opencode_settings/pool.rs
+++ b/apps/daemon/src/opencode_settings/pool.rs
@@ -102,8 +102,17 @@ impl OpenCodeSettingsService {
     /// Client for provider OAuth / config that isn't tied to a project
     /// workspace — see [`WorkspaceSettingsContextResolver::resolve_device_settings_context`].
     pub async fn client_for_device(&self) -> Result<OpenCodeSettingsClient, OpenCodeSettingsError> {
-        if let Some(base) = self.test_fixtures.lock().unwrap().get(DEVICE_FIXTURE_KEY).cloned() {
-            return Ok(OpenCodeSettingsClient::new(base, Path::new(DEVICE_FIXTURE_KEY)));
+        if let Some(base) = self
+            .test_fixtures
+            .lock()
+            .unwrap()
+            .get(DEVICE_FIXTURE_KEY)
+            .cloned()
+        {
+            return Ok(OpenCodeSettingsClient::new(
+                base,
+                Path::new(DEVICE_FIXTURE_KEY),
+            ));
         }
 
         let (Some(pool), Some(resolver)) = (&self.pool, &self.context_resolver) else {

--- a/apps/daemon/src/runtime/handle.rs
+++ b/apps/daemon/src/runtime/handle.rs
@@ -456,12 +456,11 @@ mod tests {
     #[tokio::test]
     async fn shutdown_waits_for_detach_acknowledgement() {
         let mut handle = RuntimeHandle::test_dummy();
-        let generation =
-            super::super::opencode_http::host_pool::HostGeneration::test_for_routing(
-                "gen-a",
-                IsolationDomainKey::Workspace("ws-a".to_string()),
-                ProcessEnvRevision::from_bindings(&std::collections::HashMap::new()),
-            );
+        let generation = super::super::opencode_http::host_pool::HostGeneration::test_for_routing(
+            "gen-a",
+            IsolationDomainKey::Workspace("ws-a".to_string()),
+            ProcessEnvRevision::from_bindings(&std::collections::HashMap::new()),
+        );
         handle.host_generation_id = generation.generation_id.clone();
         handle.route_lease = Some(generation.test_route_lease());
         let (cmd_tx, mut cmd_rx) = mpsc::channel(1);

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -21,13 +21,13 @@ pub mod permission_policy;
 pub mod prompt_attachments;
 pub mod refresh;
 pub mod sidecar;
-pub mod well_known_bin;
 pub mod supervisor;
 pub mod team_cloud_config;
 pub mod team_skills;
 #[cfg(test)]
 pub(crate) mod test_support;
 pub mod turn_aggregator;
+pub mod well_known_bin;
 mod workspace_runtime;
 
 pub use backend::{create_backend, AgentBackend, OpencodeHttpBackend};

--- a/apps/daemon/src/teamclu/live.rs
+++ b/apps/daemon/src/teamclu/live.rs
@@ -221,18 +221,32 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use std::sync::Mutex;
-    use teamclu_transport::PublisherError;
+    use teamclu_transport::{IncomingFrame, PublisherError};
 
     /// Records the `DeliveryGuarantee` of every `publish` call so tests can
     /// assert the QoS chosen by `LivePublisher`.
     #[derive(Default)]
     struct RecordingPublisher {
-        calls: Mutex<Vec<DeliveryGuarantee>>,
+        calls: Mutex<Vec<(DeliveryGuarantee, Vec<u8>)>>,
     }
 
     impl RecordingPublisher {
         fn guarantees(&self) -> Vec<DeliveryGuarantee> {
-            self.calls.lock().unwrap().clone()
+            self.calls
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(delivery, _)| delivery.clone())
+                .collect()
+        }
+
+        fn payloads(&self) -> Vec<Vec<u8>> {
+            self.calls
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(_, payload)| payload.clone())
+                .collect()
         }
     }
 
@@ -241,11 +255,11 @@ mod tests {
         async fn publish(
             &self,
             _topic: &str,
-            _payload: Vec<u8>,
+            payload: Vec<u8>,
             _retain: bool,
             delivery: DeliveryGuarantee,
         ) -> Result<(), PublisherError> {
-            self.calls.lock().unwrap().push(delivery);
+            self.calls.lock().unwrap().push((delivery, payload));
             Ok(())
         }
 
@@ -324,6 +338,30 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(recorder.guarantees(), vec![DeliveryGuarantee::AtMostOnce]);
+    }
+
+    #[tokio::test]
+    async fn live_event_id_is_on_wire_for_durable_replay_dedup() {
+        let (recorder, live) = publisher();
+        let env = acp_envelope(amux::acp_event::Event::Output(amux::AcpOutput {
+            text: "hi".to_string(),
+            ..Default::default()
+        }));
+        live.publish_acp_event("session-1", "actor-1", &env)
+            .await
+            .unwrap();
+
+        let payload = recorder.payloads().pop().expect("published payload");
+        let wire = LiveEventEnvelope::decode(payload.as_slice()).unwrap();
+        assert!(!wire.event_id.is_empty());
+        assert_eq!(
+            crate::mqtt::subscriber::stable_message_id(&IncomingFrame {
+                topic: "amux/team-1/session/session-1/live".to_string(),
+                payload,
+                retained: false,
+            }),
+            Some(wire.event_id)
+        );
     }
 
     #[tokio::test]

--- a/apps/daemon/tests/http_apps.rs
+++ b/apps/daemon/tests/http_apps.rs
@@ -26,6 +26,8 @@ mod error;
 mod http;
 #[path = "../src/mcp_probe.rs"]
 mod mcp_probe;
+#[path = "../src/mqtt/mod.rs"]
+mod mqtt;
 #[path = "../src/opencode_install/mod.rs"]
 mod opencode_install;
 #[path = "../src/opencode_settings/mod.rs"]

--- a/apps/daemon/tests/support/crate_modules.rs
+++ b/apps/daemon/tests/support/crate_modules.rs
@@ -19,6 +19,8 @@ mod error;
 mod http;
 #[path = "../../src/mcp_probe.rs"]
 mod mcp_probe;
+#[path = "../../src/mqtt/mod.rs"]
+mod mqtt;
 #[path = "../../src/opencode_install/mod.rs"]
 mod opencode_install;
 #[path = "../../src/opencode_settings/mod.rs"]

--- a/crates/teamclu-transport/src/publisher.rs
+++ b/crates/teamclu-transport/src/publisher.rs
@@ -9,6 +9,8 @@ use crate::{encode_subject, DeliveryGuarantee, Transport, TransportMessage};
 
 #[derive(Debug, Error)]
 pub enum PublisherError {
+    #[error("transport unavailable: {0}")]
+    Unavailable(String),
     #[error("mqtt client error: {0}")]
     Mqtt(#[from] rumqttc::ClientError),
     #[error("nats publish error: {0}")]

--- a/docs/debug/mqtt-realtime-channel-disconnect-analysis.md
+++ b/docs/debug/mqtt-realtime-channel-disconnect-analysis.md
@@ -1,0 +1,265 @@
+# MQTT 实时通道断连问题核实报告
+
+> 日期：2026-08-20
+> 现象：桌面 App 侧栏反复出现 "Agent real-time channel disconnected - Local agent is up, but its MQTT link is down" 琥珀色警告。
+> 涉及组件：桌面前端（`packages/app`）、本地 daemon（`apps/daemon`）、服务端（`accounting-copilot-test-sg`：Caddy + NanoMQ + mqtt-auth + mqtt-watchdog）。
+
+---
+
+## 一、结论摘要
+
+侧栏警告表示：**本地 daemon 的 HTTP 服务仍可访问，但 daemon 自报的 MQTT 连接为断开状态**。
+
+本次通过代码走读、本机 `~/.amuxd/logs/amuxd.log` 和测试环境容器日志核实后，结论如下：
+
+1. **90 秒恢复窗口真实存在。** rumqttc 遇到部分网络/TLS 错误后没有完成自动重连，daemon 最终依靠 `MQTT_DISCONNECT_REBUILD = 90s` 强制重建 MQTT client。
+2. **“broker 因 JWT 到期每小时踢人”不成立。** 2026-08-20 的 daemon 日志没有出现 `ConnectionRefused`；服务端 mqtt-auth 只在 CONNECT 时检查 JWT，不会在已建立的连接上按 `exp` 定时踢人。
+3. **约 55 分钟的连接时长主要来自 daemon 主动重连。** daemon 明确在 JWT 到期前 5 分钟主动断开并换取新 token，这与 Caddy 中约 3300 秒的记录一致。
+4. **NanoMQ 的 `Object closed` 刷屏主要是健康探针噪音。** watchdog 和容器健康检查都会完成 WebSocket Upgrade 后立即销毁 socket，不能据此推断所有客户端被 Caddy 或 NanoMQ 高频异常断开。
+5. **休眠后永久半开连接尚未被证实。** rumqttc 0.24.0 自带 PingResp 超时检测；如果要认定其在休眠场景失效，需要抓取复现时的连续 daemon 日志和网络状态。
+6. **前端恢复感知存在缺口。** daemon 状态依赖 20 秒定时轮询；窗口重新可见时没有直接触发 `requestDaemonProbe()`，因此已恢复状态可能继续显示到下一次有效轮询。
+
+因此，当前最准确的一句话是：
+
+> **部分网络/TLS 断连后 rumqttc 自动重连未成功，daemon 最长等待约 90 秒才强制重建；前端将 daemon 自报的断开状态显示出来，并可能在后台恢复后额外滞后。**
+
+---
+
+## 二、已确认的现场证据
+
+### 2.1 daemon 日志统计
+
+2026-08-20 本机 daemon 日志中：
+
+- `MQTT transient error`：50 条；
+- `MQTT disconnected too long`：7 次；
+- `MQTT connection refused`：0 次；
+- `JWT nearing expiry` 主动重连：4 次；
+- 主动 JWT 重连通常约 1 秒内完成。
+
+原报告写“一天 8 次非计划断连”，但表格实际只有 7 条，日志中的 90 秒兜底记录也是 7 次。
+
+主要的 90 秒兜底事件：
+
+| 时间（UTC） | daemon 首个错误 | 后续行为 |
+|---|---|---|
+| 01:47 | DNS 解析失败 | 约 90 秒后强制重建 |
+| 04:05 | connection closed by peer | 约 90 秒后强制重建 |
+| 06:11 | connection closed by peer | 约 90 秒后强制重建 |
+| 06:30 | TLS UnexpectedEof | 约 90 秒后强制重建 |
+| 07:37 | I/O: not connected | 约 90 秒后强制重建 |
+| 08:00 | connection closed by peer | 约 90 秒后强制重建 |
+| 09:01 | connection closed by peer | 约 90 秒后强制重建 |
+
+其中存在明确的非认证原因：
+
+- 04:00 UTC 附近本地 daemon 收到 shutdown signal，随后进程重新启动，不能算作单纯 MQTT 自愈耗时；
+- 08:00 UTC 对应服务端 16:00（UTC+8）附近，测试容器中的 NanoMQ 被 supervisor 正常停止，属于服务重启影响；
+- 其他事件的日志是 DNS、TCP、TLS 或未连接错误，没有认证拒绝证据。
+
+### 2.2 Caddy `/mqtt` 连接时长
+
+测试容器当前可用的 5 份 Caddy 日志中共找到 54 条 `/mqtt` WebSocket 记录，全部返回 101：
+
+| 时长区间 | 数量 |
+|---|---:|
+| 1～60 秒 | 6 |
+| 60～600 秒 | 9 |
+| 600～3000 秒 | 13 |
+| 3000～3350 秒 | 15 |
+| 3500～3560 秒 | 11 |
+
+长连接峰值包括：
+
+- 3299～3300 秒：12 条；
+- 3539～3540 秒：8 条。
+
+3300 秒正好是 55 分钟，与 daemon 的 `proactive_reconnect_delay()` 一致，属于客户端主动重连的直接证据。
+
+3540 秒附近的连接可能来自其他客户端的 token 刷新周期、网关连接寿命或其他客户端策略。Caddy access log 只记录连接关闭后的总时长，**不能判断关闭动作由客户端、网关、Caddy 还是 NanoMQ 发起**，因此不能将该聚类直接归因于 JWT 到期。
+
+### 2.3 mqtt-auth 的能力边界
+
+`mqtt-auth.mjs` 在 NanoMQ 发起 MQTT CONNECT 鉴权时：
+
+1. 校验 JWT HS256 签名；
+2. 检查 `exp` 是否已过期；
+3. 返回 200 或 403。
+
+这是一次性的 CONNECT 鉴权。连接建立后 mqtt-auth 不持有连接，也没有按 JWT `exp` 定时关闭连接的逻辑。
+
+因此：
+
+- 过期 JWT 会使**新的 CONNECT**被拒绝；
+- 现有连接不会被 mqtt-auth 主动按时踢下线；
+- 如果要证明自动重连使用旧 JWT 被拒绝，需要 mqtt-auth 输出 clientId、允许/拒绝和拒绝原因。目前日志没有这些字段。
+
+### 2.4 NanoMQ `Object closed` 日志
+
+线上 `nanomq.log` 在约 3 小时内出现约 1800 条：
+
+```text
+wstran_pipe_recv_cb: recv aio error Object closed
+```
+
+测试容器同时存在两类探针：
+
+- `mqtt-watchdog.sh` 每 10 秒执行一次 MQTT WebSocket Upgrade；
+- 容器健康检查约每 15 秒调用 `/healthz`，内部也执行 MQTT WebSocket Upgrade。
+
+探针在收到 101 后立即 `socket.destroy()`，NanoMQ 因而记录 `Object closed`。数量和时间节奏与日志高度吻合。
+
+结论：日志噪音真实存在，但它主要说明探针主动关闭连接，**不说明所有业务客户端都在异常断连**。
+
+---
+
+## 三、代码核实
+
+### 3.1 daemon 的真实恢复逻辑
+
+`apps/daemon/src/daemon/server.rs` 当前行为：
+
+1. `ConnectionRefused`：立即标记断开、作废缓存凭证并返回外层循环；
+2. 其他 transient error：保留 rumqttc client，等待其自动重连；
+3. `mqtt_connected == false` 持续 90 秒：作废凭证并强制整体重建；
+4. JWT 进入提前 5 分钟刷新窗口：主动断开并整体重建。
+
+所以“遇到 `ConnectionRefused` 仍等待 90 秒”与当前代码不符。真正的问题是：
+
+> 某些 transient error 后 rumqttc 没有在合理时间内恢复，而 daemon 对这类错误统一等待 90 秒才升级为整体重建。
+
+### 3.2 rumqttc 已有链路活性检测
+
+项目使用 rumqttc 0.24.0。其状态机记录 `last_incoming` 和 `await_pingresp`：
+
+- 每个 keepalive 周期发送 PingReq；
+- 上一次 PingReq 未收到 PingResp 时返回 `StateError::AwaitPingResp`；
+- `EventLoop::poll()` 遇到网络或状态错误后调用 `clean()`；
+- 后续继续 poll 会重新建立网络连接。
+
+因此以下说法不准确：
+
+- “rumqttc 对半开连接没有检测”；
+- “CONNACK 通用错误后继续 poll 一定会无限挂起”。
+
+额外增加 daemon 层 activity watchdog 可以作为防御性措施，但在拿到休眠复现日志前，不应列为已确认根因。
+
+### 3.3 前端状态显示
+
+前端状态来源：
+
+- 本地 HTTP 探活；
+- `GET /v1/info` 返回的 `mqtt_connected`；
+- 20 秒共享轮询。
+
+前端不会制造 MQTT 断连。轮询带来的额外影响是：
+
+- 断连可能延迟最多一个轮询周期才显示；
+- daemon 恢复后，警告可能额外保留最多一个有效轮询周期；
+- App 长期处于后台时，WebView timer 可能被冻结更久。
+
+“20 秒轮询把秒级断连放大成 1～2 分钟”不准确。日志中的约 95 秒窗口主要来自 daemon 的 90 秒兜底。
+
+当前 App 自身 MQTT 恢复逻辑已经监听 `visibilitychange`，但 daemon 状态轮询没有在 `focus` 或窗口重新可见时直接调用 `requestDaemonProbe()`。点击黄色警告会主动调用该函数，因此“点击后立即变绿”可以由状态刷新缺口解释。
+
+### 3.4 agent 药丸状态
+
+当前 `session-agent-ui-state.ts` 定义了 10 秒 connecting timeout：
+
+- 超时后本地 agent 转为 `offline`；
+- session runtime 场景转为 `runtime-error`；
+- 本地 agent 还会通过 HTTP 获取 daemon 的 `mqtt_connected` 和可达性证据。
+
+因此“MQTT 不更新会让药丸永久停在 connecting”与当前代码不符。若现场仍永久显示“连接中”，需要记录实际 UI state 输入和客户端版本，不能仅凭 MQTT presence 推导。
+
+---
+
+## 四、问题清单
+
+| # | 状态 | 问题 | 影响 | 建议 |
+|---|---|---|---|---|
+| P1 | 机制已确认，策略待灰度 | transient 网络错误后最长等待 90 秒才强制重建 | 约 1～2 分钟可见告警、消息暂不可用 | 先补齐自动重连日志；首版建议将兜底改为可配置的 30 秒并观察重连抖动 |
+| P2 | 已确认 | daemon 恢复后前端可能未及时重新探活 | 黄色警告在后台恢复后继续显示 | 在 `focus` / `visibilitychange` 时调用 `requestDaemonProbe()` |
+| P3 | 已确认 | NanoMQ 健康探针产生大量 warn 日志 | 掩盖真实异常、增加排查成本 | 调低该 transport 日志级别，或对探针关闭日志做过滤 |
+| P4 | 待复现 | 休眠唤醒后是否存在 rumqttc 未检测到的永久连接失活 | 可能需要重启 daemon | 复现时保存 daemon 连续日志、`mqtt_connected`、PingResp/错误和网络切换时间 |
+| P5 | 待确认 | 约 3540 秒连接聚类的关闭方未知 | 可能存在网关或其他客户端周期策略 | 增加 Caddy/NanoMQ/clientId 关联日志，检查网关 WebSocket 最大连接时长 |
+| P6 | 低优先级 | daemon 启动时 HTTP 先于 MQTT 就绪 | 启动瞬间短暂告警 | 可接受，或增加启动宽限/告警去抖 |
+
+以下原问题应移除：
+
+- “JWT 到期后 broker 每小时踢连接”；
+- “`ConnectionRefused` 后仍用旧凭证等待 90 秒”；
+- “CONNACK 通用错误分支必然无限挂起”；
+- “rumqttc 没有 PingResp/半开连接检测”；
+- “药丸因 connectingSince 机制永久停在连接中”。
+
+---
+
+## 五、建议的验证补强
+
+为了确定剩余 transient error 的关闭方，建议补充以下不含敏感 token 的日志：
+
+1. mqtt-auth：时间、clientId、allow/deny、deny reason；
+2. daemon：每次自动重连尝试的阶段、错误、累计次数、使用凭证的 expiry；
+3. NanoMQ：clientId 上下线原因，而不仅是 `Object closed`；
+4. Caddy：连接开始/结束时间、remote IP、upstream close error；
+5. 休眠复现：睡眠和唤醒时间、网络 online 事件、首次 PingReq/PingResp 或 timeout。
+
+在这些证据齐备前，应将根因描述为“网络/TLS 断连后的自动重连恢复不稳定”，而不是 JWT 到期或休眠半开连接。
+
+## 六、修复方案与落地顺序
+
+### 6.1 先修已确认、低风险的问题
+
+**第一步：P2 前端主动探活。**
+
+在 daemon 状态 hook 中监听 `window.focus` 和 `document.visibilitychange`，窗口重新获得焦点或重新可见时调用 `requestDaemonProbe()`。现有共享 probe 已经做了并发合并，因此不会因为定时轮询和窗口事件同时到达而发起两次 HTTP 请求。补一个 hook 测试，验证事件触发探活、卸载后移除监听，以及 probe 失败时状态仍能正确更新。
+
+这只能消除“daemon 已恢复但横幅仍是黄色”的显示滞后，不能修复 MQTT 链路本身。
+
+**第二步：P3 清理探针日志。**
+
+给 watchdog/health check 使用独立的 client 标识或 User-Agent，在 NanoMQ transport 日志侧仅降低或过滤这类主动关闭连接的记录。业务 client 的 `Object closed` 仍须保留，不能按整类关键字全部吞掉。
+
+### 6.2 P1 先观测，再缩短兜底窗口
+
+90 秒等待是已确认的恢复策略问题，但“改成连续 N 次失败”目前缺少可靠的“每次自动重连尝试”边界；不能把每次 `poll()` 错误简单当成一次尝试。第一版按以下方式落地：
+
+1. 为每次自动重连记录开始、失败、成功、累计断开时长、最终 rebuild 原因和连接代次；日志中只记录错误类型和 token expiry 时间，不记录 token 内容。
+2. 保留 rumqttc 的自动重连机制，不对 `mqtt.eventloop.poll()` 加 `tokio::timeout`。当前代码已明确说明，取消 poll future 会丢弃进行中的 TLS/TCP 状态，可能制造新的连接风暴。
+3. 将 `MQTT_DISCONNECT_REBUILD` 提取为可配置常量，首版默认从 90 秒调整为 **30 秒**。30 秒是折中值：减少用户等待，又保留一次 keepalive/网络恢复机会；上线后观察 rebuild 次数、ConnAck 成功率、重复连接和消息恢复情况，再决定是否进一步调整或改为基于失败次数。
+4. 只有收到 `ConnAck` 后才清零断开计时和失败计数；重建前继续保留当前“暂停发送、重建时刷新凭证”的行为。
+
+这一步解决的是“断了以后恢复太慢”，不是“连接为什么会断”。若 30 秒导致网络抖动期间重建次数明显上升，应回滚阈值，不能继续靠猜测调小。
+
+### 6.3 P4 先加诊断护栏，再针对性修复
+
+“02:09 到 03:52 没有 MQTT 活动，说明 `tokio::select!` 被 sock handler 卡住”是合理假设，但尚未确诊。P4 不直接对所有 handler 粗暴加 timeout，因为 timeout 会取消 future；对于已经产生部分副作用的写操作，可能造成状态半完成或调用方重试重复执行。
+
+诊断版建议包含：
+
+1. 给每个 `SockCommand` 记录 command 名称、开始时间、结束时间和耗时；超过阈值时输出 warning。
+2. 增加独立 watchdog，记录 event loop 最近一次进度、当前正在处理的 command，以及 MQTT 最近一次 `poll`/`ConnAck`/错误时间。watchdog 必须运行在 event loop 之外，才能观察 event loop 自身是否停转。
+3. 对只读且明确可取消的 handler 才加局部 timeout；有副作用的 handler 优先拆成后台 task + reply channel，或把超时放到其内部可恢复的边界。
+4. 用睡眠/唤醒、断网/恢复、broker 重启三类场景复现，至少拿到一次“handler 超时”或“event loop 停顿但无 handler”的证据后，再做正解。
+
+### 6.4 暂不处理
+
+P5 的 3540 秒连接簇还缺少连接归属和关闭方证据；P6 的启动时 HTTP 先于 MQTT 只造成短暂状态差异。两者不应和本轮恢复链路修复混在一起。
+
+### 6.5 验收标准
+
+- P2：窗口恢复可见/获得焦点后立即触发一次探活；并发事件只产生一个 in-flight probe。
+- P1：模拟 DNS、TLS、broker 重启后，正常自动重连仍能工作；无法恢复时不超过 30 秒进入 full rebuild，且没有高频建连风暴。
+- P4：复现期间能区分“网络/rumqttc 不再返回”与“sock handler 阻塞 event loop”；没有证据前不把休眠半开连接写成根因。
+- P3：探针噪音下降，同时真实业务连接关闭仍可检索。
+
+**最终优先级：P2 → P1 观测与 30 秒灰度 → P4 诊断复现 → 针对性拆分/超时 → P3 日志治理；P5/P6 暂缓。**
+
+## 七、本轮代码落地后的结论
+
+- P2 已落地：桌面端启动、获得焦点和重新可见时会主动探活，降低“daemon 已恢复但界面仍显示断开”的假象。
+- P1 已落地为 30 秒 transport recovery window。MQTT worker 在窗口内继续使用 rumqttc 自动恢复，超时后由独立 supervisor 停止旧 worker 并创建新 generation；不再依赖业务主循环里的 90 秒计时器。
+- MQTT worker 已与业务 command executor 解耦，worker 只负责 `poll()`、订阅、收发和 durable inbox/outbox；慢业务 handler 不再直接冻结 MQTT worker。
+- 这解决的是“断线后恢复路径过慢或 worker 失活时没有独立自愈边界”，不是对 P4 根因的事后证明。P4 仍需 broker 重启、TCP/TLS 故障和睡眠唤醒故障注入来确认现场是否存在永久失活。
+- 因此当前最准确的根因表述仍是：**网络大概率正常时，桌面端看到的断连可能是状态刷新滞后；真实网络抖动或 MQTT worker 失活时，旧实现的恢复升级边界过长且依赖同一事件循环。** 不能把问题归咎于 JWT 到期或 NanoMQ 探针日志。

--- a/docs/debug/mqtt-realtime-channel-reconnect-implementation-plan.md
+++ b/docs/debug/mqtt-realtime-channel-reconnect-implementation-plan.md
@@ -1,6 +1,7 @@
 # MQTT 实时通道重连架构改造计划
 
-> 状态：代码实现已完成于 `fix/p2-daemon-status-probe`，MQTT 改动尚未提交；真实 broker 故障注入仍需在可控环境验收
+> 状态：基础代码实现已提交于 `fix/p2-daemon-status-probe`；durable 崩溃窗口、旧
+> worker 事件隔离和存储故障停止重试已完成，真实 broker 故障注入仍需在可控环境验收
 >
 > 目标：一次性完成 MQTT worker、连接 supervisor、业务 command executor 和独立 watchdog 的拆分，消除当前 90 秒固定等待以及主事件循环被业务 handler 卡死后无法自愈的问题。
 >

--- a/docs/debug/mqtt-realtime-channel-reconnect-implementation-plan.md
+++ b/docs/debug/mqtt-realtime-channel-reconnect-implementation-plan.md
@@ -1,0 +1,606 @@
+# MQTT 实时通道重连架构改造计划
+
+> 状态：代码实现已完成于 `fix/p2-daemon-status-probe`，MQTT 改动尚未提交；真实 broker 故障注入仍需在可控环境验收
+>
+> 目标：一次性完成 MQTT worker、连接 supervisor、业务 command executor 和独立 watchdog 的拆分，消除当前 90 秒固定等待以及主事件循环被业务 handler 卡死后无法自愈的问题。
+>
+> 适用分支：`fix/p2-daemon-status-probe`
+
+## 1. 目标与非目标
+
+### 1.1 目标
+
+1. MQTT 网络事件循环与 socket/HTTP/cron/渠道业务处理彻底解耦。
+2. 普通网络/TLS 抖动时由 rumqttc 自动重连；在合理窗口内没有恢复时，由 supervisor 重建 MQTT client。
+3. 重建超时、重连退避和 watchdog 不依赖被监控的 MQTT/业务主循环。
+4. MQTT reconnect、订阅恢复、presence/state 重发、发送队列和连接代次具备清晰的生命周期边界。
+5. 任意一个业务 handler 的慢 HTTP、RPC、ACP、QR 或文件操作不会阻塞 MQTT `poll()`。
+6. 能从日志判断：断开原因、连接尝试次数、连接代次、当前 handler、最后一次 event-loop heartbeat，以及最终是自动恢复还是 full rebuild。
+7. daemon 在不重启进程的情况下恢复常见的 DNS、TCP、TLS、broker 重启和睡眠唤醒场景。
+
+### 1.2 非目标
+
+- 本次不修改 MQTT broker、Caddy、NanoMQ 或 mqtt-auth 的协议和部署配置。
+- 不把 JWT 到期重新认定为主要断连根因；只保留认证失败时刷新凭证的路径。
+- 不处理 3540 秒连接簇归属不明问题；该问题继续作为独立 P5 观察项。
+- 不把 P3 的 NanoMQ 探针 `Object closed` 日志治理混入核心重连改造。
+- 不通过扩大进程级重启范围解决问题；目标是只重建 MQTT worker/client。
+- 不用一个全局 `tokio::timeout` 粗暴包住所有业务 handler。
+
+## 2. 当前实现与确定的问题
+
+### 2.1 当前关键代码
+
+- MQTT 入口和 reconnect loop：`apps/daemon/src/daemon/server.rs:945`。
+- `MQTT_DISCONNECT_REBUILD = 90s`：`apps/daemon/src/daemon/server.rs:83-95`。
+- MQTT 主 `tokio::select!`：`apps/daemon/src/daemon/server.rs:1828-2110`。
+- `SockCommand` 定义：`apps/daemon/src/daemon/server.rs:221-390`。
+- socket/HTTP command bridge：`apps/daemon/src/daemon/server.rs:1207-1304`。
+- socket command listener：`apps/daemon/src/daemon/server.rs:2733-3226`。
+- MQTT client/keepalive：`apps/daemon/src/mqtt/client.rs:77-115`。
+- 重连后订阅和 presence/state 恢复：`apps/daemon/src/daemon/server.rs:878-938`。
+
+### 2.2 当前恢复流程
+
+```text
+rumqttc::EventLoop::poll()
+  -> transient error
+  -> mqtt_connected = false
+  -> 当前 select 分支同步 sleep 5s
+  -> 50ms 分支开始 disconnected_since
+  -> 继续依赖 rumqttc 自动重连
+  -> ConnAck：清零断开计时并重新订阅
+  -> ConnectionRefused：立即刷新凭证并跳出外层 loop
+  -> 断开计时满 90s：销毁 client，刷新凭证，外层重新建连
+```
+
+### 2.3 已确认的结构性问题
+
+1. `90s` 是硬编码的 wall-clock fallback，不是基于明确连接尝试次数的策略。
+2. transient error 分支的 `sleep(5s).await` 位于 `select!` 分支内部，会暂停该轮 event loop 的其它分支。
+3. 50ms 检查、proactive reconnect、MQTT poll 和大量 `SockCommand` handler 共用一个 event loop。
+4. 任一未拆出的裸 `.await` 都可能阻塞 `poll()`、90 秒计时器和 proactive timer。
+5. 当前 90 秒计时器依赖被监控的 event loop，本身不能作为独立 watchdog。
+6. 只有少数 handler 已经后台化；其余包括 channel、QR、local RPC、live ingest、workspace、prewarm 等仍有 inline await。
+7. full rebuild 会丢弃旧 `AsyncClient` 的内存队列；当前 RuntimeManager 的暂停取事件策略不能覆盖所有已经进入 MQTT client 队列的数据。
+8. 当前日志没有统一的连接代次、重连尝试、状态迁移、active handler 和 event-loop heartbeat。
+
+## 3. 目标架构
+
+```text
+                         +-----------------------------+
+                         | MQTT Connection Supervisor  |
+                         | - generation                |
+                         | - recovery deadline         |
+                         | - backoff                   |
+                         | - credential policy         |
+                         | - independent watchdog     |
+                         +-------------+---------------+
+                                       |
+                             owns JoinHandle / restart
+                                       |
+                         +-------------v---------------+
+                         | MQTT Worker                 |
+                         | - owns MqttClient           |
+                         | - owns EventLoop::poll()    |
+                         | - no business handler await |
+                         | - heartbeat                 |
+                         | - subscriptions             |
+                         +------+-----------------------+
+                                |
+              bounded events/commands, generation-tagged
+                                |
+                 +--------------v----------------+
+                 | Daemon Command Executor       |
+                 | - owns business DaemonServer  |
+                 | - serializes &mut self work   |
+                 | - runs safe slow work detached|
+                 | - handles SockCommand         |
+                 +--------------+-----------------+
+                                |
+             +------------------+------------------+
+             |                                     |
+       Unix socket / HTTP                  RuntimeManager / ACP
+       parser + reply                    cloud / channel handlers
+```
+
+### 3.1 所有权边界
+
+#### `MqttSupervisor`
+
+新增 `apps/daemon/src/daemon/mqtt_supervisor.rs`，负责：
+
+- 建立和销毁 MQTT worker generation；
+- 保存当前 generation、连接状态、断开原因和恢复 deadline；
+- 管理 transport recovery window、full rebuild 和指数退避；
+- 管理 credential refresh policy；
+- 监控 worker heartbeat；
+- 在 worker 不响应时按“fence publisher → 停止接收新请求 → 等待/终止旧 worker → 确认旧引用释放 → 创建下一代”的顺序切换；
+- 对旧 generation 的迟到事件做丢弃，不能让旧 worker 修改新连接状态。
+
+Supervisor 不直接处理 MQTT payload，也不持有 `DaemonServer` 的 `&mut self`。
+
+#### `MqttWorker`
+
+可以作为 `mqtt_supervisor.rs` 内部的 worker，负责：
+
+- 独占一个 `MqttClient` 和 `EventLoop`；
+- 唯一位置调用 `eventloop.poll()`；
+- 处理 `ConnAck`、Publish、PingResp、transport error 和 ConnectionRefused；
+- 处理 subscribe/resubscribe；
+- 将 inbound MQTT message 通过 bounded event channel 发送给 command executor；
+- 从 bounded publish queue 读取 outbound message；
+- 更新 task liveness、poll phase、poll start/return 和连接状态；
+- 不调用 `handle_incoming`、`dispatch_local_rpc`、cron、channel、ACP 等业务 handler。
+
+`eventloop.poll()` 不加可取消的普通 timeout。`MqttOptions`/`EventLoop` 使用显式 network connection timeout；只有在 poll pending 超过 keepalive 与 network timeout 的组合上限、并完成 generation fence 后，才走受控的 `EventLoop::clean()`/worker termination recovery。不能用 5～10 秒无事件直接判定 poll 卡死。
+
+#### `DaemonCommandExecutor`
+
+可以放在 `apps/daemon/src/daemon/server/command_executor.rs`，或在现有 `server.rs` 中先抽出独立 child module，负责：
+
+- 独占需要 `&mut DaemonServer` 的业务状态；
+- 消费 `SockCommand`、HTTP bridge command 和 MQTT inbound event；
+- 保持有副作用命令的串行语义；
+- 对已经确认 cancellation-safe 的慢操作后台化；
+- 通过 `MqttPublisherHandle` 向 worker 发送 outbound publish；
+- 通过原有 oneshot reply channel 给 socket 调用方返回结果；
+- 记录每个 command 的开始、结束、耗时和失败原因。
+
+不能简单把整个 `DaemonServer` 包进 `Arc<Mutex<_>>` 后对每个 command `tokio::spawn`：当前 `teamclu` 等状态有非 `Send`/顺序约束，且会把大锁持有时间隐藏起来。应保留一个业务 owner，通过消息驱动拆分网络 worker。
+
+#### 稳定 publisher 与 worker 接口
+
+业务层必须只持有一个跨 generation 稳定的 `GenerationPublisher`，不能继续持有某代 `rumqttc::AsyncClient`。建议接口明确为：
+
+```rust
+struct GenerationPublisher {
+    ingress_tx: mpsc::Sender<PublishRequest>,
+    // 只读状态：当前 generation、phase、是否允许新消息进入 outbox
+    state: Arc<PublisherRouteState>,
+}
+
+enum MqttWorkerCommand {
+    Publish(PublishRequest),
+    ApplySubscriptionPlan {
+        generation: u64,
+        plan: SubscriptionPlan,
+        reply_tx: oneshot::Sender<Result<(), MqttWorkerError>>,
+    },
+    Stop {
+        generation: u64,
+        reply_tx: oneshot::Sender<()>,
+    },
+}
+
+enum MqttWorkerEvent {
+    TransportConnected { generation: u64 },
+    SubscriptionsReady { generation: u64 },
+    Inbound(InboundEnvelope),
+    TransportError { generation: u64, kind: String },
+    WorkerExited { generation: u64, reason: WorkerExitReason },
+}
+```
+
+`GenerationPublisher` 实现现有 `MessagePublisher` trait，内部只向 supervisor 的稳定 ingress channel 投递；`SessionManager`、`LivePublisher`、`NotifyPublisher`、`RpcServer` 和后台任务均保存这个 proxy 的 `Arc`。supervisor 重建 worker 时只替换内部 route，不替换业务对象中的 `Arc`。`publish/subscribe/unsubscribe` 的 channel 容量、reply、generation 校验和 queue full 行为必须在实现前固定下来。
+
+## 4. 连接状态机与时序
+
+### 4.1 状态
+
+```text
+Starting
+  -> Connected
+  -> Recovering
+  -> Rebuilding
+  -> Backoff
+  -> Starting
+```
+
+每个 generation 维护：
+
+```rust
+struct MqttConnectionSnapshot {
+    generation: u64,
+    phase: MqttPhase,
+    connected_since: Option<Instant>,
+    disconnected_since: Option<Instant>,
+    attempts: u32,
+    last_error_kind: Option<String>,
+    last_error_at: Option<Instant>,
+    last_connack_at: Option<Instant>,
+    last_poll_progress_at: Instant,
+    credential_expiry_epoch: Option<i64>,
+}
+```
+
+状态必须至少区分：
+
+```text
+TransportConnected
+  -> SubscriptionsPending
+  -> SubscriptionsReady
+  -> GenerationReady
+```
+
+只有 `GenerationReady` 才把 `/v1/info.mqtt_connected` 的 active flag 设为 `true`。这样 UI 不会在 ConnAck 之后、SUBACK/状态恢复之前过早显示在线；日志仍单独记录 transport connected。
+
+动态订阅不能由只拥有 `MqttClient` 的 worker 自己推导。executor 根据当前 `MqttClient::Topics`、`SessionManager` 的 membership/live session 集合生成不可变的：
+
+```rust
+struct SubscriptionPlan {
+    topics: Vec<(String, DeliveryGuarantee)>,
+    generation: u64,
+}
+```
+
+worker 执行 plan，并跟踪每个 subscribe packet 的 SUBACK；`AsyncClient::subscribe()` 返回“请求已进入 client queue”不等于 broker 已确认。全部必要 SUBACK 到达后才发送 `SubscriptionsReady`，再由 executor 完成 presence/state publish，最后发送 `GenerationReady`。
+
+### 4.2 推荐时序参数
+
+首版采用明确的可配置常量，默认值如下：
+
+| 参数 | 默认值 | 作用 |
+|---|---:|---|
+| `MQTT_RECOVERY_WINDOW` | 30s | transport 断开后，允许当前 worker/rumqttc 自动恢复的最长窗口 |
+| `MQTT_RECONNECT_BACKOFF_INITIAL` | 500ms | 新一轮连接尝试的初始退避 |
+| `MQTT_RECONNECT_BACKOFF_MAX` | 10s | 单次退避上限 |
+| `MQTT_WORKER_STALL_WARN` | 5s | worker task liveness 停滞告警；不是 poll 无 MQTT event 的阈值 |
+| `MQTT_POLL_PENDING_WARN` | 45s | poll 持续 pending 的诊断阈值，结合 30s keepalive，不直接重建 |
+| `MQTT_POLL_PENDING_REBUILD` | 75s | poll pending 超过 keepalive/network timeout 组合上限后的受控恢复阈值 |
+| `MQTT_STARTUP_GRACE` | 15s | 已由前端状态层处理的启动 MQTT 探测宽限 |
+| `MQTT_OUTBOX_MAX` | 配置项 | outbound 内存队列上限，禁止无限增长 |
+
+`30s` 是 transport recovery 策略，不是 poll-stall watchdog 的阈值。watchdog 必须区分“worker task 仍活着但 poll 正常等待网络”和“task 真正不再推进”。必须在 30s keepalive、5s network timeout 的实际参数下校准 45s/75s，不能用 5～10s 无事件误杀空闲连接。
+
+### 4.3 错误分类
+
+| 错误类型 | 处理方式 |
+|---|---|
+| `ConnAck` 成功 | phase=`TransportConnected`，不立即对外宣称 generation ready |
+| DNS/TCP/TLS/EOF/未连接 | phase=`Recovering`，允许 worker 自动重试；超过 30s 后重建 generation |
+| 明确认证拒绝 | 按 reason code 分类；只有 auth/ACL/token 类拒绝才作废 cached credential，获取新 token 后重建 |
+| subscribe/resubscribe 失败 | 标记当前 generation 不健康，进入 rebuild；保留失败上下文 |
+| publish queue 满 | 明确返回 backpressure/drop 结果并记日志，不静默丢弃 |
+| worker heartbeat 超时 | supervisor 终止当前 worker generation，独立创建下一代 |
+
+不能把每一次 `poll()` 返回的 error 都当成一次真实连接尝试。attempt 只在 worker 实际开始新 socket/connect generation 时递增；日志同时保留 poll error 次数，避免两者混淆。`ConnectionRefused` 必须按 rumqttc reason code 分成认证、ACL、协议和服务端暂不可用，不能统一刷新 token。
+
+## 5. 连接重建流程
+
+### 5.1 建立新 generation
+
+1. Supervisor 分配递增的 `generation`。
+2. 根据 credential policy 获取 token：
+   - 认证拒绝或 token 即将过期：强制作废缓存并刷新；
+   - 单纯 transport failure 且 token 仍有效：优先复用有效 credential，避免无意义地频繁刷新；
+   - 如新 generation 仍收到认证拒绝，再进入一次强制 refresh。
+3. 创建 `MqttClient`、`AsyncClient` 和 `EventLoop`。
+4. 将当前 generation 的 `AsyncClient` 只交给 worker；业务层继续使用同一个 `GenerationPublisher` proxy。
+5. worker 等待 `ConnAck`，成功后发送 `TransportConnected { generation }`，但不更新对外 `mqtt_connected`。
+6. executor 生成 `SubscriptionPlan`，worker 执行所有 base/team/live subscribe 并等待 SUBACK。
+7. 收到 `SubscriptionsReady` 后，executor 按固定顺序发布 presence、actor snapshot、agent state 和必要的 pending outbox。
+8. 全部恢复动作成功后发送 `GenerationReady`，再更新 `/v1/info.mqtt_connected`。
+
+### 5.2 旧 generation 隔离
+
+- 每条 worker event、publish completion、rebuild request 都带 `generation`。
+- command executor 只接受当前 generation 的 Connected/Disconnected event。
+- 旧 worker 在 abort 后产生的迟到 event 必须被丢弃。
+- `mqtt_connected_flag` 只能由当前 generation 更新。
+- full rebuild 时先将旧 `GenerationPublisher` route 标记为 fenced，阻止新消息进入旧代；
+- 将旧代尚未发送的 publish request 转移到 supervisor outbox 或明确返回失败；
+- 发送 `Stop`，等待旧 worker `JoinHandle` 完成；只有确认旧 `AsyncClient`、worker command receiver 和 publish future 引用释放后才创建新 client；
+- 新 worker 启动后再切换 proxy route，旧 generation 的 completion 一律返回 `StaleGeneration`。
+
+## 6. Publish queue 与消息一致性
+
+### 6.1 发送路径
+
+将当前直接克隆 `AsyncClient` 的发布路径改成：
+
+```text
+business handler
+  -> MqttPublisherHandle
+  -> bounded MqttWorkerCommand queue
+  -> current MqttWorker AsyncClient
+```
+
+业务代码不再持有某一代 `AsyncClient` 的裸 clone，否则 rebuild 后会继续向旧 client 投递。
+
+`GenerationPublisher` 的 ingress channel 由 supervisor 持有，容量按消息数和 payload bytes 双限流；outbox 由 supervisor 持有，不放在 worker 内，避免 worker abort 时一起丢失。`PublishRequest` 必须带 `message_class`、`event_id/dedup_key`、QoS、retain、入队时间和 completion oneshot。
+
+`publish()` 的成功语义固定为“已进入 supervisor outbox/worker ingress”，不伪装成 broker ACK；需要 broker ACK 的 control/state 消息由 worker 跟踪 packet id 并完成对应 oneshot。state 消息按 `(topic, state_key)` coalesce，RPC response 按 request id 保留 deadline，过期请求返回明确错误；live chunk 只能按 event id/序列策略合并或丢弃。
+
+### 6.2 Inbound backpressure 策略
+
+Inbound 不能简单使用 `send().await` 或 `try_send()`：前者会因为 executor 慢而停止 `poll()`，后者可能在 QoS1 已被 client 接收后静默丢消息。
+
+本次采用两级队列：
+
+1. worker 到 inbound dispatcher 使用按**字节数和消息数双上限**的 bounded staging queue；worker 只能把 MQTT envelope 转移到该队列，不直接调用业务 handler。
+2. dispatcher 将需要可靠处理的 control/RPC envelope 写入本地 durable inbox，再交给单一 command executor；写入完成前不能报告 accepted。
+3. QoS0 live chunk 不进入 durable inbox，使用合并/丢弃策略并记录 dropped bytes/events；QoS1/control 不得静默丢弃。
+4. staging queue 和 durable inbox 都满时，进入明确的 `InboundBackpressure` 状态：暂停向业务派发、记录指标，并验证 rumqttc 对当前 packet 的 ACK/redelivery 行为；不能靠无限内存掩盖问题。
+5. integration test 必须验证 broker 重连、进程中止和 inbox replay，确认可靠消息不会因 executor 慢而丢失；如果 rumqttc 自动 ACK 时机无法满足 durable 语义，则必须调整协议/客户端 ACK 配置，而不是假设 QoS1 自动可靠。
+
+Inbound queue 的容量、持久化位置、清理策略、重复 message id 去重和恢复顺序必须在代码中显式定义。
+
+### 6.3 断开期间策略
+
+- RuntimeManager 继续暂停取出新的 live event；
+- 已生成且需要保证的消息进入 bounded outbox；
+- outbox item 带 topic、payload、QoS、event id、generation-independent dedup key；
+- 重连成功并完成订阅后按顺序 flush；
+- 超过上限时采用明确策略：优先保留 control/state，live chunk 按 event id 合并或丢弃，并输出统计；
+- 不承诺对所有大块 live chunk 做无限可靠缓存。
+
+### 6.4 重连后的恢复顺序
+
+```text
+ConnAck
+  -> MQTT team subscriptions
+  -> teamclu subscriptions
+  -> actor presence
+  -> full actor state
+  -> all agent states
+  -> bounded outbox
+  -> resume RuntimeManager event drain
+```
+
+恢复顺序要有单测，避免出现“显示在线但尚未订阅”或“重连后只发布空 presence、覆盖真实 state”的回归。
+
+## 7. Command executor 拆分策略
+
+### 7.1 主循环禁止执行的工作
+
+以下工作不能继续放在 MQTT worker 的 `select!` 分支：
+
+- `reload_channels`、channel status/chat list、channel save；
+- `handle_mcp_send`、`handle_channel_send`；
+- `dispatch_local_rpc`、`ingest_session_live`；
+- `handle_cron_prepare_session`；
+- WeChat/WeCom QR start/poll；
+- `handle_add_workspace_sock`；
+- `kick_prewarm_for_workspace`；
+- 任意 cloud API、gateway HTTP、文件扫描、ACP turn 等不可控耗时操作。
+
+### 7.2 执行模型
+
+- Socket listener 只负责解析 JSON、校验最小字段、发送 `SockCommand` 和写 reply。
+- `DaemonCommandExecutor` 对需要 `&mut self` 的操作串行执行，避免数据竞争。
+- 已经具备安全边界的长任务（例如 cron turn、remote tool、permission wait）继续采用后台 task + completion event；completion event 不得要求 MQTT worker 等待。
+- 对有副作用的操作不直接套取消型 timeout；在具体 HTTP/RPC client 内设置超时，并让操作具备幂等 key 或明确的失败状态。
+- 每个 command 必须保证 reply：成功、业务错误、取消、executor shutdown 都要完成 oneshot，不能让客户端无限等待。
+- command channel 需要有明确容量和满载行为；不能因为 MQTT 暂停导致 HTTP/socket listener 无限阻塞。
+
+### 7.3 生命周期与 shutdown
+
+- `DaemonServer` 仍是业务 owner；`MqttSupervisor`、`DaemonCommandExecutor` 和 socket listener 的 JoinHandle 由 `run()` 统一保存和等待。
+- supervisor 每次新建 generation 都从当前可变配置读取 team/broker/actor identity；不能只复制启动时的 `DaemonConfig`。现有 `run()` 对 onboarding 后 team_id 自愈的逻辑必须通过 `ConfigSnapshot`/rebuild request 传递给 supervisor。
+- MQTT 与 NATS 的 transport worker 可以共享 command executor 协议，但 NATS 的连接生命周期和旧 run loop 继续独立；不能让 MQTT supervisor 误接管 NATS。
+- shutdown 顺序固定为：停止接受新 socket/HTTP command → 向 executor 发送 shutdown → fence publisher → 请求 worker stop → 等待 worker JoinHandle → flush/失败 queued replies → 删除 socket path。
+- executor shutdown 时为所有 queued/in-flight oneshot 回复 `daemon_shutting_down`；socket listener 收到该结果后关闭连接。进行中的外部任务要有取消 token，不能留下永不完成的 reply。
+- worker rebuild 与 daemon shutdown 使用不同的 reason，shutdown 不触发 backoff/reconnect；旧 generation 的 delayed completion 必须在 shutdown 后被丢弃。
+
+### 7.4 诊断信息
+
+每个 command 记录结构化字段：
+
+```text
+command_id
+command_name
+source: sock | http | mqtt
+started_at
+finished_at
+duration_ms
+outcome
+active_generation
+```
+
+超过 `5s` 输出 warning，超过 `10s` 输出 error，并包含当前 command 名称。日志不能包含 token、完整 payload 或用户敏感内容。
+
+## 8. Watchdog 设计
+
+### 8.1 Heartbeat
+
+MQTT worker 发布两类独立 telemetry，不能只保留一个 `last_poll_progress_at`：
+
+- `task_liveness_at`：由独立 lightweight ticker 更新，证明 Tokio worker task 仍然在运行；
+- `poll_phase`：`Idle`、`Connecting`、`WaitingNetwork`、`ProcessingEvent`，并记录 `poll_started_at`、`poll_returned_at`；
+- `last_event_at`：最近一次 MQTT Event/Error/PingResp/ConnAck；
+- `last_connack_at`、`last_suback_at` 和当前 pending SUBACK 数量；
+- 当前 generation、active command、outbox/inbound queue 计数。
+
+`task_liveness_at` 存放在 `Arc<AtomicU64>` 或专用 watch channel，包含 monotonic timestamp 和 generation。`poll()` 正常等待网络时不更新 `last_event_at`，但也不应仅因为它没有更新就被误杀。
+
+### 8.2 Supervisor 处理
+
+- 每 2 秒检查 task liveness 和 poll phase；
+- task liveness 超过 5 秒没有更新：输出 warning，附带 active command、last event 和 error；
+- worker task 仍活着且 `poll_phase=WaitingNetwork`：按 `MQTT_POLL_PENDING_WARN/REBUILD` 与 keepalive/network timeout 判断，不能按 5/10 秒判死；
+- worker task 无 liveness，或 poll pending 超过组合上限：先 fence publisher、停止新请求、调用受控 `EventLoop::clean()`/结束协议，等待 `JoinHandle`；旧 worker 未退出前不创建新 client；
+- 只有确认旧 generation 已停止后，才创建下一代并恢复 route；
+- watchdog 自身不能依赖 worker 的 `select!` timer；
+- 每次 watchdog rebuild 都要限速，避免异常时形成 abort/restart tight loop。
+
+### 8.3 重要限制
+
+watchdog 只能重建 MQTT worker，不能直接 abort 整个 daemon。若 command executor 也出现长时间停顿，应单独记录，但不能因此让 MQTT 网络层一起停摆。rumqttc 的 `NetworkOptions::connection_timeout` 和 `EventLoop::clean()` 行为必须在集成测试中验证；不能凭“10 秒没有 MQTT event”判断 worker 卡死。
+
+## 9. 代码改造范围
+
+### 9.1 新增
+
+- `apps/daemon/src/mqtt/supervisor.rs`
+  - 独立 supervisor task、worker generation、30 秒 recovery deadline、credential refresh、heartbeat watchdog，以及旧 worker 的 graceful-stop/abort 兜底。
+- `apps/daemon/src/daemon/server/command_executor.rs`
+  - `SockCommand` dispatch、command timing、reply completion、business event fan-in。
+- 必要时新增纯数据类型模块，用于 `MqttWorkerEvent`、`MqttWorkerCommand`、`MqttConnectionSnapshot` 和 outbox item。
+
+### 9.2 修改
+
+- `apps/daemon/src/daemon/server.rs`
+  - 保留启动、HTTP/NATS 选择和业务状态；
+  - 删除 MQTT `select!` 中的业务 handler await；
+  - 将 `mqtt_connected_flag`、publisher handle、topics 切换到 supervisor/worker 的 generation-aware handle；
+  - 将 `mqtt_resubscribe_after_connack` 拆成 worker subscribe 与 business state republish 两部分；
+  - MQTT/NATS 共享的业务 dispatch 不改变协议行为。
+- `apps/daemon/src/daemon/mod.rs`
+  - 注册新模块。
+- `apps/daemon/src/mqtt/client.rs`
+  - 保留 client 创建和 transport 配置；
+  - 必要时抽出 error classification 和 connection attempt 事件，不在这里放业务重试策略。
+- `apps/daemon/src/daemon/server/messaging.rs`
+  - 统一使用 generation-independent publisher handle；
+  - 保证 reconnect 后 state republish 顺序。
+- `apps/daemon/src/daemon/server/rpc.rs`、`channels.rs`、`peers_workspaces.rs`、`cron.rs`、`remote_tools.rs`
+  - 改为依赖 command executor 的发布抽象；
+  - 保持现有协议、reply shape 和幂等语义。
+
+### 9.3 不应修改的行为
+
+- MQTT topic 命名和 actor identity 不变。
+- `/v1/info.mqtt_connected` 仍返回当前 active generation 的真实状态。
+- `ConnectionRefused` 不应再被无条件描述为 JWT 过期，日志需要保留 broker reason code。
+- NATS 路径继续可用；若共享 executor，必须有 NATS regression tests。
+
+## 10. 测试计划
+
+### 10.1 纯单元测试
+
+- state transition：Connected/Recovering/Rebuilding/Backoff；
+- 30 秒 recovery deadline；
+- 认证拒绝立即 refresh；
+- transport failure 不立即刷新 token；
+- exponential backoff + jitter 上限；
+- generation 隔离和迟到 event 丢弃；
+- task liveness、WaitingNetwork poll pending、keepalive/network timeout 三类 watchdog 判定；
+- outbox 上限、合并、flush 顺序和 overflow policy；
+- command reply 在成功、错误、取消、executor shutdown 时都只发送一次。
+
+### 10.2 daemon 集成测试
+
+- broker 正常启动后完成 ConnAck、subscribe 和 state publish；
+- broker 重启后 30 秒内完成 worker rebuild 并恢复订阅；
+- DNS 失败、TCP reset、TLS EOF、peer close；
+- ConnectionRefused 后刷新 credential；
+- 业务 command 阻塞 30 秒时 MQTT worker 仍能 heartbeat/重连；
+- MQTT worker task liveness 停止或 poll pending 超过组合阈值时 supervisor 能只重建 MQTT worker；
+- rebuild 时旧 generation 的事件不会污染新状态；
+- NATS transport 不受影响。
+
+### 10.3 手工/故障注入场景
+
+1. 启动 daemon 后立刻阻断 broker，确认 UI 不会永久显示旧状态。
+2. 运行中断 DNS/TCP/TLS，记录首次错误到 ConnAck/full rebuild 的时延。
+3. 重启 NanoMQ，确认不需要重启 daemon。
+4. macOS 睡眠 1～5 分钟后唤醒，确认 heartbeat、PingResp、重连和 state 恢复。
+5. 触发慢 QR/cloud/RPC/cron handler，同时观察 MQTT event log 是否继续推进。
+6. 连续制造失败，确认退避不会形成连接风暴。
+
+### 10.4 验收指标
+
+- 普通网络抖动恢复 P95 小于 5 秒。
+- broker/DNS/TLS 故障在 worker 可运行时不超过 30 秒进入 full rebuild。
+- worker task liveness 停止时能及时触发 MQTT worker rebuild；正常空闲连接在 30s keepalive 下不会被误杀。
+- 任意单个业务 handler 持续 30 秒时，MQTT heartbeat 不停止。
+- rebuild 后订阅、presence、actor state、agent state 均恢复。
+- 没有旧 generation 对新 generation 的状态污染。
+- 日志可以完整回答“什么时候断、为什么断、重试了几次、谁触发了重建、何时恢复”。
+
+## 11. 实施约束与风险控制
+
+### 11.1 不采用的做法
+
+- 不把 `MQTT_DISCONNECT_REBUILD` 单独改成 `15s` 就结束。
+- 不把所有 `.await` 简单包一层 `tokio::timeout`。
+- 不在 worker 内取消正在进行的 `eventloop.poll()` 作为正常重试手段。
+- 不把所有 handler 并行 `spawn`，避免 `DaemonServer` 状态竞争、回复乱序和重复副作用。
+- 不用无界 channel 或无界 outbox 掩盖 backpressure。
+
+### 11.2 主要风险与对策
+
+| 风险 | 对策 |
+|---|---|
+| worker 与业务拆分后 publisher 句柄失效 | 所有发布都经过 generation-independent handle；旧 generation sender 自动失败 |
+| 重建后订阅/retain/state 顺序错误 | 将 ConnAck 恢复流程拆成固定步骤并增加集成测试 |
+| 业务 command 并发导致重复副作用 | 保留单一 command owner；仅后台化已分类的慢操作 |
+| watchdog 误判导致频繁重建 | heartbeat 事件定义清晰；连续超时确认；重建全局限速 |
+| outbox 内存增长 | 有界队列、分类优先级、overflow 日志和指标 |
+| 凭证被无意义刷新 | 仅认证失败或过期窗口强刷；transport rebuild 优先复用有效 credential |
+| NATS 回归 | 保持 NATS 独立 run loop，增加 NATS 测试和编译验证 |
+
+## 12. 一次性实施顺序
+
+这里的“分步骤”只是代码落地顺序，不是先上线半成品再观察的分阶段方案；本次 PR 必须在所有边界、watchdog、重连、队列和测试完成后才算可用。
+
+1. 抽取并冻结 MQTT/worker 的事件与命令类型、连接状态快照、generation 规则和错误分类。
+2. 实现 `MqttPublisherHandle`、bounded publish queue 和 generation-aware completion；先让所有 publisher 不再直接依赖旧 `AsyncClient`。
+3. 实现 `MqttWorker`：只拥有 `MqttClient/EventLoop`，处理 poll、ConnAck、subscribe、publish queue 和 heartbeat。
+4. 实现 `MqttSupervisor`：负责 token policy、30 秒 recovery deadline、backoff、worker generation 和独立 watchdog。
+5. 把当前 `mqtt_resubscribe_after_connack` 拆成 worker 订阅动作与 command executor 的 state/presence 重发动作。
+6. 实现 `DaemonCommandExecutor`，把 SockCommand、HTTP bridge 和 MQTT inbound event 从 MQTT worker 移出；保留必须的业务串行语义。
+7. 将 cron、remote tool、permission 等已经具备后台执行模式的路径接入新的 completion channel；为其余慢 handler 加内部超时、幂等或取消边界。
+8. 从 `DaemonServer::run` 删除旧的 5 秒 inline sleep、90 秒 event-loop timer 和 MQTT 内联业务 handler；接入 supervisor/executor 生命周期和 shutdown 顺序。
+9. 加入 outbox flush、重连恢复顺序、旧 generation 隔离、shutdown/rebuild race 的测试。
+10. 运行 format、daemon tests、相关 app tests 和故障注入；修复所有阻断性 review 意见后再提交代码评审。
+
+## 13. 实施完成定义
+
+只有以下条件全部满足，才算本次架构改造完成：
+
+- MQTT `poll()` 不再和业务 handler 共用同一个可被业务 await 卡住的 loop。
+- 90 秒硬编码 fallback 被 supervisor 的独立 recovery deadline 替代。
+- 独立 watchdog 可以在 event loop 停滞时重建 MQTT worker。
+- 连接、订阅、presence、state、outbox 的重建顺序经过测试。
+- 现有 socket/HTTP/MQTT/NATS 协议行为和 reply shape 没有回归。
+- 故障注入场景不需要重启 daemon 进程即可恢复。
+- 相关 Rust 单测和编译检查通过；全仓 `cargo fmt --check` 仍受 main 分支既有无关格式问题影响，真实 broker 故障注入未在本地执行。
+- Subagent review 的阻断性意见已处理，并在本文件末尾记录 review 结果。
+
+## 14. Subagent Review 记录
+
+### Review agent
+
+`multi_agent_v1` agent `Mencius`，review 日期：2026-08-21。
+
+### Review 结论
+
+初版计划方向正确，但不能直接进入实现。review 指出的阻断点已在本版本补充：
+
+1. **Publisher 生命周期**：新增 `GenerationPublisher` 稳定 proxy、稳定 ingress、旧 generation fencing 和 publish completion 规则；明确现有 `SessionManager`、`LivePublisher`、`NotifyPublisher`、`RpcServer` 不能继续保存裸 `AsyncClient`。
+2. **动态订阅**：新增 `SubscriptionPlan`，由 executor 生成、worker 执行；恢复必须等待 SUBACK，分离 `TransportConnected`、`SubscriptionsReady`、`GenerationReady`。
+3. **Watchdog 误判**：移除“10 秒无 event 就重建”的规则，改为 task liveness、poll phase、keepalive/network timeout 三类信号；正常 30 秒 keepalive 空闲不能被误杀。
+4. **Inbound backpressure**：明确 bounded staging queue + durable inbox 的责任边界、QoS0/QoS1 策略、字节/消息双上限和满载行为；禁止 `send().await` 阻塞 worker，也禁止静默 `try_send()` 丢可靠消息。
+5. **旧 worker 终止协议**：补充 fence → 停止接收 → 转移/失败 pending publish → 等待 JoinHandle → 确认引用释放 → 创建新 generation 的顺序。
+6. **Outbox 语义**：明确 outbox owner、双上限、publish 成功语义、broker ACK 跟踪、state coalesce、RPC deadline 和 live chunk 策略。
+7. **运行时配置和 shutdown**：补充 onboarding/config 自愈、NATS 分支边界、executor/worker/listener JoinHandle 和 shutdown reply 行为。
+8. **错误分类和测试**：要求按 reason code 区分认证/ACL/协议/服务端错误，并补充 SUBACK、空闲 watchdog、旧 generation、inbound 满载、shutdown 和 NATS 回归测试。
+
+### Review 后的实现门槛
+
+在上述接口和生命周期规则没有落成具体 Rust 类型、channel 容量、queue overflow 行为及测试之前，不进入 `server.rs` 大规模迁移。尤其不能先写一个“能重连”的 demo，再补 publisher/outbox/旧 worker 释放；那会把最难验证的数据一致性问题留到线上。
+
+## 15. 本次实施核对
+
+本轮代码已落地以下边界：
+
+1. `AsyncClient`/`EventLoop` 只由 MQTT worker 持有，业务模块只持有稳定的 `MqttPublisher` proxy。
+2. 原 90 秒主循环兜底已移入 supervisor，默认恢复窗口为 30 秒；重建过程不再在 `poll()` 分支内固定 sleep 5 秒。
+3. 连接阶段拆为 `TransportConnected`、`SubscriptionsReady`、`GenerationReady`；worker 等待 SUBACK，只有完整恢复后才更新 `mqtt_connected`。
+4. 连接代次、readiness fence、durable inbox/outbox 和 QoS ACK 跟踪已实现；业务 executor 只记录慢命令，不在副作用操作外层强行取消 future。
+5. watchdog 独立于 worker 的 MQTT select，分别观察 task liveness 与 poll pending；45 秒只诊断，75 秒才请求受控重建，避免把 30 秒 keepalive 的空闲连接误判为断连。
+6. MQTT inbound 已通过 `DaemonCommandExecutor` 进入业务 owner，worker 不再调用业务 handler。
+7. supervisor 与 worker 已拆成不同 Tokio task；watchdog 请求由 supervisor 接收，先停止并等待旧 worker，超时才 abort，再创建下一代，避免 watchdog 被卡住的 `poll()` 反向阻塞。
+8. `DaemonServer` 不再持有 `MqttClient`/`AsyncClient`，RPC response 也统一经过稳定 publisher proxy；订阅计划由 supervisor 保留并传给下一代 worker。
+
+已验证：
+
+- `cargo check -p amuxd --locked`
+- `cargo test -p amuxd mqtt::supervisor --locked`
+- `cargo test -p amuxd mqtt::durable_queue --locked`
+- `git diff --check`
+- 全量 `cargo test -p amuxd --locked`：1197 passed、88 failed；失败均集中在当前沙箱禁止绑定本地端口的 HTTP/wiremock/runtime 测试，未见 MQTT 相关编译或定向单测失败。
+
+`cargo fmt --check` 仍会报告仓库中既有的非本次改动格式问题；本轮未用全仓格式化覆盖这些无关改动。真实 broker 重启、TCP reset、TLS EOF 和睡眠唤醒场景需要在可控测试 broker 环境中做集成故障注入，不能由本地编译单测替代。

--- a/docs/debug/mqtt-realtime-channel-resume-recovery-plan.md
+++ b/docs/debug/mqtt-realtime-channel-resume-recovery-plan.md
@@ -1,6 +1,6 @@
 # MQTT 实时通道睡眠唤醒与断联恢复方案
 
-> 状态：已完成 Subagent review，并按 review 修订；暂不修改实现代码
+> 状态：已完成 Subagent review，并按 review 落地实现；真实 broker 故障注入待验收
 >
 > 适用分支：`fix/p2-daemon-status-probe`
 >
@@ -10,8 +10,12 @@
 >
 > 本文不是重新设计 MQTT supervisor。此前未提交的 MQTT 架构改造是本方案的
 > 基线，本次只补齐“睡眠/唤醒、VPN 恢复后如何主动恢复”和对应的故障注入验收。
-> 本文同时明确当前未提交架构改造尚未完成的 durable 语义、代次一致性和安全边界，
-> 避免把现有的 at-least-once 实现误写成 exactly-once。
+> 执行状态（2026-08-22）：基础 supervisor/worker、recovery signal、token 协同和前端
+> 状态修复已提交；durable 崩溃窗口、outbox event identity、旧 worker 事件隔离和
+> durable 存储故障停止重试已完成；queue high-water mark、存储错误分类透传和人工
+> recovery 解锁策略已补齐，真实 broker/TCP/TLS/macOS sleep 故障注入仍需在可控环境验收。
+> 本文同时明确 durable 语义、代次一致性和安全边界，避免把 at-least-once 实现误写成
+> exactly-once。
 
 ## 0. Review 修订摘要
 
@@ -47,11 +51,16 @@ Subagent review 认为原计划不能直接进入实现，主要缺口已在下�
   - durable inbox/outbox 接入。
 - `apps/daemon/src/mqtt/durable_queue.rs`
   - append-only durable inbox/outbox；
-  - ACK、恢复、日志压缩和 torn tail 处理。
+  - ACK、恢复、日志压缩和 torn tail 处理；
+  - inbox dedup 仅保留未 ACK 项，支持旧格式兼容和崩溃后重建，避免历史 ID 无限增长；
+  - queue compact 持久化 high-water mark，旧 generation 的延迟 ACK 不会命中新消息。
 - `apps/daemon/src/daemon/server.rs`
   - daemon business owner 与 MQTT worker 解耦；
   - MQTT inbound 交给 command executor；
-  - `/v1/info.mqtt_connected` 由当前 generation 的 readiness 更新。
+  - `/v1/info.mqtt_connected` 由当前 generation 的 readiness 更新；
+  - actor retained state 发布失败会阻止当前 generation 进入 Ready，并保留 durable
+    store 错误分类；
+  - durable `StorageError` 只允许人工 recovery 解锁，网络/唤醒信号不会再次启动重建。
 - `apps/daemon/src/daemon/server/command_executor.rs`
   - MQTT worker 不再直接执行业务 handler；
   - 业务 ACK 在 handler 完成后发出。

--- a/docs/debug/mqtt-realtime-channel-resume-recovery-plan.md
+++ b/docs/debug/mqtt-realtime-channel-resume-recovery-plan.md
@@ -1,0 +1,700 @@
+# MQTT 实时通道睡眠唤醒与断联恢复方案
+
+> 状态：已完成 Subagent review，并按 review 修订；暂不修改实现代码
+>
+> 适用分支：`fix/p2-daemon-status-probe`
+>
+> 关联文档：
+> - `docs/debug/mqtt-realtime-channel-reconnect-implementation-plan.md`
+> - `docs/debug/mqtt-realtime-channel-disconnect-analysis.md`
+>
+> 本文不是重新设计 MQTT supervisor。此前未提交的 MQTT 架构改造是本方案的
+> 基线，本次只补齐“睡眠/唤醒、VPN 恢复后如何主动恢复”和对应的故障注入验收。
+> 本文同时明确当前未提交架构改造尚未完成的 durable 语义、代次一致性和安全边界，
+> 避免把现有的 at-least-once 实现误写成 exactly-once。
+
+## 0. Review 修订摘要
+
+Subagent review 认为原计划不能直接进入实现，主要缺口已在下文收敛为硬约束和测试：
+
+- durable inbox 缺少跨 MQTT redelivery 的稳定 message id，executor 也没有失败/重试/
+  dead-letter 的结果接口；
+- `SubscriptionsReady -> GenerationReady` 当前由 `DaemonServer` 完成，必须增加带
+  generation/attempt 的取消和 stale completion 防护；
+- worker、transport connection、ready 使用了混淆的 generation；需要拆成三个字段；
+- outbox 只能保证本地 durable accepted 和 at-least-once replay，不能宣称 Broker delivered
+  或 exactly-once；
+- 统一 HTTP listener 不能天然保证 loopback，recovery endpoint 必须做 bind/peer 校验、
+  coalescing 和限流；
+- `/v1/info` 需要单一版本化快照和脱敏错误码；token refresh 的失败共享必须覆盖所有
+  Backend 调用方；
+- 故障注入必须覆盖 sleep gap 与 UI signal 的触发来源，以及 ACK、compact、restore race
+  等崩溃窗口。
+
+## 1. 背景与结论
+
+### 1.1 已经完成、必须保留的改造
+
+当前工作区已经包含以下未提交改动，后续实现必须在此基础上继续：
+
+- `apps/daemon/src/mqtt/supervisor.rs`
+  - generation 独立的 MQTT supervisor/worker；
+  - worker 独占 `MqttClient` 和 `EventLoop::poll()`；
+  - 独立 watchdog；
+  - transport recovery deadline 和受控 generation rebuild；
+  - stable publisher proxy；
+  - 连接代次、订阅恢复、GenerationReady 栅栏；
+  - durable inbox/outbox 接入。
+- `apps/daemon/src/mqtt/durable_queue.rs`
+  - append-only durable inbox/outbox；
+  - ACK、恢复、日志压缩和 torn tail 处理。
+- `apps/daemon/src/daemon/server.rs`
+  - daemon business owner 与 MQTT worker 解耦；
+  - MQTT inbound 交给 command executor；
+  - `/v1/info.mqtt_connected` 由当前 generation 的 readiness 更新。
+- `apps/daemon/src/daemon/server/command_executor.rs`
+  - MQTT worker 不再直接执行业务 handler；
+  - 业务 ACK 在 handler 完成后发出。
+- `apps/daemon/src/mqtt/client.rs`、`apps/daemon/src/mqtt/mod.rs`、
+  `crates/teamclu-transport/src/publisher.rs`
+  - 传输边界和稳定 publisher 接口调整。
+- 已提交的 P2 UI 修复
+  - daemon status 统一探测；
+  - startup/focus/visibility 时主动刷新 UI 状态；
+  - 防止“daemon 已恢复但横幅仍显示断联”。
+
+后续不能退回旧的 `DaemonServer` 内联 MQTT loop，也不能重新让业务对象持有某一代
+`AsyncClient`。durable queue 不能因为 recovery 被清空或迁移到 worker 内存中。
+
+### 1.2 日志确认的实际问题
+
+最近一次笔记本睡眠、VPN 断开、重新打开并恢复网络的日志表明：
+
+```text
+watchdog 发现 MQTT worker 长时间没有 progress
+  -> 请求 controlled generation rebuild
+  -> supervisor 停止旧 worker
+  -> 获取 cloud access token 失败
+  -> worker 一直无法创建
+  -> 本地 HTTP/RPC 仍然可用
+  -> 最终某次 token refresh 成功后 MQTT generation 才恢复
+```
+
+关键点：
+
+1. 90 秒/75 秒 watchdog 只负责发现 worker 失活并请求重建，不保证重建成功。
+2. 新 generation 创建前依赖 `backend.auth_token()`，而 token refresh 访问的是
+   `copilot.accounting.i.test.shopee.io/v1/auth/refresh`，该路径失败时 MQTT
+   worker 会保持 `None`。
+3. 笔记本睡眠时 daemon 不能持续执行 5 秒、10 秒、30 秒的定时器；macOS 的
+   DarkWake 只能间歇性运行进程。因此代码中的退避间隔不是睡眠状态下的墙上时间。
+4. `/v1/healthz`、`/v1/info` 和新建 session 的本地 RPC 走 loopback，不代表 MQTT
+   或 cloud API 已恢复。
+5. 日志中发送消息发生在 MQTT generation 已经 ready 之后。发送消息不是修复动作，
+   只是本地 HTTP/SSE 路径本来就可以独立工作，UI 状态随后才被刷新。
+
+### 1.3 本次要解决的问题
+
+在不重启 daemon、不依赖用户点击“重连”、不依赖发送一条消息的情况下：
+
+- 桌面端从睡眠恢复后，能主动通知 daemon 立即恢复 MQTT；
+- VPN/网络恢复后，daemon 能跳过当前 backoff 尽快重新尝试；
+- token refresh 失败不会把恢复流程卡在共享 mutex 或重复请求队列中；
+- UI 能区分本地 HTTP 可用、MQTT 恢复中、token 恢复中和 MQTT ready；
+- MQTT generation 重建期间，durable inbox/outbox、稳定 publisher 和旧 generation
+  fence 语义保持不变。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+1. 为 daemon 增加一个仅限本机 loopback 使用的幂等 recovery signal。
+2. 将桌面端的 wake/visibility/online/focus 事件接入 daemon recovery signal。
+3. supervisor 收到 signal 后能够：
+   - ready 状态下无动作或只做状态探测；
+   - worker 失活时立即停止旧 worker；
+   - worker 正在 backoff 或等待 credential 时立即唤醒下一次尝试；
+   - 必要时让 token cache 失效，但不无条件刷新造成 refresh storm。
+4. 将 token refresh 的 single-flight、超时、失败退避和显式唤醒语义补齐。
+5. 把 recovery phase 和最近一次失败信息提供给 `/v1/info`，供 UI 使用。
+6. 增加单测、daemon 集成测试、broker 故障注入测试、durable replay 测试和真实
+   macOS sleep/VPN 测试矩阵。
+7. 保证同一时刻最多一个活动 worker generation，禁止 rebuild storm。
+
+### 2.2 非目标
+
+- 不修改 broker、NanoMQ、EMQX、Caddy 或 mqtt-auth 部署配置。
+- 不重新实现 MQTT 协议，不替代 rumqttc 的正常 auto-reconnect。
+- 不承诺笔记本真正睡眠期间仍执行后台重连；只能保证唤醒后立即恢复。
+- 不把 `navigator.onLine` 当成 VPN 可用性的唯一依据。
+- 不把本地 HTTP session 通道改成依赖 MQTT。
+- 不清空 durable inbox/outbox 来“快速恢复”。
+- 不扩大为进程级 daemon 重启；恢复目标仍然是 MQTT worker generation。
+
+## 3. 目标架构
+
+```text
+macOS wake / visibility / focus / online
+              |
+              v
+Desktop: probe daemon -> POST /v1/mqtt/recover
+              |
+              v
+Daemon local HTTP route -> MqttRecoveryHandle
+              |
+              v
+MqttSupervisor control channel
+  - coalesce recovery signals
+  - cancel current backoff
+  - decide reuse token / refresh token
+  - fence and rebuild generation
+              |
+              v
+MqttWorker
+  - owns MqttClient/EventLoop
+  - restores subscriptions
+  - durable inbox/outbox remains supervisor-independent
+              |
+              v
+DaemonCommandExecutor
+  - executes business handler
+  - ACK durable inbox only after completion
+```
+
+### 3.1 增加 daemon recovery signal
+
+在已有 `MqttSupervisor` control channel 上增加一个恢复控制消息，建议形态：
+
+```rust
+enum MqttControl {
+    GenerationReady { generation: u64, reply: oneshot::Sender<bool> },
+    Rebuild { reason: String },
+    RecoverNow {
+        reason: MqttRecoveryReason,
+        reply: Option<oneshot::Sender<MqttRecoveryAccepted>>,
+    },
+}
+```
+
+客户端只提交 reason，不直接提交 `force_credential_refresh`。是否失效 token、是否
+绕过 transient cooldown 由 supervisor 根据当前 phase、broker 错误分类和 credential
+健康状态决定，避免一个带 admin token 的客户端把 refresh 变成可重复调用的放大器。
+
+`RecoverNow` 必须是幂等的：
+
+- 当前 generation 已 `GenerationReady` 且最近没有 sleep gap：返回 `AlreadyHealthy`；
+- 当前 worker 存在但 disconnected/stalled：只允许一个 rebuild 请求；
+- 当前 worker 为 `None`：将 `next_restart` 提前到 now，不新增 worker；
+- 当前已有 recovery：合并 reason，不能再启动第二个 worker；
+- 短时间内重复请求只增加计数和最近 reason，不重置 backoff 到 0 多次。
+
+建议定义以下 reason，日志和测试都使用稳定值：
+
+```text
+Startup
+VisibilityResume
+LongVisibilityResume
+NetworkOnline
+UserRequested
+Watchdog
+CredentialRejected
+```
+
+### 3.2 本机 HTTP 接口
+
+增加 daemon 本地接口：
+
+```text
+POST /v1/mqtt/recover
+```
+
+请求体：
+
+```json
+{
+  "reason": "long_visibility_resume",
+  "force_credential_refresh": false
+}
+```
+
+响应只表示 signal 已被 supervisor 接受，不等待 broker CONNACK：
+
+```json
+{
+  "accepted": true,
+  "phase": "recovering",
+  "generation": 8,
+  "request_id": "..."
+}
+```
+
+约束：
+
+- 当前 HTTP server 是统一 TCP listener，不能只在文档里宣称“loopback”。实现时必须
+  同时要求配置 bind 为 `127.0.0.1`/`::1`，并用 `ConnectInfo<SocketAddr>` 校验实际
+  peer；非 loopback listener 直接禁用此 route 或返回 403。若后续需要远程管理，应
+  另建经过独立鉴权的管理接口，不能复用本 endpoint；
+- 继续使用现有 root/session token 认证和 `admin` scope；loopback 只减少暴露面，不能
+  替代认证；
+- 不把这个接口暴露到 Cloud API；
+- handler 只向 supervisor 的 coalescing control handle 投递消息，不能直接持有或重建
+  `MqttClient`；
+- recovery handle 使用 `try_send` 或单独的 pending-slot：同一时刻只保留一个待处理
+  signal，满载立即返回 503/`recovery_signal_unavailable`，不能用 `send().await` 排队；
+- 对请求做独立 cooldown、reason 合并和审计计数；重复请求不能重复启动 worker 或
+  refresh；
+- route 单测验证 loopback peer、权限、重复请求、supervisor 已关闭和 malformed reason。
+
+`HttpState` 保存一个与当前 supervisor 生命周期绑定的 `MqttRecoveryHandle`。daemon
+重启 supervisor 时不能更换业务层 publisher，但可以更新 handle 内部的 control sender。
+若复用统一 listener，`http::server` 必须改为 `into_make_service_with_connect_info`，
+并在 recovery handler 中强制检查 peer；不能把这个检查留给调用方自觉遵守。
+
+### 3.3 前端 wake/网络恢复接入
+
+基于现有 `packages/app/src/stores/mqtt-reconnect.ts`、
+`daemon-mqtt-status.ts`、`daemon-probe-signal.ts` 和已完成的 P2 probe 改造继续：
+
+1. `visibilitychange -> visible`：
+   - 先读取 daemon `/v1/info`；
+   - 若距离 hidden 超过 `MQTT_SLEEP_WAKE_HIDDEN_MS`、document 被 discard，或 daemon
+     报告 MQTT 非 ready，则调用 `POST /v1/mqtt/recover`；
+   - 不因为普通 tab 切换无条件 rebuild。
+2. `window.online`：
+   - 作为快速提示，先 probe daemon，再发送 `NetworkOnline` recovery signal；
+   - 不能仅凭该事件把 UI 设为 green；
+   - VPN 可能不触发 `online`，所以 visibility/focus 和定期 daemon probe 仍保留。
+3. window focus：
+   - 保留 P2 的立即 probe；
+   - 只有 probe 得到非 ready 且有 cooldown 时才发送 recovery signal；
+   - 多个组件共享同一个 in-flight request。
+4. 手动“Reconnect”按钮：
+   - 改为调用同一个 daemon recovery 接口；
+   - 继续保留桌面端 MQTT client 的 app-side reconnect，但不能只重建 app-side client。
+
+前端 recovery 请求需要独立的 cooldown 和 in-flight coalescing：
+
+```text
+同一时刻最多一个请求
+自动请求最短间隔 10s
+用户明确点击可等待当前请求完成，但仍不能并发重建
+```
+
+## 4. Supervisor 恢复策略
+
+### 4.1 状态模型
+
+在现有 generation/heartbeat 状态上补充可观察 phase，不改变 stable publisher。必须
+拆开三个容易混淆的身份：
+
+- `worker_generation`：每次新建 worker 递增一次，worker 生命周期内不变；
+- `connection_attempt`：该 worker 每次开始一次 transport 连接/收到新的 CONNACK
+  递增一次；
+- `ready_generation`：最近一次完成完整恢复的 `worker_generation`，没有 ready 时为
+  `None`。
+
+所有事件、日志、HTTP 快照和测试都使用这三个明确字段，不能再用 worker 重建前的
+generation、transport generation 和 ready generation 混用一个数字。
+
+phase：
+
+```text
+Starting
+Connecting
+TransportConnected
+Restoring
+Ready
+Recovering
+AuthRecovering
+Backoff
+Stopped
+```
+
+对外 `mqtt_connected=true` 的条件仍然只能是 `Ready`，不是 ConnAck。
+
+`/v1/info` 增加一个整体发布的 MQTT snapshot，而不是分别读取多个 atomic：
+
+```rust
+struct MqttInfo {
+    connected: bool,
+    snapshot_version: u64,
+    phase: String,
+    worker_generation: Option<u64>,
+    connection_attempt: Option<u64>,
+    ready_generation: Option<u64>,
+    last_error_code: Option<String>,
+    last_error_at: Option<DateTime<Utc>>,
+    last_recovery_reason: Option<String>,
+    next_retry_at: Option<DateTime<Utc>>,
+    last_ready_at: Option<DateTime<Utc>>,
+}
+```
+
+snapshot 使用 `watch<Arc<MqttSnapshot>>`（或单一锁保护的不可变结构）整体替换，保证
+`connected/phase/worker_generation/ready_generation` 是同一版本的快照。`/v1/info` 是
+未鉴权接口，只暴露枚举化的 `last_error_code`（如 `dns_failure`、`cloud_timeout`、
+`broker_auth_rejected`），原始错误只进入脱敏日志或需要鉴权的诊断接口。敏感 token、
+完整 URL query、payload 和 refresh token 不能写入状态或日志。
+
+### 4.2 RecoverNow 的处理顺序
+
+1. 记录 `request_id`、reason、当前 phase、`worker_generation` 和
+   `connection_attempt`。
+2. 如果当前 generation 已 ready：
+   - 检查最近 wall-clock gap 和 token expiry；
+   - 无异常则只返回 `AlreadyHealthy`；
+   - 有长 gap/过期 token 则进入受控 recovery。
+3. 如果当前 worker 仍在 poll：
+   - 标记当前 generation 为 fenced/recovering；
+   - 停止接受发往旧 worker 的新 transport 请求；
+   - 等待 `WORKER_STOP_TIMEOUT`，超时才 abort；
+   - 保留 supervisor durable outbox。
+4. 如果 worker 已退出或为 `None`：
+   - 唤醒 credential/rebuild 尝试；
+   - 不再叠加一个新的 worker。
+5. token 获取成功后创建下一代 worker。当前实现中 `SubscriptionsReady` 之后仍由
+   `DaemonServer` 持有 `SessionManager` 并执行业务 state restore，因此本方案不把这
+   段责任错误地放进 worker。新增一个 generation-scoped `RestoreAttempt` 作为唯一
+   owner，携带 `worker_generation + connection_attempt + cancellation token`，按现有
+   顺序执行：
+
+```text
+ConnAck
+ -> subscriptions restored + SUBACK
+ -> daemon/team state restore
+ -> durable outbox replay
+ -> GenerationReady
+```
+
+6. `RestoreAttempt` 在每个副作用步骤前后检查 token 是否仍为当前代次。RecoverNow、
+   watchdog Rebuild、worker exit 或 shutdown 会取消旧 attempt；旧 attempt 的延迟
+   publish 和 `mark_generation_ready` 必须被 supervisor 以 worker/connection/attempt
+   三重身份拒绝。只有当前 attempt 的 `GenerationReady` 能清零 rebuild backoff 并
+   设置 `mqtt_connected=true`。
+
+### 4.3 睡眠 gap 处理
+
+不能只依赖 `Instant`。在 heartbeat/supervisor snapshot 中同时保留 wall-clock
+`last_observed_epoch_ms`：
+
+- 每次 supervisor/worker 取得调度机会时计算 wall-clock gap；
+- gap 超过 `MQTT_WAKE_GAP_THRESHOLD`（建议 2 分钟）时标记 `WakeGapDetected`；
+- 第一次恢复调度时立即执行一次 coalesced `RecoverNow`；
+- 恢复请求不依赖 MQTT worker 自己发送 event；
+- 正常睡眠期间不产生重建风暴，因为进程未运行；唤醒后只生成一个 recovery。
+
+桌面端主动调用 recovery 是主要路径，wall-clock gap 是 daemon 独立兜底路径。
+
+### 4.4 Backoff 与重建风暴
+
+继续使用此前已有的重建退避，不另起一套计时器：
+
+```text
+5s -> 10s -> 20s -> 30s cap
+```
+
+规则：
+
+- `RecoverNow` 只把下一次尝试提前到 now 一次；
+- token refresh 连续失败时仍遵循共享 backoff；
+- 多个 watchdog/recovery signal 合并；
+- `GenerationReady` 后清零失败计数；
+- 旧 worker 未 join 前禁止创建新 worker；
+- 日志区分 `recovery_signal_count`、`worker_generation` 和 `credential_attempt`，
+  不能用 poll error 次数代替连接尝试次数。
+
+## 5. Credential refresh 协同
+
+当前 `CloudApiBackend` 已有 token cache 和 `refresh_lock`，本次不删除它，但把
+refresh coordinator 放到 Backend 内部，覆盖 MQTT supervisor、NATS、启动流程和普通
+Cloud API 调用；不能只在 supervisor 外面再包一层 cooldown。补上以下行为：
+
+1. **single-flight 结果共享**：同一时间多个调用等待同一个 refresh future/result，
+   失败后不能每个 waiter 都再次提交同一个 refresh request。
+2. **明确超时**：
+   - refresh lock 等待有上限；
+   - DNS/connect/request/response 各有可诊断的超时；
+   - 超时后释放 single-flight 状态，允许后续 recovery 重试。
+3. **失败退避**：
+   - 网络/5xx/timeout 使用短退避；
+   - 400/401 明确标记 terminal auth，交给既有 re-onboard 路径；
+   - daemon 内部根据 `CredentialRejected` 等明确 reason 可绕过 transient failure
+     cooldown 一次，但外部请求不能直接传入 force 参数，且不能绕过 single-flight。
+4. **token 使用策略**：
+   - transport 抖动且 cached token 仍有有效余量时，优先复用 token；
+   - broker 明确 auth reject 或 token 已过期时才 invalidate；
+   - 不能因为每次 TCP 失败都刷新 token。
+5. **日志**：每次 credential attempt 记录开始、结束、耗时、分类、generation 和
+   next retry；不记录 token 内容。
+
+需要补充 `Backend` 能力时，优先添加语义明确的方法，例如：
+
+```rust
+async fn auth_token(&self) -> BackendResult<String>;
+fn invalidate_cached_credential(&self);
+fn cloud_auth_health(&self) -> Option<CloudAuthSnapshot>;
+```
+
+避免把通用 `Backend` 改成暴露 CloudApiBackend 内部 mutex。现有 `refresh_lock` 只能
+保证同一时刻一个请求，不能保证第一个失败后所有 waiter 共享同一个失败结果；需要
+增加可等待的 coordinator 状态（成功值、失败分类、失败时间、cooldown、terminal
+auth latch、invalidate 版本和 shutdown/cancel），使后续 waiter 在同一轮直接得到
+同一结果，而不是依次重新刷新。
+
+## 6. Durable inbox/outbox 不变量
+
+本次 recovery 必须复用现有 durable queue，不引入第二份队列：
+
+### 6.1 Outbox
+
+- `publish()` 成功只表示消息已被 daemon 持久化接受，不表示 Broker 已送达；
+- worker generation 失败不能删除未收到 broker ACK 的 outbox item；
+- generation rebuild 后按原 id 顺序 replay；
+- 同一个 outbox id 的本地 ACK 必须幂等；Broker ACK 与本地 ACK 的崩溃窗口必须可重放；
+- outbox item 不携带 generation 作为业务身份，但必须携带稳定的 `event_id`/`dedup_key`；
+- 重复 recovery 请求不能导致重复 replay task。
+
+当前 queue 中的 `ExactlyOnce` 枚举不能单独证明 exactly-once。本次对外只承诺按
+delivery guarantee 实现的 at-most-once 或 at-least-once；若未来要承诺 exactly-once，
+必须补齐 QoS2 状态机、进程重启恢复和消费端幂等协议。
+
+### 6.2 Inbox
+
+- worker 收到可靠 inbound 后先写 durable inbox；
+- durable write 成功后才允许 MQTT ACK；
+- durable inbox 记录必须保存协议层稳定的 `message_id`/`request_id`；相同的 MQTT
+  redelivery 通过 `(source, message_id)` 去重，不能只依赖本地递增 durable id；
+- command executor 根据明确的 `HandlerOutcome` 决定 disposition：成功才 ACK，
+  可重试失败保留 item 并按退避重放，永久失败/非法消息进入 dead-letter 后再 ACK；
+- executor 失败/daemon 被杀时 item 保留，下一代/下一次启动 replay；Retry 不能创建
+  新的 durable id；
+- handler 的副作用必须使用业务幂等键。没有端到端去重事务时，只承诺 at-least-once，
+  不承诺业务 exactly-once；
+- 慢 handler 不得阻塞 MQTT poll；
+- inbox 满时进入明确 backpressure，不静默丢可靠消息。
+
+### 6.3 崩溃窗口
+
+实现和测试必须把以下窗口作为显式状态，而不是靠“通常不会发生”处理：
+
+- inbox append 后、MQTT ACK 前退出：重连收到 redelivery 时用稳定 message id 去重；
+- MQTT ACK 后、业务 ACK 前退出：本地 inbox item replay，handler 必须幂等；
+- outbox append 后、发送前退出：启动后按 event id replay；
+- Broker ACK 后、本地 outbox ACK 落盘前退出：重复发送允许发生，消费端用 event id
+  去重；
+- inbox ACK append 后、compact/rename 前退出：旧日志或新日志都必须恢复为同一集合；
+- durable 文件最后一条 torn record 可丢弃，中间损坏必须拒绝启动并报警。
+
+## 7. 测试计划
+
+测试分为“无需真实网络的确定性测试”和“真实 broker/系统行为测试”。所有新增
+测试都要保留现有 supervisor、durable queue 和 rebuild-storm 测试。
+
+### 7.1 Rust 单元测试
+
+位置建议：`apps/daemon/src/mqtt/supervisor.rs`、
+`apps/daemon/src/mqtt/durable_queue.rs`、`apps/daemon/src/http/routes.rs`、
+`apps/daemon/src/backend/cloud_api/mod.rs`。
+
+必须覆盖：
+
+1. `RecoverNow` 在 `Ready`、`Recovering`、`Backoff`、`worker=None` 下的状态转换。
+2. 连续 20 次 recovery signal 只产生一个 active rebuild；与 watchdog/Rebuild 并发
+   时仍只有一个 rebuild。
+3. recovery signal 只提前下一次 retry，不把 backoff 无限重置为 0。
+4. `GenerationReady` 清零 backoff；旧 worker generation、旧 connection attempt 和
+   旧 restore attempt 的 ready 都被拒绝。
+5. wake gap 只触发一次 coalesced recovery；shutdown 与 RecoverNow 并发不泄漏 task。
+6. token refresh concurrent callers 共享成功结果，覆盖 supervisor、NATS 和普通
+   Cloud API 调用者。
+7. token refresh 失败时 concurrent callers 共享失败结果，不串行打几十次相同请求。
+8. refresh timeout 后 lock/single-flight 能释放，下一次 recovery 可以成功。
+9. 400/401 与 timeout/5xx 的 auth health 分类正确，terminal latch 能清除。
+10. `/v1/mqtt/recover` 的 loopback peer、认证、参数、独立限流、重复请求和
+    supervisor closed 行为；channel 满时立即 503。
+11. 单一 MQTT snapshot 的版本和 phase/generation 一致，不出现 `connected=true` 与
+    `Backoff` 混合快照；未鉴权 `/v1/info` 不泄露原始错误。
+12. durable outbox 在 generation rebuild 后保持顺序和未 ACK item；验证
+    `publish()` 返回的是 durable accepted，不是 broker delivered。
+13. durable inbox 在 executor 成功、可重试失败、永久失败/dead-letter、进程重启后
+    保持原 id 和 replay 顺序。
+14. 相同协议 `message_id` 的 MQTT redelivery 只执行业务一次；没有 message id 的旧
+    消息明确按 at-least-once 处理并记录诊断。
+15. inbox append/ MQTT ACK、outbox append/Outgoing Publish、Broker ACK/本地 ACK、
+    ACK append/compact rename 各崩溃窗口可恢复。
+16. torn final record 可恢复，中间损坏记录拒绝启动；QoS0/QoS1 的 ACK 和 backpressure
+    差异正确。
+
+### 7.2 Daemon integration tests
+
+使用现有 mock backend、mock HTTP server 和测试 MQTT broker，不能只验证函数返回值：
+
+1. **正常启动**：`Starting -> Connecting -> TransportConnected -> Restoring -> Ready`。
+2. **TCP/EOF 断联**：连接恢复在 recovery window 内完成，不 rebuild storm。
+3. **broker 重启**：broker 终止后恢复，订阅和 state 恢复完成后才报告 connected。
+4. **连续三轮 broker 故障**：每轮都能恢复，generation 单调递增，旧 event 被丢弃。
+5. **TLS/502/DNS 失败**：自动退避，网络恢复后无需进程重启。
+6. **认证拒绝**：只在明确 auth reason code 时 invalidate token；新 token 成功后恢复。
+7. **Cloud API token refresh 不可用**：worker 保持 `AuthRecovering/Backoff`，不创建
+   空 worker，不阻塞本地 HTTP；恢复接口到达后立即触发下一次尝试。
+8. **RecoveryNow 期间发送消息**：消息进入 durable outbox，恢复后 replay，不丢失；
+   验证 event id 在重复发送时保持不变。
+9. **Inbound 慢处理**：handler 人为延迟 30 秒，MQTT worker heartbeat/poll 仍持续，
+   inbox ACK 只在 handler 成功后出现；可重试失败按退避，不阻塞后续 poll。
+10. **进程中止恢复**：分别在 inbox/outbox 的 ACK 临界点杀掉 daemon，再启动并验证
+    replay、去重和顺序。
+11. **Generation restore race**：state restore 尚未完成时同时触发 RecoverNow，旧
+    attempt 被取消，不能发布旧 state 或报告错误 ready。
+12. **重建风暴上限**：持续 cloud auth failure 时按 `5s/10s/20s/30s`，不存在并发
+    generation 或每秒 rebuild。
+
+### 7.3 前端单元测试
+
+位置：`packages/app/src/stores/mqtt-reconnect.test.ts`、
+`packages/app/src/stores/daemon-mqtt-status.test.ts` 及新增 daemon recovery client
+测试。
+
+必须覆盖：
+
+1. 普通 focus 只 probe，不 rebuild healthy daemon。
+2. 长时间 hidden/discarded 后发送一次 `POST /v1/mqtt/recover`。
+3. `online` 和 visibility 同时到达时只发一个 recovery request。
+4. VPN 场景没有 `online` 事件时，focus/probe 仍能触发 recovery。
+5. recover 请求进行中重复事件被 coalesce。
+6. daemon 返回 `AuthRecovering` 时 UI 不显示绿色。
+7. daemon 变为 `Ready` 后 status banner 自动变绿，不依赖发送消息。
+8. 手动 reconnect 调用 daemon recovery，而不是只 bump app-side MQTT client。
+9. daemon HTTP 不可用时不把 app state 错误地标记为 MQTT ready。
+
+### 7.4 真实故障注入矩阵
+
+在本地 `pnpm tauri:dev:daemon` 环境保留手工验收记录，至少执行：
+
+| 场景 | 注入方式 | 预期 |
+|---|---|---|
+| broker 进程终止 | 停止 NanoMQ/测试 broker | 自动恢复，订阅恢复，最多一个新 generation |
+| broker 连续终止 3 轮 | kill/restart 3 次 | 每轮恢复，无风暴、无重启 daemon |
+| TCP 黑洞 | 防火墙/代理丢包 | watchdog 发现，受控 rebuild，退避上限生效 |
+| 502/TLS 错误 | 代理返回 502 或断 TLS | transport recovery 后可恢复 |
+| DNS 暂时失败 | 临时修改解析/代理 | 网络恢复后无需点击发送消息 |
+| cloud refresh 不可用 | 阻断 `/v1/auth/refresh` | UI 显示恢复中，outbox 保留，不创建大量 worker |
+| VPN 断开后恢复 | 先断 VPN，后重连 VPN | focus/wake 后主动 recover，绿色状态自动出现 |
+| 合上笔记本 | macOS sleep，保持 daemon 运行 | 打开后不发送消息也能恢复 |
+| 睡眠期间 VPN 断开 | sleep 前断内网，醒来后再连接 | token/cloud API 恢复后 MQTT 自动 ready |
+| UI 不操作 | 醒来后不点 banner、不建 session | 仍能在 bounded time 内恢复 |
+| durable replay | recovery/kill 时有 pending inbox/outbox | item 不丢、顺序和 ACK 正确 |
+
+“UI 不操作”必须拆成两组，避免被 focus、visibility 或 online 的隐式 signal 误导：
+
+1. **daemon-only**：测试 harness 禁止调用 `/v1/mqtt/recover`，并记录
+   `recovery_trigger=daemon_wake_gap` 或 `watchdog`；只验证 daemon 在重新获得调度
+   后自行发现 wall-clock gap 并恢复。
+2. **UI-assisted**：允许 `visibility`/`focus`/`online` signal，但必须记录具体
+   `recovery_trigger`，验证前端只发一个 coalesced request 且不依赖发送消息。
+
+两组都要记录 VPN 恢复、cloud token 成功、`TransportConnected`、
+`SubscriptionsReady`、`GenerationReady` 时间，才能区分“网络恢复了但没有触发恢复”和
+“恢复已触发但 credential/restore 失败”。确定性测试使用 fake clock 模拟长睡眠，真实
+macOS sleep 只作为补充验收。
+
+真实 macOS 验收需要记录：
+
+- daemon 日志；
+- 前端 MQTT diagnostic snapshot；
+- `/v1/info` 每次 phase；
+- `pmset -g log` 的 sleep/darkwake/wake 时间；
+- VPN 恢复时间；
+- `TransportConnected`、`SubscriptionsReady`、`GenerationReady` 时间。
+
+### 7.5 验收阈值
+
+在 daemon 已被唤醒且 cloud API/VPN 已真实可达的前提下：
+
+- UI-assisted 场景中，不操作发送消息，MQTT 在一次 coalesced recovery signal 后恢复
+  到 `Ready`；daemon-only 场景中不允许有 recovery endpoint 请求；
+- 从 recovery signal 到 `Ready` 的本地处理目标不超过 30 秒，网络/认证请求耗时
+  单独记录；
+- 不产生第二个并发 worker，且 `worker_generation`、`connection_attempt`、
+  `ready_generation` 的含义和日志一致；
+- durable inbox/outbox 可靠 item 不丢失；
+- UI 在 `Ready` 事件或 probe 后变绿，不依赖发送消息；
+- cloud API 不可达时必须显示/记录原因，不能伪装成“已连接”。
+
+## 8. 实施顺序
+
+### 第一步：先接 daemon recovery signal
+
+- 增加 `MqttControl::RecoverNow` 和 `MqttRecoveryHandle`；
+- 增加强制 loopback peer 校验的 `/v1/mqtt/recover`，使用 coalescing `try_send` 和
+  独立限流；
+- 增加单一版本化 MQTT snapshot；`/v1/info` 暴露 phase、明确命名的三种代次、错误码
+  和 next retry，不暴露原始错误；
+- 固定 `SubscriptionsReady -> GenerationReady` 的 `RestoreAttempt` owner、取消和
+  stale completion 校验；
+- 保留现有 supervisor、worker、publisher 和 durable queue 行为；
+- 补 route/supervisor 单测。
+
+### 第二步：补 token single-flight failure policy
+
+- 共享 refresh result；
+- lock/request timeout；
+- transient failure cooldown；
+- explicit recovery 一次性唤醒；
+- 统一覆盖 MQTT、NATS、启动流程和普通 Cloud API 调用方；
+- 补 cloud backend 单测。
+
+### 第三步：接前端 wake/focus/online
+
+- 扩展现有 `mqtt-reconnect`，不要新建第二套 reconnect store；
+- 所有事件通过 shared probe/recovery client；
+- 手动 reconnect 复用同一接口；
+- 补前端 coalescing 和状态测试。
+
+### 第四步：补 sleep gap daemon 兜底
+
+- heartbeat 增加 wall-clock observation；
+- 首次恢复调度检测 gap 并合并 recovery；
+- 验证与 watchdog 不重复触发。
+
+### 第五步：执行故障注入和 durable replay 验收
+
+- 先跑确定性单测/集成测试；
+- 再跑多轮 broker failure、cloud auth failure；
+- 最后跑 macOS sleep/VPN 手工矩阵；
+- 根据日志补齐 attempt duration、phase、recovery reason 和 trigger 来源；
+- 完成 message id/dedup、HandlerOutcome、dead-letter 以及崩溃窗口测试后，才允许把
+  durable replay 标记为完成。
+
+## 9. 回归保护与禁止事项
+
+- 不得恢复 `server.rs` 中直接调用 `eventloop.poll()` 的旧主循环。
+- 不得让 `DaemonCommandExecutor` 在 MQTT worker 中运行。
+- 不得在 recover endpoint 中直接构造 `MqttClient`。
+- 不得在未强制 loopback peer 校验时把 `/v1/mqtt/recover` 暴露在统一非 loopback
+  listener 上。
+- 不得用 UI 的本地 `/v1/auth/exchange` 成功推断 cloud token 或 MQTT 已恢复。
+- 不得把 `navigator.onLine` 作为 VPN 已恢复的证明。
+- 不得每次 focus 都强制刷新 token/重建 generation。
+- 不得在 token refresh 失败时启动多个并发 refresh。
+- 不得在 generation rebuild 时删除 durable inbox/outbox。
+- 不得把本地递增 durable id 当成 MQTT redelivery 去重键。
+- 不得把 `publish()` 的 durable accepted 语义写成 Broker delivered 或 exactly-once。
+- 不得让旧 `RestoreAttempt` 在新 generation 中继续发布状态或报告 ready。
+- 不得通过进程重启掩盖 worker/token recovery 的问题。
+
+## 10. 完成定义
+
+本方案完成的条件：
+
+1. 旧 MQTT 架构改造的已有测试全部通过。
+2. 新增 recovery endpoint、supervisor、credential、frontend、generation race 和 durable
+   replay 测试全部通过。
+3. 三轮 broker 连续故障无 rebuild storm。
+4. cloud token refresh 持续失败时没有并发 refresh 爆炸，恢复后能自动继续。
+5. daemon-only 和 UI-assisted 两组睡眠/VPN 测试都通过：前者不调用 recovery
+   endpoint，后者不点击、不发送消息也能自动进入 `Ready`。
+6. UI status 与 daemon `/v1/info` 一致，不再出现“消息能发但横幅持续假断联”或
+   “横幅变绿但 subscriptions/state 尚未恢复”。
+7. 日志能完整回答：何时发现断联、触发来源是什么、token 是否成功、哪个
+   `worker_generation/connection_attempt` ready、durable item 是否 replay，以及
+   是否发生了 redelivery/dedup。

--- a/packages/app/src/hooks/__tests__/use-local-daemon-http-status.test.ts
+++ b/packages/app/src/hooks/__tests__/use-local-daemon-http-status.test.ts
@@ -1,5 +1,30 @@
-import { describe, it, expect } from 'vitest'
-import { resolveLocalDaemonRuntimeStatus } from '../use-local-daemon-http-status'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest'
+import { resolveLocalDaemonRuntimeStatus, useLocalDaemonHttpStatus } from '../use-local-daemon-http-status'
+
+const mocks = vi.hoisted(() => ({
+  daemonReady: true,
+  probeDaemonHttp: vi.fn(),
+}))
+
+const originalDocumentHidden = Object.getOwnPropertyDescriptor(document, 'hidden')
+
+vi.mock('@/stores/daemon-onboarding', () => ({
+  useDaemonOnboardingStore: (selector: (state: { status: string }) => unknown) =>
+    selector({ status: mocks.daemonReady ? 'ready' : 'starting' }),
+}))
+
+vi.mock('@/stores/daemon-mqtt-status', () => ({
+  useDaemonMqttConnected: () => true,
+}))
+
+vi.mock('@/lib/daemon-local-client', () => ({
+  probeDaemonHttp: mocks.probeDaemonHttp,
+}))
+
+vi.mock('@/lib/agent-device-reachability', () => ({
+  noteLocalDaemonSignals: vi.fn(),
+}))
 
 describe('resolveLocalDaemonRuntimeStatus', () => {
   it('returns offline when onboarding is not ready', () => {
@@ -70,5 +95,58 @@ describe('resolveLocalDaemonRuntimeStatus', () => {
         daemonMqttConnected: null,
       }),
     ).toBe('checking')
+  })
+})
+
+describe('useLocalDaemonHttpStatus', () => {
+  beforeEach(() => {
+    mocks.daemonReady = true
+    mocks.probeDaemonHttp.mockReset().mockResolvedValue({ ok: true, baseUrl: 'http://127.0.0.1' })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (originalDocumentHidden) {
+      Object.defineProperty(document, 'hidden', originalDocumentHidden)
+    }
+  })
+
+  it('re-probes when the window regains focus', async () => {
+    const { unmount } = renderHook(() => useLocalDaemonHttpStatus())
+
+    await waitFor(() => expect(mocks.probeDaemonHttp).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    expect(mocks.probeDaemonHttp).toHaveBeenCalledTimes(2)
+    unmount()
+
+    window.dispatchEvent(new Event('focus'))
+    expect(mocks.probeDaemonHttp).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-probes when the document becomes visible, but ignores hidden events', async () => {
+    let hidden = true
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => hidden,
+    })
+
+    const { unmount } = renderHook(() => useLocalDaemonHttpStatus())
+    await waitFor(() => expect(mocks.probeDaemonHttp).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(mocks.probeDaemonHttp).toHaveBeenCalledTimes(1)
+
+    hidden = false
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(mocks.probeDaemonHttp).toHaveBeenCalledTimes(2)
+    unmount()
   })
 })

--- a/packages/app/src/hooks/use-local-daemon-http-status.ts
+++ b/packages/app/src/hooks/use-local-daemon-http-status.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { noteLocalDaemonSignals } from '@/lib/agent-device-reachability'
 import { probeDaemonHttp } from '@/lib/daemon-local-client'
-import { onDaemonProbeRequested } from '@/lib/daemon-probe-signal'
+import { onDaemonProbeRequested, requestDaemonProbe } from '@/lib/daemon-probe-signal'
 import { QUICK_CHAT_DAEMON_PROBE_INTERVAL_MS } from '@/lib/session-agent-probe'
 import { useDaemonOnboardingStore } from '@/stores/daemon-onboarding'
 import { useDaemonMqttConnected } from '@/stores/daemon-mqtt-status'
@@ -22,6 +22,8 @@ let probeSubscribers = 0
 let probeTimer: ReturnType<typeof setInterval> | null = null
 let unsubscribeProbeSignal: (() => void) | null = null
 let probeInFlight: Promise<void> | null = null
+let onWindowFocus: (() => void) | null = null
+let onVisibilityChange: (() => void) | null = null
 
 function setSharedStatus(next: LocalDaemonHttpStatus) {
   if (sharedStatus === next) return
@@ -45,6 +47,17 @@ function startSharedProbe() {
   void runSharedProbe()
   probeTimer = setInterval(() => void runSharedProbe(), QUICK_CHAT_DAEMON_PROBE_INTERVAL_MS)
   unsubscribeProbeSignal = onDaemonProbeRequested(() => void runSharedProbe())
+
+  // A backgrounded desktop window can pause its interval, leaving the warning
+  // stale after the daemon has already recovered. Re-probe as soon as the
+  // window is usable again; requestDaemonProbe also refreshes the shared MQTT
+  // status store, and runSharedProbe coalesces this with any in-flight poll.
+  onWindowFocus = () => requestDaemonProbe()
+  onVisibilityChange = () => {
+    if (!document.hidden) requestDaemonProbe()
+  }
+  window.addEventListener('focus', onWindowFocus)
+  document.addEventListener('visibilitychange', onVisibilityChange)
 }
 
 function stopSharedProbe() {
@@ -52,6 +65,10 @@ function stopSharedProbe() {
   probeTimer = null
   unsubscribeProbeSignal?.()
   unsubscribeProbeSignal = null
+  if (onWindowFocus) window.removeEventListener('focus', onWindowFocus)
+  if (onVisibilityChange) document.removeEventListener('visibilitychange', onVisibilityChange)
+  onWindowFocus = null
+  onVisibilityChange = null
   setSharedStatus('idle')
 }
 

--- a/packages/app/src/lib/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon-local-client.ts
@@ -310,6 +310,67 @@ async function daemonFetchData<T>(path: string, init?: RequestInit): Promise<T> 
   return result.data
 }
 
+export type DaemonMqttRecoveryReason =
+  | 'startup'
+  | 'visibility_resume'
+  | 'long_visibility_resume'
+  | 'network_online'
+  | 'user_requested'
+  | 'watchdog'
+  | 'credential_rejected'
+
+export interface DaemonMqttSnapshot {
+  connected: boolean
+  phase: string
+  worker_generation: number | null
+  connection_attempt: number | null
+  ready_generation: number | null
+  last_error_code: string | null
+  last_error_at: string | null
+  last_recovery_reason: string | null
+  next_retry_at: string | null
+  last_ready_at: string | null
+  snapshot_version: number
+}
+
+/** Read the daemon's coherent MQTT snapshot without relying on a stale event. */
+export async function getDaemonMqttSnapshot(): Promise<DaemonMqttSnapshot | null> {
+  try {
+    const body = await daemonFetchData<{
+      mqtt?: DaemonMqttSnapshot
+      mqtt_connected?: boolean
+    }>('/v1/info')
+    if (body.mqtt) return body.mqtt
+    return body.mqtt_connected == null
+      ? null
+      : {
+          connected: body.mqtt_connected,
+          phase: body.mqtt_connected ? 'Ready' : 'Recovering',
+          worker_generation: null,
+          connection_attempt: null,
+          ready_generation: null,
+          last_error_code: null,
+          last_error_at: null,
+          last_recovery_reason: null,
+          next_retry_at: null,
+          last_ready_at: null,
+          snapshot_version: 0,
+        }
+  } catch {
+    return null
+  }
+}
+
+/** Wake the daemon's MQTT supervisor; this returns before broker CONNACK. */
+export async function recoverDaemonMqtt(
+  reason: DaemonMqttRecoveryReason,
+): Promise<{ accepted: boolean; outcome: string }> {
+  return daemonFetchData('/v1/mqtt/recover', {
+    method: 'POST',
+    body: JSON.stringify({ reason }),
+  })
+}
+
 /**
  * Like {@link daemonFetch} but does not parse a JSON body. Used for protobuf
  * POSTs that return an empty 2xx (e.g. `202 Accepted`).

--- a/packages/app/src/stores/__tests__/daemon-mqtt-status.test.ts
+++ b/packages/app/src/stores/__tests__/daemon-mqtt-status.test.ts
@@ -46,6 +46,20 @@ describe('daemon-mqtt-status store', () => {
     release()
   })
 
+  it('keeps the initial false result as checking while MQTT finishes starting', async () => {
+    getDaemonMqttConnected.mockReset()
+    getDaemonMqttConnected.mockResolvedValueOnce(false).mockResolvedValue(true)
+
+    const release = subscribeDaemonMqttStatus()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(useDaemonMqttStatusStore.getState().connected).toBeNull()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(getDaemonMqttConnected).toHaveBeenCalledTimes(2)
+    expect(useDaemonMqttStatusStore.getState().connected).toBe(true)
+    release()
+  })
+
   it('runs a single shared poll no matter how many consumers subscribe', async () => {
     const a = subscribeDaemonMqttStatus()
     const b = subscribeDaemonMqttStatus()

--- a/packages/app/src/stores/daemon-mqtt-status.ts
+++ b/packages/app/src/stores/daemon-mqtt-status.ts
@@ -6,6 +6,9 @@ import { onDaemonProbeRequested } from '@/lib/daemon-probe-signal'
 import { getKnownLocalDaemonActorId } from '@/lib/local-daemon-identity'
 import { QUICK_CHAT_DAEMON_PROBE_INTERVAL_MS } from '@/lib/session-agent-probe'
 
+const DAEMON_MQTT_STARTUP_SETTLE_MS = 15_000
+const DAEMON_MQTT_STARTUP_RETRY_MS = 1_000
+
 type DaemonMqttStatusState = {
   /** Daemon's own MQTT link from `GET /v1/info`. `null` = unknown / daemon unreachable. */
   connected: boolean | null
@@ -26,21 +29,58 @@ export const useDaemonMqttStatusStore = create<DaemonMqttStatusState>((set) => (
   setConnected: (connected) => set({ connected }),
   refresh: async () => {
     const connected = await getDaemonMqttConnected()
-    set({ connected })
-    // Warm the short-TTL device-reachability cache on every tick, not just when
-    // the value flips — the runtime-start gate reads it synchronously and a
-    // change-only write would leave it permanently expired.
-    const actorId = getKnownLocalDaemonActorId()
-    if (actorId) noteLocalDaemonSignals({ actorId, daemonMqttConnected: connected })
+    publishMqttStatus(connected)
   },
 }))
 
 let subscriberCount = 0
 let pollTimer: ReturnType<typeof setInterval> | null = null
+let startupRetryTimer: ReturnType<typeof setTimeout> | null = null
+let startupSettling = false
+let startupDeadline = 0
+let pollingGeneration = 0
 let unsubscribeProbe: (() => void) | null = null
 
+function publishMqttStatus(connected: boolean | null): void {
+  useDaemonMqttStatusStore.getState().setConnected(connected)
+  // Warm the short-TTL device-reachability cache on every tick, not only when
+  // the value flips — the runtime-start gate reads it synchronously and a
+  // change-only write would leave it permanently expired.
+  const actorId = getKnownLocalDaemonActorId()
+  if (actorId) noteLocalDaemonSignals({ actorId, daemonMqttConnected: connected })
+}
+
+async function pollDuringStartup(generation: number): Promise<void> {
+  const connected = await getDaemonMqttConnected()
+  if (generation !== pollingGeneration) return
+  if (startupSettling && connected !== true && Date.now() < startupDeadline) {
+    // HTTP becomes ready before the daemon finishes its first MQTT CONNACK.
+    // Keep the UI in "checking" and retry quickly instead of showing a real
+    // disconnect that disappears as soon as the user clicks the banner.
+    if (!startupRetryTimer) {
+      startupRetryTimer = setTimeout(() => {
+        startupRetryTimer = null
+        void pollDuringStartup(generation)
+      }, DAEMON_MQTT_STARTUP_RETRY_MS)
+    }
+    return
+  }
+
+  startupSettling = false
+  publishMqttStatus(connected)
+}
+
 function startPolling() {
-  const poll = () => void useDaemonMqttStatusStore.getState().refresh()
+  const generation = ++pollingGeneration
+  startupSettling = true
+  startupDeadline = Date.now() + DAEMON_MQTT_STARTUP_SETTLE_MS
+  const poll = () => {
+    if (startupSettling) {
+      void pollDuringStartup(generation)
+    } else {
+      void useDaemonMqttStatusStore.getState().refresh()
+    }
+  }
   poll()
   pollTimer = setInterval(poll, QUICK_CHAT_DAEMON_PROBE_INTERVAL_MS)
   // Retry / network-online should not have to wait out the poll interval.
@@ -48,8 +88,13 @@ function startPolling() {
 }
 
 function stopPolling() {
+  pollingGeneration += 1
   if (pollTimer) clearInterval(pollTimer)
   pollTimer = null
+  if (startupRetryTimer) clearTimeout(startupRetryTimer)
+  startupRetryTimer = null
+  startupSettling = false
+  startupDeadline = 0
   unsubscribeProbe?.()
   unsubscribeProbe = null
   useDaemonMqttStatusStore.setState({ connected: null })
@@ -86,10 +131,6 @@ export function useDaemonMqttConnected(enabled = true): boolean | null {
 
 /** @internal test helper */
 export function __resetDaemonMqttStatusForTests(): void {
-  if (pollTimer) clearInterval(pollTimer)
-  pollTimer = null
-  unsubscribeProbe?.()
-  unsubscribeProbe = null
+  stopPolling()
   subscriberCount = 0
-  useDaemonMqttStatusStore.setState({ connected: null })
 }

--- a/packages/app/src/stores/mqtt-reconnect.test.ts
+++ b/packages/app/src/stores/mqtt-reconnect.test.ts
@@ -9,6 +9,7 @@ import {
   __resetMqttReconnectForTests,
   __markAuthRecoveryForTests,
   BROWSER_RECONNECT_GRACE_MS,
+  daemonMqttNeedsRecovery,
 } from './mqtt-reconnect'
 
 vi.mock('@/lib/auth/session-store', () => ({
@@ -152,6 +153,26 @@ describe('shouldAutoRecoverMqttAfterVisibility', () => {
         hiddenMs: MQTT_SLEEP_WAKE_HIDDEN_MS - 1,
       }),
     ).toBe(false)
+  })
+})
+
+describe('daemonMqttNeedsRecovery', () => {
+  it('trusts a coherent daemon Ready snapshot over a stale app-side false', () => {
+    expect(daemonMqttNeedsRecovery({ connected: true, phase: 'Ready' }, false)).toBe(false)
+  })
+
+  it('requests recovery for a non-ready daemon snapshot', () => {
+    expect(daemonMqttNeedsRecovery({ connected: false, phase: 'Recovering' }, true)).toBe(true)
+    expect(daemonMqttNeedsRecovery({ connected: false, phase: 'Backoff' }, null)).toBe(true)
+  })
+
+  it('does not recover a deliberately stopped daemon', () => {
+    expect(daemonMqttNeedsRecovery({ connected: false, phase: 'Stopped' }, false)).toBe(false)
+  })
+
+  it('falls back to the app-side status when the daemon snapshot is unavailable', () => {
+    expect(daemonMqttNeedsRecovery(null, true)).toBe(false)
+    expect(daemonMqttNeedsRecovery(null, false)).toBe(true)
   })
 })
 

--- a/packages/app/src/stores/mqtt-reconnect.ts
+++ b/packages/app/src/stores/mqtt-reconnect.ts
@@ -82,21 +82,46 @@ let recoveryGeneration = 0
 
 type RecoverMode = 'auto' | 'user'
 
-async function runMqttRecovery(get: () => MqttReconnectState, generation: number): Promise<void> {
+type RecoveryReason =
+  | 'startup'
+  | 'visibility_resume'
+  | 'long_visibility_resume'
+  | 'network_online'
+  | 'user_requested'
+  | 'credential_rejected'
+
+async function runMqttRecovery(
+  get: () => MqttReconnectState,
+  generation: number,
+  reason: RecoveryReason,
+): Promise<void> {
   if (generation !== recoveryGeneration) return
-  try {
-    const { refreshSession } = await import('@/lib/auth/session-store')
-    await refreshSession()
-  } catch {
-    // Offline or refresh token dead — bump still retries with the best token we have.
+  const utils = await import('@/lib/utils')
+  const tasks: Promise<unknown>[] = []
+  if (utils.isTauri()) {
+    tasks.push(
+      import('@/lib/daemon-local-client')
+        .then(({ recoverDaemonMqtt }) => recoverDaemonMqtt(reason))
+        .catch(() => undefined),
+    )
   }
+  tasks.push(
+    import('@/lib/auth/session-store')
+      .then(({ refreshSession }) => refreshSession())
+      .catch(() => undefined),
+  )
+  await Promise.all(tasks)
   if (generation !== recoveryGeneration) return
   get().bump()
+  void import('@/lib/daemon-probe-signal')
+    .then((m) => m.requestDaemonProbe())
+    .catch(() => {})
 }
 
 async function recoverMqttCredentials(
   get: () => MqttReconnectState,
   mode: RecoverMode = 'auto',
+  reason: RecoveryReason = mode === 'user' ? 'user_requested' : 'visibility_resume',
 ): Promise<void> {
   if (authRecoveryInFlight) {
     if (mode === 'user') {
@@ -111,7 +136,7 @@ async function recoverMqttCredentials(
 
   lastAuthRecoveryMs = now
   const generation = recoveryGeneration
-  authRecoveryInFlight = runMqttRecovery(get, generation).finally(() => {
+  authRecoveryInFlight = runMqttRecovery(get, generation, reason).finally(() => {
     authRecoveryInFlight = null
   })
   return authRecoveryInFlight
@@ -158,7 +183,7 @@ export const useMqttReconnectStore = create<MqttReconnectState>((set, get) => ({
       // (auto mode) is cooldown-throttled so a flapping link can't spam it.
       if (typeof window !== 'undefined') {
         window.addEventListener('online', () => {
-          void recoverMqttCredentials(get)
+          void recoverMqttCredentials(get, 'auto', 'network_online')
           void import('@/lib/daemon-probe-signal')
             .then((m) => m.requestDaemonProbe())
             .catch(() => {})
@@ -190,7 +215,7 @@ export const useMqttReconnectStore = create<MqttReconnectState>((set, get) => ({
             disconnectedEscalation = setTimeout(() => {
               disconnectedEscalation = null
               if (get().connected !== true) {
-                void recoverMqttCredentials(get)
+                void recoverMqttCredentials(get, 'auto', 'visibility_resume')
               }
             }, BROWSER_RECONNECT_GRACE_MS)
           }
@@ -199,7 +224,7 @@ export const useMqttReconnectStore = create<MqttReconnectState>((set, get) => ({
           setError(message)
           logMqttNetworkDiag('error', { message, transport: 'browser' })
           if (isMqttAuthFailure(message)) {
-            void recoverMqttCredentials(get)
+            void recoverMqttCredentials(get, 'auto', 'credential_rejected')
           }
         })
         return
@@ -218,6 +243,9 @@ export const useMqttReconnectStore = create<MqttReconnectState>((set, get) => ({
         }
       }
       await probe()
+      if (get().connected !== true) {
+        void recoverMqttCredentials(get, 'auto', 'startup')
+      }
       try {
         const { listen } = await import('@tauri-apps/api/event')
         await listen<boolean>('mqtt:connected', (e) => {
@@ -231,7 +259,7 @@ export const useMqttReconnectStore = create<MqttReconnectState>((set, get) => ({
           setError(msg)
           logMqttNetworkDiag('error', { message: msg, transport: 'tauri' })
           if (isMqttAuthFailure(msg)) {
-            void recoverMqttCredentials(get)
+            void recoverMqttCredentials(get, 'auto', 'credential_rejected')
           }
         })
         // Reconcile any change that landed while the listener was attaching.
@@ -262,9 +290,23 @@ export const useMqttReconnectStore = create<MqttReconnectState>((set, get) => ({
             hiddenAtMs = null
 
             if (shouldAutoRecoverMqttAfterVisibility({ wasDiscarded, hiddenMs })) {
-              await recoverMqttCredentials(get)
+              await recoverMqttCredentials(
+                get,
+                'auto',
+                hiddenMs >= MQTT_SLEEP_WAKE_HIDDEN_MS || wasDiscarded
+                  ? 'long_visibility_resume'
+                  : 'visibility_resume',
+              )
             } else {
               get().bump()
+            }
+          })()
+        })
+        window.addEventListener('focus', () => {
+          void (async () => {
+            await probe()
+            if (get().connected !== true) {
+              await recoverMqttCredentials(get, 'auto', 'visibility_resume')
             }
           })()
         })

--- a/packages/app/src/stores/mqtt-reconnect.ts
+++ b/packages/app/src/stores/mqtt-reconnect.ts
@@ -43,6 +43,14 @@ interface MqttReconnectState {
 /** Hidden longer than this before visibility resume counts as sleep/wake. */
 export const MQTT_SLEEP_WAKE_HIDDEN_MS = 60_000
 
+export function daemonMqttNeedsRecovery(
+  snapshot: { connected: boolean; phase: string } | null,
+  fallbackConnected: boolean | null,
+): boolean {
+  if (snapshot) return !snapshot.connected && snapshot.phase !== 'Stopped'
+  return fallbackConnected !== true
+}
+
 /** True when the broker rejected MQTT credentials (expired JWT after sleep, etc.). */
 export function isMqttAuthFailure(message: string): boolean {
   const m = message.toLowerCase()
@@ -97,6 +105,17 @@ async function runMqttRecovery(
 ): Promise<void> {
   if (generation !== recoveryGeneration) return
   const utils = await import('@/lib/utils')
+  if (utils.isTauri() && reason !== 'user_requested' && reason !== 'credential_rejected') {
+    const { getDaemonMqttSnapshot } = await import('@/lib/daemon-local-client')
+    const snapshot = await getDaemonMqttSnapshot()
+    if (snapshot?.connected) {
+      get().setConnected(true)
+      void import('@/lib/daemon-probe-signal')
+        .then((m) => m.requestDaemonProbe())
+        .catch(() => {})
+      return
+    }
+  }
   const tasks: Promise<unknown>[] = []
   if (utils.isTauri()) {
     tasks.push(
@@ -232,18 +251,27 @@ export const useMqttReconnectStore = create<MqttReconnectState>((set, get) => ({
       const bridge = await import('@/lib/mqtt-bridge').catch(() => null)
       if (!bridge) return
       const { mqttStatus } = bridge
+      const { getDaemonMqttSnapshot } = await import('@/lib/daemon-local-client').catch(() => ({
+        getDaemonMqttSnapshot: async () => null,
+      }))
       const setConnected = get().setConnected
       const setError = get().setError
       const probe = async () => {
+        const daemonSnapshot = await getDaemonMqttSnapshot()
+        if (daemonSnapshot) {
+          setConnected(daemonSnapshot.connected)
+          return daemonSnapshot
+        }
         try {
           const status = await mqttStatus()
           setConnected(status.connected)
         } catch {
           setConnected(false)
         }
+        return null
       }
-      await probe()
-      if (get().connected !== true) {
+      const initialSnapshot = await probe()
+      if (daemonMqttNeedsRecovery(initialSnapshot, get().connected)) {
         void recoverMqttCredentials(get, 'auto', 'startup')
       }
       try {
@@ -280,8 +308,8 @@ export const useMqttReconnectStore = create<MqttReconnectState>((set, get) => ({
           }
           if (document.visibilityState !== 'visible') return
           void (async () => {
-            await probe()
-            if (get().connected === true) return
+            const snapshot = await probe()
+            if (!daemonMqttNeedsRecovery(snapshot, get().connected)) return
 
             const wasDiscarded =
               'wasDiscarded' in document &&
@@ -304,8 +332,8 @@ export const useMqttReconnectStore = create<MqttReconnectState>((set, get) => ({
         })
         window.addEventListener('focus', () => {
           void (async () => {
-            await probe()
-            if (get().connected !== true) {
+            const snapshot = await probe()
+            if (daemonMqttNeedsRecovery(snapshot, get().connected)) {
               await recoverMqttCredentials(get, 'auto', 'visibility_resume')
             }
           })()


### PR DESCRIPTION
## Summary
- make daemon MQTT recovery generation-based and wake/network aware
- persist reliable inbox/outbox messages across worker rebuilds with deduplication and fences
- refresh desktop daemon status on startup/focus/visibility changes
- bound dead-letter retention and make durable log recovery streaming

## Verification
- `cargo test --manifest-path apps/daemon/Cargo.toml --bin amuxd mqtt:: -- --nocapture`
- `cargo test --manifest-path apps/daemon/Cargo.toml --test teamclu_mqtt_rearchitecture -- --nocapture`
- touched Rust files pass `rustfmt --check`; `git diff --check`

## Review
- final merge review requested from subagent; QoS0 stream semantics remain intentional and documented: deltas are transient, final replies are durable.