### PR TITLE
fix(deps): 修好 lockfile 里一条 vitest peer 悬空引用，CI 装依赖恢复

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12428,7 +12428,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
     optionalDependencies:
-      vitest: 4.1.9(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.1)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.1)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:


### PR DESCRIPTION
## 症状

main 上 `pnpm install --frozen-lockfile` 必挂,`Lint, Typecheck & Test` 这个 job 死在装依赖那一步,后面 ESLint / TypeScript check / unit tests / smoke tests **全部 skipped**——CI 从来没跑到代码。所有 open PR 也会因为同一原因全红。

```
[ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY] Broken lockfile: no entry for
'vitest@4.1.9(…)(vite@8.2.1(@types/node@26.1.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))'
```

## 根因:两个 dependabot PR 撞车

注意报错里那个 key **不带 `esbuild@0.28.2`**:

- **#1056**(`esbuild 0.24.2 → 0.28.2`)把 lockfile 里所有 vite peer 后缀改成带 `(esbuild@0.28.2)`
- **#1058**(`@testing-library/jest-dom 6.9.1 → 7.0.1`)的分支开在 #1056 落地之前,合进来时新写的那条 snapshot 里 `optionalDependencies.vitest` 用的还是**旧后缀**

全文件 17 处同类 key,只有 `pnpm-lock.yaml:12431` 这一处不带 esbuild。

## 修法

把那一处改成和其余 16 处一致。没有重新生成 lockfile——`pnpm install --no-frozen-lockfile` 会顺带把 `packageManager` 改写成本机 pnpm 版本,而 CI 用哪个 pnpm 正是看这个字段。

diff 就一行。

## 验证

在最新 main 上:

- `pnpm install --frozen-lockfile` 通过(之前必挂)
- `pnpm lint` 0 error
- `pnpm typecheck` 干净
- `pnpm test:unit` 446 文件 / 2894 用例全过

`package.json` 的 `packageManager` 保持 `pnpm@11.22.0` 未动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)