### PR TITLE
feat(release): consolidate TeamClu beta delivery

### DIFF
--- a/.github/actions/brand-setup/action.yml
+++ b/.github/actions/brand-setup/action.yml
@@ -6,7 +6,7 @@ description: >
 
 inputs:
   brand:
-    description: "Brand id — a directory under brands/ in the branding repo (e.g. betly, copilot361)"
+    description: "Release channel id — built-in teamclu, or a directory under brands/ (e.g. copilot361)"
     required: true
   branding-repo:
     description: "owner/repo of the private enterprise-branding repo"
@@ -26,6 +26,10 @@ inputs:
     description: "Fallback public CDN base when the brand does not declare one"
     required: false
     default: ""
+  cdn-refresh-region-default:
+    description: "Fallback Alibaba CDN region for mutable release files"
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -39,8 +43,60 @@ runs:
         OSS_BUCKET_DEFAULT: ${{ inputs.oss-bucket-default }}
         OSS_ENDPOINT_DEFAULT: ${{ inputs.oss-endpoint-default }}
         CDN_BASE_DEFAULT: ${{ inputs.cdn-base-default }}
+        CDN_REFRESH_REGION_DEFAULT: ${{ inputs.cdn-refresh-region-default }}
       run: |
         set -euo pipefail
+
+        # TeamClu Beta is the first-party OSS channel, not an OEM brand. Keep
+        # its release definition in this repository so it cannot be silently
+        # renamed or repointed by the retired Betly configuration.
+        if [ "$BRAND" = "teamclu" ]; then
+          test -n "$OSS_BUCKET_DEFAULT" || { echo '::error::OSS bucket is not configured'; exit 1; }
+          test -n "$OSS_ENDPOINT_DEFAULT" || { echo '::error::OSS endpoint is not configured'; exit 1; }
+          test -n "$CDN_BASE_DEFAULT" || { echo '::error::OSS CDN base is not configured'; exit 1; }
+          cp build.config.production.json build.config.json
+          BRAND="$BRAND" python3 - <<'PY'
+        import json, os
+
+        with open('build.config.json', encoding='utf-8') as f:
+            cfg = json.load(f)
+        app = cfg.setdefault('app', {})
+        # The Beta page and window make the product migration explicit; the
+        # product name remains TeamClu so bundle paths stay compatible.
+        app['displayName'] = 'TeamClu 群策'
+        app['shortName'] = 'teamclu'
+        with open('build.config.json', 'w', encoding='utf-8') as f:
+            json.dump(cfg, f, ensure_ascii=False, indent=2)
+            f.write('\n')
+
+        out = {
+            'BRAND': 'teamclu',
+            'CHROME_EXTENSION_ID': '',
+            'APP_NAME': app['displayName'],
+            'APP_PRODUCT_NAME': app.get('name') or 'TeamClu',
+            'APP_SLUG': 'teamclu',
+            'OSS_BUCKET': os.environ['OSS_BUCKET_DEFAULT'],
+            'OSS_ENDPOINT': os.environ['OSS_ENDPOINT_DEFAULT'],
+            # Preserve the former TeamClaw beta URL while its domain remains
+            # the compatibility distribution hostname.
+            'OSS_PREFIX': 'beta',
+            'CDN_BASE': os.environ['CDN_BASE_DEFAULT'].rstrip('/'),
+            'CDN_REFRESH_REGION': os.environ.get('CDN_REFRESH_REGION_DEFAULT', ''),
+            'BRAND_MAC_EXTRA_ARGS': '',
+        }
+        with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as f:
+            for key, value in out.items():
+                f.write(f'{key}={value}\n')
+        with open('brand-page.json', 'w', encoding='utf-8') as f:
+            json.dump({
+                'lang': 'zh-CN',
+                'badge': '每日 Beta',
+                'noindex': False,
+                'footerNote': 'TeamClu 群策 Beta，每日构建，欢迎反馈。',
+            }, f, ensure_ascii=False)
+        PY
+          exit 0
+        fi
 
         # Unlike release.yml — which treats a missing branding repo as "build the
         # default TeamClu" — every brand this pipeline publishes is defined in
@@ -156,7 +212,7 @@ runs:
             'CDN_BASE': cdn_base.rstrip('/'),
             # Empty => bucket is served straight from the OSS endpoint with no CDN
             # in front, so there is no edge cache to purge.
-            'CDN_REFRESH_REGION': oss.get('cdnRefreshRegion') or '',
+            'CDN_REFRESH_REGION': oss.get('cdnRefreshRegion') or os.environ.get('CDN_REFRESH_REGION_DEFAULT', ''),
             'BRAND_MAC_EXTRA_ARGS': (meta.get('build') or {}).get('macExtraArgs') or '',
         }
         with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as f:

--- a/.github/workflows/mirror-opencode-oss.yml
+++ b/.github/workflows/mirror-opencode-oss.yml
@@ -62,7 +62,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          SERVED=$(curl -fsSL "https://teamclu.ucar.cc/opencode/latest.json" 2>/dev/null \
+          SERVED=$(curl -fsSL "https://teamclaw.ucar.cc/opencode/latest.json" 2>/dev/null \
             | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version",""))' 2>/dev/null || echo "")
           if [ "$SERVED" = "$VERSION" ]; then
             echo "mirror already serves $VERSION — nothing to do"
@@ -168,7 +168,7 @@ jobs:
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
           set -euo pipefail
-          BASE="https://teamclu.ucar.cc/opencode"
+          BASE="https://teamclaw.ucar.cc/opencode"
           # Fails the run if the CDN serves a manifest that disagrees with what
           # we just published — i.e. if the no-cache header is not being honored.
           SERVED=$(curl -fsSL "$BASE/latest.json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')

--- a/.github/workflows/mirror-pi-oss.yml
+++ b/.github/workflows/mirror-pi-oss.yml
@@ -1,0 +1,137 @@
+name: Mirror Pi to OSS
+
+# Pi is published only as an npm package. We create a versioned tarball with
+# Pi's full production dependency closure bundled inside it, then publish that
+# immutable artifact to OSS. This lets mainland clients install Pi without an
+# npm-registry round trip when the official route is unavailable.
+on:
+  workflow_call: {}
+  push:
+    paths:
+      - apps/daemon/pi.lock.json
+  schedule:
+    - cron: "20 18 * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: mirror-pi-oss
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    env:
+      PI_PACKAGE: '@earendil-works/pi-coding-agent'
+      OSS_BASE: https://teamclaw.ucar.cc/pi
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Resolve the required official Pi version
+        id: pi
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./apps/daemon/pi.lock.json').version.replace(/^v/, '')")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Mirroring official $PI_PACKAGE@$VERSION"
+
+      - name: Skip when OSS already has this version
+        id: skip
+        env:
+          VERSION: ${{ steps.pi.outputs.version }}
+        run: |
+          set -euo pipefail
+          SERVED=$(curl -fsSL "$OSS_BASE/latest.json" 2>/dev/null | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" 2>/dev/null || true)
+          if [ "$SERVED" = "$VERSION" ]; then
+            echo "Pi OSS mirror already serves $VERSION"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build a dependency-bundled package from the official registry
+        if: steps.skip.outputs.skip != 'true'
+        env:
+          VERSION: ${{ steps.pi.outputs.version }}
+        run: |
+          set -euo pipefail
+          WORK=$(mktemp -d)
+          mkdir -p assets "$WORK/package"
+          npm pack "$PI_PACKAGE@$VERSION" --pack-destination "$WORK"
+          tar -xzf "$WORK"/*.tgz -C "$WORK/package"
+          cd "$WORK/package/package"
+          # Install exactly the official package's production closure, then make
+          # npm include it in the new tarball. Optional native dependencies stay
+          # optional: npm may omit an unsupported platform binary, as upstream
+          # itself does during a normal install.
+          npm install --omit=dev --no-audit --no-fund
+          node <<'NODE'
+          const fs = require('fs')
+          const pkg = require('./package.json')
+          pkg.bundledDependencies = [...new Set([
+            ...Object.keys(pkg.dependencies || {}),
+            ...Object.keys(pkg.optionalDependencies || {}),
+          ])].sort()
+          fs.writeFileSync('package.json', `${JSON.stringify(pkg, null, 2)}\n`)
+          NODE
+          npm pack --pack-destination "$GITHUB_WORKSPACE/assets"
+          ls -lh "$GITHUB_WORKSPACE/assets"
+
+      - name: Upload immutable artifact and fresh manifest
+        if: steps.skip.outputs.skip != 'true'
+        env:
+          OSS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+          OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT }}
+          OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
+          VERSION: ${{ steps.pi.outputs.version }}
+        run: |
+          set -euo pipefail
+          test -n "${OSS_ACCESS_KEY_ID:-}" || { echo '::error::OSS secrets not configured'; exit 1; }
+          python3 -m pip install oss2 --quiet --break-system-packages 2>/dev/null || pip3 install oss2 --quiet --break-system-packages
+          python3 - <<'PY'
+          import glob, hashlib, json, os
+          import oss2
+
+          files = glob.glob('assets/*.tgz')
+          if len(files) != 1:
+              raise SystemExit(f'expected one bundled Pi tarball, got: {files}')
+          path = files[0]
+          asset = os.path.basename(path)
+          with open(path, 'rb') as fh:
+              sha256 = hashlib.sha256(fh.read()).hexdigest()
+          endpoint = os.environ['OSS_ENDPOINT']
+          if not endpoint.startswith('http'):
+              endpoint = 'https://' + endpoint
+          auth = oss2.Auth(os.environ['OSS_ACCESS_KEY_ID'], os.environ['OSS_ACCESS_KEY_SECRET'])
+          bucket = oss2.Bucket(auth, endpoint, os.environ['OSS_BUCKET'])
+          version = os.environ['VERSION']
+          key = f'pi/{version}/{asset}'
+          bucket.put_object_from_file(key, path, headers={'Cache-Control': 'public, max-age=31536000, immutable'})
+          manifest = json.dumps({'version': version, 'asset': asset, 'sha256': sha256}, indent=2).encode()
+          bucket.put_object('pi/latest.json', manifest, headers={
+              'Cache-Control': 'no-cache, no-store, max-age=0',
+              'Content-Type': 'application/json',
+          })
+          print(f'published {key} ({sha256})')
+          PY
+
+      - name: Verify public manifest and artifact
+        if: steps.skip.outputs.skip != 'true'
+        env:
+          VERSION: ${{ steps.pi.outputs.version }}
+        run: |
+          set -euo pipefail
+          MANIFEST=$(curl -fsSL "$OSS_BASE/latest.json")
+          echo "$MANIFEST" | node -e '
+            let s=""; process.stdin.on("data", x => s += x).on("end", () => {
+              const m = JSON.parse(s)
+              if (m.version !== process.env.VERSION || !m.asset || !/^[a-f0-9]{64}$/.test(m.sha256)) process.exit(1)
+              console.log(m.version + ' ' + m.asset)
+            })'
+          ASSET=$(echo "$MANIFEST" | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).asset")
+          curl -fsI "$OSS_BASE/$VERSION/$ASSET" >/dev/null

--- a/.github/workflows/nightly-release-oss.yml
+++ b/.github/workflows/nightly-release-oss.yml
@@ -1,18 +1,18 @@
-name: Nightly OSS Release (multi-brand)
+name: Nightly TeamClu Beta / Copilot361 Release
 
 # Nightly beta release for the OSS brands. Every night this:
 #   1. Bumps the desktop beta version by one (0.2.28-beta.1 -> 0.2.28-beta.2;
 #      or, from a stable X.Y.Z, starts X.Y.(Z+1)-beta.1) and commits that bump
 #      to `main`. The commit — NOT a git tag — is what advances the beta number,
 #      so `release.yml` (which triggers on `push: tags: v*`) is never fired.
-#   2. Dispatches release-oss.yml once per brand (copilot361 + betly) with the
+#   2. Dispatches release-oss.yml for TeamClu Beta and independent Copilot361 with the
 #      new `v<version>` tag input. That workflow re-syncs the four version
 #      sources on its runner, verifies the bump, and publishes each brand to its
 #      own OSS prefix — clients force-upgrade because the bundled amuxd version
 #      strictly increased.
 #
-# release-oss.yml stays one-brand-per-run by design (per-brand concurrency
-# groups guard each brand's latest.json), so we dispatch it twice rather than
+# release-oss.yml stays one-channel-per-run by design (per-channel concurrency
+# groups guard each channel's latest.json), so we dispatch it twice rather than
 # adding a brand matrix there.
 #
 # NOTE ON TOKENS: pushing the bump to `main` and dispatching another workflow
@@ -80,13 +80,13 @@ jobs:
           git commit -am "chore(release): nightly beta v${{ steps.ver.outputs.next }}"
           git push origin HEAD:main
 
-      - name: Dispatch release-oss.yml for each brand
+      - name: Dispatch TeamClu Beta and Copilot361 releases
         env:
           GH_TOKEN: ${{ secrets.NIGHTLY_DISPATCH_PAT || secrets.GITHUB_TOKEN }}
           TAG: v${{ steps.ver.outputs.next }}
         run: |
           set -euo pipefail
-          for brand in copilot361 betly; do
+          for brand in teamclu copilot361; do
             echo "Dispatching release-oss for $brand @ $TAG"
             gh workflow run release-oss.yml --ref main -f brand="$brand" -f tag="$TAG"
           done

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -54,7 +54,7 @@ jobs:
           # publishes to OSS, but brand-setup validates these fields.
           oss-bucket-default: ${{ secrets.OSS_BUCKET }}
           oss-endpoint-default: ${{ secrets.OSS_ENDPOINT }}
-          cdn-base-default: ${{ vars.OSS_CDN_BASE || 'https://teamclu.ucar.cc' }}
+          cdn-base-default: ${{ vars.OSS_CDN_BASE || 'https://teamclaw.ucar.cc' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -1,11 +1,14 @@
-name: Release (OSS, multi-brand)
+name: Release TeamClu Beta / Copilot361 (OSS)
 
-# Multi-brand OSS release channel. Replaces the old release-beta.yml, which was
-# hardwired to a single unbranded TeamClu build published under `beta/`.
+# OSS release channel for two independent products:
 #
-# Every brand — including `betly`, the live-beta channel that used to BE this
-# workflow's only mode — is defined by a directory in the private
-# enterprise-branding repo (see vars.BRANDING_REPO):
+# - `teamclu`: the first-party daily Beta, built from this repository and
+#   published under `/beta/` for the existing TeamClaw URL to remain valid.
+# - `copilot361`: an independent OEM build, resolved from the private branding
+#   repository (see vars.BRANDING_REPO).
+#
+# Betly is intentionally absent: its former TeamClaw channel is now TeamClu
+# Beta, with TeamClu identity and release page copy.
 #
 #   brands/<brand>/build.config.json  complete build config (backend + identity)
 #   brands/<brand>/brand.json         distribution knobs (OSS bucket/prefix/CDN,
@@ -27,18 +30,18 @@ on:
         required: true
         type: choice
         options:
-          - betly
+          - teamclu
           - copilot361
-        default: betly
+        default: teamclu
       tag:
         description: "Version tag to publish (e.g. v0.2.8-beta.1)"
         required: true
         type: string
 
-# Keyed on brand alone, deliberately: every release of a brand overwrites that
+# Keyed on channel alone, deliberately: every release overwrites that channel's
 # brand's single latest.json, so two releases of the SAME brand are never safe to
 # run concurrently regardless of tag. Including the tag here left them in
-# separate groups, so on 2026-07-16 a betly v0.2.24-beta.5 run started 3 minutes
+# separate groups, so a TeamClu Beta run that starts earlier but finishes later
 # earlier but finished 2 minutes later than a v0.2.25-beta.1 run and clobbered
 # the manifest back to the older version — last writer wins, and build duration,
 # not version order, decides the winner. Different brands publish to different
@@ -47,17 +50,17 @@ concurrency:
   group: release-oss-${{ inputs.brand }}
   cancel-in-progress: true
 
-# Per-brand values (bucket, endpoint, prefix, CDN base, app name) are exported
+# Per-channel values (bucket, endpoint, prefix, CDN base, app name) are exported
 # into $GITHUB_ENV by the brand-setup action. Only the credentials — which are
 # genuinely secret and shared across buckets — come from repo secrets. The three
-# *_DEFAULT values below are the fallbacks a brand inherits when its brand.json
-# omits that OSS field; betly relies on them to keep publishing exactly where the
-# old release-beta.yml did.
+# *_DEFAULT values below are also the complete source of distribution settings
+# for the built-in TeamClu Beta channel.
 env:
   BRANDING_REPO: ${{ vars.BRANDING_REPO }}
   OSS_BUCKET_DEFAULT: ${{ secrets.OSS_BUCKET }}
   OSS_ENDPOINT_DEFAULT: ${{ secrets.OSS_ENDPOINT }}
   CDN_BASE_DEFAULT: ${{ vars.OSS_CDN_BASE || 'https://teamclaw.ucar.cc' }}
+  CDN_REFRESH_REGION_DEFAULT: ${{ vars.OSS_CDN_REFRESH_REGION || '' }}
 
 jobs:
   mirror-pi:
@@ -104,6 +107,7 @@ jobs:
           oss-bucket-default: ${{ env.OSS_BUCKET_DEFAULT }}
           oss-endpoint-default: ${{ env.OSS_ENDPOINT_DEFAULT }}
           cdn-base-default: ${{ env.CDN_BASE_DEFAULT }}
+          cdn-refresh-region-default: ${{ env.CDN_REFRESH_REGION_DEFAULT }}
 
       - name: Verify Tauri signing key
         env:
@@ -186,7 +190,7 @@ jobs:
       # before Vite bundles them, which is why this is its own step ahead of the
       # parallel block rather than part of it.
       #
-      # A brand with no app.logo (betly) simply keeps the stock icons.
+      # TeamClu Beta uses the stock icons when it has no explicit app.logo.
       - name: Install deps + apply brand to tauri.conf + icons
         shell: bash
         run: |
@@ -305,9 +309,8 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           DEVICE_JWT_SECRET: ${{ secrets.DEVICE_JWT_SECRET }}
         with:
-          # BRAND_MAC_EXTRA_ARGS comes from brand.json build.macExtraArgs — betly
-          # passes --features beta-devtools to enable the WebKit inspector in the
-          # release build; shipping brands leave it empty.
+          # OEM brands may provide build.macExtraArgs; TeamClu Beta deliberately
+          # leaves it empty so the beta is a normal TeamClu build.
           args: "--target ${{ matrix.target }} ${{ env.BRAND_MAC_EXTRA_ARGS }}"
 
       - name: Upload installers to OSS + emit updater fragment
@@ -460,6 +463,7 @@ jobs:
           oss-bucket-default: ${{ env.OSS_BUCKET_DEFAULT }}
           oss-endpoint-default: ${{ env.OSS_ENDPOINT_DEFAULT }}
           cdn-base-default: ${{ env.CDN_BASE_DEFAULT }}
+          cdn-refresh-region-default: ${{ env.CDN_REFRESH_REGION_DEFAULT }}
 
       - name: Verify Tauri signing key
         env:
@@ -725,6 +729,7 @@ jobs:
           oss-bucket-default: ${{ env.OSS_BUCKET_DEFAULT }}
           oss-endpoint-default: ${{ env.OSS_ENDPOINT_DEFAULT }}
           cdn-base-default: ${{ env.CDN_BASE_DEFAULT }}
+          cdn-refresh-region-default: ${{ env.CDN_REFRESH_REGION_DEFAULT }}
 
       # NOT `apt-get install protobuf-compiler`. The ubuntu runner's
       # /etc/apt/apt-mirrors.txt puts the Azure-internal mirror first and the
@@ -824,6 +829,7 @@ jobs:
           oss-bucket-default: ${{ env.OSS_BUCKET_DEFAULT }}
           oss-endpoint-default: ${{ env.OSS_ENDPOINT_DEFAULT }}
           cdn-base-default: ${{ env.CDN_BASE_DEFAULT }}
+          cdn-refresh-region-default: ${{ env.CDN_REFRESH_REGION_DEFAULT }}
 
       - name: Download all updater fragments
         uses: actions/download-artifact@v8

--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -57,10 +57,15 @@ env:
   BRANDING_REPO: ${{ vars.BRANDING_REPO }}
   OSS_BUCKET_DEFAULT: ${{ secrets.OSS_BUCKET }}
   OSS_ENDPOINT_DEFAULT: ${{ secrets.OSS_ENDPOINT }}
-  CDN_BASE_DEFAULT: ${{ vars.OSS_CDN_BASE || 'https://teamclu.ucar.cc' }}
+  CDN_BASE_DEFAULT: ${{ vars.OSS_CDN_BASE || 'https://teamclaw.ucar.cc' }}
 
 jobs:
+  mirror-pi:
+    uses: ./.github/workflows/mirror-pi-oss.yml
+    secrets: inherit
+
   build-macos:
+    needs: mirror-pi
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Keep the OSS fallback populated from the exact Pi lock that ships in every
+  # manual stable release. The reusable workflow uploads the official npm
+  # package only after it has bundled and checks its production dependencies.
+  mirror-pi:
+    uses: ./.github/workflows/mirror-pi-oss.yml
+    secrets: inherit
+
   # Gate: refuse to build a release whose bundled amuxd (apps/daemon/Cargo.toml)
   # version was not bumped. The client only force-upgrades ~/.amuxd/bin/amuxd when
   # the bundled crate version is strictly greater than the installed one, so a
@@ -30,7 +37,7 @@ jobs:
 
   # macOS job creates the GitHub Release and uploads macOS artifacts
   release-macos:
-    needs: verify-version-bump
+    needs: [verify-version-bump, mirror-pi]
     permissions:
       contents: write
     strategy:
@@ -317,7 +324,7 @@ jobs:
 
   # Windows job uploads artifacts to the same GitHub Release created by macOS job
   release-windows:
-    needs: verify-version-bump
+    needs: [verify-version-bump, mirror-pi]
     permissions:
       contents: write
     runs-on: windows-latest

--- a/apps/daemon/src/opencode_install/mod.rs
+++ b/apps/daemon/src/opencode_install/mod.rs
@@ -131,7 +131,7 @@ const DEFAULT_DOWNLOAD_BASE: &str = "https://github.com/sst/opencode/releases/la
 /// build with no way to tell — "update to latest" downgraded 1.18.5 -> 1.17.7.
 /// A versioned URL names exactly one build, so only the tiny manifest has to be
 /// fresh, and a stale manifest can at worst cost us one release of latency.
-const MIRROR_BASE: &str = "https://teamclu.ucar.cc/opencode";
+const MIRROR_BASE: &str = "https://teamclaw.ucar.cc/opencode";
 
 /// How long to wait on the mirror manifest before giving up and using upstream.
 /// Deliberately short: this runs before any progress output, so a hung mirror
@@ -161,6 +161,33 @@ fn current_asset() -> Option<&'static str> {
 fn download_url(asset: &str) -> String {
     let base = DEFAULT_DOWNLOAD_BASE.trim_end_matches('/');
     format!("{base}/{asset}")
+}
+
+/// Prefer the official release when its CDN is reachable from this network.
+/// A short preflight is enough to avoid sending mainland clients into npm-style
+/// retry loops; download failures still fall back to the OSS mirror below.
+fn official_asset_available(asset: &str) -> bool {
+    let url = download_url(asset);
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .ok()
+        .and_then(|runtime| {
+            runtime.block_on(async {
+                reqwest::Client::builder()
+                    .timeout(MANIFEST_TIMEOUT)
+                    .build()
+                    .ok()?
+                    .head(url)
+                    .send()
+                    .await
+                    .ok()?
+                    .error_for_status()
+                    .ok()?;
+                Some(())
+            })
+        })
+        .is_some()
 }
 
 /// Download URL for `asset` at `version` on the mirror.
@@ -305,10 +332,9 @@ fn unpack_opencode(asset: &str, bytes: &[u8], dest: &std::path::Path) -> anyhow:
 /// Direct-download install: fetch the current platform's release asset and
 /// unpack it into `~/.opencode/bin`.
 ///
-/// Prefers the mirror (fast where GitHub is not), falling back to upstream if
-/// the mirror can't say what it carries or the download fails. `mirror_version`
-/// is the already-resolved manifest answer, so callers that needed it for an
-/// up-to-date check don't fetch it twice.
+/// Downloads from the requested OSS mirror version, falling back to upstream if
+/// that mirror download fails. `mirror_version` is the already-resolved manifest
+/// answer, so callers that needed it for an up-to-date check don't fetch it twice.
 fn direct_install(mirror_version: Option<&str>) -> anyhow::Result<()> {
     let asset = current_asset().ok_or_else(|| {
         anyhow::anyhow!(
@@ -374,10 +400,9 @@ fn install_command_path() -> String {
 /// the settings "Update" path and always re-fetches.
 ///
 /// Source selection, in order:
-///   * The OSS mirror, when its manifest answers — the fast path on networks
-///     where GitHub is slow or blocked.
-///   * Windows without the mirror: direct-download (no official curl|bash).
-///   * macOS/Linux without the mirror: the official opencode.ai installer.
+///   * The official GitHub release when its CDN is reachable from this network.
+///   * The versioned OSS mirror when the official route is slow or blocked.
+///   * macOS/Linux's official opencode.ai installer as a last fallback.
 pub fn run_install(force: bool) -> anyhow::Result<()> {
     if !force {
         if let Some((path, have)) = detect_opencode() {
@@ -392,14 +417,30 @@ pub fn run_install(force: bool) -> anyhow::Result<()> {
         progress("upgrade", "updating opencode to the latest release");
     }
 
+    let official_available = current_asset()
+        .map(official_asset_available)
+        .unwrap_or(false);
+    if official_available {
+        progress(
+            "source",
+            "official OpenCode release is reachable; downloading from upstream",
+        );
+        direct_install(None)?;
+        report_installed();
+        return Ok(());
+    }
+
+    progress(
+        "source",
+        "official OpenCode release is unavailable; trying the OSS mirror",
+    );
     // Resolved once and threaded through: the manifest is a network round-trip.
     let mirror_version = mirror_latest_version();
     if let Some(v) = &mirror_version {
         progress("mirror", &format!("mirror carries opencode {v}"));
     }
 
-    // The mirror serves every platform, so it takes precedence over both the
-    // Windows direct-download and the official installer.
+    // The mirror serves every platform after the official preflight fails.
     if mirror_version.is_some() || cfg!(windows) {
         direct_install(mirror_version.as_deref())?;
         report_installed();
@@ -688,7 +729,7 @@ mod tests {
         // that is what makes a CDN unable to serve a different build than asked.
         assert_eq!(
             mirror_asset_url("1.18.5", "opencode-darwin-arm64.zip"),
-            "https://teamclu.ucar.cc/opencode/1.18.5/opencode-darwin-arm64.zip"
+            "https://teamclaw.ucar.cc/opencode/1.18.5/opencode-darwin-arm64.zip"
         );
         assert!(!mirror_asset_url("1.18.5", "x.zip").contains("stable"));
     }

--- a/apps/daemon/src/pi_install/mod.rs
+++ b/apps/daemon/src/pi_install/mod.rs
@@ -6,6 +6,7 @@
 //! present, otherwise `pi` on PATH (including `~/.npm-global/bin`).
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::opencode_install::{parse_semver, version_ge};
 
@@ -129,18 +130,136 @@ fn progress(event: &str, message: &str) {
     );
 }
 
+const PI_NPM_PKG: &str = "@earendil-works/pi-coding-agent";
+const PI_MIRROR_BASE: &str = "https://teamclaw.ucar.cc/pi";
+const OFFICIAL_REGISTRY: &str = "https://registry.npmjs.org";
+const NETWORK_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+#[derive(Debug, Deserialize)]
+struct PiMirrorManifest {
+    version: String,
+    asset: String,
+    sha256: String,
+}
+
+fn npm_package_spec(min_version: &str) -> String {
+    format!("{PI_NPM_PKG}@{min_version}")
+}
+
+fn command_with_runtime_path(command: &str) -> std::process::Command {
+    let mut process = std::process::Command::new(command);
+    process.env("PATH", crate::runtime::well_known_bin::augmented_path());
+    process
+}
+
 fn has_command(cmd: &str) -> bool {
-    std::process::Command::new(cmd)
+    command_with_runtime_path(cmd)
         .arg("--version")
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
 }
 
-const PI_NPM_PKG: &str = "@earendil-works/pi-coding-agent";
+/// The official npm registry is the preferred source. A short probe lets users
+/// on a slow or blocked route fall back to our OSS bundle before npm spends
+/// minutes retrying its own registry requests.
+fn official_registry_available(version: &str) -> bool {
+    let url = format!("{OFFICIAL_REGISTRY}/@earendil-works%2Fpi-coding-agent/{version}");
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .ok()
+        .and_then(|runtime| {
+            runtime.block_on(async {
+                reqwest::Client::builder()
+                    .timeout(NETWORK_PROBE_TIMEOUT)
+                    .build()
+                    .ok()?
+                    .get(url)
+                    .send()
+                    .await
+                    .ok()?
+                    .error_for_status()
+                    .ok()?;
+                Some(())
+            })
+        })
+        .is_some()
+}
 
-fn npm_package_spec(min_version: &str) -> String {
-    format!("{PI_NPM_PKG}@{min_version}")
+fn mirror_manifest() -> Option<PiMirrorManifest> {
+    let url = format!("{}/latest.json", PI_MIRROR_BASE.trim_end_matches('/'));
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .ok()
+        .and_then(|runtime| {
+            runtime.block_on(async {
+                let response = reqwest::Client::builder()
+                    .timeout(NETWORK_PROBE_TIMEOUT)
+                    .build()
+                    .ok()?
+                    .get(url)
+                    .send()
+                    .await
+                    .ok()?
+                    .error_for_status()
+                    .ok()?;
+                response.json::<PiMirrorManifest>().await.ok()
+            })
+        })
+}
+
+fn download_bytes(url: &str) -> anyhow::Result<Vec<u8>> {
+    let url = url.to_owned();
+    let bytes = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(async {
+            let response = reqwest::get(url).await?.error_for_status()?;
+            Ok::<_, anyhow::Error>(response.bytes().await?)
+        })?;
+    Ok(bytes.to_vec())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+/// Fetch the versioned, dependency-bundled package from OSS and materialize it
+/// as a temporary `.tgz` that npm can install without contacting a registry.
+fn mirrored_bundle(version: &str) -> anyhow::Result<tempfile::NamedTempFile> {
+    let manifest =
+        mirror_manifest().ok_or_else(|| anyhow::anyhow!("Pi OSS mirror is unavailable"))?;
+    if manifest.version.trim_start_matches('v') != version {
+        anyhow::bail!(
+            "Pi OSS mirror has {}, but this build requires {version}",
+            manifest.version
+        );
+    }
+    if !safe_mirror_asset(&manifest.asset) {
+        anyhow::bail!("Pi OSS mirror returned an invalid asset name");
+    }
+    let url = format!(
+        "{}/{}/{}",
+        PI_MIRROR_BASE.trim_end_matches('/'),
+        version,
+        manifest.asset
+    );
+    progress("mirror", &format!("downloading Pi from OSS: {url}"));
+    let bytes = download_bytes(&url)?;
+    if sha256_hex(&bytes) != manifest.sha256.to_ascii_lowercase() {
+        anyhow::bail!(
+            "Pi OSS bundle checksum mismatch; retry later or use the official npm registry"
+        );
+    }
+    let file = tempfile::Builder::new().suffix(".tgz").tempfile()?;
+    std::fs::write(file.path(), bytes)?;
+    Ok(file)
+}
+
+fn safe_mirror_asset(asset: &str) -> bool {
+    !asset.is_empty() && !asset.contains('/') && !asset.contains('\\') && asset.ends_with(".tgz")
 }
 
 /// Install or upgrade pi via `npm install -g @earendil-works/pi-coding-agent@<lock>`
@@ -177,17 +296,50 @@ pub fn run_install(force: bool) -> anyhow::Result<()> {
         }
     }
 
-    let pkg = npm_package_spec(&want);
-    let (cmd, args): (&str, Vec<String>) = if has_command("npm") {
-        ("npm", vec!["install".into(), "-g".into(), pkg])
-    } else if has_command("bun") {
-        ("bun", vec!["add".into(), "-g".into(), pkg])
-    } else {
+    if !has_command("npm") && !has_command("bun") {
         anyhow::bail!("neither npm nor bun found; install Node.js or Bun first");
-    };
+    }
+
+    let pkg = npm_package_spec(&want);
+    let official_available = official_registry_available(&want);
+    let (cmd, args, _bundle): (&str, Vec<String>, Option<tempfile::NamedTempFile>) =
+        if official_available {
+            progress(
+                "source",
+                "official npm registry is reachable; installing Pi from upstream",
+            );
+            if has_command("npm") {
+                ("npm", vec!["install".into(), "-g".into(), pkg], None)
+            } else {
+                ("bun", vec!["add".into(), "-g".into(), pkg], None)
+            }
+        } else {
+            // Node distributions include npm. Only npm can reliably consume our
+            // bundled tarball in offline mode, so do not silently send a blocked
+            // network to Bun when the fallback has been selected.
+            if !has_command("npm") {
+                anyhow::bail!(
+                    "official npm registry is unreachable and the Pi OSS fallback requires npm"
+                );
+            }
+            let bundle = mirrored_bundle(&want)?;
+            let local = bundle.path().to_string_lossy().to_string();
+            (
+                "npm",
+                vec![
+                    "install".into(),
+                    "-g".into(),
+                    "--offline".into(),
+                    "--no-audit".into(),
+                    "--no-fund".into(),
+                    local,
+                ],
+                Some(bundle),
+            )
+        };
 
     progress("install", &format!("running {cmd} {}", args.join(" ")));
-    let output = std::process::Command::new(cmd)
+    let output = command_with_runtime_path(cmd)
         .args(args.iter().map(String::as_str))
         .output()
         .map_err(|e| anyhow::anyhow!("failed to run {cmd}: {e}"))?;
@@ -227,6 +379,18 @@ mod tests {
             npm_package_spec("0.81.1"),
             "@earendil-works/pi-coding-agent@0.81.1"
         );
+    }
+
+    #[test]
+    fn pi_mirror_manifest_is_versioned_and_uses_a_safe_asset_name() {
+        let manifest: PiMirrorManifest = serde_json::from_str(
+            r#"{"version":"0.84.2","asset":"earendil-works-pi-coding-agent-0.84.2.tgz","sha256":"abc"}"#,
+        )
+        .unwrap();
+        assert_eq!(manifest.version, "0.84.2");
+        assert!(safe_mirror_asset(&manifest.asset));
+        assert!(!safe_mirror_asset("../pi.tgz"));
+        assert!(!safe_mirror_asset("pi.zip"));
     }
 
     #[test]

--- a/apps/daemon/src/pi_install/mod.rs
+++ b/apps/daemon/src/pi_install/mod.rs
@@ -63,18 +63,50 @@ pub struct PiStatus {
     pub present: bool,
     pub version: Option<String>,
     pub path: Option<String>,
+    /// Pi is a Node CLI. Keep this separate from Pi's own version so onboarding
+    /// can explain the real prerequisite before attempting `npm install`.
+    pub node_present: bool,
+    pub node_version: Option<String>,
+    pub node_satisfied: bool,
     pub required_version: String,
     pub satisfied: bool,
 }
 
+/// Pi 0.84.x declares `node >=22.19.0`. Keep the check in the daemon (rather
+/// than the React onboarding screen) so CLI, Settings and first-run setup all
+/// make the same decision.
+const MIN_NODE_VERSION: &str = "22.19.0";
+
+fn node_version() -> Option<String> {
+    let out = std::process::Command::new("node")
+        .arg("--version")
+        .env("PATH", crate::runtime::well_known_bin::augmented_path())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .next()?
+        .trim()
+        .to_string();
+    (!line.is_empty()).then_some(line)
+}
+
 pub fn doctor() -> PiStatus {
     let want = required_version();
+    let node_version = node_version();
+    let node_satisfied = node_version
+        .as_deref()
+        .map(|v| version_ge(v, MIN_NODE_VERSION))
+        .unwrap_or(false);
     let detected = detect_pi();
     let (present, version, path) = match &detected {
         Some((p, v)) => (true, Some(v.clone()), Some(p.clone())),
         None => (false, None, None),
     };
-    let satisfied = version
+    let pi_satisfied = version
         .as_deref()
         .map(|v| version_ge(v, &want))
         .unwrap_or(false);
@@ -82,8 +114,11 @@ pub fn doctor() -> PiStatus {
         present,
         version,
         path,
+        node_present: node_version.is_some(),
+        node_version,
+        node_satisfied,
         required_version: want,
-        satisfied,
+        satisfied: pi_satisfied && node_satisfied,
     }
 }
 
@@ -112,6 +147,17 @@ fn npm_package_spec(min_version: &str) -> String {
 /// (falls back to `bun add -g` when npm is absent).
 pub fn run_install(force: bool) -> anyhow::Result<()> {
     let want = required_version();
+    let node = node_version();
+    if !node
+        .as_deref()
+        .map(|v| version_ge(v, MIN_NODE_VERSION))
+        .unwrap_or(false)
+    {
+        let found = node.as_deref().unwrap_or("not found");
+        anyhow::bail!(
+            "Pi requires Node.js >= {MIN_NODE_VERSION}; found {found}. Install or upgrade Node.js first"
+        );
+    }
 
     if !force {
         if let Some((path, have)) = detect_pi() {
@@ -189,11 +235,15 @@ mod tests {
             present: true,
             version: Some("0.81.1".into()),
             path: Some("/x/pi".into()),
+            node_present: true,
+            node_version: Some("v22.19.0".into()),
+            node_satisfied: true,
             required_version: "0.81.1".into(),
             satisfied: true,
         };
         let v = serde_json::to_value(&s).unwrap();
         assert_eq!(v["requiredVersion"], serde_json::json!("0.81.1"));
+        assert_eq!(v["nodeSatisfied"], serde_json::json!(true));
         assert_eq!(v["satisfied"], serde_json::json!(true));
     }
 }

--- a/apps/desktop/src/commands/setup.rs
+++ b/apps/desktop/src/commands/setup.rs
@@ -139,8 +139,9 @@ pub async fn setup_list_requirements<R: Runtime>(
     };
 
     // `present` = no action needed. For opencode that is simply "installed"
-    // (amuxd pins no version); pi still has a lock, so there it means "installed
-    // AND new enough". `version` = the installed version, for the UI to show.
+    // (amuxd pins no version); pi still has a lock AND requires a supported Node
+    // runtime, so there it means "installed, new enough, and runnable".
+    // `version` = the installed version, for the UI to show.
     // amuxd: desktop-managed sidecar — satisfied when the bundle includes it.
     let amuxd_version = doctor
         .as_ref()
@@ -188,7 +189,9 @@ pub async fn setup_list_requirements<R: Runtime>(
             optional: false,
             present: runtime_satisfied,
             version: runtime_version,
-            blocker: None,
+            blocker: (runtime_id == "pi")
+                .then(|| runtime.and_then(pi_blocker))
+                .flatten(),
         },
     ])
 }
@@ -244,6 +247,14 @@ fn cursor_blocker(node: &serde_json::Value) -> Option<String> {
     None
 }
 
+/// Pi's global npm shim still runs with the host Node binary. Do not let the
+/// setup wizard launch its install command until Node meets Pi's declared
+/// minimum; otherwise both the guided and self-select paths fail only after a
+/// slow npm request.
+fn pi_blocker(node: &serde_json::Value) -> Option<String> {
+    (!node["nodeSatisfied"].as_bool().unwrap_or(false)).then(|| "node".to_string())
+}
+
 /// Install status of every agent runtime the user can pick from (#881).
 ///
 /// One `amuxd doctor` call covers all four — the daemon reports every runtime
@@ -278,9 +289,11 @@ pub async fn setup_list_agent_runtimes<R: Runtime>(
             // Reported whether or not the runtime is present: a cursor install
             // with no API key is here and pickable, and the UI still has to be
             // able to say what it is waiting on.
-            blocker: (id == "cursor")
-                .then(|| node.and_then(cursor_blocker))
-                .flatten(),
+            blocker: match id {
+                "cursor" => node.and_then(cursor_blocker),
+                "pi" => node.and_then(pi_blocker),
+                _ => None,
+            },
         }
     };
     Ok(RUNTIMES

--- a/build.config.example.json
+++ b/build.config.example.json
@@ -18,7 +18,7 @@
   "features": {
     "updater": true
   },
-  "localAgent": "opencode",
+  "localAgent": "pi",
   "defaults": {
     "theme": "system"
   },

--- a/build.config.production.json
+++ b/build.config.production.json
@@ -9,6 +9,7 @@
   "features": {
     "updater": true
   },
+  "localAgent": "pi",
   "defaults": {
     "theme": "system"
   }

--- a/packages/app/src/components/onboarding/SetupStep.tsx
+++ b/packages/app/src/components/onboarding/SetupStep.tsx
@@ -125,7 +125,12 @@ function RuntimeCard({
           {t('onboarding.setup.needsApiKey', 'Needs an API key — add it in Settings → LLM later.')}
         </span>
       )}
-      {fetchable && (
+      {runtime.blocker === 'node' && (
+        <span className="text-[11px] leading-4 text-faint">
+          {t('onboarding.setup.needsNode', 'Needs Node.js 22.19 or later before Pi can be installed.')}
+        </span>
+      )}
+      {fetchable && runtime.blocker !== 'node' && (
         <button
           type="button"
           disabled={busy}
@@ -158,7 +163,9 @@ function DependencyRow({ req, installing }: { req: RequirementStatus; installing
         <span className="text-[13px] text-foreground">{req.title}</span>
       </span>
       <span className="font-mono text-[11px] text-faint">
-        {req.version ??
+        {req.blocker === 'node'
+          ? t('onboarding.setup.needsNode', 'Needs Node.js 22.19 or later before Pi can be installed.')
+          : req.version ??
           (ok
             ? t('onboarding.setup.ready', 'ready')
             : installing
@@ -237,12 +244,13 @@ export function SetupStep({ role, onDone }: { role: OnboardingRole; onDone: () =
   // app can fetch.
   const guidedRuntime = agentRuntimes.find((r) => r.id === GUIDED_RUNTIME)
   const guidedRuntimeMissing = role === 'guided' && !!guidedRuntime && !usable(guidedRuntime)
+  const guidedRuntimeNeedsNode = guidedRuntime?.blocker === 'node'
   const guidedInstallTriggered = React.useRef(false)
   React.useEffect(() => {
-    if (!guidedRuntimeMissing || guidedInstallTriggered.current) return
+    if (!guidedRuntimeMissing || guidedRuntimeNeedsNode || guidedInstallTriggered.current) return
     guidedInstallTriggered.current = true
     void install(GUIDED_RUNTIME)
-  }, [guidedRuntimeMissing, install])
+  }, [guidedRuntimeMissing, guidedRuntimeNeedsNode, install])
 
   const selectedRuntime = agentRuntimes.find((r) => r.id === selected)
   const runtimeReady = usable(selectedRuntime)
@@ -256,7 +264,11 @@ export function SetupStep({ role, onDone }: { role: OnboardingRole; onDone: () =
    * other moving part, so the whole window reads as hung. Anything that greys
    * the button out while the machine is still working spins.
    */
-  const busy = !!installing || amuxdMissing || guidedRuntimeMissing || (!runtimeReady && visibleRuntimes.length > 0)
+  const busy =
+    !!installing ||
+    amuxdMissing ||
+    (guidedRuntimeMissing && !guidedRuntimeNeedsNode) ||
+    (!runtimeReady && visibleRuntimes.length > 0 && selectedRuntime?.blocker !== 'node')
 
   const pick = (id: DaemonLocalAgent) => {
     setSelected(id)

--- a/packages/app/src/components/onboarding/SetupStep.tsx
+++ b/packages/app/src/components/onboarding/SetupStep.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Check, Loader2, AlertCircle, Download, Terminal, Cpu, MousePointer2, Bot } from 'lucide-react'
+import { Check, Loader2, AlertCircle, Download, Terminal, Cpu, MousePointer2, Bot, RefreshCw } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -195,6 +195,7 @@ export function SetupStep({ role, onDone }: { role: OnboardingRole; onDone: () =
     useSetupStore()
   const setRuntime = useOnboardingStore((s) => s.setRuntime)
   const [selected, setSelected] = React.useState<DaemonLocalAgent>(DEFAULT_RUNTIME)
+  const [rechecking, setRechecking] = React.useState(false)
 
   React.useEffect(() => {
     void listAgentRuntimes()
@@ -253,6 +254,7 @@ export function SetupStep({ role, onDone }: { role: OnboardingRole; onDone: () =
   }, [guidedRuntimeMissing, guidedRuntimeNeedsNode, install])
 
   const selectedRuntime = agentRuntimes.find((r) => r.id === selected)
+  const nodeBlocked = selectedRuntime?.blocker === 'node'
   const runtimeReady = usable(selectedRuntime)
   const canContinue = loaded && !installing && !amuxdMissing && runtimeReady
   /**
@@ -278,6 +280,18 @@ export function SetupStep({ role, onDone }: { role: OnboardingRole; onDone: () =
   const proceed = () => {
     setRuntime(selected)
     onDone()
+  }
+
+  const recheck = async () => {
+    setRechecking(true)
+    try {
+      // Node may have been installed while onboarding stayed open. Re-probe both
+      // views: the selected-runtime row controls Continue, and the picker must
+      // also restore Pi's Install action for the self-select path.
+      await Promise.all([listRequirements(selected), listAgentRuntimes()])
+    } finally {
+      setRechecking(false)
+    }
   }
 
   if (!loaded) {
@@ -353,6 +367,21 @@ export function SetupStep({ role, onDone }: { role: OnboardingRole; onDone: () =
               .filter((r) => r.id === 'git')
               .map((r) => <DependencyRow key={r.id} req={r} installing={installing === r.id} />)}
         </div>
+
+        {nodeBlocked && (
+          <Button
+            type="button"
+            variant="outline"
+            className="h-9 w-full rounded-[8px] border-border bg-paper text-[12px] text-ink-2 hover:bg-selected/30"
+            disabled={rechecking}
+            onClick={() => void recheck()}
+          >
+            <RefreshCw className={cn('mr-1.5 h-3.5 w-3.5', rechecking && 'animate-spin')} />
+            {rechecking
+              ? t('onboarding.setup.rechecking', 'Checking…')
+              : t('onboarding.setup.recheck', 'I installed Node.js — check again')}
+          </Button>
+        )}
 
         {/* The runtime error matters most on the guided path: nothing there is
             user-initiated, so a failed auto-install has no other way to surface

--- a/packages/app/src/components/onboarding/__tests__/SetupStep.brand.test.tsx
+++ b/packages/app/src/components/onboarding/__tests__/SetupStep.brand.test.tsx
@@ -62,6 +62,36 @@ describe('SetupStep on a build that targets pi', () => {
     await vi.waitFor(() => expect(install).toHaveBeenCalledWith('pi'))
   })
 
+  it('does not start the guided Pi install until Node meets Pi’s requirement', async () => {
+    const install = vi.fn(async () => {})
+    seed({
+      agentRuntimes: [
+        req('opencode', { title: 'OpenCode' }),
+        req('pi', { title: 'Pi', present: false, version: null, blocker: 'node' }),
+      ],
+      install,
+    })
+    render(<SetupStep role="guided" onDone={() => {}} />)
+
+    expect(await screen.findByText('使用 Pi 前请先安装 Node.js 22.19 或更高版本。')).toBeInTheDocument()
+    expect(install).not.toHaveBeenCalledWith('pi')
+    expect(screen.getByRole('button', { name: '继续' })).toBeDisabled()
+  })
+
+  it('does not offer the self-select Pi install until Node meets Pi’s requirement', () => {
+    seed({
+      agentRuntimes: [
+        req('opencode', { title: 'OpenCode' }),
+        req('pi', { title: 'Pi', present: false, version: null, blocker: 'node' }),
+      ],
+    })
+    render(<SetupStep role="developer" onDone={() => {}} />)
+
+    expect(screen.getByText('使用 Pi 前请先安装 Node.js 22.19 或更高版本。')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '安装' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '继续' })).toBeDisabled()
+  })
+
   it('opens the developer picker on the build’s runtime', () => {
     render(<SetupStep role="developer" onDone={() => {}} />)
     screen.getByRole('button', { name: '继续' }).click()

--- a/packages/app/src/components/onboarding/__tests__/SetupStep.brand.test.tsx
+++ b/packages/app/src/components/onboarding/__tests__/SetupStep.brand.test.tsx
@@ -92,6 +92,26 @@ describe('SetupStep on a build that targets pi', () => {
     expect(screen.getByRole('button', { name: '继续' })).toBeDisabled()
   })
 
+  it('rechecks both Pi views after the user installs Node', async () => {
+    const listRequirements = vi.fn(async () => {})
+    const listAgentRuntimes = vi.fn(async () => {})
+    seed({
+      agentRuntimes: [
+        req('opencode', { title: 'OpenCode' }),
+        req('pi', { title: 'Pi', present: false, version: null, blocker: 'node' }),
+      ],
+      listRequirements,
+      listAgentRuntimes,
+    })
+    render(<SetupStep role="guided" onDone={() => {}} />)
+    listRequirements.mockClear()
+    listAgentRuntimes.mockClear()
+
+    screen.getByRole('button', { name: '我已安装 Node.js，重新检测' }).click()
+    await vi.waitFor(() => expect(listRequirements).toHaveBeenCalledWith('pi'))
+    expect(listAgentRuntimes).toHaveBeenCalledOnce()
+  })
+
   it('opens the developer picker on the build’s runtime', () => {
     render(<SetupStep role="developer" onDone={() => {}} />)
     screen.getByRole('button', { name: '继续' }).click()

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -875,6 +875,8 @@
       "upgrade": "Upgrade",
       "needsApiKey": "Needs an API key — add it in Settings → LLM later.",
       "needsNode": "Install Node.js 22.19 or later to use Pi.",
+      "recheck": "I installed Node.js — check again",
+      "rechecking": "Checking…",
       "installed": "installed",
       "installing": "installing…",
       "ready": "ready",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -874,6 +874,7 @@
       "install": "Install",
       "upgrade": "Upgrade",
       "needsApiKey": "Needs an API key — add it in Settings → LLM later.",
+      "needsNode": "Install Node.js 22.19 or later to use Pi.",
       "installed": "installed",
       "installing": "installing…",
       "ready": "ready",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -875,6 +875,8 @@
       "upgrade": "升级",
       "needsApiKey": "缺 API Key——进去后在「设置 → LLM」里填。",
       "needsNode": "使用 Pi 前请先安装 Node.js 22.19 或更高版本。",
+      "recheck": "我已安装 Node.js，重新检测",
+      "rechecking": "检测中…",
       "installed": "已安装",
       "installing": "安装中…",
       "ready": "就绪",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -874,6 +874,7 @@
       "install": "安装",
       "upgrade": "升级",
       "needsApiKey": "缺 API Key——进去后在「设置 → LLM」里填。",
+      "needsNode": "使用 Pi 前请先安装 Node.js 22.19 或更高版本。",
       "installed": "已安装",
       "installing": "安装中…",
       "ready": "就绪",


### PR DESCRIPTION
## Summary
- default official builds to Pi and require a supported Node runtime before Pi setup
- add onboarding Node recheck so setup can continue after Node installation
- prefer official OpenCode/Pi sources and fall back to verified OSS mirrors
- consolidate Betly TeamClaw beta into TeamClu Beta while preserving /beta/ compatibility; keep Copilot361 independent

## Validation
- onboarding Vitest: 17 passed
- 
- Rust formatting and release workflow actionlint
- verified the Pi bundled artifact installs with npm <command>

Usage:

npm install        install all the dependencies in your project
npm install <foo>  add the <foo> dependency to your project
npm test           run this project's tests
npm run <foo>      run the script named <foo>
npm <command> -h   quick help on <command>
npm -l             display usage info for all commands
npm help <term>    search for help on <term>
npm help npm       more involved overview

All commands:

    access, adduser, approve-scripts, audit, bugs, cache, ci,
    completion, config, dedupe, deny-scripts, deprecate, diff,
    dist-tag, docs, doctor, edit, exec, explain, explore,
    find-dupes, fund, get, help, help-search, init, install,
    install-ci-test, install-test, link, ll, login, logout, ls,
    org, outdated, owner, pack, ping, pkg, prefix, profile,
    prune, publish, query, rebuild, repo, restart, root, run,
    sbom, search, set, shrinkwrap, stage, star, stars, start,
    stop, team, test, token, trust, undeprecate, uninstall,
    unpublish, unstar, update, version, view, whoami

Specify configs in the ini-formatted file:
    /Users/matt.chow/.npmrc
or on the command line via: npm <command> --key=value

More configuration info: npm help config
Configuration fields: npm help 7 config

npm@11.17.0 /opt/homebrew/lib/node_modules/npm