### PR TITLE
fix: scope agents_team_device_uk by owner_member_id

### DIFF
--- a/services/fc/src/db/migrations/0020_agents_team_device_uk_add_owner.sql
+++ b/services/fc/src/db/migrations/0020_agents_team_device_uk_add_owner.sql
@@ -1,0 +1,13 @@
+-- Mirrors services/supabase/migrations/20260824120000_agents_team_device_uk_add_owner.sql
+--
+-- The index was (team_id, device_id) — one agent per team+device regardless of
+-- owner. But findAgentForDevice / findOwned both filter on owner_member_id,
+-- so a device that already had an agent owned by another account would miss
+-- the existing row, try to INSERT a second one, and hit:
+--   duplicate key value violates unique agents_team_device_uk
+--
+-- Now (team_id, device_id, owner_member_id) — one agent per account per device.
+drop index if exists "agents_team_device_uk";
+--> statement-breakpoint
+create unique index if not exists "agents_team_device_uk"
+  on "agents" ("team_id", "device_id", "owner_member_id") where "device_id" is not null;

--- a/services/fc/src/lib/pg-repo/agents.ts
+++ b/services/fc/src/lib/pg-repo/agents.ts
@@ -72,7 +72,7 @@ export function makeAgentsRepo(db: DbLike, ctx: AgentsCtx = {}) {
     },
 
     /**
-     * Idempotent per (team, device): returns the caller-owned agent already bound
+     * Idempotent per (team, device, owner): returns the caller-owned agent already bound
      * to this machine in this team, creating it when absent, plus a one-shot
      * invite for the local daemon to claim.
      *
@@ -81,7 +81,7 @@ export function makeAgentsRepo(db: DbLike, ctx: AgentsCtx = {}) {
      * over the other's (mirrors amux.ensure_agent_for_device).
      *
      * Concurrency: the Supabase path serializes on an advisory lock inside the
-     * RPC. Here the unique index (team_id, device_id) is the arbiter — the loser
+     * RPC. Here the unique index (team_id, device_id, owner_member_id) is the arbiter — the loser
      * of a race catches the violation and re-reads the winner's row, so two cold
      * starts still converge on one agent.
      */
@@ -105,7 +105,6 @@ export function makeAgentsRepo(db: DbLike, ctx: AgentsCtx = {}) {
             eq(actors.teamId, teamId),
             eq(agents.deviceId, deviceId),
             eq(agents.ownerMemberId, callerActorId),
-            eq(agents.status, "active"),
           ),
         )
         .limit(1);
@@ -141,7 +140,6 @@ export function makeAgentsRepo(db: DbLike, ctx: AgentsCtx = {}) {
               eq(actors.teamId, teamId),
               eq(agents.deviceId, deviceId),
               eq(agents.ownerMemberId, callerActorId),
-              eq(agents.status, "active"),
             ),
           )
           .limit(1);
@@ -188,7 +186,7 @@ export function makeAgentsRepo(db: DbLike, ctx: AgentsCtx = {}) {
           });
           created = true;
         } catch (err) {
-          // Lost the race: the winner's row is what this machine gets.
+          // Lost the race: findOwned (no status filter) finds the winner's row.
           agentId = await findOwned();
           if (!agentId) throw err;
         }

--- a/services/fc/test/pg-repo-agents.test.ts
+++ b/services/fc/test/pg-repo-agents.test.ts
@@ -16,6 +16,7 @@ import {
   agents,
   agentMemberAccess,
 } from "../src/db/schema/index.js";
+import { makeAgentsRepo } from "../src/lib/pg-repo/agents.js";
 
 // ── Seed helpers ──────────────────────────────────────────────────────────────
 
@@ -595,4 +596,75 @@ test("authorizeAgentManagement is scoped to the team the caller named", async ()
     /agent not found/,
   );
   await assert.rejects(repo.authorizeAgentManagement(agentActor.id, ""), /teamId is required/);
+});
+
+// ── Device-scoped agent identity (agents_team_device_uk) ─────────────────────
+
+async function seedDeviceAgent(
+  db: any,
+  teamId: string,
+  ownerMemberId: string,
+  deviceId: string,
+  status = "active",
+) {
+  const [agentActor] = await db
+    .insert(actors)
+    .values({ teamId, actorType: "agent", displayName: "DeviceBot" })
+    .returning();
+  await db.insert(agents).values({
+    id: agentActor.id,
+    agentKind: "claude",
+    status,
+    visibility: "personal",
+    ownerMemberId,
+    deviceId,
+    teamId,
+  });
+  return agentActor;
+}
+
+const mockMintInvite = async (_teamId: string, _input: { displayName: string; targetActorId: string; ttlSeconds: number }) =>
+  ({ token: `mock-${Date.now()}-${Math.random()}`, expiresAt: null as string | null });
+
+test("ensureAgentForDevice: two owners on the same device each get their own agent", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const memberA = await seedMemberActor(db, team.id, { userId: "user-a" });
+  const memberB = await seedMemberActor(db, team.id, { userId: "user-b" });
+
+  const repoA = makeAgentsRepo(db, { callerActorId: memberA.id, mintAgentInvite: mockMintInvite });
+  const repoB = makeAgentsRepo(db, { callerActorId: memberB.id, mintAgentInvite: mockMintInvite });
+
+  const a = await repoA.ensureAgentForDevice(team.id, { deviceId: "dev-shared", displayName: "Bot-A" });
+  const b = await repoB.ensureAgentForDevice(team.id, { deviceId: "dev-shared", displayName: "Bot-B" });
+
+  assert.ok(a.agentId, "member A must get an agent");
+  assert.ok(b.agentId, "member B must get an agent");
+  assert.notEqual(a.agentId, b.agentId, "each owner gets a distinct agent");
+  assert.equal(a.created, true, "first call creates");
+  assert.equal(b.created, true, "second owner also creates (index scoped by owner)");
+});
+
+test("findAgentForDevice: returns the caller-owned agent regardless of status", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const member = await seedMemberActor(db, team.id, { userId: "user-find" });
+  await seedDeviceAgent(db, team.id, member.id, "dev-disabled", "disabled");
+
+  const repo = makeAgentsRepo(db, { callerActorId: member.id });
+  const found = await repo.findAgentForDevice(team.id, { deviceId: "dev-disabled" });
+  assert.ok(found.agentId, "a disabled agent must still be found (no status filter)");
+});
+
+test("ensureAgentForDevice: returns an existing disabled agent instead of inserting a duplicate", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const member = await seedMemberActor(db, team.id, { userId: "user-rebind" });
+  const existing = await seedDeviceAgent(db, team.id, member.id, "dev-rebind", "disabled");
+
+  const repo = makeAgentsRepo(db, { callerActorId: member.id, mintAgentInvite: mockMintInvite });
+  const result = await repo.ensureAgentForDevice(team.id, { deviceId: "dev-rebind", displayName: "Rebind" });
+
+  assert.equal(result.agentId, existing.id, "must return the existing agent, not create a new one");
+  assert.equal(result.created, false, "no new agent was created");
 });

--- a/services/fc/test/repository-contract.test.ts
+++ b/services/fc/test/repository-contract.test.ts
@@ -65,7 +65,7 @@ function contractRepo() {
   const roleStore = [
     { id: "role-1", teamId: "team-1", code: "admin", name: "Admin" },
   ];
-  // (team, device) → agent actor, mirroring agents_team_device_uk.
+  // (team, device, owner) → agent actor, mirroring agents_team_device_uk.
   const deviceAgentStore = new Map<string, string>();
   let inviteSeq = 0;
   const permissionStore = [

--- a/services/supabase/migrations/20260824120000_agents_team_device_uk_add_owner.sql
+++ b/services/supabase/migrations/20260824120000_agents_team_device_uk_add_owner.sql
@@ -1,0 +1,135 @@
+-- Fix: agents_team_device_uk was (team_id, device_id) — one agent per
+-- team+device regardless of owner. But findAgentForDevice / findOwned both
+-- filter on owner_member_id, so a device that already had an agent owned by
+-- another account (shared machine, account switch) would miss the existing
+-- row, try to INSERT a second one, and hit the unique constraint:
+--   duplicate key value violates unique agents_team_device_uk
+--
+-- The design intent (documented in 20260812120000) is "one agent per account
+-- per device" — a shared machine gets one agent each. The index now matches:
+-- (team_id, device_id, owner_member_id).
+--
+-- The find RPCs also dropped the status = 'active' predicate so a disabled or
+-- archived agent is found (and silently re-bound) instead of triggering a
+-- duplicate insert that the index would reject.
+
+drop index if exists amux.agents_team_device_uk;
+
+create unique index if not exists agents_team_device_uk
+  on amux.agents (team_id, device_id, owner_member_id)
+  where device_id is not null;
+
+-- ── find_agent_for_device (drop status filter) ──────────────────────────────
+
+create or replace function amux.find_agent_for_device(
+  p_team_id uuid,
+  p_device_id text
+) returns table(agent_id uuid, display_name text)
+  language sql
+  stable
+  security definer
+  set search_path to 'amux', 'public', 'auth'
+as $function$
+  select ag.id, a.display_name
+    from amux.agents ag
+    join amux.actors a on a.id = ag.id
+   where a.team_id = p_team_id
+     and ag.device_id = nullif(btrim(p_device_id), '')
+     and ag.owner_member_id = amux.current_actor_id_for_team(p_team_id)
+   limit 1
+$function$;
+
+comment on function amux.find_agent_for_device(uuid, text) is
+  'This machine''s agent in this team, if the caller already owns one. Read-only companion to ensure_agent_for_device: the client uses it to decide whether to ask the user to name a new agent. Returns the agent regardless of status — a disabled or archived agent is still bound to this device.';
+
+grant execute on function amux.find_agent_for_device(uuid, text)
+  to authenticated, service_role;
+
+-- ── ensure_agent_for_device (drop status filter from lookup) ─────────────────
+
+create or replace function amux.ensure_agent_for_device(
+  p_team_id uuid,
+  p_device_id text,
+  p_display_name text
+) returns table(agent_id uuid, token text, expires_at timestamp with time zone, created boolean)
+  language plpgsql
+  security definer
+  set search_path to 'amux', 'public', 'auth', 'app'
+as $function$
+declare
+  v_caller  uuid := amux.current_actor_id_for_team(p_team_id);
+  v_device  text := nullif(btrim(p_device_id), '');
+  v_name    text := nullif(btrim(p_display_name), '');
+  v_agent   uuid;
+  v_created boolean := false;
+  v_invite  record;
+begin
+  if v_caller is null then
+    raise exception 'ensure_agent_for_device requires team membership'
+      using errcode = '42501';
+  end if;
+  if v_device is null then
+    raise exception 'p_device_id is required' using errcode = '22023';
+  end if;
+  if v_name is null then
+    raise exception 'p_display_name is required' using errcode = '22023';
+  end if;
+
+  -- Serialize concurrent callers for the same machine. Two cold starts (or two
+  -- windows of the same app) would otherwise both find nothing and both create
+  -- an agent; the unique index would reject the loser, but only after it had
+  -- minted an invite and rotated the daemon's credentials onto it.
+  perform pg_advisory_xact_lock(hashtext(p_team_id::text || ':' || v_device)::bigint);
+
+  -- Lookup no longer filters on status = 'active'. A disabled or archived
+  -- agent is still the device's agent — finding it avoids a duplicate insert
+  -- that the unique index (now scoped by owner_member_id) would reject.
+  select ag.id into v_agent
+    from amux.agents ag
+    join amux.actors a on a.id = ag.id
+   where a.team_id = p_team_id
+     and ag.device_id = v_device
+     and ag.owner_member_id = v_caller;
+
+  if v_agent is null then
+    insert into amux.actors (team_id, actor_type, user_id, invited_by_actor_id, display_name, last_active_at)
+    values (p_team_id, 'agent', null, v_caller, v_name, null)
+    returning id into v_agent;
+
+    -- visibility is deliberately not passed: the column default ('personal') is
+    -- the wanted default now that nothing asks the user. Publishing the machine
+    -- to the team is an explicit later action (PATCH /v1/agents/{id}).
+    insert into amux.agents (id, owner_member_id, status, device_id, team_id)
+    values (v_agent, v_caller, 'active', v_device, p_team_id);
+
+    insert into amux.agent_member_access (agent_id, member_id, permission_level, granted_by_member_id)
+    values (v_agent, v_caller, 'admin', v_caller)
+    on conflict on constraint agent_member_access_agent_id_member_id_key do update
+      set permission_level = 'admin', updated_at = now();
+
+    v_created := true;
+  end if;
+  -- p_display_name is create-only on purpose. The client passes a name the user
+  -- typed when the machine was first bound; re-applying it on every rebind would
+  -- overwrite any later rename (and the client's fallback is the hostname, so a
+  -- renamed robot would silently revert on the next launch).
+
+  select * into v_invite from amux.create_team_invite(
+    p_team_id         => p_team_id,
+    p_kind            => 'agent',
+    p_display_name    => v_name,
+    p_team_role       => null,
+    p_agent_kind      => 'claude',
+    p_ttl_seconds     => 600,
+    p_target_actor_id => v_agent
+  );
+
+  return query select v_agent, v_invite.token, v_invite.expires_at, v_created;
+end;
+$function$;
+
+comment on function amux.ensure_agent_for_device(uuid, text, text) is
+  'Idempotent per (team, device, owner): returns this machine''s agent in this team, creating it (visibility personal) if absent, plus a one-shot invite for the daemon to claim. An agent owned by another account is a separate row — a shared machine gets one agent per account. The lookup ignores status so a disabled/archived agent is re-bound rather than triggering a duplicate-key violation.';
+
+grant execute on function amux.ensure_agent_for_device(uuid, text, text)
+  to authenticated, service_role;


### PR DESCRIPTION
## Problem

Naming a local agent fails with `duplicate key value violates unique agents_team_device_uk` when the device already has an agent in the team that doesn't match the caller's `owner_member_id` or has a non-active status.

## Root cause

The unique index `agents_team_device_uk` was scoped to `(team_id, device_id)` — one agent per team+device, regardless of owner. But `findAgentForDevice` and `findOwned` both filter on `owner_member_id = caller` AND `status = 'active'`. When a device already has an agent owned by another account (shared machine, account switch) or with a non-active status, the find returns null, the code tries to INSERT a second row, and the index rejects it.

The design intent (documented in `20260812120000`) is "one agent per account per device" — but the index didn't include `owner_member_id`, making this structurally impossible.

## Fix

- **Index**: Changed from `(team_id, device_id)` to `(team_id, device_id, owner_member_id)` in both Supabase and FC pg migrations. Each account can now have its own agent on a shared device.
- **Find queries**: Removed the `status = 'active'` filter from `findAgentForDevice` and `findOwned` (pg-repo) and from the `find_agent_for_device` / `ensure_agent_for_device` RPCs (Supabase). A disabled or archived agent is now found and re-bound instead of triggering a duplicate insert.
- **Catch block**: The pg-repo race-recovery `findOwned()` now works correctly because it no longer filters on status — the conflicting row is always found.

## Files changed

| File | Change |
|------|--------|
| `services/supabase/migrations/20260824120000_*.sql` | New migration: drop + recreate index, rewrite RPCs |
| `services/fc/src/db/migrations/0020_*.sql` | New FC pg migration: mirror the index change |
| `services/fc/src/lib/pg-repo/agents.ts` | Remove status filter from find queries, update comments |
| `services/fc/test/pg-repo-agents.test.ts` | 3 new tests: multi-owner, disabled agent, rebind |
| `services/fc/test/repository-contract.test.ts` | Update comment to reflect new index scope |

## Test results

- `pg-repo-agents.test.ts`: 35/35 pass (including 3 new tests)
- `supabase-repo.test.ts`: 88/88 pass
- Pre-existing LiteLLM test failure in `pg-repo-contract.test.ts` is unrelated.

## Notes

- The Supabase migration file is ready but the live database has **not** been updated via MCP yet. Apply through Supabase MCP before deploying.
