### PR TITLE
fix(release): unbreak Pi mirror verification step

### DIFF
--- a/.github/workflows/mirror-pi-oss.yml
+++ b/.github/workflows/mirror-pi-oss.yml
@@ -139,7 +139,7 @@ jobs:
             let s=""; process.stdin.on("data", x => s += x).on("end", () => {
               const m = JSON.parse(s)
               if (m.version !== process.env.VERSION || !m.asset || !/^[a-f0-9]{64}$/.test(m.sha256)) process.exit(1)
-              console.log(m.version + ' ' + m.asset)
+              console.log(m.version + " " + m.asset)
             })'
           ASSET=$(echo "$MANIFEST" | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).asset")
           curl -fsI "$OSS_BASE/$VERSION/$ASSET" >/dev/null


### PR DESCRIPTION
## Problem

The `Verify public manifest and artifact` step in `mirror-pi-oss.yml` wraps its node program in single quotes, then uses single quotes *again* for the separator:

```bash
node -e '
  ...
  console.log(m.version + ' ' + m.asset)   # <- this quote closes the shell string
'
```

The inner `' '` terminates the shell's single-quoted string, so `node -e` receives a truncated program ending at `console.log(m.version + `:

```
[eval]:5
    console.log(m.version +
Expression expected
SyntaxError: Unexpected end of input
```

This is pre-existing (not from #1035) and fires on **every real publish** — i.e. whenever the skip check is false. The mirror uploads correctly and the workflow still reports red.

## Evidence

Run [32605399288](https://github.com/different-ai-studio/teamclu/actions/runs/32605399288) mirrored Pi 0.84.2 to OSS successfully and still failed here:

```
✓ Build a dependency-bundled package from the official registry
✓ Upload immutable artifact and fresh manifest
X Verify public manifest and artifact
```

OSS is serving the artifact fine (it was 404 before that run):

- `https://teamclaw.ucar.cc/pi/latest.json` → `0.84.2`, sha256 `7ac0e6ab…`
- `https://teamclaw.ucar.cc/pi/0.84.2/earendil-works-pi-coding-agent-0.84.2.tgz` → HTTP 200, 20.7 MB

## Fix

Use double quotes for the separator — safe inside the single-quoted shell string.

## Verification

Extracted the step's `run:` block straight from the YAML (no retyping) and ran it against live OSS:

- pre-fix → same `SyntaxError: Unexpected end of input`
- post-fix → passes, prints `0.84.2 earendil-works-pi-coding-agent-0.84.2.tgz`