### PR TITLE
fix(windows): stop amuxd and its children from popping console windows

### DIFF
--- a/apps/daemon/src/claude_install/mod.rs
+++ b/apps/daemon/src/claude_install/mod.rs
@@ -11,6 +11,7 @@
 //! as its primary runtime, which the desktop then labelled "OpenCode 运行时" — a
 //! pass/fail about the wrong program.
 
+use crate::process_util::CommandNoWindow;
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -73,6 +74,7 @@ fn claude_version(binary: &str) -> Option<String> {
     // Same PATH augmentation as the other probes: a node-shebang shim needs
     // node reachable, not just itself.
     let out = std::process::Command::new(binary)
+        .no_window()
         .arg("--version")
         .env("PATH", crate::runtime::well_known_bin::augmented_path())
         .output()

--- a/apps/daemon/src/cli/manage.rs
+++ b/apps/daemon/src/cli/manage.rs
@@ -1160,8 +1160,10 @@ fn is_process_alive(pid: i32) -> bool {
 
 #[cfg(windows)]
 fn is_process_alive(pid: i32) -> bool {
+    use crate::process_util::CommandNoWindow;
     use std::process::Command;
     Command::new("tasklist")
+        .no_window()
         .args(["/FI", &format!("PID eq {pid}")])
         .output()
         .map(|o| {

--- a/apps/daemon/src/cli/process.rs
+++ b/apps/daemon/src/cli/process.rs
@@ -490,6 +490,7 @@ fn reap_opencode_pid_file_windows() {
     }
     // Verify image name looks like opencode before taskkill /T.
     let verified = std::process::Command::new("tasklist")
+        .no_window()
         .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
         .output()
         .ok()
@@ -508,6 +509,7 @@ fn reap_opencode_pid_file_windows() {
     }
     println!("amuxd: taskkill /T opencode tree pid {pid}…");
     let _ = std::process::Command::new("taskkill")
+        .no_window()
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .status();
     let _ = fs::remove_file(&path);
@@ -549,7 +551,10 @@ fn force_stop_daemon(pid: i32) {
 
 #[cfg(windows)]
 fn force_stop_daemon(pid: i32) {
+    use crate::process_util::CommandNoWindow;
+
     let _ = std::process::Command::new("taskkill")
+        .no_window()
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .status();
 }

--- a/apps/daemon/src/cli/setup.rs
+++ b/apps/daemon/src/cli/setup.rs
@@ -54,7 +54,9 @@ fn open_browser(url: &str) -> std::io::Result<()> {
     let mut cmd = std::process::Command::new("xdg-open");
     #[cfg(target_os = "windows")]
     let mut cmd = {
+        use crate::process_util::CommandNoWindow;
         let mut c = std::process::Command::new("cmd");
+        c.no_window();
         c.args(["/C", "start", ""]);
         c
     };

--- a/apps/daemon/src/config/workspace_link.rs
+++ b/apps/daemon/src/config/workspace_link.rs
@@ -116,8 +116,11 @@ fn create_link(link: &Path, target: &Path) -> LinkStatus {
 
 #[cfg(windows)]
 fn junction_create(link: &Path, target: &Path) -> std::io::Result<()> {
+    use crate::process_util::CommandNoWindow;
+
     // `mklink /J` creates a junction without admin rights.
     let status = std::process::Command::new("cmd")
+        .no_window()
         .args(["/C", "mklink", "/J"])
         .arg(link)
         .arg(target)

--- a/apps/daemon/src/cursor_install/mod.rs
+++ b/apps/daemon/src/cursor_install/mod.rs
@@ -2,6 +2,7 @@
 
 use serde::Serialize;
 
+use crate::process_util::CommandNoWindow;
 use crate::runtime::cursor_sdk::process::{default_bridge_command, default_bridge_main};
 use crate::runtime::sidecar::bridge_path::sdk_installed_for_main;
 
@@ -42,6 +43,7 @@ fn which_node() -> Option<String> {
     // node is the one dependency of the cursor bridge we can look for
     // ourselves; a Homebrew node is invisible to a GUI-launched daemon's PATH.
     let out = std::process::Command::new("node")
+        .no_window()
         .arg("--version")
         .env("PATH", crate::runtime::well_known_bin::augmented_path())
         .output()

--- a/apps/daemon/src/device_id.rs
+++ b/apps/daemon/src/device_id.rs
@@ -161,7 +161,10 @@ fn machine_id() -> Option<(&'static str, String)> {
 /// different value than a 64-bit one on the same machine.
 #[cfg(target_os = "windows")]
 fn machine_id() -> Option<(&'static str, String)> {
+    use crate::process_util::CommandNoWindow;
+
     let out = std::process::Command::new("reg")
+        .no_window()
         .args([
             "query",
             r"HKLM\SOFTWARE\Microsoft\Cryptography",

--- a/apps/daemon/src/main.rs
+++ b/apps/daemon/src/main.rs
@@ -19,6 +19,7 @@ mod onboarding;
 mod opencode_install;
 mod opencode_settings;
 mod pi_install;
+mod process_util;
 mod proto;
 mod provider_config;
 mod remote_tools;

--- a/apps/daemon/src/mcp_probe.rs
+++ b/apps/daemon/src/mcp_probe.rs
@@ -1,6 +1,7 @@
 //! MCP server tool discovery for workspace HTTP APIs.
 
 use crate::config::workspace_control::McpServerConfig;
+use crate::process_util::CommandNoWindow;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
@@ -45,6 +46,7 @@ fn resolve_spawn_program(program: &str) -> String {
         shell_escape(&program)
     );
     let out = match std::process::Command::new("sh")
+        .no_window()
         .arg("-lc")
         .arg(&script)
         .output()
@@ -140,6 +142,7 @@ pub async fn probe_local_stdio(
 
     let spawn_bin = resolve_spawn_program(command);
     let mut cmd = Command::new(&spawn_bin);
+    cmd.no_window();
     cmd.args(&config.command[1..])
         .current_dir(workspace_path)
         .stdin(std::process::Stdio::piped())

--- a/apps/daemon/src/opencode_install/mod.rs
+++ b/apps/daemon/src/opencode_install/mod.rs
@@ -12,6 +12,7 @@
 //! (`~/.opencode/bin/opencode`) so a background launchd/systemd service finds it
 //! without a login PATH.
 
+use crate::process_util::CommandNoWindow;
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -77,6 +78,7 @@ pub fn version_ge(have: &str, want: &str) -> bool {
 /// `<bin> --version`, returning the first token that looks like a version.
 fn opencode_version_of(bin: &str) -> Option<String> {
     let out = std::process::Command::new(bin)
+        .no_window()
         .arg("--version")
         .output()
         .ok()?;
@@ -528,6 +530,7 @@ pub struct DoctorReport {
 /// `<amuxd> --version` -> the first version-like token (clap prints "amuxd X.Y.Z").
 fn amuxd_installed_version(path: &std::path::Path) -> Option<String> {
     let out = std::process::Command::new(path)
+        .no_window()
         .arg("--version")
         .output()
         .ok()?;
@@ -544,7 +547,11 @@ fn amuxd_installed_version(path: &std::path::Path) -> Option<String> {
 }
 
 fn probe_version(cmd: &str, args: &[&str]) -> Option<String> {
-    let out = std::process::Command::new(cmd).args(args).output().ok()?;
+    let out = std::process::Command::new(cmd)
+        .no_window()
+        .args(args)
+        .output()
+        .ok()?;
     if !out.status.success() {
         return None;
     }

--- a/apps/daemon/src/pi_install/mod.rs
+++ b/apps/daemon/src/pi_install/mod.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::opencode_install::{parse_semver, version_ge};
+use crate::process_util::CommandNoWindow;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -56,6 +57,7 @@ fn pi_version_of(bin: &str) -> Option<String> {
     // PATH augmented: pi installs as an npm shim whose shebang is
     // `#!/usr/bin/env node`, so finding the file is not enough to run it.
     let out = std::process::Command::new(bin)
+        .no_window()
         .arg("--version")
         .env("PATH", crate::runtime::well_known_bin::augmented_path())
         .output()
@@ -109,6 +111,7 @@ const MIN_NODE_VERSION: &str = "22.19.0";
 
 fn node_version() -> Option<String> {
     let out = std::process::Command::new("node")
+        .no_window()
         .arg("--version")
         .env("PATH", crate::runtime::well_known_bin::augmented_path())
         .output()
@@ -192,6 +195,7 @@ fn npm_package_spec(min_version: &str) -> String {
 
 pub(super) fn command_with_runtime_path(command: &str) -> std::process::Command {
     let mut process = std::process::Command::new(command);
+    process.no_window();
     process.env("PATH", crate::runtime::well_known_bin::augmented_path());
     process
 }

--- a/apps/daemon/src/process_util.rs
+++ b/apps/daemon/src/process_util.rs
@@ -1,0 +1,45 @@
+//! Cross-platform child-process spawning helpers.
+//!
+//! amuxd is a console-subsystem binary, so on Windows it may run with no
+//! console of its own (started detached, or from the GUI desktop app). Every
+//! console child it then spawns — `opencode serve`, the node/pi hosts, the
+//! bridges, `tasklist`/`taskkill`, `npm`, `git` — would get its own **visible**
+//! console window unless the parent sets `CREATE_NO_WINDOW` (0x08000000).
+//!
+//! This mirrors `apps/desktop/src/process_util.rs`: a tiny trait extension that
+//! hides the window on Windows and is a no-op everywhere else.
+//!
+//! Usage:
+//! ```ignore
+//! use crate::process_util::CommandNoWindow;
+//! Command::new("git").no_window().args(["status"]).output()?;
+//! ```
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+pub trait CommandNoWindow {
+    /// Hide the spawned console window on Windows. No-op elsewhere.
+    fn no_window(&mut self) -> &mut Self;
+}
+
+impl CommandNoWindow for std::process::Command {
+    fn no_window(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            self.creation_flags(CREATE_NO_WINDOW);
+        }
+        self
+    }
+}
+
+impl CommandNoWindow for tokio::process::Command {
+    fn no_window(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            self.creation_flags(CREATE_NO_WINDOW);
+        }
+        self
+    }
+}

--- a/apps/daemon/src/runtime/claude_agent/process.rs
+++ b/apps/daemon/src/runtime/claude_agent/process.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tracing::info;
 
+use crate::process_util::CommandNoWindow;
 use crate::runtime::sidecar::bridge_path::default_claude_bridge_main;
 use crate::runtime::sidecar::client::SidecarClient;
 
@@ -187,6 +188,7 @@ impl ClaudeProcessPool {
         let api_key = self.api_key.lock().clone().filter(|k| !k.trim().is_empty());
 
         let mut cmd = tokio::process::Command::new(&bridge[0]);
+        cmd.no_window();
         for arg in bridge.iter().skip(1) {
             cmd.arg(arg);
         }

--- a/apps/daemon/src/runtime/cursor_sdk/process.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/process.rs
@@ -8,6 +8,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tracing::{info, warn};
 
 use super::{events, Shared};
+use crate::process_util::CommandNoWindow;
 use crate::runtime::sidecar::bridge_path::default_cursor_bridge_main;
 use crate::runtime::sidecar::client::SidecarClient;
 
@@ -189,6 +190,7 @@ impl CursorProcessPool {
             })?;
 
         let mut cmd = tokio::process::Command::new(&bridge[0]);
+        cmd.no_window();
         for arg in bridge.iter().skip(1) {
             cmd.arg(arg);
         }

--- a/apps/daemon/src/runtime/opencode_http/process_registry.rs
+++ b/apps/daemon/src/runtime/opencode_http/process_registry.rs
@@ -7,6 +7,9 @@ use std::time::{Duration, Instant};
 
 use tracing::warn;
 
+#[cfg(windows)]
+use crate::process_util::CommandNoWindow;
+
 pub struct ServeProcessRegistry {
     path: PathBuf,
     groups: parking_lot::Mutex<HashMap<String, u32>>,
@@ -245,6 +248,7 @@ fn cmdline_of(pid: i32) -> Option<String> {
 #[cfg(windows)]
 fn reap_verified_group(pid: u32) -> bool {
     let Ok(output) = std::process::Command::new("tasklist")
+        .no_window()
         .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
         .output()
     else {
@@ -259,6 +263,7 @@ fn reap_verified_group(pid: u32) -> bool {
         return true;
     }
     let _ = std::process::Command::new("taskkill")
+        .no_window()
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .status();
     let deadline = Instant::now() + Duration::from_millis(300);
@@ -271,6 +276,7 @@ fn reap_verified_group(pid: u32) -> bool {
 #[cfg(windows)]
 fn windows_pid_alive(pid: u32) -> bool {
     std::process::Command::new("tasklist")
+        .no_window()
         .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
         .output()
         .ok()

--- a/apps/daemon/src/runtime/opencode_http/supervisor.rs
+++ b/apps/daemon/src/runtime/opencode_http/supervisor.rs
@@ -15,6 +15,7 @@ use tracing::{info, warn};
 
 use super::client::ServeClient;
 use super::process_registry::ServeProcessRegistry;
+use crate::process_util::CommandNoWindow;
 use crate::runtime::execution_context::ProcessEnvRevision;
 
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(20);
@@ -337,6 +338,7 @@ impl ServeSupervisor {
         let base = format!("http://127.0.0.1:{port}");
 
         let mut cmd = tokio::process::Command::new(&binary);
+        cmd.no_window();
         cmd.arg("serve")
             .arg("--port")
             .arg(port.to_string())
@@ -526,6 +528,7 @@ fn kill_serve_tree(child: &mut tokio::process::Child, pgid: u32) -> bool {
         // taskkill /T terminates the whole child tree (serve + MCP children);
         // Child::start_kill alone would only hit the leader.
         let _ = std::process::Command::new("taskkill")
+            .no_window()
             .args(["/PID", &pgid.to_string(), "/T", "/F"])
             .output();
         let _ = child.start_kill();
@@ -547,6 +550,7 @@ fn kill_serve_tree(child: &mut tokio::process::Child, pgid: u32) -> bool {
 #[cfg(windows)]
 fn windows_pid_alive(pid: u32) -> bool {
     std::process::Command::new("tasklist")
+        .no_window()
         .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
         .output()
         .ok()

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -25,6 +25,7 @@ use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tracing::{info, warn};
 
+use crate::process_util::CommandNoWindow;
 use crate::runtime::execution_context::{IsolationDomainKey, ProcessEnvRevision};
 
 use super::client::PiClient;
@@ -414,6 +415,7 @@ impl PiProcessPool {
             }
         };
         let mut cmd = program;
+        cmd.no_window();
         cmd.current_dir(worktree);
 
         // TeamClu extension env contract: permission gate + MCP bridges.

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::process_util::CommandNoWindow;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
@@ -434,6 +435,7 @@ pub(crate) fn resolve_introspect_binary() -> Option<String> {
     }
 
     if std::process::Command::new("sh")
+        .no_window()
         .arg("-lc")
         .arg("command -v teamclu-introspect")
         .output()
@@ -746,6 +748,7 @@ fn binary_available(cfg: &AgentLaunchConfig) -> bool {
         return true;
     }
     std::process::Command::new("sh")
+        .no_window()
         .arg("-lc")
         .arg(format!("command -v {}", shell_escape(&cfg.binary)))
         .output()

--- a/apps/daemon/src/service/mod.rs
+++ b/apps/daemon/src/service/mod.rs
@@ -163,7 +163,10 @@ pub fn uninstall_service() -> anyhow::Result<()> {
 
 #[cfg(target_os = "windows")]
 fn schtasks_task_exists() -> bool {
+    use crate::process_util::CommandNoWindow;
+
     std::process::Command::new("schtasks")
+        .no_window()
         .args(["/Query", "/TN", "amuxd"])
         .status()
         .map(|s| s.success())
@@ -175,9 +178,7 @@ fn schtasks_task_exists() -> bool {
 /// Task Scheduler policy).
 #[cfg(target_os = "windows")]
 fn start_daemon_detached(exe: &Path) -> anyhow::Result<()> {
-    use std::os::windows::process::CommandExt;
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-    const DETACHED_PROCESS: u32 = 0x0000_0008;
+    use crate::process_util::CommandNoWindow;
 
     if let Ok(Some((pid, path))) = crate::cli::process::read_pidfile_for_service() {
         if crate::cli::process::pid_is_alive(pid) {
@@ -186,9 +187,17 @@ fn start_daemon_detached(exe: &Path) -> anyhow::Result<()> {
         let _ = std::fs::remove_file(path);
     }
 
+    // CREATE_NO_WINDOW alone — deliberately *not* `| DETACHED_PROCESS`.
+    // CreateProcess ignores CREATE_NO_WINDOW when DETACHED_PROCESS is also set,
+    // and DETACHED_PROCESS leaves the daemon with no console at all, so every
+    // console child it later spawns (opencode serve, node, tasklist, npm) gets
+    // its own *visible* console window. CREATE_NO_WINDOW gives amuxd a private
+    // hidden console instead: still isolated from the launching terminal's
+    // Ctrl+C / close events, nothing is ever drawn, and children inherit the
+    // hidden console.
     std::process::Command::new(exe)
         .arg("start")
-        .creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS)
+        .no_window()
         .spawn()
         .map(|_| ())
         .map_err(|e| anyhow::anyhow!("spawn amuxd start: {e}"))
@@ -201,6 +210,7 @@ pub fn install_service() -> anyhow::Result<()> {
 
     if schtasks_task_exists() {
         let _ = std::process::Command::new("schtasks")
+            .no_window()
             .args(["/Run", "/TN", "amuxd"])
             .status();
         start_daemon_detached(&exe)?;
@@ -210,6 +220,7 @@ pub fn install_service() -> anyhow::Result<()> {
     // schtasks /TR wants a bare command line; quote only the exe path (it may
     // contain spaces), not the whole "<exe> start" string.
     let created = std::process::Command::new("schtasks")
+        .no_window()
         .args(["/Create", "/F", "/SC", "ONLOGON", "/TN", "amuxd", "/TR"])
         .arg(format!("\"{}\" start", exe.display()))
         .status()?
@@ -217,6 +228,7 @@ pub fn install_service() -> anyhow::Result<()> {
 
     if created {
         let _ = std::process::Command::new("schtasks")
+            .no_window()
             .args(["/Run", "/TN", "amuxd"])
             .status();
         start_daemon_detached(&exe)?;
@@ -231,7 +243,10 @@ pub fn install_service() -> anyhow::Result<()> {
 
 #[cfg(target_os = "windows")]
 pub fn uninstall_service() -> anyhow::Result<()> {
+    use crate::process_util::CommandNoWindow;
+
     let _ = std::process::Command::new("schtasks")
+        .no_window()
         .args(["/Delete", "/F", "/TN", "amuxd"])
         .status();
     Ok(())

--- a/apps/daemon/src/sync/app_build.rs
+++ b/apps/daemon/src/sync/app_build.rs
@@ -3,6 +3,7 @@
 //! The async presigned-URL upload lives in the HTTP handler (reqwest is async);
 //! this module stays sync so it can run inside `spawn_blocking`.
 
+use crate::process_util::CommandNoWindow;
 use std::io::Write;
 use std::path::Path;
 use std::process::Command;
@@ -35,6 +36,7 @@ pub fn zip_dir(dir: &Path) -> anyhow::Result<Vec<u8>> {
 
 fn run(cmd: &str, args: &[&str], cwd: &Path) -> anyhow::Result<()> {
     let out = Command::new(cmd)
+        .no_window()
         .args(args)
         .current_dir(cwd)
         .env("GIT_TERMINAL_PROMPT", "0")

--- a/apps/daemon/src/sync/app_clone.rs
+++ b/apps/daemon/src/sync/app_clone.rs
@@ -10,6 +10,7 @@
 //! repo is the user's own project; writing our `AGENTS.md`/`build.mjs` over the
 //! top would rewrite files it may already have.
 
+use crate::process_util::CommandNoWindow;
 use std::path::Path;
 use std::process::Command;
 
@@ -93,6 +94,7 @@ pub fn clone_app_repo(url: &str, workdir: &Path) -> anyhow::Result<()> {
 fn run_clone(remote: &str, workdir: &Path) -> anyhow::Result<()> {
     let git = crate::runtime::well_known_bin::resolve_binary("git", None, &[]);
     let out = Command::new(&git)
+        .no_window()
         .arg("clone")
         .arg("--")
         .arg(remote)

--- a/apps/desktop/src/commands/amuxd_supervisor.rs
+++ b/apps/desktop/src/commands/amuxd_supervisor.rs
@@ -17,6 +17,8 @@ use std::time::Duration;
 use serde::Serialize;
 use tauri::{AppHandle, Manager, Runtime};
 
+use crate::process_util::CommandNoWindow;
+
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 
@@ -288,6 +290,7 @@ async fn wait_until_healthy(timeout: Duration, app_exiting: &AtomicBool) -> Resu
 fn run_bundled_once(args: &[&str]) -> Result<(), String> {
     let bin = bundled_amuxd()?;
     let out = std::process::Command::new(&bin)
+        .no_window()
         .args(args)
         .output()
         .map_err(|e| format!("spawn amuxd {}: {e}", args.join(" ")))?;
@@ -306,6 +309,7 @@ fn run_bundled_once(args: &[&str]) -> Result<(), String> {
 async fn run_bundled_once_async(args: &[&str]) -> Result<(), String> {
     let bin = bundled_amuxd()?;
     let out = tokio::process::Command::new(&bin)
+        .no_window()
         .args(args)
         .output()
         .await
@@ -618,6 +622,12 @@ impl AmuxdSupervisor {
             .ok();
 
         let mut cmd = tokio::process::Command::new(&bin);
+        // amuxd is a console-subsystem binary and the desktop app is GUI-subsystem
+        // (`windows_subsystem = "windows"`), so without this Windows allocates a
+        // console window for the daemon that stays up for the whole session — and
+        // closing it kills amuxd. The hidden console it gets instead is inherited
+        // by amuxd's own children, so opencode/node stay invisible too.
+        cmd.no_window();
         cmd.arg("start").stdin(std::process::Stdio::null());
         if let Some(f) = log_file {
             let stderr = f

--- a/apps/desktop/src/commands/setup.rs
+++ b/apps/desktop/src/commands/setup.rs
@@ -2,6 +2,8 @@ use serde::Serialize;
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 
+use crate::process_util::CommandNoWindow;
+
 /// Tauri event name carrying `SetupProgress` to the first-run wizard UI.
 const SETUP_PROGRESS_EVENT: &str = "setup-progress";
 
@@ -171,6 +173,7 @@ pub async fn setup_list_requirements<R: Runtime>(
             version: amuxd_version.or_else(|| {
                 locate_bundled_amuxd().and_then(|p| {
                     std::process::Command::new(&p)
+                        .no_window()
                         .arg("--version")
                         .output()
                         .ok()


### PR DESCRIPTION
## What

On Windows, installing and launching the app leaves a black `amuxd.exe` console window on screen. It is not a flash — `amuxd start` runs the daemon in the foreground, so the window stays up for the whole app session, and clicking its **X** kills the daemon out from under the app.

## Root cause

The desktop app is GUI-subsystem in release (`apps/desktop/src/main.rs:2`) and `amuxd` is console-subsystem, so a spawn without `CREATE_NO_WINDOW` (0x08000000) makes Windows allocate a console for the child.

The crate already had the right helper — `apps/desktop/src/process_util.rs` — and `deps.rs` / `mcp.rs` / `skillssh.rs` / `lib.rs` all use it, as does `tauri_plugin_shell` internally. **`amuxd_supervisor.rs` never imported it.**

A sweep of all 95 `Command::new` sites across `apps/desktop`, `apps/daemon`, and `crates/` turned up two more layers behind that one.

## Changes

**1. Desktop → amuxd (4 sites).** `.no_window()` on the managed `amuxd start` spawn, both `run_bundled_once` helpers (`stop`, `uninstall-service`), and the `amuxd --version` probe in the first-run wizard. This is the window users actually see.

**2. `service/mod.rs` — `CREATE_NO_WINDOW | DETACHED_PROCESS`.** CreateProcess **ignores `CREATE_NO_WINDOW` when `DETACHED_PROCESS` is also set**, and `DETACHED_PROCESS` leaves amuxd with *no console at all* — so every console child it later spawned got its own visible window. Now `CREATE_NO_WINDOW` alone: a private hidden console, still isolated from the launching terminal's Ctrl+C/close events, and children inherit it hidden.

**3. New `apps/daemon/src/process_util.rs`.** The daemon crate had no no-window helper — that flag was its only occurrence anywhere in it. Mirrors the desktop's trait and is applied to the 27 Windows-live child spawns, so hiding no longer depends on inheriting a hidden console:

| Where | Child |
|---|---|
| `runtime/opencode_http/supervisor.rs` | `opencode serve` (long-lived) |
| `runtime/pi_rpc/process.rs` | node host / `pi` (long-lived, both launch modes) |
| `runtime/{cursor_sdk,claude_agent}/process.rs` | bridge (node) |
| `mcp_probe.rs` | MCP servers (node/npx) |
| `process_registry.rs`, `opencode_http/supervisor.rs`, `cli/process.rs`, `cli/manage.rs` | `tasklist` / `taskkill` — `windows_pid_alive` polls every 50ms during a reap |
| `pi_install`, `cursor_install`, `claude_install`, `opencode_install` | node / npm / version probes |
| `service/mod.rs`, `device_id.rs`, `config/workspace_link.rs`, `cli/setup.rs`, `sync/*` | `schtasks`, `reg`, `cmd /C mklink`, `cmd /C start`, git |

Unix-only spawns (`ps`/`pgrep`/`launchctl`/`systemctl`/`open`/`xdg-open`) and tests are untouched; `explorer.exe` is GUI-subsystem and shows nothing either way. A rescan confirms every remaining unguarded site is one of those intentional skips.

## Behavior note

`amuxd install-service` run from a terminal no longer echoes `schtasks`' own `SUCCESS:`/`ERROR:` line. Only its exit status was ever consumed, and amuxd prints its own warning on failure. Every other touched site pipes or discards stdio, so nothing else is swallowed.

## Verification

- `cargo fmt --check --manifest-path apps/desktop/Cargo.toml` passes; rustfmt leaves every inserted line in the daemon untouched, so no formatting churn there either.
- All 23 touched files parse.
- The `#[cfg(windows)]` paths cannot be typechecked on macOS — **the `daemon-windows` CI job (`cargo check`/`build -p amuxd --locked`) is the compile gate for them.**
- The visible-window behavior still needs a manual check on a Windows build.

## Out of scope

The legacy `schtasks /SC ONLOGON` task registers a console app in the interactive session, so it shows its own console window at logon. The desktop no longer uses that path (`daemon_install_service` maps to a managed restart, and the supervisor runs `uninstall-service` on first start), so it only affects installs that ran `amuxd install-service` by hand. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)