### PR TITLE
fix(pi): install and detect pi on Windows, where npm is npm.cmd

### DIFF
--- a/apps/daemon/src/mcp_probe.rs
+++ b/apps/daemon/src/mcp_probe.rs
@@ -16,12 +16,9 @@ use tokio::time::timeout;
 const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// MCP configs commonly say "npx"/"npm"; those are .cmd shims on Windows.
+/// One rule for the whole daemon lives in `well_known_bin::spawn_name`.
 fn platform_program(program: &str) -> String {
-    if cfg!(windows) && matches!(program, "npx" | "npm") {
-        format!("{program}.cmd")
-    } else {
-        program.to_string()
-    }
+    crate::runtime::well_known_bin::spawn_name(program)
 }
 
 fn shell_escape(value: &str) -> String {

--- a/apps/daemon/src/pi_install/mod.rs
+++ b/apps/daemon/src/pi_install/mod.rs
@@ -56,10 +56,8 @@ pub fn resolve_binary(configured: Option<&str>) -> String {
 fn pi_version_of(bin: &str) -> Option<String> {
     // PATH augmented: pi installs as an npm shim whose shebang is
     // `#!/usr/bin/env node`, so finding the file is not enough to run it.
-    let out = std::process::Command::new(bin)
-        .no_window()
+    let out = command_with_runtime_path(bin)
         .arg("--version")
-        .env("PATH", crate::runtime::well_known_bin::augmented_path())
         .output()
         .ok()?;
     if !out.status.success() {
@@ -110,10 +108,8 @@ pub struct PiStatus {
 const MIN_NODE_VERSION: &str = "22.19.0";
 
 fn node_version() -> Option<String> {
-    let out = std::process::Command::new("node")
-        .no_window()
+    let out = command_with_runtime_path("node")
         .arg("--version")
-        .env("PATH", crate::runtime::well_known_bin::augmented_path())
         .output()
         .ok()?;
     if !out.status.success() {
@@ -193,8 +189,15 @@ fn npm_package_spec(min_version: &str) -> String {
     format!("{PI_NPM_PKG}@{min_version}")
 }
 
+/// `Command` for a CLI we shell out to, with every platform repair applied:
+/// the enriched PATH, the Windows shim name (`npm` is `npm.cmd` — see
+/// `well_known_bin::spawn_name`), and no console window (#1045).
+///
+/// Routing the version probes through here is why they no longer call
+/// `.no_window()` themselves: one helper, one place to get it right.
 pub(super) fn command_with_runtime_path(command: &str) -> std::process::Command {
-    let mut process = std::process::Command::new(command);
+    let mut process =
+        std::process::Command::new(crate::runtime::well_known_bin::spawn_name(command));
     process.no_window();
     process.env("PATH", crate::runtime::well_known_bin::augmented_path());
     process
@@ -370,7 +373,14 @@ fn ensure_pi(force: bool) -> anyhow::Result<()> {
     }
 
     if !has_command("npm") && !has_command("bun") {
-        anyhow::bail!("neither npm nor bun found; install Node.js or Bun first");
+        // Node was already proved present above, so reaching here with a Node
+        // install means npm is missing from *this process's* PATH rather than
+        // from the machine — say which one to check.
+        anyhow::bail!(
+            "neither npm nor bun found on PATH (node {} is installed); \
+             install Node.js or Bun first, or add npm's directory to PATH",
+            node.as_deref().unwrap_or("?")
+        );
     }
 
     let pkg = npm_package_spec(&want);

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -603,18 +603,37 @@ fn resolve_pi_package_root(binary: &Path) -> Option<PathBuf> {
     };
     let resolved = std::fs::canonicalize(&start).ok()?;
     for dir in resolved.ancestors().skip(1) {
-        let package_json = dir.join("package.json");
-        if !package_json.exists() || !dir.join("dist").join("index.js").exists() {
-            continue;
-        }
-        let body = std::fs::read_to_string(&package_json).ok()?;
-        if body.contains("\"@earendil-works/pi-coding-agent\"") {
+        // POSIX: the `pi` shim is a symlink *into* the package, so the package
+        // root is one of its ancestors. A package root that isn't pi's (e.g. a
+        // wrapper package) just keeps the walk going.
+        if is_pi_package_root(dir) {
             return Some(dir.to_path_buf());
         }
-        // A package root that isn't pi's (e.g. a wrapper package) — keep
-        // walking; the real root may sit above a nested bin dir.
+        // Windows: `pi.cmd` is a standalone batch shim, not a link into the
+        // package, so no ancestor is ever the package root — the package sits
+        // in the npm prefix's `node_modules` beside the shim. Without this,
+        // every Windows install silently fell back to single-session
+        // `--mode rpc`.
+        let beside = dir
+            .join("node_modules")
+            .join("@earendil-works")
+            .join("pi-coding-agent");
+        if is_pi_package_root(&beside) {
+            return Some(beside);
+        }
     }
     None
+}
+
+/// Is `dir` the `@earendil-works/pi-coding-agent` package root — i.e. does it
+/// hold the `dist/index.js` the host imports?
+fn is_pi_package_root(dir: &Path) -> bool {
+    if !dir.join("dist").join("index.js").exists() {
+        return false;
+    }
+    std::fs::read_to_string(dir.join("package.json"))
+        .map(|body| body.contains("\"@earendil-works/pi-coding-agent\""))
+        .unwrap_or(false)
 }
 
 /// Resolve the pi binary amuxd should run. Order: explicit daemon config
@@ -627,9 +646,12 @@ pub(crate) fn resolve_binary(configured: Option<&str>) -> String {
     )
 }
 
+/// `~/.pi/bin/pi` — where pi's own installer puts it. Resolved through
+/// `well_known_bin` so Windows probes every executable extension (a pi that
+/// arrived via npm is `pi.cmd`, never `pi.exe`) instead of one guess.
 fn default_bin() -> Option<PathBuf> {
-    let name = if cfg!(windows) { "pi.exe" } else { "pi" };
-    dirs::home_dir().map(|h| h.join(".pi").join("bin").join(name))
+    let dir = dirs::home_dir()?.join(".pi").join("bin");
+    crate::runtime::well_known_bin::find_with("pi", &[dir], &[])
 }
 
 /// `well_known` is a parameter rather than a call to
@@ -870,6 +892,33 @@ mod tests {
                 std::fs::canonicalize(&pkg).unwrap()
             );
         }
+    }
+
+    #[test]
+    fn package_root_found_beside_a_windows_style_shim() {
+        // What `npm install -g` produces on Windows:
+        //   %APPDATA%\npm\pi.cmd                     (a batch shim, no symlink)
+        //   %APPDATA%\npm\node_modules\@earendil-works\pi-coding-agent\
+        // Walking ancestors alone never finds the package here.
+        let dir = tempfile::tempdir().unwrap();
+        let pkg = dir
+            .path()
+            .join("node_modules/@earendil-works/pi-coding-agent");
+        std::fs::create_dir_all(pkg.join("dist")).unwrap();
+        std::fs::write(
+            pkg.join("package.json"),
+            r#"{"name":"@earendil-works/pi-coding-agent","version":"0.84.2"}"#,
+        )
+        .unwrap();
+        std::fs::write(pkg.join("dist/index.js"), "").unwrap();
+        let shim = dir.path().join("pi.cmd");
+        std::fs::write(&shim, "@ECHO off\r\n").unwrap();
+
+        let root = resolve_pi_package_root(&shim).expect("package root beside the shim");
+        assert_eq!(
+            std::fs::canonicalize(&root).unwrap(),
+            std::fs::canonicalize(&pkg).unwrap()
+        );
     }
 
     #[test]

--- a/apps/daemon/src/runtime/well_known_bin.rs
+++ b/apps/daemon/src/runtime/well_known_bin.rs
@@ -32,18 +32,66 @@ pub fn search_dirs() -> Vec<PathBuf> {
         // npm's global prefix when the user relocated it out of /usr/local.
         dirs.push(home.join(".npm-global").join("bin"));
         dirs.push(home.join("bin"));
+        if cfg!(windows) {
+            // Bun's Windows installer target. Only added here: the POSIX list
+            // is left exactly as it was, since those platforms already work.
+            dirs.push(home.join(".bun").join("bin"));
+        }
     }
-    dirs.push(PathBuf::from("/opt/homebrew/bin"));
-    dirs.push(PathBuf::from("/usr/local/bin"));
+    if cfg!(windows) {
+        // npm's global prefix on Windows. `npm install -g` writes its shims
+        // here (`pi.cmd`), and nothing about a Node MSI install puts this
+        // directory on a *service*-launched process's PATH.
+        if let Some(appdata) = std::env::var_os("APPDATA") {
+            dirs.push(PathBuf::from(appdata).join("npm"));
+        }
+        // Where the Node.js MSI itself lands: `node.exe` plus `npm.cmd`.
+        if let Some(program_files) = std::env::var_os("ProgramFiles") {
+            dirs.push(PathBuf::from(program_files).join("nodejs"));
+        }
+    } else {
+        dirs.push(PathBuf::from("/opt/homebrew/bin"));
+        dirs.push(PathBuf::from("/usr/local/bin"));
+    }
     dirs
 }
 
-/// Executable file name for this platform.
-fn exe_name(name: &str) -> String {
-    if cfg!(windows) {
-        format!("{name}.exe")
+/// The program name to hand `std::process::Command` on this platform.
+///
+/// Rust resolves a bare program name against PATH by appending `.exe` and
+/// nothing else — it never consults `PATHEXT`. Everything npm ships is a
+/// `.cmd` shim (`npm.cmd`, `npx.cmd`; there is no `npm.exe`), so
+/// `Command::new("npm")` cannot start npm on Windows even with Node installed
+/// and on PATH. That is what made `amuxd install-pi` bail with "neither npm
+/// nor bun found" on a machine whose `node --version` worked fine — `node` is
+/// a real `.exe`, so only the npm probe failed.
+///
+/// Only the shims are mapped. `bun`, `node` and friends are real executables
+/// that the implicit `.exe` already resolves.
+pub fn spawn_name(program: &str) -> String {
+    if cfg!(windows) && matches!(program, "npm" | "npx" | "pnpm" | "yarn") {
+        format!("{program}.cmd")
     } else {
-        name.to_string()
+        program.to_string()
+    }
+}
+
+/// Executable file names to try for `name`, in order.
+///
+/// Windows has no single answer. A native CLI is `bun.exe`, but a global npm
+/// install writes `pi.cmd` and no `pi.exe` at all — probing only `.exe` is why
+/// a perfectly good `npm install -g` of pi still read as "not installed".
+/// The extension-less `pi` npm writes beside the shim is a shell script
+/// `CreateProcess` cannot start, so it is deliberately not a candidate.
+fn exe_candidates(name: &str) -> Vec<String> {
+    if cfg!(windows) {
+        vec![
+            format!("{name}.exe"),
+            format!("{name}.cmd"),
+            format!("{name}.bat"),
+        ]
+    } else {
+        vec![name.to_string()]
     }
 }
 
@@ -52,11 +100,13 @@ fn exe_name(name: &str) -> String {
 /// `extra` is searched first, for a tool that owns a directory of its own
 /// (`~/.pi/bin`, `~/.claude/local`).
 pub fn find_with(name: &str, extra: &[PathBuf], dirs: &[PathBuf]) -> Option<PathBuf> {
-    let file = exe_name(name);
+    let files = exe_candidates(name);
+    // Directory-major: an earlier directory wins over a later one whatever
+    // extension each holds, so `extra` keeps beating the well-known dirs.
     extra
         .iter()
         .chain(dirs.iter())
-        .map(|dir| dir.join(&file))
+        .flat_map(|dir| files.iter().map(move |file| dir.join(file)))
         .find(|candidate| is_executable_file(candidate))
 }
 
@@ -128,9 +178,70 @@ mod tests {
 
     fn touch(dir: &Path, name: &str) -> PathBuf {
         std::fs::create_dir_all(dir).unwrap();
-        let p = dir.join(exe_name(name));
+        let p = dir.join(&exe_candidates(name)[0]);
         std::fs::write(&p, "").unwrap();
         p
+    }
+
+    #[test]
+    fn npm_is_probed_by_its_windows_shim_name() {
+        // Regression: `Command::new("npm")` never resolves `npm.cmd`, so the
+        // pi installer reported "neither npm nor bun found" on machines with
+        // Node installed. Bun and node stay bare — they are real `.exe`s.
+        if cfg!(windows) {
+            assert_eq!(spawn_name("npm"), "npm.cmd");
+            assert_eq!(spawn_name("npx"), "npx.cmd");
+        } else {
+            assert_eq!(spawn_name("npm"), "npm");
+            assert_eq!(spawn_name("npx"), "npx");
+        }
+        assert_eq!(spawn_name("bun"), "bun");
+        assert_eq!(spawn_name("node"), "node");
+    }
+
+    #[test]
+    fn windows_looks_for_the_cmd_shim_too() {
+        let got = exe_candidates("pi");
+        if cfg!(windows) {
+            assert_eq!(got, vec!["pi.exe", "pi.cmd", "pi.bat"]);
+        } else {
+            assert_eq!(got, vec!["pi"]);
+        }
+    }
+
+    #[test]
+    fn a_later_extension_in_an_earlier_dir_still_wins() {
+        // Only meaningful on Windows, where a directory holds `pi.cmd` while a
+        // later one may hold `pi.exe`; asserted everywhere so the ordering
+        // contract is not silently inverted by a refactor.
+        let tmp = tempfile::tempdir().unwrap();
+        let first = tmp.path().join("first");
+        let second = tmp.path().join("second");
+        let last_candidate = exe_candidates("pi").pop().unwrap();
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::write(first.join(&last_candidate), "").unwrap();
+        touch(&second, "pi");
+        assert_eq!(
+            find_with("pi", &[], &[first.clone(), second]),
+            Some(first.join(&last_candidate))
+        );
+    }
+
+    #[test]
+    fn windows_search_dirs_cover_the_npm_global_prefix() {
+        let dirs = search_dirs();
+        if cfg!(windows) {
+            let appdata = std::env::var_os("APPDATA").map(PathBuf::from);
+            if let Some(appdata) = appdata {
+                assert!(
+                    dirs.contains(&appdata.join("npm")),
+                    "%APPDATA%\\npm is where `npm install -g` puts pi.cmd"
+                );
+            }
+        } else {
+            assert!(dirs.contains(&PathBuf::from("/opt/homebrew/bin")));
+            assert!(dirs.contains(&PathBuf::from("/usr/local/bin")));
+        }
     }
 
     #[test]
@@ -169,7 +280,7 @@ mod tests {
     #[test]
     fn a_directory_named_like_the_binary_does_not_count() {
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(tmp.path().join(exe_name("claude"))).unwrap();
+        std::fs::create_dir_all(tmp.path().join(&exe_candidates("claude")[0])).unwrap();
         assert_eq!(find_with("claude", &[], &[tmp.path().to_path_buf()]), None);
     }
 

--- a/apps/daemon/tests/http_apps.rs
+++ b/apps/daemon/tests/http_apps.rs
@@ -34,6 +34,8 @@ mod opencode_install;
 mod opencode_settings;
 #[path = "../src/pi_install/mod.rs"]
 mod pi_install;
+#[path = "../src/process_util.rs"]
+mod process_util;
 #[path = "../src/proto.rs"]
 mod proto;
 #[path = "../src/provider_config.rs"]

--- a/apps/daemon/tests/support/crate_modules.rs
+++ b/apps/daemon/tests/support/crate_modules.rs
@@ -27,6 +27,11 @@ mod opencode_install;
 mod opencode_settings;
 #[path = "../../src/pi_install/mod.rs"]
 mod pi_install;
+// Spawning helper introduced by #1045. Only the bin crate root declared it, so
+// every src module that reached for `crate::process_util::CommandNoWindow`
+// failed to resolve here — the same E0433/E0432 shape the note below covers.
+#[path = "../../src/process_util.rs"]
+mod process_util;
 #[path = "../../src/proto.rs"]
 mod proto;
 #[path = "../../src/provider_config.rs"]


### PR DESCRIPTION
## The bug

`amuxd install-pi` bails with `neither npm nor bun found; install Node.js or Bun first` on Windows machines that have a perfectly good Node.js MSI install. Reported from a real Windows box; reinstalling Node cannot fix it.

## Root cause

Rust resolves a bare program name against PATH by appending `.exe` and nothing else — it never consults `PATHEXT`. The Node MSI ships:

- `node.exe` — a real PE, so `Command::new("node")` works and the `Node >= 22.19.0` gate passes
- `npm.cmd` — **no `npm.exe` exists**, so `Command::new("npm")` can never start npm

So `has_command("npm")` and `has_command("bun")` both return false and `ensure_pi` gives up. The daemon already knew this rule — `mcp_probe.rs` has had a private `platform_program()` doing the `.cmd` mapping for MCP servers — `pi_install` just never got it.

## What changed

The same assumption broke every step behind the probe, so this fixes the class rather than the one call:

- **`well_known_bin::spawn_name()`** — one rule for shim names (`npm`, `npx`, `pnpm`, `yarn` → `.cmd` on Windows). `pi_install::command_with_runtime_path` goes through it, which covers the probe, the install invocation and the MCP SDK step in one place. `mcp_probe::platform_program` now delegates to it instead of keeping a second copy.
- **`well_known_bin` probes `.exe`, `.cmd` and `.bat`** rather than `.exe` alone, directory-major so directory precedence is unchanged. A global npm install writes `pi.cmd` and no `pi.exe`, so detection reported "not installed" immediately after installing. The extension-less `pi` npm writes beside the shim is a shell script `CreateProcess` cannot start, so it is deliberately not a candidate.
- **`search_dirs()`** gains `%APPDATA%\npm` (npm's global prefix, where the pi shim lands), `%ProgramFiles%\nodejs` and `~/.bun/bin` on Windows. The POSIX list is untouched.
- **`resolve_pi_package_root()`** also looks in `<dir>/node_modules/@earendil-works/pi-coding-agent`. On Windows the shim is a batch file, not a symlink into the package, so no ancestor is ever the package root — every Windows install was silently falling back to the single-session `--mode rpc` protocol.

The bail message now names the Node version it found, so "npm missing from this process's PATH" is distinguishable from "no Node at all".

## Risk

macOS and Linux behavior is unchanged — every new branch is `cfg!(windows)`, and the POSIX search-dir list is byte-identical.

## Verification

- `cargo check -p amuxd --locked --all-targets` — clean
- `cargo test -p amuxd --bin amuxd` — 11/11 `well_known_bin`, 13/13 `pi_rpc::process`, including 5 new tests
- Not yet exercised on a real Windows box; the reporter's machine is the acceptance test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)