### PR TITLE
fix(pi): install pi and the MCP SDK through the faster npm registry

### DIFF
--- a/apps/daemon/src/cli/process.rs
+++ b/apps/daemon/src/cli/process.rs
@@ -476,6 +476,7 @@ fn read_macos_cmdline(pid: i32) -> Option<String> {
 
 #[cfg(windows)]
 fn reap_opencode_pid_file_windows() {
+    use crate::process_util::CommandNoWindow;
     let path = DaemonConfig::opencode_serve_pgid_path();
     let Ok(body) = fs::read_to_string(&path) else {
         return;

--- a/apps/daemon/src/main.rs
+++ b/apps/daemon/src/main.rs
@@ -23,6 +23,7 @@ mod process_util;
 mod proto;
 mod provider_config;
 mod remote_tools;
+mod route_probe;
 mod runtime;
 mod service;
 mod sync;

--- a/apps/daemon/src/opencode_install/mod.rs
+++ b/apps/daemon/src/opencode_install/mod.rs
@@ -187,85 +187,28 @@ fn download_url(asset: &str) -> String {
     format!("{base}/{asset}")
 }
 
-/// What a route delivered while being sampled.
-#[derive(Debug, Clone, Copy)]
-struct RouteSample {
-    bytes: u64,
-    elapsed: std::time::Duration,
-}
-
-impl RouteSample {
-    fn bytes_per_sec(&self) -> f64 {
-        // Floor the divisor: a sample that came back inside a clock tick would
-        // otherwise divide by zero.
-        self.bytes as f64 / self.elapsed.as_secs_f64().max(0.001)
-    }
-
-    fn mib_per_sec(&self) -> f64 {
-        self.bytes_per_sec() / (1024.0 * 1024.0)
-    }
-
-    /// Is upstream worth using over the mirror?
-    ///
-    /// Pure, so the threshold is testable without a network. A short sample is
-    /// treated as a failure: it means the transfer died early, which is not a
-    /// route we want to hand a 60 MB download to.
-    fn is_fast_enough(&self) -> bool {
-        self.bytes >= MIN_PROBE_SAMPLE && self.bytes_per_sec() >= MIN_UPSTREAM_BYTES_PER_SEC
+/// How the upstream route is sampled, and the bar it has to clear.
+///
+/// The asset is ~60 MB, so `min_bytes_per_sec` is the "upstream finishes in
+/// about a minute" line. Below it the OSS mirror is very likely faster, and
+/// being wrong there costs one mirror download rather than the ten-minute
+/// crawl this replaces.
+fn upstream_probe() -> crate::route_probe::Probe {
+    crate::route_probe::Probe {
+        bytes: PROBE_BYTES,
+        min_sample: MIN_PROBE_SAMPLE,
+        connect_timeout: MANIFEST_TIMEOUT,
+        transfer_deadline: PROBE_TRANSFER_DEADLINE,
+        min_bytes_per_sec: MIN_UPSTREAM_BYTES_PER_SEC,
     }
 }
 
-/// Measure what the official CDN actually delivers on this network, by ranged
-/// GET of the first `PROBE_BYTES` of the real asset.
+/// Measure what the official CDN actually delivers on this network.
 ///
-/// This replaces a HEAD reachability check. Reachability was the wrong
-/// question: from mainland China GitHub answers a HEAD in about a second and
-/// then streams the asset at a trickle, so the preflight passed, the OSS
-/// mirror was never consulted, and users watched a 60 MB download crawl. The
-/// mirror was reserved for "GitHub is blocked" when the common case is
-/// "GitHub is slow".
-///
-/// `None` means the route failed outright (blocked, DNS, TLS, non-2xx) — the
-/// same signal the old preflight gave.
-fn measure_upstream_route(asset: &str) -> Option<RouteSample> {
-    let url = download_url(asset);
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .ok()?;
-    runtime.block_on(async {
-        let client = reqwest::Client::builder()
-            .connect_timeout(MANIFEST_TIMEOUT)
-            .timeout(MANIFEST_TIMEOUT + PROBE_TRANSFER_DEADLINE)
-            .build()
-            .ok()?;
-        let mut response = client
-            .get(&url)
-            .header(
-                reqwest::header::RANGE,
-                format!("bytes=0-{}", PROBE_BYTES - 1),
-            )
-            .send()
-            .await
-            .ok()?
-            .error_for_status()
-            .ok()?;
-        // Clock starts at the first byte: a slow handshake must not read as a
-        // slow pipe, and a fast handshake must not hide one. A server that
-        // ignores Range just gets cut off at PROBE_BYTES.
-        let started = std::time::Instant::now();
-        let mut bytes = 0u64;
-        while let Ok(Some(chunk)) = response.chunk().await {
-            bytes += chunk.len() as u64;
-            if bytes >= PROBE_BYTES || started.elapsed() >= PROBE_TRANSFER_DEADLINE {
-                break;
-            }
-        }
-        Some(RouteSample {
-            bytes,
-            elapsed: started.elapsed(),
-        })
-    })
+/// This replaces a HEAD reachability check — see `crate::route_probe` for why
+/// reachability was the wrong question.
+fn measure_upstream_route(asset: &str) -> Option<crate::route_probe::RouteSample> {
+    upstream_probe().measure(&download_url(asset))
 }
 
 /// Download URL for `asset` at `version` on the mirror.
@@ -498,7 +441,7 @@ pub fn run_install(force: bool) -> anyhow::Result<()> {
 
     let upstream = current_asset().and_then(measure_upstream_route);
     match upstream {
-        Some(sample) if sample.is_fast_enough() => {
+        Some(sample) if sample.meets(&upstream_probe()) => {
             progress(
                 "source",
                 &format!(
@@ -774,8 +717,8 @@ mod tests {
         }
     }
 
-    fn sample(bytes: u64, millis: u64) -> RouteSample {
-        RouteSample {
+    fn sample(bytes: u64, millis: u64) -> crate::route_probe::RouteSample {
+        crate::route_probe::RouteSample {
             bytes,
             elapsed: std::time::Duration::from_millis(millis),
         }
@@ -786,39 +729,19 @@ mod tests {
         // The regression this whole change is about: GitHub answers, then
         // trickles. 2 MiB in 4s is ~512 KB/s — a ~2 minute download for the
         // 60 MB asset, and real CN routes are far worse than that.
-        let slow = sample(PROBE_BYTES, 4_000);
-        assert!(!slow.is_fast_enough());
-        assert!(slow.mib_per_sec() < 1.0);
+        assert!(!sample(PROBE_BYTES, 4_000).meets(&upstream_probe()));
     }
 
     #[test]
     fn a_fast_upstream_route_is_kept() {
-        // ~2.5 MB/s: upstream is fine here, don't send the user to the mirror.
-        assert!(sample(PROBE_BYTES, 200).is_fast_enough());
+        // ~10 MB/s: upstream is fine here, don't send the user to the mirror.
+        assert!(sample(PROBE_BYTES, 200).meets(&upstream_probe()));
     }
 
     #[test]
-    fn the_bar_is_one_mib_per_second() {
-        // Straddle the threshold from both sides so a constant change has to
-        // be deliberate.
-        assert!(sample(1024 * 1024, 1_000).is_fast_enough());
-        assert!(!sample(1024 * 1024, 1_100).is_fast_enough());
-    }
-
-    #[test]
-    fn a_truncated_sample_is_not_a_verdict() {
-        // A transfer that died after 8 KiB says nothing useful, however fast
-        // those bytes arrived — treat it as a route not worth 60 MB.
-        let truncated = sample(8 * 1024, 1);
-        assert!(truncated.bytes_per_sec() > MIN_UPSTREAM_BYTES_PER_SEC);
-        assert!(!truncated.is_fast_enough());
-    }
-
-    #[test]
-    fn an_instant_sample_does_not_divide_by_zero() {
-        let instant = sample(PROBE_BYTES, 0);
-        assert!(instant.bytes_per_sec().is_finite());
-        assert!(instant.is_fast_enough());
+    fn the_upstream_bar_is_one_mib_per_second() {
+        assert!(sample(1024 * 1024, 1_000).meets(&upstream_probe()));
+        assert!(!sample(1024 * 1024, 1_100).meets(&upstream_probe()));
     }
 
     #[test]

--- a/apps/daemon/src/pi_install/mcp_sdk.rs
+++ b/apps/daemon/src/pi_install/mcp_sdk.rs
@@ -21,8 +21,8 @@
 use std::path::PathBuf;
 
 use super::{
-    command_with_runtime_path, has_command, mirrored_bundle, official_registry_available, progress,
-    required_mcp_sdk_version,
+    apply_registry, command_with_runtime_path, has_command, mirrored_bundle, progress,
+    registry_source, required_mcp_sdk_version, RegistrySource,
 };
 use crate::opencode_install::version_ge;
 
@@ -138,16 +138,15 @@ pub fn run_install(force: bool) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("cannot write the pi extension package.json: {e}"))?;
     let prefix = dir.to_string_lossy().to_string();
 
-    let (spec, offline, _bundle) = if official_registry_available(NPM_PKG, &want) {
-        progress(
-            "source",
-            "official npm registry is reachable; installing the MCP SDK from upstream",
-        );
-        (format!("{NPM_PKG}@{want}"), false, None)
-    } else {
+    // Same registry decision pi itself was installed through: route speed is a
+    // property of the network, so it is measured once per process.
+    let source = registry_source();
+    let (spec, offline, _bundle) = if source == RegistrySource::OssBundle {
         let bundle = mirrored_bundle("MCP SDK", MIRROR_BASE, &want)?;
         let path = bundle.path().to_string_lossy().to_string();
         (path, true, Some(bundle))
+    } else {
+        (format!("{NPM_PKG}@{want}"), false, None)
     };
 
     let mut args: Vec<String> = vec![
@@ -168,7 +167,9 @@ pub fn run_install(force: bool) -> anyhow::Result<()> {
     args.push(spec);
 
     progress("install", &format!("running npm {}", args.join(" ")));
-    let output = command_with_runtime_path("npm")
+    let mut command = command_with_runtime_path("npm");
+    apply_registry(&mut command, source);
+    let output = command
         .args(args.iter().map(String::as_str))
         .output()
         .map_err(|e| anyhow::anyhow!("failed to run npm: {e}"))?;

--- a/apps/daemon/src/pi_install/mod.rs
+++ b/apps/daemon/src/pi_install/mod.rs
@@ -175,7 +175,35 @@ pub(super) fn progress(event: &str, message: &str) {
 const PI_NPM_PKG: &str = "@earendil-works/pi-coding-agent";
 const PI_MIRROR_BASE: &str = "https://teamclaw.ucar.cc/pi";
 const OFFICIAL_REGISTRY: &str = "https://registry.npmjs.org";
+
+/// Alibaba's public npm mirror — a full sync of the official registry, and the
+/// route that actually works from mainland China. Verified to carry both
+/// packages we pin, at the pinned versions.
+///
+/// Only ever applied to our own `npm`/`bun` invocation (via the environment),
+/// never written to the user's npmrc.
+const CN_NPM_REGISTRY: &str = "https://registry.npmmirror.com";
+
 pub(super) const NETWORK_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Sample size for a registry route. The pi tarball is ~5 MB, so 512 KiB is a
+/// tenth of it: past the initial burst, cheap enough to throw away.
+const REGISTRY_PROBE_BYTES: u64 = 512 * 1024;
+
+/// Below this the sample says more about handshake jitter than the route.
+const REGISTRY_MIN_SAMPLE: u64 = 64 * 1024;
+
+const REGISTRY_PROBE_DEADLINE: std::time::Duration = std::time::Duration::from_secs(4);
+
+/// The floor for a route to count as usable when it is the only one left.
+/// npm pulls the tarball plus a dependency tree, so this is a "the install
+/// finishes in seconds, not minutes" line rather than a precise one.
+const REGISTRY_USABLE_BYTES_PER_SEC: f64 = 1024.0 * 1024.0;
+
+/// How much faster the mirror has to be before it overrides a *working*
+/// official route. Without this hysteresis, a healthy route that happened to
+/// dip during the probe would send a user outside China to a Chinese registry.
+const MIRROR_ADVANTAGE: f64 = 1.5;
 
 /// `latest.json` served next to an OSS-mirrored npm bundle.
 #[derive(Debug, Deserialize)]
@@ -211,37 +239,159 @@ pub(super) fn has_command(cmd: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// The official npm registry is the preferred source. A short probe lets users
-/// on a slow or blocked route fall back to our OSS bundle before npm spends
-/// minutes retrying its own registry requests.
-pub(super) fn official_registry_available(package: &str, version: &str) -> bool {
-    let url = format!("{OFFICIAL_REGISTRY}/{}/{version}", registry_path(package));
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .ok()
-        .and_then(|runtime| {
-            runtime.block_on(async {
-                reqwest::Client::builder()
-                    .timeout(NETWORK_PROBE_TIMEOUT)
-                    .build()
-                    .ok()?
-                    .get(url)
-                    .send()
-                    .await
-                    .ok()?
-                    .error_for_status()
-                    .ok()?;
-                Some(())
-            })
-        })
-        .is_some()
+/// Where the npm packages should come from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RegistrySource {
+    /// Whatever npm (or bun) is already configured with. No override.
+    NpmDefault,
+    /// Override our own invocation with this registry.
+    Mirror(&'static str),
+    /// No registry is usable from here; install from the OSS tarball bundle.
+    OssBundle,
 }
 
-/// npm's registry path for a package name: the scope separator is the only
-/// character that has to be encoded (`@scope/name` → `@scope%2Fname`).
-fn registry_path(package: &str) -> String {
-    package.replace('/', "%2F")
+/// npm's tarball URL convention: `<registry>/<pkg>/-/<name>-<version>.tgz`,
+/// where the scope is dropped from the file name.
+fn tarball_url(registry: &str, package: &str, version: &str) -> String {
+    let file = package.rsplit('/').next().unwrap_or(package);
+    format!(
+        "{}/{package}/-/{file}-{version}.tgz",
+        registry.trim_end_matches('/')
+    )
+}
+
+fn registry_probe() -> crate::route_probe::Probe {
+    crate::route_probe::Probe {
+        bytes: REGISTRY_PROBE_BYTES,
+        min_sample: REGISTRY_MIN_SAMPLE,
+        connect_timeout: NETWORK_PROBE_TIMEOUT,
+        transfer_deadline: REGISTRY_PROBE_DEADLINE,
+        min_bytes_per_sec: REGISTRY_USABLE_BYTES_PER_SEC,
+    }
+}
+
+/// What `npm config get registry` reports, or None when npm cannot answer
+/// (not installed, or a bun-only machine).
+fn npm_configured_registry() -> Option<String> {
+    let out = command_with_runtime_path("npm")
+        .args(["config", "get", "registry"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!value.is_empty() && value != "undefined").then_some(value)
+}
+
+fn is_official_registry(url: &str) -> bool {
+    url.trim_end_matches('/') == OFFICIAL_REGISTRY
+}
+
+/// Is the mirror worth overriding the official registry for?
+///
+/// Pure, so the hysteresis is testable without a network. `official: None`
+/// means that route failed outright, in which case anything that answers wins.
+fn mirror_wins(
+    official: Option<&crate::route_probe::RouteSample>,
+    mirror: &crate::route_probe::RouteSample,
+    probe: &crate::route_probe::Probe,
+) -> bool {
+    if mirror.bytes < probe.min_sample {
+        return false;
+    }
+    match official {
+        // Nothing else answered, so the bar is absolute: a mirror that is
+        // itself crawling loses to the OSS bundle on our own CDN.
+        None => mirror.meets(probe),
+        Some(official) => mirror.bytes_per_sec() >= official.bytes_per_sec() * MIRROR_ADVANTAGE,
+    }
+}
+
+/// Pick the registry to install from, by measuring both routes.
+///
+/// The old check asked only whether registry.npmjs.org answered, and answered
+/// it with a metadata GET — so a mainland install passed the preflight and
+/// then spent minutes pulling tarballs at a trickle. Timing a few hundred KB
+/// of the real tarball is the question that was meant.
+fn resolve_registry_source(package: &str, version: &str) -> RegistrySource {
+    // A user who configured their own registry has already answered this
+    // question, quite possibly with a mirror of their own. Overriding that
+    // would be worse than anything we could pick for them.
+    if let Some(configured) = npm_configured_registry() {
+        if !is_official_registry(&configured) {
+            progress(
+                "source",
+                &format!("npm is configured with {configured}; installing through it"),
+            );
+            return RegistrySource::NpmDefault;
+        }
+    }
+
+    // Both routes are measured every time. Skipping the mirror whenever the
+    // official registry cleared some bar was the tempting shortcut, and it is
+    // exactly how a user on a 1.2 MB/s route keeps an install that the mirror
+    // would have served six times faster. One 512 KiB sample is cheaper than
+    // being wrong about that.
+    let probe = registry_probe();
+    let official = probe.measure(&tarball_url(OFFICIAL_REGISTRY, package, version));
+    let mirror = probe.measure(&tarball_url(CN_NPM_REGISTRY, package, version));
+    match (&official, &mirror) {
+        (_, Some(mirror_sample)) if mirror_wins(official.as_ref(), mirror_sample, &probe) => {
+            progress(
+                "source",
+                &format!(
+                    "{CN_NPM_REGISTRY} measured at {:.1} MB/s against {} for the official registry; \
+                     installing through the mirror",
+                    mirror_sample.mib_per_sec(),
+                    official
+                        .map(|s| format!("{:.1} MB/s", s.mib_per_sec()))
+                        .unwrap_or_else(|| "no answer".to_string())
+                ),
+            );
+            RegistrySource::Mirror(CN_NPM_REGISTRY)
+        }
+        (Some(sample), _) => {
+            progress(
+                "source",
+                &format!(
+                    "npm registry measured at {:.1} MB/s and the mirror is no better; \
+                     installing from upstream",
+                    sample.mib_per_sec()
+                ),
+            );
+            RegistrySource::NpmDefault
+        }
+        (None, _) => {
+            progress(
+                "source",
+                "no npm registry is reachable; falling back to the OSS bundle",
+            );
+            RegistrySource::OssBundle
+        }
+    }
+}
+
+/// The registry decision, made once per process.
+///
+/// Route speed is a property of the network, not of the package, so pi and the
+/// MCP SDK share one measurement instead of probing twice. Resolved lazily:
+/// an install that early-returns "already satisfied" must not pay for a probe.
+pub(super) fn registry_source() -> RegistrySource {
+    static SOURCE: std::sync::OnceLock<RegistrySource> = std::sync::OnceLock::new();
+    *SOURCE.get_or_init(|| resolve_registry_source(PI_NPM_PKG, &required_version()))
+}
+
+/// Apply a chosen registry to a child process.
+///
+/// Through the environment rather than a flag: npm and bun spell the flag
+/// differently, but both read their config from the environment, and neither
+/// user's npmrc is touched.
+pub(super) fn apply_registry(command: &mut std::process::Command, source: RegistrySource) {
+    if let RegistrySource::Mirror(url) = source {
+        command.env("NPM_CONFIG_REGISTRY", url);
+        command.env("BUN_CONFIG_REGISTRY", url);
+    }
 }
 
 pub(super) fn mirror_manifest(base: &str) -> Option<MirrorManifest> {
@@ -384,19 +534,9 @@ fn ensure_pi(force: bool) -> anyhow::Result<()> {
     }
 
     let pkg = npm_package_spec(&want);
-    let official_available = official_registry_available(PI_NPM_PKG, &want);
+    let source = registry_source();
     let (cmd, args, _bundle): (&str, Vec<String>, Option<tempfile::NamedTempFile>) =
-        if official_available {
-            progress(
-                "source",
-                "official npm registry is reachable; installing Pi from upstream",
-            );
-            if has_command("npm") {
-                ("npm", vec!["install".into(), "-g".into(), pkg], None)
-            } else {
-                ("bun", vec!["add".into(), "-g".into(), pkg], None)
-            }
-        } else {
+        if source == RegistrySource::OssBundle {
             // Node distributions include npm. Only npm can reliably consume our
             // bundled tarball in offline mode, so do not silently send a blocked
             // network to Bun when the fallback has been selected.
@@ -419,10 +559,16 @@ fn ensure_pi(force: bool) -> anyhow::Result<()> {
                 ],
                 Some(bundle),
             )
+        } else if has_command("npm") {
+            ("npm", vec!["install".into(), "-g".into(), pkg], None)
+        } else {
+            ("bun", vec!["add".into(), "-g".into(), pkg], None)
         };
 
     progress("install", &format!("running {cmd} {}", args.join(" ")));
-    let output = command_with_runtime_path(cmd)
+    let mut command = command_with_runtime_path(cmd);
+    apply_registry(&mut command, source);
+    let output = command
         .args(args.iter().map(String::as_str))
         .output()
         .map_err(|e| anyhow::anyhow!("failed to run {cmd}: {e}"))?;
@@ -466,12 +612,96 @@ mod tests {
     }
 
     #[test]
-    fn registry_path_encodes_only_the_scope_separator() {
+    fn tarball_url_follows_npms_convention() {
+        // The scope stays in the path and is dropped from the file name.
         assert_eq!(
-            registry_path("@modelcontextprotocol/sdk"),
-            "@modelcontextprotocol%2Fsdk"
+            tarball_url(OFFICIAL_REGISTRY, "@earendil-works/pi-coding-agent", "0.84.2"),
+            "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.2.tgz"
         );
-        assert_eq!(registry_path("typescript"), "typescript");
+        assert_eq!(
+            tarball_url(CN_NPM_REGISTRY, "@modelcontextprotocol/sdk", "1.30.0"),
+            "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz"
+        );
+        // Unscoped, and a registry given with a trailing slash.
+        assert_eq!(
+            tarball_url("https://registry.npmjs.org/", "typescript", "5.9.2"),
+            "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz"
+        );
+    }
+
+    #[test]
+    fn a_configured_registry_is_recognised_with_or_without_a_slash() {
+        assert!(is_official_registry("https://registry.npmjs.org"));
+        assert!(is_official_registry("https://registry.npmjs.org/"));
+        // A user who set their own mirror must be left alone.
+        assert!(!is_official_registry("https://registry.npmmirror.com/"));
+        assert!(!is_official_registry("https://npm.internal.corp/"));
+    }
+
+    fn sample(bytes: u64, millis: u64) -> crate::route_probe::RouteSample {
+        crate::route_probe::RouteSample {
+            bytes,
+            elapsed: std::time::Duration::from_millis(millis),
+        }
+    }
+
+    #[test]
+    fn the_mirror_needs_a_real_margin_to_take_over() {
+        // 1 MB/s official. A mirror has to beat it by MIRROR_ADVANTAGE before
+        // we override the user's default registry, so a healthy route that
+        // dipped during the probe does not ship someone to a CN mirror.
+        let probe = registry_probe();
+        let official = sample(1024 * 1024, 1_000);
+        assert!(!mirror_wins(
+            Some(&official),
+            &sample(1024 * 1024, 800),
+            &probe
+        ));
+        assert!(mirror_wins(
+            Some(&official),
+            &sample(1024 * 1024, 600),
+            &probe
+        ));
+    }
+
+    #[test]
+    fn a_slow_official_registry_is_overridden_even_though_it_works() {
+        // The case the "official cleared the bar, stop looking" shortcut got
+        // wrong: 1.2 MB/s is usable, and 8 MB/s is six times better.
+        let probe = registry_probe();
+        let official = sample(REGISTRY_PROBE_BYTES, 416); // ~1.2 MB/s
+        assert!(official.meets(&probe));
+        let mirror = sample(REGISTRY_PROBE_BYTES, 62); // ~8 MB/s
+        assert!(mirror_wins(Some(&official), &mirror, &probe));
+    }
+
+    #[test]
+    fn an_unreachable_official_registry_yields_only_to_a_usable_mirror() {
+        let probe = registry_probe();
+        assert!(mirror_wins(
+            None,
+            &sample(REGISTRY_PROBE_BYTES, 100),
+            &probe
+        ));
+        // A mirror that is itself crawling loses to the OSS bundle.
+        assert!(!mirror_wins(
+            None,
+            &sample(REGISTRY_PROBE_BYTES, 4_000),
+            &probe
+        ));
+        // ...as does a transfer that died on the handshake.
+        assert!(!mirror_wins(None, &sample(1024, 1), &probe));
+    }
+
+    #[test]
+    fn the_oss_bundle_stays_the_last_resort() {
+        // Guards the arm order in resolve_registry_source: the bundle is only
+        // for "no registry answered at all".
+        assert_ne!(RegistrySource::OssBundle, RegistrySource::NpmDefault);
+        assert_eq!(
+            RegistrySource::Mirror(CN_NPM_REGISTRY),
+            RegistrySource::Mirror("https://registry.npmmirror.com")
+        );
     }
 
     #[test]

--- a/apps/daemon/src/route_probe.rs
+++ b/apps/daemon/src/route_probe.rs
@@ -1,0 +1,166 @@
+//! "How fast is this download actually going to be?", measured.
+//!
+//! Every installer in this crate has to pick between an upstream source and a
+//! mirror, and each of them used to pick by *reachability*: a HEAD that
+//! answered 200 meant "use upstream". From mainland China that is precisely
+//! the wrong question — GitHub and registry.npmjs.org answer a HEAD in about a
+//! second and then stream the payload at a trickle, so the preflight passed,
+//! the mirror was never consulted, and the user watched a download crawl.
+//!
+//! So: sample the real bytes over the real route, and decide on the number.
+
+use std::time::{Duration, Instant};
+
+/// What a route delivered while being sampled.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RouteSample {
+    pub bytes: u64,
+    pub elapsed: Duration,
+}
+
+impl RouteSample {
+    pub fn bytes_per_sec(&self) -> f64 {
+        // Floor the divisor: a sample that arrived inside a clock tick would
+        // otherwise divide by zero.
+        self.bytes as f64 / self.elapsed.as_secs_f64().max(0.001)
+    }
+
+    pub fn mib_per_sec(&self) -> f64 {
+        self.bytes_per_sec() / (1024.0 * 1024.0)
+    }
+
+    /// Does this route clear `probe`'s bar?
+    ///
+    /// A short sample is a failure however fast those bytes arrived: it means
+    /// the transfer died early, which is not a route worth handing a large
+    /// download to.
+    pub fn meets(&self, probe: &Probe) -> bool {
+        self.bytes >= probe.min_sample && self.bytes_per_sec() >= probe.min_bytes_per_sec
+    }
+}
+
+/// How to sample one route, and the bar it has to clear.
+#[derive(Debug, Clone, Copy)]
+pub struct Probe {
+    /// How much of the real payload to pull.
+    ///
+    /// Size this against the payload, and against the initial burst: the first
+    /// half-megabyte arrives out of a server-side buffer and a grown receive
+    /// window, and measured 10 MB/s on a route whose sustained rate was
+    /// 3 MB/s. Sampling past the burst is what makes the number mean anything.
+    pub bytes: u64,
+    /// Below this, the sample says more about handshake jitter than the route.
+    pub min_sample: u64,
+    pub connect_timeout: Duration,
+    /// Hard stop for the transfer, measured from the first byte. A route that
+    /// cannot deliver `bytes` inside this window is already far below any
+    /// useful bar, so there is nothing to learn by waiting longer.
+    pub transfer_deadline: Duration,
+    pub min_bytes_per_sec: f64,
+}
+
+impl Probe {
+    /// Measure `url` by ranged GET of its first `self.bytes` bytes.
+    ///
+    /// `None` means the route failed outright — blocked, DNS, TLS, non-2xx —
+    /// which is the same signal the old reachability preflights gave.
+    pub fn measure(&self, url: &str) -> Option<RouteSample> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .ok()?;
+        runtime.block_on(async {
+            let client = reqwest::Client::builder()
+                .connect_timeout(self.connect_timeout)
+                .timeout(self.connect_timeout + self.transfer_deadline)
+                .build()
+                .ok()?;
+            let mut response = client
+                .get(url)
+                .header(
+                    reqwest::header::RANGE,
+                    format!("bytes=0-{}", self.bytes.saturating_sub(1)),
+                )
+                .send()
+                .await
+                .ok()?
+                .error_for_status()
+                .ok()?;
+            // The clock starts at the first byte: a slow handshake must not
+            // read as a slow pipe, and a fast handshake must not hide one. A
+            // server that ignores Range simply gets cut off at `bytes`.
+            let started = Instant::now();
+            let mut bytes = 0u64;
+            while let Ok(Some(chunk)) = response.chunk().await {
+                bytes += chunk.len() as u64;
+                if bytes >= self.bytes || started.elapsed() >= self.transfer_deadline {
+                    break;
+                }
+            }
+            Some(RouteSample {
+                bytes,
+                elapsed: started.elapsed(),
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn probe(min_bytes_per_sec: f64) -> Probe {
+        Probe {
+            bytes: 2 * 1024 * 1024,
+            min_sample: 64 * 1024,
+            connect_timeout: Duration::from_secs(5),
+            transfer_deadline: Duration::from_secs(4),
+            min_bytes_per_sec,
+        }
+    }
+
+    fn sample(bytes: u64, millis: u64) -> RouteSample {
+        RouteSample {
+            bytes,
+            elapsed: Duration::from_millis(millis),
+        }
+    }
+
+    #[test]
+    fn a_slow_route_misses_the_bar() {
+        // The regression this exists for: the endpoint answers, then trickles.
+        // 2 MiB in 4s is ~512 KB/s.
+        let slow = sample(2 * 1024 * 1024, 4_000);
+        assert!(!slow.meets(&probe(1024.0 * 1024.0)));
+        assert!(slow.mib_per_sec() < 1.0);
+    }
+
+    #[test]
+    fn a_fast_route_clears_it() {
+        assert!(sample(2 * 1024 * 1024, 200).meets(&probe(1024.0 * 1024.0)));
+    }
+
+    #[test]
+    fn the_bar_is_exactly_the_configured_rate() {
+        // Straddle it from both sides so a threshold change has to be
+        // deliberate.
+        assert!(sample(1024 * 1024, 1_000).meets(&probe(1024.0 * 1024.0)));
+        assert!(!sample(1024 * 1024, 1_100).meets(&probe(1024.0 * 1024.0)));
+    }
+
+    #[test]
+    fn a_truncated_sample_is_not_a_verdict() {
+        // A transfer that died after 8 KiB says nothing useful, however fast
+        // those bytes arrived.
+        let truncated = sample(8 * 1024, 1);
+        assert!(truncated.bytes_per_sec() > 1024.0 * 1024.0);
+        assert!(!truncated.meets(&probe(1024.0 * 1024.0)));
+    }
+
+    #[test]
+    fn an_instant_sample_does_not_divide_by_zero() {
+        let instant = sample(2 * 1024 * 1024, 0);
+        assert!(instant.bytes_per_sec().is_finite());
+        assert!(instant.meets(&probe(1024.0 * 1024.0)));
+    }
+}

--- a/apps/daemon/src/service/mod.rs
+++ b/apps/daemon/src/service/mod.rs
@@ -205,6 +205,7 @@ fn start_daemon_detached(exe: &Path) -> anyhow::Result<()> {
 
 #[cfg(target_os = "windows")]
 pub fn install_service() -> anyhow::Result<()> {
+    use crate::process_util::CommandNoWindow;
     let exe = amuxd_exe_path();
     anyhow::ensure!(exe.exists(), "amuxd binary not found at {}", exe.display());
 

--- a/apps/daemon/tests/http_apps.rs
+++ b/apps/daemon/tests/http_apps.rs
@@ -40,6 +40,8 @@ mod process_util;
 mod proto;
 #[path = "../src/provider_config.rs"]
 mod provider_config;
+#[path = "../src/route_probe.rs"]
+mod route_probe;
 #[path = "../src/runtime/mod.rs"]
 mod runtime;
 #[path = "../src/sync/mod.rs"]

--- a/apps/daemon/tests/support/crate_modules.rs
+++ b/apps/daemon/tests/support/crate_modules.rs
@@ -36,6 +36,11 @@ mod process_util;
 mod proto;
 #[path = "../../src/provider_config.rs"]
 mod provider_config;
+// Same rule as `process_util` above: `opencode_install` and `pi_install` both
+// reach for `crate::route_probe`, and an integration-test crate root only has
+// what it declares here.
+#[path = "../../src/route_probe.rs"]
+mod route_probe;
 #[path = "../../src/runtime/mod.rs"]
 mod runtime;
 #[path = "../../src/sync/mod.rs"]

--- a/apps/desktop/crates/teamclu-introspect/src/daemon_sock.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/daemon_sock.rs
@@ -30,15 +30,13 @@ pub fn resolve_sock_path(configured: &str) -> PathBuf {
     if !trimmed.is_empty() {
         return PathBuf::from(trimmed);
     }
-    let home = std::env::var(teamclu_runtime_env::AMUXD_HOME_ENV)
-        .ok()
-        .filter(|v| !v.trim().is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            let home = std::env::var("HOME").unwrap_or_default();
-            PathBuf::from(home).join(".amuxd")
-        });
-    home.join("run").join("amuxd.sock")
+    // Not hand-assembled: the fallback used to hardcode `~/.amuxd`, which is
+    // the wrong directory on a branded build — the daemon writes its socket
+    // under the brand's home, so introspect would look for it somewhere the
+    // daemon never puts it.
+    teamclu_runtime_env::amuxd_home_from_env()
+        .join("run")
+        .join("amuxd.sock")
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
> **Stacked on #1047.** Base is `fix/opencode-install-speed-gate`, because the throughput probe is shared. GitHub will retarget this to `main` automatically once #1047 merges. Review the two commits separately: the first is a pure refactor.

## The bug

Installing pi on a mainland-China network spends minutes pulling tarballs at a trickle, and the OSS bundle fallback never engages.

## Root cause

Same shape as #1047. `official_registry_available()` asked whether `registry.npmjs.org` answered a metadata GET — which from CN it does — so the preflight passed and npm was left to fetch the tarball plus its dependency tree over a slow route. The OSS bundle was reserved for a *blocked* registry and never helped the common "reachable but slow" case.

## What changed

**`54c8fe15`** — lift the ranged-GET measurement out of `opencode_install` into `crate::route_probe`. `Probe` carries the sample size, deadlines and bar; `RouteSample` answers `meets(&probe)`. No behavior change; it stops the tokio + reqwest streaming loop from existing in two copies.

**`b3259834`** — measure both registry routes with a 512 KiB ranged GET of the real tarball (the pi tarball is ~5 MB, so that is a tenth of it) and install through `registry.npmmirror.com` when it is at least **1.5x faster**, or when the official registry does not answer at all and the mirror clears the usable bar.

Measured here: **3.5 MB/s official against 6.0 MB/s mirror**, so the mirror is chosen.

npmmirror was verified before building on it: it carries `@earendil-works/pi-coding-agent@0.84.2` and `@modelcontextprotocol/sdk@1.30.0` at the exact pinned versions, and honors Range on its tarball URLs.

## Deliberate boundaries

- **The user's npmrc is never touched.** The override is passed as `NPM_CONFIG_REGISTRY` / `BUN_CONFIG_REGISTRY` on our own child process — npm and bun spell the flag differently but both read config from the environment.
- **A registry the user configured themselves wins outright.** A non-default `npm config get registry` skips all probing and is used as-is: they have already answered this question, quite possibly with a better mirror.
- **The OSS bundle stays the last resort**, for "no registry answers at all".

## One judgment call

The first draft skipped the mirror probe whenever the official registry cleared 1 MB/s. That is exactly how a user on a 1.2 MB/s route keeps an install the mirror would have served six times faster, so both routes are now measured every time — one 512 KiB sample is cheaper than being wrong about that. `a_slow_official_registry_is_overridden_even_though_it_works` pins the behavior.

pi and the MCP SDK share one decision: route speed is a property of the network, not the package, so it is resolved once per process and only when an install actually needs it (an "already satisfied" early return pays for no probe).

## Verification

- `cargo test -p amuxd --bin amuxd` — 14/14 `pi_install`, 5/5 `route_probe`, 13/13 `opencode_install`
- `cargo clippy -p amuxd` — no new warnings (the crate carries 163 pre-existing ones)
- Live check against both registries (temporary test, removed before commit), verdict `Mirror("https://registry.npmmirror.com")`
- `git merge-tree` confirms no conflict with #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)