### PR TITLE
fix(release): bound Pi mirror OSS lookup

### DIFF
--- a/.github/workflows/mirror-pi-oss.yml
+++ b/.github/workflows/mirror-pi-oss.yml
@@ -44,7 +44,7 @@ jobs:
           VERSION: ${{ steps.pi.outputs.version }}
         run: |
           set -euo pipefail
-          SERVED=$(curl -fsSL "$OSS_BASE/latest.json" 2>/dev/null | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" 2>/dev/null || true)
+          SERVED=$(curl --connect-timeout 5 --max-time 15 -fsSL "$OSS_BASE/latest.json" 2>/dev/null | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" 2>/dev/null || true)
           if [ "$SERVED" = "$VERSION" ]; then
             echo "Pi OSS mirror already serves $VERSION"
             echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Adds connection and total-time limits to the public OSS manifest lookup. When the public endpoint is unavailable, the mirror now falls through to the official package build instead of blocking a release job.