### PR TITLE
refactor(skills): 把 skills 扫描收敛到 .claude / .agents / opencode.json

### DIFF
--- a/apps/daemon/src/config/roles_skills.rs
+++ b/apps/daemon/src/config/roles_skills.rs
@@ -90,19 +90,6 @@ fn process_brand() -> String {
     teamclu_runtime_env::brand_short_name_from_env()
 }
 
-/// Canonical (write) skills directory for the process brand.
-fn brand_skills_dir(workspace_path: &Path) -> PathBuf {
-    teamclu_runtime_env::workspace_meta_write_path_from_env(workspace_path, "skills")
-}
-
-/// Meta skills roots to scan (canonical first, then legacy `.teamclu/skills`).
-fn meta_skills_dirs(workspace_path: &Path) -> Vec<PathBuf> {
-    teamclu_runtime_env::workspace_meta_read_roots(workspace_path, &process_brand())
-        .into_iter()
-        .map(|root| root.join("skills"))
-        .collect()
-}
-
 fn meta_roles_dirs(workspace_path: &Path) -> Vec<PathBuf> {
     teamclu_runtime_env::workspace_meta_read_roots(workspace_path, &process_brand())
         .into_iter()
@@ -112,14 +99,6 @@ fn meta_roles_dirs(workspace_path: &Path) -> Vec<PathBuf> {
 
 fn brand_roles_dir(workspace_path: &Path) -> PathBuf {
     teamclu_runtime_env::workspace_meta_write_path_from_env(workspace_path, "roles")
-}
-
-fn workspace_brand_config_rel() -> String {
-    format!(
-        "{}/{}",
-        teamclu_runtime_env::workspace_meta_dir_name(&process_brand()),
-        teamclu_runtime_env::workspace_config_file_name(&process_brand())
-    )
 }
 
 struct RawSkill {
@@ -132,9 +111,6 @@ struct RawSkill {
     is_role_skill: bool,
 }
 
-/// The brand meta directory outranks every other root.
-const RANK_META: u8 = 0;
-
 struct SkillDirSpec {
     path: PathBuf,
     /// Display label. Never used to order anything — see `rank`.
@@ -146,31 +122,10 @@ struct SkillDirSpec {
     /// edits, and feeds to an agent. The numbers mirror the frontend's
     /// `SKILL_SOURCE_PRIORITY` so both loaders resolve a collision the same way.
     rank: u8,
-    /// The brand meta directory, where `builtin` / `clawhub` classification
-    /// applies. Stated here instead of inferred from the path: the inference
-    /// (`is_meta_skills_dir`) matched any `skills` directory under a dot-prefixed
-    /// parent, which is all of them.
-    is_meta: bool,
 }
 
 fn io_err(e: std::io::Error) -> WorkspaceControlError {
     WorkspaceControlError::Io(e.to_string())
-}
-
-fn read_clawhub_slugs(workspace_path: &Path) -> HashSet<String> {
-    for lock_name in [".clawhub/lock.json", ".clawdhub/lock.json"] {
-        let lock_path = workspace_path.join(lock_name);
-        let Ok(content) = std::fs::read_to_string(&lock_path) else {
-            continue;
-        };
-        let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&content) else {
-            continue;
-        };
-        if let Some(skills) = parsed.get("skills").and_then(|v| v.as_object()) {
-            return skills.keys().cloned().collect();
-        }
-    }
-    HashSet::new()
 }
 
 fn read_json_paths(workspace_path: &Path, config_rel: &str, key: &str) -> Vec<PathBuf> {
@@ -303,16 +258,6 @@ fn load_skills_from_dir(dir: &Path, source: &str) -> Result<Vec<RawSkill>, Works
     Ok(skills)
 }
 
-fn classify_teamclu_skill(filename: &str, clawhub_slugs: &HashSet<String>) -> &'static str {
-    if is_inherent_skill(filename) {
-        "builtin"
-    } else if clawhub_slugs.contains(filename) {
-        "clawhub"
-    } else {
-        "local"
-    }
-}
-
 fn onboarded_team_id() -> Option<String> {
     super::DaemonConfig::load(&super::DaemonConfig::default_path())
         .ok()
@@ -392,19 +337,15 @@ fn collect_team_skill_paths(workspace_path: &Path) -> Vec<PathBuf> {
         }
     };
 
-    for config_rel in [
-        workspace_brand_config_rel(),
-        format!(
-            "{}/{}",
-            teamclu_runtime_env::WORKSPACE_META_DIR,
-            teamclu_runtime_env::WORKSPACE_CONFIG_FILE
-        ),
-        "teamclu.json".to_string(),
-    ] {
-        for extra in read_json_paths(workspace_path, &config_rel, "/skills/paths") {
-            push(extra);
-        }
-    }
+    // `opencode.json` is the only config consulted for `skills.paths`.
+    //
+    // It is also the only one anything writes: the desktop's
+    // `ensure_agents_skills_paths` registers `~/.agents/skills` in
+    // `<ws>/opencode.json`, `.claude/settings.json` and `~/.claude/settings.json`
+    // — never in a brand config. The three brand files this used to read
+    // (`.teamclu/teamclu.json`, `.teamclu/teamclaw.json`, `teamclu.json`) had no
+    // writer, so parsing them only widened the surface a hand-edited file could
+    // pull skills in from.
     for extra in read_json_paths(workspace_path, "opencode.json", "/skills/paths") {
         push(extra);
     }
@@ -428,55 +369,26 @@ fn collect_team_skill_paths(workspace_path: &Path) -> Vec<PathBuf> {
 
 /// Every root scanned for skills, in one place so the ranks can be read — and
 /// tested — as a table rather than inferred from call order.
+///
+/// Deliberately short. The roots that used to be here and are not any more:
+///
+/// - the brand meta dir (`.teamclu/skills` + the legacy `.teamclaw/skills`) —
+///   nothing writes it. `upsert_skill` writes the caller's `dir_path`, the
+///   desktop's "new skill" dialog writes `~/.agents/skills` directly, and the
+///   inherent skills are seeded there too (`runtime::supervisor`).
+/// - `.opencode/skills` and `~/.config/opencode/skills` — opencode-era roots
+///   with no writer left; the seeded copies in the former always lost to a
+///   higher-ranked root anyway, so they were never what an agent loaded.
+/// - `~/.config/teamclu/skills` — never had a writer either.
 fn skill_dir_specs(workspace_path: &Path, home: &Path) -> Vec<SkillDirSpec> {
     let home_str = home.to_string_lossy();
     let home_trimmed = home_str.trim_end_matches('/');
 
-    let mut specs: Vec<SkillDirSpec> = meta_skills_dirs(workspace_path)
-        .into_iter()
-        .map(|path| SkillDirSpec {
-            path,
-            source: "local",
-            rank: RANK_META,
-            is_meta: true,
-        })
-        .collect();
-    specs.extend([
-        SkillDirSpec {
-            path: workspace_path.join(".opencode/skills"),
-            source: "opencode",
-            rank: 11,
-            is_meta: false,
-        },
+    let mut specs: Vec<SkillDirSpec> = vec![
         SkillDirSpec {
             path: workspace_path.join(".claude/skills"),
             source: "claude",
             rank: 1,
-            is_meta: false,
-        },
-        SkillDirSpec {
-            path: workspace_path.join(".agents/skills"),
-            source: "shared",
-            rank: 3,
-            is_meta: false,
-        },
-        SkillDirSpec {
-            path: PathBuf::from(format!("{home_trimmed}/.config/teamclu/skills")),
-            source: "global-teamclu",
-            rank: 7,
-            is_meta: false,
-        },
-        SkillDirSpec {
-            path: PathBuf::from(format!("{home_trimmed}/.config/opencode/skills")),
-            source: "global-opencode",
-            rank: 10,
-            is_meta: false,
-        },
-        SkillDirSpec {
-            path: PathBuf::from(format!("{home_trimmed}/.claude/skills")),
-            source: "global-claude",
-            rank: 8,
-            is_meta: false,
         },
         SkillDirSpec {
             path: PathBuf::from(format!("{home_trimmed}/.agents/skills")),
@@ -493,16 +405,24 @@ fn skill_dir_specs(workspace_path: &Path, home: &Path) -> Vec<SkillDirSpec> {
             // the install path offers exactly that when it has to take a path
             // over (`archive_unmanaged`).
             rank: 2,
-            is_meta: false,
         },
-    ]);
+        SkillDirSpec {
+            path: workspace_path.join(".agents/skills"),
+            source: "shared",
+            rank: 3,
+        },
+        SkillDirSpec {
+            path: PathBuf::from(format!("{home_trimmed}/.claude/skills")),
+            source: "global-claude",
+            rank: 5,
+        },
+    ];
 
     for extra in collect_team_skill_paths(workspace_path) {
         specs.push(SkillDirSpec {
             path: extra,
             source: "team",
             rank: 4,
-            is_meta: false,
         });
     }
 
@@ -513,7 +433,6 @@ fn load_all_skills(
     workspace_path: &Path,
     home: &Path,
 ) -> Result<Vec<RawSkill>, WorkspaceControlError> {
-    let clawhub_slugs = read_clawhub_slugs(workspace_path);
     let specs = skill_dir_specs(workspace_path, home);
 
     // Which copy of a duplicated slug survives is decided by the *directory* it
@@ -528,15 +447,17 @@ fn load_all_skills(
     for spec in specs {
         let mut batch = load_skills_from_dir(&spec.path, spec.source)?;
         for skill in batch.drain(..) {
-            // `builtin` / `clawhub` are properties of the brand meta directory —
-            // they are read out of that workspace's own lockfile and inherent
-            // list — so the classification only applies there. The frontend
-            // loader has always scoped it that way (`skill-loader.ts`:
-            // "`.teamclu/skills/` → 'local' / 'builtin' / 'clawhub'"); this used
-            // to apply it to every root whose parent name began with a dot,
-            // which is every skills root there is.
-            let source = if spec.is_meta {
-                classify_teamclu_skill(&skill.filename, &clawhub_slugs).to_owned()
+            // `builtin` is a property of the skill's *name*, not of the root it
+            // sits in. The inherent skills are seeded into `~/.agents/skills`
+            // (`runtime::supervisor`) alongside everything else there, and the
+            // Agent-side inventory already classifies them this way
+            // (`daemon::server::rpc::skill_inventory`). Labelling by root, as
+            // this used to, only worked while they lived in a root of their own.
+            //
+            // The rank stays the spec's: what a skill is *called* must not
+            // decide which copy of a duplicated slug the app opens and edits.
+            let source = if is_inherent_skill(&skill.filename) {
+                "builtin".to_owned()
             } else {
                 skill.source.clone()
             };
@@ -829,8 +750,10 @@ pub struct UpsertSkillRequest {
     pub content: String,
     #[serde(default)]
     pub skill_name: Option<String>,
-    #[serde(default)]
-    pub install_location: Option<String>,
+    // `installLocation` used to pick between the brand meta dir and
+    // `~/.agents/skills`. There is one root left, so the field is gone; an old
+    // client that still sends it is ignored, not rejected (no
+    // `deny_unknown_fields`).
     #[serde(default)]
     pub dir_path: Option<String>,
     #[serde(default)]
@@ -932,6 +855,14 @@ fn confine_path(
     }
 }
 
+/// Where a skill goes when the caller names no directory.
+///
+/// Always `~/.agents/skills`. It is the one root every runtime reads (opencode,
+/// Claude Code and pi all get it through `skills.paths` /
+/// `ensure_agents_skills_paths`), and it is where the desktop's own "new skill"
+/// dialog has always written. There is no second choice to offer: the arm this
+/// used to have named the brand meta dir, which is not scanned any more, so
+/// honouring it would write a file nothing can see.
 fn skills_dir_for_request(
     workspace_path: &Path,
     home: &Path,
@@ -940,10 +871,7 @@ fn skills_dir_for_request(
     if let Some(dir) = req.dir_path.as_deref().filter(|d| !d.is_empty()) {
         return confine_path(dir, workspace_path, home);
     }
-    if req.install_location.as_deref() == Some("global") {
-        return Ok(home.join(".agents/skills"));
-    }
-    Ok(brand_skills_dir(workspace_path))
+    Ok(home.join(".agents/skills"))
 }
 
 pub fn upsert_skill(
@@ -1045,15 +973,18 @@ pub fn delete_skill(
         vec![confine_path(dir, workspace_path, &home)?.join(slug)]
     } else {
         {
-            let mut paths: Vec<PathBuf> = meta_skills_dirs(workspace_path)
-                .into_iter()
-                .map(|dir| dir.join(slug))
-                .collect();
-            paths.push(workspace_path.join(".opencode/skills").join(slug));
+            // Only the roots this daemon writes to itself. Every caller that can
+            // see a skill also has its `dirPath` and passes it, so this fallback
+            // exists for the one it wrote without being told where — which is
+            // always `~/.agents/skills` now (`skills_dir_for_request`).
+            //
+            // Deliberately not "every scanned root": that would let a delete
+            // with no `dirPath` reach into `.claude/skills`, where the team
+            // bridge keeps its symlinks.
+            let mut paths = vec![home.join(".agents/skills").join(slug)];
             for roles in meta_roles_dirs(workspace_path) {
                 paths.push(roles.join(ROLE_SKILL_DIR).join(slug));
             }
-            paths.push(home.join(".config/opencode/skills").join(slug));
             paths
         }
     };
@@ -1251,7 +1182,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let ws = dir.path();
 
-        let skill_dir = ws.join(".teamclu/skills/demo-skill");
+        let skill_dir = ws.join(".claude/skills/demo-skill");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -1276,27 +1207,37 @@ mod tests {
         );
     }
 
+    /// A directory-less upsert lands in `~/.agents/skills`, and the matching
+    /// delete finds it there.
     #[test]
     fn upsert_and_delete_skill_round_trip() {
-        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
         let ws = tempfile::tempdir().unwrap();
         let req = UpsertSkillRequest {
             content: "# Demo\n\nBody".to_owned(),
             skill_name: Some("Demo Skill".to_owned()),
-            install_location: Some("workspace".to_owned()),
             dir_path: None,
             filename: None,
         };
         let saved = upsert_skill(ws.path(), "demo-skill", &req).unwrap();
         assert_eq!(saved.filename, "demo-skill");
+        assert!(home
+            .path()
+            .join(".agents/skills/demo-skill/SKILL.md")
+            .is_file());
+        assert!(
+            !ws.path().join(".teamclu/skills/demo-skill").exists(),
+            "the brand meta dir is no longer a write target"
+        );
 
         delete_skill(ws.path(), "demo-skill", None).unwrap();
         let state = scan_roles_skills_state(ws.path()).unwrap();
         assert!(
             !state.skills.iter().any(|s| s.filename == "demo-skill"),
-            "deleted workspace skill must be gone"
+            "deleted skill must be gone"
         );
-        assert!(!ws.path().join(".teamclu/skills/demo-skill").exists());
+        assert!(!home.path().join(".agents/skills/demo-skill").exists());
     }
 
     /// Write a one-file skill and return its directory.
@@ -1330,24 +1271,61 @@ mod tests {
         let pack_root = rank_of(home.path().join(".agents/skills"));
 
         assert!(pack_root < rank_of(home.path().join(".claude/skills")));
-        assert!(pack_root < rank_of(home.path().join(".config/opencode/skills")));
-        assert!(pack_root < rank_of(ws.path().join(".opencode/skills")));
-        // The workspace's own dirs still win: a project that ships a skill is
-        // making a narrower statement than the team registry.
+        assert!(pack_root < rank_of(ws.path().join(".agents/skills")));
+        // The workspace's own `.claude/skills` still wins: a project that ships
+        // a skill is making a narrower statement than the team registry.
         assert!(pack_root > rank_of(ws.path().join(".claude/skills")));
-        assert!(pack_root > RANK_META);
+    }
+
+    /// The retired roots stay retired. Each of these had a writer once and has
+    /// none now; scanning them again would resurrect copies that no longer
+    /// match what the runtimes load.
+    #[test]
+    fn the_retired_roots_are_not_scanned() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let ws = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let scanned: Vec<PathBuf> = skill_dir_specs(ws.path(), home.path())
+            .into_iter()
+            .map(|spec| spec.path)
+            .collect();
+
+        for retired in [
+            ws.path().join(".teamclu/skills"),
+            ws.path().join(".teamclaw/skills"),
+            ws.path().join(".opencode/skills"),
+            home.path().join(".config/teamclu/skills"),
+            home.path().join(".config/opencode/skills"),
+        ] {
+            assert!(
+                !scanned.contains(&retired),
+                "{} must not be scanned any more",
+                retired.display()
+            );
+        }
+        assert_eq!(scanned.len(), 4, "four fixed roots, plus config paths");
     }
 
     #[test]
     fn a_duplicated_slug_resolves_by_root_rank_not_by_scan_order() {
         let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
         // `.claude/skills` (rank 1) outranks `.agents/skills` (3), which
-        // outranks `.opencode/skills` (11) — regardless of the order the specs
-        // happen to be listed in. Ordering used to be derived from the source
-        // label, and since every dot-prefixed root was relabelled `local` they
-        // all tied, leaving the winner to array position.
+        // outranks a config-declared team path (4) — regardless of the order the
+        // specs happen to be listed in. Ordering used to be derived from the
+        // source label, and since every dot-prefixed root was relabelled `local`
+        // they all tied, leaving the winner to array position.
         let ws = tempfile::tempdir().unwrap();
-        seed_skill(ws.path(), ".opencode/skills", "dup", "opencode");
+        let team_root = ws.path().join("team-skills");
+        std::fs::create_dir_all(&team_root).unwrap();
+        std::fs::write(
+            ws.path().join("opencode.json"),
+            format!(
+                r#"{{"skills":{{"paths":["{}"]}}}}"#,
+                team_root.to_string_lossy()
+            ),
+        )
+        .unwrap();
+        seed_skill(ws.path(), "team-skills", "dup", "team");
         seed_skill(ws.path(), ".agents/skills", "dup", "agents");
         let expected = seed_skill(ws.path(), ".claude/skills", "dup", "claude");
 
@@ -1363,30 +1341,18 @@ mod tests {
         assert!(rows[0].content.contains("claude"));
     }
 
+    /// `builtin` is a property of the skill's name, not of the root it sits in.
+    ///
+    /// The inherent skills used to live in a root of their own (the brand meta
+    /// dir), so labelling by root and labelling by name were the same thing.
+    /// They are seeded into `~/.agents/skills` now, next to team packs and the
+    /// user's own files, and only the name still separates them — which is how
+    /// the Agent-side inventory has always read them.
     #[test]
-    fn only_the_brand_meta_dir_gets_the_local_builtin_clawhub_labels() {
+    fn inherent_skills_are_labelled_builtin_whatever_root_they_sit_in() {
         let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
-        // `builtin` and `clawhub` are read out of the workspace's own inherent
-        // list and lockfile, so they describe the brand meta directory and
-        // nothing else. This used to be applied to every root whose parent name
-        // began with a dot — i.e. every skills root — which flattened the
-        // settings UI's source badges to one value and, worse, collapsed the
-        // precedence order they were being derived from.
         let ws = tempfile::tempdir().unwrap();
-        std::fs::write(
-            ws.path().join(".clawhub-lock-placeholder"),
-            "not the lockfile",
-        )
-        .unwrap();
-        std::fs::create_dir_all(ws.path().join(".clawhub")).unwrap();
-        std::fs::write(
-            ws.path().join(".clawhub/lock.json"),
-            r#"{"skills":{"market-pack":{"version":"1"}}}"#,
-        )
-        .unwrap();
-
-        seed_skill(ws.path(), ".teamclu/skills", "market-pack", "in meta dir");
-        seed_skill(ws.path(), ".teamclu/skills", "create-role", "inherent");
+        seed_skill(ws.path(), ".agents/skills", "create-role", "inherent");
         seed_skill(ws.path(), ".agents/skills", "elsewhere", "shared root");
         seed_skill(ws.path(), ".claude/skills", "claude-one", "claude root");
 
@@ -1399,10 +1365,8 @@ mod tests {
                 .and_then(|s| s.source.clone())
         };
 
-        // Inside the meta dir: classified.
-        assert_eq!(source_of("market-pack").as_deref(), Some("clawhub"));
         assert_eq!(source_of("create-role").as_deref(), Some("builtin"));
-        // Outside it: the root's own label, not `local`.
+        // Everything else keeps its root's own label.
         assert_eq!(source_of("elsewhere").as_deref(), Some("shared"));
         assert_eq!(source_of("claude-one").as_deref(), Some("claude"));
     }
@@ -1422,9 +1386,9 @@ mod tests {
         // just written to, which the loser never gets: the file was written
         // correctly and only the confirmation failed.
         let ws = tempfile::tempdir().unwrap();
-        // The lower-ranked root, standing in for `~/.agents/skills` (rank 9),
+        // The lower-ranked root, standing in for `~/.agents/skills` (rank 2),
         // where team packs live — without needing to move HOME.
-        let pack_dir = ws.path().join(".opencode/skills");
+        let pack_dir = ws.path().join(".agents/skills");
         std::fs::create_dir_all(pack_dir.join("deploy-check")).unwrap();
         std::fs::write(
             pack_dir.join("deploy-check/SKILL.md"),
@@ -1455,7 +1419,6 @@ mod tests {
         let req = UpsertSkillRequest {
             content: "---\nname: deploy-check\n---\nedited by the user\n".to_owned(),
             skill_name: Some("deploy-check".to_owned()),
-            install_location: None,
             dir_path: Some(pack_dir.to_string_lossy().into_owned()),
             filename: Some("deploy-check".to_owned()),
         };
@@ -1483,7 +1446,6 @@ mod tests {
         let req = UpsertSkillRequest {
             content: "# Evil".to_owned(),
             skill_name: Some("Evil".to_owned()),
-            install_location: None,
             dir_path: Some(outside.path().to_string_lossy().into_owned()),
             filename: Some("pwned".to_owned()),
         };
@@ -1494,12 +1456,12 @@ mod tests {
 
     #[test]
     fn upsert_skill_rejects_traversal_in_filename() {
-        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
         let ws = tempfile::tempdir().unwrap();
         let req = UpsertSkillRequest {
             content: "# Evil".to_owned(),
             skill_name: None,
-            install_location: Some("workspace".to_owned()),
             dir_path: None,
             filename: Some("../../escape".to_owned()),
         };
@@ -1542,10 +1504,11 @@ mod tests {
     }
 
     #[test]
-    fn white_label_scan_reads_brand_meta_without_teamclu_dir() {
+    fn white_label_scan_reads_brand_meta_roles_without_teamclu_dir() {
         let _guard = crate::test_brand_env::BrandEnvGuard::set("copilot361");
         let ws = tempfile::tempdir().unwrap();
-        let skill_dir = ws.path().join(".copilot361/skills/brand-skill");
+        // Skills are brand-independent now — `.claude/skills` under any brand.
+        let skill_dir = ws.path().join(".claude/skills/brand-skill");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -1564,7 +1527,7 @@ mod tests {
         let state = scan_roles_skills_state(ws.path()).unwrap();
         assert!(
             state.skills.iter().any(|s| s.filename == "brand-skill"),
-            "brand meta skills must be visible"
+            "workspace skills must be visible under a white-label brand too"
         );
         assert!(
             state.roles.iter().any(|r| r.slug == "brand-role"),
@@ -1572,8 +1535,10 @@ mod tests {
         );
     }
 
+    /// Roles still fall back to the legacy meta dir; skills do not, because no
+    /// meta dir is a skills root any more.
     #[test]
-    fn white_label_scan_falls_back_to_legacy_teamclu_meta() {
+    fn white_label_roles_fall_back_to_legacy_teamclu_meta_but_skills_do_not() {
         let _guard = crate::test_brand_env::BrandEnvGuard::set("copilot361");
         let ws = tempfile::tempdir().unwrap();
         let skill_dir = ws.path().join(".teamclu/skills/legacy-skill");
@@ -1583,31 +1548,45 @@ mod tests {
             "---\nname: Legacy Skill\ndescription: legacy\n---\n\n# Legacy",
         )
         .unwrap();
+        let role_dir = ws.path().join(".teamclu/roles/legacy-role");
+        std::fs::create_dir_all(&role_dir).unwrap();
+        std::fs::write(
+            role_dir.join("ROLE.md"),
+            "---\nname: legacy-role\ndescription: Legacy role\n---\n\n## Role\nLegacy.\n",
+        )
+        .unwrap();
 
         let state = scan_roles_skills_state(ws.path()).unwrap();
         assert!(
-            state.skills.iter().any(|s| s.filename == "legacy-skill"),
-            "legacy .teamclu/skills must still be scanned for white-label"
+            state.roles.iter().any(|r| r.slug == "legacy-role"),
+            "legacy .teamclu/roles must still be scanned for white-label"
+        );
+        assert!(
+            !state.skills.iter().any(|s| s.filename == "legacy-skill"),
+            "the meta dir is not a skills root any more"
         );
     }
 
+    /// Skills are not brand-namespaced any more: a white-label build writes the
+    /// same `~/.agents/skills` as the official one, because that is the root
+    /// every runtime reads.
     #[test]
-    fn white_label_upsert_writes_brand_skills_dir() {
-        let _guard = crate::test_brand_env::BrandEnvGuard::set("copilot361");
+    fn white_label_upsert_writes_the_shared_agents_dir() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("copilot361", home.path());
         let ws = tempfile::tempdir().unwrap();
         let req = UpsertSkillRequest {
             content: "# Brand\n\nBody".to_owned(),
             skill_name: Some("Brand Skill".to_owned()),
-            install_location: Some("workspace".to_owned()),
             dir_path: None,
             filename: None,
         };
         let saved = upsert_skill(ws.path(), "brand-skill", &req).unwrap();
         assert_eq!(saved.filename, "brand-skill");
-        assert!(ws
+        assert!(home
             .path()
-            .join(".copilot361/skills/brand-skill/SKILL.md")
+            .join(".agents/skills/brand-skill/SKILL.md")
             .is_file());
-        assert!(!ws.path().join(".teamclu/skills/brand-skill").exists());
+        assert!(!ws.path().join(".copilot361/skills/brand-skill").exists());
     }
 }

--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -18,32 +18,16 @@ fn brand_workspace_config(workspace: &Path) -> PathBuf {
     teamclu_runtime_env::workspace_config_path_from_env(workspace)
 }
 
-fn brand_skills_dir(workspace: &Path) -> PathBuf {
-    teamclu_runtime_env::workspace_meta_write_path_from_env(workspace, "skills")
-}
-
 fn legacy_workspace_config(workspace: &Path) -> PathBuf {
     workspace
         .join(teamclu_runtime_env::WORKSPACE_META_DIR)
         .join(teamclu_runtime_env::WORKSPACE_CONFIG_FILE)
 }
 
-fn legacy_skills_dir(workspace: &Path) -> PathBuf {
-    workspace
-        .join(teamclu_runtime_env::WORKSPACE_META_DIR)
-        .join("skills")
-}
-
 fn is_workspace_config_path(path: &Path, workspace: &Path) -> bool {
     let brand = brand_workspace_config(workspace);
     let legacy = legacy_workspace_config(workspace);
     path == brand || (legacy != brand && path == legacy)
-}
-
-fn is_meta_skills_path(path: &Path, workspace: &Path) -> bool {
-    let brand = brand_skills_dir(workspace);
-    let legacy = legacy_skills_dir(workspace);
-    path.starts_with(&brand) || (legacy != brand && path.starts_with(&legacy))
 }
 
 /// Return both the workspace-visible team path and its physical target.
@@ -177,10 +161,12 @@ pub fn classify_change_path(
     let mut changes = Vec::new();
     let mut seen = HashSet::new();
 
+    // Mirrors `config::roles_skills::skill_dir_specs`. A root that is watched
+    // but not scanned only produces refreshes nothing can see; a root that is
+    // scanned but not watched leaves the panel stale until something else
+    // touches the workspace.
     let is_global_skill_path = home.is_some_and(|home_dir| {
-        path.starts_with(home_dir.join(".config/teamclu/skills"))
-            || path.starts_with(home_dir.join(".config/opencode/skills"))
-            || path.starts_with(home_dir.join(".claude/skills"))
+        path.starts_with(home_dir.join(".claude/skills"))
             || path.starts_with(home_dir.join(".agents/skills"))
     });
 
@@ -199,9 +185,7 @@ pub fn classify_change_path(
         ) || path.starts_with(workspace.workspace_path.join("teamclaw").join("_secrets"))
         {
             Some(RefreshChangeKind::EnvVars)
-        } else if is_meta_skills_path(path, &workspace.workspace_path)
-            || path.starts_with(workspace.workspace_path.join(".opencode/skills"))
-            || path.starts_with(workspace.workspace_path.join(".claude/skills"))
+        } else if path.starts_with(workspace.workspace_path.join(".claude/skills"))
             || path.starts_with(workspace.workspace_path.join(".agents/skills"))
             || is_team_skills_path(path, &workspace.workspace_path)
             || is_global_skill_path
@@ -252,22 +236,6 @@ fn watch_roots(workspaces: &[WatchedWorkspace], home: Option<&Path>) -> Vec<Watc
                 recursive: false,
             });
         }
-        let brand_skills = brand_skills_dir(&workspace.workspace_path);
-        let legacy_skills = legacy_skills_dir(&workspace.workspace_path);
-        roots.push(WatchRoot {
-            path: brand_skills.clone(),
-            recursive: true,
-        });
-        if legacy_skills != brand_skills {
-            roots.push(WatchRoot {
-                path: legacy_skills,
-                recursive: true,
-            });
-        }
-        roots.push(WatchRoot {
-            path: workspace.workspace_path.join(".opencode/skills"),
-            recursive: true,
-        });
         roots.push(WatchRoot {
             path: workspace.workspace_path.join(".claude/skills"),
             recursive: true,
@@ -295,14 +263,6 @@ fn watch_roots(workspaces: &[WatchedWorkspace], home: Option<&Path>) -> Vec<Watc
         });
     }
     if let Some(home_dir) = home {
-        roots.push(WatchRoot {
-            path: home_dir.join(".config/teamclu/skills"),
-            recursive: true,
-        });
-        roots.push(WatchRoot {
-            path: home_dir.join(".config/opencode/skills"),
-            recursive: true,
-        });
         roots.push(WatchRoot {
             path: home_dir.join(".claude/skills"),
             recursive: true,
@@ -558,22 +518,6 @@ mod tests {
 
         let cases = [
             (
-                Path::new("/tmp/ws-1/.teamclu/skills/demo-skill/SKILL.md"),
-                RefreshChangeKind::Skills,
-            ),
-            (
-                Path::new("/tmp/ws-1/.opencode/skills/demo-skill/SKILL.md"),
-                RefreshChangeKind::Skills,
-            ),
-            (
-                Path::new("/Users/tester/.config/teamclu/skills/global-skill/SKILL.md"),
-                RefreshChangeKind::Skills,
-            ),
-            (
-                Path::new("/Users/tester/.config/opencode/skills/global-skill/SKILL.md"),
-                RefreshChangeKind::Skills,
-            ),
-            (
                 Path::new("/tmp/ws-1/.claude/skills/demo-skill/SKILL.md"),
                 RefreshChangeKind::Skills,
             ),
@@ -621,6 +565,21 @@ mod tests {
                 kind
             );
         }
+
+        // Roots the scanner dropped. A write here refreshes nothing, because
+        // nothing can load it — see `skill_dir_specs`.
+        for retired in [
+            Path::new("/tmp/ws-1/.teamclu/skills/demo-skill/SKILL.md"),
+            Path::new("/tmp/ws-1/.opencode/skills/demo-skill/SKILL.md"),
+            Path::new("/Users/tester/.config/teamclu/skills/global-skill/SKILL.md"),
+            Path::new("/Users/tester/.config/opencode/skills/global-skill/SKILL.md"),
+        ] {
+            assert!(
+                classify_change_path(retired, &workspaces, Some(home)).is_empty(),
+                "{} is no longer a skills root",
+                retired.display()
+            );
+        }
     }
 
     #[cfg(unix)]
@@ -659,7 +618,7 @@ mod tests {
         let workspaces = vec![watched_workspace("ws-1", "/tmp/ws-1")];
         let mut debounce = RefreshDebounce::new(Duration::from_millis(250));
         let now = Instant::now();
-        let path = Path::new("/tmp/ws-1/.teamclu/skills/demo-skill/SKILL.md");
+        let path = Path::new("/tmp/ws-1/.claude/skills/demo-skill/SKILL.md");
 
         record_classified_changes(
             &coordinator,
@@ -718,7 +677,7 @@ mod tests {
             &mut debounce,
             &workspaces,
             None,
-            &dir.path().join(".teamclu/skills/demo-skill/SKILL.md"),
+            &dir.path().join(".claude/skills/demo-skill/SKILL.md"),
             Instant::now(),
         )
         .await;
@@ -767,7 +726,7 @@ mod tests {
             &mut debounce,
             &workspaces,
             None,
-            &dir.path().join(".teamclu/skills/demo-skill/SKILL.md"),
+            &dir.path().join(".claude/skills/demo-skill/SKILL.md"),
             Instant::now(),
         )
         .await;
@@ -982,18 +941,31 @@ mod tests {
             &workspaces,
             None,
         );
-        assert_eq!(brand_skill[0].kind, RefreshChangeKind::Skills);
+        assert!(
+            brand_skill.is_empty(),
+            "a brand meta dir is not a skills root under any brand"
+        );
+
+        let claude_skill = classify_change_path(
+            Path::new("/tmp/ws-1/.claude/skills/demo/SKILL.md"),
+            &workspaces,
+            None,
+        );
+        assert_eq!(claude_skill[0].kind, RefreshChangeKind::Skills);
     }
 
     #[test]
-    fn white_label_watch_roots_include_brand_and_legacy() {
+    /// Config files are still brand-namespaced (and keep the legacy fallback);
+    /// skills are not watched under a meta dir at all any more.
+    fn white_label_watch_roots_include_brand_and_legacy_configs() {
         let _guard = crate::test_brand_env::BrandEnvGuard::set("copilot361");
         let workspaces = vec![watched_workspace("ws-1", "/tmp/ws-1")];
         let roots = watch_roots(&workspaces, None);
         let paths: Vec<_> = roots.iter().map(|r| r.path.clone()).collect();
         assert!(paths.contains(&PathBuf::from("/tmp/ws-1/.copilot361/copilot361.json")));
-        assert!(paths.contains(&PathBuf::from("/tmp/ws-1/.copilot361/skills")));
         assert!(paths.contains(&PathBuf::from("/tmp/ws-1/.teamclu/teamclu.json")));
-        assert!(paths.contains(&PathBuf::from("/tmp/ws-1/.teamclu/skills")));
+        assert!(paths.contains(&PathBuf::from("/tmp/ws-1/.claude/skills")));
+        assert!(!paths.contains(&PathBuf::from("/tmp/ws-1/.copilot361/skills")));
+        assert!(!paths.contains(&PathBuf::from("/tmp/ws-1/.teamclu/skills")));
     }
 }

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -665,6 +665,21 @@ fn remove_non_native_desktop_control_skills(skills_dir: &Path) {
     }
 }
 
+/// Where the skills that ship with the binary are written: `~/.agents/skills`.
+///
+/// Not a workspace directory, and not brand-namespaced. They used to be seeded
+/// per workspace into the brand meta dir *and* `.opencode/skills` — two copies
+/// per project, of which only the meta one was ever read, and neither is a
+/// scanned root any more (`config::roles_skills::skill_dir_specs`). One copy in
+/// the root every runtime already reads replaces both, and it is where the
+/// Agent-side inventory has always looked for them
+/// (`daemon::server::rpc::skill_inventory`).
+fn inherent_skills_dir() -> Result<PathBuf, WorkspaceControlError> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| WorkspaceControlError::Io("home directory not found".to_owned()))?;
+    Ok(home.join(".agents/skills"))
+}
+
 fn ensure_inherent_skills_in_dir(skills_dir: &Path) -> Result<(), WorkspaceControlError> {
     std::fs::create_dir_all(skills_dir).map_err(|e| WorkspaceControlError::Io(e.to_string()))?;
     remove_non_native_desktop_control_skills(skills_dir);
@@ -723,11 +738,7 @@ pub fn prepare_workspace(workspace_path: &Path) -> Result<(), WorkspaceControlEr
 
     install_instruction_plugin_file(workspace_path)?;
     materialize_opencode_for_prepare(workspace_path)?;
-    ensure_inherent_skills_in_dir(&teamclu_runtime_env::workspace_meta_write_path_from_env(
-        workspace_path,
-        "skills",
-    ))?;
-    ensure_inherent_skills_in_dir(&workspace_path.join(".opencode/skills"))?;
+    ensure_inherent_skills_in_dir(&inherent_skills_dir()?)?;
     crate::runtime::claude_skills::ensure_claude_team_skills(workspace_path)?;
 
     if let Ok(Some(result)) =
@@ -2372,7 +2383,8 @@ mod tests {
 
     #[test]
     fn prepare_workspace_creates_defaults() {
-        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
         let dir = tempfile::tempdir().unwrap();
         prepare_workspace(dir.path()).unwrap();
 
@@ -2386,16 +2398,22 @@ mod tests {
             "amuxd-remote-tools must not be auto-injected"
         );
 
-        assert!(dir
+        assert!(home
             .path()
-            .join(".teamclu/skills/create-role/SKILL.md")
+            .join(".agents/skills/create-role/SKILL.md")
             .is_file());
+        assert!(
+            !dir.path().join(".teamclu/skills/create-role").exists(),
+            "inherent skills are no longer seeded per workspace"
+        );
+        assert!(!dir.path().join(".opencode/skills").exists());
         assert!(!dir.path().join(".opencode/data").exists());
     }
 
     #[test]
     fn prepare_workspace_strips_paused_remote_tools_mcp() {
-        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("opencode.json"),
@@ -2420,18 +2438,21 @@ mod tests {
     }
 
     #[test]
-    fn prepare_workspace_white_label_writes_brand_skills() {
-        let _guard = crate::test_brand_env::BrandEnvGuard::set("copilot361");
+    /// A white-label build seeds the same shared root as the official one:
+    /// skills are not brand-namespaced any more.
+    fn prepare_workspace_white_label_seeds_the_shared_agents_dir() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("copilot361", home.path());
 
         let dir = tempfile::tempdir().unwrap();
         prepare_workspace(dir.path()).unwrap();
-        assert!(dir
+        assert!(home
             .path()
-            .join(".copilot361/skills/create-role/SKILL.md")
+            .join(".agents/skills/create-role/SKILL.md")
             .is_file());
         assert!(!dir
             .path()
-            .join(".teamclu/skills/create-role/SKILL.md")
+            .join(".copilot361/skills/create-role/SKILL.md")
             .exists());
     }
 
@@ -2470,7 +2491,8 @@ mod tests {
         // afterwards, and under pi the extension's bridge spawn took the whole
         // runtime down with it, so every session in the workspace failed with
         // "process exited before responding".
-        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("opencode.json"),

--- a/apps/daemon/src/test_brand_env.rs
+++ b/apps/daemon/src/test_brand_env.rs
@@ -17,6 +17,7 @@ pub struct BrandEnvGuard {
     _lock: MutexGuard<'static, ()>,
     previous_brand: Option<String>,
     previous_home: Option<String>,
+    previous_user_home: Option<String>,
 }
 
 impl BrandEnvGuard {
@@ -32,7 +33,23 @@ impl BrandEnvGuard {
             _lock: lock,
             previous_brand,
             previous_home,
+            previous_user_home: None,
         }
+    }
+
+    /// [`set`], plus a temporary `HOME`.
+    ///
+    /// Needed by anything that resolves `~/.agents/skills` — the default write
+    /// root for skills — because `dirs::home_dir()` reads the real `HOME` and a
+    /// test that does not move it writes into the developer's own skills
+    /// directory. Same lock as the brand, so it cannot race the white-label
+    /// tests.
+    pub fn set_with_home(brand: &str, home: &Path) -> Self {
+        let mut guard = Self::set(brand);
+        guard.previous_user_home = Some(std::env::var("HOME").unwrap_or_default());
+        // SAFETY: serialized by TEST_HOME_LOCK, held by `guard`.
+        std::env::set_var("HOME", home);
+        guard
     }
 
     /// Set an explicit `AMUXD_HOME` override (brand env left unchanged).
@@ -45,6 +62,7 @@ impl BrandEnvGuard {
             _lock: lock,
             previous_brand,
             previous_home,
+            previous_user_home: None,
         }
     }
 }
@@ -58,6 +76,13 @@ impl Drop for BrandEnvGuard {
         match &self.previous_home {
             Some(v) => std::env::set_var(teamclu_runtime_env::AMUXD_HOME_ENV, v),
             None => std::env::remove_var(teamclu_runtime_env::AMUXD_HOME_ENV),
+        }
+        if let Some(v) = &self.previous_user_home {
+            if v.is_empty() {
+                std::env::remove_var("HOME");
+            } else {
+                std::env::set_var("HOME", v);
+            }
         }
     }
 }

--- a/packages/app/src/components/settings/ClawHubMarketplace.tsx
+++ b/packages/app/src/components/settings/ClawHubMarketplace.tsx
@@ -110,10 +110,8 @@ export const ClawHubMarketplace = React.memo(function ClawHubMarketplace({
       try {
         const home = await pathModule.homeDir()
         const dirsToCheck = [
-          `${workspacePath}/.opencode/skills`,
           `${workspacePath}/.claude/skills`,
           `${workspacePath}/.agents/skills`,
-          `${home.replace(/\/$/, '')}/.config/opencode/skills`,
           `${home.replace(/\/$/, '')}/.claude/skills`,
           `${home.replace(/\/$/, '')}/.agents/skills`,
         ]

--- a/packages/app/src/components/settings/SkillsSection.tsx
+++ b/packages/app/src/components/settings/SkillsSection.tsx
@@ -38,7 +38,7 @@ import {
   deleteDaemonSkill,
 } from '@/lib/daemon-local-client'
 import { cn } from '@/lib/utils'
-import { appDisplayName, TEAMCLU_DIR } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import { ensureAgentsSkillsPaths } from '@/lib/skills/ensure-agents-paths'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -427,22 +427,17 @@ ${skillContent.trim()}`
     }
 
     try {
-      if (targetSkill.source === 'clawhub') {
-        await invoke<string>('clawhub_uninstall', {
-          workspacePath,
-          slug: targetSkill.filename,
-        })
-      } else {
-        const deleted = await deleteDaemonSkill(
-          encodeWorkspaceId(workspacePath),
-          targetSkill.filename,
-          targetSkill.dirPath,
-        )
-        if (!deleted) {
-          const { remove } = await import('@tauri-apps/plugin-fs')
-          const baseDir = targetSkill.dirPath ?? `${workspacePath}/${TEAMCLU_DIR}/skills`
-          await remove(`${baseDir}/${targetSkill.filename}`, { recursive: true })
-        }
+      const deleted = await deleteDaemonSkill(
+        encodeWorkspaceId(workspacePath),
+        targetSkill.filename,
+        targetSkill.dirPath,
+      )
+      if (!deleted) {
+        const { remove } = await import('@tauri-apps/plugin-fs')
+        const { homeDir } = await import('@tauri-apps/api/path')
+        const baseDir =
+          targetSkill.dirPath ?? `${(await homeDir()).replace(/\/$/, '')}/.agents/skills`
+        await remove(`${baseDir}/${targetSkill.filename}`, { recursive: true })
       }
 
       setDeleteConfirmOpen(false)
@@ -475,8 +470,10 @@ ${skillContent.trim()}`
     setEditingSkill(skill)
     setSkillName(skill.name)
     setSkillContent(skill.content)
-    // Set view mode for non-editable skills (not local or clawhub)
-    const isEditable = skill.source === 'local' || skill.source === 'clawhub' || skill.isRoleSkill
+    // Everything the scan returns is written back through its own `dirPath`,
+    // so the only thing that is not editable is an inherent skill — the daemon
+    // reseeds those on every `prepare_workspace`.
+    const isEditable = skill.source !== 'builtin' && Boolean(skill.dirPath)
     setIsViewMode(!isEditable)
     setSkillDialogMode(isEditable ? 'edit' : 'view')
     setDialogOpen(true)

--- a/packages/app/src/lib/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon-local-client.ts
@@ -1021,7 +1021,6 @@ export async function getDaemonRoles(
 export interface DaemonUpsertSkillRequest {
   content: string
   skillName?: string
-  installLocation?: 'workspace' | 'global'
   dirPath?: string
   filename?: string
 }

--- a/packages/app/src/lib/roles/loader.ts
+++ b/packages/app/src/lib/roles/loader.ts
@@ -311,7 +311,7 @@ export async function loadRolesSkillsWorkspaceStateFromFs(
       content: skill.content,
       description: extractSkillDescription(skill.content, skill.name),
       source: skill.source,
-      dirPath: skill.dirPath ?? `${workspacePath}/${TEAMCLU_DIR}/skills`,
+      dirPath: skill.dirPath,
       linkedRoles: roleUsageBySkill[skill.filename] ?? [],
       isRoleSkill: false,
     })
@@ -340,14 +340,11 @@ function skillRecordKey(skill: Pick<ManagedSkillRecord, "dirPath" | "filename">)
 const SKILL_SOURCE_PRIORITY: Record<SkillSource, number> = {
   local: 0,
   claude: 1,
-  clawhub: 2,
+  builtin: 2,
+  "global-agent": 2,
   shared: 3,
   team: 4,
-  builtin: 5,
-  plugin: 6,
-  "global-teamclu": 7,
-  "global-claude": 8,
-  "global-agent": 9,
+  "global-claude": 5,
   personal: 10,
 }
 
@@ -538,11 +535,20 @@ export async function deleteRole(workspacePath: string, roleSlug: string, roleFi
   }
 }
 
+/**
+ * Skills a role can be given a copy of.
+ *
+ * Scoped to the TeamClu-managed roots — `~/.agents/skills` (where the desktop
+ * writes new skills, and where the registry and ClawHub install) and the
+ * workspace's `.agents/skills`. This used to be the brand meta skills dir,
+ * which nothing writes and nothing scans any more; `.claude/skills` is
+ * deliberately left out, because those belong to Claude Code rather than to
+ * this app.
+ */
 export async function loadAttachableSkills(workspacePath: string): Promise<AttachableSkill[]> {
   const { skills } = await loadAllSkills(workspacePath)
-  const workspaceSkillRoot = `${workspacePath}/${TEAMCLU_DIR}/skills`
   return skills
-    .filter((skill) => skill.source === "local" && skill.dirPath === workspaceSkillRoot)
+    .filter((skill) => skill.source === "global-agent" || skill.source === "shared")
     .map((skill) => ({
       filename: skill.filename,
       name: skill.name,
@@ -602,7 +608,17 @@ export async function attachSkillToRole(input: AttachSkillToRoleInput): Promise<
     throw new Error(`Role "${roleSlug}" does not exist`)
   }
 
-  const sourceDir = `${workspacePath}/${TEAMCLU_DIR}/skills/${skillSlug}`
+  // Resolve the source through the attachable list rather than assuming a
+  // root: the skill can be in `~/.agents/skills` or the workspace's
+  // `.agents/skills`, and the single dir this used to hard-code (the brand meta
+  // skills dir) is not written or scanned any more, so attaching always failed
+  // with "not available".
+  const attachable = await loadAttachableSkills(workspacePath)
+  const source = attachable.find((skill) => skill.filename === skillSlug)
+  if (!source) {
+    throw new Error(`Skill "${skillSlug}" is not available for role attachment`)
+  }
+  const sourceDir = `${source.dirPath}/${skillSlug}`
   const sourceSkillPath = `${sourceDir}/SKILL.md`
   if (!(await exists(sourceSkillPath))) {
     throw new Error(`Skill "${skillSlug}" is not available for role attachment`)

--- a/packages/app/src/lib/skill-diagnostics.ts
+++ b/packages/app/src/lib/skill-diagnostics.ts
@@ -44,10 +44,8 @@ export interface SkillsDiagnosticsReport {
 }
 
 const DIRECTORY_LABELS: Record<string, string> = {
-  workspace: `${TEAMCLU_DIR}/skills`,
   claude: '.claude/skills',
   agents: '.agents/skills',
-  globalTeamclu: '~/.config/teamclu/skills',
   globalClaude: '~/.claude/skills',
   globalAgents: '~/.agents/skills',
 }
@@ -68,14 +66,12 @@ function summarizeChecks(checks: SkillDiagnosticCheck[]): SkillDiagnosticStatus 
 function labelForDirectory(path: string, workspacePath: string): string {
   const normalized = path.replace(/\\/g, '/')
   const workspace = workspacePath.replace(/\\/g, '/')
-  if (normalized.includes(`/${TEAMCLU_DIR}/skills`)) return DIRECTORY_LABELS.workspace
   if (normalized.includes('/.claude/skills')) {
     return normalized.startsWith(workspace) ? DIRECTORY_LABELS.claude : DIRECTORY_LABELS.globalClaude
   }
   if (normalized.includes('/.agents/skills')) {
     return normalized.startsWith(workspace) ? DIRECTORY_LABELS.agents : DIRECTORY_LABELS.globalAgents
   }
-  if (normalized.includes('/.config/teamclu/skills')) return DIRECTORY_LABELS.globalTeamclu
   if (normalized.includes(`/${TEAM_SHARE_LINK_DIR}/skills`)) return `${TEAM_SHARE_LINK_DIR}/skills`
   if (normalized.includes('/roles/skills')) return `${TEAMCLU_DIR}/roles/skills`
   return path

--- a/packages/app/src/lib/skills/__tests__/loader-team-path.test.ts
+++ b/packages/app/src/lib/skills/__tests__/loader-team-path.test.ts
@@ -25,10 +25,9 @@ vi.mock("@tauri-apps/api/path", () => ({
   join: (...args: unknown[]) => mockJoin(...(args as string[])),
 }))
 
-const teamclujson = (paths: string[]) =>
-  JSON.stringify({ skills: { paths } })
+const opencodeJson = (paths: string[]) => JSON.stringify({ skills: { paths } })
 
-describe("skill-loader dynamic team paths (from teamclu.json)", () => {
+describe("skill-loader dynamic team paths (from opencode.json)", () => {
   const workspacePath = "/tmp/ws"
 
   beforeEach(() => {
@@ -40,18 +39,18 @@ describe("skill-loader dynamic team paths (from teamclu.json)", () => {
     mockJoin.mockImplementation((...args: string[]) => Promise.resolve(args.join("/")))
   })
 
-  it("loads team skills from paths listed in teamclu.json", async () => {
+  it("loads team skills from paths listed in opencode.json", async () => {
     const teamDir = `${workspacePath}/${TEAM_REPO_DIR}/skills`
 
     mockExists.mockImplementation((path: string) => {
-      if (path === `${workspacePath}/teamclu.json`) return Promise.resolve(true)
+      if (path === `${workspacePath}/opencode.json`) return Promise.resolve(true)
       if (path === teamDir) return Promise.resolve(true)
       if (path.includes("my-team-skill") && path.endsWith("SKILL.md")) return Promise.resolve(true)
       return Promise.resolve(false)
     })
     mockReadTextFile.mockImplementation((path: string) => {
-      if (path === `${workspacePath}/teamclu.json`)
-        return Promise.resolve(teamclujson([`${TEAM_REPO_DIR}/skills`]))
+      if (path === `${workspacePath}/opencode.json`)
+        return Promise.resolve(opencodeJson([`${TEAM_REPO_DIR}/skills`]))
       if (path.includes("my-team-skill"))
         return Promise.resolve("# my-team-skill\n")
       return Promise.resolve("")
@@ -73,14 +72,14 @@ describe("skill-loader dynamic team paths (from teamclu.json)", () => {
     const expandedDir = "/home/user/shared-skills"
 
     mockExists.mockImplementation((path: string) => {
-      if (path === `${workspacePath}/teamclu.json`) return Promise.resolve(true)
+      if (path === `${workspacePath}/opencode.json`) return Promise.resolve(true)
       if (path === expandedDir) return Promise.resolve(true)
       if (path.includes("home-skill") && path.endsWith("SKILL.md")) return Promise.resolve(true)
       return Promise.resolve(false)
     })
     mockReadTextFile.mockImplementation((path: string) => {
-      if (path === `${workspacePath}/teamclu.json`)
-        return Promise.resolve(teamclujson(["~/shared-skills"]))
+      if (path === `${workspacePath}/opencode.json`)
+        return Promise.resolve(opencodeJson(["~/shared-skills"]))
       if (path.includes("home-skill"))
         return Promise.resolve("# home-skill\n")
       return Promise.resolve("")
@@ -102,12 +101,12 @@ describe("skill-loader dynamic team paths (from teamclu.json)", () => {
     const absoluteDir = "D:\\shared\\skills"
 
     mockExists.mockImplementation((path: string) => {
-      if (path === `${workspacePath}/teamclu.json`) return Promise.resolve(true)
+      if (path === `${workspacePath}/opencode.json`) return Promise.resolve(true)
       return Promise.resolve(false)
     })
     mockReadTextFile.mockImplementation((path: string) => {
-      if (path === `${workspacePath}/teamclu.json`) {
-        return Promise.resolve(teamclujson([absoluteDir]))
+      if (path === `${workspacePath}/opencode.json`) {
+        return Promise.resolve(opencodeJson([absoluteDir]))
       }
       return Promise.resolve("")
     })
@@ -120,12 +119,12 @@ describe("skill-loader dynamic team paths (from teamclu.json)", () => {
     mockHomeDir.mockResolvedValue("C:\\Users\\alice")
 
     mockExists.mockImplementation((path: string) => {
-      if (path === `${workspacePath}/teamclu.json`) return Promise.resolve(true)
+      if (path === `${workspacePath}/opencode.json`) return Promise.resolve(true)
       return Promise.resolve(false)
     })
     mockReadTextFile.mockImplementation((path: string) => {
-      if (path === `${workspacePath}/teamclu.json`) {
-        return Promise.resolve(teamclujson(["~\\shared-skills"]))
+      if (path === `${workspacePath}/opencode.json`) {
+        return Promise.resolve(opencodeJson(["~\\shared-skills"]))
       }
       return Promise.resolve("")
     })
@@ -137,13 +136,12 @@ describe("skill-loader dynamic team paths (from teamclu.json)", () => {
 
   it("contributes zero team skills when no team share dir and no skills.paths", async () => {
     mockExists.mockImplementation((path: string) => {
-      if (path === `${workspacePath}/teamclu.json`) return Promise.resolve(true)
-      if (path === `${workspacePath}/opencode.json`) return Promise.resolve(false)
+      if (path === `${workspacePath}/opencode.json`) return Promise.resolve(true)
       if (path === `${workspacePath}/${TEAM_SHARE_LINK_DIR}/skills`) return Promise.resolve(false)
       return Promise.resolve(false)
     })
     mockReadTextFile.mockImplementation((path: string) => {
-      if (path === `${workspacePath}/teamclu.json`)
+      if (path === `${workspacePath}/opencode.json`)
         return Promise.resolve(JSON.stringify({}))
       return Promise.resolve("")
     })
@@ -158,7 +156,6 @@ describe("skill-loader dynamic team paths (from teamclu.json)", () => {
     const globalSkills = `${globalTeamDir}/skills`
 
     mockExists.mockImplementation((path: string) => {
-      if (path === `${workspacePath}/teamclu.json`) return Promise.resolve(false)
       if (path === `${workspacePath}/opencode.json`) return Promise.resolve(true)
       if (path === brokenLinkSkills) return Promise.resolve(false)
       if (path === `${workspacePath}/${TEAM_SHARE_LINK_DIR}`) return Promise.resolve(false)
@@ -189,10 +186,11 @@ describe("skill-loader dynamic team paths (from teamclu.json)", () => {
     expect(skills.some((s) => s.source === "team" && s.filename === "shared-skill")).toBe(true)
   })
 
-  it("auto-loads the global team skills dir without teamclu.json skills.paths", async () => {
-    // No workspace-link fallback anymore: skills come from the daemon-owned
-    // global dir `~/.amuxd/teams/<team_id>/shared/teamclu-team/skills`.
-    expect(TEAM_SHARE_LINK_DIR).toBe("teamclu-team")
+  it("does not auto-load the global team skills dir without a skills.paths entry", async () => {
+    // The team drive's own `skills/` used to be added on sight. It has had no
+    // writer since the registry took over (OSS sync RETIRED_PREFIXES), so what
+    // is left on disk is whatever the last sync before that migration wrote —
+    // exactly the stale copies the registry exists to retire.
     const globalTeamDir = `/home/user/.amuxd/teams/team-abc/shared/${TEAM_SHARE_LINK_DIR}`
     const globalSkills = `${globalTeamDir}/skills`
 
@@ -215,27 +213,30 @@ describe("skill-loader dynamic team paths (from teamclu.json)", () => {
       return Promise.resolve("")
     })
 
-    const paths = await collectTeamSkillPaths(workspacePath)
-    expect(paths).toContain(globalSkills)
+    expect(await collectTeamSkillPaths(workspacePath)).toEqual([])
 
     const { skills } = await loadAllSkills(workspacePath)
-    expect(skills.some((s) => s.source === "team" && s.filename === "shared-skill")).toBe(true)
+    expect(skills.some((s) => s.filename === "shared-skill")).toBe(false)
   })
 
   it("still reads a daemon.toml that names the team with the legacy team_id key", async () => {
     // The daemon writes `active_team` but keeps a serde alias for `team_id`
     // (DaemonConfig::team_id), so an older daemon under a newer app must not
-    // read as un-onboarded.
+    // read as un-onboarded — the remap of a `teamclu-team/...` entry in
+    // `opencode.json` depends on resolving the team.
     const globalTeamDir = `/home/user/.amuxd/teams/team-abc/shared/${TEAM_SHARE_LINK_DIR}`
     const globalSkills = `${globalTeamDir}/skills`
 
     mockExists.mockImplementation((path: string) => {
+      if (path === `${workspacePath}/opencode.json`) return Promise.resolve(true)
       if (path === `/home/user/.amuxd/daemon.toml`) return Promise.resolve(true)
       if (path === globalTeamDir) return Promise.resolve(true)
       if (path === globalSkills) return Promise.resolve(true)
       return Promise.resolve(false)
     })
     mockReadTextFile.mockImplementation((path: string) => {
+      if (path === `${workspacePath}/opencode.json`)
+        return Promise.resolve(opencodeJson([`${TEAM_SHARE_LINK_DIR}/skills`]))
       if (path === `/home/user/.amuxd/daemon.toml`)
         return Promise.resolve('team_id = "team-abc"\n')
       return Promise.resolve("")
@@ -299,7 +300,7 @@ describe("skill-loader dynamic team paths (from teamclu.json)", () => {
   })
 
   it("prefers flat skill over bundled skill with same slug", async () => {
-    const localDir = `${workspacePath}/.teamclu/skills`
+    const localDir = `${workspacePath}/.claude/skills`
     const globalBundleDir = "/home/user/.agents/skills"
     const superpowersDir = `${globalBundleDir}/superpowers`
 
@@ -337,12 +338,12 @@ describe("skill-loader dynamic team paths (from teamclu.json)", () => {
     const { skills, overrides } = await loadAllSkills(workspacePath)
     const resolved = skills.find((s) => s.filename === "brainstorming")
 
-    expect(resolved?.source).toBe("local")
+    expect(resolved?.source).toBe("claude")
     expect(resolved?.dirPath).toBe(localDir)
     expect(resolved?.invocationName).toBe("brainstorming")
     expect(overrides).toContainEqual({
       name: "brainstorming",
-      winner: "local",
+      winner: "claude",
       loser: "global-agent",
     })
   })
@@ -357,151 +358,7 @@ describe("skill-loader dynamic team paths (from teamclu.json)", () => {
     expect(buildSkillInvocationName("C:\\Users\\alice\\.agents\\skills\\superpowers", "brainstorming")).toBe("superpowers/brainstorming")
   })
 
-  it("getSourceDirHint(team) shows team share directory", () => {
-    expect(getSourceDirHint("team")).toBe(`${TEAM_REPO_DIR}/skills/ (team share)`)
-  })
-})
-
-describe("skill-loader plugin cache scanning", () => {
-  const workspacePath = "/tmp/ws"
-  const pluginCacheDir = `${workspacePath}/.teamclu/cache/agent/node_modules`
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mockExists.mockReturnValue(false)
-    mockReadDir.mockResolvedValue([])
-    mockReadTextFile.mockResolvedValue("# Test Skill\n")
-    mockHomeDir.mockResolvedValue("/home/user")
-  })
-
-  it("loads skills from plugin cache directory", async () => {
-    const superpowersSkillsDir = `${pluginCacheDir}/superpowers/skills`
-
-    mockExists.mockImplementation((path: string) => {
-      if (path === pluginCacheDir) return Promise.resolve(true)
-      if (path === superpowersSkillsDir) return Promise.resolve(true)
-      if (path === `${superpowersSkillsDir}/brainstorming/SKILL.md`) return Promise.resolve(true)
-      if (path === `${superpowersSkillsDir}/systematic-debugging/SKILL.md`) return Promise.resolve(true)
-      return Promise.resolve(false)
-    })
-
-    mockReadDir.mockImplementation((path: string) => {
-      if (path === pluginCacheDir) {
-        return Promise.resolve([{ name: "superpowers", isDirectory: true }])
-      }
-      if (path === superpowersSkillsDir) {
-        return Promise.resolve([
-          { name: "brainstorming", isDirectory: true },
-          { name: "systematic-debugging", isDirectory: true },
-        ])
-      }
-      return Promise.resolve([])
-    })
-
-    mockReadTextFile.mockImplementation((path: string) => {
-      if (path === `${superpowersSkillsDir}/brainstorming/SKILL.md`) {
-        return Promise.resolve("---\nname: brainstorming\ndescription: Brainstorm first\n---\n")
-      }
-      if (path === `${superpowersSkillsDir}/systematic-debugging/SKILL.md`) {
-        return Promise.resolve("---\nname: systematic-debugging\n---\n")
-      }
-      return Promise.resolve("")
-    })
-
-    const { skills } = await loadAllSkills(workspacePath)
-    const pluginSkills = skills.filter((s) => s.source === "plugin")
-
-    expect(pluginSkills).toHaveLength(2)
-    expect(pluginSkills.some((s) => s.filename === "brainstorming")).toBe(true)
-    expect(pluginSkills.some((s) => s.filename === "systematic-debugging")).toBe(true)
-  })
-
-  it("skips plugins without a skills/ directory", async () => {
-    mockExists.mockImplementation((path: string) => {
-      if (path === pluginCacheDir) return Promise.resolve(true)
-      if (path === `${pluginCacheDir}/some-plugin/skills`) return Promise.resolve(false)
-      return Promise.resolve(false)
-    })
-
-    mockReadDir.mockImplementation((path: string) => {
-      if (path === pluginCacheDir) {
-        return Promise.resolve([{ name: "some-plugin", isDirectory: true }])
-      }
-      return Promise.resolve([])
-    })
-
-    const { skills } = await loadAllSkills(workspacePath)
-    expect(skills.filter((s) => s.source === "plugin")).toHaveLength(0)
-  })
-
-  it("local skills override plugin skills with the same name", async () => {
-    const localDir = `${workspacePath}/.teamclu/skills`
-    const superpowersSkillsDir = `${pluginCacheDir}/superpowers/skills`
-
-    mockExists.mockImplementation((path: string) => {
-      if (path === localDir) return Promise.resolve(true)
-      if (path === `${localDir}/brainstorming/SKILL.md`) return Promise.resolve(true)
-      if (path === pluginCacheDir) return Promise.resolve(true)
-      if (path === superpowersSkillsDir) return Promise.resolve(true)
-      if (path === `${superpowersSkillsDir}/brainstorming/SKILL.md`) return Promise.resolve(true)
-      return Promise.resolve(false)
-    })
-
-    mockReadDir.mockImplementation((path: string) => {
-      if (path === localDir) {
-        return Promise.resolve([{ name: "brainstorming", isDirectory: true }])
-      }
-      if (path === pluginCacheDir) {
-        return Promise.resolve([{ name: "superpowers", isDirectory: true }])
-      }
-      if (path === superpowersSkillsDir) {
-        return Promise.resolve([{ name: "brainstorming", isDirectory: true }])
-      }
-      return Promise.resolve([])
-    })
-
-    mockReadTextFile.mockImplementation((path: string) => {
-      if (path === `${localDir}/brainstorming/SKILL.md`) {
-        return Promise.resolve("---\nname: brainstorming\n---\nLocal version")
-      }
-      if (path === `${superpowersSkillsDir}/brainstorming/SKILL.md`) {
-        return Promise.resolve("---\nname: brainstorming\n---\nPlugin version")
-      }
-      return Promise.resolve("")
-    })
-
-    const { skills, overrides } = await loadAllSkills(workspacePath)
-    const resolved = skills.find((s) => s.filename === "brainstorming")
-
-    expect(resolved?.source).toBe("local")
-    expect(overrides).toContainEqual({
-      name: "brainstorming",
-      winner: "local",
-      loser: "plugin",
-    })
-  })
-
-  it("skips hidden directories in plugin cache", async () => {
-    mockExists.mockImplementation((path: string) => {
-      if (path === pluginCacheDir) return Promise.resolve(true)
-      return Promise.resolve(false)
-    })
-
-    mockReadDir.mockImplementation((path: string) => {
-      if (path === pluginCacheDir) {
-        return Promise.resolve([
-          { name: ".package-lock.json", isDirectory: false },
-          { name: ".cache", isDirectory: true },
-        ])
-      }
-      return Promise.resolve([])
-    })
-
-    const { skills } = await loadAllSkills(workspacePath)
-    expect(skills.filter((s) => s.source === "plugin")).toHaveLength(0)
-  })
-
-  it("getSourceDirHint(plugin) shows teamclu.json reference", () => {
-    expect(getSourceDirHint("plugin")).toBe("teamclu.json → plugin")
+  it("getSourceDirHint(team) points at the one config that declares team paths", () => {
+    expect(getSourceDirHint("team")).toBe("opencode.json → skills.paths")
   })
 })

--- a/packages/app/src/lib/skills/loader.ts
+++ b/packages/app/src/lib/skills/loader.ts
@@ -4,8 +4,7 @@ import { frontmatterString } from '@/lib/skills/frontmatter'
 import { homeDir } from '@tauri-apps/api/path'
 import type { SkillWithSource, SkillSource } from './types'
 import { INHERENT_SKILL_NAMES, shouldIncludeDesktopControlSkill } from './types'
-import type { ClawHubLockfile } from '@/lib/clawhub/types'
-import { appDisplayName, TEAMCLU_DIR, TEAM_REPO_DIR } from '@/lib/build-config'
+import { appDisplayName } from '@/lib/build-config'
 import i18n from '@/lib/i18n'
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -95,31 +94,6 @@ async function loadSkillsFromDir(
   return skills
 }
 
-/** Read .clawhub/lock.json to identify skills installed from ClawHub */
-async function readClawHubLockfile(workspacePath: string): Promise<Set<string>> {
-  const slugs = new Set<string>()
-  const paths = [
-    `${workspacePath}/.clawhub/lock.json`,
-    `${workspacePath}/.clawdhub/lock.json`,
-  ]
-  for (const lockPath of paths) {
-    try {
-      if (!(await exists(lockPath))) continue
-      const raw = await readTextFile(lockPath)
-      const lock: ClawHubLockfile = JSON.parse(raw)
-      if (lock.skills) {
-        for (const slug of Object.keys(lock.skills)) {
-          slugs.add(slug)
-        }
-      }
-      return slugs
-    } catch {
-      // try next
-    }
-  }
-  return slugs
-}
-
 // ─── Multi-Source Loader ────────────────────────────────────────────────────
 
 export { collectTeamSkillPaths, readConfigSkillPaths } from '@/lib/team-skill-paths'
@@ -127,14 +101,9 @@ export { collectTeamSkillPaths, readConfigSkillPaths } from '@/lib/team-skill-pa
 /** Return all known skill directories for the current workspace/user context. */
 export async function getSkillDirectories(workspacePath: string | null): Promise<string[]> {
   const home = trimTrailingPathSeparators(await homeDir())
-  const dirs = new Set<string>([
-    `${home}/.config/teamclu/skills`,
-    `${home}/.claude/skills`,
-    `${home}/.agents/skills`,
-  ])
+  const dirs = new Set<string>([`${home}/.claude/skills`, `${home}/.agents/skills`])
 
   if (workspacePath) {
-    dirs.add(`${workspacePath}/${TEAMCLU_DIR}/skills`)
     dirs.add(`${workspacePath}/.claude/skills`)
     dirs.add(`${workspacePath}/.agents/skills`)
 
@@ -150,18 +119,21 @@ export async function getSkillDirectories(workspacePath: string | null): Promise
 /**
  * Load skills from all sources with priority-based merging.
  *
+ * Kept in step with the daemon's `skill_dir_specs`, which is the list that
+ * decides what an agent actually loads. Two loaders disagreeing about which
+ * roots exist is how the settings page ends up showing a skill no runtime can
+ * see (and hiding one it can).
+ *
  * Workspace paths (project-level):
- * 1. TEAMCLU_DIR/skills/  → source: 'local' / 'builtin' / 'clawhub'
- * 2. `.claude/skills/`     → source: 'claude'
- * 3. `.agents/skills/`     → source: 'shared'
+ * 1. `.claude/skills/`     → source: 'claude'
+ * 2. `.agents/skills/`     → source: 'shared'
  *
  * Global paths (user-level):
- * 4. `~/.config/teamclu/skills/` → source: 'global-teamclu'
- * 5. `~/.claude/skills/`          → source: 'global-claude'
- * 6. `~/.agents/skills/`          → source: 'global-agent'
+ * 3. `~/.claude/skills/`          → source: 'global-claude'
+ * 4. `~/.agents/skills/`          → source: 'global-agent'
  *
- * Dynamic paths (from teamclu.json `skills.paths`):
- * 7+. Each configured path → source: 'team'
+ * Dynamic paths (from `opencode.json` `skills.paths`):
+ * 5+. Each configured path → source: 'team'
  *
  * Same-name skills are resolved by priority — workspace > global.
  */
@@ -182,92 +154,47 @@ export async function loadAllSkills(
   // Get user home directory
   const home = await homeDir()
 
-  // Read ClawHub lockfile to identify which .teamclu/skills were installed from ClawHub
-  let clawhubSlugs = new Set<string>()
-  if (workspacePath) {
-    clawhubSlugs = await readClawHubLockfile(workspacePath)
-  }
+  // `builtin` is decided by name, not by root: the inherent skills are seeded
+  // into `~/.agents/skills` and sit there next to team packs and the user's own
+  // files. Applied at every root so a copy left behind by an older build reads
+  // the same way.
+  const labelled = (skill: SkillWithSource, isGlobal: boolean): SkillWithSource =>
+    INHERENT_SKILL_NAMES.has(skill.filename)
+      ? { ...skill, source: 'builtin' as SkillSource, isGlobal }
+      : { ...skill, isGlobal }
 
   // ============ Workspace Skills (Project-level) ============
 
-  // 1. Load workspace .teamclu/skills (highest priority — user local)
-  //    Skills whose dirname matches INHERENT_SKILL_NAMES are marked as 'builtin'.
-  //    Skills whose dirname matches a ClawHub lockfile entry are marked as 'clawhub'.
-  if (workspacePath) {
-    const localDir = `${workspacePath}/${TEAMCLU_DIR}/skills`
-    const localSkills = await loadSkillsFromDir(localDir, 'local')
-    for (const skill of localSkills) {
-      if (INHERENT_SKILL_NAMES.has(skill.filename)) {
-        pushSkill({ ...skill, source: 'builtin' as SkillSource, isGlobal: false })
-      } else if (clawhubSlugs.has(skill.filename)) {
-        pushSkill({ ...skill, source: 'clawhub' as SkillSource, isGlobal: false })
-      } else {
-        pushSkill({ ...skill, isGlobal: false })
-      }
-    }
-  }
-
-  // 2. Load workspace .claude/skills (Cursor/Claude skills)
+  // 1. Load workspace .claude/skills (Cursor/Claude skills)
   if (workspacePath) {
     const claudeDir = `${workspacePath}/.claude/skills`
     const claudeSkills = await loadSkillsFromDir(claudeDir, 'claude')
-    for (const s of claudeSkills) pushSkill({ ...s, isGlobal: false })
+    for (const s of claudeSkills) pushSkill(labelled(s, false))
   }
 
-  // 3. Load workspace .agents/skills
+  // 2. Load workspace .agents/skills
   if (workspacePath) {
     const sharedDir = `${workspacePath}/.agents/skills`
     const sharedSkills = await loadSkillsFromDir(sharedDir, 'shared')
-    for (const s of sharedSkills) pushSkill({ ...s, isGlobal: false })
+    for (const s of sharedSkills) pushSkill(labelled(s, false))
   }
 
   // ============ Global Skills (User-level) ============
 
-  // 4. Load global ~/.config/teamclu/skills
-  const globalTeamcluDir = `${home.replace(/\/$/, '')}/.config/teamclu/skills`
-  const globalTeamcluSkills = await loadSkillsFromDir(globalTeamcluDir, 'global-teamclu')
-  for (const s of globalTeamcluSkills) pushSkill({ ...s, isGlobal: true })
-
-  // 5. Load global ~/.claude/skills
+  // 3. Load global ~/.claude/skills
   const globalClaudeDir = `${home.replace(/\/$/, '')}/.claude/skills`
   const globalClaudeSkills = await loadSkillsFromDir(globalClaudeDir, 'global-claude')
-  for (const s of globalClaudeSkills) pushSkill({ ...s, isGlobal: true })
+  for (const s of globalClaudeSkills) pushSkill(labelled(s, true))
 
-  // 6. Load global ~/.agents/skills
+  // 4. Load global ~/.agents/skills — where the registry, ClawHub and the
+  //    inherent skills all install.
   const globalAgentDir = `${home.replace(/\/$/, '')}/.agents/skills`
   const globalAgentSkills = await loadSkillsFromDir(globalAgentDir, 'global-agent')
-  for (const s of globalAgentSkills) pushSkill({ ...s, isGlobal: true })
+  for (const s of globalAgentSkills) pushSkill(labelled(s, true))
 
-  // ============ Plugin Skills ============
+  // ============ Dynamic paths from opencode.json ============
 
-  // 7. Scan plugin cache for skills installed via teamclu.json "plugin" array
-  if (workspacePath) {
-    const pluginCacheDir = `${workspacePath}/${TEAMCLU_DIR}/cache/agent/node_modules`
-    try {
-      if (await exists(pluginCacheDir)) {
-        const pluginEntries = await readDir(pluginCacheDir)
-        for (const entry of pluginEntries) {
-          if (entry.isDirectory && entry.name && !entry.name.startsWith('.')) {
-            const skillsDir = `${pluginCacheDir}/${entry.name}/skills`
-            try {
-              if (await exists(skillsDir)) {
-                const pluginSkills = await loadSkillsFromDir(skillsDir, 'plugin')
-                for (const s of pluginSkills) pushSkill({ ...s, isGlobal: false })
-              }
-            } catch {
-              // skip inaccessible plugin
-            }
-          }
-        }
-      }
-    } catch {
-      console.warn('[SkillLoader] Cannot access plugin cache directory')
-    }
-  }
-
-  // ============ Dynamic paths from teamclu.json ============
-
-  // 8+. Team-shared + configured skill paths (teamclu.json, opencode.json, teamclu-team/skills)
+  // 5+. Configured skill paths (`opencode.json` → `skills.paths`)
   if (workspacePath) {
     const configPaths = await collectTeamSkillPaths(workspacePath)
     for (const dirPath of configPaths) {
@@ -277,17 +204,14 @@ export async function loadAllSkills(
       const normalizedHome = home.replace(/\\/g, '/')
       const isGlobalPath =
         normalizedDirPath.startsWith(normalizedHome) ||
-        normalizedDirPath.includes('.config/teamclu') ||
         normalizedDirPath.includes('.claude') ||
         normalizedDirPath.includes('.agents')
-      for (const s of skills) pushSkill({ ...s, isGlobal: isGlobalPath })
+      for (const s of skills) pushSkill(labelled(s, isGlobalPath))
     }
   }
 
   // Deduplicate by filename with priority:
-  // Workspace (project) > Global (user)
-  // Within workspace: local > claude > clawhub > shared > team > builtin
-  // Within global: global-teamclu > global-claude > global-agent
+  // claude > global-agent > shared > team > global-claude
   //
   // `global-agent` (~/.agents/skills) is the exception to that ordering: it is
   // where team packs are installed, so it sits ahead of every personal root
@@ -298,17 +222,19 @@ export async function loadAllSkills(
   // `skill_dir_specs` ranks; two loaders disagreeing about which copy is real
   // is the bug this table exists to prevent.
   const priorityOrder: Record<SkillSource, number> = {
+    // Role-managed skills, which no root contributes — they are merged in
+    // separately and never collide with a scanned slug.
     local: 0,
     claude: 1,
+    // Same rank as the root it lives in: `builtin` is a label, and a label must
+    // not decide which copy of a duplicated slug wins. The inherent skills only
+    // ever exist in `~/.agents/skills`, so the tie is unreachable in practice.
+    builtin: 2,
     'global-agent': 2,
-    clawhub: 3,
-    shared: 4,
-    team: 5,
-    builtin: 6,
-    plugin: 7,
-    'global-teamclu': 8,
-    'global-claude': 9,
-    personal: 10,
+    shared: 3,
+    team: 4,
+    'global-claude': 5,
+    personal: 6,
   }
   const seen = new Map<string, SkillWithSource>()
 
@@ -346,23 +272,17 @@ export async function loadAllSkills(
 export function getSourceLabel(source: SkillSource): string {
   switch (source) {
     case 'local':
-      return 'Local'
+      return i18n.t('skills.roleManagedLabel')
     case 'claude':
       return 'Claude'
-    case 'clawhub':
-      return 'ClawHub'
     case 'shared':
       return 'Shared'
     case 'team':
       return 'Team'
     case 'builtin':
       return i18n.t('skills.builtinLabel')
-    case 'plugin':
-      return 'Plugin'
     case 'personal':
       return 'Personal'
-    case 'global-teamclu':
-      return 'Global'
     case 'global-claude':
       return 'Global Claude'
     case 'global-agent':
@@ -376,23 +296,17 @@ export function getSourceLabel(source: SkillSource): string {
 export function getSourceDirHint(source: SkillSource): string {
   switch (source) {
     case 'local':
-      return `${TEAMCLU_DIR}/skills/`
+      return 'roles/<role>/skills/'
     case 'claude':
       return '.claude/skills/'
-    case 'clawhub':
-      return `${TEAMCLU_DIR}/skills/ (ClawHub)`
     case 'shared':
       return '.agents/skills/'
     case 'team':
-      return `${TEAM_REPO_DIR}/skills/ (team share)`
+      return 'opencode.json → skills.paths'
     case 'builtin':
       return i18n.t('skills.builtinPath', { app: appDisplayName })
-    case 'plugin':
-      return 'teamclu.json → plugin'
     case 'personal':
       return ''
-    case 'global-teamclu':
-      return '~/.config/teamclu/skills/'
     case 'global-claude':
       return '~/.claude/skills/'
     case 'global-agent':
@@ -409,20 +323,14 @@ export function getSourceBadgeClass(source: SkillSource): string {
       return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300'
     case 'claude':
       return 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300'
-    case 'clawhub':
-      return 'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-300'
     case 'shared':
       return 'bg-violet-100 text-violet-800 dark:bg-violet-900 dark:text-violet-300'
     case 'team':
       return 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300'
     case 'builtin':
       return 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300 border border-blue-200/60 dark:border-blue-700/50'
-    case 'plugin':
-      return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300'
     case 'personal':
       return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300'
-    case 'global-teamclu':
-      return 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-300'
     case 'global-claude':
       return 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300'
     case 'global-agent':

--- a/packages/app/src/lib/skills/types.ts
+++ b/packages/app/src/lib/skills/types.ts
@@ -124,16 +124,23 @@ export function isTeamMember(obj: unknown): obj is TeamMember {
 // ─── Skill Source Types ────────────────────────────────────────────────────
 
 /** Source badge for a loaded skill */
-export type SkillSource = 
-  | 'local' 
-  | 'claude' 
-  | 'clawhub' 
-  | 'shared' 
-  | 'personal' 
-  | 'team' 
+/**
+ * Where a skill was loaded from. One entry per root in the daemon's
+ * `skill_dir_specs`, plus three labels that are not roots:
+ *
+ * - `builtin` — an inherent skill, decided by name wherever it sits.
+ * - `local` — role-managed, from `{meta}/roles/<role>/skills`. The only
+ *   remaining meaning of this value: it used to be the brand meta skills dir,
+ *   which is not scanned any more.
+ * - `personal` — an Agent inventory row, which carries no path at all.
+ */
+export type SkillSource =
+  | 'claude'
+  | 'shared'
+  | 'personal'
+  | 'team'
   | 'builtin'
-  | 'plugin'
-  | 'global-teamclu'
+  | 'local'
   | 'global-claude'
   | 'global-agent'
 

--- a/packages/app/src/lib/team-skill-paths.ts
+++ b/packages/app/src/lib/team-skill-paths.ts
@@ -127,14 +127,6 @@ async function readSkillPathsFromConfig(
   }
 }
 
-/**
- * All directories that should contribute `source: 'team'` skills for a workspace.
- *
- * Sources (deduped):
- * - `teamclu.json` → `skills.paths`
- * - `opencode.json` → `skills.paths` (legacy / OpenCode-aligned config)
- * - `<workspace>/teamclu-team/skills` when the team share link exists on disk
- */
 async function remapTeamSkillPath(
   workspacePath: string,
   path: string,
@@ -152,31 +144,33 @@ async function remapTeamSkillPath(
   return (await exists(remapped)) ? remapped : null
 }
 
+/**
+ * All directories that should contribute `source: 'team'` skills for a workspace.
+ *
+ * One source: `opencode.json` → `skills.paths`. It is the only config anything
+ * writes — the desktop's `ensure_agents_skills_paths` registers
+ * `~/.agents/skills` there — and the daemon reads exactly the same file
+ * (`config::roles_skills::collect_team_skill_paths`).
+ *
+ * Two former sources are gone. `teamclu.json` never had a writer for
+ * `skills.paths`. `<workspace>/teamclu-team/skills` lost its writer when
+ * `skills/` moved to the registry and joined the OSS sync's RETIRED_PREFIXES;
+ * the leftovers on disk kept reaching agents, which is exactly the "quietly
+ * running a version the team retired" case the registry exists to end.
+ */
 export async function collectTeamSkillPaths(workspacePath: string): Promise<string[]> {
   const dirs = new Set<string>()
   const teamId = await readOnboardedTeamId()
 
-  for (const path of await readSkillPathsFromConfig(workspacePath, 'teamclu.json')) {
-    const resolved = await remapTeamSkillPath(workspacePath, path, teamId)
-    if (resolved) dirs.add(resolved)
-  }
   for (const path of await readSkillPathsFromConfig(workspacePath, 'opencode.json')) {
     const resolved = await remapTeamSkillPath(workspacePath, path, teamId)
     if (resolved) dirs.add(resolved)
   }
 
-  const teamDir = await resolveTeamDir(workspacePath)
-  if (teamDir) {
-    const defaultTeamSkillsDir = joinPath(teamDir, 'skills')
-    if (await exists(defaultTeamSkillsDir)) {
-      dirs.add(defaultTeamSkillsDir)
-    }
-  }
-
   return Array.from(dirs)
 }
 
-/** Paths from `teamclu.json` only — used by tests that assert config parsing. */
+/** Raw `skills.paths` entries, unresolved — used by tests that assert parsing. */
 export async function readConfigSkillPaths(workspacePath: string): Promise<string[]> {
-  return readSkillPathsFromConfig(workspacePath, 'teamclu.json')
+  return readSkillPathsFromConfig(workspacePath, 'opencode.json')
 }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -3163,7 +3163,8 @@
   },
   "skills": {
     "builtinLabel": "Built-in",
-    "builtinPath": ".teamclu/skills/ ({{app}} built-in)"
+    "builtinPath": "~/.agents/skills/ ({{app}} built-in)",
+    "roleManagedLabel": "Role"
   },
   "daemon": {
     "agentRuntime": {

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -3163,7 +3163,8 @@
   },
   "skills": {
     "builtinLabel": "内置",
-    "builtinPath": ".teamclu/skills/（{{app}} 内置）"
+    "builtinPath": "~/.agents/skills/（{{app}} 内置）",
+    "roleManagedLabel": "角色"
   },
   "daemon": {
     "agentRuntime": {

--- a/packages/app/src/stores/__tests__/team-share-personal-rows.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-personal-rows.test.ts
@@ -48,8 +48,7 @@ describe('planPersonalRow', () => {
     })
   })
 
-  test('market and builtin copies are not personal skills', () => {
-    expect(row({ source: 'clawhub' }).hidden).toBe(true)
+  test('builtin copies are not personal skills', () => {
     expect(row({ source: 'builtin' }).hidden).toBe(true)
   })
 })

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -463,8 +463,8 @@ export function planPersonalRow(row: {
   if (row.registryOwnsSlug && row.packOnDisk && row.source === 'global-agent') {
     return { hidden: true, id: row.slug }
   }
-  // Builtin / clawhub market copies are not "my personal skills".
-  if (row.source === 'builtin' || row.source === 'clawhub') {
+  // Builtin copies are not "my personal skills".
+  if (row.source === 'builtin') {
     return { hidden: true, id: row.slug }
   }
   // Rows are selected by id and resolved by first match, so a colliding row


### PR DESCRIPTION
## 背景

选中一个 Agent actor 后,第二列列出的技能来自两处:Agent 的 RPC inventory(只扫 `<amuxd home>/teams/<team>/state/cloud/skills` 和 `~/.agents/skills`),以及——仅当那个 Agent 就是本机 daemon 时——`GET /v1/workspaces/{id}/skills` 的全量 workspace 扫描,用来补 `dirPath` / `content` 让详情页可编辑。

后者原来扫 8 个 root + 4 个配置文件,其中大半已经没有写入方。前端 `loadAllSkills` 还维护了另一份不一样的列表,两个 loader 在好几项上对不上。

## 收敛后的 root 表

daemon `skill_dir_specs` 与前端 `loadAllSkills` 现在是同一张表:

| rank | root | source |
|---|---|---|
| 1 | `<ws>/.claude/skills` | `claude` |
| 2 | `~/.agents/skills` | `global-agent` |
| 3 | `<ws>/.agents/skills` | `shared` |
| 4 | `opencode.json` → `skills.paths` | `team` |
| 5 | `~/.claude/skills` | `global-claude` |

删掉的:

- `.teamclu/skills`(含 legacy `.teamclaw/skills`)—— `upsert_skill` 写调用方给的 `dirPath`,设置页新建直接写 `~/.agents/skills`,兜底分支在产品里走不到
- `.opencode/skills` / `~/.config/opencode/skills` —— opencode 时代遗留
- `~/.config/teamclu/skills` —— 从来没有写入方
- `.teamclu/teamclu.json` / `.teamclu/teamclaw.json` / `teamclu.json` 的 `skills.paths` —— 没有写入方。`ensure_agents_skills_paths` 只写 `opencode.json` 和两个 `.claude/settings.json`
- 前端独有的 `.teamclu/cache/agent/node_modules/*/skills`(plugin 缓存)—— daemon 从来不扫

## 必须一起改的三处

**内置技能改种到 `~/.agents/skills`**(`supervisor.rs`)。原来 `prepare_workspace` 往 `.teamclu/skills` 和 `.opencode/skills` 各种一份,后者 rank 最低永远被盖住。现在一份,而且和 Agent 侧 `skill_inventory` 找它们的位置一致了。`builtin` 标签同步改成按名字判(`is_inherent_skill`),不再按 root——否则搬家后徽章和删除保护都没了。

**`attachSkillToRole` 是坏的**(`roles/loader.ts`)。它硬编码 `<ws>/.teamclu/skills/<slug>` 当拷贝源,那个目录搬空后"附加技能到角色"必然抛 `not available for role attachment`。改成从 attachable 列表解析实际 `dirPath`。

**`refresh_watch` 的监听 root 同步收窄**。监听一个不扫的目录 = 为看不见的文件触发刷新;漏监听 = 面板一直是陈的。

## 顺带清掉的死代码

`clawhub` 这个 source 已经死了:ClawHub 装到 `~/.agents/skills`(`clawhub.rs:576` "Always install under ~/.agents/skills"),而分类只认 meta root。SkillsSection 里走 `clawhub_uninstall` 的分支从来不会命中,一并删除;marketplace 自己的卸载入口不受影响。

`local` 保留但含义收窄成"角色管理的技能"(`{meta}/roles/<role>/skills`)——daemon 的 `load_role_managed_skills` 一直发这个值。

## 已知后果

存量用户 `.teamclu/skills` 里的技能升级后从面板消失(文件还在磁盘)。这是有意的,本次不做迁移。

## 验证

- `cargo test -p amuxd --locked --no-fail-fast` 全过。跑了两轮,各红一个不同用例(`pi_rpc::catalog_probe`、`cursor_sdk::ask_policy`、`sidecar::mcp::assemble`),单独跑均绿——机器负载导致的时序 flake,模块都不在改动范围内
- `pnpm typecheck` / `pnpm lint`:0 error
- `pnpm test:unit`:453 文件 / 2962 用例全过
- 改动的 4 个 Rust 文件 `rustfmt --check` 干净(没跑整包 fmt,那会动 51 个无关文件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)