### PR TITLE
fix(release): ignore stale Pi shrinkwrap

### DIFF
--- a/.github/workflows/mirror-pi-oss.yml
+++ b/.github/workflows/mirror-pi-oss.yml
@@ -67,6 +67,9 @@ jobs:
           # npm include it in the new tarball. Optional native dependencies stay
           # optional: npm may omit an unsupported platform binary, as upstream
           # itself does during a normal install.
+          # The upstream tarball's shrinkwrap includes stale development
+          # entries. It is not usable for a production-only bundle.
+          rm npm-shrinkwrap.json
           npm install --omit=dev --no-audit --no-fund
           node <<'NODE'
           const fs = require('fs')


### PR DESCRIPTION
The upstream Pi tarball contains an out-of-sync shrinkwrap with stale development entries. Remove it only in the temporary mirror build copy, then resolve the production dependency closure. Verified locally against the official Pi 0.84.2 tarball.