### PR TITLE
fix(daemon): MQTT 认证被拒后重建 worker 换新 token，不再 ~100 次/秒空转

### DIFF
--- a/apps/daemon/src/mqtt/supervisor.rs
+++ b/apps/daemon/src/mqtt/supervisor.rs
@@ -530,6 +530,22 @@ fn restart_delay(failure_count: u32) -> Duration {
         .min(REBUILD_RETRY_MAX)
 }
 
+/// Whether a CONNACK refusal is one a fresh credential could fix.
+///
+/// Both codes show up against a JWT-authenticating broker and both mean the
+/// password is the problem: EMQX answers `BadUserNamePassword` when the
+/// signature verified but `exp` has passed, and `NotAuthorized` when no
+/// authenticator matched the signature at all. Everything else (protocol
+/// version, identifier rejected, server unavailable) is not about the
+/// credential, so rebuilding the worker around a new token would not help.
+fn connect_refusal_is_credential_failure(code: &rumqttc::mqttbytes::v4::ConnectReturnCode) -> bool {
+    use rumqttc::mqttbytes::v4::ConnectReturnCode;
+    matches!(
+        code,
+        ConnectReturnCode::BadUserNamePassword | ConnectReturnCode::NotAuthorized
+    )
+}
+
 fn inbound_retry_delay(attempt: u32) -> Duration {
     let exponent = attempt.saturating_sub(1).min(5);
     Duration::from_secs(1_u64 << exponent).min(INBOUND_RETRY_MAX)
@@ -1487,6 +1503,19 @@ impl MqttWorker {
         let mut auto_restore_subscriptions = false;
         let mut subscriptions_ready_announced = false;
         let mut exit_reason = "MQTT worker stopped".to_string();
+        // An ABSOLUTE deadline, deliberately hoisted out of the loop. It used
+        // to be a fresh `sleep(SUPERVISOR_TICK)` per iteration, which starves
+        // the tick arm whenever the event loop errors faster than the tick
+        // period: a rejected CONNACK comes back in ~10ms, so the timer was
+        // dropped and recreated ~100x/s and never once elapsed. That silently
+        // disabled everything the tick arm owns — `RECOVERY_DEADLINE`,
+        // `forced_rebuild`, and the proactive credential refresh. Observed in
+        // production as a worker stuck at `generation=0` with
+        // `poll_error_count=3065410` after 8.4 hours, hammering the broker at
+        // ~100 connects/s and never picking up the refreshed token sitting on
+        // disk. With an absolute deadline the arm fires on schedule no matter
+        // how fast the loop spins.
+        let mut next_tick = tokio::time::Instant::now() + SUPERVISOR_TICK;
 
         loop {
             self.heartbeat.touch();
@@ -1501,7 +1530,7 @@ impl MqttWorker {
                 self.flush_pending(&mut client, &mut pending, &mut publish_waiting_for_write);
             }
 
-            let tick = tokio::time::sleep(SUPERVISOR_TICK);
+            let tick = tokio::time::sleep_until(next_tick);
             tokio::pin!(tick);
 
             if let Some(active) = client.as_mut() {
@@ -1743,10 +1772,27 @@ impl MqttWorker {
                                 );
                                 let reason = error.to_string();
                                 if let rumqttc::ConnectionError::ConnectionRefused(code) = &error {
-                                    use rumqttc::mqttbytes::v4::ConnectReturnCode;
-                                    if matches!(code, ConnectReturnCode::BadUserNamePassword | ConnectReturnCode::NotAuthorized) {
+                                    if connect_refusal_is_credential_failure(code) {
                                         self.backend.invalidate_cached_credential();
-                                        warn!(?code, "MQTT authentication rejected; invalidating cached credential");
+                                        // Invalidating the cache is not enough on its
+                                        // own: rumqttc reconnects from the same
+                                        // `MqttOptions`, so it replays the password
+                                        // this worker was built with and can only ever
+                                        // be rejected again. The refreshed token on
+                                        // disk reaches the broker exactly when a new
+                                        // worker is built around it, so exit and let
+                                        // the supervisor rebuild — `schedule_restart`
+                                        // spaces those out 5s→30s, where the bare
+                                        // retry ran flat out at ~100/s.
+                                        forced_rebuild.get_or_insert_with(|| {
+                                            format!("MQTT credential rejected ({code:?})")
+                                        });
+                                        // Fire the tick arm on the next pass rather
+                                        // than burning up to a full second of retries
+                                        // waiting for the deadline it would otherwise
+                                        // have.
+                                        next_tick = tokio::time::Instant::now();
+                                        warn!(?code, "MQTT authentication rejected; invalidating cached credential and rebuilding the worker");
                                     } else {
                                         warn!(?code, "MQTT connection refused for a non-auth reason");
                                     }
@@ -1769,7 +1815,8 @@ impl MqttWorker {
                                         .map(|started| started.elapsed().as_millis() as u64)
                                         .unwrap_or_default(),
                                     %reason,
-                                    "MQTT transport error; rumqttc automatic recovery remains active"
+                                    rebuild_pending = forced_rebuild.is_some(),
+                                    "MQTT transport error; recovery in progress"
                                 );
                             }
                             Ok(_) => {
@@ -1782,6 +1829,10 @@ impl MqttWorker {
                     }
                     _ = &mut tick => {
                         self.heartbeat.touch();
+                        // Re-arm before the early-return path below: this arm
+                        // only breaks when a rebuild is due, so on every other
+                        // tick the loop continues and needs the next deadline.
+                        next_tick = tokio::time::Instant::now() + SUPERVISOR_TICK;
                         let recovery_expired = recovery_started
                             .is_some_and(|started| started.elapsed() >= RECOVERY_DEADLINE);
                         let proactive_due = next_proactive_reconnect
@@ -2433,6 +2484,33 @@ mod tests {
         assert!(heartbeat.last_progress_ms.load(Ordering::Relaxed) > 0);
         heartbeat.end_poll();
         assert_eq!(heartbeat.poll_pending_since_ms.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn credential_refusals_force_a_rebuild_and_other_refusals_do_not() {
+        use rumqttc::mqttbytes::v4::ConnectReturnCode;
+
+        // A JWT broker rejects an expired token as BadUserNamePassword and an
+        // unverifiable signature as NotAuthorized. Both are fixed by a new
+        // token, so both must take the rebuild path — leaving either one on
+        // rumqttc's own reconnect replays the dead password forever.
+        assert!(connect_refusal_is_credential_failure(
+            &ConnectReturnCode::BadUserNamePassword
+        ));
+        assert!(connect_refusal_is_credential_failure(
+            &ConnectReturnCode::NotAuthorized
+        ));
+
+        for code in [
+            ConnectReturnCode::RefusedProtocolVersion,
+            ConnectReturnCode::BadClientId,
+            ConnectReturnCode::ServiceUnavailable,
+        ] {
+            assert!(
+                !connect_refusal_is_credential_failure(&code),
+                "{code:?} is not a credential problem; a fresh token cannot fix it"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 背景

自建环境 broker 侧的认证配置出错期间（EMQX 上多了一个同 `id` 的 JWT 认证器，把正牌那个顶掉，全体客户端 `rc=5 not_authorized`），amuxd 连续 **8.4 小时以 ~100 次/秒**重连：

```
poll_error_count=3065411  recovery_elapsed_ms=30368305  generation=0
reason=Connection refused, return code: `NotAuthorized`
```

broker 侧对应 ~8000 条 `authentication_failure`/分钟（被 EMQX 日志限流吞掉大半）。期间磁盘上的 token 一直在正常刷新，但**一次都没送到 broker**。

服务端配置已单独修复。这个 PR 修的是客户端侧那两个「让一次瞬时拒绝变成永久故障」的 bug。

## 改动

只动 `apps/daemon/src/mqtt/supervisor.rs`。

### 1. 1 秒的 supervisor tick 从来没有触发过

`let tick = tokio::time::sleep(SUPERVISOR_TICK)` 建在 `loop` 体**内部**，每轮重造一个定时器。被拒的 CONNACK 约 10ms 就返回，循环转得比 tick 周期快，于是定时器每轮被丢弃重建、**从未elapsed 过一次**。

而 tick 分支持有的是这些东西：

- `RECOVERY_DEADLINE`（30s 后重建 worker）
- `forced_rebuild`
- 主动凭据刷新（`next_proactive_reconnect`）

全部静默失效——这就是 `generation` 8.4 小时停在 0 的原因。

改成 loop 外的绝对 deadline + `sleep_until`，循环转多快都按时触发；tick 分支里重新武装（它只在该重建时才 `break`，其余情况要继续跑）。

### 2. 认证被拒后不会换新 token

原来收到 `BadUserNamePassword` / `NotAuthorized` 只调 `invalidate_cached_credential()` 就继续往下走。但 rumqttc 的自动重连复用同一份 `MqttOptions`，重放的还是本 worker 构建时那个密码，**只可能一直被拒**；作废缓存要等到有新 worker 围着新 token 建起来才有意义。

现在同时置 `forced_rebuild` 并把 tick deadline 提前到当下，让 worker 退出、由 supervisor 走既有的 `schedule_restart` 退避（5s→30s）重建。重连速率从 ~100 次/秒降到最多每 5–30 秒 2 次。

### 附带

- 抽出纯函数 `connect_refusal_is_credential_failure()` 并配单测。注释里记了实测出的返回码映射：EMQX 对**签名验过但 `exp` 过期**答 `BadUserNamePassword`，对**签名对不上**答 `NotAuthorized`，两者都该走重建。
- `"rumqttc automatic recovery remains active"` 改成带 `rebuild_pending` 字段的准确措辞——排查时正是这句把方向带偏了。

## 测试

- `cargo test -p amuxd --locked`：10 个测试二进制全绿（含新用例 `credential_refusals_force_a_rebuild_and_other_refusals_do_not`）
- `rustfmt --check` 该文件干净；clippy 对新代码零 finding

## 遗留

这两处修好后 daemon 能自己换新 token、不再空转，但**换来的 token 得是 broker 认的**——遇到服务端认证配置出错这类情况，客户端只会从「100 次/秒失败」变成「每 30 秒失败一次」，真正的恢复仍靠服务端。要做到无人值守，还缺一个把持续认证失败暴露出来的告警（目前只有 daemon 本地日志和 UI 上一个红点）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)