### PR TITLE
feat(app): make conversation header icons configurable, hidden by default

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -102,6 +102,7 @@ import { useTeamShareBrowserStore } from "@/stores/team-share-browser";
 import { TeamShareDetailContent } from "@/components/teamshare/TeamShareTabContent";
 import { IdeasDetailColumn } from "@/components/panel/IdeaDetailPane";
 import { useTerminalStore } from "@/stores/terminal-store";
+import { useHeaderPreferencesStore } from "@/stores/header-preferences-store";
 import { TabBar } from "@/components/tab-bar/TabBar";
 import { TabContentRenderer } from "@/components/tab-bar/TabContentRenderer";
 import { WebViewToolbar } from "@/components/tab-bar/WebViewToolbar";
@@ -657,6 +658,11 @@ function AppContent() {
   // before the user ever opens the panel or Settings → Team.
   const refreshTeamShare = useTeamShareStore((s) => s.refresh);
   const mainContentLayout = useUIStore((s) => s.mainContentLayout);
+  // Header icon visibility — additive gates on top of the capability/session
+  // conditions below. Defaults hidden; users enable per-icon in Settings →
+  // General → "会话头部图标". See stores/header-preferences-store.ts.
+  const showTerminalToggle = useHeaderPreferencesStore((s) => s.showTerminalToggle);
+  const showChangesTab = useHeaderPreferencesStore((s) => s.showChangesTab);
   const { open: sidebarOpen, setOpen: setSidebarOpen } = useSidebar();
   const hasActiveFileTab = !!useTabsStore(selectActiveTab);
   const hasHiddenTabs = useTabsStore(selectHasHiddenTabs);
@@ -1127,7 +1133,7 @@ function AppContent() {
                   <AppWindow className="h-4 w-4" />
                 </button>
               )}
-              {capabilities.workspace && workspacePath && (
+              {capabilities.workspace && workspacePath && showTerminalToggle && (
                 <TerminalToggleButton workspacePath={workspacePath} />
               )}
               {hasCurrentSession && !isSoloBuild() && (
@@ -1142,7 +1148,7 @@ function AppContent() {
                   left nav, where the same tree renders in column two with its
                   editor in column three. Kept out of the header so the two do
                   not diverge. */}
-              {capabilities.workspace && hasCurrentSession && (
+              {capabilities.workspace && hasCurrentSession && showChangesTab && (
                 <HeaderPanelTab
                   icon={FolderGit}
                   label={t("navigation.changes", "Changes")}

--- a/packages/app/src/components/settings/GeneralSection.tsx
+++ b/packages/app/src/components/settings/GeneralSection.tsx
@@ -13,6 +13,8 @@ import {
   User,
   Bug,
   PanelBottom,
+  TerminalSquare,
+  FolderGit,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn, isTauri } from '@/lib/utils'
@@ -33,6 +35,7 @@ import { SettingCard, SectionHeader, ToggleSwitch } from './shared'
 import { TeamDefaultAgentCard } from './TeamDefaultAgentCard'
 import { SwitchTeamDialog } from '@/components/auth/SwitchTeamDialog'
 import { useAcpDebugStore } from '@/stores/acp-debug-store'
+import { useHeaderPreferencesStore } from '@/stores/header-preferences-store'
 import { appStoragePrefix, buildConfig } from '@/lib/build-config'
 import { NOTIFICATION_LEVEL_KEY } from '@/lib/notification-service'
 import { LANGUAGE_OPTIONS, getPreferredLanguage, normalizeSupportedLanguage, persistLanguage } from '@/lib/locale'
@@ -152,6 +155,10 @@ export const GeneralSection = React.memo(function GeneralSection() {
   }, [])
   const acpStreamDebugEnabled = useAcpDebugStore((s) => s.enabled)
   const setAcpStreamDebugEnabled = useAcpDebugStore((s) => s.setEnabled)
+  const showTerminalToggle = useHeaderPreferencesStore((s) => s.showTerminalToggle)
+  const setShowTerminalToggle = useHeaderPreferencesStore((s) => s.setShowTerminalToggle)
+  const showChangesTab = useHeaderPreferencesStore((s) => s.showChangesTab)
+  const setShowChangesTab = useHeaderPreferencesStore((s) => s.setShowChangesTab)
   const [closePref, setClosePref] = React.useState<'ask' | 'tray' | 'quit'>('ask')
   React.useEffect(() => {
     if (!isTauri()) return
@@ -417,6 +424,51 @@ export const GeneralSection = React.memo(function GeneralSection() {
               <ToggleSwitch
                 enabled={acpStreamDebugEnabled}
                 onChange={setAcpStreamDebugEnabled}
+              />
+            </div>
+          </div>
+        </div>
+      </SettingCard>
+
+      <SettingCard>
+        <h4 className="font-medium mb-4 flex items-center gap-2">
+          <PanelBottom className="h-4 w-4 text-muted-foreground" />
+          {t('settings.general.headerIcons', '会话头部图标')}
+        </h4>
+        <p className="text-xs text-muted-foreground mb-4">
+          {t('settings.general.headerIconsDesc', '控制会话右上角操作图标的显示。默认隐藏，需要时在此开启。')}
+        </p>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <label className="text-[13px] font-medium flex items-center gap-2">
+                <TerminalSquare className="h-4 w-4 text-muted-foreground" />
+                {t('settings.general.showTerminalToggle', '终端开关')}
+              </label>
+              <p className="text-xs text-muted-foreground">
+                {t('settings.general.showTerminalToggleDesc', '在会话右上角显示终端面板开关。快捷键 Ctrl+` 始终可用，不受此设置影响。')}
+              </p>
+            </div>
+            <ToggleSwitch
+              enabled={showTerminalToggle}
+              onChange={setShowTerminalToggle}
+            />
+          </div>
+
+          <div className="border-t pt-4">
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-1">
+                <label className="text-[13px] font-medium flex items-center gap-2">
+                  <FolderGit className="h-4 w-4 text-muted-foreground" />
+                  {t('settings.general.showChangesTab', '文件更改')}
+                </label>
+                <p className="text-xs text-muted-foreground">
+                  {t('settings.general.showChangesTabDesc', '在会话右上角显示本会话的文件更改入口。仅在有活跃会话时显示。')}
+                </p>
+              </div>
+              <ToggleSwitch
+                enabled={showChangesTab}
+                onChange={setShowChangesTab}
               />
             </div>
           </div>

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1335,7 +1335,13 @@
       "notifImportant": "Important only",
       "notifMute": "Mute",
       "acpStreamDebug": "ACP stream debug",
-      "acpStreamDebugDesc": "Show live ACP event stream above the chat thread"
+      "acpStreamDebugDesc": "Show live ACP event stream above the chat thread",
+      "headerIcons": "Conversation header icons",
+      "headerIconsDesc": "Control which action icons appear in the conversation's top-right. Hidden by default; enable here as needed.",
+      "showTerminalToggle": "Terminal toggle",
+      "showTerminalToggleDesc": "Show the terminal panel toggle in the conversation's top-right. The Ctrl+` shortcut always works regardless of this setting.",
+      "showChangesTab": "File changes",
+      "showChangesTabDesc": "Show this session's file-changes entry in the conversation's top-right. Only appears when there is an active session."
     },
     "llm": {
       "cursorTitle": "Cursor models",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1335,7 +1335,13 @@
       "notifImportant": "仅重要通知",
       "notifMute": "静音",
       "acpStreamDebug": "ACP 流调试",
-      "acpStreamDebugDesc": "在聊天区域上方显示实时 ACP 事件流"
+      "acpStreamDebugDesc": "在聊天区域上方显示实时 ACP 事件流",
+      "headerIcons": "会话头部图标",
+      "headerIconsDesc": "控制会话右上角操作图标的显示。默认隐藏，需要时在此开启。",
+      "showTerminalToggle": "终端开关",
+      "showTerminalToggleDesc": "在会话右上角显示终端面板开关。快捷键 Ctrl+` 始终可用，不受此设置影响。",
+      "showChangesTab": "文件更改",
+      "showChangesTabDesc": "在会话右上角显示本会话的文件更改入口。仅在有活跃会话时显示。"
     },
     "llm": {
       "cursorTitle": "Cursor 模型",

--- a/packages/app/src/stores/__tests__/header-preferences-store.test.ts
+++ b/packages/app/src/stores/__tests__/header-preferences-store.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { useHeaderPreferencesStore } from "@/stores/header-preferences-store";
+import { loadFromStorage, saveToStorage } from "@/lib/storage";
+import { appStoragePrefix } from "@/lib/build-config";
+
+/**
+ * Header icon visibility preferences — persisted to localStorage under the
+ * shared `appStoragePrefix`-keyed `header-prefs` entry. Defaults are false
+ * (icons hidden out of the box); the store mirrors the git-settings pattern.
+ *
+ * We exercise the store + the persistence helpers together rather than
+ * re-importing the module under `vi.resetModules`: the latter re-binds the
+ * store's `localStorage` closure to a separate realm in jsdom under vitest,
+ * so writes round-trip invisibly to the test's `localStorage`. The
+ * module-level `persisted` snapshot is read once at import; the restore
+ * path is instead asserted through the storage helpers directly (which is
+ * what the store itself calls).
+ */
+const STORAGE_KEY = `${appStoragePrefix}-header-prefs`;
+
+describe("header-preferences-store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Reset the live store instance to defaults for state assertions.
+    useHeaderPreferencesStore.setState({
+      showTerminalToggle: false,
+      showChangesTab: false,
+    });
+  });
+
+  test("defaults are hidden (false)", () => {
+    const s = useHeaderPreferencesStore.getState();
+    expect(s.showTerminalToggle).toBe(false);
+    expect(s.showChangesTab).toBe(false);
+  });
+
+  test("setShowTerminalToggle flips state and persists to localStorage", () => {
+    useHeaderPreferencesStore.getState().setShowTerminalToggle(true);
+    expect(useHeaderPreferencesStore.getState().showTerminalToggle).toBe(true);
+    const loaded = loadFromStorage(STORAGE_KEY, null);
+    expect(loaded).toEqual({
+      showTerminalToggle: true,
+      showChangesTab: false,
+    });
+  });
+
+  test("setShowChangesTab flips state and persists to localStorage", () => {
+    useHeaderPreferencesStore.getState().setShowChangesTab(true);
+    expect(useHeaderPreferencesStore.getState().showChangesTab).toBe(true);
+    const loaded = loadFromStorage(STORAGE_KEY, null);
+    expect(loaded).toEqual({
+      showTerminalToggle: false,
+      showChangesTab: true,
+    });
+  });
+
+  test("the two toggles are independent", () => {
+    useHeaderPreferencesStore.getState().setShowTerminalToggle(true);
+    useHeaderPreferencesStore.getState().setShowTerminalToggle(false);
+    useHeaderPreferencesStore.getState().setShowChangesTab(true);
+    const s = useHeaderPreferencesStore.getState();
+    expect(s.showTerminalToggle).toBe(false);
+    expect(s.showChangesTab).toBe(true);
+  });
+
+  test("storage helpers round-trip the persisted shape the store writes", () => {
+    saveToStorage(STORAGE_KEY, {
+      showTerminalToggle: true,
+      showChangesTab: true,
+    });
+    expect(loadFromStorage(STORAGE_KEY, null)).toEqual({
+      showTerminalToggle: true,
+      showChangesTab: true,
+    });
+  });
+
+  test("missing persisted keys fall back to the false defaults (loadFromStorage semantics)", () => {
+    // Only one key seeded — the store reads `persisted.showChangesTab` as
+    // undefined and applies `?? false`.
+    saveToStorage(STORAGE_KEY, { showTerminalToggle: true });
+    const loaded = loadFromStorage<Partial<{
+      showTerminalToggle: boolean;
+      showChangesTab: boolean;
+    }>>(STORAGE_KEY, {});
+    expect(loaded.showTerminalToggle ?? false).toBe(true);
+    expect(loaded.showChangesTab ?? false).toBe(false);
+  });
+});

--- a/packages/app/src/stores/header-preferences-store.ts
+++ b/packages/app/src/stores/header-preferences-store.ts
@@ -1,0 +1,56 @@
+import { create } from 'zustand'
+import { loadFromStorage, saveToStorage } from '@/lib/storage'
+import { appStoragePrefix } from '@/lib/build-config'
+
+/**
+ * Per-user preferences for the conversation header's right-side action icons.
+ *
+ * These gate the header panel-tab buttons rendered in `App.tsx` (the terminal
+ * toggle and the "Changes" diff-panel entry). They are *additive* gates: a
+ * preference of `true` only *allows* the icon to render — the existing
+ * capability/session conditions still apply on top.
+ *
+ * Defaults are intentionally `false` (icons hidden out of the box) so the
+ * conversation header stays quiet. The terminal keyboard shortcut (Ctrl+`)
+ * keeps working regardless, because hiding the icon only removes the visible
+ * entry affordance — the terminal panel itself is owned by `terminal-store`.
+ *
+ * Persistence mirrors `git-settings.ts`: Zustand + a manual localStorage
+ * round-trip via `loadFromStorage`/`saveToStorage`, keyed with the shared
+ * `appStoragePrefix`.
+ */
+export interface HeaderPreferencesState {
+  /** Show the terminal toggle icon in the conversation header. Default false. */
+  showTerminalToggle: boolean
+  /** Show the "Changes" (file diff) panel entry in the conversation header. Default false. */
+  showChangesTab: boolean
+  setShowTerminalToggle: (show: boolean) => void
+  setShowChangesTab: (show: boolean) => void
+}
+
+const STORAGE_KEY = `${appStoragePrefix}-header-prefs`
+
+const persisted = loadFromStorage<Partial<HeaderPreferencesState>>(STORAGE_KEY, {})
+
+function persist(state: HeaderPreferencesState) {
+  saveToStorage(STORAGE_KEY, {
+    showTerminalToggle: state.showTerminalToggle,
+    showChangesTab: state.showChangesTab,
+  })
+}
+
+export const useHeaderPreferencesStore = create<HeaderPreferencesState>((set, get) => ({
+  // Defaults: hidden. `?? false` is belt-and-suspenders — loadFromStorage's
+  // fallback is already `{}`, so missing keys read as `undefined` → false.
+  showTerminalToggle: persisted.showTerminalToggle ?? false,
+  showChangesTab: persisted.showChangesTab ?? false,
+
+  setShowTerminalToggle: (show) => {
+    set({ showTerminalToggle: show })
+    persist(get())
+  },
+  setShowChangesTab: (show) => {
+    set({ showChangesTab: show })
+    persist(get())
+  },
+}))


### PR DESCRIPTION
## What

Adds a persisted preference store that gates the **terminal toggle** and the **"Changes" (file-diff) panel entry** in the conversation header's top-right action row. Both default to **hidden**; users enable them per-icon in **Settings → General → "会话头部图标"**.

## Why

The header currently hard-codes these icons with capability/session conditions but offers no user control — the user flagged that the terminal icon shows while the folder/changes icon disappears (the latter requires an active session, which is also why it's gone when login is blocked). This makes the header quiet by default and gives users an explicit on/off for each icon.

## Changes

- **New** `packages/app/src/stores/header-preferences-store.ts` — persisted Zustand store mirroring the `git-settings.ts` pattern. `showTerminalToggle` / `showChangesTab`, default `false`, localStorage round-trip via the shared `appStoragePrefix` under the `header-prefs` key.
- `packages/app/src/App.tsx` — import the store + additive selector gates on `TerminalToggleButton` and the `FolderGit` "Changes" `HeaderPanelTab`. The gates are *additive*: the existing `capabilities.workspace` / `hasCurrentSession` conditions still apply on top.
- `packages/app/src/components/settings/GeneralSection.tsx` — new "会话头部图标 / Conversation header icons" `SettingCard` with two `ToggleSwitch` rows (reuses the shared `ToggleSwitch`, same shape as the "ACP stream debug" row).
- `packages/app/src/locales/{en,zh-CN}.json` — en + zh keys for the card and both rows.
- **New** `packages/app/src/stores/__tests__/header-preferences-store.test.ts` — defaults, persistence round-trip, toggle independence, fallback semantics.

## Behavior notes

- Default: both icons **hidden** — the conversation header stays quiet out of the box.
- The `Ctrl+\`` keyboard shortcut keeps working regardless of the terminal toggle setting (hiding the icon only removes the visible entry affordance; the terminal panel itself is owned by `terminal-store`).
- Enabling an icon still respects the existing capability/session gate (e.g. "Changes" only renders with an active session).

## Verification

- ✅ `vitest run src/stores/__tests__/header-preferences-store.test.ts` — 6/6 pass
- ✅ `tsc --noEmit` — clean
- ✅ `pnpm lint` — 0 errors (only pre-existing warnings, none in changed files)

## Out of scope

- The unrelated `apps/desktop/tauri.conf.json` product-name rename was left out of this PR.
- Other header icons (AppWindow hide/show tabs, Actors, files, collapse-panel) are not gated — this PR only adds user toggles for the two icons the user asked about.
