### PR TITLE
fix(release): pin Pi mirror to npm 11

### DIFF
--- a/.github/workflows/mirror-pi-oss.yml
+++ b/.github/workflows/mirror-pi-oss.yml
@@ -30,6 +30,12 @@ jobs:
         with:
           node-version: 22
 
+      # npm bundled with the Node 22 runner image crashes while resolving Pi's
+      # production dependency tree ("edgesOut" is null). npm 11 handles the
+      # same official tarball successfully.
+      - name: Use npm 11 for Pi dependency bundling
+        run: npm install --global npm@11
+
       - name: Resolve the required official Pi version
         id: pi
         run: |


### PR DESCRIPTION
GitHub runner Node 22 bundled npm fails with `Cannot read properties of null (reading edgesOut)` while resolving Pi production dependencies. Pin npm 11, which successfully bundled the same official Pi 0.84.2 tarball locally.