### PR TITLE
fix(team-share): 团队共享状态与角标不再要求打开 workspace

### DIFF
--- a/apps/desktop/src/commands/team_share/enable.rs
+++ b/apps/desktop/src/commands/team_share/enable.rs
@@ -159,9 +159,17 @@ pub(crate) fn global_team_dir_display(team_id: &str) -> Option<String> {
     )
 }
 
+/// Share mode for a team, plus local decoration.
+///
+/// `workspace_path` is optional. The mode itself is the TEAM's and comes from
+/// FC; the only thing a workspace contributes is `linkStatus`, which describes
+/// one workspace's `teamclu-team` entry. Requiring one meant the app never
+/// learned whether share was on until a folder was opened — and every consumer
+/// of that status (the shared-files tab, the sync button, the nav counts) stayed
+/// dark on a client with no folder.
 pub async fn get_share_status_impl(
     team_id: String,
-    workspace_path: String,
+    workspace_path: Option<String>,
     access_token: String,
     cloud_api_url: String,
 ) -> Result<serde_json::Value, String> {
@@ -172,10 +180,13 @@ pub async fn get_share_status_impl(
     // so the settings UI can show where synced content lives and whether this
     // workspace is linked. camelCase to match the existing payload shape.
     if let Some(obj) = value.as_object_mut() {
-        obj.insert(
-            "linkStatus".to_string(),
-            json!(detect_link_status(&workspace_path)),
-        );
+        if let Some(ws) = workspace_path
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        {
+            obj.insert("linkStatus".to_string(), json!(detect_link_status(ws)));
+        }
         if let Some(p) = global_team_dir_display(&team_id) {
             obj.insert("globalPath".to_string(), json!(p));
         }
@@ -186,7 +197,7 @@ pub async fn get_share_status_impl(
 #[tauri::command]
 pub async fn team_share_get_status(
     team_id: String,
-    workspace_path: String,
+    workspace_path: Option<String>,
     access_token: String,
     cloud_api_url: String,
 ) -> Result<serde_json::Value, String> {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -829,10 +829,18 @@ function AppContent() {
   }, [currentTeamId]);
 
   // Keep team-share status fresh so the top-right "team shared files" tab shows
-  // only when share is actually enabled (shareMode != null). Without this the
-  // status would stay null until the user visited the panel or Settings → Team.
+  // only when share is actually enabled (shareMode != null). This is the ONLY
+  // place that loads it, and everything downstream reads the result: the sidebar
+  // tab (`teamShareActive`), the cloud-sync button's `available`, and the sync
+  // status poll in useAppInit.
+  //
+  // Deliberately not gated on a workspace. Share mode is the team's and comes
+  // from the Cloud API; a workspace only decorates the result with its own
+  // `linkStatus`. The old `!workspacePath` guard meant a client with no folder
+  // open reported "share is off" for a team where it is on — which is what left
+  // the sync button greyed out and the shared-files tab hidden.
   useEffect(() => {
-    if (!currentTeamId || !workspacePath) return;
+    if (!currentTeamId) return;
     void refreshTeamShare(currentTeamId, workspacePath);
   }, [currentTeamId, workspacePath, refreshTeamShare]);
 

--- a/packages/app/src/components/sidebar/TeamShareNavSection.tsx
+++ b/packages/app/src/components/sidebar/TeamShareNavSection.tsx
@@ -28,6 +28,18 @@ const ALL_SECTIONS: TeamShareSection[] = ['skills', 'mcp', 'env', 'knowledge']
  * Loads every section's count once. Split out of the rows because the nav now
  * renders team-share entries in two places (default group + 高级 group) and the
  * counts must still be fetched exactly once per team/workspace.
+ *
+ * Not gated on a workspace. Team-share content is the team's: skills and MCP
+ * come from the registry (plus the selected Agent over RPC), knowledge from the
+ * team's own directory under the amuxd home. The old `!workspacePath` guard
+ * meant a client with no folder open showed 0 for all four, and the sections
+ * behind them looked empty rather than unloaded.
+ *
+ * `workspacePath` stays in the deps: opening a folder adds this machine's local
+ * rows (personal skills / MCP), so the counts have to be read again.
+ *
+ * `loadCounts` uses `allSettled`, so a section that does still need a workspace
+ * — Env, whose catalog read throws without one — cannot take the others down.
  */
 export function useTeamShareCountsLoader(): void {
   const currentTeamId = useCurrentTeamStore((s) => s.team?.id ?? null)
@@ -35,7 +47,7 @@ export function useTeamShareCountsLoader(): void {
   const loadCounts = useTeamShareBrowserStore((s) => s.loadCounts)
 
   React.useEffect(() => {
-    if (!currentTeamId || !workspacePath) return
+    if (!currentTeamId) return
     void loadCounts()
   }, [currentTeamId, workspacePath, loadCounts])
 }

--- a/packages/app/src/components/sidebar/__tests__/TeamShareNavSection.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/TeamShareNavSection.test.tsx
@@ -50,6 +50,7 @@ function CountsLoaderHarness() {
 describe('useTeamShareCountsLoader', () => {
   it('loads counts after the current team becomes available', async () => {
     teamState.id = null
+    workspaceState.path = '/workspace'
     loadCounts.mockReset()
 
     const view = render(<CountsLoaderHarness />)
@@ -59,6 +60,36 @@ describe('useTeamShareCountsLoader', () => {
     view.rerender(<CountsLoaderHarness />)
 
     await waitFor(() => expect(loadCounts).toHaveBeenCalledTimes(1))
+  })
+
+  /**
+   * Team-share content is the team's — the skill/MCP registries and the team's
+   * own knowledge directory. Gating this on a workspace showed 0 for all four
+   * sections on a client with no folder open, which reads as "the team has
+   * nothing shared" rather than "not loaded yet".
+   */
+  it('loads counts with no workspace open', async () => {
+    teamState.id = 'team-1'
+    workspaceState.path = null
+    loadCounts.mockReset()
+
+    render(<CountsLoaderHarness />)
+
+    await waitFor(() => expect(loadCounts).toHaveBeenCalledTimes(1))
+  })
+
+  it('reloads when a workspace opens, which adds this machine\'s local rows', async () => {
+    teamState.id = 'team-1'
+    workspaceState.path = null
+    loadCounts.mockReset()
+
+    const view = render(<CountsLoaderHarness />)
+    await waitFor(() => expect(loadCounts).toHaveBeenCalledTimes(1))
+
+    workspaceState.path = '/workspace'
+    view.rerender(<CountsLoaderHarness />)
+
+    await waitFor(() => expect(loadCounts).toHaveBeenCalledTimes(2))
   })
 })
 

--- a/packages/app/src/stores/__tests__/team-share-refresh.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-refresh.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockInvoke = vi.fn()
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}))
+vi.mock('@/lib/utils', () => ({ isTauri: () => true }))
+vi.mock('@/lib/auth/session-store', () => ({
+  getFreshAccessToken: async () => 'access-token',
+}))
+vi.mock('@/lib/server-config', () => ({
+  getEffectiveServerConfigSync: () => ({ cloudApiUrl: 'https://api.example.test' }),
+}))
+
+import { useTeamShareStore } from '../team-share'
+
+describe('team-share refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useTeamShareStore.setState({
+      status: { mode: null, enabledAt: null },
+      loading: false,
+      lastError: null,
+    })
+    mockInvoke.mockResolvedValue({ mode: 'oss', enabledAt: '2026-06-01T00:00:00Z' })
+  })
+
+  /**
+   * Share mode is the TEAM's and comes from the Cloud API — a workspace only
+   * decorates the result with its own `linkStatus`. This used to be gated on a
+   * workspace being open, and since this is the only place the status is ever
+   * loaded, a client with no folder open reported "share is off" for a team
+   * where it is on: no shared-files tab, a greyed-out sync button, no nav counts.
+   */
+  it('reads the team share mode with no workspace open', async () => {
+    const status = await useTeamShareStore.getState().refresh('team-1', null)
+
+    expect(mockInvoke).toHaveBeenCalledWith('team_share_get_status', {
+      teamId: 'team-1',
+      workspacePath: null,
+      accessToken: 'access-token',
+      cloudApiUrl: 'https://api.example.test',
+    })
+    expect(status.mode).toBe('oss')
+    expect(useTeamShareStore.getState().status.mode).toBe('oss')
+    // Nothing to describe: there is no single workspace whose link this is.
+    expect(status.linkStatus).toBeUndefined()
+  })
+
+  it('still passes a workspace through when there is one', async () => {
+    mockInvoke.mockResolvedValue({ mode: 'oss', linkStatus: 'symlink' })
+
+    const status = await useTeamShareStore.getState().refresh('team-1', '/ws')
+
+    expect(mockInvoke).toHaveBeenCalledWith(
+      'team_share_get_status',
+      expect.objectContaining({ workspacePath: '/ws' }),
+    )
+    expect(status.linkStatus).toBe('symlink')
+  })
+
+  it('coalesces concurrent reads for the same team', async () => {
+    const [a, b] = await Promise.all([
+      useTeamShareStore.getState().refresh('team-1', null),
+      useTeamShareStore.getState().refresh('team-1', null),
+    ])
+
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+    expect(a).toEqual(b)
+  })
+})

--- a/packages/app/src/stores/team-share.ts
+++ b/packages/app/src/stores/team-share.ts
@@ -46,6 +46,8 @@ export interface ShareStatus {
   enabledAt?: string | null
   // Per-workspace link to the daemon's single global copy, and where that
   // global copy lives on disk (~/.amuxd/teams/<team_id>/teamclu-team).
+  // Absent when the status was read without a workspace — there is no single
+  // workspace whose link it could describe.
   linkStatus?: LinkStatus
   globalPath?: string | null
 }
@@ -66,7 +68,12 @@ export interface TeamShareState {
   loading: boolean
   lastError: string | null
 
-  refresh(teamId: string, workspacePath: string): Promise<ShareStatus>
+  /**
+   * Read the team's share mode. `workspacePath` is optional and only decorates
+   * the result with that workspace's `linkStatus` — the mode is the team's, and
+   * comes from the Cloud API.
+   */
+  refresh(teamId: string, workspacePath?: string | null): Promise<ShareStatus>
   /**
    * Save the team secret and deliver it to the daemon. Resolves to a warning
    * string when the save succeeded but the daemon did not take delivery — the
@@ -105,7 +112,7 @@ export const useTeamShareStore = create<TeamShareState>((set) => ({
   async refresh(teamId, workspacePath) {
     if (!isTauri()) return { ...EMPTY_STATUS }
 
-    const key = `${teamId}\0${workspacePath}`
+    const key = `${teamId}\0${workspacePath ?? ''}`
     if (shareRefreshInflight && shareRefreshInflightKey === key) {
       return shareRefreshInflight
     }
@@ -120,7 +127,7 @@ export const useTeamShareStore = create<TeamShareState>((set) => ({
         const cloudApiUrl = getCloudApiUrlForNativeCommand()
         const raw = await invoke<ShareStatus>('team_share_get_status', {
           teamId,
-          workspacePath,
+          workspacePath: workspacePath ?? null,
           accessToken,
           cloudApiUrl,
         })


### PR DESCRIPTION
接 #1074。那个 PR 把知识库、fs watch、sync 都从 workspace 解耦了，但整条链的**源头**还卡着——所以 sync 那部分在 UI 上其实看不出效果。这个 PR 修源头。

## 1. team-share 状态（`App.tsx`）

`App.tsx` 那个 effect 是全 app **唯一**加载 team-share 状态的地方，却带着 `!workspacePath` 的门。而 share mode 完全来自 Cloud API（`GET /v1/teams/:id/share-mode`），workspace 只贡献一个 `linkStatus`。结果是：没打开文件夹的客户端，对一个明明开了共享的团队报告「没开共享」。

连锁反应三处，全部因此瞎掉：

- `app-sidebar.tsx:227` 的 `teamShareActive` 为假 → 右上角「团队共享文件」入口不显示
- `use-team-cloud-sync.ts` 的 `available` 为假 → 同步按钮灰着（#1074 刚把它从 workspace 解耦，卡在这里没生效）
- `useAppInit.ts` 的同步状态轮询直接跳过

改动：

- desktop：`team_share_get_status` / `get_share_status_impl` 的 `workspace_path` 变 `Option<String>`；给了才附加 `linkStatus`——它描述的就是某一个 workspace 的 `teamclu-team` 入口，没有 workspace 就没有可描述的对象。`mode` / `enabledAt` 本来就纯来自 FC，`globalPath` 也只按 team id 算
- store：`refresh(teamId, workspacePath?)`，in-flight 去重的 key 容纳 null
- `App.tsx`：去掉 workspace 门

## 2. 四个 section 的角标（`TeamShareNavSection.tsx`）

`useTeamShareCountsLoader` 是计数唯一的加载点，和上面是同一处病。第 1 条修完入口能出现了，点进去四个角标却全是 0——看起来像「团队什么都没共享」，而不是「还没加载」。

这些内容都是团队的：skills / mcp 来自注册表（外加选中 Agent 走 RPC），knowledge 来自 amuxd home 下团队自己的目录。`workspacePath` 留在 deps 里——打开文件夹会多出本机的个人 skills / MCP 行，计数得重读。

`loadCounts` 用的是 `allSettled`，所以确实还需要 workspace 的 Env（目录读取会抛）不会把另外三个拖下水。

## 安全性

入口打开后点进去不会炸，逐个核对过：`listTeamSkills(null, …)` / `listTeamMcp(null, …)` 的 `wsPath` 参数本来就是 `string | null`，各自有 null 分支（前者本地文件返回空 Map，后者走 `teamId && actorId` 的 Agent RPC 路径）。

## 后续

Env 区、MCP 工具探测、个人 MCP 增删改、skill 编辑、providers 列表、`TeamDirInitPanel`、`introspect_api` 的 `handle_team_sync_all` 等剩余项在后续 PR 处理。

## 测试

- `pnpm typecheck` / `pnpm rust:check`：干净
- `pnpm test:unit`：449 files / 2922 passed（新增 5 个用例）
- `pnpm lint`：改动文件无告警；`cargo fmt` desktop 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)
