### PR TITLE
fix(chat): agent pill layered send vs sync status over debounced MQTT

### DIFF
--- a/packages/app/src/components/chat/AgentSelectorDock.tsx
+++ b/packages/app/src/components/chat/AgentSelectorDock.tsx
@@ -41,9 +41,10 @@ import type { AttachedAgent } from '@/packages/ai/prompt-input-insert-hooks'
 import type { EngagedAgentUiEntry } from '@/hooks/use-engaged-agent-ui-states'
 import {
   resolveAgentPillDot,
+  type SessionAgentSyncHint,
   type SessionAgentUiState,
 } from '@/lib/session-agent-ui-state'
-import { pillSuffixForUiState } from '@/components/chat/EngagedAgentOfflineBanner'
+import { pillSuffixForAgentPill } from '@/components/chat/EngagedAgentOfflineBanner'
 import { isSoloBuild } from '@/lib/solo-build'
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -81,8 +82,8 @@ export function AgentSelectorDock({
   agentMentionLocked = false,
 }: AgentSelectorDockProps) {
   const runtimeStates = useRuntimeStateStore((s) => s.byRuntimeId)
-  const uiStateByAgentId = React.useMemo(
-    () => new Map(engagedUiEntries.map((e) => [e.agent.id, e.uiState])),
+  const uiEntryByAgentId = React.useMemo(
+    () => new Map(engagedUiEntries.map((e) => [e.agent.id, e])),
     [engagedUiEntries],
   )
 
@@ -109,7 +110,8 @@ export function AgentSelectorDock({
             dbRuntimeId={dbRuntimeId}
             backendType={backendType}
             runtimeInfo={runtimeEntry?.info}
-            uiState={uiStateByAgentId.get(agent.id) ?? 'connecting'}
+            uiState={uiEntryByAgentId.get(agent.id)?.uiState ?? 'connecting'}
+            syncHint={uiEntryByAgentId.get(agent.id)?.syncHint ?? null}
             mentionLocked={agentMentionLocked}
             onRemove={() => {
               if (activeSessionId) {
@@ -135,6 +137,7 @@ function AgentPill({
   backendType,
   runtimeInfo,
   uiState,
+  syncHint = null,
   mentionLocked = false,
   onRemove,
 }: {
@@ -144,6 +147,7 @@ function AgentPill({
   backendType: string | undefined
   runtimeInfo: RuntimeInfo | undefined
   uiState: SessionAgentUiState
+  syncHint?: SessionAgentSyncHint
   mentionLocked?: boolean
   onRemove: () => void
 }) {
@@ -202,7 +206,7 @@ function AgentPill({
     ],
   )
 
-  const statusSuffix = pillSuffixForUiState(effectiveUiState, t)
+  const statusSuffix = pillSuffixForAgentPill(effectiveUiState, syncHint, t)
   const hideModelOnPill = isSoloBuild()
   // `unconfigured` is a settled answer ("nothing to run"), so it must not read
   // as loading — that is the spinner-forever bug this state exists to end.
@@ -457,7 +461,12 @@ function AgentPill({
           {statusSuffix ? (
             <>
               {isSelf ? null : <span className="shrink-0 text-muted-foreground/70">·</span>}
-              <span className="min-w-0 flex-1 truncate text-[11px] text-faint">
+              <span
+                className={cn(
+                  'min-w-0 flex-1 truncate text-[11px]',
+                  syncHint === 'degraded' ? 'text-amber-600' : 'text-faint',
+                )}
+              >
                 {effectiveUiState === 'connecting' &&
                 (runtimeInfoLoading || availableModels.length === 0) ? (
                   <span className="inline-flex items-center gap-1">

--- a/packages/app/src/components/chat/EngagedAgentOfflineBanner.tsx
+++ b/packages/app/src/components/chat/EngagedAgentOfflineBanner.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { AlertCircle } from 'lucide-react'
 import type { AttachedAgent } from '@/packages/ai/prompt-input-insert-hooks'
 import type { EngagedAgentUiEntry } from '@/hooks/use-engaged-agent-ui-states'
-import type { SessionAgentUiState } from '@/lib/session-agent-ui-state'
+import type { SessionAgentUiState, SessionAgentSyncHint } from '@/lib/session-agent-ui-state'
 
 type Props = {
   entries: EngagedAgentUiEntry[]
@@ -151,4 +151,17 @@ export function pillSuffixForUiState(
     default:
       return null
   }
+}
+
+export function pillSuffixForAgentPill(
+  uiState: SessionAgentUiState,
+  syncHint: SessionAgentSyncHint,
+  t: (key: string, fallback: string) => string,
+): string | null {
+  const hardFailure = pillSuffixForUiState(uiState, t)
+  if (hardFailure !== null) return hardFailure
+  if (syncHint === 'degraded') {
+    return t('chat.sessionAgent.pillSyncDegraded', 'Team sync interrupted')
+  }
+  return null
 }

--- a/packages/app/src/components/chat/__tests__/AgentSelectorDock.test.tsx
+++ b/packages/app/src/components/chat/__tests__/AgentSelectorDock.test.tsx
@@ -65,7 +65,7 @@ function dockProps(
   const engagedAgents = partial.engagedAgents ?? []
   const engagedUiEntries: EngagedAgentUiEntry[] =
     partial.engagedUiEntries ??
-    engagedAgents.map((agent) => ({ agent, uiState: 'ready' as const }))
+    engagedAgents.map((agent) => ({ agent, uiState: 'ready' as const, syncHint: null }))
   return {
     activeSessionId: null as string | null,
     engagedUiEntries,
@@ -115,7 +115,7 @@ describe('AgentSelectorDock', () => {
       <AgentSelectorDock
         {...dockProps({
           engagedAgents: [agent],
-          engagedUiEntries: [{ agent, uiState: 'ready' }],
+          engagedUiEntries: [{ agent, uiState: 'ready', syncHint: null }],
         })}
       />,
     )
@@ -349,6 +349,7 @@ describe('AgentSelectorDock', () => {
             {
               agent: { id: 'a-1', displayName: 'Ghost Bot' },
               uiState: 'offline',
+              syncHint: null,
             },
           ],
         })}
@@ -374,6 +375,7 @@ describe('AgentSelectorDock', () => {
             {
               agent: { id: 'a-1', displayName: 'OpenCode Bot' },
               uiState: 'ready',
+              syncHint: null,
             },
           ],
         })}

--- a/packages/app/src/components/chat/__tests__/engaged-agent-pill-label.test.ts
+++ b/packages/app/src/components/chat/__tests__/engaged-agent-pill-label.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { pillSuffixForUiState } from '../EngagedAgentOfflineBanner'
+import { pillSuffixForAgentPill, pillSuffixForUiState } from '../EngagedAgentOfflineBanner'
 import type { SessionAgentUiState } from '@/lib/session-agent-ui-state'
 
 // Returns the key so a missing case is visible as `null` rather than as a
@@ -33,5 +33,25 @@ describe('pillSuffixForUiState', () => {
 
   it('leaves a ready agent unlabelled', () => {
     expect(pillSuffixForUiState('ready', t)).toBeNull()
+  })
+})
+
+describe('pillSuffixForAgentPill', () => {
+  const t = (key: string) => key
+
+  it('shows a sync-degraded suffix on an otherwise ready local pill', () => {
+    expect(pillSuffixForAgentPill('ready', 'degraded', t)).toBe(
+      'chat.sessionAgent.pillSyncDegraded',
+    )
+  })
+
+  it('prefers hard failure labels over sync-degraded', () => {
+    expect(pillSuffixForAgentPill('runtime-error', 'degraded', t)).toBe(
+      'chat.sessionAgent.pillRuntimeError',
+    )
+  })
+
+  it('leaves a healthy ready pill unlabelled', () => {
+    expect(pillSuffixForAgentPill('ready', null, t)).toBeNull()
   })
 })

--- a/packages/app/src/hooks/__tests__/use-engaged-agent-ui-states.test.ts
+++ b/packages/app/src/hooks/__tests__/use-engaged-agent-ui-states.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   presenceByActor: {} as Record<string, { online: boolean } | undefined>,
   probeResult: 'reachable' as 'reachable' | 'unreachable',
   localDaemonActorId: 'local-agent' as string | null,
+  daemonMqttConnected: true as boolean | null,
 }))
 
 vi.mock('@/stores/runtime-state-store', async (importOriginal) => {
@@ -59,12 +60,16 @@ vi.mock('@/lib/local-daemon-identity', () => ({
   noteLocalDaemonActorId: vi.fn(),
 }))
 
+vi.mock('@/stores/daemon-mqtt-status', () => ({
+  useDaemonMqttConnected: () => mocks.daemonMqttConnected,
+}))
+
 describe('hasAnyNonReadyEngaged', () => {
   it('returns true when any engaged agent is not ready', () => {
     expect(
       hasAnyNonReadyEngaged([
-        { agent: { id: 'a', displayName: 'A' }, uiState: 'ready' },
-        { agent: { id: 'b', displayName: 'B' }, uiState: 'offline' },
+        { agent: { id: 'a', displayName: 'A' }, uiState: 'ready', syncHint: null },
+        { agent: { id: 'b', displayName: 'B' }, uiState: 'offline', syncHint: null },
       ]),
     ).toBe(true)
   })
@@ -72,7 +77,7 @@ describe('hasAnyNonReadyEngaged', () => {
   it('returns false when all engaged agents are ready', () => {
     expect(
       hasAnyNonReadyEngaged([
-        { agent: { id: 'a', displayName: 'A' }, uiState: 'ready' },
+        { agent: { id: 'a', displayName: 'A' }, uiState: 'ready', syncHint: null },
       ]),
     ).toBe(false)
   })
@@ -86,6 +91,7 @@ describe('useEngagedAgentUiStates', () => {
     mocks.presenceByActor = {}
     mocks.probeResult = 'reachable'
     mocks.localDaemonActorId = 'local-agent'
+    mocks.daemonMqttConnected = true
   })
 
   it('marks agent offline when presence is false despite active runtime retain', () => {

--- a/packages/app/src/hooks/__tests__/use-ensure-engaged-runtimes-on-session-focus.test.ts
+++ b/packages/app/src/hooks/__tests__/use-ensure-engaged-runtimes-on-session-focus.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/lib/teamclu/ensure-agent-runtime', () => ({
 }))
 
 function entry(id: string, uiState: EngagedAgentUiEntry['uiState']): EngagedAgentUiEntry {
-  return { agent: { id, displayName: id }, uiState }
+  return { agent: { id, displayName: id }, uiState, syncHint: null }
 }
 
 describe('hasConnectingEngagedAgent / hasRecoverableNonReadyAgent', () => {

--- a/packages/app/src/hooks/__tests__/use-reensure-runtimes-on-mqtt-reconnect.test.ts
+++ b/packages/app/src/hooks/__tests__/use-reensure-runtimes-on-mqtt-reconnect.test.ts
@@ -17,7 +17,7 @@ vi.mock('@/stores/mqtt-reconnect', () => ({
 }))
 
 function entry(id: string, uiState: EngagedAgentUiEntry['uiState']): EngagedAgentUiEntry {
-  return { agent: { id, displayName: id }, uiState }
+  return { agent: { id, displayName: id }, uiState, syncHint: null }
 }
 
 describe('useReensureRuntimesOnMqttReconnect', () => {

--- a/packages/app/src/hooks/use-engaged-agent-ui-states.ts
+++ b/packages/app/src/hooks/use-engaged-agent-ui-states.ts
@@ -9,9 +9,11 @@ import { mergeAgentDevicePresence } from '@/lib/agent-device-reachability'
 import { resolveRuntimeStateEntryForAgent } from '@/lib/runtime-state-resolve'
 import {
   SESSION_AGENT_CONNECTING_TIMEOUT_MS,
+  resolveSessionAgentSyncHint,
   resolveSessionAgentUiState,
   type ReachabilityEvidence,
   type SessionAgentContext,
+  type SessionAgentSyncHint,
   type SessionAgentUiState,
 } from '@/lib/session-agent-ui-state'
 import {
@@ -43,10 +45,12 @@ import {
   LOCAL_AGENT_READY_PROBE_INTERVAL_MS,
   LOCAL_CATALOG_POLL_INTERVAL_MS,
 } from '@/lib/session-agent-probe'
+import { useDaemonMqttConnected } from '@/stores/daemon-mqtt-status'
 
 export type EngagedAgentUiEntry = {
   agent: AttachedAgent
   uiState: SessionAgentUiState
+  syncHint: SessionAgentSyncHint
 }
 
 /**
@@ -203,6 +207,27 @@ function computeProvisionalState(
   })
 }
 
+function computeSyncHint(
+  agent: AttachedAgent,
+  uiState: SessionAgentUiState,
+  reachabilityByAgent: Record<string, ReachabilityEvidence>,
+  contextKey: string,
+  daemonMqttConnected: boolean | null,
+): SessionAgentSyncHint {
+  const localId = getKnownLocalDaemonActorId()
+  const isLocalAgent = !!localId && agent.id === localId
+  const reachability = reachabilityByAgent[agent.id]
+  const currentReachability =
+    reachability?.contextKey === `${contextKey}:${agent.id}` ? reachability : undefined
+
+  return resolveSessionAgentSyncHint({
+    uiState,
+    isLocalAgent,
+    daemonMqttConnected,
+    reachability: currentReachability,
+  })
+}
+
 function latestPositiveEvidenceAt(
   agent: AttachedAgent,
   agentToRuntimeId: Map<string, string>,
@@ -328,6 +353,7 @@ export function useEngagedAgentUiStates(
   const requestIdRef = React.useRef(0)
   const teamId = useCurrentTeamStore((s) => s.team?.id)?.trim() || ''
   const contextKey = `${teamId}:${context.kind}:${context.kind === 'session' ? context.sessionId : 'draft'}`
+  const daemonMqttConnected = useDaemonMqttConnected(!!getKnownLocalDaemonActorId())
   const stableContext = React.useMemo<SessionAgentContext>(
     () => context.kind === 'session'
       ? { kind: 'session', sessionId: context.sessionId }
@@ -618,9 +644,8 @@ export function useEngagedAgentUiStates(
 
   return React.useMemo(() => {
     const now = Date.now()
-    return engagedAgents.map((agent) => ({
-      agent,
-      uiState: computeProvisionalState(
+    return engagedAgents.map((agent) => {
+      const uiState = computeProvisionalState(
         agent,
         agentToRuntimeId,
         byRuntimeId,
@@ -633,8 +658,19 @@ export function useEngagedAgentUiStates(
         stableContext,
         contextKey,
         now,
-      ),
-    }))
+      )
+      return {
+        agent,
+        uiState,
+        syncHint: computeSyncHint(
+          agent,
+          uiState,
+          reachabilityByAgent,
+          contextKey,
+          daemonMqttConnected,
+        ),
+      }
+    })
   }, [
     engagedAgents,
     engagedSignature,
@@ -651,6 +687,7 @@ export function useEngagedAgentUiStates(
     stableContext,
     contextKey,
     tick,
+    daemonMqttConnected,
   ])
 }
 

--- a/packages/app/src/lib/__tests__/agent-model-multi-check-evidence.test.tsx
+++ b/packages/app/src/lib/__tests__/agent-model-multi-check-evidence.test.tsx
@@ -292,7 +292,7 @@ describe("agent model multi-check UI evidence", () => {
         activeSessionId="session-1"
         engagedAgents={[{ id: "agent-mac", displayName: "MACPRO" }]}
         engagedUiEntries={[
-          { agent: { id: "agent-mac", displayName: "MACPRO" }, uiState: "ready" },
+          { agent: { id: "agent-mac", displayName: "MACPRO" }, uiState: "ready", syncHint: null },
         ]}
         agentToRuntimeId={new Map([["agent-mac", "rt-1"]])}
         agentToBackendType={new Map([["agent-mac", "opencode"]])}

--- a/packages/app/src/lib/__tests__/agent-pill-mqtt-layered-status.integration.test.ts
+++ b/packages/app/src/lib/__tests__/agent-pill-mqtt-layered-status.integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Integrated pipeline for agent-pill MQTT layered status.
+ *
+ * Exercises the same data path as draft-page idle without a live desktop:
+ * daemon poll → debounced uiConnected → sidebar status + pill syncHint + suffix.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { RuntimeLifecycle } from '@/lib/proto/amux_pb'
+import { pillSuffixForAgentPill } from '@/components/chat/EngagedAgentOfflineBanner'
+import {
+  resolveLocalDaemonRuntimeStatus,
+  type LocalDaemonHttpStatus,
+} from '@/hooks/use-local-daemon-http-status'
+import {
+  resolveSessionAgentSyncHint,
+  resolveSessionAgentUiState,
+  type ReachabilityEvidence,
+} from '@/lib/session-agent-ui-state'
+import {
+  subscribeDaemonMqttStatus,
+  useDaemonMqttStatusStore,
+  __resetDaemonMqttStatusForTests,
+} from '@/stores/daemon-mqtt-status'
+
+const getDaemonMqttConnected = vi.hoisted(() => vi.fn<() => Promise<boolean | null>>())
+
+vi.mock('@/lib/daemon-agent-admin', () => ({ getDaemonMqttConnected }))
+vi.mock('@/lib/agent-device-reachability', () => ({ noteLocalDaemonSignals: vi.fn() }))
+vi.mock('@/lib/local-daemon-identity', () => ({
+  getKnownLocalDaemonActorId: () => 'local-agent',
+}))
+vi.mock('@/lib/daemon-probe-signal', () => ({
+  onDaemonProbeRequested: () => () => {},
+}))
+
+function evidence(status: ReachabilityEvidence['status']): ReachabilityEvidence {
+  return {
+    status,
+    startedAt: 0,
+    observedAt: 1,
+    requestId: 1,
+    contextKey: 'team:draft:draft:local-agent',
+  }
+}
+
+function sidebarStatus(daemonMqttConnected: boolean | null): ReturnType<typeof resolveLocalDaemonRuntimeStatus> {
+  return resolveLocalDaemonRuntimeStatus({
+    daemonOnboardingReady: true,
+    httpStatus: 'online' satisfies LocalDaemonHttpStatus,
+    daemonMqttConnected,
+  })
+}
+
+function pillSyncHint(
+  uiState: 'ready' | 'connecting',
+  daemonMqttConnected: boolean | null,
+): ReturnType<typeof resolveSessionAgentSyncHint> {
+  return resolveSessionAgentSyncHint({
+    uiState,
+    isLocalAgent: true,
+    daemonMqttConnected,
+    reachability: evidence('reachable'),
+  })
+}
+
+const t = (_key: string, fallback?: string) => fallback ?? _key
+
+describe('agent pill mqtt layered status — integrated pipeline', () => {
+  describe('daemon mqtt poll debounce (store → sidebar + pill)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      getDaemonMqttConnected.mockReset()
+      getDaemonMqttConnected.mockResolvedValue(true)
+      __resetDaemonMqttStatusForTests()
+    })
+
+    afterEach(() => {
+      __resetDaemonMqttStatusForTests()
+      vi.useRealTimers()
+    })
+
+    it('matches the draft-idle repro: one transient false keeps sidebar and pill healthy', async () => {
+      const release = subscribeDaemonMqttStatus()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(sidebarStatus(useDaemonMqttStatusStore.getState().uiConnected)).toBe('online')
+      expect(pillSyncHint('ready', useDaemonMqttStatusStore.getState().uiConnected)).toBeNull()
+      expect(
+        pillSuffixForAgentPill('ready', pillSyncHint('ready', useDaemonMqttStatusStore.getState().uiConnected), t),
+      ).toBeNull()
+
+      getDaemonMqttConnected.mockResolvedValue(false)
+      await vi.advanceTimersByTimeAsync(20_000)
+
+      const ui = useDaemonMqttStatusStore.getState().uiConnected
+      expect(useDaemonMqttStatusStore.getState().connected).toBe(false)
+      expect(ui).toBe(true)
+      expect(sidebarStatus(ui)).toBe('online')
+      expect(pillSyncHint('ready', ui)).toBeNull()
+      expect(pillSuffixForAgentPill('ready', pillSyncHint('ready', ui), t)).toBeNull()
+
+      getDaemonMqttConnected.mockResolvedValue(true)
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(sidebarStatus(useDaemonMqttStatusStore.getState().uiConnected)).toBe('online')
+      release()
+    })
+
+    it('alarms sidebar and pill together after sustained mqtt outage', async () => {
+      getDaemonMqttConnected.mockResolvedValue(true)
+      const release = subscribeDaemonMqttStatus()
+      await vi.advanceTimersByTimeAsync(0)
+
+      getDaemonMqttConnected.mockResolvedValue(false)
+      await vi.advanceTimersByTimeAsync(20_000)
+      await vi.advanceTimersByTimeAsync(20_000)
+
+      const ui = useDaemonMqttStatusStore.getState().uiConnected
+      expect(ui).toBe(false)
+      expect(sidebarStatus(ui)).toBe('daemonMqttDisconnected')
+
+      const hint = pillSyncHint('ready', ui)
+      expect(hint).toBe('degraded')
+      expect(pillSuffixForAgentPill('ready', hint, t)).toBe('Team sync interrupted')
+
+      getDaemonMqttConnected.mockResolvedValue(true)
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(sidebarStatus(useDaemonMqttStatusStore.getState().uiConnected)).toBe('online')
+      expect(pillSyncHint('ready', useDaemonMqttStatusStore.getState().uiConnected)).toBeNull()
+      release()
+    })
+  })
+
+  describe('send layer stays ready on local draft/session mqtt blip', () => {
+    const localLoopbackReady = {
+      isLocalAgent: true,
+      runtimeInfo: undefined,
+      availableModelCount: 2,
+      isStaleBinding: false,
+      connectingTimedOut: true,
+      reachability: evidence('reachable'),
+      localCatalog: 'ready' as const,
+    }
+
+    it('keeps draft uiState ready when merged presence is unknown but loopback is up', () => {
+      expect(resolveSessionAgentUiState({
+        ...localLoopbackReady,
+        context: { kind: 'draft' },
+        presenceOnline: undefined,
+      })).toBe('ready')
+    })
+
+    it('does not borrow runtime-error from connecting timeout on session mqtt blip', () => {
+      expect(resolveSessionAgentUiState({
+        ...localLoopbackReady,
+        context: { kind: 'session', sessionId: 'session-1' },
+        presenceOnline: false,
+      })).toBe('ready')
+    })
+
+    it('still surfaces runtime-error when loopback sees FAILED', () => {
+      expect(resolveSessionAgentUiState({
+        ...localLoopbackReady,
+        context: { kind: 'session', sessionId: 'session-1' },
+        presenceOnline: true,
+        runtimeInfo: { state: RuntimeLifecycle.FAILED } as never,
+      })).toBe('runtime-error')
+    })
+  })
+})

--- a/packages/app/src/lib/__tests__/session-agent-ui-state.test.ts
+++ b/packages/app/src/lib/__tests__/session-agent-ui-state.test.ts
@@ -3,6 +3,7 @@ import { AgentStatus, RuntimeLifecycle } from '@/lib/proto/amux_pb'
 import {
   isDriftedLocalGhostBinding,
   resolveAgentPillDot,
+  resolveSessionAgentSyncHint,
   resolveSessionAgentUiState,
   toMentionDeliverySnapshot,
   type ReachabilityEvidence,
@@ -241,6 +242,108 @@ describe('resolveSessionAgentUiState', () => {
       runtimeInfo: { state: RuntimeLifecycle.ACTIVE } as never,
       reachability: evidence('unreachable'),
     })).toBe('offline')
+  })
+
+  describe('local session — loopback layered over MQTT retain', () => {
+    const localSession = {
+      ...sessionBase,
+      isLocalAgent: true,
+      reachability: evidence('reachable'),
+    }
+
+    it('stays ready when broker presence drops but loopback and catalog remain', () => {
+      expect(resolveSessionAgentUiState({
+        ...localSession,
+        presenceOnline: false,
+        runtimeInfo: undefined,
+        localCatalog: 'ready',
+        availableModelCount: 3,
+      })).toBe('ready')
+    })
+
+    it('does not escalate MQTT blip to runtime-error after connecting timeout', () => {
+      expect(resolveSessionAgentUiState({
+        ...localSession,
+        presenceOnline: false,
+        runtimeInfo: undefined,
+        localCatalog: 'ready',
+        availableModelCount: 3,
+        connectingTimedOut: true,
+      })).toBe('ready')
+    })
+
+    it('still reports runtime-error when loopback sees FAILED', () => {
+      expect(resolveSessionAgentUiState({
+        ...localSession,
+        presenceOnline: true,
+        runtimeInfo: { state: RuntimeLifecycle.FAILED } as never,
+      })).toBe('runtime-error')
+    })
+
+    it('converges local session cold-start timeout to runtime-error like remote', () => {
+      expect(resolveSessionAgentUiState({
+        ...localSession,
+        presenceOnline: true,
+        runtimeInfo: { state: RuntimeLifecycle.STARTING } as never,
+        connectingTimedOut: true,
+      })).toBe('runtime-error')
+    })
+
+    it('leaves remote session on the MQTT retain path unchanged', () => {
+      expect(resolveSessionAgentUiState({
+        ...sessionBase,
+        presenceOnline: false,
+        runtimeInfo: { state: RuntimeLifecycle.ACTIVE } as never,
+        connectingTimedOut: true,
+      })).toBe('offline')
+    })
+  })
+})
+
+describe('resolveSessionAgentSyncHint', () => {
+  it('is null for non-ready agents', () => {
+    expect(resolveSessionAgentSyncHint({
+      uiState: 'connecting',
+      isLocalAgent: true,
+      daemonMqttConnected: false,
+      reachability: evidence('reachable'),
+    })).toBeNull()
+  })
+
+  it('flags degraded when debounced daemon mqtt reads false', () => {
+    expect(resolveSessionAgentSyncHint({
+      uiState: 'ready',
+      isLocalAgent: true,
+      daemonMqttConnected: false,
+      reachability: evidence('reachable'),
+    })).toBe('degraded')
+  })
+
+  it('does not degrade on stale broker presence when daemon mqtt is up', () => {
+    expect(resolveSessionAgentSyncHint({
+      uiState: 'ready',
+      isLocalAgent: true,
+      daemonMqttConnected: true,
+      reachability: evidence('reachable'),
+    })).toBeNull()
+  })
+
+  it('is null while daemon mqtt status is still unknown', () => {
+    expect(resolveSessionAgentSyncHint({
+      uiState: 'ready',
+      isLocalAgent: true,
+      daemonMqttConnected: null,
+      reachability: evidence('reachable'),
+    })).toBeNull()
+  })
+
+  it('ignores remote agents', () => {
+    expect(resolveSessionAgentSyncHint({
+      uiState: 'ready',
+      isLocalAgent: false,
+      daemonMqttConnected: false,
+      reachability: evidence('reachable'),
+    })).toBeNull()
   })
 })
 

--- a/packages/app/src/lib/session-agent-ui-state.ts
+++ b/packages/app/src/lib/session-agent-ui-state.ts
@@ -78,6 +78,22 @@ export function isDriftedLocalGhostBinding(input: {
   return localReady
 }
 
+export type SessionAgentSyncHint = 'degraded' | null
+
+export function resolveSessionAgentSyncHint(input: {
+  uiState: SessionAgentUiState
+  isLocalAgent?: boolean
+  /** Debounced daemon MQTT link for UI (from daemon-mqtt-status store). */
+  daemonMqttConnected?: boolean | null
+  reachability?: ReachabilityEvidence
+}): SessionAgentSyncHint {
+  if (input.uiState !== 'ready') return null
+  if (!input.isLocalAgent) return null
+  if (input.reachability?.status !== 'reachable') return null
+  if (input.daemonMqttConnected !== false) return null
+  return 'degraded'
+}
+
 export function resolveSessionAgentUiState(input: {
   context: SessionAgentContext
   isLocalAgent?: boolean
@@ -110,6 +126,38 @@ export function resolveSessionAgentUiState(input: {
     const runtimeObservedAt = input.runtimeObservedAt ?? 0
 
     if (input.context.kind === 'session') {
+      // Local session: loopback is authoritative for send readiness. A broker
+      // retain blip must not paint the pill red when this machine can still run.
+      if (input.isLocalAgent) {
+        if (reachabilityStatus === 'unreachable') return 'offline'
+
+        if (reachabilityStatus === 'reachable') {
+          switch (input.runtimeInfo?.state) {
+            case RuntimeLifecycle.ACTIVE:
+              return 'ready'
+            case RuntimeLifecycle.FAILED:
+            case RuntimeLifecycle.STOPPED:
+              return 'runtime-error'
+            case RuntimeLifecycle.STARTING:
+            case RuntimeLifecycle.UNKNOWN:
+            default:
+              if (input.availableModelCount > 0 || input.localCatalog === 'ready') {
+                return 'ready'
+              }
+              if (input.localCatalog === 'empty') return 'unconfigured'
+              if (input.localCatalog === 'error') return 'catalog-error'
+              return input.connectingTimedOut ? 'runtime-error' : 'connecting'
+          }
+        }
+
+        if (
+          input.presenceOnline === false &&
+          input.runtimeInfo?.state === RuntimeLifecycle.ACTIVE
+        ) {
+          return 'ready'
+        }
+      }
+
       if (input.presenceOnline === false) return 'offline'
       if (input.isLocalAgent && reachabilityStatus === 'unreachable') return 'offline'
 

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -699,6 +699,7 @@
       "pillUnconfigured": "No model configured",
       "pillCatalogError": "Model list unavailable",
       "pillRuntimeError": "Agent start failed",
+      "pillSyncDegraded": "Team sync interrupted",
       "mentionOffline": "Offline",
       "mentionStale": "Rebind required",
       "mentionConnecting": "Connecting…",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -699,6 +699,7 @@
       "pillUnconfigured": "未配置模型",
       "pillCatalogError": "无法获取模型列表",
       "pillRuntimeError": "Agent 启动失败",
+      "pillSyncDegraded": "云同步断开",
       "mentionOffline": "离线",
       "mentionStale": "需重新绑定",
       "mentionConnecting": "连接中…",

--- a/packages/app/src/stores/__tests__/daemon-mqtt-status.test.ts
+++ b/packages/app/src/stores/__tests__/daemon-mqtt-status.test.ts
@@ -42,7 +42,9 @@ describe('daemon-mqtt-status store', () => {
     const release = subscribeDaemonMqttStatus()
     expect(getDaemonMqttConnected).toHaveBeenCalledTimes(1)
     await vi.advanceTimersByTimeAsync(0)
-    expect(useDaemonMqttStatusStore.getState().connected).toBe(true)
+    const state = useDaemonMqttStatusStore.getState()
+    expect(state.connected).toBe(true)
+    expect(state.uiConnected).toBe(true)
     release()
   })
 
@@ -90,7 +92,10 @@ describe('daemon-mqtt-status store', () => {
     await vi.advanceTimersByTimeAsync(0)
     expect(useDaemonMqttStatusStore.getState().connected).toBe(true)
     release()
-    expect(useDaemonMqttStatusStore.getState().connected).toBeNull()
+    const state = useDaemonMqttStatusStore.getState()
+    expect(state.connected).toBeNull()
+    expect(state.uiConnected).toBeNull()
+    expect(state.falseStreak).toBe(0)
   })
 
   it('is idempotent when a release function is called twice', async () => {
@@ -131,7 +136,38 @@ describe('daemon-mqtt-status store', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(getDaemonMqttConnected).toHaveBeenCalledTimes(1)
+    const state = useDaemonMqttStatusStore.getState()
+    expect(state.connected).toBe(false)
+    // One transient false after a stable true — UI stays up until debounce trips.
+    expect(state.uiConnected).toBe(true)
+    expect(state.falseStreak).toBe(1)
+    release()
+  })
+
+  it('debounces UI disconnect until consecutive false polls', async () => {
+    getDaemonMqttConnected.mockResolvedValue(false)
+    const release = subscribeDaemonMqttStatus()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(useDaemonMqttStatusStore.getState().uiConnected).toBeNull()
+
+    getDaemonMqttConnected.mockResolvedValue(true)
+    await vi.advanceTimersByTimeAsync(20_000)
+    expect(useDaemonMqttStatusStore.getState().uiConnected).toBe(true)
+
+    getDaemonMqttConnected.mockResolvedValue(false)
+    await vi.advanceTimersByTimeAsync(20_000)
     expect(useDaemonMqttStatusStore.getState().connected).toBe(false)
+    expect(useDaemonMqttStatusStore.getState().uiConnected).toBe(true)
+    expect(useDaemonMqttStatusStore.getState().falseStreak).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    expect(useDaemonMqttStatusStore.getState().uiConnected).toBe(false)
+    expect(useDaemonMqttStatusStore.getState().falseStreak).toBe(2)
+
+    getDaemonMqttConnected.mockResolvedValue(true)
+    await vi.advanceTimersByTimeAsync(20_000)
+    expect(useDaemonMqttStatusStore.getState().uiConnected).toBe(true)
+    expect(useDaemonMqttStatusStore.getState().falseStreak).toBe(0)
     release()
   })
 })

--- a/packages/app/src/stores/daemon-mqtt-status.ts
+++ b/packages/app/src/stores/daemon-mqtt-status.ts
@@ -9,9 +9,15 @@ import { QUICK_CHAT_DAEMON_PROBE_INTERVAL_MS } from '@/lib/session-agent-probe'
 const DAEMON_MQTT_STARTUP_SETTLE_MS = 15_000
 const DAEMON_MQTT_STARTUP_RETRY_MS = 1_000
 
+/** Consecutive raw false polls before UI surfaces a disconnect (sidebar, pill). */
+export const DAEMON_MQTT_UI_FALSE_STREAK_REQUIRED = 2
+
 type DaemonMqttStatusState = {
-  /** Daemon's own MQTT link from `GET /v1/info`. `null` = unknown / daemon unreachable. */
+  /** Latest raw reading from `GET /v1/info`. `null` = unknown / daemon unreachable. */
   connected: boolean | null
+  /** Debounced reading for UI — filters transient rebuild windows. */
+  uiConnected: boolean | null
+  falseStreak: number
   setConnected: (connected: boolean | null) => void
   refresh: () => Promise<void>
 }
@@ -26,6 +32,8 @@ type DaemonMqttStatusState = {
  */
 export const useDaemonMqttStatusStore = create<DaemonMqttStatusState>((set) => ({
   connected: null,
+  uiConnected: null,
+  falseStreak: 0,
   setConnected: (connected) => set({ connected }),
   refresh: async () => {
     const connected = await getDaemonMqttConnected()
@@ -41,11 +49,35 @@ let startupDeadline = 0
 let pollingGeneration = 0
 let unsubscribeProbe: (() => void) | null = null
 
+function nextUiConnected(
+  raw: boolean | null,
+  prevUi: boolean | null,
+  prevStreak: number,
+): { uiConnected: boolean | null; falseStreak: number } {
+  if (raw === true) {
+    return { uiConnected: true, falseStreak: 0 }
+  }
+  if (raw === false) {
+    const falseStreak = prevStreak + 1
+    if (falseStreak >= DAEMON_MQTT_UI_FALSE_STREAK_REQUIRED) {
+      return { uiConnected: false, falseStreak }
+    }
+    return { uiConnected: prevUi, falseStreak }
+  }
+  return { uiConnected: null, falseStreak: 0 }
+}
+
 function publishMqttStatus(connected: boolean | null): void {
-  useDaemonMqttStatusStore.getState().setConnected(connected)
+  const prev = useDaemonMqttStatusStore.getState()
+  const { uiConnected, falseStreak } = nextUiConnected(
+    connected,
+    prev.uiConnected,
+    prev.falseStreak,
+  )
+  useDaemonMqttStatusStore.setState({ connected, uiConnected, falseStreak })
   // Warm the short-TTL device-reachability cache on every tick, not only when
   // the value flips — the runtime-start gate reads it synchronously and a
-  // change-only write would leave it permanently expired.
+  // change-only write would leave it permanently expired. Always the raw poll.
   const actorId = getKnownLocalDaemonActorId()
   if (actorId) noteLocalDaemonSignals({ actorId, daemonMqttConnected: connected })
 }
@@ -97,7 +129,7 @@ function stopPolling() {
   startupDeadline = 0
   unsubscribeProbe?.()
   unsubscribeProbe = null
-  useDaemonMqttStatusStore.setState({ connected: null })
+  useDaemonMqttStatusStore.setState({ connected: null, uiConnected: null, falseStreak: 0 })
 }
 
 /**
@@ -117,16 +149,20 @@ export function subscribeDaemonMqttStatus(): () => void {
 }
 
 /**
- * Daemon's own MQTT connection state. Pass `enabled: false` while the daemon is
- * not expected to be up (onboarding incomplete) to avoid pointless polling.
+ * Daemon's own MQTT connection state for UI (sidebar, settings, pill sync hint).
+ * Pass `enabled: false` while the daemon is not expected to be up (onboarding
+ * incomplete) to avoid pointless polling.
+ *
+ * Returns a debounced value: one transient false poll does not flip UI to
+ * disconnected. Runtime gates still read the raw poll via `noteLocalDaemonSignals`.
  */
 export function useDaemonMqttConnected(enabled = true): boolean | null {
-  const connected = useDaemonMqttStatusStore((s) => s.connected)
+  const uiConnected = useDaemonMqttStatusStore((s) => s.uiConnected)
   React.useEffect(() => {
     if (!enabled) return
     return subscribeDaemonMqttStatus()
   }, [enabled])
-  return enabled ? connected : null
+  return enabled ? uiConnected : null
 }
 
 /** @internal test helper */


### PR DESCRIPTION
## Summary

- Split agent pill status into **send layer** (loopback/runtime authoritative for local sessions) and **sync layer** (debounced daemon MQTT disconnect shown as amber suffix).
- Debounce daemon MQTT UI signal: require 2 consecutive false polls before sidebar/settings/pill show disconnected; raw poll still feeds runtime gates immediately.
- Fix local session cold-start timeout to converge to `runtime-error` (same as remote), not `offline`.

## Test plan

- [x] `pnpm test:unit` — session-agent-ui-state, daemon-mqtt-status, use-engaged-agent-ui-states, pill label, AgentSelectorDock, integration (95 tests)
- [ ] Manual: New Chat draft idle ~30s → pill + sidebar stay green (no false amber/red)
- [ ] Manual: sustained MQTT disconnect ≥40s → sidebar + pill both show amber「云同步断开」


Made with [Cursor](https://cursor.com)