### PR TITLE
fix(release): unblock Pi OSS mirror workflow

### DIFF
--- a/.github/workflows/mirror-pi-oss.yml
+++ b/.github/workflows/mirror-pi-oss.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: npm
 
       - name: Resolve the required official Pi version
         id: pi


### PR DESCRIPTION
Removes the npm cache setting from the Pi mirror setup step. The repository has no root npm lockfile, so setup-node fails before mirroring. This restores the TeamClu and Copilot361 OSS release path.