### PR TITLE
feat(skills): 第二列沉底显示 skills 扫描目录，超出部分悬停展开

### DIFF
--- a/packages/app/src/components/sidebar/SkillScanPaths.tsx
+++ b/packages/app/src/components/sidebar/SkillScanPaths.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { FolderSearch } from 'lucide-react'
+import { homeDir } from '@tauri-apps/api/path'
+import { getSkillDirectories } from '@/lib/skills/loader'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+/**
+ * How many roots the pinned footer shows before the rest move into the
+ * tooltip. Three fits under the list without eating the list.
+ */
+const VISIBLE_ROOTS = 3
+
+function trimTrailingSlash(path: string): string {
+  return path.replace(/[/\\]+$/, '')
+}
+
+/**
+ * Display form of a scan root: `~` for the user's home, workspace-relative for
+ * anything inside the open workspace, absolute otherwise.
+ *
+ * Same spelling the diagnostics report uses (`skill-diagnostics`'
+ * `DIRECTORY_LABELS`), so a path read here and a path read there are
+ * recognisably the same directory.
+ */
+export function shortenScanPath(
+  dir: string,
+  opts: { home?: string | null; workspacePath?: string | null } = {},
+): string {
+  const home = opts.home ? trimTrailingSlash(opts.home) : ''
+  const workspace = opts.workspacePath ? trimTrailingSlash(opts.workspacePath) : ''
+  if (workspace && dir.startsWith(`${workspace}/`)) return dir.slice(workspace.length + 1)
+  if (home && dir.startsWith(`${home}/`)) return `~/${dir.slice(home.length + 1)}`
+  return dir
+}
+
+/**
+ * The skills column's footer: which directories this machine scans for skills.
+ *
+ * Answers the question the list itself cannot — "where did these come from, and
+ * where do I put a new one" — without sending anyone to Diagnostics. Order is
+ * the daemon's resolution order (`skill_dir_specs`), highest precedence first,
+ * which is also what decides the winner when two roots hold the same slug.
+ *
+ * Local roots only: the caller renders this exclusively for the Agent that IS
+ * this device, because a remote Agent's skills sit on a disk these paths say
+ * nothing about.
+ */
+export function SkillScanPaths({
+  workspacePath,
+  refreshKey = 0,
+}: {
+  workspacePath: string | null
+  refreshKey?: number
+}) {
+  const { t } = useTranslation()
+  const [dirs, setDirs] = React.useState<string[]>([])
+  const [home, setHome] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const [roots, userHome] = await Promise.all([
+          getSkillDirectories(workspacePath),
+          homeDir(),
+        ])
+        if (cancelled) return
+        setDirs(roots)
+        setHome(userHome)
+      } catch {
+        // Browser mode, or the fs plugin said no. A footer that cannot name the
+        // roots has nothing to say, so it says nothing.
+        if (!cancelled) setDirs([])
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [workspacePath, refreshKey])
+
+  if (dirs.length === 0) return null
+
+  const visible = dirs.slice(0, VISIBLE_ROOTS)
+  const hidden = dirs.length - visible.length
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className="shrink-0 cursor-default border-t border-border bg-panel/60 px-3 py-2"
+          data-testid="skill-scan-paths"
+        >
+          <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-faint">
+            <FolderSearch className="h-3 w-3 shrink-0" />
+            <span className="truncate">{t('teamShare.skillScanPaths', '扫描目录')}</span>
+            <span className="font-mono tracking-normal">· {dirs.length}</span>
+            {hidden > 0 && (
+              <span className="ml-auto shrink-0 rounded bg-muted px-1 font-mono text-[10px] tracking-normal text-muted-foreground">
+                +{hidden}
+              </span>
+            )}
+          </div>
+          <ul className="mt-1 space-y-px">
+            {visible.map((dir) => (
+              <li
+                key={dir}
+                className="truncate font-mono text-[10.5px] leading-[1.5] text-muted-foreground"
+              >
+                {shortenScanPath(dir, { home, workspacePath })}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        align="start"
+        sideOffset={6}
+        className="max-w-[min(30rem,80vw)] [text-wrap:initial]"
+      >
+        <div className="mb-1 text-[11px] font-semibold">
+          {t('teamShare.skillScanPathsHint', 'Skills 从这些目录加载，优先级从高到低')}
+        </div>
+        <ol className="space-y-0.5">
+          {dirs.map((dir, index) => (
+            <li key={dir} className="flex gap-2 font-mono text-[11px] leading-[1.45]">
+              <span className="shrink-0 tabular-nums opacity-60">{index + 1}</span>
+              <span className="break-all">{dir}</span>
+            </li>
+          ))}
+        </ol>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/packages/app/src/components/sidebar/TeamShareListColumn.tsx
+++ b/packages/app/src/components/sidebar/TeamShareListColumn.tsx
@@ -61,6 +61,8 @@ import {
 import { detailSelectionForSection } from '@/lib/tabs/teamshare-target'
 import type { ConnectedAgentRow } from '@/lib/backend/types'
 import { useActorPresenceStore } from '@/stores/actor-presence-store'
+import { getKnownLocalDaemonActorId } from '@/lib/local-daemon-identity'
+import { SkillScanPaths } from './SkillScanPaths'
 
 const SECTION_META: Record<
   TeamShareSection,
@@ -263,6 +265,7 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
   const [rootCreating, setRootCreating] = React.useState<'file' | 'folder' | null>(null)
   const openExternalRoot = useWorkspaceStore((s) => s.openExternalRoot)
   const selectFile = useWorkspaceStore((s) => s.selectFile)
+  const workspacePath = useWorkspaceStore((s) => s.workspacePath)
 
   const [query, setQuery] = React.useState('')
   const [searchOpen, setSearchOpen] = React.useState(false)
@@ -1082,6 +1085,12 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
           ))
         )}
       </div>
+
+      {/* Local roots only — a remote Agent's skills live on a disk these paths
+          say nothing about. */}
+      {section === 'skills' && subjectActorId && subjectActorId === getKnownLocalDaemonActorId() && (
+        <SkillScanPaths workspacePath={workspacePath} refreshKey={treeRefreshKey} />
+      )}
     </div>
   )
 }

--- a/packages/app/src/components/sidebar/__tests__/SkillScanPaths.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SkillScanPaths.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, fallback: string) => fallback }),
+}))
+
+const { getSkillDirectories, homeDir } = vi.hoisted(() => ({
+  getSkillDirectories: vi.fn(),
+  homeDir: vi.fn(),
+}))
+vi.mock('@/lib/skills/loader', () => ({ getSkillDirectories }))
+vi.mock('@tauri-apps/api/path', () => ({ homeDir }))
+
+import { SkillScanPaths, shortenScanPath } from '../SkillScanPaths'
+
+const ROOTS = [
+  '/ws/.claude/skills',
+  '/Users/me/.agents/skills',
+  '/ws/.agents/skills',
+  '/Users/me/.amuxd/teams/t1/shared/teamclu-team/skills',
+  '/Users/me/.claude/skills',
+]
+
+describe('shortenScanPath', () => {
+  it('spells the workspace roots relative and the home roots with ~', () => {
+    const opts = { home: '/Users/me', workspacePath: '/ws' }
+    expect(shortenScanPath('/ws/.claude/skills', opts)).toBe('.claude/skills')
+    expect(shortenScanPath('/Users/me/.agents/skills', opts)).toBe('~/.agents/skills')
+  })
+
+  it('leaves an unrelated absolute path alone', () => {
+    expect(shortenScanPath('/opt/skills', { home: '/Users/me', workspacePath: '/ws' })).toBe(
+      '/opt/skills',
+    )
+  })
+
+  it('does not treat a sibling directory as being inside the workspace', () => {
+    // `/ws-other` starts with `/ws` as a string but is a different directory.
+    expect(shortenScanPath('/ws-other/.claude/skills', { workspacePath: '/ws' })).toBe(
+      '/ws-other/.claude/skills',
+    )
+  })
+})
+
+describe('SkillScanPaths', () => {
+  beforeEach(() => {
+    getSkillDirectories.mockReset()
+    homeDir.mockReset()
+    homeDir.mockResolvedValue('/Users/me')
+  })
+
+  it('shows the first three roots and counts the rest', async () => {
+    getSkillDirectories.mockResolvedValue(ROOTS)
+
+    render(<SkillScanPaths workspacePath="/ws" />)
+
+    await waitFor(() => expect(screen.getByText('.claude/skills')).toBeTruthy())
+    expect(screen.getByText('~/.agents/skills')).toBeTruthy()
+    expect(screen.getByText('.agents/skills')).toBeTruthy()
+    // Fourth and fifth roots are only in the tooltip.
+    expect(screen.queryByText('~/.claude/skills')).toBeNull()
+    expect(screen.getByText('+2')).toBeTruthy()
+    expect(screen.getByText('· 5')).toBeTruthy()
+  })
+
+  it('drops the "+N" badge when every root fits', async () => {
+    getSkillDirectories.mockResolvedValue(ROOTS.slice(0, 2))
+
+    render(<SkillScanPaths workspacePath="/ws" />)
+
+    await waitFor(() => expect(screen.getByText('.claude/skills')).toBeTruthy())
+    expect(screen.queryByText(/^\+\d+$/)).toBeNull()
+  })
+
+  it('renders nothing when the roots cannot be read', async () => {
+    getSkillDirectories.mockRejectedValue(new Error('not tauri'))
+
+    const { container } = render(<SkillScanPaths workspacePath={null} />)
+
+    await waitFor(() => expect(getSkillDirectories).toHaveBeenCalled())
+    expect(container.querySelector('[data-testid="skill-scan-paths"]')).toBeNull()
+  })
+
+  it('re-reads the roots when the refresh key changes', async () => {
+    getSkillDirectories.mockResolvedValue(ROOTS)
+
+    const view = render(<SkillScanPaths workspacePath="/ws" refreshKey={0} />)
+    await waitFor(() => expect(getSkillDirectories).toHaveBeenCalledTimes(1))
+
+    view.rerender(<SkillScanPaths workspacePath="/ws" refreshKey={1} />)
+    await waitFor(() => expect(getSkillDirectories).toHaveBeenCalledTimes(2))
+  })
+})

--- a/packages/app/src/lib/skills/loader.ts
+++ b/packages/app/src/lib/skills/loader.ts
@@ -98,20 +98,35 @@ async function loadSkillsFromDir(
 
 export { collectTeamSkillPaths, readConfigSkillPaths } from '@/lib/team-skill-paths'
 
-/** Return all known skill directories for the current workspace/user context. */
+/**
+ * Every skill directory scanned for the current workspace/user context, in the
+ * daemon's resolution order — highest precedence first.
+ *
+ * The order is the one `skill_dir_specs` ranks by
+ * (`apps/daemon/src/config/roles_skills.rs`), because it is what decides which
+ * copy of a duplicated slug an agent actually loads. Callers that only need the
+ * set (watchers, diagnostics) are unaffected by it; the skills column shows the
+ * list to the user, where "which of these wins" is the whole point.
+ */
 export async function getSkillDirectories(workspacePath: string | null): Promise<string[]> {
   const home = trimTrailingPathSeparators(await homeDir())
-  const dirs = new Set<string>([`${home}/.claude/skills`, `${home}/.agents/skills`])
+  const dirs = new Set<string>()
 
+  // rank 1
+  if (workspacePath) dirs.add(`${workspacePath}/.claude/skills`)
+  // rank 2 — ahead of the personal roots on purpose: this is where team packs
+  // are installed, and a team skill is a team standard.
+  dirs.add(`${home}/.agents/skills`)
+  // rank 3
+  if (workspacePath) dirs.add(`${workspacePath}/.agents/skills`)
+  // rank 4
   if (workspacePath) {
-    dirs.add(`${workspacePath}/.claude/skills`)
-    dirs.add(`${workspacePath}/.agents/skills`)
-
-    const configPaths = await collectTeamSkillPaths(workspacePath)
-    for (const dirPath of configPaths) {
+    for (const dirPath of await collectTeamSkillPaths(workspacePath)) {
       dirs.add(dirPath)
     }
   }
+  // rank 5
+  dirs.add(`${home}/.claude/skills`)
 
   return Array.from(dirs)
 }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -149,6 +149,8 @@
     "skillDiffEmpty": "Nothing to compare.",
     "skillDiffBinary": "Binary file — not shown.",
     "skillDiffFailed": "Could not load changes: {{msg}}",
+    "skillScanPaths": "Scan paths",
+    "skillScanPathsHint": "Skills are loaded from these directories, highest precedence first",
     "browseMarketplace": "Browse marketplace",
     "marketplaceTitle": "Skills Marketplace",
     "marketplaceEmpty": "The catalog is empty",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -149,6 +149,8 @@
     "skillDiffEmpty": "没有可对比的内容。",
     "skillDiffBinary": "二进制文件，不显示。",
     "skillDiffFailed": "无法加载改动：{{msg}}",
+    "skillScanPaths": "扫描目录",
+    "skillScanPathsHint": "Skills 从这些目录加载，优先级从高到低",
     "browseMarketplace": "浏览市场",
     "marketplaceTitle": "Skills 市场",
     "marketplaceEmpty": "目录为空",


### PR DESCRIPTION
## 为什么

Skills 第二列只说「有哪些技能」，不说「它们从哪儿扫来的、我新写一个该放哪儿」。这个答案此前只藏在 Diagnostics 里。

## 改了什么

把扫描目录沉在列底（不随列表滚动）：

- 常驻显示前 **3** 个根目录。home 下的写成 `~/...`，工作区内的写成相对路径 —— 和 `skill-diagnostics` 的 `DIRECTORY_LABELS` 同一套拼法，两处读到的是认得出的同一个目录。
- 标题行 `扫描目录 · 5`，右侧 `+2` 表示还有几条没显示。
- **鼠标悬停**出完整清单：全部根目录的绝对路径，带 1/2/3… 序号，顶上一行写明「优先级从高到低」。

显示顺序 = daemon `skill_dir_specs`（`apps/daemon/src/config/roles_skills.rs`）的解析顺序。同名 slug 谁覆盖谁就是这个顺序，所以这个列表本身就是那张优先级表：

1. `<ws>/.claude/skills`
2. `~/.agents/skills` —— 故意排在个人根目录前面：团队包装在这儿，团队 skill 是团队标准
3. `<ws>/.agents/skills`
4. 配置声明的团队路径
5. `~/.claude/skills`

为此 `getSkillDirectories` 从 Set 插入序改成了 rank 序。两个既有调用方（skills 文件监听 `useAppInit`、诊断报告）都不依赖顺序。

点列头的刷新按钮会连带重读这几条路径（复用已有的 `treeRefreshKey`）。

## 一个判断

**只在选中的 Agent 就是本机 daemon 时渲染。** 选的是远端 Agent 时，它的技能在另一块磁盘上，这几条本机路径描述不了它 —— 与 `localSkillFiles` 决定详情面板能否编辑用的是同一个判据。

## 验证

- `pnpm typecheck` 通过，`pnpm lint` 0 error
- `pnpm test:unit` 全量 2929 passed
- 新增 7 个用例：路径缩写（含 `/ws-other` 不该被当成 `/ws` 内部的边界）、`+N` 折叠与不折叠、读不到根目录时不渲染、refreshKey 变化会重读

未做真机目视验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)