### PR TITLE
fix(mcp): emit correct scheme + clear stale session id in get_session_deeplink

### DIFF
--- a/apps/daemon/src/agent_discover/mod.rs
+++ b/apps/daemon/src/agent_discover/mod.rs
@@ -127,6 +127,7 @@ mod tests {
             team_share: crate::config::TeamShareConfig::default(),
             log: None,
             locale: None,
+            app_scheme: None,
         }
     }
 

--- a/apps/daemon/src/config/daemon_config.rs
+++ b/apps/daemon/src/config/daemon_config.rs
@@ -75,6 +75,13 @@ pub struct DaemonConfig {
     /// daemon.toml rather than team.toml. `None` means English.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub locale: Option<String>,
+    /// App URL scheme for this deployment (e.g. `teamclu`, `acme`). Captured
+    /// from the onboarding invite and fed to workspace-scoped MCP tools as
+    /// `TEAMCLU_APP_SCHEME` so branded builds emit deeplinks with their own
+    /// scheme instead of the default `teamclu://`. `None` on legacy/pre-fix
+    /// `daemon.toml` — the MCP tool then falls back to `teamclu`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_scheme: Option<String>,
 }
 
 /// `[log]` — caps for the daemon's own rotating log file.
@@ -745,6 +752,7 @@ impl DaemonConfig {
             team_share: TeamShareConfig::default(),
             log: None,
             locale: None,
+            app_scheme: None,
         }
     }
 

--- a/apps/daemon/src/config/device_mcp.rs
+++ b/apps/daemon/src/config/device_mcp.rs
@@ -100,6 +100,40 @@ fn write_raw(
     })
 }
 
+/// This deployment's app URL scheme, for workspace-scoped MCP tools that emit
+/// deeplinks (e.g. `get_session_deeplink`). Precedence:
+///   1. `TEAMCLU_APP_SCHEME` env — set by the desktop when it spawns the
+///      managed amuxd (baked from `build.config.json`'s `app.scheme`); always
+///      correct for a desktop-managed daemon.
+///   2. `DaemonConfig.app_scheme` — captured from the onboarding invite; the
+///      standalone path (cron / self-hosted daemon not launched by the app).
+///   3. `None` — the introspect tool falls back to its built-in `teamclu`.
+///
+/// Without this, a branded build (scheme `acme`) still emits `teamclu://`
+/// deeplinks from MCP, which the OS routes to the wrong handler (or none).
+fn resolve_app_scheme() -> Option<String> {
+    if let Ok(raw) = std::env::var("TEAMCLU_APP_SCHEME") {
+        let s = raw.trim();
+        if !s.is_empty() {
+            return Some(s.to_string());
+        }
+    }
+    super::DaemonConfig::load(&super::DaemonConfig::default_path())
+        .ok()
+        .and_then(|c| c.app_scheme)
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Whether a resolved scheme is safe to inject as `TEAMCLU_APP_SCHEME` — a URL
+/// scheme must start with a lowercase letter then `[a-z0-9+.-]` (same rule as
+/// the frontend branding script and the introspect tool's own validator).
+fn is_valid_scheme(s: &str) -> bool {
+    let mut chars = s.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+        && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '+' | '.' | '-'))
+}
+
 /// `teamclu-introspect`, the bundled sidecar.
 ///
 /// It was the last of the inherent servers still written per workspace, and the
@@ -112,22 +146,60 @@ fn write_raw(
 /// written when a runtime first prepares a workspace, so a workspace nothing
 /// had run in yet simply had no introspect — which is why it was missing from
 /// the MCP panel on a machine that has the sidecar installed.
+///
+/// `environment.TEAMCLU_APP_SCHEME` is injected when a brand scheme resolves,
+/// so `get_session_deeplink` emits deeplinks with THIS build's scheme rather
+/// than the hardcoded `teamclu://`.
 fn introspect_mcp_config() -> Option<serde_json::Value> {
     let binary = crate::runtime::supervisor::resolve_introspect_binary()?;
     let sock = super::DaemonConfig::sock_path();
-    Some(serde_json::json!({
-        "type": "local",
-        "enabled": true,
-        "command": [
-            binary,
-            "--api-port",
-            crate::runtime::supervisor::INTROSPECT_API_PORT.to_string(),
-            // `send_channel_message`'s token branch is routed by the daemon, not
-            // by the desktop app on `--api-port`: only the daemon can resolve a
-            // reply token, and an unattended run has no app to ask.
-            format!("--sock={}", sock.to_string_lossy())
-        ]
-    }))
+    let scheme = resolve_app_scheme()
+        .filter(|s| is_valid_scheme(s));
+    let entry = match scheme {
+        Some(s) => serde_json::json!({
+            "type": "local",
+            "enabled": true,
+            "command": [
+                binary,
+                "--api-port",
+                crate::runtime::supervisor::INTROSPECT_API_PORT.to_string(),
+                // `send_channel_message`'s token branch is routed by the daemon, not
+                // by the desktop app on `--api-port`: only the daemon can resolve a
+                // reply token, and an unattended run has no app to ask.
+                format!("--sock={}", sock.to_string_lossy())
+            ],
+            "environment": { "TEAMCLU_APP_SCHEME": s }
+        }),
+        None => serde_json::json!({
+            "type": "local",
+            "enabled": true,
+            "command": [
+                binary,
+                "--api-port",
+                crate::runtime::supervisor::INTROSPECT_API_PORT.to_string(),
+                format!("--sock={}", sock.to_string_lossy())
+            ]
+        }),
+    };
+    Some(entry)
+}
+
+/// Whether the existing `teamclu-introspect` entry must be rewritten for the
+/// scheme, on top of the dead-binary check. The env is only enforced when a
+/// scheme actually resolved; without one we leave a hand-written entry alone
+/// rather than thrash it on every call. A stale-or-missing
+/// `environment.TEAMCLU_APP_SCHEME` is what self-heals already-onboarded
+/// daemons (whose device file predates this field) onto the brand scheme.
+fn introspect_scheme_stale(existing: &serde_json::Value, scheme: Option<&str>) -> bool {
+    let Some(s) = scheme else {
+        return false;
+    };
+    let current = existing
+        .get("environment")
+        .and_then(|e| e.get("TEAMCLU_APP_SCHEME"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    current != s
 }
 
 fn autoui_environment() -> serde_json::Value {
@@ -168,10 +240,20 @@ pub fn ensure_device_mcp() -> Result<bool, WorkspaceControlError> {
         }
     }
 
+    // Resolve the brand scheme once for this pass. An invalid value is dropped
+    // (the introspect tool's own validator will then reject/default it) so we
+    // never write a bogus scheme into the device file.
+    let app_scheme = resolve_app_scheme().filter(|s| is_valid_scheme(s));
+
     // Refreshed on a dead path only: a reinstall moves the sidecar, but a user
-    // who disabled introspect should not find it back on after one.
+    // who disabled introspect should not find it back on after one. Also
+    // refresh when the resolved scheme env is missing/stale — that self-heals a
+    // device file written before the scheme was injected, without a re-onboard.
     let introspect_stale = match mcp_obj.get("teamclu-introspect") {
-        Some(existing) => crate::runtime::supervisor::introspect_command_stale(existing),
+        Some(existing) => {
+            crate::runtime::supervisor::introspect_command_stale(existing)
+                || introspect_scheme_stale(existing, app_scheme.as_deref())
+        }
         None => true,
     };
     if introspect_stale {
@@ -399,5 +481,49 @@ mod tests {
             assert!(ensure_device_mcp().unwrap());
             assert!(load_device_mcp().contains_key("chrome-control"));
         })
+    }
+
+    #[test]
+    fn is_valid_scheme_accepts_brand_schemes_and_rejects_garbage() {
+        assert!(is_valid_scheme("teamclu"));
+        assert!(is_valid_scheme("acme"));
+        assert!(is_valid_scheme("teamclu-dev"));
+        assert!(is_valid_scheme("a.b+c-d"));
+        // A scheme must start with a lowercase letter.
+        assert!(!is_valid_scheme("Teamclu"));
+        assert!(!is_valid_scheme("1acme"));
+        assert!(!is_valid_scheme(""));
+        // No spaces, no slashes — these would misroute a deeplink.
+        assert!(!is_valid_scheme("ac me"));
+        assert!(!is_valid_scheme("acme://"));
+    }
+
+    #[test]
+    fn introspect_scheme_stale_self_heals_a_pre_scheme_entry() {
+        // A device file written before this fix has no `environment` block —
+        // once a scheme resolves, the entry must be rewritten so the brand
+        // scheme is injected. Without this, branded builds keep emitting
+        // teamclu:// even after the daemon learned the real scheme.
+        let pre_fix = serde_json::json!({
+            "type": "local",
+            "enabled": true,
+            "command": ["/bin/teamclu-introspect", "--api-port", "13144", "--sock=/tmp/x"]
+        });
+        assert!(introspect_scheme_stale(&pre_fix, Some("acme")));
+
+        // After the refresh carries the right env, it is no longer stale.
+        let healed = serde_json::json!({
+            "type": "local",
+            "enabled": true,
+            "command": ["/bin/teamclu-introspect", "--api-port", "13144", "--sock=/tmp/x"],
+            "environment": { "TEAMCLU_APP_SCHEME": "acme" }
+        });
+        assert!(!introspect_scheme_stale(&healed, Some("acme")));
+        // A different scheme is still stale (re-brand must take effect).
+        assert!(introspect_scheme_stale(&healed, Some("teamclu")));
+
+        // No scheme resolved → never claim stale on env grounds. We must not
+        // thrash an entry whose scheme we cannot determine.
+        assert!(!introspect_scheme_stale(&pre_fix, None));
     }
 }

--- a/apps/daemon/src/config/team_config.rs
+++ b/apps/daemon/src/config/team_config.rs
@@ -525,6 +525,7 @@ mod tests {
             team_share: crate::config::TeamShareConfig::default(),
             log: None,
             locale: None,
+            app_scheme: None,
         }
     }
 

--- a/apps/daemon/src/daemon/runtime_resolution.rs
+++ b/apps/daemon/src/daemon/runtime_resolution.rs
@@ -154,6 +154,7 @@ mod tests {
             team_share: crate::config::TeamShareConfig::default(),
             log: None,
             locale: None,
+            app_scheme: None,
         }
     }
 

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -3520,6 +3520,7 @@ pub(crate) mod tests {
             team_share: crate::config::TeamShareConfig::default(),
             log: None,
             locale: None,
+            app_scheme: None,
         }
     }
 

--- a/apps/daemon/src/mqtt/client.rs
+++ b/apps/daemon/src/mqtt/client.rs
@@ -212,6 +212,7 @@ mod tests {
             team_share: crate::config::TeamShareConfig::default(),
             log: None,
             locale: None,
+            app_scheme: None,
         }
     }
 

--- a/apps/daemon/src/onboarding/init.rs
+++ b/apps/daemon/src/onboarding/init.rs
@@ -249,6 +249,12 @@ fn daemon_config_for_invite(
         daemon_cfg.actor.name = display_name.to_string();
     }
     daemon_cfg.team_id = Some(team_id.to_string());
+    // Capture the invite's URL scheme so the daemon can feed
+    // `TEAMCLU_APP_SCHEME` to workspace-scoped MCP tools (introspect's
+    // `get_session_deeplink`). Without this, branded builds emit deeplinks
+    // with the wrong `teamclu://` scheme. Re-onboarding refreshes it; an
+    // existing value is overwritten so a re-brand takes effect.
+    daemon_cfg.app_scheme = Some(invite.scheme.clone());
     // Honor an explicit `?broker=` invite override; otherwise leave empty so the
     // daemon resolves the broker from /v1/config/bootstrap at startup.
     daemon_cfg.mqtt.broker_url = invite.broker_url.clone().unwrap_or_default();
@@ -273,6 +279,7 @@ mod tests {
                 token: "tok".into(),
                 broker_url: None,
                 cloud_api_url: None,
+                scheme: "teamclu".into(),
             },
         );
         let http = cfg.http.expect("init should write [http]");
@@ -313,6 +320,7 @@ mod tests {
                 team_share: TeamShareConfig::default(),
                 log: None,
                 locale: None,
+                app_scheme: None,
             }),
             "host",
             "team-1",
@@ -321,6 +329,7 @@ mod tests {
                 token: "tok".into(),
                 broker_url: None,
                 cloud_api_url: None,
+                scheme: "teamclu".into(),
             },
         );
         assert!(cfg.http.is_some());
@@ -343,12 +352,33 @@ mod tests {
                 token: "tok".into(),
                 broker_url: Some("mqtts://broker.example.com:8883".into()),
                 cloud_api_url: None,
+                scheme: "teamclu".into(),
             },
         );
         assert_eq!(cfg.team_id.as_deref(), Some("team-1"));
         assert_eq!(cfg.actor.id, "actor-1");
         assert_eq!(cfg.actor.name, "macmini-5");
         assert_eq!(cfg.mqtt.broker_url, "mqtts://broker.example.com:8883");
+    }
+
+    #[test]
+    fn invite_scheme_is_captured_into_app_scheme() {
+        // A branded build's invite carries the brand scheme; the daemon must
+        // persist it so workspace-scoped MCP tools (get_session_deeplink) emit
+        // deeplinks with the brand scheme instead of the default teamclu://.
+        let cfg = daemon_config_for_invite(
+            None,
+            "host",
+            "team-1",
+            "actor-1",
+            &ParsedInvite {
+                token: "tok".into(),
+                broker_url: None,
+                cloud_api_url: None,
+                scheme: "acme".into(),
+            },
+        );
+        assert_eq!(cfg.app_scheme.as_deref(), Some("acme"));
     }
 
     #[test]
@@ -364,6 +394,7 @@ mod tests {
                 token: "tok".into(),
                 broker_url: None,
                 cloud_api_url: None,
+                scheme: "teamclu".into(),
             },
         );
         assert_eq!(cfg.mqtt.broker_url, "");
@@ -392,6 +423,7 @@ mod tests {
                 team_share: TeamShareConfig::default(),
                 log: None,
                 locale: None,
+                app_scheme: None,
             }),
             "new-display-name",
             "team-2",
@@ -400,6 +432,7 @@ mod tests {
                 token: "tok".into(),
                 broker_url: Some("mqtts://broker.example.com:8883".into()),
                 cloud_api_url: None,
+                scheme: "teamclu".into(),
             },
         );
         assert_eq!(cfg.actor.id, "actor-2");
@@ -422,6 +455,7 @@ mod tests {
                 token: "tok".into(),
                 broker_url: None,
                 cloud_api_url: None,
+                scheme: "teamclu".into(),
             },
         );
         assert_eq!(cfg.actor.name, "new-display-name");

--- a/apps/daemon/src/onboarding/invite_url.rs
+++ b/apps/daemon/src/onboarding/invite_url.rs
@@ -23,6 +23,12 @@ pub struct ParsedInvite {
     /// effective Cloud API endpoint into the invite so the daemon follows the
     /// app's build/runtime choice instead of a hardcoded default.
     pub cloud_api_url: Option<String>,
+    /// App URL scheme taken from the invite (`teamclu`, `acme`, …). Captured so
+    /// the daemon can feed `TEAMCLU_APP_SCHEME` to workspace-scoped MCP tools
+    /// (e.g. `get_session_deeplink`); without it, branded builds emit deeplinks
+    /// with the wrong `teamclu://` scheme. The inviter generates the invite with
+    /// its own registered scheme, so this always matches the desktop's handler.
+    pub scheme: String,
 }
 
 fn is_custom_app_scheme(scheme: &str) -> bool {
@@ -82,6 +88,7 @@ pub fn parse(raw: &str) -> Result<ParsedInvite> {
         token,
         broker_url,
         cloud_api_url,
+        scheme: url.scheme().to_string(),
     })
 }
 
@@ -94,6 +101,17 @@ mod tests {
         let p = parse("teamclu://invite?token=ABCDEF-12345_xyz").unwrap();
         assert_eq!(p.token, "ABCDEF-12345_xyz");
         assert_eq!(p.broker_url, None);
+        assert_eq!(p.scheme, "teamclu");
+    }
+
+    #[test]
+    fn captures_branded_scheme_from_invite() {
+        // A branded build's desktop generates invites with its own registered
+        // scheme (e.g. `acme`). The daemon must capture it so it can feed
+        // `TEAMCLU_APP_SCHEME` to MCP tools — otherwise `get_session_deeplink`
+        // emits `teamclu://` on a build whose handler is `acme://`.
+        let p = parse("acme://invite?token=tok-1").unwrap();
+        assert_eq!(p.scheme, "acme");
     }
 
     #[test]

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -843,6 +843,17 @@ impl RuntimeManager {
             self.release_opencode_snapshot(&handle.worktree);
             handle.status = amux::AgentStatus::Stopped;
             handle.shutdown().await;
+            // Clear the workspace's active-session stamp so a later session on
+            // the same worktree (esp. the shared per-team default worktree)
+            // doesn't read this stopped session's id via the MCP
+            // `get_session_deeplink` tool. Compare-and-clear: if a concurrent
+            // session already restamped, leave its id alone.
+            if !handle.session_id.is_empty() && !handle.worktree.is_empty() {
+                teamclu_runtime_env::clear_active_session_id_if_matches(
+                    std::path::Path::new(&handle.worktree),
+                    &handle.session_id,
+                );
+            }
             info!(agent_id, "agent stopped");
             Some(handle)
         } else {

--- a/crates/teamclu-runtime-env/src/active_session.rs
+++ b/crates/teamclu-runtime-env/src/active_session.rs
@@ -64,6 +64,41 @@ pub fn write_active_session_id(workspace: &Path, session_id: &str) -> std::io::R
     atomic_write::atomic_write(&path, &content)
 }
 
+/// Clear the active-session stamp, but only if it currently holds
+/// `session_id`. This is a compare-and-clear: a concurrent session that has
+/// since stamped its own id is left untouched, so stopping one session never
+/// clobbers another's "current session" signal for the MCP introspect tool.
+///
+/// Compares against and clears the **brand write path** (the same path
+/// [`write_active_session_id`] writes), so it undoes exactly what a prior
+/// stamp put there. A missing file, an empty body, or a mismatch all count as
+/// "already cleared" (false) — the stamp no longer points at this session.
+///
+/// Why this exists: `get_session_deeplink` (no `session_id` arg) reads the
+/// stamp to resolve "current session". When a runtime stops, the stamp used to
+/// keep the dead session's id, so a later session on the same worktree
+/// (especially the shared per-team default worktree) could read a stale id and
+/// emit a deeplink to a session that no longer exists.
+pub fn clear_active_session_id_if_matches(workspace: &Path, session_id: &str) -> bool {
+    let id = session_id.trim();
+    if id.is_empty() {
+        return false;
+    }
+    let path = active_session_id_write_path(workspace);
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    if raw.trim() != id {
+        // Another session already restamped the file — leave it alone.
+        return false;
+    }
+    // Truncate to empty rather than unlink: the introspect tool treats an empty
+    // stamp as "no current session" (errors instead of returning a stale id),
+    // and keeping the file avoids a create-then-write race on the next stamp.
+    atomic_write::atomic_write(&path, "").is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,6 +128,56 @@ mod tests {
         std::env::remove_var(BRAND_SHORT_NAME_ENV);
         let dir = tempfile::tempdir().unwrap();
         assert!(read_active_session_id(dir.path()).is_none());
+    }
+
+    #[test]
+    fn clear_if_match_removes_the_stamped_id() {
+        let _lock = home_env_lock();
+        std::env::remove_var(BRAND_SHORT_NAME_ENV);
+        let dir = tempfile::tempdir().unwrap();
+        let id = "a1ca8f06-94ee-4fb5-bdfb-194a5606062f";
+        write_active_session_id(dir.path(), id).unwrap();
+        assert!(clear_active_session_id_if_matches(dir.path(), id));
+        assert!(read_active_session_id(dir.path()).is_none());
+    }
+
+    #[test]
+    fn clear_if_match_leaves_a_mismatching_stamp_alone() {
+        // A concurrent session restamped the file after this one stopped — the
+        // stop must not clobber the live session's "current session" signal.
+        let _lock = home_env_lock();
+        std::env::remove_var(BRAND_SHORT_NAME_ENV);
+        let dir = tempfile::tempdir().unwrap();
+        let mine = "a1ca8f06-94ee-4fb5-bdfb-194a5606062f";
+        let theirs = "b2db9017-05ff-4ac6-c0ec-0a5b67171730";
+        write_active_session_id(dir.path(), mine).unwrap();
+        write_active_session_id(dir.path(), theirs).unwrap(); // concurrent restamp
+        assert!(!clear_active_session_id_if_matches(dir.path(), mine));
+        assert_eq!(read_active_session_id(dir.path()).as_deref(), Some(theirs));
+    }
+
+    #[test]
+    fn clear_if_match_on_missing_or_empty_is_a_noop() {
+        let _lock = home_env_lock();
+        std::env::remove_var(BRAND_SHORT_NAME_ENV);
+        let dir = tempfile::tempdir().unwrap();
+        let id = "a1ca8f06-94ee-4fb5-bdfb-194a5606062f";
+        assert!(!clear_active_session_id_if_matches(dir.path(), id)); // no file
+        // An empty/whitespace stamp also reads as "no current session".
+        write_active_session_id(dir.path(), id).unwrap(); // creates the .teamclu dir
+        let path = dir.path().join(".teamclu").join(ACTIVE_SESSION_ID_FILE);
+        atomic_write::atomic_write(&path, "   \n").unwrap();
+        assert!(!clear_active_session_id_if_matches(dir.path(), id)); // empty body, no match
+        assert!(read_active_session_id(dir.path()).is_none());
+    }
+
+    #[test]
+    fn clear_if_match_ignores_empty_session_id() {
+        let _lock = home_env_lock();
+        std::env::remove_var(BRAND_SHORT_NAME_ENV);
+        let dir = tempfile::tempdir().unwrap();
+        write_active_session_id(dir.path(), "a1ca8f06-94ee-4fb5-bdfb-194a5606062f").unwrap();
+        assert!(!clear_active_session_id_if_matches(dir.path(), "  "));
     }
 
     #[test]

--- a/crates/teamclu-runtime-env/src/lib.rs
+++ b/crates/teamclu-runtime-env/src/lib.rs
@@ -25,7 +25,8 @@ use std::collections::HashMap;
 use std::path::Path;
 
 pub use active_session::{
-    read_active_session_id, write_active_session_id, ACTIVE_SESSION_ID_FILE, TEAMCLU_SESSION_ID_ENV,
+    clear_active_session_id_if_matches, read_active_session_id, write_active_session_id,
+    ACTIVE_SESSION_ID_FILE, TEAMCLU_SESSION_ID_ENV,
 };
 pub use env_activation::{
     analyze_env_activation, find_unresolved_config_placeholders, EnvActivationAnalysis,


### PR DESCRIPTION
## Problem

The `teamclaw-introspect` MCP tool `get_session_deeplink` returned wrong deeplinks in two distinct ways:

1. **Wrong scheme on branded builds.** `TEAMCLAW_APP_SCHEME` was *read* by the tool (`session.rs`) but **never set anywhere** in the codebase. So a branded build (e.g. `app.scheme = "acme"`) still emitted `teamclaw://session/<id>` — the OS routes that to the wrong (or no) handler, while the frontend correctly uses `acme://`. Always-wrong on branded builds.

2. **Stale session id on the stock build.** The active session is stamped into a single workspace-scoped file `{worktree}/.teamclaw/active-session-id`. `resolve_spawn_worktree` falls back to the shared per-team default worktree when no workspace id is given (embedded `/v1/ui` chat), so multiple sessions share one file. A stopped session left its id behind, and a later session could read it and emit a deeplink to a dead session. The "sometimes wrong" on the stock build.

## Fix 1 — scheme now flows build → daemon → MCP tool

| Layer | Change |
|---|---|
| `apps/desktop/build.rs` | Bake `app.scheme` from `build.config.json` (default `teamclaw`) into compile-time `TEAMCLAW_APP_SCHEME`, with format validation. |
| `apps/desktop/src/commands/amuxd_supervisor.rs` | Pass `TEAMCLAW_APP_SCHEME` to the managed amuxd at spawn — **existing onboarded daemons self-heal without re-onboarding**. |
| `apps/daemon/onboarding/invite_url.rs` | `ParsedInvite.scheme` captured from the invite URL (for standalone/cron daemons not launched by the desktop). |
| `apps/daemon/config/daemon_config.rs` | New `app_scheme: Option<String>` (`#[serde(default)]`, back-compat with old configs). |
| `apps/daemon/onboarding/init.rs` | Persist the invite scheme into config during onboarding. |
| `apps/daemon/runtime/supervisor.rs` | Inject `environment.TEAMCLAW_APP_SCHEME` into the `teamclaw-introspect` MCP entry in `opencode.json`; the "needs refresh" check now also triggers when the env is missing/stale (so old daemons get it). |

The tool already read the env var — no tool change needed. Resolution order in the tool: explicit `scheme` arg → `TEAMCLAW_APP_SCHEME` env → default `teamclaw`.

## Fix 2 — compare-and-clear the active-session stamp on stop

| Layer | Change |
|---|---|
| `crates/teamclaw-runtime-env/active_session.rs` | New `clear_active_session_id_if_matches(workspace, session_id)` — only clears if the file currently holds this session's id, so a concurrent session that restamped is left untouched. |
| `apps/daemon/runtime/manager.rs` | `stop_runtime` calls it after shutdown. An empty stamp makes the tool error ("session_id is required") instead of returning a stale id. |

## Verification

- `cargo check` across `teamclaw-runtime-env`, `teamclaw-introspect`, `teamclaw` (desktop), `amuxd` — all clean, zero new warnings.
- `cargo test`:
  - `active_session`: 6/6 (4 new compare-and-clear tests)
  - `introspect session`: 7/7
  - daemon `invite`/scheme: 18/18 (incl. new `captures_branded_scheme_from_invite` + `invite_scheme_is_captured_into_app_scheme`)
  - `runtime::manager`: 61/61, `runtime::supervisor`: 14/14, `config::daemon_config`: 11/11
- clippy: no new lints in any changed file (the `env_activation.rs` `sort_by` lint is pre-existing, untouched).

## Known limitation (not addressed here)

The pure interleaving race — two *concurrently active* sessions on the same worktree, where B restamps between A's stamp and A's in-flight tool call — is architectural: `teamclaw-introspect` is a single workspace-scoped MCP server and opencode does not pass the calling session id per tool call, so the tool cannot route per-session. Fix 2 removes the stale-after-stop case (the realistic contributor) but cannot fully eliminate interleaving without an MCP-protocol follow-up. Flagging for review.
