### PR TITLE
fix(knowledge): 侧边栏知识库直读 ~/.amuxd 绝对路径 + fs watch + sync 解耦 workspace

### DIFF
--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -1209,28 +1209,15 @@ impl DaemonServer {
         // the MQTT reconnect loop.
         self.start_channels().await;
         self.sync_team_shared_dirs_for_known_workspaces().await;
-        {
-            let team_id = self.backend.team_id().to_string();
-            let grouped = if team_id.trim().is_empty() {
-                Vec::new()
-            } else {
-                match self.backend.get_workspaces_by_team(&team_id).await {
-                    Ok(rows) => {
-                        let paths = cloud_rows_to_local_linkable_paths(&rows);
-                        if paths.is_empty() {
-                            Vec::new()
-                        } else {
-                            vec![(team_id, paths)]
-                        }
-                    }
-                    Err(e) => {
-                        tracing::debug!("sync timer: get_workspaces_by_team failed: {e}");
-                        Vec::new()
-                    }
-                }
-            };
-            crate::sync::timer::spawn(self.sync_dispatcher.clone(), grouped);
-        }
+        // The timer syncs the daemon's team, full stop. It used to ask the cloud
+        // for that team's workspaces first and stand down when the list came
+        // back empty or the call failed — so a device with no registered
+        // workspace, or one that booted while FC was unreachable, silently never
+        // auto-synced. The synced tree is the team's, not a workspace's.
+        crate::sync::timer::spawn(
+            self.sync_dispatcher.clone(),
+            self.backend.team_id().to_string(),
+        );
 
         // Populate the refresh watchers from the cloud workspace list on a
         // background task (moved off the pre-bind path above). The watcher poll

--- a/apps/daemon/src/daemon/server/peers_workspaces.rs
+++ b/apps/daemon/src/daemon/server/peers_workspaces.rs
@@ -282,22 +282,17 @@ impl DaemonServer {
         if !team_id.trim().is_empty() {
             let gate = crate::team_link::team_share_gate(self.backend.as_ref(), team_id).await;
             crate::team_link::materialize_or_teardown(gate, team_id, &canonical_str);
-            // Clone the team's shared repo now instead of waiting for a daemon
-            // restart. The periodic sync timer captures its workspace list once
-            // at boot; on a fresh install that list was empty (the workspace
-            // wasn't cloud-registered yet), so without this the team dirs
-            // (knowledge/, skills/, .mcp/) never materialize until the next
-            // restart re-captures the now-registered workspace. Fire-and-forget
-            // so registration stays responsive; failures (e.g. team secret not
-            // delivered yet) are logged and left to the timer / secret self-heal.
-            // Fire-and-forget initial sync only when auto_sync is enabled.
+            // Pull the team's shared tree now instead of waiting for the timer's
+            // next tick, so the team dirs (knowledge/, .mcp/) are there by the
+            // time the user looks. Fire-and-forget so registration stays
+            // responsive; failures (e.g. team secret not delivered yet) are
+            // logged and left to the timer / secret self-heal.
             if crate::config::DaemonConfig::team_share_auto_sync_enabled_from_disk() {
                 let dispatcher = self.sync_dispatcher.clone();
                 let team = team_id.to_string();
-                let path = canonical_str.clone();
                 tokio::spawn(async move {
                     let status = dispatcher
-                        .sync_team(&team, &path, crate::sync::dispatch::SyncOptions::default())
+                        .sync_team(&team, crate::sync::dispatch::SyncOptions::default())
                         .await;
                     match status.last_error {
                         Some(err) => warn!(

--- a/apps/daemon/src/http/team_sync.rs
+++ b/apps/daemon/src/http/team_sync.rs
@@ -2,10 +2,14 @@
 //!
 //! The desktop app drives team sync over the daemon's loopback HTTP API rather
 //! than running OSS sync itself. `POST /v1/team/sync` kicks a sync for the
-//! workspace's onboarded team; `GET /v1/team/sync/status` reads the cached last
+//! daemon's onboarded team; `GET /v1/team/sync/status` reads the cached last
 //! status. The daemon is single-team, so the team_id is resolved from
 //! `daemon.toml` (teamclu.json carries no team_id) — same lookup as
 //! `/v1/team/link`.
+//!
+//! `workspacePath` is optional and only ever used to repair that workspace's
+//! team links as a side effect. What gets synced is the team's own tree under
+//! the amuxd home, so a client with no folder open can still sync.
 use axum::extract::{Path, Query, State};
 use axum::Json;
 use serde::{Deserialize, Serialize};
@@ -18,7 +22,10 @@ use crate::sync::versions::{ChangedFile, VersionEntry};
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncRequest {
-    pub workspace_path: String,
+    /// Optional. Present only so this call can also repair that workspace's
+    /// team links; it never decides what is synced.
+    #[serde(default)]
+    pub workspace_path: Option<String>,
     /// When `true`, run sync even if `team_share.auto_sync` is `false`.
     #[serde(default)]
     pub force_sync: bool,
@@ -30,24 +37,27 @@ pub struct SyncResponse {
     pub status: crate::sync::dispatch::SyncStatus,
 }
 
-/// `POST /v1/team/sync` — body `{ "workspacePath": "<abs path>" }`.
+/// `POST /v1/team/sync` — body `{ "workspacePath"?: "<abs path>" }`.
 pub async fn sync_now(
     principal: Principal,
     State(state): State<HttpState>,
     Json(body): Json<SyncRequest>,
 ) -> Result<Json<SyncResponse>, HttpError> {
     require_scope(&principal, "workspace:write")?;
-    let workspace_path = body.workspace_path.trim();
-    if workspace_path.is_empty() {
-        return Err(HttpError::validation("workspacePath must not be empty"));
+    let workspace_path = body
+        .workspace_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|p| !p.is_empty());
+    let team_id = active_team_id()?;
+    // Opportunistic repair of the caller's workspace links, when it named one.
+    if let Some(path) = workspace_path {
+        crate::team_link::ensure_team_link(&team_id, path);
     }
-    let team_id = team_id_for_workspace(workspace_path)?;
-    crate::team_link::ensure_team_link(&team_id, workspace_path);
     let status = state
         .sync_dispatcher
         .sync_team(
             &team_id,
-            workspace_path,
             crate::sync::dispatch::SyncOptions {
                 force: body.force_sync,
             },
@@ -129,7 +139,7 @@ pub async fn reconcile_cloud_config(
             (!trimmed.is_empty()).then_some(trimmed)
         })
         .map(Ok)
-        .unwrap_or_else(|| team_id_for_workspace(""))?;
+        .unwrap_or_else(active_team_id)?;
 
     let outcome = reconcile_team_cloud_after_write(&state, &team_id).await?;
 
@@ -246,7 +256,7 @@ pub async fn install_team_mcp(
     Path(name): Path<String>,
 ) -> Result<Json<TeamMcpInstallResponse>, HttpError> {
     require_scope(&principal, "workspace:write")?;
-    let team_id = team_id_for_workspace("")?;
+    let team_id = active_team_id()?;
     let backend = state
         .backend
         .as_ref()
@@ -269,7 +279,7 @@ pub async fn uninstall_team_mcp(
     Path(name): Path<String>,
 ) -> Result<Json<TeamMcpInstallResponse>, HttpError> {
     require_scope(&principal, "workspace:write")?;
-    let team_id = team_id_for_workspace("")?;
+    let team_id = active_team_id()?;
     let backend = state
         .backend
         .as_ref()
@@ -878,7 +888,9 @@ pub async fn list_changed(
 
 /// Resolve the team_id for a workspace from the daemon's onboarded team
 /// (teamclu.json carries no team_id; daemon.toml does — same as /v1/team/link).
-fn team_id_for_workspace(_workspace_path: &str) -> Result<String, HttpError> {
+/// The team this daemon is onboarded to. Named for what it reads: `daemon.toml`,
+/// never the workspace.
+fn active_team_id() -> Result<String, HttpError> {
     let config = crate::config::DaemonConfig::load(&crate::config::DaemonConfig::default_path())
         .map_err(|e| HttpError::internal(format!("load daemon config: {e}")))?;
     config
@@ -893,6 +905,24 @@ fn team_id_for_workspace(_workspace_path: &str) -> Result<String, HttpError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The desktop can trigger a sync with no folder open. `workspacePath` used
+    /// to be required and rejected as a validation error when empty, which made
+    /// "no workspace" look like "cannot sync" for a tree that belongs to the
+    /// team, not to any workspace.
+    #[test]
+    fn sync_request_accepts_a_body_without_a_workspace() {
+        let body: SyncRequest = serde_json::from_str(r#"{"forceSync":true}"#).unwrap();
+        assert_eq!(body.workspace_path, None);
+        assert!(body.force_sync);
+
+        // An older client still sends one, and it still comes through — that is
+        // what asks for the workspace's team links to be repaired.
+        let with_ws: SyncRequest =
+            serde_json::from_str(r#"{"workspacePath":"/tmp/ws","forceSync":false}"#).unwrap();
+        assert_eq!(with_ws.workspace_path.as_deref(), Some("/tmp/ws"));
+        assert!(!with_ws.force_sync);
+    }
 
     #[test]
     fn mcp_workspace_paths_include_the_daemon_default_workspace() {

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -728,6 +728,45 @@ pub fn ensure_instruction_plugin(workspace_path: &Path) -> Result<(), WorkspaceC
     Ok(())
 }
 
+/// Rebuild `<workspace>/team-knowledge` on every workspace init, so a stale,
+/// dangling or missing link never survives one.
+///
+/// Two attempts, in order. The workspace-derived one chains through this
+/// workspace's own `teamclu-team` link; when THAT link is the thing that went
+/// missing it can derive nothing, and the workspace was previously stuck
+/// without a knowledge link until something else re-linked the team. So fall
+/// back to the daemon's active team, which is where the knowledge dir lives
+/// anyway.
+///
+/// The fallback only ever re-points at a directory that already exists: it is
+/// gated on the team's synced `knowledge/` dir being there, so it cannot
+/// resurrect a link for a team whose share was torn down (which would fight
+/// `team_link::materialize_or_teardown`), and it skips app checkouts for the
+/// same reason `ensure_team_link` does.
+fn ensure_workspace_knowledge_link(workspace_path: &Path) {
+    use crate::config::workspace_link::{
+        ensure_team_knowledge_link, ensure_team_knowledge_link_from_workspace, LinkStatus,
+    };
+
+    let mut status = ensure_team_knowledge_link_from_workspace(workspace_path);
+    if matches!(status, LinkStatus::Fallback) {
+        let team_id = crate::config::layout::active_team();
+        // Same target `ensure_team_knowledge_link` would link to.
+        let knowledge_dir =
+            crate::config::global_team_store::sync_content_root(&team_id).join("knowledge");
+        let is_app = workspace_path
+            .to_str()
+            .is_some_and(crate::team_link::is_app_workspace);
+        if team_id != crate::config::layout::UNCLAIMED_TEAM && !is_app && knowledge_dir.is_dir() {
+            status = ensure_team_knowledge_link(workspace_path, &team_id);
+        }
+    }
+    tracing::debug!(
+        workspace = %workspace_path.display(),
+        "workspace team-knowledge link: {status:?}"
+    );
+}
+
 /// Prepare a workspace directory for OpenCode/ACP agent use.
 pub fn prepare_workspace(workspace_path: &Path) -> Result<(), WorkspaceControlError> {
     if !workspace_path.is_dir() {
@@ -736,10 +775,7 @@ pub fn prepare_workspace(workspace_path: &Path) -> Result<(), WorkspaceControlEr
         ));
     }
 
-    // Re-ensure the workspace team-knowledge link on every open/switch so a
-    // stale or dangling symlink never survives. No team_id here: it chains
-    // through the workspace own teamclu-team link.
-    let _ = crate::config::workspace_link::ensure_team_knowledge_link_from_workspace(workspace_path);
+    ensure_workspace_knowledge_link(workspace_path);
 
     install_instruction_plugin_file(workspace_path)?;
     materialize_opencode_for_prepare(workspace_path)?;
@@ -2413,6 +2449,53 @@ mod tests {
         );
         assert!(!dir.path().join(".opencode/skills").exists());
         assert!(!dir.path().join(".opencode/data").exists());
+    }
+
+    /// A workspace can lose `teamclu-team` (never linked, torn down, deleted by
+    /// hand). The workspace-derived repair then has nothing to chain through,
+    /// and before this the workspace stayed without a knowledge link until
+    /// something else re-linked the team. Every init rebuilds it now.
+    #[test]
+    fn prepare_workspace_rebuilds_team_knowledge_without_the_team_link() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
+        let amuxd = home.path().join(".amuxd");
+        std::fs::create_dir_all(&amuxd).unwrap();
+        std::fs::write(amuxd.join("daemon.toml"), "active_team = \"team-abc\"\n").unwrap();
+        let knowledge = amuxd.join("teams/team-abc/shared/knowledge");
+        std::fs::create_dir_all(&knowledge).unwrap();
+
+        let ws = tempfile::tempdir().unwrap();
+        assert!(!ws.path().join("teamclu-team").exists());
+
+        prepare_workspace(ws.path()).unwrap();
+
+        let link = ws.path().join("team-knowledge");
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "team-knowledge must be rebuilt from the active team"
+        );
+        assert_eq!(std::fs::read_link(&link).unwrap(), knowledge);
+    }
+
+    /// The fallback re-points at a directory that exists; it never materializes
+    /// one. A team whose share was torn down has no `shared/knowledge`, and
+    /// re-creating a link into it would fight `materialize_or_teardown`.
+    #[test]
+    fn prepare_workspace_leaves_team_knowledge_alone_when_the_team_dir_is_gone() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
+        let amuxd = home.path().join(".amuxd");
+        std::fs::create_dir_all(&amuxd).unwrap();
+        std::fs::write(amuxd.join("daemon.toml"), "active_team = \"team-abc\"\n").unwrap();
+
+        let ws = tempfile::tempdir().unwrap();
+        prepare_workspace(ws.path()).unwrap();
+
+        assert!(!ws.path().join("team-knowledge").exists());
     }
 
     #[test]

--- a/apps/daemon/src/sync/dispatch.rs
+++ b/apps/daemon/src/sync/dispatch.rs
@@ -101,19 +101,21 @@ impl SyncDispatcher {
     }
 
     /// Sync one team for one workspace path. Serialized per team_id.
-    pub async fn sync_team(
-        &self,
-        team_id: &str,
-        workspace_path: &str,
-        options: SyncOptions,
-    ) -> SyncStatus {
+    /// Sync one team's shared tree.
+    ///
+    /// Takes no workspace: the synced content root is
+    /// `~/.amuxd[-<brand>]/teams/<id>/shared`, which belongs to the team, not to
+    /// any workspace. The parameter used to be here and was already unused —
+    /// keeping it made every caller invent a workspace it did not need, and made
+    /// "no folder open" look like "cannot sync".
+    pub async fn sync_team(&self, team_id: &str, options: SyncOptions) -> SyncStatus {
         let lock = self.team_lock(team_id).await;
         let _guard = lock.lock().await;
         {
             let mut s = self.status.lock().await;
             s.entry(team_id.to_string()).or_default().syncing = true;
         }
-        let result = self.run_once(team_id, workspace_path, options).await;
+        let result = self.run_once(team_id, options).await;
         let mut s = self.status.lock().await;
         let entry = s.entry(team_id.to_string()).or_default();
         match result {
@@ -136,12 +138,7 @@ impl SyncDispatcher {
         entry.clone()
     }
 
-    async fn run_once(
-        &self,
-        team_id: &str,
-        _workspace_path: &str,
-        options: SyncOptions,
-    ) -> Result<SyncStatus, String> {
+    async fn run_once(&self, team_id: &str, options: SyncOptions) -> Result<SyncStatus, String> {
         if !options.force && !crate::config::DaemonConfig::team_share_auto_sync_enabled_from_disk()
         {
             return Ok(SyncStatus {
@@ -152,7 +149,7 @@ impl SyncDispatcher {
         }
         use crate::sync::oss;
         // The share mode comes from FC; the OSS content secret comes from the
-        // per-team secret store. The workspace path is no longer consulted.
+        // per-team secret store.
         let backend = self
             .backend
             .as_ref()
@@ -228,9 +225,7 @@ mod tests {
             .unwrap();
 
         let (d, _backend) = dispatcher_with_mock(&tmp);
-        let st = d
-            .sync_team("t", "/tmp/ws", SyncOptions { force: false })
-            .await;
+        let st = d.sync_team("t", SyncOptions { force: false }).await;
         assert!(st.skipped);
         assert!(st.last_error.is_none());
 
@@ -259,18 +254,14 @@ mod tests {
 
         let store = SecretStore::with_base(tmp.path().to_path_buf());
         let d = SyncDispatcher::new(store, None);
-        let err_st = d
-            .sync_team("t", "/tmp/ws", SyncOptions { force: true })
-            .await;
+        let err_st = d.sync_team("t", SyncOptions { force: true }).await;
         assert!(err_st.last_error.is_some());
 
         team.team_share.auto_sync = false;
         crate::config::team_config::save_typed(&crate::config::layout::active_team(), &team)
             .unwrap();
 
-        let st = d
-            .sync_team("t", "/tmp/ws", SyncOptions { force: false })
-            .await;
+        let st = d.sync_team("t", SyncOptions { force: false }).await;
         assert!(st.skipped);
         assert!(st.last_error.is_some());
 

--- a/apps/daemon/src/sync/timer.rs
+++ b/apps/daemon/src/sync/timer.rs
@@ -1,15 +1,22 @@
 //! Autonomous 300s sync loop: covers the app-closed / headless case. The
 //! desktop's HTTP trigger handles instant sync while the app is open.
 //!
-//! The workspace list is captured at spawn time. Teams added later are covered
-//! immediately by the HTTP /v1/team/sync path, and re-captured on the next
-//! daemon restart. (A live-refreshing timer is intentionally out of scope.)
+//! Keyed by team, not by workspace. The synced tree is
+//! `~/.amuxd[-<brand>]/teams/<id>/shared`, which exists whether or not this
+//! device has a folder open — the old form captured a cloud workspace list at
+//! boot and skipped the team entirely when it came back empty, so a device that
+//! had not registered a workspace yet never auto-synced at all.
 
 use std::time::Duration;
 
 use crate::sync::dispatch::{SyncDispatcher, SyncOptions};
 
-pub fn spawn(dispatcher: SyncDispatcher, workspaces: Vec<(String, Vec<String>)>) {
+pub fn spawn(dispatcher: SyncDispatcher, team_id: String) {
+    let team_id = team_id.trim().to_string();
+    if team_id.is_empty() {
+        tracing::debug!("sync timer not started: daemon is not onboarded to a team");
+        return;
+    }
     tokio::spawn(async move {
         let mut tick = tokio::time::interval(Duration::from_secs(300));
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -19,19 +26,13 @@ pub fn spawn(dispatcher: SyncDispatcher, workspaces: Vec<(String, Vec<String>)>)
                 tracing::debug!("timer sync skipped: team_share.auto_sync is disabled");
                 continue;
             }
-            for (team_id, paths) in &workspaces {
-                if let Some(ws) = paths.first() {
-                    if dispatcher.status(team_id).await.syncing {
-                        tracing::debug!(team_id, "timer sync skipped: sync already in progress");
-                        continue;
-                    }
-                    let st = dispatcher
-                        .sync_team(team_id, ws, SyncOptions::default())
-                        .await;
-                    if let Some(err) = &st.last_error {
-                        tracing::warn!(team_id, "timer sync error: {err}");
-                    }
-                }
+            if dispatcher.status(&team_id).await.syncing {
+                tracing::debug!(team_id, "timer sync skipped: sync already in progress");
+                continue;
+            }
+            let st = dispatcher.sync_team(&team_id, SyncOptions::default()).await;
+            if let Some(err) = &st.last_error {
+                tracing::warn!(team_id, "timer sync error: {err}");
             }
         }
     });

--- a/apps/desktop/src/commands/introspect_api.rs
+++ b/apps/desktop/src/commands/introspect_api.rs
@@ -189,7 +189,7 @@ async fn handle_team_sync_all(app: &AppHandle, _body: &[u8]) -> Result<String, S
         .ok_or_else(|| "No workspace path set. Please select a workspace first.".to_string())?;
     // Plan B Task 8: the desktop sync engine is gone — the daemon owns team
     // sync now. Forward to the daemon's team-sync endpoint for the workspace.
-    let result = super::team_sync_proxy::daemon_team_sync(&workspace, true).await?;
+    let result = super::team_sync_proxy::daemon_team_sync(Some(&workspace), true).await?;
     serde_json::to_string(&result).map_err(|e| format!("Serialization error: {e}"))
 }
 

--- a/apps/desktop/src/commands/team_sync_proxy.rs
+++ b/apps/desktop/src/commands/team_sync_proxy.rs
@@ -166,20 +166,25 @@ fn urlencode(value: &str) -> String {
 
 // ─── typed helpers ─────────────────────────────────────────────────────────
 
-/// `POST /v1/team/sync` `{ workspacePath, forceSync? }` — trigger a team sync.
+/// `POST /v1/team/sync` `{ workspacePath?, forceSync? }` — trigger a team sync.
+///
+/// The workspace is optional and never decides what is synced — the daemon
+/// syncs the team's own tree under its amuxd home. Passing one only asks the
+/// daemon to repair that workspace's team links on the way through.
 pub async fn daemon_team_sync(
-    workspace_path: &str,
+    workspace_path: Option<&str>,
     force_sync: bool,
 ) -> Result<serde_json::Value, String> {
+    let mut body = serde_json::json!({ "forceSync": force_sync });
+    if let Some(path) = workspace_path.map(str::trim).filter(|p| !p.is_empty()) {
+        body["workspacePath"] = serde_json::Value::String(path.to_string());
+    }
     daemon_request(
         reqwest::Method::POST,
         "/v1/team/sync",
         "",
         &["workspace:write"],
-        Some(&serde_json::json!({
-            "workspacePath": workspace_path,
-            "forceSync": force_sync,
-        })),
+        Some(&body),
     )
     .await
 }
@@ -393,7 +398,7 @@ pub async fn team_env_runtime_status(
         .map(str::trim)
         .filter(|s| !s.is_empty())
     {
-        if redeliver_local_team_secret(&team_id, wp).await {
+        if redeliver_local_team_secret(&team_id, Some(wp)).await {
             return daemon_team_env_available(&team_id).await;
         }
     }
@@ -430,9 +435,17 @@ fn local_team_secret_for_redelivery(workspace_path: &str, team_id: &str) -> Opti
 /// desktop is the source of truth for the secret (persisted in
 /// `team_secret_store`), so if the daemon is missing it we push it back.
 ///
+/// Needs a workspace: the secret lookup reads the legacy per-workspace stores,
+/// and the re-link is per-workspace by definition. With no folder open there is
+/// nothing to recover from, so the caller's sync simply reports the daemon's
+/// own error instead.
+///
 /// Returns `true` if a secret existed locally and was delivered, `false`
-/// otherwise (no local secret to recover from, or delivery failed).
-async fn redeliver_local_team_secret(team_id: &str, workspace_path: &str) -> bool {
+/// otherwise (no workspace, no local secret, or delivery failed).
+async fn redeliver_local_team_secret(team_id: &str, workspace_path: Option<&str>) -> bool {
+    let Some(workspace_path) = workspace_path.map(str::trim).filter(|p| !p.is_empty()) else {
+        return false;
+    };
     let Some(secret) = local_team_secret_for_redelivery(workspace_path, team_id) else {
         return false;
     };
@@ -444,26 +457,31 @@ async fn redeliver_local_team_secret(team_id: &str, workspace_path: &str) -> boo
     true
 }
 
-/// `oss_sync_now(workspacePath, teamId)` — trigger a team sync via the daemon.
+/// `oss_sync_now(workspacePath?, teamId)` — trigger a team sync via the daemon.
+///
+/// `workspacePath` is optional: team sync is per team, not per workspace, so
+/// this works with no folder open. When one is given it also gets its team
+/// links repaired, and it is what the secret self-heal below reads.
 ///
 /// The frontend only reads back fresh status afterwards (it does not depend on
 /// the exact `{pulled,pushed,conflicts}` numbers), so we map the daemon's sync
 /// response into that shape, defaulting any missing field to `0`.
 #[tauri::command]
 pub async fn oss_sync_now(
-    workspace_path: String,
+    workspace_path: Option<String>,
     team_id: String,
 ) -> Result<serde_json::Value, String> {
-    let mut status = daemon_team_sync(&workspace_path, true).await?;
+    let workspace_path = workspace_path.as_deref();
+    let mut status = daemon_team_sync(workspace_path, true).await?;
     // Self-heal: if the daemon reports it has no team secret, re-deliver the
     // locally-stored one and retry the sync once.
     if status
         .get("lastError")
         .and_then(|v| v.as_str())
         .is_some_and(is_missing_team_secret_error)
-        && redeliver_local_team_secret(&team_id, &workspace_path).await
+        && redeliver_local_team_secret(&team_id, workspace_path).await
     {
-        status = daemon_team_sync(&workspace_path, true).await?;
+        status = daemon_team_sync(workspace_path, true).await?;
     }
     let pick = |k: &str| status.get(k).and_then(|v| v.as_u64()).unwrap_or(0);
     Ok(serde_json::json!({
@@ -473,16 +491,16 @@ pub async fn oss_sync_now(
     }))
 }
 
-/// `oss_sync_status(workspacePath, teamId)` — current sync status from the daemon.
+/// `oss_sync_status(workspacePath?, teamId)` — current sync status from the daemon.
 ///
-/// Returns the daemon status JSON verbatim (Phase 3 aligns the TS type). The
-/// `workspacePath` arg is accepted for signature compatibility; the daemon keys
-/// status by team.
+/// Returns the daemon status JSON verbatim. The daemon keys status by team; the
+/// optional `workspacePath` only feeds the secret self-heal below.
 #[tauri::command]
 pub async fn oss_sync_status(
-    workspace_path: String,
+    workspace_path: Option<String>,
     team_id: String,
 ) -> Result<serde_json::Value, String> {
+    let workspace_path = workspace_path.as_deref();
     let status = daemon_team_sync_status(&team_id).await?;
     // Self-heal a stale "no OSS team secret" state: the desktop holds the secret
     // locally, so re-deliver it and run a sync so the daemon clears its
@@ -493,9 +511,9 @@ pub async fn oss_sync_status(
         .get("lastError")
         .and_then(|v| v.as_str())
         .is_some_and(is_missing_team_secret_error)
-        && redeliver_local_team_secret(&team_id, &workspace_path).await
+        && redeliver_local_team_secret(&team_id, workspace_path).await
     {
-        let _ = daemon_team_sync(&workspace_path, true).await;
+        let _ = daemon_team_sync(workspace_path, true).await;
         return daemon_team_sync_status(&team_id).await;
     }
     Ok(status)
@@ -567,7 +585,7 @@ fn team_sync_success_payload() -> serde_json::Value {
 }
 
 async fn invoke_daemon_team_sync(
-    workspace_path: &str,
+    workspace_path: Option<&str>,
     force_sync: bool,
 ) -> Result<serde_json::Value, String> {
     match daemon_team_sync(workspace_path, force_sync).await {

--- a/packages/app/src/components/FileEditor.tsx
+++ b/packages/app/src/components/FileEditor.tsx
@@ -23,7 +23,10 @@ import {
   History,
 } from "lucide-react";
 import { cn, isTauri } from "@/lib/utils";
-import { TEAM_REPO_DIR } from "@/lib/build-config";
+import {
+  globalTeamKnowledgeShareDir,
+  teamSyncKeyForPath,
+} from "@/lib/team-skill-paths";
 import { getEditorType } from "@/components/editors/utils";
 import { UNSUPPORTED_BINARY_EXTENSIONS } from "@/components/viewers/UnsupportedFileViewer";
 import { supportsPreview } from "@/components/editors/utils";
@@ -365,7 +368,6 @@ export function FileEditor({
   onClose: () => void;
 }) {
   const { t } = useTranslation();
-  const isTeamFile = filePath?.includes(`/${TEAM_REPO_DIR}/`) ?? false
   const targetLine = useWorkspaceStore((s) => s.targetLine);
   const targetHeading = useWorkspaceStore((s) => s.targetHeading);
   const [currentContent, setCurrentContent] = useState(content);
@@ -405,23 +407,39 @@ export function FileEditor({
       ? filePath.slice(workspacePath.length + 1)
       : (filePath ?? "");
 
-  const teamRepoPath = useMemo(
-    () =>
-      workspacePath ? `${workspacePath.replace(/\/+$/, '')}/${TEAM_REPO_DIR}` : null,
-    [workspacePath],
-  )
+  // The team's real knowledge dir (`~/.amuxd[-<brand>]/teams/<id>/shared/
+  // knowledge`) — the directory the OSS sync engine owns, resolved by absolute
+  // path rather than through any workspace link.
+  const [knowledgeDir, setKnowledgeDir] = useState<string | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    globalTeamKnowledgeShareDir()
+      .then((dir) => { if (!cancelled) setKnowledgeDir(dir) })
+      .catch(() => { if (!cancelled) setKnowledgeDir(null) })
+    return () => { cancelled = true }
+  }, [])
 
-  const relativeTeamPath = useMemo(() => {
-    if (!teamRepoPath || !filePath) return null
-    const norm = filePath.replace(/\/+$/, '')
-    if (!norm.startsWith(teamRepoPath + '/')) return null
-    return norm.slice(teamRepoPath.length + 1)
-  }, [teamRepoPath, filePath])
+  // The key sync addresses this file by (`knowledge/<rel>`), null when the file
+  // is not team-synced content. Files opened from the Knowledge column carry the
+  // real absolute path; files opened from the workspace panel come in under the
+  // `team-knowledge` symlink. Both map to the same key, so the same document has
+  // the same history whichever surface opened it.
+  const teamSyncKey = useMemo(
+    () => (filePath ? teamSyncKeyForPath(filePath, { knowledgeDir, workspacePath }) : null),
+    [filePath, knowledgeDir, workspacePath],
+  )
+  // Team content is exactly what sync carries. This used to be "anywhere under
+  // `teamclu-team/`", which is a tree sync retired: it offered history on files
+  // that have none, and offered none on knowledge documents, which are the only
+  // files that do.
+  const isTeamFile = !!teamSyncKey
 
   const historyProvider = useMemo(() => {
-    if (!teamRepoPath || !relativeTeamPath || !workspacePath) return null
-    return new OssHistoryProvider(workspacePath, relativeTeamPath)
-  }, [teamRepoPath, relativeTeamPath, workspacePath])
+    if (!teamSyncKey) return null
+    // `workspacePath` is accepted for signature compatibility only — the daemon
+    // keys versions by team id + sync key, and the Tauri command drops it.
+    return new OssHistoryProvider(workspacePath ?? '', teamSyncKey)
+  }, [teamSyncKey, workspacePath])
 
   // Fetch the file's baseline content from the daemon for gutter decorations
   // (team files only). The daemon's `team_file_content(..., "baseline")` proxy
@@ -429,7 +447,7 @@ export function FileEditor({
   // so the gutter works for both team share modes.
   useEffect(() => {
     const teamId = useCurrentTeamStore.getState().team?.id;
-    if (!isTauri() || !isTeamFile || !relativeTeamPath || !teamId) {
+    if (!isTauri() || !teamSyncKey || !teamId) {
       setGitHeadContent(null);
       return;
     }
@@ -441,7 +459,7 @@ export function FileEditor({
         const { invoke } = await import("@tauri-apps/api/core");
         const res = await invoke<{ content: string | null }>("team_file_content", {
           teamId,
-          path: relativeTeamPath,
+          path: teamSyncKey,
           ref: "baseline",
         });
         if (!cancelled) {
@@ -457,7 +475,7 @@ export function FileEditor({
     return () => {
       cancelled = true;
     };
-  }, [relativeTeamPath, isTeamFile]);
+  }, [teamSyncKey]);
 
   // Check if this file supports preview
   const previewType = supportsPreview(filename);

--- a/packages/app/src/components/FileEditor.tsx
+++ b/packages/app/src/components/FileEditor.tsx
@@ -436,9 +436,10 @@ export function FileEditor({
 
   const historyProvider = useMemo(() => {
     if (!teamSyncKey) return null
-    // `workspacePath` is accepted for signature compatibility only — the daemon
-    // keys versions by team id + sync key, and the Tauri command drops it.
-    return new OssHistoryProvider(workspacePath ?? '', teamSyncKey)
+    // `workspacePath` is passed through but never decides anything — the daemon
+    // keys versions by team id + sync key. A knowledge document opened with no
+    // folder open still has its history.
+    return new OssHistoryProvider(workspacePath, teamSyncKey)
   }, [teamSyncKey, workspacePath])
 
   // Fetch the file's baseline content from the daemon for gutter decorations

--- a/packages/app/src/components/__tests__/FileEditor.test.tsx
+++ b/packages/app/src/components/__tests__/FileEditor.test.tsx
@@ -61,6 +61,9 @@ vi.mock('@/lib/history/oss-provider', () => ({
 vi.mock('@/components/editors/utils', () => ({
   getEditorType: () => 'code',
   supportsPreview: () => null,
+  // CodeEditor calls this during render; without it the mock throws mid-render
+  // and the failure surfaces as an unrelated "no export defined" error.
+  getLanguageFromFilename: () => 'markdown',
 }))
 
 vi.mock('@/components/editors/useAutoSave', () => ({
@@ -154,7 +157,36 @@ describe('FileEditor', () => {
     expect(screen.queryByTitle(/查看历史|View history|历史/i)).toBeNull()
   })
 
-  it('renders the history button for team files and toggles history view', async () => {
+  /**
+   * Team content is exactly what sync carries: the `knowledge/` prefix. This
+   * file arrives under the workspace `team-knowledge` symlink — the spelling
+   * the workspace file panel produces — and maps to the same sync key as the
+   * copy the Knowledge column opens by its real ~/.amuxd path.
+   */
+  it('renders the history button for team knowledge files and toggles history view', async () => {
+    isTauriMock.mockReturnValue(true)
+    render(
+      <FileEditor
+        content=""
+        filename="note.md"
+        filePath="/workspace/team-knowledge/note.md"
+        onClose={() => {}}
+      />,
+    )
+    const button = await screen.findByTitle(/查看历史|View history|历史/i)
+    fireEvent.click(button)
+    await waitFor(() =>
+      expect(screen.getByText('该文件还没有提交历史')).toBeDefined(),
+    )
+    isTauriMock.mockReturnValue(false)
+  })
+
+  /**
+   * `teamclu-team/` is a tree sync retired — nothing under it has versions. It
+   * used to get the button anyway, which offered a history that could only ever
+   * come back empty.
+   */
+  it('does not render the history button for retired teamclu-team content', () => {
     isTauriMock.mockReturnValue(true)
     render(
       <FileEditor
@@ -164,11 +196,7 @@ describe('FileEditor', () => {
         onClose={() => {}}
       />,
     )
-    const button = await screen.findByTitle(/查看历史|View history|历史/i)
-    fireEvent.click(button)
-    await waitFor(() =>
-      expect(screen.getByText('该文件还没有提交历史')).toBeDefined(),
-    )
+    expect(screen.queryByTitle(/查看历史|View history|历史/i)).toBeNull()
     isTauriMock.mockReturnValue(false)
   })
 })

--- a/packages/app/src/components/editors/MarkdownEditor.tsx
+++ b/packages/app/src/components/editors/MarkdownEditor.tsx
@@ -43,6 +43,10 @@ import type { EditorProps } from './types';
 import { detectClipboardImage, saveClipboardImage } from './image-paste-handler';
 import { parseWikiLinkText } from '@/lib/wiki-link-utils';
 import { resolveWikiLinkPath, createNoteFromLink } from '@/lib/wiki-link-resolver';
+import {
+  globalTeamKnowledgeShareDir,
+  teamKnowledgeRootForPath,
+} from '@/lib/team-skill-paths';
 import { useWorkspaceStore } from '@/stores/workspace';
 
 export interface MarkdownEditorHandle {
@@ -137,7 +141,7 @@ const wikiLinkPlugin = ViewPlugin.fromClass(
   { decorations: (v) => v.decorations },
 );
 
-function handleWikiLinkClick(event: MouseEvent): boolean {
+function handleWikiLinkClick(event: MouseEvent, filePath?: string): boolean {
   const target = event.target;
   if (!(target instanceof HTMLElement)) return false;
   const el = target.closest('.cm-wiki-link');
@@ -148,29 +152,39 @@ function handleWikiLinkClick(event: MouseEvent): boolean {
 
   const parts = parseWikiLinkText(match[1]);
   const workspace = useWorkspaceStore.getState();
-  const workspacePath = workspace.workspacePath;
-  if (!workspacePath) return false;
-
   const heading = parts.heading ?? undefined;
-  void resolveWikiLinkPath(workspacePath, "team-knowledge", parts.target)
-    .then((resolved) => {
+
+  void (async () => {
+    try {
+      // Resolve inside the knowledge tree the open document belongs to: the
+      // real `~/.amuxd[-<brand>]/teams/<id>/shared/knowledge` dir for a document
+      // opened from the Knowledge column, the `team-knowledge` symlink for one
+      // opened from the workspace file panel. Resolving both against the
+      // symlink would open the same note under a second path — two tabs over
+      // one file. A document outside any knowledge tree still links into the
+      // team's notes, and does so by the real directory.
+      const root =
+        (filePath
+          ? teamKnowledgeRootForPath(filePath, { workspacePath: workspace.workspacePath })
+          : null) ?? (await globalTeamKnowledgeShareDir());
+      if (!root) return;
+
+      const resolved = await resolveWikiLinkPath(root, parts.target);
       if (resolved) {
-        workspace.selectFile(`${workspacePath}/${resolved}`, undefined, heading);
+        await workspace.selectFile(resolved, undefined, heading);
         return;
       }
-      return createNoteFromLink(workspacePath, "team-knowledge", parts.target).then(
-        (newPath) => {
-          workspace.selectFile(newPath, undefined, heading);
-        },
-      );
-    })
-    .catch((err) => {
+      const newPath = await createNoteFromLink(root, parts.target);
+      await workspace.selectFile(newPath, undefined, heading);
+    } catch (err) {
       console.error('[MarkdownEditor] wiki-link resolution failed:', err);
-      // Surfaced, not swallowed: the common failure is "team-knowledge isn't
-      // linked yet", and creating the note anyway would shadow the daemon's
-      // symlink for good. Silence would just read as a dead click.
+      // Surfaced, not swallowed: the common failure is "the team knowledge dir
+      // isn't there yet", and creating the note anyway would materialize a
+      // directory the daemon means to own. Silence would just read as a dead
+      // click.
       toast.error(String(err instanceof Error ? err.message : err));
-    });
+    }
+  })();
   return true;
 }
 
@@ -297,7 +311,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorHandle, EditorProps>(
             return true;
           },
           mousedown(event) {
-            return handleWikiLinkClick(event);
+            return handleWikiLinkClick(event, filePathRef.current ?? undefined);
           },
         }),
         EditorView.updateListener.of((update) => {

--- a/packages/app/src/components/sidebar/TeamShareListColumn.tsx
+++ b/packages/app/src/components/sidebar/TeamShareListColumn.tsx
@@ -260,7 +260,7 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
 
   // Inline "name this thing" row at the top of the knowledge tree.
   const [rootCreating, setRootCreating] = React.useState<'file' | 'folder' | null>(null)
-  const refreshFileTree = useWorkspaceStore((s) => s.refreshFileTree)
+  const openExternalRoot = useWorkspaceStore((s) => s.openExternalRoot)
   const selectFile = useWorkspaceStore((s) => s.selectFile)
 
   const [query, setQuery] = React.useState('')
@@ -652,7 +652,9 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
         ? await createNewFolder(knowledgeRoot, trimmed)
         : await createNewFile(knowledgeRoot, trimmed)
     if (!ok) return
-    await refreshFileTree()
+    // The knowledge tree is its own root in the store — re-list THAT. The
+    // workspace tree has nothing to do with this column any more.
+    await openExternalRoot(knowledgeRoot)
     void loadSection('knowledge', { force: true })
     if (rootCreating !== 'folder') selectFile(`${knowledgeRoot}/${trimmed}`)
   }

--- a/packages/app/src/components/sidebar/TeamShareListColumn.tsx
+++ b/packages/app/src/components/sidebar/TeamShareListColumn.tsx
@@ -788,6 +788,66 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
         </div>
       </div>
 
+      {(section === 'skills' || section === 'mcp') && (
+        <div className="border-b border-border px-3 py-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                className="h-9 w-full justify-between bg-panel px-2.5 text-[12.5px] font-medium"
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="truncate">
+                    {manageableAgents.find((agent) => agent.id === subjectActorId)?.display_name ||
+                      t('teamShare.selectAgent', '选择 Agent')}
+                  </span>
+                  {subjectActorId && (
+                    <span
+                      className={cn(
+                        'h-1.5 w-1.5 shrink-0 rounded-full',
+                        presenceByActor[subjectActorId]?.online ? 'bg-emerald-500' : 'bg-faint',
+                      )}
+                    />
+                  )}
+                </span>
+                <ChevronDown className="h-3.5 w-3.5 text-faint" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-[240px]">
+              {manageableAgents.length === 0 ? (
+                <DropdownMenuItem disabled>
+                  {t('teamShare.noManageableAgents', '没有可管理的 Agent')}
+                </DropdownMenuItem>
+              ) : (
+                manageableAgents.map((agent) => (
+                  <DropdownMenuItem
+                    key={agent.id}
+                    onSelect={() => void setSubjectActor(agent.id)}
+                    className="flex items-center gap-2"
+                  >
+                    <span
+                      className={cn(
+                        'h-1.5 w-1.5 rounded-full',
+                        presenceByActor[agent.id]?.online ? 'bg-emerald-500' : 'bg-faint',
+                      )}
+                    />
+                    <span className="min-w-0 flex-1 truncate">{agent.display_name || agent.id}</span>
+                    {presenceByActor[agent.id]?.online === false ? (
+                      <span className="font-mono text-[10.5px] text-faint">
+                        {t('common.offline', '离线')}
+                      </span>
+                    ) : null}
+                    {agent.id === subjectActorId && <Check className="h-3.5 w-3.5" />}
+                  </DropdownMenuItem>
+                ))
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
+
       {searchOpen && (
         <div className="border-b border-border px-3 py-2">
           <input
@@ -1022,65 +1082,6 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
           ))
         )}
       </div>
-      {(section === 'skills' || section === 'mcp') && (
-        <div className="border-t border-border p-3">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                className="h-9 w-full justify-between bg-panel px-2.5 text-[12.5px] font-medium"
-              >
-                <span className="flex min-w-0 items-center gap-2">
-                  <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
-                  <span className="truncate">
-                    {manageableAgents.find((agent) => agent.id === subjectActorId)?.display_name ||
-                      t('teamShare.selectAgent', '选择 Agent')}
-                  </span>
-                  {subjectActorId && (
-                    <span
-                      className={cn(
-                        'h-1.5 w-1.5 shrink-0 rounded-full',
-                        presenceByActor[subjectActorId]?.online ? 'bg-emerald-500' : 'bg-faint',
-                      )}
-                    />
-                  )}
-                </span>
-                <ChevronDown className="h-3.5 w-3.5 text-faint" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-[240px]">
-              {manageableAgents.length === 0 ? (
-                <DropdownMenuItem disabled>
-                  {t('teamShare.noManageableAgents', '没有可管理的 Agent')}
-                </DropdownMenuItem>
-              ) : (
-                manageableAgents.map((agent) => (
-                  <DropdownMenuItem
-                    key={agent.id}
-                    onSelect={() => void setSubjectActor(agent.id)}
-                    className="flex items-center gap-2"
-                  >
-                    <span
-                      className={cn(
-                        'h-1.5 w-1.5 rounded-full',
-                        presenceByActor[agent.id]?.online ? 'bg-emerald-500' : 'bg-faint',
-                      )}
-                    />
-                    <span className="min-w-0 flex-1 truncate">{agent.display_name || agent.id}</span>
-                    {presenceByActor[agent.id]?.online === false ? (
-                      <span className="font-mono text-[10.5px] text-faint">
-                        {t('common.offline', '离线')}
-                      </span>
-                    ) : null}
-                    {agent.id === subjectActorId && <Check className="h-3.5 w-3.5" />}
-                  </DropdownMenuItem>
-                ))
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      )}
     </div>
   )
 }

--- a/packages/app/src/components/sidebar/TeamShareListColumn.tsx
+++ b/packages/app/src/components/sidebar/TeamShareListColumn.tsx
@@ -34,6 +34,7 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { useWorkspaceStore } from '@/stores/workspace'
+import { useFileChangeListener } from '@/hooks/useFileChangeListener'
 import { useCurrentTeamStore } from '@/stores/current-team'
 import { getBackend } from '@/lib/backend/provider'
 import {
@@ -321,6 +322,19 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
     }
     if (syncAvailable) await syncNow()
   }, [section, loadSection, syncAvailable, syncNow])
+
+  // A write inside the knowledge dir — a teammate's note arriving over sync, an
+  // agent editing a document — also changes the count in this header and in the
+  // nav rail. The tree refreshes itself (FileBrowser watches the same root);
+  // this is the other half.
+  useFileChangeListener(
+    () => {
+      void loadSection('knowledge', { force: true })
+    },
+    500,
+    section === 'knowledge' && !!knowledgeRoot,
+    (event) => !!knowledgeRoot && event.payload.path.startsWith(`${knowledgeRoot}/`),
+  )
 
   // Reload after any successful cloud sync, ours or another surface's.
   React.useEffect(() => {

--- a/packages/app/src/components/teamshare/KnowledgeVersionHistory.tsx
+++ b/packages/app/src/components/teamshare/KnowledgeVersionHistory.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { History } from 'lucide-react'
 import { useVersionHistoryStore } from '@/stores/version-history'
 import { useCurrentTeamStore } from '@/stores/current-team'
+import { useWorkspaceStore } from '@/stores/workspace'
+import { globalTeamKnowledgeShareDir, teamSyncKeyForPath } from '@/lib/team-skill-paths'
 import { VersionList } from '@/components/version/VersionList'
 import { VersionPreview } from '@/components/version/VersionPreview'
 
@@ -16,6 +18,23 @@ import { VersionPreview } from '@/components/version/VersionPreview'
 export function KnowledgeVersionHistory({ path }: { path: string }) {
   const { t } = useTranslation()
   const teamId = useCurrentTeamStore((s) => s.team?.id)
+  const workspacePath = useWorkspaceStore((s) => s.workspacePath)
+
+  // The daemon addresses versions by sync key (`knowledge/<rel>`), never by an
+  // absolute path — the tab carries the absolute one because that is what
+  // identifies the document on this machine.
+  const [knowledgeDir, setKnowledgeDir] = React.useState<string | null>(null)
+  React.useEffect(() => {
+    let cancelled = false
+    globalTeamKnowledgeShareDir()
+      .then((dir) => { if (!cancelled) setKnowledgeDir(dir) })
+      .catch(() => { if (!cancelled) setKnowledgeDir(null) })
+    return () => { cancelled = true }
+  }, [])
+  const syncKey = React.useMemo(
+    () => teamSyncKeyForPath(path, { knowledgeDir, workspacePath }),
+    [path, knowledgeDir, workspacePath],
+  )
 
   const fileVersions = useVersionHistoryStore((s) => s.fileVersions)
   const selectedRef = useVersionHistoryStore((s) => s.selectedRef)
@@ -33,13 +52,13 @@ export function KnowledgeVersionHistory({ path }: { path: string }) {
 
   React.useEffect(() => {
     selectFile(path)
-    if (teamId) void loadFileVersions(teamId, path)
-  }, [path, teamId, selectFile, loadFileVersions])
+    if (teamId && syncKey) void loadFileVersions(teamId, syncKey)
+  }, [path, syncKey, teamId, selectFile, loadFileVersions])
 
   React.useEffect(() => {
     let cancelled = false
-    if (teamId && selectedRef) {
-      void fetchVersionContent(teamId, path, selectedRef).then((content) => {
+    if (teamId && syncKey && selectedRef) {
+      void fetchVersionContent(teamId, syncKey, selectedRef).then((content) => {
         if (!cancelled) setVersionContent(content)
       })
     } else {
@@ -48,17 +67,17 @@ export function KnowledgeVersionHistory({ path }: { path: string }) {
     return () => {
       cancelled = true
     }
-  }, [teamId, path, selectedRef, fetchVersionContent])
+  }, [teamId, syncKey, selectedRef, fetchVersionContent])
 
   const handleRestore = React.useCallback(async () => {
-    if (!teamId || !selectedRef) return
+    if (!teamId || !syncKey || !selectedRef) return
     setRestoring(true)
     try {
-      await restoreFileVersion(teamId, path, selectedRef)
+      await restoreFileVersion(teamId, syncKey, selectedRef)
     } finally {
       setRestoring(false)
     }
-  }, [teamId, path, selectedRef, restoreFileVersion])
+  }, [teamId, syncKey, selectedRef, restoreFileVersion])
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/packages/app/src/components/teamshare/TeamDirInitPanel.tsx
+++ b/packages/app/src/components/teamshare/TeamDirInitPanel.tsx
@@ -9,15 +9,16 @@ import { linkDaemonTeamWorkspace } from '@/lib/daemon-local-client'
 import { isTauri } from '@/lib/utils'
 
 /**
- * Shown in the Knowledge column when the team directory is missing on THIS
- * machine — `<workspace>/teamclu-team` does not resolve, so there is no root to
- * render a file tree from.
+ * Shown in the Knowledge column when the team's knowledge directory is missing
+ * on THIS machine — `~/.amuxd[-<brand>]/teams/<id>/shared/knowledge` is not
+ * there, so there is no root to render a file tree from. (It no longer means
+ * "this workspace has no symlink": the column reads that directory by absolute
+ * path and does not go through the workspace link at all.)
  *
  * This is a local-state problem, not an account one: sync is on for the team
- * either way. The daemon owns the directory (one global copy under
- * `~/.amuxd/teams/<id>/shared/`, exposed per workspace as a symlink), and
- * `POST /v1/team/link` is idempotent — it materializes whichever half is
- * missing. So the fix is one button, and pressing it twice is harmless.
+ * either way. The daemon owns the directory, and `POST /v1/team/link` is
+ * idempotent — it materializes whichever half is missing. So the fix is one
+ * button, and pressing it twice is harmless.
  *
  * `strict: true` because the whole point here is to report failure: the
  * best-effort default would swallow "daemon not running", which is the most
@@ -27,7 +28,6 @@ export function TeamDirInitPanel() {
   const { t } = useTranslation()
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
   const loadSection = useTeamShareBrowserStore((s) => s.loadSection)
-  const refreshFileTree = useWorkspaceStore((s) => s.refreshFileTree)
 
   const [busy, setBusy] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
@@ -40,10 +40,9 @@ export function TeamDirInitPanel() {
     setError(null)
     try {
       await linkDaemonTeamWorkspace(workspacePath, { strict: true })
-      // The symlink is new, so the cached workspace tree does not contain it
-      // yet — refresh before re-resolving the root, or `knowledgeRoot` stays
-      // null and the column bounces straight back to this panel.
-      await refreshFileTree()
+      // Re-resolving the root is enough. It reads the daemon's directory
+      // directly, so there is no cached workspace tree standing between the
+      // repair and the column noticing it.
       await loadSection('knowledge', { force: true })
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))

--- a/packages/app/src/components/teamshare/__tests__/TeamDirInitPanel.test.tsx
+++ b/packages/app/src/components/teamshare/__tests__/TeamDirInitPanel.test.tsx
@@ -41,7 +41,7 @@ describe('TeamDirInitPanel', () => {
     linkDaemonTeamWorkspace.mockResolvedValue({ ok: true })
   })
 
-  it('rebuilds the link, then refreshes the tree before re-resolving the root', async () => {
+  it('rebuilds the team folder, then re-resolves the root without the workspace tree', async () => {
     render(<TeamDirInitPanel />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Rebuild team folder' }))
@@ -50,8 +50,9 @@ describe('TeamDirInitPanel', () => {
     // strict: a silent failure here would loop the user back to this panel with
     // no explanation, which is the bug the strict flag exists to prevent.
     expect(linkDaemonTeamWorkspace).toHaveBeenCalledWith('/workspace', { strict: true })
-    // Ordering matters: the symlink is new, so a stale tree resolves no root.
-    expect(workspaceState.refreshFileTree).toHaveBeenCalled()
+    // The column resolves its root from the daemon's directory, not from the
+    // workspace file tree — refreshing that tree would be work for nobody.
+    expect(workspaceState.refreshFileTree).not.toHaveBeenCalled()
     expect(loadSection).toHaveBeenCalledWith('knowledge', { force: true })
   })
 

--- a/packages/app/src/components/workspace/FileBrowser.tsx
+++ b/packages/app/src/components/workspace/FileBrowser.tsx
@@ -64,6 +64,7 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
   const fileTree = useWorkspaceStore(s => s.fileTree)
   const externalTrees = useWorkspaceStore(s => s.externalTrees)
   const openExternalRoot = useWorkspaceStore(s => s.openExternalRoot)
+  const refreshExternalRoot = useWorkspaceStore(s => s.refreshExternalRoot)
   const refreshFileTree = useWorkspaceStore(s => s.refreshFileTree)
   const collapseAll = useWorkspaceStore(s => s.collapseAll)
   const undo = useWorkspaceStore(s => s.undo)
@@ -164,6 +165,15 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
     }
   }, [rootPaths, rootPath, fileTree, isExternalRoot, externalTrees, openExternalRoot])
 
+  // Re-list an already-registered external root on mount. The store owns both
+  // the tree and its watch, so both outlive this component — anything that
+  // landed while the column was closed is not in the rendered tree yet.
+  React.useEffect(() => {
+    if (!isExternalRoot || !rootPath) return
+    if (useWorkspaceStore.getState().externalTrees[rootPath] === undefined) return
+    void useWorkspaceStore.getState().refreshExternalRoot(rootPath)
+  }, [isExternalRoot, rootPath])
+
   // Auto-refresh file tree when panel opens (default variant) or when mounted (panel variant)
   React.useEffect(() => {
     // An external root does not read from the workspace tree, so refreshing it
@@ -181,7 +191,24 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
   }, [variant, isPanelOpen, workspacePath, fileTree.length, refreshFileTree, isExternalRoot])
 
   // Listen for file-change events from Tauri file watcher
-  useFileChangeListener(() => refreshFileTree(), 300, !!workspacePath)
+  useFileChangeListener(() => refreshFileTree(), 300, !!workspacePath && !isExternalRoot)
+
+  // An external root is watched in its own right (see `openExternalRoot`) and is
+  // not part of the workspace tree, so it re-lists itself — and only for events
+  // that landed inside it, which is also what keeps the debounce from being
+  // starved by unrelated workspace writes.
+  useFileChangeListener(
+    () => {
+      if (rootPath) void refreshExternalRoot(rootPath)
+    },
+    300,
+    isExternalRoot,
+    (event) => {
+      if (!rootPath) return false
+      const changed = event.payload.path
+      return changed === rootPath || changed.startsWith(`${rootPath}/`)
+    },
+  )
 
   // Ctrl/Cmd+Z undo handler
   React.useEffect(() => {

--- a/packages/app/src/components/workspace/FileBrowser.tsx
+++ b/packages/app/src/components/workspace/FileBrowser.tsx
@@ -62,6 +62,8 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
   const workspacePath = useWorkspaceStore(s => s.workspacePath)
   const isPanelOpen = useWorkspaceStore(s => s.isPanelOpen)
   const fileTree = useWorkspaceStore(s => s.fileTree)
+  const externalTrees = useWorkspaceStore(s => s.externalTrees)
+  const openExternalRoot = useWorkspaceStore(s => s.openExternalRoot)
   const refreshFileTree = useWorkspaceStore(s => s.refreshFileTree)
   const collapseAll = useWorkspaceStore(s => s.collapseAll)
   const undo = useWorkspaceStore(s => s.undo)
@@ -78,6 +80,16 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
   // Multi-root trees have no single directory to fall back to, so only the
   // single-root form tells FileTree where untargeted drops and pastes belong.
   const singleRootPath = rootPaths && rootPaths.length > 0 ? undefined : rootPath
+  // A root outside the workspace — the team Knowledge tree, which browses the
+  // daemon's real `~/.amuxd/teams/<id>/shared/knowledge` directory rather than
+  // the workspace `team-knowledge` symlink. It carries its own tree in the
+  // store, so none of the workspace-tree lookups below apply to it.
+  const isExternalRoot =
+    !!singleRootPath &&
+    !(
+      workspacePath &&
+      (singleRootPath === workspacePath || singleRootPath.startsWith(`${workspacePath}/`))
+    )
 
   // OSS team-share "sync now" — only surfaced when this workspace actually has
   // OSS sync state (oss_sync_status reports a teamId). Non-team / git-mode
@@ -110,8 +122,9 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
       })
     }
     if (!rootPath) return undefined
+    if (isExternalRoot) return externalTrees[rootPath] ?? []
     return findSubtree(fileTree, rootPath) ?? []
-  }, [rootPaths, rootLabels, rootPath, fileTree])
+  }, [rootPaths, rootLabels, rootPath, fileTree, isExternalRoot, externalTrees])
 
   // Ensure custom rootPath(s) are present in the global tree before we try to
   // render them as virtual roots. In practice the initial attempt can race the
@@ -142,22 +155,30 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
           expandWithAncestors(p)
         }
       }
+    } else if (rootPath && isExternalRoot) {
+      // Never in `fileTree` by design: it is registered as its own root, and
+      // `undefined` (not an empty array) is what "not registered yet" means.
+      if (externalTrees[rootPath] === undefined) void openExternalRoot(rootPath)
     } else if (rootPath && needsLoad(rootPath)) {
       expandWithAncestors(rootPath)
     }
-  }, [rootPaths, rootPath, fileTree])
+  }, [rootPaths, rootPath, fileTree, isExternalRoot, externalTrees, openExternalRoot])
 
   // Auto-refresh file tree when panel opens (default variant) or when mounted (panel variant)
   React.useEffect(() => {
-    const shouldRefresh = variant === 'panel'
-      ? workspacePath && fileTree.length === 0
-      : isPanelOpen && workspacePath && fileTree.length === 0
+    // An external root does not read from the workspace tree, so refreshing it
+    // would be pure IPC for a tree nothing here renders.
+    const shouldRefresh = isExternalRoot
+      ? false
+      : variant === 'panel'
+        ? workspacePath && fileTree.length === 0
+        : isPanelOpen && workspacePath && fileTree.length === 0
 
     if (shouldRefresh) {
       console.log('[FileBrowser] Auto-refreshing file tree for:', workspacePath)
       refreshFileTree()
     }
-  }, [variant, isPanelOpen, workspacePath, fileTree.length, refreshFileTree])
+  }, [variant, isPanelOpen, workspacePath, fileTree.length, refreshFileTree, isExternalRoot])
 
   // Listen for file-change events from Tauri file watcher
   useFileChangeListener(() => refreshFileTree(), 300, !!workspacePath)

--- a/packages/app/src/hooks/use-team-cloud-sync.ts
+++ b/packages/app/src/hooks/use-team-cloud-sync.ts
@@ -24,10 +24,14 @@ export function useTeamCloudSync() {
   const syncing = useOssSyncStore((s) => s.syncing)
   const ossSyncNow = useOssSyncStore((s) => s.syncNow)
 
-  const available = isTauri() && !!workspacePath && shareMode === 'oss'
+  // No workspace requirement: the daemon syncs the team's own tree under its
+  // amuxd home, so "no folder open" is not a reason to hide the button. A
+  // workspace, when there is one, is passed along only so the daemon can repair
+  // its team links on the way through.
+  const available = isTauri() && shareMode === 'oss'
 
   const syncNow = React.useCallback(async () => {
-    if (!available || syncing || !workspacePath) return
+    if (!available || syncing) return
     await ossSyncNow(workspacePath)
     const err = useOssSyncStore.getState().lastError
     if (err) {

--- a/packages/app/src/hooks/useAppInit.ts
+++ b/packages/app/src/hooks/useAppInit.ts
@@ -30,7 +30,7 @@ import { useWorkspaceRuntimeRefreshStore } from "@/stores/workspace-runtime-refr
 import { useTeamShareStore } from "@/stores/team-share";
 import { useOssSyncStore } from "@/stores/oss-sync";
 import { getSkillDirectories, loadAllSkills } from "@/lib/skills/loader";
-import { DEFAULT_WORKSPACE_PATH, TEAM_REPO_DIR } from "@/lib/build-config";
+import { DEFAULT_WORKSPACE_PATH } from "@/lib/build-config";
 import { WORKSPACE_STORAGE_KEY } from "@/stores/workspace";
 import { markStartup } from "@/lib/startup-perf";
 
@@ -467,51 +467,19 @@ export function useGitReposInit() {
 
   }, [workspacePath, workspaceReady]);
 
-  // Real-time: refresh team-git file status and member roles when team files change
-  useEffect(() => {
-    if (!workspacePath || !isTauri()) return;
-    let unlistenFileChange: (() => void) | undefined;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    let cancelled = false;
-
-    const normalizePath = (value: string) => value.replace(/\\/g, "/").replace(/\/$/, "");
-    const teamDirPrefix = `${workspacePath}/${TEAM_REPO_DIR}/`;
-
-    import("@tauri-apps/api/event").then(({ listen }) => {
-      if (cancelled) return;
-      listen<{ path: string; kind: string }>("file-change", (event) => {
-        const path = normalizePath(event.payload.path);
-
-        if (!path.startsWith(teamDirPrefix)) return;
-        if (timer) clearTimeout(timer);
-        timer = setTimeout(async () => {
-          if (useTeamShareStore.getState().status.mode === "oss") {
-            // Re-scan per-file sync status for tree coloring.
-            void useOssSyncStore.getState().refresh(workspacePath);
-          }
-        }, 500);
-      }).then((fn) => {
-        if (cancelled) {
-          fn();
-          return;
-        }
-        unlistenFileChange = fn;
-      });
-    });
-
-    return () => {
-      cancelled = true;
-      if (timer) clearTimeout(timer);
-      unlistenFileChange?.();
-    };
-  }, [workspacePath]);
-
-  // Initial population of per-file team sync status for file-tree coloring,
-  // re-run whenever the cloud share mode changes, so the teamclu-team files
-  // are colored on first paint too.
+  // Team sync status, read once share mode is known.
+  //
+  // Not gated on a workspace: the status the daemon reports is per team.
+  //
+  // What used to be here as well — a `file-change` listener under
+  // `<workspace>/teamclu-team/` that re-read this status on every team file
+  // write — is gone. It existed to repaint per-file sync badges, which the
+  // daemon stopped exposing (`fileSyncStatusMap` has been `{}` since), and it
+  // watched a tree sync retired: team content lives in the team's own
+  // `shared/knowledge` now, which that path never pointed at.
   const shareMode = useTeamShareStore((s) => s.status.mode);
   useEffect(() => {
-    if (!workspacePath || !isTauri()) return;
+    if (!isTauri()) return;
     if (shareMode === "oss") {
       void useOssSyncStore.getState().refresh(workspacePath);
     }

--- a/packages/app/src/hooks/useFileChangeListener.ts
+++ b/packages/app/src/hooks/useFileChangeListener.ts
@@ -12,14 +12,23 @@ type FileChangeEvent = {
  * @param handler  Called with the file-change event after debounce
  * @param delay    Debounce delay in ms (default 500)
  * @param enabled  Whether to listen (default true) — pass false to conditionally disable
+ * @param filter   Applied BEFORE the debounce; events it rejects are ignored
+ *                 entirely. It has to run first: the watcher broadcasts every
+ *                 window's events to every listener, and the debounce keeps
+ *                 only the last one — so a listener that filtered inside its
+ *                 handler would lose its own event whenever an unrelated one
+ *                 landed in the same window.
  */
 export function useFileChangeListener(
   handler: (event: FileChangeEvent) => void,
   delay: number = 500,
   enabled: boolean = true,
+  filter?: (event: FileChangeEvent) => boolean,
 ): void {
   const handlerRef = useRef(handler)
   handlerRef.current = handler
+  const filterRef = useRef(filter)
+  filterRef.current = filter
 
   useEffect(() => {
     if (!enabled || !isTauri()) return
@@ -29,6 +38,7 @@ export function useFileChangeListener(
 
     import('@tauri-apps/api/event').then(({ listen }) => {
       listen<{ path: string; kind: string }>('file-change', (event) => {
+        if (filterRef.current && !filterRef.current(event)) return
         clearTimeout(timer)
         timer = setTimeout(() => handlerRef.current(event), delay)
       }).then((fn) => {

--- a/packages/app/src/lib/__tests__/team-skill-paths.test.ts
+++ b/packages/app/src/lib/__tests__/team-skill-paths.test.ts
@@ -22,7 +22,13 @@ vi.mock('@/lib/build-config', async (importOriginal) => {
   }
 })
 
-import { amuxdHomePath, resolveTeamDir, TEAM_SHARE_LINK_DIR } from '../team-skill-paths'
+import {
+  amuxdHomePath,
+  globalTeamKnowledgeShareDir,
+  resolveTeamDir,
+  teamSyncKeyForPath,
+  TEAM_SHARE_LINK_DIR,
+} from '../team-skill-paths'
 
 describe('team-skill-paths (white-label amuxd home)', () => {
   beforeEach(() => {
@@ -75,5 +81,60 @@ describe('team-skill-paths (white-label amuxd home)', () => {
     })
 
     await expect(resolveTeamDir('/tmp/ws')).resolves.toBeNull()
+  })
+})
+
+/**
+ * The key the OSS sync engine addresses a file by — its path relative to the
+ * team's sync content root. Everything version-related (history, baseline diff,
+ * restore) is keyed by this, and it is derived from the absolute
+ * `~/.amuxd[-<brand>]/teams/<id>/shared/knowledge` path, never from a workspace.
+ */
+describe('teamSyncKeyForPath', () => {
+  const KNOWLEDGE = '/home/user/.amuxd-copilot361/teams/team-abc/shared/knowledge'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockHomeDir.mockResolvedValue('/home/user')
+    mockExists.mockResolvedValue(false)
+    mockReadTextFile.mockResolvedValue('')
+  })
+
+  it('maps a file under the real knowledge dir to its sync key', () => {
+    expect(teamSyncKeyForPath(`${KNOWLEDGE}/guides/setup.md`, { knowledgeDir: KNOWLEDGE })).toBe(
+      'knowledge/guides/setup.md',
+    )
+  })
+
+  /**
+   * The workspace panel still renders the daemon's `team-knowledge` symlink, so
+   * the same document reaches the editor under two spellings. Both must produce
+   * the same key, or a note's history would depend on which surface opened it.
+   */
+  it('maps the workspace team-knowledge symlink to the same key', () => {
+    expect(
+      teamSyncKeyForPath('/ws/team-knowledge/guides/setup.md', {
+        knowledgeDir: KNOWLEDGE,
+        workspacePath: '/ws',
+      }),
+    ).toBe('knowledge/guides/setup.md')
+  })
+
+  it('returns null for a file outside any knowledge tree', () => {
+    expect(
+      teamSyncKeyForPath('/ws/src/main.ts', { knowledgeDir: KNOWLEDGE, workspacePath: '/ws' }),
+    ).toBeNull()
+    // The root itself is a directory, not a synced file.
+    expect(teamSyncKeyForPath(KNOWLEDGE, { knowledgeDir: KNOWLEDGE })).toBeNull()
+  })
+
+  it('falls back to the last resolved knowledge dir when none is passed', async () => {
+    mockExists.mockImplementation((path: string) =>
+      Promise.resolve(path === '/home/user/.amuxd-copilot361/daemon.toml'),
+    )
+    mockReadTextFile.mockResolvedValue('active_team = "team-abc"\n')
+
+    await expect(globalTeamKnowledgeShareDir()).resolves.toBe(KNOWLEDGE)
+    expect(teamSyncKeyForPath(`${KNOWLEDGE}/top.md`)).toBe('knowledge/top.md')
   })
 })

--- a/packages/app/src/lib/history/oss-provider.ts
+++ b/packages/app/src/lib/history/oss-provider.ts
@@ -10,7 +10,8 @@ export class OssHistoryProvider implements HistoryProvider {
   private readonly versionToHash = new Map<number, string>()
 
   constructor(
-    private readonly workspacePath: string,
+    /** Optional; the daemon keys versions by team + sync key, not by workspace. */
+    private readonly workspacePath: string | null,
     private readonly path: string,
   ) {}
 

--- a/packages/app/src/lib/team-skill-paths.ts
+++ b/packages/app/src/lib/team-skill-paths.ts
@@ -88,11 +88,76 @@ async function globalTeamKnowledgeDir(teamId: string): Promise<string> {
   return `${await amuxdRoot()}/teams/${teamId}/shared/knowledge`
 }
 
+/**
+ * Workspace symlink name surfacing the team's synced knowledge dir. Must match
+ * `TEAM_KNOWLEDGE_LINK_NAME` in `apps/daemon/src/config/workspace_link.rs`.
+ *
+ * Nothing reads team knowledge *through* this link any more — it exists for
+ * agents and for the workspace file panel, which renders the workspace as it is
+ * on disk. It is listed here only so a file opened from that panel can still be
+ * recognised as team-synced content.
+ */
+export const TEAM_KNOWLEDGE_LINK_DIR = 'team-knowledge'
+
+/**
+ * Last resolved global knowledge dir. Cached because mapping a path to its sync
+ * key happens inside renders, where awaiting the daemon config is not an option.
+ */
+let lastKnownKnowledgeDir: string | null = null
+
 /** Active team global knowledge dir (~/.amuxd[-<brand>]/teams/<id>/shared/knowledge). */
 export async function globalTeamKnowledgeShareDir(): Promise<string | null> {
   const teamId = await readOnboardedTeamId()
   if (!teamId) return null
-  return globalTeamKnowledgeDir(teamId)
+  const dir = await globalTeamKnowledgeDir(teamId)
+  lastKnownKnowledgeDir = dir
+  return dir
+}
+
+function isUnder(root: string | null | undefined, path: string): boolean {
+  if (!root) return false
+  const normalized = trimTrailingPathSeparators(root)
+  return path === normalized || path.startsWith(`${normalized}/`)
+}
+
+/**
+ * The knowledge tree root that contains `absPath`, or null when it holds no
+ * team knowledge.
+ *
+ * Two spellings reach the same bytes: the real directory under the amuxd home —
+ * what the Knowledge column browses and what the sync engine owns — and
+ * `<workspace>/team-knowledge`, the daemon-managed symlink the workspace file
+ * panel renders. Both have to be recognised, or a document opened from one
+ * surface loses the history the same document has when opened from the other.
+ */
+export function teamKnowledgeRootForPath(
+  absPath: string,
+  opts: { knowledgeDir?: string | null; workspacePath?: string | null } = {},
+): string | null {
+  const knowledgeDir = opts.knowledgeDir ?? lastKnownKnowledgeDir
+  if (isUnder(knowledgeDir, absPath)) return trimTrailingPathSeparators(knowledgeDir as string)
+  const linkDir = opts.workspacePath
+    ? `${trimTrailingPathSeparators(opts.workspacePath)}/${TEAM_KNOWLEDGE_LINK_DIR}`
+    : null
+  if (isUnder(linkDir, absPath)) return linkDir
+  return null
+}
+
+/**
+ * The key the team sync engine addresses a file by: its path relative to the
+ * sync content root (`~/.amuxd[-<brand>]/teams/<id>/shared`), e.g.
+ * `knowledge/onboarding.md`. Null when the file is not team-synced content.
+ *
+ * Version history, baseline diffs and conflict resolution all take this key —
+ * never an absolute path, and never a workspace-relative one.
+ */
+export function teamSyncKeyForPath(
+  absPath: string,
+  opts: { knowledgeDir?: string | null; workspacePath?: string | null } = {},
+): string | null {
+  const root = teamKnowledgeRootForPath(absPath, opts)
+  if (!root || absPath === root) return null
+  return `knowledge/${absPath.slice(root.length + 1)}`
 }
 
 /** Where to read this workspace team knowledge: the global shared/knowledge dir. */

--- a/packages/app/src/lib/wiki-link-resolver.ts
+++ b/packages/app/src/lib/wiki-link-resolver.ts
@@ -1,17 +1,21 @@
 import { exists, readDir, mkdir, writeTextFile } from "@tauri-apps/plugin-fs";
 import { buildFileMap, resolveWikiLink, type WikiFileMap } from "@/lib/wiki-link-index";
 
-// Standalone wiki-link resolution against a workspace subdirectory (the
-// team-shared knowledge dir surfaced as `team-knowledge`). The previous
-// implementation lived on the RAG knowledge store, which built and cached a
-// file map from `knowledge/`. With the RAG module removed, wiki links resolve
-// against the symlinked team knowledge dir instead — cached here, because the
-// store that used to own that cache is gone and every click would otherwise
-// re-walk the whole tree, one IPC round-trip per directory.
+// Standalone wiki-link resolution against a knowledge tree, addressed by its
+// ABSOLUTE root. Callers pass the root the open document lives under — normally
+// the daemon's real `~/.amuxd[-<brand>]/teams/<id>/shared/knowledge`, the same
+// directory the OSS sync engine owns. (A document opened from the workspace
+// file panel arrives under the `team-knowledge` symlink instead; that path is a
+// valid root too, and links resolve within whichever one the document came from
+// so a click never re-opens the same file under a second path.)
+//
+// Maps are cached here because the store that used to own that cache is gone
+// and every click would otherwise re-walk the whole tree, one IPC round-trip
+// per directory.
 
 /**
- * Depth cap for the walk. `team-knowledge` is a symlink and nothing stops a
- * note tree from holding another one, so bound the recursion rather than hang.
+ * Depth cap for the walk. A knowledge tree can hold symlinks of its own, so
+ * bound the recursion rather than hang.
  */
 const MAX_DEPTH = 12;
 
@@ -25,12 +29,12 @@ const CACHE_TTL_MS = 5_000;
 const cache = new Map<string, { at: number; map: WikiFileMap }>();
 
 /** Drop a cached map (or all of them) after something writes into the tree. */
-export function invalidateWikiFileMap(workspacePath?: string, subdir?: string): void {
-  if (workspacePath === undefined || subdir === undefined) {
+export function invalidateWikiFileMap(rootDir?: string): void {
+  if (rootDir === undefined) {
     cache.clear();
     return;
   }
-  cache.delete(`${workspacePath}/${subdir}`);
+  cache.delete(rootDir);
 }
 
 async function readDirRecursive(rootPath: string): Promise<string[]> {
@@ -51,40 +55,38 @@ async function readDirRecursive(rootPath: string): Promise<string[]> {
   return results;
 }
 
-export async function buildWikiFileMap(
-  workspacePath: string,
-  subdir: string,
-): Promise<WikiFileMap> {
-  const dir = `${workspacePath}/${subdir}`;
-  const hit = cache.get(dir);
+/** Map of page name → path relative to `rootDir`. */
+export async function buildWikiFileMap(rootDir: string): Promise<WikiFileMap> {
+  const hit = cache.get(rootDir);
   if (hit && Date.now() - hit.at < CACHE_TTL_MS) {
     return hit.map;
   }
   try {
-    const relFiles = await readDirRecursive(dir);
-    const map = buildFileMap(relFiles.map((f) => `${subdir}/${f}`));
-    cache.set(dir, { at: Date.now(), map });
+    const relFiles = await readDirRecursive(rootDir);
+    const map = buildFileMap(relFiles);
+    cache.set(rootDir, { at: Date.now(), map });
     return map;
   } catch {
-    // Either the dir is missing (no team link yet) or the walk failed midway.
-    // Deliberately not cached: an empty map parked for the whole TTL would keep
-    // every link "unresolved", and callers treat that as "create a new note".
+    // Either the dir is missing (no team onboarded yet) or the walk failed
+    // midway. Deliberately not cached: an empty map parked for the whole TTL
+    // would keep every link "unresolved", and callers treat that as "create a
+    // new note".
     return new Map();
   }
 }
 
+/** Absolute path of the note `target` names, or null when it does not exist. */
 export async function resolveWikiLinkPath(
-  workspacePath: string,
-  subdir: string,
+  rootDir: string,
   target: string,
 ): Promise<string | null> {
-  const map = await buildWikiFileMap(workspacePath, subdir);
-  return resolveWikiLink(map, target);
+  const map = await buildWikiFileMap(rootDir);
+  const rel = resolveWikiLink(map, target);
+  return rel === null ? null : `${rootDir}/${rel}`;
 }
 
 export async function createNoteFromLink(
-  workspacePath: string,
-  subdir: string,
+  rootDir: string,
   pageName: string,
 ): Promise<string> {
   const clean = pageName.trim();
@@ -94,16 +96,15 @@ export async function createNoteFromLink(
   if (clean.includes("..") || clean.startsWith("/") || clean.includes("\\")) {
     throw new Error(`Invalid page name: ${pageName}`);
   }
-  const targetDir = `${workspacePath}/${subdir}`;
-  // `team-knowledge` is a daemon-managed symlink into the team's synced
-  // `shared/knowledge`. Materializing it here as a real directory would shadow
-  // that link permanently — `ensure_link_to` sees `is_dir()` and returns
-  // Fallback on every later call — so notes written into it would never sync
-  // and the team's actual knowledge would never appear. Wait for the daemon.
-  if (!(await exists(targetDir))) {
-    throw new Error(`Team knowledge directory is not available yet: ${targetDir}`);
+  // Never materialize the root itself. When it is the `team-knowledge` symlink,
+  // creating it as a real directory would shadow the link for good
+  // (`ensure_link_to` sees `is_dir()` and returns Fallback on every later call),
+  // so notes written into it would never sync. When it is the real knowledge
+  // dir, its absence means no team is onboarded yet. Either way: wait.
+  if (!(await exists(rootDir))) {
+    throw new Error(`Team knowledge directory is not available yet: ${rootDir}`);
   }
-  const filePath = `${targetDir}/${clean}.md`;
+  const filePath = `${rootDir}/${clean}.md`;
   // Never clobber an existing note. Resolution returns an empty map on a
   // transient walk failure, which reads as "unresolved" and lands here — that
   // must not overwrite a real note with an empty frontmatter stub.
@@ -112,14 +113,14 @@ export async function createNoteFromLink(
   }
   const lastSlash = filePath.lastIndexOf("/");
   const parentDir = filePath.slice(0, lastSlash);
-  // Safe now that `targetDir` is known to exist: this can only create
-  // subdirectories *inside* the knowledge tree, never the link itself.
-  if (parentDir !== targetDir) {
+  // Safe now that `rootDir` is known to exist: this can only create
+  // subdirectories *inside* the knowledge tree, never the root itself.
+  if (parentDir !== rootDir) {
     await mkdir(parentDir, { recursive: true });
   }
   const now = new Date().toISOString();
   const content = `---\ntitle: ${clean}\ncreated: ${now}\nupdated: ${now}\n---\n\n`;
   await writeTextFile(filePath, content);
-  invalidateWikiFileMap(workspacePath, subdir);
+  invalidateWikiFileMap(rootDir);
   return filePath;
 }

--- a/packages/app/src/stores/__tests__/workspace-external-root.test.ts
+++ b/packages/app/src/stores/__tests__/workspace-external-root.test.ts
@@ -109,6 +109,69 @@ describe("workspace external roots", () => {
   });
 
   /**
+   * The daemon writes a teammate's synced note straight into its own directory.
+   * A recursive watch on the workspace never saw those writes — `notify` does
+   * not follow the `team-knowledge` symlink — so the real directory has to be
+   * watched in its own right.
+   */
+  it("watches the external root, and does not re-subscribe when it is re-listed", async () => {
+    await useWorkspaceStore.getState().openExternalRoot(KNOWLEDGE);
+    expect(mockInvoke).toHaveBeenCalledWith("watch_directory", { path: KNOWLEDGE });
+
+    mockInvoke.mockClear();
+    await useWorkspaceStore.getState().openExternalRoot(KNOWLEDGE);
+    expect(mockInvoke).not.toHaveBeenCalledWith("watch_directory", { path: KNOWLEDGE });
+  });
+
+  it("re-lists on refresh and drops expansions that vanished from disk", async () => {
+    await useWorkspaceStore.getState().openExternalRoot(KNOWLEDGE);
+    await useWorkspaceStore.getState().expandDirectory(`${KNOWLEDGE}/guides`);
+    useWorkspaceStore.setState({
+      workspacePath: "/workspace",
+      expandedPaths: new Set([...useWorkspaceStore.getState().expandedPaths, "/workspace/src"]),
+    });
+
+    // A teammate deleted `guides/` on their machine and sync applied it here.
+    mockInvoke.mockImplementation(async (cmd: string, args: any) => {
+      if (cmd === "read_workspace_directory") {
+        return args.path === KNOWLEDGE ? [file(KNOWLEDGE, "top.md")] : [];
+      }
+      return null;
+    });
+    await useWorkspaceStore.getState().refreshExternalRoot(KNOWLEDGE);
+
+    expect(useWorkspaceStore.getState().externalTrees[KNOWLEDGE].map((n) => n.name)).toEqual([
+      "top.md",
+    ]);
+    const expanded = useWorkspaceStore.getState().expandedPaths;
+    expect(expanded.has(`${KNOWLEDGE}/guides`)).toBe(false);
+    expect(expanded.has(KNOWLEDGE)).toBe(true);
+    // The workspace's own expansions are none of this refresh's business.
+    expect(expanded.has("/workspace/src")).toBe(true);
+  });
+
+  /**
+   * Switching teams repoints knowledge at another directory. The old one must
+   * stop being rendered and stop reporting, or the previous team's writes keep
+   * waking the column.
+   */
+  it("forgets the tree, its expansions and the watch when the root is closed", async () => {
+    await useWorkspaceStore.getState().openExternalRoot(KNOWLEDGE);
+    await useWorkspaceStore.getState().expandDirectory(`${KNOWLEDGE}/guides`);
+    useWorkspaceStore.setState({
+      expandedPaths: new Set([...useWorkspaceStore.getState().expandedPaths, "/workspace/src"]),
+    });
+
+    await useWorkspaceStore.getState().closeExternalRoot(KNOWLEDGE);
+
+    expect(mockInvoke).toHaveBeenCalledWith("unwatch_directory", { path: KNOWLEDGE });
+    expect(useWorkspaceStore.getState().externalTrees[KNOWLEDGE]).toBeUndefined();
+    const expanded = [...useWorkspaceStore.getState().expandedPaths];
+    expect(expanded.some((p) => p.startsWith(KNOWLEDGE))).toBe(false);
+    expect(expanded).toContain("/workspace/src");
+  });
+
+  /**
    * `refreshFileTree` rebuilds the WORKSPACE tree; the external root is not in
    * its listing at all. Dropping its expansions there would collapse the
    * Knowledge tree every time a workspace file changed.

--- a/packages/app/src/stores/__tests__/workspace-external-root.test.ts
+++ b/packages/app/src/stores/__tests__/workspace-external-root.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockInvoke = vi.fn();
+
+vi.mock("@/lib/utils", () => ({
+  isTauri: () => true,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+import { useWorkspaceStore } from "../workspace";
+
+/**
+ * The team's real knowledge directory, as the daemon and the OSS sync engine
+ * address it. The Knowledge column browses THIS path — never the per-workspace
+ * `team-knowledge` symlink — so it is outside any workspace by construction.
+ */
+const KNOWLEDGE = "/Users/x/.amuxd/teams/team-1/shared/knowledge";
+
+const dir = (parent: string, name: string) => ({
+  name,
+  path: `${parent}/${name}`,
+  type: "directory" as const,
+});
+const file = (parent: string, name: string) => ({
+  name,
+  path: `${parent}/${name}`,
+  type: "file" as const,
+});
+
+const findNode = (nodes: Array<{ path: string; children?: unknown }>, target: string): any => {
+  for (const node of nodes as any[]) {
+    if (node.path === target) return node;
+    if (node.children) {
+      const hit = findNode(node.children, target);
+      if (hit) return hit;
+    }
+  }
+  return null;
+};
+
+describe("workspace external roots", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorkspaceStore.setState({
+      workspacePath: null,
+      fileTree: [],
+      externalTrees: {},
+      expandedPaths: new Set<string>(),
+      loadingPaths: new Set<string>(),
+      selectedFile: null,
+      fileContent: null,
+    });
+    mockInvoke.mockImplementation(async (cmd: string, args: any) => {
+      if (cmd === "read_workspace_directory") {
+        if (args.path === KNOWLEDGE) return [dir(KNOWLEDGE, "guides"), file(KNOWLEDGE, "top.md")];
+        if (args.path === `${KNOWLEDGE}/guides`) return [file(`${KNOWLEDGE}/guides`, "setup.md")];
+        if (args.path === "/workspace") return [dir("/workspace", "src")];
+        return [];
+      }
+      if (cmd === "read_workspace_text_file") return "# hello";
+      return null;
+    });
+  });
+
+  /**
+   * Knowledge is per-team, not per-workspace. Reading it used to require a
+   * workspace to be open only because the tree was rendered through that
+   * workspace's symlink — with the real path there is nothing left to wait for.
+   */
+  it("lists an external root with no workspace open, reading against the root itself", async () => {
+    await useWorkspaceStore.getState().openExternalRoot(KNOWLEDGE);
+
+    expect(mockInvoke).toHaveBeenCalledWith("read_workspace_directory", {
+      workspacePath: KNOWLEDGE,
+      path: KNOWLEDGE,
+    });
+    expect(useWorkspaceStore.getState().externalTrees[KNOWLEDGE].map((n) => n.name)).toEqual([
+      "guides",
+      "top.md",
+    ]);
+    // And it stays out of the workspace tree, which is what the right-hand file
+    // panel renders — a foreign root parked there would show up as a stray
+    // top-level folder.
+    expect(useWorkspaceStore.getState().fileTree).toEqual([]);
+  });
+
+  it("expands a subdirectory inside the external tree", async () => {
+    await useWorkspaceStore.getState().openExternalRoot(KNOWLEDGE);
+    await useWorkspaceStore.getState().expandDirectory(`${KNOWLEDGE}/guides`);
+
+    const guides = findNode(useWorkspaceStore.getState().externalTrees[KNOWLEDGE], `${KNOWLEDGE}/guides`);
+    expect(guides.children.map((n: { name: string }) => n.name)).toEqual(["setup.md"]);
+  });
+
+  it("reads an external file against its own root", async () => {
+    await useWorkspaceStore.getState().openExternalRoot(KNOWLEDGE);
+    useWorkspaceStore.setState({ workspacePath: "/workspace" });
+
+    await useWorkspaceStore.getState().selectFile(`${KNOWLEDGE}/top.md`);
+
+    expect(mockInvoke).toHaveBeenCalledWith("read_workspace_text_file", {
+      workspacePath: KNOWLEDGE,
+      path: `${KNOWLEDGE}/top.md`,
+    });
+    expect(useWorkspaceStore.getState().fileContent).toBe("# hello");
+  });
+
+  /**
+   * `refreshFileTree` rebuilds the WORKSPACE tree; the external root is not in
+   * its listing at all. Dropping its expansions there would collapse the
+   * Knowledge tree every time a workspace file changed.
+   */
+  it("keeps external expansions across a workspace tree refresh", async () => {
+    await useWorkspaceStore.getState().openExternalRoot(KNOWLEDGE);
+    await useWorkspaceStore.getState().expandDirectory(`${KNOWLEDGE}/guides`);
+    useWorkspaceStore.setState({ workspacePath: "/workspace" });
+
+    await useWorkspaceStore.getState().refreshFileTree();
+
+    const expanded = useWorkspaceStore.getState().expandedPaths;
+    expect(expanded.has(KNOWLEDGE)).toBe(true);
+    expect(expanded.has(`${KNOWLEDGE}/guides`)).toBe(true);
+    expect(
+      findNode(useWorkspaceStore.getState().externalTrees[KNOWLEDGE], `${KNOWLEDGE}/guides`).children,
+    ).toHaveLength(1);
+  });
+});

--- a/packages/app/src/stores/oss-sync.ts
+++ b/packages/app/src/stores/oss-sync.ts
@@ -60,10 +60,17 @@ export interface OssSyncState {
   failed: number
   lastError: string | null
 
-  refresh(workspacePath: string): Promise<void>
-  syncNow(workspacePath: string): Promise<void>
+  /**
+   * Team sync is per TEAM, not per workspace: the daemon syncs
+   * `~/.amuxd[-<brand>]/teams/<id>/shared`, which exists whether or not a folder
+   * is open. `workspacePath` stays optional on these calls purely so the daemon
+   * can repair that workspace's team links on the way through, and so the
+   * desktop's team-secret self-heal has somewhere to read from.
+   */
+  refresh(workspacePath?: string | null): Promise<void>
+  syncNow(workspacePath?: string | null): Promise<void>
   listVersions(
-    workspacePath: string,
+    workspacePath: string | null,
     path: string,
     cursor?: string | null,
   ): Promise<VersionPage>
@@ -73,14 +80,14 @@ export interface OssSyncState {
    * message. Callers (history providers) already degrade to a "preview
    * unavailable" state on rejection rather than crashing.
    */
-  getVersionContent(workspacePath: string, contentHash: string): Promise<string>
+  getVersionContent(workspacePath: string | null, contentHash: string): Promise<string>
   restoreVersion(
-    workspacePath: string,
+    workspacePath: string | null,
     path: string,
     contentHash: string,
   ): Promise<void>
   resolveConflict(
-    workspacePath: string,
+    workspacePath: string | null,
     path: string,
     choice: 'keepRemote' | 'keepLocal',
   ): Promise<void>
@@ -124,7 +131,7 @@ export const useOssSyncStore = create<OssSyncState>((set, get) => ({
   failed: 0,
   lastError: null,
 
-  async refresh(workspacePath: string) {
+  async refresh(workspacePath?: string | null) {
     if (!isTauri()) return
     const teamId = activeTeamId()
     if (!teamId) {
@@ -134,7 +141,7 @@ export const useOssSyncStore = create<OssSyncState>((set, get) => ({
     }
     try {
       const status = await invoke<SyncStatusResult>('oss_sync_status', {
-        workspacePath,
+        workspacePath: workspacePath ?? null,
         teamId,
       })
       set({
@@ -153,17 +160,17 @@ export const useOssSyncStore = create<OssSyncState>((set, get) => ({
     }
   },
 
-  async syncNow(workspacePath: string) {
+  async syncNow(workspacePath?: string | null) {
     if (!isTauri()) return
     const teamId = activeTeamId()
     if (!teamId) {
-      set({ lastError: 'No active team to sync. Open a team workspace first.' })
+      set({ lastError: 'No active team to sync.' })
       return
     }
     set({ syncing: true, lastError: null })
     try {
       const result = await invoke<SyncNowResult>('oss_sync_now', {
-        workspacePath,
+        workspacePath: workspacePath ?? null,
         teamId,
       })
       set({
@@ -182,7 +189,7 @@ export const useOssSyncStore = create<OssSyncState>((set, get) => ({
   },
 
   async listVersions(
-    workspacePath: string,
+    workspacePath: string | null,
     path: string,
     cursor?: string | null,
   ): Promise<VersionPage> {
@@ -195,7 +202,7 @@ export const useOssSyncStore = create<OssSyncState>((set, get) => ({
   },
 
   async getVersionContent(
-    workspacePath: string,
+    workspacePath: string | null,
     contentHash: string,
   ): Promise<string> {
     // The daemon does not yet support version content fetch; the command
@@ -208,7 +215,7 @@ export const useOssSyncStore = create<OssSyncState>((set, get) => ({
     })
   },
 
-  async restoreVersion(workspacePath: string, path: string, contentHash: string) {
+  async restoreVersion(workspacePath: string | null, path: string, contentHash: string) {
     await invoke<void>('oss_sync_restore_version', {
       workspacePath,
       teamId: activeTeamId(),
@@ -218,7 +225,7 @@ export const useOssSyncStore = create<OssSyncState>((set, get) => ({
   },
 
   async resolveConflict(
-    workspacePath: string,
+    workspacePath: string | null,
     path: string,
     choice: 'keepRemote' | 'keepLocal',
   ) {

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -1698,6 +1698,14 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
         // link into it". Note there is no workspace gate left: knowledge is
         // per-team, not per-workspace.
         const root = await resolveTeamKnowledgeDir()
+        const previous = get().knowledgeRoot
+        if (previous && previous !== root) {
+          // Switching teams repoints knowledge at a different directory. The old
+          // one has to stop being rendered and, more importantly, stop being
+          // watched — otherwise the previous team's writes keep waking this
+          // column.
+          await useWorkspaceStore.getState().closeExternalRoot(previous)
+        }
         const items = root ? await listTeamKnowledge(root) : []
         set({ knowledgeRoot: root, knowledge: { items, loading: false, loaded: true, error: null } })
       } else if (section === 'mcp') {

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -363,11 +363,7 @@ function currentTeamId(): string | null {
  * any other file type — a PDF, an image — was shared by sync yet invisible to
  * the count.
  */
-async function listTeamKnowledge(): Promise<TeamKnowledgeItem[]> {
-  // No workspace argument: knowledge is one global per-team dir now, resolved
-  // from the daemon home rather than from the workspace link.
-  const knowledgeDir = await resolveTeamKnowledgeDir()
-  if (!knowledgeDir) return []
+async function listTeamKnowledge(knowledgeDir: string): Promise<TeamKnowledgeItem[]> {
   const { exists, readDir } = await import('@tauri-apps/plugin-fs')
   if (!(await exists(knowledgeDir))) return []
 
@@ -1684,38 +1680,25 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
         )
         set({ skills: { items, loading: false, loaded: true, error: registryError } })
       } else if (section === 'knowledge') {
-        // The tree renders straight off disk now, so this only has to resolve
-        // where its root is. The flat listing stays for the nav count.
+        // The daemon's own directory, by absolute path:
+        // `~/.amuxd[-brand]/teams/<id>/shared/knowledge`. That is the tree the
+        // OSS sync engine scans, pushes and pulls (`sync_content_root` +
+        // the `knowledge/` prefix), so it is the only honest source here.
         //
-        // Two things this path has to get right, both of which were wrong:
+        // The per-workspace `team-knowledge` symlink is deliberately NOT used.
+        // It is a convenience surface for agents and the workspace file panel,
+        // and reading through it made this column depend on a link that need
+        // not exist — no workspace open, a workspace opened before the daemon's
+        // link sweep, a Windows `LinkStatus::Fallback` machine — while the
+        // content sat right there on disk. It also disagreed with the nav
+        // count, which has always been read from the real directory.
         //
-        // 1. It must be the IN-WORKSPACE path, not `resolveTeamDir`'s answer.
-        //    `teamclu-team` is a symlink into ~/.amuxd, and resolveTeamDir
-        //    returns the link TARGET — but the workspace file tree is built
-        //    from workspace paths, so `findSubtree` looked up an absolute
-        //    ~/.amuxd path that is never in the tree and always came back
-        //    empty. The column read "No files found" no matter what was on
-        //    disk.
-        //
-        // 2. It must be `knowledge/`, not the team root. File sync carries
-        //    that one prefix now, so a file created at the root is silently
-        //    never synced, and the team dir's other entries (skills/, .mcp/,
-        //    _secrets/, _meta/, _feedback/) are all retired.
-        // team-knowledge is a daemon-managed symlink to shared/knowledge; the
-        // daemon ensures it on every workspace open/switch. Do NOT ensureDir
-        // here — a real dir would block the symlink the daemon recreates.
-        //
-        // 3. It must be gated on the link actually being there. `null` is what
-        //    makes TeamShareListColumn fall back to `TeamDirInitPanel`, the only
-        //    UI that can repair a missing team link. Returning a path
-        //    unconditionally made that unreachable and pointed FileBrowser at
-        //    something that need not exist — a Windows `LinkStatus::Fallback`
-        //    machine, or a workspace opened before the first team-link sweep.
-        //    `exists` follows symlinks, so a dangling link reads as absent too.
-        const linkPath = wsPath ? `${wsPath}/team-knowledge` : null
-        const { exists: linkExists } = await import('@tauri-apps/plugin-fs')
-        const root = linkPath && (await linkExists(linkPath)) ? linkPath : null
-        const items = wsPath ? await listTeamKnowledge() : []
+        // `null` still falls back to `TeamDirInitPanel`, but now it means "the
+        // team dir is missing on this machine", not "this workspace lacks a
+        // link into it". Note there is no workspace gate left: knowledge is
+        // per-team, not per-workspace.
+        const root = await resolveTeamKnowledgeDir()
+        const items = root ? await listTeamKnowledge(root) : []
         set({ knowledgeRoot: root, knowledge: { items, loading: false, loaded: true, error: null } })
       } else if (section === 'mcp') {
         // Not gated on `wsPath`: with an Agent selected this goes over RPC to

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -162,6 +162,8 @@ interface WorkspaceState {
   loadDirectory: (path: string) => Promise<FileNode[]>;
   expandDirectory: (path: string) => Promise<void>;
   openExternalRoot: (rootPath: string) => Promise<void>;
+  refreshExternalRoot: (rootPath: string) => Promise<void>;
+  closeExternalRoot: (rootPath: string) => Promise<void>;
   collapseDirectory: (path: string) => void;
   collapseAll: () => void;
   refreshFileTree: () => Promise<void>;
@@ -703,7 +705,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   },
 
   /**
-   * Register a root outside the workspace and list it.
+   * Register a root outside the workspace, list it, and watch it.
+   *
+   * The watch is what makes a teammate's synced note appear without a manual
+   * refresh: the daemon writes into its own directory, and a recursive watch on
+   * the workspace never saw those writes — `notify` does not follow the
+   * `team-knowledge` symlink, so the real directory was watched by nobody.
    *
    * Idempotent, and re-listing is the point: a create or delete inside the
    * knowledge tree refreshes it by calling this again.
@@ -711,8 +718,72 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   openExternalRoot: async (rootPath: string) => {
     if (!(rootPath in get().externalTrees)) {
       set({ externalTrees: { ...get().externalTrees, [rootPath]: [] } });
+      // Awaited, and before the listing: a watch started afterwards would miss
+      // anything written while the first listing was in flight.
+      await startWatching(rootPath);
     }
     await get().expandDirectory(rootPath);
+  },
+
+  /**
+   * Re-list an external root and every expanded directory under it.
+   *
+   * `refreshFileTree`'s counterpart for a tree that is not the workspace's.
+   * Expansions that no longer exist on disk are dropped; the workspace's own
+   * expansions are never touched.
+   */
+  refreshExternalRoot: async (rootPath: string) => {
+    const { loadDirectory } = get();
+    if (!(rootPath in get().externalTrees)) return;
+
+    const expandedPaths = get().expandedPaths;
+    const stillValid = new Set<string>();
+    const refreshExpanded = async (tree: FileNode[]): Promise<FileNode[]> =>
+      Promise.all(
+        tree.map(async (node) => {
+          if (node.type === "directory" && expandedPaths.has(node.path)) {
+            const children = await loadDirectory(node.path);
+            stillValid.add(node.path);
+            return { ...node, children: await refreshExpanded(children) };
+          }
+          return node;
+        }),
+      );
+
+    const refreshed = await refreshExpanded(await loadDirectory(rootPath));
+
+    const nextExpanded = new Set<string>();
+    for (const path of get().expandedPaths) {
+      const underRoot = path === rootPath || path.startsWith(`${rootPath}/`);
+      // The root is the tree rather than a node in it, so it stays expanded.
+      if (!underRoot || path === rootPath || stillValid.has(path)) {
+        nextExpanded.add(path);
+      }
+    }
+
+    set({
+      externalTrees: { ...get().externalTrees, [rootPath]: refreshed },
+      expandedPaths: nextExpanded,
+    });
+  },
+
+  /**
+   * Forget an external root and stop watching it. Used when the root itself
+   * changes — switching teams repoints the knowledge dir at another directory,
+   * and the old one must stop reporting.
+   */
+  closeExternalRoot: async (rootPath: string) => {
+    const externalTrees = { ...get().externalTrees };
+    if (!(rootPath in externalTrees)) return;
+    delete externalTrees[rootPath];
+
+    const nextExpanded = new Set<string>();
+    for (const path of get().expandedPaths) {
+      if (path !== rootPath && !path.startsWith(`${rootPath}/`)) nextExpanded.add(path);
+    }
+
+    set({ externalTrees, expandedPaths: nextExpanded });
+    await stopWatching(rootPath);
   },
 
   // Collapse a directory node

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -115,6 +115,18 @@ interface WorkspaceState {
 
   // File browser state
   fileTree: FileNode[];
+  /**
+   * File trees rooted OUTSIDE the workspace, keyed by root path; the value is
+   * that root's children.
+   *
+   * The team Knowledge column browses the daemon's real directory
+   * (`~/.amuxd/teams/<id>/shared/knowledge`) — the same absolute path the OSS
+   * sync engine owns — and never the per-workspace `team-knowledge` symlink.
+   * That tree cannot live in `fileTree`: `fileTree` is workspace-rooted and is
+   * what the right-hand file panel renders, so a foreign root parked in it
+   * would show up there as a stray top-level folder.
+   */
+  externalTrees: Record<string, FileNode[]>;
   expandedPaths: Set<string>; // Tracks which directories are expanded (decoupled from tree data)
   loadingPaths: Set<string>; // Tracks which directories are currently loading
   selectedFile: string | null;
@@ -149,6 +161,7 @@ interface WorkspaceState {
   // File tree actions
   loadDirectory: (path: string) => Promise<FileNode[]>;
   expandDirectory: (path: string) => Promise<void>;
+  openExternalRoot: (rootPath: string) => Promise<void>;
   collapseDirectory: (path: string) => void;
   collapseAll: () => void;
   refreshFileTree: () => Promise<void>;
@@ -263,6 +276,17 @@ function updateNodeChildren(
 // leave the new file invisible.
 const expandChain = new Map<string, Promise<void>>();
 
+/**
+ * The registered external root that owns `path`, or null when the workspace
+ * owns it. Prefix match on a path boundary so `/a/bc` never matches root `/a/b`.
+ */
+function externalRootFor(roots: string[], path: string): string | null {
+  for (const root of roots) {
+    if (path === root || path.startsWith(`${root}/`)) return root;
+  }
+  return null;
+}
+
 function findNodeByPath(nodes: FileNode[], path: string): FileNode | null {
   for (const node of nodes) {
     if (node.path === path) return node;
@@ -299,6 +323,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   isPanelOpen: false,
   activeTab: "shortcuts",
   fileTree: [],
+  externalTrees: {},
   expandedPaths: new Set<string>(),
   loadingPaths: new Set<string>(),
   selectedFile: null,
@@ -354,6 +379,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       }
 
       await refreshFileTree();
+      // A paste can land inside an external root (the Knowledge tree), which
+      // the workspace refresh above does not touch.
+      if (externalRootFor(Object.keys(get().externalTrees), targetDir)) {
+        await get().expandDirectory(targetDir);
+      }
       return allSuccess;
     } catch (error) {
       console.error("[Workspace] Paste failed:", error);
@@ -562,8 +592,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
   // Load directory contents using Tauri FS plugin
   loadDirectory: async (path: string): Promise<FileNode[]> => {
-    const { workspacePath } = get();
-    if (!workspacePath) {
+    const { workspacePath, externalTrees } = get();
+    // An external root reads against itself. `read_workspace_directory` only
+    // checks that the target sits under the root it is handed, so the team
+    // knowledge dir under ~/.amuxd browses even with no workspace open.
+    const base = externalRootFor(Object.keys(externalTrees), path) ?? workspacePath;
+    if (!base) {
       console.log("[Workspace] No workspace path set");
       return [];
     }
@@ -575,9 +609,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
 
     try {
-      const fullPath = path === "." ? workspacePath : path;
+      const fullPath = path === "." ? base : path;
       console.log("[Workspace] Loading directory:", fullPath);
-      const nodes = await readWorkspaceDirectory(workspacePath, fullPath);
+      const nodes = await readWorkspaceDirectory(base, fullPath);
       console.log("[Workspace] Found", nodes.length, "entries");
 
       const visibleNodes = [...nodes];
@@ -616,8 +650,27 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       // Load children
       const children = await loadDirectory(path);
 
+      // Whichever tree owns this path is the one that gets rewritten.
+      const externalRoot = externalRootFor(Object.keys(get().externalTrees), path);
+      const currentExternal = externalRoot
+        ? (get().externalTrees[externalRoot] ?? [])
+        : [];
+      const updatedExternal = externalRoot
+        ? {
+            ...get().externalTrees,
+            // The root itself holds no node of its own — its children ARE the
+            // tree — so it merges directly instead of going through the tree walk.
+            [externalRoot]:
+              path === externalRoot
+                ? mergeLoadedChildren(currentExternal, children)
+                : updateNodeChildren(currentExternal, path, children),
+          }
+        : get().externalTrees;
+
       // Update only the target node's children in the tree (minimal copy)
-      const updatedTree = updateNodeChildren(get().fileTree, path, children);
+      const updatedTree = externalRoot
+        ? get().fileTree
+        : updateNodeChildren(get().fileTree, path, children);
 
       // Always clone CURRENT expandedPaths to avoid race conditions —
       // the Set reference may have been replaced by refreshFileTree during the await
@@ -628,6 +681,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
       set({
         fileTree: updatedTree,
+        externalTrees: updatedExternal,
         expandedPaths: nextExpanded,
         loadingPaths: doneLoading,
       });
@@ -646,6 +700,19 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       // Last one out clears the slot, so the map cannot grow unbounded.
       if (expandChain.get(path) === settled) expandChain.delete(path);
     }
+  },
+
+  /**
+   * Register a root outside the workspace and list it.
+   *
+   * Idempotent, and re-listing is the point: a create or delete inside the
+   * knowledge tree refreshes it by calling this again.
+   */
+  openExternalRoot: async (rootPath: string) => {
+    if (!(rootPath in get().externalTrees)) {
+      set({ externalTrees: { ...get().externalTrees, [rootPath]: [] } });
+    }
+    await get().expandDirectory(rootPath);
   },
 
   // Collapse a directory node
@@ -747,6 +814,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     };
 
     const refreshedTree = await refreshExpanded(rootNodes);
+    // This rebuilds the WORKSPACE tree only. Expansions inside an external root
+    // are not represented in `rootNodes`, so dropping them here would collapse
+    // the Knowledge tree every time a workspace file changed.
+    const externalRoots = Object.keys(get().externalTrees);
+    for (const path of expandedPaths) {
+      if (externalRootFor(externalRoots, path)) stillValid.add(path);
+    }
     set({
       fileTree: refreshedTree,
       expandedPaths: stillValid,
@@ -777,8 +851,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
   // Select and load a file using Tauri FS plugin
   selectFile: async (path: string, line?: number, heading?: string) => {
-    const { workspacePath, fileTree } = get();
-    const knownNode = findNodeByPath(fileTree, path);
+    const { workspacePath, fileTree, externalTrees } = get();
+    // Reads are rooted at whichever tree owns the path: the workspace, or an
+    // external root such as the team knowledge dir under ~/.amuxd.
+    const readRoot = externalRootFor(Object.keys(externalTrees), path) ?? workspacePath;
+    const knownNode =
+      findNodeByPath(fileTree, path) ??
+      findNodeByPath(Object.values(externalTrees).flat(), path);
 
     if (knownNode?.type === "directory") {
       set({
@@ -837,10 +916,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         // The viewer will detect the file type from filename and show an appropriate message
         set({ fileContent: "", isLoadingFile: false });
       } else if (isPreviewableBinary) {
-        if (!workspacePath) {
+        if (!readRoot) {
           throw new Error("No workspace path set");
         }
-        const bytes = await readWorkspaceBinaryFile(workspacePath, path);
+        const bytes = await readWorkspaceBinaryFile(readRoot, path);
 
         // Convert to base64
         let binary = "";
@@ -870,10 +949,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
           isLoadingFile: false,
         });
       } else {
-        if (!workspacePath) {
+        if (!readRoot) {
           throw new Error("No workspace path set");
         }
-        const content = await readWorkspaceTextFile(workspacePath, path);
+        const content = await readWorkspaceTextFile(readRoot, path);
         set({ fileContent: content, isLoadingFile: false });
       }
     } catch (error) {
@@ -889,8 +968,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   // Unlike selectFile, this does NOT set fileContent: null or isLoadingFile: true,
   // so the editor stays mounted and can apply the change incrementally.
   reloadSelectedFile: async () => {
-    const { selectedFile, workspacePath } = get();
-    if (!selectedFile || !workspacePath) return;
+    const { selectedFile, workspacePath, externalTrees } = get();
+    if (!selectedFile) return;
+    const readRoot =
+      externalRootFor(Object.keys(externalTrees), selectedFile) ?? workspacePath;
+    if (!readRoot) return;
 
     // In web mode, nothing to reload
     if (!isTauri()) return;
@@ -915,7 +997,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         await selectFile(selectedFile);
       } else {
         // Text files: just re-read content and update — no unmount cycle
-        const content = await readWorkspaceTextFile(workspacePath, selectedFile);
+        const content = await readWorkspaceTextFile(readRoot, selectedFile);
         set({ fileContent: content });
       }
     } catch (error) {


### PR DESCRIPTION
## 起因

侧边栏 Knowledge 的文件树把根设成 `<workspace>/team-knowledge`（daemon 建的软链），只是为了迁就 `FileBrowser`——它只能渲染 workspace 全局 `fileTree` 的子树。于是：没开 workspace、软链缺失/悬空、Windows `LinkStatus::Fallback`，三种情况下磁盘上明明有内容，列表却弹「团队目录缺失」；而同一 section 的角标计数一直读的是真目录，两个数字对不上。

daemon 的 OSS 同步本来就只认 `~/.amuxd[-brand]/teams/<id>/shared`（`sync_content_root` + `knowledge/` 前缀），软链从头到尾不参与同步。这个 PR 让 UI 与之对齐，并顺着这条线把 watch 和 sync 也解耦掉 workspace。

## 1. 知识库直读绝对路径（`deb6a6b6`）

- `workspace` store 支持 workspace 之外的根（`externalTrees`）：读目录、读文件都以该根为 base（`read_workspace_directory` 只校验 target 在传入根之下，Rust 侧零改动）；刷新 workspace 树时保留外部根的展开态；外部根不进 `fileTree`，右侧文件面板不受影响
- `knowledgeRoot` 改为 `resolveTeamKnowledgeDir()` 的绝对路径，不再依赖 `wsPath`。`null` 现在的含义是「这台机器上团队目录不存在」，而不是「这个 workspace 没软链」
- 版本历史 / baseline 统一按同步 key（`knowledge/<rel>`）寻址：新增 `teamSyncKeyForPath`，绝对路径与 `team-knowledge` 软链路径映射到同一个 key。顺带修好两处已经坏掉的地方——`relativeTeamPath` 只认已退役的 `teamclu-team/`（知识文档一直拿不到历史和 baseline diff）、`KnowledgeVersionHistory` 直接把绝对路径丢给 daemon（daemon 要的是相对 key）
- wiki link 在文档所属的那棵知识树里解析，避免同一文件开出两个路径的 tab
- daemon：`prepare_workspace` 每次都重建 `team-knowledge` 软链；`teamclu-team` 不在时回退到 `active_team`（仅当 `shared/knowledge` 已存在且不是 app checkout，避免和 `materialize_or_teardown` 的拆除逻辑打架）

右侧文件面板照旧渲染软链，agent 侧不变。

## 2. 知识目录加 fs watch（`bde4fccf`）

根因是 `notify` 不跟随软链：workspace 上的递归 watch 从来看不见 daemon 往真目录的写入，队友同步过来的笔记要手动刷新才出现。

- `openExternalRoot` 注册外部根时一并 `watch_directory`；**await 且在首次列目录之前**，事后再 watch 会漏掉列目录期间的写入
- 新增 `refreshExternalRoot`（只重列该根及其展开的子目录）与 `closeExternalRoot`（切团队时注销并 unwatch）
- `useFileChangeListener` 支持在 debounce **之前**过滤：watcher 是广播的，debounce 只保留最后一个事件，不先过滤的话自己的事件会被无关写入挤掉
- FileBrowser 重新挂载时补一次重列（watch 由 store 持有，列被关掉期间的变更不在树里）

## 3. sync 解耦 workspace（`a2b43aa5`）

`run_once` 里 `workspace_path` 早就是 `_workspace_path` 没人用，但整条链上到处要求一个 workspace。顺手挖出一个真 bug：

> **定时同步在启动时 `get_workspaces_by_team`，列表为空或云端调用失败就整个不启动。** 新装还没注册工作区、或启动时 FC 不通的设备，300s 自动同步从来没跑过。

- daemon：`sync_team`/`run_once` 去掉 `workspace_path`；timer 改为按 team 触发；`POST /v1/team/sync` 的 `workspacePath` 变可选（给了就顺手修该 workspace 的软链），team id 一律从 `daemon.toml` 读（`team_id_for_workspace` → `active_team_id`）
- desktop：`daemon_team_sync` / `oss_sync_now` / `oss_sync_status` 的 workspacePath 变 `Option`；团队密钥自愈需要 workspace（读的是旧的按工作区存的库），没有就跳过、直接报 daemon 自己的错
- app：store 各方法接受 `string | null`；同步按钮 `available` 去掉 workspacePath 条件；删掉 `useAppInit` 里监听 `<ws>/teamclu-team/` 刷同步状态的 effect——它服务的 per-file 徽标早就没了（`fileSyncStatusMap` 恒为 `{}`），监听的目录也是已退役的树

## 4. Agent 选择器移到列顶部（`9554ac79`）

纯位置调整：同一个下拉块从列表底部搬到搜索框上方，逻辑与内容不变。

## 测试

- `pnpm typecheck` / `pnpm lint`：干净（0 error）
- `pnpm test:unit`：447 files / 2911 passed（新增 workspace 外部根 7 个用例、sync key 4 个用例）
- `cargo test -p amuxd --bin amuxd`：1354 passed（新增 prepare_workspace 软链重建 2 个、SyncRequest 契约 1 个）
- `pnpm rust:check` / `pnpm rust:clippy`：无 error；改动文件 `cargo fmt` 干净
- 顺带补了 `FileEditor.test.tsx` 里 `@/components/editors/utils` mock 缺 `getLanguageFromFilename` 的坑

🤖 Generated with [Claude Code](https://claude.com/claude-code)
