### PR TITLE
fix(release): bound and retry the Pi mirror verification curls

### DIFF
--- a/.github/workflows/mirror-pi-oss.yml
+++ b/.github/workflows/mirror-pi-oss.yml
@@ -134,7 +134,13 @@ jobs:
           VERSION: ${{ steps.pi.outputs.version }}
         run: |
           set -euo pipefail
-          MANIFEST=$(curl -fsSL "$OSS_BASE/latest.json")
+          # Read back through the CDN, which is reachable from GitHub runners
+          # only most of the time. A bare curl has no connect timeout, so one
+          # unreachable edge burned 300s and then failed an otherwise-complete
+          # release (run 32605980446: "Failed to connect to teamclaw.ucar.cc
+          # port 443 after 300450 ms"). Bound the wait and retry instead.
+          RETRY=(--connect-timeout 10 --max-time 60 --retry 3 --retry-delay 5 --retry-connrefused)
+          MANIFEST=$(curl -fsSL "${RETRY[@]}" "$OSS_BASE/latest.json")
           echo "$MANIFEST" | node -e '
             let s=""; process.stdin.on("data", x => s += x).on("end", () => {
               const m = JSON.parse(s)
@@ -142,4 +148,4 @@ jobs:
               console.log(m.version + " " + m.asset)
             })'
           ASSET=$(echo "$MANIFEST" | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).asset")
-          curl -fsI "$OSS_BASE/$VERSION/$ASSET" >/dev/null
+          curl -fsI "${RETRY[@]}" "$OSS_BASE/$VERSION/$ASSET" >/dev/null


### PR DESCRIPTION
## Problem

The `Verify public manifest and artifact` step reads the freshly published manifest and artifact back **through the CDN**, which is reachable from GitHub runners only most of the time. Both curls were bare — no connect timeout, no retry:

```bash
MANIFEST=$(curl -fsSL "$OSS_BASE/latest.json")
...
curl -fsI "$OSS_BASE/$VERSION/$ASSET" >/dev/null
```

When the edge was briefly unreachable, the manifest read sat for five minutes and then failed the job:

```
curl: (28) Failed to connect to teamclaw.ucar.cc port 443 after 300450 ms: Timeout was reached
```

## Why it mattered

`build-macos` and `publish-manifest` are gated on `mirror-pi`. That one network blip skipped both and cost **copilot361 its entire v0.4.1-beta.23 release** ([run 32605980446](https://github.com/different-ai-studio/teamclu/actions/runs/32605980446)) — even though the artifact had already uploaded correctly with the expected sha256 (`published pi/0.84.2/…tgz (7ac0e6ab…)`).

This is the second time this step alone has failed a complete release; #1036 fixed a quoting bug in the same step.

## Fix

Bound the wait and retry:

```bash
RETRY=(--connect-timeout 10 --max-time 60 --retry 3 --retry-delay 5 --retry-connrefused)
```

applied to both curls.

The skip-check curl already carries `--connect-timeout 5 --max-time 15` and is deliberately left alone: when *it* times out it falls back to `skip=false`, which merely re-uploads an identical artifact.

## Verification

Extracted the step's `run:` block from the YAML with PyYAML (not retyped) and ran it:

| Case | Result |
|---|---|
| Real OSS, correct version | passes — `0.84.2 earendil-works-pi-coding-agent-0.84.2.tgz` |
| Unreachable host (`10.255.255.1`) | fails in **55s after 4 attempts**, vs ~300s on a single attempt before |