### PR TITLE
feat(pi): bridge MCP with the official SDK, installed alongside pi

### DIFF
--- a/.github/workflows/mirror-pi-oss.yml
+++ b/.github/workflows/mirror-pi-oss.yml
@@ -1,9 +1,13 @@
-name: Mirror Pi to OSS
+name: Mirror Pi runtime to OSS
 
-# Pi is published only as an npm package. We create a versioned tarball with
-# Pi's full production dependency closure bundled inside it, then publish that
-# immutable artifact to OSS. This lets mainland clients install Pi without an
-# npm-registry round trip when the official route is unavailable.
+# Pi and the MCP SDK the TeamClu pi extension imports are published only as npm
+# packages. We create a versioned tarball with each one's full production
+# dependency closure bundled inside it, then publish that immutable artifact to
+# OSS. This lets mainland clients install both without an npm-registry round
+# trip when the official route is unavailable.
+#
+# Both jobs read `apps/daemon/pi.lock.json` (`version` / `mcpSdkVersion`), the
+# same file `pi_install` compiles in, so a lock bump refreshes both mirrors.
 on:
   workflow_call: {}
   push:
@@ -139,6 +143,136 @@ jobs:
           # unreachable edge burned 300s and then failed an otherwise-complete
           # release (run 32605980446: "Failed to connect to teamclaw.ucar.cc
           # port 443 after 300450 ms"). Bound the wait and retry instead.
+          RETRY=(--connect-timeout 10 --max-time 60 --retry 3 --retry-delay 5 --retry-connrefused)
+          MANIFEST=$(curl -fsSL "${RETRY[@]}" "$OSS_BASE/latest.json")
+          echo "$MANIFEST" | node -e '
+            let s=""; process.stdin.on("data", x => s += x).on("end", () => {
+              const m = JSON.parse(s)
+              if (m.version !== process.env.VERSION || !m.asset || !/^[a-f0-9]{64}$/.test(m.sha256)) process.exit(1)
+              console.log(m.version + " " + m.asset)
+            })'
+          ASSET=$(echo "$MANIFEST" | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).asset")
+          curl -fsI "${RETRY[@]}" "$OSS_BASE/$VERSION/$ASSET" >/dev/null
+
+  mirror-mcp-sdk:
+    # The pi extension is the MCP client (pi has no MCP of its own) and imports
+    # `@modelcontextprotocol/sdk` from a node_modules next to it. `amuxd pi
+    # install` installs it; this job is the mainland fallback for that install.
+    runs-on: ubuntu-latest
+    env:
+      SDK_PACKAGE: '@modelcontextprotocol/sdk'
+      OSS_BASE: https://teamclaw.ucar.cc/mcp-sdk
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Use npm 11 for dependency bundling
+        run: npm install --global npm@11
+
+      - name: Resolve the required MCP SDK version
+        id: sdk
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "(require('./apps/daemon/pi.lock.json').mcpSdkVersion || '').replace(/^v/, '')")
+          if [ -z "$VERSION" ]; then
+            echo "::error::apps/daemon/pi.lock.json has no mcpSdkVersion"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Mirroring official $SDK_PACKAGE@$VERSION"
+
+      - name: Skip when OSS already has this version
+        id: skip
+        env:
+          VERSION: ${{ steps.sdk.outputs.version }}
+        run: |
+          set -euo pipefail
+          SERVED=$(curl --connect-timeout 5 --max-time 15 -fsSL "$OSS_BASE/latest.json" 2>/dev/null | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" 2>/dev/null || true)
+          if [ "$SERVED" = "$VERSION" ]; then
+            echo "MCP SDK OSS mirror already serves $VERSION"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build a dependency-bundled package from the official registry
+        if: steps.skip.outputs.skip != 'true'
+        env:
+          VERSION: ${{ steps.sdk.outputs.version }}
+        run: |
+          set -euo pipefail
+          WORK=$(mktemp -d)
+          mkdir -p assets "$WORK/package"
+          npm pack "$SDK_PACKAGE@$VERSION" --pack-destination "$WORK"
+          tar -xzf "$WORK"/*.tgz -C "$WORK/package"
+          cd "$WORK/package/package"
+          npm install --omit=dev --no-audit --no-fund
+          node <<'NODE'
+          const fs = require('fs')
+          const pkg = require('./package.json')
+          pkg.bundledDependencies = [...new Set([
+            ...Object.keys(pkg.dependencies || {}),
+            ...Object.keys(pkg.optionalDependencies || {}),
+          ])].sort()
+          fs.writeFileSync('package.json', `${JSON.stringify(pkg, null, 2)}\n`)
+          NODE
+          # --ignore-scripts is required, not hygiene: the published package
+          # carries a `prepack` that runs `tsc` against sources the tarball does
+          # not ship, so a plain `npm pack` here fails outright.
+          npm pack --ignore-scripts --pack-destination "$GITHUB_WORKSPACE/assets"
+          ls -lh "$GITHUB_WORKSPACE/assets"
+
+      - name: Upload immutable artifact and fresh manifest
+        if: steps.skip.outputs.skip != 'true'
+        env:
+          OSS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+          OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT }}
+          OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
+          VERSION: ${{ steps.sdk.outputs.version }}
+        run: |
+          set -euo pipefail
+          test -n "${OSS_ACCESS_KEY_ID:-}" || { echo '::error::OSS secrets not configured'; exit 1; }
+          python3 -m pip install oss2 --quiet --break-system-packages 2>/dev/null || pip3 install oss2 --quiet --break-system-packages
+          python3 - <<'PY'
+          import glob, hashlib, json, os
+          import oss2
+
+          files = glob.glob('assets/*.tgz')
+          if len(files) != 1:
+              raise SystemExit(f'expected one bundled MCP SDK tarball, got: {files}')
+          path = files[0]
+          asset = os.path.basename(path)
+          with open(path, 'rb') as fh:
+              sha256 = hashlib.sha256(fh.read()).hexdigest()
+          endpoint = os.environ['OSS_ENDPOINT']
+          if not endpoint.startswith('http'):
+              endpoint = 'https://' + endpoint
+          auth = oss2.Auth(os.environ['OSS_ACCESS_KEY_ID'], os.environ['OSS_ACCESS_KEY_SECRET'])
+          bucket = oss2.Bucket(auth, endpoint, os.environ['OSS_BUCKET'])
+          version = os.environ['VERSION']
+          key = f'mcp-sdk/{version}/{asset}'
+          bucket.put_object_from_file(key, path, headers={'Cache-Control': 'public, max-age=31536000, immutable'})
+          manifest = json.dumps({'version': version, 'asset': asset, 'sha256': sha256}, indent=2).encode()
+          bucket.put_object('mcp-sdk/latest.json', manifest, headers={
+              'Cache-Control': 'no-cache, no-store, max-age=0',
+              'Content-Type': 'application/json',
+          })
+          print(f'published {key} ({sha256})')
+          PY
+
+      - name: Verify public manifest and artifact
+        if: steps.skip.outputs.skip != 'true'
+        env:
+          VERSION: ${{ steps.sdk.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Same bounded read-back as the pi job: the CDN is reachable from
+          # GitHub runners only most of the time, and a bare curl has no connect
+          # timeout.
           RETRY=(--connect-timeout 10 --max-time 60 --retry 3 --retry-delay 5 --retry-connrefused)
           MANIFEST=$(curl -fsSL "${RETRY[@]}" "$OSS_BASE/latest.json")
           echo "$MANIFEST" | node -e '

--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -17,9 +17,29 @@
  *
  * - `TEAMCLU_REMOTE_TOOLS_CMD` — JSON array, e.g.
  *       ["/path/to/amuxd", "remote-tools-mcp", "--sock=/path/amuxd.sock"]
- *   A stdio MCP server (newline-delimited JSON-RPC). When set, the extension
- *   spawns it, lists its tools, and registers each as a pi tool proxying
- *   tools/call. Unset ⇒ no bridge.
+ *   A stdio MCP server. When set, the extension connects to it, lists its
+ *   tools, and registers each as a pi tool proxying tools/call. Unset ⇒ no
+ *   bridge.
+ *
+ * - `TEAMCLU_MCP_SERVERS` — JSON object of the workspace's other MCP servers,
+ *   normalized by `pi_server_spec` (`pi_rpc/mod.rs`) into the two shapes
+ *   opencode understands:
+ *       { "<name>": { "type": "local",  "command": [...], "environment": {…} } }
+ *       { "<name>": { "type": "remote", "url": "…",       "headers": {…} } }
+ *
+ * - `TEAMCLU_MCP_CONFIG_PATH` — the `opencode.json` that payload came from,
+ *   watched so an edit re-bridges without restarting pi.
+ *
+ * - `TEAMCLU_MCP_TOOL_CACHE_DIR` — where each server's `tools/list` result is
+ *   cached, so session startup does not wait on a cold connection.
+ *
+ * ## MCP
+ *
+ * pi has no MCP of its own. This extension is the MCP client, built on the
+ * official `@modelcontextprotocol/sdk`, which `amuxd pi install` installs into
+ * this file's directory (`pi_install::mcp_sdk`). Local (stdio) and remote
+ * (streamable HTTP, falling back to SSE) servers are both supported, matching
+ * what opencode loads natively.
  *
  * ## Permission flow
  *
@@ -33,10 +53,15 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { spawn, type ChildProcess } from "node:child_process";
 
-// Loose ExtensionAPI typing: keeps this file dependency-free (the real types
-// live in @earendil-works/pi-coding-agent; runtime shape is what matters).
+// Loose ExtensionAPI typing: the real types live in
+// @earendil-works/pi-coding-agent, which is not a dependency of this directory
+// (only @modelcontextprotocol/sdk is) — runtime shape is what matters.
+/** What pi accepts back from a tool: `AgentToolResult.content` is
+ *  `(TextContent | ImageContent)[]`. */
+type PiToolContent =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
 type ToolCallEvent = {
   toolName: string;
   toolCallId: string;
@@ -73,7 +98,7 @@ type ExtensionAPI = {
       // ctx.ui, the MCP proxies ignore both.
       onUpdate?: unknown,
       ctx?: ExtensionContext,
-    ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }>;
+    ): Promise<{ content: PiToolContent[]; isError?: boolean }>;
   }): void;
   registerProvider(id: string, config: Record<string, unknown>): void;
 };
@@ -141,123 +166,6 @@ function summarize(toolName: string, input: Record<string, unknown>): string {
 }
 
 // ---------------------------------------------------------------------------
-// Minimal stdio MCP client (newline-delimited JSON-RPC, no deps)
-// ---------------------------------------------------------------------------
-
-class McpBridge {
-  private child: ChildProcess;
-  private nextId = 1;
-  private pending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();
-  private buffer = "";
-  /** First fatal error seen (spawn failure or child exit). Once set, every
-   *  request fails immediately instead of writing to a dead pipe. */
-  private failure: Error | null = null;
-
-  constructor(cmd: string[], env?: Record<string, string>) {
-    this.child = spawn(cmd[0], cmd.slice(1), {
-      stdio: ["pipe", "pipe", "inherit"],
-      env: env ? { ...process.env, ...env } : process.env,
-    });
-    this.child.stdout!.setEncoding("utf8");
-    this.child.stdout!.on("data", (chunk: string) => this.onData(chunk));
-    // A ChildProcess "error" event with NO listener is an uncaught exception in
-    // node — it takes the whole pi process down, before `host_ready` and before
-    // any response. That is how one stale entry in the workspace MCP config (a
-    // renamed binary, an absolute path from another machine) turned every
-    // session in that workspace into "pi exited before responding". Bridging is
-    // best-effort by design (`bridgeMcpServer` catches and carries on); this
-    // listener is what lets that catch ever run.
-    this.child.on("error", (e: unknown) => {
-      this.fail(e instanceof Error ? e : new Error(String(e)));
-    });
-    this.child.on("exit", (code, signal) => {
-      this.fail(
-        new Error(`MCP server "${cmd[0]}" exited (code=${code ?? "null"} signal=${signal ?? "null"})`),
-      );
-    });
-  }
-
-  /** Record the first fatal error and fail everything in flight. */
-  private fail(err: Error): void {
-    if (!this.failure) this.failure = err;
-    for (const p of this.pending.values()) p.reject(err);
-    this.pending.clear();
-  }
-
-  /** Kill the child and fail anything still in flight. Used when a server's
-   *  command changed or it was removed from the config. */
-  dispose(): void {
-    this.fail(new Error("MCP bridge disposed"));
-    try {
-      this.child.kill();
-    } catch {
-      // Already gone: nothing to do.
-    }
-  }
-
-  private onData(chunk: string): void {
-    this.buffer += chunk;
-    let idx: number;
-    while ((idx = this.buffer.indexOf("\n")) >= 0) {
-      const line = this.buffer.slice(0, idx).trim();
-      this.buffer = this.buffer.slice(idx + 1);
-      if (!line) continue;
-      try {
-        const msg = JSON.parse(line);
-        if (typeof msg.id === "number" && this.pending.has(msg.id)) {
-          const p = this.pending.get(msg.id)!;
-          this.pending.delete(msg.id);
-          if (msg.error) p.reject(new Error(msg.error.message ?? "MCP error"));
-          else p.resolve(msg.result);
-        }
-      } catch {
-        // non-JSON noise on stdout: ignore
-      }
-    }
-  }
-
-  request(method: string, params?: unknown, timeoutMs = 60_000): Promise<any> {
-    if (this.failure) return Promise.reject(this.failure);
-    const id = this.nextId++;
-    const payload = JSON.stringify({ jsonrpc: "2.0", id, method, params: params ?? {} });
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`MCP ${method} timed out`));
-      }, timeoutMs);
-      this.pending.set(id, {
-        resolve: (v) => {
-          clearTimeout(timer);
-          resolve(v);
-        },
-        reject: (e) => {
-          clearTimeout(timer);
-          reject(e);
-        },
-      });
-      try {
-        this.child.stdin!.write(payload + "\n");
-      } catch (e) {
-        // Dead pipe (child already gone): reject rather than throw out of the
-        // executor, so the caller sees a normal bridge failure.
-        this.pending.delete(id);
-        clearTimeout(timer);
-        reject(e instanceof Error ? e : new Error(String(e)));
-      }
-    });
-  }
-
-  notify(method: string, params?: unknown): void {
-    if (this.failure) return;
-    try {
-      this.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params: params ?? {} }) + "\n");
-    } catch {
-      // Same as `request`: a dead bridge is not a fatal condition.
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Team shared LLM provider
 // ---------------------------------------------------------------------------
 
@@ -313,15 +221,68 @@ function registerTeamProvider(pi: ExtensionAPI): void {
 }
 
 // ---------------------------------------------------------------------------
-// MCP server bridge (pi has no native MCP)
+// MCP client (official @modelcontextprotocol/sdk)
 // ---------------------------------------------------------------------------
 
-/** Resolve `${VAR}` / `$VAR` references in a server's environment map against
- *  the pi process env (which amuxd populated with team/personal secrets). */
-function resolveEnv(env: Record<string, unknown> | undefined): Record<string, string> {
+/**
+ * pi ships no MCP client — "**No MCP.** … or build an extension that adds MCP
+ * support" (pi's README). This section is that client: it connects to every
+ * server the workspace configures and republishes their tools as pi tools, so
+ * a workspace presents the same tool set on pi as it does on opencode.
+ *
+ * The SDK is installed next to this file by `amuxd pi install`
+ * (`pi_install::mcp_sdk`); pi resolves the bare import from
+ * `<cache>/pi/extensions/node_modules`. The import is dynamic and guarded on
+ * purpose: a missing SDK must cost MCP tools only, not the permission gate and
+ * the question tool that share this extension and have nothing to do with MCP.
+ */
+type Sdk = {
+  Client: any;
+  StdioClientTransport: any;
+  StreamableHTTPClientTransport: any;
+  SSEClientTransport: any;
+  ToolListChangedNotificationSchema: any;
+};
+
+const SDK_STATE: { promise: Promise<Sdk | null> | null } = ((globalThis as any).__teamcluMcpSdk ??= {
+  promise: null,
+});
+
+function loadSdk(): Promise<Sdk | null> {
+  SDK_STATE.promise ??= (async () => {
+    try {
+      const [client, stdio, streamable, sse, types] = await Promise.all([
+        import("@modelcontextprotocol/sdk/client/index.js"),
+        import("@modelcontextprotocol/sdk/client/stdio.js"),
+        import("@modelcontextprotocol/sdk/client/streamableHttp.js"),
+        import("@modelcontextprotocol/sdk/client/sse.js"),
+        import("@modelcontextprotocol/sdk/types.js"),
+      ]);
+      return {
+        Client: (client as any).Client,
+        StdioClientTransport: (stdio as any).StdioClientTransport,
+        StreamableHTTPClientTransport: (streamable as any).StreamableHTTPClientTransport,
+        SSEClientTransport: (sse as any).SSEClientTransport,
+        ToolListChangedNotificationSchema: (types as any).ToolListChangedNotificationSchema,
+      };
+    } catch (e) {
+      console.error(
+        "[teamclu] @modelcontextprotocol/sdk is not resolvable next to this extension; " +
+          `MCP tools are unavailable. Run \`amuxd pi install\` to repair. (${e})`,
+      );
+      return null;
+    }
+  })();
+  return SDK_STATE.promise as Promise<Sdk | null>;
+}
+
+/** `${VAR}` / `$VAR` against the pi process env (which amuxd populated with
+ *  team/personal secrets). Used for a local server's `environment` and for a
+ *  remote server's `headers`, which carry tokens the same way. */
+function resolveVars(raw: Record<string, unknown> | undefined): Record<string, string> {
   const out: Record<string, string> = {};
-  if (!env) return out;
-  for (const [k, v] of Object.entries(env)) {
+  if (!raw) return out;
+  for (const [k, v] of Object.entries(raw)) {
     if (typeof v !== "string") continue;
     out[k] = v.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (_m, a, b) => {
       const name = a || b;
@@ -330,6 +291,215 @@ function resolveEnv(env: Record<string, unknown> | undefined): Record<string, st
   }
   return out;
 }
+
+/**
+ * The environment a stdio server is spawned with.
+ *
+ * The SDK defaults to `getDefaultEnvironment()` — a small allow-list — where
+ * this extension previously spawned children with the full `process.env`. That
+ * difference is not cosmetic: amuxd injects the team API key, provider
+ * credentials and an enriched PATH into pi's environment, and every one of
+ * them would vanish from MCP servers under the SDK default.
+ */
+function childEnv(environment: Record<string, unknown> | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return { ...out, ...resolveVars(environment) };
+}
+
+type LocalServerSpec = {
+  type?: "local";
+  command: string[];
+  environment?: Record<string, unknown>;
+};
+type RemoteServerSpec = {
+  type: "remote";
+  url: string;
+  headers?: Record<string, unknown>;
+};
+type McpServerSpec = LocalServerSpec | RemoteServerSpec;
+
+function isRemote(spec: McpServerSpec): spec is RemoteServerSpec {
+  return (spec as RemoteServerSpec).type === "remote";
+}
+
+type McpTool = { name: string; description?: string; inputSchema?: unknown };
+
+/** Cap on `tools/list` pages, so a server that always returns a cursor cannot
+ *  hang session startup. */
+const MAX_TOOL_PAGES = 50;
+
+/** One connected MCP server. */
+class McpBridge {
+  private constructor(
+    readonly client: any,
+    readonly label: string,
+  ) {}
+
+  static async connect(label: string, spec: McpServerSpec, sdk: Sdk): Promise<McpBridge> {
+    const make = () =>
+      new sdk.Client({ name: "teamclu-pi-extension", version: "1.0.0" }, { capabilities: {} });
+    if (isRemote(spec)) {
+      const url = new URL(spec.url);
+      const requestInit = { headers: resolveVars(spec.headers) };
+      try {
+        const client = make();
+        await client.connect(new sdk.StreamableHTTPClientTransport(url, { requestInit }));
+        return new McpBridge(client, label);
+      } catch (e) {
+        // Servers that only speak the older HTTP+SSE transport reject the
+        // streamable POST. A fresh Client per attempt: one whose connect threw
+        // already holds a dead transport.
+        const client = make();
+        await client.connect(new sdk.SSEClientTransport(url, { requestInit }));
+        console.error(`[teamclu] MCP ${label}: streamable HTTP failed, using SSE (${e})`);
+        return new McpBridge(client, label);
+      }
+    }
+    const [command, ...args] = spec.command;
+    const client = make();
+    await client.connect(
+      new sdk.StdioClientTransport({
+        command,
+        args,
+        env: childEnv(spec.environment),
+        // The server's own stderr belongs in pi's, which amuxd captures.
+        stderr: "inherit",
+      }),
+    );
+    return new McpBridge(client, label);
+  }
+
+  /** Every tool, following `nextCursor`. Servers with more tools than one page
+   *  used to silently expose only the first page. */
+  async listTools(): Promise<McpTool[]> {
+    const tools: McpTool[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < MAX_TOOL_PAGES; page++) {
+      const result = await this.client.listTools(cursor ? { cursor } : {});
+      for (const tool of result?.tools ?? []) {
+        if (tool && typeof tool.name === "string") tools.push(tool);
+      }
+      cursor = result?.nextCursor;
+      if (!cursor) return tools;
+    }
+    console.error(`[teamclu] MCP ${this.label}: stopped paginating tools after ${MAX_TOOL_PAGES} pages`);
+    return tools;
+  }
+
+  onToolListChanged(sdk: Sdk, handler: () => void): void {
+    try {
+      this.client.setNotificationHandler(sdk.ToolListChangedNotificationSchema, () => handler());
+    } catch (e) {
+      // A server that never sends the notification is normal; a client that
+      // cannot register the handler is not fatal either.
+      console.error(`[teamclu] MCP ${this.label}: tools/list_changed handler unavailable (${e})`);
+    }
+  }
+
+  callTool(name: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<any> {
+    return this.client.callTool({ name, arguments: args ?? {} }, undefined, {
+      signal,
+      // A tool that reports progress is working, not stuck.
+      resetTimeoutOnProgress: true,
+    });
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.client.close();
+    } catch {
+      // Already gone: nothing to do.
+    }
+  }
+}
+
+/** MCP tool result → pi tool result content. */
+function toPiContent(result: any): PiToolContent[] {
+  const out: PiToolContent[] = [];
+  for (const part of Array.isArray(result?.content) ? result.content : []) {
+    if (!part || typeof part !== "object") continue;
+    if (part.type === "text" && typeof part.text === "string") {
+      out.push({ type: "text", text: part.text });
+    } else if (part.type === "image" && typeof part.data === "string") {
+      // pi accepts image content in tool results and normalizes oversized ones
+      // (`normalizeToolResultImages`, which names MCP bridges as a source).
+      // Stringifying these — what this bridge used to do — turned a screenshot
+      // into a wall of base64 JSON.
+      out.push({ type: "image", data: part.data, mimeType: part.mimeType || "image/png" });
+    } else if (part.type === "resource" && typeof part.resource?.text === "string") {
+      out.push({ type: "text", text: part.resource.text });
+    } else {
+      out.push({ type: "text", text: JSON.stringify(part) });
+    }
+  }
+  if (out.length === 0 && result?.structuredContent !== undefined) {
+    out.push({ type: "text", text: JSON.stringify(result.structuredContent) });
+  }
+  if (out.length === 0) out.push({ type: "text", text: JSON.stringify(result ?? null) });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tool names
+// ---------------------------------------------------------------------------
+
+/** Names the model is allowed to call: providers reject anything else, and pi
+ *  keys its tool registry by name. */
+function sanitizeToolName(name: string): string {
+  const safe = name.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 64);
+  return safe.length > 0 ? safe : "tool";
+}
+
+/** Which `<label>:<tool>` currently owns a registered name. Process-wide for
+ *  the same reason the bridge registry is: pi re-runs this extension's entry
+ *  point per session, and a name must resolve to the same server every time. */
+const TOOL_OWNERS: Map<string, string> = ((globalThis as any).__teamcluMcpToolOwners ??= new Map());
+
+/**
+ * The name a server's tool is registered under.
+ *
+ * Identity for the common case — `browser_click` stays `browser_click`, so
+ * skills and prompts that name a tool keep working. Only an actual clash with
+ * a different server takes the qualified name, and the first claimant is never
+ * renamed, which keeps the outcome independent of registration order.
+ */
+function registeredName(label: string, original: string): string {
+  const owner = `${label}:${original}`;
+  const base = sanitizeToolName(original);
+  const held = TOOL_OWNERS.get(base);
+  if (held === undefined || held === owner) {
+    TOOL_OWNERS.set(base, owner);
+    return base;
+  }
+  for (const candidate of [
+    sanitizeToolName(`${label}_${original}`),
+    ...Array.from({ length: 8 }, (_, i) => sanitizeToolName(`${label}_${original}_${i + 2}`)),
+  ]) {
+    const owned = TOOL_OWNERS.get(candidate);
+    if (owned === undefined || owned === owner) {
+      TOOL_OWNERS.set(candidate, owner);
+      return candidate;
+    }
+  }
+  console.error(`[teamclu] MCP ${label}: cannot find a free name for tool ${original}`);
+  return base;
+}
+
+/** Give up the names a server held, so a renamed or removed server does not
+ *  keep pushing its replacement into a qualified name forever. */
+function releaseToolNames(label: string): void {
+  const prefix = `${label}:`;
+  for (const [name, owner] of [...TOOL_OWNERS]) {
+    if (owner.startsWith(prefix)) TOOL_OWNERS.delete(name);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bridge registry
+// ---------------------------------------------------------------------------
 
 /**
  * Process-wide MCP bridge registry.
@@ -353,14 +523,12 @@ function resolveEnv(env: Record<string, unknown> | undefined): Record<string, st
  * would give the module fresh state, and re-import is exactly the case this has
  * to survive.
  */
-type McpTool = { name: string; description?: string; inputSchema?: unknown };
-
 type BridgeEntry = {
-  /** Resolves once the child has completed the MCP handshake. Held as a
+  /** Resolves once the client has completed the MCP handshake. Held as a
    *  promise, not a value, because a cache hit registers tools before the
-   *  child is even spawned. */
+   *  connection is even attempted. */
   ready: Promise<McpBridge>;
-  /** The command that produced this bridge; a change means respawn. */
+  /** The spec that produced this bridge; a change means reconnect. */
   signature: string;
   tools: McpTool[];
   /** `tools` came from the on-disk cache and no live `tools/list` has
@@ -371,8 +539,10 @@ type BridgeEntry = {
 const BRIDGE_REGISTRY: Map<string, BridgeEntry> = ((globalThis as any).__teamcluMcpBridges ??=
   new Map());
 
-function bridgeSignature(cmd: string[], env?: Record<string, string>): string {
-  return JSON.stringify([cmd, env ?? {}]);
+function bridgeSignature(spec: McpServerSpec): string {
+  return isRemote(spec)
+    ? JSON.stringify(["remote", spec.url, spec.headers ?? {}])
+    : JSON.stringify(["local", spec.command, spec.environment ?? {}]);
 }
 
 // ---------------------------------------------------------------------------
@@ -384,8 +554,8 @@ function bridgeSignature(cmd: string[], env?: Record<string, string>): string {
  *
  * pi cannot start a session until the extension's entry point returns, and the
  * entry point cannot register a server's tools until `tools/list` answers —
- * which means spawning the child and completing the MCP handshake first. Timed
- * inside pi on this machine, that is where the cold first message goes:
+ * which means connecting first. Timed inside pi on this machine, that is where
+ * the cold first message goes:
  *
  *   pi boot -> extension loaded    1.05s
  *   remote-tools bridge            0.03s
@@ -396,9 +566,9 @@ function bridgeSignature(cmd: string[], env?: Record<string, string>): string {
  *   entry done                     5.33s
  *
  * The tool list is the only part the entry point actually needs, and it barely
- * changes between runs. Cached on disk it registers instantly and the child is
- * spawned in the background, taking the slowest server off the critical path.
- * A tool call that arrives before its child is ready simply awaits `ready`.
+ * changes between runs. Cached on disk it registers instantly and the client
+ * connects in the background, taking the slowest server off the critical path.
+ * A tool call that arrives before its bridge is ready simply awaits `ready`.
  */
 const TOOL_CACHE_DIR = process.env.TEAMCLU_MCP_TOOL_CACHE_DIR;
 
@@ -425,7 +595,7 @@ function readToolCache(label: string, signature: string): McpTool[] | null {
   try {
     const parsed = JSON.parse(fs.readFileSync(p, "utf8"));
     // The signature is stored as well as hashed: a hash collision, or a stale
-    // file from an older command, must miss rather than register wrong tools.
+    // file from an older spec, must miss rather than register wrong tools.
     if (parsed?.signature !== signature) return null;
     const tools = parsed?.tools;
     if (!Array.isArray(tools) || tools.length === 0) return null;
@@ -439,48 +609,45 @@ function writeToolCache(label: string, signature: string, tools: McpTool[]): voi
   const p = cachePath(label, signature);
   if (!p || tools.length === 0) return;
   try {
-    fs.writeFileSync(p, JSON.stringify({ signature, tools }));
+    // Only the fields registration needs; annotations and the rest would bloat
+    // the file without changing what gets registered.
+    const slim = tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    }));
+    fs.writeFileSync(p, JSON.stringify({ signature, tools: slim }));
   } catch (e) {
     console.error(`[teamclu] MCP tool cache write failed (${label}): ${e}`);
   }
 }
 
-/** Spawn the child and complete the MCP handshake. */
+/** Connect and list, or throw. */
 async function handshake(
-  cmd: string[],
-  env?: Record<string, string>,
+  label: string,
+  spec: McpServerSpec,
+  sdk: Sdk,
 ): Promise<{ bridge: McpBridge; tools: McpTool[] }> {
-  const bridge = new McpBridge(cmd, env);
+  const bridge = await McpBridge.connect(label, spec, sdk);
   try {
-    await bridge.request("initialize", {
-      protocolVersion: "2024-11-05",
-      capabilities: {},
-      clientInfo: { name: "teamclu-pi-extension", version: "1.0.0" },
-    });
-    bridge.notify("notifications/initialized");
-    const listed = await bridge.request("tools/list");
-    return { bridge, tools: listed?.tools ?? [] };
+    return { bridge, tools: await bridge.listTools() };
   } catch (e) {
-    bridge.dispose(); // never leak a child whose handshake failed
+    void bridge.close(); // never leak a connection whose listing failed
     throw e;
   }
 }
 
 /**
- * Get a bridge entry for `label`, spawning only when there is not already one
- * with the same command. A changed command tears the old child down first —
- * that is what makes an MCP config edit take effect without restarting pi.
+ * Get a bridge entry for `label`, connecting only when there is not already one
+ * with the same spec. A changed spec tears the old one down first — that is
+ * what makes an MCP config edit take effect without restarting pi.
  *
  * Returns as soon as a tool list is known: from the live registry, from the
- * on-disk cache (child spawning in the background), or — only on the very
- * first run for a given command — from a full handshake.
+ * on-disk cache (connecting in the background), or — only on the very first run
+ * for a given spec — from a full handshake.
  */
-async function ensureBridge(
-  label: string,
-  cmd: string[],
-  env?: Record<string, string>,
-): Promise<BridgeEntry> {
-  const signature = bridgeSignature(cmd, env);
+async function ensureBridge(label: string, spec: McpServerSpec, sdk: Sdk): Promise<BridgeEntry> {
+  const signature = bridgeSignature(spec);
   const existing = BRIDGE_REGISTRY.get(label);
   if (existing) {
     if (existing.signature === signature) return existing;
@@ -488,9 +655,27 @@ async function ensureBridge(
     BRIDGE_REGISTRY.delete(label);
   }
 
+  const watchToolList = (entry: BridgeEntry, bridge: McpBridge) => {
+    bridge.onToolListChanged(sdk, () => {
+      void bridge
+        .listTools()
+        .then((tools) => {
+          entry.tools = tools;
+          entry.provisional = false;
+          writeToolCache(label, signature, tools);
+          // Newly announced tools have to be registered on the extension
+          // instance that is live now; the one this bridge was created from
+          // may belong to a session that has since ended.
+          const target = WATCH_STATE.target;
+          if (target) registerBridgeTools(target.pi, target.ownTools, label, entry);
+        })
+        .catch((e) => console.error(`[teamclu] MCP ${label}: tools/list_changed refresh failed: ${e}`));
+    });
+  };
+
   const cached = readToolCache(label, signature);
   if (cached) {
-    const pending = handshake(cmd, env);
+    const pending = handshake(label, spec, sdk);
     const entry: BridgeEntry = {
       ready: pending.then((r) => r.bridge),
       signature,
@@ -501,10 +686,11 @@ async function ensureBridge(
     // Derived chain, so `entry.ready` keeps its own rejection for awaiting
     // tool calls instead of being swallowed here.
     void pending.then(
-      ({ tools }) => {
+      ({ bridge, tools }) => {
         entry.tools = tools;
         entry.provisional = false;
         writeToolCache(label, signature, tools);
+        watchToolList(entry, bridge);
       },
       (e) => {
         // Drop the entry so the next session retries rather than inheriting a
@@ -516,7 +702,7 @@ async function ensureBridge(
     return entry;
   }
 
-  const { bridge, tools } = await handshake(cmd, env);
+  const { bridge, tools } = await handshake(label, spec, sdk);
   writeToolCache(label, signature, tools);
   const entry: BridgeEntry = {
     ready: Promise.resolve(bridge),
@@ -525,13 +711,17 @@ async function ensureBridge(
     provisional: false,
   };
   BRIDGE_REGISTRY.set(label, entry);
+  watchToolList(entry, bridge);
   return entry;
 }
 
 function disposeEntry(entry: BridgeEntry): void {
-  // The child may still be starting; dispose when it lands either way.
+  // The connection may still be opening; close it when it lands either way.
   void entry.ready.then(
-    (b) => b.dispose(),
+    (b) => {
+      releaseToolNames(b.label);
+      void b.close();
+    },
     () => {},
   );
 }
@@ -545,13 +735,11 @@ function disposeRemovedBridges(configured: Set<string>): void {
   }
 }
 
-type McpServerSpec = { command: string[]; environment?: Record<string, unknown> };
-
 /**
  * Read the workspace MCP config the same way amuxd does when it builds
- * `TEAMCLU_MCP_SERVERS` (`mcp_servers_from_value` in `pi_rpc/mod.rs`): skip the
- * daemon's own remote-tools entry, skip `type: "remote"` and `enabled: false`,
- * and require a non-empty string `command` array.
+ * `TEAMCLU_MCP_SERVERS` (`pi_server_spec` in `pi_rpc/mod.rs`): skip the
+ * daemon's own remote-tools entry and `enabled: false`; a `type: "remote"`
+ * entry needs a URL, anything else needs a non-empty string `command` array.
  *
  * Kept deliberately in sync with the Rust side — the env payload is a snapshot
  * of this file at spawn, so a watcher re-reading it must apply the same rules
@@ -576,21 +764,32 @@ function readMcpServers(configPath: string): Record<string, McpServerSpec> | nul
   const out: Record<string, McpServerSpec> = {};
   for (const [name, raw] of Object.entries(mcp)) {
     if (name === "amuxd-remote-tools") continue;
-    const spec = raw as any;
-    if (!spec || typeof spec !== "object") continue;
-    if (spec.type === "remote") continue;
-    if (spec.enabled === false) continue;
-    const cmd = spec.command;
-    if (!Array.isArray(cmd) || cmd.length === 0 || !cmd.every((c: unknown) => typeof c === "string")) {
-      continue;
-    }
-    out[name] = { command: cmd as string[], environment: spec.environment };
+    const spec = normalizeServerSpec(raw);
+    if (spec) out[name] = spec;
   }
   return out;
 }
 
-/** Bring the live bridges in line with `servers`: drop what is gone, spawn what
- *  is new, leave unchanged ones alone (the registry decides by signature). */
+/** One config entry (from the env payload or a config reload) → a spec, or
+ *  null when it cannot be bridged. */
+function normalizeServerSpec(raw: unknown): McpServerSpec | null {
+  const spec = raw as any;
+  if (!spec || typeof spec !== "object") return null;
+  if (spec.enabled === false) return null;
+  if (spec.type === "remote") {
+    return typeof spec.url === "string" && spec.url.length > 0
+      ? { type: "remote", url: spec.url, headers: spec.headers }
+      : null;
+  }
+  const cmd = spec.command;
+  if (!Array.isArray(cmd) || cmd.length === 0 || !cmd.every((c: unknown) => typeof c === "string")) {
+    return null;
+  }
+  return { type: "local", command: cmd as string[], environment: spec.environment };
+}
+
+/** Bring the live bridges in line with `servers`: drop what is gone, connect
+ *  what is new, leave unchanged ones alone (the registry decides by signature). */
 async function reconcileBridges(
   pi: ExtensionAPI,
   ownTools: Set<string>,
@@ -599,11 +798,7 @@ async function reconcileBridges(
   const names = Object.keys(servers);
   // "remote-tools" is bridged from its own env contract, not from this file.
   disposeRemovedBridges(new Set([...names, "remote-tools"]));
-  await Promise.all(
-    names.map((name) =>
-      bridgeMcpServer(pi, ownTools, name, servers[name].command, resolveEnv(servers[name].environment)),
-    ),
-  );
+  await Promise.all(names.map((name) => bridgeMcpServer(pi, ownTools, name, servers[name])));
 }
 
 /**
@@ -663,46 +858,56 @@ function ensureMcpConfigWatcher(): void {
   }
 }
 
-/** Reuse (or spawn) one stdio MCP server and register its tools on `pi`.
+/** Register (or re-register) every tool a bridge currently exposes. Safe to
+ *  call repeatedly: the name a tool gets is stable for its server. */
+function registerBridgeTools(
+  pi: ExtensionAPI,
+  ownTools: Set<string>,
+  label: string,
+  entry: BridgeEntry,
+): void {
+  for (const tool of entry.tools) {
+    const name = registeredName(label, tool.name);
+    ownTools.add(name);
+    pi.registerTool({
+      name,
+      label: name,
+      description: tool.description ?? `TeamClu MCP tool ${tool.name} (${label})`,
+      // MCP inputSchema is plain JSON Schema; pi's TypeBox parameters are
+      // JSON Schema objects at runtime, so pass it through directly.
+      parameters: tool.inputSchema ?? { type: "object", properties: {} },
+      async execute(_toolCallId, params, signal) {
+        // A server can drop a tool at runtime (`tools/list_changed`). pi has no
+        // unregister, so the registration outlives the tool: answer honestly
+        // instead of calling a name the server no longer knows.
+        if (!entry.tools.some((t) => t.name === tool.name)) {
+          return {
+            content: [{ type: "text" as const, text: `MCP tool ${tool.name} is no longer offered by ${label}.` }],
+            isError: true,
+          };
+        }
+        // On a cached start the connection may still be opening; this is the
+        // only place that waits for it, and only when a tool is actually used.
+        const bridge = await entry.ready;
+        const result = await bridge.callTool(tool.name, params ?? {}, signal);
+        return { content: toPiContent(result), isError: result?.isError === true };
+      },
+    });
+  }
+}
+
+/** Reuse (or open) one MCP server and register its tools on `pi`.
  *  Best-effort: a failed server never breaks the others. */
 async function bridgeMcpServer(
   pi: ExtensionAPI,
   ownTools: Set<string>,
   label: string,
-  cmd: string[],
-  env?: Record<string, string>,
+  spec: McpServerSpec,
 ): Promise<void> {
+  const sdk = await loadSdk();
+  if (!sdk) return; // already reported once by loadSdk
   try {
-    const entry = await ensureBridge(label, cmd, env);
-    for (const tool of entry.tools) {
-      ownTools.add(tool.name);
-      pi.registerTool({
-        name: tool.name,
-        label: tool.name,
-        description: tool.description ?? `TeamClu MCP tool ${tool.name} (${label})`,
-        // MCP inputSchema is plain JSON Schema; pi's TypeBox parameters are
-        // JSON Schema objects at runtime, so pass it through directly.
-        parameters: tool.inputSchema ?? { type: "object", properties: {} },
-        async execute(_toolCallId, params) {
-          // On a cached start the child may still be handshaking; this is the
-          // only place that waits for it, and only when a tool is actually used.
-          const bridge = await entry.ready;
-          const result = await bridge.request("tools/call", {
-            name: tool.name,
-            arguments: params ?? {},
-          });
-          const content = Array.isArray(result?.content)
-            ? result.content
-                .filter((c: any) => c?.type === "text" && typeof c.text === "string")
-                .map((c: any) => ({ type: "text" as const, text: c.text }))
-            : [];
-          return {
-            content: content.length ? content : [{ type: "text" as const, text: JSON.stringify(result ?? null) }],
-            isError: result?.isError === true,
-          };
-        },
-      });
-    }
+    registerBridgeTools(pi, ownTools, label, await ensureBridge(label, spec, sdk));
   } catch (e) {
     // Bridge is best-effort: pi still works without this server's tools.
     console.error(`[teamclu] MCP bridge unavailable (${label}): ${e}`);
@@ -880,7 +1085,7 @@ export default async function (pi: ExtensionAPI) {
     try {
       const cmd = JSON.parse(cmdRaw);
       if (Array.isArray(cmd) && cmd.length > 0 && cmd.every((c) => typeof c === "string")) {
-        await bridgeMcpServer(pi, ownTools, "remote-tools", cmd);
+        await bridgeMcpServer(pi, ownTools, "remote-tools", { type: "local", command: cmd });
       }
     } catch (e) {
       console.error(`[teamclu] invalid TEAMCLU_REMOTE_TOOLS_CMD: ${e}`);
@@ -888,8 +1093,10 @@ export default async function (pi: ExtensionAPI) {
   }
 
   // 2) The workspace's other MCP servers (from opencode.json `mcp`), bridged so
-  //    pi gets the same tools opencode loads natively. Payload:
-  //    { "<name>": { "command": [...], "environment": {...} }, ... }
+  //    pi gets the same tools opencode loads natively — local and remote alike,
+  //    normalized by amuxd into:
+  //    { "<name>": { "type": "local",  "command": [...], "environment": {…} } }
+  //    { "<name>": { "type": "remote", "url": "…",       "headers": {…} } }
   // Point the config watcher at this session's instance BEFORE bridging, and
   // unconditionally — including when nothing is configured yet. Doing it inside
   // the "has servers" branch below would mean a workspace that starts with no
@@ -900,7 +1107,7 @@ export default async function (pi: ExtensionAPI) {
 
   const serversRaw = process.env.TEAMCLU_MCP_SERVERS;
   if (serversRaw) {
-    let servers: Record<string, { command?: unknown; environment?: Record<string, unknown> }>;
+    let servers: Record<string, unknown>;
     try {
       servers = JSON.parse(serversRaw);
     } catch (e) {
@@ -909,16 +1116,16 @@ export default async function (pi: ExtensionAPI) {
     }
     const valid: Record<string, McpServerSpec> = {};
     for (const [name, spec] of Object.entries(servers)) {
-      const cmd = spec?.command;
-      if (Array.isArray(cmd) && cmd.length > 0 && cmd.every((c) => typeof c === "string")) {
-        valid[name] = { command: cmd as string[], environment: spec.environment };
-      }
+      // Same normalizer the config watcher uses, so a server accepted at spawn
+      // and a server accepted on reload can never disagree.
+      const normalized = normalizeServerSpec(spec);
+      if (normalized) valid[name] = normalized;
     }
     // Drops servers that are no longer configured before adding the rest (so an
     // edit that replaces one server with another does not leave both running),
-    // then spawns in parallel. Only the FIRST session in this process pays a
-    // spawn at all — later ones reuse the registry — but that first one used to
-    // pay for every server end to end, ~4s each for the npx-based ones.
+    // then connects in parallel. Only the FIRST session in this process pays a
+    // connection at all — later ones reuse the registry — but that first one
+    // used to pay for every server end to end, ~4s each for the npx-based ones.
     await reconcileBridges(pi, ownTools, valid);
   }
 }

--- a/apps/daemon/pi.lock.json
+++ b/apps/daemon/pi.lock.json
@@ -1,3 +1,4 @@
 {
-  "version": "0.84.2"
+  "version": "0.84.2",
+  "mcpSdkVersion": "1.30.0"
 }

--- a/apps/daemon/src/pi_install/mcp_sdk.rs
+++ b/apps/daemon/src/pi_install/mcp_sdk.rs
@@ -1,0 +1,250 @@
+//! `@modelcontextprotocol/sdk` install for the TeamClu pi extension.
+//!
+//! pi ships no MCP client ("**No MCP.** … or build an extension that adds MCP
+//! support" — pi's own README), so `assets/pi-extension/teamclu.ts` is the MCP
+//! client: it connects to every configured server and republishes their tools
+//! as pi tools. That file imports the official SDK, and pi resolves an
+//! extension's bare imports from a `node_modules/` next to it
+//! (`docs/extensions.md`: "Add a package.json next to your extension … and
+//! imports from node_modules/ are resolved automatically").
+//!
+//! So the SDK is installed into the directory the extension is materialized to
+//! — `<cache>/pi/extensions/` — and is treated as part of the pi install
+//! rather than an optional extra: without it there is no remote-tools bridge
+//! and no workspace MCP at all.
+//!
+//! Mainland users get the same OSS fallback pi itself has: when the official
+//! registry is unreachable, a dependency-bundled tarball is downloaded from
+//! `https://teamclaw.ucar.cc/mcp-sdk` (published by
+//! `.github/workflows/mirror-pi-oss.yml`) and installed with `npm --offline`.
+
+use std::path::PathBuf;
+
+use super::{
+    command_with_runtime_path, has_command, mirrored_bundle, official_registry_available, progress,
+    required_mcp_sdk_version,
+};
+use crate::opencode_install::version_ge;
+
+pub(super) const NPM_PKG: &str = "@modelcontextprotocol/sdk";
+const MIRROR_BASE: &str = "https://teamclaw.ucar.cc/mcp-sdk";
+
+/// The directory the extension is materialized into. npm installs here, and
+/// pi's loader resolves the extension's imports from `<here>/node_modules`.
+pub fn deps_dir() -> PathBuf {
+    crate::runtime::pi_rpc::process::extension_dir()
+}
+
+fn sdk_package_json_path() -> PathBuf {
+    deps_dir()
+        .join("node_modules")
+        .join("@modelcontextprotocol")
+        .join("sdk")
+        .join("package.json")
+}
+
+/// The manifest that makes `<cache>/pi/extensions/` an npm root. Written before
+/// installing so npm has a project to install into, and kept afterwards so a
+/// user can repair the tree by hand with a plain `npm install` there.
+pub fn package_json(version: &str) -> String {
+    format!(
+        r#"{{
+  "name": "teamclu-pi-extension",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "amuxd-managed directory: teamclu.ts is materialized here and its npm dependencies live in ./node_modules. Edits are overwritten.",
+  "dependencies": {{
+    "{NPM_PKG}": "{version}"
+  }},
+  "pi": {{
+    "extensions": ["./teamclu.ts"]
+  }}
+}}
+"#
+    )
+}
+
+/// Write the manifest when it is missing or out of date. Same "only on change"
+/// rule the extension itself uses, so mtimes stay stable across spawns.
+pub fn materialize_package_json() -> std::io::Result<Option<PathBuf>> {
+    let want = required_mcp_sdk_version();
+    if want.is_empty() {
+        return Ok(None);
+    }
+    let dir = deps_dir();
+    let path = dir.join("package.json");
+    let content = package_json(&want);
+    if std::fs::read_to_string(&path).unwrap_or_default() != content {
+        std::fs::create_dir_all(&dir)?;
+        std::fs::write(&path, &content)?;
+    }
+    Ok(Some(path))
+}
+
+/// `version` out of an npm package manifest.
+fn version_of_manifest(body: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    let version = value.get("version")?.as_str()?.trim();
+    (!version.is_empty()).then(|| version.to_string())
+}
+
+/// The SDK version currently installed next to the extension, if any.
+pub fn installed_version() -> Option<String> {
+    version_of_manifest(&std::fs::read_to_string(sdk_package_json_path()).ok()?)
+}
+
+/// True when the installed SDK satisfies the lock (or the lock pins nothing).
+pub fn satisfied() -> bool {
+    let want = required_mcp_sdk_version();
+    if want.is_empty() {
+        return true;
+    }
+    installed_version()
+        .map(|have| version_ge(&have, &want))
+        .unwrap_or(false)
+}
+
+/// Install or upgrade the SDK into the extension directory.
+///
+/// Runs as part of `pi_install::run_install`; safe to call on its own.
+pub fn run_install(force: bool) -> anyhow::Result<()> {
+    let want = required_mcp_sdk_version();
+    if want.is_empty() {
+        return Ok(());
+    }
+    if !force {
+        if let Some(have) = installed_version() {
+            if version_ge(&have, &want) {
+                progress(
+                    "ok",
+                    &format!("MCP SDK {have} already satisfies >= {want} (pi extension)"),
+                );
+                return Ok(());
+            }
+        }
+    }
+
+    // npm only: the offline fallback installs a tarball, which bun cannot
+    // consume the same way (the pi install path makes the same call).
+    if !has_command("npm") {
+        anyhow::bail!("npm not found; the pi MCP bridge needs npm to install {NPM_PKG}");
+    }
+
+    let dir = deps_dir();
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| anyhow::anyhow!("cannot create {}: {e}", dir.display()))?;
+    materialize_package_json()
+        .map_err(|e| anyhow::anyhow!("cannot write the pi extension package.json: {e}"))?;
+    let prefix = dir.to_string_lossy().to_string();
+
+    let (spec, offline, _bundle) = if official_registry_available(NPM_PKG, &want) {
+        progress(
+            "source",
+            "official npm registry is reachable; installing the MCP SDK from upstream",
+        );
+        (format!("{NPM_PKG}@{want}"), false, None)
+    } else {
+        let bundle = mirrored_bundle("MCP SDK", MIRROR_BASE, &want)?;
+        let path = bundle.path().to_string_lossy().to_string();
+        (path, true, Some(bundle))
+    };
+
+    let mut args: Vec<String> = vec![
+        "install".into(),
+        "--prefix".into(),
+        prefix,
+        "--no-audit".into(),
+        "--no-fund".into(),
+        "--omit=dev".into(),
+        // npm rewrites the manifest's dependency range on install. Without
+        // this it writes `^1.30.0` over the exact pin, and the next spawn
+        // rewrites it back — a file that churns on every launch for no reason.
+        "--save-exact".into(),
+    ];
+    if offline {
+        args.push("--offline".into());
+    }
+    args.push(spec);
+
+    progress("install", &format!("running npm {}", args.join(" ")));
+    let output = command_with_runtime_path("npm")
+        .args(args.iter().map(String::as_str))
+        .output()
+        .map_err(|e| anyhow::anyhow!("failed to run npm: {e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !output.status.success() {
+        anyhow::bail!(
+            "MCP SDK install failed ({}): {}",
+            output.status,
+            if stderr.is_empty() { stdout } else { stderr }
+        );
+    }
+    // An `--offline` install of a bundled tarball can succeed while resolving
+    // to a different version than the manifest asked for; check the tree, not
+    // npm's exit code.
+    match installed_version() {
+        Some(have) if version_ge(&have, &want) => {
+            progress(
+                "ok",
+                &format!("MCP SDK {have} installed (require >= {want})"),
+            );
+            Ok(())
+        }
+        Some(have) => anyhow::bail!("MCP SDK install produced {have}, but {want} is required"),
+        None => anyhow::bail!(
+            "MCP SDK install reported success but {} is missing",
+            sdk_package_json_path().display()
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_json_pins_the_locked_version_and_points_pi_at_the_extension() {
+        let manifest = package_json("1.30.0");
+        let parsed: serde_json::Value = serde_json::from_str(&manifest).unwrap();
+        assert_eq!(
+            parsed["dependencies"]["@modelcontextprotocol/sdk"],
+            serde_json::json!("1.30.0")
+        );
+        // Exact pin, not a caret range: the extension is written against a
+        // known client API and the OSS mirror serves exactly one version.
+        assert!(!manifest.contains("^1"), "must not widen to a range");
+        assert_eq!(
+            parsed["pi"]["extensions"],
+            serde_json::json!(["./teamclu.ts"])
+        );
+        assert_eq!(parsed["private"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn deps_dir_is_where_the_extension_is_materialized() {
+        // pi resolves an extension's imports from a node_modules next to it;
+        // installing anywhere else silently yields "no MCP servers". Both
+        // paths derive from HOME, so hold the lock the HOME-mutating tests use
+        // rather than race one of them between the two calls.
+        let _lock = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let extension = crate::runtime::pi_rpc::process::extension_path();
+        assert_eq!(deps_dir(), extension.parent().unwrap());
+    }
+
+    #[test]
+    fn version_is_read_from_the_installed_manifest() {
+        assert_eq!(
+            version_of_manifest(r#"{"name":"@modelcontextprotocol/sdk","version":"1.30.0"}"#)
+                .as_deref(),
+            Some("1.30.0")
+        );
+        // A half-written or version-less manifest must read as "not installed"
+        // so the next `pi install` repairs it, not as a satisfied requirement.
+        assert_eq!(version_of_manifest(r#"{"version":""}"#), None);
+        assert_eq!(version_of_manifest("{"), None);
+    }
+}

--- a/apps/daemon/src/pi_install/mod.rs
+++ b/apps/daemon/src/pi_install/mod.rs
@@ -319,9 +319,21 @@ pub(super) fn safe_mirror_asset(asset: &str) -> bool {
     !asset.is_empty() && !asset.contains('/') && !asset.contains('\\') && asset.ends_with(".tgz")
 }
 
+/// Install or upgrade the whole pi runtime: the agent itself, then the MCP SDK
+/// its extension needs.
+///
+/// The two steps are separate functions rather than one body because
+/// `ensure_pi` returns early on every "nothing to do" path, and an early return
+/// there used to skip the SDK — which is the path *every existing install*
+/// takes, so the bridge silently never appeared.
+pub fn run_install(force: bool) -> anyhow::Result<()> {
+    ensure_pi(force)?;
+    mcp_sdk::run_install(force)
+}
+
 /// Install or upgrade pi via `npm install -g @earendil-works/pi-coding-agent@<lock>`
 /// (falls back to `bun add -g` when npm is absent).
-pub fn run_install(force: bool) -> anyhow::Result<()> {
+fn ensure_pi(force: bool) -> anyhow::Result<()> {
     let want = required_version();
     let node = node_version();
     if !node
@@ -413,12 +425,6 @@ pub fn run_install(force: bool) -> anyhow::Result<()> {
         );
     }
     progress("ok", &format!("pi installed/upgraded (require >= {want})"));
-
-    // pi has no MCP of its own; the TeamClu extension bridges it, and that
-    // bridge imports `@modelcontextprotocol/sdk`. Installing pi without it
-    // yields a runtime with no remote-tools and no workspace MCP servers, so
-    // the two are installed as one unit.
-    mcp_sdk::run_install(force)?;
     Ok(())
 }
 

--- a/apps/daemon/src/pi_install/mod.rs
+++ b/apps/daemon/src/pi_install/mod.rs
@@ -4,6 +4,12 @@
 //! installed via npm (`npm install -g @earendil-works/pi-coding-agent@<lock>`,
 //! bun fallback); the global `pi` binary is resolved via `~/.pi/bin/pi` when
 //! present, otherwise `pi` on PATH (including `~/.npm-global/bin`).
+//!
+//! The same lock file pins `@modelcontextprotocol/sdk`, which the TeamClu pi
+//! extension imports to bridge MCP servers into pi (pi itself ships no MCP —
+//! see `mcp_sdk`). Installing pi installs that too: they are one runtime.
+
+pub mod mcp_sdk;
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -11,8 +17,14 @@ use sha2::{Digest, Sha256};
 use crate::opencode_install::{parse_semver, version_ge};
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PiLock {
     pub version: String,
+    /// `@modelcontextprotocol/sdk` version the pi extension's MCP bridge is
+    /// written against. Defaulted rather than required so a lock file from an
+    /// older build still parses (the SDK step then simply does not run).
+    #[serde(default)]
+    pub mcp_sdk_version: String,
 }
 
 /// Embedded at compile time from apps/daemon/pi.lock.json
@@ -22,6 +34,14 @@ pub const LOCK_JSON: &str = include_str!("../../pi.lock.json");
 pub fn required_version() -> String {
     serde_json::from_str::<PiLock>(LOCK_JSON)
         .map(|l| l.version.trim().trim_start_matches('v').to_string())
+        .unwrap_or_default()
+}
+
+/// The `@modelcontextprotocol/sdk` version this build's extension requires.
+/// Empty means the lock file does not pin one — treat MCP as unmanaged.
+pub fn required_mcp_sdk_version() -> String {
+    serde_json::from_str::<PiLock>(LOCK_JSON)
+        .map(|l| l.mcp_sdk_version.trim().trim_start_matches('v').to_string())
         .unwrap_or_default()
 }
 
@@ -70,6 +90,15 @@ pub struct PiStatus {
     pub node_version: Option<String>,
     pub node_satisfied: bool,
     pub required_version: String,
+    /// `@modelcontextprotocol/sdk` under the materialized extension directory.
+    /// Reported separately from pi's own version because it is installed
+    /// separately, but folded into `satisfied` — without it the extension
+    /// bridges no MCP servers at all, which costs remote-tools and every team
+    /// tool with it.
+    pub mcp_sdk_present: bool,
+    pub mcp_sdk_version: Option<String>,
+    pub required_mcp_sdk_version: String,
+    pub mcp_sdk_satisfied: bool,
     pub satisfied: bool,
 }
 
@@ -111,6 +140,16 @@ pub fn doctor() -> PiStatus {
         .as_deref()
         .map(|v| version_ge(v, &want))
         .unwrap_or(false);
+    let want_sdk = required_mcp_sdk_version();
+    let sdk_version = mcp_sdk::installed_version();
+    let sdk_satisfied = if want_sdk.is_empty() {
+        true
+    } else {
+        sdk_version
+            .as_deref()
+            .map(|v| version_ge(v, &want_sdk))
+            .unwrap_or(false)
+    };
     PiStatus {
         present,
         version,
@@ -119,11 +158,15 @@ pub fn doctor() -> PiStatus {
         node_version,
         node_satisfied,
         required_version: want,
-        satisfied: pi_satisfied && node_satisfied,
+        mcp_sdk_present: sdk_version.is_some(),
+        mcp_sdk_version: sdk_version,
+        required_mcp_sdk_version: want_sdk,
+        mcp_sdk_satisfied: sdk_satisfied,
+        satisfied: pi_satisfied && node_satisfied && sdk_satisfied,
     }
 }
 
-fn progress(event: &str, message: &str) {
+pub(super) fn progress(event: &str, message: &str) {
     println!(
         "{}",
         serde_json::json!({ "event": event, "message": message })
@@ -133,26 +176,27 @@ fn progress(event: &str, message: &str) {
 const PI_NPM_PKG: &str = "@earendil-works/pi-coding-agent";
 const PI_MIRROR_BASE: &str = "https://teamclaw.ucar.cc/pi";
 const OFFICIAL_REGISTRY: &str = "https://registry.npmjs.org";
-const NETWORK_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+pub(super) const NETWORK_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// `latest.json` served next to an OSS-mirrored npm bundle.
 #[derive(Debug, Deserialize)]
-struct PiMirrorManifest {
-    version: String,
-    asset: String,
-    sha256: String,
+pub(super) struct MirrorManifest {
+    pub version: String,
+    pub asset: String,
+    pub sha256: String,
 }
 
 fn npm_package_spec(min_version: &str) -> String {
     format!("{PI_NPM_PKG}@{min_version}")
 }
 
-fn command_with_runtime_path(command: &str) -> std::process::Command {
+pub(super) fn command_with_runtime_path(command: &str) -> std::process::Command {
     let mut process = std::process::Command::new(command);
     process.env("PATH", crate::runtime::well_known_bin::augmented_path());
     process
 }
 
-fn has_command(cmd: &str) -> bool {
+pub(super) fn has_command(cmd: &str) -> bool {
     command_with_runtime_path(cmd)
         .arg("--version")
         .output()
@@ -163,8 +207,8 @@ fn has_command(cmd: &str) -> bool {
 /// The official npm registry is the preferred source. A short probe lets users
 /// on a slow or blocked route fall back to our OSS bundle before npm spends
 /// minutes retrying its own registry requests.
-fn official_registry_available(version: &str) -> bool {
-    let url = format!("{OFFICIAL_REGISTRY}/@earendil-works%2Fpi-coding-agent/{version}");
+pub(super) fn official_registry_available(package: &str, version: &str) -> bool {
+    let url = format!("{OFFICIAL_REGISTRY}/{}/{version}", registry_path(package));
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -187,8 +231,14 @@ fn official_registry_available(version: &str) -> bool {
         .is_some()
 }
 
-fn mirror_manifest() -> Option<PiMirrorManifest> {
-    let url = format!("{}/latest.json", PI_MIRROR_BASE.trim_end_matches('/'));
+/// npm's registry path for a package name: the scope separator is the only
+/// character that has to be encoded (`@scope/name` → `@scope%2Fname`).
+fn registry_path(package: &str) -> String {
+    package.replace('/', "%2F")
+}
+
+pub(super) fn mirror_manifest(base: &str) -> Option<MirrorManifest> {
+    let url = format!("{}/latest.json", base.trim_end_matches('/'));
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -205,12 +255,12 @@ fn mirror_manifest() -> Option<PiMirrorManifest> {
                     .ok()?
                     .error_for_status()
                     .ok()?;
-                response.json::<PiMirrorManifest>().await.ok()
+                response.json::<MirrorManifest>().await.ok()
             })
         })
 }
 
-fn download_bytes(url: &str) -> anyhow::Result<Vec<u8>> {
+pub(super) fn download_bytes(url: &str) -> anyhow::Result<Vec<u8>> {
     let url = url.to_owned();
     let bytes = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -222,35 +272,42 @@ fn download_bytes(url: &str) -> anyhow::Result<Vec<u8>> {
     Ok(bytes.to_vec())
 }
 
-fn sha256_hex(bytes: &[u8]) -> String {
+pub(super) fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(Sha256::digest(bytes))
 }
 
 /// Fetch the versioned, dependency-bundled package from OSS and materialize it
 /// as a temporary `.tgz` that npm can install without contacting a registry.
-fn mirrored_bundle(version: &str) -> anyhow::Result<tempfile::NamedTempFile> {
-    let manifest =
-        mirror_manifest().ok_or_else(|| anyhow::anyhow!("Pi OSS mirror is unavailable"))?;
+///
+/// `label` only names the thing in errors and progress lines; `base` is the
+/// OSS prefix that serves `latest.json` and `<version>/<asset>`.
+pub(super) fn mirrored_bundle(
+    label: &str,
+    base: &str,
+    version: &str,
+) -> anyhow::Result<tempfile::NamedTempFile> {
+    let manifest = mirror_manifest(base)
+        .ok_or_else(|| anyhow::anyhow!("{label} OSS mirror is unavailable"))?;
     if manifest.version.trim_start_matches('v') != version {
         anyhow::bail!(
-            "Pi OSS mirror has {}, but this build requires {version}",
+            "{label} OSS mirror has {}, but this build requires {version}",
             manifest.version
         );
     }
     if !safe_mirror_asset(&manifest.asset) {
-        anyhow::bail!("Pi OSS mirror returned an invalid asset name");
+        anyhow::bail!("{label} OSS mirror returned an invalid asset name");
     }
     let url = format!(
         "{}/{}/{}",
-        PI_MIRROR_BASE.trim_end_matches('/'),
+        base.trim_end_matches('/'),
         version,
         manifest.asset
     );
-    progress("mirror", &format!("downloading Pi from OSS: {url}"));
+    progress("mirror", &format!("downloading {label} from OSS: {url}"));
     let bytes = download_bytes(&url)?;
     if sha256_hex(&bytes) != manifest.sha256.to_ascii_lowercase() {
         anyhow::bail!(
-            "Pi OSS bundle checksum mismatch; retry later or use the official npm registry"
+            "{label} OSS bundle checksum mismatch; retry later or use the official npm registry"
         );
     }
     let file = tempfile::Builder::new().suffix(".tgz").tempfile()?;
@@ -258,7 +315,7 @@ fn mirrored_bundle(version: &str) -> anyhow::Result<tempfile::NamedTempFile> {
     Ok(file)
 }
 
-fn safe_mirror_asset(asset: &str) -> bool {
+pub(super) fn safe_mirror_asset(asset: &str) -> bool {
     !asset.is_empty() && !asset.contains('/') && !asset.contains('\\') && asset.ends_with(".tgz")
 }
 
@@ -301,7 +358,7 @@ pub fn run_install(force: bool) -> anyhow::Result<()> {
     }
 
     let pkg = npm_package_spec(&want);
-    let official_available = official_registry_available(&want);
+    let official_available = official_registry_available(PI_NPM_PKG, &want);
     let (cmd, args, _bundle): (&str, Vec<String>, Option<tempfile::NamedTempFile>) =
         if official_available {
             progress(
@@ -322,7 +379,7 @@ pub fn run_install(force: bool) -> anyhow::Result<()> {
                     "official npm registry is unreachable and the Pi OSS fallback requires npm"
                 );
             }
-            let bundle = mirrored_bundle(&want)?;
+            let bundle = mirrored_bundle("Pi", PI_MIRROR_BASE, &want)?;
             let local = bundle.path().to_string_lossy().to_string();
             (
                 "npm",
@@ -356,6 +413,12 @@ pub fn run_install(force: bool) -> anyhow::Result<()> {
         );
     }
     progress("ok", &format!("pi installed/upgraded (require >= {want})"));
+
+    // pi has no MCP of its own; the TeamClu extension bridges it, and that
+    // bridge imports `@modelcontextprotocol/sdk`. Installing pi without it
+    // yields a runtime with no remote-tools and no workspace MCP servers, so
+    // the two are installed as one unit.
+    mcp_sdk::run_install(force)?;
     Ok(())
 }
 
@@ -374,6 +437,24 @@ mod tests {
     }
 
     #[test]
+    fn lock_pins_the_mcp_sdk_the_extension_imports() {
+        // The extension's MCP bridge is written against the 1.x client API
+        // (`Client`, `StdioClientTransport`, `StreamableHTTPClientTransport`).
+        let v = required_mcp_sdk_version();
+        assert!(!v.is_empty(), "lock must pin an MCP SDK version");
+        assert!(version_ge(&v, "1.29.0"), "MCP SDK lock too old: {v}");
+    }
+
+    #[test]
+    fn registry_path_encodes_only_the_scope_separator() {
+        assert_eq!(
+            registry_path("@modelcontextprotocol/sdk"),
+            "@modelcontextprotocol%2Fsdk"
+        );
+        assert_eq!(registry_path("typescript"), "typescript");
+    }
+
+    #[test]
     fn npm_package_spec_uses_pi_coding_agent() {
         assert_eq!(
             npm_package_spec("0.81.1"),
@@ -383,7 +464,7 @@ mod tests {
 
     #[test]
     fn pi_mirror_manifest_is_versioned_and_uses_a_safe_asset_name() {
-        let manifest: PiMirrorManifest = serde_json::from_str(
+        let manifest: MirrorManifest = serde_json::from_str(
             r#"{"version":"0.84.2","asset":"earendil-works-pi-coding-agent-0.84.2.tgz","sha256":"abc"}"#,
         )
         .unwrap();
@@ -403,11 +484,17 @@ mod tests {
             node_version: Some("v22.19.0".into()),
             node_satisfied: true,
             required_version: "0.81.1".into(),
+            mcp_sdk_present: true,
+            mcp_sdk_version: Some("1.30.0".into()),
+            required_mcp_sdk_version: "1.30.0".into(),
+            mcp_sdk_satisfied: true,
             satisfied: true,
         };
         let v = serde_json::to_value(&s).unwrap();
         assert_eq!(v["requiredVersion"], serde_json::json!("0.81.1"));
         assert_eq!(v["nodeSatisfied"], serde_json::json!(true));
+        assert_eq!(v["mcpSdkVersion"], serde_json::json!("1.30.0"));
+        assert_eq!(v["requiredMcpSdkVersion"], serde_json::json!("1.30.0"));
         assert_eq!(v["satisfied"], serde_json::json!(true));
     }
 }

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -220,13 +220,19 @@ fn remote_tools_cmd_from_mcp_config(path: &Path) -> Option<String> {
 
 /// Build the `TEAMCLU_MCP_SERVERS` payload for the pi extension from a
 /// workspace `opencode.json` (the MCP SSOT: team + inherent + user servers all
-/// merge into its `mcp` map). pi has no native MCP, so the extension spawns each
-/// enabled local server and proxies its tools. Returns `{ "<name>": { "command":
-/// [...], "environment": {...} }, ... }` as a JSON string, or None when there is
-/// nothing to bridge.
+/// merge into its `mcp` map). pi has no native MCP, so the extension connects
+/// to each enabled server with the official MCP SDK and proxies its tools.
 ///
-/// Excluded: disabled servers, non-`local` (remote/url) servers the stdio bridge
-/// can't spawn, and `amuxd-remote-tools` (already bridged via
+/// Returns a JSON string keyed by server name, carrying the same two shapes
+/// opencode understands, normalized so the extension does not have to repeat
+/// opencode's defaulting rules:
+///
+/// - local (stdio):  `{ "type": "local",  "command": [...], "environment": {...} }`
+/// - remote (HTTP):  `{ "type": "remote", "url": "...",     "headers": {...} }`
+///
+/// None when there is nothing to bridge. Excluded: disabled servers, local
+/// servers whose command path does not exist on this machine, remote servers
+/// with no URL, and `amuxd-remote-tools` (already bridged via
 /// `TEAMCLU_REMOTE_TOOLS_CMD`).
 /// The `command[0]` of an MCP server entry when it names a path that does not
 /// exist on this machine.
@@ -246,6 +252,70 @@ fn missing_command_path(command: &[serde_json::Value]) -> Option<String> {
     Some(first.to_string())
 }
 
+/// One `opencode.json` `mcp` entry → the extension's server spec, or None when
+/// it cannot be bridged.
+fn pi_server_spec(
+    name: &str,
+    obj: &serde_json::Map<String, serde_json::Value>,
+) -> Option<serde_json::Value> {
+    if obj.get("enabled").and_then(|v| v.as_bool()) == Some(false) {
+        return None;
+    }
+    if obj.get("type").and_then(|v| v.as_str()) == Some("remote") {
+        let url = obj.get("url").and_then(|v| v.as_str()).unwrap_or_default();
+        if url.is_empty() {
+            warn!(server = %name, "remote MCP server has no url; not bridging it into pi");
+            return None;
+        }
+        let mut entry = serde_json::Map::new();
+        entry.insert(
+            "type".to_string(),
+            serde_json::Value::String("remote".into()),
+        );
+        entry.insert(
+            "url".to_string(),
+            serde_json::Value::String(url.to_string()),
+        );
+        if let Some(headers) = obj.get("headers").and_then(|v| v.as_object()) {
+            entry.insert(
+                "headers".to_string(),
+                serde_json::Value::Object(headers.clone()),
+            );
+        }
+        return Some(serde_json::Value::Object(entry));
+    }
+    let command = match obj.get("command").and_then(|v| v.as_array()) {
+        Some(c) if !c.is_empty() && c.iter().all(|a| a.is_string()) => c.clone(),
+        _ => return None,
+    };
+    if let Some(missing) = missing_command_path(&command) {
+        // A path that is not there cannot become a working bridge, and a
+        // whole workspace was once taken down by one of these: a leftover
+        // `teamclaw-introspect` entry from before the rename, pointing into
+        // an app bundle that no longer has that binary. Drop it here rather
+        // than hand pi a server it can only fail to spawn.
+        warn!(
+            server = %name,
+            path = %missing,
+            "MCP server command not found on this machine; not bridging it into pi"
+        );
+        return None;
+    }
+    let mut entry = serde_json::Map::new();
+    entry.insert(
+        "type".to_string(),
+        serde_json::Value::String("local".into()),
+    );
+    entry.insert("command".to_string(), serde_json::Value::Array(command));
+    if let Some(env) = obj.get("environment").and_then(|v| v.as_object()) {
+        entry.insert(
+            "environment".to_string(),
+            serde_json::Value::Object(env.clone()),
+        );
+    }
+    Some(serde_json::Value::Object(entry))
+}
+
 fn mcp_servers_from_value(root: &serde_json::Value) -> Option<String> {
     let mcp = root.get("mcp")?.as_object()?;
     let mut out = serde_json::Map::new();
@@ -257,39 +327,9 @@ fn mcp_servers_from_value(root: &serde_json::Value) -> Option<String> {
             Some(o) => o,
             None => continue,
         };
-        // Only stdio "local" servers with a command array can be bridged.
-        if obj.get("type").and_then(|v| v.as_str()) == Some("remote") {
-            continue;
+        if let Some(entry) = pi_server_spec(name, obj) {
+            out.insert(name.clone(), entry);
         }
-        if obj.get("enabled").and_then(|v| v.as_bool()) == Some(false) {
-            continue;
-        }
-        let command = match obj.get("command").and_then(|v| v.as_array()) {
-            Some(c) if !c.is_empty() && c.iter().all(|a| a.is_string()) => c.clone(),
-            _ => continue,
-        };
-        if let Some(missing) = missing_command_path(&command) {
-            // A path that is not there cannot become a working bridge, and a
-            // whole workspace was once taken down by one of these: a leftover
-            // `teamclaw-introspect` entry from before the rename, pointing into
-            // an app bundle that no longer has that binary. Drop it here rather
-            // than hand pi a server it can only fail to spawn.
-            warn!(
-                server = %name,
-                path = %missing,
-                "MCP server command not found on this machine; not bridging it into pi"
-            );
-            continue;
-        }
-        let mut entry = serde_json::Map::new();
-        entry.insert("command".to_string(), serde_json::Value::Array(command));
-        if let Some(env) = obj.get("environment").and_then(|v| v.as_object()) {
-            entry.insert(
-                "environment".to_string(),
-                serde_json::Value::Object(env.clone()),
-            );
-        }
-        out.insert(name.clone(), serde_json::Value::Object(entry));
     }
     if out.is_empty() {
         return None;
@@ -1697,6 +1737,51 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
         assert!(parsed.get("gone").is_none(), "dead path must be dropped");
         assert!(parsed.get("bare").is_some(), "bare name must be kept");
+        assert_eq!(parsed["bare"]["type"], serde_json::json!("local"));
+    }
+
+    #[test]
+    fn remote_servers_are_bridged_with_url_and_headers() {
+        // The SDK bridge speaks streamable HTTP / SSE, so a `type: "remote"`
+        // entry is no longer dropped: opencode loads these natively and pi has
+        // to see the same tool set.
+        let root = serde_json::json!({
+            "mcp": {
+                "hosted": {"type": "remote", "url": "https://example.invalid/mcp",
+                           "headers": {"Authorization": "Bearer ${TOKEN}"}},
+                "off": {"type": "remote", "enabled": false, "url": "https://example.invalid/mcp"},
+                "no-url": {"type": "remote"},
+            }
+        });
+        let payload = mcp_servers_from_value(&root).expect("remote server survives");
+        let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(parsed["hosted"]["type"], serde_json::json!("remote"));
+        assert_eq!(
+            parsed["hosted"]["url"],
+            serde_json::json!("https://example.invalid/mcp")
+        );
+        assert_eq!(
+            parsed["hosted"]["headers"]["Authorization"],
+            serde_json::json!("Bearer ${TOKEN}")
+        );
+        assert!(parsed.get("off").is_none(), "disabled must be dropped");
+        assert!(parsed.get("no-url").is_none(), "url-less must be dropped");
+    }
+
+    #[test]
+    fn untyped_entries_still_bridge_as_local() {
+        // opencode treats a missing `type` with a command as local; the
+        // payload must normalize that rather than leave the extension guessing.
+        let root = serde_json::json!({
+            "mcp": { "bare": {"command": ["npx", "-y", "@scope/server"]} }
+        });
+        let payload = mcp_servers_from_value(&root).expect("untyped server survives");
+        let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(parsed["bare"]["type"], serde_json::json!("local"));
+        assert_eq!(
+            parsed["bare"]["command"],
+            serde_json::json!(["npx", "-y", "@scope/server"])
+        );
     }
 
     #[test]

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -370,6 +370,18 @@ impl PiProcessPool {
                 None
             }
         };
+        // The extension degrades to "no MCP servers" without the SDK (its
+        // import is guarded), which otherwise shows up only as tools quietly
+        // missing from the model's list. Say so where it is diagnosable.
+        if extension.is_some() && !crate::pi_install::mcp_sdk::satisfied() {
+            warn!(
+                dir = %crate::pi_install::mcp_sdk::deps_dir().display(),
+                required = %crate::pi_install::required_mcp_sdk_version(),
+                installed = ?crate::pi_install::mcp_sdk::installed_version(),
+                "MCP SDK missing or too old; pi will start with no MCP tools. \
+                 Run `amuxd pi install` to repair"
+            );
+        }
 
         let (program, mode) = match &launch.mode {
             LaunchMode::Host { node, package_root } => {
@@ -683,8 +695,16 @@ fn amuxd_pi_dir() -> PathBuf {
     crate::config::layout::cache_dir().join("pi")
 }
 
+/// Where the extension is materialized. Also an npm root: the extension's MCP
+/// bridge imports `@modelcontextprotocol/sdk`, and pi resolves an extension's
+/// bare imports from a `node_modules/` next to it, so
+/// `pi_install::mcp_sdk` installs into this same directory.
+pub(crate) fn extension_dir() -> PathBuf {
+    amuxd_pi_dir().join("extensions")
+}
+
 pub(crate) fn extension_path() -> PathBuf {
-    amuxd_pi_dir().join("extensions").join("teamclu.ts")
+    extension_dir().join("teamclu.ts")
 }
 
 pub(crate) fn host_script_path() -> PathBuf {
@@ -714,6 +734,12 @@ fn materialize(path: PathBuf, content: &str) -> std::io::Result<PathBuf> {
 }
 
 fn materialize_extension() -> std::io::Result<PathBuf> {
+    // The manifest travels with the extension: it is what makes a hand-run
+    // `npm install` in this directory repair a missing SDK, and what pi reads
+    // when the directory is loaded as a package.
+    if let Err(e) = crate::pi_install::mcp_sdk::materialize_package_json() {
+        warn!(error = %e, "pi extension package.json write failed");
+    }
     materialize(extension_path(), TEAMCLU_EXTENSION_TS)
 }
 

--- a/docs/architecture/pi-agent-backend.md
+++ b/docs/architecture/pi-agent-backend.md
@@ -33,7 +33,7 @@ first-wins，workspace A 的 env 会粘进 B 的进程）。会话文件仍只�
 | 流式事件 | SSE：`message.part.delta` 等 | stdout 事件：`message_update`（text/thinking delta）、`tool_execution_start/update/end`、`agent_end`，全部带 `sessionId` |
 | 权限审批 | 内建 `permission.asked` / reply 端点 | **无内建**——TeamClu pi extension 拦截工具执行，经 `extension_ui_request(confirm)` ↔ `extension_ui_response` 与宿主交互；host 模式下 uiContext 按会话闭包，请求天然归属正确会话 |
 | question 工具 | 内建 | extension 注册 `question` 工具，经带 `teamclu.question=` 标记的 `select` dialog 走同一 UI 通道，amuxd 译成 `question_asked` |
-| MCP | 内建（`opencode.json` 的 `mcp` 表） | **无内建**——extension 桥接（amuxd-remote-tools + workspace MCP），host 进程内共享一份 |
+| MCP | 内建（`opencode.json` 的 `mcp` 表） | **无内建**——extension 用官方 `@modelcontextprotocol/sdk` 做客户端，桥接同一张 `mcp` 表（local stdio + remote streamable HTTP/SSE），host 进程内共享一份 |
 | 模型 | `/config/providers` 目录 | `get_available_models`（host 级）/ `set_model`（会话级）；自定义 provider 用 `registerProvider` |
 | 取消 | per-session abort 端点 | `abort {sessionId}`，只中断该会话 |
 | slash 命令 | 静态表（`builtin_commands.rs`） | 运行时 `get_commands` 真实列表，attach 时以 `AvailableCommands` 事件上报 |
@@ -95,10 +95,36 @@ pi 无内建权限。方案：随 daemon 分发一个 **TeamClu pi extension**�
 
 ### MCP / remote-tools
 
-同一个 TeamClu extension 内实现 MCP 客户端桥（pi 生态无内建 MCP）：
-读取 daemon 注入的 MCP server 清单（沿用现在物化到 worktree 的配置文件，
-或 env 指针），把 MCP tools 注册为 pi 工具。第一版可只桥
-`amuxd-remote-tools`（gateway/团队功能依赖），通用 MCP 桥后续跟进。
+pi 官方明确不做 MCP（README：「**No MCP.** … or build an extension that adds
+MCP support」），所以 **TeamClu extension 本身就是 MCP 客户端**，基于官方
+`@modelcontextprotocol/sdk`：
+
+- **服务器清单同源**：仍是 workspace `opencode.json` 的 `mcp` 表（团队 +
+  inherent + 用户三处合并的 SSOT）。daemon 的 `pi_server_spec`
+  （`pi_rpc/mod.rs`）把它归一成两种形状塞进 `TEAMCLU_MCP_SERVERS`：
+  `{type:"local", command, environment}` / `{type:"remote", url, headers}`。
+  `amuxd-remote-tools` 走自己的 `TEAMCLU_REMOTE_TOOLS_CMD`（要带 socket 参数）。
+- **两种 transport 都支持**：local 走 `StdioClientTransport`，remote 先试
+  streamable HTTP，被拒再退 SSE——与 opencode 原生加载的集合对齐。
+  （SDK 之前是手写的 stdio JSON-RPC，remote 服务器整个丢弃。）
+- **SDK 带来的能力**：`tools/list` 翻页、`notifications/tools/list_changed`
+  运行时增量注册、`AbortSignal` 透传取消、image 结果按 `ImageContent` 原样
+  回传（pi 的 `normalizeToolResultImages` 明确把 MCP bridge 列为来源）。
+- **进程内共享**：bridge 注册表挂在 `globalThis`，按 (label, spec 签名) 复用；
+  `tools/list` 结果落盘缓存（`TEAMCLU_MCP_TOOL_CACHE_DIR`），冷启动不必等最慢
+  的那个 npx server。config 文件有 watcher，改 `mcp` 表无需重启 pi。
+- **工具名**：默认原样注册（`browser_click` 还是 `browser_click`），只有真撞名
+  才给后来者加 `<server>_` 前缀，先到先得，与注册顺序无关。
+
+**安装**：SDK 不是可选项——没有它就没有 remote-tools、没有任何团队工具。
+`pi_install::mcp_sdk` 把 `@modelcontextprotocol/sdk` 装进 extension 物化目录
+（`<cache>/pi/extensions/node_modules`，pi 会从 extension 同级目录解析裸导入），
+版本与 pi 一起锁在 `apps/daemon/pi.lock.json` 的 `mcpSdkVersion`，并计入
+`doctor().satisfied`。官方 registry 不通时退到 OSS 镜像
+（`https://teamclaw.ucar.cc/mcp-sdk`，`.github/workflows/mirror-pi-oss.yml`
+的 `mirror-mcp-sdk` job 发布依赖内联的 tarball，`npm --offline` 装），与 pi
+自己的镜像回退同一套机制。extension 里的 import 是**动态且带 try/catch** 的：
+SDK 缺失只损失 MCP 工具，权限门与 question 工具照常工作。
 
 ### 模型 / LiteLLM
 


### PR DESCRIPTION
pi ships no MCP client by design — its README says "**No MCP.** … or build an
extension that adds MCP support" — so the TeamClu pi extension *is* the MCP
client. Until now that client was a hand-rolled stdio JSON-RPC bridge: no
remote servers, no `tools/list` pagination, no `tools/list_changed`, no
cancellation, and image results stringified into JSON.

This replaces it with the official `@modelcontextprotocol/sdk`, and installs
that SDK as part of installing pi.

## Install

- `pi.lock.json` pins `mcpSdkVersion` next to pi's own version; both mirrors
  refresh from that one file.
- `pi_install::mcp_sdk` installs the SDK into the directory the extension is
  materialized into (`<cache>/pi/extensions`) — where pi resolves an
  extension's bare imports from. `doctor().satisfied` covers it: without the
  SDK there is no remote-tools bridge and no team tooling at all, so it is not
  an optional extra.
- Mainland fallback mirrors pi's own: when the official registry is
  unreachable, a dependency-bundled tarball is fetched from OSS
  (`https://teamclaw.ucar.cc/mcp-sdk`) and installed with `npm --offline`,
  published by a new `mirror-mcp-sdk` job. `npm pack --ignore-scripts` is
  required there — the published SDK carries a `prepack` that runs `tsc`
  against sources the tarball does not ship.
- `run_install` is `ensure_pi(force)?; mcp_sdk::run_install(force)`. The split
  matters: the old single function returned early on "pi already satisfies
  >= <lock>" — the path *every* existing install takes — so the SDK step never
  ran and the bridge silently never appeared. Making the order structural means
  no future early return can skip it.

## Bridge

- Remote (`type: "remote"`) servers are bridged now instead of dropped:
  streamable HTTP, falling back to SSE. `pi_server_spec` normalizes both shapes
  so the extension does not re-derive opencode's defaulting rules.
- `tools/list` pagination, `tools/list_changed` re-registration, `AbortSignal`
  passthrough, and image content returned as `ImageContent` rather than JSON.
- Tool names stay identity (`browser_click` stays `browser_click`); only a real
  clash qualifies the newcomer, and the first claimant is never renamed.
- The SDK's stdio transport defaults to a *filtered* env; the bridge passes the
  full process env explicitly, or every amuxd-injected secret would vanish from
  MCP servers.
- The import is dynamic and guarded: a missing SDK costs MCP tools only, not the
  permission gate or the question tool that share this extension.

## Verification

- Loaded the extension through `jiti` with a stub `ExtensionAPI` against real
  MCP servers (stdio and streamable HTTP): env passthrough, image results,
  `list_changed`, cancellation, registry reuse across sessions, and the
  SDK-absent degradation path.
- Ran `amuxd install-pi` for real on an already-up-to-date install — that is how
  the skipped-SDK bug surfaced. After the fix it installs the SDK into
  `~/.amuxd/cache/pi/extensions` and `amuxd doctor` reports `mcpSdkPresent` /
  `mcpSdkSatisfied` true.
- `cargo check` and `cargo test -p amuxd` green (1323 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
