### PR TITLE
fix(release): stop the nightly racing two brands into one mirror group

### DIFF
--- a/.github/workflows/nightly-release-oss.yml
+++ b/.github/workflows/nightly-release-oss.yml
@@ -86,7 +86,63 @@ jobs:
           TAG: v${{ steps.ver.outputs.next }}
         run: |
           set -euo pipefail
-          for brand in teamclu copilot361; do
+
+          # Both brands' releases call the SAME reusable mirror-pi-oss workflow,
+          # which serializes every caller on one global concurrency group.
+          # Dispatching them back to back put two callers in that single group
+          # and GitHub killed one mid-flight: teamclu's mirror-pi was cancelled
+          # 11 seconds in, one second after copilot361's was created. Because
+          # build-macos (and through it publish-manifest) is gated on mirror-pi,
+          # that skipped both and cost the brand its entire release -- while the
+          # nightly version bump had already landed on main, so the version
+          # number moved and nothing shipped behind it.
+          #
+          # Keep the serialization rather than giving each brand its own group:
+          # the mirror drops the upstream shrinkwrap and runs `npm install
+          # --omit=dev` with no lockfile, so two concurrent mirrors can resolve
+          # different dependency trees. Interleaved asset/manifest writes would
+          # then leave latest.json advertising a sha256 for bytes that are no
+          # longer at that key, which every client rejects as a checksum
+          # mismatch. Stagger the callers instead.
+          dispatch_and_wait() {
+            local brand="$1" before after run_id state
+            before=$(gh run list --workflow release-oss.yml --limit 1 \
+              --json databaseId --jq '.[0].databaseId // 0')
+
             echo "Dispatching release-oss for $brand @ $TAG"
             gh workflow run release-oss.yml --ref main -f brand="$brand" -f tag="$TAG"
+
+            # `gh workflow run` does not report the run it created, so wait for a
+            # new id to show up. We dispatch one brand at a time, so the newest
+            # release-oss run is unambiguously ours.
+            run_id=""
+            for _ in $(seq 1 30); do
+              after=$(gh run list --workflow release-oss.yml --limit 1 \
+                --json databaseId --jq '.[0].databaseId // 0')
+              if [ "$after" != "$before" ]; then run_id="$after"; break; fi
+              sleep 5
+            done
+            if [ -z "$run_id" ]; then
+              echo "::warning::could not identify the $brand run — dispatching the next brand without waiting"
+              return 0
+            fi
+            echo "  -> run $run_id; waiting for its mirror-pi to release the group"
+
+            # Wait on mirror-pi only, not the whole release. Everything after it
+            # shares no group with the other brand and is meant to overlap, so
+            # blocking on the full run would serialize two ~30-minute builds.
+            for _ in $(seq 1 120); do
+              state=$(gh run view "$run_id" --json jobs \
+                --jq '[.jobs[] | select(.name | startswith("mirror-pi")) | .status] | first // ""')
+              if [ "$state" = "completed" ]; then
+                echo "  -> mirror-pi finished; group is free"
+                return 0
+              fi
+              sleep 10
+            done
+            echo "::warning::timed out waiting for $brand mirror-pi — dispatching the next brand anyway"
+          }
+
+          for brand in teamclu copilot361; do
+            dispatch_and_wait "$brand"
           done


### PR DESCRIPTION
## Problem

Both brands' releases call the same reusable `mirror-pi-oss.yml`, which serializes every caller on one global concurrency group:

```yaml
concurrency:
  group: mirror-pi-oss
  cancel-in-progress: false
```

The nightly dispatched both brands back to back in a tight loop, putting two callers into that single group — and GitHub killed one mid-flight:

```
teamclu    mirror-pi   started 00:25:49   cancelled 00:26:00
copilot361 mirror-pi   created 00:25:59
```

Cancelled 11 seconds in, one second after the second caller was created.

`build-macos` — and through it `publish-manifest` — is gated on `mirror-pi`, so both were **skipped** and that brand published nothing. Meanwhile the nightly version bump had already landed on `main`. The version number moved and nothing shipped behind it: the same silent-failure shape as #1035 / #1036 / #1037 / #1041.

Worth noting it happened on the **fast skip path**, where `mirror-pi` has no work to do at all (11s). This is not a slow-mirror problem, and it does not need a pi version bump to trigger.

## Why not give each brand its own group

That was the tempting one-line fix, and it's wrong. The mirror does:

```bash
rm npm-shrinkwrap.json
npm install --omit=dev --no-audit --no-fund
```

No lockfile — so two concurrent mirrors can resolve **different dependency trees** and produce different tarballs. Assets go up before the manifest, so an interleaved pair of writes can leave `latest.json` advertising a sha256 for bytes that are no longer at that key. That is exactly the `Pi OSS bundle checksum mismatch` clients refuse (`pi_install/mod.rs`).

The global group is correct. The bug is the nightly firing two callers into it at once.

## Fix

Stagger the callers: dispatch a brand, wait for its `mirror-pi` to release the group, then dispatch the next.

Waiting is scoped to `mirror-pi` only, **not** the whole run — everything after it shares no group across brands and is meant to overlap, so blocking on the full release would serialize two ~30-minute builds.

## Verification

`bash -n` and `shellcheck` clean. Beyond syntax, I exercised the real extracted script against a mock `gh`:

| Case | Result |
|---|---|
| Happy path | `DISPATCH teamclu` → `MIRROR-PI-DONE 101` → `DISPATCH copilot361` → `MIRROR-PI-DONE 102` — never two callers in the group |
| Run id never appears | warns, dispatches next brand anyway, exit 0 |
| `mirror-pi` never completes | times out, warns, dispatches next brand anyway, exit 0 |

Both failure paths degrade to a warning rather than deadlocking the nightly.