### PR TITLE
fix(release): stop two flakes from silently killing a brand's release

### DIFF
--- a/.github/actions/brand-setup/action.yml
+++ b/.github/actions/brand-setup/action.yml
@@ -212,7 +212,20 @@ runs:
             'CDN_BASE': cdn_base.rstrip('/'),
             # Empty => bucket is served straight from the OSS endpoint with no CDN
             # in front, so there is no edge cache to purge.
-            'CDN_REFRESH_REGION': oss.get('cdnRefreshRegion') or os.environ.get('CDN_REFRESH_REGION_DEFAULT', ''),
+            #
+            # A brand that DECLARES the key owns the answer, even when the answer
+            # is null/"" ("I have no CDN"). Only a brand that omits it entirely
+            # inherits the repo-level default. `or` could not tell those apart:
+            # it treats an explicit null as absent, so copilot361 — which is
+            # served straight from OSS and declares cdnRefreshRegion: null —
+            # silently inherited the default the moment one was set, and its
+            # release then failed on `InvalidDomain.NotFound` trying to purge a
+            # domain that is not a CDN domain at all.
+            'CDN_REFRESH_REGION': (
+                (oss.get('cdnRefreshRegion') or '')
+                if 'cdnRefreshRegion' in oss
+                else os.environ.get('CDN_REFRESH_REGION_DEFAULT', '')
+            ),
             'BRAND_MAC_EXTRA_ARGS': (meta.get('build') or {}).get('macExtraArgs') or '',
         }
         with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as f:

--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -511,9 +511,17 @@ jobs:
           # save of the Windows target/ dir.
           cache-targets: false
 
+      # arduino/setup-protoc pulls a pinned protoc from GitHub Releases. The
+      # chocolatey package it replaces reported success and still left protoc
+      # off PATH for the amuxd build ("Could not find `protoc`" in run
+      # 32607969228, which passed on retry from the very same commit) — and
+      # because publish-manifest is gated on this job, that flake silently cost
+      # a whole brand its release. Same action the linux amuxd job and ci.yml's
+      # daemon-windows job already use.
       - name: Install protoc (for prost_build)
-        shell: bash
-        run: choco install protoc -y
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # See build-macos: sync all four version sources + Cargo.lock to the tag and
       # enforce the bundled amuxd bump. Runs after Rust + protoc are available


### PR DESCRIPTION
Both of these cost v0.4.1-beta.23 a release attempt, and both fail in the same shape: a job that `build-macos` / `publish-manifest` are gated on goes red, so the brand publishes **nothing** while the version number still moves forward.

---

## 1. Windows `protoc` was installed by chocolatey and randomly went missing

`choco install protoc -y` reported success and still left protoc off PATH for the amuxd build:

```
error: failed to run custom build command for `teamclu-proto`
Could not find `protoc`. If `protoc` is installed, try setting the `PROTOC` environment variable
```

That was [run 32607969228](https://github.com/different-ai-studio/teamclu/actions/runs/32607969228). The **same commit passed on retry**, and copilot361's Windows build passed concurrently — so this is flake, not a real break.

Switch to `arduino/setup-protoc@v3`, which pins protoc from GitHub Releases. It's already what `build-amuxd-linux` and `ci.yml`'s `daemon-windows` job use; the workflow even carries a comment recommending it. After this, protoc is consistent:

| Job | Source |
|---|---|
| `build-macos` | `brew install protobuf` (unchanged) |
| `build-windows` | `arduino/setup-protoc@v3` ← was `choco` |
| `build-amuxd-linux` | `arduino/setup-protoc@v3` |

---

## 2. A brand could not opt out of the CDN refresh

`brand-setup/action.yml` resolved the region as:

```python
oss.get('cdnRefreshRegion') or os.environ.get('CDN_REFRESH_REGION_DEFAULT', '')
```

`or` cannot distinguish *"brand omitted the key"* from *"brand explicitly said null"* — an explicit `null` reads as absent.

copilot361 is served **straight from OSS with no CDN in front** (`Server: AliyunOSS`, no `X-Cache`/`Age`) and declares `cdnRefreshRegion: null` for exactly that reason. The moment a repo-level default existed, it inherited it and tried to purge a domain that isn't a CDN domain:

```
ERROR: SDK.ServerError
ErrorCode: InvalidDomain.NotFound      (download.copilot361.com)
```

This is the workflow's own documented case — *"Empty when the bucket is served straight from its OSS endpoint (no CDN in front) — there is no edge cache to purge"* — that the fallback quietly overrode.

Key it on **presence** instead: a brand that declares the key owns the answer even when that answer is empty; only a brand that omits it inherits the default.

### Verified against all three real brand configs

| Brand | `cdnRefreshRegion` | Before | After | Correct |
|---|---|---|---|---|
| copilot361 | `null` (explicit, no CDN) | `cn-hangzhou` ✗ | *(empty)* | ✅ |
| betly | `"cn-shenzhen"` | `cn-shenzhen` | `cn-shenzhen` | ✅ |
| teamclu | *key absent* (built-in) | `cn-hangzhou` | `cn-hangzhou` | ✅ |
| *(hypothetical `""`)* | `""` | `cn-hangzhou` ✗ | *(empty)* | ✅ |

teamclu still inherits the default it genuinely needs — its channel *is* behind a CDN (`Server: Tengine`), and that refresh is what finally made beta.23 visible to the updater.

**No branding-repo change is required**: copilot361 already declares `cdnRefreshRegion: null`; this just makes that declaration mean what it says.

---

### Validation

- Both YAML files parse; the patched embedded Python compiles
- Region resolution exercised against all four cases in the table above